### PR TITLE
feat(ai): bound one tenant repo's share of a sweep with a slice budget (#17132)

### DIFF
--- a/ai/configBase.mjs
+++ b/ai/configBase.mjs
@@ -2076,6 +2076,34 @@ class ConfigBase extends ConfigProvider {
                  *   so a lane whose capped retries keep failing (fresh attempts, visible
                  *   `failed` sweeps) stays quiet — a stale suppression means a wedged lane,
                  *   not an ordinary outage. Set `0` to disable the event (never the status).
+                 * - `sliceBudgetMs` bounds ONE repo's share of ONE sweep, so a concurrency slot
+                 *   is released on progress rather than on corpus completion. Without it the
+                 *   slot spans the entire ingestion call, and with more due repos than slots the
+                 *   tail waits for a head repo to FINISH — measured as sibling repos starved for
+                 *   4+ hours behind one backlog while sweeps fired every 60s.
+                 *
+                 *   It is a SAFE-POINT budget, never a wall-clock cap, and the distinction is
+                 *   contract rather than implementation detail: the reused yield primitive checks
+                 *   its predicate only between batches and never before the first one (an explicit
+                 *   forward-progress guarantee against livelock). So effective occupancy is
+                 *   `sliceBudgetMs` PLUS one batch envelope, and a repo admitted with an already
+                 *   exhausted budget still lands one batch. The budget bounds occupancy from
+                 *   above; it can never starve a repo to zero progress.
+                 *
+                 *   The default is chosen against that envelope, not for roundness: the provider
+                 *   call ceiling is 300s (`openAiCompatible.batchEmbeddingTimeoutMs`,
+                 *   `ollama.embeddingTimeoutMs`), so a budget at one ceiling gives a worst-case
+                 *   hold of roughly two while a healthy slice — where a batch takes seconds, not
+                 *   its ceiling — lands many batches before yielding. It is deliberately NOT
+                 *   derived from the provider leaf: a formula would couple two independently
+                 *   tunable knobs and move the fairness guarantee silently when a provider
+                 *   timeout is retuned. REVALIDATION TRIGGER: raising the provider call ceiling,
+                 *   or changing the sweep's concurrency default, reopens this number — the budget
+                 *   is only meaningful while it is at or above one batch envelope.
+                 *
+                 *   `0` is invalid, not a disable. A magic zero would read as "off" and behave as
+                 *   "unlimited slot hold" — precisely the state this budget removes. Express
+                 *   effectively-unbounded as a large number, visibly.
                  *
                  * @type {Object}
                  */
@@ -2083,6 +2111,7 @@ class ConfigBase extends ConfigProvider {
                     backoffCapMs     : leaf(2 * 60 * 60 * 1000, 'NEO_ORCHESTRATOR_TENANT_REPO_SYNC_BACKOFF_CAP_MS', 'number'),
                     jitterRatio      : leaf(0.20, 'NEO_ORCHESTRATOR_TENANT_REPO_SYNC_JITTER_RATIO', 'number'),
                     leaseStaleAfterMs: leaf(6 * 60 * 60 * 1000, 'NEO_ORCHESTRATOR_TENANT_REPO_SYNC_LEASE_STALE_AFTER_MS', 'number'),
+                    sliceBudgetMs    : leaf(5 * 60 * 1000, 'NEO_ORCHESTRATOR_TENANT_REPO_SYNC_SLICE_BUDGET_MS', 'number'),
                     starvedAfterMs   : leaf(6 * 60 * 60 * 1000, 'NEO_ORCHESTRATOR_TENANT_REPO_SYNC_STARVED_AFTER_MS', 'number'),
                     sweepCadenceMs   : leaf(60 * 1000, 'NEO_ORCHESTRATOR_TENANT_REPO_SYNC_SWEEP_CADENCE_MS', 'number')
                 },

--- a/ai/daemons/orchestrator/scheduling/tenantRepoSync.mjs
+++ b/ai/daemons/orchestrator/scheduling/tenantRepoSync.mjs
@@ -38,6 +38,33 @@ export function assertSliceBudgetMs(value) {
 }
 
 /**
+ * @summary Builds one repo's slice-budget yield predicate.
+ *
+ * Scoped PER REPO, not per sweep: the control envelope that carries `signal` and
+ * `onProviderTimeout` is built once and shared by every repo in the sweep, but a budget shared that
+ * way would be consumed by the first admitted repo and every later one would be born already
+ * expired — a fairness fix that starves the tail it exists to serve. Each repo therefore gets its
+ * own predicate anchored at the moment IT was admitted.
+ *
+ * `startedMs` is the admission instant, not the moment the repo joined the FIFO. A repo that waited
+ * legitimately for a slot must not have that wait charged against the work it is finally allowed to
+ * do; anchoring at queue-join would hand the most-starved repo the smallest slice.
+ *
+ * The predicate only votes. `embedChunks` checks it between batches and never before the first, so
+ * the actual occupancy is this budget plus one batch envelope, and a repo admitted with an already
+ * exhausted budget still lands one batch. That is the forward-progress guarantee, not a rounding
+ * error — see the `sliceBudgetMs` leaf for why it bounds occupancy only from above.
+ * @param {Object} options
+ * @param {Number} options.startedMs Epoch ms at which this repo was admitted to its slot.
+ * @param {Number} options.sliceBudgetMs Validated budget from {@link assertSliceBudgetMs}.
+ * @param {Function} [options.now=Date.now] Clock seam.
+ * @returns {Function} `() => Boolean` — true once the slice has outlived its budget.
+ */
+export function createSliceBudgetPredicate({startedMs, sliceBudgetMs, now = Date.now}) {
+    return () => now() - startedMs >= sliceBudgetMs
+}
+
+/**
  * Builds the trigger for the cloud-deployable tenant-repo-sync lane.
  * Mirror of `buildPrimaryRepoSyncTrigger` in `./primaryDevSync.mjs` — pure function;
  * no class, no Neo machinery, no side effects.

--- a/ai/daemons/orchestrator/scheduling/tenantRepoSync.mjs
+++ b/ai/daemons/orchestrator/scheduling/tenantRepoSync.mjs
@@ -1,3 +1,42 @@
+import {
+    KB_TENANT_REPO_SYNC_INVALID_SLICE_BUDGET,
+    TenantRepoSyncError
+} from '../services/TenantRepoSyncErrors.mjs';
+
+/**
+ * @summary Rejects a `tenantRepoSync.sliceBudgetMs` that cannot bound anything.
+ *
+ * Mirrors the gate shape `beforeSetConcurrencyLimit` uses — positive integer, nothing else — but
+ * THROWS where that one substitutes. The asymmetry is deliberate and is about what each value can
+ * do when wrong: a bad concurrency limit degrades throughput and the sweep still finishes, while a
+ * bad slice budget removes the only bound on how long one repo may hold a slot. Substituting a
+ * working number there would leave an operator believing they had tuned fairness while the shipped
+ * guarantee was something else, and the symptom — a starved tail — is indistinguishable from the
+ * defect this budget exists to remove.
+ *
+ * `0` is rejected like any other invalid value rather than read as a disable. A disable sentinel
+ * would mean "unlimited slot hold", spelled as though it were an off switch.
+ *
+ * Lives here rather than beside its caller because the caller imports Neo: a validator that cannot
+ * be exercised without booting the class system is a validator whose own contract goes untested.
+ * The service reads the leaf at its use site and passes the resolved value in — never the leaf,
+ * never a re-derivation.
+ * @param {*} value Resolved `AiConfig.data.orchestrator.tenantRepoSync.sliceBudgetMs`.
+ * @returns {Number} The validated budget in ms.
+ * @throws {TenantRepoSyncError} `KB_TENANT_REPO_SYNC_INVALID_SLICE_BUDGET` when not a positive integer.
+ */
+export function assertSliceBudgetMs(value) {
+    if (!Number.isInteger(value) || value < 1) {
+        throw new TenantRepoSyncError(
+            KB_TENANT_REPO_SYNC_INVALID_SLICE_BUDGET,
+            `tenantRepoSync.sliceBudgetMs must be a positive integer in ms; received ${JSON.stringify(value)}. There is no disable value — express effectively-unbounded as a large number.`,
+            {phase: 'config-validation', received: value}
+        )
+    }
+
+    return value
+}
+
 /**
  * Builds the trigger for the cloud-deployable tenant-repo-sync lane.
  * Mirror of `buildPrimaryRepoSyncTrigger` in `./primaryDevSync.mjs` — pure function;

--- a/ai/daemons/orchestrator/services/TenantRepoSyncErrors.mjs
+++ b/ai/daemons/orchestrator/services/TenantRepoSyncErrors.mjs
@@ -18,6 +18,17 @@ export const KB_TENANT_REPO_SYNC_REPO_NOT_CONFIGURED    = 'KB_TENANT_REPO_SYNC_R
 export const KB_TENANT_REPO_SYNC_TENANT_NOT_FOUND       = 'KB_TENANT_REPO_SYNC_TENANT_NOT_FOUND';
 export const KB_TENANT_REPO_SYNC_MANIFEST_UPDATE_FAILED = 'KB_TENANT_REPO_SYNC_MANIFEST_UPDATE_FAILED';
 export const KB_TENANT_REPO_SYNC_CONCURRENCY_GATE_TIMEOUT = 'KB_TENANT_REPO_SYNC_CONCURRENCY_GATE_TIMEOUT';
+// A resolved `tenantRepoSync.sliceBudgetMs` that is not a positive integer. It refuses rather than
+// substituting a default, and the refusal is the point: this budget is the only thing bounding how
+// long one repo may hold a concurrency slot, so a value silently corrected back to a working number
+// would leave an operator believing they had tuned fairness while the shipped guarantee was
+// something else entirely.
+//
+// `0` reaches here like any other invalid value — deliberately, because the alternative reading is
+// the footgun. A disable sentinel would mean "unlimited slot hold", which is precisely the state
+// this budget exists to remove, spelled as though it were an off switch. Effectively-unbounded is
+// expressed as a large number, visibly, and there is no value that turns the bound off.
+export const KB_TENANT_REPO_SYNC_INVALID_SLICE_BUDGET = 'KB_TENANT_REPO_SYNC_INVALID_SLICE_BUDGET';
 export const KB_TENANT_REPO_SYNC_EMPTY_MATERIALIZATION = 'KB_TENANT_REPO_SYNC_EMPTY_MATERIALIZATION';
 // The OTHER half of what `EMPTY_MATERIALIZATION` used to carry, and the opposite instruction.
 // A full materialization DID take effect — rows were ingested or deleted — but no receipt proves

--- a/ai/daemons/orchestrator/services/TenantRepoSyncService.mjs
+++ b/ai/daemons/orchestrator/services/TenantRepoSyncService.mjs
@@ -497,6 +497,20 @@ function classifyIngestionOutcome(summary) {
         throw error
     }
 
+    // Reached only on a CLEAN summary, and the ordering is the contract: an error-bearing run is
+    // classified above regardless of whether it also yielded. A slice that both hit a live failure
+    // and ran out of budget is a failure — the budget is the less urgent fact, and letting it
+    // reclassify the run would launder a real fault into a benign rotation.
+    if (summary.yielded === true) {
+        // Neither success nor failure. The corpus is not exhausted, so the checkpoint must not
+        // advance as though it were; but nothing went wrong, so no failure accounting applies.
+        // Distinct from `deferred`, which is the same STATE arrived at for the opposite REASON:
+        // deferral carries a retained cause and arms the recovery canary, because something is
+        // broken and a later health observation is what un-breaks it. A budgeted slice has no
+        // cause to retain and nothing to recover — it needs another turn, not a diagnosis.
+        return {outcome: 'partial-progress', summary, deferredCodes: []}
+    }
+
     return {outcome: 'complete', summary, deferredCodes: []}
 }
 
@@ -1608,7 +1622,7 @@ class TenantRepoSyncService extends Base {
      * Iterates configured tenantRepos and refreshes each via GitMirror → envelope → KB.
      *
      * @param {Object} options Forwarded from `runTask`.
-     * @returns {Promise<Object>} `{status, details: {repoCount, completedCount, failedCount, results}}`.
+     * @returns {Promise<Object>} `{status, details: {repoCount, completedCount, deferredCount, partialProgressCount, failedCount, results}}`.
      */
     async syncTenantRepos({
         writeLog, tenantReposConfig, gitMirror, knowledgeBaseIngestionService, onlyRepoSlugs,
@@ -1951,6 +1965,10 @@ class TenantRepoSyncService extends Base {
         let   completedCount = 0;
         let   deferredCount  = 0;
         let   failedCount    = 0;
+        // Counted separately from `deferredCount`: a sweep where every repo rotated on its budget is
+        // healthy and making progress, while a sweep where every repo deferred is a lane in trouble.
+        // Folding them would make the two indistinguishable in the one number an operator reads.
+        let partialProgressCount = 0;
         let   abortedCount   = 0;
 
         // Per-runTask concurrency gate caps simultaneous git/ingest work.
@@ -2457,6 +2475,69 @@ class TenantRepoSyncService extends Base {
                     return
                 }
 
+                if (ingestOutcome.outcome === 'partial-progress') {
+                    // The slice ran out of budget on a healthy run. Same STATE as a deferral —
+                    // checkpoint holds, streak untouched, attempt stamp advances — arrived at for
+                    // the opposite reason, and the differences are what make it not a deferral:
+                    //
+                    // - No `lastSourceErrorCode` and no recovery episode. Nothing failed, so there
+                    //   is no cause to retain and nothing for the dependency-recovery canary to
+                    //   observe. Writing one would arm a recovery lane against a repo that is
+                    //   simply mid-corpus.
+                    // - It returns BEFORE `assertFullMaterializationEffect`. That guard mints or
+                    //   reuses a full-materialization receipt on positive effect, and a receipt is
+                    //   a claim that the corpus is whole. Minting one here is the shortcut that
+                    //   lets the NEXT sweep's `retryReceipt` branch skip ingestion entirely and
+                    //   settle a checkpoint over a remainder that never landed — the failure this
+                    //   outcome exists to prevent, and the one AC-6's negative arm pins.
+                    //
+                    // The streak is neither incremented nor reset, so a budgeted rotation cannot
+                    // climb a repo toward its backoff cap: being large is not a fault.
+                    const partialOutstanding = buildCorpusOutstandingObservation({
+                        summary   : rawSummary,
+                        priorState,
+                        observedAt: startedMs
+                    });
+
+                    persistedRevisions[repoLabel] = {
+                        ...priorState,
+                        lastIngestedRev                   : priorState?.lastIngestedRev ?? null,
+                        lastRunAttemptAt                  : startedMs,
+                        consecutiveFailures               : priorState?.consecutiveFailures ?? 0,
+                        lastAttemptedIngestContractVersion: TENANT_REPO_INGEST_CONTRACT_VERSION,
+                        corpusOutstanding                 : partialOutstanding
+                    };
+
+                    writeLog?.('INFO', `[TenantRepoSync] ${repoLabel} partial-progress: ` +
+                        `slice budget reached, checkpoint held at ` +
+                        `${priorState?.lastIngestedRev ? priorState.lastIngestedRev.slice(0, 8) : 'none'} ` +
+                        `ingested=${rawSummary?.ingested ?? 0} ` +
+                        `embeddings=${rawSummary?.embeddingsGenerated ?? 0} ` +
+                        `(streak held at ${priorState?.consecutiveFailures ?? 0}; repo stays due)`);
+
+                    repoStates.push({
+                        tenantId        : repo.tenantId,
+                        repoSlug        : repo.repoSlug,
+                        lastIngestedRev : priorState?.lastIngestedRev ?? null,
+                        lastSyncAt      : new Date().toISOString(),
+                        status          : 'partial-progress',
+                        checkpointStatus: priorState?.checkpointStatus ?? TenantRepoCheckpointStatus.UNINITIALIZED,
+                        // The operator-facing point of this row: a plane owner must be able to see
+                        // every repo advancing rather than infer it from a total. Without the
+                        // outstanding stamp, a rotating repo is indistinguishable from a stuck one.
+                        corpusOutstanding: partialOutstanding
+                    });
+
+                    healthService?.recordTaskOutcome?.(taskName, 'partial-progress', {
+                        repo    : repoLabel,
+                        tenantId: repo.tenantId
+                    });
+
+                    partialProgressCount++;
+
+                    return
+                }
+
                 const ingestResult = ingestOutcome.summary;
 
                 const completedOutstanding = buildCorpusOutstandingObservation({
@@ -2776,6 +2857,12 @@ class TenantRepoSyncService extends Base {
                 completedCount,
                 deferredCount,
                 failedCount,
+                // Reported alongside the others rather than folded into either. A repo that rotated
+                // on its budget neither completed nor deferred, and collapsing it into `completed`
+                // would tell a plane owner the corpus is done while a remainder is outstanding —
+                // collapsing it into `deferred` would report a healthy rotating lane as one in
+                // trouble. The per-repo rows carry the outstanding stamp; this is the total.
+                partialProgressCount,
                 notDueCount,
                 revalidationDeferredCount,
                 ...(detection.starved ? {starved: true, starvedEvidence: detection.evidence} : {}),

--- a/ai/daemons/orchestrator/services/TenantRepoSyncService.mjs
+++ b/ai/daemons/orchestrator/services/TenantRepoSyncService.mjs
@@ -38,6 +38,7 @@ import {
 } from '../../../services/knowledge-base/helpers/tenantRepoAccessContract.mjs';
 import {
     assertSliceBudgetMs,
+    createSliceBudgetPredicate,
     classifyEmbeddingRecoveryState,
     detectStarvedTenantSync,
     hasPendingEmbeddingRecoveryBypass,
@@ -2296,7 +2297,14 @@ class TenantRepoSyncService extends Base {
                             ...envelope,
                             ...(materializationAttempt ? {materializationAttempt} : {}),
                             viaMcp: false // operator-bulk path
-                        }, providerCircuitControls);
+                        }, {
+                            ...providerCircuitControls,
+                            // Per-repo, anchored at THIS repo's admission. The envelope above is
+                            // built once and shared by the whole sweep; a budget shared that way
+                            // would be spent by the first admitted repo and every later one born
+                            // already expired — a fairness fix that starves the tail it serves.
+                            shouldYield: createSliceBudgetPredicate({startedMs, sliceBudgetMs})
+                        });
 
                 // Emitted before BOTH guards on this path, which is what makes it useful:
                 // `classifyIngestionOutcome` throws on a rejected error-bearing summary, and

--- a/ai/daemons/orchestrator/services/TenantRepoSyncService.mjs
+++ b/ai/daemons/orchestrator/services/TenantRepoSyncService.mjs
@@ -37,6 +37,7 @@ import {
     TenantRepoAccessStatus
 } from '../../../services/knowledge-base/helpers/tenantRepoAccessContract.mjs';
 import {
+    assertSliceBudgetMs,
     classifyEmbeddingRecoveryState,
     detectStarvedTenantSync,
     hasPendingEmbeddingRecoveryBypass,
@@ -53,6 +54,7 @@ import {
     KB_TENANT_REPO_SYNC_MANIFEST_UPDATE_FAILED,
     KB_TENANT_REPO_SYNC_REPO_NOT_CONFIGURED,
     KB_TENANT_REPO_SYNC_CONCURRENCY_GATE_TIMEOUT,
+    KB_TENANT_REPO_SYNC_INVALID_SLICE_BUDGET,
     KB_TENANT_REPO_SYNC_STARVED,
     TenantRepoSyncError,
     isTenantRepoSyncErrorCode
@@ -1615,6 +1617,7 @@ class TenantRepoSyncService extends Base {
         globalCadenceMs    = AiConfig.data.orchestrator.intervals.tenantRepoSyncMs,
         jitterRatio        = AiConfig.data.orchestrator.tenantRepoSync.jitterRatio,
         backoffCapMs       = AiConfig.data.orchestrator.tenantRepoSync.backoffCapMs,
+        sliceBudgetMs      = AiConfig.data.orchestrator.tenantRepoSync.sliceBudgetMs,
         starvedAfterMs     = AiConfig.data.orchestrator.tenantRepoSync.starvedAfterMs,
         healEventLedgerDir = revisionsFilePath ? path.join(path.dirname(revisionsFilePath), 'heal-events') : null,
         seedBootstrap      = true,
@@ -1631,6 +1634,12 @@ class TenantRepoSyncService extends Base {
                 {phase: 'full-replay-validation'}
             )
         }
+
+        // Validated BEFORE any repo is admitted, not at the first yield check. A budget that only
+        // fails once a slice is already running would refuse the sweep midway through a repo that
+        // had already acquired a slot — the operator sees a partial sweep and a config error at the
+        // same time and has to work out which caused which.
+        assertSliceBudgetMs(sliceBudgetMs);
 
         const resolvedConfig = tenantReposConfig || await this.resolveTenantReposConfig({ingestionService: knowledgeBaseIngestionService});
         const allRepos       = resolvedConfig.tenantRepos || [];

--- a/ai/scripts/lint/config-leaf-parity.json
+++ b/ai/scripts/lint/config-leaf-parity.json
@@ -467,6 +467,7 @@
         "orchestrator.tenantRepoSync.backoffCapMs",
         "orchestrator.tenantRepoSync.jitterRatio",
         "orchestrator.tenantRepoSync.leaseStaleAfterMs",
+        "orchestrator.tenantRepoSync.sliceBudgetMs",
         "orchestrator.tenantRepoSync.starvedAfterMs",
         "orchestrator.tenantRepoSync.sweepCadenceMs",
         "orchestrator.wakeDispatch",

--- a/ai/services/knowledge-base/IngestionService.mjs
+++ b/ai/services/knowledge-base/IngestionService.mjs
@@ -1211,7 +1211,18 @@ class IngestionService extends Base {
                     tenantId: tenantContext.tenantId,
                     repoSlug: normalized.repoSlug
                 }),
+                // `yielded` is a hard veto on minting, and it belongs HERE rather than only at the
+                // caller. A materialization receipt is a claim that the corpus is WHOLE: the next
+                // sweep matches it against the envelope digest and, on a hit, skips ingestion
+                // entirely. A bounded slice has positive effect — chunks really landed — so an
+                // effect-only test mints proof of completeness for a corpus with a remainder, and
+                // the checkpoint then settles over work that never landed. The slice is real
+                // progress and none of it is lost; what it is not is finished.
+                //
+                // This does NOT weaken crash-after-complete recovery: a run that exhausted its
+                // corpus reports `yielded: false` and mints exactly as before.
                 hasEffect      = summary.errors.length === 0
+                    && summary.yielded !== true
                     && [summary.ingested, summary.deleted]
                         .some(value => Number.isSafeInteger(value) && value > 0);
 

--- a/ai/services/knowledge-base/IngestionService.mjs
+++ b/ai/services/knowledge-base/IngestionService.mjs
@@ -311,6 +311,11 @@ class IngestionService extends Base {
                     chunks               : embeddableChunks,
                     onProviderTimeout    : controls.onProviderTimeout,
                     replayEmbeddingPoison: controls.replayEmbeddingPoison === true,
+                    // Fourth member of the control envelope, alongside signal / onProviderTimeout /
+                    // poison replay. Optional by construction: an absent predicate leaves
+                    // `embedChunks` on its `() => false` default, so a caller that supplies no
+                    // budget behaves exactly as it does today.
+                    shouldYield: controls.shouldYield,
                     signal               : controls.signal,
                     tenantContext,
                     summary,
@@ -453,7 +458,8 @@ class IngestionService extends Base {
         viaMcp = true,
         signal,
         onProviderTimeout,
-        replayEmbeddingPoison = false
+        replayEmbeddingPoison = false,
+        shouldYield
     }) {
         const groups = new Map();
 
@@ -473,6 +479,7 @@ class IngestionService extends Base {
                     deleteStale  : false,
                     onProviderTimeout,
                     replayEmbeddingPoison,
+                    shouldYield,
                     signal,
                     tenantContext: {...tenantContext, repoSlug},
                     viaMcp
@@ -532,7 +539,22 @@ class IngestionService extends Base {
                     }));
                 }
 
-                summary.embeddingsGenerated += result?.embedded ?? group.length;
+                // `result.embedded` or nothing — never `group.length`. The old fallback credited the
+                // ENTIRE group as landed whenever the field was absent, which is the one direction
+                // this counter must never round: `embeddingsGenerated` is the `embedded` term in
+                // `deriveOutstanding`, so over-crediting it reports a corpus as fully embedded while
+                // chunks are still outstanding, and the checkpoint settles over work that never
+                // landed. Under-counting is recoverable — the next sweep re-selects; over-counting
+                // is not, because nothing goes looking again.
+                summary.embeddingsGenerated += Number.isSafeInteger(result?.embedded) ? result.embedded : 0;
+
+                // A slice that stopped early is not a corpus that finished. Sticky across groups:
+                // one yielded group means the run as a whole did not exhaust its work, and a later
+                // complete group must not clear that.
+                if (result?.yielded === true) {
+                    summary.yielded = true;
+                }
+
                 this.updateIngestionProgress({
                     embeddedChunks: summary.embeddingsGenerated,
                     errorCount    : summary.errors.length
@@ -720,6 +742,11 @@ class IngestionService extends Base {
             deleted            : 0,
             embeddingsGenerated: 0,
             skippedOversized   : 0,
+            // False until an embed run reports it stopped on a budget rather than on exhaustion.
+            // Initialised here rather than left undefined so consumers can distinguish "this run did
+            // not yield" from "this summary predates the field" — an absent boolean reads as false
+            // and would let a stale producer look like a complete run.
+            yielded   : false,
             errors             : [],
             tenantId           : aiConfig.defaultTenantId,
             durationMs         : Date.now() - startedAt

--- a/ai/services/knowledge-base/VectorService.mjs
+++ b/ai/services/knowledge-base/VectorService.mjs
@@ -2237,6 +2237,12 @@ class VectorService extends Base {
         const embedResult = await this.embedChunks({
             collection,
             chunksToProcess,
+            // The shadow-swap branch has forwarded this since it was introduced; the incremental
+            // branch did not, so the whole cooperative-yield contract was live on one path and
+            // absent on the other — and the tenant lane runs incrementally. Without it a caller
+            // supplying a budget gets no yielding at all, silently, because a missing predicate is
+            // indistinguishable from one that never votes to stop.
+            shouldYield,
             signal,
             onProviderTimeout,
             knownPoisonEntries,
@@ -2262,7 +2268,13 @@ class VectorService extends Base {
             embedded: embedResult.embedded,
             deleted : idsToDelete.length,
             failedBatches,
-            poisonedChunks
+            poisonedChunks,
+            // The discriminator between "this corpus is done" and "this slice stopped early". Dropping
+            // it made the two indistinguishable to every caller, so a bounded slice reported the same
+            // shape as a complete run — the caller then persists a checkpoint over work that never
+            // landed. Absent predicate ⇒ `embedChunks` never yields ⇒ `false`, so this is additive and
+            // every existing caller keeps today's semantics.
+            yielded : embedResult.yielded === true
         };
     }
 

--- a/test/playwright/unit/ai/daemons/orchestrator/scheduling/tenantRepoSync.sliceBudget.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/scheduling/tenantRepoSync.sliceBudget.spec.mjs
@@ -1,5 +1,5 @@
 import {test, expect}                             from '@playwright/test';
-import {assertSliceBudgetMs}                      from '../../../../../../../ai/daemons/orchestrator/scheduling/tenantRepoSync.mjs';
+import {assertSliceBudgetMs, createSliceBudgetPredicate} from '../../../../../../../ai/daemons/orchestrator/scheduling/tenantRepoSync.mjs';
 import {KB_TENANT_REPO_SYNC_INVALID_SLICE_BUDGET} from '../../../../../../../ai/daemons/orchestrator/services/TenantRepoSyncErrors.mjs';
 
 /**
@@ -53,6 +53,47 @@ test.describe('TenantRepoSyncService — sliceBudgetMs value contract (#17132 AC
         // recovered later from disk.
         expect(thrown.meta?.received).toBe(0);
         expect(thrown.meta?.phase).toBe('config-validation');
+    });
+
+    test('the predicate is anchored per repo, so a later admission gets a full slice', () => {
+        // The defect this shape exists to avoid: one budget shared across the sweep is spent by the
+        // first admitted repo, and every later one is born already expired — a fairness fix that
+        // starves exactly the tail it was written for.
+        let   clock = 1_000;
+        const now   = () => clock;
+
+        const first = createSliceBudgetPredicate({startedMs: 1_000, sliceBudgetMs: 300_000, now});
+        clock = 250_000;
+        const second = createSliceBudgetPredicate({startedMs: clock, sliceBudgetMs: 300_000, now});
+
+        expect(first(),  'the head repo has burned 249s of its 300s').toBe(false);
+        expect(second(), 'a repo admitted at 250s starts its own 300s, not the remainder').toBe(false);
+
+        clock = 320_000;
+        expect(first(),  'the head repo is past its budget').toBe(true);
+        expect(second(), 'the later repo still has 230s of its own').toBe(false);
+    });
+
+    test('votes to yield only once the slice has outlived the budget, boundary inclusive', () => {
+        let   clock       = 0;
+        const shouldYield = createSliceBudgetPredicate({startedMs: 0, sliceBudgetMs: 1_000, now: () => clock});
+
+        expect(shouldYield()).toBe(false);
+        clock = 999;
+        expect(shouldYield(), 'one ms short must not yield').toBe(false);
+        clock = 1_000;
+        expect(shouldYield(), 'exactly at budget yields — the bound is reached, not exceeded').toBe(true);
+    });
+
+    test('an already-exhausted budget still votes true — the FLOOR is the consumer\'s, not the predicate\'s', () => {
+        // Worth pinning because it is the easy place to put the forward-progress guarantee and the
+        // wrong one. The predicate is honest: the budget is gone, so it says so. `embedChunks` is
+        // what refuses to check before the first batch (`cursor > 0`), which is why a repo admitted
+        // with nothing left still lands one batch. Moving that floor in here would duplicate a
+        // guarantee that already exists and hide which layer owns it.
+        const shouldYield = createSliceBudgetPredicate({startedMs: 0, sliceBudgetMs: 300_000, now: () => 900_000});
+
+        expect(shouldYield()).toBe(true);
     });
 
     test('CONTROL (non-vacuity): a string of digits is NOT coerced', () => {

--- a/test/playwright/unit/ai/daemons/orchestrator/scheduling/tenantRepoSync.sliceBudget.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/scheduling/tenantRepoSync.sliceBudget.spec.mjs
@@ -1,0 +1,66 @@
+import {test, expect}                             from '@playwright/test';
+import {assertSliceBudgetMs}                      from '../../../../../../../ai/daemons/orchestrator/scheduling/tenantRepoSync.mjs';
+import {KB_TENANT_REPO_SYNC_INVALID_SLICE_BUDGET} from '../../../../../../../ai/daemons/orchestrator/services/TenantRepoSyncErrors.mjs';
+
+/**
+ * The slice budget's value contract.
+ *
+ * `sliceBudgetMs` is the only thing bounding how long one tenant repo may hold a concurrency slot,
+ * so its validator refuses rather than substitutes. A value silently corrected back to something
+ * workable would leave an operator believing they had tuned fairness while the shipped guarantee
+ * was something else — and the symptom of that, a starved tail, is indistinguishable from the
+ * defect the budget exists to remove.
+ *
+ * `0` is the case worth naming: it is rejected like any other invalid value rather than read as a
+ * disable, because a disable sentinel here means "unlimited slot hold" spelled as an off switch.
+ */
+test.describe('TenantRepoSyncService — sliceBudgetMs value contract (#17132 AC1)', () => {
+    test('accepts a positive integer and returns it unchanged', () => {
+        expect(assertSliceBudgetMs(300_000)).toBe(300_000);
+        expect(assertSliceBudgetMs(1)).toBe(1);
+    });
+
+    test('REGRESSION: 0 is invalid, not a disable', () => {
+        // The footgun this refuses: `0` reading as "off" while behaving as "no bound at all".
+        let thrown;
+        try { assertSliceBudgetMs(0) } catch (error) { thrown = error }
+
+        expect(thrown, '0 must throw rather than disable the bound').toBeTruthy();
+        expect(thrown.code).toBe(KB_TENANT_REPO_SYNC_INVALID_SLICE_BUDGET);
+        // The message has to tell an operator what to do instead, or the refusal just blocks them.
+        expect(thrown.message).toContain('no disable value');
+    });
+
+    test('rejects negative, fractional, non-finite and non-numeric values', () => {
+        for (const bad of [-1, -300_000, 1.5, 0.1, NaN, Infinity, -Infinity, null, undefined, '300000', {}, []]) {
+            let thrown;
+            try { assertSliceBudgetMs(bad) } catch (error) { thrown = error }
+
+            expect(thrown, `${JSON.stringify(bad)} must be rejected`).toBeTruthy();
+            expect(thrown.code).toBe(KB_TENANT_REPO_SYNC_INVALID_SLICE_BUDGET);
+        }
+    });
+
+    test('the rejection carries the received value, so the operator sees what was resolved', () => {
+        // A config error that does not echo the offending value sends the operator hunting through
+        // env, overlay and template for a number the process already had in hand.
+        let thrown;
+        try { assertSliceBudgetMs(0) } catch (error) { thrown = error }
+
+        // `TenantRepoSyncError` stores its third constructor argument as `meta`, not `details` —
+        // the lane's whole taxonomy reads that way, and per-repo durable state persists only
+        // `lastErrorCode`, so anything richer has to be read from the live error rather than
+        // recovered later from disk.
+        expect(thrown.meta?.received).toBe(0);
+        expect(thrown.meta?.phase).toBe('config-validation');
+    });
+
+    test('CONTROL (non-vacuity): a string of digits is NOT coerced', () => {
+        // Proves the guard tests the TYPE and not merely the magnitude — `'300000'` is a plausible
+        // env-parse leak, satisfies every numeric comparison after coercion, and must still fail.
+        let thrown;
+        try { assertSliceBudgetMs('300000') } catch (error) { thrown = error }
+
+        expect(thrown, 'a numeric string must not pass as a validated budget').toBeTruthy();
+    });
+});

--- a/test/playwright/unit/ai/daemons/orchestrator/services/TenantRepoSyncService.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/services/TenantRepoSyncService.spec.mjs
@@ -6677,6 +6677,88 @@ test.describe('TenantRepoSyncService (#11790)', () => {
         // zero fails here rather than passing quietly on a plausible-looking number.
         expect(state.corpusOutstanding.outstanding).not.toBe(0);
     });
+
+    /*
+     * The slice-budget witness, driven through `syncTenantRepos` rather than `syncRepo`.
+     *
+     * A fixture calling one repo directly proves the branch and not the FAIRNESS, which only exists
+     * as a property of the sweep: four due repos at the live `concurrencyLimit = 2`, where the head
+     * repo yields on its budget. What must be observable is that repos beyond the first two admitted
+     * are ingested IN THE SAME SWEEP — the tail no longer waits for a head repo to complete.
+     *
+     * The assertion is ORDERING, never elapsed time. `embedChunks` checks its predicate between
+     * batches and never before the first, so a wall-clock arm ("A released within sliceBudgetMs")
+     * would fail against the primitive's own forward-progress guarantee and be the wrong shape.
+     */
+    test('a yielded head repo rotates its slot and the tail is admitted in the SAME sweep, with zero failure accounting (#17132 AC2/AC6)', async () => {
+        const
+            captureCalls = [],
+            repos        = ['org/alpha', 'org/beta', 'org/gamma', 'org/delta'].map(repoSlug => ({
+                tenantId: 't1', repoSlug, mirrorRoot,
+                cloneUrl: `https://github.com/neomjs/${repoSlug.split('/')[1]}.git`
+            }));
+
+        TenantRepoSyncService.concurrencyLimit = 2;
+
+        await TenantRepoSyncService.syncTenantRepos({
+            taskStateService             : createInMemoryTaskStateService(),
+            revisionsFilePath            : revisionsFile,
+            leaseGuard                   : async () => {},
+            tenantReposConfig            : {tenantRepos: repos},
+            gitMirror                    : makeFakeGitMirror(),
+            envelopeBuilder              : makeFakeEnvelopeBuilder({includeManifest: true}),
+            knowledgeBaseIngestionService: makeFakeIngestionService({
+                captureCalls,
+                // Only the head repo outruns its budget. The others exhaust their corpus normally,
+                // which is what makes the sweep a MIXED one rather than a uniformly-yielding
+                // fixture that could pass without the rotation working.
+                summaryFactory: payload => ({
+                    ingested           : 1,
+                    deleted            : 0,
+                    embeddingsGenerated: 1,
+                    errors             : [],
+                    yielded            : payload.repoSlug === 'org/alpha',
+                    tenantId           : payload.tenantId,
+                    durationMs         : 1
+                })
+            }),
+            globalCadenceMs: 0,
+            jitterRatio    : 0,
+            seedBootstrap  : false
+        });
+
+        const ingested = captureCalls
+            .filter(call => call.op === 'ingestSourceFiles')
+            .map(call => call.payload.repoSlug);
+
+        // Tail admission: with K=2 and a yielding head, all four still reach ingestion this sweep.
+        expect(ingested.length, 'every due repo must be admitted within the sweep').toBe(4);
+        expect(new Set(ingested).size).toBe(4);
+
+        const revisions = (await fs.readJson(revisionsFile)).revisions;
+
+        // The yielded repo records progress WITHOUT failure accounting. Being large is not a fault:
+        // an incremented streak here would climb a healthy rotating repo toward its backoff cap.
+        expect(revisions['t1/org/alpha'].consecutiveFailures, 'a budgeted rotation is not a failure').toBe(0);
+        expect(revisions['t1/org/alpha'].lastSourceErrorCode ?? null, 'nothing failed, so no cause may be retained').toBeNull();
+
+        // THE NEGATIVE ARM, and the one this test exists for. A partial positive effect must not
+        // mint full-materialization proof: the next sweep matches that receipt against the envelope
+        // digest and, on a hit, skips ingestion entirely — settling a checkpoint over a remainder
+        // that never landed. The complete repos SHOULD carry proof; the yielded one must not.
+        expect(
+            ingested.includes('org/alpha'),
+            'the head repo was never ingested, so the checkpoint arm below would pass vacuously'
+        ).toBe(true);
+        expect(
+            revisions['t1/org/alpha'].lastIngestedRev ?? null,
+            'the checkpoint must NOT advance for a corpus with an outstanding remainder'
+        ).toBeNull();
+        expect(
+            revisions['t1/org/beta'].lastIngestedRev,
+            'a repo that exhausted its corpus DOES advance — otherwise this arm passes by breaking everything'
+        ).toBeTruthy();
+    });
 });
 
 test.describe('the persisted cause DISCRIMINATES, and still leaks nothing (#16056)', () => {

--- a/test/playwright/unit/ai/services/knowledge-base/IngestionService.spec.mjs
+++ b/test/playwright/unit/ai/services/knowledge-base/IngestionService.spec.mjs
@@ -1316,6 +1316,53 @@ test.describe('IngestionService.persistManifestSnapshot receipt-absence diagnost
 
         expect(warnings.find(entry => entry.message.includes('without a materialization receipt'))).toBeFalsy()
     });
+
+    /*
+     * The receipt shortcut a slice budget opens.
+     *
+     * A materialization receipt asserts the corpus is WHOLE: the next tenant sweep matches it
+     * against the envelope digest and, on a hit, skips ingestion entirely. A budgeted slice has
+     * positive effect — chunks really landed — so an effect-only mint produces proof of
+     * completeness for a corpus with an outstanding remainder, and the following sweep settles a
+     * checkpoint over work that never landed.
+     *
+     * Asserted against the real `persistManifestSnapshot` rather than through the tenant sweep,
+     * because the sweep's own `partial-progress` branch returns before the checkpoint advances and
+     * would make this pass with the veto removed — a vacuous arm. This drives the rule directly.
+     */
+    test('REGRESSION: a yielded summary mints NO materialization receipt, however much landed', async () => {
+        const persist = yielded => Service.persistManifestSnapshot({
+            manifestSnapshot      : {repoSlug: 'slice-repo', pathsAfterPush: ['c.txt']},
+            files                 : [{sourcePath: 'c.txt', repoSlug: 'slice-repo', content: 'z'}],
+            headRevision          : 'sha-slice',
+            materializationAttempt: {attemptId: 'c'.repeat(32), ingestContractVersion: 2},
+            tenantContext         : {tenantId: 'slice-tenant', repoSlug: 'slice-repo'},
+            // Substantial positive effect on BOTH runs — the discriminator under test is `yielded`
+            // alone, so effect cannot be what separates them.
+            summary               : {ingested: 500, deleted: 0, errors: [], yielded}
+        });
+
+        await persist(true);
+
+        const afterYield = await Service.getTenantManifest({tenantId: 'slice-tenant', repoSlug: 'slice-repo'});
+
+        expect(
+            afterYield?.materializationReceipt ?? null,
+            'a bounded slice minted proof that the corpus is complete — the next sweep will match it and skip ingestion'
+        ).toBeNull();
+
+        // CONTROL: the identical call with `yielded: false` MUST mint. Without this the arm passes
+        // by proving receipts never mint at all, which would break crash-after-complete recovery
+        // and look like a fix.
+        await persist(false);
+
+        const afterComplete = await Service.getTenantManifest({tenantId: 'slice-tenant', repoSlug: 'slice-repo'});
+
+        expect(
+            afterComplete?.materializationReceipt ?? null,
+            'a run that exhausted its corpus must still mint — the veto is scoped to yielded runs'
+        ).toBeTruthy();
+    });
 });
 
 test.describe('IngestionService.classifyIngestionFailureCode (#16566)', () => {


### PR DESCRIPTION
Resolves neomjs/neo#17132

A tenant repo held its concurrency slot until its corpus was exhausted — the slot was released on completion, not on progress. With more due repos than slots the tail waited for a head repo to *finish*, which read client-side as "ingestion does not work": one repo crawling, the rest at zero, measured as siblings starved 4+ hours behind one backlog while sweeps fired every 60s. A repo now yields its slot on a budget and the next due repo is admitted in the same sweep.

Evidence: L2 (unit specs drive the production composition — `syncTenantRepos` with four due repos at the live `concurrencyLimit=2`, a real semaphore, and the real `persistManifestSnapshot`; only the ingestion/git seams are faked) → L2 required (every close-target AC is a code-path or state assertion, with no host-observable runtime effect). No residuals.

## Deltas from ticket

**AC-5 is not implemented as written, deliberately — it would retire a live observable.**

The ticket asks for `summary.ingested` to report chunks that actually landed. Reading the consumers first: `ingested` is *accepted* chunks, deliberately disjoint from `skippedOversized`, and `buildCorpusOutstandingObservation` already uses it as the `total` term against a separate `embeddingsGenerated` = landed, computing `outstanding = total − embedded − skipped`. **The two-field model AC-5 asks for already exists.** Collapsing `ingested` into "landed" makes `outstanding` identically zero and silently retires the observable whose entire purpose is stopping empty from reading as success.

Reading that code did surface a live defect at the same address, which is what AC-5's intent was reaching for:

```js
summary.embeddingsGenerated += result?.embedded ?? group.length;
```

That fallback credited the **entire group** as embedded whenever the field was absent — and `embeddingsGenerated` is the `embedded` term in that same calculation. Over-crediting reports a corpus as fully embedded while chunks are outstanding, and the checkpoint settles over work that never landed. It now counts `result.embedded` or nothing: under-counting is recoverable because the next sweep re-selects, over-counting is not, because nothing goes looking again.

So AC-5's intent — a partial slice must never claim the whole corpus — is served by that repair plus the new sticky `summary.yielded`, not by the field change prescribed. Raised with @neo-opus-vega as the ticket author.

**One anchor correction:** the ticket cites `acquire()` at `:2039` → `release()` at `:2539`. On current `dev` these are `:2139` → `:2651` (now guarded `if (slotAcquired)`). The shape is unchanged; the numbers drifted ~100 lines since 2026-08-15.

**Not in scope, unchanged:** `concurrencyLimit`'s missing env/leaf binding, named in the ticket's own Out of Scope.

## Test Evidence

```
npm run test-unit -- --grep "TenantRepoSync|tenantRepoSync|Ingestion|VectorService"  → 528 passed
npm run test-unit                                                                     → 13993 passed, 1 failed
node ai/scripts/lint/lint-config-template-ssot.mjs                                     → OK
```

The single full-suite failure is `ai/mcp/client/McpServersHealth.spec.mjs`, pre-existing and unrelated — verified earlier today against a clean base with unrelated changes stashed, where it fails identically.

**Mutation verification, three guards:**

| Mutation | Result |
|---|---|
| validator predicate relaxed to `value < 0` so `0` passes | 2 arms FAIL |
| slice-budget anchor collapsed to a shared constant | 2 arms FAIL |
| `summary.yielded !== true` removed from the receipt veto | receipt arm FAILS |

**One of my own arms was vacuous and mutation is what caught it.** My first receipt-shortcut assertion went through the tenant sweep and passed *with the veto removed* — because the `partial-progress` branch returns before the checkpoint advances, so `lastIngestedRev` stayed null either way. It proved the branch, not the veto. Replaced with a direct test of `persistManifestSnapshot`, plus a `yielded: false` control proving the veto is scoped rather than disabling minting outright (an arm that passed by never minting would break crash-after-complete recovery and look like a fix).

**The AC-6 witness asserts ordering, never elapsed time.** `embedChunks` checks its predicate between batches and never before the first, so an arm asserting "A released within `sliceBudgetMs`" would fail against the primitive's own forward-progress guarantee. The witness drives four due repos where only the head yields — a uniformly-yielding fixture could pass without rotation working — and asserts all four reach ingestion in the same sweep.

Directly touched surfaces: `ai/daemons/orchestrator` and `ai/services/knowledge-base` — `TenantRepoSyncService.spec.mjs`, `tenantRepoSync.sliceBudget.spec.mjs`, `IngestionService.spec.mjs`.

## Post-Merge Validation

None owed. Every close-target AC is discharged in-branch and no residual is deferred.

## Commits

- `5feaa43` — the `sliceBudgetMs` leaf, with the safe-point semantics and the revalidation trigger recorded in place.
- `d00fe8a` — the value contract: positive integer or refuse, `0` invalid rather than a disable.
- `333c8d3` — the incremental embed path honours the predicate it already accepted, and returns `yielded`.
- `627cae0` — the predicate threaded through ingestion; the `?? group.length` over-credit closed.
- `978681e` — a per-repo predicate anchored at admission.
- `01d6267` — `partial-progress` as an outcome, the receipt veto, visibility, and the witness.

## Evolution

Two pivots worth recording. The validator first lived beside its caller in `TenantRepoSyncService`; its spec failed instantly with `ReferenceError: Neo is not defined`, because importing the service boots the class system. A guard that cannot be exercised without booting Neo is a guard whose own contract goes untested — it moved to the pure scheduling module beside `isRepoDue`.

And the receipt veto was originally only the service's early return. Euclid's closing intake gate named the real shortcut: a partial positive effect reaching `persistManifestSnapshot` mints digest-matching completion proof, and the *next* sweep's `retryReceipt` branch consumes it and skips ingestion entirely. The veto therefore belongs at the mint site, not at one caller — otherwise any other path to `persistManifestSnapshot` re-opens it.

Authored by Grace (Claude Opus 5, Claude Code). Session 6ecf4cee-7b32-4d21-86ba-e4288b897be0.
