### PR TITLE
feat(memory-core): who_is_online counts open re-review loops from the A2A trail (#17267)

### DIFF
--- a/ai/mcp/server/memory-core/openapi.yaml
+++ b/ai/mcp/server/memory-core/openapi.yaml
@@ -510,6 +510,14 @@ paths:
         a seat top and never renders as fine.
 
 
+        Load axis: the second owned axis, also container-plane — re-review obligations counted from
+        the plane-resident A2A review-lifecycle ping trail (a reviewer holding N open
+        CHANGES_REQUESTED loops reads N, never 0). Terse carries the sparse reviewLoad map
+        (identity → open loop count; absent IS the counted zero); verbose rows carry {open,
+        returned, loops[]} oldest-first. A review that never pinged is invisible to this trail —
+        the envelope's reason says so.
+
+
         Terse by default: {summary, windows, online[], idle[], dark[], neverConnected[], benched[]}
         (identity arrays). Buckets separate liveness from membership: idle is stale but within the
         configured cutoff, dark is stale beyond it, neverConnected has no activity on this deployment
@@ -545,7 +553,7 @@ paths:
               schema:
                 type: object
                 description: >
-                  Terse default: {generatedAt, axes, summary, windows, online[], idle[], dark[],
+                  Terse default: {generatedAt, axes, summary, windows, reviewLoad, online[], idle[], dark[],
                   neverConnected[], benched[]}. With verbose:true: {generatedAt, axes, signalStatus,
                   agents[]}.
                 properties:
@@ -558,10 +566,19 @@ paths:
                       The composed-axes honesty surface — a declared superset of the Fleet's
                       capability-envelope grammar (adds plane/signal: this tool serves axes it
                       cannot own, so the plane travels on the envelope). Terse: the presence
-                      envelope (wired/observed, proxy declared) plus an unobserved marker naming
-                      the host-originated axes (throttle, lifecycle, liveness). Verbose: each host
-                      axis as its full degraded/none envelope until the fleet publishes. An unknown
-                      axis never ranks a seat top and never renders as fine.
+                      envelope (wired/observed, proxy declared), the load envelope (wired/observed,
+                      the A2A review-lifecycle trail's blind class named), plus an unobserved marker
+                      naming the host-originated axes (throttle, lifecycle, liveness). Verbose: each
+                      host axis as its full degraded/none envelope until the fleet publishes. An
+                      unknown axis never ranks a seat top and never renders as fine.
+                  reviewLoad:
+                    type: object
+                    additionalProperties: {type: integer}
+                    description: >
+                      Terse default — the sparse load map: identity → open re-review loop count,
+                      only seats holding at least one. Absent IS the counted zero. Derived from the
+                      plane-resident A2A review-lifecycle ping trail; a review that never pinged is
+                      invisible to it.
                   summary:
                     type: string
                     description: >
@@ -624,6 +641,12 @@ paths:
                             Per-row composed axes: every host-originated axis the tool cannot
                             observe (throttle, lifecycle, liveness) is unknown until the fleet
                             publishes — never a verdict fabricated from the recency primitive.
+                        reviewLoad:
+                          type: object
+                          description: >
+                            Per-row re-review load from the A2A review-lifecycle trail: {open,
+                            returned, loops[]} with loops oldest-first (the stalest obligation at
+                            the head). A seat with no open loops reads the counted zero.
         '500':
           description: Operation failed.
           content:

--- a/ai/services/memory-core/WakeSubscriptionService.mjs
+++ b/ai/services/memory-core/WakeSubscriptionService.mjs
@@ -775,8 +775,8 @@ class WakeSubscriptionService extends Base {
         const nowMs       = this._coerceDate(now).getTime(),
               projected   = this._listAgentIdentityNodes(family).map(node => this._projectAgentLiveness(node, nowMs)),
               generatedAt = new Date(nowMs).toISOString(),
-              axes        = this._composedAxesEnvelope(generatedAt),
-              reviewLoad  = this._readReviewLifecycleLoad(nowMs);
+              reviewTrail = this._readReviewLifecycleLoad(nowMs),
+              axes        = this._composedAxesEnvelope(generatedAt, reviewTrail);
 
         if (verbose) {
             return {
@@ -797,7 +797,11 @@ class WakeSubscriptionService extends Base {
                 agents: projected.map(row => ({
                     ...row,
                     axes      : this._unobservedComposedAxes(),
-                    reviewLoad: reviewLoad.get(row.identity) ?? {loops: [], open: 0, returned: 0}
+                    // an unreadable trail serves honest absence (null), never a fabricated zero —
+                    // the load envelope above carries the degraded reason
+                    reviewLoad: reviewTrail.available
+                        ? (reviewTrail.byReviewer.get(row.identity) ?? {loops: [], open: 0, returned: 0})
+                        : null
                 }))
             };
         }
@@ -833,10 +837,13 @@ class WakeSubscriptionService extends Base {
             windows,
             // Sparse by construction: only identities holding open re-review loops appear, so the
             // routing question ("who can take one more?") reads the default answer — and an absent
-            // entry IS the counted zero, never an unknown.
-            reviewLoad: Object.fromEntries(
-                [...reviewLoad].filter(([, load]) => load.open > 0).map(([identity, load]) => [identity, load.open])
-            ),
+            // entry IS the counted zero. The whole key is OMITTED when the trail is unreadable:
+            // a present-but-empty map would read as "everyone is zero" over absence of observation.
+            ...(reviewTrail.available ? {
+                reviewLoad: Object.fromEntries(
+                    [...reviewTrail.byReviewer].filter(([, load]) => load.open > 0).map(([identity, load]) => [identity, load.open])
+                )
+            } : {}),
             ...buckets
         };
     }
@@ -858,16 +865,19 @@ class WakeSubscriptionService extends Base {
      * one. `presence` is the axis this tool owns: `wired/observed`, and its `reason` is the plane
      * declaration (a container-side `add_memory`-recency proxy, not an availability verdict).
      * `load` is the second container-plane axis: re-review obligations derived from the
-     * plane-resident A2A review-lifecycle trail (`reviewLoadProjection`), `wired/observed`, its
-     * `reason` naming the trail's blind class — a review that never pinged is invisible to it.
+     * plane-resident A2A review-lifecycle trail (`reviewLoadProjection`) — `wired/observed` when
+     * the trail is readable, a `degraded/none` envelope carrying the failure reason when it is
+     * not: absence of observation never renders as a counted zero.
      * The host-originated axes ({@link COMPOSED_HOST_AXES}) report `degraded/none` with a named reason
      * until the fleet publishes its observations into the plane — the envelope's `capturedAt` echoes
      * the projection's own observation bound (`generatedAt`), never a re-stamped clock.
      * @param {String} capturedAt The projection's observation bound (ISO).
+     * @param {Object} reviewTrail `{available, reason?}` from the trail read — availability is
+     *     tri-state honesty for the `load` envelope, not a caching hint.
      * @returns {Object} `{presence, load, throttle, lifecycle, liveness}` capability envelopes.
      * @protected
      */
-    _composedAxesEnvelope(capturedAt) {
+    _composedAxesEnvelope(capturedAt, reviewTrail) {
         const unobserved = axis => ({
             capability: {
                 source    : null,
@@ -879,6 +889,28 @@ class WakeSubscriptionService extends Base {
                             `unknown is the platform truth until one lands`
             }
         });
+
+        const loadCapability = reviewTrail.available
+            ? {
+                source    : 'memory-core:whoIsOnline',
+                plane     : 'container',
+                signal    : 'a2a-review-lifecycle',
+                state     : 'wired',
+                confidence: 'observed',
+                capturedAt,
+                reason    : 're-review obligations counted from the plane-resident A2A ' +
+                            'review-lifecycle ping trail — a review that never pinged is ' +
+                            'invisible here, and loops age out past the declared trail horizon'
+            }
+            : {
+                source    : 'memory-core:whoIsOnline',
+                plane     : 'container',
+                signal    : 'a2a-review-lifecycle',
+                state     : 'degraded',
+                confidence: 'none',
+                capturedAt,
+                reason    : reviewTrail.reason
+            };
 
         return {
             presence: {
@@ -893,19 +925,7 @@ class WakeSubscriptionService extends Base {
                                 'activity observation, not an availability verdict'
                 }
             },
-            load: {
-                capability: {
-                    source    : 'memory-core:whoIsOnline',
-                    plane     : 'container',
-                    signal    : 'a2a-review-lifecycle',
-                    state     : 'wired',
-                    confidence: 'observed',
-                    capturedAt,
-                    reason    : 're-review obligations counted from the plane-resident A2A ' +
-                                'review-lifecycle ping trail — a review that never pinged is ' +
-                                'invisible here, and loops age out past the declared trail horizon'
-                }
-            },
+            load: {capability: loadCapability},
             ...Object.fromEntries(COMPOSED_HOST_AXES.map(axis => [axis, unobserved(axis)]))
         };
     }
@@ -927,19 +947,35 @@ class WakeSubscriptionService extends Base {
      * already uses, so the trail scan adds no transport and no second authority: the derivation
      * itself is pure ({@link module:ai/services/memory-core/helpers/reviewLoadProjection}), and the
      * served envelope names the trail's blind class — a review that never pinged is invisible here.
+     *
+     * The scan is BOUND at the SQL layer: the `MESSAGE:` id-prefix prefilter rides the primary-key
+     * index (the mailbox's own production read pattern), so memory-class rows — the dominant row
+     * class — never reach the JSON walk. Availability is tri-state by construction: a missing
+     * store handle or a thrown read returns `{available: false, reason}` rather than an empty
+     * derivation, because absence of observation must never render as a counted zero — and a
+     * failed trail read never takes the roster answer down with it.
      * @param {Number} nowMs The projection's observation bound (epoch ms).
-     * @returns {Map<String, {open: Number, returned: Number, loops: Object[]}>} Reviewer identity →
-     *     load; identities with no open loops are absent (the absent entry IS the zero).
+     * @returns {Object} `{available: true, byReviewer: Map}` or
+     *     `{available: false, byReviewer: Map, reason: String}`.
      * @protected
      */
     _readReviewLifecycleLoad(nowMs) {
-        const sqlite = GraphService.db?.storage?.db;
-        if (!sqlite) return new Map();
+        const unavailable = reason => ({available: false, byReviewer: new Map(), reason});
 
-        const rows = sqlite.prepare(`
-            SELECT data FROM Nodes
-            WHERE json_extract(data, '$.label') = 'MESSAGE'
-        `).all();
+        const sqlite = GraphService.db?.storage?.db;
+        if (!sqlite) return unavailable('the review-lifecycle trail store is not readable on this deployment');
+
+        let rows;
+
+        try {
+            rows = sqlite.prepare(`
+                SELECT data FROM Nodes
+                WHERE id LIKE 'MESSAGE:%' AND json_extract(data, '$.label') = 'MESSAGE'
+            `).all();
+        } catch (error) {
+            logger.warn(`[WakeSubscription] who_is_online: review-lifecycle trail read failed: ${error?.message ?? error}`);
+            return unavailable(`the review-lifecycle trail read failed: ${error?.message ?? error}`)
+        }
 
         const messages = [];
 
@@ -958,7 +994,7 @@ class WakeSubscriptionService extends Base {
             }
         }
 
-        return deriveReviewLoad(messages, {now: nowMs})
+        return {available: true, byReviewer: deriveReviewLoad(messages, {now: nowMs})}
     }
 
     /**

--- a/ai/services/memory-core/WakeSubscriptionService.mjs
+++ b/ai/services/memory-core/WakeSubscriptionService.mjs
@@ -14,6 +14,7 @@ import {buildWakeDigest, getHighestWakePriority}                                
 import {HEARTBEAT_PULSE_ENTITY_PREFIX, HEARTBEAT_PULSE_ENTITY_TYPE, match, matchHeartbeatPulse} from './heartbeatPulseEvaluator.mjs';
 import {resolveResidentFamilyById}                                                              from '../graph/agentFamilyResolution.mjs';
 import {PRESENCE_STATES}                                                                        from '../fleet/fleetPresenceStateAdapter.mjs';
+import {deriveReviewLoad}                                                                       from './helpers/reviewLoadProjection.mjs';
 import {readActiveWakeSubscriptionObservations}                                                 from './readActiveWakeSubscriptionIdentities.mjs';
 import {
     activeWakeSubscriptionStatusSql,
@@ -730,8 +731,10 @@ class WakeSubscriptionService extends Base {
      * availability verdict: a long turn (the definition of working) is structurally
      * indistinguishable from absence on this signal, and a fresh write says a turn ENDED recently,
      * not that the seat is free. The payload says so itself: every return carries an `axes`
-     * surface. Terse holds the `presence` envelope (wired/observed, proxy declared) plus a compact
-     * `unobserved` marker naming the host-originated axes (`throttle`, `lifecycle`, `liveness`);
+     * surface. Terse holds the `presence` envelope (wired/observed, proxy declared), the `load`
+     * envelope (the second owned axis — re-review obligations counted from the plane-resident A2A
+     * review-lifecycle trail, wired/observed, its blind class named), plus a compact `unobserved`
+     * marker naming the host-originated axes (`throttle`, `lifecycle`, `liveness`);
      * verbose serves each host axis as its full `degraded/none` envelope until the fleet publishes
      * its observations into the plane, and each verbose row carries those axes as `unknown`. The
      * envelope shape is a declared superset of the Fleet Manager's capability-envelope grammar —
@@ -744,31 +747,36 @@ class WakeSubscriptionService extends Base {
      * @param {Object} [opts]
      * @param {String} [opts.family] Optional model-family filter (e.g. `'claude'`, `'gpt'`).
      * @param {Boolean} [opts.verbose=false] When false (default) returns the terse roster summary
-     *   (`{generatedAt, axes, summary, online, idle, benched}`) — a "who is online?" answer, not a
-     *   diagnostics dump. When true returns the full per-agent projection (signalStatus + per-agent
-     *   reason/signals) for diagnostics. Default stays terse so the per-call token cost is
-     *   proportional to the question.
+     *   (`{generatedAt, axes, summary, windows, reviewLoad, online, idle, benched}`) — a "who is
+     *   online?" answer, not a diagnostics dump. When true returns the full per-agent projection
+     *   (signalStatus + per-agent reason/signals) for diagnostics. Default stays terse so the
+     *   per-call token cost is proportional to the question.
      * @param {Date|String|Number} [opts.now=new Date()] Clock source (unit-test seam).
      * @returns {Promise<Object>} Terse (default):
-     *   `{generatedAt, axes, summary, windows, online[], idle[], dark[], neverConnected[], benched[]}`
+     *   `{generatedAt, axes, summary, windows, reviewLoad, online[], idle[], dark[], neverConnected[], benched[]}`
      *   (identity arrays). The five buckets separate LIVENESS from MEMBERSHIP: `online` (acting
      *   now), `idle` (stale but inside the idle cutoff), `dark` (stale beyond it), `neverConnected`
      *   (rostered but never observed on THIS deployment), `benched` (participationStatus gate).
      *   `windows` carries the resolved `{activityFreshMs, idleCutoffMs}` so the counts are
-     *   interpretable without reading source. Terse `axes` carries ONLY what the default answer
-     *   needs (the tool is terse-by-default — diagnostics live behind `verbose`, never bloat the
-     *   context window): the full `presence` capability envelope with its plane declaration, and a
-     *   compact `unobserved` marker naming the host-originated axes — declared, never fabricated.
+     *   interpretable without reading source. `reviewLoad` is the sparse load map — identity →
+     *   open re-review loop count, only seats holding at least one; absent IS the counted zero.
+     *   Terse `axes` carries ONLY what the default answer needs (the tool is terse-by-default —
+     *   diagnostics live behind `verbose`, never bloat the context window): the full `presence`
+     *   and `load` capability envelopes with their plane declarations, and a compact `unobserved`
+     *   marker naming the host-originated axes — declared, never fabricated.
      *   Verbose: `{generatedAt, axes, signalStatus, agents}` — `axes` serves every host-originated
      *   axis as its full `degraded/none` envelope, and each agent row is
-     *   `{identity, name, family, participationStatus, online, state, reason, signals, axes}` —
-     *   the per-row `axes` holds every host-originated axis as `unknown` until the fleet publishes.
+     *   `{identity, name, family, participationStatus, online, state, reason, signals, axes, reviewLoad}` —
+     *   the per-row `axes` holds every host-originated axis as `unknown` until the fleet publishes,
+     *   and the per-row `reviewLoad` is `{open, returned, loops[]}` (loops oldest-first, so the
+     *   stalest obligation surfaces at the head).
      */
     async whoIsOnline({family, verbose = false, now = new Date()} = {}) {
         const nowMs       = this._coerceDate(now).getTime(),
               projected   = this._listAgentIdentityNodes(family).map(node => this._projectAgentLiveness(node, nowMs)),
               generatedAt = new Date(nowMs).toISOString(),
-              axes        = this._composedAxesEnvelope(generatedAt);
+              axes        = this._composedAxesEnvelope(generatedAt),
+              reviewLoad  = this._readReviewLifecycleLoad(nowMs);
 
         if (verbose) {
             return {
@@ -783,7 +791,14 @@ class WakeSubscriptionService extends Base {
                 // Per-row `unknown` axes are verbose diagnostics — allocated only on this path, so
                 // the default answer never pays for objects its buckets discard. The tool never
                 // fabricates a host-originated verdict from its container-side primitive.
-                agents: projected.map(row => ({...row, axes: this._unobservedComposedAxes()}))
+                // `reviewLoad` rides the same rows: open re-review loops counted from the
+                // review-lifecycle trail, `{open: 0, returned: 0, loops: []}` when the trail holds
+                // nothing for the seat — a counted zero, never an unknown.
+                agents: projected.map(row => ({
+                    ...row,
+                    axes      : this._unobservedComposedAxes(),
+                    reviewLoad: reviewLoad.get(row.identity) ?? {loops: [], open: 0, returned: 0}
+                }))
             };
         }
 
@@ -804,8 +819,9 @@ class WakeSubscriptionService extends Base {
             // The presence envelope is the default answer's honesty (the plane declaration), so it
             // stays terse-side; the three host-originated envelopes would repeat byte-identical
             // "nothing published" on every call — diagnostics by definition — so terse DECLARES
-            // their axes unobserved and verbose serves the full envelopes.
-            axes: {presence: axes.presence, unobserved: [...COMPOSED_HOST_AXES]},
+            // their axes unobserved and verbose serves the full envelopes. The load envelope is
+            // the second owned axis: wired, container-plane, its trail named in the reason.
+            axes: {presence: axes.presence, load: axes.load, unobserved: [...COMPOSED_HOST_AXES]},
             // The summary states the windows it applied: the same counts mean different things under
             // a 15-minute and a 4-hour window, so a bare number is not interpretable without them.
             // Counts and labels derive from the same imported taxonomy as the buckets — a rename at
@@ -815,6 +831,12 @@ class WakeSubscriptionService extends Base {
                      ).join(' · ') +
                      ` (online ≤ ${formatWindow(windows.activityFreshMs)}, idle ≤ ${formatWindow(windows.idleCutoffMs)})`,
             windows,
+            // Sparse by construction: only identities holding open re-review loops appear, so the
+            // routing question ("who can take one more?") reads the default answer — and an absent
+            // entry IS the counted zero, never an unknown.
+            reviewLoad: Object.fromEntries(
+                [...reviewLoad].filter(([, load]) => load.open > 0).map(([identity, load]) => [identity, load.open])
+            ),
             ...buckets
         };
     }
@@ -834,12 +856,15 @@ class WakeSubscriptionService extends Base {
      *
      * Envelopes are served UN-FLATTENED per axis, so a degraded source can never paint a healthy
      * one. `presence` is the axis this tool owns: `wired/observed`, and its `reason` is the plane
-     * declaration (a container-side `add_memory`-recency proxy, not an availability verdict). The
-     * host-originated axes ({@link COMPOSED_HOST_AXES}) report `degraded/none` with a named reason
+     * declaration (a container-side `add_memory`-recency proxy, not an availability verdict).
+     * `load` is the second container-plane axis: re-review obligations derived from the
+     * plane-resident A2A review-lifecycle trail (`reviewLoadProjection`), `wired/observed`, its
+     * `reason` naming the trail's blind class — a review that never pinged is invisible to it.
+     * The host-originated axes ({@link COMPOSED_HOST_AXES}) report `degraded/none` with a named reason
      * until the fleet publishes its observations into the plane — the envelope's `capturedAt` echoes
      * the projection's own observation bound (`generatedAt`), never a re-stamped clock.
      * @param {String} capturedAt The projection's observation bound (ISO).
-     * @returns {Object} `{presence, throttle, lifecycle, liveness}` capability envelopes.
+     * @returns {Object} `{presence, load, throttle, lifecycle, liveness}` capability envelopes.
      * @protected
      */
     _composedAxesEnvelope(capturedAt) {
@@ -868,6 +893,19 @@ class WakeSubscriptionService extends Base {
                                 'activity observation, not an availability verdict'
                 }
             },
+            load: {
+                capability: {
+                    source    : 'memory-core:whoIsOnline',
+                    plane     : 'container',
+                    signal    : 'a2a-review-lifecycle',
+                    state     : 'wired',
+                    confidence: 'observed',
+                    capturedAt,
+                    reason    : 're-review obligations counted from the plane-resident A2A ' +
+                                'review-lifecycle ping trail — a review that never pinged is ' +
+                                'invisible here, and loops age out past the declared trail horizon'
+                }
+            },
             ...Object.fromEntries(COMPOSED_HOST_AXES.map(axis => [axis, unobserved(axis)]))
         };
     }
@@ -881,6 +919,46 @@ class WakeSubscriptionService extends Base {
      */
     _unobservedComposedAxes() {
         return Object.fromEntries(COMPOSED_HOST_AXES.map(axis => [axis, 'unknown']));
+    }
+
+    /**
+     * @summary Reads the plane-resident A2A review-lifecycle trail and derives each rostered
+     * peer's open re-review load. The mailbox lives in the same graph store the roster read
+     * already uses, so the trail scan adds no transport and no second authority: the derivation
+     * itself is pure ({@link module:ai/services/memory-core/helpers/reviewLoadProjection}), and the
+     * served envelope names the trail's blind class — a review that never pinged is invisible here.
+     * @param {Number} nowMs The projection's observation bound (epoch ms).
+     * @returns {Map<String, {open: Number, returned: Number, loops: Object[]}>} Reviewer identity →
+     *     load; identities with no open loops are absent (the absent entry IS the zero).
+     * @protected
+     */
+    _readReviewLifecycleLoad(nowMs) {
+        const sqlite = GraphService.db?.storage?.db;
+        if (!sqlite) return new Map();
+
+        const rows = sqlite.prepare(`
+            SELECT data FROM Nodes
+            WHERE json_extract(data, '$.label') = 'MESSAGE'
+        `).all();
+
+        const messages = [];
+
+        for (const row of rows) {
+            try {
+                const properties = JSON.parse(row.data).properties ?? {};
+
+                messages.push({
+                    from   : properties.from,
+                    sentAt : properties.sentAt,
+                    subject: properties.subject,
+                    to     : properties.to
+                });
+            } catch (error) {
+                logger.warn(`[WakeSubscription] who_is_online: skipped unparseable MESSAGE row: ${error.message}`);
+            }
+        }
+
+        return deriveReviewLoad(messages, {now: nowMs})
     }
 
     /**

--- a/ai/services/memory-core/helpers/reviewLoadProjection.mjs
+++ b/ai/services/memory-core/helpers/reviewLoadProjection.mjs
@@ -1,0 +1,117 @@
+/**
+ * @module ai/services/memory-core/helpers/reviewLoadProjection
+ * @summary Pure derivation of per-reviewer open re-review loops from the plane-resident A2A
+ * review-lifecycle trail.
+ *
+ * The swarm's review protocol makes the lifecycle pings mandatory, so the mailbox holds the
+ * canonical record of who is holding what: a reviewer opens a loop with a `CHANGES_REQUESTED`
+ * review-posted ping and retires it with their own later `APPROVED` one, and the author hands the
+ * ball back with a re-review request addressed to the reviewer. The subject line is the protocol
+ * surface — `relatedTickets` deliberately plays no part, because a review ping also lists the
+ * TICKETS it resolves, and counting those would open phantom loops on issues nobody reviewed.
+ *
+ * The classifier is anchored on the FIRST bracket tag so that prose naming a disposition without
+ * being one — a stale-approval warning quoting `APPROVED`, an author response quoting the
+ * `CHANGES_REQUESTED` it answers — neither opens nor retires a loop. Messages whose subjects do not
+ * follow the ping conventions are invisible to this derivation; the serving envelope declares that
+ * blind class rather than pretending completeness.
+ *
+ * This helper performs no I/O, repair, configuration lookup, or mutation: callers pass already-read
+ * message rows and receive the per-reviewer projection.
+ */
+
+/**
+ * The trail horizon: a loop whose latest movement is older than this ages out of the count. A
+ * months-older open loop is a stale trail, not a live obligation — the envelope declares the
+ * window rather than silently keeping or silently dropping it.
+ * @type {Number}
+ */
+export const REVIEW_LOAD_TRAIL_HORIZON_MS = 30 * 24 * 60 * 60 * 1000;
+
+const APPROVED_PATTERN   = /\bAPPROVED\b/i;
+const CHANGES_PATTERN    = /\bCHANGES_REQUESTED\b/i;
+const CLOSE_TAG_PATTERN  = /^(?:review-posted|APPROVED)\b/i;
+const FIRST_TAG_PATTERN  = /^\s*\[([^\]]+)]/;
+const OPEN_TAG_PATTERN   = /^(?:review-posted|CHANGES_REQUESTED|REQUEST_CHANGES)\b/i;
+const PR_REF_PATTERN     = /\bPR\s*#(\d+)\b/gi;
+const RETURN_TAG_PATTERN = /^(?:re-?review|review-response|author[- ]response)\b/i;
+
+/**
+ * @summary Derives the per-reviewer re-review load from raw mailbox message rows.
+ *
+ * A loop `(reviewer, PR)` opens on the reviewer's `CHANGES_REQUESTED` ping and retires on their
+ * own later `APPROVED` ping for the same PR — any later reviewer, any later round, only the same
+ * identity closes what it opened. A fresh `CHANGES_REQUESTED` on an open loop re-arms it (the ball
+ * is the author's again) and moves its clock. A re-review-class ping addressed TO the reviewer
+ * marks the loop `returned`: the ball is provably back with its holder.
+ *
+ * @param {Object[]} messages Raw rows: `{from, to, subject, sentAt}` (missing fields skip a row).
+ * @param {Object} [options]
+ * @param {Number} [options.horizonMs=REVIEW_LOAD_TRAIL_HORIZON_MS] Trail window; older movement
+ *     does not participate.
+ * @param {Date|String|Number} [options.now=Date.now()] Clock source (unit-test seam).
+ * @returns {Map<String, {open: Number, returned: Number, loops: Object[]}>} Reviewer identity →
+ *     its load. `loops` rides oldest-first so the stalest obligation surfaces at the head. A
+ *     reviewer with no open loops has NO map entry — the absent entry IS the zero.
+ */
+export function deriveReviewLoad(messages, {horizonMs = REVIEW_LOAD_TRAIL_HORIZON_MS, now = Date.now()} = {}) {
+    const
+        nowMs   = now instanceof Date ? now.getTime() : new Date(now).getTime(),
+        floorMs = nowMs - horizonMs,
+        loops   = new Map();
+
+    const sorted = (Array.isArray(messages) ? messages : [])
+        .slice()
+        .sort((a, b) => new Date(a?.sentAt || 0).getTime() - new Date(b?.sentAt || 0).getTime());
+
+    for (const message of sorted) {
+        const {from, to, sentAt, subject} = message ?? {};
+
+        if (!from || !subject || !sentAt) continue;
+
+        const sentMs = new Date(sentAt).getTime();
+        if (!Number.isFinite(sentMs) || sentMs < floorMs || sentMs > nowMs) continue;
+
+        const refs = [...String(subject).matchAll(PR_REF_PATTERN)].map(match => Number(match[1]));
+        if (refs.length === 0) continue;
+
+        const firstTag = subject.match(FIRST_TAG_PATTERN)?.[1] ?? '';
+
+        if (CHANGES_PATTERN.test(subject) && OPEN_TAG_PATTERN.test(firstTag)) {
+            for (const pr of refs) {
+                loops.set(`${from}|${pr}`, {pr, returned: false, reviewer: from, since: new Date(sentMs).toISOString()});
+            }
+        } else if (APPROVED_PATTERN.test(subject) && CLOSE_TAG_PATTERN.test(firstTag)) {
+            for (const pr of refs) {
+                loops.delete(`${from}|${pr}`);
+            }
+        } else if (to && RETURN_TAG_PATTERN.test(firstTag)) {
+            for (const pr of refs) {
+                const loop = loops.get(`${to}|${pr}`);
+                if (loop) loop.returned = true;
+            }
+        }
+    }
+
+    const byReviewer = new Map();
+
+    for (const loop of loops.values()) {
+        const list = byReviewer.get(loop.reviewer) ?? [];
+        list.push(loop);
+        byReviewer.set(loop.reviewer, list);
+    }
+
+    const result = new Map();
+
+    for (const [reviewer, reviewerLoops] of byReviewer) {
+        reviewerLoops.sort((a, b) => new Date(a.since).getTime() - new Date(b.since).getTime());
+
+        result.set(reviewer, {
+            loops   : reviewerLoops,
+            open    : reviewerLoops.length,
+            returned: reviewerLoops.filter(loop => loop.returned).length
+        });
+    }
+
+    return result
+}

--- a/ai/services/memory-core/helpers/reviewLoadProjection.mjs
+++ b/ai/services/memory-core/helpers/reviewLoadProjection.mjs
@@ -29,7 +29,7 @@
 export const REVIEW_LOAD_TRAIL_HORIZON_MS = 30 * 24 * 60 * 60 * 1000;
 
 const APPROVED_PATTERN   = /\bAPPROVED\b/i;
-const CHANGES_PATTERN    = /\bCHANGES_REQUESTED\b/i;
+const CHANGES_PATTERN    = /\b(?:CHANGES_REQUESTED|REQUEST_CHANGES)\b/i;
 const CLOSE_TAG_PATTERN  = /^(?:review-posted|APPROVED)\b/i;
 const FIRST_TAG_PATTERN  = /^\s*\[([^\]]+)]/;
 const OPEN_TAG_PATTERN   = /^(?:review-posted|CHANGES_REQUESTED|REQUEST_CHANGES)\b/i;
@@ -77,11 +77,18 @@ export function deriveReviewLoad(messages, {horizonMs = REVIEW_LOAD_TRAIL_HORIZO
 
         const firstTag = subject.match(FIRST_TAG_PATTERN)?.[1] ?? '';
 
-        if (CHANGES_PATTERN.test(subject) && OPEN_TAG_PATTERN.test(firstTag)) {
+        const
+            approvedAt = subject.search(APPROVED_PATTERN),
+            changesAt  = subject.search(CHANGES_PATTERN);
+
+        // The disposition a subject IS beats the disposition it QUOTES: when both vocabularies
+        // appear, the earlier mention carries the verdict — "APPROVED — all CHANGES_REQUESTED
+        // items verified" retires the loop it names, it does not open one.
+        if (changesAt > -1 && (approvedAt === -1 || changesAt < approvedAt) && OPEN_TAG_PATTERN.test(firstTag)) {
             for (const pr of refs) {
                 loops.set(`${from}|${pr}`, {pr, returned: false, reviewer: from, since: new Date(sentMs).toISOString()});
             }
-        } else if (APPROVED_PATTERN.test(subject) && CLOSE_TAG_PATTERN.test(firstTag)) {
+        } else if (approvedAt > -1 && CLOSE_TAG_PATTERN.test(firstTag)) {
             for (const pr of refs) {
                 loops.delete(`${from}|${pr}`);
             }

--- a/test/playwright/unit/ai/services/memory-core/WakeSubscriptionService.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/WakeSubscriptionService.spec.mjs
@@ -3200,10 +3200,11 @@ test.describe('Neo.ai.services.memory-core.WakeSubscriptionService', () => {
 
         // AC4 fixture: a MESSAGE node of the review-lifecycle trail — `from`/`to`/`subject`/`sentAt`
         // ride the node properties exactly as MailboxService writes them; the subject is the
-        // protocol surface the disposition classifier reads.
+        // protocol surface the disposition classifier reads. Ids carry the production `MESSAGE:`
+        // prefix because the service read pre-filters on it.
         function seedReviewPing({id, from, subject, sentAt, to = 'AGENT:*'}) {
             GraphService.upsertNode({
-                id,
+                id        : `MESSAGE:${id}`,
                 type      : 'MESSAGE',
                 name      : subject,
                 properties: {from, to, subject, sentAt}
@@ -3217,14 +3218,14 @@ test.describe('Neo.ai.services.memory-core.WakeSubscriptionService', () => {
             seedActivity('@neo-ac4-quiet', {timestamp: iso(T0ms - 2 * 60 * 1000)});
 
             // Two OPEN loops: a CHANGES_REQUESTED review-ping per PR, no later disposition.
-            seedReviewPing({id: 'MSG:AC4-CR-1', from: '@neo-ac4-reviewer', sentAt: iso(T0ms - 60 * 60 * 1000),
+            seedReviewPing({id: 'AC4-CR-1', from: '@neo-ac4-reviewer', sentAt: iso(T0ms - 60 * 60 * 1000),
                 subject: '[review-posted][CHANGES_REQUESTED][PR #101 @ aaa1111111] two edits'});
-            seedReviewPing({id: 'MSG:AC4-CR-2', from: '@neo-ac4-reviewer', sentAt: iso(T0ms - 30 * 60 * 1000),
+            seedReviewPing({id: 'AC4-CR-2', from: '@neo-ac4-reviewer', sentAt: iso(T0ms - 30 * 60 * 1000),
                 subject: '[review-posted][CHANGES_REQUESTED][PR #102 @ bbb2222222] one edit'});
             // One CLOSED loop: the same reviewer's later APPROVED ping retires the CR.
-            seedReviewPing({id: 'MSG:AC4-CR-3', from: '@neo-ac4-reviewer', sentAt: iso(T0ms - 2 * 60 * 60 * 1000),
+            seedReviewPing({id: 'AC4-CR-3', from: '@neo-ac4-reviewer', sentAt: iso(T0ms - 2 * 60 * 60 * 1000),
                 subject: '[review-posted][CHANGES_REQUESTED][PR #103 @ ccc3333333] nits'});
-            seedReviewPing({id: 'MSG:AC4-OK-3', from: '@neo-ac4-reviewer', sentAt: iso(T0ms - 45 * 60 * 1000),
+            seedReviewPing({id: 'AC4-OK-3', from: '@neo-ac4-reviewer', sentAt: iso(T0ms - 45 * 60 * 1000),
                 subject: '[APPROVED][PR #103 @ ddd4444444] all addressed'});
 
             const {agents} = await WakeSubscriptionService.whoIsOnline({verbose: true, now: new Date(T0)});
@@ -3243,10 +3244,10 @@ test.describe('Neo.ai.services.memory-core.WakeSubscriptionService', () => {
             seedAgent('@neo-ac4-returned');
             seedActivity('@neo-ac4-returned', {timestamp: iso(T0ms - 2 * 60 * 1000)});
 
-            seedReviewPing({id: 'MSG:AC4-CR-4', from: '@neo-ac4-returned', sentAt: iso(T0ms - 60 * 60 * 1000),
+            seedReviewPing({id: 'AC4-CR-4', from: '@neo-ac4-returned', sentAt: iso(T0ms - 60 * 60 * 1000),
                 subject: '[review-posted][CHANGES_REQUESTED][PR #201 @ eee5555555] three actions'});
             // The author returns the ball: a re-review request ADDRESSED to the reviewer.
-            seedReviewPing({id: 'MSG:AC4-RR-4', from: '@neo-ac4-author', to: '@neo-ac4-returned', sentAt: iso(T0ms - 10 * 60 * 1000),
+            seedReviewPing({id: 'AC4-RR-4', from: '@neo-ac4-author', to: '@neo-ac4-returned', sentAt: iso(T0ms - 10 * 60 * 1000),
                 subject: '[re-review request][PR #201 @ fff6666666] all RAs discharged'});
 
             const {agents} = await WakeSubscriptionService.whoIsOnline({verbose: true, now: new Date(T0)});
@@ -3266,10 +3267,10 @@ test.describe('Neo.ai.services.memory-core.WakeSubscriptionService', () => {
             seedActivity('@neo-ac4-author', {timestamp: iso(T0ms - 2 * 60 * 1000)});
 
             // A stale-approval WARNING names APPROVED but is not a disposition ping.
-            seedReviewPing({id: 'MSG:AC4-STALE', from: '@neo-ac4-robust', sentAt: iso(T0ms - 20 * 60 * 1000),
+            seedReviewPing({id: 'AC4-STALE', from: '@neo-ac4-robust', sentAt: iso(T0ms - 20 * 60 * 1000),
                 subject: '[approval STALE — do not merge on it][PR #301 @ 999aaaaaaa] GitHub still shows APPROVED from the dead head'});
             // An author's re-review request may QUOTE the RC vocabulary; the first tag is not a disposition.
-            seedReviewPing({id: 'MSG:AC4-QUOTE', from: '@neo-ac4-author', to: '@neo-ac4-robust', sentAt: iso(T0ms - 15 * 60 * 1000),
+            seedReviewPing({id: 'AC4-QUOTE', from: '@neo-ac4-author', to: '@neo-ac4-robust', sentAt: iso(T0ms - 15 * 60 * 1000),
                 subject: '[re-review request][PR #302 @ 888bbbbbbb] your CHANGES_REQUESTED items are all discharged'});
 
             const {agents} = await WakeSubscriptionService.whoIsOnline({verbose: true, now: new Date(T0)});
@@ -3287,7 +3288,7 @@ test.describe('Neo.ai.services.memory-core.WakeSubscriptionService', () => {
             seedAgent('@neo-ac4-terse-quiet');
             seedActivity('@neo-ac4-terse-quiet', {timestamp: iso(T0ms - 2 * 60 * 1000)});
 
-            seedReviewPing({id: 'MSG:AC4-CR-5', from: '@neo-ac4-terse', sentAt: iso(T0ms - 30 * 60 * 1000),
+            seedReviewPing({id: 'AC4-CR-5', from: '@neo-ac4-terse', sentAt: iso(T0ms - 30 * 60 * 1000),
                 subject: '[review-posted][CHANGES_REQUESTED][PR #401 @ 123abcdef0] one blocking edit'});
 
             const terse = await WakeSubscriptionService.whoIsOnline({now: new Date(T0)});
@@ -3311,13 +3312,89 @@ test.describe('Neo.ai.services.memory-core.WakeSubscriptionService', () => {
             seedAgent('@neo-ac4-horizon');
             seedActivity('@neo-ac4-horizon', {timestamp: iso(T0ms - 2 * 60 * 1000)});
 
-            seedReviewPing({id: 'MSG:AC4-OLD', from: '@neo-ac4-horizon', sentAt: iso(T0ms - 31 * 24 * 60 * 60 * 1000),
+            seedReviewPing({id: 'AC4-OLD', from: '@neo-ac4-horizon', sentAt: iso(T0ms - 31 * 24 * 60 * 60 * 1000),
                 subject: '[review-posted][CHANGES_REQUESTED][PR #501 @ 000fffffff1] ancient loop'});
 
             const {agents} = await WakeSubscriptionService.whoIsOnline({verbose: true, now: new Date(T0)});
             const reviewer = agents.find(a => a.identity === '@neo-ac4-horizon');
 
             expect(reviewer.reviewLoad.open).toBe(0);
+        });
+
+        test('#17267 review — an UNREADABLE trail degrades the load envelope; it never serves a counted zero over absence', async () => {
+            seedAgent('@neo-ac4-degraded');
+            seedActivity('@neo-ac4-degraded', {timestamp: iso(T0ms - 2 * 60 * 1000)});
+
+            const realDb = GraphService.db;
+
+            try {
+                // Branch 1: the store handle is absent entirely — the answer still returns (an
+                // empty roster is the bigger outage's truth, not this axis's concern), the load
+                // envelope degrades, and the sparse map is OMITTED rather than present-but-empty
+                // (which would read as "everyone is zero" over absence of observation).
+                GraphService.db = {storage: {db: null}};
+
+                const terse = await WakeSubscriptionService.whoIsOnline({now: new Date(T0)});
+
+                expect(terse.axes.load.capability.state).toBe('degraded');
+                expect(terse.axes.load.capability.confidence).toBe('none');
+                expect(typeof terse.axes.load.capability.reason).toBe('string');
+                expect('reviewLoad' in terse).toBe(false);
+
+                // Branch 2: the trail read ALONE throws (a contended store) — the roster answer
+                // must survive its axis failing. The stub kills only the MESSAGE query.
+                const realSqlite = realDb.storage.db;
+
+                GraphService.db = {storage: {db: {
+                    prepare: sql => {
+                        if (sql.includes('MESSAGE')) throw new Error('disk i/o error');
+                        return realSqlite.prepare(sql)
+                    }
+                }}};
+
+                const thrown = await WakeSubscriptionService.whoIsOnline({now: new Date(T0)});
+
+                expect(thrown.axes.load.capability.state).toBe('degraded');
+                expect(thrown.axes.load.capability.reason).toContain('disk i/o error');
+                expect(thrown.online).toContain('@neo-ac4-degraded');
+
+                const verbose = await WakeSubscriptionService.whoIsOnline({verbose: true, now: new Date(T0)});
+                const entry   = verbose.agents.find(a => a.identity === '@neo-ac4-degraded');
+
+                expect(entry.reviewLoad).toBeNull(); // honest absence, distinct from the counted zero
+            } finally {
+                GraphService.db = realDb
+            }
+        });
+
+        test('#17267 review — a dual-mention subject RETIRES the loop: the first disposition word wins', async () => {
+            seedAgent('@neo-ac4-dual');
+            seedActivity('@neo-ac4-dual', {timestamp: iso(T0ms - 2 * 60 * 1000)});
+
+            seedReviewPing({id: 'AC4-D1', from: '@neo-ac4-dual', sentAt: iso(T0ms - 60 * 60 * 1000),
+                subject: '[review-posted][CHANGES_REQUESTED][PR #601 @ aaaa0000001] two edits'});
+            // The approval names the prior RC vocabulary — the disposition it IS beats the one it QUOTES.
+            seedReviewPing({id: 'AC4-D2', from: '@neo-ac4-dual', sentAt: iso(T0ms - 30 * 60 * 1000),
+                subject: '[review-posted][PR #601 @ bbbb0000002] APPROVED — all CHANGES_REQUESTED items verified'});
+
+            const {agents} = await WakeSubscriptionService.whoIsOnline({verbose: true, now: new Date(T0)});
+            const reviewer = agents.find(a => a.identity === '@neo-ac4-dual');
+
+            expect(reviewer.reviewLoad.open).toBe(0);
+        });
+
+        test('#17267 review — a REQUEST_CHANGES-tagged ping opens a loop (the tag-set and word-set agree)', async () => {
+            seedAgent('@neo-ac4-rcform');
+            seedActivity('@neo-ac4-rcform', {timestamp: iso(T0ms - 2 * 60 * 1000)});
+
+            seedReviewPing({id: 'AC4-RC', from: '@neo-ac4-rcform', sentAt: iso(T0ms - 30 * 60 * 1000),
+                subject: '[REQUEST_CHANGES][PR #701 @ cccc0000003] two edits'});
+
+            const {agents} = await WakeSubscriptionService.whoIsOnline({verbose: true, now: new Date(T0)});
+            const reviewer = agents.find(a => a.identity === '@neo-ac4-rcform');
+
+            expect(reviewer.reviewLoad.open).toBe(1);
+            expect(reviewer.reviewLoad.loops[0].pr).toBe(701);
         });
     });
 

--- a/test/playwright/unit/ai/services/memory-core/WakeSubscriptionService.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/WakeSubscriptionService.spec.mjs
@@ -3197,6 +3197,128 @@ test.describe('Neo.ai.services.memory-core.WakeSubscriptionService', () => {
                 expect(detector(src), `${path.relative(root, file)} re-declares the presence vocabulary`).toBe(false);
             }
         });
+
+        // AC4 fixture: a MESSAGE node of the review-lifecycle trail — `from`/`to`/`subject`/`sentAt`
+        // ride the node properties exactly as MailboxService writes them; the subject is the
+        // protocol surface the disposition classifier reads.
+        function seedReviewPing({id, from, subject, sentAt, to = 'AGENT:*'}) {
+            GraphService.upsertNode({
+                id,
+                type      : 'MESSAGE',
+                name      : subject,
+                properties: {from, to, subject, sentAt}
+            });
+        }
+
+        test('#17225 AC4 — the load axis counts open re-review loops: a peer holding N reads N, a zero peer reads zero', async () => {
+            seedAgent('@neo-ac4-reviewer');
+            seedActivity('@neo-ac4-reviewer', {timestamp: iso(T0ms - 2 * 60 * 1000)});
+            seedAgent('@neo-ac4-quiet');
+            seedActivity('@neo-ac4-quiet', {timestamp: iso(T0ms - 2 * 60 * 1000)});
+
+            // Two OPEN loops: a CHANGES_REQUESTED review-ping per PR, no later disposition.
+            seedReviewPing({id: 'MSG:AC4-CR-1', from: '@neo-ac4-reviewer', sentAt: iso(T0ms - 60 * 60 * 1000),
+                subject: '[review-posted][CHANGES_REQUESTED][PR #101 @ aaa1111111] two edits'});
+            seedReviewPing({id: 'MSG:AC4-CR-2', from: '@neo-ac4-reviewer', sentAt: iso(T0ms - 30 * 60 * 1000),
+                subject: '[review-posted][CHANGES_REQUESTED][PR #102 @ bbb2222222] one edit'});
+            // One CLOSED loop: the same reviewer's later APPROVED ping retires the CR.
+            seedReviewPing({id: 'MSG:AC4-CR-3', from: '@neo-ac4-reviewer', sentAt: iso(T0ms - 2 * 60 * 60 * 1000),
+                subject: '[review-posted][CHANGES_REQUESTED][PR #103 @ ccc3333333] nits'});
+            seedReviewPing({id: 'MSG:AC4-OK-3', from: '@neo-ac4-reviewer', sentAt: iso(T0ms - 45 * 60 * 1000),
+                subject: '[APPROVED][PR #103 @ ddd4444444] all addressed'});
+
+            const {agents} = await WakeSubscriptionService.whoIsOnline({verbose: true, now: new Date(T0)});
+            const reviewer = agents.find(a => a.identity === '@neo-ac4-reviewer');
+            const quiet    = agents.find(a => a.identity === '@neo-ac4-quiet');
+
+            expect(reviewer.reviewLoad.open).toBe(2);
+            expect(reviewer.reviewLoad.loops.map(loop => loop.pr).sort()).toEqual([101, 102]);
+            // The ticket's positive control: a peer whose load is genuinely zero reads ZERO —
+            // a counted absence, never an unknown axis.
+            expect(quiet.reviewLoad.open).toBe(0);
+            expect(quiet.reviewLoad.loops).toEqual([]);
+        });
+
+        test('#17225 AC4 — a returned ball reads as the re-review obligation it is', async () => {
+            seedAgent('@neo-ac4-returned');
+            seedActivity('@neo-ac4-returned', {timestamp: iso(T0ms - 2 * 60 * 1000)});
+
+            seedReviewPing({id: 'MSG:AC4-CR-4', from: '@neo-ac4-returned', sentAt: iso(T0ms - 60 * 60 * 1000),
+                subject: '[review-posted][CHANGES_REQUESTED][PR #201 @ eee5555555] three actions'});
+            // The author returns the ball: a re-review request ADDRESSED to the reviewer.
+            seedReviewPing({id: 'MSG:AC4-RR-4', from: '@neo-ac4-author', to: '@neo-ac4-returned', sentAt: iso(T0ms - 10 * 60 * 1000),
+                subject: '[re-review request][PR #201 @ fff6666666] all RAs discharged'});
+
+            const {agents} = await WakeSubscriptionService.whoIsOnline({verbose: true, now: new Date(T0)});
+            const reviewer = agents.find(a => a.identity === '@neo-ac4-returned');
+
+            expect(reviewer.reviewLoad.open).toBe(1);
+            expect(reviewer.reviewLoad.returned).toBe(1);
+            expect(reviewer.reviewLoad.loops[0]).toMatchObject({pr: 201, returned: true});
+        });
+
+        test('#17225 AC4 — non-disposition mentions of the magic words neither open nor close a loop', async () => {
+            seedAgent('@neo-ac4-robust');
+            seedActivity('@neo-ac4-robust', {timestamp: iso(T0ms - 2 * 60 * 1000)});
+            // The author is rostered TOO, so a phantom loop opened for the sender is observable —
+            // an unrostered author would make this assertion vacuous.
+            seedAgent('@neo-ac4-author');
+            seedActivity('@neo-ac4-author', {timestamp: iso(T0ms - 2 * 60 * 1000)});
+
+            // A stale-approval WARNING names APPROVED but is not a disposition ping.
+            seedReviewPing({id: 'MSG:AC4-STALE', from: '@neo-ac4-robust', sentAt: iso(T0ms - 20 * 60 * 1000),
+                subject: '[approval STALE — do not merge on it][PR #301 @ 999aaaaaaa] GitHub still shows APPROVED from the dead head'});
+            // An author's re-review request may QUOTE the RC vocabulary; the first tag is not a disposition.
+            seedReviewPing({id: 'MSG:AC4-QUOTE', from: '@neo-ac4-author', to: '@neo-ac4-robust', sentAt: iso(T0ms - 15 * 60 * 1000),
+                subject: '[re-review request][PR #302 @ 888bbbbbbb] your CHANGES_REQUESTED items are all discharged'});
+
+            const {agents} = await WakeSubscriptionService.whoIsOnline({verbose: true, now: new Date(T0)});
+            const reviewer = agents.find(a => a.identity === '@neo-ac4-robust');
+            const author   = agents.find(a => a.identity === '@neo-ac4-author');
+
+            expect(reviewer.reviewLoad.open).toBe(0);
+            // The author never reviewed: quoting the vocabulary opens nothing for the sender either.
+            expect(author.reviewLoad.open).toBe(0);
+        });
+
+        test('#17225 AC4 — terse carries the sparse reviewLoad map plus the wired container-plane load envelope', async () => {
+            seedAgent('@neo-ac4-terse');
+            seedActivity('@neo-ac4-terse', {timestamp: iso(T0ms - 2 * 60 * 1000)});
+            seedAgent('@neo-ac4-terse-quiet');
+            seedActivity('@neo-ac4-terse-quiet', {timestamp: iso(T0ms - 2 * 60 * 1000)});
+
+            seedReviewPing({id: 'MSG:AC4-CR-5', from: '@neo-ac4-terse', sentAt: iso(T0ms - 30 * 60 * 1000),
+                subject: '[review-posted][CHANGES_REQUESTED][PR #401 @ 123abcdef0] one blocking edit'});
+
+            const terse = await WakeSubscriptionService.whoIsOnline({now: new Date(T0)});
+
+            // Sparse by construction: a zero-load peer pays no entry — absent IS zero.
+            expect(terse.reviewLoad['@neo-ac4-terse']).toBe(1);
+            expect(terse.reviewLoad['@neo-ac4-terse-quiet']).toBeUndefined();
+
+            const load = terse.axes?.load?.capability;
+            expect(load).toBeTruthy();
+            expect(load.plane).toBe('container');
+            expect(load.signal).toBe('a2a-review-lifecycle');
+            expect(load.state).toBe('wired');
+            expect(load.confidence).toBe('observed');
+            expect(load.capturedAt).toBe(terse.generatedAt);
+            // The envelope names its own blind class: a review that never pinged is invisible here.
+            expect(load.reason).toContain('ping');
+        });
+
+        test('#17225 AC4 — a loop older than the trail horizon ages out, declared not hidden', async () => {
+            seedAgent('@neo-ac4-horizon');
+            seedActivity('@neo-ac4-horizon', {timestamp: iso(T0ms - 2 * 60 * 1000)});
+
+            seedReviewPing({id: 'MSG:AC4-OLD', from: '@neo-ac4-horizon', sentAt: iso(T0ms - 31 * 24 * 60 * 60 * 1000),
+                subject: '[review-posted][CHANGES_REQUESTED][PR #501 @ 000fffffff1] ancient loop'});
+
+            const {agents} = await WakeSubscriptionService.whoIsOnline({verbose: true, now: new Date(T0)});
+            const reviewer = agents.find(a => a.identity === '@neo-ac4-horizon');
+
+            expect(reviewer.reviewLoad.open).toBe(0);
+        });
     });
 
     test.describe('rotateKey — the repair door for a row that lost its signing key', () => {


### PR DESCRIPTION
Resolves neomjs/neo#17267

The load axis of neomjs/neo-agent-brain#31 (slice PR2, per the posted slice plan): `who_is_online` now counts each peer's open re-review obligations from the plane-resident A2A review-lifecycle trail — a reviewer holding N open `CHANGES_REQUESTED` loops reads N, and a peer whose load is genuinely zero reads the counted zero. The derivation is a new pure helper (`reviewLoadProjection.mjs`) over the mailbox's MESSAGE nodes — same SQLite store the roster read already uses, so no new transport and no second authority. The classifier is first-bracket-tag anchored with first-disposition-word-wins: prose that names a disposition without being one (stale-approval warnings quoting `APPROVED`, author responses quoting the `CHANGES_REQUESTED` they answer, approvals noting the RC items they verified) neither opens nor retires a loop, and PR refs come from the subject only — `relatedTickets` lists resolved TICKETS, so counting them would open phantom loops on issues. Both shapes carry the `load` capability envelope (container plane, wired/observed, signal `a2a-review-lifecycle`, blind class named); terse gains the sparse `reviewLoad` map, verbose rows gain `{open, returned, loops[]}` oldest-first. An UNREADABLE trail degrades the envelope (`degraded`/`none` + reason) — the sparse map is omitted and verbose rows carry `null`, because absence of observation must never render as a counted zero.

Evidence: L2 (unit-spec ceiling: fixtures drive the real service over the in-memory graph; the live-tree pin needs the redeployed plane) → L2 required (close-target ACs 1-5 are spec-verifiable; AC6 is the PMV live pin). Residual: the live-tree pin, Residual-Owner: neomjs/neo-agent-brain#31

## Deltas from ticket

- The ticket was authored against the as-built surface in the same session; the Contract Ledger matches the diff row-for-row (the three fallback cells were synced in place after the RC round's tri-state repair). Two implementation details beyond the ticket text: messages stamped in the FUTURE (`sentAt > now`) are excluded from the derivation — a clock-skew guard, symmetric to the horizon floor — and the trail scan is bound at the SQL layer by the `MESSAGE:` id-prefix (the mailbox's own production read pattern), so memory-class rows never reach the JSON walk.

## Test Evidence

- `UNIT_TEST_MODE=true npx playwright test -c test/playwright/playwright.config.unit.mjs test/playwright/unit/ai/services/memory-core/WakeSubscriptionService.spec.mjs` → **136 passed** (8 new AC4/RC pins + full file).
- Red-proof cycle (pre-fix blindness): all 8 new tests red against their respective pre-fix implementations (run individually to defeat the `describe.serial` first-failure skip).
- Mutation controls at the fix head: (A) close-branch disabled → the N-reads-N pin reds; (B) unanchored open-classifier → the robustness pin reds; (C) horizon floor removed → the horizon pin reds; (D) first-mention order flipped → the dual-mention pin reds. All restored byte-identical; full file re-green. Mutation B also exposed a vacuous-assertion risk in the robustness pin (the author was unrostered) — the pin now rosters the author, and bites.
- Adjacent suites: `planeWhoIsOnlineReader`, `fleetPresenceStateAdapter`, `fleetCockpitStatus`, `fleetCockpit`, `fleetGrid`, `onboardPeer`, `Server`, `OpenApiValidatorCompliance`, `OpenApiServiceParityGate` → **107 passed**.
- Surfaces: `ai/services/memory-core` + `ai/mcp/server/memory-core` — covered above; in-repo consumers verified additive-safe by read (`toolService.mjs` destructures the five buckets; `planeWhoIsOnlineReader` passes `agents` through with one array-shape guard).

## Post-Merge Validation

- [ ] Live-tree pin (ticket AC6): after the plane redeploys past this head, `who_is_online` verbose `reviewLoad` for a seat holding a known open loop matches hand-counted GitHub state — and the terse sparse map carries exactly the seats holding loops. The same beat measures the trail scan's live cost (row count + wall time), closing the measurement arm of the RC's RA-2.

Residual-Owner: neomjs/neo-agent-brain#31

## Commits

- e2e9684543 — the load axis: pure derivation helper, service wiring, envelopes, openapi contract, five red-proofed pins
- d4a59b2c19 — the RC round: tri-state trail honesty (degraded envelope, omitted map, null rows), the id-prefix scan bound, first-disposition-word-wins + `REQUEST_CHANGES` word-parity, three more pins

Authored by Iris (K3, Kimi Code CLI). Session ade8fd5d-4732-49ad-9763-b1c8b6772826.
