### PR TITLE
feat(cockpit): add the live-plane journey (cockpit:live) (#17276)

### DIFF
--- a/buildScripts/devCockpit.mjs
+++ b/buildScripts/devCockpit.mjs
@@ -50,8 +50,9 @@
  * is composed against the containerized plane — one command for the real-fleet journey, no
  * hand-assembled wiring. Before any spawn, the launcher resolves the plane binding
  * ({@link resolveLivePlaneConfig}: `NEO_FLEET_PLANE_BASE` else the canonical local plane address;
- * bearer from `NEO_FLEET_PLANE_BEARER`, else a `NEO_FLEET_PLANE_BEARER_FILE` secret file, else the
- * `gh auth token` identity — the same account the viewer claim resolves through) and probes the
+ * bearer from `NEO_FLEET_PLANE_BEARER`, else a `NEO_FLEET_PLANE_BEARER_FILE` secret file, else —
+ * LOOPBACK bases only — the `gh auth token` identity, whose implicit PAT never travels to a
+ * non-loopback host) and probes the
  * plane's MCP ingress unauthenticated ({@link probePlaneIdentity}: the auth guard's 401 IS the
  * plane signature). Bearer custody is deliberate: the value materializes ONLY into the fleet
  * child's env ({@link buildFleetChildEnv}) — never `process.env`, never the webpack child, never
@@ -245,6 +246,27 @@ function readGhAuthToken() {
 }
 
 /**
+ * @summary The loopback gate for the implicit gh credential: parses the resolved plane base and
+ * answers whether it names THIS machine — the only destination the viewer-claim identity's PAT may
+ * travel to without an explicit operator credential decision. Same loopback vocabulary the app's
+ * bridge installer enforces. An unparseable base answers false: fail-closed, and the probe or the
+ * fleet entry owns the downstream diagnosis.
+ * @param {String} planeBase
+ * @returns {Boolean}
+ */
+function isLoopbackPlaneBase(planeBase) {
+    let hostname;
+
+    try {
+        hostname = new URL(planeBase).hostname
+    } catch {
+        return false
+    }
+
+    return ['127.0.0.1', 'localhost', '[::1]'].includes(hostname)
+}
+
+/**
  * @summary Resolves the live journey's plane binding — the pure decision seam the witnesses pin.
  *
  * Precedence, each half named in the notes so a boot log always shows WHICH source armed the run:
@@ -252,6 +274,13 @@ function readGhAuthToken() {
  *  - bearer: `NEO_FLEET_PLANE_BEARER` (direct) else the `NEO_FLEET_PLANE_BEARER_FILE` secret file
  *    (materialized into the direct env channel for the fleet child — the dev fleet entry reads only
  *    the direct leaf, so the launcher is where the file's value crosses) else `gh auth token`.
+ *
+ * The two halves are deliberately NOT independent: the implicit `gh auth token` fallback fires only
+ * for a LOOPBACK base. It resolves the viewer-claim identity's own PAT, and a credential like that
+ * may travel implicitly to this machine and nowhere else — the probe's 401 signature proves
+ * reachability, never that the host should receive a credential. A pinned non-loopback base with no
+ * explicit bearer is REFUSED with the remediation: a remote deployment pins an explicit credential
+ * (an explicit decision for an explicit destination).
  *
  * Fail-closed: a pinned-but-unreadable file REFUSES (a launcher that thinks it pinned a credential
  * must not silently run on a different one), and all-three-empty refuses with the remediation.
@@ -310,6 +339,23 @@ export async function resolveLivePlaneConfig({env = process.env, readGhToken = r
     }
 
     if (!planeBearer) {
+        // The implicit gh fallback is COUPLED to the destination: it resolves the viewer-claim
+        // identity's own PAT, which may travel implicitly to a loopback plane (the canonical local
+        // journey) and nowhere else. A pinned non-loopback base with no explicit bearer refuses —
+        // the probe's 401 signature proves reachability, never that the host should receive one.
+        if (!isLoopbackPlaneBase(planeBase)) {
+            return {
+                refuse      : true,
+                planeBase,
+                planeBearer : '',
+                bearerSource: null,
+                notes       : [
+                    ...notes,
+                    `REFUSED: ${planeBase} is not a loopback plane and no explicit credential is pinned — the \`gh auth token\` identity's PAT never travels to a non-loopback host implicitly. Set NEO_FLEET_PLANE_BEARER or NEO_FLEET_PLANE_BEARER_FILE for a remote deployment (an explicit credential for an explicit destination), or unset NEO_FLEET_PLANE_BASE for the canonical local journey.`
+                ]
+            }
+        }
+
         planeBearer = (await readGhToken()).trim();
         source      = planeBearer ? 'gh' : null
     }

--- a/buildScripts/devCockpit.mjs
+++ b/buildScripts/devCockpit.mjs
@@ -45,9 +45,25 @@
  * Signals: SIGINT/SIGTERM forward to every child this launcher spawned; a webpack exit tears the
  * session down; a fleet-server exit logs loudly while the cockpit degrades to its honest
  * seed/stale states (the operable-cold banner names it on the surface).
+ *
+ * Live mode (`--live`, the `cockpit:live` script): the same supervised boot, but the fleet child
+ * is composed against the containerized plane — one command for the real-fleet journey, no
+ * hand-assembled wiring. Before any spawn, the launcher resolves the plane binding
+ * ({@link resolveLivePlaneConfig}: `NEO_FLEET_PLANE_BASE` else the canonical local plane address;
+ * bearer from `NEO_FLEET_PLANE_BEARER`, else a `NEO_FLEET_PLANE_BEARER_FILE` secret file, else the
+ * `gh auth token` identity — the same account the viewer claim resolves through) and probes the
+ * plane's MCP ingress unauthenticated ({@link probePlaneIdentity}: the auth guard's 401 IS the
+ * plane signature). Bearer custody is deliberate: the value materializes ONLY into the fleet
+ * child's env ({@link buildFleetChildEnv}) — never `process.env`, never the webpack child, never
+ * a log line. Bearer VALIDITY stays with the fleet entry's plane-side verified admission (one
+ * verification authority); this launcher fails fast only on "no plane serving there at all".
+ * Live mode never adopts an incumbent fleet transport: the incumbent's plane binding is not
+ * observable through `/fleet/probe`, so reuse could silently point the cockpit at the wrong
+ * plane — an occupied endpoint refuses with the remediation named.
  */
-import {spawn} from 'node:child_process';
-import http    from 'node:http';
+import {spawn}        from 'node:child_process';
+import {readFileSync} from 'node:fs';
+import http           from 'node:http';
 
 const FLEET_PORT_DEFAULT = 8083;
 
@@ -202,16 +218,227 @@ export function planCockpitBoot({fleetPort, endpointStatus, endpointDetail = '',
 }
 
 /**
+ * @summary The canonical local Agent OS plane's published loopback base — the deployment fact the
+ * live journey defaults to when `NEO_FLEET_PLANE_BASE` is not pinned. Path-routed `/mc/mcp` +
+ * `/kb/mcp` live behind this address in the canonical local profile; the literal names the
+ * DEPLOYMENT's published port (never a hash-derived or guessed one), and the env leaf always wins.
+ * @type {String}
+ */
+export const CANONICAL_LOCAL_PLANE_BASE = 'http://127.0.0.1:3102';
+
+/**
+ * @summary Default gh-CLI seam for {@link resolveLivePlaneConfig}: `gh auth token` resolves the
+ * active gh identity's PAT — the same account the fleet viewer claim resolves through, which is
+ * exactly the subject the plane's provider-PAT authority verifies. Captured into launcher memory
+ * only: stdout is read, never echoed; a missing/failing gh resolves `''` and the caller decides.
+ * @returns {Promise<String>} The trimmed token, or `''` on every failure path.
+ */
+function readGhAuthToken() {
+    return new Promise(resolve => {
+        const child = spawn('gh', ['auth', 'token'], {stdio: ['ignore', 'pipe', 'ignore']});
+        let   out   = '';
+
+        child.stdout.on('data', chunk => out += chunk);
+        child.on('error', () => resolve(''));
+        child.on('close', code => resolve(code === 0 ? out.trim() : ''));
+    })
+}
+
+/**
+ * @summary Resolves the live journey's plane binding — the pure decision seam the witnesses pin.
+ *
+ * Precedence, each half named in the notes so a boot log always shows WHICH source armed the run:
+ *  - base: `NEO_FLEET_PLANE_BASE` (an explicit pin always wins) else {@link CANONICAL_LOCAL_PLANE_BASE}.
+ *  - bearer: `NEO_FLEET_PLANE_BEARER` (direct) else the `NEO_FLEET_PLANE_BEARER_FILE` secret file
+ *    (materialized into the direct env channel for the fleet child — the dev fleet entry reads only
+ *    the direct leaf, so the launcher is where the file's value crosses) else `gh auth token`.
+ *
+ * Fail-closed: a pinned-but-unreadable file REFUSES (a launcher that thinks it pinned a credential
+ * must not silently run on a different one), and all-three-empty refuses with the remediation.
+ * The bearer VALUE never enters the notes — sources are named, secrets are not.
+ *
+ * @param {Object}   [options]
+ * @param {Object}   [options.env=process.env]        Environment to resolve from.
+ * @param {Function} [options.readGhToken]            Injectable gh seam; default {@link readGhAuthToken}.
+ * @param {Function} [options.readFile]               Injectable file seam for tests; defaults to `readFileSync`.
+ * @returns {Promise<{refuse: Boolean, planeBase: String, planeBearer: String, bearerSource: ('env'|'file'|'gh'|null), notes: String[]}>}
+ */
+export async function resolveLivePlaneConfig({env = process.env, readGhToken = readGhAuthToken, readFile = null} = {}) {
+    const
+        planeBase = env.NEO_FLEET_PLANE_BASE?.trim() || CANONICAL_LOCAL_PLANE_BASE,
+        notes     = [
+            env.NEO_FLEET_PLANE_BASE?.trim()
+                ? `plane base pinned via NEO_FLEET_PLANE_BASE (${planeBase})`
+                : `plane base defaulted to the canonical local plane (${planeBase}) — pin NEO_FLEET_PLANE_BASE to target a different deployment`
+        ];
+
+    let planeBearer = env.NEO_FLEET_PLANE_BEARER?.trim() || '',
+        source      = planeBearer ? 'env' : null;
+
+    if (!planeBearer && env.NEO_FLEET_PLANE_BEARER_FILE?.trim()) {
+        const bearerFile = env.NEO_FLEET_PLANE_BEARER_FILE.trim();
+
+        try {
+            const read = readFile ?? (target => readFileSync(target, 'utf8'));
+            planeBearer = String(read(bearerFile)).trim();
+            source      = planeBearer ? 'file' : null
+        } catch (error) {
+            return {
+                refuse      : true,
+                planeBase,
+                planeBearer : '',
+                bearerSource: null,
+                notes       : [
+                    ...notes,
+                    `REFUSED: NEO_FLEET_PLANE_BEARER_FILE is pinned but unreadable (${bearerFile}: ${error.message}) — a pinned credential must never silently fall through to another source. Fix the file or unset the variable.`
+                ]
+            }
+        }
+
+        if (!planeBearer) {
+            return {
+                refuse      : true,
+                planeBase,
+                planeBearer : '',
+                bearerSource: null,
+                notes       : [
+                    ...notes,
+                    `REFUSED: NEO_FLEET_PLANE_BEARER_FILE (${bearerFile}) read empty — a pinned credential must never silently fall through to another source. Fix the file or unset the variable.`
+                ]
+            }
+        }
+    }
+
+    if (!planeBearer) {
+        planeBearer = (await readGhToken()).trim();
+        source      = planeBearer ? 'gh' : null
+    }
+
+    if (!planeBearer) {
+        return {
+            refuse      : true,
+            planeBase,
+            planeBearer : '',
+            bearerSource: null,
+            notes       : [
+                ...notes,
+                'REFUSED: no plane credential resolved — export NEO_FLEET_PLANE_BEARER, point NEO_FLEET_PLANE_BEARER_FILE at a token file, or `gh auth login`. The live journey authenticates to the plane as your gh identity, and a credential it cannot resolve must never become a guess.'
+            ]
+        }
+    }
+
+    notes.push(`plane bearer resolved from ${source === 'env' ? 'NEO_FLEET_PLANE_BEARER' : source === 'file' ? 'NEO_FLEET_PLANE_BEARER_FILE' : '`gh auth token` (the viewer-claim identity)'} — value held in launcher memory, injected into the fleet child only`);
+
+    return {refuse: false, planeBase, planeBearer, bearerSource: source, notes}
+}
+
+/**
+ * @summary Probes the live plane's MCP ingress WITHOUT credentials: the auth guard's 401 before
+ * any session is the plane's identity signature — deterministic, side-effect-free, and exactly as
+ * unforgeable-by-accident as the fleet transport's own refusal envelope. Reachability is the only
+ * question this probe answers; bearer validity stays with the fleet entry's verified admission.
+ * @param {Object}   options
+ * @param {String}   options.planeBase                    The resolved plane base URL.
+ * @param {Function} [options.fetchImpl=globalThis.fetch] Injectable fetch for tests.
+ * @param {Number}   [options.timeoutMs=3000]             Probe patience.
+ * @returns {Promise<{status: ('plane'|'unreachable'|'incompatible'), detail: String}>}
+ */
+export async function probePlaneIdentity({planeBase, fetchImpl = globalThis.fetch, timeoutMs = 3000}) {
+    const url = `${planeBase.replace(/\/+$/, '')}/mc/mcp`;
+
+    let response;
+
+    try {
+        response = await fetchImpl(url, {
+            method : 'POST',
+            headers: {'Content-Type': 'application/json'},
+            body   : JSON.stringify({jsonrpc: '2.0', id: 0, method: 'initialize', params: {}}),
+            signal : AbortSignal.timeout(timeoutMs)
+        })
+    } catch (error) {
+        return {
+            status: 'unreachable',
+            detail: `no plane answering at ${url} (${error.cause?.code || error.message}) — start the canonical local plane first: docker compose --env-file .env -f ai/deploy/docker-compose.yml -f ai/deploy/docker-compose.local-agent-os.yml --profile cloud --profile ingress --profile fleet up -d --wait (see ai/scripts/lifecycle/local-agent-os/README.md)`
+        }
+    }
+
+    if (response.status === 401) {
+        return {status: 'plane', detail: 'plane identity confirmed (authenticated ingress refusal)'}
+    }
+
+    return {status: 'incompatible', detail: `${url} answered HTTP ${response.status} — not the plane's authenticated MCP ingress; check NEO_FLEET_PLANE_BASE`}
+}
+
+/**
+ * @summary Builds the fleet child's environment — the ONE place launch-resolved credentials cross
+ * into a process. The transport bearer + handshake arm always ride; the live plane binding rides
+ * only in live mode. Custody rule: this env goes to the fleet child ALONE — the webpack child
+ * keeps the launcher's own environment untouched, so a gh/file-materialized plane bearer never
+ * reaches a process that does not need it. Pure: the input env is copied, never mutated.
+ * @param {Object}      options
+ * @param {Object}      options.baseEnv            The launcher's environment to extend.
+ * @param {String}      options.fleetBearer        The process-lifetime transport bearer.
+ * @param {Object|null} [options.livePlane=null]   The resolved live binding ({planeBase, planeBearer}).
+ * @returns {Object} The child environment.
+ */
+export function buildFleetChildEnv({baseEnv, fleetBearer, livePlane = null}) {
+    const env = {...baseEnv, NEO_FLEET_BEARER: fleetBearer, NEO_FLEET_BEARER_HANDSHAKE: '1'};
+
+    if (livePlane) {
+        env.NEO_FLEET_PLANE_BASE   = livePlane.planeBase;
+        env.NEO_FLEET_PLANE_BEARER = livePlane.planeBearer
+    }
+
+    return env
+}
+
+/**
  * @summary Process entry: resolve authority, probe, plan, spawn, supervise. The webpack child is
  * spawned via an injectable command seam (`NEO_COCKPIT_WEBPACK_CMD`, JSON `[cmd, ...args]`) so the
  * composed-boot integration witness can substitute a stub without touching the production default.
+ * Live mode (`--live`) resolves + probes the plane binding BEFORE anything spawns, never adopts an
+ * incumbent fleet transport (its plane binding is not probe-observable), and refuses named.
  * @returns {Promise<void>}
  * @protected
  */
 async function main() {
     const
-        fleetPort = Number(process.env.NEO_FLEET_PORT) || FLEET_PORT_DEFAULT,
-        probe     = fleetPort === FLEET_PORT_DEFAULT ? await probeFleetEndpoint(fleetPort) : null;
+        liveMode  = process.argv.includes('--live'),
+        fleetPort = Number(process.env.NEO_FLEET_PORT) || FLEET_PORT_DEFAULT;
+
+    // Live journey first: resolve the plane binding and prove the plane serves BEFORE anything
+    // spawns — a misresolved credential or an absent plane fails fast with no browser opened.
+    let livePlane = null;
+
+    if (liveMode) {
+        const resolved = await resolveLivePlaneConfig({env: process.env});
+
+        resolved.notes.forEach(note => console.log(`[cockpit:live] ${note}`));
+
+        if (resolved.refuse) {
+            process.exit(1)
+        }
+
+        const planeProbe = await probePlaneIdentity({planeBase: resolved.planeBase});
+
+        if (planeProbe.status !== 'plane') {
+            console.error(`[cockpit:live] REFUSED: ${planeProbe.detail}`);
+            process.exit(1)
+        }
+
+        console.log(`[cockpit:live] ${planeProbe.detail} at ${resolved.planeBase}`);
+        livePlane = resolved
+    }
+
+    const probe = fleetPort === FLEET_PORT_DEFAULT ? await probeFleetEndpoint(fleetPort) : null;
+
+    // Live mode never adopts an incumbent: the reuse proof binds token + viewer but NOT the
+    // incumbent's plane read — an in-process incumbent would silently boot the cockpit off the
+    // wrong plane. Refuse named; the operator stops it or takes the in-process journey.
+    if (liveMode && probe?.status === 'fleet') {
+        console.error(`[cockpit:live] REFUSED: :${fleetPort} already serves a fleet transport — its plane binding is not observable through /fleet/probe, so adopting it could point the cockpit at the wrong plane. Stop the incumbent and re-run, or use \`npm run cockpit\` for the in-process journey.`);
+        process.exit(1)
+    }
 
     // A protocol-identity occupant needs the AUTHENTICATED reuse proof before it may become the
     // page's credential authority. The proof can only be attempted when this environment pins the
@@ -284,9 +511,10 @@ async function main() {
         // NEO_FLEET_BEARER_HANDSHAKE: this launcher opens the page AND holds the bearer, so it is
         // the one place arming the browser handshake is a coherent custody decision — the page the
         // webpack child opens redeems the secret itself (apps/agentos/fleet/redeemFleetBearerHandshake.mjs),
-        // closing the launcher→page hand-off without an agent seam.
+        // closing the launcher→page hand-off without an agent seam. The live plane binding (when
+        // `--live` resolved one) rides the same child-only channel — never the webpack env.
         const fleet = spawn(fleetCmd[0], fleetCmd.slice(1), {
-            env  : {...process.env, NEO_FLEET_BEARER: fleetBearer, NEO_FLEET_BEARER_HANDSHAKE: '1'},
+            env  : buildFleetChildEnv({baseEnv: process.env, fleetBearer, livePlane}),
             stdio: 'inherit'
         });
 

--- a/learn/agentos/RunningTheFleetCockpit.md
+++ b/learn/agentos/RunningTheFleetCockpit.md
@@ -141,6 +141,47 @@ For deployment-side auth, identity, and readiness details, continue with
 [Cloud deployment security](./cloud-deployment/Security.md) and the
 [Day-0 tutorial](./cloud-deployment/Day0Tutorial.md).
 
+## The one command against the live plane
+
+```bash
+npm run cockpit:live
+```
+
+Same supervised boot as above — but the fleet transport binds to the **containerized plane**, so
+the cockpit renders the real fleet's truth: presence bands from the live presence surface, the
+activity stream from the real A2A/PR lanes, and the mailbox, memories, and catch-up panes reading
+plane content — no hand-assembled wiring, no exported credential ritual.
+
+The launcher resolves the plane binding itself, naming every source it used:
+
+1. **Base URL** — `NEO_FLEET_PLANE_BASE` wins; otherwise the canonical local plane
+   (`http://127.0.0.1:3102`). Pin the variable to target a different deployment.
+2. **Bearer** — `NEO_FLEET_PLANE_BEARER` wins, then the `NEO_FLEET_PLANE_BEARER_FILE` secret file,
+   then `gh auth token` (the same identity the viewer claim resolves through, which is exactly the
+   subject the plane's provider-PAT authority verifies). All three empty refuses with the
+   remediation; a pinned-but-unreadable file refuses rather than falling through to a different
+   credential. The resolved value is held in launcher memory and injected into the fleet child's
+   environment only — never the webpack child, never a log line.
+3. **Plane probe** — before anything spawns, an unauthenticated call to the plane's MCP ingress
+   must answer with its auth guard's `401` (that refusal IS the plane's identity signature).
+   Nothing serving there fails fast with the plane-start command
+   (`docker compose --env-file .env -f ai/deploy/docker-compose.yml -f ai/deploy/docker-compose.local-agent-os.yml --profile cloud --profile ingress --profile fleet up -d --wait`,
+   see [`local-agent-os/README.md`](../../ai/scripts/lifecycle/local-agent-os/README.md)).
+
+Live mode **never adopts an incumbent** fleet transport: an existing server on `:8083` cannot
+report which plane it reads through `/fleet/probe`, so adopting it could point the cockpit at the
+wrong plane. Stop the old transport and re-run, or use `npm run cockpit` for the in-process
+journey. Bearer *validity* is verified where it has always been verified — the fleet entry's
+plane-side admission refuses a bearer whose subject is not the resolved viewer, fail-closed.
+
+What renders real, and what stays honestly degraded: the roster itself is still **this checkout's
+managed fleet** (the seats registered here) — plane mode moves the truth axes (presence, activity,
+mailbox, memories, catch-up, wake subscriptions), not the roster's ownership. A checkout that
+manages no seats renders the labelled empty-registry state, never resurrected sample residents.
+The wake **push** lane arms only when the deployment declares a fleet-surface credential
+(`fleet.planeAdmissionBearer` / `…File`); without one the stream axis renders its honest
+not-armed reason and the brokered digest poll remains the truth lane.
+
 ## Without the fleet transport
 
 The cockpit itself always boots — `npm run server-start` alone still serves it. Without the

--- a/learn/agentos/RunningTheFleetCockpit.md
+++ b/learn/agentos/RunningTheFleetCockpit.md
@@ -158,10 +158,13 @@ The launcher resolves the plane binding itself, naming every source it used:
    (`http://127.0.0.1:3102`). Pin the variable to target a different deployment.
 2. **Bearer** — `NEO_FLEET_PLANE_BEARER` wins, then the `NEO_FLEET_PLANE_BEARER_FILE` secret file,
    then `gh auth token` (the same identity the viewer claim resolves through, which is exactly the
-   subject the plane's provider-PAT authority verifies). All three empty refuses with the
-   remediation; a pinned-but-unreadable file refuses rather than falling through to a different
-   credential. The resolved value is held in launcher memory and injected into the fleet child's
-   environment only — never the webpack child, never a log line.
+   subject the plane's provider-PAT authority verifies). The `gh auth token` fallback is **coupled
+   to the destination**: it fires only for a loopback base — the implicit PAT never travels to a
+   non-loopback host, so a pinned remote base needs an explicit credential (an explicit decision
+   for an explicit destination). All three empty refuses with the remediation; a
+   pinned-but-unreadable file refuses rather than falling through to a different credential. The
+   resolved value is held in launcher memory and injected into the fleet child's environment only —
+   never the webpack child, never a log line.
 3. **Plane probe** — before anything spawns, an unauthenticated call to the plane's MCP ingress
    must answer with its auth guard's `401` (that refusal IS the plane's identity signature).
    Nothing serving there fails fast with the plane-start command

--- a/package.json
+++ b/package.json
@@ -119,6 +119,7 @@
         "devindex:optout"                      : "node ./apps/devindex/services/cli.mjs optout",
         "devindex:spider"                      : "node ./apps/devindex/services/cli.mjs spider",
         "cockpit"                              : "node ./buildScripts/devCockpit.mjs",
+        "cockpit:live"                         : "node ./buildScripts/devCockpit.mjs --live",
         "devindex:update"                      : "node ./apps/devindex/services/cli.mjs update --limit 200",
         "generate-docs-json"                   : "node ./buildScripts/docs/generateDocsJson.mjs",
         "install-brain"                        : "node ./buildScripts/util/installBrain.mjs",

--- a/test/playwright/unit/ai/buildScripts/devCockpit.spec.mjs
+++ b/test/playwright/unit/ai/buildScripts/devCockpit.spec.mjs
@@ -1,6 +1,8 @@
 import {test, expect}  from '@playwright/test';
 import {spawn}         from 'node:child_process';
+import fs              from 'node:fs';
 import {createServer}  from 'node:net';
+import os              from 'node:os';
 import path            from 'node:path';
 import {fileURLToPath} from 'node:url';
 
@@ -12,9 +14,9 @@ import InstanceManager from '../../../../../src/manager/Instance.mjs';
 
 import http from 'node:http';
 
-import {COCKPIT_OPEN_TARGET, FLEET_PROBE_METHOD, planCockpitBoot, probeFleetEndpoint} from '../../../../../buildScripts/devCockpit.mjs';
-import {startFleetBridgeServer}                                                       from '../../../../../ai/services/fleet/fleetBridgeServer.mjs';
-import {generateLocalBearerToken}                                                     from '../../../../../ai/mcp/server/shared/helpers/localBearer.mjs';
+import {COCKPIT_OPEN_TARGET, FLEET_PROBE_METHOD, buildFleetChildEnv, planCockpitBoot, probeFleetEndpoint, probePlaneIdentity, resolveLivePlaneConfig} from '../../../../../buildScripts/devCockpit.mjs';
+import {startFleetBridgeServer}                                                                                                                       from '../../../../../ai/services/fleet/fleetBridgeServer.mjs';
+import {generateLocalBearerToken}                                                                                                                     from '../../../../../ai/mcp/server/shared/helpers/localBearer.mjs';
 
 const authenticatedOptions = overrides => ({
     port         : 0,
@@ -295,5 +297,287 @@ test.describe('buildScripts/devCockpit — the live-by-default boot plan', () =>
     test('the composed command opens the COCKPIT surface, not the dev-server root', () => {
         expect(COCKPIT_OPEN_TARGET).toBe('apps/agentos/index.html');
         expect(FLEET_PROBE_METHOD).toContain('probe')
+    })
+});
+
+/**
+ * The live-journey witnesses (`--live`, the `cockpit:live` script): the plane-binding resolution
+ * seam (env > file > gh precedence, fail-closed refusals, secret values never in the notes), the
+ * unauthenticated plane-identity probe (the auth guard's 401 IS the signature), the child-env
+ * custody rule (the fleet child alone carries the materialized bearer), and three composed runs
+ * through the REAL launcher — the full live boot against a fixture plane, the unreachable-plane
+ * fail-fast, and the never-adopt-an-incumbent refusal.
+ */
+test.describe('buildScripts/devCockpit — the live-plane journey (cockpit:live)', () => {
+    // The composed witnesses below own :8083 in turn (serial, same discipline as the boot-plan suite).
+    test.describe.configure({mode: 'serial'});
+
+    test('resolveLivePlaneConfig: env pin wins and the gh seam is never consulted', async () => {
+        const resolved = await resolveLivePlaneConfig({
+            env        : {NEO_FLEET_PLANE_BASE: 'http://127.0.0.1:4000', NEO_FLEET_PLANE_BEARER: 'env-token'},
+            readGhToken: async () => { throw new Error('the gh seam must not run when the env pins the bearer') }
+        });
+
+        expect(resolved.refuse).toBe(false);
+        expect(resolved.planeBase).toBe('http://127.0.0.1:4000');
+        expect(resolved.planeBearer).toBe('env-token');
+        expect(resolved.bearerSource).toBe('env');
+        expect(resolved.notes[0]).toContain('pinned via NEO_FLEET_PLANE_BASE')
+    });
+
+    test('resolveLivePlaneConfig: the secret-file half materializes and never consults gh', async () => {
+        const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'cockpit-live-'));
+
+        fs.writeFileSync(path.join(dir, 'token'), '  file-token-42\n');
+
+        const resolved = await resolveLivePlaneConfig({
+            env        : {NEO_FLEET_PLANE_BEARER_FILE: path.join(dir, 'token')},
+            readGhToken: async () => { throw new Error('the gh seam must not run when the file pins the bearer') }
+        });
+
+        expect(resolved.refuse).toBe(false);
+        expect(resolved.planeBearer).toBe('file-token-42');
+        expect(resolved.bearerSource).toBe('file');
+        expect(resolved.planeBase).toBe('http://127.0.0.1:3102');
+        expect(resolved.notes[0]).toContain('canonical local plane')
+    });
+
+    test('resolveLivePlaneConfig: gh is the fallback of last resort — and a pinned-but-dead file REFUSES instead of falling through', async () => {
+        const viaGh = await resolveLivePlaneConfig({env: {}, readGhToken: async () => 'gh-token'});
+
+        expect(viaGh.refuse).toBe(false);
+        expect(viaGh.bearerSource).toBe('gh');
+        expect(viaGh.planeBearer).toBe('gh-token');
+
+        const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'cockpit-live-'));
+
+        for (const pinned of [path.join(dir, 'missing'), path.join(dir, 'empty')]) {
+            if (pinned.endsWith('empty')) {
+                fs.writeFileSync(pinned, '   \n')
+            }
+
+            const resolved = await resolveLivePlaneConfig({
+                env        : {NEO_FLEET_PLANE_BEARER_FILE: pinned},
+                readGhToken: async () => 'gh-token-that-must-not-be-reached'
+            });
+
+            expect(resolved.refuse, pinned).toBe(true);
+            expect(resolved.planeBearer, pinned).toBe('');
+            expect(resolved.notes.at(-1), pinned).toContain('REFUSED');
+            expect(resolved.notes.at(-1), pinned).toContain('must never silently fall through');
+            expect(resolved.notes.join(' '), pinned).not.toContain('gh-token-that-must-not-be-reached')
+        }
+    });
+
+    test('resolveLivePlaneConfig: all-three-empty refuses with the remediation — and no resolved value ever reaches the notes', async () => {
+        const resolved = await resolveLivePlaneConfig({env: {}, readGhToken: async () => ''});
+
+        expect(resolved.refuse).toBe(true);
+        expect(resolved.notes.at(-1)).toContain('REFUSED');
+        expect(resolved.notes.at(-1)).toContain('NEO_FLEET_PLANE_BEARER');
+        expect(resolved.notes.at(-1)).toContain('gh auth login');
+
+        // The custody witness: a resolved bearer VALUE never leaks into the operator-facing notes
+        // (sources are named, secrets are not) — across all three sources.
+        const SECRET = 'fixture-secret-value-that-must-stay-out-of-logs';
+
+        for (const [env, readGhToken] of [
+            [{NEO_FLEET_PLANE_BEARER: SECRET}, async () => ''],
+            [{}, async () => SECRET]
+        ]) {
+            const leakProbe = await resolveLivePlaneConfig({env, readGhToken});
+
+            expect(leakProbe.refuse).toBe(false);
+            expect(leakProbe.notes.join(' ')).not.toContain(SECRET)
+        }
+    });
+
+    test('probePlaneIdentity: the auth guard 401 IS the plane signature; anything else is named', async () => {
+        // (a) a fixture ingress answering 401 before any session — the plane's fail-closed shape
+        const guard = http.createServer((req, res) => {
+            res.writeHead(401, {'Content-Type': 'application/json'});
+            res.end(JSON.stringify({error: 'invalid_token', error_description: 'Missing Authorization header'}))
+        });
+
+        await new Promise(resolve => guard.listen(0, '127.0.0.1', resolve));
+
+        const guardPort  = guard.address().port,
+              guardProbe = await probePlaneIdentity({planeBase: `http://127.0.0.1:${guardPort}`});
+
+        expect(guardProbe.status).toBe('plane');
+        expect(guardProbe.detail).toContain('identity confirmed');
+
+        await new Promise(resolve => guard.close(resolve));
+
+        // (b) an HTTP-ish occupant answering 200-ok is NOT the authenticated ingress
+        const foreign = http.createServer((req, res) => {
+            res.writeHead(200, {'Content-Type': 'application/json'});
+            res.end(JSON.stringify({ok: true}))
+        });
+
+        await new Promise(resolve => foreign.listen(0, '127.0.0.1', resolve));
+
+        const foreignProbe = await probePlaneIdentity({planeBase: `http://127.0.0.1:${foreign.address().port}`});
+
+        expect(foreignProbe.status).toBe('incompatible');
+        expect(foreignProbe.detail).toContain('HTTP 200');
+
+        await new Promise(resolve => foreign.close(resolve));
+
+        // (c) the just-closed port → unreachable, with the plane-start remediation named
+        const deadProbe = await probePlaneIdentity({planeBase: `http://127.0.0.1:${guardPort}`});
+
+        expect(deadProbe.status).toBe('unreachable');
+        expect(deadProbe.detail).toContain('docker compose');
+        expect(deadProbe.detail).toContain('local-agent-os')
+    });
+
+    test('buildFleetChildEnv: the fleet child alone carries the binding — the base env is never mutated', () => {
+        const baseEnv = {PATH: '/usr/bin'},
+              env     = buildFleetChildEnv({baseEnv, fleetBearer: 'transport-bearer', livePlane: {planeBase: 'http://127.0.0.1:3102', planeBearer: 'plane-secret'}});
+
+        expect(env.NEO_FLEET_BEARER).toBe('transport-bearer');
+        expect(env.NEO_FLEET_BEARER_HANDSHAKE).toBe('1');
+        expect(env.NEO_FLEET_PLANE_BASE).toBe('http://127.0.0.1:3102');
+        expect(env.NEO_FLEET_PLANE_BEARER).toBe('plane-secret');
+
+        // custody: nothing reached back into the launcher's own environment (the webpack child's)
+        expect(baseEnv).toEqual({PATH: '/usr/bin'});
+
+        // the in-process journey adds no plane surface at all
+        const inProcess = buildFleetChildEnv({baseEnv, fleetBearer: 'transport-bearer'});
+
+        expect('NEO_FLEET_PLANE_BASE' in inProcess).toBe(false);
+        expect('NEO_FLEET_PLANE_BEARER' in inProcess).toBe(false)
+    });
+
+    test('composed live boot: the file-pinned bearer materializes into the FLEET child only — the webpack child never sees it', async () => {
+        test.setTimeout(60000);
+
+        if ((await probeFleetEndpoint(8083)).status !== 'free') {
+            test.skip(true, 'the default fleet endpoint is occupied on this machine — the composed live witness needs to own it');
+            return
+        }
+
+        // the fixture plane: an ingress whose 401-before-session is the identity signature
+        const fixturePlane = http.createServer((req, res) => {
+            res.writeHead(401, {'Content-Type': 'application/json'});
+            res.end(JSON.stringify({error: 'invalid_token'}))
+        });
+
+        await new Promise(resolve => fixturePlane.listen(0, '127.0.0.1', resolve));
+
+        const
+            planeBase = `http://127.0.0.1:${fixturePlane.address().port}`,
+            dir       = fs.mkdtempSync(path.join(os.tmpdir(), 'cockpit-live-')),
+            tokenFile = path.join(dir, 'plane-token');
+
+        fs.writeFileSync(tokenFile, 'fixture-file-token-42\n');
+
+        const launcher = spawn(process.execPath, [path.join(repoRoot, 'buildScripts/devCockpit.mjs'), '--live'], {
+            cwd: repoRoot,
+            env: {
+                ...process.env,
+                NEO_FLEET_PLANE_BASE       : planeBase,
+                NEO_FLEET_PLANE_BEARER_FILE: tokenFile,
+                // the fleet stub proves the materialized binding ARRIVED (value compared inside the
+                // child, only the boolean printed); the webpack stub proves custody (its env lacks it)
+                NEO_COCKPIT_FLEET_CMD   : JSON.stringify([process.execPath, '-e',
+                    `console.log('FLEET_STUB planeBase=' + process.env.NEO_FLEET_PLANE_BASE + ' bearerMatch=' + (process.env.NEO_FLEET_PLANE_BEARER === 'fixture-file-token-42')); setInterval(() => {}, 1000)`]),
+                NEO_COCKPIT_WEBPACK_CMD : JSON.stringify([process.execPath, '-e',
+                    `console.log('WEBPACK_STUB planeBearerAbsent=' + (process.env.NEO_FLEET_PLANE_BEARER === undefined)); setInterval(() => {}, 1000)`])
+            },
+            stdio: ['ignore', 'pipe', 'pipe']
+        });
+
+        let output = '';
+        launcher.stdout.on('data', chunk => output += chunk);
+        launcher.stderr.on('data', chunk => output += chunk);
+
+        try {
+            await expect.poll(() => output.includes('WEBPACK_STUB'), {timeout: 15000}).toBe(true);
+
+            expect(output).toContain(`[cockpit:live] plane identity confirmed (authenticated ingress refusal) at ${planeBase}`);
+            expect(output).toContain(`FLEET_STUB planeBase=${planeBase} bearerMatch=true`);
+            expect(output).toContain('WEBPACK_STUB planeBearerAbsent=true');
+            // and the bearer VALUE stayed out of every launcher log line
+            expect(output).not.toContain('fixture-file-token-42')
+        } finally {
+            const exited = new Promise(resolve => launcher.on('exit', resolve));
+            launcher.kill('SIGTERM');
+            await exited;
+            await new Promise(resolve => fixturePlane.close(resolve))
+        }
+    });
+
+    test('live mode fails FAST on an unreachable plane — before any page or transport spawns', async () => {
+        test.setTimeout(30000);
+
+        const launcher = spawn(process.execPath, [path.join(repoRoot, 'buildScripts/devCockpit.mjs'), '--live'], {
+            cwd: repoRoot,
+            env: {
+                ...process.env,
+                NEO_FLEET_PLANE_BASE   : 'http://127.0.0.1:9',
+                NEO_FLEET_PLANE_BEARER : 'dummy-token',
+                NEO_COCKPIT_WEBPACK_CMD: JSON.stringify([process.execPath, '-e', 'console.log("WEBPACK_STUB_STARTED"); setInterval(() => {}, 1000)'])
+            },
+            stdio: ['ignore', 'pipe', 'pipe']
+        });
+
+        let output = '';
+        launcher.stdout.on('data', chunk => output += chunk);
+        launcher.stderr.on('data', chunk => output += chunk);
+
+        const code = await new Promise(resolve => launcher.on('exit', resolve));
+
+        expect(code).toBe(1);
+        expect(output).toContain('[cockpit:live] REFUSED: no plane answering');
+        expect(output).toContain('docker compose');
+        expect(output).not.toContain('WEBPACK_STUB_STARTED')
+    });
+
+    test('live mode NEVER adopts an incumbent fleet transport — its plane binding is not probe-observable', async () => {
+        test.setTimeout(60000);
+
+        if ((await probeFleetEndpoint(8083)).status !== 'free') {
+            test.skip(true, 'the default fleet endpoint is occupied on this machine — the no-adoption witness needs to own it');
+            return
+        }
+
+        const incumbent = await startFleetBridgeServer(authenticatedOptions({port: 8083}));
+
+        try {
+            const result = await new Promise(resolve => {
+                const child = spawn(process.execPath, [path.join(repoRoot, 'buildScripts/devCockpit.mjs'), '--live'], {
+                    cwd: repoRoot,
+                    env: {
+                        ...process.env,
+                        NEO_FLEET_PLANE_BASE   : 'http://127.0.0.1:3102',
+                        NEO_FLEET_PLANE_BEARER : 'dummy-token',
+                        NEO_COCKPIT_WEBPACK_CMD: JSON.stringify([process.execPath, '-e', 'console.log("WEBPACK_STUB_STARTED"); setInterval(() => {}, 1000)'])
+                    },
+                    stdio: ['ignore', 'pipe', 'pipe']
+                });
+
+                let output = '';
+                child.stdout.on('data', chunk => output += chunk);
+                child.stderr.on('data', chunk => output += chunk);
+                child.on('exit', code => resolve({code, output}))
+            });
+
+            // The plane probe may refuse first on machines without a serving plane — both refusals
+            // are fail-closed before any page; the witness pins the no-adoption reason when the
+            // plane half passed (fixture-free: the probe result decides which refusal surfaced).
+            expect(result.code).toBe(1);
+            expect(result.output).toContain('[cockpit:live] REFUSED');
+            expect(result.output).not.toContain('WEBPACK_STUB_STARTED');
+
+            if (result.output.includes('already serves a fleet transport')) {
+                expect(result.output).toContain('plane binding is not observable');
+                expect(result.output).toContain('npm run cockpit')
+            }
+        } finally {
+            await new Promise(resolve => incumbent.close(resolve))
+        }
     })
 });

--- a/test/playwright/unit/ai/buildScripts/devCockpit.spec.mjs
+++ b/test/playwright/unit/ai/buildScripts/devCockpit.spec.mjs
@@ -369,6 +369,39 @@ test.describe('buildScripts/devCockpit — the live-plane journey (cockpit:live)
         }
     });
 
+    test('resolveLivePlaneConfig: the gh fallback is COUPLED to a loopback destination — a pinned remote or unreadable base with no explicit bearer refuses, gh never consulted', async () => {
+        // The axis that decides trust is the HOST, not the port: every pre-existing witness varies
+        // the port on loopback; this one pins the dangerous field. gh is a throwing seam — reaching
+        // it at all is the failure being guarded.
+        for (const base of ['https://plane.example.internal', 'not-a-url']) {
+            const resolved = await resolveLivePlaneConfig({
+                env        : {NEO_FLEET_PLANE_BASE: base},
+                readGhToken: async () => { throw new Error('the gh seam must never run for a non-loopback base without an explicit bearer') }
+            });
+
+            expect(resolved.refuse, base).toBe(true);
+            expect(resolved.planeBearer, base).toBe('');
+            expect(resolved.bearerSource, base).toBe(null);
+            expect(resolved.notes.at(-1), base).toContain('REFUSED');
+            expect(resolved.notes.at(-1), base).toContain('non-loopback');
+            expect(resolved.notes.at(-1), base).toContain('NEO_FLEET_PLANE_BEARER');
+            expect(resolved.notes.at(-1), base).toContain('canonical local journey')
+        }
+    });
+
+    test('resolveLivePlaneConfig: a pinned remote base with an EXPLICIT bearer proceeds — the credential decision matches the destination decision', async () => {
+        // The gate couples the IMPLICIT fallback only: an explicit credential is an explicit
+        // decision, valid for any destination the operator pins.
+        const resolved = await resolveLivePlaneConfig({
+            env        : {NEO_FLEET_PLANE_BASE: 'https://plane.example.internal', NEO_FLEET_PLANE_BEARER: 'explicit-remote-token'},
+            readGhToken: async () => { throw new Error('the gh seam must not run when the env pins the bearer') }
+        });
+
+        expect(resolved.refuse).toBe(false);
+        expect(resolved.planeBearer).toBe('explicit-remote-token');
+        expect(resolved.bearerSource).toBe('env')
+    });
+
     test('resolveLivePlaneConfig: all-three-empty refuses with the remediation — and no resolved value ever reaches the notes', async () => {
         const resolved = await resolveLivePlaneConfig({env: {}, readGhToken: async () => ''});
 


### PR DESCRIPTION
Resolves #17276

One command — `npm run cockpit:live` — now boots the supervised cockpit against the LIVE containerized plane. The launcher resolves the plane binding itself (base: `NEO_FLEET_PLANE_BASE` else the canonical local plane; bearer: direct env, else the declared secret file, else `gh auth token` — the same identity the viewer claim resolves through), probes the plane's ingress unauthenticated (the auth guard's 401 IS the identity signature), refuses named and pre-spawn on every failure branch, and injects the binding into the fleet child's env only — never the webpack child, never a log line. The zero-setup `npm run cockpit` journey is byte-identical without the flag. Live evidence run from this seat: zero env hand-assembly, plane-bound boot with the viewer verified plane-side, presence cross-checked against `who_is_online` at capture time, and the activity stream showing this morning's real A2A — including this lane's own claim.

Evidence: L3 (live non-destructive probe — the real canonical plane, the real launcher, headless-Chromium cockpit render) → L3 required (close-target AC1–AC9, all live-probe satisfiable). Residual: the parent-level operator-witnessed L1 beat (#17271 AC5), Residual-Owner: #17271.

## Deltas from ticket

None substantive — the ticket's Contract Ledger shipped as written. One intake-recorded adjacent debt stays deliberately untouched: `devFleetServer` reads only the direct `fleet.planeBearer` leaf (the file indirection resolves only in the composed server); the launcher's file branch materializes the value into the fleet child's direct env channel, so the journey is unblocked and the entry-level gap is recorded on #17271 for its own owner.

## Test Evidence

- `UNIT_TEST_MODE=true npx playwright test -c test/playwright/playwright.config.unit.mjs test/playwright/unit/ai/buildScripts/devCockpit.spec.mjs` → 20/20 green — 9 new live-journey witnesses: resolution precedence + fail-closed refusals, the probe signature matrix (401 = plane / 200-ok ≠ / closed = unreachable with remediation), the custody rule, and three composed runs through the real launcher (file-pinned bearer materializing into the FLEET child while the webpack child provably never sees it; unreachable-plane fail-fast before any page; never-adopt-an-incumbent).
- `lintNpmScriptEntrypoints.spec.mjs` → 8/8 green (the `cockpit:live` entry resolves; the real-tree pin holds).
- Live run receipts (this seat, `node buildScripts/devCockpit.mjs --live`, zero hand-assembly):
  - Boot: `[cockpit:live] plane bearer resolved from gh auth token` → `[fleet] mailbox/compose/catch-up seams bound to the containerized plane at http://127.0.0.1:3102 (viewer @neo-kimi-iris verified plane-side; host graph not consulted)`.
  - Presence: roster wire row `presence: {state: 'dark', confidence: 'observed', lastSeenAt: 2026-08-16T23:21:51.262Z}` on the real card — cross-checked against `who_is_online` at capture time (same identity, same `dark` verdict, same last-write timestamp, `turnPresence: null`). The deployed plane serves `9f38f6a2e6` (pre-#17249): the surface under-reports an active mid-turn seat as dark — the known inversion, merged but not deployed; its improvements are keyed to the operator's redeploy, not claimed here.
  - Activity: the stream showed `07:31 A2A [pr-opened][PR #17273…]` (3 min before capture), `07:09 LANE [lane-claim][#17271]…` (this lane's own claim), `06:56 A2A [review-capacity…]` — all matching the mailbox trail; zero seeded rows in live mode.
  - Wake: the telltale rendered `wake stream disconnected (not started) — poll remains the truth lane` — the honest not-armed lane, no fleet-surface credential declared.
  - Screenshots (receipt files): the empty-registry state renders the LABELLED static roster (`Fleet data unavailable — showing the static roster · server connected · fleet registry empty`); after registering this seat as a real row, one real card, zero sample rows.
- Surface map: `buildScripts/devCockpit.mjs`: devCockpit.spec 20/20 · `package.json`: entrypoint lint 8/8 · `learn/agentos/RunningTheFleetCockpit.md`: doc-only, no spec surface · `apps/agentos`: untouched (no app-side change — intake evidence found the roster/stream admission paths already honest for populated registries, and the empty-registry state labelled, not masked).

## Post-Merge Validation

- [ ] Operator runs `npm run cockpit:live` on the canonical machine (his populated registry, the same zero-wiring journey) — the #17271 AC5 L1 beat; receipts land on #17271.

Residual-Owner: #17271

## Commits

- `87e6f0353b` — the `--live` journey (resolution seam, plane probe, custody helper), 9 witnesses, runbook section, npm script

Authored by Iris (Kimi K3, Kimi Code CLI). Session 0c5a1cf3-093b-4e9d-a7ba-74137e4d4f23.
