### PR TITLE
fix(test): import Neural Link services directly, not through the Brain barrel (#17369)

### DIFF
--- a/test/playwright/fixtures.mjs
+++ b/test/playwright/fixtures.mjs
@@ -1,15 +1,36 @@
 import { test as base, expect } from '@playwright/test';
 import * as RmaHelpers          from './util/RmaHelpers.mjs';
-import {
-    NeuralLink_ConnectionService,
-    NeuralLink_InstanceService,
-    NeuralLink_ComponentService,
-    NeuralLink_DataService,
-    NeuralLink_DockService,
-    NeuralLink_RuntimeService,
-    NeuralLink_InteractionService
-} from '../../ai/services.mjs';
-import aiConfig from '../../ai/mcp/server/neural-link/config.template.mjs';
+
+// `Neo` plus the core class system, imported for their SIDE EFFECT and not for these bindings.
+//
+// They are the half of this change that is easy to delete and expensive to restore. `ai/services.mjs`
+// used to supply them incidentally, because a barrel that reaches the whole Brain also reaches
+// whatever bootstraps the class system. Importing the Neural Link services directly removes that,
+// and the failure is a `ReferenceError: Neo is not defined` thrown from `src/core/Compare.mjs` —
+// a file this module does not name, during a service construction it did not obviously trigger.
+// `ai/mcp/server/neural-link/run-bridge.mjs` carries the same pair for the same reason.
+import Neo       from '../../src/Neo.mjs';
+import * as core from '../../src/core/_export.mjs';
+
+// Imported per-service rather than from `ai/services.mjs`, deliberately.
+//
+// This fixture needs seven Neural Link symbols. `ai/services.mjs` re-exports them alongside the
+// knowledge-base, memory-core and ingestion families, so importing it pulls the entire Brain into
+// the test process of every project that uses this fixture — including `ai/graph/storage/SQLite.mjs`
+// and, through it, the native `better-sqlite3` binding. A downstream adopter's CI showed the cost:
+// every test passing, then `Statement::~Statement()` aborting at teardown, on a repository with zero
+// first-party SQLite importers that could not drop the dependency because this file demanded it.
+//
+// These modules import only `src/core/Base.mjs`, their own config and logger, `RuntimeFreshnessService`,
+// their siblings, and node builtins — no graph, no vector store, no native bindings.
+import NeuralLink_ComponentService   from '../../ai/services/neural-link/ComponentService.mjs';
+import NeuralLink_ConnectionService  from '../../ai/services/neural-link/ConnectionService.mjs';
+import NeuralLink_DataService        from '../../ai/services/neural-link/DataService.mjs';
+import NeuralLink_DockService        from '../../ai/services/neural-link/DockService.mjs';
+import NeuralLink_InstanceService    from '../../ai/services/neural-link/InstanceService.mjs';
+import NeuralLink_InteractionService from '../../ai/services/neural-link/InteractionService.mjs';
+import NeuralLink_RuntimeService     from '../../ai/services/neural-link/RuntimeService.mjs';
+import aiConfig                      from '../../ai/mcp/server/neural-link/config.template.mjs';
 
 export const test = base.extend({
     /**

--- a/test/playwright/unit/ai/services/hostBarrelRuntimeReach.spec.mjs
+++ b/test/playwright/unit/ai/services/hostBarrelRuntimeReach.spec.mjs
@@ -162,5 +162,38 @@ test.describe('host-plane runtime reach — a store handle must be unreachable b
             `the host barrel died, but not of the js-yaml denial — so this control does not show ` +
             `the probe observes its resolution.\n\n--- probe output ---\n${stdout}`
         ).toMatch(/js-yaml/)
+    });
+
+    test('the shared Playwright fixture survives the same denial — a consumer must not inherit the Brain (#17369)', () => {
+        // 104 spec files import this fixture, so whatever it resolves, every consumer's test process
+        // resolves too. It reached the Brain through `ai/services.mjs` for seven Neural Link symbols,
+        // and a downstream adopter's CI aborted at teardown on the native `better-sqlite3` binding it
+        // never used.
+        //
+        // This lives here rather than in a lint because the property is a RUNTIME one and the static
+        // guard cannot see it twice over: `engine-brain-boundary-lint.yml` path-filters on
+        // `buildScripts/**` and `src/**`, and a walk cannot see that `initAsync()` is scheduled by
+        // `setupClass` on the next microtask — the same reason this file exists at all. e2e is not in
+        // the CI matrix, so before this arm nothing in CI stopped the regression returning.
+        //
+        // Discriminating, not merely green: at `dev`'s barrel-importing revision this same call dies
+        // with `DENIED_CLOUD_PLANE_PACKAGE: chromadb`. The two CONTROL arms above license that
+        // reading — they establish the denial is real and that the probe observes the target's own
+        // resolution, so this arm does not have to re-prove either.
+        const {survived, stdout} = probe({
+            target: 'test/playwright/fixtures.mjs',
+            denied: CLOUD_ONLY
+        });
+
+        expect(
+            survived,
+            'the shared Playwright fixture resolved a cloud-plane package, so every project using it ' +
+            'pulls the Brain into its test process. Import the seven Neural Link services directly ' +
+            'from `ai/services/neural-link/*` rather than through `ai/services.mjs`, and keep the ' +
+            '`Neo` / `core/_export` pair — the barrel supplied that class-system bootstrap ' +
+            'incidentally, and without it this dies as `ReferenceError: Neo is not defined` from ' +
+            '`src/core/Compare.mjs`, a file the fixture never names.' +
+            `\n\n--- probe output ---\n${stdout}`
+        ).toBe(true)
     })
 });


### PR DESCRIPTION
Resolves #17369

`test/playwright/fixtures.mjs` needed seven Neural Link symbols and imported them from `ai/services.mjs`, a barrel that also re-exports the knowledge-base, memory-core and ingestion families. Every project using this fixture therefore pulled the entire Brain into its test process — including `ai/graph/storage/SQLite.mjs` and, through it, the native `better-sqlite3` binding. This imports the seven services directly and keeps the `Neo` / `core/_export` bootstrap the barrel had been supplying incidentally.

Evidence: L3 (unit, component and full local e2e — the fixture is exercised in-process by every suite that uses it; e2e is not a `dev` CI gate, so it was run locally) → L3 required (every AC on #17369 is in-tree). Residual: none.

## What changed, and the half that is easy to delete

Two lines look like dead bindings and are not:

```js
import Neo       from '../../src/Neo.mjs';
import * as core from '../../src/core/_export.mjs';
```

Removing them fails as `ReferenceError: Neo is not defined` thrown from `src/core/Compare.mjs` — a file this module never names, during a service construction it does not obviously trigger. A barrel that reaches the whole Brain also reaches whatever bootstraps the class system; importing per-service removes that, so the bootstrap has to become explicit. `ai/mcp/server/neural-link/run-bridge.mjs` and `test/playwright/unit/ai/services-resilient-load.spec.mjs` both carry the same pair, so this is repo idiom rather than invention. The comment at the import records why, because the next reader's instinct will be to simplify it away.

**Measured import-graph reach of the fixture**, walker with a before/after control over the same entry point:

| | modules reached | under `ai/graph` or `ai/services/{memory-core,knowledge-base,ingestion}` |
|---|---|---|
| before | 308 | **117** |
| after | **38** | **0** |

## Deltas from ticket

**The fix is scoped to a class, and I checked the class rather than the file.** Sweeping the whole test tree for barrel and Brain-family importers: `fixtures.mjs` is the only *shared infrastructure* that reached the Brain. `test/playwright/unit/ai/services-resilient-load.spec.mjs` and `TemporalSummaryAggregationService.spec.mjs` also import the barrel, legitimately — they are Brain-tier specs testing Brain symbols, and they pay for themselves. `restoreEmptyTargetMeasurementAdapter.mjs` sits in the same shared directory and imports `better-sqlite3` directly, but has exactly one importer (its own spec), so it is not a second instance. The boundary that matters is *shared infrastructure must not reach the Brain; Brain-tier specs may* — and 104 files import this fixture, which is why it was the one that mattered.

**AC-5 discharged via its second branch.** The AC allows the `SQLite.mjs:49` caller to be identified *or* a follow-up filed. Filed as **#17383**, with the question narrowed rather than punted: the dynamic import is method-scoped inside `initAsync()`, and neither `SQLite.mjs` nor `GraphService.mjs` instantiates at module scope, so the ticket's original "reached during initialization" premise survives but is not pinned. #17383 carries both candidate explanations and an AC requiring a captured stack rather than an error message.

**Observation, no action taken here:** `engine-brain-boundary-lint.yml` path-filters on `buildScripts/**` and `src/**` and does not cover `test/**` — a guard built to catch an engine→Brain import could not see this file. Not widened here, because a blanket `test/**` rule would be wrong: Brain-tier specs import the Brain by design. Recording it rather than filing, since the correct predicate is narrower than a path filter and deserves shaping before it becomes a ticket.

## The regression guard — added in review, and it demotes everything below it

@neo-opus-grace's review made the right catch: my e2e control was well built and did not need to carry this much. `test/playwright/unit/ai/services/hostBarrelRuntimeReach.spec.mjs` already owns this exact concern and already has a `probe({target, denied})` that spawns a real node process with the cloud plane unresolvable. She pointed it at this fixture and handed over four arms of evidence; folded in as one arm.

It is a **runtime** guard on purpose, for the same reason that file exists: `better-sqlite3` is reached through `await import()` inside `initAsync()`, which `setupClass` schedules on the next microtask, so no static walk can see it — and `engine-brain-boundary-lint.yml` path-filters on `buildScripts/**` and `src/**`, so it cannot see this file at all.

Verified discriminating in both directions, by me, independently of her run:

| | fixture | result |
|---|---|---|
| this branch | per-service imports | **6 passed** |
| `dev` | barrel import | fails — `DENIED_CLOUD_PLANE_PACKAGE: chromadb` |

The two existing CONTROL arms in that file license the reading — they already establish that the denial is real and that the probe observes the target's own resolution, so this arm re-proves neither. It runs in the **unit** tier in about a second.

**This matters more than the line count.** e2e is not in the CI matrix, so before this arm nothing in CI stopped the regression returning — and it already shipped once, costing a downstream adopter's CI. The e2e control below is now corroboration rather than the load-bearing evidence for this property.

## Test Evidence

Run at `c644762` (pre-rebase tree; the rebase adds only data-sync content and one devindex **unit** spec, nothing under `test/playwright/e2e/**`, `src/` or `ai/services/neural-link/`, so the attribution below carries).

- **unit:** `npm run test-unit` — 14196 passed.
- **components:** `npm run test-components` — 50 passed.
- **e2e — the gap this PR existed to close, and the reason no PR was opened earlier.** 104 files use this fixture, and e2e is where it runs against a real browser and a live Neural Link bridge, so a green unit run proves little about it. `npm run test-e2e`: **40 failed / 175 passed / 6 skipped (27.6m)**.

  Those 40 are **pre-existing on `dev`, not caused by this change**, and I ran a control rather than asserting it. Same worktree, same build, same machine, same suite, with only `test/playwright/fixtures.mjs` reverted to the `origin/dev` version — one variable:

  | | failed | passed | skipped |
  |---|---|---|---|
  | with this change | 40 | 175 | 6 |
  | control (`dev` fixture) | 41 | 174 | 6 |

  **Zero spec files fail only in the treatment.** One (`e2e/workstation/WorkstationSplitterGridGeometryNL.spec.mjs`) fails only in the control; that is a one-spec delta and I read it as flake, not as this change fixing anything. I deliberately did **not** run the control over only the failing specs, which would have been ~3 minutes instead of ~25: this config is `workers: 1, fullyParallel: false`, so execution order is part of the conditions, and a subset control runs green on any cross-file leak and returns exactly the wrong attribution.

- **integration / integration-parity:** not run locally; they are exact-head required CI on this PR and that is the sanctioned evidence for them.

Per directly touched surface — `test/playwright/fixtures.mjs`: no dedicated spec exists for the fixture itself (`None found`); its coverage is every suite that consumes it, which is what the runs above exercise.

## Post-Merge Validation

None owed. Every AC is discharged in-tree and unit/e2e-observable; nothing here depends on a deployed surface.

Two things worth recording that are **not** obligations, so they are stated rather than checkboxed:

- A downstream consumer whose CI aborted at teardown on `Statement::~Statement()` can drop `better-sqlite3` once it consumes a `neo.mjs` carrying this fix. That is their step, not ours; recorded so the dependency direction is legible.
- `dev` currently carries 40 failing e2e specs across agentos, dashboard, grid, neural-link, rendering and workstation — established by the control run above, which is the honest reading of those numbers. e2e is not in the `dev` CI matrix (`unit`, `components`, `integration-unified`, `integration-parity`), which is how it stays invisible. Out of scope here, and I am deliberately not filing against it from a single observation.

## Commits

- `8f90bc0717` — fix(test): import Neural Link services directly, not through the Brain barrel (#17369)
- `3376b90f04` — test(ai): guard the shared Playwright fixture against Brain reach at runtime (#17369)

Authored by Ada (Claude Opus 5, Claude Code). Session 4979b8c3-8aed-4a62-814a-7d8135423b61.
