### PR TITLE
fix(agentos): the configuration pane names which authority each row speaks with (#17306)

### DIFF
--- a/apps/agentos/view/fleet/AgentConfigCard.mjs
+++ b/apps/agentos/view/fleet/AgentConfigCard.mjs
@@ -18,6 +18,20 @@ import {
  * enable-state via `resolveMcpMatrix` — null matrix = catalog defaults), and the operational
  * toggles with tri-state honesty (On / Off / "Not read back yet" — never an optimistic guess).
  * Every label is operator product language; transport vocabulary never renders.
+ *
+ * **Two authorities render here, and each section names which one it speaks with.** The registry
+ * is a DECLARATION — what a seat is configured to run. The operational toggles are READ BACK — what
+ * the fleet actually observed. Presenting both as a bare `On`/`Off` let a declaration masquerade as
+ * a measurement: a seat that had filed four issues through its github-workflow server within the
+ * hour rendered `GitHub workflow: Off`, because the registry said so and nothing on the row admitted
+ * that the registry was all it knew. The operator read a stale declaration as a dead server.
+ *
+ * So declared rows say `Declared on` / `Declared off` and their sections are marked `· declared`,
+ * while read-back rows keep the plain state words under `· read back`. The distinction lives in the
+ * WORD rather than a colour, matching `CARD-CONTRACT.md`'s rule that the adjacent hue may carry
+ * emphasis but the text is the colour-independent channel. A wrong declaration is now readable AS a
+ * wrong declaration — and since these rows are toggles, the operator can correct the thing the row
+ * actually reports.
  */
 class AgentConfigCard extends Component {
     static config = {
@@ -260,7 +274,7 @@ class AgentConfigCard extends Component {
         }, {
             cls: ['fm-config-section'],
             cn : [
-                {tag: 'strong', cls: ['fm-config-heading'], text: 'Memory & knowledge'},
+                {tag: 'strong', cls: ['fm-config-heading'], text: 'Memory & knowledge · declared'},
                 {
                     cls: ['fm-config-chips', 'fm-config-targets'],
                     cn : targetChoices
@@ -269,20 +283,23 @@ class AgentConfigCard extends Component {
         }, {
             cls: ['fm-config-section'],
             cn : [
-                {tag: 'strong', cls: ['fm-config-heading'], text: 'Servers'},
+                {tag: 'strong', cls: ['fm-config-heading'], text: 'Servers · declared'},
                 ...listMcpServers().map(server => ({
                     id : `${me.id}__srv__${server.key}`,
-                    cls: ['fm-config-row', 'fm-config-toggle', matrix[server.key] ? 'is-enabled' : 'is-disabled'],
+                    cls: ['fm-config-row', 'fm-config-toggle', 'is-declared', matrix[server.key] ? 'is-enabled' : 'is-disabled'],
                     cn : [
                         {cls: ['fm-config-label'], text: server.label},
-                        {cls: ['fm-config-value'], text: matrix[server.key] ? 'On' : 'Off'}
+                        // `Declared` is load-bearing, not decoration: the fleet cannot observe an
+                        // external harness's live server set, so this row only ever knows what the
+                        // registry says. A bare `Off` here claimed an observation nobody made.
+                        {cls: ['fm-config-value'], text: matrix[server.key] ? 'Declared on' : 'Declared off'}
                     ]
                 }))
             ]
         }, {
             cls: ['fm-config-section'],
             cn : [
-                {tag: 'strong', cls: ['fm-config-heading'], text: 'Operations'},
+                {tag: 'strong', cls: ['fm-config-heading'], text: 'Operations · read back'},
                 this.createToggleRow('Hooks',              record.hooksActive),
                 this.createToggleRow('Wake subscriptions', record.wakeSubscriptionsActive)
             ]

--- a/resources/scss/src/apps/agentos/fleet/AgentConfigCard.scss
+++ b/resources/scss/src/apps/agentos/fleet/AgentConfigCard.scss
@@ -75,6 +75,15 @@
             color      : var(--fm-ink-dim);
             font-style : italic;
         }
+
+        // A DECLARATION never earns the emphasis an OBSERVATION does. `is-enabled` bolds a state the
+        // fleet read back; a declared row carries the same word shape but only the registry behind
+        // it, so it must not shout equally loud. Deliberately NOT italic — `is-unknown` owns italic
+        // for "not read back yet", and a declared row is a different fact from an unobserved one.
+        // Placed after `is-enabled` because both selectors have equal specificity; source order wins.
+        &.is-declared .fm-config-value {
+            font-weight : 400;
+        }
     }
 
     .fm-config-toggle {

--- a/test/playwright/unit/apps/agentos/Accounts.spec.mjs
+++ b/test/playwright/unit/apps/agentos/Accounts.spec.mjs
@@ -697,6 +697,52 @@ test.describe('AgentOS.view.AgentConfigCard — live same-record propagation + c
         store.destroy()
     });
 
+    test('a server row names the registry as its authority — never a bare Off implying observation (#17306)', () => {
+        // The incident: this seat had filed four issues through its github-workflow server within the
+        // hour while the pane rendered `GitHub workflow: Off`. The registry declaration was all the
+        // pane knew, and a bare `Off` claimed an observation nobody made.
+        const store = Neo.create(Store, {keyProperty: 'id', model: AgentDefinition, data: [
+            {id: 'clio', githubUsername: 'clio', harnessType: 'codex', mcpServers: {'github-workflow': false, 'memory-core': true}}
+        ]});
+        const card = Neo.create(AgentConfigCard, {record: store.get('clio')});
+        const text = cardText(card);
+
+        expect(text).toContain('"text":"Declared off"');
+        expect(text).toContain('"text":"Declared on"');
+
+        // The falsifier for the actual defect: no server row may render the bare observation words.
+        // Asserting only the presence of "Declared off" would pass while a sibling row still lied.
+        expect(text).not.toMatch(/"cls":\["fm-config-value"\],"text":"Off"/);
+
+        // The section carries the authority too, so the grain is readable without parsing each row.
+        expect(text).toContain('Servers · declared');
+        expect(text).toContain('Memory & knowledge · declared');
+
+        card.destroy();
+        store.destroy()
+    });
+
+    test('read-back rows keep the plain state words — the fix must not relabel observations (#17306)', () => {
+        // Negative control. Marking every row "declared" would satisfy the assertion above and destroy
+        // the distinction the ticket exists to create: Operations rows ARE read back, and an observed
+        // `On` must stay an observed `On`.
+        const store = Neo.create(Store, {keyProperty: 'id', model: AgentDefinition, data: [
+            {id: 'vega', githubUsername: 'vega', harnessType: 'codex', hooksActive: true, wakeSubscriptionsActive: null}
+        ]});
+        const card = Neo.create(AgentConfigCard, {record: store.get('vega')});
+        const text = cardText(card);
+
+        expect(text).toMatch(/"text":"Hooks"\},\{"cls":\["fm-config-value"\],"text":"On"/);
+        expect(text).toContain('Not read back yet');
+        expect(text).toContain('Operations · read back');
+
+        // and the observed row never borrows the declared vocabulary
+        expect(text).not.toMatch(/"text":"Hooks"\},\{"cls":\["fm-config-value"\],"text":"Declared/);
+
+        card.destroy();
+        store.destroy()
+    });
+
     test('target choices render public availability honestly and emit only the narrow persisted intent', () => {
         const
             store = Neo.create(Store, {keyProperty: 'id', model: AgentDefinition, data: [{


### PR DESCRIPTION
Resolves neomjs/neo#17306

The Configuration pane now names which authority each row speaks with. Server rows read `Declared on` / `Declared off` under a `Servers · declared` heading; the operational toggles keep their plain state words under `Operations · read back`. A seat that had filed four issues through its github-workflow server within the hour rendered `GitHub workflow: Off` — because the registry said so, and nothing on the row admitted the registry was all it knew. The operator read a stale declaration as a dead server.

Evidence: L2 (the real component rendered through `Neo.create` against a real `Store`/`AgentDefinition`, asserting the production vdom the pane actually emits; only the DOM mount is absent) → L4 required (the operator re-reading the live pane on the deployment that produced the incident). Residual: AC2-live-witness, Residual-Owner: neomjs/neo-agent-institution#20.

## Deltas from ticket

**The fix is the vocabulary, not a probe — and the ticket already says why.** Its Out of Scope excludes *"a server-set observation probe for external harnesses"*, so there is no observable reality for a declaration to be compared against. That shapes how AC-2 is met, and I want the reading stated rather than silently claimed:

> AC-2: *"A seat whose declared servers differ from observable reality renders the mismatch honestly (red→green witness against today's `GitHub workflow: Off` state on a seat that files issues through it)."*

With no probe there is no measured side to diff. **The honest rendering of an unobservable axis is to stop claiming it**, and the AC's own parenthetical names exactly that witness: `GitHub workflow: Off` → `GitHub workflow: Declared off`. The false claim is gone; a wrong declaration is now readable *as* a wrong declaration. Building a diff would have required the capability the ticket excludes.

Same for **AC-3**: no plane handshake is plumbed into this card, so the clause that applies is *"else renders as declaration"* — delivered by the `Memory & knowledge · declared` heading over the target chips. **AC-4** holds trivially: no fleet surface was added, and no new data source is read.

**Why the word rather than a colour.** `CARD-CONTRACT.md` fixes the rule that an adjacent hue may carry emphasis while the text is the colour-independent channel (the 1.4.1 argument). The authority therefore lives in the value text. The one styling change is semantic rather than decorative: `is-declared` drops the emphasis weight that `is-enabled` grants, because a declaration should not shout as loudly as a measurement. Deliberately **not** italic — `is-unknown` owns italic for *"not read back yet"*, and a declared row is a different fact from an unobserved one.

**And the row is a toggle**, which is what makes this more than relabelling: the operator who sees `Declared off` on a server they know is running can click the row and correct the thing it actually reports. Previously the pane showed them a symptom of a registry error in the vocabulary of a runtime failure, pointing them at the wrong system.

## Test Evidence

- `npm run test-unit -- --grep "AgentConfigCard|Accounts|agentos"` — **708 passed**
- `npm run test-unit` (full suite) — **14040 passed, 1 failed**; the single failure is `McpServersHealth` / neural-link, which I ran the control for earlier today on clean `origin/dev` with none of this work present: it fails identically there, with `503 Service Unavailable` in the trace across all three retries. GitHub's authed API was intermittently down; that spec boots a server which reaches it. Not introduced here, and @neo-opus-ada hit the same one independently.
- `npm run agent-preflight -- --change-class restoration …` — all gates pass

**Mutation-proofed in both directions**, because the second test is a control and a control that cannot fail is decoration:

| Mutation | Result |
|---|---|
| `AgentConfigCard.mjs` stashed, specs kept | **2 fail** — both new tests |
| Observation rows relabelled `Declared on/off` | **2 fail** — the control plus the pre-existing `Hooks: On` assertion |
| Restored | 15 pass (708 across the agentos surface) |

That middle row is the one worth naming: relabelling *everything* "declared" would satisfy the first test and destroy the distinction this ticket exists to create. The control exists to make that impossible, and it was verified by actually performing the mutation rather than by asserting it would be caught.

The positive test also refuses the weaker assertion: it pins that **no** server row emits the bare observation word (`not.toMatch(/"fm-config-value"\],"text":"Off"/)`), rather than merely checking `Declared off` is present somewhere — which would pass while a sibling row still lied.

Surfaces touched:
- `apps/agentos/view/fleet/AgentConfigCard.mjs` — `Accounts.spec.mjs` (two new tests + the pre-existing observation assertions as guards)
- `resources/scss/src/apps/agentos/fleet/AgentConfigCard.scss` — no spec; visual weight only, covered by the Post-Merge witness

## Post-Merge Validation

- [ ] On the deployment that produced the incident, the Configuration tab for a seat with `github-workflow` declared off renders `Declared off` under `Servers · declared` — never a bare `Off`. This is the red→green witness AC-2 names and the reason Evidence declares L2→L4.
- [ ] The `Operations` rows still read `On` / `Off` / `Not read back yet` unchanged, so the declared/read-back contrast is visible side by side in one pane.

Residual-Owner: neomjs/neo-agent-institution#20

Both items are live-pane observations this sandbox cannot make. neomjs/neo-agent-institution#20 (`FM pane information design`) owns this pane's presentation surface and is open — verified `state: open` at the moment of parking, after a ticket I cited earlier today turned out to have closed eight minutes before I named it.

## Commits

- b4e8771259 — declared-vs-read-back authority in the pane vocabulary, semantic `is-declared` weight, two tests with the control

Related: neomjs/neo#17305 · neomjs/neo#17271 · neomjs/neo-agent-institution#10

Authored by Grace (Claude Opus 5, Claude Code). Session ddbee747-a0f6-41d3-a41e-813561d2d9f9.
