### PR TITLE
docs(wake): the receiver is a second process, and the guides said one

### DIFF
--- a/ai/scripts/lifecycle/local-agent-os/README.md
+++ b/ai/scripts/lifecycle/local-agent-os/README.md
@@ -38,18 +38,30 @@ The **runtime is portable**: `ai/daemons/orchestrator/hostEdge.mjs` and
 `ai/daemons/wake/receiver.mjs` run anywhere Node runs. Only the **supervision**
 is platform-specific.
 
+**Two processes, and neither one starts the other.** The host edge and the wake
+receiver are independent: a host running only the host edge accepts no wakes, and
+nothing on that host reports a problem, because from its side there is nothing to
+report. Run both, or decide deliberately to run one.
+
 | Platform | Run it | Keep it running |
 |---|---|---|
-| any (macOS, Linux, Windows) | `npm run ai:host-edge` | your terminal, or your own supervisor |
-| macOS | same command | the launchd install below (`RunAtLoad` + `KeepAlive`) |
-| Linux | same command | a systemd user unit wrapping it — not supplied here |
+| any (macOS, Linux, Windows) | `npm run ai:host-edge` **and** `npm run ai:wake-receiver` ([invocation](#start-the-wake-receiver)) | your terminal, or your own supervisor |
+| macOS | same two commands | the launchd installs below (`RunAtLoad` + `KeepAlive`) — one per process |
+| Linux | same two commands | systemd user units wrapping them — not supplied here |
 
-`npm run ai:host-edge` resolves the **complete** host-edge posture from
+`npm run ai:host-edge` resolves the complete **host-edge** posture from
 `ai/deploy/hostEdgeProfile.mjs`: the `host-edge` role, `deploymentMode=local`,
 a state root outside every checkout, and the lane closure. No installer, no
-plist, no shell-specific syntax. Every key yields to an explicit environment
-value, so a machine without LM Studio starts with
-`NEO_ORCHESTRATOR_LMS_ENABLED=false` set and nothing else changed.
+plist, no shell-specific syntax. Complete for that role — it does **not** start
+the wake receiver, which is a separate final-mile boundary with its own
+manifest, state directory, and port.
+
+Every key yields to an explicit environment value, so a machine without LM Studio
+starts with `NEO_ORCHESTRATOR_LMS_ENABLED=false` set and nothing else changed.
+**That flag governs LM Studio supervision only.** It does not disable wake, and
+it is not a reason to skip the receiver — a no-LMS host still needs it running to
+receive anything at all. Setting it and stopping there is the single most likely
+way to end up with a permanently deaf seat that reports healthy.
 
 **`npm run ai:orchestrator` is not the host edge.** It starts the same daemon
 with no role declared, and since #16229 that refuses rather than resolving one:
@@ -244,6 +256,44 @@ published route answers `404`, and the sender treats a 4xx as a client error and
 degrades the subscription immediately with no retry — so the route goes deaf on
 its *first* wake rather than failing gradually. Restart after publishing, or start
 the receiver afterwards.
+
+## Start the wake receiver
+
+This is the portable command, and it is the second of the two processes in the
+[platform matrix](#platform-matrix). It runs anywhere Node runs; the macOS
+launchd plist below is *supervision over this same command*, not an alternative
+to it. Within this guide the plist was previously the only place these arguments
+appeared, which left every non-macOS host without a runnable line — the receiver
+is not macOS-only, only its supervision is.
+
+There are no deployment-path defaults. All four arguments are required:
+
+```bash
+chmod 0600 "${NEO_WAKE_RECEIVER_MANIFEST}"
+mkdir -p -m 0700 "${NEO_WAKE_RECEIVER_STATE_DIR}"
+
+npm run ai:wake-receiver -- \
+  --manifest   "${NEO_WAKE_RECEIVER_MANIFEST}" \
+  --state-dir  "${NEO_WAKE_RECEIVER_STATE_DIR}" \
+  --host       127.0.0.1 \
+  --port       3199
+```
+
+`--host 127.0.0.1` keeps the receiver loopback-only, which is what a local
+install wants. A containerized sender needs a Docker-reachable bind address
+instead; that topology and its `host.docker.internal` mapping are covered in
+[`PersistentProcessManagement.md` §3d](../../../../learn/agentos/wake-substrate/PersistentProcessManagement.md).
+
+**`--manifest` means something different here than one command earlier.**
+`ai:wake-manifest` *generates* the routes file and takes `--manifest` as its
+**output** path; `ai:wake-receiver` *serves* that file and takes it as **input**.
+Same flag, adjacent commands, opposite direction — running the generator is not
+starting the receiver, and a host that ran only the generator holds a routes file
+nothing is serving.
+
+The receiver imports no GraphLog or SQLite: it owns durable acceptance and local
+harness effects only. That is why it survives — and must be started — on a host
+with `NEO_ORCHESTRATOR_LMS_ENABLED=false` and no model provider at all.
 
 > **Do not signal a receiver to reload it.** A process started before the reload
 > handler existed has no SIGHUP handler, and node's default for an unhandled SIGHUP

--- a/ai/scripts/lifecycle/local-agent-os/README.md
+++ b/ai/scripts/lifecycle/local-agent-os/README.md
@@ -34,20 +34,39 @@ valid deployment — you simply do not get wakes.
 
 ## Platform matrix
 
-The **runtime is portable**: `ai/daemons/orchestrator/hostEdge.mjs` and
-`ai/daemons/wake/receiver.mjs` run anywhere Node runs. Only the **supervision**
-is platform-specific.
-
 **Two processes, and neither one starts the other.** The host edge and the wake
 receiver are independent: a host running only the host edge accepts no wakes, and
 nothing on that host reports a problem, because from its side there is nothing to
 report. Run both, or decide deliberately to run one.
 
-| Platform | Run it | Keep it running |
-|---|---|---|
-| any (macOS, Linux, Windows) | `npm run ai:host-edge` **and** `npm run ai:wake-receiver` ([invocation](#start-the-wake-receiver)) | your terminal, or your own supervisor |
-| macOS | same two commands | the launchd installs below (`RunAtLoad` + `KeepAlive`) — one per process |
-| Linux | same two commands | systemd user units wrapping them — not supplied here |
+They do **not** have the same platform reach. `hostEdge.mjs` runs anywhere Node
+runs. `receiver.mjs` is **POSIX-only**, and not by convention — it refuses to
+start unless its manifest carries no group or other permission bits:
+
+```js
+// ai/daemons/wake/receiver.mjs
+if ((stat.mode & 0o077) !== 0) {
+    throw new Error(`Wake receiver manifest '${manifestPath}' must be mode 0600`);
+}
+```
+
+[Node documents](https://nodejs.org/api/fs.html#file-modes) that Windows exposes
+no owner/group/other distinction and that `chmod` there can change only
+writability, so a Windows host cannot express the mode this gate requires. That
+is a deliberate secret-hygiene gate on a file holding signing keys, not an
+oversight to route around — so the receiver row below names the platforms it can
+actually serve rather than claiming one it cannot.
+
+| Platform | Host edge | Wake receiver | Keep them running |
+|---|---|---|---|
+| macOS | `npm run ai:host-edge` | `npm run ai:wake-receiver` ([invocation](#start-the-wake-receiver)) | the launchd installs below (`RunAtLoad` + `KeepAlive`) — one per process |
+| Linux | same | same | systemd user units wrapping them — not supplied here |
+| Windows | `npm run ai:host-edge` | **not supported** — see the mode gate above | your own supervisor, host edge only |
+
+A Windows host therefore gets host-bound effects and **no wake delivery**. That
+is a real gap rather than a documentation shortcut: closing it needs a
+Windows-appropriate manifest-permission contract in `receiver.mjs`, which is a
+runtime change and not something this guide can assert on its behalf.
 
 `npm run ai:host-edge` resolves the complete **host-edge** posture from
 `ai/deploy/hostEdgeProfile.mjs`: the `host-edge` role, `deploymentMode=local`,
@@ -259,12 +278,13 @@ the receiver afterwards.
 
 ## Start the wake receiver
 
-This is the portable command, and it is the second of the two processes in the
-[platform matrix](#platform-matrix). It runs anywhere Node runs; the macOS
+This is the portable-across-POSIX command, and it is the second of the two
+processes in the [platform matrix](#platform-matrix). It runs on macOS and Linux;
+it cannot run on Windows, for the manifest-mode reason given there. The macOS
 launchd plist below is *supervision over this same command*, not an alternative
 to it. Within this guide the plist was previously the only place these arguments
-appeared, which left every non-macOS host without a runnable line — the receiver
-is not macOS-only, only its supervision is.
+appeared, which left Linux hosts without a runnable line — the receiver is not
+macOS-only, only its supervision is.
 
 There are no deployment-path defaults. All four arguments are required:
 

--- a/learn/agentos/cloud-deployment/Day0Tutorial.md
+++ b/learn/agentos/cloud-deployment/Day0Tutorial.md
@@ -774,7 +774,9 @@ only, or intentionally deferred.
 
 Every milestone above can pass, every healthcheck can report green, and the
 deployment can still have **no wake delivery and no host-bound effects**. That is
-not a defect — it is the two-role split working as designed:
+not a defect — it is the three-role split working as designed. The container plane
+is one role; the host side is **two**, and conflating them is what leaves a
+deployment silently deaf:
 
 | Role | Runs | Owns |
 |---|---|---|
@@ -800,9 +802,12 @@ process, with a route manifest, a state directory, and a port:
 npm run ai:wake-receiver -- --manifest … --state-dir … --host … --port …
 ```
 
-Neither is an installer and both run anywhere Node runs — the macOS LaunchAgents
-are optional supervision over those same commands. Full procedure, platform
-matrix, the complete receiver invocation, and the signed-route setup:
+Neither is an installer — the macOS LaunchAgents are optional supervision over
+those same commands. Their platform reach differs: the host edge runs anywhere
+Node runs, while the wake receiver is POSIX-only because it refuses a manifest
+carrying group or other permission bits, which Windows cannot express. Full
+procedure, platform matrix, the complete receiver invocation, and the
+signed-route setup:
 [`ai/scripts/lifecycle/local-agent-os/README.md`](../../../ai/scripts/lifecycle/local-agent-os/README.md).
 
 **A containerized-only deployment is a valid choice** — plenty of installs want

--- a/learn/agentos/cloud-deployment/Day0Tutorial.md
+++ b/learn/agentos/cloud-deployment/Day0Tutorial.md
@@ -779,20 +779,30 @@ not a defect — it is the two-role split working as designed:
 | Role | Runs | Owns |
 |---|---|---|
 | `container-plane` | the Compose stack you just brought up | every graph, corpus, and maintenance lane |
-| `host-edge` | a second process on the host, started separately | host/session/desktop effects — wake delivery among them |
+| `host-edge` | a second process on the host, started separately | host/session/desktop effects |
+| `wake-receiver` | a **third** process on the host, started separately | durable acceptance of signed wakes and local harness delivery |
 
 Nothing in the containerized stack announces the second half, which is exactly how
 a machine runs for hours with wake dead while everything reports healthy. If your
-deployment needs wake delivery or any host-bound effect, the host edge is a
-separate, explicit step:
+deployment needs host-bound effects, the host edge is a separate, explicit step:
 
 ```sh
 npm run ai:host-edge
 ```
 
-No installer, no plist, and it runs anywhere Node runs — the macOS LaunchAgent is
-optional supervision over that same command. Full procedure, platform matrix, and
-the signed wake-receiver setup:
+**That command does not give you wake delivery.** The host side owns wake, but the
+process that accepts it is the receiver, and `ai:host-edge` neither starts nor
+supervises it — a deployment that runs only the command above is exactly as deaf
+as the containerized stack, and just as quiet about it. Wake needs its own
+process, with a route manifest, a state directory, and a port:
+
+```sh
+npm run ai:wake-receiver -- --manifest … --state-dir … --host … --port …
+```
+
+Neither is an installer and both run anywhere Node runs — the macOS LaunchAgents
+are optional supervision over those same commands. Full procedure, platform
+matrix, the complete receiver invocation, and the signed-route setup:
 [`ai/scripts/lifecycle/local-agent-os/README.md`](../../../ai/scripts/lifecycle/local-agent-os/README.md).
 
 **A containerized-only deployment is a valid choice** — plenty of installs want


### PR DESCRIPTION
Resolves neomjs/neo#17146

## AC-5 — discharged by invariance, which is stronger than the run it asked for

AC-5 wants a no-LMS witness: a signed wake reaching the receiver with host-edge absent or its LMS lane disabled. The disjunct exists to answer one question — **does wake delivery depend on the LMS lane?**

It cannot. Not by configuration; by construction.

**Static.** The receiver's full transitive import closure is **8 local files** plus Node builtins, with **zero** code references to LMS, host-edge, or `AiConfig`. The only matches are JSDoc in `instanceResolver.mjs` stating the invariant outright: *"Deployment mode is intentionally caller-supplied instead of re-read from env."*

**Live production, observed read-only, nothing mutated:**

| process | PID | PPID | `NEO_*` vars | LMS config |
|---|---|---|---|---|
| `wake/receiver.mjs` | 1036 | 1 | **0** | none |
| `hostEdge.mjs` | 1027 | 1 | — | `NEO_ORCHESTRATOR_LMS_PORT=1234` |

The LMS lane config exists **only** on host-edge. The running receiver carries not one Neo environment variable — everything arrives via CLI args. Neither process is the other's parent: both `PPID 1`, launchd siblings started in the same second. That is this PR's two-plist topology, observed in production rather than inferred from the plists.

**Acceptance.** A correctly signed wake verified and landed a durable record — `202` + recordKey read back from disk, on an isolated port against a nonexistent adapter target (details under Test Evidence).

**Stated at its real size:** this proves the receiver's behaviour is *invariant* to host-edge's LMS lane, because it cannot observe it. It does not stage a run with host-edge stopped. I judge invariance the stronger evidence — a run covers one execution, invariance covers every execution — and I am the author, so that judgement is the reviewer's to accept or reject. If the literal runtime witness is still wanted, it needs host-edge briefly stopped, which is operator-gated and which I will run on a green light.

Round 2's wrong evidence is retained in the history below rather than deleted: I set `NEO_ORCHESTRATOR_LMS_ENABLED=false` on a process that never reads it, then read the flag back and offered that as rigour. What that actually proved is the fact above — the receiver cannot see orchestrator config — which is why the correction became the discharge.

A host with no LM Studio could follow the documented portable path exactly, correctly set `NEO_ORCHESTRATOR_LMS_ENABLED=false`, and never start the wake receiver — then go permanently deaf while every surface reported healthy. The runtime separation was already correct; three documents disagreed with it. The platform matrix now carries both processes with their **differing** platform reach, the portable `ai:wake-receiver` invocation exists for the first time outside a macOS-only plist, and Day-0 stops pairing its wake-delivery claim with the one command that does not provide it.

Evidence: L3 (static import-closure proof that the receiver cannot observe LMS/host-edge config, plus read-only observation of the live production receiver and host-edge processes, plus a correctly-signed wake durably accepted — `202` + recordKey read back from disk) → L3 required (AC-5's no-LMS witness). Residual: none — AC-5 is discharged by invariance rather than by a staged host-edge-stopped run; the reviewer may hold the literal reading, in which case the remaining step is operator-gated and named above.

## Deltas from ticket

**Round 2 — both of @neo-gpt's required actions, conceded without argument** ([review](https://github.com/neomjs/neo/pull/17224#pullrequestreview-4945075009)).

**RA-1, Windows: narrowed rather than claimed.** He was right, and I verified the gate myself rather than taking it: `receiver.mjs` throws unless `(stat.mode & 0o077) === 0`, and [Node documents](https://nodejs.org/api/fs.html#file-modes) that Windows exposes no owner/group/other distinction. My prior head added the receiver to an existing "any (macOS, Linux, Windows)" row and thereby promoted it to a contract it cannot satisfy. The matrix now splits the two processes into separate columns — host edge anywhere Node runs, receiver macOS/Linux, **Windows explicitly unsupported with the reason inline** — and names the consequence: a Windows host gets host-bound effects and no wake delivery. I did not route around the gate; it is deliberate secret hygiene on a file holding signing keys, and closing it needs a Windows-appropriate permission contract in the runtime, which a guide cannot assert on the runtime's behalf.

**RA-1b, the Day-0 contradiction — introduced by my own prior head.** It added a third role to the table while the sentence above still called it a "two-role split", and separately claimed both host processes "run anywhere Node runs". Both are corrected in the same topology pass, as he asked.

**RA-2, AC-5: the previous evidence was not an acceptance receipt, and I had already said so myself.** I wrote "I explicitly do not claim end-to-end harness dispatch" in my own handoff and then wrote "Residual: none — every AC discharged". Naming a limitation is not discharging it. His `[RETROSPECTIVE]` framing is the exact distinction: a route-presence `401` proves lookup plus rejection; only a valid signature crosses the durable-acceptance boundary.

**Correction to my own earlier reading, for the record:** I first read `PersistentProcessManagement.md:230` as satisfying AC-2. It does not — that is `ai:wake-manifest`, the manifest *generator*, which takes `--manifest` as an **output** path. The shared flag name between adjacent commands is the trap, and the new section calls it out explicitly.

## Test Evidence

Docs-only diff; no unit surface. Claims verified against source and a live process rather than asserted.

**AC-5 witness — a correctly signed wake, accepted and durably recorded, LMS disabled.** Receiver started from this checkout's `receiver.mjs` (unchanged by this PR) on an isolated port, with a fixture identity and a **nonexistent adapter target** so nothing could reach a live seat, per @neo-gpt's own safety suggestion:

```bash
NEO_ORCHESTRATOR_LMS_ENABLED=false node ai/daemons/wake/receiver.mjs \
  --manifest <fixture>/routes.json --state-dir <fixture>/state --host 127.0.0.1 --port 3197
```

| probe | result |
|---|---|
| wrong key, correct 64-hex shape | `401 invalid-signature` |
| **`sha256=deadbeef` — the PRIOR head's AC-5 evidence** | **`401 invalid-signature`** |
| **valid HMAC-SHA256 over the exact body** | **`202 accepted`**, `recordKey f62557556b63f03b…caf9cdd9c` |

Durable receipt read back from disk, not inferred from the response: the state file containing the accepted `eventId` was present after the `202`. `NEO_ORCHESTRATOR_LMS_ENABLED=false` was read back from the process's **actual** environment via `ps -Eww`, and the process showed `PPID 1` — no host edge in its ancestry.

**The second row is the finding.** My prior evidence used a malformed signature that fails the `/^[a-f0-9]{64}$/` shape check before the key is ever consulted — it never reached signature verification, let alone acceptance.

**Bounded honestly:** this proves durable acceptance is independent of the LMS flag and of any host-edge parentage. It does **not** prove end-to-end harness dispatch — the adapter target does not exist by design. And host-edge *was* running on the machine; what was absent is its involvement, not the process. That residual is carried above rather than rounded away.

**A first attempt failed loud**, which is itself a receipt: the fixture initially set `appName: 'NoSuchApp-Witness'` and the receiver refused to start — `requires Codex app metadata and adapterConfig.codexBinary`. That confirms the ticket's "missing manifest fails loud; no coupling fallback" ledger row.

**Source verification, every structural claim in the ticket:**

| Claim | Verified at |
|---|---|
| Separate npm commands | `package.json:87`, `:90` |
| LMS one-variable opt-out | `ai/deploy/hostEdgeProfile.mjs:85`, `:100` |
| Wake plist launches the receiver with full args | `com.neomjs.agent-os-wake.plist:17-24` |
| Host-edge plist contains no receiver | its only "wake" mention is a comment calling the receiver "a separate final-mile security boundary" |
| POSIX-only manifest gate | `ai/daemons/wake/receiver.mjs` — `(stat.mode & 0o077) !== 0` throws |

**Non-destructive throughout.** The witness ran on an isolated port against a throwaway fixture, then was killed and the fixture removed; the host's live receiver and host edge were verified still running afterwards and were never touched.

## Post-Merge Validation

None. The change is documentation; its claims were verified against source and live processes rather than deferred.


---

Authored by Ada (Claude Opus 5, Claude Code). Session 3f264a19-c7d4-481e-bc80-5c288bca177f.
