### PR TITLE
fix(build): derive the roster seed's roster-source fact as declared absence (#17210)

### DIFF
--- a/apps/agentos/resources/data/fleetRoster.json
+++ b/apps/agentos/resources/data/fleetRoster.json
@@ -1,6 +1,6 @@
 {
     "_meta": {
-        "generatedAt": "2026-07-24T21:49:28.860Z",
+        "generatedAt": "2026-08-15T21:03:37.192Z",
         "authority": "ai/graph/identityRoots.mjs",
         "engineTags": "learn/agentos/ModelStats.md (observation-owned, mirrored per-entry in the generator)",
         "generator": "buildScripts/util/deriveFleetRoster.mjs",
@@ -19,7 +19,12 @@
             "participationStatus": "active",
             "openLaneCount": null,
             "sources": {
-                "roster": "identityRoots-snapshot"
+                "roster": {
+                    "source": "fleet:listAgents",
+                    "state": "not-wired",
+                    "confidence": "none",
+                    "reason": "static roster (identityRoots snapshot) · unobserved"
+                }
             }
         },
         {
@@ -34,7 +39,12 @@
             "participationStatus": "active",
             "openLaneCount": null,
             "sources": {
-                "roster": "identityRoots-snapshot"
+                "roster": {
+                    "source": "fleet:listAgents",
+                    "state": "not-wired",
+                    "confidence": "none",
+                    "reason": "static roster (identityRoots snapshot) · unobserved"
+                }
             }
         },
         {
@@ -49,7 +59,12 @@
             "participationStatus": "active",
             "openLaneCount": null,
             "sources": {
-                "roster": "identityRoots-snapshot"
+                "roster": {
+                    "source": "fleet:listAgents",
+                    "state": "not-wired",
+                    "confidence": "none",
+                    "reason": "static roster (identityRoots snapshot) · unobserved"
+                }
             }
         },
         {
@@ -64,7 +79,12 @@
             "participationStatus": "active",
             "openLaneCount": null,
             "sources": {
-                "roster": "identityRoots-snapshot"
+                "roster": {
+                    "source": "fleet:listAgents",
+                    "state": "not-wired",
+                    "confidence": "none",
+                    "reason": "static roster (identityRoots snapshot) · unobserved"
+                }
             }
         },
         {
@@ -79,7 +99,12 @@
             "participationStatus": "active",
             "openLaneCount": null,
             "sources": {
-                "roster": "identityRoots-snapshot"
+                "roster": {
+                    "source": "fleet:listAgents",
+                    "state": "not-wired",
+                    "confidence": "none",
+                    "reason": "static roster (identityRoots snapshot) · unobserved"
+                }
             }
         },
         {
@@ -94,7 +119,12 @@
             "participationStatus": "operator_benched",
             "openLaneCount": null,
             "sources": {
-                "roster": "identityRoots-snapshot"
+                "roster": {
+                    "source": "fleet:listAgents",
+                    "state": "not-wired",
+                    "confidence": "none",
+                    "reason": "static roster (identityRoots snapshot) · unobserved"
+                }
             }
         },
         {
@@ -109,7 +139,12 @@
             "participationStatus": "active",
             "openLaneCount": null,
             "sources": {
-                "roster": "identityRoots-snapshot"
+                "roster": {
+                    "source": "fleet:listAgents",
+                    "state": "not-wired",
+                    "confidence": "none",
+                    "reason": "static roster (identityRoots snapshot) · unobserved"
+                }
             }
         },
         {
@@ -124,7 +159,12 @@
             "participationStatus": "active",
             "openLaneCount": null,
             "sources": {
-                "roster": "identityRoots-snapshot"
+                "roster": {
+                    "source": "fleet:listAgents",
+                    "state": "not-wired",
+                    "confidence": "none",
+                    "reason": "static roster (identityRoots snapshot) · unobserved"
+                }
             }
         },
         {
@@ -139,7 +179,12 @@
             "participationStatus": "active",
             "openLaneCount": null,
             "sources": {
-                "roster": "identityRoots-snapshot"
+                "roster": {
+                    "source": "fleet:listAgents",
+                    "state": "not-wired",
+                    "confidence": "none",
+                    "reason": "static roster (identityRoots snapshot) · unobserved"
+                }
             }
         },
         {
@@ -154,7 +199,12 @@
             "participationStatus": "active",
             "openLaneCount": null,
             "sources": {
-                "roster": "identityRoots-snapshot"
+                "roster": {
+                    "source": "fleet:listAgents",
+                    "state": "not-wired",
+                    "confidence": "none",
+                    "reason": "static roster (identityRoots snapshot) · unobserved"
+                }
             }
         }
     ]

--- a/buildScripts/util/deriveFleetRoster.mjs
+++ b/buildScripts/util/deriveFleetRoster.mjs
@@ -1,6 +1,7 @@
-import fs           from 'node:fs';
-import path         from 'node:path';
-import {IDENTITIES} from '../../ai/graph/identityRoots.mjs';
+import fs                      from 'node:fs';
+import path                    from 'node:path';
+import {FLEET_COCKPIT_SOURCES} from '../../apps/agentos/config/cockpitSources.mjs';
+import {IDENTITIES}            from '../../ai/graph/identityRoots.mjs';
 
 /**
  * @summary Derives the AgentOS cockpit roster seed (`apps/agentos/resources/data/fleetRoster.json`)
@@ -17,6 +18,13 @@ import {IDENTITIES} from '../../ai/graph/identityRoots.mjs';
  *   `active → 'ok'` and any known non-active status → `'off'`, and stamps the provenance per row
  *   (`sources.roster`) plus the `_meta` block, so "this is a registry snapshot" is visible in the
  *   data itself. Live session state is the wired roster path's job (`FleetCockpit.loadRoster`).
+ *   The per-row stamp is a DECLARED-CALM source fact in the cockpit's source-health contract
+ *   (`apps/agentos/view/fleet/sourceHealth.mjs`): it names the live producer as expected-absent
+ *   (`not-wired` / `none`) and carries the static provenance in `reason`. A bare provenance string
+ *   is a present-but-malformed fact there — `invalid`, one red alarm per card on the offline
+ *   first-run; declared absence is the one present shape allowed to be calm. The producer literal
+ *   rides the Body-side vocabulary twin, which `lint-fleet-vocabulary-parity` binds to the Brain
+ *   authority, so the emitted literal tracks the contract it must satisfy.
  *
  * **Honesty invariants (the model's own contract, `apps/agentos/model/FleetAgent.mjs`):**
  * - `openLaneCount` stays `null` — the model renders NO badge for null; a derived count would be
@@ -92,7 +100,15 @@ function toRosterRow(entry) {
         laneLine           : props.statusReason ?? null,
         participationStatus: status,
         openLaneCount      : null,
-        sources            : {roster: 'identityRoots-snapshot'}
+        // declared expected-absence: the live roster producer is not wired for a static seed row,
+        // and the contract's one calm present shape keeps the provenance in `reason` (a bare
+        // string here normalizes as `invalid` — rejected evidence, one alarm per card)
+        sources            : {roster: {
+            source    : FLEET_COCKPIT_SOURCES.roster,
+            state     : 'not-wired',
+            confidence: 'none',
+            reason    : 'static roster (identityRoots snapshot) · unobserved'
+        }}
     };
 }
 

--- a/test/playwright/e2e/agentos/Cockpit.spec.mjs
+++ b/test/playwright/e2e/agentos/Cockpit.spec.mjs
@@ -37,4 +37,22 @@ test.describe('AgentOS harness shell — left-rail keeper-view nav', () => {
         await page.locator('.agent-shell').getByText('Accounts', {exact: true}).click();
         await expect(page.locator('.agent-definition-form')).toBeVisible({timeout: 30000})
     });
+
+    test('offline first-run renders the calm static-roster view — zero per-card source alarms (#17210)', async ({page}) => {
+        await page.goto('/apps/agentos/index.html');
+
+        await expect(page.locator('.fm-fleet-cockpit')).toBeVisible({timeout: 60000});
+        await expect(page.locator('.fm-agent-card').first()).toBeVisible({timeout: 60000});
+
+        // the topology gate: this test's acceptance surface is the OFFLINE first-run — the sample
+        // badge must be up (no fleet server reachable), else the run is measuring the wrong topology
+        await expect(page.locator('.fm-fleet-head')).toHaveClass(/is-sample/, {timeout: 30000});
+        await expect(page.locator('.fm-fleet-stale')).toHaveText('static roster');
+
+        // the retired defect: one red "Roster not nominal · malformed source fact" strip per card.
+        // Declared absence earns zero pixels — every strip stays hidden; the badge + banner announce
+        // the condition once.
+        expect(await page.locator('.fm-agent-card').count()).toBeGreaterThan(0);
+        await expect(page.locator('.fm-card-strip:visible')).toHaveCount(0)
+    });
 });

--- a/test/playwright/unit/ai/buildScripts/util/deriveFleetRoster.spec.mjs
+++ b/test/playwright/unit/ai/buildScripts/util/deriveFleetRoster.spec.mjs
@@ -1,6 +1,12 @@
 import {expect, test}      from '@playwright/test';
 import fs                  from 'node:fs';
 import {deriveFleetRoster} from '../../../../../../buildScripts/util/deriveFleetRoster.mjs';
+import {
+    normalizeFleetSources,
+    normalizeSourceFact,
+    resolveFleetDisplayState,
+    summarizeAnsweredAbnormal
+} from '../../../../../../apps/agentos/view/fleet/sourceHealth.mjs';
 
 // Pure derivation — imported directly (the module's main-execution guard makes import side-effect-free).
 // The committed seed is also checked against a fresh derivation so hand-painting fails in CI, not in film.
@@ -42,8 +48,30 @@ test.describe('deriveFleetRoster (registry-derived cockpit roster, #15621)', () 
         for (const row of doc.data) {
             expect(row.participationStatus).toBeTruthy();
             expect(row.openLaneCount).toBeNull();   // the model renders no badge for null — never a fake 0
-            expect(row.sources.roster).toBe('identityRoots-snapshot');
+            // declared expected-absence: the one present shape the source-health contract holds calm
+            expect(row.sources.roster).toEqual({
+                source    : 'fleet:listAgents',
+                state     : 'not-wired',
+                confidence: 'none',
+                reason    : 'static roster (identityRoots snapshot) · unobserved'
+            });
         }
+    });
+
+    test('source-health pin (#17210): the shipped seed reads calm through the card contract; the legacy string shape stays invalid', () => {
+        const committed = JSON.parse(fs.readFileSync(COMMITTED, 'utf8')).data;
+
+        for (const row of committed) {
+            // the offline first-run defect: every card alarmed "Roster not nominal · malformed source fact"
+            expect(summarizeAnsweredAbnormal(row.sources).level, `${row.agentId} source strip`).toBe('ok');
+            expect(normalizeFleetSources(row.sources).roster.state, `${row.agentId} roster axis`).toBe('not-wired');
+            // display truth unchanged: participation-active with no session observation, or external
+            expect(resolveFleetDisplayState({state: row.state, sources: row.sources}), row.agentId).toMatch(/^unobserved$|^external$/);
+        }
+
+        // the validator itself is correct and STAYS: a present non-object fact remains rejected evidence
+        expect(normalizeSourceFact('identityRoots-snapshot'))
+            .toEqual({source: null, state: 'invalid', confidence: 'none', reason: 'malformed source fact'});
     });
 
     test('engine tags mirror ModelStats for mapped identities and stay null (never fabricated) elsewhere', () => {


### PR DESCRIPTION
Resolves neomjs/neo#17210

The offline first-run view no longer greets a new operator with ten red "Roster not nominal · malformed source fact" strips. The defect sat one level up from where the alarm rendered: the fleet roster seed is **derived** (`buildScripts/util/deriveFleetRoster.mjs` ← `ai/graph/identityRoots.mjs`), and the generator stamped each row's roster-source provenance as a bare string (`'identityRoots-snapshot'`) — a PRESENT, non-object fact, which the `sourceHealth.mjs` contract correctly rejects as `invalid` (rejected evidence is never conflated with absence; the validator itself stays). The generator now emits the contract's one declared-calm present shape — `{source: 'fleet:listAgents', state: 'not-wired', confidence: 'none', reason: 'static roster (identityRoots snapshot) · unobserved'}`: the live producer's expected absence, honestly declared, static provenance carried in the reason. The producer literal is read from the Body-side vocabulary twin (`apps/agentos/config/cockpitSources.mjs`), which `lint-fleet-vocabulary-parity` binds to the Brain authority, so the emitted literal tracks the contract it must satisfy. Zero view changes were needed: the card strip already grants `not-wired` zero pixels (`AgentCard.applyRecord` hides it at `level: 'ok'`), so the grid badge (`static roster`) and spine banner remain the one announcement — one condition, one announcement, never a chorus. Card display states are unchanged (`unobserved` / `external` per the existing mapping).

Evidence: L3 (live-rendered offline first-run view, local Chrome e2e on this checkout) → L3 required (AC4's offline-topology first-run view). No residuals.

## Deltas from ticket

None substantive. AC1's first offered route taken (satisfy the contract; no new `static-roster` source kind — that would have meant contract surgery plus a parity-lint registration for zero honesty gain). AC2 required no presentation work: the calm-down is exactly what the contract already does for declared absence; the alarm was purely the malformed data. The fix locus moved one level up to the generator (the seed is generated, so a JSON hand-edit would be silently reverted on the next derivation) — the ticket's mechanism section left this open ("the fix decides which after reading the wiring"), and hypothesis (a) confirmed: fallback data predated the contract.

## Test Evidence

- Red control (pre-fix, this checkout): every committed seed row through the real `summarizeAnsweredAbnormal` → 10/10 `bad`, "Roster not nominal · malformed source fact". Post-fix: 0/10, display states `unobserved`/`external` unchanged.
- `npm run test-unit -- test/playwright/unit/ai/buildScripts/util/deriveFleetRoster.spec.mjs test/playwright/unit/apps/agentos/view/fleet/sourceHealthMarker.spec.mjs test/playwright/unit/apps/agentos/view/fleet/agentCard.spec.mjs test/playwright/unit/apps/agentos/view/fleet/fleetGrid.spec.mjs` → **64 passed** (includes the new AC3 pin: the committed seed reads calm through the card contract, and the legacy string shape still classifies `invalid`).
- `npm run test-unit -- test/playwright/unit/apps/agentos/view/fleet/fleetCockpit.spec.mjs` → **99 passed**.
- `node buildScripts/util/deriveFleetRoster.mjs --check` → committed seed in sync (the anti-hand-paint guard).
- AC4 surface (apps/agentos offline first-run): `NEO_E2E_RUN_ID=17210-cockpit npx playwright test -c test/playwright/playwright.config.e2e.mjs e2e/agentos/Cockpit.spec.mjs` → **2 passed**, including the new pin: sample badge `static roster` up (topology gate), zero `.fm-card-strip:visible` across all cards, live local Chrome render.
- Per directly touched surface: apps/agentos fleet cockpit → `Cockpit.spec.mjs` (e2e) + the unit specs above; buildScripts roster derivation → `deriveFleetRoster.spec.mjs`.

## Post-Merge Validation

- [x] None owed — AC1–AC4 all carry pre-merge receipts, including the AC4 live offline render. The operator's next offline cockpit open is the living confirmation.

Authored by Iris (Kimi k3, Kimi Code CLI). Session 7d0477c6-e112-4903-a79a-42f06095863e.
