### PR TITLE
fix(ai): five config-only consumers stop reaching the Brain barrel (#17390)

### DIFF
--- a/ai/daemons/kb-alerting/KbAlertingService.mjs
+++ b/ai/daemons/kb-alerting/KbAlertingService.mjs
@@ -3,7 +3,7 @@
 // canonical Orchestrator class+wrapper pattern. `Neo.setupClass(KbAlertingService)`
 // at file bottom uses `globalThis.Neo`, populated by the entry-point bootstrap chain.
 import Base                           from '../../../src/core/Base.mjs';
-import {Memory_Config as aiConfig}    from '../../services.mjs';
+import aiConfig                       from '../../mcp/server/memory-core/config.mjs';
 import KBRecorderService              from '../../services/knowledge-base/KBRecorderService.mjs';
 import MailboxService                 from '../../services/memory-core/MailboxService.mjs';
 import RequestContextService          from '../../mcp/server/shared/services/RequestContextService.mjs';

--- a/ai/daemons/kb-gc/KbGarbageCollectionService.mjs
+++ b/ai/daemons/kb-gc/KbGarbageCollectionService.mjs
@@ -2,11 +2,11 @@
 // InstanceManager) lives in `ai/daemons/kb-gc/daemon.mjs`, following the canonical
 // Orchestrator class+wrapper pattern. `Neo.setupClass(KbGarbageCollectionService)`
 // at file bottom uses `globalThis.Neo`, populated by the entry-point bootstrap chain.
-import Base                        from '../../../src/core/Base.mjs';
-import {Memory_Config as aiConfig} from '../../services.mjs';
-import ChromaManager               from '../../services/knowledge-base/ChromaManager.mjs';
-import KBRecorderService           from '../../services/knowledge-base/KBRecorderService.mjs';
-import logger                      from '../../mcp/server/knowledge-base/logger.mjs';
+import Base              from '../../../src/core/Base.mjs';
+import aiConfig          from '../../mcp/server/memory-core/config.mjs';
+import ChromaManager     from '../../services/knowledge-base/ChromaManager.mjs';
+import KBRecorderService from '../../services/knowledge-base/KBRecorderService.mjs';
+import logger            from '../../mcp/server/knowledge-base/logger.mjs';
 import {
     formatGcDetail,
     selectExpiredChunks
@@ -167,11 +167,11 @@ class KbGarbageCollectionService extends Base {
      */
     async pulse() {
         try {
-            const kbConfig    = this.getKbConfig(),
-                  retention   = kbConfig.gcRetention,
-                  autoDelete  = kbConfig.gcAutoDelete === true,
-                  defragGate  = Number.isFinite(kbConfig.gcDefragThreshold) ? kbConfig.gcDefragThreshold : 0,
-                  tenants     = await this.fetchTenants();
+            const kbConfig   = this.getKbConfig(),
+                  retention  = kbConfig.gcRetention,
+                  autoDelete = kbConfig.gcAutoDelete === true,
+                  defragGate = Number.isFinite(kbConfig.gcDefragThreshold) ? kbConfig.gcDefragThreshold : 0,
+                  tenants    = await this.fetchTenants();
 
             if (tenants.length === 0) {
                 return // no tenants have ingestion telemetry yet → nothing to collect
@@ -325,7 +325,7 @@ class KbGarbageCollectionService extends Base {
      * @protected
      */
     async fetchTenantRows(collection, tenantId) {
-        const rows = [];
+        const rows   = [];
         let   offset = 0,
               batch;
 

--- a/ai/daemons/kb-reconciliation/KbReconciliationService.mjs
+++ b/ai/daemons/kb-reconciliation/KbReconciliationService.mjs
@@ -2,12 +2,12 @@
 // InstanceManager) lives in `ai/daemons/kb-reconciliation/daemon.mjs`, following the
 // canonical Orchestrator class+wrapper pattern. `Neo.setupClass(KbReconciliationService)`
 // at file bottom uses `globalThis.Neo`, populated by the entry-point bootstrap chain.
-import Base                          from '../../../src/core/Base.mjs';
-import {Memory_Config as aiConfig}   from '../../services.mjs';
-import ChromaManager                 from '../../services/knowledge-base/ChromaManager.mjs';
-import KBRecorderService             from '../../services/knowledge-base/KBRecorderService.mjs';
-import IngestionService              from '../../services/knowledge-base/IngestionService.mjs';
-import logger                        from '../../mcp/server/knowledge-base/logger.mjs';
+import Base              from '../../../src/core/Base.mjs';
+import aiConfig          from '../../mcp/server/memory-core/config.mjs';
+import ChromaManager     from '../../services/knowledge-base/ChromaManager.mjs';
+import KBRecorderService from '../../services/knowledge-base/KBRecorderService.mjs';
+import IngestionService  from '../../services/knowledge-base/IngestionService.mjs';
+import logger            from '../../mcp/server/knowledge-base/logger.mjs';
 import {
     diffTenantChunks,
     diffTenantManifest,
@@ -349,7 +349,7 @@ class KbReconciliationService extends Base {
      * @protected
      */
     async fetchTenantRows(collection, tenantId) {
-        const rows = [];
+        const rows   = [];
         let   offset = 0,
               batch;
 

--- a/ai/services/graph/TopologyInferenceEngine.mjs
+++ b/ai/services/graph/TopologyInferenceEngine.mjs
@@ -1,10 +1,10 @@
-import fs                            from 'fs';
-import path                          from 'path';
-import { Memory_Config as AiConfig } from '../../services.mjs';
-import {writeFileAtomic}             from '../shared/atomicFileWrite.mjs';
-import Base                          from '../../../src/core/Base.mjs';
-import Json                          from '../../../src/util/Json.mjs';
-import logger                        from '../../mcp/server/memory-core/logger.mjs';
+import fs                from 'fs';
+import path              from 'path';
+import AiConfig          from '../../mcp/server/memory-core/config.mjs';
+import {writeFileAtomic} from '../shared/atomicFileWrite.mjs';
+import Base              from '../../../src/core/Base.mjs';
+import Json              from '../../../src/util/Json.mjs';
+import logger            from '../../mcp/server/memory-core/logger.mjs';
 import {
     bytesToTokens,
     emitConsumerFriction,

--- a/ai/services/graph/activePrCycleSection.mjs
+++ b/ai/services/graph/activePrCycleSection.mjs
@@ -1,5 +1,5 @@
-import {Memory_Config as aiConfig} from '../../services.mjs';
-import {hasCrossFamilyReview}      from './agentFamilyResolution.mjs';
+import aiConfig               from '../../mcp/server/memory-core/config.mjs';
+import {hasCrossFamilyReview} from './agentFamilyResolution.mjs';
 
 /**
  * @module ai/services/graph/activePrCycleSection


### PR DESCRIPTION
Resolves #17390

Part of #17383.

Five modules imported `Memory_Config` — a config object — from `ai/services.mjs`, and paid a **graph database open** for it. Each now imports the same module directly. Three of the five no longer open the database; two are improved but still reach it by another path, and this PR says which.

Evidence: L3 (runtime probe with a before/after control on the exact import each file performs) → L3 required. Residual: none — the two unclosed files are stated as unclosed, not deferred.

## Why the diff is larger than five lines

Each swap replaces a long specifier (`{Memory_Config as aiConfig}`, `{ Memory_Config as AiConfig }`) with a short one (`aiConfig`, `AiConfig`), and Neo aligns an import block to its **longest** member — so shortening the longest identifier legitimately re-flows the block left. That is `check-block-alignment.mjs --fix`'s output, not hand-formatting: 10 lines in `KbGarbageCollectionService`, 6 each in `KbReconciliationService` and `TopologyInferenceEngine`, 1 in `activePrCycleSection`.

I first hand-aligned my own line up to the existing column to keep a one-line diff per file, which looked tidier and was wrong — the checker then reported the *untouched* neighbours as misaligned, because the block's expected column had moved. The tool is the authority here; a smaller diff that fights it is not the better diff.

## Why this is idiom rather than invention

`ai/services.mjs:64` is literally `import Memory_Config from './mcp/server/memory-core/config.mjs'`, and sibling non-entrypoint services already import that module directly — `MemoryCoreRecorderService:5`, `SourceRegistryService:5`, `SummaryService:1`. The config binding is unchanged. Only the reach shrinks.

Checked against **ADR-0019 §critical_gates #10** before touching anything: C1 is zero-tolerance on `AiConfig` imports in non-entrypoints, so a naive "swap the import" could have traded barrel reach for a C1 violation across five files. It does not — importing `config.mjs` is the sanctioned form these siblings already use, and the ADR's own V-B-A correction names `TaskDefinitions.mjs` as the single genuine C1 site.

## Measured, with a control

A `load` hook injects a log at `me.db = new Database(...)` in `ai/graph/storage/SQLite.mjs`, so this observes the **open itself** rather than inferring from the import graph. The probe imports `src/Neo.mjs` + `src/core/_export.mjs` first — without that bootstrap these modules die as `ReferenceError: Neo is not defined` from `src/core/Compare.mjs`, which is #17369's lesson biting the instrument.

| module | control (`origin/dev`) | this branch |
|---|---|---|
| `KbGarbageCollectionService` | opens DB | **clean** |
| `activePrCycleSection` | opens DB | **clean** |
| `TopologyInferenceEngine` | opens DB | **clean** |
| `KbAlertingService` | opens DB | still opens — via `MailboxService` |
| `KbReconciliationService` | opens DB | still opens — path not isolated |

**The two unclosed files are the honest part.** `MailboxService` opens the graph itself, so `KbAlertingService` keeps a path this change does not touch; `KbReconciliationService`'s remaining path is not yet identified (`KBRecorderService`, `RequestContextService` and `normalizeAgentIdentityNodeId` all probe clean, so it is none of those). Their edits stand on their own merits — a config leaf should not arrive through the Brain barrel whether or not another path also exists — and I would rather ship two correct-but-insufficient changes named as such than quietly claim five closures.

An earlier run of this measurement reported `KbAlertingService` as never opening the DB at all. That was a **false zero from a crashed probe** — it was dying on the missing `Neo` bootstrap before reaching anything. Recorded because the corrected instrument is what produced the table above.

## Deltas from ticket

#17383's body proposed two shapes, and this is neither. Lazy acquisition in `GraphService` was killed empirically rather than argued: deferring it makes `WakeSubscriptionService.init:212` throw `GraphService unavailable: graph database is not mounted` — a hard failure, so 16 services would need explicit sequencing first. Containment-only was rejected earlier as leaving the defect true. The tractable third path is per-importer triage, and this is its first slice.

Triage state for the remaining work, so the next slice does not re-derive it: **49 non-spec importers of the cloud barrel; 35 genuinely use graph/KB/ingestion symbols; 14 do not.** Of those 14, five were config-only (this PR). The rest pull real services (`Memory_SessionService`, `KB_QueryService`, `AppWorker_BridgeService`) and need per-service reach checks; `ai/agent/Loop.mjs` does `import * as SDK` so its use cannot be read from the import at all.

Closes **#17390**, the leaf for this slice. **#17383 stays open** — it is the eager open in `GraphService.initAsync` itself, and removing consumers from the path does not change what the path does.

## Test Evidence

- `npm run test-unit` scoped to the touched daemons (`kb-gc`, `kb-alerting`, `kb-reconciliation`): **60 passed**.
- `hostBarrelRuntimeReach.spec.mjs` — the guard arm added in #17384: **6 passed**, so the fixture-side property is untouched.
- Runtime probe with control: the table above.

Per directly touched surface — `KbGarbageCollectionService` / `KbReconciliationService` / `KbAlertingService`: covered by their own specs (60 above). `activePrCycleSection` / `TopologyInferenceEngine`: `None found` — no dedicated spec exists for either; the import change is behaviour-preserving and the runtime probe is the evidence.

## Post-Merge Validation

None owed. Behaviour-preserving import changes, verified in-process.

Authored by Ada (Claude Opus 5, Claude Code). Session 4979b8c3-8aed-4a62-814a-7d8135423b61.
