### PR TITLE
fix(ai): a degraded lane-landscape census reports unknown counts, never zero ones

### DIFF
--- a/ai/mcp/server/memory-core/openapi.yaml
+++ b/ai/mcp/server/memory-core/openapi.yaml
@@ -970,8 +970,12 @@ paths:
                     properties:
                       assignedCount:
                         type: integer
+                        nullable: true
+                        description: "null when the census is degraded — a count over an incomplete set is an unknown wearing a number. Never read a null as 0."
                       unassignedCount:
                         type: integer
+                        nullable: true
+                        description: "null when the census is degraded. `unassignedIds` still lists what WAS seen; its length is a floor, not this count."
                       unassignedIds:
                         type: array
                         description: Unassigned per the SOURCE's own assignee/author evidence — never inferred from a local store's silence.
@@ -980,10 +984,15 @@ paths:
                   coverage:
                     type: object
                     description: "Census completeness. A degraded census means the narrative is withheld rather than served partial."
-                    required: [totalOpenItems, edgeCount, degraded, degradedReasons]
+                    required: [totalOpenItems, observedOpenItems, edgeCount, degraded, degradedReasons]
                     properties:
                       totalOpenItems:
                         type: integer
+                        nullable: true
+                        description: "null whenever `degraded` is true — a TOTAL is a completeness claim, and completeness is the exact thing a degraded census failed to establish. Do not coerce: `null > 0` is false, so a `> 0` guard on a degraded census silently concludes the backlog is empty. Branch on `degraded`, or read `observedOpenItems`."
+                      observedOpenItems:
+                        type: integer
+                        description: "What the census actually saw — always a number, and a FLOOR rather than a total. A partial read keeps its value here instead of being flattened away with the completeness claim it cannot make."
                       edgeCount:
                         type: integer
                       degraded:

--- a/ai/services/graph/laneLandscapeProjection.mjs
+++ b/ai/services/graph/laneLandscapeProjection.mjs
@@ -182,7 +182,8 @@ export function projectLaneLandscape({items = [], edges = [], now, degraded = fa
     // this keys on identity — which is the honest fingerprint for a STRUCTURAL view: an edited body
     // does not change the landscape, while a state change removes the item from the census and moves
     // the hash.
-    const sourceManifestHash = hashSourceManifest(citations);
+    const sourceManifestHash = hashSourceManifest(citations),
+          isDegraded         = degraded === true;
 
     return Object.freeze({
         capturedAt       : capturedDate.toISOString(),
@@ -191,14 +192,40 @@ export function projectLaneLandscape({items = [], edges = [], now, degraded = fa
         citations        : Object.freeze(citations.map(citation => Object.freeze(citation))),
         sourceManifestHash,
         authorityCoverage: Object.freeze({
-            assignedCount  : assignedIds.length,
-            unassignedCount: unassignedIds.length,
+            // `null` under degradation, never 0 — see the coverage block below. A count of an
+            // incomplete set is not a smaller true count; it is an unknown wearing a number.
+            assignedCount  : isDegraded ? null : assignedIds.length,
+            unassignedCount: isDegraded ? null : unassignedIds.length,
+            // The IDS stay: they are what the census DID see, which is a floor rather than a claim,
+            // and dropping them would discard the only usable half of a partial read.
             unassignedIds  : Object.freeze([...unassignedIds].sort())
         }),
         coverage: Object.freeze({
-            totalOpenItems: openItems.length,
-            edgeCount     : relEdges.length,
-            degraded      : degraded === true,
+            /**
+             * `null` whenever the census is degraded. **A degraded census cannot report a total by
+             * definition** — "total" is a completeness claim, and completeness is the exact thing
+             * that failed.
+             *
+             * This is not pedantry; it is the defect this field carried. When the plane holds no
+             * GitHub credential every page read fails, and the projection emitted
+             * `totalOpenItems: 0` beside `degraded: true` — the same shape a genuinely empty
+             * backlog produces. Suppressing the narrative synthesis (which this already did) only
+             * covered half of it: the census numbers stayed confidently populated with zeros, so a
+             * caller that read the count without branching on the flag learned "there is no work"
+             * from a tool whose real answer was "I could not look". For a next-lane engine that is
+             * the worse direction of error — it does not misroute a seat, it reports no lanes.
+             *
+             * `null` is unreadable as a quantity, so the flag can no longer be skipped by accident.
+             */
+            totalOpenItems: isDegraded ? null : openItems.length,
+            /**
+             * What the census actually saw, always truthful and always a number — a FLOOR, not a
+             * total. Partial reads keep their value here rather than being flattened to `null`
+             * along with the completeness claim they cannot make.
+             */
+            observedOpenItems: openItems.length,
+            edgeCount        : relEdges.length,
+            degraded         : isDegraded,
             // The provenance of the degradation: a caller must be able to see WHICH part of the
             // picture is missing, not merely that some part is.
             degradedReasons: Object.freeze(Array.isArray(degradedReasons) ? [...degradedReasons] : [])

--- a/ai/services/graph/laneLandscapeSynthesis.mjs
+++ b/ai/services/graph/laneLandscapeSynthesis.mjs
@@ -47,6 +47,22 @@ export function selectLandscapeSynthesisInputIds(landscape = {}) {
  * @param {Object} params.landscape A projected current-state landscape.
  * @returns {String} The prompt.
  */
+/**
+ * @summary Renders a census count for the prompt, keeping "I could not look" distinct from "zero".
+ *
+ * A degraded census reports `null` counts because a total is a completeness claim it cannot make.
+ * Rendering that as `0` would hand a model a fabricated fact in the one section of the prompt it is
+ * told to treat as ground truth ("use ONLY the structure above"), and the model has no way to tell
+ * an absent measurement from a measured absence. The word does what the `null` does: it cannot be
+ * read as a quantity.
+ *
+ * @param {Number|null|undefined} value A census count, or `null` when the census was degraded.
+ * @returns {String|Number} The count, or an explicit unknown marker.
+ */
+function countForPrompt(value) {
+    return typeof value === 'number' ? value : 'unknown (census degraded — not zero)'
+}
+
 export function buildLaneLandscapeSynthesisPrompt({landscape} = {}) {
     const goal      = landscape?.goalTrajectory || [],
           blocked   = landscape?.dependencyPath || [],
@@ -72,11 +88,18 @@ export function buildLaneLandscapeSynthesisPrompt({landscape} = {}) {
         ...blockedLines,
         '',
         'AUTHORITY COVERAGE:',
-        `- assigned: ${authority.assignedCount ?? 0}`,
-        `- unassigned: ${authority.unassignedCount ?? 0}${(authority.unassignedIds || []).length > 0 ? ` (${authority.unassignedIds.join(', ')})` : ''}`,
+        // `?? 0` here would be the projection's own defect one layer lower and pointed at a MODEL:
+        // a degraded census now reports `null` counts (a total is a completeness claim it cannot
+        // make), and coercing that to `0` would write "assigned: 0" into a prompt as fact. The
+        // caller skips synthesis entirely while degraded, so this is unreachable through
+        // `exploreLaneLandscape` — but the builder is exported and its spec calls it directly, so
+        // the honest rendering is what belongs here rather than a default that only stays correct
+        // while an upstream guard holds.
+        `- assigned: ${countForPrompt(authority.assignedCount)}`,
+        `- unassigned: ${countForPrompt(authority.unassignedCount)}${(authority.unassignedIds || []).length > 0 ? ` (${authority.unassignedIds.join(', ')})` : ''}`,
         '',
         'CENSUS COVERAGE:',
-        `- total open items: ${coverage.totalOpenItems ?? 0}`,
+        `- total open items: ${countForPrompt(coverage.totalOpenItems)}`,
         `- relation edges: ${coverage.edgeCount ?? 0}`,
         '',
         'Write a concise structural description across three dimensions: goal trajectory, dependency /',

--- a/test/playwright/unit/ai/services/graph/laneLandscapeProjection.spec.mjs
+++ b/test/playwright/unit/ai/services/graph/laneLandscapeProjection.spec.mjs
@@ -217,7 +217,8 @@ test.describe('laneLandscapeProjection — current-state lane landscape', () => 
             now
         });
 
-        expect(result.coverage).toEqual({totalOpenItems: 2, edgeCount: 1, degraded: false, degradedReasons: []});
+        // A complete census is the one case where the total IS knowable, so both fields carry it.
+        expect(result.coverage).toEqual({totalOpenItems: 2, observedOpenItems: 2, edgeCount: 1, degraded: false, degradedReasons: []});
         expect(result.authorityCoverage.unassignedIds).toEqual(['issue-1']);
         expect(result.dependencyPath).toEqual([{id: 'issue-1', blockedBy: ['issue-2']}]);
     });
@@ -235,8 +236,12 @@ test.describe('laneLandscapeProjection — current-state lane landscape', () => 
         });
 
         expect(result.coverage.degraded).toBe(true);
-        // the partial evidence still surfaces — labelled incomplete rather than discarded
-        expect(result.coverage.totalOpenItems).toBe(1);
+        // the partial evidence still surfaces — labelled incomplete rather than discarded — but as a
+        // FLOOR, not a total: the walk stopped at a bound, so "1" is what was seen and the real
+        // total is unknown. Reporting it as `totalOpenItems` would be the clipped read claiming
+        // completeness it explicitly failed to prove.
+        expect(result.coverage.observedOpenItems).toBe(1);
+        expect(result.coverage.totalOpenItems).toBeNull();
         // and it says WHICH part is missing: a degraded flag without its reason is only half-honest
         expect(result.coverage.degradedReasons).toEqual(['open issues: walk stopped at the bound']);
     });
@@ -266,10 +271,30 @@ test.describe('laneLandscapeProjection — current-state lane landscape', () => 
         });
 
         expect(result.coverage.degraded).toBe(true);
-        expect(result.coverage.totalOpenItems).toBe(0);
         expect(result.goalTrajectory).toEqual([]);
         expect(result.notAuthority).toBe(true);
         // the failure names itself rather than presenting as an empty landscape
         expect(result.coverage.degradedReasons.join(' ')).toContain('graphql down');
+
+        // THE defect, asserted directly. This line previously read `toBe(0)` — directly beneath the
+        // comment above claiming the landscape does not present as empty, while asserting the exact
+        // shape an empty one produces. A caller that reads a count without branching on `degraded`
+        // could not tell "no open work" from "the census could not run", and for a next-lane engine
+        // that is the worse direction: it reports no lanes rather than the wrong lane.
+        expect(result.coverage.totalOpenItems).toBeNull();
+        expect(result.authorityCoverage.assignedCount).toBeNull();
+        expect(result.authorityCoverage.unassignedCount).toBeNull();
+        // observed stays a real number — zero items were genuinely seen, which is true and useful
+        expect(result.coverage.observedOpenItems).toBe(0);
+
+        // The property that matters, stated as the contract rather than as three field assertions:
+        // no count in a degraded landscape may be read as a quantity.
+        const counts = [
+            result.coverage.totalOpenItems,
+            result.authorityCoverage.assignedCount,
+            result.authorityCoverage.unassignedCount
+        ];
+
+        expect(counts.every(value => typeof value !== 'number')).toBe(true);
     });
 });


### PR DESCRIPTION
Resolves #17278

The unconditional half of #17278. `explore_lane_landscape` — the fleet's next-lane engine, which every seat reads at boot — returned a payload indistinguishable from an empty backlog whenever its census could not run.

Evidence: L2 (the projection, the prompt-builder and the published response schema all exercised directly, including the exact degraded shape the live tool produced this morning) → L2 required (the AC is "can a caller read a quantity out of an unknown", answerable in-process). Residual: none.

## Deltas from ticket

- **The published response schema is in scope**, added at review time. `openapi.yaml` declared the three counts as `type: integer`, required, and did not declare `observedOpenItems` at all — so the payload stopped lying while the contract describing it kept doing so. That channel is the one consuming agents read *instead of* the payload. @neo-opus-grace found it by checking that the file was absent from the diff rather than assuming the schema rode along.
- **The credential fork is now its own leaf, #17283**, also at review time: `Resolves #17278` closes its target on merge regardless of a body saying the ticket stays open, so the undelivered half could not live under this close-target. #17278 is re-scoped to the payload half, which this PR fully delivers, and now carries a Contract Ledger.
- **The synthesis prompt builder is in scope**, which the ticket did not name. It coerced these counts with `?? 0`, so once `null` became possible it would have written a fabricated count into a **model prompt** — in the one section the prompt instructs the model to treat as ground truth. Unreachable today (the caller skips synthesis while degraded) and fixed anyway, because a default that is only correct while an upstream guard holds is the next defect.
- Otherwise none substantive.

## What was wrong

The live return, this morning, from a seat picking its first lane:

```json
{"coverage":{"totalOpenItems":0,"edgeCount":3,"degraded":true,
  "degradedReasons":["open issues: page 1 failed (Could not authenticate with GitHub…)"]},
 "authorityCoverage":{"assignedCount":0,"unassignedCount":0,"unassignedIds":[]},
 "synthesis":{"available":false,"unavailableReason":"coverage-degraded"}}
```

Nothing there is a lie. `degraded` is true, the reasons are specific and correct, and the narrative is honestly suppressed. **But every count is `0`** — the same shape a real empty backlog produces. Branch on `degraded` and you are fine; read `totalOpenItems` and you are told there is no work.

Suppressing synthesis was the right instinct and shows the shape was considered. It covered the narrative half and left the census numbers confidently populated.

## What changed

`totalOpenItems`, `assignedCount`, `unassignedCount` → **`null` whenever degraded**. A total is a completeness claim, and completeness is precisely what failed. `null` cannot be read as a quantity, so the flag can no longer be skipped by accident.

`observedOpenItems` added, **always a real number** — a floor, not a total. A clipped-but-successful walk keeps its value instead of being flattened away along with the claim it cannot make. `unassignedIds` stays for the same reason: what the census *did* see is evidence, not an assertion about what it missed.

## The assertion that was the defect

```js
expect(result.coverage.degraded).toBe(true);
expect(result.coverage.totalOpenItems).toBe(0);          // ← this
// the failure names itself rather than presenting as an empty landscape
```

The comment claims the landscape does not present as empty. The line directly above it asserts the exact shape an empty one has. It now asserts `toBeNull()`, plus a property-level check that **no** count in a degraded landscape is a `number` — so a future field cannot reintroduce the class by being added without thought.

## What this PR deliberately does NOT do

**#17283** — no container in the local plane holds a GitHub credential — measured, not inferred:

| container | `GH_TOKEN` | `GITHUB_TOKEN` | `gh` binary |
|---|---|---|---|
| `mc-server` | unset | unset | **absent** |
| `orchestrator` | unset | unset | — |
| `kb-server` | unset | unset | — |
| `fleet-server` | unset | unset | — |

All three branches of `GraphqlService.#getAuthToken()` therefore fail by construction. Whether that is a bug or the intended posture is a **genuine architectural fork** — the plane may be deliberately credential-free — and it belongs to whoever owns the plane's outbound stance, not to this PR. It is filed as **#17283** and is not a close-target here.

The split is the point: this half is correct under **either** answer. If a credential is wired, a transient GitHub outage still produces the degraded path, and it must not report an empty backlog then either.

## Test Evidence

- `npm run test-unit -- test/playwright/unit/ai/services/graph test/playwright/unit/ai/mcp` → **1138 passed**. The single failure, `McpServersHealth` / neural-link boot, is **pre-existing**: verified as a control by running that spec against clean `origin/dev` with none of this diff applied, where it fails identically.
- `lint-openapi-service-parity` → PASS; `lint-identity-vocabulary` → PASS.
- Schema verified by **parsing** the document rather than reading the diff: the three counts resolve `type=integer nullable=true`, `observedOpenItems` resolves `nullable=false` and is in `required`, `edgeCount` stays non-nullable.
- Three pre-existing specs failed against the change before being updated — they encoded the old shape, and one of them *was* the defect (above). Stated rather than folded in silently: the diff changes assertions, and a reviewer should know which and why.
- Diagnosis commands, re-runnable: `docker exec neo-local-agent-os-mc-server-1 sh -c 'command -v gh; echo $GH_TOKEN'` and `GraphqlService.mjs:127-149` for the three-branch resolution.

## Post-Merge Validation

None — every claim is settled by pure-function specs plus a parsed-schema check. The credential fork is tracked on #17283 and is not a deferral of anything this PR claims.

Authored by Ada (Claude Opus 5, Claude Code). Session 80b326bf-b37a-4efd-8313-1a9eae09e9c4.

⚖️ **Ada** · `@neo-opus-ada` · Claude Opus 5 · Claude Code
