### PR TITLE
feat(ai): an operator can clear tenant-sync backoff without restarting the orchestrator (#17067)

### DIFF
--- a/ai/daemons/orchestrator/services/DeploymentStateBridgeService.mjs
+++ b/ai/daemons/orchestrator/services/DeploymentStateBridgeService.mjs
@@ -2686,7 +2686,12 @@ function summarizeTenantRepoState({
         lastIngestedRev    : shortRevision(normalizedCheckpoint?.lastIngestedRev),
         lastRunAttemptAt   : lastAttempt > 0 ? new Date(lastAttempt).toISOString() : null,
         consecutiveFailures: failures,
-        stopReasonCode     : failures > 0
+        // Operator-consumed backoff clears, surfaced where an operator can see them without a
+        // shell. Absent until one happens, and NOT cleared by later sweeps: it answers "did someone
+        // intervene here, and what did they release", which stays true after the streak moves on.
+        backoffClearedAt          : normalizedCheckpoint?.backoffClearedAt ?? null,
+        backoffClearedFromFailures: numberOrNull(normalizedCheckpoint?.backoffClearedFromFailures),
+        stopReasonCode            : failures > 0
             ? (normalizedCheckpoint?.embeddingRecovery?.causeCode
                 || normalizedCheckpoint?.lastSourceErrorCode
                 || normalizedCheckpoint?.lastErrorCode

--- a/ai/daemons/orchestrator/services/TenantRepoSyncService.mjs
+++ b/ai/daemons/orchestrator/services/TenantRepoSyncService.mjs
@@ -3302,7 +3302,8 @@ class TenantRepoSyncService extends Base {
               // over every checkpoint on disk.
               revisions = await this.readPersistedRevisions({filePath, strict: true}),
               cleared   = [],
-              unchanged = [];
+              unchanged = [],
+              clearedAt = new Date().toISOString();
 
         for (const slug of targetSlugs) {
             const state  = revisions[slug],
@@ -3313,7 +3314,17 @@ class TenantRepoSyncService extends Base {
                 continue
             }
 
-            revisions[slug] = {...state, consecutiveFailures: 0};
+            // The consumption marker is PERSISTED beside the reset, not merely logged: a log line
+            // lives in one container's stdout, while the deployment-state snapshot is the surface an
+            // operator reads without shell access. Recording what the streak WAS matters as much as
+            // when — "cleared at 12:40" tells you an intervention happened, "cleared 42 → 0 at
+            // 12:40" tells you whether the suppression it removed was the one you were chasing.
+            revisions[slug] = {
+                ...state,
+                consecutiveFailures       : 0,
+                backoffClearedAt          : clearedAt,
+                backoffClearedFromFailures: streak
+            };
             cleared.push({repoSlug: slug, previousConsecutiveFailures: streak})
         }
 

--- a/ai/daemons/orchestrator/services/TenantRepoSyncService.mjs
+++ b/ai/daemons/orchestrator/services/TenantRepoSyncService.mjs
@@ -3228,6 +3228,104 @@ class TenantRepoSyncService extends Base {
             );
         }
     }
+
+    /**
+     * @summary Clears the persisted backoff streak for tenant repos, without restarting the process.
+     *
+     * The backoff itself is correct congestion control; what it lacked was an EXIT. Every failure in
+     * a shared-dependency outage lands on the per-repo `consecutiveFailures` counter, so when the
+     * cause is repaired the repos stay suppressed for up to `backoffCapMs` each — and the operator's
+     * only levers were to wait out the cap or restart the orchestrator to clear a counter. That
+     * makes every fix cost a fix plus a wait, and it makes the fix unverifiable in the meantime:
+     * "the repair did not work" and "the lane has not been allowed to try yet" look identical.
+     *
+     * **Why a second process can do this at all.** The streak is not daemon memory — it lives in the
+     * persisted revisions manifest, and {@link #syncTenantRepos} re-reads that manifest at the top of
+     * EVERY sweep. So a one-shot container-plane run that rewrites the counter is observed by the
+     * next sweep of the long-running daemon with no restart and nothing shared but the file. The
+     * caller must hold the same cross-process heavy-maintenance lease the sweep takes; without it
+     * this races a sweep mid-write on the one manifest they share.
+     *
+     * **Only the streak is cleared.** `lastIngestedRev` and the materialization proofs are left
+     * exactly as found: they are the record of what was successfully ingested, and resetting them
+     * would turn "let this lane retry now" into "re-ingest everything from a null base" — a far more
+     * expensive request than the operator made.
+     *
+     * Repos with no persisted entry, or already at zero, are reported as `unchanged` rather than
+     * silently succeeding: an operator who clears a backoff and is told nothing has no way to tell a
+     * completed no-op from a misspelled selector, which is the ambiguity this whole path exists to
+     * remove.
+     *
+     * @param {Object} [options]
+     * @param {String[]|null} [options.onlyRepoSlugs=null] Restrict to these configured slugs; omit for every configured repo. An unknown slug is refused, never silently skipped.
+     * @param {Object|null} [options.tenantReposConfig=null] Injected repo config; defaults to the deployment's. Mirrors {@link #syncTenantRepos}'s seam rather than reading the singleton directly, so a caller can scope this the same way the sweep is scoped.
+     * @param {String|null} [options.revisionsFilePath=null] Manifest path override; defaults to {@link #defaultRevisionsFilePath}.
+     * @param {Function|null} [options.writeLog=null] Structured log sink.
+     * @returns {Promise<{status: String, details: Object}>} `completed` with a per-repo outcome list, or `failed` carrying `KB_TENANT_REPO_SYNC_REPO_NOT_CONFIGURED`.
+     */
+    async clearTenantRepoBackoff({onlyRepoSlugs = null, revisionsFilePath = null, writeLog = null, tenantReposConfig = null} = {}) {
+        const resolvedConfig = tenantReposConfig || AiConfig.data.orchestrator.tenantRepoSync,
+              allRepos       = resolvedConfig.tenantRepos || [],
+              knownSlugs     = allRepos.map(repo => repo.repoSlug);
+
+        // The SAME refusal the sweep gives an unknown selector, deliberately: an operator who
+        // mistypes a slug must get one vocabulary back, not a second one invented for this path.
+        if (onlyRepoSlugs?.length > 0) {
+            const unknownSlugs = onlyRepoSlugs.filter(slug => !knownSlugs.includes(slug));
+
+            if (unknownSlugs.length > 0) {
+                const details = {
+                    reason         : 'repo-not-configured',
+                    reasonCode     : KB_TENANT_REPO_SYNC_REPO_NOT_CONFIGURED,
+                    requestedSlugs : onlyRepoSlugs,
+                    unknownSlugs,
+                    configuredSlugs: knownSlugs
+                };
+
+                writeLog?.('WARN', `[TenantRepoSync] clear-backoff: requested repoSlug(s) not configured: ${unknownSlugs.join(', ')}. Configured: ${knownSlugs.join(', ') || '(none)'}.`);
+
+                return {status: 'failed', details}
+            }
+        }
+
+        const targetSlugs = onlyRepoSlugs?.length > 0 ? onlyRepoSlugs : knownSlugs;
+
+        if (targetSlugs.length === 0) {
+            writeLog?.('INFO', '[TenantRepoSync] clear-backoff: no tenantRepos configured; nothing to clear.');
+
+            return {status: 'completed', details: {reason: 'no-tenant-repos-configured', cleared: [], unchanged: []}}
+        }
+
+        const filePath = revisionsFilePath || this.defaultRevisionsFilePath(),
+              // strict: a corrupt manifest must not be overwritten by a well-meaning reset — the
+              // fail-open read would hand back {} and this method would then persist that emptiness
+              // over every checkpoint on disk.
+              revisions = await this.readPersistedRevisions({filePath, strict: true}),
+              cleared   = [],
+              unchanged = [];
+
+        for (const slug of targetSlugs) {
+            const state  = revisions[slug],
+                  streak = state?.consecutiveFailures ?? 0;
+
+            if (!state || streak === 0) {
+                unchanged.push({repoSlug: slug, consecutiveFailures: streak, reason: state ? 'already-clear' : 'no-persisted-state'});
+                continue
+            }
+
+            revisions[slug] = {...state, consecutiveFailures: 0};
+            cleared.push({repoSlug: slug, previousConsecutiveFailures: streak})
+        }
+
+        if (cleared.length > 0) {
+            await this.writePersistedRevisions({filePath, revisions})
+        }
+
+        writeLog?.('INFO', `[TenantRepoSync] clear-backoff: cleared ${cleared.length} of ${targetSlugs.length} selected repo(s)${cleared.length ? ` (${cleared.map(entry => `${entry.repoSlug} ${entry.previousConsecutiveFailures}->0`).join(', ')})` : ''}; ${unchanged.length} already clear.`);
+
+        return {status: 'completed', details: {cleared, unchanged, filePath}}
+    }
+
 }
 
 export default Neo.setupClass(TenantRepoSyncService);

--- a/ai/daemons/orchestrator/services/tenantRepoCheckpointValidity.mjs
+++ b/ai/daemons/orchestrator/services/tenantRepoCheckpointValidity.mjs
@@ -113,7 +113,10 @@ export function normalizeTenantRepoCheckpointState(value) {
             corpusOutstanding  : null,
             // And the fence censuses: null is "never observed", never "zero fenced".
             undeliverableChunks: null,
-            contentPoisonChunks: null
+            contentPoisonChunks: null,
+            // A bare SHA predates the operator-clear marker too, so no intervention was recorded.
+            backoffClearedAt          : null,
+            backoffClearedFromFailures: null
         };
     }
 
@@ -151,7 +154,16 @@ export function normalizeTenantRepoCheckpointState(value) {
         // Two fence families, two censuses, one reader. A record written before the content-poison
         // census existed normalizes to null — "never observed", which is exactly what it is.
         undeliverableChunks: normalizeFenceCensus(value.undeliverableChunks),
-        contentPoisonChunks: normalizeFenceCensus(value.contentPoisonChunks)
+        contentPoisonChunks: normalizeFenceCensus(value.contentPoisonChunks),
+        // Operator-consumed backoff clear. This normalizer is an ALLOWLIST — a field absent from it
+        // is silently dropped on read, so a marker written by the clear path would vanish before any
+        // reader saw it. Kept as a plain ISO string / count rather than parsed: the snapshot renders
+        // it, nothing branches on it, and a stricter shape would turn an old record into a malformed
+        // checkpoint over a field that is purely informational.
+        backoffClearedAt          : typeof value.backoffClearedAt === 'string' && value.backoffClearedAt
+            ? value.backoffClearedAt
+            : null,
+        backoffClearedFromFailures: normalizeFailureCount(value.backoffClearedFromFailures) || null
     };
 }
 

--- a/ai/scripts/maintenance/syncTenantRepos.mjs
+++ b/ai/scripts/maintenance/syncTenantRepos.mjs
@@ -54,7 +54,7 @@ import {
  * @returns {Object} Parsed replay intent, optional help flag, and selected repo slugs.
  */
 function parseArgs(argv) {
-    const args = {fullReplay: false, repoSlugs: []};
+    const args = {fullReplay: false, repoSlugs: [], clearBackoff: false};
     for (let i = 2; i < argv.length; i++) {
         const v = argv[i];
         if (v === '--repo-slug' || v === '-r') {
@@ -66,6 +66,8 @@ function parseArgs(argv) {
             i++;
         } else if (v === '--full') {
             args.fullReplay = true;
+        } else if (v === '--clear-backoff') {
+            args.clearBackoff = true;
         } else if (v === '--help' || v === '-h') {
             args.help = true;
         } else {
@@ -77,11 +79,19 @@ function parseArgs(argv) {
         throw new Error('--full requires at least one --repo-slug selector.')
     }
 
+    // The two modes answer different questions and must not be combined: --full says "re-ingest
+    // this repo from a null base", --clear-backoff says "let this repo attempt again on its normal
+    // cadence". Silently running one while the operator asked for both is the kind of no-op this
+    // path exists to eliminate.
+    if (args.clearBackoff && args.fullReplay) {
+        throw new Error('--clear-backoff cannot be combined with --full; clear the backoff, then run the replay if you still want one.')
+    }
+
     return args;
 }
 
 function printHelp() {
-    console.log(`Usage: node ./ai/scripts/maintenance/syncTenantRepos.mjs [--repo-slug <slug>]... [--full]
+    console.log(`Usage: node ./ai/scripts/maintenance/syncTenantRepos.mjs [--repo-slug <slug>]... [--full | --clear-backoff]
 
 Forces a single tenant-repo-sync sweep. With no flags, processes every configured
 tenantRepo. Pass --repo-slug to scope to a specific repo (repeatable).
@@ -92,6 +102,13 @@ Runs first acquire the deployment-wide heavy-maintenance lease, then the
 tenant-repo-sync lease next to the revisions manifest. If Dream/REM, another
 heavy lane, or another sync is active, this CLI exits immediately with code 4
 instead of racing it. Crashed lease owners recover automatically; simply re-run.
+
+Pass --clear-backoff to reset the per-repo failure streak that drives suppression,
+without a process restart and without touching stored checkpoints. Scope it with
+--repo-slug, or omit the selector to clear every configured repo. The next sweep
+re-reads the manifest, so the release is observed without restarting the daemon.
+Use it after repairing a shared dependency, when the streak recorded during the
+outage would otherwise suppress a lane that now works.
 
 Exit codes:
   0  completed (or partial-completed with at least one repo successful)
@@ -158,23 +175,37 @@ function buildRunTaskOptions({parsed, taskStateService, writeLog}) {
  * @param {Function} options.writeLog
  * @param {Function} [options.runTaskImpl] Test seam for the service dispatch.
  * @param {Function|null} [options.withLeaseImpl] Test seam for the lease wrapper.
+ * @param {Function} [options.clearBackoffImpl] Test seam for the clear-backoff dispatch.
  * @returns {Promise<Object>} Global lease outcome containing the service result when admitted.
  */
 function runTenantRepoSyncWithGlobalLease({
     parsed,
     taskStateService,
     writeLog,
-    runTaskImpl   = options => TenantRepoSyncService.runTask(options),
-    withLeaseImpl = null
+    runTaskImpl      = options => TenantRepoSyncService.runTask(options),
+    withLeaseImpl    = null,
+    clearBackoffImpl = options => TenantRepoSyncService.clearTenantRepoBackoff(options)
 }) {
     const withLease = withLeaseImpl ?? withHeavyMaintenanceLease;
 
+    // Both modes run UNDER the same lease, and that is not symmetry for its own sake: the clear
+    // rewrites the very revisions manifest a concurrent sweep reads at its top and writes at its
+    // end. Outside the lease this would race a sweep mid-flight and could drop a checkpoint the
+    // sweep had just committed — losing ingestion progress to fix a backoff, which is a strictly
+    // worse trade than the wait it removes.
+    const invoke = parsed.clearBackoff
+        ? () => clearBackoffImpl({
+            onlyRepoSlugs: parsed.repoSlugs.length > 0 ? parsed.repoSlugs : null,
+            writeLog
+        })
+        : () => runTaskImpl(buildRunTaskOptions({parsed, taskStateService, writeLog}));
+
     return withLease(
-        () => runTaskImpl(buildRunTaskOptions({parsed, taskStateService, writeLog})),
+        invoke,
         {
             leasePath   : resolveHeavyMaintenanceLeasePath({dataDir: AiConfig.orchestrator.dataDir}),
             owner       : 'tenant-repo-sync',
-            reason      : 'container-one-shot',
+            reason      : parsed.clearBackoff ? 'container-clear-backoff' : 'container-one-shot',
             staleAfterMs: AiConfig.orchestrator.heavyMaintenanceLease.staleAfterMs,
             metadata    : {script: 'ai/scripts/maintenance/syncTenantRepos.mjs'}
         }

--- a/test/playwright/unit/ai/daemons/orchestrator/services/TenantRepoSyncService.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/services/TenantRepoSyncService.spec.mjs
@@ -275,7 +275,20 @@ test.describe('TenantRepoSyncService (#11790)', () => {
         expect(persisted[throttled].lastRunAttemptAt).toBe(111);
         expect(persisted[throttled].ingestContractVersion).toBe(3);
         // and a repo outside the selector is not collateral
-        expect(persisted[untouched].consecutiveFailures).toBe(7)
+        expect(persisted[untouched].consecutiveFailures).toBe(7);
+
+        // AC-1's third clause: the consumption is RECORDED, not just performed. Persisted beside the
+        // reset so the deployment-state snapshot can surface it to an operator with no shell — and
+        // carrying what the streak was, because "cleared 42 -> 0" answers a question "cleared" does
+        // not: whether the suppression removed was the one being chased.
+        expect(persisted[throttled].backoffClearedFromFailures).toBe(42);
+        expect(typeof persisted[throttled].backoffClearedAt).toBe('string');
+        // an unchanged repo earns no marker — a clear that did nothing must not read as an
+        // intervention later. NULL rather than absent: the checkpoint normalizer is an allowlist
+        // that materializes every field, so "never cleared" is present-and-null exactly like every
+        // other unobserved field in that shape.
+        expect(persisted[healthy].backoffClearedAt).toBeNull();
+        expect(persisted[untouched].backoffClearedAt).toBeNull()
     });
 
     test('clear-backoff refuses an unknown slug with the sweep\'s own error code, rather than clearing nothing quietly', () => {

--- a/test/playwright/unit/ai/daemons/orchestrator/services/TenantRepoSyncService.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/services/TenantRepoSyncService.spec.mjs
@@ -7266,6 +7266,78 @@ test.describe('syncTenantRepos container-plane CLI (#15748)', () => {
         });
     });
 
+    // The clear rewrites the same revisions manifest a sweep reads at its top and writes at its end,
+    // so it has to hold the lease for the same reason the sweep does. The sibling lease cases above
+    // all drive `runTaskImpl`; without these two, hoisting the clear outside `withLease` — the exact
+    // shape a later refactor would reach for, since the clear needs no taskStateService — passes.
+    test('a held lease defers the CLEAR as well, so a reset never races a sweep mid-flight', async () => {
+        await withTempLease(async ({leasePath}) => {
+            const incumbent = await acquireHeavyMaintenanceLease({
+                leasePath,
+                owner       : 'dream',
+                reason      : 'scheduled',
+                staleAfterMs: 60_000
+            });
+            const clearBackoffCalls = [];
+
+            try {
+                const outcome = await runTenantRepoSyncWithGlobalLease({
+                    parsed          : {fullReplay: false, repoSlugs: ['org/a'], clearBackoff: true},
+                    taskStateService: {name: 'task-state'},
+                    writeLog        : () => {},
+                    runTaskImpl     : () => { throw new Error('the clear path must never run a sweep'); },
+                    clearBackoffImpl: options => {
+                        clearBackoffCalls.push(options);
+                        return {status: 'completed', details: {cleared: [], unchanged: []}};
+                    },
+                    withLeaseImpl: injectLeasePath(leasePath)
+                });
+
+                expect(outcome.status).toBe('held');
+                expect(outcome.lease.owner).toBe('dream');
+                expect(clearBackoffCalls).toHaveLength(0);
+            } finally {
+                await releaseHeavyMaintenanceLease({
+                    leasePath,
+                    token: incumbent.lease.token
+                });
+            }
+        });
+    });
+
+    test('the clear dispatches under the lease with its own reason, maps selectors, and releases', async () => {
+        for (const [repoSlugs, expectedOnlyRepoSlugs] of [[['org/a', 'org/b'], ['org/a', 'org/b']], [[], null]]) {
+            await withTempLease(async ({leasePath}) => {
+                const writeLog          = () => {};
+                const clearBackoffCalls = [];
+                const leaseOptions      = [];
+                const outcome           = await runTenantRepoSyncWithGlobalLease({
+                    parsed          : {fullReplay: false, repoSlugs, clearBackoff: true},
+                    taskStateService: {name: 'task-state'},
+                    writeLog,
+                    runTaskImpl     : () => { throw new Error('the clear path must never run a sweep'); },
+                    clearBackoffImpl: async options => {
+                        clearBackoffCalls.push(options);
+                        return {status: 'completed', details: {cleared: [{repoSlug: 'org/a', previousConsecutiveFailures: 42}], unchanged: []}};
+                    },
+                    withLeaseImpl: (task, options) => {
+                        leaseOptions.push(options);
+                        return injectLeasePath(leasePath)(task, options);
+                    }
+                });
+
+                expect(outcome.status).toBe('completed');
+                expect(outcome.result.details.cleared).toEqual([{repoSlug: 'org/a', previousConsecutiveFailures: 42}]);
+                // The reset takes its own lease reason: an operator reading a held-lease refusal has to
+                // be able to tell which of the two container-plane paths is holding it.
+                expect(leaseOptions[0].reason).toBe('container-clear-backoff');
+                expect(leaseOptions[0].owner).toBe('tenant-repo-sync');
+                expect(clearBackoffCalls).toEqual([{onlyRepoSlugs: expectedOnlyRepoSlugs, writeLog}]);
+                expect((await inspectHeavyMaintenanceLease({leasePath})).status).toBe('missing');
+            });
+        }
+    });
+
     test('resolveExitCode maps runTask results onto the documented exit-code contract (#15763)', () => {
         expect(resolveExitCode({status: 'completed', details: {}})).toBe(0);
         expect(resolveExitCode({status: 'skipped', details: {reasonCode: 'KB_TENANT_REPO_SYNC_LEASE_HELD'}})).toBe(4);

--- a/test/playwright/unit/ai/daemons/orchestrator/services/TenantRepoSyncService.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/services/TenantRepoSyncService.spec.mjs
@@ -253,6 +253,26 @@ test.describe('TenantRepoSyncService (#11790)', () => {
             }
         });
 
+        // AC-1's "reflected in the next sweep" clause, asserted through the production derivation
+        // rather than through the streak value that feeds it. `consecutiveFailures === 0` is a PROXY
+        // for release; `isRepoDue` is what the sweep actually calls, so it is what has to flip.
+        // The window is chosen to discriminate: at a streak of 42 the cadence caps at backoffCapMs
+        // (120s) and the repo is suppressed at now-111; cleared, it falls back to the 60s base and
+        // is due. A `now` outside that band would pass in both directions and prove nothing.
+        const dueStateFor = state => isRepoDue({
+            repo              : {tenantId: 't1', repoSlug: throttled},
+            persistedRepoState: state,
+            now               : 100_000,
+            globalCadenceMs   : 60_000,
+            backoffCapMs      : 120_000
+        });
+
+        const beforeClear = await TenantRepoSyncService.readPersistedRevisions({filePath: revisionsFile});
+
+        // and the suppression is attributable to the STREAK: no embeddingRecovery in this fixture,
+        // so `recoveryBypass` cannot be what releases the lane a moment from now.
+        expect(dueStateFor(beforeClear[throttled])).toMatchObject({due: false, recoveryBypass: false, backoffCapped: true});
+
         const result = await TenantRepoSyncService.clearTenantRepoBackoff({
             onlyRepoSlugs    : [throttled, healthy],
             revisionsFilePath: revisionsFile,
@@ -288,7 +308,13 @@ test.describe('TenantRepoSyncService (#11790)', () => {
         // that materializes every field, so "never cleared" is present-and-null exactly like every
         // other unobserved field in that shape.
         expect(persisted[healthy].backoffClearedAt).toBeNull();
-        expect(persisted[untouched].backoffClearedAt).toBeNull()
+        expect(persisted[untouched].backoffClearedAt).toBeNull();
+
+        // the other half of the clause: the same derivation, same instant, now releases the lane —
+        // and the repo left outside the selector stays suppressed, so this is a scoped release
+        // rather than a manifest-wide one.
+        expect(dueStateFor(persisted[throttled])).toMatchObject({due: true, dueReason: 'cadence'});
+        expect(dueStateFor(persisted[untouched]).due).toBe(false)
     });
 
     test('clear-backoff refuses an unknown slug with the sweep\'s own error code, rather than clearing nothing quietly', () => {

--- a/test/playwright/unit/ai/daemons/orchestrator/services/TenantRepoSyncService.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/services/TenantRepoSyncService.spec.mjs
@@ -236,6 +236,65 @@ test.describe('TenantRepoSyncService (#11790)', () => {
         TenantRepoSyncService.clearEmbeddingRecoveryProbeState();
     });
 
+    test('clear-backoff resets ONLY the streak, leaves every checkpoint field untouched, and never silently no-ops', async () => {
+        // The safety property is the second assertion, not the first. Resetting `lastIngestedRev`
+        // alongside the streak would turn "let this lane retry now" into "re-ingest from a null
+        // base" — a far more expensive request than the operator made, and one they cannot undo.
+        const throttled = 'acme/throttled',
+              healthy   = 'acme/healthy',
+              untouched = 'acme/untouched';
+
+        await TenantRepoSyncService.writePersistedRevisions({
+            filePath : revisionsFile,
+            revisions: {
+                [throttled]: {lastIngestedRev: 'sha-throttled', lastRunAttemptAt: 111, consecutiveFailures: 42, ingestContractVersion: 3},
+                [healthy]  : {lastIngestedRev: 'sha-healthy',   lastRunAttemptAt: 222, consecutiveFailures: 0},
+                [untouched]: {lastIngestedRev: 'sha-untouched', lastRunAttemptAt: 333, consecutiveFailures: 7}
+            }
+        });
+
+        const result = await TenantRepoSyncService.clearTenantRepoBackoff({
+            onlyRepoSlugs    : [throttled, healthy],
+            revisionsFilePath: revisionsFile,
+            tenantReposConfig: {tenantRepos: [throttled, healthy, untouched].map(repoSlug => ({repoSlug, tenantId: 't1'}))}
+        });
+
+        expect(result.status).toBe('completed');
+        expect(result.details.cleared).toEqual([{repoSlug: throttled, previousConsecutiveFailures: 42}]);
+        // Already-clear is REPORTED, not folded into success: an operator who clears a backoff and
+        // is told nothing cannot distinguish a completed no-op from a mistyped selector.
+        expect(result.details.unchanged).toEqual([
+            {repoSlug: healthy, consecutiveFailures: 0, reason: 'already-clear'}
+        ]);
+
+        const persisted = await TenantRepoSyncService.readPersistedRevisions({filePath: revisionsFile});
+
+        expect(persisted[throttled].consecutiveFailures).toBe(0);
+        // every other field survives verbatim — the streak is the only thing this operation owns
+        expect(persisted[throttled].lastIngestedRev).toBe('sha-throttled');
+        expect(persisted[throttled].lastRunAttemptAt).toBe(111);
+        expect(persisted[throttled].ingestContractVersion).toBe(3);
+        // and a repo outside the selector is not collateral
+        expect(persisted[untouched].consecutiveFailures).toBe(7)
+    });
+
+    test('clear-backoff refuses an unknown slug with the sweep\'s own error code, rather than clearing nothing quietly', () => {
+        // Same vocabulary as `syncTenantRepos`, deliberately: an operator who mistypes a slug gets
+        // one error code across both entry paths, and the CLI's existing exit-code-3 mapping needed
+        // no change to cover this mode.
+        return TenantRepoSyncService.clearTenantRepoBackoff({
+            onlyRepoSlugs    : ['acme/known', 'acme/typo'],
+            revisionsFilePath: revisionsFile,
+            tenantReposConfig: {tenantRepos: [{repoSlug: 'acme/known', tenantId: 't1'}]}
+        }).then(result => {
+            expect(result.status).toBe('failed');
+            expect(result.details.reasonCode).toBe('KB_TENANT_REPO_SYNC_REPO_NOT_CONFIGURED');
+            expect(result.details.unknownSlugs).toEqual(['acme/typo']);
+            // the valid half is NOT partially applied — a refused selector clears nothing
+            expect(result.details.cleared).toBeUndefined()
+        })
+    });
+
     test('embedding recovery checkpoints degrade by omission, retain restart truth, and consumed grants become history (#16692)', async () => {
         const
             episodeId    = 'a'.repeat(32),
@@ -7059,14 +7118,37 @@ test.describe('syncTenantRepos container-plane CLI (#15748)', () => {
             '-r',
             'org/b'
         ])).toEqual({
-            fullReplay: true,
-            repoSlugs : ['org/a', 'org/b']
+            clearBackoff: false,
+            fullReplay  : true,
+            repoSlugs   : ['org/a', 'org/b']
         });
     });
 
     test('rejects full replay without a repo selector', () => {
         expect(() => parseArgs(['node', 'syncTenantRepos.mjs', '--full']))
             .toThrow('--full requires at least one --repo-slug selector.')
+    });
+
+    test('parses --clear-backoff, scoped and unscoped', () => {
+        expect(parseArgs(['node', 'syncTenantRepos.mjs', '--clear-backoff'])).toEqual({
+            clearBackoff: true,
+            fullReplay  : false,
+            repoSlugs   : []
+        });
+
+        expect(parseArgs(['node', 'syncTenantRepos.mjs', '--clear-backoff', '-r', 'org/a'])).toEqual({
+            clearBackoff: true,
+            fullReplay  : false,
+            repoSlugs   : ['org/a']
+        });
+    });
+
+    test('refuses --clear-backoff combined with --full', () => {
+        // The two modes answer different questions — "re-ingest from a null base" versus "let this
+        // lane attempt again on its normal cadence". Running one while the operator asked for both
+        // is the silent no-op this whole path exists to remove, so the parser refuses instead.
+        expect(() => parseArgs(['node', 'syncTenantRepos.mjs', '--clear-backoff', '--full', '-r', 'org/a']))
+            .toThrow('--clear-backoff cannot be combined with --full')
     });
 
     test('dispatches full replay and selectors to TenantRepoSyncService', () => {

--- a/test/playwright/unit/ai/scripts/maintenance/manualHeavyMaintenanceScriptLeaseAdoption.spec.mjs
+++ b/test/playwright/unit/ai/scripts/maintenance/manualHeavyMaintenanceScriptLeaseAdoption.spec.mjs
@@ -86,9 +86,13 @@ test.describe('Manual heavy-maintenance script lease adoption', () => {
             heldExitPattern: /process\.exit\(0\)/
         },
         {
-            file           : 'maintenance/syncTenantRepos.mjs',
-            owner          : 'tenant-repo-sync',
-            reason         : 'container-one-shot',
+            file : 'maintenance/syncTenantRepos.mjs',
+            owner: 'tenant-repo-sync',
+            // Two container-plane modes, so two declared reasons. The distinction is operational,
+            // not cosmetic: a held lease reading 'container-one-shot' means a full sweep is running
+            // and the caller should wait it out, while 'container-clear-backoff' means another
+            // operator is doing the near-instant reset. Same owner cannot tell those apart.
+            reason         : ['container-clear-backoff', 'container-one-shot'],
             invocation     : 'withLeaseImpl ?? withHeavyMaintenanceLease',
             heldExitPattern: /process\.exit\(4\)/
         }
@@ -128,9 +132,22 @@ test.describe('Manual heavy-maintenance script lease adoption', () => {
             expect(optionsStart, `${file}: wrapper options must begin before leasePath`).toBeGreaterThan(invocationIndex);
 
             const wrapperOptions = source.slice(optionsStart);
+            // A script may declare more than one container-plane mode, and then `reason` is a
+            // ternary rather than a bare literal. The set stays STATIC either way: every branch must
+            // be a literal drawn from the declared list, so a script that grows a third mode — or
+            // computes its reason at runtime — fails here instead of shipping a lease reason no
+            // reader of this table knows about. Widening this to "any expression" would retire the
+            // only check that keeps the declared owners/reasons honest against the source.
+            const reasons = (Array.isArray(reason) ? reason : [reason])
+                .map(item => item.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'));
+            const reasonLit   = `['"](?:${reasons.join('|')})['"]`;
+            const reasonMatch = reasons.length > 1
+                ? `(?:${reasonLit}|[^,\\n]*\\?\\s*${reasonLit}\\s*:\\s*${reasonLit})`
+                : reasonLit;
+
             expect(wrapperOptions).toMatch(new RegExp(
                 `^\\{\\s*leasePath\\s*:\\s*resolveHeavyMaintenanceLeasePath\\(\\{dataDir\\s*:\\s*AiConfig\\.orchestrator\\.dataDir\\}\\)\\s*,` +
-                `\\s*owner\\s*:\\s*['"]${owner}['"]\\s*,\\s*reason\\s*:\\s*['"]${reason}['"]`
+                `\\s*owner\\s*:\\s*['"]${owner}['"]\\s*,\\s*reason\\s*:\\s*${reasonMatch}`
             ));
         });
 


### PR DESCRIPTION
Resolves #17067

An operator who repairs the cause of a tenant-sync outage still had to wait out the backoff it left behind — up to two hours per repo — or restart the orchestrator to clear a counter. This adds the missing exit: `--clear-backoff` on the existing container-plane CLI, resetting the per-repo failure streak that drives suppression, consumed by the running daemon on its next sweep.

Evidence: L2 (spec-driven contract tests over real manifest read/write, the production `isRepoDue` derivation, and CLI lease dispatch through injected seams) → L2 required (every AC-1 clause is reachable in-sandbox; the in-container run below is deployment verification of shipped code, not an unmet AC). No residuals.

## What this delivers

AC-1 is one sentence with four clauses, and each one is a separate design decision:

**1. Clears for a named repo and for all repos.** `--repo-slug` scopes it (repeatable); omitting the selector clears every configured repo. A repo outside the selector is not collateral.

**2. Without a process restart, reflected in the next sweep.** The clear mutates the *existing* persisted revisions manifest — the same file the sweep reads at its top. `consecutiveFailures` is the only input to the backoff decision, so zeroing it releases the lane on the next evaluation with no new state, no second source of truth about when a repo may run, and no restart. This is the mechanism the ticket's Contract Ledger pins, and it is why no signal-file or IPC channel was introduced.

**3. An unknown identifier is rejected with a named error, never a silent no-op.** It reuses the sweep's own `KB_TENANT_REPO_SYNC_REPO_NOT_CONFIGURED`, deliberately: an operator who mistypes a slug gets one vocabulary across both entry paths rather than a second invented for this one. That reuse paid measurably — `resolveExitCode` needed **zero changes**, because exit code 3 was already wired to that reason.

**4. Consumption is recorded in the deployment-state snapshot.** `backoffClearedAt` and `backoffClearedFromFailures` are persisted beside the reset and surfaced per repo. A log line lives in one container's stdout; the snapshot is what an operator reads without shell access. Recording *what the streak was* matters as much as when — "cleared at 12:40" says an intervention happened, "cleared 42 → 0 at 12:40" says whether the suppression removed was the one being chased.

## Two constraints worth the reviewer's attention

**Only the streak is cleared.** `lastIngestedRev` and the materialization proofs survive verbatim. Resetting them alongside the streak would silently convert "let this lane retry now" into "re-ingest from a null base" — a far more expensive request than the operator made, and one they cannot undo. This is the property the mutation test targets, not the reset itself.

**The clear runs under the same heavy-maintenance lease as the sweep.** Not symmetry for its own sake: the clear rewrites the very manifest a concurrent sweep reads at its top and commits at its end. Outside the lease it would race a sweep mid-flight and could drop a checkpoint that sweep had just committed — losing ingestion progress in order to fix a backoff, which is strictly worse than the wait it removes. It takes its own lease reason (`container-clear-backoff`) so a held-lease refusal names which of the two container-plane paths is holding.

`--clear-backoff` refuses combination with `--full`. They answer different questions — "attempt again on the normal cadence" versus "re-ingest from a null base" — and silently running one while the operator asked for both is exactly the class of no-op this path exists to eliminate.

## Deltas from ticket

- **No new MCP tool**, per the ledger's explicit disposition. The auto-release path for healed shared dependencies already shipped (#16712 / #16713); this lever exists for repair classes no canary observes — credentials, refs, config — whose operators by definition already hold plane access.
- **No `nextAttemptAt` alias.** The ticket's struck AC-4 called for it; the snapshot already exposes `nextDueAt` for that concept, and adding a second name would have shipped the duplicate-alias failure that row's own rule exists to prevent.
- **`unchanged` is reported, not folded into success.** Not specified by the AC. An operator told only "completed" cannot distinguish a clear that did nothing from a mistyped selector — the same silent-no-op failure mode the AC names, one level down.
- **A repo with no persisted state earns no marker.** A clear that changed nothing must not read later as an intervention that happened.

## Test Evidence

`npm run test-unit` — the **full** unit suite, **14112 passed**. Then `test/playwright/unit/ai/scripts/ + ai/daemons/orchestrator/` — **3800 passed**.

**The full-suite run is here because the directory run was not the blast radius, and CI proved it.** I first validated against `ai/daemons/orchestrator/` (1636 passed) and reported that as the blast radius. It was not: `manualHeavyMaintenanceScriptLeaseAdoption.spec.mjs` lives in `ai/scripts/` and statically pins every manual heavy-maintenance CLI to a literal `{leasePath, owner, reason}` options object. Adding a second container-plane mode made `reason` a ternary, which that guard read as an undeclared shape and refused — correctly. A directory narrower than the suite CI runs is not a blast radius; it is a sample.

Three red-proofs, each verified to fail on the specific defect it names:

| Property | Mutation | Result |
|---|---|---|
| Checkpoints survive the clear | make the clear also null `lastIngestedRev` | fails exactly the checkpoint-preservation case |
| The clear holds the lease | hoist the clear outside `withLease` | held-lease case fails (clear dispatched anyway); lease-reason case fails (no lease taken) |
| The lane is actually released | floor the backoff multiplier so a cleared streak stays suppressed | fails the `isRepoDue` assertion **while every `consecutiveFailures === 0` assertion above it still passes** |
| The lease-adoption guard is still strict | declare an undeclared `reason` in the source | the guard rejects it, so enumerating the allowed set did not soften it into "any expression" |

That third row is the one that changed the diff. The suite originally asserted `consecutiveFailures === 0` — the *input* to the sweep's decision rather than the decision. A change to `isRepoDue` that kept a cleared lane suppressed would have left the proxy green and AC-1 broken, so both directions now run through `isRepoDue` itself, in a window chosen to discriminate (at streak 42 the cadence caps and the repo is suppressed; cleared, it falls back to base cadence and is due). `recoveryBypass` is false throughout, so the release is attributable to the cleared streak and not to an unrelated bypass.

One transient red was observed in a single scoped re-run immediately after an aborted mutation run (`TenantRepoSyncService.spec.mjs` deferred-repo publishing case). It did not reproduce, including in the full-suite run above; recorded here rather than omitted.

**The two reasons earn their keep**, which is why the guard was widened rather than the ternary removed: a held lease reading `container-one-shot` means a full sweep is running and the caller should wait it out, while `container-clear-backoff` means another operator is doing the near-instant reset. The shared `owner` cannot distinguish those, and the wait they imply differs by minutes.

## Post-Merge Validation

Inside the orchestrator container, against a repo showing `status: backoff-suppressed`:

```
node ./ai/scripts/maintenance/syncTenantRepos.mjs --clear-backoff --repo-slug <slug>
```

Expect exit `0` and a `cleared <slug> N->0` log line; exit `3` for an unconfigured slug; exit `4` if a heavy lane holds the lease. Then confirm the deployment-state snapshot shows `backoffClearedFromFailures: N` for that repo and that the next sweep attempts it rather than logging `suppressed by backoff`.

Authored by Grace (Claude Opus 5, Claude Code). Session ad99f59b-9d2c-4f82-b6ce-8c8357ef1879.
