### PR TITLE
fix(build): the scoped repair checks the coordinates it was assuming (#17226)

### DIFF
--- a/buildScripts/util/check-block-alignment.mjs
+++ b/buildScripts/util/check-block-alignment.mjs
@@ -1,6 +1,6 @@
-import fs                    from 'fs';
-import {execFileSync}        from 'node:child_process';
-import {getStagedAddedLines} from './stagedDiff.mjs';
+import fs                                           from 'fs';
+import {execFileSync}                               from 'node:child_process';
+import {getStagedAddedLines, isWorkingTreeCleanFor} from './stagedDiff.mjs';
 
 /**
  * @module buildScripts/util/check-block-alignment
@@ -569,6 +569,14 @@ function formatViolation(file, {lineIndex, expectedColumn, kind}) {
  * from the deliberate whole-file pass, whose gitRoot is likewise null.
  * @returns {String} `'clean' | 'reported' | 'fixed' | 'unfixable'`
  */
+/**
+ * Why each scoped repair was refused, keyed by file. Two different causes need two different author
+ * actions — stash your unstaged edits, versus fix your git state — so the driver reports them apart
+ * instead of collapsing both into one message that fits neither.
+ * @type {Map<String,String>}
+ */
+const unfixableReasons = new Map();
+
 function processFile(file, fix, gitRoot = null, scopedFix = false) {
     const allViolations = [];
     const originalLines = fs.readFileSync(file, 'utf8').split('\n');
@@ -587,12 +595,25 @@ function processFile(file, fix, gitRoot = null, scopedFix = false) {
         if (scopedFix) {
             const added = gitRoot ? getStagedAddedLines(file, gitRoot) : null;
 
-            // Fail CLOSED: no reliable staged-line set ⇒ report, never rewrite — a git hiccup must
-            // never silently become a whole-file reformat inside an author's commit.
-            if (!added) {
+            // The staged-line set is expressed in INDEX coordinates, and this function rewrites the
+            // WORKING TREE. They agree only while the file has no unstaged changes; on a partially
+            // staged file they drift by the unstaged edit's line delta, and the scoped repair then
+            // writes lines the author never staged while leaving the staged drift in place. Both
+            // halves of that go out reported as success.
+            //
+            // So the precondition is checked rather than assumed, and it fails the same CLOSED way a
+            // missing staged-line set does: report, never rewrite — a git hiccup, or a half-staged
+            // file, must not silently become an edit to somebody's unstaged work.
+            const coordinatesAgree = Boolean(added) && isWorkingTreeCleanFor(file, gitRoot);
+
+            if (!coordinatesAgree) {
                 for (const violation of allViolations.sort((a, b) => a.lineIndex - b.lineIndex)) {
                     console.error(formatViolation(file, violation));
                 }
+
+                // Distinguished so the author can tell "stage or stash your other edits" from "git is
+                // broken" — the two need different actions, and one message for both taught neither.
+                unfixableReasons.set(file, added ? 'unstaged-changes' : 'no-staged-line-set');
 
                 return 'unfixable';
             }
@@ -678,7 +699,13 @@ if (hadDrift && !fix) {
 }
 
 if (hadUnfixable) {
-    console.error('\nBlock-alignment repair skipped: staged-line detection failed. No files were rewritten — resolve the git error and retry.');
+    const unstaged = [...unfixableReasons].filter(([, reason]) => reason === 'unstaged-changes').map(([file]) => file);
+
+    console.error(
+        unstaged.length === unfixableReasons.size
+            ? `\nBlock-alignment repair skipped: ${unstaged.join(', ')} has unstaged changes, so the staged line numbers do not address the file on disk. No files were rewritten — stage or stash the rest, then retry.`
+            : '\nBlock-alignment repair skipped: the staged line numbers could not be trusted for every file (unstaged changes, or a failed staged-line read). No files were rewritten — resolve that, then retry.'
+    );
 }
 
 if (hadError || hadUnfixable || (hadDrift && !fix)) {

--- a/buildScripts/util/check-block-alignment.mjs
+++ b/buildScripts/util/check-block-alignment.mjs
@@ -678,11 +678,17 @@ let
     hadError     = false,
     hadUnfixable = false;
 
+// Files this run actually wrote. A per-file guard makes each REFUSAL safe; it does not make the BATCH
+// mutation-free, because files ahead of the refusal in argv were already rewritten. The summary has to
+// know that to stay true.
+const repairedFiles = [];
+
 for (const file of files) {
     try {
         const result = processFile(file, fix, gitRoot, staged && fix);
         if (result === 'reported' || result === 'fixed') hadDrift = true;
-        if (result === 'unfixable') hadUnfixable = true;
+        if (result === 'fixed')                          repairedFiles.push(file);
+        if (result === 'unfixable')                      hadUnfixable = true;
     } catch (err) {
         console.error(`Error processing ${file}: ${err.message}`);
         hadError = true;
@@ -699,12 +705,25 @@ if (hadDrift && !fix) {
 }
 
 if (hadUnfixable) {
-    const unstaged = [...unfixableReasons].filter(([, reason]) => reason === 'unstaged-changes').map(([file]) => file);
+    const
+        refused  = [...unfixableReasons.keys()],
+        unstaged = [...unfixableReasons].filter(([, reason]) => reason === 'unstaged-changes').map(([file]) => file);
 
     console.error(
         unstaged.length === unfixableReasons.size
-            ? `\nBlock-alignment repair skipped: ${unstaged.join(', ')} has unstaged changes, so the staged line numbers do not address the file on disk. No files were rewritten — stage or stash the rest, then retry.`
-            : '\nBlock-alignment repair skipped: the staged line numbers could not be trusted for every file (unstaged changes, or a failed staged-line read). No files were rewritten — resolve that, then retry.'
+            ? `\nBlock-alignment repair skipped for ${refused.join(', ')}: the staged line numbers do not address the file on disk, because it has unstaged changes — stage or stash the rest, then retry.`
+            : `\nBlock-alignment repair skipped for ${refused.join(', ')}: the staged line numbers could not be trusted (unstaged changes, or a failed staged-line read) — resolve that, then retry.`
+    );
+
+    // The refusal is per FILE, so "no files were rewritten" is only true when none were. Any file
+    // ahead of the refusal in argv has already been written, and its repair is sitting UNSTAGED in the
+    // author's tree — telling them nothing happened sends them away from a real edit they still owe a
+    // `git add`. @neo-gpt drove the mixed batch at the exact head and caught the message claiming the
+    // opposite of the mutation that had just occurred.
+    console.error(
+        repairedFiles.length === 0
+            ? 'No files were rewritten.'
+            : `Note: ${repairedFiles.join(', ')} was already repaired before the refusal — that write stands, and is unstaged.`
     );
 }
 

--- a/buildScripts/util/stagedDiff.mjs
+++ b/buildScripts/util/stagedDiff.mjs
@@ -63,3 +63,37 @@ export function getStagedAddedLines(file, gitRoot) {
         return null;
     }
 }
+
+/**
+ * @summary Whether a file's working-tree content still matches what is staged for it.
+ *
+ * The line numbers {@link getStagedAddedLines} returns are INDEX coordinates — they come from
+ * `git diff --cached`, whose new side is the staged content. Any consumer that then reads or writes
+ * the file from disk is using working-tree coordinates, and the two agree only while the file has no
+ * unstaged changes. On a partially staged file they drift by however many lines the unstaged edit
+ * added or removed above the staged region, so an index line number silently addresses the wrong
+ * working-tree line.
+ *
+ * For a REPORTING consumer that drift misnames a line. For a REWRITING one it edits the wrong line,
+ * which is why this predicate exists: the caller can refuse rather than write blind. `lint-staged`
+ * stashes unstaged changes before running tasks, so the hook path normally satisfies this — the
+ * exposure is a direct invocation.
+ *
+ * Fails CLOSED in the useful direction: anything other than a clean "no unstaged changes" answer
+ * returns `false`, so an unreadable git state is treated as unsafe rather than assumed safe.
+ *
+ * @param {String} file    Path to the file.
+ * @param {String} gitRoot Repository root (cwd for the git invocation).
+ * @returns {Boolean} `true` only when git confirms the working tree matches the index for this file.
+ */
+export function isWorkingTreeCleanFor(file, gitRoot) {
+    try {
+        // `--quiet` implies `--exit-code`: 0 = no unstaged differences, 1 = differences (thrown by
+        // execFileSync as a non-zero exit). Both answers are informative; anything else is not.
+        execFileSync('git', ['diff', '--quiet', '--', file], {cwd: gitRoot, encoding: 'utf-8'});
+
+        return true;
+    } catch (e) {
+        return false;
+    }
+}

--- a/test/playwright/unit/ai/buildScripts/util/check-block-alignment.spec.mjs
+++ b/test/playwright/unit/ai/buildScripts/util/check-block-alignment.spec.mjs
@@ -717,4 +717,48 @@ test.describe('check-block-alignment.mjs --fix --staged index-vs-worktree precon
         expect(run(['--fix', 'src.mjs']).status).toBe(0);
         expect(fs.readFileSync(file, 'utf8')).toContain('const zz  = 1;');
     });
+
+    // The usage header accepts `<file.mjs> [...]`, and a per-file refusal does NOT make the batch
+    // mutation-free: a safe file earlier in argv is already written when a later one refuses. Saying
+    // "no files were rewritten" there is the opposite of what just happened, and it sends the author
+    // away from a real repair sitting UNSTAGED in their tree. Found by @neo-gpt at the exact head.
+    test('a mixed batch reports the earlier repair instead of claiming nothing was written (#17226)', () => {
+        const safe = path.join(stagedDir, 'safe.mjs'),
+              file = path.join(stagedDir, 'src.mjs');
+
+        // Both baselines are committed in ONE commit before anything is staged. `git commit` with no
+        // pathspec commits the whole index, so seeding these files in sequence would sweep the first
+        // file's staged drift into the second file's commit and leave it with nothing staged.
+        fs.writeFileSync(safe, "import a from 'a';\nimport bb from 'b';\n", 'utf8');
+        fs.writeFileSync(file, 'const zz = 1;\n', 'utf8');
+        git('add', 'safe.mjs', 'src.mjs');
+        git('commit', '-m', 'init');
+
+        // safe.mjs: drift entirely on staged-added lines, no unstaged edit → repairable.
+        fs.writeFileSync(safe, "import a from 'a';\nimport bb from 'b';\nconst obj = {\n    id: 1,\n    namelong: 2\n};\n", 'utf8');
+        // src.mjs: staged drift, then an unstaged edit above it that shifts the coordinates → refused.
+        fs.writeFileSync(file, 'const zz = 1;\nconst obj = {\n    id: 1,\n    namelong: 2\n};\n', 'utf8');
+        git('add', 'safe.mjs', 'src.mjs');
+        fs.writeFileSync(file, '// unstaged A\n// unstaged B\n// unstaged C\nconst zz = 1;\nconst obj = {\n    id: 1,\n    namelong: 2\n};\n', 'utf8');
+
+        const result = run(['--fix', '--staged', 'safe.mjs', 'src.mjs']);
+
+        // The earlier file really was rewritten...
+        expect(fs.readFileSync(safe, 'utf8')).toContain('    id      : 1,');
+        // ...so the summary must say so, and must NOT claim the batch was a no-op.
+        expect(result.output).toContain('safe.mjs was already repaired before the refusal');
+        expect(result.output).not.toContain('No files were rewritten');
+        expect(result.status).toBe(1);
+    });
+
+    // The control that keeps the truthful-summary fix from inverting: when nothing was written, the
+    // no-op claim is correct and must survive.
+    test('an all-refused batch still reports that nothing was written (#17226)', () => {
+        seedShiftedFile();
+
+        const result = run(['--fix', '--staged', 'src.mjs']);
+
+        expect(result.output).toContain('No files were rewritten');
+        expect(result.output).not.toContain('already repaired before the refusal');
+    });
 });

--- a/test/playwright/unit/ai/buildScripts/util/check-block-alignment.spec.mjs
+++ b/test/playwright/unit/ai/buildScripts/util/check-block-alignment.spec.mjs
@@ -625,3 +625,96 @@ test.describe('check-block-alignment.mjs --fix --staged scoped repair (#17201)',
         expect(fs.readFileSync(file, 'utf8')).toBe("import a  from 'a';\nimport bb from 'b';\n");
     });
 });
+
+/**
+ * The scoped repair's unchecked precondition: `getStagedAddedLines` speaks INDEX coordinates and the
+ * repair writes the WORKING TREE. On a partially staged file they drift by the unstaged edit's line
+ * delta, so index line N addresses a different line on disk — the repair then edits lines the author
+ * never staged and leaves the staged drift in place, reporting success for both halves.
+ */
+test.describe('check-block-alignment.mjs --fix --staged index-vs-worktree precondition (#17226)', () => {
+    let stagedDir;
+
+    const git = (...a) => execFileSync('git', a, {cwd: stagedDir, stdio: 'ignore'});
+
+    const run = (args, cwd = stagedDir) => {
+        try {
+            return {status: 0, output: execFileSync('node', [scriptPath, ...args], {cwd, encoding: 'utf8', stdio: 'pipe'})};
+        } catch (error) {
+            return {status: error.status, output: (error.stderr || '') + (error.stdout || '')};
+        }
+    };
+
+    // A file whose staged content carries alignable drift, then an unstaged edit ABOVE it that shifts
+    // every subsequent line by three — the shape that makes index and worktree coordinates disagree.
+    const seedShiftedFile = () => {
+        const file = path.join(stagedDir, 'src.mjs');
+
+        fs.writeFileSync(file, 'const zz = 1;\n', 'utf8');
+        git('add', 'src.mjs');
+        git('commit', '-m', 'init');
+
+        fs.writeFileSync(file, 'const zz = 1;\nconst obj = {\n    id: 1,\n    namelong: 2\n};\n', 'utf8');
+        git('add', 'src.mjs');
+
+        fs.writeFileSync(file, '// unstaged A\n// unstaged B\n// unstaged C\nconst zz = 1;\nconst obj = {\n    id: 1,\n    namelong: 2\n};\n', 'utf8');
+
+        return file
+    };
+
+    test.beforeEach(() => {
+        stagedDir = fs.mkdtempSync(path.join(os.tmpdir(), 'neo-blockalign-coords-'));
+        git('init');
+        git('config', 'user.email', 'test@example.com');
+        git('config', 'user.name', 'Test User');
+    });
+
+    test.afterEach(() => {
+        fs.rmSync(stagedDir, {recursive: true, force: true});
+    });
+
+    test('refuses to rewrite a file whose working tree has drifted from the index (#17226)', () => {
+        const file   = seedShiftedFile(),
+              before = fs.readFileSync(file, 'utf8'),
+              result = run(['--fix', '--staged', 'src.mjs']);
+
+        // Byte-identical is the assertion that matters: before this precondition the run rewrote
+        // `const zz` — a line the author never staged — and left the staged object block unrepaired.
+        expect(fs.readFileSync(file, 'utf8')).toBe(before);
+        expect(result.status).toBe(1);
+        expect(result.output).toContain('unstaged changes');
+    });
+
+    test('names the unstaged-changes cause apart from a failed staged-line read (#17226)', () => {
+        seedShiftedFile();
+
+        // Two causes, two author actions — stash your other edits, versus fix your git state. One
+        // message for both told the author neither, which is why the reason is carried per file.
+        expect(run(['--fix', '--staged', 'src.mjs']).output).toContain('stage or stash the rest');
+    });
+
+    test('a fully staged file is unaffected — the repair still runs (#17226)', () => {
+        const file = path.join(stagedDir, 'src.mjs');
+
+        fs.writeFileSync(file, "import a from 'a';\nimport bb from 'b';\n", 'utf8');
+        git('add', 'src.mjs');
+        git('commit', '-m', 'init');
+
+        fs.writeFileSync(file, "import a from 'a';\nimport bb from 'b';\nconst obj = {\n    id: 1,\n    namelong: 2\n};\n", 'utf8');
+        git('add', 'src.mjs');
+
+        // The control that keeps the new precondition from becoming a blanket refusal: with no
+        // unstaged changes the coordinates agree, so the scoped repair must behave exactly as before.
+        expect(run(['--fix', '--staged', 'src.mjs']).status).toBe(0);
+        expect(fs.readFileSync(file, 'utf8')).toContain('    id      : 1,');
+    });
+
+    test('pure --fix is unaffected by the precondition — still whole-file (#17226)', () => {
+        const file = seedShiftedFile();
+
+        // The deliberate pass has no staged-line set to misapply, so an unstaged edit is irrelevant
+        // to it; refusing here would break the documented remedy for grandfathered drift.
+        expect(run(['--fix', 'src.mjs']).status).toBe(0);
+        expect(fs.readFileSync(file, 'utf8')).toContain('const zz  = 1;');
+    });
+});


### PR DESCRIPTION
Resolves #17226

The scoped block-alignment repair was reading its line numbers in one coordinate system and writing in another. `getStagedAddedLines` derives them from `git diff --cached` — **index** coordinates — while the repair rewrites the **working tree**. Those agree only while a file has no unstaged changes.

Evidence: L3 (real-git fixture repos driving the shipped script end to end, including the original reproduction) → L2 required (a pure precondition over a git read; no host, UI, or deployment surface). No residuals.

## Deltas from ticket

None substantive. One addition the ticket scoped but did not name: the refusal message distinguishes its two causes, carried per file in `unfixableReasons`, because "stash your other edits" and "your git state is broken" need different actions from the author and a single message served neither.

## The defect, as reproduced

Found while reviewing PR #17223 (@neo-kimi-iris's convert-to-repair work), not from reading it. A file with a staged misaligned object block, plus three later *unstaged* comment lines inserted above it so every subsequent line shifts by three:

```
$ node buildScripts/util/check-block-alignment.mjs --fix --staged f.mjs
Aligned 1 line(s) in f.mjs — left 1 untouched-line violation(s) as-is
exit=0

// unstaged line A/B/C
const zz  = 1;      ← REWRITTEN. Never staged, never touched by the staged change.
const obj = {
    id: 1,          ← the actually-staged drift, left unrepaired
    namelong: 2
};
```

Two failures in one pass, and the run reports success for both.

**This is inherited, not introduced by #17223.** Check mode has had the same divergence since #13720; what changed was the *consequence* — from naming the wrong line in a report to rewriting the wrong line on disk. That is why it is worth a fix rather than a shrug: the direction of the error changed, and a silent wrong write is the worst of the available failures.

## The fix

`isWorkingTreeCleanFor` in `stagedDiff.mjs`, beside the function whose coordinates it qualifies, so the git knowledge stays in one module. `git diff --quiet -- <file>`: exit 0 means the working tree matches the index, and **anything else** — including an unreadable git state — returns `false`, so unsafe is the default rather than the exception.

The repair then refuses the same fail-closed way it already refuses a missing staged-line set, reusing the `'unfixable'` disposition #17223 added rather than inventing a fifth state. Refusing is the correct answer instead of translating coordinates: a partially staged file has no single authoritative content for the repair to target, and remapping would reintroduce the same class of error with more machinery for a case where refusing costs the author one `git stash`.

**The hook path was never exposed.** `lint-staged` stashes unstaged changes before running tasks, so index and working tree agree there — which is why #17223's live dogfood passed honestly. This closes the direct invocation the script's own usage header documents.

## Test Evidence

```
npm run test-unit -- test/playwright/unit/ai/buildScripts/util/check-block-alignment.spec.mjs
→ 37 passed  (33 pre-existing unmodified + 4 new)
```

Four real-git specs, each driving the shipped script through `execFileSync` in a fixture repo:

| spec | pins |
|---|---|
| refuses a drifted working tree | the file is **byte-identical** after the run, exit 1 |
| names the cause | `stage or stash the rest`, distinct from the git-failure message |
| fully staged control | the repair still runs — this is not a blanket refusal |
| pure `--fix` control | the deliberate whole-file pass is untouched by the precondition |

The last two are the ones that matter for over-reach: a precondition that refuses too much would break the documented remedy for grandfathered drift, and both controls fail if it does.

Mutation-verified, each reverted after:

| mutation | tests failed |
|---|---|
| precondition removed (i.e. the pre-fix behaviour) | **2** — the reproduction and the message pin |
| cause distinction collapsed to one message | **1** — the message pin only |

Each mutation asserts its own text matched before running, so a no-op edit cannot masquerade as a passing mutation.

## Post-Merge Validation

None deferred. Every AC is proven at the PR head by fixtures that drive the real script.

## Commits

- `fdec81e5ac` — the precondition, the two-cause message, and the four specs

Authored by Grace (Claude Opus 5, Claude Code). Session b17338dd-b474-494f-b08c-683044de2ddb. Found while reviewing @neo-kimi-iris's PR #17223 and filed against my own review rather than raised as a blocker on hers, since the shipped path there is safe.
