### PR TITLE
fix(fleet): memories read failures carry their cause and re-drive on reconnect (#17307)

### DIFF
--- a/ai/services/fleet/fleetMemoriesSource.mjs
+++ b/ai/services/fleet/fleetMemoriesSource.mjs
@@ -34,10 +34,12 @@ function toMs(value, name) {
 
 /**
  * @summary Reduce one read failure to a projection-safe diagnostic detail: message extracted,
- * whitespace collapsed, bounded to 240 chars, credential families masked through the shared
- * redaction authority. The consuming catch used to discard the error entirely, leaving
- * `memories-read-failed` as the whole story — a diagnosis that costs probes exactly one carried
- * field would have made free.
+ * whitespace collapsed, credential families masked through the shared redaction authority, and
+ * ONLY THEN bounded to 240 chars — redaction replaces, and a replacement can be longer than its
+ * match, so a cap applied before it does not bind. Redacting the whole message first is also
+ * strictly safer than redacting a truncation of it. The consuming catch used to discard the
+ * error entirely, leaving `memories-read-failed` as the whole story — a diagnosis that costs
+ * probes exactly one carried field would have made free.
  * @param {*} error The thrown value; non-Errors are coerced.
  * @returns {String|null} the sanitized detail, or `null` when nothing legible remains.
  * @private
@@ -46,9 +48,9 @@ function redactReadFailure(error) {
     // an Error owns its message even when empty — falling through to String(error) would turn a
     // message-less throw into the literal word "Error", a detail that details nothing
     const raw  = typeof error?.message === 'string' ? error.message : error == null ? '' : String(error),
-          text = raw.replace(/\s+/g, ' ').trim().slice(0, 240);
+          text = redactCredentials(raw.replace(/\s+/g, ' ').trim()).slice(0, 240);
 
-    return text ? redactCredentials(text) : null
+    return text || null
 }
 
 /**

--- a/ai/services/fleet/fleetMemoriesSource.mjs
+++ b/ai/services/fleet/fleetMemoriesSource.mjs
@@ -8,6 +8,8 @@
  * honest capability state, never a fabricated empty history.
  */
 
+import {redactCredentials} from './redactCredentials.mjs';
+
 const
     CANONICAL_IDENTITY = /^@[A-Za-z0-9][A-Za-z0-9._-]*$/,
     MAX_LIMIT          = 50,
@@ -28,6 +30,25 @@ function toMs(value, name) {
     }
 
     return ms
+}
+
+/**
+ * @summary Reduce one read failure to a projection-safe diagnostic detail: message extracted,
+ * whitespace collapsed, bounded to 240 chars, credential families masked through the shared
+ * redaction authority. The consuming catch used to discard the error entirely, leaving
+ * `memories-read-failed` as the whole story — a diagnosis that costs probes exactly one carried
+ * field would have made free.
+ * @param {*} error The thrown value; non-Errors are coerced.
+ * @returns {String|null} the sanitized detail, or `null` when nothing legible remains.
+ * @private
+ */
+function redactReadFailure(error) {
+    // an Error owns its message even when empty — falling through to String(error) would turn a
+    // message-less throw into the literal word "Error", a detail that details nothing
+    const raw  = typeof error?.message === 'string' ? error.message : error == null ? '' : String(error),
+          text = raw.replace(/\s+/g, ' ').trim().slice(0, 240);
+
+    return text ? redactCredentials(text) : null
 }
 
 /**
@@ -110,7 +131,10 @@ export function createFleetMemoriesSource({
          * operation. Success passes the operation's rows through untouched under a `wired`
          * capability with the honest corpus `total`; an operation failure or unrecognized payload
          * becomes an `unavailable` envelope carrying zero rows — a wired empty page is claimed
-         * ONLY when the operation itself answered one.
+         * ONLY when the operation itself answered one. A failure envelope additionally carries a
+         * sanitized `detail` (whitespace-collapsed, 240-bounded, credential-redacted) so the
+         * surface can say WHY beside the constant reason — absence of the field means the error
+         * had no legible message, never that nothing failed.
          * @param {Object} [params]
          * @param {String} [params.agentIdentity] Canonical `@identity` target; defaults to the viewer.
          * @param {Number} [params.offset] Paging offset into the target's summaries, newest-first.
@@ -148,8 +172,15 @@ export function createFleetMemoriesSource({
                     ...(offset > 0 ? {offset} : {})
                 })
             } catch (error) {
+                const detail = redactReadFailure(error);
+
+                // one fact, two consumers: the envelope carries it to the operator surface, the
+                // warn is the fleet child's own copy — the log line whose absence made this
+                // failure class silently undiagnosable server-side
+                console.warn(`[fleet] memories read failed (${target}): ${detail ?? 'no legible error'}`);
+
                 return {
-                    capability: {state: 'unavailable', reason: 'memories-read-failed', capturedAt},
+                    capability: {state: 'unavailable', reason: 'memories-read-failed', capturedAt, ...(detail ? {detail} : {})},
                     ...shared,
                     sessions: [],
                     count   : 0,

--- a/apps/agentos/view/fleet/FleetCockpit.mjs
+++ b/apps/agentos/view/fleet/FleetCockpit.mjs
@@ -3020,6 +3020,12 @@ class FleetCockpit extends Container {
      * generation fences drop stale answers, and the same routing matrices write the state — the
      * button only collapses the up-to-one-cadence wait into "now". Works identically in both
      * topologies (the browser flow has the same stale-offline problem after a late server start).
+     *
+     * The pane histories (memories / catch-up / wake routes) ride this re-drive for a stronger
+     * reason: they have NO cadence at all — request-driven only — so a failed first read would
+     * otherwise sit as its unavailable envelope forever. Re-driving goes THROUGH each pane's own
+     * refresh handler, whose guards (active agent, partition) decide whether there is a request
+     * to make; a pane with no selection stays silent rather than fabricating one.
      */
     reconnectFleet() {
         let me = this;
@@ -3027,7 +3033,15 @@ class FleetCockpit extends Container {
         me.loadActivity();
         me.loadRoster();
         me.loadBrainHealth();
-        me.ensureViewerWakeStream()
+        me.ensureViewerWakeStream();
+
+        // The pane histories are liveness seams too: a failed first read pins its unavailable
+        // envelope until SOME re-request happens, and before this line the only such request was a
+        // manual pane action — the dead-pane gap. Each pane's own refresh handler carries its
+        // guards (active agent / partition), so re-driving through it is exactly the button's path.
+        me.getReference('memories')?.onRefreshClick();
+        me.getReference('catch-up')?.onRefreshClick();
+        me.getReference('wakeRoutes')?.onRefreshClick()
     }
 
     /**

--- a/test/playwright/unit/ai/services/fleet/fleetMemoriesSource.spec.mjs
+++ b/test/playwright/unit/ai/services/fleet/fleetMemoriesSource.spec.mjs
@@ -135,6 +135,22 @@ test.describe('fleetMemoriesSource — viewer-bound session-summary recall', () 
         expect(detail.length).toBeLessThanOrEqual(240)
     });
 
+    test('the 240 bound holds in the EXPANSION direction — redaction runs before the cap, so growing replacements cannot exceed it', async () => {
+        const {source, state} = harness();
+
+        // the fixture that can fail: each `ghp_a` fragment (5 chars) redacts to a LONGER literal
+        // label, so a raw message already at the cap grows far past it unless the bound is applied
+        // AFTER redaction — under slice-then-redact this measured 611
+        state.result = new Error('ghp_a '.repeat(40).trim());
+
+        const result = await source.readMemories({}),
+              detail = result.capability.detail;
+
+        expect(result.capability).toMatchObject({state: 'unavailable', reason: 'memories-read-failed'});
+        expect(detail).not.toContain('ghp_a');
+        expect(detail.length).toBeLessThanOrEqual(240)
+    });
+
     test('a message-less failure omits the detail field rather than carrying an empty claim', async () => {
         const {source, state} = harness();
 

--- a/test/playwright/unit/ai/services/fleet/fleetMemoriesSource.spec.mjs
+++ b/test/playwright/unit/ai/services/fleet/fleetMemoriesSource.spec.mjs
@@ -111,13 +111,39 @@ test.describe('fleetMemoriesSource — viewer-bound session-summary recall', () 
         const result = await source.readMemories({agentIdentity: '@neo-opus-ada'});
 
         expect(result).toMatchObject({
-            capability: {state: 'unavailable', reason: 'memories-read-failed'},
+            capability: {state: 'unavailable', reason: 'memories-read-failed', detail: 'plane down'},
             viewer    : '@neo-fable-clio',
             target    : '@neo-opus-ada',
             sessions  : [],
             count     : 0,
             total     : null
         })
+    });
+
+    test('the failure detail is sanitized: credentials masked, whitespace collapsed, length bounded', async () => {
+        const {source, state} = harness();
+
+        // credential family + multi-line noise + oversized tail in one thrown message
+        state.result = new Error(`bearer github_pat_11ABCDEF0123456789abcdef refused\n   by   upstream ${'x'.repeat(400)}`);
+
+        const result = await source.readMemories({}),
+              detail = result.capability.detail;
+
+        expect(result.capability).toMatchObject({state: 'unavailable', reason: 'memories-read-failed'});
+        expect(detail).not.toContain('github_pat_');
+        expect(detail).not.toMatch(/\s{2,}/);
+        expect(detail.length).toBeLessThanOrEqual(240)
+    });
+
+    test('a message-less failure omits the detail field rather than carrying an empty claim', async () => {
+        const {source, state} = harness();
+
+        state.result = new Error('');
+
+        const result = await source.readMemories({});
+
+        expect(result.capability).toMatchObject({state: 'unavailable', reason: 'memories-read-failed'});
+        expect(result.capability).not.toHaveProperty('detail')
     });
 
     test('an unrecognized payload is named rather than rendered', async () => {

--- a/test/playwright/unit/apps/agentos/view/fleet/fleetCockpit.spec.mjs
+++ b/test/playwright/unit/apps/agentos/view/fleet/fleetCockpit.spec.mjs
@@ -1522,13 +1522,36 @@ test.describe('Fleet cockpit — the spine-banner slot sync (syncSpineBanner)', 
     });
 
     test('reconnectFleet re-drives every liveness seam immediately — the one-click recovery', () => {
+        const
+            driven = [],
+            panes  = {
+                'catch-up'  : {onRefreshClick: () => driven.push('catchUpHistory')},
+                'memories'  : {onRefreshClick: () => driven.push('memoriesHistory')},
+                'wakeRoutes': {onRefreshClick: () => driven.push('wakeRoutesHistory')}
+            };
+
+        FleetCockpit.prototype.reconnectFleet.call({
+            loadActivity          : () => driven.push('activity'),
+            loadBrainHealth       : () => driven.push('brainHealth'),
+            loadRoster            : () => driven.push('roster'),
+            ensureViewerWakeStream: () => driven.push('viewerWake'),
+            getReference          : reference => panes[reference] ?? null
+        });
+
+        expect(driven.sort()).toEqual([
+            'activity', 'brainHealth', 'catchUpHistory', 'memoriesHistory', 'roster', 'viewerWake', 'wakeRoutesHistory'
+        ])
+    });
+
+    test('reconnectFleet tolerates unmounted panes — a missing reference is silence, never a throw', () => {
         const driven = [];
 
         FleetCockpit.prototype.reconnectFleet.call({
             loadActivity          : () => driven.push('activity'),
             loadBrainHealth       : () => driven.push('brainHealth'),
             loadRoster            : () => driven.push('roster'),
-            ensureViewerWakeStream: () => driven.push('viewerWake')
+            ensureViewerWakeStream: () => driven.push('viewerWake'),
+            getReference          : () => null
         });
 
         expect(driven.sort()).toEqual(['activity', 'brainHealth', 'roster', 'viewerWake'])


### PR DESCRIPTION
Resolves neomjs/neo#17307

A failed memories read now tells you why, and a healed transport now heals its panes. The source catch that discarded every error carries a sanitized `detail` (whitespace-collapsed, 240-bounded, credential families masked through the shared redaction authority — message-less failures omit the field rather than claiming emptily) and logs the same fact in the fleet child, where its absence made this failure class silently undiagnosable server-side. `reconnectFleet()` — whose contract reads "every liveness seam, immediately" — now includes the one read class that has NO cadence of its own: the pane histories (memories / catch-up / wake routes), re-driven THROUGH each pane's own refresh handler so the panes' guards (active agent, partition) keep deciding whether a request exists; an unmounted pane is silence, never a throw. The dead-pane gap the origin incident demonstrated (a 16:35Z failure envelope pinned until a 17:52Z manual click) closes at the seam that was already designed to be the recovery path.

Evidence: L2 (unit-proven envelope + re-drive mechanics; the live-plane recovery journey is unreachable from this sandbox without restarting the operator's running cockpit session) → L1 live observation required (AC "post-merge, live plane"). Residual: post-merge AC, Residual-Owner: neomjs/neo-agent-brain#28 (its closing witness is the designated live-plane operator session of this ticket family; the reconnect re-drive and the warn line are directly observable there).

## Deltas from ticket

None substantive — the ticket body was re-scoped on-ticket (with the falsifier-ladder comments as the trail) after the standalone reproducer killed the original schema hypothesis; this PR delivers exactly the re-scoped ACs. The malformed-UUID corpus row is retired to a data-quality note (parses fine, not causal).

## Test Evidence

- `npm run test-unit -- test/playwright/unit/ai/services/fleet/fleetMemoriesSource.spec.mjs` → 15 passed (3 new: detail carry `plane down`, sanitization triple — `github_pat_` masked to `authorization=[redacted]` form, whitespace collapsed, ≤240 —, message-less omission).
- `npm run test-unit -- test/playwright/unit/apps/agentos/view/fleet/fleetCockpit.spec.mjs` (with source spec, post-rebase head) → 115 passed. The existing `reconnectFleet re-drives every liveness seam` test grew the three pane seams; a new sibling asserts unmounted-pane tolerance (`getReference → null` drives the original four seams only, no throw).
- Full owning trees pre-rebase: `test/playwright/unit/apps/agentos/` → 696 passed. `test/playwright/unit/ai/` → 11261 passed, 1 failed: `McpServersHealth.spec` `neural-link` boot — diff-independent (zero Neural-Link files touched; the authoring session's own live NL server collides with the spec's boot; expected green in CI where no NL instance runs).
- apps/agentos surface: `fleetCockpit.spec.mjs` (extended, above). ai/services/fleet surface: `fleetMemoriesSource.spec.mjs` (extended, above).

## Post-Merge Validation

- [ ] Live plane: a real failed memories read produces the `[fleet] memories read failed (<target>): <detail>` warn in the fleet child's log.
- [ ] Live plane: after a transport outage heals, `Reconnect` (or the transport-recovery path invoking it) un-pins a previously failed pane without a manual pane action — the origin incident's shape, inverted.

Residual-Owner: neomjs/neo-agent-brain#28

## Commits (if multi-commit)

Single commit: 91bf69f643 — the full delta described above (rebased onto dev before open).

Authored by Clio (Fable 5, Claude Code). Session 7ee47ccf-d1c7-469d-a75e-15cebf3b5ea5.