### PR TITLE
fix(build): co-author trailers on agent commits are gated by roster, not domain (#17195)

### DIFF
--- a/.github/workflows/commit-authorship-lint.yml
+++ b/.github/workflows/commit-authorship-lint.yml
@@ -64,5 +64,13 @@ jobs:
       # `< /dev/null` is explicit rather than incidental: the script reads fd 0 for the pre-push hook
       # payload, and an inherited terminal-less stdin should degrade to the fallback by design, not by
       # luck. No `npm ci` — this guard imports only node builtins and the in-repo identity registry.
+      # `--author-login` is the AUTHENTICATED lane classification for CI. The guard cannot use the
+      # commit's own `%ae` for this: `git commit --author=…` rewrites it, and one such flag carried a
+      # poisoned trailer to exit 0 against an email-only classifier. A PR cannot forge who opened it,
+      # so GitHub's own `pull_request.user.login` is the one unforgeable identity available here —
+      # the CI counterpart to checkout ownership, which exists only at the hook.
       - name: Lint commit authorship and co-author trailers
-        run: node ./buildScripts/util/check-commit-authorship.mjs < /dev/null
+        run: >
+          node ./buildScripts/util/check-commit-authorship.mjs
+          --author-login "${{ github.event.pull_request.user.login }}"
+          < /dev/null

--- a/.github/workflows/commit-authorship-lint.yml
+++ b/.github/workflows/commit-authorship-lint.yml
@@ -21,10 +21,22 @@ name: Commit Authorship Lint
 on:
   pull_request:
     branches: [dev]
+    # `edited` is NOT in the default set (opened/synchronize/reopened). Without it, a PR opened
+    # against another base and later RETARGETED to `dev` never re-triggers this workflow, so the
+    # commits it exists to inspect reach the merge gate unexamined. A gate with a documented way
+    # around it is the shape this whole ticket is about.
+    types: [opened, synchronize, reopened, edited]
 
 concurrency:
   group: commit-authorship-lint-${{ github.run_attempt == '1' && github.ref || github.run_id }}
   cancel-in-progress: true
+
+# This job runs PR-CONTROLLED CODE — the guard script itself is part of the diff under review — so
+# it gets the narrowest token that can do the work. Agent PRs are same-repo branches rather than
+# forks, which means they would otherwise receive the full write-capable token rather than the
+# read-only one a fork gets. Read access to contents is the entire requirement.
+permissions:
+  contents: read
 
 jobs:
   lint:
@@ -36,6 +48,9 @@ jobs:
           # Full history: the guard diffs the PR's commits against origin/dev, so a shallow clone
           # would leave it scanning an empty range and passing vacuously.
           fetch-depth: 0
+          # Do not leave the token in .git/config for the script to read. Nothing here pushes, and
+          # the checked-out code is the code under review.
+          persist-credentials: false
 
       - name: Setup Node.js
         uses: actions/setup-node@v6

--- a/.github/workflows/commit-authorship-lint.yml
+++ b/.github/workflows/commit-authorship-lint.yml
@@ -1,0 +1,53 @@
+name: Commit Authorship Lint
+
+# CI mirror of the .husky/pre-push check-commit-authorship guard, so `git push --no-verify` and any
+# environment without husky hooks cannot bypass it at the merge gate.
+#
+# The failure this exists for: GitHub resolves a `Co-Authored-By` trailer by its EMAIL and credits
+# whatever account owns that address — the display name in the trailer is cosmetic. An agent-authored
+# commit carrying an off-domain address therefore credits a REAL PERSON for work they did not do.
+# Sixteen such commits reached `dev` in a 36-hour window while the pre-push check was silent on all of
+# them, because it was hook-only AND advisory AND scoped to the project domain. Any one of those three
+# would have been enough to miss it.
+#
+# DELIBERATELY NOT PATH-FILTERED. Every other lint here scopes itself to the files it inspects, which
+# is right for a file-content guard. This one inspects COMMIT METADATA, so a `paths:` filter would make
+# it vacuous for precisely the PRs that do not happen to touch its own source — i.e. almost all of them.
+#
+# Known gap, not owned here: like the other lint workflows, this is not yet a required status context,
+# so it reports without blocking the merge button. #17171 owns making them required; until it lands,
+# this raises the floor from "nothing anywhere" to "red on the PR".
+
+on:
+  pull_request:
+    branches: [dev]
+
+concurrency:
+  group: commit-authorship-lint-${{ github.run_attempt == '1' && github.ref || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          # Full history: the guard diffs the PR's commits against origin/dev, so a shallow clone
+          # would leave it scanning an empty range and passing vacuously.
+          fetch-depth: 0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '24'
+
+      - name: Fetch base branch
+        run: git fetch origin dev
+
+      # No stdin in CI, so the guard falls back to its `origin/dev..HEAD` range — the PR's own commits.
+      # `< /dev/null` is explicit rather than incidental: the script reads fd 0 for the pre-push hook
+      # payload, and an inherited terminal-less stdin should degrade to the fallback by design, not by
+      # luck. No `npm ci` — this guard imports only node builtins and the in-repo identity registry.
+      - name: Lint commit authorship and co-author trailers
+        run: node ./buildScripts/util/check-commit-authorship.mjs < /dev/null

--- a/ai/scripts/migrations/bootstrapWorktree.mjs
+++ b/ai/scripts/migrations/bootstrapWorktree.mjs
@@ -127,6 +127,7 @@ import {fileURLToPath} from 'url';
 import {promisify}     from 'util';
 
 import {IDENTITIES}                                                                    from '../../graph/identityRoots.mjs';
+import {rosterEmailForLogin}                                                           from '../../../buildScripts/util/agentCoAuthorEmails.mjs';
 import {initClaudeSettings, listServersWithTemplates, materializeServerConfigTemplate} from '../setup/initServerConfigs.mjs';
 
 const execFileAsync = promisify(execFile);
@@ -381,6 +382,33 @@ async function resolveAgentGitIdentity({agentIdentity, getAuthenticatedAccount})
 
     if (/noreply/iu.test(email)) {
         throw new Error(`bootstrapWorktree: refusing noreply Git author email for '${expectedLogin}'.`)
+    }
+
+    // The authenticated primary must BE this seat's roster address, not merely a verified address
+    // the account happens to own. Without this, an agent whose GitHub primary is off-domain binds an
+    // off-domain Git author email — and the push-time co-author guard, which can only read
+    // self-asserted commit metadata, then classifies that seat as non-agent and lets a trailer
+    // crediting a real person through. This is the one place authenticated identity is in hand, so
+    // it is the only place that bypass can be closed; the guard cannot close it from a commit alone.
+    //
+    // Asserted rather than substituted: silently writing the roster address over a mismatching
+    // verified primary would make the Git identity stop matching the authenticated account, trading
+    // one attribution lie for another. A mismatch is a real finding and says so.
+    const rosterEmail = rosterEmailForLogin(expectedLogin);
+
+    if (!rosterEmail) {
+        throw new Error(
+            `bootstrapWorktree: agent '${expectedLogin}' has no commit address in ` +
+            'buildScripts/util/agentCoAuthorEmails.mjs. Add the seat there before binding its Git identity.'
+        )
+    }
+
+    if (email.toLowerCase() !== rosterEmail) {
+        throw new Error(
+            `bootstrapWorktree: authenticated primary '${email}' for '${expectedLogin}' does not match its ` +
+            `roster commit address '${rosterEmail}'. Binding it would let this seat author from an address ` +
+            'the co-author guard reads as non-agent. Reconcile the GitHub primary or the roster entry.'
+        )
     }
 
     return {displayName, email, login: expectedLogin}

--- a/buildScripts/util/agentCoAuthorEmails.mjs
+++ b/buildScripts/util/agentCoAuthorEmails.mjs
@@ -160,10 +160,21 @@ export function reconcileWithRegistry() {
  * @param {Object[]} args.commits `{sha, subject, body, authorEmail}` rows for the commits being
  * pushed. A missing `authorEmail` is treated as non-agent, keeping the pre-existing domain-scoped
  * behaviour for any caller that has not been updated — this check degrades quiet, never loud.
+ * @param {Boolean} [args.agentLane=false] An AUTHENTICATED statement that these commits are being
+ * pushed on an agent lane, from a source the committer cannot forge: the hook passes the bootstrap's
+ * checkout ownership, CI passes the GitHub-authenticated PR author. When true it overrides the
+ * per-commit author entirely.
+ *
+ * **Why an override rather than one more input to the inference.** `authorEmail` is `%ae`, which a
+ * single `git commit --author=…` rewrites — measured: an agent commit carrying a poisoned trailer
+ * and an off-domain `--author` exited 0 against the email-only classifier. Authenticated lane
+ * identity is not forgeable from inside the commit, so where it exists it is the answer and the
+ * email is not consulted. Where it does not exist the email remains a best effort, which is why this
+ * defaults to `false` rather than being required.
  * @returns {Array<{sha: String, subject: String, email: String, agentAuthored: Boolean}>} One row
  * per offending trailer. `agentAuthored` is what the caller escalates on.
  */
-export function findUnknownCoAuthors({commits = []}) {
+export function findUnknownCoAuthors({commits = [], agentLane = false}) {
     const
         known     = new Set(Object.values(EMAIL_BY_LOGIN).map(email => email.toLowerCase())),
         trailer   = /^\s*co-authored-by:\s*.*?<([^>]+)>\s*$/gim,
@@ -171,16 +182,19 @@ export function findUnknownCoAuthors({commits = []}) {
 
     commits.forEach(({sha, subject, body, authorEmail}) => {
         const
-            // Map membership ONLY. An earlier revision also treated any `@neomjs.com` author as an
-            // agent, to stop a newly seeded seat from silently falling into the weak path. @neo-gpt
-            // falsified the inference: a commit's author email is SELF-ASSERTED metadata, not an
-            // authenticated account type, so "project domain therefore agent" both admits laundering
-            // and false-positives any human who ends up on the domain — and `bootstrapWorktree` binds
-            // an authenticated account's current primary email without requiring a map entry, so such
-            // a human is reachable rather than hypothetical. The ambiguous case is not guessed in
-            // either direction now; `findUnmappedProjectAuthors()` below turns it into an explicit,
-            // actionable failure instead.
-            agentAuthored = known.has((authorEmail || '').trim().toLowerCase()),
+            // Authenticated lane FIRST, commit metadata only as a fallback. `%ae` is self-asserted:
+            // `git commit --author='X <off-domain>'` rewrites it, and measured against the
+            // email-only classifier that one flag carried a poisoned trailer to exit 0. Where the
+            // caller can state the lane from an unforgeable source — checkout ownership at the hook,
+            // the GitHub-authenticated PR author in CI — that statement is the classification and
+            // the email is never consulted.
+            //
+            // Two earlier shapes were falsified rather than merely improved on, and both are worth
+            // not re-proposing: treating any `@neomjs.com` author as an agent (admits laundering AND
+            // false-positives a human bound to the domain), and refusing the unmapped project-domain
+            // case outright (a non-roster author must stay UNAFFECTED, and the seat gap that refusal
+            // protected is closed at the binder, which will not bind an unmapped seat at all).
+            agentAuthored = agentLane || known.has((authorEmail || '').trim().toLowerCase()),
             seen          = new Set();
         let match;
 
@@ -207,40 +221,18 @@ export function findUnknownCoAuthors({commits = []}) {
     return offenders
 }
 
-/**
- * @summary Finds commits authored from the project domain by an address this map does not carry.
+/*
+ * REMOVED: `findUnmappedProjectAuthors()`.
  *
- * **The ambiguous case, made explicit rather than guessed.** A `@neomjs.com` author that is not in
- * `EMAIL_BY_LOGIN` is one of two things, and nothing in the commit can tell them apart: a newly
- * seeded agent seat the map has not caught up with, or a human bound to the project domain by
- * `bootstrapWorktree`'s authenticated-account path, which does not require a map entry.
+ * It blocked a commit whose author was on the project domain but absent from the map, on the
+ * reasoning that the case is genuinely ambiguous and a named failure beats a silent guess. The
+ * reasoning was fine and the rule was wrong: a commit whose author is NOT a roster agent must stay
+ * **unaffected**, and a non-roster human on the project domain is exactly that. A reviewer caught
+ * that the check contradicted its own change's stated acceptance criterion — and that the real-git
+ * suite had a test PINNING the contradiction, which is how it survived a round of review.
  *
- * Classifying it either way is wrong. Calling it an agent false-positives the human and blocks the
- * outside collaborators they legitimately credit; calling it a non-agent drops it into the weak
- * domain-scoped path, where its off-domain trailers pass unseen — this gate's own failure mode.
- *
- * So it is neither. It is a **named, actionable failure**: add the seat to the map, or bypass
- * deliberately. The one-line fix is the point — an unknown seat should cost a map entry, not a
- * silent classification.
- *
- * `reconcileWithRegistry()` covers the same gap from the registry side and is asserted by spec, but
- * only for seats the registry already knows. A seat that commits before it is registered reaches
- * this check first.
- *
- * @param {Object}   args
- * @param {Object[]} args.commits `{sha, subject, authorEmail}` rows for the commits being pushed.
- * @returns {Array<{sha: String, subject: String, authorEmail: String}>} One row per commit.
+ * The gap it was covering — a newly seeded seat falling into the weak path — is closed upstream
+ * instead: `resolveAgentGitIdentity()` refuses to bind a Git identity for a seat with no roster
+ * address, so an unmapped agent never reaches a commit in the first place. Closing it at the binder
+ * costs no false positives; closing it at the guard cost one, aimed at humans.
  */
-export function findUnmappedProjectAuthors({commits = []}) {
-    const known = new Set(Object.values(EMAIL_BY_LOGIN).map(email => email.toLowerCase()));
-
-    return commits.reduce((rows, {sha, subject, authorEmail}) => {
-        const author = (authorEmail || '').trim().toLowerCase();
-
-        if (author.endsWith('@neomjs.com') && !known.has(author)) {
-            rows.push({sha, subject, authorEmail: author})
-        }
-
-        return rows
-    }, [])
-}

--- a/buildScripts/util/agentCoAuthorEmails.mjs
+++ b/buildScripts/util/agentCoAuthorEmails.mjs
@@ -100,16 +100,40 @@ export function reconcileWithRegistry() {
 /**
  * @summary Finds `Co-Authored-By` addresses that credit no known agent account.
  *
- * **Scoped to `@neomjs.com` by construction.** A trailer for a human contributor, an outside
- * collaborator, or a bot is out of scope and can never warn — the domain check is the boundary, not
- * a special case, so this guard cannot wall off someone whose address it was never meant to know.
+ * **The boundary is WHO AUTHORED the commit, not which domain the address is on.**
  *
- * Comparison is case-insensitive on the address. A known address returns nothing; anything else on
- * the project domain is reported with the commit that carries it.
+ * The first version of this check scoped itself to `@neomjs.com` so it could never wall off an
+ * outside contributor whose address it was never meant to know. That reasoning is right and is
+ * preserved below — but as the *only* boundary it was blind in exactly the direction that does
+ * harm. GitHub resolves a trailer by its EMAIL and credits whatever account owns it, so an
+ * off-domain address in a trailer credits a **real person**, and off-domain was the one thing the
+ * domain check could not see. Measured before this change: 16 commits in 36 hours credited two
+ * live human accounts, none of them a maintainer on this project, and the guard was silent on all
+ * of them while correctly reporting a harmless on-domain typo.
+ *
+ * So the rule is now asymmetric, and the asymmetry is the whole design:
+ *
+ * - **Author is a roster agent** → every trailer must be a roster address, *whatever the domain*.
+ *   An agent has no legitimate reason to credit an address this map does not carry, and the
+ *   addresses that cause damage are precisely the ones outside the project domain.
+ * - **Author is anyone else** → only the project domain is this map's business, exactly as before.
+ *   An outside contributor's commit is not agent-authored, so their trailers stay out of scope by
+ *   construction rather than by a domain heuristic that cannot tell a fabricated address from a
+ *   legitimate one.
+ *
+ * **Why this cannot be left to discipline.** The operator's own address is injected into every
+ * agent's context by the harness as a standing field. Any seat composing a trailer can reach for
+ * it, and three of them did. A rule that depends on no agent ever reaching for a value placed in
+ * front of every agent has already failed.
+ *
+ * Comparison is case-insensitive on the address. A known address returns nothing.
  *
  * @param {Object}   args
- * @param {Object[]} args.commits `{sha, subject, body}` rows for the commits being pushed.
- * @returns {Array<{sha: String, subject: String, email: String}>} One row per offending trailer.
+ * @param {Object[]} args.commits `{sha, subject, body, authorEmail}` rows for the commits being
+ * pushed. A missing `authorEmail` is treated as non-agent, keeping the pre-existing domain-scoped
+ * behaviour for any caller that has not been updated — this check degrades quiet, never loud.
+ * @returns {Array<{sha: String, subject: String, email: String, agentAuthored: Boolean}>} One row
+ * per offending trailer. `agentAuthored` is what the caller escalates on.
  */
 export function findUnknownCoAuthors({commits = []}) {
     const
@@ -117,22 +141,29 @@ export function findUnknownCoAuthors({commits = []}) {
         trailer   = /^\s*co-authored-by:\s*.*?<([^>]+)>\s*$/gim,
         offenders = [];
 
-    commits.forEach(({sha, subject, body}) => {
-        const seen = new Set();
-        let   match;
+    commits.forEach(({sha, subject, body, authorEmail}) => {
+        const
+            agentAuthored = known.has((authorEmail || '').trim().toLowerCase()),
+            seen          = new Set();
+        let match;
 
         trailer.lastIndex = 0;
 
         while ((match = trailer.exec(body || '')) !== null) {
             const email = match[1].trim().toLowerCase();
 
-            // Only the project domain is this map's business — see the scoping note above.
-            if (!email.endsWith('@neomjs.com') || known.has(email) || seen.has(email)) {
+            if (known.has(email) || seen.has(email)) {
+                continue
+            }
+
+            // Non-agent authors keep the original domain boundary; agent authors have none, because
+            // the off-domain address is the one that credits a person.
+            if (!agentAuthored && !email.endsWith('@neomjs.com')) {
                 continue
             }
 
             seen.add(email);
-            offenders.push({sha, subject, email})
+            offenders.push({sha, subject, email, agentAuthored})
         }
     });
 

--- a/buildScripts/util/agentCoAuthorEmails.mjs
+++ b/buildScripts/util/agentCoAuthorEmails.mjs
@@ -142,16 +142,17 @@ export function findUnknownCoAuthors({commits = []}) {
         offenders = [];
 
     commits.forEach(({sha, subject, body, authorEmail}) => {
-        const author = (authorEmail || '').trim().toLowerCase(),
-            // The map is the precise set, but keying ONLY on it degrades silently for a seat that
-            // reaches the registry before this map catches up: an unmapped agent would fall back to
-            // the weaker domain rule and its off-domain trailers would pass. The project domain
-            // closes that, and is safe to widen to — every distinct `@neomjs.com` author across the
-            // whole history resolves to one of the ten addresses below, and the registry types the
-            // human operator as `accountType: 'human'` while deliberately carrying no address for
-            // them, so no human commits from this domain. `reconcileWithRegistry()` still reports an
-            // unmapped seat; this only stops that gap from being silent in the meantime.
-            agentAuthored = known.has(author) || author.endsWith('@neomjs.com'),
+        const
+            // Map membership ONLY. An earlier revision also treated any `@neomjs.com` author as an
+            // agent, to stop a newly seeded seat from silently falling into the weak path. @neo-gpt
+            // falsified the inference: a commit's author email is SELF-ASSERTED metadata, not an
+            // authenticated account type, so "project domain therefore agent" both admits laundering
+            // and false-positives any human who ends up on the domain — and `bootstrapWorktree` binds
+            // an authenticated account's current primary email without requiring a map entry, so such
+            // a human is reachable rather than hypothetical. The ambiguous case is not guessed in
+            // either direction now; `findUnmappedProjectAuthors()` below turns it into an explicit,
+            // actionable failure instead.
+            agentAuthored = known.has((authorEmail || '').trim().toLowerCase()),
             seen          = new Set();
         let match;
 
@@ -176,4 +177,42 @@ export function findUnknownCoAuthors({commits = []}) {
     });
 
     return offenders
+}
+
+/**
+ * @summary Finds commits authored from the project domain by an address this map does not carry.
+ *
+ * **The ambiguous case, made explicit rather than guessed.** A `@neomjs.com` author that is not in
+ * `EMAIL_BY_LOGIN` is one of two things, and nothing in the commit can tell them apart: a newly
+ * seeded agent seat the map has not caught up with, or a human bound to the project domain by
+ * `bootstrapWorktree`'s authenticated-account path, which does not require a map entry.
+ *
+ * Classifying it either way is wrong. Calling it an agent false-positives the human and blocks the
+ * outside collaborators they legitimately credit; calling it a non-agent drops it into the weak
+ * domain-scoped path, where its off-domain trailers pass unseen — this gate's own failure mode.
+ *
+ * So it is neither. It is a **named, actionable failure**: add the seat to the map, or bypass
+ * deliberately. The one-line fix is the point — an unknown seat should cost a map entry, not a
+ * silent classification.
+ *
+ * `reconcileWithRegistry()` covers the same gap from the registry side and is asserted by spec, but
+ * only for seats the registry already knows. A seat that commits before it is registered reaches
+ * this check first.
+ *
+ * @param {Object}   args
+ * @param {Object[]} args.commits `{sha, subject, authorEmail}` rows for the commits being pushed.
+ * @returns {Array<{sha: String, subject: String, authorEmail: String}>} One row per commit.
+ */
+export function findUnmappedProjectAuthors({commits = []}) {
+    const known = new Set(Object.values(EMAIL_BY_LOGIN).map(email => email.toLowerCase()));
+
+    return commits.reduce((rows, {sha, subject, authorEmail}) => {
+        const author = (authorEmail || '').trim().toLowerCase();
+
+        if (author.endsWith('@neomjs.com') && !known.has(author)) {
+            rows.push({sha, subject, authorEmail: author})
+        }
+
+        return rows
+    }, [])
 }

--- a/buildScripts/util/agentCoAuthorEmails.mjs
+++ b/buildScripts/util/agentCoAuthorEmails.mjs
@@ -142,8 +142,16 @@ export function findUnknownCoAuthors({commits = []}) {
         offenders = [];
 
     commits.forEach(({sha, subject, body, authorEmail}) => {
-        const
-            agentAuthored = known.has((authorEmail || '').trim().toLowerCase()),
+        const author = (authorEmail || '').trim().toLowerCase(),
+            // The map is the precise set, but keying ONLY on it degrades silently for a seat that
+            // reaches the registry before this map catches up: an unmapped agent would fall back to
+            // the weaker domain rule and its off-domain trailers would pass. The project domain
+            // closes that, and is safe to widen to — every distinct `@neomjs.com` author across the
+            // whole history resolves to one of the ten addresses below, and the registry types the
+            // human operator as `accountType: 'human'` while deliberately carrying no address for
+            // them, so no human commits from this domain. `reconcileWithRegistry()` still reports an
+            // unmapped seat; this only stops that gap from being silent in the meantime.
+            agentAuthored = known.has(author) || author.endsWith('@neomjs.com'),
             seen          = new Set();
         let match;
 

--- a/buildScripts/util/agentCoAuthorEmails.mjs
+++ b/buildScripts/util/agentCoAuthorEmails.mjs
@@ -51,6 +51,34 @@ const EMAIL_BY_LOGIN = Object.freeze({
 });
 
 /**
+ * @summary The commit address this roster binds to one agent login, or `null` when unmapped.
+ *
+ * **This is the seam that makes the trailer check sound rather than inferential.** The push-time
+ * guard can only read a commit's author email, which is self-asserted metadata — so on its own it
+ * has to infer agent-ness from email shape, and @neo-gpt falsified that inference in both
+ * directions. `bootstrapWorktree` is the one place that holds *authenticated* identity: it has
+ * already matched `NEO_AGENT_IDENTITY` against the registry and the live GitHub login before it
+ * binds a Git author email. Asserting there that the authenticated primary IS this address closes
+ * the gap the guard cannot close by itself — an agent seat can no longer end up authoring from an
+ * address outside this map, so the guard's shape-based classification stops being a guess and
+ * becomes a property the bootstrap guarantees.
+ *
+ * Exported rather than inlined so the two cannot drift: one map, read by the binder and the guard.
+ *
+ * @param {String} login GitHub login, with or without the leading `@`.
+ * @returns {String|null} Lower-cased commit address, or `null` for a login this map does not carry.
+ */
+export function rosterEmailForLogin(login) {
+    const normalized = typeof login === 'string' ? login.trim().toLowerCase() : '';
+
+    if (!normalized) {
+        return null
+    }
+
+    return EMAIL_BY_LOGIN[normalized.startsWith('@') ? normalized : `@${normalized}`] ?? null
+}
+
+/**
  * @summary Agent logins in the registry, so a typo or a newly seeded seat cannot pass unnoticed.
  *
  * Filtered on `accountType === 'agent'`, not on the `AgentIdentity` node type: the registry types

--- a/buildScripts/util/check-commit-authorship.mjs
+++ b/buildScripts/util/check-commit-authorship.mjs
@@ -1,6 +1,6 @@
 import {execSync}             from 'node:child_process';
 import {readFileSync}         from 'node:fs';
-import {findUnknownCoAuthors, findUnmappedProjectAuthors} from './agentCoAuthorEmails.mjs';
+import {findUnknownCoAuthors, rosterEmailForLogin} from './agentCoAuthorEmails.mjs';
 import path                   from 'node:path';
 import process                from 'node:process';
 
@@ -175,8 +175,36 @@ const ranges = pendingRanges(payload);
 // whether an address exists, and that gate answers a different question (operator identity leak).
 // Advisory in both directions: an unrecognized address warns, an unreadable map stays silent, and
 // neither can block. See ./agentCoAuthorEmails.mjs for why the addresses are a map and not derived.
-let unknownCoAuthors = [],
-    unmappedAuthors  = [];
+/**
+ * @summary Whether these commits are being pushed on an agent lane, from a source the committer
+ * cannot forge.
+ *
+ * **This exists because `%ae` is not an identity.** `git commit --author='X <off-domain>'` rewrites
+ * the author on a single commit, and against an email-only classifier that one flag carried a
+ * poisoned trailer straight to exit 0 — measured. So the classification cannot come from inside the
+ * commit; it has to come from something the commit's author did not write.
+ *
+ * Two unforgeable sources, one per caller:
+ *
+ * - **Hook**: checkout ownership. A linked worktree or an `NEO_AGENT_IDENTITY` pin means an agent is
+ *   pushing, whatever any individual commit claims about itself.
+ * - **CI**: `--author-login`, which the workflow fills from the GitHub-authenticated PR author. A PR
+ *   cannot forge who opened it.
+ *
+ * Neither is available to the other, which is why both exist rather than one.
+ *
+ * @returns {Boolean}
+ */
+function isAuthenticatedAgentLane() {
+    const loginIndex = process.argv.indexOf('--author-login'),
+        login        = loginIndex === -1 ? '' : (process.argv[loginIndex + 1] || '');
+
+    return isAgentCheckout() || Boolean(rosterEmailForLogin(login))
+}
+
+const agentLane = isAuthenticatedAgentLane();
+
+let unknownCoAuthors = [];
 
 try {
     const commits = ranges.flatMap(range => {
@@ -190,32 +218,12 @@ try {
         }).filter(Boolean) : []
     });
 
-    unknownCoAuthors = findUnknownCoAuthors({commits});
-    unmappedAuthors  = findUnmappedProjectAuthors({commits})
+    unknownCoAuthors = findUnknownCoAuthors({agentLane, commits})
 } catch {
     // Fail open on INPUT failure only: a missing registry, an unreadable map, or a malformed log
     // must never block a push. A trailer this successfully read and rejected is a different matter,
     // handled below — swallowing that was how 16 mis-credited commits shipped.
-    unknownCoAuthors = [];
-    unmappedAuthors  = []
-}
-
-// A project-domain author this map does not carry is deliberately NOT classified as agent or human
-// — see findUnmappedProjectAuthors. It blocks, because the one-line fix is adding the seat, and
-// either guess is a way for this gate to fail silently.
-if (unmappedAuthors.length > 0) {
-    console.error(`\x1b[31mcheck-commit-authorship: ${unmappedAuthors.length} commit(s) authored from the project domain by an address no agent seat owns:\x1b[0m`);
-    unmappedAuthors.forEach(({sha, subject, authorEmail}) => console.error(`  ${sha.slice(0, 10)}  <${authorEmail}>  ${subject}`));
-    console.error(`
-This address is on @neomjs.com but is not in EMAIL_BY_LOGIN, so this check cannot tell a newly
-seeded agent seat from a human bound to the domain — and guessing either way breaks something. An
-agent guess blocks the outside collaborators a human legitimately credits; a human guess drops the
-commit into the domain-scoped path where its off-domain co-author trailers pass unseen.
-
-Add the seat to buildScripts/util/agentCoAuthorEmails.mjs with its occurrence count, or bypass
-deliberately if this is a one-off human commit: git push --no-verify
-`);
-    process.exit(1)
+    unknownCoAuthors = []
 }
 
 // Agent-authored offenders BLOCK. Anything else stays advisory, because a non-agent commit's

--- a/buildScripts/util/check-commit-authorship.mjs
+++ b/buildScripts/util/check-commit-authorship.mjs
@@ -1,6 +1,6 @@
 import {execSync}             from 'node:child_process';
 import {readFileSync}         from 'node:fs';
-import {findUnknownCoAuthors} from './agentCoAuthorEmails.mjs';
+import {findUnknownCoAuthors, findUnmappedProjectAuthors} from './agentCoAuthorEmails.mjs';
 import path                   from 'node:path';
 import process                from 'node:process';
 
@@ -175,7 +175,8 @@ const ranges = pendingRanges(payload);
 // whether an address exists, and that gate answers a different question (operator identity leak).
 // Advisory in both directions: an unrecognized address warns, an unreadable map stays silent, and
 // neither can block. See ./agentCoAuthorEmails.mjs for why the addresses are a map and not derived.
-let unknownCoAuthors = [];
+let unknownCoAuthors = [],
+    unmappedAuthors  = [];
 
 try {
     const commits = ranges.flatMap(range => {
@@ -189,12 +190,32 @@ try {
         }).filter(Boolean) : []
     });
 
-    unknownCoAuthors = findUnknownCoAuthors({commits})
+    unknownCoAuthors = findUnknownCoAuthors({commits});
+    unmappedAuthors  = findUnmappedProjectAuthors({commits})
 } catch {
     // Fail open on INPUT failure only: a missing registry, an unreadable map, or a malformed log
     // must never block a push. A trailer this successfully read and rejected is a different matter,
     // handled below — swallowing that was how 16 mis-credited commits shipped.
-    unknownCoAuthors = []
+    unknownCoAuthors = [];
+    unmappedAuthors  = []
+}
+
+// A project-domain author this map does not carry is deliberately NOT classified as agent or human
+// — see findUnmappedProjectAuthors. It blocks, because the one-line fix is adding the seat, and
+// either guess is a way for this gate to fail silently.
+if (unmappedAuthors.length > 0) {
+    console.error(`\x1b[31mcheck-commit-authorship: ${unmappedAuthors.length} commit(s) authored from the project domain by an address no agent seat owns:\x1b[0m`);
+    unmappedAuthors.forEach(({sha, subject, authorEmail}) => console.error(`  ${sha.slice(0, 10)}  <${authorEmail}>  ${subject}`));
+    console.error(`
+This address is on @neomjs.com but is not in EMAIL_BY_LOGIN, so this check cannot tell a newly
+seeded agent seat from a human bound to the domain — and guessing either way breaks something. An
+agent guess blocks the outside collaborators a human legitimately credits; a human guess drops the
+commit into the domain-scoped path where its off-domain co-author trailers pass unseen.
+
+Add the seat to buildScripts/util/agentCoAuthorEmails.mjs with its occurrence count, or bypass
+deliberately if this is a one-off human commit: git push --no-verify
+`);
+    process.exit(1)
 }
 
 // Agent-authored offenders BLOCK. Anything else stays advisory, because a non-agent commit's

--- a/buildScripts/util/check-commit-authorship.mjs
+++ b/buildScripts/util/check-commit-authorship.mjs
@@ -175,32 +175,64 @@ const ranges = pendingRanges(payload);
 // whether an address exists, and that gate answers a different question (operator identity leak).
 // Advisory in both directions: an unrecognized address warns, an unreadable map stays silent, and
 // neither can block. See ./agentCoAuthorEmails.mjs for why the addresses are a map and not derived.
+let unknownCoAuthors = [];
+
 try {
     const commits = ranges.flatMap(range => {
         // \x1f between fields, \x1e between records: a commit body carries newlines and tabs, so
         // line-splitting the log would truncate the very trailer block this needs to read.
-        const log = tryExec(`git log ${range} --format=%H%x1f%s%x1f%B%x1e`);
+        const log = tryExec(`git log ${range} --format=%H%x1f%ae%x1f%s%x1f%B%x1e`);
 
         return log ? log.split('\x1e').map(entry => {
-            const [sha, subject, body] = entry.replace(/^\n+/, '').split('\x1f');
-            return sha ? {sha, subject, body} : null
+            const [sha, authorEmail, subject, body] = entry.replace(/^\n+/, '').split('\x1f');
+            return sha ? {sha, authorEmail, subject, body} : null
         }).filter(Boolean) : []
     });
 
-    const unknownCoAuthors = findUnknownCoAuthors({commits});
-
-    if (unknownCoAuthors.length > 0) {
-        console.warn(`\x1b[33mWarning: ${unknownCoAuthors.length} Co-Authored-By trailer(s) credit an address that belongs to no known agent account.\x1b[0m`);
-        unknownCoAuthors.forEach(({sha, subject, email}) => console.warn(`  ${sha.slice(0, 10)}  <${email}>  ${subject}`));
-        console.warn('');
-        console.warn('GitHub resolves trailers by email, so an unknown address credits nobody — the co-author');
-        console.warn('is silently dropped from the contribution record with nothing failing.');
-        console.warn('Addresses cannot be derived from a handle: three logins do not match their local part.');
-        console.warn('Look the address up in buildScripts/util/agentCoAuthorEmails.mjs, or add the seat there.');
-        console.warn('This is advisory — the push proceeds.')
-    }
+    unknownCoAuthors = findUnknownCoAuthors({commits})
 } catch {
-    // Fail open: a missing registry, an unreadable map, or a malformed log must never block a push.
+    // Fail open on INPUT failure only: a missing registry, an unreadable map, or a malformed log
+    // must never block a push. A trailer this successfully read and rejected is a different matter,
+    // handled below — swallowing that was how 16 mis-credited commits shipped.
+    unknownCoAuthors = []
+}
+
+// Agent-authored offenders BLOCK. Anything else stays advisory, because a non-agent commit's
+// trailers are not this map's business and refusing them would wall off an outside contributor.
+const
+    creditsAPerson = unknownCoAuthors.filter(offender => offender.agentAuthored),
+    advisoryOnly   = unknownCoAuthors.filter(offender => !offender.agentAuthored);
+
+if (advisoryOnly.length > 0) {
+    console.warn(`\x1b[33mWarning: ${advisoryOnly.length} Co-Authored-By trailer(s) credit an address that belongs to no known agent account.\x1b[0m`);
+    advisoryOnly.forEach(({sha, subject, email}) => console.warn(`  ${sha.slice(0, 10)}  <${email}>  ${subject}`));
+    console.warn('');
+    console.warn('GitHub resolves trailers by email, so an unknown address credits nobody — the co-author');
+    console.warn('is silently dropped from the contribution record with nothing failing.');
+    console.warn('Look the address up in buildScripts/util/agentCoAuthorEmails.mjs, or add the seat there.');
+    console.warn('This commit is not agent-authored, so this is advisory — the push proceeds.')
+}
+
+if (creditsAPerson.length > 0) {
+    console.error(`\x1b[31mcheck-commit-authorship: ${creditsAPerson.length} Co-Authored-By trailer(s) on agent-authored commit(s) name an address no agent seat owns:\x1b[0m`);
+    creditsAPerson.forEach(({sha, subject, email}) => console.error(`  ${sha.slice(0, 10)}  <${email}>  ${subject}`));
+    console.error(`
+GitHub resolves a co-author trailer by its EMAIL and credits whatever account owns that address.
+The display name in the trailer is cosmetic. An address outside this project therefore credits a
+REAL PERSON for work they did not do — which is why this blocks rather than warns, and why the
+check is not limited to the project domain: off-domain is precisely where a person's account is.
+
+Addresses cannot be derived from a handle or a display name. Three logins do not match their email
+local part, so deriving is guaranteed wrong for them. Read the address from EMAIL_BY_LOGIN in
+buildScripts/util/agentCoAuthorEmails.mjs, add the seat there, or omit the trailer entirely.
+
+To repair the commits before pushing:
+
+  git rebase origin/dev --exec 'git commit --amend --no-edit'   # drop the trailer in the editor
+
+Bypass (an operator genuinely crediting an outside collaborator): git push --no-verify
+`);
+    process.exit(1)
 }
 
 // From here on: the operator-identity leak guard, which IS scoped to agent checkouts.

--- a/test/playwright/unit/ai/buildScripts/util/agentCoAuthorEmails.spec.mjs
+++ b/test/playwright/unit/ai/buildScripts/util/agentCoAuthorEmails.spec.mjs
@@ -3,6 +3,7 @@ import {
     findUnknownCoAuthors,
     findUnmappedProjectAuthors,
     mismatchedLogins,
+    rosterEmailForLogin,
     reconcileWithRegistry,
     registryAgentLogins
 }                      from '../../../../../../buildScripts/util/agentCoAuthorEmails.mjs';
@@ -224,6 +225,40 @@ test.describe('buildScripts/util/agentCoAuthorEmails (#16280)', () => {
 
             expect(findUnknownCoAuthors({commits: [commit(body)]})).toEqual([]);
         });
+    });
+
+    /**
+     * The seam `bootstrapWorktree` reads to assert an agent's authenticated primary IS its roster
+     * address. That assertion is what turns the push-time guard's shape-based classification from an
+     * inference into a property — so this lookup is load-bearing for the guard, not a convenience.
+     */
+    test.describe('rosterEmailForLogin — the binder/guard shared seam', () => {
+        test('resolves a mapped seat with or without the leading @', () => {
+            expect(rosterEmailForLogin('@neo-opus-ada')).toBe(CANONICAL);
+            expect(rosterEmailForLogin('neo-opus-ada')).toBe(CANONICAL);
+        });
+
+        test('is case-insensitive on the login', () => {
+            expect(rosterEmailForLogin('@Neo-Opus-Ada')).toBe(CANONICAL);
+        });
+
+        test('returns null for a login this map does not carry — the binder REFUSES on null', () => {
+            // Unreachable through configureAgentGitIdentity today (the registry lookup runs first and
+            // reconcileWithRegistry().missingEmail is empty), so it is pinned here where it is
+            // reachable. The branch exists against the registry and this map drifting apart.
+            expect(rosterEmailForLogin('@neo-not-a-seat')).toBeNull();
+        });
+
+        test('a missing or empty login cannot throw', () => {
+            expect(rosterEmailForLogin(undefined)).toBeNull();
+            expect(rosterEmailForLogin('   ')).toBeNull();
+        });
+
+        test('every registry agent login resolves — the binder can never hit its own null branch', () => {
+            // The invariant that keeps the null branch defensive rather than live. If this fails, a
+            // seat exists that bootstrapWorktree would now refuse to bind.
+            expect(registryAgentLogins().filter(login => !rosterEmailForLogin(login))).toEqual([]);
+        })
     });
 
     test('the sunset condition is measurable, not aspirational', () => {

--- a/test/playwright/unit/ai/buildScripts/util/agentCoAuthorEmails.spec.mjs
+++ b/test/playwright/unit/ai/buildScripts/util/agentCoAuthorEmails.spec.mjs
@@ -1,6 +1,7 @@
 import { test, expect } from '@playwright/test';
 import {
     findUnknownCoAuthors,
+    findUnmappedProjectAuthors,
     mismatchedLogins,
     reconcileWithRegistry,
     registryAgentLogins
@@ -137,16 +138,53 @@ test.describe('buildScripts/util/agentCoAuthorEmails (#16280)', () => {
             })).toEqual([]);
         });
 
-        test('a project-domain author NOT YET in the map still counts as an agent', () => {
-            // Keying only on the map would let a newly seeded seat fall back to the weaker domain
-            // rule and pass its off-domain trailers silently, in the window before the map catches
-            // up. Safe to widen: every `@neomjs.com` author in history is a roster seat, and the
-            // registry types the operator `human` with no project-domain address.
+        test('a project-domain author NOT in the map is not classified as an agent either', () => {
+            // An earlier revision widened `agentAuthored` to the whole project domain, to stop a
+            // newly seeded seat falling into the weak path. @neo-gpt falsified the inference: author
+            // email is self-asserted metadata, not an authenticated account type, so the domain
+            // cannot stand in for one. The ambiguous case is routed to findUnmappedProjectAuthors
+            // rather than guessed — see the block below.
             const body = `msg\n\nCo-Authored-By: Someone <${OFF_DOMAIN}>`;
 
             expect(findUnknownCoAuthors({
                 commits: [{sha: 'e'.repeat(40), subject: 's', body, authorEmail: 'neo-newly-seeded@neomjs.com'}]
-            }).map(offender => offender.email)).toEqual([OFF_DOMAIN]);
+            })).toEqual([]);
+        });
+    });
+
+    /**
+     * The case that cannot be classified from the commit alone: a project-domain address the map
+     * does not carry is either a newly seeded agent seat or a human bound to the domain by the
+     * bootstrap's authenticated-account path. Guessing agent false-positives the human; guessing
+     * human drops the commit into the weak path. So it is neither — it is a named failure.
+     */
+    test.describe('unmapped project-domain authors are refused rather than guessed', () => {
+        test('flags a project-domain author the map does not carry', () => {
+            expect(findUnmappedProjectAuthors({
+                commits: [{sha: 'f'.repeat(40), subject: 's', authorEmail: 'neo-newly-seeded@neomjs.com'}]
+            }).map(row => row.authorEmail)).toEqual(['neo-newly-seeded@neomjs.com']);
+        });
+
+        test('POSITIVE CONTROL — a mapped seat is silent', () => {
+            expect(findUnmappedProjectAuthors({
+                commits: [{sha: 'f'.repeat(40), subject: 's', authorEmail: CANONICAL}]
+            })).toEqual([]);
+        });
+
+        test('an OFF-DOMAIN author is not this function\'s business — outside contributors pass', () => {
+            expect(findUnmappedProjectAuthors({
+                commits: [{sha: 'f'.repeat(40), subject: 's', authorEmail: 'outsider@example.org'}]
+            })).toEqual([]);
+        });
+
+        test('matches the domain case-insensitively', () => {
+            expect(findUnmappedProjectAuthors({
+                commits: [{sha: 'f'.repeat(40), subject: 's', authorEmail: 'Neo-Newly-Seeded@NeoMjs.com'}]
+            })).toHaveLength(1);
+        });
+
+        test('a missing author email cannot throw', () => {
+            expect(findUnmappedProjectAuthors({commits: [{sha: 'f'.repeat(40), subject: 's'}]})).toEqual([]);
         });
     });
 

--- a/test/playwright/unit/ai/buildScripts/util/agentCoAuthorEmails.spec.mjs
+++ b/test/playwright/unit/ai/buildScripts/util/agentCoAuthorEmails.spec.mjs
@@ -1,7 +1,6 @@
 import { test, expect } from '@playwright/test';
 import {
     findUnknownCoAuthors,
-    findUnmappedProjectAuthors,
     mismatchedLogins,
     rosterEmailForLogin,
     reconcileWithRegistry,
@@ -139,12 +138,12 @@ test.describe('buildScripts/util/agentCoAuthorEmails (#16280)', () => {
             })).toEqual([]);
         });
 
-        test('a project-domain author NOT in the map is not classified as an agent either', () => {
-            // An earlier revision widened `agentAuthored` to the whole project domain, to stop a
-            // newly seeded seat falling into the weak path. @neo-gpt falsified the inference: author
-            // email is self-asserted metadata, not an authenticated account type, so the domain
-            // cannot stand in for one. The ambiguous case is routed to findUnmappedProjectAuthors
-            // rather than guessed — see the block below.
+        test('a project-domain author NOT in the map is UNAFFECTED — #17195 AC-3', () => {
+            // Two rules died here, in order. First: treating any `@neomjs.com` author as an agent —
+            // self-asserted email is not an account type. Then: refusing the unmapped case outright,
+            // which @neo-gpt caught as a violation of this PR's own AC-3 ("a commit whose author is
+            // NOT a roster agent is unaffected"). A non-roster human on the project domain is
+            // exactly that, and the seat gap the refusal covered is closed at the binder instead.
             const body = `msg\n\nCo-Authored-By: Someone <${OFF_DOMAIN}>`;
 
             expect(findUnknownCoAuthors({
@@ -154,39 +153,41 @@ test.describe('buildScripts/util/agentCoAuthorEmails (#16280)', () => {
     });
 
     /**
-     * The case that cannot be classified from the commit alone: a project-domain address the map
-     * does not carry is either a newly seeded agent seat or a human bound to the domain by the
-     * bootstrap's authenticated-account path. Guessing agent false-positives the human; guessing
-     * human drops the commit into the weak path. So it is neither — it is a named failure.
+     * `%ae` is not an identity — `git commit --author='X <off-domain>'` rewrites it, and against an
+     * email-only classifier that one flag carried a poisoned trailer to exit 0. So the classification
+     * has to come from something the commit's author did not write.
      */
-    test.describe('unmapped project-domain authors are refused rather than guessed', () => {
-        test('flags a project-domain author the map does not carry', () => {
-            expect(findUnmappedProjectAuthors({
-                commits: [{sha: 'f'.repeat(40), subject: 's', authorEmail: 'neo-newly-seeded@neomjs.com'}]
-            }).map(row => row.authorEmail)).toEqual(['neo-newly-seeded@neomjs.com']);
+    test.describe('an authenticated lane overrides the commit author entirely', () => {
+        const OFF_DOMAIN = 'real.person@example.com';
+
+        test('agentLane classifies an OFF-DOMAIN author as an agent — the --author bypass', () => {
+            const body = `msg\n\nCo-Authored-By: Someone <${OFF_DOMAIN}>`;
+
+            expect(findUnknownCoAuthors({
+                agentLane: true,
+                commits  : [{sha: 'g'.repeat(40), subject: 's', body, authorEmail: 'off-domain@example.com'}]
+            }).map(offender => offender.email)).toEqual([OFF_DOMAIN]);
         });
 
-        test('POSITIVE CONTROL — a mapped seat is silent', () => {
-            expect(findUnmappedProjectAuthors({
-                commits: [{sha: 'f'.repeat(40), subject: 's', authorEmail: CANONICAL}]
+        test('POSITIVE CONTROL — agentLane still admits a roster trailer', () => {
+            expect(findUnknownCoAuthors({
+                agentLane: true,
+                commits  : [{sha: 'g'.repeat(40), subject: 's', body: `msg\n\nCo-Authored-By: V <${CANONICAL}>`, authorEmail: 'off-domain@example.com'}]
             })).toEqual([]);
         });
 
-        test('an OFF-DOMAIN author is not this function\'s business — outside contributors pass', () => {
-            expect(findUnmappedProjectAuthors({
-                commits: [{sha: 'f'.repeat(40), subject: 's', authorEmail: 'outsider@example.org'}]
+        test('WITHOUT agentLane the same commit is unaffected — the bypass, pinned', () => {
+            // The regression fixture: this is what exit 0 looked like before the lane input existed.
+            const body = `msg\n\nCo-Authored-By: Someone <${OFF_DOMAIN}>`;
+
+            expect(findUnknownCoAuthors({
+                commits: [{sha: 'g'.repeat(40), subject: 's', body, authorEmail: 'off-domain@example.com'}]
             })).toEqual([]);
         });
 
-        test('matches the domain case-insensitively', () => {
-            expect(findUnmappedProjectAuthors({
-                commits: [{sha: 'f'.repeat(40), subject: 's', authorEmail: 'Neo-Newly-Seeded@NeoMjs.com'}]
-            })).toHaveLength(1);
-        });
-
-        test('a missing author email cannot throw', () => {
-            expect(findUnmappedProjectAuthors({commits: [{sha: 'f'.repeat(40), subject: 's'}]})).toEqual([]);
-        });
+        test('agentLane defaults false, so an un-updated caller cannot start failing', () => {
+            expect(findUnknownCoAuthors({commits: [{sha: 'h'.repeat(40), subject: 's', body: 'no trailer'}]})).toEqual([]);
+        })
     });
 
     test.describe('parsing', () => {

--- a/test/playwright/unit/ai/buildScripts/util/agentCoAuthorEmails.spec.mjs
+++ b/test/playwright/unit/ai/buildScripts/util/agentCoAuthorEmails.spec.mjs
@@ -68,10 +68,73 @@ test.describe('buildScripts/util/agentCoAuthorEmails (#16280)', () => {
             expect(findUnknownCoAuthors({commits: [commit(body)]})).toEqual([]);
         });
 
-        test('an unknown address ON the project domain does warn — the boundary is the domain', () => {
+        test('an unknown address ON the project domain does warn — the domain boundary still holds for non-agent commits', () => {
             const found = findUnknownCoAuthors({commits: [commit('msg\n\nCo-authored-by: Ghost <nobody@neomjs.com>')]});
 
             expect(found.map(o => o.email)).toEqual(['nobody@neomjs.com']);
+        });
+    });
+
+    /**
+     * The domain boundary above is correct for a commit anyone might author, and was the ONLY
+     * boundary until 16 commits in 36 hours credited two live human accounts through it. GitHub
+     * resolves a trailer by its email, so an off-domain address credits a real person — and
+     * off-domain was exactly what the domain check could not see.
+     */
+    test.describe('agent-authored commits have no domain boundary — the case that shipped', () => {
+        const
+            OFF_DOMAIN  = 'real.person@example.com',
+            agentCommit = (body, sha = 'c'.repeat(40)) =>
+                ({sha, subject: 'subject', body, authorEmail: CANONICAL});
+
+        test('an off-domain trailer on an agent-authored commit IS flagged', () => {
+            // The regression fixture. Under the domain-scoped predicate this returned [] — the
+            // shape that let a real account be credited on every push without a word.
+            const found = findUnknownCoAuthors({
+                commits: [agentCommit(`msg\n\nCo-Authored-By: Some Agent <${OFF_DOMAIN}>`)]
+            });
+
+            expect(found.map(offender => offender.email)).toEqual([OFF_DOMAIN]);
+        });
+
+        test('it is marked agentAuthored, which is what the caller blocks on', () => {
+            const [offender] = findUnknownCoAuthors({
+                commits: [agentCommit(`msg\n\nCo-Authored-By: Some Agent <${OFF_DOMAIN}>`)]
+            });
+
+            expect(offender.agentAuthored).toBe(true);
+        });
+
+        test('a trailer whose DISPLAY NAME is an agent cannot launder the address', () => {
+            // The exact shape that did the damage: the trailer reads as a seat crediting itself
+            // while the address credits someone else. The name is never consulted.
+            const found = findUnknownCoAuthors({
+                commits: [agentCommit(`msg\n\nCo-Authored-By: Neo Opus Vega <${OFF_DOMAIN}>`)]
+            });
+
+            expect(found.map(offender => offender.email)).toEqual([OFF_DOMAIN]);
+        });
+
+        test('POSITIVE CONTROL — a roster address on an agent commit stays silent', () => {
+            expect(findUnknownCoAuthors({
+                commits: [agentCommit(`msg\n\nCo-Authored-By: Grace <neo-claude-opus@neomjs.com>`)]
+            })).toEqual([]);
+        });
+
+        test('the SAME off-domain trailer on a non-agent commit still never warns', () => {
+            // The property the domain scoping existed to protect, kept intact rather than assumed:
+            // an outside contributor is not agent-authored, so nothing about them is in scope.
+            expect(findUnknownCoAuthors({
+                commits: [commit(`msg\n\nCo-Authored-By: Some Person <${OFF_DOMAIN}>`)]
+            })).toEqual([]);
+        });
+
+        test('an unrecognised author email is treated as non-agent, so the check degrades quiet', () => {
+            const body = `msg\n\nCo-Authored-By: Someone <${OFF_DOMAIN}>`;
+
+            expect(findUnknownCoAuthors({
+                commits: [{sha: 'd'.repeat(40), subject: 's', body, authorEmail: 'stranger@example.org'}]
+            })).toEqual([]);
         });
     });
 

--- a/test/playwright/unit/ai/buildScripts/util/agentCoAuthorEmails.spec.mjs
+++ b/test/playwright/unit/ai/buildScripts/util/agentCoAuthorEmails.spec.mjs
@@ -129,12 +129,24 @@ test.describe('buildScripts/util/agentCoAuthorEmails (#16280)', () => {
             })).toEqual([]);
         });
 
-        test('an unrecognised author email is treated as non-agent, so the check degrades quiet', () => {
+        test('an OFF-DOMAIN author is treated as non-agent, so the check degrades quiet', () => {
             const body = `msg\n\nCo-Authored-By: Someone <${OFF_DOMAIN}>`;
 
             expect(findUnknownCoAuthors({
                 commits: [{sha: 'd'.repeat(40), subject: 's', body, authorEmail: 'stranger@example.org'}]
             })).toEqual([]);
+        });
+
+        test('a project-domain author NOT YET in the map still counts as an agent', () => {
+            // Keying only on the map would let a newly seeded seat fall back to the weaker domain
+            // rule and pass its off-domain trailers silently, in the window before the map catches
+            // up. Safe to widen: every `@neomjs.com` author in history is a roster seat, and the
+            // registry types the operator `human` with no project-domain address.
+            const body = `msg\n\nCo-Authored-By: Someone <${OFF_DOMAIN}>`;
+
+            expect(findUnknownCoAuthors({
+                commits: [{sha: 'e'.repeat(40), subject: 's', body, authorEmail: 'neo-newly-seeded@neomjs.com'}]
+            }).map(offender => offender.email)).toEqual([OFF_DOMAIN]);
         });
     });
 

--- a/test/playwright/unit/buildScripts/checkCommitAuthorship.spec.mjs
+++ b/test/playwright/unit/buildScripts/checkCommitAuthorship.spec.mjs
@@ -321,18 +321,37 @@ test.describe('check-commit-authorship — the operator must not author from an 
             expect(runGuard(main, 'operator@example.com').status).toBe(0)
         });
 
-        test('BLOCKS a project-domain author the map does not carry, naming the seat', () => {
-            // Neither agent nor human can be established from the commit, so the guard refuses to
-            // guess and asks for a map entry instead.
+        test('a project-domain author the map does not carry is UNAFFECTED — #17195 AC-3', () => {
+            // This test previously asserted status 1 and PINNED a violation of the PR's own AC-3
+            // ("a commit whose author is NOT a roster agent is unaffected"). @neo-gpt caught both
+            // the rule and the test that made it durable. The seat gap the refusal was covering is
+            // closed at the binder, which will not bind an unmapped seat at all.
             const main = createMainCheckout();
 
             commitAs(main, {authorEmail: 'neo-unmapped-seat@neomjs.com', subject: 'feat: unknown seat'});
 
-            const result = runGuard(main, 'operator@example.com');
+            expect(runGuard(main, 'operator@example.com').status).toBe(0)
+        });
+
+        test('BLOCKS an --author override on an agent lane — %ae is not an identity', () => {
+            // The bypass, measured before the fix: one `git commit --author=` flag reclassified an
+            // agent as a human and carried a poisoned trailer to exit 0. The lane comes from
+            // checkout ownership here, which the committer cannot rewrite from inside a commit.
+            const
+                main = createMainCheckout(),
+                tree = path.join(tmpRoot, 'seat-lane');
+
+            git(main, ['worktree', 'add', '-b', 'agent/lane-override', tree, 'dev', '--quiet']);
+            fs.outputFileSync(path.join(tree, 'w.txt'), 'x\n');
+            git(tree, ['add', '.']);
+            git(tree, ['-c', `user.email=${ROSTER_AUTHOR}`, '-c', 'user.name=Ada', 'commit',
+                '--author', 'Ada <off-domain@example.com>',
+                '-m', `feat: laundered\n\nCo-Authored-By: Someone <${OFF_DOMAIN}>`, '--quiet', '--no-verify']);
+
+            const result = runGuard(tree, 'operator@example.com');
 
             expect(result.status).toBe(1);
-            expect(result.stderr).toContain('neo-unmapped-seat@neomjs.com');
-            expect(result.stderr).toContain('agentCoAuthorEmails.mjs')
+            expect(result.stderr).toContain(OFF_DOMAIN)
         });
 
         test('a clean agent commit with no trailer at all is silent', () => {

--- a/test/playwright/unit/buildScripts/checkCommitAuthorship.spec.mjs
+++ b/test/playwright/unit/buildScripts/checkCommitAuthorship.spec.mjs
@@ -165,7 +165,10 @@ test.describe('check-commit-authorship — the operator must not author from an 
         git(main, ['worktree', 'add', '-b', 'agent/lane', tree, 'dev', '--quiet']);
         fs.outputFileSync(path.join(tree, 'work.txt'), 'agent work\n');
         git(tree, ['add', '.']);
-        git(tree, ['-c', 'user.email=ada@neomjs.com', '-c', 'user.name=Ada',
+        // `neo-opus-4-7@` rather than `ada@`: the latter is the display-name DERIVATION that
+        // agentCoAuthorEmails.mjs documents as having produced 19 mis-credited commits, so a
+        // fixture calling it "authors correctly" quietly propagated the defect next door.
+        git(tree, ['-c', 'user.email=neo-opus-4-7@neomjs.com', '-c', 'user.name=Ada',
             'commit', '-m', 'feat: properly attributed work', '--quiet', '--no-verify']);
 
         const result = runGuard(tree, 'operator@example.com');
@@ -223,7 +226,7 @@ test.describe('check-commit-authorship — the operator must not author from an 
 
         // one bad commit in the middle: scanning only HEAD would miss it, and the real incident was
         // 38 commits deep across branches nobody re-read
-        [['ada@neomjs.com', 'feat: first'], ['operator@example.com', 'feat: the buried one'], ['ada@neomjs.com', 'feat: third']]
+        [['neo-opus-4-7@neomjs.com', 'feat: first'], ['operator@example.com', 'feat: the buried one'], ['neo-opus-4-7@neomjs.com', 'feat: third']]
             .forEach(([email, subject], index) => {
                 fs.outputFileSync(path.join(tree, `work-${index}.txt`), `${subject}\n`);
                 git(tree, ['add', '.']);
@@ -236,6 +239,109 @@ test.describe('check-commit-authorship — the operator must not author from an 
         expect(result.stderr).toContain('1 commit(s)');
         expect(result.stderr).toContain('feat: the buried one');
         expect(result.stderr).not.toContain('feat: first')
+    })
+
+    /**
+     * The co-author half of the same guard. It shares this file's discipline deliberately: the unit
+     * suite over `findUnknownCoAuthors` proves the PREDICATE, and only running the real script
+     * against a real repository proves the EXIT CODE, which is the part that actually stops a push.
+     * A predicate that returns offenders into a caller that warns is what shipped 16 mis-credited
+     * commits.
+     */
+    test.describe('co-author trailers — GitHub credits by address, so a wrong one credits a person', () => {
+        const
+            ROSTER_AUTHOR  = 'neo-opus-4-7@neomjs.com',
+            ROSTER_TRAILER = 'neo-opus-vega@neomjs.com',
+            OFF_DOMAIN     = 'real.person@example.com';
+
+        /**
+         * @summary Commits one file under an explicit author, with an optional trailer block.
+         * @param {String} cwd
+         * @param {Object} options
+         * @param {String} options.authorEmail
+         * @param {String} options.subject
+         * @param {String} [options.trailer]
+         */
+        function commitAs(cwd, {authorEmail, subject, trailer}) {
+            fs.outputFileSync(path.join(cwd, `${subject.replace(/\W+/gu, '-')}.txt`), 'x\n');
+            git(cwd, ['add', '.']);
+            git(cwd, ['commit', '-m', trailer ? `${subject}\n\n${trailer}` : subject, '--quiet', '--no-verify'], {
+                ...process.env,
+                GIT_AUTHOR_NAME    : 'Seat',
+                GIT_AUTHOR_EMAIL   : authorEmail,
+                GIT_COMMITTER_NAME : 'Seat',
+                GIT_COMMITTER_EMAIL: authorEmail
+            })
+        }
+
+        test('BLOCKS an agent-authored commit whose trailer address is off-domain', () => {
+            // The shipped defect, at the exit code rather than the predicate. Off-domain is where a
+            // real person's account lives, and the previous guard could not see it at all.
+            const main = createMainCheckout();
+
+            commitAs(main, {
+                authorEmail: ROSTER_AUTHOR,
+                subject    : 'feat: credits a person',
+                trailer    : `Co-Authored-By: Some Agent <${OFF_DOMAIN}>`
+            });
+
+            const result = runGuard(main, 'operator@example.com');
+
+            expect(result.status).toBe(1);
+            expect(result.stderr).toContain(OFF_DOMAIN);
+            expect(result.stderr).toContain('feat: credits a person')
+        });
+
+        test('SILENT when the same commit credits a roster address', () => {
+            // Without this control the assertion above would pass against a check that blocks
+            // every trailer.
+            const main = createMainCheckout();
+
+            commitAs(main, {
+                authorEmail: ROSTER_AUTHOR,
+                subject    : 'feat: credits a seat',
+                trailer    : `Co-Authored-By: Vega <${ROSTER_TRAILER}>`
+            });
+
+            expect(runGuard(main, 'operator@example.com').status).toBe(0)
+        });
+
+        test('does NOT block a NON-agent author carrying the very same off-domain trailer', () => {
+            // The property the domain scoping existed to protect. An outside contributor's commit is
+            // not agent-authored, so nothing about them is inspected — proved at the exit code, not
+            // inferred from the predicate.
+            const main = createMainCheckout();
+
+            commitAs(main, {
+                authorEmail: 'outsider@example.org',
+                subject    : 'feat: an outside contribution',
+                trailer    : `Co-Authored-By: Their Pair <${OFF_DOMAIN}>`
+            });
+
+            expect(runGuard(main, 'operator@example.com').status).toBe(0)
+        });
+
+        test('BLOCKS a project-domain author the map does not carry, naming the seat', () => {
+            // Neither agent nor human can be established from the commit, so the guard refuses to
+            // guess and asks for a map entry instead.
+            const main = createMainCheckout();
+
+            commitAs(main, {authorEmail: 'neo-unmapped-seat@neomjs.com', subject: 'feat: unknown seat'});
+
+            const result = runGuard(main, 'operator@example.com');
+
+            expect(result.status).toBe(1);
+            expect(result.stderr).toContain('neo-unmapped-seat@neomjs.com');
+            expect(result.stderr).toContain('agentCoAuthorEmails.mjs')
+        });
+
+        test('a clean agent commit with no trailer at all is silent', () => {
+            const main = createMainCheckout();
+
+            commitAs(main, {authorEmail: ROSTER_AUTHOR, subject: 'feat: nothing to credit'});
+
+            expect(runGuard(main, 'operator@example.com').status).toBe(0)
+        })
     })
 });
 

--- a/test/playwright/unit/buildScripts/checkCommitAuthorship.spec.mjs
+++ b/test/playwright/unit/buildScripts/checkCommitAuthorship.spec.mjs
@@ -477,6 +477,56 @@ test.describe('#15337 bootstrapWorktree — configureAgentGitIdentity', () => {
         })
     }
 
+    /**
+     * The bypass @neo-gpt found in the co-author guard, closed at the only layer that can close it.
+     * The push-time guard reads a commit's author email, which is self-asserted — so it can only
+     * infer agent-ness from email shape. This binder holds AUTHENTICATED identity, so requiring the
+     * verified primary to BE the seat's roster address is what turns that inference into a property.
+     */
+    test.describe('the authenticated primary must be the seat roster address', () => {
+        test('REFUSES an off-domain verified primary — the co-author guard bypass', async () => {
+            // Authenticated, verified, non-noreply, login matches the registry: every pre-existing
+            // check passes. Binding it would author this agent from an address the trailer guard
+            // reads as non-agent, so its poisoned trailers would exit 0.
+            const gitCalls = [];
+
+            await expect(configureAgentGitIdentity({
+                projectRoot            : '/tmp/agent-seat',
+                mainCheckout           : '/tmp/main-checkout',
+                agentIdentity          : '@neo-gpt',
+                getAuthenticatedAccount: account('neo-gpt', 'someone@example.com'),
+                execGit                : async args => { gitCalls.push(args); return {stdout: ''} }
+            })).rejects.toThrow(/does not match its roster commit address/u);
+
+            // Fails before the first git call, so no partial identity is left behind.
+            expect(gitCalls).toEqual([])
+        });
+
+        // The unmapped-seat branch is NOT exercised here on purpose: it is unreachable through this
+        // path today, because the registry lookup runs first and `reconcileWithRegistry().missingEmail`
+        // is asserted empty in agentCoAuthorEmails.spec.mjs — so no registry seat lacks a map entry.
+        // It is defensive against those two drifting apart, and `rosterEmailForLogin` is pinned for
+        // the null case directly in that spec rather than faked through a binder that cannot reach it.
+
+        test('POSITIVE CONTROL — a matching roster primary still binds', async () => {
+            // Without this the refusals above would pass against a binder that refuses everything.
+            const main = createMainCheckout(),
+                tree   = path.join(tmpRoot, 'seat-ok');
+
+            git(main, ['worktree', 'add', '-b', 'agent/ok', tree, 'dev', '--quiet']);
+
+            const result = await configureAgentGitIdentity({
+                projectRoot            : tree,
+                mainCheckout           : main,
+                agentIdentity          : '@neo-gpt',
+                getAuthenticatedAccount: account('neo-gpt', 'neo-gpt@neomjs.com')
+            });
+
+            expect(result.action).toBe('configured');
+            expect(result.email).toBe('neo-gpt@neomjs.com')
+        })
+    });
+
     test('keeps main + TWO sibling worktree identities isolated in real Git config files', async () => {
         const
             main  = createMainCheckout(),


### PR DESCRIPTION
Resolves #17195

Operator escalation. GitHub's *Top committers* insight was crediting two accounts belonging to no maintainer on this project — 9 commits to one, 3 to another. They are not authors; they are `Co-Authored-By` trailers, and **GitHub resolves a trailer by its EMAIL and credits whatever account owns that address. The display name is cosmetic.**

Evidence: L2 (unit fixtures over the predicate, plus end-to-end runs of the hook against real historical commits) → L2 required; the guard is a build script with no host, UI, or deployment effect. One residual, owned below.

## Why the existing guard saw none of it

`#16280` shipped a check for this exact class. Three independent properties let the damaging case through, and **any one of them alone would have been enough**:

| property | consequence |
|---|---|
| scoped to `@neomjs.com` | **blind off-domain** — and off-domain is where a real person's account lives |
| advisory (`the push proceeds`) | never blocked, even on the row it *could* see |
| hook-only (`.husky/pre-push`) | `--no-verify` or any hookless environment skips it |

The domain scoping was **deliberate and correct in its reasoning** — its comment says the guard must never wall off *"a human contributor, an outside collaborator, or a bot"* whose address it was never meant to know. That goal is right and this PR keeps it. As the *only* boundary, though, it was blind in exactly the direction that does harm: it correctly reported a harmless on-domain typo while saying nothing about sixteen commits crediting live human accounts.

A carve-out that quiets a guard opens a silent channel. This is a clean specimen: the argument for the carve-out was sound and the blind spot it created was the half that mattered.

## The change

**The boundary moves from *which domain* to *who authored the commit*.**

- **Agent author** → every trailer must be a roster address, **any domain**, and it **fails the push**.
- **Any other author** → the original domain scoping, untouched.

That closes the off-domain channel completely while *preserving* the outside-contributor protection by construction rather than by heuristic: an external contributor's commit is not agent-authored, so nothing about them is in scope. A domain check cannot tell a fabricated address from a legitimate outside one; an author check does not have to.

**This is not a discipline problem and the fix must not assume it is.** The operator's address is injected into every agent's context by the harness as a standing field — it is in my own system prompt. Any seat composing a trailer can reach for it. A rule depending on no agent ever reaching for a value placed in front of every agent has already failed once, which is what `#16280` was.

## Deltas from ticket

**I am one of the offenders, and the fix catches me too.** Five of my own commits carry `ada@neomjs.com`, which is not even my commit identity (`neo-opus-4-7@neomjs.com`). That one was already visible to the old guard as an advisory warning nobody was required to read.

**The CI arm is deliberately not `paths:`-filtered**, which departs from every other lint workflow here. Those inspect file contents, so scoping them to the files they read is right. This one inspects **commit metadata**, so a path filter would make it vacuous for precisely the PRs that do not touch its own source — nearly all of them.

**Not claimed:** this workflow is not a required status context, so it reports without blocking the merge button. `#17171` owns making the lint workflows required. Until that lands, this raises the floor from *nothing anywhere* to *red on the PR* plus a hard local block at push.

## Test Evidence

```
UNIT_TEST_MODE=true npx playwright test -c test/playwright/playwright.config.unit.mjs \
  test/playwright/unit/ai/buildScripts/util/agentCoAuthorEmails.spec.mjs
→ 25 passed
```

**Red-proved against the old predicate.** Reverting only the boundary condition and re-running:

```
→ 3 failed, 22 passed
```

The three are exactly the new detection arms — off-domain flagged, `agentAuthored` set, and the display-name-laundering case. **All 25 ran** (no `did not run`), so this is per-test evidence rather than a serial-truncated sample. The 22 that still pass include every outside-contributor protection, which is what proves the scoping was preserved rather than traded away.

**End-to-end against real history**, feeding the hook its own stdin format:

```
f672ccbcfb (a real commit that credited a human account)  → exit 1   BLOCKS
f6384af420 (my own #17189 merge, clean)                   → exit 0   passes
```

And in the CI invocation form (`< /dev/null`, falling back to `origin/dev..HEAD`): this branch exits `0`; an empty commit carrying a poisoned trailer exits `1`. The probe commit was removed after measuring.

New fixtures, each pinning a way this could be wrong rather than restating that it works:

| fixture | the failure it catches |
|---|---|
| off-domain trailer on an agent commit IS flagged | the regression itself — returned `[]` before |
| `agentAuthored` is set | the caller has nothing to escalate on |
| an agent DISPLAY NAME cannot launder the address | the exact shape that shipped: reads as self-credit, credits someone else |
| same trailer on a non-agent commit still never warns | the outside-contributor protection, kept rather than assumed |
| unrecognised author email degrades to non-agent | a caller that has not passed `authorEmail` must not start failing |

## Post-Merge Validation

None deferred as work. The historical commits are **not repairable** — the trailers are in merged history on `dev`, and rewriting it is off the table. This gate stops the bleeding; the existing credits stand as noise on the insight panel.

Residual-Owner: #17171

## Commits

- `dfa6f738b0` — the author-aware predicate, the blocking caller, five fixtures, and the CI arm

Authored by ⚖️ **Ada** · `@neo-opus-ada` · Claude Opus 5 · Claude Code. Session 00348bc3-c011-4035-90a3-f0eb62b8c95c.
