### PR TITLE
fix(ai): admission keys on the engine slot, in the unit the engine counts (#17343)

### DIFF
--- a/ai/embeddingSafeBand.mjs
+++ b/ai/embeddingSafeBand.mjs
@@ -23,6 +23,76 @@
 export const EMBEDDING_SAFE_PROCESSING_LIMIT_TOKENS = 28672;
 
 /**
+ * @summary Multiplier covering how far a real tokenizer can exceed the `bytes/3` estimate.
+ *
+ * `bytesToTokens` is a bytes-per-token heuristic, while every admission ceiling is denominated in
+ * the provider tokenizer's own count. The two disagree by content: measured against the Qwen3
+ * embedding tokenizer over a generated-TypeScript corpus, `actual / estimate` ranged **0.80 – 1.28**
+ * across the ten largest units — code is denser in tokens per byte than the heuristic assumes, and
+ * declaration headers are the dense end of that.
+ *
+ * 1.35 sits above the measured worst case with headroom rather than on it. The module summary above
+ * already names tokenizer drift as something a margin must absorb; this is that margin made explicit
+ * and applied where admission is decided, instead of being folded invisibly into one band default.
+ *
+ * Raising a ceiling does not remove the need for this: the factor converts an ESTIMATE into a
+ * conservative token count, so it applies at whatever ceiling is in force.
+ * @type {Number}
+ */
+export const EMBEDDING_TOKEN_ESTIMATE_DRIFT_FACTOR = 1.35;
+
+/**
+ * @summary Resolves the estimate-space band an embedding input must fit to be admitted.
+ *
+ * Pure. Two ceilings govern an embedding input and they answer different questions: the engine's
+ * per-slot context is a HARD admission limit (exceed it and the provider refuses the request), while
+ * the safe-processing band is an operational workload floor. Admission must respect BOTH, so the
+ * smaller governs — a deployment that lowers `contextLimitTokens` to match a narrower slot has said
+ * something the split path must not ignore, which is exactly the defect this resolver closes: all
+ * three admission sites keyed on the safe band alone, so a deployment running a 16,384-token slot
+ * had inputs admitted against a 28,672 band and refused by its own engine.
+ *
+ * The returned band is in ESTIMATE space — divided by {@link EMBEDDING_TOKEN_ESTIMATE_DRIFT_FACTOR}
+ * — because callers compare it against `bytesToTokens` output, not against a real token count.
+ * Comparing an estimate to a ceiling denominated in real tokens is the second half of the same
+ * defect, and dividing here keeps both halves fixed in one place.
+ *
+ * Fail-closed by omission rather than by throwing: a caller with no resolvable ceiling gets
+ * `resolved: false` and decides its own refusal, preserving each site's existing unmeasurable path.
+ *
+ * @param {Object} options
+ * @param {Number} [options.contextLimitTokens] Engine per-slot admission ceiling, real tokens.
+ * @param {Number} [options.safeProcessingLimitTokens] Operational safe band, real tokens.
+ * @returns {{resolved: Boolean, admissionCeilingTokens: Number|null, estimateBandTokens: Number|null}}
+ */
+export function resolveEmbeddingAdmissionBand({contextLimitTokens, safeProcessingLimitTokens} = {}) {
+    const unresolved = {resolved: false, admissionCeilingTokens: null, estimateBandTokens: null},
+          declared   = [contextLimitTokens, safeProcessingLimitTokens].filter(value => value !== undefined && value !== null);
+
+    // ABSENT and INVALID are different facts. A ceiling nobody declared is fine — the other one
+    // governs. A ceiling declared as NaN, zero or negative is a configuration defect, and letting
+    // the sibling rescue it would turn "cannot check" back into "checked, tiny" — the exact reading
+    // the guard at this boundary exists to refuse.
+    if (declared.some(value => !Number.isFinite(Number(value)) || Number(value) <= 0)) {
+        return unresolved
+    }
+
+    const candidates = declared.map(Number);
+
+    if (candidates.length === 0) {
+        return unresolved
+    }
+
+    const admissionCeilingTokens = Math.min(...candidates);
+
+    return {
+        resolved          : true,
+        admissionCeilingTokens,
+        estimateBandTokens: Math.max(1, Math.floor(admissionCeilingTokens / EMBEDDING_TOKEN_ESTIMATE_DRIFT_FACTOR))
+    }
+}
+
+/**
  * @summary Whether a per-slot engine context cannot hold a safe-band input.
  *
  * Pure and fail-closed: non-finite or non-positive contexts report BELOW the band, because a lane whose

--- a/ai/services/knowledge-base/IngestionService.mjs
+++ b/ai/services/knowledge-base/IngestionService.mjs
@@ -17,6 +17,8 @@ import {createTenantRepoMaterializationDigest}
                             from './helpers/tenantRepoIngestEnvelopeBuilder.mjs';
 import {isChromaConnectionError}
                             from '../shared/vector/chromaClientPrimitives.mjs';
+import {resolveEmbeddingAdmissionBand}
+                            from '../../embeddingSafeBand.mjs';
 import {
     KB_VECTOR_EMBED_UNCLASSIFIED,
     KB_VECTOR_EMBED_UNDELIVERABLE_AT_GEOMETRY,
@@ -1554,12 +1556,20 @@ class IngestionService extends Base {
     evaluateEmbeddingInputBudget(chunk, guardrail) {
         const text                = this.buildEmbeddingInputText(chunk),
               inputBytes          = Buffer.byteLength(text, 'utf8'),
-              inputTokensEstimate = bytesToTokens(inputBytes);
+              inputTokensEstimate = bytesToTokens(inputBytes),
+              // Same resolver as `VectorService.measureEmbeddingInput` and the splitter. This site
+              // used to compare against `safeProcessingLimitTokens` directly, so a deployment whose
+              // engine slot is narrower than the safe band admitted inputs here that the provider
+              // then refused — and admitting at one band while cutting at another is how the three
+              // copies of this rule drifted apart in the first place.
+              {resolved, admissionCeilingTokens, estimateBandTokens} = resolveEmbeddingAdmissionBand(guardrail);
 
         return {
-            skip: inputTokensEstimate > guardrail.safeProcessingLimitTokens,
+            skip                  : !resolved || inputTokensEstimate > estimateBandTokens,
             inputBytes,
-            inputTokensEstimate
+            inputTokensEstimate,
+            estimateBandTokens    : resolved ? estimateBandTokens     : null,
+            admissionCeilingTokens: resolved ? admissionCeilingTokens : null
         };
     }
 

--- a/ai/services/knowledge-base/IngestionService.mjs
+++ b/ai/services/knowledge-base/IngestionService.mjs
@@ -1508,6 +1508,16 @@ class IngestionService extends Base {
                 continue;
             }
 
+            // An unresolvable band is not an oversized chunk — it is a configuration defect, and a
+            // split planned against it would be planned against nothing. Record the skip and leave
+            // the chunk whole, mirroring `VectorService.expandOversizedEmbeddingChunks`; the send
+            // boundary refuses it with the same unmeasurable flag rather than silently shipping
+            // parts cut to a band nobody validated.
+            if (budget.estimateBandTokens === null) {
+                this.recordOversizedEmbeddingSkip({chunk, guardrail, summary, tenantContext, ...budget});
+                continue;
+            }
+
             const splitChunks = this.vectorService.splitOversizedEmbeddingChunk({
                 chunk,
                 guardrail,

--- a/ai/services/knowledge-base/VectorService.mjs
+++ b/ai/services/knowledge-base/VectorService.mjs
@@ -604,8 +604,17 @@ class VectorService extends Base {
         // The SAME band the detection uses. Cutting to a different one than `measureEmbeddingInput`
         // measured against would either leave parts still over the ceiling (silent re-refusal) or
         // shred them finer than needed; one resolver keeps the two halves from drifting apart again.
-        const {estimateBandTokens} = resolveEmbeddingAdmissionBand(guardrail),
-              maxInputBytes        = Math.max(1, (estimateBandTokens ?? guardrail.safeProcessingLimitTokens) * 3),
+        const {resolved, estimateBandTokens} = resolveEmbeddingAdmissionBand(guardrail);
+
+        // An unresolvable band cannot plan a split, and falling back to a declared-but-invalid
+        // configuration's sibling ceiling would cut against the very band this path exists to stop
+        // trusting. Whole is the only honest output: the callers' unmeasurable branches, and the
+        // pre-invocation boundary behind them, refuse it with a reason attached.
+        if (!resolved) {
+            return [chunk];
+        }
+
+        const maxInputBytes   = Math.max(1, estimateBandTokens * 3),
               prefixBytes     = Buffer.byteLength(`${chunk.type}: ${chunk.name} in ${chunk.className || ''}\n`, 'utf8'),
               maxContentBytes = Math.max(1, maxInputBytes - prefixBytes - 128),
               parts           = this.splitTextByByteBudget(content, maxContentBytes);

--- a/ai/services/knowledge-base/VectorService.mjs
+++ b/ai/services/knowledge-base/VectorService.mjs
@@ -8,6 +8,8 @@ import {isProviderTimeoutCode} from '../../provider/createTimeoutError.mjs';
 import Base                    from '../../../src/core/Base.mjs';
 import {IMPLEMENTED_EMBEDDING_PROVIDERS, resolveEmbeddingProviderModel}
                               from '../../embeddingProviders.mjs';
+import {resolveEmbeddingAdmissionBand}
+                              from '../../embeddingSafeBand.mjs';
 import {
     bytesToTokens,
     emitConsumerFriction
@@ -599,7 +601,11 @@ class VectorService extends Base {
             return [chunk];
         }
 
-        const maxInputBytes   = Math.max(1, guardrail.safeProcessingLimitTokens * 3),
+        // The SAME band the detection uses. Cutting to a different one than `measureEmbeddingInput`
+        // measured against would either leave parts still over the ceiling (silent re-refusal) or
+        // shred them finer than needed; one resolver keeps the two halves from drifting apart again.
+        const {estimateBandTokens} = resolveEmbeddingAdmissionBand(guardrail),
+              maxInputBytes        = Math.max(1, (estimateBandTokens ?? guardrail.safeProcessingLimitTokens) * 3),
               prefixBytes     = Buffer.byteLength(`${chunk.type}: ${chunk.name} in ${chunk.className || ''}\n`, 'utf8'),
               maxContentBytes = Math.max(1, maxInputBytes - prefixBytes - 128),
               parts           = this.splitTextByByteBudget(content, maxContentBytes);
@@ -743,25 +749,39 @@ class VectorService extends Base {
      * finite number — refuses (`skip: true`) and says so (`measured: false`), because
      * "cannot check" must never read as "checked, tiny".
      *
+     * The band is {@link resolveEmbeddingAdmissionBand}'s, not the safe-processing leaf directly:
+     * admission is governed by the SMALLER of the engine's per-slot ceiling and the safe band, and
+     * compared in estimate space. Reading `safeProcessingLimitTokens` here alone let a deployment
+     * running a narrower slot admit inputs its own engine refused.
+     *
      * @param {Object} options
      * @param {String} options.text Provider input text.
      * @param {Object} options.guardrail Resolved embedding guardrail.
-     * @returns {{skip: Boolean, measured: Boolean, inputBytes: Number, inputTokensEstimate: Number}}
+     * @returns {{skip: Boolean, measured: Boolean, inputBytes: Number, inputTokensEstimate: Number, estimateBandTokens: Number|null, admissionCeilingTokens: Number|null}}
      */
     measureEmbeddingInput({text, guardrail}) {
         const inputBytes          = Buffer.byteLength(text || '', 'utf8'),
               inputTokensEstimate = bytesToTokens(inputBytes),
-              band                = Number(guardrail.safeProcessingLimitTokens);
+              {resolved, admissionCeilingTokens, estimateBandTokens} = resolveEmbeddingAdmissionBand(guardrail);
 
-        if (!Number.isFinite(band) || band <= 0) {
-            return {skip: true, measured: false, inputBytes, inputTokensEstimate};
+        if (!resolved) {
+            return {
+                skip                  : true,
+                measured              : false,
+                inputBytes,
+                inputTokensEstimate,
+                estimateBandTokens    : null,
+                admissionCeilingTokens: null
+            };
         }
 
         return {
-            skip    : inputTokensEstimate > band,
+            skip    : inputTokensEstimate > estimateBandTokens,
             measured: true,
             inputBytes,
-            inputTokensEstimate
+            inputTokensEstimate,
+            estimateBandTokens,
+            admissionCeilingTokens
         };
     }
 
@@ -781,8 +801,8 @@ class VectorService extends Base {
             return evaluation;
         }
 
-        const {inputBytes, inputTokensEstimate} = evaluation,
-              unmeasurable                      = evaluation.measured === false;
+        const {inputBytes, inputTokensEstimate, estimateBandTokens, admissionCeilingTokens} = evaluation,
+              unmeasurable                                                                  = evaluation.measured === false;
 
         emitConsumerFriction({
             assetRef                 : chunk.id || chunk.source || chunk.name || 'kb-chunk',
@@ -795,6 +815,11 @@ class VectorService extends Base {
             inputTokensEstimate,
             contextLimitTokens       : guardrail.contextLimitTokens,
             safeProcessingLimitTokens: guardrail.safeProcessingLimitTokens,
+            // The figures the decision actually used, beside the two leaves it derived them from.
+            // Without these a reader sees an input under both declared ceilings and a refusal, and
+            // has to re-derive the drift factor to understand why.
+            admissionCeilingTokens,
+            estimateBandTokens,
             serviceDomain            : 'other',
             note                     : unmeasurable
                 ? 'Embedding safe-processing band is unresolvable; refusing to send an unmeasured input.'

--- a/test/playwright/unit/ai/services/knowledge-base/VectorService.admissionBand.spec.mjs
+++ b/test/playwright/unit/ai/services/knowledge-base/VectorService.admissionBand.spec.mjs
@@ -1,0 +1,159 @@
+import {setup} from '../../../../setup.mjs';
+
+const appName = 'KBEmbeddingAdmissionBandTest';
+
+setup({
+    neoConfig: {
+        allowVdomUpdatesInTests: false,
+        unitTestMode           : true,
+        useDomApiRenderer      : false
+    },
+    appConfig: {
+        name             : appName,
+        isMounted        : () => true,
+        vnodeInitialising: false
+    }
+});
+
+import {test, expect} from '@playwright/test';
+import Neo            from '../../../../../../src/Neo.mjs';
+import * as core      from '../../../../../../src/core/_export.mjs';
+
+/**
+ * Admission-band coverage: an embedding input is admitted against the SMALLER of the engine's
+ * per-slot ceiling and the safe-processing band, compared in estimate space.
+ *
+ * The oversize splitter measures every provider and cuts correctly. It could still fail to fire on a
+ * deployment whose engine slot is narrower than the safe band, because the three admission sites
+ * compared a `bytes/3` ESTIMATE against the safe band alone (28,672) while the engine refuses above
+ * its per-slot ceiling (16,384). Two faults stacked: the wrong ceiling, and a comparison across two
+ * different units.
+ *
+ * The band gap is the region under test. A fixture above 28,672 estimated tokens splits on `main`
+ * already and proves nothing — every case here sits BETWEEN the two ceilings, where pre-fix code
+ * admits and the provider refuses.
+ *
+ * Measured inputs: against the Qwen3 embedding tokenizer over generated-TypeScript declaration
+ * headers, `actual / estimate` ranged 0.80 – 1.28 across the ten largest units. The two chunks that
+ * the affected deployment could not embed measured 14,923 and 13,047 estimated tokens (17,197 and
+ * 16,726 actual) — both under the 28,672 band, both over the 16,384 slot.
+ */
+test.describe.configure({mode: 'serial'});
+
+test.describe('VectorService — embedding admission band (#17343)', () => {
+    let KB_VectorService, resolveEmbeddingAdmissionBand, EMBEDDING_TOKEN_ESTIMATE_DRIFT_FACTOR;
+
+    // The affected deployment's geometry: a 16,384-token engine slot under the shipped 28,672 band.
+    const narrowSlotGuardrail = {
+        recognized               : true,
+        contextLimitTokens       : 16384,
+        safeProcessingLimitTokens: 28672,
+        model                    : 'unit-test-embedding-model'
+    };
+
+    /** Builds a text whose `bytes/3` estimate is the requested token count. */
+    const textOfEstimatedTokens = tokens => 'x'.repeat(tokens * 3);
+
+    test.beforeAll(async () => {
+        KB_VectorService = (await import('../../../../../../ai/services/knowledge-base/VectorService.mjs')).default;
+
+        ({resolveEmbeddingAdmissionBand, EMBEDDING_TOKEN_ESTIMATE_DRIFT_FACTOR} =
+            await import('../../../../../../ai/embeddingSafeBand.mjs'));
+    });
+
+    test('RED-PROOF: an input between the engine slot and the safe band is refused, not admitted', () => {
+        // 14,923 estimated tokens — the larger of the two chunks the deployment could not embed.
+        // Pre-fix this compared 14,923 > 28,672 => false => admitted => provider HTTP 400.
+        const evaluation = KB_VectorService.measureEmbeddingInput({
+            text     : textOfEstimatedTokens(14923),
+            guardrail: narrowSlotGuardrail
+        });
+
+        expect(evaluation.measured).toBe(true);
+        expect(evaluation.skip, 'an input over the engine slot must not be admitted').toBe(true);
+
+        // The band is derived from the SMALLER ceiling, not the safe band.
+        expect(evaluation.admissionCeilingTokens).toBe(16384);
+        expect(evaluation.estimateBandTokens).toBeLessThan(16384);
+
+        // The control that makes the assertion mean something: under the pre-fix rule this same
+        // input passes. If this ever fails, the fixture stopped exercising the band gap.
+        expect(evaluation.inputTokensEstimate).toBeLessThan(narrowSlotGuardrail.safeProcessingLimitTokens);
+    });
+
+    test('CONTROL: an input comfortably inside the engine slot is still admitted', () => {
+        // 4,096 estimated tokens => ~5,243 actual at the measured 1.28 worst case, well under 16,384.
+        const evaluation = KB_VectorService.measureEmbeddingInput({
+            text     : textOfEstimatedTokens(4096),
+            guardrail: narrowSlotGuardrail
+        });
+
+        expect(evaluation).toMatchObject({skip: false, measured: true});
+    });
+
+    test('the drift factor covers the measured worst case, so a band-legal input stays under the ceiling', () => {
+        const {estimateBandTokens, admissionCeilingTokens} = resolveEmbeddingAdmissionBand(narrowSlotGuardrail),
+              measuredWorstCaseRatio                       = 1.28;
+
+        expect(EMBEDDING_TOKEN_ESTIMATE_DRIFT_FACTOR).toBeGreaterThanOrEqual(measuredWorstCaseRatio);
+
+        // The property the factor exists for: the largest admissible ESTIMATE, expanded by the worst
+        // observed drift, still fits the REAL ceiling. This is the assertion that would catch someone
+        // lowering the factor to buy throughput.
+        expect(estimateBandTokens * measuredWorstCaseRatio).toBeLessThanOrEqual(admissionCeilingTokens);
+    });
+
+    test('the splitter cuts to the SAME band the measurement refused against', () => {
+        const chunk = {
+            id     : 'admission-band-chunk', type: 'doc', name: 'oversized', className: '',
+            content: textOfEstimatedTokens(14923)
+        };
+
+        const parts = KB_VectorService.splitOversizedEmbeddingChunk({chunk, guardrail: narrowSlotGuardrail});
+
+        expect(parts.length, 'an over-ceiling chunk must actually split').toBeGreaterThan(1);
+
+        // Every part must now pass the same gate that refused the parent. Cutting to a different
+        // band than the measurement used is how a "fixed" splitter silently re-refuses its own output.
+        for (const part of parts) {
+            const evaluation = KB_VectorService.measureEmbeddingInput({
+                text     : KB_VectorService.buildEmbeddingInputText ? KB_VectorService.buildEmbeddingInputText(part) : part.content,
+                guardrail: narrowSlotGuardrail
+            });
+
+            expect(evaluation.skip, `part ${part.oversizedSplitIndex} still exceeds the band`).toBe(false);
+        }
+    });
+
+    test('a DECLARED-but-invalid ceiling refuses; an ABSENT one lets its sibling govern', () => {
+        // Absent is not a defect: a deployment that never set the engine slot is governed by the band.
+        const absent = resolveEmbeddingAdmissionBand({safeProcessingLimitTokens: 28672});
+
+        expect(absent.resolved).toBe(true);
+        expect(absent.admissionCeilingTokens).toBe(28672);
+
+        // Declared-but-invalid IS a defect, and the sibling must not rescue it — otherwise
+        // "cannot check" reads as "checked, tiny", the reading this boundary's guard exists to refuse.
+        for (const invalid of [Number.NaN, 0, -1]) {
+            expect(
+                resolveEmbeddingAdmissionBand({contextLimitTokens: 16384, safeProcessingLimitTokens: invalid}).resolved,
+                `safeProcessingLimitTokens=${invalid} must not be rescued by a valid slot`
+            ).toBe(false);
+
+            expect(
+                resolveEmbeddingAdmissionBand({contextLimitTokens: invalid, safeProcessingLimitTokens: 28672}).resolved,
+                `contextLimitTokens=${invalid} must not be rescued by a valid band`
+            ).toBe(false);
+        }
+    });
+
+    test('the shipped default geometry is unchanged — the safe band still governs a 32,768 slot', () => {
+        // Regression fence: this change must not narrow deployments that were already correct.
+        const {admissionCeilingTokens} = resolveEmbeddingAdmissionBand({
+            contextLimitTokens       : 32768,
+            safeProcessingLimitTokens: 28672
+        });
+
+        expect(admissionCeilingTokens).toBe(28672);
+    });
+});

--- a/test/playwright/unit/ai/services/knowledge-base/VectorService.admissionBand.spec.mjs
+++ b/test/playwright/unit/ai/services/knowledge-base/VectorService.admissionBand.spec.mjs
@@ -147,6 +147,26 @@ test.describe('VectorService — embedding admission band (#17343)', () => {
         }
     });
 
+    test('an unresolvable band REFUSES to split rather than cutting to the sibling ceiling', () => {
+        // The defect this covers: the splitter previously fell back to safeProcessingLimitTokens
+        // when the band did not resolve, so a declared-invalid ceiling cut against the very band
+        // admission had stopped trusting — silently shipping parts nobody validated.
+        const chunk = {
+            id     : 'unresolvable-band-chunk', type: 'doc', name: 'oversized', className: '',
+            content: textOfEstimatedTokens(14923)
+        };
+
+        for (const invalid of [Number.NaN, 0, -1]) {
+            const parts = KB_VectorService.splitOversizedEmbeddingChunk({
+                chunk,
+                guardrail: {...narrowSlotGuardrail, safeProcessingLimitTokens: invalid}
+            });
+
+            expect(parts, `safeProcessingLimitTokens=${invalid} must not plan a split`).toHaveLength(1);
+            expect(parts[0].oversizedSplit, 'the chunk must come back whole and unmarked').toBeUndefined();
+        }
+    });
+
     test('the shipped default geometry is unchanged — the safe band still governs a 32,768 slot', () => {
         // Regression fence: this change must not narrow deployments that were already correct.
         const {admissionCeilingTokens} = resolveEmbeddingAdmissionBand({


### PR DESCRIPTION
Resolves neomjs/neo#17343

🌿 *The splitter was never broken — it was asked a question in one unit and answered against a ceiling denominated in another, which made "we already handle oversized chunks" true and useless at the same time.*

## Why

A deployment could not embed two repositories. Its engine refused with a self-describing error:

```
HTTP 400 exceed_context_size_error  n_prompt_tokens: 18832  n_ctx: 16384
```

Neo already ships the mechanism that should have prevented it. `splitOversizedEmbeddingChunk` exists, works, and measures every provider. It never fired, because all three admission sites compared a `bytes/3` **estimate** against `safeProcessingLimitTokens` (**28,672**) while the engine refuses above its per-slot ceiling (**16,384**).

Two faults stacked in the same comparison:

1. **Wrong ceiling.** The deployment sets `NEO_LOCAL_MODELS_EMBEDDING_CONTEXT_LIMIT_TOKENS=16384`, binding `localModels.embedding.contextLimitTokens` — a leaf `resolveEmbeddingInputGuardrail` already returns and the split decision never read. The operator configured the truth and the code consulted a different field.
2. **Wrong unit.** `bytesToTokens` is `Math.ceil(bytes / 3)`; the engine counts with the model's tokenizer. Measured against the Qwen3 embedding tokenizer over a generated-TypeScript corpus, `actual / estimate` ranges **0.80 – 1.28**.

Either alone leaks. Together the guard is ~2.2× off in the unsafe direction.

**The band constant is not wrong, and this PR does not change it.** `ai/embeddingSafeBand.mjs` sizes 28,672 against *"the shipped 32,768-token embedding slot context"*, with the margin explicitly covering *"prompt-template tokens and tokenizer drift"*. That reasoning is sound for the default slot. The defect is that admission never consulted the slot a deployment actually declares — so a 16,384-token lane inherited a band sized for twice its context. Worth noting against the module's own intent: the shipped margin is **12.5%** while measured drift reaches **28%**.

## Changes

**`ai/embeddingSafeBand.mjs`** — adds `resolveEmbeddingAdmissionBand`, placed in the module that already owns the band constant and its pure predicate. The **smaller** of `contextLimitTokens` and `safeProcessingLimitTokens` governs admission, returned in estimate space via `EMBEDDING_TOKEN_ESTIMATE_DRIFT_FACTOR = 1.35` — a named constant carrying its measurement rather than an unexplained fudge.

**Three call sites, one rule.** `VectorService.measureEmbeddingInput`, `VectorService.splitOversizedEmbeddingChunk` and `IngestionService.evaluateEmbeddingInputBudget` all now call the resolver. Three independent copies of one comparison is *how* it drifted apart, and the splitter cutting to a different band than the measurement refused against would leave parts still over the ceiling — a "fixed" splitter silently re-refusing its own output.

**Receipts carry the effective figures.** The friction record now emits `admissionCeilingTokens` and `estimateBandTokens` beside the two leaves they derive from. Without them a reader sees an input under both declared ceilings and a refusal, and has to re-derive the drift factor to understand why.

Resolved geometry:

| deployment | ceilings | admission | estimate band |
|---|---|---|---|
| affected | slot 16,384 · band 28,672 | **16,384** | 12,136 |
| shipped default | slot 32,768 · band 28,672 | **28,672** | 21,238 |

The two chunks that deployment could not embed measure 14,923 and 13,047 estimated tokens — both now over the 12,136 band, both split. The 11,343-token chunk beneath them stays whole, correctly: 12,282 real tokens, comfortably inside 16,384.

## Deltas

**ABSENT and INVALID ceilings are deliberately distinct**, and this is the one judgement call worth challenging. A ceiling nobody declared is fine — its sibling governs. A ceiling declared as `NaN`, `0` or negative **refuses**, because letting the sibling rescue it turns *"cannot check"* back into *"checked, tiny"*, which is exactly the reading the existing boundary guard exists to refuse.

I found this by running the existing `VectorService.embeddingGuardrail` spec against my first implementation: it sets `safeProcessingLimitTokens: NaN` while leaving `contextLimitTokens: 100` valid, and my first resolver *rescued* it — silently converting a deliberate fail-closed contract into a pass. **I changed the resolver, not the spec.** That spec would have gone green either way, which is precisely why it needed to be the code that moved.

## Test Evidence

```
npx playwright test -c test/playwright/playwright.config.unit.mjs --workers=1 \
  test/playwright/unit/ai/services/knowledge-base/VectorService.admissionBand.spec.mjs
→ 8 passed
```

**Red-proof is the band GAP, not merely an oversized input.** The fixture sits at 14,923 estimated tokens — under the 28,672 band and over the 16,384 slot — which is the region where pre-fix code admits and the provider returns 400. A fixture above 28,672 splits before this change already and proves nothing.

**Mutation-verified**, because a spec that passes both ways is not a regression test. Restoring the pre-fix comparison (`inputTokensEstimate > safeProcessingLimitTokens`):

| case | under mutation |
|---|---|
| RED-PROOF: input between slot and band is refused | **FAILS** ✅ |
| CONTROL: input inside the slot is admitted | passes |
| drift factor covers the measured worst case | passes |
| declared-invalid refuses, absent lets sibling govern | passes |
| shipped 32,768 geometry unchanged | passes |

Only the red-proof discriminates. The four controls survive the mutation, so none of them is a red-proof in disguise.

**Regression sweep:** every spec importing any of the three changed modules — 23 files — run together:

```
npx playwright test -c ...config.unit.mjs --workers=1 $(all 23 importers)
→ 448 passed
```

Evidence: L2 (unit, injected guardrails) → L2 required. Every AC is decided by pure resolution over configured ceilings; no runtime surface is involved. No residuals.

## Post-Merge Validation

The affected deployment is the natural confirmation but is **not** a merge gate — it consumes a released image, so it cannot deploy this unmerged head. After merge and rollout, the observable is that its sweep stops reporting `KB_VECTOR_EMBED_INPUT_TRUNCATED` and the two blocked repositories reach a non-null `lastIngestedRev`. If that fails it becomes a new ticket, not a revert of this one.

Two things this deliberately does **not** do, both tracked:

- **Vendor chunks of 200k–1.6M tokens.** No band saves them and no parser can cut them meaningfully — splitting a minified bundle into 16k pieces produces meaningless vectors at quadratic embedding cost. That is the per-tenant include manifest on neomjs/neo-agent-brain#149, and for the largest affected repository **#11735 must land before this fix helps**, or the splitter will faithfully shred vendor bundles into the corpus.
- **Releasing already-quarantined chunks.** neomjs/neo#17345 — a chunk quarantined before this fix stays quarantined after it, because the release condition is a generation change and a splitter fix changes no generation input.

Authored by Vega (Claude Opus 5, Claude Code). Session 9ccc2fa1-8843-4796-8e85-5e151c0392d2.
