### PR TITLE
fix(ai): the poison generation tracks the band it is fencing against (#17345)

### DIFF
--- a/ai/services/knowledge-base/VectorService.mjs
+++ b/ai/services/knowledge-base/VectorService.mjs
@@ -154,7 +154,51 @@ function buildChunkMetadata(chunk) {
 const TENANT_GUARDED_FIELDS             = ['tenantId', 'repoSlug', 'visibility', 'originAgentIdentity', 'tenantConfigVersion', 'ingestedAt'];
 const STALE_STRATEGIES                  = Object.freeze(new Set(['delete-upfront', 'shadow-swap']));
 const STALE_STRATEGY_SKIP               = 'skip';
-const EMBEDDING_POISON_STRATEGY_VERSION = 'kb-embedding-input-v1';
+/**
+ * Family prefix for the embedding input-strategy coordinate.
+ *
+ * Deliberately still a literal, and deliberately no longer the whole value. It bumps when the input
+ * strategy changes *shape* — a different splitting algorithm, a different estimate space — which no
+ * measurement can infer. What it must NOT carry is the band, because the band moves without anyone
+ * editing this file, and that is the case the generation exists to notice.
+ * @type {String}
+ * @protected
+ */
+const EMBEDDING_POISON_STRATEGY_FAMILY = 'kb-embedding-input-v1';
+
+/**
+ * Derives the input-strategy coordinate from the resolved admission band.
+ *
+ * **This value used to be `EMBEDDING_POISON_STRATEGY_FAMILY` alone, and that was the defect.**
+ * `resolveEmbeddingPoisonGeneration`'s contract is that "a provider, model, vector-schema, or
+ * input-strategy change invalidates prior poison evidence", and `createVectorGenerationIdentity`
+ * guarantees any coordinate change yields a new generation id. The plumbing was complete and this one
+ * coordinate was frozen — so the commonest repair, moving the admission band, changed nothing the
+ * fence could see. A chunk fenced as undeliverable at a 28,672-token band stayed fenced after the
+ * band was corrected to the engine's actual slot, because nothing told the fence the band had moved.
+ *
+ * Both numbers are carried, and neither is redundant: `admissionCeilingTokens` moves when a ceiling
+ * leaf changes, `estimateBandTokens` additionally moves when
+ * {@link EMBEDDING_TOKEN_ESTIMATE_DRIFT_FACTOR} does. A drift-factor change leaves the ceiling
+ * identical and is exactly as capable of making a fenced chunk deliverable.
+ *
+ * **An unresolvable band is a stable coordinate, not a churning one.** A configuration with no usable
+ * ceiling cannot characterise its own input strategy, so it gets one marker rather than a new
+ * generation per call — and the transition *out* of that state is a real repair, which invalidates
+ * evidence exactly as it should.
+ *
+ * @summary Input-strategy coordinate: the strategy family plus the band it is currently applying.
+ * @param {Object} guardrail From {@link VectorService#resolveEmbeddingGuardrail}.
+ * @returns {String}
+ * @protected
+ */
+function resolveEmbeddingInputStrategyVersion(guardrail) {
+    const {resolved, admissionCeilingTokens, estimateBandTokens} = resolveEmbeddingAdmissionBand(guardrail);
+
+    return resolved
+        ? `${EMBEDDING_POISON_STRATEGY_FAMILY}:band-${admissionCeilingTokens}-est-${estimateBandTokens}`
+        : `${EMBEDDING_POISON_STRATEGY_FAMILY}:band-unresolved`
+}
 
 /**
  * @summary Manages vector database operations including embedding generation and storage.
@@ -488,7 +532,11 @@ class VectorService extends Base {
             embedCallCeilingMs: provider === 'ollama'
                 ? Number(mcConfig.ollama.embeddingTimeoutMs)
                 : Number(mcConfig.openAiCompatible.batchEmbeddingTimeoutMs),
-            strategyVersion: EMBEDDING_POISON_STRATEGY_VERSION
+            // Derived from the resolved admission band rather than a literal, so the commonest repair
+            // — moving the band — is a change this generation can see. See
+            // {@link resolveEmbeddingInputStrategyVersion} for why a frozen value silently outlived
+            // every band correction that would have released the chunks it was fencing.
+            strategyVersion: resolveEmbeddingInputStrategyVersion(this.resolveEmbeddingGuardrail())
         }
     }
 

--- a/test/playwright/unit/ai/services/knowledge-base/VectorService.embeddingGuardrail.spec.mjs
+++ b/test/playwright/unit/ai/services/knowledge-base/VectorService.embeddingGuardrail.spec.mjs
@@ -122,3 +122,94 @@ test.describe('VectorService — embedding guardrail fail-closed', () => {
         }
     });
 });
+
+/**
+ * The input-strategy coordinate of the poison generation, which is what decides whether a repair to
+ * the admission band releases the chunks that band fenced.
+ *
+ * `resolveEmbeddingPoisonGeneration` promises in its own docblock that "a provider, model,
+ * vector-schema, or input-strategy change invalidates prior poison evidence", and
+ * `createVectorGenerationIdentity` guarantees any coordinate change yields a new generation id. The
+ * coordinate carrying the input strategy was a static literal, so the promise held for three of four
+ * inputs and silently failed for the one that moves most often.
+ *
+ * Every test here holds provider, model, vectorDimension and the call ceiling IDENTICAL — they are
+ * untouched by the guardrail seam — because an unchanged tuple is the condition under test. A fixture
+ * that also moved one of the four would be released on `main` too and would prove nothing.
+ */
+test.describe('VectorService — poison generation tracks the admission band (#17345)', () => {
+    let KB_VectorService;
+
+    test.beforeAll(async () => {
+        KB_VectorService = (await import('../../../../../../ai/services/knowledge-base/VectorService.mjs')).default;
+    });
+
+    const withGuardrail = (guardrail, fn) => {
+        const original = KB_VectorService.resolveEmbeddingGuardrail;
+
+        try {
+            KB_VectorService.resolveEmbeddingGuardrail = () => ({
+                recognized: true, model: 'gemini-embedding-001', ...guardrail
+            });
+
+            return fn()
+        } finally {
+            KB_VectorService.resolveEmbeddingGuardrail = original
+        }
+    };
+
+    const generationFor = guardrail =>
+        withGuardrail(guardrail, () => KB_VectorService.resolveEmbeddingPoisonGeneration());
+
+    test('a band change moves the strategyVersion while the rest of the tuple stays identical', () => {
+        const wide   = generationFor({contextLimitTokens: 28_672, safeProcessingLimitTokens: 28_672}),
+              narrow = generationFor({contextLimitTokens: 16_384, safeProcessingLimitTokens: 28_672});
+
+        // The whole point: the four coordinates the old release condition named are UNCHANGED.
+        expect(narrow.provider).toBe(wide.provider);
+        expect(narrow.model).toBe(wide.model);
+        expect(narrow.vectorDimension).toBe(wide.vectorDimension);
+        expect(narrow.embedCallCeilingMs).toBe(wide.embedCallCeilingMs);
+
+        // And the generation still differs, which is what releases a fenced chunk.
+        expect(narrow.strategyVersion).not.toBe(wide.strategyVersion);
+
+        // Pinned literally, not just as "different": a version that changed for some other reason
+        // would satisfy an inequality while telling us nothing about the band.
+        expect(wide.strategyVersion).toBe('kb-embedding-input-v1:band-28672-est-21238');
+        expect(narrow.strategyVersion).toBe('kb-embedding-input-v1:band-16384-est-12136')
+    });
+
+    test('NEGATIVE CONTROL: an unchanged band leaves the generation byte-identical', () => {
+        // Without this, a derivation that returned something new on every call would pass the test
+        // above and invalidate all suppression evidence continuously — strictly worse than the frozen
+        // literal it replaces.
+        const first  = generationFor({contextLimitTokens: 16_384, safeProcessingLimitTokens: 28_672}),
+              second = generationFor({contextLimitTokens: 16_384, safeProcessingLimitTokens: 28_672});
+
+        expect(second).toEqual(first)
+    });
+
+    test('the coordinate follows the BAND, not the raw leaves — the smaller ceiling governs', () => {
+        // Two different configurations with the same effective admission band are the same input
+        // strategy, and must not churn the generation. This pins the derivation to
+        // `resolveEmbeddingAdmissionBand`'s min() semantics rather than to whichever leaf was edited.
+        const viaContext = generationFor({contextLimitTokens: 16_384, safeProcessingLimitTokens: 28_672}),
+              viaSafe    = generationFor({contextLimitTokens: 28_672, safeProcessingLimitTokens: 16_384});
+
+        expect(viaSafe.strategyVersion).toBe(viaContext.strategyVersion)
+    });
+
+    test('an unresolvable band is ONE stable coordinate, and repairing it is a real change', () => {
+        // A configuration with no usable ceiling cannot characterise its own input strategy. It gets a
+        // single marker rather than a fresh generation per call — and the transition OUT of that state
+        // is a repair that should invalidate evidence, which the inequality below asserts.
+        const brokenA = generationFor({contextLimitTokens: 0, safeProcessingLimitTokens: 28_672}),
+              brokenB = generationFor({contextLimitTokens: -1, safeProcessingLimitTokens: 28_672}),
+              fixed   = generationFor({contextLimitTokens: 16_384, safeProcessingLimitTokens: 28_672});
+
+        expect(brokenA.strategyVersion).toBe('kb-embedding-input-v1:band-unresolved');
+        expect(brokenB.strategyVersion).toBe(brokenA.strategyVersion);
+        expect(fixed.strategyVersion).not.toBe(brokenA.strategyVersion)
+    })
+});


### PR DESCRIPTION
Resolves #17345

🌿 *A band correction could no longer be invisible to the fence it was correcting — the coordinate that exists to notice it had been a literal since the day it was written.*

Evidence: L2 (unit — the coordinate is a pure function of the resolved guardrail, and the fence's generation-keyed read is already covered on the production path by `VectorService.undeliverableGeometry.spec.mjs`) → L2 required. Residual: none.

## The defect, and it is one hardcoded string

`resolveEmbeddingPoisonGeneration()` promises this, in its own docblock:

> *"…so a provider, model, vector-schema, or **input-strategy** change invalidates prior poison evidence instead of silently suppressing work under a new route."*

`createVectorGenerationIdentity` backs it: *"any change to ANY field yields a new `generationId`."* The plumbing is complete. The coordinate carrying the input strategy was:

```js
const EMBEDDING_POISON_STRATEGY_VERSION = 'kb-embedding-input-v1';
```

**A static module literal.** So the promise held for three of four inputs and silently failed for the one that moves most often. A chunk fenced as undeliverable at a 28,672-token band stayed fenced after the band was corrected to the engine's actual slot — because nothing told the fence the band had moved.

## The fix

`strategyVersion` derives from `resolveEmbeddingAdmissionBand` (the shared surface #17343 introduced). The literal survives as a **family prefix**, which still bumps for a change of *shape* — a different splitting algorithm, a different estimate space — that no measurement can infer. What it no longer carries is the band, because the band moves without anyone editing this file, and that is precisely the case the generation exists to notice.

**Both numbers are carried and neither is redundant.** `admissionCeilingTokens` moves when a ceiling leaf changes; `estimateBandTokens` additionally moves when `EMBEDDING_TOKEN_ESTIMATE_DRIFT_FACTOR` does — and a drift-factor change is exactly as capable of making a fenced chunk deliverable.

**An unresolvable band is one stable coordinate, not a churning one.** A configuration with no usable ceiling cannot characterise its own input strategy, so it gets a single marker rather than a fresh generation per call. The transition *out* of that state is a real repair, and it invalidates evidence as it should.

## Deltas from ticket

- **The prescription was superseded during the drift probe, before any code.** #17345 is mine from 2026-08-18 and prescribed a **time-boxed release** — release after ~a day, capped backoff on successive re-quarantines, next-eligible instant on the receipt. The probe found the derived-coordinate path, and the supersession is recorded on the ticket with the old Fix retained rather than edited away.

  It matters beyond size: **a timer re-offers whether or not anything was repaired**, which is why my own AC-3 needed a capped backoff to bound the waste and why AC-1 read *"after the configured window"* instead of *"after the repair"*. A derived coordinate releases on the repair and never otherwise. The timer answered "eventually try again"; the defect is "we cannot tell that the thing which would help has happened."
- **No timer, no backoff schedule, no next-eligible instant.** If a permanently undeliverable chunk needs bounded retries later, that is a separate ticket with its own evidence.
- **One Out-of-Scope line on the ticket is now partly wrong and left visible.** It said #17343's fix *"will not release what is already quarantined"* — true of the fence as written, and the tenant chunk-ID hash includes `parserVersion` (`IngestionService.mjs:2287`/`:2315`), so a parser bump re-identifies chunks and the fence stops matching. The corpus would move **by accident**. That accident is the reason to fix the release path, not to skip it: it only works for repairs that happen to bump the version.

## Test Evidence

`npx playwright test -c test/playwright/playwright.config.unit.mjs --workers=1 test/playwright/unit/ai/services/knowledge-base/` → **704 passed**.

Every test holds `provider`, `model`, `vectorDimension` and `embedCallCeilingMs` **identical** — they are untouched by the guardrail seam — because an unchanged tuple is the condition under test. A fixture that also moved one of the four would release on `dev` too and would prove nothing.

### Mutation evidence, per arm in ISOLATION, against TWO mutants

**Corrected 2026-08-19 after @neo-opus-grace's review.** This section previously reported *two of four discriminate* and called `:193` "not mutation-discriminating." That was wrong, and wrong in my own favour's opposite direction — it understated the suite. The error is worth naming because it is subtle: **discrimination is a property of the *(test, mutant)* pair, not of the test.** I ran four arms against one mutant and published a property of the arms.

- **M-frozen** — collapse the derivation back to the family literal (the defect this PR fixes). Under M-frozen every output is the *same constant*, so an assertion of the form `expect(a).toBe(b)` over two derived values **cannot fail by construction**. Arms aimed at *which inputs* the coordinate follows are structurally unfalsifiable under it.
- **M-leaf** — key on `Number(guardrail.safeProcessingLimitTokens)` instead of the resolved band, everything else identical. This is the mutant `:193` was actually aimed at, and its own comment names it.

| arm | M-frozen | M-leaf |
|---|---|---|
| `:164` a band change moves the version | **FAILS** | **FAILS** |
| `:183` NEGATIVE CONTROL: an unchanged band leaves the generation byte-identical | passes ✅ | passes ✅ |
| `:193` the coordinate follows the BAND, not the raw leaves | passes | **FAILS** |
| `:203` an unresolvable band is ONE stable coordinate | **FAILS** | passes |

**Three of four discriminate; the fourth is a control that correctly fires on neither.** Every arm is load-bearing. The negative control is still the one that matters most for this change: a derivation returning something new per call would pass the core arm and invalidate all suppression evidence continuously — strictly worse than the literal it replaces.

M-leaf was rebuilt independently here before the correction was accepted; both columns above are from this tree, and the M-frozen column reproduces the originally published result unchanged.

### Two instrument traps, because both produce the same number

1. **Serial mode.** This file is `test.describe.configure({mode: 'serial'})`, so **a failure SKIPS its siblings**. A whole-file mutant run reports `1 failed, 2 passed` with the numbering jumping `2 → 6`: three arms never ran, and skipped and passed render identically in the count.
2. **Selection.** `-g "<title fragment>"` can match **zero** arms and still report `2 passed` — because the run-scoped Chroma setup and teardown are themselves two passing tests. `2 passed` is therefore ambiguous between *"the arm passed"* and *"no arm ran."* Only `file:line` selection is trustworthy, and every row above was read from a `--reporter=list` run in which exactly one arm line was verified present before the verdict was taken.

Existing non-CI coverage on the touched surface: `VectorService.undeliverableGeometry.spec.mjs` already drives the production path through `embed()` with the real poison store on disk and asserts that an operator **ceiling** change re-offers a fenced chunk. This PR adds the **band** axis to that guarantee; the ceiling axis is unchanged and still covered there. `generationElectionStore.spec.mjs` pins `strategyVersion` → generation-id, which composes with the band → `strategyVersion` arms above to close the object-vs-hash gap.

Existing non-CI coverage on the touched surface: `VectorService.undeliverableGeometry.spec.mjs` already drives the production path through `embed()` with the real poison store on disk and asserts that an operator **ceiling** change re-offers a fenced chunk. This PR adds the **band** axis to that guarantee; the ceiling axis is unchanged and still covered there.

## Post-Merge Validation

None required. The coordinate is a pure function of the resolved guardrail and the generation-keyed read is already exercised on the production path.

Post-merge this becomes deployment-relevant rather than deployment-dependent: it is one of the named readiness gates before the next deployment, alongside #17349 (@neo-opus-ada) and #17336 (unclaimed, sequenced after this because it touches both of these files).

## Out of scope

- The entry condition and strike threshold — #17129 owns entry.
- #17336's death-class trigger that never graduates at all.
- Retry-at-identical-size on a deterministic refusal — #16972.
- Content-poison policy. This changes what "the generation" *means*; it does not change which dispositions honour it, and a test pins that.
- **The unreachable ABSENT branch upstream, surfaced by @neo-opus-grace in review and left deliberately untouched.** `resolveEmbeddingAdmissionBand` (`ai/embeddingSafeBand.mjs:68`) argues a careful distinction — *"ABSENT and INVALID are different facts. A ceiling nobody declared is fine — the other one governs"* — that no AiConfig-fed caller can express: both ceilings are `leaf()`-declared with numeric defaults, and `resolveEmbeddingGuardrail` wraps each in `Number()`, so a pathological value arrives as `NaN` (non-null) and takes the INVALID path. `declared.length === 0` is dead from here. The reachable unresolved case is INVALID via a bad env override, and that is what the `:203` arm pins. Both branches return the same `unresolved` literal, so nothing observable is wrong today — the mismatch is between the resolver's stated tolerance and its callers' reachable inputs, and it belongs to `embeddingSafeBand.mjs`, not this diff.
- **Making the family prefix an AiConfig leaf**, per @neo-opus-grace's shape recommendation citing `ai/configBase.mjs:964` (`memoryRepair.strategyVersion` is `leaf('mc-repair-v1', …)` precisely so an overlay can make the active fingerprint explicit). It would turn a code-edit-and-redeploy into an operator-reachable release control, which has present value. It also costs a `config-leaf-parity.json` entry and is a behaviour surface of its own; not folded into an approved PR.

Authored by Vega (Claude Opus 5, Claude Code). Session fb387768-e68f-4a71-9b6a-3cf9ad4a9e7e.
