### PR TITLE
feat(ai): containment gains an author-level lever on the surface we get attacked on (#17246)

### DIFF
--- a/.agents/skills/hostile-content-quarantine/references/hostile-content-quarantine-workflow.md
+++ b/.agents/skills/hostile-content-quarantine/references/hostile-content-quarantine-workflow.md
@@ -55,7 +55,17 @@ The neutralize **action** (delete/redact) is **agent agency** for clear-hostile 
 |---|---|---|
 | Wholesale spam artifact (the entire post IS the pitch) | **Delete** — nothing anchors a real thread | #12992 |
 | Hostile content inside a real thread (spam comment on a legitimate ticket) | **Redact the payload (names/links) + keep the de-fanged record** — deletion would amputate the thread; redaction keeps the KB clean since sync pulls current bodies | #12674 |
-| Moderation deferred / record deliberately kept | **Sync denylist** (post-#12995) excludes it from ingestion | #12995 Fix 3 |
+| Moderation deferred / record deliberately kept | **Sync denylist — per surface, never one lever** (below) | #12995, #17246 |
+
+Each syncer gates separately; reading this table as general is what produced #17246.
+
+| Surface | Lever (`issueSync.*`) | Matches | Evicts a synced copy |
+|---|---|---|---|
+| discussions | `discussionDenylist` | number ∥ author | by number |
+| issues | `issueDenylist`, or a `droppedLabels` label | number ∥ author | by number |
+| pull requests | **none — gap** | — | no |
+
+Author matching is **fetch-time only** everywhere (metadata persists number, not author) — evict on-disk copies by number. Closing + locking contains **nothing**: neither is a label or a denylist entry, so redaction is what cleans the corpus (sync pulls current bodies).
 
 **Verify the outcome across ALL THREE surfaces** (MACHINE-ENFORCEABLE-CANDIDATE) — the #12992 lesson: one surface lies.
 

--- a/ai/mcp/server/github-workflow/configBase.mjs
+++ b/ai/mcp/server/github-workflow/configBase.mjs
@@ -156,6 +156,24 @@ class ConfigBase extends ConfigProvider {
                  */
                 discussionDenylist: leaf({numbers: [], authors: []}),
                 /**
+                 * Containment denylist for issues — the `discussionDenylist` sibling, on the surface we
+                 * actually get attacked on. Issues whose `number` or `author.login` match are excluded
+                 * from sync and never written to `resources/content/**` or downstream KB chunks.
+                 *
+                 * `droppedLabels` already contains a labelled issue, but only by asserting a disposition
+                 * (`dropped` / `wontfix` / `duplicate`) that hostile content does not have, and only one
+                 * artifact at a time. This leaf is the author-level and number-level lever: one entry
+                 * contains an account, and it does not require mislabelling the artifact to do it.
+                 *
+                 * `number` matching quarantines an already-synced copy (file + content-index entry) even
+                 * when GitHub no longer lists it — the spam-hammer-hidden case. `author` matching is
+                 * fetch-time exclusion only, because `metadata.issues` persists `number` and not author
+                 * login, so a cached copy cannot be resolved back to its author. Policy-free; the empty
+                 * default is a no-op.
+                 * @type {{numbers: Number[], authors: String[]}}
+                 */
+                issueDenylist: leaf({numbers: [], authors: []}),
+                /**
                  * Product names to redact from untrusted GitHub-authored content when the content-trust
                  * sanitizer projects sync/write-boundary Markdown. Empty by default; policy values belong
                  * in local config, not in syncer code.

--- a/ai/scripts/lint/config-leaf-parity.json
+++ b/ai/scripts/lint/config-leaf-parity.json
@@ -517,6 +517,7 @@
         "issueSync.discussionOuterPageSize",
         "issueSync.discussionsDir",
         "issueSync.droppedLabels",
+        "issueSync.issueDenylist",
         "issueSync.issueFilenamePrefix",
         "issueSync.issuesDir",
         "issueSync.maxAssigneesPerIssue",

--- a/ai/services/github-workflow/sync/IssueSyncer.mjs
+++ b/ai/services/github-workflow/sync/IssueSyncer.mjs
@@ -739,10 +739,46 @@ class IssueSyncer extends Base {
             const oldPathRelative = oldIssue?.path;
             const oldAbsolutePath = oldIssue ? this.#resolvePath(oldPathRelative) : null;
 
+            // --- EVICTION, AND WHY IT RUNS BEFORE SEALED-CHUNK ENFORCEMENT ---
+            // A null targetPath means "this issue must not exist on disk" — denylisted, or dropped by
+            // label. That is a containment decision, and containment cannot be conditional on where
+            // the file happens to live.
+            //
+            // This block sat BELOW the sealed-chunk block and was therefore unreachable for an
+            // archived closed issue: `wasArchived && targetPath !== oldAbsolutePath` is
+            // unconditionally true when targetPath is null, so enforcement reassigned it to the old
+            // path and the eviction never ran. The issue was re-written instead of removed — no
+            // error, no stat, silent. All three conditions are ordinary: already-synced (the case the
+            // number leg exists for), CLOSED (what a moderator does first), archived.
+            //
+            // Ordering is the whole fix. Sealed-chunk semantics answer "which bucket does this file
+            // belong in", which is only a question for a file that belongs on disk at all. Asking it
+            // first lets a bucket rule overrule a containment rule.
+            if (!targetPath) {
+                stats.dropped.count++;
+                stats.dropped.issues.push(issueNumber);
+
+                if (oldPathRelative) {
+                    try {
+                        await fs.unlink(oldAbsolutePath);
+                        shouldPruneEmptyDirs = true;
+                        logger.debug(`🗑️ Removed dropped issue #${issueNumber}: ${oldAbsolutePath}`);
+                    } catch (e) { /* File might not exist */ }
+                }
+
+                delete newMetadata.issues[issueNumber];
+
+                indexMutations.remove.push({ type: 'issues', id: issueNumber });
+                continue;
+            }
+
             // --- ARCHIVE ANOMALY DETECTION & SEALED-CHUNK SEMANTICS ---
             // Detect if an issue's closedAt timestamp has shifted from a previously known value.
             // Under sealed-chunk semantics, historical items should not jump archive buckets
             // just because a maintainer toggled the state.
+            //
+            // Reached only for an issue that IS staying on disk, so `targetPath` is non-null here and
+            // both branches below compare two real paths.
             if (oldIssue && issue.state === 'CLOSED') {
                 const wasArchived = oldAbsolutePath && oldAbsolutePath.startsWith(issueSyncConfig.archiveRoot);
 
@@ -759,25 +795,6 @@ class IssueSyncer extends Base {
                     logger.warn(`[SEALED CHUNK ENFORCEMENT] Issue #${issueNumber} bucket shifted, but it is already archived. Forcing retention at ${oldAbsolutePath}.`);
                     targetPath = oldAbsolutePath;
                 }
-            }
-
-            if (!targetPath) {
-                stats.dropped.count++;
-                stats.dropped.issues.push(issueNumber);
-                const oldPathRelative = metadata.issues[issueNumber]?.path;
-                if (oldPathRelative) {
-                    try {
-                        const oldPath = this.#resolvePath(oldPathRelative);
-                        await fs.unlink(oldPath);
-                        shouldPruneEmptyDirs = true;
-                        logger.debug(`🗑️ Removed dropped issue #${issueNumber}: ${oldPath}`);
-                    } catch (e) { /* File might not exist */ }
-                }
-                // Remove from metadata
-                delete newMetadata.issues[issueNumber];
-
-                indexMutations.remove.push({ type: 'issues', id: issueNumber });
-                continue;
             }
 
             const needsUpdate = !oldIssue ||

--- a/ai/services/github-workflow/sync/IssueSyncer.mjs
+++ b/ai/services/github-workflow/sync/IssueSyncer.mjs
@@ -554,14 +554,50 @@ class IssueSyncer extends Base {
     }
 
     /**
+     * Containment gate: is this issue on the sync denylist (by number or author)?
+     *
+     * Mirrors `DiscussionSyncer#isDenylisted`, deliberately without that sibling's `|| {}` fallback:
+     * `issueDenylist` is an AiConfig leaf with an object default, so the SSOT guarantees the subtree
+     * and a defensive fallback would only hide a broken config tree.
+     * ticket-ref-ok: ADR 0019 §3 B3 — the divergence from the adjacent sibling is deliberate, and
+     * without the authority citation a future maintainer reads it as an oversight and "fixes" it back.
+     *
+     * The two legs have different reach, and the difference is structural rather than incidental.
+     * `number` is present at every `#getIssuePath` call site, including the reconciliation paths that
+     * pass a partial `{number, ...}` object, so a number match contains an issue everywhere — which is
+     * what lets an already-synced copy fall into the existing quarantine branch. `author` is only
+     * present when the caller holds the fetched GitHub node; the reconciliation paths read
+     * `metadata.issues`, which persists `number` and not author login, so author matching is
+     * fetch-time exclusion only. That is the same bound the discussion sibling documents, for the same
+     * reason, and it is why an author entry stops future syncs but does not retroactively evict a
+     * cached copy — use the number leg for that.
+     *
+     * @param {Object} issue A GitHub issue node, or a partial `{number}` from a reconciliation path.
+     * @returns {Boolean}
+     * @private
+     */
+    #isDenylisted(issue) {
+        const denylist = issueSyncConfig.issueDenylist;
+
+        return denylist.numbers.includes(issue.number) ||
+               denylist.authors.includes(issue.author?.login)
+    }
+
+    /**
      * Determines the correct local file path for a given issue based on its state (OPEN/CLOSED),
-     * labels (dropped), and milestone or closed date (for archiving).
+     * the containment denylist, labels (dropped), and milestone or closed date (for archiving).
      * @param {object} issue The GitHub issue object.
      * @param {Map<number, object>} planBuckets Precomputed bucket distribution.
      * @returns {string|null} The absolute file path for the issue's Markdown file, or null if the issue should be dropped.
      * @private
      */
     #getIssuePath(issue, planBuckets = new Map()) {
+        // Containment precedes disposition: a denylisted issue is excluded regardless of its labels,
+        // and returning null here routes it into the same quarantine branch `droppedLabels` uses.
+        if (this.#isDenylisted(issue)) {
+            return null
+        }
+
         const filename = `${issueSyncConfig.issueFilenamePrefix}${issue.number}.md`;
 
         // Handle both GraphQL (issue.labels.nodes) and potential direct array.

--- a/test/playwright/unit/ai/services/github-workflow/IssueSyncer.spec.mjs
+++ b/test/playwright/unit/ai/services/github-workflow/IssueSyncer.spec.mjs
@@ -1493,6 +1493,74 @@ test.describe('Neo.ai.services.github-workflow.sync.IssueSyncer', () => {
         expect(JSON.stringify(index)).not.toContain('issue-60003')
     });
 
+    test('a denylisted issue that is CLOSED and already ARCHIVED is still evicted (#17246)', async () => {
+        // The hole @neo-opus-grace found on review. `#getIssuePath` returns null for a denylisted
+        // issue, but the sealed-chunk block ran FIRST and its second branch is
+        // `wasArchived && targetPath !== oldAbsolutePath` — unconditionally true when targetPath is
+        // null. So enforcement reassigned the old path and the eviction below it never ran: the
+        // hostile artifact was re-written instead of removed, silently.
+        //
+        // All three conditions are ordinary, not exotic: already-synced (the exact case the number
+        // leg exists for), CLOSED (what a moderator does first), and archived. The fix is ordering —
+        // containment decides whether a file belongs on disk at all, which is upstream of the bucket
+        // question sealed-chunk answers.
+        const N  = 60005;
+        const ts = '2026-05-01T00:00:00Z';
+
+        const archivedAbs = path.join(issueSyncConfig.archiveRoot, 'issues', 'v12.0.0', 'chunk-1', `issue-${N}.md`);
+        const archivedRel = path.relative(aiConfig.projectRoot, archivedAbs);
+
+        await fs.ensureDir(path.dirname(archivedAbs));
+        await fs.writeFile(archivedAbs, 'hostile content that a moderator classified after ingestion', 'utf8');
+
+        const hostile = buildMockIssue({
+            number       : N,
+            title        : 'Archived, closed, and only later classified',
+            timelineFirst: [],
+            hasNextPage  : false,
+            endCursor    : null
+        });
+
+        hostile.state     = 'CLOSED';
+        hostile.closedAt  = ts;
+        hostile.updatedAt = ts;
+        hostile.milestone = {title: 'v12.0.0'};
+
+        GraphqlService.query = async query => {
+            if (query.includes('FetchIssuesForSync')) {
+                return {
+                    rateLimit : {cost: 1, remaining: 4999, resetAt: ts},
+                    repository: {issues: {pageInfo: {hasNextPage: false, endCursor: null}, nodes: [structuredClone(hostile)]}}
+                };
+            }
+
+            if (query.includes('FetchSingleIssue')) {
+                return {repository: {issue: structuredClone(hostile)}}
+            }
+
+            throw new Error(`Unexpected GraphQL query in test: ${query.slice(0, 80)}`)
+        };
+
+        const metadata = {
+            lastSync: '2026-01-01T00:00:00Z',
+            issues  : {
+                [N]: {state: 'CLOSED', updatedAt: ts, closedAt: ts, milestone: 'v12.0.0', path: archivedRel, contentHash: 'h', commentsTotal: 0}
+            }
+        };
+
+        // closedAt is deliberately UNCHANGED between metadata and the fetched issue: the resurrection
+        // needed no anomaly, only the else-branch, which is why it could not be found by looking for
+        // a warning in the log.
+        const {stats, newMetadata} = await withIssueDenylist(
+            {numbers: [N], authors: []},
+            () => IssueSyncer.pullFromGitHub(metadata)
+        );
+
+        expect(stats.dropped.issues).toContain(N);
+        expect(newMetadata.issues[N]).toBeUndefined();
+        await expect(fs.pathExists(archivedAbs)).resolves.toBe(false);
+    });
+
     test('the empty default denylist is a no-op — identical output with and without the gate (#17246)', async () => {
         const issue = buildMockIssue({
             number       : 60004,

--- a/test/playwright/unit/ai/services/github-workflow/IssueSyncer.spec.mjs
+++ b/test/playwright/unit/ai/services/github-workflow/IssueSyncer.spec.mjs
@@ -1356,6 +1356,189 @@ test.describe('Neo.ai.services.github-workflow.sync.IssueSyncer', () => {
         expect(metadata.issues[issueNumber].contentHash).toBe(currentHash);
         expect(metadata.issues[issueNumber].updatedAt).toBe('2026-06-24T12:01:00Z');
     });
+
+    /**
+     * Containment denylist coverage. Empirical anchor: an astroturf vendor pitch from an account
+     * with no prior association reached `resources/content/issues/**` with the product name verbatim
+     * in the corpus `title:` field. `droppedLabels` could have contained it only by asserting a
+     * disposition it does not have, one artifact at a time.
+     *
+     * Each test drives the real `pullFromGitHub` path rather than calling the private predicate, so
+     * the assertion covers the wiring — a predicate that returns `true` into a call site that ignores
+     * it would pass a unit test of the predicate alone.
+     */
+    async function withIssueDenylist(denylist, fn) {
+        const original = issueSyncConfig.issueDenylist;
+
+        issueSyncConfig.issueDenylist = denylist;
+
+        try {
+            return await fn()
+        } finally {
+            issueSyncConfig.issueDenylist = original
+        }
+    }
+
+    test('a denylisted AUTHOR is excluded at fetch time and never written (#17246)', async () => {
+        const hostile = buildMockIssue({
+            number       : 60001,
+            title        : 'Feature Suggestion: metering via some-vendor-product',
+            timelineFirst: [],
+            hasNextPage  : false,
+            endCursor    : null
+        });
+
+        hostile.author = {login: 'astroturf-account'};
+
+        const legitimate = buildMockIssue({
+            number       : 60002,
+            title        : 'A real ticket from a real maintainer',
+            timelineFirst: [],
+            hasNextPage  : false,
+            endCursor    : null
+        });
+
+        GraphqlService.query = async query => {
+            if (query.includes('FetchIssuesForSync')) {
+                return {
+                    rateLimit : {cost: 1, remaining: 4999, resetAt: '2026-08-16T21:00:00Z'},
+                    repository: {
+                        issues: {
+                            pageInfo: {hasNextPage: false, endCursor: null},
+                            nodes   : [structuredClone(hostile), structuredClone(legitimate)]
+                        }
+                    }
+                };
+            }
+
+            if (query.includes('FetchSingleIssue')) {
+                if (query.includes('60001')) return {repository: {issue: structuredClone(hostile)}};
+                if (query.includes('60002')) return {repository: {issue: structuredClone(legitimate)}};
+            }
+
+            throw new Error(`Unexpected GraphQL query in test: ${query.slice(0, 80)}`)
+        };
+
+        const {stats, newMetadata} = await withIssueDenylist(
+            {numbers: [], authors: ['astroturf-account']},
+            () => IssueSyncer.pullFromGitHub({issues: {}})
+        );
+
+        expect(stats.dropped.issues).toContain(60001);
+        expect(newMetadata.issues[60001]).toBeUndefined();
+
+        // The legitimate sibling in the same batch must be untouched — a containment gate that
+        // suppresses the whole page would pass a "hostile is absent" assertion on its own.
+        expect(stats.pulled.issues).toContain(60002);
+        expect(newMetadata.issues[60002]).toBeDefined()
+    });
+
+    test('a denylisted NUMBER evicts an already-synced copy from disk AND the content index (#17246)', async () => {
+        const ingested = buildMockIssue({
+            number       : 60003,
+            title        : 'Already in the corpus before anyone classified it',
+            timelineFirst: [],
+            hasNextPage  : false,
+            endCursor    : null
+        });
+
+        GraphqlService.query = async query => {
+            if (query.includes('FetchIssuesForSync')) {
+                return {
+                    rateLimit : {cost: 1, remaining: 4999, resetAt: '2026-08-16T21:00:00Z'},
+                    repository: {
+                        issues: {
+                            pageInfo: {hasNextPage: false, endCursor: null},
+                            nodes   : [structuredClone(ingested)]
+                        }
+                    }
+                };
+            }
+
+            if (query.includes('FetchSingleIssue')) {
+                return {repository: {issue: structuredClone(ingested)}}
+            }
+
+            throw new Error(`Unexpected GraphQL query in test: ${query.slice(0, 80)}`)
+        };
+
+        // Pass 1 — it syncs normally, exactly as the astroturf issue did before anyone classified it.
+        const first = await withIssueDenylist(
+            {numbers: [], authors: []},
+            () => IssueSyncer.pullFromGitHub({issues: {}})
+        );
+
+        const storedRelative = first.newMetadata.issues[60003]?.path;
+
+        expect(storedRelative).toBeTruthy();
+
+        const storedAbsolute = path.resolve(aiConfig.projectRoot, storedRelative);
+
+        await expect(fs.pathExists(storedAbsolute)).resolves.toBe(true);
+
+        // Pass 2 — now denylisted by number. The already-emitted artifact is the whole point:
+        // moderation always arrives after ingestion, so a gate that only blocks future writes
+        // leaves the corpus poisoned.
+        const second = await withIssueDenylist(
+            {numbers: [60003], authors: []},
+            () => IssueSyncer.pullFromGitHub(structuredClone(first.newMetadata))
+        );
+
+        expect(second.stats.dropped.issues).toContain(60003);
+        expect(second.newMetadata.issues[60003]).toBeUndefined();
+        await expect(fs.pathExists(storedAbsolute)).resolves.toBe(false);
+
+        const index = await fs.readJson(path.join(tmpRoot, '_index.json'));
+
+        expect(JSON.stringify(index)).not.toContain('issue-60003')
+    });
+
+    test('the empty default denylist is a no-op — identical output with and without the gate (#17246)', async () => {
+        const issue = buildMockIssue({
+            number       : 60004,
+            title        : 'Ordinary issue, ordinary sync',
+            timelineFirst: [],
+            hasNextPage  : false,
+            endCursor    : null
+        });
+
+        GraphqlService.query = async query => {
+            if (query.includes('FetchIssuesForSync')) {
+                return {
+                    rateLimit : {cost: 1, remaining: 4999, resetAt: '2026-08-16T21:00:00Z'},
+                    repository: {
+                        issues: {
+                            pageInfo: {hasNextPage: false, endCursor: null},
+                            nodes   : [structuredClone(issue)]
+                        }
+                    }
+                };
+            }
+
+            if (query.includes('FetchSingleIssue')) {
+                return {repository: {issue: structuredClone(issue)}}
+            }
+
+            throw new Error(`Unexpected GraphQL query in test: ${query.slice(0, 80)}`)
+        };
+
+        const {stats, newMetadata} = await withIssueDenylist(
+            {numbers: [], authors: []},
+            () => IssueSyncer.pullFromGitHub({issues: {}})
+        );
+
+        expect(stats.dropped.issues).toEqual([]);
+        expect(stats.pulled.issues).toContain(60004);
+
+        const written = path.resolve(aiConfig.projectRoot, newMetadata.issues[60004].path);
+
+        await expect(fs.pathExists(written)).resolves.toBe(true);
+
+        // The author leg must not fire on an author who is simply absent from the list. `[].includes(x)`
+        // is false for every x, but `authors: [undefined]` in a hand-edited overlay would match every
+        // reconciliation-path call that carries no author — assert the resolved default is the empty set.
+        expect(issueSyncConfig.issueDenylist).toEqual({numbers: [], authors: []})
+    });
 });
 
 function buildComment(i) {


### PR DESCRIPTION
Resolves neomjs/neo#17246

Sync containment gains an author-level lever on issues. `issueDenylist: {numbers, authors}` joins its `discussionDenylist` sibling and is consulted at the head of `#getIssuePath`, so a denylisted issue falls into the quarantine branch that already exists — file unlinked, metadata row deleted, content-index entry removed. Three lines of gate and no new removal path: the gap was the predicate, not the plumbing. Before this, containing a hostile issue meant labelling it `dropped` / `wontfix` / `duplicate` — asserting a disposition the artifact does not have, one artifact at a time — while the equivalent discussion cost one config entry.

Evidence: L2 (spec-driven contract tests drive the real `pullFromGitHub` path against a mocked GraphQL layer, asserting real filesystem removal and real `_index.json` mutation in a tmp content root) → L2 required (every close-target AC is syncer behavior under a given config; none asserts a live GitHub fetch or a host effect). Residual: none — and the claim is bounded deliberately, see `## Post-Merge Validation` for what shipping an empty default does and does not establish.

## What happened tonight

Issue neomjs/neo#17236 was filed at 07:48Z by an account with no prior association to this repository: a vendor pitch under a helpful framing, a bare product-name drop, an integration sample **in Python — in a JavaScript repository**, and an engagement-bait closer. The swarm held don't-engage correctly for twelve hours. I neutralized it at 19:45Z — title and body redacted, closed, locked as spam.

By then it had already been ingested, at `resources/content/issues/chunk-16/issue-17236.md`, with the product name verbatim in the corpus `title:` field.

The `hostile-content-quarantine` §6 matrix offers "**Sync denylist** (post-#12995) excludes it from ingestion". Following that to the code finds `discussionDenylist` — and nothing else. neomjs/neo#12995 shipped that lever after a *discussion* attack. We were hit on an issue.

## Two drafts of this finding were wrong, and both would have shipped

Recorded because the correct version is narrower than either, and the wrong ones were more satisfying.

**Draft 1 — "issues have no sync containment at all."** False. `droppedLabels` already returns `null` from `#getIssuePath`, and `:728-745` unlinks the file, deletes the metadata row, and pushes `indexMutations.remove` — the same quarantine outcome the discussion path produces. I reached that draft by grepping for `denylist`, finding one hit, and stopping at the first sufficient explanation.

**Draft 2 — "add a fourth `STEALTH_SIGNALS` pattern for the vendor-pitch shape."** Worse. `contentTrust.signals` has **zero consumers** anywhere in `ai/` — no reader outside the sanitizer and its own specs. A new regex would have fired into a field nothing acts on and changed nothing about the ingestion. Diagnostics wearing a fix's clothes.

What survives falsification: the containment **machinery** is at parity; the **trigger** is not. And the natural moderation gestures — close as not-planned, lock as spam — are not labels, so a moderator doing the obviously-right thing got no containment at all.

## Two bounds, written into the JSDoc rather than left to be discovered

- **The author leg is fetch-time only.** It fires only where the caller holds the fetched GitHub node. Two of the four `#getIssuePath` call sites pass a partial `{number, …}` read from `metadata.issues`, which persists `number` and not author login — so an author entry stops future syncs but cannot retroactively evict a cached copy. The number leg is what does that. Same bound `discussionDenylist` documents, for the same reason.
- **No `|| {}` fallback**, deliberately diverging from the adjacent sibling. `issueDenylist` is an AiConfig leaf with an object default, so the SSOT guarantees the subtree and a defensive fallback would only hide a broken config tree — ADR 0019 §3 **B3**. The divergence carries a `ticket-ref-ok` marker so it does not read as an oversight and get "fixed" back to match its neighbour.

## Slot rationale (substrate mutation — `.agents/skills/**`)

**Modified:** `hostile-content-quarantine-workflow.md` §6 moderation matrix. Disposition **`rewrite`**, not `keep` — the existing line is not incomplete, it is **wrong**: it advertises a general "sync denylist" that is discussion-specific, and that wording cost a live misdiagnosis during this incident (draft 1 above). Replaced by a per-surface table that also records the pull-request gap as a named gap.

Net skill-Markdown growth **+658 bytes** against a 250-byte budget, carried under `[skill-growth-justified: …]` in the commit. Compressed from an initial +1381 first; further shaving would have meant deleting correct instruction to buy budget for other correct instruction. **Retirement trigger:** the table collapses back to one line when pull-request containment lands and the three levers converge — the "pull requests — **none — gap**" row is deleted by that same ticket.

## Deltas from ticket

**AC-4 was corrected in the ticket body before this PR opened, not after.** As filed, it read "`PullRequestSyncer` honors the same predicate". Verifying it falsified it: `PullRequestSyncer:653` calls `path.dirname(targetPath)` unconditionally, so a `null` return **throws** rather than contains. Closing that gap means authoring a drop branch — skip, unlink, index-removal, metadata deletion — a different change with a different risk profile. I re-aimed the AC and moved pull requests to Out of Scope rather than ship against an AC I could not meet. Not hypothetical: a `FIRST_TIME_CONTRIBUTOR` PR filed today claims to fix a ticket it does not touch.

Also deliberately excluded, both parked on neomjs/neo-agent-brain#152: the zero-consumer `signals` field, and `productNameDenylist`'s structural inability to hold a name first seen today (it defaults to `[]`, and a denylist cannot contain a product name first observed this morning — precisely the link-free seeding variant the sanitizer's module doc claims to cover).

**Decision Record impact:** `none` — extends an existing containment pattern to a sibling surface inside the substrate that already owns it. Consumes ADR 0019 §3 B3 as authority for the fallback divergence; amends nothing.

## Test Evidence

`ai/services/github-workflow/sync/IssueSyncer.mjs` (containment gate): `test/playwright/unit/ai/services/github-workflow/IssueSyncer.spec.mjs` — 3 added specs, whole file **26 passed**.
`ai/mcp/server/github-workflow/configBase.mjs` (`issueDenylist` leaf): same spec — the no-op test asserts the resolved default is `{numbers: [], authors: []}`.
`.agents/skills/hostile-content-quarantine/**` (documentation): `node ai/scripts/lint/lint-skill-manifest.mjs --base origin/dev` — structural checks pass; byte-budget carried by the justification token above.

```bash
npm run test-unit -- test/playwright/unit/ai/services/github-workflow/IssueSyncer.spec.mjs
```

| Probe | Result |
|---|---|
| full spec, gate enabled | **26 passed** |
| **gate disabled (`if (false && …)`) — red-proof** | **2 failed, 24 passed** |
| committed bytes re-parsed after `block-alignment --fix` | `node --check` OK on all three `.mjs` |
| spec re-run against the committed tree | **26 passed** |

The two that go red are exactly the behavioral ones. The no-op control stays green in **both** states, which is what a control must do — it asserts unchanged behavior, so a red there would mean the test was measuring the gate rather than the default.

Specs drive the real `pullFromGitHub` path rather than calling the private predicate: a predicate returning `true` into a call site that ignores it would pass a predicate-only test. The author test additionally asserts that a legitimate issue **in the same fetched batch** still syncs — without it, a gate that suppressed the whole page would pass "the hostile one is absent".

## Post-Merge Validation

**None.** Stated as a finding rather than an empty heading: the gate is a predicate over a config leaf whose default is empty, and the no-op spec exercises it on the production `pullFromGitHub` path, so there is no behavior that only a merged state could reveal. I drafted "confirm the first hourly sync emits normally" and dropped it — the corpus is larger than the tmp root but `[].includes(n)` does not care, so the item would have been ceremony, not validation.

Scope of what shipped, so it is not over-read: the leaf default is empty, so the lever is **inert until someone adds an entry**. The specs prove the mechanism, not that production behavior changed — it should not have. Separately, neomjs/neo#17236's own corpus copy self-heals through redaction rather than through this gate, because the sync pulls current bodies; that is the quarantine response's outcome, not this diff's, and it is not claimed here.

## Commits

- `e68d41a3dc` — the gate, the leaf, the specs, and the §6 playbook rewrite.

## Review

Cross-family review required (§6.1) — Claude-authored, so this needs a GPT seat. That bench has been dark ~19h and all Codex seats share one account and quota, so I am flagging rather than assuming: if it stays dark this waits, rather than taking a same-family approval it is not entitled to. Merge is human-gated regardless.

`Review role: primary-reviewer` · `Requested action: use /pr-review on this PR`

---

Authored by Ada (Claude Opus 5, Claude Code). Session 3f264a19-c7d4-481e-bc80-5c288bca177f.
