### PR TITLE
fix(test): delete two redundant spin-gated assertions (#17188)

### DIFF
--- a/test/playwright/unit/ai/services/memory-core/MailboxService.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/MailboxService.spec.mjs
@@ -1259,12 +1259,19 @@ test.describe('Neo.ai.services.memory-core.MailboxService', () => {
             const second = MailboxService.repairMessageGraphIntegrity({target: '@bob', box: 'inbox', limit: 1});
 
             await readEntered;
-            // The first caller is parked inside the payload read. Give the second caller several
-            // turns to reach the same id; without the load promise it opens the segment too.
+            // Overlap insurance, NOT an assertion. Caller one is parked inside the payload read, and
+            // the single-flight entry is dropped when that read RESOLVES — so a caller two that only
+            // decided after the release would legitimately miss it, open its own read, and fail the
+            // post-completion check on correct code. These turns buy the overlap that prevents that
+            // false failure; nothing is asserted here, because "one read so far" is strictly weaker
+            // than the "one read in total" checked below.
+            //
+            // Deliberately no assertion at this point: an earlier revision asserted here and the
+            // assertion was redundant. Measured — with this budget at ZERO and the single-flight
+            // disabled, the post-completion check below still fails. The detection never lived here.
             for (let turn = 0; turn < 3; turn++) {
                 await new Promise(resolve => setImmediate(resolve));
             }
-            expect(payloadReads).toBe(1);
             releasePayloadRead();
 
             const results = await Promise.all([first, second]);
@@ -1335,10 +1342,12 @@ test.describe('Neo.ai.services.memory-core.MailboxService', () => {
             });
 
             await readEntered;
+            // Overlap insurance, NOT an assertion — see the sibling case above for the full reason.
+            // The post-completion checks below are deterministic and carry the detection; asserting
+            // here would only restate a weaker form of them while depending on this budget.
             for (let turn = 0; turn < 3; turn++) {
                 await new Promise(resolve => setImmediate(resolve));
             }
-            expect(payloadReads, 'different ids in one segment must join before either read completes').toBe(1);
             releasePayloadRead();
 
             const results = await Promise.all([globalRepair, explicitRepair]);

--- a/test/playwright/unit/ai/services/memory-core/MailboxService.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/MailboxService.spec.mjs
@@ -1259,19 +1259,17 @@ test.describe('Neo.ai.services.memory-core.MailboxService', () => {
             const second = MailboxService.repairMessageGraphIntegrity({target: '@bob', box: 'inbox', limit: 1});
 
             await readEntered;
-            // Overlap insurance, NOT an assertion. Caller one is parked inside the payload read, and
-            // the single-flight entry is dropped when that read RESOLVES — so a caller two that only
-            // decided after the release would legitimately miss it, open its own read, and fail the
-            // post-completion check on correct code. These turns buy the overlap that prevents that
-            // false failure; nothing is asserted here, because "one read so far" is strictly weaker
-            // than the "one read in total" checked below.
+            // No wait, and no assertion. Both callers pass the SAME `target` rather than ids, so
+            // both route through `getMailboxGraphProjectionRepairCandidates()` — whose coalescing
+            // promise is process-wide rather than keyed (`MailboxService.mjs:1573`), and which the
+            // id path skips entirely (`:2705`, `idFilter ? null : await …`). These two are therefore
+            // already joined UPSTREAM of the segment load, and caller two cannot reach its decision
+            // independently of caller one. A turn budget here had nothing to synchronise.
             //
-            // Deliberately no assertion at this point: an earlier revision asserted here and the
-            // assertion was redundant. Measured — with this budget at ZERO and the single-flight
-            // disabled, the post-completion check below still fails. The detection never lived here.
-            for (let turn = 0; turn < 3; turn++) {
-                await new Promise(resolve => setImmediate(resolve));
-            }
+            // The assertion that used to sit here was a strictly weaker form of the exact-count
+            // check below — "one read so far" versus "one read in total" — and measured at zero
+            // turns with the single-flight disabled, that check still fails. Detection never lived
+            // here either.
             releasePayloadRead();
 
             const results = await Promise.all([first, second]);
@@ -1342,12 +1340,22 @@ test.describe('Neo.ai.services.memory-core.MailboxService', () => {
             });
 
             await readEntered;
-            // Overlap insurance, NOT an assertion — see the sibling case above for the full reason.
-            // The post-completion checks below are deterministic and carry the detection; asserting
-            // here would only restate a weaker form of them while depending on this budget.
+            // LEFT UNCHANGED, deliberately. Unlike the same-target pair above, these two callers
+            // DIVERGE before the join: the global path awaits the coalescing candidate scan while
+            // the explicit-ids path skips it (`MailboxService.mjs:2705`), so caller two's arrival is
+            // not coupled to caller one's. The single-flight entry drops when caller one's read
+            // RESOLVES, so a legitimately late caller two can open read #2 on CORRECT production and
+            // false-red the exact-count assertion below.
+            //
+            // This budget narrows that window; it does not close it, and no test-side anchor can —
+            // a joining caller produces no observable, and the segment-load helper is module-private.
+            // Removing the pre-release assertion here would imply the remaining wait is sound, which
+            // is a claim this path cannot support. The deterministic rendezvous needs a production
+            // seam and is tracked separately.
             for (let turn = 0; turn < 3; turn++) {
                 await new Promise(resolve => setImmediate(resolve));
             }
+            expect(payloadReads, 'different ids in one segment must join before either read completes').toBe(1);
             releasePayloadRead();
 
             const results = await Promise.all([globalRepair, explicitRepair]);


### PR DESCRIPTION
Resolves #17188

Removes a pre-release assertion and its turn budget from `MailboxService.spec.mjs:1224`. Both are inert for that pair, for two independent reasons.

Evidence: L2 (in-process spec runs, a mutation experiment against the production single-flight with the turn budget at zero, and a 20-run specificity measurement) → L2 required; the change is confined to one spec file with no host, UI, or deployment effect. No residuals.

## Scope narrowed after review — this is now half of what it was

The first cut of this PR touched **both** `turn < 3` spins. @neo-gpt's review established at source that they are not the same case, and only one is fixable here.

`MailboxService.mjs:2705`

```js
const candidateState = idFilter ? null : await getMailboxGraphProjectionRepairCandidates(),
```

- **Same-target pair** (`:1224`) — both callers pass `target`, so both await `getMailboxGraphProjectionRepairCandidates()`, whose coalescing promise is **process-wide** rather than keyed (`:1573`). They are joined **upstream** of the segment load; caller two cannot reach its decision independently. The wait has nothing to synchronise. **This PR.**
- **Global+explicit pair** (`:1298`) — the explicit caller has `idFilter` truthy, **skips the scan entirely**, and diverges before the join. A legitimately late caller two can open a second read on **correct production** and false-red the assertion. **Reverted to its original state here**, and filed as **#17204**, because no test-side anchor can fix it and the deterministic rendezvous needs a production seam that #17188 places out of scope.

`#17188` is re-scoped to the same-target case so `Resolves` is true against what landed; `#15861` stays blocked on **#17204**, a named ticket rather than a resolved one.

## Why the assertion was inert

Two reasons, either sufficient:

1. **Subsumed.** "One read *so far*" is strictly weaker than "one read *in total*", which the post-completion assertion checks deterministically after both callers settle.
2. **Nothing to synchronise.** The upstream join above.

## Deltas from ticket

**The ticket's original claim was wrong and I proved it wrong before building on it.** #17188 said these spins *pass vacuously* and silently stop testing. With the turn budget set to **zero** and the single-flight disabled, the post-completion assertion **still fails** — detection never lived in the spin. The body carries the superseded claim under *Superseded original claim* rather than quietly replacing it, in two stages: my own wrong inference, and then the corrected-but-still-wrong version that treated both spins as one case.

**Two candidate arrival anchors were falsified** while investigating the divergent pair, and are recorded in #17204 so they are not re-proposed: the marker `readFile` (`fs.stat`, plus a cache-hit skip) and the `readdir` in `listMessageWalSegmentKeys` (**measured**: fires at turn 0, two turns before the decision it would need to prove).

**Also checked and cleared:** `projectionStatsCache` is module-scope keyed by `dir`, which looks like cross-file worker state in the class #15861 hunts. It is not — `messageWal.dirTest` derives from the active test's `memoryWal.dir`, isolating the key by construction (`configBase.mjs:544-549`).

## Test Evidence

```
UNIT_TEST_MODE=true npx playwright test -c test/playwright/playwright.config.unit.mjs \
  test/playwright/unit/ai/services/memory-core/MailboxService.spec.mjs
→ 159 passed
```

**Sensitivity AND specificity**, since the prior round proved only the first — @neo-gpt's distinction, and the reason this section has two rows instead of one:

| property | method | result |
|---|---|---|
| **sensitivity** | single-flight forced to never reuse its pending promise | same-target test **fails** |
| **specificity** | correct production, **20 consecutive runs** | **20 passed, 0 failed** |

A broken-reuse red proof shows the arm *can* fire. It says nothing about whether it fires when the code is right, which is the entire question for a false-flaky.

**Each red check run individually.** `test.describe.configure({mode: 'serial'})` at line 25 skips the remainder after a failure — a combined run reports `1 failed, 1 did not run`, which looks like two verified arms and is one.

Production restored and verified **byte-identical to HEAD** (`git diff --stat` empty) before commit; the working tree carried only the spec.

## Post-Merge Validation

None deferred as work. `#15861`'s `workers: 4` / `flaky: 0` sampling is owned by that ticket and its probe PR #17183, and is not claimed here.

Residual-Owner: #17204

## Commits

- `7c11fb3f69` — the first cut, both spins
- `2ed0d296e3` — same-target wait removed with the upstream-join reason; divergent pair reverted

Authored by ⚖️ **Ada** · `@neo-opus-ada` · Claude Opus 5 · Claude Code. Session 00348bc3-c011-4035-90a3-f0eb62b8c95c.
