### PR TITLE
feat(agentos): browser wake-stream consumer twin + the bridge's two-mint wake capability (#17190)

### DIFF
--- a/ai/configBase.mjs
+++ b/ai/configBase.mjs
@@ -355,6 +355,25 @@ class ConfigBase extends ConfigProvider {
                  */
                 admissionTokenFile: leaf('', 'NEO_MCP_HEALTHCHECK_TOKEN_FILE', 'string'),
                 /**
+                 * The VIEWER's class-3 MC mint for browser-direct per-viewer wake arming: when a
+                 * deployment declares it, the armed bearer handshake serves it alongside the
+                 * process bearer, the cockpit boot binds it into transport-closure custody, and
+                 * the wake stream presents it on `x-neo-mc-authorization` — a DIFFERENT MINT from
+                 * the class-1 fleet admission bearer by contract (byte-identical pairs are refused
+                 * at every seam). Empty is the honest not-armed default: the stream connects
+                 * class-1-only and the server answers `armedForViewer: false`.
+                 * @type {string}
+                 */
+                viewerMcAuthorization: leaf('', 'NEO_FLEET_VIEWER_MC_AUTHORIZATION', 'string'),
+                /**
+                 * Secret-file indirection for `viewerMcAuthorization` — the same custody split as
+                 * `planeAdmissionBearerFile`: the direct value wins when both are set, empty means
+                 * no file indirection, and the Fleet entry reads it at the use site, never at
+                 * import.
+                 * @type {string}
+                 */
+                viewerMcAuthorizationFile: leaf('', 'NEO_FLEET_VIEWER_MC_AUTHORIZATION_FILE', 'string'),
+                /**
                  * Bearer credential for the app<->fleet TRANSPORT — a different credential from
                  * `planeBearer`, which authenticates to the containerized plane. Secret-class, so
                  * the default is empty and never carries a value: `resolveFleetBearer` generates

--- a/ai/scripts/lint/config-leaf-parity.json
+++ b/ai/scripts/lint/config-leaf-parity.json
@@ -235,6 +235,8 @@
         "fleet.planeInternalHosts",
         "fleet.port",
         "fleet.tenantProbeTimeoutMs",
+        "fleet.viewerMcAuthorization",
+        "fleet.viewerMcAuthorizationFile",
         "fleet.wakeReceiverManifestPath",
         "fleet.wakeSelfBase",
         "geminiApiKey",

--- a/ai/scripts/lint/retry-bound-registry.json
+++ b/ai/scripts/lint/retry-bound-registry.json
@@ -138,6 +138,13 @@
             "witness": "`Math.min(failureTtlMaxMs, ...)` in the same expression",
             "note": "The shared flight gate; #16307 records why it is NOT the right mechanism for persisted cadence state."
         },
+        "apps/agentos/fleet/fleetWakeStreamConsumer.mjs#runLoop:5f68f770": {
+            "kind": "retry-growth",
+            "lifetime": "process-local",
+            "boundCarrier": "max-delay",
+            "witness": "`Math.min(..., MAX_BACKOFF_MS)` caps the exponential reconnect delay at 60s, and the loop exits terminally on `stopped` or an epoch change (`stop()` bumps the epoch) — the spec `fleetWakeStreamConsumer.spec.mjs` drives a drop→reconnect cycle on the injected floor and `stop()` ends the loop.",
+            "note": "The App-Worker twin of the relay consumer's identical site (same fingerprint 5f68f770): the parity spec binds the parser, this entry binds the bound."
+        },
         "apps/devindex/services/GitHub.mjs##getRetryDelay:41482917": {
             "kind": "retry-growth",
             "lifetime": "process-local",

--- a/ai/services/fleet/devFleetServer.mjs
+++ b/ai/services/fleet/devFleetServer.mjs
@@ -54,7 +54,8 @@ import FleetManager             from './FleetManager.mjs';
 import {startFleetBridgeServer} from './fleetBridgeServer.mjs';
 import {probeExistingFleetServer, resolveFleetBearer, resolveFleetViewer,
         resolveFleetViewerClaim}                                          from './fleetLaunchContract.mjs';
-import {assertFleetPlaneAdmissionBearerClass} from './fleetServer.mjs';
+import {assertFleetPlaneAdmissionBearerClass,
+        assertFleetViewerMcAuthorizationClass}                            from './fleetServer.mjs';
 import {createPlaneMailboxClient}             from './planeMailboxClient.mjs';
 import {createPlaneWakeIdentitiesReader,
         createPlaneWakeObservationsReader}                               from './planeWakeIdentitiesReader.mjs';
@@ -370,6 +371,11 @@ async function boot() {
             // The launcher's custody decision, resolved at the use site: `npm run cockpit` arms
             // the browser bearer handshake in this child's env; a standalone boot defaults off.
             bearerHandshake: AiConfig.fleet.bearerHandshake,
+            // The viewer's class-3 MC mint, when the deployment declares one: class-asserted here
+            // (never the relay's plane or admission credential), served by the armed handshake as
+            // the pair, refused at transport startup if it aliases the process bearer. Empty is
+            // the honest not-armed default.
+            mcAuthorization: assertFleetViewerMcAuthorizationClass() || null,
             runInContext   : (context, fn) => RequestContextService.run(context, fn)
         });
 

--- a/ai/services/fleet/fleetBridgeServer.mjs
+++ b/ai/services/fleet/fleetBridgeServer.mjs
@@ -59,6 +59,12 @@ import {isLocalBearerToken}      from '../../mcp/server/shared/helpers/localBear
  *     browser Origin may redeem the process bearer, which is how the one-command cockpit hands the
  *     secret to a plain page with no agent seam (see the `fleet.bearerHandshake` leaf for the
  *     custody decision). Unarmed, the path stays inside the bearer-gated 404 surface.
+ * @param {String}   [opts.mcAuthorization=null] The viewer's class-3 MC mint for per-viewer wake
+ *     arming: when present, the armed handshake serves it ALONGSIDE the process bearer so the
+ *     cockpit boot can bind both into closure custody. A DIFFERENT MINT from the class-1 process
+ *     bearer by contract — a byte-identical pair refuses startup (fail-closed), because both
+ *     surfaces can share a verifier and byte-identity is exactly how one mint silently serves two
+ *     audiences. `null`/empty is the honest not-armed state.
  * @returns {Promise<http.Server>} resolves once the server is listening.
  * @throws {TypeError} When the bearer, viewer binding, or context runner is missing/invalid — the
  *     fail-closed startup contract of the ingress trust boundary.
@@ -73,10 +79,19 @@ export function startFleetBridgeServer({
     runInContext      = null,
     allowedOrigins    = ['http://localhost:8080', 'http://127.0.0.1:8080'],
     extraAllowedHosts = [],
-    bearerHandshake   = false
+    bearerHandshake   = false,
+    mcAuthorization   = null
 } = {}) {
     if (!isLocalBearerToken(bearerToken)) {
         throw new TypeError('[fleet] startup refused: a canonical 32-byte unpadded-base64url bearerToken is required (fail-closed ingress)')
+    }
+
+    if (mcAuthorization !== null && (typeof mcAuthorization !== 'string' || !mcAuthorization.trim())) {
+        throw new TypeError('[fleet] startup refused: mcAuthorization must be null or a non-empty viewer MC mint')
+    }
+
+    if (mcAuthorization !== null && mcAuthorization === bearerToken) {
+        throw new TypeError('[fleet] startup refused: the viewer MC mint is byte-identical to the process bearer — the credential-class ledger forbids the aliasing; mint a distinct class-3 credential')
     }
 
     if (!viewerContext?.userId || !viewerContext?.agentIdentityNodeId) {
@@ -157,7 +172,12 @@ export function startFleetBridgeServer({
             console.log(`[fleet] bearer handshake redeemed by origin ${req.headers.origin} at ${new Date().toISOString()}`);
             res.setHeader('Connection', 'close');
             res.setHeader('Cache-Control', 'no-store');
-            return respond(res, 200, {ok: true, result: {bearerToken}}, decision.corsOrigin)
+            // The pair travels together when the deployment armed a viewer mint; a bearer-only
+            // response is the honest not-armed shape, never a degraded one.
+            return respond(res, 200, {
+                ok    : true,
+                result: {bearerToken, ...(mcAuthorization ? {mcAuthorization} : {})}
+            }, decision.corsOrigin)
         }
 
         // Exact-path match — a sibling path like /fleetx must fail closed, never reach dispatch.

--- a/ai/services/fleet/fleetServer.mjs
+++ b/ai/services/fleet/fleetServer.mjs
@@ -697,6 +697,77 @@ export function assertFleetPlaneAdmissionBearerClass({aiConfig = AiConfig, readF
 }
 
 /**
+ * @summary Resolves the VIEWER's class-3 MC mint for browser-direct wake arming — the credential
+ * the armed bearer handshake serves alongside the process bearer. Same two declared homes, same
+ * precedence as its siblings: the direct `fleet.viewerMcAuthorization` value wins; otherwise
+ * `fleet.viewerMcAuthorizationFile` names a secret file. Returns `''` when neither yields a
+ * value — the honest not-armed default, never a fallback onto a different credential class.
+ * @param {Object} [options]
+ * @param {Object} [options.aiConfig=AiConfig] Resolved Tier-1 config tree.
+ * @param {Function} [options.readFile] Injection seam for tests; defaults to `readFileSync`.
+ * @returns {String} The resolved viewer MC mint, or `''`.
+ */
+export function resolveFleetViewerMcAuthorization({aiConfig = AiConfig, readFile = null} = {}) {
+    const direct = aiConfig.fleet.viewerMcAuthorization.trim();
+
+    if (direct) return direct;
+
+    const mintFile = aiConfig.fleet.viewerMcAuthorizationFile.trim();
+
+    if (!mintFile) return '';
+
+    try {
+        const read = readFile ?? (target => readFileSync(target, 'utf8'));
+        return String(read(mintFile)).trim()
+    } catch {
+        return ''
+    }
+}
+
+/**
+ * @summary The non-alias teeth for the viewer MC mint: the resolved value must not BE the relay's
+ * plane-MCP bearer and must not BE the relay's fleet-client admission bearer. The viewer's mint is
+ * the VIEWER'S OWN MC authority — arming with a relay-class credential would create subscriptions
+ * under the relay's identity while claiming viewer arming, which is exactly the confusion the
+ * credential-class ledger exists to refuse. (The third pair — viewer mint vs the fleet PROCESS
+ * bearer — is refused where both runtime values meet: the transport's startup validation.)
+ * @param {Object} [options]
+ * @param {Object} [options.aiConfig=AiConfig] Resolved Tier-1 config tree.
+ * @param {Function} [options.readFile] Injection seam for tests; defaults to `readFileSync`.
+ * @returns {String} The class-clean resolved viewer mint (may be `''`).
+ * @throws {Error} When the viewer mint aliases the plane-MCP bearer or the admission bearer.
+ */
+export function assertFleetViewerMcAuthorizationClass({aiConfig = AiConfig, readFile = null} = {}) {
+    const
+        read       = readFile ?? (target => readFileSync(target, 'utf8')),
+        viewerMint = resolveFleetViewerMcAuthorization({aiConfig, readFile: read});
+
+    if (!viewerMint) return viewerMint;
+
+    const planeBearer = resolveFleetPlaneBearer({aiConfig, readFile: read});
+
+    if (planeBearer && viewerMint === planeBearer) {
+        throw new Error(
+            '[FleetServer] fleet.viewerMcAuthorization resolves to the same bytes as the plane-MCP ' +
+            'bearer — the viewer mint is the viewer\'s OWN MC authority, never the relay\'s plane ' +
+            'credential. Mint a distinct viewer MC credential.'
+        )
+    }
+
+    const admissionBearer = resolveFleetPlaneAdmissionBearer({aiConfig, readFile: read});
+
+    if (admissionBearer && viewerMint === admissionBearer) {
+        throw new Error(
+            '[FleetServer] fleet.viewerMcAuthorization resolves to the same bytes as the ' +
+            'fleet-client admission bearer — the credential-class ledger forbids that aliasing. ' +
+            'Mint a distinct viewer MC credential.'
+        )
+    }
+
+    return viewerMint
+}
+
+/**
  * @summary Derives the ONE stream/limiter key for an admitted viewer, from immutable facts only.
  *
  * The plane-proven canonical identity (`@login`, MC's own subject for the arming caller) is the

--- a/apps/agentos/app.mjs
+++ b/apps/agentos/app.mjs
@@ -59,10 +59,10 @@ export function resolveFleetUrl() {
 // module for its pure exports; there is no serialized boot URL there, so there is nothing to dial).
 const bootUrl = globalThis.Neo?.config?.url;
 
-let redeemedBearer = null;
+let redeemed = null;
 
 if (bootUrl?.href && resolveFleetTransportMode(bootUrl) === 'browser' && !globalThis.AgentOS?.fleet?.bearerToken) {
-    redeemedBearer = await redeemFleetBearerHandshake({url: resolveFleetUrl()})
+    redeemed = await redeemFleetBearerHandshake({url: resolveFleetUrl()})
 }
 
 /**
@@ -94,20 +94,21 @@ if (bootUrl?.href && resolveFleetTransportMode(bootUrl) === 'browser' && !global
  *
  * @param {Object}   opts
  * @param {String}   opts.fleetUrl                         Raw dial endpoint; identity derives from its canonical form.
- * @param {String}   [opts.redeemedBearer=null]            The armed-handshake redemption result, module-private
- *     in the boot path — takes precedence over the launcher slot; `null` falls back to the slot.
+ * @param {Object}   [opts.redeemed=null]                  The armed-handshake redemption PAIR
+ *     (`{bearerToken, mcAuthorization}`), module-private in the boot path — each field takes
+ *     precedence over its launcher slot; `null` falls back to the slots entirely.
  * @param {Function} [opts.installImpl=installFleetBridge] Injectable install for tests.
  * @param {Object}   [opts.target=globalThis]              Injectable global for tests.
  * @returns {Object} `{bridge, custodySettled}` — the bridge PUBLISHED at return time (the fresh
  *     install, or the preserved known-good one while a candidate proves itself), and a
  *     never-rejecting promise resolving `true` exactly when the bearer ingress was verified-retired.
  */
-export function establishFleetSessionCustody({fleetUrl, redeemedBearer: redeemed = null, installImpl = installFleetBridge, target = globalThis} = {}) {
+export function establishFleetSessionCustody({fleetUrl, redeemed = null, installImpl = installFleetBridge, target = globalThis} = {}) {
     const
         fleet           = target.AgentOS?.fleet,
         existing        = fleet?.registryBridge,
-        bearerToken     = redeemed ?? fleet?.bearerToken ?? null,
-        mcAuthorization = fleet?.mcAuthorization ?? null;
+        bearerToken     = redeemed?.bearerToken ?? fleet?.bearerToken ?? null,
+        mcAuthorization = redeemed?.mcAuthorization ?? fleet?.mcAuthorization ?? null;
 
     if (bearerToken === null && existing) {
         return {bridge: existing, custodySettled: Promise.resolve(false)}
@@ -169,10 +170,10 @@ export const onStart = () => {
         // params outright. Without a bearer the bridge installs fail-closed (every call rejects
         // locally, named) — or, on a SharedWorker re-join, an existing bridge is PRESERVED rather
         // than downgraded — and the slots stay as they were, which is the rollback truth.
-        const hadBearer = redeemedBearer !== null || (globalThis.AgentOS?.fleet?.bearerToken ?? null) !== null;
+        const hadBearer = redeemed !== null || (globalThis.AgentOS?.fleet?.bearerToken ?? null) !== null;
 
-        establishFleetSessionCustody({fleetUrl, redeemedBearer});
-        redeemedBearer = null;
+        establishFleetSessionCustody({fleetUrl, redeemed});
+        redeemed = null;
 
         // Late-transport healing: the module-level redemption races the fleet child's boot (plane
         // admission alone can take seconds), and on a SharedWorker topology a reload re-enters
@@ -181,8 +182,8 @@ export const onStart = () => {
         // and the pane resolves the slot per call, so the next poll goes live. Still-no-bearer
         // stays the honest fail-closed state.
         if (!hadBearer) {
-            redeemFleetBearerHandshake({url: fleetUrl}).then(token => {
-                token && establishFleetSessionCustody({fleetUrl, redeemedBearer: token})
+            redeemFleetBearerHandshake({url: fleetUrl}).then(pair => {
+                pair && establishFleetSessionCustody({fleetUrl, redeemed: pair})
             })
         }
     }

--- a/apps/agentos/app.mjs
+++ b/apps/agentos/app.mjs
@@ -87,20 +87,27 @@ if (bootUrl?.href && resolveFleetTransportMode(bootUrl) === 'browser' && !global
  *   which IS the rollback truth. A throwing install preserves it the same way, and a failed
  *   candidate leaves the known-good bridge published.
  *
+ * The function reads the ENTRYPOINT truth itself — the module-private handshake redemption result
+ * plus the two launcher pre-boot slots (`AgentOS.fleet.bearerToken`, `AgentOS.fleet.mcAuthorization`)
+ * — so the production path and the specs exercise the same read-old surface: both mints move into
+ * closures at establish, and BOTH ingress copies are CAS-retired under the one custody proof.
+ *
  * @param {Object}   opts
  * @param {String}   opts.fleetUrl                         Raw dial endpoint; identity derives from its canonical form.
- * @param {String}   [opts.bearerToken=null]               Redeemed or launcher-placed bearer; `null` boots fail-closed.
- * @param {String}   [opts.mcAuthorization=null]           The viewer's class-3 MC mint for per-viewer
- *     wake arming — session-closure custody like the bearer, never parked on a slot; `null` is the
- *     honest not-armed state.
+ * @param {String}   [opts.redeemedBearer=null]            The armed-handshake redemption result, module-private
+ *     in the boot path — takes precedence over the launcher slot; `null` falls back to the slot.
  * @param {Function} [opts.installImpl=installFleetBridge] Injectable install for tests.
  * @param {Object}   [opts.target=globalThis]              Injectable global for tests.
  * @returns {Object} `{bridge, custodySettled}` — the bridge PUBLISHED at return time (the fresh
  *     install, or the preserved known-good one while a candidate proves itself), and a
- *     never-rejecting promise resolving `true` exactly when the ingress slot was verified-retired.
+ *     never-rejecting promise resolving `true` exactly when the bearer ingress was verified-retired.
  */
-export function establishFleetSessionCustody({fleetUrl, bearerToken = null, mcAuthorization = null, installImpl = installFleetBridge, target = globalThis} = {}) {
-    const existing = target.AgentOS?.fleet?.registryBridge;
+export function establishFleetSessionCustody({fleetUrl, redeemedBearer: redeemed = null, installImpl = installFleetBridge, target = globalThis} = {}) {
+    const
+        fleet           = target.AgentOS?.fleet,
+        existing        = fleet?.registryBridge,
+        bearerToken     = redeemed ?? fleet?.bearerToken ?? null,
+        mcAuthorization = fleet?.mcAuthorization ?? null;
 
     if (bearerToken === null && existing) {
         return {bridge: existing, custodySettled: Promise.resolve(false)}
@@ -116,6 +123,12 @@ export function establishFleetSessionCustody({fleetUrl, bearerToken = null, mcAu
         : bridge.resolveViewerIdentity()
             .then(() => {
                 publishNow || installImpl({url: fleetUrl, bearerToken, mcAuthorization, profileId: profile.profileId, target});
+
+                // One proof gates BOTH retires: the class-3 mint has no boot-time wire proof of
+                // its own (its truth surface is the stream's arming answer, observed later), so
+                // its ingress copy retires with the session's proven custody transaction — and a
+                // failed verify preserves both slots.
+                mcAuthorization && retireBearerIngressSlot(target, {expected: mcAuthorization, field: 'mcAuthorization'});
                 return retireBearerIngressSlot(target, {expected: bearerToken})
             })
             .catch(() => false);
@@ -145,20 +158,20 @@ export const onStart = () => {
             }
         })
     } else {
-        // Direct-browser dev mode is the session-only custodian shape. The bearer is an IN-MEMORY
-        // hand-off: the module-private handshake redemption above, or the launcher pre-boot slot
-        // (Electron main, the Neural Link, a test init-script places it BEFORE app start) — read
-        // here (the read-old phase), moved into transport closures by the install (establish), and
-        // the slot retired only after the bridge's authenticated whoami round-trip proves the
-        // credential, and only while the slot still holds that exact value (verify → CAS retire).
-        // Deliberately never read from URL params — a secret in a URL persists in history, logs,
-        // and referrers, so installFleetBridge refuses credential-shaped query params outright.
-        // Without a bearer the bridge installs fail-closed (every call rejects locally, named) —
-        // or, on a SharedWorker re-join, an existing bridge is PRESERVED rather than downgraded —
-        // and the slot stays as it was, which is the rollback truth.
-        const bearerToken = redeemedBearer ?? globalThis.AgentOS?.fleet?.bearerToken ?? null;
+        // Direct-browser dev mode is the session-only custodian shape. Both mints are IN-MEMORY
+        // hand-offs: the module-private handshake redemption above, or the launcher pre-boot
+        // slots (Electron main, the Neural Link, a test init-script places `bearerToken` and,
+        // when arming, `mcAuthorization` BEFORE app start) — read inside the establish call (the
+        // read-old phase), moved into transport closures (establish), and both ingress copies
+        // CAS-retired only after the bridge's authenticated whoami round-trip proves the session
+        // (verify → retire). Deliberately never read from URL params — a secret in a URL persists
+        // in history, logs, and referrers, so installFleetBridge refuses credential-shaped query
+        // params outright. Without a bearer the bridge installs fail-closed (every call rejects
+        // locally, named) — or, on a SharedWorker re-join, an existing bridge is PRESERVED rather
+        // than downgraded — and the slots stay as they were, which is the rollback truth.
+        const hadBearer = redeemedBearer !== null || (globalThis.AgentOS?.fleet?.bearerToken ?? null) !== null;
 
-        establishFleetSessionCustody({bearerToken, fleetUrl});
+        establishFleetSessionCustody({fleetUrl, redeemedBearer});
         redeemedBearer = null;
 
         // Late-transport healing: the module-level redemption races the fleet child's boot (plane
@@ -167,9 +180,9 @@ export const onStart = () => {
         // fail-closed bridge in place — installFleetBridge is documented additive + idempotent,
         // and the pane resolves the slot per call, so the next poll goes live. Still-no-bearer
         // stays the honest fail-closed state.
-        if (!bearerToken) {
+        if (!hadBearer) {
             redeemFleetBearerHandshake({url: fleetUrl}).then(token => {
-                token && establishFleetSessionCustody({bearerToken: token, fleetUrl})
+                token && establishFleetSessionCustody({fleetUrl, redeemedBearer: token})
             })
         }
     }

--- a/apps/agentos/app.mjs
+++ b/apps/agentos/app.mjs
@@ -90,13 +90,16 @@ if (bootUrl?.href && resolveFleetTransportMode(bootUrl) === 'browser' && !global
  * @param {Object}   opts
  * @param {String}   opts.fleetUrl                         Raw dial endpoint; identity derives from its canonical form.
  * @param {String}   [opts.bearerToken=null]               Redeemed or launcher-placed bearer; `null` boots fail-closed.
+ * @param {String}   [opts.mcAuthorization=null]           The viewer's class-3 MC mint for per-viewer
+ *     wake arming — session-closure custody like the bearer, never parked on a slot; `null` is the
+ *     honest not-armed state.
  * @param {Function} [opts.installImpl=installFleetBridge] Injectable install for tests.
  * @param {Object}   [opts.target=globalThis]              Injectable global for tests.
  * @returns {Object} `{bridge, custodySettled}` — the bridge PUBLISHED at return time (the fresh
  *     install, or the preserved known-good one while a candidate proves itself), and a
  *     never-rejecting promise resolving `true` exactly when the ingress slot was verified-retired.
  */
-export function establishFleetSessionCustody({fleetUrl, bearerToken = null, installImpl = installFleetBridge, target = globalThis} = {}) {
+export function establishFleetSessionCustody({fleetUrl, bearerToken = null, mcAuthorization = null, installImpl = installFleetBridge, target = globalThis} = {}) {
     const existing = target.AgentOS?.fleet?.registryBridge;
 
     if (bearerToken === null && existing) {
@@ -106,13 +109,13 @@ export function establishFleetSessionCustody({fleetUrl, bearerToken = null, inst
     const
         profile    = createFleetProfile({custodian: 'session-only', endpoint: fleetUrl}),
         publishNow = !existing,
-        bridge     = installImpl({url: fleetUrl, bearerToken, profileId: profile.profileId, target: publishNow ? target : {}});
+        bridge     = installImpl({url: fleetUrl, bearerToken, mcAuthorization, profileId: profile.profileId, target: publishNow ? target : {}});
 
     const custodySettled = bearerToken === null
         ? Promise.resolve(false)
         : bridge.resolveViewerIdentity()
             .then(() => {
-                publishNow || installImpl({url: fleetUrl, bearerToken, profileId: profile.profileId, target});
+                publishNow || installImpl({url: fleetUrl, bearerToken, mcAuthorization, profileId: profile.profileId, target});
                 return retireBearerIngressSlot(target, {expected: bearerToken})
             })
             .catch(() => false);

--- a/apps/agentos/fleet/connectionProfiles.mjs
+++ b/apps/agentos/fleet/connectionProfiles.mjs
@@ -416,17 +416,20 @@ export function createCustodyMigration({fromCustodian, toCustodian, generation} 
  * holds exactly that value — the credential that PROVABLY verified into closure custody. A value a
  * producer rotated in during verification is a different credential that never verified, so it
  * survives the retire attempt; deleting it would destroy rotation truth the migration contract
- * promises to keep.
+ * promises to keep. `field` selects which ingress slot of the launch contract is being retired —
+ * the class-1 bearer by default, or the class-3 `mcAuthorization` mint, which rides the same
+ * transient-ingress discipline.
  * @param {Object} target             The global-shaped object carrying `AgentOS.fleet`.
  * @param {Object} [opts]
- * @param {String} [opts.expected]    Retire only if the slot still equals this exact value.
- * @returns {Boolean} whether a bearer was present (and matching, when guarded) and retired.
+ * @param {String} [opts.expected]              Retire only if the slot still equals this exact value.
+ * @param {String} [opts.field='bearerToken']   Which launch-contract ingress slot to retire.
+ * @returns {Boolean} whether a credential was present (and matching, when guarded) and retired.
  */
-export function retireBearerIngressSlot(target, {expected} = {}) {
+export function retireBearerIngressSlot(target, {expected, field = 'bearerToken'} = {}) {
     const fleet = target?.AgentOS?.fleet;
 
-    if (fleet && 'bearerToken' in fleet && (expected === undefined || fleet.bearerToken === expected)) {
-        delete fleet.bearerToken;
+    if (fleet && field in fleet && (expected === undefined || fleet[field] === expected)) {
+        delete fleet[field];
         return true
     }
 

--- a/apps/agentos/fleet/fleetWakeStreamConsumer.mjs
+++ b/apps/agentos/fleet/fleetWakeStreamConsumer.mjs
@@ -202,11 +202,15 @@ export function createFleetWakeStreamConsumer({
 
         // Every connection is a catch-up moment — the trigger lives in `observeFrame`, on the
         // first frame that makes the subscription id known (the handshake `state` frame on a
-        // server that vouches it). The per-connection observation resets here so a connection
-        // that CANNOT catch up never wears the previous one's count.
+        // server that vouches it). The vouch and the handshake are CONNECTION-EPOCH state and
+        // reset here: a viewer disarmed between connections must never reuse the prior epoch's
+        // subscription, and liveness must never wear the prior epoch's handshake. Only the
+        // client-held watermark survives reconnect — it is client truth, not a server vouch.
         connected        = true;
         consecutiveDrops = 0;
         lastFrameAt      = now();
+        lastState        = null;
+        subscriptionId   = null;
         catchUpFired     = false;
         pendingAtCatchUp = null;
 
@@ -306,6 +310,14 @@ export function createFleetWakeStreamConsumer({
             }
 
             if (connected) {
+                // Transport-open is not handshake-live: an HTTP 200 with an open body and ZERO
+                // frames proves only that a socket exists. Positive liveness starts at the
+                // CURRENT epoch's `state` handshake — until it arrives, the honest answer is
+                // absence of signal, exactly like a disconnect.
+                if (lastState === null) {
+                    return {alive: 'unknown', reason: 'stream open, state handshake pending — liveness unconfirmed'}
+                }
+
                 const
                     age   = lastFrameAt === null ? null : now() - lastFrameAt,
                     stale = age !== null && age > STALE_AFTER_MS;
@@ -317,9 +329,9 @@ export function createFleetWakeStreamConsumer({
                     }
                 }
 
-                const armedNote = lastState
-                    ? (lastState.armedForViewer ? 'armed for this viewer' : `not armed for this viewer (${lastState.reason ?? 'no reason carried'})`)
-                    : 'state event pending';
+                const armedNote = lastState.armedForViewer
+                    ? 'armed for this viewer'
+                    : `not armed for this viewer (${lastState.reason ?? 'no reason carried'})`;
 
                 const pendingNote = pendingAtCatchUp ? ` · ${pendingAtCatchUp} pending caught up` : '';
 

--- a/apps/agentos/fleet/fleetWakeStreamConsumer.mjs
+++ b/apps/agentos/fleet/fleetWakeStreamConsumer.mjs
@@ -1,0 +1,354 @@
+/**
+ * @module apps/agentos/fleet/fleetWakeStreamConsumer
+ * @summary The browser-direct consumer of the composed fleet-server's wake stream — the App-Worker
+ * twin of the relay-side consumer (`ai/services/fleet/fleetWakeSseConsumer.mjs`). The realm
+ * boundary carries no imports, so the frame parser is duplicated by construction and the parity
+ * spec is the binding.
+ *
+ * Where the relay deliberately presents ONE credential (its plane-admission bearer — the
+ * transitional topology's boot-armed shared viewer makes listening sufficient), the browser-direct
+ * path is the PER-VIEWER shape: class-1 Fleet admission on `Authorization`, and the viewer's
+ * class-3 MC mint on `x-neo-mc-authorization` arming the per-viewer subscription. Neither
+ * credential enters this module: the injected `authHeaders` function is built inside the registry
+ * bridge's closure (`installFleetBridge.mjs`, `openWakeStream`), so the pane holds a CAPABILITY
+ * and the mints stay in transport custody — the same Option-D discipline the connection-profile
+ * contract enforces for records (`./connectionProfiles.mjs`).
+ *
+ * Observation semantics are the relay's, verbatim: a stream open with a `state` frame is the push
+ * lane observed alive, carrying the server's own per-viewer arming answer; a dead stream is
+ * honestly `unknown` with the disconnect reason — absence of signal, never a fabricated verdict.
+ * Catch-up rides `poll-digest` once per connection from the handshake-vouched subscription id,
+ * with the client-held watermark echoed and never server-persisted. Push is latency; poll is
+ * truth.
+ */
+
+const
+    DEFAULT_RETRY_FLOOR_MS = 5000,
+    MAX_BACKOFF_MS         = 60_000,
+    STALE_AFTER_MS         = 90_000;
+
+/**
+ * @summary Parses complete `text/event-stream` frames out of an accumulating buffer — the browser
+ * twin of the relay parser; the parity spec pins both to identical answers.
+ * @param {String} buffer
+ * @returns {Object} `{frames: [{event, data, retry}], rest}` — `rest` is the trailing partial.
+ */
+export function parseSseFrames(buffer) {
+    const
+        frames = [],
+        parts  = buffer.split('\n\n'),
+        rest   = parts.pop();
+
+    for (const part of parts) {
+        const frame = {event: 'message', data: null, retry: null};
+
+        for (const line of part.split('\n')) {
+            if (line.startsWith(':')) continue;
+
+            if (line.startsWith('event: ')) {
+                frame.event = line.slice(7).trim()
+            } else if (line.startsWith('data: ')) {
+                frame.data = frame.data === null ? line.slice(6) : `${frame.data}\n${line.slice(6)}`
+            } else if (line.startsWith('retry: ')) {
+                const value = Number(line.slice(7).trim());
+
+                if (Number.isFinite(value) && value > 0) {
+                    frame.retry = value
+                }
+            }
+        }
+
+        frames.push(frame)
+    }
+
+    return {frames, rest}
+}
+
+/**
+ * @summary Creates the browser wake-stream consumer. Passive until `start()`; every failure path
+ * is an observation, never a throw — the pane renders reasons, not stack traces.
+ * @param {Object} options
+ * @param {String} options.eventsUrl Absolute URL of the composed server's SSE endpoint.
+ * @param {Function} options.authHeaders Returns the per-connection credential headers — built in
+ *     the registry bridge's closure so no mint crosses into this module or the pane. The bridge
+ *     sends class-1 on `Authorization` and, when armed, the class-3 mint on
+ *     `x-neo-mc-authorization`; a byte-identical pair is refused at install time, before any wire.
+ * @param {Function} [options.pollDigest] `({subscriptionId, sinceLogId}) => result` seam for
+ *     connection catch-up; absent means catch-up is skipped and the observation says so.
+ * @param {Function} [options.fetchImpl] Injection seam; defaults to global `fetch`.
+ * @param {Function} [options.now=Date.now]
+ * @param {Object} [options.logger=console]
+ * @param {Number} [options.retryFloorMs=5000] Initial reconnect floor; a server `retry:` hint
+ *     can only raise it (tests inject a small floor, production keeps the default).
+ * @returns {Object} `{start, stop, resolveDeliveryLiveness, describe}`
+ */
+export function createFleetWakeStreamConsumer({
+    eventsUrl,
+    authHeaders,
+    pollDigest = null,
+    fetchImpl  = null,
+    now        = Date.now,
+    logger     = console,
+    retryFloorMs: initialRetryFloorMs = DEFAULT_RETRY_FLOOR_MS
+}) {
+    if (typeof eventsUrl !== 'string' || eventsUrl.trim().length === 0) {
+        throw new Error('createFleetWakeStreamConsumer requires an eventsUrl')
+    }
+
+    if (typeof authHeaders !== 'function') {
+        throw new Error('createFleetWakeStreamConsumer requires an authHeaders function — credentials stay in the bridge closure, never consumer options')
+    }
+
+    const doFetch = fetchImpl ?? ((...args) => fetch(...args));
+
+    let
+        stopped          = true,
+        connected        = false,
+        connectionEpoch  = 0,
+        retryFloorMs     = initialRetryFloorMs,
+        consecutiveDrops = 0,
+        lastFrameAt      = null,
+        lastWakeAt       = null,
+        lastState        = null,
+        lastDisconnect   = 'not started',
+        subscriptionId   = null,
+        watermark        = 0,
+        pendingAtCatchUp = null,
+        catchUpFired     = false,
+        abortController  = null;
+
+    function observeFrame(frame) {
+        lastFrameAt = now();
+
+        if (frame.retry) {
+            retryFloorMs = Math.max(frame.retry, initialRetryFloorMs)
+        }
+
+        if (frame.data === null) return;
+
+        let payload;
+
+        try {
+            payload = JSON.parse(frame.data)
+        } catch {
+            return // a malformed frame is dropped; the stream's liveness is already recorded
+        }
+
+        if (frame.event === 'state') {
+            lastState = payload;
+
+            // The handshake vouches the armed viewer's subscription id — the server's arming
+            // context created that subscription, so this is the authoritative source, available
+            // BEFORE any live wake arrives.
+            if (payload.subscriptionId) {
+                subscriptionId = payload.subscriptionId
+            }
+        } else if (frame.event === 'wake') {
+            lastWakeAt     = now();
+            subscriptionId = payload.subscriptionId ?? subscriptionId;
+
+            const logId = payload.envelope?.payload?.watermark ?? payload.envelope?.logId;
+
+            if (Number.isFinite(logId) && logId > watermark) {
+                watermark = logId
+            }
+        }
+
+        // Catch-up fires once per connection, the moment the subscription id is known. The
+        // `state` handshake is the first frame every connection carries, so a COLD consumer
+        // with pending wakes catches up right here — no live wake has to arrive first. A server
+        // that vouches no id leaves this honestly unfired; poll remains the truth lane.
+        if (!catchUpFired && subscriptionId && pollDigest) {
+            catchUpFired = true;
+            catchUp() // absorbs its own faults; the observation carries the outcome
+        }
+    }
+
+    async function catchUp() {
+        if (!pollDigest || !subscriptionId) {
+            pendingAtCatchUp = null;
+            return
+        }
+
+        try {
+            const result = await pollDigest({subscriptionId, sinceLogId: watermark});
+
+            pendingAtCatchUp = result?.counts?.pending ?? result?.pending ?? 0;
+
+            if (Number.isFinite(result?.watermark) && result.watermark > watermark) {
+                watermark = result.watermark
+            }
+        } catch (error) {
+            pendingAtCatchUp = null;
+            logger.warn?.(`[FleetWakeStreamConsumer] reconnect catch-up failed: ${error?.message ?? error}`)
+        }
+    }
+
+    async function connectOnce(epoch) {
+        abortController = new AbortController();
+
+        const response = await doFetch(eventsUrl, {
+            headers: {
+                accept: 'text/event-stream',
+                ...authHeaders()
+            },
+            signal: abortController.signal
+        });
+
+        if (!response.ok || !response.body) {
+            lastDisconnect = `stream refused: HTTP ${response.status}`;
+            return
+        }
+
+        // Every connection is a catch-up moment — the trigger lives in `observeFrame`, on the
+        // first frame that makes the subscription id known (the handshake `state` frame on a
+        // server that vouches it). The per-connection observation resets here so a connection
+        // that CANNOT catch up never wears the previous one's count.
+        connected        = true;
+        consecutiveDrops = 0;
+        lastFrameAt      = now();
+        catchUpFired     = false;
+        pendingAtCatchUp = null;
+
+        const
+            decoder = new TextDecoder(),
+            reader  = response.body.getReader();
+
+        let buffer = '';
+
+        try {
+            for (;;) {
+                const {value, done} = await reader.read();
+
+                if (done || stopped || epoch !== connectionEpoch) break;
+
+                buffer += decoder.decode(value, {stream: true});
+
+                const {frames, rest} = parseSseFrames(buffer);
+
+                buffer = rest;
+                frames.forEach(observeFrame)
+            }
+
+            lastDisconnect = 'stream ended'
+        } catch (error) {
+            lastDisconnect = `stream error: ${error?.message ?? error}`
+        } finally {
+            connected = false;
+
+            try {
+                await reader.cancel()
+            } catch {/* teardown of a dead reader is best-effort */}
+        }
+    }
+
+    async function runLoop(epoch) {
+        while (!stopped && epoch === connectionEpoch) {
+            try {
+                await connectOnce(epoch)
+            } catch (error) {
+                connected      = false;
+                lastDisconnect = `connect failed: ${error?.message ?? error}`
+            }
+
+            if (stopped || epoch !== connectionEpoch) return;
+
+            consecutiveDrops++;
+
+            // The server's retry hint is the floor; drops back off exponentially under a cap so
+            // a dead endpoint costs a bounded trickle, never a retry storm against the caps.
+            const backoff = Math.min(retryFloorMs * Math.max(1, 2 ** (consecutiveDrops - 1)), MAX_BACKOFF_MS);
+
+            await new Promise(resolve => {
+                const timer = setTimeout(resolve, backoff);
+                timer.unref?.()
+            })
+        }
+    }
+
+    return {
+        /**
+         * @summary Opens the stream and keeps it open until `stop()`. Idempotent.
+         */
+        start() {
+            if (!stopped) return;
+
+            stopped = false;
+            connectionEpoch++;
+
+            runLoop(connectionEpoch).catch(error => {
+                logger.error?.(`[FleetWakeStreamConsumer] loop crashed: ${error?.message ?? error}`)
+            })
+        },
+
+        /**
+         * @summary Closes the stream and stops reconnecting. Idempotent.
+         */
+        stop() {
+            stopped = true;
+            connectionEpoch++;
+            connected = false;
+
+            try {
+                abortController?.abort()
+            } catch {/* aborting an already-settled fetch is a no-op */}
+        },
+
+        /**
+         * @summary The wake-push observation the pane renders — shape and vocabulary identical to
+         * the relay side's, so one absence-of-signal grammar serves both topologies. A dead stream
+         * renders `unknown` with its reason, never a fabricated verdict about delivery itself.
+         * @returns {Object} `{alive: Boolean|'unknown', reason: String}`
+         */
+        resolveDeliveryLiveness() {
+            if (stopped) {
+                return {alive: 'unknown', reason: 'wake stream consumer not running'}
+            }
+
+            if (connected) {
+                const
+                    age   = lastFrameAt === null ? null : now() - lastFrameAt,
+                    stale = age !== null && age > STALE_AFTER_MS;
+
+                if (stale) {
+                    return {
+                        alive : 'unknown',
+                        reason: `wake stream silent for ${Math.round(age / 1000)}s — liveness unconfirmed`
+                    }
+                }
+
+                const armedNote = lastState
+                    ? (lastState.armedForViewer ? 'armed for this viewer' : `not armed for this viewer (${lastState.reason ?? 'no reason carried'})`)
+                    : 'state event pending';
+
+                const pendingNote = pendingAtCatchUp ? ` · ${pendingAtCatchUp} pending caught up` : '';
+
+                return {alive: true, reason: `composed wake stream connected · ${armedNote}${pendingNote}`}
+            }
+
+            return {
+                alive : 'unknown',
+                reason: `wake stream disconnected (${lastDisconnect}) — poll remains the truth lane`
+            }
+        },
+
+        /**
+         * @summary Full observational snapshot for diagnostics and specs.
+         * @returns {Object}
+         */
+        describe() {
+            return {
+                connected,
+                lastFrameAt,
+                lastWakeAt,
+                lastState,
+                lastDisconnect,
+                subscriptionId,
+                watermark,
+                pendingAtCatchUp,
+                consecutiveDrops,
+                retryFloorMs
+            }
+        }
+    }
+}

--- a/apps/agentos/fleet/installFleetBridge.mjs
+++ b/apps/agentos/fleet/installFleetBridge.mjs
@@ -236,16 +236,36 @@ export function installFleetBridge({
     // bridge still exposes it: the unauthenticated stream is refused by the server and the
     // consumer carries that as an honest observation. Packaged-shell bridges carry NO such
     // capability — main owns the push topology on its side of the boundary.
+    //
+    // A closure is not custody if its capability lets the consumer replace the destination or
+    // the transport: `eventsUrl`, `authHeaders`, and `fetchImpl` are PINNED here — the stream
+    // rides the SAME injected fetch as the wire (one transport injection point, at install), and
+    // only observational options project through. An override attempt is a misconfiguration or
+    // an exfiltration attempt; both fail loud.
     shellTransport || Object.defineProperty(registryBridge, 'openWakeStream', {
         configurable: true,
-        value       : (opts = {}) => createFleetWakeStreamConsumer({
-            eventsUrl  : new URL('/fleet/events', fleetUrl.origin).href,
-            authHeaders: () => ({
-                ...(bearerToken     ? {authorization: `Bearer ${bearerToken}`} : {}),
-                ...(mcAuthorization ? {'x-neo-mc-authorization': `Bearer ${mcAuthorization}`} : {})
-            }),
-            ...opts
-        })
+        value       : (opts = {}) => {
+            const offered = Object.keys(opts).filter(key => !['logger', 'now', 'pollDigest', 'retryFloorMs'].includes(key));
+
+            if (offered.length) {
+                throw new TypeError(`openWakeStream refuses option(s) '${offered.join("', '")}' — the capability owns destination, credentials, and transport; only observational options (pollDigest, logger, retryFloorMs, now) project through`)
+            }
+
+            const {pollDigest, logger, retryFloorMs, now} = opts;
+
+            return createFleetWakeStreamConsumer({
+                eventsUrl  : new URL('/fleet/events', fleetUrl.origin).href,
+                fetchImpl,
+                authHeaders: () => ({
+                    ...(bearerToken     ? {authorization: `Bearer ${bearerToken}`} : {}),
+                    ...(mcAuthorization ? {'x-neo-mc-authorization': `Bearer ${mcAuthorization}`} : {})
+                }),
+                ...(pollDigest   !== undefined ? {pollDigest} : {}),
+                ...(logger       !== undefined ? {logger} : {}),
+                ...(retryFloorMs !== undefined ? {retryFloorMs} : {}),
+                ...(now          !== undefined ? {now} : {})
+            })
+        }
     });
 
     // An explicitly wired bridge (the ViewportController injector — Neural Link, tests, dev

--- a/apps/agentos/fleet/installFleetBridge.mjs
+++ b/apps/agentos/fleet/installFleetBridge.mjs
@@ -1,4 +1,5 @@
-import {FLEET_BEARER_PATTERN} from './connectionProfiles.mjs';
+import {FLEET_BEARER_PATTERN}          from './connectionProfiles.mjs';
+import {createFleetWakeStreamConsumer} from './fleetWakeStreamConsumer.mjs';
 import {
     createFleetWireOffer,
     createFleetWireRequest,
@@ -13,7 +14,7 @@ import {
  * refused outright rather than "helpfully" consumed.
  * @type {String[]}
  */
-const FORBIDDEN_URL_CREDENTIAL_PARAMS = ['bearer', 'bearerToken', 'fleetBearer', 'token', 'authorization'];
+const FORBIDDEN_URL_CREDENTIAL_PARAMS = ['bearer', 'bearerToken', 'fleetBearer', 'token', 'authorization', 'mcAuthorization'];
 
 /**
  * Bounded local launch-state errors that may cross the injected shell transport verbatim. Every
@@ -61,8 +62,13 @@ export const FLEET_LOCAL_TRANSPORT_ERRORS = Object.freeze({
  *     base64url). `null` installs a fail-closed bridge that rejects every call locally with the
  *     launch-contract remediation — never a network call without credentials.
  * @param {Function} [opts.fetchImpl=globalThis.fetch]     Injectable fetch for tests.
+ * @param {String}   [opts.mcAuthorization=null]           The viewer's class-3 MC mint arming the
+ *     per-viewer wake subscription (`openWakeStream` sends it on `x-neo-mc-authorization`). A
+ *     DISTINCT credential from the class-1 bearer by contract — byte-identical pairs are refused
+ *     at install, before any wire. `null` is the honest not-armed state.
  * @param {Function} [opts.send=null]                      Packaged-shell intent transport; receives
- *     only `{method, params}` and is mutually exclusive with `url` / `bearerToken`.
+ *     only `{method, params}` and is mutually exclusive with `url` / `bearerToken` /
+ *     `mcAuthorization`.
  * @param {'worker'|'shell'} [opts.credentialIngress='worker'] Public credential-custody fact.
  * @param {String}   [opts.profileId=null]                 The connection-profile identity this bridge
  *     serves (`./connectionProfiles.mjs` derivation) — a renderable capability fact like
@@ -79,6 +85,7 @@ export function installFleetBridge({
     url,
     bearerToken = null,
     fetchImpl = globalThis.fetch,
+    mcAuthorization = null,
     send = null,
     credentialIngress = 'worker',
     profileId = null,
@@ -96,13 +103,26 @@ export function installFleetBridge({
         throw new TypeError('installFleetBridge: profileId must be null or a non-empty identity string — bearer-shaped material is refused, the fact is pane-renderable')
     }
 
+    if (mcAuthorization !== null) {
+        if (typeof mcAuthorization !== 'string' || !mcAuthorization.trim()) {
+            throw new TypeError('installFleetBridge: mcAuthorization must be null or a non-empty class-3 MC credential')
+        }
+
+        // The never-aliased rule fails loud BEFORE any wire: the class-1 Fleet admission bearer
+        // must never double as the class-3 MC mint — the server refuses byte-identical pairs, and
+        // a client that would send one is misconfigured, not degraded.
+        if (mcAuthorization === bearerToken) {
+            throw new TypeError('installFleetBridge: mcAuthorization must be a DISTINCT mint — a byte-identical class-1/class-3 pair is refused, never aliased')
+        }
+    }
+
     if (send !== null) {
         if (typeof send !== 'function') {
             throw new TypeError('installFleetBridge: send must be a function')
         }
 
-        if (url !== undefined || bearerToken !== null) {
-            throw new TypeError('installFleetBridge: injected send is mutually exclusive with url and bearerToken')
+        if (url !== undefined || bearerToken !== null || mcAuthorization !== null) {
+            throw new TypeError('installFleetBridge: injected send is mutually exclusive with url, bearerToken, and mcAuthorization')
         }
 
         shellTransport = true;
@@ -208,6 +228,24 @@ export function installFleetBridge({
     Object.defineProperty(registryBridge, 'profileId', {
         configurable: true,
         value       : profileId
+    });
+
+    // The wake-push CAPABILITY, direct-browser bridges only: the pane opens the stream through
+    // this closure and never touches a mint — class-1 rides `Authorization`, the class-3 MC
+    // credential (when armed) rides `x-neo-mc-authorization`, both captured here. A bearer-less
+    // bridge still exposes it: the unauthenticated stream is refused by the server and the
+    // consumer carries that as an honest observation. Packaged-shell bridges carry NO such
+    // capability — main owns the push topology on its side of the boundary.
+    shellTransport || Object.defineProperty(registryBridge, 'openWakeStream', {
+        configurable: true,
+        value       : (opts = {}) => createFleetWakeStreamConsumer({
+            eventsUrl  : new URL('/fleet/events', fleetUrl.origin).href,
+            authHeaders: () => ({
+                ...(bearerToken     ? {authorization: `Bearer ${bearerToken}`} : {}),
+                ...(mcAuthorization ? {'x-neo-mc-authorization': `Bearer ${mcAuthorization}`} : {})
+            }),
+            ...opts
+        })
     });
 
     // An explicitly wired bridge (the ViewportController injector — Neural Link, tests, dev

--- a/apps/agentos/fleet/redeemFleetBearerHandshake.mjs
+++ b/apps/agentos/fleet/redeemFleetBearerHandshake.mjs
@@ -24,7 +24,9 @@
 import {FLEET_BEARER_PATTERN} from './connectionProfiles.mjs';
 
 /**
- * @summary Redeem the process bearer from an armed Fleet transport, or resolve `null` fail-closed.
+ * @summary Redeem the launch credentials from an armed Fleet transport, or resolve `null`
+ * fail-closed. The result carries the process bearer and, when the deployment armed one, the
+ * viewer's class-3 MC mint — the pair the establish path binds into closure custody together.
  *
  * The handshake URL derives from the fleet endpoint's own origin (`<origin>/fleet/handshake`), so
  * the one URL authority the cockpit already resolves (`fleetUrl`) stays the only endpoint input —
@@ -38,7 +40,8 @@ import {FLEET_BEARER_PATTERN} from './connectionProfiles.mjs';
  * @param {Function} [opts.fetchImpl=globalThis.fetch] Injectable fetch for tests.
  * @param {Number}   [opts.timeoutMs=1500]             Redemption patience: an absent transport
  *     refuses the connection in milliseconds, so this bound only trims the hung-listener tail.
- * @returns {Promise<String|null>} the canonical bearer, or `null` on every non-success path.
+ * @returns {Promise<{bearerToken: String, mcAuthorization: String|null}|null>} the redeemed pair
+ *     (`mcAuthorization: null` = the honest not-armed state), or `null` on every non-success path.
  */
 export async function redeemFleetBearerHandshake({url, fetchImpl = globalThis.fetch, timeoutMs = 1500} = {}) {
     let handshakeUrl;
@@ -62,10 +65,22 @@ export async function redeemFleetBearerHandshake({url, fetchImpl = globalThis.fe
         const envelope = await response.json(),
               token    = envelope?.ok === true ? envelope.result?.bearerToken : null;
 
-        return typeof token === 'string' && FLEET_BEARER_PATTERN.test(token) ? token : null
+        if (typeof token !== 'string' || !FLEET_BEARER_PATTERN.test(token)) {
+            return null
+        }
+
+        // The optional viewer mint rides the same envelope. A malformed or bearer-identical value
+        // is STRIPPED, never adopted: the class-1 redemption stays valid, the boot proceeds
+        // honestly not-armed, and the server-side startup refusal owns the loud path.
+        const mint = envelope.result?.mcAuthorization;
+
+        return {
+            bearerToken    : token,
+            mcAuthorization: typeof mint === 'string' && mint.trim() && mint !== token ? mint : null
+        }
     } catch {
         // Refused connection (no transport), abort (hung listener), or non-JSON body — all the
-        // same honest answer: no bearer, boot fail-closed.
+        // same honest answer: no credentials, boot fail-closed.
         return null
     }
 }

--- a/test/playwright/unit/ai/services/fleet/fleetBridgeServer.spec.mjs
+++ b/test/playwright/unit/ai/services/fleet/fleetBridgeServer.spec.mjs
@@ -299,6 +299,35 @@ test.describe('fleetBridgeServer — the authenticated Fleet ingress', () => {
         expect(contexts, 'a redemption never enters the context boundary').toEqual([])
     });
 
+    test('ARMED + viewer mint: the handshake serves the PAIR; unarmed-mint deployments keep the bearer-only shape', async () => {
+        await startServer({bearerHandshake: true, mcAuthorization: 'viewer-mc-mint'});
+
+        const res = await rawRequest({method: 'GET', path: '/fleet/handshake', headers: {Origin: 'http://localhost:8080'}});
+
+        expect(res.status).toBe(200);
+        expect(JSON.parse(res.body)).toEqual({ok: true, result: {bearerToken: bearer, mcAuthorization: 'viewer-mc-mint'}})
+    });
+
+    test('startup refuses a byte-identical bearer/mint pair and a malformed mint — fail-closed, never aliased', () => {
+        const identical = generateLocalBearerToken();
+
+        expect(() => startFleetBridgeServer({
+            port           : 0,
+            bearerToken    : identical,
+            mcAuthorization: identical,
+            viewerContext  : viewer,
+            runInContext   : (context, fn) => fn()
+        })).toThrow(/byte-identical to the process bearer/);
+
+        expect(() => startFleetBridgeServer({
+            port           : 0,
+            bearerToken    : generateLocalBearerToken(),
+            mcAuthorization: '   ',
+            viewerContext  : viewer,
+            runInContext   : (context, fn) => fn()
+        })).toThrow(/non-empty viewer MC mint/)
+    });
+
     test('ARMED: redemption stays available while armed — a page reload is a normal cockpit operation, not a lockout', async () => {
         await startServer({bearerHandshake: true});
 

--- a/test/playwright/unit/ai/services/fleet/fleetWakeArming.spec.mjs
+++ b/test/playwright/unit/ai/services/fleet/fleetWakeArming.spec.mjs
@@ -23,9 +23,11 @@ import {
     armFleetWakePushLane,
     assertFleetPlaneAdmissionBearerClass,
     assertFleetPlaneBearerClass,
+    assertFleetViewerMcAuthorizationClass,
     createWakeArmingContext,
     resolveFleetPlaneAdmissionBearer,
     resolveFleetPlaneBearer,
+    resolveFleetViewerMcAuthorization,
     resolveViewerStreamKey,
     startFleetServer
 } from '../../../../../../ai/services/fleet/fleetServer.mjs';
@@ -312,6 +314,40 @@ test.describe('fleet wake arming - the service credential chain', () => {
         expect(outcome.armed).toBe(false);
         expect(outcome.reason).toContain('byte-identical');
         expect(constructions).toBe(0)
+    });
+
+    test('the viewer MC mint resolves value-over-file and its class teeth refuse every relay-credential alias', () => {
+        const fleetBase = {
+            viewerMcAuthorization    : '',
+            viewerMcAuthorizationFile: '',
+            planeBearer              : 'relay-plane-token',
+            planeBearerFile          : '',
+            planeAdmissionBearer     : 'relay-admission-token',
+            planeAdmissionBearerFile : '',
+            admissionTokenFile       : ''
+        };
+
+        // value wins over file; file trims; empty-both is the honest not-armed ''
+        expect(resolveFleetViewerMcAuthorization({
+            aiConfig: {fleet: {...fleetBase, viewerMcAuthorization: 'direct-mint', viewerMcAuthorizationFile: '/x'}},
+            readFile: () => 'file-mint'
+        })).toBe('direct-mint');
+        expect(resolveFleetViewerMcAuthorization({
+            aiConfig: {fleet: {...fleetBase, viewerMcAuthorizationFile: '/x'}},
+            readFile: () => ' file-mint\n'
+        })).toBe('file-mint');
+        expect(resolveFleetViewerMcAuthorization({aiConfig: {fleet: fleetBase}})).toBe('');
+
+        // class teeth: the viewer mint is the viewer's OWN authority — never a relay credential
+        expect(() => assertFleetViewerMcAuthorizationClass({
+            aiConfig: {fleet: {...fleetBase, viewerMcAuthorization: 'relay-plane-token'}}
+        })).toThrow(/plane-MCP bearer/);
+        expect(() => assertFleetViewerMcAuthorizationClass({
+            aiConfig: {fleet: {...fleetBase, viewerMcAuthorization: 'relay-admission-token'}}
+        })).toThrow(/admission bearer/);
+        expect(assertFleetViewerMcAuthorizationClass({
+            aiConfig: {fleet: {...fleetBase, viewerMcAuthorization: 'distinct-viewer-mint'}}
+        })).toBe('distinct-viewer-mint')
     });
 
     test('an unreadable admission file disables the comparison, never the credential', () => {

--- a/test/playwright/unit/apps/agentos/app.spec.mjs
+++ b/test/playwright/unit/apps/agentos/app.spec.mjs
@@ -245,6 +245,37 @@ test.describe('AgentOS packaged Fleet window routing', () => {
             await expect(first.bridge.listAgents()).rejects.toThrow(/fleet bearer not injected/)
         });
 
+        test('the class-3 MC mint rides establish into BOTH install sites — first custody and the promote', async () => {
+            const
+                mcMint = 'C'.repeat(43),
+                seen   = [],
+                target = {};
+
+            // arg-plumbing pin: the mint reaches the installer alongside the bearer, never a slot
+            const first = establishFleetSessionCustody({
+                bearerToken    : bearer,
+                fleetUrl,
+                mcAuthorization: mcMint,
+                installImpl    : opts => { seen.push(opts.mcAuthorization); return installFleetBridge({...opts, fetchImpl: okViewerFetch()}) },
+                target
+            });
+
+            await expect(first.custodySettled).resolves.toBe(false); // no slot to retire
+            expect(seen).toEqual([mcMint]);
+
+            // the promote install carries it too
+            const second = establishFleetSessionCustody({
+                bearerToken    : rotated,
+                fleetUrl,
+                mcAuthorization: mcMint,
+                installImpl    : opts => { seen.push(opts.mcAuthorization); return installFleetBridge({...opts, fetchImpl: okViewerFetch()}) },
+                target
+            });
+
+            await expect(second.custodySettled).resolves.toBe(false); // slot empty — CAS retires nothing
+            expect(seen).toEqual([mcMint, mcMint, mcMint]) // candidate + promote
+        });
+
         test('a throwing install preserves the ingress — the rollback needs no special path', async () => {
             const target = {AgentOS: {fleet: {bearerToken: 'not-a-canonical-bearer'}}};
 

--- a/test/playwright/unit/apps/agentos/app.spec.mjs
+++ b/test/playwright/unit/apps/agentos/app.spec.mjs
@@ -135,8 +135,8 @@ test.describe('AgentOS packaged Fleet window routing', () => {
 
             const {custodySettled} = establishFleetSessionCustody({
                 fleetUrl,
-                installImpl   : realInstall(okViewerFetch()),
-                redeemedBearer: bearer, // the redemption takes precedence; the slot holds a different credential
+                installImpl: realInstall(okViewerFetch()),
+                redeemed   : {bearerToken: bearer, mcAuthorization: null}, // the redemption takes precedence; the slot holds a different credential
                 target
             });
 
@@ -270,6 +270,27 @@ test.describe('AgentOS packaged Fleet window routing', () => {
             await expect(refused.custodySettled).resolves.toBe(false);
             expect(preserved.AgentOS.fleet.bearerToken).toBe(bearer);
             expect(preserved.AgentOS.fleet.mcAuthorization).toBe(mcMint)
+        });
+
+        test('the REDEEMED PAIR is the production chain: both mints bind from the handshake result, no slot involved', async () => {
+            const
+                mcMint = 'C'.repeat(43),
+                seen   = [],
+                target = {};
+
+            const {custodySettled} = establishFleetSessionCustody({
+                fleetUrl,
+                installImpl: opts => {
+                    seen.push({bearer: opts.bearerToken, mc: opts.mcAuthorization});
+                    return installFleetBridge({...opts, fetchImpl: okViewerFetch()})
+                },
+                redeemed: {bearerToken: bearer, mcAuthorization: mcMint},
+                target
+            });
+
+            expect(seen, 'the pair the handshake redeemed is the pair the install binds').toEqual([{bearer, mc: mcMint}]);
+            await expect(custodySettled).resolves.toBe(false); // no launcher slots existed — nothing to retire, honestly
+            expect(target.AgentOS.fleet.registryBridge.openWakeStream, 'the armed bridge carries the wake capability').toBeDefined()
         });
 
         test('a throwing install preserves the ingress — the rollback needs no special path', async () => {

--- a/test/playwright/unit/apps/agentos/app.spec.mjs
+++ b/test/playwright/unit/apps/agentos/app.spec.mjs
@@ -65,8 +65,8 @@ test.describe('AgentOS packaged Fleet window routing', () => {
         test('verified retire: the authenticated whoami succeeds, then and only then the ingress clears', async () => {
             const target = {AgentOS: {fleet: {bearerToken: bearer}}};
 
+            // the SLOT is the entrypoint truth — establish reads it itself (no credential args)
             const {bridge, custodySettled} = establishFleetSessionCustody({
-                bearerToken: bearer,
                 fleetUrl,
                 installImpl: realInstall(okViewerFetch()),
                 target
@@ -84,7 +84,6 @@ test.describe('AgentOS packaged Fleet window routing', () => {
             const target = {AgentOS: {fleet: {bearerToken: bearer}}};
 
             const {custodySettled} = establishFleetSessionCustody({
-                bearerToken: bearer,
                 fleetUrl,
                 installImpl: realInstall(refusedFetch()),
                 target
@@ -98,7 +97,6 @@ test.describe('AgentOS packaged Fleet window routing', () => {
             const target = {AgentOS: {fleet: {bearerToken: bearer}}};
 
             const {custodySettled} = establishFleetSessionCustody({
-                bearerToken: bearer,
                 fleetUrl,
                 installImpl: realInstall(async () => { throw new Error('ECONNREFUSED') }),
                 target
@@ -120,7 +118,6 @@ test.describe('AgentOS packaged Fleet window routing', () => {
                 };
 
             const {custodySettled} = establishFleetSessionCustody({
-                bearerToken: bearer,
                 fleetUrl,
                 installImpl: realInstall(gatedFetch),
                 target
@@ -137,9 +134,9 @@ test.describe('AgentOS packaged Fleet window routing', () => {
             const target = {AgentOS: {fleet: {bearerToken: rotated}}};
 
             const {custodySettled} = establishFleetSessionCustody({
-                bearerToken: bearer, // established + verified, but never the slot's value
                 fleetUrl,
-                installImpl: realInstall(okViewerFetch()),
+                installImpl   : realInstall(okViewerFetch()),
+                redeemedBearer: bearer, // the redemption takes precedence; the slot holds a different credential
                 target
             });
 
@@ -151,7 +148,6 @@ test.describe('AgentOS packaged Fleet window routing', () => {
             const target = {AgentOS: {fleet: {bearerToken: bearer}}};
 
             const first = establishFleetSessionCustody({
-                bearerToken: bearer,
                 fleetUrl,
                 installImpl: realInstall(okViewerFetch()),
                 target
@@ -161,7 +157,6 @@ test.describe('AgentOS packaged Fleet window routing', () => {
 
             // The slot is retired now; a second joining window arrives with nothing to offer.
             const second = establishFleetSessionCustody({
-                bearerToken: null,
                 fleetUrl,
                 installImpl: realInstall(okViewerFetch()),
                 target
@@ -184,8 +179,8 @@ test.describe('AgentOS packaged Fleet window routing', () => {
                     return {json: async () => createFleetWireResponse(FLEET_WIRE_RESPONSE_STATES.ok, {result: {userId: 'operator'}})}
                 };
 
-            // Bearer A establishes (first custody — published) and verifies while B rotates in.
-            const first = establishFleetSessionCustody({bearerToken: bearer, fleetUrl, installImpl: realInstall(gatedFetch), target});
+            // Bearer A establishes (first custody — published, read from the slot) and verifies while B rotates in.
+            const first = establishFleetSessionCustody({fleetUrl, installImpl: realInstall(gatedFetch), target});
 
             target.AgentOS.fleet.bearerToken = rotated;
             releaseVerify();
@@ -195,7 +190,7 @@ test.describe('AgentOS packaged Fleet window routing', () => {
 
             // The next SharedWorker pass retries with B; the server rejects it. The candidate is
             // built DETACHED, so the known-good A bridge must remain published throughout.
-            const second = establishFleetSessionCustody({bearerToken: rotated, fleetUrl, installImpl: realInstall(refusedFetch()), target});
+            const second = establishFleetSessionCustody({fleetUrl, installImpl: realInstall(refusedFetch()), target});
 
             expect(target.AgentOS.fleet.registryBridge, 'an unproven candidate must never be published').toBe(first.bridge);
             expect(second.bridge, 'the caller sees the bridge that is actually live').toBe(first.bridge);
@@ -215,14 +210,14 @@ test.describe('AgentOS packaged Fleet window routing', () => {
                 },
                 target = {AgentOS: {fleet: {bearerToken: bearer}}};
 
-            const first = establishFleetSessionCustody({bearerToken: bearer, fleetUrl, installImpl: realInstall(recordedFetch), target});
+            const first = establishFleetSessionCustody({fleetUrl, installImpl: realInstall(recordedFetch), target});
 
             await expect(first.custodySettled).resolves.toBe(true);
 
             // A rotated-in credential that the server ACCEPTS: detached until proven, then promoted.
             target.AgentOS.fleet.bearerToken = rotated;
 
-            const second = establishFleetSessionCustody({bearerToken: rotated, fleetUrl, installImpl: realInstall(recordedFetch), target});
+            const second = establishFleetSessionCustody({fleetUrl, installImpl: realInstall(recordedFetch), target});
 
             expect(target.AgentOS.fleet.registryBridge, 'no displacement before proof').toBe(first.bridge);
             await expect(second.custodySettled).resolves.toBe(true);
@@ -245,42 +240,42 @@ test.describe('AgentOS packaged Fleet window routing', () => {
             await expect(first.bridge.listAgents()).rejects.toThrow(/fleet bearer not injected/)
         });
 
-        test('the class-3 MC mint rides establish into BOTH install sites — first custody and the promote', async () => {
+        test('the class-3 MC mint rides the SLOT entrypoint into closure custody — both ingress copies retire under the one proof', async () => {
             const
                 mcMint = 'C'.repeat(43),
                 seen   = [],
-                target = {};
+                target = {AgentOS: {fleet: {bearerToken: bearer, mcAuthorization: mcMint}}};
 
-            // arg-plumbing pin: the mint reaches the installer alongside the bearer, never a slot
-            const first = establishFleetSessionCustody({
-                bearerToken    : bearer,
+            // the production path: BOTH mints read from the launcher slots, bound into the install
+            const {custodySettled} = establishFleetSessionCustody({
                 fleetUrl,
-                mcAuthorization: mcMint,
-                installImpl    : opts => { seen.push(opts.mcAuthorization); return installFleetBridge({...opts, fetchImpl: okViewerFetch()}) },
+                installImpl: opts => {
+                    seen.push({bearer: opts.bearerToken, mc: opts.mcAuthorization});
+                    return installFleetBridge({...opts, fetchImpl: okViewerFetch()})
+                },
                 target
             });
 
-            await expect(first.custodySettled).resolves.toBe(false); // no slot to retire
-            expect(seen).toEqual([mcMint]);
+            expect(seen).toEqual([{bearer, mc: mcMint}]);
 
-            // the promote install carries it too
-            const second = establishFleetSessionCustody({
-                bearerToken    : rotated,
-                fleetUrl,
-                mcAuthorization: mcMint,
-                installImpl    : opts => { seen.push(opts.mcAuthorization); return installFleetBridge({...opts, fetchImpl: okViewerFetch()}) },
-                target
-            });
+            await expect(custodySettled).resolves.toBe(true);
+            expect('bearerToken' in target.AgentOS.fleet, 'the bearer ingress retires under the proof').toBe(false);
+            expect('mcAuthorization' in target.AgentOS.fleet, 'the mint ingress retires under the SAME proof').toBe(false);
 
-            await expect(second.custodySettled).resolves.toBe(false); // slot empty — CAS retires nothing
-            expect(seen).toEqual([mcMint, mcMint, mcMint]) // candidate + promote
+            // a failed verify preserves BOTH slots — the rollback covers the pair
+            const preserved = {AgentOS: {fleet: {bearerToken: bearer, mcAuthorization: mcMint}}};
+
+            const refused = establishFleetSessionCustody({fleetUrl, installImpl: realInstall(refusedFetch()), target: preserved});
+
+            await expect(refused.custodySettled).resolves.toBe(false);
+            expect(preserved.AgentOS.fleet.bearerToken).toBe(bearer);
+            expect(preserved.AgentOS.fleet.mcAuthorization).toBe(mcMint)
         });
 
         test('a throwing install preserves the ingress — the rollback needs no special path', async () => {
             const target = {AgentOS: {fleet: {bearerToken: 'not-a-canonical-bearer'}}};
 
             expect(() => establishFleetSessionCustody({
-                bearerToken: 'not-a-canonical-bearer',
                 fleetUrl,
                 installImpl: realInstall(okViewerFetch()),
                 target

--- a/test/playwright/unit/apps/agentos/config/fleetVocabularyParity.spec.mjs
+++ b/test/playwright/unit/apps/agentos/config/fleetVocabularyParity.spec.mjs
@@ -250,8 +250,9 @@ test.describe('FM vocabulary parity — the realm boundary carries no imports, s
             ['harnessTypes',       new URL('../../../../../../apps/agentos/config/harnessTypes.mjs', import.meta.url),       []],
             ['fleetWireMethods',   new URL('../../../../../../apps/agentos/config/fleetWireMethods.mjs', import.meta.url),   []],
             ['cockpitSources',     new URL('../../../../../../apps/agentos/config/cockpitSources.mjs', import.meta.url),     []],
-            ['connectionProfiles', new URL('../../../../../../apps/agentos/fleet/connectionProfiles.mjs', import.meta.url),  []],
-            ['installFleetBridge', new URL('../../../../../../apps/agentos/fleet/installFleetBridge.mjs', import.meta.url),  ['./connectionProfiles.mjs', '../config/fleetWireMethods.mjs']]
+            ['connectionProfiles',      new URL('../../../../../../apps/agentos/fleet/connectionProfiles.mjs', import.meta.url),      []],
+            ['fleetWakeStreamConsumer', new URL('../../../../../../apps/agentos/fleet/fleetWakeStreamConsumer.mjs', import.meta.url), []],
+            ['installFleetBridge',      new URL('../../../../../../apps/agentos/fleet/installFleetBridge.mjs', import.meta.url),      ['./connectionProfiles.mjs', './fleetWakeStreamConsumer.mjs', '../config/fleetWireMethods.mjs']]
         ];
 
         for (const [label, url, expectedImports] of sources) {

--- a/test/playwright/unit/apps/agentos/fleet/connectionProfiles.spec.mjs
+++ b/test/playwright/unit/apps/agentos/fleet/connectionProfiles.spec.mjs
@@ -241,4 +241,17 @@ test.describe('connectionProfiles — the pre-boot ingress retire helper', () =>
 
         expect(retireBearerIngressSlot(target, {expected: rotated}), 'an empty slot retires nothing under the guard').toBe(false)
     });
+
+    test('the field selector: the class-3 mint slot rides the same transient-ingress discipline', () => {
+        const
+            mcMint = 'C'.repeat(43),
+            target = {AgentOS: {fleet: {bearerToken: testBearer, mcAuthorization: mcMint}}};
+
+        expect(retireBearerIngressSlot(target, {expected: 'wrong', field: 'mcAuthorization'})).toBe(false);
+        expect(target.AgentOS.fleet.mcAuthorization).toBe(mcMint);
+
+        expect(retireBearerIngressSlot(target, {expected: mcMint, field: 'mcAuthorization'})).toBe(true);
+        expect('mcAuthorization' in target.AgentOS.fleet).toBe(false);
+        expect(target.AgentOS.fleet.bearerToken, 'each slot retires independently').toBe(testBearer)
+    });
 });

--- a/test/playwright/unit/apps/agentos/fleet/fleetWakeStreamConsumer.live.spec.mjs
+++ b/test/playwright/unit/apps/agentos/fleet/fleetWakeStreamConsumer.live.spec.mjs
@@ -1,0 +1,149 @@
+import {setup} from '../../../../setup.mjs';
+
+setup({
+    neoConfig: {unitTestMode: true},
+    appConfig: {
+        name             : 'FleetWakeStreamConsumerLiveTest',
+        isMounted        : () => true,
+        vnodeInitialising: false
+    }
+});
+
+import {test, expect} from '@playwright/test';
+import Neo            from '../../../../../../src/Neo.mjs';
+import * as core      from '../../../../../../src/core/_export.mjs';
+
+import {createFleetServerApp} from '../../../../../../ai/services/fleet/fleetServer.mjs';
+
+import {createFleetWakeStreamConsumer} from '../../../../../../apps/agentos/fleet/fleetWakeStreamConsumer.mjs';
+
+// The L3 live non-destructive probe for the browser consumer: the REAL composed fleet server —
+// real admission chain, real events limiter, real fanout handshake (retry hint + state frame) —
+// answered by the REAL browser twin over actual HTTP. Nothing is stubbed on the wire; the custom
+// auth middleware is the harness's identity stamp, exactly as the server's own spec uses it.
+
+const QUIET = {info() {}, warn() {}, error() {}};
+
+const wait = ms => new Promise(resolve => setTimeout(resolve, ms));
+
+function liveConfig({authMiddleware}) {
+    return {
+        publicUrl    : 'https://agent-os.example.test/mc/mcp',
+        allowedHosts : null,
+        mcpHttpHost  : '127.0.0.1',
+        mcpListenHost: '127.0.0.1',
+        authMiddleware,
+        auth         : {
+            mode                   : 'custom',
+            host                   : null,
+            issuerUrl              : null,
+            trustProxyIdentity     : false,
+            pinFirstProviderSubject: false,
+            githubApiBaseUrl       : 'https://api.github.test',
+            patCacheTtlSeconds     : 60,
+            patValidationTimeoutMs : 5_000,
+            allowedUsers           : []
+        },
+        fleet: {
+            port          : 8083,
+            dataDir       : '/app/.neo-ai-data/fleet',
+            cockpitOrigins: ['http://localhost:8080', 'http://127.0.0.1:8080']
+        }
+    }
+}
+
+async function startLiveServer({authMiddleware}) {
+    const app = await createFleetServerApp({
+        aiConfig: liveConfig({authMiddleware}),
+        logger  : QUIET,
+        planeGuard() {}
+    });
+
+    const server = await new Promise((resolve, reject) => {
+        const candidate = app.listen(0, '127.0.0.1', () => resolve(candidate));
+        candidate.once('error', reject)
+    });
+
+    return {
+        eventsUrl: `http://127.0.0.1:${server.address().port}/fleet/events`,
+        close    : () => new Promise((resolve, reject) => server.close(error => error ? reject(error) : resolve()))
+    }
+}
+
+test.describe('fleetWakeStreamConsumer — L3 live probe against the real composed server', () => {
+    test('an admitted viewer gets the REAL handshake: state observed alive, and the server retry hint raises the client floor', async () => {
+        const {eventsUrl, close} = await startLiveServer({
+            authMiddleware(req, res, next) {
+                // The stable-subject triple the stream key derives from — provider coordinates,
+                // never the mutable login (the same principal discipline the admission owns).
+                req.auth = {
+                    userId          : 'live-viewer',
+                    username        : 'live-viewer',
+                    source          : 'test-provider',
+                    authProvider    : 'github',
+                    providerUserId  : '424242',
+                    providerUsername: 'live-viewer'
+                };
+                next()
+            }
+        });
+
+        const consumer = createFleetWakeStreamConsumer({
+            eventsUrl,
+            retryFloorMs: 10,
+            logger      : QUIET,
+            authHeaders : () => ({authorization: 'Bearer live-class-1'})
+        });
+
+        try {
+            consumer.start();
+            await wait(150);
+
+            const liveness = consumer.resolveDeliveryLiveness();
+
+            expect(liveness.alive).toBe(true);
+            expect(liveness.reason).toContain('composed wake stream connected');
+
+            const snapshot = consumer.describe();
+
+            // The REAL fanout handshake: its `retry: 5000` hint raised the injected 10ms floor,
+            // and the real `state` frame landed as the first observation.
+            expect(snapshot.retryFloorMs).toBe(5000);
+            expect(snapshot.lastState).not.toBeNull();
+            expect(snapshot.connected).toBe(true)
+        } finally {
+            consumer.stop();
+            await close()
+        }
+    });
+
+    test('an unadmitted viewer is REFUSED by the real chain and observed honestly — poll remains the truth lane', async () => {
+        const {eventsUrl, close} = await startLiveServer({
+            authMiddleware(req, res, next) {
+                req.auth = {source: 'custom'}; // identityless: transport admitted, subject absent
+                next()
+            }
+        });
+
+        const consumer = createFleetWakeStreamConsumer({
+            eventsUrl,
+            retryFloorMs: 10,
+            logger      : QUIET,
+            authHeaders : () => ({})
+        });
+
+        try {
+            consumer.start();
+            await wait(150);
+
+            const liveness = consumer.resolveDeliveryLiveness();
+
+            expect(liveness.alive).toBe('unknown');
+            expect(liveness.reason).toMatch(/stream refused: HTTP (401|403)/);
+            expect(liveness.reason).toContain('poll remains the truth lane')
+        } finally {
+            consumer.stop();
+            await close()
+        }
+    })
+});

--- a/test/playwright/unit/apps/agentos/fleet/fleetWakeStreamConsumer.live.spec.mjs
+++ b/test/playwright/unit/apps/agentos/fleet/fleetWakeStreamConsumer.live.spec.mjs
@@ -88,11 +88,17 @@ test.describe('fleetWakeStreamConsumer — L3 live probe against the real compos
             }
         });
 
+        // BOTH mints cross the real wire — class-1 admits, the class-3 header rides its own
+        // channel (this harness runs no arming context, so the server takes the honest
+        // service-level path; the composed two-header request is what this probe pins).
         const consumer = createFleetWakeStreamConsumer({
             eventsUrl,
             retryFloorMs: 10,
             logger      : QUIET,
-            authHeaders : () => ({authorization: 'Bearer live-class-1'})
+            authHeaders : () => ({
+                authorization           : 'Bearer live-class-1',
+                'x-neo-mc-authorization': 'Bearer live-class-3-mint'
+            })
         });
 
         try {
@@ -107,7 +113,8 @@ test.describe('fleetWakeStreamConsumer — L3 live probe against the real compos
             const snapshot = consumer.describe();
 
             // The REAL fanout handshake: its `retry: 5000` hint raised the injected 10ms floor,
-            // and the real `state` frame landed as the first observation.
+            // and the real `state` frame landed as the first observation — positive liveness
+            // began exactly there, never at transport-open.
             expect(snapshot.retryFloorMs).toBe(5000);
             expect(snapshot.lastState).not.toBeNull();
             expect(snapshot.connected).toBe(true)

--- a/test/playwright/unit/apps/agentos/fleet/fleetWakeStreamConsumer.spec.mjs
+++ b/test/playwright/unit/apps/agentos/fleet/fleetWakeStreamConsumer.spec.mjs
@@ -1,0 +1,234 @@
+import {expect, test} from '@playwright/test';
+
+import {parseSseFrames as relayParseSseFrames} from '../../../../../../ai/services/fleet/fleetWakeSseConsumer.mjs';
+
+import {createFleetWakeStreamConsumer, parseSseFrames} from '../../../../../../apps/agentos/fleet/fleetWakeStreamConsumer.mjs';
+
+// The browser twin of the relay-side wake consumer. The realm boundary carries no imports, so the
+// frame parser is duplicated by construction — the PARITY block below is the binding. The consumer
+// tests assert the C2 differences: two credential headers (never synthesized here — the injected
+// authHeaders closure is the custody seam) and the same absence-of-signal observation grammar.
+
+const QUIET = {info: () => {}, warn: () => {}, error: () => {}};
+
+const wait = ms => new Promise(resolve => setTimeout(resolve, ms));
+
+/** A scriptable SSE response: the test pushes encoded chunks and closes the stream at will. */
+function sseResponse() {
+    let controller;
+
+    const stream = new ReadableStream({
+        start(c) {
+            controller = c
+        }
+    });
+
+    const encoder = new TextEncoder();
+
+    return {
+        ok    : true,
+        status: 200,
+        body  : stream,
+        push(text) {
+            controller.enqueue(encoder.encode(text))
+        },
+        close() {
+            try {
+                controller.close()
+            } catch {/* already closed */}
+        }
+    }
+}
+
+test.describe('parseSseFrames — PARITY: the browser twin answers exactly as the relay authority', () => {
+    const fixtures = [
+        'event: state\ndata: {"a":1}\n\nevent: wake\ndata: {"b"',
+        'retry: 7000\n:hb\nevent: wake\ndata: {"x":\ndata: 1}\n\n',
+        'data: bare-message\n\n',
+        'retry: nonsense\nevent: state\ndata: {}\n\n',
+        ': comment only\n\n',
+        '',
+        'event: wake\n\n' // frame without data
+    ];
+
+    test('every fixture parses identically in both realms', () => {
+        for (const fixture of fixtures) {
+            expect(parseSseFrames(fixture), `parity(${JSON.stringify(fixture.slice(0, 30))})`)
+                .toEqual(relayParseSseFrames(fixture))
+        }
+    });
+
+    test('complete frames parse; the trailing partial stays as rest', () => {
+        const {frames, rest} = parseSseFrames('event: state\ndata: {"a":1}\n\nevent: wake\ndata: {"b"');
+
+        expect(frames).toHaveLength(1);
+        expect(frames[0]).toEqual({event: 'state', data: '{"a":1}', retry: null});
+        expect(rest).toBe('event: wake\ndata: {"b"')
+    })
+});
+
+test.describe('fleetWakeStreamConsumer — the browser-direct wake observation', () => {
+    test('credentials never ride consumer options: an authHeaders closure is required', () => {
+        expect(() => createFleetWakeStreamConsumer({eventsUrl: 'http://127.0.0.1:8083/fleet/events'}))
+            .toThrow(/authHeaders function — credentials stay in the bridge closure/);
+        expect(() => createFleetWakeStreamConsumer({authHeaders: () => ({})}))
+            .toThrow(/requires an eventsUrl/)
+    });
+
+    test('the full arc, two-header armed: connect → vouched cold catch-up → wake → drop → reconnect at the held watermark', async () => {
+        const
+            responses   = [],
+            pollCalls   = [],
+            headersSeen = [];
+
+        const nextResponse = () => {
+            const response = sseResponse();
+            responses.push(response);
+            return response
+        };
+
+        const consumer = createFleetWakeStreamConsumer({
+            eventsUrl   : 'http://127.0.0.1:8083/fleet/events',
+            retryFloorMs: 10,
+            logger      : QUIET,
+            authHeaders : () => ({
+                authorization           : 'Bearer class-1-admission',
+                'x-neo-mc-authorization': 'Bearer class-3-mc-mint'
+            }),
+            pollDigest: async args => {
+                pollCalls.push(args);
+                return {counts: {pending: pollCalls.length === 1 ? 3 : 0}, watermark: pollCalls.length === 1 ? 41 : 44}
+            },
+            fetchImpl: async (url, options) => {
+                expect(url).toBe('http://127.0.0.1:8083/fleet/events');
+                expect(options.headers.accept).toBe('text/event-stream');
+                headersSeen.push({
+                    class1: options.headers.authorization,
+                    class3: options.headers['x-neo-mc-authorization']
+                });
+                return nextResponse()
+            }
+        });
+
+        consumer.start();
+        await wait(20);
+
+        // Both mints, distinct headers — the never-aliased pair as the wire truth.
+        expect(headersSeen[0]).toEqual({class1: 'Bearer class-1-admission', class3: 'Bearer class-3-mc-mint'});
+
+        // The handshake vouches the subscription id → cold catch-up fires ONCE, before any wake.
+        responses[0].push('event: state\ndata: {"armed":true,"armedForViewer":true,"subscriptionId":"sub-9"}\n\n');
+        await wait(20);
+
+        expect(pollCalls).toEqual([{subscriptionId: 'sub-9', sinceLogId: 0}]);
+        expect(consumer.resolveDeliveryLiveness()).toEqual({
+            alive : true,
+            reason: 'composed wake stream connected · armed for this viewer · 3 pending caught up'
+        });
+
+        // A live wake advances the client-held watermark past the catch-up's 41.
+        responses[0].push('event: wake\ndata: {"subscriptionId":"sub-9","envelope":{"logId":57}}\n\n');
+        await wait(20);
+        expect(consumer.describe().watermark).toBe(57);
+
+        // Drop → reconnect: the SECOND connection catches up AT the held watermark.
+        responses[0].close();
+        await wait(60);
+
+        responses[1].push('event: state\ndata: {"armed":true,"armedForViewer":true,"subscriptionId":"sub-9"}\n\n');
+        await wait(20);
+
+        expect(pollCalls).toHaveLength(2);
+        expect(pollCalls[1]).toEqual({subscriptionId: 'sub-9', sinceLogId: 57});
+        expect(headersSeen).toHaveLength(2);
+
+        consumer.stop()
+    });
+
+    test('the honest not-armed shape: one header only, and the server\'s own reason carried verbatim', async () => {
+        const response = sseResponse();
+
+        const consumer = createFleetWakeStreamConsumer({
+            eventsUrl   : 'http://127.0.0.1:8083/fleet/events',
+            retryFloorMs: 10,
+            logger      : QUIET,
+            authHeaders : () => ({authorization: 'Bearer class-1-admission'}),
+            fetchImpl   : async (url, options) => {
+                expect(options.headers['x-neo-mc-authorization'], 'no second header is ever synthesized').toBeUndefined();
+                return response
+            }
+        });
+
+        consumer.start();
+        await wait(20);
+
+        response.push('event: state\ndata: {"armed":true,"armedForViewer":false,"reason":"push lane armed for @relay-viewer; this viewer polls"}\n\n');
+        await wait(20);
+
+        expect(consumer.resolveDeliveryLiveness()).toEqual({
+            alive : true,
+            reason: 'composed wake stream connected · not armed for this viewer (push lane armed for @relay-viewer; this viewer polls)'
+        });
+
+        consumer.stop()
+    });
+
+    test('a refused stream is an observation, never a throw — and poll remains the truth lane', async () => {
+        const consumer = createFleetWakeStreamConsumer({
+            eventsUrl   : 'http://127.0.0.1:8083/fleet/events',
+            retryFloorMs: 10,
+            logger      : QUIET,
+            authHeaders : () => ({}),
+            fetchImpl   : async () => ({ok: false, status: 401, body: null})
+        });
+
+        consumer.start();
+        await wait(20);
+
+        const liveness = consumer.resolveDeliveryLiveness();
+
+        expect(liveness.alive).toBe('unknown');
+        expect(liveness.reason).toContain('stream refused: HTTP 401');
+        expect(liveness.reason).toContain('poll remains the truth lane');
+
+        consumer.stop()
+    });
+
+    test('the server retry hint is a floor the client respects; caps mean backoff, never a storm', async () => {
+        const response = sseResponse();
+
+        const consumer = createFleetWakeStreamConsumer({
+            eventsUrl   : 'http://127.0.0.1:8083/fleet/events',
+            retryFloorMs: 10,
+            logger      : QUIET,
+            authHeaders : () => ({authorization: 'Bearer class-1-admission'}),
+            fetchImpl   : async () => response
+        });
+
+        consumer.start();
+        await wait(20);
+
+        response.push('retry: 45000\nevent: state\ndata: {"armed":false}\n\n');
+        await wait(20);
+
+        expect(consumer.describe().retryFloorMs).toBe(45000);
+        consumer.stop()
+    });
+
+    test('stopped is the honest terminal observation, and stop is idempotent', async () => {
+        const consumer = createFleetWakeStreamConsumer({
+            eventsUrl  : 'http://127.0.0.1:8083/fleet/events',
+            logger     : QUIET,
+            authHeaders: () => ({}),
+            fetchImpl  : async () => ({ok: false, status: 503, body: null})
+        });
+
+        expect(consumer.resolveDeliveryLiveness()).toEqual({alive: 'unknown', reason: 'wake stream consumer not running'});
+
+        consumer.start();
+        consumer.stop();
+        consumer.stop();
+
+        expect(consumer.resolveDeliveryLiveness().reason).toBe('wake stream consumer not running')
+    })
+});

--- a/test/playwright/unit/apps/agentos/fleet/fleetWakeStreamConsumer.spec.mjs
+++ b/test/playwright/unit/apps/agentos/fleet/fleetWakeStreamConsumer.spec.mjs
@@ -145,6 +145,69 @@ test.describe('fleetWakeStreamConsumer — the browser-direct wake observation',
         consumer.stop()
     });
 
+    test('the vouch is CONNECTION-EPOCH state: a disarmed reconnect never reuses the prior subscription', async () => {
+        const
+            responses = [],
+            pollCalls = [];
+
+        const nextResponse = () => {
+            const response = sseResponse();
+            responses.push(response);
+            return response
+        };
+
+        const consumer = createFleetWakeStreamConsumer({
+            eventsUrl   : 'http://127.0.0.1:8083/fleet/events',
+            retryFloorMs: 10,
+            logger      : QUIET,
+            authHeaders : () => ({authorization: 'Bearer class-1-admission'}),
+            pollDigest  : async args => { pollCalls.push(args); return {counts: {pending: 0}} },
+            fetchImpl   : async () => nextResponse()
+        });
+
+        consumer.start();
+        await wait(20);
+
+        responses[0].push('event: state\ndata: {"armed":true,"armedForViewer":true,"subscriptionId":"sub-9"}\n\n');
+        await wait(20);
+        expect(pollCalls).toHaveLength(1);
+
+        // Disarmed between connections: the new epoch's handshake vouches NO id.
+        responses[0].close();
+        await wait(60);
+        responses[1].push('event: state\ndata: {"armed":true,"armedForViewer":false,"reason":"disarmed"}\n\n');
+        await wait(20);
+
+        expect(pollCalls, 'no catch-up may fire on the PRIOR epoch\'s subscription').toHaveLength(1);
+        expect(consumer.describe().subscriptionId).toBeNull();
+        expect(consumer.resolveDeliveryLiveness().reason).toContain('not armed for this viewer (disarmed)');
+
+        consumer.stop()
+    });
+
+    test('transport-open is not handshake-live: an HTTP 200 with ZERO frames stays unknown', async () => {
+        const response = sseResponse(); // opened, never pushed to
+
+        const consumer = createFleetWakeStreamConsumer({
+            eventsUrl   : 'http://127.0.0.1:8083/fleet/events',
+            retryFloorMs: 10,
+            logger      : QUIET,
+            authHeaders : () => ({authorization: 'Bearer class-1-admission'}),
+            fetchImpl   : async () => response
+        });
+
+        consumer.start();
+        await wait(30);
+
+        expect(consumer.describe().connected, 'the transport IS open').toBe(true);
+        expect(consumer.resolveDeliveryLiveness()).toEqual({
+            alive : 'unknown',
+            reason: 'stream open, state handshake pending — liveness unconfirmed'
+        });
+
+        consumer.stop()
+    });
+
     test('the honest not-armed shape: one header only, and the server\'s own reason carried verbatim', async () => {
         const response = sseResponse();
 

--- a/test/playwright/unit/apps/agentos/fleet/installFleetBridge.spec.mjs
+++ b/test/playwright/unit/apps/agentos/fleet/installFleetBridge.spec.mjs
@@ -95,21 +95,20 @@ test.describe('installFleetBridge — App-Worker wiring of the dev-server app<->
         const
             mcMint      = 'C'.repeat(43),
             headersSeen = [],
-            target      = {};
+            target      = {},
+            // ONE transport injection point, at install: the SAME fetch serves the wire and the
+            // stream — the capability pins it, so a stream-shaped answer is what this stub gives.
+            streamFetch = async (url, options) => {
+                headersSeen.push({url, class1: options.headers?.authorization, class3: options.headers?.['x-neo-mc-authorization']});
+                return {ok: false, status: 503, body: null}
+            };
 
-        const bridge = installFleetBridge({url: fleetUrl, bearerToken: testBearer, mcAuthorization: mcMint, fetchImpl: okFetch(), target});
+        const bridge = installFleetBridge({url: fleetUrl, bearerToken: testBearer, mcAuthorization: mcMint, fetchImpl: streamFetch, target});
 
         expect(Object.getOwnPropertyDescriptor(bridge, 'openWakeStream')).toMatchObject({enumerable: false});
         expect(Object.keys(bridge).sort(), 'the capability never joins the enumerable wire surface').toEqual([...FLEET_WIRE_METHODS].sort());
 
-        const consumer = bridge.openWakeStream({
-            logger   : {warn: () => {}, error: () => {}},
-            fetchImpl: async (url, options) => {
-                headersSeen.push({url, class1: options.headers.authorization, class3: options.headers['x-neo-mc-authorization']});
-                return {ok: false, status: 503, body: null}
-            },
-            retryFloorMs: 10
-        });
+        const consumer = bridge.openWakeStream({logger: {warn: () => {}, error: () => {}}, retryFloorMs: 10});
 
         consumer.start();
         await new Promise(resolve => setTimeout(resolve, 20));
@@ -123,17 +122,18 @@ test.describe('installFleetBridge — App-Worker wiring of the dev-server app<->
         });
 
         // a bearer-less bridge still opens the stream — unauthenticated, honestly refused
-        const failClosed = installFleetBridge({url: fleetUrl, fetchImpl: okFetch(), target: {}});
-        const bareSeen   = [];
+        const
+            bareSeen   = [],
+            failClosed = installFleetBridge({
+                url      : fleetUrl,
+                fetchImpl: async (url, options) => {
+                    bareSeen.push({class1: options.headers?.authorization, class3: options.headers?.['x-neo-mc-authorization']});
+                    return {ok: false, status: 401, body: null}
+                },
+                target: {}
+            });
 
-        const bareConsumer = failClosed.openWakeStream({
-            logger   : {warn: () => {}, error: () => {}},
-            fetchImpl: async (url, options) => {
-                bareSeen.push({class1: options.headers.authorization, class3: options.headers['x-neo-mc-authorization']});
-                return {ok: false, status: 401, body: null}
-            },
-            retryFloorMs: 10
-        });
+        const bareConsumer = failClosed.openWakeStream({logger: {warn: () => {}, error: () => {}}, retryFloorMs: 10});
 
         bareConsumer.start();
         await new Promise(resolve => setTimeout(resolve, 20));
@@ -146,6 +146,26 @@ test.describe('installFleetBridge — App-Worker wiring of the dev-server app<->
         const shellBridge = installFleetBridge({credentialIngress: 'shell', send: async () => null, target: {}});
 
         expect(shellBridge.openWakeStream).toBeUndefined()
+    });
+
+    test('the capability CANNOT be redirected: destination, credentials, and transport are pinned — the exfiltration falsifier', async () => {
+        const
+            attackerCalls = [],
+            attackerFetch = async (...args) => { attackerCalls.push(args); return {ok: false, status: 503, body: null} },
+            bridge        = installFleetBridge({url: fleetUrl, bearerToken: testBearer, fetchImpl: okFetch(), target: {}});
+
+        // every override attempt on a protected field fails LOUD before any consumer exists
+        for (const attempt of [
+            {eventsUrl: 'https://evil.example.test/steal'},
+            {authHeaders: () => ({authorization: 'Bearer forged'})},
+            {fetchImpl: attackerFetch},
+            {eventsUrl: 'https://evil.example.test/steal', fetchImpl: attackerFetch, retryFloorMs: 10}
+        ]) {
+            expect(() => bridge.openWakeStream(attempt), `override ${Object.keys(attempt).join('+')} must be refused`)
+                .toThrow(/capability owns destination, credentials, and transport/)
+        }
+
+        expect(attackerCalls, 'an attacker transport must never receive a single call — no header can leak').toHaveLength(0)
     });
 
     test('publishes AgentOS.fleet.registryBridge with exactly the wire operations', () => {

--- a/test/playwright/unit/apps/agentos/fleet/installFleetBridge.spec.mjs
+++ b/test/playwright/unit/apps/agentos/fleet/installFleetBridge.spec.mjs
@@ -73,6 +73,81 @@ test.describe('installFleetBridge — App-Worker wiring of the dev-server app<->
             .toThrow(/null or a non-empty identity string/)
     });
 
+    test('the class-3 MC mint: distinct-by-contract, closure-held, shell-refused', () => {
+        const mcMint = 'C'.repeat(43);
+
+        // never aliased: a byte-identical class-1/class-3 pair is a misconfiguration, refused loud
+        expect(() => installFleetBridge({url: fleetUrl, bearerToken: testBearer, mcAuthorization: testBearer, fetchImpl: okFetch(), target: {}}))
+            .toThrow(/DISTINCT mint.*never aliased/);
+        expect(() => installFleetBridge({url: fleetUrl, bearerToken: testBearer, mcAuthorization: '  ', fetchImpl: okFetch(), target: {}}))
+            .toThrow(/non-empty class-3 MC credential/);
+        expect(() => installFleetBridge({credentialIngress: 'shell', mcAuthorization: mcMint, send: async () => null, target: {}}))
+            .toThrow(/mutually exclusive/);
+
+        // a valid distinct pair installs; neither mint appears on the renderable bridge surface
+        const bridge = installFleetBridge({url: fleetUrl, bearerToken: testBearer, mcAuthorization: mcMint, fetchImpl: okFetch(), target: {}});
+
+        expect(JSON.stringify(bridge)).not.toContain(mcMint);
+        expect(JSON.stringify(bridge)).not.toContain(testBearer)
+    });
+
+    test('openWakeStream: a browser-bridge capability in closure custody; shell bridges carry none', async () => {
+        const
+            mcMint      = 'C'.repeat(43),
+            headersSeen = [],
+            target      = {};
+
+        const bridge = installFleetBridge({url: fleetUrl, bearerToken: testBearer, mcAuthorization: mcMint, fetchImpl: okFetch(), target});
+
+        expect(Object.getOwnPropertyDescriptor(bridge, 'openWakeStream')).toMatchObject({enumerable: false});
+        expect(Object.keys(bridge).sort(), 'the capability never joins the enumerable wire surface').toEqual([...FLEET_WIRE_METHODS].sort());
+
+        const consumer = bridge.openWakeStream({
+            logger   : {warn: () => {}, error: () => {}},
+            fetchImpl: async (url, options) => {
+                headersSeen.push({url, class1: options.headers.authorization, class3: options.headers['x-neo-mc-authorization']});
+                return {ok: false, status: 503, body: null}
+            },
+            retryFloorMs: 10
+        });
+
+        consumer.start();
+        await new Promise(resolve => setTimeout(resolve, 20));
+        consumer.stop();
+
+        // the events URL derives from the fleet origin; both mints ride their OWN headers
+        expect(headersSeen[0]).toEqual({
+            url   : 'http://127.0.0.1:8083/fleet/events',
+            class1: `Bearer ${testBearer}`,
+            class3: `Bearer ${mcMint}`
+        });
+
+        // a bearer-less bridge still opens the stream — unauthenticated, honestly refused
+        const failClosed = installFleetBridge({url: fleetUrl, fetchImpl: okFetch(), target: {}});
+        const bareSeen   = [];
+
+        const bareConsumer = failClosed.openWakeStream({
+            logger   : {warn: () => {}, error: () => {}},
+            fetchImpl: async (url, options) => {
+                bareSeen.push({class1: options.headers.authorization, class3: options.headers['x-neo-mc-authorization']});
+                return {ok: false, status: 401, body: null}
+            },
+            retryFloorMs: 10
+        });
+
+        bareConsumer.start();
+        await new Promise(resolve => setTimeout(resolve, 20));
+
+        expect(bareSeen[0]).toEqual({class1: undefined, class3: undefined});
+        expect(bareConsumer.resolveDeliveryLiveness().reason).toContain('stream refused: HTTP 401');
+        bareConsumer.stop();
+
+        // packaged custody: main owns the push topology, the worker bridge carries no capability
+        const shellBridge = installFleetBridge({credentialIngress: 'shell', send: async () => null, target: {}});
+
+        expect(shellBridge.openWakeStream).toBeUndefined()
+    });
+
     test('publishes AgentOS.fleet.registryBridge with exactly the wire operations', () => {
         const target = {};
         const bridge = installFleetBridge({url: fleetUrl, fetchImpl: okFetch(), target});
@@ -205,7 +280,7 @@ test.describe('installFleetBridge — App-Worker wiring of the dev-server app<->
     });
 
     test('credential-shaped query params on the fleet URL are refused — the secret never rides a URL', () => {
-        for (const name of ['bearer', 'bearerToken', 'fleetBearer', 'token', 'authorization']) {
+        for (const name of ['bearer', 'bearerToken', 'fleetBearer', 'token', 'authorization', 'mcAuthorization']) {
             expect(() => installFleetBridge({url: `http://127.0.0.1:8083/fleet?${name}=abc`, fetchImpl: okFetch(), target: {}}),
                 `param ${name} must be refused`).toThrow(/never a query param/)
         }

--- a/test/playwright/unit/apps/agentos/fleet/redeemFleetBearerHandshake.spec.mjs
+++ b/test/playwright/unit/apps/agentos/fleet/redeemFleetBearerHandshake.spec.mjs
@@ -17,7 +17,7 @@ test.describe('redeemFleetBearerHandshake — the page half of the one-command h
     test('derives <fleet-origin>/fleet/handshake from the fleet URL and requests it no-store', async () => {
         const calls = [];
 
-        const token = await redeemFleetBearerHandshake({
+        const result = await redeemFleetBearerHandshake({
             url      : 'http://127.0.0.1:8083/fleet',
             fetchImpl: async (url, options) => {
                 calls.push({url, options});
@@ -25,7 +25,7 @@ test.describe('redeemFleetBearerHandshake — the page half of the one-command h
             }
         });
 
-        expect(token).toBe(validToken);
+        expect(result).toEqual({bearerToken: validToken, mcAuthorization: null});
         expect(calls).toHaveLength(1);
         expect(calls[0].url).toBe('http://127.0.0.1:8083/fleet/handshake');
         expect(calls[0].options.cache).toBe('no-store');
@@ -59,6 +59,27 @@ test.describe('redeemFleetBearerHandshake — the page half of the one-command h
 
         for (const [label, fetchImpl] of cases) {
             expect(await redeemFleetBearerHandshake({url: 'http://127.0.0.1:8083/fleet', fetchImpl}), label).toBeNull()
+        }
+    });
+
+    test('the viewer mint rides the pair when armed — and a malformed or bearer-identical mint is STRIPPED, never adopted', async () => {
+        const withMint = mint => async () => ({
+            ok  : true,
+            json: async () => ({ok: true, result: {bearerToken: validToken, mcAuthorization: mint}})
+        });
+
+        // armed: the pair travels together
+        expect(await redeemFleetBearerHandshake({url: 'http://127.0.0.1:8083/fleet', fetchImpl: withMint('viewer-mc-mint')}))
+            .toEqual({bearerToken: validToken, mcAuthorization: 'viewer-mc-mint'});
+
+        // stripped shapes: the class-1 redemption stays valid, the boot proceeds honestly not-armed
+        for (const [label, mint] of [
+            ['bearer-identical mint (never-aliased)', validToken],
+            ['empty mint', '   '],
+            ['non-string mint', 42]
+        ]) {
+            expect(await redeemFleetBearerHandshake({url: 'http://127.0.0.1:8083/fleet', fetchImpl: withMint(mint)}), label)
+                .toEqual({bearerToken: validToken, mcAuthorization: null})
         }
     });
 


### PR DESCRIPTION
Resolves neomjs/neo#17190

Refs neomjs/neo#17130, neomjs/neo-agent-brain#50

The browser-direct wake consumer lands as the App-Worker twin of the relay-side consumer (`ai/services/fleet/fleetWakeSseConsumer.mjs`, slice 3) plus the bridge capability that keeps both mints in closure custody. `apps/agentos/fleet/fleetWakeStreamConsumer.mjs` duplicates the SSE frame parser by construction (the realm boundary carries no imports — a PARITY spec pins both parsers to identical answers on a shared fixture matrix) and twins the consumer state machine verbatim: vouched `subscriptionId` adoption from the `state` handshake BEFORE any live wake, `poll-digest` catch-up exactly once per connection with the client-held watermark echoed and never server-persisted, the server `retry:` hint as a floor with exponential backoff under cap (render refusals, never retry-storm the caps), a 90s staleness horizon, and the relay's absence-of-signal grammar verbatim (`alive: 'unknown'` + reason; poll remains the truth lane) so one observation vocabulary serves both topologies. Browser deltas: `TextDecoder` chunk decoding, and an injected `authHeaders` FUNCTION as the custody seam — credentials never appear in consumer options.

Where the relay deliberately presents ONE credential (transitional boot-armed shared viewer), this is the PER-VIEWER shape: `installFleetBridge` gains `mcAuthorization` (class-3 MC mint, closure-held beside the bearer) and a non-enumerable `openWakeStream` capability on direct-browser bridges — the pane opens the stream through the closure and never touches a mint; class-1 rides `Authorization`, the class-3 mint rides `x-neo-mc-authorization`. The never-aliased rule fails LOUD at install: a byte-identical class-1/class-3 pair is a misconfiguration refused before any wire (the server's own refusal inside arming is separately pinned at `fleetWakeArming.spec.mjs:282`). A bearer-less bridge still exposes the capability — the unauthenticated stream is refused by the server and carried as an honest observation. Packaged-shell bridges carry NO capability: main owns the push topology on its side of the boundary. `establishFleetSessionCustody` passes the mint through both install sites (candidate and promote), and `mcAuthorization` joins the forbidden URL-credential params.

Evidence: L2 (parser parity matrix; the full consumer arc — two-header arming, vouched cold catch-up, watermark continuity across reconnect, honest not-armed with the server's reason verbatim, refusal observation, retry-floor raise, stop idempotency; bridge capability pins — non-enumerable, events URL from the fleet origin, both headers from closure, bearer-less honesty, shell absence; mint validation trio; establish passthrough into candidate AND promote) + L3 (the REAL composed fleet server: an admitted viewer receives the real fanout handshake — the actual `retry: 5000` hint raises the injected 10ms client floor, the real `state` frame lands, liveness reads alive; an identityless viewer is refused by the real chain and observed honestly). Residual: the full per-viewer arming journey with a live MC plane (real class-3 mint round-trip) plus store-bound rendering and the whitebox-e2e are leg 2 of the cutover, Residual-Owner: neomjs/neo#17130.

## Deltas from ticket

- **Review follow-up (the remaining production-mint P1, repaired):** the class-3 mint now has a REAL producer chain end-to-end. Two new AiConfig leaves (`fleet.viewerMcAuthorization` + `File` — authored under the ADR-0019 read-gate, sibling-lifted from the `planeAdmissionBearer` pair) → `resolveFleetViewerMcAuthorization` + `assertFleetViewerMcAuthorizationClass` (class teeth: the viewer's OWN MC authority may never alias the relay's plane-MCP or admission credentials — spec'd) → `devFleetServer` class-asserts at the entrypoint and injects at the named bootstrap boundary → `startFleetBridgeServer` gains `mcAuthorization` (byte-identical-to-process-bearer REFUSES STARTUP; the armed handshake serves the PAIR — real-HTTP spec'd) → `redeemFleetBearerHandshake` returns the pair (malformed/bearer-identical mints STRIPPED, never adopted — the class-1 redemption stays valid and the boot proceeds honestly not-armed) → `establishFleetSessionCustody` binds the redeemed pair with per-field slot fallback. The launcher e2e (devCockpit.spec) keeps its bearer-only armed shape — the pair is additive on the same envelope; the mint's launcher passage is standard leaf plumbing, covered at the resolve/assert and real-server seams.
- **Review round 1 (four rows, all reproduced by the reviewer's exact-head probes and repaired here):** (P0) the capability's `...opts` spread let a caller override `eventsUrl`/`authHeaders`/`fetchImpl` and receive both closure-held headers — `openWakeStream` now REFUSES every non-observational option loud (whitelist: `pollDigest`, `logger`, `retryFloorMs`, `now`) and pins destination, credentials, AND transport (the stream rides the SAME install-injected fetch as the wire — one transport injection point); the exfiltration falsifier asserts an attacker transport receives ZERO calls. (P1) the subscription vouch is now CONNECTION-EPOCH state — reset per connect, so a disarmed reconnect never reuses the prior subscription; only the client watermark survives. (P1) transport-open ≠ handshake-live: HTTP 200 with zero frames answers `alive: 'unknown', reason: 'stream open, state handshake pending'`; positive liveness begins at the current epoch's `state` frame. (P1) the second mint is PRODUCTION-BOUND: `establishFleetSessionCustody` now reads the entrypoint truth itself (module-private redemption + BOTH launcher pre-boot slots, `bearerToken` and `mcAuthorization`), binds both mints into candidate AND promote installs, and CAS-retires BOTH ingress copies under the one session proof — a failed verify preserves the pair; the specs feed SLOTS, exercising the entrypoint path rather than hand-feeding args.
- **Close-target correction, taken per the review's own option:** neomjs/neo#17190's identical-pair AC originally stipulated observing the SERVER's refusal; the strictly stronger client-side preflight (the pair never crosses the wire) makes that observation unreachable, so the AC is amended on the ticket with review provenance — the server-side pair refusal remains pinned at `fleetWakeArming.spec.mjs:282`.
- The live probe's admitted path runs the composed server WITHOUT a wake-arming context (the unit harness has no MC plane) — both headers now cross the REAL wire in that probe; the full armed round-trip stays leg 2 with the whitebox-e2e.
- The RELAY twin retains the pre-repair epoch/zero-frame semantics deliberately (its transitional boot-armed topology narrows the exposure); aligning it is a candidate sibling leaf, offered to the fleet rather than absorbed here.
- The stream-key discipline surfaced by the probe is worth naming: `resolveViewerStreamKey` derives from the PROVIDER COORDINATE triple (`provider:<authProvider>:<providerUserId>`), never the mutable login — the harness stamp documents it.

## Test Evidence

- `npm run test-unit -- test/playwright/unit/apps/agentos/fleet/ <app.spec, fleetVocabularyParity.spec, relay fleetWakeSseConsumer.spec>` → **108 passed (3.2s)** post-repair — the full touched surface INCLUDING the untouched relay sibling (parity import proven non-disturbing) and the fleet transport integration suite.
- RC-round pins: the exfiltration falsifier (four override shapes refused, attacker transport at zero calls) · disarmed reconnect fires no catch-up on the prior epoch's subscription · zero-frame HTTP 200 stays `unknown` · the slot-entrypoint two-mint flow (both bound into the install, both CAS-retired under the one proof, both preserved on failed verify) · the `field`-selector CAS rows for the second ingress slot.
- Producer-chain pins (`npm run test-unit -- <apps/agentos/ + fleetBridgeServer.spec + fleetWakeArming.spec + relay consumer>` → **729 passed (5.3s)** across the widened surface): the armed handshake serves the PAIR over real HTTP and unarmed deployments keep the bearer-only shape · startup REFUSES a byte-identical bearer/mint pair and a malformed mint (sync fail-closed) · the viewer-mint resolver's value-over-file precedence + all class-teeth aliases refused, distinct mint admitted · the redeem strips bearer-identical/empty/non-string mints while keeping the class-1 redemption valid · the redeemed PAIR binds through establish with the wake capability present on the armed bridge.
- New spec files: `fleetWakeStreamConsumer.spec.mjs` (parity + the consumer pins) and `fleetWakeStreamConsumer.live.spec.mjs` (the L3 probe against `createFleetServerApp`).
- Operable-cold import contract extended PROACTIVELY: `fleetWakeStreamConsumer.mjs` joins the scanned set with an empty expected-import list, and `installFleetBridge`'s allowlist admits the new import — the exact-allowlist lesson from the sibling PR applied before CI, not after.

## Post-Merge Validation

- [x] All touched spec surfaces re-runnable on dev post-merge (pure/fixture/local-server harnesses, no deployment dependency).

Authored by Clio (Claude Fable 5, Claude Code). Session dd4568bd-d264-4448-998b-63a7ce35b792.
