### PR TITLE
feat(build): comment density, unticketed deferrals, and a pre-push consumer

### DIFF
--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -15,3 +15,10 @@ payload="$(cat)"
 printf '%s\n' "$payload" | node ./buildScripts/util/check-branch-discipline.mjs
 printf '%s\n' "$payload" | node ./ai/scripts/lint/check-commit-authorship.mjs
 printf '%s\n' "$payload" | node ./buildScripts/util/check-spec-retirement.mjs
+
+# Advisory, and `set -e` above makes that a property this line has to state rather than assume: a
+# crash in an advisory guard would otherwise block the push it was never meant to block. Reports the
+# two prose-density axes and any comment that defers work without binding it to a ticket. Advisory
+# because both signals are heuristics over prose — a blocking version would be worded around, and
+# the deferral escape hatch is a marker another guard owns.
+printf '%s\n' "$payload" | node ./buildScripts/util/check-comment-density.mjs --pre-push || true

--- a/buildScripts/util/check-comment-density.mjs
+++ b/buildScripts/util/check-comment-density.mjs
@@ -24,7 +24,7 @@ import {readFileSync}        from 'node:fs';
 import path                  from 'node:path';
 import {fileURLToPath}       from 'node:url';
 import {extractComment}      from './check-ticket-archaeology.mjs';
-import {getStagedAddedLines} from './stagedDiff.mjs';
+import {getStagedAddedLines, parseAddedLines} from './stagedDiff.mjs';
 
 const __dirname  = path.dirname(fileURLToPath(import.meta.url)),
       scriptRoot = path.resolve(__dirname, '../..');
@@ -69,6 +69,79 @@ export function isProseLine(comment) {
 }
 
 /**
+ * Deferral vocabulary: prose that records work still owed. A `To Do: 0` census across 755 Brain files
+ * is not cleanliness — the debt is written as essays, where no tool looks.
+ *
+ * The vocabulary is AUTHORIAL STANCE only, because a wider one was measured and rejected. A first
+ * draft added `deferred`, `not yet`, `follow-up` and `TBD`; over 2564 in-scope files those four
+ * carried 326 of 458 total hits and almost none were deferrals — `deferred` is this repo's own
+ * scheduler noun (`0 updated, 30 deferred` per pass), `not yet` describes runtime state (`not yet
+ * POSTed`, `not yet hydrated`), and `follow-up` names sequences that already exist. Precision, not
+ * recall, is what a warning nobody silences has to buy: the markers kept fire 33 times and read as
+ * confessions on inspection ("Pass generic env for now", "For now, assume user base").
+ * @type {RegExp}
+ */
+export const CONFESSION_MARKERS = /\b(for now|left alone|would be nice|should really|come back to|revisit|ideally)\b/i;
+
+/**
+ * Unticketed-work markers in MARKER form — a colon, a paren, or the end of the token — never the
+ * English word. Bare `todo` matched 90 lines, most of them prose about obligations ("someone else's
+ * todo"); the marker form matched 14 and every one was real ("TODO: Implement geocoding").
+ * @type {RegExp}
+ */
+export const TODO_MARKERS = /(?:^|[^\w])(?:TODO|FIXME|XXX|HACK)(?=[:(\s]|$)/;
+
+/**
+ * Prose that DECIDES rather than defers: a rationale is attached and nothing is owed.
+ *
+ * Deliberately NOT including "deliberately": *"worthwhile and deliberately left alone"* is the census
+ * specimen this vocabulary was built on — a known consolidation, reasoned, unticketed. A deferral
+ * asserting its own intent is still a deferral, and exempting the word would exempt the best-dressed
+ * confessions.
+ * @type {RegExp}
+ */
+export const DECIDED_MARKERS = /\b(intentionally|on purpose|by design)\b/i;
+
+/**
+ * A bound obligation: an escape marker, or a ticket reference. Either means the debt has an owner
+ * somewhere a reader can follow, so the comment is not the only record.
+ *
+ * The two arms have UNEQUAL reach, which the remedy text depends on. `check-ticket-archaeology`
+ * scans `ai`, `src`, `test/playwright` — via lint-staged on staged paths and in CI against
+ * `origin/dev` — and its first pattern is `#\d{4,}\b`, so a NEW comment line carrying a bare ticket
+ * number there is rejected before it can reach this check. In those three roots the second arm is
+ * therefore only ever satisfied on lines the escape marker already satisfies; it is independently
+ * live only under `buildScripts/`, which archaeology does not scan. Suggesting a bare `#N` as the
+ * remedy would hand an author a fix another guard blocks, so the warning names the marker instead.
+ * @type {RegExp}
+ */
+export const BOUND_OBLIGATION = /ticket-ref-ok|#\d{4,}/;
+
+/**
+ * @summary Whether a comment defers work without binding the obligation anywhere.
+ *
+ * The discriminator is DEFER-vs-DECIDE, not the marker words: a decision with a rationale owes
+ * nothing, a deferral owes a ticket. The cost of getting it wrong is asymmetric — a false positive
+ * costs one glance, an unticketed debt costs what an unfiled debt costs — so the check errs toward
+ * asking.
+ *
+ * Naming the ticket inside the comment is NOT the remedy: `check-ticket-archaeology` correctly keeps
+ * decaying refs out of durable comments. The remedy is that the deferral belongs in a ticket, and the
+ * comment describes behaviour.
+ * @param {String} comment Comment text for one line.
+ * @returns {Boolean}
+ */
+export function isConfession(comment) {
+    if (BOUND_OBLIGATION.test(comment)) {
+        return false
+    }
+
+    // A marker is its own admission, so no stance test applies to it: `FIXME` does not become a
+    // decision by adding the word "intentionally".
+    return TODO_MARKERS.test(comment) || (CONFESSION_MARKERS.test(comment) && !DECIDED_MARKERS.test(comment))
+}
+
+/**
  * @summary Measures prose share and the longest contiguous prose run over a file's ADDED lines.
  *
  * Every line is walked so block-comment state stays correct, but only lines in `addedLines` are
@@ -82,6 +155,8 @@ export function isProseLine(comment) {
  */
 export function measureProseDensity(lines, addedLines) {
     const state = {inBlock: false};
+
+    const confessions = [];
 
     let added = 0, prose = 0, run = 0, longestRun = 0;
 
@@ -99,13 +174,17 @@ export function measureProseDensity(lines, addedLines) {
         if (isProseLine(comment)) {
             prose++;
             run++;
-            longestRun = Math.max(longestRun, run)
+            longestRun = Math.max(longestRun, run);
+
+            if (isConfession(comment)) {
+                confessions.push({line: index + 1, text: comment.trim().slice(0, 100)})
+            }
         } else {
             run = 0
         }
     });
 
-    return {added, prose, longestRun}
+    return {added, prose, longestRun, confessions}
 }
 
 /**
@@ -175,6 +254,101 @@ export function isInScopePath(file, scanPaths = DEFAULT_SCAN_PATHS) {
     return file.endsWith('.mjs') && scanPaths.some(prefix => file.startsWith(prefix))
 }
 
+const ZERO_SHA = '0'.repeat(40);
+
+/**
+ * @summary Prints whatever the measurement found: the two density axes, then any deferral prose.
+ * @param {Object[]} files Per-file measurements.
+ * @returns {void}
+ */
+function reportDensity(files) {
+    const summary     = summarizeDensity(files),
+          confessions = files.flatMap(row => (row.confessions || []).map(entry => ({...entry, file: row.file})));
+
+    if (summary.warn) {
+        console.warn(formatDensityWarning(summary))
+    }
+
+    if (confessions.length > 0) {
+        console.warn(`check-comment-density: ${confessions.length} comment(s) defer work without binding it to a ticket:`);
+        confessions.slice(0, 10).forEach(entry => console.warn(`  ${entry.file}:${entry.line}  ${entry.text}`));
+        console.warn('  A deferral in a comment is a ticket nobody filed. File it, then let the comment describe behaviour.');
+        console.warn('  Load-bearing and not a deferral? Say so on the line with a "ticket-ref-ok: <reason>" marker — a bare #ticket is what check-ticket-archaeology rejects.')
+    }
+}
+
+/**
+ * @summary Rev ranges this push will publish, from the pre-push stdin payload.
+ *
+ * `remoteSha` is the boundary git will apply, so `remoteSha..localSha` is the true new-commit set.
+ * A new remote branch reports the zero-sha, where the honest fallback is everything the branch adds to
+ * the trunk. A deletion sends no commits. Empty stdin means a manual run, which measures the branch
+ * rather than nothing — a check that no-ops when it cannot see its input is useless.
+ * @param {String} stdin Raw hook payload.
+ * @returns {String[]}
+ */
+export function pendingRanges(stdin) {
+    const rows = (stdin || '').split('\n').map(line => line.trim()).filter(Boolean);
+
+    if (rows.length === 0) {
+        return ['origin/dev..HEAD']
+    }
+
+    return rows.map(row => {
+        const [, localSha, , remoteSha] = row.split(/\s+/);
+
+        if (!localSha || localSha === ZERO_SHA) {
+            return null
+        }
+
+        return !remoteSha || remoteSha === ZERO_SHA ? `origin/dev..${localSha}` : `${remoteSha}..${localSha}`
+    }).filter(Boolean)
+}
+
+/**
+ * @summary Measures one rev range, reading each file at the range TIP rather than from the work tree.
+ *
+ * The work tree may already have moved past what is being pushed, and measuring what is not being
+ * published would report the wrong thing in both directions.
+ * @param {String} range Rev range (`A..B`).
+ * @param {String} gitRoot
+ * @returns {Object[]} Per-file measurements.
+ */
+export function measureRange(range, gitRoot) {
+    const tip   = range.split('..').pop(),
+          files = [];
+
+    let changed;
+
+    try {
+        changed = execFileSync('git', ['diff', '--name-only', '--diff-filter=ACMR', range], {cwd: gitRoot, encoding: 'utf-8'})
+            .split('\n').map(line => line.trim()).filter(file => file.length > 0 && isInScopePath(file))
+    } catch {
+        return files
+    }
+
+    for (const file of changed) {
+        let addedLines, content;
+
+        try {
+            addedLines = parseAddedLines(execFileSync('git', ['diff', '--unified=0', range, '--', file], {cwd: gitRoot, encoding: 'utf-8'}));
+            content    = execFileSync('git', ['show', `${tip}:${file}`], {cwd: gitRoot, encoding: 'utf-8'})
+        } catch (error) {
+            // Never a silent skip: an undefined helper and a deleted path both land here, and one is a
+            // programming error. A zero-file measurement that prints nothing is indistinguishable from
+            // a clean range.
+            console.warn(`check-comment-density: could not measure ${file} (${error.message})`);
+            continue
+        }
+
+        if (!addedLines || addedLines.size === 0) continue;
+
+        files.push({file, ...measureProseDensity(content.split('\n'), addedLines)})
+    }
+
+    return files
+}
+
 function main() {
     let gitRoot;
 
@@ -182,6 +356,20 @@ function main() {
         gitRoot = execFileSync('git', ['rev-parse', '--show-toplevel'], {cwd: scriptRoot, encoding: 'utf-8'}).trim()
     } catch {
         return 0 // not a work tree — nothing to measure, never a failure
+    }
+
+    if (process.argv.includes('--pre-push')) {
+        let stdin = '';
+
+        try {
+            stdin = readFileSync(0, 'utf-8')
+        } catch { /* no payload — pendingRanges falls back to the branch range */ }
+
+        const files = pendingRanges(stdin).flatMap(range => measureRange(range, gitRoot));
+
+        reportDensity(files);
+
+        return 0
     }
 
     const staged = execFileSync('git', ['diff', '--cached', '--name-only', '--diff-filter=ACMR'], {cwd: gitRoot, encoding: 'utf-8'})
@@ -207,11 +395,7 @@ function main() {
         files.push({file, ...measureProseDensity(content.split('\n'), addedLines)})
     }
 
-    const summary = summarizeDensity(files);
-
-    if (summary.warn) {
-        console.warn(formatDensityWarning(summary))
-    }
+    reportDensity(files);
 
     return 0 // advisory by design
 }

--- a/buildScripts/util/check-comment-density.mjs
+++ b/buildScripts/util/check-comment-density.mjs
@@ -38,11 +38,24 @@ const __dirname  = path.dirname(fileURLToPath(import.meta.url)),
 export const DEFAULT_SCAN_PATHS = ['ai/', 'src/', 'test/', 'buildScripts/'];
 
 /**
- * `maxProseRun` sits inside the measured p90–p99 band for this repo's files, so a warning means
- * "unusual" rather than "long". `maxProseShare` is the operator's ~30% observation.
+ * Both bars are the **p90 of the seats whose behaviour did not change**, which is the one reference a
+ * threshold can be anchored to without drifting along with what it measures. A trailing median follows
+ * the engine up; a pre-regression distribution does not move and is already in the repository.
+ *
+ * Measured per commit over `origin/dev`, commits with ≥ 20 added in-scope lines, two independent flat
+ * controls landing on the same numbers:
+ *
+ * | | p90 Opus 4.8 (n=552) | p90 Fable (n=162) | bar | fire rate now (n=92) | fire rate, controls |
+ * |---|---|---|---|---|---|
+ * | block run | 34 | 35 | **35** | 20.7% | 10.0% / 10.5% |
+ * | prose share | 31.9% | 28.5% | **30%** | 34.8% | 12.9% / 9.3% |
+ *
+ * A warning therefore means "top decile of the seats that were not part of the change". The share axis
+ * is the more gameable of the two, since its denominator is author-controlled, which is what the run
+ * axis covers.
  * @type {{maxProseShare: Number, maxProseRun: Number}}
  */
-export const DEFAULT_BOUNDS = Object.freeze({maxProseShare: 0.3, maxProseRun: 34});
+export const DEFAULT_BOUNDS = Object.freeze({maxProseShare: 0.3, maxProseRun: 35});
 
 /**
  * @summary Whether a comment's text is a type contract rather than prose.
@@ -106,13 +119,11 @@ export const DECIDED_MARKERS = /\b(intentionally|on purpose|by design)\b/i;
  * A bound obligation: an escape marker, or a ticket reference. Either means the debt has an owner
  * somewhere a reader can follow, so the comment is not the only record.
  *
- * The two arms have UNEQUAL reach, which the remedy text depends on. `check-ticket-archaeology`
- * scans `ai`, `src`, `test/playwright` — via lint-staged on staged paths and in CI against
- * `origin/dev` — and its first pattern is `#\d{4,}\b`, so a NEW comment line carrying a bare ticket
- * number there is rejected before it can reach this check. In those three roots the second arm is
- * therefore only ever satisfied on lines the escape marker already satisfies; it is independently
- * live only under `buildScripts/`, which archaeology does not scan. Suggesting a bare `#N` as the
- * remedy would hand an author a fix another guard blocks, so the warning names the marker instead.
+ * The two arms have UNEQUAL reach, which the remedy text depends on. `check-ticket-archaeology` scans
+ * `ai`, `src`, `test/playwright` and rejects a bare `#\d{4,}` on a new comment line there, so in those
+ * roots the second arm only ever fires on lines the escape marker already covers — it is independently
+ * live under `buildScripts/` alone. The warning therefore names the marker: suggesting a bare `#N`
+ * would hand an author a fix another guard blocks.
  * @type {RegExp}
  */
 export const BOUND_OBLIGATION = /ticket-ref-ok|#\d{4,}/;
@@ -120,15 +131,13 @@ export const BOUND_OBLIGATION = /ticket-ref-ok|#\d{4,}/;
 /**
  * @summary Drops quoted spans, so a marker being MENTIONED is not read as a marker being USED.
  *
- * Any file that documents deferral vocabulary — this one, its spec, a guide — quotes the markers as
- * examples, and quoting one is not owing work. Measured on this repo: the rule drops 3 of 49 hits and
- * all 3 are mentions, so it costs no recall.
+ * Any file documenting deferral vocabulary quotes the markers as examples, and quoting one is not
+ * owing work.
  *
- * An ODD quote count means a span crosses a line boundary, and the trailing-drop below covers the
- * common case where it OPENS on this line. It cannot cover every pairing: when the balanced pass
- * consumes the wrong two of three quotes, a mention can survive as a hit. Deciding that needs quote
- * state carried across lines, which `check-ticket-archaeology` deliberately does not carry either —
- * the ambiguity is in the input, so the honest boundary is stated rather than guessed at.
+ * NOT exhaustive, and callers depend on knowing that: an odd quote count means a span crosses a line
+ * boundary, and the trailing drop below covers only the case where it OPENS here. Three quotes on a
+ * line can pair wrongly and leave a mention exposed. Deciding that needs quote state carried across
+ * lines, which `check-ticket-archaeology` declines to carry too.
  * @param {String} comment Comment text for one line.
  * @returns {String}
  */
@@ -173,49 +182,81 @@ export function isConfession(rawComment) {
 }
 
 /**
- * @summary Measures prose share and the longest contiguous prose run over a file's ADDED lines.
+ * @summary Whether a line is part of a comment block at all — delimiters included.
+ *
+ * The run axis measures what a reader faces, and a reader faces the whole block. `extractComment`
+ * yields `*` for a `/**` opener and whitespace for a closer, so neither is detectable by text alone.
+ * @param {String} line Raw source line.
+ * @param {String} comment Its extracted comment text.
+ * @returns {Boolean}
+ */
+function isCommentLine(line, comment) {
+    return comment.trim().length > 0 || /^\s*(\/\*|\*\/|\*|\/\/)/.test(line)
+}
+
+/**
+ * @summary Measures prose share and the longest contiguous ADDED COMMENT run in a file.
  *
  * Every line is walked so block-comment state stays correct, but only lines in `addedLines` are
- * counted — a docblock that already existed is not this commit's prose. A run is broken by a
- * non-prose added line, by a tag line, and by any unchanged line, since prose split by untouched
- * code is not one block.
+ * counted — a docblock that already existed is not this commit's. A run is broken by an added line
+ * that is not a comment and by any unchanged line, since a block split by untouched code is not one
+ * block.
+ *
+ * The two axes measure DIFFERENT objects on purpose. `prose` excludes tag lines, because a typed
+ * signature is contract rather than narration. `longestRun` includes them, because a 45-line docblock
+ * is 45 lines to whoever opens the file whether or not `@param` sits in the middle.
  *
  * @param {String[]} lines The file's full content, split by line.
  * @param {Set<Number>} addedLines 1-based line numbers this commit adds.
- * @returns {{added: Number, prose: Number, longestRun: Number}}
+ * @returns {{added: Number, prose: Number, longestRun: Number, runs: Number[], confessions: Object[]}}
  */
 export function measureProseDensity(lines, addedLines) {
     const state = {inBlock: false};
 
-    const confessions = [];
+    const confessions = [],
+          runs        = [];
 
     let added = 0, prose = 0, run = 0, longestRun = 0;
+
+    const closeRun = () => {
+        if (run > 0) {
+            runs.push(run)
+        }
+
+        run = 0
+    };
 
     lines.forEach((line, index) => {
         const comment = extractComment(line, state),
               isAdded = addedLines.has(index + 1);
 
         if (!isAdded) {
-            run = 0;
+            closeRun();
             return
         }
 
         added++;
 
+        if (!isCommentLine(line, comment)) {
+            closeRun();
+            return
+        }
+
+        run++;
+        longestRun = Math.max(longestRun, run);
+
         if (isProseLine(comment)) {
             prose++;
-            run++;
-            longestRun = Math.max(longestRun, run);
 
             if (isConfession(comment)) {
                 confessions.push({line: index + 1, text: comment.trim().slice(0, 100)})
             }
-        } else {
-            run = 0
         }
     });
 
-    return {added, prose, longestRun, confessions}
+    closeRun();
+
+    return {added, prose, longestRun, runs, confessions}
 }
 
 /**
@@ -235,6 +276,11 @@ export function summarizeDensity(files = [], bounds = DEFAULT_BOUNDS) {
           worst                        = rows.reduce((best, row) => (row?.longestRun ?? 0) > (best?.longestRun ?? 0) ? row : best, null),
           share                        = added > 0 ? prose / added : 0,
           longestRun                   = worst?.longestRun ?? 0,
+          // Reported beside the longest run because a tail-only number misses that the FLOOR rose:
+          // across the model boundary the median block went 15 to 23 while the p90 went 34 to 42. A
+          // commit of twelve twenty-line blocks never trips the bar and is the thing being described.
+          allRuns                      = rows.flatMap(row => row?.runs ?? []).sort((a, b) => a - b),
+          medianRun                    = allRuns.length > 0 ? allRuns[Math.floor(allRuns.length / 2)] : 0,
           shareExceeded                = added > 0 && share > maxProseShare,
           runExceeded                  = longestRun > maxProseRun;
 
@@ -243,6 +289,8 @@ export function summarizeDensity(files = [], bounds = DEFAULT_BOUNDS) {
         prose,
         share,
         longestRun,
+        medianRun,
+        blocks   : allRuns.length,
         worstFile: runExceeded ? (worst?.file ?? null) : null,
         shareExceeded,
         runExceeded,
@@ -262,7 +310,8 @@ export function formatDensityWarning(summary, bounds = DEFAULT_BOUNDS) {
           lines                        = [
               `check-comment-density: ${summary.prose} of ${summary.added} added lines are prose ` +
               `(${Math.round(summary.share * 100)}%, bar ${Math.round(maxProseShare * 100)}%); ` +
-              `longest contiguous run ${summary.longestRun} (bar ${maxProseRun}).`
+              `longest contiguous run ${summary.longestRun} (bar ${maxProseRun}), ` +
+              `median of ${summary.blocks ?? 0} block(s) ${summary.medianRun ?? 0}.`
           ];
 
     if (summary.runExceeded && summary.worstFile) {

--- a/buildScripts/util/check-comment-density.mjs
+++ b/buildScripts/util/check-comment-density.mjs
@@ -85,8 +85,8 @@ export const CONFESSION_MARKERS = /\b(for now|left alone|would be nice|should re
 
 /**
  * Unticketed-work markers in MARKER form — a colon, a paren, or the end of the token — never the
- * English word. Bare `todo` matched 90 lines, most of them prose about obligations ("someone else's
- * todo"); the marker form matched 14 and every one was real ("TODO: Implement geocoding").
+ * English word. Bare `todo` matched 90 lines, most of them prose about obligations — one reads
+ * `an announcement becomes someone else's todo`. The marker form matched 14, every one real.
  * @type {RegExp}
  */
 export const TODO_MARKERS = /(?:^|[^\w])(?:TODO|FIXME|XXX|HACK)(?=[:(\s]|$)/;
@@ -118,6 +118,35 @@ export const DECIDED_MARKERS = /\b(intentionally|on purpose|by design)\b/i;
 export const BOUND_OBLIGATION = /ticket-ref-ok|#\d{4,}/;
 
 /**
+ * @summary Drops quoted spans, so a marker being MENTIONED is not read as a marker being USED.
+ *
+ * Any file that documents deferral vocabulary — this one, its spec, a guide — quotes the markers as
+ * examples, and quoting one is not owing work. Measured on this repo: the rule drops 3 of 49 hits and
+ * all 3 are mentions, so it costs no recall.
+ *
+ * An ODD quote count means a span crosses a line boundary, and the trailing-drop below covers the
+ * common case where it OPENS on this line. It cannot cover every pairing: when the balanced pass
+ * consumes the wrong two of three quotes, a mention can survive as a hit. Deciding that needs quote
+ * state carried across lines, which `check-ticket-archaeology` deliberately does not carry either —
+ * the ambiguity is in the input, so the honest boundary is stated rather than guessed at.
+ * @param {String} comment Comment text for one line.
+ * @returns {String}
+ */
+export function dropQuotedSpans(comment) {
+    const text = (comment ?? '')
+        .replace(/"[^"]*"/g, ' ')
+        .replace(/`[^`]*`/g, ' ')
+        .replace(/'[^']*'/g, ' ')
+        .replace(/\*\*[^*]*\*\*/g, ' ');
+
+    return ['"', '`'].reduce((carried, mark) => {
+        const parts = carried.split(mark);
+
+        return parts.length % 2 === 0 ? parts.slice(0, -1).join(mark) : carried
+    }, text)
+}
+
+/**
  * @summary Whether a comment defers work without binding the obligation anywhere.
  *
  * The discriminator is DEFER-vs-DECIDE, not the marker words: a decision with a rationale owes
@@ -128,10 +157,12 @@ export const BOUND_OBLIGATION = /ticket-ref-ok|#\d{4,}/;
  * Naming the ticket inside the comment is NOT the remedy: `check-ticket-archaeology` correctly keeps
  * decaying refs out of durable comments. The remedy is that the deferral belongs in a ticket, and the
  * comment describes behaviour.
- * @param {String} comment Comment text for one line.
+ * @param {String} rawComment Comment text for one line, quotes intact.
  * @returns {Boolean}
  */
-export function isConfession(comment) {
+export function isConfession(rawComment) {
+    const comment = dropQuotedSpans(rawComment);
+
     if (BOUND_OBLIGATION.test(comment)) {
         return false
     }

--- a/buildScripts/util/check-comment-density.mjs
+++ b/buildScripts/util/check-comment-density.mjs
@@ -1,0 +1,221 @@
+#!/usr/bin/env node
+/**
+ * @summary Warns when a commit's ADDED lines are mostly prose, on two independent axes.
+ *
+ * Comments are read substrate twice over: a maintainer pays on every visit, and the text is ingested
+ * into the Knowledge Base, where a long derivation dilutes the invariant it wraps and then competes
+ * with it for retrieval. Neither cost is visible at authoring time, and no other check measures it —
+ * `check-ticket-archaeology` governs decay-prone refs, `check-substrate-size` governs turn-loaded
+ * bytes.
+ *
+ * **Two axes, because a share alone has an author-controlled denominator.** A commit adding 200 lines
+ * of fixture dilutes a 36-line docblock to 21%, so adding tests buys room for narrative. The longest
+ * contiguous prose run has no denominator to dilute.
+ *
+ * **Warn, never block.** A hard gate would breed suppression markers, and then the markers are the
+ * bloat. The number exists to make an author look; whether a comment is DESERVED is not computable —
+ * an invariant survives the incident that taught it, a derivation does not.
+ *
+ * @module buildScripts/util/check-comment-density
+ */
+
+import {execFileSync}        from 'node:child_process';
+import {readFileSync}        from 'node:fs';
+import path                  from 'node:path';
+import {fileURLToPath}       from 'node:url';
+import {extractComment}      from './check-ticket-archaeology.mjs';
+import {getStagedAddedLines} from './stagedDiff.mjs';
+
+const __dirname  = path.dirname(fileURLToPath(import.meta.url)),
+      scriptRoot = path.resolve(__dirname, '../..');
+
+/**
+ * Directories whose added lines are measured. Specs are included because prose in a spec is read as
+ * often as prose in a service, and `buildScripts/` because a checker exempt from its own rule is not a
+ * rule. Excluding either would restore the denominator loophole this check exists to close.
+ * @type {String[]}
+ */
+export const DEFAULT_SCAN_PATHS = ['ai/', 'src/', 'test/', 'buildScripts/'];
+
+/**
+ * `maxProseRun` sits inside the measured p90–p99 band for this repo's files, so a warning means
+ * "unusual" rather than "long". `maxProseShare` is the operator's ~30% observation.
+ * @type {{maxProseShare: Number, maxProseRun: Number}}
+ */
+export const DEFAULT_BOUNDS = Object.freeze({maxProseShare: 0.3, maxProseRun: 34});
+
+/**
+ * @summary Whether a comment's text is a type contract rather than prose.
+ *
+ * JSDoc tag lines are the contract, not the narrative. Counting them as prose makes a densely-typed
+ * signature read as bloat, at which point the number stops being actionable.
+ * @param {String} comment Comment text for one line (as returned by `extractComment`).
+ * @returns {Boolean}
+ */
+export function isTagLine(comment) {
+    return /^[\s*]*@\w/.test(comment)
+}
+
+/**
+ * @summary Whether a comment line is prose rather than a delimiter or a type contract.
+ *
+ * A `/**` opener extracts as `*` and a `*\/` closer as whitespace; counting either would score a
+ * two-line docblock the same as a four-line one. Prose needs an actual word.
+ * @param {String} comment Comment text for one line.
+ * @returns {Boolean}
+ */
+export function isProseLine(comment) {
+    return /\w/.test(comment) && !isTagLine(comment)
+}
+
+/**
+ * @summary Measures prose share and the longest contiguous prose run over a file's ADDED lines.
+ *
+ * Every line is walked so block-comment state stays correct, but only lines in `addedLines` are
+ * counted — a docblock that already existed is not this commit's prose. A run is broken by a
+ * non-prose added line, by a tag line, and by any unchanged line, since prose split by untouched
+ * code is not one block.
+ *
+ * @param {String[]} lines The file's full content, split by line.
+ * @param {Set<Number>} addedLines 1-based line numbers this commit adds.
+ * @returns {{added: Number, prose: Number, longestRun: Number}}
+ */
+export function measureProseDensity(lines, addedLines) {
+    const state = {inBlock: false};
+
+    let added = 0, prose = 0, run = 0, longestRun = 0;
+
+    lines.forEach((line, index) => {
+        const comment = extractComment(line, state),
+              isAdded = addedLines.has(index + 1);
+
+        if (!isAdded) {
+            run = 0;
+            return
+        }
+
+        added++;
+
+        if (isProseLine(comment)) {
+            prose++;
+            run++;
+            longestRun = Math.max(longestRun, run)
+        } else {
+            run = 0
+        }
+    });
+
+    return {added, prose, longestRun}
+}
+
+/**
+ * @summary Folds per-file measurements into the commit-level verdict.
+ *
+ * The share is summed across files because a commit is the unit a hook can see; the run is a maximum
+ * because a run is contiguous within one file and never spans two.
+ * @param {Object[]} files `[{file, added, prose, longestRun}]`.
+ * @param {{maxProseShare: Number, maxProseRun: Number}} [bounds=DEFAULT_BOUNDS]
+ * @returns {{added: Number, prose: Number, share: Number, longestRun: Number, worstFile: (String|null), shareExceeded: Boolean, runExceeded: Boolean, warn: Boolean}}
+ */
+export function summarizeDensity(files = [], bounds = DEFAULT_BOUNDS) {
+    const {maxProseShare, maxProseRun} = {...DEFAULT_BOUNDS, ...(bounds ?? {})},
+          rows                         = Array.isArray(files) ? files : [],
+          added                        = rows.reduce((total, row) => total + (row?.added ?? 0), 0),
+          prose                        = rows.reduce((total, row) => total + (row?.prose ?? 0), 0),
+          worst                        = rows.reduce((best, row) => (row?.longestRun ?? 0) > (best?.longestRun ?? 0) ? row : best, null),
+          share                        = added > 0 ? prose / added : 0,
+          longestRun                   = worst?.longestRun ?? 0,
+          shareExceeded                = added > 0 && share > maxProseShare,
+          runExceeded                  = longestRun > maxProseRun;
+
+    return {
+        added,
+        prose,
+        share,
+        longestRun,
+        worstFile: runExceeded ? (worst?.file ?? null) : null,
+        shareExceeded,
+        runExceeded,
+        warn     : shareExceeded || runExceeded
+    }
+}
+
+/**
+ * @summary Formats the warning. Both raw numbers are printed, never only a verdict — an author who
+ * cannot see the ratio cannot tell whether the fix is trimming prose or that the commit is small.
+ * @param {Object} summary From {@link summarizeDensity}.
+ * @param {{maxProseShare: Number, maxProseRun: Number}} [bounds=DEFAULT_BOUNDS]
+ * @returns {String}
+ */
+export function formatDensityWarning(summary, bounds = DEFAULT_BOUNDS) {
+    const {maxProseShare, maxProseRun} = {...DEFAULT_BOUNDS, ...(bounds ?? {})},
+          lines                        = [
+              `check-comment-density: ${summary.prose} of ${summary.added} added lines are prose ` +
+              `(${Math.round(summary.share * 100)}%, bar ${Math.round(maxProseShare * 100)}%); ` +
+              `longest contiguous run ${summary.longestRun} (bar ${maxProseRun}).`
+          ];
+
+    if (summary.runExceeded && summary.worstFile) {
+        lines.push(`  longest run in ${summary.worstFile}`)
+    }
+
+    lines.push('  Comments must be deserved: would this sentence still be true and useful if the bug had never happened?');
+    lines.push('  An invariant survives the incident. A derivation belongs in the ticket, which closes; a comment never does.');
+
+    return lines.join('\n')
+}
+
+/**
+ * @summary Whether a staged path is measured.
+ * @param {String} file Repo-relative path.
+ * @param {String[]} [scanPaths=DEFAULT_SCAN_PATHS]
+ * @returns {Boolean}
+ */
+export function isInScopePath(file, scanPaths = DEFAULT_SCAN_PATHS) {
+    return file.endsWith('.mjs') && scanPaths.some(prefix => file.startsWith(prefix))
+}
+
+function main() {
+    let gitRoot;
+
+    try {
+        gitRoot = execFileSync('git', ['rev-parse', '--show-toplevel'], {cwd: scriptRoot, encoding: 'utf-8'}).trim()
+    } catch {
+        return 0 // not a work tree — nothing to measure, never a failure
+    }
+
+    const staged = execFileSync('git', ['diff', '--cached', '--name-only', '--diff-filter=ACMR'], {cwd: gitRoot, encoding: 'utf-8'})
+        .split('\n')
+        .map(line => line.trim())
+        .filter(file => file.length > 0 && isInScopePath(file));
+
+    const files = [];
+
+    for (const file of staged) {
+        const addedLines = getStagedAddedLines(file, gitRoot);
+
+        if (!addedLines || addedLines.size === 0) continue;
+
+        let content;
+
+        try {
+            content = readFileSync(path.join(gitRoot, file), 'utf-8')
+        } catch {
+            continue // a staged deletion or an unreadable path measures nothing
+        }
+
+        files.push({file, ...measureProseDensity(content.split('\n'), addedLines)})
+    }
+
+    const summary = summarizeDensity(files);
+
+    if (summary.warn) {
+        console.warn(formatDensityWarning(summary))
+    }
+
+    return 0 // advisory by design
+}
+
+if (process.argv[1] && import.meta.url === `file://${process.argv[1]}`) {
+    process.exit(main())
+}

--- a/test/playwright/unit/buildScripts/checkCommentDensity.spec.mjs
+++ b/test/playwright/unit/buildScripts/checkCommentDensity.spec.mjs
@@ -1,0 +1,146 @@
+import {test, expect} from '@playwright/test';
+import {
+    DEFAULT_BOUNDS,
+    formatDensityWarning,
+    isInScopePath,
+    isProseLine,
+    isTagLine,
+    measureProseDensity,
+    summarizeDensity
+} from '../../../../buildScripts/util/check-comment-density.mjs';
+
+/**
+ * Two axes, warned on independently. The share axis has an author-controlled denominator — fixture
+ * lines in the same commit dilute a long docblock below the bar — so the run axis exists to catch what
+ * the share cannot see. Every commit named below was measured on this repo.
+ */
+test.describe('check-comment-density — share and run axes', () => {
+    const measured = {
+        // 62% share, the worst share observed in the sampled window.
+        highShare: {file: 'a.mjs', added: 343, prose: 214, longestRun: 20},
+        // 21% share with a 36-line run: under the share bar, operator change-requested for bloat.
+        dilutedRun: {file: 'b.mjs', added: 316, prose: 69, longestRun: 36},
+        // 20% share, 11-line run — at the repo median on both axes.
+        clean: {file: 'c.mjs', added: 105, prose: 21, longestRun: 11}
+    };
+
+    test('the share axis warns high and stays silent at the median', () => {
+        expect(summarizeDensity([measured.highShare]).shareExceeded).toBe(true);
+        expect(summarizeDensity([measured.clean]).shareExceeded).toBe(false);
+    });
+
+    test('RED-PROOF: the run axis warns where the share axis provably cannot', () => {
+        const summary = summarizeDensity([measured.dilutedRun]);
+
+        expect(summary.shareExceeded, 'a 21% share is under the bar').toBe(false);
+        expect(summary.runExceeded, 'a 36-line run must still warn').toBe(true);
+        expect(summary.warn).toBe(true);
+        expect(summary.worstFile).toBe('b.mjs');
+    });
+
+    test('SILENT ARM for the run axis, so a guard that warns on everything fails here', () => {
+        const summary = summarizeDensity([measured.clean]);
+
+        expect(summary.runExceeded).toBe(false);
+        expect(summary.warn).toBe(false);
+    });
+
+    test('the run bar sits in the measured p90–p99 band, so a warning means unusual', () => {
+        // p90 32, p99 64 across ai/services/**. A bar below p90 warns on ordinary files; above p99
+        // warns on almost nothing.
+        expect(DEFAULT_BOUNDS.maxProseRun).toBeGreaterThanOrEqual(32);
+        expect(DEFAULT_BOUNDS.maxProseRun).toBeLessThan(64);
+        expect(DEFAULT_BOUNDS.maxProseShare).toBeCloseTo(0.3);
+    });
+
+    test('a changed bound changes the outcome — the bars are inputs, not baked-in numbers', () => {
+        expect(summarizeDensity([measured.dilutedRun], {maxProseRun: 100}).runExceeded).toBe(false);
+        expect(summarizeDensity([measured.clean], {maxProseShare: 0.05}).shareExceeded).toBe(true);
+    });
+
+    test('partial bounds normalize onto the defaults rather than disabling an axis', () => {
+        expect(summarizeDensity([measured.dilutedRun], {maxProseShare: 0.9}).runExceeded).toBe(true);
+    });
+
+    test('the run is a per-file maximum, never summed across files', () => {
+        const summary = summarizeDensity([
+            {file: 'x.mjs', added: 50, prose: 5, longestRun: 20},
+            {file: 'y.mjs', added: 50, prose: 5, longestRun: 25}
+        ]);
+
+        expect(summary.longestRun).toBe(25);
+        expect(summary.runExceeded).toBe(false);
+    });
+
+    test('an empty staged set never warns', () => {
+        const summary = summarizeDensity([]);
+
+        expect(summary).toMatchObject({added: 0, prose: 0, share: 0, longestRun: 0, warn: false});
+    });
+});
+
+test.describe('check-comment-density — prose classification', () => {
+    const added = lines => measureProseDensity(lines, new Set(lines.map((_, i) => i + 1)));
+
+    test('a JSDoc tag line is contract, not prose', () => {
+        expect(isTagLine(' * @param {String} x')).toBe(true);
+        expect(isTagLine(' * @returns {Boolean}')).toBe(true);
+        expect(isTagLine(' * an explanation')).toBe(false);
+
+        // Tags break a run: a densely-typed signature must not read as one long block.
+        expect(added(['/**', ' * prose', ' * @param {String} x', ' * prose', ' */']).longestRun).toBe(1);
+        expect(isProseLine('*'), 'a `/**` opener extracts as `*` and is a delimiter, not prose').toBe(false);
+        expect(isProseLine(' one'), 'a comment with a word is prose').toBe(true);
+    });
+
+    test('a comment marker inside a string literal is not prose', () => {
+        expect(added(['const s = "// not a comment";']).prose).toBe(0);
+        expect(added(['const u = "https://example.com";']).prose).toBe(0);
+    });
+
+    test('a block comment accumulates one run across its TEXT lines', () => {
+        // The `/*` and `*/` delimiter lines carry no text, so they are not prose. Measuring text rather
+        // than markers keeps a two-line docblock from scoring the same as a four-line one.
+        expect(added(['/*', ' * one', ' * two', ' * three', ' */', 'code();']).longestRun).toBe(3);
+        expect(added([' * orphan prose outside a block']).prose, 'not a comment without an opener').toBe(0);
+    });
+
+    test('an UNCHANGED line breaks the run — prose split by untouched code is not one block', () => {
+        const lines  = ['// one', '// two', 'const untouched = 1;', '// three', '// four'];
+        const result = measureProseDensity(lines, new Set([1, 2, 4, 5]));
+
+        expect(result.added).toBe(4);
+        expect(result.prose).toBe(4);
+        expect(result.longestRun, 'the unchanged line must split the two pairs').toBe(2);
+    });
+
+    test('pre-existing prose is not counted as this commit\'s', () => {
+        const lines  = ['// old', '// old', '// new'];
+        const result = measureProseDensity(lines, new Set([3]));
+
+        expect(result.added).toBe(1);
+        expect(result.prose).toBe(1);
+        expect(result.longestRun).toBe(1);
+    });
+});
+
+test.describe('check-comment-density — scope and output', () => {
+    test('measures source and specs, ignores everything else', () => {
+        expect(isInScopePath('ai/services/x.mjs')).toBe(true);
+        expect(isInScopePath('src/core/Base.mjs')).toBe(true);
+        expect(isInScopePath('test/playwright/unit/x.spec.mjs')).toBe(true);
+        expect(isInScopePath('learn/guide.md')).toBe(false);
+        expect(isInScopePath('ai/config.json')).toBe(false);
+        // A checker exempt from its own rule is not a rule.
+        expect(isInScopePath('buildScripts/util/x.mjs')).toBe(true);
+    });
+
+    test('the warning prints both raw numbers, never only a verdict', () => {
+        const text = formatDensityWarning(summarizeDensity([{file: 'b.mjs', added: 316, prose: 69, longestRun: 36}]));
+
+        expect(text).toContain('69 of 316');
+        expect(text).toContain('longest contiguous run 36');
+        expect(text).toContain('bar 34');
+        expect(text).toContain('b.mjs');
+    });
+});

--- a/test/playwright/unit/buildScripts/checkCommentDensity.spec.mjs
+++ b/test/playwright/unit/buildScripts/checkCommentDensity.spec.mjs
@@ -1,5 +1,8 @@
 import {test, expect} from '@playwright/test';
 import {execFileSync} from 'node:child_process';
+import {mkdirSync, mkdtempSync, rmSync, writeFileSync} from 'node:fs';
+import {tmpdir}                                        from 'node:os';
+import path                                            from 'node:path';
 import {
     DEFAULT_BOUNDS,
     dropQuotedSpans,
@@ -318,31 +321,62 @@ test.describe('check-comment-density — pre-push consumer', () => {
         expect(pendingRanges(`refs/heads/a ${sha('1')} refs/heads/a ${sha('2')}\nrefs/heads/b ${sha('3')} refs/heads/b ${sha('4')}`)).toHaveLength(2);
     });
 
-    test('measureRange reads REAL git history, so the consumer is proven end to end', () => {
-        const gitRoot = execFileSync('git', ['rev-parse', '--show-toplevel'], {encoding: 'utf-8'}).trim(),
-              head    = execFileSync('git', ['rev-parse', 'HEAD'], {cwd: gitRoot, encoding: 'utf-8'}).trim(),
-              files   = measureRange(`${head}~1..${head}`, gitRoot);
+    /**
+     * @summary measureRange against a two-commit repo built here, so the subject always exists.
+     *
+     * This arm first read THIS repository's `HEAD~1..HEAD` and asserted `Array.isArray`. It was green
+     * in CI while measuring nothing: the checkout is depth 1, `HEAD~1` does not resolve, and
+     * measureRange returns `[]` on any git failure — so the shape assertion passed over a swallowed
+     * error. Tightening the assertion is what surfaced it, which is the argument for tightening.
+     *
+     * A disposable repo keeps the git plumbing real — diff parsing, `git show`, scope filtering, the
+     * added-lines set — while owing nothing to how the host was cloned.
+     */
+    test('measureRange reads REAL git history, on a repo it builds so the subject always exists', () => {
+        const root = mkdtempSync(path.join(tmpdir(), 'density-')),
+              git  = (...args) => execFileSync('git', args, {cwd: root, encoding: 'utf-8'}),
+              file = 'ai/services/probe.mjs';
 
-        // NOT just `Array.isArray`: measureRange returns [] on any git failure, so a shape-only
-        // assertion passes vacuously on a broken git path — the same vacuity as asserting a number the
-        // fixture supplied. Asserting a fixed non-zero count instead would break on any commit that
-        // touches no in-scope file, so the arm compares against an INDEPENDENT git read: whatever that
-        // says is in scope, measureRange must have measured.
-        // `--numstat` rather than `--name-only`, to match the tool's contract exactly: measureRange
-        // skips a file with no ADDED lines, which a pure rename is, and name-only would list it.
-        const expected = execFileSync('git', ['diff', '--numstat', '--diff-filter=ACMR', `${head}~1..${head}`], {cwd: gitRoot, encoding: 'utf-8'})
-            .split('\n')
-            .map(line => line.split('\t'))
-            .filter(([added, , file]) => Number(added) > 0 && file && isInScopePath(file))
-            .map(([, , file]) => file);
+        try {
+            git('init', '--quiet', '-b', 'main');
+            git('config', 'user.email', 'spec@example.com');
+            git('config', 'user.name', 'Spec');
+            mkdirSync(path.join(root, 'ai/services'), {recursive: true});
 
-        expect(files.map(row => row.file).sort()).toEqual(expected.sort());
-        files.forEach(row => {
-            expect(row.added).toBeGreaterThan(0);
-            expect(isInScopePath(row.file)).toBe(true);
-            expect(row).toHaveProperty('longestRun');
-            expect(row).toHaveProperty('confessions');
-        });
+            writeFileSync(path.join(root, file), 'const first = 1;\n');
+            git('add', '-A');
+            git('commit', '--quiet', '--no-gpg-sign', '-m', 'base');
+
+            // Second commit adds a 4-line block plus code, and one line out of scope that must NOT
+            // appear — the scope filter is part of what this proves.
+            writeFileSync(path.join(root, file), [
+                'const first = 1;',
+                '/**',
+                ' * @summary narrative one',
+                ' * narrative two',
+                ' */',
+                'const second = 2;',
+                '// for now, a deferral the consumer must report',
+                ''
+            ].join('\n'));
+            writeFileSync(path.join(root, 'notes.md'), 'out of scope\n');
+            git('add', '-A');
+            git('commit', '--quiet', '--no-gpg-sign', '-m', 'add a block');
+
+            const head  = git('rev-parse', 'HEAD').trim(),
+                  files = measureRange(`${head}~1..${head}`, root);
+
+            expect(files.map(row => row.file), 'notes.md is out of scope and must not be measured').toEqual([file]);
+
+            const [row] = files;
+
+            expect(row.added, 'six added lines: four block, one code, one comment').toBe(6);
+            expect(row.longestRun, 'the block including both delimiters').toBe(4);
+            expect(row.prose, 'two narrative lines; @summary is a tag and the delimiters are not prose').toBe(2);
+            expect(row.confessions.map(entry => entry.line)).toEqual([7]);
+        } finally {
+            rmSync(root, {recursive: true, force: true})
+        }
     });
 
     test('an unresolvable range yields no files instead of throwing into the hook', () => {

--- a/test/playwright/unit/buildScripts/checkCommentDensity.spec.mjs
+++ b/test/playwright/unit/buildScripts/checkCommentDensity.spec.mjs
@@ -22,7 +22,7 @@ import {
  * lines in the same commit dilute a long docblock below the bar — so the run axis exists to catch what
  * the share cannot see.
  */
-test.describe('check-comment-density — the axes measured on real commits', () => {
+test.describe('check-comment-density — the two axes', () => {
     /**
      * The red-proof supplies LINES and lets the tool compute the number.
      *
@@ -88,34 +88,25 @@ test.describe('check-comment-density — the axes measured on real commits', () 
         expect(summary.warn).toBe(true);
     });
 
-    const measured = {
-        // 62% share, the worst share observed in the sampled window.
+    /**
+     * Rows for the FOLD, not for the measurement.
+     *
+     * These are inputs to `summarizeDensity` alone — how per-file rows combine, how a bound is applied,
+     * what an empty set does. They are deliberately not red-proofs: the arms above own that, by
+     * measuring. Naming a hand-written row a red-proof is what let a dead axis stay green for a day,
+     * so the distinction is kept in the names.
+     */
+    const rows = {
         highShare: {file: 'a.mjs', added: 343, prose: 214, longestRun: 20},
-        // 21% share with a 36-line run: under the share bar, operator change-requested for bloat.
-        dilutedRun: {file: 'b.mjs', added: 316, prose: 69, longestRun: 36},
-        // 20% share, 11-line run — at the repo median on both axes.
-        clean: {file: 'c.mjs', added: 105, prose: 21, longestRun: 11}
+        longRun  : {file: 'b.mjs', added: 316, prose: 69, longestRun: 36},
+        quiet    : {file: 'c.mjs', added: 105, prose: 21, longestRun: 11}
     };
 
-    test('the share axis warns high and stays silent at the median', () => {
-        expect(summarizeDensity([measured.highShare]).shareExceeded).toBe(true);
-        expect(summarizeDensity([measured.clean]).shareExceeded).toBe(false);
-    });
-
-    test('RED-PROOF: the run axis warns where the share axis provably cannot', () => {
-        const summary = summarizeDensity([measured.dilutedRun]);
-
-        expect(summary.shareExceeded, 'a 21% share is under the bar').toBe(false);
-        expect(summary.runExceeded, 'a 36-line run must still warn').toBe(true);
-        expect(summary.warn).toBe(true);
-        expect(summary.worstFile).toBe('b.mjs');
-    });
-
-    test('SILENT ARM for the run axis, so a guard that warns on everything fails here', () => {
-        const summary = summarizeDensity([measured.clean]);
-
-        expect(summary.runExceeded).toBe(false);
-        expect(summary.warn).toBe(false);
+    test('the fold applies each bar independently and names the worst file', () => {
+        expect(summarizeDensity([rows.highShare]).shareExceeded).toBe(true);
+        expect(summarizeDensity([rows.quiet]).shareExceeded).toBe(false);
+        expect(summarizeDensity([rows.longRun].map(row => ({...row}))).worstFile).toBe('b.mjs');
+        expect(summarizeDensity([rows.quiet]).worstFile, 'no worst file when nothing is exceeded').toBe(null);
     });
 
     test('both bars are the p90 of the seats whose behaviour did NOT change', () => {
@@ -129,12 +120,12 @@ test.describe('check-comment-density — the axes measured on real commits', () 
     });
 
     test('a changed bound changes the outcome — the bars are inputs, not baked-in numbers', () => {
-        expect(summarizeDensity([measured.dilutedRun], {maxProseRun: 100}).runExceeded).toBe(false);
-        expect(summarizeDensity([measured.clean], {maxProseShare: 0.05}).shareExceeded).toBe(true);
+        expect(summarizeDensity([rows.longRun], {maxProseRun: 100}).runExceeded).toBe(false);
+        expect(summarizeDensity([rows.quiet], {maxProseShare: 0.05}).shareExceeded).toBe(true);
     });
 
     test('partial bounds normalize onto the defaults rather than disabling an axis', () => {
-        expect(summarizeDensity([measured.dilutedRun], {maxProseShare: 0.9}).runExceeded).toBe(true);
+        expect(summarizeDensity([rows.longRun], {maxProseShare: 0.9}).runExceeded).toBe(true);
     });
 
     test('the run is a per-file maximum, never summed across files', () => {

--- a/test/playwright/unit/buildScripts/checkCommentDensity.spec.mjs
+++ b/test/playwright/unit/buildScripts/checkCommentDensity.spec.mjs
@@ -1,11 +1,15 @@
 import {test, expect} from '@playwright/test';
+import {execFileSync} from 'node:child_process';
 import {
     DEFAULT_BOUNDS,
     formatDensityWarning,
+    isConfession,
     isInScopePath,
     isProseLine,
     isTagLine,
     measureProseDensity,
+    measureRange,
+    pendingRanges,
     summarizeDensity
 } from '../../../../buildScripts/util/check-comment-density.mjs';
 
@@ -121,6 +125,118 @@ test.describe('check-comment-density — prose classification', () => {
         expect(result.added).toBe(1);
         expect(result.prose).toBe(1);
         expect(result.longestRun).toBe(1);
+    });
+});
+
+test.describe('check-comment-density — deferral detection', () => {
+    test('the founding specimen fires: a reasoned, unticketed deferral is still a deferral', () => {
+        // The census specimen. `deliberately` asserts intent without discharging the obligation, so it
+        // is not in DECIDED_MARKERS — exempting it would exempt the best-dressed confessions.
+        expect(isConfession('worthwhile and deliberately left alone')).toBe(true);
+        expect(isConfession('Pass generic env for now')).toBe(true);
+        expect(isConfession('Ideally we hydrate the source store here')).toBe(true);
+    });
+
+    test('a marker is its own admission — no stance word converts it into a decision', () => {
+        expect(isConfession('TODO: Implement geocoding')).toBe(true);
+        expect(isConfession('FIXME intentionally')).toBe(true);
+        expect(isConfession('HACK(perf): re-reads the tree')).toBe(true);
+    });
+
+    test('MARKER form only — the English word is prose about obligations, not an obligation', () => {
+        // Bare `todo` matched 90 repo lines, mostly prose; the marker form matched 14, all real.
+        expect(isConfession("an announcement becomes someone else's todo")).toBe(false);
+        expect(isConfession('TODO: cache all regex')).toBe(true);
+    });
+
+    test('REFUTED VOCABULARY: this repo\'s domain nouns are not deferrals', () => {
+        // These four carried 326 of 458 hits in a first draft and were measured out, not guessed out.
+        expect(isConfession('a CPU deployment burned ~2.3 cores at `0 updated, 30 deferred` per pass')).toBe(false);
+        expect(isConfession('Webhook delivery is recognized in config but not yet POSTed.')).toBe(false);
+        expect(isConfession('the follow-up wires mutating ops — the dispatch core fails CLOSED')).toBe(false);
+        expect(isConfession("Placeholder values ('unknown', 'n/a', 'tbd') THROW")).toBe(false);
+    });
+
+    test('REFUTED VOCABULARY: concession shapes scored 0 true across 13 candidate hits', () => {
+        // The operator's specimen ("duplicating code is bad, but…") is a real behaviour that this
+        // repo does not write in words a regex can separate from precise technical prose. Both
+        // candidate shapes were measured repo-wide: lexical `i know…` was 0 true / 8 false, and
+        // structural `<norm>…but` was 0 true / 5 false. Neither ships; these arms pin the negative
+        // so a future author re-adding one has to beat a recorded measurement, not an opinion.
+        expect(isConfession('answering "admissible" would certify precisely the case we know')).toBe(false);
+        expect(isConfession('scrolls we caused, because we know we caused them')).toBe(false);
+        expect(isConfession('declared `number`, which accepts values that are not wrong-ish but INVALID')).toBe(false);
+        expect(isConfession('rejects bad rows at the upsert boundary, but a replace-mode import truncates')).toBe(false);
+    });
+
+    test('a bound obligation is not a confession, and the marker is the reachable escape', () => {
+        expect(isConfession('left alone for now — ticket-ref-ok: covered by the parent sweep')).toBe(false);
+        expect(isConfession('skipped by design for now')).toBe(false);
+        // Unequal reach, deliberately: check-ticket-archaeology rejects a bare ref on a NEW comment
+        // line under ai/ src/ test/, so this arm is independently live only under buildScripts/.
+        expect(isConfession('revisit once #17400 lands')).toBe(false);
+    });
+
+    test('confessions ride along with the density measurement, carrying line numbers', () => {
+        const lines  = ['// for now, assume one tenant', 'const x = 1;', '// TODO: widen'],
+              result = measureProseDensity(lines, new Set([1, 2, 3]));
+
+        expect(result.confessions).toHaveLength(2);
+        expect(result.confessions.map(entry => entry.line)).toEqual([1, 3]);
+    });
+
+    test('a PRE-EXISTING confession is not this commit\'s — only added lines are reported', () => {
+        const result = measureProseDensity(['// TODO: old debt', '// for now, mine'], new Set([2]));
+
+        expect(result.confessions).toHaveLength(1);
+        expect(result.confessions[0].line).toBe(2);
+    });
+});
+
+test.describe('check-comment-density — pre-push consumer', () => {
+    const ZERO = '0'.repeat(40),
+          sha  = char => char.repeat(40);
+
+    test('the pushed range is remoteSha..localSha, the boundary git itself applies', () => {
+        expect(pendingRanges(`refs/heads/x ${sha('a')} refs/heads/x ${sha('b')}`)).toEqual([`${sha('b')}..${sha('a')}`]);
+    });
+
+    test('a NEW remote branch has no boundary sha, so the range falls back to the trunk', () => {
+        expect(pendingRanges(`refs/heads/x ${sha('a')} refs/heads/x ${ZERO}`)).toEqual([`origin/dev..${sha('a')}`]);
+    });
+
+    test('a branch DELETION pushes no commits and measures nothing', () => {
+        expect(pendingRanges(`refs/heads/x ${ZERO} refs/heads/x ${sha('b')}`)).toEqual([]);
+    });
+
+    test('empty stdin is a manual run — it measures the branch rather than no-opping', () => {
+        // A check that silently passes when it cannot see its input is not a check.
+        expect(pendingRanges('')).toEqual(['origin/dev..HEAD']);
+        expect(pendingRanges(undefined)).toEqual(['origin/dev..HEAD']);
+    });
+
+    test('every pushed ref is measured, not just the first', () => {
+        expect(pendingRanges(`refs/heads/a ${sha('1')} refs/heads/a ${sha('2')}\nrefs/heads/b ${sha('3')} refs/heads/b ${sha('4')}`)).toHaveLength(2);
+    });
+
+    test('measureRange reads REAL git history, so the consumer is proven end to end', () => {
+        const gitRoot = execFileSync('git', ['rev-parse', '--show-toplevel'], {encoding: 'utf-8'}).trim(),
+              head    = execFileSync('git', ['rev-parse', 'HEAD'], {cwd: gitRoot, encoding: 'utf-8'}).trim(),
+              files   = measureRange(`${head}~1..${head}`, gitRoot);
+
+        expect(Array.isArray(files)).toBe(true);
+        files.forEach(row => {
+            expect(row.added).toBeGreaterThan(0);
+            expect(isInScopePath(row.file)).toBe(true);
+            expect(row).toHaveProperty('longestRun');
+            expect(row).toHaveProperty('confessions');
+        });
+    });
+
+    test('an unresolvable range yields no files instead of throwing into the hook', () => {
+        const gitRoot = execFileSync('git', ['rev-parse', '--show-toplevel'], {encoding: 'utf-8'}).trim();
+
+        expect(measureRange('definitely-not-a-ref..also-not-a-ref', gitRoot)).toEqual([]);
     });
 });
 

--- a/test/playwright/unit/buildScripts/checkCommentDensity.spec.mjs
+++ b/test/playwright/unit/buildScripts/checkCommentDensity.spec.mjs
@@ -2,6 +2,7 @@ import {test, expect} from '@playwright/test';
 import {execFileSync} from 'node:child_process';
 import {
     DEFAULT_BOUNDS,
+    dropQuotedSpans,
     formatDensityWarning,
     isConfession,
     isInScopePath,
@@ -167,6 +168,30 @@ test.describe('check-comment-density — deferral detection', () => {
         expect(isConfession('scrolls we caused, because we know we caused them')).toBe(false);
         expect(isConfession('declared `number`, which accepts values that are not wrong-ish but INVALID')).toBe(false);
         expect(isConfession('rejects bad rows at the upsert boundary, but a replace-mode import truncates')).toBe(false);
+    });
+
+    test('USE vs MENTION: quoting a marker as an example is not owing work', () => {
+        // Any file documenting this vocabulary quotes the markers, this one included. Measured on the
+        // repo: the rule drops 3 of 49 hits and all 3 are mentions, so it costs no recall.
+        expect(isConfession('"Pass generic env for now" is the specimen')).toBe(false);
+        expect(isConfession('the marker form matched ("TODO: Implement geocoding")')).toBe(false);
+        expect(isConfession('`// TODO: remove when it lands` is observed by nobody')).toBe(false);
+        expect(isConfession('**for now** is the marker this names')).toBe(false);
+
+        // The same words UNQUOTED still fire — the rule reads quoting, not vocabulary.
+        expect(isConfession('Pass generic env for now')).toBe(true);
+        expect(isConfession('TODO: Implement geocoding')).toBe(true);
+    });
+
+    test('an unbalanced quote is treated as a span that OPENS here, not as unquoted text', () => {
+        expect(isConfession('unbalanced mention opens here ("for now')).toBe(false);
+        // An EVEN count pairs correctly, so the mention is dropped.
+        expect(dropQuotedSpans('a "b" c "TODO: x").').includes('TODO')).toBe(false);
+
+        // Stated limit, not a silent one, and this was a real line in this file: with THREE quotes the
+        // balanced pass consumes the first two, leaving the third dangling and the mention exposed.
+        // Deciding it needs cross-line quote state, which check-ticket-archaeology declines too.
+        expect(dropQuotedSpans('todo"); the form matched ("TODO: x").').includes('TODO')).toBe(true);
     });
 
     test('a bound obligation is not a confession, and the marker is the reachable escape', () => {

--- a/test/playwright/unit/buildScripts/checkCommentDensity.spec.mjs
+++ b/test/playwright/unit/buildScripts/checkCommentDensity.spec.mjs
@@ -21,42 +21,68 @@ import {
  */
 test.describe('check-comment-density — the axes measured on real commits', () => {
     /**
-     * The red-proof runs the TOOL over named commits rather than asserting hand-written numbers.
+     * The red-proof supplies LINES and lets the tool compute the number.
      *
-     * An earlier version of this file fed `longestRun: 36` in as a fixture, which passed while the
-     * tool computed 9 on the same commit — the bar logic was proven and the measurement was not. The
-     * defect that hid behind it: the run broke on tag lines, so a 45-line docblock scored 9 and the
-     * axis fired on 0 of 92 recent commits.
+     * An earlier version supplied the number: `longestRun: 36` as a fixture field, which passed while
+     * the tool computed 9 on the commit the AC named. Bar logic proven, measurement never proven — and
+     * the defect hiding behind it was that the run broke on tag lines, so a 45-line docblock scored 9
+     * and the axis fired on 0 of 92 post-rotation commits.
+     *
+     * These arms cannot repeat that: every number below comes out of `measureProseDensity`. The real
+     * commits stay in the ticket as calibration evidence, since CI checks out too shallow to reach
+     * them and an arm that skips where it matters most is the same failure wearing a green tick.
+     *
+     * @param {Number} blockLines How many comment lines the docblock spans, tags included.
+     * @param {Number} codeLines Added code lines, the share axis's denominator.
+     * @returns {Object} A one-file measurement, computed.
      */
-    const commit = range => summarizeDensity(measureRange(range, execFileSync('git', ['rev-parse', '--show-toplevel'], {encoding: 'utf-8'}).trim()));
+    function commitShaped(blockLines, codeLines) {
+        const lines = ['/**'];
 
-    test('RED-PROOF, run axis: the tool warns where the share axis provably cannot', () => {
-        // a17ade4264 — the head the operator change-requested for a 45-line docblock.
-        const summary = commit('a17ade4264~1..a17ade4264');
+        for (let i = 1; i < blockLines - 1; i++) {
+            // Interleave real tag lines: the docblock a reader faces does not stop at `@param`.
+            lines.push(i % 4 === 0 ? ` * @param {String} arg${i} a value` : ` * narrative line ${i}`)
+        }
 
-        expect(summary.longestRun, 'the docblock the operator flagged').toBe(45);
-        expect(summary.shareExceeded, '19% share is comfortably under the bar').toBe(false);
+        lines.push(' */');
+
+        for (let i = 0; i < codeLines; i++) lines.push(`const value${i} = ${i};`);
+
+        return {file: 'shaped.mjs', ...measureProseDensity(lines, new Set(lines.map((_, i) => i + 1)))}
+    }
+
+    test('RED-PROOF, run axis: warns where the share axis provably cannot', () => {
+        // The shape of a17ade4264 — the head the operator change-requested: a 45-line docblock diluted
+        // by ~270 other added lines. Tag lines inside it must NOT break the run; that break is the
+        // defect, and with it this arm computes single digits and goes green on nothing.
+        const summary = summarizeDensity([commitShaped(45, 271)]);
+
+        expect(summary.longestRun, 'the whole docblock, tags included').toBe(45);
+        expect(summary.shareExceeded, 'a diluted share is comfortably under the bar').toBe(false);
         expect(summary.runExceeded).toBe(true);
         expect(summary.warn).toBe(true);
     });
 
     test('SILENT ARM: a commit at the repo median warns on neither axis', () => {
-        const summary = commit('087114e8ab~1..087114e8ab');
+        // 11-line block, the measured median shape. Without this arm, a guard that warns on
+        // everything passes the red-proof above.
+        const summary = summarizeDensity([commitShaped(11, 60)]);
 
         expect(summary.longestRun).toBe(11);
         expect(summary.shareExceeded).toBe(false);
         expect(summary.runExceeded).toBe(false);
-        expect(summary.warn, 'without this, a guard that warns on everything passes the arm above').toBe(false);
+        expect(summary.warn).toBe(false);
     });
 
     test('the share axis catches what the run axis misses — the two are independent', () => {
-        // 027125dcf7, the change-request FIX: the run collapses 45 -> 5, and 27 of its 32 added lines
-        // are comment, so the share axis is what still has something to say.
-        const summary = commit('027125dcf7~1..027125dcf7');
+        // The shape of the change-request FIX: the block collapses, and most added lines are still
+        // comment, so the share axis is what still has something to say. 6 of 17 added lines prose.
+        const summary = summarizeDensity([commitShaped(9, 8)]);
 
-        expect(summary.longestRun).toBe(5);
+        expect(summary.longestRun).toBe(9);
         expect(summary.runExceeded).toBe(false);
         expect(summary.shareExceeded).toBe(true);
+        expect(summary.warn).toBe(true);
     });
 
     const measured = {
@@ -297,7 +323,20 @@ test.describe('check-comment-density — pre-push consumer', () => {
               head    = execFileSync('git', ['rev-parse', 'HEAD'], {cwd: gitRoot, encoding: 'utf-8'}).trim(),
               files   = measureRange(`${head}~1..${head}`, gitRoot);
 
-        expect(Array.isArray(files)).toBe(true);
+        // NOT just `Array.isArray`: measureRange returns [] on any git failure, so a shape-only
+        // assertion passes vacuously on a broken git path — the same vacuity as asserting a number the
+        // fixture supplied. Asserting a fixed non-zero count instead would break on any commit that
+        // touches no in-scope file, so the arm compares against an INDEPENDENT git read: whatever that
+        // says is in scope, measureRange must have measured.
+        // `--numstat` rather than `--name-only`, to match the tool's contract exactly: measureRange
+        // skips a file with no ADDED lines, which a pure rename is, and name-only would list it.
+        const expected = execFileSync('git', ['diff', '--numstat', '--diff-filter=ACMR', `${head}~1..${head}`], {cwd: gitRoot, encoding: 'utf-8'})
+            .split('\n')
+            .map(line => line.split('\t'))
+            .filter(([added, , file]) => Number(added) > 0 && file && isInScopePath(file))
+            .map(([, , file]) => file);
+
+        expect(files.map(row => row.file).sort()).toEqual(expected.sort());
         files.forEach(row => {
             expect(row.added).toBeGreaterThan(0);
             expect(isInScopePath(row.file)).toBe(true);

--- a/test/playwright/unit/buildScripts/checkCommentDensity.spec.mjs
+++ b/test/playwright/unit/buildScripts/checkCommentDensity.spec.mjs
@@ -17,9 +17,48 @@ import {
 /**
  * Two axes, warned on independently. The share axis has an author-controlled denominator — fixture
  * lines in the same commit dilute a long docblock below the bar — so the run axis exists to catch what
- * the share cannot see. Every commit named below was measured on this repo.
+ * the share cannot see.
  */
-test.describe('check-comment-density — share and run axes', () => {
+test.describe('check-comment-density — the axes measured on real commits', () => {
+    /**
+     * The red-proof runs the TOOL over named commits rather than asserting hand-written numbers.
+     *
+     * An earlier version of this file fed `longestRun: 36` in as a fixture, which passed while the
+     * tool computed 9 on the same commit — the bar logic was proven and the measurement was not. The
+     * defect that hid behind it: the run broke on tag lines, so a 45-line docblock scored 9 and the
+     * axis fired on 0 of 92 recent commits.
+     */
+    const commit = range => summarizeDensity(measureRange(range, execFileSync('git', ['rev-parse', '--show-toplevel'], {encoding: 'utf-8'}).trim()));
+
+    test('RED-PROOF, run axis: the tool warns where the share axis provably cannot', () => {
+        // a17ade4264 — the head the operator change-requested for a 45-line docblock.
+        const summary = commit('a17ade4264~1..a17ade4264');
+
+        expect(summary.longestRun, 'the docblock the operator flagged').toBe(45);
+        expect(summary.shareExceeded, '19% share is comfortably under the bar').toBe(false);
+        expect(summary.runExceeded).toBe(true);
+        expect(summary.warn).toBe(true);
+    });
+
+    test('SILENT ARM: a commit at the repo median warns on neither axis', () => {
+        const summary = commit('087114e8ab~1..087114e8ab');
+
+        expect(summary.longestRun).toBe(11);
+        expect(summary.shareExceeded).toBe(false);
+        expect(summary.runExceeded).toBe(false);
+        expect(summary.warn, 'without this, a guard that warns on everything passes the arm above').toBe(false);
+    });
+
+    test('the share axis catches what the run axis misses — the two are independent', () => {
+        // 027125dcf7, the change-request FIX: the run collapses 45 -> 5, and 27 of its 32 added lines
+        // are comment, so the share axis is what still has something to say.
+        const summary = commit('027125dcf7~1..027125dcf7');
+
+        expect(summary.longestRun).toBe(5);
+        expect(summary.runExceeded).toBe(false);
+        expect(summary.shareExceeded).toBe(true);
+    });
+
     const measured = {
         // 62% share, the worst share observed in the sampled window.
         highShare: {file: 'a.mjs', added: 343, prose: 214, longestRun: 20},
@@ -50,11 +89,13 @@ test.describe('check-comment-density — share and run axes', () => {
         expect(summary.warn).toBe(false);
     });
 
-    test('the run bar sits in the measured p90–p99 band, so a warning means unusual', () => {
-        // p90 32, p99 64 across ai/services/**. A bar below p90 warns on ordinary files; above p99
-        // warns on almost nothing.
-        expect(DEFAULT_BOUNDS.maxProseRun).toBeGreaterThanOrEqual(32);
-        expect(DEFAULT_BOUNDS.maxProseRun).toBeLessThan(64);
+    test('both bars are the p90 of the seats whose behaviour did NOT change', () => {
+        // Measured per commit on origin/dev, ≥ 20 added in-scope lines. Two independent flat controls
+        // land on the same numbers: block-run p90 34 (Opus 4.8, n=552) and 35 (Fable, n=162); share
+        // p90 31.9% and 28.5%. A trailing median would drift up with the behaviour it measures; a
+        // pre-regression distribution does not move. An earlier bar cited a whole-FILE distribution,
+        // which is a different substrate from the per-commit added lines the tool actually measures.
+        expect(DEFAULT_BOUNDS.maxProseRun).toBe(35);
         expect(DEFAULT_BOUNDS.maxProseShare).toBeCloseTo(0.3);
     });
 
@@ -92,8 +133,12 @@ test.describe('check-comment-density — prose classification', () => {
         expect(isTagLine(' * @returns {Boolean}')).toBe(true);
         expect(isTagLine(' * an explanation')).toBe(false);
 
-        // Tags break a run: a densely-typed signature must not read as one long block.
-        expect(added(['/**', ' * prose', ' * @param {String} x', ' * prose', ' */']).longestRun).toBe(1);
+        // A tag is excluded from PROSE but does not break the RUN: the two axes measure different
+        // objects, and a 45-line docblock is 45 lines to a reader whether or not `@param` sits in it.
+        const block = added(['/**', ' * prose', ' * @param {String} x', ' * prose', ' */']);
+
+        expect(block.longestRun, 'the whole block, delimiters included').toBe(5);
+        expect(block.prose, 'two prose lines; the tag and both delimiters are not prose').toBe(2);
         expect(isProseLine('*'), 'a `/**` opener extracts as `*` and is a delimiter, not prose').toBe(false);
         expect(isProseLine(' one'), 'a comment with a word is prose').toBe(true);
     });
@@ -103,10 +148,13 @@ test.describe('check-comment-density — prose classification', () => {
         expect(added(['const u = "https://example.com";']).prose).toBe(0);
     });
 
-    test('a block comment accumulates one run across its TEXT lines', () => {
-        // The `/*` and `*/` delimiter lines carry no text, so they are not prose. Measuring text rather
-        // than markers keeps a two-line docblock from scoring the same as a four-line one.
-        expect(added(['/*', ' * one', ' * two', ' * three', ' */', 'code();']).longestRun).toBe(3);
+    test('a block comment is ONE run across its full extent, and code ends it', () => {
+        // The delimiters carry no text, so they are not prose — but they are part of the block a
+        // reader faces, so the run counts them. `code();` is not a comment and closes the run.
+        const block = added(['/*', ' * one', ' * two', ' * three', ' */', 'code();']);
+
+        expect(block.longestRun).toBe(5);
+        expect(block.prose, 'three text lines; the two delimiters are not prose').toBe(3);
         expect(added([' * orphan prose outside a block']).prose, 'not a comment without an opener').toBe(0);
     });
 
@@ -276,12 +324,14 @@ test.describe('check-comment-density — scope and output', () => {
         expect(isInScopePath('buildScripts/util/x.mjs')).toBe(true);
     });
 
-    test('the warning prints both raw numbers, never only a verdict', () => {
-        const text = formatDensityWarning(summarizeDensity([{file: 'b.mjs', added: 316, prose: 69, longestRun: 36}]));
+    test('the warning prints every raw number, never only a verdict', () => {
+        const text = formatDensityWarning(summarizeDensity([{file: 'b.mjs', added: 316, prose: 69, longestRun: 36, runs: [8, 12, 36]}]));
 
         expect(text).toContain('69 of 316');
         expect(text).toContain('longest contiguous run 36');
-        expect(text).toContain('bar 34');
+        // The median sits beside the longest, because the floor rising is invisible to a tail number.
+        expect(text).toContain('median of 3 block(s) 12');
+        expect(text).toContain('bar 35');
         expect(text).toContain('b.mjs');
     });
 });


### PR DESCRIPTION
Resolves neomjs/neo#17406
Resolves neomjs/neo-agent-brain#24

> 🌿 A deferral could be written as an essay and counted as documentation; after this, prose that owes work is prose that says so out loud.

Nothing measured comment density in shipped source, so the only gate was the author's own judgement. `check-comment-density` reports four numbers over a commit's added lines — prose share, longest comment block, that commit's median block, and unticketed deferrals — and runs on `pre-push`.

Evidence: L3 (pure measurement functions; every AC decidable in-process) → L3 required.

## The scope change, and why the first version was the wrong noun

Operator, 2026-08-20: *"a tool without a consumer is utterly pointless. and the topic is way more complex. not just lines… WAY more important: EXCUSES inside comments, instead of creating tickets."*

neomjs/neo-agent-brain#24's own Context named **EXCUSES**. The two density axes measure **volume**, which is a proxy: a 400-line docblock of pure behaviour trips them, and a one-line unticketed deferral does not. The deferral axis measures the noun; the hook makes it reachable.

## The run axis measured the wrong object and could not fire

Found by running the finished tool over the population it is meant to guard, after @neo-opus-ada's calibration broadcast gave me a number to disagree with.

The run broke on **tag lines**. So the 45-line docblock the operator change-requested on `a17ade4264` scored **9**, and the axis fired on **0 of 92** post-rotation commits at every bar the calibration could justify.

The spec passed the whole time, because its red-proof fed `longestRun: 36` in as a hand-written fixture rather than measuring the commit. Bar logic proven; measurement never proven. A red-proof that supplies its own subject cannot fail for the reason it exists to catch.

| commit | before | after | what it is |
|---|---|---|---|
| `a17ade4264` | 9 | **45** | the docblock the operator change-requested |
| `087114e8ab` | 11 | **11** | the silent arm, unchanged |
| `027125dcf7` | 5 | **5** | the change-request fix — run collapses, share is what still speaks |

Fixed both ways: the run measures block extent (contiguous added comment lines, tags included — a reader faces the whole block), and the red-proof now supplies **lines** and lets `measureProseDensity` compute the number. `prose` still excludes tags, because the two axes measure different objects on purpose.

Running the tool over the real SHAs was my first repair and CI rejected it — the checkout is too shallow to reach them. Reaching for a deeper fetch would couple a shared workflow to one spec, and skipping when unreachable is the same green tick over an arm that never ran. So the arms stop needing those commits: a fixture builds a docblock of N comment lines with real `@param` lines inside it, and the tool measures it. **Proven by mutation** — with the old tag-breaking rule the same fixture computes **3** against an asserted **45**, so the arm fails for exactly the reason it exists. The commits stay in neomjs/neo-agent-brain#24 as calibration evidence, which is where evidence belongs.

## Both bars are now a fixed reference, and one axis survives a peer's DROP verdict

Ada's argument for anchoring is right and is now implemented: a trailing median drifts upward along with the behaviour it measures, while a pre-regression distribution does not move and is already in the repository. Both bars are the **p90 of the seats whose behaviour did not change**, and two independent flat controls agree on them.

| axis | p90 Opus 4.8 (n=552) | p90 Fable (n=162) | bar | fires now (n=92) | fires, controls | ratio |
|---|---|---|---|---|---|---|
| block run | 34 | 35 | **35** | 20.7% | 10.0% / 10.5% | 2.1x |
| prose share | 31.9% | 28.5% | **30%** | 34.8% | 12.9% / 9.3% | **2.7x** |

**I cannot reproduce the case for dropping the share axis.** Ada measured 84.5% fire at a 30% bar and concluded the axis is unsalvageable; on this instrument, per commit, it fires on **34.8%** and is the **better** discriminator of the two (2.7x versus 2.1x). Different unit — hers is per block, mine is per commit, and a hook fires per commit. The axis stays, with her objection recorded rather than resolved: its denominator is author-controlled, which is exactly what the run axis covers. Sent to her for reconciliation; either number changes the bar, not the shape.

This PR's own last commit warns at 36% share, which is the same weakness seen from the honest side — it is nearly all comment because it is a calibration commit, with no code added to dilute it.

## The vocabulary is measured, not chosen

Over 2564 in-scope files:

| vocabulary | hits | verdict |
|---|---|---|
| first draft (12 markers) | 458 | 4 markers carried **326** and were nearly all false |
| `deferred` | 203 | this repo's scheduler noun — `0 updated, 30 deferred` per pass |
| `not yet` | 68 | runtime state — `not yet POSTed`, `not yet hydrated` |
| `follow-up`, `TBD` | 62 | names sequences that already exist |
| bare word `todo` | 90 | prose about obligations — *an announcement becomes someone else's todo* |
| **shipped** (7 stance markers + `TODO\|FIXME\|XXX\|HACK` in marker form) | **47** | reads as confessions on inspection |

Precision is what a warning nobody silences has to buy. Marker form beat the bare word 14/14 versus 14-of-90.

## Two candidate shapes for the operator's specimen scored zero

The specimen — *"i know duplicating code is bad, but it was duplicated 3 times already, let me add the 4th"* — is a real behaviour that this repo does not write in words a regex separates from precise technical prose.

| candidate | hits | true | what fired instead |
|---|---|---|---|
| lexical (`i know`, `admittedly`, `not ideal`) | 8 | **0** | this repo's epistemic idiom — *the case we know* |
| structural (`<norm>…but`) | 5 | **0** | contrastive *not X but Y* — *values that are not wrong-ish but INVALID* |

Neither ships. Negative spec arms pin both, so re-adding one means beating a measurement rather than an opinion. Reporting the null result is the deliverable here; a regex firing on *"not wrong-ish but INVALID"* would have looked like coverage.

## Deltas from ticket

**The vocabulary shrank from 12 markers to 8** after the census above. neomjs/neo-agent-brain#24's ACs now carry the measurement, so the narrowing is the ticket's requirement rather than a quiet implementation choice.

**"The threshold is a config leaf"** (#17400 AC) is unimplementable in its literal reading. `check-engine-brain-boundary.mjs` scans `buildScripts/**/*.mjs` and flags resolution into `ai/`, so a build script cannot import AiConfig. Delivered as the intent instead: a frozen exported default, injectable per call, with a fixture asserting a changed bound flips the outcome. No sibling `buildScripts/util` lint sources thresholds from AiConfig.

**"Any rule that a marker can silence"** is neomjs/neo-agent-brain#24's own Out of Scope, and the deferral axis honours `ticket-ref-ok`. No new pragma was minted: a bound obligation is this rule's success condition, not an exemption from it. Residual, named because it is real — `ticket-ref-ok: <reason>` can be used as a pure mute. At advisory posture the cost of that is one line not printed.

## The escape hatch had to be the one the repo already owns

`check-ticket-archaeology` scans `ai`, `src`, `test/playwright` and its first pattern is `#\d{4,}\b`, so a bare ticket number on a **new** comment line is rejected before this check sees it. The remedy text therefore names `ticket-ref-ok: <reason>`; suggesting a fix another guard blocks is worse than suggesting none. Found by running that guard on this diff, which rejected three of my own refs.

## Use versus mention

The hook's first run flagged three lines in the checker's own vocabulary docs, where the markers are quoted as examples. Quoted spans are now dropped before the vocabulary applies: 3 of 49 hits removed, all three mentions, recall unchanged. The odd-quote limit is stated and pinned by an arm — three quotes on a line can pair wrongly and expose a mention, and deciding that needs cross-line quote state that `check-ticket-archaeology` declines to carry either.

## The consumer

`.husky/pre-push`, on `remoteSha..localSha` — the boundary git itself applies — read from the hook's stdin payload rather than a guessed range.

| case | behaviour |
|---|---|
| new remote branch (zero-sha) | falls back to the trunk range |
| branch deletion | measures nothing |
| empty stdin (manual run) | measures the branch — a check that no-ops when it cannot see its input is not a check |
| multiple refs | every ref measured, not just the first |
| unmeasurable file | logs and continues; the first version returned 0 files from a missing import and looked like a pass |

Non-blocking, and stated at the call site: the hook runs `set -e`, so an advisory guard must be explicitly non-blocking or a crash in it blocks a push it was never meant to block.

## Test Evidence

`test/playwright/unit/buildScripts/checkCommentDensity.spec.mjs` — **33 passed**.

- **Red-proof, run axis:** a 45-line block diluted by 271 code lines — share under the bar, run over it. **Silent arm:** an 11-line block at the measured median shape, silent on both. **Third arm:** the block collapses to 9 while 6 of 17 added lines stay prose, so the share axis is what still speaks — the two axes are independent in both directions.
- **No arm passes vacuously.** `measureRange` returns `[]` on any git failure, so asserting `Array.isArray` proved nothing; it now agrees with an independent `git diff --numstat` read, which also matches the tool's contract on a rename with no added lines.
- **Deferral axis:** the founding specimen fires (*worthwhile and deliberately left alone*); markers are their own admission (`FIXME intentionally` fires); domain nouns and both refuted concession shapes do not.
- **Consumer:** `measureRange` runs against real git history, and an unresolvable range yields no files instead of throwing into the hook.

Verified on this branch, not on the diff: the hook ran on its own push and reported three self-hits, which is what produced the use/mention rule; the following push reported none.

## Post-Merge Validation

None. The one item this section held — *wire the check into a hook* — is delivered in this PR rather than deferred out of it, which is what the operator's correction asked for. Nothing else here is observable only after merge: the vocabulary census, the hook's range handling and the self-hit round trip were all run on this branch.

## Commits

- `af10a5b373` — the two density axes, their derived bars, 15 arms.
- `f46db809ae` — the deferral axis and the `pre-push` consumer.
- `05955adf7c` — quoted markers are mentions.
- `9038334a57` — the run axis's unit and both bars' derivation.
- `31592bc089` — the red-proof supplies lines, not its own answer.
- `019397ef31` — the git arm builds its own repo, after CI's depth-1 checkout exposed it as green-over-nothing.
- `874f12b725` — only the arms that measure are called red-proofs.

Authored by Vega (Claude Opus 5, Claude Code). Session 046f993e-13ba-47dd-827d-d786428e318b.
