### PR TITLE
docs(agentos): context recovery reads what the agent SENT, not only what it received (#16618)

### DIFF
--- a/.agents/skills/context-recovery/references/context-recovery-workflow.md
+++ b/.agents/skills/context-recovery/references/context-recovery-workflow.md
@@ -42,10 +42,13 @@ message already redirects it.
      self-DM (`from == to == @me`) in full, *regardless of read status* — bulk
      `mark_read` and read-projection rollbacks hide it from `unread` scoping.
      None → `sunset-body: none-found`.
-   - **Outbox:** `list_messages({box:'outbox'})` over the current window — relayed
-     rulings, lane claims, review verdicts. A ruling you RELAYED lives only in what
-     you SENT, and contradicting your own broadcast is worse than not knowing it,
-     because peers have already acted. None → `outbox: none-in-window`.
+   - **Outbox:** `list_messages({box:'outbox'})` over the current window. The test is
+     not what KIND of thing you sent but whether the outbox is its ONLY durable
+     holder — a relayed ruling, a lane claim, a verdict, a measurement, a negative
+     result: none of these reach your inbox, your turn memories, or GitHub. Harm
+     needs no reader. A row with `readAt: null` still costs silent re-derivation and
+     a second, contradicting answer published beside the first, both yours. None →
+     `outbox: none-in-window`.
 2. **Recency feed:** call `query_recent_turns({agentIdentity: '@me', detail:
    'summary', limit: 20})` first. This is the chronological axis: identify the
    last lane, PR/ticket ids, branch, review verdicts, blockers, and unresolved

--- a/.agents/skills/context-recovery/references/context-recovery-workflow.md
+++ b/.agents/skills/context-recovery/references/context-recovery-workflow.md
@@ -35,6 +35,17 @@ message already redirects it.
 
 1. **Mailbox first:** call `list_messages({status: 'unread'})` and classify each
    unread item as actionable, FYI, lane collision, blocker, or redirect.
+
+1a. **Read what YOU sent** — every other axis here reads what was done TO you, so
+   nothing else surfaces your own commitments. Neither read blocks; record the null.
+   - **Sunset handover, BODY not subject:** `get_message` the latest continuity
+     self-DM (`from == to == @me`) in full, *regardless of read status* — bulk
+     `mark_read` and read-projection rollbacks hide it from `unread` scoping.
+     None → `sunset-body: none-found`.
+   - **Outbox:** `list_messages({box:'outbox'})` over the current window — relayed
+     rulings, lane claims, review verdicts. A ruling you RELAYED lives only in what
+     you SENT, and contradicting your own broadcast is worse than not knowing it,
+     because peers have already acted. None → `outbox: none-in-window`.
 2. **Recency feed:** call `query_recent_turns({agentIdentity: '@me', detail:
    'summary', limit: 20})` first. This is the chronological axis: identify the
    last lane, PR/ticket ids, branch, review verdicts, blockers, and unresolved
@@ -53,6 +64,10 @@ message already redirects it.
 Use `detail: 'full'` only when summaries are insufficient to identify the next
 action. Summary detail is the cheap graph-first path; full detail joins Chroma
 for prompt/response content and should be targeted.
+
+**A recall miss never supports a "was never saved" claim.** A failed search is
+evidence about the index, not the store; a failed or truncated read is not a read
+that found nothing. Read the primary artifact before asserting any absence.
 
 6. **Identity quarantine (post-compaction prior):** the self-story is the
    context most silently reconstructed after compaction — nothing fails loudly
@@ -88,6 +103,8 @@ Produce a compact recovery ledger before resuming:
 ```text
 context-recovery:
 - mailbox: <count + actionable ids>
+- sunset-body: <messageId read in full | none-found>
+- outbox: <commitments already published | none-in-window>
 - recency: <last ticket/PR/branch/action>
 - semantic: <memory ids or clear miss>
 - live-state: <issue/PR/branch verification>


### PR DESCRIPTION
Resolves #16618

🌿 *Recovery could reconstruct everything done **to** an agent, and nothing it had **said** — so contradicting your own broadcast was unsayable-as-a-defect until someone did it twice.*

## Why

Every axis in the recovery sequence reads something done **to** the agent: messages received, turns recorded, live GitHub. Nothing reads what the agent itself published. Two incidents four days apart landed in that gap.

**2026-08-07** — an agent ran the full runbook, drained a 64-message mailbox by subject plus bulk `mark_read`, then publicly asserted a decision from its own sunset session *"was never memory-saved"* — while it sat durably in the **body** of its own continuity self-DM, whose subject had been read and marked read. The false negative propagated into a persistent identity memory and was only caught by the operator recovering the prior transcript by hand.

**2026-08-17** — @neo-opus-grace relayed an operator ruling to `AGENT:*` at `11:07:44`, compacted, forgot it, told a peer a seat *"could never have cleared §6.1"*, then asked the operator a question her own broadcast had already answered. She found it by checking her outbox after being challenged, and verified rather than conceded.

## What the second incident changed about this ticket

The fix **as originally prescribed on the ticket** — read the latest sunset self-DM — matches `from == to == @me`, so it would have missed her entirely. This patch does not: the outbox read is unconditional and catches her case. Her commitment went to `AGENT:*`: not her inbox, not distinctive in the recency feed, not on GitHub at all. The sunset self-DM is one instance of the class, not the class.

## What the third specimen changed, after review

@neo-opus-ada found the third shape by running this probe on **herself** and it falsified my scoping, so the payload no longer enumerates. Her specimen is a `defect-note` she broadcast at `2026-08-17T20:22:08Z` with `readAt: null`, then re-derived the same territory this morning and landed on a *different* model — two numbers for one phenomenon in the fleet record, both hers.

It breaks the enumeration in two independent ways:

- **A defect-note binds no one.** My named instances — a relayed ruling, a lane claim — are all *commitments*. An agent checking "does this apply to me?" against `relayed rulings, lane claims, review verdicts` gets **no** for a finding or a measurement, even though the probe would have fired.
- **My rationale was narrower than my own probe.** I justified with *"because peers have already acted."* Hers had `readAt: null` — no peer acted at all — and the harm landed anyway.

So the payload now names the **property** rather than the shapes: whether the outbox is the input's *only durable holder*. That covers commitments, findings, measurements and negative results alike, and it drops the peer-action dependency her specimen falsified. `readAt` is named too, since it is the field that distinguishes "nobody has seen this" from "peers already acted on it" — which changes what you do next, not whether you look.

## Changes

- **§3 step 1a** — both reads under one heading, framed by why nothing else surfaces them. Sunset handover body-read **regardless of read status** (bulk `mark_read` and read-projection rollbacks hide it from `unread` scoping); outbox scan over the current window for relayed rulings, lane claims, review verdicts. Neither blocks; both record a null and continue.
- **§4 ledger** — `sunset-body:` and `outbox:` rows, so recovery output proves the reads ran rather than asserting they did.
- **§3** — a recall miss never supports a "was never saved" claim: a failed search is evidence about the index, and a failed or truncated read is not a read that found nothing.

## Deltas

- **Scope amended on the ticket before implementing.** #16618 was unassigned and scoped to the sunset self-DM only; I self-assigned, recorded the 2026-08-17 incident beside the 2026-08-07 one, and added the outbox AC plus its ledger row. Folded rather than filed a sibling — same root (*a send-side mandate with no read-side dual*, the ticket's own phrase), same twelve lines of payload.
- **Compressed twice, then took the exception honestly.** 1342 → 1125 bytes against a 250-byte net cap; the review round added 208 more for the property rewrite, so the shipped delta is **+1333**. Declaring the growth rather than quietly re-baselining it: the exception's basis is unchanged (zero per-turn bytes), but the number it covers is bigger than when I first claimed it. `[skill-growth-justified:]` is in the commit, single-line as the matcher requires (`/\[skill-growth-justified:\s*[^\]\n]+\]/i` — my first attempt spanned ten lines and silently failed to match).
- **I did not pay for these bytes by compressing §3 step 6's per-harness identity diagnostics.** That was the available removal and I declined it: the content is load-bearing for harnesses I do not own, and trimming someone else's guidance to fund my feature is worse substrate behaviour than an honest exception.

## Gates

- **ADR-0007** read first, as the substrate-mutation gate requires. 3-axis: task-triggered frequency, high failure-severity, discipline-only enforceability → a skill payload, not an L1 anchor rule.
- **turn-memory-pre-flight** decision tree: Step 1 no (not every turn), Step 2 yes (an identifiable lifecycle event whose skill already exists) → the `context-recovery` payload. Placement confirmed, not assumed.
- **Load-runtime effect verified mechanically, not asserted:** this payload appears in neither `.claude/settings.json` nor `.codex/hooks.json`; the router reads it via `view_file` on trigger. The addition costs **zero per-turn bytes** — which is the whole basis of the growth exception.
- Progressive Disclosure held: references payload only, router `SKILL.md` untouched, no hooks or detectors, nothing added to `AGENTS.md`.

## Test Evidence

```
node ai/scripts/lint/lint-skill-manifest.mjs --base origin/dev   → OK
npm run ai:check-substrate-size                                  → PASSED
```

Evidence: L1 (documentation-only substrate change) → L1 required. No runtime surface; the ACs are satisfied by the payload text and the two lint gates. No residuals.

## Post-Merge Validation

None owed. Every AC discharges in-branch and both gates run in CI.

Authored by Vega (Claude Opus 5, Claude Code). Origin Session ID: 68271c49-daeb-444e-9d49-6f843639d224

