### PR TITLE
feat(ai): a deferring residency repair registers its wait instead of logging it (#17295)

### DIFF
--- a/ai/daemons/orchestrator/Orchestrator.mjs
+++ b/ai/daemons/orchestrator/Orchestrator.mjs
@@ -100,6 +100,17 @@ import {
 import {resolveCloudOnlyDefault} from './services/deploymentDurabilityPosture.mjs';
 
 /**
+ * Stable waiter identity for the provider-residency repair actuator.
+ *
+ * It is deliberately NOT in `DEFAULT_HEAVY_MAINTENANCE_TASK_NAMES`: this actuator competes for the
+ * heavy lane but is not itself heavy maintenance, so it registers a wait without joining the mutex
+ * that would then block on itself.
+ * @type {String}
+ */
+const PROVIDER_RESIDENCY_TASK_NAME = 'provider-residency-repair';
+
+
+/**
  * Deadline for the boot-time configured-tenant-repo coverage prewarm. An internal liveness bound
  * rather than deployment policy: exceeding it costs ranking precision on the first sweep (the
  * unresolved fail-safe posture still ranks bootstrap), while an unbounded wait would stop the
@@ -678,21 +689,72 @@ export class Orchestrator extends Base {
         try {
             activeTask = this.maintenanceBackpressureService.getActiveHeavyMaintenanceTask();
         } catch (error) {
+            // An inspection FAULT is not contention: there is no competitor to register a wait
+            // against, and recording one would attribute a broken read to a starving actuator.
             this.writeLog('ERROR', `[Orchestrator] Heavy-maintenance task inspection failed; deferring provider residency repair: ${error.message}`);
             return false;
         }
 
         if (activeTask) {
             this.writeLog('INFO', `[Orchestrator] Deferring provider residency repair; heavy maintenance task ${activeTask} is active.`);
+            this.recordProviderResidencyDeferral({
+                reasonText      : `heavy maintenance task ${activeTask} is active`,
+                blockingTaskName: activeTask
+            });
             return false;
         }
 
         if (this.isHeavyMaintenanceLeaseActive(now)) {
             this.writeLog('INFO', '[Orchestrator] Deferring provider residency repair; the shared heavy-maintenance lease is active or could not be inspected.');
+            this.recordProviderResidencyDeferral({
+                reasonText: 'the shared heavy-maintenance lease is active or could not be inspected'
+            });
             return false;
         }
 
+        // Admitted: it is running, so it must stop counting as a competitor. Leaving the entry
+        // behind would make other acquirers yield to work that already proceeded.
+        this.maintenanceBackpressureService.clearWaiter(PROVIDER_RESIDENCY_TASK_NAME);
+
         return true;
+    }
+
+    /**
+     * @summary Records a provider-residency deferral as a MEASURED wait, not just a log line.
+     *
+     * This actuator used to inspect-and-skip: it logged on every deferred poll and registered
+     * nothing, so it could never appear in `listActiveWaitersSync` and therefore never in the
+     * starvation receipt that `foldHeavyMaintenanceStarvation` scores. On one plane it deferred
+     * every ~30s for hours while the health surface reported three breaches and not this one —
+     * the surface was not wrong, it was scoring a population this consumer never joined.
+     *
+     * Routed through `recordDeferral` rather than registering directly, because that is where the
+     * durable streak anchor is computed: `registerWaiterSync` refuses an unmeasured wait, so a
+     * call-time timestamp would restart the streak on every poll and a multi-hour starvation would
+     * read as permanently fresh.
+     *
+     * Registration only — it does not acquire the lease or change what is scheduled. Making the
+     * wait VISIBLE and making it ADMITTED are separable, and only the first is in scope here.
+     * @param {Object} options
+     * @param {String} options.reasonText Human-readable scheduling reason.
+     * @param {String|null} [options.blockingTaskName] The competing task, when one is known.
+     * @returns {void}
+     * @protected
+     */
+    recordProviderResidencyDeferral({reasonText, blockingTaskName = null}) {
+        try {
+            this.maintenanceBackpressureService.recordDeferral({
+                taskName  : PROVIDER_RESIDENCY_TASK_NAME,
+                // A contention class, so `recordDeferral` promotes it to a registered waiter; the
+                // policy classes (shed windows, dependency gates) deliberately do not register.
+                reasonCode: 'heavy-maintenance-backpressure',
+                reasonText,
+                blockingTaskName
+            })
+        } catch (error) {
+            // Observability must never take down the actuator it observes.
+            this.writeLog('ERROR', `[Orchestrator] Provider-residency deferral record failed: ${error.message}`)
+        }
     }
 
     beforeSetMaintenanceBackpressureService(value) {

--- a/ai/daemons/orchestrator/services/MaintenanceBackpressureService.mjs
+++ b/ai/daemons/orchestrator/services/MaintenanceBackpressureService.mjs
@@ -632,6 +632,23 @@ export class MaintenanceBackpressureService extends Base {
     }
 
     /**
+     * @summary Drops this task's waiter entry — it is running, so it is no longer competing.
+     *
+     * Public because a deferring consumer outside the acquisition path needs the same release: a
+     * consumer that registers a waiter and never clears it leaves other acquirers yielding to work
+     * that already proceeded. Pairs with the registration inside {@link recordDeferral}.
+     * @param {String} taskName Stable orchestrator task name.
+     * @returns {void}
+     */
+    clearWaiter(taskName) {
+        try {
+            clearWaiterSync({leasePath: this.resolveHeavyMaintenanceLeasePath(), taskName})
+        } catch (e) {
+            this.writeLog('ERROR', `[Orchestrator] Waiter clear failed for ${taskName}: ${e.message}`)
+        }
+    }
+
+    /**
      * @param {Object} options
      * @param {String} options.taskName Deferred task name.
      * @param {String} options.reasonCode Discriminator field.
@@ -1009,11 +1026,7 @@ export class MaintenanceBackpressureService extends Base {
 
         // The task proceeds (own lease or compatible-pair bypass): it is no longer a waiter, and a
         // stale self-entry must not make OTHER acquirers yield to work that is already running.
-        try {
-            clearWaiterSync({leasePath: this.resolveHeavyMaintenanceLeasePath(), taskName});
-        } catch (e) {
-            this.writeLog('ERROR', `[Orchestrator] Waiter clear failed for ${taskName}: ${e.message}`);
-        }
+        this.clearWaiter(taskName);
 
         const releaseLease = () => {
             if (!leaseToken) return;

--- a/test/playwright/unit/ai/daemons/orchestrator/Orchestrator.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/Orchestrator.spec.mjs
@@ -877,6 +877,89 @@ test.describe('Neo.ai.daemons.Orchestrator (#11009)', () => {
         })).toBe(true);
     });
 
+    // The actuator used to inspect-and-skip — it logged on every deferred poll and
+    // registered nothing, so it could never enter the population `foldHeavyMaintenanceStarvation`
+    // scores. On a live plane it deferred every ~30s for hours while the starvation surface
+    // reported three breaches and not this one. These arms pin the wait as a MEASURED fact.
+    test('a deferred provider-residency repair REGISTERS its wait, with the blocking task named', () => {
+        const orchestrator = createTestOrchestrator({kbSyncEnabled: false}),
+              deferrals    = [];
+
+        orchestrator.writeLog = () => {};
+        orchestrator.maintenanceBackpressureService.getActiveHeavyMaintenanceTask = () => 'tenant-repo-sync';
+        orchestrator.maintenanceBackpressureService.recordDeferral = entry => deferrals.push(entry);
+
+        expect(orchestrator.isProviderWarmStillAdmitted(10_000)).toBe(false);
+        expect(deferrals).toHaveLength(1);
+        expect(deferrals[0].taskName).toBe('provider-residency-repair');
+        expect(deferrals[0].blockingTaskName).toBe('tenant-repo-sync');
+
+        // Mutation control on the reasonCode, not merely its presence: `recordDeferral` promotes a
+        // deferral to a registered waiter ONLY for the contention classes. A policy class here
+        // would log identically, register nothing, and restore the invisibility this fixes.
+        expect(['heavy-maintenance-lease-held', 'heavy-maintenance-backpressure', 'heavy-maintenance-yield-to-waiter'])
+            .toContain(deferrals[0].reasonCode);
+    });
+
+    test('a lease-held deferral registers too, with no blocking task to name', () => {
+        const orchestrator = createTestOrchestrator({kbSyncEnabled: false}),
+              deferrals    = [];
+
+        orchestrator.writeLog = () => {};
+        orchestrator.maintenanceBackpressureService.getActiveHeavyMaintenanceTask = () => null;
+        orchestrator.inspectHeavyMaintenanceLeaseFn = () => ({status: 'active', active: true});
+        orchestrator.maintenanceBackpressureService.recordDeferral = entry => deferrals.push(entry);
+
+        expect(orchestrator.isProviderWarmStillAdmitted(10_000)).toBe(false);
+        expect(deferrals).toHaveLength(1);
+        expect(deferrals[0].blockingTaskName).toBeNull();
+    });
+
+    test('an inspection FAULT does not register — a broken read is not a starving actuator', () => {
+        const orchestrator = createTestOrchestrator({kbSyncEnabled: false}),
+              deferrals    = [];
+
+        orchestrator.writeLog = () => {};
+        orchestrator.maintenanceBackpressureService.getActiveHeavyMaintenanceTask = () => {
+            throw new Error('task-state unreadable')
+        };
+        orchestrator.maintenanceBackpressureService.recordDeferral = entry => deferrals.push(entry);
+
+        expect(orchestrator.isProviderWarmStillAdmitted(10_000)).toBe(false);
+        // There is no competitor to wait on. Registering here would attribute an unreadable read
+        // to contention and put a phantom waiter in front of real acquirers.
+        expect(deferrals).toEqual([]);
+    });
+
+    test('admission CLEARS the waiter — a running actuator must stop making acquirers yield', () => {
+        const orchestrator = createTestOrchestrator({kbSyncEnabled: false}),
+              cleared      = [];
+
+        orchestrator.writeLog = () => {};
+        orchestrator.maintenanceBackpressureService.getActiveHeavyMaintenanceTask = () => null;
+        orchestrator.inspectHeavyMaintenanceLeaseFn = () => ({status: 'missing', active: false});
+        orchestrator.maintenanceBackpressureService.clearWaiter = taskName => cleared.push(taskName);
+
+        expect(orchestrator.isProviderWarmStillAdmitted(10_000)).toBe(true);
+        expect(cleared).toEqual(['provider-residency-repair']);
+    });
+
+    test('observability never takes down the actuator it observes', () => {
+        const orchestrator = createTestOrchestrator({kbSyncEnabled: false}),
+              logs         = [];
+
+        orchestrator.writeLog = (level, message) => logs.push({level, message});
+        orchestrator.maintenanceBackpressureService.getActiveHeavyMaintenanceTask = () => 'tenant-repo-sync';
+        orchestrator.maintenanceBackpressureService.recordDeferral = () => {
+            throw new Error('ledger unwritable')
+        };
+
+        // A failed registration is a lost observation, never a changed admission decision.
+        expect(() => orchestrator.isProviderWarmStillAdmitted(10_000)).not.toThrow();
+        expect(orchestrator.isProviderWarmStillAdmitted(10_000)).toBe(false);
+        expect(logs.some(entry => entry.level === 'ERROR' && /deferral record failed/i.test(entry.message))).toBe(true);
+    });
+
     test('provider warm admission yields to task, lease or inspection uncertainty', () => {
         const orchestrator = createTestOrchestrator({kbSyncEnabled: false});
         let   activeTask   = 'tenant-repo-sync',


### PR DESCRIPTION
Resolves #17295

🌿 A consumer that only ever logged its wait can no longer starve unseen.

`isProviderWarmStillAdmitted` inspected the heavy-maintenance lane, logged, and returned. It never reached `registerWaiterSync`, so it could not appear in `listActiveWaitersSync` — and therefore never in the receipt `foldHeavyMaintenanceStarvation` scores. On a live plane it deferred every ~30s **for hours** while the starvation surface reported three breaches and not this one. The surface was not wrong; it was scoring a population this consumer never joined.

Found by @neo-opus-grace, who traced the mechanism and flagged it to this surface rather than claiming it.

Evidence: L2 (unit witnesses, mutation-verified) → L2 required. The live plane observation that motivated it is diagnosis, not verification of this fix. No residuals.

## Deltas from ticket

One, and it narrowed the work. The ticket's census AC asked whether `isProviderWarmStillAdmitted` is one of a class of inspect-and-skip consumers, on the expectation that a shared registration helper might be needed. The census says it is not — see below — so this ships one call site and no helper. The AC is answered rather than assumed away.

## The census decided the shape

I filed this expecting a class of inspect-and-skip consumers and a shared helper. Enumerating every `getActiveHeavyMaintenanceTask()` caller said otherwise:

| call site | behaviour |
|---|---|
| `pipeline.mjs:256`, `:284` | reads the active task **name** for scheduling; makes no admission decision |
| `MaintenanceBackpressureService:904` | blocks and calls `recordDeferral()` → **registers** |
| `Orchestrator.mjs:679` | logs and returns → **the sole non-registrant** |

One call site, not a class. No shared helper, and the AC that asked for the census is answered rather than assumed.

**Strengthened at review by @neo-opus-grace**, who re-ran the census independently and traced one hop further than I did. My classification of the pipeline pair — "reads the name, makes no admission decision" — is true but shallow. Following where that `activeHeavyTask` payload *goes*: `acquireLeaseAndExecute:899-900` computes `blockingTaskName` from it and calls `recordDeferral` at `:904`. The pair does not merely abstain from deciding; it **feeds the path that registers**. The sole-non-registrant claim holds end-to-end, for a better reason than I proved. She also cleared an ordering hazard I had not checked: `clearWaiter` fires before the repair actually runs, but the next deferred poll re-registers, so a failed repair cannot leave the actuator invisible.

## Why `recordDeferral` and not `registerWaiterSync`

`registerWaiterSync` **refuses an unmeasured wait** — it throws unless `deferredSince` is the durable ISO streak start. A call-time timestamp would restart the streak on every poll, and a multi-hour starvation would read as permanently fresh: visible, and wrong in the direction that matters. `recordDeferral` is where the durable anchor is computed, so routing through it gets the streak, the registration and the existing error handling in one call.

## Scope

**Registration only.** It does not acquire the lease and does not change what is scheduled. Making a wait *visible* and making it *admitted* are separable, and only the first is in scope — the ticket says so and this diff holds to it.

Two behaviours preserved deliberately:

- **An inspection FAULT still does not register.** There is no competitor to wait on; recording one would attribute a broken read to a starving actuator and put a phantom waiter in front of real acquirers.
- **Observability cannot take down the actuator it observes.** A throwing ledger loses the observation and logs; the admission decision is unchanged.

Also adds `MaintenanceBackpressureService.clearWaiter()` and folds the previously inline clear at the acquisition path onto it — one clear path instead of two copies.

## Test Evidence

Five arms in `Orchestrator.spec.mjs`; **103 passed** in that file, **446** across every spec importing either changed file.

**Red-proof, with the mutation verified before running:** stripped both `recordProviderResidencyDeferral` call sites and the `clearWaiter` call, asserted `2 → 0` call sites and `clearWaiter` absent, then ran — **4 of 5 fail**. The fifth is the inspection-fault arm, which asserts an *absence* and is therefore red-provable only by the opposite mutation (adding registration to the fault path). Stated rather than counted as a pass.

My first red-proof attempt was faulty and I am recording it because the failure is instructive: a `[^}]*` regex stopped at the first brace, left one call site intact, and reported only 2 failures. I read that as weak arms before checking the harness. **Verify the mutation landed before drawing conclusions from what survives it.**

The load-bearing assertion is the reasonCode one. `recordDeferral` promotes a deferral to a registered waiter **only for the contention classes**, so a policy class there would log identically, register nothing, and silently restore exactly the invisibility this fixes. Asserting membership in that set catches it; asserting the field is present would not.

## Post-Merge Validation

Nothing owed. Whether the residency repair should additionally be *admitted* during heavy maintenance is a policy question this deliberately leaves open — the wait is now measurable, which is the precondition for answering it.

Authored by Vega (Claude Opus 5, Claude Code). Session c992afd0-2e26-410e-b460-b480ccd0a240.
