### PR TITLE
fix(grid): a column's width comes from its config unless layout owns it (#17327)

### DIFF
--- a/src/grid/header/Toolbar.mjs
+++ b/src/grid/header/Toolbar.mjs
@@ -330,6 +330,29 @@ class Toolbar extends BaseToolbar {
     }
 
     /**
+     * @summary Whether a header item's width has to be MEASURED, because the config does not own it.
+     *
+     * A column sized by `flex`, by no width at all, or by a non-px string (`'20%'`, `'auto'`) has its
+     * real width decided by layout, so only the DOM can answer. Anything with an explicit px width
+     * already carries the answer in its config, and the DOM is merely a projection of it.
+     *
+     * `flex` must be compared, never merely tested for truthiness: {@link Neo.grid.header.Button}
+     * defaults it to the STRING `'none'`, which is the CSS keyword for "do not flex" — and truthy.
+     * A bare `item.flex` check therefore called every column in every grid dynamic, so the whole
+     * header was always sized from a layout read even when every width was an explicit px config.
+     *
+     * The distinction is the single source of truth for {@link #passSizeToBody}'s two questions —
+     * "does this toolbar need a layout read at all?" and "where does THIS column's width come from?"
+     * @param {Neo.grid.header.Button} item
+     * @returns {Boolean}
+     */
+    isMeasuredWidth(item) {
+        let {flex, width} = item;
+
+        return !!((flex && flex !== 'none') || !width || (Neo.isString(width) && !width.endsWith('px')))
+    }
+
+    /**
      * @summary Derives `columnPositions` + `availableWidth` from the rendered header buttons,
      * then repaints the body rows against the new geometry (unless `silent`).
      *
@@ -350,13 +373,10 @@ class Toolbar extends BaseToolbar {
             layoutFinished  = true,
             i               = 0,
             len             = items.length,
-            item, rects, w, width;
+            item, rects, width;
 
         for (; i < len; i++) {
-            item = items[i];
-            w = item.width;
-
-            if (item.flex || !w || (Neo.isString(w) && !w.endsWith('px'))) {
+            if (me.isMeasuredWidth(items[i])) {
                 hasDynamicWidth = true;
                 break
             }
@@ -379,29 +399,26 @@ class Toolbar extends BaseToolbar {
             await me.timeout(100);
             await me.passSizeToBody(silent)
         } else {
-            if (hasDynamicWidth) {
-                for (i = 0; i < len; i++) {
-                    columnPositions.push({
-                        dataField: items[i].dataField,
-                        width    : rects[i].width,
-                        x        : currentX
-                    });
+            for (i = 0; i < len; i++) {
+                item = items[i];
 
-                    currentX += rects[i].width
-                }
-            } else {
-                for (i = 0; i < len; i++) {
-                    item = items[i];
-                    width = item.hidden ? 0 : parseInt(item.width, 10);
+                // Per COLUMN, not per toolbar. A single flex column used to force every sibling's
+                // width to come from the layout read below — including columns whose width the
+                // config already owns. Those two sources agree at rest and disagree for exactly one
+                // frame after a write, which is the whole resize-drop defect: `Resizable#onDragEnd`
+                // writes the button's new width and calls this synchronously, so the rect still
+                // carried the PRE-resize width and every cell was repainted onto the geometry the
+                // drag had just replaced — while the header, whose config was set directly, kept the
+                // new one. Measure only what we do not own, and the race has nothing to bite on.
+                width = item.hidden ? 0 : (me.isMeasuredWidth(item) ? rects[i].width : parseInt(item.width, 10));
 
-                    columnPositions.push({
-                        dataField: item.dataField,
-                        width,
-                        x        : currentX
-                    });
+                columnPositions.push({
+                    dataField: item.dataField,
+                    width,
+                    x        : currentX
+                });
 
-                    currentX += width
-                }
+                currentX += width
             }
 
             body.columnPositions.clear();

--- a/test/playwright/e2e/grid/HeaderResizeRectSync.spec.mjs
+++ b/test/playwright/e2e/grid/HeaderResizeRectSync.spec.mjs
@@ -159,5 +159,43 @@ test.describe('Grid header↔cell rect sync across a column resize', () => {
             .toBeLessThan(before.width - 20);
 
         assertAligned(await readPairs(page), 'after narrowing "Number 7"')
+    });
+
+    /**
+     * The MIXED surface: one genuinely flex-sized column beside explicitly-sized ones.
+     *
+     * This is the case the per-column width decision exists for. When the toolbar contains any
+     * column whose width only layout can answer, the geometry pass still has to measure — but it
+     * must measure ONLY that column, and keep reading the explicit px widths from the configs that
+     * own them. Sizing the whole header from one layout read is what let a stale rect repaint every
+     * cell; a spec that only ever runs all-explicit columns cannot tell the two designs apart.
+     */
+    test('a flex column beside explicit ones does not drag the others onto a stale measurement', async ({page, neuralLink}) => {
+        await page.goto('/examples/grid/bigData/');
+        page.on('pageerror', err => console.error('BROWSER JS ERROR:', err));
+
+        await expect(page.locator('[role="grid"]').first()).toBeVisible({timeout: 30000});
+        await expect(page.locator('.neo-grid-body [role="row"]').first()).toBeVisible({timeout: 30000});
+        await page.waitForTimeout(600);
+
+        const app     = await neuralLink.connectToApp('Neo.examples.grid.bigData'),
+              buttons = await app.queryComponent({className: 'Neo.grid.header.Button'}, ['dataField', 'id']),
+              flexCol = buttons.find(b => b.properties.dataField === 'number13');
+
+        expect(flexCol, 'the surface exposes a column to make dynamic').toBeTruthy();
+
+        // make it genuinely measured: no explicit width, a real flex value
+        await app.setProperties(flexCol.properties.id, {flex: 1, width: null});
+        await page.waitForTimeout(800);
+
+        assertAligned(await readPairs(page), 'baseline with a flex column present');
+
+        const before = await resizeColumn(page, 'Number 7', 160),
+              after  = await page.locator('.neo-grid-header-button', {hasText: 'Number 7'}).first().boundingBox();
+
+        expect(after.width, `the widen gesture engaged (before=${before.width} after=${after.width})`)
+            .toBeGreaterThan(before.width + 20);
+
+        assertAligned(await readPairs(page), 'after widening beside a flex column')
     })
 });

--- a/test/playwright/e2e/grid/HeaderResizeRectSync.spec.mjs
+++ b/test/playwright/e2e/grid/HeaderResizeRectSync.spec.mjs
@@ -38,13 +38,19 @@ test.describe('Grid header↔cell rect sync across a column resize', () => {
     test.setTimeout(90000);
     test.use({viewport: {width: 1600, height: 900}});
 
-    /** Visible headers + first-row cells, x-sorted and clipped to the body box. */
-    const readPairs = page => page.evaluate(() => {
-        const body   = document.querySelector('.neo-grid-body'),
+    /**
+     * Visible headers + first-row cells, x-sorted and clipped to the body box.
+     *
+     * The region index matters on a locked grid: a grid owns up to three toolbar/body pairs and
+     * `grid.header.Toolbar#body` routes between them, so a pairing read that always took index 0
+     * would silently assert the locked-start region while the gesture happened in the centre.
+     */
+    const readPairs = (page, region = 0) => page.evaluate(({region}) => {
+        const body   = document.querySelectorAll('.neo-grid-body')[region],
               clip   = body.getBoundingClientRect(),
               inClip = r => r.width > 0 && r.right > clip.left + 1 && r.left < clip.right - 1;
 
-        const toolbar = document.querySelector('.neo-grid-header-toolbar'),
+        const toolbar = document.querySelectorAll('.neo-grid-header-toolbar')[region],
               headers = [...toolbar.children]
                   .map(b => ({b, r: b.getBoundingClientRect()}))
                   .filter(({b, r}) => inClip(r) && getComputedStyle(b).visibility !== 'hidden')
@@ -67,7 +73,7 @@ test.describe('Grid header↔cell rect sync across a column resize', () => {
                   .sort((a, b2) => a.x - b2.x);
 
         return {headers, cells};
-    });
+    }, {region});
 
     /**
      * Every visible header must sit pixel-exactly on a first-row cell. A drop that leaves the cells
@@ -197,5 +203,57 @@ test.describe('Grid header↔cell rect sync across a column resize', () => {
             .toBeGreaterThan(before.width + 20);
 
         assertAligned(await readPairs(page), 'after widening beside a flex column')
+    });
+
+    /**
+     * The LOCKED surface: a grid owning three toolbar/body pairs.
+     *
+     * `grid.header.Toolbar#body` routes each toolbar to its own region's body, and the geometry
+     * pass this fix changes runs per toolbar. So a resize in the centre must move the centre's
+     * cells and leave the locked regions exactly where they were — a repair that accidentally
+     * sized every region from the centre's items would still satisfy the single-body specs above.
+     */
+    test('resizing a centre column leaves the locked regions untouched', async ({page}) => {
+        await page.goto('/examples/grid/lockedColumns/');
+        page.on('pageerror', err => console.error('BROWSER JS ERROR:', err));
+
+        await expect(page.locator('[role="grid"]').first()).toBeVisible({timeout: 30000});
+        await expect(page.locator('.neo-grid-body [role="row"]').first()).toBeVisible({timeout: 30000});
+        await page.waitForTimeout(800);
+
+        const lockedBefore = await readPairs(page, 0);
+
+        assertAligned(lockedBefore, 'locked-start baseline');
+        assertAligned(await readPairs(page, 1), 'centre baseline');
+
+        // the centre toolbar owns the resizable target; grab its first header
+        const centreHeader = page.locator('.neo-grid-header-toolbar').nth(1).locator('.neo-grid-header-button').first(),
+              label        = (await centreHeader.locator('.neo-button-text').innerText()).trim();
+
+        const box = await centreHeader.boundingBox(),
+              y   = box.y + box.height / 2,
+              x   = box.x + box.width - 3;
+
+        await page.mouse.move(x, y);
+        await expect(centreHeader.locator('.neo-resizable-right')).toBeAttached({timeout: 5000});
+        await page.mouse.down();
+        await page.mouse.move(x + 140, y, {steps: 40});
+        await page.waitForTimeout(400);
+        await page.mouse.up();
+        await page.waitForTimeout(900);
+
+        const after = await centreHeader.boundingBox();
+
+        expect(after.width, `the centre widen engaged on "${label}" (before=${box.width} after=${after.width})`)
+            .toBeGreaterThan(box.width + 20);
+
+        assertAligned(await readPairs(page, 1), `centre after widening "${label}"`);
+
+        // the locked region is not a participant in this gesture and must not have moved
+        const lockedAfter = await readPairs(page, 0);
+
+        assertAligned(lockedAfter, 'locked-start after the centre resize');
+        expect(JSON.stringify(lockedAfter.cells), 'the locked-start cells are byte-identical across a centre resize')
+            .toBe(JSON.stringify(lockedBefore.cells))
     })
 });

--- a/test/playwright/e2e/grid/HeaderResizeRectSync.spec.mjs
+++ b/test/playwright/e2e/grid/HeaderResizeRectSync.spec.mjs
@@ -1,0 +1,163 @@
+import {test, expect} from '../../fixtures.mjs';
+
+/**
+ * @summary Whitebox-e2e: header↔cell rect synchronization across a real column RESIZE, asserted
+ * where it actually breaks — AFTER the drop.
+ *
+ * ## Why a second spec, next to a net that already asserts this exact property
+ *
+ * `HeaderCellRectSync.spec.mjs` already pairs every visible header rect against its first-row cell
+ * rect on x and width, at mid-drag hold points and after every drop. It is the right net. It has
+ * never once fired on a resize defect, and it structurally cannot: its only gesture is a column
+ * REORDER, grabbed at the button's centre via `.neo-draggable`. Resize is armed exclusively from
+ * `.neo-resizable` (the right-edge handle), and `grid.header.Toolbar#createSortZone` sets
+ * `ignoreDragSelector: '.neo-resizable'` so the two gestures provably never overlap. A
+ * reorder-driven spec therefore cannot reach the resize path, however many passes it runs.
+ *
+ * So the assertion core below is deliberately the same shape; only the DRIVER is new. The
+ * separation that makes both features correct is what left half of the property uncovered.
+ *
+ * ## Gesture realism
+ *
+ * The resize handles are not in the DOM at rest — `plugin.Resizable#onMouseMove` injects them when
+ * the pointer is over a header button. So the hover is load-bearing setup, not padding: without it
+ * there is nothing to grab, and a spec that skipped it would fail for the wrong reason. The drag
+ * itself must be a real stepped mouse gesture; a synthetic worker-side event does not arm Neo's
+ * Mouse drag sensor and would green-wash the whole class.
+ *
+ * ## What it covers
+ *
+ * Both directions (widen AND narrow — the 9k-era defect was shrink-only, and a widen-only spec
+ * re-opens that blind spot), on the fixed-px surface. The dynamic-width surface takes a
+ * structurally different branch in `passSizeToBody` (it awaits a DOM measurement) and needs its
+ * own case.
+ *
+ * Run: npm run test-e2e -- test/playwright/e2e/grid/HeaderResizeRectSync.spec.mjs --workers=1
+ */
+test.describe('Grid header↔cell rect sync across a column resize', () => {
+    test.setTimeout(90000);
+    test.use({viewport: {width: 1600, height: 900}});
+
+    /** Visible headers + first-row cells, x-sorted and clipped to the body box. */
+    const readPairs = page => page.evaluate(() => {
+        const body   = document.querySelector('.neo-grid-body'),
+              clip   = body.getBoundingClientRect(),
+              inClip = r => r.width > 0 && r.right > clip.left + 1 && r.left < clip.right - 1;
+
+        const toolbar = document.querySelector('.neo-grid-header-toolbar'),
+              headers = [...toolbar.children]
+                  .map(b => ({b, r: b.getBoundingClientRect()}))
+                  .filter(({b, r}) => inClip(r) && getComputedStyle(b).visibility !== 'hidden')
+                  .map(({b, r}) => ({
+                      text: b.querySelector('.neo-button-text')?.textContent ?? b.id,
+                      x   : Math.round(r.left),
+                      w   : Math.round(r.width)
+                  }))
+                  .sort((a, b2) => a.x - b2.x);
+
+        const row   = body.querySelector('[role="row"]'),
+              cells = [...row.children]
+                  .map(c => ({c, r: c.getBoundingClientRect()}))
+                  .filter(({c, r}) => inClip(r) && getComputedStyle(c).display !== 'none')
+                  .map(({c, r}) => ({
+                      id: c.id.split('__').pop(),
+                      x : Math.round(r.left),
+                      w : Math.round(r.width)
+                  }))
+                  .sort((a, b2) => a.x - b2.x);
+
+        return {headers, cells};
+    });
+
+    /**
+     * Every visible header must sit pixel-exactly on a first-row cell. A drop that leaves the cells
+     * on the pre-drag geometry fails every lookup at and after the resized column and prints both
+     * rect sets, so the failure names the offending column and the offset rather than a bare count.
+     */
+    const assertAligned = ({headers, cells}, label) => {
+        const dump = `headers=${JSON.stringify(headers)} cells=${JSON.stringify(cells)}`;
+
+        expect(headers.length, `${label}: visible header/cell count parity — ${dump}`).toBe(cells.length);
+
+        headers.forEach(h => {
+            const c = cells.find(cell => Math.abs(cell.x - h.x) <= 1);
+
+            expect(c, `${label}: no cell under header "${h.text}" (x=${h.x}, w=${h.w}) — ${dump}`).toBeDefined();
+            expect(Math.abs(h.w - c.w), `${label}: width mismatch for "${h.text}": header w=${h.w} vs cell "${c.id}" w=${c.w}`)
+                .toBeLessThanOrEqual(1)
+        })
+    };
+
+    /**
+     * One real resize: hover the button to materialize the handle, grab it, drag `delta` px with a
+     * stepped move, drop. Returns the button's pre-drag box so the caller can assert the intent
+     * actually landed rather than trusting that the gesture engaged at all.
+     */
+    const resizeColumn = async (page, headerText, delta) => {
+        const header = page.locator('.neo-grid-header-button', {hasText: headerText}).first();
+
+        await expect(header).toBeVisible({timeout: 15000});
+
+        const box = await header.boundingBox(),
+              y   = box.y + box.height / 2,
+              x   = box.x + box.width - 3;
+
+        // the handles are injected on hover — without this there is nothing to grab
+        await page.mouse.move(x, y);
+        await expect(header.locator('.neo-resizable-right')).toBeAttached({timeout: 5000});
+
+        await page.mouse.down();
+        await page.mouse.move(x + delta, y, {steps: 40});
+        await page.waitForTimeout(400);
+        await page.mouse.up();
+        await page.waitForTimeout(900);
+
+        return box
+    };
+
+    test('widening a column moves its cells with it', async ({page}) => {
+        await page.goto('/examples/grid/bigData/');
+        page.on('pageerror', err => console.error('BROWSER JS ERROR:', err));
+
+        await expect(page.locator('[role="grid"]').first()).toBeVisible({timeout: 30000});
+        await expect(page.locator('.neo-grid-body [role="row"]').first()).toBeVisible({timeout: 30000});
+        await page.waitForTimeout(600);
+
+        assertAligned(await readPairs(page), 'baseline');
+
+        const before = await resizeColumn(page, 'Number 7', 160);
+
+        // the gesture must have actually resized something, or the parity below is vacuous
+        const after = await page.locator('.neo-grid-header-button', {hasText: 'Number 7'}).first().boundingBox();
+
+        expect(after.width, `the widen gesture engaged (before=${before.width} after=${after.width})`)
+            .toBeGreaterThan(before.width + 20);
+
+        assertAligned(await readPairs(page), 'after widening "Number 7"')
+    });
+
+    test('narrowing a column moves its cells with it', async ({page}) => {
+        await page.goto('/examples/grid/bigData/');
+        page.on('pageerror', err => console.error('BROWSER JS ERROR:', err));
+
+        await expect(page.locator('[role="grid"]').first()).toBeVisible({timeout: 30000});
+        await expect(page.locator('.neo-grid-body [role="row"]').first()).toBeVisible({timeout: 30000});
+        await page.waitForTimeout(600);
+
+        assertAligned(await readPairs(page), 'baseline');
+
+        // widen first: the column ships at the 100px `columnDefaults` width and `minWidth` is 100,
+        // so there is no room to shrink from the shipped size — the narrow leg needs headroom, and
+        // taking it through a real resize keeps the whole gesture chain under test.
+        await resizeColumn(page, 'Number 7', 200);
+        assertAligned(await readPairs(page), 'after the setup widen');
+
+        const before = await resizeColumn(page, 'Number 7', -120),
+              after  = await page.locator('.neo-grid-header-button', {hasText: 'Number 7'}).first().boundingBox();
+
+        expect(after.width, `the narrow gesture engaged (before=${before.width} after=${after.width})`)
+            .toBeLessThan(before.width - 20);
+
+        assertAligned(await readPairs(page), 'after narrowing "Number 7"')
+    })
+});


### PR DESCRIPTION
Resolves #17327

Dropping a column resize repainted every cell onto the geometry the drag had just replaced — the header kept its new width while the cells snapped back to the old grid. The cause is not in the drop path that PR `#17291` touched: `item.flex` was tested for truthiness, and `grid/header/Button` defaults `flex` to the **string `'none'`** — the CSS keyword for *"do not flex"*. So `hasDynamicWidth` has been true for every column of every grid, and the header geometry was always derived from a `getLayoutRect()` DOM measurement instead of from the configs that own it. `Resizable#onDragEnd` writes the new width and calls `passSizeToBody` synchronously, so that measurement still carried the pre-resize width.

Evidence: L3 (live browser e2e — real stepped mouse gesture on the real resize handle, directory-level stashed control, two-direction mutation) → L3 required (every close-target AC is runtime-observable in the e2e sandbox; nothing here needs an operator-gated handoff). Residual: none.

## The measurement

Widening `Number 7` by 160px on `examples/grid/bigData` at 1600×900:

| phase | availableWidth | header | cell |
|---|---|---|---|
| mid-drag | 5317 | 257 | 257 |
| after drop | **5160** | 257 | **100** |

The revert is synchronous with the drop, and only two places write `availableWidth`, which isolated it to `passSizeToBody` recomputing the original total while the button config already held 257.

## The repair

Ask the question per **column** rather than per toolbar. A width the config owns (explicit px, `flex: 'none'`) is read from the config; only a width layout owns (a real flex value, no width, a non-px string) is measured. The DOM is a projection of an explicit width, not a second authority for it — two sources for one value agree at rest and disagree for exactly one frame after a write, which is the entire defect.

The two branches of the geometry loop collapse into one, and the predicate deciding *measure or read* is single-sourced as `isMeasuredWidth()`. Previously it existed as two copies applied at two different granularities, which is how they came apart.

## Deltas from ticket

- **The root cause is none of the ticket's four hypotheses.** H3 was closest in shape (a measurement race) but I had explicitly ranked it *"unlikely on this surface"* on the wrong premise that every `bigData` column carries a px width. They do — and it took the measured branch anyway, because `flex: 'none'` is truthy. No hypothesis named the trigger; the falsifier run did.
- H2 is refuted by the data: it predicts header and cells agreeing on a slightly wrong width, and they disagree completely. H1 was already partially exculpated in the ticket and is not implicated.
- `isMeasuredWidth()` is a small extraction beyond the minimal one-line fix. It is what makes the per-column decision expressible at all, and it removes the duplicated predicate that allowed the two granularities to drift.
- **AC-6 (the drag-time lag) is characterized, not fixed, and needs no follow-up ticket.** It is a different mechanism from the drop miss: `drag:move` never measures — `updateCellPositions` applies the config value directly — so mid-drag geometry is correct, as the table above shows. The perceived lag is the per-tick worker→DOM round trip every Neo visual update crosses. I did not measure its frame-level latency; if it is worth reducing that is a performance lane, not a correctness one.

## Test Evidence

`test/playwright/e2e/grid/HeaderResizeRectSync.spec.mjs` — new. Same assertion core as `HeaderCellRectSync.spec.mjs`, new driver. That existing net asserts this exact property and structurally cannot reach a resize: its only gesture is a column reorder via `.neo-draggable`, while resize is armed solely from `.neo-resizable`, and `createSortZone` sets `ignoreDragSelector: '.neo-resizable'` so the two provably never overlap.

Four cases: widen, narrow, a flex column beside explicit ones, and a centre resize on a locked grid asserting the locked regions are byte-identical afterwards.

```
npm run test-e2e -- test/playwright/e2e/grid/HeaderResizeRectSync.spec.mjs --workers=1   4 passed
npm run test-unit -- test/playwright/unit/grid/                                          61 passed
npm run test-unit                                                          14030 passed / 2 failed
```

**Directory-level control** (not isolation — a per-file rerun heals cross-file leaks):

```
npm run test-e2e -- test/playwright/e2e/grid/   fix stashed   5 failed / 25 passed
npm run test-e2e -- test/playwright/e2e/grid/   fix applied   3 failed / 27 passed
```

The 3 residual failures are pre-existing: `GridViewFocus:29` fails identically in both runs, and `TreeBigData` fails twice in both while varying *which* two, so it is flaky independently of this change.

The 2 full-suite failures are in the `unit-brain` project — one is an outright HTTP 400 model-load error from the local embedding host. A grid header change cannot reach `ai/services/**`; I did not run a stashed full-suite control, so CI is the clean signal there.

**Mutation-verified in both directions.** Reverting the per-column decision while keeping the flex fix turns exactly one spec red — the mixed-width case — and leaves the others green, so neither half of the repair is decoration and no spec is vacuous. Against the pre-fix source (`git checkout HEAD~1` of the file, not a stash) all four go red.

One control was vacuous before it was sound: the first mutation attempt stashed a working tree that no longer held the fix, since it was already committed. The suite passed and proved nothing. Recorded because a green control is worth exactly as much as the mutation behind it.

## Post-Merge Validation

None, and the lint was right to push back on my first draft here. I had written an item asking someone to confirm real dynamic-column apps still lay out correctly, which reads like diligence and is actually hedging: a genuinely dynamic column satisfies `isMeasuredWidth()`, so it still reads `rects[i].width` exactly as before. There is no behavioral delta on that path to observe after merge, and every close-target AC is verified in the sandbox above.

## Commits

- `51cbd73bf6` — red-proof the resize drop leaving cells on the old geometry
- `2ca53df05e` — the repair: a column's width comes from its config unless layout owns it
- `326be8c7d3` — locked-region coverage; pin the pair read to its region

## Evolution

The lane was scoped as a falsifier run over four ranked hypotheses. What actually resolved it was one instrumented ledger read, and it disconfirmed my own ranking: I had reasoned about which branch `passSizeToBody` takes instead of measuring it, and the branch I dismissed for this surface was the branch it took. The one-line premise — "all `bigData` columns carry px widths, therefore the synchronous path runs" — was true in its first half and wrong in its conclusion.

Authored by Grace (Claude Opus 5, Claude Code). Session ad99f59b-9d2c-4f82-b6ce-8c8357ef1879.
