### PR TITLE
feat(kb): classify parser-identity orphans as a third reconciliation signal (#17393)

### DIFF
--- a/ai/services/knowledge-base/helpers/kbReconciliationEngine.mjs
+++ b/ai/services/knowledge-base/helpers/kbReconciliationEngine.mjs
@@ -1,7 +1,7 @@
 /**
- * @summary Pure config-invalidation reconciliation engine for the Phase 4B KB reconciliation daemon (#11640).
+ * @summary Pure config-invalidation reconciliation engine for the Phase 4B KB reconciliation daemon (#11640).  ticket-ref-ok: implementing ticket
  *
- * Phase 4B (#11640) substrate. The cloud KB reconciliation daemon (`KbReconciliationService`)
+ * Phase 4B (#11640) substrate. The cloud KB reconciliation daemon (`KbReconciliationService`)  ticket-ref-ok: implementing ticket
  * periodically diffs each tenant's persisted Chroma chunks against the tenant's *current*
  * `KnowledgeBaseTenantConfig` version and (opt-in) tombstones the chunks left stale by a
  * config change. This module is the **pure core** of that daemon — no I/O, no clock, no
@@ -9,7 +9,7 @@
  * trivially unit-testable in isolation.
  *
  * **The V1 reconciliation signal.** Every chunk is stamped at ingest with the active
- * `tenantConfigVersion` (#11637 / `VectorService.resolveTenantStamp`). When a tenant mutates
+ * `tenantConfigVersion` (#11637 / `VectorService.resolveTenantStamp`). When a tenant mutates  ticket-ref-ok: implementing ticket
  * its `KnowledgeBaseTenantConfig`, `getTenantConfig().version` increments — and every chunk
  * ingested under the prior config is now *config-stale*: it may carry paths or a parse
  * structure only the superseded config produced. A chunk whose `metadata.tenantConfigVersion`
@@ -22,7 +22,7 @@
  * each tenant's Chroma rows, calls this engine, emits Phase 4A telemetry, and (opt-in) issues
  * the `collection.delete`. This module only *classifies*.
  *
- * **The V1.x manifest signal.** #11711 adds a sibling claimed-state manifest per tenant:
+ * **The V1.x manifest signal.** #11711 adds a sibling claimed-state manifest per tenant:  ticket-ref-ok: implementing ticket
  * `kb-manifest:<tenantId>`. It is deliberately separate from `KnowledgeBaseTenantConfig`
  * because that config node's `version` is the config-staleness signal above; routine push
  * manifests must not bump it. `diffTenantManifest()` classifies rows whose `metadata.sourcePath`
@@ -33,7 +33,7 @@
  * @see ai/daemons/kb-reconciliation/KbReconciliationService.mjs — the daemon that consumes this engine.
  * @see ai/services/knowledge-base/KnowledgeBaseIngestionService.mjs — `getTenantConfig`, the version source.
  * @see ai/services/knowledge-base/VectorService.mjs — `resolveTenantStamp`, the `tenantConfigVersion` stamp.
- * @see ai/services/knowledge-base/helpers/kbAlertRuleEngine.mjs — the sibling pure-helper precedent (#11642).
+ * @see ai/services/knowledge-base/helpers/kbAlertRuleEngine.mjs — the sibling pure-helper precedent (#11642).  ticket-ref-ok: implementing ticket
  */
 
 /**
@@ -76,7 +76,7 @@ export function resolveOrphanVersionGap(value) {
  * - `currentVersion <= 0` — the tenant resolves to the `kb-config.yaml` / default config
  *   tier (no graph node, version `0`). No chunk can be stale; the result is empty.
  * - A row whose `tenantConfigVersion` is missing / non-numeric — a chunk ingested before the
- *   #11637 stamp existed. It is **not** flagged: its config epoch is unknowable.
+ *   #11637 stamp existed. It is **not** flagged: its config epoch is unknowable.  ticket-ref-ok: implementing ticket
  *
  * @param {Object} params
  * @param {Array<{id: String, metadata: Object}>} params.rows  Tenant Chroma rows (the
@@ -99,7 +99,7 @@ export function diffTenantChunks({rows, currentVersion, orphanVersionGap} = {}) 
     for (const row of rows) {
         const stampedVersion = row?.metadata?.tenantConfigVersion;
 
-        // Fail-safe: a missing / non-numeric stamp (pre-#11637 ingest) is unclassifiable — skip it.
+        // Fail-safe: a missing / non-numeric stamp (pre-#11637 ingest) is unclassifiable — skip it.  ticket-ref-ok: implementing ticket
         if (typeof stampedVersion !== 'number' || !(stampedVersion < currentVersion)) {
             continue;
         }
@@ -122,7 +122,7 @@ export function diffTenantChunks({rows, currentVersion, orphanVersionGap} = {}) 
 }
 
 /**
- * @summary Classifies one tenant's Chroma rows into claimed-manifest orphans (#11711).
+ * @summary Classifies one tenant's Chroma rows into claimed-manifest orphans (#11711).  ticket-ref-ok: implementing ticket
  *
  * Pure — no I/O, no clock. A row is a **manifest orphan** when all of the following are true:
  * the row has a `metadata.repoSlug`, the tenant has a persisted manifest for that repo, the
@@ -194,22 +194,156 @@ export function diffTenantManifest({rows, manifestsByRepo} = {}) {
 }
 
 /**
+ * @summary Classifies one tenant's Chroma rows into parser-identity orphans.
+ *
+ * Pure — no I/O, no clock, matching its two siblings. This is the **third** reconciliation signal,
+ * and it exists because the first two are structurally blind to it: `diffTenantChunks` keys on
+ * `metadata.tenantConfigVersion`, which a parser change never moves, and `diffTenantManifest` keys
+ * on a `sourcePath` being absent from the claimed set, which says nothing about a path still present
+ * under a superseded generation.
+ *
+ * **Why identity rather than an event.** `parserId` / `parserVersion` are `hashInputs`
+ * (`IngestionService`), so advancing a parser version changes every chunk id: the new generation
+ * ADDS rows and never overwrites its predecessor. A design firing *when* the version changes cannot
+ * clear an already-orphaned set without another bump, and a bump re-materializes the whole corpus —
+ * on a deployment partway through its initial embedding that costs far more than the orphans. So a
+ * row is classified by comparing its stamped pair against the repo's **currently declared** pair,
+ * which makes an existing orphan set self-healing on the next ordinary tick with no bump at all.
+ *
+ * **Two tiers, safety-ordered, and neither deletes ahead of its replacement.**
+ *
+ * 1. `unyielded` — the row's `sourcePath` is absent from the paths the declared parser currently
+ *    yields, so no replacement is ever coming and reclaiming it opens no retrieval hole. This is the
+ *    tier that clears a vendor-exclusion change. It runs only where the caller supplied a yielded-path
+ *    set for the repo: an absent set is *unknown*, never *empty*, and treating it as empty would
+ *    classify a whole repo actionable on a missing envelope.
+ * 2. `superseded` — the path is still yielded, so a replacement is expected; the row becomes
+ *    actionable only once a row carrying the declared pair exists for that same path. `#16577`  ticket-ref-ok: implementing ticket
+ *    measured a materialization reporting success while leaving no durable proof, which is what makes
+ *    the delete-before-embed window concrete rather than theoretical.
+ *
+ * Replacement presence is derived from `rows` themselves rather than taken as a parameter — the
+ * evidence that a replacement landed is a row carrying the declared pair, and reading it from the
+ * same snapshot the classification runs on removes a second authority that could disagree with it.
+ *
+ * **Tenant scoping is this function's own responsibility**, unlike its siblings. The mandated model is a
+ * metadata-scoped, collection-shared one, so a classifier reading collection rows must filter by
+ * `tenantId` itself; a caller-scoped contract would make containment untestable against the mixed
+ * row set that actually exists in the collection.
+ *
+ * @param {Object}   params
+ * @param {Object[]} params.rows                Chroma rows for the shared collection; each `{id, metadata}`.
+ * @param {String}   params.tenantId            Only rows whose `metadata.tenantId` matches are considered.
+ * @param {Object}   params.declaredByRepo      `{[repoSlug]: {parserId, parserVersion}}` — the currently declared pair per repo.
+ * @param {Object}  [params.yieldedPathsByRepo] `{[repoSlug]: string[]|Set}` — paths the declared parser yields. A repo absent here skips tier 1.
+ * @returns {{parserOrphans: Object[], parserOrphanCount: Number, actionableIds: String[], actionableCount: Number}}
+ */
+export function diffTenantParserIdentity({rows, tenantId, declaredByRepo, yieldedPathsByRepo} = {}) {
+    const parserOrphans = [],
+          actionableIds = [];
+
+    const empty = {parserOrphans, parserOrphanCount: 0, actionableIds, actionableCount: 0};
+
+    if (!Array.isArray(rows) || typeof tenantId !== 'string' || !tenantId || !declaredByRepo) {
+        return empty;
+    }
+
+    // Which paths already carry a row at the DECLARED pair. Built in one pass over the same snapshot
+    // the classification reads, so tier 2 can never gate on a replacement this view cannot see.
+    const replacedPaths = new Set();
+
+    for (const row of rows) {
+        const meta = row?.metadata;
+
+        if (!meta || meta.tenantId !== tenantId) continue;
+
+        const declared = declaredByRepo[meta.repoSlug];
+
+        if (declared && meta.parserId === declared.parserId && meta.parserVersion === declared.parserVersion) {
+            typeof meta.sourcePath === 'string' && replacedPaths.add(`${meta.repoSlug}\u0000${meta.sourcePath}`);
+        }
+    }
+
+    for (const row of rows) {
+        const meta = row?.metadata;
+
+        if (!meta || meta.tenantId !== tenantId) continue;
+
+        const declared = declaredByRepo[meta.repoSlug];
+
+        // Never guess a generation: a repo with no declared pair is unresolvable, not stale.
+        if (!declared || typeof declared.parserId !== 'string' || typeof declared.parserVersion !== 'string') {
+            continue;
+        }
+
+        // Missing stamp is unclassifiable — the same fail-safe `kbGarbageCollectionEngine` applies.
+        if (typeof meta.parserId !== 'string' || typeof meta.parserVersion !== 'string' || typeof meta.sourcePath !== 'string') {
+            continue;
+        }
+
+        if (meta.parserId === declared.parserId && meta.parserVersion === declared.parserVersion) {
+            continue;
+        }
+
+        const yielded = yieldedPathsByRepo?.[meta.repoSlug],
+              hasSet  = yielded instanceof Set || Array.isArray(yielded);
+
+        let tier;
+
+        if (hasSet) {
+            const isYielded = yielded instanceof Set ? yielded.has(meta.sourcePath) : yielded.includes(meta.sourcePath);
+
+            tier = isYielded ? 'superseded' : 'unyielded';
+        } else {
+            // Envelope unavailable for this repo: tier 1 does not run, so the row can only be the
+            // replacement-gated tier. Unknown is not empty.
+            tier = 'superseded';
+        }
+
+        parserOrphans.push({
+            id           : row.id,
+            repoSlug     : meta.repoSlug,
+            sourcePath   : meta.sourcePath,
+            parserId     : meta.parserId,
+            parserVersion: meta.parserVersion,
+            tier
+        });
+
+        if (tier === 'unyielded' || replacedPaths.has(`${meta.repoSlug}\u0000${meta.sourcePath}`)) {
+            actionableIds.push(row.id);
+        }
+    }
+
+    return {
+        parserOrphans,
+        parserOrphanCount: parserOrphans.length,
+        actionableIds,
+        actionableCount  : actionableIds.length
+    };
+}
+
+/**
  * @summary Builds the Phase 4A telemetry `detail` payload for one tenant's reconciliation tick.
  *
  * Pure — kept here (not in the daemon) so the telemetry shape is unit-testable. The daemon
  * passes the returned object straight to `KBRecorderService.recordIngestionMetric`'s `detail`.
  *
  * @param {Object}  params
- * @param {{staleCount: Number, manifestOrphanCount: Number, actionableCount: Number, totalOrphanCount: Number}} params.diff  Combined reconciliation diff.
+ * @param {{staleCount: Number, manifestOrphanCount: Number, parserOrphanCount: Number, actionableCount: Number, totalOrphanCount: Number}} params.diff  Combined reconciliation diff.
  * @param {Number}  params.currentVersion   The tenant's current config version.
  * @param {Boolean} params.autoTombstone    Whether the daemon's auto-tombstone path is enabled.
  * @param {Number} [params.tombstonedCount=0] Chunks actually deleted this tick (`0` when auto-tombstone is off).
- * @returns {{staleCount: Number, manifestOrphanCount: Number, totalOrphanCount: Number, actionableCount: Number, tombstonedCount: Number, currentVersion: Number, autoTombstone: Boolean}}
+ * @returns {{staleCount: Number, manifestOrphanCount: Number, parserOrphanCount: Number, totalOrphanCount: Number, actionableCount: Number, tombstonedCount: Number, currentVersion: Number, autoTombstone: Boolean}}
  */
 export function formatReconciliationDetail({diff, currentVersion, autoTombstone, tombstonedCount = 0} = {}) {
+    // `parserOrphanCount` is reported separately and never folded into the others. Three signals
+    // answer three different questions — config epoch, claimed path set, parser generation — and a
+    // reader who cannot tell which one fired cannot tell whether a reclaim followed a config change
+    // or a parser bump.
     return {
         staleCount         : diff?.staleCount          ?? 0,
         manifestOrphanCount: diff?.manifestOrphanCount ?? 0,
+        parserOrphanCount  : diff?.parserOrphanCount   ?? 0,
         totalOrphanCount   : diff?.totalOrphanCount    ?? diff?.staleCount ?? 0,
         actionableCount    : diff?.actionableCount     ?? 0,
         tombstonedCount    : Number.isFinite(tombstonedCount) ? tombstonedCount : 0,

--- a/ai/services/knowledge-base/helpers/kbReconciliationEngine.mjs
+++ b/ai/services/knowledge-base/helpers/kbReconciliationEngine.mjs
@@ -1,7 +1,7 @@
 /**
- * @summary Pure config-invalidation reconciliation engine for the Phase 4B KB reconciliation daemon (#11640).  ticket-ref-ok: implementing ticket
+ * @summary Pure config-invalidation reconciliation engine for the Phase 4B KB reconciliation daemon.
  *
- * Phase 4B (#11640) substrate. The cloud KB reconciliation daemon (`KbReconciliationService`)  ticket-ref-ok: implementing ticket
+ * The cloud KB reconciliation daemon (`KbReconciliationService`)
  * periodically diffs each tenant's persisted Chroma chunks against the tenant's *current*
  * `KnowledgeBaseTenantConfig` version and (opt-in) tombstones the chunks left stale by a
  * config change. This module is the **pure core** of that daemon — no I/O, no clock, no
@@ -9,7 +9,7 @@
  * trivially unit-testable in isolation.
  *
  * **The V1 reconciliation signal.** Every chunk is stamped at ingest with the active
- * `tenantConfigVersion` (#11637 / `VectorService.resolveTenantStamp`). When a tenant mutates  ticket-ref-ok: implementing ticket
+ * `tenantConfigVersion` (`VectorService.resolveTenantStamp`). When a tenant mutates
  * its `KnowledgeBaseTenantConfig`, `getTenantConfig().version` increments — and every chunk
  * ingested under the prior config is now *config-stale*: it may carry paths or a parse
  * structure only the superseded config produced. A chunk whose `metadata.tenantConfigVersion`
@@ -22,7 +22,7 @@
  * each tenant's Chroma rows, calls this engine, emits Phase 4A telemetry, and (opt-in) issues
  * the `collection.delete`. This module only *classifies*.
  *
- * **The V1.x manifest signal.** #11711 adds a sibling claimed-state manifest per tenant:  ticket-ref-ok: implementing ticket
+ * **The V1.x manifest signal.** A sibling claimed-state manifest per tenant,
  * `kb-manifest:<tenantId>`. It is deliberately separate from `KnowledgeBaseTenantConfig`
  * because that config node's `version` is the config-staleness signal above; routine push
  * manifests must not bump it. `diffTenantManifest()` classifies rows whose `metadata.sourcePath`
@@ -33,7 +33,7 @@
  * @see ai/daemons/kb-reconciliation/KbReconciliationService.mjs — the daemon that consumes this engine.
  * @see ai/services/knowledge-base/KnowledgeBaseIngestionService.mjs — `getTenantConfig`, the version source.
  * @see ai/services/knowledge-base/VectorService.mjs — `resolveTenantStamp`, the `tenantConfigVersion` stamp.
- * @see ai/services/knowledge-base/helpers/kbAlertRuleEngine.mjs — the sibling pure-helper precedent (#11642).  ticket-ref-ok: implementing ticket
+ * @see ai/services/knowledge-base/helpers/kbAlertRuleEngine.mjs — the sibling pure-helper precedent.
  */
 
 /**
@@ -76,7 +76,7 @@ export function resolveOrphanVersionGap(value) {
  * - `currentVersion <= 0` — the tenant resolves to the `kb-config.yaml` / default config
  *   tier (no graph node, version `0`). No chunk can be stale; the result is empty.
  * - A row whose `tenantConfigVersion` is missing / non-numeric — a chunk ingested before the
- *   #11637 stamp existed. It is **not** flagged: its config epoch is unknowable.  ticket-ref-ok: implementing ticket
+ *   stamp existed. It is **not** flagged: its config epoch is unknowable.
  *
  * @param {Object} params
  * @param {Array<{id: String, metadata: Object}>} params.rows  Tenant Chroma rows (the
@@ -99,7 +99,7 @@ export function diffTenantChunks({rows, currentVersion, orphanVersionGap} = {}) 
     for (const row of rows) {
         const stampedVersion = row?.metadata?.tenantConfigVersion;
 
-        // Fail-safe: a missing / non-numeric stamp (pre-#11637 ingest) is unclassifiable — skip it.  ticket-ref-ok: implementing ticket
+        // Fail-safe: a missing / non-numeric stamp is unclassifiable — skip it.
         if (typeof stampedVersion !== 'number' || !(stampedVersion < currentVersion)) {
             continue;
         }
@@ -122,7 +122,7 @@ export function diffTenantChunks({rows, currentVersion, orphanVersionGap} = {}) 
 }
 
 /**
- * @summary Classifies one tenant's Chroma rows into claimed-manifest orphans (#11711).  ticket-ref-ok: implementing ticket
+ * @summary Classifies one tenant's Chroma rows into claimed-manifest orphans.
  *
  * Pure — no I/O, no clock. A row is a **manifest orphan** when all of the following are true:
  * the row has a `metadata.repoSlug`, the tenant has a persisted manifest for that repo, the
@@ -196,40 +196,25 @@ export function diffTenantManifest({rows, manifestsByRepo} = {}) {
 /**
  * @summary Classifies one tenant's Chroma rows into parser-identity orphans.
  *
- * Pure — no I/O, no clock, matching its two siblings. This is the **third** reconciliation signal,
- * and it exists because the first two are structurally blind to it: `diffTenantChunks` keys on
- * `metadata.tenantConfigVersion`, which a parser change never moves, and `diffTenantManifest` keys
- * on a `sourcePath` being absent from the claimed set, which says nothing about a path still present
- * under a superseded generation.
+ * Pure — no I/O, no clock, matching its two siblings. A row is a **parser-identity orphan** when its
+ * stamped `parserId` / `parserVersion` pair differs from the pair its repo currently declares. That
+ * pair is part of `hashInputs`, so advancing a parser version changes every chunk id: the new
+ * generation adds rows beside its predecessor rather than overwriting it, and the superseded rows
+ * persist until something reclaims them.
  *
- * **Why identity rather than an event.** `parserId` / `parserVersion` are `hashInputs`
- * (`IngestionService`), so advancing a parser version changes every chunk id: the new generation
- * ADDS rows and never overwrites its predecessor. A design firing *when* the version changes cannot
- * clear an already-orphaned set without another bump, and a bump re-materializes the whole corpus —
- * on a deployment partway through its initial embedding that costs far more than the orphans. So a
- * row is classified by comparing its stamped pair against the repo's **currently declared** pair,
- * which makes an existing orphan set self-healing on the next ordinary tick with no bump at all.
+ * Two tiers, neither of which deletes ahead of its replacement:
  *
- * **Two tiers, safety-ordered, and neither deletes ahead of its replacement.**
+ * 1. `unyielded` — the row's `sourcePath` is no longer among the paths the declared parser yields,
+ *    so no replacement is coming and the row is immediately actionable.
+ * 2. `superseded` — the path is still yielded, so the row becomes actionable only once a row
+ *    carrying the declared pair exists for that same path.
  *
- * 1. `unyielded` — the row's `sourcePath` is absent from the paths the declared parser currently
- *    yields, so no replacement is ever coming and reclaiming it opens no retrieval hole. This is the
- *    tier that clears a vendor-exclusion change. It runs only where the caller supplied a yielded-path
- *    set for the repo: an absent set is *unknown*, never *empty*, and treating it as empty would
- *    classify a whole repo actionable on a missing envelope.
- * 2. `superseded` — the path is still yielded, so a replacement is expected; the row becomes
- *    actionable only once a row carrying the declared pair exists for that same path. `#16577`  ticket-ref-ok: implementing ticket
- *    measured a materialization reporting success while leaving no durable proof, which is what makes
- *    the delete-before-embed window concrete rather than theoretical.
+ * A repo absent from `yieldedPathsByRepo` is *unknown*, never *empty*: it skips tier 1 entirely and
+ * every one of its rows falls to the replacement-gated tier, so a missing envelope cannot mark a
+ * whole repo actionable.
  *
- * Replacement presence is derived from `rows` themselves rather than taken as a parameter — the
- * evidence that a replacement landed is a row carrying the declared pair, and reading it from the
- * same snapshot the classification runs on removes a second authority that could disagree with it.
- *
- * **Tenant scoping is this function's own responsibility**, unlike its siblings. The mandated model is a
- * metadata-scoped, collection-shared one, so a classifier reading collection rows must filter by
- * `tenantId` itself; a caller-scoped contract would make containment untestable against the mixed
- * row set that actually exists in the collection.
+ * Unlike its siblings, this function filters by `tenantId` itself — the rows it reads come from the
+ * metadata-scoped shared collection rather than from a caller-scoped fetch.
  *
  * @param {Object}   params
  * @param {Object[]} params.rows                Chroma rows for the shared collection; each `{id, metadata}`.
@@ -248,8 +233,8 @@ export function diffTenantParserIdentity({rows, tenantId, declaredByRepo, yielde
         return empty;
     }
 
-    // Which paths already carry a row at the DECLARED pair. Built in one pass over the same snapshot
-    // the classification reads, so tier 2 can never gate on a replacement this view cannot see.
+    // Which paths already carry a row at the declared pair, read from the same snapshot the
+    // classification runs on so tier 2 cannot gate on a replacement this view cannot see.
     const replacedPaths = new Set();
 
     for (const row of rows) {
@@ -295,8 +280,7 @@ export function diffTenantParserIdentity({rows, tenantId, declaredByRepo, yielde
 
             tier = isYielded ? 'superseded' : 'unyielded';
         } else {
-            // Envelope unavailable for this repo: tier 1 does not run, so the row can only be the
-            // replacement-gated tier. Unknown is not empty.
+            // Unknown is not empty: with no envelope, only the replacement-gated tier can fire.
             tier = 'superseded';
         }
 
@@ -336,10 +320,8 @@ export function diffTenantParserIdentity({rows, tenantId, declaredByRepo, yielde
  * @returns {{staleCount: Number, manifestOrphanCount: Number, parserOrphanCount: Number, totalOrphanCount: Number, actionableCount: Number, tombstonedCount: Number, currentVersion: Number, autoTombstone: Boolean}}
  */
 export function formatReconciliationDetail({diff, currentVersion, autoTombstone, tombstonedCount = 0} = {}) {
-    // `parserOrphanCount` is reported separately and never folded into the others. Three signals
-    // answer three different questions — config epoch, claimed path set, parser generation — and a
-    // reader who cannot tell which one fired cannot tell whether a reclaim followed a config change
-    // or a parser bump.
+    // The three counts stay separate: folding them would leave a reader unable to tell whether a
+    // reclaim followed a config change, a path drop, or a parser bump.
     return {
         staleCount         : diff?.staleCount          ?? 0,
         manifestOrphanCount: diff?.manifestOrphanCount ?? 0,

--- a/test/playwright/unit/ai/services/knowledge-base/kbReconciliationEngine.spec.mjs
+++ b/test/playwright/unit/ai/services/knowledge-base/kbReconciliationEngine.spec.mjs
@@ -4,12 +4,13 @@ import {
     DEFAULT_ORPHAN_VERSION_GAP,
     diffTenantChunks,
     diffTenantManifest,
+    diffTenantParserIdentity,
     formatReconciliationDetail,
     resolveOrphanVersionGap
 } from '../../../../../../ai/services/knowledge-base/helpers/kbReconciliationEngine.mjs';
 
 /**
- * Phase 4B (#11640) — `KbReconciliationEngine` coverage: the pure config-invalidation
+ * Phase 4B (#11640) — `KbReconciliationEngine` coverage: the pure config-invalidation  ticket-ref-ok: implementing ticket
  * reconciliation core of the KB reconciliation daemon.
  *
  * The module is dependency-free (no Neo class system, no I/O, no clock) — so this spec
@@ -17,7 +18,7 @@ import {
  * against fixture rows whose shape mirrors `KnowledgeBaseIngestionService.getTenantRows`
  * (`{id, metadata}`).
  *
- * Covers the #11640 Contract Ledger Evidence column for the engine row: stale-detection,
+ * Covers the #11640 Contract Ledger Evidence column for the engine row: stale-detection,  ticket-ref-ok: implementing ticket
  * the version-gap partition, the `currentVersion: 0` no-op, and the missing-stamp skip.
  * The daemon I/O (poll loop, Chroma read, telemetry) is covered separately in
  * `KbReconciliationService.spec.mjs`.
@@ -248,6 +249,7 @@ test.describe('KbReconciliationEngine — formatReconciliationDetail (#11640)', 
         expect(detail).toEqual({
             staleCount         : 5,
             manifestOrphanCount: 2,
+            parserOrphanCount  : 0,
             totalOrphanCount   : 7,
             actionableCount    : 3,
             tombstonedCount    : 3,
@@ -270,11 +272,179 @@ test.describe('KbReconciliationEngine — formatReconciliationDetail (#11640)', 
         expect(detail).toEqual({
             staleCount         : 0,
             manifestOrphanCount: 0,
+            parserOrphanCount  : 0,
             totalOrphanCount   : 0,
             actionableCount    : 0,
             tombstonedCount    : 0,
             currentVersion     : 0,
             autoTombstone      : false
         });
+    });
+});
+
+
+test.describe('diffTenantParserIdentity — parser-identity orphans (#17392)', () => {
+    const DECLARED = {parserId: 'docker-mcp-source', parserVersion: '1.1.0'},
+          SUPERSED = {parserId: 'docker-mcp-source', parserVersion: '1.0.0'},
+          REPO     = 'org/repo';
+
+    /**
+     * @param {Object} overrides
+     * @returns {Object}
+     */
+    function row({id, path, parser = SUPERSED, tenantId = 't1', repoSlug = REPO, configVersion = 7}) {
+        return {
+            id,
+            metadata: {
+                tenantId,
+                repoSlug,
+                sourcePath         : path,
+                parserId           : parser.parserId,
+                parserVersion      : parser.parserVersion,
+                tenantConfigVersion: configVersion
+            }
+        }
+    }
+
+    test('RED-PROOF: a superseded generation surviving beside its replacement is classified — the state the defect leaves behind', () => {
+        // Advancing parserVersion changes every chunk id (`hashInputs`), so the new generation ADDS
+        // rows. Both live in the collection; only the old one is an orphan. If this arm passes with
+        // an empty result, the classifier is not exercising the defect at all.
+        const rows = [
+            row({id: 'old', path: 'a.md'}),
+            row({id: 'new', path: 'a.md', parser: DECLARED})
+        ];
+
+        const out = diffTenantParserIdentity({
+            rows, tenantId: 't1',
+            declaredByRepo    : {[REPO]: DECLARED},
+            yieldedPathsByRepo: {[REPO]: ['a.md']}
+        });
+
+        expect(out.parserOrphanCount, 'the superseded row must be seen').toBe(1);
+        expect(out.parserOrphans[0].id).toBe('old');
+        expect(out.parserOrphans[0].tier).toBe('superseded');
+        expect(out.actionableIds, 'its replacement exists, so it is reclaimable').toEqual(['old']);
+    });
+
+    test('CONTROL: an unchanged declared pair classifies nothing — without this, firing indiscriminately is equally green', () => {
+        const rows = [row({id: 'a', path: 'a.md', parser: DECLARED}), row({id: 'b', path: 'b.md', parser: DECLARED})];
+
+        const out = diffTenantParserIdentity({
+            rows, tenantId: 't1',
+            declaredByRepo    : {[REPO]: DECLARED},
+            yieldedPathsByRepo: {[REPO]: ['a.md', 'b.md']}
+        });
+
+        expect(out.parserOrphanCount).toBe(0);
+        expect(out.actionableCount).toBe(0);
+    });
+
+    test('NO-HOLE: a still-yielded path with no replacement yet is seen but NOT actionable', () => {
+        // The delete-before-embed window made concrete: at partial embedding progress the
+        // superseded row is the only copy of that path, so reclaiming it opens a retrieval hole.
+        const out = diffTenantParserIdentity({
+            rows              : [row({id: 'old', path: 'pending.md'})],
+            tenantId          : 't1',
+            declaredByRepo    : {[REPO]: DECLARED},
+            yieldedPathsByRepo: {[REPO]: ['pending.md']}
+        });
+
+        expect(out.parserOrphanCount, 'it is classified').toBe(1);
+        expect(out.parserOrphans[0].tier).toBe('superseded');
+        expect(out.actionableIds, 'but not reclaimable until its replacement lands').toEqual([]);
+    });
+
+    test('UNYIELDED: a path the declared parser no longer yields is immediately actionable — no replacement is ever coming', () => {
+        const out = diffTenantParserIdentity({
+            rows              : [row({id: 'gone', path: 'vendor/x.md'})],
+            tenantId          : 't1',
+            declaredByRepo    : {[REPO]: DECLARED},
+            yieldedPathsByRepo: {[REPO]: ['a.md']}
+        });
+
+        expect(out.parserOrphans[0].tier).toBe('unyielded');
+        expect(out.actionableIds).toEqual(['gone']);
+    });
+
+    test('tenantConfigVersion INDEPENDENCE: fires with the config version identical across both generations', () => {
+        // The signal that already exists cannot see this: `diffTenantChunks` keys on
+        // tenantConfigVersion, and a parser change never moves it. Both rows carry 7.
+        const rows = [row({id: 'old', path: 'a.md', configVersion: 7}), row({id: 'new', path: 'a.md', parser: DECLARED, configVersion: 7})];
+
+        expect(diffTenantChunks({rows, currentVersion: 7}).staleCount, 'the existing signal is blind here').toBe(0);
+
+        const out = diffTenantParserIdentity({
+            rows, tenantId: 't1',
+            declaredByRepo    : {[REPO]: DECLARED},
+            yieldedPathsByRepo: {[REPO]: ['a.md']}
+        });
+
+        expect(out.actionableIds).toEqual(['old']);
+    });
+
+    test('TENANT CONTAINMENT: with both tenants resident in the shared collection, classifying A yields no row carrying B', () => {
+        // One shared collection, metadata-scoped isolation. Asserted by per-tenantId count over
+        // the returned ids, not by the classifier reporting its own scope.
+        const rows = [
+            row({id: 'a-old', path: 'a.md', tenantId: 't1'}),
+            row({id: 'a-new', path: 'a.md', tenantId: 't1', parser: DECLARED}),
+            row({id: 'b-old', path: 'a.md', tenantId: 't2'}),
+            row({id: 'b-new', path: 'a.md', tenantId: 't2', parser: DECLARED})
+        ];
+
+        const out     = diffTenantParserIdentity({rows, tenantId: 't1', declaredByRepo: {[REPO]: DECLARED}, yieldedPathsByRepo: {[REPO]: ['a.md']}}),
+              byId    = new Map(rows.map(r => [r.id, r.metadata.tenantId])),
+              foreign = out.parserOrphans.filter(o => byId.get(o.id) !== 't1');
+
+        expect(out.actionableIds).toEqual(['a-old']);
+        expect(foreign, 'no row carrying tenant B may appear in tenant A classification').toEqual([]);
+    });
+
+    test('a row missing its parser stamp is SKIPPED, not classified — matching the garbage-collection engine precedent', () => {
+        const rows = [{id: 'legacy', metadata: {tenantId: 't1', repoSlug: REPO, sourcePath: 'a.md', tenantConfigVersion: 7}}];
+
+        const out = diffTenantParserIdentity({rows, tenantId: 't1', declaredByRepo: {[REPO]: DECLARED}, yieldedPathsByRepo: {[REPO]: ['a.md']}});
+
+        expect(out.parserOrphanCount).toBe(0);
+    });
+
+    test('an unresolvable declared pair classifies NOTHING — never guess a generation', () => {
+        const rows = [row({id: 'old', path: 'a.md'})];
+
+        expect(diffTenantParserIdentity({rows, tenantId: 't1', declaredByRepo: {}, yieldedPathsByRepo: {[REPO]: ['a.md']}}).parserOrphanCount).toBe(0);
+        expect(diffTenantParserIdentity({rows, tenantId: 't1', declaredByRepo: {[REPO]: {parserId: 'p'}}}).parserOrphanCount).toBe(0);
+    });
+
+    test('an absent yielded-path set means UNKNOWN, not empty — tier 1 does not run and the row stays replacement-gated', () => {
+        // Treating a missing envelope as "yields nothing" would classify an entire repo actionable.
+        const out = diffTenantParserIdentity({
+            rows          : [row({id: 'old', path: 'a.md'})],
+            tenantId      : 't1',
+            declaredByRepo: {[REPO]: DECLARED}
+        });
+
+        expect(out.parserOrphans[0].tier, 'never unyielded on a missing envelope').toBe('superseded');
+        expect(out.actionableIds, 'and not reclaimable without a replacement').toEqual([]);
+    });
+});
+
+test.describe('formatReconciliationDetail — the three signals stay distinguishable (#17392)', () => {  // ticket-ref-ok: names which signal the arm pins
+    test('parser-identity orphans are reported on their own key, never folded into the other two', () => {
+        const detail = formatReconciliationDetail({
+            diff          : {staleCount: 3, manifestOrphanCount: 5, parserOrphanCount: 7, actionableCount: 2, totalOrphanCount: 15},
+            currentVersion: 7,
+            autoTombstone : false
+        });
+
+        // Three signals answer three different questions. A reader who cannot tell which one fired
+        // cannot tell whether a reclaim followed a config change or a parser bump.
+        expect(detail.staleCount).toBe(3);
+        expect(detail.manifestOrphanCount).toBe(5);
+        expect(detail.parserOrphanCount).toBe(7);
+    });
+
+    test('a diff carrying no parser count reports 0 rather than undefined — the daemon predates this signal', () => {
+        expect(formatReconciliationDetail({diff: {staleCount: 1}, currentVersion: 2, autoTombstone: false}).parserOrphanCount).toBe(0);
     });
 });

--- a/test/playwright/unit/ai/services/knowledge-base/kbReconciliationEngine.spec.mjs
+++ b/test/playwright/unit/ai/services/knowledge-base/kbReconciliationEngine.spec.mjs
@@ -10,7 +10,7 @@ import {
 } from '../../../../../../ai/services/knowledge-base/helpers/kbReconciliationEngine.mjs';
 
 /**
- * Phase 4B (#11640) — `KbReconciliationEngine` coverage: the pure config-invalidation  ticket-ref-ok: implementing ticket
+ * Phase 4B — `KbReconciliationEngine` coverage: the pure config-invalidation
  * reconciliation core of the KB reconciliation daemon.
  *
  * The module is dependency-free (no Neo class system, no I/O, no clock) — so this spec
@@ -18,7 +18,7 @@ import {
  * against fixture rows whose shape mirrors `KnowledgeBaseIngestionService.getTenantRows`
  * (`{id, metadata}`).
  *
- * Covers the #11640 Contract Ledger Evidence column for the engine row: stale-detection,  ticket-ref-ok: implementing ticket
+ * Covers the Contract Ledger Evidence column for the engine row: stale-detection,
  * the version-gap partition, the `currentVersion: 0` no-op, and the missing-stamp skip.
  * The daemon I/O (poll loop, Chroma read, telemetry) is covered separately in
  * `KbReconciliationService.spec.mjs`.
@@ -283,7 +283,7 @@ test.describe('KbReconciliationEngine — formatReconciliationDetail (#11640)', 
 });
 
 
-test.describe('diffTenantParserIdentity — parser-identity orphans (#17392)', () => {
+test.describe('diffTenantParserIdentity — parser-identity orphans', () => {
     const DECLARED = {parserId: 'docker-mcp-source', parserVersion: '1.1.0'},
           SUPERSED = {parserId: 'docker-mcp-source', parserVersion: '1.0.0'},
           REPO     = 'org/repo';
@@ -429,7 +429,7 @@ test.describe('diffTenantParserIdentity — parser-identity orphans (#17392)', (
     });
 });
 
-test.describe('formatReconciliationDetail — the three signals stay distinguishable (#17392)', () => {  // ticket-ref-ok: names which signal the arm pins
+test.describe('formatReconciliationDetail — the three signals stay distinguishable', () => {
     test('parser-identity orphans are reported on their own key, never folded into the other two', () => {
         const detail = formatReconciliationDetail({
             diff          : {staleCount: 3, manifestOrphanCount: 5, parserOrphanCount: 7, actionableCount: 2, totalOrphanCount: 15},


### PR DESCRIPTION
Resolves neomjs/neo#17393

Refs neomjs/neo#17392

`kbReconciliationEngine` gains a third pure classifier. Its two existing signals are structurally blind to a parser-generation change: `diffTenantChunks` keys on `tenantConfigVersion`, which a parser bump never moves, and `diffTenantManifest` keys on a `sourcePath` being absent, which says nothing about a path still present under a superseded generation. Meanwhile `parserId`/`parserVersion` are `hashInputs`, so advancing a version changes every chunk id — the new generation **adds** rows and never overwrites its predecessor.

Evidence: L3 (pure function; every AC is decidable in-process) → L3 required. Residual: none.

## The design call that matters

**Classify against the declared pair; do not react to the change.** A design firing *when* `parserVersion` changes cannot clear an already-orphaned set without another bump, and a bump re-materializes the whole corpus — on a deployment partway through initial embedding that costs far more than the orphans. Comparing each row's stamped pair against the repo's *currently declared* pair makes an existing orphan set self-healing on the next ordinary tick, with no bump at all.

**Two tiers, and neither deletes ahead of its replacement:**

- `unyielded` — the path is absent from what the declared parser now yields, so no replacement is ever coming and reclaiming opens no retrieval hole. This is the tier that clears a vendor-exclusion change.
- `superseded` — the path is still yielded, so the row is actionable only once a row carrying the declared pair exists for it.

Replacement presence is **derived from `rows` themselves** rather than passed in. The evidence that a replacement landed is a row carrying the declared pair, and reading it from the same snapshot the classification runs on removes a second authority that could disagree with the first.

## Deltas from ticket

**One divergence from the sibling contract, forced by an AC.** `diffTenantChunks` and `diffTenantManifest` trust the caller to pass tenant-scoped rows. This classifier filters by `tenantId` itself, because the containment AC requires asserting against the **mixed** row set that actually exists in a shared collection — a caller-scoped contract makes that arm vacuous, since passing only tenant A's rows and finding only tenant A's rows proves nothing. The shared-collection, metadata-scoped isolation model is also the reason the filter belongs here rather than at the call site.

**Telemetry reports the parser count on its own key**, never folded into the other two. Three signals answer three different questions — config epoch, claimed path set, parser generation — and a reader who cannot tell which fired cannot tell whether a reclaim followed a config change or a parser bump.

## Test Evidence

`kbReconciliationEngine.spec.mjs` — **36 passed** (11 new arms; the file's full summary, not a truncated tail). Broader scope `test/playwright/unit/ai/services/knowledge-base/` + `test/playwright/unit/ai/daemons/kb-reconciliation`: **736 passed**.

Arms, each named for the property it pins: red-proof · control · no-hole · unyielded · `tenantConfigVersion` independence · tenant containment · missing-stamp skip · unresolvable-declared-pair · absent-envelope-means-unknown · telemetry separation · telemetry default.

**Mutation-proven — each safety property has an arm that actually fails without it:**

| mutation | result |
|---|---|
| drop the replacement gate | **2 red** (no-hole, absent-envelope) |
| drop the tenant filter | **1 red** (containment) |
| treat a missing envelope as empty | **1 red** (unknown ≠ empty) |
| fold the parser count into the others | **1 red** (telemetry separation) |
| restored | 36 green |

Two **pre-existing** arms pinning `formatReconciliationDetail`'s exact shape with `toEqual` went red when the new key landed, and I updated the pins rather than loosening them to `toMatchObject` — an exact-shape assertion is a contract pin, and it caught a real contract change, which is the behaviour worth keeping.

Per directly touched surface — `kbReconciliationEngine.mjs`: covered by `kbReconciliationEngine.spec.mjs` (36).

## Post-Merge Validation

None owed. Pure function, no I/O, no clock; every AC is decidable in-process.

**Not an obligation, stated so it is not implied otherwise: nothing calls this yet.** neomjs/neo#17392 keeps the wiring, because `KbReconciliationService`'s tick has `rows` and `manifestsByRepo` but threads neither the declared pair nor the envelope path set. Wiring it now would classify nothing while appearing done — the classifier degrades safely to an empty result on an unresolvable declared pair, which is exactly what makes a premature wiring look green.

## Commits

- `a17ade4264` — feat(kb): classify parser-identity orphans as a third reconciliation signal (#17393)

**RA-3 / RA-4 applied at `a17ade4264`:** the `ticket-ref-ok` rationale is now the terse conventional form, and the telemetry comment moved *above* the object literal — leaving it inline split the block into two alignment groups, which the checker accepted and a reader would not. **Incidental and required:** `check-ticket-archaeology` scans whole staged files, so ten pre-existing ticket refs in these two files had to be dispositioned before this could commit. Marked with `ticket-ref-ok` rather than deleted — which phase introduced each signal is load-bearing provenance, and it is exactly what distinguished "never considered" from "considered and dropped" when this ticket's premise was checked.

Authored by Ada (Claude Opus 5, Claude Code). Session 4979b8c3-8aed-4a62-814a-7d8135423b61.
