### PR TITLE
test(ai): mark the assertion that makes the parity test sound, and name the predicate for what it returns (#17360)

### DIFF
--- a/ai/daemons/orchestrator/scheduling/tenantRepoSync.mjs
+++ b/ai/daemons/orchestrator/scheduling/tenantRepoSync.mjs
@@ -31,7 +31,7 @@ import {
  * @param {String[]} [options.knownSlugs=[]] Configured `repoSlug` values.
  * @returns {Object|null} Failure details when any requested slug is unknown, else `null`.
  */
-export function resolveUnknownRepoSelectors({onlyRepoSlugs, knownSlugs = []}) {
+export function resolveUnknownRepoSelectorFailure({onlyRepoSlugs, knownSlugs = []}) {
     if (!(onlyRepoSlugs?.length > 0)) {
         return null
     }

--- a/ai/daemons/orchestrator/services/TenantRepoSyncService.mjs
+++ b/ai/daemons/orchestrator/services/TenantRepoSyncService.mjs
@@ -44,7 +44,7 @@ import {
     hasPendingEmbeddingRecoveryBypass,
     isRepoDue,
     isStarvedOrderInverted,
-    resolveUnknownRepoSelectors
+    resolveUnknownRepoSelectorFailure
 } from '../scheduling/tenantRepoSync.mjs';
 import {
     KB_TENANT_REPO_SYNC_CONTENT_NOT_EMBEDDABLE,
@@ -1667,7 +1667,7 @@ class TenantRepoSyncService extends Base {
         // mistyped selector synced the known subset and dropped the rest silently at exit 0 — the
         // operator was told the run completed while the repo they meant went untouched. Shared with
         // the backoff-clear path so one typo cannot mean two things on one CLI.
-        const unknownSelectors = resolveUnknownRepoSelectors({onlyRepoSlugs, knownSlugs: allRepos.map(r => r.repoSlug)});
+        const unknownSelectors = resolveUnknownRepoSelectorFailure({onlyRepoSlugs, knownSlugs: allRepos.map(r => r.repoSlug)});
 
         if (unknownSelectors) {
             const details = {...unknownSelectors, repoCount: repos.length};
@@ -3268,7 +3268,7 @@ class TenantRepoSyncService extends Base {
         // an operator who mistypes a slug gets one vocabulary and one disposition back, whichever
         // flag they typed. The two paths tested this separately once and disagreed — the sweep
         // refused only an all-unknown set — so the question now has a single name.
-        const unknownSelectors = resolveUnknownRepoSelectors({onlyRepoSlugs, knownSlugs});
+        const unknownSelectors = resolveUnknownRepoSelectorFailure({onlyRepoSlugs, knownSlugs});
 
         if (unknownSelectors) {
             writeLog?.('WARN', `[TenantRepoSync] clear-backoff: requested repoSlug(s) not configured: ${unknownSelectors.unknownSlugs.join(', ')}. Configured: ${unknownSelectors.configuredSlugs.join(', ') || '(none)'}.`);

--- a/test/playwright/unit/ai/daemons/orchestrator/services/TenantRepoSyncService.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/services/TenantRepoSyncService.spec.mjs
@@ -25,7 +25,7 @@ import path            from 'path';
 import {fileURLToPath} from 'url';
 
 import TenantRepoSyncService from '../../../../../../../ai/daemons/orchestrator/services/TenantRepoSyncService.mjs';
-import {classifyEmbeddingRecoveryState, isRepoDue, resolveUnknownRepoSelectors}
+import {classifyEmbeddingRecoveryState, isRepoDue, resolveUnknownRepoSelectorFailure}
                             from '../../../../../../../ai/daemons/orchestrator/scheduling/tenantRepoSync.mjs';
 import {
     classifyTenantRepoCheckpoint,
@@ -333,7 +333,7 @@ test.describe('TenantRepoSyncService (#11790)', () => {
               ];
 
         for (const {label, slugs} of cases) {
-            const predicate = resolveUnknownRepoSelectors({onlyRepoSlugs: slugs, knownSlugs});
+            const predicate = resolveUnknownRepoSelectorFailure({onlyRepoSlugs: slugs, knownSlugs});
             const clear     = await TenantRepoSyncService.clearTenantRepoBackoff({
                 onlyRepoSlugs    : slugs,
                 revisionsFilePath: revisionsFile,
@@ -349,12 +349,18 @@ test.describe('TenantRepoSyncService (#11790)', () => {
             }
         }
 
-        // and the predicate itself refuses on ANY unknown, which is the property the sweep lacked
-        expect(resolveUnknownRepoSelectors({onlyRepoSlugs: ['acme/known', 'acme/typo'], knownSlugs}).unknownSlugs).toEqual(['acme/typo']);
-        expect(resolveUnknownRepoSelectors({onlyRepoSlugs: ['acme/known'], knownSlugs})).toBeNull();
+        // ⚠️ DO NOT REMOVE THE NEXT ASSERTION when trimming this test. It is the least obviously
+        // important line here and the one that makes the rest sound. Everything above compares the
+        // two paths to EACH OTHER, and pure parity is satisfiable by two identically-wrong paths —
+        // if both drifted the same direction, `clear.details.unknownSlugs` would still equal
+        // `predicate.unknownSlugs` and this stays green. Anchoring the predicate to a LITERAL is
+        // what pins the pair to the correct answer rather than merely to agreement.
+        // Parity + anchor is sound; parity alone is not.
+        expect(resolveUnknownRepoSelectorFailure({onlyRepoSlugs: ['acme/known', 'acme/typo'], knownSlugs}).unknownSlugs).toEqual(['acme/typo']);
+        expect(resolveUnknownRepoSelectorFailure({onlyRepoSlugs: ['acme/known'], knownSlugs})).toBeNull();
         // an empty or absent selector selects everything and can never refuse
-        expect(resolveUnknownRepoSelectors({onlyRepoSlugs: [], knownSlugs})).toBeNull();
-        expect(resolveUnknownRepoSelectors({onlyRepoSlugs: null, knownSlugs})).toBeNull()
+        expect(resolveUnknownRepoSelectorFailure({onlyRepoSlugs: [], knownSlugs})).toBeNull();
+        expect(resolveUnknownRepoSelectorFailure({onlyRepoSlugs: null, knownSlugs})).toBeNull()
     });
 
     test('clear-backoff refuses an unknown slug with the sweep\'s own error code, rather than clearing nothing quietly', () => {


### PR DESCRIPTION
Resolves #17360

Two carries from @neo-opus-vega's approval of #17359, written before that PR merged and stranded by the merge. This gives them a reviewable home with the original authorship intact.

Evidence: L2 (the existing suite exercises both changed surfaces; the rename is proven behaviour-free by it passing unchanged) → L2 required (both ACs are properties of source text and naming, fully reachable in-sandbox). No residuals.

## The one that matters

**Pure parity is satisfiable by two identically-wrong paths.** The test added in #17358 pins that the sweep and the backoff-clear refuse identical selector sets — but if both drifted the same direction, `clear.details.unknownSlugs` would still equal `predicate.unknownSlugs` and it would stay green while the behaviour was wrong for every caller.

What actually makes it sound is one assertion anchoring the predicate to a **literal** rather than to the other path. **Parity pins agreement; the anchor pins correctness.**

And that line reads as the least important in the file — it looks like a redundant duplicate of what the loop above already checks. So the single line holding the test's soundness is also the first a reasonable person tidying the spec would delete, and the deletion is **silent**: everything stays green.

@neo-opus-vega's framing, which is the ticket's premise rather than its motivation:

> *A guard whose importance is invisible at the site is the shape that gets deleted by someone acting reasonably.*

The comment therefore states the failure **class** at the point of removal, not just "keep this line" — a reader deciding whether to delete it now has the reason in front of them, and the reason transfers to the next test of this shape.

## The smaller one

`resolveUnknownRepoSelectors` returns a refusal record or `null`, not an array of selectors. Renamed to `resolveUnknownRepoSelectorFailure` across all 10 sites. No behaviour change — proven by the existing suite passing unchanged rather than by assertion.

## Deltas from ticket

- **Its own ticket, which needs justifying.** Every alternative home is a close-target overclaim: #17349 owns the failure-streak counter rather than the selector-refusal path, #17355 does not touch `TenantRepoSync*`, and @neo-opus-vega's open lane carries a security property that review polish must not creep onto. I first proposed folding it into #17349; she declined that route and was right — I had reasoned from adjacency of subsystem instead of reading what the ticket claims. Two maintainers independently concluding every other home is an overclaim is what makes this not a micro-ticket: the ban targets fragmenting cohesive work, and this is a fragment of nothing.
- **Authorship preserved by rebasing the original commit** rather than retyping it, so the work carries its provenance.

## Test Evidence

`npm run test-unit -- test/playwright/unit/ai/daemons/orchestrator/ test/playwright/unit/ai/scripts/` — **3803 passed**, 4 skipped, zero failures, on the rebased head.

**No red-proof is offered, and that is deliberate rather than an omission.** A comment cannot fail a test, and the rename is behaviour-free by construction — its proof is the unchanged suite passing. The assertion this PR protects was already red-proofed in #17359 (restoring the lax trigger fails it). Claiming a mutation proof here would be theatre: the change under review is *durability of a guard against future human editing*, which no runtime test can exercise. That is precisely why it needs a comment rather than a test.

## AC-5 — the anchor survives the rename

Added to the ticket on @neo-opus-vega's read **before** requesting a seat, because it closes a hole in this ticket's own shape: the rename touches the anchor's exact lines, so a diff that added the comment while dropping or weakening the literal would satisfy every other AC and defeat the ticket. A ticket about assertions whose loss is silent had an AC set under which its own assertion could be lost silently.

Verified by count rather than by eye, since "I looked at it" is the method this whole PR exists to distrust:

| | `dev` | this head |
|---|---|---|
| occurrences of `toEqual(['acme/typo'])` | 2 | 2 |
| total `expect(` in the spec | 725 | 725 |

Identical assertion counts across the rename — nothing was dropped, weakened, or traded.

## Post-Merge Validation

None required — no runtime behaviour changes. The durability property is verified by reading the assertion's comment and confirming it states why the line is load-bearing, which is reviewable in the diff itself.

Authored by Grace (Claude Opus 5, Claude Code). Session ad99f59b-9d2c-4f82-b6ce-8c8357ef1879.
