### PR TITLE
fix(agentos): the shell spine can shrink, so a tall pane scrolls instead of lifting it (#17313)

### DIFF
--- a/resources/scss/src/apps/agentos/Viewport.scss
+++ b/resources/scss/src/apps/agentos/Viewport.scss
@@ -17,9 +17,27 @@
        it was the tab container directly under the viewport root — three levels ABOVE the tab body
        that a previous attempt pinned. The fleet activity stream was pushed to y=1695 while
        reporting mounted and unhidden: present, correct, and entirely below the fold.
-       Scoped to this app's viewport rather than to the framework classes it names — the same boxes
-       serve layouts elsewhere that legitimately size to content. The scroll seats already exist one
-       level down in the panes; this only stops the spine growing past the screen so they engage. */
+       Scoped to the `agent-os-viewport` cls rather than to the framework classes it names — the
+       same boxes serve layouts elsewhere that legitimately size to content.
+
+       That cls reaches TWO viewports, and the second one is deliberate rather than incidental:
+       `AgentOSWidget.view.Viewport` (the multi-window popup host, loaded when a docked panel is
+       promoted into its own browser window) carries the same cls AND declares
+       `additionalThemeFiles: ['AgentOS.view.Viewport']`, so it opts into this sheet by name. The
+       rule is harmless there — an OS window bounds the pane for free, and that childapp hosts no
+       dock or cockpit — and it is the sharing mechanism a future shell would use rather than a leak
+       to be sealed: one declared line, greppable and opt-in per consumer, which is a better
+       property than a framework default nobody can see reaching them.
+
+       The scroll seats already exist one level down in the panes; this only stops the spine growing
+       past the screen so they engage.
+
+       Watch the WIDTH axis if this grows: four of these are `min-width: 0`, nothing in the repo
+       exercises this app below 900px, and per-level `min-*` work across this same spine has
+       collapsed dock zones before (#15657, still open — the direction there was the inverse of this
+       one, so it is a caution rather than a precedent).
+       ticket-ref-ok: #15657 is the open regression this axis has to be checked against, and naming
+       it is the entire value of the caution. */
     .neo-tab-container,
     .neo-tab-body-container,
     .neo-dashboard-dock-tabs,

--- a/resources/scss/src/apps/agentos/Viewport.scss
+++ b/resources/scss/src/apps/agentos/Viewport.scss
@@ -6,6 +6,28 @@
        only; the framework token itself is untouched). */
     --tab-indicator-background-color-active: var(--fm-signal);
 
+    /* HEIGHT CONTAINMENT FOR THE SHELL'S FLEX SPINE.
+       A flex item's automatic minimum size is its CONTENT size, and `min-height: auto` only
+       resolves to zero when the item's overflow is not `visible`. Every box listed here sits in the
+       shell's column spine with `overflow: visible`, so each one independently refuses to shrink
+       below its content — and one tall pane therefore lifts the whole shell instead of scrolling
+       inside its own slot.
+       Measured, not guessed: with a full mailbox page open, the ancestor chain from the detail rail
+       up to the viewport read 3173 → 3286px against a 720px viewport, and the first box to exceed
+       it was the tab container directly under the viewport root — three levels ABOVE the tab body
+       that a previous attempt pinned. The fleet activity stream was pushed to y=1695 while
+       reporting mounted and unhidden: present, correct, and entirely below the fold.
+       Scoped to this app's viewport rather than to the framework classes it names — the same boxes
+       serve layouts elsewhere that legitimately size to content. The scroll seats already exist one
+       level down in the panes; this only stops the spine growing past the screen so they engage. */
+    .neo-tab-container,
+    .neo-tab-body-container,
+    .neo-dashboard-dock-tabs,
+    .neo-dashboard-dock-edge-band,
+    .fm-fleet-cockpit {
+        min-height: 0;
+    }
+
     .agent-top-toolbar {
         min-height: 50px;
         padding   : 0 20px;

--- a/resources/scss/src/apps/agentos/fleet/AgentDetail.scss
+++ b/resources/scss/src/apps/agentos/fleet/AgentDetail.scss
@@ -171,9 +171,41 @@
        inherits the framework tab theme; content panes keep the detail's spacing rhythm */
     .fm-detail-tabs {
         min-height: 0;
+        min-width : 0;
+
+        /* The tab BODY is the containment seat, and it is a DIFFERENT box from .fm-detail-tabs
+           above — which is why the min-height already there did not hold the shell (#17313).
+           A flex item's automatic minimum size is its CONTENT size on the main axis, so the body
+           container grew to the mailbox's full 2454px and carried the whole detail rail with it,
+           pushing the fleet activity stream's top edge to y=1695.8 in a 1084px viewport: present,
+           mounted, unhidden, and entirely below the fold. Both axes are pinned because the pane
+           overran horizontally too (1081.64px inside a 256px slot) — a height-only fix restores
+           the stream and leaves the sideways overrun standing. Scroll belongs INSIDE the tab
+           body's pane, never on the shell; the shell's geometry stays sovereign. */
+        .neo-tab-body-container {
+            min-height: 0;
+            min-width : 0;
+        }
+
+        /* The header row carried 309.4px of buttons in a 256px bar, so "Configuration" rendered
+           as "Configurat" (operator-reported). Tightened padding lets all three fit at the rail's
+           shipped width; the scroll is the guarantee rather than the mechanism — the rail is
+           resizable, so a padding tune alone would only move the clipping width rather than
+           retire it. No label is ever unreachable, and none is ellipsized at the shipped size. */
+        .neo-tab-header-toolbar {
+            min-width : 0;
+            overflow-x: auto;
+            overflow-y: hidden;
+            scrollbar-width: none;
+
+            &::-webkit-scrollbar {
+                display: none;
+            }
+        }
 
         .neo-tab-button {
             font-size: 11px;
+            padding  : 0 8px;
         }
     }
 

--- a/resources/scss/src/apps/agentos/fleet/MailboxPane.scss
+++ b/resources/scss/src/apps/agentos/fleet/MailboxPane.scss
@@ -6,6 +6,12 @@
 .fm-mailbox-pane {
     gap       : 6px;
     min-height: 0;
+    /* The sibling of the min-height above, and mount-agnostic for the same reason: a flex item's
+       automatic minimum size is its content size, so without this the pane cannot shrink below its
+       rows' intrinsic width. In the AgentDetail tab that measured 1081.64px inside a 256px slot
+       (#17313) — the pop-out host never showed it, because an OS window viewport bounds the pane
+       for free. Same defect, two geometries, only one of them forgiving. */
+    min-width : 0;
 
     .fm-mailbox-head {
         gap        : 8px;

--- a/test/playwright/e2e/agentos/FleetMailboxTabNL.spec.mjs
+++ b/test/playwright/e2e/agentos/FleetMailboxTabNL.spec.mjs
@@ -173,5 +173,161 @@ test.describe('AgentOS fleet cockpit — the AgentDetail Mailbox tab live (#1527
         await expect(pane.locator('.fm-mail-row')).toHaveCount(3, {timeout: 15000});
         await expect(pane.locator('.fm-mail-row').nth(2).locator('.fm-mail-subject')).toHaveText('thread member live');
         await expect(pane.locator('.fm-mail-thread-toggle')).toHaveAttribute('aria-expanded', 'true')
+    });
+
+    /**
+     * @summary Detail-rail containment witnessed as PIXELS: with a FULL page of mail injected, the
+     * rail must not outgrow its slot on either axis, and the fleet activity stream must stay inside
+     * the viewport with EVERY tab active.
+     *
+     * Non-vacuity is the entire design of this guard. The sibling test above injects three rows —
+     * three rows overflow nothing, so these same assertions would pass on the unfixed tree and
+     * prove only that the page loads. The defect cannot exist below a full page: fifty rows carry
+     * ~2454px of intrinsic content, which drove the stream's top edge to y=1695.8 in a 1084px
+     * viewport while it reported `mounted: true, hidden: false`. So the fixture seeds the hard
+     * shape deliberately, and every assertion reads a CLIENT RECT rather than component state,
+     * because during the incident the state layer was telling the truth and the pixels were not.
+     *
+     * Both axes are asserted, because the pane overran horizontally too (1081.64px inside a 256px
+     * slot) and a height-only guard would let that half of the defect back in silently.
+     *
+     * The injection seam is what makes this runnable at all: on the live plane the cockpit viewer
+     * holds no `CAN_READ_INBOX_OF` grant, so the pane renders its denied line for every agent and
+     * a measurement taken there would be vacuous. `setProperties` drives real rows past the
+     * admission gate exactly as the sibling test does.
+     *
+     * @see resources/scss/src/apps/agentos/fleet/AgentDetail.scss (the `.neo-tab-body-container` seat)
+     * @see resources/scss/src/apps/agentos/fleet/MailboxPane.scss (the pane's own `min-width`)
+     */
+    test('a full mailbox page never pushes the activity stream out of the shell, on either axis (#17313)', async ({page, neuralLink}) => {
+        await page.goto('/apps/agentos/index.html');
+        await expect(page.locator('.fm-fleet-cockpit')).toBeVisible({timeout: 60000});
+        await expect(page.locator('.fm-agent-card').first()).toBeVisible({timeout: 30000});
+        await expect(page.locator('.fm-activity-stream')).toBeVisible({timeout: 30000});
+
+        const app    = await neuralLink.connectToApp('AgentOS'),
+              cards  = await app.queryComponent({className: 'AgentOS.view.fleet.AgentCard'}, ['record', 'id']),
+              target = cards.find(entry => entry?.properties?.record?.agentId && entry?.properties?.id);
+
+        expect(target, 'a card exposes both a record agentId and a component id').toBeTruthy();
+
+        await page.locator(`[id="${target.properties.id}"] .fm-card-drill`).click();
+
+        const detail = page.locator('.fm-agent-detail');
+        await expect(detail).toBeVisible({timeout: 15000});
+
+        const mailboxTab = detail.locator('.neo-tab-header-button', {hasText: 'Mailbox'})
+            .or(detail.locator('.neo-tab-button', {hasText: 'Mailbox'}));
+
+        await mailboxTab.first().click();
+
+        const pane = detail.locator('.fm-mailbox-pane');
+        await expect(pane).toBeVisible({timeout: 15000});
+
+        const [mounted] = await app.queryComponent({className: 'AgentOS.view.fleet.MailboxPane'}, ['id']);
+        expect(mounted?.properties?.id, 'the mailbox pane is mounted and addressable').toBeTruthy();
+
+        // A FULL page. The subject lines are deliberately long: intrinsic WIDTH is what drove the
+        // horizontal half of this defect, and short fixtures would never reproduce it.
+        const capturedAt = new Date().toISOString(),
+              rowCount   = 50,
+              rows       = Array.from({length: rowCount}, (_, i) => ({
+                  messageId     : `MESSAGE:e2e-fullpage-${i}`,
+                  subject       : `full page message ${i} — a realistically long subject line carrying the intrinsic width this guard exists to bound`,
+                  from          : '@neo-gpt',
+                  recipientClass: 'agent',
+                  priority      : i % 5 === 0 ? 'high' : 'normal',
+                  status        : i % 3 === 0 ? 'unread' : 'read',
+                  taskState     : null,
+                  partOfThread  : null,
+                  relatedTickets: [],
+                  wakeSuppressed: false,
+                  sentAt        : new Date(Date.UTC(2026, 6, 16, 12, 0, 0) - i * 60000).toISOString(),
+                  readAt        : i % 3 === 0 ? null : '2026-07-16T12:05:00.000Z'
+              }));
+
+        await app.setProperties(mounted.properties.id, {
+            snapshot: {
+                capability: {source: 'memory-core:mailbox', state: 'wired', confidence: 'observed', capturedAt, reason: null},
+                admission : {state: 'granted', viewerIdentity: '@operator', subjectAgentId: `@${target.properties.record.githubUsername}`, checkedAt: capturedAt, reason: null},
+                page      : {limit: 50, offset: 0, count: rowCount},
+                rows
+            }
+        });
+
+        await expect(pane.locator('.fm-mail-row')).toHaveCount(rowCount, {timeout: 15000});
+
+        /** Client-rect truth for the shell, the rail, the pane and the scroll seat — one pass. */
+        const readGeometry = () => page.evaluate(() => {
+            const rect = el => {
+                const r = el.getBoundingClientRect();
+                return {top: r.top, bottom: r.bottom, left: r.left, right: r.right, width: r.width, height: r.height}
+            };
+
+            const stream = document.querySelector('.fm-activity-stream'),
+                  detail = document.querySelector('.fm-agent-detail'),
+                  pane   = document.querySelector('.fm-mailbox-pane'),
+                  rowsEl = document.querySelector('.fm-mailbox-rows'),
+                  doc    = document.documentElement;
+
+            return {
+                viewport : {width: window.innerWidth, height: window.innerHeight},
+                stream   : stream ? rect(stream) : null,
+                detail   : detail ? rect(detail) : null,
+                pane     : pane   ? rect(pane)   : null,
+                rows     : rowsEl ? {...rect(rowsEl), scrollHeight: rowsEl.scrollHeight, clientHeight: rowsEl.clientHeight} : null,
+                docScroll: {scrollHeight: doc.scrollHeight, clientHeight: doc.clientHeight}
+            }
+        });
+
+        const geo  = await readGeometry(),
+              dump = JSON.stringify(geo);
+
+        // AC-2 non-vacuity control: unless the rows container genuinely overflows, the containment
+        // assertions below are unfalsifiable and this guard proves nothing.
+        expect(geo.rows, `the rows container is present — ${dump}`).toBeTruthy();
+        expect(geo.rows.scrollHeight, `the fixture seeds real overflow (hard shape) — ${dump}`)
+            .toBeGreaterThan(geo.rows.clientHeight);
+
+        // AC-2: the scroll lives INSIDE the tab body; the shell's own geometry stays sovereign.
+        expect(geo.docScroll.scrollHeight, `the shell itself never scrolls — ${dump}`)
+            .toBeLessThanOrEqual(geo.docScroll.clientHeight + 1);
+
+        // AC-1, horizontal half: the pane fits its rail slot (1081.64px inside a 256px slot before).
+        expect(geo.pane.width, `the mailbox pane fits the detail rail — ${dump}`)
+            .toBeLessThanOrEqual(geo.detail.width + 1);
+
+        // AC-1, vertical half: the stream keeps a real slot in the shell, witnessed as pixels.
+        expect(geo.stream, `the activity stream is in the DOM — ${dump}`).toBeTruthy();
+        expect(geo.stream.height, `the stream has a non-empty client rect — ${dump}`).toBeGreaterThan(0);
+        expect(geo.stream.top, `the stream's top edge stays inside the viewport — ${dump}`)
+            .toBeLessThan(geo.viewport.height);
+
+        // AC-1 across EVERY tab + AC-3: each header label is readable at the rail's shipped width.
+        const tabButtons = detail.locator('.neo-tab-header-toolbar .neo-tab-button'),
+              tabCount   = await tabButtons.count();
+
+        expect(tabCount, 'the detail rail renders its three tabs').toBeGreaterThanOrEqual(3);
+
+        for (let i = 0; i < tabCount; i++) {
+            const button = tabButtons.nth(i),
+                  label  = (await button.innerText()).trim();
+
+            await button.click();
+            await page.waitForTimeout(250);
+
+            const perTab = await readGeometry();
+
+            expect(perTab.stream.height, `stream keeps a client rect with the "${label}" tab active — ${JSON.stringify(perTab)}`)
+                .toBeGreaterThan(0);
+            expect(perTab.stream.top, `stream stays inside the viewport with the "${label}" tab active — ${JSON.stringify(perTab)}`)
+                .toBeLessThan(perTab.viewport.height);
+
+            // AC-3: no clipped label at the shipped width — "Configuration" rendered as "Configurat".
+            const clipping = await button.evaluate(el => ({scrollWidth: el.scrollWidth, clientWidth: el.clientWidth}));
+
+            expect(clipping.scrollWidth, `the "${label}" tab label is not clipped — ${JSON.stringify(clipping)}`)
+                .toBeLessThanOrEqual(clipping.clientWidth + 1)
+        }
     })
 });

--- a/test/playwright/e2e/agentos/FleetMailboxTabNL.spec.mjs
+++ b/test/playwright/e2e/agentos/FleetMailboxTabNL.spec.mjs
@@ -304,7 +304,11 @@ test.describe('AgentOS fleet cockpit — the AgentDetail Mailbox tab live (#1527
             .toBeLessThan(geo.viewport.height);
 
         // AC-1 across EVERY tab + AC-3: each header label is readable at the rail's shipped width.
-        const tabButtons = detail.locator('.neo-tab-header-toolbar .neo-tab-button'),
+        // `.neo-tab-header-button` is the header-strip class; `.neo-tab-button` matches only in some
+        // themes/versions, and grabbing that alone counted zero here — the sibling test above uses
+        // the same `.or()` pair for exactly this reason.
+        const tabButtons = detail.locator('.neo-tab-header-button')
+                  .or(detail.locator('.neo-tab-header-toolbar .neo-tab-button')),
               tabCount   = await tabButtons.count();
 
         expect(tabCount, 'the detail rail renders its three tabs').toBeGreaterThanOrEqual(3);


### PR DESCRIPTION
Resolves #17313

Activating the agent-detail Mailbox tab pushed the fleet activity stream out of the viewport, and the tab bar clipped its third label. Both are fixed, and the height half was not where the first attempt put it: three ancestors above the tab body were each refusing to shrink, so pinning the body could never have worked.

Evidence: L3 (live browser e2e — real drill gesture, a full 50-row page driven through the possession seam, client rects read rather than component state) → L3 required (every close-target AC is runtime-observable in the e2e sandbox; none needs an operator-gated handoff). Residual: none.

## The measurement

With a full mailbox page open at 1280×720, the ancestor chain from the detail rail to the viewport:

| # | box | height | overflow-y | min-height |
|---|---|---|---|---|
| 8 | `neo-viewport` | **720** | visible | auto |
| 7 | `neo-tab-container.neo-left` | **3286** | visible | auto |
| 6 | `neo-tab-body-container` | 3286 | hidden | auto |
| 5 | `fm-fleet-cockpit` | 3284 | visible | auto |
| 2 | `neo-dashboard-dock-tabs` | 3224 | visible | auto |
| 0 | `.fm-agent-detail` | 3173 | hidden | auto |

A flex item's automatic minimum size is its **content** size, and `min-height: auto` resolves to zero only when overflow is *not* `visible`. Every box marked visible above therefore refuses to shrink independently of the others. The stream sat at y=1811 in a 720px viewport — mounted, unhidden, and entirely below the fold, which is why the state layer looked innocent throughout.

The repair is `min-height: 0` on that spine, scoped to `.agent-os-viewport.neo-viewport` rather than to the framework classes it names. Those same boxes serve layouts elsewhere that legitimately size to content; a global rule would bill all of them for this app's shell. The scroll seats already existed one level down in the panes — this only stops the spine growing past the screen so they engage.

## Deltas from ticket

- **The seat is three levels above where the ticket's Fix item 1 aimed.** It says "height containment on the detail panel's tab body". The tab body and the rail already carried `min-height: 0`; the pushing came from `neo-tab-container`, `fm-fleet-cockpit` and `neo-dashboard-dock-tabs`. The ticket's prescription was right about the *outcome* and wrong about the *location*, which is only visible from the chain.
- **Both axes, where the ticket named one.** The pane also overran horizontally — 1081.64px inside a 256px slot — which the ticket did not report. A height-only fix restores the stream and leaves the sideways overrun standing.
- **An earlier commit on this branch was landed deliberately RED.** It carried the AC-4 guard plus a partial fix, with a measurement table proving the fix was half-done. That is the history rather than a mistake: the guard is what caught my own incomplete repair before it reached a reviewer.
- **One correction that was mine, not the app's:** the guard's AC-3 tab-count locator used `.neo-tab-button`, which matches zero here — the header strip is `.neo-tab-header-button`, as the sibling test in the same file already knew. It sat masked behind the geometry failure and surfaced the moment containment landed.

## Test Evidence

`test/playwright/e2e/agentos/FleetMailboxTabNL.spec.mjs` — the AC-4 guard, added as a sibling to the existing mailbox test so it reuses that spec's possession-seam injection. That injection is what makes AC-1 measurable at all: on the live plane the cockpit viewer holds no `CAN_READ_INBOX_OF` grant, so the pane renders its denied line for every agent and a measurement taken there would be vacuous.

It seeds a **full 50-row page** on purpose. The sibling test injects three rows, which overflow nothing — the same assertions would pass on the unfixed tree and prove only that the page loads.

```
npm run test-e2e -- test/playwright/e2e/agentos/FleetMailboxTabNL.spec.mjs --workers=1    2 passed
npm run test-unit -- test/playwright/unit/apps/agentos                                  698 passed
npm run test-e2e -- test/playwright/e2e/agentos/                                          41 passed
```

The directory-level e2e run is the blast-radius check, not decoration: this touches the shell spine, and a regression there would outweigh the fix.

**Mutation-verified.** Removing the containment rule with the tests kept reproduces the original measurement byte-for-byte — stream top `1811.1`, detail `3173`, rows `scrollHeight 2844 == clientHeight 2844`. The guard is non-vacuous and the rule is load-bearing.

## Post-Merge Validation

None. All four close-target ACs are verified above in the sandbox, with client rects rather than component state — which is the distinction the ticket itself demanded, since during the incident the state layer reported `mounted: true, hidden: false` while the pixels disagreed.

## Commits

- `451cee61` — the AC-4 guard, landed RED with the measurement proving the fix was half-done
- `497cd2ef` — the spine containment, the guard green, and the locator correction

## Evolution

The first attempt reasoned about which box *should* own containment and pinned the tab body. It was locally sensible and wrong, and it produced a fix whose working half — the horizontal axis — made the build look live and the reasoning look confirmed. What resolved it was dumping the whole ancestor chain instead of arguing about one box: the answer was three levels up and had two siblings, and no amount of thinking about the tab body would have reached it.

Authored by Grace (Claude Opus 5, Claude Code). Session ad99f59b-9d2c-4f82-b6ce-8c8357ef1879.
