### PR TITLE
test(ai): the do-not-remove marker covers both anchors, not one (#17363)

### DIFF
--- a/test/playwright/unit/ai/daemons/orchestrator/services/TenantRepoSyncService.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/services/TenantRepoSyncService.spec.mjs
@@ -349,13 +349,20 @@ test.describe('TenantRepoSyncService (#11790)', () => {
             }
         }
 
-        // ⚠️ DO NOT REMOVE THE NEXT ASSERTION when trimming this test. It is the least obviously
-        // important line here and the one that makes the rest sound. Everything above compares the
-        // two paths to EACH OTHER, and pure parity is satisfiable by two identically-wrong paths —
-        // if both drifted the same direction, `clear.details.unknownSlugs` would still equal
-        // `predicate.unknownSlugs` and this stays green. Anchoring the predicate to a LITERAL is
-        // what pins the pair to the correct answer rather than merely to agreement.
+        // ⚠️ DO NOT REMOVE THE NEXT TWO ASSERTIONS when trimming this test. They are the least
+        // obviously important lines here and the ones that make the rest sound. Everything above
+        // compares the two paths to EACH OTHER, and pure parity is satisfiable by two
+        // identically-wrong paths — if both drifted the same direction, `clear.details.unknownSlugs`
+        // would still equal `predicate.unknownSlugs` and this stays green. Anchoring the predicate to
+        // LITERALS is what pins the pair to the correct answer rather than merely to agreement.
         // Parity + anchor is sound; parity alone is not.
+        //
+        // BOTH, because one alone is satisfiable by a broken predicate. The first pins that an
+        // any-unknown selector refuses AND names the right set; a predicate that refused EVERY
+        // selector would pass it. The second is what rules that out — an all-known selector must
+        // return null — so the pair fences over-refusal and under-refusal from opposite sides. The
+        // two `toBeNull()` calls below the next comment are a different property (an empty or absent
+        // selector selects everything) and are not part of this pair.
         expect(resolveUnknownRepoSelectorFailure({onlyRepoSlugs: ['acme/known', 'acme/typo'], knownSlugs}).unknownSlugs).toEqual(['acme/typo']);
         expect(resolveUnknownRepoSelectorFailure({onlyRepoSlugs: ['acme/known'], knownSlugs})).toBeNull();
         // an empty or absent selector selects everything and can never refuse


### PR DESCRIPTION
Resolves #17363

🌿 *The marker protected one anchor and two stood under it; now the pair is named with the reason each carries, and "which line was I told not to delete" has no second answer.*

Evidence: L3 (comment-only change, existing suite green at head, and the comment's load-bearing claim verified by mutation) → L3 required (#17363's ACs are all reachable in-tree). Residual: none.

## What this fixes, and why it is not cosmetic

`#17360` added a `⚠️ DO NOT REMOVE` marker above the assertion that makes the parity test sound. It said **THE NEXT ASSERTION**, singular, and **two** anchors follow it.

The second — an all-known selector must return `null` — is also an anchor and also pins **correctness** rather than agreement. Under a literal reading it was unprotected.

So this is **#17360's own defect recurring one line below #17360's fix**: a guard whose importance is invisible at its site, sitting directly beneath the comment written to prevent exactly that.

## The fix names why, not just how many

Widening `ASSERTION` → `TWO ASSERTIONS` would have closed the count and left the same weakness, because a reader deciding whether to delete a line needs the *reason*, not the prohibition. The comment now states why **one alone is insufficient**:

- The **first** pins that an any-unknown selector refuses *and* names the right unknown set. A predicate that refused **every** selector would also pass it.
- The **second** is what rules that out.

Together they fence over-refusal and under-refusal from opposite sides. Neither is redundant, which is precisely what makes both look deletable.

It also **delimits the pair**: the two `toBeNull()` calls below the next comment test a different property — an empty or absent selector selects everything — so widening the marker does not silently annex assertions it was never about.

## Deltas from ticket

None substantive. The ticket asked for the marker to cover both anchors; this additionally states the reason and bounds the pair, which is the same fix done once rather than twice.

## Test Evidence

- `npx playwright test -c test/playwright/playwright.config.unit.mjs --workers=1 test/playwright/unit/ai/daemons/orchestrator/services/TenantRepoSyncService.spec.mjs` → **145 passed**
- Comment-only, proven by count rather than claimed: `expect(` totals are **725 on `origin/dev`** and **725 here**. (Count equality proves no *net* change, not that the same assertions survived — so it is used here only for what it does prove, and the diff is visibly comment-only.)

**The comment's central claim is verified by mutation rather than asserted.** I replaced the predicate with one that refuses *every* selector — the exact break the second assertion exists to catch:

| predicate | assertion 1 | assertion 2 |
|---|---|---|
| real | PASS | PASS |
| mutant: refuses everything | **PASS** | **FAIL** |

The mutant satisfies the first and is caught only by the second, so the comment describes the behaviour these assertions actually have.

Per touched surface: `TenantRepoSyncService.spec.mjs` → itself, 145 passed. No production file changed, so **`None found`** is not applicable — there is no runtime surface to cover.

## Post-Merge Validation

**None owed.** Comment-only, verified in-tree, and no runtime behaviour moved.

## Commits

- `19f9227` — the marker covers both anchors, with the reason and the pair bounded

## Evolution

This PR exists because I graded a review wrong. I found the gap while reviewing #17361, wrote it as *"fold or decline"*, and approved — and the PR merged 39 seconds later, so there was never a fold window for the author to use. @tobiu's model is the correction: **approval is a PR's terminal state, so a note attached to one is either work that never happens or work that costs a whole new ticket, branch, PR, review and merge.** This is that cost, paid. One `RC` round on #17361 would have carried the same fix for a fraction of it.

Authored by Vega (Claude Opus 5, Claude Code). Session 9ccc2fa1-8843-4796-8e85-5e151c0392d2.
