### PR TITLE
fix(ai): a mistyped repo selector refuses the run instead of syncing the rest (#17358)

### DIFF
--- a/ai/daemons/orchestrator/scheduling/tenantRepoSync.mjs
+++ b/ai/daemons/orchestrator/scheduling/tenantRepoSync.mjs
@@ -1,7 +1,55 @@
 import {
     KB_TENANT_REPO_SYNC_INVALID_SLICE_BUDGET,
+    KB_TENANT_REPO_SYNC_REPO_NOT_CONFIGURED,
     TenantRepoSyncError
 } from '../services/TenantRepoSyncErrors.mjs';
+
+/**
+ * @summary Refuses an operator selector naming any repo the config does not hold.
+ *
+ * ANY unknown slug refuses, never only an all-unknown set. The distinction is the whole reason this
+ * exists: keyed on "nothing matched", `--repo-slug good --repo-slug typo` processes `good`, drops
+ * `typo` without a word, and exits `0` — the operator is told the run completed while the repo they
+ * most likely cared about was never touched. A partial no-op hides better than a total one because
+ * something did happen, and `0` is the code a runbook or wrapper branches on.
+ *
+ * Named and shared rather than inlined at each entry path, because two sites asking this question
+ * had already answered it differently — the sweep on "nothing matched", the backoff clear on "any
+ * unknown". Two call sites with one question is where the question earns a name; a third entry path
+ * would otherwise inherit whichever copy it was written beside.
+ *
+ * Returns the failure DETAILS rather than throwing or returning a boolean: both callers surface the
+ * same envelope to the CLI, whose `resolveExitCode` branches on `reasonCode` for exit `3`. A boolean
+ * would make each caller rebuild the payload, which is how the two drifted in the first place.
+ *
+ * Pure, and here rather than beside its callers for the reason the module's other validators are —
+ * the callers import Neo, and a validator that cannot be exercised without booting the class system
+ * is a validator whose own contract goes untested.
+ *
+ * @param {Object} options
+ * @param {String[]|null} [options.onlyRepoSlugs] Operator-supplied selector; empty/absent selects everything and cannot refuse.
+ * @param {String[]} [options.knownSlugs=[]] Configured `repoSlug` values.
+ * @returns {Object|null} Failure details when any requested slug is unknown, else `null`.
+ */
+export function resolveUnknownRepoSelectors({onlyRepoSlugs, knownSlugs = []}) {
+    if (!(onlyRepoSlugs?.length > 0)) {
+        return null
+    }
+
+    const unknownSlugs = onlyRepoSlugs.filter(slug => !knownSlugs.includes(slug));
+
+    if (unknownSlugs.length === 0) {
+        return null
+    }
+
+    return {
+        reason         : 'repo-not-configured',
+        reasonCode     : KB_TENANT_REPO_SYNC_REPO_NOT_CONFIGURED,
+        requestedSlugs : onlyRepoSlugs,
+        unknownSlugs,
+        configuredSlugs: knownSlugs
+    }
+}
 
 /**
  * @summary Rejects a `tenantRepoSync.sliceBudgetMs` that cannot bound anything.

--- a/ai/daemons/orchestrator/services/TenantRepoSyncService.mjs
+++ b/ai/daemons/orchestrator/services/TenantRepoSyncService.mjs
@@ -43,7 +43,8 @@ import {
     detectStarvedTenantSync,
     hasPendingEmbeddingRecoveryBypass,
     isRepoDue,
-    isStarvedOrderInverted
+    isStarvedOrderInverted,
+    resolveUnknownRepoSelectors
 } from '../scheduling/tenantRepoSync.mjs';
 import {
     KB_TENANT_REPO_SYNC_CONTENT_NOT_EMBEDDABLE,
@@ -53,7 +54,6 @@ import {
     KB_TENANT_REPO_SYNC_LEASE_HELD,
     KB_TENANT_REPO_SYNC_LEASE_LOST,
     KB_TENANT_REPO_SYNC_MANIFEST_UPDATE_FAILED,
-    KB_TENANT_REPO_SYNC_REPO_NOT_CONFIGURED,
     KB_TENANT_REPO_SYNC_CONCURRENCY_GATE_TIMEOUT,
     KB_TENANT_REPO_SYNC_INVALID_SLICE_BUDGET,
     KB_TENANT_REPO_SYNC_STARVED,
@@ -1356,7 +1356,7 @@ class TenantRepoSyncService extends Base {
      * | `KB_TENANT_REPO_SYNC_EMPTY_MATERIALIZATION` | per-repo `lastErrorCode` | full materialization produced NO positive effect and no matching unacknowledged retry receipt — nothing arrived; look at the embed stage |
      * | `KB_TENANT_REPO_SYNC_MATERIALIZATION_UNPROVEN` | per-repo `lastErrorCode` | full materialization DID take effect, but no receipt proves this attempt — the rows landed and the proof is missing, so do NOT re-ingest |
      * | `KB_TENANT_REPO_SYNC_CONTENT_NOT_EMBEDDABLE` | per-repo `lastErrorCode` | the repo declares content and every candidate chunk was refused BEFORE the provider — re-ingesting cannot help; the actionable surface is chunking or the safe band |
-     * | `KB_TENANT_REPO_SYNC_REPO_NOT_CONFIGURED` | outer `details.reasonCode` | `onlyRepoSlugs` filter requested a slug that is not in `tenantRepos[]` |
+     * | `KB_TENANT_REPO_SYNC_REPO_NOT_CONFIGURED` | outer `details.reasonCode` | `onlyRepoSlugs` requested ANY slug that is not in `tenantRepos[]` — the run refuses whole rather than processing the recognised subset |
      * | `KB_TENANT_REPO_SYNC_MANIFEST_UPDATE_FAILED` | outer `details.reasonCode` | `tenant-repo-sync-revisions.json` write failure (next cycle settles the unacknowledged graph receipt idempotently) |
      * | `KB_TENANT_REPO_SYNC_TENANT_NOT_FOUND` | reserved | future `--tenant-id` CLI flag; no current emitter |
      * | `KB_TENANT_REPO_SYNC_CONCURRENCY_GATE_TIMEOUT` | per-repo `lastErrorCode` | concurrency-gate slot-acquisition timeout after `concurrencyGateTimeoutMs` |
@@ -1370,7 +1370,7 @@ class TenantRepoSyncService extends Base {
      * @param {Object} [options.tenantReposConfig] Pre-normalized tenantRepos config. If omitted, resolved across config tiers via `KnowledgeBaseIngestionService.listConfiguredTenantRepos`.
      * @param {Object} [options.gitMirror=GitMirror] Injectable mirror primitive (test seam).
      * @param {Object} [options.knowledgeBaseIngestionService] KB ingestion service singleton (test seam). Resolved from `ai/services.mjs` if omitted.
-     * @param {String[]} [options.onlyRepoSlugs] If provided, only sync repos whose `repoSlug` is in the list. Used by the manual CLI run path. Empty filter result against non-empty list surfaces `KB_TENANT_REPO_SYNC_REPO_NOT_CONFIGURED`.
+     * @param {String[]} [options.onlyRepoSlugs] If provided, only sync repos whose `repoSlug` is in the list. Used by the manual CLI run path. ANY requested slug that is not configured surfaces `KB_TENANT_REPO_SYNC_REPO_NOT_CONFIGURED` and syncs nothing — a partially mistyped selector refuses rather than silently processing the subset it recognised.
      * @param {Boolean} [options.fullReplay=false] Build selected-repo envelopes from a null revision base. Requires non-empty `onlyRepoSlugs`; persisted checkpoints remain unchanged until each replay completes without summary errors.
      * @param {String} [options.revisionsFilePath] Override the per-tenant-repo lastIngestedRev persistence file path (test seam). Defaults to `<orchestrator dataDir leaf>/tenant-repo-sync-revisions.json`.
      * @param {Number} [options.leaseStaleAfterMs] Override the cross-process lease TTL (test seam). Defaults to the `orchestrator.tenantRepoSync.leaseStaleAfterMs` leaf. Crashed owners recover immediately via pid-liveness; the TTL only bounds a live-but-wedged owner.
@@ -1662,21 +1662,17 @@ class TenantRepoSyncService extends Base {
             ? allRepos.filter(r => onlyRepoSlugs.includes(r.repoSlug))
             : allRepos;
 
-        // Distinguish "operator-requested-unknown-slug" from "no config at all".
-        // Empty filter result with non-empty onlyRepoSlugs = stable REPO_NOT_CONFIGURED
-        // error so the CLI / future API surface can branch on `error.code`.
-        if (repos.length === 0 && onlyRepoSlugs?.length > 0) {
-            const knownSlugs   = allRepos.map(r => r.repoSlug);
-            const unknownSlugs = onlyRepoSlugs.filter(s => !knownSlugs.includes(s));
-            const details      = {
-                reason         : 'repo-not-configured',
-                reasonCode     : KB_TENANT_REPO_SYNC_REPO_NOT_CONFIGURED,
-                repoCount      : 0,
-                requestedSlugs : onlyRepoSlugs,
-                unknownSlugs,
-                configuredSlugs: knownSlugs
-            };
-            writeLog?.('WARN', `[TenantRepoSync] Requested repoSlug(s) not configured: ${unknownSlugs.join(', ')}. Configured: ${knownSlugs.join(', ') || '(none)'}.`);
+        // Distinguish "operator-requested-unknown-slug" from "no config at all", and refuse on ANY
+        // unknown slug rather than only an all-unknown set. Keyed on "nothing matched", a partially
+        // mistyped selector synced the known subset and dropped the rest silently at exit 0 — the
+        // operator was told the run completed while the repo they meant went untouched. Shared with
+        // the backoff-clear path so one typo cannot mean two things on one CLI.
+        const unknownSelectors = resolveUnknownRepoSelectors({onlyRepoSlugs, knownSlugs: allRepos.map(r => r.repoSlug)});
+
+        if (unknownSelectors) {
+            const details = {...unknownSelectors, repoCount: repos.length};
+
+            writeLog?.('WARN', `[TenantRepoSync] Requested repoSlug(s) not configured: ${unknownSelectors.unknownSlugs.join(', ')}. Configured: ${unknownSelectors.configuredSlugs.join(', ') || '(none)'}.`);
             return {status: 'failed', details};
         }
 
@@ -3268,24 +3264,16 @@ class TenantRepoSyncService extends Base {
               allRepos       = resolvedConfig.tenantRepos || [],
               knownSlugs     = allRepos.map(repo => repo.repoSlug);
 
-        // The SAME refusal the sweep gives an unknown selector, deliberately: an operator who
-        // mistypes a slug must get one vocabulary back, not a second one invented for this path.
-        if (onlyRepoSlugs?.length > 0) {
-            const unknownSlugs = onlyRepoSlugs.filter(slug => !knownSlugs.includes(slug));
+        // The same refusal the sweep gives an unknown selector, through the same shared predicate:
+        // an operator who mistypes a slug gets one vocabulary and one disposition back, whichever
+        // flag they typed. The two paths tested this separately once and disagreed — the sweep
+        // refused only an all-unknown set — so the question now has a single name.
+        const unknownSelectors = resolveUnknownRepoSelectors({onlyRepoSlugs, knownSlugs});
 
-            if (unknownSlugs.length > 0) {
-                const details = {
-                    reason         : 'repo-not-configured',
-                    reasonCode     : KB_TENANT_REPO_SYNC_REPO_NOT_CONFIGURED,
-                    requestedSlugs : onlyRepoSlugs,
-                    unknownSlugs,
-                    configuredSlugs: knownSlugs
-                };
+        if (unknownSelectors) {
+            writeLog?.('WARN', `[TenantRepoSync] clear-backoff: requested repoSlug(s) not configured: ${unknownSelectors.unknownSlugs.join(', ')}. Configured: ${unknownSelectors.configuredSlugs.join(', ') || '(none)'}.`);
 
-                writeLog?.('WARN', `[TenantRepoSync] clear-backoff: requested repoSlug(s) not configured: ${unknownSlugs.join(', ')}. Configured: ${knownSlugs.join(', ') || '(none)'}.`);
-
-                return {status: 'failed', details}
-            }
+            return {status: 'failed', details: unknownSelectors}
         }
 
         const targetSlugs = onlyRepoSlugs?.length > 0 ? onlyRepoSlugs : knownSlugs;

--- a/test/playwright/unit/ai/daemons/orchestrator/services/TenantRepoSyncService.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/services/TenantRepoSyncService.spec.mjs
@@ -25,7 +25,7 @@ import path            from 'path';
 import {fileURLToPath} from 'url';
 
 import TenantRepoSyncService from '../../../../../../../ai/daemons/orchestrator/services/TenantRepoSyncService.mjs';
-import {classifyEmbeddingRecoveryState, isRepoDue}
+import {classifyEmbeddingRecoveryState, isRepoDue, resolveUnknownRepoSelectors}
                             from '../../../../../../../ai/daemons/orchestrator/scheduling/tenantRepoSync.mjs';
 import {
     classifyTenantRepoCheckpoint,
@@ -315,6 +315,46 @@ test.describe('TenantRepoSyncService (#11790)', () => {
         // rather than a manifest-wide one.
         expect(dueStateFor(persisted[throttled])).toMatchObject({due: true, dueReason: 'cadence'});
         expect(dueStateFor(persisted[untouched]).due).toBe(false)
+    });
+
+    test('both entry paths refuse the SAME selector sets — the divergence cannot reopen silently', async () => {
+        // The two paths tested this question separately and answered it differently: the sweep
+        // refused only an all-unknown set, the clear refused any unknown. A per-path assertion
+        // cannot catch that — each was internally consistent and green. This drives BOTH through
+        // the same cases and compares refusals, so a future edit to one is only green if the other
+        // moved with it.
+        const config     = {tenantRepos: [{repoSlug: 'acme/known', tenantId: 't1'}]},
+              knownSlugs = ['acme/known'],
+              cases      = [
+                  {label: 'all known',      slugs: ['acme/known']},
+                  {label: 'partly unknown', slugs: ['acme/known', 'acme/typo']},
+                  {label: 'all unknown',    slugs: ['acme/typo']},
+                  {label: 'no selector',    slugs: null}
+              ];
+
+        for (const {label, slugs} of cases) {
+            const predicate = resolveUnknownRepoSelectors({onlyRepoSlugs: slugs, knownSlugs});
+            const clear     = await TenantRepoSyncService.clearTenantRepoBackoff({
+                onlyRepoSlugs    : slugs,
+                revisionsFilePath: revisionsFile,
+                tenantReposConfig: config
+            });
+            const clearRefused = clear.status === 'failed';
+
+            expect(clearRefused, `${label}: clear must follow the shared predicate`).toBe(Boolean(predicate));
+
+            if (predicate) {
+                expect(clear.details.unknownSlugs, `${label}: same unknown set`).toEqual(predicate.unknownSlugs);
+                expect(clear.details.reasonCode).toBe(predicate.reasonCode)
+            }
+        }
+
+        // and the predicate itself refuses on ANY unknown, which is the property the sweep lacked
+        expect(resolveUnknownRepoSelectors({onlyRepoSlugs: ['acme/known', 'acme/typo'], knownSlugs}).unknownSlugs).toEqual(['acme/typo']);
+        expect(resolveUnknownRepoSelectors({onlyRepoSlugs: ['acme/known'], knownSlugs})).toBeNull();
+        // an empty or absent selector selects everything and can never refuse
+        expect(resolveUnknownRepoSelectors({onlyRepoSlugs: [], knownSlugs})).toBeNull();
+        expect(resolveUnknownRepoSelectors({onlyRepoSlugs: null, knownSlugs})).toBeNull()
     });
 
     test('clear-backoff refuses an unknown slug with the sweep\'s own error code, rather than clearing nothing quietly', () => {
@@ -4274,6 +4314,64 @@ test.describe('TenantRepoSyncService (#11790)', () => {
         // that defers every repo must not read as "1 completed, 0 failed" on the one line an
         // operator actually scans.
         expect(summaryLine.msg).toMatch(/1 repos, 1 completed, 0 deferred, 0 failed/);
+    });
+
+    test('a PARTIALLY unknown selector refuses whole — the known subset is not quietly synced', async () => {
+        // The defect this pins: keyed on "nothing matched", a run with one good slug and one typo
+        // synced the good one, dropped the typo without a word, and exited 0 — the operator reads a
+        // completed run while the repo they meant was never touched. The known-good repo IS
+        // provisioned and would sync happily, so the refusal has to come from the selector check
+        // rather than from the run failing for some unrelated reason.
+        const taskStateService = createInMemoryTaskStateService();
+        const ingestion        = makeFakeIngestionService();
+        await provisionMirrorDir({tenantId: 't1', repoSlug: 'org/known'});
+
+        const result = await TenantRepoSyncService.runTask({
+            reason           : 'manual',
+            taskStateService,
+            writeLog         : () => {},
+            tenantReposConfig: {tenantRepos: [
+                {tenantId: 't1', repoSlug: 'org/known', mirrorRoot, cloneUrl: 'https://github.com/neomjs/known.git'}
+            ]},
+            onlyRepoSlugs                : ['org/known', 'org/typo'],
+            gitMirror                    : makeFakeGitMirror(),
+            envelopeBuilder              : makeFakeEnvelopeBuilder(),
+            knowledgeBaseIngestionService: ingestion,
+            revisionsFilePath            : revisionsFile
+        });
+
+        expect(result.status).toBe('failed');
+        expect(result.details.reasonCode).toBe('KB_TENANT_REPO_SYNC_REPO_NOT_CONFIGURED');
+        // ONLY the typo is named — a refusal that listed the good slug would send the operator
+        // hunting a second, non-existent mistake.
+        expect(result.details.unknownSlugs).toEqual(['org/typo']);
+        expect(result.details.requestedSlugs).toEqual(['org/known', 'org/typo']);
+        // and nothing was ingested: the refusal precedes the work, it does not undo it
+        expect(ingestion.calls?.length ?? 0).toBe(0)
+    });
+
+    test('an ALL-known selector is unaffected — the stricter trigger does not over-refuse', async () => {
+        // Non-vacuity control for the case above. Without it, a predicate that refused every
+        // non-empty selector would pass the partial-unknown test and break every legitimate run.
+        const taskStateService = createInMemoryTaskStateService();
+        await provisionMirrorDir({tenantId: 't1', repoSlug: 'org/known'});
+
+        const result = await TenantRepoSyncService.runTask({
+            reason           : 'manual',
+            taskStateService,
+            writeLog         : () => {},
+            tenantReposConfig: {tenantRepos: [
+                {tenantId: 't1', repoSlug: 'org/known', mirrorRoot, cloneUrl: 'https://github.com/neomjs/known.git'}
+            ]},
+            onlyRepoSlugs                : ['org/known'],
+            gitMirror                    : makeFakeGitMirror(),
+            envelopeBuilder              : makeFakeEnvelopeBuilder(),
+            knowledgeBaseIngestionService: makeFakeIngestionService(),
+            revisionsFilePath            : revisionsFile
+        });
+
+        expect(result.status).not.toBe('failed');
+        expect(result.details.reasonCode).toBeUndefined()
     });
 
     test('--repo-slug filter against unknown slug surfaces stable KB_TENANT_REPO_SYNC_REPO_NOT_CONFIGURED', async () => {


### PR DESCRIPTION
Resolves #17358

An operator who mistypes one slug in a multi-repo `--repo-slug` invocation was told the run **completed**. The sweep refused only when *every* requested slug was unknown, so a partially mistyped selector synced the subset it recognised, dropped the rest without a word, and exited `0` — the code a runbook or wrapper branches on.

Evidence: L2 (spec-driven contract tests over both entry paths and the extracted predicate, with config and manifest injected) → L2 required (every AC is an input/output property of the selector guard, reachable in-sandbox). No residuals.

## What this changes

**One predicate, two callers.** `resolveUnknownRepoSelectors` refuses when **any** requested slug is unknown, and both the sweep and the backoff clear now consume it. Before this, the two paths asked the same question and answered it differently:

| Invocation | Sweep (before) | Sweep (after) | `--clear-backoff` |
|---|---|---|---|
| `--repo-slug typo` | refuses, exit 3 | refuses, exit 3 | refuses, exit 3 |
| `--repo-slug good --repo-slug typo` | **syncs `good`, drops `typo`, exit 0** | refuses, exit 3 | refuses, exit 3 |

The strict path was already correct — #17067's AC-1 required an unknown identifier be *"rejected with a named error, never a silent no-op"*, and a partial-match run that ignores the remainder **is** a silent partial no-op. It merely hides better than the total-miss case, because something did happen. So the lax path moved.

The near-miss that made this cheap: `unknownSlugs` was **already computed inside the old guard**. The exact set needed to refuse correctly was derived and then only reachable when everything had failed.

## Where the predicate lives, and why it is shared rather than copied

`ai/daemons/orchestrator/scheduling/tenantRepoSync.mjs`, beside the lane's other pure validators, for the reason that module's own header gives: **the callers import Neo, and a validator that cannot be exercised without booting the class system is a validator whose own contract goes untested.**

Shared rather than duplicated because two sites had already drifted once. Two call sites with one question is where the question earns a name; a third entry path would otherwise inherit whichever copy it was written beside. It returns the failure **details** rather than a boolean, because both callers surface the same envelope to the CLI — a boolean would make each rebuild the payload, which is how they diverged in the first place.

## Deltas from ticket

- **Two JSDoc corrections, not one.** The ticket named the `clearTenantRepoBackoff` "SAME refusal" clause. Chasing it found `runTask`'s `@param` for `onlyRepoSlugs` carrying the *same* overclaim from the other side — *"Empty filter result against non-empty list surfaces …"* — plus the error-code table row. All three now describe ANY-unknown.
- **A dead import removed.** Extracting the predicate left `KB_TENANT_REPO_SYNC_REPO_NOT_CONFIGURED` imported into the service and used nowhere in code — only in three JSDoc mentions, which is exactly what makes such an import read as live on a grep.
- **`repoCount` is now the real matched count** rather than a hardcoded `0`. The old guard could only fire when nothing matched, so `0` was true by construction; under the new trigger a refusal can carry a non-empty match, and reporting `0` would misdescribe what the selector actually hit.
- **`resolveExitCode` unchanged**, and pinned by an existing test — exit `3` was already wired to this reason code, so the exit contract is proven unmoved rather than assumed.

## Test Evidence

`npm run test-unit` — the **full** suite: **14133 passed**, 2 failed, 11 skipped. Owning spec: 145 passed. The full run rather than the owning directory is deliberate — a directory-scoped run missed a cross-tree guard on my previous PR, and a directory narrower than the suite CI runs is a sample, not a blast radius.

**Both failures were cleared with controls, not by inspection:**

| Failure | Control | Verdict |
|---|---|---|
| `McpServersHealth` — neural-link boot/JSON-RPC | ran on clean `dev` without my change | **fails there too — pre-existing**, unrelated |
| `devCockpit` — composed boot / SIGTERM teardown | ran isolated on this branch | **22 passed** — a full-suite interaction, not this diff |

Neither is attributable to this change, and neither is asserted to be "obviously unrelated" — each was actually run.

Three new cases, each red-proofed against the old lax trigger:

| Case | Asserts | Red-proof |
|---|---|---|
| partially unknown selector | refuses whole; names **only** the typo; nothing ingested | restoring the lax trigger → `status` is not `failed` |
| all-known selector | unaffected — the stricter trigger does not over-refuse | non-vacuity control: a predicate refusing every non-empty selector would pass the case above and break every legitimate run |
| **both paths refuse the same sets** | four selector shapes driven through the predicate *and* the clear, refusals compared | restoring the lax trigger → parity assertion fails |

**The parity case is the one that matters.** A per-path assertion could not have caught the original divergence: each path was internally consistent and green while disagreeing with the other. Driving both through the same cases means a future edit to one is only green if the other moved with it.

Both red-proofs were run **in isolation**, because the runner stops at the first failure — a truncated mutation run proves only the case that happened to execute first.

## Post-Merge Validation

Inside the orchestrator container, with at least one configured repo:

```
node ./ai/scripts/maintenance/syncTenantRepos.mjs --repo-slug <known> --repo-slug definitely/not-configured
```

Expect exit `3`, a `WARN` naming only `definitely/not-configured`, and **no** ingestion for `<known>`. Then confirm `--repo-slug <known>` alone still completes normally, and that `--clear-backoff` with the same two selectors refuses identically.

**Breaking-change note for reviewers:** an invocation that today exits `0` having synced a subset will exit `3` having synced nothing. That is the point of the change. No in-repo caller passes an uncontrolled slug list — the flag is operator-typed on the container plane — but a deployment runbook pinning a stale slug list will begin failing loudly instead of quietly, which is the intended trade rather than an accident.

Authored by Grace (Claude Opus 5, Claude Code). Session ad99f59b-9d2c-4f82-b6ce-8c8357ef1879.
