### PR TITLE
feat(fleet): the memories pane pops out — click vessel on the tear-out substrate (#17315)

### DIFF
--- a/apps/agentos/view/fleet/FleetCockpit.mjs
+++ b/apps/agentos/view/fleet/FleetCockpit.mjs
@@ -1028,6 +1028,21 @@ class FleetCockpit extends Container {
                 text    : torn ? 'Detail torn out' : (out ? 'Reattach detail' : 'Pop out detail')
             })
         }
+
+        let memoriesToggle = me.getReference('memories-window-toggle');
+
+        if (memoriesToggle) {
+            // click pop-out and gesture tear-out are ONE pathway for this pane, so an adopted
+            // vessel honestly offers the return action either way; only the mid-gesture window
+            // (captured handle, no adopted vessel yet) disables instead of racing the gesture
+            let adopted    = Boolean(me.tearOutPanes?.memories),
+                midGesture = !adopted && Boolean(me.tearOutPaneHandles?.memories);
+
+            memoriesToggle.set({
+                disabled: midGesture,
+                text    : adopted ? 'Return memories' : 'Pop out memories'
+            })
+        }
     }
 
     /**
@@ -1107,6 +1122,16 @@ class FleetCockpit extends Container {
                     cls      : ['fm-fleet-start-summary'],
                     hidden   : true,
                     reference: 'fleet-start-summary'
+                }, {
+                    // SHELL-owned pop-out affordance for the Memories pane — the detail
+                    // toggle's grammar on the tear-out pathway. Provisional bar placement pending
+                    // the shell navigation-model redesign (per-pane chrome is that pass's scope).
+                    module   : Button,
+                    cls      : ['fm-memories-window-toggle'],
+                    handler  : me.onMemoriesWindowToggle.bind(me),
+                    iconCls  : 'fa-solid fa-arrow-up-right-from-square',
+                    reference: 'memories-window-toggle',
+                    text     : 'Pop out memories'
                 }, {
                     // SHELL-owned pop-out affordance — panes are layout-blind and the shell owns
                     // docking behavior. Routes by the vessel state machine; the label is synced
@@ -1333,13 +1358,17 @@ class FleetCockpit extends Container {
                 // The selected target travels WITH the snapshot (one coherent state key), so a
                 // rematerialized pane never shows cards no selection points at. Agent choices
                 // derive from the same provider-owned roster as the cards — no second resident list.
+                // The listener scope is bound EXPLICITLY to the owning controller: string handlers
+                // resolve through the component's controller chain at fire time, and a vesseled
+                // pane (click pop-out / gesture tear-out) has no controller above it — an
+                // unscoped string would resolve dead in the vessel and cache that miss.
                 return {
                     module      : MemoriesPane,
                     cls         : [marker],
                     activeAgent : me.memoriesTarget ?? me.memoriesSnapshot?.target ?? null,
                     snapshot    : me.memoriesSnapshot,
                     agentOptions: me.buildMemoriesAgentOptions(),
-                    listeners   : {memoriesRequest: 'onMemoriesRequest'},
+                    listeners   : {memoriesRequest: 'onMemoriesRequest', scope: me.getController()},
                     reference   : 'memories'
                 };
             case 'wakeRoutes':
@@ -1457,6 +1486,22 @@ class FleetCockpit extends Container {
     }
 
     /**
+     * @summary Resolve the live {@link AgentOS.view.fleet.MemoriesPane} instance whether it is
+     * docked, revealed, or vesseled — the click pop-out ({@link #popOutMemories}) and the gesture
+     * tear-out share one pathway, so one handle map answers both. Owner-side pushes (snapshot
+     * writes, roster option refreshes, reconnect re-drives) must route through this accessor
+     * instead of stopping at `getReference()`: a vesseled pane lives outside this cockpit's
+     * projected tree.
+     * @returns {Neo.container.Base|null} The memories pane, or `null` before materialization.
+     */
+    getMemoriesPane() {
+        // returningTearOutPanes covers the vessel-death parking window: the rail's lazy reveal may
+        // not adopt the returning pane for a while, and an owner push landing in that window must
+        // still reach the LIVE instance — otherwise the eventual adoption renders a stale snapshot.
+        return this.tearOutPaneHandles?.memories || this.returningTearOutPanes?.memories || this.getReference('memories')
+    }
+
+    /**
      * The tear-out admission seam: opens the vessel window for a mid-gesture boundary exit,
      * reusing the SAME widget-childapp shell the click pop-out proves (an empty pane host — the
      * cockpit reparents on connect). Fail-closed per the admission contract: `Neo.Main.windowOpen`
@@ -1467,10 +1512,13 @@ class FleetCockpit extends Container {
      * @param {Object} request
      * @param {String} request.itemId
      * @param {Object} request.proxyRect
+     * @param {Boolean} [request.requireProjectedPane=true] The gesture needs a LIVE projected pane
+     *     (you tear what you can see); the click pop-out ({@link #popOutMemories}) materializes a
+     *     rail-lazy pane from owner-held state itself, so it opts out of this precondition only.
      * @returns {Promise<{popupHeight: Number, popupWidth: Number, windowName: String}|null>}
      * @protected
      */
-    async openTearOutVessel({itemId, proxyRect}) {
+    async openTearOutVessel({itemId, proxyRect, requireProjectedPane = true}) {
         let me         = this,
             windowName = `fm-tearout-${itemId}-${me.id}`;
 
@@ -1478,7 +1526,7 @@ class FleetCockpit extends Container {
         if (
             me.tearOutPanes?.[itemId] || me.tearOutPaneHandles?.[itemId] ||
             (itemId === 'detail' && me.detachedDetail) ||
-            !me.findProjectedDockPane(itemId)
+            (requireProjectedPane && !me.findProjectedDockPane(itemId))
         ) {
             return null
         }
@@ -1947,11 +1995,12 @@ class FleetCockpit extends Container {
      * App-Worker console bridges into the Neural Link console stream, so harnesses and agents can
      * distinguish an admission failure from a deliberate return without polling cockpit state.
      * @param {String} kind The failure edge: 'blocked' or 'timeout'.
-     * @param {Object} meta Window name + bound context, so the line stands alone in a log.
+     * @param {Object} meta Window name + bound context, so the line stands alone in a log;
+     *     `meta.itemId` names the vessel's item (absent → the click-detail pathway's 'detail').
      * @protected
      */
     warnVesselAdmissionFailure(kind, meta) {
-        console.warn(`[FleetCockpit] detail-vessel admission failed (${kind}):`, meta)
+        console.warn(`[FleetCockpit] ${meta?.itemId ?? 'detail'}-vessel admission failed (${kind}):`, meta)
     }
 
     /**
@@ -1970,6 +2019,117 @@ class FleetCockpit extends Container {
         }
 
         return me.detachedDetail ? me.reattachAgentDetail() : me.popOutAgentDetail()
+    }
+
+    /**
+     * @summary Detach the Memories pane into its own OS window on the shared heap — the click
+     * pop-out riding the GENERIC tear-out substrate, never a second vessel state machine.
+     *
+     * The vessel URL rides the established tear-out param shape —
+     * `?tearout=memories&cockpitId=<id>` — the same widget childapp the click pop-out's
+     * `?detail=agent-detail` shape loads; {@link #onWindowConnect}'s tear-out branch adopts it.
+     * The dock document stays the layout SSOT: {@link #applyTearOutOperation} captures the exact
+     * `{tabsNodeId, index}` placement before the `detachItem` commit, so the vessel-death return
+     * ({@link #reintegrateTearOutItem}) restores the item at its stored rail position.
+     *
+     * Selection travel is BY IDENTITY: the vessel hosts the LIVE pane instance (or one
+     * materialized from the owner-held `memoriesTarget`/`memoriesSnapshot` when the rail's lazy
+     * reveal never projected it), so the active agent and cards move with the window — stronger
+     * than a URL parameter, and exactly the rematerialization contract the memories source
+     * documents. A blocked popup (`windowOpen` resolves `false`, it never throws) refuses before
+     * any document mutation — commit-or-neither.
+     * @returns {Promise<{detached: Boolean, errors: String[]}>}
+     */
+    async popOutMemories() {
+        let me     = this,
+            itemId = 'memories';
+
+        if (me.tearOutPanes?.[itemId] || me.tearOutPaneHandles?.[itemId]) {
+            return {detached: false, errors: ['memories is already in a vessel']}
+        }
+
+        if (!DockZoneModel.findContainingTabsId(me.dockModel, itemId)) {
+            return {detached: false, errors: ['memories is not a docked item']}
+        }
+
+        let vessel = await me.openTearOutVessel({itemId, proxyRect: null, requireProjectedPane: false});
+
+        if (!vessel) {
+            // the silent-refusal witness (the detail pathway's observability contract): the click
+            // mutates nothing on this edge, so without this line a blocked popup is visually
+            // indistinguishable from a dead button
+            me.warnVesselAdmissionFailure('blocked', {itemId, windowName: `fm-tearout-${itemId}-${me.id}`});
+
+            return {detached: false, errors: ['popup blocked: the vessel window did not open']}
+        }
+
+        if (me.isDestroyed) {
+            return {detached: false, errors: ['cockpit destroyed during vessel open']}
+        }
+
+        // the item record is read BEFORE the commit prunes the tree entry (the catalog record
+        // survives a detach, so this is belt-and-braces ordering, not a correctness dependency)
+        let item   = me.dockModel.items[itemId],
+            result = me.applyTearOutOperation({operation: 'detachItem', itemId});
+
+        if (result.errors.length) {
+            await me.closeTearOutVessel({itemId, windowName: vessel.windowName});
+            return {detached: false, errors: result.errors}
+        }
+
+        // capture the live pane synchronously before the commit's re-projection can destroy it
+        // (the gesture order); a rail-lazy pane that was never projected materializes from
+        // owner-held state instead — same resolver, vessel-bound rather than projection-bound
+        me.captureTearOutPane(itemId);
+
+        if (!me.tearOutPaneHandles[itemId]) {
+            me.tearOutPaneHandles[itemId] = Neo.create(me.resolveDockComponentRef(item?.componentRef, item, itemId))
+        }
+
+        me.onDockZoneDocumentChange(result.document);
+        me.adoptTearOutPane(itemId);
+
+        return {detached: true, errors: []}
+    }
+
+    /**
+     * @summary Bring the vesseled Memories pane home by closing its OS window: vessel death IS
+     * the return path — {@link #onWindowDisconnect}'s tear-out branch correlates the close and
+     * {@link #reintegrateTearOutItem} restores the same live instance at its stored rail
+     * position. Closing by the immutable window NAME covers the not-yet-connected window too.
+     * @returns {Promise<{returned: Boolean, errors: String[]}>}
+     */
+    async returnMemories() {
+        let me    = this,
+            entry = me.tearOutPanes?.memories;
+
+        if (!entry) {
+            return {returned: false, errors: ['memories is not in a vessel']}
+        }
+
+        try {
+            await Neo.Main.windowClose({names: [entry.windowName], windowId: me.windowId})
+        } catch (error) {
+            // best-effort: a already-gone window still fires (or already fired) the disconnect
+        }
+
+        return {returned: true, errors: []}
+    }
+
+    /**
+     * @summary SHELL-owned toggle routing for the Memories pane vessel — the
+     * {@link #onDetailWindowToggle} grammar on the tear-out pathway. Mid-gesture ownership
+     * (captured handle without an adopted vessel) refuses instead of racing the gesture.
+     * @returns {Promise<Object>} The routed operation's result.
+     */
+    onMemoriesWindowToggle() {
+        let me = this;
+
+        if (!me.tearOutPanes?.memories && me.tearOutPaneHandles?.memories) {
+            return Promise.resolve({errors: ['a gesture tear-out owns the pane'], detached: false})
+        }
+
+        return me.tearOutPanes?.memories ? me.returnMemories() : me.popOutMemories()
     }
 
     /**
@@ -2385,7 +2545,7 @@ class FleetCockpit extends Container {
             // next poll. Absent/malformed envelopes plumb null — the chip claims nothing.
             grid.presenceCapability = capabilities?.presence ?? null;
             me.getReference('catch-up')?.set({partitionOptions: me.buildCatchUpPartitionOptions()});
-            me.getReference('memories')?.set({agentOptions: me.buildMemoriesAgentOptions()});
+            me.getMemoriesPane()?.set({agentOptions: me.buildMemoriesAgentOptions()});
             me.clearDegradedReason('grid')
         } catch (error) {
             // fenced: a slow failure must not overwrite a newer success (see the stream twin)
@@ -2583,7 +2743,7 @@ class FleetCockpit extends Container {
             // rematerialized while this read was in flight — a call-time reference would write
             // the accepted truth into the DESTROYED instance and leave the live pane pending
             // forever. The owner state above plus this live-resolve keep both variants coherent.
-            const livePane = me.getReference('memories');
+            const livePane = me.getMemoriesPane();
 
             livePane && (livePane.snapshot = snapshot)
         }
@@ -3039,7 +3199,7 @@ class FleetCockpit extends Container {
         // envelope until SOME re-request happens, and before this line the only such request was a
         // manual pane action — the dead-pane gap. Each pane's own refresh handler carries its
         // guards (active agent / partition), so re-driving through it is exactly the button's path.
-        me.getReference('memories')?.onRefreshClick();
+        me.getMemoriesPane()?.onRefreshClick();
         me.getReference('catch-up')?.onRefreshClick();
         me.getReference('wakeRoutes')?.onRefreshClick()
     }

--- a/resources/scss/src/apps/agentos/fleet/FleetCockpit.scss
+++ b/resources/scss/src/apps/agentos/fleet/FleetCockpit.scss
@@ -59,6 +59,7 @@
            as a second alarm beside the line that already carries the severity. */
         .neo-button.fm-preset-button,
         .neo-button.fm-detail-window-toggle,
+        .neo-button.fm-memories-window-toggle,
         .neo-button.fm-reconnect-button {
             border       : 1px solid var(--fm-line);
             border-radius: 6px;

--- a/test/playwright/unit/apps/agentos/view/fleet/fleetCockpit.spec.mjs
+++ b/test/playwright/unit/apps/agentos/view/fleet/fleetCockpit.spec.mjs
@@ -213,7 +213,10 @@ test.describe('Fleet cockpit — Store-backed roster (loadRoster)', () => {
     const makeCockpit = (grid, rosterWired = false, gridAdapterState = 'sample', rosterSourceMode = 'sample') => ({
         clearDegradedReason: FleetCockpit.prototype.clearDegradedReason,
         degradeWiredSurface: FleetCockpit.prototype.degradeWiredSurface,
-        getReference       : reference => reference === 'fleet-grid' ? grid : null,
+        // the memories owner push routes through the phase-blind accessor; an
+        // unmaterialized pane resolves null — the same silence contract as getReference
+        getMemoriesPane: () => null,
+        getReference   : reference => reference === 'fleet-grid' ? grid : null,
         // mirrors the class field default — the loss edge reads it to keep a never-wired surface
         // on its honest sample seed instead of claiming last-known data
         gridAdapterState,
@@ -597,8 +600,11 @@ test.describe('Fleet cockpit — Store-backed roster (loadRoster)', () => {
         const cockpit = {
             // the real accessor runs against this fake's getReference — the detail consumers
             // route through it (docked: projected pane; detached: the owner-held handle)
-            detachedDetailPane : null,
-            getAgentDetailPane : FleetCockpit.prototype.getAgentDetailPane,
+            detachedDetailPane: null,
+            getAgentDetailPane: FleetCockpit.prototype.getAgentDetailPane,
+            // the REAL phase-blind memories accessor over this fake's surface: no
+            // tear-out maps here → safe-nav falls through to getReference, same as the detail twin
+            getMemoriesPane    : FleetCockpit.prototype.getMemoriesPane,
             clearDegradedReason: FleetCockpit.prototype.clearDegradedReason,
             degradeWiredSurface: FleetCockpit.prototype.degradeWiredSurface,
             getReference       : reference => reference === 'fleet-grid' ? grid : reference === 'agent-detail' ? detail : null,
@@ -1270,14 +1276,17 @@ test.describe('Fleet cockpit — controller re-polls the roster on a settled lif
         const cockpit = {
             clearDegradedReason: FleetCockpit.prototype.clearDegradedReason,
             degradeWiredSurface: FleetCockpit.prototype.degradeWiredSurface,
-            getReference       : reference => reference === 'fleet-grid' ? {adapterState: 'sample', store} : null,
-            gridAdapterState   : 'sample',
-            gridReadGeneration : 0,
-            mapRosterRow       : FleetCockpit.prototype.mapRosterRow,
-            reconcileRoster    : FleetCockpit.prototype.reconcileRoster,
-            reconcileSelection : FleetCockpit.prototype.reconcileSelection,
-            loadRoster         : FleetCockpit.prototype.loadRoster,
-            rosterWired        : false,
+            // the memories owner push routes through the phase-blind accessor; an
+            // unmaterialized pane resolves null — the same silence contract as getReference
+            getMemoriesPane   : () => null,
+            getReference      : reference => reference === 'fleet-grid' ? {adapterState: 'sample', store} : null,
+            gridAdapterState  : 'sample',
+            gridReadGeneration: 0,
+            mapRosterRow      : FleetCockpit.prototype.mapRosterRow,
+            reconcileRoster   : FleetCockpit.prototype.reconcileRoster,
+            reconcileSelection: FleetCockpit.prototype.reconcileSelection,
+            loadRoster        : FleetCockpit.prototype.loadRoster,
+            rosterWired       : false,
             // the real banner sync: null getReference for the slot → guarded no-op, no stub drift
             syncSpineBanner    : FleetCockpit.prototype.syncSpineBanner
         };
@@ -1535,7 +1544,10 @@ test.describe('Fleet cockpit — the spine-banner slot sync (syncSpineBanner)', 
             loadBrainHealth       : () => driven.push('brainHealth'),
             loadRoster            : () => driven.push('roster'),
             ensureViewerWakeStream: () => driven.push('viewerWake'),
-            getReference          : reference => panes[reference] ?? null
+            // the memories re-drive routes through the phase-blind accessor: a vesseled
+            // pane must receive the reconnect re-drive too, so the seam is the accessor, not the raw reference
+            getMemoriesPane: () => panes.memories,
+            getReference   : reference => panes[reference] ?? null
         });
 
         expect(driven.sort()).toEqual([
@@ -1551,6 +1563,7 @@ test.describe('Fleet cockpit — the spine-banner slot sync (syncSpineBanner)', 
             loadBrainHealth       : () => driven.push('brainHealth'),
             loadRoster            : () => driven.push('roster'),
             ensureViewerWakeStream: () => driven.push('viewerWake'),
+            getMemoriesPane       : () => null,
             getReference          : () => null
         });
 

--- a/test/playwright/unit/apps/agentos/view/fleet/fleetCockpitPopOut.spec.mjs
+++ b/test/playwright/unit/apps/agentos/view/fleet/fleetCockpitPopOut.spec.mjs
@@ -490,3 +490,276 @@ test.describe.serial('AgentOS.view.fleet.FleetCockpit — detail pop-out state m
         cockpit = null
     })
 });
+
+/**
+ * Contract specs for the Memories click pop-out: the shell verb rides the GENERIC
+ * tear-out substrate — no second vessel state machine. The pins: document truth + the established
+ * `?tearout=` param shape, selection-carry BY IDENTITY (live and rail-lazy materialization paths),
+ * owner-push routing through {@link getMemoriesPane} in every phase (vesseled, returning-parked),
+ * intent routing from the vessel (the explicit listener scope — a vesseled pane has no controller
+ * chain), exact-position reintegration on vessel death, the blocked-popup refusal before any
+ * document mutation, and toggle routing incl. the mid-gesture guard.
+ */
+test.describe.serial('AgentOS.view.fleet.FleetCockpit — memories click pop-out (#17315)', () => {
+    let cockpit, vessel;
+
+    const RAIL_HOME = ['detail', 'perspectives', 'defineAgent', 'catchUp', 'memories', 'wakeRoutes', 'operator'];
+
+    /**
+     * A minimal wired memories envelope for owner-held state and push assertions.
+     * @param {String} target
+     * @param {String} title
+     * @returns {Object}
+     */
+    function wiredEnvelope(target, title) {
+        return {
+            capability: {state: 'wired', capturedAt: '2026-08-18T08:00:00.000Z'},
+            viewer    : '@operator',
+            target,
+            page      : {offset: 0, limit: 5},
+            sessions  : [{id: `${title}-1`, sessionId: 'abcdef12-0000-0000-0000-000000000000', timestamp: '2026-08-18T07:00:00.000Z', title, summary: 'summary', category: 'analysis', memoryCount: 3, quality: 4}],
+            count     : 1,
+            total     : 1
+        }
+    }
+
+    /**
+     * Reveals the auto-hidden memories pane through the standard commit loop — the materialized
+     * pre-state of the "live pane" pop-out path.
+     * @returns {Promise<Neo.container.Base>} the projected MemoriesPane instance
+     */
+    async function revealMemories() {
+        const result = cockpit.applyDockZoneOperation({operation: 'setItemAutoHidden', itemId: 'memories', autoHidden: false});
+
+        expect(result.errors).toEqual([]);
+        cockpit.onDockZoneDocumentChange(result.document);
+        await cockpit.refreshPromise;
+
+        const pane = cockpit.getReference('memories');
+
+        expect(pane).toBeTruthy();
+        return pane
+    }
+
+    /**
+     * The canonical tear-out vessel URL the connect handler's tear-out branch matches on.
+     * @returns {String}
+     */
+    function memoriesVesselUrl() {
+        return `https://unit.test/apps/agentos/childapps/widget/index.html?tearout=memories&cockpitId=${cockpit.id}`
+    }
+
+    /**
+     * Simulates the vessel window joining the shared heap (tear-out branch).
+     * @param {String} windowId
+     * @returns {Promise<Neo.container.Base>} the vessel's mainView
+     */
+    async function simulateConnect(windowId) {
+        const mainView = Neo.create(Container, {});
+
+        Neo.apps ??= {};
+        Neo.apps[windowId] = {mainView};
+
+        await cockpit.onWindowConnect({windowId});
+
+        return mainView
+    }
+
+    test.beforeEach(() => {
+        cockpit = Neo.create(FleetCockpit, {
+            stateProvider: {
+                module: StateProvider,
+                stores: {fleetRoster: {module: FleetRoster, autoLoad: false}}
+            }
+        })
+    });
+
+    test.afterEach(() => {
+        cockpit?.destroy();
+        cockpit = null;
+        vessel?.restore();
+        vessel = null;
+        Neo.apps = {}
+    });
+
+    test('pop-out of the REVEALED pane: same instance, document truth, the established param shape', async () => {
+        vessel = installWindowVessel({popupUrl: null});
+
+        const pane   = await revealMemories(),
+              result = await cockpit.popOutMemories();
+
+        expect(result).toEqual({detached: true, errors: []});
+
+        // document truth: the item left the rail but keeps its catalog record
+        const doc = cockpit.getDockZoneDocument();
+
+        expect(doc.items.memories).toBeTruthy();
+        expect(doc.nodes['secondary-rail'].items).not.toContain('memories');
+
+        // the LIVE pane is vessel-owned — same instance, never a recreation
+        expect(cockpit.tearOutPaneHandles.memories).toBe(pane);
+        expect(pane.isDestroyed).toBeFalsy();
+        expect(cockpit.getMemoriesPane()).toBe(pane);
+
+        // one vessel open on the established tear-out param shape
+        expect(vessel.openCalls).toHaveLength(1);
+        expect(vessel.openCalls[0].url).toContain('tearout=memories');
+        expect(vessel.openCalls[0].url).toContain(`cockpitId=${cockpit.id}`);
+
+        // the shell affordance now names the reverse action
+        expect(cockpit.getReference('memories-window-toggle').text).toBe('Return memories')
+    });
+
+    test('pop-out of the RAIL-LAZY pane materializes from owner-held state — selection carries', async () => {
+        vessel = installWindowVessel({popupUrl: memoriesVesselUrl()});
+
+        // never revealed: the rail's lazy projection holds no live pane
+        expect(cockpit.getReference('memories')).toBeFalsy();
+
+        cockpit.memoriesTarget   = '@neo-fable-clio';
+        cockpit.memoriesSnapshot = wiredEnvelope('@neo-fable-clio', 'owner-held');
+
+        const result = await cockpit.popOutMemories();
+
+        expect(result).toEqual({detached: true, errors: []});
+
+        const pane = cockpit.tearOutPaneHandles.memories;
+
+        expect(pane).toBeTruthy();
+        expect(pane.activeAgent).toBe('@neo-fable-clio');
+        expect(pane.snapshot?.sessions?.[0]?.title).toBe('owner-held');
+
+        // the vessel adopts the materialized pane on connect
+        const mainView = await simulateConnect('mem-vessel-lazy');
+
+        expect(mainView.items).toContain(pane)
+    });
+
+    test('owner pushes reach the vesseled pane; vessel-fired intents reach the controller', async () => {
+        vessel = installWindowVessel({popupUrl: memoriesVesselUrl()});
+
+        const pane = await revealMemories();
+
+        await cockpit.popOutMemories();
+        await simulateConnect('mem-vessel-push');
+
+        // vessel-fired intent → controller → bridge: the explicit listener scope is what makes
+        // this resolve OUTSIDE the controller chain (a vesseled pane has none above it).
+        // `globalThis.AgentOS` is the app CLASS NAMESPACE root, not a test-owned object — stub
+        // only the `fleet` key and restore it, never delete the namespace (that unregisters
+        // every AgentOS.* class for the rest of the worker).
+        const bridgeCalls = [],
+              prevFleet   = globalThis.AgentOS?.fleet;
+
+        globalThis.AgentOS.fleet = {registryBridge: {
+            fleetMemories: async params => {
+                bridgeCalls.push(params);
+                return wiredEnvelope(params.agentIdentity, 'pushed')
+            }
+        }};
+
+        try {
+            // the REAL user path: the agent-chip click sets the pane's own selection AND fires
+            // the intent — exactly what a click in the vessel window does
+            pane.onAgentClick('@neo-opus-grace');
+
+            await expect.poll(() => bridgeCalls.length, {timeout: 2000}).toBe(1);
+            expect(bridgeCalls[0].agentIdentity).toBe('@neo-opus-grace');
+
+            // the accepted snapshot lands on the VESSELED pane through the accessor route
+            await expect.poll(() => pane.snapshot?.sessions?.[0]?.title, {timeout: 2000}).toBe('pushed');
+            expect(pane.activeAgent).toBe('@neo-opus-grace')
+        } finally {
+            prevFleet === undefined ? delete globalThis.AgentOS.fleet : globalThis.AgentOS.fleet = prevFleet
+        }
+    });
+
+    test('vessel death brings the pane home at its exact rail position — state intact', async () => {
+        vessel = installWindowVessel({popupUrl: memoriesVesselUrl()});
+
+        const pane = await revealMemories();
+
+        pane.activeAgent = '@neo-fable-clio';
+
+        await cockpit.popOutMemories();
+        await simulateConnect('mem-vessel-home');
+
+        cockpit.onWindowDisconnect({windowId: 'mem-vessel-home'});
+        await cockpit.refreshPromise;
+
+        // exact-position restore: memories back at its stored rail index, full order preserved
+        await expect.poll(() => cockpit.getDockZoneDocument().nodes['secondary-rail'].items, {timeout: 2000}).toEqual(RAIL_HOME);
+
+        // the same live instance survived the return; owner pushes still reach it while parked
+        expect(pane.isDestroyed).toBeFalsy();
+        expect(cockpit.getMemoriesPane()).toBe(pane);
+        expect(pane.activeAgent).toBe('@neo-fable-clio');
+
+        // the shell affordance names the forward action again
+        expect(cockpit.getReference('memories-window-toggle').text).toBe('Pop out memories')
+    });
+
+    test('blocked popup refuses BEFORE any document mutation — commit-or-neither', async () => {
+        vessel = installWindowVessel({openResult: false, popupUrl: null});
+
+        await revealMemories();
+
+        // the silent edge carries a log witness — captured with a PAIRED restore
+        const warns    = [],
+              origWarn = console.warn;
+
+        console.warn = (...args) => warns.push(args);
+
+        try {
+            const result = await cockpit.popOutMemories();
+
+            expect(result.detached).toBe(false);
+            expect(result.errors[0]).toContain('popup blocked');
+
+            // zero mutation: the rail still holds the item, nothing is vessel-owned, nothing closed
+            expect(cockpit.getDockZoneDocument().nodes['secondary-rail'].items).toEqual(RAIL_HOME);
+            expect(cockpit.tearOutPanes.memories).toBeFalsy();
+            expect(cockpit.tearOutPaneHandles.memories).toBeFalsy();
+            expect(vessel.closeCalls).toHaveLength(0);
+
+            // the flap witness names ITS vessel — a blocked memories click is distinguishable
+            // from a dead button AND from a detail-vessel flap in the same log
+            expect(warns.some(args => String(args[0]).includes('memories-vessel admission failed (blocked)'))).toBe(true)
+        } finally {
+            console.warn = origWarn
+        }
+    });
+
+    test('toggle routes by vessel state; a mid-gesture capture refuses instead of racing', async () => {
+        vessel = installWindowVessel({popupUrl: memoriesVesselUrl()});
+
+        await revealMemories();
+
+        // docked → toggle detaches
+        const out = await cockpit.onMemoriesWindowToggle();
+
+        expect(out.detached).toBe(true);
+
+        await simulateConnect('mem-vessel-toggle');
+
+        // vesseled → toggle returns (window close by the immutable vessel name)
+        const back = await cockpit.onMemoriesWindowToggle();
+
+        expect(back.returned).toBe(true);
+        expect(vessel.closeCalls).toHaveLength(1);
+        expect(vessel.closeCalls[0].names).toEqual([`fm-tearout-memories-${cockpit.id}`]);
+
+        // mid-gesture ownership (captured handle, no adopted vessel) → guarded refusal
+        cockpit.onWindowDisconnect({windowId: 'mem-vessel-toggle'});
+        await cockpit.refreshPromise;
+
+        cockpit.tearOutPaneHandles.memories = {isDestroyed: false};
+
+        const guarded = await cockpit.onMemoriesWindowToggle();
+
+        expect(guarded.detached).toBe(false);
+        expect(guarded.errors[0]).toContain('gesture');
+
+        delete cockpit.tearOutPaneHandles.memories
+    })
+});

--- a/test/playwright/unit/apps/agentos/view/fleet/memoriesOwnerSeam.spec.mjs
+++ b/test/playwright/unit/apps/agentos/view/fleet/memoriesOwnerSeam.spec.mjs
@@ -25,7 +25,12 @@ function ownerStub({memoriesTarget = null, memoriesSnapshot = null, pane = null}
         memoriesSnapshot,
         memoriesReadGeneration   : 0,
         buildMemoriesAgentOptions: () => [],
-        getReference             : () => pane
+        // the cockpit surface the seam methods consume: the explicit listener scope
+        // resolves through getController, and owner pushes route through the phase-blind
+        // accessor instead of a raw reference read
+        getController  : () => null,
+        getMemoriesPane: () => pane,
+        getReference   : () => pane
     }
 }
 
@@ -72,7 +77,9 @@ test.describe('FleetCockpit — memories owner seam (pending selection + write-t
                 memoriesTarget        : null,
                 memoriesSnapshot      : null,
                 memoriesReadGeneration: 0,
-                getReference          : () => currentPane
+                // the WRITE-time resolve rides the phase-blind accessor
+                getMemoriesPane: () => currentPane,
+                getReference   : () => currentPane
             };
 
             const read = proto.loadMemories.call(me, {agentIdentity: '@neo-gpt-bob'});


### PR DESCRIPTION
Resolves neomjs/neo#17315

The Memories pane now pops out to its own OS window through a SHELL-owned click toggle — implemented as a thin verb over the EXISTING generic tear-out substrate (capture → detach-commit → vessel-adopt → disconnect-reintegrate), never a second vessel state machine. Selection travels BY IDENTITY: the vessel hosts the live pane instance (or one materialized from owner-held `memoriesTarget`/`memoriesSnapshot` when the rail's lazy reveal never projected it), so the active agent and cards move with the window and return intact to the exact rail position on vessel death.

Evidence: L2 achieved (unit-pinned machinery + live browser drive: the toggle renders styled, and a blocked-popup click held commit-or-neither with the rail intact) → L3 required (the real two-OS-window journey; the embedded preview pane blocks popups by policy). Residual: AC-1's OS-window witness, Residual-Owner: neomjs/neo#17316.

## Deltas from ticket

- **Route shape:** the ticket allowed "`?detail=memories&agent=…` or the established param shape" — shipped on the established `?tearout=memories&cockpitId=<id>` shape (one widget childapp serves both pathways; an `agent` param is unnecessary because selection travels with the instance, stronger than a URL parameter). Documented in the `popOutMemories` JSDoc beside the `?detail=` shape.
- **Two latent defects fixed in scope** (both would have failed AC-2, "the popped pane loads/refreshes independently"): (1) the pane's string listeners resolved through the fire-time controller chain, which a vessel window does not have — now bound with an explicit controller scope at materialization; (2) owner pushes resolved the pane via `getReference` only — now routed through the phase-blind `getMemoriesPane()` accessor (vessel handle → returning-parked → projected reference), covering the parking window after vessel death too.
- **Same-class defect on the sibling panes filed, not absorbed:** neomjs/neo#17333 (mailbox, catch-up and wakeRoutes carry the identical listener/push classes; the engine-side `closestController` null-cache is surfaced there for the engine owners).
- **Blocked-edge witness parity:** the click-detail pathway's admission-failure console witness now also fires for a blocked memories pop-out and names its vessel, so a blocked popup is distinguishable from a dead button — found by driving the live app, where the embedded pane's popup policy exercised exactly this edge.
- **Provisional affordance placement:** the toggle joins the cockpit bar in the detail toggle's exact grammar; per-pane chrome placement belongs to the navigation-model pass (#17269, its cut 2) and is noted as provisional in the code.

## Test Evidence

- `npx playwright test -c test/playwright/playwright.config.unit.mjs test/playwright/unit/apps/agentos` → **704 passed** (the full owning tree; scoped-spec-only green explicitly avoided).
- Six new contract specs in `fleetCockpitPopOut.spec.mjs`: revealed-pane pop-out (document truth + same-instance identity + the param shape) · rail-lazy materialization with selection carry · vessel-fired intent reaches the controller + owner push reaches the vesseled pane · vessel-death exact-position reintegration with state intact · blocked popup commit-or-neither + the named witness · toggle routing incl. the mid-gesture guard.
- Sibling suites grew the cockpit stub surface (`getMemoriesPane`, `getController`) in `fleetCockpit.spec.mjs` + `memoriesOwnerSeam.spec.mjs`; where the builder idiom runs real accessors over fakes (the detail twin's pattern), the memories accessor now does the same.
- Live drive (dev server + embedded browser, themes rebuilt for the added SCSS selector): the toggle renders on the bar in the quiet-base family; the click exercised the blocked-popup edge — rail intact, zero document mutation (commit-or-neither held in production code, not only in the spec).
- apps/agentos surface: the three suites above (this PR); the real two-window journey class lives with the NL e2e witness pattern (`FleetCockpitPopOutNL.spec.mjs`), outside CI by design.

## Post-Merge Validation

- [ ] Live operator session (real Chrome, popups permitted): Pop out memories → the OS window carries the selection; closing it returns the pane to its rail slot with cards intact.
- [ ] The popped-projection AC of the drill-in sibling exercises the route end-to-end.

Residual-Owner: neomjs/neo#17316

Authored by Clio (Claude Fable 5, Claude Code). Session ca3c67ac-a3d6-4e93-98e0-c5f7f65011ee.
