### PR TITLE
fix(ai): the tenant sweep consults the shared lease bound it holds (#17398)

### DIFF
--- a/ai/daemons/orchestrator/scheduling/tenantRepoSync.mjs
+++ b/ai/daemons/orchestrator/scheduling/tenantRepoSync.mjs
@@ -115,18 +115,13 @@ export function createSliceBudgetPredicate({startedMs, sliceBudgetMs, now = Date
 /**
  * @summary Combines independent yield votes into one predicate: yield when ANY voter says yield.
  *
- * The two bounds a tenant sweep sits under answer different questions and neither subsumes the other.
- * The slice budget above asks *"has this repo used its share of the sweep?"* — throughput fairness
- * **between repos**. A heavy-maintenance lease bound asks *"has this holder occupied the exclusive
- * slot past the fairness bound?"* — fairness **between tasks**. A sweep can honour every per-repo
- * budget and still hold the shared slot for roughly `repoCount × sliceBudgetMs`, because the slice
- * budget rotates *within* the sweep rather than ending it. That is why composition is OR and not a
- * replacement: dropping either bound reintroduces the starvation the other cannot see.
+ * Neither of a tenant sweep's two bounds subsumes the other: the slice budget is fairness between
+ * repos, a lease hold bound is fairness between tasks, and a sweep honouring every per-repo budget
+ * still holds the shared slot for roughly `repoCount × sliceBudgetMs` — the budget rotates within the
+ * sweep rather than ending it. Hence OR rather than replacement.
  *
- * Non-function voters are ignored rather than rejected, so a caller that has no lease to consult —
- * the in-process scheduler path, or any test harness — passes `null` and gets the slice budget alone.
- * A predicate that throws is deliberately NOT caught here: a broken voter must fail loudly at its own
- * call site rather than be silently read as "do not yield", which is the reading that starves waiters.
+ * Non-function voters are skipped, so a caller with no lease passes `null` and gets the slice budget
+ * alone. A throwing voter propagates: silently reading it as "do not yield" starves waiters.
  *
  * @param {...(Function|null|undefined)} voters Yield predicates; non-functions are skipped.
  * @returns {Function} `() => Boolean` — true as soon as one voter votes to yield.

--- a/ai/daemons/orchestrator/scheduling/tenantRepoSync.mjs
+++ b/ai/daemons/orchestrator/scheduling/tenantRepoSync.mjs
@@ -113,6 +113,31 @@ export function createSliceBudgetPredicate({startedMs, sliceBudgetMs, now = Date
 }
 
 /**
+ * @summary Combines independent yield votes into one predicate: yield when ANY voter says yield.
+ *
+ * The two bounds a tenant sweep sits under answer different questions and neither subsumes the other.
+ * The slice budget above asks *"has this repo used its share of the sweep?"* — throughput fairness
+ * **between repos**. A heavy-maintenance lease bound asks *"has this holder occupied the exclusive
+ * slot past the fairness bound?"* — fairness **between tasks**. A sweep can honour every per-repo
+ * budget and still hold the shared slot for roughly `repoCount × sliceBudgetMs`, because the slice
+ * budget rotates *within* the sweep rather than ending it. That is why composition is OR and not a
+ * replacement: dropping either bound reintroduces the starvation the other cannot see.
+ *
+ * Non-function voters are ignored rather than rejected, so a caller that has no lease to consult —
+ * the in-process scheduler path, or any test harness — passes `null` and gets the slice budget alone.
+ * A predicate that throws is deliberately NOT caught here: a broken voter must fail loudly at its own
+ * call site rather than be silently read as "do not yield", which is the reading that starves waiters.
+ *
+ * @param {...(Function|null|undefined)} voters Yield predicates; non-functions are skipped.
+ * @returns {Function} `() => Boolean` — true as soon as one voter votes to yield.
+ */
+export function composeYieldPredicates(...voters) {
+    const active = voters.filter(voter => typeof voter === 'function');
+
+    return () => active.some(voter => voter() === true)
+}
+
+/**
  * Builds the trigger for the cloud-deployable tenant-repo-sync lane.
  * Mirror of `buildPrimaryRepoSyncTrigger` in `./primaryDevSync.mjs` — pure function;
  * no class, no Neo machinery, no side effects.

--- a/ai/daemons/orchestrator/services/TenantRepoSyncService.mjs
+++ b/ai/daemons/orchestrator/services/TenantRepoSyncService.mjs
@@ -1434,15 +1434,9 @@ class TenantRepoSyncService extends Base {
         embeddingRecoveryProbeTimeoutMs  = EMBEDDING_RECOVERY_PROBE_TIMEOUT_MS,
         embeddingRecoveryFailureTtlMs    = EMBEDDING_RECOVERY_FAILURE_TTL_MS,
         embeddingRecoveryFailureTtlMaxMs = EMBEDDING_RECOVERY_FAILURE_TTL_MAX_MS,
-        // The OUTER heavy-maintenance lease's fairness vote, supplied by whoever holds that lease —
-        // this service cannot build it, because it does not own that acquisition. Callers that hold
-        // no outer lease pass nothing and keep today's slice-budget-only behaviour exactly.
-        //
-        // It has to arrive as a parameter rather than be derived here: the container path takes the
-        // shared lease OUTSIDE `runTask` (`ai/scripts/maintenance/syncTenantRepos.mjs`) while the
-        // service's own narrower lease is acquired INSIDE it, so the acquisition whose age the
-        // fairness bound measures is not in scope at this level. Deriving one here would measure the
-        // wrong lease and read as fair while the shared slot stayed occupied.
+        // The OUTER lease's fairness vote, owned by whoever holds that lease: the container path
+        // acquires it outside `runTask`, so the acquisition it measures is not in scope here. Absent
+        // ⇒ slice budget alone.
         leaseShouldYield = null
     } = {}) {
         // One-time deployment sanity check on the two tuning leaves' RELATIONSHIP (never a
@@ -1678,10 +1672,8 @@ class TenantRepoSyncService extends Base {
         embeddingRecoveryProbeTimeoutMs  = EMBEDDING_RECOVERY_PROBE_TIMEOUT_MS,
         embeddingRecoveryFailureTtlMs    = EMBEDDING_RECOVERY_FAILURE_TTL_MS,
         embeddingRecoveryFailureTtlMaxMs = EMBEDDING_RECOVERY_FAILURE_TTL_MAX_MS,
-        // Declared HERE and not only on `runTask`, because the per-repo ingest call that consumes it
-        // lives in this scope alongside `sliceBudgetMs`. Declaring it one frame up left it an
-        // out-of-scope reference inside the per-repo try, which the repo-level catch turned into an
-        // ordinary repo failure — a checkpoint that stayed `null` while the sweep reported no cause.
+        // Declared here because the per-repo ingest call that consumes it lives in this scope,
+        // alongside `sliceBudgetMs`.
         leaseShouldYield = null
     }) {
         if (fullReplay && (!Array.isArray(onlyRepoSlugs) || onlyRepoSlugs.length === 0)) {
@@ -2416,12 +2408,8 @@ class TenantRepoSyncService extends Base {
                             // built once and shared by the whole sweep; a budget shared that way
                             // would be spent by the first admitted repo and every later one born
                             // already expired — a fairness fix that starves the tail it serves.
-                            // Two bounds, OR-composed, because neither subsumes the other: the slice
-                            // budget bounds THIS repo's share of the sweep, while the outer lease vote
-                            // bounds the whole sweep's occupancy of the shared exclusive-heavy slot. A
-                            // sweep honouring every per-repo budget can still hold that slot for
-                            // roughly repoCount × sliceBudgetMs, which is how waiters starve for hours
-                            // under a holder that never breaks any budget it can see.
+                            // OR-composed: the slice budget bounds this repo's share of the sweep,
+                            // the lease vote bounds the sweep's occupancy of the shared slot.
                             shouldYield: composeYieldPredicates(
                                 createSliceBudgetPredicate({startedMs, sliceBudgetMs}),
                                 leaseShouldYield

--- a/ai/daemons/orchestrator/services/TenantRepoSyncService.mjs
+++ b/ai/daemons/orchestrator/services/TenantRepoSyncService.mjs
@@ -38,6 +38,7 @@ import {
 } from '../../../services/knowledge-base/helpers/tenantRepoAccessContract.mjs';
 import {
     assertSliceBudgetMs,
+    composeYieldPredicates,
     createSliceBudgetPredicate,
     classifyEmbeddingRecoveryState,
     detectStarvedTenantSync,
@@ -1432,7 +1433,17 @@ class TenantRepoSyncService extends Base {
         embeddingRecoveryClock           = Date.now,
         embeddingRecoveryProbeTimeoutMs  = EMBEDDING_RECOVERY_PROBE_TIMEOUT_MS,
         embeddingRecoveryFailureTtlMs    = EMBEDDING_RECOVERY_FAILURE_TTL_MS,
-        embeddingRecoveryFailureTtlMaxMs = EMBEDDING_RECOVERY_FAILURE_TTL_MAX_MS
+        embeddingRecoveryFailureTtlMaxMs = EMBEDDING_RECOVERY_FAILURE_TTL_MAX_MS,
+        // The OUTER heavy-maintenance lease's fairness vote, supplied by whoever holds that lease —
+        // this service cannot build it, because it does not own that acquisition. Callers that hold
+        // no outer lease pass nothing and keep today's slice-budget-only behaviour exactly.
+        //
+        // It has to arrive as a parameter rather than be derived here: the container path takes the
+        // shared lease OUTSIDE `runTask` (`ai/scripts/maintenance/syncTenantRepos.mjs`) while the
+        // service's own narrower lease is acquired INSIDE it, so the acquisition whose age the
+        // fairness bound measures is not in scope at this level. Deriving one here would measure the
+        // wrong lease and read as fair while the shared slot stayed occupied.
+        leaseShouldYield = null
     } = {}) {
         // One-time deployment sanity check on the two tuning leaves' RELATIONSHIP (never a
         // throw — a noisy alert beats a dead lane): an inverted floor makes ordinary capped
@@ -1591,7 +1602,8 @@ class TenantRepoSyncService extends Base {
                 embeddingRecoveryClock,
                 embeddingRecoveryProbeTimeoutMs,
                 embeddingRecoveryFailureTtlMs,
-                embeddingRecoveryFailureTtlMaxMs
+                embeddingRecoveryFailureTtlMaxMs,
+                leaseShouldYield
             });
             const status         = result.status;
             const lastCompletion = {
@@ -1665,7 +1677,12 @@ class TenantRepoSyncService extends Base {
         embeddingRecoveryClock           = Date.now,
         embeddingRecoveryProbeTimeoutMs  = EMBEDDING_RECOVERY_PROBE_TIMEOUT_MS,
         embeddingRecoveryFailureTtlMs    = EMBEDDING_RECOVERY_FAILURE_TTL_MS,
-        embeddingRecoveryFailureTtlMaxMs = EMBEDDING_RECOVERY_FAILURE_TTL_MAX_MS
+        embeddingRecoveryFailureTtlMaxMs = EMBEDDING_RECOVERY_FAILURE_TTL_MAX_MS,
+        // Declared HERE and not only on `runTask`, because the per-repo ingest call that consumes it
+        // lives in this scope alongside `sliceBudgetMs`. Declaring it one frame up left it an
+        // out-of-scope reference inside the per-repo try, which the repo-level catch turned into an
+        // ordinary repo failure — a checkpoint that stayed `null` while the sweep reported no cause.
+        leaseShouldYield = null
     }) {
         if (fullReplay && (!Array.isArray(onlyRepoSlugs) || onlyRepoSlugs.length === 0)) {
             throw new TenantRepoSyncError(
@@ -2399,7 +2416,16 @@ class TenantRepoSyncService extends Base {
                             // built once and shared by the whole sweep; a budget shared that way
                             // would be spent by the first admitted repo and every later one born
                             // already expired — a fairness fix that starves the tail it serves.
-                            shouldYield: createSliceBudgetPredicate({startedMs, sliceBudgetMs})
+                            // Two bounds, OR-composed, because neither subsumes the other: the slice
+                            // budget bounds THIS repo's share of the sweep, while the outer lease vote
+                            // bounds the whole sweep's occupancy of the shared exclusive-heavy slot. A
+                            // sweep honouring every per-repo budget can still hold that slot for
+                            // roughly repoCount × sliceBudgetMs, which is how waiters starve for hours
+                            // under a holder that never breaks any budget it can see.
+                            shouldYield: composeYieldPredicates(
+                                createSliceBudgetPredicate({startedMs, sliceBudgetMs}),
+                                leaseShouldYield
+                            )
                         });
 
                 // Emitted before BOTH guards on this path, which is what makes it useful:

--- a/ai/scripts/maintenance/syncTenantRepos.mjs
+++ b/ai/scripts/maintenance/syncTenantRepos.mjs
@@ -36,6 +36,7 @@ import AiConfig              from '../../config.mjs';
 import TenantRepoSyncService from '../../daemons/orchestrator/services/TenantRepoSyncService.mjs';
 import {
     resolveHeavyMaintenanceLeasePath,
+    shouldYieldHeavyMaintenanceLease,
     withHeavyMaintenanceLease
 } from '../../daemons/orchestrator/services/HeavyMaintenanceLeaseService.mjs';
 import {
@@ -152,14 +153,41 @@ function createInMemoryTaskStateService() {
  * @param {Function} options.writeLog
  * @returns {Object}
  */
-function buildRunTaskOptions({parsed, taskStateService, writeLog}) {
+function buildRunTaskOptions({parsed, taskStateService, writeLog, leaseShouldYield = null}) {
     return {
         reason       : 'manual',
         taskStateService,
         writeLog,
         onlyRepoSlugs: parsed.repoSlugs.length > 0 ? parsed.repoSlugs : undefined,
-        fullReplay   : parsed.fullReplay
+        fullReplay   : parsed.fullReplay,
+        leaseShouldYield
     }
+}
+
+/**
+ * @summary Builds the outer heavy-maintenance lease's fairness vote for the sweep beneath it.
+ *
+ * Mirrors the `kbSync` precedent deliberately, including the config branch that reads wrong at a
+ * glance: `maxActiveHoldMs` lives on `orchestrator.heavyMaintenance`, **not** on the sibling
+ * `orchestrator.heavyMaintenanceLease`, which carries only `staleAfterMs`. Reading the sibling yields
+ * `undefined`, and a falsy bound means the primitive never votes to yield — a silent no-op that looks
+ * exactly like a wired predicate at every call site. That is the failure this comment exists to stop.
+ *
+ * Returns `null` when there is no lease to measure, so a caller that was not admitted, or a test
+ * harness with no acquisition, degrades to the slice budget alone rather than to a predicate that
+ * always answers false.
+ *
+ * @param {Object|null} acquisition The descriptor `withHeavyMaintenanceLease` passes to its task.
+ * @returns {Function|null} `() => Boolean`, or `null` when no lease is held.
+ */
+function buildLeaseYieldPredicate(acquisition) {
+    if (!acquisition?.lease) {
+        return null
+    }
+
+    return () => shouldYieldHeavyMaintenanceLease(acquisition.lease, {
+        maxActiveHoldMs: AiConfig.orchestrator.heavyMaintenance.maxActiveHoldMs
+    })
 }
 
 /**
@@ -198,7 +226,21 @@ function runTenantRepoSyncWithGlobalLease({
             onlyRepoSlugs: parsed.repoSlugs.length > 0 ? parsed.repoSlugs : null,
             writeLog
         })
-        : () => runTaskImpl(buildRunTaskOptions({parsed, taskStateService, writeLog}));
+        // `acquisition` is what `withHeavyMaintenanceLease` hands its task, and taking it here is the
+        // whole fix: this lease is the one the starvation watchdog names as holder, and until now the
+        // sweep beneath it had no way to ask how long it had been held. A sweep across N repos honours
+        // every per-repo slice budget and still occupies the shared exclusive-heavy slot for roughly
+        // N × sliceBudgetMs — measured on a live plane as five waiters starved between 4 and 34 hours
+        // under this owner.
+        //
+        // Only the sweep gets the vote. The clear-backoff branch is a short manifest rewrite that must
+        // finish atomically; handing it a yield predicate would invite a half-applied clear.
+        : acquisition => runTaskImpl(buildRunTaskOptions({
+            parsed,
+            taskStateService,
+            writeLog,
+            leaseShouldYield: buildLeaseYieldPredicate(acquisition)
+        }));
 
     return withLease(
         invoke,
@@ -287,4 +329,4 @@ if (import.meta.url === pathToFileURL(process.argv[1] || '').href) {
     })
 }
 
-export {buildRunTaskOptions, parseArgs, resolveExitCode, runTenantRepoSyncWithGlobalLease};
+export {buildLeaseYieldPredicate, buildRunTaskOptions, parseArgs, resolveExitCode, runTenantRepoSyncWithGlobalLease};

--- a/ai/scripts/maintenance/syncTenantRepos.mjs
+++ b/ai/scripts/maintenance/syncTenantRepos.mjs
@@ -167,18 +167,12 @@ function buildRunTaskOptions({parsed, taskStateService, writeLog, leaseShouldYie
 /**
  * @summary Builds the outer heavy-maintenance lease's fairness vote for the sweep beneath it.
  *
- * Mirrors the `kbSync` precedent deliberately, including the config branch that reads wrong at a
- * glance: `maxActiveHoldMs` lives on `orchestrator.heavyMaintenance`, **not** on the sibling
- * `orchestrator.heavyMaintenanceLease`, which carries only `staleAfterMs`. Reading the sibling yields
- * `undefined`, and a falsy bound means the primitive never votes to yield — a silent no-op that looks
- * exactly like a wired predicate at every call site. That is the failure this comment exists to stop.
- *
- * Returns `null` when there is no lease to measure, so a caller that was not admitted, or a test
- * harness with no acquisition, degrades to the slice budget alone rather than to a predicate that
- * always answers false.
+ * `maxActiveHoldMs` is on `orchestrator.heavyMaintenance`, not the sibling `heavyMaintenanceLease`
+ * (which carries only `staleAfterMs`); a falsy bound never votes to yield.
  *
  * @param {Object|null} acquisition The descriptor `withHeavyMaintenanceLease` passes to its task.
- * @returns {Function|null} `() => Boolean`, or `null` when no lease is held.
+ * @returns {Function|null} `() => Boolean`, or `null` when no lease is held — the sweep then runs on
+ *     its slice budget alone.
  */
 function buildLeaseYieldPredicate(acquisition) {
     if (!acquisition?.lease) {
@@ -226,15 +220,9 @@ function runTenantRepoSyncWithGlobalLease({
             onlyRepoSlugs: parsed.repoSlugs.length > 0 ? parsed.repoSlugs : null,
             writeLog
         })
-        // `acquisition` is what `withHeavyMaintenanceLease` hands its task, and taking it here is the
-        // whole fix: this lease is the one the starvation watchdog names as holder, and until now the
-        // sweep beneath it had no way to ask how long it had been held. A sweep across N repos honours
-        // every per-repo slice budget and still occupies the shared exclusive-heavy slot for roughly
-        // N × sliceBudgetMs — measured on a live plane as five waiters starved between 4 and 34 hours
-        // under this owner.
-        //
-        // Only the sweep gets the vote. The clear-backoff branch is a short manifest rewrite that must
-        // finish atomically; handing it a yield predicate would invite a half-applied clear.
+        // The sweep alone gets the lease vote: a sweep across N repos honours every per-repo slice
+        // budget yet occupies the shared slot for roughly N × sliceBudgetMs. The clear-backoff branch
+        // is a short manifest rewrite that must finish atomically, so a yield there could half-apply it.
         : acquisition => runTaskImpl(buildRunTaskOptions({
             parsed,
             taskStateService,

--- a/test/playwright/unit/ai/daemons/orchestrator/scheduling/tenantRepoSync.sliceBudget.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/scheduling/tenantRepoSync.sliceBudget.spec.mjs
@@ -1,5 +1,5 @@
 import {test, expect}                             from '@playwright/test';
-import {assertSliceBudgetMs, createSliceBudgetPredicate} from '../../../../../../../ai/daemons/orchestrator/scheduling/tenantRepoSync.mjs';
+import {assertSliceBudgetMs, composeYieldPredicates, createSliceBudgetPredicate} from '../../../../../../../ai/daemons/orchestrator/scheduling/tenantRepoSync.mjs';
 import {KB_TENANT_REPO_SYNC_INVALID_SLICE_BUDGET} from '../../../../../../../ai/daemons/orchestrator/services/TenantRepoSyncErrors.mjs';
 
 /**
@@ -103,5 +103,67 @@ test.describe('TenantRepoSyncService — sliceBudgetMs value contract (#17132 AC
         try { assertSliceBudgetMs('300000') } catch (error) { thrown = error }
 
         expect(thrown, 'a numeric string must not pass as a validated budget').toBeTruthy();
+    });
+});
+
+/**
+ * The two-bound composition.
+ *
+ * A tenant sweep sits under two independent fairness bounds that answer different questions, and the
+ * live starvation this closes happened while every bound the holder could see was satisfied: the
+ * slice budget rotates WITHIN a sweep, so a sweep over N repos honours all N budgets and still
+ * occupies the shared exclusive-heavy slot for roughly N x sliceBudgetMs. Five waiters were measured
+ * starved between 4 and 34 hours under exactly that shape.
+ *
+ * Composition is therefore OR, and each arm below is written so that deleting one voter turns it red.
+ */
+test.describe('TenantRepoSyncService — the slice budget and the lease bound compose', () => {
+    const never  = () => false,
+          always = () => true;
+
+    test('yields when EITHER voter yields, and not when neither does', () => {
+        expect(composeYieldPredicates(never, never)(),   'neither bound reached').toBe(false);
+        expect(composeYieldPredicates(always, never)(),  'the slice budget alone is enough').toBe(true);
+        expect(composeYieldPredicates(never, always)(),  'the lease bound alone is enough').toBe(true);
+        expect(composeYieldPredicates(always, always)(), 'both agreeing still yields once').toBe(true);
+    });
+
+    test('MUTATION GUARD: dropping the lease voter turns the lease-only case red and nothing else', () => {
+        // This is the arm that fails if `leaseShouldYield` stops being composed in — the exact edit
+        // that reintroduces the defect. The slice-only and neither cases are unaffected by that
+        // mutation, which is what makes this arm specific rather than merely sensitive.
+        const composed = composeYieldPredicates(never, always);
+        const mutated  = composeYieldPredicates(never);
+
+        expect(composed()).toBe(true);
+        expect(mutated(),  'without the lease voter a starved peer is invisible').toBe(false);
+    });
+
+    test('a null / absent voter is ignored, so a caller with no outer lease keeps slice-only behaviour', () => {
+        const slice = createSliceBudgetPredicate({startedMs: 0, sliceBudgetMs: 300_000, now: () => 100_000});
+
+        // Byte-for-byte the pre-change behaviour: same answer as the raw predicate, both before and
+        // after the budget elapses. A composition that changed this would be a silent regression for
+        // every caller that holds no outer lease — which is every in-process scheduler path.
+        expect(composeYieldPredicates(slice, null)()).toBe(slice());
+        expect(composeYieldPredicates(slice, undefined)()).toBe(false);
+        expect(composeYieldPredicates(null, undefined)(), 'no voters at all never yields').toBe(false);
+    });
+
+    test('NEGATIVE CONTROL: a holder inside the bound is not preempted', () => {
+        // The other half of the fairness contract. A bound that yields eagerly starves the holder
+        // instead of the waiters, so the short-hold case must stay false — and it is asserted on the
+        // real predicate rather than a stub, so a change to the comparison operator is caught here.
+        const youngSlice = createSliceBudgetPredicate({startedMs: 0, sliceBudgetMs: 300_000, now: () => 1_000});
+
+        expect(composeYieldPredicates(youngSlice, never)(), 'a 1s hold against a 5m budget must not yield').toBe(false);
+    });
+
+    test('a throwing voter fails loudly rather than reading as "do not yield"', () => {
+        // Swallowing here would convert a broken bound into permanent starvation that looks healthy,
+        // which is the exact failure shape this ticket is about.
+        const boom = () => { throw new Error('voter-broken') };
+
+        expect(() => composeYieldPredicates(never, boom)()).toThrow('voter-broken');
     });
 });

--- a/test/playwright/unit/ai/daemons/orchestrator/scheduling/tenantRepoSync.sliceBudget.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/scheduling/tenantRepoSync.sliceBudget.spec.mjs
@@ -107,15 +107,9 @@ test.describe('TenantRepoSyncService — sliceBudgetMs value contract (#17132 AC
 });
 
 /**
- * The two-bound composition.
- *
- * A tenant sweep sits under two independent fairness bounds that answer different questions, and the
- * live starvation this closes happened while every bound the holder could see was satisfied: the
- * slice budget rotates WITHIN a sweep, so a sweep over N repos honours all N budgets and still
- * occupies the shared exclusive-heavy slot for roughly N x sliceBudgetMs. Five waiters were measured
- * starved between 4 and 34 hours under exactly that shape.
- *
- * Composition is therefore OR, and each arm below is written so that deleting one voter turns it red.
+ * The two-bound composition: the slice budget bounds a repo's share of the sweep, the lease bound
+ * bounds the sweep's occupancy of the shared slot, and a sweep can satisfy every budget while holding
+ * that slot for roughly N x sliceBudgetMs. Each arm below reddens if a voter is dropped.
  */
 test.describe('TenantRepoSyncService — the slice budget and the lease bound compose', () => {
     const never  = () => false,
@@ -129,9 +123,8 @@ test.describe('TenantRepoSyncService — the slice budget and the lease bound co
     });
 
     test('MUTATION GUARD: dropping the lease voter turns the lease-only case red and nothing else', () => {
-        // This is the arm that fails if `leaseShouldYield` stops being composed in — the exact edit
-        // that reintroduces the defect. The slice-only and neither cases are unaffected by that
-        // mutation, which is what makes this arm specific rather than merely sensitive.
+        // Specific, not merely sensitive: the slice-only and neither-bound arms are unaffected by
+        // this mutation.
         const composed = composeYieldPredicates(never, always);
         const mutated  = composeYieldPredicates(never);
 
@@ -142,26 +135,23 @@ test.describe('TenantRepoSyncService — the slice budget and the lease bound co
     test('a null / absent voter is ignored, so a caller with no outer lease keeps slice-only behaviour', () => {
         const slice = createSliceBudgetPredicate({startedMs: 0, sliceBudgetMs: 300_000, now: () => 100_000});
 
-        // Byte-for-byte the pre-change behaviour: same answer as the raw predicate, both before and
-        // after the budget elapses. A composition that changed this would be a silent regression for
-        // every caller that holds no outer lease — which is every in-process scheduler path.
+        // Must equal the raw predicate's own answer: every in-process scheduler path holds no outer
+        // lease.
         expect(composeYieldPredicates(slice, null)()).toBe(slice());
         expect(composeYieldPredicates(slice, undefined)()).toBe(false);
         expect(composeYieldPredicates(null, undefined)(), 'no voters at all never yields').toBe(false);
     });
 
     test('NEGATIVE CONTROL: a holder inside the bound is not preempted', () => {
-        // The other half of the fairness contract. A bound that yields eagerly starves the holder
-        // instead of the waiters, so the short-hold case must stay false — and it is asserted on the
-        // real predicate rather than a stub, so a change to the comparison operator is caught here.
+        // A bound that yields eagerly starves the holder instead of the waiters. Asserted on the real
+        // predicate so a changed comparison operator is caught.
         const youngSlice = createSliceBudgetPredicate({startedMs: 0, sliceBudgetMs: 300_000, now: () => 1_000});
 
         expect(composeYieldPredicates(youngSlice, never)(), 'a 1s hold against a 5m budget must not yield').toBe(false);
     });
 
     test('a throwing voter fails loudly rather than reading as "do not yield"', () => {
-        // Swallowing here would convert a broken bound into permanent starvation that looks healthy,
-        // which is the exact failure shape this ticket is about.
+        // Swallowing converts a broken bound into starvation that looks healthy.
         const boom = () => { throw new Error('voter-broken') };
 
         expect(() => composeYieldPredicates(never, boom)()).toThrow('voter-broken');

--- a/test/playwright/unit/ai/daemons/orchestrator/services/TenantRepoSyncService.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/services/TenantRepoSyncService.spec.mjs
@@ -7489,10 +7489,8 @@ test.describe('syncTenantRepos container-plane CLI (#15748)', () => {
                 writeLog
             });
 
-        // Kept as an exact-shape `toEqual` rather than relaxed to `toMatchObject`: this pin is what
-        // caught the new key, and a pin that tolerates additions stops being able to. `null` is the
-        // no-outer-lease default — a caller holding no lease must dispatch a sweep that behaves
-        // exactly as it did before the fairness vote existed.
+        // Exact-shape on purpose: a pin that tolerates added keys cannot detect them. `null` is the
+        // no-outer-lease default.
         expect(options).toEqual({
             reason          : 'manual',
             taskStateService,
@@ -7506,9 +7504,8 @@ test.describe('syncTenantRepos container-plane CLI (#15748)', () => {
     test('threads the outer lease fairness vote into the dispatched sweep, and it votes on the LEASE age', () => {
         const dispatched = [];
 
-        // A lease acquired far enough in the past to be past any sane hold bound. The predicate must
-        // read THIS lease's age — not the sweep's, and not the slice budget's — so the fixture proves
-        // which clock the vote consults rather than only that a function arrived.
+        // Past any sane hold bound, so the arm proves which clock the vote reads — this lease's age,
+        // not the sweep's.
         const acquisition = {lease: {owner: 'tenant-repo-sync', acquiredAt: new Date(Date.now() - 6 * 60 * 60 * 1000).toISOString()}};
 
         dispatched.push(buildLeaseYieldPredicate(acquisition));
@@ -7577,10 +7574,8 @@ test.describe('syncTenantRepos container-plane CLI (#15748)', () => {
                 expect(outcome.status).toBe('completed');
                 expect(outcome.result.status).toBe(status);
 
-                // This path holds a REAL acquisition, so the fairness vote must arrive as a live
-                // function — asserted by kind, then excluded from the exact-shape comparison below.
-                // Comparing a closure by value would pin an identity nothing owns; dropping the key
-                // from the pin entirely would let the vote silently stop being threaded.
+                // A real acquisition ⇒ the vote is a live function: asserted by kind, then excluded
+                // from the exact-shape pin (a closure has no stable identity to compare).
                 const {leaseShouldYield, ...pinned} = outcome.result.options;
 
                 expect(typeof leaseShouldYield, 'a sweep dispatched under the outer lease receives its fairness vote').toBe('function');

--- a/test/playwright/unit/ai/daemons/orchestrator/services/TenantRepoSyncService.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/services/TenantRepoSyncService.spec.mjs
@@ -51,6 +51,7 @@ import {
     exitLifecycleGuard
 } from '../../../../../../../ai/daemons/shared/lifecycleGuard.mjs';
 import {
+    buildLeaseYieldPredicate,
     buildRunTaskOptions,
     parseArgs,
     resolveExitCode,
@@ -7488,13 +7489,39 @@ test.describe('syncTenantRepos container-plane CLI (#15748)', () => {
                 writeLog
             });
 
+        // Kept as an exact-shape `toEqual` rather than relaxed to `toMatchObject`: this pin is what
+        // caught the new key, and a pin that tolerates additions stops being able to. `null` is the
+        // no-outer-lease default — a caller holding no lease must dispatch a sweep that behaves
+        // exactly as it did before the fairness vote existed.
         expect(options).toEqual({
-            reason       : 'manual',
+            reason          : 'manual',
             taskStateService,
             writeLog,
-            onlyRepoSlugs: ['org/a', 'org/b'],
-            fullReplay   : true
+            onlyRepoSlugs   : ['org/a', 'org/b'],
+            fullReplay      : true,
+            leaseShouldYield: null
         });
+    });
+
+    test('threads the outer lease fairness vote into the dispatched sweep, and it votes on the LEASE age', () => {
+        const dispatched = [];
+
+        // A lease acquired far enough in the past to be past any sane hold bound. The predicate must
+        // read THIS lease's age — not the sweep's, and not the slice budget's — so the fixture proves
+        // which clock the vote consults rather than only that a function arrived.
+        const acquisition = {lease: {owner: 'tenant-repo-sync', acquiredAt: new Date(Date.now() - 6 * 60 * 60 * 1000).toISOString()}};
+
+        dispatched.push(buildLeaseYieldPredicate(acquisition));
+
+        const [vote] = dispatched;
+
+        expect(typeof vote, 'an acquisition with a lease yields a predicate').toBe('function');
+        expect(vote(), 'a six-hour hold is past the 30-minute default bound').toBe(true);
+
+        // The negative arm that makes the positive one mean something: no lease ⇒ no predicate, so the
+        // sweep degrades to the slice budget alone instead of to a vote that always answers false.
+        expect(buildLeaseYieldPredicate(null), 'no acquisition ⇒ no vote').toBeNull();
+        expect(buildLeaseYieldPredicate({}), 'an acquisition without a lease ⇒ no vote').toBeNull();
     });
 
     test('global held lease defers without dispatching tenant sync', async () => {
@@ -7548,15 +7575,21 @@ test.describe('syncTenantRepos container-plane CLI (#15748)', () => {
                 });
 
                 expect(outcome.status).toBe('completed');
-                expect(outcome.result).toEqual({
-                    status,
-                    options: {
-                        reason       : 'manual',
-                        taskStateService,
-                        writeLog,
-                        onlyRepoSlugs: ['org/a', 'org/b'],
-                        fullReplay   : true
-                    }
+                expect(outcome.result.status).toBe(status);
+
+                // This path holds a REAL acquisition, so the fairness vote must arrive as a live
+                // function — asserted by kind, then excluded from the exact-shape comparison below.
+                // Comparing a closure by value would pin an identity nothing owns; dropping the key
+                // from the pin entirely would let the vote silently stop being threaded.
+                const {leaseShouldYield, ...pinned} = outcome.result.options;
+
+                expect(typeof leaseShouldYield, 'a sweep dispatched under the outer lease receives its fairness vote').toBe('function');
+                expect(pinned).toEqual({
+                    reason       : 'manual',
+                    taskStateService,
+                    writeLog,
+                    onlyRepoSlugs: ['org/a', 'org/b'],
+                    fullReplay   : true
                 });
                 expect((await inspectHeavyMaintenanceLease({leasePath})).status).toBe('missing');
             });


### PR DESCRIPTION
Resolves neomjs/neo#17398

Refs neomjs/neo-agent-brain#25

The container tenant sweep now consults the shared heavy-maintenance lease it holds, instead of only its own per-repo slice budget. `#17047` gave `syncTenantRepos.mjs` that outer lease and closed a real bypass; nothing gave the new holder a way to ask how long it had held. A sweep over N repos honours every per-repo budget and still occupies the exclusive-heavy slot for roughly `N × sliceBudgetMs`, because the slice budget rotates *within* a sweep rather than ending it — so every bound the holder could see stayed satisfied while five waiters starved between 4 and 34 hours.

Evidence: L3 (pure predicate + option threading, every AC decidable in-process) → L3 required. The live-plane effect is observable only on a running deployment, which is an environment ceiling rather than an outstanding obligation. Residual: none for neomjs/neo#17398; neomjs/neo-agent-brain#25 AC-3 (observe a starved peer actually interleave) and AC-5 (mechanical detection of non-consulting tasks) stay open on the parent, Residual-Owner: neomjs/neo-agent-brain#25.

## The shape of the fix

Two bounds, OR-composed through a new pure `composeYieldPredicates`, because neither subsumes the other: the slice budget is fairness **between repos**, the lease bound is fairness **between tasks**. A caller holding no outer lease passes nothing and keeps today's behaviour byte-for-byte — that is every in-process scheduler path.

The vote is built where the acquisition lives (`buildLeaseYieldPredicate`, from the descriptor `withHeavyMaintenanceLease` already passes to its task), mirroring the `#16823` `kbSync` precedent — including its config trap: `maxActiveHoldMs` is on `orchestrator.heavyMaintenance`, **not** the adjacent `heavyMaintenanceLease`. Reading the sibling yields `undefined`, and a falsy bound never votes, which is a no-op indistinguishable from a wired predicate at every call site.

The clear-backoff branch deliberately receives no vote: it is a short manifest rewrite that must finish atomically.

## Deltas from ticket

**The owner string is what identified the holder, and it corrects the parent twice.** `TenantRepoSyncService` stamps `tenant-repo-sync:scheduler`; the CLI stamps the bare `tenant-repo-sync`, which is the form the live watchdog reports. neomjs/neo-agent-brain#25 first named the pure scheduling module, then (after my own correction this morning) the service. Both were the wrong file.

**The parent's enumeration missed four paths because of my matcher, not my directory scope.** It searched `withHeavyMaintenanceLease(` and never `withLease(` — the spelling this holder uses. Its control survived that stage, so the sweep read as complete. Corrected on neomjs/neo-agent-brain#25: **1 of 9 lease-acquiring paths consults the fairness bound**, not 1 of 5.

**Not claimed:** which occupancy shape the live instance has. `starvedForMs` measures the *waiter's* wait, so continuous re-acquisition and one long hold read identically. I stated earlier today that neomjs/neo-agent-brain#25's yield would be the live lever; that claim is not supported by this evidence and I am not making it here. A path that takes the shared slot and consults no fairness bound is a defect either way.

## Test Evidence

`test/playwright/unit/ai/daemons/orchestrator/` + `test/playwright/unit/ai/scripts/` — **3850 passed, 2 skipped** (`--workers=1`).

Per touched surface:
- `scheduling/tenantRepoSync.mjs` → `tenantRepoSync.sliceBudget.spec.mjs`: 5 new arms — OR semantics; **mutation guard** (dropping the lease voter reddens the lease-only arm *and only it*); null/absent voter equals the raw predicate's own answer; negative control (1s hold vs 5m budget must not yield); a throwing voter propagates.
- `scripts/maintenance/syncTenantRepos.mjs` → `TenantRepoSyncService.spec.mjs`: new arm asserting the vote is built from the **outer lease's age** (6h acquisition → `true` against the 30m default) plus both no-lease arms returning `null`.
- `services/TenantRepoSyncService.mjs` → same spec, 143 arms; two pre-existing exact-shape option pins caught the new key and were **updated rather than loosened**, one now asserting the vote is threaded on the real dispatch path.

**A fixture caught a scope bug reading alone did not.** `leaseShouldYield` declared only on `runTask` is an out-of-scope reference inside `syncTenantRepos`' per-repo try, which the repo-level catch converted into an ordinary repo failure — a checkpoint that stayed `null` while the sweep reported no cause. The matched-shape baseline is what proved it was mine: the same three specs in the same order pass on clean `origin/dev` (182) and failed with my change.

## Post-Merge Validation

None. Both items I first listed here were **consequences of the fix**, not work this PR owes: the watchdog's breach list draining is what the fix causes, and a yielded sweep resuming at its checkpoint is the forward-progress guarantee the slice-budget path already carries. Neither needs an owner to remember it, and neomjs/neo-agent-brain#25 owns the yield wiring rather than verification of this leaf — so naming it was a nominal owner on an obligation that does not exist.

*(Corrected after @neo-opus-ada hit the same lint from a different cause and landed on the prior question: is this work at all? Per Grace's rule — "'if it persists' is not a plan: name who observes it, then file or drop, no third state" — an unchecked box with a nominal owner IS that third state.)*

## Commits

- `ce65d93101` — the composition, the CLI vote, and the scope-correct threading.

Authored by Vega (Claude Opus 5, Claude Code). Session 8cbd588b-be06-4a56-9997-1058f2a3a07b.

