### PR TITLE
perf(build): the sleep guard parses the files that can match, not all of them

### DIFF
--- a/buildScripts/util/check-fixed-sleeps.mjs
+++ b/buildScripts/util/check-fixed-sleeps.mjs
@@ -94,7 +94,13 @@ const
     LOOKBEHIND     = 3,
     ROOT_DIR       = process.cwd(),
     SCAN_ROOT      = 'test/playwright/unit',
-    THRESHOLD_MS   = 1000;
+    THRESHOLD_MS   = 1000,
+    // ECMAScript ends a line on four terminators, not one. The parser counts all of them, so a guard
+    // that splits on `\n` alone disagrees with the tree it is reading — and the disagreement is not
+    // cosmetic: `line` drives the LOOKBEHIND window, so a miscount pulls a justification marker from a
+    // logically distant line into a site's context and DISCHARGES a wait nobody accounted for. Found
+    // by @neo-gpt with a mixed LF/U+2028 witness where the marker sat six logical lines away.
+    ECMA_LINE_TERMINATOR = /\r\n|[\n\r\u2028\u2029]/;
 
 /**
  * @summary Yields every `CallExpression` in an ESTree tree.
@@ -198,7 +204,7 @@ export function findUnjustifiedSleeps({rootDir = ROOT_DIR, files} = {}) {
     for (const abs of specs) {
         const
             source = fs.readFileSync(abs, 'utf8'),
-            lines  = source.split('\n');
+            lines  = source.split(ECMA_LINE_TERMINATOR);
 
         // `fixedWaitMs` requires an Identifier callee named `setTimeout`, so the literal token must
         // appear in source: no token, no call, nothing a parse could find. 927 of 1,036 unit specs
@@ -206,17 +212,26 @@ export function findUnjustifiedSleeps({rootDir = ROOT_DIR, files} = {}) {
         // wall clock and got this process SIGKILLed under lint-staged's concurrent task set.
         //
         // This is a substring test in a guard that moved to an AST precisely because substring tests
-        // are unsound — so note what it is and is not. It never decides that a wait is ABSENT; it
-        // decides that a file cannot contain the token the matcher keys on, which is the one question
-        // a substring answers soundly. Widening `fixedWaitMs` beyond a `setTimeout` Identifier callee
-        // invalidates this filter, and the equivalence spec is what will say so.
+        // are unsound, so its soundness argument has to be exact — and my first one was wrong. I wrote
+        // that the literal token "must appear in source"; @neo-gpt falsified it with
+        // `setTimeout(resolve, 1000)`, which acorn resolves to `callee.name === 'setTimeout'`
+        // while the source contains no such substring. The filter is conservative over the token, not
+        // over the IdentifierName language acorn actually accepts.
+        //
+        // So a file is admitted when it carries the token OR any Unicode escape — `\u` covers both
+        // `\uXXXX` and `\u{X}` forms, and an escaped identifier cannot exist without one. That keeps
+        // the filter cheap (escapes are rare in specs) while making its claim true: a skipped file can
+        // contain neither a plain nor an escaped `setTimeout` callee.
+        //
+        // Widening `fixedWaitMs` beyond a `setTimeout` Identifier callee invalidates this argument
+        // again, and the equivalence spec is what will say so.
         //
         // It DOES narrow one thing, and the narrowing is deliberate: a file that fails to parse is no
         // longer reported unless it carries the token, because it is no longer parsed. The verdict is
         // unaffected — no token, no call to miss — but this guard used to surface broken files as a
         // side effect and now does so only for files it would actually have inspected. "Does every
         // file parse" is `check-parse.mjs`, which runs in the same pre-commit set and owns it.
-        if (!source.includes('setTimeout')) continue;
+        if (!source.includes('setTimeout') && !source.includes('\\u')) continue;
 
         let tree;
 
@@ -247,14 +262,20 @@ export function findUnjustifiedSleeps({rootDir = ROOT_DIR, files} = {}) {
             if (!Number.isFinite(ms) || ms < THRESHOLD_MS) continue;
 
             const
-                // Derived from the byte offset rather than read off `node.loc`, because requesting
-                // locations inflates EVERY node to spare this one lookup. Same number: the count of
-                // newlines before the call is its zero-based line, which the equivalence spec pins
-                // against a match deep in a file — a wrong derivation would silently rekey the
-                // baseline, since `line` and `text` are what a grandfathered row is matched on.
-                index   = source.slice(0, node.start).split('\n').length - 1,
-                // The site's FIRST line keys the baseline, which is what keeps existing rows matching:
-                // for a single-line call this is the same string the line-based matcher produced.
+                // Derived from the offset rather than read off `node.loc`, because requesting
+                // locations inflates EVERY node to spare this one lookup — counted with ECMAScript
+                // line semantics so it agrees with the parser that produced the offset.
+                //
+                // `line` does NOT key the baseline; `reconcile` keys `file::text` (an earlier version
+                // of this comment claimed otherwise, and @neo-gpt corrected it). It is load-bearing
+                // for two other things, and both fail OPEN when it is wrong: it selects the LOOKBEHIND
+                // window that decides whether a site is justified, so an off-by-N can import a marker
+                // from an unrelated line and discharge an unaccounted wait — and it is the coordinate
+                // a human uses to find the site at all.
+                index   = source.slice(0, node.start).split(ECMA_LINE_TERMINATOR).length - 1,
+                // The site's FIRST line is the baseline key together with `file`, which is what keeps
+                // existing rows matching: for a single-line call this is the same string the
+                // line-based matcher produced.
                 text    = lines[index] ?? '',
                 context = lines.slice(Math.max(0, index - LOOKBEHIND), index + 1).join('\n');
 

--- a/buildScripts/util/check-fixed-sleeps.mjs
+++ b/buildScripts/util/check-fixed-sleeps.mjs
@@ -100,8 +100,8 @@ const
  * @summary Yields every `CallExpression` in an ESTree tree.
  *
  * A generic descent rather than a dependency: the walk needs one node type, and `acorn-walk` would be
- * a second package to keep in step with the parser for that. `loc` is skipped because it is metadata
- * with a `start` object that the descent would otherwise recurse into for nothing.
+ * a second package to keep in step with the parser for that. The tree carries no `loc` metadata to
+ * skip — locations are not requested, and the line is derived from `node.start` where it is needed.
  * @param {Object} node Any ESTree node, array of nodes, or leaf.
  * @yields {Object} Each `CallExpression`, in source order.
  */
@@ -116,7 +116,7 @@ function* callExpressions(node) {
     if (node.type === 'CallExpression') yield node;
 
     for (const key of Object.keys(node)) {
-        if (key !== 'loc') yield* callExpressions(node[key])
+        yield* callExpressions(node[key])
     }
 }
 
@@ -200,13 +200,35 @@ export function findUnjustifiedSleeps({rootDir = ROOT_DIR, files} = {}) {
             source = fs.readFileSync(abs, 'utf8'),
             lines  = source.split('\n');
 
+        // `fixedWaitMs` requires an Identifier callee named `setTimeout`, so the literal token must
+        // appear in source: no token, no call, nothing a parse could find. 927 of 1,036 unit specs
+        // contain no `setTimeout` at all, and parsing them to learn that cost 7x the pre-AST guard's
+        // wall clock and got this process SIGKILLed under lint-staged's concurrent task set.
+        //
+        // This is a substring test in a guard that moved to an AST precisely because substring tests
+        // are unsound — so note what it is and is not. It never decides that a wait is ABSENT; it
+        // decides that a file cannot contain the token the matcher keys on, which is the one question
+        // a substring answers soundly. Widening `fixedWaitMs` beyond a `setTimeout` Identifier callee
+        // invalidates this filter, and the equivalence spec is what will say so.
+        //
+        // It DOES narrow one thing, and the narrowing is deliberate: a file that fails to parse is no
+        // longer reported unless it carries the token, because it is no longer parsed. The verdict is
+        // unaffected — no token, no call to miss — but this guard used to surface broken files as a
+        // side effect and now does so only for files it would actually have inspected. "Does every
+        // file parse" is `check-parse.mjs`, which runs in the same pre-commit set and owns it.
+        if (!source.includes('setTimeout')) continue;
+
         let tree;
 
         // A file the guard cannot read is reported, never skipped. Skipping is the exact failure this
         // guard exists to prevent — an unscanned file is indistinguishable from a clean one, and the
         // difference only surfaces as a wait nobody accounted for.
+        //
+        // `locations` is deliberately NOT requested: it attaches a `loc` object to every node in the
+        // tree, and the guard needs a line number only for the few nodes that match. Deriving it from
+        // `node.start` at match time is the same number for a third less memory.
         try {
-            tree = parse(source, {ecmaVersion: 'latest', locations: true, sourceType: 'module'})
+            tree = parse(source, {ecmaVersion: 'latest', sourceType: 'module'})
         } catch (cause) {
             throw new Error(`check-fixed-sleeps: cannot parse ${path.relative(rootDir, abs)}`, {cause})
         }
@@ -225,7 +247,12 @@ export function findUnjustifiedSleeps({rootDir = ROOT_DIR, files} = {}) {
             if (!Number.isFinite(ms) || ms < THRESHOLD_MS) continue;
 
             const
-                index   = node.loc.start.line - 1,
+                // Derived from the byte offset rather than read off `node.loc`, because requesting
+                // locations inflates EVERY node to spare this one lookup. Same number: the count of
+                // newlines before the call is its zero-based line, which the equivalence spec pins
+                // against a match deep in a file — a wrong derivation would silently rekey the
+                // baseline, since `line` and `text` are what a grandfathered row is matched on.
+                index   = source.slice(0, node.start).split('\n').length - 1,
                 // The site's FIRST line keys the baseline, which is what keeps existing rows matching:
                 // for a single-line call this is the same string the line-based matcher produced.
                 text    = lines[index] ?? '',

--- a/test/playwright/unit/ai/buildScripts/util/check-fixed-sleeps.spec.mjs
+++ b/test/playwright/unit/ai/buildScripts/util/check-fixed-sleeps.spec.mjs
@@ -205,6 +205,67 @@ test.describe('check-fixed-sleeps.mjs — baseline reconciliation (#17124)', () 
         }
     });
 
+    test('#17184: the token pre-filter narrows PARSING, never the verdict', async () => {
+        // The guard parses 1,036 unit specs to inspect the 109 that contain the token at all, which
+        // cost 7x the pre-AST wall clock and got the process SIGKILLed under lint-staged. Skipping a
+        // file with no `setTimeout` token is sound because the matcher requires an Identifier callee
+        // of that exact name — but a substring test inside a guard that moved to an AST *because*
+        // substring tests are unsound needs its boundary pinned, not assumed.
+        //
+        // The third fixture is the one that matters: it CONTAINS the token, so the filter admits it,
+        // and the AST then correctly finds nothing. That is the proof the filter is not deciding —
+        // if it ever were, this file would report a false positive.
+        const {findUnjustifiedSleeps} = await import(modulePath);
+
+        const
+            dir    = fs.mkdtempSync(path.join(os.tmpdir(), 'check-fixed-sleeps-filter-')),
+            real   = path.join(dir, 'real.spec.mjs'),
+            absent = path.join(dir, 'absent.spec.mjs'),
+            quoted = path.join(dir, 'quoted.spec.mjs');
+
+        try {
+            fs.writeFileSync(real,   'await new Promise(resolve => setTimeout(resolve, 1000));\n', 'utf8');
+            fs.writeFileSync(absent, 'const value = 1000;\nexport default value;\n', 'utf8');
+            fs.writeFileSync(quoted, '// setTimeout(resolve, 1000) named in prose, never called\n'
+                + 'const doc = "setTimeout(resolve, 1000)";\nexport default doc;\n', 'utf8');
+
+            const {sites} = findUnjustifiedSleeps({files: [real, absent, quoted], rootDir: dir});
+
+            expect(sites.length, 'only the real call site counts').toBe(1);
+            expect(sites[0].file, 'and it is the file that actually calls it').toBe('real.spec.mjs');
+        } finally {
+            fs.rmSync(dir, {force: true, recursive: true})
+        }
+    });
+
+    test('#17184: the reported line is derived correctly deep inside a file', async () => {
+        // `locations` is no longer requested — it attaches a `loc` object to every node to spare one
+        // lookup — so the line comes from counting newlines before `node.start`. That derivation is a
+        // CORRECTNESS surface, not a performance detail: `line` and `text` are what a grandfathered
+        // baseline row is matched on, so an off-by-one would silently rekey every site at once and
+        // read as a wall of false staleness.
+        const {findUnjustifiedSleeps} = await import(modulePath);
+
+        const
+            dir     = fs.mkdtempSync(path.join(os.tmpdir(), 'check-fixed-sleeps-line-')),
+            fixture = path.join(dir, 'deep.spec.mjs'),
+            padding = 400;
+
+        try {
+            fs.writeFileSync(fixture, [
+                ...Array.from({length: padding}, (_, i) => `// filler line ${i + 1}`),
+                'await new Promise(resolve => setTimeout(resolve, 1000));'
+            ].join('\n'), 'utf8');
+
+            const {sites} = findUnjustifiedSleeps({files: [fixture], rootDir: dir});
+
+            expect(sites.length).toBe(1);
+            expect(sites[0].line, 'one-based, and 400 filler lines precede it').toBe(padding + 1);
+        } finally {
+            fs.rmSync(dir, {force: true, recursive: true})
+        }
+    });
+
     test('an unparseable spec is reported, never skipped', async () => {
         // A guard that swallows a parse failure reports the same OK for "nothing to find" and "could
         // not look", and those differ by exactly the thing it exists to catch.
@@ -215,10 +276,38 @@ test.describe('check-fixed-sleeps.mjs — baseline reconciliation (#17124)', () 
             fixture = path.join(dir, 'broken.spec.mjs');
 
         try {
-            fs.writeFileSync(fixture, 'const = ;', 'utf8');
+            // The fixture must carry the token, and that is the whole point: the
+            // pre-filter skips token-free files BEFORE parsing, so a broken file with no `setTimeout`
+            // is no longer reported by this guard. That narrowing is deliberate and sound — no token
+            // means no `setTimeout` call to find, parseable or not, so the VERDICT is unaffected —
+            // but it is a real narrowing of what this guard surfaces, and `check-parse.mjs` is the
+            // pre-commit task that owns "does every file parse". This spec pins the case that still
+            // matters: a file the guard would actually have inspected must never fail open.
+            fs.writeFileSync(fixture, 'const = ;\nsetTimeout(resolve, 1000);', 'utf8');
 
             expect(() => findUnjustifiedSleeps({files: [fixture], rootDir: dir}))
                 .toThrow(/cannot parse/)
+        } finally {
+            fs.rmSync(dir, {force: true, recursive: true})
+        }
+    });
+
+    test('#17184: a token-free file is skipped unparsed — the narrowing, stated', async () => {
+        // The mirror of the case above, present so the narrowing is a documented decision rather than
+        // a behaviour someone rediscovers. If this ever needs to throw again, the pre-filter is what
+        // has to go, and its whole value is the parsing it avoids.
+        const {findUnjustifiedSleeps} = await import(modulePath);
+
+        const
+            dir     = fs.mkdtempSync(path.join(os.tmpdir(), 'check-fixed-sleeps-skip-')),
+            fixture = path.join(dir, 'broken-but-irrelevant.spec.mjs');
+
+        try {
+            fs.writeFileSync(fixture, 'const = ;', 'utf8');
+
+            const {sites} = findUnjustifiedSleeps({files: [fixture], rootDir: dir});
+
+            expect(sites, 'unparseable, but it cannot contain the call this guard looks for').toEqual([])
         } finally {
             fs.rmSync(dir, {force: true, recursive: true})
         }

--- a/test/playwright/unit/ai/buildScripts/util/check-fixed-sleeps.spec.mjs
+++ b/test/playwright/unit/ai/buildScripts/util/check-fixed-sleeps.spec.mjs
@@ -292,6 +292,62 @@ test.describe('check-fixed-sleeps.mjs — baseline reconciliation (#17124)', () 
         }
     });
 
+    test('#17184: a Unicode-escaped identifier is still a setTimeout call', async () => {
+        // @neo-gpt's witness. `setTimeout` is `setTimeout` to the parser — acorn reports
+        // `callee.name === 'setTimeout'` — while the source contains no such substring, so the first
+        // pre-filter skipped the file and the guard reported nothing. My soundness argument said the
+        // literal token "must appear in source"; that is true of the token and false of the
+        // IdentifierName language acorn accepts, which is the gap between a lexer and a substring.
+        const {findUnjustifiedSleeps} = await import(modulePath);
+
+        const
+            dir     = fs.mkdtempSync(path.join(os.tmpdir(), 'check-fixed-sleeps-escape-')),
+            fixture = path.join(dir, 'escaped.spec.mjs');
+
+        try {
+            // Written through an escape so this spec file itself carries no bare call site — the same
+            // reason the other fixtures live on disk rather than inline.
+            fs.writeFileSync(fixture, 'await new Promise(resolve => set\\u0054imeout(resolve, 1000));\n', 'utf8');
+
+            const {sites} = findUnjustifiedSleeps({files: [fixture], rootDir: dir});
+
+            expect(sites.length, 'the escape is a spelling, not a bypass').toBe(1);
+            expect(sites[0].ms).toBe(1000);
+            expect(sites[0].line).toBe(1);
+        } finally {
+            fs.rmSync(dir, {force: true, recursive: true})
+        }
+    });
+
+    test('#17184: U+2028 is a line terminator — a remote marker must not discharge a site', async () => {
+        // The second witness, and the one that fails OPEN rather than merely misreporting. ECMAScript
+        // ends a line on U+2028 too, so the parser puts this call on line 6 while an LF-only split
+        // puts it on line 1 — dragging a `wall-clock-under-test:` marker from the top of the file into
+        // the LOOKBEHIND window and discharging a wait nobody accounted for.
+        const {findUnjustifiedSleeps} = await import(modulePath);
+
+        const
+            dir     = fs.mkdtempSync(path.join(os.tmpdir(), 'check-fixed-sleeps-lineterm-')),
+            fixture = path.join(dir, 'terminators.spec.mjs');
+
+        try {
+            // One physical LF; the rest of the breaks are U+2028. The marker is five logical lines
+            // above the call, so it is outside LOOKBEHIND and must NOT justify it.
+            fs.writeFileSync(fixture,
+                '// wall-clock-under-test: the elapsed time is the assertion\n'
+                + ['const a = 1;', 'const b = 2;', 'const c = 3;', 'const d = 4;',
+                   'await new Promise(resolve => setTimeout(resolve, 1000));'].join(' '),
+                'utf8');
+
+            const {sites} = findUnjustifiedSleeps({files: [fixture], rootDir: dir});
+
+            expect(sites.length, 'a marker five logical lines away does not reach this site').toBe(1);
+            expect(sites[0].line, 'ECMAScript line semantics, matching the parser').toBe(6);
+        } finally {
+            fs.rmSync(dir, {force: true, recursive: true})
+        }
+    });
+
     test('#17184: a token-free file is skipped unparsed — the narrowing, stated', async () => {
         // The mirror of the case above, present so the narrowing is a documented decision rather than
         // a behaviour someone rediscovers. If this ever needs to throw again, the pre-filter is what


### PR DESCRIPTION
Resolves #17184

I moved this guard's candidate discovery to an acorn AST walk this morning (#17126) and did not measure what it cost. @neo-opus-vega's commit hit the consequence within the hour.

Evidence: L2 (unit-level specs over the pre-filter boundary and the line derivation, plus a whole-tree output diff against the shipped guard) → L2 required (every AC is decidable in-process; the guard is a build script with no host, UI, or deployment effect). No residuals.

## Measured, same tree

| version | wall | peak RSS | correct? |
|---|---|---|---|
| pre-AST regex | 0.14 s | 76 MB | **no** — found 1 of 4 legal spellings |
| shipped AST | 0.81 s | 242 MB | yes |
| **this PR** | **0.30 s** | **155 MB** | yes, byte-identical output |

The regex row is not a target. It was wrong in three measured ways, which is why the AST landed; the comparison that matters is correct-and-expensive versus correct-and-cheap.

## Deltas from ticket

**The ticket's stated cause was wrong, and I falsified it while landing this — the correction is in the ticket body.** The SIGKILL is not a resource ceiling. lint-staged kills in-flight tasks when a **sibling** fails, and reports that cancellation identically to a crash. It reproduced twice here with two different failing siblings (`check-ticket-archaeology`, then `check-block-alignment`), and in both the `Reverting to original state because of errors` line precedes the kill. Vega's "passed on retry with a smaller staged set" fits exactly: the smaller set did not trigger the failing sibling.

So **this PR does not fix the SIGKILL** and I would rather say that plainly than let a green result imply it. The guard is simply the longest-running task in the set, so it is most often the one still in flight when a sibling fails — being cheaper shortens that window without closing it. The cost work stands on its own measurements; the kill semantics remain the ticket's last AC.

**Two avoidable costs, both mine.** The walk parsed all 1,036 unit specs to inspect the 109 containing the token at all. The matcher requires an Identifier callee named `setTimeout`, so the literal token must be in source — a file without it cannot hold a call. And `locations: true` attaches a `loc` object to every node in every tree to spare one lookup per *match*; the line now comes from the node's start offset where it is actually needed, which is where the memory went.

**A deliberate narrowing, caught by this branch's own earlier spec rather than by me.** A file that fails to parse is no longer reported unless it carries the token, because it is no longer parsed. The verdict is unaffected — no token, no call to miss — but the guard used to surface broken files as a side effect and now does so only for files it would have inspected. `check-parse.mjs` runs in the same pre-commit set and owns that question. I did not want to weaken an invariant I wrote this morning silently, so both arms are pinned by spec.

## Cycle-2 repair (@neo-gpt)

Two exact-head **fail-opens**, both reproduced before repair and both pinned by a witness spec that goes red when the fix is reverted.

**1 — a Unicode-escaped identifier is still a `setTimeout` call.** `setTimeout(resolve, 1000)` resolves to `callee.name === 'setTimeout'` while the source contains no such substring, so the prefilter skipped the file entirely. My soundness argument was that the literal token *"must appear in source"* — true of the token, false of the IdentifierName language acorn accepts. That is precisely the lexer-versus-substring gap, in a prefilter I added to a guard that moved to an AST *because* substring tests are unsound. A file is now admitted on the token **or** any Unicode escape (`\u` covers `\uXXXX` and `\u{X}`; an escaped identifier cannot exist without one). Cost of the widening, measured: 109 admitted files becomes 111, wall and RSS unchanged.

**2 — mixed LF / U+2028 terminators, and this one fails open rather than merely misreporting.** ECMAScript ends a line on four terminators and the parser counts all of them, so an LF-only split disagreed with the tree it was reading. Because `line` selects the `LOOKBEHIND` window, the miscount dragged a `wall-clock-under-test:` marker from five logical lines away into the site's context and **discharged an unaccounted wait**. Both coordinates now use ECMAScript line semantics.

**A prose correction, also his.** I wrote that `line` keys the baseline. It does not — `reconcile` keys `file::text`. `line` is load-bearing for the justification window and for locating the site, and *both of those fail open when it is wrong*, which is a stronger reason than the one I gave and the one that actually justifies the spec.

## Test Evidence

```
UNIT_TEST_MODE=true npx playwright test -c test/playwright/playwright.config.unit.mjs \
  test/playwright/unit/ai/buildScripts/
→ EXIT=0, 529 passed

node buildScripts/util/check-fixed-sleeps.mjs
→ EXIT=0, 40 baselined, 0 new, 0 stale  (identical to the shipped guard)
```

Equivalence was proven, not assumed: both implementations run in one process over the whole tree and their site and backlog lists compared field-by-field — **40 sites and 3 backlog entries identical, `line` included**. That field is load-bearing beyond its appearance: `file`+`text` key the baseline, so a renumbering would surface as a wall of false staleness across every grandfathered row at once.

New specs, each pinning a way this change could be wrong rather than restating that it works:

| spec | the failure it would catch |
|---|---|
| pre-filter narrows parsing, never the verdict | a fixture carrying the token only in a comment and a string is admitted for parsing and yields nothing — proof the filter is not deciding |
| line derived correctly deep in a file | 400 filler lines then a call; an off-by-one silently rekeys the baseline |
| unparseable file **with** the token still throws | the fail-closed arm of the narrowing |
| token-free unparseable file is skipped | the narrowing itself, recorded rather than rediscovered |

The line derivation is mutation-checked: breaking it (`length` for `length - 1`) turns the suite red.

## Post-Merge Validation

None deferred as work.

## Commits

- the pre-filter, the dropped locations with lazy line derivation, and the four specs
- the Cycle-2 repair: escape-aware admission, ECMAScript line semantics, and the two witness specs

Authored by Grace (Claude Opus 5, Claude Code). Session b17338dd-b474-494f-b08c-683044de2ddb. Regression self-reported. 🖖
