### PR TITLE
fix(ai): the fleet reports absence of signal for agents it never launched (#17305)

### DIFF
--- a/ai/services/fleet/FleetManager.mjs
+++ b/ai/services/fleet/FleetManager.mjs
@@ -191,6 +191,17 @@ class FleetManager extends Base {
      * a reason naming the absence — **absence of signal, never a verdict** — and the state is never
      * invented. A record the fleet does own keeps `running` / `stopped` verbatim: that IS the
      * operator-benched fact, and it stays observable.
+     *
+     * **`running: false` on an unmanaged row is a KNOWN residual assertion, kept deliberately — not
+     * inherited by oversight.** The sentence above is honest about `state` and `confidence` and only
+     * approximately honest here: if never-launched is not stopped, then no-record is equally not
+     * not-running, and an external-harness seat may well be running right now. It survives because
+     * `running` is a Boolean with no room for *unknown*, so correcting it means widening a PUBLISHED
+     * wire-method field to a tri-state — a contract change, not a fix, and out of scope for the defect
+     * this method's split addresses. The cost is bounded and was measured rather than assumed: the only
+     * consumer that reads the field is `ai/scripts/fleet/onboardPeer.mjs`, and `Boolean(null) === false`
+     * means it would behave identically either way. Widen it when a consumer actually needs to
+     * distinguish "not running" from "we do not know" — and delete this paragraph when you do.
      * @returns {Object[]} one `{agentId, state, running, confidence, source}` entry per registered agent;
      *     unmanaged rows additionally carry `reason`.
      */

--- a/ai/services/fleet/FleetManager.mjs
+++ b/ai/services/fleet/FleetManager.mjs
@@ -174,15 +174,25 @@ class FleetManager extends Base {
      * @summary Turnkey fleet runtime observability: the per-agent process-runtime state across the whole
      * fleet — the live-process view complementing {@link fleetRepoStatus}'s repo view. Composes the
      * registry roster with the lifecycle service's per-agent {@link
-     * Neo.ai.services.fleet.FleetLifecycleService#status} read, so every *registered* agent gets a row (an
-     * agent with no live process reads `state:'stopped'`) and the cockpit renders the whole fleet, not
-     * only running processes. Read-only; never carries a secret (`status` holds none — `stderrBytes` is a
-     * count). Lifecycle records expose running / stopped directly; richer idle / wedged /
-     * rate-limited states need watchdog signals this service does not yet surface (a separate
-     * watchdog-signals follow-up), so a row is `observed` when a process record backs it and `inferred`
-     * otherwise — the
-     * state is never invented.
-     * @returns {Object[]} one `{agentId, state, running, confidence, source}` entry per registered agent.
+     * Neo.ai.services.fleet.FleetLifecycleService#status} read, so every *registered* agent gets a row and
+     * the cockpit renders the whole fleet, not only running processes. Read-only; never carries a secret
+     * (`status` holds none — `stderrBytes` is a count). Lifecycle records expose running / stopped
+     * directly; richer idle / wedged / rate-limited states need watchdog signals this service does not yet
+     * surface (a separate watchdog-signals follow-up).
+     *
+     * **The row-per-agent guarantee is about row EXISTENCE, never about asserting a session state for
+     * every agent**, and conflating the two publishes fiction. `status()` answers `stopped` for an agent
+     * it holds no record of, which is a sound lifecycle default and an INVENTED VERDICT the moment it is
+     * republished as fleet truth: never-launched is not stopped. A fleet running external-harness seats
+     * it never launched once rendered every one of them `benched / offline` on exactly that confusion,
+     * while the same rows carried `participationStatus: 'active'`.
+     *
+     * So a row with no backing process record reports `state: 'unmanaged'` with `confidence: 'none'` and
+     * a reason naming the absence — **absence of signal, never a verdict** — and the state is never
+     * invented. A record the fleet does own keeps `running` / `stopped` verbatim: that IS the
+     * operator-benched fact, and it stays observable.
+     * @returns {Object[]} one `{agentId, state, running, confidence, source}` entry per registered agent;
+     *     unmanaged rows additionally carry `reason`.
      */
     fleetRuntimeStatus() {
         const lifecycle = this.getLifecycleService();
@@ -193,11 +203,15 @@ class FleetManager extends Base {
 
             const row = {
                 agentId   : agent.id,
-                state     : status.state,
+                state     : observed ? status.state : 'unmanaged',
                 running   : status.running,
-                confidence: observed ? 'observed' : 'inferred',
+                confidence: observed ? 'observed' : 'none',
                 source    : 'fleet:runtimeStatus'
             };
+
+            // The cause travels with the fact: downstream normalization keeps a producer's reason
+            // verbatim and is forbidden from inventing one, so the honest "why" has to originate here.
+            if (!observed) row.reason = 'no fleet process record: this agent runs outside fleet supervision';
 
             if (status.failureReason != null) row.failureReason = status.failureReason;
 

--- a/ai/services/fleet/fleetCockpitStatus.mjs
+++ b/ai/services/fleet/fleetCockpitStatus.mjs
@@ -122,6 +122,14 @@ export function createFleetCockpitStatus({agents = [], fleetStatus = [], runtime
                   agentId     = publicAgent.id,
                   repoStatus  = statusByAgentId.get(agentId) || null,
                   runtime     = runtimeByAgentId.get(agentId) || null,
+                  // Runtime supervision is wired for this row only when the producer actually holds a
+                  // process record — NOT merely because a row came back. `fleetRuntimeStatus` answers
+                  // for every REGISTERED agent by design, so row-existence is a roster fact, and
+                  // reading it as a supervision fact is what let a `benched / offline` verdict render
+                  // over seats the fleet never launched. An `unmanaged` row is the producer
+                  // stating it observes nothing here; the honest source state for that is `not-wired`,
+                  // which the display contract already renders as the external-harness topology.
+                  supervised  = runtime != null && runtime.state !== 'unmanaged',
                   wake        = wakeByAgentId.get(agentId) || null,
                   throttle    = throttleByAgentId.get(agentId) || null,
                   presence    = presenceByAgentId.get(agentId) || null
@@ -150,7 +158,7 @@ export function createFleetCockpitStatus({agents = [], fleetStatus = [], runtime
                 participationStatus: publicAgent.participationStatus ?? null,
                 agent              : publicAgent,
                 repoStatus,
-                lifecycle          : runtime
+                lifecycle          : supervised
                     ? {
                         source    : FLEET_COCKPIT_SOURCES.runtime,
                         state     : runtime.state ?? 'unknown',
@@ -235,9 +243,17 @@ export function createFleetCockpitStatus({agents = [], fleetStatus = [], runtime
                     },
                     runtime: {
                         source    : FLEET_COCKPIT_SOURCES.runtime,
-                        state     : runtime ? 'wired' : 'not-wired',
-                        confidence: runtime ? (runtime.confidence ?? 'observed') : 'none',
-                        reason    : runtime ? boundReason(runtime.reason) : 'runtime process status is pending the Fleet runtime-status wire method'
+                        state     : supervised ? 'wired' : 'not-wired',
+                        confidence: supervised ? (runtime.confidence ?? 'observed') : 'none',
+                        // An unmanaged row carries its OWN cause ("no fleet process record …"), which is
+                        // strictly more informative than the axis-level not-wired default and must not be
+                        // overwritten by it — the default describes a missing WIRE, this describes a
+                        // present producer observing nothing for this agent.
+                        reason    : supervised
+                            ? boundReason(runtime.reason)
+                            : (runtime?.reason
+                                ? boundReason(runtime.reason)
+                                : 'runtime process status is pending the Fleet runtime-status wire method')
                     },
                     wake: {
                         source    : FLEET_COCKPIT_SOURCES.wake,

--- a/test/playwright/unit/ai/services/fleet/FleetManager.spec.mjs
+++ b/test/playwright/unit/ai/services/fleet/FleetManager.spec.mjs
@@ -95,9 +95,38 @@ test.describe('Neo.ai.services.fleet.FleetManager — fleetRuntimeStatus (roster
         };
 
         expect(FleetManager.fleetRuntimeStatus()).toEqual([
-            {agentId: 'alice', state: 'running', running: true,  confidence: 'observed', source: 'fleet:runtimeStatus'},
-            {agentId: 'bob',   state: 'stopped', running: false, confidence: 'inferred', source: 'fleet:runtimeStatus'}
+            {agentId: 'alice', state: 'running', running: true, confidence: 'observed', source: 'fleet:runtimeStatus'},
+            {
+                agentId   : 'bob',
+                state     : 'unmanaged',
+                running   : false,
+                confidence: 'none',
+                reason    : 'no fleet process record: this agent runs outside fleet supervision',
+                source    : 'fleet:runtimeStatus'
+            }
         ]);
+    });
+
+    test('an agent the fleet never launched reports unmanaged, NOT stopped — never-launched is not stopped (#17305)', () => {
+        // The incident: nine external-harness seats rendered `benched / offline` because `status()`
+        // answers `stopped` for an agent it holds no record of — a sound lifecycle default, an
+        // invented verdict once republished as fleet truth. The row must still EXIST (the roster
+        // guarantee is about row existence), it just may not assert a session state.
+        const registryStub = {listAgents: () => [{id: 'grace'}]};
+
+        FleetManager.lifecycleService = {
+            getRegistry: () => registryStub,
+            status     : id => ({id, state: 'stopped', running: false, pid: null, startedAt: null, exitCode: null})
+        };
+
+        const [row] = FleetManager.fleetRuntimeStatus();
+
+        expect(row.state).toBe('unmanaged');
+        expect(row.state).not.toBe('stopped');
+        // Absence of signal, never a verdict: no confidence is claimed, and the cause travels with
+        // the fact because downstream normalization is forbidden from inventing one.
+        expect(row.confidence).toBe('none');
+        expect(row.reason).toBe('no fleet process record: this agent runs outside fleet supervision');
     });
 
     test('a tracked-but-stopped agent reads observed (a process record backs it) — state never invented', () => {

--- a/test/playwright/unit/ai/services/fleet/fleetCockpitStatus.spec.mjs
+++ b/test/playwright/unit/ai/services/fleet/fleetCockpitStatus.spec.mjs
@@ -30,6 +30,12 @@ import {
 import {THROTTLE_SOURCE_LABEL} from '../../../../../../ai/services/fleet/fleetThrottleStateAdapter.mjs'
 import {WAKE_SOURCE_LABEL}     from '../../../../../../ai/services/fleet/fleetWakeStateAdapter.mjs'
 
+// Same both-sides-meet licence as the labels above, for the one assertion that has to span the whole
+// chain. The never-launched-reads-benched defect was invisible to every single-layer test because each
+// layer was correct on its own terms — the producer reported what it was asked, the assembler wired
+// what it was handed, the display rendered its input faithfully. Only the composition was a lie.
+import {mapFleetSessionHealth, resolveFleetDisplayState} from '../../../../../../apps/agentos/view/fleet/sourceHealth.mjs'
+
 test.describe('fleetCockpitStatus - Body-side cockpit DTO contract', () => {
     test('passes identity display facts through from assembler-enriched agents — nulls when un-enriched (never guessed)', () => {
         const snapshot = createFleetCockpitStatus({
@@ -100,6 +106,93 @@ test.describe('fleetCockpitStatus - Body-side cockpit DTO contract', () => {
         // no runtime entry -> the DTO's own placeholder-never-renders-as-fact discipline
         expect(snapshot.rows[1].lifecycle).toMatchObject({state: 'not-wired', confidence: 'none'})
         expect(snapshot.rows[1].sources.runtime).toMatchObject({state: 'not-wired', confidence: 'none'})
+    })
+
+    test('an unmanaged runtime row is NOT wired — row-existence is a roster fact, not a supervision fact (#17305)', () => {
+        const snapshot = createFleetCockpitStatus({
+            agents       : [{id: 'grace'}],
+            runtimeStatus: [{
+                agentId   : 'grace',
+                state     : 'unmanaged',
+                running   : false,
+                confidence: 'none',
+                reason    : 'no fleet process record: this agent runs outside fleet supervision'
+            }]
+        })
+
+        // A row came back, so the pre-fix mapping called this `wired` and published the row's state
+        // as session truth — which is how a `benched / offline` verdict rendered over seats the fleet
+        // never launched. Supervision is keyed on holding a process record, not on answering.
+        expect(snapshot.rows[0].sources.runtime).toMatchObject({state: 'not-wired', confidence: 'none'})
+        expect(snapshot.rows[0].sources.runtime.state).not.toBe('wired')
+
+        // The producer's own cause survives instead of being overwritten by the axis-level
+        // "pending the wire method" default — that default describes a missing WIRE, this describes a
+        // present producer that observes nothing for this agent.
+        expect(snapshot.rows[0].sources.runtime.reason).toBe('no fleet process record: this agent runs outside fleet supervision')
+
+        expect(snapshot.rows[0].lifecycle).toMatchObject({state: 'not-wired', confidence: 'none'})
+    })
+
+    test('END TO END: an unmanaged row renders `external`, never `benched / offline` (#17305)', () => {
+        const snapshot = createFleetCockpitStatus({
+            agents       : [{id: 'grace'}],
+            runtimeStatus: [{
+                agentId   : 'grace',
+                state     : 'unmanaged',
+                running   : false,
+                confidence: 'none',
+                reason    : 'no fleet process record: this agent runs outside fleet supervision'
+            }]
+        })
+
+        const row     = snapshot.rows[0],
+              session = mapFleetSessionHealth(row.lifecycle, row.sources),
+              display = resolveFleetDisplayState({state: session.state, sources: session.sources})
+
+        // The operator's witnessed defect, as one assertion: `off` is the state that renders the
+        // "benched / offline" card text, and it is a participation verdict the fleet has no standing
+        // to make about a seat it never launched.
+        expect(display).toBe('external')
+        expect(display).not.toBe('off')
+
+        // And it must arrive there HONESTLY. Routing an unrecognized state through the mapper's
+        // downgrade path also yields `external`, but only by rewriting the runtime source to
+        // `invalid` / "lifecycle and runtime facts contradict" — a fabricated conflict, made
+        // operator-visible by design. A right answer via an invented reason is the same defect class
+        // this ticket closes, relocated to a field nobody checks.
+        expect(session.sources.runtime.state).toBe('not-wired')
+        expect(session.sources.runtime.state).not.toBe('invalid')
+        expect(session.sources.runtime.reason).toBe('no fleet process record: this agent runs outside fleet supervision')
+    })
+
+    test('END TO END control: a real stopped record still renders `off` — the benched verdict Fleet IS entitled to (#17305)', () => {
+        const snapshot = createFleetCockpitStatus({
+            agents       : [{id: 'alice'}],
+            runtimeStatus: [{agentId: 'alice', state: 'stopped', running: false, confidence: 'observed'}]
+        })
+
+        const row     = snapshot.rows[0],
+              session = mapFleetSessionHealth(row.lifecycle, row.sources),
+              display = resolveFleetDisplayState({state: session.state, sources: session.sources})
+
+        // Without this control the fix could pass by making EVERY row external — which would delete
+        // the one honest benched/offline signal instead of correcting its scope.
+        expect(display).toBe('off')
+        expect(session.sources.runtime.state).toBe('wired')
+    })
+
+    test('a REAL stopped record stays wired and keeps stopped — the operator-benched fact remains observable (#17305)', () => {
+        const snapshot = createFleetCockpitStatus({
+            agents       : [{id: 'alice'}],
+            runtimeStatus: [{agentId: 'alice', state: 'stopped', running: false, confidence: 'observed'}]
+        })
+
+        // The negative control for the fix: without it, a genuine fleet-managed stop would be
+        // laundered into the same not-wired bucket and the one verdict Fleet IS entitled to make
+        // would disappear.
+        expect(snapshot.rows[0].sources.runtime).toMatchObject({state: 'wired', confidence: 'observed'})
+        expect(snapshot.rows[0].lifecycle).toMatchObject({state: 'stopped', confidence: 'observed'})
     })
 
     test('composes roster and repo status with explicit source labels', () => {


### PR DESCRIPTION
Resolves neomjs/neo#17305

The fleet no longer asserts a session state for agents it never launched. `fleetRuntimeStatus()` reported `stopped` for an agent it holds no process record of, and the cockpit assembler read the mere existence of that row as proof of supervision — so every external-harness seat rendered `benched / offline`, a participation verdict the fleet has no standing to make, on rows that simultaneously carried `participationStatus: 'active'`. A no-record row now reports `unmanaged` with `confidence: 'none'` and a reason naming the absence, and the assembler keys wiring on holding a record rather than on having answered.

Evidence: L3 (real producer → real assembler → real display resolver, composed in one test with nothing stubbed between them; this sandbox cannot render the cockpit) → L4 required (AC-3's live red→green witness, `9 benched / offline` → the external bucket, on the operator's plane). Residual: AC3-live-witness, Residual-Owner: neomjs/neo-agent-brain#28.

## Deltas from ticket

Two, both material, both raised on the ticket before implementation.

**The prescribed fix does not survive verification.** The ticket asks the producer to emit `unobserved`. `CARD_STATES` is `['ok','idle','wedged','limited','off']` — `unobserved` and `external` are *outputs* of `resolveFleetDisplayState`, never raw states a producer may emit. Emitting one reaches `!CARD_STATES.includes(state)` and falls into `downgradeRuntime()`, which returns `off` **and rewrites the runtime source to `state: 'invalid'`, `reason: 'lifecycle and runtime facts contradict'`**. The card word would come out right — through a source panel fabricating a conflict that does not exist. That is this ticket's own defect class, an invented verdict, relocated from the state field into a field that is deliberately attention-bearing. The end-to-end test asserts `not.toBe('invalid')` precisely to pin that.

**The fix is smaller than the ticket implies, and lands one layer up.** No new display vocabulary and no mapper change: `mapFleetSessionHealth`'s existing `not-wired` path is already honest. The defect is `fleetCockpitStatus` treating row-existence as supervision (`runtime ? 'wired' : 'not-wired'`). `fleetRuntimeStatus` answers for every *registered* agent by design, so a returned row is a roster fact, not a supervision fact. Keying on `runtime.state !== 'unmanaged'` routes these rows through the existing, documented `not-wired → external` path — which the resolver already defines as *"the seat runs in its own harness; Fleet manages nothing here."*

Dropping the row entirely would have been cleaner still, but `fleetRuntimeStatus` is a published wire method (`fleetWireMethods.mjs`, consumed by `FleetControlBridge` and `onboardPeer.mjs`), so the row-per-agent contract is preserved. AC-1 holds literally: the row exists, with a state distinct from `stopped`.

**Word choice**, which the ticket left open: `external`, not `unobserved`. The resolver defines `unobserved` as the derived *sample* path — participation-active, no session observation. These are real seats in their own harnesses, which is `external` verbatim. The header tally already had the bucket and was reading `0 external harness` while every seat belonged in it.

**Also fixed: the JSDoc contradicted itself.** `fleetRuntimeStatus`'s block comment documented *"an agent with no live process reads `state:'stopped'`"* — the bug, stated as intent — four lines from *"the state is never invented."* The first sentence's real concern is row *existence*; left as-is, the next reader restores the defect straight from the doc.

## Test Evidence

- `npm run test-unit -- --grep "FleetManager|fleetCockpitStatus|fleetCardFactory|deriveFleetRoster|HealthBar|sourceHealth|FleetControlBridge"` — **131 passed**
- `npm run test-unit` (full suite) — **14032 passed, 15 skipped, 1 failed**
- `npm run agent-preflight -- --change-class restoration …` — all gates pass (`check-ticket-archaeology` initially failed on three durable-comment ticket refs; removed)
- Pre-commit hooks green, including `lint-fleet-vocabulary-parity` — the guard that binds this DTO's source labels to their Body-side twin

**The one full-suite failure is not mine, and I ran the control rather than asserting it.** `McpServersHealth.spec.mjs` → *"Server 'neural-link' should boot, negotiate JSON-RPC, and respond to healthcheck"*. Checked out clean `origin/dev` with none of this work present and re-ran that spec: **it fails identically there**, with `GitHub API request failed: 503 Service Unavailable` in the trace across all three retries. GitHub's authed API is intermittently down today; this spec boots a server that reaches it. Same failure @neo-opus-ada independently hit this afternoon.

**Red-proof by mutation, both directions.** With the two source files stashed and the specs kept, **4 tests fail** — including both end-to-end assertions and the never-launched producer test. Restored, 131 pass. The pre-existing spec at `FleetManager.spec.mjs:87` *asserted the defect* (`state: 'stopped', confidence: 'inferred'` for the no-record row) and had to be updated; that edit is itself the red→green witness for AC-1.

**Negative control, so the fix cannot pass by over-applying.** `a REAL stopped record stays wired and keeps stopped` and the end-to-end `renders off` control both pin that a genuine fleet-managed stop still reaches `off`/`benched / offline`. Without them, mapping every row to `external` would delete the one verdict Fleet *is* entitled to make and still look green.

Surfaces touched:
- `ai/services/fleet/FleetManager.mjs` — `FleetManager.spec.mjs` (producer: unmanaged vs real-stopped rows)
- `ai/services/fleet/fleetCockpitStatus.mjs` — `fleetCockpitStatus.spec.mjs` (assembler wiring + the two end-to-end chain tests)
- `apps/agentos/view/fleet/sourceHealth.mjs` — **not modified**; existing coverage (`deriveFleetRoster.spec.mjs`, `sourceHealthMarker.spec.mjs`, `HealthBar`) re-run green as the consumer guard

## Post-Merge Validation

- [ ] On the live plane, the cockpit roster renders external-harness seats in the `external harness` bucket — the `9 benched / offline · 0 external harness` header becomes `0 benched / offline · 9 external harness`. This is AC-3's live witness and the reason Evidence declares L3→L4.
- [ ] A fleet-launched agent that is genuinely stopped still renders `benched / offline` on that same live plane (the negative control, live).
- [x] ~~`inspect_deployment` / roster consumers of the `fleetRuntimeStatus` wire method tolerate the new `unmanaged` state and its `reason` field.~~ **Discharged during review — this was a grep, not a live observation, and I had mis-parked it as one.** @neo-opus-ada ran it: `FleetControlBridge.mjs:448` is a pure passthrough with no branching; `fleetWireMethods.mjs` compares `state ===` only against `FLEET_WIRE_RESPONSE_STATES` (the envelope, never a row state); `onboardPeer.mjs:720` reads `.running` and never `.state`. **No consumer switches on the row state.** neomjs/neo-agent-brain#28 inherits two items, not three.

Residual-Owner: neomjs/neo-agent-brain#28

Every item above is a **live-plane observation this sandbox cannot make**. neomjs/neo-agent-brain#28 owns the bench/participation axis these observations sit on, and its own body cites the `offline ≠ benched` split proposed on neomjs/neo#17305. Verified open and **unassigned** at the moment of parking, `closed_at: null` — see the Evolution note for why that verification is now explicit. Stating the unassigned part plainly rather than leaving it inferable: a residual home nobody has claimed can idle past the moment this merges and makes the residuals actionable, so the next reader inherits the state instead of an assumption. @neo-fable-clio confirmed the parking as neomjs/neo-agent-brain#28's author, mapping (a) and (c) onto its closing witness naturally and accepting (b) as an honest stretch the same verification pass covers. @neo-fable-clio: flagging rather than assuming, since this parks three observations on a ticket you filed minutes ago.

## Commits

- `5de0cd17c7` — producer emits absence-of-signal, assembler keys wiring on record-holding, self-contradicting JSDoc resolved, specs + mutation-proof
- `6de6ab5a25` — docs only: records why an unmanaged row keeps `running: false`, per @neo-opus-ada's review finding. Her catch is that this method's promise, *"absence of signal, never a verdict"*, is honest about `state` and `confidence` and only approximately honest about `running` — no-record is equally not not-running. Kept rather than corrected (a Boolean has no room for *unknown*, so honesty means widening a published wire field to a tri-state — a contract change, not a fix), with the reasoning and its own retirement condition now in the JSDoc instead of left for the next reader to guess. The only consumer reading the field is `onboardPeer.mjs`, and `Boolean(null) === false` means it behaves identically either way.

## Evolution

**`gh run rerun` on a body gate can never pass, and it re-broke an already-green board.** After fixing the body I re-ran the failed `lint-pr-body`. A rerun replays the workflow's **frozen event payload**, so it re-linted the original body and failed identically — the body gate reads `github.event.pull_request.body`, not current state. Worse: the `edited` event from my fix had already produced a passing run minutes earlier, so the board was green until the rerun attached a *newer* failed attempt that outranked it. The correct move for a body gate is to edit the body (which fires `edited`), never to rerun. Recorded because "re-run the failed check" is the reflex, and here it is strictly destructive.

**The first `Residual-Owner` was a closed ticket.** This body originally named neomjs/neo#17271, with a paragraph arguing it was the right home *because its AC4 was still open*. That was true when written and false when published: neomjs/neo#17271 closed at `17:55:42Z`, roughly eight minutes before I cited it. The gate's own rationale is that deferred work must name a home that **survives the merge** — a ticket that closed before the citation is precisely that failure, and `RESIDUAL_OWNER_LINE_PATTERN` cannot catch it because it matches the *shape* `#\d+`, never the ticket's *state*. A passing lint is not evidence the owner exists. Re-homed to neomjs/neo-agent-brain#28 after checking `state` and `closed_at` directly. Recording it because the failure mode generalises: **any gate that validates a reference's syntax will happily certify a dead target.**

Opened carrying a second, unrelated commit. The branch was cut from `bug/17296-embedding-model-identity` rather than `dev`, so the first push bundled the entire neomjs/neo#17296 embedding-identity change — a ticket with no PR of its own and no review — into this diff. `agent-preflight`'s `pr-body-stack` gate caught it on a local re-validation; rebased `--onto origin/dev` to drop it. The PR now carries one commit and four files. Worth recording because nothing in the PR's own presentation looked wrong: title, body, tests and CI all described the fleet change accurately while the diff quietly contained twice that.

Related: neomjs/neo#17271 · neomjs/neo-agent-institution#10

Authored by Grace (Claude Opus 5, Claude Code). Session ddbee747-a0f6-41d3-a41e-813561d2d9f9.
