### PR TITLE
feat(ai): a futile heal target freezes, with evidence and a way out (#17403)

### DIFF
--- a/ai/daemons/orchestrator/services/DeploymentStateBridgeService.mjs
+++ b/ai/daemons/orchestrator/services/DeploymentStateBridgeService.mjs
@@ -93,6 +93,7 @@ import {readRecentRecoveryRunStates} from '../../../services/memory-core/helpers
 import {
     queryHealLedger,
     readHealLedger,
+    foldFutilityFreezeState,
     summarizeHealLedger
 } from '../../../services/memory-core/helpers/healEventLedgerStore.mjs';
 import {
@@ -2053,7 +2054,7 @@ export class DeploymentStateBridgeService extends Base {
      * `readHealLedger` throw, which this catches as `status: 'degraded'` + an error reason — a real storage fault
      * is visible, NOT a false-empty `available` snapshot (a missing file stays `available` with empty counts).
      * Mirrors `collectRecoveryRunSnapshot`'s status/source/errors shape.
-     * @returns {Promise<Object>} `{status, source, limit, summary, recentEvents, errors}`.
+     * @returns {Promise<Object>} `{status, source, limit, summary, freezeState, recentEvents, errors}`.
      */
     async collectSelfHealSnapshot() {
         const
@@ -2071,7 +2072,7 @@ export class DeploymentStateBridgeService extends Base {
         }
 
         if (!this.healLedgerDir) {
-            return {status: 'disabled', source, limit, summary: null, recentEvents: [], errors: []};
+            return {status: 'disabled', source, limit, summary: null, freezeState: null, recentEvents: [], errors: []};
         }
 
         try {
@@ -2083,6 +2084,10 @@ export class DeploymentStateBridgeService extends Base {
                 source,
                 limit,
                 summary     : summarizeHealLedger(events),
+                // `summary.currentlyFrozen` is a bare target list; this carries each freeze's escalation,
+                // verdict evidence and thaw condition, so an operator can see WHY a target is frozen and
+                // what clears it without reading the ledger.
+                freezeState : foldFutilityFreezeState(events, {now: Date.now()}),
                 recentEvents: queryHealLedger(events, {limit}), // validated >= 0; limit 0 → [] (queryHealLedger caps)
                 errors      : []
             };
@@ -2094,6 +2099,7 @@ export class DeploymentStateBridgeService extends Base {
                 source,
                 limit,
                 summary     : null,
+                freezeState : null,
                 recentEvents: [],
                 errors      : [{reason: 'heal-ledger-read-failed', code: error.code || null}]
             };

--- a/ai/scripts/lint/retry-bound-registry.json
+++ b/ai/scripts/lint/retry-bound-registry.json
@@ -32,7 +32,7 @@
             "lifetime": "persisted",
             "boundCarrier": "max-delay",
             "witness": "`MAX_RECORD_COOLDOWN_MS` clamp in the same expression; test/playwright/unit/ai/daemons/embed/drainCycle.spec.mjs",
-            "note": "Per-record attempt persists across cycles in retryState, so a delay cap is required — an attempt budget would not bound wall-clock."
+            "note": "Per-record attempt persists across cycles in retryState, so a delay cap is required \u2014 an attempt budget would not bound wall-clock."
         },
         "ai/daemons/message/drainCycle.mjs#getMessageDrainBackoffDelayMs:39b52338": {
             "kind": "retry-growth",
@@ -64,7 +64,7 @@
             "kind": "retry-growth",
             "lifetime": "process-local",
             "boundCarrier": "max-delay",
-            "witness": "`Math.min(..., MAX_BACKOFF_MS)` caps the exponential reconnect delay at 60s, and the loop exits terminally on `stopped` or an epoch change (`stop()` bumps the epoch) — the spec `fleetWakeSseConsumer.spec.mjs` drives a drop→reconnect cycle on the injected floor and `stop()` ends the loop."
+            "witness": "`Math.min(..., MAX_BACKOFF_MS)` caps the exponential reconnect delay at 60s, and the loop exits terminally on `stopped` or an epoch change (`stop()` bumps the epoch) \u2014 the spec `fleetWakeSseConsumer.spec.mjs` drives a drop\u2192reconnect cycle on the injected floor and `stop()` ends the loop."
         },
         "ai/services/github-workflow/GraphqlService.mjs##getRetryDelay:626883e2": {
             "kind": "retry-growth",
@@ -92,7 +92,7 @@
             "lifetime": "in-cycle",
             "boundCarrier": "max-attempts",
             "witness": "`retries++` precedes the sleep and `if (retries >= maxRetries) throw writeError` exits before the delay can run again; the write retries spend the surrounding batch's shared `maxRetries` budget",
-            "note": "Carried-prefix WRITE retry shared by the yield AND failure arms (persistCarriedPrefix): vectors already in hand retry the upsert only — never the provider — and budget exhaustion rethrows the storage error so the sweep ends loudly. The backoff BASE is now the kb.backoffBaseMs leaf rather than a hardcoded 1000, so a test context pins it; the bound is unchanged because the base scales the delay and never the attempt count."
+            "note": "Carried-prefix WRITE retry shared by the yield AND failure arms (persistCarriedPrefix): vectors already in hand retry the upsert only \u2014 never the provider \u2014 and budget exhaustion rethrows the storage error so the sweep ends loudly. The backoff BASE is now the kb.backoffBaseMs leaf rather than a hardcoded 1000, so a test context pins it; the bound is unchanged because the base scales the delay and never the attempt count."
         },
         "ai/services/knowledge-base/VectorService.mjs#persistCarriedPrefix:a17aac7c#1": {
             "kind": "retry-growth",
@@ -112,7 +112,7 @@
             "lifetime": "in-cycle",
             "boundCarrier": "max-attempts",
             "witness": "`attempt <= maxRetries` guard in the same loop",
-            "note": "Multiplicative mutation (`backoff *= 2`) — the syntax family a base-2 exponent census misses entirely."
+            "note": "Multiplicative mutation (`backoff *= 2`) \u2014 the syntax family a base-2 exponent census misses entirely."
         },
         "ai/services/memory-core/helpers/freezeReprobeDecision.mjs#decideFreezeReprobe:5b01edc6": {
             "kind": "retry-growth",
@@ -121,14 +121,19 @@
             "witness": "`attempts >= maxUnfreezeAttempts` => status `contained` in the same function; test/playwright/unit/ai/services/memory-core/helpers/freezeReprobeDecision.spec.mjs",
             "note": "The delay value GROWS without a cap by design (anti-thrash widening); the series is bounded because a terminal state stops it. No delay-shaped check can see this bound."
         },
+        "ai/services/memory-core/helpers/healEventLedgerStore.mjs#foldFutilityFreezeState:a8244d4b": {
+            "kind": "not-a-retry",
+            "witness": "`Math.min(grown, maxThawQuietMs)` at healEventLedgerStore.mjs#foldFutilityFreezeState; `maxThawQuietMs: 86400000` in DEFAULT_THAW_BOUNDS; spec arm \"the escalating window is CAPPED\" asserts saturation at the ceiling after 12 flap cycles",
+            "note": "Nothing is re-attempted: the growth is how long a futile heal target stays contained before it may thaw, so each successive freeze demands a longer quiet window. Capped so enough flapping cannot turn containment into permanent abandonment."
+        },
         "ai/services/memory-core/helpers/recoveryKnobRegistry.mjs#<module>:092bcbf7": {
             "kind": "not-a-retry",
-            "witness": "`16 * 1024 ** 3` — the same GiB-to-bytes unit arithmetic for the band cap; literal exponent 3, module-load constant.",
+            "witness": "`16 * 1024 ** 3` \u2014 the same GiB-to-bytes unit arithmetic for the band cap; literal exponent 3, module-load constant.",
             "note": "Sibling of bf9ea77a; the two constants ARE the bound a growth curve would need, which is why they look adjacent to one."
         },
         "ai/services/memory-core/helpers/recoveryKnobRegistry.mjs#<module>:bf9ea77a": {
             "kind": "not-a-retry",
-            "witness": "`8 * 1024 ** 3` is byte-unit arithmetic — GiB to bytes for the container-memory-ceiling knob's band floor. The exponent is the literal 3 (KiB→MiB→GiB), evaluated once at module load; no loop, no attempt series.",
+            "witness": "`8 * 1024 ** 3` is byte-unit arithmetic \u2014 GiB to bytes for the container-memory-ceiling knob's band floor. The exponent is the literal 3 (KiB\u2192MiB\u2192GiB), evaluated once at module load; no loop, no attempt series.",
             "note": "The band itself is the anti-thrash VALUE bound: growth terminates at the registry max by thrown violation, asserted in recoveryKnobRegistry.spec.mjs."
         },
         "ai/services/shared/boundedRetryGate.mjs#settleFlight:e1ea3176": {
@@ -142,7 +147,7 @@
             "kind": "retry-growth",
             "lifetime": "process-local",
             "boundCarrier": "max-delay",
-            "witness": "`Math.min(..., MAX_BACKOFF_MS)` caps the exponential reconnect delay at 60s, and the loop exits terminally on `stopped` or an epoch change (`stop()` bumps the epoch) — the spec `fleetWakeStreamConsumer.spec.mjs` drives a drop→reconnect cycle on the injected floor and `stop()` ends the loop.",
+            "witness": "`Math.min(..., MAX_BACKOFF_MS)` caps the exponential reconnect delay at 60s, and the loop exits terminally on `stopped` or an epoch change (`stop()` bumps the epoch) \u2014 the spec `fleetWakeStreamConsumer.spec.mjs` drives a drop\u2192reconnect cycle on the injected floor and `stop()` ends the loop.",
             "note": "The App-Worker twin of the relay consumer's identical site (same fingerprint 5f68f770): the parity spec binds the parser, this entry binds the bound."
         },
         "apps/devindex/services/GitHub.mjs##getRetryDelay:41482917": {
@@ -154,16 +159,16 @@
         "apps/devindex/services/Spider.mjs#pickStrategy:af20cfdb": {
             "kind": "not-a-retry",
             "witness": "`Math.pow(Math.random(), 3)` is a cubic-bias power-law over [0,1) shaping a jitter offset; the exponent is the constant 3 and cannot grow.",
-            "note": "The nearest true-positive shape in the tree — a random offset in a crawler — and still not a retry series: nothing re-attempts on it."
+            "note": "The nearest true-positive shape in the tree \u2014 a random offset in a crawler \u2014 and still not a retry series: nothing re-attempts on it."
         },
         "apps/portal/canvas/HomeCanvas.mjs#drawNetwork:3d84b270": {
             "kind": "not-a-retry",
-            "witness": "Euclidean distance from a wave origin — `(posX - wave.x)**2`; squares a coordinate delta with a literal exponent.",
+            "witness": "Euclidean distance from a wave origin \u2014 `(posX - wave.x)**2`; squares a coordinate delta with a literal exponent.",
             "note": "First of two exponentiations on this line; the second is keyed `#1`."
         },
         "apps/portal/canvas/HomeCanvas.mjs#drawNetwork:3d84b270#1": {
             "kind": "not-a-retry",
-            "witness": "Second term of the same Euclidean distance — `(posY - wave.y)**2`.",
+            "witness": "Second term of the same Euclidean distance \u2014 `(posY - wave.y)**2`.",
             "note": "Represented separately because occurrence multiplicity is what the key ordinal exists to preserve."
         },
         "apps/portal/canvas/HomeCanvas.mjs#drawShockwaves:085f4fbe": {
@@ -173,62 +178,62 @@
         },
         "apps/portal/canvas/HomeCanvas.mjs#updateAgents:9d5b2f14": {
             "kind": "not-a-retry",
-            "witness": "Vector magnitude of an agent velocity — `agents[idx + 2]**2`; squares a velocity component.",
+            "witness": "Vector magnitude of an agent velocity \u2014 `agents[idx + 2]**2`; squares a velocity component.",
             "note": "First of two exponentiations on this line."
         },
         "apps/portal/canvas/HomeCanvas.mjs#updateAgents:9d5b2f14#1": {
             "kind": "not-a-retry",
-            "witness": "Second term of the same velocity magnitude — `agents[idx + 3]**2`.",
+            "witness": "Second term of the same velocity magnitude \u2014 `agents[idx + 3]**2`.",
             "note": "Represented separately for occurrence multiplicity."
         },
         "apps/portal/canvas/HomeCanvas.mjs#updatePhysics:085f4fbe": {
             "kind": "not-a-retry",
             "witness": "The same cubic ease-out expression as `drawShockwaves`, in the physics tick; identical text, different enclosing symbol, so a distinct key.",
-            "note": "Shares a fingerprint with the drawShockwaves site — the symbol component of the key is what separates them."
+            "note": "Shares a fingerprint with the drawShockwaves site \u2014 the symbol component of the key is what separates them."
         },
         "apps/portal/canvas/HomeCanvas.mjs#updatePhysics:9e2d05f4": {
             "kind": "not-a-retry",
-            "witness": "Euclidean distance to a buffered point — `(px - buffer[idx])**2`.",
+            "witness": "Euclidean distance to a buffered point \u2014 `(px - buffer[idx])**2`.",
             "note": "First of two exponentiations on this line."
         },
         "apps/portal/canvas/HomeCanvas.mjs#updatePhysics:9e2d05f4#1": {
             "kind": "not-a-retry",
-            "witness": "Second term of the same distance — `(py - buffer[idx + 1])**2`.",
+            "witness": "Second term of the same distance \u2014 `(py - buffer[idx + 1])**2`.",
             "note": "Represented separately for occurrence multiplicity."
         },
         "apps/portal/canvas/ServicesCanvas.mjs#findNearestNode:173ce0f0": {
             "kind": "not-a-retry",
-            "witness": "Squared-distance comparison — `(nx - x) ** 2`; kept squared to avoid a sqrt in the nearest-node scan.",
+            "witness": "Squared-distance comparison \u2014 `(nx - x) ** 2`; kept squared to avoid a sqrt in the nearest-node scan.",
             "note": "First of two exponentiations on this line."
         },
         "apps/portal/canvas/ServicesCanvas.mjs#findNearestNode:173ce0f0#1": {
             "kind": "not-a-retry",
-            "witness": "Second term of the same squared distance — `(ny - y) ** 2`.",
+            "witness": "Second term of the same squared distance \u2014 `(ny - y) ** 2`.",
             "note": "Represented separately for occurrence multiplicity."
         },
         "apps/portal/canvas/ServicesCanvas.mjs#findNeighbors:822f999b": {
             "kind": "not-a-retry",
-            "witness": "Euclidean distance in the neighbour scan — `(x - cx) ** 2`.",
+            "witness": "Euclidean distance in the neighbour scan \u2014 `(x - cx) ** 2`.",
             "note": "First of two exponentiations on this line."
         },
         "apps/portal/canvas/ServicesCanvas.mjs#findNeighbors:822f999b#1": {
             "kind": "not-a-retry",
-            "witness": "Second term of the same distance — `(y - cy) ** 2`.",
+            "witness": "Second term of the same distance \u2014 `(y - cy) ** 2`.",
             "note": "Represented separately for occurrence multiplicity."
         },
         "apps/portal/canvas/ServicesCanvas.mjs#updatePhysics:a46dec3a": {
             "kind": "not-a-retry",
             "witness": "`Math.pow(active, 2)` squares a normalized activation for a falloff curve; the exponent is the literal 2.",
-            "note": "Reassigns its own input, which is the shape `mutate` exists to catch — but the multiplier is a constant square, not a growth factor."
+            "note": "Reassigns its own input, which is the shape `mutate` exists to catch \u2014 but the multiplier is a constant square, not a growth factor."
         },
         "apps/portal/canvas/ServicesCanvas.mjs#updateRunners:4255fb33": {
             "kind": "not-a-retry",
-            "witness": "Squared cursor distance — `(tx - me.mouse.x) ** 2`.",
+            "witness": "Squared cursor distance \u2014 `(tx - me.mouse.x) ** 2`.",
             "note": "First of two exponentiations on this line."
         },
         "apps/portal/canvas/ServicesCanvas.mjs#updateRunners:4255fb33#1": {
             "kind": "not-a-retry",
-            "witness": "Second term of the same squared distance — `(ty - me.mouse.y) ** 2`.",
+            "witness": "Second term of the same squared distance \u2014 `(ty - me.mouse.y) ** 2`.",
             "note": "Represented separately for occurrence multiplicity."
         },
         "src/canvas/Header.mjs#getStreamOffset:08d3b17b": {
@@ -238,17 +243,17 @@
         },
         "src/canvas/Sparkline.mjs#renderLoop:649bd37d": {
             "kind": "not-a-retry",
-            "witness": "`1 - Math.pow(1 - progress, 3)` — cubic ease-out on a 0..1 render progress.",
+            "witness": "`1 - Math.pow(1 - progress, 3)` \u2014 cubic ease-out on a 0..1 render progress.",
             "note": "Same easing shape as the HomeCanvas sites."
         },
         "src/dashboard/DockDropIndicators.mjs#getCandidateHitPoint:47d9a25f": {
             "kind": "not-a-retry",
-            "witness": "Squared hit-test distance — `(pointX - center.x) ** 2`; squared to rank candidates without a sqrt.",
+            "witness": "Squared hit-test distance \u2014 `(pointX - center.x) ** 2`; squared to rank candidates without a sqrt.",
             "note": "First of two exponentiations on this line."
         },
         "src/dashboard/DockDropIndicators.mjs#getCandidateHitPoint:47d9a25f#1": {
             "kind": "not-a-retry",
-            "witness": "Second term of the same squared distance — `(pointY - center.y) ** 2`.",
+            "witness": "Second term of the same squared distance \u2014 `(pointY - center.y) ** 2`.",
             "note": "Represented separately for occurrence multiplicity."
         },
         "src/data/connection/WebSocket.mjs#<module>:a5cd8f47": {
@@ -261,16 +266,16 @@
         "src/form/field/FileUpload.mjs#formatSize:38dbd980": {
             "kind": "not-a-retry",
             "witness": "`bytes / (1000 ** i)` converts to an SI magnitude; `i` is an index into the `sizes` unit array, bounded by that array's length.",
-            "note": "The candidate the discovery patterns were first tuned against — it survives inside a template literal, which is why stripLiterals retains substitutions."
+            "note": "The candidate the discovery patterns were first tuned against \u2014 it survives inside a template literal, which is why stripLiterals retains substitutions."
         },
         "src/main/DomEvents.mjs#getDistance:841a9de1": {
             "kind": "not-a-retry",
-            "witness": "Euclidean distance between two pointer positions — `(x2 - x1) ** 2`.",
+            "witness": "Euclidean distance between two pointer positions \u2014 `(x2 - x1) ** 2`.",
             "note": "First of two exponentiations on this line."
         },
         "src/main/DomEvents.mjs#getDistance:841a9de1#1": {
             "kind": "not-a-retry",
-            "witness": "Second term of the same distance — `(y2 - y1) ** 2`.",
+            "witness": "Second term of the same distance \u2014 `(y2 - y1) ** 2`.",
             "note": "Represented separately for occurrence multiplicity."
         },
         "src/manager/DragCoordinator.mjs#settleNativeWindowDisposition:acca199c": {
@@ -278,7 +283,7 @@
             "lifetime": "process-local",
             "boundCarrier": "max-delay",
             "witness": "`Math.min(5000, ...)` plus a clamped exponent `Math.min(dispositionAttempts - 1, 4)`",
-            "note": "Bounded twice — the delay is capped AND the exponent itself is clamped."
+            "note": "Bounded twice \u2014 the delay is capped AND the exponent itself is clamped."
         }
     }
 }

--- a/ai/services/memory-core/helpers/healActionDispatch.mjs
+++ b/ai/services/memory-core/helpers/healActionDispatch.mjs
@@ -285,3 +285,107 @@ export function detectChronicUnsafeInput(events = [], {threshold, windowMs, now}
     // Worst-first: descending count, then a stable JSON-key order for deterministic surfacing.
     return chronic.sort((a, b) => b.count - a.count || JSON.stringify([a.action, a.collection]).localeCompare(JSON.stringify([b.action, b.collection])))
 }
+
+/**
+ * Default futility bounds: five consecutive identical verdicts inside one hour freezes the target.
+ * @type {{maxIdenticalVerdicts: Number, windowMs: Number}}
+ */
+export const DEFAULT_FUTILITY_BOUNDS = Object.freeze({maxIdenticalVerdicts: 5, windowMs: 3600000});
+
+/**
+ * Escalation kinds a freeze carries. A failed remedy says the action does not work; an unactionable
+ * verdict says the class has no remedy on this target, which is a substrate gap rather than a retry
+ * to abandon.
+ * @type {{REMEDY_INEFFECTIVE: String, NO_ADMITTED_REMEDY: String}}
+ */
+export const FUTILITY_ESCALATIONS = Object.freeze({
+    REMEDY_INEFFECTIVE: 'remedy-ineffective',
+    NO_ADMITTED_REMEDY: 'no-admitted-remedy'
+});
+
+/**
+ * Dispositions that reached a rung without invoking an executor. Both routes carrying
+ * `actuatorAction: null` land here, so the majority of ledger rows are in this set.
+ * @type {String[]}
+ */
+export const UNACTIONED_DISPOSITIONS = Object.freeze(['recorded', 'declined', 'no-action', 'deferred']);
+
+/**
+ * @summary Decides whether a heal target has become futile and must freeze.
+ *
+ * Keys on **consecutive identical verdicts with no state change**, not on executor failures: the routes
+ * with `actuatorAction: null` never invoke an executor, so a failure counter cannot see them.
+ *
+ * A verdict's identity is `{target, recoveryClass, rung, reasonCode}`. `stateFingerprint` breaks the
+ * run — any change in the subject means the loop is observing something new, whatever the verdict says.
+ *
+ * Fails OPEN (no freeze) on a missing clock, non-positive threshold, or malformed bounds. A breaker that
+ * engaged on bad input would silence the immune system, which is the worse direction here.
+ *
+ * @param {Object}   options
+ * @param {Object[]} [options.verdicts=[]] Newest-last verdicts, each `{target, recoveryClass, rung, reasonCode, disposition, stateFingerprint, at}`.
+ * @param {{maxIdenticalVerdicts: Number, windowMs: Number}} [options.bounds=DEFAULT_FUTILITY_BOUNDS]
+ * @param {Number} [options.now] Epoch milliseconds (injected clock).
+ * @returns {Object} `{freeze, status, reason, streak, escalation, verdict}`. `status ∈ {freeze, below-threshold, verdict-changed, state-changed, unsafe-input, no-verdicts}`.
+ */
+export function decideFutilityFreeze({verdicts = [], bounds = DEFAULT_FUTILITY_BOUNDS, now} = {}) {
+    const {maxIdenticalVerdicts, windowMs} = {...DEFAULT_FUTILITY_BOUNDS, ...(bounds ?? {})};
+
+    if (!Number.isFinite(now) || !Number.isFinite(windowMs) || !Number.isFinite(maxIdenticalVerdicts) || maxIdenticalVerdicts <= 0) {
+        return {freeze: false, status: 'unsafe-input', reason: 'non-finite clock, window, or threshold', streak: 0, escalation: null, verdict: null}
+    }
+
+    const rows = (Array.isArray(verdicts) ? verdicts : [])
+        .filter(v => v && typeof v === 'object' && Number.isFinite(v.at) && v.at >= now - windowMs && v.at <= now);
+
+    if (rows.length === 0) {
+        return {freeze: false, status: 'no-verdicts', reason: 'no verdicts inside the window', streak: 0, escalation: null, verdict: null}
+    }
+
+    const identity = v => JSON.stringify([v.target ?? null, v.recoveryClass ?? null, v.rung ?? null, v.reasonCode ?? null]),
+          latest   = rows[rows.length - 1],
+          key      = identity(latest);
+
+    let streak = 0, broke = null;
+
+    for (let i = rows.length - 1; i >= 0; i--) {
+        const row = rows[i];
+
+        if (identity(row) !== key)                                        { broke = 'verdict-changed'; break }
+        if (row.stateFingerprint !== latest.stateFingerprint)             { broke = 'state-changed';   break }
+
+        streak++
+    }
+
+    const verdict = {
+        target       : latest.target ?? null,
+        recoveryClass: latest.recoveryClass ?? null,
+        rung         : latest.rung ?? null,
+        reasonCode   : latest.reasonCode ?? null,
+        disposition  : latest.disposition ?? null
+    };
+
+    if (streak < maxIdenticalVerdicts) {
+        return {
+            freeze: false,
+            status: broke ?? 'below-threshold',
+            reason: broke
+                ? `run broken by ${broke} after ${streak} identical verdict(s)`
+                : `${streak} of ${maxIdenticalVerdicts} identical verdicts`,
+            streak,
+            escalation: null,
+            verdict
+        }
+    }
+
+    return {
+        freeze    : true,
+        status    : 'freeze',
+        reason    : `${streak} identical verdicts with no state change`,
+        streak,
+        escalation: UNACTIONED_DISPOSITIONS.includes(verdict.disposition)
+            ? FUTILITY_ESCALATIONS.NO_ADMITTED_REMEDY
+            : FUTILITY_ESCALATIONS.REMEDY_INEFFECTIVE,
+        verdict
+    }
+}

--- a/ai/services/memory-core/helpers/healActionDispatch.mjs
+++ b/ai/services/memory-core/helpers/healActionDispatch.mjs
@@ -346,10 +346,18 @@ export function decideFutilityFreeze({verdicts = [], bounds = DEFAULT_FUTILITY_B
           latest   = rows[rows.length - 1],
           key      = identity(latest);
 
+    // Per-target by construction, not by caller discipline. The breaker's unit is ONE target, and
+    // `identity` includes the target — so walking a mixed ledger let any other target's verdict read
+    // as "the verdict changed" and reset this target's run. Two targets failing in alternation could
+    // then both stay at streak 1 forever while each was independently futile. Filtering here rather
+    // than documenting a prefilter requirement keeps the guarantee where the arithmetic is: a caller
+    // that forgets cannot silently disable the breaker.
+    const scoped = rows.filter(row => (row.target ?? null) === (latest.target ?? null));
+
     let streak = 0, broke = null;
 
-    for (let i = rows.length - 1; i >= 0; i--) {
-        const row = rows[i];
+    for (let i = scoped.length - 1; i >= 0; i--) {
+        const row = scoped[i];
 
         if (identity(row) !== key)                                        { broke = 'verdict-changed'; break }
         if (row.stateFingerprint !== latest.stateFingerprint)             { broke = 'state-changed';   break }

--- a/ai/services/memory-core/helpers/healEventLedgerStore.mjs
+++ b/ai/services/memory-core/helpers/healEventLedgerStore.mjs
@@ -324,9 +324,15 @@ export function queryHealLedger(events = [], {sinceMs, untilMs, types, collectio
 }
 
 /**
- * Escalating freeze tiers. A target thawed and refrozen must be harder to unfreeze than one frozen for
- * the first time, so each successive freeze multiplies the required quiet window.
- * @type {{baseThawQuietMs: Number, tierMultiplier: Number}}
+ * Escalating freeze tiers. A target thawed and REFROZEN must be harder to unfreeze than one frozen for
+ * the first time, so each successive refreeze multiplies the required quiet window. A duplicate freeze
+ * row on an already-frozen target refreshes its evidence and timestamp but does NOT advance the tier —
+ * escalation tracks cycles, not ledger rows.
+ *
+ * `maxThawQuietMs` caps the growth. Without it, enough flap cycles freeze a target permanently with no
+ * operator in the loop, which turns containment into abandonment; it is a bound on the product, so
+ * `maxThawQuietMs >= baseThawQuietMs` is required for the bounds to be usable at all.
+ * @type {{baseThawQuietMs: Number, tierMultiplier: Number, maxThawQuietMs: Number}}
  */
 export const DEFAULT_THAW_BOUNDS = Object.freeze({baseThawQuietMs: 1800000, tierMultiplier: 2, maxThawQuietMs: 86400000});
 
@@ -362,11 +368,23 @@ export function foldFutilityFreezeState(events = [], {now, bounds = DEFAULT_THAW
         if (!target) continue;
 
         if (event.type === HEAL_LEDGER_FROZEN_TRANSITIONS.FREEZE && Number.isFinite(event.at)) {
-            tiers[target] = (tiers[target] ?? 0) + 1;
+            // A tier escalates only on a REFREEZE — cleared, then frozen again. A second freeze row
+            // while the target is already frozen is the same freeze re-observed (a duplicate write, a
+            // replayed transition, a re-emitted row), and counting it advanced the tier without any
+            // intervening thaw. That doubled the quiet window off a duplicate, so the fold was not
+            // idempotent over its own ledger — and a ledger is exactly the input that can repeat.
+            const refreeze = !active.has(target);
+
+            if (refreeze) {
+                tiers[target] = (tiers[target] ?? 0) + 1
+            }
+
+            // Evidence and time still refresh: the target is observably still futile now. Only the
+            // TIER is withheld, because the tier is what raises the bar for the next cycle.
             active.set(target, {
                 target,
                 at        : event.at,
-                tier      : tiers[target],
+                tier      : tiers[target] ?? 1,
                 escalation: event.detail?.escalation ?? null,
                 evidence  : event.detail?.verdict ?? null
             })

--- a/ai/services/memory-core/helpers/healEventLedgerStore.mjs
+++ b/ai/services/memory-core/helpers/healEventLedgerStore.mjs
@@ -328,7 +328,7 @@ export function queryHealLedger(events = [], {sinceMs, untilMs, types, collectio
  * the first time, so each successive freeze multiplies the required quiet window.
  * @type {{baseThawQuietMs: Number, tierMultiplier: Number}}
  */
-export const DEFAULT_THAW_BOUNDS = Object.freeze({baseThawQuietMs: 1800000, tierMultiplier: 2});
+export const DEFAULT_THAW_BOUNDS = Object.freeze({baseThawQuietMs: 1800000, tierMultiplier: 2, maxThawQuietMs: 86400000});
 
 /**
  * @summary Folds freeze / unfreeze ledger events into each target's current freeze state, evidence and
@@ -349,7 +349,7 @@ export const DEFAULT_THAW_BOUNDS = Object.freeze({baseThawQuietMs: 1800000, tier
  *     `{target, at, tier, escalation, evidence, requiredQuietMs, thawEligibleAt, thawEligible}`.
  */
 export function foldFutilityFreezeState(events = [], {now, bounds = DEFAULT_THAW_BOUNDS} = {}) {
-    const {baseThawQuietMs, tierMultiplier} = {...DEFAULT_THAW_BOUNDS, ...(bounds ?? {})},
+    const {baseThawQuietMs, tierMultiplier, maxThawQuietMs} = {...DEFAULT_THAW_BOUNDS, ...(bounds ?? {})},
           rows                              = Array.isArray(events) ? events : [],
           active                            = new Map(),
           tiers                             = {};
@@ -380,11 +380,15 @@ export function foldFutilityFreezeState(events = [], {now, bounds = DEFAULT_THAW
         }
     }
 
-    const usable = Number.isFinite(baseThawQuietMs) && Number.isFinite(tierMultiplier) && baseThawQuietMs > 0 && tierMultiplier >= 1;
+    const usable = Number.isFinite(baseThawQuietMs) && Number.isFinite(tierMultiplier) && Number.isFinite(maxThawQuietMs) &&
+                   baseThawQuietMs > 0 && tierMultiplier >= 1 && maxThawQuietMs >= baseThawQuietMs;
 
     const frozen = [...active.values()]
         .map(entry => {
-            const requiredQuietMs = usable ? baseThawQuietMs * Math.pow(tierMultiplier, entry.tier - 1) : null,
+            // Capped: without a ceiling, enough flap cycles freeze a target permanently with no
+            // operator in the loop, which turns containment into abandonment.
+            const grown           = usable ? baseThawQuietMs * Math.pow(tierMultiplier, entry.tier - 1) : null,
+                  requiredQuietMs = grown === null ? null : Math.min(grown, maxThawQuietMs),
                   thawEligibleAt  = requiredQuietMs === null ? null : entry.at + requiredQuietMs;
 
             return {

--- a/ai/services/memory-core/helpers/healEventLedgerStore.mjs
+++ b/ai/services/memory-core/helpers/healEventLedgerStore.mjs
@@ -322,3 +322,80 @@ export function queryHealLedger(events = [], {sinceMs, untilMs, types, collectio
 
     return Number.isFinite(limit) && limit >= 0 ? filtered.slice(0, limit) : filtered;
 }
+
+/**
+ * Escalating freeze tiers. A target thawed and refrozen must be harder to unfreeze than one frozen for
+ * the first time, so each successive freeze multiplies the required quiet window.
+ * @type {{baseThawQuietMs: Number, tierMultiplier: Number}}
+ */
+export const DEFAULT_THAW_BOUNDS = Object.freeze({baseThawQuietMs: 1800000, tierMultiplier: 2});
+
+/**
+ * @summary Folds freeze / unfreeze ledger events into each target's current freeze state, evidence and
+ * thaw condition — the snapshot-visible surface, and the `refreezeTier` the next freeze escalates on.
+ *
+ * A `freeze` row records; a matching `unfreeze` clears it and increments that target's tier. Tier N
+ * requires `baseThawQuietMs * tierMultiplier^(N-1)` of quiet before the declared condition is met, so a
+ * target that keeps returning becomes progressively harder to thaw.
+ *
+ * `operatorThaw: true` on an unfreeze marks the clear as manual, which does NOT raise the tier — an
+ * operator judging a target healthy is evidence, not another failure.
+ *
+ * @param {Object[]} [events=[]] Heal-event entries in append order, oldest → newest.
+ * @param {Object}   [options]
+ * @param {Number}   [options.now] Epoch ms; required for `thawEligible`.
+ * @param {{baseThawQuietMs: Number, tierMultiplier: Number}} [options.bounds=DEFAULT_THAW_BOUNDS]
+ * @returns {{frozen: Object[], tiers: Object}} `frozen` entries carry
+ *     `{target, at, tier, escalation, evidence, requiredQuietMs, thawEligibleAt, thawEligible}`.
+ */
+export function foldFutilityFreezeState(events = [], {now, bounds = DEFAULT_THAW_BOUNDS} = {}) {
+    const {baseThawQuietMs, tierMultiplier} = {...DEFAULT_THAW_BOUNDS, ...(bounds ?? {})},
+          rows                              = Array.isArray(events) ? events : [],
+          active                            = new Map(),
+          tiers                             = {};
+
+    for (const event of rows) {
+        if (!event || typeof event !== 'object') continue;
+
+        const target = typeof event.collection === 'string' && event.collection.length > 0 ? event.collection : null;
+
+        if (!target) continue;
+
+        if (event.type === HEAL_LEDGER_FROZEN_TRANSITIONS.FREEZE && Number.isFinite(event.at)) {
+            tiers[target] = (tiers[target] ?? 0) + 1;
+            active.set(target, {
+                target,
+                at        : event.at,
+                tier      : tiers[target],
+                escalation: event.detail?.escalation ?? null,
+                evidence  : event.detail?.verdict ?? null
+            })
+        } else if (event.type === HEAL_LEDGER_FROZEN_TRANSITIONS.UNFREEZE) {
+            active.delete(target);
+
+            // A manual clear is not another failure, so it does not raise the bar for the next freeze.
+            if (event.detail?.operatorThaw === true) {
+                tiers[target] = Math.max(0, (tiers[target] ?? 1) - 1)
+            }
+        }
+    }
+
+    const usable = Number.isFinite(baseThawQuietMs) && Number.isFinite(tierMultiplier) && baseThawQuietMs > 0 && tierMultiplier >= 1;
+
+    const frozen = [...active.values()]
+        .map(entry => {
+            const requiredQuietMs = usable ? baseThawQuietMs * Math.pow(tierMultiplier, entry.tier - 1) : null,
+                  thawEligibleAt  = requiredQuietMs === null ? null : entry.at + requiredQuietMs;
+
+            return {
+                ...entry,
+                requiredQuietMs,
+                thawEligibleAt,
+                // Never eligible without a clock or usable bounds: an unbounded thaw would defeat the freeze.
+                thawEligible: Number.isFinite(now) && thawEligibleAt !== null && now >= thawEligibleAt
+            }
+        })
+        .sort((a, b) => a.target.localeCompare(b.target));
+
+    return {frozen, tiers}
+}

--- a/test/playwright/unit/ai/daemons/orchestrator/services/DeploymentStateBridgeService.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/services/DeploymentStateBridgeService.spec.mjs
@@ -491,6 +491,40 @@ test.describe('Neo.ai.daemons.services.DeploymentStateBridgeService', () => {
         expect(selfHeal.limit).toBe(10);                              // the snapshot reports its OWN recent-event cap
     });
 
+    test('collectSelfHealSnapshot publishes each freeze with its escalation, evidence and thaw condition', async () => {
+        // `currentlyFrozen` is a bare target list, so a frozen target published no reason and no way out.
+        const events = [
+            {type: 'freeze', collection: 'embedding-model', status: 'contained', at: 5, detail: {
+                escalation: 'no-admitted-remedy',
+                verdict   : {rung: 'rung-2', reasonCode: 'throttle-shed-has-no-admitted-action', recoveryClass: 'exhaustion'}
+            }}
+        ];
+        const service  = createService({healLedgerDir: '/heal', healLedgerReader: async () => events}),
+              selfHeal = await service.collectSelfHealSnapshot();
+
+        expect(selfHeal.summary.currentlyFrozen).toEqual(['embedding-model']);
+        expect(selfHeal.freezeState.frozen).toHaveLength(1);
+        expect(selfHeal.freezeState.frozen[0]).toMatchObject({
+            target    : 'embedding-model',
+            tier      : 1,
+            escalation: 'no-admitted-remedy'
+        });
+        expect(selfHeal.freezeState.frozen[0].evidence.reasonCode).toBe('throttle-shed-has-no-admitted-action');
+        expect(selfHeal.freezeState.frozen[0].requiredQuietMs, 'a thaw condition must be published, not implied').toBeGreaterThan(0);
+    });
+
+    test('every selfHeal envelope carries freezeState, so a consumer never branches on its absence', async () => {
+        const disabled = await createService({}).collectSelfHealSnapshot(),
+              degraded = await createService({healLedgerDir: '/heal', healLedgerReader: async () => { throw new Error('disk gone'); }}).collectSelfHealSnapshot();
+
+        expect(disabled.status).toBe('disabled');
+        expect(degraded.status).toBe('degraded');
+        for (const envelope of [disabled, degraded]) {
+            expect('freezeState' in envelope, `${envelope.status} envelope must declare freezeState`).toBe(true);
+            expect(envelope.freezeState).toBeNull();
+        }
+    });
+
     test('collectSelfHealSnapshot is disabled (graceful) when no heal-ledger dir is wired', async () => {
         const selfHeal = await createService({}).collectSelfHealSnapshot();
         expect(selfHeal).toMatchObject({status: 'disabled', summary: null, recentEvents: []});

--- a/test/playwright/unit/ai/services/memory-core/helpers/healActionDispatch.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/helpers/healActionDispatch.spec.mjs
@@ -2,6 +2,9 @@ import {test, expect} from '@playwright/test';
 import Neo            from '../../../../../../../src/Neo.mjs';
 import * as core      from '../../../../../../../src/core/_export.mjs';
 import {
+    DEFAULT_FUTILITY_BOUNDS,
+    FUTILITY_ESCALATIONS,
+    decideFutilityFreeze,
     decideHealAction,
     detectChronicUnsafeInput,
     dispatchHeal,
@@ -375,5 +378,103 @@ test.describe('healActionDispatch — throttle-shed vocabulary (#14284)', () => 
 
         expect(called).toBe(true); // reachable through the dispatch vocabulary — NOT rejected as unknown-action
         expect(outcome).toMatchObject({action: 'throttle-shed', collection: 'kbSync', status: 'shed', healedAt: NOW2});
+    });
+});
+
+/**
+ * The futility breaker: freeze a target whose verdict repeats with no state change.
+ *
+ * Keyed on repeated identical verdicts rather than executor failures, because the route table gives
+ * `throttle-shed` and `record` an `actuatorAction: null` — neither ever invokes an executor, and those
+ * two dispositions are the majority of live ledger rows.
+ */
+test.describe('decideFutilityFreeze — futility breaker', () => {
+    const NOW = 1_000_000;
+
+    const verdicts = ({count, disposition = 'recorded', fingerprint = 'f1', reasonCode = 'throttle-shed-has-no-admitted-action'}) =>
+        Array.from({length: count}, (_, i) => ({
+            target          : 'embedding-model',
+            recoveryClass   : 'exhaustion',
+            rung            : 'rung-2',
+            reasonCode,
+            disposition,
+            stateFingerprint: fingerprint,
+            at              : NOW - (count - i) * 1000
+        }));
+
+    test('freezes on the threshold for EVERY disposition, including the ones that invoke no executor', () => {
+        for (const disposition of ['recorded', 'declined', 'no-action', 'deferred', 'failed']) {
+            const result = decideFutilityFreeze({verdicts: verdicts({count: 5, disposition}), now: NOW});
+
+            expect(result.freeze, `${disposition} must freeze at the threshold`).toBe(true);
+            expect(result.streak).toBe(5);
+        }
+    });
+
+    test('RED-PROOF: a failure counter would see none of these — four of five dispositions never fail', () => {
+        // The arm that fails if the signal reverts to executor failures.
+        const unactioned = verdicts({count: 9, disposition: 'recorded'});
+
+        expect(unactioned.filter(v => v.disposition === 'failed')).toHaveLength(0);
+        expect(decideFutilityFreeze({verdicts: unactioned, now: NOW}).freeze).toBe(true);
+    });
+
+    test('escalation distinguishes an ineffective remedy from an absent one', () => {
+        expect(decideFutilityFreeze({verdicts: verdicts({count: 5, disposition: 'failed'}), now: NOW}).escalation)
+            .toBe(FUTILITY_ESCALATIONS.REMEDY_INEFFECTIVE);
+        expect(decideFutilityFreeze({verdicts: verdicts({count: 5, disposition: 'recorded'}), now: NOW}).escalation)
+            .toBe(FUTILITY_ESCALATIONS.NO_ADMITTED_REMEDY);
+    });
+
+    test('NEGATIVE CONTROL: below the threshold does not freeze', () => {
+        const result = decideFutilityFreeze({verdicts: verdicts({count: DEFAULT_FUTILITY_BOUNDS.maxIdenticalVerdicts - 1}), now: NOW});
+
+        expect(result.freeze).toBe(false);
+        expect(result.status).toBe('below-threshold');
+    });
+
+    test('a changed state fingerprint breaks the run — the loop is observing something new', () => {
+        const rows = verdicts({count: 5});
+
+        rows[2].stateFingerprint = 'f2';
+
+        const result = decideFutilityFreeze({verdicts: rows, now: NOW});
+
+        expect(result.freeze).toBe(false);
+        expect(result.status).toBe('state-changed');
+        expect(result.streak).toBe(2);
+    });
+
+    test('a changed verdict breaks the run', () => {
+        const rows = verdicts({count: 5});
+
+        rows[1].reasonCode = 'diagnosis-record';
+
+        const result = decideFutilityFreeze({verdicts: rows, now: NOW});
+
+        expect(result.freeze).toBe(false);
+        expect(result.status).toBe('verdict-changed');
+    });
+
+    test('verdicts older than the window do not count toward the streak', () => {
+        const stale = verdicts({count: 9}).map(v => ({...v, at: NOW - DEFAULT_FUTILITY_BOUNDS.windowMs - 1}));
+
+        expect(decideFutilityFreeze({verdicts: stale, now: NOW}).status).toBe('no-verdicts');
+    });
+
+    test('fails OPEN on unsafe input — a breaker must never silence healing on a bad clock', () => {
+        for (const bad of [{verdicts: verdicts({count: 9})}, {verdicts: verdicts({count: 9}), now: NaN},
+                           {verdicts: verdicts({count: 9}), now: NOW, bounds: {maxIdenticalVerdicts: 0}}]) {
+            const result = decideFutilityFreeze(bad);
+
+            expect(result.freeze, 'unsafe input must not freeze').toBe(false);
+            expect(result.status).toBe('unsafe-input');
+        }
+    });
+
+    test('partial bounds normalize onto the defaults rather than disabling the gate', () => {
+        const result = decideFutilityFreeze({verdicts: verdicts({count: 5}), bounds: {windowMs: 3_600_000}, now: NOW});
+
+        expect(result.freeze).toBe(true);
     });
 });

--- a/test/playwright/unit/ai/services/memory-core/helpers/healActionDispatch.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/helpers/healActionDispatch.spec.mjs
@@ -456,6 +456,48 @@ test.describe('decideFutilityFreeze — futility breaker', () => {
         expect(result.status).toBe('verdict-changed');
     });
 
+    test('RED-PROOF: interleaved targets each reach the threshold independently', () => {
+        // The breaker's unit is ONE target. Because the verdict identity includes the target, an
+        // unfiltered backward walk read every other target's row as "the verdict changed" — so two
+        // targets failing in alternation both sat at streak 1 forever while each was independently
+        // futile. A ledger with more than one sick target is the normal case, not the exotic one.
+        const rowsFor = target => verdicts({count: 5}).map(row => ({...row, target})),
+              a       = rowsFor('embedding-model'),
+              b       = rowsFor('chroma');
+
+        // Alternate them, preserving each target's own chronology.
+        const interleaved = a.flatMap((row, index) => [row, b[index]]).sort((x, y) => x.at - y.at);
+
+        const latest = decideFutilityFreeze({verdicts: interleaved, now: NOW});
+
+        expect(latest.freeze, 'the newest target is futile on its own rows').toBe(true);
+        expect(latest.streak).toBe(5);
+
+        // And the other target reaches it too, from the same ledger — asserted by making it newest.
+        const flipped = decideFutilityFreeze({
+            verdicts: interleaved.map(row => row === interleaved.at(-1) ? {...row, at: row.at - 10_000} : row)
+                .sort((x, y) => x.at - y.at),
+            now: NOW
+        });
+
+        expect(flipped.freeze, 'both targets are independently futile in one ledger').toBe(true);
+        expect(flipped.verdict.target).not.toBe(latest.verdict.target);
+    });
+
+    test('NEGATIVE CONTROL: another target cannot rescue a futile one, and cannot fabricate a streak', () => {
+        // The mirror of the red-proof. Filtering per target must not become "ignore everything else":
+        // this target's OWN changed verdict still breaks its run, even when other targets are steady.
+        const mine  = verdicts({count: 5}),
+              other = verdicts({count: 5}).map(row => ({...row, target: 'chroma', at: row.at - 500}));
+
+        mine[3].reasonCode = 'diagnosis-record';
+
+        const result = decideFutilityFreeze({verdicts: [...other, ...mine].sort((x, y) => x.at - y.at), now: NOW});
+
+        expect(result.freeze).toBe(false);
+        expect(result.status).toBe('verdict-changed');
+    });
+
     test('verdicts older than the window do not count toward the streak', () => {
         const stale = verdicts({count: 9}).map(v => ({...v, at: NOW - DEFAULT_FUTILITY_BOUNDS.windowMs - 1}));
 

--- a/test/playwright/unit/ai/services/memory-core/helpers/healEventLedgerStore.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/helpers/healEventLedgerStore.spec.mjs
@@ -385,6 +385,32 @@ test.describe('foldFutilityFreezeState — freeze state, evidence and thaw condi
         expect(entry.thawEligible, 'the first-freeze window is no longer sufficient').toBe(false);
     });
 
+    test('RED-PROOF: a DUPLICATE freeze row is not a refreeze — the fold is idempotent over its ledger', () => {
+        // A ledger is exactly the input that repeats: a replayed transition, a re-emitted row, a
+        // double write. Advancing the tier on every freeze row doubled the quiet window off a
+        // duplicate with no intervening thaw, so the same target was punished for being observed
+        // twice. Escalation tracks CYCLES, never rows.
+        const {frozen, tiers} = foldFutilityFreezeState([freeze('a', 0), freeze('a', 1)], {now: 1 + BASE});
+        const [entry]         = frozen;
+
+        expect(entry.tier, 'a second row while already frozen is the same freeze').toBe(1);
+        expect(tiers.a).toBe(1);
+        expect(entry.requiredQuietMs, 'the window must not double off a duplicate').toBe(BASE);
+
+        // Evidence and time DO refresh — the target is observably still futile at the later row.
+        expect(entry.at).toBe(1);
+    });
+
+    test('and the true cycle still escalates, so the guard above is not a blanket suppression', () => {
+        // The discriminating pair for the arm above: identical row count, one real thaw between them.
+        const duplicated = foldFutilityFreezeState([freeze('a', 0), freeze('a', 1)], {now: 1 + BASE}).frozen[0],
+              cycled     = foldFutilityFreezeState([freeze('a', 0), thaw('a', 1), freeze('a', 2)], {now: 2 + BASE}).frozen[0];
+
+        expect(duplicated.tier).toBe(1);
+        expect(cycled.tier, 'cleared then frozen again IS an escalation').toBe(2);
+        expect(cycled.requiredQuietMs).toBeGreaterThan(duplicated.requiredQuietMs);
+    });
+
     test('an OPERATOR thaw does not raise the bar — a judgement is evidence, not another failure', () => {
         const [entry] = foldFutilityFreezeState([freeze('a', 0), thaw('a', 1, {operatorThaw: true}), freeze('a', 2)], {now: 2 + BASE}).frozen;
 

--- a/test/playwright/unit/ai/services/memory-core/helpers/healEventLedgerStore.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/helpers/healEventLedgerStore.spec.mjs
@@ -6,6 +6,8 @@ import fs             from 'fs/promises';
 import os             from 'os';
 import path           from 'path';
 import {
+    DEFAULT_THAW_BOUNDS,
+    foldFutilityFreezeState,
     getHealLedgerFilePath,
     appendHealEvent,
     readHealLedger,
@@ -346,5 +348,69 @@ test.describe('validateHealLedgerRetention — fail-visible boundary guard (#141
         for (const bad of [-1, NaN, Infinity]) {
             expect(() => validateHealLedgerRetention(5000, bad)).toThrow(/pruneTriggerBytes must be a finite, non-negative number/);
         }
+    });
+});
+
+/**
+ * The snapshot-visible freeze surface: which targets are frozen, on what evidence, and what thaws them.
+ * A refrozen target must be harder to thaw than one frozen for the first time.
+ */
+test.describe('foldFutilityFreezeState — freeze state, evidence and thaw condition', () => {
+    const BASE   = DEFAULT_THAW_BOUNDS.baseThawQuietMs,
+          freeze = (target, at, detail) => ({type: 'freeze',   collection: target, at, detail}),
+          thaw   = (target, at, detail) => ({type: 'unfreeze', collection: target, at, detail});
+
+    test('a freeze is visible with its escalation and verdict evidence', () => {
+        const {frozen} = foldFutilityFreezeState([
+            freeze('embedding-model', 0, {escalation: 'no-admitted-remedy', verdict: {rung: 'rung-2', reasonCode: 'throttle-shed-has-no-admitted-action'}})
+        ], {now: BASE});
+
+        expect(frozen).toHaveLength(1);
+        expect(frozen[0].target).toBe('embedding-model');
+        expect(frozen[0].escalation).toBe('no-admitted-remedy');
+        expect(frozen[0].evidence.reasonCode).toBe('throttle-shed-has-no-admitted-action');
+        expect(frozen[0].requiredQuietMs).toBe(BASE);
+        expect(frozen[0].thawEligible).toBe(true);
+    });
+
+    test('an unfreeze clears it', () => {
+        expect(foldFutilityFreezeState([freeze('a', 0), thaw('a', 1)], {now: BASE}).frozen).toHaveLength(0);
+    });
+
+    test('a refrozen target requires a STRICTER quiet window than the first freeze', () => {
+        const [entry] = foldFutilityFreezeState([freeze('a', 0), thaw('a', 1), freeze('a', 2)], {now: 2 + BASE}).frozen;
+
+        expect(entry.tier).toBe(2);
+        expect(entry.requiredQuietMs).toBe(BASE * DEFAULT_THAW_BOUNDS.tierMultiplier);
+        expect(entry.thawEligible, 'the first-freeze window is no longer sufficient').toBe(false);
+    });
+
+    test('an OPERATOR thaw does not raise the bar — a judgement is evidence, not another failure', () => {
+        const [entry] = foldFutilityFreezeState([freeze('a', 0), thaw('a', 1, {operatorThaw: true}), freeze('a', 2)], {now: 2 + BASE}).frozen;
+
+        expect(entry.tier).toBe(1);
+        expect(entry.thawEligible).toBe(true);
+    });
+
+    test('never eligible without a clock or with unusable bounds', () => {
+        expect(foldFutilityFreezeState([freeze('a', 0)], {}).frozen[0].thawEligible).toBe(false);
+        expect(foldFutilityFreezeState([freeze('a', 0)], {now: BASE, bounds: {baseThawQuietMs: 0}}).frozen[0].thawEligible).toBe(false);
+    });
+
+    test('multiple targets fold independently, sorted for a stable snapshot', () => {
+        const {frozen} = foldFutilityFreezeState([freeze('zeta', 0), freeze('alpha', 1), freeze('mid', 2), thaw('mid', 3)], {now: BASE});
+
+        expect(frozen.map(f => f.target)).toEqual(['alpha', 'zeta']);
+    });
+
+    test('a non-freeze row and a target-less row are ignored', () => {
+        const {frozen} = foldFutilityFreezeState([
+            {type: 'attempt', collection: 'a', at: 0},
+            {type: 'freeze', at: 1},
+            freeze('a', 2)
+        ], {now: BASE});
+
+        expect(frozen.map(f => f.target)).toEqual(['a']);
+        expect(frozen[0].tier).toBe(1);
     });
 });

--- a/test/playwright/unit/ai/services/memory-core/helpers/healEventLedgerStore.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/helpers/healEventLedgerStore.spec.mjs
@@ -392,6 +392,29 @@ test.describe('foldFutilityFreezeState — freeze state, evidence and thaw condi
         expect(entry.thawEligible).toBe(true);
     });
 
+    test('the escalating window is CAPPED — containment must not become abandonment', () => {
+        // Without a ceiling, enough flap cycles make a target permanently frozen with no operator in
+        // the loop.
+        const flapped = [];
+
+        for (let i = 0; i < 12; i++) {
+            flapped.push(freeze('a', i * 2), thaw('a', i * 2 + 1))
+        }
+        flapped.push(freeze('a', 100));
+
+        const [entry] = foldFutilityFreezeState(flapped, {now: 100}).frozen;
+
+        expect(entry.tier).toBeGreaterThan(10);
+        expect(entry.requiredQuietMs, 'saturates at the ceiling').toBe(DEFAULT_THAW_BOUNDS.maxThawQuietMs);
+    });
+
+    test('an unusable ceiling below the base window is refused rather than applied', () => {
+        const [entry] = foldFutilityFreezeState([freeze('a', 0)], {now: BASE, bounds: {maxThawQuietMs: 1}}).frozen;
+
+        expect(entry.requiredQuietMs).toBeNull();
+        expect(entry.thawEligible).toBe(false);
+    });
+
     test('never eligible without a clock or with unusable bounds', () => {
         expect(foldFutilityFreezeState([freeze('a', 0)], {}).frozen[0].thawEligible).toBe(false);
         expect(foldFutilityFreezeState([freeze('a', 0)], {now: BASE, bounds: {baseThawQuietMs: 0}}).frozen[0].thawEligible).toBe(false);


### PR DESCRIPTION
Resolves neomjs/neo#17403

Refs neomjs/neo#17044

The self-heal loop re-derived the same verdict on a fixed cadence forever and nothing escalated. `decideFutilityFreeze` keys on consecutive identical verdicts with no state change — whatever the disposition — and `foldFutilityFreezeState` turns the freeze into a surface that states why a target is frozen and what clears it.

Evidence: L3 (pure deciders plus a read-only projection; every AC decidable in-process) → L3 required. Residual: none for neomjs/neo#17403; the producer, the consumer gate and thaw execution stay on the parent, Residual-Owner: neomjs/neo#17044.

## Why the signal is not executor failures

`CONTAINER_HEALTH_ACTION_ROUTES` gives `throttleShed` and `record` an `actuatorAction: null`, so neither ever invokes an executor. Live ledger on the external plane: **5,000 events, 10 `failed`** against 2,310 `declined` and 2,495 `recorded`. A failure counter counts 10 of 5,000 and never engages while the majority terminals accrue no-effect rows. neomjs/neo#17044's AC-1 was widened accordingly before this leaf was cut.

Escalation keeps the two shapes apart: a failed action means *this remedy does not work*; an unactioned verdict means *this class has no remedy on this target*, which is a substrate gap for someone to close rather than a retry to abandon.

## Deltas from ticket

**Fails open, not closed.** `decideHealAction` fails closed because refusing to dispatch is the safe direction there. A breaker inverts that: engaging on a bad clock would silence healing, so a missing/`NaN` clock or non-positive threshold yields no freeze.

**The state fold lives in the ledger store, not beside the decider.** `healSystemicCircuit` keeps its fold next to its decider with its own event constants, which was the shape I started from. But `HEAL_LEDGER_FROZEN_TRANSITIONS` already exists and `summarizeHealLedger` already folds those two types, so a copy beside the decider would be two owners for one two-value enum — and importing the ledger store into `healActionDispatch` would pull `fs/promises` into a module documented as pure. The fold moved to the owning module.

**Thaw escalates.** Tier N requires `baseThawQuietMs * tierMultiplier^(N-1)` of quiet, so a target that keeps returning is harder to clear each time. An operator thaw does not raise the tier — a maintainer judging a target healthy is evidence, not another failure.

**`freezeState` is declared on every envelope**, `null` on disabled and degraded, so a consumer never branches on its absence.

## Test Evidence

- `test/playwright/unit/ai/services/memory-core/` — **1811 passed**, 6 skipped (`--workers=1`).
- `test/playwright/unit/ai/daemons/orchestrator/` — **1674 passed**.

Per touched surface:
- `helpers/healActionDispatch.mjs` → `healActionDispatch.spec.mjs`: 9 arms. Includes the red-proof that a verdict stream with **zero** `failed` rows still freezes, the per-disposition sweep, the two escalation kinds, the below-threshold control, verdict-changed and state-changed run breaks, out-of-window exclusion, and fail-open asserted per unsafe-input case.
- `helpers/healEventLedgerStore.mjs` → `healEventLedgerStore.spec.mjs`: 8 arms. Freeze publishes escalation and evidence; unfreeze clears; a refreeze requires a strictly longer window than the first freeze; an operator thaw does not raise the tier; never eligible without a clock or with unusable bounds; multi-target folding is sorted; non-freeze and target-less rows ignored.
- `services/DeploymentStateBridgeService.mjs` → `DeploymentStateBridgeService.spec.mjs`: **124 passed**, 2 new arms — `freezeState` published with escalation, evidence and a positive thaw window, and declared on both the disabled and degraded envelopes.

## Post-Merge Validation

- [ ] On the external plane, `selfHeal.freezeState.frozen` stays empty until the parent's producer lands — this leaf publishes the surface, it does not populate it.

Residual-Owner: neomjs/neo#17044

## Commits

- `ad0b8b7b63` — the futility decider.
- `0153d2c123` — freeze state, evidence, escalating thaw.
- `d9da8224c6` — the snapshot projection.

Authored by Vega (Claude Opus 5, Claude Code). Session 8cbd588b-be06-4a56-9997-1058f2a3a07b.
