### PR TITLE
fix(build): a surface that extracted nothing stops reading as clean (#17230)

### DIFF
--- a/buildScripts/util/check-theme-surfaces.mjs
+++ b/buildScripts/util/check-theme-surfaces.mjs
@@ -201,6 +201,30 @@ export function collectThemeSurfaceFailures({
           dark                     = extractFmTokens(darkPath,  tokenPattern),
           light                    = extractFmTokens(lightPath, tokenPattern);
 
+    // check 0 — the surface was actually READ. Every check below iterates the extracted maps, so an
+    // empty pair produces zero failures by CONSTRUCTION rather than by verdict: a registry entry whose
+    // `tokenPattern` does not match its surface's namespace reports clean while being entirely
+    // unexamined. Nothing in the output distinguishes "clean" from "read nothing".
+    //
+    // The class is measured, not hypothetical — building the workstation surface I ran it under the
+    // agentos `--fm-*` pattern, extracted zero tokens, and got a pass that looked exactly like success.
+    // A spec caught that one because the pair was registered; the next wrong pattern will not have had
+    // a spec written for it in advance, which is why the collector has to own this rather than the
+    // suite. Raised by @neo-kimi-iris.
+    //
+    // BOTH empty is the condition, not either: one empty skin is a real state the completeness check
+    // below already reports with a better message, whereas both empty can only mean the pattern never
+    // matched anything.
+    if (dark.size === 0 && light.size === 0) {
+        failures.push(`[surface] extracted no tokens from either skin — the token pattern ${tokenPattern} matches nothing in ${path.basename(darkPath)}, so this surface is unchecked rather than clean`);
+
+        // Deliberately NOT an early return, though the first draft was one to spare the reader the
+        // derived findings. The pre-existing symmetric-empty-palette spec refuted that: when views do
+        // consume tokens, `[completeness]` names the missing token exactly, which is sharper than this
+        // line and is the older, more specific diagnosis. Short-circuiting would have traded real
+        // information for a tidier report.
+    }
+
     // check 1 — skin parity
     for (const [name, darkValue] of dark) {
         if (!light.has(name)) {

--- a/test/playwright/unit/ai/buildScripts/util/check-theme-surfaces.spec.mjs
+++ b/test/playwright/unit/ai/buildScripts/util/check-theme-surfaces.spec.mjs
@@ -84,8 +84,41 @@ test.describe('check-theme-surfaces.mjs', () => {
 
         expect(run({...fixture, tokenPattern: WS_PATTERN, modeInvariant: new Set()}).length,
             'the right namespace SEES the copied skin').toBeGreaterThan(0);
-        expect(run({...fixture}).length,
-            'the --fm-* default extracts nothing here — a clean report over an empty map').toBe(0);
+
+        // This assertion USED TO READ `.toBe(0)` — the spec demonstrated the vacuous green and then
+        // pinned it as expected. It proved the class existed for the registered pair while leaving the
+        // collector free to keep reporting it as clean for every future one. Inverted now: the wrong
+        // pattern FAILS instead of passing over an empty map.
+        expect(run({...fixture}).some(failure => failure.startsWith('[surface]')),
+            'the --fm-* default extracts nothing here — that is a registry defect, not a clean surface').toBe(true);
+    });
+
+    test('#17230: both skins empty fails; one empty skin stays with the completeness check', () => {
+        // BOTH empty is the discriminator. One empty skin is a real, reportable state that the parity
+        // and completeness checks already describe better than a generic "unread surface" would, so
+        // widening this to `||` would swallow their sharper message behind a vaguer one.
+        const oneSideEmpty = run({
+            dark : ':root .x {\n    --fm-ink: #d6dce6;\n}\n',
+            light: ':root .x {\n}\n'
+        });
+
+        expect(oneSideEmpty.some(failure => failure.startsWith('[surface]')),
+            'the dark skin extracted fine — this is not an unread surface').toBe(false);
+        expect(oneSideEmpty.some(failure => failure.includes('[parity]')),
+            'and the existing parity check still owns it').toBe(true);
+    });
+
+    test('#17230: the surface failure names the pattern that matched nothing', () => {
+        // The message has to carry the diagnosis, because the author's next question is always "which
+        // field is wrong" — and a registry entry has several.
+        const [failure] = run({
+            dark : ':root .x {\n    --workstation-ink: #111;\n}\n',
+            light: ':root .x {\n    --workstation-ink: #eee;\n}\n'
+        });
+
+        expect(failure).toContain('[surface]');
+        expect(failure).toContain('token pattern');
+        expect(failure).toContain('unchecked rather than clean');
     });
 
     test('#17200: a bare color literal in a view fails token-only — #14618 AC-2, at the layer that owns it', () => {


### PR DESCRIPTION
Resolves neomjs/neo#17230

A registered theme surface whose `tokenPattern` does not match its namespace extracted zero tokens and reported **clean**. Every check in the collector iterates the extracted maps, so an empty pair produces zero failures by *construction* rather than by verdict — the surface is unexamined, and nothing in the output distinguishes that from healthy.

Evidence: L2 (unit specs over the pure collector, plus the real tree still green) → L2 required (a static SCSS analyser; no runtime, host, or deployment surface). No residuals.

## Deltas from ticket

None substantive. The ticket's condition, message and controls landed as written.

## Why this is not hypothetical

Raised by @neo-kimi-iris while reviewing PR neomjs/neo#17205, and the class had already bitten me once in the work that created the registry: building neomjs/neo#17200 I ran the workstation surface under the agentos `--fm-*` pattern, extracted zero tokens, and got a pass that looked exactly like success.

Her framing is the argument for putting this in the collector rather than the suite: a spec caught my instance **because that pair was registered**. The next wrong pattern will not have had a spec written for it in advance. The suite proves the classes someone thought of; the collector has to protect the ones nobody did.

## The condition

**Both** maps empty, not either. One empty skin is a real, reportable state that parity and completeness already describe with a sharper message; widening to `||` would swallow their diagnosis behind a vaguer one. Pinned by a spec, and mutation-verified below.

## One draft the existing suite refuted

The first version returned early after pushing the new failure, to spare the reader the derived findings that follow from an empty map. The pre-existing `symmetrically empty palettes still fail completeness` spec went red and was right to: when views *do* consume tokens, `[completeness]` names the missing token exactly, which is more precise than the new line and is the older diagnosis. The early return traded real information for a tidier report, so it is gone — the new failure is the headline and the existing checks still add their detail.

That spec is a regression guard doing exactly its job, and I would not have found the trade by reading.

## One pre-existing assertion changes, deliberately

`#17200: a foreign namespace extracts tokens — the vacuous-green control` asserted `.toBe(0)` on precisely this input. It **demonstrated** the vacuous green and then pinned it as expected behaviour — proving the class existed for the registered pair while leaving the collector free to keep reporting it as clean for every future one. That assertion is inverted here. It is the only pre-existing assertion that changes, and flagging it matters more than a clean "no existing specs modified" line would.

## Test Evidence

```
npm run test-unit -- test/playwright/unit/ai/buildScripts/util/check-theme-surfaces.spec.mjs
→ 27 passed

node buildScripts/util/check-theme-surfaces.mjs
→ exit 0 — ✓ agentos + workstation: parity + token-only + completeness + text-safe ink all pass
```

Mutation-verified in both directions, each reverted, each asserting its own text matched before running:

| mutation | tests failed |
|---|---|
| check removed entirely (the pre-fix behaviour) | **2** — the inverted control, and the message pin |
| broadened to `\|\|` (either skin empty) | **1** — exactly the one-empty-skin boundary |

The second is the one that matters: it proves the condition is *bounded*, not just present. A guard that fires too widely would pass the first mutation test and still be wrong.

All six lint gates green; `lint-skill-manifest --base origin/dev` OK.

## Post-Merge Validation

None deferred.

## Commits

- `251c04e772` — the surface check, its bounded condition, and three specs

Authored by Grace (Claude Opus 5, Claude Code). Session b17338dd-b474-494f-b08c-683044de2ddb. Low priority — nothing blocks a peer on this, and it can sit behind neomjs/neo#17218 and neomjs/neo#17232 in the queue.
