### PR TITLE
fix(memory-core): rendezvous on the join decision instead of guessing at it

### DIFF
--- a/ai/services/memory-core/MailboxService.mjs
+++ b/ai/services/memory-core/MailboxService.mjs
@@ -65,7 +65,9 @@ const graphProjectionRepairCursorByView    = new Map(),
     messageWalCandidateSegmentLoadByKey    = new Map(),
     messageWalCandidateMetadataCacheById   = new Map(),
     unreadableMessageWalCandidateStateById = new Map();
-let graphProjectionCandidateScanPromise = null;
+let graphProjectionCandidateScanPromise     = null,
+    messageWalCandidateSegmentLoadDecisions = 0,
+    messageWalCandidateSegmentLoadJoins     = 0;
 
 // Collision-class substrate: claim signals are STATUS, not interrupts — their broadcasts default to
 // quiet at the `addMessage` resolution seam (operator-directed 2026-07-26; peers read claims at their
@@ -1199,6 +1201,12 @@ function getMessageWalCandidateSegmentLoad({segmentKey, segmentById, payloadSign
     let pending = messageWalCandidateSegmentLoadByKey.get(loadKey),
         joined  = Boolean(pending);
 
+    messageWalCandidateSegmentLoadDecisions++;
+
+    if (joined) {
+        messageWalCandidateSegmentLoadJoins++;
+    }
+
     if (!pending) {
         pending = (async () => {
             try {
@@ -1221,6 +1229,47 @@ function getMessageWalCandidateSegmentLoad({segmentKey, segmentById, payloadSign
     }
 
     return {joined, pending, signature}
+}
+
+/**
+ * @summary Read-only tallies of the candidate segment-load join decision above: how many callers
+ * reached it, and how many of those found an in-flight load to join.
+ *
+ * **A read-only observation, and the narrowness is the design.** No reset, no injection, no callback,
+ * no event: production behaves identically whether or not anything reads this. Both decisions are
+ * already made at the lines above — this only lets a caller see that they happened. A hook that
+ * changed what production *does* when observed would be a different thing entirely, and refusing
+ * that shape is the line worth holding.
+ *
+ * **Why a production surface exists for a test at all**, which is the part worth arguing with. A
+ * caller that joins an in-flight segment load produces no side effect — joining is silence by
+ * construction. So nothing external can distinguish "joined" from "has not arrived yet": three
+ * candidate anchors were tried and failed for three different reasons, the last by firing two turns
+ * before the decision. Without this, a test can only guess how long to wait for a second caller that
+ * diverged upstream, and a fixed guess is a budget standing in for a condition.
+ *
+ * **Why both numbers, rather than the decision count alone.** Measured, and the reason this shape
+ * changed: a decision-count rendezvous alone releases a test's gate the microtask the second caller
+ * DECIDES, which is strictly before any read it opens has registered. An assertion placed there
+ * therefore reads one physical read whether the caller joined or not, and passes vacuously with
+ * single-flight broken — the count of reads is a PROXY for joining, and a proxy that resolves late.
+ * `joins` is the fact itself, final in the same synchronous block as the decision it belongs to, so
+ * an assertion on it cannot be early. A test wanting "the second caller joined" should assert this,
+ * not a read count.
+ *
+ * Counted at the decision rather than at function entry: nothing awaits between the two today, so
+ * they are the same moment, but binding the counters to the decision keeps them true if that changes.
+ *
+ * **Monotonic for process lifetime.** Read a baseline before the work under observation and compare
+ * deltas. Absolute values carry every earlier call in the process and mean nothing alone.
+ *
+ * @returns {{decisions: Number, joins: Number}} Totals since module load.
+ */
+export function readMessageWalSegmentLoadObservations() {
+    return {
+        decisions: messageWalCandidateSegmentLoadDecisions,
+        joins    : messageWalCandidateSegmentLoadJoins
+    }
 }
 
 /**

--- a/test/playwright/unit/ai/services/memory-core/MailboxService.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/MailboxService.spec.mjs
@@ -27,7 +27,7 @@ test.describe.configure({ mode: 'serial' });
 test.describe('Neo.ai.services.memory-core.MailboxService', () => {
     let MailboxService, GraphService, PermissionService, LifecycleService, SwarmHeartbeatService, buildMailboxDelta, callMemoryCoreTool, originalAutoSave, mailboxAiConfig, originalMailboxPolicy, readWalMessages, readPendingMessageWalRecords;
     let readBackgroundDeliveryState;
-    let messageWalDir, getWakeDeliverySeries;
+    let messageWalDir, getWakeDeliverySeries, readMessageWalSegmentLoadObservations;
 
     test.beforeAll(async () => {
 
@@ -38,6 +38,7 @@ test.describe('Neo.ai.services.memory-core.MailboxService', () => {
         MailboxService = (await import('../../../../../../ai/services/memory-core/MailboxService.mjs')).default;
         getWakeDeliverySeries = (await import('../../../../../../ai/services/memory-core/MailboxService.mjs')).getWakeDeliverySeries;
         readBackgroundDeliveryState = (await import('../../../../../../ai/services/memory-core/MailboxService.mjs')).readBackgroundDeliveryState;
+        readMessageWalSegmentLoadObservations = (await import('../../../../../../ai/services/memory-core/MailboxService.mjs')).readMessageWalSegmentLoadObservations;
         PermissionService = (await import('../../../../../../ai/services/memory-core/PermissionService.mjs')).default;
         LifecycleService = (await import('../../../../../../ai/services/memory-core/lifecycle/SystemLifecycleService.mjs')).default;
         SwarmHeartbeatService = (await import('../../../../../../ai/daemons/orchestrator/services/SwarmHeartbeatService.mjs')).default;
@@ -1332,6 +1333,9 @@ test.describe('Neo.ai.services.memory-core.MailboxService', () => {
         };
 
         try {
+            // Baseline BEFORE either caller starts. The tallies are monotonic for the process, so
+            // absolute readings would carry every segment load this suite already performed.
+            const loadBaseline = readMessageWalSegmentLoadObservations();
             const globalRepair = MailboxService.repairMessageGraphIntegrity({
                 target: '@bob', box: 'inbox', limit: 1
             });
@@ -1340,26 +1344,34 @@ test.describe('Neo.ai.services.memory-core.MailboxService', () => {
             });
 
             await readEntered;
-            // LEFT UNCHANGED, deliberately. Unlike the same-target pair above, these two callers
+            // A RENDEZVOUS, not a budget. Unlike the same-target pair above, these two callers
             // DIVERGE before the join: the global path awaits the coalescing candidate scan while
-            // the explicit-ids path skips it (`MailboxService.mjs:2705`), so caller two's arrival is
-            // not coupled to caller one's. The single-flight entry drops when caller one's read
-            // RESOLVES, so a legitimately late caller two can open read #2 on CORRECT production and
-            // false-red the exact-count assertion below.
-            //
-            // This budget narrows that window; it does not close it, and no test-side anchor can —
-            // a joining caller produces no observable, and the segment-load helper is module-private.
-            // Removing the pre-release assertion here would imply the remaining wait is sound, which
-            // is a claim this path cannot support. The deterministic rendezvous needs a production
-            // seam and is tracked separately.
-            for (let turn = 0; turn < 3; turn++) {
-                await new Promise(resolve => setImmediate(resolve));
-            }
-            expect(payloadReads, 'different ids in one segment must join before either read completes').toBe(1);
+            // the explicit-ids path skips it, so caller two's arrival is not coupled to caller one's.
+            // Waiting a fixed number of turns for it is a budget standing in for a condition; this
+            // waits for the condition. A timeout here means the second caller genuinely never
+            // reached the decision, never that it was slow.
+            await waitForObservedCount(
+                () => readMessageWalSegmentLoadObservations().decisions - loadBaseline.decisions,
+                2,
+                'both repair callers to reach the segment-load join decision'
+            );
+            // Assert the JOIN, not the read count. Measured, and the reason this is not
+            // `expect(payloadReads).toBe(1)` here: the decision lands strictly before any read it
+            // opens has registered, so a read-count check at this point reads 1 whether the second
+            // caller joined or opened its own, and passes vacuously with single-flight broken. The
+            // read count is a proxy for joining and it resolves late; the join tally is the fact
+            // itself, final in the same synchronous block as the decision.
+            expect(readMessageWalSegmentLoadObservations().joins - loadBaseline.joins,
+                'the second caller must JOIN the in-flight load rather than open its own').toBe(1);
             releasePayloadRead();
 
             const results = await Promise.all([globalRepair, explicitRepair]);
-            expect(payloadReads).toBe(1);
+            expect(payloadReads, 'different ids in one segment must join before either read completes').toBe(1);
+            // One decision per caller is the assumption the rendezvous rests on. If either path ever
+            // spans a second segment, the wait above could be satisfied by one caller alone and
+            // silently decay back into a race — this pins it so that says so instead.
+            expect(readMessageWalSegmentLoadObservations().decisions - loadBaseline.decisions,
+                'the rendezvous assumes exactly one join decision per caller').toBe(2);
             expect(projectCalls).toBe(2);
             expect(results.map(item => item.repaired)).toEqual([1, 1]);
             expect(results.every(item => item.failed === 0)).toBe(true);


### PR DESCRIPTION
Resolves #17204

The divergent-path segment-load test waited a fixed 3 turns for its second caller and then asserted an exact read count. This replaces the budget with the condition it was standing in for: production exports read-only tallies of callers reaching the segment-load join decision and of those finding an in-flight load to join, and the test holds its gate until both callers have decided, then asserts the join directly. **Read the "Deltas from ticket" section before the diff** — the false red this ticket was filed to close does not reproduce, and my first implementation of the fix measurably weakened the test before measurement caught it.

Evidence: L3 (live in-process probes against real production code — instrumented decision-timing measurement plus red and green proofs at two system-load levels) → L3 required (every close-target AC is a property of the test suite itself and is fully verifiable in-sandbox at `--workers=1`, which is what they ask for). Residual: AC-3 re-verified under `workers: 4`, Residual-Owner: #15861 — that configuration does not exist in this repo until its re-land, and its own AC-2 full-suite samples exercise this test there by construction.

## Deltas from ticket

**Substantive, and it cuts against the ticket's own premise.**

**1. The false red does not reproduce.** The ticket asserts that caller two can reach its segment-load decision *after* the single-flight entry is dropped, open its own read, and fail the exact-count assertion on correct production. I instrumented the decision point and measured when caller two actually arrives, across 16 runs at two load levels — ambient, then 36 busy loops on 18 cores, which stretched wall time from 13.6s to 33.6s and confirms the load was real. In every run, **both callers had already reached the join decision before the first physical read even opened**. There is no thin margin; caller two is early by at least one full read-open.

**2. The old test does not false-green either.** With single-flight forced never to reuse its pending promise, the version on `dev` fails at its pre-release assertion in every run (n=5). So the budget is not currently biting in either direction, and the test as it stands is sound in this environment.

**3. What this therefore is: hardening, not a defect fix.** Worth stating plainly rather than letting the ticket's framing stand. What makes the budget safe today is incidental rather than guaranteed — caller one carries strictly more work before its segment load (it awaits the coalescing candidate scan; the explicit-ids path skips it), and that margin is what keeps caller two early. Both then do filesystem work of unbounded duration, so start order does not fix finish order. Nothing pins the ordering, and a change to the coalescing scan could invert it.

**4. Consequence for the board: #17204 does not block #15861.** The ticket declares "Blocks #15861" on the theory that this test is a flake source for the `workers: 4` re-land. On the evidence above it is not one. @neo-opus-vega owns #15861 and #17192 — that dependency should come off.

**5. The seam is two tallies, not the one AC-1 recorded.** AC-1 committed to a bare decision counter. I built that first, and it *regressed the test*: the decision lands strictly before any read it opens has registered, so releasing the gate on decisions alone left the following `payloadReads` check reading 1 whether caller two joined or opened its own — vacuous with single-flight broken. The read count was always a proxy for joining, and one that resolves late. AC-2 asked for arrival that is not observed "through a proxy"; the decisions-only design did not deliver that, and adding the join tally is what finally does. Still read-only, still no reset/injection/callback — the line AC-1 actually drew is intact.

**Given all of the above, the reviewer's live option is to reject the production surface as unearned** and close #17204 won't-fix, leaving the budget in place. I think shipping is the better call — a fixed budget standing in for a condition is a shape this arc has already had to repair once, and the join assertion is strictly stronger than the read-count proxy regardless of the timing question — but the case is weaker than the ticket claimed and I would rather you weigh it than inherit my framing.

## Test Evidence

`test/playwright/unit/ai/services/memory-core/MailboxService.spec.mjs` — the one directly touched surface. Each proof run individually, since `mode: 'serial'` makes a combined run report `1 did not run` for the second test and prove nothing about it.

```bash
npx playwright test -c test/playwright/playwright.config.unit.mjs test/playwright/unit/ai/services/memory-core/MailboxService.spec.mjs -g "concurrent global and explicit repairs share one physical segment load" --workers=1 --retries=0 --repeat-each=10
```

| proof | condition | result |
|---|---|---|
| **Specificity** (AC-3) | correct production, 10 consecutive runs, system load average ~134 on 18 cores | **12 passed** (10 repeats + chroma setup/teardown), 54.8s |
| **Sensitivity** (AC-4) | single-flight forced never to reuse its pending promise, n=5 | **5 failed** at `the second caller must JOIN the in-flight load rather than open its own` — `Expected: 1, Received: 0` |
| **Decision timing** (AC-2) | instrumented probe, n=8 ambient + n=8 under 36 busy loops | delta at first read-open = **2 in all 16 runs**; caller two decides at turn 0 |
| **Old-test control** | `dev` spec + broken single-flight, n=5 | fails at the pre-release assertion every run — no false green to fix |
| **First-design control** | decisions-only rendezvous + broken single-flight, n=5 | passed the pre-release check, failed only post-release — the regression that drove delta 5 |

Repeats run in one process, so each re-takes its baseline — which also exercises the monotonic-tally contract that an absolute reading would have failed. Sensitivity was re-confirmed against the exact committed artifact after the final rebuild, not only against the pre-amend working tree.

Every probe reverted before commit; production is byte-identical to `origin/dev` apart from the three additions in the diff.

## Post-Merge Validation

- [ ] Confirm the test stays green under `workers: 4` when #15861 re-lands — the only condition this repo cannot exercise today, and one its own full-suite samples exercise by construction.
  Residual-Owner: #15861

Delta 4 needs no post-merge step: @neo-opus-vega is being told directly, so the blocker edge comes off #15861 on his judgement rather than on a checkbox nobody re-reads.

## Commits

- `bfa7daca48` — replace the turn budget with a decision rendezvous, assert the join rather than the read count

## Evolution

Shipped the bare decision counter AC-1 recorded, proved specificity on it, then ran sensitivity and found it failing at the *post*-release assertion rather than the pre-release one. That meant my own rendezvous had made the pre-release check vacuous — released one microtask too early, before caller two's read could register. The counter was measuring the right event and the assertion was still reading a proxy. Adding the join tally moved the assertion onto the fact itself, which is what AC-2 had asked for and what the decisions-only shape quietly failed to deliver.

Separately, the instrumentation intended to show the rendezvous was load-bearing showed the opposite — caller two is comfortably early, not marginally so. That falsified the ticket's central claim, which I wrote, so the framing above is a correction of my own premise rather than a discovery about someone else's.

Authored by Ada (Claude Opus 5, Claude Code). Session 00348bc3-c011-4035-90a3-f0eb62b8c95c.
