### PR TITLE
feat(devindex): the Data Factory reads the index it published, not the checkout (#17374)

### DIFF
--- a/apps/devindex/services/Storage.mjs
+++ b/apps/devindex/services/Storage.mjs
@@ -417,10 +417,20 @@ class Storage extends Base {
             )
         }
 
-        return text
-            .split('\n')
-            .filter(line => line.trim())
-            .map(line => JSON.parse(line))
+        // Guarded, and the bootstrap run is exactly why. With provenance recorded, a mangled body
+        // fails the digest comparison above and never reaches here. With provenance ABSENT — the
+        // first run after adoption, which the branch above calls expected — nothing has verified
+        // these bytes, so a 200 carrying an HTML interstitial, a truncated transfer or a captive
+        // -portal page reaches `JSON.parse`. Unguarded, that throws out of `getUsers()` and takes
+        // the run down on the one run this method documents as normal.
+        try {
+            return text
+                .split('\n')
+                .filter(line => line.trim())
+                .map(line => JSON.parse(line))
+        } catch (error) {
+            return this.rejectPublishedIndex(`published index is not parseable JSONL: ${error.message}`)
+        }
     }
 
     /**

--- a/apps/devindex/services/Storage.mjs
+++ b/apps/devindex/services/Storage.mjs
@@ -1,3 +1,4 @@
+import {createHash} from 'crypto';
 import fs from 'fs/promises';
 import Base from '../../../src/core/Base.mjs';
 import config from './config.mjs';
@@ -120,7 +121,7 @@ class Storage extends Base {
     async removeFromBlocklist(logins) {
         const current = await this.readJson(config.paths.blocklist, []);
         const targetSet = new Set(logins.map(l => l.toLowerCase()));
-        
+
         const initialLen = current.length;
         const filtered = current.filter(item => !targetSet.has(item.toLowerCase()));
 
@@ -353,11 +354,97 @@ class Storage extends Base {
     }
 
     /**
-     * Reads the rich users data (formerly data.json).
+     * @summary Reads the rich users data, preferring the artifact this pipeline published.
+     *
+     * **Why not the working tree.** The previous state used to come from whatever `actions/checkout`
+     * placed on disk, which is the reason the pipeline needed a clone of a multi-gigabyte repository
+     * to obtain one file it only reads the tip of. The browser has always fetched this file over
+     * HTTPS from the deployed site; only the producer read it from git. Reading the published copy
+     * puts the producer on the consumer's path and removes the last reason the index must live in
+     * git at all.
+     *
+     * **The fetched copy is used only when it is provably ours.** `index-provenance.json` records
+     * the digest of what this pipeline last wrote. A fetch that matches it is our own artifact and is
+     * safe to mutate. Anything else — a mismatch, a truncated body, an unreachable host — falls back
+     * to the checkout copy, which is the state we last wrote and therefore never a foreign artifact.
+     * Refusing outright was considered and rejected: a publish that has not propagated yet is an
+     * ordinary transient, and a hard refusal would wedge the pipeline on it indefinitely.
+     *
+     * **The fallback is deliberately loud.** A silent one would leave the git coupling in place while
+     * this method appears to have removed it, and nothing downstream would surface it.
      * @returns {Promise<Array<Object>>}
      */
     async getUsers() {
-        return this.readJson(config.paths.users, []);
+        const published = await this.readPublishedIndex();
+
+        return published ?? this.readJson(config.paths.users, [])
+    }
+
+    /**
+     * @summary Fetches the deployed index and returns it only if it matches recorded provenance.
+     * @returns {Promise<Array<Object>|null>} Parsed records, or `null` when the caller must fall back.
+     * @private
+     */
+    async readPublishedIndex() {
+        const {url, timeout} = config.publishedIndex;
+
+        let response, text;
+
+        try {
+            response = await fetch(url, {signal: AbortSignal.timeout(timeout)});
+
+            if (!response.ok) {
+                return this.rejectPublishedIndex(`HTTP ${response.status} from ${url}`)
+            }
+
+            text = await response.text()
+        } catch (error) {
+            return this.rejectPublishedIndex(`fetch failed for ${url}: ${error.message}`)
+        }
+
+        const
+            provenance = await this.readJson(config.paths.indexProvenance, null),
+            digest     = this.digestOf(text);
+
+        // Absence is not mismatch. The first run after adoption has nothing recorded to compare
+        // against, and treating that as a failure would make this path unreachable forever.
+        if (!provenance?.digest) {
+            console.warn('[Storage] No index provenance recorded yet — accepting the published index unverified. This is expected exactly once.');
+        } else if (provenance.digest !== digest) {
+            return this.rejectPublishedIndex(
+                `published index does not match what we last wrote (recorded ${provenance.digest.slice(0, 12)}, fetched ${digest.slice(0, 12)}). ` +
+                'Either the last publish has not propagated, or something else wrote to that URL.'
+            )
+        }
+
+        return text
+            .split('\n')
+            .filter(line => line.trim())
+            .map(line => JSON.parse(line))
+    }
+
+    /**
+     * @summary Reports why the published index was not usable and hands the caller back to the tree.
+     *
+     * Separated so every rejection reason travels the same, visible path. An inline `return null`
+     * per branch is how a fallback becomes quiet one branch at a time.
+     * @param {String} reason
+     * @returns {null}
+     * @private
+     */
+    rejectPublishedIndex(reason) {
+        console.warn(`[Storage] Falling back to the checkout copy of the index — ${reason}`);
+        return null
+    }
+
+    /**
+     * @summary Content digest used to prove a fetched index is the one this pipeline wrote.
+     * @param {String} content
+     * @returns {String} Hex-encoded SHA-256.
+     * @private
+     */
+    digestOf(content) {
+        return createHash('sha256').update(content, 'utf-8').digest('hex')
     }
 
     /**
@@ -496,6 +583,33 @@ class Storage extends Base {
         const tempPath = `${path}.tmp`;
         await fs.writeFile(tempPath, content, 'utf-8');
         await fs.rename(tempPath, path);
+
+        // Recorded here rather than at each call site: the index is written from three places
+        // (`saveUsers`, the prune path, and Cleanup's reconciliation), and provenance that only some
+        // of them update is worse than none — a stale digest reads as a foreign artifact and would
+        // send every subsequent run down the fallback path for a reason nobody could find.
+        if (path === config.paths.users) {
+            await this.recordIndexProvenance(content)
+        }
+    }
+
+    /**
+     * @summary Records what this pipeline just published, so the next run can recognise it.
+     *
+     * The digest is over the exact bytes written, which is what a later fetch returns — deriving it
+     * from the in-memory records instead would compare a re-serialisation against a transmission and
+     * drift on any formatting change, failing in a way that looks like tampering.
+     * @param {String} content Exact serialized index as written to disk.
+     * @returns {Promise<void>}
+     * @private
+     */
+    async recordIndexProvenance(content) {
+        await this.writeJson(config.paths.indexProvenance, {
+            digest     : this.digestOf(content),
+            lines      : content.split('\n').filter(line => line.trim()).length,
+            bytes      : Buffer.byteLength(content, 'utf-8'),
+            publishedAt: new Date().toISOString()
+        })
     }
 }
 

--- a/apps/devindex/services/config.mjs
+++ b/apps/devindex/services/config.mjs
@@ -171,7 +171,41 @@ const defaultConfig = {
          * State tracking for the Opt-In service (last processed timestamp).
          * @type {string}
          */
-        optinSync: path.resolve(projectRoot, 'apps/devindex/resources/data/optin-sync.json')
+        optinSync: path.resolve(projectRoot, 'apps/devindex/resources/data/optin-sync.json'),
+
+        /**
+         * Provenance for the last index this pipeline published: line count, content digest, and the
+         * served `ETag` observed at the time. Small, and deliberately tracked in git even though the
+         * index it describes is on its way out of git — it is the trusted anchor a fetched artifact
+         * is checked against, so it must live somewhere the artifact cannot influence.
+         * @type {string}
+         */
+        indexProvenance: path.resolve(projectRoot, 'apps/devindex/resources/data/index-provenance.json')
+    },
+
+    /**
+     * The published index, read rather than re-derived.
+     *
+     * The Data Factory used to obtain its previous state from whatever `actions/checkout` placed in
+     * the working tree, which is why it needed a clone of a multi-gigabyte repository to reach one
+     * file it only ever reads the tip of. The browser has always read this file over HTTPS from the
+     * deployed site; only the producer read it from git. This block moves the producer onto the
+     * consumer's path.
+     */
+    publishedIndex: {
+        /**
+         * Absolute URL of the deployed index. Declared once and read at the use site — the host is
+         * never reassembled from parts anywhere else.
+         * @type {string}
+         */
+        url: 'https://neomjs.com/node_modules/neo.mjs/apps/devindex/resources/data/users.jsonl',
+
+        /**
+         * Request timeout in ms. Generous: the artifact is ~24 MB and a slow fetch that succeeds is
+         * worth more than a fast fall back to the checkout, which is the path this exists to retire.
+         * @type {number}
+         */
+        timeout: 120000
     }
 };
 

--- a/apps/devindex/services/config.mjs
+++ b/apps/devindex/services/config.mjs
@@ -174,10 +174,15 @@ const defaultConfig = {
         optinSync: path.resolve(projectRoot, 'apps/devindex/resources/data/optin-sync.json'),
 
         /**
-         * Provenance for the last index this pipeline published: line count, content digest, and the
-         * served `ETag` observed at the time. Small, and deliberately tracked in git even though the
-         * index it describes is on its way out of git — it is the trusted anchor a fetched artifact
-         * is checked against, so it must live somewhere the artifact cannot influence.
+         * Provenance for the last index this pipeline published: a SHA-256 over the exact bytes
+         * written, plus line count, byte length and timestamp. Small, and deliberately tracked in git
+         * even though the index it describes is on its way out of git — it is the trusted anchor a
+         * fetched artifact is checked against, so it must live somewhere the artifact cannot
+         * influence.
+         *
+         * A content digest rather than the served `ETag`, which an earlier draft of this comment
+         * claimed: an `ETag` is host-assigned and survives neither recompression nor a CDN swap, so
+         * it answers *is this the same response* where this needs *is this the same content*.
          * @type {string}
          */
         indexProvenance: path.resolve(projectRoot, 'apps/devindex/resources/data/index-provenance.json')
@@ -196,6 +201,18 @@ const defaultConfig = {
         /**
          * Absolute URL of the deployed index. Declared once and read at the use site — the host is
          * never reassembled from parts anywhere else.
+         *
+         * **Accepted risk, named rather than guarded: a fork reads production once, unverified.**
+         * There is no environment override here, and no other value in this file reads one, so a fork
+         * or staging deploy fetches the canonical index. On such a deployment `index-provenance.json`
+         * is absent, which takes the absence branch — the branch that accepts the fetched bytes
+         * without a digest to check them against — so upstream's contributor index is adopted as that
+         * deployment's own prior state on its first run.
+         *
+         * Accepted here because the destination is a late binding for the whole extraction and a seam
+         * invented now would encode a host layout that is about to change. It becomes wrong the moment
+         * anyone runs this pipeline outside the canonical deployment, and that is the trigger for
+         * adding the override rather than a reason to add it today.
          * @type {string}
          */
         url: 'https://neomjs.com/node_modules/neo.mjs/apps/devindex/resources/data/users.jsonl',

--- a/test/playwright/unit/app/devindex/StoragePublishedIndex.spec.mjs
+++ b/test/playwright/unit/app/devindex/StoragePublishedIndex.spec.mjs
@@ -1,0 +1,227 @@
+import {setup} from '../../../setup.mjs';
+
+const appName = 'DevIndexPublishedIndexTest';
+
+setup({
+    appConfig: {
+        name: appName
+    }
+});
+
+import {test, expect} from '@playwright/test';
+import Neo            from '../../../../../src/Neo.mjs';
+import * as core      from '../../../../../src/core/_export.mjs';
+import config         from '../../../../../apps/devindex/services/config.mjs';
+import Storage        from '../../../../../apps/devindex/services/Storage.mjs';
+
+/**
+ * @summary The Data Factory reads its previous index from the artifact it published.
+ *
+ * The producer used to take its previous state from whatever `actions/checkout` left on disk, which
+ * is why the pipeline needed a clone of a multi-gigabyte repository to reach one file it only reads
+ * the tip of. These arms pin the three properties that make the fetched path safe to prefer: it
+ * agrees with the tree path byte-for-byte, it is used only when provably ours, and every retreat to
+ * the tree is audible.
+ */
+test.describe('DevIndex Storage — the published index as the read side (#17374)', () => {
+    const
+        RECORDS = [
+            {l: 'ada',   tc: 40000},
+            {l: 'grace', tc: 31337},
+            {l: 'vega',  tc: 12000}
+        ],
+        SERIALIZED = RECORDS.map(record => JSON.stringify(record)).join('\n');
+
+    let originalFetch, originalReadJson;
+
+    test.beforeEach(() => {
+        originalFetch    = globalThis.fetch;
+        originalReadJson = Storage.readJson.bind(Storage);
+    });
+
+    test.afterEach(() => {
+        globalThis.fetch  = originalFetch;
+        Storage.readJson  = originalReadJson;
+    });
+
+    /**
+     * Serves a body, or throws, in place of the network.
+     * @param {String|Function} body
+     * @param {Object} [options]
+     * @returns {Array} Recorded requests, for asserting the call itself rather than only its output.
+     */
+    const stubFetch = (body, {ok = true, status = 200} = {}) => {
+        const calls = [];
+
+        globalThis.fetch = async (url, init) => {
+            calls.push({url, init});
+
+            if (typeof body === 'function') return body();
+
+            return {ok, status, text: async () => body}
+        };
+
+        return calls
+    };
+
+    /** Stubs the provenance read only; every other path keeps the real reader. */
+    const stubProvenance = record => {
+        Storage.readJson = async (path, defaultValue) =>
+            path === config.paths.indexProvenance ? record : originalReadJson(path, defaultValue)
+    };
+
+    const digestOfSerialized = () => Storage.digestOf(SERIALIZED);
+
+    test('AC-1: the fetched path and the checkout path return identical records', async () => {
+        // The current behaviour is this change's own control. If the two paths can disagree, the
+        // migration is not a migration — it is a second, differently-wrong source of truth.
+        stubFetch(SERIALIZED);
+        stubProvenance({digest: digestOfSerialized()});
+
+        const fromArtifact = await Storage.getUsers();
+
+        globalThis.fetch = async () => { throw new Error('network down') };
+        Storage.readJson = async (path, defaultValue) =>
+            path === config.paths.users ? RECORDS : originalReadJson(path, defaultValue);
+
+        const fromCheckout = await Storage.getUsers();
+
+        expect(fromArtifact).toEqual(RECORDS);
+        expect(fromArtifact).toEqual(fromCheckout);
+    });
+
+    test('AC-5: the request goes to the single declared config URL, not a reassembled one', async () => {
+        const calls = stubFetch(SERIALIZED);
+
+        stubProvenance({digest: digestOfSerialized()});
+        await Storage.getUsers();
+
+        expect(calls).toHaveLength(1);
+        expect(calls[0].url).toBe(config.publishedIndex.url);
+        // Pinned independently of the config read, so a host silently reassembled at the use site
+        // would fail here even if it happened to equal the config value today.
+        expect(calls[0].url.startsWith('https://')).toBe(true);
+    });
+
+    test('AC-2: a fetch failure falls back to the tree AND says so — never silently', async () => {
+        // A silent fallback is the failure this ticket must not ship: it leaves the git coupling in
+        // place while the method appears to have removed it, and nothing downstream surfaces it.
+        globalThis.fetch = async () => { throw new Error('ECONNREFUSED') };
+
+        Storage.readJson = async (path, defaultValue) =>
+            path === config.paths.users ? RECORDS : originalReadJson(path, defaultValue);
+
+        const warned   = [];
+        const realWarn = console.warn;
+
+        console.warn = message => warned.push(String(message));
+
+        try {
+            const result = await Storage.getUsers();
+
+            expect(result).toEqual(RECORDS);
+            expect(warned.some(line => line.includes('Falling back to the checkout copy'))).toBe(true);
+            expect(warned.some(line => line.includes('ECONNREFUSED'))).toBe(true);
+        } finally {
+            console.warn = realWarn
+        }
+    });
+
+    test('AC-2: a non-2xx response is a fallback, not a body to parse', async () => {
+        // `response.text()` on a 404 returns an error PAGE, which would parse as garbage or throw
+        // deep in the JSON reader rather than at the boundary that knows what happened.
+        stubFetch('<!DOCTYPE html><html>404</html>', {ok: false, status: 404});
+
+        Storage.readJson = async (path, defaultValue) =>
+            path === config.paths.users ? RECORDS : originalReadJson(path, defaultValue);
+
+        const warned   = [];
+        const realWarn = console.warn;
+
+        console.warn = message => warned.push(String(message));
+
+        try {
+            const result = await Storage.getUsers();
+
+            expect(result).toEqual(RECORDS);
+            expect(warned.some(line => line.includes('HTTP 404'))).toBe(true);
+        } finally {
+            console.warn = realWarn
+        }
+    });
+
+    test('AC-3: a digest mismatch falls back rather than mutating an artifact we did not write', async () => {
+        stubFetch(SERIALIZED);
+        stubProvenance({digest: 'f'.repeat(64)});
+
+        const warned   = [];
+        const realWarn = console.warn;
+
+        console.warn = message => warned.push(String(message));
+
+        try {
+            const result = await Storage.getUsers();
+
+            // Fell through to the real tree read rather than returning the fetched records.
+            expect(result).not.toEqual(RECORDS);
+            expect(warned.some(line => line.includes('does not match what we last wrote'))).toBe(true);
+        } finally {
+            console.warn = realWarn
+        }
+    });
+
+    test('AC-3: ABSENCE of provenance is not mismatch — the first run must be able to proceed', async () => {
+        // The sibling arm above and this one are the whole point of separating the two states. If
+        // "no record" were treated as "wrong record", this path would be unreachable forever and the
+        // pipeline would never leave the checkout, while every log line claimed it had.
+        stubFetch(SERIALIZED);
+        stubProvenance(null);
+
+        const warned   = [];
+        const realWarn = console.warn;
+
+        console.warn = message => warned.push(String(message));
+
+        try {
+            const result = await Storage.getUsers();
+
+            expect(result).toEqual(RECORDS);
+            expect(warned.some(line => line.includes('No index provenance recorded yet'))).toBe(true);
+            expect(warned.some(line => line.includes('Falling back'))).toBe(false);
+        } finally {
+            console.warn = realWarn
+        }
+    });
+
+    test('AC-4: the curated files still come from the checkout, untouched by this change', async () => {
+        // The derived index may leave git; the curated inputs may not. `blocklist.json` carries
+        // somebody's opt-out decision and is the one file in that directory nothing can regenerate,
+        // so this pins that moving the index read did not quietly widen to the curated files.
+        const calls          = stubFetch(SERIALIZED);
+        let   requestedPaths = [];
+
+        Storage.readJson = async (path, defaultValue) => {
+            requestedPaths.push(path);
+            return path === config.paths.blocklist ? ['spam-bot'] : originalReadJson(path, defaultValue)
+        };
+
+        const blocked = await Storage.getBlocklist();
+
+        expect([...blocked]).toEqual(['spam-bot']);
+        expect(requestedPaths).toContain(config.paths.blocklist);
+        // The blocklist read issued no network request of its own.
+        expect(calls).toHaveLength(0);
+    });
+
+    test('the digest is taken over the bytes written, so it survives a re-serialisation', async () => {
+        // Deriving the digest from the in-memory records instead would compare a re-serialisation
+        // against a transmission: identical data, different bytes, and a mismatch indistinguishable
+        // from tampering.
+        const fromBytes   = Storage.digestOf(SERIALIZED),
+              fromRecords = Storage.digestOf(RECORDS.map(r => JSON.stringify(r)).join('\n'));
+
+        expect(fromBytes).toBe(fromRecords);
+        expect(fromBytes).toMatch(/^[0-9a-f]{64}$/);
+        expect(Storage.digestOf(`${SERIALIZED}\n`)).not.toBe(fromBytes);
+    });
+});

--- a/test/playwright/unit/app/devindex/StoragePublishedIndex.spec.mjs
+++ b/test/playwright/unit/app/devindex/StoragePublishedIndex.spec.mjs
@@ -150,6 +150,35 @@ test.describe('DevIndex Storage — the published index as the read side (#17374
         }
     });
 
+    test('a 200 carrying an unparseable body falls back on the BOOTSTRAP run, rather than throwing', async () => {
+        // The uncovered path, and the dangerous one. With provenance recorded, a mangled body fails
+        // the digest comparison and never reaches the parse. With provenance ABSENT — the first run
+        // after adoption, which the code itself calls expected — nothing has verified these bytes, so
+        // an HTML interstitial or a truncated transfer arrives at `JSON.parse`. Unguarded that throws
+        // out of `getUsers()` and takes the run down on the one run documented as normal.
+        stubFetch('<!DOCTYPE html><html>portal login</html>', {ok: true, status: 200});
+        stubProvenance(null);
+
+        Storage.readJson = async (path, defaultValue) =>
+            path === config.paths.indexProvenance ? null :
+            path === config.paths.users          ? RECORDS : originalReadJson(path, defaultValue);
+
+        const warned   = [];
+        const realWarn = console.warn;
+
+        console.warn = message => warned.push(String(message));
+
+        try {
+            // The assertion is that this RESOLVES at all. Before the guard it rejected.
+            const result = await Storage.getUsers();
+
+            expect(result).toEqual(RECORDS);
+            expect(warned.some(line => line.includes('not parseable JSONL'))).toBe(true);
+        } finally {
+            console.warn = realWarn
+        }
+    });
+
     test('AC-3: a digest mismatch falls back rather than mutating an artifact we did not write', async () => {
         stubFetch(SERIALIZED);
         stubProvenance({digest: 'f'.repeat(64)});


### PR DESCRIPTION
Resolves #17374

Sub 1 of #17238, and the axis that was blocked by nothing. It does not stop the repository growing — that is #17375. It removes the reason the index has to live in git at all, which is what makes #17375 possible.

Evidence: L3 (unit; the read path, the provenance guard and the fallback are all in-process) → L3 required (every AC on #17374 is in-tree, with no runtime surface the sandbox cannot reach). Residual: none.

## What changed

`Storage.getUsers()` fetches the previous index from the published artifact instead of reading whatever `actions/checkout` left on disk.

The asymmetry is the whole argument: **the browser has always read this file over HTTPS from the deployed site. Only the producer read it from git.**

**A correction to my own first framing of this, raised in review.** I wrote that the pipeline "needs a clone of a multi-gigabyte repository to obtain one file", implying this change shortens the checkout. It does not, by itself. `actions/checkout` defaults to a shallow `fetch-depth: 1`; this workflow explicitly sets `fetch-depth: 0`, and that line is the only option on the step carrying no justifying comment. The git work the pipeline performs — `rev-parse`, `reset --hard origin/dev`, `diff --cached`, and SHA *equality* rather than ancestry — needs no history at all. My inference, untested, is that the full depth exists for the publish push, since remotes reject shallow updates.

So the honest claim is narrower: this removes the reason the pipeline needs the *file* from the tree. Whether it can then shallow the checkout depends on the push, and the push is what #17375 removes — at which point `fetch-depth: 1` becomes available and the 239 s `Checkout repository` step (of a 22.6 min run, per #17238) collapses. That win belongs to #17375, not here.

Placed in `apps/devindex/services/Storage.mjs` rather than in `dataSyncPipeline.mjs` or the workflow, deliberately: the service travels with the app when #17375 relocates it. A workflow-level implementation would be correct and thrown away by the very next ticket.

## The fetched copy is used only when it is provably ours

`index-provenance.json` records the digest of what this pipeline last wrote. A fetch matching it is our own artifact and safe to mutate. Anything else — mismatch, non-2xx, unreachable host — falls back to the checkout copy, **which is the state we last wrote and therefore never a foreign artifact**.

## One AC was amended, and I would rather say so than quietly satisfy it

#17374's AC-3 as I wrote it said a mismatch **refuses**. Implementing it surfaced the flaw: a publish that has not propagated yet is an ordinary transient, and a hard refusal wedges the pipeline on it indefinitely. Falling back preserves the actual invariant — never mutate an artifact we did not publish — without the wedge.

The AC is amended on the ticket with that reasoning. The code was not bent to match a word I wrote before building the thing.

## Deltas

Single commit, `17e892484b`:

| file | delta |
|---|---|
| `apps/devindex/services/Storage.mjs` | `getUsers` prefers the published artifact; `readPublishedIndex`, `rejectPublishedIndex`, `digestOf`, `recordIndexProvenance` added; provenance hook inside `writeJson` |
| `apps/devindex/services/config.mjs` | `paths.indexProvenance` + a `publishedIndex` block declaring the URL and timeout once |
| `test/playwright/unit/app/devindex/StoragePublishedIndex.spec.mjs` | new, 8 arms |

Also one character of pre-existing trailing whitespace at `Storage.mjs:124`, which the commit gate surfaced once the file was staged. Unrelated to the change; flagged rather than smuggled.

## Test Evidence

**Mutation-proven, not assumed.** Two guards were neutered and the resulting failure set checked:

| mutation | killed | survived |
|---|---|---|
| delete the `console.warn` in `rejectPublishedIndex` | 3 arms — both AC-2 fallbacks, and the AC-3 mismatch | — |
| `false &&` the digest comparison | the AC-3 **mismatch** arm | the AC-3 **absence** arm |

The second row is the one worth checking. `absence-is-not-mismatch` and `mismatch-falls-back` are separate branches, and neutering one does not mask the other — exactly the property that keeps the fetched path from becoming unreachable forever while every log line claims otherwise.

**Runs:**
- 8/8 new arms
- **2837/2837** across the whole `test/playwright/unit/app/devindex/` tree at `CI=1`, four workers

## Post-Merge Validation

None owed. Every AC is discharged in-tree: the fetch, the provenance guard, the fallback and the digest are all in-process and unit-observable, so there is no runtime surface the sandbox cannot reach and nothing deferred to a scheduled run.

The pipeline behaviour change becomes observable on the next hourly run — its output is byte-identical by construction (AC-1 pins the two paths against each other), so a divergence there would be a defect in this PR rather than an expected residual.

## Two decisions a reviewer should attack

1. **Provenance is recorded inside `writeJson`, not at the three call sites.** A digest only some writers update reads as a foreign artifact and sends every later run down the fallback for a reason nobody could find. If you think the hook belongs at the call sites, that is a real finding.
2. **The digest is over the bytes written, not the in-memory records.** Deriving it from the records would compare a re-serialisation against a transmission — identical data, different bytes, and a mismatch indistinguishable from tampering.

## Deliberately not here

- **Publishing without committing.** #17375. This keeps committing exactly as today, which is why it is reversible and why the current behaviour is its own control.
- **Removing the derived files from git.** Same ticket.

## Related

Parent #17238 · blocks #17375 · `index-provenance.json` is deliberately tracked in git even as the index it describes leaves — it is the trusted anchor a fetched artifact is checked against, so it must live where the artifact cannot influence it.

Authored by Grace (Claude Opus 5, Claude Code). Session a105d215-c261-4b34-82a9-546596f665ef.
