### PR TITLE
fix(build): the package-contents gate stops inheriting the blind spot it exists to end

### DIFF
--- a/buildScripts/util/check-package-contents.mjs
+++ b/buildScripts/util/check-package-contents.mjs
@@ -42,6 +42,17 @@ const ROOT       = path.resolve(__dirname, '../..');
  * Directories that must not appear in the tarball, each with the exact subtrees deliberately
  * carved out of it. A carve-out is spelled as a prefix so the intent stays readable next to the
  * rule it mirrors — and so an ADDED sibling of a carve-out fails rather than inheriting its pass.
+ *
+ * **Directories only, and that is a boundary rather than an omission.** The `.npmignore` also
+ * excludes two individual generated FILES — `/apps/portal/sitemap.xml` and `/apps/portal/llms.txt`,
+ * 3.22 MiB of crawler-addressed SEO output — and they are deliberately absent here. The distinction
+ * is exposure vs bloat: every prefix below names a tree whose contents must never leave this
+ * machine (agent memories, the synced corpus, a crawler dataset), where a leak is a disclosure. The
+ * portal files are public artifacts already served from `neomjs.com`; shipping them wastes bytes and
+ * discloses nothing, so they are worth an ignore rule and not worth a gate.
+ *
+ * Raised by @neo-opus-grace on review — "the next reader will otherwise see an omission rather than
+ * a boundary", which was correct, because nothing here said so.
  * @type {Array<{prefix: String, allow: String[], why: String}>}
  */
 export const FORBIDDEN_PREFIXES = [
@@ -51,9 +62,24 @@ export const FORBIDDEN_PREFIXES = [
         why   : 'Agent OS plane state — server logs, wake-daemon files, deployment snapshots, and the Memory Core SQLite graph (agent memories, session records, A2A edges). The tracked concept ontology is the sole intended export.'
     },
     {
-        prefix: 'apps/devindex/resources/data/',
-        allow : [],
-        why   : 'DevIndex crawler corpus — 26.5 MiB with no framework consumer; the browser store fetches it over HTTP from the deployed site, never from the package.'
+        // Anchored on `resources/` rather than `resources/data/`, and that is the whole point.
+        //
+        // Defect #1 this guard exists for was a rule pinned to `apps/devindex/resources/*.json`,
+        // which went vacuous when the corpus moved into `data/` and grew a `.jsonl`. A rule pinned
+        // to `resources/data/` reproduces that exactly: rename `data/` → `corpus/` and the
+        // `.npmignore` line and this gate go vacuous TOGETHER, so the guard prints OK over a 26.5 MiB
+        // leak. An observer that inherits the blind spot of the thing it observes is not an observer.
+        //
+        // Prefix-plus-allowlist survives the rename: a subtree that does not exist yet is excluded by
+        // default, and only `images/` is named. `resources/` holds exactly two children today —
+        // `images/` (one 4 KB SVG) and `data/` (26.5 MiB) — so if a legitimate non-corpus subdirectory
+        // is added later, the correct response is to add it here, which is a decision someone makes
+        // rather than one a rename makes for them.
+        //
+        // Raised by @neo-opus-grace on review of the PR that introduced this file.
+        prefix: 'apps/devindex/resources/',
+        allow : ['apps/devindex/resources/images/'],
+        why   : 'DevIndex crawler corpus — 26.5 MiB with no framework consumer; the browser store fetches it over HTTP from the deployed site, never from the package. The app\'s own images are the sole intended export.'
     },
     {
         prefix: 'resources/content/',
@@ -96,14 +122,23 @@ export function findForbiddenEntries(packedPaths, rules = FORBIDDEN_PREFIXES) {
  * @summary Extracts the JSON payload from `npm pack --json` output.
  *
  * Lifecycle scripts write to stdout ahead of the payload, so the raw output is not parseable as-is.
- * The payload is the last top-level array, which starts at the first line that is exactly `[`.
+ * The payload is the FIRST top-level array — the first line that is exactly `[`. The doc previously
+ * said "last" while the code took the first; they now agree on the first, which is the correct one:
+ * `npm pack --json` emits exactly one array, and anything after it would be trailing noise that
+ * `JSON.parse` rejects anyway.
+ *
+ * **The leading newline is not required.** Matching only `'\n[\n'` meant a payload beginning at
+ * offset 0 — which is what happens the moment the `prepare` lifecycle stops writing to stdout —
+ * threw `no JSON array found` over output that had one. The direction of that failure was safe (a
+ * throw exits non-zero and reds the gate, so it could never false-PASS), but a guard that fails on
+ * a clean environment is a guard people learn to distrust. Raised by @neo-opus-grace on review.
  *
  * @param {String} raw Combined stdout of the pack invocation.
  * @returns {Object[]} The parsed pack report.
  * @throws {Error} When no JSON array is present.
  */
 export function parsePackOutput(raw) {
-    const start = raw.indexOf('\n[\n');
+    const start = raw.startsWith('[\n') ? 0 : raw.indexOf('\n[\n');
 
     if (start === -1) {
         throw new Error('check-package-contents: no JSON array found in `npm pack --json` output')

--- a/test/playwright/unit/buildScripts/checkPackageContents.spec.mjs
+++ b/test/playwright/unit/buildScripts/checkPackageContents.spec.mjs
@@ -102,4 +102,40 @@ test.describe('check-package-contents — fires on private state, not on the tra
         // "no forbidden entries" over a pack that never happened.
         expect(() => parsePackOutput('npm ERR! something went wrong\n')).toThrow(/no JSON array/);
     });
+
+    test('parsePackOutput finds a payload that starts at offset 0', () => {
+        // The lifecycle scripts are not a contract. The moment `prepare` stops writing to stdout the
+        // payload begins the string, and a matcher requiring a PRECEDING newline threw
+        // "no JSON array found" over output that had one. Safe direction — a throw reds the gate and
+        // can never false-pass — but a guard that breaks on a cleaner environment gets distrusted.
+        expect(parsePackOutput('[\n  {"entryCount": 2, "files": []}\n]\n')[0].entryCount).toBe(2);
+    });
+
+    test('the DevIndex rule survives the corpus being RENAMED — the defect it exists to end', () => {
+        // The sharpest case in this file, because the guard nearly reproduced defect #1 itself.
+        //
+        // The original `.npmignore` rule was pinned to `apps/devindex/resources/*.json` and went
+        // vacuous when the corpus moved into `data/` and became `.jsonl`. A gate pinned to
+        // `resources/data/` would go vacuous on the SAME move — rename `data/` → `corpus/` and both
+        // the ignore rule and its observer fall silent together, printing OK over a 26.5 MiB leak.
+        //
+        // Anchoring on `resources/` with `images/` allowed means a subtree that does not exist yet is
+        // excluded by default, so only a deliberate allowlist edit can widen it.
+        expect(findForbiddenEntries(['apps/devindex/resources/data/users.jsonl'])).toHaveLength(1);
+        expect(findForbiddenEntries(['apps/devindex/resources/corpus/users.jsonl'])).toHaveLength(1);
+        expect(findForbiddenEntries(['apps/devindex/resources/some-future-dataset/x.json'])).toHaveLength(1);
+
+        // and the one carve-out still passes, at any depth
+        expect(findForbiddenEntries(['apps/devindex/resources/images/logo.svg'])).toEqual([]);
+        expect(findForbiddenEntries(['apps/devindex/resources/images/icons/nested.svg'])).toEqual([]);
+    });
+
+    test('the rule set names DIRECTORIES only — the two generated portal FILES are a boundary, not a gap', () => {
+        // `.npmignore` also excludes `/apps/portal/sitemap.xml` and `/apps/portal/llms.txt` (3.22 MiB),
+        // and they are deliberately not gated here. Every prefix in the set names a tree whose leak
+        // would be a DISCLOSURE; the portal files are already public on neomjs.com, so shipping them
+        // is waste and not exposure. Asserted so the distinction is enforced rather than merely
+        // written down — a later editor adding a file-shaped rule has to change this test and say why.
+        expect(FORBIDDEN_PREFIXES.every(rule => rule.prefix.endsWith('/'))).toBe(true);
+    });
 });


### PR DESCRIPTION
Resolves #17274

Post-merge hardening of the gate PR #17253 shipped. @neo-opus-grace raised three non-blocking challenges asking for a disposition before merge; her approval and @tobiu's merge both landed first, so they arrive here instead of as a fold-in.

Evidence: L3 (a real `npm pack --dry-run` over the working tree, plus the rule logic exercised directly against the rename that used to escape) → L3 required (the AC is "what does the tarball contain", which only a real pack settles). Residual: none.

## Deltas from ticket

- **B is asserted, not just documented.** The ticket asks for a docstring; a docstring stating a boundary is a claim, so `FORBIDDEN_PREFIXES.every(rule => rule.prefix.endsWith('/'))` makes a later file-shaped rule change a test and say why.
- **A nested-image case beyond the three @neo-opus-grace verified.** `startsWith` on the allow entry should hold at any depth; that was assumed rather than asserted, so it is asserted now.
- Otherwise none substantive.

## The one that mattered

**A is a latent defect, not a style preference.** #17240's defect #1 was a rule pinned to `apps/devindex/resources/*.json` that went vacuous when the corpus moved. The gate written to end that class was pinned to `apps/devindex/resources/data/` — so the same move, `data/` → `corpus/`, silences the `.npmignore` line and its observer **together**, and the check prints `OK` over a 26.5 MiB leak.

That is worse than having no gate. Without one, the next measurement finds the leak; with a green one, the measurement has already been made and it was wrong.

| path | before | after |
|---|---|---|
| `resources/data/users.jsonl` | 1 finding | 1 finding |
| `resources/corpus/users.jsonl` — the rename | **0** | **1** |
| `resources/some-future-dataset/x.json` | 0 | 1 |
| `resources/images/logo.svg` | pass | pass |
| `resources/images/icons/nested.svg` | pass | pass |
| `apps/devindex/view/Viewport.mjs`, `index.html` | pass | pass |

## Test Evidence

- `npm run test-unit -- test/playwright/unit/buildScripts/checkPackageContents.spec.mjs` → **13 passed, exit 0** (10 existing, 3 new).
- **The real gate on a real pack** — the only thing that settles what ships: `check-package-contents: OK — 7388 files, 28.43 MiB tarball, 66.73 MiB unpacked; no forbidden entries.`
- `parsePackOutput` exercised on both shapes rather than reasoned about: payload at offset 0 → parses; payload behind lifecycle stdout → parses.

## Post-Merge Validation

None. Every claim here is settled by a local pack and the unit suite; nothing waits on a deployed surface.

Authored by Ada (Claude Opus 5, Claude Code). Session 80b326bf-b37a-4efd-8313-1a9eae09e9c4.

⚖️ **Ada** · `@neo-opus-ada` · Claude Opus 5 · Claude Code
