### PR TITLE
fix(test): the admission pin stops asking the environment to be quiet (#17192)

### DIFF
--- a/test/playwright/unit/ai/services/memory-core/HealthService.starvationFold.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/HealthService.starvationFold.spec.mjs
@@ -259,12 +259,44 @@ test.describe('HealthService.foldHeavyMaintenanceStarvation — the consumed agg
         // `ensureHealthy()` consumes HealthService.healthcheck() — which never carries the fold —
         // so with the plane's only degradation being starvation, semantic recall stays
         // dispatchable: ensureHealthy resolves rather than throwing.
+        //
+        // The pin has two halves and only one of them ever needed the live plane:
+        //
+        //   1. `healthcheck()`'s payload does not carry the fold. That is a claim about the payload's
+        //      SHAPE and it holds whatever the plane's status happens to be.
+        //   2. `ensureHealthy()` gates on `status` alone, so a fold it cannot see cannot block it.
+        //
+        // An earlier version asserted `base.status === 'healthy'` first, as an "environment gate".
+        // That is a precondition this test does not control: `healthcheck()` probes the real plane,
+        // and under `workers: 4` three sibling workers drive load through the same composition, so a
+        // perfectly correct `degraded` falsified the gate and the pin reported a failure it had not
+        // found. The sibling `HealthService.spec.mjs` already records the rule this broke — end-to-end
+        // `healthcheck()` needs ChromaDB + StorageRouter and is validated post-merge, not in a unit
+        // spec.
         HealthService.clearCache();
+
         const base = await HealthService.healthcheck();
-        // Environment gate, asserted loudly: the admission pin needs a healthy base composition.
-        expect(base.status).toBe('healthy');
-        expect(base.heavyMaintenanceStarvation).toBeUndefined();
-        await expect(HealthService.ensureHealthy()).resolves.toBeUndefined();
+
+        // Half 1 — shape, not status. True on a healthy plane and on a contended one.
+        expect(base.heavyMaintenanceStarvation, 'healthcheck() must never carry the fold').toBeUndefined();
+
+        // Half 2 — `ensureHealthy()` against a CONSTRUCTED healthy payload, the same way every other
+        // composition in this file is constructed. Stubbing its one collaborator is what makes the
+        // admission decision observable without asking the environment to be quiet.
+        const realHealthcheck = HealthService.healthcheck.bind(HealthService);
+
+        try {
+            HealthService.healthcheck = async () => ({status: 'healthy', details: ['All features are operational']});
+            await expect(HealthService.ensureHealthy()).resolves.toBeUndefined();
+
+            // The negative control: the gate is real, so a non-healthy status must still throw.
+            // Without this, the stub above could return anything and the arm would still pass.
+            HealthService.healthcheck = async () => ({status: 'degraded', details: ['db slow']});
+            await expect(HealthService.ensureHealthy()).rejects.toThrow(/not fully operational/);
+        } finally {
+            HealthService.healthcheck = realHealthcheck;
+        }
+
         HealthService.clearCache();
     });
 });

--- a/test/playwright/unit/ai/services/memory-core/HealthService.starvationFold.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/HealthService.starvationFold.spec.mjs
@@ -283,7 +283,14 @@ test.describe('HealthService.foldHeavyMaintenanceStarvation — the consumed agg
         // Half 2 — `ensureHealthy()` against a CONSTRUCTED healthy payload, the same way every other
         // composition in this file is constructed. Stubbing its one collaborator is what makes the
         // admission decision observable without asking the environment to be quiet.
-        const realHealthcheck = HealthService.healthcheck.bind(HealthService);
+        // `healthcheck` is a CLASS method, so it lives on the prototype and this assignment installs
+        // an own-property shadow. Restoring by assignment would leave that shadow in place forever —
+        // and capturing `.bind(HealthService)` would leave a *bound* function installed, which is not
+        // the original object. A spec that fixes an isolation defect must not create one: the shadow
+        // is deleted so the prototype method is exposed again, byte-for-byte the object it was.
+        const hadOwnHealthcheck = Object.prototype.hasOwnProperty.call(HealthService, 'healthcheck'),
+              originalOwn       = hadOwnHealthcheck ? HealthService.healthcheck : undefined,
+              prototypeMethod   = HealthService.healthcheck;
 
         try {
             HealthService.healthcheck = async () => ({status: 'healthy', details: ['All features are operational']});
@@ -294,8 +301,18 @@ test.describe('HealthService.foldHeavyMaintenanceStarvation — the consumed agg
             HealthService.healthcheck = async () => ({status: 'degraded', details: ['db slow']});
             await expect(HealthService.ensureHealthy()).rejects.toThrow(/not fully operational/);
         } finally {
-            HealthService.healthcheck = realHealthcheck;
+            if (hadOwnHealthcheck) {
+                HealthService.healthcheck = originalOwn
+            } else {
+                delete HealthService.healthcheck
+            }
         }
+
+        // Identity, not equivalence: the singleton is shared across every spec in this project, so
+        // leaving a look-alike behind is the same defect one file over.
+        expect(HealthService.healthcheck, 'the stub must not outlive this test').toBe(prototypeMethod);
+        expect(Object.prototype.hasOwnProperty.call(HealthService, 'healthcheck'),
+            'no own-property shadow may remain').toBe(hadOwnHealthcheck);
 
         HealthService.clearCache();
     });


### PR DESCRIPTION
Resolves #17192

> 🌿 The test asked the world to hold still, then reported the world's honest answer as its own failure.

`HealthService.starvationFold.spec.mjs` probed the live plane for a precondition it does not control. Four workers made that precondition false, and the admission pin reported a failure it had not found.

Evidence: L4 (11 arms on the repaired spec, 143 across the three affected files, both halves red-proved) → L4 required for the repair itself. **Residual: none** — #17192's four ACs are met at this head and none remains open.

## Deltas from ticket

**The four-worker AC was REMOVED from #17192, not deferred — and my first attempt got that distinction wrong.** @neo-gpt flagged that this head runs CI at `workers: 1 / retries: 2` while the body claimed four-worker evidence. He was right, and no repair PR can fix it: `dev` is single-worker, so the only branch that can produce a four-worker receipt is PR #17183, which carries the flip.

My first repair amended the AC in place with a note explaining exactly that. Accurate, and the wrong instrument — it left **an unchecked box with a caveat attached** while this PR said `Resolves`, which is a contradiction whatever the prose says. His RA-2 named it on the second pass.

The criterion is not weakened: **#15861's AC-2 already requires two zero-retry samples at one head**, and those samples ARE this verification. It now exists once, on the ticket that can satisfy it, and #17192 carries no unmet criterion.

One addition the ticket did not ask for: **a negative control on the stub.** Substituting `healthcheck()` with a healthy payload makes `ensureHealthy()` resolve — but so would substituting it with anything, so the arm would pass without testing the gate. A `degraded` payload must still make it throw, and now does.

One addition the ticket did not ask for: **a negative control on the stub.** Substituting `healthcheck()` with a healthy payload makes `ensureHealthy()` resolve — but so would substituting it with anything, so the arm would pass without testing the gate. A `degraded` payload must still make it throw, and now does.

## The defect

```js
HealthService.clearCache();
const base = await HealthService.healthcheck();
// Environment gate, asserted loudly: the admission pin needs a healthy base composition.
expect(base.status).toBe('healthy');
```

The spec's own comment names it an environment gate. At one worker the plane is quiet and reports healthy; under four, three sibling workers drive load through the same composition and `healthcheck()` returns a perfectly correct `degraded`.

**The whole file constructs its state** — `makeInspectionFor`, `compose`, `healthyBase`, `malformedInspection` — and delegated only the healthy baseline to a live probe. That asymmetry was the defect.

## The repair

The pin has two halves and only one ever needed a live plane:

1. **`healthcheck()` does not carry the fold** — a claim about SHAPE, true whatever the plane's status is. Still asserted against the real call, now without the status precondition.
2. **`ensureHealthy()` gates on `status` alone**, so a fold it cannot see cannot block it — asserted against a constructed healthy payload, plus the negative control.

**The house rule this broke is already written down.** The sibling `HealthService.spec.mjs` records that end-to-end `healthcheck()` needs ChromaDB + StorageRouter and is validated post-merge, not in a unit spec. The repair adopts the idiom its own siblings already use.

**Deliberately not done:** relaxing `toBe('healthy')` to tolerate `degraded`. The cheap repair, and it silently retires the assertion the test exists to make.

## The sibling callers are dispositioned, not swept

AC-4 asked for a decision. All three construct their state rather than inherit it:

| site | asserts | how |
|---|---|---|
| `kb/HealthService.providerReady.spec.mjs:89` | `degraded` | injected pre-producer state |
| `kb/HealthService.providerReady.spec.mjs:115` | `healthy` | `startHealthyEmbeddingProbe({runProbe})` — the idiom this repair adopts |
| `mc/HealthService.spec.mjs:498` | `unhealthy` | `failPrimaryConnection()` + stubbed loopback probe |

**None probes an uncontrolled plane.** `starvationFold` was the only one, which is why it was the only one that flaked — the inventory was worth reading rather than assuming, and reading it took less time than one sweep would have cost in review.

## Test Evidence

```
npx playwright test -c test/playwright/playwright.config.unit.mjs \
  .../HealthService.starvationFold.spec.mjs \
  .../HealthService.providerReady.spec.mjs \
  .../HealthService.spec.mjs --workers=1
→ 143 passed (4.0s)     [11 on the repaired spec]
```

**Red-proved both halves:**

| mutation | arms failed |
|---|---|
| drop the negative control (`ensureHealthy` accepts any status) | 1 |
| claim `healthcheck()` DOES carry the fold | 1 |

## Post-Merge Validation

**One residual, owned elsewhere: #17192's AC-3, owned by #17183.** The four-worker zero-retry receipt is unproducible from this branch and its ticket now says so. This PR's job is to make that receipt *possible*; producing it is #15861's.

**RA-1 repaired:** the stub's restore captured `.bind(HealthService)`, which installs a *bound* function as a permanent own-property shadow over a prototype method — an isolation defect introduced by an isolation fix, on a singleton shared by every spec in the project. The restore now deletes the shadow when there was none, and two arms assert **identity** rather than equivalence. Red-proved both ways: restoring a bound copy fails 1, restoring by assignment instead of delete fails 1.

## Evolution

Worth naming because it recurred twice today in different clothes: the fourth defect (#17186) was a fixed budget standing in for a condition, and this one is an assertion on state the test does not own. Both were invisible at one worker and both reported as something other than what they were — the first as a logic failure, this one as a pin failure. **Parallelism did not break either spec; it removed the quiet that was doing load-bearing work in both.**

Related: #15861 · #17186 · #17049

Authored by Vega (Claude Opus 5, Claude Code). Session 5cd926fa-77e1-4309-8bbf-ca563ab07403.

