### PR TITLE
feat(ai): a container's startup facts survive the log tail aging out (#17357)

### DIFF
--- a/ai/configBase.mjs
+++ b/ai/configBase.mjs
@@ -1423,6 +1423,22 @@ class ConfigBase extends ConfigProvider {
                     includeLogs                 : leaf(true, 'NEO_DEPLOYMENT_STATE_BRIDGE_INCLUDE_LOGS', 'boolean'),
                     logTail                     : leaf(120, 'NEO_DEPLOYMENT_STATE_BRIDGE_LOG_TAIL', 'number'),
                     logMaxBytes                 : leaf(32 * 1024, 'NEO_DEPLOYMENT_STATE_BRIDGE_LOG_MAX_BYTES', 'number'),
+                    /**
+                     * How far past a container's start the startup-log head reaches, in ms.
+                     *
+                     * Startup output is emitted exactly once and then stops, so a *time* window bounds
+                     * it server-side far more tightly than a line count could: the read asks Docker
+                     * for `since=StartedAt, until=StartedAt+window` and gets the banner rather than
+                     * the banner plus hours of runtime traffic.
+                     *
+                     * `60_000` is sized against model loading, which is the slowest startup on this
+                     * plane and the one whose reported geometry is most wanted — a small embedding
+                     * model banners in seconds, a large one can take most of a minute. Too small
+                     * silently truncates the very facts the window exists to capture, which is the
+                     * expensive direction; too large only costs bytes that `logMaxBytes` already caps.
+                     * @type {number}
+                     */
+                    startupLogWindowMs          : leaf(60 * 1000, 'NEO_DEPLOYMENT_STATE_BRIDGE_STARTUP_LOG_WINDOW_MS', 'number'),
                     statsSampleWindow           : leaf(2, 'NEO_DEPLOYMENT_STATE_BRIDGE_STATS_SAMPLE_WINDOW', 'number'),
                     providerResidencyServiceKeys: leaf(['local-model', 'model'], 'NEO_DEPLOYMENT_STATE_BRIDGE_PROVIDER_RESIDENCY_SERVICE_KEYS', 'csv'),
                     /**

--- a/ai/daemons/orchestrator/services/DeploymentStateBridgeService.mjs
+++ b/ai/daemons/orchestrator/services/DeploymentStateBridgeService.mjs
@@ -74,6 +74,7 @@ import {
 } from '../../../services/knowledge-base/helpers/tenantRepoAccessContract.mjs';
 
 import {
+    boundUtf8Head,
     boundUtf8Tail,
     createDeploymentStateSnapshot,
     writeDeploymentStateSnapshot
@@ -284,6 +285,20 @@ export class DeploymentStateBridgeService extends Base {
     lastWriteAt           = 0
     writeInFlight         = false
     statsSamplesByService = new Map()
+
+    /**
+     * Startup-log heads, keyed by `serviceKey`, holding `{startedAt, record}`.
+     *
+     * Cached because the head is invariant for the life of an incarnation — a process emits its
+     * startup output once and then stops — so re-reading it every collection would pay a Docker call
+     * per service per sweep to receive the same bytes. The cache key is the incarnation start, which
+     * makes invalidation structural rather than time-based: a restart changes `StartedAt`, the key
+     * misses, and the next collection fetches the new incarnation's head. Nothing expires; there is
+     * no staleness to expire against.
+     * @member {Map<String,Object>} startupLogHeadsByService
+     * @protected
+     */
+    startupLogHeadsByService = new Map()
     // Last service-state signature written to the log; gates the edge-triggered success line so a
     // healthy steady-state stops re-emitting an identical INFO line on every snapshot write.
     lastLoggedSignature   = null
@@ -699,7 +714,16 @@ export class DeploymentStateBridgeService extends Base {
                 proofByOperation.inspect.target.containerId === proofByOperation.stats?.target?.containerId
                 ? proofByOperation.inspect.target.containerId
                 : null,
-            logSummary     = summarizeLogs(logs, bridgeConfig.logMaxBytes, {sameTarget}),
+            logSummary     = summarizeLogs(logs, bridgeConfig.logMaxBytes, {
+                sameTarget,
+                // Published INSIDE `logs` rather than as a sibling field, because it answers a
+                // question about the same stream: the tail says what this service is doing, the head
+                // says what it decided. A reader chasing one will look where the other lives.
+                startup: await this.readStartupLogHead({
+                    serviceKey,
+                    incarnationStartedAt: inspectSummary?.state?.startedAt ?? null
+                })
+            }),
             // Consumes the SAME `nodeCommand` observation the heap attribution uses, rather than
             // re-deriving what "a Node service" means. Placed after the summary for that reason
             // alone; it is otherwise a sibling of `providerResidency` — nullable, non-Docker-derived,
@@ -1477,6 +1501,136 @@ export class DeploymentStateBridgeService extends Base {
     }
 
     /**
+     * @summary Reads the head of this incarnation's log stream, where a process reports what it decided.
+     *
+     * **The gap this closes.** Startup output is emitted exactly once, in the first seconds, and is
+     * where a process states its resolved geometry, allocation plan, model identity and negotiated
+     * features. The published tail is a rolling window sized for recent activity — correct for "what
+     * is this service doing now" and structurally wrong for "what did it decide when it started",
+     * because the banner's distance from the tail grows with uptime. On this plane an embedding
+     * provider's KV-cache and compute-buffer sizes were unreadable after four hours, so a memory
+     * footprint got attributed from a fitted formula while the engine's own numbers had been
+     * available and were discarded by retention.
+     *
+     * **Raising `logTail` is not the fix**, which is why this is a second read rather than a bigger
+     * one: any fixed line count is a bet on how soon someone looks, and the bet gets worse the longer
+     * a deployment runs well.
+     *
+     * **A time window, not a line count.** Docker bounds `since`/`until` server-side, so asking for
+     * `StartedAt → StartedAt + window` returns the banner instead of the banner plus hours of runtime
+     * traffic. That also makes the read self-limiting on a chatty service without needing to guess a
+     * line budget.
+     *
+     * **Nothing is stored, and that is the design.** An earlier shape for this captured the head once
+     * and retained it, with wholesale replacement on restart. Retention turned out to be unnecessary:
+     * the window keys off `StartedAt`, so the read is *always* about the current incarnation and can
+     * simply be re-derived. What remains is a cache keyed on that same value — invalidation is
+     * structural, not temporal, and there is no stale-record arm to get wrong.
+     *
+     * **Absence carries a reason, never an empty string.** A bridge that first observed a service
+     * already running, or whose window fell off the far side of log rotation, has no head to publish —
+     * and `text: ''` would read as *this service printed nothing at startup*, a confident claim about
+     * a process nobody watched boot. That is the failure this method exists to prevent, arriving by a
+     * different route.
+     *
+     * @param {Object}      options
+     * @param {String}      options.serviceKey           Service whose head to read.
+     * @param {String|null} options.incarnationStartedAt Current incarnation's start, ISO.
+     * @param {Object}     [options.config]              Resolved `deploymentStateBridge` leaves.
+     * @returns {Promise<Object>} Always an envelope; `text` is `null` whenever `status` is `unavailable`.
+     */
+    async readStartupLogHead({serviceKey, incarnationStartedAt, config = AiConfig.orchestrator.deploymentStateBridge}) {
+        const unavailable = reason => ({
+            schemaVersion       : 1,
+            recordType          : 'deployment-startup-log-head',
+            serviceKey,
+            status              : 'unavailable',
+            unavailableReason   : reason,
+            incarnationStartedAt: incarnationStartedAt ?? null,
+            windowMs            : null,
+            lines               : null,
+            text                : null,
+            truncated           : false
+        });
+
+        if (!config.includeLogs) {
+            // A disabled log channel is not evidence that the service reported nothing.
+            return unavailable('channel-disabled')
+        }
+
+        const startedAtMs = Date.parse(incarnationStartedAt ?? '');
+
+        // Without a known incarnation start there is no window to ask for, and guessing one would
+        // reach into a PREVIOUS incarnation — the exact poison `since` exists to remove on the tail.
+        if (!Number.isFinite(startedAtMs)) {
+            return unavailable('incarnation-start-unknown')
+        }
+
+        const windowMs = Number.isFinite(config.startupLogWindowMs) && config.startupLogWindowMs > 0
+            ? config.startupLogWindowMs
+            : null;
+
+        if (windowMs === null) {
+            return unavailable('window-not-configured')
+        }
+
+        const cached = this.startupLogHeadsByService.get(serviceKey);
+
+        // Structural invalidation: same incarnation start means the same head, byte for byte.
+        if (cached && cached.startedAt === incarnationStartedAt) {
+            return cached.record
+        }
+
+        let response;
+
+        try {
+            response = await this.runtimeAccessService.readObserve({
+                serviceKey,
+                operation: 'logs',
+                since    : incarnationStartedAt,
+                until    : new Date(startedAtMs + windowMs).toISOString(),
+                // Generous, because the WINDOW is the bound that matters here. A line cap would take
+                // the last N lines *of the window*, which is a tail of the head — the wrong end of the
+                // wrong thing. `logMaxBytes` is the real ceiling and it trims from the correct side.
+                tail     : 10_000
+            });
+        } catch (error) {
+            return unavailable(error.code === 'ENOENT' ? 'absent' : 'unreadable')
+        }
+
+        // `readObserve` answers `{data, proof}`; the payload is on `data`. Unwrapped here rather than
+        // consumed raw, because the collection path's own `read()` helper does the same and a reader
+        // that skipped it would find `undefined` and report an empty window — a wrong reason rather
+        // than a missing value, which is the harder failure to notice.
+        const bounded = boundUtf8Head(response?.data?.logs, config.logMaxBytes),
+              text    = bounded.text.trim();
+
+        if (!text) {
+            // Distinguished from a failed read: the window was asked for and came back empty, which on
+            // a long-running container means rotation has carried the head away. Naming that is what
+            // keeps a reader from concluding the service was silent at boot.
+            return unavailable('window-empty-or-rotated')
+        }
+
+        const record = {
+            schemaVersion    : 1,
+            recordType       : 'deployment-startup-log-head',
+            serviceKey,
+            status           : 'available',
+            unavailableReason: null,
+            incarnationStartedAt,
+            windowMs,
+            lines            : text.split('\n').length,
+            text             : bounded.text,
+            truncated        : bounded.truncated
+        };
+
+        this.startupLogHeadsByService.set(serviceKey, {startedAt: incarnationStartedAt, record});
+
+        return record
+    }
+
+    /**
      * @summary Persists the restart-churn baseline for one service.
      *
      * Returns the outcome rather than only logging it. The ERROR log below is written to a stream
@@ -2132,12 +2286,19 @@ function summarizeStats(stats) {
     };
 }
 
-function summarizeLogs(logs, maxBytes, {sameTarget = false} = {}) {
-    if (!logs || typeof logs !== 'object') return null;
+function summarizeLogs(logs, maxBytes, {sameTarget = false, startup = null} = {}) {
+    // A missing tail read must not suppress the startup head: the two come from separate reads and
+    // fail independently, so collapsing them would hide a head that was successfully captured behind
+    // an unrelated tail failure.
+    if (!logs || typeof logs !== 'object') return startup ? {startup} : null;
 
     const bounded = boundUtf8Tail(logs.logs, maxBytes);
 
     return {
+        // The head of THIS incarnation, where the process reported what it decided. Always an
+        // envelope, never a bare string — every unavailable arm carries its own reason, so an absent
+        // head is never read as "this service printed nothing at startup".
+        startup,
         // `incarnationBounded` is set ONLY from the producer's echoed receipt — never from a
         // caller-supplied flag and never inferred here. A consumer that attributes a death to this
         // slice is trusting that the daemon actually applied the interval, so the claim has to

--- a/ai/scripts/lint/config-leaf-parity.json
+++ b/ai/scripts/lint/config-leaf-parity.json
@@ -348,6 +348,7 @@
         "orchestrator.deploymentStateBridge.selfHealRecentEventLimit",
         "orchestrator.deploymentStateBridge.snapshotPath",
         "orchestrator.deploymentStateBridge.staleAfterMs",
+        "orchestrator.deploymentStateBridge.startupLogWindowMs",
         "orchestrator.deploymentStateBridge.statsSampleWindow",
         "orchestrator.deploymentStateBridge.writeIntervalMs",
         "orchestrator.devServer",

--- a/ai/services/memory-core/helpers/deploymentStateBridgeStore.mjs
+++ b/ai/services/memory-core/helpers/deploymentStateBridgeStore.mjs
@@ -228,6 +228,48 @@ export function boundUtf8Tail(value, maxBytes) {
     };
 }
 
+/**
+ * @summary Bounds a UTF-8 string to the FIRST `maxBytes` bytes, cut on a line boundary.
+ *
+ * The twin of {@link boundUtf8Tail}, for the one case where the beginning is the payload: a
+ * container's startup output. A tail bound keeps the end because that is where a death is written;
+ * a head bound keeps the beginning because that is where a process reports what it decided — its
+ * resolved geometry, allocation plan and negotiated features, each emitted exactly once.
+ *
+ * **It cuts back to the last complete line, which its twin does not.** That is a deliberate
+ * difference rather than an inconsistency: a truncated head is read forward by a human looking for a
+ * specific reported value, so a dangling half-line invites misreading a number that was cut in two.
+ * Trimming to a line boundary also removes the split-multi-byte-character case for free.
+ *
+ * @param {String|null|undefined} value Text to bound.
+ * @param {Number} maxBytes Byte cap.
+ * @returns {{text: String, truncated: Boolean, maxBytes: Number}}
+ */
+export function boundUtf8Head(value, maxBytes) {
+    const text = value == null ? '' : String(value);
+
+    if (!Number.isFinite(maxBytes) || maxBytes <= 0) {
+        return {text: '', truncated: text.length > 0, maxBytes};
+    }
+
+    const buffer = Buffer.from(text, 'utf8');
+
+    if (buffer.length <= maxBytes) {
+        return {text, truncated: false, maxBytes};
+    }
+
+    const sliced      = buffer.subarray(0, maxBytes).toString('utf8'),
+          lastNewline = sliced.lastIndexOf('\n');
+
+    return {
+        // No newline inside the cap means one line longer than the whole budget — keep the byte cut
+        // rather than returning nothing, since an over-long single line is still evidence.
+        text     : lastNewline > 0 ? sliced.slice(0, lastNewline + 1) : sliced,
+        truncated: true,
+        maxBytes
+    };
+}
+
 function unavailable({filePath = null, reason, details = null}) {
     return {
         ok      : false,

--- a/test/playwright/unit/ai/daemons/orchestrator/services/DeploymentStateBridgeService.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/services/DeploymentStateBridgeService.spec.mjs
@@ -3706,3 +3706,223 @@ test.describe('Neo.ai.daemons.services.DeploymentStateBridgeService — identity
         bridge.destroy()
     });
 });
+
+/**
+ * @summary The startup-log head is bounded, incarnation-keyed, and never publishes an empty string.
+ *
+ * Startup output is emitted once, in the first seconds, and is where a process reports what it
+ * decided. The published tail cannot reach it on a long-running container — the banner's distance
+ * from the tail grows with uptime — so the arms that matter here are the ones proving the WINDOW is
+ * asked for server-side, that the cache invalidates on a restart rather than on a clock, and that an
+ * unreachable head reports a reason rather than an empty string.
+ */
+test.describe('Neo.ai.daemons.services.DeploymentStateBridgeService — startup log head', () => {
+    const
+        STARTED = '2026-08-18T10:00:00.000Z',
+        WINDOW  = 60_000,
+        cfg     = overrides => ({
+            includeLogs: true, logMaxBytes: 32 * 1024, logTail: 120, startupLogWindowMs: WINDOW, ...overrides
+        }),
+        // Records every readObserve call so the WINDOW itself can be asserted, not just its output.
+        //
+        // The stub returns the REAL `{data, proof}` envelope rather than a bare payload. An earlier
+        // version of this fixture returned `{logs}` directly, which happened to match a bug in the
+        // reader — it consumed the response without unwrapping `.data`. Every isolated test passed and
+        // only the published-record test caught it. A fixture shaped like the mistake cannot fail on it.
+        bridgeWith = (logsText, {calls = []} = {}) => {
+            const service = createService({});
+
+            service.runtimeAccessService = {
+                async readObserve(request) {
+                    calls.push(request);
+
+                    if (typeof logsText === 'function') return logsText(request);
+
+                    return {data: {logs: logsText}, proof: {operation: request.operation}}
+                }
+            };
+
+            return service
+        },
+        read = (service, overrides = {}) => service.readStartupLogHead({
+            serviceKey          : 'embedding-model',
+            incarnationStartedAt: STARTED,
+            config              : cfg(),
+            ...overrides
+        });
+
+    test('the head is requested as a server-side WINDOW, not a line count', async () => {
+        // The mechanism claim: `since`/`until` bound the read at Docker rather than trimming a tail
+        // client-side. Without both, `readTargetLogs` drops the interval entirely and returns a tail.
+        const calls  = [],
+              result = await read(bridgeWith('llama_kv_cache: size = 7168 MiB\nlistening\n', {calls}));
+
+        expect(result.status).toBe('available');
+        expect(calls).toHaveLength(1);
+        expect(calls[0].operation).toBe('logs');
+        expect(calls[0].since).toBe(STARTED);
+        expect(calls[0].until).toBe(new Date(Date.parse(STARTED) + WINDOW).toISOString());
+        expect(result.windowMs).toBe(WINDOW);
+        expect(result.text).toContain('llama_kv_cache');
+    });
+
+    test('the cache is keyed on the INCARNATION, so a restart invalidates and a re-read does not', async () => {
+        const calls   = [],
+              service = bridgeWith(
+                  request => ({data: {logs: `boot at ${request.since}\n`}, proof: {operation: request.operation}}),
+                  {calls}
+              );
+
+        const first  = await read(service),
+              second = await read(service);
+
+        // Same incarnation: one Docker call, identical record. This is the whole reason for the cache —
+        // the head is invariant for a container's life, so re-reading buys nothing.
+        expect(calls).toHaveLength(1);
+        expect(second).toEqual(first);
+
+        // A restart changes StartedAt. Invalidation is structural, not temporal — nothing expires.
+        const restarted = '2026-08-18T12:00:00.000Z',
+              third     = await read(service, {incarnationStartedAt: restarted});
+
+        expect(calls).toHaveLength(2);
+        expect(third.incarnationStartedAt).toBe(restarted);
+        expect(third.text).toContain(restarted);
+    });
+
+    test('HONESTY: every unavailable arm names a reason and nulls `text` — never an empty string', async () => {
+        // `text: ''` would read as "this service printed nothing at startup", which is a confident
+        // claim about a process nobody watched boot. That is the failure this method exists to prevent.
+        const arms = [
+            ['channel-disabled',         () => read(bridgeWith('x\n'), {config: cfg({includeLogs: false})})],
+            ['incarnation-start-unknown', () => read(bridgeWith('x\n'), {incarnationStartedAt: null})],
+            ['incarnation-start-unknown', () => read(bridgeWith('x\n'), {incarnationStartedAt: 'not-a-date'})],
+            ['window-not-configured',    () => read(bridgeWith('x\n'), {config: cfg({startupLogWindowMs: 0})})],
+            ['window-empty-or-rotated',  () => read(bridgeWith('   \n  \n'))],
+            ['window-empty-or-rotated',  () => read(bridgeWith(null))],
+            ['unreadable',               () => read(bridgeWith(() => { throw new Error('docker said no') }))]
+        ];
+
+        for (const [expectedReason, run] of arms) {
+            const result = await run();
+
+            expect(result.status, expectedReason).toBe('unavailable');
+            expect(result.unavailableReason, expectedReason).toBe(expectedReason);
+            expect(result.text, `${expectedReason}: text must be null, not ''`).toBeNull();
+            expect(result.lines, `${expectedReason}: lines must be null`).toBeNull();
+        }
+    });
+
+    test('an empty window is distinguished from a failed read — rotation is not an error', async () => {
+        // Both produce no head, and conflating them would make a rotated-away banner look like a
+        // broken instrument. The remedies differ: one is expected on a long-lived container, the other
+        // is a Docker problem.
+        const rotated = await read(bridgeWith('')),
+              broken  = await read(bridgeWith(() => { throw new Error('boom') }));
+
+        expect(rotated.unavailableReason).toBe('window-empty-or-rotated');
+        expect(broken.unavailableReason).toBe('unreadable');
+    });
+
+    test('the head is byte-bounded from the correct END, cut on a line boundary', async () => {
+        // A tail bound would keep the LAST bytes, discarding exactly the banner this read exists for.
+        const lines  = Array.from({length: 500}, (_, i) => `line ${i} ${'x'.repeat(80)}`).join('\n') + '\n',
+              result = await read(bridgeWith(lines), {config: cfg({logMaxBytes: 2_000})});
+
+        expect(result.status).toBe('available');
+        expect(result.truncated).toBe(true);
+        expect(result.text.startsWith('line 0 '), 'the HEAD must survive, not the tail').toBe(true);
+        expect(result.text).not.toContain('line 499');
+
+        // Cut on a line boundary: no dangling half-line for a human reading forward for a value.
+        expect(result.text.endsWith('\n')).toBe(true);
+        expect(Buffer.byteLength(result.text, 'utf8')).toBeLessThanOrEqual(2_000);
+    });
+
+    test('the field reaches the PUBLISHED record under `logs`', async () => {
+        // An isolated reader corpus cannot catch an unreachable call site. The head answers a question
+        // about the same stream as the tail, so it is published inside `logs` where a reader chasing
+        // one will find the other.
+        const bridge = Neo.create(DeploymentStateBridgeService, {
+            runtimeAccessService  : {
+                async readObserve(request) {
+                    if (request.operation === 'inspect') {
+                        return {
+                            data : {
+                                Id    : 'c-x',
+                                State : {Status: 'running', StartedAt: STARTED},
+                                Config: {Cmd: ['node', 'server.mjs']}
+                            },
+                            proof: {operation: 'inspect'}
+                        }
+                    }
+
+                    if (request.operation === 'logs') {
+                        return {data: {logs: 'llama_kv_cache: size = 7168 MiB\n', bounded: true}, proof: {operation: 'logs'}}
+                    }
+
+                    return {data: null, proof: {operation: request.operation}}
+                }
+            },
+            diagnosisService      : Neo.create(ContainerHealthDiagnosisService, {}),
+            providerResidencyProbe: async () => null,
+            writeLog              : () => {},
+            nowFn                 : () => OBSERVED_AT
+        });
+
+        const record = await bridge.collectServiceSnapshot({serviceKey: 'embedding-model', observedAt: OBSERVED_AT});
+
+        expect(record.logs?.startup, 'the head must reach the record, not just the reader').toBeTruthy();
+        expect(record.logs.startup.recordType).toBe('deployment-startup-log-head');
+        expect(record.logs.startup.serviceKey).toBe('embedding-model');
+
+        bridge.destroy()
+    });
+
+    test('a failed TAIL read does not suppress a captured head — they fail independently', async () => {
+        // Two reads of the same operation, two failure modes. Collapsing them would hide a head that
+        // WAS captured behind an unrelated tail failure — the shape that kept this gap invisible.
+        //
+        // The stub separates them the way the code does: the tail read carries a null `until` (a
+        // running container has no FinishedAt), the head read carries a real one. No private function
+        // is exported to test this; the property is asserted through the published record.
+        const bridge = Neo.create(DeploymentStateBridgeService, {
+            runtimeAccessService  : {
+                async readObserve(request) {
+                    if (request.operation === 'inspect') {
+                        return {
+                            data : {
+                                Id    : 'c-x',
+                                State : {Status: 'running', StartedAt: STARTED},
+                                Config: {Cmd: ['node', 'server.mjs']}
+                            },
+                            proof: {operation: 'inspect'}
+                        }
+                    }
+
+                    if (request.operation === 'logs') {
+                        // The HEAD read (has `until`) succeeds; the TAIL read (no `until`) fails.
+                        if (request.until) {
+                            return {data: {logs: 'llama_kv_cache: size = 7168 MiB\n'}, proof: {operation: 'logs'}}
+                        }
+
+                        throw new Error('tail read failed')
+                    }
+
+                    return {data: null, proof: {operation: request.operation}}
+                }
+            },
+            diagnosisService      : Neo.create(ContainerHealthDiagnosisService, {}),
+            providerResidencyProbe: async () => null,
+            writeLog              : () => {},
+            nowFn                 : () => OBSERVED_AT
+        });
+
+        const record = await bridge.collectServiceSnapshot({serviceKey: 'embedding-model', observedAt: OBSERVED_AT});
+
+        expect(record.logs?.startup?.status, 'a tail failure must not take the head with it').toBe('available');
+        expect(record.logs.startup.text).toContain('llama_kv_cache');
+
+        bridge.destroy()
+    });
+});

--- a/test/playwright/unit/ai/daemons/orchestrator/services/DeploymentStateBridgeService.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/services/DeploymentStateBridgeService.spec.mjs
@@ -3788,6 +3788,13 @@ test.describe('Neo.ai.daemons.services.DeploymentStateBridgeService — startup 
         expect(calls).toHaveLength(2);
         expect(third.incarnationStartedAt).toBe(restarted);
         expect(third.text).toContain(restarted);
+
+        // REPLACES rather than appends, and this is the half that carries the property. Asserting the
+        // new incarnation's content is present cannot distinguish a replacement from an accumulation —
+        // both contain it. The old incarnation being ABSENT is what rules out two boots reading as one,
+        // where the earlier values would still look current to anyone reading the head.
+        expect(third.text,
+            "a restart's head must not carry the previous incarnation's output").not.toContain(STARTED);
     });
 
     test('HONESTY: every unavailable arm names a reason and nulls `text` — never an empty string', async () => {

--- a/test/playwright/unit/ai/services/memory-core/helpers/deploymentStateBridgeStore.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/helpers/deploymentStateBridgeStore.spec.mjs
@@ -4,6 +4,7 @@ import os             from 'os';
 import path           from 'path';
 
 import {
+    boundUtf8Head,
     boundUtf8Tail,
     createDeploymentStateSnapshot,
     readDeploymentStateSnapshot,
@@ -139,6 +140,33 @@ test.describe('deploymentStateBridgeStore', () => {
             truncated: true,
             maxBytes : 4
         });
+    });
+
+    test('bounds log HEADS from the opposite end, cut on a line boundary (#17357)', () => {
+        // The twin of the tail bound, and the contrast IS the test: same input, same cap, opposite
+        // survivor. A tail keeps the end because that is where a death is written; a head keeps the
+        // beginning because that is where a process reports what it decided, exactly once.
+        expect(boundUtf8Tail('0123456789', 4).text).toBe('6789');
+        expect(boundUtf8Head('0123456789', 4).text).toBe('0123');
+
+        // Cuts back to the last complete line, which the tail deliberately does not: a truncated head
+        // is read FORWARD by a human hunting a reported value, so a dangling half-line invites
+        // misreading a number that was cut in two.
+        const lines = boundUtf8Head('aaaa\nbbbb\ncccc\n', 7);
+
+        expect(lines.text).toBe('aaaa\n');
+        expect(lines.truncated).toBe(true);
+
+        // A single line longer than the whole budget still yields bytes rather than nothing — an
+        // over-long line is evidence, and returning '' would read as "printed nothing".
+        expect(boundUtf8Head('xxxxxxxxxx', 4)).toEqual({text: 'xxxx', truncated: true, maxBytes: 4});
+
+        // Under the cap: untouched and not marked truncated, matching its twin.
+        expect(boundUtf8Head('short\n', 1024)).toEqual({text: 'short\n', truncated: false, maxBytes: 1024});
+
+        // Degenerate caps behave as the twin does rather than throwing.
+        expect(boundUtf8Head('abc', 0)).toEqual({text: '', truncated: true, maxBytes: 0});
+        expect(boundUtf8Head(null, 8)).toEqual({text: '', truncated: false, maxBytes: 8});
     });
 });
 


### PR DESCRIPTION
Resolves #17357

🌿 *A process reported what it decided and the sentence aged out before anyone read it; now the head of an incarnation is retrievable for as long as the incarnation lives, and "the engine must have allocated roughly this much" is a guess nobody has to make.*

Evidence: L3 (unit + published-record integration, seven unavailable arms each asserted with its reason, byte-bounding proven against its twin) → L3 required (every AC on #17357 is in-tree; the read, the bound, the cache and the wiring are all in-process). Residual: none.

## What this closes

Startup output is emitted **exactly once**, in the first seconds, and it is where a process states its resolved geometry, allocation plan, model identity and negotiated features. The published tail is a rolling window sized for recent activity — correct for *what is this doing now*, structurally wrong for *what did it decide*, because the banner's distance from the tail grows with uptime.

On the adopter plane an embedding provider's KV-cache and compute-buffer sizes were unreadable after four hours. So ~23 GB of a 31 GB footprint got attributed from a **fitted formula** while the engine's own numbers had been available and were discarded by retention. The formula happened to be right to 2.2%, which is the uncomfortable part — a wrong one would have looked equally confident.

## Deltas from ticket

**One, and it is a correction to the ticket's own prescription.** #17357 specified capturing a bounded head once and **retaining** it, with wholesale replacement on restart. Probing the runtime layer showed retention is unnecessary:

- `readObserve` already accepts `since`/`until`, and `readTargetLogs` only includes the interval when **both** are present — so `StartedAt → StartedAt + window` is a server-side bounded window.
- The window keys off `StartedAt`, so the read is **always** about the current incarnation and can simply be re-derived.

What remains is a cache on that same value, which makes invalidation **structural rather than temporal**: a restart changes the key, the entry misses, the next collection fetches the new head. There is no stale-record arm to get wrong, and the whole retention/replacement mechanism the ticket described is gone. The ticket body is corrected to the shipped shape.

**Cost, priced honestly:** one extra Docker logs call per service *per incarnation* — not per collection, which is what the cache buys. The window is bounded server-side to `startupLogWindowMs` (60 s default) and byte-capped by the existing `logMaxBytes`.

## Why a second read rather than a bigger one

Raising `logTail` is a longer bet on the same wrong instrument: any fixed line count is a wager on how soon someone looks, and the wager gets **worse the longer a deployment runs well**. A time window does not degrade with uptime.

And a line cap cannot substitute: `tail` takes the last N lines **of the window**, which is a tail of the head — the wrong end of the wrong thing. `logMaxBytes` is the real ceiling and `boundUtf8Head` trims from the correct side.

## Absence carries a reason, never an empty string

`text: ''` would read as *this service printed nothing at startup* — a confident claim about a process nobody watched boot, which is the failure this closes arriving by a different route. Seven arms, each asserted with its own reason:

`channel-disabled` · `incarnation-start-unknown` · `window-not-configured` · `window-empty-or-rotated` · `unreadable` · plus `text: null` and `lines: null` on every one.

`window-empty-or-rotated` is kept distinct from `unreadable` deliberately: one is **expected** on a long-lived container, the other is a Docker problem, and the remedies differ.

## `boundUtf8Head`, and why it differs from its twin

The twin of `boundUtf8Tail`, for the one case where the beginning is the payload. A tail keeps the end because that is where a death is written; a head keeps the beginning because that is where a process reports what it decided.

**It cuts back to the last complete line, which its twin does not.** Deliberate rather than inconsistent: a truncated head is read *forward* by a human hunting a reported value, so a dangling half-line invites misreading a number cut in two. Trimming to a line boundary also removes the split-multi-byte-character case for free.

## Test Evidence

- `npx playwright test -c test/playwright/playwright.config.unit.mjs --workers=1 <bridge spec>` → **108 passed** (9 new)
- Importer sweep across every changed basename — `deploymentStateBridgeStore.spec.mjs`, `offHostSync.spec.mjs`, `McpServerListToolsSmoke.spec.mjs`, the bridge spec and `ContainerHealthDiagnosisService.spec.mjs` → **316 passed**
- `node ai/scripts/lint/lint-config-template-ssot.mjs` → OK; it caught the new leaf and its parity snapshot is committed **in the same commit**, per the lint's own instruction

Per touched surface:

- `DeploymentStateBridgeService.readStartupLogHead` → bridge spec, 9 new cases including the server-side-window assertion and incarnation-keyed cache invalidation
- `boundUtf8Head` → `deploymentStateBridgeStore.spec.mjs`, asserted **against its twin on the same input** so the opposite-survivor property is the test
- `configBase` leaf → covered by the parity lint, which is the mechanical guard for exactly this surface

**The integration test earned its place, and I want that on the record.** My isolated fixtures returned a bare payload, which matched a bug in the reader: it consumed `readObserve`'s response without unwrapping `.data`. **All eight isolated arms passed and only the published-record test failed.** The fixture is now the real `{data, proof}` envelope, so it cannot pass against that mistake again — a fixture shaped like the bug can never fail on it.

## Post-Merge Validation

**None owed.** Every AC is verified in-tree. The live-plane observation I would like — reading an embedding provider's actual `llama_kv_cache` line out of the snapshot after hours of uptime — is the field doing its job in production, not work this PR owes; if it fails to populate that is a new defect with its own evidence.

## Commits

- `d1a2fb1` — the incarnation-keyed head read, `boundUtf8Head`, the config leaf and its parity snapshot

## Evolution

Two pivots, both from probing rather than designing. The retention mechanism died when `readTargetLogs` turned out to bound `since`/`until` server-side — the ticket's central machinery was unnecessary, and re-derivation is strictly simpler than storage plus invalidation. And the `.data` unwrapping bug survived every isolated test because I had written the fixtures and the reader from the same wrong assumption; the wiring test is the only thing that could have caught it, which is the second time today that has been true.

Authored by Vega (Claude Opus 5, Claude Code). Session 9ccc2fa1-8843-4796-8e85-5e151c0392d2.
