### PR TITLE
refactor(ai): the enforcement is the documentation — cut the prose the guards already say

### DIFF
--- a/.agents/skills/pr-review/assets/pr-review-round-2-template.md
+++ b/.agents/skills/pr-review/assets/pr-review-round-2-template.md
@@ -27,14 +27,7 @@ One row per Round-1 required action, **quoted verbatim** — no re-wording, no r
 
 [Approve · Approve+Follow-Up (only if it passes the standalone-ticket counterfactual) · **COMMENT** if any item is STILL_OPEN]
 
-**A `STILL_OPEN` round submits as `COMMENT`, never `Request Changes`.** The whole claim of `STILL_OPEN`
-is that the Round-1 review remains authoritative for that item — a new `Request Changes` would replace
-it with this round's verdict, and would spend a second round the per-family budget does not have. The
-managed path enforces this pairing, so an APPROVED round carrying a `STILL_OPEN` is refused rather
-than silently discharging the item it just declared unresolved.
-
-After posting, send the new **review ID or URL** to the author via A2A — `manage_pr_review` returns
-`reviewId` / `url`, not a `commentId`, and an author handed the wrong identifier cannot fetch the round.
+After posting, A2A the author the **review ID or URL** (`manage_pr_review` returns those, not a `commentId`).
 
 ---
 

--- a/.agents/skills/pr-review/audits/review-cost-circuit-breaker.md
+++ b/.agents/skills/pr-review/audits/review-cost-circuit-breaker.md
@@ -5,9 +5,7 @@ This payload closes expensive review loops without turning discussion size into 
 ## Counter and cutover
 
 - PRs with `createdAt` after `PullRequestService.reviewBudgetActivatedAt` are gated; older PRs are grandfathered to reviewer judgment.
-- The unit is the **reviewer family**, not the review. **One ordinary `CHANGES_REQUESTED` per family** spends that family's budget, counted across heads, identities, and later retractions — a family cannot buy a second round by rotating seats, and another family keeps its own independent round.
-- A submitter the identity graph cannot classify is **refused**, not waived: an unplaceable login would otherwise spend nobody's budget and review without limit.
-- The managed path refuses mutation when its 100-review history projection is incomplete or truncated.
+- The unit is the **reviewer family**, not the review: one ordinary `CHANGES_REQUESTED` per family, counted across heads, identities and retractions. An unclassifiable submitter is refused, and an incomplete history projection refuses the mutation — both fail closed at the managed path, which is where the rule is enforced rather than remembered.
 - Measure one PR or a corpus with `node ai/scripts/diagnostics/review-cost-meter.mjs <PR_NUMBER...>`; use `--json` for machine-readable output.
 
 ## The second round

--- a/.agents/skills/pr-review/references/measurement-methodology.md
+++ b/.agents/skills/pr-review/references/measurement-methodology.md
@@ -20,7 +20,7 @@ For the initial review (Cycle 1), the following must be measured and reported:
 ### 2.2 Cycle N (Warm-Cache) Measurement
 For subsequent re-reviews (Cycle N), the measurement must capture the delta payload:
 **Static Surface:**
-1. **The Round-2 Template:** `wc -c .agents/skills/pr-review/assets/pr-review-round-2-template.md` for an ordinary Cycle 2 — the disposition asset is what an ordinary second round actually loads. Measure `pr-review-followup-template.md` instead only for the exceptional shapes that still use it (a validated Drop+Supersede or a guarded repair-minted re-entry). Measuring the follow-up asset for every Cycle N overstates the warm-cache surface, because the ordinary case no longer loads it.
+1. **The selected asset:** `wc -c` the template the round actually loads — `pr-review-round-2-template.md` for an ordinary Cycle 2, `pr-review-followup-template.md` only for a Drop+Supersede or repair-minted re-entry.
 **Dynamic Surface:**
 2. **The Delta Payloads:** The `wc -c` of new commits, new conversation comments, and any re-grounding context fetched.
 


### PR DESCRIPTION
Resolves neomjs/neo#17207
Refs neomjs/neo-agent-brain#34

@tobiu asked the obvious question about neomjs/neo#17179: *"wasn't the goal that skills get SHORTER? this made them longer."* It did. This removes the part that was removable and says plainly where the rest stops.

Evidence: L2 (the full pr-review validator corpus green, plus `lint-skill-manifest` passing without a growth-justified marker) → L2 required (Markdown payloads and their template-validator tiers; no host, UI or deployment effect). No residuals.

## Deltas from ticket

**One principle did all the cutting**, and it is worth more than the bytes:

> Where a guard refuses something at the moment it matters, a template arguing for the rule pays bytes on every load to say what the code already says.

The largest single piece was a paragraph explaining why a `STILL_OPEN` round must be `COMMENT`. The managed path **refuses** an APPROVED round carrying a `STILL_OPEN`, and refuses a `REQUEST_CHANGES` that dispositions everything — so the paragraph argued for a rule the reviewer cannot break. The verdict line already says it in a clause.

Three smaller instances of the same shape: the review-id note (two sentences → one clause), the measurement-methodology addition (three sentences → one routing fact), and a circuit-breaker restatement of the per-family budget that repeated the service's contract instead of pointing at where it fails closed.

**Where it stops, and why that is the honest answer.** The tree lands at 103,422 — still **+1,578** against the pre-#17179 baseline of 101,844. That remainder *is* the format: a Round-2 disposition asset cannot be free. Reaching a genuine net decrease from here means deleting sections from the follow-up template that governs terminal **Drop+Supersede** and **repair-minted re-entry**. Removing contract surface to hit a byte target is the metric moving while the goal stands still — the exact trade this substrate's guards exist to refuse.

So **AC-7's byte clause remains unmet, stated rather than dressed**. A number bought with contract would be worse than an honest miss.

**And the figure in the merged PR was wrong**, which is the part I most want on the record: neomjs/neo#17179's body claimed +1,654 when the merged tree was +2,635. I measured before four Cycle-2 repair rounds and never re-measured before the final push. Corrected in place on that PR rather than left to be discovered here.

## Test Evidence

```
npm run test-unit -- test/playwright/unit/ai/services/github-workflow/
→ EXIT=0, 676 passed

node ai/scripts/lint/lint-skill-manifest.mjs --base origin/dev
→ [lint-skill-manifest] OK        (no growth-justified marker needed)
```

Measured on this exact head after rebasing onto `dev`, not carried from an earlier run:

| surface | dev | here | delta |
|---|---|---|---|
| `pr-review/**` tree | 104,479 | **103,422** | **−1,057** |
| ordinary Round 2 **loads** | 2,359 | **1,787** | **−24%** |
| vs pre-#17179 baseline (101,844) | +2,635 | **+1,578** | — |

Tree bytes are paid once on disk; the template is paid on every review. Both are reported because they are different claims, and only the first is what AC-7 asked about.

No template section is deleted and no validator tier changes — the existing corpus staying green is the proof.

## Post-Merge Validation

None deferred as work.

## Commits

- `888f618f31` — the four prose cuts

Authored by Grace (Claude Opus 5, Claude Code). Session b17338dd-b474-494f-b08c-683044de2ddb. Self-reported: I claimed AC-7 with an exception rather than meeting it, and with a stale figure. 🖖
