### PR TITLE
fix(ai): the backoff cap must clear the jittered cadence, or the curve is inert (#17386)

### DIFF
--- a/ai/configBase.mjs
+++ b/ai/configBase.mjs
@@ -2101,10 +2101,21 @@ class ConfigBase extends ConfigProvider {
                  *   so a failing repo is guaranteed a retry inside the cap window regardless of
                  *   streak length — including across restarts, since the streak is persisted
                  *   state (an uncapped multiplier suppressed a never-ingested repo for 25+
-                 *   hours while sweeps read green). Must comfortably exceed the per-repo
-                 *   base cadence (floor `intervals.tenantRepoSyncMs`, 30min default) so it binds
-                 *   only on failure streaks; the 2-hour default mirrors the operator-visible
-                 *   recovery expectation for a transient mirror/credential outage.
+                 *   hours while sweeps read green). **Must be at least the per-repo base cadence
+                 *   plus its jitter ceiling** — `baseCadenceMs + floor(baseCadenceMs *
+                 *   jitterRatio)`, where the base is `tenantRepos[].cadenceMs` or the
+                 *   `intervals.tenantRepoSyncMs` floor (30min default) — so it binds only on
+                 *   failure streaks. The jitter term is load-bearing rather than pedantic: the
+                 *   cap comparison happens AFTER jitter is added, so a cap set merely above the
+                 *   base cadence still binds at `consecutiveFailures: 0` for most repo seeds.
+                 *   A cap that does not clear that bound makes the whole doubling curve inert —
+                 *   a repo failing consecutively is retried exactly as often as a healthy one —
+                 *   and pins `backoffCapped` to `true`, which is the one field that would
+                 *   otherwise distinguish a configured cadence from a capped one. Checked at the
+                 *   sweep boundary, which WARNs once per process and never throws. The 2-hour
+                 *   default mirrors the operator-visible recovery expectation for a transient
+                 *   mirror/credential outage. **`0` means no cap, never "no backoff":** the
+                 *   doubling then grows unbounded, so flat cadence is not expressible here.
                  * - `jitterRatio` caps the deterministic per-repo jitter offset as a fraction
                  *   of the base cadence. Default `0.20` keeps jitter within the operator-visible
                  *   cadence window.

--- a/ai/daemons/orchestrator/scheduling/tenantRepoSync.mjs
+++ b/ai/daemons/orchestrator/scheduling/tenantRepoSync.mjs
@@ -197,6 +197,28 @@ export function computeDeterministicJitter({tenantId, repoSlug, baseCadenceMs, j
 }
 
 /**
+ * @summary Resolves one repo's base cadence: its own override where usable, else the global.
+ *
+ * Extracted because two callers now decide it and both must decide it identically — {@link isRepoDue},
+ * which turns it into a due-time, and the sweep-boundary margin check, which turns it into the minimum
+ * legal `backoffCapMs`. A guard that resolved the base differently from the scheduler would warn about
+ * a configuration the scheduler is happy with, or stay silent on one it is not, and the only symptom
+ * would be a log line nobody could reconcile against behaviour.
+ *
+ * Two further copies of this fallback predate the extraction — `getAccessReadinessMaxAgeMs` here, and
+ * the bootstrap seed in `TenantRepoSyncService` — left alone deliberately rather than swept into an
+ * unrelated ticket.
+ *
+ * @param {Object} options
+ * @param {Object} options.repo Repo config; `cadenceMs` is an optional operator override.
+ * @param {Number} options.globalCadenceMs Fallback from `intervals.tenantRepoSyncMs`.
+ * @returns {Number}
+ */
+export function resolveRepoBaseCadenceMs({repo, globalCadenceMs}) {
+    return Number.isFinite(repo?.cadenceMs) && repo.cadenceMs > 0 ? repo.cadenceMs : globalCadenceMs
+}
+
+/**
  * @summary Returns whether durable recovery evidence grants one immediate sync attempt.
  *
  * This stays inside the existing per-repo due computation: the persisted scheduler remains the sole
@@ -283,7 +305,7 @@ export function classifyEmbeddingRecoveryState({persistedRepoState, probeSnapsho
  *     jitterMs: Number, backoffMultiplier: Number, backoffCapped: Boolean, lastRunAttemptAt: Number}}
  */
 export function isRepoDue({repo, persistedRepoState, now, globalCadenceMs, jitterRatio = 0, backoffCapMs = 0}) {
-    const baseCadenceMs       = Number.isFinite(repo?.cadenceMs) && repo.cadenceMs > 0 ? repo.cadenceMs : globalCadenceMs;
+    const baseCadenceMs       = resolveRepoBaseCadenceMs({repo, globalCadenceMs});
     const consecutiveFailures = persistedRepoState?.consecutiveFailures ?? 0;
     const lastRunAttemptAt    = persistedRepoState?.lastRunAttemptAt ?? 0;
     const jitterMs            = computeDeterministicJitter({
@@ -406,10 +428,22 @@ export function isStarvedOrderInverted({backoffCapMs, starvedAfterMs}) {
  * separate a *configured* cadence from a streak-driven one pinned at the cap; when every repo is
  * capped from zero it reads `true` unconditionally and separates nothing.
  *
- * The bound mirrors `isRepoDue`'s arithmetic rather than restating it, `Math.floor` included, so the
- * check cannot drift from the behaviour it describes. Two configurations are sound and must not be
- * reported: `backoffCapMs: 0` is the documented no-cap value, and with jitter disabled a cap equal to
- * the base cadence first binds at streak one, because the cap comparison is strictly-greater.
+ * **The bound is a SUPREMUM over every possible repo seed, deliberately, not the jitter of the repos
+ * actually configured.** `computeDeterministicJitter` is a hash of `tenantId + repoSlug`, so a real
+ * repo typically draws well under `maxJitterMs` — a measured fixture drew 24.6% of it — and there is
+ * therefore a band of caps where this reports collapsed while every configured repo happens to be
+ * fine. That over-warn is the safe direction on a non-throwing WARN, and the alternative is worse: a
+ * max-over-configured-repos bound would go quiet the moment the offending repo is removed and come
+ * back silently when a new one is added, which is a guard whose verdict depends on roster churn
+ * rather than on configuration. The signature takes no `tenantId`/`repoSlug` precisely so a per-seed
+ * variant is not expressible here without a caller deciding whose seed to privilege.
+ *
+ * The cap/jitter arithmetic mirrors `isRepoDue`'s rather than restating it, `Math.floor` included, and
+ * the base cadence comes from the shared {@link resolveRepoBaseCadenceMs} both callers use — so the
+ * only remaining freedom is the supremum-vs-per-seed choice above, which is stated rather than
+ * inherited. Two configurations are sound and must not be reported: `backoffCapMs: 0` is the
+ * documented no-cap value, and with jitter disabled a cap equal to the base cadence first binds at
+ * streak one, because the cap comparison is strictly-greater.
  *
  * Deliberately independent of `isRepoDue`, exactly as {@link isStarvedOrderInverted} is: the
  * relationship binds how the values are CONFIGURED, not how the computation uses them.
@@ -421,11 +455,34 @@ export function isStarvedOrderInverted({backoffCapMs, starvedAfterMs}) {
  * @returns {Boolean}
  */
 export function isBackoffMarginCollapsed({backoffCapMs, baseCadenceMs, jitterRatio = 0}) {
-    if (!Number.isFinite(backoffCapMs) || backoffCapMs <= 0)     return false;
-    if (!Number.isFinite(baseCadenceMs) || baseCadenceMs <= 0)   return false;
+    if (!Number.isFinite(backoffCapMs) || backoffCapMs <= 0) return false;
 
-    const ratio       = Number.isFinite(jitterRatio) && jitterRatio > 0 ? jitterRatio : 0,
-          maxJitterMs = Math.floor(baseCadenceMs * ratio);
+    const minimumCapMs = resolveMinimumBackoffCapMs({baseCadenceMs, jitterRatio});
 
-    return backoffCapMs < baseCadenceMs + maxJitterMs
+    return minimumCapMs !== null && backoffCapMs < minimumCapMs
+}
+
+/**
+ * @summary The smallest `backoffCapMs` that binds only on failure streaks, for one base cadence.
+ *
+ * The number an operator actually needs, and the reason it is exported rather than inlined into
+ * {@link isBackoffMarginCollapsed}: the guard's entire user-visible surface is a log line, so the
+ * message must be able to print the same value the predicate compares against. Computing it twice —
+ * once to decide, once to report — is how a remedy comes to disagree with the check that demanded it,
+ * and a stated remedy one unit stronger than the predicate is a real, if quiet, defect.
+ *
+ * `null` for an unresolvable base cadence: a cadence that cannot be read has no minimum, and `0`
+ * would read as "any cap will do".
+ *
+ * @param {Object} options
+ * @param {Number} options.baseCadenceMs Effective base cadence from {@link resolveRepoBaseCadenceMs}.
+ * @param {Number} [options.jitterRatio=0] From `tenantRepoSync.jitterRatio`.
+ * @returns {Number|null} Inclusive minimum in ms — a cap EQUAL to this is sound.
+ */
+export function resolveMinimumBackoffCapMs({baseCadenceMs, jitterRatio = 0}) {
+    if (!Number.isFinite(baseCadenceMs) || baseCadenceMs <= 0) return null;
+
+    const ratio = Number.isFinite(jitterRatio) && jitterRatio > 0 ? jitterRatio : 0;
+
+    return baseCadenceMs + Math.floor(baseCadenceMs * ratio)
 }

--- a/ai/daemons/orchestrator/scheduling/tenantRepoSync.mjs
+++ b/ai/daemons/orchestrator/scheduling/tenantRepoSync.mjs
@@ -393,3 +393,39 @@ export function isStarvedOrderInverted({backoffCapMs, starvedAfterMs}) {
         && Number.isFinite(backoffCapMs) && backoffCapMs > 0
         && starvedAfterMs <= backoffCapMs
 }
+
+/**
+ * @summary Pure relationship check for the OTHER tenant-repo-sync ordering: the backoff cap must
+ * leave room above the JITTERED base cadence, or it binds at `consecutiveFailures: 0` and the whole
+ * `2^n` curve becomes inert — a repo failing consecutively is retried exactly as often as a healthy
+ * one. `isRepoDue` adds jitter BEFORE comparing against the cap, so the honest bound is
+ * `baseCadenceMs + maxJitter`, not `baseCadenceMs`: at `jitterRatio: 0.20` a cap set just above the
+ * base cadence still caps most repo seeds at streak zero.
+ *
+ * Collapsing the margin also silences the only field that reports it. `backoffCapped` exists to
+ * separate a *configured* cadence from a streak-driven one pinned at the cap; when every repo is
+ * capped from zero it reads `true` unconditionally and separates nothing.
+ *
+ * The bound mirrors `isRepoDue`'s arithmetic rather than restating it, `Math.floor` included, so the
+ * check cannot drift from the behaviour it describes. Two configurations are sound and must not be
+ * reported: `backoffCapMs: 0` is the documented no-cap value, and with jitter disabled a cap equal to
+ * the base cadence first binds at streak one, because the cap comparison is strictly-greater.
+ *
+ * Deliberately independent of `isRepoDue`, exactly as {@link isStarvedOrderInverted} is: the
+ * relationship binds how the values are CONFIGURED, not how the computation uses them.
+ *
+ * @param {Object} options
+ * @param {Number} options.backoffCapMs Failure-backoff ceiling (`tenantRepoSync.backoffCapMs`).
+ * @param {Number} options.baseCadenceMs The repo's effective base cadence — `tenantRepos[].cadenceMs` where set, else `intervals.tenantRepoSyncMs`.
+ * @param {Number} [options.jitterRatio=0] Deterministic jitter ceiling as a fraction of the base cadence (`tenantRepoSync.jitterRatio`).
+ * @returns {Boolean}
+ */
+export function isBackoffMarginCollapsed({backoffCapMs, baseCadenceMs, jitterRatio = 0}) {
+    if (!Number.isFinite(backoffCapMs) || backoffCapMs <= 0)     return false;
+    if (!Number.isFinite(baseCadenceMs) || baseCadenceMs <= 0)   return false;
+
+    const ratio       = Number.isFinite(jitterRatio) && jitterRatio > 0 ? jitterRatio : 0,
+          maxJitterMs = Math.floor(baseCadenceMs * ratio);
+
+    return backoffCapMs < baseCadenceMs + maxJitterMs
+}

--- a/ai/daemons/orchestrator/services/TenantRepoSyncService.mjs
+++ b/ai/daemons/orchestrator/services/TenantRepoSyncService.mjs
@@ -45,6 +45,8 @@ import {
     isBackoffMarginCollapsed,
     isRepoDue,
     isStarvedOrderInverted,
+    resolveMinimumBackoffCapMs,
+    resolveRepoBaseCadenceMs,
     resolveUnknownRepoSelectorFailure
 } from '../scheduling/tenantRepoSync.mjs';
 import {
@@ -866,6 +868,19 @@ function assertFullMaterializationEffect(envelope, summary, priorState, material
  */
 const IN_FLIGHT_SUFFIX = '.in-flight';
 
+/**
+ * How many repo identities the collapsed-backoff-margin WARN names per required-minimum group.
+ *
+ * The message is the guard's only user-visible surface and an operator edits config from it, so the
+ * identities have to be there — but a deployment with a hundred repos on one cadence would otherwise
+ * put a hundred labels in one line. Grouping by required minimum keeps the useful part bounded by the
+ * number of distinct cadences; this bounds the tail inside each group, and the elision is printed as
+ * `+N more` rather than dropped, because a truncated list that looks complete is worse than a long one.
+ *
+ * @member {Number} IDENTITIES_PER_WARN_GROUP=3
+ */
+const IDENTITIES_PER_WARN_GROUP = 3;
+
 class TenantRepoSyncService extends Base {
     /**
      * Latches the once-per-process inverted-leaf-order warning (runTask boundary): the
@@ -1684,15 +1699,48 @@ class TenantRepoSyncService extends Base {
         // Evaluated over ALL configured repos, not the selected subset: a scoped CLI run must not
         // hide a collapsed margin on a repo it happened to skip.
         if (!this.backoffMarginWarned) {
-            const collapsed = allRepos.filter(repo => isBackoffMarginCollapsed({
-                backoffCapMs,
-                baseCadenceMs: (Number.isFinite(repo.cadenceMs) && repo.cadenceMs > 0) ? repo.cadenceMs : globalCadenceMs,
-                jitterRatio
-            }));
+            const collapsed = allRepos
+                .map(repo => {
+                    const baseCadenceMs = resolveRepoBaseCadenceMs({repo, globalCadenceMs});
+
+                    return {
+                        label       : `${repo.tenantId}/${repo.repoSlug}`,
+                        baseCadenceMs,
+                        minimumCapMs: resolveMinimumBackoffCapMs({baseCadenceMs, jitterRatio}),
+                        collapsed   : isBackoffMarginCollapsed({backoffCapMs, baseCadenceMs, jitterRatio})
+                    }
+                })
+                .filter(entry => entry.collapsed);
 
             if (collapsed.length > 0) {
+                // Grouped by required minimum, and the minimum comes from the same helper the
+                // predicate compares against rather than being recomputed here. A per-repo
+                // `cadenceMs` override is the case this check moved to the sweep boundary to catch,
+                // so naming only the global base would hand exactly that operator the wrong number
+                // to work from — and the latch means they never see the message twice.
+                const groups = new Map();
+
+                for (const entry of collapsed) {
+                    const key = `${entry.minimumCapMs}/${entry.baseCadenceMs}`;
+
+                    groups.has(key) || groups.set(key, {...entry, labels: []});
+                    groups.get(key).labels.push(entry.label);
+                }
+
+                // Identities are capped per group and the elision is stated: a silent truncation
+                // reads as a complete list, and this list is what an operator edits config from.
+                const detail = [...groups.values()].map(group => {
+                    const shown      = group.labels.slice(0, IDENTITIES_PER_WARN_GROUP),
+                          elided     = group.labels.length - shown.length,
+                          identities = elided > 0 ? `${shown.join(', ')}, +${elided} more` : shown.join(', ');
+
+                    return `needs >= ${group.minimumCapMs} for base ${group.baseCadenceMs} (${identities})`;
+                }).join('; ');
+
+                const highestMinimum = Math.max(...collapsed.map(entry => entry.minimumCapMs));
+
                 this.backoffMarginWarned = true;
-                writeLog?.('WARN', `[TenantRepoSync] tenantRepoSync.backoffCapMs (${backoffCapMs}) does not clear the jittered base cadence for ${collapsed.length}/${allRepos.length} repo(s) [${collapsed.map(r => `${r.tenantId}/${r.repoSlug}`).join(', ')}]: the cap binds at consecutiveFailures=0, so failure backoff never becomes a delay and backoffCapped reads true for a healthy repo. Raise backoffCapMs above baseCadence + floor(baseCadence * jitterRatio) (global base ${globalCadenceMs}, jitterRatio ${jitterRatio}), or lower the cadence.`);
+                writeLog?.('WARN', `[TenantRepoSync] tenantRepoSync.backoffCapMs (${backoffCapMs}) is below the minimum that binds only on failure streaks, for ${collapsed.length}/${allRepos.length} repo(s): ${detail}. At this cap those repos are capped at consecutiveFailures=0, so failure backoff never becomes a delay and backoffCapped reads true for a healthy repo. Raise backoffCapMs to at least ${highestMinimum}, or lower those repos' cadenceMs. jitterRatio=${jitterRatio}.`);
             }
         }
 

--- a/ai/daemons/orchestrator/services/TenantRepoSyncService.mjs
+++ b/ai/daemons/orchestrator/services/TenantRepoSyncService.mjs
@@ -42,6 +42,7 @@ import {
     classifyEmbeddingRecoveryState,
     detectStarvedTenantSync,
     hasPendingEmbeddingRecoveryBypass,
+    isBackoffMarginCollapsed,
     isRepoDue,
     isStarvedOrderInverted,
     resolveUnknownRepoSelectorFailure
@@ -874,6 +875,15 @@ class TenantRepoSyncService extends Base {
      * @protected
      */
     starvedOrderWarned = false
+    /**
+     * Latches the once-per-process collapsed-backoff-margin warning (sweep boundary, where the
+     * repo set is resolved): the first sweep emits it, later sweeps stay quiet. Sibling of
+     * {@link TenantRepoSyncService#starvedOrderWarned} and process-local latch state for the
+     * same reason — it is not configuration.
+     * @member {Boolean} backoffMarginWarned=false
+     * @protected
+     */
+    backoffMarginWarned = false
 
     static config = {
         /**
@@ -1661,6 +1671,30 @@ class TenantRepoSyncService extends Base {
         const repos          = onlyRepoSlugs
             ? allRepos.filter(r => onlyRepoSlugs.includes(r.repoSlug))
             : allRepos;
+
+        // One-time deployment sanity check on the OTHER leaf relationship, and never a throw for the
+        // same reason as its sibling at the runTask boundary. A cap that does not clear the JITTERED
+        // base cadence binds at consecutiveFailures=0, so the 2^n curve never becomes a delay — a repo
+        // failing consecutively is retried exactly as often as a healthy one — and `backoffCapped`
+        // stops distinguishing a configured cadence from a capped one, which is the only reason it is
+        // published. This check lives here rather than beside the starved-order one because the bound
+        // is per-repo: a `tenantRepos[].cadenceMs` override larger than the global collapses the margin
+        // for that repo alone, and the repo set does not exist until the config resolves.
+        //
+        // Evaluated over ALL configured repos, not the selected subset: a scoped CLI run must not
+        // hide a collapsed margin on a repo it happened to skip.
+        if (!this.backoffMarginWarned) {
+            const collapsed = allRepos.filter(repo => isBackoffMarginCollapsed({
+                backoffCapMs,
+                baseCadenceMs: (Number.isFinite(repo.cadenceMs) && repo.cadenceMs > 0) ? repo.cadenceMs : globalCadenceMs,
+                jitterRatio
+            }));
+
+            if (collapsed.length > 0) {
+                this.backoffMarginWarned = true;
+                writeLog?.('WARN', `[TenantRepoSync] tenantRepoSync.backoffCapMs (${backoffCapMs}) does not clear the jittered base cadence for ${collapsed.length}/${allRepos.length} repo(s) [${collapsed.map(r => `${r.tenantId}/${r.repoSlug}`).join(', ')}]: the cap binds at consecutiveFailures=0, so failure backoff never becomes a delay and backoffCapped reads true for a healthy repo. Raise backoffCapMs above baseCadence + floor(baseCadence * jitterRatio) (global base ${globalCadenceMs}, jitterRatio ${jitterRatio}), or lower the cadence.`);
+            }
+        }
 
         // Distinguish "operator-requested-unknown-slug" from "no config at all", and refuse on ANY
         // unknown slug rather than only an all-unknown set. Keyed on "nothing matched", a partially

--- a/test/playwright/unit/ai/daemons/orchestrator/scheduling/tenantRepoSync.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/scheduling/tenantRepoSync.spec.mjs
@@ -6,6 +6,7 @@ import {
     detectStarvedTenantSync,
     getDueTask,
     hasPendingEmbeddingRecoveryBypass,
+    isBackoffMarginCollapsed,
     isRepoDue,
     isStarvedOrderInverted
 } from '../../../../../../../ai/daemons/orchestrator/scheduling/tenantRepoSync.mjs';
@@ -480,5 +481,116 @@ test.describe('isStarvedOrderInverted (#16312)', () => {
         expect(isStarvedOrderInverted({backoffCapMs: 0,   starvedAfterMs: 1000})).toBe(false);
         expect(isStarvedOrderInverted({backoffCapMs: NaN, starvedAfterMs: 1000})).toBe(false);
         expect(isStarvedOrderInverted({backoffCapMs: 1000, starvedAfterMs: NaN})).toBe(false);
+    });
+});
+
+test.describe('isBackoffMarginCollapsed (#17386)', () => {
+    const HALF_HOUR = 30 * 60 * 1000,
+          TWO_HOURS = 2  * 60 * 60 * 1000;
+
+    test('NEGATIVE CONTROL: the shipped defaults leave a sound margin', () => {
+        // Without this arm a predicate hard-coded to `true` satisfies every other criterion here.
+        expect(isBackoffMarginCollapsed({backoffCapMs: TWO_HOURS, baseCadenceMs: HALF_HOUR, jitterRatio: 0.20})).toBe(false);
+    });
+
+    test('a cap EQUAL to the jittered base cadence collapses the margin', () => {
+        // The observed deployment shape: NEO_..._BACKOFF_CAP_MS overridden to the same 30 minutes
+        // that intervals.tenantRepoSyncMs already defaults to. The cap then binds at streak 0.
+        expect(isBackoffMarginCollapsed({backoffCapMs: HALF_HOUR, baseCadenceMs: HALF_HOUR, jitterRatio: 0.20})).toBe(true);
+    });
+
+    test('the JITTER TERM is what the bound turns on, and it is the reason "> base cadence" was wrong', () => {
+        // A cap 10% above the base cadence reads as compliant against the old prose and still binds at
+        // streak 0 for any repo whose deterministic jitter lands above 10%. This pair is the whole
+        // correction: same base, same ratio, one cap either side of `base + floor(base * ratio)`.
+        expect(isBackoffMarginCollapsed({backoffCapMs: HALF_HOUR * 1.10, baseCadenceMs: HALF_HOUR, jitterRatio: 0.20})).toBe(true);
+        expect(isBackoffMarginCollapsed({backoffCapMs: HALF_HOUR * 1.25, baseCadenceMs: HALF_HOUR, jitterRatio: 0.20})).toBe(false);
+
+        // The exact boundary is sound, not collapsed: `isRepoDue` caps on strictly-greater, and the
+        // largest jitter any seed can draw is `floor(base * ratio)`.
+        const exactBound = HALF_HOUR + Math.floor(HALF_HOUR * 0.20);
+
+        expect(isBackoffMarginCollapsed({backoffCapMs: exactBound,     baseCadenceMs: HALF_HOUR, jitterRatio: 0.20})).toBe(false);
+        expect(isBackoffMarginCollapsed({backoffCapMs: exactBound - 1, baseCadenceMs: HALF_HOUR, jitterRatio: 0.20})).toBe(true);
+    });
+
+    test('the bound agrees with isRepoDue at the worst-case seed, rather than restating it', () => {
+        // The predicate is only worth having if it decides the same thing the scheduler does. Drive the
+        // real computation at a collapsed config and at a sound one, and read `backoffCapped` at
+        // consecutiveFailures 0 — which is the state the guard claims to predict.
+        const repo  = {tenantId: 'acme', repoSlug: 'docs'},
+              state = {lastRunAttemptAt: 0, consecutiveFailures: 0};
+
+        const collapsed = isRepoDue({
+            repo, persistedRepoState: state, now: 1, globalCadenceMs: HALF_HOUR,
+            jitterRatio: 0.20, backoffCapMs: HALF_HOUR
+        });
+        const sound = isRepoDue({
+            repo, persistedRepoState: state, now: 1, globalCadenceMs: HALF_HOUR,
+            jitterRatio: 0.20, backoffCapMs: TWO_HOURS
+        });
+
+        // This repo's deterministic jitter must be non-zero, or the arm proves nothing about jitter.
+        expect(computeDeterministicJitter({...repo, baseCadenceMs: HALF_HOUR, jitterRatio: 0.20})).toBeGreaterThan(0);
+
+        expect(collapsed.backoffCapped).toBe(true);                              // capped with ZERO failures
+        expect(collapsed.effectiveCadenceMs).toBe(HALF_HOUR);
+        expect(sound.backoffCapped).toBe(false);
+        expect(isBackoffMarginCollapsed({backoffCapMs: HALF_HOUR, baseCadenceMs: HALF_HOUR, jitterRatio: 0.20})).toBe(true);
+        expect(isBackoffMarginCollapsed({backoffCapMs: TWO_HOURS, baseCadenceMs: HALF_HOUR, jitterRatio: 0.20})).toBe(false);
+    });
+
+    test('a collapsed margin makes the doubling curve inert: streak 309 costs exactly what streak 0 costs', () => {
+        // The claim that motivated the ticket, asserted rather than argued. `backoffMultiplier` is
+        // published beside the cadence precisely so this arithmetic is falsifiable — the multiplier is
+        // astronomically large and the cadence does not move.
+        const repo = {tenantId: 'acme', repoSlug: 'docs'},
+              args = {repo, now: 1, globalCadenceMs: HALF_HOUR, jitterRatio: 0.20, backoffCapMs: HALF_HOUR};
+
+        const fresh    = isRepoDue({...args, persistedRepoState: {lastRunAttemptAt: 0, consecutiveFailures: 0}}),
+              hammered = isRepoDue({...args, persistedRepoState: {lastRunAttemptAt: 0, consecutiveFailures: 309}});
+
+        expect(hammered.effectiveCadenceMs).toBe(fresh.effectiveCadenceMs);
+        expect(hammered.backoffMultiplier).toBeGreaterThan(1e90);                // the display number
+        expect(hammered.effectiveCadenceMs).toBe(HALF_HOUR);                     // the actual delay
+    });
+
+    test('jitter disabled with a cap EQUAL to the base cadence is SOUND, and must not warn', () => {
+        // This arm replaced an acceptance criterion that required the opposite. With jitterRatio 0 the
+        // uncapped cadence at streak 0 is exactly the base, and `isRepoDue` caps on strictly-greater,
+        // so the cap first binds at streak 1 — which is what "binds only on failure streaks" means. A
+        // guard that fired here would warn about a correct configuration.
+        expect(isBackoffMarginCollapsed({backoffCapMs: HALF_HOUR, baseCadenceMs: HALF_HOUR, jitterRatio: 0})).toBe(false);
+
+        const repo = {tenantId: 'acme', repoSlug: 'docs'},
+              args = {repo, now: 1, globalCadenceMs: HALF_HOUR, jitterRatio: 0, backoffCapMs: HALF_HOUR};
+
+        expect(isRepoDue({...args, persistedRepoState: {lastRunAttemptAt: 0, consecutiveFailures: 0}}).backoffCapped).toBe(false);
+        expect(isRepoDue({...args, persistedRepoState: {lastRunAttemptAt: 0, consecutiveFailures: 1}}).backoffCapped).toBe(true);
+    });
+
+    test('backoffCapMs 0 (the documented no-cap value) is never collapsed', () => {
+        // Mirrors isStarvedOrderInverted's treatment of starvedAfterMs 0: a guard that fires on the
+        // documented disable warns about a legal config and gets muted.
+        expect(isBackoffMarginCollapsed({backoffCapMs: 0, baseCadenceMs: HALF_HOUR, jitterRatio: 0.20})).toBe(false);
+    });
+
+    test('unresolvable values cannot be judged and are not collapsed', () => {
+        expect(isBackoffMarginCollapsed({backoffCapMs: NaN,       baseCadenceMs: HALF_HOUR, jitterRatio: 0.20})).toBe(false);
+        expect(isBackoffMarginCollapsed({backoffCapMs: HALF_HOUR, baseCadenceMs: NaN,       jitterRatio: 0.20})).toBe(false);
+        expect(isBackoffMarginCollapsed({backoffCapMs: HALF_HOUR, baseCadenceMs: 0,         jitterRatio: 0.20})).toBe(false);
+        expect(isBackoffMarginCollapsed({backoffCapMs: HALF_HOUR, baseCadenceMs: -1,        jitterRatio: 0.20})).toBe(false);
+
+        // A non-finite ratio degrades to no-jitter rather than poisoning the bound with NaN.
+        expect(isBackoffMarginCollapsed({backoffCapMs: HALF_HOUR + 1, baseCadenceMs: HALF_HOUR, jitterRatio: NaN})).toBe(false);
+    });
+
+    test('a per-repo cadenceMs override collapses the margin for that repo alone', () => {
+        // The reason the guard runs per repo rather than once on the global pair: an override LARGER
+        // than the global makes the same cap unsound for one repo while the rest stay sound, which a
+        // global-only check reports as clean.
+        expect(isBackoffMarginCollapsed({backoffCapMs: TWO_HOURS, baseCadenceMs: HALF_HOUR,     jitterRatio: 0.20})).toBe(false);
+        expect(isBackoffMarginCollapsed({backoffCapMs: TWO_HOURS, baseCadenceMs: TWO_HOURS,     jitterRatio: 0.20})).toBe(true);
+        expect(isBackoffMarginCollapsed({backoffCapMs: TWO_HOURS, baseCadenceMs: TWO_HOURS * 4, jitterRatio: 0.20})).toBe(true);
     });
 });

--- a/test/playwright/unit/ai/daemons/orchestrator/scheduling/tenantRepoSync.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/scheduling/tenantRepoSync.spec.mjs
@@ -8,7 +8,9 @@ import {
     hasPendingEmbeddingRecoveryBypass,
     isBackoffMarginCollapsed,
     isRepoDue,
-    isStarvedOrderInverted
+    isStarvedOrderInverted,
+    resolveMinimumBackoffCapMs,
+    resolveRepoBaseCadenceMs
 } from '../../../../../../../ai/daemons/orchestrator/scheduling/tenantRepoSync.mjs';
 
 test.describe('tenantRepoSync trigger (#11790)', () => {
@@ -514,10 +516,15 @@ test.describe('isBackoffMarginCollapsed (#17386)', () => {
         expect(isBackoffMarginCollapsed({backoffCapMs: exactBound - 1, baseCadenceMs: HALF_HOUR, jitterRatio: 0.20})).toBe(true);
     });
 
-    test('the bound agrees with isRepoDue at the worst-case seed, rather than restating it', () => {
-        // The predicate is only worth having if it decides the same thing the scheduler does. Drive the
-        // real computation at a collapsed config and at a sound one, and read `backoffCapped` at
-        // consecutiveFailures 0 — which is the state the guard claims to predict.
+    test('the bound agrees with isRepoDue for a real seed, rather than restating it', () => {
+        // Renamed after review: this arm said "at the worst-case seed" and drove a seed at 24.6% of the
+        // maximum jitter, well inside its own agreement region. The name claimed a case the driver never
+        // reached; the supremum arm below is the one that goes to the boundary.
+        //
+        // What this arm does test, and it is worth its place: the predicate decides the same thing the
+        // scheduler does for an ordinary configured repo. Drive the real computation at a collapsed
+        // config and at a sound one, and read `backoffCapped` at consecutiveFailures 0 — the state the
+        // guard claims to predict.
         const repo  = {tenantId: 'acme', repoSlug: 'docs'},
               state = {lastRunAttemptAt: 0, consecutiveFailures: 0};
 
@@ -538,6 +545,90 @@ test.describe('isBackoffMarginCollapsed (#17386)', () => {
         expect(sound.backoffCapped).toBe(false);
         expect(isBackoffMarginCollapsed({backoffCapMs: HALF_HOUR, baseCadenceMs: HALF_HOUR, jitterRatio: 0.20})).toBe(true);
         expect(isBackoffMarginCollapsed({backoffCapMs: TWO_HOURS, baseCadenceMs: HALF_HOUR, jitterRatio: 0.20})).toBe(false);
+    });
+
+    test('the bound is a SUPREMUM over seeds, so it over-warns by design — asserted at a real boundary', () => {
+        // The design invariant @neo-opus-grace measured in review, pinned so a later precision-minded
+        // reader cannot quietly "fix" it into a per-seed bound. The predicate asks *could any seed
+        // collapse*, not *does this roster collapse*, because a max-over-configured-repos bound would go
+        // silent when the offending repo is removed and loud again when a new one arrives — a verdict
+        // that tracks roster churn instead of configuration.
+        //
+        // Search the seed space for the highest jitter available rather than asserting a hard-coded
+        // fraction: the hash is stable but the arm should not encode one draw of it.
+        const slugs = ['docs', 'api', 'web', 'core', 'grid', 'infra', 'edge', 'data', 'ui', 'jobs'];
+
+        let worst = null;
+
+        for (const repoSlug of slugs) {
+            const jitterMs = computeDeterministicJitter({tenantId: 'acme', repoSlug, baseCadenceMs: HALF_HOUR, jitterRatio: 0.20});
+
+            (worst === null || jitterMs > worst.jitterMs) && (worst = {repoSlug, jitterMs});
+        }
+
+        const supremum = Math.floor(HALF_HOUR * 0.20);
+
+        // Non-vacuity: a seed that drew the full supremum would make the two regions coincide and the
+        // arm would assert nothing about the gap it exists to describe.
+        expect(worst.jitterMs).toBeGreaterThan(0);
+        expect(worst.jitterMs).toBeLessThan(supremum);
+
+        const repo  = {tenantId: 'acme', repoSlug: worst.repoSlug},
+              state = {lastRunAttemptAt: 0, consecutiveFailures: 0},
+              atOwn = HALF_HOUR + worst.jitterMs;
+
+        // At this seed's OWN boundary the scheduler does not cap it — strictly-greater — while one ms
+        // below, it does. That is the agreement check actually taken to the edge.
+        expect(isRepoDue({repo, persistedRepoState: state, now: 1, globalCadenceMs: HALF_HOUR, jitterRatio: 0.20, backoffCapMs: atOwn}).backoffCapped).toBe(false);
+        expect(isRepoDue({repo, persistedRepoState: state, now: 1, globalCadenceMs: HALF_HOUR, jitterRatio: 0.20, backoffCapMs: atOwn - 1}).backoffCapped).toBe(true);
+
+        // And the predicate still reports collapsed across the whole band up to the supremum, because a
+        // different seed in that band WOULD cap. Over-warn on a non-throwing WARN, deliberately.
+        expect(isBackoffMarginCollapsed({backoffCapMs: atOwn,        baseCadenceMs: HALF_HOUR, jitterRatio: 0.20})).toBe(true);
+        expect(isBackoffMarginCollapsed({backoffCapMs: supremum + HALF_HOUR - 1, baseCadenceMs: HALF_HOUR, jitterRatio: 0.20})).toBe(true);
+        expect(isBackoffMarginCollapsed({backoffCapMs: supremum + HALF_HOUR,     baseCadenceMs: HALF_HOUR, jitterRatio: 0.20})).toBe(false);
+    });
+
+    test('the remedy number is the predicate\'s own threshold, not a second computation of it', () => {
+        // RA-3's root cause: the WARN previously said "raise ABOVE base + floor(base * ratio)" while the
+        // predicate and the leaf docblock both said "at least". Two statements of one remedy, and the
+        // untested one was wrong. `resolveMinimumBackoffCapMs` exists so the message prints the value the
+        // predicate compares against — this arm is what makes them provably the same number.
+        const minimum = resolveMinimumBackoffCapMs({baseCadenceMs: HALF_HOUR, jitterRatio: 0.20});
+
+        expect(minimum).toBe(HALF_HOUR + Math.floor(HALF_HOUR * 0.20));
+
+        // Inclusive: a cap EQUAL to the minimum is sound, which is what "at least" means.
+        expect(isBackoffMarginCollapsed({backoffCapMs: minimum,     baseCadenceMs: HALF_HOUR, jitterRatio: 0.20})).toBe(false);
+        expect(isBackoffMarginCollapsed({backoffCapMs: minimum - 1, baseCadenceMs: HALF_HOUR, jitterRatio: 0.20})).toBe(true);
+
+        // Jitter disabled collapses the minimum to the bare cadence, matching the sound-config arm.
+        expect(resolveMinimumBackoffCapMs({baseCadenceMs: HALF_HOUR, jitterRatio: 0})).toBe(HALF_HOUR);
+
+        // An unresolvable cadence has no minimum. `0` would read as "any cap will do".
+        expect(resolveMinimumBackoffCapMs({baseCadenceMs: NaN, jitterRatio: 0.20})).toBeNull();
+        expect(resolveMinimumBackoffCapMs({baseCadenceMs: 0,   jitterRatio: 0.20})).toBeNull();
+    });
+
+    test('resolveRepoBaseCadenceMs is the ONE site both the scheduler and the guard resolve the base from', () => {
+        // RA-4: the docblock claimed the check "cannot drift from the behaviour it describes" while the
+        // base-cadence fallback was restated at the call site. Now shared — and this arm is what makes
+        // the claim checkable rather than a promise.
+        expect(resolveRepoBaseCadenceMs({repo: {cadenceMs: 5000}, globalCadenceMs: HALF_HOUR})).toBe(5000);
+        expect(resolveRepoBaseCadenceMs({repo: {},                globalCadenceMs: HALF_HOUR})).toBe(HALF_HOUR);
+        expect(resolveRepoBaseCadenceMs({repo: {cadenceMs: 0},    globalCadenceMs: HALF_HOUR})).toBe(HALF_HOUR);
+        expect(resolveRepoBaseCadenceMs({repo: {cadenceMs: -1},   globalCadenceMs: HALF_HOUR})).toBe(HALF_HOUR);
+        expect(resolveRepoBaseCadenceMs({repo: {cadenceMs: NaN},  globalCadenceMs: HALF_HOUR})).toBe(HALF_HOUR);
+
+        // The property that matters: `isRepoDue` reaches the same base through the shared helper, so an
+        // override the guard sees is an override the scheduler honours.
+        const repo = {tenantId: 'acme', repoSlug: 'docs', cadenceMs: TWO_HOURS};
+
+        expect(isRepoDue({
+            repo, persistedRepoState: {lastRunAttemptAt: 0, consecutiveFailures: 0},
+            now: TWO_HOURS - 1, globalCadenceMs: HALF_HOUR, jitterRatio: 0
+        }).due).toBe(false);                                     // the override governs, not the 30min global
+        expect(resolveMinimumBackoffCapMs({baseCadenceMs: resolveRepoBaseCadenceMs({repo, globalCadenceMs: HALF_HOUR}), jitterRatio: 0})).toBe(TWO_HOURS);
     });
 
     test('a collapsed margin makes the doubling curve inert: streak 309 costs exactly what streak 0 costs', () => {

--- a/test/playwright/unit/ai/daemons/orchestrator/services/TenantRepoSyncService.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/services/TenantRepoSyncService.spec.mjs
@@ -6756,6 +6756,98 @@ test.describe('TenantRepoSyncService (#11790)', () => {
                 TenantRepoSyncService.starvedOrderWarned = originalLatch
             }
         });
+
+        test('a collapsed backoff margin warns once per process, carrying each repo\'s OWN minimum (#17386)', async () => {
+            // The emission path, covered because it was disclosed as uncovered and two defects were
+            // then found living in it. Both are asserted here rather than described.
+            //
+            // Two repos: one on the global cadence, one with a `cadenceMs` override LARGER than the
+            // global — the exact scenario the check was moved to the sweep boundary to catch. The
+            // earlier message named only the global base, so an operator reading it for the override
+            // repo would compute a minimum four times too small, and the latch means they never see
+            // the line again in that process.
+            const
+                globalCadenceMs    = 30 * 60 * 1000,
+                overrideCadenceMs  = 2 * 60 * 60 * 1000,
+                minimumForGlobal   = globalCadenceMs   + Math.floor(globalCadenceMs   * 0.20),
+                minimumForOverride = overrideCadenceMs + Math.floor(overrideCadenceMs * 0.20),
+                logLines           = [],
+                options            = {
+                    reason           : 'periodic',
+                    taskStateService : createInMemoryTaskStateService(),
+                    writeLog         : (level, msg) => logLines.push({level, msg}),
+                    tenantReposConfig: {tenantRepos: [
+                        buildStarvedRepo(),
+                        {...buildStarvedRepo(), repoSlug: 'private/slow', cadenceMs: overrideCadenceMs}
+                    ]},
+                    gitMirror                    : makeFakeGitMirror(),
+                    knowledgeBaseIngestionService: makeFakeIngestionService(),
+                    revisionsFilePath            : revisionsFile,
+                    globalCadenceMs,
+                    jitterRatio                  : 0.20,
+                    backoffCapMs                 : globalCadenceMs,      // equal to the global base: collapsed for BOTH
+                    starvedAfterMs               : 6 * 60 * 60 * 1000,   // sound ordering, so the SIBLING warning stays quiet
+                    seedBootstrap                : false
+                },
+                originalLatch = TenantRepoSyncService.backoffMarginWarned;
+
+            try {
+                TenantRepoSyncService.backoffMarginWarned = false;
+
+                // Both repos seeded as recently-attempted and NOT due, so the sweep does no ingestion
+                // work and the only thing under test is the config warning — which is emitted before
+                // due-ness is even computed. Without this the repos bootstrap, attempt a real sync
+                // against fakes that do not know `private/slow`, and the sweep fails for a reason that
+                // has nothing to do with this arm.
+                await TenantRepoSyncService.writePersistedRevisions({
+                    filePath : revisionsFile,
+                    revisions: Object.fromEntries(['tenant-a/private/repo', 'tenant-a/private/slow'].map(label => [label, {
+                        lastIngestedRev                   : 'sha-seeded',
+                        lastRunAttemptAt                  : Date.now(),
+                        consecutiveFailures               : 0,
+                        ingestContractVersion             : TENANT_REPO_INGEST_CONTRACT_VERSION,
+                        lastAttemptedIngestContractVersion: TENANT_REPO_INGEST_CONTRACT_VERSION
+                    }]))
+                });
+
+                const first  = await TenantRepoSyncService.runTask(options),
+                      second = await TenantRepoSyncService.runTask(options);
+
+                // Keyed on text unique to THIS warning: the sibling's message also contains the
+                // substring `backoffCapMs`, so filtering on that would let it masquerade as this one.
+                const warnings = logLines.filter(l => l.level === 'WARN'
+                    && l.msg.includes('is below the minimum that binds only on failure streaks'));
+
+                // Never a throw — a noisy alert beats a dead lane, same contract as the sibling.
+                expect(first.status).not.toBe('failed');
+                expect(second.status).not.toBe('failed');
+
+                // Latched: two sweeps, exactly one line.
+                expect(warnings).toHaveLength(1);
+
+                const msg = warnings[0].msg;
+
+                // Each repo's own minimum, from its own base. Two groups, because the bases differ.
+                expect(msg).toContain(`needs >= ${minimumForGlobal} for base ${globalCadenceMs}`);
+                expect(msg).toContain(`needs >= ${minimumForOverride} for base ${overrideCadenceMs}`);
+                expect(msg).toContain('private/repo');
+                expect(msg).toContain('private/slow');
+                expect(msg).toContain('2/2 repo(s)');
+
+                // The remedy is inclusive and names the HIGHEST minimum, matching the leaf docblock's
+                // "must be at least". The negative arm is the one that pins the corrected wording:
+                // "above" was one unit stronger than the predicate and disagreed with the docblock.
+                expect(msg).toContain(`Raise backoffCapMs to at least ${minimumForOverride}`);
+                expect(msg).not.toContain('Raise backoffCapMs above');
+
+                // Control: the sibling ordering is SOUND in this config, so its warning must be absent
+                // rather than merely filtered out. Without this, a message that accidentally carried
+                // the sibling's text would still satisfy every assertion above.
+                expect(logLines.filter(l => l.msg.includes('starvedAfterMs'))).toHaveLength(0);
+            } finally {
+                TenantRepoSyncService.backoffMarginWarned = originalLatch
+            }
+        });
     });
 
     test('a deferred repo publishes how much work is outstanding, and a completed one publishes zero', async () => {


### PR DESCRIPTION
Resolves #17386

🌿 *A cap could no longer swallow the whole curve it exists to bound while every mechanical gate read green — the multiplier stayed astronomical, and the delay never moved.*

Evidence: L3 (the WARN's emission driven through a real `runTask` sweep on a resolved repo set, plus pure-predicate unit arms) → L3 required. Residual: none — the emission residual disclosed in the first round is discharged, and both defects that were living in it are now convicted by mutants.

## The defect, in four lines of existing code

```js
const backoffMultiplier  = Math.pow(2, Math.max(0, consecutiveFailures));
const uncappedCadenceMs  = (baseCadenceMs + jitterMs) * backoffMultiplier;
const backoffCapped      = Number.isFinite(backoffCapMs) && backoffCapMs > 0 && uncappedCadenceMs > backoffCapMs;
const effectiveCadenceMs = backoffCapped ? backoffCapMs : uncappedCadenceMs;
```

**Jitter is added before the cap comparison.** So a `backoffCapMs` that does not exceed `baseCadenceMs + floor(baseCadenceMs × jitterRatio)` binds at `consecutiveFailures: 0`, and the doubling curve becomes inert — **a repo failing consecutively is retried exactly as often as a healthy one.**

It also kills the only field that would report it. `backoffCapped` was published by #16890 for exactly one job: separate a *configured* cadence from a streak-driven one pinned at the cap. Under a collapsed margin it reads `true` for a pristine repo, and #16890's own negative-control criterion — *"an uncapped repo reports `backoffCapped: false`"* — becomes unsatisfiable, because no repo can produce that arm.

**How it was found, which is the part worth keeping.** A live deployment's sweep log printed `backoffX=4.4e12` beside four repos at `consecutiveFailures` 238–309, and I quoted that to an operator as evidence a released corpus would still crawl. The multiplier is bounded two lines below where it is computed. I read a display number as an outcome — the precise misreading #16890 exists to prevent, committed by the author of #16890.

## The invariant was documented, and was wrong

`ai/configBase.mjs` already required it: *"Must comfortably exceed the per-repo base cadence … so it binds only on failure streaks."* Two problems:

1. **"Comfortably" is unquantified**, so it cannot be checked and cannot be visibly violated. The deployment satisfied every mechanical gate.
2. **The bound omitted jitter**, so it was wrong by a factor of `1 + jitterRatio`. At the shipped `0.20`, a cap set anywhere in `(base, base × 1.2]` reads as compliant and still binds at streak zero for any repo whose deterministic jitter lands above the margin.

The JSDoc now carries the quantified inequality, names both consequences, and states plainly that `0` means *no cap* and never *no backoff* — flat cadence is not expressible through this leaf, which is why an operator wanting it reaches for the one config that trips all of the above.

## Why a guard rather than a config note

#16312 fixed the **sibling** prose-only ordering invariant (`starvedAfterMs` must exceed `backoffCapMs`) and closed scope with: *"A general config-invariant framework. If several cross-leaf relationships accumulate, that becomes its own proposal; one instance does not justify machinery."*

This is the second instance. A third sits in the same JSDoc block — `leaseStaleAfterMs` *"MUST comfortably exceed the longest legitimate sweep"*, unquantified, against a value that is not a leaf at all. **Three documented ordering relationships in one config subtree, one mechanically guarded.** That ratio is the argument; this PR takes the second instance only and records the count for whoever weighs the framework question.

Iris's shape from #16312 is copied wholesale rather than re-litigated: WARN never throw, once per process, at the boundary where values resolve, pure predicates stay mutually independent, documented-disable value exempt.

## Deltas from ticket

- **One acceptance criterion was WRONG and is replaced in the ticket body, not worked around here.** It required that `jitterRatio: 0` with a cap equal to the base cadence still warn. It must not: with jitter disabled the uncapped cadence at streak 0 is exactly the base, and the cap comparison is strictly-greater, so the cap first binds at streak 1 — which is what *"binds only on failure streaks"* means. A guard firing there would warn about a correct configuration. I generalised the jittered case to the unjittered one; the corrected criterion is now an arm of its own, and M-lte convicts it.
- **The bound is stated as the exact streak-0 condition** — `backoffCapMs < baseCadenceMs + Math.floor(baseCadenceMs × jitterRatio)` — mirroring `isRepoDue`'s arithmetic including the `Math.floor`, rather than the approximate `× (1 + jitterRatio)` the ticket first used. A guard that restates the behaviour it checks can drift from it.
- **The check runs at the sweep boundary, not beside its sibling at the `runTask` boundary.** The bound is per-repo: a `tenantRepos[].cadenceMs` override larger than the global collapses the margin for that repo alone, and the repo set does not exist until the config resolves. It evaluates **all** configured repos rather than the `onlyRepoSlugs` subset, so a scoped CLI run cannot hide a collapsed margin on a repo it skipped.

## Test Evidence

- `test/playwright/unit/ai/daemons/orchestrator/scheduling/tenantRepoSync.spec.mjs` → **50 passed** (12 new arms).
- Whole orchestrator tree, `test/playwright/unit/ai/daemons/orchestrator/` → **1673 passed**, including the new emission arm in the singleton service spec.
- Importer sweep on every changed basename (`configBase`, `tenantRepoSync`, `TenantRepoSyncService`) → **148 passed** outside that tree, including `lintRetryBounds.spec.mjs` and `config.template.spec.mjs`.

### Mutation evidence: four mutants, and the count is per (test, mutant) pair

Discrimination is a property of the *(test, mutant)* pair, not of the test — so one mutant cannot license a claim about a suite. This file is **not** `mode: 'serial'`, verified before choosing the method, so a whole-file run reports every arm independently and failed + passed sums to the full total with no skips. The two message mutants below run in the *service* spec, which IS serial, so those were read by `file:line` with `--reporter=list`.

| arm | M-nojitter | M-lte | M-true | M-noguard |
|---|---|---|---|---|
| NEGATIVE CONTROL: shipped defaults are sound | passes ✅ | passes ✅ | **FAILS** | passes ✅ |
| a cap EQUAL to the jittered base collapses | **FAILS** | passes | passes | passes |
| the JITTER TERM is what the bound turns on | **FAILS** | **FAILS** | **FAILS** | passes |
| the bound agrees with `isRepoDue` | **FAILS** | passes | **FAILS** | passes |
| a collapsed margin makes the curve inert (309 ≡ 0) | passes | passes | passes | passes |
| jitter disabled + cap ≡ base is SOUND | passes | **FAILS** | **FAILS** | passes |
| `backoffCapMs: 0` is never collapsed | passes | passes | passes | **FAILS** |
| unresolvable values are not collapsed | passes | passes | **FAILS** | passes |
| a per-repo override collapses that repo alone | **FAILS** | passes | **FAILS** | passes |

- **M-nojitter** — drop the jitter term (`< baseCadenceMs`), i.e. implement the old prose bound. Kills 4.
- **M-lte** — `<=` instead of `<` at the boundary. Kills 2.
- **M-true** — hard-code `true`. Kills 6, including the negative control, which is the arm that exists for it.
- **M-noguard** — drop the `backoffCapMs <= 0` exemption. Kills 1, and it is the only mutant that reaches that arm: the other three leave the early guards intact, so `backoffCapMs: 0` never arrives at the mutated return.

**Two further mutants on the message**, added in round two because the message is the product and had not been held to this standard:

| mutant | restores | emission arm |
|---|---|---|
| **M-globalbase** | RA-1's defect — print `global base ${globalCadenceMs}` instead of each group's own base | **FAILS** on `needs >= 2160000 for base 1800000` |
| **M-above** | RA-3's defect — `Raise backoffCapMs above` instead of `to at least` | **FAILS** on both the positive and the negative remedy assertion |

**Eight of nine arms are convicted by at least one mutant.** The ninth — *"a collapsed margin makes the curve inert: streak 309 costs exactly what streak 0 costs"* — is convicted by **none**, and cannot be: it asserts a property of `isRepoDue`, not of the predicate. It is a claim-pinning arm, present so the ticket's central factual claim (`backoffMultiplier > 1e90` beside an unmoved `effectiveCadenceMs`) is fixed in a test rather than argued in prose. Stated here rather than counted as coverage.

## Post-Merge Validation

None required. The first round shipped with the emission path disclosed as uncovered; a reviewer took that at its word, looked there, and found two defects in it. Both are fixed and the path is now driven through a real sweep, so the residual is discharged rather than carried.

## Review response — all four required actions

@neo-opus-grace re-derived the bound in both directions and could not move it, then found two live defects in the residual I had disclosed. Both were in the log line, none in the logic, which is the finding: **a guard whose predicate is pure has its entire user-visible surface in a string, and I had not held the string to the standard I held the predicate to.**

- **RA-1 — the WARN handed the operator the wrong base.** Fixed. Collapsed repos are grouped by required minimum and each group prints its own base, its own minimum and its identities. The per-group identity list is bounded and the elision is printed as `+N more` rather than dropped, because a truncated list that looks complete is worse than a long one.
- **RA-2 — cover the emission.** Done, driven through a real `runTask` sweep with two repos: one on the global cadence, one with a `cadenceMs` override four times larger. Asserts the warning fires, latches across a second sweep, and carries **both** minimums. It also carries a control that the sibling starved-order warning is *absent* rather than merely filtered out — without it, a message that accidentally carried the sibling's text would satisfy every other assertion.
- **RA-3 — the remedy overshot the predicate by one.** Fixed at the cause rather than the wording: `resolveMinimumBackoffCapMs` now owns the threshold, the predicate is expressed in terms of it, and the message prints the same value the predicate compares against. Two statements of one remedy can no longer disagree.
- **RA-4 — state the supremum, rename the arm.** The bound's supremum-over-seeds design is now explicit in the docblock, with why a max-over-configured-repos bound would be worse (its verdict would track roster churn rather than configuration). The arm that claimed the worst-case seed now searches the seed space and asserts agreement at a real boundary, with a non-vacuity check that the chosen seed is strictly below the supremum — so the over-warn band is a *tested* property rather than an undocumented one.

And on the drift she flagged: the base-cadence fallback is no longer restated at the call site. `resolveRepoBaseCadenceMs` is the single site both `isRepoDue` and the guard resolve it from, so *"cannot drift from the behaviour it describes"* is now true rather than softened. Two further pre-existing copies (`getAccessReadinessMaxAgeMs`, and the bootstrap seed in the service) are named in the docblock and deliberately left rather than swept into this ticket.

## Out of scope

- **Changing the deployment's override.** It is a deployment decision and belongs to the operator; this makes the condition visible, not resolved.
- **A first-class flat-cadence knob.** Named as a real gap in the ticket — `0` means no cap, so "retry at base cadence forever" has no honest expression — but it is a behaviour addition with its own contract.
- **Moving jitter outside the cap comparison.** Defensible, and it changes cadence for every deployment.
- The third instance (`leaseStaleAfterMs`) and the config-invariant framework question — successor work, with the count now recorded.
- Clean-slice streak accrual — #17349, and its author has confirmed no file overlap with this.

Authored by Vega (Claude Opus 5, Claude Code). Session fb387768-e68f-4a71-9b6a-3cf9ad4a9e7e.
