### PR TITLE
fix(grid): restore header→cell width sync on column resize (#17289)

### DIFF
--- a/src/grid/Body.mjs
+++ b/src/grid/Body.mjs
@@ -429,12 +429,7 @@ class GridBody extends Component {
      */
     afterSetBufferColumnRange(value, oldValue) {
         if (oldValue !== undefined) {
-            let me = this;
-
-            me.skipCreateViewData = true;
-            me.updateMountedAndVisibleColumns(true);
-            me.skipCreateViewData = false;
-            me.createViewData()
+            this.refreshColumns(true)
         }
     }
 
@@ -467,17 +462,10 @@ class GridBody extends Component {
      */
     afterSetContainerWidth(value, oldValue) {
         if (value > 0) {
-            let me = this;
-
-            // updateMountedAndVisibleColumns only re-renders rows as a side effect of mountedColumns
-            // *changing*. A width-invariant region — e.g. a single-column locked-end body whose
-            // mounted range is always [0, 0] regardless of width — would otherwise never render its
-            // rows once measured. Recompute with the row render suppressed, then fire exactly one
-            // explicit createViewData (mirroring the afterSetBufferColumnRange pattern above).
-            me.skipCreateViewData = true;
-            me.updateMountedAndVisibleColumns();
-            me.skipCreateViewData = false;
-            me.createViewData()
+            // A width-invariant region — e.g. a single-column locked-end body whose mounted range is
+            // always [0, 0] regardless of width — would never render its rows once measured if we
+            // relied on the mounted-range side effect. refreshColumns() guarantees the repaint.
+            this.refreshColumns()
         }
     }
 
@@ -1442,6 +1430,34 @@ class GridBody extends Component {
 
         me.updateDepth = 2;
         me.update()
+    }
+
+    /**
+     * @summary Recomputes the mounted/visible column range and repaints the rows EXACTLY once.
+     *
+     * `mountedColumns` is used as the "did the columns change?" proxy in TWO places, and a pure
+     * width change (a column resize) satisfies neither — the mounted range stays equal, and
+     * `core.Config` only notifies on `!isEqual` while `core.Compare` deep-compares arrays:
+     *
+     * 1. {@link #updateMountedAndVisibleColumns} repaints rows only as a *side effect* of the range
+     *    changing (see {@link #afterSetMountedColumns}), so nothing renders at all.
+     * 2. {@link #createViewData} auto-detects a column change the same way; without it, `recycle`
+     *    stays true and the recycled cells keep the geometry that was just replaced.
+     *
+     * This closes both: the incidental render is suppressed, the range recomputed, and exactly one
+     * explicit `createViewData()` fired — with `force` propagated so a geometry change actually
+     * re-applies `columnPositions` instead of recycling past it.
+     * @param {Boolean} [force=false] True when column GEOMETRY changed (widths / positions), not
+     * merely the mounted range. Forwarded to both {@link #updateMountedAndVisibleColumns} and
+     * {@link #createViewData}, where it disables cell recycling.
+     */
+    refreshColumns(force = false) {
+        let me = this;
+
+        me.skipCreateViewData = true;
+        me.updateMountedAndVisibleColumns(force);
+        me.skipCreateViewData = false;
+        me.createViewData(false, force)
     }
 
     /**

--- a/src/grid/header/Toolbar.mjs
+++ b/src/grid/header/Toolbar.mjs
@@ -96,6 +96,31 @@ class Toolbar extends BaseToolbar {
     pendingScrollTarget = null
 
     /**
+     * @summary The grid body this toolbar drives — the single source of truth for header→body routing.
+     *
+     * In the multi-body architecture a grid owns up to three toolbar/body pairs, matched by
+     * {@link #layoutLock}: 'start' → `bodyStart`, 'end' → `bodyEnd`, null (center) → `body`.
+     *
+     * Consumers MUST resolve the body through this getter, never by walking the component tree:
+     * `grid.header.Wrapper` sits between a toolbar and the `grid.Container` (it owns the header
+     * region's lifecycle), so a `parent.parent.body` walk silently yields `undefined` — no throw,
+     * just a body update that stops happening.
+     * @returns {Neo.grid.Body|null}
+     */
+    get body() {
+        let {gridContainer, layoutLock} = this;
+
+        if (!gridContainer) {
+            return null
+        }
+
+        if (layoutLock === 'start') { return gridContainer.bodyStart }
+        if (layoutLock === 'end')   { return gridContainer.bodyEnd   }
+
+        return gridContainer.body
+    }
+
+    /**
      * Triggered after the mounted config got changed
      * @param {Boolean} value
      * @param {Boolean} oldValue
@@ -305,7 +330,8 @@ class Toolbar extends BaseToolbar {
     }
 
     /**
-     * @summary Derives `columnPositions` + `availableWidth` from the rendered header buttons.
+     * @summary Derives `columnPositions` + `availableWidth` from the rendered header buttons,
+     * then repaints the body rows against the new geometry (unless `silent`).
      *
      * Dynamic-width buttons are measured via LAYOUT-box metrics (`getLayoutRect()`), never
      * `getBoundingClientRect()`: this measurement races presentation windows (committed dock
@@ -317,10 +343,7 @@ class Toolbar extends BaseToolbar {
      */
     async passSizeToBody(silent = false) {
         let me              = this,
-            gridContainer   = me.gridContainer,
-            layoutLock      = me.layoutLock,
-            body            = layoutLock === 'start' ? gridContainer.bodyStart : (layoutLock === 'end' ? gridContainer.bodyEnd : gridContainer.body),
-            { items }       = me,
+            {body, items}   = me,
             columnPositions = [],
             currentX        = 0,
             hasDynamicWidth = false,
@@ -388,7 +411,12 @@ class Toolbar extends BaseToolbar {
                 availableWidth: currentX
             });
 
-            !silent && body.updateMountedAndVisibleColumns()
+            // refreshColumns(true), not updateMountedAndVisibleColumns(): we just replaced the
+            // column geometry above, and a pure width change (a column resize) leaves the mounted
+            // range [startIndex, endIndex] equal — so neither the range side effect nor
+            // createViewData's own change-detection would repaint, and the cells would keep the
+            // geometry we just discarded. `true` marks this as a geometry change.
+            !silent && body.refreshColumns(true)
         }
     }
 

--- a/src/grid/header/plugin/Resizable.mjs
+++ b/src/grid/header/plugin/Resizable.mjs
@@ -56,8 +56,11 @@ class Resizable extends BaseResizable {
                 newWidth = parseInt(dragProxy.wrapperStyle.width, 10);
 
             if (newWidth && newWidth !== owner.width) {
-                let toolbar = owner.parent,
-                    body    = toolbar?.parent?.body;
+                // Resolve the body via the toolbar's own getter, never by walking parents:
+                // `grid.header.Wrapper` sits between the toolbar and the grid.Container, so the
+                // former `toolbar.parent.body` walk yielded undefined and this live cell update
+                // silently stopped running — the header resized alone.
+                let body = owner.parent?.body;
 
                 owner.width = newWidth;
 

--- a/test/playwright/unit/grid/ColumnResizeCellSync.spec.mjs
+++ b/test/playwright/unit/grid/ColumnResizeCellSync.spec.mjs
@@ -1,0 +1,295 @@
+/**
+ * @file test/playwright/unit/grid/ColumnResizeCellSync.spec.mjs
+ * @summary Guards the header→body width-sync path used by grid column resizing.
+ *
+ * Resizing a column has to move two surfaces: the header button AND every body cell below it.
+ * Two independent links carry that, and both failed SILENTLY (no thrown error) — which is why the
+ * regression reached an operator instead of CI:
+ *
+ * 1. **Body routing.** `grid.header.plugin.Resizable#onDragMove` used to reach the body by walking
+ *    `toolbar.parent.body`. The multi-body split inserted `grid.header.Wrapper` between a toolbar
+ *    and the `grid.Container`, so that walk started yielding `undefined` and the live per-frame cell
+ *    update stopped running behind a falsy `if (body)` guard. {@link Neo.grid.header.Toolbar#body}
+ *    is now the single source of truth, and it is region-aware (locked start/end included).
+ *
+ * 2. **Repaint guarantee.** `passSizeToBody` rebuilt `columnPositions` and then relied on
+ *    `updateMountedAndVisibleColumns()`, which repaints rows only as a *side effect* of the mounted
+ *    range changing. A pure width change leaves `[startIndex, endIndex]` equal, the config never
+ *    notifies (`core.Config` gates on `!isEqual`, and `core.Compare` deep-compares arrays), so the
+ *    cells kept the geometry that had just been replaced. {@link Neo.grid.Body#refreshColumns}
+ *    makes the repaint explicit.
+ *
+ * Defect 2 was latent from the start and MASKED by defect 1 working: the live path kept cells
+ * correct, so by drop time they already matched. Each test below is written to fail if its own link
+ * is reverted — including the non-vacuity control in the repaint group, which proves the bare
+ * `updateMountedAndVisibleColumns()` really does skip the render it is being blamed for.
+ *
+ * @see Neo.grid.header.Toolbar
+ * @see Neo.grid.header.plugin.Resizable
+ * @see Neo.grid.Body
+ */
+
+import {setup} from '../../setup.mjs';
+
+setup({
+    neoConfig: {
+        allowVdomUpdatesInTests: true,
+        unitTestMode           : true,
+        useDomApiRenderer      : true,
+        useVdomWorker          : false
+    },
+    appConfig: {
+        name             : 'GridColumnResizeCellSyncTest',
+        vnodeInitialising: false
+    }
+});
+
+import {test, expect}     from '@playwright/test';
+import Neo                from '../../../../src/Neo.mjs';
+import * as core          from '../../../../src/core/_export.mjs';
+import InstanceManager    from '../../../../src/manager/Instance.mjs';
+import GridContainer      from '../../../../src/grid/Container.mjs';
+import Store              from '../../../../src/data/Store.mjs';
+import Toolbar            from '../../../../src/grid/header/Toolbar.mjs';
+import VdomHelper         from '../../../../src/vdom/Helper.mjs';
+import DomApiVnodeCreator from '../../../../src/vdom/util/DomApiVnodeCreator.mjs';
+
+/**
+ * Reads the style of the cell rendered for `dataField` in the body's first active row.
+ * Mirrors how `grid.Body#updateCellPositions` locates cells: a flat `vdom.cn` scan keyed by
+ * `cell.data.field`.
+ * @param {Neo.grid.Body} body
+ * @param {String} dataField
+ * @returns {Object|null}
+ */
+function getCellStyle(body, dataField) {
+    const row = body.items[0];
+
+    return row?.vdom.cn.find(cell => cell.data?.field === dataField)?.style || null
+}
+
+test.describe('grid.header.Toolbar#body — region-aware body routing', () => {
+    /**
+     * Method-level probe: the getter reads only `gridContainer` + `layoutLock`, so distinct sentinel
+     * objects are enough to prove WHICH body each region resolves to. A fix that hardcodes
+     * `gridContainer.body` passes the centre case and fails both locked cases here.
+     */
+    function makeToolbar(layoutLock) {
+        const toolbar = Neo.create(Toolbar, {});
+
+        toolbar.gridContainer = {
+            body     : {region: 'center'},
+            bodyStart: {region: 'start'},
+            bodyEnd  : {region: 'end'}
+        };
+
+        toolbar.layoutLock = layoutLock;
+
+        return toolbar
+    }
+
+    test('layoutLock null (centre) resolves the centre body', () => {
+        const tb = makeToolbar(null);
+
+        expect(tb.body.region).toBe('center');
+
+        tb.destroy()
+    });
+
+    test('layoutLock "start" resolves bodyStart, not the centre body', () => {
+        const tb = makeToolbar('start');
+
+        expect(tb.body.region).toBe('start');
+
+        tb.destroy()
+    });
+
+    test('layoutLock "end" resolves bodyEnd, not the centre body', () => {
+        const tb = makeToolbar('end');
+
+        expect(tb.body.region).toBe('end');
+
+        tb.destroy()
+    });
+
+    test('an unconstructed toolbar (no gridContainer) resolves null rather than throwing', () => {
+        const tb = Neo.create(Toolbar, {});
+
+        expect(tb.body).toBeNull();
+
+        tb.destroy()
+    });
+});
+
+test.describe('grid column resize — header/cell width sync', () => {
+    test.skip(!!process.env.NEO_TEST_SKIP_CI, 'bucket B: Grid tests require Playwright browsers in CI');
+
+    let grid, store;
+
+    test.beforeEach(async () => {
+        const data = [];
+
+        for (let i = 0; i < 5; i++) {
+            data.push({id: i, col1: `C1-${i}`, col2: `C2-${i}`, col3: `C3-${i}`})
+        }
+
+        store = Neo.create(Store, {
+            keyProperty: 'id',
+            data,
+            model      : {
+                fields: [
+                    {name: 'id',   type: 'Integer'},
+                    {name: 'col1', type: 'String'},
+                    {name: 'col2', type: 'String'},
+                    {name: 'col3', type: 'String'}
+                ]
+            }
+        });
+
+        // Every column carries a fixed px width on purpose: passSizeToBody then takes its pure-math
+        // path instead of awaiting getLayoutRect(), so the drop path is exercised without DOM metrics.
+        grid = Neo.create(GridContainer, {
+            appName  : 'GridColumnResizeCellSyncTest',
+            height   : 400,
+            width    : 600,
+            store,
+            rowHeight: 40,
+            columns  : [
+                {dataField: 'col1', text: 'Col 1', width: 100},
+                {dataField: 'col2', text: 'Col 2', width: 100},
+                {dataField: 'col3', text: 'Col 3', width: 100}
+            ]
+        });
+
+        await grid.initVnode();
+        grid.mounted = true;
+
+        // The single-thread unit environment has no ResizeObserver, so the body never receives its
+        // measured box and would render no rows at all. Inject ONLY those two measurements.
+        grid.body.set({
+            availableHeight: 360,
+            containerWidth : 600
+        });
+
+        // Header buttons carry `flex: 'none'` (truthy), so `passSizeToBody` always takes its
+        // `getLayoutRect()` branch — even for a fully fixed-width grid. That call needs main-thread
+        // DOM, which this environment does not have. Substitute ONLY the measurement, modelling what
+        // a browser reports for fixed-width flex-none buttons laid out in a row: everything
+        // downstream (columnPositions, the repaint, the cell styles asserted below) stays real.
+        grid.headerToolbar.getLayoutRect = async () => {
+            let x = 0;
+
+            return grid.headerToolbar.items.map(item => {
+                const rect = {height: 40, width: item.width, x, y: 0};
+
+                x += item.width;
+
+                return rect
+            })
+        };
+
+        // In production the toolbar seeds the initial geometry from `afterSetMounted`; that path
+        // does not fire here, so drive it explicitly to establish the baseline.
+        await grid.headerToolbar.passSizeToBody();
+
+        await grid.timeout(50)
+    });
+
+    test.afterEach(async () => {
+        await grid.timeout(20);
+        grid?.destroy();
+        store?.destroy()
+    });
+
+    test('REGRESSION: the header toolbar reaches its body through the Wrapper topology', () => {
+        // `owner` in grid.header.plugin.Resizable IS the header button, so evaluate both candidate
+        // expressions from exactly that subject on the real component tree.
+        const owner = grid.headerToolbar.items[0];
+
+        expect(owner.parent).toBe(grid.headerToolbar);
+
+        // The defect's precondition: a container level (grid.header.Wrapper) DOES sit between the
+        // toolbar and the grid, so the pre-multi-body `owner.parent.parent.body` walk resolves to
+        // nothing at all — silently, which is why it never raised.
+        expect(owner.parent.parent).not.toBe(grid);
+        expect(owner.parent.parent.body).toBeUndefined();
+
+        // ...while the expression the plugin now uses lands on the real body.
+        expect(owner.parent.body).toBe(grid.body)
+    });
+
+    test('CONTROL (non-vacuity): a bare updateMountedAndVisibleColumns skips the repaint when the range is unchanged', () => {
+        const {body} = grid;
+
+        let   renders                = 0;
+        const originalCreateViewData = body.createViewData;
+
+        body.createViewData = function(...args) {
+            renders++;
+            return originalCreateViewData.apply(this, args)
+        };
+
+        // Re-run with identical geometry: the mounted range cannot move, so the side effect the old
+        // drop path depended on never fires. Without this control the guard below could pass
+        // vacuously — it would not prove refreshColumns() is what makes the difference.
+        body.updateMountedAndVisibleColumns();
+
+        expect(renders).toBe(0);
+
+        body.createViewData = originalCreateViewData
+    });
+
+    test('refreshColumns repaints even when the mounted column range is unchanged', () => {
+        const {body} = grid;
+
+        let   renders                = 0;
+        const originalCreateViewData = body.createViewData;
+
+        body.createViewData = function(...args) {
+            renders++;
+            return originalCreateViewData.apply(this, args)
+        };
+
+        body.refreshColumns();
+
+        expect(renders).toBe(1);
+
+        body.createViewData = originalCreateViewData
+    });
+
+    test('REGRESSION: on drop, passSizeToBody widens the cells, not just the header', async () => {
+        const {body, headerToolbar} = grid;
+
+        expect(getCellStyle(body, 'col1').width).toBe('100px');
+        expect(getCellStyle(body, 'col2').left).toBe('100px');
+
+        // What Resizable#onDragEnd does: commit the new width onto the header button, then hand the
+        // geometry to the body.
+        headerToolbar.getColumn('col1').width = 250;
+
+        await headerToolbar.passSizeToBody();
+        await grid.timeout(20);
+
+        // The mounted range is deliberately unchanged here — that is the whole defect condition.
+        expect(body.mountedColumns).toEqual([0, 2]);
+
+        // The resized column's cells grow...
+        expect(getCellStyle(body, 'col1').width).toBe('250px');
+        // ...and every following column shifts by the same delta. Asserting the neighbour's `left`
+        // (not just the resized column's width) is what makes this a geometry check rather than a
+        // single-property one: a partial repaint would leave col2 overlapping col1.
+        expect(getCellStyle(body, 'col2').left).toBe('250px')
+    });
+
+    test('REGRESSION: shrinking a column pulls the cells back in as well', async () => {
+        const {body, headerToolbar} = grid;
+
+        headerToolbar.getColumn('col1').width = 60;
+
+        await headerToolbar.passSizeToBody();
+        await grid.timeout(20);
+
+        expect(getCellStyle(body, 'col1').width).toBe('60px');
+        expect(getCellStyle(body, 'col2').left).toBe('60px')
+    });
+});

--- a/test/playwright/unit/grid/ColumnResizeCellSync.spec.mjs
+++ b/test/playwright/unit/grid/ColumnResizeCellSync.spec.mjs
@@ -146,8 +146,8 @@ test.describe('grid column resize — header/cell width sync', () => {
             }
         });
 
-        // Every column carries a fixed px width on purpose: passSizeToBody then takes its pure-math
-        // path instead of awaiting getLayoutRect(), so the drop path is exercised without DOM metrics.
+        // Every column carries a fixed px width, so the geometry under assertion is exact arithmetic
+        // rather than whatever a layout engine rounds to.
         grid = Neo.create(GridContainer, {
             appName  : 'GridColumnResizeCellSyncTest',
             height   : 400,


### PR DESCRIPTION
Resolves #17289

Column resize moved the header and left every body cell at its old width and `left` offset. Two links had to fail for that, both silently: the resize plugin reached the body by walking `toolbar.parent.body`, an expression written before `grid.header.Wrapper` existed and never updated when that orchestrator was inserted between the toolbar and the grid — so the live per-frame cell update died behind a falsy `if (body)` guard; and the drop path relied on `mountedColumns` changing to trigger a repaint, which a pure width change never does. This introduces `grid.header.Toolbar#body` as the region-aware routing SSOT (locked start/end included) and `grid.Body#refreshColumns(force)` to make the repaint explicit instead of incidental.

Evidence: L2 (unit specs drive the real production path — `passSizeToBody` → `refreshColumns` → `createViewData` → rendered cell `style.width`/`left`; only the DOM measurement `getLayoutRect()` and the ResizeObserver box are substituted, since the single-thread unit environment has neither) → L2 required (every close-target AC is a code-path assertion, not a host-observable effect). No residuals.

## Deltas from ticket

**One substantive delta: the ticket named two short-circuits; there are three.** `mountedColumns` is the "did the columns change?" proxy in two places, not one:

1. `Body.mjs` `afterSetMountedColumns` — the side-effect repaint (the one the ticket identified).
2. `Body.mjs` `createViewData` — `if (!force && !Neo.isEqual(me.mountedColumns, me.#lastMountedColumns)) { force = true }`. With an equal range, `force` stays false, `recycle` stays **true**, and `Row#updateContent` recycles the existing cell nodes straight past the `columnPositions` that were just rebuilt.

So the first prescription — extract the suppress-then-render-once idiom and call it — would have made the render fire and still shipped the bug. `refreshColumns(force)` therefore propagates `force` to **both** consumers of the stale proxy; `passSizeToBody` passes `true` because it has just replaced the geometry.

The ticket body has been corrected to describe all three; this paragraph is the audit trail for why it changed.

Also observed, deliberately **not** fixed: header buttons carry `flex: 'none'` (truthy), so `passSizeToBody` always takes its `getLayoutRect()` measurement branch even for a fully fixed-width grid where the pure-math branch would serve. That is a possible avoidable main-thread round-trip, but it needs its own measurement before anyone calls it a defect, and it is orthogonal to this regression.

## Test Evidence

`test/playwright/unit/grid/ColumnResizeCellSync.spec.mjs` — 9 new tests, all green.

```
npm run test-unit -- test/playwright/unit/grid/     → 61 passed (includes the 9 new)
npm run test-unit                                   → 13963 passed, 2 failed
```

Both full-suite failures are pre-existing and unrelated (`ai/mcp/client/McpServersHealth.spec.mjs`, `ai/services/memory-core/TextEmbeddingService.retry.spec.mjs`). Verified as a control, not assumed: with this branch's `src/` changes stashed, the identical full-suite run reproduces both. The `TextEmbeddingService` one passes in isolation and only fails under the full run, so isolation would have laundered it into "flaky" — the control was run full-suite for exactly that reason.

**Mutation verification** — every geometry guard was confirmed to fail when its fix is reverted, three separate ways:

| Reverted to | Result |
|---|---|
| `passSizeToBody` → bare `updateMountedAndVisibleColumns()` | both cell-geometry tests FAIL |
| `refreshColumns` → `createViewData()` without `force` | both cell-geometry tests FAIL |
| whole `src/` change stashed | 7 of 9 tests FAIL |

**Non-vacuity control** ships as a test in its own right: with an unchanged mounted range, a bare `updateMountedAndVisibleColumns()` performs **zero** renders. Without it, the repaint guard could pass without proving that `refreshColumns` is what makes the difference.

The widening test also asserts `mountedColumns` is `[0, 2]` *unchanged* at the moment it checks the new cell widths — the defect condition is part of the assertion rather than an assumption.

Directly touched surfaces: `src/grid` — `test/playwright/unit/grid/` (61 passed). No `apps/**` surface touched.

## Post-Merge Validation

None owed. Every close-target AC is discharged in-branch by the guards above, so nothing is deferred past merge and no residual owner is needed. The operator who reported the symptom will naturally see it resolved on their next resize — that is confirmation of a fix already evidenced here, not an outstanding item this PR is carrying.

## Commits

- `442917d` — the fix: routing SSOT, `refreshColumns`, plugin consumes the getter, 9 guards.
- `f8fd37c` — corrects a spec comment that contradicted the `getLayoutRect` finding.

## Evolution

The first implementation extracted `refreshColumns` and called it without `force`, on the theory that a guaranteed `createViewData()` was the whole fix. The behaviour test — asserting rendered cell `width`/`left` rather than counting calls — failed against it and exposed the second `mountedColumns` short-circuit inside `createViewData` itself. A call-count assertion passes there. The guard set was rebuilt around geometry assertions for that reason, which is also why the mutation table above exercises the `force` propagation as its own revert.

Reviewer note for the routing half: no automated test drives a *real pointer drag* through `Resizable`. The topology guard asserts both candidate expressions on the real component tree — the old `owner.parent.parent.body` resolves `undefined`, the shipped `owner.parent.body` resolves the body — which pins the seam where the defect lived, but a synthetic pointer driver against a live app remains a separate coverage lane (prior art: the driver built for `#16375`).

Authored by Grace (Claude Opus 5, Claude Code). Session 6ecf4cee-7b32-4d21-86ba-e4288b897be0.
