### PR TITLE
feat(build): scoped block-alignment repair replaces rejection in the pre-commit hook (#17201)

### DIFF
--- a/buildScripts/util/check-block-alignment.mjs
+++ b/buildScripts/util/check-block-alignment.mjs
@@ -24,8 +24,10 @@ import {getStagedAddedLines} from './stagedDiff.mjs';
  * never touches an un-alignable shape and cannot false-positive. The column math is the entire point.
  *
  * Usage:
- *   node buildScripts/util/check-block-alignment.mjs <file.mjs> [...]       # check; exit 1 on drift
- *   node buildScripts/util/check-block-alignment.mjs --fix <file.mjs> [...] # rewrite to aligned form
+ *   node buildScripts/util/check-block-alignment.mjs <file.mjs> [...]                # check; exit 1 on drift
+ *   node buildScripts/util/check-block-alignment.mjs --staged <file.mjs> [...]       # check, scoped to staged-added lines
+ *   node buildScripts/util/check-block-alignment.mjs --fix <file.mjs> [...]          # rewrite whole-file (deliberate pass)
+ *   node buildScripts/util/check-block-alignment.mjs --fix --staged <file.mjs> [...] # pre-commit repair: rewrite only staged-added lines
  */
 
 // ───────────────────────────── import-`from` (v1) ─────────────────────────────
@@ -554,14 +556,24 @@ function formatViolation(file, {lineIndex, expectedColumn, kind}) {
  * @summary Checks (or, with `fix`, rewrites) one file across all three alignment groups. The
  * evaluators are chained — each sees the prior's fixed lines — which is safe because none changes the
  * line COUNT and the three line-shapes (import / property / declaration) are disjoint.
+ *
+ * Dispositions: check mode reports drift (scoped to staged-added lines under `--staged`); pure
+ * `--fix` rewrites whole-file as a deliberate pass; `--fix --staged` (the pre-commit repair)
+ * rewrites ONLY violations on the author's staged-added lines, so a grandfathered misalignment on an
+ * untouched line is never sprayed into an unrelated commit. The scoped repair fails CLOSED: without
+ * a reliable staged-line set it reports and writes nothing (`'unfixable'`).
  * @param {String}  file
  * @param {Boolean} fix
- * @returns {Boolean} whether the file had (check) or had-and-fixed (fix) drift.
+ * @param {String}  [gitRoot]   Repository root for staged-line scoping (check `--staged` and `--fix --staged`).
+ * @param {Boolean} [scopedFix] `true` only in `--fix --staged` mode — distinguishes the scoped repair
+ * from the deliberate whole-file pass, whose gitRoot is likewise null.
+ * @returns {String} `'clean' | 'reported' | 'fixed' | 'unfixable'`
  */
-function processFile(file, fix, gitRoot = null) {
+function processFile(file, fix, gitRoot = null, scopedFix = false) {
     const allViolations = [];
-    let   lines         = fs.readFileSync(file, 'utf8').split('\n');
-    const maskedLines   = computeTemplateLiteralLineMask(lines);
+    const originalLines = fs.readFileSync(file, 'utf8').split('\n');
+    const maskedLines   = computeTemplateLiteralLineMask(originalLines);
+    let   lines         = originalLines;
 
     for (const evaluate of EVALUATORS) {
         const {violations, fixedLines} = evaluate(lines, maskedLines);
@@ -569,28 +581,56 @@ function processFile(file, fix, gitRoot = null) {
         lines = fixedLines;
     }
 
-    if (allViolations.length === 0) return false;
+    if (allViolations.length === 0) return 'clean';
 
     if (fix) {
+        if (scopedFix) {
+            const added = gitRoot ? getStagedAddedLines(file, gitRoot) : null;
+
+            // Fail CLOSED: no reliable staged-line set ⇒ report, never rewrite — a git hiccup must
+            // never silently become a whole-file reformat inside an author's commit.
+            if (!added) {
+                for (const violation of allViolations.sort((a, b) => a.lineIndex - b.lineIndex)) {
+                    console.error(formatViolation(file, violation));
+                }
+
+                return 'unfixable';
+            }
+
+            const owned = allViolations.filter(v => added.has(v.lineIndex + 1));
+
+            if (owned.length === 0) return 'clean';
+
+            // The scoped repair = the whole-file fix masked to owned lines: each violation's fixed
+            // line is exactly what a deliberate pass would write for it, applied nowhere else.
+            const applied = originalLines.slice();
+            for (const violation of owned) {
+                applied[violation.lineIndex] = lines[violation.lineIndex];
+            }
+
+            fs.writeFileSync(file, applied.join('\n'), 'utf8');
+            console.log(`Aligned ${owned.length} line(s) in ${file}` + (owned.length < allViolations.length ? ` — left ${allViolations.length - owned.length} untouched-line violation(s) as-is` : ''));
+            return 'fixed';
+        }
+
         fs.writeFileSync(file, lines.join('\n'), 'utf8');
         console.log(`Aligned ${allViolations.length} line(s) in ${file}`);
-        return true;
+        return 'fixed';
     }
 
     // Staged (pre-commit) check mode: report only drift the author introduced on staged-added lines,
     // so a grandfathered misalignment on an untouched line never blocks an unrelated commit. Fail
     // CLOSED: a null detection (git read failure) reports the whole file rather than suppressing drift.
-    // (gitRoot is set only in --staged check mode; --fix always rewrites whole-file.)
     const added    = gitRoot ? getStagedAddedLines(file, gitRoot) : null;
     const reported = added ? allViolations.filter(v => added.has(v.lineIndex + 1)) : allViolations;
 
-    if (reported.length === 0) return false;
+    if (reported.length === 0) return 'clean';
 
     for (const violation of reported.sort((a, b) => a.lineIndex - b.lineIndex)) {
         console.error(formatViolation(file, violation));
     }
 
-    return true;
+    return 'reported';
 }
 
 const
@@ -599,11 +639,12 @@ const
     staged = args.includes('--staged'),
     files  = args.filter(arg => arg !== '--fix' && arg !== '--staged');
 
-// --staged (pre-commit) mode: resolve the repo root once so processFile can scope check-mode drift to
-// the author's staged-added lines. Fail-closed: a rev-parse failure → null gitRoot → whole-file (drift
-// is never suppressed by a git failure). Only meaningful in check mode; --fix always rewrites whole-file.
+// --staged (pre-commit) mode: resolve the repo root once so processFile can scope drift to the
+// author's staged-added lines — in check mode for the REPORT set, in `--fix --staged` mode for the
+// REWRITE set. Fail-closed: a rev-parse failure → null gitRoot → check mode reports whole-file and
+// the scoped repair refuses to write (drift is neither suppressed nor half-repaired by a git failure).
 let gitRoot = null;
-if (staged && !fix) {
+if (staged) {
     try {
         gitRoot = execFileSync('git', ['rev-parse', '--show-toplevel'], {encoding: 'utf8'}).trim();
     } catch (e) {
@@ -612,12 +653,15 @@ if (staged && !fix) {
 }
 
 let
-    hadDrift = false,
-    hadError = false;
+    hadDrift     = false,
+    hadError     = false,
+    hadUnfixable = false;
 
 for (const file of files) {
     try {
-        if (processFile(file, fix, gitRoot)) hadDrift = true;
+        const result = processFile(file, fix, gitRoot, staged && fix);
+        if (result === 'reported' || result === 'fixed') hadDrift = true;
+        if (result === 'unfixable') hadUnfixable = true;
     } catch (err) {
         console.error(`Error processing ${file}: ${err.message}`);
         hadError = true;
@@ -626,11 +670,17 @@ for (const file of files) {
 
 // A file that could NOT be processed (missing, unreadable, unwritable) is always a failure — including
 // under --fix, where a silent exit 0 would mask a repair that never happened. Alignment drift, by
-// contrast, fails only in check mode: --fix repairs it, so a clean repair exits 0.
+// contrast, fails only in check mode: --fix repairs it, so a clean repair exits 0. A scoped repair
+// that could not obtain a reliable staged-line set reported instead of rewriting — that fails too,
+// since the drift it found is still in the file.
 if (hadDrift && !fix) {
     console.error('\nBlock-alignment drift found. Run: node buildScripts/util/check-block-alignment.mjs --fix <files>');
 }
 
-if (hadError || (hadDrift && !fix)) {
+if (hadUnfixable) {
+    console.error('\nBlock-alignment repair skipped: staged-line detection failed. No files were rewritten — resolve the git error and retry.');
+}
+
+if (hadError || hadUnfixable || (hadDrift && !fix)) {
     process.exit(1);
 }

--- a/package.json
+++ b/package.json
@@ -258,7 +258,7 @@
             "node ./buildScripts/util/check-shorthand.mjs",
             "node ./buildScripts/util/check-jsdoc-types.mjs",
             "node ./buildScripts/util/check-ticket-archaeology.mjs",
-            "node ./buildScripts/util/check-block-alignment.mjs --staged",
+            "node ./buildScripts/util/check-block-alignment.mjs --fix --staged",
             "node ./buildScripts/util/check-parse.mjs"
         ],
         "test/**/*.mjs": [

--- a/test/playwright/unit/ai/buildScripts/util/check-block-alignment.spec.mjs
+++ b/test/playwright/unit/ai/buildScripts/util/check-block-alignment.spec.mjs
@@ -511,3 +511,117 @@ test.describe('check-block-alignment.mjs --staged diff-scope (#13720)', () => {
         expect(r.output).toContain('Misaligned');
     });
 });
+
+/**
+ * Real-git integration for the scoped pre-commit REPAIR (`--fix --staged`): the hook converts from
+ * reject to repair, rewriting ONLY drift on the author's staged-added lines. A grandfathered
+ * misalignment on an untouched line stays byte-identical; a git detection failure reports and never
+ * writes (fail-closed); pure `--fix` stays the deliberate whole-file pass. The detector is untouched —
+ * the entire pre-existing suite above runs unmodified against the new disposition surface.
+ */
+test.describe('check-block-alignment.mjs --fix --staged scoped repair (#17201)', () => {
+    let stagedDir;
+
+    const git = (...a) => execFileSync('git', a, {cwd: stagedDir, stdio: 'ignore'});
+
+    // execFileSync with an argv array (no shell), cwd-pinned to the fixture repo: the script resolves
+    // its gitRoot from the process cwd, exactly as lint-staged's invocation resolves the real one.
+    const run = (args, cwd = stagedDir) => {
+        try {
+            return {status: 0, output: execFileSync('node', [scriptPath, ...args], {cwd, encoding: 'utf8', stdio: 'pipe'})};
+        } catch (error) {
+            return {status: error.status, output: (error.stderr || '') + (error.stdout || '')};
+        }
+    };
+
+    test.beforeEach(() => {
+        stagedDir = fs.mkdtempSync(path.join(os.tmpdir(), 'neo-blockalign-scopedfix-'));
+        git('init');
+        git('config', 'user.email', 'test@example.com');
+        git('config', 'user.name', 'Test User');
+    });
+
+    test.afterEach(() => {
+        fs.rmSync(stagedDir, {recursive: true, force: true});
+    });
+
+    test('rewrites only staged-added-line drift; a grandfathered misalignment stays byte-identical (AC1)', () => {
+        const file = path.join(stagedDir, 'src.mjs');
+        // Committed: a misaligned import pair (line 1 drifts) — grandfathered, never owned again.
+        fs.writeFileSync(file, "import a from 'a';\nimport bb from 'b';\n", 'utf8');
+        git('add', 'src.mjs');
+        git('commit', '-m', 'init');
+
+        // Staged: an unrelated object block whose colon drift sits entirely on the ADDED lines.
+        fs.writeFileSync(file, [
+            "import a from 'a';",
+            "import bb from 'b';",
+            'const config = {',
+            '    db: 1,',
+            '    intervals: 3',
+            '};',
+            ''
+        ].join('\n'), 'utf8');
+        git('add', 'src.mjs');
+
+        expect(run(['--fix', '--staged', 'src.mjs']).status).toBe(0);
+
+        const lines = fs.readFileSync(file, 'utf8').split('\n');
+        expect(lines[0]).toBe("import a from 'a';");   // grandfathered import drift: byte-identical
+        expect(lines[1]).toBe("import bb from 'b';");
+        expect(lines[3]).toBe('    db       : 1,');    // owned colon drift: repaired
+        expect(lines[4]).toBe('    intervals: 3');
+    });
+
+    test('fails closed without a reliable staged-line set: reports, never writes (AC2)', () => {
+        // No git repository at or above this cwd: rev-parse fails, so the scoped repair must refuse
+        // to write rather than degrade into a whole-file reformat on a transient git error.
+        const bareDir = fs.mkdtempSync(path.join(os.tmpdir(), 'neo-blockalign-norepo-'));
+        try {
+            const file     = path.join(bareDir, 'src.mjs');
+            const original = "import a from 'a';\nimport bb from 'b';\n";
+            fs.writeFileSync(file, original, 'utf8');
+
+            const r = run(['--fix', '--staged', file], bareDir);
+            expect(r.status).toBe(1);
+            expect(r.output).toContain('Misaligned');
+            expect(r.output).toContain('repair skipped');
+            expect(fs.readFileSync(file, 'utf8')).toBe(original);   // byte-identical: nothing rewritten
+        } finally {
+            fs.rmSync(bareDir, {recursive: true, force: true});
+        }
+    });
+
+    test('the hook disposition: stage misaligned → --fix --staged repairs → commit proceeds, aligned (AC3)', () => {
+        const file = path.join(stagedDir, 'src.mjs');
+        // A brand-new file whose entire content is staged-added: every violation is owned.
+        fs.writeFileSync(file, "import a from 'a';\nimport bb from 'b';\n", 'utf8');
+        git('add', 'src.mjs');
+
+        // What the pre-commit hook now runs (the package.json lint-staged entry pinned below).
+        expect(run(['--fix', '--staged', 'src.mjs']).status).toBe(0);
+
+        git('add', 'src.mjs');                      // lint-staged re-stages the repair
+        git('commit', '-m', 'fixture commit');      // the commit proceeds without author action
+
+        const committed = execFileSync('git', ['show', 'HEAD:src.mjs'], {cwd: stagedDir, encoding: 'utf8'});
+        expect(committed).toBe("import a  from 'a';\nimport bb from 'b';\n");
+    });
+
+    test('the lint-staged entry invokes the scoped repair (AC3 wiring pin)', () => {
+        const pkg = JSON.parse(fs.readFileSync(path.resolve(__dirname, '../../../../../../package.json'), 'utf8'));
+        expect(pkg['lint-staged']['*.mjs']).toContain('node ./buildScripts/util/check-block-alignment.mjs --fix --staged');
+    });
+
+    test('pure --fix remains the deliberate whole-file pass, grandfathered drift included (AC4)', () => {
+        const file = path.join(stagedDir, 'src.mjs');
+        fs.writeFileSync(file, "import a from 'a';\nimport bb from 'b';\n", 'utf8');
+        git('add', 'src.mjs');
+        git('commit', '-m', 'init');
+
+        // Nothing staged at all: the scoped repair would own no line, but a deliberate --fix
+        // rewrites the whole file regardless of staging.
+        expect(run(['--fix', 'src.mjs']).status).toBe(0);
+        expect(fs.readFileSync(file, 'utf8')).toBe("import a  from 'a';\nimport bb from 'b';\n");
+    });
+});


### PR DESCRIPTION
Resolves #17201

The block-alignment gate converts from reject to repair: `--fix --staged` rewrites only violations on the author's staged-added lines (the deliberate whole-file fix, masked to owned lines), and the pre-commit hook now runs it — same violations, same detector, zero author round-trips. Fail-closed: no reliable staged-line set ⇒ report, never rewrite. Pure `--fix` stays the deliberate whole-file pass.

Evidence: L3 (real-git fixture repos + live dogfood of the repo's own pre-commit hook on this branch's commit) → L2 required (all five ACs are sandbox-provable; AC3 itself names a fixture commit). No residuals.

## Deltas from ticket

None substantive — the ticket's three-step fix landed as written: Ada's existing `getStagedAddedLines` scoping applied to the rewrite set, fail-closed on git-read failure, hook wired to `--fix --staged` with lint-staged re-staging. One naming addition the ticket left open: the per-file disposition is now a 4-state return (`'clean' | 'reported' | 'fixed' | 'unfixable'`) so the driver can exit 1 when a scoped repair had to report instead of write — the `hadError`/`hadDrift` split from PR #13558 is preserved untouched.

## Test Evidence

- `npm run test-unit -- test/playwright/unit/ai/buildScripts/util/check-block-alignment.spec.mjs` → **33 passed, 0 failed** at head e7b438dff3 (28 pre-existing detector/scoping pins unmodified + 5 new scoped-repair specs).
- Mutation positive control (script change stashed, specs kept): AC1 + AC2 specs fail on the old code, the 3 unchanged-behavior/wiring pins pass — the red pair proves the specs measure the new semantics, not incidental state.
- AC mapping: AC1 → `rewrites only staged-added-line drift; a grandfathered misalignment stays byte-identical (AC1)`; AC2 → `fails closed without a reliable staged-line set: reports, never writes (AC2)`; AC3 → `the hook disposition: stage misaligned → --fix --staged repairs → commit proceeds, aligned (AC3)` + `the lint-staged entry invokes the scoped repair (AC3 wiring pin)`; AC4 → `pure --fix remains the deliberate whole-file pass, grandfathered drift included (AC4)`; AC5 → the 28 pre-existing specs green without a single modification (detector untouched).
- Live dogfood: this branch's own commit ran the real hook — the lint-staged log shows `node ./buildScripts/util/check-block-alignment.mjs --fix --staged` COMPLETED followed by `Staging changes from tasks…`; commit proceeded without author action.
- Per directly touched surface: `buildScripts/util/check-block-alignment.mjs`: spec above; `package.json` lint-staged entry: wiring-pin spec + the `lint-guard-ci-parity` hook (passes — the clientOnly registry keys on the script path, so the flag change needs no registry delta).

## Post-Merge Validation

None — every AC is proven at the PR head (fixtures + live dogfood). Informational only: the first organic misaligned commit by any seat will exercise the repair inline, visible as `Aligned N line(s)` in the lint-staged output.

Authored by Iris (K3, Kimi Code CLI). Session 4660afcc-8b00-427a-8d39-4b1f3624a410.
