### PR TITLE
fix(orchestrator): a clean slice clears the streak it can never otherwise decay (#17349)

### DIFF
--- a/ai/daemons/orchestrator/services/TenantRepoSyncService.mjs
+++ b/ai/daemons/orchestrator/services/TenantRepoSyncService.mjs
@@ -2487,8 +2487,55 @@ class TenantRepoSyncService extends Base {
                     //   settle a checkpoint over a remainder that never landed — the failure this
                     //   outcome exists to prevent, and the one AC-6's negative arm pins.
                     //
-                    // The streak is neither incremented nor reset, so a budgeted rotation cannot
-                    // climb a repo toward its backoff cap: being large is not a fault.
+                    // The streak is CLEARED, for the same reason `complete` clears it: this branch is
+                    // reachable only on a clean summary. An error-bearing summary throws before the
+                    // `yielded` check, so `partial-progress` is by construction a run in which nothing
+                    // failed. The streak exists to back off from FAILURES, and a clean slice is
+                    // positive evidence there is no longer a fault to back off from. The only thing
+                    // separating this outcome from `complete` is that the corpus is not exhausted,
+                    // which is not a fault signal.
+                    //
+                    // Holding it instead — the prior behaviour — was not neutral, because a repo whose
+                    // corpus exceeds one slice budget never REACHES `complete`, and `complete` is the
+                    // only outcome that cleared the streak. Such a repo could therefore never decay a
+                    // streak it accrued while a real fault was live, no matter how well it ran.
+                    // Observed on a live plane: `errors=0` printed beside `streak held at 42`.
+                    //
+                    // Decaying by one instead of clearing does not fix it, and the cap is why.
+                    // `effectiveCadence` is `min(2^streak x (base + jitter), cap)` with the shipped
+                    // leaves `backoffCapMs` 2 h, `intervals.tenantRepoSyncMs` 30 min and
+                    // `jitterRatio` 0.20 (`ai/configBase.mjs:2168`, `:1621`, `:2169`) — so the curve
+                    // is capped from streak 2 onward and every streak above it is indistinguishable.
+                    // Walking 42 down to 1 is 41 clean sweeps spaced at the 2 h cap: ~82 h, about
+                    // 3.4 days. At the 309 seen on the live plane it is ~25.7 days. A decrement the
+                    // cap absorbs is a fixed budget standing in for a condition, which is the shape
+                    // this ticket exists to remove.
+                    //
+                    // Do NOT read the `backoffX` in the sync log as a delay: it is the raw multiplier,
+                    // printed before the cap is applied two lines later in `isRepoDue`. Both
+                    // @neo-opus-vega and I quoted `4.4e12` as though it were an interval; it never was.
+                    //
+                    // A repo alternating clean and failing slices is still protected: the failure path
+                    // increments on the very next bad slice, and it alone retains `lastSourceErrorCode`
+                    // and arms the recovery canary. What stops happening is a repo being throttled for
+                    // delivering.
+                    //
+                    // An armed embedding-recovery episode needs no carve-out here.
+                    // `classifyEmbeddingRecoveryState` inspects `embeddingRecovery` BEFORE the failure
+                    // count — its own comment names that ordering as load-bearing — and all three
+                    // returns inside `if (recovery)` are reached without consulting `failures`, pacing
+                    // off `probeSnapshot.nextAttemptAt` instead. `...priorState` carries the episode
+                    // through untouched.
+                    //
+                    // Scoped deliberately to the ARMED arm, because the streak is not unread by that
+                    // function: the fall-through past `if (recovery)` is `failures <= 0 ? null :
+                    // 'ordinary-repo-backoff'`. So for a repo with NO episode this clear flips the
+                    // published `recoveryState` to `null`, and the `repoStates.push` below reads the
+                    // freshly-written state, so the flip reaches the operator row. Benign and correct —
+                    // `null` is the documented return, the repo genuinely is no longer in ordinary
+                    // backoff, and no consumer reads `null` as unknown — but it is a real effect, and
+                    // an earlier revision of this comment claimed the streak was never read at all.
+                    // Narrowed after @neo-opus-vega grepped the function rather than accepting it.
                     const partialOutstanding = buildCorpusOutstandingObservation({
                         summary   : rawSummary,
                         priorState,
@@ -2499,17 +2546,24 @@ class TenantRepoSyncService extends Base {
                         ...priorState,
                         lastIngestedRev                   : priorState?.lastIngestedRev ?? null,
                         lastRunAttemptAt                  : startedMs,
-                        consecutiveFailures               : priorState?.consecutiveFailures ?? 0,
+                        consecutiveFailures               : 0,
                         lastAttemptedIngestContractVersion: TENANT_REPO_INGEST_CONTRACT_VERSION,
                         corpusOutstanding                 : partialOutstanding
                     };
+
+                    // Report the streak TRANSITION rather than a single number. `streak held at 42`
+                    // beside `errors=0` was true and unreadable: it named the state without naming
+                    // what the state was doing, so a reader could not tell a repo recovering from one
+                    // stuck at the cap. `42 -> 0` says which of the two this is in one glance.
+                    const priorStreak = priorState?.consecutiveFailures ?? 0;
 
                     writeLog?.('INFO', `[TenantRepoSync] ${repoLabel} partial-progress: ` +
                         `slice budget reached, checkpoint held at ` +
                         `${priorState?.lastIngestedRev ? priorState.lastIngestedRev.slice(0, 8) : 'none'} ` +
                         `ingested=${rawSummary?.ingested ?? 0} ` +
                         `embeddings=${rawSummary?.embeddingsGenerated ?? 0} ` +
-                        `(streak held at ${priorState?.consecutiveFailures ?? 0}; repo stays due)`);
+                        `(clean slice: streak ${priorStreak} -> 0` +
+                        `${priorStreak > 0 ? ', backoff cleared' : ''}; repo due next cycle)`);
 
                     repoStates.push({
                         tenantId        : repo.tenantId,

--- a/test/playwright/unit/ai/daemons/orchestrator/services/TenantRepoSyncService.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/services/TenantRepoSyncService.spec.mjs
@@ -6899,6 +6899,88 @@ test.describe('TenantRepoSyncService (#11790)', () => {
      * batches and never before the first, so a wall-clock arm ("A released within sliceBudgetMs")
      * would fail against the primitive's own forward-progress guarantee and be the wrong shape.
      */
+    test('a clean slice CLEARS an inherited streak, while an error-bearing one still accrues it (#17349)', async () => {
+        const taskStateService = createInMemoryTaskStateService();
+
+        await provisionMirrorDir({tenantId: 't1', repoSlug: 'org/rotating'});
+        await provisionMirrorDir({tenantId: 't1', repoSlug: 'org/failing'});
+
+        // Imported rather than written as a literal. A seeded checkpoint on a foreign contract
+        // version is diverted before the outcome branch this test is about, so a hardcoded number
+        // that later goes stale would not fail — it would quietly stop exercising the fix and keep
+        // passing on a path nobody meant to test.
+        const {TENANT_REPO_INGEST_CONTRACT_VERSION: contractVersion} =
+            await import('../../../../../../../ai/daemons/orchestrator/services/tenantRepoCheckpointValidity.mjs');
+
+        // Both repos start at the SAME inherited streak, accrued while a real fault was live. The
+        // pair is the point: without the failing arm this test cannot tell "clears on a clean slice"
+        // from "never holds a streak at all", and the second reading would be a live regression —
+        // the backoff would stop protecting anything.
+        await TenantRepoSyncService.writePersistedRevisions({
+            filePath : revisionsFile,
+            revisions: {
+                't1/org/rotating': {lastIngestedRev: 'sha-rotating', lastRunAttemptAt: 111, consecutiveFailures: 42, ingestContractVersion: contractVersion, lastCommittedMaterializationAttemptId: 'a'.repeat(32)},
+                't1/org/failing' : {lastIngestedRev: 'sha-failing',  lastRunAttemptAt: 111, consecutiveFailures: 42, ingestContractVersion: contractVersion, lastCommittedMaterializationAttemptId: 'a'.repeat(32)}
+            }
+        });
+
+        await TenantRepoSyncService.runTask({
+            reason           : 'periodic-sweep:60000',
+            taskStateService,
+            tenantReposConfig: {tenantRepos: [
+                {tenantId: 't1', repoSlug: 'org/rotating', mirrorRoot, cloneUrl: 'https://github.com/neomjs/rotating.git'},
+                {tenantId: 't1', repoSlug: 'org/failing',  mirrorRoot, cloneUrl: 'https://github.com/neomjs/failing.git'}
+            ]},
+            gitMirror                    : makeFakeGitMirror(),
+            envelopeBuilder              : makeFakeEnvelopeBuilder(),
+            knowledgeBaseIngestionService: makeFakeIngestionService({
+                summaryFactory: payload => ({
+                    ingested           : 5916,
+                    deleted            : 0,
+                    embeddingsGenerated: 55,
+                    // The discriminator is NOT an error count on a partial slice — an error-bearing
+                    // summary is classified as a failure before the `yielded` check is ever reached,
+                    // so `partial-progress` is a clean run by construction. The two arms below are
+                    // therefore different OUTCOMES, not two flavours of one.
+                    errors             : payload.repoSlug === 'org/failing'
+                        ? [{code: 'KB_VECTOR_EMBED_INPUT_TRUNCATED', message: 'oversized chunk'}]
+                        : [],
+                    yielded   : payload.repoSlug === 'org/rotating',
+                    tenantId  : payload.tenantId,
+                    durationMs: 1
+                })
+            }),
+            revisionsFilePath: revisionsFile,
+            seedBootstrap    : false
+        });
+
+        const revisions = (await fs.readJson(revisionsFile)).revisions;
+
+        // The defect: `complete` was the only outcome that cleared the streak, and a repo whose
+        // corpus exceeds one slice budget never reaches `complete`. It could therefore never decay a
+        // streak it accrued while broken, no matter how cleanly it ran — measured live at streak 42
+        // with backoffX=4398046511104 and ~25 min between slices.
+        expect(
+            revisions['t1/org/rotating'].consecutiveFailures,
+            'a clean slice is evidence there is no fault left to back off from'
+        ).toBe(0);
+
+        // The control, and it is the reason this test can fail. It sits OUTSIDE the branch the fix
+        // touches: an error-bearing slice must still accrue, or the change did not clear a streak on
+        // success — it removed backoff.
+        expect(
+            revisions['t1/org/failing'].consecutiveFailures,
+            'a failing slice still accrues, so backoff still protects a genuinely broken repo'
+        ).toBe(43);
+
+        // Clearing the streak must not advance the checkpoint. The corpus is NOT exhausted; a
+        // rotating repo that also settled its checkpoint would silently claim a remainder landed.
+        expect(
+            revisions['t1/org/rotating'].lastIngestedRev,
+            'a budgeted slice clears the streak without claiming the corpus is whole'
+        ).toBe('sha-rotating');
+    });
+
     test('a yielded head repo rotates its slot and the tail is admitted in the SAME sweep, with zero failure accounting (#17132 AC2/AC6)', async () => {
         const
             captureCalls = [],


### PR DESCRIPTION
Resolves #17349

`partial-progress` held `consecutiveFailures` unchanged, and `complete` was the only outcome that cleared it. A repo whose corpus exceeds one slice budget never reaches `complete`, so it could never decay a streak accrued while a real fault was live. Now a clean slice clears it.

Evidence: L3 (unit; the streak write and its scheduling consumer are both in-process) → L3 required. Residual: none.

## Deltas from ticket

Two, both recorded on #17349 rather than silently implemented.

**The `errors=0` discriminator does not exist at this site.** `partial-progress` is reachable only on a clean summary — an error-bearing one throws at `TenantRepoSyncService.mjs:497`, before the `yielded` check. So AC-2 ("a `partial-progress` slice with `errors>0` holds the streak exactly as today") describes an unreachable state, and a test for it could only pass vacuously. The control I wrote instead is a repo whose slice *fails*, which exercises a different outcome and still accrues — that is the arm that can actually fail.

**Clears rather than decays by one.** `effectiveCadence` is `min(2^streak × (base + jitter), cap)`. On the shipped leaves — `backoffCapMs` 2 h, `intervals.tenantRepoSyncMs` 30 min, `jitterRatio` 0.20 (`ai/configBase.mjs:2168`, `:1621`, `:2169`) — the curve caps from **streak 2**, so every streak above it is indistinguishable:

| streak | uncapped | effective |
|---|---|---|
| 0 | ~36 min | ~36 min |
| 1 | ~72 min | ~72 min |
| 2 | ~144 min | **2 h (capped)** |
| 42 / 309 | — | 2 h |

Decay-by-one therefore walks 41 clean sweeps at the cap from streak 42 — **~82 h, about 3.4 days** — and 308 from the 309 observed live, **~25.7 days**. A decrement the cap absorbs is the same fixed-budget-standing-in-for-a-condition shape the ticket exists to remove. @neo-opus-vega preferred decay for a good reason — an alternating repo should not have a genuine streak erased — and that case is still covered, because the failure path increments on the very next bad slice and it alone retains `lastSourceErrorCode`.

**Correction to my own first framing, and it was load-bearing.** An earlier revision of this PR quoted a 60 s base, a "~25 min cap" and ~15 hours. I inferred the cap from a `next ~11:42:58` interval in a log line instead of reading the config leaves, and I quoted `backoffX=4398046511104` beside it as though a multiplier were a delay — it is printed before `isRepoDue` applies the cap two lines later. @neo-opus-vega re-derived the real curve and I reproduced it at source before rewriting. The conclusion did not change; it got stronger, and the arithmetic under it was not mine to keep.

I checked one thing before assuming it: an armed embedding-recovery episode needs no carve-out here. `classifyEmbeddingRecoveryState` inspects `embeddingRecovery` before the failure count and paces retries off its own `probeSnapshot.nextAttemptAt`, so recovery pacing never read this streak.

## Test Evidence

`TenantRepoSyncService.spec.mjs` — one test, two arms plus a checkpoint assertion:

- clean slice on a repo seeded at streak 42 → streak 0
- **control:** failing slice on a repo seeded at the same 42 → 43. Without it the test cannot distinguish "clears on a clean slice" from "never holds a streak", and the second reading would be a live regression.
- the checkpoint is not advanced — a rotating repo must not claim its corpus is whole.

Mutation-proven: reverting the one-line change turns the clean arm red (42 vs 0) while the control stays green, so the control is not what carries the test.

`npm run test-unit` scoped to the file: **146 passed**, matching the 145-passed baseline on a clean tree plus the new test. One run showed an unrelated red at `:5426` (#15763); two further full-file runs were green and the same test passes under `-g`, so I read it as pre-existing flake and did not attribute it.

Per directly touched surface — `ai/daemons/orchestrator/services/TenantRepoSyncService.mjs`: covered by `TenantRepoSyncService.spec.mjs` (146 tests).

## Post-Merge Validation

None owed. The change is in-process and unit-observable.

Worth watching, not an obligation, and scoped honestly: the live plane has four repos at streaks 238–309, and they clear on their first clean slice. But **that deployment will show no timing change**, because it sets `backoffCapMs` to 30 min without overriding the 30 min `intervals.tenantRepoSyncMs` — cap equals cadence, so jitter pushes `uncapped > cap` at *every* streak including zero and the failure backoff is inert there. Those repos were being retried every 30 minutes throughout, not suppressed. This PR's effect is on correctly-configured deployments; the collapse itself is @neo-opus-vega's #17386, not this ticket.

## Commits

- `9e7d2d98be` — fix(orchestrator): a clean slice clears the streak it can never otherwise decay (#17349)

Authored by Ada (Claude Opus 5, Claude Code). Session 4979b8c3-8aed-4a62-814a-7d8135423b61.
