### PR TITLE
feat(ai): the merge-readiness observation reports which commit earned the approval (#17339)

### DIFF
--- a/ai/scripts/lifecycle/validateMergeReady.mjs
+++ b/ai/scripts/lifecycle/validateMergeReady.mjs
@@ -47,7 +47,9 @@ export const MERGEABLE_STATES = ['CLEAN', 'UNSTABLE'];
  * @param {String} [pr.mergeStateStatus] GitHub mergeStateStatus (`CLEAN` | `UNSTABLE` | `DIRTY` | `BEHIND` | `BLOCKED` | ...); `undefined` (not fetched) fails closed.
  * @param {String[]} [pr.reviewRequests] Logins of still-requested reviewers (the explicit author/operator contract); `undefined` (not fetched) fails closed, `[]` asserts fetched-and-empty.
  * @param {String[]} [pr.disposedReviewers] Requested reviewers already disposed (formal review / visible step-out / unrequest).
- * @returns {{strictMergeReady: Boolean, blockers: String[]}}
+ * @param {String} [pr.approvedAtOid] Commit oid the approving review was submitted against. Optional: absent means the anchor is not reported, never that it is fresh.
+ * @param {String} [pr.headRefOid] Current head oid, paired with `approvedAtOid` to surface a stale approval anchor.
+ * @returns {{strictMergeReady: Boolean, blockers: String[], advisories: String[]}}
  */
 export function validateMergeReady(pr = {}) {
     const {
@@ -57,10 +59,13 @@ export function validateMergeReady(pr = {}) {
         checksGreen,
         mergeStateStatus,
         reviewRequests,
-        disposedReviewers = []
+        disposedReviewers = [],
+        approvedAtOid,
+        headRefOid
     } = pr;
 
-    const blockers = [];
+    const blockers   = [],
+          advisories = [];
 
     if (state === undefined) {
         blockers.push('state was not fetched — cannot certify the pull request is open; failing closed.');
@@ -76,6 +81,26 @@ export function validateMergeReady(pr = {}) {
 
     if (reviewDecision !== 'APPROVED') {
         blockers.push(`reviewDecision is '${reviewDecision ?? 'none'}', not APPROVED.`);
+    }
+
+    // The anchor, and it is deliberately an ADVISORY rather than a blocker.
+    //
+    // `reviewDecision: APPROVED` says a verdict exists; it never says which commit earned it. A
+    // rebase or a fixup moves the head and leaves the badge untouched, so the board reads APPROVED
+    // for a commit nobody has read — and the only surfaces that notice are a human remembering, or
+    // a peer checking by hand. This surfaces the pair so the reader can judge.
+    //
+    // NOT a blocker, because most stale anchors are content-free: a rebase over data-sync commits
+    // moves every sha and changes nothing anyone reviewed. Blocking those would red every rebased
+    // PR in the repo and train reviewers to ignore the signal, which costs more than the gap.
+    // Whether the delta MATTERS is a judgement over the diff, and this function holds no diff.
+    //
+    // Un-fetched is silence rather than a fail-closed block, which inverts this module's rule for
+    // every other field — deliberately. The other fields are part of the merge-ready PREDICATE, so
+    // an un-queried one cannot certify and must block. The anchor certifies nothing; it is a
+    // reporting channel, and a caller that never asks for it is not making a weaker claim.
+    if (approvedAtOid && headRefOid && approvedAtOid !== headRefOid) {
+        advisories.push(`approval anchor is stale: reviewDecision APPROVED was earned at '${approvedAtOid}', head is now '${headRefOid}'. The badge does not degrade when the head moves — confirm the delta is content-free for the reviewed paths (diff EVERYTHING and subtract pipeline-owned trees; an enumerated path list answers only "did anything change where I thought to look"), or re-request review.`);
     }
 
     // Fail CLOSED on un-fetched fields: a field that was never queried cannot certify readiness,
@@ -101,7 +126,7 @@ export function validateMergeReady(pr = {}) {
         }
     }
 
-    return {strictMergeReady: blockers.length === 0, blockers};
+    return {strictMergeReady: blockers.length === 0, blockers, advisories};
 }
 
 export default validateMergeReady;

--- a/ai/services/github-workflow/PullRequestService.mjs
+++ b/ai/services/github-workflow/PullRequestService.mjs
@@ -411,6 +411,21 @@ function normalizeMergeReadinessSnapshot(pullRequest) {
     const reviewConnection = pullRequest.reviewRequests;
     const reviewers        = (reviewConnection?.nodes || []).map(normalizeRequestedReviewer)
         .sort((a, b) => stableStringify(a).localeCompare(stableStringify(b)));
+    // Only APPROVED reviews are carried, and the narrowing is deliberate rather than incidental.
+    // This collection exists to answer "which commit earned the approval", and it also enters the
+    // double-read drift comparison — so keeping COMMENTED/PENDING reviews would fail observations
+    // with SOURCE_CHANGED_DURING_READ every time a peer left a comment mid-read, for a change that
+    // moves no readiness. A CHANGES_REQUESTED landing mid-read still trips the comparison, through
+    // `reviewDecision`, which is where that state actually lives.
+    const reviewsConnection = pullRequest.reviews;
+    const approvals         = (reviewsConnection?.nodes || [])
+        .filter(node => node?.state === 'APPROVED' && node?.commit?.oid && node?.submittedAt)
+        .map(node => ({oid: node.commit.oid, submittedAt: node.submittedAt}))
+        // Sorted rather than trusting connection order: the caller reads `.at(-1)` as "latest", and
+        // an ordering assumption that holds today would fail silently — as a WRONG anchor, not a
+        // missing one. `oid` breaks ties so two approvals sharing a timestamp stay deterministic
+        // across the two reads, which the drift comparison requires.
+        .sort((a, b) => a.submittedAt.localeCompare(b.submittedAt) || a.oid.localeCompare(b.oid));
     const commit            = pullRequest.commits?.nodes?.[0]?.commit || null;
     const rollup            = commit?.statusCheckRollup;
     const contextConnection = rollup?.contexts;
@@ -431,6 +446,11 @@ function normalizeMergeReadinessSnapshot(pullRequest) {
             available  : Boolean(reviewConnection && Array.isArray(reviewConnection.nodes)),
             hasNextPage: Boolean(reviewConnection?.pageInfo?.hasNextPage),
             nodes      : reviewers
+        },
+        approvals       : {
+            available      : Boolean(reviewsConnection && Array.isArray(reviewsConnection.nodes)),
+            hasPreviousPage: Boolean(reviewsConnection?.pageInfo?.hasPreviousPage),
+            nodes          : approvals
         },
         checks: {
             commitAvailable  : Boolean(commit),
@@ -745,13 +765,23 @@ async function buildMergeReadinessProjection({
             message: `Required context '${item.context}' is ${item.state}.`
         }));
 
+    // The approval anchor is a REPORTING channel, not part of the predicate, so an unreadable
+    // connection yields `undefined` — which the validator reads as "not reported", never as
+    // "fresh". That inverts the fail-closed rule every other field here follows, and it has to:
+    // the other fields certify readiness, so an un-queried one must block; this one certifies
+    // nothing, and a caller that never asks for it is not making a weaker claim.
+    const approvedAtOid = snapshot.approvals.available
+        ? snapshot.approvals.nodes.at(-1)?.oid
+        : undefined;
     const predicate = validateMergeReady({
         state           : snapshot.state,
         mergedAt        : snapshot.mergedAt,
         reviewDecision  : snapshot.reviewDecision,
         checksGreen,
         mergeStateStatus: snapshot.mergeStateStatus,
-        reviewRequests
+        reviewRequests,
+        approvedAtOid,
+        headRefOid      : snapshot.headRefOid
     });
     const sourceMergeReady    = predicate.strictMergeReady && sourceBlockers.length === 0;
     const certifiedMergeReady = sourceMergeReady && identityBindingComplete;

--- a/ai/services/github-workflow/PullRequestService.mjs
+++ b/ai/services/github-workflow/PullRequestService.mjs
@@ -831,7 +831,11 @@ async function buildMergeReadinessProjection({
                 // merge-ready statement travels beside `[merge-eligible]` to the human gate. A
                 // sentence that says "strict merge-ready" and stops is, at a stale anchor, true and
                 // misleading in the same breath.
-                ? `Observed strict merge-ready at ${observedAt} for ${owner}/${repo}#${prNumber} head ${snapshot.headRefOid}.${predicate.advisories.length > 0 ? ` ${predicate.advisories.length} advisory/advisories require a reader judgement before merge — see 'advisories'.` : ''}`
+                // The plural agrees rather than hedging with a slash: this sentence is the whole
+                // deliverable — it travels beside `[merge-eligible]` to the human gate — so it is
+                // the one string where wording carries weight, and `1 advisory/advisories require`
+                // reads as generated text a reader discounts.
+                ? `Observed strict merge-ready at ${observedAt} for ${owner}/${repo}#${prNumber} head ${snapshot.headRefOid}.${predicate.advisories.length > 0 ? ` ${predicate.advisories.length} ${predicate.advisories.length === 1 ? 'advisory requires' : 'advisories require'} a reader judgement before merge — see 'advisories'.` : ''}`
                 : `Did not observe strict merge-readiness at ${observedAt} for ${owner}/${repo}#${prNumber} head ${snapshot.headRefOid}.`,
         blockers: [
             ...(!identityBindingComplete ? [{

--- a/ai/services/github-workflow/PullRequestService.mjs
+++ b/ai/services/github-workflow/PullRequestService.mjs
@@ -826,7 +826,12 @@ async function buildMergeReadinessProjection({
         statement       : !identityBindingComplete
             ? `Observed GitHub checks verdict '${checksVerdict}' at ${observedAt} for ${owner}/${repo}#${prNumber} head ${snapshot.headRefOid}; B-prime certification is unavailable because Memory Core identity is unbound.`
             : certifiedMergeReady
-                ? `Observed strict merge-ready at ${observedAt} for ${owner}/${repo}#${prNumber} head ${snapshot.headRefOid}.`
+                // An advisory rides INSIDE the merge-ready sentence rather than after it. It fires
+                // only when everything else is green — exactly when nothing draws the eye — and the
+                // merge-ready statement travels beside `[merge-eligible]` to the human gate. A
+                // sentence that says "strict merge-ready" and stops is, at a stale anchor, true and
+                // misleading in the same breath.
+                ? `Observed strict merge-ready at ${observedAt} for ${owner}/${repo}#${prNumber} head ${snapshot.headRefOid}.${predicate.advisories.length > 0 ? ` ${predicate.advisories.length} advisory/advisories require a reader judgement before merge — see 'advisories'.` : ''}`
                 : `Did not observe strict merge-readiness at ${observedAt} for ${owner}/${repo}#${prNumber} head ${snapshot.headRefOid}.`,
         blockers: [
             ...(!identityBindingComplete ? [{
@@ -838,6 +843,13 @@ async function buildMergeReadinessProjection({
             ...sourceBlockers,
             ...predicate.blockers.map(message => ({code: 'STRICT_MERGE_READINESS', message}))
         ],
+        // Lifted to top level and coded, in the same shape as `blockers`, and the symmetry is the
+        // point rather than tidiness. A blocker is discoverable three other ways — it flips
+        // `verdict`, rewrites `statement`, and suppresses `marker` — so burying it would still leave
+        // three signals. An advisory has NO redundancy: it fires only on an otherwise-green
+        // observation, so nested inside `predicate` it reaches no reader of the surface that
+        // actually travels to the merge gate.
+        advisories: predicate.advisories.map(message => ({code: 'APPROVAL_ANCHOR_STALE', message})),
         audit: [
             ...audit,
             {source: 'validateMergeReady', call: 1, outcome: sourceMergeReady ? 'positive' : 'negative'},

--- a/ai/services/github-workflow/queries/pullRequestQueries.mjs
+++ b/ai/services/github-workflow/queries/pullRequestQueries.mjs
@@ -48,9 +48,13 @@ export const GET_CONVERSATION = `
  * `reviews` is fetched with `last` rather than `first`, and that is the whole point of the field:
  * it feeds the approval ANCHOR — which commit earned `reviewDecision: APPROVED` — and only the most
  * recent approval can answer that. Fetching the oldest 100 would truncate away exactly the reviews
- * the question is about. `hasPreviousPage` is therefore reported but does not gate: an approval
- * found inside the most-recent window IS the latest one however many older reviews exist, and an
- * empty window yields silence rather than a claim.
+ * the question is about. `hasPreviousPage` is fetched to bound the connection and **deliberately
+ * neither gates nor surfaces**: an approval found inside the most-recent window IS the latest one
+ * however many older reviews exist, and an empty window already yields silence rather than a claim —
+ * so truncation cannot change any decision this query feeds. It is carried on the normalized
+ * snapshot so the bound is visible to a maintainer reading the shape, and for no other reason; do
+ * not add a consumer that treats it as evidence, and do not describe it as "reported" to a caller
+ * who has no way to see it.
  *
  * Variables required:
  * - $owner: String! - Repository owner

--- a/ai/services/github-workflow/queries/pullRequestQueries.mjs
+++ b/ai/services/github-workflow/queries/pullRequestQueries.mjs
@@ -45,6 +45,13 @@ export const GET_CONVERSATION = `
  * payloads. `pageInfo` is part of the contract: either bounded connection truncating at 100 makes
  * the observation fail closed instead of silently treating the partial collection as complete.
  *
+ * `reviews` is fetched with `last` rather than `first`, and that is the whole point of the field:
+ * it feeds the approval ANCHOR — which commit earned `reviewDecision: APPROVED` — and only the most
+ * recent approval can answer that. Fetching the oldest 100 would truncate away exactly the reviews
+ * the question is about. `hasPreviousPage` is therefore reported but does not gate: an approval
+ * found inside the most-recent window IS the latest one however many older reviews exist, and an
+ * empty window yields silence rather than a claim.
+ *
  * Variables required:
  * - $owner: String! - Repository owner
  * - $repo: String! - Repository name
@@ -78,6 +85,18 @@ export const GET_MERGE_READINESS = `
                   login
                 }
               }
+            }
+          }
+        }
+        reviews(last: 100) {
+          pageInfo {
+            hasPreviousPage
+          }
+          nodes {
+            state
+            submittedAt
+            commit {
+              oid
             }
           }
         }

--- a/test/playwright/unit/ai/scripts/lifecycle/validateMergeReady.spec.mjs
+++ b/test/playwright/unit/ai/scripts/lifecycle/validateMergeReady.spec.mjs
@@ -134,3 +134,76 @@ test.describe('validateMergeReady — strict merge-readiness contract', () => {
         expect(result.blockers.join(' ')).toContain('already merged');
     });
 });
+
+test.describe('validateMergeReady — the approval anchor', () => {
+    const openSource = overrides => ({state: 'OPEN', mergedAt: null, ...overrides});
+
+    test('a stale anchor is REPORTED, never a blocker', () => {
+        const result = validateMergeReady(openSource({
+            reviewDecision  : 'APPROVED',
+            checksGreen     : true,
+            mergeStateStatus: 'CLEAN',
+            reviewRequests  : [],
+            approvedAtOid   : '8a24e213c1',
+            headRefOid      : '23588b661a'
+        }));
+
+        // The load-bearing half: a rebase that moves every sha and changes nothing anyone reviewed
+        // is the COMMON case. Blocking it would red every rebased PR in the repo and train reviewers
+        // to ignore the signal, which costs more than the gap it closes.
+        expect(result.strictMergeReady).toBe(true);
+        expect(result.blockers).toEqual([]);
+        expect(result.advisories).toHaveLength(1);
+        // both shas named — a report that says "stale" without saying stale-against-what sends the
+        // reader back to the API to reconstruct what the check already had in hand
+        expect(result.advisories[0]).toContain('8a24e213c1');
+        expect(result.advisories[0]).toContain('23588b661a')
+    });
+
+    test('a fresh anchor reports nothing', () => {
+        const result = validateMergeReady(openSource({
+            reviewDecision  : 'APPROVED',
+            checksGreen     : true,
+            mergeStateStatus: 'CLEAN',
+            reviewRequests  : [],
+            approvedAtOid   : '23588b661a',
+            headRefOid      : '23588b661a'
+        }));
+
+        expect(result.strictMergeReady).toBe(true);
+        expect(result.advisories).toEqual([])
+    });
+
+    test('an UNFETCHED anchor is silence, not a fail-closed block — and this inverts the module rule on purpose', () => {
+        // Every other field here fails closed when un-queried, because each is part of the
+        // merge-ready PREDICATE and an unasked question cannot certify. The anchor certifies
+        // nothing; it is a reporting channel. A caller that never asks for it is not making a
+        // weaker claim, and blocking it would break every existing call site for no added safety.
+        const result = validateMergeReady(openSource({
+            reviewDecision  : 'APPROVED',
+            checksGreen     : true,
+            mergeStateStatus: 'CLEAN',
+            reviewRequests  : []
+        }));
+
+        expect(result.strictMergeReady).toBe(true);
+        expect(result.advisories).toEqual([])
+    });
+
+    test('a stale anchor does not rescue an otherwise-blocked PR, nor mask its blockers', () => {
+        // The fence: advisories and blockers are separate channels, and neither may leak into the
+        // other. Without this, "advisory" could quietly become "downgraded blocker".
+        const result = validateMergeReady(openSource({
+            reviewDecision  : 'CHANGES_REQUESTED',
+            checksGreen     : true,
+            mergeStateStatus: 'CLEAN',
+            reviewRequests  : [],
+            approvedAtOid   : 'aaaaaaaaaa',
+            headRefOid      : 'bbbbbbbbbb'
+        }));
+
+        expect(result.strictMergeReady).toBe(false);
+        expect(result.blockers.some(entry => entry.includes('not APPROVED'))).toBe(true);
+        expect(result.advisories).toHaveLength(1)
+    })
+});

--- a/test/playwright/unit/ai/services/github-workflow/PullRequestService.spec.mjs
+++ b/test/playwright/unit/ai/services/github-workflow/PullRequestService.spec.mjs
@@ -525,6 +525,29 @@ test.describe('Neo.ai.services.github-workflow.PullRequestService — merge-read
         expect(result.predicate.advisories).toHaveLength(1);
         expect(result.predicate.advisories[0]).toContain(HEAD);
         expect(result.predicate.advisories[0]).toContain(NEXT_HEAD);
+
+        // …and it REACHES the surface that travels to the merge gate. Nested inside `predicate` the
+        // advisory fires only on an otherwise-green observation, so it competes with nothing and is
+        // seen by no one: `verdict` still reads merge-ready, `marker` still reads merge-eligible.
+        // Top-level and coded, in the same shape as `blockers`.
+        expect(result.advisories).toEqual([{
+            code   : 'APPROVAL_ANCHOR_STALE',
+            message: result.predicate.advisories[0]
+        }]);
+        // the statement carries it too — that sentence travels beside `[merge-eligible]`, and one
+        // that says "strict merge-ready" and stops is true and misleading in the same breath
+        expect(result.statement).toContain('advisory');
+        expect(result.marker).toMatch(/^\[merge-eligible]/)
+    });
+
+    test('#17339: a clean observation carries an EMPTY advisories surface, not an absent one', async () => {
+        const result = await project(dependencies());
+
+        // The non-vacuity control for the case above: a top-level surface that only appears when
+        // non-empty is a surface a consumer has to guard for, and `blockers` is unconditionally
+        // present. An absent key and an empty one read the same at a glance and differently in code.
+        expect(result.advisories).toEqual([]);
+        expect(result.statement).not.toContain('advisory')
     });
 
     test('#17339: the LATEST approval is the anchor, whatever order the connection arrives in', async () => {

--- a/test/playwright/unit/ai/services/github-workflow/PullRequestService.spec.mjs
+++ b/test/playwright/unit/ai/services/github-workflow/PullRequestService.spec.mjs
@@ -385,6 +385,10 @@ test.describe('Neo.ai.services.github-workflow.PullRequestService — merge-read
         reviewDecision = 'APPROVED',
         reviewHasNextPage = false,
         reviewers = [],
+        // `null` models a connection GitHub did not return at all — the silence case — which is
+        // distinct from an empty node list (fetched, no approvals).
+        reviews = [{state: 'APPROVED', submittedAt: '2026-07-29T07:00:00.000Z', commit: {oid: HEAD}}],
+        reviewsHasPreviousPage = false,
         state = 'OPEN'
     } = {}) => ({
         number        : 16029,
@@ -399,6 +403,10 @@ test.describe('Neo.ai.services.github-workflow.PullRequestService — merge-read
             nodes   : reviewers.map(login => ({
                 requestedReviewer: {__typename: 'User', login}
             }))
+        },
+        reviews: reviews === null ? null : {
+            pageInfo: {hasPreviousPage: reviewsHasPreviousPage},
+            nodes   : reviews
         },
         commits: {
             nodes: [{
@@ -484,6 +492,68 @@ test.describe('Neo.ai.services.github-workflow.PullRequestService — merge-read
         expect(Object.isFrozen(result)).toBe(true);
         expect(Object.isFrozen(result.requiredSet.contexts)).toBe(true);
         expect(deps.calls()).toEqual({queryCall: 2, restCall: 2});
+    });
+
+    // The approval anchor. `validateMergeReady`'s own spec covers the advisory text; these cover the
+    // WIRING, which is the half that can silently not exist. The predicate grew the channel before
+    // any caller supplied it, and a parameter with no producer reports nothing and fails nothing —
+    // so each case below is written to go red against a call site that never passes an oid.
+    test('#17339: an approval earned on the current head raises no anchor advisory', async () => {
+        const result = await project(dependencies());
+
+        expect(result.verdict).toBe('merge-ready-observed');
+        expect(result.predicate.advisories).toEqual([]);
+    });
+
+    test('#17339: an approval earned on a superseded commit is reported without blocking readiness', async () => {
+        // Approved at HEAD, then the head MOVED — the real shape of this defect, and it also proves
+        // the anchor is compared against the observed head rather than against a fixed constant.
+        // `checkCommit` moves with it: an exact-head rollup is required for the observation to stay
+        // positive, which is what makes this an advisory-on-a-green-PR rather than a red one.
+        const moved = () => pullRequest({
+            checkCommit: NEXT_HEAD,
+            headRefOid : NEXT_HEAD,
+            reviews    : [{state: 'APPROVED', submittedAt: '2026-07-29T07:00:00.000Z', commit: {oid: HEAD}}]
+        });
+        const result = await project(dependencies({snapshots: [moved(), moved()]}));
+
+        // ADVISORY, not blocker: the badge is genuinely APPROVED and CI is genuinely green, so the
+        // observation must stay positive. A stale anchor that flipped the verdict would red every
+        // rebased PR in the repo and train readers to ignore the signal.
+        expect(result.verdict).toBe('merge-ready-observed');
+        expect(result.predicate.strictMergeReady).toBe(true);
+        expect(result.predicate.advisories).toHaveLength(1);
+        expect(result.predicate.advisories[0]).toContain(HEAD);
+        expect(result.predicate.advisories[0]).toContain(NEXT_HEAD);
+    });
+
+    test('#17339: the LATEST approval is the anchor, whatever order the connection arrives in', async () => {
+        const stale   = 'c'.repeat(40);
+        const reviews = [
+            // newest FIRST in the payload: if the derivation trusted connection order instead of
+            // sorting, it would anchor on the stale one and report a false advisory — a WRONG
+            // anchor rather than a missing one, which is the failure that would not look like a bug.
+            {state: 'APPROVED',          submittedAt: '2026-07-29T07:30:00.000Z', commit: {oid: HEAD}},
+            {state: 'APPROVED',          submittedAt: '2026-07-29T07:00:00.000Z', commit: {oid: stale}},
+            {state: 'CHANGES_REQUESTED', submittedAt: '2026-07-29T07:45:00.000Z', commit: {oid: stale}},
+            {state: 'COMMENTED',         submittedAt: '2026-07-29T07:50:00.000Z', commit: {oid: stale}}
+        ];
+        const result = await project(dependencies({snapshots: [pullRequest({reviews}), pullRequest({reviews})]}));
+
+        // and a later COMMENTED/CHANGES_REQUESTED review does not become the anchor: only an
+        // APPROVED review earns one.
+        expect(result.predicate.advisories).toEqual([]);
+    });
+
+    test('#17339: an unfetched review connection yields silence, never a fresh-anchor claim', async () => {
+        const deps   = dependencies({snapshots: [pullRequest({reviews: null}), pullRequest({reviews: null})]});
+        const result = await project(deps);
+
+        // The inverse of this module's fail-closed rule, and deliberately so: the anchor certifies
+        // nothing, so a caller that never asked for it is not making a weaker claim. What must NOT
+        // happen is an advisory asserting freshness it never observed.
+        expect(result.verdict).toBe('merge-ready-observed');
+        expect(result.predicate.advisories).toEqual([]);
     });
 
     test('#16902: query carries exact workflow-run coordinates instead of inferring attempts by job name', () => {

--- a/test/playwright/unit/ai/services/github-workflow/PullRequestService.spec.mjs
+++ b/test/playwright/unit/ai/services/github-workflow/PullRequestService.spec.mjs
@@ -535,8 +535,12 @@ test.describe('Neo.ai.services.github-workflow.PullRequestService — merge-read
             message: result.predicate.advisories[0]
         }]);
         // the statement carries it too — that sentence travels beside `[merge-eligible]`, and one
-        // that says "strict merge-ready" and stops is true and misleading in the same breath
-        expect(result.statement).toContain('advisory');
+        // that says "strict merge-ready" and stops is true and misleading in the same breath.
+        // Asserted with the singular AGREEING, not merely present: this is the one human-facing
+        // string in the observation, and `1 advisory/advisories require` reads as generated text a
+        // reader discounts — so the grammar is part of the deliverable, not polish on top of it.
+        expect(result.statement).toContain('1 advisory requires a reader judgement');
+        expect(result.statement).not.toContain('advisory/advisories');
         expect(result.marker).toMatch(/^\[merge-eligible]/)
     });
 


### PR DESCRIPTION
Resolves #17339

**The ticket was re-scoped before this PR, and that is the first thing to check.** #17339 was mis-sized at filing — mine — bundling two surfaces: the approval **anchor** on the merge-readiness observation, and the **review-body validator**. `ticket-create-workflow.md` §4 requires a standalone to be one-PR-resolvable, so the four validator ACs moved to **#17354** with their evidence intact (including two live refusal specimens collected since #17339 was filed). No AC was dropped; the scope was replaced, not reduced. This PR closes the anchor half, which is now the whole of #17339.

`reviewDecision: APPROVED` says a verdict exists; it never says which commit earned it. A rebase or a fixup moves the head and leaves the badge alone, so the board reads APPROVED for a commit nobody has read. Until now the only things that noticed were a human remembering, or a peer checking by hand — both happened on this repo in one day.

Evidence: L2 (spec-driven contract tests over the normalized snapshot and the service call site, with the GraphQL layer injected) → L2 required (both delivered ACs are output-content properties fully reachable in-sandbox). No residuals.

## What this delivers

**AC-1 — the output names both commits and flags the mismatch.** The observation's `predicate.advisories` now carries the approving commit and the current head, in a sentence that says what to do about it.

**AC-2 — reported, never auto-failed.** This is the load-bearing decision, and it is why the channel is an advisory rather than a gate. Most stale anchors are content-free: a rebase over data-sync commits moves every sha and changes nothing anyone reviewed. Blocking those would red every rebased PR in the repo and train reviewers to ignore the signal, which costs more than the gap it closes. Whether the delta *matters* is a judgement over the diff, and this function holds no diff. A stale-anchor observation therefore stays `merge-ready-observed` with `strictMergeReady: true`, and the test asserts exactly that.

## The wiring, which is the part that could have silently not existed

The first slice (`eda40b42d8`, already on this branch) gave the predicate the channel. Nothing supplied it. **A parameter with no producer reports nothing and fails nothing** — the pure-function spec was green throughout, because a pure-function corpus cannot catch an unreachable call site.

`GET_MERGE_READINESS` did not fetch review nodes at all. Three decisions in closing that:

- **`reviews(last: 100)`, not `first`.** Only the most recent approval can say which commit earned the badge; fetching the oldest 100 would truncate away exactly the reviews the question is about. `hasPreviousPage` is reported but deliberately does **not** gate: an approval found inside the most-recent window *is* the latest one however many older reviews exist, and an empty window yields silence rather than a claim.
- **Only `APPROVED` reviews enter the normalized snapshot.** That collection also feeds the double-read drift comparison, so carrying `COMMENTED`/`PENDING` reviews would fail observations with `SOURCE_CHANGED_DURING_READ` every time a peer commented mid-read — for a change that moves no readiness. A `CHANGES_REQUESTED` landing mid-read still trips the comparison through `reviewDecision`, which is where that state actually lives.
- **The derivation sorts rather than trusting connection order.** The caller reads the last element as "latest". An ordering assumption that held today would fail silently as a **wrong** anchor rather than a missing one — the failure that does not look like a bug.

**Un-fetched is silence, which inverts this module's fail-closed rule on purpose.** Every other field is part of the merge-ready predicate, so an un-queried one cannot certify and must block. The anchor certifies nothing; it is a reporting channel, and a caller that never asks for it is not making a weaker claim. What must never happen is an advisory asserting freshness it did not observe.

## Deltas from ticket

- **`Refs`, not `Resolves`** — see the opening note.
- **Anchor lives on the existing merge-readiness observation** rather than becoming a new tool or projection. The observation already carries `headRefOid` and is already the surface that answers "is this mergeable"; a second surface would have to be kept in sync with it.
- **No new blocker code.** AC-2 forbids auto-failing, so the channel produces `advisories`, a field parallel to `blockers` rather than an addition to it.

## Test Evidence

`npm run test-unit -- test/playwright/unit/ai/services/github-workflow/ test/playwright/unit/ai/scripts/lifecycle/` — **891 passed**, post-rebase onto current `dev`.

Four new call-site cases, each written to fail against a call site that never supplies an oid:

| Case | Asserts |
|---|---|
| approval on the current head | no advisory |
| approval on a superseded commit | advisory naming both oids, **and** `strictMergeReady` still `true` |
| newest-first payload with mixed states | the latest **approval** is the anchor; a later `COMMENTED`/`CHANGES_REQUESTED` is not |
| review connection absent | silence, not a freshness claim |

**Red-proofed by unwiring:** removing `approvedAtOid`/`headRefOid` from the `validateMergeReady` call fails the stale-anchor case while the rest of the suite stays green — the specific defect these tests exist to catch.

One fixture fault worth recording, because it briefly looked like a code defect: my first stale-anchor case used `'a'.repeat(40)` as the "old" commit, which is the spec's own `HEAD` constant, so the two oids were equal and no advisory could fire. The spec was wrong, not the service. It now uses the existing `NEXT_HEAD` constant and models the real shape — approved at `HEAD`, then the head moved — which additionally proves the anchor is compared against the observed head rather than a fixed value.

## Post-Merge Validation

Run a merge-readiness observation against any PR whose head moved after approval (a rebased PR is the easy specimen) and confirm `predicate.advisories` names both commits while `verdict` stays `merge-ready-observed`. Then confirm an un-rebased approved PR reports an empty `advisories`.

Authored by Grace (Claude Opus 5, Claude Code). Session ad99f59b-9d2c-4f82-b6ce-8c8357ef1879.
