### PR TITLE
fix(fleet): arm the dev plane credential through the assert variant (#17286)

### DIFF
--- a/ai/services/fleet/devFleetServer.mjs
+++ b/ai/services/fleet/devFleetServer.mjs
@@ -55,8 +55,8 @@ import {startFleetBridgeServer} from './fleetBridgeServer.mjs';
 import {probeExistingFleetServer, resolveFleetBearer, resolveFleetViewer,
         resolveFleetViewerClaim}                                          from './fleetLaunchContract.mjs';
 import {assertFleetPlaneAdmissionBearerClass,
-        assertFleetViewerMcAuthorizationClass,
-        resolveFleetPlaneBearer}                                                from './fleetServer.mjs';
+        assertFleetPlaneBearerClass,
+        assertFleetViewerMcAuthorizationClass}                            from './fleetServer.mjs';
 import {createPlaneMailboxClient}             from './planeMailboxClient.mjs';
 import {createPlaneWakeIdentitiesReader,
         createPlaneWakeObservationsReader}                               from './planeWakeIdentitiesReader.mjs';
@@ -97,12 +97,13 @@ async function boot() {
     //    decision — refusal is the only honest outcome.
     //  - in-process mode: the existing host-graph verification (seeded AgentIdentity node).
     const planeBase = AiConfig.fleet.planeBase.trim(),
-          // The credential resolves through the sanctioned two-home read (direct value, else the
-          // declared secret file): the dev entry is a Fleet entry, so the file custody class the
-          // leaf documents holds on this journey too — never the direct leaf alone.
+          // The credential arms through the ASSERT variant — matching the composed server's call
+          // site for this same credential, so the two-home custody split AND the credential-class
+          // non-alias teeth arrive together: a bearer aliasing the deployment's admission token
+          // fails this boot exactly as in production. Never the direct leaf alone.
           planeClient = planeBase ? createPlaneMailboxClient({
               baseUrl   : `${planeBase.replace(/\/+$/, '')}/mc/mcp`,
-              credential: resolveFleetPlaneBearer()
+              credential: assertFleetPlaneBearerClass()
           }) : null;
 
     let

--- a/ai/services/fleet/fleetServer.mjs
+++ b/ai/services/fleet/fleetServer.mjs
@@ -632,6 +632,10 @@ export async function createFleetServerApp({
  * compose secret, and a credential does not belong in an env literal). Returns `''` when
  * neither yields a value — the caller decides whether that is an honest unarmed state or a
  * refused boot.
+ *
+ * Call sites ARMING a plane credential use the assert variant ({@link assertFleetPlaneBearerClass})
+ * so the credential-class teeth arrive with the resolution; this bare form is for comparison
+ * operands that need the value itself.
  * @param {Object} [options]
  * @param {Object} [options.aiConfig=AiConfig] Resolved Tier-1 config tree.
  * @param {Function} [options.readFile] Injection seam for tests; defaults to `readFileSync`.

--- a/test/playwright/unit/ai/services/fleet/resolveFleetPlaneBearer.spec.mjs
+++ b/test/playwright/unit/ai/services/fleet/resolveFleetPlaneBearer.spec.mjs
@@ -4,16 +4,17 @@ import os              from 'node:os';
 import path            from 'node:path';
 import {fileURLToPath} from 'node:url';
 
-import {resolveFleetPlaneBearer} from '../../../../../../ai/services/fleet/fleetServer.mjs';
+import {assertFleetPlaneBearerClass, resolveFleetPlaneBearer} from '../../../../../../ai/services/fleet/fleetServer.mjs';
 
 const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../../../../../..');
 
 /**
- * The two-home plane-bearer contract the dev fleet entry now consumes: direct value wins, the
+ * The two-home plane-bearer contract the dev fleet entry consumes: direct value wins, the
  * declared secret file materializes otherwise, and every empty/unreadable path resolves `''` so
  * the caller's own fail-closed admission owns the refusal. Plus the consuming-site ratchet: the
- * dev entry builds its plane client THROUGH this resolver — never by reading the direct leaf —
- * so the documented file indirection cannot silently go inert on the dev journey again.
+ * dev entry arms its plane client through the ASSERT variant — never by reading the direct leaf,
+ * never by the bare resolver — so the file indirection and the credential-class teeth are both
+ * pinned against regressions at the consuming site (source-form pins, not a behavior proof).
  */
 test.describe('resolveFleetPlaneBearer — the two-home plane credential contract', () => {
     const config = ({direct = '', file = ''} = {}) => ({fleet: {planeBearer: direct, planeBearerFile: file}});
@@ -52,32 +53,88 @@ test.describe('resolveFleetPlaneBearer — the two-home plane credential contrac
         expect(resolveFleetPlaneBearer({aiConfig: config()})).toBe('')
     });
 
-    test('the REAL config tree honors the file the leaf documents — end-to-end through the default AiConfig binding', () => {
-        // Not a mock: the resolver's default aiConfig is the real tree, so this proves the leaf
-        // names the file indirection reads. Env is scrubbed by the UNIT_TEST_MODE construction;
-        // the direct leaf stays empty on a stock checkout, so the file half is the only branch
-        // a hermetic spec can drive — through the readFile seam, against the real leaf paths.
+    test('the default readFileSync seam materializes the file the leaf documents — no injected reader', () => {
+        // Proves the DEFAULT file seam (readFile: null → the real readFileSync), not just the
+        // injection path: a minimal tree carrying the REAL leaf names, a real file on disk.
         const dir  = fs.mkdtempSync(path.join(os.tmpdir(), 'plane-bearer-')),
               file = path.join(dir, 'token');
 
         fs.writeFileSync(file, 'real-tree-file-token\n');
 
-        // The live binding is env-driven; rather than mutating shared config (forbidden), assert
-        // the resolver against a minimal tree carrying the REAL leaf names — the shape the real
-        // tree answers with, keyed by the same properties the leaf declares.
         const resolved = resolveFleetPlaneBearer({
             aiConfig: {fleet: {planeBearer: '', planeBearerFile: file}},
-            readFile: null // the real readFileSync — proves the default seam, not just the injection
+            readFile: null
         });
 
         expect(resolved).toBe('real-tree-file-token')
     });
+});
 
-    test('ratchet: the dev fleet entry constructs its plane client THROUGH the resolver — never the direct leaf', () => {
+/**
+ * The credential-class ledger's teeth at the arming site: the assert variant resolves through the
+ * same two-home read, then refuses a bearer that aliases the deployment's bootstrap/healthcheck
+ * admission token — the refusal production has and the dev journey must match. `''` early when
+ * nothing resolves, so the tokenless path is preserved byte-for-byte; a missing or unreadable
+ * admission file disables the comparison, never the resolution.
+ */
+test.describe('assertFleetPlaneBearerClass — the credential-class non-alias teeth', () => {
+    const config = ({direct = '', file = '', admissionFile = ''} = {}) => ({
+        fleet: {planeBearer: direct, planeBearerFile: file, admissionTokenFile: admissionFile}
+    });
+
+    test('a bearer aliasing the admission token throws the named ledger refusal', () => {
+        expect(() => assertFleetPlaneBearerClass({
+            aiConfig: config({direct: 'shared-token', admissionFile: '/deploy/secrets/admission'}),
+            readFile: target => {
+                expect(target).toBe('/deploy/secrets/admission');
+                return 'shared-token\n'
+            }
+        })).toThrow(/credential-class ledger forbids that aliasing/)
+    });
+
+    test('distinct bearer + admission token passes through the resolved bearer', () => {
+        const resolved = assertFleetPlaneBearerClass({
+            aiConfig: config({direct: 'plane-token', admissionFile: '/deploy/secrets/admission'}),
+            readFile: () => 'admission-token\n'
+        });
+
+        expect(resolved).toBe('plane-token')
+    });
+
+    test('an unreadable admission file disables the COMPARISON, never the resolution', () => {
+        const resolved = assertFleetPlaneBearerClass({
+            aiConfig: config({direct: 'plane-token', admissionFile: '/deploy/secrets/gone'}),
+            readFile: () => { throw new Error('ENOENT') }
+        });
+
+        expect(resolved).toBe('plane-token')
+    });
+
+    test('no admission file declared disables the comparison', () => {
+        const resolved = assertFleetPlaneBearerClass({
+            aiConfig: config({direct: 'plane-token'}),
+            readFile: () => { throw new Error('must not be consulted without an admission file') }
+        });
+
+        expect(resolved).toBe('plane-token')
+    });
+
+    test('nothing resolves returns empty EARLY — the tokenless path never touches the comparison', () => {
+        const resolved = assertFleetPlaneBearerClass({
+            aiConfig: config({admissionFile: '/deploy/secrets/admission'}),
+            readFile: () => { throw new Error('must not be consulted when nothing resolved') }
+        });
+
+        expect(resolved).toBe('')
+    });
+
+    test('ratchet: the dev fleet entry arms its plane client through the ASSERT variant — never the direct leaf, never the bare resolver', () => {
         const source = fs.readFileSync(path.join(repoRoot, 'ai/services/fleet/devFleetServer.mjs'), 'utf8');
 
-        expect(source).toContain('resolveFleetPlaneBearer');
-        // the gap this ticket closes: the direct-leaf credential read at the construction site
-        expect(source).not.toMatch(/credential:\s*AiConfig\.fleet\.planeBearer\b/)
+        expect(source).toContain('assertFleetPlaneBearerClass');
+        // the gaps this ticket line closes, pinned as source forms: the direct-leaf credential
+        // read, and the teeth-free bare-resolver arm
+        expect(source).not.toMatch(/credential:\s*AiConfig\.fleet\.planeBearer\b/);
+        expect(source).not.toMatch(/credential:\s*resolveFleetPlaneBearer\(/)
     });
 });


### PR DESCRIPTION
Resolves #17286

The follow-up to the merged #17282, per @neo-opus-vega's undisposed cycle-1 RA: `devFleetServer` now arms the plane-MCP credential through `assertFleetPlaneBearerClass()` — matching the composed server's call site for the identical credential (`fleetServer.mjs:930`) and the entry's own two sibling chains. The two-home custody split and the credential-class non-alias teeth now arrive together on the dev journey: a plane bearer aliasing the deployment's admission token fails this boot exactly as in production. The tokenless/in-process path is preserved byte-for-byte (the assert returns `''` early when nothing resolves). Both prose notes from the same review are folded in, plus the one-line export pointer she suggested.

Evidence: L3 (live non-destructive probe — a FILE-only boot against the real canonical plane with the assert-armed entry bound every seam plane-side, clean teardown) → L3 required (all ACs live-probe satisfiable). No residuals.

## Deltas from ticket

None substantive — the ticket shipped as written, including the two folded prose corrections (test rename to what it proves, ratchet wording to what its patterns pin) and the optional export note (`fleetServer.mjs`: arming call sites use the assert variant; the bare resolver is for comparison operands).

## Test Evidence

- `UNIT_TEST_MODE=true npx playwright test -c test/playwright/playwright.config.unit.mjs test/playwright/unit/ai/services/fleet/resolveFleetPlaneBearer.spec.mjs` → 13/13 green. New assert-variant witnesses: alias → throws the named ledger refusal; distinct pair passes; unreadable admission file disables the COMPARISON never the resolution; undeclared admission file → comparison off (seam unconsulted); nothing resolved → `''` early. The consuming-site ratchet now pins all three source forms: assert-variant present, direct-leaf read absent, bare-resolver arm absent.
- Live regression boot (this seat, real canonical plane): `NEO_FLEET_PLANE_BASE=http://127.0.0.1:3102 NEO_FLEET_PLANE_BEARER_FILE=<token-file>`, direct var unset → `mailbox/compose/catch-up seams bound to the containerized plane … viewer @neo-kimi-iris verified plane-side` → transport listening → clean SIGTERM (AC4's regression half).
- Surface map: `ai/services/fleet/devFleetServer.mjs`: process entry — live boot above is its evidence · `ai/services/fleet/fleetServer.mjs`: one JSDoc line · spec: 13/13.

## Post-Merge Validation

Nothing owed by this PR — the swap is complete at merge. Vega's cycle-1 RA is dispositioned by her re-review of this PR (review-side, not post-merge verification).

## Commits

- one commit — the identifier swap, the assert witnesses, the prose corrections, the export note

Authored by Iris (Kimi K3, Kimi Code CLI). Session 0c5a1cf3-093b-4e9d-a7ba-74137e4d4f23.
