### PR TITLE
feat(ai): the embedding lane states its model identity at embed time and on the deployment snapshot (#17296)

### DIFF
--- a/ai/configBase.mjs
+++ b/ai/configBase.mjs
@@ -1442,7 +1442,30 @@ class ConfigBase extends ConfigProvider {
                      * @type {String[]}
                      */
                     providerLaneShapeServiceKeys: leaf(['local-model', 'embedding-model'], 'NEO_DEPLOYMENT_STATE_BRIDGE_PROVIDER_LANE_SHAPE_SERVICE_KEYS', 'csv'),
-                    recoveryRunLimit            : leaf(10, 'NEO_DEPLOYMENT_STATE_BRIDGE_RECOVERY_RUN_LIMIT', 'number'),
+                    /**
+                     * @summary Services the embedding-lane MODEL-IDENTITY receipt attaches to — is the
+                     * configured `openAiCompatible.embeddingModel` the one the endpoint actually serves?
+                     *
+                     * A third key rather than a reuse, for the same reason the shape key is not the
+                     * residency key — and the sibling above already argues the lane half. This one adds
+                     * the REMEDIATION half, which is what makes reuse actively harmful rather than merely
+                     * imprecise: the residency verdict's advice is vendor-coupled (`ollama pull <model>`,
+                     * built into its message). Attaching identity to residency would tell a llama.cpp
+                     * container to run an `ollama` command that cannot work — emitted on the very surface
+                     * an operator reads WITHOUT shell access, which is the surface this observation exists
+                     * to make trustworthy. Wrong remediation is worse than silence: silence is a gap, a
+                     * confident wrong instruction is a false lead.
+                     *
+                     * Reusing the SHAPE key would be closer but still wrong: geometry and identity are
+                     * different assertions with different answerability, and one gate over two assertions
+                     * is exactly the defect this ticket's runtime half repaired.
+                     *
+                     * Same two-topology default as its siblings: `local-model` where one service holds
+                     * both roles, `embedding-model` where the lanes are split.
+                     * @type {String[]}
+                     */
+                    providerModelIdentityServiceKeys: leaf(['local-model', 'embedding-model'], 'NEO_DEPLOYMENT_STATE_BRIDGE_PROVIDER_MODEL_IDENTITY_SERVICE_KEYS', 'csv'),
+                    recoveryRunLimit                : leaf(10, 'NEO_DEPLOYMENT_STATE_BRIDGE_RECOVERY_RUN_LIMIT', 'number'),
                     // Self-heal snapshot's recent-event cap — a DIFFERENT surface from recoveryRunLimit (heal-ledger
                     // events vs recovery-run states). collectSelfHealSnapshot validates it finite/non-negative (0 = no
                     // recent-event list) so a negative value can never expand the snapshot to every retained event.

--- a/ai/daemons/orchestrator/services/DeploymentStateBridgeService.mjs
+++ b/ai/daemons/orchestrator/services/DeploymentStateBridgeService.mjs
@@ -7,7 +7,8 @@ import {
     fetchEmbeddingLaneSlots,
     fetchOpenAiCompatibleModelIds,
     getOpenAiCompatibleHost,
-    probeProviderParallelModelCapacity
+    probeProviderParallelModelCapacity,
+    satisfiesRequiredModelIdOnOpenAiCompatibleLane
 }                                          from '../../../services/graph/providerReadinessHelper.mjs';
 import {
     classifyProviderLaneLiveShape,
@@ -1186,7 +1187,12 @@ export class DeploymentStateBridgeService extends Base {
             };
         }
 
-        return servedModelIds.includes(configuredModel)
+        // Implicit-tag tolerant for the same reason the embed path is: this lane's default host is
+        // byte-identical to `ollama.host`, Ollama reports an untagged pull as `name:latest`, and an
+        // exact compare would publish `mismatch` — telling the operator to re-point a lane that is
+        // already correct. A confident wrong instruction is a worse failure than silence, which is
+        // the argument this service's own remediation prose makes.
+        return servedModelIds.some(servedId => satisfiesRequiredModelIdOnOpenAiCompatibleLane(configuredModel, servedId))
             ? {state: 'match', configuredModel, servedModelIds, host, observedAt, reason: null}
             : {
                 state : 'mismatch', configuredModel, servedModelIds, host, observedAt,

--- a/ai/daemons/orchestrator/services/DeploymentStateBridgeService.mjs
+++ b/ai/daemons/orchestrator/services/DeploymentStateBridgeService.mjs
@@ -5,6 +5,7 @@ import Base         from '../../../../src/core/Base.mjs';
 import AiConfig     from '../../../config.mjs';
 import {
     fetchEmbeddingLaneSlots,
+    fetchOpenAiCompatibleModelIds,
     getOpenAiCompatibleHost,
     probeProviderParallelModelCapacity
 }                                          from '../../../services/graph/providerReadinessHelper.mjs';
@@ -216,6 +217,18 @@ export class DeploymentStateBridgeService extends Base {
          * @protected
          */
         providerLaneShapeReceipt: null,
+        /**
+         * One-shot OpenAI-compatible `GET /v1/models` reader: `async ({host, timeoutMs}) => String[]`.
+         * Injected so specs can drive every arm — match, mismatch, empty list, unreachable — without a
+         * live engine. Falls back to {@link fetchOpenAiCompatibleModelIds}.
+         *
+         * Deliberately NOT memoized by a sibling receipt member: the lane's slot geometry cannot change
+         * without a restart, but the model a running endpoint serves can, and a cached `match` would
+         * outlive the fact it reported.
+         * @member {Function|null} providerModelIdentityProbe=null
+         * @protected
+         */
+        providerModelIdentityProbe: null,
         /**
          * Read-only provider-activity seam. The orchestrator injects the recorder-owned ledger
          * projection; this service never opens or mutates the telemetry database itself.
@@ -642,6 +655,15 @@ export class DeploymentStateBridgeService extends Base {
             ? await this.collectProviderLaneShape({observedAt: observationNow()})
             : null;
 
+        // The identity axis, gated by its OWN predicate for the same reason the shape is: geometry
+        // and identity are different assertions with different answerability, and the remediation
+        // vocabularies differ too. Unmemoized on purpose — the shape receipt is a boot reading of a
+        // value that cannot change without a restart, while a served model CAN change under a
+        // running endpoint, and a cached "match" would outlive the fact it reported.
+        const providerModelIdentity = this.isProviderModelIdentityServiceKey(serviceKey)
+            ? await this.collectProviderModelIdentity({observedAt: observationNow()})
+            : null;
+
         // The SECOND evidence channel. Until this existed, `endpointProbe` had no producer anywhere in
         // the orchestrator, so ADR-0025 §2.4's authoritative pair could never form and a wedged // ticket-ref-ok: the ADR clause is the reason this call exists at all
         // container was diagnosed and never acted on.
@@ -729,6 +751,7 @@ export class DeploymentStateBridgeService extends Base {
                 providerResidency,
                 providerActivity,
                 providerLaneShape,
+                providerModelIdentity,
                 providerResidencyEligible: this.isProviderResidencyServiceKey(serviceKey),
                 churnBaseline            : churnBaseline?.unreadable ? undefined : churnBaseline,
                 plannedRestarts          : plannedRestarts.count,
@@ -841,6 +864,12 @@ export class DeploymentStateBridgeService extends Base {
             // point is that the answer is now in the artifact either way. `observable: false` carries
             // its own reason, so a blank shape is never mistaken for a verified one.
             providerLaneShape,
+            // Published on a MATCH too, for the same reason the shape is: an operator asking "is this
+            // plane serving the model I configured?" needs the answer in the artifact either way, and
+            // proving it right previously meant reading two literals out of a container log by hand.
+            // Every non-match arm carries its own `reason`, so a `null` here means the service is not
+            // an identity participant — never that identity was checked and found fine.
+            providerModelIdentity,
             heapObservation,
             restartChurn,
             // EVERY snapshot, independent of load. The classification, the threshold that applies to
@@ -1072,6 +1101,97 @@ export class DeploymentStateBridgeService extends Base {
      */
     isProviderLaneShapeServiceKey(serviceKey) {
         return AiConfig.orchestrator.deploymentStateBridge.providerLaneShapeServiceKeys.includes(serviceKey);
+    }
+
+    /**
+     * @summary Resolves whether a Compose service carries the embedding-lane MODEL-IDENTITY receipt.
+     *
+     * A third predicate rather than a reuse of either sibling. Against residency the reason is
+     * remediation: that verdict's advice is vendor-coupled (`ollama pull <model>`), so attaching
+     * identity there tells a llama.cpp container to run a command that cannot work — on the surface
+     * an operator reads without shell access. Against lane-shape the reason is answerability:
+     * geometry and identity are different assertions, and one gate over two assertions is precisely
+     * the defect this ticket's runtime half repaired.
+     *
+     * @param {String} serviceKey Compose service key.
+     * @returns {Boolean}
+     */
+    isProviderModelIdentityServiceKey(serviceKey) {
+        return AiConfig.orchestrator.deploymentStateBridge.providerModelIdentityServiceKeys.includes(serviceKey);
+    }
+
+    /**
+     * @summary Observe whether the configured embedding model is the one the endpoint actually
+     * serves — the operator-visible half of the identity check the embed path enforces at runtime.
+     *
+     * The runtime guard throws at embed time, which only ever reaches whoever is reading a stack
+     * trace. This publishes the same comparison where an operator or agent reads deployment state
+     * with no shell, so a wrong model is legible BEFORE it is inferred from slow embeddings — which
+     * is how a production plane served an 8B model against a 0.6B configuration across two deploys.
+     *
+     * **Every arm is an observation, never a verdict.** No host or no configured model means the
+     * question was never asked (`unconfigured`); an endpoint that will not answer means it could not
+     * be asked (`unobservable`); an answer that omits the configured id is the finding. A probe that
+     * cannot run is an unanswered question, never a confirmed match — the same rule the runtime half
+     * follows, because a health surface that reports "fine" on an unmeasured axis is the defect.
+     *
+     * **Remediation speaks THIS lane's language.** `/v1/models` is served by llama.cpp, vLLM, LM
+     * Studio and any OpenAI-compatible runtime, so the advice names the served-vs-configured pair and
+     * leaves the fix to whoever owns that runtime, rather than borrowing a vendor's pull command.
+     *
+     * @param {Object} [options={}]
+     * @param {Date|String} [options.observedAt] Observation stamp.
+     * @returns {Promise<Object|null>} `{state, configuredModel, servedModelIds, host, reason, observedAt}`
+     *     — `null` only when no OpenAI-compatible host is configured at all.
+     */
+    async collectProviderModelIdentity({observedAt = this.now()} = {}) {
+        const host = getOpenAiCompatibleHost(AiConfig);
+
+        if (!host) {
+            return null;
+        }
+
+        const configuredModel = AiConfig.openAiCompatible.embeddingModel;
+
+        if (!configuredModel) {
+            return {
+                state : 'unconfigured', configuredModel: null, servedModelIds: null, host, observedAt,
+                reason: 'no embedding model is configured for the OpenAI-compatible lane; nothing to compare against'
+            };
+        }
+
+        const probe = this.providerModelIdentityProbe || fetchOpenAiCompatibleModelIds;
+
+        let servedModelIds = null;
+
+        try {
+            servedModelIds = await probe({
+                host,
+                timeoutMs: AiConfig.orchestrator.providerReadiness.timeoutMs
+            });
+        } catch (error) {
+            return {
+                state : 'unobservable', configuredModel, servedModelIds: null, host, observedAt,
+                reason: `the endpoint did not answer GET /v1/models (${error.message}); identity is unobserved, not confirmed`
+            };
+        }
+
+        // `/v1/models` is conventional rather than guaranteed: a proxy or minimal runtime can answer
+        // 200 carrying nothing enumerable, and zero rows there cannot separate "serves no models"
+        // from "does not answer this question". Unobservable, not a mismatch.
+        if (!Array.isArray(servedModelIds) || servedModelIds.length === 0) {
+            return {
+                state : 'unobservable', configuredModel, servedModelIds: null, host, observedAt,
+                reason: 'the endpoint answered with no enumerable model list; identity is unobserved, not confirmed'
+            };
+        }
+
+        return servedModelIds.includes(configuredModel)
+            ? {state: 'match', configuredModel, servedModelIds, host, observedAt, reason: null}
+            : {
+                state : 'mismatch', configuredModel, servedModelIds, host, observedAt,
+                reason: `configured embedding model '${configuredModel}' is not served by this endpoint; observed=${servedModelIds.join(', ')}. Point the lane at a served id, or load the configured model on the runtime that owns this endpoint.`
+            };
     }
 
     isProviderResidencyServiceKey(serviceKey) {

--- a/ai/scripts/lint/config-leaf-parity.json
+++ b/ai/scripts/lint/config-leaf-parity.json
@@ -342,6 +342,7 @@
         "orchestrator.deploymentStateBridge.logTail",
         "orchestrator.deploymentStateBridge.maxSnapshotBytes",
         "orchestrator.deploymentStateBridge.providerLaneShapeServiceKeys",
+        "orchestrator.deploymentStateBridge.providerModelIdentityServiceKeys",
         "orchestrator.deploymentStateBridge.providerResidencyServiceKeys",
         "orchestrator.deploymentStateBridge.recoveryRunLimit",
         "orchestrator.deploymentStateBridge.selfHealRecentEventLimit",

--- a/ai/services/graph/providerReadinessHelper.mjs
+++ b/ai/services/graph/providerReadinessHelper.mjs
@@ -100,6 +100,36 @@ export function satisfiesRequiredModelId(required, observed, provider) {
 }
 
 /**
+ * @summary The `openAiCompatible` lane's form of {@link satisfiesRequiredModelId}: it tolerates
+ * Ollama's implicit `:latest`, because on this lane Ollama cannot be ruled out.
+ *
+ * The lane is defined by a wire protocol rather than by a runtime, so a call site here never learns
+ * which provider answered. It does not have to: `aiConfig.openAiCompatible.host` defaults to
+ * `http://127.0.0.1:11434` — byte-identical to `aiConfig.ollama.host` — and the lane's own config
+ * JSDoc names "Ollama's OpenAI-compatible surface" among what it covers. So the shipped default IS
+ * Ollama, and an exact compare refuses a model that is loaded and serving: Ollama reports an
+ * untagged pull as `name:latest`, `/v1/models` returns ids verbatim, and `qwen3-embedding` therefore
+ * never equals the `qwen3-embedding:latest` it is looking at. The same mechanism was measured on a
+ * real plane once already, on the ollama lane; this is it arriving on a second one.
+ *
+ * **The `'ollama'` argument selects the RULE, and is not a claim about who answered.** The rule is
+ * the right one regardless: it is directional and tag-only, so it accepts a more specific observed
+ * id for an untagged requirement and never the reverse — a requirement that names a tag still gets
+ * an exact compare.
+ *
+ * Delegating rather than restating the predicate is deliberate. The sibling `redactCredentials`
+ * module exists because five private copies of one rule drifted; a second copy of the implicit-tag
+ * rule would start that story here, and the copy that drifts is always the one nobody is looking at.
+ *
+ * @param {*} required Configured model id (owns the requirement).
+ * @param {*} observed Model id reported by the endpoint.
+ * @returns {Boolean}
+ */
+export function satisfiesRequiredModelIdOnOpenAiCompatibleLane(required, observed) {
+    return satisfiesRequiredModelId(required, observed, 'ollama');
+}
+
+/**
  * @summary Resolves which REQUIRED id (if any) an observed id satisfies — the keyed-lookup form of
  * `satisfiesRequiredModelId`, for maps whose keys are configured ids.
  *

--- a/ai/services/memory-core/TextEmbeddingService.mjs
+++ b/ai/services/memory-core/TextEmbeddingService.mjs
@@ -1127,12 +1127,26 @@ class TextEmbeddingService extends Base {
             return null;
         }
 
-        const loadedModel = loadedModels.find(item => item.id === model);
+        // Implicit-tag tolerant, because this compare is NOT LM Studio-only any more: the identity
+        // gate now reaches every OpenAI-compatible endpoint, and the lane's default host is
+        // byte-identical to `ollama.host`. Ollama reports an untagged pull as `name:latest` and
+        // `/v1/models` returns ids verbatim, so an exact compare refuses a model that is loaded and
+        // serving, and it is the shipped default rather than an exotic host. The rule stays directional: a
+        // requirement that names a tag still gets an exact compare.
+        const {satisfiesRequiredModelIdOnOpenAiCompatibleLane} = await import('../graph/providerReadinessHelper.mjs');
+
+        throwIfEmbeddingAborted(signal, operationLabel);
+
+        const loadedModel = loadedModels.find(item => satisfiesRequiredModelIdOnOpenAiCompatibleLane(model, item.id));
 
         if (!loadedModel) {
-            const observedIds = loadedModels.map(item => item.id).filter(Boolean).slice(0, 5).join(', ') || 'none',
+            // The lane, not the vendor: this path serves LM Studio only when the context gate is on,
+            // and naming LM Studio to an operator running Ollama is the "confident wrong instruction"
+            // this ticket's own config JSDoc argues against.
+            const lane        = this.#shouldAssertOpenAiCompatibleEmbeddingContext() ? 'LM Studio' : 'OpenAI-compatible',
+                  observedIds = loadedModels.map(item => item.id).filter(Boolean).slice(0, 5).join(', ') || 'none',
                   error       = markEmbeddingModelNotResidentError(
-                      new Error(`TextEmbeddingService: LM Studio embedding model '${model}' is not resident under its configured identifier; observed=${observedIds}`)
+                      new Error(`TextEmbeddingService: ${lane} embedding model '${model}' is not resident under its configured identifier; observed=${observedIds}`)
                   );
 
             // The preflight rejection is the OTHER origin of "not resident", and it carries the same

--- a/ai/services/memory-core/TextEmbeddingService.mjs
+++ b/ai/services/memory-core/TextEmbeddingService.mjs
@@ -918,9 +918,32 @@ class TextEmbeddingService extends Base {
             return this.openAiCompatibleLoadedModelsProbe({timeoutMs, signal});
         }
 
-        const {fetchLmsLoadedModels} = await import('../graph/providerReadinessHelper.mjs');
+        const helper = await import('../graph/providerReadinessHelper.mjs');
         throwIfEmbeddingAborted(signal, operationLabel);
-        return fetchLmsLoadedModels({timeoutMs, signal});
+
+        if (this.#shouldAssertOpenAiCompatibleEmbeddingContext()) {
+            return helper.fetchLmsLoadedModels({timeoutMs, signal});
+        }
+
+        // Provider-shaped fallback: `GET /v1/models`, which every OpenAI-compatible server answers.
+        // Ids only — no `contextLength`, which is precisely why the context assertion stays behind
+        // the LM Studio gate. Normalised to the same row shape so the identity comparison below is
+        // one code path rather than two.
+        const ids = await helper.fetchOpenAiCompatibleModelIds({
+            host: aiConfig.openAiCompatible.host,
+            timeoutMs
+        });
+
+        // `null` means UNANSWERABLE; `[]` means answered-and-empty. Only this source can be
+        // unanswerable-while-succeeding: `/v1/models` is conventional rather than guaranteed, so a
+        // proxy or minimal runtime can return 200 carrying nothing enumerable, and zero rows cannot
+        // distinguish "serves no models" from "does not answer this question".
+        //
+        // The distinction is scoped to this source deliberately. An empty `lms ps` is a real
+        // negative on a surface we own, and an injected test probe returning `[]` is an explicit
+        // statement that nothing is resident — collapsing all three would silently retire the
+        // not-resident preflight everywhere.
+        return ids.length > 0 ? ids.map(id => ({id})) : null;
     }
 
     /**
@@ -959,6 +982,41 @@ class TextEmbeddingService extends Base {
     }
 
     /**
+     * @summary Whether the served model IDENTITY can be verified on this endpoint. Provider-shaped.
+     *
+     * Distinct from {@link #isLmStudioEmbeddingLane}, and the split is the whole point. Two different
+     * assertions used to share one vendor gate:
+     *
+     * - **Identity** — is the configured model the one actually being served? Answerable on ANY
+     *   OpenAI-compatible endpoint via `GET /v1/models`.
+     * - **Context** — is the loaded context window large enough? Answerable only from `lms ps`,
+     *   because `/v1/models` reports no context length.
+     *
+     * Gating both behind the LM Studio port meant identity verification existed for the developer
+     * laptop and not for the deployment — the inverse of where it is needed. A production plane then
+     * served `Qwen3-Embedding-8B-Q4_K_M` while configured for `qwen3-embedding-0.6b` across two
+     * deploys, every container healthy, the only symptom slow embeddings read as a performance
+     * problem.
+     *
+     * Widening the SHARED gate instead of splitting it would have been worse than the gap: the
+     * context assertion would then fire on llama.cpp, where `contextLength` is structurally unknown,
+     * and refuse every embed with a spurious unknown-context error.
+     *
+     * @returns {Boolean}
+     * @private
+     */
+    #shouldAssertOpenAiCompatibleEmbeddingIdentity() {
+        if (this.openAiCompatibleLoadedModelsProbe) {
+            return true;
+        }
+        if (Neo.config.unitTestMode) {
+            return false;
+        }
+
+        return Boolean(aiConfig.openAiCompatible.host && aiConfig.openAiCompatible.embeddingModel);
+    }
+
+    /**
      * @summary Determines whether the active OpenAI-compatible endpoint is the orchestrator-owned LM Studio lane.
      *
      * OpenAI-compatible covers LM Studio, Ollama's compatibility surface, llama.cpp, vLLM, and
@@ -969,9 +1027,11 @@ class TextEmbeddingService extends Base {
      * @private
      */
     #shouldAssertOpenAiCompatibleEmbeddingContext() {
-        if (this.openAiCompatibleLoadedModelsProbe) {
-            return true;
-        }
+        // The probe seam deliberately does NOT answer this one. It means "use this instead of the
+        // real fetch", not "you are LM Studio" — and while both assertions shared a gate the two
+        // readings were indistinguishable. Now that context enforcement is lane-specific, letting an
+        // injected probe imply the LMS lane would demand a `contextLength` from every seam that
+        // supplies only ids, and refuse the embed for a context nobody ever claimed to observe.
         if (Neo.config.unitTestMode) {
             return false;
         }
@@ -1011,7 +1071,7 @@ class TextEmbeddingService extends Base {
         operation.phase = 'preflight';
         throwIfEmbeddingAborted(signal, operationLabel);
 
-        if (!this.#shouldAssertOpenAiCompatibleEmbeddingContext()) {
+        if (!this.#shouldAssertOpenAiCompatibleEmbeddingIdentity()) {
             return null;
         }
 
@@ -1039,10 +1099,33 @@ class TextEmbeddingService extends Base {
                 throw getEmbeddingAbortError(signal, operationLabel);
             }
 
-            throw new Error(`TextEmbeddingService: unable to verify LM Studio embedding context for '${model}': ${error.message}`);
+            // The LM Studio lane keeps refusing: `lms ps` is orchestrator-owned, so a probe failure
+            // there means the lane we manage is not answering, and proceeding would embed blind
+            // against a provider we are supposed to control.
+            if (this.#shouldAssertOpenAiCompatibleEmbeddingContext()) {
+                throw new Error(`TextEmbeddingService: unable to verify LM Studio embedding context for '${model}': ${error.message}`);
+            }
+
+            // Every other OpenAI-compatible endpoint degrades to UNKNOWN instead. `/v1/models` is
+            // conventional, not guaranteed — vLLM, a CI fixture server or a proxy may not serve it,
+            // and a transient 503 must not take embedding down. An identity check that cannot run is
+            // an unanswered question, never a confirmed match, and never grounds for refusing work
+            // that was previously allowed: turning an observability gap into an outage is a worse
+            // failure than the gap.
+            //
+            // A probe that DOES answer and disagrees still throws — that path is below, and it is
+            // the one this ticket exists for.
+            return null;
         }
 
         throwIfEmbeddingAborted(signal, operationLabel);
+
+        // `null` is the UNANSWERABLE signal from the provider-shaped probe (see its return site).
+        // Distinct from `[]`, which is a real "nothing is resident" from a source that can say so.
+        // An identity check that cannot run is an unanswered question, never a confirmed match.
+        if (loadedModels === null) {
+            return null;
+        }
 
         const loadedModel = loadedModels.find(item => item.id === model);
 
@@ -1060,7 +1143,12 @@ class TextEmbeddingService extends Base {
 
             throw error
         }
-        if (!Neo.isNumber(loadedModel.contextLength)) {
+        // Context enforcement is LM-Studio-only BY EVIDENCE, not by preference: `lms ps` reports the
+        // loaded context window and `GET /v1/models` does not. On any other OpenAI-compatible lane
+        // the number is structurally unknown, so demanding it here would refuse every embed with a
+        // spurious unknown-context error — turning an observability fix into an outage. Identity has
+        // already been asserted above and is the half that catches a wrong model.
+        if (this.#shouldAssertOpenAiCompatibleEmbeddingContext() && !Neo.isNumber(loadedModel.contextLength)) {
             throw new Error(`TextEmbeddingService: LM Studio embedding model '${model}' has unknown loaded context; configured>=${configuredContextLength}`);
         }
 
@@ -1082,6 +1170,19 @@ class TextEmbeddingService extends Base {
      */
     #assertOpenAiCompatibleEmbeddingContext(inputData, runtime) {
         if (!runtime) {
+            return;
+        }
+
+        // An unknown loaded context is UNKNOWN, and enforcement declines rather than guesses. Only
+        // `lms ps` reports a context window; a provider-shaped `/v1/models` row carries an id and
+        // nothing else, so this runs on rows where the number was never observable.
+        //
+        // Stated explicitly rather than left to fall through: every comparison below happens to be
+        // false against `undefined`, so the correct behaviour is currently an accident of JS
+        // coercion. One change to `isEmbeddingContextBelowSafeBand`'s handling of a non-number and
+        // this silently starts refusing every embed on llama.cpp — a spurious outage produced by a
+        // helper that never knew it had become load-bearing.
+        if (!Neo.isNumber(runtime.loadedModel?.contextLength)) {
             return;
         }
 

--- a/test/playwright/unit/ai/daemons/orchestrator/services/DeploymentStateBridgeService.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/services/DeploymentStateBridgeService.spec.mjs
@@ -3512,6 +3512,49 @@ test.describe('Neo.ai.daemons.services.DeploymentStateBridgeService — embeddin
         bridge.destroy()
     });
 
+    test('an UNTAGGED configured model matches Ollama\'s implicit :latest — the shipped default host', async () => {
+        // The fixtures around this one are tagged on BOTH sides, so they match by exact compare and
+        // pass whichever rule is in force — they conceal this case rather than covering it. Here the
+        // tag exists on ONE side only, which is production's actual shape: `openAiCompatible.host`
+        // defaults to `http://127.0.0.1:11434` (byte-identical to `ollama.host`), Ollama reports an
+        // untagged pull as `name:latest`, and `/v1/models` returns ids verbatim. Under an exact
+        // compare this published `mismatch` and told the operator to re-point a lane that was
+        // already correct — the same mechanism previously measured on the ollama lane, arriving here.
+        AiConfig.openAiCompatible.embeddingModel = 'qwen3-embedding';
+
+        const bridge = createService({
+                  providerModelIdentityProbe: async () => ['qwen3-embedding:latest']
+              }),
+              identity = await bridge.collectProviderModelIdentity({observedAt: 11});
+
+        expect(identity.state).toBe('match');
+        expect(identity.reason).toBeNull();
+        // the SERVED id is still reported verbatim — tolerating the tag must not launder what the
+        // endpoint actually answered
+        expect(identity.servedModelIds).toEqual(['qwen3-embedding:latest']);
+
+        bridge.destroy()
+    });
+
+    test('the tolerance is DIRECTIONAL: a configured tag is not satisfied by an untagged served id', async () => {
+        // The fence, and it is the half that stops this fix widening into a false negative. An
+        // operator who pinned `:latest` asked for that exact id; answering with the bare name is a
+        // different model as far as the requirement is concerned, and must still read as a mismatch.
+        // Without this, "tolerant" would quietly mean "equal", and the previous test would pass for
+        // the wrong reason.
+        AiConfig.openAiCompatible.embeddingModel = 'qwen3-embedding:latest';
+
+        const bridge = createService({
+                  providerModelIdentityProbe: async () => ['qwen3-embedding']
+              }),
+              identity = await bridge.collectProviderModelIdentity({observedAt: 12});
+
+        expect(identity.state).toBe('mismatch');
+        expect(identity.reason).toContain('qwen3-embedding:latest');
+
+        bridge.destroy()
+    });
+
     test('an endpoint that will not answer is UNOBSERVABLE, never a mismatch', async () => {
         const bridge = createService({
             providerModelIdentityProbe: async () => { throw new Error('ECONNREFUSED') }

--- a/test/playwright/unit/ai/daemons/orchestrator/services/DeploymentStateBridgeService.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/services/DeploymentStateBridgeService.spec.mjs
@@ -41,6 +41,7 @@ const BRIDGE_CONFIG_PATHS = [
     'orchestrator.deploymentStateBridge.statsSampleWindow',
     'orchestrator.deploymentStateBridge.providerResidencyServiceKeys',
     'orchestrator.deploymentStateBridge.providerLaneShapeServiceKeys',
+    'orchestrator.deploymentStateBridge.providerModelIdentityServiceKeys',
     'orchestrator.deploymentStateBridge.recoveryRunLimit',
     'orchestrator.deploymentStateBridge.selfHealRecentEventLimit',
     'orchestrator.deploymentStateBridge.snapshotPath',
@@ -97,6 +98,7 @@ function createService({
     directProbeFn = null,
     providerResidencyProbe = async () => null,
     providerLaneShapeProbe = null,
+    providerModelIdentityProbe = null,
     providerActivityProbe = null,
     providerActivityWindowMs = 24 * 60 * 60 * 1000,
     providerActivityLimit = 50,
@@ -117,6 +119,7 @@ function createService({
         directProbeFn,
         providerResidencyProbe,
         providerLaneShapeProbe,
+        providerModelIdentityProbe,
         providerActivityProbe,
         providerActivityWindowMs,
         providerActivityLimit,
@@ -3442,6 +3445,220 @@ test.describe('provider-lane shape routing — the embedding receipt must not ri
         expect(bridge.isProviderLaneShapeServiceKey('embedding-model')).toBe(true);
         expect(bridge.isProviderLaneShapeServiceKey('local-model')).toBe(true);
         expect(bridge.isProviderLaneShapeServiceKey('chat-model')).toBe(false);
+
+        bridge.destroy()
+    });
+});
+
+test.describe('Neo.ai.daemons.services.DeploymentStateBridgeService — embedding-lane model identity', () => {
+    const IDENTITY_CONFIG_PATHS = [
+        'orchestrator.deploymentStateBridge.providerModelIdentityServiceKeys',
+        'orchestrator.deploymentStateBridge.providerLaneShapeServiceKeys',
+        'orchestrator.deploymentStateBridge.providerResidencyServiceKeys',
+        'openAiCompatible.host',
+        'openAiCompatible.embeddingModel'
+    ];
+
+    let restoreIdentityConfig;
+
+    test.beforeEach(() => {
+        restoreIdentityConfig = snapshotAiConfig(AiConfig, IDENTITY_CONFIG_PATHS);
+
+        AiConfig.openAiCompatible.host           = 'http://127.0.0.1:8090';
+        AiConfig.openAiCompatible.embeddingModel = 'qwen3-embedding-0.6b'
+    });
+
+    test.afterEach(() => {
+        restoreIdentityConfig?.()
+    });
+
+    test('the served list naming the configured model reads MATCH, and publishes on a healthy plane too', async () => {
+        const bridge = createService({
+            providerModelIdentityProbe: async () => ['qwen3-embedding-0.6b', 'some-other-model']
+        });
+
+        const identity = await bridge.collectProviderModelIdentity({observedAt: 7});
+
+        expect(identity.state).toBe('match');
+        expect(identity.configuredModel).toBe('qwen3-embedding-0.6b');
+        expect(identity.reason).toBeNull();
+        // Published on a MATCH as well: proving a lane is serving the right model previously took a
+        // shell on the host, so the answer belongs in the artifact either way.
+        expect(identity.observedAt).toBe(7);
+
+        bridge.destroy()
+    });
+
+    test('the real incident reproduces: configured 0.6b, served 8B, and the SERVED id is named', async () => {
+        // A production plane ran Qwen3-Embedding-8B against a 0.6b configuration across two deploys.
+        // The only symptom was slow embeddings, read as a performance problem rather than a
+        // configuration one — this is the surface that makes it legible without a shell.
+        const bridge = createService({
+            providerModelIdentityProbe: async () => ['Qwen3-Embedding-8B-Q4_K_M']
+        });
+
+        const identity = await bridge.collectProviderModelIdentity({observedAt: 8});
+
+        expect(identity.state).toBe('mismatch');
+        expect(identity.reason).toContain('qwen3-embedding-0.6b');
+        expect(identity.reason).toContain('Qwen3-Embedding-8B-Q4_K_M');
+        expect(identity.servedModelIds).toEqual(['Qwen3-Embedding-8B-Q4_K_M']);
+
+        // The remediation speaks THIS lane's language. Borrowing the residency verdict's vendor-coupled
+        // advice would tell a llama.cpp container to run an `ollama` command that cannot work — on the
+        // very surface an operator reads without shell access.
+        expect(identity.reason).not.toContain('ollama');
+
+        bridge.destroy()
+    });
+
+    test('an endpoint that will not answer is UNOBSERVABLE, never a mismatch', async () => {
+        const bridge = createService({
+            providerModelIdentityProbe: async () => { throw new Error('ECONNREFUSED') }
+        });
+
+        const identity = await bridge.collectProviderModelIdentity({observedAt: 9});
+
+        // An identity check that cannot run is an unanswered question, never a confirmed match — and
+        // never a reported mismatch either, which would send an operator to fix a model that is fine.
+        expect(identity.state).toBe('unobservable');
+        expect(identity.reason).toContain('ECONNREFUSED');
+        expect(identity.servedModelIds).toBeNull();
+
+        bridge.destroy()
+    });
+
+    test('an answered-but-empty list is UNOBSERVABLE too — /v1/models is conventional, not guaranteed', async () => {
+        const bridge = createService({providerModelIdentityProbe: async () => []});
+
+        const identity = await bridge.collectProviderModelIdentity({observedAt: 10});
+
+        // Zero rows cannot separate "serves no models" from "does not answer this question", so a
+        // proxy or minimal runtime answering 200 with nothing enumerable must not read as a mismatch.
+        expect(identity.state).toBe('unobservable');
+
+        bridge.destroy()
+    });
+
+    test('no configured model is UNCONFIGURED — the question was never asked', async () => {
+        AiConfig.openAiCompatible.embeddingModel = '';
+
+        let probeCalls = 0;
+
+        const bridge = createService({
+            providerModelIdentityProbe: async () => { probeCalls++; return ['anything'] }
+        });
+
+        const identity = await bridge.collectProviderModelIdentity({observedAt: 11});
+
+        expect(identity.state).toBe('unconfigured');
+        expect(probeCalls, 'nothing to compare against, so the endpoint is not disturbed').toBe(0);
+
+        bridge.destroy()
+    });
+
+    test('the identity predicate is its OWN key — never residency, never lane-shape', async () => {
+        AiConfig.orchestrator.deploymentStateBridge.providerModelIdentityServiceKeys = ['embedding-model'];
+        AiConfig.orchestrator.deploymentStateBridge.providerLaneShapeServiceKeys     = ['local-model'];
+        AiConfig.orchestrator.deploymentStateBridge.providerResidencyServiceKeys     = ['chat-model'];
+
+        const bridge = createService();
+
+        // Three sets, three lanes. Collapsing any pair publishes one lane's facts on another's record
+        // — and for residency specifically it would attach `ollama pull` remediation to a llama.cpp
+        // endpoint, which is the reason this is a third key rather than a reuse.
+        expect(bridge.isProviderModelIdentityServiceKey('embedding-model')).toBe(true);
+        expect(bridge.isProviderModelIdentityServiceKey('local-model')).toBe(false);
+        expect(bridge.isProviderModelIdentityServiceKey('chat-model')).toBe(false);
+
+        bridge.destroy()
+    });
+
+    test('a served model that changes under a running endpoint is re-read, never memoized', async () => {
+        // Deliberately unlike the lane-shape receipt, which is a one-shot boot reading. Slot geometry
+        // cannot change without a restart; the model a running endpoint serves CAN, so a cached match
+        // would outlive the fact it reported — a health surface asserting yesterday's truth.
+        let served = ['qwen3-embedding-0.6b'];
+
+        const bridge = createService({providerModelIdentityProbe: async () => served});
+
+        expect((await bridge.collectProviderModelIdentity({observedAt: 1})).state).toBe('match');
+
+        served = ['Qwen3-Embedding-8B-Q4_K_M'];
+
+        expect((await bridge.collectProviderModelIdentity({observedAt: 2})).state).toBe('mismatch');
+
+        bridge.destroy()
+    });
+});
+
+test.describe('Neo.ai.daemons.services.DeploymentStateBridgeService — identity gating at the CALL SITE', () => {
+    const IDENTITY_WIRING_PATHS = [
+        'orchestrator.deploymentStateBridge.providerModelIdentityServiceKeys',
+        'orchestrator.deploymentStateBridge.providerResidencyServiceKeys',
+        'orchestrator.deploymentStateBridge.providerLaneShapeServiceKeys',
+        'openAiCompatible.host',
+        'openAiCompatible.embeddingModel'
+    ];
+
+    let restoreWiringConfig;
+
+    /** Minimal runtime seam — this suite asserts gating, not container facts. */
+    function runtimeStub() {
+        return {
+            async readObserve(request) {
+                return request.operation === 'inspect'
+                    ? {data: {Id: 'c-x', State: {Status: 'running'}}, proof: {operation: 'inspect'}}
+                    : {data: null, proof: {operation: request.operation}}
+            }
+        }
+    }
+
+    test.beforeEach(() => {
+        restoreWiringConfig = snapshotAiConfig(AiConfig, IDENTITY_WIRING_PATHS);
+
+        AiConfig.openAiCompatible.host           = 'http://127.0.0.1:8090';
+        AiConfig.openAiCompatible.embeddingModel = 'qwen3-embedding-0.6b';
+        // The three sets are made DISJOINT so a collapsed gate cannot accidentally still fire.
+        AiConfig.orchestrator.deploymentStateBridge.providerModelIdentityServiceKeys = ['embedding-model'];
+        AiConfig.orchestrator.deploymentStateBridge.providerResidencyServiceKeys     = ['chat-model'];
+        AiConfig.orchestrator.deploymentStateBridge.providerLaneShapeServiceKeys     = ['local-model']
+    });
+
+    test.afterEach(() => {
+        restoreWiringConfig?.()
+    });
+
+    test('the snapshot publishes identity for a participant and withholds it for a non-participant', async () => {
+        // This is the assertion the predicate test could NOT make. Testing `isProviderModelIdentity-
+        // ServiceKey` in isolation proves the function; it says nothing about which predicate the
+        // collection path actually calls. A mutation swapping the call site onto the residency
+        // predicate left the isolated predicate test green — a pure-function corpus cannot catch an
+        // unreachable or mis-wired call site, so the gate has to be exercised through the snapshot.
+        const bridge = Neo.create(DeploymentStateBridgeService, {
+            runtimeAccessService      : runtimeStub(),
+            diagnosisService          : Neo.create(ContainerHealthDiagnosisService, {}),
+            providerResidencyProbe    : async () => null,
+            providerModelIdentityProbe: async () => ['qwen3-embedding-0.6b'],
+            writeLog                  : () => {},
+            nowFn                     : () => OBSERVED_AT
+        });
+
+        const participant = await bridge.collectServiceSnapshot({serviceKey: 'embedding-model', observedAt: OBSERVED_AT});
+
+        expect(participant.providerModelIdentity).not.toBeNull();
+        expect(participant.providerModelIdentity.state).toBe('match');
+
+        // `chat-model` is the RESIDENCY key here. If the call site were gated on residency this would
+        // carry an identity receipt — which is exactly the mutation this test exists to kill.
+        const residencyOnly = await bridge.collectServiceSnapshot({serviceKey: 'chat-model', observedAt: OBSERVED_AT});
+
+        expect(residencyOnly.providerModelIdentity).toBeNull();
+
+        // …and `local-model` is the LANE-SHAPE key, so the other possible collapse is covered too.
+        const shapeOnly = await bridge.collectServiceSnapshot({serviceKey: 'local-model', observedAt: OBSERVED_AT});
+
+        expect(shapeOnly.providerModelIdentity).toBeNull();
 
         bridge.destroy()
     });

--- a/test/playwright/unit/ai/services/memory-core/TextEmbeddingService.retry.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/TextEmbeddingService.retry.spec.mjs
@@ -410,6 +410,54 @@ test.describe.serial('TextEmbeddingService #11393/#11402/#12487/#12509 — openA
         }
     });
 
+    test('an UNTAGGED configured model embeds against Ollama\'s implicit :latest', async () => {
+        // The shipped default, not an exotic topology: `openAiCompatible.host` defaults to
+        // `http://127.0.0.1:11434` — byte-identical to `ollama.host` — and the lane's config JSDoc
+        // names Ollama's OpenAI-compatible surface among what it covers. Ollama reports an untagged
+        // pull as `name:latest` and `/v1/models` returns ids verbatim, so an exact compare refused
+        // to embed against a model that was loaded and serving. This path only became reachable for
+        // non-LMS endpoints when the identity gate split from the context gate, which is why the
+        // case is new rather than pre-existing.
+        serverBehavior = 'succeed';
+
+        const originalUnitTestMode = Neo.config.unitTestMode;
+
+        try {
+            Neo.config.unitTestMode                                = false;
+            aiConfig.orchestrator.lms.port                         = '1234';
+            aiConfig.openAiCompatible.embeddingModel               = 'qwen3-embedding';
+            TextEmbeddingService.openAiCompatibleLoadedModelsProbe = async () => [{id: 'qwen3-embedding:latest'}];
+
+            expect(await TextEmbeddingService.embedText('hello', 'openAiCompatible')).toEqual([0.1, 0.2, 0.3]);
+        } finally {
+            Neo.config.unitTestMode = originalUnitTestMode;
+        }
+    });
+
+    test('FENCE: a configured tag is still not satisfied by an untagged served id', async () => {
+        // Passes in BOTH directions by design — it is what stops the tolerance above widening into
+        // "equal", not evidence that the tolerance works. Counting it as red-proof would be the
+        // vacuous-control mistake; it is recorded here as a fence so nobody later reads it as one.
+        serverBehavior = 'succeed';
+
+        const originalUnitTestMode = Neo.config.unitTestMode;
+
+        try {
+            Neo.config.unitTestMode                                = false;
+            aiConfig.orchestrator.lms.port                         = '1234';
+            aiConfig.openAiCompatible.embeddingModel               = 'qwen3-embedding:latest';
+            TextEmbeddingService.openAiCompatibleLoadedModelsProbe = async () => [{id: 'qwen3-embedding'}];
+
+            let thrown;
+            try { await TextEmbeddingService.embedText('hello', 'openAiCompatible') } catch (error) { thrown = error }
+
+            expect(thrown, 'a pinned tag must not be satisfied by the bare name').toBeTruthy();
+            expect(thrown.residencyDisposition).toBe(EMBEDDING_RESIDENCY_NEVER_RESIDENT);
+        } finally {
+            Neo.config.unitTestMode = originalUnitTestMode;
+        }
+    });
+
     test('an UNREACHABLE model list degrades to unknown rather than refusing the embed', async () => {
         // AC-5's other half. `/v1/models` is conventional, not guaranteed, and a transient 503 must
         // not take embedding down — an identity check that cannot run is an unanswered question, not

--- a/test/playwright/unit/ai/services/memory-core/TextEmbeddingService.retry.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/TextEmbeddingService.retry.spec.mjs
@@ -105,8 +105,10 @@ test.describe.serial('TextEmbeddingService #11393/#11402/#12487/#12509 — openA
     let originalLmsPort;
     let originalLoadedModelsProbe;
 
+    let EMBEDDING_RESIDENCY_NEVER_RESIDENT;
+
     test.beforeAll(async () => {
-        ({default: TextEmbeddingService} = await import(
+        ({default: TextEmbeddingService, EMBEDDING_RESIDENCY_NEVER_RESIDENT} = await import(
             '../../../../../../ai/services/memory-core/TextEmbeddingService.mjs'
         ));
 
@@ -352,6 +354,83 @@ test.describe.serial('TextEmbeddingService #11393/#11402/#12487/#12509 — openA
         clearAggregatedFrictions();
     });
 
+    /*
+     * The incident, reproduced. A production plane served `Qwen3-Embedding-8B-Q4_K_M` while
+     * configured for `qwen3-embedding-0.6b`, across two deploys, every container healthy — and the
+     * only symptom was slow embeddings, read as a performance problem rather than a configuration
+     * one. Proving it took reading two literals out of a container log by hand.
+     *
+     * Neo already had the check and the right words for it; it was gated behind an LM Studio port
+     * comparison, so identity verification existed for the developer laptop and not for the
+     * deployment. These arms pin the widened gate and, just as importantly, the two ways it must
+     * NOT harden into a refusal.
+     */
+    test('REGRESSION: a served model that is not the configured one is named, on a non-LMS endpoint', async () => {
+        const originalUnitTestMode = Neo.config.unitTestMode;
+
+        try {
+            Neo.config.unitTestMode = false;
+            // Not the LMS lane: the host port is the test server, the LMS port is something else.
+            aiConfig.orchestrator.lms.port                        = '1234';
+            aiConfig.openAiCompatible.embeddingModel              = 'qwen3-embedding-0.6b';
+            // What `/v1/models` actually answered on the incident plane.
+            TextEmbeddingService.openAiCompatibleLoadedModelsProbe = async () => [{id: 'Qwen3-Embedding-8B-Q4_K_M'}];
+
+            let thrown;
+            try { await TextEmbeddingService.embedText('hello', 'openAiCompatible') } catch (error) { thrown = error }
+
+            expect(thrown, 'a wrong served model must not embed silently — this is the whole incident').toBeTruthy();
+            // The served identifier must be NAMED. "not resident" without it sends an operator back
+            // to the container logs, which is the manual step this check exists to replace.
+            expect(thrown.message).toContain('Qwen3-Embedding-8B-Q4_K_M');
+            expect(thrown.message).toContain('qwen3-embedding-0.6b');
+            expect(thrown.residencyDisposition).toBe(EMBEDDING_RESIDENCY_NEVER_RESIDENT);
+        } finally {
+            Neo.config.unitTestMode = originalUnitTestMode;
+        }
+    });
+
+    test('CONTROL: the matching model on the same non-LMS path embeds normally', async () => {
+        // Without this the arm above could pass by refusing everything — an identity check that
+        // never confirms is indistinguishable from one that always rejects, and would take the lane
+        // down rather than observe it.
+        serverBehavior = 'succeed';
+
+        const originalUnitTestMode = Neo.config.unitTestMode;
+
+        try {
+            Neo.config.unitTestMode                                = false;
+            aiConfig.orchestrator.lms.port                         = '1234';
+            aiConfig.openAiCompatible.embeddingModel               = 'qwen3-embedding-0.6b';
+            TextEmbeddingService.openAiCompatibleLoadedModelsProbe = async () => [{id: 'qwen3-embedding-0.6b'}];
+
+            expect(await TextEmbeddingService.embedText('hello', 'openAiCompatible')).toEqual([0.1, 0.2, 0.3]);
+        } finally {
+            Neo.config.unitTestMode = originalUnitTestMode;
+        }
+    });
+
+    test('an UNREACHABLE model list degrades to unknown rather than refusing the embed', async () => {
+        // AC-5's other half. `/v1/models` is conventional, not guaranteed, and a transient 503 must
+        // not take embedding down — an identity check that cannot run is an unanswered question, not
+        // a confirmed mismatch. The inverse failure (probe outage reads as identity-confirmed) is
+        // covered by the arm above, which throws on a real disagreement.
+        serverBehavior = 'succeed';
+
+        const originalUnitTestMode = Neo.config.unitTestMode;
+
+        try {
+            Neo.config.unitTestMode                                = false;
+            aiConfig.orchestrator.lms.port                         = '1234';
+            aiConfig.openAiCompatible.embeddingModel               = 'qwen3-embedding-0.6b';
+            TextEmbeddingService.openAiCompatibleLoadedModelsProbe = async () => { throw new Error('connect ECONNREFUSED') };
+
+            expect(await TextEmbeddingService.embedText('hello', 'openAiCompatible')).toEqual([0.1, 0.2, 0.3]);
+        } finally {
+            Neo.config.unitTestMode = originalUnitTestMode;
+        }
+    });
+
     test('first-call-succeeds-no-retry path', async () => {
         serverBehavior = 'succeed';
         const result = await TextEmbeddingService.embedText('hello', 'openAiCompatible');
@@ -511,7 +590,7 @@ test.describe.serial('TextEmbeddingService #11393/#11402/#12487/#12509 — openA
         expect(requestCount, 'the resident-model preflight fails before transport').toBe(0);
     });
 
-    test('openAiCompatible skips LM Studio context probe for non-LMS endpoints (#13944)', async () => {
+    test('openAiCompatible verifies identity provider-shaped on non-LMS endpoints, and still skips the LM Studio context probe (#13944)', async () => {
         serverBehavior = 'succeed';
 
         const originalUnitTestMode = Neo.config.unitTestMode;
@@ -521,12 +600,27 @@ test.describe.serial('TextEmbeddingService #11393/#11402/#12487/#12509 — openA
             aiConfig.orchestrator.lms.port = '1234';
             TextEmbeddingService.openAiCompatibleLoadedModelsProbe = null;
 
+            allRequests.length = 0;
+
             const result = await TextEmbeddingService.embedText('hello', 'openAiCompatible');
 
             expect(result).toEqual([0.1, 0.2, 0.3]);
 
-            expect(requestCount).toBe(1);
+            // Asserted as SHAPE rather than as a count. The original arm proved "no LM Studio probe"
+            // with `requestCount === 1`, which never actually established it — `lms ps` is a CLI, so
+            // it would not have shown up in an HTTP count either way. Identity verification is now
+            // provider-shaped, so a second request exists BY DESIGN and a bare count would have to be
+            // loosened to a number that asserts nothing.
+            const urls = allRequests.map(entry => entry.url);
+
+            expect(urls.filter(url => url.includes('/v1/models')), 'the provider-shaped identity probe must run').toHaveLength(1);
+            expect(urls.filter(url => url.includes('/embeddings')), 'exactly one embedding request').toHaveLength(1);
             expect(lastRequest.body.input).toBe('hello');
+
+            // The mock answers `/v1/models` with embedding rows carrying no `id`, so the parsed list
+            // is EMPTY — the "endpoint does not really enumerate" case. That must degrade to unknown
+            // and let the embed proceed, never harden into a confident not-resident refusal.
+            expect(result, 'an unenumerable endpoint must not block embedding').toEqual([0.1, 0.2, 0.3]);
         } finally {
             Neo.config.unitTestMode = originalUnitTestMode;
         }


### PR DESCRIPTION
Resolves neomjs/neo#17296

The embedding lane now states its model identity on both surfaces it was silent on. At embed time, identity verification runs on **any** OpenAI-compatible endpoint instead of only the LM Studio lane — the inverse of where it was needed. And the same comparison is published to the deployment snapshot, so a wrong model is legible to an operator or agent **with no shell**, rather than inferred from slow embeddings. That inference is what cost a production plane two deploys serving `Qwen3-Embedding-8B-Q4_K_M` against a `qwen3-embedding-0.6b` configuration, every container healthy throughout.

Evidence: L2 (both halves proven against injected probe seams driving every arm — match, mismatch, unreachable, empty list, unconfigured; the runtime half additionally mutation-verified against the pre-fix vendor gate) → L4 required (an operator reading `inspect_deployment` on a live plane and finding the identity row). Residual: AC3-live-witness, Residual-Owner: neomjs/neo-agent-brain#54.

## Deltas from ticket

**The runtime fix is a SPLIT, not a widening, and that distinction is the whole design.** One vendor gate guarded two different assertions:

- **Identity** — is the configured model the one actually served? Answerable on any OpenAI-compatible endpoint via `GET /v1/models`.
- **Context** — is the loaded window large enough? Answerable only from `lms ps`; `/v1/models` reports no context length.

Widening the shared gate would have been worse than the gap it closed: the context assertion would then fire on llama.cpp, where the number is structurally unknown, and refuse every embed with a spurious unknown-context error. Identity now runs wherever a host and model are configured; context stays LM-Studio-only.

**AC-3 gets a THIRD service-key set, not a reuse — @neo-opus-vega's ruling, and her reason is better than authorial intent.** `providerReadinessHelper.mjs` hardcodes `ollama pull <model>` into the residency verdict's remediation. Adding `embedding-model` to `providerResidencyServiceKeys` would therefore tell a llama.cpp container to run `ollama pull Qwen3-Embedding-0.6B` — emitted on `inspect_deployment`, the exact surface AC-3 exists to make trustworthy. **Wrong remediation is worse than silence: silence is a gap, a confident wrong instruction is a false lead.** Reusing the lane-SHAPE key would be closer and still wrong: geometry and identity are different assertions with different answerability, and one gate over two assertions is precisely the defect the runtime half repairs.

**Three ways it must not harden into a refusal**, each its own arm: an unreachable endpoint degrades to unknown (a check that cannot run is an unanswered question, never a confirmed match, and never grounds for refusing work previously allowed); an UNANSWERABLE list stays distinct from an EMPTY one, because collapsing them would silently retire the not-resident preflight everywhere; and the probe seam no longer implies the LM Studio lane.

**The snapshot publishes on a MATCH too.** Proving a lane is serving the right model previously required a shell and a multi-session investigation. `null` means the service is not an identity participant — never that identity was checked and found fine.

**Deliberately not memoized**, unlike the lane-shape receipt beside it: slot geometry cannot change without a restart, but the model a running endpoint serves can, and a cached `match` would outlive the fact it reported.

**ADR-0019** — `aligned-with`. A plain env-bound leaf (no formula, no re-derivation), read at the use site, no defensive `?.` on AiConfig reads, no runtime mutation, no threaded config values.

## Test Evidence

- `npm run test-unit -- --grep "DeploymentStateBridge|TextEmbedding|ContainerHealth|configBase|AiConfig"` — **534 passed**
- `npm run test-unit` (full suite) — **14055 passed, 1 failed** (the known-environmental neural-link 503 below; the brain intermittency did not recur on this run)
- `npm run agent-preflight` — all gates, both commits

**Mutation-proofed on both halves, and the second mutation found a real hole rather than confirming a belief.**

| mutation | result |
|---|---|
| restore the vendor gate on the runtime identity arm | that arm goes **SILENT** — the pre-fix behaviour the ticket requires |
| gate the snapshot identity on the **residency** predicate | **fails** — but only after the call-site test below existed |

That second row is the one worth reading. My first pass tested `isProviderModelIdentityServiceKey` in isolation, and collapsing the call site onto the residency predicate left **every test green**. A pure-function corpus proves the function and says nothing about which predicate the collection path actually calls. The wiring test now drives `collectServiceSnapshot` against three **disjoint** key sets, so either possible collapse — onto residency or onto lane-shape — fails. Without running the mutation I would have shipped a gate nothing verified.

The mismatch arm also asserts its remediation **never contains `ollama`**, which is the failure Vega's ruling exists to prevent, pinned rather than trusted.

**The config-parity gate caught a real omission and I took its prescribed fix.** Adding the leaf changed the declared-path set, and `lint-config-template-ssot` failed with *"a config path reads `undefined` at runtime, in a peer's process, when it silently leaves this surface — no other gate can see it."* Snapshot regenerated via `--update-parity` and **amended into the same commit as the leaf**, per the lint's own instruction that the record be reviewable alongside the change.

**Known-environmental:** `McpServersHealth` / neural-link fails with GitHub 503s in the trace; control-run on clean `origin/dev` reproduces it there. The `[unit-brain]` project also shows intermittent cross-file failures whose victim spec moves between runs — characterised by a negative experiment (removing an unrelated added spec file changed *which* brain specs failed, not whether), and broadcast as a defect-note.

## Post-Merge Validation

- [ ] On a live plane, `inspect_deployment` carries `providerModelIdentity` for the embedding service, and a deliberately mis-configured `embeddingModel` renders `state: 'mismatch'` naming the served id — the red→green witness AC-3 exists for.
- [ ] The remediation string on that surface names the served-vs-configured pair and contains no vendor pull command.

Residual-Owner: neomjs/neo-agent-brain#54

Both are live-plane reads this sandbox cannot make. neomjs/neo-agent-brain#54 owns external-plane observability and is open — verified `state: open`, `closed_at: null` at the moment of parking, after a ticket I cited earlier today turned out to have closed eight minutes before I named it.

## Commits

- `f34df7c505` — the runtime split: identity on any OpenAI-compatible endpoint, context stays LM-Studio-gated
- `3c8251119a` — AC-3: the identity observation reaches the deployment snapshot, with its own service-key set

Related: neomjs/neo#17295 · neomjs/neo#17069 · neomjs/neo#16948 · neomjs/neo-agent-brain#54

Authored by Grace (Claude Opus 5, Claude Code). Session ddbee747-a0f6-41d3-a41e-813561d2d9f9.
