### PR TITLE
feat(kb): a provider-killing chunk graduates to geometry instead of earning a content verdict (#17336)

### DIFF
--- a/ai/services/knowledge-base/VectorService.mjs
+++ b/ai/services/knowledge-base/VectorService.mjs
@@ -41,7 +41,9 @@ import {
     KB_VECTOR_EMBED_PROVIDER_CIRCUIT_OPEN,
     KB_VECTOR_EMBED_UNDELIVERABLE_AT_GEOMETRY,
     classifyEmbedFailureError,
-    classifyEmbedResidencyDisposition
+    classifyEmbedResidencyDisposition,
+    isAcceptedThenDiedError,
+    isProviderDeathError
 }                                                                     from './helpers/embedFailureClassification.mjs';
 
 /**
@@ -74,7 +76,15 @@ const undeliverableEvidence = {
     generationId: null,
     strikes     : new Map(),
     suspects    : new Set(),
-    seq         : 0
+    seq         : 0,
+    // Death-class evidence, kept in its own map rather than folded into `strikes` because the
+    // two automata differ in WHEN a strike is earned. A call-ceiling expiry is self-proving: the
+    // deadline fired, and repetition is the whole evidence. A provider death proves nothing on its own
+    // — the provider might simply be down — so a death is recorded as PENDING and becomes a strike only
+    // once a later dispatch succeeds, which is what separates "this input kills it" from "it was
+    // down". Sharing one map would have made the threshold read a mixture of proven and unproven
+    // observations.
+    deaths      : new Map()
 };
 
 /**
@@ -901,8 +911,18 @@ class VectorService extends Base {
      * @summary Whether an embedding failure forbids poison isolation.
      *
      * These terminals say nothing about content. A timeout may leave provider work running, an
-     * abort/circuit refusal deliberately ended admission, and a cooperative yield transfers the
-     * lane. None may trigger exploratory provider calls.
+     * abort/circuit refusal deliberately ended admission, a cooperative yield transfers the lane,
+     * and a dead provider answered nothing at all. None may trigger exploratory provider calls.
+     *
+     * **Why provider death is here even though the isolation walk already pairs its evidence.**
+     * The fresh control at the decision boundary below proves the provider was alive
+     * *immediately before* the suspect was dispatched — which is exactly the trace a chunk that
+     * KILLS the provider leaves behind. So the strongest exculpatory check available convicts the
+     * one input it should exonerate, and the surrounding contract's abort-rather-than-quarantine
+     * promise covers the remainder while the trigger is quarantined anyway. Without this term a
+     * poison entry is written whose own `reasonCode` names a socket failure. Death is evidence
+     * about deliverability at the current geometry, which is `undeliverableEvidence`'s domain,
+     * never a content verdict.
      *
      * @param {*} error Provider failure.
      * @param {AbortSignal} [signal] Active run signal.
@@ -910,6 +930,12 @@ class VectorService extends Base {
      */
     isPoisonIsolationForbidden(error, signal) {
         if (signal?.aborted === true) return true;
+
+        // Outside the walk below, deliberately: `isProviderDeathError` runs its own bounded
+        // cause-chain classification, so calling it per depth would re-walk the same chain from
+        // every link. The terms inside the loop are surface reads of one error object and need
+        // the walk; this one owns it.
+        if (isProviderDeathError(error)) return true;
 
         const visited = new Set();
         let   current = error;
@@ -1173,7 +1199,11 @@ class VectorService extends Base {
      *     through so one sweep's strikes, suspicions, and durable dispositions share one generation;
      *     absent, it is resolved once at entry from the same leaves.
      * @param {Function} [options.now] Clock seam for bounded poison receipts.
-     * @returns {Promise<{embedded: Number, skipped: Number, yielded: Boolean, failedBatches: Object[], poisonedChunks: Object[]}>}
+     * @returns {Promise<{embedded: Number, skipped: Number, yielded: Boolean, failedBatches: Object[], poisonedChunks: Object[], deathGraduations: Object[], deathStrikeProgress: Object[]}>}
+     *     `poisonedChunks` reports what was already fenced when the sweep started; `deathGraduations`
+     *     reports what THIS sweep fenced on death-class evidence and why; `deathStrikeProgress` reports
+     *     unfinished death evidence, with `pending` separating a recorded-but-unproven observation from
+     *     a confirmed strike so the two are never summed.
      *     `failedBatches` carries `{batchIndex, chunkIds, reason}` for every batch that exhausted its retries
      *     while other batches were succeeding. Such a batch is skipped rather than aborting the sweep, because
      *     aborting strands every later batch permanently — see the rationale at the exhaustion branch. A sweep
@@ -1215,6 +1245,11 @@ class VectorService extends Base {
         const {backoffBaseMs, batchSize, batchDelay, maxRetries, undeliverableTimeoutStrikes} = aiConfig;
         const guardrail                                                                       = this.resolveEmbeddingGuardrail();
         const failedBatches                                                                   = [];
+        // Death-class graduation receipts for this sweep. Separate from
+        // `poisonedChunks`, which reports what was ALREADY fenced when the sweep started: this reports
+        // what this sweep fenced and on what evidence, so convergence is visible in the summary instead
+        // of only as a repo-level failure count climbing with no stated reason.
+        const deathGraduations = [];
         const poisonedChunks                                                                  = knownPoisonEntries.map(entry => ({...entry}));
         const poisonIds                                                                       = new Set(poisonedChunks.map(entry => entry.chunkId));
         const preEmbeddedIds                                                                  = new Set();
@@ -1235,6 +1270,48 @@ class VectorService extends Base {
         // chunk from the front of a stride, and the remainder must be re-offered THIS sweep instead
         // of silently skipping to the next stride boundary.
         let cursor = 0;
+
+        /**
+         * Mints one death-class geometry disposition, and it is a closure rather than inline code
+         * because it now fires from BOTH provider outcomes. The success path converts a pending
+         * observation once the provider answers again; the failure path graduates directly when the
+         * failure itself proved liveness (`isAcceptedThenDiedError`). Inlining it twice would let the
+         * two sites drift on the receipt shape, which is the artifact an operator reads.
+         *
+         * Fail-open on a persistence error, matching the timeout path: a disposition that cannot
+         * persist must never suppress provider work.
+         *
+         * @param {String} suspectId
+         * @param {Object} deathEntry
+         * @param {Number} recoveredTokenEstimate Tokens the provider demonstrably served — the
+         *     suspect's own size on the failure path, since accepting the request IS the evidence.
+         * @returns {Promise<Boolean>} Whether a disposition was minted.
+         */
+        const graduateDeathSuspect = async (suspectId, deathEntry, recoveredTokenEstimate) => {
+            if (deathEntry.strikes < undeliverableTimeoutStrikes || typeof onPoisonEntries !== 'function') {
+                return false
+            }
+
+            const deathReceipt = {
+                chunkId      : suspectId,
+                tokenEstimate: deathEntry.tokenEstimate,
+                attempts     : deathEntry.strikes,
+                recoveredTokenEstimate,
+                failureCode  : deathEntry.failureCode
+            };
+
+            try {
+                await onPoisonEntries([{chunkId: suspectId, reasonCode: KB_VECTOR_EMBED_UNDELIVERABLE_AT_GEOMETRY}]);
+                evidence.deaths.delete(suspectId);
+                evidence.suspects.delete(suspectId);
+                deathGraduations.push(deathReceipt);
+                logger.warn(`[VectorService] Chunk ${suspectId} graduated to undeliverable-at-geometry after ${deathReceipt.attempts} single-input dispatches that killed the provider (${deathReceipt.failureCode}, ~${deathReceipt.tokenEstimate} tokens); it stops being offered until the embedding generation changes. The provider accepted each request before dying, which is what attributes the death to this input rather than to an outage — it does not prove the lane can serve an input this size.`);
+                return true
+            } catch (persistError) {
+                logger.warn(`[VectorService] Could not persist the undeliverable disposition for chunk ${suspectId} (${persistError.message}); the chunk remains offered.`);
+                return false
+            }
+        };
 
         while (cursor < chunksToProcess.length) {
             // Cooperative heavy-maintenance-lease yield-point: BETWEEN batches (never before the
@@ -1395,7 +1472,45 @@ class VectorService extends Base {
                     batchToEmbed.forEach(chunk => {
                         evidence.strikes.delete(chunk.id);
                         evidence.suspects.delete(chunk.id);
+                        // A chunk that embeds is not a killer. Its own success clears death evidence
+                        // against it — pending or already proven — for the same reason a non-timeout
+                        // outcome clears its timeout strikes.
+                        evidence.deaths.delete(chunk.id);
                     });
+
+                    // The RECOVERY half of the death-class automaton, and the half that makes
+                    // the evidence attributable at all. This dispatch succeeded, so the provider is
+                    // answering again — which is what turns a pending death from "the provider was
+                    // down" into "that input took it down". A death whose provider never comes back
+                    // stays pending forever and never fences anything, which is today's behaviour.
+                    //
+                    // Only observations pending from BEFORE this dispatch convert: `pendingSeq <=
+                    // dispatchSeq` is the same overlap guard the timeout path uses, and it matters more
+                    // here, because a death recorded by a request that overlapped this success would be
+                    // "confirmed" by a success that was already in flight when the provider died.
+                    //
+                    // The recovering input's token estimate is recorded beside the suspect's rather
+                    // than asserted away: this success may be a much smaller chunk, so it proves the
+                    // provider is LIVE, not that it can serve an input the suspect's size. That is
+                    // sufficient for a disposition that says *geometry* — and only because the poison
+                    // generation derives from the resolved admission band, so repairing the geometry
+                    // moves the band, changes the generation, and re-offers everything fenced under the
+                    // old one. Without that reversibility this graduation would be a one-way door.
+                    const recoveredTokenEstimate = bytesToTokens(
+                        textsToEmbed.reduce((total, text) => total + Buffer.byteLength(text || '', 'utf8'), 0)
+                    );
+
+                    for (const [suspectId, deathEntry] of evidence.deaths) {
+                        if (deathEntry.pendingSeq === null || deathEntry.pendingSeq > dispatchSeq) {
+                            continue
+                        }
+
+                        deathEntry.strikes                 += 1;
+                        deathEntry.pendingSeq               = null;
+                        deathEntry.recoveredTokenEstimate   = recoveredTokenEstimate;
+
+                        await graduateDeathSuspect(suspectId, deathEntry, recoveredTokenEstimate);
+                    }
 
                     const metadatas = batchToEmbed.map(buildChunkMetadata);
 
@@ -1480,7 +1595,12 @@ class VectorService extends Base {
                     // never be misclassified as provider work that might still be running.
                     const
                         providerCircuitOpen = embeddings === null && err?.code === KB_VECTOR_EMBED_PROVIDER_CIRCUIT_OPEN,
-                        providerTimedOut    = embeddings === null && isProviderTimeoutCode(err?.code);
+                        providerTimedOut    = embeddings === null && isProviderTimeoutCode(err?.code),
+                        // Death is classified through the cause chain, not `err.code`, because a
+                        // transport death routinely arrives wrapped by a stage-naming error. The
+                        // `embeddings === null` guard carries the same phase meaning as its siblings:
+                        // a write error with a death-shaped code is storage work, not provider work.
+                        providerDied        = embeddings === null && isProviderDeathError(err);
 
                     if (providerCircuitOpen || providerTimedOut) {
                         // Deterministic-undeliverable classification, on EXACT attribution only. One
@@ -1585,10 +1705,107 @@ class VectorService extends Base {
                             persistedCount: carryShrunkCount
                         });
 
+                        // Death-class RECORDING, and this is the only path a death reaches: the
+                        // end-sweep branch above fires on circuit-open and timeout, so a death falls
+                        // through to here. Placing it there instead would have been dead code.
+                        //
+                        // The timeout path graduates on its own evidence, because a fired deadline
+                        // proves itself. A death splits in two, and the failure code is what tells
+                        // them apart. An ACCEPTED-then-died failure carries its own liveness proof and
+                        // graduates below. A REFUSED connection proves only that nothing was listening,
+                        // so it records a PENDING observation and fences nothing — the isolation
+                        // contract is explicit that a dead provider "proves nothing about content and
+                        // must never be bisected into a poison disposition", and a refusal cannot
+                        // distinguish a killer input from an unrelated outage.
+                        //
+                        // Single-input only, for the same reason the timeout path is: a death on a
+                        // multi-input request cannot name which member caused it.
+                        const deathSuspect = providerDied && failedRequestChunks.length === 1
+                            ? failedRequestChunks[0]
+                            : null;
+
+                        // Suspicion for the MULTI-input death, and without it the whole automaton is
+                        // unreachable — found by instrumenting a fixture rather than by reading the
+                        // code. A death only becomes attributable once the suspect is dispatched ALONE,
+                        // and the thing that isolates it is suspicion; the timeout path adds it in its
+                        // own `else` branch, but that branch lives inside the end-sweep block a death
+                        // never enters. Without this the sweep re-dispatched the same three-input batch
+                        // three times and aborted, so no single-input death could ever be recorded.
+                        //
+                        // Same semantics the timeout path documents: suspicion costs one isolation
+                        // offer and never a fence, so suspecting every member of an unattributable
+                        // death is the conservative move rather than a widening.
+                        const deathMembers = providerDied
+                            ? (failedRequestChunks.length > 0 ? failedRequestChunks : batchToEmbed)
+                            : [];
+                        const deathMemberIds = new Set(deathMembers.map(chunk => chunk.id));
+
+                        if (deathSuspect) {
+                            const entry = evidence.deaths.get(deathSuspect.id) ?? {
+                                strikes               : 0,
+                                pendingSeq            : null,
+                                tokenEstimate         : 0,
+                                recoveredTokenEstimate: null,
+                                failureCode           : null
+                            };
+
+                            const suspectTokens = bytesToTokens(
+                                Buffer.byteLength(textsToEmbed[batchToEmbed.indexOf(deathSuspect)] || '', 'utf8')
+                            );
+
+                            // The liveness half of attribution comes from the FAILURE CODE, not from a
+                            // recovery probe — see `isAcceptedThenDiedError`. A reset / EPIPE / socket-end
+                            // needs an established connection, so the provider was answering when this
+                            // input left and this input is the one that was in flight. That is the whole
+                            // "provider was alive AND this killed it" pair, at zero extra provider cost.
+                            //
+                            // A recovery probe was the first design and it is unreachable in the case that
+                            // matters: once the suspect is the only chunk left, nothing further is
+                            // dispatched, no recovery is ever observed, and the counter freezes one strike
+                            // below threshold while the corpus never converges. Measured on the fixture —
+                            // strikes stuck at 1 across six sweeps with the chunk fenced by nothing.
+                            if (isAcceptedThenDiedError(err)) {
+                                entry.strikes                += 1;
+                                entry.pendingSeq              = null;
+                                entry.tokenEstimate           = suspectTokens;
+                                entry.recoveredTokenEstimate  = suspectTokens;
+                                entry.failureCode             = classifyEmbedFailureError(err);
+                                evidence.deaths.set(deathSuspect.id, entry);
+
+                                // Graduate HERE, on the failure path, because the case this ticket
+                                // exists for never reaches the success path: once the suspect is the
+                                // only chunk left, no dispatch after it succeeds, so a success-gated
+                                // graduation is unreachable exactly when it is needed. Measured — the
+                                // counter sat one strike below threshold across six sweeps.
+                                await graduateDeathSuspect(deathSuspect.id, entry, suspectTokens);
+                            }
+                            // A REFUSED connection proves the provider was already dead, so it says nothing
+                            // about this input. It stays a pending observation exactly as before: one at a
+                            // time, because a second refusal while the first is unconfirmed is the same
+                            // unproven fact rather than a second strike.
+                            else if (entry.pendingSeq === null) {
+                                entry.pendingSeq    = ++evidence.seq;
+                                entry.tokenEstimate = suspectTokens;
+                                entry.failureCode   = classifyEmbedFailureError(err);
+                                evidence.deaths.set(deathSuspect.id, entry);
+                            }
+                        }
+
                         (failedRequestChunks.length > 0 ? failedRequestChunks : batchToEmbed).forEach(chunk => {
                             evidence.strikes.delete(chunk.id);
-                            evidence.suspects.delete(chunk.id);
+
+                            // Death members keep their suspicion, and that exemption is the point:
+                            // suspicion is what dispatches a candidate ALONE next time, which is the
+                            // only way its next death is attributable to it rather than to its
+                            // neighbours. Clearing it here — as the timeout automaton's reset does for
+                            // everyone else — would re-batch the suspect and make the observation
+                            // unconfirmable, which is precisely the state the fixture caught.
+                            if (!deathMemberIds.has(chunk.id)) {
+                                evidence.suspects.delete(chunk.id)
+                            }
                         });
+
+                        deathMembers.forEach(chunk => evidence.suspects.add(chunk.id));
                     }
 
                     lastError = err;
@@ -1717,7 +1934,17 @@ class VectorService extends Base {
             cursor += cursorAdvance;
         }
 
-        return {embedded: embeddedCount, skipped: skippedCount, yielded, failedBatches, poisonedChunks};
+        // Death-class strike PROGRESS, not just its terminal receipts. The ticket's complaint was that
+        // an operator watched `consecutiveFailures` climb with no explanation; a chunk that has struck
+        // once and is waiting on a recovery to confirm a second is exactly the state that was invisible.
+        // `pending` distinguishes "recorded, unproven" from "proven" so the two are never summed.
+        const deathStrikeProgress = [...evidence.deaths].map(([chunkId, entry]) => ({
+            chunkId,
+            strikes: entry.strikes,
+            pending: entry.pendingSeq !== null
+        }));
+
+        return {embedded: embeddedCount, skipped: skippedCount, yielded, failedBatches, poisonedChunks, deathGraduations, deathStrikeProgress};
     }
 
     /**
@@ -2356,7 +2583,20 @@ class VectorService extends Base {
             // shape as a complete run — the caller then persists a checkpoint over work that never
             // landed. Absent predicate ⇒ `embedChunks` never yields ⇒ `false`, so this is additive and
             // every existing caller keeps today's semantics.
-            yielded : embedResult.yielded === true
+            yielded : embedResult.yielded === true,
+            // Death-class evidence forwarded rather than assumed to travel. This census picks
+            // fields explicitly, so anything `embedChunks` returns and this does not name is silently
+            // dropped — which is exactly what happened on the first attempt: the fields existed on the
+            // inner return, arrived `undefined` at the caller, and the AC that asks for them in the
+            // ingestion summary read as satisfied from the producer's side alone.
+            //
+            // `deathGraduations` is what THIS sweep fenced and on what evidence; `deathStrikeProgress`
+            // is the unfinished half, with `pending` separating a recorded-but-unproven observation
+            // from a confirmed strike so a reader never sums the two. Defaulted to `[]` in the same
+            // shape as `failedBatches` and `poisonedChunks` above, so a caller cannot tell a sweep with
+            // no death evidence from an older producer that never reported any.
+            deathGraduations   : embedResult.deathGraduations    || [],
+            deathStrikeProgress: embedResult.deathStrikeProgress || []
         };
     }
 

--- a/ai/services/knowledge-base/VectorService.mjs
+++ b/ai/services/knowledge-base/VectorService.mjs
@@ -77,13 +77,25 @@ const undeliverableEvidence = {
     strikes     : new Map(),
     suspects    : new Set(),
     seq         : 0,
-    // Death-class evidence, kept in its own map rather than folded into `strikes` because the
-    // two automata differ in WHEN a strike is earned. A call-ceiling expiry is self-proving: the
-    // deadline fired, and repetition is the whole evidence. A provider death proves nothing on its own
-    // — the provider might simply be down — so a death is recorded as PENDING and becomes a strike only
-    // once a later dispatch succeeds, which is what separates "this input kills it" from "it was
-    // down". Sharing one map would have made the threshold read a mixture of proven and unproven
-    // observations.
+    // Death-class evidence, kept in its own map rather than folded into `strikes` because the two
+    // automata differ in WHEN a strike is earned. A call-ceiling expiry is self-proving: the deadline
+    // fired, and repetition is the whole evidence. A death has to establish two things first — that the
+    // provider was alive, and that THIS input killed it — and where that proof comes from splits the
+    // automaton in two:
+    //
+    // - **Accepted-then-died** (`isAcceptedThenDiedError`: reset / EPIPE / socket-end). The failure code
+    //   is itself the liveness proof, since those require an established connection, so the pair is
+    //   complete at failure time: the strike is earned IMMEDIATELY and graduates in the same step. No
+    //   later success is waited for — once the suspect is the only chunk left, no later dispatch happens,
+    //   so a success-gated rule would be unreachable exactly when it is needed.
+    // - **Refused** (the provider was already down). That says nothing about this input, so it is
+    //   recorded PENDING and becomes a strike only once a later dispatch succeeds. One pending
+    //   observation at a time: a second refusal while the first is unconfirmed is the same unproven
+    //   fact, not a second strike.
+    //
+    // Sharing one map with `strikes` would have made the threshold read a mixture of proven and
+    // unproven observations. Entry shape: `{strikes, pendingSeq, tokenEstimate, recoveredTokenEstimate,
+    // failureCode}`, where a null `pendingSeq` means "nothing awaiting confirmation".
     deaths      : new Map()
 };
 
@@ -97,6 +109,13 @@ function resolveUndeliverableEvidence(generationId) {
         undeliverableEvidence.generationId = generationId;
         undeliverableEvidence.strikes.clear();
         undeliverableEvidence.suspects.clear();
+        // Deaths reset with the rest. A pending death is evidence about ONE geometry — this input
+        // killed the provider at THIS context width and batch shape — so carrying it across a
+        // generation change would let a strike earned under repaired coordinates fence a chunk the
+        // repair may have made deliverable. Every other map here clears for that reason; omitting
+        // this one made the death automaton the single piece of state that outlived its own
+        // authority coordinate.
+        undeliverableEvidence.deaths.clear();
         undeliverableEvidence.seq = 0;
     }
 
@@ -1540,10 +1559,19 @@ class VectorService extends Base {
 
                         // The carried prefix is a dispatched provider SUCCESS for those inputs, so
                         // their automaton entries reset here on the same provider-outcome rule as the
-                        // ordinary success path.
+                        // ordinary success path — INCLUDING a pending death, which an input that just
+                        // embedded has disproven about itself.
+                        //
+                        // Deliberately narrower than the ordinary success path in one respect: that
+                        // path also GRADUATES every other pending death, because a success proves the
+                        // provider was alive. A carried prefix proves the same thing, but graduating
+                        // here would convert deaths to strikes on a path that is mid-abort, so this arm
+                        // only clears what it disproves and leaves graduation to the next ordinary
+                        // success. Evidence is deferred, never dropped.
                         batchToEmbed.slice(0, err.completedTextCount || 0).forEach(chunk => {
                             evidence.strikes.delete(chunk.id);
                             evidence.suspects.delete(chunk.id);
+                            evidence.deaths.delete(chunk.id);
                         });
 
                         await persistCarriedPrefix(carried, err.completedTextCount, 'Yielded');
@@ -1565,11 +1593,15 @@ class VectorService extends Base {
                     let carryShrunkCount = 0;
 
                     if (embeddings === null && Number.isInteger(err?.completedTextCount) && err.completedTextCount > 0) {
-                        // Same provider-outcome reset as the yield arm: the completed prefix is a
-                        // dispatched provider success for those inputs, whatever the write does next.
+                        // Same provider-outcome reset as the yield arm, deaths included: the completed
+                        // prefix is a dispatched provider success for those inputs, whatever the write
+                        // does next, and an input that embedded has disproven its own pending death.
+                        // Graduation of OTHER pending deaths is likewise left to the next ordinary
+                        // success, for the reason stated on the yield arm.
                         batchToEmbed.slice(0, err.completedTextCount).forEach(chunk => {
                             evidence.strikes.delete(chunk.id);
                             evidence.suspects.delete(chunk.id);
+                            evidence.deaths.delete(chunk.id);
                         });
 
                         const persistedCount = await persistCarriedPrefix(err.embeddings || [], err.completedTextCount, 'Failed');

--- a/ai/services/knowledge-base/VectorService.mjs
+++ b/ai/services/knowledge-base/VectorService.mjs
@@ -1707,7 +1707,7 @@ class VectorService extends Base {
 
                         // Death-class RECORDING, and this is the only path a death reaches: the
                         // end-sweep branch above fires on circuit-open and timeout, so a death falls
-                        // through to here. Placing it there instead would have been dead code.
+                        // through to here.
                         //
                         // The timeout path graduates on its own evidence, because a fired deadline
                         // proves itself. A death splits in two, and the failure code is what tells
@@ -1759,11 +1759,6 @@ class VectorService extends Base {
                             // input left and this input is the one that was in flight. That is the whole
                             // "provider was alive AND this killed it" pair, at zero extra provider cost.
                             //
-                            // A recovery probe was the first design and it is unreachable in the case that
-                            // matters: once the suspect is the only chunk left, nothing further is
-                            // dispatched, no recovery is ever observed, and the counter freezes one strike
-                            // below threshold while the corpus never converges. Measured on the fixture —
-                            // strikes stuck at 1 across six sweeps with the chunk fenced by nothing.
                             if (isAcceptedThenDiedError(err)) {
                                 entry.strikes                += 1;
                                 entry.pendingSeq              = null;
@@ -1772,11 +1767,9 @@ class VectorService extends Base {
                                 entry.failureCode             = classifyEmbedFailureError(err);
                                 evidence.deaths.set(deathSuspect.id, entry);
 
-                                // Graduate HERE, on the failure path, because the case this ticket
-                                // exists for never reaches the success path: once the suspect is the
-                                // only chunk left, no dispatch after it succeeds, so a success-gated
-                                // graduation is unreachable exactly when it is needed. Measured — the
-                                // counter sat one strike below threshold across six sweeps.
+                                // Graduating here and not only on the success path: once the suspect is
+                                // the only chunk left, no later dispatch succeeds, so a success-gated
+                                // graduation is unreachable exactly when it is needed.
                                 await graduateDeathSuspect(deathSuspect.id, entry, suspectTokens);
                             }
                             // A REFUSED connection proves the provider was already dead, so it says nothing

--- a/ai/services/knowledge-base/helpers/embedFailureClassification.mjs
+++ b/ai/services/knowledge-base/helpers/embedFailureClassification.mjs
@@ -86,6 +86,22 @@ export const KB_VECTOR_EMBED_PROVIDER_CIRCUIT_OPEN = 'KB_VECTOR_EMBED_PROVIDER_C
 export const KB_VECTOR_EMBED_UNDELIVERABLE_AT_GEOMETRY = 'KB_VECTOR_EMBED_UNDELIVERABLE_AT_GEOMETRY';
 
 /**
+ * @summary Bounded cause for a transport that closed mid-request — the provider stopped answering
+ * rather than answering slowly.
+ *
+ * Deliberately NOT folded into {@link KB_VECTOR_EMBED_CONNECTION_REFUSED}, for the reason this whole
+ * map exists: a refused connection means nothing was listening when we dialled, while a reset or a
+ * half-closed socket means a live process accepted the request and then stopped existing. Those have
+ * different fixes — start the service, versus find out what killed it — and an operator who reads
+ * "refused" for a mid-request death looks at the wrong thing first.
+ *
+ * Both are nonetheless *death* for classification purposes ({@link isProviderDeathError}), because the
+ * question that disposition asks is "did the provider stop answering", not "at which instant".
+ * @type {String}
+ */
+export const KB_VECTOR_EMBED_TRANSPORT_CLOSED = 'KB_VECTOR_EMBED_TRANSPORT_CLOSED';
+
+/**
  * @summary The codes our OWN layers raise on the embed path, and the only ones allowed through
  * unchanged.
  *
@@ -120,6 +136,13 @@ const INTERNAL_EMBED_ERROR_CODES = Object.freeze(new Set([
 const PROVIDER_ERROR_CODE_MAP = Object.freeze({
     ABORT_ERR                        : 'KB_VECTOR_EMBED_ABORTED',
     ECONNREFUSED                     : 'KB_VECTOR_EMBED_CONNECTION_REFUSED',
+    // Three vocabularies for one event: the peer reset the connection (`ECONNRESET`), we wrote to a
+    // socket the peer had already closed (`EPIPE`), or undici observed the socket end mid-request
+    // (`UND_ERR_SOCKET`). All three mean a live process took the request and stopped existing, which
+    // is why they share a code and why that code is not `…CONNECTION_REFUSED`.
+    ECONNRESET                       : 'KB_VECTOR_EMBED_TRANSPORT_CLOSED',
+    EPIPE                            : 'KB_VECTOR_EMBED_TRANSPORT_CLOSED',
+    UND_ERR_SOCKET                   : 'KB_VECTOR_EMBED_TRANSPORT_CLOSED',
     EMBEDDING_CONTEXT_INSUFFICIENT   : 'KB_VECTOR_EMBED_CONTEXT_INSUFFICIENT',
     EMBEDDING_INPUT_TRUNCATED        : 'KB_VECTOR_EMBED_INPUT_TRUNCATED',
     EMBEDDING_MODEL_NOT_RESIDENT     : 'KB_VECTOR_EMBED_MODEL_NOT_RESIDENT',
@@ -185,6 +208,75 @@ export function classifyEmbedFailureError(error) {
     }
 
     return KB_VECTOR_EMBED_UNCLASSIFIED
+}
+
+/**
+ * @summary The bounded codes that mean the provider stopped answering, as opposed to answering slowly.
+ *
+ * **Module-private, and a `Set` rather than an exported list, for the reason `createTimeoutError.mjs`
+ * records about its own timeout set:** `Object.freeze` does not stop `.add()`, so an exported set is a
+ * shared mutable classifier any consumer could widen for every other consumer at once. Only the
+ * predicate crosses the boundary.
+ *
+ * **Disjoint from the timeout vocabulary, and that disjointness is load-bearing rather than tidy.** A
+ * timeout already has a disposition — the call-ceiling strike path graduates it — and a chunk that
+ * merely times out must never reach the death path, because the death path's evidence is weaker: it
+ * infers attributability from a later success rather than from a repeated deadline. Folding
+ * `ETIMEDOUT` in here would let the weaker evidence fence chunks the stronger path already handles,
+ * and a fixture built on a timeout stub would pass before and after the change while proving nothing.
+ * @type {Set<String>}
+ */
+const PROVIDER_DEATH_CODES = Object.freeze(new Set([
+    'KB_VECTOR_EMBED_CONNECTION_REFUSED',
+    KB_VECTOR_EMBED_TRANSPORT_CLOSED
+]));
+
+/**
+ * @summary Whether an embed failure means the provider stopped answering mid-flight or refused outright.
+ *
+ * Classified through {@link classifyEmbedFailureError} rather than by reading `error.code` directly, so
+ * a transport death wrapped by a stage-naming error still classifies — the same reason that walker
+ * exists. Reusing it also means the death vocabulary cannot drift from the map: a code absent from
+ * `PROVIDER_ERROR_CODE_MAP` classifies as unclassified and is therefore not death, which is the
+ * conservative direction.
+ *
+ * **Not a content claim, deliberately.** A dead provider says nothing about whether the bytes were
+ * valid, which is why `isolateFirstFailedBatch` refuses to bisect one into a poison disposition. This
+ * predicate answers only "did the provider stop answering"; whether that is *attributable to one
+ * input* is a separate question the caller answers with paired evidence.
+ *
+ * @param {*} error Error-like value whose `code` / `cause` chain should be classified.
+ * @returns {Boolean} `true` only for a classified provider-death code.
+ */
+export function isProviderDeathError(error) {
+    return PROVIDER_DEATH_CODES.has(classifyEmbedFailureError(error))
+}
+
+/**
+ * @summary Whether the provider ACCEPTED this request and then stopped existing, as opposed to refusing it.
+ *
+ * The distinction is load-bearing and it is free. `ECONNRESET` / `EPIPE` / `UND_ERR_SOCKET` all require an
+ * **established connection** before they can be observed — a peer cannot reset, or close under our write, a
+ * connection it never accepted. So this code carries its own liveness proof: the provider was answering at
+ * the moment the request left, and the request that was in flight is the one that was in flight.
+ * `KB_VECTOR_EMBED_CONNECTION_REFUSED` is the opposite — nothing was listening, which proves the provider
+ * was ALREADY dead and attributes nothing to the input.
+ *
+ * **Why this matters for the death-class graduation in `VectorService`.** Attribution needs
+ * "the provider was alive, and *this* input killed it". The obvious way to get the liveness half is to probe
+ * for recovery afterwards — but a probe costs a provider request per death, and it is *unreachable* once the
+ * suspect is the only chunk left in the corpus: nothing further is dispatched, so no recovery is ever
+ * observed and the automaton freezes one strike below its threshold. An accepted-then-died code supplies the
+ * same liveness half from the failure itself, at zero cost, on every sweep including the last.
+ *
+ * A single sample is still only a sample — a network blip can reset a connection without the input being at
+ * fault — which is why the caller's strike threshold, not this predicate, is what gates a graduation.
+ *
+ * @param {*} error Error-like value whose `code` / `cause` chain should be classified.
+ * @returns {Boolean} `true` only when the classified code means an established connection died mid-request.
+ */
+export function isAcceptedThenDiedError(error) {
+    return classifyEmbedFailureError(error) === KB_VECTOR_EMBED_TRANSPORT_CLOSED
 }
 
 /**

--- a/ai/services/knowledge-base/helpers/embedFailureClassification.mjs
+++ b/ai/services/knowledge-base/helpers/embedFailureClassification.mjs
@@ -262,15 +262,12 @@ export function isProviderDeathError(error) {
  * `KB_VECTOR_EMBED_CONNECTION_REFUSED` is the opposite — nothing was listening, which proves the provider
  * was ALREADY dead and attributes nothing to the input.
  *
- * **Why this matters for the death-class graduation in `VectorService`.** Attribution needs
- * "the provider was alive, and *this* input killed it". The obvious way to get the liveness half is to probe
- * for recovery afterwards — but a probe costs a provider request per death, and it is *unreachable* once the
- * suspect is the only chunk left in the corpus: nothing further is dispatched, so no recovery is ever
- * observed and the automaton freezes one strike below its threshold. An accepted-then-died code supplies the
- * same liveness half from the failure itself, at zero cost, on every sweep including the last.
+ * `VectorService`'s death-class graduation needs "the provider was alive, and *this* input killed it".
+ * This code supplies the liveness half from the failure itself, so no recovery probe is needed and the
+ * evidence is available even when the suspect is the last chunk in the corpus.
  *
- * A single sample is still only a sample — a network blip can reset a connection without the input being at
- * fault — which is why the caller's strike threshold, not this predicate, is what gates a graduation.
+ * A reset can also come from a network blip with the input blameless, so the caller's strike threshold —
+ * not this predicate — gates a graduation.
  *
  * @param {*} error Error-like value whose `code` / `cause` chain should be classified.
  * @returns {Boolean} `true` only when the classified code means an established connection died mid-request.

--- a/test/playwright/unit/ai/services/knowledge-base/VectorService.undeliverableGeometry.spec.mjs
+++ b/test/playwright/unit/ai/services/knowledge-base/VectorService.undeliverableGeometry.spec.mjs
@@ -322,10 +322,8 @@ test.describe('VectorService.embed — DEATH-class graduation through the produc
         // hashing `hashInputs`, so the stored keys are content hashes and never the fixture's
         // logical names. An id-literal assertion here failed on shape and masked the assertion
         // below, which is the one that carries the ticket.
-        // Aggregated across sweeps ON PURPOSE, and the earlier per-sweep form was wrong for a
-        // reason worth keeping: graduation is a ONE-TIME event, so `findLast(non-error)` reads the
-        // last SUCCESSFUL sweep — which, once the fix works, is a quiet sweep long after the
-        // graduating one. The assertion has to span the run the AC describes, not one frame of it.
+        // Aggregated across sweeps: graduation is a one-time event, so a per-sweep read lands on a
+        // quiet sweep long after the graduating one.
         const graduations = outcomes
             .filter(value => !(value instanceof Error))
             .flatMap(value => value?.deathGraduations ?? []);
@@ -343,9 +341,7 @@ test.describe('VectorService.embed — DEATH-class graduation through the produc
         expect(spy.storedByIds.size).toBe(2);
         expect([...spy.storedByIds.keys()]).not.toContain(killerId);
 
-        // THE discriminator, and the whole point of the ticket: the killer ends up fenced under
-        // *geometry*, never under a content verdict. Before this change it was fenced as content
-        // poison carrying a transport-death reason code — a false claim about the bytes.
+        // The discriminator: the killer ends up fenced under *geometry*, never a content verdict.
         const finalPoison = outcomes.findLast(value => !(value instanceof Error))?.poisonedChunks ?? [];
 
         expect(finalPoison.map(entry => entry.chunkId)).toContain(killerId);

--- a/test/playwright/unit/ai/services/knowledge-base/VectorService.undeliverableGeometry.spec.mjs
+++ b/test/playwright/unit/ai/services/knowledge-base/VectorService.undeliverableGeometry.spec.mjs
@@ -214,3 +214,142 @@ test.describe('VectorService.embed — undeliverable-at-geometry through the pro
         ).toBeGreaterThan(monsterDispatchesBefore);
     });
 });
+
+test.describe('VectorService.embed — DEATH-class graduation through the production path (#17336)', () => {
+    let SDK, KB_VectorService, KB_Config, TextEmbeddingService, ChromaManager;
+    let originalEmbedTexts, originalBatchConfig, originalGetCollection, originalResumeStateDir;
+    let tmpDir, corpusFile;
+
+    const isKillerText = text => text.includes('killer body');
+
+    const chunks = [
+        {id: 'd-a', type: 'guide', name: 'typical-a', hash: 'd'.repeat(64), content: 'typical body a'},
+        {id: 'd-k', type: 'guide', name: 'killer',    hash: 'e'.repeat(64), content: 'killer body'},
+        {id: 'd-b', type: 'guide', name: 'typical-b', hash: 'f'.repeat(64), content: 'typical body b'}
+    ];
+
+    const tenantContext = {tenantId: 't-death', repoSlug: 'org/death-class'};
+
+    test.beforeAll(async () => {
+        SDK                  = await import('../../../../../../ai/services.mjs');
+        KB_Config            = SDK.KB_Config;
+        TextEmbeddingService = SDK.Memory_TextEmbeddingService;
+
+        const VectorServiceModule = await import('../../../../../../ai/services/knowledge-base/VectorService.mjs');
+        const ChromaManagerModule = await import('../../../../../../ai/services/knowledge-base/ChromaManager.mjs');
+
+        KB_VectorService = VectorServiceModule.default;
+        ChromaManager    = ChromaManagerModule.default;
+
+        originalEmbedTexts     = TextEmbeddingService.embedTexts.bind(TextEmbeddingService);
+        originalGetCollection  = ChromaManager.getKnowledgeBaseCollection;
+        originalResumeStateDir = KB_VectorService.resumeStateDir;
+        originalBatchConfig    = {
+            batchSize : KB_Config.data.batchSize,
+            batchDelay: KB_Config.data.batchDelay,
+            maxRetries: KB_Config.data.maxRetries
+        };
+
+        tmpDir     = await fs.mkdtemp(path.join(os.tmpdir(), 'neo-kb-death-'));
+        corpusFile = path.join(tmpDir, 'corpus.jsonl');
+
+        await fs.writeFile(corpusFile, chunks.map(chunk => JSON.stringify(chunk)).join('\n') + '\n');
+
+        KB_VectorService.resumeStateDir = path.join(tmpDir, 'state');
+        Object.assign(KB_Config.data, {batchSize: 50, batchDelay: 0, maxRetries: 3});
+    });
+
+    test.afterAll(async () => {
+        TextEmbeddingService.embedTexts           = originalEmbedTexts;
+        ChromaManager.getKnowledgeBaseCollection  = originalGetCollection;
+        KB_VectorService.resumeStateDir           = originalResumeStateDir;
+        Object.assign(KB_Config.data, originalBatchConfig);
+
+        await fs.remove(tmpDir);
+    });
+
+    test('a killer chunk graduates on death-class evidence, and the corpus advances past it', async () => {
+        const spy              = createSpyCollection();
+        const dispatchedInputs = [];
+
+        ChromaManager.getKnowledgeBaseCollection = async () => spy;
+
+        // DEATH, not timeout — and the distinction is the red-proof. `ECONNRESET` is what a provider
+        // that accepted the request and then stopped existing looks like on the wire. A timeout stub
+        // here would exercise the pre-existing call-ceiling path and pass identically before and after
+        // this change.
+        TextEmbeddingService.embedTexts = async texts => {
+            dispatchedInputs.push([...texts]);
+
+            if (!texts.some(isKillerText)) {
+                return texts.map(() => new Array(384).fill(0))
+            }
+
+            const error = new Error('socket hang up');
+
+            error.code             = 'ECONNRESET';
+            error.failedTextOffset = 0;
+            error.failedTextCount  = texts.length;
+            throw error
+        };
+
+        // MULTIPLE sweeps, and the reason is architectural rather than incidental: the isolation gate
+        // is evaluated at BATCH ASSEMBLY, outside the retry loop, so suspicion recorded during a
+        // failure is only acted on by a later sweep. The retry loop re-dispatches the identical batch.
+        // The timeout automaton gets away with a single call because a timeout ENDS the sweep; a death
+        // falls through to the retry path, so a one-sweep fixture can only ever observe the abort.
+        const outcomes = [];
+
+        for (let sweep = 0; sweep < 8; sweep++) {
+            outcomes.push(await KB_VectorService.embed(corpusFile, {
+                deleteStale: false,
+                tenantContext
+            }).then(value => value, error => error));
+        }
+
+        const outcome = outcomes.findLast(value => !(value instanceof Error)) ?? outcomes.at(-1);
+
+        // Instrumentation first: what the sweep ACTUALLY dispatched, so the assertions below are
+        // calibrated against observed interleaving rather than predicted interleaving.
+        console.log('[#17336 fixture] dispatches:', JSON.stringify(dispatchedInputs.map(texts => texts.map(t => t.slice(0, 14)))));
+        outcomes.forEach((value, index) => console.log(`[#17336 fixture] sweep ${index}:`, value instanceof Error
+            ? `ERROR ${value.message}`
+            : JSON.stringify({e: value?.embedded, grad: value?.deathGraduations, prog: value?.deathStrikeProgress, poison: (value?.poisonedChunks||[]).map(x=>({id:(x.chunkId||'').slice(0,8), r:x.reasonCode}))})));
+        console.log('[#17336 fixture] stored ids:', JSON.stringify([...spy.storedByIds.keys()]));
+
+        // The corpus advances past the killer: both typicals land. Asserted on count plus the
+        // killer's ABSENCE rather than on two literal ids — production derives a chunk id by
+        // hashing `hashInputs`, so the stored keys are content hashes and never the fixture's
+        // logical names. An id-literal assertion here failed on shape and masked the assertion
+        // below, which is the one that carries the ticket.
+        // Aggregated across sweeps ON PURPOSE, and the earlier per-sweep form was wrong for a
+        // reason worth keeping: graduation is a ONE-TIME event, so `findLast(non-error)` reads the
+        // last SUCCESSFUL sweep — which, once the fix works, is a quiet sweep long after the
+        // graduating one. The assertion has to span the run the AC describes, not one frame of it.
+        const graduations = outcomes
+            .filter(value => !(value instanceof Error))
+            .flatMap(value => value?.deathGraduations ?? []);
+
+        // Exactly once, on death-class evidence, naming the code that proved liveness.
+        expect(graduations).toHaveLength(1);
+        expect(graduations[0].failureCode).toBe('KB_VECTOR_EMBED_TRANSPORT_CLOSED');
+        expect(graduations[0].attempts).toBeGreaterThanOrEqual(2);
+
+        const killerId = graduations[0].chunkId;
+
+        // The corpus advances past the killer: both typicals land, and the killer is not among
+        // them. Asserted on count plus the killer's absence rather than on two literal ids —
+        // production derives a chunk id by hashing `hashInputs`, so stored keys are content hashes.
+        expect(spy.storedByIds.size).toBe(2);
+        expect([...spy.storedByIds.keys()]).not.toContain(killerId);
+
+        // THE discriminator, and the whole point of the ticket: the killer ends up fenced under
+        // *geometry*, never under a content verdict. Before this change it was fenced as content
+        // poison carrying a transport-death reason code — a false claim about the bytes.
+        const finalPoison = outcomes.findLast(value => !(value instanceof Error))?.poisonedChunks ?? [];
+
+        expect(finalPoison.map(entry => entry.chunkId)).toContain(killerId);
+        expect(finalPoison.find(entry => entry.chunkId === killerId).reasonCode)
+            .toBe('KB_VECTOR_EMBED_UNDELIVERABLE_AT_GEOMETRY');
+    });
+});

--- a/test/playwright/unit/ai/services/knowledge-base/VectorService.undeliverableGeometry.spec.mjs
+++ b/test/playwright/unit/ai/services/knowledge-base/VectorService.undeliverableGeometry.spec.mjs
@@ -348,4 +348,127 @@ test.describe('VectorService.embed — DEATH-class graduation through the produc
         expect(finalPoison.find(entry => entry.chunkId === killerId).reasonCode)
             .toBe('KB_VECTOR_EMBED_UNDELIVERABLE_AT_GEOMETRY');
     });
+
+    /**
+     * @summary Moves the effective call ceiling, which is part of the poison generation coordinate.
+     * @param {Number} deltaMs Offset from the process default.
+     * @returns {void}
+     */
+    function shiftGeneration(deltaMs) {
+        const Memory_Config = SDK.Memory_Config,
+              base          = Memory_Config.embeddingProvider === 'ollama'
+                  ? Memory_Config.ollama.embeddingTimeoutMs
+                  : Memory_Config.openAiCompatible.batchEmbeddingTimeoutMs;
+
+        if (Memory_Config.embeddingProvider === 'ollama') {
+            Memory_Config.ollama.embeddingTimeoutMs = Number(base) + deltaMs
+        } else {
+            Memory_Config.openAiCompatible.batchEmbeddingTimeoutMs = Number(base) + deltaMs
+        }
+    }
+
+    /**
+     * @summary Sweeps until a death graduation is observed, or the cap is reached.
+     * @param {Number} [maxSweeps=8]
+     * @returns {Promise<Object[]>} Graduation receipts observed across the sweeps.
+     */
+    async function sweepUntilGraduation(maxSweeps = 16) {
+        const seen = [];
+
+        for (let sweep = 0; sweep < maxSweeps && seen.length === 0; sweep++) {
+            const value = await KB_VectorService.embed(corpusFile, {deleteStale: false, tenantContext})
+                .then(result => result, error => error);
+
+
+            if (!(value instanceof Error)) {
+                seen.push(...(value.deathGraduations ?? []))
+            }
+        }
+
+        return seen
+    }
+
+    /*
+        // Asserted by making the boundary the ONLY thing that changes the answer.
+        //
+        // The tempting shape — graduate under A, graduate under B, compare `attempts` — is not
+        // constructible here: graduation can complete inside a single sweep across its retries, and a
+        // sweep that ends on the provider error carries no summary, so its receipt is unobservable.
+        // Measured, not assumed: instrumenting it showed the disposition re-minted under the new
+        // generation during an erroring sweep, which is correct behaviour that the assertion could
+        // not see.
+        //
+        // So instead the killer STOPS killing after the boundary. No new death can then mask a
+        // carried one, and `deathStrikeProgress` must be empty. With the strike carried across the
+        // generation it still lists the chunk, which is the whole leak in one field.
+     */
+    test('NEGATIVE CONTROL: a strike does not survive the generation that authorised it', async () => {
+        // Its own tenant, so the durable poison scope cannot carry in from a sibling arm. This file
+        // is `mode: 'serial'` over a MODULE-level evidence map and an on-disk store keyed by tenant —
+        // sharing one scope made arm order part of the contract, which is not a contract anyone
+        // declared. Raising sweep budgets papers over that; scoping removes it.
+        const scoped = {tenantId: 't-death-generation', repoSlug: 'org/death-generation'};
+        const spy    = createSpyCollection();
+
+        ChromaManager.getKnowledgeBaseCollection = async () => spy;
+
+        let lethal = true;
+
+        TextEmbeddingService.embedTexts = async texts => {
+            if (!lethal || !texts.some(isKillerText)) {
+                return texts.map(() => new Array(384).fill(0))
+            }
+
+            const error = new Error('socket hang up');
+
+            error.code             = 'ECONNRESET';
+            error.failedTextOffset = 0;
+            error.failedTextCount  = texts.length;
+            throw error
+        };
+
+        shiftGeneration(480_000);
+
+        // Earn a real strike, and stop BELOW the threshold so nothing graduates and the evidence is
+        // still transient rather than durable.
+        let earned = null;
+
+        for (let sweep = 0; sweep < 8 && earned === null; sweep++) {
+            const value = await KB_VectorService.embed(corpusFile, {deleteStale: false, tenantContext: scoped})
+                .then(result => result, error => error);
+
+            if (!(value instanceof Error)) {
+                earned = (value.deathStrikeProgress ?? []).find(entry => entry.strikes > 0) ?? null
+            }
+        }
+
+        expect(earned, 'a strike must exist before the boundary or this control proves nothing').not.toBeNull();
+
+        // Cross the boundary, and remove the cause. Any entry still listed after this is carried
+        // evidence, because nothing on this side of the boundary can create one.
+        shiftGeneration(600_000);
+        lethal = false;
+
+        const after = await KB_VectorService.embed(corpusFile, {deleteStale: false, tenantContext: scoped})
+            .then(result => result, error => error);
+
+        expect(after, 'with the killer no longer lethal the sweep must complete').not.toBeInstanceOf(Error);
+        expect(after.deathStrikeProgress, 'a carried strike would still be listed here').toEqual([]);
+    });
+
+    /*
+     * OUTSTANDING — the second control @neo-gpt asked for (a carried provider success breaking a
+     * chunk's death chain) is NOT here, and the omission is deliberate rather than forgotten.
+     *
+     * The production code is fixed: both carry arms now delete the chunk's death entry alongside its
+     * strike and suspicion. What is missing is a production-path assertion, and four fixture shapes
+     * failed on the same wall: a PENDING death is only recorded on a sweep that ends on the provider
+     * error, and an erroring sweep returns no summary — so the state the control needs to observe has
+     * no observable. A discriminating pair (graduate-vs-not, keyed on whether a carry intervenes) was
+     * the closest attempt and did not land either.
+     *
+     * Rather than ship an arm that passes without exercising the reset, this is stated and returned to
+     * the reviewer, in the review response rather than here — a pull-request number in a durable
+     * comment is exactly what `check-ticket-archaeology` exists to keep out.
+     */
 });

--- a/test/playwright/unit/ai/services/knowledge-base/VectorService.undeliverableGeometry.spec.mjs
+++ b/test/playwright/unit/ai/services/knowledge-base/VectorService.undeliverableGeometry.spec.mjs
@@ -456,19 +456,125 @@ test.describe('VectorService.embed — DEATH-class graduation through the produc
         expect(after.deathStrikeProgress, 'a carried strike would still be listed here').toEqual([]);
     });
 
-    /*
-     * OUTSTANDING — the second control @neo-gpt asked for (a carried provider success breaking a
-     * chunk's death chain) is NOT here, and the omission is deliberate rather than forgotten.
+    /**
+     * @summary Drives the killer to a PENDING death, then through one carried-success arm.
      *
-     * The production code is fixed: both carry arms now delete the chunk's death entry alongside its
-     * strike and suspicion. What is missing is a production-path assertion, and four fixture shapes
-     * failed on the same wall: a PENDING death is only recorded on a sweep that ends on the provider
-     * error, and an erroring sweep returns no summary — so the state the control needs to observe has
-     * no observable. A discriminating pair (graduate-vs-not, keyed on whether a carry intervenes) was
-     * the closest attempt and did not land either.
+     * The shape is @neo-gpt's, and the piece I was missing is the remainder: a sweep that ends on the
+     * provider error returns no summary, so every earlier attempt had nothing to assert on. A yield
+     * `break`s gracefully and a failure-carry whose remainder then SUCCEEDS completes the sweep — both
+     * return the census, which is where `deathStrikeProgress` lives.
      *
-     * Rather than ship an arm that passes without exercising the reset, this is stated and returned to
-     * the reviewer, in the review response rather than here — a pull-request number in a durable
-     * comment is exactly what `check-ticket-archaeology` exists to keep out.
+     * @param {String} tenantId Own scope: the poison store is keyed by tenant, and sharing one made
+     *     arm order part of a contract nobody declared.
+     * @param {String} arm `'yield'` or `'failure-carry'`.
+     * @returns {Promise<Object>} The final sweep's summary.
      */
+    async function carryArm(tenantId, arm) {
+        const spy    = createSpyCollection(),
+              scoped = {tenantId, repoSlug: 'org/death-carry'},
+              SDKMem = await import('../../../../../../ai/services/memory-core/TextEmbeddingService.mjs');
+
+        ChromaManager.getKnowledgeBaseCollection = async () => spy;
+
+        let phase = 'refuse';
+
+        TextEmbeddingService.embedTexts = async texts => {
+            if (!texts.some(isKillerText)) {
+                return texts.map(() => new Array(384).fill(0))
+            }
+
+            // A REFUSED connection: the provider was already down, so this input is unproven and the
+            // death is recorded PENDING rather than as a strike.
+            if (phase === 'refuse') {
+                const error = new Error('connect ECONNREFUSED 127.0.0.1:11434');
+
+                error.code             = 'ECONNREFUSED';
+                error.failedTextOffset = 0;
+                error.failedTextCount  = texts.length;
+                throw error
+            }
+
+            const vectors = texts.map(() => new Array(384).fill(0));
+
+            if (phase === 'yield') {
+                // The lease-yield arm: a graceful stop carrying its completed prefix. The sweep breaks
+                // out and returns, which is what makes the census observable at all.
+                const error = new Error('openAiCompatible batch embedding yielded the heavy-maintenance lease');
+
+                error.code                = SDKMem.EMBEDDING_BATCH_YIELDED_CODE;
+                error.completedChunkCount = 1;
+                error.totalChunkCount     = 2;
+                error.completedTextCount  = texts.length;
+                error.embeddings          = vectors;
+                throw error
+            }
+
+            if (phase === 'failure-carry') {
+                // The failure-carry arm: the prefix embedded, then the request failed. The phase is
+                // deliberately NOT advanced — an earlier version flipped to a healthy provider here,
+                // and the killer's death was then cleared by the ORDINARY success path rather than by
+                // this arm's reset. Deleting the failure-arm reset left that fixture green, which is
+                // precisely the vacuity the reviewer's per-arm mutation requirement exists to catch.
+                // NOT a death code. `ECONNRESET` would take the accepted-then-died branch, earn an
+                // immediate strike, graduate, and delete the entry itself — so the carrier would be
+                // doing the cleanup and this arm would pass with its own reset removed. A transient
+                // write failure carries a prefix without saying anything about the provider's life.
+                const error = new Error('the carried prefix landed, the write did not');
+
+                error.code               = 'KB_VECTOR_WRITE_RETRY_EXHAUSTED';
+                error.completedTextCount = texts.length;
+                error.embeddings         = vectors;
+                error.failedTextOffset   = 0;
+                error.failedTextCount    = texts.length;
+                throw error
+            }
+
+            return vectors
+        };
+
+        const sweep = () => KB_VectorService.embed(corpusFile, {deleteStale: false, tenantContext: scoped})
+            .then(result => result, error => error);
+
+        // Multi-input failure, then isolation, then a single-input refusal: the pending death.
+        for (let i = 0; i < 4; i++) await sweep();
+
+        phase = arm;
+
+        let last = await sweep();
+
+        for (let i = 0; i < 3 && last instanceof Error; i++) last = await sweep();
+
+        return last
+    }
+
+    test('NEGATIVE CONTROL: a YIELD-carried provider success breaks that chunk\'s death chain', async () => {
+        shiftGeneration(720_000);
+
+        const summary = await carryArm('t-carry-yield', 'yield');
+
+        expect(summary, 'a yield is a graceful stop, so the sweep returns its census').not.toBeInstanceOf(Error);
+        expect(summary.deathStrikeProgress, 'the carried prefix disproved its own pending death').toEqual([]);
+    });
+
+    test('SMOKE ONLY — a failure-carried prefix completes the sweep with no death evidence left', async () => {
+        // ⚠️ NOT a negative control, and labelled so deliberately. The per-arm mutation check the
+        // reviewer requires does NOT isolate this arm: deleting the failure-carry `deaths.delete`
+        // leaves this green, so it does not prove that reset. Three carriers were ruled out —
+        // `ECONNRESET` (a death code, so graduation deletes the entry itself and the carrier does the
+        // cleanup), a phase-advanced healthy provider (the ORDINARY success path clears it), and a
+        // non-death transient write failure (still green). What remains unexplained is which path
+        // clears the entry in the third case, and until that is known this arm asserts an end state
+        // rather than a mechanism.
+        //
+        // The sibling YIELD arm above IS mutation-verified: removing its reset turns it, and only it,
+        // red. Kept as smoke coverage because a non-death carry completing the sweep is worth holding;
+        // renamed because calling it a control would be the exact overclaim that got a sibling PR
+        // dropped today.
+        shiftGeneration(840_000);
+
+        const summary = await carryArm('t-carry-failure', 'failure-carry');
+
+        expect(summary).not.toBeInstanceOf(Error);
+        expect(summary.deathStrikeProgress).toEqual([]);
+    });
 });

--- a/test/playwright/unit/ai/services/knowledge-base/VectorService.undeliverableGeometry.spec.mjs
+++ b/test/playwright/unit/ai/services/knowledge-base/VectorService.undeliverableGeometry.spec.mjs
@@ -556,25 +556,84 @@ test.describe('VectorService.embed — DEATH-class graduation through the produc
         expect(summary.deathStrikeProgress, 'the carried prefix disproved its own pending death').toEqual([]);
     });
 
-    test('SMOKE ONLY — a failure-carried prefix completes the sweep with no death evidence left', async () => {
-        // ⚠️ NOT a negative control, and labelled so deliberately. The per-arm mutation check the
-        // reviewer requires does NOT isolate this arm: deleting the failure-carry `deaths.delete`
-        // leaves this green, so it does not prove that reset. Three carriers were ruled out —
-        // `ECONNRESET` (a death code, so graduation deletes the entry itself and the carrier does the
-        // cleanup), a phase-advanced healthy provider (the ORDINARY success path clears it), and a
-        // non-death transient write failure (still green). What remains unexplained is which path
-        // clears the entry in the third case, and until that is known this arm asserts an end state
-        // rather than a mechanism.
+    test('NEGATIVE CONTROL: a FAILURE-carried prefix breaks the death chain on its own reset', async () => {
+        // @neo-gpt's corrected shape, after his falsifier explained why three of my fixtures had a
+        // green deletion mutant: the carried prefix claimed the WHOLE request, which shrank the retry
+        // to an empty one, and that empty success walked the pending observation 0 -> 1 -> 2 until
+        // `graduateDeathSuspect` deleted it at threshold 2. Independent graduation was doing the
+        // cleanup every time, so removing this arm's reset changed nothing.
         //
-        // The sibling YIELD arm above IS mutation-verified: removing its reset turns it, and only it,
-        // red. Kept as smoke coverage because a non-death carry completing the sweep is worth holding;
-        // renamed because calling it a control would be the exact overclaim that got a sibling PR
-        // dropped today.
+        // The fix is a fresh pending-only state that cannot reach the threshold: an arm-private
+        // two-chunk corpus, one seeding sweep narrow enough that no healthy input runs, and a carry
+        // covering exactly ONE input so the remainder is real work rather than an empty request.
+        const armCorpus = path.join(tmpDir, 'carry-corpus.jsonl'),
+              armChunks = [
+                  {id: 'c-k', type: 'guide', name: 'killer',  hash: '1'.repeat(64), content: 'killer body'},
+                  {id: 'c-h', type: 'guide', name: 'healthy', hash: '2'.repeat(64), content: 'healthy body'}
+              ];
+
+        await fs.writeFile(armCorpus, armChunks.map(chunk => JSON.stringify(chunk)).join('\n') + '\n');
+
+        const spy    = createSpyCollection(),
+              scoped = {tenantId: 't-carry-failure', repoSlug: 'org/death-carry'};
+
+        ChromaManager.getKnowledgeBaseCollection = async () => spy;
         shiftGeneration(840_000);
 
-        const summary = await carryArm('t-carry-failure', 'failure-carry');
+        let phase = 'refuse';
 
-        expect(summary).not.toBeInstanceOf(Error);
-        expect(summary.deathStrikeProgress).toEqual([]);
+        TextEmbeddingService.embedTexts = async texts => {
+            if (!texts.some(isKillerText)) {
+                return texts.map(() => new Array(384).fill(0))
+            }
+
+            if (phase === 'refuse') {
+                // Provider already down: the death is recorded PENDING, strikes 0. Nothing is proven
+                // about this input yet, which is the state the reset has to be shown to clear.
+                const error = new Error('connect ECONNREFUSED 127.0.0.1:11434');
+
+                error.code             = 'ECONNREFUSED';
+                error.failedTextOffset = 0;
+                error.failedTextCount  = texts.length;
+                throw error
+            }
+
+            // NOT a death code — `ECONNRESET` would take the accepted-then-died branch and delete the
+            // entry via graduation. And exactly ONE completed input, so the remainder is the healthy
+            // chunk rather than an empty request whose success would graduate the pending observation.
+            const error = new Error('the carried prefix landed, the write did not');
+
+            error.code               = 'KB_VECTOR_WRITE_RETRY_EXHAUSTED';
+            error.completedTextCount = 1;
+            error.embeddings         = [new Array(384).fill(0)];
+            error.failedTextOffset   = 0;
+            error.failedTextCount    = texts.length;
+            throw error
+        };
+
+        const sweep = () => KB_VectorService.embed(armCorpus, {deleteStale: false, tenantContext: scoped})
+            .then(result => result, error => error);
+
+        try {
+            // Narrow enough that the killer is dispatched alone and no healthy input has run yet.
+            Object.assign(KB_Config.data, {batchSize: 1, maxRetries: 1});
+
+            const seeded = await sweep();
+
+            expect(seeded, 'the seeding sweep ends on the refusal').toBeInstanceOf(Error);
+
+            // Suspicion now isolates the killer, so the first dispatch is single-input.
+            Object.assign(KB_Config.data, {batchSize: 2, maxRetries: 2});
+            phase = 'failure-carry';
+
+            let summary = await sweep();
+
+            for (let i = 0; i < 3 && summary instanceof Error; i++) summary = await sweep();
+
+            expect(summary, 'the healthy stride completes the sweep and returns its census').not.toBeInstanceOf(Error);
+            expect(summary.deathStrikeProgress, 'the failure-carry reset cleared the pending death').toEqual([]);
+        } finally {
+            Object.assign(KB_Config.data, {batchSize: 50, maxRetries: 3});
+        }
     });
 });

--- a/test/playwright/unit/ai/services/knowledge-base/embedFailureClassification.spec.mjs
+++ b/test/playwright/unit/ai/services/knowledge-base/embedFailureClassification.spec.mjs
@@ -16,7 +16,9 @@ import {
     classifyEmbedFailureCode,
     classifyEmbedFailureError,
     classifyEmbedResidencyDisposition,
-    isEmbedFailureCode
+    isEmbedFailureCode,
+    KB_VECTOR_EMBED_TRANSPORT_CLOSED,
+    isProviderDeathError
 } from '../../../../../../ai/services/knowledge-base/helpers/embedFailureClassification.mjs';
 import {normalizeTenantRepoCheckpointState}
     from '../../../../../../ai/daemons/orchestrator/services/tenantRepoCheckpointValidity.mjs';
@@ -527,5 +529,64 @@ test.describe('classifyEmbedDisposition (retry-or-discard)', () => {
         expect(classifyEmbedDisposition('')).toBe(EMBED_DISPOSITION.deferrable);
         expect(classifyEmbedDisposition('constructor')).toBe(EMBED_DISPOSITION.deferrable);
         expect(classifyEmbedDisposition({code: 'KB_TENANT_SPOOF_REJECTED'})).toBe(EMBED_DISPOSITION.deferrable);
+    });
+});
+
+test.describe('isProviderDeathError (#17336)', () => {
+    test('the three transport-death vocabularies all classify, and refusal stays its own code', () => {
+        // One event, three vocabularies: the peer reset us, we wrote to an already-closed socket, or
+        // undici saw the socket end mid-request. All are death; only the pre-connect refusal is
+        // `…CONNECTION_REFUSED`, because "nothing was listening" and "it died holding my request" have
+        // different first things to look at.
+        expect(isProviderDeathError({code: 'ECONNRESET'})).toBe(true);
+        expect(isProviderDeathError({code: 'EPIPE'})).toBe(true);
+        expect(isProviderDeathError({code: 'UND_ERR_SOCKET'})).toBe(true);
+        expect(isProviderDeathError({code: 'ECONNREFUSED'})).toBe(true);
+
+        expect(classifyEmbedFailureCode('ECONNRESET')).toBe(KB_VECTOR_EMBED_TRANSPORT_CLOSED);
+        expect(classifyEmbedFailureCode('ECONNREFUSED')).toBe('KB_VECTOR_EMBED_CONNECTION_REFUSED');
+        expect(classifyEmbedFailureCode('ECONNRESET')).not.toBe(classifyEmbedFailureCode('ECONNREFUSED'));
+    });
+
+    test('DISJOINT from the timeout vocabulary — the control the death path depends on', () => {
+        // Load-bearing, not tidy. A timeout already has a disposition: the call-ceiling strike path
+        // graduates it on self-proving evidence. A death is self-proving only when the provider
+        // ACCEPTED the request before dying, which a timeout never establishes — so a timeout code
+        // must never enter the death set. If this arm goes green with one added, a fixture built on
+        // a timeout stub would pass before and after the change and prove nothing, which is exactly
+        // the trap the red-proof exists to close.
+        for (const code of ['ETIMEDOUT', 'ESOCKETTIMEDOUT', 'PROVIDER_TIMEOUT', 'OPENAI_COMPATIBLE_REQUEST_TIMEOUT', 'EMBEDDING_PROBE_TIMEOUT']) {
+            expect(isProviderDeathError({code}), `${code} must not classify as provider death`).toBe(false);
+        }
+
+        // And the adjacent non-death faults stay out too: an abort is caller-owned, an open circuit
+        // never dispatched, and an oversize refusal is an answer rather than a silence.
+        for (const code of ['ABORT_ERR', 'EMBEDDING_INPUT_TRUNCATED', 'EMBEDDING_CONTEXT_INSUFFICIENT']) {
+            expect(isProviderDeathError({code}), `${code} must not classify as provider death`).toBe(false);
+        }
+    });
+
+    test('classifies through a WRAPPED cause, which is the shape a real death arrives in', () => {
+        // The reason this predicate goes through `classifyEmbedFailureError` instead of reading
+        // `error.code`: a transport death routinely arrives wrapped by a stage-naming error, and
+        // reading only the outer code would report the sentinel and silently skip the death path.
+        expect(isProviderDeathError(new Error('embedding stage failed', {cause: {code: 'ECONNRESET'}}))).toBe(true);
+        expect(isProviderDeathError({code: 'KB_STAGE', cause: {code: 'UND_ERR_SOCKET'}})).toBe(true);
+
+        // Depth and cycle safety are inherited from the walker rather than re-implemented.
+        const cyclic = {code: 'KB_STAGE'};
+        cyclic.cause = cyclic;
+        expect(isProviderDeathError(cyclic)).toBe(false);
+    });
+
+    test('total over hostile and absent input, and an unmapped code is NOT death', () => {
+        // Conservative direction on purpose: a code absent from the map classifies as unclassified and
+        // is therefore not death, so an unknown transport error cannot start fencing chunks.
+        expect(isProviderDeathError(undefined)).toBe(false);
+        expect(isProviderDeathError(null)).toBe(false);
+        expect(isProviderDeathError({})).toBe(false);
+        expect(isProviderDeathError({code: 'constructor'})).toBe(false);
+        expect(isProviderDeathError({code: 'ESOMETHINGNEW'})).toBe(false);
+        expect(isProviderDeathError({code: KB_VECTOR_EMBED_UNCLASSIFIED})).toBe(false);
     });
 });


### PR DESCRIPTION
Resolves #17336

> 🌿 The lane can still die on a chunk — it can no longer call the chunk guilty.

Evidence: L3 (in-process fixture driving `VectorService.embed` through the production path with a stubbed provider; every AC is decidable without a live engine) → L3 required. Residual: none.

## The defect was not the hole the ticket described

An OOM-killed embedding provider does not time out, so the timeout-gated graduation never fires. The ticket originally claimed the chunk is then "re-offered forever". **Measured, it is not** — the isolation walk fences it at the next sweep as **content poison**, carrying a transport-death reason code.

That is worse than a hole. `createPoisonEntry` stamps the failure's own classified code onto the entry, so the store ends up holding a *poison* verdict whose reason names a socket failure — a false claim about the bytes, and precisely the outcome the geometry/content distinction exists to prevent. The ticket's title survives (it never reaches `KB_VECTOR_EMBED_UNDELIVERABLE_AT_GEOMETRY`); its stated harm did not, and the body records the correction.

**Why the paired control does not save it.** The isolation walk takes real care here: it issues a *fresh* control immediately before attributing, because "the earlier control success is not enough". That protects the **remainder**, which is what the surrounding contract claims. It does not protect the **trigger** — for a chunk that kills the provider the trace is always *control succeeds → suspect dispatched → provider dies*, so the strongest exculpatory check available is the one that convicts.

## Two halves, and they must land together

1. **The poison-isolation guard gains a provider-death term.** A death during isolation now throws instead of attributing, so no poison entry can be stamped with a transport code. Placed outside the guard's per-depth cause walk deliberately — the classifier runs its own bounded chain walk, so calling it per depth would re-walk from every link.
2. **The death-class graduation lands with it.** The guard alone is a regression: today the chunk is at least fenced, so the corpus advances. Forbid death-induced poison without providing a geometry disposition and it is fenced by *nothing*.

## The liveness evidence is free — this supersedes the ticket's first prescription

`ECONNRESET` / `EPIPE` / `UND_ERR_SOCKET` all classify as transport-closed, and every one **requires an established connection**: a peer cannot reset, or close under our write, a connection it never accepted. So the code already proves the provider was answering when the request left *and* that this input was in flight — the whole "alive **and** this killed it" pair, at **zero extra provider requests**. A refused connection proves the opposite and attributes nothing, so it stays an unattributable pending observation.

**What that replaces.** The first design probed for recovery after each death. It is unreachable in the case the ticket exists for: once the suspect is the only chunk left, nothing is dispatched after it, no success is ever observed, and the counter freezes one strike below threshold. Measured — strikes stuck at `1` across six sweeps with the chunk fenced by nothing. It also cost one provider request per death, which is not free on a CPU-saturated embedding lane.

**A second gap the fixture exposed.** With strikes finally accruing, graduation still did not fire: the check lived inside the *success* path and skipped entries whose pending observation had already converted. So it was unreachable for exactly the same reason the probe was. Graduation is now one closure called from **both** provider outcomes — a closure rather than two inline copies, because the receipt is what an operator reads and two sites would drift on its shape.

**Stated limit, unchanged.** Accepting a request proves *liveness*, not *capacity at the suspect's size*. That is sufficient for a disposition that says **geometry**, and only because the poison generation derives from the resolved admission band — repair the geometry, the band moves, the generation changes, everything fenced under the old one is re-offered. A single reset is also only a sample, so the strike **threshold**, not the predicate, gates a graduation.

## Test Evidence

`709 passed` — the full `knowledge-base` unit suite, run before the commit, after it, and again after rebasing onto `origin/dev`.

The `#17336` fixture drives multiple sweeps through the production `embed` path with a provider stub that dies on the killer text, and asserts:

- the killer graduates **exactly once**, on `KB_VECTOR_EMBED_TRANSPORT_CLOSED`, at `attempts >= 2`;
- its final disposition is `KB_VECTOR_EMBED_UNDELIVERABLE_AT_GEOMETRY` — **not** a content verdict, which is the whole point;
- both healthy chunks land and the killer is not among the stored ids;
- graduation is reachable **with the killer as the last unembedded work**, which is the case a corpus-with-surviving-work fixture cannot witness.

Two assertion corrections worth naming, because both were mine and both would have read as green:

- the id assertion compared against fixture names, but production derives ids by hashing `hashInputs`, so it tripped on shape and masked the assertion that carried the ticket;
- the graduation assertion used `findLast(non-error)`, which — once the fix worked — pointed at a *quiet* sweep long after the graduating one. Graduation is a one-time event, so it has to be asserted across the run the AC describes rather than one frame of it.

The classifier spec pins that timeout codes must **never** enter the death set: a death is self-proving only when the provider accepted the request first, and a fixture built on a timeout stub would pass before and after this change while proving nothing.

## Deltas from ticket

Three, and the first is a replaced mechanism rather than a refinement. All three are recorded on #17336 as a third re-census, so the ticket and this PR agree rather than the ticket carrying a superseded prescription.

| ticket said | shipped | why |
|---|---|---|
| Convert a pending death to a strike once **a later dispatch succeeds** (recovery probe). | Strike immediately when the failure classifies as **accepted-then-died**; a refused connection stays pending. | The probe is unreachable once the suspect is the last chunk — strikes froze at `1` across six sweeps, measured — and cost a provider request per death on a saturated lane. The failure code already carries the liveness proof. |
| Graduate at threshold (single site, on the success path). | Graduate from **both** provider outcomes, via one shared closure. | A success-gated graduation is unreachable for the same reason the probe was. |
| Receipt records "the recovering input's size alongside the suspect's". | Records the suspect's own size as the served size on the failure path. | Accepting the request *is* the observation, so the served input and the suspect are the same input. The field keeps its meaning: tokens the provider demonstrably served. |

Also dropped from an earlier revision of the ticket, before any code was written: a claimed second defect that the single-input isolation path lacks the bisection path's fresh paired control. Reading the function's opening showed the control is issued **up front**, so on that path it is one request old at attribution — already fresh. The asymmetry is justified; nothing to fix.

## Post-Merge Validation

Nothing here blocks merge — the ACs are decidable in-process and are decided. What only a live plane can show:

- **A real death graduating to geometry.** The fixture stubs the provider, so it proves the automaton, not that a genuine OOM kill classifies as transport-closed rather than refused on a specific engine. On a plane where a death occurs, `deathGraduations` in the ingestion summary and a `KB_VECTOR_EMBED_UNDELIVERABLE_AT_GEOMETRY` disposition are the two observations to read. Note the live trigger is currently **discharged** — admission now refuses the oversized chunk before dispatch — so this may not be observable until a different geometry produces an in-band killer.
- **No pre-existing content-poison entries are rewritten.** This change stops *new* death-caused poison entries; it does not migrate entries already written under the old behaviour. Those release when the embedding generation changes, by the existing reversibility path. If a plane shows a stale poison entry whose `reasonCode` names a transport failure, that is residue rather than a regression of this change.

Failure of either observation creates a new ticket rather than reopening this one.

## Not in this PR

- Flipping `reconciliationEnabled`, `staleStrategy`'s destructive branch, batch sizing, and the deployment's memory ceiling — all scoped out on the ticket.
- The naming of the shared `undeliverableTimeoutStrikes` threshold, which now gates death evidence too. Renaming a config leaf is an env-var contract change and does not belong in a behaviour fix.

## Self-identification

Authored by **Vega** (Claude Opus 5, Claude Code), a Neo maintainer agent.

Origin Session ID: 8cbd588b-be06-4a56-9997-1058f2a3a07b

Retrieval Hint: `query_raw_memories("accepted-then-died carries its own liveness proof, recovery probe unreachable when the suspect is the last chunk, death graduates to geometry not content poison")`
