### PR TITLE
feat(build): the entrypoint guard reports what it cannot classify and rejects directory specifiers (#17202)

### DIFF
--- a/ai/scripts/lint/lint-npm-script-entrypoints.mjs
+++ b/ai/scripts/lint/lint-npm-script-entrypoints.mjs
@@ -72,25 +72,39 @@ export function readRelativeSpecifiers(source, absPath) {
 }
 
 /**
- * Extracts the `ai:*` script entries whose command executes a file under `ai/scripts`.
- * Handles node flags before the path (`node --expose-gc ./ai/scripts/…`) and trailing args.
+ * Extracts the `ai:*` script entries whose command executes a file under `ai/scripts`, plus the
+ * entries it cannot classify. Extraction is global — every `ai/scripts/*.mjs` path in the
+ * command becomes an entry (a compound command's second entrypoint is checked, never silently
+ * dropped) — and tolerant of the bare `ai/scripts/…` form (no leading `./`). An `ai:*` command
+ * that references `ai/scripts` yet yields no entry is reported as unclassifiable: the guard's
+ * coverage count must never be able to shrink without saying so.
  * @param {Object<String,String>} scripts package.json `scripts`.
- * @returns {Array<{name: String, entry: String}>}
+ * @returns {{entries: Array<{name: String, entry: String}>, unclassifiable: Array<{name: String, command: String}>}}
  */
 export function extractEntrypoints(scripts) {
-    const entries = [];
+    const entries        = [];
+    const unclassifiable = [];
+    const ENTRY_PATTERN  = /(?:^|[\s;&|'"(])((?:\.\/)?ai\/scripts\/[^\s;&|'"]+\.mjs)/g;
 
     for (const [name, command] of Object.entries(scripts ?? {})) {
         if (!name.startsWith('ai:')) continue;
 
-        const match = String(command).match(/(?:^|\s)(\.\/ai\/scripts\/[^\s;&|'"]+\.mjs)/);
+        const text   = String(command),
+              before = entries.length;
 
-        if (match) {
-            entries.push({name, entry: match[1]});
+        ENTRY_PATTERN.lastIndex = 0;
+
+        let match;
+        while ((match = ENTRY_PATTERN.exec(text)) !== null) {
+            entries.push({name, entry: match[1].startsWith('./') ? match[1] : `./${match[1]}`});
+        }
+
+        if (entries.length === before && text.includes('ai/scripts')) {
+            unclassifiable.push({name, command: text});
         }
     }
 
-    return entries;
+    return {entries, unclassifiable};
 }
 
 /**
@@ -105,9 +119,10 @@ export function extractEntrypoints(scripts) {
  * @param {Set}      [options.okCache] Files whose subtree is already proven resolvable.
  * @param {Function} [options.readFile=fs.readFileSync] Injectable for specs.
  * @param {Function} [options.exists=fs.existsSync]     Injectable for specs.
+ * @param {Function} [options.stat=fs.statSync]         Injectable for specs.
  * @returns {String[]} Unresolvable edges, formatted for the report. Empty when clean.
  */
-export function collectUnresolved({entryFile, rootDir, okCache = new Set(), readFile = fs.readFileSync, exists = fs.existsSync}) {
+export function collectUnresolved({entryFile, rootDir, okCache = new Set(), readFile = fs.readFileSync, exists = fs.existsSync, stat = fs.statSync}) {
     const unresolved = [];
     const visiting   = new Set();
 
@@ -153,6 +168,13 @@ export function collectUnresolved({entryFile, rootDir, okCache = new Set(), read
                 continue;
             }
 
+            // A directory satisfies exists() but ESM rejects the import at runtime
+            // (ERR_UNSUPPORTED_DIR_IMPORT) — resolvability means a loadable file, never a dir.
+            if (stat(candidate).isDirectory()) {
+                unresolved.push(`${entryFile}: ${absPath} imports '${specifier}' — a directory, which ESM rejects (ERR_UNSUPPORTED_DIR_IMPORT)`);
+                continue;
+            }
+
             if (candidate.endsWith('.mjs')) {
                 walk(candidate);
             }
@@ -171,16 +193,23 @@ export function collectUnresolved({entryFile, rootDir, okCache = new Set(), read
 const isMain = process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url);
 
 if (isMain) {
-    const args       = process.argv.slice(2),
-          rootArg    = args.indexOf('--root'),
-          rootDir    = rootArg === -1 ? process.cwd() : path.resolve(args[rootArg + 1]),
-          pkg        = JSON.parse(fs.readFileSync(path.join(rootDir, 'package.json'), 'utf8')),
-          entries    = extractEntrypoints(pkg.scripts),
-          okCache    = new Set(),
-          violations = [];
+    const args                      = process.argv.slice(2),
+          rootArg                   = args.indexOf('--root'),
+          rootDir                   = rootArg === -1 ? process.cwd() : path.resolve(args[rootArg + 1]),
+          pkg                       = JSON.parse(fs.readFileSync(path.join(rootDir, 'package.json'), 'utf8')),
+          {entries, unclassifiable} = extractEntrypoints(pkg.scripts),
+          okCache                   = new Set(),
+          violations                = [];
 
     for (const {entry} of entries) {
         violations.push(...collectUnresolved({entryFile: entry, rootDir, okCache}));
+    }
+
+    // Unclassifiable entries are printed, never silently excluded — and never a verdict: an
+    // `ai:*` command that references ai/scripts without running one of its files is not a
+    // broken entrypoint, but the coverage count must say what it could not classify.
+    for (const {name, command} of unclassifiable) {
+        console.warn(`[lint-npm-script-entrypoints] note — "${name}" references ai/scripts but no entrypoint was extractable; not checked: ${command}`);
     }
 
     if (violations.length > 0) {
@@ -190,5 +219,5 @@ if (isMain) {
         process.exit(1);
     }
 
-    console.log(`[lint-npm-script-entrypoints] OK — ${entries.length} ai:* entr(ies) into ai/scripts, every static relative import resolvable.`);
+    console.log(`[lint-npm-script-entrypoints] OK — ${entries.length} ai:* entr(ies) into ai/scripts, every static relative import resolvable${unclassifiable.length ? ` (${unclassifiable.length} unclassifiable, see notes)` : ''}.`);
 }

--- a/test/playwright/unit/ai/scripts/lint/lintNpmScriptEntrypoints.spec.mjs
+++ b/test/playwright/unit/ai/scripts/lint/lintNpmScriptEntrypoints.spec.mjs
@@ -27,21 +27,34 @@ function writeFixture(relPath, content) {
 }
 
 test.describe('lint-npm-script-entrypoints — the dead-published-entrypoint guard', () => {
-    test('extractEntrypoints keeps only ai:* entries executing ai/scripts files', () => {
-        const entries = extractEntrypoints({
+    test('extractEntrypoints classifies every ai/scripts path shape and reports what it cannot', () => {
+        const {entries, unclassifiable} = extractEntrypoints({
             'ai:agent'       : 'node ./ai/scripts/runners/runAgent.mjs',
             'ai:benchmark'   : 'node --expose-gc ./ai/scripts/benchmark/probe.mjs',
+            'ai:bare'        : 'node ai/scripts/maintenance/no-dot-slash.mjs',
             'ai:reseed'      : 'node ./ai/scripts/maintenance/restore.mjs --operation reseed',
             'ai:fleet-server': 'node ./ai/services/fleet/devFleetServer.mjs',
             'build'          : 'node ./buildScripts/buildAll.mjs',
-            'ai:piped'       : 'node ./buildScripts/x.mjs && node ./ai/scripts/maintenance/y.mjs'
+            'ai:piped'       : 'node ./buildScripts/x.mjs && node ./ai/scripts/maintenance/y.mjs',
+            'ai:compound'    : 'node ./ai/scripts/one.mjs && node ./ai/scripts/two.mjs',
+            'ai:mention-only': 'echo ai/scripts is the scripts home'
         });
 
+        // Every extractable shape is CLASSIFIED — bare `ai/scripts/…`, flags, trailing args,
+        // pipes, and both halves of a compound command. Nothing checkable falls out of the count.
         expect(entries).toEqual([
             {name: 'ai:agent',     entry: './ai/scripts/runners/runAgent.mjs'},
             {name: 'ai:benchmark', entry: './ai/scripts/benchmark/probe.mjs'},
+            {name: 'ai:bare',      entry: './ai/scripts/maintenance/no-dot-slash.mjs'},
             {name: 'ai:reseed',    entry: './ai/scripts/maintenance/restore.mjs'},
-            {name: 'ai:piped',     entry: './ai/scripts/maintenance/y.mjs'}
+            {name: 'ai:piped',     entry: './ai/scripts/maintenance/y.mjs'},
+            {name: 'ai:compound',  entry: './ai/scripts/one.mjs'},
+            {name: 'ai:compound',  entry: './ai/scripts/two.mjs'}
+        ]);
+
+        // A reference with no extractable entrypoint is REPORTED — the count can never shrink silently.
+        expect(unclassifiable).toEqual([
+            {name: 'ai:mention-only', command: 'echo ai/scripts is the scripts home'}
         ]);
     });
 
@@ -99,6 +112,16 @@ test.describe('lint-npm-script-entrypoints — the dead-published-entrypoint gua
         expect(bare[0]).toContain('config.mjs');
     });
 
+    test('a relative specifier resolving to a directory is rejected — ESM rejects directory imports', () => {
+        writeFixture('ai/scripts/dir/entry.mjs', 'import {x} from "./foo";');
+        fs.mkdirSync(path.join(fixtureDir, 'ai/scripts/dir/foo'), {recursive: true});
+
+        const result = collectUnresolved({entryFile: 'ai/scripts/dir/entry.mjs', rootDir: fixtureDir});
+
+        expect(result.length).toBe(1);
+        expect(result[0]).toContain('ERR_UNSUPPORTED_DIR_IMPORT');
+    });
+
     test('an unreadable entry file itself is reported', () => {
         const result = collectUnresolved({entryFile: 'ai/scripts/absent.mjs', rootDir: fixtureDir});
 
@@ -107,12 +130,15 @@ test.describe('lint-npm-script-entrypoints — the dead-published-entrypoint gua
     });
 
     test('the real package.json tree is clean — the pin that would have caught the specimen', () => {
-        const pkg        = JSON.parse(fs.readFileSync(path.join(repoRoot, 'package.json'), 'utf8')),
-              entries    = extractEntrypoints(pkg.scripts),
-              okCache    = new Set(),
-              violations = entries.flatMap(({entry}) => collectUnresolved({entryFile: entry, rootDir: repoRoot, okCache}));
+        const pkg                       = JSON.parse(fs.readFileSync(path.join(repoRoot, 'package.json'), 'utf8')),
+              {entries, unclassifiable} = extractEntrypoints(pkg.scripts),
+              okCache                   = new Set(),
+              violations                = entries.flatMap(({entry}) => collectUnresolved({entryFile: entry, rootDir: repoRoot, okCache}));
 
         expect(entries.length).toBeGreaterThan(0);
         expect(violations).toEqual([]);
+        // The truthful-coverage pin: today nothing is unclassifiable, so if a future entry
+        // escapes classification this arm fails here rather than shrinking the count silently.
+        expect(unclassifiable).toEqual([]);
     });
 });


### PR DESCRIPTION
Resolves #17202

The entrypoint guard (#17199) can no longer under-report in the two shapes the #17199 review measured latent-zero. First, extraction is now global and tolerant — every `ai/scripts/*.mjs` path in an `ai:*` command is *classified* (bare `ai/scripts/…` without `./`, node flags, trailing args, pipes, and both halves of a compound command), and an `ai:*` command that references `ai/scripts` with no extractable entrypoint is *reported* as unclassifiable rather than silently excluded — so the `OK — 63 ai:* entr(ies)` coverage count can never shrink without saying so. Second, the resolver rejects a specifier that resolves to a directory (`fs.existsSync` alone accepted it; ESM throws `ERR_UNSUPPORTED_DIR_IMPORT` at runtime), named in the report. One deliberate strengthening over the ticket's literal shape: the ticket said "report" for the missing-`./` and compound shapes, but classification beats flagging — those entries are now *checked*, and the residual unclassifiable class (reference with zero extractable entries) is what gets reported. The truthful-coverage AC is identical either way, and the real-tree pin now asserts `unclassifiable` is empty so a future escape fails in the spec rather than in production.

Evidence: L2 (unit specs incl. both AC red-proofs + the real-tree pin; live guard run 63/63) → L2 required (every AC decidable in-process; the guard's own workflow re-runs on this PR since it touches the lint). Residual: none.

## Deltas from ticket

- **Classification over flagging** (above): the widened extraction regex (`/(?:^|[\s;&|'"(])((?:\.\/)?ai\/scripts\/[^\s;&|'"]+\.mjs)/g`, global) checks the two shapes the ticket asked to have flagged; only a zero-extraction reference is reported. The spec arms cover all three: bare form classified, compound classified twice, mention-only reported.
- **`extractEntrypoints` return shape changed** `{entries}` → `{entries, unclassifiable}` — the module is one PR old with exactly two consumers (its CLI and its spec), so this is a signature change with no migration surface.

## Test Evidence

- `lintNpmScriptEntrypoints.spec.mjs`: extraction arms (bare/flags/args/pipes/compound/mention-only/non-`ai:`/non-`ai/scripts`), the directory red-proof (`foo/` fixture → `ERR_UNSUPPORTED_DIR_IMPORT` named), the unclassifiable report, and the real-tree pin now asserting zero unclassifiable entries — **10/10 green**.
- Live guard run on the real tree: `63 ai:* entr(ies), every static relative import resolvable`.
- Full lint-spec dir: **332/332**.
- Surface: `ai/scripts/lint/lint-npm-script-entrypoints.mjs` — spec + live run above | Surface: `package.json` entry population — real-tree arm above.

## Post-Merge Validation

Observable on any later PR that adds an oddly-shaped `ai:*` entry: the guard either checks it (classified) or prints the `note — "<name>" references ai/scripts but no entrypoint was extractable` line in the workflow log (unclassifiable) — never silence. No further action required.

Authored by Phoebe (Kimi k3, opencode). Session 8952cca9-29e5-474f-a180-01ee3ff0840d.
