### PR TITLE
feat(ai): brokered viewer poll-digest on the events origin (#17252)

### DIFF
--- a/ai/services/fleet/fleetServer.mjs
+++ b/ai/services/fleet/fleetServer.mjs
@@ -503,6 +503,82 @@ export async function createFleetServerApp({
         }
     });
 
+    // The catch-up truth lane's client surface — the events origin's sibling, taking exactly the
+    // stream's two headers: class-1 admission already proven by the chain above, the viewer's
+    // class-3 MC credential brokered in-flight (poll-digest is an authenticated MC call and the
+    // browser page holds no plane credential by design — this route is how the cold drain reaches
+    // it). Same connection-attempt shape as the stream: a consumer polls once per connection.
+    const digestLimiter = rateLimit({
+        windowMs       : 60_000,
+        limit          : 30,
+        standardHeaders: false,
+        legacyHeaders  : false,
+        validate       : {xForwardedForHeader: false},
+        keyGenerator   : req => resolveViewerStreamKey(req.fleetRequestContext, app.fleetWakeArming?.provenIdentity?.() ?? null)
+            ?? 'unidentified',
+        handler        : (req, res) => res.status(429).json(createFleetWireResponse(FLEET_WIRE_RESPONSE_STATES.refused, {
+            error: 'fleet: too many digest polls'
+        }))
+    });
+
+    app.post('/fleet/events/digest', digestLimiter, async (req, res) => {
+        const streamKey = resolveViewerStreamKey(req.fleetRequestContext, app.fleetWakeArming?.provenIdentity?.() ?? null);
+
+        if (!streamKey) {
+            res.status(403).json(createFleetWireResponse(FLEET_WIRE_RESPONSE_STATES.refused, {
+                error: 'fleet: viewer identity carries no stable subject'
+            }));
+            return
+        }
+
+        if (!app.fleetWakeArming?.pollDigestForViewer) {
+            res.status(403).json(createFleetWireResponse(FLEET_WIRE_RESPONSE_STATES.refused, {
+                error: 'fleet: wake catch-up is not wired on this deployment — no wake lane declared'
+            }));
+            return
+        }
+
+        const {subscriptionId, sinceLogId = 0} = req.body ?? {};
+
+        if (typeof subscriptionId !== 'string' || subscriptionId.trim().length === 0 ||
+            !Number.isFinite(sinceLogId) || sinceLogId < 0
+        ) {
+            res.status(400).json(createFleetWireResponse(FLEET_WIRE_RESPONSE_STATES.refused, {
+                error: 'fleet: malformed digest poll — subscriptionId (string) and a non-negative sinceLogId are required'
+            }));
+            return
+        }
+
+        const
+            fleetBearer    = (req.headers.authorization ?? '').replace(/^Bearer\s+/i, '').trim(),
+            mcBearer       = (req.headers['x-neo-mc-authorization'] ?? '').replace(/^Bearer\s+/i, '').trim(),
+            canonicalClaim = normalizeAgentIdentity(req.fleetRequestContext.providerUsername ?? req.fleetRequestContext.username);
+
+        if (!mcBearer || !canonicalClaim) {
+            res.status(403).json(createFleetWireResponse(FLEET_WIRE_RESPONSE_STATES.refused, {
+                error: "fleet: digest poll requires the viewer's own MC credential — the catch-up lane is per-viewer"
+            }));
+            return
+        }
+
+        const outcome = await app.fleetWakeArming.pollDigestForViewer({
+            canonicalClaim,
+            bearer              : mcBearer,
+            fleetAdmissionBearer: fleetBearer,
+            subscriptionId,
+            sinceLogId
+        });
+
+        if (!outcome.ok) {
+            res.status(403).json(createFleetWireResponse(FLEET_WIRE_RESPONSE_STATES.refused, {
+                error: `fleet: ${outcome.reason}`
+            }));
+            return
+        }
+
+        res.status(200).json(createFleetWireResponse(FLEET_WIRE_RESPONSE_STATES.ok, {result: outcome.result}))
+    });
+
     app.post('/fleet', async (req, res) => {
         let envelope;
 
@@ -1033,6 +1109,68 @@ export function createWakeArmingContext({
 
             outcomesByViewer.set(viewerKey, mutation);
             return mutation
+        },
+
+        /**
+         * @summary Runs one viewer-credentialed `poll-digest` against the plane — the catch-up
+         * truth lane, brokered exactly like per-viewer arming: an ephemeral MC session under the
+         * viewer's OWN presented credential (init proof → poll-digest → close), used in-flight
+         * and never stored. MC's caller-owned subscription model holds per viewer with no
+         * delegation surface; the poll reaches exactly the subscriptions the presented credential
+         * owns. Deliberately UNLATCHED (unlike arming's single-flight cache): a poll is
+         * per-request truth, so every call runs its own session and no outcome is remembered.
+         * Refusals return reasons, never throw.
+         * @param {Object} options
+         * @param {String} options.canonicalClaim The viewer's canonical `@login` claim, proven
+         *     against MC by the session init.
+         * @param {String} options.bearer The viewer's own presented plane credential.
+         * @param {String} [options.fleetAdmissionBearer=''] The class-1 bearer the request was
+         *     admitted on — equality here IS the forbidden class-1→class-3 forwarding, refused
+         *     before any MC client exists (same teeth as {@link ensureArmedForViewer}).
+         * @param {String} options.subscriptionId The handshake-vouched subscription to poll.
+         * @param {Number} [options.sinceLogId=0] The client-held watermark.
+         * @returns {Promise<Object>} `{ok: true, result}` or `{ok: false, reason}`.
+         */
+        async pollDigestForViewer({canonicalClaim, bearer, fleetAdmissionBearer = '', subscriptionId, sinceLogId = 0}) {
+            if (closed) {
+                return {ok: false, reason: 'poll-refused: arming context closed'}
+            }
+
+            if (!planeBase || typeof bearer !== 'string' || bearer.length === 0 || !canonicalClaim) {
+                return {ok: false, reason: 'poll-refused: no per-viewer plane credential presented'}
+            }
+
+            if (fleetAdmissionBearer && bearer === fleetAdmissionBearer) {
+                return {ok: false, reason: 'poll-refused: the presented MC credential is byte-identical to the Fleet admission bearer — the credential-class ledger forbids the aliasing'}
+            }
+
+            let viewerClient;
+
+            try {
+                viewerClient = createPlaneClient({
+                    baseUrl            : `${planeBase.replace(/\/+$/, '')}/mc/mcp`,
+                    credential         : bearer,
+                    allowPlainHttpHosts: aiConfig.fleet.planeInternalHosts
+                });
+
+                const admission = await viewerClient.init({expectedIdentity: canonicalClaim});
+
+                if (!admission.ok) {
+                    return {ok: false, reason: `poll-refused: viewer admission refused (${admission.reason})`}
+                }
+
+                const result = await viewerClient.callTool('manage_wake_subscription', {
+                    action: 'poll-digest',
+                    subscriptionId,
+                    sinceLogId
+                });
+
+                return {ok: true, result}
+            } catch (error) {
+                return {ok: false, reason: `poll-refused: ${error?.message ?? error}`}
+            } finally {
+                await viewerClient?.close?.()
+            }
         },
 
         /**

--- a/apps/agentos/fleet/installFleetBridge.mjs
+++ b/apps/agentos/fleet/installFleetBridge.mjs
@@ -253,14 +253,50 @@ export function installFleetBridge({
 
             const {pollDigest, onWake, logger, retryFloorMs, now} = opts;
 
+            const authHeaders = () => ({
+                ...(bearerToken     ? {authorization: `Bearer ${bearerToken}`} : {}),
+                ...(mcAuthorization ? {'x-neo-mc-authorization': `Bearer ${mcAuthorization}`} : {})
+            });
+
+            // The catch-up truth lane's DEFAULT: the composed server's brokered digest poll on
+            // the events origin, riding the SAME pinned fetch + header closure as the stream —
+            // no mint crosses into the consumer or the pane. An explicit observational
+            // `pollDigest` option (tests, alternate compositions) still overrides. A server
+            // without the endpoint (or a refused poll) throws here and the consumer records the
+            // honest `failed` catch-up observation with this reason — once per connection,
+            // bounded, never a retry storm.
+            const brokeredPollDigest = async ({subscriptionId, sinceLogId}) => {
+                const response = await fetchImpl(new URL('/fleet/events/digest', fleetUrl.origin).href, {
+                    method : 'POST',
+                    headers: {
+                        'Content-Type': 'application/json',
+                        ...authHeaders()
+                    },
+                    body: JSON.stringify({subscriptionId, sinceLogId})
+                });
+
+                let envelope = null;
+
+                try {
+                    envelope = await response.json()
+                } catch {/* a body-less refusal (older server's 404 page) falls through to the status throw */}
+
+                if (!response.ok) {
+                    throw new Error(envelope?.error || `digest poll unavailable: HTTP ${response.status}`)
+                }
+
+                if (envelope?.state !== FLEET_WIRE_RESPONSE_STATES.ok) {
+                    throw new Error(envelope?.error || 'digest poll failed')
+                }
+
+                return envelope.result
+            };
+
             return createFleetWakeStreamConsumer({
-                eventsUrl  : new URL('/fleet/events', fleetUrl.origin).href,
+                eventsUrl : new URL('/fleet/events', fleetUrl.origin).href,
                 fetchImpl,
-                authHeaders: () => ({
-                    ...(bearerToken     ? {authorization: `Bearer ${bearerToken}`} : {}),
-                    ...(mcAuthorization ? {'x-neo-mc-authorization': `Bearer ${mcAuthorization}`} : {})
-                }),
-                ...(pollDigest   !== undefined ? {pollDigest} : {}),
+                authHeaders,
+                pollDigest: pollDigest !== undefined ? pollDigest : brokeredPollDigest,
                 ...(onWake       !== undefined ? {onWake} : {}),
                 ...(logger       !== undefined ? {logger} : {}),
                 ...(retryFloorMs !== undefined ? {retryFloorMs} : {}),

--- a/apps/agentos/view/fleet/FleetCockpit.mjs
+++ b/apps/agentos/view/fleet/FleetCockpit.mjs
@@ -3001,9 +3001,13 @@ class FleetCockpit extends Container {
                 signals
             });
 
-        slot.set({cls, text});
+        // vdom attributes FIRST, then the config set, then one explicit flush: `set()` batches its
+        // own update asynchronously, so an update flushed BEFORE the text config lands pushes a
+        // vdom without the chip's text — a blank frame on every stamp cadence (the race the wake
+        // e2e caught as an empty telltale). Ordered this way, every flush carries text + title.
         slot.vdom.title         = title;
         slot.vdom['aria-label'] = ariaLabel;
+        slot.set({cls, text});
         slot.update()
     }
 

--- a/test/playwright/e2e/agentos/FleetCockpitViewerWakeNL.spec.mjs
+++ b/test/playwright/e2e/agentos/FleetCockpitViewerWakeNL.spec.mjs
@@ -18,11 +18,13 @@ import {E2E_FLEET_VIEWER, wireAuthenticatedFleetBridge} from './authenticatedFle
  * and activity stay honestly degraded throughout, proving the viewer-wake axis is independent
  * chrome, not a spine passenger.
  *
- * Honest scope: the cold-drain `poll-digest` leg is NOT driven here — the browser page holds no
- * plane credential by design, so the cockpit's `wakePollDigest` seam is a worker-realm injection
- * no page-side test can supply. The catch-up mechanics (cold drain from the vouched id, watermark
- * continuity, fresh ≠ empty ≠ failed) are pinned in `fleetWakeStreamConsumer.spec.mjs`; the seam
- * pass-through is pinned in `fleetCockpitViewerWake.spec.mjs`.
+ * The cold-drain leg rides the capability's BROKERED digest-poll default: the vouched handshake
+ * triggers one `POST /fleet/events/digest` carrying the SAME two headers as the stream, the
+ * fixture answers the endpoint contract, and the drained count renders in the telltale detail —
+ * no worker-realm injection, no mint outside the bridge closure. The consumer-level catch-up
+ * mechanics (watermark continuity, fresh ≠ empty ≠ failed) stay pinned in
+ * `fleetWakeStreamConsumer.spec.mjs`; the server-side brokering (viewer-credentialed MC session)
+ * is pinned in `fleetWakeArming.spec.mjs` + `FleetServerComposition.spec.mjs`.
  *
  * Run: NEO_E2E_PORT=8121 npx playwright test agentos/FleetCockpitViewerWakeNL -c test/playwright/playwright.config.e2e.mjs --workers=1
  *
@@ -49,6 +51,7 @@ async function startWakeFixture({bearerToken, port = 0}) {
 
     const
         fanout      = createFleetWakeFanout({heartbeatMs: 1000, logger: {error: () => {}, warn: () => {}}}),
+        digestCalls = [],
         headersSeen = [];
 
     const server = createServer((req, res) => {
@@ -65,6 +68,36 @@ async function startWakeFixture({bearerToken, port = 0}) {
                 'access-control-allow-methods': 'GET, POST'
             });
             res.end();
+            return
+        }
+
+        if (req.method === 'POST' && req.url.startsWith('/fleet/events/digest')) {
+            const class1 = (req.headers.authorization ?? '').replace(/^Bearer\s+/i, '').trim();
+
+            let raw = '';
+
+            req.on('data', chunk => { raw += chunk });
+            req.on('end', () => {
+                let body = null;
+
+                try { body = JSON.parse(raw) } catch {/* refused below */}
+
+                digestCalls.push({
+                    body,
+                    class1Matches: class1 === bearerToken,
+                    class3       : req.headers['x-neo-mc-authorization'] ?? null
+                });
+
+                if (class1 !== bearerToken || !req.headers['x-neo-mc-authorization'] || !body?.subscriptionId) {
+                    res.writeHead(403, {'content-type': 'application/json'});
+                    res.end('{"state":"refused","error":"fleet: digest poll refused"}');
+                    return
+                }
+
+                // the endpoint contract: the brokered MC poll-digest result inside the ok envelope
+                res.writeHead(200, {'content-type': 'application/json'});
+                res.end(JSON.stringify({state: 'ok', result: {counts: {pending: 4}, watermark: 7}}))
+            });
             return
         }
 
@@ -96,6 +129,7 @@ async function startWakeFixture({bearerToken, port = 0}) {
     const boundPort = server.address().port;
 
     return {
+        digestCalls,
         fanout,
         headersSeen,
         port    : boundPort,
@@ -121,7 +155,10 @@ async function startWakeFixture({bearerToken, port = 0}) {
         close() {
             return new Promise(resolve => {
                 fanout.dispose();
-                server.close(resolve)
+                server.close(resolve);
+                // the brokered digest poll leaves a keep-alive socket behind — without this,
+                // `server.close` waits out the idle timeout and the test eats its own budget
+                server.closeAllConnections?.()
             })
         }
     }
@@ -182,6 +219,21 @@ test.describe('FleetCockpit — viewer wake push journey (#17130 leg 2)', () => 
 
         expect(admitted.length).toBeGreaterThan(0);
         expect(admitted[admitted.length - 1].class3).toBe(`Bearer ${mcMint}`);
+
+        // ── the COLD DRAIN through the brokered default: the vouched handshake fired exactly one
+        // digest poll on the events origin, carrying the SAME two headers, and the drained count
+        // renders in the telltale detail — the catch-up truth lane, end-to-end in the page
+        await expect.poll(async () => await telltale.getAttribute('title') ?? '', {
+            message: 'the brokered cold drain reaches the telltale detail', timeout: 20000, intervals: [250]
+        }).toContain('catch-up: fresh (4 pending drained)');
+
+        const drained = fixture.digestCalls[0];
+
+        expect(drained, 'the vouched handshake must trigger the digest poll').toBeTruthy();
+        expect(drained.class1Matches).toBe(true);
+        expect(drained.class3).toBe(`Bearer ${mcMint}`);
+        expect(drained.body.subscriptionId).toBe(subscriptionId);
+        expect(drained.body.sinceLogId).toBe(0);
 
         // ── a digest pushed through the PRODUCTION fan-out lands in the page ────────────────────
         fixture.fanout.handleDigest({

--- a/test/playwright/unit/ai/services/fleet/FleetServerComposition.spec.mjs
+++ b/test/playwright/unit/ai/services/fleet/FleetServerComposition.spec.mjs
@@ -448,6 +448,149 @@ test.describe('FleetServerComposition - per-viewer ownership through the real se
     })
 });
 
+test.describe('FleetServerComposition - the brokered digest poll on the events origin', () => {
+    test('the catch-up lane is per-viewer: refusal matrix + a proven poll passing the MC result through verbatim', async () => {
+        const {startFleetServer} = await import('../../../../../../ai/services/fleet/fleetServer.mjs');
+
+        const
+            viewersByBearer = {
+                'ada-token'    : {login: 'ada', providerUserId: 1, identity: '@ada'},
+                'service-token': {login: 'svc', providerUserId: 9, identity: '@svc'},
+                'ada-mc-token' : {login: 'ada', providerUserId: 1, identity: '@ada'}
+            },
+            pollsByIdentity = {};
+
+        const createPlaneClient = ({credential}) => {
+            const viewer = viewersByBearer[credential];
+
+            return {
+                async init() {
+                    return viewer ? {ok: true, identity: viewer.identity} : {ok: false, reason: 'unknown bearer'}
+                },
+                async callTool(name, args) {
+                    (pollsByIdentity[viewer.identity] ??= []).push(args);
+
+                    if (args.action === 'subscribe')   return {subscriptionId: `WAKE_SUB:${viewer.login}`};
+                    if (args.action === 'rotate-key')  return {subscriptionId: `WAKE_SUB:${viewer.login}`, signingKey: 'a'.repeat(64)};
+                    if (args.action === 'poll-digest') return {counts: {pending: 5}, watermark: 77, entries: [{logId: 77}]}
+                },
+                async close() {}
+            }
+        };
+
+        const server = await startFleetServer({
+            host    : '127.0.0.1',
+            port    : 0,
+            aiConfig: {
+                publicUrl    : 'http://127.0.0.1:3102/fleet',
+                mcpHttpHost  : '127.0.0.1',
+                mcpListenHost: '127.0.0.1',
+                fleet        : {
+                    port              : 0,
+                    dataDir           : '/unused',
+                    wakeSelfBase      : 'http://fleet-server:8083',
+                    planeBase         : 'http://ingress:8080',
+                    planeBearer       : 'service-token',
+                    planeBearerFile   : '',
+                    admissionTokenFile: '',
+                    planeInternalHosts: ['ingress']
+                }
+            },
+            planeGuard        : () => {},
+            logger            : QUIET,
+            createPlaneClient,
+            resolveViewerClaim: async () => ({agentIdentityNodeId: '@svc'}),
+            authService       : {
+                setupPreCors() {},
+                async setup({app: target}) {
+                    target.use((req, res, next) => {
+                        const bearer = (req.headers.authorization ?? '').replace(/^Bearer\s+/i, '').trim();
+                        const viewer = viewersByBearer[bearer];
+
+                        if (viewer) {
+                            req.auth = {
+                                userId          : viewer.login,
+                                username        : `${viewer.login} display`,
+                                providerUsername: viewer.login,
+                                authProvider    : 'github',
+                                providerUserId  : viewer.providerUserId
+                            }
+                        }
+
+                        next()
+                    })
+                }
+            },
+            transportService: {
+                computeAllowedHosts: () => ['127.0.0.1'],
+                installCors() {}
+            }
+        });
+
+        const base = `http://127.0.0.1:${server.address().port}`;
+
+        const poll = (headers, body) => fetch(`${base}/fleet/events/digest`, {
+            method : 'POST',
+            headers: {'content-type': 'application/json', ...headers},
+            body   : JSON.stringify(body)
+        });
+
+        try {
+            // class-1 alone: the admission bearer is NEVER forwarded to the MC audience — the
+            // per-viewer lane refuses instead of borrowing the service session.
+            const classOneOnly = await poll({authorization: 'Bearer ada-token'}, {subscriptionId: 'WAKE_SUB:ada'});
+
+            expect(classOneOnly.status).toBe(403);
+            expect((await classOneOnly.json()).error).toContain("viewer's own MC credential");
+
+            // the identical-token mutant: equality IS the forbidden class-1→class-3 forwarding
+            const aliased = await poll(
+                {authorization: 'Bearer ada-token', 'x-neo-mc-authorization': 'Bearer ada-token'},
+                {subscriptionId: 'WAKE_SUB:ada'}
+            );
+
+            expect(aliased.status).toBe(403);
+            expect((await aliased.json()).error).toContain('byte-identical');
+            expect(pollsByIdentity['@ada'], 'no MC client may exist for a refused pair').toBeUndefined();
+
+            // malformed body: shape refused before any brokering
+            const malformed = await poll(
+                {authorization: 'Bearer ada-token', 'x-neo-mc-authorization': 'Bearer ada-mc-token'},
+                {sinceLogId: -1}
+            );
+
+            expect(malformed.status).toBe(400);
+            expect((await malformed.json()).error).toContain('malformed digest poll');
+
+            // an unknown class-3 credential: the viewer admission itself refuses
+            const unknownMint = await poll(
+                {authorization: 'Bearer ada-token', 'x-neo-mc-authorization': 'Bearer forged-mint'},
+                {subscriptionId: 'WAKE_SUB:ada'}
+            );
+
+            expect(unknownMint.status).toBe(403);
+            expect((await unknownMint.json()).error).toContain('viewer admission refused');
+
+            // the proven poll: the viewer's OWN credential brokers poll-digest and the MC result
+            // crosses back VERBATIM inside the ok envelope
+            const proven = await poll(
+                {authorization: 'Bearer ada-token', 'x-neo-mc-authorization': 'Bearer ada-mc-token'},
+                {subscriptionId: 'WAKE_SUB:ada', sinceLogId: 41}
+            );
+
+            expect(proven.status).toBe(200);
+
+            const envelope = await proven.json();
+
+            expect(envelope.state).toBe('ok');
+            expect(envelope.result).toEqual({counts: {pending: 5}, watermark: 77, entries: [{logId: 77}]});
+            expect(pollsByIdentity['@ada']).toEqual([{action: 'poll-digest', subscriptionId: 'WAKE_SUB:ada', sinceLogId: 41}])
+        } finally {
+            await new Promise(resolve => server.close(resolve))
+        }
+    })
+});
+
 test.describe('FleetServerComposition - the relay stream consumer against the composed admission chain', () => {
     test('the production credential chain end-to-end: the resolved fleet-client mint is admitted and drives cold catch-up; the plane-MCP mint is refused with an honest observation', async () => {
         const {startFleetServer, assertFleetPlaneAdmissionBearerClass} = await import('../../../../../../ai/services/fleet/fleetServer.mjs');

--- a/test/playwright/unit/ai/services/fleet/fleetWakeArming.spec.mjs
+++ b/test/playwright/unit/ai/services/fleet/fleetWakeArming.spec.mjs
@@ -513,6 +513,156 @@ test.describe('fleet wake arming - the shutdown fence (delayed mutations cross a
     })
 });
 
+test.describe('pollDigestForViewer — the brokered catch-up truth lane', () => {
+    /** A poll-focused fixture: the fake plane client answers `poll-digest` and records lifecycle. */
+    function pollFixture({initOk = true} = {}) {
+        const
+            fanout        = createFleetWakeFanout({logger: QUIET, heartbeatMs: 0}),
+            constructions = [],
+            toolCalls     = [],
+            closes        = [];
+
+        const context = createWakeArmingContext({
+            fanout,
+            aiConfig: {fleet: {
+                planeBase         : 'http://ingress:8080',
+                planeBearer       : 'service-token',
+                planeBearerFile   : '',
+                admissionTokenFile: '',
+                planeInternalHosts: ['ingress'],
+                wakeSelfBase      : 'http://fleet-server:8083'
+            }},
+            logger           : QUIET,
+            createPlaneClient: options => {
+                constructions.push(options);
+
+                return {
+                    async init({expectedIdentity}) {
+                        return initOk
+                            ? {ok: true, identity: expectedIdentity}
+                            : {ok: false, reason: 'subject mismatch'}
+                    },
+                    async callTool(name, args) {
+                        toolCalls.push({name, args});
+                        return {counts: {pending: 2}, watermark: 41, entries: [{logId: 41}]}
+                    },
+                    async close() {
+                        closes.push(true)
+                    }
+                }
+            },
+            resolveViewerClaim: async () => ({agentIdentityNodeId: '@svc'})
+        });
+
+        return {closes, constructions, context, fanout, toolCalls}
+    }
+
+    test('a byte-identical viewer/fleet bearer pair is refused before any MC client exists', async () => {
+        const {constructions, context} = pollFixture();
+
+        const outcome = await context.pollDigestForViewer({
+            canonicalClaim      : '@ada',
+            bearer              : 'the-same-pat',
+            fleetAdmissionBearer: 'the-same-pat',
+            subscriptionId      : 'WAKE_SUB:x'
+        });
+
+        expect(outcome.ok).toBe(false);
+        expect(outcome.reason).toContain('byte-identical');
+        expect(constructions).toHaveLength(0)
+    });
+
+    test('a refused viewer admission answers the reason and closes the ephemeral session', async () => {
+        const {closes, context} = pollFixture({initOk: false});
+
+        const outcome = await context.pollDigestForViewer({
+            canonicalClaim: '@ada',
+            bearer        : 'viewer-mint',
+            subscriptionId: 'WAKE_SUB:x'
+        });
+
+        expect(outcome.ok).toBe(false);
+        expect(outcome.reason).toContain('viewer admission refused');
+        expect(closes).toHaveLength(1)
+    });
+
+    test('a proven poll passes the MC result through VERBATIM and closes the session', async () => {
+        const {closes, context, toolCalls} = pollFixture();
+
+        const outcome = await context.pollDigestForViewer({
+            canonicalClaim: '@ada',
+            bearer        : 'viewer-mint',
+            subscriptionId: 'WAKE_SUB:ada',
+            sinceLogId    : 17
+        });
+
+        expect(outcome.ok).toBe(true);
+        expect(outcome.result).toEqual({counts: {pending: 2}, watermark: 41, entries: [{logId: 41}]});
+        expect(toolCalls).toEqual([{
+            name: 'manage_wake_subscription',
+            args: {action: 'poll-digest', subscriptionId: 'WAKE_SUB:ada', sinceLogId: 17}
+        }]);
+        expect(closes).toHaveLength(1)
+    });
+
+    test('UNLATCHED by design: every poll runs its own ephemeral session — no cached outcome', async () => {
+        const {closes, constructions, context} = pollFixture();
+
+        await context.pollDigestForViewer({canonicalClaim: '@ada', bearer: 'viewer-mint', subscriptionId: 'WAKE_SUB:ada'});
+        await context.pollDigestForViewer({canonicalClaim: '@ada', bearer: 'viewer-mint', subscriptionId: 'WAKE_SUB:ada'});
+
+        expect(constructions).toHaveLength(2);
+        expect(closes).toHaveLength(2)
+    });
+
+    test('a throwing plane tool becomes a reason, never a throw — and the session still closes', async () => {
+        const
+            closes = [],
+            fanout = createFleetWakeFanout({logger: QUIET, heartbeatMs: 0});
+
+        const context = createWakeArmingContext({
+            fanout,
+            aiConfig: {fleet: {
+                planeBase         : 'http://ingress:8080',
+                planeBearer       : 'service-token',
+                planeBearerFile   : '',
+                admissionTokenFile: '',
+                planeInternalHosts: ['ingress'],
+                wakeSelfBase      : 'http://fleet-server:8083'
+            }},
+            logger           : QUIET,
+            createPlaneClient: () => ({
+                async init() { return {ok: true, identity: '@ada'} },
+                async callTool() { throw new Error('digest source unreachable') },
+                async close() { closes.push(true) }
+            }),
+            resolveViewerClaim: async () => ({agentIdentityNodeId: '@svc'})
+        });
+
+        const outcome = await context.pollDigestForViewer({
+            canonicalClaim: '@ada',
+            bearer        : 'viewer-mint',
+            subscriptionId: 'WAKE_SUB:ada'
+        });
+
+        expect(outcome.ok).toBe(false);
+        expect(outcome.reason).toContain('digest source unreachable');
+        expect(closes).toHaveLength(1)
+    });
+
+    test('a closed context and a missing credential both answer honest refusals', async () => {
+        const {context} = pollFixture();
+
+        expect((await context.pollDigestForViewer({canonicalClaim: '@ada', bearer: '', subscriptionId: 'WAKE_SUB:x'})).reason)
+            .toContain('no per-viewer plane credential');
+
+        await context.close();
+
+        expect((await context.pollDigestForViewer({canonicalClaim: '@ada', bearer: 'mint', subscriptionId: 'WAKE_SUB:x'})).reason)
+            .toContain('arming context closed')
+    })
+});
+
 test.describe('resolveViewerStreamKey - immutable-fact keying, never display names', () => {
     const proven = '@viewer';
 

--- a/test/playwright/unit/apps/agentos/fleet/installFleetBridge.spec.mjs
+++ b/test/playwright/unit/apps/agentos/fleet/installFleetBridge.spec.mjs
@@ -207,6 +207,117 @@ test.describe('installFleetBridge — App-Worker wiring of the dev-server app<->
         expect(observed[0].subscriptionId).toBe('sub-w')
     });
 
+    test('the capability supplies the BROKERED digest-poll default: same origin, same two headers, override still wins', async () => {
+        const
+            mcMint      = 'D'.repeat(43),
+            digestCalls = [],
+            encoder     = new TextEncoder();
+
+        let pushChunk;
+
+        const streamFetch = async (url, options) => {
+            if (String(url).endsWith('/fleet/events/digest')) {
+                digestCalls.push({url: String(url), headers: options.headers, body: JSON.parse(options.body)});
+
+                return {
+                    ok    : true,
+                    status: 200,
+                    json  : async () => ({state: 'ok', result: {counts: {pending: 3}, watermark: 44}})
+                }
+            }
+
+            return {
+                ok    : true,
+                status: 200,
+                body  : new ReadableStream({
+                    start(controller) {
+                        pushChunk = text => controller.enqueue(encoder.encode(text))
+                    }
+                })
+            }
+        };
+
+        const bridge = installFleetBridge({url: fleetUrl, bearerToken: testBearer, mcAuthorization: mcMint, fetchImpl: streamFetch, target: {}});
+
+        const consumer = bridge.openWakeStream({logger: {warn: () => {}, error: () => {}}, retryFloorMs: 10});
+
+        consumer.start();
+        await new Promise(resolve => setTimeout(resolve, 20));
+
+        // the vouched handshake triggers the connection catch-up through the brokered default
+        pushChunk('event: state\ndata: {"armed":true,"armedForViewer":true,"subscriptionId":"sub-d"}\n\n');
+        await new Promise(resolve => setTimeout(resolve, 20));
+
+        consumer.stop();
+
+        expect(digestCalls).toHaveLength(1);
+        expect(digestCalls[0].url).toBe('http://127.0.0.1:8083/fleet/events/digest');
+        expect(digestCalls[0].body).toEqual({subscriptionId: 'sub-d', sinceLogId: 0});
+        // both mints ride their OWN headers on the poll, exactly like the stream
+        expect(digestCalls[0].headers.authorization).toBe(`Bearer ${testBearer}`);
+        expect(digestCalls[0].headers['x-neo-mc-authorization']).toBe(`Bearer ${mcMint}`);
+
+        const observation = consumer.describe();
+
+        expect(observation.lastCatchUp.state).toBe('fresh');
+        expect(observation.lastCatchUp.pending).toBe(3);
+        expect(observation.watermark).toBe(44);
+
+        // an explicit observational pollDigest OVERRIDES the default — the wire sees no digest POST
+        const overrideCalls = [];
+
+        const overridden = bridge.openWakeStream({
+            logger      : {warn: () => {}, error: () => {}},
+            retryFloorMs: 10,
+            pollDigest  : async args => { overrideCalls.push(args); return {counts: {pending: 0}} }
+        });
+
+        overridden.start();
+        await new Promise(resolve => setTimeout(resolve, 20));
+        pushChunk?.('event: state\ndata: {"armed":true,"armedForViewer":true,"subscriptionId":"sub-o"}\n\n');
+        await new Promise(resolve => setTimeout(resolve, 20));
+        overridden.stop();
+
+        expect(overrideCalls).toEqual([{subscriptionId: 'sub-o', sinceLogId: 0}]);
+        expect(digestCalls, 'the brokered default must stay silent under an override').toHaveLength(1)
+    });
+
+    test('an older server without the digest endpoint lands as the honest FAILED catch-up observation — never a fabricated drain', async () => {
+        const encoder = new TextEncoder();
+
+        let pushChunk;
+
+        const streamFetch = async (url, options) => {
+            if (String(url).endsWith('/fleet/events/digest')) {
+                return {ok: false, status: 404, json: async () => { throw new Error('no body') }}
+            }
+
+            return {
+                ok    : true,
+                status: 200,
+                body  : new ReadableStream({
+                    start(controller) {
+                        pushChunk = text => controller.enqueue(encoder.encode(text))
+                    }
+                })
+            }
+        };
+
+        const bridge   = installFleetBridge({url: fleetUrl, bearerToken: testBearer, fetchImpl: streamFetch, target: {}});
+        const consumer = bridge.openWakeStream({logger: {warn: () => {}, error: () => {}}, retryFloorMs: 10});
+
+        consumer.start();
+        await new Promise(resolve => setTimeout(resolve, 20));
+        pushChunk('event: state\ndata: {"armed":true,"subscriptionId":"sub-old"}\n\n');
+        await new Promise(resolve => setTimeout(resolve, 20));
+        consumer.stop();
+
+        const {lastCatchUp} = consumer.describe();
+
+        expect(lastCatchUp.state).toBe('failed');
+        expect(lastCatchUp.pending).toBe(null)
+    });
+
     test('publishes AgentOS.fleet.registryBridge with exactly the wire operations', () => {
         const target = {};
         const bridge = installFleetBridge({url: fleetUrl, fetchImpl: okFetch(), target});


### PR DESCRIPTION
Resolves neomjs/neo#17252

The cold-drain truth lane, end-to-end: the composed fleet server brokers `poll-digest` for the browser viewer exactly like connect-time arming (an ephemeral MC session under the viewer's OWN presented class-3 credential — init proof → poll → close, used in-flight, never stored, deliberately UNLATCHED because a poll is per-request truth), exposed as `POST /fleet/events/digest` with the stream's exact two-header credential shape and the full refusal matrix (aliased pair, missing class-3, malformed body, refused admission). Client side, the `openWakeStream` capability gains a brokered `pollDigest` DEFAULT built from the same pinned fetch + header closure it already owns — zero cockpit change (the `wakePollDigest` injection seam still overrides), and neomjs/neo#17130's residual cold-drain clause closes with the consumer's existing catch-up mechanics lighting up unchanged.

Evidence: L2 (unit 1328/1328 across the full agentos + fleet trees at the rebased head; whitebox-e2e drives the BROKERED cold drain in the page — the vouched handshake fires one digest POST carrying both headers, and `catch-up: fresh (4 pending drained)` renders in the telltale detail) → L2 required (per-viewer brokering, refusal matrix, capability default, older-server honesty). Residual: the plane-backed live journey (real MC behind the composed server), Residual-Owner: neomjs/neo-agent-brain#50

## Deltas from ticket

- **AC 4 amended in the ticket body pre-PR (own artifact, in place):** an older server lands as the consumer's honest `failed` catch-up observation WITH the endpoint-absent reason — not as absence. A poll was attempted and refused; rendering that as absence would hide a real signal. Absence stays reserved for genuinely unwired seams. Red-pinned in `installFleetBridge.spec.mjs` (404 → `lastCatchUp {state:'failed', pending:null}`).
- **Two ride-along hardenings in the same seam** (composed with this PR's catch-up cadence): the telltale sync now writes vdom title/aria BEFORE the config set so every flush carries the chip text (ordering hazard, unobserved in production but structurally possible), and the e2e fixture closes keep-alive sockets explicitly (`server.closeAllConnections`) — the brokered digest POST's idle socket otherwise holds `server.close()` through its timeout and starves the test budget (the observed failure that led here).
- None otherwise — the endpoint shape, arming-parity guards, and capability default landed as the ticket's Contract Ledger specifies.

## Test Evidence

- `npm run test-unit -- test/playwright/unit/apps/agentos test/playwright/unit/ai/services/fleet` → **1328 passed (7.2s)** at the rebased head `a76abf183e` — new coverage: `pollDigestForViewer` (aliased-pair refused before any client construction, admission-refused closes the ephemeral session, result passes through verbatim, UNLATCHED by design = two polls two sessions, throwing plane tool → reason never throw, closed-context refusal) · the server route matrix on a REAL `startFleetServer` (class-1-only refused, identical-token mutant refused with zero MC construction, malformed 400, unknown mint → admission refusal, proven poll → ok envelope verbatim) · the capability default (same origin + both headers + watermark adoption, explicit `pollDigest` override wins with the wire silent, 404 → honest `failed`).
- `NEO_E2E_PORT=8121 npx playwright test agentos/FleetCockpitViewerWakeNL -c test/playwright/playwright.config.e2e.mjs --workers=1` → **1 passed (9.8s)** at the rebased head — the journey now includes the brokered cold drain: handshake-triggered digest POST observed server-side with both mints on their own headers, `catch-up: fresh (4 pending drained)` rendered in the page, plus the existing loss/self-reconnect legs. Non-CI by design; exact-head local receipt.
- Surfaces: `ai/services/fleet` server: composition + arming spec extensions above | `apps/agentos` bridge/cockpit: capability + wiring specs above + the NL journey.

## Post-Merge Validation

- [ ] The plane-backed journey (real MC behind the composed server): a browser viewer with both mints drains real pending wakes on cold start — neomjs/neo#17252's AC 1 wording against the live composed deployment.
- [ ] devCockpit smoke with the digest endpoint present: telltale reaches `wake: live` with a `catch-up:` line sourced from the real plane.

Residual-Owner: neomjs/neo-agent-brain#50

Authored by Clio (Claude Fable 5, Claude Code). Session 71baabc5-3ebe-46ff-99ce-a301e78cb7c5.
