### PR TITLE
feat(ai): refuse a starvation verdict its own consumer cannot read (#17290)

### DIFF
--- a/ai/configBase.mjs
+++ b/ai/configBase.mjs
@@ -1520,7 +1520,14 @@ class ConfigBase extends ConfigProvider {
                      * entry expiry clears it on the next check. `<= 0` disables. Consumed by
                      * `scheduling/heavyMaintenanceStarvationWatchdog.mjs`.
                      */
-                    starvationDegradeAfterMs: leaf(HOUR_MS, 'NEO_HEAVY_MAINTENANCE_LEASE_STARVATION_DEGRADE_MS', 'number')
+                    starvationDegradeAfterMs: leaf(HOUR_MS, 'NEO_HEAVY_MAINTENANCE_LEASE_STARVATION_DEGRADE_MS', 'number'),
+                    /**
+                     * Explicit override for how long a starvation RECEIPT stays consumable. Leave
+                     * unset (the default) and the bound derives from the producer's own cadence via
+                     * the `starvationReceiptStaleAfterMs` formula — see it for why the pair must be
+                     * coupled rather than tuned side by side.
+                     */
+                    starvationReceiptStaleAfterMsOverride: leaf(null, 'NEO_HEAVY_MAINTENANCE_LEASE_STARVATION_RECEIPT_STALE_MS', 'number')
                 },
                 /**
                  * Maintenance-loop intervals consumed by the orchestrator daemon.
@@ -2368,6 +2375,25 @@ class ConfigBase extends ConfigProvider {
                 data.auth.mode === 'github-pat',
             'auth.autoProvisionIdentitySources': data => data.auth.autoProvisionIdentitySourcesOverride ??
                 (['github-pat', 'gitlab-pat'].includes(data.auth.mode) ? [data.auth.mode] : []),
+            /**
+             * How long a starvation receipt stays consumable, derived from the cadence of the
+             * watchdog that STAMPS it — never from an unrelated clock.
+             *
+             * The consumer bound and the producer cadence are one decision, not two. Bounding a
+             * receipt by `deploymentStateBridge.staleAfterMs` (a bridge-WRITE staleness clock)
+             * shipped a fold that could only degrade for 2 minutes of every 10: measured on a live
+             * plane, 15 consecutive samples read healthy over an hours-long starvation before one
+             * sample caught the fresh window. The pair now moves together — re-tune the
+             * cadence and the window follows.
+             *
+             * Two cadences of tolerance: one full period plus a single missed run. Past that the
+             * receipt SHOULD go stale — a watchdog that has skipped two runs is no longer evidence
+             * about the plane, and `foldHeavyMaintenanceStarvation` correctly declines to degrade
+             * on it. The bound exists to expire a dead producer, not to widen a live one.
+             */
+            'orchestrator.heavyMaintenanceLease.starvationReceiptStaleAfterMs': data =>
+                data.orchestrator.heavyMaintenanceLease.starvationReceiptStaleAfterMsOverride ??
+                data.orchestrator.intervals.heavyMaintenanceStarvationWatchdogCheckMs * 2,
             'engines.chroma.useTestDatabase': data => data.engines.chroma.useUnitTestDatabase || data.engines.chroma.useTestHarness,
             'engines.chroma.dataDir'        : data => data.engines.chroma.useTestDatabase ? data.engines.chroma.dataDirTest : data.engines.chroma.dataDirProd,
             'engines.chroma.host'           : data => data.engines.chroma.useTestDatabase ? data.engines.chroma.hostTest    : data.engines.chroma.hostProd,

--- a/ai/daemons/orchestrator/daemon.mjs
+++ b/ai/daemons/orchestrator/daemon.mjs
@@ -34,6 +34,7 @@ import AiConfig                                                          from '.
 import Orchestrator, {rotateLogFileIfNewDay}                             from './Orchestrator.mjs';
 import {acquireAuthorityLease, AUTHORITY_LEASE_TTL_MS}                   from './authorityLease.mjs';
 import {assertAuthorityProfile, isTaskOwnedByProfile}                    from './taskAuthority.mjs';
+import {describeStarvationReceiptReachability}                           from './scheduling/heavyMaintenanceStarvationWatchdog.mjs';
 import {assertConfigFresh}                                               from '../../scripts/setup/initServerConfigs.mjs';
 import {DAEMON_EXIT_CRASH, DAEMON_EXIT_OK}                               from '../shared/daemonExit.mjs';
 import Tier1ConfigBase, {PLANE_MEMBER_PATHS as TIER1_PLANE_MEMBER_PATHS} from '../../configBase.mjs';
@@ -298,6 +299,44 @@ export function assertOrchestratorPlane({aiConfig = AiConfig, rootDir = REPO_ROO
 }
 
 /**
+ * @summary Refuses a boot whose starvation verdict would be unreadable most of the time.
+ *
+ * The watchdog restamps the receipt once per cadence; the health fold consumes it only while it is
+ * inside its freshness window. A window shorter than the cadence therefore leaves a gap in which a
+ * continuously starved plane answers `healthy` — the detector runs, the verdict is written, and
+ * almost every poll misses it. Sibling of `assertOrchestratorPlane`: a config pair that cannot
+ * mean what it claims is refused here, ahead of `startOrchestrator`, so a rejected launch writes no
+ * state directory, no PID file and no log. ticket-ref-ok: ADR-0019 §10.8 is the authority
+ * that assigns boot-time config refusal to this entrypoint rather than to a service hook.
+ *
+ * The shipped pair was 600,000ms restamped against a 120,000ms window — readable roughly a fifth of
+ * the time, through green CI and a live plane starved for days.
+ * @param {Object} [options]
+ * @param {Object} [options.aiConfig=AiConfig] Config singleton (injectable for tests).
+ * @returns {Object} The reachability descriptor, for callers that want the numbers.
+ * @throws {Error} When the consumer window is shorter than the producer cadence.
+ */
+export function assertStarvationReceiptReadable({aiConfig = AiConfig} = {}) {
+    const reachability = describeStarvationReceiptReachability({
+        checkMs     : aiConfig.orchestrator.intervals.heavyMaintenanceStarvationWatchdogCheckMs,
+        staleAfterMs: aiConfig.orchestrator.heavyMaintenanceLease.starvationReceiptStaleAfterMs
+    });
+
+    if (!reachability.reachable) {
+        throw new Error(
+            '[Orchestrator] the heavy-maintenance starvation receipt is restamped every ' +
+            `${reachability.checkMs}ms but stays consumable for only ${reachability.staleAfterMs}ms, ` +
+            `leaving ${reachability.unreadableMs}ms of every cycle in which a starved plane reports ` +
+            'healthy. Unset NEO_HEAVY_MAINTENANCE_LEASE_STARVATION_RECEIPT_STALE_MS to let the ' +
+            'derived default track the cadence, raise it to at least the cadence, or lower ' +
+            'NEO_ORCHESTRATOR_HEAVY_STARVATION_WATCHDOG_INTERVAL_MS.'
+        );
+    }
+
+    return reachability;
+}
+
+/**
  * @summary Resolves whether an orchestrator role owns graph-backed plane work.
  *
  * The data-integrity sweep is a canonical container-plane lane, so its authority
@@ -463,6 +502,7 @@ export async function bootOrchestratorCli() {
     await assertConfigFresh({requiredFindings: findings});
 
     assertAuthorityProfile(AiConfig.orchestrator.authorityProfile);
+    assertStarvationReceiptReadable();
 
     return startOrchestrator();
 }

--- a/ai/daemons/orchestrator/scheduling/heavyMaintenanceStarvationWatchdog.mjs
+++ b/ai/daemons/orchestrator/scheduling/heavyMaintenanceStarvationWatchdog.mjs
@@ -128,3 +128,44 @@ export function getDueTask({state, now, heavyMaintenanceStarvationWatchdogCheckM
 
     return null;
 }
+
+/**
+ * @summary Is the starvation verdict readable on every poll, or only just after each stamp?
+ * A receipt is restamped once per watchdog run and consumed only while inside `staleAfterMs`, so a
+ * window shorter than the cadence leaves a gap in which a continuously starved plane reports
+ * healthy — the detector fires, and almost nobody sees it. That is the unspannable-geometry class
+ * `describeMemoryWindowReachability` refuses for the memory window, arriving through a second door:
+ * a bound sized against the wrong producer rather than a window nothing can span.
+ *
+ * Shipped once as 600,000ms restamped against a 120,000ms window — readable ~20% of the time, with
+ * green CI throughout.
+ *
+ * Disabled lanes are reachable by definition: `checkMs <= 0` stops the producer, and a verdict that
+ * is never stamped cannot go unread. A disabled detector is a loud, deliberate state; a live one
+ * nobody can observe is the quiet failure this refuses.
+ * @param {Object} options
+ * @param {Number} options.checkMs Producer cadence — `intervals.heavyMaintenanceStarvationWatchdogCheckMs`.
+ * @param {Number} options.staleAfterMs Consumer window — `heavyMaintenanceLease.starvationReceiptStaleAfterMs`.
+ * @returns {{reachable: Boolean, checkMs: Number, staleAfterMs: Number, unreadableMs: Number}}
+ *   `unreadableMs` is the gap per cycle in which a stamped verdict is already stale.
+ */
+export function describeStarvationReceiptReachability({checkMs, staleAfterMs}) {
+    const finite = [checkMs, staleAfterMs].every(Number.isFinite);
+
+    if (!finite) {
+        return {reachable: false, checkMs, staleAfterMs, unreadableMs: NaN};
+    }
+
+    if (checkMs <= 0) {
+        return {reachable: true, checkMs, staleAfterMs, unreadableMs: 0};
+    }
+
+    // A window equal to the cadence is the floor, not a safe setting — it leaves zero tolerance for
+    // a late run. Equality passes; the config default buys a second cadence of slack on purpose.
+    return {
+        reachable   : staleAfterMs >= checkMs,
+        checkMs,
+        staleAfterMs,
+        unreadableMs: Math.max(0, checkMs - staleAfterMs)
+    };
+}

--- a/ai/mcp/server/memory-core/toolService.mjs
+++ b/ai/mcp/server/memory-core/toolService.mjs
@@ -356,9 +356,11 @@ const serviceMapping = {
         // Fresh bridge truth only. `composeMemoryCoreHealthcheck` keeps stale/unavailable
         // observations explicit but prevents either from authorizing a backup degradation.
         deploymentInspection: await readDeploymentInspection(),
-        // The starvation receipt's own checkedAt freshness reads the same deployment-state
-        // authority that bounds the snapshot — one leaf governs the whole consumed surface.
-        starvationStaleAfterMs: AiConfig.orchestrator.deploymentStateBridge.staleAfterMs,
+        // The starvation receipt is bounded by ITS OWN producer's cadence, never by the bridge's
+        // write-staleness clock: the snapshot is rewritten every 30s, the receipt only every
+        // watchdog run, so one leaf governing both made the verdict readable 2 minutes in 10
+        // The formula couples this bound to that cadence.
+        starvationStaleAfterMs: AiConfig.orchestrator.heavyMaintenanceLease.starvationReceiptStaleAfterMs,
         // Elected + parked vector-generation identities (never throws; `missing` on a plane that
         // has not declared an election) — acceptance for a generation cutover reads this block.
         vectorGeneration: await projectVectorGenerationHealth({

--- a/ai/scripts/lint/config-leaf-parity.json
+++ b/ai/scripts/lint/config-leaf-parity.json
@@ -363,6 +363,7 @@
         "orchestrator.heavyMaintenanceLease.fairnessYieldAfterMs",
         "orchestrator.heavyMaintenanceLease.staleAfterMs",
         "orchestrator.heavyMaintenanceLease.starvationDegradeAfterMs",
+        "orchestrator.heavyMaintenanceLease.starvationReceiptStaleAfterMsOverride",
         "orchestrator.intervals",
         "orchestrator.intervals.backupMs",
         "orchestrator.intervals.backupRetryDelayMs",

--- a/ai/services/memory-core/HealthService.mjs
+++ b/ai/services/memory-core/HealthService.mjs
@@ -1073,9 +1073,11 @@ export function foldServiceMemoryPressure({payload, inspection, now, staleAfterM
  *   `heavyMaintenanceStarvation` consumed-observation descriptor).
  * @param {Object|null} options.inspection `readDeploymentStateSnapshot()` result, or null when the read threw.
  * @param {Number} options.now Epoch-ms clock for receipt freshness.
- * @param {Number} options.staleAfterMs Freshness bound applied to the RECEIPT's `checkedAt` — the same
- *   deployment-state authority that bounds the snapshot itself, so one config leaf governs the whole
- *   consumed surface.
+ * @param {Number} options.staleAfterMs Freshness bound applied to the RECEIPT's `checkedAt`, sized
+ *   from the cadence of the watchdog that stamps it (`heavyMaintenanceLease.starvationReceiptStaleAfterMs`).
+ *   It must NOT be the snapshot's own bridge-write bound: the bridge rewrites every 30s while the
+ *   receipt is restamped only per watchdog run, so borrowing that clock left this fold able to
+ *   degrade for 2 minutes in every 10. `<= 0` disables consumption entirely.
  * @returns {Object} The consumed-observation descriptor written onto the payload.
  */
 export function foldHeavyMaintenanceStarvation({payload, inspection, now, staleAfterMs}) {
@@ -1110,6 +1112,14 @@ export function foldHeavyMaintenanceStarvation({payload, inspection, now, staleA
             // the two statements cannot coexist in one response.
             payload.details = payload.details.filter(detail => detail !== 'All features are operational');
             payload.details.push(`Heavy-maintenance starvation: ${(receipt.breaches ?? []).map(breach => `${breach.taskName} deferred since ${breach.deferredSince}`).join(', ') || 'degraded receipt'} (lease holder: ${receipt.leaseHolder ?? 'none'})`);
+        } else if (receipt.posture === 'unknown') {
+            // Inconclusive is its own answer. A fresh `unknown` means the watchdog READ the ledger
+            // and could not decide (unreadable entries, or a watchdog fault) — so it may not
+            // degrade, and it may equally not ride the all-clear line into a green report. Folding
+            // it into `consumed-clear` asserted exactly the claim it cannot support.
+            observation.state = 'consumed-unknown';
+            payload.details   = payload.details.filter(detail => detail !== 'All features are operational');
+            payload.details.push('Heavy-maintenance starvation: the watchdog could not determine a verdict — starvation state is unknown, not clear.');
         } else {
             observation.state = 'consumed-clear';
         }

--- a/test/playwright/unit/ai/daemons/orchestrator/daemon.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/daemon.spec.mjs
@@ -8,6 +8,7 @@ import '../../../../../../src/Neo.mjs';
 import '../../../../../../src/core/_export.mjs';
 import {
     acquireAuthorityLeaseSurvivingSelfSuccession,
+    assertStarvationReceiptReadable,
     enforceSingleton,
     LOCAL_AI_CONFIG_FILE,
     isOrchestratorDaemonCommand,
@@ -550,4 +551,43 @@ test.describe('ai/daemons/orchestrator/daemon.mjs (#11006/#11009)', () => {
         expect(LOCAL_AI_CONFIG_FILE).toBe(path.resolve(process.cwd(), 'ai/config.mjs'));
     });
 
+});
+
+test.describe('assertStarvationReceiptReadable — boot refuses an unreadable starvation verdict (#17290)', () => {
+    const aiConfig = ({checkMs, staleAfterMs}) => ({
+        orchestrator: {
+            intervals            : {heavyMaintenanceStarvationWatchdogCheckMs: checkMs},
+            heavyMaintenanceLease: {starvationReceiptStaleAfterMs: staleAfterMs}
+        }
+    });
+
+    test('the shipped 10min/2min pair is refused, and the error names both numbers and the gap', () => {
+        let thrown;
+
+        try {
+            assertStarvationReceiptReadable({aiConfig: aiConfig({checkMs: 600000, staleAfterMs: 120000})});
+        } catch (error) {
+            thrown = error;
+        }
+
+        expect(thrown).toBeTruthy();
+        expect(thrown.message).toContain('600000ms');
+        expect(thrown.message).toContain('120000ms');
+        expect(thrown.message).toContain('480000ms');
+        // The remediation must name the leaves, not just the symptom.
+        expect(thrown.message).toContain('NEO_HEAVY_MAINTENANCE_LEASE_STARVATION_RECEIPT_STALE_MS');
+        expect(thrown.message).toContain('NEO_ORCHESTRATOR_HEAVY_STARVATION_WATCHDOG_INTERVAL_MS');
+    });
+
+    test('the derived default boots and returns its numbers', () => {
+        expect(assertStarvationReceiptReadable({
+            aiConfig: aiConfig({checkMs: 600000, staleAfterMs: 1200000})
+        })).toMatchObject({reachable: true, unreadableMs: 0});
+    });
+
+    test('a disabled watchdog boots — nothing is stamped, so nothing goes unread', () => {
+        expect(assertStarvationReceiptReadable({
+            aiConfig: aiConfig({checkMs: 0, staleAfterMs: 0})
+        })).toMatchObject({reachable: true});
+    });
 });

--- a/test/playwright/unit/ai/daemons/orchestrator/scheduling/heavyMaintenanceStarvationWatchdog.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/scheduling/heavyMaintenanceStarvationWatchdog.spec.mjs
@@ -1,5 +1,6 @@
 import {test, expect} from '@playwright/test';
 import {
+    describeStarvationReceiptReachability,
     evaluateWaiterStarvation,
     getDueTask
 } from '../../../../../../../ai/daemons/orchestrator/scheduling/heavyMaintenanceStarvationWatchdog.mjs';
@@ -168,5 +169,48 @@ test.describe('orchestrator/scheduling/heavyMaintenanceStarvationWatchdog (#1704
             now                                      : 999999999,
             heavyMaintenanceStarvationWatchdogCheckMs: 0
         })).toBeNull();
+    });
+});
+
+test.describe('describeStarvationReceiptReachability — the producer/consumer pairing (#17290)', () => {
+    test('the shipped pair is UNREACHABLE: 10min restamp against a 2min window', () => {
+        const result = describeStarvationReceiptReachability({checkMs: 600000, staleAfterMs: 120000});
+
+        expect(result.reachable).toBe(false);
+        // 8 of every 10 minutes a stamped verdict is already stale — the measured duty cycle.
+        expect(result.unreadableMs).toBe(480000);
+    });
+
+    test('the derived default is reachable and leaves no unreadable gap', () => {
+        const result = describeStarvationReceiptReachability({checkMs: 600000, staleAfterMs: 1200000});
+
+        expect(result.reachable).toBe(true);
+        expect(result.unreadableMs).toBe(0);
+    });
+
+    test('a window EQUAL to the cadence is the floor — reachable, with zero slack', () => {
+        expect(describeStarvationReceiptReachability({checkMs: 600000, staleAfterMs: 600000})).toMatchObject({
+            reachable: true, unreadableMs: 0
+        });
+
+        expect(describeStarvationReceiptReachability({checkMs: 600000, staleAfterMs: 599999})).toMatchObject({
+            reachable: false, unreadableMs: 1
+        });
+    });
+
+    test('a DISABLED producer is reachable by definition — a verdict never stamped cannot go unread', () => {
+        expect(describeStarvationReceiptReachability({checkMs: 0, staleAfterMs: 0})).toMatchObject({
+            reachable: true, unreadableMs: 0
+        });
+
+        expect(describeStarvationReceiptReachability({checkMs: -1, staleAfterMs: 120000})).toMatchObject({
+            reachable: true
+        });
+    });
+
+    test('non-finite input fails closed rather than passing on a NaN comparison', () => {
+        for (const pair of [{checkMs: NaN, staleAfterMs: 120000}, {checkMs: 600000, staleAfterMs: undefined}]) {
+            expect(describeStarvationReceiptReachability(pair).reachable).toBe(false);
+        }
     });
 });

--- a/test/playwright/unit/ai/services/memory-core/HealthService.starvationFold.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/HealthService.starvationFold.spec.mjs
@@ -76,9 +76,107 @@ test.describe('HealthService.foldHeavyMaintenanceStarvation — the consumed agg
             });
 
             expect(payload.status).toBe('healthy');
-            expect(payload.details).toEqual([]);
+        }
+    });
+
+    test('healthy and disabled postures read CLEAR and keep the all-clear line', () => {
+        for (const posture of ['healthy', 'disabled']) {
+            const payload = makePayload();
+
+            payload.details.push('All features are operational');
+
+            foldHeavyMaintenanceStarvation({
+                payload,
+                inspection  : makeInspection({receipt: makeReceipt({posture, breaches: []})}),
+                now         : NOW,
+                staleAfterMs: STALE_AFTER_MS
+            });
+
+            expect(payload.status).toBe('healthy');
+            expect(payload.details).toEqual(['All features are operational']);
             expect(payload.heavyMaintenanceStarvation).toMatchObject({state: 'consumed-clear', posture});
         }
+    });
+
+    // `unknown` used to fall through to `consumed-clear`, which left the all-clear line
+    // standing — the fold asserting "operational" on the strength of a verdict the watchdog
+    // explicitly could not reach. Inconclusive may neither degrade nor claim green.
+    test('a FRESH unknown posture neither degrades nor asserts green — the all-clear line is withdrawn', () => {
+        const payload = makePayload();
+
+        payload.details.push('All features are operational');
+
+        foldHeavyMaintenanceStarvation({
+            payload,
+            inspection  : makeInspection({receipt: makeReceipt({posture: 'unknown', breaches: []})}),
+            now         : NOW,
+            staleAfterMs: STALE_AFTER_MS
+        });
+
+        expect(payload.status).toBe('healthy');
+        expect(payload.details).not.toContain('All features are operational');
+        expect(payload.details.join(' ')).toContain('unknown, not clear');
+        expect(payload.heavyMaintenanceStarvation).toMatchObject({state: 'consumed-unknown', posture: 'unknown'});
+    });
+
+    // Duty cycle: the receipt is only restamped once per watchdog cadence, so the worst-case
+    // age a live verdict ever reaches is one full cadence. The bound must cover that age; the
+    // superseded bridge-write clock did not, which is the whole 8-of-10-minutes defect.
+    test('a receipt aged one full producer cadence stays consumable under the derived bound', () => {
+        const cadenceMs = 10 * 60 * 1000,
+              derived   = cadenceMs * 2,
+              payload   = makePayload();
+
+        foldHeavyMaintenanceStarvation({
+            payload,
+            inspection  : makeInspection({receipt: makeReceipt({checkedAgoMs: cadenceMs})}),
+            now         : NOW,
+            staleAfterMs: derived
+        });
+
+        expect(payload.status).toBe('degraded');
+        expect(payload.heavyMaintenanceStarvation).toMatchObject({state: 'consumed-degraded'});
+    });
+
+    // The bound's upper end is the other half of the contract: it exists to expire a DEAD producer,
+    // not to widen a live one. Two cadences is the tolerance (one full period plus a missed run);
+    // past that the receipt stops being evidence and the fold must decline to degrade on it.
+    test('the derived bound spans two producer cadences and expires past them', () => {
+        const cadenceMs = 10 * 60 * 1000,
+              derived   = cadenceMs * 2;
+
+        for (const [checkedAgoMs, expectedState, expectedStatus] of [
+            [cadenceMs * 2,     'consumed-degraded', 'degraded'],
+            [cadenceMs * 2 + 1, 'receipt-stale',     'healthy']
+        ]) {
+            const payload = makePayload();
+
+            foldHeavyMaintenanceStarvation({
+                payload,
+                inspection  : makeInspection({receipt: makeReceipt({checkedAgoMs})}),
+                now         : NOW,
+                staleAfterMs: derived
+            });
+
+            expect(payload.status).toBe(expectedStatus);
+            expect(payload.heavyMaintenanceStarvation.state).toBe(expectedState);
+        }
+    });
+
+    test('mutation control: the same receipt under the superseded bridge bound reads stale and stays green', () => {
+        const cadenceMs        = 10 * 60 * 1000,
+              supersededBridge = 2 * 60 * 1000,
+              payload          = makePayload();
+
+        foldHeavyMaintenanceStarvation({
+            payload,
+            inspection  : makeInspection({receipt: makeReceipt({checkedAgoMs: cadenceMs})}),
+            now         : NOW,
+            staleAfterMs: supersededBridge
+        });
+
+        expect(payload.status).toBe('healthy');
+        expect(payload.heavyMaintenanceStarvation).toMatchObject({state: 'receipt-stale', posture: 'degraded'});
     });
 
     test('a STALE receipt cannot authorize degradation even when its posture is degraded', () => {


### PR DESCRIPTION
Resolves neomjs/neo#17290

🌿 A plane can no longer starve for hours behind a verdict that was written, correct, and unreadable.

The heavy-maintenance starvation fold consumed a receipt restamped every 10 minutes while accepting it as fresh for only 2 — `deploymentStateBridge.staleAfterMs`, a bridge-**write** staleness clock with no relationship to the watchdog that stamps the receipt. So the detector fired correctly and almost nobody saw it: any single poll of a continuously starved plane had roughly 80% odds of reading `healthy` with "All features are operational" asserted.

This is the same defect class neomjs/neo#17049 already solved for a *different* clock. Its own Contract Ledger says *"waiter freshness reads the ADMISSION authority — never the 6h lease TTL — so health expires a dead waiter on the same clock the fairness gate does."* One clock for admission and health. The receipt bound then borrowed an unrelated third clock. Second door, same room.

Evidence: L2 (unit witnesses + live config-resolution probes against the real tree) → L3 desirable for the production duty cycle, unreachable from this head (the fold ships inside the MC server image; observing it requires a plane redeploy). The L3 measurement below is the **diagnosis** of the defect, not verification of the fix. Residual: post-merge observation that a starved plane reads degraded on every poll — Residual-Owner: neomjs/neo-agent-brain#54 (external plane self-recovery, which already owns plane-side observation follow-ups).

## What changed

**The bound stops borrowing.** `heavyMaintenanceLease.starvationReceiptStaleAfterMs` becomes a formula over the producer's own cadence, with an explicit `…Override` leaf that wins when set. Per ADR-0019 §10.5 a value genuinely computed from another leaf's resolved value is a formula, not a re-derivation — so re-tuning the cadence moves the window with it and the pair cannot silently drift apart again. Two cadences of tolerance: one full period plus a single missed run. Past that the receipt *should* expire — a watchdog that has skipped two runs is no longer evidence about the plane.

**Boot refuses an unreadable pairing.** `assertStarvationReceiptReadable` sits beside `assertOrchestratorPlane` in `bootOrchestratorCli`, ahead of `startOrchestrator`, so a refused launch writes no state directory, no PID file and no log (ADR-0019 §10.8). It mirrors `describeMemoryWindowReachability`, whose own comment already argues this exact case for the sibling pair: *"A disabled detector and a detector with no floor are different failures, and only one of them is loud — so the quiet one has to be refused here."* A disabled watchdog stays reachable by definition — a verdict never stamped cannot go unread.

**`unknown` stops asserting green.** A fresh `unknown` posture fell through to `consumed-clear`, which left the all-clear line standing — the fold claiming "operational" on the strength of a verdict the watchdog explicitly could not reach. It now withdraws that line and says so, **without** degrading.

## Deltas from ticket

None substantive. The ticket's fork recommended (a)+(b) and both shipped; (c) and (d) stay rejected for the recorded reasons.

One judgment call worth a reviewer's eyes, because I made it while its author is unavailable. @neo-gpt's falsification listed three symptoms for `unknown`: maps to `consumed-clear`, *preserves top-level healthy*, and preserves the all-clear assertion. But neomjs/neo#17049's contract also states `unknown` must **never degrade** — so leaving `status: healthy` is the only non-degrading option available. I read the actionable symptom as the all-clear assertion, and treated status and details as the two separate levers the fold already uses for the degraded case. If the intent was stronger, this is the line to overturn. GPT seats are rate-limited, so this went ahead on the recorded recommendation rather than waiting.

**Change class:** declared `capability` → `feat`, not `fix`. A bug motivated the work, but the boot gate is a separately-testable operable path that did not exist: a configuration that booted yesterday now refuses. §3.1 says capability wins in exactly that case. Challenge it if you read the delta as pure restoration.

## Test Evidence

- `HealthService.starvationFold.spec.mjs` → 16/16 green. New arms: the `unknown` posture withdraws the all-clear without degrading; a receipt aged one full cadence stays consumable under the derived bound; the bound spans two cadences and expires at `2×cadence + 1` (the dead-producer half, and the AC's two-cadence witness); and a **mutation control** — the identical receipt under the superseded 120,000 ms bridge bound reads `receipt-stale` and stays green, which is the defect reproduced on demand.
- `heavyMaintenanceStarvationWatchdog.spec.mjs` → reachability arms: the shipped 10min/2min pair is refused with `unreadableMs: 480000` (the measured 8-of-10 duty cycle, asserted as a number); the derived default leaves no gap; a window *equal* to the cadence is the floor (reachable) and one millisecond under is not; a disabled producer is reachable; non-finite input fails closed rather than passing on a NaN comparison.
- `daemon.spec.mjs` → boot refusal names both numbers, the gap, and **both** remediation env vars; the derived default boots; a disabled watchdog boots.
- Combined targeted run at the committed tree: **51 passed**.
- Live config-resolution probes against the real tree (not a stub): default `600000 → 1200000`; cadence raised to `1800000 → 3600000`; lowered to `60000 → 120000`; explicit override `999000` wins over the derivation. The formula tracks its producer in both directions.
- `ai:lint-config-template-ssot` caught the new leaf as an unrecorded declared path; the parity snapshot is updated in this same commit, as the lint requires.
- Full local Brain-tree run was attempted and hung with no output (the known local chroma/webserver hang, unrelated to this diff) — killed rather than reported as a pass. CI owns that surface.

## The measurement that diagnosed it

On a live external production plane with three heavy tasks starved 47–68 hours throughout, so the underlying condition never varied:

- Receipt stamps at `07:27:38Z` and `07:47:38Z` — the 10-minute cadence.
- 16 samples at 30s: `07:50:04 → 07:57:23` **all 15** read `healthy` / `receipt-stale`; sample 16 at `07:57:55` flipped to `degraded` / `consumed-degraded`.
- The next stamp was predicted at `07:57:38` before the run; the observed flip bracketed it inside one sampling interval.

## Post-Merge Validation

One item, owned above: after this ships to a plane, a starved plane should read `degraded` on every poll rather than one in five. Not verifiable from this head.

## Commits

- one commit — the formula + override leaf, the consumer swap, the `unknown` branch, the boot gate and its pure predicate, the parity snapshot, and the witnesses.

Authored by Vega (Claude Opus 5, Claude Code). Session c992afd0-2e26-410e-b460-b480ccd0a240.
