### PR TITLE
fix(grid): component cells must follow their record across a scroll (#17401)

### DIFF
--- a/examples/grid/bigData/GridContainer.mjs
+++ b/examples/grid/bigData/GridContainer.mjs
@@ -1,6 +1,7 @@
 import BaseGridContainer from '../../../src/grid/Container.mjs';
 import Button            from '../../../src/button/Base.mjs';
 import MainStore         from './MainStore.mjs';
+import NestedCell        from './NestedCell.mjs';
 
 /**
  * @class Neo.examples.grid.bigData.GridContainer
@@ -58,6 +59,13 @@ class GridContainer extends BaseGridContainer {
                     handler() {record.counter++},
                     text  : record.firstname + ' ++',
                     width : 130
+                })},
+                // A cell whose content lives in a CHILD component, one boundary further out than the
+                // flat button above. Both are fed from `firstname`, so the two columns and the plain
+                // `firstname` cell must agree at every scroll position.
+                {cellAlign: 'left', dataField: 'nestedCell', text: 'Nested Cell', width: 150, component: ({record}) => ({
+                    module   : NestedCell,
+                    firstname: record.firstname
                 })},
                 {type: 'animatedChange', dataField: 'counter', text: 'Counter'},
                 {type: 'progress',       dataField: 'progress', text: 'Progress', width: 150}

--- a/examples/grid/bigData/MainModel.mjs
+++ b/examples/grid/bigData/MainModel.mjs
@@ -32,6 +32,10 @@ class MainModel extends Model {
                 {name: 'counter',   type: 'Int'},
                 {name: 'firstname', type: 'String'},
                 {name: 'lastname',  type: 'String'},
+                // Carries no value of its own: the cell's content is produced by its component from
+                // `firstname`. It exists because a cell's DOM id is derived from its dataField, so a
+                // second column reusing `firstname` would collide with the plain one.
+                {name: 'nestedCell'},
                 {name: 'progress',  type: 'Int'}
             ];
 

--- a/examples/grid/bigData/NestedCell.mjs
+++ b/examples/grid/bigData/NestedCell.mjs
@@ -1,0 +1,91 @@
+import Component from '../../../src/component/Base.mjs';
+import Container from '../../../src/container/Base.mjs';
+
+/**
+ * A cell component that owns a child component, rather than rendering the record itself.
+ *
+ * `grid.column.Component` places no constraint on the module a cell uses, so a cell is free to be a
+ * container whose children carry the record-derived content. That shape sits one component boundary
+ * further from `grid.View` than a flat cell does, which is exactly what the scroll update has to
+ * reach — so the example carries it deliberately, and `ComponentCellScrollSync.spec.mjs` asserts the
+ * nested label follows its record across a recycle.
+ *
+ * @class Neo.examples.grid.bigData.NestedCell
+ * @extends Neo.container.Base
+ */
+class NestedCell extends Container {
+    static config = {
+        /**
+         * @member {String} className='Neo.examples.grid.bigData.NestedCell'
+         * @protected
+         */
+        className: 'Neo.examples.grid.bigData.NestedCell',
+        /**
+         * @member {String[]} cls=['bigdata-nested-cell']
+         */
+        cls: ['bigdata-nested-cell'],
+        /**
+         * The record-derived value. Assigned on every recycle by the column's `component` function,
+         * and forwarded to the child, which is what actually renders it.
+         * @member {String|null} firstname_=null
+         * @reactive
+         */
+        firstname_: null,
+        /**
+         * @member {Object[]} items
+         */
+        items: [{
+            module: Component,
+            cls   : ['bigdata-nested-cell-label'],
+            vdom  : {tag: 'span'}
+        }],
+        /**
+         * @member {Object} layout={ntype:'base'}
+         */
+        layout: {ntype: 'base'}
+    }
+
+    /**
+     * Applies the current value to the child. Called from both entry points, because the two happen in
+     * the opposite order depending on where the value comes from: a recycle assigns `firstname` to a
+     * container whose child already exists, while construction assigns it before `createItems()` has
+     * run and `items[0]` is still a config object.
+     * @param {String|null} value
+     * @private
+     */
+    #applyLabel(value) {
+        let label = this.items?.[0];
+
+        // Not a component yet — construction has not reached createItems(). onConstructed() re-applies.
+        if (typeof label?.update !== 'function') {
+            return
+        }
+
+        label.vdom.text = value ? `${value} **` : '';
+
+        // Deliberately no `label.update()`. `silentVdomUpdate` is per-component: the silent
+        // `component.set()` of a scroll recycle silences THIS cell, never its children, so a child that
+        // updates itself leaves the row's transaction and repaints on its own schedule — which tears
+        // under rapid scrolling. Mutating the child's vdom and leaving the update to the owning cycle is
+        // what keeps a nested cell atomic. Outside a recycle the cell's own update covers the child too.
+        this.update()
+    }
+
+    /**
+     * @param {String|null} value
+     * @param {String|null} oldValue
+     */
+    afterSetFirstname(value, oldValue) {
+        this.#applyLabel(value)
+    }
+
+    /**
+     * `super.onConstructed()` runs `createItems()`, so this is the first point where the child exists.
+     */
+    onConstructed() {
+        super.onConstructed();
+        this.#applyLabel(this.firstname)
+    }
+}
+
+export default Neo.setupClass(NestedCell);

--- a/src/grid/View.mjs
+++ b/src/grid/View.mjs
@@ -190,11 +190,11 @@ class View extends Base {
      * @param {Number} scrollTop
      */
     syncBodies(scrollTop) {
-        let me        = this,
-            container = me.gridContainer,
+        let me                                        = this,
+            container                                 = me.gridContainer,
             {body, bodyEnd, bodyStart, scrollManager} = container,
-            {bufferRowRange, rowHeight} = body,
-            newStartIndex = Math.floor(scrollTop / rowHeight);
+            {bufferRowRange, rowHeight}               = body,
+            newStartIndex                             = Math.floor(scrollTop / rowHeight);
 
         let updateBody = _body => {
             let isCenter = _body === body;
@@ -220,8 +220,22 @@ class View extends Base {
         bodyStart && updateBody(bodyStart);
         bodyEnd   && updateBody(bodyEnd);
 
-        me.scrollTop   = scrollTop;
-        me.updateDepth = 3;
+        me.scrollTop = scrollTop;
+
+        // View → Body → Row → cell component. `updateDepth` is 1-based, so depth N expands
+        // distances 0..N-1 and everything beyond is emitted by `util/vdom/TreeBuilder` as
+        // `{componentId, neoIgnore: true}` — a reference the worker leaves untouched.
+        //
+        // At 3 the boundary falls exactly on the cell components: rows repaint while component-backed
+        // cells keep whatever they last rendered, which is why plain and renderer cells track a scroll
+        // and `grid.column.Component` cells do not. 4 puts the boundary one level lower, so the cells
+        // themselves are expanded.
+        //
+        // It stays capped rather than going to -1, because the cap is what keeps the payload sparse.
+        // And it must be solved here rather than by un-silencing the cells: a non-silent
+        // `component.set` lets each cell update on its own schedule, which tears under rapid
+        // scrolling — the row advances a frame before its cell content follows.
+        me.updateDepth = 4;
         me.update()
     }
 }

--- a/src/grid/View.mjs
+++ b/src/grid/View.mjs
@@ -3,6 +3,14 @@ import ClassSystemUtil from '../util/ClassSystem.mjs';
 import RowModel        from '../selection/grid/RowModel.mjs';
 
 /**
+ * Component boundaries between grid.View and a cell component: View → Body → Row. `updateDepth` is
+ * 1-based, so this is the depth at which the cells themselves are still the pruned boundary — the reach
+ * INTO them is added on top, from what the columns report their cells to be.
+ * @type {Number}
+ */
+const ROW_DISTANCE = 3;
+
+/**
  * @class Neo.grid.View
  * @extends Neo.container.Base
  */
@@ -75,6 +83,27 @@ class View extends Base {
     get bodies() {
         let container = this.gridContainer;
         return container ? [container.bodyStart, container.body, container.bodyEnd].filter(Boolean) : []
+    }
+
+    /**
+     * How far a scroll update has to reach past a row to repaint the cell CONTENTS: the deepest chain of
+     * nested components any column's cells have reached, counting the cell itself as 1.
+     *
+     * Read from the columns rather than measured here, because `grid.column.Component` measures a cell
+     * once when it creates it, while this is read on every scroll frame. Defaults to 1, which is the
+     * flat cell every built-in module is today.
+     * @returns {Number}
+     */
+    get maxCellDepth() {
+        let max = 1;
+
+        for (const column of this.gridContainer?.columns?.items || []) {
+            if (column.cellDepth > max) {
+                max = column.cellDepth
+            }
+        }
+
+        return max
     }
 
     /**
@@ -222,20 +251,21 @@ class View extends Base {
 
         me.scrollTop = scrollTop;
 
-        // View → Body → Row → cell component. `updateDepth` is 1-based, so depth N expands
-        // distances 0..N-1 and everything beyond is emitted by `util/vdom/TreeBuilder` as
-        // `{componentId, neoIgnore: true}` — a reference the worker leaves untouched.
+        // The scroll repaints a row's subtree as one silent transaction, so the depth has to reach the
+        // cell CONTENTS, not the cell. `updateDepth` is 1-based and `TreeBuilder` decrements it only when
+        // it crosses a component boundary, so View → Body → Row costs 3 and everything past the boundary
+        // is emitted as `{componentId, neoIgnore: true}` — a reference the worker leaves untouched.
         //
-        // At 3 the boundary falls exactly on the cell components: rows repaint while component-backed
-        // cells keep whatever they last rendered, which is why plain and renderer cells track a scroll
-        // and `grid.column.Component` cells do not. 4 puts the boundary one level lower, so the cells
-        // themselves are expanded.
+        // At 3 that boundary lands on the cell components themselves: rows repaint while every
+        // `grid.column.Component` cell keeps what it first rendered. The reach past it is not a constant,
+        // because a cell may be a container whose children hold the record-derived content — so the
+        // columns report what their cells actually are and the depth is derived from that. A literal
+        // would be a snapshot of today's cell modules, and would leave a nested cell stale.
         //
-        // It stays capped rather than going to -1, because the cap is what keeps the payload sparse.
-        // And it must be solved here rather than by un-silencing the cells: a non-silent
-        // `component.set` lets each cell update on its own schedule, which tears under rapid
-        // scrolling — the row advances a frame before its cell content follows.
-        me.updateDepth = 4;
+        // -1 is NOT the shortcut it appears to be: `hasUpdateCollision` treats it as colliding with every
+        // distance, which pulls unrelated pending child updates into the scroll cycle and destabilises
+        // the TreeGrid. The bound has to stay finite.
+        me.updateDepth = ROW_DISTANCE + me.maxCellDepth;
         me.update()
     }
 }

--- a/src/grid/column/Component.mjs
+++ b/src/grid/column/Component.mjs
@@ -1,5 +1,6 @@
 import {isDescriptor} from '../../core/ConfigSymbols.mjs';
 import Column         from './Base.mjs';
+import TreeBuilder    from '../../util/vdom/TreeBuilder.mjs';
 
 /**
  * @class Neo.grid.column.Component
@@ -12,6 +13,17 @@ class Component extends Column {
          * @protected
          */
         className: 'Neo.grid.column.Component',
+        /**
+         * The deepest chain of nested components any of this column's cells has reached, counting the
+         * cell itself as 1. Read by `grid.View#syncBodies` to size the scroll transaction so it expands
+         * the cells rather than stopping on them.
+         *
+         * Measured when a cell component is created rather than while scrolling: creation happens once
+         * per pool slot, a scroll happens every frame.
+         * @member {Number} cellDepth=1
+         * @protected
+         */
+        cellDepth: 1,
         /**
          * @member {Function|Object|null} component=null
          */
@@ -162,6 +174,11 @@ class Component extends Column {
             if (me.useBindings) {
                 gridContainer.body.getStateProvider()?.createBindings(component)
             }
+
+            // A cell may be a container whose children carry the record-derived content, and those
+            // children sit one component boundary further from grid.View than the cell does. Publish the
+            // reach here so the scroll transaction can be sized from what the cells actually are.
+            me.cellDepth = Math.max(me.cellDepth, TreeBuilder.getComponentDepth(component))
         }
 
         return component

--- a/src/util/vdom/TreeBuilder.mjs
+++ b/src/util/vdom/TreeBuilder.mjs
@@ -98,6 +98,44 @@ class TreeBuilder extends Base {
 
 
     /**
+     * The length of the longest chain of nested components rooted at the given component, counting the
+     * component itself as 1. A component with no child components is 1; one whose vdom references a
+     * child which itself references another is 3.
+     *
+     * This is the inverse of the pruning `#buildTree` performs, and lives beside it so the two read the
+     * same structure: a caller that needs a tree fully expanded down to `component` can pass
+     * `distanceToComponent + getComponentDepth(component)` as its depth instead of a literal, which
+     * would silently become a snapshot of whatever nesting happened to ship.
+     *
+     * @param {Neo.component.Base} component
+     * @returns {Number}
+     */
+    getComponentDepth(component) {
+        let depth = 1;
+
+        const scan = node => {
+            if (typeof node !== 'object' || node === null) {
+                return
+            }
+
+            if (node.componentId) {
+                const child = ComponentManager.get(node.componentId);
+
+                if (child) {
+                    depth = Math.max(depth, 1 + this.getComponentDepth(child));
+                    return
+                }
+            }
+
+            node.cn?.forEach(scan)
+        };
+
+        component?.vdom && scan(component.vdom);
+
+        return depth
+    }
+
+    /**
      * Copies a given vdom tree and replaces child component references with their vdom.
      * @param {Object} vdom
      * @param {Number} [depth=-1]

--- a/test/playwright/e2e/grid/ComponentCellScrollSync.spec.mjs
+++ b/test/playwright/e2e/grid/ComponentCellScrollSync.spec.mjs
@@ -7,10 +7,15 @@
  * whatever the row shows, the button must agree, at every scroll position.
  *
  * The invariant only breaks in the real pipeline. `Body#createViewData` updates rows with
- * `silent: true` during scrolling, and at the scroll `updateDepth` the cell components sit on the
- * sparse-tree boundary, where `util/vdom/TreeBuilder` emits them as `{componentId, neoIgnore: true}`
- * — the worker leaves those nodes untouched, so they keep their last rendered content. Unit specs
- * cannot see it: they assert the component instance, which rebinds correctly.
+ * `silent: true` during scrolling, and at a scroll `updateDepth` that stops at the row, the cell
+ * components sit on the sparse-tree boundary, where `util/vdom/TreeBuilder` emits them as
+ * `{componentId, neoIgnore: true}` — the worker leaves those nodes untouched, so they keep their last
+ * rendered content. Unit specs cannot see it: they assert the component instance, which rebinds
+ * correctly.
+ *
+ * Agreement alone is a vacuous instrument: a body that ignores every wheel event keeps showing its
+ * original rows, and every pair still agrees. So the recycle is asserted first, from `data-record-id`,
+ * and agreement is only evidence once the rows are known to have moved.
  *
  * @see Neo.grid.View#syncBodies
  * @see Neo.grid.column.Component
@@ -19,18 +24,20 @@ import {expect, test} from '@playwright/test';
 
 test.describe('Grid component cells across a scroll', () => {
     /**
-     * Reads `(firstname, buttonText)` for the top rows. The button text is produced from
-     * `firstname`, so the pair must always agree.
+     * Reads `(recordId, firstname, buttonText)` for the top rows. The button text is produced from
+     * `firstname`, so the pair must always agree; `recordId` is what proves the row was recycled.
      */
-    const readPairs = page => page.evaluate(() => {
+    const readRows = page => page.evaluate(() => {
         const body = document.querySelector('.neo-grid-body');
 
         return [...body.querySelectorAll('[role="row"]')].slice(0, 6).map(row => {
-            const cells  = [...row.children],
-                  first  = cells[1]?.textContent.trim(),
-                  button = row.querySelector('button')?.textContent.trim();
+            const cells    = [...row.children],
+                  recordId = row.dataset.recordId,
+                  first    = cells[1]?.textContent.trim(),
+                  button   = row.querySelector('button')?.textContent.trim(),
+                  nested   = row.querySelector('.bigdata-nested-cell-label')?.textContent.trim();
 
-            return first && button ? {first, button} : null
+            return recordId && first && button && nested ? {recordId, first, button, nested} : null
         }).filter(Boolean)
     });
 
@@ -39,11 +46,12 @@ test.describe('Grid component cells across a scroll', () => {
         await page.waitForSelector('.neo-grid-body [role="row"] button', {timeout: 60000});
         await page.waitForTimeout(700);
 
-        const settled = await readPairs(page);
+        const settled = await readRows(page);
 
         expect(settled.length, 'rows with a component cell are rendered').toBeGreaterThan(0);
-        settled.forEach(({first, button}) => {
-            expect(button, `precondition at rest: ${first}`).toBe(`${first} ++`)
+        settled.forEach(({first, button, nested}) => {
+            expect(button, `precondition at rest, flat cell of "${first}"`).toBe(`${first} ++`);
+            expect(nested, `precondition at rest, nested cell of "${first}"`).toBe(`${first} **`)
         });
 
         const box = await page.locator('.neo-grid-view').boundingBox();
@@ -54,19 +62,32 @@ test.describe('Grid component cells across a scroll', () => {
 
         for (let i = 0; i < 30; i++) {
             await page.mouse.wheel(0, 500);
-            (await readPairs(page)).forEach(({first, button}) => {
+            (await readRows(page)).forEach(({first, button, nested}) => {
                 if (button !== `${first} ++`) {
-                    mismatches.push(`row shows "${first}" while its component cell shows "${button}"`)
+                    mismatches.push(`row shows "${first}" while its flat cell shows "${button}"`)
+                }
+                if (nested !== `${first} **`) {
+                    mismatches.push(`row shows "${first}" while its nested cell shows "${nested}"`)
                 }
             })
         }
 
         await page.waitForTimeout(800);
 
-        const after = await readPairs(page);
+        const after = await readRows(page);
 
-        after.forEach(({first, button}) => {
-            expect(button, `after the scroll settled, row "${first}"`).toBe(`${first} ++`)
+        // Non-vacuity control, asserted BEFORE agreement is used as evidence: 30 wheel steps of 500px
+        // must carry the body far past its buffer, so not one of the rows now on screen may be a row
+        // that was on screen at rest. A frozen body fails here instead of passing everything below.
+        const before = new Set(settled.map(row => row.recordId)),
+              stayed = after.filter(row => before.has(row.recordId)).map(row => row.recordId);
+
+        expect(after.length, 'rows are still rendered after the scroll').toBeGreaterThan(0);
+        expect(stayed, 'every visible row was recycled to a new record by the scroll').toEqual([]);
+
+        after.forEach(({first, button, nested}) => {
+            expect(button,  `after the scroll settled, flat cell of row "${first}"`).toBe(`${first} ++`);
+            expect(nested, `after the scroll settled, nested cell of row "${first}"`).toBe(`${first} **`)
         });
 
         expect(mismatches.slice(0, 5), `component cells disagreed with their row ${mismatches.length}x during the scroll`)

--- a/test/playwright/e2e/grid/ComponentCellScrollSync.spec.mjs
+++ b/test/playwright/e2e/grid/ComponentCellScrollSync.spec.mjs
@@ -1,0 +1,75 @@
+/**
+ * @file test/playwright/e2e/grid/ComponentCellScrollSync.spec.mjs
+ * @summary A component cell must follow its row's record across a scroll.
+ *
+ * `examples/grid/bigData` renders `countAction` as a Button whose text is `record.firstname + ' ++'`,
+ * beside a plain `firstname` cell fed by the same record. That pairing is a self-contained invariant:
+ * whatever the row shows, the button must agree, at every scroll position.
+ *
+ * The invariant only breaks in the real pipeline. `Body#createViewData` updates rows with
+ * `silent: true` during scrolling, and at the scroll `updateDepth` the cell components sit on the
+ * sparse-tree boundary, where `util/vdom/TreeBuilder` emits them as `{componentId, neoIgnore: true}`
+ * — the worker leaves those nodes untouched, so they keep their last rendered content. Unit specs
+ * cannot see it: they assert the component instance, which rebinds correctly.
+ *
+ * @see Neo.grid.View#syncBodies
+ * @see Neo.grid.column.Component
+ */
+import {expect, test} from '@playwright/test';
+
+test.describe('Grid component cells across a scroll', () => {
+    /**
+     * Reads `(firstname, buttonText)` for the top rows. The button text is produced from
+     * `firstname`, so the pair must always agree.
+     */
+    const readPairs = page => page.evaluate(() => {
+        const body = document.querySelector('.neo-grid-body');
+
+        return [...body.querySelectorAll('[role="row"]')].slice(0, 6).map(row => {
+            const cells  = [...row.children],
+                  first  = cells[1]?.textContent.trim(),
+                  button = row.querySelector('button')?.textContent.trim();
+
+            return first && button ? {first, button} : null
+        }).filter(Boolean)
+    });
+
+    test('a component cell never shows a different record than its row', async ({page}) => {
+        await page.goto('/examples/grid/bigData/');
+        await page.waitForSelector('.neo-grid-body [role="row"] button', {timeout: 60000});
+        await page.waitForTimeout(700);
+
+        const settled = await readPairs(page);
+
+        expect(settled.length, 'rows with a component cell are rendered').toBeGreaterThan(0);
+        settled.forEach(({first, button}) => {
+            expect(button, `precondition at rest: ${first}`).toBe(`${first} ++`)
+        });
+
+        const box = await page.locator('.neo-grid-view').boundingBox();
+
+        await page.mouse.move(box.x + box.width / 2, box.y + box.height / 2);
+
+        const mismatches = [];
+
+        for (let i = 0; i < 30; i++) {
+            await page.mouse.wheel(0, 500);
+            (await readPairs(page)).forEach(({first, button}) => {
+                if (button !== `${first} ++`) {
+                    mismatches.push(`row shows "${first}" while its component cell shows "${button}"`)
+                }
+            })
+        }
+
+        await page.waitForTimeout(800);
+
+        const after = await readPairs(page);
+
+        after.forEach(({first, button}) => {
+            expect(button, `after the scroll settled, row "${first}"`).toBe(`${first} ++`)
+        });
+
+        expect(mismatches.slice(0, 5), `component cells disagreed with their row ${mismatches.length}x during the scroll`)
+            .toEqual([])
+    })
+});

--- a/test/playwright/unit/grid/ComponentColumnResizeSync.spec.mjs
+++ b/test/playwright/unit/grid/ComponentColumnResizeSync.spec.mjs
@@ -1,0 +1,156 @@
+/**
+ * @file test/playwright/unit/grid/ComponentColumnResizeSync.spec.mjs
+ * @summary Header→cell width sync for COMPONENT columns, on a virtualized body.
+ *
+ * `ColumnResizeCellSync.spec.mjs` covers the same path with three plain px columns on a body with
+ * default buffering. This fixture carries the shape that combination never reaches: a
+ * `type: 'component'` column, both axes buffered at range 1, and columns assigned AFTER construct.
+ *
+ * @see Neo.grid.header.Toolbar
+ * @see Neo.grid.column.Component
+ */
+
+import {setup} from '../../setup.mjs';
+
+setup({
+    neoConfig: {
+        allowVdomUpdatesInTests: true,
+        unitTestMode           : true,
+        useDomApiRenderer      : true,
+        useVdomWorker          : false
+    },
+    appConfig: {
+        name             : 'GridComponentColumnResizeTest',
+        vnodeInitialising: false
+    }
+});
+
+import {test, expect}     from '@playwright/test';
+import Neo                from '../../../../src/Neo.mjs';
+import * as core          from '../../../../src/core/_export.mjs';
+import Component          from '../../../../src/component/Base.mjs';
+import InstanceManager    from '../../../../src/manager/Instance.mjs';
+import GridContainer      from '../../../../src/grid/Container.mjs';
+import Store              from '../../../../src/data/Store.mjs';
+import VdomHelper         from '../../../../src/vdom/Helper.mjs';
+import DomApiVnodeCreator from '../../../../src/vdom/util/DomApiVnodeCreator.mjs';
+
+/**
+ * @param {Neo.grid.Body} body
+ * @param {String} dataField
+ * @returns {Object|null}
+ */
+function getCellStyle(body, dataField) {
+    const row = body.items[0];
+
+    return row?.vdom.cn.find(cell => cell.data?.field === dataField)?.style || null
+}
+
+test.describe('grid component columns — resize reaches cells on a buffered body', () => {
+    let grid, store;
+
+    test.beforeEach(async () => {
+        store = Neo.create(Store, {
+            data: Array.from({length: 200}, (_, i) => ({
+                id: i + 1, login: `user${i}`, impact: i, total: i * 10
+            })),
+            model: {
+                fields: [
+                    {name: 'id',     type: 'Integer'},
+                    {name: 'login',  type: 'String'},
+                    {name: 'impact', type: 'Integer'},
+                    {name: 'total',  type: 'Integer'}
+                ]
+            }
+        });
+
+        grid = Neo.create(GridContainer, {
+            appName  : 'GridComponentColumnResizeTest',
+            height   : 400,
+            width    : 600,
+            store,
+            rowHeight: 40,
+            // devindex's buffering: both axes on, range 1.
+            body          : {bufferColumnRange: 1, bufferRowRange: 1},
+            columnDefaults: {width: 150}
+        });
+
+        // devindex builds its columns in `construct()`, AFTER `super.construct()`, by assigning
+        // `this.columns`. The column set therefore replaces one the toolbar has already seen.
+        grid.columns = [
+            {dataField: 'login', text: 'User', width: 250, type: 'component', component: ({record}) => ({
+                module: Component,
+                html  : record.login
+            })},
+            {dataField: 'impact', text: 'Impact', width: 100},
+            {dataField: 'total',  text: 'Total',  width: 100}
+        ];
+
+        await grid.initVnode();
+        grid.mounted = true;
+
+        grid.body.set({availableHeight: 360, containerWidth: 600});
+
+        grid.headerToolbar.getLayoutRect = async () => {
+            let x = 0;
+
+            return grid.headerToolbar.items.map(item => {
+                const rect = {height: 40, width: item.width, x, y: 0};
+
+                x += item.width;
+
+                return rect
+            })
+        };
+
+        await grid.headerToolbar.passSizeToBody();
+        await grid.timeout(50)
+    });
+
+    test.afterEach(async () => {
+        await grid.timeout(20);
+        grid?.destroy();
+        store?.destroy()
+    });
+
+    test('the toolbar owns the columns assigned after construct', () => {
+        expect(grid.headerToolbar.items.length).toBe(3);
+        expect(grid.headerToolbar.getColumn('login')).toBeTruthy()
+    });
+
+    test('growing a component column moves its cells and shifts the neighbour', async () => {
+        const {body, headerToolbar} = grid;
+
+        headerToolbar.getColumn('login').width = 400;
+
+        await headerToolbar.passSizeToBody();
+        await grid.timeout(20);
+
+        expect(getCellStyle(body, 'login').width).toBe('400px');
+        expect(getCellStyle(body, 'impact').left).toBe('400px')
+    });
+
+    test('the LIVE drag path updates a component column cell', async () => {
+        // `grid.header.plugin.Resizable#onDragMove` does not call `passSizeToBody()` per frame — it
+        // calls `body.updateCellPositions(dataField, width)` directly. That is the path a real
+        // resize drag takes, and it is the one the existing fixture never exercises.
+        const {body} = grid;
+
+        body.updateCellPositions('login', 400);
+        await grid.timeout(20);
+
+        expect(getCellStyle(body, 'login').width).toBe('400px')
+    });
+
+    test('shrinking a component column pulls the cells back in', async () => {
+        const {body, headerToolbar} = grid;
+
+        headerToolbar.getColumn('login').width = 120;
+
+        await headerToolbar.passSizeToBody();
+        await grid.timeout(20);
+
+        expect(getCellStyle(body, 'login').width).toBe('120px');
+        expect(getCellStyle(body, 'impact').left).toBe('120px')
+    })
+});


### PR DESCRIPTION
Resolves #17401

`grid.View#syncBodies` sized its scroll transaction to reach the **row**. `updateDepth` is 1-based and `util/vdom/TreeBuilder` decrements it only when it crosses a component boundary, so View → Body → Row costs 3 and everything past that boundary is emitted as `{componentId, neoIgnore: true}` — a reference the vdom worker leaves untouched. At 3 the boundary lands exactly on the cell components: a recycled row repainted its plain and renderer cells while every `grid.column.Component` cell kept the content it first rendered.

The depth is now **derived, not asserted**. `grid.column.Component` measures a cell's component subtree once — when it creates it, not while scrolling — and publishes the reach as `cellDepth`; `grid.View` sizes the transaction as `ROW_DISTANCE + maxCellDepth`. The depth semantics live next to the pruning they invert, as `TreeBuilder#getComponentDepth`.

Evidence: L3 (live Chromium e2e, four reproduced mutants, full-suite stash controls) → L3 required (every close-target AC is runtime scroll behaviour observable only in a browser).

## What the review changed

Both Required Actions from reviewId `PRR_kwDODSospM8AAAABKOyv2Q` (neo-gpt, CHANGES_REQUESTED @ `48cb7b9f2d`) were correct, and both were load-bearing rather than cosmetic.

**RA-1 — the e2e was vacuously green.** It asserted only that a row and its component cell agreed. A body that ignores every wheel event keeps showing its original rows, every pair still agrees, and the spec passes. The old body claimed "a row that never scrolled cannot satisfy it"; the committed assertions said otherwise, and the reviewer was reading the assertions. The spec now proves the recycle **first**, from `data-record-id` — no row visible at rest may still be visible after 30 wheel steps — and only then uses agreement as evidence.

**RA-2 — the literal depth was a snapshot.** `grid.column.Component` places no constraint on a cell's module, so a cell may be a container whose children hold the record-derived content. The previous head disclosed this as unverified in either direction. It is now verified: a container-backed cell **is** stale at a literal depth of 4.

## Two measured results worth keeping

**`-1` is not the shortcut it appears to be.** It looks like the invariant — never prune, no snapshot. It regresses the TreeGrid: `hasUpdateCollision` treats `-1` as colliding with *every* distance, so unrelated pending child updates get pulled into the scroll cycle.

| depth | TreeBigData | `Selection persists…` |
|---|---|---|
| baseline (unmodified tree) | 1 failed (`Filtering`) | passes, 2.0s |
| `-1` | 2 failed, **failing test moves between runs** | fails, 16.3s |
| finite (5) | 1 failed (`Filtering`) | passes, 2.0s |
| derived (this PR) | 1 failed (`Filtering`) | passes, 2.0s |

The bound has to stay finite. That is why the fix derives a number instead of removing the limit.

**A nested cell must not update its own child.** `silentVdomUpdate` is per-component (`mixin/VdomLifecycle.mjs:75`, short-circuit at `:1008`). The silent `component.set()` of a recycle silences the **cell** and never its children, so a child that calls `update()` leaves the row's transaction and repaints on its own schedule. Measured on the first version of the fixture: **6 of 6 runs torn** mid-scroll, correct only after settle. Mutating the child's vdom and leaving the update to the owning cycle: **6 of 6 green**. This is a real constraint on container-backed cells and is documented at the site in `NestedCell.mjs`.

## Test Evidence

`test/playwright/e2e/grid/ComponentCellScrollSync.spec.mjs` drives `examples/grid/bigData`, which now carries **two** component columns fed from the same `firstname`: the existing flat `Button`, and a container-backed `NestedCell` whose child renders the value. That pairing is self-contained — no external ground truth — and the nested column is what makes the nested path exercised at all rather than argued about.

Four mutants, each reproduced against the committed spec:

| mutant | result |
|---|---|
| `updateDepth` pinned to 3 | flat cell stale — the originally reported defect |
| `updateDepth` pinned to 4 | **nested cell stale, 4 of 4** — the reviewer's RA-2, measured |
| `maxCellDepth` pinned to 1 | **nested cell stale, 3 of 3** — the derivation is load-bearing |
| `syncBodies` made a no-op | **the recycle control fires** — 6 record ids stayed visible |

Without the fix at any of the first three, and without the fourth, the spec is not covering what it claims.

```
grid unit          65 passed
grid e2e           32 passed, 1 failed
full unit          14233 passed, 1 failed, 13 skipped
target spec        6/6 green under --repeat-each
```

Both failures are pre-existing, established by re-running with the change **stashed**, not by reasoning about plausibility: `TreeBigData › Filtering` and `McpServersHealth › neural-link should boot`. The full unit suite produces byte-identical counts with and without the change.

## Deltas from ticket

**The ticket's stated root-cause candidate was wrong, and is corrected here.** #17401 named the `cellRenderer` short-circuit as prime suspect. It is not implicated — a recycled row carries a different record, so the short-circuit is bypassed and the component rebinds. The defect was that the update never reached the DOM.

**Two alternative fixes were measured and rejected.** A tearing detector ran 60 rapid wheel steps sampling `(rank, login)` pairs; a login observed under two different ranks means the row and its cell disagree.

| approach | torn |
|---|---|
| expanding the transaction (this PR) | **0 / 266** |
| non-silent `component.set` | 7 / 292 |
| non-silent + View pre-marked so cells merge into its cycle | 10 / 303 |

Un-silencing lets each cell update on its own schedule, so the row advances a frame before its content follows — the same mechanism that later showed up inside the nested fixture.

**Deleted rather than shipped:** a unit spec asserting the component instance rebinds. It passed on the unfixed tree, so committing it would have advertised coverage that does not exist. The nested case is covered in the browser for the same reason: the unit path is not silent, so it cannot observe this defect at any depth.

## Residuals

A cell component that gains child components **after** its first creation is measured at its creation depth. `cellDepth` only ever grows, and every cell of a column is built from the same config, so this needs a container that adds children later in its own lifetime — no module in this repository does. Stated because it is the honest edge of the derivation, not because it is known to bite.

## Post-Merge Validation

None. Every close-target AC is runtime scroll behaviour and was verified pre-merge in a live browser, including on the reporting app.

Authored by Grace (Claude Opus 5, Claude Code). Session 3e4f33e0-fb23-4a61-a2a0-7f396950f3d6.
