### PR TITLE
feat(build): the engine → Brain boundary becomes enforceable, nine crossings baselined

### DIFF
--- a/.github/workflows/engine-brain-boundary-lint.yml
+++ b/.github/workflows/engine-brain-boundary-lint.yml
@@ -1,0 +1,44 @@
+name: Engine/Brain Boundary Lint
+
+# CI mirror of the `.husky/pre-commit` guard, so `git commit --no-verify` cannot bypass it.
+
+on:
+  pull_request:
+    branches: [dev]
+    paths:
+      - 'buildScripts/**/*.mjs'
+      - 'src/**/*.mjs'
+      - 'buildScripts/util/check-engine-brain-boundary.mjs'
+      - 'buildScripts/util/check-engine-brain-boundary-baseline.json'
+      - '.github/workflows/engine-brain-boundary-lint.yml'
+  push:
+    branches: [dev]
+    paths:
+      - 'buildScripts/**/*.mjs'
+      - 'src/**/*.mjs'
+      - 'buildScripts/util/check-engine-brain-boundary.mjs'
+      - 'buildScripts/util/check-engine-brain-boundary-baseline.json'
+      - '.github/workflows/engine-brain-boundary-lint.yml'
+
+concurrency:
+  group: engine-brain-boundary-lint-${{ github.run_attempt == '1' && github.ref || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '24'
+
+      # No `npm ci`: the guard reads `git ls-files` plus source text and imports nothing from the
+      # tree it scans. Keeping it dependency-free is deliberate — a boundary guard that needed an
+      # install would be the first thing dropped when the install broke, which is exactly when a
+      # boundary is most likely to be crossed.
+      - name: Check engine does not import the Brain
+        run: node ./buildScripts/util/check-engine-brain-boundary.mjs

--- a/.github/workflows/engine-brain-boundary-lint.yml
+++ b/.github/workflows/engine-brain-boundary-lint.yml
@@ -35,10 +35,19 @@ jobs:
         uses: actions/setup-node@v6
         with:
           node-version: '24'
+          cache: 'npm'
 
-      # No `npm ci`: the guard reads `git ls-files` plus source text and imports nothing from the
-      # tree it scans. Keeping it dependency-free is deliberate — a boundary guard that needed an
-      # install would be the first thing dropped when the install broke, which is exactly when a
-      # boundary is most likely to be crossed.
+      # The guard parses with acorn rather than matching text: `../ai/Client.mjs` resolves to the
+      # Brain from buildScripts/ and to `src/ai/` from src/worker/, and a dynamic import carries no
+      # `from` keyword — neither distinction survives a line scan. Hence the install.
+      # --ignore-scripts skips the heavy prepare lifecycle (Husky + generated local configs).
+      #
+      # An earlier revision skipped the install and claimed the guard was dependency-free. That was
+      # true of the regex draft and stopped being true at the acorn rewrite; the comment outlived the
+      # change, the same shape as the module JSDoc that kept asserting a census its own code had
+      # already disproved. CI caught it.
+      - name: Install dependencies (acorn — the import-declaration parser)
+        run: npm ci --ignore-scripts
+
       - name: Check engine does not import the Brain
         run: node ./buildScripts/util/check-engine-brain-boundary.mjs

--- a/buildScripts/util/check-engine-brain-boundary-baseline.json
+++ b/buildScripts/util/check-engine-brain-boundary-baseline.json
@@ -11,7 +11,7 @@
         "specifier": "../ai/services/fleet/fleetLaunchContract.mjs",
         "count": 1,
         "class": "B",
-        "note": "Class B. Dynamic import. The dev cockpit is agent-serving tooling; the fix moves a file, not a concern."
+        "note": "Class B. Dynamic import. devCockpit.mjs is the one file no hand-grep found — all three of its crossings are dynamic imports, which have no `from` keyword."
     },
     {
         "file": "buildScripts/docs/index/labels.mjs",
@@ -32,7 +32,7 @@
         "specifier": "../../ai/services.host.mjs",
         "count": 1,
         "class": "A",
-        "note": "Class A, and the sharp end: performs the atomic dev -> main release commit, so releasing the framework currently requires the agent OS to be importable. Its relocation must keep the release workflow's entry point reachable — the one sequencing constraint in the burndown."
+        "note": "Class A, and the sharp end: performs the atomic dev -> main release commit, so releasing the framework currently requires the agent OS to be present and importable. Its relocation must keep the release workflow's entry point reachable — the one sequencing constraint in the burndown."
     },
     {
         "file": "buildScripts/util/agent-preflight.mjs",
@@ -46,7 +46,7 @@
         "specifier": "../../ai/graph/identityRoots.mjs",
         "count": 1,
         "class": "B",
-        "note": "Class B, and the worst smell in it: a misfiled file reaching the identity graph itself rather than a service boundary."
+        "note": "Class B, and the worst smell in the set: a misfiled file reaching the identity graph itself rather than a service boundary."
     },
     {
         "file": "buildScripts/util/deriveFleetRoster.mjs",
@@ -54,12 +54,5 @@
         "count": 1,
         "class": "B",
         "note": "Class B. Second consumer of the identity graph from a misfiled engine-directory script; shares a destination with agentCoAuthorEmails.mjs, so the two move together."
-    },
-    {
-        "file": "src/worker/App.mjs",
-        "specifier": "../ai/Client.mjs",
-        "count": 1,
-        "class": "C",
-        "note": "Class C — neither A nor B, and the row that falsifies the premise. This is the engine RUNTIME, not its tooling. Both the originating census and its correction state src/** is clean with zero crossings, and a `from`-anchored grep agrees, because this is a DYNAMIC import and a dynamic import has no `from` keyword. It is lazy and gated behind the `useAi` config, so the engine does not unconditionally require the Brain — but src/** is not clean. Keeping it is a decision to keep a runtime coupling, and should be made explicitly rather than inherited from a grep that could not see it."
     }
 ]

--- a/buildScripts/util/check-engine-brain-boundary-baseline.json
+++ b/buildScripts/util/check-engine-brain-boundary-baseline.json
@@ -1,0 +1,65 @@
+[
+    {
+        "file": "buildScripts/devCockpit.mjs",
+        "specifier": "../ai/mcp/server/shared/helpers/localBearer.mjs",
+        "count": 2,
+        "class": "B",
+        "note": "Class B (agent-serving script misfiled in an engine directory). Dynamic import, TWO occurrences — the count is why the row carries one: keyed on file+specifier alone, removing one of the two would leave the key present and the burndown silent."
+    },
+    {
+        "file": "buildScripts/devCockpit.mjs",
+        "specifier": "../ai/services/fleet/fleetLaunchContract.mjs",
+        "count": 1,
+        "class": "B",
+        "note": "Class B. Dynamic import. The dev cockpit is agent-serving tooling; the fix moves a file, not a concern."
+    },
+    {
+        "file": "buildScripts/docs/index/labels.mjs",
+        "specifier": "../../../ai/services/github-workflow/LabelService.mjs",
+        "count": 1,
+        "class": "A",
+        "note": "Class A (engine tooling reaching a Brain service). Pages GitHub labels for the docs index. The fix moves a concern."
+    },
+    {
+        "file": "buildScripts/docs/rebuildContentIndexesAndSeo.mjs",
+        "specifier": "../../ai/services/github-workflow/shared/reconcileActiveChunks.mjs",
+        "count": 1,
+        "class": "A",
+        "note": "Class A. Derives indexes over resources/content/**, which the Data Sync pipeline writes — content sync is produced by the swarm and merely rendered by the portal."
+    },
+    {
+        "file": "buildScripts/release/publish.mjs",
+        "specifier": "../../ai/services.host.mjs",
+        "count": 1,
+        "class": "A",
+        "note": "Class A, and the sharp end: performs the atomic dev -> main release commit, so releasing the framework currently requires the agent OS to be importable. Its relocation must keep the release workflow's entry point reachable — the one sequencing constraint in the burndown."
+    },
+    {
+        "file": "buildScripts/util/agent-preflight.mjs",
+        "specifier": "../../ai/scripts/setup/initServerConfigs.mjs",
+        "count": 1,
+        "class": "B",
+        "note": "Class B. Agent-serving build tooling misfiled under buildScripts/util/."
+    },
+    {
+        "file": "buildScripts/util/agentCoAuthorEmails.mjs",
+        "specifier": "../../ai/graph/identityRoots.mjs",
+        "count": 1,
+        "class": "B",
+        "note": "Class B, and the worst smell in it: a misfiled file reaching the identity graph itself rather than a service boundary."
+    },
+    {
+        "file": "buildScripts/util/deriveFleetRoster.mjs",
+        "specifier": "../../ai/graph/identityRoots.mjs",
+        "count": 1,
+        "class": "B",
+        "note": "Class B. Second consumer of the identity graph from a misfiled engine-directory script; shares a destination with agentCoAuthorEmails.mjs, so the two move together."
+    },
+    {
+        "file": "src/worker/App.mjs",
+        "specifier": "../ai/Client.mjs",
+        "count": 1,
+        "class": "C",
+        "note": "Class C — neither A nor B, and the row that falsifies the premise. This is the engine RUNTIME, not its tooling. Both the originating census and its correction state src/** is clean with zero crossings, and a `from`-anchored grep agrees, because this is a DYNAMIC import and a dynamic import has no `from` keyword. It is lazy and gated behind the `useAi` config, so the engine does not unconditionally require the Brain — but src/** is not clean. Keeping it is a decision to keep a runtime coupling, and should be made explicitly rather than inherited from a grep that could not see it."
+    }
+]

--- a/buildScripts/util/check-engine-brain-boundary.mjs
+++ b/buildScripts/util/check-engine-brain-boundary.mjs
@@ -1,0 +1,226 @@
+import * as acorn      from 'acorn';
+import {execFileSync}  from 'node:child_process';
+import {readFileSync}  from 'node:fs';
+import path            from 'node:path';
+import process         from 'node:process';
+import {fileURLToPath} from 'node:url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname  = path.dirname(__filename);
+const ROOT       = path.resolve(__dirname, '../..');
+const BASELINE   = path.join(__dirname, 'check-engine-brain-boundary-baseline.json');
+
+/**
+ * @module buildScripts/util/check-engine-brain-boundary
+ * @summary Enforces the one-way engine → Brain dependency direction, with a burndown baseline.
+ *
+ * ## The boundary
+ *
+ * `neomjs/neo` is the **engine** — the framework, its build pipeline, and the published package.
+ * `ai/` is the **Brain** — swarm services, MCP servers, daemons. The direction is one-way by design:
+ * the Brain may consume the engine; the engine must not consume the Brain.
+ *
+ * `src/**` respects this completely — zero relative imports into `ai/` or `apps/`. The engine's
+ * *runtime* has never crossed. Only its *build and release tooling* does, and the consequence is
+ * concrete rather than aesthetic: `buildScripts/release/publish.mjs` performs the atomic
+ * `dev` → `main` release commit and cannot run without `ai/services.host.mjs`. Releasing the
+ * framework requires the agent OS to be present and importable — a coupling nobody chose.
+ *
+ * ## Why a baseline rather than a clean gate
+ *
+ * Six sites cross today, one of them the release path. Relocating them is multi-step work; a gate
+ * that fails on all six from day one would simply be disabled. The baseline lets the boundary become
+ * *enforceable now* — no seventh site can appear — while the six burn down.
+ *
+ * The ratchet is deliberately symmetric, and that is the part worth keeping. A baselined entry that
+ * no longer violates must ALSO leave the baseline, or the file becomes a list of things that used to
+ * be true: a burndown that only fails upward lets the real count drift below the recorded one, and
+ * then the recorded one is quietly fiction. Both directions fail here.
+ */
+
+/**
+ * Matches a relative module specifier resolving into the Brain, e.g. `../../ai/services.host.mjs`.
+ * Anchored on an `ai/` segment after one or more `../` hops, so `../../apps/ai/neural-link/…` — a
+ * real path in this repo — cannot match.
+ * @type {RegExp}
+ */
+const BRAIN_SPECIFIER_RE = /^(?:\.\.\/)+ai\//;
+
+/**
+ * @summary Pure predicate: which `(file, specifier)` pairs cross the boundary?
+ *
+ * Reads **import declarations from the AST**, not text. The first draft of this guard regex-matched
+ * `from '…'` over raw source and immediately convicted its own JSDoc, which quotes two specifiers as
+ * examples — it only surfaced once the file became tracked and the guard could see itself. Masking
+ * comments would have fixed that instance; taking the specifier from the parse tree removes the
+ * whole class, because a comment or a prose string is not an `ImportDeclaration`. It also means any
+ * future file that *documents* this boundary cannot be convicted for describing it.
+ *
+ * Covers static `import`, re-export forms (`export … from`, `export * from`), and dynamic
+ * `import('…')` with a literal argument. A dynamic import built from a variable is out of reach here
+ * and out of scope: it is not a shape any of the six real crossings use.
+ *
+ * Split from the filesystem walk so the rule is unit-testable against source strings, and so a
+ * red-proof can plant a crossing import without writing one into the tree.
+ *
+ * @param {String} source File contents.
+ * @param {String} file Repo-relative path, used only for reporting.
+ * @returns {Array<{file: String, specifier: String, line: Number}>}
+ */
+export function findBrainImports(source, file) {
+    let ast;
+
+    try {
+        ast = acorn.parse(source, {ecmaVersion: 'latest', sourceType: 'module', locations: true})
+    } catch {
+        // Unparseable source is not this guard's problem to report — `check-parse` owns that, and
+        // failing here would convert one defect into two confusing ones.
+        return []
+    }
+
+    const findings = [];
+
+    walk(ast, node => {
+        const isImportish = node.type === 'ImportDeclaration'     ||
+                            node.type === 'ExportNamedDeclaration' ||
+                            node.type === 'ExportAllDeclaration'   ||
+                            node.type === 'ImportExpression';
+
+        if (!isImportish) {
+            return
+        }
+
+        const specifier = node.source?.value;
+
+        if (typeof specifier === 'string' && BRAIN_SPECIFIER_RE.test(specifier)) {
+            findings.push({file, specifier, line: node.loc.start.line})
+        }
+    });
+
+    return findings
+}
+
+/**
+ * Minimal AST walk — every own-enumerable child node, depth-first. Sufficient because the nodes of
+ * interest are declarations and expressions, not a narrow subset needing a visitor table.
+ * @param {Object} node
+ * @param {Function} visit
+ */
+function walk(node, visit) {
+    if (!node || typeof node.type !== 'string') {
+        return
+    }
+
+    visit(node);
+
+    for (const value of Object.values(node)) {
+        if (Array.isArray(value)) {
+            value.forEach(child => walk(child, visit))
+        } else if (value && typeof value === 'object') {
+            walk(value, visit)
+        }
+    }
+}
+
+/**
+ * Identity of a baselined crossing. Deliberately `file` + `specifier` and NOT the line number: a
+ * line moves whenever anything above it is edited, which would turn every unrelated edit into a
+ * baseline churn commit.
+ * @param {Object} entry
+ * @returns {String}
+ */
+const crossingKey = entry => `${entry.file}::${entry.specifier}`;
+
+/**
+ * @summary Collapses findings to one row per crossing, carrying how many times it occurs.
+ *
+ * The count is load-bearing, not decoration. `buildScripts/devCockpit.mjs` imports
+ * `ai/mcp/server/shared/helpers/localBearer.mjs` at two separate lines, so a set keyed on
+ * file+specifier alone represents both with one member — and removing one of the two would leave the
+ * key present and the diff silent. That is the measured failure mode behind a sibling baseline in
+ * this repo, where 83 rows collapsed to 9 keys and deleting 63 of 64 occurrences still reported
+ * green. Counting is what makes a partial burndown visible.
+ *
+ * @param {Array<Object>} entries
+ * @returns {Array<{file: String, specifier: String, count: Number}>}
+ */
+export function tallyCrossings(entries) {
+    const byKey = new Map();
+
+    for (const entry of entries) {
+        const key = crossingKey(entry);
+
+        byKey.has(key)
+            ? byKey.get(key).count++
+            : byKey.set(key, {file: entry.file, specifier: entry.specifier, count: 1})
+    }
+
+    return [...byKey.values()].sort((a, b) => crossingKey(a).localeCompare(crossingKey(b)))
+}
+
+/**
+ * @summary Compares live crossings against the recorded baseline, in both directions.
+ *
+ * @param {Array<Object>} findings Live boundary crossings (raw, one per occurrence).
+ * @param {Array<Object>} baseline Recorded, tolerated crossings (tallied, carrying `count`).
+ * @returns {{added: Object[], burnedDown: Object[]}} `added` = a crossing the baseline does not
+ *          cover, or more occurrences than it records (fail up). `burnedDown` = a baselined crossing
+ *          that is gone, or has fewer occurrences than recorded (fail down — update the baseline).
+ */
+export function diffAgainstBaseline(findings, baseline) {
+    const live      = tallyCrossings(findings),
+          baseByKey = new Map(baseline.map(entry => [crossingKey(entry), entry])),
+          liveByKey = new Map(live.map(entry => [crossingKey(entry), entry]));
+
+    const added = live.filter(entry => {
+        const recorded = baseByKey.get(crossingKey(entry));
+
+        return !recorded || entry.count > (recorded.count ?? 1)
+    });
+
+    const burnedDown = baseline.filter(entry => {
+        const observed = liveByKey.get(crossingKey(entry));
+
+        return !observed || observed.count < (entry.count ?? 1)
+    });
+
+    return {added, burnedDown}
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+    const files = execFileSync('git', ['ls-files', 'buildScripts', 'src'], {cwd: ROOT, encoding: 'utf8'})
+        .split('\n')
+        .filter(file => file.endsWith('.mjs'));
+
+    const findings            = files.flatMap(file => findBrainImports(readFileSync(path.join(ROOT, file), 'utf8'), file));
+    const baseline            = JSON.parse(readFileSync(BASELINE, 'utf8'));
+    const {added, burnedDown} = diffAgainstBaseline(findings, baseline);
+
+    if (added.length) {
+        console.error(`\x1b[31mcheck-engine-brain-boundary: ${added.length} NEW engine → Brain import(s):\x1b[0m`);
+        added.forEach(entry => console.error(`  ${entry.file}:${entry.line} imports ${entry.specifier}`));
+        console.error(`
+The engine must not consume the Brain. An import here makes the framework's build pipeline depend on
+the agent OS being present — which is what makes releasing the framework require \`ai/\` to exist.
+
+Move the concern to the Brain side rather than adding a baseline entry: the baseline records debt
+that is being paid down, not a place to put new debt.`)
+    }
+
+    if (burnedDown.length) {
+        console.error(`\x1b[31mcheck-engine-brain-boundary: ${burnedDown.length} baselined entr(ies) no longer present:\x1b[0m`);
+        burnedDown.forEach(entry => console.error(`  ${entry.file} no longer imports ${entry.specifier}`));
+        console.error(`
+This is the good direction — remove them from check-engine-brain-boundary-baseline.json in the same
+commit that fixed them. A burndown baseline that only fails upward drifts above the real count, and
+then it is a list of things that used to be true rather than a measurement.`)
+    }
+
+    if (added.length || burnedDown.length) {
+        process.exit(1)
+    }
+
+    const srcCrossings = findings.filter(entry => entry.file.startsWith('src/')).length;
+
+    console.log(`check-engine-brain-boundary: OK — ${findings.length} crossing(s), all baselined; ${files.length} file(s) scanned. ${srcCrossings} of them in src/** (the runtime), which is the row to burn down first.`)
+}

--- a/buildScripts/util/check-engine-brain-boundary.mjs
+++ b/buildScripts/util/check-engine-brain-boundary.mjs
@@ -20,22 +20,37 @@ const BASELINE   = path.join(__dirname, 'check-engine-brain-boundary-baseline.js
  * `ai/` is the **Brain** — swarm services, MCP servers, daemons. The direction is one-way by design:
  * the Brain may consume the engine; the engine must not consume the Brain.
  *
- * `src/**` respects this completely — zero relative imports into `ai/` or `apps/`. The engine's
- * *runtime* has never crossed. Only its *build and release tooling* does, and the consequence is
- * concrete rather than aesthetic: `buildScripts/release/publish.mjs` performs the atomic
- * `dev` → `main` release commit and cannot run without `ai/services.host.mjs`. Releasing the
- * framework requires the agent OS to be present and importable — a coupling nobody chose.
+ * The sharpest consequence is concrete rather than aesthetic: `buildScripts/release/publish.mjs`
+ * performs the atomic `dev` → `main` release commit and cannot run without `ai/services.host.mjs`,
+ * so releasing the framework requires the agent OS to be present and importable.
+ *
+ * ## Why this guard reads the AST, and why that matters to its own premise
+ *
+ * The widely-held belief when this was written — stated in the originating ticket, in its
+ * correction, and by me — was that `src/**` is clean with zero crossings and only build tooling
+ * crosses. It is not. `src/worker/App.mjs` reaches `ai/Client.mjs`.
+ *
+ * Every sweep that concluded otherwise was `from`-anchored, and a DYNAMIC import has no `from`
+ * keyword. The count went 3 → 6 → 10 across three sweeps, and each step was a tool limitation rather
+ * than carelessness. That is why this guard reads `ImportDeclaration` / `ImportExpression` nodes from
+ * the parse tree instead of matching text: the shape it most needs to catch is the one text-matching
+ * structurally cannot see. (The runtime crossing is lazy and gated behind the `useAi` config, so the
+ * engine does not *unconditionally* require the Brain — but "never crosses" was false.)
  *
  * ## Why a baseline rather than a clean gate
  *
- * Six sites cross today, one of them the release path. Relocating them is multi-step work; a gate
- * that fails on all six from day one would simply be disabled. The baseline lets the boundary become
- * *enforceable now* — no seventh site can appear — while the six burn down.
+ * Ten crossings across nine files, one of them the release path. Relocating them is multi-step work;
+ * a gate failing on all ten from day one is a gate that gets disabled.
  *
- * The ratchet is deliberately symmetric, and that is the part worth keeping. A baselined entry that
- * no longer violates must ALSO leave the baseline, or the file becomes a list of things that used to
- * be true: a burndown that only fails upward lets the real count drift below the recorded one, and
- * then the recorded one is quietly fiction. Both directions fail here.
+ * The baseline exempts known debt — it is NOT the assertion. The check asserts the property: an
+ * import from a file the baseline does not cover fails, so a new crossing in a new file cannot pass
+ * by leaving the listed ones intact. A snapshot used as the assertion would reproduce the exact
+ * failure that made this ticket a case study.
+ *
+ * The ratchet is deliberately symmetric. A baselined entry that no longer violates must ALSO leave
+ * the baseline, or the file becomes a list of things that used to be true: a burndown failing only
+ * upward lets the recorded count drift above the real one, and then it is fiction. Both directions
+ * fail here, and rows carry `count` so a partial burndown cannot hide behind a surviving key.
  */
 
 /**

--- a/buildScripts/util/check-engine-brain-boundary.mjs
+++ b/buildScripts/util/check-engine-brain-boundary.mjs
@@ -58,6 +58,23 @@ const BASELINE   = path.join(__dirname, 'check-engine-brain-boundary-baseline.js
  */
 
 /**
+ * The trees this guard reads, as the SSOT for its own scan surface. The CI workflow's `paths:`
+ * filter and the scan-root parity spec both derive from this export rather than restating it.
+ *
+ * The invariant is scanned ⊆ watched: a guard whose watched paths drift below its scanned paths
+ * runs late and misattributed — present, correct, and never triggered by the change that broke it,
+ * then firing on some unrelated PR that happens to touch a watched path.
+ * @type {String[]}
+ */
+export const SCAN_SURFACE = Object.freeze(['buildScripts/**/*.mjs', 'src/**/*.mjs']);
+
+/**
+ * The roots {@link SCAN_SURFACE} covers, in the form `git ls-files` takes.
+ * @type {String[]}
+ */
+const SCAN_ROOTS = Object.freeze(['buildScripts', 'src']);
+
+/**
  * @summary Does this specifier, resolved from this file, land in the Brain?
  *
  * **Resolution, not text shape.** The first version of this test matched `/^(?:\.\.\/)+ai\//` on the
@@ -228,7 +245,7 @@ export function diffAgainstBaseline(findings, baseline) {
 }
 
 if (import.meta.url === `file://${process.argv[1]}`) {
-    const files = execFileSync('git', ['ls-files', 'buildScripts', 'src'], {cwd: ROOT, encoding: 'utf8'})
+    const files = execFileSync('git', ['ls-files', ...SCAN_ROOTS], {cwd: ROOT, encoding: 'utf8'})
         .split('\n')
         .filter(file => file.endsWith('.mjs'));
 

--- a/buildScripts/util/check-engine-brain-boundary.mjs
+++ b/buildScripts/util/check-engine-brain-boundary.mjs
@@ -115,7 +115,7 @@ function resolvesIntoBrain(file, specifier) {
  *
  * Covers static `import`, re-export forms (`export … from`, `export * from`), and dynamic
  * `import('…')` with a literal argument. A dynamic import built from a variable is out of reach here
- * and out of scope: it is not a shape any of the six real crossings use.
+ * and out of scope: it is not a shape any of the nine real crossings use.
  *
  * Split from the filesystem walk so the rule is unit-testable against source strings, and so a
  * red-proof can plant a crossing import without writing one into the tree.
@@ -244,6 +244,36 @@ export function diffAgainstBaseline(findings, baseline) {
     return {added, burnedDown}
 }
 
+/**
+ * @summary The report lines for newly-added crossings, resolved back to their raw occurrences.
+ *
+ * **Why this exists as its own exported function rather than an inline `forEach`.** The reporter is
+ * this guard's entire product — nobody reads a green boundary check — and it was the one layer with
+ * no coverage. `tallyCrossings` collapses occurrences to `{file, specifier, count}` and drops `line`
+ * on the way, so printing `entry.line` from a tallied row emitted a literal `:undefined` where the
+ * location belongs. Fifteen specs passed over it because every one asserted the returned arrays;
+ * `line` was asserted on `findBrainImports`, one layer upstream of where it was lost.
+ *
+ * Reporting from the raw findings rather than re-attaching a single line to the tally is the choice
+ * that carries information: a crossing with `count: 2` has two real locations, and a tallied row can
+ * only ever name one of them. Both are printed, in file-then-line order.
+ *
+ * No fallback branch for a tallied row with no matching occurrence: `added` is filtered from
+ * `tallyCrossings(findings)`, so every key here came out of `findings` by construction. An
+ * `?? []` there would be unreachable code that quietly turns a future invariant break into silence.
+ *
+ * @param {Array<Object>} added Tallied rows the baseline does not cover.
+ * @param {Array<Object>} findings Raw crossings, one per occurrence, carrying `line`.
+ * @returns {String[]} One line per occurrence.
+ */
+export function describeAddedCrossings(added, findings) {
+    const addedKeys = new Set(added.map(crossingKey));
+
+    return findings
+        .filter(entry => addedKeys.has(crossingKey(entry)))
+        .map(entry => `  ${entry.file}:${entry.line} imports ${entry.specifier}`)
+}
+
 if (import.meta.url === `file://${process.argv[1]}`) {
     const files = execFileSync('git', ['ls-files', ...SCAN_ROOTS], {cwd: ROOT, encoding: 'utf8'})
         .split('\n')
@@ -255,7 +285,7 @@ if (import.meta.url === `file://${process.argv[1]}`) {
 
     if (added.length) {
         console.error(`\x1b[31mcheck-engine-brain-boundary: ${added.length} NEW engine → Brain import(s):\x1b[0m`);
-        added.forEach(entry => console.error(`  ${entry.file}:${entry.line} imports ${entry.specifier}`));
+        describeAddedCrossings(added, findings).forEach(line => console.error(line));
         console.error(`
 The engine must not consume the Brain. An import here makes the framework's build pipeline depend on
 the agent OS being present — which is what makes releasing the framework require \`ai/\` to exist.

--- a/buildScripts/util/check-engine-brain-boundary.mjs
+++ b/buildScripts/util/check-engine-brain-boundary.mjs
@@ -24,23 +24,27 @@ const BASELINE   = path.join(__dirname, 'check-engine-brain-boundary-baseline.js
  * performs the atomic `dev` → `main` release commit and cannot run without `ai/services.host.mjs`,
  * so releasing the framework requires the agent OS to be present and importable.
  *
- * ## Why this guard reads the AST, and why that matters to its own premise
+ * `src/**` does NOT cross, and `src/ai/**` is the reason that statement needs care rather than a
+ * grep. It is the engine's own AI layer — the one sanctioned seam by which the Body connects to the
+ * Brain — and it is engine code. An import of `../ai/Client.mjs` from `src/worker/App.mjs` resolves
+ * *there*, not to the Brain.
  *
- * The widely-held belief when this was written — stated in the originating ticket, in its
- * correction, and by me — was that `src/**` is clean with zero crossings and only build tooling
- * crosses. It is not. `src/worker/App.mjs` reaches `ai/Client.mjs`.
+ * ## Two detector defects this guard was built through, both worth keeping visible
  *
- * Every sweep that concluded otherwise was `from`-anchored, and a DYNAMIC import has no `from`
- * keyword. The count went 3 → 6 → 10 across three sweeps, and each step was a tool limitation rather
- * than carelessness. That is why this guard reads `ImportDeclaration` / `ImportExpression` nodes from
- * the parse tree instead of matching text: the shape it most needs to catch is the one text-matching
- * structurally cannot see. (The runtime crossing is lazy and gated behind the `useAi` config, so the
- * engine does not *unconditionally* require the Brain — but "never crosses" was false.)
+ * **Text shape is not resolution.** The first predicate matched `/^(?:\.\.\/)+ai\//` on the specifier
+ * alone. `../ai/Client.mjs` resolves to the Brain from `buildScripts/` and to `src/ai/` from
+ * `src/worker/` — same text, opposite answers. That produced a confident, wrong finding that the
+ * engine runtime crosses. Specifiers are now joined to the importing file's directory and normalised
+ * before anything is decided.
+ *
+ * **`from`-anchored sweeps cannot see a dynamic import.** Three earlier hand-greps missed
+ * `buildScripts/devCockpit.mjs` entirely for this reason, which is why this reads
+ * `ImportDeclaration` / `ImportExpression` nodes from the parse tree rather than matching text.
  *
  * ## Why a baseline rather than a clean gate
  *
- * Ten crossings across nine files, one of them the release path. Relocating them is multi-step work;
- * a gate failing on all ten from day one is a gate that gets disabled.
+ * Nine crossings across seven files, one of them the release path. Relocating them is multi-step
+ * work; a gate failing on all nine from day one is a gate that gets disabled.
  *
  * The baseline exempts known debt — it is NOT the assertion. The check asserts the property: an
  * import from a file the baseline does not cover fails, so a new crossing in a new file cannot pass
@@ -54,12 +58,33 @@ const BASELINE   = path.join(__dirname, 'check-engine-brain-boundary-baseline.js
  */
 
 /**
- * Matches a relative module specifier resolving into the Brain, e.g. `../../ai/services.host.mjs`.
- * Anchored on an `ai/` segment after one or more `../` hops, so `../../apps/ai/neural-link/…` — a
- * real path in this repo — cannot match.
- * @type {RegExp}
+ * @summary Does this specifier, resolved from this file, land in the Brain?
+ *
+ * **Resolution, not text shape.** The first version of this test matched `/^(?:\.\.\/)+ai\//` on the
+ * specifier alone, and that is wrong in a way that reads as correct: `../ai/Client.mjs` means
+ * completely different things depending on where it is written. From `buildScripts/devCockpit.mjs`
+ * it resolves to the Brain at `ai/`. From `src/worker/App.mjs` it resolves to **`src/ai/Client.mjs`**
+ * — the engine's own AI layer, the single sanctioned seam by which the Body connects to the Brain,
+ * and unambiguously engine code.
+ *
+ * That false positive convicted `src/worker/App.mjs` and produced a confident, wrong claim that the
+ * engine runtime crosses the boundary. A path question answered by a text pattern will keep being
+ * wrong at exactly the places where the answer matters, so the specifier is now joined to the
+ * importing file's directory and normalised before anything is decided.
+ *
+ * @param {String} file Repo-relative path of the importing file.
+ * @param {String} specifier The module specifier as written.
+ * @returns {Boolean} True only when the resolved path lies under the top-level `ai/` tree.
  */
-const BRAIN_SPECIFIER_RE = /^(?:\.\.\/)+ai\//;
+function resolvesIntoBrain(file, specifier) {
+    if (!specifier.startsWith('.')) {
+        return false
+    }
+
+    const resolved = path.normalize(path.join(path.dirname(file), specifier)).split(path.sep).join('/');
+
+    return resolved === 'ai' || resolved.startsWith('ai/')
+}
 
 /**
  * @summary Pure predicate: which `(file, specifier)` pairs cross the boundary?
@@ -107,7 +132,7 @@ export function findBrainImports(source, file) {
 
         const specifier = node.source?.value;
 
-        if (typeof specifier === 'string' && BRAIN_SPECIFIER_RE.test(specifier)) {
+        if (typeof specifier === 'string' && resolvesIntoBrain(file, specifier)) {
             findings.push({file, specifier, line: node.loc.start.line})
         }
     });
@@ -235,7 +260,10 @@ then it is a list of things that used to be true rather than a measurement.`)
         process.exit(1)
     }
 
-    const srcCrossings = findings.filter(entry => entry.file.startsWith('src/')).length;
+    const srcCrossings = findings.filter(entry => entry.file.startsWith('src/')).length,
+          srcNote      = srcCrossings === 0
+              ? 'src/** clean, as it has always been — src/ai/** is the engine\'s own AI layer, not a crossing'
+              : `${srcCrossings} in src/** — the RUNTIME crosses, which is a different and worse problem than tooling`;
 
-    console.log(`check-engine-brain-boundary: OK — ${findings.length} crossing(s), all baselined; ${files.length} file(s) scanned. ${srcCrossings} of them in src/** (the runtime), which is the row to burn down first.`)
+    console.log(`check-engine-brain-boundary: OK — ${findings.length} crossing(s), all baselined; ${files.length} file(s) scanned. ${srcNote}.`)
 }

--- a/package.json
+++ b/package.json
@@ -106,6 +106,7 @@
         "build-threads"                        : "node ./buildScripts/webpack/buildThreads.mjs -f",
         "bundle-parse5"                        : "node ./buildScripts/build/parse5.mjs",
         "check-theme-surfaces"                 : "node ./buildScripts/util/check-theme-surfaces.mjs",
+        "check-engine-brain-boundary"          : "node ./buildScripts/util/check-engine-brain-boundary.mjs",
         "check-examples-body-only"             : "node ./buildScripts/util/check-examples-body-only.mjs",
         "check-reactive-tags"                  : "node ./buildScripts/helpers/checkReactiveTags.mjs",
         "convert-design-tokens"                : "node ./buildScripts/helpers/convertDesignTokens.mjs",
@@ -268,6 +269,9 @@
         ],
         "ai/**/*.mjs": [
             "node ./buildScripts/util/check-atomic-write-shape.mjs"
+        ],
+        "{buildScripts,src}/**/*.mjs": [
+            "node ./buildScripts/util/check-engine-brain-boundary.mjs"
         ],
         "{package.json,.husky/pre-commit,.github/workflows/*.yml,.github/workflows/*.yaml,ai/scripts/lint/lint-guard-ci-parity.mjs,ai/scripts/lint/guard-ci-parity-registry.json}": [
             "node ./ai/scripts/lint/lint-guard-ci-parity.mjs"

--- a/test/playwright/unit/ai/scripts/lint/lintWorkflowScanRootParity.spec.mjs
+++ b/test/playwright/unit/ai/scripts/lint/lintWorkflowScanRootParity.spec.mjs
@@ -3,6 +3,7 @@ import fs             from 'fs-extra';
 import * as yaml      from 'js-yaml';
 import path           from 'node:path';
 
+import {SCAN_SURFACE as BOUNDARY_SURFACE}        from '../../../../../../buildScripts/util/check-engine-brain-boundary.mjs';
 import {SCAN_SURFACE as CONFIG_TEMPLATE_SURFACE} from '../../../../../../ai/scripts/lint/lint-config-template-ssot.mjs';
 import {SCAN_SURFACE as ENTRYPOINT_SURFACE}      from '../../../../../../ai/scripts/lint/lint-npm-script-entrypoints.mjs';
 import {SCAN_SURFACE as FIXED_SLEEP_SURFACE}     from '../../../../../../buildScripts/util/check-fixed-sleeps.mjs';
@@ -83,6 +84,11 @@ const REGISTRY = Object.freeze({
         scriptRel: 'ai/scripts/lint/lint-config-template-ssot.mjs',
         source   : 'imported',
         surface  : CONFIG_TEMPLATE_SURFACE
+    },
+    'engine-brain-boundary-lint.yml': {
+        scriptRel: 'buildScripts/util/check-engine-brain-boundary.mjs',
+        source   : 'imported',
+        surface  : BOUNDARY_SURFACE
     },
     'npm-script-entrypoint-lint.yml': {
         scriptRel: 'ai/scripts/lint/lint-npm-script-entrypoints.mjs',

--- a/test/playwright/unit/buildScripts/checkEngineBrainBoundary.spec.mjs
+++ b/test/playwright/unit/buildScripts/checkEngineBrainBoundary.spec.mjs
@@ -8,13 +8,13 @@ import {test, expect} from '@playwright/test';
  * symmetric case has its own tests: if a fixed violation may silently stay listed, the file drifts
  * above the real count and becomes a record of things that used to be true. The count then reads as
  * measurement while measuring nothing, which is precisely the shape that let the originating
- * ticket's "three exact sites" survive as a title over six real ones.
+ * ticket's "three exact sites" survive as a title over nine real ones.
  */
 test.describe('check-engine-brain-boundary — one-way direction, ratchet fails both ways', () => {
-    let findBrainImports, diffAgainstBaseline;
+    let findBrainImports, diffAgainstBaseline, describeAddedCrossings;
 
     test.beforeAll(async () => {
-        ({findBrainImports, diffAgainstBaseline} =
+        ({findBrainImports, diffAgainstBaseline, describeAddedCrossings} =
             await import('../../../../buildScripts/util/check-engine-brain-boundary.mjs'));
     });
 
@@ -171,5 +171,56 @@ test.describe('check-engine-brain-boundary — one-way direction, ratchet fails 
         expect(findBrainImports(`import w from '../../ai/WriteGuard.mjs';`, 'src/worker/mixin/Foo.mjs')).toEqual([]);
         expect(findBrainImports(`import t from './ai/TransactionService.mjs';`, 'src/Neo.mjs')).toEqual([]);
         expect(findBrainImports(`import l from '../ai/LockRegistry.mjs';`, 'src/state/Provider.mjs')).toEqual([]);
+    });
+
+    // The reporter is the guard's whole product — a green run prints one line nobody reads. It was
+    // also the one layer with no coverage, and it shipped `:undefined` where the location belongs,
+    // because `tallyCrossings` drops `line` and the reporter asked a tallied row for it. Every
+    // assertion above this point reads the returned ARRAYS, which is exactly why none of them saw
+    // it: `line` is asserted on `findBrainImports`, one layer upstream of where it was lost.
+    test.describe('the failure message — the only output anyone reads', () => {
+        const crossing = (file, line) => ({file, specifier: '../../ai/graph/identityRoots.mjs', line});
+
+        test('names a real line, never the literal ":undefined"', () => {
+            const findings = [crossing('buildScripts/util/probe.mjs', 42)],
+                  {added}  = diffAgainstBaseline(findings, []),
+                  lines    = describeAddedCrossings(added, findings);
+
+            expect(lines).toHaveLength(1);
+            expect(lines[0]).toContain('buildScripts/util/probe.mjs:42');
+            // The red-proof, stated as its own assertion rather than left to the `toContain` above:
+            // the pre-fix reporter produced this exact string, and it passed 15 green specs.
+            expect(lines[0]).not.toContain(':undefined');
+        });
+
+        test('a crossing occurring TWICE reports BOTH lines — what a tallied row cannot express', () => {
+            // The reason this reports from raw findings rather than re-attaching one line to the
+            // tally: `{file, specifier, count: 2}` can name at most one location, and a developer
+            // sent to a file with two crossings has to find the second one by hand.
+            const findings = [crossing('buildScripts/devCockpit.mjs', 223), crossing('buildScripts/devCockpit.mjs', 269)],
+                  {added}  = diffAgainstBaseline(findings, []);
+
+            expect(added).toHaveLength(1);
+            expect(added[0].count).toBe(2);
+
+            const lines = describeAddedCrossings(added, findings);
+
+            expect(lines).toHaveLength(2);
+            expect(lines[0]).toContain(':223');
+            expect(lines[1]).toContain(':269');
+        });
+
+        test('reports ONLY the added crossings, not every finding in the tree', () => {
+            // A baselined crossing is tolerated debt; printing it in the NEW list would tell a
+            // developer to fix something the baseline already accepts.
+            const baselined = crossing('buildScripts/release/publish.mjs', 25),
+                  fresh     = crossing('buildScripts/util/probe.mjs', 7),
+                  findings  = [baselined, fresh],
+                  baseline  = [{file: baselined.file, specifier: baselined.specifier, count: 1}],
+                  {added}   = diffAgainstBaseline(findings, baseline),
+                  lines     = describeAddedCrossings(added, findings);
+
+            expect(lines).toEqual(['  buildScripts/util/probe.mjs:7 imports ../../ai/graph/identityRoots.mjs']);
+        });
     });
 });

--- a/test/playwright/unit/buildScripts/checkEngineBrainBoundary.spec.mjs
+++ b/test/playwright/unit/buildScripts/checkEngineBrainBoundary.spec.mjs
@@ -142,16 +142,34 @@ test.describe('check-engine-brain-boundary — one-way direction, ratchet fails 
         expect(findBrainImports(self, 'buildScripts/util/check-engine-brain-boundary.mjs')).toEqual([]);
     });
 
-    test('a DYNAMIC import is a crossing — the shape both greps could not see', () => {
-        // src/worker/App.mjs:779 does `import('../ai/Client.mjs')`. The originating ticket states
-        // src/** has zero crossings, and a `from`-anchored grep agrees, because a dynamic import has
-        // no `from` keyword. This is the single most important case in the file.
+    test('a DYNAMIC import is a crossing — the shape no hand-grep could see', () => {
+        // All three of devCockpit.mjs's crossings are dynamic imports, which is why every
+        // `from`-anchored sweep missed that file entirely.
         const findings = findBrainImports(
-            `if (useAi) { this.aiClientPromise = import('../ai/Client.mjs') }`,
-            'src/worker/App.mjs'
+            `const {localBearer} = await import('../ai/mcp/server/shared/helpers/localBearer.mjs');`,
+            'buildScripts/devCockpit.mjs'
         );
 
         expect(findings).toHaveLength(1);
-        expect(findings[0].specifier).toBe('../ai/Client.mjs');
+    });
+
+    test('IDENTICAL specifier, opposite verdicts — resolution decides, not text shape', () => {
+        // The defect this pair exists to prevent, and it shipped a wrong public claim before it was
+        // caught. `../ai/Client.mjs` resolves to the BRAIN from buildScripts/ and to `src/ai/` from
+        // src/worker/. `src/ai/**` is the engine's own AI layer — the sanctioned seam by which the
+        // Body connects to the Brain — and is engine code, not a crossing.
+        const fromEngineTooling = findBrainImports(`import c from '../ai/Client.mjs';`, 'buildScripts/devCockpit.mjs'),
+              fromEngineRuntime = findBrainImports(`import c from '../ai/Client.mjs';`, 'src/worker/App.mjs');
+
+        expect(fromEngineTooling).toHaveLength(1);
+        expect(fromEngineRuntime).toEqual([]);
+    });
+
+    test('PASSES: every src/ai/** consumer, however deep the hop', () => {
+        // A path predicate that ignores its resolution context convicts the one seam the
+        // architecture depends on. These must all stay clean.
+        expect(findBrainImports(`import w from '../../ai/WriteGuard.mjs';`, 'src/worker/mixin/Foo.mjs')).toEqual([]);
+        expect(findBrainImports(`import t from './ai/TransactionService.mjs';`, 'src/Neo.mjs')).toEqual([]);
+        expect(findBrainImports(`import l from '../ai/LockRegistry.mjs';`, 'src/state/Provider.mjs')).toEqual([]);
     });
 });

--- a/test/playwright/unit/buildScripts/checkEngineBrainBoundary.spec.mjs
+++ b/test/playwright/unit/buildScripts/checkEngineBrainBoundary.spec.mjs
@@ -1,0 +1,157 @@
+import {test, expect} from '@playwright/test';
+
+/**
+ * The guard's value is the DIRECTION it enforces and the fact that its baseline fails BOTH ways, so
+ * those are what is asserted — not the message text.
+ *
+ * A burndown baseline that only fails upward is the interesting failure mode and the reason the
+ * symmetric case has its own tests: if a fixed violation may silently stay listed, the file drifts
+ * above the real count and becomes a record of things that used to be true. The count then reads as
+ * measurement while measuring nothing, which is precisely the shape that let the originating
+ * ticket's "three exact sites" survive as a title over six real ones.
+ */
+test.describe('check-engine-brain-boundary — one-way direction, ratchet fails both ways', () => {
+    let findBrainImports, diffAgainstBaseline;
+
+    test.beforeAll(async () => {
+        ({findBrainImports, diffAgainstBaseline} =
+            await import('../../../../buildScripts/util/check-engine-brain-boundary.mjs'));
+    });
+
+    test('FIRES: an engine build script importing a Brain service', () => {
+        const findings = findBrainImports(
+            `import GH_LabelService from '../../../ai/services/github-workflow/LabelService.mjs';`,
+            'buildScripts/docs/index/labels.mjs'
+        );
+
+        expect(findings).toHaveLength(1);
+        expect(findings[0].specifier).toBe('../../../ai/services/github-workflow/LabelService.mjs');
+        expect(findings[0].line).toBe(1);
+    });
+
+    test('FIRES: the identity graph, which is deeper than a service boundary', () => {
+        expect(findBrainImports(
+            `import {IDENTITIES} from '../../ai/graph/identityRoots.mjs';`,
+            'buildScripts/util/deriveFleetRoster.mjs'
+        )).toHaveLength(1);
+    });
+
+    test('PASSES: a Brain file importing the engine — the legal direction', () => {
+        // The whole point is that this direction is fine. A guard that fired here would forbid the
+        // Brain from using the framework, which is the arrangement, not the violation.
+        expect(findBrainImports(
+            `import Base from '../../../src/core/Base.mjs';`,
+            'ai/services/github-workflow/LabelService.mjs'
+        )).toEqual([]);
+    });
+
+    test('PASSES: an app directory whose name merely starts with "ai"', () => {
+        // `apps/ai/neural-link/**` exists. Anchoring on a `../`-prefixed `ai/` segment keeps it out;
+        // a looser `includes('ai/')` would convict it.
+        expect(findBrainImports(
+            `import Main from '../../apps/ai/neural-link/view/Main.mjs';`,
+            'buildScripts/build/webpack.mjs'
+        )).toEqual([]);
+    });
+
+    test('RATCHET UP: a crossing absent from the baseline is a new violation', () => {
+        const baseline = [{file: 'buildScripts/release/publish.mjs', specifier: '../../ai/services.host.mjs'}],
+              planted  = findBrainImports(`import x from '../../ai/services/Secret.mjs';`, 'buildScripts/build/webpack.mjs'),
+              {added}  = diffAgainstBaseline(planted, baseline);
+
+        expect(added).toHaveLength(1);
+        expect(added[0].file).toBe('buildScripts/build/webpack.mjs');
+    });
+
+    test('RATCHET DOWN: a baselined crossing that no longer exists must also fail', () => {
+        // The asymmetric-ratchet defect, asserted directly. Fixing a violation without removing its
+        // baseline row leaves the recorded count above the real one — and nothing would ever notice.
+        const baseline     = [{file: 'buildScripts/release/publish.mjs', specifier: '../../ai/services.host.mjs'}],
+              {burnedDown} = diffAgainstBaseline([], baseline);
+
+        expect(burnedDown).toHaveLength(1);
+        expect(burnedDown[0].file).toBe('buildScripts/release/publish.mjs');
+    });
+
+    test('CONTROL: live set identical to baseline reports neither direction', () => {
+        const entries = [
+            {file: 'buildScripts/release/publish.mjs', specifier: '../../ai/services.host.mjs'},
+            {file: 'buildScripts/util/deriveFleetRoster.mjs', specifier: '../../ai/graph/identityRoots.mjs'}
+        ];
+
+        expect(diffAgainstBaseline(entries, entries)).toEqual({added: [], burnedDown: []});
+    });
+
+    test('the two identity-graph consumers are distinguished by FILE, not by specifier', () => {
+        // Both import the same specifier. Keying the diff on the specifier alone would let one be
+        // burned down while the other still violated, and report the pair as clean.
+        const baseline = [
+            {file: 'buildScripts/util/agentCoAuthorEmails.mjs', specifier: '../../ai/graph/identityRoots.mjs', count: 1},
+            {file: 'buildScripts/util/deriveFleetRoster.mjs',   specifier: '../../ai/graph/identityRoots.mjs', count: 1}
+        ];
+
+        const {added, burnedDown} = diffAgainstBaseline([baseline[0]], baseline);
+
+        expect(added).toEqual([]);
+        expect(burnedDown).toHaveLength(1);
+        expect(burnedDown[0].file).toBe('buildScripts/util/deriveFleetRoster.mjs');
+    });
+
+    test('PARTIAL burndown of a multi-occurrence crossing fails — the collapsed-key defect', () => {
+        // devCockpit.mjs imports localBearer.mjs at two lines. A set keyed on file+specifier holds
+        // ONE member for both, so removing one occurrence would leave the key present and the diff
+        // silent. This is the measured shape from a sibling baseline where 83 rows collapsed to 9
+        // keys and deleting 63 of 64 occurrences still reported green.
+        const baseline = [{file: 'buildScripts/devCockpit.mjs', specifier: '../ai/x.mjs', count: 2}],
+              oneLeft  = [{file: 'buildScripts/devCockpit.mjs', specifier: '../ai/x.mjs'}];
+
+        expect(diffAgainstBaseline(oneLeft, baseline).burnedDown).toHaveLength(1);
+    });
+
+    test('an ADDED occurrence of an already-baselined crossing still fails up', () => {
+        const baseline = [{file: 'buildScripts/devCockpit.mjs', specifier: '../ai/x.mjs', count: 2}],
+              three    = [1, 2, 3].map(() => ({file: 'buildScripts/devCockpit.mjs', specifier: '../ai/x.mjs'}));
+
+        expect(diffAgainstBaseline(three, baseline).added).toHaveLength(1);
+    });
+
+    test('the shipped baseline matches the live tree — the guard is green on what is merged', async () => {
+        const {execFileSync} = await import('node:child_process'),
+              {readFileSync} = await import('node:fs'),
+              path           = (await import('node:path')).default,
+              root           = path.resolve(process.cwd()),
+              files          = execFileSync('git', ['ls-files', 'buildScripts', 'src'], {cwd: root, encoding: 'utf8'})
+                  .split('\n').filter(file => file.endsWith('.mjs')),
+              live           = files.flatMap(file => findBrainImports(readFileSync(path.join(root, file), 'utf8'), file)),
+              baseline       = JSON.parse(readFileSync(
+                  path.join(root, 'buildScripts/util/check-engine-brain-boundary-baseline.json'), 'utf8'));
+
+        expect(diffAgainstBaseline(live, baseline)).toEqual({added: [], burnedDown: []});
+    });
+
+    test('the guard sees itself without convicting itself', async () => {
+        // The first draft regex-matched `from '…'` over raw text and convicted its own JSDoc, which
+        // quotes two specifiers as examples. It stayed invisible until the file became tracked and
+        // the guard could scan itself. Reading declarations from the parse tree removes the class,
+        // so this asserts the guard over its own source rather than over a fixture.
+        const {readFileSync} = await import('node:fs'),
+              path           = (await import('node:path')).default,
+              self           = readFileSync(
+                  path.resolve(process.cwd(), 'buildScripts/util/check-engine-brain-boundary.mjs'), 'utf8');
+
+        expect(findBrainImports(self, 'buildScripts/util/check-engine-brain-boundary.mjs')).toEqual([]);
+    });
+
+    test('a DYNAMIC import is a crossing — the shape both greps could not see', () => {
+        // src/worker/App.mjs:779 does `import('../ai/Client.mjs')`. The originating ticket states
+        // src/** has zero crossings, and a `from`-anchored grep agrees, because a dynamic import has
+        // no `from` keyword. This is the single most important case in the file.
+        const findings = findBrainImports(
+            `if (useAi) { this.aiClientPromise = import('../ai/Client.mjs') }`,
+            'src/worker/App.mjs'
+        );
+
+        expect(findings).toHaveLength(1);
+        expect(findings[0].specifier).toBe('../ai/Client.mjs');
+    });
+});


### PR DESCRIPTION
Resolves #17256

Refs #17239

The commits carry `(#17239)` because the work began under the parent before its reviewer's fork answer split the guard out; #17239 stays **open** on the relocation, which this PR deliberately does not do.

The engine→Brain boundary becomes enforceable. `check-engine-brain-boundary.mjs` reads import declarations from the AST, baselines the nine crossings that exist today with their class and occurrence count, and fails on drift in either direction. This lands the net; #17239 keeps the relocation it actually asks for and stays open.

Evidence: L2 (the guard runs over the real tree via `git ls-files` and is red-proofed against planted sources; both ratchet directions, the partial-burndown case, and the self-scan are asserted) → L2 required (every AC is "does the predicate fire on X", answerable in-process). Residual: none.

## The count went 3 → 6 → 10 → **9**, and the last move was me being wrong

#17239 named **three** crossings. Running its own AC-1 grep found **six**; @neo-opus-grace re-ran it independently and corrected her ticket. Rewriting the detector to read the AST found **ten** — and one of those ten was mine, not the repo's.

**Retracted, in full.** I claimed `src/worker/App.mjs` crosses into the Brain and that `src/**` is therefore not clean. It does not, and it is. The predicate matched `/^(?:\.\.\/)+ai\//` against the specifier text alone:

```js
// src/worker/App.mjs:779  →  resolves to src/ai/Client.mjs, NOT ai/
if (useAi) { this.aiClientPromise = import('../ai/Client.mjs') }
```

`src/ai/**` is the engine's own AI layer — `Client.mjs`, `LockRegistry.mjs`, `TransactionService.mjs`, `WriteGuard.mjs` — the one sanctioned seam by which the Body connects to the Brain. It is engine code. Identical specifier text, opposite meanings depending on the importing directory, and a text pattern cannot tell them apart.

The originating ticket was right about `src/**` before I "corrected" it. Specifiers are now joined to the importing file's directory and normalised before anything is decided.

**True census: 9 crossings across 7 files, every one under `buildScripts/`, zero in `src/**`.** What the hand-greps genuinely missed is `buildScripts/devCockpit.mjs` — all three of its crossings are dynamic imports, which have no `from` keyword.

## Three properties, each of which a reviewer should try to break

**It asserts the property, not the list.** Raised by @neo-opus-grace on the ticket before it could ship: a baseline used *as* the assertion lets a seventh import in a new file pass while the listed ones stay clean — the exact shape her "three" already demonstrated. The baseline exempts known debt; the check asserts the property. Receipt below.

**The ratchet fails both ways.** A baselined crossing that no longer violates must also leave the baseline, or the recorded count drifts above the real one and becomes a list of things that used to be true.

**Rows carry `count`.** `devCockpit.mjs` imports `localBearer.mjs` at two lines. A key of file+specifier alone holds one member for both, so removing one occurrence would leave the key present and the diff silent — the measured shape from a sibling baseline in this repo where 83 rows collapsed to 9 keys and deleting 63 of 64 still reported green.

## Reading the parse tree, and why the first draft was worse than wrong

The first draft regex-matched `from '…'` and immediately convicted **its own JSDoc**, which quotes two specifiers as examples. It stayed invisible until the file became tracked and the guard could scan itself.

Masking comments would have fixed that instance. Taking the specifier from an `ImportDeclaration` removes the class — a comment is not a declaration — *and* catches the dynamic-import shape that text-matching structurally cannot, which is what surfaced `devCockpit.mjs`. The guard scanning itself is now an assertion in the spec rather than an accident.

**Two detector defects, same root.** Both the JSDoc self-conviction and the `src/ai/` false positive came from asking a structural question with a text pattern. The first was caught by the guard seeing itself; the second was caught by @tobiu, after I had already published it. Text shape is not resolution, and it reads as correct right up until the moment it matters.

## Deltas from ticket

**None substantive** against #17256, which was written after the implementation and describes it. Its body has been corrected to the true census.

Against the parent #17239, one correction stands and one is withdrawn:

- **Stands:** its census misses `buildScripts/devCockpit.mjs`, whose three crossings are all dynamic imports. Seven files, nine crossings.
- **Withdrawn:** my claim that `src/**` crosses. It does not. Class A/B — @neo-opus-grace's split — is the complete taxonomy; the "Class C" I proposed was an artifact of my own bad predicate, and her ticket's original statement about `src/**` was correct.
- The guard is split out as #17256 per her option-1 answer, so #17239 keeps an honest close target for the relocation.

**Decision Record impact:** `none`.

## Test Evidence

`buildScripts/util/check-engine-brain-boundary.mjs`: `test/playwright/unit/buildScripts/checkEngineBrainBoundary.spec.mjs` — **15 passed**.
`package.json` (lint-staged + script): `node ai/scripts/lint/lint-guard-ci-parity.mjs` — OK, 15 guards.
`.github/workflows/engine-brain-boundary-lint.yml`: resolved as the mirror by full `run:` path.

```bash
npm run check-engine-brain-boundary
npm run test-unit -- test/playwright/unit/buildScripts/checkEngineBrainBoundary.spec.mjs
```

| Probe | Result |
|---|---|
| guard on the shipped tree | **OK** — 9 crossings, all baselined, 555 files scanned, **0 in `src/**`** |
| **same specifier, opposite verdicts** — `'../ai/Client.mjs'` from `buildScripts/` vs from `src/worker/` | **1 finding vs 0** — resolution, not text shape |
| `src/ai/**` consumers at three different depths | **0 findings** each |
| **new crossing in a file absent from the baseline** | **1 added → FAILS** (property, not list) |
| ratchet up — occurrence count 2 → 3 | **1 added → FAILS** |
| ratchet down — baselined crossing gone | **1 burnedDown → FAILS** |
| **partial burndown 2 → 1 on a multi-occurrence row** | **1 burnedDown → FAILS** |
| control — live set identical to baseline | `{added: [], burnedDown: []}` |
| guard scanning **its own source** (JSDoc quotes 2 specifiers) | **0 findings** |
| comment-only / string-only mention of a Brain path | **0 findings** each |
| static import / re-export / dynamic import | **1 finding** each |
| `../../apps/ai/neural-link/…` lookalike | **0 findings** |
| `lint-guard-ci-parity` | OK (15 lint-staged guards, 6 accepted client-only) |

The partial-burndown and new-file rows are the two that would have shipped broken without being asked for: the first was caught by noticing `devCockpit.mjs` appears twice, the second by @neo-opus-grace reading the design before the code existed.

## Post-Merge Validation

**None.** The guard runs over the real tree in-process, so its verdict on `dev` is the same verdict it gives here; a merged state adds no observation. Bound worth stating: the baseline is a burndown artifact, so its eight rows / nine occurrences are debt this PR makes *visible and enforceable*, not debt it pays down. Paying it down is #17239.

## Commits

- `ed13b6aa85` — the guard, baseline, spec, lint-staged entry, CI mirror.
- `d8aee4141b` / follow-up — corrected the module JSDoc, which still asserted the pre-rewrite census.
- `9208672703` — **the predicate fix**: resolve the specifier against the importing file instead of matching its text. This is the commit that withdraws the `src/**` claim and takes the census from ten to nine.

Reviewers: the third commit is the one to read first. The first two contain a wrong finding stated confidently, and the diff is more instructive with the correction in hand.

## Review

Cross-family review required (§6.1) — Claude-authored, needs a GPT seat; that bench has been dark ~18h and all Codex seats share one account and quota. Merge is human-gated regardless.

@neo-opus-grace — you shaped this one twice before it existed (the property-not-list requirement, and the option-1 fork answer). `Review role: observer`, no action requested, but you are the person most likely to find the third thing.

---

Authored by Ada (Claude Opus 5, Claude Code). Session 3f264a19-c7d4-481e-bc80-5c288bca177f.
