### PR TITLE
feat(fleet): the operator seat's conflation is named at boot and beside compose (#17310)

### DIFF
--- a/ai/scripts/fleet/devCockpit.mjs
+++ b/ai/scripts/fleet/devCockpit.mjs
@@ -58,6 +58,20 @@
  * child's env ({@link buildFleetChildEnv}) — never `process.env`, never the webpack child, never
  * a log line. Bearer VALIDITY stays with the fleet entry's plane-side verified admission (one
  * verification authority); this launcher fails fast only on "no plane serving there at all".
+ *
+ * **The operator-seat credential journey (seat-conflation honesty).** The implicit `gh auth token`
+ * fallback resolves whatever identity the CHECKOUT's gh CLI is logged in as — on a multi-seat
+ * machine that is typically an AGENT seat's account, so the plane admits the session as that
+ * agent and every operator action through the transport (compose sends above all) is attributed
+ * to the agent's identity: graph pollution of the worst class, messages an agent never wrote
+ * reading as their own words. The fleet entry detects the collision at boot (resolved viewer ∈
+ * registered agent identities → a loud OPERATOR-SEAT CONFLATION warn) and the cockpit renders the
+ * same truth beside the compose surface. To make the transport fact TRUE instead of merely
+ * honest, run the operator seat with an operator-class subject: EITHER pin
+ * `NEO_FLEET_PLANE_BEARER` (or the `_FILE` variant) to a PAT whose subject is the operator's own
+ * account, OR run the launcher from a checkout whose `gh auth` identity is the operator's. The
+ * detection never blocks the boot — sending knowingly is the operator's call; sending unknowingly
+ * was the defect.
  * Live mode never adopts an incumbent fleet transport: the incumbent's plane binding is not
  * observable through `/fleet/probe`, so reuse could silently point the cockpit at the wrong
  * plane — an occupied endpoint refuses with the remediation named.

--- a/ai/services/fleet/devFleetServer.mjs
+++ b/ai/services/fleet/devFleetServer.mjs
@@ -415,14 +415,23 @@ async function boot() {
         // means every operator action through this transport inherits agent attribution — the
         // gh-auth fallback on a seat machine produces exactly this. The transport stays up (the
         // admission is truthful about its subject); the operator sends knowingly or fixes the
-        // credential. Registry unavailability degrades the CHECK silently, never the boot.
+        // credential. All three check outcomes are named or deliberately silent: conflated warns
+        // loudly; a null decision (empty id list — the registry reader swallows missing/corrupt
+        // files into empty, so [] is genuinely ambiguous between "no agents" and "unreadable",
+        // and the reader's own warn is the disambiguator) logs that it CANNOT judge; only a
+        // verified-clean posture is silent — the healthy operator case earns no noise. A throwing
+        // check degrades the CHECK (named), never the boot.
         try {
             const conflation = describeOperatorSeatConflation({
                 viewerIdentity: viewer.agentIdentityNodeId,
                 registeredIds : FleetManager.getLifecycleService().getRegistry().listAgents().map(entry => entry.id)
             });
 
-            conflation?.conflated && console.warn(`[fleet] ${operatorSeatConflationWarning(conflation.seatIdentity)}`)
+            if (conflation?.conflated) {
+                console.warn(`[fleet] ${operatorSeatConflationWarning(conflation.seatIdentity)}`)
+            } else if (conflation === null) {
+                console.log('[fleet] operator-seat conflation check: the registry lists no agents — cannot judge (a fresh plane, or an unreadable registry; an unreadable one warns separately).')
+            }
         } catch (error) {
             console.warn(`[fleet] operator-seat conflation check unavailable (non-fatal): ${error.message}`)
         }

--- a/ai/services/fleet/devFleetServer.mjs
+++ b/ai/services/fleet/devFleetServer.mjs
@@ -43,15 +43,16 @@
 
 // Neo namespace bootstrap (entry-point invariant): `Neo` + `core/_export` populate globalThis.Neo so
 // the fleet singletons' `Neo.setupClass` succeeds at module-load; `InstanceManager` binds the aliases.
-import Neo                      from '../../../src/Neo.mjs';
-import * as core                from '../../../src/core/_export.mjs';
-import InstanceManager          from '../../../src/manager/Instance.mjs';
-import AiConfig                 from '../../config.mjs';
-import memoryCoreConfig         from '../../mcp/server/memory-core/config.mjs';
-import RequestContextService    from '../../mcp/server/shared/services/RequestContextService.mjs';
-import FleetControlBridge       from './FleetControlBridge.mjs';
-import FleetManager             from './FleetManager.mjs';
-import {startFleetBridgeServer} from './fleetBridgeServer.mjs';
+import Neo                                                             from '../../../src/Neo.mjs';
+import * as core                                                       from '../../../src/core/_export.mjs';
+import InstanceManager                                                 from '../../../src/manager/Instance.mjs';
+import AiConfig                                                        from '../../config.mjs';
+import memoryCoreConfig                                                from '../../mcp/server/memory-core/config.mjs';
+import RequestContextService                                           from '../../mcp/server/shared/services/RequestContextService.mjs';
+import FleetControlBridge                                              from './FleetControlBridge.mjs';
+import FleetManager                                                    from './FleetManager.mjs';
+import {describeOperatorSeatConflation, operatorSeatConflationWarning} from './operatorSeatConflation.mjs';
+import {startFleetBridgeServer}                                        from './fleetBridgeServer.mjs';
 import {probeExistingFleetServer, resolveFleetBearer, resolveFleetViewer,
         resolveFleetViewerClaim}                                          from './fleetLaunchContract.mjs';
 import {assertFleetPlaneAdmissionBearerClass,
@@ -408,7 +409,23 @@ async function boot() {
 
         // Identity facts only — the bearer is deliberately absent from every log line this
         // process emits; the launcher that supplied (or will inject) it owns the hand-off.
-        console.log(`[fleet] authenticated app<->fleet transport listening on http://127.0.0.1:${server.address().port}/fleet (viewer: ${viewer.agentIdentityNodeId}, bearer: ${AiConfig.fleet.bearer ? 'supplied' : 'generated'})`)
+        console.log(`[fleet] authenticated app<->fleet transport listening on http://127.0.0.1:${server.address().port}/fleet (viewer: ${viewer.agentIdentityNodeId}, bearer: ${AiConfig.fleet.bearer ? 'supplied' : 'generated'})`);
+
+        // Seat-conflation honesty at boot: a viewer claim that IS a registered agent identity
+        // means every operator action through this transport inherits agent attribution — the
+        // gh-auth fallback on a seat machine produces exactly this. The transport stays up (the
+        // admission is truthful about its subject); the operator sends knowingly or fixes the
+        // credential. Registry unavailability degrades the CHECK silently, never the boot.
+        try {
+            const conflation = describeOperatorSeatConflation({
+                viewerIdentity: viewer.agentIdentityNodeId,
+                registeredIds : FleetManager.getLifecycleService().getRegistry().listAgents().map(entry => entry.id)
+            });
+
+            conflation?.conflated && console.warn(`[fleet] ${operatorSeatConflationWarning(conflation.seatIdentity)}`)
+        } catch (error) {
+            console.warn(`[fleet] operator-seat conflation check unavailable (non-fatal): ${error.message}`)
+        }
     } catch (error) {
         // EVERY exit below this line closes the proven plane session AWAITED — startup failures,
         // probe failures, reuse, and refusal alike would otherwise orphan it on the plane. The

--- a/ai/services/fleet/operatorSeatConflation.mjs
+++ b/ai/services/fleet/operatorSeatConflation.mjs
@@ -1,0 +1,51 @@
+/**
+ * @module ai/services/fleet/operatorSeatConflation
+ * @summary The operator-seat conflation check, as one pure decision leaf: a fleet transport whose
+ * resolved viewer claim IS a registered agent identity attributes every operator action to that
+ * seat — messages an agent never wrote enter the identity graph as the agent's own words, the
+ * worst pollution class a provenance-first substrate has. Admission itself is correct (the claim
+ * is the credential's true subject); what is missing without this check is HONESTY about what
+ * that subject means at an operator keyboard.
+ *
+ * The check is deliberately a pure function over two facts the caller already holds (the resolved
+ * viewer identity + the registry's public agent list), so the boot path, the cockpit, and the
+ * unit suite all consume the identical decision — no re-derivation, no drift.
+ */
+
+/**
+ * @summary Decide whether a resolved viewer claim collides with a registered agent identity.
+ *
+ * Identity forms are canonicalized on both sides (`@`-prefix stripped, case preserved — agent
+ * ids are case-sensitive registry keys). An empty registry answers `null` (cannot judge), never
+ * `{conflated: false}` — absence of roster truth is not a clean bill.
+ *
+ * @param {Object} options
+ * @param {String|null} options.viewerIdentity The transport's resolved viewer claim (`@`-form or bare).
+ * @param {String[]} [options.registeredIds=[]] Registered agent identities (`@`-form or bare).
+ * @returns {{conflated: Boolean, seatIdentity: String}|null} The decision, or `null` when either
+ *     side is missing — the caller renders unknown as unknown.
+ */
+export function describeOperatorSeatConflation({viewerIdentity, registeredIds = []} = {}) {
+    if (typeof viewerIdentity !== 'string' || !viewerIdentity.trim() || !Array.isArray(registeredIds) || registeredIds.length < 1) {
+        return null
+    }
+
+    const
+        bare      = id => String(id).trim().replace(/^@/, ''),
+        viewer    = bare(viewerIdentity),
+        conflated = registeredIds.some(id => bare(id) === viewer);
+
+    return {conflated, seatIdentity: `@${viewer}`}
+}
+
+/**
+ * @summary The boot-log sentence for a conflated seat — one place owns the wording, so the server
+ * warn and any future surface say the same thing.
+ * @param {String} seatIdentity The `@`-form seat the transport is bound to.
+ * @returns {String}
+ */
+export function operatorSeatConflationWarning(seatIdentity) {
+    return `OPERATOR-SEAT CONFLATION: the transport viewer (${seatIdentity}) is a REGISTERED AGENT identity — operator actions through this session will be attributed to that seat. Establish an operator-class credential (an explicit NEO_FLEET_PLANE_BEARER whose subject is the operator, or gh auth as the operator's own identity) so the transport fact becomes true.`
+}
+
+export default describeOperatorSeatConflation;

--- a/apps/agentos/view/fleet/FleetCockpit.mjs
+++ b/apps/agentos/view/fleet/FleetCockpit.mjs
@@ -559,6 +559,17 @@ class FleetCockpit extends Container {
      */
     operatorRecord = null
     /**
+     * Owner-held operator-seat identity posture — `{conflated, seatIdentity}` once the resolved
+     * viewer identity has been compared against the roster's registered agent identities, `null`
+     * while unresolved or while the roster holds no rows to judge against (unknown renders as
+     * unknown, never as a clean bill). A conflated posture means every send through this
+     * transport is attributed to an AGENT seat — the pane renders that truth beside the compose
+     * surface instead of letting the operator send unknowingly.
+     * @member {Object|null} operatorIdentityPosture=null
+     * @protected
+     */
+    operatorIdentityPosture = null
+    /**
      * The last operator-inbox mailbox-mirror snapshot — OWNER-held so a re-projected operator-mailbox pane
      * re-materializes at current truth (written by {@link #loadOperatorInbox}). `null` = `unobserved`.
      * @member {Object|null} operatorSnapshot=null
@@ -1352,6 +1363,7 @@ class FleetCockpit extends Container {
                     record          : me.operatorRecord,
                     snapshot        : me.operatorSnapshot,
                     recipientOptions: me.buildOperatorRecipientOptions(),
+                    identityPosture : me.operatorIdentityPosture,
                     listeners       : {compose: 'onOperatorCompose', inboxPageRequest: 'onOperatorInboxPageRequest'},
                     reference       : 'operator-mailbox'
                 };
@@ -3001,10 +3013,40 @@ class FleetCockpit extends Container {
             // `@`-form authority, so carry both: `githubUsername` for the possession match, the node id as
             // the explicit read subject (they canonicalize to the same value).
             me.operatorRecord = {agentIdentityNodeId: nodeId, githubUsername: nodeId.replace(/^@/, '')};
+            // the seat-conflation honesty check rides the same resolution: the roster the cockpit
+            // already holds knows every registered agent identity, and a viewer claim matching one
+            // means sends are attributed to that seat — a truth the pane must render, not swallow
+            me.operatorIdentityPosture = me.deriveOperatorIdentityPosture(nodeId);
             // a materialized pane picks up the identity live and reads; an autoHidden one materializes from
             // the held record on reveal
-            me.getOperatorMailboxPane()?.set({record: me.operatorRecord})
+            me.getOperatorMailboxPane()?.set({record: me.operatorRecord, identityPosture: me.operatorIdentityPosture})
         }
+    }
+
+    /**
+     * @summary Compare the resolved viewer identity against the provider-owned roster's agent
+     * identities — the cockpit half of the seat-conflation honesty contract (the fleet server
+     * runs the same decision server-side at boot over the registry; the check is trivial enough
+     * that duplicating it beats an app→Brain import across the parity boundary).
+     *
+     * An empty roster answers `null` (cannot judge) rather than `{conflated: false}` — absence of
+     * roster truth is not a clean bill, and the pane renders unknown as unknown.
+     * @param {String} viewerIdentity The resolved `@`-form viewer identity.
+     * @returns {{conflated: Boolean, seatIdentity: String}|null}
+     */
+    deriveOperatorIdentityPosture(viewerIdentity) {
+        const rows = this.getReference('fleet-grid')?.store?.items ?? [];
+
+        if (typeof viewerIdentity !== 'string' || !viewerIdentity.trim() || rows.length < 1) {
+            return null
+        }
+
+        const
+            bare      = id => String(id).trim().replace(/^@/, ''),
+            viewer    = bare(viewerIdentity),
+            conflated = rows.some(row => bare(row.agentId ?? '') === viewer);
+
+        return {conflated, seatIdentity: `@${viewer}`}
     }
 
     /**

--- a/apps/agentos/view/fleet/OperatorMailbox.mjs
+++ b/apps/agentos/view/fleet/OperatorMailbox.mjs
@@ -78,6 +78,18 @@ class OperatorMailbox extends Container {
          */
         composeOutcome_: null,
         /**
+         * The operator-seat identity posture (`{conflated, seatIdentity}` | `null`), injected by the
+         * cockpit from its resolved viewer identity vs the roster. A conflated posture renders the
+         * truth marker directly above the compose surface: sends through this transport are
+         * attributed to an AGENT seat, and the operator must see that BEFORE writing — the marker
+         * changes honesty, never authority (the form stays senderless either way). `null` and
+         * `{conflated: false}` both render nothing: unknown is not a warning, and a clean posture
+         * needs no chrome.
+         * @member {Object|null} identityPosture_=null
+         * @reactive
+         */
+        identityPosture_: null,
+        /**
          * @member {Object} layout={ntype:'vbox',align:'stretch'}
          * @reactive
          */
@@ -90,6 +102,15 @@ class OperatorMailbox extends Container {
             flex     : 1,
             header   : {text: 'Your inbox'},
             reference: 'operator-inbox-pane'
+        }, {
+            // the seat-conflation truth marker — hidden until a conflated posture is injected;
+            // placed directly above the compose surface so the fact sits where the writing starts
+            ntype    : 'component',
+            cls      : ['fm-operator-identity-warning'],
+            flex     : 'none',
+            hidden   : true,
+            reference: 'operator-identity-warning',
+            role     : 'alert'
         }, {
             // shrinkable, never 'none': in the height-bounded drawer slot the form's natural
             // height exceeds the well, and a rigid form starves the inbox above it to 0px —
@@ -129,10 +150,40 @@ class OperatorMailbox extends Container {
             me.snapshot && (inbox.snapshot = me.snapshot)
         }
         form && me.recipientOptions?.length && (form.recipientOptions = me.recipientOptions);
+        me.applyIdentityPosture();
 
         // a construction-time identity lands its first inbox read without a page gesture (afterSetRecord
         // was skipped pre-construct, so this is the single fire for the reveal path)
         me.record && me.onInboxPageRequest({offset: 0})
+    }
+
+    /**
+     * Triggered after the identity posture changed — rendered by the marker, never held anywhere else.
+     * @param {Object|null} value
+     * @param {Object|null} oldValue
+     * @protected
+     */
+    afterSetIdentityPosture(value, oldValue) {
+        this.isConstructed && this.applyIdentityPosture()
+    }
+
+    /**
+     * @summary Render the seat-conflation truth marker from the injected posture. Only a POSITIVE
+     * conflation shows chrome; `null` (cannot judge) and a clean posture both stay silent — the
+     * marker asserts a verified fact, never a suspicion.
+     * @protected
+     */
+    applyIdentityPosture() {
+        const
+            marker    = this.getReference('operator-identity-warning'),
+            conflated = this.identityPosture?.conflated === true;
+
+        marker?.set({
+            hidden: !conflated,
+            text  : conflated
+                ? `Sending as agent seat ${this.identityPosture.seatIdentity} — operator principal not established. Messages will carry that seat's identity.`
+                : null
+        })
     }
 
     /**

--- a/resources/scss/src/apps/agentos/fleet/OperatorMailbox.scss
+++ b/resources/scss/src/apps/agentos/fleet/OperatorMailbox.scss
@@ -14,6 +14,20 @@
         min-height: 96px;
     }
 
+    /* the seat-conflation truth marker — sits directly above the compose surface so the fact is
+       read before the writing starts. Alert-kind wash: this is a verified identity fact with
+       consequences, not decoration; it must not be mistakable for the quiet meta family. */
+    > .fm-operator-identity-warning {
+        margin       : 8px 0 0;
+        padding      : 7px 10px;
+        border       : 1px solid var(--fm-kind-alert);
+        border-radius: 6px;
+        background   : color-mix(in srgb, var(--fm-kind-alert) 12%, transparent);
+        color        : var(--fm-ink);
+        font-size    : 11.5px;
+        line-height  : 1.4;
+    }
+
     /* the compose form sits under a soft divider — the read half above, the write half below;
        when squeezed it owns its vertical overflow instead of starving the inbox */
     > .fm-operator-compose-form {

--- a/test/playwright/unit/ai/services/fleet/operatorSeatConflation.spec.mjs
+++ b/test/playwright/unit/ai/services/fleet/operatorSeatConflation.spec.mjs
@@ -1,0 +1,49 @@
+import {expect, test}                                                  from '@playwright/test';
+import {describeOperatorSeatConflation, operatorSeatConflationWarning} from '../../../../../../ai/services/fleet/operatorSeatConflation.mjs';
+
+/**
+ * @summary The pure seat-conflation decision: one canonicalized comparison shared by the fleet
+ * entry's boot warn and the suite. The pins: form-insensitivity (`@`-prefixed and bare ids match
+ * either way), the null-not-clean contract (missing viewer OR empty registry answers `null`,
+ * never `{conflated: false}`), and the warning sentence carrying the seat it names.
+ */
+test.describe('operatorSeatConflation — the seat-conflation decision leaf', () => {
+    const REGISTERED = ['@neo-fable-clio', '@neo-opus-vega', 'neo-opus-ada'];
+
+    test('a viewer matching a registered agent identity is conflated — in every id form pairing', () => {
+        expect(describeOperatorSeatConflation({viewerIdentity: '@neo-fable-clio', registeredIds: REGISTERED}))
+            .toEqual({conflated: true, seatIdentity: '@neo-fable-clio'});
+        expect(describeOperatorSeatConflation({viewerIdentity: 'neo-fable-clio', registeredIds: REGISTERED}))
+            .toEqual({conflated: true, seatIdentity: '@neo-fable-clio'});
+        // the bare-registered form matches an @-form viewer too
+        expect(describeOperatorSeatConflation({viewerIdentity: '@neo-opus-ada', registeredIds: REGISTERED}))
+            .toEqual({conflated: true, seatIdentity: '@neo-opus-ada'})
+    });
+
+    test('a viewer outside the registry is a clean posture, not silence', () => {
+        expect(describeOperatorSeatConflation({viewerIdentity: '@tobiu', registeredIds: REGISTERED}))
+            .toEqual({conflated: false, seatIdentity: '@tobiu'})
+    });
+
+    test('missing viewer or empty registry answers null — absence of truth is not a clean bill', () => {
+        expect(describeOperatorSeatConflation({viewerIdentity: null, registeredIds: REGISTERED})).toBeNull();
+        expect(describeOperatorSeatConflation({viewerIdentity: '   ', registeredIds: REGISTERED})).toBeNull();
+        expect(describeOperatorSeatConflation({viewerIdentity: '@tobiu', registeredIds: []})).toBeNull();
+        expect(describeOperatorSeatConflation({viewerIdentity: '@tobiu'})).toBeNull();
+        expect(describeOperatorSeatConflation()).toBeNull()
+    });
+
+    test('identity matching is exact after canonicalization — no substring or case forgiveness', () => {
+        expect(describeOperatorSeatConflation({viewerIdentity: '@neo-fable', registeredIds: REGISTERED}).conflated).toBe(false);
+        expect(describeOperatorSeatConflation({viewerIdentity: '@NEO-FABLE-CLIO', registeredIds: REGISTERED}).conflated).toBe(false)
+    });
+
+    test('the warning sentence names the seat and the remediation classes', () => {
+        const warning = operatorSeatConflationWarning('@neo-fable-clio');
+
+        expect(warning).toContain('@neo-fable-clio');
+        expect(warning).toContain('OPERATOR-SEAT CONFLATION');
+        expect(warning).toContain('NEO_FLEET_PLANE_BEARER');
+        expect(warning).toContain('gh auth')
+    })
+});

--- a/test/playwright/unit/apps/agentos/view/fleet/fleetCockpit.spec.mjs
+++ b/test/playwright/unit/apps/agentos/view/fleet/fleetCockpit.spec.mjs
@@ -2762,16 +2762,23 @@ test.describe('Fleet cockpit — operator mailbox (compose · recipients · own-
 
         const paneSets = [],
               pane     = {set(cfg) { paneSets.push(cfg) }},
-              cockpit  = {operatorRecord: null, getOperatorMailboxPane: () => pane};
+              cockpit  = {
+                  operatorRecord               : null,
+                  deriveOperatorIdentityPosture: FleetCockpit.prototype.deriveOperatorIdentityPosture,
+                  getReference                 : () => null,
+                  getOperatorMailboxPane       : () => pane
+              };
 
         await FleetCockpit.prototype.loadOperatorIdentity.call(cockpit);
 
         // the record MUST carry `githubUsername` — MailboxPane's possession guard canonicalizes it to
         // `@<username>` and matches the admission's subjectAgentId; seeding only the node id fails
         // possession closed and the own inbox never renders (the exact review finding).
+        // The push also carries the seat-conflation posture (null here: no roster in this fake —
+        // absence of roster truth is not a clean bill).
         const expected = {agentIdentityNodeId: '@neo-opus-grace', githubUsername: 'neo-opus-grace'};
         expect(cockpit.operatorRecord).toEqual(expected);
-        expect(paneSets).toEqual([{record: expected}])
+        expect(paneSets).toEqual([{record: expected, identityPosture: null}])
     });
 
     test('identity · a refusal (ok:false — unbound / source-not-wired) never seeds a wrong subject', async () => {
@@ -2788,11 +2795,72 @@ test.describe('Fleet cockpit — operator mailbox (compose · recipients · own-
         setBridge({resolveViewerIdentity: async () => ({ok: true, agentIdentityNodeId: '@neo-opus-grace'})});
 
         // the pane is not materialized yet (accessor → null); the `?.set` no-ops but the record is held
-        // owner-side (with the possession authority), so a later projection materializes the pane and reads
-        const cockpit = {operatorRecord: null, getOperatorMailboxPane: () => null};
+        // owner-side (with the possession authority), so a later projection materializes the pane and reads.
+        // The posture derive rides the same resolution over the cockpit surface (an absent grid → null posture).
+        const cockpit = {
+            operatorRecord               : null,
+            deriveOperatorIdentityPosture: FleetCockpit.prototype.deriveOperatorIdentityPosture,
+            getReference                 : () => null,
+            getOperatorMailboxPane       : () => null
+        };
 
         await FleetCockpit.prototype.loadOperatorIdentity.call(cockpit);
 
         expect(cockpit.operatorRecord).toEqual({agentIdentityNodeId: '@neo-opus-grace', githubUsername: 'neo-opus-grace'})
+    });
+});
+
+
+test.describe('Fleet cockpit — operator-seat identity posture (the conflation honesty half)', () => {
+    let FleetCockpit;
+
+    test.beforeAll(async () => {
+        FleetCockpit = (await import('../../../../../../../apps/agentos/view/fleet/FleetCockpit.mjs')).default
+    });
+
+    const derive = (viewerIdentity, rows) => FleetCockpit.prototype.deriveOperatorIdentityPosture.call(
+        {getReference: reference => reference === 'fleet-grid' ? {store: {items: rows}} : null},
+        viewerIdentity
+    );
+
+    const ROWS = [{agentId: 'neo-fable-clio'}, {agentId: 'neo-opus-vega'}, {agentId: 'neo-opus-ada'}];
+
+    test('a viewer matching a roster agent identity is conflated; an outside viewer is clean', () => {
+        expect(derive('@neo-fable-clio', ROWS)).toEqual({conflated: true, seatIdentity: '@neo-fable-clio'});
+        expect(derive('@tobiu', ROWS)).toEqual({conflated: false, seatIdentity: '@tobiu'})
+    });
+
+    test('an empty roster answers null — absence of roster truth is not a clean bill', () => {
+        expect(derive('@tobiu', [])).toBeNull();
+        expect(derive(null, ROWS)).toBeNull();
+        expect(derive('   ', ROWS)).toBeNull()
+    });
+
+    test('loadOperatorIdentity holds the posture owner-side and pushes record + posture through the accessor', async () => {
+        const pushes = [],
+              me     = {
+                  isDestroyed                  : false,
+                  deriveOperatorIdentityPosture: FleetCockpit.prototype.deriveOperatorIdentityPosture,
+                  getReference                 : reference => reference === 'fleet-grid' ? {store: {items: ROWS}} : null,
+                  getOperatorMailboxPane       : () => ({set: config => pushes.push(config)})
+              },
+              previousNs = globalThis.AgentOS;
+
+        globalThis.AgentOS = {fleet: {registryBridge: {
+            resolveViewerIdentity: async () => ({ok: true, agentIdentityNodeId: '@neo-fable-clio'})
+        }}};
+
+        try {
+            await FleetCockpit.prototype.loadOperatorIdentity.call(me);
+
+            expect(me.operatorRecord).toEqual({agentIdentityNodeId: '@neo-fable-clio', githubUsername: 'neo-fable-clio'});
+            expect(me.operatorIdentityPosture).toEqual({conflated: true, seatIdentity: '@neo-fable-clio'});
+            expect(pushes).toEqual([{
+                record         : {agentIdentityNodeId: '@neo-fable-clio', githubUsername: 'neo-fable-clio'},
+                identityPosture: {conflated: true, seatIdentity: '@neo-fable-clio'}
+            }])
+        } finally {
+            globalThis.AgentOS = previousNs
+        }
     });
 });

--- a/test/playwright/unit/apps/agentos/view/fleet/operatorMailbox.spec.mjs
+++ b/test/playwright/unit/apps/agentos/view/fleet/operatorMailbox.spec.mjs
@@ -170,4 +170,38 @@ test.describe('AgentOS OperatorMailbox — the operator mailbox surface (#15377)
 
         box.destroy()
     })
+
+    test('the seat-conflation marker renders ONLY a verified conflation — null and clean stay silent', () => {
+        const box    = createBox(),
+              marker = box.getReference('operator-identity-warning');
+
+        // default: no posture → hidden (unknown is not a warning)
+        expect(marker.hidden).toBe(true);
+
+        // a clean posture needs no chrome
+        box.identityPosture = {conflated: false, seatIdentity: '@tobiu'};
+        expect(marker.hidden).toBe(true);
+
+        // a verified conflation renders the truth beside the compose surface
+        box.identityPosture = {conflated: true, seatIdentity: '@neo-fable-clio'};
+        expect(marker.hidden).toBe(false);
+        expect(marker.text).toContain('@neo-fable-clio');
+        expect(marker.text).toContain('operator principal not established');
+
+        // posture withdrawal hides it again — the marker asserts current truth only
+        box.identityPosture = null;
+        expect(marker.hidden).toBe(true);
+
+        box.destroy()
+    });
+
+    test('a construction-time posture flushes to the marker on the reveal path', () => {
+        const box    = createBox({identityPosture: {conflated: true, seatIdentity: '@neo-opus-vega'}}),
+              marker = box.getReference('operator-identity-warning');
+
+        expect(marker.hidden).toBe(false);
+        expect(marker.text).toContain('@neo-opus-vega');
+
+        box.destroy()
+    });
 });

--- a/test/playwright/unit/apps/agentos/view/fleet/operatorSeatConflationParity.spec.mjs
+++ b/test/playwright/unit/apps/agentos/view/fleet/operatorSeatConflationParity.spec.mjs
@@ -1,0 +1,61 @@
+import {expect, test}                   from '@playwright/test';
+import {describeOperatorSeatConflation} from '../../../../../../../ai/services/fleet/operatorSeatConflation.mjs';
+import FleetCockpit                     from '../../../../../../../apps/agentos/view/fleet/FleetCockpit.mjs';
+
+/**
+ * @summary The parity pin for a DELIBERATE cross-boundary duplication: the seat-conflation
+ * decision exists twice by design — the pure leaf in `ai/services/fleet` (the fleet entry's boot
+ * consumer) and `FleetCockpit#deriveOperatorIdentityPosture` (the pane consumer) — because an
+ * app→Brain runtime import would cost more than three duplicated lines (the parity-twin
+ * philosophy). A duplication defended by a comment decays the first time someone edits one side;
+ * THIS table is what converts the architectural bet into an enforced one. A cross-boundary import
+ * in a TEST is not a runtime coupling — it is the standard pin for a deliberate twin.
+ *
+ * One shared fixture drives BOTH implementations; a divergence fails here instead of surviving
+ * until an incident notices. Every row names the case the form-insensitive canonicalization
+ * exists to handle — including the bare-form viewer, deletable from either side without any
+ * single-sided spec noticing (the reviewed decay path, now closed).
+ */
+test.describe('operatorSeatConflation — cross-boundary parity pin (leaf ↔ cockpit twin)', () => {
+    const REGISTERED = ['@neo-fable-clio', '@neo-opus-vega', 'neo-opus-ada'];
+
+    /**
+     * The ONE shared truth table. `expected: null` asserts the null-not-clean contract on both
+     * sides; the others assert the decision AND the canonical seat identity.
+     */
+    const TABLE = [
+        {label: '@-form viewer vs @-form registered',   viewer: '@neo-fable-clio', expected: {conflated: true,  seatIdentity: '@neo-fable-clio'}},
+        {label: 'bare viewer vs @-form registered',     viewer: 'neo-fable-clio',  expected: {conflated: true,  seatIdentity: '@neo-fable-clio'}},
+        {label: '@-form viewer vs bare registered',     viewer: '@neo-opus-ada',   expected: {conflated: true,  seatIdentity: '@neo-opus-ada'}},
+        {label: 'bare viewer vs bare registered',       viewer: 'neo-opus-ada',    expected: {conflated: true,  seatIdentity: '@neo-opus-ada'}},
+        {label: 'clean operator viewer',                viewer: '@tobiu',          expected: {conflated: false, seatIdentity: '@tobiu'}},
+        {label: 'prefix is not a match',                viewer: '@neo-fable',      expected: {conflated: false, seatIdentity: '@neo-fable'}},
+        {label: 'case is not forgiven',                 viewer: '@NEO-FABLE-CLIO', expected: {conflated: false, seatIdentity: '@NEO-FABLE-CLIO'}},
+        {label: 'blank viewer cannot be judged',        viewer: '   ',             expected: null},
+        {label: 'missing viewer cannot be judged',      viewer: null,              expected: null}
+    ];
+
+    const
+        leafDecision    = viewer => describeOperatorSeatConflation({viewerIdentity: viewer, registeredIds: REGISTERED}),
+        cockpitDecision = viewer => FleetCockpit.prototype.deriveOperatorIdentityPosture.call(
+            {getReference: reference => reference === 'fleet-grid'
+                ? {store: {items: REGISTERED.map(id => ({agentId: String(id).replace(/^@/, '')}))}}
+                : null},
+            viewer
+        );
+
+    for (const {label, viewer, expected} of TABLE) {
+        test(`both twins agree: ${label}`, () => {
+            expect(leafDecision(viewer), 'leaf').toEqual(expected);
+            expect(cockpitDecision(viewer), 'cockpit twin').toEqual(expected)
+        })
+    }
+
+    test('the empty-list null contract holds on both sides — absence of truth is not a clean bill', () => {
+        expect(describeOperatorSeatConflation({viewerIdentity: '@tobiu', registeredIds: []})).toBeNull();
+        expect(FleetCockpit.prototype.deriveOperatorIdentityPosture.call(
+            {getReference: reference => reference === 'fleet-grid' ? {store: {items: []}} : null},
+            '@tobiu'
+        )).toBeNull()
+    })
+});


### PR DESCRIPTION
Resolves neomjs/neo#17310

The operator-seat conflation — a fleet transport whose viewer claim IS a registered agent identity, so every operator send is attributed to that seat — is now NAMED on both surfaces instead of silently executing: the fleet entry warns loudly at boot (the resolved viewer checked against the registry through one pure decision leaf), and the cockpit renders a truth marker directly above the compose surface ("Sending as agent seat @x — operator principal not established"). Detection changes HONESTY, never authority: the compose path stays senderless, the boot never blocks, and the credential journey to a TRUE operator subject is documented at the launcher. The principal model itself stays neomjs/neo-agent-brain#52's, exactly as the ticket's ladder scopes.

Evidence: L3 achieved for the boot half (red→green on the INCIDENT's own configuration: the same gh-auth fallback that mis-attributed the L1 session's sends now boots with the loud named warn — transcript in Test Evidence) → live pane-marker witness required for the compose half (needs a resolved viewer over the authenticated bridge; the embedded pane's SharedWorker cannot reach the fleet transport — the established environment bound). Residual: the AC-4 marker half + the credential-journey walk.

## Deltas from ticket

- **The decision is ONE pure leaf** (`ai/services/fleet/operatorSeatConflation.mjs`): canonicalized comparison + the single warning sentence, consumed by the boot path and spec'd directly. The cockpit half deliberately does NOT import it — the app→Brain boundary (the parity-twin philosophy neomjs/neo#17239 guards) is worth more than three lines of DRY; the cockpit derives the same posture over its provider-owned roster rows, and both sides' JSDoc names the duplication as a boundary decision.
- **Null-not-clean contract:** a missing viewer or an empty roster/registry answers `null` (cannot judge), never `{conflated: false}` — and the pane renders unknown as SILENCE, a warning only on a verified positive. Absence of truth is not a clean bill, and a suspicion is not a fact.
- **The marker is `role: 'alert'` chrome above the compose form** — read before writing starts — styled in the alert-kind token family (`--fm-kind-alert` wash), visually disjoint from the quiet meta family.
- **Registry unavailability degrades the CHECK, never the boot** — the warn's absence in that path is itself logged as non-fatal, so a silent check failure cannot masquerade as a clean posture.

## Test Evidence

- `npx playwright test -c test/playwright/playwright.config.unit.mjs test/playwright/unit/apps/agentos test/playwright/unit/ai/services/fleet` → **1391 passed** (both owning trees; two sibling stubs in the operator-identity suite grew the new surface consciously — the push now carries `identityPosture`, asserted as `null` where no roster truth exists).
- New `operatorSeatConflation.spec.mjs` (5 contract specs: form-insensitive matching both id shapes, clean-vs-null distinction, exact-after-canonicalization matching, the warning sentence's seat + remediation content).
- Extended `operatorMailbox.spec.mjs` (+2: the marker renders ONLY a verified conflation — null and clean stay silent, withdrawal hides; construction-time posture flushes on the reveal path) and `fleetCockpit.spec.mjs` (+3: derive over roster rows, empty-roster null, `loadOperatorIdentity` owner-holds + pushes record AND posture through the accessor).
- **The red→green boot witness, run live on this machine** (the incident's exact configuration — gh-auth fallback resolving a registered agent seat):

```
[fleet] authenticated app<->fleet transport listening on http://127.0.0.1:8083/fleet (viewer: @neo-fable-clio, bearer: generated)
[fleet] OPERATOR-SEAT CONFLATION: the transport viewer (@neo-fable-clio) is a REGISTERED AGENT identity — operator actions through this session will be attributed to that seat. Establish an operator-class credential (an explicit NEO_FLEET_PLANE_BEARER whose subject is the operator, or gh auth as the operator's own identity) so the transport fact becomes true.
```

- apps/agentos + ai/services/fleet surfaces: the suites above (this PR); the operator compose journey class lives with `OperatorMailboxNL.spec.mjs` (e2e witness, outside CI by design).

## Post-Merge Validation

- [ ] Live cockpit with a resolved viewer: the conflation marker renders above the compose form when the seat conflates; a clean operator-class credential shows no marker AND no boot warn.
- [ ] The credential journey walked once as documented (operator-subject `NEO_FLEET_PLANE_BEARER` or operator gh identity) — the transport fact made TRUE, not merely honest.

Residual-Owner: neomjs/neo-agent-brain#28

The marker's live half joins neomjs/neo-agent-brain#28's closing-witness session as its third resident (body edited this round): with the operator at the keyboard, either the boot warn confirms a clean credential or the compose surface shows the marker — the unit suite pins the render, the live session witnesses which truth applies.

Authored by Clio (Claude Fable 5, Claude Code). Session ca3c67ac-a3d6-4e93-98e0-c5f7f65011ee.
