### PR TITLE
feat(ai): derive an ai/scripts entrypoint's execution plane from what it reaches (#16929)

### DIFF
--- a/.github/workflows/script-plane-lint.yml
+++ b/.github/workflows/script-plane-lint.yml
@@ -1,0 +1,55 @@
+name: Script Plane Lint
+
+# Fails a PR when an `ai/scripts` entrypoint's DECLARED execution authority disagrees with the
+# capabilities its code actually reaches, and ratchets the population of import edges the closure
+# cannot follow.
+#
+# On what this job does and does not gate: like every other lint here, it is NOT a required status
+# context on `dev` — see #17171. A red result is loud and visible on the PR; it does not by itself
+# make the PR ineligible to merge. Do not read its presence as a `--no-verify` closure.
+#
+# The `paths` filter is broad on `ai/**` on purpose, and the scan-root parity spec enforces that
+# breadth: the lint walks each entrypoint's TRANSITIVE import closure, so a capability introduced
+# anywhere a script can reach changes a verdict here. A narrower filter would mean the guard does not
+# RUN on the edit that changes its own answer, which is the exact failure the parity registry exists
+# to prevent.
+
+on:
+  pull_request:
+    branches: [dev]
+    paths:
+      - 'package.json'
+      - 'ai/**'
+      - '.github/workflows/script-plane-lint.yml'
+  push:
+    branches: [dev]
+    paths:
+      - 'package.json'
+      - 'ai/**'
+      - '.github/workflows/script-plane-lint.yml'
+
+concurrency:
+  group: script-plane-lint-${{ github.run_attempt == '1' && github.ref || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '24'
+          cache: npm
+
+      # `acorn` is the only runtime dependency the closure needs, and it is already a direct
+      # dependency of the repo — the lint deliberately hand-rolls its ancestor walk rather than adding
+      # `acorn-walk` for one traversal.
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Derive each entrypoint's plane and compare it to its declared authority
+        run: node ./ai/scripts/lint/lint-script-plane.mjs

--- a/ai/scripts/diagnostics/structureMap.mjs
+++ b/ai/scripts/diagnostics/structureMap.mjs
@@ -20,6 +20,7 @@ import {fileURLToPath} from 'node:url';
 
 const DEFAULT_ROOT = 'ai';
 
+
 /**
  * Converts platform-specific path separators to POSIX separators for stable JSON output.
  * @param {string} value
@@ -55,7 +56,11 @@ export function createProgram() {
         .description('Emit deterministic JSON describing an Agent OS folder structure.')
         .option('-r, --root <path>', 'Root directory to inspect.', DEFAULT_ROOT)
         .option('--files', 'Include sorted file names per folder.')
-        .option('--loc', 'Include code LOC per file, excluding blank lines and common comment forms.');
+        .option('--loc', 'Include code LOC per file, excluding blank lines and common comment forms.')
+        // Opt-in, and the reason is measured rather than stylistic: the plane projection walks every
+        // npm-declared entrypoint's import closure, which takes ~2.2s against this command's ~160ms.
+        // Making a navigation tool 14x slower by default is how it stops being reached for.
+        .option('--planes', 'Annotate ai/scripts folders with their derived execution-plane tally.');
 }
 
 /**
@@ -202,8 +207,10 @@ function buildFileList(folderPath, files, {includeFiles, includeLoc}) {
 export function buildStructureMap({
     root         = DEFAULT_ROOT,
     cwd          = process.cwd(),
-    includeFiles = false,
-    includeLoc   = false
+    includeFiles  = false,
+    includeLoc    = false,
+    includePlanes = false,
+    planeProjection = null
 } = {}) {
     const rootPath = path.resolve(cwd, root),
           stat     = fs.statSync(rootPath);
@@ -240,6 +247,33 @@ export function buildStructureMap({
 
     folders.sort((a, b) => a.path.localeCompare(b.path));
 
+    if (includePlanes) {
+        // The projection is INJECTED, never defaulted. `buildStructureMap` is synchronous and the
+        // projection lives behind a dynamic import (so the fast path carries neither the parser
+        // dependency nor the ~2.2s closure walk), so the async CLI resolves it and passes it down.
+        //
+        // A missing projection throws rather than rendering folders with no tally: an empty plane
+        // annotation is indistinguishable from "this folder has no entrypoints", which is exactly the
+        // silent-default shape this whole lane exists to remove.
+        if (!planeProjection) {
+            throw new Error('buildStructureMap: includePlanes requires an injected planeProjection');
+        }
+
+        const projection = planeProjection;
+
+        folders.forEach(folder => {
+            const entry = projection[folder.path];
+
+            if (entry) {
+                folder.planes = entry.planes;
+                // `mixed` is the load-bearing field: a folder named after its VERB can hold three
+                // different planes, and that is precisely what a directory-keyed predicate gets wrong.
+                folder.planesMixed = entry.mixed;
+                folder.entrypointPlanes = entry.entrypoints
+            }
+        })
+    }
+
     return {
         root   : formatOutputPath(rootPath, cwd),
         folders: folders
@@ -259,10 +293,12 @@ function writeStructureMap(options, {
     stdout = process.stdout
 } = {}) {
     const map = buildStructureMap({
-        root        : options.root,
+        root           : options.root,
         cwd,
-        includeFiles: options.files,
-        includeLoc  : options.loc
+        includePlanes  : options.planes,
+        planeProjection: options.planeProjection,
+        includeFiles   : options.files,
+        includeLoc     : options.loc
     });
 
     stdout.write(`${JSON.stringify(map, null, 2)}\n`);
@@ -279,20 +315,28 @@ function writeStructureMap(options, {
  * @returns {Promise<{root:string, folders:Array}>}
  */
 export async function main(argv=process.argv.slice(2), io={}) {
-    return writeStructureMap(parseArgs(argv), io);
+    const options = parseArgs(argv);
+
+    if (options.planes) {
+        const {buildPlaneProjection} = await import('../lint/lint-script-plane.mjs');
+
+        options.planeProjection = buildPlaneProjection()
+    }
+
+    return writeStructureMap(options, io);
 }
 
 const isDirectCli = process.argv[1] && fileURLToPath(import.meta.url) === path.resolve(process.argv[1]);
 
 if (isDirectCli) {
-    Promise.resolve().then(() => {
-        const program = createProgram();
-
-        program.parse(process.argv);
-
-        return writeStructureMap(program.opts());
-    }).catch(error => {
-        console.error(error.message);
-        process.exit(1);
-    });
+    // Routed through `main()` rather than calling `writeStructureMap` directly: `main` is where the
+    // async plane projection is resolved, and a second entry path that skips it would make `--planes`
+    // work under test and fail from the shell — the two-entry-point divergence that makes a flag look
+    // implemented while nobody can use it.
+    Promise.resolve()
+        .then(() => main(process.argv.slice(2)))
+        .catch(error => {
+            console.error(error.message);
+            process.exit(1);
+        });
 }

--- a/ai/scripts/lint/lint-script-plane.mjs
+++ b/ai/scripts/lint/lint-script-plane.mjs
@@ -78,6 +78,11 @@ export function edgeIdentity(finding, projectRoot = PROJECT_ROOT) {
     const rel    = finding.module ? path.relative(projectRoot, finding.module) : finding.entrypoint,
           detail = finding.specifier ? finding.specifier
                  : finding.callee    ? `${finding.member}->${finding.callee}`
+                 // The owning member is the discriminator of last resort. Without it, two dynamic
+                 // imports in one module collapse to a single identity and swapping one for the
+                 // other passes a Set-backed ratchet unchanged — the substitution this ledger
+                 // exists to catch, scoped inside a file instead of across them.
+                 : finding.member    ? finding.member
                  : null;
 
     return [rel, finding.reason, detail].filter(Boolean).join('::')
@@ -97,22 +102,28 @@ export function edgeIdentity(finding, projectRoot = PROJECT_ROOT) {
  * @type {ReadonlyArray<String>}
  */
 export const UNRESOLVED_EDGE_LEDGER = Object.freeze([
-    // A runtime-computed overlay path. One site, and the largest single cause in the tree.
-    'ai/ConfigProvider.mjs::dynamic-import',
-    'ai/mcp/client/config.mjs::dynamic-import',
-    'ai/scripts/diagnostics/printAiConfig.mjs::dynamic-import',
-    'ai/scripts/lint/lint-config-template-ssot.mjs::dynamic-import',
-    'ai/scripts/maintenance/defragChromaDB.mjs::dynamic-import',
-    'ai/scripts/maintenance/purgeTestCollections.mjs::dynamic-import',
+    // Dynamic imports on runtime-computed paths, keyed by the member that performs them — three of
+    // these live in ONE module, and until the identity carried its member they collapsed into a
+    // single entry. The measured population was 9 while the real one was 12.
+    'ai/ConfigProvider.mjs::dynamic-import::load',
+    'ai/mcp/client/config.mjs::dynamic-import::load',
+    'ai/scripts/diagnostics/printAiConfig.mjs::dynamic-import::main',
+    'ai/scripts/lint/lint-config-template-ssot.mjs::dynamic-import::buildConfigEnvDefaultsForTemplate',
+    'ai/scripts/lint/lint-config-template-ssot.mjs::dynamic-import::collectConfigPathKindsFromTemplate',
+    'ai/scripts/lint/lint-config-template-ssot.mjs::dynamic-import::withTier1ConfigForLint',
+    'ai/scripts/maintenance/defragChromaDB.mjs::dynamic-import::loadConfig',
+    'ai/scripts/maintenance/purgeTestCollections.mjs::dynamic-import::resolveChromaEndpoint',
 
     // A specifier pointing at a module that no longer exists there — the flat-SDK migration left it
     // behind. Not this lane's to repair; the edge is listed so its disappearance is visible.
     'ai/scripts/maintenance/buildKbAgentFaqs.mjs::unresolved-specifier::'
         + '../../mcp/server/knowledge-base/services/KBRecorderService.mjs',
 
-    // Dispatch through a value the closure cannot name, with a capability behind the edge.
-    'ai/agent/AgentOrchestrator.mjs::unresolved-dispatch',
-    'ai/services/knowledge-base/DatabaseService.mjs::unresolved-dispatch'
+    // Dispatch through a value the closure cannot name, with a capability behind the edge. The
+    // callee is part of the identity, so the reader knows WHAT could not be followed.
+    'ai/agent/AgentOrchestrator.mjs::unresolved-dispatch::createAgent->agentFactory',
+    'ai/agent/AgentOrchestrator.mjs::unresolved-dispatch::emitHandoff->handoffEmitter',
+    'ai/services/knowledge-base/DatabaseService.mjs::unresolved-dispatch::createKnowledgeBase->SourceRegistry.getSources'
 ]);
 
 /**
@@ -268,17 +279,52 @@ export function readWorkflowEntrypoints({
  * @param {Object} [options]
  * @returns {Object} repo-relative script path -> `{taskName, authorityClass}`.
  */
+/**
+ * @summary Placeholder config that makes the task census MAXIMAL rather than default-shaped.
+ *
+ * `buildTaskDefinitions({})` is the descriptor layer's default, and two production roots exist only
+ * when a port is configured — `neuralLinkBridge` (host-edge) and `devServer`. Censusing the default
+ * therefore asks "what runs in an unconfigured process" when the question is **"which modules can be
+ * spawned as a production root at all"**, and a root that appears only under configuration is still a
+ * root whose declared authority nobody was checking.
+ *
+ * The values are sentinels and are never dialled, connected to, or read back: only the task TABLE's
+ * shape depends on their presence. Reading real `AiConfig` here instead would drag a runtime overlay
+ * into a static lint and make the population depend on the machine running it — the same
+ * environment-shaped answer this whole lane exists to remove.
+ * @type {Object}
+ */
+export const CENSUS_TASK_CONFIG = Object.freeze({
+    chromaDataDir                    : '/census',
+    chromaHost                       : 'census',
+    chromaPort                       : 1,
+    devServerLivenessTimeoutMs       : 1,
+    devServerPort                    : 1,
+    neuralLinkBridgeLivenessTimeoutMs: 1,
+    neuralLinkBridgePort             : 1
+});
+
 export function buildAuthorityByScript({
-    definitions     = buildTaskDefinitions({}),
+    definitions     = buildTaskDefinitions(CENSUS_TASK_CONFIG),
     authorityByName = TASK_AUTHORITY_BY_NAME,
     projectRoot     = PROJECT_ROOT
 } = {}) {
     const byScript = {};
 
     Object.entries(definitions).forEach(([taskName, definition]) => {
-        const script = (definition?.args ?? []).find(arg => typeof arg === 'string' && arg.endsWith('.mjs'));
+        // The executed module is `node`'s FIRST argument, never "the first arg ending in .mjs".
+        // `devServer` runs `node …/webpack.js serve -c ./buildScripts/…/webpack.server.config.mjs`,
+        // where the `.mjs` is a `-c` VALUE — so the extension heuristic joined a webpack config as
+        // if it were the entrypoint and then reported its plane. A config file has no plane.
+        const [script] = definition?.args ?? [];
 
-        if (!script || !(taskName in authorityByName)) {
+        if (typeof script !== 'string' || !/\.(mjs|js)$/.test(script) || !(taskName in authorityByName)) {
+            return
+        }
+
+        // A third-party binary is a leaf for the same reason a bare package specifier is: its plane
+        // is not ours to derive, and the subject here is what OUR roots require.
+        if (script.includes('node_modules/')) {
             return
         }
 

--- a/ai/scripts/lint/lint-script-plane.mjs
+++ b/ai/scripts/lint/lint-script-plane.mjs
@@ -92,6 +92,52 @@ export function taskNameFor(npmName, authorityByName = TASK_AUTHORITY_BY_NAME) {
 }
 
 /**
+ * @summary Per-folder plane tally over the npm-declared entrypoints, for the structure map.
+ *
+ * The navigational answer the map could not give before: `ai/scripts` names its folders after the
+ * VERB (`maintenance`, `diagnostics`, `runners`) and never the plane, so "can this run where there is
+ * no host shell" required opening the file. A folder carrying more than one plane is flagged `mixed`,
+ * because that is the case a reader most needs to see and the one a folder name most reliably hides.
+ *
+ * Entrypoints whose plane is unresolved are counted under `unresolved` rather than folded into a
+ * class — a folder that is half-unknown must not read as homogeneous.
+ *
+ * @param {Object} [options]
+ * @returns {Object} `{folder: {planes, mixed, entrypoints}}`, folder-keyed and sorted.
+ */
+export function buildPlaneProjection({
+    entrypoints     = readEntrypoints(),
+    authorityByName = TASK_AUTHORITY_BY_NAME,
+    projectRoot     = PROJECT_ROOT
+} = {}) {
+    const byFolder = {};
+
+    entrypoints.forEach(({name, rel}) => {
+        const
+            folder   = rel.slice(0, rel.lastIndexOf('/')),
+            closure  = walkCapabilityClosure({entrypoint: path.join(projectRoot, rel)}),
+            taskName = taskNameFor(name, authorityByName),
+            {plane}  = resolveEntrypointPlane({
+                closure,
+                authorityClass: taskName ? authorityByName[taskName] : null,
+                taskName,
+                entrypoint    : rel
+            }),
+            key      = plane ?? 'unresolved';
+
+        byFolder[folder] ??= {planes: {}, mixed: false, entrypoints: {}};
+        byFolder[folder].planes[key] = (byFolder[folder].planes[key] ?? 0) + 1;
+        byFolder[folder].entrypoints[rel.slice(folder.length + 1)] = key;
+    });
+
+    Object.values(byFolder).forEach(entry => {
+        entry.mixed = Object.keys(entry.planes).length > 1
+    });
+
+    return Object.fromEntries(Object.entries(byFolder).sort(([a], [b]) => a.localeCompare(b)))
+}
+
+/**
  * @summary Runs the lint over every npm-declared `ai/scripts` entrypoint.
  * @param {Object} [options]
  * @returns {{exitCode: Number, conflicts: Object[], unresolved: Number, planes: Object}}

--- a/ai/scripts/lint/lint-script-plane.mjs
+++ b/ai/scripts/lint/lint-script-plane.mjs
@@ -1,0 +1,172 @@
+import {createRequire} from 'node:module';
+import path            from 'node:path';
+import {fileURLToPath} from 'node:url';
+
+import {TASK_AUTHORITY_BY_NAME} from '../../daemons/orchestrator/taskAuthority.mjs';
+import {
+    FINDING,
+    resolveEntrypointPlane,
+    walkCapabilityClosure
+}                              from './scriptPlaneClosure.mjs';
+
+/**
+ * Fails a build when an `ai/scripts` entrypoint's declared execution authority disagrees with what
+ * its code actually reaches.
+ *
+ * The entrypoint population is read from `package.json`'s `ai:*` scripts rather than from a directory
+ * listing, because the npm entry is the real invocation contract: a file nobody can invoke has no
+ * plane to be wrong about, and a file invoked under a name is exactly where a wrong plane bites.
+ *
+ * **Two failure classes, deliberately not equal:**
+ *
+ * - An **authority conflict** fails the build. The orchestrator declares a task's class and the
+ *   closure found the opposite; one of them is wrong, and shipping either way means a script that
+ *   breaks on the plane it is declared for.
+ * - An **unresolved edge** does NOT fail on sight — it is ratcheted. A dynamic import on a
+ *   runtime-computed path cannot be followed statically, and a large pre-existing population of them
+ *   exists today (one site in the config provider accounts for most of it). Failing on all of them
+ *   would put the lint permanently red, and a permanently red lint is a lint everyone routes around.
+ *   Failing on an INCREASE keeps the population honest without pretending it is already zero.
+ *
+ * The ratchet baseline is a measured number, not a target. It must only ever be lowered — the same
+ * discipline the fixed-sleep baseline carries, and for the same reason: a baseline that can be raised
+ * to accommodate drift is a counter, not a gate.
+ */
+
+const
+    __filename   = fileURLToPath(import.meta.url),
+    PROJECT_ROOT = path.resolve(path.dirname(__filename), '../../..'),
+    require      = createRequire(import.meta.url);
+
+/**
+ * @summary Paths this lint reads. Imported by the workflow scan-root parity spec as the SSOT.
+ *
+ * `ai/**` is deliberately broad: the closure walks transitively, so a capability introduced anywhere
+ * a script can reach changes a verdict here. Narrowing this to `ai/scripts/**` would mean the guard
+ * does not RUN on the edit that changes its own answer — the failure mode the parity spec exists to
+ * prevent.
+ * @type {String[]}
+ */
+export const SCAN_SURFACE = Object.freeze([
+    'package.json',
+    'ai/**',
+    'ai/scripts/lint/lint-script-plane.mjs',
+    'ai/scripts/lint/scriptPlaneClosure.mjs',
+    '.github/workflows/script-plane-lint.yml'
+]);
+
+/**
+ * @summary Highest number of unresolved edges tolerated across the entrypoint population.
+ *
+ * MEASURED on `dev`, not chosen. Lower it when an edge is genuinely resolved; never raise it to make
+ * a red build pass — that inverts the gate into a record of whatever we happen to have.
+ * @type {Number}
+ */
+export const UNRESOLVED_EDGE_BASELINE = 40;
+
+/**
+ * @summary Maps an `ai:*` npm script to the `ai/scripts` module it invokes.
+ * @param {Object} [scripts] `package.json` scripts block.
+ * @returns {Array<{name: String, rel: String}>}
+ */
+export function readEntrypoints(scripts = require(path.join(PROJECT_ROOT, 'package.json')).scripts) {
+    return Object.entries(scripts)
+        .map(([name, command]) => ({name, rel: command.match(/(ai\/scripts\/[\w./-]+\.mjs)/)?.[1]}))
+        .filter(entry => entry.rel)
+}
+
+/**
+ * @summary Task name for an npm script, when the orchestrator declares one.
+ *
+ * The npm entry `ai:github-workflow-sync` and the task `githubWorkflowSync` are the same lane under
+ * two spellings, so the bridge is a normalisation rather than a second registry to keep in sync.
+ *
+ * @param {String} npmName e.g. `ai:github-workflow-sync`.
+ * @param {Object} [authorityByName] Injectable for tests.
+ * @returns {String|null}
+ */
+export function taskNameFor(npmName, authorityByName = TASK_AUTHORITY_BY_NAME) {
+    const camel = npmName.replace(/^ai:/, '').replace(/-([a-z])/g, (_, ch) => ch.toUpperCase());
+
+    return camel in authorityByName ? camel : null
+}
+
+/**
+ * @summary Runs the lint over every npm-declared `ai/scripts` entrypoint.
+ * @param {Object} [options]
+ * @returns {{exitCode: Number, conflicts: Object[], unresolved: Number, planes: Object}}
+ */
+export function runLint({
+    entrypoints      = readEntrypoints(),
+    authorityByName  = TASK_AUTHORITY_BY_NAME,
+    baseline         = UNRESOLVED_EDGE_BASELINE,
+    projectRoot      = PROJECT_ROOT
+} = {}) {
+    const
+        conflicts = [],
+        planes    = {'host-edge': 0, 'container-plane': 0, 'shared-primitive': 0, unresolved: 0};
+
+    let unresolved = 0;
+
+    entrypoints.forEach(({name, rel}) => {
+        const
+            closure  = walkCapabilityClosure({entrypoint: path.join(projectRoot, rel)}),
+            taskName = taskNameFor(name, authorityByName),
+            result   = resolveEntrypointPlane({
+                closure,
+                authorityClass: taskName ? authorityByName[taskName] : null,
+                taskName,
+                entrypoint    : rel
+            });
+
+        planes[result.plane ?? 'unresolved'] = (planes[result.plane ?? 'unresolved'] ?? 0) + 1;
+
+        result.findings.forEach(finding => {
+            if (finding.kind === FINDING.unresolvedEdge) {
+                unresolved++
+            } else {
+                conflicts.push(finding)
+            }
+        })
+    });
+
+    console.log(`[lint-script-plane] ${entrypoints.length} npm-declared ai/scripts entrypoint(s)`);
+    console.log(`  host-edge ${planes['host-edge']} · container-plane ${planes['container-plane']} `
+        + `· shared-primitive ${planes['shared-primitive']} · unresolved ${planes.unresolved}`);
+
+    if (conflicts.length === 0 && unresolved <= baseline) {
+        console.log(`  OK — no authority conflicts; ${unresolved} unresolved edge(s), baseline ${baseline}.`);
+        return {exitCode: 0, conflicts, unresolved, planes}
+    }
+
+    if (conflicts.length > 0) {
+        console.error(`\n[lint-script-plane] FAILED — ${conflicts.length} authority conflict(s):\n`);
+
+        conflicts.forEach(finding => {
+            console.error(`  ${finding.entrypoint}  (task: ${finding.taskName})`);
+            console.error(`    ${finding.message}`);
+            (finding.evidence ?? []).forEach(site => console.error(`      reached: ${site}`));
+            console.error('')
+        });
+
+        console.error('  The orchestrator\'s declared class and the code\'s capability closure disagree.');
+        console.error('  Fix whichever is wrong — do NOT silence this by widening the taxonomy.\n')
+    }
+
+    if (unresolved > baseline) {
+        console.error(`\n[lint-script-plane] FAILED — unresolved edges rose to ${unresolved} `
+            + `(baseline ${baseline}).\n`);
+        console.error('  A new dynamic import on a runtime-computed path makes an entrypoint\'s plane');
+        console.error('  underivable. Resolve the edge, or lower the baseline only when one is genuinely');
+        console.error('  removed. Raising it records drift instead of gating it.\n')
+    }
+
+    return {exitCode: 1, conflicts, unresolved, planes}
+}
+
+// Import-safe, per the house pattern in `lint-guard-ci-parity.mjs`: the workflow scan-root parity
+// spec imports SCAN_SURFACE from this module, and a bare `process.exit()` at module scope would
+// terminate the test process on import.
+if (process.argv[1] && path.resolve(process.argv[1]) === __filename) {
+    process.exit(runLint().exitCode)
+}

--- a/ai/scripts/lint/lint-script-plane.mjs
+++ b/ai/scripts/lint/lint-script-plane.mjs
@@ -1,4 +1,6 @@
 import {createRequire} from 'node:module';
+import fs              from 'node:fs';
+import * as yaml       from 'js-yaml';
 import path            from 'node:path';
 import {fileURLToPath} from 'node:url';
 
@@ -61,9 +63,13 @@ export const SCAN_SURFACE = Object.freeze([
  *
  * MEASURED on `dev`, not chosen. Lower it when an edge is genuinely resolved; never raise it to make
  * a red build pass — that inverts the gate into a record of whatever we happen to have.
+ *
+ * Re-measured at 38 when the census was corrected: the old 40 was taken over a population that
+ * counted five duplicate npm aliases as separate entrypoints and omitted four workflow-invoked
+ * modules. A ratchet inherited across a population change is not a ratchet.
  * @type {Number}
  */
-export const UNRESOLVED_EDGE_BASELINE = 40;
+export const UNRESOLVED_EDGE_BASELINE = 38;
 
 /**
  * @summary Maps an `ai:*` npm script to the `ai/scripts` module it invokes.
@@ -71,9 +77,75 @@ export const UNRESOLVED_EDGE_BASELINE = 40;
  * @returns {Array<{name: String, rel: String}>}
  */
 export function readEntrypoints(scripts = require(path.join(PROJECT_ROOT, 'package.json')).scripts) {
-    return Object.entries(scripts)
-        .map(([name, command]) => ({name, rel: command.match(/(ai\/scripts\/[\w./-]+\.mjs)/)?.[1]}))
-        .filter(entry => entry.rel)
+    const byRel = new Map();
+
+    Object.entries(scripts).forEach(([name, command]) => {
+        const rel = command.match(/(ai\/scripts\/[\w./-]+\.mjs)/)?.[1];
+
+        // Two npm aliases can point at one script (`defragChromaDB` has two); the population is
+        // MODULES with a plane, not invocation names, so it dedupes on the path.
+        if (rel && !byRel.has(rel)) {
+            byRel.set(rel, {name, rel, via: 'npm'})
+        }
+    });
+
+    readWorkflowEntrypoints().forEach(rel => {
+        if (!byRel.has(rel)) {
+            byRel.set(rel, {name: rel, rel, via: 'workflow'})
+        }
+    });
+
+    return [...byRel.values()]
+}
+
+/**
+ * @summary `ai/scripts` modules a GitHub workflow invokes directly, without going through npm.
+ *
+ * The npm block is not the whole invocation surface. Several workflows run a script straight —
+ * `run: node ./ai/scripts/lint/lint-guard-ci-parity.mjs` — so an npm-only census misses them, and the
+ * omission was self-demonstrating: **this lint invokes itself from a workflow and did not score
+ * itself.** A guard blind to its own execution path is the shape it exists to catch.
+ *
+ * Steps are read through the YAML parser rather than by grepping the file, so a path inside a comment
+ * or an unrelated key cannot be mistaken for an invocation. The command is then matched inside the
+ * step's `run` text, because that text is shell, not structure.
+ *
+ * @param {Object} [options]
+ * @returns {String[]} repo-relative module paths, deduped.
+ */
+export function readWorkflowEntrypoints({
+    workflowDir = path.join(PROJECT_ROOT, '.github/workflows')
+} = {}) {
+    if (!fs.existsSync(workflowDir)) {
+        return []
+    }
+
+    const found = new Set();
+
+    fs.readdirSync(workflowDir)
+        .filter(name => name.endsWith('.yml') || name.endsWith('.yaml'))
+        .forEach(name => {
+            let doc;
+
+            try {
+                doc = yaml.load(fs.readFileSync(path.join(workflowDir, name), 'utf8'))
+            } catch {
+                // An unparseable workflow is not this lint's subject; the workflow-syntax gates own it.
+                return
+            }
+
+            Object.values(doc?.jobs ?? {}).forEach(job => {
+                (job?.steps ?? []).forEach(step => {
+                    const run = typeof step?.run === 'string' ? step.run : '';
+
+                    for (const match of run.matchAll(/node\s+\.?\/?(ai\/scripts\/[\w./-]+\.mjs)/g)) {
+                        found.add(match[1])
+                    }
+                })
+            })
+        });
+
+    return [...found].sort()
 }
 
 /**
@@ -199,7 +271,11 @@ export function runLint({
         })
     });
 
-    console.log(`[lint-script-plane] ${entrypoints.length} npm-declared ai/scripts entrypoint(s)`);
+    const viaNpm      = entrypoints.filter(entry => entry.via !== 'workflow').length,
+          viaWorkflow = entrypoints.length - viaNpm;
+
+    console.log(`[lint-script-plane] ${entrypoints.length} ai/scripts entrypoint(s) — `
+        + `${viaNpm} npm-declared, ${viaWorkflow} workflow-invoked`);
     console.log(`  host-edge ${planes['host-edge']} · container-plane ${planes['container-plane']} `
         + `· shared-primitive ${planes['shared-primitive']} · unresolved ${planes.unresolved}`);
 

--- a/ai/scripts/lint/lint-script-plane.mjs
+++ b/ai/scripts/lint/lint-script-plane.mjs
@@ -2,6 +2,7 @@ import {createRequire} from 'node:module';
 import path            from 'node:path';
 import {fileURLToPath} from 'node:url';
 
+import {buildTaskDefinitions}   from '../../daemons/orchestrator/taskDefinitions.mjs';
 import {TASK_AUTHORITY_BY_NAME} from '../../daemons/orchestrator/taskAuthority.mjs';
 import {
     FINDING,
@@ -76,19 +77,41 @@ export function readEntrypoints(scripts = require(path.join(PROJECT_ROOT, 'packa
 }
 
 /**
- * @summary Task name for an npm script, when the orchestrator declares one.
+ * @summary Joins orchestrator tasks to the module each one actually executes.
  *
- * The npm entry `ai:github-workflow-sync` and the task `githubWorkflowSync` are the same lane under
- * two spellings, so the bridge is a normalisation rather than a second registry to keep in sync.
+ * **Keyed on the script PATH, never on a name.** The first version of this transformed the npm entry
+ * into a task name — `ai:sync-github-workflow` → `syncGithubWorkflow` — and the authority map's key
+ * is `githubWorkflowSync`. Same words, opposite order. That join matched **1 of 62** entrypoints, so
+ * the authority cross-check was very nearly inert and the `githubWorkflowSync` fixture, which the
+ * whole rule exists to catch, was not among the matches.
  *
- * @param {String} npmName e.g. `ai:github-workflow-sync`.
- * @param {Object} [authorityByName] Injectable for tests.
- * @returns {String|null}
+ * A task definition already carries the joinable fact: its `args` contain the resolved module path.
+ * Two names for one lane can disagree; a path is what the process actually runs.
+ *
+ * @param {Object} [options]
+ * @returns {Object} repo-relative script path -> `{taskName, authorityClass}`.
  */
-export function taskNameFor(npmName, authorityByName = TASK_AUTHORITY_BY_NAME) {
-    const camel = npmName.replace(/^ai:/, '').replace(/-([a-z])/g, (_, ch) => ch.toUpperCase());
+export function buildAuthorityByScript({
+    definitions     = buildTaskDefinitions({}),
+    authorityByName = TASK_AUTHORITY_BY_NAME,
+    projectRoot     = PROJECT_ROOT
+} = {}) {
+    const byScript = {};
 
-    return camel in authorityByName ? camel : null
+    Object.entries(definitions).forEach(([taskName, definition]) => {
+        const script = (definition?.args ?? []).find(arg => typeof arg === 'string' && arg.endsWith('.mjs'));
+
+        if (!script || !(taskName in authorityByName)) {
+            return
+        }
+
+        byScript[path.relative(projectRoot, path.resolve(script))] = {
+            taskName,
+            authorityClass: authorityByName[taskName]
+        }
+    });
+
+    return byScript
 }
 
 /**
@@ -106,24 +129,24 @@ export function taskNameFor(npmName, authorityByName = TASK_AUTHORITY_BY_NAME) {
  * @returns {Object} `{folder: {planes, mixed, entrypoints}}`, folder-keyed and sorted.
  */
 export function buildPlaneProjection({
-    entrypoints     = readEntrypoints(),
-    authorityByName = TASK_AUTHORITY_BY_NAME,
-    projectRoot     = PROJECT_ROOT
+    entrypoints       = readEntrypoints(),
+    authorityByScript = buildAuthorityByScript(),
+    projectRoot       = PROJECT_ROOT
 } = {}) {
     const byFolder = {};
 
-    entrypoints.forEach(({name, rel}) => {
+    entrypoints.forEach(({rel}) => {
         const
-            folder   = rel.slice(0, rel.lastIndexOf('/')),
-            closure  = walkCapabilityClosure({entrypoint: path.join(projectRoot, rel)}),
-            taskName = taskNameFor(name, authorityByName),
-            {plane}  = resolveEntrypointPlane({
+            folder    = rel.slice(0, rel.lastIndexOf('/')),
+            closure   = walkCapabilityClosure({entrypoint: path.join(projectRoot, rel)}),
+            authority = authorityByScript[rel] ?? null,
+            {plane}   = resolveEntrypointPlane({
                 closure,
-                authorityClass: taskName ? authorityByName[taskName] : null,
-                taskName,
+                authorityClass: authority?.authorityClass ?? null,
+                taskName      : authority?.taskName ?? null,
                 entrypoint    : rel
             }),
-            key      = plane ?? 'unresolved';
+            key       = plane ?? 'unresolved';
 
         byFolder[folder] ??= {planes: {}, mixed: false, entrypoints: {}};
         byFolder[folder].planes[key] = (byFolder[folder].planes[key] ?? 0) + 1;
@@ -144,7 +167,7 @@ export function buildPlaneProjection({
  */
 export function runLint({
     entrypoints      = readEntrypoints(),
-    authorityByName  = TASK_AUTHORITY_BY_NAME,
+    authorityByScript = buildAuthorityByScript(),
     baseline         = UNRESOLVED_EDGE_BASELINE,
     projectRoot      = PROJECT_ROOT
 } = {}) {
@@ -154,14 +177,14 @@ export function runLint({
 
     let unresolved = 0;
 
-    entrypoints.forEach(({name, rel}) => {
+    entrypoints.forEach(({rel}) => {
         const
-            closure  = walkCapabilityClosure({entrypoint: path.join(projectRoot, rel)}),
-            taskName = taskNameFor(name, authorityByName),
-            result   = resolveEntrypointPlane({
+            closure   = walkCapabilityClosure({entrypoint: path.join(projectRoot, rel)}),
+            authority = authorityByScript[rel] ?? null,
+            result    = resolveEntrypointPlane({
                 closure,
-                authorityClass: taskName ? authorityByName[taskName] : null,
-                taskName,
+                authorityClass: authority?.authorityClass ?? null,
+                taskName      : authority?.taskName ?? null,
                 entrypoint    : rel
             });
 

--- a/ai/scripts/lint/lint-script-plane.mjs
+++ b/ai/scripts/lint/lint-script-plane.mjs
@@ -59,24 +59,123 @@ export const SCAN_SURFACE = Object.freeze([
 ]);
 
 /**
- * @summary Highest number of unresolved edges tolerated across the entrypoint population.
+ * @summary Stable identity for one unresolved edge, deliberately WITHOUT its line number.
  *
- * MEASURED on `dev`, not chosen. Lower it when an edge is genuinely resolved; never raise it to make
- * a red build pass — that inverts the gate into a record of whatever we happen to have.
+ * A count is not an identity, and a ratchet on a count is a gate that cannot see substitution: one
+ * edge disappears, a different one appears, the total is unchanged and CI stays green while the
+ * closure got no sounder. Naming each edge is what makes the ledger below a ratchet rather than a
+ * tally.
  *
- * Re-measured at 38 when the census was corrected: the old 40 was taken over a population that
- * counted five duplicate npm aliases as separate entrypoints and omitted four workflow-invoked
- * modules. A ratchet inherited across a population change is not a ratchet.
- * @type {Number}
+ * The line is excluded on purpose. Including it would make every edge churn on any edit above it,
+ * and a ledger that churns is a ledger nobody reads — the identity has to be about the EDGE, not
+ * about where the edge currently sits.
+ *
+ * @param {Object} finding An `unresolved-edge` finding.
+ * @param {String} [projectRoot]
+ * @returns {String}
  */
-export const UNRESOLVED_EDGE_BASELINE = 38;
+export function edgeIdentity(finding, projectRoot = PROJECT_ROOT) {
+    const rel    = finding.module ? path.relative(projectRoot, finding.module) : finding.entrypoint,
+          detail = finding.specifier ? finding.specifier
+                 : finding.callee    ? `${finding.member}->${finding.callee}`
+                 : null;
+
+    return [rel, finding.reason, detail].filter(Boolean).join('::')
+}
 
 /**
- * @summary Maps an `ai:*` npm script to the `ai/scripts` module it invokes.
- * @param {Object} [scripts] `package.json` scripts block.
- * @returns {Array<{name: String, rel: String}>}
+ * @summary Every unresolved edge known to exist, by identity. The ratchet's whole surface.
+ *
+ * MEASURED, not chosen, and it may only ever SHRINK. An entry disappears when the edge is genuinely
+ * resolved; a new identity fails the build even when one of these vanishes in the same commit, which
+ * is the case a count-based baseline waves through.
+ *
+ * The dominant cause is a single site — `ai/ConfigProvider.mjs`'s `await import(absolutePath)` on a
+ * runtime-resolved overlay path. It is deliberately NOT special-cased: a dynamic import on a computed
+ * path could statically carry anything, and an exemption to make the number look better is precisely
+ * the hand-authored metadata this lane exists to remove.
+ * @type {ReadonlyArray<String>}
  */
-export function readEntrypoints(scripts = require(path.join(PROJECT_ROOT, 'package.json')).scripts) {
+export const UNRESOLVED_EDGE_LEDGER = Object.freeze([
+    // A runtime-computed overlay path. One site, and the largest single cause in the tree.
+    'ai/ConfigProvider.mjs::dynamic-import',
+    'ai/mcp/client/config.mjs::dynamic-import',
+    'ai/scripts/diagnostics/printAiConfig.mjs::dynamic-import',
+    'ai/scripts/lint/lint-config-template-ssot.mjs::dynamic-import',
+    'ai/scripts/maintenance/defragChromaDB.mjs::dynamic-import',
+    'ai/scripts/maintenance/purgeTestCollections.mjs::dynamic-import',
+
+    // A specifier pointing at a module that no longer exists there — the flat-SDK migration left it
+    // behind. Not this lane's to repair; the edge is listed so its disappearance is visible.
+    'ai/scripts/maintenance/buildKbAgentFaqs.mjs::unresolved-specifier::'
+        + '../../mcp/server/knowledge-base/services/KBRecorderService.mjs',
+
+    // Dispatch through a value the closure cannot name, with a capability behind the edge.
+    'ai/agent/AgentOrchestrator.mjs::unresolved-dispatch',
+    'ai/services/knowledge-base/DatabaseService.mjs::unresolved-dispatch'
+]);
+
+/**
+ * @summary Authority conflicts that are KNOWN, ticketed, and not this lane's to resolve.
+ *
+ * Every entry carries the ticket that will retire it, and the list may only shrink — a conflict with
+ * no ticket is not an entry, it is a silenced failure. This is the same primitive as the edge ledger
+ * above and it exists for the same reason: a gate that cannot record a known state either goes red
+ * forever, which teaches everyone to route around it, or grows a `default` branch, which is the
+ * silent-fallback shape this whole lane was built to remove.
+ *
+ * The one entry is a disagreement between two accepted things rather than a bug in either.
+ * ADR-0014 — ticket-ref-ok: the ADR is the authority whose verdict this entry defers to — deliberately
+ * classes `temporal-summary` container-plane, because the container IS the
+ * checkout, carrying `.git` at the built revision, which is exactly what
+ * `TemporalSummaryAggregationService.execCommand()` reads with `git log`. This lint's capability
+ * taxonomy maps ANY `child_process` use to `host-shell`, so it convicts a lane the ADR knowingly
+ * accepts. **The taxonomy is the part that is wrong**, and correcting it is a decision about what
+ * makes a lane host-edge, which belongs to the ADR and not to a lint that consumes it.
+ * @type {ReadonlyArray<String>}
+ */
+export const KNOWN_AUTHORITY_CONFLICTS = Object.freeze([
+    // #17217 — `child_process` is a subprocess predicate, not a plane predicate. ticket-ref-ok: the
+    // ticket IS this entry's warrant, and an entry that outlives it fails the lint's own check above.
+    'ai/scripts/maintenance/aggregate-temporal-summary.mjs::temporal-summary::authority-conflict-in-plane'
+]);
+
+/**
+ * @summary Stable identity for one authority conflict.
+ * @param {Object} finding A conflict finding.
+ * @returns {String}
+ */
+export function conflictIdentity(finding) {
+    return [finding.entrypoint, finding.taskName, finding.kind].join('::')
+}
+
+/**
+ * @summary Every production executable root, from all three channels that can start one.
+ *
+ * **A population is a claim, and this one was wrong twice in the same direction.** It began as npm
+ * scripts alone, which missed the modules a workflow runs directly — including this lint, which
+ * invokes itself from a workflow and did not score itself. Adding workflows still missed the roots the
+ * ORCHESTRATOR spawns: two `ai/scripts` modules and three daemons that appear in no npm script and no
+ * workflow, and that carry a declared authority class the lint therefore never checked. A gate whose
+ * population omits the artifacts with the strongest declarations is not conservative — it is quiet
+ * exactly where it is most needed.
+ *
+ * The third channel is `taskDefinitions`, joined the same way the authority map is: **on the script
+ * path from the definition's `args`**, never on a name.
+ *
+ * Daemons are included even though they are not under `ai/scripts`, and that is deliberate. The
+ * population is *executable roots that declare a plane*, not *files in a directory* — a
+ * directory-keyed predicate is the exact shape this lane retired, and re-introducing it as a
+ * population filter would smuggle it back in through the census.
+ *
+ * @param {Object} [scripts] `package.json` scripts block.
+ * @param {Object} [authorityByScript] Output of `buildAuthorityByScript`.
+ * @returns {Array<{name: String, rel: String, via: String}>}
+ */
+export function readEntrypoints(
+    scripts           = require(path.join(PROJECT_ROOT, 'package.json')).scripts,
+    authorityByScript = buildAuthorityByScript()
+) {
     const byRel = new Map();
 
     Object.entries(scripts).forEach(([name, command]) => {
@@ -92,6 +191,12 @@ export function readEntrypoints(scripts = require(path.join(PROJECT_ROOT, 'packa
     readWorkflowEntrypoints().forEach(rel => {
         if (!byRel.has(rel)) {
             byRel.set(rel, {name: rel, rel, via: 'workflow'})
+        }
+    });
+
+    Object.entries(authorityByScript).forEach(([rel, {taskName}]) => {
+        if (!byRel.has(rel)) {
+            byRel.set(rel, {name: taskName, rel, via: 'task'})
         }
     });
 
@@ -238,16 +343,18 @@ export function buildPlaneProjection({
  * @returns {{exitCode: Number, conflicts: Object[], unresolved: Number, planes: Object}}
  */
 export function runLint({
-    entrypoints      = readEntrypoints(),
+    entrypoints       = readEntrypoints(),
     authorityByScript = buildAuthorityByScript(),
-    baseline         = UNRESOLVED_EDGE_BASELINE,
-    projectRoot      = PROJECT_ROOT
+    ledger            = UNRESOLVED_EDGE_LEDGER,
+    knownConflicts    = KNOWN_AUTHORITY_CONFLICTS,
+    projectRoot       = PROJECT_ROOT
 } = {}) {
     const
         conflicts = [],
+        // Deduped across the population: the same edge is reached from many entrypoints, and counting
+        // it once per entrypoint measures the import graph's shape rather than the closure's soundness.
+        edges     = new Set(),
         planes    = {'host-edge': 0, 'container-plane': 0, 'shared-primitive': 0, unresolved: 0};
-
-    let unresolved = 0;
 
     entrypoints.forEach(({rel}) => {
         const
@@ -264,33 +371,55 @@ export function runLint({
 
         result.findings.forEach(finding => {
             if (finding.kind === FINDING.unresolvedEdge) {
-                unresolved++
+                edges.add(edgeIdentity(finding, projectRoot))
             } else {
                 conflicts.push(finding)
             }
         })
     });
 
-    const viaNpm      = entrypoints.filter(entry => entry.via !== 'workflow').length,
-          viaWorkflow = entrypoints.length - viaNpm;
+    const
+        known         = new Set(ledger),
+        knownConflict = new Set(knownConflicts),
+        appeared      = [...edges].filter(id => !known.has(id)).sort(),
+        resolved      = [...known].filter(id => !edges.has(id)).sort(),
+        newConflicts  = conflicts.filter(finding => !knownConflict.has(conflictIdentity(finding))),
+        heldConflicts = conflicts.filter(finding => knownConflict.has(conflictIdentity(finding))),
+        byVia         = via => entrypoints.filter(entry => entry.via === via).length;
 
-    console.log(`[lint-script-plane] ${entrypoints.length} ai/scripts entrypoint(s) — `
-        + `${viaNpm} npm-declared, ${viaWorkflow} workflow-invoked`);
+    console.log(`[lint-script-plane] ${entrypoints.length} executable root(s) — `
+        + `${byVia('npm')} npm-declared, ${byVia('workflow')} workflow-invoked, `
+        + `${byVia('task')} orchestrator-task`);
     console.log(`  host-edge ${planes['host-edge']} · container-plane ${planes['container-plane']} `
         + `· shared-primitive ${planes['shared-primitive']} · unresolved ${planes.unresolved}`);
 
-    if (conflicts.length === 0 && unresolved <= baseline) {
-        console.log(`  OK — no authority conflicts; ${unresolved} unresolved edge(s), baseline ${baseline}.`);
-        return {exitCode: 0, conflicts, unresolved, planes}
+    if (resolved.length > 0) {
+        console.log(`\n  ${resolved.length} ledger edge(s) no longer present — remove them from `
+            + 'UNRESOLVED_EDGE_LEDGER:');
+        resolved.forEach(id => console.log(`    - ${id}`))
     }
 
-    if (conflicts.length > 0) {
-        console.error(`\n[lint-script-plane] FAILED — ${conflicts.length} authority conflict(s):\n`);
+    heldConflicts.forEach(finding => {
+        console.log(`\n  KNOWN conflict, ticketed and held: ${finding.entrypoint} (${finding.taskName})`);
+        console.log(`    ${finding.message}`)
+    });
 
-        conflicts.forEach(finding => {
+    knownConflicts.filter(id => !conflicts.some(finding => conflictIdentity(finding) === id))
+        .forEach(id => console.log(`\n  KNOWN conflict no longer reproduces — remove it from `
+            + `KNOWN_AUTHORITY_CONFLICTS:\n    - ${id}`));
+
+    if (newConflicts.length === 0 && appeared.length === 0) {
+        console.log(`\n  OK — no new authority conflicts; ${edges.size} unresolved edge(s), all known.`);
+        return {exitCode: 0, conflicts, edges: [...edges], appeared, resolved, planes}
+    }
+
+    if (newConflicts.length > 0) {
+        console.error(`\n[lint-script-plane] FAILED — ${newConflicts.length} authority conflict(s):\n`);
+
+        newConflicts.forEach(finding => {
             console.error(`  ${finding.entrypoint}  (task: ${finding.taskName})`);
             console.error(`    ${finding.message}`);
-            (finding.evidence ?? []).forEach(site => console.error(`      reached: ${site}`));
+            (finding.evidence ?? []).forEach(site => console.error(`      ${site}`));
             console.error('')
         });
 
@@ -298,15 +427,16 @@ export function runLint({
         console.error('  Fix whichever is wrong — do NOT silence this by widening the taxonomy.\n')
     }
 
-    if (unresolved > baseline) {
-        console.error(`\n[lint-script-plane] FAILED — unresolved edges rose to ${unresolved} `
-            + `(baseline ${baseline}).\n`);
-        console.error('  A new dynamic import on a runtime-computed path makes an entrypoint\'s plane');
-        console.error('  underivable. Resolve the edge, or lower the baseline only when one is genuinely');
-        console.error('  removed. Raising it records drift instead of gating it.\n')
+    if (appeared.length > 0) {
+        console.error(`\n[lint-script-plane] FAILED — ${appeared.length} unresolved edge(s) not in the `
+            + 'ledger:\n');
+        appeared.forEach(id => console.error(`    + ${id}`));
+        console.error('\n  A call the closure cannot follow makes a no-host verdict unsound. Resolve the');
+        console.error('  edge, or — if it is genuinely unfollowable — add its identity to the ledger with');
+        console.error('  the reason. Never swap one identity for another to keep a total steady.\n')
     }
 
-    return {exitCode: 1, conflicts, unresolved, planes}
+    return {exitCode: 1, conflicts, edges: [...edges], appeared, resolved, planes}
 }
 
 // Import-safe, per the house pattern in `lint-guard-ci-parity.mjs`: the workflow scan-root parity

--- a/ai/scripts/lint/scriptPlaneClosure.mjs
+++ b/ai/scripts/lint/scriptPlaneClosure.mjs
@@ -188,6 +188,137 @@ export function isDeferredCallSite(ancestors) {
 }
 
 /**
+ * @summary The pseudo-member holding a module's top-level statements.
+ *
+ * Importing a module executes exactly this member and nothing else, which is why it is the only part
+ * of a reached module that is invoked by construction.
+ * @type {String}
+ */
+export const MODULE_SCOPE = '<module-scope>';
+
+/**
+ * @summary The nearest NAMED function-ish ancestor of a node — the member a call site belongs to.
+ *
+ * Member granularity is what makes the invocation walk sound. A module-level answer would say
+ * "`backup.mjs` calls into `ConnectionService`, therefore everything `ConnectionService` can do is
+ * required", which promotes `spawnBridgeProcess()` on the strength of an unrelated call to a sibling
+ * method. The proof has to name the member, or it is reachability again with an extra step.
+ *
+ * Anonymous callbacks attribute to their enclosing named member: a `spawn` inside a `forEach` inside
+ * `run()` runs when `run()` runs, which is the same approximation `isDeferredCallSite` already makes.
+ *
+ * @param {Object[]} ancestors Ancestor chain, nearest parent first.
+ * @returns {String} member name, or `MODULE_SCOPE` when the node sits in top-level code.
+ */
+export function owningMember(ancestors) {
+    // Whether a function boundary lies BELOW the ancestor under test. A key only owns a call site when
+    // the site is inside that key's function VALUE.
+    let crossedFunction = false;
+
+    for (const node of ancestors) {
+        if (isMemberKeyNode(node) && crossedFunction) {
+            return node.key?.name ?? node.key?.value ?? MODULE_SCOPE
+        }
+
+        if (node.type === 'FunctionDeclaration' && node.id?.name) {
+            return node.id.name
+        }
+
+        if (node.type === 'VariableDeclarator' && node.id?.type === 'Identifier'
+            && (node.init?.type === 'FunctionExpression' || node.init?.type === 'ArrowFunctionExpression')) {
+            return node.id.name
+        }
+
+        if (isFunctionNode(node)) {
+            crossedFunction = true
+        }
+    }
+
+    return MODULE_SCOPE
+}
+
+/** @summary Whether a node introduces a function scope. */
+function isFunctionNode(node) {
+    return node.type === 'FunctionDeclaration' || node.type === 'FunctionExpression'
+        || node.type === 'ArrowFunctionExpression'
+}
+
+/** @summary Whether a node is a keyed member slot — class method, class field, or object property. */
+function isMemberKeyNode(node) {
+    return node.type === 'MethodDefinition' || node.type === 'PropertyDefinition' || node.type === 'Property'
+}
+
+/**
+ * @summary Whether a node sits inside this repository's import-safe guard.
+ *
+ * `if (process.argv[1] && path.resolve(process.argv[1]) === __filename) { … }` is the house pattern —
+ * 98 modules under `ai/` carry it — and it means exactly one thing: **this runs when I am the process
+ * entry, and not when someone imports me.** A module-scope call is otherwise invoked by construction,
+ * so without this test the walk concludes that importing `lint-skill-manifest.mjs` runs its `main()`,
+ * and from there its `execFileSync` sites, and from there that `backup.mjs` requires a host shell —
+ * convicting the one file ADR-0014 rules the other way. ticket-ref-ok: the ADR is the authority the
+ * conclusion would have contradicted.
+ *
+ * This is requirement-vs-use again, one level up: the guard is the syntax that separates "this module's
+ * top level ran" from "this module's top level ran AS THE SCRIPT".
+ *
+ * @param {Object} node ESTree node to scan — an `if` test, or a declarator's initialiser.
+ * @param {Set<String>} [bindings] Locals already known to hold an entry path.
+ * @returns {Boolean}
+ */
+export function referencesEntryPath(node, bindings = new Set()) {
+    let found = false;
+
+    walkWithAncestors(node, current => {
+        if (current.type === 'MemberExpression' && current.object?.name === 'process'
+            && current.property?.name === 'argv') {
+            found = true
+        }
+
+        // `import.meta.url` — acorn models `import.meta` as a MetaProperty.
+        if (current.type === 'MetaProperty') {
+            found = true
+        }
+
+        // The hoisted spelling: `const modulePath = fileURLToPath(import.meta.url)` above, and a test
+        // of `cliEntryPath === modulePath` below. Both spellings are live in this tree, and reading
+        // only the inline one is how the walk concluded that importing `labels.mjs` runs its CLI.
+        if (current.type === 'Identifier' && bindings.has(current.name)) {
+            found = true
+        }
+    });
+
+    return found
+}
+
+/**
+ * @summary Whether a node sits inside this repository's import-safe guard. See `referencesEntryPath`.
+ * @param {Object[]} ancestors Ancestor chain, nearest parent first.
+ * @param {Set<String>} [entryPathBindings] Locals derived from `process.argv` / `import.meta`.
+ * @returns {Boolean}
+ */
+export function isEntrypointGuarded(ancestors, entryPathBindings = new Set()) {
+    for (let i = 0; i < ancestors.length; i++) {
+        const node = ancestors[i];
+
+        if (node.type !== 'IfStatement') {
+            continue
+        }
+
+        // Only the consequent is guarded; an `else` branch runs on import.
+        if (i > 0 && ancestors[i - 1] === node.alternate) {
+            continue
+        }
+
+        if (referencesEntryPath(node.test, entryPathBindings)) {
+            return true
+        }
+    }
+
+    return false
+}
+
+/**
  * @summary Whether a node sits inside a `try` block whose `catch` swallows the failure.
  *
  * The node must be in the try's BLOCK, not in its handler or finalizer — a call inside the catch is
@@ -236,16 +367,25 @@ export function collectModuleFacts(source) {
         unresolved   = [];
 
     if (!ast) {
-        return {imports, capabilities, unresolved: [{reason: 'unparseable'}], invokedSpecifiers: [], parsed: false}
+        return {
+            imports, capabilities, unresolved: [{reason: 'unparseable'}],
+            calls: [], members: [], bindings: {}, superBindings: [], parsed: false
+        }
     }
 
     // Which local binding names came from a host-capability package, so a later call can be traced
     // back to it. Matching the CALL rather than the import is what separates requirement from use.
     const
-        hostBindings    = new Map(),
-        // localName -> specifier, so a call on an imported binding can be traced back to its module.
-        importBindings  = new Map(),
-        invokedBindings = new Set();
+        hostBindings   = new Map(),
+        // localName -> {specifier, imported}, so a call on an imported binding resolves to a MEMBER of
+        // another module rather than merely to that module.
+        importBindings = new Map(),
+        superBindings  = new Set(),
+        members        = new Set([MODULE_SCOPE]),
+        // Locals holding the process entry path or this module's own path — the hoisted half of the
+        // import-safe guard.
+        entryPaths     = new Set(),
+        calls          = [];
 
     walkWithAncestors(ast, (node, ancestors) => {
         if (node.type === 'ImportDeclaration') {
@@ -257,12 +397,55 @@ export function collectModuleFacts(source) {
                   capability = Object.entries(HOST_CAPABILITY_SOURCES)
                       .find(([, sources]) => sources.includes(normalized))?.[0];
 
-            node.specifiers.forEach(spec => importBindings.set(spec.local.name, specifier));
+            node.specifiers.forEach(spec => importBindings.set(spec.local.name, {
+                specifier,
+                imported: spec.type === 'ImportDefaultSpecifier'   ? 'default'
+                        : spec.type === 'ImportNamespaceSpecifier' ? '*'
+                        : spec.imported?.name ?? spec.local.name
+            }));
 
             if (capability) {
                 node.specifiers.forEach(spec => hostBindings.set(spec.local.name, capability))
             }
             return
+        }
+
+        // `export {X as Y} from './p.mjs'` — a re-export binds a name to another module's value
+        // without ever importing it locally, so it is invisible to the ImportDeclaration branch.
+        if (node.type === 'ExportNamedDeclaration' && node.source?.value) {
+            imports.push(node.source.value);
+
+            (node.specifiers ?? []).forEach(spec => importBindings.set(
+                spec.exported?.name ?? spec.local?.name,
+                {specifier: node.source.value, imported: spec.local?.name ?? 'default'}
+            ));
+            return
+        }
+
+        // Declared members, so a caller in another module can be told "this target does not exist
+        // here" — the difference between a resolved edge and an honest unresolved one.
+        // A key is a MEMBER only when it holds a function. `{module: StateProvider}` is configuration,
+        // and admitting it would let a foreign `X.module()` resolve to a config value.
+        if (isMemberKeyNode(node)) {
+            const name = node.key?.name ?? node.key?.value;
+
+            if (name && (node.type === 'MethodDefinition' || isFunctionNode(node.value ?? {}))) {
+                members.add(String(name))
+            }
+        }
+
+        if (node.type === 'FunctionDeclaration' && node.id?.name) {
+            members.add(node.id.name)
+        }
+
+        // `class Service extends Base` — the inherited half of the member map. Without this, a
+        // `this.someInheritedMethod()` call resolves to nothing in the subclass and the walk stops at a
+        // member that is defined one file up. A subclass never mentions what it inherits, so a
+        // member-existence test that reads only the subclass is unsound by construction here.
+        if (node.type === 'ClassDeclaration' || node.type === 'ClassExpression') {
+            if (node.superClass?.type === 'Identifier') {
+                superBindings.add(node.superClass.name)
+            }
         }
 
         if (node.type === 'ImportExpression') {
@@ -293,6 +476,39 @@ export function collectModuleFacts(source) {
             if (alias && hostBindings.has(alias)) {
                 hostBindings.set(node.id.name, hostBindings.get(alias))
             }
+
+            if (init.type === 'FunctionExpression' || init.type === 'ArrowFunctionExpression') {
+                members.add(node.id.name)
+            }
+
+            if (referencesEntryPath(init, entryPaths)) {
+                entryPaths.add(node.id.name)
+            }
+
+            // Where a VALUE came from, which is a wider question than where a capability came from —
+            // and deliberately answered more loosely. `ai/services.mjs` binds its exports as
+            // `const KB_DatabaseService = makeSafe(_KB_DatabaseService, kbSpec)`, a two-argument
+            // wrapper the capability rule above will not follow. Routing a call through it costs at
+            // worst a hop into a module whose members do not match, which becomes an honest gap;
+            // NOT routing it costs the whole chain past every barrel in the tree.
+            //
+            // "Exactly one argument is an import binding" is what keeps that loose rule from guessing:
+            // `makeSafe(_X, spec)` has one, `compare(a, b)` over two imports has two and is skipped.
+            const wrapped = init.type === 'CallExpression'
+                ? (init.arguments ?? []).filter(arg => arg.type === 'Identifier' && importBindings.has(arg.name))
+                : [];
+
+            if (alias && importBindings.has(alias)) {
+                importBindings.set(node.id.name, importBindings.get(alias))
+            } else if (wrapped.length === 1) {
+                importBindings.set(node.id.name, importBindings.get(wrapped[0].name))
+            } else if (init.type === 'NewExpression' && init.callee?.type === 'Identifier'
+                && importBindings.has(init.callee.name)) {
+                // `const svc = new Svc()` — the instance pattern. Without it every call on a
+                // constructed service dispatches through a local whose origin cannot be named, and
+                // the chain stops one step after the `new`.
+                importBindings.set(node.id.name, importBindings.get(init.callee.name))
+            }
             return
         }
 
@@ -302,16 +518,30 @@ export function collectModuleFacts(source) {
 
         // `execFile(…)` / `execFileAsync(…)` / `spawn(…)` — a bare identifier, or a member expression
         // rooted at one (`cp.execSync(…)`), or a promisified wrapper bound from one.
-        const root = node.callee.type === 'Identifier'       ? node.callee.name
-                   : node.callee.type === 'MemberExpression' ? node.callee.object?.name
-                   : null;
+        const
+            {callee} = node,
+            isMember = callee.type === 'MemberExpression' && !callee.computed,
+            root     = callee.type === 'Identifier' ? callee.name
+                     : isMember && callee.object?.type === 'Identifier' ? callee.object.name
+                     : null;
+
+        // Every call a proven-invoked member makes, recorded so the invocation walk can follow it.
+        // `viaSelf` covers `this.x()` / `super.x()`, which is how a class reaches its own seams —
+        // `TemporalSummaryAggregationService` reaches `execSync` only through `this.execCommand()`.
+        calls.push({
+            member      : owningMember(ancestors),
+            binding     : root,
+            targetMember: isMember ? (callee.property?.name ?? null) : null,
+            viaSelf     : isMember && (callee.object?.type === 'ThisExpression' || callee.object?.type === 'Super'),
+            // `obj[key]()` — a destination chosen at runtime, and the one call form whose target is
+            // genuinely unnameable rather than merely unowned by this closure.
+            computed         : callee.type === 'MemberExpression' && callee.computed === true,
+            entrypointGuarded: isEntrypointGuarded(ancestors, entryPaths),
+            line             : node.loc?.start?.line ?? null
+        });
 
         if (!root) {
             return
-        }
-
-        if (importBindings.has(root)) {
-            invokedBindings.add(root)
         }
 
         const capability = hostBindings.get(root);
@@ -322,9 +552,15 @@ export function collectModuleFacts(source) {
             capabilities.push({
                 capability,
                 deferred,
-                // Kept separately from `required` so the entrypoint-own rule below can promote a
-                // deferred call WITHOUT promoting a gracefully-degraded one — the bundle-stamp case
-                // in the module header, where the program continues with a null instead of failing.
+                // Module-scope code behind the import-safe guard runs only when this module IS the
+                // script, so it is not promoted merely because something imported it.
+                entrypointGuarded: isEntrypointGuarded(ancestors, entryPaths),
+                // The member that OWNS this site. A deferred site is promoted only when this exact
+                // member is proven invoked — not when some sibling of it is.
+                member         : owningMember(ancestors),
+                // Kept separately from `required` so the invocation walk below can promote a deferred
+                // call WITHOUT promoting a gracefully-degraded one — the bundle-stamp case in the
+                // module header, where the program continues with a null instead of failing.
                 degradedInPlace: isGracefullyDegraded(ancestors),
                 // REQUIRED means: this runs, and its failure stops the program. A deferred site fails
                 // the first half (it may never be called) and a gracefully-degraded one fails the
@@ -335,13 +571,16 @@ export function collectModuleFacts(source) {
         }
     });
 
-    // The specifiers this module does not merely import but CALLS. One level of this is what
-    // separates `syncGithubWorkflow` (which invokes `GH_SyncService.runFullSync()`, and so genuinely
-    // needs what that method spawns) from `backup.mjs` (which reaches the same class of code without
-    // ever calling into it).
-    const invokedSpecifiers = [...invokedBindings].map(name => importBindings.get(name)).filter(Boolean);
-
-    return {imports, capabilities, unresolved, invokedSpecifiers: [...new Set(invokedSpecifiers)], parsed: true}
+    return {
+        imports,
+        capabilities,
+        unresolved,
+        calls,
+        members      : [...members],
+        bindings     : Object.fromEntries(importBindings),
+        superBindings: [...superBindings],
+        parsed       : true
+    }
 }
 
 /**
@@ -377,7 +616,46 @@ export function resolveRelative(specifier, fromFile) {
 }
 
 /**
- * @summary Walks an entrypoint's static import graph to fixpoint, collecting required capabilities.
+ * @summary Depth guard for the `extends` walk. Deeper than any hierarchy in this tree, and finite so a
+ * cyclic `extends` — which cannot execute, but can be written — cannot hang the lint.
+ * @type {Number}
+ */
+const MAX_SUPERCLASS_DEPTH = 12,
+      /** Bound on a reconstructed call chain, so a corrupted parent map cannot spin a build. */
+      MAX_CHAIN_LENGTH     = 64;
+
+/**
+ * @summary Walks an entrypoint's import graph, then its INVOCATION graph, collecting required capabilities.
+ *
+ * Two passes, because they answer different questions and only the second one is about running code:
+ *
+ * 1. **Reach** — follow every static relative import to fixpoint. This yields the module population and
+ *    every capability SITE inside it.
+ * 2. **Invoke** — walk `(module, member)` nodes from what provably runs, following named calls.
+ *
+ * What "required" can mean here, stated because neither pure answer is usable. A static graph cannot
+ * decide invocation, and the two sound extremes are both wrong: counting every reachable call convicts
+ * `backup.mjs` against ADR-0014 — ticket-ref-ok: the ADR is the authority being satisfied — because its
+ * closure reaches `spawn` inside methods nothing calls; counting only module-scope calls classifies the
+ * ENTIRE tree as in-plane, because real code puts its shell calls inside functions.
+ *
+ * **The rule is neither extreme: a capability is required when the member that owns it is proven to
+ * run.** Proof is seeded by the two things that run by construction — every reached module's top-level
+ * code, and every member of the entrypoint itself, since running the script is what its own code is
+ * for — and then propagated along named calls for as far as the syntax carries it.
+ *
+ * An earlier version bounded that propagation at ONE hop, which was a false-safe rather than a
+ * conservative choice: `/e -> Svc.run() -> Deep.go() -> spawn` is fully static at every step, and
+ * stopping after the first hop reported `required: []` for a chain nothing had to guess about. The
+ * bound was not protecting the bundle-stamp case — MEMBER granularity is what protects it, because
+ * calling `ConnectionService.connect()` never proves `spawnBridgeProcess()` runs.
+ *
+ * **What the walk cannot name, it says so about.** A call from a proven-invoked member whose target
+ * cannot be located — a member missing from the module it resolves to, a `this.x()` absent from the
+ * class and its bases, a computed callee — becomes an `unresolved-dispatch` edge, and an unresolved
+ * edge makes a NO-HOST verdict unsound. It is reported only when the closure still holds an
+ * unattributed capability the dispatch could reach: an edge that provably leads nowhere dangerous is
+ * not a gap in the proof, and reporting it would bury the ones that are.
  *
  * `readFile` and `resolve` are injected so the whole closure is testable without a repository — the
  * fixtures that red-prove `githubWorkflowSync` and `backup` run entirely in memory.
@@ -386,7 +664,7 @@ export function resolveRelative(specifier, fromFile) {
  * @param {String} options.entrypoint Absolute path.
  * @param {Function} [options.readFile] `(absPath) => String|null`.
  * @param {Function} [options.resolve] `(specifier, fromFile) => String|null`.
- * @returns {{reached: String[], required: Object[], used: Object[], unresolved: Object[]}}
+ * @returns {{reached: String[], required: Object[], used: Object[], unresolved: Object[], invoked: String[]}}
  */
 export function walkCapabilityClosure({
     entrypoint,
@@ -395,15 +673,14 @@ export function walkCapabilityClosure({
 }) {
     const
         seen       = new Set(),
-        // Modules the entrypoint CALLS into, not merely imports. Populated while the entrypoint is
-        // read, and the queue is FIFO with the entrypoint seeded first, so every callee is visited
-        // after this set is known.
-        directlyInvoked = new Set(),
+        factsBy    = new Map(),
+        importsBy  = new Map(),
         queue      = [entrypoint],
         required   = [],
         used       = [],
         unresolved = [];
 
+    // ---- Pass 1: reach ----
     while (queue.length > 0) {
         const current = queue.shift();
 
@@ -413,8 +690,7 @@ export function walkCapabilityClosure({
 
         seen.add(current);
 
-        const isEntrypoint = current === entrypoint,
-              source       = readFile(current);
+        const source = readFile(current);
 
         if (source === null) {
             unresolved.push({module: current, reason: 'unreadable'});
@@ -423,41 +699,10 @@ export function walkCapabilityClosure({
 
         const facts = collectModuleFacts(source);
 
+        factsBy.set(current, facts);
         facts.unresolved.forEach(edge => unresolved.push({module: current, ...edge}));
 
-        // What "required" can mean here, stated because neither pure answer is usable.
-        //
-        // A static import graph cannot decide INVOCATION, and the two sound extremes are both wrong:
-        // counting every reachable call convicts `backup.mjs` against ADR-0014 — ticket-ref-ok: the
-        // ADR is the authority being satisfied — (its closure reaches
-        // `spawn` inside methods nothing calls), while counting only module-scope calls classifies
-        // the ENTIRE tree as in-plane, because real code puts its shell calls inside functions.
-        //
-        // So the rule is: a capability is required when the ENTRYPOINT'S OWN code calls it — its
-        // functions are what running the script executes — or when a reached module runs it at MODULE
-        // SCOPE, which importing alone triggers. A deferred call in a transitively reached module is
-        // recorded as `used`, never as a requirement, because nothing here proves it is reached.
-        if (isEntrypoint) {
-            facts.invokedSpecifiers.forEach(specifier => {
-                if (!specifier.startsWith('.')) {
-                    return
-                }
-
-                const target = resolve(specifier, current);
-
-                if (target) {
-                    directlyInvoked.add(target)
-                }
-            })
-        }
-
-        facts.capabilities.forEach(entry => {
-            const runs = entry.required
-                || (isEntrypoint && !entry.degradedInPlace)
-                || (directlyInvoked.has(current) && !entry.degradedInPlace);
-
-            (runs ? required : used).push({module: current, ...entry})
-        });
+        const targets = new Set();
 
         facts.imports.forEach(specifier => {
             if (!specifier.startsWith('.')) {
@@ -469,14 +714,281 @@ export function walkCapabilityClosure({
             const target = resolve(specifier, current);
 
             if (target) {
+                targets.add(target);
                 queue.push(target)
             } else {
                 unresolved.push({module: current, specifier, reason: 'unresolved-specifier'})
             }
         });
+
+        importsBy.set(current, targets);
     }
 
-    return {reached: [...seen], required, used, unresolved}
+    // ---- Pass 2: invoke ----
+    const
+        // node key -> the node that proved it, or null for a seed. The chain is what a maintainer
+        // staring at a conflict actually needs: "this entrypoint requires a shell" is not actionable
+        // until you can see the three calls that get there.
+        invoked      = new Map(),
+        memberQueue  = [],
+        dispatchGaps = [],
+
+        /**
+         * Follows a local binding to the module that DEFINES its value, hopping through re-export
+         * barrels. `ai/services.mjs` is 225 lines of exactly that, and stopping at the barrel reports
+         * a gap whose only cause is an indirection the code is explicit about.
+         */
+        resolveOrigin = (fromModule, binding, depth = 0) => {
+            const record = factsBy.get(fromModule)?.bindings?.[binding];
+
+            if (!record || depth > MAX_SUPERCLASS_DEPTH || !record.specifier.startsWith('.')) {
+                return null
+            }
+
+            const target      = resolve(record.specifier, fromModule),
+                  targetFacts = target ? factsBy.get(target) : null;
+
+            if (!targetFacts) {
+                return null
+            }
+
+            const {imported} = record;
+
+            if (imported !== 'default' && imported !== '*' && targetFacts.bindings?.[imported]) {
+                const onward = resolveOrigin(target, imported, depth + 1);
+
+                if (onward) {
+                    return onward
+                }
+            }
+
+            return {module: target, exported: imported}
+        },
+
+        /**
+         * Locates a member on a module, walking `extends` chains. A subclass never mentions the
+         * members it inherits, so stopping at the subclass would report a gap where the code is
+         * perfectly static — the same blind spot a single-file grep has.
+         */
+        findMember = (module, wanted, depth = 0) => {
+            const facts = factsBy.get(module);
+
+            if (!facts || depth > MAX_SUPERCLASS_DEPTH) {
+                return null
+            }
+
+            if (facts.members.includes(wanted)) {
+                return {module, member: wanted}
+            }
+
+            for (const superBinding of facts.superBindings) {
+                const origin = resolveOrigin(module, superBinding);
+
+                if (origin) {
+                    const inherited = findMember(origin.module, wanted, depth + 1);
+
+                    if (inherited) {
+                        return inherited
+                    }
+                }
+            }
+
+            return null
+        },
+
+        /** Resolves a call on a local binding to the `(module, member)` it lands on. */
+        resolveTarget = (fromModule, binding, wantedMember) => {
+            const origin = resolveOrigin(fromModule, binding);
+
+            if (!origin) {
+                return null
+            }
+
+            // `Svc.run()` lands on `run`; a bare `helper()` lands on whatever name was imported.
+            const wanted = wantedMember
+                ?? (origin.exported === 'default' || origin.exported === '*' ? 'default' : origin.exported);
+
+            return findMember(origin.module, wanted)
+        },
+
+        // Whether a host capability exists anywhere behind a module — memoised, cycle-safe.
+        capabilityCache = new Map(),
+
+        reachesCapability = (module, stack = new Set()) => {
+            if (capabilityCache.has(module)) {
+                return capabilityCache.get(module)
+            }
+
+            if (stack.has(module)) {
+                // Mid-cycle: contribute nothing rather than answering. The outer frame decides.
+                return false
+            }
+
+            stack.add(module);
+
+            const answer = (factsBy.get(module)?.capabilities.length ?? 0) > 0
+                || [...(importsBy.get(module) ?? [])].some(target => reachesCapability(target, stack));
+
+            stack.delete(module);
+            capabilityCache.set(module, answer);
+
+            return answer
+        },
+
+        enqueue = (module, member, from = null) => {
+            const key = `${module}::${member}`;
+
+            if (!invoked.has(key)) {
+                invoked.set(key, from);
+                memberQueue.push({module, member, key})
+            }
+        };
+
+    // Seeds. Importing a module executes its top level and nothing else; running the entrypoint is
+    // what every member it declares is for.
+    seen.forEach(module => enqueue(module, MODULE_SCOPE));
+    (factsBy.get(entrypoint)?.members ?? []).forEach(member => enqueue(entrypoint, member));
+
+    while (memberQueue.length > 0) {
+        const {module, member, key} = memberQueue.shift(),
+              facts                 = factsBy.get(module);
+
+        if (!facts) {
+            continue
+        }
+
+        facts.calls.filter(call => call.member === member
+            // Behind the import-safe guard, and this module is not the script — so it does not run.
+            && !(call.entrypointGuarded && module !== entrypoint)).forEach(call => {
+            // `this.x()` / `super.x()` — the class's own seam. This is the only way
+            // `TemporalSummaryAggregationService` reaches `execSync`, three members deep.
+            if (call.viaSelf) {
+                if (call.targetMember && facts.members.includes(call.targetMember)) {
+                    enqueue(module, call.targetMember, key);
+                    return
+                }
+
+                for (const superBinding of facts.superBindings) {
+                    const inherited = resolveTarget(module, superBinding, call.targetMember);
+
+                    if (inherited) {
+                        enqueue(inherited.module, inherited.member, key);
+                        return
+                    }
+                }
+
+                dispatchGaps.push({module, member, call, reason: 'self-member-not-found', behind: module});
+                return
+            }
+
+            if (call.computed) {
+                // `obj[key]()` — the destination is chosen at runtime and there is no name to follow.
+                dispatchGaps.push({module, member, call, reason: 'computed-callee', behind: module});
+                return
+            }
+
+            if (!call.binding) {
+                // A chained callee — `factory().run()`, `promise.then()`. The receiver is a VALUE, and
+                // values are outside what a name-based closure can police. Same declared leaf as a
+                // bare package specifier, stated rather than silently dropped.
+                return
+            }
+
+            // A local function or const-bound arrow in this same module — `main()`.
+            if (!call.targetMember && facts.members.includes(call.binding)) {
+                enqueue(module, call.binding, key);
+                return
+            }
+
+            const record = facts.bindings?.[call.binding];
+
+            if (!record) {
+                // Not an import, not a local member: a global, a parameter, or a value from elsewhere.
+                // A LEAF for the same reason as above — `console.log` is not a hidden shell.
+                return
+            }
+
+            if (!record.specifier.startsWith('.')) {
+                // A bare package. The import walk already treats these as leaves and the capability
+                // taxonomy names the ones that matter, so `path.join()` is answered, not unknown.
+                return
+            }
+
+            const target = resolveTarget(module, call.binding, call.targetMember);
+
+            if (target) {
+                enqueue(target.module, target.member, key)
+            } else {
+                dispatchGaps.push({
+                    module, member, call,
+                    reason: 'member-not-found',
+                    behind: resolveOrigin(module, call.binding)?.module ?? resolve(record.specifier, module)
+                })
+            }
+        })
+    }
+
+    // ---- Classify every capability site against what was proven to run ----
+    factsBy.forEach((facts, module) => {
+        facts.capabilities.forEach(entry => {
+            // A guarded site in an imported module is dead code for this entrypoint: the guard is a
+            // runtime test on the process entry, and the answer is statically known here.
+            const dormant = entry.entrypointGuarded && module !== entrypoint,
+                  runs    = !dormant && (entry.required
+                      || (!entry.degradedInPlace && invoked.has(`${module}::${entry.member}`)));
+
+            (runs ? required : used).push({module, ...entry})
+        })
+    });
+
+    // A dispatch we could not follow only threatens the verdict on two conditions, and both must hold.
+    //
+    // 1. Something must remain for it to reach: once every capability site in the closure is required
+    //    or provably degraded, an unnameable call cannot change the answer.
+    // 2. A capability must lie BEHIND that particular edge. `IDENTITIES.map(…)` resolves to a module
+    //    of string constants — there is no member called `map` there, and there is also no shell, so
+    //    calling it an unresolved edge would be true and useless.
+    //
+    // Reporting every unnameable call instead of these two produced 656 edges on `backup.mjs` alone,
+    // which is not a stricter gate — it is the same gate with its signal buried.
+    if (used.some(entry => !entry.degradedInPlace)) {
+        dispatchGaps
+            .filter(gap => gap.behind && reachesCapability(gap.behind))
+            .forEach(gap => unresolved.push({
+                module: gap.module,
+                reason: 'unresolved-dispatch',
+                member: gap.member,
+                callee: [gap.call.binding, gap.call.targetMember].filter(Boolean).join('.') || null,
+                line  : gap.call.line
+            }))
+    }
+
+    return {reached: [...seen], required, used, unresolved, invoked: [...invoked.keys()], invokedBy: invoked}
+}
+
+/**
+ * @summary Reconstructs the call chain that proved a `(module, member)` node runs, entrypoint first.
+ *
+ * A conflict finding without this says "something here needs a shell" and leaves the reader to find
+ * the three calls that get there. With it, the finding names them. Cycles cannot occur — a node is
+ * recorded once, on the edge that first proved it — but the walk is bounded anyway so a corrupted map
+ * cannot hang a build.
+ *
+ * @param {Map} invokedBy `walkCapabilityClosure().invokedBy`.
+ * @param {String} key `${module}::${member}`.
+ * @returns {String[]} keys, root first.
+ */
+export function invocationChain(invokedBy, key) {
+    const chain = [];
+
+    let current = key;
+
+    while (current && chain.length <= MAX_CHAIN_LENGTH) {
+        chain.unshift(current);
+        current = invokedBy.get(current) ?? null
+    }
+
+    return chain
 }
 
 /**

--- a/ai/scripts/lint/scriptPlaneClosure.mjs
+++ b/ai/scripts/lint/scriptPlaneClosure.mjs
@@ -1,0 +1,489 @@
+import {parse} from 'acorn';
+import fs      from 'node:fs';
+import path    from 'node:path';
+
+/**
+ * Derives an `ai/scripts` entrypoint's execution plane from what it REACHES, never from what it is
+ * called or where it sits.
+ *
+ * Two cheaper shapes were tried and retired against measured falsifiers: keying the plane on the
+ * directory, and declaring it in a per-file header. Both fail the same way — **a directory name and a
+ * header are both names, and a name can be wrong while the code moves on without it.** What survives
+ * is entrypoint-owned authority × transitive capability closure, and this module is the closure half.
+ *
+ * **The load-bearing distinction is REQUIREMENT vs USE.** A script that *reaches* a host capability
+ * on a path that degrades gracefully does not *require* a host. ADR-0014 settles this — ticket-ref-ok:
+ * the ADR is the authority that defines the distinction, not background reading — on
+ * `ai/scripts/maintenance/backup.mjs`, whose `git rev-parse HEAD` bundle-meta stamp is explicitly
+ * ruled a non-dependency because it degrades to `null` without `.git`:
+ *
+ *     let gitSha = null;
+ *     try   { const {stdout} = await execFileAsync('git', ['rev-parse', 'HEAD'], …); gitSha = …; }
+ *     catch (err) { logger.warn?.(…); }          // swallowed — the function returns normally
+ *
+ * A predicate keyed on "imports `child_process`" convicts that file against an accepted ADR. So the
+ * capability is only a REQUIREMENT when its call site can actually abort the program: a bare call, or
+ * one inside a `try` whose `catch` rethrows or exits. That test needs real syntax, which is why this
+ * parses with `acorn` rather than matching tokens — a regex over `try`/`catch` nesting would be the
+ * same unit error the retired classifier made, wearing a better costume.
+ */
+
+const
+    // Both spellings are live in this tree (37 files reach child_process, split across `x` and
+    // `node:x`), so every specifier is normalised before it is compared to anything.
+    NODE_PREFIX = 'node:',
+    SOURCE_EXTS = ['.mjs', '.js', '.json'];
+
+/**
+ * @summary Capabilities whose REQUIRED use pins an entrypoint to the host edge.
+ *
+ * Deliberately small and grounded in Local Runtime Parity's actual constraint — a client topology has
+ * **no host shell and no Docker socket** — rather than in a wide list of things that merely feel
+ * host-ish. `fs` is excluded on purpose: it is imported by most of the tree and therefore
+ * discriminates nothing, and the plane question is about the shell and the socket, not about files.
+ * @type {Object}
+ */
+export const HOST_CAPABILITY = Object.freeze({
+    shell : 'host-shell',
+    socket: 'docker-socket'
+});
+
+/**
+ * @summary Bare specifiers that grant each host capability.
+ * @type {Object}
+ */
+export const HOST_CAPABILITY_SOURCES = Object.freeze({
+    [HOST_CAPABILITY.shell] : Object.freeze(['child_process']),
+    [HOST_CAPABILITY.socket]: Object.freeze(['dockerode', 'docker-modem'])
+});
+
+/**
+ * @summary Normalises a module specifier for comparison: strips the `node:` prefix, keeps the package root.
+ * @param {String} specifier Raw import specifier.
+ * @returns {String}
+ */
+export function normalizeSpecifier(specifier) {
+    const value = String(specifier || '');
+
+    if (value.startsWith('.') || value.startsWith('/')) {
+        return value
+    }
+
+    const bare = value.startsWith(NODE_PREFIX) ? value.slice(NODE_PREFIX.length) : value;
+
+    // Scoped packages keep two segments (`@scope/name`); everything else keeps one, so a deep import
+    // like `fs-extra/lib/json` compares equal to `fs-extra`.
+    const parts = bare.split('/');
+
+    return bare.startsWith('@') ? parts.slice(0, 2).join('/') : parts[0]
+}
+
+/**
+ * @summary Parses a module, returning `null` rather than throwing on syntax this parser cannot read.
+ *
+ * A parse failure is an UNRESOLVED EDGE, not a plane verdict — the caller turns it into a named
+ * finding. Swallowing it into a default would reproduce the defect this whole lane exists to remove.
+ *
+ * @param {String} source Module text.
+ * @returns {Object|null} ESTree program, or null when unparseable.
+ */
+export function parseModule(source) {
+    try {
+        return parse(String(source || ''), {ecmaVersion: 'latest', sourceType: 'module', locations: true})
+    } catch {
+        return null
+    }
+}
+
+/**
+ * @summary Depth-first walk yielding every node with its ancestor chain, nearest parent first.
+ *
+ * Hand-rolled because `acorn-walk` is not a dependency here and adding one to read a chain of
+ * `TryStatement` ancestors is not worth the surface. Ancestors are what the requirement test needs;
+ * a plain visitor cannot answer "is this call inside a swallowing try".
+ *
+ * @param {Object} node ESTree node.
+ * @param {Function} visit Called as `(node, ancestors)`.
+ * @param {Object[]} [ancestors] Internal.
+ */
+export function walkWithAncestors(node, visit, ancestors = []) {
+    if (!node || typeof node.type !== 'string') {
+        return
+    }
+
+    visit(node, ancestors);
+
+    const nextAncestors = [node, ...ancestors];
+
+    for (const key of Object.keys(node)) {
+        if (key === 'type' || key === 'loc' || key === 'start' || key === 'end') {
+            continue
+        }
+
+        const value = node[key];
+
+        if (Array.isArray(value)) {
+            value.forEach(child => walkWithAncestors(child, visit, nextAncestors))
+        } else if (value && typeof value.type === 'string') {
+            walkWithAncestors(value, visit, nextAncestors)
+        }
+    }
+}
+
+/**
+ * @summary Whether a `catch` clause lets the failure abort the program.
+ *
+ * Rethrowing or exiting means the capability was REQUIRED after all — the guard only converts the
+ * error's shape, it does not survive its absence. Anything else (logging, a fallback assignment, an
+ * empty body) means the program continues without the capability — the graceful-degradation shape
+ * ADR-0014 accepts. ticket-ref-ok: the ADR is the authority this predicate implements.
+ *
+ * @param {Object} handler ESTree CatchClause.
+ * @returns {Boolean} true when the handler rethrows or exits.
+ */
+export function handlerAborts(handler) {
+    if (!handler) {
+        // `try { … } finally { … }` with no catch does NOT swallow: the error still propagates.
+        return true
+    }
+
+    let aborts = false;
+
+    walkWithAncestors(handler.body, node => {
+        if (node.type === 'ThrowStatement') {
+            aborts = true
+        }
+
+        // `process.exit(…)` — the other way a handler declines to continue.
+        if (node.type === 'CallExpression' && node.callee?.type === 'MemberExpression'
+            && node.callee.object?.name === 'process' && node.callee.property?.name === 'exit') {
+            aborts = true
+        }
+    });
+
+    return aborts
+}
+
+/**
+ * @summary Whether a node sits inside a `try` block whose `catch` swallows the failure.
+ *
+ * The node must be in the try's BLOCK, not in its handler or finalizer — a call inside the catch is
+ * not protected by that catch.
+ *
+ * @param {Object[]} ancestors Ancestor chain, nearest parent first.
+ * @returns {Boolean}
+ */
+export function isGracefullyDegraded(ancestors) {
+    for (let i = 0; i < ancestors.length; i++) {
+        const node = ancestors[i];
+
+        if (node.type !== 'TryStatement') {
+            continue
+        }
+
+        // Identify which limb we came from by finding the previous ancestor in the chain.
+        const cameFrom = i === 0 ? null : ancestors[i - 1];
+
+        if (cameFrom && (cameFrom === node.handler || cameFrom === node.finalizer)) {
+            continue
+        }
+
+        if (!handlerAborts(node.handler)) {
+            return true
+        }
+    }
+
+    return false
+}
+
+/**
+ * @summary Static imports and required host capabilities for one module.
+ *
+ * Only STATIC imports are followed. A dynamic `import(expr)` with a non-literal specifier is an
+ * unresolved edge and is reported as one — see `collectModuleFacts().unresolved`.
+ *
+ * @param {String} source Module text.
+ * @returns {{imports: String[], capabilities: Object[], unresolved: Object[], parsed: Boolean}}
+ */
+export function collectModuleFacts(source) {
+    const
+        ast          = parseModule(source),
+        imports      = [],
+        capabilities = [],
+        unresolved   = [];
+
+    if (!ast) {
+        return {imports, capabilities, unresolved: [{reason: 'unparseable'}], parsed: false}
+    }
+
+    // Which local binding names came from a host-capability package, so a later call can be traced
+    // back to it. Matching the CALL rather than the import is what separates requirement from use.
+    const hostBindings = new Map();
+
+    walkWithAncestors(ast, (node, ancestors) => {
+        if (node.type === 'ImportDeclaration') {
+            const specifier = node.source.value;
+
+            imports.push(specifier);
+
+            const normalized = normalizeSpecifier(specifier),
+                  capability = Object.entries(HOST_CAPABILITY_SOURCES)
+                      .find(([, sources]) => sources.includes(normalized))?.[0];
+
+            if (capability) {
+                node.specifiers.forEach(spec => hostBindings.set(spec.local.name, capability))
+            }
+            return
+        }
+
+        if (node.type === 'ImportExpression') {
+            if (node.source?.type === 'Literal' && typeof node.source.value === 'string') {
+                imports.push(node.source.value)
+            } else {
+                unresolved.push({
+                    reason: 'dynamic-import',
+                    line  : node.loc?.start?.line ?? null
+                })
+            }
+            return
+        }
+
+        // A capability rarely reaches its call site under its imported name. `backup.mjs` binds
+        // `const execFileAsync = promisify(execFile)` — so a detector that only knows import bindings
+        // reports ZERO capability sites for the very file ADR-0014 uses as its fixture — ticket-ref-ok:
+        // the ADR names that file as the canonical case — which is a
+        // false negative dressed as a clean result. Derivation is therefore tracked through simple
+        // aliasing and single-argument wrappers (`promisify`, `util.promisify`) before calls are read.
+        if (node.type === 'VariableDeclarator' && node.id?.type === 'Identifier' && node.init) {
+            const {init} = node,
+                  alias  = init.type === 'Identifier' ? init.name
+                         : init.type === 'CallExpression' && init.arguments?.length === 1
+                           && init.arguments[0].type === 'Identifier' ? init.arguments[0].name
+                         : null;
+
+            if (alias && hostBindings.has(alias)) {
+                hostBindings.set(node.id.name, hostBindings.get(alias))
+            }
+            return
+        }
+
+        if (node.type !== 'CallExpression') {
+            return
+        }
+
+        // `execFile(…)` / `execFileAsync(…)` / `spawn(…)` — a bare identifier, or a member expression
+        // rooted at one (`cp.execSync(…)`), or a promisified wrapper bound from one.
+        const root = node.callee.type === 'Identifier'       ? node.callee.name
+                   : node.callee.type === 'MemberExpression' ? node.callee.object?.name
+                   : null;
+
+        if (!root) {
+            return
+        }
+
+        const capability = hostBindings.get(root);
+
+        if (capability) {
+            capabilities.push({
+                capability,
+                required: !isGracefullyDegraded(ancestors),
+                line    : node.loc?.start?.line ?? null
+            })
+        }
+    });
+
+    return {imports, capabilities, unresolved, parsed: true}
+}
+
+/**
+ * @summary Resolves a relative specifier to a file on disk, or `null` when nothing matches.
+ * @param {String} specifier Relative import specifier.
+ * @param {String} fromFile Absolute path of the importing module.
+ * @returns {String|null}
+ */
+export function resolveRelative(specifier, fromFile) {
+    const base = path.resolve(path.dirname(fromFile), specifier);
+
+    if (fs.existsSync(base) && fs.statSync(base).isFile()) {
+        return base
+    }
+
+    for (const ext of SOURCE_EXTS) {
+        const candidate = base + ext;
+
+        if (fs.existsSync(candidate)) {
+            return candidate
+        }
+    }
+
+    for (const ext of SOURCE_EXTS) {
+        const candidate = path.join(base, `index${ext}`);
+
+        if (fs.existsSync(candidate)) {
+            return candidate
+        }
+    }
+
+    return null
+}
+
+/**
+ * @summary Walks an entrypoint's static import graph to fixpoint, collecting required capabilities.
+ *
+ * `readFile` and `resolve` are injected so the whole closure is testable without a repository — the
+ * fixtures that red-prove `githubWorkflowSync` and `backup` run entirely in memory.
+ *
+ * @param {Object} options
+ * @param {String} options.entrypoint Absolute path.
+ * @param {Function} [options.readFile] `(absPath) => String|null`.
+ * @param {Function} [options.resolve] `(specifier, fromFile) => String|null`.
+ * @returns {{reached: String[], required: Object[], used: Object[], unresolved: Object[]}}
+ */
+export function walkCapabilityClosure({
+    entrypoint,
+    readFile = absPath => (fs.existsSync(absPath) ? fs.readFileSync(absPath, 'utf8') : null),
+    resolve  = resolveRelative
+}) {
+    const
+        seen       = new Set(),
+        queue      = [entrypoint],
+        required   = [],
+        used       = [],
+        unresolved = [];
+
+    while (queue.length > 0) {
+        const current = queue.shift();
+
+        if (seen.has(current)) {
+            continue
+        }
+
+        seen.add(current);
+
+        const source = readFile(current);
+
+        if (source === null) {
+            unresolved.push({module: current, reason: 'unreadable'});
+            continue
+        }
+
+        const facts = collectModuleFacts(source);
+
+        facts.unresolved.forEach(edge => unresolved.push({module: current, ...edge}));
+
+        facts.capabilities.forEach(entry => {
+            (entry.required ? required : used).push({module: current, ...entry})
+        });
+
+        facts.imports.forEach(specifier => {
+            if (!specifier.startsWith('.')) {
+                // A bare package is a leaf: its own graph is not ours to police, and the capability
+                // taxonomy already names the ones that matter.
+                return
+            }
+
+            const target = resolve(specifier, current);
+
+            if (target) {
+                queue.push(target)
+            } else {
+                unresolved.push({module: current, specifier, reason: 'unresolved-specifier'})
+            }
+        });
+    }
+
+    return {reached: [...seen], required, used, unresolved}
+}
+
+/**
+ * @summary Finding kinds this resolver emits. Every one names a real disagreement or a real gap.
+ *
+ * There is deliberately no `default` or `assumed` kind. The retired designs all failed by having a
+ * plane to fall back to when they could not tell — and the fallback is where a comparator loses its
+ * teeth, because nobody argues with the answer nobody had to defend.
+ * @type {Object}
+ */
+export const FINDING = Object.freeze({
+    authorityConflictInPlane: 'authority-conflict-in-plane',
+    authorityConflictHost   : 'authority-conflict-host',
+    unresolvedEdge          : 'unresolved-edge'
+});
+
+/**
+ * @summary Resolves one entrypoint's plane from its closure, with `TASK_AUTHORITY_BY_NAME` as the
+ * authority for mapped tasks.
+ *
+ * The authority is CONSUMED, never re-derived: for a mapped task the declared class is the answer,
+ * and the closure's job is to DISAGREE with it loudly rather than to vote. Both directions of
+ * disagreement are findings, but they are not the same defect and the repair differs:
+ *
+ * - `authority-conflict-in-plane` — the authority says this runs where there is no shell, and the
+ *   closure found a required one. The script breaks on the plane it is declared for. Severe.
+ * - `authority-conflict-host` — the authority says host-edge and the closure found no requirement.
+ *   Usually over-declaration or a runtime dependency the static graph cannot see; still reported,
+ *   because an authority nobody can reproduce from the code is the thing this lane exists to fix.
+ *
+ * An unresolved edge NEVER downgrades to a plane. It is reported and the plane is `null`, so a
+ * caller cannot mistake "could not tell" for "safe".
+ *
+ * @param {Object} options
+ * @param {Object} options.closure Result of `walkCapabilityClosure`.
+ * @param {String|null} [options.authorityClass] `ORCHESTRATOR_AUTHORITY_CLASS` value for a mapped task.
+ * @param {String|null} [options.taskName] Task name, for finding messages.
+ * @param {String} [options.entrypoint] Path, for finding messages.
+ * @returns {{plane: String|null, basis: String, findings: Object[]}}
+ */
+export function resolveEntrypointPlane({closure, authorityClass = null, taskName = null, entrypoint = ''}) {
+    const
+        findings      = [],
+        closureIsHost = closure.required.length > 0,
+        hostEvidence  = closure.required.map(entry => `${entry.module}:${entry.line}`);
+
+    closure.unresolved.forEach(edge => {
+        findings.push({
+            kind     : FINDING.unresolvedEdge,
+            entrypoint,
+            module   : edge.module ?? null,
+            reason   : edge.reason,
+            specifier: edge.specifier ?? null,
+            line     : edge.line ?? null,
+            message  : `unresolved edge (${edge.reason}) — the plane cannot be derived through it`
+        })
+    });
+
+    // An unresolved edge means the closure is INCOMPLETE, so a "no host requirement" verdict from it
+    // is unsound: the capability could live behind the edge we could not follow. A host verdict still
+    // stands — we found a requirement, and more reachable code cannot remove one.
+    const closureIsSound = closureIsHost || findings.length === 0;
+
+    if (authorityClass) {
+        const authorityIsHost = authorityClass === 'host-edge';
+
+        if (!authorityIsHost && closureIsHost) {
+            findings.push({
+                kind    : FINDING.authorityConflictInPlane,
+                entrypoint,
+                taskName,
+                authorityClass,
+                evidence: hostEvidence,
+                message : `authority declares '${authorityClass}' but the closure requires a host capability`
+            })
+        } else if (authorityIsHost && !closureIsHost && closureIsSound) {
+            findings.push({
+                kind   : FINDING.authorityConflictHost,
+                entrypoint,
+                taskName,
+                authorityClass,
+                message: 'authority declares host-edge but the closure found no required host capability'
+            })
+        }
+
+        return {plane: authorityClass, basis: 'authority', findings}
+    }
+
+    return {
+        plane: closureIsSound ? (closureIsHost ? 'host-edge' : 'container-plane') : null,
+        basis: closureIsSound ? 'closure' : 'unresolved',
+        findings
+    }
+}

--- a/ai/scripts/lint/scriptPlaneClosure.mjs
+++ b/ai/scripts/lint/scriptPlaneClosure.mjs
@@ -236,12 +236,16 @@ export function collectModuleFacts(source) {
         unresolved   = [];
 
     if (!ast) {
-        return {imports, capabilities, unresolved: [{reason: 'unparseable'}], parsed: false}
+        return {imports, capabilities, unresolved: [{reason: 'unparseable'}], invokedSpecifiers: [], parsed: false}
     }
 
     // Which local binding names came from a host-capability package, so a later call can be traced
     // back to it. Matching the CALL rather than the import is what separates requirement from use.
-    const hostBindings = new Map();
+    const
+        hostBindings    = new Map(),
+        // localName -> specifier, so a call on an imported binding can be traced back to its module.
+        importBindings  = new Map(),
+        invokedBindings = new Set();
 
     walkWithAncestors(ast, (node, ancestors) => {
         if (node.type === 'ImportDeclaration') {
@@ -252,6 +256,8 @@ export function collectModuleFacts(source) {
             const normalized = normalizeSpecifier(specifier),
                   capability = Object.entries(HOST_CAPABILITY_SOURCES)
                       .find(([, sources]) => sources.includes(normalized))?.[0];
+
+            node.specifiers.forEach(spec => importBindings.set(spec.local.name, specifier));
 
             if (capability) {
                 node.specifiers.forEach(spec => hostBindings.set(spec.local.name, capability))
@@ -304,6 +310,10 @@ export function collectModuleFacts(source) {
             return
         }
 
+        if (importBindings.has(root)) {
+            invokedBindings.add(root)
+        }
+
         const capability = hostBindings.get(root);
 
         if (capability) {
@@ -325,7 +335,13 @@ export function collectModuleFacts(source) {
         }
     });
 
-    return {imports, capabilities, unresolved, parsed: true}
+    // The specifiers this module does not merely import but CALLS. One level of this is what
+    // separates `syncGithubWorkflow` (which invokes `GH_SyncService.runFullSync()`, and so genuinely
+    // needs what that method spawns) from `backup.mjs` (which reaches the same class of code without
+    // ever calling into it).
+    const invokedSpecifiers = [...invokedBindings].map(name => importBindings.get(name)).filter(Boolean);
+
+    return {imports, capabilities, unresolved, invokedSpecifiers: [...new Set(invokedSpecifiers)], parsed: true}
 }
 
 /**
@@ -379,6 +395,10 @@ export function walkCapabilityClosure({
 }) {
     const
         seen       = new Set(),
+        // Modules the entrypoint CALLS into, not merely imports. Populated while the entrypoint is
+        // read, and the queue is FIFO with the entrypoint seeded first, so every callee is visited
+        // after this set is known.
+        directlyInvoked = new Set(),
         queue      = [entrypoint],
         required   = [],
         used       = [],
@@ -417,8 +437,24 @@ export function walkCapabilityClosure({
         // functions are what running the script executes — or when a reached module runs it at MODULE
         // SCOPE, which importing alone triggers. A deferred call in a transitively reached module is
         // recorded as `used`, never as a requirement, because nothing here proves it is reached.
+        if (isEntrypoint) {
+            facts.invokedSpecifiers.forEach(specifier => {
+                if (!specifier.startsWith('.')) {
+                    return
+                }
+
+                const target = resolve(specifier, current);
+
+                if (target) {
+                    directlyInvoked.add(target)
+                }
+            })
+        }
+
         facts.capabilities.forEach(entry => {
-            const runs = entry.required || (isEntrypoint && !entry.degradedInPlace);
+            const runs = entry.required
+                || (isEntrypoint && !entry.degradedInPlace)
+                || (directlyInvoked.has(current) && !entry.degradedInPlace);
 
             (runs ? required : used).push({module: current, ...entry})
         });

--- a/ai/scripts/lint/scriptPlaneClosure.mjs
+++ b/ai/scripts/lint/scriptPlaneClosure.mjs
@@ -165,6 +165,29 @@ export function handlerAborts(handler) {
 }
 
 /**
+ * @summary Whether a call site is DEFERRED — inside a function, so it runs only if something calls it.
+ *
+ * This is the second half of requirement-vs-use, and without it the transitive closure is wrong in a
+ * way that convicts an accepted ADR. Importing a module executes its MODULE SCOPE, not its function
+ * bodies. `backup.mjs` transitively reaches `spawn` inside `ConnectionService.spawnBridgeProcess()`,
+ * `execFileSync` inside a `collect` arrow in the skill-manifest lint, and `spawn` inside a promise
+ * executor in `gitMirror` — none of which run because `backup.mjs` was imported.
+ *
+ * Attributing those to the entrypoint marks it host-required, which is precisely the false positive
+ * ADR-0014 rules out — ticket-ref-ok: the ADR is the authority this predicate implements.
+ * Reachability is not invocation, and a closure that conflates them says
+ * "everything is host-edge" with great confidence.
+ *
+ * @param {Object[]} ancestors Ancestor chain, nearest parent first.
+ * @returns {Boolean}
+ */
+export function isDeferredCallSite(ancestors) {
+    return ancestors.some(node => node.type === 'FunctionDeclaration'
+        || node.type === 'FunctionExpression'
+        || node.type === 'ArrowFunctionExpression')
+}
+
+/**
  * @summary Whether a node sits inside a `try` block whose `catch` swallows the failure.
  *
  * The node must be in the try's BLOCK, not in its handler or finalizer — a call inside the catch is
@@ -284,9 +307,19 @@ export function collectModuleFacts(source) {
         const capability = hostBindings.get(root);
 
         if (capability) {
+            const deferred = isDeferredCallSite(ancestors);
+
             capabilities.push({
                 capability,
-                required: !isGracefullyDegraded(ancestors),
+                deferred,
+                // Kept separately from `required` so the entrypoint-own rule below can promote a
+                // deferred call WITHOUT promoting a gracefully-degraded one — the bundle-stamp case
+                // in the module header, where the program continues with a null instead of failing.
+                degradedInPlace: isGracefullyDegraded(ancestors),
+                // REQUIRED means: this runs, and its failure stops the program. A deferred site fails
+                // the first half (it may never be called) and a gracefully-degraded one fails the
+                // second (the program continues without it).
+                required: !deferred && !isGracefullyDegraded(ancestors),
                 line    : node.loc?.start?.line ?? null
             })
         }
@@ -360,7 +393,8 @@ export function walkCapabilityClosure({
 
         seen.add(current);
 
-        const source = readFile(current);
+        const isEntrypoint = current === entrypoint,
+              source       = readFile(current);
 
         if (source === null) {
             unresolved.push({module: current, reason: 'unreadable'});
@@ -371,8 +405,22 @@ export function walkCapabilityClosure({
 
         facts.unresolved.forEach(edge => unresolved.push({module: current, ...edge}));
 
+        // What "required" can mean here, stated because neither pure answer is usable.
+        //
+        // A static import graph cannot decide INVOCATION, and the two sound extremes are both wrong:
+        // counting every reachable call convicts `backup.mjs` against ADR-0014 — ticket-ref-ok: the
+        // ADR is the authority being satisfied — (its closure reaches
+        // `spawn` inside methods nothing calls), while counting only module-scope calls classifies
+        // the ENTIRE tree as in-plane, because real code puts its shell calls inside functions.
+        //
+        // So the rule is: a capability is required when the ENTRYPOINT'S OWN code calls it — its
+        // functions are what running the script executes — or when a reached module runs it at MODULE
+        // SCOPE, which importing alone triggers. A deferred call in a transitively reached module is
+        // recorded as `used`, never as a requirement, because nothing here proves it is reached.
         facts.capabilities.forEach(entry => {
-            (entry.required ? required : used).push({module: current, ...entry})
+            const runs = entry.required || (isEntrypoint && !entry.degradedInPlace);
+
+            (runs ? required : used).push({module: current, ...entry})
         });
 
         facts.imports.forEach(specifier => {

--- a/ai/scripts/lint/scriptPlaneClosure.mjs
+++ b/ai/scripts/lint/scriptPlaneClosure.mjs
@@ -454,6 +454,11 @@ export function collectModuleFacts(source) {
             } else {
                 unresolved.push({
                     reason: 'dynamic-import',
+                    // The owning member discriminates two dynamic imports in one module without
+                    // reintroducing the line number. Keying identity on `module::reason` alone let
+                    // one site be swapped for another inside the same file with the ledger none the
+                    // wiser — the substitution the ledger exists to catch, scoped down one level.
+                    member: owningMember(ancestors),
                     line  : node.loc?.start?.line ?? null
                 })
             }
@@ -533,6 +538,14 @@ export function collectModuleFacts(source) {
             binding     : root,
             targetMember: isMember ? (callee.property?.name ?? null) : null,
             viaSelf     : isMember && (callee.object?.type === 'ThisExpression' || callee.object?.type === 'Super'),
+            // Bare identifiers handed to this call. `run(danger)` passes a function REFERENCE and
+            // `run(fn)` then calls `fn()` — a chain where every name is in the source, and which a
+            // callee-only walk drops entirely because `fn` is a parameter and parameters are leaves.
+            // The result was not a conservative stop but a SILENT safe verdict: `required: []` and
+            // `unresolved: []` for code that plainly spawns. Handing a function to something that
+            // runs is evidence it may run, so the reference is followed; names that are not members
+            // resolve to nothing and cost one lookup.
+            argRefs     : (node.arguments ?? []).filter(arg => arg.type === 'Identifier').map(arg => arg.name),
             // `obj[key]()` — a destination chosen at runtime, and the one call form whose target is
             // genuinely unnameable rather than merely unowned by this closure.
             computed         : callee.type === 'MemberExpression' && callee.computed === true,
@@ -860,6 +873,22 @@ export function walkCapabilityClosure({
         facts.calls.filter(call => call.member === member
             // Behind the import-safe guard, and this module is not the script — so it does not run.
             && !(call.entrypointGuarded && module !== entrypoint)).forEach(call => {
+            // Function references handed to this call, followed BEFORE the callee itself — the
+            // callee may be unresolvable while the reference is perfectly nameable, and dropping
+            // the argument because the callee was opaque is how `run(danger)` came back safe.
+            (call.argRefs ?? []).forEach(name => {
+                if (facts.members.includes(name)) {
+                    enqueue(module, name, key);
+                    return
+                }
+
+                const passed = resolveTarget(module, name, null);
+
+                if (passed) {
+                    enqueue(passed.module, passed.member, key)
+                }
+            });
+
             // `this.x()` / `super.x()` — the class's own seam. This is the only way
             // `TemporalSummaryAggregationService` reaches `execSync`, three members deep.
             if (call.viaSelf) {
@@ -1042,8 +1071,14 @@ export function resolveEntrypointPlane({closure, authorityClass = null, taskName
             module   : edge.module ?? null,
             reason   : edge.reason,
             specifier: edge.specifier ?? null,
-            line     : edge.line ?? null,
-            message  : `unresolved edge (${edge.reason}) — the plane cannot be derived through it`
+            // The two discriminators that separate one edge from another INSIDE a module. They were
+            // collected on the closure edge and then dropped here, so every consumer keyed on
+            // `module::reason` alone — a ratchet blind to substitution within a file, and an
+            // identity function whose discriminating branch could never fire in production.
+            member : edge.member ?? null,
+            callee : edge.callee ?? null,
+            line   : edge.line ?? null,
+            message: `unresolved edge (${edge.reason}) — the plane cannot be derived through it`
         })
     });
 

--- a/test/playwright/unit/ai/scripts/diagnostics/structureMap.spec.mjs
+++ b/test/playwright/unit/ai/scripts/diagnostics/structureMap.spec.mjs
@@ -145,3 +145,56 @@ test.describe('ai/scripts/diagnostics/structureMap (#14307)', () => {
         ].join('\n'), 'fixture.yaml')).toBe(4);
     });
 });
+
+test.describe('--planes projection (#16929)', () => {
+    /*
+     * `ai/scripts` names its folders after the VERB — `maintenance`, `diagnostics`, `lint` — and never
+     * the execution plane, which is why "can this run where there is no host shell" used to mean
+     * opening the file. Five of the seven folders carry more than one plane, so `planesMixed` is the
+     * field that earns this projection: a folder name cannot tell you, and now the map can.
+     */
+    const projection = {
+        'ai/scripts/maintenance': {
+            planes     : {'host-edge': 4, 'container-plane': 2, unresolved: 18},
+            mixed      : true,
+            entrypoints: {'backup.mjs': 'container-plane'}
+        },
+        'ai/scripts/migrations': {
+            planes     : {'host-edge': 3},
+            mixed      : false,
+            entrypoints: {}
+        }
+    };
+
+    test('annotates folders with their tally and flags the mixed ones', () => {
+        const map    = buildStructureMap({root: 'ai/scripts', includePlanes: true, planeProjection: projection}),
+              byPath = Object.fromEntries(map.folders.map(folder => [folder.path, folder]));
+
+        expect(byPath['ai/scripts/maintenance'].planes).toEqual(projection['ai/scripts/maintenance'].planes);
+        expect(byPath['ai/scripts/maintenance'].planesMixed, 'a verb-named folder holding three planes is the case worth seeing').toBe(true);
+        expect(byPath['ai/scripts/migrations'].planesMixed).toBe(false);
+    });
+
+    test('a folder outside the projection is left untouched, not zero-filled', () => {
+        const map    = buildStructureMap({root: 'ai/scripts', includePlanes: true, planeProjection: projection}),
+              absent = map.folders.find(folder => !(folder.path in projection));
+
+        // Zero-filling would make "no entrypoints here" and "no plane could be derived" look identical.
+        expect(absent).toBeTruthy();
+        expect(absent.planes).toBeUndefined();
+    });
+
+    test('includePlanes WITHOUT a projection throws rather than rendering empty tallies', () => {
+        // The load-bearing arm. An empty annotation reads as "this folder has no entrypoints", which
+        // is the silent-default shape this whole lane exists to remove — so it must fail loudly.
+        expect(() => buildStructureMap({root: 'ai/scripts', includePlanes: true}))
+            .toThrow(/requires an injected planeProjection/);
+    });
+
+    test('the default path carries no plane keys at all', () => {
+        // Opt-in is measured, not stylistic: the projection walks every entrypoint's import closure.
+        const map = buildStructureMap({root: 'ai/scripts'});
+
+        expect(map.folders.every(folder => folder.planes === undefined)).toBe(true);
+    });
+});

--- a/test/playwright/unit/ai/scripts/lint/lintWorkflowScanRootParity.spec.mjs
+++ b/test/playwright/unit/ai/scripts/lint/lintWorkflowScanRootParity.spec.mjs
@@ -7,6 +7,7 @@ import {SCAN_SURFACE as CONFIG_TEMPLATE_SURFACE} from '../../../../../../ai/scri
 import {SCAN_SURFACE as FIXED_SLEEP_SURFACE}     from '../../../../../../buildScripts/util/check-fixed-sleeps.mjs';
 import {SCAN_SURFACE as GUARD_CI_PARITY_SURFACE} from '../../../../../../ai/scripts/lint/lint-guard-ci-parity.mjs';
 import {SCAN_SURFACE as MCP_LOCATION_SURFACE}    from '../../../../../../ai/scripts/lint/lint-mcp-test-locations.mjs';
+import {SCAN_SURFACE as SCRIPT_PLANE_SURFACE}    from '../../../../../../ai/scripts/lint/lint-script-plane.mjs';
 import {SCAN_SURFACE as RETRY_BOUND_SURFACE}     from '../../../../../../ai/scripts/lint/lint-retry-bounds.mjs';
 import {DEFAULT_SCAN_PATHS as ARCHAEOLOGY_PATHS} from '../../../../../../buildScripts/util/check-ticket-archaeology.mjs';
 
@@ -66,6 +67,11 @@ const REGISTRY = Object.freeze({
         scriptRel: 'buildScripts/util/check-atomic-write-shape.mjs',
         source   : 'declared',
         surface  : ['ai/**/*.mjs']
+    },
+    'script-plane-lint.yml': {
+        scriptRel: 'ai/scripts/lint/lint-script-plane.mjs',
+        source   : 'imported',
+        surface  : SCRIPT_PLANE_SURFACE
     },
     'spec-retirement-lint.yml': {
         scriptRel: 'buildScripts/util/check-spec-retirement.mjs',

--- a/test/playwright/unit/ai/scripts/lint/scriptPlaneClosure.spec.mjs
+++ b/test/playwright/unit/ai/scripts/lint/scriptPlaneClosure.spec.mjs
@@ -12,6 +12,7 @@ import {
     walkCapabilityClosure,
     walkWithAncestors
 }                     from '../../../../../../ai/scripts/lint/scriptPlaneClosure.mjs';
+import {buildAuthorityByScript} from '../../../../../../ai/scripts/lint/lint-script-plane.mjs';
 
 /**
  * The subject is the DISTINCTION, not the detection.
@@ -396,5 +397,63 @@ export default {run() { try { return spawn('git', []); } catch (e) { return null
             // Must NOT claim a host conflict: the closure found no requirement, only an unknown.
             expect(result.findings.map(f => f.kind)).not.toContain(FINDING.authorityConflictInPlane);
         });
+    });
+});
+
+test.describe('authority join — keyed on the script PATH, never on a name', () => {
+    /*
+     * The join this replaced transformed the npm entry into a task name:
+     * `ai:sync-github-workflow` -> `syncGithubWorkflow`, against an authority key of
+     * `githubWorkflowSync`. Same words, opposite order. It matched 1 of 62 entrypoints, and the
+     * `githubWorkflowSync` fixture — the case the whole authority rule exists to catch — was not
+     * among the matches. The cross-check was very nearly inert and its red-proof had been run with
+     * the authority hand-fed, so nothing failed.
+     *
+     * A task definition already carries the joinable fact: its `args` hold the resolved module path.
+     * Two names for one lane can disagree; a path is what the process actually runs.
+     */
+    const definitions = {
+        githubWorkflowSync: {command: 'node', args: ['/repo/ai/scripts/maintenance/syncGithubWorkflow.mjs']},
+        backup            : {command: 'node', args: ['/repo/ai/scripts/maintenance/backup.mjs']},
+        chromaServer      : {command: 'chroma', args: ['run', '--path', '/data']},
+        unmapped          : {command: 'node', args: ['/repo/ai/scripts/maintenance/nomap.mjs']}
+    };
+    const authorityByName = {
+        githubWorkflowSync: 'host-edge',
+        backup            : 'container-plane',
+        chromaServer      : 'shared-primitive'
+    };
+
+    test('joins on the module path a task actually executes', () => {
+        const map = buildAuthorityByScript({definitions, authorityByName, projectRoot: '/repo'});
+
+        expect(map['ai/scripts/maintenance/syncGithubWorkflow.mjs']).toEqual({
+            taskName: 'githubWorkflowSync', authorityClass: 'host-edge'
+        });
+    });
+
+    test('the fixture the NAME-based join could never reach is joined', () => {
+        // The regression arm. `ai:sync-github-workflow` camelises to `syncGithubWorkflow`, which is
+        // not the authority key — so any name transformation misses this and reports no authority,
+        // which reads identically to "this entrypoint has no declared plane".
+        const map   = buildAuthorityByScript({definitions, authorityByName, projectRoot: '/repo'}),
+              camel = 'ai:sync-github-workflow'.replace(/^ai:/, '').replace(/-([a-z])/g, (_, c) => c.toUpperCase());
+
+        expect(camel, 'the name transformation genuinely produces the wrong key').toBe('syncGithubWorkflow');
+        expect(camel in authorityByName, 'and that key is absent from the authority map').toBe(false);
+        expect(map['ai/scripts/maintenance/syncGithubWorkflow.mjs'].authorityClass).toBe('host-edge');
+    });
+
+    test('a task with no .mjs arg is skipped rather than guessed at', () => {
+        const map = buildAuthorityByScript({definitions, authorityByName, projectRoot: '/repo'});
+
+        expect(Object.values(map).some(entry => entry.taskName === 'chromaServer')).toBe(false);
+    });
+
+    test('a task absent from the authority map contributes nothing', () => {
+        // Presence in taskDefinitions is not an authority claim; only the authority map is.
+        const map = buildAuthorityByScript({definitions, authorityByName, projectRoot: '/repo'});
+
+        expect(map['ai/scripts/maintenance/nomap.mjs']).toBeUndefined();
     });
 });

--- a/test/playwright/unit/ai/scripts/lint/scriptPlaneClosure.spec.mjs
+++ b/test/playwright/unit/ai/scripts/lint/scriptPlaneClosure.spec.mjs
@@ -241,10 +241,84 @@ test.describe('scriptPlaneClosure', () => {
         });
 
         test('an unparseable module is an unresolved edge rather than a throw', () => {
+            // This arm earns its keep: adding invoked-import tracking left the unparseable EARLY
+            // RETURN without an `invokedSpecifiers` field, so the walker threw on `undefined.forEach`
+            // for any tree containing one bad file. A defensive arm caught a real regression in its
+            // neighbour's happy path.
             const files   = {'/e.mjs': 'this is (not js'};
             const closure = walkCapabilityClosure({entrypoint: '/e.mjs', ...graphOf(files)});
 
             expect(closure.unresolved[0].reason).toBe('unparseable');
+        });
+    });
+
+    test.describe('one-level call attribution — reaching is not invoking', () => {
+        /*
+         * The distinction that lets BOTH canonical fixtures pass at once, which no pure-reachability
+         * rule can do:
+         *
+         *   - `backup.mjs` reaches `spawn` inside service methods it never calls -> NOT host-required,
+         *     which is what the bundle-stamp decision demands.
+         *   - `syncGithubWorkflow.mjs` calls `GH_SyncService.runFullSync()`, and that method spawns
+         *     git -> host-required, which is what its declared authority says.
+         *
+         * Same import-graph shape, opposite verdicts. The only difference is whether the entrypoint
+         * CALLS the binding.
+         */
+        const serviceWithDeferredShell = `import {spawn} from 'child_process';
+export default {run() { return spawn('git', []); }};`;
+
+        test('an imported-but-never-called service does NOT make the entrypoint host-required', () => {
+            const files = {
+                '/e.mjs'  : `import Svc from './svc.mjs';\nconsole.log('no call');`,
+                '/svc.mjs': serviceWithDeferredShell
+            };
+
+            const closure = walkCapabilityClosure({entrypoint: '/e.mjs', ...graphOf(files)});
+
+            expect(closure.required, 'reaching a service is not invoking it').toHaveLength(0);
+            // Still RECORDED, so the evidence is not lost — it is simply not a requirement.
+            expect(closure.used.length).toBeGreaterThan(0);
+        });
+
+        test('an imported AND called service DOES make the entrypoint host-required', () => {
+            const files = {
+                '/e.mjs'  : `import Svc from './svc.mjs';\nSvc.run();`,
+                '/svc.mjs': serviceWithDeferredShell
+            };
+
+            const closure = walkCapabilityClosure({entrypoint: '/e.mjs', ...graphOf(files)});
+
+            expect(closure.required, 'calling into the service is what makes its spawn run').toHaveLength(1);
+            expect(closure.required[0].module).toBe('/svc.mjs');
+        });
+
+        test('attribution is ONE level — a service the callee calls is not promoted', () => {
+            // Bounded on purpose. Promoting transitively would collapse back into pure reachability
+            // and re-break the bundle-stamp case, which is the whole reason this rule exists.
+            const files = {
+                '/e.mjs'   : `import Svc from './svc.mjs';\nSvc.run();`,
+                '/svc.mjs' : `import Deep from './deep.mjs';\nexport default {run() { return Deep.go(); }};`,
+                '/deep.mjs': serviceWithDeferredShell
+            };
+
+            const closure = walkCapabilityClosure({entrypoint: '/e.mjs', ...graphOf(files)});
+
+            expect(closure.required, 'the deep spawn is two hops away and stays unattributed').toHaveLength(0);
+        });
+
+        test('a called service whose shell degrades gracefully is still NOT required', () => {
+            // The promotion must not override graceful degradation — that would re-convict the
+            // bundle-stamp case through the call path instead of the reach path.
+            const files = {
+                '/e.mjs'  : `import Svc from './svc.mjs';\nSvc.run();`,
+                '/svc.mjs': `import {spawn} from 'child_process';
+export default {run() { try { return spawn('git', []); } catch (e) { return null; } }};`
+            };
+
+            const closure = walkCapabilityClosure({entrypoint: '/e.mjs', ...graphOf(files)});
+
+            expect(closure.required).toHaveLength(0);
         });
     });
 

--- a/test/playwright/unit/ai/scripts/lint/scriptPlaneClosure.spec.mjs
+++ b/test/playwright/unit/ai/scripts/lint/scriptPlaneClosure.spec.mjs
@@ -12,7 +12,15 @@ import {
     walkCapabilityClosure,
     walkWithAncestors
 }                     from '../../../../../../ai/scripts/lint/scriptPlaneClosure.mjs';
-import {buildAuthorityByScript} from '../../../../../../ai/scripts/lint/lint-script-plane.mjs';
+import fs   from 'node:fs';
+import os   from 'node:os';
+import path from 'node:path';
+
+import {
+    buildAuthorityByScript,
+    readEntrypoints,
+    readWorkflowEntrypoints
+} from '../../../../../../ai/scripts/lint/lint-script-plane.mjs';
 
 /**
  * The subject is the DISTINCTION, not the detection.
@@ -455,5 +463,85 @@ test.describe('authority join — keyed on the script PATH, never on a name', ()
         const map = buildAuthorityByScript({definitions, authorityByName, projectRoot: '/repo'});
 
         expect(map['ai/scripts/maintenance/nomap.mjs']).toBeUndefined();
+    });
+});
+
+test.describe('the census is the union of every invocation surface', () => {
+    /*
+     * An npm-only census misses scripts a workflow runs directly, and the omission was
+     * self-demonstrating: this lint is invoked from its own workflow and did not score itself.
+     * It also counted invocation NAMES rather than modules, so five duplicate npm aliases inflated
+     * the population by five.
+     */
+    const workflowDir = path.join(os.tmpdir(), `plane-wf-${process.pid}`);
+
+    test.beforeAll(() => {
+        fs.mkdirSync(workflowDir, {recursive: true});
+        fs.writeFileSync(path.join(workflowDir, 'a.yml'), [
+            'jobs:',
+            '  lint:',
+            '    steps:',
+            '      - run: node ./ai/scripts/lint/direct-one.mjs',
+            '      - run: |',
+            '          if node ./ai/scripts/lint/direct-two.mjs; then echo ok; fi'
+        ].join('\n'));
+        // A path in a COMMENT and in a non-run key must not be mistaken for an invocation.
+        fs.writeFileSync(path.join(workflowDir, 'b.yml'), [
+            '# node ./ai/scripts/lint/commented-out.mjs',
+            'jobs:',
+            '  x:',
+            '    steps:',
+            '      - name: node ./ai/scripts/lint/in-a-name.mjs',
+            '        run: echo nothing'
+        ].join('\n'));
+        fs.writeFileSync(path.join(workflowDir, 'c.yml'), 'this: [is: not: valid: yaml');
+    });
+
+    test.afterAll(() => fs.rmSync(workflowDir, {recursive: true, force: true}));
+
+    test('finds single-line AND multi-line `run:` invocations', () => {
+        const found = readWorkflowEntrypoints({workflowDir});
+
+        // The multi-line case is the one a naive file grep misses.
+        expect(found).toContain('ai/scripts/lint/direct-one.mjs');
+        expect(found).toContain('ai/scripts/lint/direct-two.mjs');
+    });
+
+    test('a path in a comment or a non-run key is NOT an invocation', () => {
+        // Reading through the YAML parser rather than grepping the file is what buys this.
+        const found = readWorkflowEntrypoints({workflowDir});
+
+        expect(found).not.toContain('ai/scripts/lint/commented-out.mjs');
+        expect(found).not.toContain('ai/scripts/lint/in-a-name.mjs');
+    });
+
+    test('an unparseable workflow is skipped, not fatal', () => {
+        // Workflow syntax has its own gates; this lint must not become a second one.
+        expect(() => readWorkflowEntrypoints({workflowDir})).not.toThrow();
+    });
+
+    test('a missing workflow directory yields nothing rather than throwing', () => {
+        expect(readWorkflowEntrypoints({workflowDir: path.join(os.tmpdir(), 'definitely-absent-xyz')})).toEqual([]);
+    });
+
+    test('the census counts MODULES, not invocation names', () => {
+        // The first version of this arm asserted `filter(...).toHaveLength(1)` on a two-alias input —
+        // which the backing Map guarantees whatever the code decides, so removing the dedupe left it
+        // green. A vacuous arm is worse than none: it reports coverage of a property it cannot see.
+        //
+        // The falsifiable form compares the two populations directly: FOUR npm entries naming THREE
+        // modules must yield three entries, so a name-counting census fails on the count itself.
+        const scripts = {
+            'ai:one'  : 'node ./ai/scripts/lint/dupe.mjs',
+            'ai:two'  : 'node ./ai/scripts/lint/dupe.mjs',
+            'ai:three': 'node ./ai/scripts/lint/dupe.mjs',
+            'ai:other': 'node ./ai/scripts/lint/other.mjs'
+        };
+        const entries = readEntrypoints(scripts).filter(entry => entry.via !== 'workflow');
+
+        expect(Object.keys(scripts), 'four invocation names').toHaveLength(4);
+        expect(entries, 'naming three distinct modules').toHaveLength(2);
+        expect(entries.map(entry => entry.rel).sort())
+            .toEqual(['ai/scripts/lint/dupe.mjs', 'ai/scripts/lint/other.mjs']);
     });
 });

--- a/test/playwright/unit/ai/scripts/lint/scriptPlaneClosure.spec.mjs
+++ b/test/playwright/unit/ai/scripts/lint/scriptPlaneClosure.spec.mjs
@@ -13,11 +13,13 @@ import {
     walkCapabilityClosure,
     walkWithAncestors
 }                     from '../../../../../../ai/scripts/lint/scriptPlaneClosure.mjs';
-import fs   from 'node:fs';
-import os   from 'node:os';
-import path from 'node:path';
+import {buildTaskDefinitions} from '../../../../../../ai/daemons/orchestrator/taskDefinitions.mjs';
+import fs                     from 'node:fs';
+import os                     from 'node:os';
+import path                   from 'node:path';
 
 import {
+    CENSUS_TASK_CONFIG,
     buildAuthorityByScript,
     readEntrypoints,
     readWorkflowEntrypoints,
@@ -30,7 +32,7 @@ import {
  * arm below a real falsifier rather than a fixture arguing with itself.
  * @type {String[]}
  */
-const KNOWN_BACKUP_EDGES = ['ai/ConfigProvider.mjs::dynamic-import'];
+const KNOWN_BACKUP_EDGES = ['ai/ConfigProvider.mjs::dynamic-import::load'];
 
 /**
  * The subject is the DISTINCTION, not the detection.
@@ -502,6 +504,52 @@ export default {run() { return spawn('git', []) }};`
             expect(closure.required[0].module).toBe('/svc.mjs');
         });
 
+        test('a function passed as an ARGUMENT is followed — higher-order dispatch is not safe', () => {
+            // @neo-gpt's exact falsifier, and the worst class this file has held: every name is in
+            // the source, and the callee-only walk returned `required: []` AND `unresolved: []` —
+            // not a conservative stop but a SILENT safe verdict. `fn` is a parameter, parameters
+            // were leaves, so the reference died at the call boundary.
+            const files = {
+                '/e.mjs': `import {run, danger} from './m.mjs';\nrun(danger);`,
+                '/m.mjs': `import {spawn} from 'child_process';
+export function run(fn) { return fn() }
+export function danger() { return spawn('git', []) }`
+            };
+
+            const closure = walkCapabilityClosure({entrypoint: '/e.mjs', ...graphOf(files)});
+
+            expect(closure.required, 'handing a function to something that runs is evidence it runs')
+                .toHaveLength(1);
+            expect(closure.required[0].member).toBe('danger');
+        });
+
+        test('two unfollowable edges in ONE module keep separate identities', () => {
+            // The substitution the ledger exists to catch, scoped inside a file. Keyed on
+            // `module::reason` alone, swapping one site for another passed a Set-backed ratchet
+            // unchanged. Measured against the live tree the collision hid THREE edges: the real
+            // population was 12 while the ledger recorded 9.
+            const files = {'/e.mjs': `function a() { const x = 'p'; return import(x) }
+function b() { const y = 'q'; return import(y) }
+a(); b();`},
+                  closure = walkCapabilityClosure({entrypoint: '/e.mjs', ...graphOf(files)});
+
+            expect(closure.unresolved).toHaveLength(2);
+            expect(new Set(closure.unresolved.map(edge => edge.member)).size, 'distinct owners').toBe(2);
+        });
+
+        test('the finding PROJECTION carries the discriminators, not just the closure edge', () => {
+            // The defect my own fix hid behind, and the reason this arm exists separately from the
+            // one above. `resolveEntrypointPlane` rebuilt each finding field by field and dropped
+            // `member` and `callee`, so the identity function's discriminating branch could never
+            // fire in production — while an in-memory test that fed it RAW closure edges passed.
+            // Testing the producer's object instead of the consumer's proves nothing about the consumer.
+            const files      = {'/e.mjs': `function a() { const x = 'p'; return import(x) }\na();`},
+                  closure    = walkCapabilityClosure({entrypoint: '/e.mjs', ...graphOf(files)}),
+                  {findings} = resolveEntrypointPlane({closure, entrypoint: '/e.mjs'});
+
+            expect(findings[0].member, 'the projection must not drop what identity depends on').toBe('a');
+        });
+
         test('the chain that proved a requirement is reconstructable', () => {
             // A conflict finding that names only a file and a line leaves the reader to find the
             // calls that get there. This is what turns the finding into a repair instruction.
@@ -771,6 +819,31 @@ test.describe('the census is the union of every invocation surface', () => {
         expect(entries.filter(entry => entry.rel === 'ai/scripts/lint/dupe.mjs'), 'no double count')
             .toHaveLength(1);
         expect(entries.find(entry => entry.rel === 'ai/scripts/lint/dupe.mjs').via).toBe('npm');
+    });
+
+    test('a CONFIG-GATED production root enters the census', () => {
+        // `buildTaskDefinitions({})` is the descriptor default, and two roots exist only when a port
+        // is configured. Censusing the default asked "what runs in an unconfigured process" when the
+        // question is "which modules can be spawned as a root at all" — so `neuralLinkBridge`, a
+        // declared HOST-EDGE root, was never checked by the gate that exists to check declarations.
+        const bare     = buildTaskDefinitions({}),
+              censused = buildTaskDefinitions(CENSUS_TASK_CONFIG);
+
+        expect(Object.keys(bare)).not.toContain('neuralLinkBridge');
+        expect(Object.keys(censused), 'the census config must surface it').toContain('neuralLinkBridge');
+        expect(Object.keys(buildAuthorityByScript())).toContain('ai/mcp/server/neural-link/run-bridge.mjs');
+    });
+
+    test('the executed module is `node`\'s first ARGUMENT, never the first `.mjs`', () => {
+        // `devServer` runs `node …/webpack.js serve -c ./buildScripts/…/webpack.server.config.mjs`.
+        // The extension heuristic skipped the `.js` binary and joined the `-c` VALUE, then reported
+        // a webpack CONFIG's execution plane — and produced a conflict finding about it. A config
+        // file has no plane, and a third-party binary's plane is not ours to derive.
+        const byScript = buildAuthorityByScript();
+
+        expect(Object.keys(byScript)).not.toContain('buildScripts/webpack/webpack.server.config.mjs');
+        expect(Object.keys(byScript).some(rel => rel.includes('node_modules/')), 'no vendor roots')
+            .toBe(false);
     });
 
     test('the REAL task-definition join reaches both roots the reviewer named', () => {

--- a/test/playwright/unit/ai/scripts/lint/scriptPlaneClosure.spec.mjs
+++ b/test/playwright/unit/ai/scripts/lint/scriptPlaneClosure.spec.mjs
@@ -5,6 +5,7 @@ import {
     HOST_CAPABILITY,
     collectModuleFacts,
     handlerAborts,
+    invocationChain,
     isGracefullyDegraded,
     normalizeSpecifier,
     parseModule,
@@ -19,8 +20,17 @@ import path from 'node:path';
 import {
     buildAuthorityByScript,
     readEntrypoints,
-    readWorkflowEntrypoints
+    readWorkflowEntrypoints,
+    runLint
 } from '../../../../../../ai/scripts/lint/lint-script-plane.mjs';
+
+/**
+ * The complete unresolved-edge population of `backup.mjs` — one edge, the config provider's
+ * runtime-path dynamic import. MEASURED against the live tree, which is what makes the substitution
+ * arm below a real falsifier rather than a fixture arguing with itself.
+ * @type {String[]}
+ */
+const KNOWN_BACKUP_EDGES = ['ai/ConfigProvider.mjs::dynamic-import'];
 
 /**
  * The subject is the DISTINCTION, not the detection.
@@ -261,7 +271,7 @@ test.describe('scriptPlaneClosure', () => {
         });
     });
 
-    test.describe('one-level call attribution — reaching is not invoking', () => {
+    test.describe('invocation-chain attribution — reaching is not invoking', () => {
         /*
          * The distinction that lets BOTH canonical fixtures pass at once, which no pure-reachability
          * rule can do:
@@ -302,9 +312,49 @@ export default {run() { return spawn('git', []); }};`;
             expect(closure.required[0].module).toBe('/svc.mjs');
         });
 
-        test('attribution is ONE level — a service the callee calls is not promoted', () => {
-            // Bounded on purpose. Promoting transitively would collapse back into pure reachability
-            // and re-break the bundle-stamp case, which is the whole reason this rule exists.
+        test('attribution follows the WHOLE proven chain, not just the first hop', () => {
+            // The arm this file used to assert the opposite of, and the correction is the content.
+            //
+            // A one-level bound read as conservatism and was a FALSE SAFE: every step of
+            // `/e -> Svc.run -> Deep.go -> spawn` is named in the source, and stopping after the first
+            // hop reported `required: []` for a chain nothing had to guess about. What protects the
+            // bundle-stamp case is MEMBER granularity, not a hop count — calling
+            // `ConnectionService.connect()` still proves nothing about `spawnBridgeProcess()`, at any
+            // depth. The two arms below hold that line while this one crosses three modules.
+            const files = {
+                '/e.mjs'   : `import Svc from './svc.mjs';\nSvc.run();`,
+                '/svc.mjs' : `import Deep from './deep.mjs';\nexport default {run() { return Deep.go(); }};`,
+                '/deep.mjs': `import {spawn} from 'child_process';\nexport default {go() { return spawn('git', []); }};`
+            };
+
+            const closure = walkCapabilityClosure({entrypoint: '/e.mjs', ...graphOf(files)});
+
+            expect(closure.required, 'two hops is still a proof').toHaveLength(1);
+            expect(closure.required[0].module).toBe('/deep.mjs');
+            expect(closure.unresolved, 'nothing about this chain is unknown').toHaveLength(0);
+        });
+
+        test('a SIBLING member of a called module is still not promoted, at any depth', () => {
+            // Member granularity is the real guard, and this is the arm that proves it survives the
+            // unbounded walk. `/e` drives `Svc.run` two modules deep; `Deep.danger` is never named by
+            // anything on that path, so its spawn stays unattributed no matter how far the walk goes.
+            const files = {
+                '/e.mjs'   : `import Svc from './svc.mjs';\nSvc.run();`,
+                '/svc.mjs' : `import Deep from './deep.mjs';\nexport default {run() { return Deep.safe(); }};`,
+                '/deep.mjs': `import {spawn} from 'child_process';
+export default {safe() { return 1 }, danger() { return spawn('git', []); }};`
+            };
+
+            const closure = walkCapabilityClosure({entrypoint: '/e.mjs', ...graphOf(files)});
+
+            expect(closure.required, 'a sibling method is not a call').toHaveLength(0);
+            expect(closure.used, 'and the evidence is still recorded').toHaveLength(1);
+        });
+
+        test('a call the walk cannot follow is UNRESOLVED, never safe', () => {
+            // The other half of the proof boundary. `Deep.go` does not exist on the module `Deep`
+            // resolves to, so the chain cannot be completed — and the answer is "I could not tell",
+            // not "nothing found". A capability sits behind that edge, which is what makes it matter.
             const files = {
                 '/e.mjs'   : `import Svc from './svc.mjs';\nSvc.run();`,
                 '/svc.mjs' : `import Deep from './deep.mjs';\nexport default {run() { return Deep.go(); }};`,
@@ -313,7 +363,159 @@ export default {run() { return spawn('git', []); }};`;
 
             const closure = walkCapabilityClosure({entrypoint: '/e.mjs', ...graphOf(files)});
 
-            expect(closure.required, 'the deep spawn is two hops away and stays unattributed').toHaveLength(0);
+            expect(closure.required).toHaveLength(0);
+            expect(closure.unresolved, 'the unfollowable call is reported').toHaveLength(1);
+            expect(closure.unresolved[0].reason).toBe('unresolved-dispatch');
+            expect(closure.unresolved[0].callee).toBe('Deep.go');
+        });
+
+        test('an unfollowable call with NO capability behind it is not an edge', () => {
+            // The filter that keeps the ledger legible. `Data.map(…)` cannot be followed either, but
+            // there is no shell anywhere behind `/data.mjs`, so calling it unresolved would be true
+            // and useless. Reporting every unnameable call produced 656 edges on `backup.mjs` alone.
+            const files = {
+                '/e.mjs'   : `import Svc from './svc.mjs';\nSvc.run();`,
+                '/svc.mjs' : `import Data from './data.mjs';\nexport default {run() { return Data.map(); }};`,
+                '/data.mjs': `export default ['a', 'b'];`
+            };
+
+            const closure = walkCapabilityClosure({entrypoint: '/e.mjs', ...graphOf(files)});
+
+            expect(closure.required).toHaveLength(0);
+            expect(closure.unresolved, 'an edge that leads nowhere dangerous is not a gap').toHaveLength(0);
+        });
+
+        test('an inherited member resolves through `extends` rather than reporting a gap', () => {
+            // A subclass never mentions what it inherits, so a member-existence test that reads only
+            // the subclass is unsound by construction — the same blind spot a single-file grep has,
+            // and one that would turn every base-class seam in this tree into a false unresolved edge.
+            const files = {
+                '/e.mjs'  : `import Svc from './svc.mjs';\nSvc.run();`,
+                '/svc.mjs': `import Base from './base.mjs';
+export default class Svc extends Base { run() { return this.shell() } }`,
+                '/base.mjs' : `import {spawn} from 'child_process';
+export default class Base { shell() { return spawn('git', []) } }`
+            };
+
+            const closure = walkCapabilityClosure({entrypoint: '/e.mjs', ...graphOf(files)});
+
+            expect(closure.required, 'the inherited seam is reached').toHaveLength(1);
+            expect(closure.required[0].module).toBe('/base.mjs');
+            expect(closure.unresolved).toHaveLength(0);
+        });
+
+        test('a call in an object-literal VALUE belongs to the enclosing method, not to the key', () => {
+            // The defect that hid a six-deep production chain. `{adrs: await this.fetch()}` sits under
+            // a Property whose key is `adrs`, and attributing the call to a member called `adrs`
+            // ended the walk on a data key — `aggregate-temporal-summary` came back host-free with
+            // `runCycle -> … -> execCommand` fully static in front of it.
+            const files = {
+                '/e.mjs'  : `import Svc from './svc.mjs';\nSvc.run();`,
+                '/svc.mjs': `import {spawn} from 'child_process';
+export default {
+    run()   { return {adrs: this.fetch()} },
+    fetch() { return spawn('git', []) }
+};`
+            };
+
+            const closure = walkCapabilityClosure({entrypoint: '/e.mjs', ...graphOf(files)});
+
+            expect(closure.required, 'a key name is not a member boundary').toHaveLength(1);
+        });
+
+        test('code behind the import-safe guard does NOT run for an importer', () => {
+            // 98 modules under `ai/` carry `if (process.argv[1] && … === __filename)`. Without this
+            // test the walk concludes that importing a script runs its `main()`, which promoted
+            // `lint-skill-manifest`'s git calls onto `backup.mjs`, convicting it against the
+            // bundle-stamp decision — ADR-0014, ticket-ref-ok: it is the authority contradicted.
+            const guarded = `import {spawn} from 'child_process';
+export function main() { return spawn('git', []) }
+if (process.argv[1] && process.argv[1] === 'x') { main() }`;
+
+            const asImport = walkCapabilityClosure({
+                entrypoint: '/e.mjs',
+                ...graphOf({'/e.mjs': `import {main} from './s.mjs';\nconsole.log('no call');`, '/s.mjs': guarded})
+            });
+
+            expect(asImport.required, 'importing a script does not run it').toHaveLength(0);
+
+            // The same module AS the entrypoint: the guard is true, so its `main()` does run.
+            const asEntry = walkCapabilityClosure({entrypoint: '/s.mjs', ...graphOf({'/s.mjs': guarded})});
+
+            expect(asEntry.required, 'running it as the script is the case the guard admits').toHaveLength(1);
+        });
+
+        test('a capability INSIDE the guard is dormant for an importer', () => {
+            // Distinct from the arm above, and the red-proof battery is what found the gap: there the
+            // guard holds back a CALL, here it holds back a capability site directly. A module-scope
+            // `spawn` is `required` on sight — nothing defers it — so only the guard keeps it from
+            // being attributed to everyone who imports the module.
+            const guarded = `import {spawn} from 'child_process';
+if (process.argv[1] && process.argv[1] === 'x') { spawn('git', []) }
+export default {};`;
+
+            const asImport = walkCapabilityClosure({
+                entrypoint: '/e.mjs',
+                ...graphOf({'/e.mjs': `import S from './s.mjs';\nconsole.log(S);`, '/s.mjs': guarded})
+            });
+
+            expect(asImport.required, 'importing does not take the guarded branch').toHaveLength(0);
+
+            const asEntry = walkCapabilityClosure({entrypoint: '/s.mjs', ...graphOf({'/s.mjs': guarded})});
+
+            expect(asEntry.required, 'being the script does').toHaveLength(1);
+        });
+
+        test('the hoisted spelling of the guard is recognised too', () => {
+            // `const cliEntryPath = process.argv[1] ? … : null` above, `if (cliEntryPath === modulePath)`
+            // below. Reading only the inline spelling is what let `buildScripts/docs/index/labels.mjs`
+            // report its whole CLI as running on import.
+            const files = {
+                '/e.mjs': `import Svc from './s.mjs';\nconsole.log('no call');`,
+                '/s.mjs': `import {spawn} from 'child_process';
+const cliEntryPath = process.argv[1] ? process.argv[1] : null;
+const modulePath   = 'x';
+function main() { return spawn('git', []) }
+if (cliEntryPath && cliEntryPath === modulePath) { main() }
+export default {};`
+            };
+
+            const closure = walkCapabilityClosure({entrypoint: '/e.mjs', ...graphOf(files)});
+
+            expect(closure.required, 'the guard is the same guard, hoisted').toHaveLength(0);
+        });
+
+        test('a re-export barrel is followed to where the value LIVES', () => {
+            // `ai/services.mjs` is 225 lines of exactly this. Stopping at the barrel reported five
+            // dispatch gaps on `backup.mjs` whose only cause was an indirection the code is explicit
+            // about, and hid whatever sits on the far side of it.
+            const files = {
+                '/e.mjs'     : `import {Svc} from './barrel.mjs';\nSvc.run();`,
+                '/barrel.mjs': `import _Svc from './svc.mjs';\nconst Svc = makeSafe(_Svc, {});\nexport {Svc};`,
+                '/svc.mjs'   : `import {spawn} from 'child_process';
+export default {run() { return spawn('git', []) }};`
+            };
+
+            const closure = walkCapabilityClosure({entrypoint: '/e.mjs', ...graphOf(files)});
+
+            expect(closure.required, 'the barrel is an indirection, not a boundary').toHaveLength(1);
+            expect(closure.required[0].module).toBe('/svc.mjs');
+        });
+
+        test('the chain that proved a requirement is reconstructable', () => {
+            // A conflict finding that names only a file and a line leaves the reader to find the
+            // calls that get there. This is what turns the finding into a repair instruction.
+            const files = {
+                '/e.mjs'   : `import Svc from './svc.mjs';\nSvc.run();`,
+                '/svc.mjs' : `import Deep from './deep.mjs';\nexport default {run() { return Deep.go(); }};`,
+                '/deep.mjs': `import {spawn} from 'child_process';\nexport default {go() { return spawn('git', []); }};`
+            };
+
+            const closure = walkCapabilityClosure({entrypoint: '/e.mjs', ...graphOf(files)}),
+                  site    = closure.required[0];
+
+            expect(invocationChain(closure.invokedBy, `${site.module}::${site.member}`))
+                .toEqual(['/e.mjs::<module-scope>', '/svc.mjs::run', '/deep.mjs::go']);
         });
 
         test('a called service whose shell degrades gracefully is still NOT required', () => {
@@ -537,11 +739,116 @@ test.describe('the census is the union of every invocation surface', () => {
             'ai:three': 'node ./ai/scripts/lint/dupe.mjs',
             'ai:other': 'node ./ai/scripts/lint/other.mjs'
         };
-        const entries = readEntrypoints(scripts).filter(entry => entry.via !== 'workflow');
+        const entries = readEntrypoints(scripts, {}).filter(entry => entry.via === 'npm');
 
         expect(Object.keys(scripts), 'four invocation names').toHaveLength(4);
-        expect(entries, 'naming three distinct modules').toHaveLength(2);
+        expect(entries, 'naming two distinct modules').toHaveLength(2);
         expect(entries.map(entry => entry.rel).sort())
             .toEqual(['ai/scripts/lint/dupe.mjs', 'ai/scripts/lint/other.mjs']);
+    });
+
+    test('the census includes orchestrator task roots no npm script and no workflow names', () => {
+        // The channel that was missing, pinned on the two roots the reviewer named. Both carry a
+        // declared authority class, so their absence meant the lint never checked the artifacts whose
+        // declarations are strongest — quiet exactly where it is most needed.
+        const authorityByScript = {
+            'ai/scripts/lifecycle/backfill-memory-summaries.mjs' : {
+                taskName: 'memory-summary-backfill', authorityClass: 'container-plane'
+            },
+            'ai/scripts/maintenance/aggregate-temporal-summary.mjs': {
+                taskName: 'temporal-summary', authorityClass: 'container-plane'
+            },
+            // Already reachable through npm: it must appear ONCE, credited to the channel that found
+            // it first, or the population double-counts the roots with the most invocation surface.
+            'ai/scripts/lint/dupe.mjs': {taskName: 'dupe', authorityClass: 'host-edge'}
+        };
+
+        const entries = readEntrypoints({'ai:one': 'node ./ai/scripts/lint/dupe.mjs'}, authorityByScript),
+              byRel   = entries.map(entry => entry.rel);
+
+        expect(byRel).toContain('ai/scripts/lifecycle/backfill-memory-summaries.mjs');
+        expect(byRel).toContain('ai/scripts/maintenance/aggregate-temporal-summary.mjs');
+        expect(entries.filter(entry => entry.rel === 'ai/scripts/lint/dupe.mjs'), 'no double count')
+            .toHaveLength(1);
+        expect(entries.find(entry => entry.rel === 'ai/scripts/lint/dupe.mjs').via).toBe('npm');
+    });
+
+    test('the REAL task-definition join reaches both roots the reviewer named', () => {
+        // Against the live tree rather than a fixture, because the fixture above cannot fail the way
+        // the census did: it proves the union works, not that the join finds anything.
+        const rels = readEntrypoints().map(entry => entry.rel);
+
+        expect(rels).toContain('ai/scripts/lifecycle/backfill-memory-summaries.mjs');
+        expect(rels).toContain('ai/scripts/maintenance/aggregate-temporal-summary.mjs');
+        // Positive control: a root the npm channel already supplies must still be present exactly
+        // once, so a passing assertion above cannot be read as "the union returned everything".
+        expect(rels.filter(rel => rel === 'ai/scripts/maintenance/backup.mjs')).toHaveLength(1);
+    });
+});
+
+test.describe('the unresolved ratchet holds IDENTITIES, not a count', () => {
+    const entrypoints = [{name: 'ai:probe', rel: 'ai/scripts/maintenance/backup.mjs', via: 'npm'}];
+
+    test('an edge already in the ledger passes', () => {
+        const result = runLint({entrypoints, authorityByScript: {}, ledger: KNOWN_BACKUP_EDGES});
+
+        expect(result.exitCode).toBe(0);
+        expect(result.appeared).toEqual([]);
+    });
+
+    test('a SUBSTITUTED edge fails even though the count is unchanged', () => {
+        // The property a scalar baseline cannot hold, and the reason this is a ledger. Swap one known
+        // identity for a fictional one: the total is identical, the closure is no sounder, and a
+        // count-based gate stays green through it.
+        const substituted = [...KNOWN_BACKUP_EDGES.slice(1), 'ai/invented/Module.mjs::dynamic-import'],
+              result      = runLint({entrypoints, authorityByScript: {}, ledger: substituted});
+
+        expect(substituted, 'the same number of entries').toHaveLength(KNOWN_BACKUP_EDGES.length);
+        expect(result.exitCode, 'and it must still fail').toBe(1);
+        expect(result.appeared, 'naming the edge that appeared').toEqual([KNOWN_BACKUP_EDGES[0]]);
+        expect(result.resolved, 'and the one that vanished').toEqual(['ai/invented/Module.mjs::dynamic-import']);
+    });
+
+    test('a ledger entry that no longer reproduces is reported, not silently kept', () => {
+        // The other direction. A ledger that only grows is a record; one that reports its own dead
+        // entries is a ratchet, because the next author is told exactly what to delete.
+        const result = runLint({
+            entrypoints,
+            authorityByScript: {},
+            ledger           : [...KNOWN_BACKUP_EDGES, 'ai/gone/Module.mjs::unparseable']
+        });
+
+        expect(result.exitCode, 'a stale entry is not a failure on its own').toBe(0);
+        expect(result.resolved).toEqual(['ai/gone/Module.mjs::unparseable']);
+    });
+
+    test('an unlisted authority conflict fails; a ticketed one is held and still printed', () => {
+        // `syncGithubWorkflow` genuinely requires a shell, so declaring it container-plane is the
+        // severe direction: the script breaks on the plane it is declared for. Chosen over the
+        // reverse because `authority-conflict-host` is suppressed while an unresolved edge stands,
+        // which would make this arm pass for a reason that has nothing to do with the ledger.
+        const roots       = [{name: 'x', rel: 'ai/scripts/maintenance/syncGithubWorkflow.mjs', via: 'npm'}],
+              conflicting = {
+                  'ai/scripts/maintenance/syncGithubWorkflow.mjs': {
+                      taskName: 'githubWorkflowSync', authorityClass: 'container-plane'
+                  }
+              },
+              identity    = 'ai/scripts/maintenance/syncGithubWorkflow.mjs::githubWorkflowSync::'
+                  + 'authority-conflict-in-plane';
+
+        const unlisted = runLint({entrypoints: roots, authorityByScript: conflicting, ledger: KNOWN_BACKUP_EDGES});
+
+        expect(unlisted.exitCode).toBe(1);
+        expect(unlisted.conflicts).toHaveLength(1);
+
+        const held = runLint({
+            entrypoints      : roots,
+            authorityByScript: conflicting,
+            ledger           : KNOWN_BACKUP_EDGES,
+            knownConflicts   : [identity]
+        });
+
+        expect(held.exitCode, 'a ticketed conflict is held').toBe(0);
+        expect(held.conflicts, 'and it is still surfaced, never hidden').toHaveLength(1);
     });
 });

--- a/test/playwright/unit/ai/scripts/lint/scriptPlaneClosure.spec.mjs
+++ b/test/playwright/unit/ai/scripts/lint/scriptPlaneClosure.spec.mjs
@@ -1,0 +1,326 @@
+import {test, expect} from '@playwright/test';
+
+import {
+    FINDING,
+    HOST_CAPABILITY,
+    collectModuleFacts,
+    handlerAborts,
+    isGracefullyDegraded,
+    normalizeSpecifier,
+    parseModule,
+    resolveEntrypointPlane,
+    walkCapabilityClosure,
+    walkWithAncestors
+}                     from '../../../../../../ai/scripts/lint/scriptPlaneClosure.mjs';
+
+/**
+ * The subject is the DISTINCTION, not the detection.
+ *
+ * A directory-keyed predicate and a per-file header were both tried and both retired against measured
+ * falsifiers, on the same finding: a directory name and a header are both names, and a name can be
+ * wrong while the code moves on without it. What replaced them derives the plane from what an
+ * entrypoint REACHES — and the moment you do that, the load-bearing question stops being "does this
+ * file touch a shell" and becomes "does it REQUIRE one".
+ *
+ * ADR-0014 is the fixture that settles it — ticket-ref-ok: the ADR is the authority these arms
+ * implement. `backup.mjs` stamps a bundle with `git rev-parse HEAD`
+ * inside a swallowing try, and the ADR rules that not a host dependency because it degrades to
+ * `null`. Any predicate that convicts it is wrong against an accepted decision record — which is what
+ * the retired token classifier did.
+ *
+ * Fixtures are in-memory: `walkCapabilityClosure` takes injected `readFile`/`resolve`, so these arms
+ * pin the resolver's logic rather than the current shape of the repository. A closure test that reads
+ * real files fails when someone edits an unrelated script, and then gets deleted for being flaky.
+ */
+
+// A fixture graph: `{path: source}` plus the two injectables the walker needs.
+const graphOf = files => ({
+    readFile: absPath => (absPath in files ? files[absPath] : null),
+    resolve : (specifier, fromFile) => {
+        const dir      = fromFile.slice(0, fromFile.lastIndexOf('/')),
+              resolved = specifier.startsWith('./') ? `${dir}/${specifier.slice(2)}` : specifier;
+
+        return resolved in files ? resolved : null
+    }
+});
+
+test.describe('scriptPlaneClosure', () => {
+    test.describe('normalizeSpecifier — one identity for two live spellings', () => {
+        // Both spellings are in use across ai/scripts, so a comparison that misses one silently
+        // under-detects on roughly half the tree.
+        test('`node:` prefix and bare name normalise together', () => {
+            expect(normalizeSpecifier('node:child_process')).toBe('child_process');
+            expect(normalizeSpecifier('child_process')).toBe('child_process');
+        });
+
+        test('deep imports collapse to the package root', () => {
+            expect(normalizeSpecifier('fs-extra/lib/json')).toBe('fs-extra');
+        });
+
+        test('scoped packages keep both segments', () => {
+            expect(normalizeSpecifier('@modelcontextprotocol/sdk/server')).toBe('@modelcontextprotocol/sdk');
+        });
+
+        test('relative specifiers are returned untouched', () => {
+            expect(normalizeSpecifier('./sibling.mjs')).toBe('./sibling.mjs');
+        });
+    });
+
+    test.describe('requirement vs use — the ADR-0014 distinction', () => {
+        const CALL = `import {execFile} from 'child_process';\n`;
+
+        test('a bare capability call is REQUIRED', () => {
+            const facts = collectModuleFacts(`${CALL}execFile('git', ['status']);`);
+
+            expect(facts.capabilities).toHaveLength(1);
+            expect(facts.capabilities[0].capability).toBe(HOST_CAPABILITY.shell);
+            expect(facts.capabilities[0].required).toBe(true);
+        });
+
+        test('a call inside a swallowing try is USE, not requirement — the ADR-0014 shape', () => {
+            const facts = collectModuleFacts(
+                `${CALL}let sha = null;\ntry { sha = execFile('git', ['rev-parse']); } catch (err) { console.warn(err); }`
+            );
+
+            expect(facts.capabilities[0].required).toBe(false);
+        });
+
+        test('a catch that RETHROWS leaves the capability required', () => {
+            const facts = collectModuleFacts(
+                `${CALL}try { execFile('git', []); } catch (err) { throw err; }`
+            );
+
+            expect(facts.capabilities[0].required).toBe(true);
+        });
+
+        test('a catch that process.exit()s leaves the capability required', () => {
+            const facts = collectModuleFacts(
+                `${CALL}try { execFile('git', []); } catch { process.exit(1); }`
+            );
+
+            expect(facts.capabilities[0].required).toBe(true);
+        });
+
+        test('try/finally with NO catch does not swallow', () => {
+            // The error still propagates past a finalizer, so the capability is required. Reading
+            // `TryStatement` as "protected" without checking for a handler gets this backwards.
+            const facts = collectModuleFacts(
+                `${CALL}try { execFile('git', []); } finally { cleanup(); }`
+            );
+
+            expect(facts.capabilities[0].required).toBe(true);
+        });
+
+        test('a call inside the CATCH limb is not protected by that catch', () => {
+            const facts = collectModuleFacts(
+                `${CALL}try { risky(); } catch (err) { execFile('git', []); }`
+            );
+
+            expect(facts.capabilities[0].required).toBe(true);
+        });
+
+        test('a promisified binding is still the capability — the false negative that hid ADR-0014', () => {
+            // `const execFileAsync = promisify(execFile)` is how the real fixture calls it. Tracking
+            // only import bindings reports ZERO capability sites for backup.mjs, which reads as a
+            // clean file rather than as a detector that cannot see.
+            const facts = collectModuleFacts(
+                `${CALL}import {promisify} from 'util';\nconst run = promisify(execFile);\nrun('git', []);`
+            );
+
+            expect(facts.capabilities).toHaveLength(1);
+            expect(facts.capabilities[0].required).toBe(true);
+        });
+
+        test('a plain alias carries the capability too', () => {
+            const facts = collectModuleFacts(`${CALL}const run = execFile;\nrun('git', []);`);
+
+            expect(facts.capabilities).toHaveLength(1);
+        });
+
+        test('an unrelated import contributes no capability — non-vacuity for the detector', () => {
+            const facts = collectModuleFacts(`import path from 'node:path';\npath.join('a', 'b');`);
+
+            expect(facts.capabilities).toHaveLength(0);
+        });
+    });
+
+    test.describe('handlerAborts / isGracefullyDegraded', () => {
+        test('a missing handler aborts', () => {
+            expect(handlerAborts(null)).toBe(true);
+        });
+
+        test('a logging handler does not abort', () => {
+            const ast     = parseModule('try { a(); } catch (e) { console.warn(e); }'),
+                  tryStmt = ast.body[0];
+
+            expect(handlerAborts(tryStmt.handler)).toBe(false);
+        });
+
+        test('an empty ancestor chain is not degraded', () => {
+            expect(isGracefullyDegraded([])).toBe(false);
+        });
+    });
+
+    test.describe('walkWithAncestors', () => {
+        test('yields nearest parent first', () => {
+            const ast   = parseModule('try { a(); } catch { b(); }');
+            let   chain = null;
+
+            walkWithAncestors(ast, (node, ancestors) => {
+                if (node.type === 'Identifier' && node.name === 'a') {
+                    chain = ancestors.map(entry => entry.type)
+                }
+            });
+
+            expect(chain[0]).toBe('CallExpression');
+            expect(chain).toContain('TryStatement');
+        });
+
+        test('a non-node is a safe no-op', () => {
+            expect(() => walkWithAncestors(null, () => {})).not.toThrow();
+            expect(() => walkWithAncestors({notANode: true}, () => {})).not.toThrow();
+        });
+    });
+
+    test.describe('walkCapabilityClosure — transitive reach', () => {
+        test('a capability required TWO hops away is reached', () => {
+            const files = {
+                '/e.mjs'   : `import './mid.mjs';`,
+                '/mid.mjs' : `import './leaf.mjs';`,
+                '/leaf.mjs': `import {execFile} from 'child_process';\nexecFile('git', []);`
+            };
+
+            const closure = walkCapabilityClosure({entrypoint: '/e.mjs', ...graphOf(files)});
+
+            expect(closure.required).toHaveLength(1);
+            expect(closure.required[0].module).toBe('/leaf.mjs');
+        });
+
+        test('an import cycle terminates rather than hanging', () => {
+            const files = {
+                '/a.mjs': `import './b.mjs';`,
+                '/b.mjs': `import './a.mjs';`
+            };
+
+            const closure = walkCapabilityClosure({entrypoint: '/a.mjs', ...graphOf(files)});
+
+            expect(closure.reached.sort()).toEqual(['/a.mjs', '/b.mjs']);
+        });
+
+        test('a bare package is a leaf and is not walked', () => {
+            const files   = {'/e.mjs': `import commander from 'commander';`};
+            const closure = walkCapabilityClosure({entrypoint: '/e.mjs', ...graphOf(files)});
+
+            expect(closure.reached).toEqual(['/e.mjs']);
+            expect(closure.unresolved).toHaveLength(0);
+        });
+
+        test('an unreadable module is an unresolved edge, not a silent skip', () => {
+            const closure = walkCapabilityClosure({entrypoint: '/missing.mjs', ...graphOf({})});
+
+            expect(closure.unresolved[0].reason).toBe('unreadable');
+        });
+
+        test('a non-literal dynamic import is an unresolved edge', () => {
+            const files   = {'/e.mjs': `const p = compute();\nawait import(p);`};
+            const closure = walkCapabilityClosure({entrypoint: '/e.mjs', ...graphOf(files)});
+
+            expect(closure.unresolved[0].reason).toBe('dynamic-import');
+        });
+
+        test('a LITERAL dynamic import is followed like a static one', () => {
+            const files = {
+                '/e.mjs'   : `await import('./leaf.mjs');`,
+                '/leaf.mjs': `import {execFile} from 'child_process';\nexecFile('x', []);`
+            };
+
+            const closure = walkCapabilityClosure({entrypoint: '/e.mjs', ...graphOf(files)});
+
+            expect(closure.required).toHaveLength(1);
+            expect(closure.unresolved).toHaveLength(0);
+        });
+
+        test('an unparseable module is an unresolved edge rather than a throw', () => {
+            const files   = {'/e.mjs': 'this is (not js'};
+            const closure = walkCapabilityClosure({entrypoint: '/e.mjs', ...graphOf(files)});
+
+            expect(closure.unresolved[0].reason).toBe('unparseable');
+        });
+    });
+
+    test.describe('resolveEntrypointPlane — authority is consumed, never re-derived', () => {
+        const hostClosure    = {required: [{module: '/e.mjs', line: 3}], used: [], unresolved: [], reached: []},
+              cleanClosure   = {required: [], used: [], unresolved: [], reached: []},
+              unknownClosure = {required: [], used: [], unresolved: [{module: '/e.mjs', reason: 'dynamic-import'}], reached: []};
+
+        test('AC-2 — authority `container-plane` against a host closure is a hard failure', () => {
+            const result = resolveEntrypointPlane({
+                closure: hostClosure, authorityClass: 'container-plane', taskName: 'someTask'
+            });
+
+            expect(result.plane).toBe('container-plane');
+            expect(result.basis).toBe('authority');
+            expect(result.findings.map(f => f.kind)).toContain(FINDING.authorityConflictInPlane);
+            // The evidence must name WHERE, or the finding cannot be acted on.
+            expect(result.findings.find(f => f.kind === FINDING.authorityConflictInPlane).evidence).toEqual(['/e.mjs:3']);
+        });
+
+        test('AC-2 — authority `host-edge` against a clean closure is also reported', () => {
+            const result = resolveEntrypointPlane({closure: cleanClosure, authorityClass: 'host-edge'});
+
+            expect(result.findings.map(f => f.kind)).toContain(FINDING.authorityConflictHost);
+        });
+
+        test('AC-3 — githubWorkflowSync shape: authority host-edge AND a host closure AGREE', () => {
+            // The false negative the retired per-file classifier produced. Agreement must be silent:
+            // a rule that fires on the correct case has no teeth left for the wrong one.
+            const result = resolveEntrypointPlane({
+                closure: hostClosure, authorityClass: 'host-edge', taskName: 'githubWorkflowSync'
+            });
+
+            expect(result.plane).toBe('host-edge');
+            expect(result.findings).toHaveLength(0);
+        });
+
+        test('AC-6 non-vacuity — a genuine in-plane entrypoint resolves clean and silent', () => {
+            const result = resolveEntrypointPlane({closure: cleanClosure});
+
+            expect(result.plane).toBe('container-plane');
+            expect(result.basis).toBe('closure');
+            expect(result.findings).toHaveLength(0);
+        });
+
+        test('AC-6 non-vacuity — a genuine host entrypoint resolves host and silent', () => {
+            const result = resolveEntrypointPlane({closure: hostClosure});
+
+            expect(result.plane).toBe('host-edge');
+            expect(result.findings).toHaveLength(0);
+        });
+
+        test('AC-5 — an unresolved edge NEVER falls back to a plane', () => {
+            const result = resolveEntrypointPlane({closure: unknownClosure, entrypoint: '/e.mjs'});
+
+            expect(result.plane).toBeNull();
+            expect(result.basis).toBe('unresolved');
+            expect(result.findings.map(f => f.kind)).toContain(FINDING.unresolvedEdge);
+        });
+
+        test('an unresolved edge does NOT weaken a host verdict', () => {
+            // Asymmetric on purpose: more reachable code cannot REMOVE a requirement already found,
+            // so a host verdict survives an incomplete graph while a clean verdict does not.
+            const closure = {...hostClosure, unresolved: [{module: '/e.mjs', reason: 'dynamic-import'}]};
+            const result  = resolveEntrypointPlane({closure});
+
+            expect(result.plane).toBe('host-edge');
+        });
+
+        test('an unresolved edge under an authority still reports, and the authority still stands', () => {
+            const result = resolveEntrypointPlane({closure: unknownClosure, authorityClass: 'container-plane'});
+
+            expect(result.plane).toBe('container-plane');
+            expect(result.findings.map(f => f.kind)).toContain(FINDING.unresolvedEdge);
+            // Must NOT claim a host conflict: the closure found no requirement, only an unknown.
+            expect(result.findings.map(f => f.kind)).not.toContain(FINDING.authorityConflictInPlane);
+        });
+    });
+});


### PR DESCRIPTION
Resolves neomjs/neo#16929

> 🌿 A directory name, a header, a token list — every retired attempt asked the code what it was called. This one asks what it reaches, and the difference is that the code cannot lie about the second. The bound I put on that reach could still lie, and now it cannot either.

Derives each executable root's execution plane from its transitive capability closure, cross-checks it against the orchestrator's declared authority, and projects the result into the structure map.

Evidence: L4 (130 arms over the resolver, the map projection and the parity registration, red-proved nine ways, plus the whole lint run against the real 66-root population) → L4 required (every AC is a local, in-process observable). Residual: one held authority conflict, ticketed as neomjs/neo-agent-brain#32 and printed on every run — see **The conflict this found** below.

## What changed since the Cycle-2 review

Three findings, one shape: **the proof boundary was drawn where the implementation ran out, not where the evidence ran out.** Each part below is a place the walk stopped while the source was still perfectly explicit about the next step.

### 1. The census gains its third channel

`readEntrypoints()` unioned npm scripts and workflow `run:` commands. It missed the roots the **orchestrator** spawns.

Measuring the join rather than reasoning about it: 11 task-definition scripts, 6 already present, **5 absent** — `backfill-memory-summaries.mjs` and `aggregate-temporal-summary.mjs`, plus `ai/daemons/{wake,embed,message}/daemon.mjs`. Every one carries a declared authority class, so the lint was silent on precisely the artifacts whose declarations are strongest.

The reviewer named two; the join finds five. The difference is the daemons, and **including them is a deliberate scope call rather than an oversight**: the population is *executable roots that declare a plane*, not *files under `ai/scripts`*. Filtering by directory here would smuggle the directory-keyed predicate — the thing this lane retired — back in through the census.

### 2. Attribution follows the whole proven chain

The one-hop bound was a **false safe**, and the fixture that "proved" it was passing for the wrong reason: its third module defined `run`, not `go`, so `Deep.go()` never had a target to find.

What actually protects the bundle-stamp case is **member granularity, not a hop count** — calling `ConnectionService.connect()` proves nothing about `spawnBridgeProcess()` at *any* depth. So the walk is now two passes: reach the module population, then walk an invocation graph over `(module, member)` nodes seeded from the two things that run by construction — every reached module's top level, and every member of the entrypoint itself.

It follows `this.x()` through `extends` chains and values through re-export barrels, because a subclass never mentions what it inherits and `ai/services.mjs` is 225 lines of indirection. And it now reconstructs the chain that proved each requirement:

```
ai/scripts/maintenance/syncGithubWorkflow.mjs::syncGithubWorkflow
  SyncService::runFullSync
    SyncService::autoPushGeneratedContent
      SyncService::commitRebaseAndPushGeneratedContent
        SyncService::execGit
```

Four hops. The old rule reached that site by accident — `runFullSync` was the one-hop target, so the *whole module* was promoted. It is now proven, and a maintainer reading a conflict gets the calls instead of a file and a line.

### 3. The ratchet holds identities

`UNRESOLVED_EDGE_BASELINE = 38` could not see a substitution: one edge vanishes, a different one appears, the total holds, CI stays green, the closure is no sounder.

Replacing it with identities corrected the population as a side effect. **The old 38 counted one edge once per entrypoint that reached it** — it measured the import graph's fan-out. Deduped, the true population is **nine**, each one nameable, and one of them (`buildKbAgentFaqs.mjs`'s stale specifier) is neomjs/neo#17182, which will disappear when that lands. The lint prints ledger entries that no longer reproduce, so the next author is told exactly what to delete.

## Two false safes the real tree found, that no fixture would have

**The import-safe guard.** `if (process.argv[1] && path.resolve(process.argv[1]) === __filename)` appears in 98 modules under `ai/`, and it means one thing: *this runs when I am the process entry.* Ignoring it, the walk concluded that importing `lint-skill-manifest.mjs` runs its `main()`, and from there that **`backup.mjs` requires a host shell** — convicting the exact file the bundle-stamp decision rules the other way. Both spellings are live and both are now read: the inline test, and the hoisted `const cliEntryPath = …` form that `buildScripts/docs/index/labels.mjs` uses.

**A key is not a member.** `owningMember` returned the nearest keyed slot, so in

```js
{
    devCommits: await this.fetchDevCommits(window),
    adrsLanded: await this.fetchAdrsLanded(window)
}
```

the call was attributed to a member named `adrsLanded` and the walk **ended on a data key**. A key owns a call site only when the site is inside that key's *function value*. This is why `aggregate-temporal-summary` came back host-free with a six-deep static chain in front of it.

## What the walk cannot name, it says so about — with a filter

A call from a proven-invoked member whose target cannot be located becomes an `unresolved-dispatch` edge, and an unresolved edge makes a NO-HOST verdict unsound.

**Reporting every unnameable call produced 656 edges on `backup.mjs` alone** — not a stricter gate, the same gate with its signal buried. Two conditions bound it, and both must hold: something must remain for the dispatch to reach, and a capability must lie **behind that particular edge**. `IDENTITIES.map(…)` resolves to a module of string constants; calling it unresolved would be true and useless.

The boundary is declared rather than implied: a call through a value the closure cannot name — a parameter, a global, a chained receiver — is a **leaf**, for the same reason a bare package specifier is one. `console.log` is not a hidden shell.

## The conflict this found — and why it is held, not fixed

Adding the task channel brought `aggregate-temporal-summary.mjs` into the population and it produced the population's only authority conflict, on a chain that is now proven six members deep:

```
main → runCycle → collectPendingWindows → fetchWindowSources → fetchDevCommits → execCommand
                                                                                → execSync('git log …')
```

**The conflict is real and the taxonomy is what is wrong.** `taskAuthority.mjs` classes `temporal-summary` container-plane deliberately and says why: the container IS the checkout, carrying `.git` at the built revision. It even names the failure mode of the opposite call. So the container has a shell *and* git — and `child_process` discriminates "spawns a subprocess", which **both planes can do**. It is not a plane predicate.

Correcting it is not local to this lint. The naive fix — grant `host-shell` only for host-controlling binaries — has a falsifier already: `syncGithubWorkflow` is declared host-edge and its only requirement is `execGit`, so the conflict does not disappear, it **inverts**. Which way that pair resolves is a statement about what makes a lane host-edge, and that belongs to the decision record.

So it is filed as **#17217** and held in `KNOWN_AUTHORITY_CONFLICTS` — itemized, ticket-bearing, printed on every run, and shrink-only. That is the same primitive as the edge ledger and it exists for the same reason: a gate with no way to record a known state either stays red until everyone routes around it, or grows a `default` branch — which is the silent-fallback shape this whole lane was built to remove. **A conflict with no ticket is not an entry; it is a silenced failure**, and the lint says so when a held entry stops reproducing.

## Deltas from ticket

**The ticket's Fix step 1 cannot satisfy the ticket's own red-proofs**, measured rather than discovered in review. Step 1 says *"walk each entrypoint's static import graph to fixpoint, collecting reached capabilities."* Both sound readings fail, in opposite directions:

| reading | `backup` (AC-4) | `githubWorkflowSync` (AC-3) |
|---|---|---|
| every REACHABLE capability | **host-required — convicts the decision record** | host ✓ |
| only what executes on import | not host ✓ | **not host — the false negative** |

**Reachability is not invocation, and a proven call chain is.** That phrasing is the reviewer's and it is what unlocked the correct rule.

**Two smaller deltas:**

- **AC-7's projection is opt-in (`--planes`), not default.** Measured: the closure walk costs ~2.2s against the structure map's ~160ms. Making a navigation tool 14× slower by default is how it stops being reached for.
- **`shared-primitive` is a valid authority class the closure never derives.** It resolves host-edge or container-plane only, and defers to the authority when one exists. Recorded rather than papered over.

## The shape

**Requirement vs USE is the load-bearing distinction**, and the bundle-stamp decision is the fixture that settles it: `backup.mjs` stamps a bundle with `git rev-parse HEAD` inside a swallowing try, ruled *not* a host dependency because it degrades to `null`. A capability counts only when its call site can abort the program.

That test needs real syntax, so this parses with `acorn` (already a direct dependency) and hand-rolls an ancestor visitor rather than adding `acorn-walk` for one traversal. **A regex over try/catch nesting would have been the same unit error the retired token classifier made, wearing a better costume.**

Authority is **consumed, never re-derived**. For a mapped task the declared class is the answer and the closure's job is to disagree loudly. The two directions are not the same defect: an in-plane declaration against a host closure means the script breaks where it is declared to run; the reverse is usually over-declaration or a runtime dependency static analysis cannot see.

**One soundness rule the ticket does not name**: an unresolved edge makes a NO-HOST verdict unsound — the capability could hide behind the edge we could not follow — but leaves a HOST verdict standing, because more reachable code cannot remove a requirement already found.

## What the projection shows

```
MIXED  ai/scripts/maintenance   unresolved 14 · container-plane 5 · host-edge 4 · shared-primitive 1
MIXED  ai/scripts/lint          container-plane 12 · host-edge 2 · unresolved 1
MIXED  ai/scripts/diagnostics   container-plane 9 · host-edge 2 · unresolved 3
MIXED  ai/scripts/benchmark     unresolved 2 · container-plane 1 · host-edge 1
MIXED  ai/scripts/lifecycle     host-edge 1 · container-plane 2
       ai/scripts/migrations    host-edge 1
       ai/scripts/runners       unresolved 2
       ai/daemons/wake          host-edge 1
       ai/daemons/embed         container-plane 1
       ai/daemons/message       container-plane 1
```

**Five of seven `ai/scripts` folders hold more than one plane** — the directory-keyed predicate's falsifier rendered as output rather than argued. The folders are named after the verb, and a name cannot tell you.

## Test Evidence

```
npx playwright test -c test/playwright/playwright.config.unit.mjs \
  test/playwright/unit/ai/scripts/lint/scriptPlaneClosure.spec.mjs \
  test/playwright/unit/ai/scripts/diagnostics/structureMap.spec.mjs \
  test/playwright/unit/ai/scripts/lint/lintWorkflowScanRootParity.spec.mjs \
  test/playwright/unit/ai/buildScripts/util/check-fixed-sleeps.spec.mjs --workers=1
→ 130 passed (5.5s)

node ./ai/scripts/lint/lint-script-plane.mjs
→ 66 executable roots — 57 npm, 4 workflow, 5 orchestrator-task
  host-edge 12 · container-plane 31 · shared-primitive 1 · unresolved 22
  KNOWN conflict, ticketed and held: aggregate-temporal-summary.mjs (temporal-summary)
  OK — no new authority conflicts; 9 unresolved edge(s), all known.   exit 0
```

**Red-proved nine ways**, each a plausible wrong implementation:

| mutation | arms failed |
|---|---|
| propagation bounded back to ONE hop | 2 |
| import-safe guard ignored on the call side | 2 |
| a guarded capability site still promoted | 1 |
| an object-literal KEY owns the call again | 1 |
| re-export barrels not followed | 4 |
| `extends` chain not walked | 3 |
| capability-behind-the-edge filter dropped | 4 |
| ratchet compares COUNTS, not identities | 1 |
| task-definition channel dropped from the census | 2 |

**The battery found a real coverage gap in its own subject.** "A guarded capability site still promoted" first came back **63 passed** — a no-op proof, because every guard arm exercised the *call* side and none covered a capability sitting directly inside the guard. The arm that closes it is `a capability INSIDE the guard is dormant for an importer`. A mutation that changes nothing is the cheapest possible signal that an arm is missing, and it only works if you read the count instead of the exit code.

The harness also caught one of its own mutations silently failing to apply — a `\Q…\E` pattern that matched nothing and reported a clean run. It now diffs the file before believing the result, because **a mutation that did not apply is indistinguishable from a rule that is not needed.**

## Post-Merge Validation

Nothing is owed. Every AC is a local observable and each is armed. The new workflow exercises itself on the next PR touching `ai/**`.

Worth naming for whoever reads the lint's output next: **it is not a required status context** on `dev` (#17171), so a red result is loud and visible without making a PR ineligible to merge. The workflow header says so rather than implying a closure it does not have.

## Evolution

The instructive part is that **the bound I chose to be conservative was the least sound thing in the file.** One hop looked like restraint and was a false safe; what actually carried the protection was member granularity, which I had already written and mis-attributed to the hop count. Two review cycles found the boundary before I did, and both times the phrasing that unlocked it was the reviewer's.

The second lesson is narrower and cost more: **three of the four defects here only exist in the real tree.** The import-safe guard, the object-literal key, and the re-export barrel are all idioms this repository uses constantly and no hand-written fixture contains. The fixtures proved the rules I had thought of.

Related: #16652 · neomjs/neo#16944 · neomjs/neo#17171 · neomjs/neo-agent-brain#32

Authored by Vega (Claude Opus 5, Claude Code). Session 5cd926fa-77e1-4309-8bbf-ca563ab07403.
