### PR TITLE
feat(memory-core): who_is_online declares its container plane and serves unobservable axes as unknown (#17248)

### DIFF
--- a/ai/mcp/server/memory-core/openapi.yaml
+++ b/ai/mcp/server/memory-core/openapi.yaml
@@ -501,11 +501,13 @@ paths:
         Plane declaration: the presence signal is add_memory-recency, a CONTAINER-side proxy
         observed at turn boundaries. A long turn (the definition of working) is structurally
         indistinguishable from absence on this signal, and a fresh write says a turn ENDED
-        recently — not that the seat is free. Every response carries an axes surface in the Fleet's
-        capability-envelope grammar: presence is wired/observed and declares this proxy; the
-        host-originated composed axes (throttle, lifecycle, liveness) are served as degraded/none
-        envelopes until the fleet publishes its observations into the plane, and each verbose row
-        carries them as unknown. An unknown axis never ranks a seat top and never renders as fine.
+        recently — not that the seat is free. Every response carries an axes surface (a declared
+        superset of the Fleet's capability-envelope grammar, adding plane/signal because this tool
+        serves axes it cannot own): terse holds the presence envelope (wired/observed, proxy
+        declared) plus a compact unobserved marker naming the host-originated axes (throttle,
+        lifecycle, liveness); verbose serves each as its full degraded/none envelope until the
+        fleet publishes, and each verbose row carries them as unknown. An unknown axis never ranks
+        a seat top and never renders as fine.
 
 
         Terse by default: {summary, windows, online[], idle[], dark[], neverConnected[], benched[]}
@@ -553,12 +555,13 @@ paths:
                   axes:
                     type: object
                     description: >
-                      The composed-axes honesty surface, in the Fleet's capability-envelope grammar.
-                      presence is wired/observed and declares this tool's plane (container) and
-                      signal (add_memory-recency — an activity observation, not an availability
-                      verdict); the host-originated axes (throttle, lifecycle, liveness) are
-                      degraded/none envelopes until the fleet publishes its observations into the
-                      plane. An unknown axis never ranks a seat top and never renders as fine.
+                      The composed-axes honesty surface — a declared superset of the Fleet's
+                      capability-envelope grammar (adds plane/signal: this tool serves axes it
+                      cannot own, so the plane travels on the envelope). Terse: the presence
+                      envelope (wired/observed, proxy declared) plus an unobserved marker naming
+                      the host-originated axes (throttle, lifecycle, liveness). Verbose: each host
+                      axis as its full degraded/none envelope until the fleet publishes. An unknown
+                      axis never ranks a seat top and never renders as fine.
                   summary:
                     type: string
                     description: >

--- a/ai/mcp/server/memory-core/openapi.yaml
+++ b/ai/mcp/server/memory-core/openapi.yaml
@@ -492,10 +492,20 @@ paths:
       x-annotations:
         readOnlyHint: true
       description: >
-        Reports per-maintainer live availability — who is completing turns recently, not whether the
-        process is up. Advisory liveness for review-routing, lane-handoff, lead-baton, and
-        wake-targeting: surfaces probably-dark maintainers so a request to a dark agent fails loud
-        instead of stalling the merge gate silently.
+        Reports per-maintainer recent ACTIVITY for review-routing, lane-handoff, lead-baton, and
+        wake-targeting — who is completing turns recently, not whether the process is up, and NOT
+        an availability verdict. Advisory liveness: surfaces probably-dark maintainers so a request
+        to a dark agent fails loud instead of stalling the merge gate silently.
+
+
+        Plane declaration: the presence signal is add_memory-recency, a CONTAINER-side proxy
+        observed at turn boundaries. A long turn (the definition of working) is structurally
+        indistinguishable from absence on this signal, and a fresh write says a turn ENDED
+        recently — not that the seat is free. Every response carries an axes surface in the Fleet's
+        capability-envelope grammar: presence is wired/observed and declares this proxy; the
+        host-originated composed axes (throttle, lifecycle, liveness) are served as degraded/none
+        envelopes until the fleet publishes its observations into the plane, and each verbose row
+        carries them as unknown. An unknown axis never ranks a seat top and never renders as fine.
 
 
         Terse by default: {summary, windows, online[], idle[], dark[], neverConnected[], benched[]}
@@ -533,12 +543,22 @@ paths:
               schema:
                 type: object
                 description: >
-                  Terse default: {generatedAt, summary, windows, online[], idle[], dark[],
-                  neverConnected[], benched[]}. With verbose:true: {generatedAt, signalStatus, agents[]}.
+                  Terse default: {generatedAt, axes, summary, windows, online[], idle[], dark[],
+                  neverConnected[], benched[]}. With verbose:true: {generatedAt, axes, signalStatus,
+                  agents[]}.
                 properties:
                   generatedAt:
                     type: string
                     description: ISO timestamp the projection was computed at.
+                  axes:
+                    type: object
+                    description: >
+                      The composed-axes honesty surface, in the Fleet's capability-envelope grammar.
+                      presence is wired/observed and declares this tool's plane (container) and
+                      signal (add_memory-recency — an activity observation, not an availability
+                      verdict); the host-originated axes (throttle, lifecycle, liveness) are
+                      degraded/none envelopes until the fleet publishes its observations into the
+                      plane. An unknown axis never ranks a seat top and never renders as fine.
                   summary:
                     type: string
                     description: >
@@ -595,6 +615,12 @@ paths:
                           description: The projected bucket. Mutually exclusive with the other four.
                         reason: {type: string}
                         signals: {type: object}
+                        axes:
+                          type: object
+                          description: >
+                            Per-row composed axes: every host-originated axis the tool cannot
+                            observe (throttle, lifecycle, liveness) is unknown until the fleet
+                            publishes — never a verdict fabricated from the recency primitive.
         '500':
           description: Operation failed.
           content:

--- a/ai/services/memory-core/WakeSubscriptionService.mjs
+++ b/ai/services/memory-core/WakeSubscriptionService.mjs
@@ -13,6 +13,7 @@ import {DELIVERABLE_HARNESS_TARGET}                                             
 import {buildWakeDigest, getHighestWakePriority}                                                from '../../daemons/wake/wakeDigestBuilder.mjs';
 import {HEARTBEAT_PULSE_ENTITY_PREFIX, HEARTBEAT_PULSE_ENTITY_TYPE, match, matchHeartbeatPulse} from './heartbeatPulseEvaluator.mjs';
 import {resolveResidentFamilyById}                                                              from '../graph/agentFamilyResolution.mjs';
+import {PRESENCE_STATES}                                                                        from '../fleet/fleetPresenceStateAdapter.mjs';
 import {readActiveWakeSubscriptionObservations}                                                 from './readActiveWakeSubscriptionIdentities.mjs';
 import {
     activeWakeSubscriptionStatusSql,
@@ -39,6 +40,15 @@ function formatWindow(ms) {
 
     return `${ms}ms`;
 }
+
+/**
+ * The host-originated composed axes `who_is_online` cannot observe from its own plane. Served as
+ * per-row `unknown` under `degraded/none` capability envelopes until the fleet publishes its
+ * host-edge observations into the plane — absence of truth is never rendered as fine, and an
+ * unobservable axis never ranks a seat top.
+ * @type {String[]}
+ */
+const COMPOSED_HOST_AXES = Object.freeze(['throttle', 'lifecycle', 'liveness']);
 
 /**
  * @summary Service for managing graph-resident WAKE_SUBSCRIPTION nodes and the
@@ -715,31 +725,55 @@ class WakeSubscriptionService extends Base {
      * lane-handoff / lead-baton / wake-targeting so a request to a dark agent fails loud instead
      * of stalling silently; it is not a hard routing gate.
      *
+     * **Plane declaration (what this answer is NOT).** The presence signal is
+     * `add_memory`-recency — a container-side proxy observed at turn boundaries, never an
+     * availability verdict: a long turn (the definition of working) is structurally
+     * indistinguishable from absence on this signal, and a fresh write says a turn ENDED recently,
+     * not that the seat is free. The payload says so itself: every return carries an `axes`
+     * surface in the Fleet's capability-envelope grammar (`{capability: {source, plane, state,
+     * confidence, capturedAt, reason}}`), where `presence` declares its proxy plane and the
+     * host-originated composed axes (`throttle`, `lifecycle`, `liveness`) are served as
+     * `degraded/none` envelopes until the fleet publishes its observations into the plane — each
+     * verbose row carries those axes as `unknown`. An `unknown` axis never ranks a seat top and
+     * never renders as fine. The presence state vocabulary itself is imported from the Fleet's
+     * taxonomy (`PRESENCE_STATES`, whose one exporting home is `fleetPresenceStateAdapter`), so
+     * the cockpit's downstream mapping can never drift from this tool's words.
+     *
      * @param {Object} [opts]
      * @param {String} [opts.family] Optional model-family filter (e.g. `'claude'`, `'gpt'`).
      * @param {Boolean} [opts.verbose=false] When false (default) returns the terse roster summary
-     *   (`{generatedAt, summary, online, idle, benched}`) — a "who is online?" answer, not a
+     *   (`{generatedAt, axes, summary, online, idle, benched}`) — a "who is online?" answer, not a
      *   diagnostics dump. When true returns the full per-agent projection (signalStatus + per-agent
      *   reason/signals) for diagnostics. Default stays terse so the per-call token cost is
      *   proportional to the question.
      * @param {Date|String|Number} [opts.now=new Date()] Clock source (unit-test seam).
      * @returns {Promise<Object>} Terse (default):
-     *   `{generatedAt, summary, windows, online[], idle[], dark[], neverConnected[], benched[]}`
+     *   `{generatedAt, axes, summary, windows, online[], idle[], dark[], neverConnected[], benched[]}`
      *   (identity arrays). The five buckets separate LIVENESS from MEMBERSHIP: `online` (acting
      *   now), `idle` (stale but inside the idle cutoff), `dark` (stale beyond it), `neverConnected`
      *   (rostered but never observed on THIS deployment), `benched` (participationStatus gate).
      *   `windows` carries the resolved `{activityFreshMs, idleCutoffMs}` so the counts are
-     *   interpretable without reading source. Verbose: `{generatedAt, signalStatus, agents}` where
-     *   each agent is `{identity, name, family, participationStatus, online, state, reason, signals}`.
+     *   interpretable without reading source. `axes` carries the capability envelopes above —
+     *   `presence` wired/observed with its plane declaration, the host-originated axes
+     *   degraded/none. Verbose: `{generatedAt, axes, signalStatus, agents}` where each agent is
+     *   `{identity, name, family, participationStatus, online, state, reason, signals, axes}` —
+     *   the per-row `axes` holds every host-originated axis as `unknown` until the fleet publishes.
      */
     async whoIsOnline({family, verbose = false, now = new Date()} = {}) {
-        const nowMs       = this._coerceDate(now).getTime(),
-              agents      = this._listAgentIdentityNodes(family).map(node => this._projectAgentLiveness(node, nowMs)),
-              generatedAt = new Date(nowMs).toISOString();
+        const nowMs = this._coerceDate(now).getTime(),
+              // Every projected row carries the unobservable composed axes as `unknown` — the
+              // tool never fabricates a host-originated verdict from its container-side primitive.
+              agents      = this._listAgentIdentityNodes(family).map(node => ({
+                  ...this._projectAgentLiveness(node, nowMs),
+                  axes: this._unobservedComposedAxes()
+              })),
+              generatedAt = new Date(nowMs).toISOString(),
+              axes        = this._composedAxesEnvelope(generatedAt);
 
         if (verbose) {
             return {
                 generatedAt,
+                axes,
                 signalStatus: 'Precedence: (1) participationStatus hard gate; (2) a fresh turn-presence beacon, ' +
                               'which decides online before any absence verdict — add_memory lands at turn ' +
                               'boundaries, so a first or long turn is present without a recent write; (3) ' +
@@ -753,32 +787,82 @@ class WakeSubscriptionService extends Base {
         // Terse default — a "who is online?" answer, not a diagnostics book. The signalStatus essay
         // and the per-agent reason/signals live behind verbose:true so the per-call token cost stays
         // proportional to the question. Buckets are keyed off the projected state so the wire shape
-        // and the per-agent verdict can never disagree.
-        const inState        = state => agents.filter(agent => agent.state === state).map(agent => agent.identity),
-              online         = inState('online'),
-              idle           = inState('idle'),
-              dark           = inState('dark'),
-              neverConnected = inState('neverConnected'),
-              benched        = inState('benched'),
-              windows        = {
+        // and the per-agent verdict can never disagree, and they are DERIVED from the Fleet's
+        // exported taxonomy — the tool's state vocabulary is imported, never re-declared.
+        const inState = state => agents.filter(agent => agent.state === state).map(agent => agent.identity),
+              buckets = Object.fromEntries(PRESENCE_STATES.map(state => [state, inState(state)])),
+              windows = {
                   activityFreshMs: AiConfig.whoIsOnline.activityFreshMs,
                   idleCutoffMs   : AiConfig.whoIsOnline.idleCutoffMs
               };
 
         return {
             generatedAt,
+            axes,
             // The summary states the windows it applied: the same counts mean different things under
             // a 15-minute and a 4-hour window, so a bare number is not interpretable without them.
-            summary: `${online.length} online · ${idle.length} idle · ${dark.length} dark · ` +
-                     `${neverConnected.length} never-connected · ${benched.length} benched ` +
+            summary: `${buckets.online.length} online · ${buckets.idle.length} idle · ${buckets.dark.length} dark · ` +
+                     `${buckets.neverConnected.length} never-connected · ${buckets.benched.length} benched ` +
                      `(online ≤ ${formatWindow(windows.activityFreshMs)}, idle ≤ ${formatWindow(windows.idleCutoffMs)})`,
             windows,
-            online,
-            idle,
-            dark,
-            neverConnected,
-            benched
+            ...buckets
         };
+    }
+
+    /**
+     * @summary Builds the composed-axes honesty surface both `who_is_online` return shapes carry.
+     *
+     * The grammar is the Fleet Manager's capability envelope — `{source, plane, state, confidence,
+     * capturedAt, reason}` — served UN-FLATTENED per axis, so a degraded source can never paint a
+     * healthy one. `presence` is the axis this tool owns: `wired/observed`, and its `reason` is the
+     * plane declaration (a container-side `add_memory`-recency proxy, not an availability verdict).
+     * The host-originated axes ({@link COMPOSED_HOST_AXES}) report `degraded/none` with a named
+     * reason until the fleet publishes its observations into the plane — the envelope's
+     * `capturedAt` echoes the projection's own observation bound (`generatedAt`), never a
+     * re-stamped clock.
+     * @param {String} capturedAt The projection's observation bound (ISO).
+     * @returns {Object} `{presence, throttle, lifecycle, liveness}` capability envelopes.
+     * @protected
+     */
+    _composedAxesEnvelope(capturedAt) {
+        const unobserved = axis => ({
+            capability: {
+                source    : null,
+                plane     : 'host',
+                state     : 'degraded',
+                confidence: 'none',
+                capturedAt,
+                reason    : `no fleet ${axis} observation has been published to the plane — ` +
+                            `unknown is the platform truth until one lands`
+            }
+        });
+
+        return {
+            presence: {
+                capability: {
+                    source    : 'memory-core:whoIsOnline',
+                    plane     : 'container',
+                    signal    : 'add_memory-recency',
+                    state     : 'wired',
+                    confidence: 'observed',
+                    capturedAt,
+                    reason    : 'container-side recency proxy observed at turn boundaries — an ' +
+                                'activity observation, not an availability verdict'
+                }
+            },
+            ...Object.fromEntries(COMPOSED_HOST_AXES.map(axis => [axis, unobserved(axis)]))
+        };
+    }
+
+    /**
+     * @summary The per-row composed-axes truth for a plane-only projection: every host-originated
+     * axis is `unknown`, because nothing has published it into the plane. A fresh object per row —
+     * rows must never share a mutable axes reference.
+     * @returns {Object} e.g. `{throttle: 'unknown', lifecycle: 'unknown', liveness: 'unknown'}`.
+     * @protected
+     */
+    _unobservedComposedAxes() {
+        return Object.fromEntries(COMPOSED_HOST_AXES.map(axis => [axis, 'unknown']));
     }
 
     /**

--- a/ai/services/memory-core/WakeSubscriptionService.mjs
+++ b/ai/services/memory-core/WakeSubscriptionService.mjs
@@ -730,14 +730,16 @@ class WakeSubscriptionService extends Base {
      * availability verdict: a long turn (the definition of working) is structurally
      * indistinguishable from absence on this signal, and a fresh write says a turn ENDED recently,
      * not that the seat is free. The payload says so itself: every return carries an `axes`
-     * surface in the Fleet's capability-envelope grammar (`{capability: {source, plane, state,
-     * confidence, capturedAt, reason}}`), where `presence` declares its proxy plane and the
-     * host-originated composed axes (`throttle`, `lifecycle`, `liveness`) are served as
-     * `degraded/none` envelopes until the fleet publishes its observations into the plane — each
-     * verbose row carries those axes as `unknown`. An `unknown` axis never ranks a seat top and
-     * never renders as fine. The presence state vocabulary itself is imported from the Fleet's
-     * taxonomy (`PRESENCE_STATES`, whose one exporting home is `fleetPresenceStateAdapter`), so
-     * the cockpit's downstream mapping can never drift from this tool's words.
+     * surface. Terse holds the `presence` envelope (wired/observed, proxy declared) plus a compact
+     * `unobserved` marker naming the host-originated axes (`throttle`, `lifecycle`, `liveness`);
+     * verbose serves each host axis as its full `degraded/none` envelope until the fleet publishes
+     * its observations into the plane, and each verbose row carries those axes as `unknown`. The
+     * envelope shape is a declared superset of the Fleet Manager's capability-envelope grammar —
+     * see {@link WakeSubscriptionService#_composedAxesEnvelope} for the two added fields. An
+     * `unknown` axis never ranks a seat top and never renders as fine. The presence state
+     * vocabulary itself is imported from the Fleet's taxonomy (`PRESENCE_STATES`, whose one
+     * exporting home is `fleetPresenceStateAdapter`), so the cockpit's downstream mapping can never
+     * drift from this tool's words.
      *
      * @param {Object} [opts]
      * @param {String} [opts.family] Optional model-family filter (e.g. `'claude'`, `'gpt'`).
@@ -753,20 +755,18 @@ class WakeSubscriptionService extends Base {
      *   now), `idle` (stale but inside the idle cutoff), `dark` (stale beyond it), `neverConnected`
      *   (rostered but never observed on THIS deployment), `benched` (participationStatus gate).
      *   `windows` carries the resolved `{activityFreshMs, idleCutoffMs}` so the counts are
-     *   interpretable without reading source. `axes` carries the capability envelopes above —
-     *   `presence` wired/observed with its plane declaration, the host-originated axes
-     *   degraded/none. Verbose: `{generatedAt, axes, signalStatus, agents}` where each agent is
+     *   interpretable without reading source. Terse `axes` carries ONLY what the default answer
+     *   needs (the tool is terse-by-default — diagnostics live behind `verbose`, never bloat the
+     *   context window): the full `presence` capability envelope with its plane declaration, and a
+     *   compact `unobserved` marker naming the host-originated axes — declared, never fabricated.
+     *   Verbose: `{generatedAt, axes, signalStatus, agents}` — `axes` serves every host-originated
+     *   axis as its full `degraded/none` envelope, and each agent row is
      *   `{identity, name, family, participationStatus, online, state, reason, signals, axes}` —
      *   the per-row `axes` holds every host-originated axis as `unknown` until the fleet publishes.
      */
     async whoIsOnline({family, verbose = false, now = new Date()} = {}) {
-        const nowMs = this._coerceDate(now).getTime(),
-              // Every projected row carries the unobservable composed axes as `unknown` — the
-              // tool never fabricates a host-originated verdict from its container-side primitive.
-              agents      = this._listAgentIdentityNodes(family).map(node => ({
-                  ...this._projectAgentLiveness(node, nowMs),
-                  axes: this._unobservedComposedAxes()
-              })),
+        const nowMs       = this._coerceDate(now).getTime(),
+              projected   = this._listAgentIdentityNodes(family).map(node => this._projectAgentLiveness(node, nowMs)),
               generatedAt = new Date(nowMs).toISOString(),
               axes        = this._composedAxesEnvelope(generatedAt);
 
@@ -780,7 +780,10 @@ class WakeSubscriptionService extends Base {
                               'add_memory-recency, the deployment-agnostic fallback where no beacon is emitted, ' +
                               'roster-scoped and graph-backed (survives an embed-drain). Advisory, not a hard ' +
                               'routing gate.',
-                agents
+                // Per-row `unknown` axes are verbose diagnostics — allocated only on this path, so
+                // the default answer never pays for objects its buckets discard. The tool never
+                // fabricates a host-originated verdict from its container-side primitive.
+                agents: projected.map(row => ({...row, axes: this._unobservedComposedAxes()}))
             };
         }
 
@@ -789,7 +792,7 @@ class WakeSubscriptionService extends Base {
         // proportional to the question. Buckets are keyed off the projected state so the wire shape
         // and the per-agent verdict can never disagree, and they are DERIVED from the Fleet's
         // exported taxonomy — the tool's state vocabulary is imported, never re-declared.
-        const inState = state => agents.filter(agent => agent.state === state).map(agent => agent.identity),
+        const inState = state => projected.filter(agent => agent.state === state).map(agent => agent.identity),
               buckets = Object.fromEntries(PRESENCE_STATES.map(state => [state, inState(state)])),
               windows = {
                   activityFreshMs: AiConfig.whoIsOnline.activityFreshMs,
@@ -798,12 +801,19 @@ class WakeSubscriptionService extends Base {
 
         return {
             generatedAt,
-            axes,
+            // The presence envelope is the default answer's honesty (the plane declaration), so it
+            // stays terse-side; the three host-originated envelopes would repeat byte-identical
+            // "nothing published" on every call — diagnostics by definition — so terse DECLARES
+            // their axes unobserved and verbose serves the full envelopes.
+            axes: {presence: axes.presence, unobserved: [...COMPOSED_HOST_AXES]},
             // The summary states the windows it applied: the same counts mean different things under
             // a 15-minute and a 4-hour window, so a bare number is not interpretable without them.
-            summary: `${buckets.online.length} online · ${buckets.idle.length} idle · ${buckets.dark.length} dark · ` +
-                     `${buckets.neverConnected.length} never-connected · ${buckets.benched.length} benched ` +
-                     `(online ≤ ${formatWindow(windows.activityFreshMs)}, idle ≤ ${formatWindow(windows.idleCutoffMs)})`,
+            // Counts and labels derive from the same imported taxonomy as the buckets — a rename at
+            // the vocabulary's exporting home renames both, never a cross-module TypeError here.
+            summary: PRESENCE_STATES.map(state =>
+                         `${buckets[state].length} ${state === 'neverConnected' ? 'never-connected' : state}`
+                     ).join(' · ') +
+                     ` (online ≤ ${formatWindow(windows.activityFreshMs)}, idle ≤ ${formatWindow(windows.idleCutoffMs)})`,
             windows,
             ...buckets
         };
@@ -812,14 +822,22 @@ class WakeSubscriptionService extends Base {
     /**
      * @summary Builds the composed-axes honesty surface both `who_is_online` return shapes carry.
      *
-     * The grammar is the Fleet Manager's capability envelope — `{source, plane, state, confidence,
-     * capturedAt, reason}` — served UN-FLATTENED per axis, so a degraded source can never paint a
-     * healthy one. `presence` is the axis this tool owns: `wired/observed`, and its `reason` is the
-     * plane declaration (a container-side `add_memory`-recency proxy, not an availability verdict).
-     * The host-originated axes ({@link COMPOSED_HOST_AXES}) report `degraded/none` with a named
-     * reason until the fleet publishes its observations into the plane — the envelope's
-     * `capturedAt` echoes the projection's own observation bound (`generatedAt`), never a
-     * re-stamped clock.
+     * The shape is a DECLARED SUPERSET of the Fleet Manager's capability-envelope grammar
+     * (`{source, state, confidence, capturedAt, reason}`, per `fleetThrottleStateAdapter.mjs`) with
+     * exactly two added fields, named rather than smuggled: `plane` — which plane the axis's truth
+     * lives on — and `signal` — the owning axis's signal name. The Fleet's envelopes never carry
+     * `plane` because they are emitted by the adapter that OWNS the axis; this tool serves axes it
+     * cannot own, so the plane must travel on the envelope (that IS the tool's plane declaration).
+     * `signal` appears only on `presence`, the one axis with a live signal to name. `source: null`
+     * on the host-originated axes is equally deliberate: the FM's adapters stamp their own source
+     * label because they ARE the producer — an axis nothing has published has no producer to name.
+     *
+     * Envelopes are served UN-FLATTENED per axis, so a degraded source can never paint a healthy
+     * one. `presence` is the axis this tool owns: `wired/observed`, and its `reason` is the plane
+     * declaration (a container-side `add_memory`-recency proxy, not an availability verdict). The
+     * host-originated axes ({@link COMPOSED_HOST_AXES}) report `degraded/none` with a named reason
+     * until the fleet publishes its observations into the plane — the envelope's `capturedAt` echoes
+     * the projection's own observation bound (`generatedAt`), never a re-stamped clock.
      * @param {String} capturedAt The projection's observation bound (ISO).
      * @returns {Object} `{presence, throttle, lifecycle, liveness}` capability envelopes.
      * @protected

--- a/test/playwright/unit/ai/services/memory-core/WakeSubscriptionService.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/WakeSubscriptionService.spec.mjs
@@ -3119,20 +3119,33 @@ test.describe('Neo.ai.services.memory-core.WakeSubscriptionService', () => {
             expect(verbose.axes.presence.capability).toEqual(presence);
         });
 
-        test('#17225 AC3 — unobservable axes are FM-grammar degraded/none envelopes: unknown never ranks top, never renders as fine', async () => {
+        test('#17225 AC3 — unobservable axes: declared in terse, served as degraded/none envelopes in verbose', async () => {
+            // The terse-by-default contract (diagnostics behind the optional param, never bloat the
+            // context window) bounds WHAT the default answer pays for: the presence envelope is the
+            // answer's honesty and stays; three byte-identical "nothing published" envelopes on
+            // every call would be diagnostics in the default path. So terse DECLARES the host axes
+            // unobserved, and verbose serves the full FM-grammar envelopes.
             seedAgent('@neo-ac3');
             seedActivity('@neo-ac3', {timestamp: iso(T0ms - 2 * 60 * 1000)});
 
             const terse = await WakeSubscriptionService.whoIsOnline({now: new Date(T0)});
 
+            expect(terse.axes.unobserved).toEqual(['throttle', 'lifecycle', 'liveness']);
+            expect(terse.axes.throttle, 'diagnostics stay out of the default answer').toBeUndefined();
+            expect(terse.axes.lifecycle).toBeUndefined();
+            expect(terse.axes.liveness).toBeUndefined();
+            expect(terse.axes.presence?.capability?.state).toBe('wired');
+
+            const verbose = await WakeSubscriptionService.whoIsOnline({verbose: true, now: new Date(T0)});
+
             for (const axis of ['throttle', 'lifecycle', 'liveness']) {
-                const capability = terse.axes?.[axis]?.capability;
+                const capability = verbose.axes?.[axis]?.capability;
 
                 expect(capability, `${axis} envelope`).toBeTruthy();
                 expect(capability.state).toBe('degraded');        // absence of truth is declared, never hidden
                 expect(capability.confidence).toBe('none');       // never rendered as fine
                 expect(typeof capability.reason).toBe('string');  // the hole names itself
-                expect(capability.capturedAt).toBe(terse.generatedAt);
+                expect(capability.capturedAt).toBe(verbose.generatedAt);
             }
         });
 
@@ -3144,16 +3157,44 @@ test.describe('Neo.ai.services.memory-core.WakeSubscriptionService', () => {
             // exporting home, so the FM's downstream mapping can never drift from the tool's words.
             expect(serviceSrc).toContain("from '../fleet/fleetPresenceStateAdapter.mjs'");
 
-            // The grep control: no second literal list of the presence states anywhere in the MC
-            // services tree — one exporting home, every consumer imports.
-            const dir         = path.resolve(process.cwd(), 'ai/services/memory-core');
-            const listPattern = /\[[^\]]*'online'[^\]]*'idle'[^\]]*'dark'[^\]]*\]/;
+            // The grep control, positive-controlled first: an absence-assertion never shown capable
+            // of presence is indistinguishable from a test that does nothing. The detector flags any
+            // 150-char window holding >= 3 DISTINCT vocabulary words as quoted literals — the shape a
+            // re-declared list takes in any spelling (array, reordered, double-quoted, switch/case
+            // cluster) — while scattered single uses stay silent.
+            const VOCAB    = ['online', 'idle', 'dark', 'benched', 'neverConnected'],
+                  detector = src => {
+                      const hits = [...src.matchAll(/(['"])(online|idle|dark|benched|neverConnected)\1/g)];
 
-            for (const file of await fs.readdir(dir)) {
-                if (!file.endsWith('.mjs')) continue;
+                      for (let i = 0; i < hits.length; i++) {
+                          const windowed = hits.filter(h => h.index >= hits[i].index && h.index < hits[i].index + 150);
 
-                const src = await fs.readFile(path.join(dir, file), 'utf8');
-                expect(listPattern.test(src), `${file} re-declares the presence state list`).toBe(false);
+                          if (new Set(windowed.map(h => h[2])).size >= 3) return true;
+                      }
+
+                      return false;
+                  };
+
+            // The positive controls — each spelling a re-declaration could take, including the four
+            // evasions a naive ordered single-quote pattern misses.
+            expect(detector(`const S = ['online', 'idle', 'dark', 'benched', 'neverConnected']`)).toBe(true);
+            expect(detector(`const S = ['neverConnected', 'dark', 'online']`)).toBe(true);
+            expect(detector('const S = ["online", "idle", "dark"]')).toBe(true);
+            expect(detector(`switch (s) { case 'online': case 'idle': case 'dark': return s; }`)).toBe(true);
+            // and the negative control: one scattered use is a usage, not a vocabulary.
+            expect(detector(`row.state = 'online';`)).toBe(false);
+
+            // The sweep itself: recursive — subdirectories are exactly where a second copy would hide.
+            const root = path.resolve(process.cwd(), 'ai/services/memory-core'),
+                  walk = dir => fs.readdirSync(dir, {withFileTypes: true}).flatMap(entry => {
+                      const abs = path.join(dir, entry.name);
+
+                      return entry.isDirectory() ? walk(abs) : (entry.name.endsWith('.mjs') ? [abs] : []);
+                  });
+
+            for (const file of walk(root)) {
+                const src = await fs.readFile(file, 'utf8');
+                expect(detector(src), `${path.relative(root, file)} re-declares the presence vocabulary`).toBe(false);
             }
         });
     });

--- a/test/playwright/unit/ai/services/memory-core/WakeSubscriptionService.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/WakeSubscriptionService.spec.mjs
@@ -3069,6 +3069,93 @@ test.describe('Neo.ai.services.memory-core.WakeSubscriptionService', () => {
             expect(res.neverConnected).toContain('@neo-dispatch');
             expect(res.idle).not.toContain('@neo-dispatch');
         });
+
+        test('#17225 AC2 — the inversion red-proof: a beaconless mid-turn peer and an idle-but-fresh-write peer carry identical unobservable axes', async () => {
+            // The ticket's fixture, beaconless by construction (today's fleet-wide truth: nothing
+            // emits turn-presence, so the mid-turn rescue cannot fire). One peer mid-turn with a
+            // stale write, one idle peer with a fresh one. The recency observation honestly
+            // differs — and that is ALL the tool may claim. Every axis the tool cannot observe
+            // must answer `unknown` for BOTH, so no served axis can rank the idle peer as more
+            // available than the working one.
+            seedAgent('@neo-ac2-midturn');
+            seedActivity('@neo-ac2-midturn', {timestamp: iso(T0ms - 20 * 60 * 1000)}); // stale, no beacon
+            seedAgent('@neo-ac2-idlefresh');
+            seedActivity('@neo-ac2-idlefresh', {timestamp: iso(T0ms - 2 * 60 * 1000)}); // fresh
+
+            const {agents}  = await WakeSubscriptionService.whoIsOnline({verbose: true, now: new Date(T0)});
+            const midturn   = agents.find(a => a.identity === '@neo-ac2-midturn');
+            const idlefresh = agents.find(a => a.identity === '@neo-ac2-idlefresh');
+
+            // The presence observation differs honestly — recency is the one signal this tool owns.
+            expect(midturn.state).toBe('idle');
+            expect(idlefresh.state).toBe('online');
+
+            // Every composed axis the tool cannot observe: unknown for BOTH, never a verdict.
+            const unobserved = {throttle: 'unknown', lifecycle: 'unknown', liveness: 'unknown'};
+            expect(midturn.axes).toEqual(unobserved);
+            expect(idlefresh.axes).toEqual(unobserved);
+            expect(idlefresh.axes).toEqual(midturn.axes);
+        });
+
+        test('#17225 AC1 — the payload declares its own plane: a container-side add_memory-recency proxy, never an availability verdict', async () => {
+            seedAgent('@neo-ac1');
+            seedActivity('@neo-ac1', {timestamp: iso(T0ms - 2 * 60 * 1000)});
+
+            const terse    = await WakeSubscriptionService.whoIsOnline({now: new Date(T0)});
+            const presence = terse.axes?.presence?.capability;
+
+            expect(presence).toBeTruthy();
+            expect(presence.plane).toBe('container');
+            expect(presence.signal).toContain('add_memory');
+            expect(presence.state).toBe('wired');
+            expect(presence.confidence).toBe('observed');
+            // The envelope echoes the projection's observation bound — it never mints its own.
+            expect(presence.capturedAt).toBe(terse.generatedAt);
+            expect(presence.reason).toContain('not an availability verdict');
+
+            // Terse and verbose carry the same declaration — the plane honesty is not paywalled
+            // behind the diagnostics surface.
+            const verbose = await WakeSubscriptionService.whoIsOnline({verbose: true, now: new Date(T0)});
+            expect(verbose.axes.presence.capability).toEqual(presence);
+        });
+
+        test('#17225 AC3 — unobservable axes are FM-grammar degraded/none envelopes: unknown never ranks top, never renders as fine', async () => {
+            seedAgent('@neo-ac3');
+            seedActivity('@neo-ac3', {timestamp: iso(T0ms - 2 * 60 * 1000)});
+
+            const terse = await WakeSubscriptionService.whoIsOnline({now: new Date(T0)});
+
+            for (const axis of ['throttle', 'lifecycle', 'liveness']) {
+                const capability = terse.axes?.[axis]?.capability;
+
+                expect(capability, `${axis} envelope`).toBeTruthy();
+                expect(capability.state).toBe('degraded');        // absence of truth is declared, never hidden
+                expect(capability.confidence).toBe('none');       // never rendered as fine
+                expect(typeof capability.reason).toBe('string');  // the hole names itself
+                expect(capability.capturedAt).toBe(terse.generatedAt);
+            }
+        });
+
+        test('#17225 AC5 — the presence vocabulary is imported from the Fleet taxonomy, never re-declared in the MC tree', async () => {
+            const servicePath = path.resolve(process.cwd(), 'ai/services/memory-core/WakeSubscriptionService.mjs');
+            const serviceSrc  = await fs.readFile(servicePath, 'utf8');
+
+            // The import is the admission: fleetPresenceStateAdapter is the vocabulary's ONE
+            // exporting home, so the FM's downstream mapping can never drift from the tool's words.
+            expect(serviceSrc).toContain("from '../fleet/fleetPresenceStateAdapter.mjs'");
+
+            // The grep control: no second literal list of the presence states anywhere in the MC
+            // services tree — one exporting home, every consumer imports.
+            const dir         = path.resolve(process.cwd(), 'ai/services/memory-core');
+            const listPattern = /\[[^\]]*'online'[^\]]*'idle'[^\]]*'dark'[^\]]*\]/;
+
+            for (const file of await fs.readdir(dir)) {
+                if (!file.endsWith('.mjs')) continue;
+
+                const src = await fs.readFile(path.join(dir, file), 'utf8');
+                expect(listPattern.test(src), `${file} re-declares the presence state list`).toBe(false);
+            }
+        });
     });
 
     test.describe('rotateKey — the repair door for a row that lost its signing key', () => {


### PR DESCRIPTION
Resolves neomjs/neo#17248

`who_is_online` now declares its own plane in its tool description and payload, and serves every axis it cannot observe as an honest `unknown` — the honest-surface unit and first slice of neomjs/neo-agent-brain#31 (parent AC1+AC2+AC3+AC5; the parent stays open for the load axis and the fleet-publish slice). Both return shapes carry an `axes` surface in the Fleet Manager's capability-envelope grammar: `presence` is `wired/observed` and declares itself a container-side `add_memory`-recency proxy — an activity observation, not an availability verdict — while the host-originated composed axes (`throttle`, `lifecycle`, `liveness`) are served as `degraded/none` envelopes until the fleet publishes its observations into the plane, with every verbose row carrying them as `unknown`. The presence state vocabulary is now imported from `PRESENCE_STATES` (the Fleet taxonomy's one exporting home, `fleetPresenceStateAdapter.mjs:43`) rather than living as scattered literals, and the presence inversion is red-proved by fixture: a beaconless mid-turn peer and an idle-but-fresh-write peer carry deep-equal `unknown` composed axes, so no served axis can rank the idle one as more available.

Evidence: L2 (unit-spec ceiling: the fixtures drive the real service over the in-memory graph; the live mid-turn falsifier needs a running plane) → L2 required (all four close-target ACs are spec-verifiable). Residual: the live-plane re-read, Residual-Owner: neomjs/neo-agent-brain#31

## Deltas from ticket

- Unobservable-axis envelopes carry `source: null` — no publisher exists yet, and the Fleet's own source labels belong to the adapters that will publish (PR3), so the degraded envelope names the hole in `reason` instead of borrowing a label.
- The per-row `axes` object is built fresh per agent (never a shared mutable reference across rows).
- Terse buckets are now *derived* from the imported `PRESENCE_STATES` (the grep-control's mechanical teeth), so a sixth state entering the Fleet taxonomy surfaces here as a bucket automatically.

## Test Evidence

- `UNIT_TEST_MODE=true npx playwright test -c test/playwright/playwright.config.unit.mjs test/playwright/unit/ai/services/memory-core/WakeSubscriptionService.spec.mjs` — **128 passed** (4 new AC-pinning tests + full file).
- Adjacent suites: `planeWhoIsOnlineReader`, `fleetPresenceStateAdapter`, `fleetCockpitStatus`, `fleetCockpit`, `fleetGrid`, `onboardPeer`, `Server`, `OpenApiValidatorCompliance`, `OpenApiServiceParityGate` — **280 passed**.
- Red-proof cycle (pre-fix blindness): all 4 new tests red against the pre-fix implementation (run individually to defeat the `describe.serial` first-failure skip).
- Mutation controls at the fix head: `degraded→wired` on the unobserved envelopes reds AC3; `unknown→none` on the per-row axes reds AC2. Restored byte-identical, full file re-green.
- Surface `ai/services/memory-core` + `ai/mcp/server/memory-core`: covered by the above; no other in-repo consumer of the changed payload fields (`planeWhoIsOnlineReader` passes `agents` through; `toolService.mjs:166` destructures the five unchanged buckets).

## Post-Merge Validation

- [ ] Live falsifier on the dev plane: call `who_is_online` mid-turn — the calling seat's verbose row carries the three `unknown` composed axes, and `axes.presence.capability.reason` declares the proxy in the terse payload.

Residual-Owner: neomjs/neo-agent-brain#31

## Commits

- 100c69bbd8 — the honest surface: plane declaration, axes envelopes, imported vocabulary, four red-proofed specs

Authored by Iris (K3, Kimi Code CLI). Session 2455da9f-c848-4c52-b0f0-daea86aea9c3.
