### PR TITLE
fix(build): build-themes reseeds the theme-map from the effective SCSS tree (#17222)

### DIFF
--- a/apps/agentos/app.mjs
+++ b/apps/agentos/app.mjs
@@ -189,8 +189,7 @@ export const onStart = () => {
     }
 
     Neo.app({
-        appThemeFolder: 'agentos',
-        mainView      : Viewport,
-        name          : 'AgentOS'
+        mainView: Viewport,
+        name    : 'AgentOS'
     })
 };

--- a/apps/workstation/app.mjs
+++ b/apps/workstation/app.mjs
@@ -27,9 +27,8 @@ export const onStart = () => {
         });
 
     return Neo.app({
-        appThemeFolder: 'workstation',
-        mainView      : {module: Viewport, theme},
-        name          : 'Workstation',
+        mainView: {module: Viewport, theme},
+        name    : 'Workstation',
         windowId
     })
 };

--- a/buildScripts/build/themes.mjs
+++ b/buildScripts/build/themes.mjs
@@ -202,29 +202,6 @@ if (programOpts.info) {
         }
 
         /**
-         * @param {String} filePath
-         * @returns {Object}
-         */
-        function getThemeMap(filePath) {
-            let themeMapJson = path.resolve(cwd, filePath),
-                themeMap;
-
-            if (fs.existsSync(themeMapJson)) {
-                themeMap = requireJson(themeMapJson);
-            } else {
-                themeMapJson = path.resolve(neoPath, filePath);
-
-                if (fs.existsSync(themeMapJson)) {
-                    themeMap = requireJson(themeMapJson);
-                } else {
-                    themeMap = {};
-                }
-            }
-
-            return themeMap;
-        }
-
-        /**
          * @param {Array|String} names The class name string containing dots or an Array of the string parts
          * @param {Boolean} [create] Set create to true to create empty objects for non existing parts
          * @param {Object} [scope] Set a different starting point as globalThis
@@ -335,7 +312,14 @@ if (programOpts.info) {
             }
         }
 
-        themeMap = getThemeMap(themeMapFile);
+        // Full builds REGENERATE the map from the effective SCSS tree: seeding from the previous
+        // artifact made deletions/renames permanent (insertion is create-only, so no key ever left).
+        // The only legitimate seed is the ENGINE's map in a workspace build (cwd !== neoPath), which
+        // keeps engine components resolvable (guide §8); a workspace's own previous output fossilizes
+        // identically and is not a seed either.
+        themeMap = cwd !== neoPath && fs.existsSync(path.resolve(neoPath, themeMapFile))
+            ? requireJson(path.resolve(neoPath, themeMapFile))
+            : {};
 
         // dist/development
         if (env === 'all' || env === 'dev') {

--- a/learn/guides/uibuildingblocks/StylingAndTheming.md
+++ b/learn/guides/uibuildingblocks/StylingAndTheming.md
@@ -196,26 +196,6 @@ Applications follow a similar rule, but with one important exception: the `view`
 
 Notice how `view/` is not present in the SCSS path. The engine's build tools and runtime loader are specifically coded to handle this convention. Adhering to it is essential for your application's styles to be loaded correctly.
 
-## 4. SCSS File & Namespace Mapping
-
-For the automatic lazy-loading of theme files to work, it is **critical** that the path of an SCSS file mirrors the namespace of the JavaScript class it styles. The build process uses this convention to generate the `theme-map.json`.
-
-### Engine Components
-
-For standard engine components, the mapping is direct. The path within `resources/scss/src` (or a theme folder) matches the class path after `Neo.`.
-
--   **JS Class:** `src/button/Base.mjs` (which defines `Neo.button.Base`)
--   **Maps to SCSS:** `resources/scss/src/button/Base.scss`
-
-### Application Components (The `view` rule)
-
-Applications follow a similar rule, but with one important exception: the `view` folder in the JavaScript path is **omitted** from the SCSS path. It is a mandatory convention that only components inside an application's `view` folder should have associated SCSS files.
-
--   **JS Class:** `apps/portal/view/Viewport.mjs` (defines `Portal.view.Viewport`)
--   **Maps to SCSS:** `resources/scss/src/apps/portal/Viewport.scss`
-
-Notice how `view/` is not present in the SCSS path. The engine's build tools and runtime loader are specifically coded to handle this convention. Adhering to it is essential for your application's styles to be loaded correctly.
-
 ## 5. Theme Inheritance
 
 The theming engine uses a powerful and automatic inheritance model. You **do not** need to manually `@import` base styles into your theme's SCSS files. The engine handles this for you at runtime.
@@ -376,6 +356,8 @@ The `npm run build-themes` command is the main script for a full theme build. It
 
 The `theme-map.json` file creates a mapping between every class name and the themes that have custom styles for it. This file is the key to the lazy loading mechanism.
 
+A full build **regenerates** the map from the effective SCSS tree on every run — it does not merge the previous map, so deleting or renaming an SCSS file removes its key on the next build. The one merge that remains is the workspace overlay (§8): a workspace build seeds from the *engine's* map so engine components stay resolvable, then overlays the workspace's own scan.
+
 ### `watch-themes`
 
 For development, you can use `npm run watch-themes`. Existing non-partial files stay on the fast path: the watcher recompiles only the file whose content changed.
@@ -384,7 +366,7 @@ Run `npm run build-themes -- -n -e dev -t all` once before starting the watcher.
 
 Structural events use a wider source-census reconciliation. Adding or renaming an entry builds every newly discovered or stale output; deleting or renaming an entry removes retired CSS and source maps; and each structural pass replaces both development copies of `theme-map.json` from the effective framework-plus-workspace SCSS tree. A partial change rebuilds its owning `src` or theme root (shared mixins rebuild all roots), so a broken importer produces a visible error instead of silently retaining stale CSS.
 
-## 9. Lazy Loading in Action
+## 10. Lazy Loading in Action
 
 You do not need to manually include any theme CSS files in your application's `index.html`. The engine handles it automatically.
 

--- a/test/playwright/unit/ai/buildScripts/build/themes.spec.mjs
+++ b/test/playwright/unit/ai/buildScripts/build/themes.spec.mjs
@@ -1,0 +1,96 @@
+import {test, expect}  from '@playwright/test';
+import {execFileSync}  from 'node:child_process';
+import fs              from 'node:fs';
+import os              from 'node:os';
+import path            from 'node:path';
+import {fileURLToPath} from 'node:url';
+
+const
+    __filename = fileURLToPath(import.meta.url),
+    __dirname  = path.dirname(__filename),
+    scriptPath = path.resolve(__dirname, '../../../../../../buildScripts/build/themes.mjs');
+
+/**
+ * build-themes theme-map regeneration: a full build reseeds the map from the effective SCSS
+ * tree — deletions and renames land on the next build — instead of merging the previous artifact
+ * (create-only insertion made deleted skins permanent fossils, re-inherited on every rebuild). The
+ * one preserved merge is the workspace overlay: the ENGINE's map still seeds a workspace build, so
+ * engine components stay resolvable. Fixtures run the real CLI against a minimal tmp tree, so the
+ * pin covers the shipped path rather than a re-implementation of it.
+ */
+test.describe('build-themes theme-map regeneration (#17222)', () => {
+    let root;
+
+    test.afterEach(() => {
+        fs.rmSync(root, {recursive: true, force: true});
+    });
+
+    const writeScss = (base, rel) => {
+        const filePath = path.join(base, 'resources/scss/src', rel);
+        fs.mkdirSync(path.dirname(filePath), {recursive: true});
+        fs.writeFileSync(filePath, '.x { color: red; }\n', 'utf8');
+    };
+
+    // execFileSync (not execSync): node is spawned directly with an argv array — no shell, so the
+    // absolute scriptPath can never be interpolated into a shell command (CodeQL-clean).
+    const runBuild = (cwd) => execFileSync('node', [scriptPath, '-n', '-e', 'dev', '-t', 'all'], {cwd, encoding: 'utf8', stdio: 'pipe'});
+
+    const readMap = (cwd) => JSON.parse(fs.readFileSync(path.join(cwd, 'resources/theme-map.json'), 'utf8'));
+
+    const mapKeys = (map) => {
+        const keys = [];
+        const walk = (node, prefix) => {
+            for (const [key, value] of Object.entries(node)) {
+                if (Array.isArray(value)) {
+                    keys.push(prefix + key);
+                } else {
+                    walk(value, prefix + key + '.');
+                }
+            }
+        };
+        walk(map, '');
+        return keys;
+    };
+
+    test('a full build reseeds from the effective SCSS tree — a fossil key from the previous map is gone (AC1)', () => {
+        root = fs.mkdtempSync(path.join(os.tmpdir(), 'neo-themes-seed-'));
+        fs.writeFileSync(path.join(root, 'package.json'), JSON.stringify({
+            bugs   : {url: 'https://example.invalid'},
+            name   : 'neo.mjs-fixture',
+            version: '1.0.0'
+        }));
+        writeScss(root, 'apps/demo/Widget.scss');
+
+        // The previous artifact carries a fossil: a key whose SCSS file no longer exists.
+        fs.writeFileSync(path.join(root, 'resources/theme-map.json'), JSON.stringify({apps: {demo: {Fossil: ['src']}}}));
+
+        runBuild(root);
+
+        const keys = mapKeys(readMap(root));
+        expect(keys).toContain('apps.demo.Widget');      // the real tree lands
+        expect(keys).not.toContain('apps.demo.Fossil');  // the fossil does not survive a fresh build
+    });
+
+    test('a workspace build still seeds from the ENGINE map, but never from its own previous output (AC2)', () => {
+        root = fs.mkdtempSync(path.join(os.tmpdir(), 'neo-themes-workspace-'));
+        fs.writeFileSync(path.join(root, 'package.json'), JSON.stringify({
+            bugs   : {url: 'https://example.invalid'},
+            name   : 'demo-workspace',
+            version: '1.0.0'
+        }));
+        writeScss(root, 'apps/demo/Widget.scss');
+
+        // The engine ships a built map; the workspace's own previous output carries a fossil.
+        const engineResources = path.join(root, 'node_modules/neo.mjs/resources');
+        fs.mkdirSync(engineResources, {recursive: true});
+        fs.writeFileSync(path.join(engineResources, 'theme-map.json'), JSON.stringify({Neo: {button: {Base: ['src']}}}));
+        fs.writeFileSync(path.join(root, 'resources/theme-map.json'), JSON.stringify({apps: {demo: {Fossil: ['src']}}}));
+
+        runBuild(root);
+
+        const keys = mapKeys(readMap(root));
+        expect(keys).toContain('Neo.button.Base');       // the engine overlay is preserved
+        expect(keys).toContain('apps.demo.Widget');      // the workspace's own tree lands
+        expect(keys).not.toContain('apps.demo.Fossil');  // the workspace's own fossil is not inherited
+    });
+});


### PR DESCRIPTION
Resolves #17222

The theme-map's memory is gone: full builds reseed from the effective SCSS tree instead of the previous artifact, so deleted and renamed skins leave the map on the next build. (Insertion was create-only, so a key never left — and a workspace's own previous output fossilized identically. Both seeds are removed.) The one legitimate merge survives: a workspace build still seeds from the *engine's* map, keeping engine components resolvable per the §8 overlay contract. Riders: the two value-identical `appThemeFolder` self-sets removed; the guide's duplicated §4 and doubled §9 repaired, with the replace semantics now stated for both build paths.

Evidence: L3 (live full build on the real tree — fossils absent from all four emitted copies; CLI-fixture specs drive the shipped CLI, not a re-implementation; config-identity + fresh-map keys for both apps) → L4 required (AC4's visual render smoke). Residual: AC4 visual arm, Residual-Owner: #17209.

## Deltas from ticket

None substantive — the ticket's fix landed as written. Two observations, not deviations: the seed is inlined at the call site (6 lines carrying the why-comment) and the now-dead `getThemeMap` is removed rather than left as drift; and `DockPreview` turned out to be a *relocation* fossil (its file lives under `dashboard/` — the create-only seed never aged the old key out), which fits the ticket's deletions/renames model without extending it.

## Test Evidence

- New spec `test/playwright/unit/ai/buildScripts/build/themes.spec.mjs`: **4 passed** on the new code (2 target tests + chroma lifecycle). Mutation positive control (`themes.mjs` stashed): **both target tests fail** (AC1: fossil survives the old seed; AC2: fossil inherited *and* engine key absent) — the red pair proves the specs measure the new seed semantics.
- AC mapping: AC1 → `a full build reseeds from the effective SCSS tree … (AC1)`; AC2 → `a workspace build still seeds from the ENGINE map, but never from its own previous output (AC2)`; AC3 → live full-build receipt: fossils **NONE** in `resources/`, `dist/development`, `dist/esm`, `dist/production` copies; `apps.agentos` keys at the honest 4 (`Accounts, Viewport, childapps, fleet`), my own tree's `FleetSettingsPanel` fossil also gone; AC4 → fallback identity (`src/worker/App.mjs:499` yields the identical folder name) + `node --check` both apps + fresh-map keys present for both apps — visual arm in PMV; AC5 → guide diff: §4 appears once, Lazy Loading renumbered to §10, and the build-themes section now states the regenerate-from-tree semantics alongside the watcher's existing replace contract.
- Adjacent suites (same substrate, untouched code paths): `watchThemes.spec.mjs` + `developmentThemeAssets.spec.mjs` → **23 passed**.
- Per directly touched surface: `buildScripts/build/themes.mjs`: spec above; `apps/agentos/app.mjs` + `apps/workstation/app.mjs`: `node --check` + config-identity argument; guide: markdown diff, no runtime surface.

## Post-Merge Validation

- [ ] Visual smoke: agentos + workstation render themed on their next natural boots (agentos rides Clio's #17209 review loop, workstation rides the operator's cockpit).
- Residual-Owner: #17209

## Commits

- `db3c53c1bf` — seed fix, self-set removals, guide repair, regression spec (one commit).

Authored by Iris (K3, Kimi Code CLI). Session 4660afcc-8b00-427a-8d39-4b1f3624a410.
