### PR TITLE
feat(build): the fixed-sleep guard sees callback-form waits and exempts self-naming failure deadlines (#17177)

### DIFF
--- a/buildScripts/util/check-fixed-sleeps-baseline.json
+++ b/buildScripts/util/check-fixed-sleeps-baseline.json
@@ -43,5 +43,35 @@
         "file": "test/playwright/unit/ai/daemons/wake/daemon.spec.mjs",
         "text": "await new Promise(resolve => setTimeout(resolve, 2600));",
         "count": 1
+    },
+    {
+        "file": "test/playwright/unit/ai/daemons/kb-alerting/KbAlertingService.spec.mjs",
+        "text": "KbAlertingService.scheduleNext = function () { this.pollHandle = setTimeout(() => {}, 60_000) };",
+        "count": 1
+    },
+    {
+        "file": "test/playwright/unit/ai/daemons/kb-gc/KbGarbageCollectionService.spec.mjs",
+        "text": "KbGarbageCollectionService.scheduleNext = function () { this.pollHandle = setTimeout(() => {}, 60_000) };",
+        "count": 1
+    },
+    {
+        "file": "test/playwright/unit/ai/daemons/kb-reconciliation/KbReconciliationService.spec.mjs",
+        "text": "KbReconciliationService.scheduleNext = function () { this.pollHandle = setTimeout(() => {}, 60_000) };",
+        "count": 1
+    },
+    {
+        "file": "test/playwright/unit/manager/DragCoordinator.spec.mjs",
+        "text": "timeoutId     : setTimeout(() => { sourceTimerCleared = false }, 60_000)",
+        "count": 1
+    },
+    {
+        "file": "test/playwright/unit/manager/DragCoordinator.spec.mjs",
+        "text": "timeoutId     : setTimeout(() => { targetTimerCleared = false }, 60_000)",
+        "count": 1
+    },
+    {
+        "file": "test/playwright/unit/manager/DragCoordinator.spec.mjs",
+        "text": "timeoutId     : setTimeout(() => {}, 60_000)",
+        "count": 1
     }
 ]

--- a/buildScripts/util/check-fixed-sleeps.mjs
+++ b/buildScripts/util/check-fixed-sleeps.mjs
@@ -42,6 +42,13 @@
  * `out-waits:` is the one that pays forward — it names a leaf candidate, and a constant named here is a
  * constant somebody can make injectable.
  *
+ * Two forms are exempt without a marker, because both already name what the rule asks named. A
+ * named-constant delay is injectable by construction, so the wait's name travels with it. And a
+ * self-naming failure deadline — `setTimeout(() => reject(new Error('…')), N)` — is not a wait at
+ * all: it costs nothing on a green run, fires only to fail a wedged one, and its error text is the
+ * naming. The exemption is shape-checked conservatively (`isSelfNamingDeadline`); a form it cannot
+ * prove is simply counted.
+ *
  * ## The baseline is annotation debt. It is NOT a wall-clock metric.
  *
  * This guard reports two numbers with opposite meanings, and conflating them would defeat it.
@@ -137,24 +144,62 @@ function* callExpressions(node) {
  *
  * A named constant is an `Identifier`, not a `Literal`, so it yields `NaN` and is skipped — the wait
  * names what it waits for, which is exactly what this guard asks of it.
+ *
+ * The FIRST argument is deliberately free: this guard's subject is the WAIT, not the callback's
+ * spelling — an inline `setTimeout(() => {…}, 8000)` blocks the wall clock exactly as long as the
+ * Identifier form and names nothing either. The Identifier restriction lived here only because the
+ * pre-AST matcher's `[A-Za-z_$][\w$]*` capture group could express nothing else; it was never argued
+ * on the merits. What is REFUSED is unchanged: only the delay-literal contract decides that, and a
+ * named-constant delay stays out on either arm.
+ *
+ * One callback form is exempt on the same self-naming principle as the named-constant delay, and
+ * {@link isSelfNamingDeadline} owns it: `() => reject(new Error('…'))` is a failure deadline, not a
+ * wait — it costs nothing on a green run, fires only to fail a wedged one, and names what it waits
+ * for in the error it carries. That is more naming than a marker comment holds, so policing it here
+ * would be ceremony, not accounting.
  * @param {Object} node A `CallExpression` node.
  * @returns {Number} Milliseconds, or `NaN` when this is not a fixed-delay `setTimeout`.
  */
 function fixedWaitMs(node) {
     if (node.callee?.type !== 'Identifier' || node.callee.name !== 'setTimeout') return NaN;
 
-    // The callback arm stays an IDENTIFIER, which is the contract the previous matcher enforced through
-    // its `[A-Za-z_$][\w$]*` group. Dropping the restriction is defensible on the merits — an inline
-    // `setTimeout(() => {…}, 8000)` waits just as long — but it is a widening of SCOPE, not the
-    // formatting-independence this change is for, and it is not free: measured against the tree at this
-    // head, the unrestricted walk surfaces 63 further unaccounted sites. Baselining 63 rows inside a fix
-    // for three parse forms would make one diff argue two different cases. Deferred with its number
-    // taken, so the successor starts from evidence instead of re-measuring.
-    if (node.arguments[0]?.type !== 'Identifier') return NaN;
+    if (isSelfNamingDeadline(node.arguments[0])) return NaN;
 
     const delay = node.arguments[1];
 
     return delay?.type === 'Literal' && typeof delay.value === 'number' ? delay.value : NaN
+}
+
+/**
+ * @summary Whether a `setTimeout` callback is a self-naming failure deadline: the single-expression
+ * form `() => reject(new Error('…'))`.
+ *
+ * The exemption is deliberately narrow, because every widening of what this guard SKIPS must fail
+ * safe — a form it cannot prove self-naming is simply counted, never waved through:
+ *
+ * - expression-body arrows only. A block body (`() => { reject(…) }`) is not inspected, because a
+ *   block can run anything before the reject; the uniform in-tree idiom is the single-expression
+ *   form, and anything else stays visible as a counted site.
+ * - the callee must be the bare identifier `reject` — the Promise-executor convention — called with
+ * - `new Error('<a string literal>')`: the deadline's name must be statically visible. A variable
+ *   message (`reject(new Error(msg))`) or a message-free `reject()` names nothing this guard can
+ *   read, so both are still counted.
+ * @param {Object} callback The `setTimeout` call's first argument.
+ * @returns {Boolean}
+ */
+function isSelfNamingDeadline(callback) {
+    if (callback?.type !== 'ArrowFunctionExpression' && callback?.type !== 'FunctionExpression') return false;
+
+    const body = callback.body;
+
+    return body?.type === 'CallExpression'
+        && body.callee?.type === 'Identifier'
+        && body.callee.name === 'reject'
+        && body.arguments?.[0]?.type === 'NewExpression'
+        && body.arguments[0].callee?.type === 'Identifier'
+        && body.arguments[0].callee.name === 'Error'
+        && body.arguments[0].arguments?.[0]?.type === 'Literal'
+        && typeof body.arguments[0].arguments[0].value === 'string'
 }
 
 // The workflow-parity SSOT: every glob this guard READS, so the sibling scanned-subset-of-watched

--- a/test/playwright/unit/ai/buildScripts/devCockpit.spec.mjs
+++ b/test/playwright/unit/ai/buildScripts/devCockpit.spec.mjs
@@ -261,7 +261,9 @@ test.describe('buildScripts/devCockpit — the live-by-default boot plan', () =>
             child.on('exit', code => resolve({code, output, child}));
 
             // the positive control never exits on its own — give it time to prove the reuse plan,
-            // then tear it down; the refusal path exits(1) well inside this window
+            // then tear it down; the refusal path exits(1) well inside this window.
+            // wall-clock-under-test: the still-running child inside this window IS the reuse-plan
+            // proof; the kill only tears down a passing child
             setTimeout(() => {
                 if (child.exitCode === null) {
                     child.kill('SIGTERM')

--- a/test/playwright/unit/ai/buildScripts/util/check-fixed-sleeps.spec.mjs
+++ b/test/playwright/unit/ai/buildScripts/util/check-fixed-sleeps.spec.mjs
@@ -1,4 +1,5 @@
 import {test, expect}  from '@playwright/test';
+import {spawnSync}     from 'node:child_process';
 import fs              from 'node:fs';
 import os              from 'node:os';
 import path            from 'node:path';
@@ -401,5 +402,76 @@ test.describe('check-fixed-sleeps.mjs — baseline reconciliation (#17124)', () 
         // failure message — the suite reports nothing rather than red. Reaching this assertion at all
         // is the proof, since the import happens in beforeAll.
         expect(typeof reconcile, 'the module imported without exiting the worker').toBe('function');
+    });
+
+    test('#17177: the callback arm is a wait too — inline-callback positives, named-constant-delay negative', async () => {
+        // The guard's own docstring states its subject: "a fixed second-scale wait that does not name
+        // what it waits for." An inline callback names nothing, and it blocks the wall clock exactly as
+        // long as the Identifier form — the first-argument restriction was a regex-capture artifact,
+        // never a decision. Widening what the guard SEES, though, must not widen what it REFUSES: the
+        // delay-literal contract is untouched, so a named-constant delay stays out on either arm.
+        const {findUnjustifiedSleeps} = await import(modulePath);
+
+        const
+            dir     = fs.mkdtempSync(path.join(os.tmpdir(), 'check-fixed-sleeps-callback-')),
+            fixture = path.join(dir, 'callback.spec.mjs');
+
+        try {
+            fs.writeFileSync(fixture, [
+                // The positives: both inline-callback spellings, invisible while the first argument
+                // must be an Identifier.
+                "setTimeout(() => { poll(); }, 8000);",
+                "setTimeout(function () { poll(); }, 1500);",
+                // The negative: a named-constant DELAY stays out regardless of the callback arm —
+                // the constant already names what this guard asks named.
+                "setTimeout(() => { poll(); }, DELAY_MS);",
+                // The Identifier control anchors the set: without it a zero-detection bug reads green.
+                "await new Promise(resolve => setTimeout(resolve, 1000));",
+                // The self-naming failure deadline: a failure detector, not a wait — its error text
+                // is the naming, so it is exempt like the named-constant delay.
+                "setTimeout(() => reject(new Error('the wake never landed')), 5000);",
+                // The exemption's boundary, pinned from both sides: a message-free reject names
+                // nothing, and a message behind a variable is not statically visible — both stay
+                // counted, because a form the guard cannot prove self-naming must never be waved through.
+                "setTimeout(() => reject(), 5000);",
+                "setTimeout(() => reject(new Error(msg)), 5000);"
+            ].join('\n'), 'utf8');
+
+            const {sites} = findUnjustifiedSleeps({files: [fixture], rootDir: dir});
+
+            expect(sites.map(entry => entry.ms), 'both callback spellings, the control, and the two unnamed deadline forms are seen')
+                .toEqual([8000, 1500, 1000, 5000, 5000]);
+            expect(sites.map(entry => entry.line), 'each at its own call site, the negatives absent')
+                .toEqual([1, 2, 4, 6, 7]);
+        } finally {
+            fs.rmSync(dir, {force: true, recursive: true})
+        }
+    });
+
+    test('#17177: the CLI exits 1 on a fresh callback-form wait and 0 on a clean tree', () => {
+        // The library-level pins above prove the site is SEEN; this proves the verdict crosses the
+        // process boundary. A sandbox cwd is the whole tree to the CLI (ROOT_DIR is process.cwd()),
+        // so the clean-tree leg runs without touching the repo — and on the pre-widening matcher the
+        // fixture leg inverts: the callback form is invisible, the exit stays 0, and this test is red.
+        const
+            dir      = fs.mkdtempSync(path.join(os.tmpdir(), 'check-fixed-sleeps-cli-')),
+            unitRoot = path.join(dir, 'test', 'playwright', 'unit');
+
+        fs.mkdirSync(unitRoot, {recursive: true});
+
+        try {
+            let res = spawnSync(process.execPath, [modulePath], {cwd: dir, encoding: 'utf8'});
+
+            expect(res.status, `clean tree exits 0: ${res.stderr}`).toBe(0);
+
+            fs.writeFileSync(path.join(unitRoot, 'fresh.spec.mjs'), 'setTimeout(() => { poll(); }, 8000);\n', 'utf8');
+
+            res = spawnSync(process.execPath, [modulePath], {cwd: dir, encoding: 'utf8'});
+
+            expect(res.status, `a fresh callback-form wait fails the guard: ${res.stdout}`).toBe(1);
+            expect(res.stderr).toContain('8000ms');
+        } finally {
+            fs.rmSync(dir, {force: true, recursive: true})
+        }
     });
 });

--- a/test/playwright/unit/ai/daemons/wake/daemon.spec.mjs
+++ b/test/playwright/unit/ai/daemons/wake/daemon.spec.mjs
@@ -1731,6 +1731,8 @@ test.describe('Wake Daemon', () => {
         let   deliveryCount   = 0;
         let   finalDigest     = '';
         const deliveryPromise = new Promise((resolve, reject) => {
+            // wall-clock-under-test: the 8s window is the duplicate-delivery observation bound — a
+            // second delivery against 50ms poll cycles must surface inside it
             const timeout = setTimeout(() => {
                 resolve(); // Resolve instead of reject because we expect exactly one delivery. We'll wait a bit.
             }, 8000);
@@ -3217,6 +3219,8 @@ test.describe('Wake Daemon', () => {
         // this orphan logs a false success at 2s even though the owner already resolved failed.
         const stubServer = http.createServer((req, res) => {
             requests.push(Date.now());
+            // out-waits: the 1s delivery-owner bound — the orphan response lands only after the
+            // owner has already resolved failed
             setTimeout(() => {
                 if (!res.destroyed) {
                     res.writeHead(204);
@@ -4100,6 +4104,7 @@ test.describe('Wake Daemon', () => {
                     env  : { ...process.env, NEO_MEMORY_DB_PATH: DB_PATH, NEO_AI_DAEMON_DIR: DAEMON_DIR, NEO_WAKE_DAEMON_POLL_INTERVAL_MS: FAST_POLL_MS }
                 });
 
+                // out-waits: FAST_POLL_MS (50ms) — the stimulus lands inside the daemon's first poll cycles
                 setTimeout(() => insertMessageWake(db, {agentId, subject: 'Webhook Address Wake'}), 1000);
             });
         });

--- a/test/playwright/unit/ai/services/fleet/FleetServerComposition.spec.mjs
+++ b/test/playwright/unit/ai/services/fleet/FleetServerComposition.spec.mjs
@@ -426,6 +426,8 @@ test.describe('FleetServerComposition - per-viewer ownership through the real se
 
             const adaChunk = await Promise.race([
                 adaReader.read().then(({value}) => Buffer.from(value).toString('utf8')),
+                // wall-clock-under-test: the SSE chunk must win this 1500ms race — a 'TIMEOUT' win
+                // is the silent-delivery failure
                 new Promise(resolve => setTimeout(() => resolve('TIMEOUT'), 1500))
             ]);
 

--- a/test/playwright/unit/ai/services/memory-core/MailboxService.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/MailboxService.spec.mjs
@@ -327,6 +327,8 @@ test.describe('Neo.ai.services.memory-core.MailboxService', () => {
                         subject: 'durable receipt boundary',
                         body   : 'graph projection is deliberately paused'
                     }).then(receipt => ({receipt})),
+                    // wall-clock-under-test: the durable receipt must beat this 1s deadline arm —
+                    // the race bound is the latency assertion
                     new Promise(resolve => setTimeout(() => resolve({deadline: true}), 1000))
                 ])
             });

--- a/test/playwright/unit/ai/services/shared/providerActivityStatusStore.spec.mjs
+++ b/test/playwright/unit/ai/services/shared/providerActivityStatusStore.spec.mjs
@@ -138,6 +138,8 @@ test.describe('providerActivityStatusStore', () => {
         });
 
         await new Promise((resolve, reject) => {
+            // wall-clock-under-test: the write must stay pending through this live-contention
+            // window (25ms retry against a fresh foreign owner) before the contender is removed
             setTimeout(async () => {
                 try {
                     await fs.unlink(ownerPath);
@@ -184,6 +186,8 @@ test.describe('providerActivityStatusStore', () => {
 
         writer.publishSuccess(300);
         await new Promise((resolve, reject) => {
+            // wall-clock-under-test: the write must stay pending through this live-contention
+            // window (25ms retry against a fresh foreign owner) before the contender is removed
             setTimeout(async () => {
                 try {
                     await fs.unlink(ownerPath);


### PR DESCRIPTION
Resolves neomjs/neo#17177

The fixed-sleep guard now sees every fixed-delay `setTimeout`, not just the Identifier-callback form — the first-argument restriction (a regex-capture artifact, never a decision) is gone. The widened walk surfaced 63 previously invisible sites on this tree (the ticket measured 63 at filing; the intake re-measure on current `dev` found 68 unrestricted minus 5 already-marker-justified — the number moved only by tree growth). Every one of the 63 is now classified: **49 are self-naming failure deadlines** (`() => reject(new Error('…'))`) exempt by shape, **8 carry new justification markers** with their real constants named, and **6 are grandfathered baseline rows** (inert 60s scheduler/candidate-map stubs — test-double scaffolding whose conversion is the wall-clock program's per-site work, explicitly out of scope). The `out-waits:` backlog restates honestly at 5 sites / ~11.7s (was 3 / ~8.7s — the +2 are daemon.spec's stimulus injection and orphan-response fixture, both naming their constants).

Evidence: L2 (unit-spec + guard CLI over the live tree) → L2 required (all five ACs are spec/CLI-verifiable). Residual: none for this ticket's ACs — converting the classified sites is the wall-clock program's per-site work, Residual-Owner: neomjs/neo#17123's program (tracked per-site via the `out-waits:` backlog).

## Deltas from ticket

- **The classification gained a third outcome.** The ticket offered baseline-row-or-marker per site. The measured set's majority class — 49 of 63 — are `() => reject(new Error('…'))` failure deadlines, which fit neither honestly: they are not unaccounted waits (the error text names the condition), and no existing marker describes a timer that costs nothing on a green run. Rather than 49 noise comments or 49 debt-mislabeled baseline rows, the guard now exempts the form by shape (`isSelfNamingDeadline`), on the same self-naming principle as the named-constant delay. The exemption is deliberately narrow — expression-body arrows, bare `reject`, `new Error` with a string-literal message — and every non-matching form stays counted (spec-pinned from both sides). **Framing per the ticket author's fork answer: this is a net TIGHTENING, not a loosening — the exemption is a carve-out from newly-gained coverage (every non-Identifier callback was invisible before), not a hole in existing coverage.** And the bypass it could invite was checked, not assumed: the reject-then-swallow disguise (`new Promise((_, reject) => setTimeout(() => reject(new Error('x')), N)).catch(() => {})`) was censused across `test/`, `ai/`, `src/`, `buildScripts/` and is **absent — 0 of 56 reject-form `setTimeout` sites at c7aed9b6df** (receipt: @neo-opus-grace's fork answer, MESSAGE:09f9908f). That absence is a property of the tree and can drift: if a swallowing `.catch` ever appears on this form, the exemption needs a consumption check rather than a shape check.
- The guard's docstring ("What satisfies it") and `fixedWaitMs` contract text now state the widened detection surface and the exemption's soundness argument (AC5's comment rewrite landed as contract prose, since the deferral comment it replaces was the record of this exact scope decision).
- Intake re-measure on current `dev`: the ticket's "63 further sites" is 63 fresh **rows/sites after marker filtering**; the raw unrestricted delta is 68. First witness unchanged: `devCockpit.spec.mjs:265` @ 8000ms.

## Test Evidence

- `UNIT_TEST_MODE=true npx playwright test -c test/playwright/playwright.config.unit.mjs test/playwright/unit/ai/buildScripts/util/check-fixed-sleeps.spec.mjs` — **21 passed** (2 new pins: callback-form positives + named-constant-delay negative + deadline-exemption boundary forms; CLI exit 1 on a fresh callback-form wait / exit 0 on a clean tree).
- Red-proof: both new tests red against the pre-fix predicate (run individually — `describe.serial` skips siblings after the first failure).
- Mutation controls at the fix head: restoring the Identifier restriction reds both new tests; stubbing `isSelfNamingDeadline` to false fails the guard with the 49 deadline sites as fresh (exit 1). Reverts byte-verified, all green after.
- Guard CLI on the intact tree: `OK — 46 unaccounted site(s) baselined, 0 new, 0 stale` + restated backlog (5 sites, ~11.7s).
- Marker-carrying spec suites re-run green: `devCockpit`, `daemon` (wake), `FleetServerComposition`, `MailboxService`, `providerActivityStatusStore`, `DragCoordinator`, kb-alerting/kb-gc/kb-reconciliation — **194 + 227 passed**; `lintWorkflowScanRootParity` (the SCAN_SURFACE parity twin) included and green.
- Surface `buildScripts/util/check-fixed-sleeps.mjs` + its baseline: covered above; no other consumer (`grep` repo-wide: the guard is CLI + spec only).

## Post-Merge Validation

- [ ] First CI run on `dev` prints the restated line (`46 baselined, 0 new, 0 stale`; backlog 5 / ~11.7s) — the guard's own workflow watches the baseline file, so this PR's run is the pre-merge witness.

Residual-Owner: neomjs/neo#17124

## Commits

- c7aed9b6df — predicate drop + self-naming-deadline exemption + 8 site markers + 6 stub baseline rows + spec pins

Authored by Iris (K3, Kimi Code CLI). Session 2455da9f-c848-4c52-b0f0-daea86aea9c3.

