### PR TITLE
fix(test): the Playwright fixture supplies the bridge cwd it needs (#17402)

### DIFF
--- a/ai/services/neural-link/ConnectionService.mjs
+++ b/ai/services/neural-link/ConnectionService.mjs
@@ -8,6 +8,14 @@ import Base      from '../../../src/core/Base.mjs';
 import logger    from '../../mcp/server/neural-link/logger.mjs';
 
 /**
+ * The npm script `spawnBridge` runs. Exported so an entrypoint deriving its own `cwd` can validate
+ * that candidate against the script that will actually be run there, rather than against a copy of
+ * this name that is free to drift from it.
+ * @type {String}
+ */
+export const BRIDGE_NPM_SCRIPT = 'ai:server-neural-link';
+
+/**
  * @summary Decides what `initAsync()` may do about the Bridge at construction time.
  *
  * Exported as a plain function so specs drive the production decision rather than a mirror of it:
@@ -818,7 +826,7 @@ class ConnectionService extends Base {
         // nothing and produced an ENOENT three layers away. A hidden default that substitutes a
         // wrong value is worse than no default: it converts a missing input into a distant symptom.
         return new Promise((resolve, reject) => {
-            const args    = ['run', 'ai:server-neural-link'];
+            const args    = ['run', BRIDGE_NPM_SCRIPT];
             const file    = getBridgeStdioLogPath({logPath});
             const logFile = this.openBridgeLogFile(file);
             const port    = aiConfig.port;

--- a/learn/guides/testing/WhiteboxE2E.md
+++ b/learn/guides/testing/WhiteboxE2E.md
@@ -36,6 +36,8 @@ npx playwright test test/playwright/e2e/<domain>/YourTestNL.spec.mjs -c test/pla
 
 Whitebox E2E tests are located in `test/playwright/e2e/`. Instead of manually establishing WebSocket connections, the Neo.mjs team provides a powerful Playwright fixture called `neuralLink`.
 
+The fixture connects to a Bridge already listening on `aiConfig.port`, and spawns one when none is. You never need a Bridge running first — the fixture supplies the working directory a spawn requires, using `process.cwd()`, which a Playwright run guarantees is the project root.
+
 ### Core Connection Boilerplate
 When tests launch, you can use the `neuralLink` parameter injected by Playwright. This abstracts away the internal component architecture and exposes a simple SDK.
 

--- a/learn/guides/testing/WhiteboxE2E.md
+++ b/learn/guides/testing/WhiteboxE2E.md
@@ -36,7 +36,9 @@ npx playwright test test/playwright/e2e/<domain>/YourTestNL.spec.mjs -c test/pla
 
 Whitebox E2E tests are located in `test/playwright/e2e/`. Instead of manually establishing WebSocket connections, the Neo.mjs team provides a powerful Playwright fixture called `neuralLink`.
 
-The fixture connects to a Bridge already listening on `aiConfig.port`, and spawns one when none is. You never need a Bridge running first — the fixture supplies the working directory a spawn requires, using `process.cwd()`, which a Playwright run guarantees is the project root.
+The fixture connects to a Bridge already listening on `aiConfig.port`, and spawns one when none is. You never need a Bridge running first — the fixture supplies the working directory a spawn requires, by walking up from its own location to the package that declares the Bridge npm script.
+
+It deliberately does not use `process.cwd()`. Playwright resolves `testDir` from the config file and never changes directory, so `npx playwright test -c /abs/path/config.mjs` invoked from anywhere is a valid run whose worker cwd is that anywhere. Where no ancestor declares the script, the fixture leaves the working directory unset and the spawn refuses by name, rather than starting `npm` somewhere it cannot resolve.
 
 ### Core Connection Boilerplate
 When tests launch, you can use the `neuralLink` parameter injected by Playwright. This abstracts away the internal component architecture and exposes a simple SDK.

--- a/test/playwright/findBridgeScriptRoot.mjs
+++ b/test/playwright/findBridgeScriptRoot.mjs
@@ -1,0 +1,45 @@
+import {existsSync, readFileSync} from 'node:fs';
+import path                       from 'node:path';
+
+/**
+ * @summary Finds the directory that owns a given npm script, walking up from a starting directory.
+ *
+ * The Playwright fixture is the second Neural Link Bridge entrypoint, and it owes `spawnBridge` the
+ * same working directory the MCP server supplies via `--cwd`. It cannot use `process.cwd()` for that:
+ * Playwright resolves `testDir` from the CONFIG and never changes directory, so
+ * `npx playwright test -c /abs/config.mjs` from any directory is a valid run whose worker cwd owns
+ * nothing. Anchoring on a caller-supplied directory inside the package is what makes the answer
+ * portable.
+ *
+ * Each candidate is confirmed by reading the script out of its `package.json`, so a returned path is
+ * one where `npm run <scriptName>` is known to resolve rather than one that merely looks like a root.
+ * `null` means no ancestor declared it — the caller must leave the cwd unassigned and let the spawn
+ * refuse by name, because substituting an unvalidated directory turns that named refusal into an
+ * ENOENT from `npm` several layers away.
+ *
+ * Both parameters are required on purpose: a default for either would be a hidden default of exactly
+ * the kind this function exists to remove.
+ *
+ * @param {String} fromDir    Absolute directory to start the walk at (typically the caller's own).
+ * @param {String} scriptName The npm script the returned directory must declare.
+ * @returns {String|null} The nearest ancestor declaring `scriptName`, or `null`.
+ */
+export function findBridgeScriptRoot(fromDir, scriptName) {
+    let dir = fromDir;
+
+    for (let previous = null; dir && dir !== previous; previous = dir, dir = path.dirname(dir)) {
+        const manifest = path.join(dir, 'package.json');
+
+        if (!existsSync(manifest)) continue;
+
+        try {
+            if (JSON.parse(readFileSync(manifest, 'utf-8'))?.scripts?.[scriptName]) return dir
+        } catch {
+            // An unreadable or malformed manifest is not this walk's to report: a nearer ancestor may
+            // still own the script, and stopping here would answer "not found" for a different reason
+            // than the one the caller acts on.
+        }
+    }
+
+    return null
+}

--- a/test/playwright/fixtures.mjs
+++ b/test/playwright/fixtures.mjs
@@ -1,4 +1,7 @@
 import { test as base, expect } from '@playwright/test';
+import path                     from 'node:path';
+import { fileURLToPath }        from 'node:url';
+import { findBridgeScriptRoot } from './findBridgeScriptRoot.mjs';
 import * as RmaHelpers          from './util/RmaHelpers.mjs';
 
 // `Neo` plus the core class system, imported for their SIDE EFFECT and not for these bindings.
@@ -31,6 +34,10 @@ import NeuralLink_InstanceService    from '../../ai/services/neural-link/Instanc
 import NeuralLink_InteractionService from '../../ai/services/neural-link/InteractionService.mjs';
 import NeuralLink_RuntimeService     from '../../ai/services/neural-link/RuntimeService.mjs';
 import aiConfig                      from '../../ai/mcp/server/neural-link/config.template.mjs';
+import {BRIDGE_NPM_SCRIPT}           from '../../ai/services/neural-link/ConnectionService.mjs';
+
+// Resolved once at import: the answer is a property of where this file sits, which no test can move.
+const bridgeScriptRoot = findBridgeScriptRoot(path.dirname(fileURLToPath(import.meta.url)), BRIDGE_NPM_SCRIPT);
 
 export const test = base.extend({
     /**
@@ -100,12 +107,9 @@ export const test = base.extend({
     },
 
     neuralLink: async ({ page }, use) => {
-        // This fixture is the second Bridge entrypoint, alongside the MCP server, and the only one
-        // for which `process.cwd()` is correct by construction: Playwright resolves its config and
-        // `testDir` from the invocation directory, so a run always starts at the consuming project's
-        // root. `spawnBridge` refuses an unresolved cwd precisely because a GUI-launched server has
-        // no such guarantee. `??=` yields to an entrypoint that already supplied one.
-        NeuralLink_ConnectionService.cwd ??= process.cwd();
+        // This fixture is the second Bridge entrypoint, alongside the MCP server, so it owes the same
+        // `cwd` the MCP server supplies via `--cwd`. `??=` yields to an entrypoint that already did.
+        NeuralLink_ConnectionService.cwd ??= bridgeScriptRoot;
 
         // 1. Ensure Bridge connects
         await NeuralLink_ConnectionService.manageConnection({action: 'start'});

--- a/test/playwright/fixtures.mjs
+++ b/test/playwright/fixtures.mjs
@@ -100,6 +100,13 @@ export const test = base.extend({
     },
 
     neuralLink: async ({ page }, use) => {
+        // This fixture is the second Bridge entrypoint, alongside the MCP server, and the only one
+        // for which `process.cwd()` is correct by construction: Playwright resolves its config and
+        // `testDir` from the invocation directory, so a run always starts at the consuming project's
+        // root. `spawnBridge` refuses an unresolved cwd precisely because a GUI-launched server has
+        // no such guarantee. `??=` yields to an entrypoint that already supplied one.
+        NeuralLink_ConnectionService.cwd ??= process.cwd();
+
         // 1. Ensure Bridge connects
         await NeuralLink_ConnectionService.manageConnection({action: 'start'});
 

--- a/test/playwright/unit/test/findBridgeScriptRoot.spec.mjs
+++ b/test/playwright/unit/test/findBridgeScriptRoot.spec.mjs
@@ -1,0 +1,103 @@
+import {test, expect}                                  from '@playwright/test';
+import {mkdtempSync, mkdirSync, rmSync, writeFileSync} from 'node:fs';
+import {tmpdir}                                        from 'node:os';
+import path                                            from 'node:path';
+import {findBridgeScriptRoot}                          from '../../findBridgeScriptRoot.mjs';
+
+/**
+ * Coverage for the Bridge working-directory derivation the Playwright fixture owes `spawnBridge`.
+ *
+ * The contract: a returned directory has been CONFIRMED to declare the script, so `npm run <script>`
+ * resolves there; a directory that merely looks like a project root is not an answer. `null` is a
+ * real result the caller acts on — it leaves the cwd unassigned so the spawn refuses by name.
+ */
+const SCRIPT = 'ai:server-neural-link';
+
+/**
+ * @param {Object} tree Relative dir -> package.json contents (or null to create the dir bare).
+ * @returns {String} The temp root.
+ */
+function buildTree(tree) {
+    const root = mkdtempSync(path.join(tmpdir(), 'bridge-root-'));
+
+    for (const [relative, manifest] of Object.entries(tree)) {
+        const dir = path.join(root, relative);
+
+        mkdirSync(dir, {recursive: true});
+
+        if (manifest !== null) writeFileSync(path.join(dir, 'package.json'), manifest)
+    }
+
+    return root
+}
+
+test.describe('test/playwright/findBridgeScriptRoot — validated Bridge cwd derivation', () => {
+    const roots = [];
+
+    test.afterAll(() => roots.forEach(root => rmSync(root, {force: true, recursive: true})));
+
+    const make = tree => { const root = buildTree(tree); roots.push(root); return root };
+
+    test('returns the ancestor that declares the script', () => {
+        const root = make({
+            '.'              : JSON.stringify({scripts: {[SCRIPT]: 'node ./run.mjs'}}),
+            'test/playwright': null
+        });
+
+        expect(findBridgeScriptRoot(path.join(root, 'test/playwright'), SCRIPT)).toBe(root)
+    });
+
+    test('a package.json WITHOUT the script is not an answer — the walk continues past it', () => {
+        const root = make({
+            '.'             : JSON.stringify({scripts: {[SCRIPT]: 'node ./run.mjs'}}),
+            'packages/inner': JSON.stringify({name: 'inner', scripts: {build: 'tsc'}})
+        });
+
+        // The nearer manifest looks exactly like a project root and owns nothing relevant. Returning
+        // it is the defect this function exists to prevent: `npm run` there exits non-zero, and the
+        // caller sees a distant ENOENT instead of the named refusal.
+        expect(findBridgeScriptRoot(path.join(root, 'packages/inner'), SCRIPT)).toBe(root)
+    });
+
+    test('the NEAREST declaring ancestor wins over a further one', () => {
+        const root = make({
+            '.'            : JSON.stringify({scripts: {[SCRIPT]: 'node ./outer.mjs'}}),
+            'nested'       : JSON.stringify({scripts: {[SCRIPT]: 'node ./inner.mjs'}}),
+            'nested/deeper': null
+        });
+
+        expect(findBridgeScriptRoot(path.join(root, 'nested/deeper'), SCRIPT)).toBe(path.join(root, 'nested'))
+    });
+
+    test('returns null when no ancestor declares the script', () => {
+        const root = make({'.': JSON.stringify({name: 'unrelated'}), 'a/b': null});
+
+        expect(findBridgeScriptRoot(path.join(root, 'a/b'), SCRIPT)).toBeNull()
+    });
+
+    test('a malformed manifest does not end the walk', () => {
+        const root = make({
+            '.'     : JSON.stringify({scripts: {[SCRIPT]: 'node ./run.mjs'}}),
+            'broken': '{ this is not json'
+        });
+
+        expect(findBridgeScriptRoot(path.join(root, 'broken'), SCRIPT)).toBe(root)
+    });
+
+    test('an empty script value is not a declaration', () => {
+        const root = make({'.': JSON.stringify({scripts: {[SCRIPT]: ''}}), 'x': null});
+
+        expect(findBridgeScriptRoot(path.join(root, 'x'), SCRIPT)).toBeNull()
+    });
+
+    test('this checkout resolves to a root that really declares the script', async () => {
+        const {default: pkg} = await import(
+            path.join(findBridgeScriptRoot(path.dirname(new URL(import.meta.url).pathname), SCRIPT), 'package.json'),
+            {with: {type: 'json'}}
+        );
+
+        // The positive control for the walk itself: run against the real tree rather than a fixture,
+        // so a derivation that only works on synthetic trees cannot pass this file.
+        expect(pkg.scripts[SCRIPT]).toBeTruthy()
+    })
+});


### PR DESCRIPTION
Resolves #17402

The Playwright fixture is a second Bridge entrypoint and supplied no `cwd`, so `spawnBridge` refused wherever no Bridge was already listening — which is every clean container, and no maintainer seat. It now supplies one **derived from its own module location and validated**, never read from the ambient process.

`findBridgeScriptRoot(fromDir, scriptName)` walks up from a caller-supplied directory and returns the first ancestor whose `package.json` **declares the script**, so a returned path is one where `npm run` is known to resolve rather than one that merely looks like a root. Both arguments are required — a default for either would be a hidden default of exactly the kind this replaces. `null` stays `null`, leaving `ConnectionService.cwd` unassigned so the spawn refuses **by name**.

`BRIDGE_NPM_SCRIPT` moves to a named export on `ConnectionService`, so the fixture validates against the same script name `spawnBridge` will run rather than a copy free to drift from it.

Evidence: L3 (live e2e on this host, real browser, real spawn — the refusal reproduced, then eliminated, and the spawn path carried through to a live session). No residual.

## Deltas from ticket

**The ticket's own prescription was wrong, and this PR does not implement it.** #17402 specified `NeuralLink_ConnectionService.cwd ??= process.cwd()` and justified it structurally: *"Playwright resolves its config and `testDir` relative to the invocation directory, so a fixture only ever runs from the consuming project's root."* That is backwards. Playwright resolves `testDir` from the **config file** and never calls `chdir`, which is precisely why the invocation directory is unconstrained.

Falsified by `@neo-gpt-emmy` in review, then reproduced here on a two-arm probe:

| arm | invoked from | worker `cwd` | `package.json` there | run |
|---|---|---|---|---|
| A | project root | project root | yes | passed |
| B | `/private/tmp`, absolute `-c` | `/private/tmp` | **no** | **passed** |

Arm B is the finding: a fully valid, green invocation whose worker cwd owns nothing. The consequence is worse than an inaccuracy — `process.cwd()` hands `spawnBridge` a **plausible wrong value** where it previously had none, which is the exact class its refusal was hardened against in #16429. `ConnectionService.mjs` says so in its own words: *"A hidden default that substitutes a wrong value is worse than no default: it converts a missing input into a distant symptom."* The first version of this PR shipped that sentence's counterexample.

#17402 has been corrected: the falsified paragraph is struck through and marked rather than silently rewritten, the Fix section and Contract Ledger carry the derivation, and **AC-6** was added for the portability property AC-1 alone cannot catch — AC-1 is satisfiable by a value that only works when the invocation happens to start at the root, which is how the original prescription passed it.

AC-4 (guide states the contract) is delivered in the same commit rather than split, because the guide sentence is what made the defect invisible to an author. It previously repeated the false `process.cwd()` claim; it now states the derivation and names the foreign-cwd invocation explicitly.

## Test Evidence

**E2E — three arms, same port and same invocation, differing only in the derivation.** Run on a free Bridge port (`NEO_NL_PORT=8124`, nothing listening at start) with the example app pointed at the same port, so the spawn path executes end to end without taking down the shared Bridge this machine's other seats use:

| arm | invoked from | cwd source | result |
|---|---|---|---|
| **red** | `/private/tmp`, absolute `-c` | `process.cwd()` | **4 failed** — `BRIDGE_EXIT_254`, then `ECONNREFUSED 127.0.0.1:8124` |
| green | `/private/tmp`, absolute `-c` | derived | **4 passed** — `Verified Neural Link Bridge freshness on port 8124` |
| green | project root | derived | **4 passed** |

The red arm is the AC-6 falsifier and it is the same class as the production failure: `npm run` cannot resolve the script in `/private/tmp`, so the Bridge dies at startup and the fixture waits on a socket that never opens. Note the failure signature — a distant `ECONNREFUSED`, not the named refusal the guard would have produced with no cwd at all.

`spawnBridge` is reached in every arm: the port is free at start, verified immediately before each run. That check is not ceremonial — an earlier probe of mine left a stray Bridge listening on the test port, and the resulting control showed no refusal in *either* arm. A control polluted by its own earlier arm reads exactly like a passing control.

**Unit — `test/playwright/unit/test/findBridgeScriptRoot.spec.mjs`, 7 arms, all green.** Nearest-declaring-ancestor wins; a `package.json` **without** the script is not an answer and the walk continues past it; `null` when no ancestor declares it; an empty script value is not a declaration; a malformed manifest does not end the walk; plus a positive control that runs the walk against this real checkout, so a derivation that only works on synthetic trees cannot pass the file.

Mutation-proven: replacing the script check with a bare `package.json` existence check kills **3 of the 7**. Full unit suite **2845 passed** — the `BRIDGE_NPM_SCRIPT` extraction touches a live service and regressed nothing.

The helper is a standalone module rather than a function inside `fixtures.mjs` because `fixtures.mjs` imports `ConnectionService`, a connect-on-init singleton: importing it from a unit spec would spawn a Bridge during the import. Extracting the pure logic is the pattern `.agents/skills/unit-test` prescribes for exactly this.

**Not claimed:** neo has no e2e job, so exact-head CI cannot observe any of the e2e arms above. They are manual receipts from this host. The unit arms do run in CI.

## Post-Merge Validation

None owed by this PR.

#17402's AC-5 — the downstream consumer's e2e passing on a pin carrying this fix — now names its observer on the ticket rather than sitting in this body as an obligation with nobody watching it. It is observed by the consumer's pin-bump pipeline, which is already open and already waiting on this merge: the pin bump *is* the check, and it fails loudly there if this is wrong. Tracked on the consumer side, not gating this close.

## Evolution

The first shape was the ticket's: assign `process.cwd()`. It passed AC-1, passed CI, and was approved-in-principle by its own Contract Ledger — because AC-1 only ever exercises the invocation shape the author happens to use. What broke it was a reviewer running a *different valid invocation*, which is the argument for the seat existing.

The second shape was `path.resolve(__dirname, '../../')` — count the directories up to the root. Rejected: the repo already has that pattern in two `configBase.mjs` files, paired with a `process.cwd() === '/'` special case, and both halves are the thing #16429 removed. A fixed depth is a guess that happens to be right, and it breaks silently the moment the file moves.

The shape that shipped validates instead of counting. It cannot be right by luck: either an ancestor declares the script or the function returns `null` and the guard refuses by name. That property is what made the red arm reproducible and what the mutant test pins.

Reviewer credit: `@neo-gpt-emmy` supplied the falsifier, the framing (*"the new fallback recreates the wrong-value class that `spawnBridge` was hardened to refuse"*), and the observation that the green arm in the previous body ran on a port that already had a Bridge — i.e. it was evidence for AC-2, promoted to AC-1.

Authored by Ada (Claude Opus 5, Claude Code). Session 356852dc-c28f-4c77-b932-f2c03075647b.
