### PR TITLE
fix(ai): drop null from healthcheck posture enum (#17220)

### DIFF
--- a/ai/mcp/server/memory-core/openapi.yaml
+++ b/ai/mcp/server/memory-core/openapi.yaml
@@ -3403,7 +3403,7 @@ components:
             posture:
               type: string
               nullable: true
-              enum: [degraded, healthy, unknown, disabled, null]
+              enum: [degraded, healthy, unknown, disabled]
               example: "healthy"
             leaseHolder:
               type: string


### PR DESCRIPTION
Resolves #17220

One-line contract repair: `HealthCheckResponse.heavyMaintenanceStarvation.posture` in the memory-core MCP OpenAPI spec declared `nullable: true` AND a literal `null` inside its `enum` — the only such double declaration across all six server specs. The OpenAPI→zod→JSON-Schema pipeline (`buildZodSchemaFromNode` → `z.enum([..., null]).nullable()` → `z.toJSONSchema({target: 'openapi-3.0'})`) then emitted `{"nullable": true, "enum": [...]}` with no `type`, because zod v4 cannot assert `type: string` over an enum containing null. Kimi Code CLI's strict tool-schema validator rejects `nullable` without `type` and marks the entire `neo-mjs-memory-core` server unavailable at attach — one spec node removed all 42 memory-core tools from that seat (harness log evidence on the ticket: two boot-time rejections at 2026-08-15T20:40:29Z and 21:54:56Z). Lenient harnesses (Claude Code, Gemini CLI, Codex, OpenCode) never noticed, which is why the server "worked" for every peer. Dropping the redundant `null` member — nullability stays via `nullable: true`, and the runtime's `posture: null` return is still accepted through the `.nullable()` wrap at `openApiValidator.mjs:255-257` — restores a typed emission: `{type: 'string', nullable: true, enum: [degraded, healthy, unknown, disabled]}`.

Evidence: L1 (converter-level emission, red→green through the repo's own `openApiValidator.mjs`) achieved → L2 (live Kimi Code CLI session attach) is gated on the daemon redeploy; residual AC4 tracked under Post-Merge Validation.

## Deltas from ticket

None substantive — the ticket prescribed exactly this one-line change; the diff is one line (verified against the ticket's Contract Ledger before opening).

## Test Evidence

- RED control (pre-fix, real converter pipeline): healthcheck output schema built via `buildOutputZodSchema` + `toOpenApiJsonSchema` from the unedited spec → `posture` node `{"nullable":true,"enum":["degraded","healthy","unknown","disabled",null]}` — `type` absent, matching the live-served byte-shape probed over the streamable-HTTP endpoint at 2026-08-15T21:59Z.
- GREEN (post-fix): identical run → `{"nullable":true,"type":"string","enum":["degraded","healthy","unknown","disabled"]}`.
- AC3 census (js-yaml walk over `ai/mcp/server/*/openapi.yaml`): zero `null`-in-enum nodes remain across all six server specs.
- `npm run test-unit -- test/playwright/unit/ai/mcp/validation/OpenApiValidatorCompliance.spec.mjs` → 51 passed (4.4s). Note for reviewers: this suite compiles with Ajv `strict: false`, which tolerates a bare `nullable` — it could not have caught this defect; the Kimi Code CLI validator is stricter. The suite passing post-fix confirms no existing assertion depended on the removed enum member.
- Touched surface coverage beyond the compliance suite (converter-level, all five servers' specs): `None found` — no dedicated healthcheck-output-schema spec exists.

## Post-Merge Validation

AC4's live-attach proof is deployment-gated, not PR-gated. The daemon serving `127.0.0.1:3102` (an ssh forward to a remote process) picks up this spec on its next redeploy — an operator routine, recorded as AC4 on the ticket. After that redeploy, a fresh Kimi Code CLI session must attach `neo-mjs-memory-core` (42 tools visible, no `nullable` error in the harness log); a failure there is a new defect sighting, not work this PR owes.

Authored by Iris (Kimi K3, Kimi Code CLI). Session session_d72a0190-8d4a-47aa-b22f-58d988e1c878.
