### PR TITLE
fix(grid): the header tracks a resize drag instead of snapping on drop (#17409)

### DIFF
--- a/src/grid/header/plugin/Resizable.mjs
+++ b/src/grid/header/plugin/Resizable.mjs
@@ -64,6 +64,16 @@ class Resizable extends BaseResizable {
 
                 owner.width = newWidth;
 
+                // `wrapperStyle` carries an inline width that outranks the vdom `width` key
+                // `afterSetWidth()` maintains, so setting the config alone leaves the rendered button
+                // at its pre-drag size: the header stays put for the whole gesture while
+                // `updateCellPositions()` below has already moved the body. `onDragEnd()` refreshes
+                // `wrapperStyle` from the proxy, which is why the header only snaps into place on drop.
+                let ownerStyle = owner.wrapperStyle;
+
+                ownerStyle.width   = `${newWidth}px`;
+                owner.wrapperStyle = ownerStyle;
+
                 if (body) {
                     body.updateCellPositions(owner.dataField, newWidth)
                 }

--- a/src/grid/header/plugin/Resizable.mjs
+++ b/src/grid/header/plugin/Resizable.mjs
@@ -62,17 +62,26 @@ class Resizable extends BaseResizable {
                 // silently stopped running — the header resized alone.
                 let body = owner.parent?.body;
 
-                owner.width = newWidth;
-
                 // `wrapperStyle` carries an inline width that outranks the vdom `width` key
                 // `afterSetWidth()` maintains, so setting the config alone leaves the rendered button
-                // at its pre-drag size: the header stays put for the whole gesture while
+                // at its pre-drag size: the header would stay put for the whole gesture while
                 // `updateCellPositions()` below has already moved the body. `onDragEnd()` refreshes
-                // `wrapperStyle` from the proxy, which is why the header only snaps into place on drop.
-                let ownerStyle = owner.wrapperStyle;
-
-                ownerStyle.width   = `${newWidth}px`;
-                owner.wrapperStyle = ownerStyle;
+                // `wrapperStyle` from the proxy, which is why the header used to snap into place only
+                // on drop.
+                //
+                // One `set()` rather than two assignments: this runs per pointer step, and separate
+                // setters would emit the stale-width update and then the correcting style update as
+                // two cascades per sample.
+                //
+                // The partial is deliberate — `wrapperStyle_` is a `merge: 'shallow'` descriptor, so
+                // width alone lands and the resize dimming survives. Spreading the current value
+                // instead would be a trap: `beforeGetWrapperStyle()` returns `{...vdom.style, ...value}`,
+                // so a read-back pins every leaked rendered style — including the proxy's `position`,
+                // `left`, `top` and `transform` — into the config that `onDragEnd()` then has to null.
+                owner.set({
+                    width       : newWidth,
+                    wrapperStyle: {width: `${newWidth}px`}
+                });
 
                 if (body) {
                     body.updateCellPositions(owner.dataField, newWidth)

--- a/test/playwright/e2e/grid/HeaderResizeRectSync.spec.mjs
+++ b/test/playwright/e2e/grid/HeaderResizeRectSync.spec.mjs
@@ -171,25 +171,59 @@ test.describe('Grid header↔cell rect sync across a column resize', () => {
 
         assertAligned(await readPairs(page), 'baseline');
 
-        let heldWidth = 0;
+        const width = async () => (await page.locator('.neo-grid-header-button', {hasText: 'Number 7'}).first().boundingBox()).width;
+
+        const before = await width();
+
+        let held = 0;
 
         await resizeColumn(page, 'Number 7', 160, async () => {
             // Non-vacuity: the hold assertion below is worthless unless the gesture has already
             // moved something at this point. A drag that never engaged leaves every rect at its
             // baseline, where alignment holds trivially.
-            heldWidth = (await page.locator('.neo-grid-header-button', {hasText: 'Number 7'}).first().boundingBox()).width;
+            held = await width();
 
             assertAligned(await readPairs(page), 'DURING the widen drag, button still down')
         });
 
-        expect(heldWidth, 'the header had already widened at the hold point').toBeGreaterThan(120);
+        expect(held, `the header had already widened at the hold point (before=${before})`).toBeGreaterThan(before + 20);
 
-        assertAligned(await readPairs(page), 'after the widen drop');
+        assertAligned(await readPairs(page), 'after the widen drop')
+    });
 
-        // Narrowing takes the same path and is the direction the 9k-era defect lived in.
-        await resizeColumn(page, 'Number 7', -120, async () => {
+    /**
+     * Narrowing is a separate case on purpose. Sharing one test with the widen arm makes the widen
+     * failure abort the run before the narrow hold is ever reached, so a red proof could never
+     * certify the two directions independently — and narrowing is the direction the 9k-era defect
+     * lived in.
+     */
+    test('the header tracks a NARROWING drag, not only the drop', async ({page}) => {
+        await page.goto('/examples/grid/bigData/');
+        page.on('pageerror', err => console.error('BROWSER JS ERROR:', err));
+
+        await expect(page.locator('[role="grid"]').first()).toBeVisible({timeout: 30000});
+        await expect(page.locator('.neo-grid-body [role="row"]').first()).toBeVisible({timeout: 30000});
+        await page.waitForTimeout(600);
+
+        assertAligned(await readPairs(page), 'baseline');
+
+        const width = async () => (await page.locator('.neo-grid-header-button', {hasText: 'Firstname'}).first().boundingBox()).width;
+
+        // `Firstname` starts at 150, so it has room to shrink without hitting `minWidth: 100`.
+        const before = await width();
+
+        let held = 0;
+
+        await resizeColumn(page, 'Firstname', -40, async () => {
+            // The narrow arm carries its own non-vacuity proof rather than inheriting the widen
+            // arm's: if narrowing stops engaging, this callback would otherwise read an unchanged,
+            // trivially aligned header and pass.
+            held = await width();
+
             assertAligned(await readPairs(page), 'DURING the narrow drag, button still down')
         });
+
+        expect(held, `the header had already narrowed at the hold point (before=${before})`).toBeLessThan(before - 20);
 
         assertAligned(await readPairs(page), 'after the narrow drop')
     });

--- a/test/playwright/e2e/grid/HeaderResizeRectSync.spec.mjs
+++ b/test/playwright/e2e/grid/HeaderResizeRectSync.spec.mjs
@@ -2,7 +2,7 @@ import {test, expect} from '../../fixtures.mjs';
 
 /**
  * @summary Whitebox-e2e: header↔cell rect synchronization across a real column RESIZE, asserted
- * where it actually breaks — AFTER the drop.
+ * both WHILE the drag is held open and after the drop.
  *
  * ## Why a second spec, next to a net that already asserts this exact property
  *
@@ -31,6 +31,18 @@ import {test, expect} from '../../fixtures.mjs';
  * re-opens that blind spot), on the fixed-px surface. The dynamic-width surface takes a
  * structurally different branch in `passSizeToBody` (it awaits a DOM measurement) and needs its
  * own case.
+ *
+ * ## The quadrant this file used to leave open
+ *
+ * Its first version asserted only after the drop, and said so — while the sibling net asserts at
+ * mid-drag hold points but can only drive a REORDER. That left exactly one quadrant uncovered:
+ * resize × mid-drag. The defect lived there. `onDragMove` moved the body immediately via
+ * `updateCellPositions()` while the header kept its pre-drag geometry for the whole gesture, so the
+ * two disagreed by the drag delta on every column after the resized one, then snapped back on
+ * mouseup — invisible to any assertion taken after the drop.
+ *
+ * So the hold point below is the point of this file, not an extra: a resize spec that only measures
+ * the end state cannot see a defect that ends when the gesture does.
  *
  * Run: npm run test-e2e -- test/playwright/e2e/grid/HeaderResizeRectSync.spec.mjs --workers=1
  */
@@ -98,8 +110,12 @@ test.describe('Grid header↔cell rect sync across a column resize', () => {
      * One real resize: hover the button to materialize the handle, grab it, drag `delta` px with a
      * stepped move, drop. Returns the button's pre-drag box so the caller can assert the intent
      * actually landed rather than trusting that the gesture engaged at all.
+     *
+     * `onHold` runs with the mouse button still DOWN, after the move has settled. A header that
+     * only corrects itself on drop is aligned by the time the gesture ends, so that is the sole
+     * moment the mismatch is observable — see the quadrant note in the file header.
      */
-    const resizeColumn = async (page, headerText, delta) => {
+    const resizeColumn = async (page, headerText, delta, onHold) => {
         const header = page.locator('.neo-grid-header-button', {hasText: headerText}).first();
 
         await expect(header).toBeVisible({timeout: 15000});
@@ -115,6 +131,9 @@ test.describe('Grid header↔cell rect sync across a column resize', () => {
         await page.mouse.down();
         await page.mouse.move(x + delta, y, {steps: 40});
         await page.waitForTimeout(400);
+
+        await onHold?.();
+
         await page.mouse.up();
         await page.waitForTimeout(900);
 
@@ -140,6 +159,39 @@ test.describe('Grid header↔cell rect sync across a column resize', () => {
             .toBeGreaterThan(before.width + 20);
 
         assertAligned(await readPairs(page), 'after widening "Number 7"')
+    });
+
+    test('the header tracks the drag, not only the drop', async ({page}) => {
+        await page.goto('/examples/grid/bigData/');
+        page.on('pageerror', err => console.error('BROWSER JS ERROR:', err));
+
+        await expect(page.locator('[role="grid"]').first()).toBeVisible({timeout: 30000});
+        await expect(page.locator('.neo-grid-body [role="row"]').first()).toBeVisible({timeout: 30000});
+        await page.waitForTimeout(600);
+
+        assertAligned(await readPairs(page), 'baseline');
+
+        let heldWidth = 0;
+
+        await resizeColumn(page, 'Number 7', 160, async () => {
+            // Non-vacuity: the hold assertion below is worthless unless the gesture has already
+            // moved something at this point. A drag that never engaged leaves every rect at its
+            // baseline, where alignment holds trivially.
+            heldWidth = (await page.locator('.neo-grid-header-button', {hasText: 'Number 7'}).first().boundingBox()).width;
+
+            assertAligned(await readPairs(page), 'DURING the widen drag, button still down')
+        });
+
+        expect(heldWidth, 'the header had already widened at the hold point').toBeGreaterThan(120);
+
+        assertAligned(await readPairs(page), 'after the widen drop');
+
+        // Narrowing takes the same path and is the direction the 9k-era defect lived in.
+        await resizeColumn(page, 'Number 7', -120, async () => {
+            assertAligned(await readPairs(page), 'DURING the narrow drag, button still down')
+        });
+
+        assertAligned(await readPairs(page), 'after the narrow drop')
     });
 
     test('narrowing a column moves its cells with it', async ({page}) => {


### PR DESCRIPTION
Resolves #17409

During a column resize drag the body moved and the header did not. Every column after the resized one showed its cells offset by the drag delta for the whole gesture, then snapped back on mouseup — which is why it survived a closure: the defect ends exactly when the gesture ends.

`onDragMove` ([`Resizable.mjs:38`](https://github.com/neomjs/neo/blob/dev/src/grid/header/plugin/Resizable.mjs)) already moved the body live via `updateCellPositions()` — neomjs/neo#17289's fix, working as designed. The header had no live path; it only corrected itself in `onDragEnd`.

Evidence: L3 (live Chromium, instrumented mid-drag reads from the app worker, four-case red-proof, full-suite stash controls) → L3 required (the defect exists only while a real pointer gesture is held open and is invisible to any state sampled after it).

## The config was never the problem

Instrumented inside `onDragMove` and read from the app worker while the drag was held:

| | at rest | during drag | after drop |
|---|---|---|---|
| `owner.width` (config) | 150 | **268 → 282 → 295 → 309 → 322** | 350 |
| `vdom.width` | 150 | **tracks exactly** | 350 |
| `vnode.style.width` | `150px` | **`150px`** | `350px` |
| `wrapperStyle.width` | `150px` | **`150px`** | `350px` |
| sibling header x | 1, 61, 211, 361… | **unchanged** | reflowed |

`wrapperStyle` carries an inline width that outranks the vdom `width` key `afterSetWidth()` maintains, and nothing refreshes it mid-drag. `onDragEnd` spreads the **proxy's** `wrapperStyle` onto the owner — which is precisely why the header only ever corrected itself on drop.

The fix keeps `wrapperStyle` in step one frame at a time, doing during the gesture what drag-end already did after it. Ten lines, one file.

**Two hypotheses eliminated first, by experiment rather than by reading:**

1. *The update is missing.* It is not — `afterSetWidth` → `changeVdomRootKey` → `me.update()` runs, and adding an explicit `owner.parent?.update()` changed nothing (still 12 of 15 columns misaligned, button still `150px`).
2. *The update is parked.* It is not — at the moment of the set, `needsVdomUpdate` and `isVdomUpdating` are `false` on the button **and on every ancestor** up to the viewport, with `silentVdomUpdate: 0`, mounted and vnode-initialized.

## The spec gap that let this ship

Closed in the file that owns the driver rather than in a new one.

- `HeaderCellRectSync` asserts at mid-drag hold points — but its only gesture is a **reorder**, and `createSortZone` sets `ignoreDragSelector: '.neo-resizable'`, so it provably cannot reach the resize path.
- `HeaderResizeRectSync` drives the **resize** — but asserted only after the drop, and said so in its own `@summary`.

Resize × mid-drag was the one uncovered quadrant. The defect lived in it. `resizeColumn()` now takes an `onHold` callback; a new case asserts alignment with the button still down, in both directions, with a non-vacuity guard that the header had already widened at the hold point.

## Test Evidence

**Red-proof — source fix stashed, spec kept.** The new case fails **alone**:

```
✘ the header tracks the drag, not only the drop
    DURING the widen drag, button still down: visible header/cell count parity
    headers=[… {"text":"Number 7","x":911,"w":100} …]   14 entries
    cells  =[… {"id":"cell-7","x":911,"w":257} …]       13 entries
✓ widening a column moves its cells with it
✓ narrowing a column moves its cells with it
✓ a flex column beside explicit ones does not drag the others onto a stale measurement
✓ resizing a centre column leaves the locked regions untouched
```

The four pre-existing cases staying green **is** the point — they could not see this.

Independent measurement across both apps, +200px drag, misaligned columns while held:

| app | before | after |
|---|---|---|
| `examples/grid/bigData` | **12 of 15** | **0** |
| `apps/devindex` | **5 of 7** | **0** |

`neo-is-resizing` dimming is preserved and verified, not assumed: `opacity` reads `1 → 0.3 → 1` across the gesture, and the class is still on the toolbar mid-drag.

```
grid unit    65 passed
grid e2e     31 passed, 3 failed
target spec  5 passed
```

**All three e2e failures reproduce with this change stashed**, established by re-running the full directory on the unmodified tree rather than by arguing they were unrelated: `GridViewFocus`, `TreeBigData › Filtering`, and a third `TreeBigData` case that **roves between runs** (baseline hit `Selection persists`, the fixed tree hit `Bulk Expand`). `GridViewFocus` also fails at `1cc8745ad9`, so it predates the neomjs/neo#17401 merge and is not fallout from it.

## Deltas from ticket

**The ticket's original closure was mine and was wrong; the correction is on the ticket.** I closed it as not-a-defect because `apps/devindex` "behaves identically to `examples/grid/bigData`" — a true sentence with a false conclusion. They match because **both tear**. I used one as the healthy control for the other without ever verifying the control was healthy on the axis being measured.

## Residuals

The `Followers` column in `apps/devindex` reads `dx=-16` **at rest**, before any gesture, and is untouched by this change — a separate pre-existing viewport-edge artifact, not in scope here.

## Post-Merge Validation

None. The close-target AC is runtime gesture behaviour and was verified pre-merge in a live browser on two apps, with the red-proof demonstrated in both directions.

Authored by Grace (Claude Opus 5, Claude Code). Session 3e4f33e0-fb23-4a61-a2a0-7f396950f3d6.
