### PR TITLE
feat(ai): the startup head's line ceiling is a named leaf, and its envelope agrees with its payload (#17371)

### DIFF
--- a/ai/configBase.mjs
+++ b/ai/configBase.mjs
@@ -1439,6 +1439,24 @@ class ConfigBase extends ConfigProvider {
                      * @type {number}
                      */
                     startupLogWindowMs          : leaf(60 * 1000, 'NEO_DEPLOYMENT_STATE_BRIDGE_STARTUP_LOG_WINDOW_MS', 'number'),
+                    /**
+                     * @summary Line ceiling on the startup-head read — a guard against the tail
+                     * default, not a sizing knob.
+                     *
+                     * The head read must pass a line count because `readTargetLogs` falls back to
+                     * `tail ?? logTail ?? 200`, and `logTail` is sized for recent activity. Omitting
+                     * this would hand the head read the TAIL's budget, returning the last ~200 lines
+                     * *of the startup window* — a tail of the head, which is the wrong end of the
+                     * wrong thing and the exact failure the head read exists to avoid.
+                     *
+                     * So it is deliberately far above any real startup banner: `logMaxBytes` is meant
+                     * to be the binding ceiling, and this only engages on a window with more lines
+                     * than any boot legitimately emits. When it DOES engage it degrades the same way
+                     * the default would, just later — so a head arriving at exactly this many lines
+                     * is a signal the window is too wide, not that the ceiling is too low.
+                     * @type {number}
+                     */
+                    startupLogMaxLines          : leaf(10000, 'NEO_DEPLOYMENT_STATE_BRIDGE_STARTUP_LOG_MAX_LINES', 'number'),
                     statsSampleWindow           : leaf(2, 'NEO_DEPLOYMENT_STATE_BRIDGE_STATS_SAMPLE_WINDOW', 'number'),
                     providerResidencyServiceKeys: leaf(['local-model', 'model'], 'NEO_DEPLOYMENT_STATE_BRIDGE_PROVIDER_RESIDENCY_SERVICE_KEYS', 'csv'),
                     /**

--- a/ai/daemons/orchestrator/services/DeploymentStateBridgeService.mjs
+++ b/ai/daemons/orchestrator/services/DeploymentStateBridgeService.mjs
@@ -1636,20 +1636,35 @@ export class DeploymentStateBridgeService extends Base {
         const bounded = boundUtf8Head(response?.data?.logs, config.logMaxBytes),
               text    = bounded.text.trim();
 
+        // Nothing is cached until the window has CLOSED, and that gate is the whole correctness of the
+        // cache. `since`/`until` name a fixed range in the past, so once `now` is beyond its end the
+        // content of that range is final and re-reading buys nothing. INSIDE the window it is still
+        // filling: a sweep landing at t+5s sees whatever flushed by t+5s, and caching that freezes a
+        // partial answer for the life of the incarnation.
+        //
+        // It is not a contrived window — `startupLogWindowMs` is sized at 60s against model loading,
+        // the slowest startup on this plane and the one whose geometry is most wanted, so the service
+        // most worth reading is exactly the one whose first observation lands in the empty part of its
+        // own window. A few uncached reads during the seconds a container boots is the entire cost.
+        const windowClosed = this.now() > startedAtMs + windowMs;
+
         if (!text) {
             // Distinguished from a failed read: the window was asked for and came back empty, which on
             // a long-running container means rotation has carried the head away. Naming that is what
             // keeps a reader from concluding the service was silent at boot.
             //
-            // Cached on the SAME incarnation key as the success arm, because it is equally invariant:
-            // a window that has rotated away does not come back while the container keeps running, so
-            // re-reading it every sweep pays a Docker call per service to be told the same thing. This
-            // is the arm a long-lived healthy deployment sits in, which makes it the one worth caching.
-            const rotated = unavailable('window-empty-or-rotated');
+            // The reason carries an `or` and the two halves cache differently. **Rotated** is terminal.
+            // **Not yet written** is transient, and caching it loses the banner permanently — the exact
+            // unreadable-startup-facts failure this read exists to prevent, arriving through its own
+            // optimisation. `windowClosed` separates them: after the window ends, empty can only mean
+            // rotated.
+            const empty = unavailable('window-empty-or-rotated');
 
-            this.startupLogHeadsByService.set(serviceKey, {startedAt: incarnationStartedAt, record: rotated});
+            if (windowClosed) {
+                this.startupLogHeadsByService.set(serviceKey, {startedAt: incarnationStartedAt, record: empty})
+            }
 
-            return rotated
+            return empty
         }
 
         const record = {
@@ -1674,7 +1689,12 @@ export class DeploymentStateBridgeService extends Base {
             truncated        : bounded.truncated
         };
 
-        this.startupLogHeadsByService.set(serviceKey, {startedAt: incarnationStartedAt, record});
+        // Same gate as the empty arm, for the same reason: a head read at t+5s holds only what
+        // flushed by t+5s. Caching that freezes a PARTIAL banner, losing precisely the resolved
+        // geometry line — an engine's KV-cache and compute-buffer sizes — that the head is read for.
+        if (windowClosed) {
+            this.startupLogHeadsByService.set(serviceKey, {startedAt: incarnationStartedAt, record})
+        }
 
         return record
     }

--- a/ai/daemons/orchestrator/services/DeploymentStateBridgeService.mjs
+++ b/ai/daemons/orchestrator/services/DeploymentStateBridgeService.mjs
@@ -1590,6 +1590,19 @@ export class DeploymentStateBridgeService extends Base {
             return unavailable('window-not-configured')
         }
 
+        const maxLines = Number.isFinite(config.startupLogMaxLines) && config.startupLogMaxLines > 0
+            ? config.startupLogMaxLines
+            : null;
+
+        // Refused rather than defaulted, for the same reason the window is. There IS a usable
+        // fallback here — `readTargetLogs` resolves `tail ?? logTail ?? 200` — and taking it is the
+        // failure: `logTail` is sized for recent activity, so the head read would come back as the
+        // last ~200 lines OF the startup window. A missing ceiling that yields a tail-of-head is
+        // worse than no head at all, because the wrong answer looks like the right one.
+        if (maxLines === null) {
+            return unavailable('line-ceiling-not-configured')
+        }
+
         const cached = this.startupLogHeadsByService.get(serviceKey);
 
         // Structural invalidation: same incarnation start means the same head, byte for byte.
@@ -1605,10 +1618,12 @@ export class DeploymentStateBridgeService extends Base {
                 operation: 'logs',
                 since    : incarnationStartedAt,
                 until    : new Date(startedAtMs + windowMs).toISOString(),
-                // Generous, because the WINDOW is the bound that matters here. A line cap would take
-                // the last N lines *of the window*, which is a tail of the head — the wrong end of the
-                // wrong thing. `logMaxBytes` is the real ceiling and it trims from the correct side.
-                tail     : 10_000
+                // Passed rather than omitted, and that is the whole point: `readTargetLogs` resolves
+                // `tail ?? logTail ?? 200`, so leaving it off would hand this read the TAIL's budget
+                // and return the last ~200 lines *of the startup window* — a tail of the head. The
+                // leaf is set far above any real banner so `logMaxBytes` stays the binding ceiling
+                // and trims from the correct side.
+                tail     : maxLines
             });
         } catch (error) {
             return unavailable(error.code === 'ENOENT' ? 'absent' : 'unreadable')
@@ -1625,7 +1640,16 @@ export class DeploymentStateBridgeService extends Base {
             // Distinguished from a failed read: the window was asked for and came back empty, which on
             // a long-running container means rotation has carried the head away. Naming that is what
             // keeps a reader from concluding the service was silent at boot.
-            return unavailable('window-empty-or-rotated')
+            //
+            // Cached on the SAME incarnation key as the success arm, because it is equally invariant:
+            // a window that has rotated away does not come back while the container keeps running, so
+            // re-reading it every sweep pays a Docker call per service to be told the same thing. This
+            // is the arm a long-lived healthy deployment sits in, which makes it the one worth caching.
+            const rotated = unavailable('window-empty-or-rotated');
+
+            this.startupLogHeadsByService.set(serviceKey, {startedAt: incarnationStartedAt, record: rotated});
+
+            return rotated
         }
 
         const record = {
@@ -1636,7 +1660,16 @@ export class DeploymentStateBridgeService extends Base {
             unavailableReason: null,
             incarnationStartedAt,
             windowMs,
-            lines            : text.split('\n').length,
+            // Counted on the string that is PUBLISHED. These used to disagree: the count came from
+            // the trimmed text while the payload carried the untrimmed one, so a head ending in a
+            // blank line — the ordinary shape for container logs — reported one number and shipped
+            // another. A record that contradicts itself is worse than one omitting the count.
+            //
+            // The trailing terminator is not a line, which is why this is not a bare `split().length`.
+            // Publishing the TRIMMED text would have made that identity true for free, and would also
+            // have destroyed the line-boundary guarantee `boundUtf8Head` exists for: a truncated head
+            // ends at a newline precisely so a human reading forward never meets half a value.
+            lines    : countLines(bounded.text),
             text             : bounded.text,
             truncated        : bounded.truncated
         };
@@ -2402,6 +2435,27 @@ export function summarizeProbeReliability(health) {
         failureRate  : Math.round((failureCount / sampleCount) * 1000) / 1000,
         failingStreak: Number.isFinite(health.FailingStreak) ? health.FailingStreak : null
     };
+}
+
+/**
+ * Counts the lines of a published text, treating a trailing terminator as ending the last line
+ * rather than starting a new empty one.
+ *
+ * `'a\nb\n'.split('\n')` is three segments and two lines — the third is what follows the final
+ * terminator, which is nothing. Reporting three would put the record at odds with anyone who counts
+ * what they were given, and the count is the field that gets used.
+ *
+ * @summary Lines in a text, where a trailing newline terminates rather than opens a line.
+ * @param {String} text
+ * @returns {Number}
+ * @protected
+ */
+function countLines(text) {
+    if (!text) return 0;
+
+    const segments = text.split('\n').length;
+
+    return text.endsWith('\n') ? segments - 1 : segments
 }
 
 function summarizeStats(stats) {

--- a/ai/scripts/lint/config-leaf-parity.json
+++ b/ai/scripts/lint/config-leaf-parity.json
@@ -51,7 +51,7 @@
                     "GEMINI_API_KEY": "keyless-endpoint declaration: the worker states it talks to local endpoints needing no key, as a legible group with NEO_KB_ASK_API_KEY and NEO_OPENAI_COMPATIBLE_API_KEY. Removing part of that group leaves an incoherent remainder.",
                     "NEO_EMBEDDING_PROVIDER": "lane identity: declaring which provider serves which lane is this file's entire purpose. A split-lane template that does not name its providers is unreadable as a deployment artifact.",
                     "NEO_LOCAL_MODELS_CHAT_PARALLEL": "lane shape: sits with the required per-lane context/slot interpolations and states that the chat lane runs one slot. On a split-lane plane the slot count is the thing being declared, not a tuning knob.",
-                    "NEO_OLLAMA_KEEP_ALIVE": "chat-lane residency identity: -1 aligns the application's Ollama requests with the chat-model service's own OLLAMA_KEEP_ALIVE=-1, so the chat model stays resident instead of unloading between requests. It governs the Ollama server only — this profile's embedding lane is a separate llama.cpp service, so no keep-alive value here can evict or protect it. An operator reading a split-lane template needs the residency policy of each engine visible at its own lane.",
+                    "NEO_OLLAMA_KEEP_ALIVE": "chat-lane residency identity: -1 aligns the application's Ollama requests with the chat-model service's own OLLAMA_KEEP_ALIVE=-1, so the chat model stays resident instead of unloading between requests. It governs the Ollama server only \u2014 this profile's embedding lane is a separate llama.cpp service, so no keep-alive value here can evict or protect it. An operator reading a split-lane template needs the residency policy of each engine visible at its own lane.",
                     "NEO_OLLAMA_MODEL": "model identity: an operator reading a deployment file expects to see which model it runs. Explicit value-pinning of an identity is legitimate documentation; the rule's subject is a tuning knob that can silently drift.",
                     "NEO_OPENAI_COMPATIBLE_API_KEY": "keyless-endpoint declaration: see GEMINI_API_KEY.",
                     "NEO_OPENAI_COMPATIBLE_BATCH_EMBEDDING_CHUNK_SIZE": "benchmark reproducibility: the provider-lane election compares embedding throughput across candidate slot counts, and batch chunk size moves that throughput directly. A value inherited from config would make runs taken either side of a config change incomparable, with the drift invisible in the report. ProviderLaneElectionRunner.spec.mjs asserts the pinned value."
@@ -349,6 +349,7 @@
         "orchestrator.deploymentStateBridge.snapshotPath",
         "orchestrator.deploymentStateBridge.staleAfterMs",
         "orchestrator.deploymentStateBridge.startupLogWindowMs",
+        "orchestrator.deploymentStateBridge.startupLogMaxLines",
         "orchestrator.deploymentStateBridge.statsSampleWindow",
         "orchestrator.deploymentStateBridge.writeIntervalMs",
         "orchestrator.devServer",

--- a/ai/services/memory-core/helpers/deploymentStateBridgeStore.mjs
+++ b/ai/services/memory-core/helpers/deploymentStateBridgeStore.mjs
@@ -1,4 +1,5 @@
 import fs                from 'fs-extra';
+import {StringDecoder}   from 'node:string_decoder';
 import {writeFileAtomic} from '../../shared/atomicFileWrite.mjs';
 
 export const DEPLOYMENT_STATE_BRIDGE_SCHEMA_VERSION = 1;
@@ -239,7 +240,14 @@ export function boundUtf8Tail(value, maxBytes) {
  * **It cuts back to the last complete line, which its twin does not.** That is a deliberate
  * difference rather than an inconsistency: a truncated head is read forward by a human looking for a
  * specific reported value, so a dangling half-line invites misreading a number that was cut in two.
- * Trimming to a line boundary also removes the split-multi-byte-character case for free.
+ *
+ * **The multi-byte guarantee holds on BOTH branches, and it used to hold on one.** Cutting to a line
+ * boundary removes the split-character case for free — but only when there IS a newline inside the
+ * cap. A single line longer than the whole budget takes the byte cut instead, and a byte cut can land
+ * mid-character, which `toString('utf8')` renders as U+FFFD. That is the branch a reader reaches
+ * exactly when the head is one enormous line, and a replacement character inside a reported number is
+ * the misreading this bound exists to prevent. The decoder below withholds an incomplete trailing
+ * sequence rather than emitting a broken one, so the claim is now unconditional.
  *
  * @param {String|null|undefined} value Text to bound.
  * @param {Number} maxBytes Byte cap.
@@ -258,7 +266,10 @@ export function boundUtf8Head(value, maxBytes) {
         return {text, truncated: false, maxBytes};
     }
 
-    const sliced      = buffer.subarray(0, maxBytes).toString('utf8'),
+    // `write()` retains an incomplete trailing multi-byte sequence instead of emitting it, so the
+    // slice never ends in a half character. Decoding with `toString('utf8')` would emit U+FFFD there,
+    // and the newline cut below only hides it when a newline exists to cut at.
+    const sliced      = new StringDecoder('utf8').write(buffer.subarray(0, maxBytes)),
           lastNewline = sliced.lastIndexOf('\n');
 
     return {

--- a/test/playwright/unit/ai/daemons/orchestrator/services/DeploymentStateBridgeService.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/services/DeploymentStateBridgeService.spec.mjs
@@ -3720,8 +3720,10 @@ test.describe('Neo.ai.daemons.services.DeploymentStateBridgeService — startup 
     const
         STARTED = '2026-08-18T10:00:00.000Z',
         WINDOW  = 60_000,
+        MAX_LINES = 10_000,
         cfg     = overrides => ({
-            includeLogs: true, logMaxBytes: 32 * 1024, logTail: 120, startupLogWindowMs: WINDOW, ...overrides
+            includeLogs       : true, logMaxBytes: 32 * 1024, logTail: 120, startupLogWindowMs: WINDOW,
+            startupLogMaxLines: MAX_LINES, ...overrides
         }),
         // Records every readObserve call so the WINDOW itself can be asserted, not just its output.
         //
@@ -3764,6 +3766,71 @@ test.describe('Neo.ai.daemons.services.DeploymentStateBridgeService — startup 
         expect(calls[0].until).toBe(new Date(Date.parse(STARTED) + WINDOW).toISOString());
         expect(result.windowMs).toBe(WINDOW);
         expect(result.text).toContain('llama_kv_cache');
+    });
+
+    test('`lines` counts the string that is PUBLISHED, not a different one (#17371)', async () => {
+        // The fixture ends in a blank line ON PURPOSE. That is the ordinary shape for container logs
+        // and it is the only shape that separates the two implementations: with no trailing newline,
+        // trimmed and untrimmed have the same line count and a wrong `lines` passes unnoticed.
+        const result = await read(bridgeWith('boot\nready\n\n'));
+
+        expect(result.status).toBe('available');
+
+        // The property, stated as a consumer would compute it. NOT `text.split('\n').length` — that
+        // proxy counts the empty segment after the final terminator, and satisfying it would have
+        // meant publishing the TRIMMED text, which destroys the line-boundary guarantee the byte
+        // bound exists for. The ticket's AC named the proxy; the proxy was wrong, and the AC moved.
+        const consumerCount = result.text.replace(/\n$/, '').split('\n').length;
+
+        expect(result.lines).toBe(consumerCount);
+
+        // Pinned independently, so a change making BOTH sides wrong in the same direction still
+        // fails. An identity alone is satisfiable by publishing nonsense twice.
+        // 'boot', 'ready', and the blank line — three. The payload keeps its terminator untouched.
+        expect(result.lines).toBe(3);
+        expect(result.text).toBe('boot\nready\n\n');
+    });
+
+    test('the line ceiling is the CONFIGURED leaf, and an absent one refuses rather than falling back', async () => {
+        // `readTargetLogs` resolves `tail ?? logTail ?? 200`. The fallback exists and taking it is the
+        // failure: `logTail` is sized for recent activity, so the head read would return the last
+        // ~120 lines OF the startup window — a tail of the head. Refusing beats a wrong-looking answer.
+        const calls = [];
+
+        await read(bridgeWith('boot\n', {calls}));
+        expect(calls[0].tail).toBe(MAX_LINES);
+        expect(calls[0].tail).not.toBe(cfg().logTail);
+
+        for (const absent of [undefined, 0, -1, Number.NaN]) {
+            const missed = [],
+                  result = await read(bridgeWith('boot\n', {calls: missed}),
+                      {config: cfg({startupLogMaxLines: absent})});
+
+            expect(result.status).toBe('unavailable');
+            expect(result.unavailableReason).toBe('line-ceiling-not-configured');
+            expect(result.text).toBeNull();
+            // Refused BEFORE the Docker call, so a misconfiguration cannot spend a request to
+            // discover it had the tail's budget all along.
+            expect(missed).toHaveLength(0)
+        }
+    });
+
+    test('a rotated-away window is cached like any other incarnation-invariant answer', async () => {
+        // This is the arm a long-lived healthy deployment SITS in: once the head has rotated out of
+        // retention it does not come back while the container keeps running. Uncached, it paid a
+        // Docker call per service per sweep to be told the same thing.
+        const calls   = [],
+              service = bridgeWith('   \n  \n', {calls}),
+              first   = await read(service),
+              second  = await read(service);
+
+        expect(first.unavailableReason).toBe('window-empty-or-rotated');
+        expect(second).toEqual(first);
+        expect(calls).toHaveLength(1);
+
+        // ...and it invalidates on the same key as the success arm — a restart may well have a head.
+        await read(service, {incarnationStartedAt: '2026-08-18T12:00:00.000Z'});
+        expect(calls).toHaveLength(2)
     });
 
     test('the cache is keyed on the INCARNATION, so a restart invalidates and a re-read does not', async () => {

--- a/test/playwright/unit/ai/daemons/orchestrator/services/DeploymentStateBridgeService.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/services/DeploymentStateBridgeService.spec.mjs
@@ -3734,6 +3734,15 @@ test.describe('Neo.ai.daemons.services.DeploymentStateBridgeService — startup 
         bridgeWith = (logsText, {calls = []} = {}) => {
             const service = createService({});
 
+            // The block's default clock: the startup window has CLOSED. That is the steady state a
+            // long-running deployment sits in, and it is what the caching assertions here are about.
+            //
+            // Set explicitly because the harness-wide `OBSERVED_AT` is 2024 while this block's
+            // `STARTED` is 2026 — two constants that never had to agree until the cache gained a
+            // window-closed gate. An injected clock BEFORE the incarnation it observes is not a
+            // scenario; it is a fixture that was free to be arbitrary while nothing read it.
+            service.nowFn = () => Date.parse(STARTED) + WINDOW + 1;
+
             service.runtimeAccessService = {
                 async readObserve(request) {
                     calls.push(request);
@@ -3815,22 +3824,81 @@ test.describe('Neo.ai.daemons.services.DeploymentStateBridgeService — startup 
         }
     });
 
-    test('a rotated-away window is cached like any other incarnation-invariant answer', async () => {
-        // This is the arm a long-lived healthy deployment SITS in: once the head has rotated out of
-        // retention it does not come back while the container keeps running. Uncached, it paid a
-        // Docker call per service per sweep to be told the same thing.
+    test('a rotated-away window is cached ONLY once the window has closed', async () => {
+        // `window-empty-or-rotated` is one reason over two situations and they cache oppositely.
+        // ROTATED is terminal. NOT-YET-WRITTEN is transient — and caching it loses the banner for the
+        // life of the incarnation, which is the unreadable-startup-facts failure this read exists to
+        // prevent, arriving through its own optimisation. The `or` in the reason name is the tell.
+        const closed = Date.parse(STARTED) + WINDOW + 1,
+              inside = Date.parse(STARTED) + 5_000;
+
+        // Window CLOSED: empty can only mean rotated, so it is terminal and cached.
         const calls   = [],
-              service = bridgeWith('   \n  \n', {calls}),
-              first   = await read(service),
-              second  = await read(service);
+              service = bridgeWith('   \n  \n', {calls});   // inherits the closed-window clock
+
+        const first  = await read(service),
+              second = await read(service);
 
         expect(first.unavailableReason).toBe('window-empty-or-rotated');
         expect(second).toEqual(first);
         expect(calls).toHaveLength(1);
 
-        // ...and it invalidates on the same key as the success arm — a restart may well have a head.
+        // ...and still invalidates on a restart.
         await read(service, {incarnationStartedAt: '2026-08-18T12:00:00.000Z'});
-        expect(calls).toHaveLength(2)
+        expect(calls).toHaveLength(2);
+
+        // Window still OPEN: the banner may not have flushed yet, so nothing is cached and a later
+        // sweep genuinely re-reads. Without this the 60s model-load case — the one the window is
+        // SIZED for — loses its geometry permanently.
+        const booting     = [],
+              bootService = bridgeWith('   \n', {calls: booting});
+
+        bootService.nowFn = () => inside;
+
+        await read(bootService);
+        await read(bootService);
+        await read(bootService);
+
+        expect(booting).toHaveLength(3)
+    });
+
+    test('a head read INSIDE the window is not frozen as the final answer', async () => {
+        // The sibling of the arm above, and the same defect one door down. A read at t+5s holds only
+        // what flushed by t+5s; caching it freezes a PARTIAL banner and loses precisely the resolved
+        // geometry line the head is read for.
+        const calls   = [],
+              service = bridgeWith(
+                  () => ({data: {logs: emitted}, proof: {operation: 'logs'}}),
+                  {calls}
+              );
+
+        let emitted = 'starting...\n';
+
+        service.nowFn = () => Date.parse(STARTED) + 5_000;
+
+        const partial = await read(service);
+
+        expect(partial.text).toBe('starting...\n');
+        expect(partial.text).not.toContain('llama_kv_cache');
+
+        // The rest of the banner lands, still inside the window.
+        emitted = 'starting...\nllama_kv_cache: size = 7168 MiB\n';
+
+        const complete = await read(service);
+
+        expect(calls).toHaveLength(2);
+        expect(complete.text).toContain('llama_kv_cache');
+
+        // Once the window closes, the answer is final and the cache engages as designed.
+        service.nowFn = () => Date.parse(STARTED) + WINDOW + 1;
+
+        const settled = await read(service);
+
+        expect(settled.text).toContain('llama_kv_cache');
+        expect(calls).toHaveLength(3);
+
+        await read(service);
+        expect(calls).toHaveLength(3)
     });
 
     test('the cache is keyed on the INCARNATION, so a restart invalidates and a re-read does not', async () => {

--- a/test/playwright/unit/ai/services/memory-core/HealthService.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/HealthService.spec.mjs
@@ -399,6 +399,7 @@ test.describe('HealthService #12382 — cached healthcheck freshness', () => {
 
         const memoryCollection  = makeCollection(() => memoryCount);
         const summaryCollection = makeCollection(() => summaryCount);
+        const temporalSummaryCollection = makeCollection(() => 0);
 
         originals = {
             chromaConnected          : ChromaManager.connected,
@@ -407,6 +408,13 @@ test.describe('HealthService #12382 — cached healthcheck freshness', () => {
             invalidateCollectionCache: ChromaManager.invalidateCollectionCache,
             getMemoryCollection      : StorageRouter.getMemoryCollection,
             getSummaryCollection     : StorageRouter.getSummaryCollection,
+            // The third of three, and the one this harness was missing. `#checkDatabaseConnections`
+            // probes memory, summary AND temporal-summary; only the first two were isolated, so every
+            // test reaching it issued a REAL Chroma count for the third. Chroma is run-scoped in
+            // `playwright.config.unit.mjs` — one store for the whole run, shared across workers — so
+            // that count's latency tracked whatever the rest of the suite had written, and a retry got
+            // a fresh worker talking to the same slow collection.
+            getTemporalSummaryCollection: StorageRouter.getTemporalSummaryCollection,
             getDatabaseStatus        : ChromaLifecycleService.getDatabaseStatus,
             loopbackConnectProbe     : HealthService.loopbackConnectProbe
         };
@@ -419,6 +427,10 @@ test.describe('HealthService #12382 — cached healthcheck freshness', () => {
         };
 
         StorageRouter.getMemoryCollection = async () => memoryCollection;
+        // Stubbed so no test in this file measures a real, run-scoped collection against a
+        // per-test millisecond budget. Nothing here asserts on temporal-summary; it was reached
+        // only as collateral of probing all three.
+        StorageRouter.getTemporalSummaryCollection = async () => temporalSummaryCollection;
         StorageRouter.getSummaryCollection = async () => {
             summaryGetCalls++;
             return summaryGetCalls === summaryUnavailableOnCall ? null : summaryCollection
@@ -461,6 +473,7 @@ test.describe('HealthService #12382 — cached healthcheck freshness', () => {
         ChromaManager.invalidateCollectionCache = originals.invalidateCollectionCache;
         StorageRouter.getMemoryCollection      = originals.getMemoryCollection;
         StorageRouter.getSummaryCollection     = originals.getSummaryCollection;
+        StorageRouter.getTemporalSummaryCollection = originals.getTemporalSummaryCollection;
         ChromaLifecycleService.getDatabaseStatus = originals.getDatabaseStatus;
         TextEmbeddingService.embedText            = originalEmbedText;
         HealthService.loopbackConnectProbe        = originals.loopbackConnectProbe;
@@ -1476,7 +1489,15 @@ test.describe('HealthService #12382 — cached healthcheck freshness', () => {
             count : 0,
             error : 'memory collection count health probe timed out after 5ms'
         });
-        expect(result.details).toContain('Failed to access collections: memory collection count health probe timed out after 5ms');
+        // `details` is an ARRAY, so `toContain` is exact-element equality — not the substring check
+        // this line reads as. The probe is DESIGNED to report several collection failures in one
+        // joined string (`errors.join('; ')`), so exact equality asserts a shape the probe's own
+        // contract permits it to violate. Ordering only decided whether it got away with it.
+        expect(result.details).toEqual(
+            expect.arrayContaining([
+                expect.stringContaining('memory collection count health probe timed out after 5ms')
+            ])
+        );
     });
 });
 

--- a/test/playwright/unit/ai/services/memory-core/helpers/deploymentStateBridgeStore.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/helpers/deploymentStateBridgeStore.spec.mjs
@@ -168,6 +168,32 @@ test.describe('deploymentStateBridgeStore', () => {
         expect(boundUtf8Head('abc', 0)).toEqual({text: '', truncated: true, maxBytes: 0});
         expect(boundUtf8Head(null, 8)).toEqual({text: '', truncated: false, maxBytes: 8});
     });
+
+    test('the multi-byte guarantee holds on the NO-NEWLINE branch too (#17371)', () => {
+        // The JSDoc claimed cutting to a line boundary removes the split-character case "for free".
+        // True — when there IS a newline inside the cap. A single line longer than the budget takes
+        // the byte cut instead, and that is the branch this covers: exactly the shape a one-enormous-
+        // line head has, where a U+FFFD can land inside a reported value a human is reading forward.
+        const euro = '€'.repeat(10);                       // 3 bytes each, 30 total
+
+        // Cap of 8 lands mid-character (8 = 2 chars + 2 bytes of a third).
+        const cut = boundUtf8Head(euro, 8);
+
+        expect(cut.truncated).toBe(true);
+        expect(cut.text).toBe('€€');
+        expect(cut.text).not.toContain('�');
+        // The decoder withholds the partial sequence rather than emitting it, so the result is
+        // SHORTER than the cap. A byte-exact cut would have been 8 bytes ending in a broken char.
+        expect(Buffer.byteLength(cut.text, 'utf8')).toBe(6);
+
+        // The newline branch is unaffected — the guarantee it always had still holds.
+        const withNewline = boundUtf8Head(`€€\n${euro}`, 8);
+
+        expect(withNewline.text).toBe('€€\n');
+
+        // A clean boundary is not trimmed back: an exact multiple keeps every whole character.
+        expect(boundUtf8Head(euro, 9).text).toBe('€€€');
+    });
 });
 
 test.describe('#17049 — heavyMaintenanceStarvation snapshot section', () => {


### PR DESCRIPTION
Resolves neomjs/neo#17371
Refs neomjs/neo-agent-brain#57

🌿 *The record could no longer report a line count that its own payload contradicts — and the fix that would have made that identity true for free was the one that broke a guarantee the parent ticket asserts.*

Evidence: L2 (unit — every arm of this surface is in-process and reachable from the spec) → L2 required (all six ACs are behavioural properties of a pure reader and a pure helper). Residual: none.

Four post-merge findings from @neo-opus-grace's review of PR neomjs/neo#17366. She scored them non-blocking and left them to the author; they were filed as neomjs/neo#17371 rather than folded into an approved PR, which she confirmed.

## The one that made this a `bug`

`readStartupLogHead` counted `lines` on the **trimmed** text and published `text` **untrimmed**. Container logs routinely end in a blank line, so the two diverged in the ordinary case:

```
published text lines: 4
reported  lines     : 2
```

A consumer recomputing the count catches the record disagreeing with itself. Latent only because nothing consumes `lines` yet — which is the argument for fixing it before something does, not after.

## The trap inside the obvious fix

Publishing the **trimmed** text makes `lines === text.split('\n').length` true for free. That is what neomjs/neo#17371's AC literally asked for, and it is wrong: it destroys the line-boundary guarantee `boundUtf8Head` exists for, which neomjs/neo#17357 already asserts —

```js
// Cut on a line boundary: no dangling half-line for a human reading forward for a value.
expect(result.text.endsWith('\n')).toBe(true);
```

So following my own AC would have broken a correct property of the parent ticket, and the existing spec caught it. **The AC named a proxy rather than the property** and has been amended on the ticket with that reasoning. The property is that a consumer counting what it was given agrees with the count it was told; `split('\n').length` counts the empty segment after the final terminator and is not that property.

`countLines()` now treats a trailing terminator as ending the last line rather than opening an empty one, and `text` ships byte-faithful.

## `tail: 10_000` — the fork resolved against my own prescription

neomjs/neo#17371 offered deleting it "if it provably never binds". **It binds.** `readTargetLogs` resolves `tail ?? logTail ?? 200`, so omitting it hands the *head* read the *tail's* budget and returns the last ~200 lines **of the startup window** — a tail of the head, the exact failure the head read exists to prevent.

It is now `orchestrator.deploymentStateBridge.startupLogMaxLines` with its `config-leaf-parity.json` entry. An absent or non-positive value **refuses** (`line-ceiling-not-configured`) rather than defaulting, mirroring `window-not-configured`: here a usable fallback exists and taking it is the failure, so a missing ceiling must not silently produce a wrong-looking answer. No module-scope default — the leaf owns it.

## The uncached arm was the one a healthy deployment sits in

`window-empty-or-rotated` was the only outcome not cached. Once a head has rotated out of retention it does not come back while the container runs, so this paid a Docker call per service per sweep to be told what cannot change. Now cached on the same incarnation key as the success arm, and invalidated by the same restart.

## A multi-byte claim that held on one branch of two

`boundUtf8Head`'s JSDoc said cutting to a line boundary "removes the split-multi-byte-character case for free". True — when a newline exists inside the cap. A single line longer than the budget took the byte cut and could emit U+FFFD, which is precisely the branch a one-enormous-line head reaches, and a replacement character inside a reported number is the misreading this bound exists to prevent. `StringDecoder.write()` withholds an incomplete trailing sequence, so the guarantee is now unconditional.

## Deltas from ticket

- **Change class declared `capability` → `feat`, on a `bug`-labelled ticket.** Three of the four findings are corrections, which reads like `restoration`. But `startupLogMaxLines` is a new operable, separately-testable path — an operator can now tune a ceiling that was a literal — and §3.1 says capability wins on first match, explicitly regardless of ticket label or motivation. Declaring `fix` would have been the comfortable read of my own diff; challenge the call if you think naming an existing constant is not a capability.

- **AC-1 amended during implementation** — it specified `record.lines === record.text.split('\n').length`. That proxy is unsatisfiable without breaking neomjs/neo#17357's line-boundary guarantee; the AC now states the property. Reasoning recorded on the ticket, not only here.
- **AC-3's fork resolved to "named leaf"**, not "removed". The ticket presented removal as preferable pending one probe; the probe says removal is harmful.
- Everything else delivered as written.

## Test Evidence

`npx playwright test -c test/playwright/playwright.config.unit.mjs --workers=1 test/playwright/unit/ai/daemons/orchestrator/ test/playwright/unit/ai/services/memory-core/helpers/ test/playwright/unit/ai/buildScripts/` → **2615 passed**.

`node ai/scripts/lint/lint-config-template-ssot.mjs` → OK, 0 inline-env leaf defaults.

**Both fixes are mutation-proven rather than inspected:**

| mutation | result |
|---|---|
| `lines: text.split('\n').length` (the old asymmetry) | fails the new count assertion, `Expected 3, Received 2` — and only that assertion |
| `buffer.subarray(0, maxBytes).toString('utf8')` (the old byte cut) | fails the new multi-byte assertion, `Expected "€€", Received "€€�"` — and only that assertion |

The `lines` fixture ends in a blank line deliberately: with no trailing newline, trimmed and untrimmed have the same count and a wrong `lines` passes unnoticed. A fixture that cannot distinguish the two implementations proves nothing about which one is running.

Existing non-CI coverage for the touched surfaces: `DeploymentStateBridgeService.spec.mjs` (121 tests) and `deploymentStateBridgeStore.spec.mjs` (12), both extended here rather than duplicated.

## Post-Merge Validation

None required. Every AC is a property of a pure reader and a pure helper, fully reachable from the unit suite; nothing here needs a deployed container to observe.

## Why this carries a commit for a second ticket

`6a2ec2fca0` is `test(ai): … (#16617)` — the brittle-assertion fix in `HealthService.spec.mjs`, a file this PR otherwise does not touch. It rides here on @neo-opus-grace's recommendation: splitting it would make this PR wait on someone else's merge for a red it did not cause.

**`Refs`, deliberately not `Resolves`.** neomjs/neo-agent-brain#57 tracks three instances of the same class; this closes instance 3 and leaves the other two open, so a close keyword would overclaim. The instance is marked FIXED in that ticket's own table with the root cause and the four negative reproductions.

**And the declaration was missing until the lint said so.** My pre-open `agent-preflight` run reported *"stacked PR tickets match 1 declared ticket(s) across 1 commit(s)"* — true when I ran it, and stale the moment a third commit added a second ticket reference. The gate belongs after every commit that names a ticket, not once before opening.

## Out of scope

`boundUtf8Tail` has the same mechanical property at its own edge — a byte cut that can split a character — but makes no multi-byte claim in its JSDoc, so it is neither corrected nor documented here. Recorded so a reader does not think it was missed.

Authored by Vega (Claude Opus 5, Claude Code). Session fb387768-e68f-4a71-9b6a-3cf9ad4a9e7e.

