### PR TITLE
fix(test): the segment-load wait ends on its condition, not a 50-turn budget (#17186)

### DIFF
--- a/test/playwright/unit/ai/services/memory-core/MailboxService.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/MailboxService.spec.mjs
@@ -221,6 +221,46 @@ test.describe('Neo.ai.services.memory-core.MailboxService', () => {
         }
     }
 
+    /**
+     * @summary Waits until an observed counter reaches `target`, or fails naming what it awaited.
+     *
+     * Replaces a fixed turn budget — `for (let turn = 0; turn < 50 && payloadReads < 2; turn++)` —
+     * that could not distinguish *"the second read never happened"* from *"it has not happened yet"*.
+     * On expiry that loop fell through into the value assertion, so a real defect and a busy machine
+     * both reported `Received: 1`. At one worker the budget held; at four workers it did not.
+     *
+     * The deadline is a FAILURE bound, not a wait. The happy path ends the moment the condition holds,
+     * so a slower machine costs nothing and only a genuine absence reaches the throw — which is the
+     * whole difference from the budget it replaces.
+     *
+     * Polled at 25 ms rather than raced against a single `setTimeout(…, 10000)` for a specific reason:
+     * a fixed second-scale timer in a unit spec is what `check-fixed-sleeps.mjs` exists to catch, and
+     * neither of that guard's justifications would be truthful here. `wall-clock-under-test:` is false
+     * (no elapsed time is asserted) and `out-waits:` is false (it out-waits no production constant) —
+     * this timer never elapses when the code is right. Annotating it to buy silence would put a lie in
+     * the one place the guard reads, so the wait stays under the threshold and needs no annotation.
+     *
+     * @param {Function} getCount Reads the observed counter.
+     * @param {Number} target Count that ends the wait.
+     * @param {String} awaited What is being waited for, quoted verbatim into the failure message.
+     * @param {Number} [timeoutMs=10000] Failure bound.
+     * @returns {Promise<void>}
+     */
+    async function waitForObservedCount(getCount, target, awaited, timeoutMs = 10000) {
+        const deadline = Date.now() + timeoutMs;
+
+        while (getCount() < target) {
+            if (Date.now() >= deadline) {
+                throw new Error(
+                    `Timed out after ${timeoutMs}ms awaiting ${awaited} — reached ${getCount()} of ${target}. ` +
+                    'This wait ends on its condition, so the count is genuinely absent rather than late.'
+                )
+            }
+
+            await new Promise(resolve => setTimeout(resolve, 25));
+        }
+    }
+
     test('addMessage enforces identity and routes correctly', async () => {
         await RequestContextService.run({ agentIdentityNodeId: '@bob' }, async () => {
             await PermissionService.grantPermission({ to: '@alice', scope: 'CAN_REPLY_TO' });
@@ -1375,9 +1415,10 @@ test.describe('Neo.ai.services.memory-core.MailboxService', () => {
                 ids: [charlieMessage.messageId], limit: 1
             });
 
-            for (let turn = 0; turn < 50 && payloadReads < 2; turn++) {
-                await new Promise(resolve => setImmediate(resolve));
-            }
+            await waitForObservedCount(
+                () => payloadReads, 2,
+                'the new marker cohort to open its own physical segment read'
+            );
             expect(payloadReads, 'a marker-only cohort change needs an independent segment result').toBe(2);
             releasePayloadRead();
 


### PR DESCRIPTION
Resolves #17186

@neo-opus-vega found this with the `workers: 4` probe, and the finding almost did not survive its own instrument: the CI job reported `success`, every check was green, and `1 flaky` was the only thing that distinguished the run from a healthy one.

Evidence: L2 (in-process spec run, plus a mutation experiment against the production single-flight to prove the repaired arm still fires) → L2 required; the change is confined to one spec file with no host, UI, or deployment effect. One residual, owned below.

## The defect, and why the repair is not "a bigger number"

```js
for (let turn = 0; turn < 50 && payloadReads < 2; turn++) {
    await new Promise(resolve => setImmediate(resolve));
}
expect(payloadReads, '…').toBe(2);
```

On expiry this **falls through into the assertion**. It cannot distinguish *"the second read never happened"* from *"it has not happened yet"* — both arrive as `Received: 1`. Fifty turns is a guess at how long a second payload read needs; at one worker the guess holds, at four it does not.

The replacement ends on the observed condition, so a slower machine costs nothing, and a genuine absence throws instead of asserting:

```
Error: Timed out after 10000ms awaiting the new marker cohort to open its own physical
segment read — reached 1 of 2. This wait ends on its condition, so the count is
genuinely absent rather than late.
```

## Deltas from ticket

**AC-4's disposition is a third answer, and it is the one finding here I did not expect.** The ticket offered *repaired* or *"explicitly recorded as waiting on something synchronous"*. Measurement says neither holds, so the two `turn < 3` siblings are filed as **#17188** rather than dispositioned as safe.

They assert a **non-event** — that a second caller did *not* open its own read — which inverts the failure mode. `:1381` fails **loudly** when its budget is short; `:1224` and `:1298` pass **vacuously**. Measured: with the single-flight disabled, the second read arrives at **turn 2 against a budget of 3**. One turn of headroom, at one worker, on an idle machine — while `:1381` proved contention can inflate that requirement by more than 25×.

Both arms *are* live today (each fails `Received: 2` under the mutation), which is why this is a latent defect and not a dead test. @neo-opus-vega's refusal to sweep them was right; what the evidence changes is the conclusion, not the discipline.

**AC-5's inventory is wider than the ticket's list, and the finding narrowed as a result.** The ticket named five spec files from memory. A whole-tree grep finds **seven** carrying `setImmediate` — `BaseServer.spec.mjs` and `WakeSubscriptionService.spec.mjs` were not on the list. Reading all seven, the *shape* count is **3**, all in `MailboxService.spec.mjs`: one repaired here, two filed as #17188. The rest are single yields and precise interleaving points, not wait budgets. Widening the corpus is what let the finding shrink honestly rather than by assertion.

**A guard interaction worth stating, because the tempting fix was a lie.** The repair needs a failure deadline, and `check-fixed-sleeps.mjs` flags fixed waits at or above 1000 ms. Neither of its justifications would be truthful here: `wall-clock-under-test:` is false (no elapsed time is asserted) and `out-waits:` is false (it out-waits no production constant) — this timer never elapses when the code is right. Annotating it to buy silence would put a lie in the one place that guard reads. The wait polls at 25 ms and owns its deadline via `Date.now()`, matching `sessionSummaryReceiptStore.spec.mjs`'s existing pattern, and needs no annotation. Guard verified clean: `0 new, 0 stale`.

**Out of scope and left alone:** the guard cannot see turn-budget spins at all, since it matches on `setTimeout` delay. That is guard coverage and belongs with `#17177`'s callback-form blind spot, not here.

## Test Evidence

```
UNIT_TEST_MODE=true npx playwright test -c test/playwright/playwright.config.unit.mjs \
  test/playwright/unit/ai/services/memory-core/MailboxService.spec.mjs
→ 159 passed

node buildScripts/util/check-fixed-sleeps.mjs
→ EXIT=0, 40 baselined, 0 new, 0 stale
```

**Red-proved, not assumed.** The repaired wait was run against a deliberately broken single-flight — `loadKey` stripped of its cohort digest, so the new marker cohort joins the old load instead of opening its own read:

```
Error: Timed out after 10000ms awaiting the new marker cohort to open its own physical
segment read — reached 1 of 2.
→ 1 failed
```

It fails **naming what it awaited**, which is the AC — not by falling through to `Expected: 2, Received: 1`. Production restored and verified byte-identical before commit.

**Each red check was run individually, on purpose.** `test.describe.configure({mode: 'serial'})` at line 25 skips the remainder after a failure: the first sibling run reported `1 failed, 1 did not run`, which looks like two verified arms and is one. The second was re-run alone to get its own evidence.

## Post-Merge Validation

**#17186 AC-3 — `--workers=4` in CI with a zero flaky count — cannot be discharged from this branch**, and is not being claimed. CI runs single-worker on `dev` today, so the falsifier only exists inside the probe run on PR #17183. This spec must be on `dev` before that probe can exercise it.

That is a genuine ordering dependency, not deferred work: the repair lands, then the probe re-runs and reads `flaky: 0` from the run rather than the job verdict, per #15861's amended AC-2.

Residual-Owner: #15861

## Commits

- `2d43940343` — the condition wait, its deadline rationale, and the one call site

Authored by ⚖️ **Ada** · `@neo-opus-ada` · Claude Opus 5 · Claude Code. Session 00348bc3-c011-4035-90a3-f0eb62b8c95c.
