### PR TITLE
docs(agent-os): the session-signature rule reaches ideation-sandbox, restatements point at one shared statement (#17143)

### DIFF
--- a/.agents/skills/ideation-sandbox/references/ideation-sandbox-workflow.md
+++ b/.agents/skills/ideation-sandbox/references/ideation-sandbox-workflow.md
@@ -31,6 +31,10 @@ Before drafting a Discussion/proposal, run [`../audits/pre-authoring-adjacency-s
 
 Before Discussion prose, read [`reference-hygiene.md`](../../../../learn/agentos/process/reference-hygiene.md): relationships stay bare; descriptive tokens use backticks.
 
+### 2.2 Provenance Signature
+
+Close Discussion bodies and substantive comments (divergence cycles, sweeps, graduation signals) with `Name (Model, Harness) · session <uuid>` — the fields GitHub does not render. Acks and one-line replies are exempt.
+
 ## 3. Author's Note Convention (The `#10119` Annotation Pattern)
 Discussions are meant to evolve. Instead of creating noisy parallel comment threads to reflect updates to the core idea, the authoritative substrate is the Discussion body itself.
 - Use **"the `#10119` annotation pattern"**: Treat the Discussion body like a PR diff. When the idea evolves, edit the body directly with `manage_discussion({action: 'update_body', discussion_number, body})` (like a force-push).

--- a/.agents/skills/ticket-create/references/ticket-create-workflow.md
+++ b/.agents/skills/ticket-create/references/ticket-create-workflow.md
@@ -146,7 +146,7 @@ Skeleton tickets are forbidden. Every ticket body MUST contain:
 - **Out of Scope** — what this ticket deliberately does NOT do. Prevents scope creep during implementation.
 - **Avoided Traps** / **Gold Standards Rejected** *(when applicable)* — alternatives considered and rejected, with rationale. Especially critical when rejecting a generic industry/LLM "best practice" (e.g. standard React patterns, generic node workflows) that is a trap in Neo.mjs's multi-threaded architecture.
 - **Related** — sibling tickets, superseded tickets, dependencies, PRs.
-- **Origin Session ID** — Memory Core session ID that produced the ticket. **Optional, but highly recommended** for genuinely single-session tickets. Serves as a direct pointer for the A2A Contextual Bridge Protocol (`AGENTS.md §14`); also the intent authority a reviewer mines (`learn/agentos/process/correction-culture.md`). Format: `Origin Session ID: <uuid>` on its own line near the end of the body.
+- **Origin Session ID** — `Origin Session ID: <uuid>` on its own line near the end of the body; optional but highly recommended for genuinely single-session tickets.
 - **Handoff Retrieval Hints** — Semantic query patterns (`query_raw_memories`, `query_summaries`) or exact Git commit-range anchors to assist subsequent agents in resuming the workstream across fragmented session IDs post-restart. **REQUIRED for architecturally substantive tickets or multi-session workflows.** Example: `Retrieval Hint: "cross-harness MCP singleton cache divergence"` or `Retrieval Hint: Commit SHA 1234abcd..5678efgh`.
 
 ### 5.1 Reference Hygiene: Backtick-Escape for Descriptive `#N`


### PR DESCRIPTION
Resolves #17143

One line, per the operator's ruling on the first shape (too much prose for a trivial rule — signatures must be near-zero tokens): `ideation-sandbox` gains a four-line §2.2 mandating the `Name (Model, Harness) · session <uuid>` signature on Discussion bodies and substantive comments, with acks/one-liners exempt. No shared doc, no pointer apparatus. The `ticket-create` §5 bullet sheds its prose tail as the offset — **net `.agents/skills/**` is +75 B** (under the 250 B cap; the first shape was +2,395 B all-in).

Evidence: L1 (convention change; premise grep-verified — zero mandate in `ideation-sandbox`, sibling restatements censused) → L1 required. Residual: none.

## Deltas from ticket

- AC2's "shared statement" framing is dropped per operator direction — the rule is described in place in one line, not exported to a doc. AC1 (mandate on bodies + substantive comments) and AC3 (low-substance exemption) stand. AC4 (net loaded-bytes): +75 B, measured with `wc -c`.
- The ticket-create bullet keeps its optional-but-recommended status and the exact format string; only the rationale prose moved out.

## Slot rationale (substrate-mutation pre-flight)

- **Added** `ideation-sandbox-workflow.md` §2.2 — disposition `keep` in skill payload: trigger-gated load, trivial cost (one line), discipline-only enforcement per the ticket's Out-of-Scope.
- **Modified** `ticket-create-workflow.md` §5 bullet — disposition `rewrite` (prose tail removed, format kept).
- No always-loaded surface touched; no new files.

## Test Evidence

- `node ai/scripts/lint/lint-skill-manifest.mjs --base origin/dev` — **OK** (net-delta cap, per-file budgets, reference integrity).
- Byte ledger (`wc -c`): ideation-sandbox-workflow.md +330 B section, ticket-create-workflow.md −255 B bullet → net +75 B.
- Docs-only; no unit-test surface for the prose itself — `None found` beyond the manifest lint.

## Post-Merge Validation

None deferred — adoption is witnessed on the next high-blast Discussion's comment sweep; the ticket's Out-of-Scope reserves any mechanical gate until the convention measurably fails.

## Commits

- 83340239f3 — the one-line mandate + the bullet compression (supersedes the prose-heavy first shape at 76afd77737, replaced pre-review per operator ruling)

Authored by Iris (K3, Kimi Code CLI). Session 2455da9f-c848-4c52-b0f0-daea86aea9c3.
