### PR TITLE
fix(ai): gate [promoted] suppression on its ticket reference (#17197)

### DIFF
--- a/ai/services/memory-core/helpers/defectObservationTriggers.mjs
+++ b/ai/services/memory-core/helpers/defectObservationTriggers.mjs
@@ -14,7 +14,8 @@ import {defectNoteFingerprint} from './defectObservationFold.mjs';
  *
  * The read side's discipline mirrors the channel's write side: capture is cheap, attention is
  * not. A digest fires at most once per count growth per observation, and promotion stays a
- * deliberate full-ceremony act — this module produces attention, never backlog admission.
+ * deliberate full-ceremony act — the ticket reference is what makes it one, and a bare
+ * `[promoted]` suppresses nothing. This module produces attention, never backlog admission.
  */
 
 /**
@@ -24,7 +25,7 @@ import {defectNoteFingerprint} from './defectObservationFold.mjs';
  */
 export const DIGEST_SUBJECT_PREFIX = 'defect-ledger-digest:';
 
-const PROMOTED_MARKER_PATTERN  = /^\s*\[promoted\b[^\]]*\]\s*/i;
+const PROMOTED_MARKER_PATTERN  = /^\s*\[promoted\b([^\]]*)\]\s*/i;
 const DISMISSED_MARKER_PATTERN = /^\s*\[dismissed\b[^\]]*\]\s*/i;
 
 /**
@@ -44,11 +45,16 @@ export function independentSecondOccurrence(record) {
 /**
  * @summary Fingerprints whose promotion or dismissal is already on the record.
  *
- * A `[promoted #N]` note from any seat suppresses (promotion ran its ceremony; re-attention
- * adds nothing). A `[dismissed]` note suppresses only from an operator identity — anyone else's
- * is prose, not a disposition. The marker note keys to the same observation by stripping the
- * marker and re-fingerprinting the remainder, so the suppression rides the channel's own
- * identity rule rather than a parallel keying scheme.
+ * A `[promoted #N]` note from any seat suppresses: the ticket reference IS the ceremony — any
+ * seat may promote, and the reference is the accountability trail (verifying that the ticket
+ * exists needs a GitHub read, deliberately out of scope for this pure helper). A bare
+ * `[promoted]` suppresses NOTHING, from any seat, the operator included: an accidental or
+ * template-copied marker degrades toward re-attention (a visible duplicate row at triage),
+ * never toward the permanent silence an unauthorised suppression would leave behind.
+ * A `[dismissed]` note suppresses only from an operator identity — anyone else's is prose, not
+ * a disposition. The marker note keys to the same observation by stripping the marker and
+ * re-fingerprinting the remainder, so the suppression rides the channel's own identity rule
+ * rather than a parallel keying scheme.
  *
  * @param {Object[]} rows Raw `defect-note:` mailbox rows (`{subject, from}`).
  * @param {Object}     [options]
@@ -59,10 +65,16 @@ export function collectSuppressedFingerprints(rows, {operatorIdentities = ['@tob
     const suppressed = new Set();
 
     for (const row of Array.isArray(rows) ? rows : []) {
-        const text = String(row?.subject || '').replace(/^\s*defect-note:\s*/i, '');
+        const
+            text     = String(row?.subject || '').replace(/^\s*defect-note:\s*/i, ''),
+            promoted = text.match(PROMOTED_MARKER_PATTERN);
 
-        if (PROMOTED_MARKER_PATTERN.test(text)) {
-            suppressed.add(defectNoteFingerprint(text.replace(PROMOTED_MARKER_PATTERN, '')));
+        if (promoted) {
+            // the reference is enforced, not decorative: a bare `[promoted]` is prose, exactly
+            // like a non-operator `[dismissed]` — the observation keeps qualifying for the digest
+            if (/#\d+/.test(promoted[1])) {
+                suppressed.add(defectNoteFingerprint(text.replace(PROMOTED_MARKER_PATTERN, '')));
+            }
         } else if (DISMISSED_MARKER_PATTERN.test(text) && operatorIdentities.includes(row?.from)) {
             suppressed.add(defectNoteFingerprint(text.replace(DISMISSED_MARKER_PATTERN, '')));
         }

--- a/test/playwright/unit/ai/services/memory-core/helpers/defectObservationTriggers.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/helpers/defectObservationTriggers.spec.mjs
@@ -97,6 +97,27 @@ test.describe('defectObservationTriggers — the defect-ledger observer layer', 
         expect(collectSuppressedFingerprints([recovered]).size).toBe(0);
     });
 
+    test('a bare [promoted] suppresses nothing — the ticket reference is the ceremony (#17197)', () => {
+        const
+            barePeer     = {from: '@a',     subject: NOTE.replace('defect-note:', 'defect-note: [promoted]')},
+            bareOperator = {from: '@tobiu', subject: NOTE.replace('defect-note:', 'defect-note: [promoted]')},
+            referenced   = {from: '@a',     subject: NOTE.replace('defect-note:', 'defect-note: [promoted #17136]')},
+            noteRow      = record({fingerprint: defectNoteFingerprint(NOTE)});
+
+        // both arms: with the reference, any seat's promotion suppresses...
+        expect(collectSuppressedFingerprints([referenced]).size).toBe(1);
+        // ...without it, nothing suppresses — not a peer's, and not even the operator's
+        expect(collectSuppressedFingerprints([barePeer]).size).toBe(0);
+        expect(collectSuppressedFingerprints([bareOperator]).size).toBe(0);
+
+        // the failure direction directly: an unauthorised suppression attempt leaves the
+        // observation still qualifying — the regression surfaces as a visible row, never silence
+        expect(selectDigestRecords({
+            records               : [noteRow],
+            suppressedFingerprints: collectSuppressedFingerprints([barePeer])
+        })).toHaveLength(1);
+    });
+
     test('digest coverage round-trips: max count per fingerprint, malformed bodies cover nothing', () => {
         const body = buildDigestBody({records: [record(), record({fingerprint: 'eeee111122223333', count: 5})]});
 


### PR DESCRIPTION
Resolves #17197

A bare `[promoted]` marker no longer suppresses a defect observation. The promotion arm of `collectSuppressedFingerprints` swallowed the optional `#N` (`[^\]]*`) and never read it, so any seat — by accident, template copy, or triage slip — could take an observation off the digest ledger permanently and silently, through the exact mechanism built to end durable-but-unattended knowledge. The ticket reference is now enforced as the ceremony: `[promoted #N]` from any seat suppresses (the reference is the accountability trail; verifying that the ticket exists stays out of this pure helper's scope); a bare `[promoted]` — from any seat, the operator included — suppresses nothing, so a mistaken marker degrades toward re-attention (a visible duplicate row at triage) instead of silence. The identity question is decided on the record in the module docstring (AC2/AC3): promotion is deliberately **not** operator-gated like dismissal, because peer promotion-with-reference is the fleet's working triage flow — the hole was the missing reference, not the speaker.

Evidence: L2 (unit specs over the pure helper — both marker arms plus the failure direction) → L2 required (AC1/AC4 are spec pins; AC2/AC3 are docstring obligations). No residuals.

## Deltas from ticket

None substantive. The ticket's offered decision resolved as "any seat may promote, reference as the trail" (its own matrix marks peer `[promoted #N]` as correct), with the reasoning moved into the module docstring per AC3. The module header's "deliberate full-ceremony act" claim is now literally true instead of aspirational.

## Test Evidence

- `npm run test-unit -- test/playwright/unit/ai/services/memory-core/helpers/defectObservationTriggers.spec.mjs` → **8 passed** (6 spec tests + run-scoped chroma setup/teardown), including the new AC1+AC4 pin `a bare [promoted] suppresses nothing — the ticket reference is the ceremony (#17197)`: the referenced arm suppresses (any seat), the bare arm suppresses nothing (peer **or** operator), and an unauthorised suppression attempt leaves the observation still qualifying (`selectDigestRecords` → length 1 — the failure surfaces as a visible row, never silence).
- Consumer sweep: no marker writers exist (markers are hand-written mailbox notes, and the digest's own guidance text already teaches the `[promoted #N]` form), so the gate cannot un-suppress any machine-generated marker class. `ai/scripts/diagnostics/defectObservations.mjs` consumes the returned set unchanged.
- Per directly touched surface: ai/services/memory-core defect-ledger helpers → the spec above.

## Post-Merge Validation

- [x] None owed — all four ACs carry pre-merge receipts (spec pins + docstring alignment). The next digest run that meets a bare `[promoted]` marker is the living confirmation.

Authored by Iris (Kimi k3, Kimi Code CLI). Session 7d0477c6-e112-4903-a79a-42f06095863e.
