### PR TITLE
feat(tab): add flat header actions (#17418)

### DIFF
--- a/examples/tab/container/MainContainer.mjs
+++ b/examples/tab/container/MainContainer.mjs
@@ -4,6 +4,7 @@ import NumberField           from '../../../src/form/field/Number.mjs';
 import Radio                 from '../../../src/form/field/Radio.mjs';
 import TextField             from '../../../src/form/field/Text.mjs';
 import TabContainer          from '../../../src/tab/Container.mjs';
+import TabOverflow           from '../../../src/tab/plugin/Overflow.mjs';
 
 /**
  * @summary An interactive example demonstrating the Neo.tab.Container.
@@ -207,8 +208,19 @@ class MainContainer extends ConfigurationViewport {
         return Neo.create(TabContainer, {
             dragResortable: true,
             height        : 300,
-            width         : 500,
-            style         : {margin: '20px'},
+            headerActions : [{
+                action    : 'next-tab',
+                contextual: false,
+                iconCls   : 'fas fa-arrow-right'
+            }, {
+                action : 'previous-tab',
+                iconCls: 'fas fa-arrow-left'
+            }],
+            headerToolbar: {
+                plugins: [{module: TabOverflow}]
+            },
+            width: 500,
+            style: {margin: '20px'},
 
             itemDefaults: {
                 ntype: 'component',
@@ -218,20 +230,36 @@ class MainContainer extends ConfigurationViewport {
 
             items: [{
                 header: {iconCls: 'fa fa-home', text: 'Tab 1', flag: 'tab1',},
-                vdom  : {html: 'Tab 1 Content'}
+                vdom  : {html: 'Tab 1 Content', tabIndex: 0}
             }, {
                 header: {iconCls: 'fa fa-play-circle', text: 'Tab 2'},
-                vdom  : {html: 'Tab 2 Content'}
+                vdom  : {html: 'Tab 2 Content', tabIndex: 0}
             }, {
                 header: {iconCls: 'fa fa-user', text: 'Tab 3', badgeText: 'hello'},
-                vdom  : {html: 'Tab 3 Content'}
+                vdom  : {html: 'Tab 3 Content', tabIndex: 0}
             }],
 
             listeners: {
                 activeIndexChange: this.onUserActiveIndexChange,
+                headerAction     : this.onHeaderAction,
                 scope            : this
             }
         })
+    }
+
+    /**
+     * Demonstrates application-owned effects for generic TabContainer header intent.
+     * @param {Object} data
+     * @param {String} data.action
+     * @param {Neo.tab.Container} data.tabContainer
+     */
+    onHeaderAction({action, tabContainer}) {
+        let delta = action === 'next-tab' ? 1 : action === 'previous-tab' ? -1 : 0,
+            count = tabContainer.getCount();
+
+        if (delta && count > 0) {
+            tabContainer.activeIndex = (tabContainer.activeIndex + delta + count) % count
+        }
     }
 
     /**
@@ -240,7 +268,7 @@ class MainContainer extends ConfigurationViewport {
      * @returns {Neo.tab.header.Button}
      */
     getBadgeTabHeader() {
-        let tabHeaders = this.exampleComponent.getTabBar().items,
+        let tabHeaders = this.exampleComponent.getTabButtons(),
             item;
 
         for (item of tabHeaders) {
@@ -256,7 +284,7 @@ class MainContainer extends ConfigurationViewport {
      * @returns {Neo.tab.header.Button}
      */
     getFirstTabHeader() {
-        let tabHeaders = this.exampleComponent.getTabBar().items,
+        let tabHeaders = this.exampleComponent.getTabButtons(),
             item;
 
         for (item of tabHeaders) {

--- a/examples/tab/container/neo-config.json
+++ b/examples/tab/container/neo-config.json
@@ -3,5 +3,6 @@
     "basePath"   : "../../../",
     "environment": "development",
     "mainPath"   : "./Main.mjs",
-    "themes"     : ["neo-theme-dark", "neo-theme-light", "neo-theme-neo-light"]
+    "themes"     : ["neo-theme-dark", "neo-theme-light", "neo-theme-neo-light"],
+    "useAiClient": true
 }

--- a/resources/scss/src/toolbar/Base.scss
+++ b/resources/scss/src/toolbar/Base.scss
@@ -11,6 +11,11 @@
         }
     }
 
+    .neo-toolbar-action-context-inactive {
+        pointer-events: none;
+        visibility    : hidden;
+    }
+
     &.neo-dock-left {
         .neo-button {
             padding: 12px 6px;

--- a/src/code/LivePreview.mjs
+++ b/src/code/LivePreview.mjs
@@ -229,10 +229,10 @@ class LivePreview extends Container {
             delete me.collapseRect;
 
             Object.assign(vdom.style, {
-                height  : rect.height + 'px',
-                left    : rect.x      + 'px',
-                top     : rect.y      + 'px',
-                width   : rect.width  + 'px'
+                height: rect.height + 'px',
+                left  : rect.x      + 'px',
+                top   : rect.y      + 'px',
+                width : rect.width  + 'px'
             });
 
             me.update();
@@ -392,7 +392,9 @@ class LivePreview extends Container {
             me.getReference('preview').removeAll()
         }
 
-        me.getReference('popout-window-button').hidden = !isPreview
+        let popoutButton = me.tabContainer.getActionItem('popout');
+
+        popoutButton && (popoutButton.hidden = !isPreview);
         me.disableRunSource = false;
     }
 
@@ -410,20 +412,25 @@ class LivePreview extends Container {
 
         if (me.enableFullscreen) {
             items.push({
-                handler: me.collapseExpand.bind(me),
-                iconCls: 'fas fa-expand',
-                ui     : 'ghost'
+                action    : 'fullscreen',
+                contextual: false,
+                handler   : me.collapseExpand.bind(me),
+                iconCls   : 'fas fa-expand',
+                ui        : 'ghost',
+                vdom      : {'aria-label': 'Toggle fullscreen preview'}
             })
         }
 
         // Only add the popout window button in case we are using shared workers
         if (Neo.config.useSharedWorkers) {
             items.push({
-                handler  : me.popoutPreview.bind(me),
-                hidden   : tabContainer.activeIndex !== 1,
-                iconCls  : 'far fa-window-maximize',
-                reference: 'popout-window-button',
-                ui       : 'ghost'
+                action    : 'popout',
+                contextual: false,
+                handler   : me.popoutPreview.bind(me),
+                hidden    : tabContainer.activeIndex !== 1,
+                iconCls   : 'far fa-window-maximize',
+                ui        : 'ghost',
+                vdom      : {'aria-label': 'Open preview in a separate window'}
             });
 
             Neo.currentWorker.on({
@@ -433,12 +440,7 @@ class LivePreview extends Container {
             })
         }
 
-        items.unshift('->');
-
-        // we want to add a normal (non-header) button
-        tabContainer.getTabBar().add(items);
-
-        tabContainer.getTabBar().update();
+        tabContainer.headerActions = items;
 
         tabContainer.on('activeIndexChange', me.onActiveIndexChange, me);
 
@@ -468,10 +470,10 @@ class LivePreview extends Container {
      * @param {Number} data.windowId
      */
     async onWindowConnect({windowId}) {
-        let me           = this,
-            url          = await Neo.Main.getByPath({path: 'document.URL', windowId}),
-            params       = new URL(url).searchParams,
-            id           = params.get('id');
+        let me     = this,
+            url    = await Neo.Main.getByPath({path: 'document.URL', windowId}),
+            params = new URL(url).searchParams,
+            id     = params.get('id');
 
         if (id === me.id) {
             me.connectedWindowId = windowId;
@@ -518,7 +520,7 @@ class LivePreview extends Container {
             me.disableRunSource = true; // will get reset after the next activeIndex change (async)
             tabContainer.activeIndex = 1;        // switch to the source view
 
-            me.getReference('popout-window-button').disabled = false;
+            tabContainer.getActionItem('popout').disabled = false;
             tabContainer.getTabAtIndex(1).disabled = false;
 
             me.connectedWindowId = null

--- a/src/dashboard/DockProjectionReconciler.mjs
+++ b/src/dashboard/DockProjectionReconciler.mjs
@@ -1,6 +1,5 @@
 import Component from '../component/Base.mjs';
 import Base      from '../core/Base.mjs';
-import NeoArray  from '../util/Array.mjs';
 
 const projectionNodeTypes = new Set(['edge-zone', 'split', 'tabs']);
 
@@ -595,7 +594,7 @@ class DockProjectionReconciler extends Base {
                     return {
                         bar   : tab.getTabBar(),
                         body,
-                        button: tab.getTabBar().items[index],
+                        button: tab.getTabButtons()[index],
                         index,
                         tab
                     }
@@ -628,7 +627,7 @@ class DockProjectionReconciler extends Base {
                         throw new Error(`Dock projection placed item "${itemId}" into the wrong tab body`)
                     }
 
-                    stagedButton = targetBar.items[placeholderIndex];
+                    stagedButton = targetBar.getTabButtons()[placeholderIndex];
 
                     if (!stagedButton) {
                         throw new Error(`Dock projection could not stage tab chrome for item "${itemId}"`)
@@ -649,15 +648,13 @@ class DockProjectionReconciler extends Base {
                     // its already-mounted button leaves that DOM lifecycle coupled to the destroyed
                     // placeholder pane. Materialize the live pair together, then commit its toolbar
                     // explicitly through the direct-owner transaction above. Silent insertion skips
-                    // SortZone#onItemInsert and the configured SortZone can still be awaiting its
-                    // construction microtask, so stamp the delegated drag marker into the button's
-                    // creation transaction instead of depending on a later timing-sensitive repair.
+                    // SortZone#onItemInsert, so the materializedBars commit below reapplies the same
+                    // semantic membership predicate used by every ordinary insert.
                     if (stagedButton) {
                         targetBar.remove(stagedButton, true, true)
                     }
 
-                    NeoArray.add(buttonConfig.wrapperCls ||= [], 'neo-draggable');
-                    targetBar.insert(targetIndex, buttonConfig, true);
+                    targetBar.insertTab(targetIndex, buttonConfig, true);
                     materializedBars.add(targetBar);
 
                     resolvedItems.set(itemId, inserted);
@@ -673,9 +670,9 @@ class DockProjectionReconciler extends Base {
                 if (state.tab === targetTab && state.index === targetIndex) return;
 
                 state.body.removeAt(state.index, false, true, true);
-                state.bar.removeAt(state.index, false, true, true);
+                state.bar.removeTabAt(state.index, false, true, true);
                 targetBody.insert(targetIndex, pane, true, false);
-                targetBar.insert(targetIndex, state.button, true, false)
+                targetBar.insertTab(targetIndex, state.button, true, false)
             })
         });
 
@@ -705,7 +702,7 @@ class DockProjectionReconciler extends Base {
                 }
 
                 state.body.removeAt(state.index, !preservedItems.has(itemId), true);
-                state.bar.removeAt(state.index, true, true)
+                state.bar.removeTabAt(state.index, true, true)
             })
         });
 
@@ -723,7 +720,7 @@ class DockProjectionReconciler extends Base {
                 };
 
             if (body.items.length !== plan.desiredItems.length
-                || bar.items.length !== plan.desiredItems.length) {
+                || bar.getTabButtons().length !== plan.desiredItems.length) {
                 throw new Error(`Dock projection tab chrome "${nodeId}" has an inexact item set`)
             }
 
@@ -740,7 +737,7 @@ class DockProjectionReconciler extends Base {
             plan.desiredItems.forEach((itemId, index) => {
                 const
                     pane   = resolve(itemId),
-                    button = bar.items[index],
+                    button = bar.getTabButtons()[index],
                     header = tab.getTabButtonConfig(pane?.header, index);
 
                 if (body.items[index] !== pane || !button) {

--- a/src/dashboard/DockTabSortZone.mjs
+++ b/src/dashboard/DockTabSortZone.mjs
@@ -164,10 +164,9 @@ class DockTabSortZone extends TabHeaderSortZone {
 
     /**
      * The source toolbar's PRISTINE viewport rect, measured once per gesture at
-     * {@link #onDragStart} — BEFORE the base runs and trims its in-memory `ownerRect` to the
-     * draggable button span. Dock toolbars disable the base's live owner-width write, but the
-     * trimmed rect is still a sort-local surface rather than the real toolbar boundary
-     * {@link #releaseVoidsReorder} decides against.
+     * {@link #onDragStart}. The base keeps its full `ownerRect` for outer drag/tear-out authority
+     * and snapshots the draggable tab span separately in `sortBoundaryRect`; this pristine copy
+     * remains the release boundary {@link #releaseVoidsReorder} decides against.
      * @member {Object|null} dockSourceToolbarRect=null
      * @protected
      */
@@ -950,8 +949,9 @@ class DockTabSortZone extends TabHeaderSortZone {
 
         if (me.isStackHandleDrag?.(data)) {
             let pathIds     = new Set((data.path || []).map(node => node.id).filter(Boolean)),
-                draggedItem = me.owner.items.find(item => pathIds.has(item.id)),
-                index       = me.owner.items.indexOf(draggedItem);
+                tabButtons  = me.owner.getTabButtons(),
+                draggedItem = tabButtons.find(item => pathIds.has(item.id)),
+                index       = tabButtons.indexOf(draggedItem);
 
             if (!draggedItem || index < 0 || !me.dockWorkspaceId) {
                 return
@@ -975,8 +975,8 @@ class DockTabSortZone extends TabHeaderSortZone {
 
         me.stackDragActive = false;
 
-        // The real toolbar boundary — measured BEFORE the base trims its sort-local ownerRect to
-        // the draggable button span. One pre-gesture measure, off the per-frame hot path.
+        // The real toolbar boundary, distinct from the base's tab-only sortBoundaryRect.
+        // One pre-gesture measure, off the per-frame hot path.
         me.dockSourceToolbarRect = await me.owner?.getDomRect() ?? null;
 
         await super.onDragStart(data);

--- a/src/dialog/header/Toolbar.mjs
+++ b/src/dialog/header/Toolbar.mjs
@@ -57,7 +57,6 @@ class Toolbar extends Base {
      */
     createItems() {
         let me      = this,
-            handler = me.fireAction.bind(me),
             items   = me.items || [],
             {title} = me;
 
@@ -68,18 +67,6 @@ class Toolbar extends Base {
             hidden: !title,
             text  : title
         });
-
-        if (me.actions) {
-            items.push('->');
-
-            me.actions.forEach(action => {
-                if (Neo.typeOf(action) !== 'Object') {
-                    action = me.actionMap[action]()
-                }
-
-                items.push({handler, ...action})
-            })
-        }
 
         me.items = items;
 

--- a/src/draggable/container/DragZone.mjs
+++ b/src/draggable/container/DragZone.mjs
@@ -55,16 +55,34 @@ class DragZone extends BaseDragZone {
             wrapperCls;
 
         owner.items.forEach(item => {
-            // spacers
-            if (typeof item === 'string') {
+            if (typeof item === 'string' || !item) {
                 return;
             }
 
             wrapperCls = item.wrapperCls || [];
 
-            NeoArray.toggle(wrapperCls, 'neo-draggable', draggable);
+            NeoArray.toggle(wrapperCls, 'neo-draggable', draggable && me.isDraggableItem(item));
             item.wrapperCls = wrapperCls;
         });
+    }
+
+    /**
+     * Returns the owner items admitted to this drag zone.
+     * @param {Object[]} [items=this.owner.items]
+     * @returns {Neo.component.Base[]}
+     */
+    getDraggableItems(items=this.owner.items) {
+        return (items || []).filter(item => this.isDraggableItem(item))
+    }
+
+    /**
+     * The generic container contract admits every component item. Specialised drag zones override
+     * this one predicate so initial marking and dynamic insertion cannot drift.
+     * @param {*} item
+     * @returns {Boolean}
+     */
+    isDraggableItem(item) {
+        return Boolean(item) && typeof item !== 'string'
     }
 
     /**
@@ -113,11 +131,18 @@ class DragZone extends BaseDragZone {
      * @param {Neo.component.Base} data.item
      */
     onItemInsert(data) {
-        let {item}     = data,
-            wrapperCls = item.wrapperCls || [];
+        let items = Array.isArray(data.item) ? data.item : [data.item];
 
-        NeoArray.add(wrapperCls, 'neo-draggable');
-        item.wrapperCls = wrapperCls;
+        items.forEach(item => {
+            if (!item || typeof item === 'string') {
+                return
+            }
+
+            let wrapperCls = item.wrapperCls || [];
+
+            NeoArray.toggle(wrapperCls, 'neo-draggable', this.isDraggableItem(item));
+            item.wrapperCls = wrapperCls
+        })
     }
 
     /**

--- a/src/draggable/container/SortZone.mjs
+++ b/src/draggable/container/SortZone.mjs
@@ -1,5 +1,4 @@
 import DragZone  from './DragZone.mjs';
-import NeoArray  from '../../util/Array.mjs';
 import Rectangle from '../../util/Rectangle.mjs';
 import VDomUtil  from '../../util/VDom.mjs';
 
@@ -115,6 +114,12 @@ class SortZone extends DragZone {
          */
         ownerRect: null,
         /**
+         * Optional local sorting boundary, distinct from the outer drag/tear-out boundary.
+         * @member {Neo.util.Rectangle|null} sortBoundaryRect=null
+         * @protected
+         */
+        sortBoundaryRect: null,
+        /**
          * @member {Object} ownerStyle=null
          * @protected
          */
@@ -167,7 +172,13 @@ class SortZone extends DragZone {
          * @member {Number} startIndex=-1
          * @protected
          */
-        startIndex: -1
+        startIndex: -1,
+        /**
+         * True keeps the owner's full box during a drag and derives local sorting bounds from the
+         * rendered sortable-item union.
+         * @member {Boolean} useItemSortBoundary=false
+         */
+        useItemSortBoundary: false
     }
 
     /**
@@ -265,26 +276,44 @@ class SortZone extends DragZone {
     }
 
     /**
-     * Toggles the neo-draggable cls on items inside our owner.
-     * @param {Boolean} draggable
+     * Applies the optional handle-selector membership contract to every marking/insertion/snapshot
+     * path inherited from the container DragZone.
+     * @param {*} item
+     * @returns {Boolean}
      */
-    adjustItemCls(draggable) {
-        let me = this;
+    isDraggableItem(item) {
+        let admitted = super.isDraggableItem(item);
 
-        if (me.dragHandleSelector) {
-            const handleCls     = me.dragHandleSelector.startsWith('.') ? me.dragHandleSelector.substring(1) : me.dragHandleSelector;
-            const sortableItems = me.owner.items.filter(item =>
-                typeof item !== 'string' && VDomUtil.find(item.vdom, {cls: handleCls})
-            );
-
-            sortableItems.forEach(item => {
-                const wrapperCls = item.wrapperCls || [];
-                NeoArray.toggle(wrapperCls, 'neo-draggable', draggable);
-                item.wrapperCls = wrapperCls
-            });
-        } else {
-            super.adjustItemCls(draggable)
+        if (!admitted || !this.dragHandleSelector) {
+            return admitted
         }
+
+        let handleCls = this.dragHandleSelector.startsWith('.')
+            ? this.dragHandleSelector.substring(1)
+            : this.dragHandleSelector;
+
+        return Boolean(VDomUtil.find(item.vdom, {cls: handleCls}))
+    }
+
+    /**
+     * Returns the union of non-zero rendered sortable-item rectangles.
+     * @param {Neo.util.Rectangle[]} rects
+     * @returns {Neo.util.Rectangle|null}
+     * @protected
+     */
+    getSortBoundaryRect(rects) {
+        let rendered = rects.filter(rect => rect && rect.width > 0 && rect.height > 0);
+
+        if (rendered.length === 0) {
+            return null
+        }
+
+        let left   = Math.min(...rendered.map(rect => rect.left)),
+            top    = Math.min(...rendered.map(rect => rect.top)),
+            right  = Math.max(...rendered.map(rect => rect.right)),
+            bottom = Math.max(...rendered.map(rect => rect.bottom));
+
+        return new Rectangle(left, top, right - left, bottom - top)
     }
 
     /**
@@ -297,10 +326,10 @@ class SortZone extends DragZone {
 
         if (proxyRect && me.boundaryContainerRect) {
             const
-                boundaryRect      = me.boundaryContainerRect,
-                intersection      = Rectangle.getIntersection(proxyRect, boundaryRect),
-                proxyArea         = proxyRect.width * proxyRect.height,
-                intersectionArea  = intersection ? intersection.width * intersection.height : 0,
+                boundaryRect     = me.boundaryContainerRect,
+                intersection     = Rectangle.getIntersection(proxyRect, boundaryRect),
+                proxyArea        = proxyRect.width * proxyRect.height,
+                intersectionArea = intersection ? intersection.width * intersection.height : 0,
                 // During window-drag the move payload's proxy embodies the FUTURE VESSEL
                 // (popupWidth × popupHeight, src/main/addon/DragDrop.mjs), which can dwarf a
                 // strip-scale boundary; a proxy-area denominator then caps the ratio at
@@ -601,6 +630,7 @@ class SortZone extends DragZone {
                 lastInBoundY    : null,
                 ownerRect       : null,
                 scrollLeft      : 0,
+                sortBoundaryRect: null,
                 startIndex      : -1,
                 sortableItems   : null
             });
@@ -645,6 +675,7 @@ class SortZone extends DragZone {
         let {clientX, clientY} = data,
             index              = me.currentIndex,
             {itemRects}        = me,
+            localBoundary      = me.sortBoundaryRect || me.boundaryContainerRect,
             maxItems           = itemRects.length - 1,
             // itemRects leave viewport space through EITHER conversion mechanism: the
             // adjustItemRectsToParent flag (parent-managed) or a subclass-provided
@@ -661,13 +692,13 @@ class SortZone extends DragZone {
 
         if (me.sortDirection === 'horizontal') {
             delta               = clientX - ownerX + me.scrollLeft - me.offsetX - itemRects[index].left;
-            isOverDraggingEnd   = clientX > me.boundaryContainerRect.right;
-            isOverDraggingStart = clientX < me.boundaryContainerRect.left;
+            isOverDraggingEnd   = clientX > localBoundary.right;
+            isOverDraggingStart = clientX < localBoundary.left;
             itemHeightOrWidth   = 'width'
         } else {
             delta               = clientY - ownerY + me.scrollTop - me.offsetY - itemRects[index].top;
-            isOverDraggingEnd   = clientY > me.boundaryContainerRect.bottom;
-            isOverDraggingStart = clientY < me.boundaryContainerRect.top;
+            isOverDraggingEnd   = clientY > localBoundary.bottom;
+            isOverDraggingStart = clientY < localBoundary.top;
             itemHeightOrWidth   = 'height'
         }
 
@@ -809,18 +840,16 @@ class SortZone extends DragZone {
                     return
                 }
 
-                sortableItems = owner.items.filter(item => VDomUtil.find(item.vdom, {
-                    cls: dragHandleSelector.startsWith('.') ? dragHandleSelector.substring(1) : dragHandleSelector
-                }));
+                sortableItems = me.getDraggableItems(owner.items);
                 index         = sortableItems.indexOf(draggedItem);
-
-                if (index < 0) {
-                    return
-                }
             } else {
                 draggedItem   = Neo.getComponent(data.path[0].id);
-                sortableItems = owner.items;
-                index         = owner.indexOf(draggedItem.id)
+                sortableItems = me.getDraggableItems(owner.items);
+                index         = sortableItems.indexOf(draggedItem)
+            }
+
+            if (index < 0) {
+                return
             }
 
             indexMap = {};
@@ -853,31 +882,21 @@ class SortZone extends DragZone {
             const itemRects = await owner.getDomRect([owner.id].concat(sortableItems.map(e => e.id)));
 
             me.ownerRect = itemRects.shift();
+            me.sortBoundaryRect = me.useItemSortBoundary ? me.getSortBoundaryRect(itemRects) : null;
 
             // Calculate real owner dimensions based on first and last item rects (accounting for padding)
-            if (itemRects.length > 0) {
+            if (!me.useItemSortBoundary && itemRects.length > 0) {
                 const firstItemRect = itemRects[0];
                 const lastItemRect  = itemRects[itemRects.length - 1];
 
-                if (me.sortDirection === 'horizontal') {
-                    if (firstItemRect.x > me.ownerRect.x) {
-                        me.ownerRect.x = firstItemRect.x
-                    }
-                    if (firstItemRect.y > me.ownerRect.y) {
-                        me.ownerRect.y = firstItemRect.y
-                    }
-                    me.ownerRect.width  = (lastItemRect.x + lastItemRect.width)  - me.ownerRect.x;
-                    me.ownerRect.height = (lastItemRect.y + lastItemRect.height) - me.ownerRect.y
-                } else {
-                    if (firstItemRect.x > me.ownerRect.x) {
-                        me.ownerRect.x = firstItemRect.x
-                    }
-                    if (firstItemRect.y > me.ownerRect.y) {
-                        me.ownerRect.y = firstItemRect.y
-                    }
-                    me.ownerRect.width  = (lastItemRect.x + lastItemRect.width)  - me.ownerRect.x;
-                    me.ownerRect.height = (lastItemRect.y + lastItemRect.height) - me.ownerRect.y
+                if (firstItemRect.x > me.ownerRect.x) {
+                    me.ownerRect.x = firstItemRect.x
                 }
+                if (firstItemRect.y > me.ownerRect.y) {
+                    me.ownerRect.y = firstItemRect.y
+                }
+                me.ownerRect.width  = (lastItemRect.x + lastItemRect.width)  - me.ownerRect.x;
+                me.ownerRect.height = (lastItemRect.y + lastItemRect.height) - me.ownerRect.y
             }
 
             owner.style = {

--- a/src/draggable/tab/header/toolbar/SortZone.mjs
+++ b/src/draggable/tab/header/toolbar/SortZone.mjs
@@ -22,7 +22,41 @@ class SortZone extends BaseSortZone {
          */
         dragProxyConfig: {
             cls: ['neo-tab-header-toolbar', 'neo-toolbar']
-        }
+        },
+        /**
+         * Every tab header already carries this root class. Spacer/action items therefore never
+         * become draggable members or targets.
+         * @member {String} dragHandleSelector='.neo-tab-header-button'
+         */
+        dragHandleSelector: '.neo-tab-header-button',
+        /**
+         * Keep the full toolbar box while sorting and use the rendered tab union for local moves.
+         * @member {Boolean} useItemSortBoundary=true
+         */
+        useItemSortBoundary: true
+    }
+
+    /**
+     * True while drag start excludes Overflow projection and prepares the stable item snapshot.
+     * @member {Boolean} sortSnapshotPending=false
+     * @protected
+     */
+    sortSnapshotPending = false
+    /**
+     * Invalidates a drag start still waiting for Overflow when its pointer terminal arrives.
+     * @member {Number} sortGestureGeneration=0
+     * @protected
+     */
+    sortGestureGeneration = 0
+
+    /**
+     * Uses the owner toolbar's exact semantic tab predicate, including its explicit action
+     * exclusion, for initial marking, insertion, snapshots, targets, and traces.
+     * @param {*} item
+     * @returns {Boolean}
+     */
+    isDraggableItem(item) {
+        return super.isDraggableItem(item) && this.owner?.isTabButton?.(item) === true
     }
 
     /**
@@ -31,8 +65,15 @@ class SortZone extends BaseSortZone {
      * @param {Number} toIndex
      */
     moveTo(fromIndex, toIndex) {
+        let owner      = this.owner,
+            tabButtons = owner?.getTabButtons?.() || [],
+            fromButton = owner?.items?.[fromIndex],
+            toButton   = owner?.items?.[toIndex],
+            fromTab    = tabButtons.indexOf(fromButton),
+            toTab      = tabButtons.indexOf(toButton);
+
         // Optional-chained: a mid-gesture re-projection can detach or destroy the owner chain.
-        this.owner?.up?.()?.moveTo(fromIndex, toIndex)
+        fromTab > -1 && toTab > -1 && owner?.up?.()?.moveTo(fromTab, toTab)
     }
 
     /**
@@ -60,12 +101,40 @@ class SortZone extends BaseSortZone {
     async onDragStart(data) {
         let me      = this,
             {owner} = me,
-            cls     = owner.cls || [];
+            cls     = owner.cls || [],
+            overflow,
+            generation;
+
+        if (!data.path?.some(node => node.cls?.includes('neo-tab-header-button'))) {
+            return
+        }
 
         NeoArray.add(cls, 'neo-no-animation');
         owner.cls = cls;
 
-        await super.onDragStart(data)
+        overflow = owner.getPlugin?.('tab-overflow');
+        generation = ++me.sortGestureGeneration;
+        me.sortSnapshotPending = true;
+
+        try {
+            await overflow?.whenProjectionIdle?.();
+            if (generation !== me.sortGestureGeneration || me.isDestroyed || owner.isDestroyed) {
+                return
+            }
+            await super.onDragStart(data)
+        } finally {
+            me.sortSnapshotPending = false;
+            !overflow?.isDestroyed && overflow?.onSortSnapshotReady?.()
+        }
+    }
+
+    /**
+     * Invalidates a start still waiting on the projection handshake before normal terminal cleanup.
+     * @param {Object} data
+     */
+    async onDragEnd(data) {
+        this.sortGestureGeneration++;
+        await super.onDragEnd(data)
     }
 }
 

--- a/src/menu/List.mjs
+++ b/src/menu/List.mjs
@@ -109,13 +109,6 @@ class List extends BaseList {
     }
 
     /**
-     * If the menu is floating, it will anchor itself to the parentRect
-     * @member {Neo.component.Base|null} parentComponent=null
-     * @reactive
-     */
-    parentComponent = null
-
-    /**
      * Triggered after the items config got changed
      * @param {Object[]} value
      * @param {Object[]} oldValue

--- a/src/tab/Container.mjs
+++ b/src/tab/Container.mjs
@@ -1,9 +1,10 @@
-import BaseContainer from '../container/Base.mjs';
-import BodyContainer from './BodyContainer.mjs';
-import HeaderButton  from './header/Button.mjs';
-import HeaderToolbar from './header/Toolbar.mjs';
-import NeoArray      from '../util/Array.mjs';
-import Strip         from './Strip.mjs';
+import BaseContainer  from '../container/Base.mjs';
+import BodyContainer  from './BodyContainer.mjs';
+import HeaderButton   from './header/Button.mjs';
+import HeaderToolbar  from './header/Toolbar.mjs';
+import NeoArray       from '../util/Array.mjs';
+import Strip          from './Strip.mjs';
+import {isDescriptor} from '../core/ConfigSymbols.mjs';
 
 /**
  * @summary Manages a tabbed interface with a header toolbar and a content body.
@@ -79,6 +80,19 @@ class Container extends BaseContainer {
          */
         headerToolbar: null,
         /**
+         * Optional flat action configs for the tab header toolbar. Tab actions are contextual by
+         * default; an action can set contextual=false to stay persistent.
+         * @member {Object[]|String[]|null} headerActions=null
+         * @reactive
+         */
+        headerActions_: {
+            [isDescriptor]: true,
+            clone         : 'shallow',
+            cloneOnGet    : 'none',
+            isEqual       : () => false,
+            value         : null
+        },
+        /**
          * @member {Object|null} layout=null
          * @reactive
          */
@@ -133,7 +147,7 @@ class Container extends BaseContainer {
      * @returns {Neo.component.Base|Neo.component.Base[]} The newly created component(s).
      */
     add(item) {
-        return this.insert(this.getTabBar().items.length, item)
+        return this.insert(this.getCount(), item)
     }
 
     /**
@@ -194,6 +208,20 @@ class Container extends BaseContainer {
     afterSetDragResortable(value, oldValue) {
         if (oldValue !== undefined) {
             this.getTabBar().dragResortable = value
+        }
+    }
+
+    /**
+     * Replaces the live header action group after construction.
+     * @param {Object[]|String[]|null} value
+     * @param {Object[]|String[]|null} oldValue
+     * @protected
+     */
+    afterSetHeaderActions(value, oldValue) {
+        if (oldValue !== undefined) {
+            let tabBar = this.getTabBar();
+
+            tabBar && (tabBar.actions = value)
         }
     }
 
@@ -286,6 +314,7 @@ class Container extends BaseContainer {
 
         me.items = [{
             module        : HeaderToolbar,
+            actions       : me.headerActions,
             dock          : me.tabBarPosition,
             dragResortable: me.dragResortable,
             flex          : 'none',
@@ -346,7 +375,24 @@ class Container extends BaseContainer {
      * @returns {Number} The number of tabs.
      */
     getCount() {
-        return this.getTabBar().items.length
+        return this.getTabButtons().length
+    }
+
+    /**
+     * Returns the stable header action instances.
+     * @returns {Neo.component.Base[]}
+     */
+    getActionItems() {
+        return this.getTabBar()?.getActionItems() || []
+    }
+
+    /**
+     * Returns a stable header action instance by semantic action name.
+     * @param {String} action
+     * @returns {Neo.component.Base|null}
+     */
+    getActionItem(action) {
+        return this.getTabBar()?.getActionItem(action) || null
     }
 
     /**
@@ -389,7 +435,7 @@ class Container extends BaseContainer {
      * @returns {Neo.tab.header.Button|null} The tab button component or null if not found.
      */
     getTabAtIndex(index) {
-        return this.getTabBar().items[index] || null
+        return this.getTabButtons()[index] || null
     }
 
     /**
@@ -398,6 +444,14 @@ class Container extends BaseContainer {
      */
     getTabBar() {
         return Neo.getComponent(this.tabBarId)
+    }
+
+    /**
+     * Returns the semantic tab-header button collection.
+     * @returns {Neo.tab.header.Button[]}
+     */
+    getTabButtons() {
+        return this.getTabBar()?.getTabButtons() || []
     }
 
     /**
@@ -413,10 +467,11 @@ class Container extends BaseContainer {
         let me = this,
 
         defaultConfig = {
-            module : HeaderButton,
-            flex   : 'none',
+            module               : HeaderButton,
+            flex                 : 'none',
             index,
-            pressed: me.activeIndex === index,
+            pressed              : me.activeIndex === index,
+            useActiveTabIndicator: me.useActiveTabIndicator,
 
             domListeners: [{
                 click(data) {
@@ -481,14 +536,14 @@ class Container extends BaseContainer {
             }
 
             if (!hasItem) {
-                tab = tabBar.insert(index, me.getTabButtonConfig(item.header, index));
+                tab = tabBar.insertTab(index, me.getTabButtonConfig(item.header, index));
 
                 // todo: non index based matching of tab buttons and cards
                 i = 0;
-                len = tabBar.items.length;
+                len = me.getTabButtons().length;
 
                 for (; i < len; i++) {
-                    tabBar.items[i].index = i
+                    me.getTabButtons()[i].index = i
                 }
 
                 item.flex = 1;
@@ -520,7 +575,7 @@ class Container extends BaseContainer {
         let me            = this,
             cardContainer = me.getCardContainer(),
             tabBar        = me.getTabBar(),
-            activeTab     = tabBar.items[me.activeIndex],
+            activeTab     = me.getTabButtons()[me.activeIndex],
             index, returnValue;
 
         tabBar.moveTo(fromIndex, toIndex);
@@ -549,7 +604,50 @@ class Container extends BaseContainer {
      */
     onConstructed() {
         this.layout = {ntype: 'flexbox', ...this.getLayoutConfig()};
-        super.onConstructed()
+        super.onConstructed();
+
+        this.getTabBar().on('action', this.onHeaderAction, this)
+    }
+
+    /**
+     * Arms contextual actions only when focus enters the tab body. Header/action focus retains the
+     * current state through manager.Focus's closest-common-component path.
+     * @param {Object} data
+     */
+    onFocusEnter(data) {
+        super.onFocusEnter(data);
+
+        this.isBodyFocusPath(data.path) && (this.getTabBar().contextualActionsVisible = true)
+    }
+
+    /**
+     * Arms contextual actions when an internal focus move enters the body.
+     * @param {Object} data
+     */
+    onFocusMove(data) {
+        this.isBodyFocusPath(data.path) && (this.getTabBar().contextualActionsVisible = true)
+    }
+
+    /**
+     * Disarms contextual actions only after focus leaves the complete TabContainer realm.
+     * @param {Object} data
+     */
+    onFocusLeave(data) {
+        super.onFocusLeave(data);
+        this.getTabBar().contextualActionsVisible = false
+    }
+
+    /**
+     * Re-emits generic toolbar intent with TabContainer and active-card context.
+     * @param {Object} data
+     * @protected
+     */
+    onHeaderAction(data) {
+        this.fire('headerAction', {
+            activeCard  : this.getActiveCard(),
+            tabContainer: this,
+            ...data
+        })
     }
 
     /**
@@ -564,12 +662,13 @@ class Container extends BaseContainer {
             cardContainer = me.getCardContainer(),
             tabBar        = me.getTabBar(),
             i             = 0,
-            len           = tabBar.items.length,
+            tabButtons    = me.getTabButtons(),
+            len           = tabButtons.length,
             index         = -1,
             card;
 
         for (; i < len; i++) {
-            if (tabBar.items[i].id === buttonId) {
+            if (tabButtons[i].id === buttonId) {
                 index = i;
                 break
             }
@@ -622,7 +721,7 @@ class Container extends BaseContainer {
             card, i, len;
 
         card = cardContainer.removeAt(index, destroyItem, silent, keepMounted);
-        tabBar       .removeAt(index, true,        silent);
+        tabBar       .removeTabAt(index, true,     silent);
 
         if (index < activeIndex) {
             // silent updates
@@ -646,10 +745,10 @@ class Container extends BaseContainer {
 
         // todo: non index based matching of tab buttons and cards
         i   = 0;
-        len = tabBar.items.length;
+        len = me.getTabButtons().length;
 
         for (; i < len; i++) {
-            tabBar.items[i].index = i
+            me.getTabButtons()[i].index = i
         }
 
         return card
@@ -664,7 +763,7 @@ class Container extends BaseContainer {
     updateTabButtons(silent=false) {
         let me            = this,
             {activeIndex} = me,
-            tabButtons    = me.getTabBar()?.items || [];
+            tabButtons    = me.getTabButtons();
 
         tabButtons.forEach((item, index) => {
             if (silent) {
@@ -673,6 +772,28 @@ class Container extends BaseContainer {
                 item.pressed = index === activeIndex
             }
         })
+    }
+
+    /**
+     * True when a focused DOM path resolves through the tab body component.
+     * @param {Object[]} [path=[]]
+     * @returns {Boolean}
+     * @protected
+     */
+    isBodyFocusPath(path=[]) {
+        let component = path
+            .map(node => Neo.getComponent(node.id))
+            .find(Boolean);
+
+        while (component && component !== this) {
+            if (component.id === this.bodyContainerId) {
+                return true
+            }
+
+            component = component.parent
+        }
+
+        return false
     }
 }
 

--- a/src/tab/header/EffectButton.mjs
+++ b/src/tab/header/EffectButton.mjs
@@ -67,6 +67,29 @@ class EffectTabButton extends EffectButton {
     }
 
     /**
+     * Keeps the generated indicator child in sync when the toolbar changes this config at runtime.
+     * @param {Boolean} value
+     * @param {Boolean} oldValue
+     * @protected
+     */
+    afterSetUseActiveTabIndicator(value, oldValue) {
+        this.updateUseActiveTabIndicator()
+    }
+
+    /**
+     * Updates the generated indicator child.
+     * @param {Boolean} [silent=false]
+     */
+    updateUseActiveTabIndicator(silent=false) {
+        let indicator = this.vdom?.cn?.find(item => item.cls?.includes('neo-tab-button-indicator'));
+
+        if (indicator) {
+            indicator.removeDom = !this.useActiveTabIndicator;
+            !silent && this.update()
+        }
+    }
+
+    /**
      * @param {Object} data
      */
     showRipple(data) {

--- a/src/tab/header/Toolbar.mjs
+++ b/src/tab/header/Toolbar.mjs
@@ -7,6 +7,13 @@ import BaseToolbar from '../../toolbar/Base.mjs';
 class Toolbar extends BaseToolbar {
     static config = {
         /**
+         * Tab-header actions are contextual by default. Persistent actions opt out explicitly.
+         * @member {Object} actionDefaults={contextual:true}
+         */
+        actionDefaults: {
+            contextual: true
+        },
+        /**
          * @member {String} className='Neo.tab.header.Toolbar'
          * @protected
          */
@@ -44,7 +51,7 @@ class Toolbar extends BaseToolbar {
         if (oldValue !== undefined) {
             let me = this;
 
-            me.items.forEach(item => {
+            me.getTabButtons().forEach(item => {
                 // silent updates
                 item._useActiveTabIndicator = value;
                 item.updateUseActiveTabIndicator(true)
@@ -55,16 +62,58 @@ class Toolbar extends BaseToolbar {
     }
 
     /**
-     * @protected
+     * Resolves a semantic tab insertion index to the raw toolbar position immediately before the
+     * action group.
+     * @param {Number} index
+     * @returns {Number}
      */
-    createItems() {
-        let me       = this,
-            defaults = me.itemDefaults || {};
+    getTabInsertIndex(index) {
+        let me      = this,
+            buttons = me.getTabButtons(),
+            target  = buttons[index],
+            spacer;
 
-        defaults.useActiveTabIndicator = me.useActiveTabIndicator;
-        me.itemDefaults = defaults;
+        if (target) {
+            return me.items.indexOf(target)
+        }
 
-        super.createItems()
+        spacer = me.getActionSpacer();
+
+        return spacer ? me.items.indexOf(spacer) : me.items.length
+    }
+
+    /**
+     * Returns only semantic tab-header buttons, excluding the action group and spacer.
+     * @returns {Neo.tab.header.Button[]}
+     */
+    getTabButtons() {
+        return (this.items || []).filter(item => this.isTabButton(item))
+    }
+
+    /**
+     * The single semantic membership answer shared with the tab SortZone. A tab-styled action is
+     * still an action and must never become card chrome or a drag target.
+     * @param {*} item
+     * @returns {Boolean}
+     */
+    isTabButton(item) {
+        return item?.isToolbarAction !== true
+            && item?.isToolbarActionSpacer !== true
+            && item?.baseCls?.includes('neo-tab-header-button')
+    }
+
+    /**
+     * Inserts a tab button at a semantic tab index.
+     * @param {Number} index
+     * @param {Object|Neo.tab.header.Button} item
+     * @param {Boolean} [silent=false]
+     * @param {Boolean} [removeFromPreviousParent=true]
+     * @returns {Neo.tab.header.Button}
+     */
+    insertTab(index, item, silent=false, removeFromPreviousParent=true) {
+        let bounded = Math.max(0, Math.min(Number(index) || 0, this.getTabButtons().length));
+
+        return this.insert(this.getTabInsertIndex(bounded), item, silent, removeFromPreviousParent)
     }
 
     /**
@@ -110,15 +159,39 @@ class Toolbar extends BaseToolbar {
      * @returns {Neo.component.Base}
      */
     moveTo(fromIndex, toIndex) {
-        let returnValue = super.moveTo(fromIndex, toIndex);
+        let me         = this,
+            buttons    = me.getTabButtons(),
+            fromButton = buttons[fromIndex],
+            toButton   = buttons[toIndex],
+            returnValue;
+
+        if (!fromButton || !toButton) {
+            return null
+        }
+
+        returnValue = super.moveTo(me.items.indexOf(fromButton), me.items.indexOf(toButton));
 
         if (fromIndex !== toIndex) {
-            this.items.forEach((item, index) => {
+            me.getTabButtons().forEach((item, index) => {
                 item.index = index
             })
         }
 
         return returnValue
+    }
+
+    /**
+     * Removes a tab button at a semantic tab index.
+     * @param {Number} index
+     * @param {Boolean} [destroyItem=true]
+     * @param {Boolean} [silent=false]
+     * @param {Boolean} [keepMounted=false]
+     * @returns {Neo.tab.header.Button|null}
+     */
+    removeTabAt(index, destroyItem=true, silent=false, keepMounted=false) {
+        let button = this.getTabButtons()[index];
+
+        return button ? this.remove(button, destroyItem, silent, keepMounted) : null
     }
 }
 

--- a/src/tab/plugin/Overflow.mjs
+++ b/src/tab/plugin/Overflow.mjs
@@ -2,8 +2,8 @@ import Button from '../../button/Base.mjs';
 import Plugin from '../../plugin/Base.mjs';
 
 /**
- * @summary The tab-overflow affordance for a projected tab header toolbar: when the headers exceed the
- * available width, the overflowing tabs collapse behind a floating overflow control whose menu reaches them.
+ * @summary The tab-overflow affordance for a projected tab header toolbar: when headers exceed the
+ * available main-axis extent, overflowing tabs collapse behind a floating control whose menu reaches them.
  *
  * The pure decision is this plugin's own static {@link Neo.tab.plugin.Overflow.computeOverflow} — a
  * projection concern, nothing persists. This plugin is the RUNTIME complement: it measures the live header extents
@@ -15,13 +15,11 @@ import Plugin from '../../plugin/Base.mjs';
  * It attaches to the projected tab header toolbar (`Neo.tab.header.Toolbar`) — it is NOT a dock-specific
  * `tab.Container` fork (the model contract's Split/Tab Adapter Boundary). The overflow control is an
  * OUT-OF-COLLECTION floating button rooted at `document.body`, deliberately NOT a member of `owner.items`:
- * the dock enables `dragResortable` (`DockLayoutAdapter`), so the header toolbar wires a SortZone that marks
- * every `owner.items` entry draggable and commits reorders via the `moveTo` the container fires on drop. A
- * trailing control inside `owner.items` would therefore be drag-reorderable and would corrupt the committed
- * dock tab order. Keeping the control floating (out of the collection) preserves the collection invariant —
- * `owner.items` stays exactly the real tabs, so the SortZone never sees it. The control also carries none of
- * a tab button's `activeIndex` click wiring (that lives in `getTabButtonConfig`, which the plugin bypasses),
- * so selecting it opens its menu rather than activating a phantom card.
+ * the control has independent mount/alignment/menu lifecycle and therefore remains outside `owner.items`.
+ * Ordinary flat toolbar actions can live in that collection because the tab toolbar and SortZone now expose
+ * one explicit tab-button subset; the overflow control is still intentionally not an action or tab. It carries
+ * none of a tab button's `activeIndex` click wiring (that lives in `getTabButtonConfig`, which the plugin
+ * bypasses), so selecting it opens its menu rather than activating a phantom card.
  *
  * Natural-width discipline: overflowing buttons are removed from the DOM (Neo's built-in `hidden` /
  * removeDom), so re-measuring them would collapse their width to 0 and corrupt the next split. The plugin
@@ -45,9 +43,9 @@ class Overflow extends Plugin {
          */
         ntype: 'plugin-tab-overflow',
         /**
-         * Width (px) the overflow control reserves from the header extent — handed to the pure core as
+         * Main-axis size (px) the overflow control reserves from the header extent — handed to the pure core as
          * `controlWidth`, which reserves it ONLY when something overflows (a control that exists only when
-         * needed must not consume width while everything fits).
+         * needed must not consume space while everything fits). The historic config name stays compatible.
          * @member {Number} controlWidth=40
          */
         controlWidth: 40
@@ -127,9 +125,8 @@ class Overflow extends Plugin {
     }
 
     /**
-     * Plugin-owned active-button caps: button id → the caller's own `maxWidth` config value at
-     * cap time (`null` when the consumer had none). Property presence on the button is NOT
-     * provenance — a consumer may legitimately configure `maxWidth` — so this ledger is the one
+     * Plugin-owned active-button caps: button id → `{maxSize, value}` for the caller's own main-axis
+     * max-size config at cap time. Property presence on the button is NOT provenance, so this ledger is the one
      * source of truth for "the plugin installed this cap", and clearing always restores the exact
      * recorded caller value through the same public config channel.
      * @member {Map|null} appliedCaps=null
@@ -147,7 +144,7 @@ class Overflow extends Plugin {
      */
     measuring = false
     /**
-     * The control's RENDERED width, measured while it is mounted (same round-trip as the extent read).
+     * The control's rendered main-axis extent, measured while it is mounted.
      * The `controlWidth` config is only the pre-creation estimate — the first overflow decision runs
      * before any control exists to measure. Once render truth is available, the reservation uses
      * `max(config, measured)`, so a skin that renders the control wider than the estimate can never
@@ -156,7 +153,7 @@ class Overflow extends Plugin {
      */
     measuredControlWidth = null
     /**
-     * Natural (un-hidden) header widths keyed by tab-button id — see the class note on natural-width
+     * Natural (un-hidden) header main-axis extents keyed by tab-button id — see the class note on natural-width
      * discipline. `null` until the first capture.
      * @member {Object|null} naturalWidths=null
      */
@@ -189,6 +186,31 @@ class Overflow extends Plugin {
      * @member {Boolean} remountArming=false
      */
     remountArming = false
+    /**
+     * A projection requested while the tab SortZone owned a gesture.
+     * @member {Boolean} sortDragProjectionQueued=false
+     */
+    sortDragProjectionQueued = false
+    /**
+     * Sticky recapture intent for the post-drag projection.
+     * @member {Boolean} sortDragRecaptureQueued=false
+     */
+    sortDragRecaptureQueued = false
+    /**
+     * SortZone whose drag terminal releases queued projections.
+     * @member {Neo.draggable.container.SortZone|null} sortDragZone=null
+     */
+    sortDragZone = null
+    /**
+     * A post-terminal drain task is already scheduled.
+     * @member {Boolean} sortDragDrainScheduled=false
+     */
+    sortDragDrainScheduled = false
+    /**
+     * Drag-start callers waiting for the complete projection transaction to settle.
+     * @member {Function[]|null} projectionIdleWaiters=null
+     */
+    projectionIdleWaiters = null
 
     /**
      * @param {Object} config
@@ -212,7 +234,12 @@ class Overflow extends Plugin {
                 me.observeConfig(component, 'theme', () => {
                     queueMicrotask(() => !me.isDestroyed && me.onOwnerThemeChange())
                 })
-            })
+            });
+            if (me.owner.getConfig?.('dock')) {
+                me.observeConfig(me.owner, 'dock', () => {
+                    queueMicrotask(() => !me.isDestroyed && me.project(true))
+                })
+            }
         }
     }
 
@@ -226,12 +253,48 @@ class Overflow extends Plugin {
     }
 
     /**
-     * The header buttons that participate in overflow: the toolbar's items (the control is never among
-     * them — see the class note).
+     * The semantic header buttons that participate in overflow. Actions, their spacer, and the floating
+     * control remain outside this view.
      * @returns {Neo.tab.header.Button[]}
      */
     getTabButtons() {
-        return (this.owner.items || []).filter(item => item !== this.control)
+        return this.owner.getTabButtons?.() || []
+    }
+
+    /**
+     * Visible or geometry-reserved actions which reduce the tab strip's main-axis extent.
+     * @returns {Neo.component.Base[]}
+     */
+    getActionItems() {
+        return (this.owner.getActionItems?.() || [])
+            .filter(item => !item.hidden || item.hideMode === 'visibility')
+    }
+
+    /**
+     * Returns the orientation-dependent geometry contract used by measurement, capping, and
+     * floating-control alignment.
+     * @returns {{actionAlign: String, dimension: String, maxSize: String, ownerAlign: String}}
+     */
+    getMainAxisConfig() {
+        return this.owner.dock === 'left' || this.owner.dock === 'right'
+            ? {actionAlign: 'b0-t0', dimension: 'height', maxSize: 'maxHeight', ownerAlign: 'b0-b0'}
+            : {actionAlign: 'r0-l0', dimension: 'width',  maxSize: 'maxWidth',  ownerAlign: 'r0-r0'}
+    }
+
+    /**
+     * Aligns the floating overflow control immediately before the action group, or to the owner's
+     * trailing edge when no action currently consumes space.
+     * @returns {Object}
+     */
+    getControlAlign() {
+        let me          = this,
+            firstAction = me.getActionItems()[0],
+            geometry    = me.getMainAxisConfig();
+
+        return {
+            edgeAlign: firstAction ? geometry.actionAlign : geometry.ownerAlign,
+            target   : firstAction?.id || me.owner.id
+        }
     }
 
     /**
@@ -262,8 +325,138 @@ class Overflow extends Plugin {
         // so recapture to keep the split live.
         owner.on('insert', me.onTabSetChange, me);
         owner.on('remove', me.onTabSetChange, me);
+        owner.on('actionsChange', me.onActionSetChange, me);
+        owner.on('actionGeometryChange', me.onActionSetChange, me);
+        owner.on('actionVisibilityChange', me.onActionSetChange, me);
         me.getTabContainer()?.on('moveTo', me.onTabSetChange, me);
         me.project(true)
+    }
+
+    /**
+     * Action membership/availability changes alter the tab-exclusive extent, not tab natural widths.
+     */
+    onActionSetChange() {
+        this.project(false)
+    }
+
+    /**
+     * Reprojects when the floating control's rendered main-axis size changes.
+     * @protected
+     */
+    onControlResize() {
+        this.project(false)
+    }
+
+    /**
+     * Drains one sticky projection after the SortZone has restored its snapshotted tab geometry.
+     * @protected
+     */
+    onSortDragEnd() {
+        this.scheduleSortDragProjection()
+    }
+
+    /**
+     * Releases work queued only by the snapshot-pending handshake when no drag started.
+     * @protected
+     */
+    onSortSnapshotReady() {
+        let sortZone = this.owner?.sortZone;
+
+        if (!(sortZone?.sortSnapshotPending || sortZone?.startIndex > -1 || sortZone?.dragEndActive)) {
+            this.scheduleSortDragProjection()
+        }
+    }
+
+    /**
+     * Defers a projection while the tab SortZone owns a stable gesture snapshot.
+     * @param {Boolean} recapture
+     * @param {Boolean} [includeSnapshotPending=true] New work waits behind snapshot preparation;
+     *        an already-running transaction may finish its restoring split before releasing that waiter.
+     * @returns {Boolean} True when the caller must stop its current projection.
+     * @protected
+     */
+    queueSortDragProjection(recapture, includeSnapshotPending=true) {
+        let me       = this,
+            sortZone = me.owner.sortZone;
+
+        if (!((includeSnapshotPending && sortZone?.sortSnapshotPending)
+            || sortZone?.startIndex > -1
+            || sortZone?.dragEndActive)) {
+            return false
+        }
+
+        if (me.sortDragZone !== sortZone) {
+            me.sortDragZone?.un('dragEnd', me.onSortDragEnd, me);
+            me.sortDragZone = sortZone;
+            me.sortDragZone.on('dragEnd', me.onSortDragEnd, me)
+        }
+
+        me.sortDragProjectionQueued = true;
+        me.sortDragRecaptureQueued  = me.sortDragRecaptureQueued || recapture;
+
+        return true
+    }
+
+    /**
+     * Schedules the latest sticky projection after every SortZone terminal latch has released.
+     * Dock terminals can outlive the first task, so retry at a bounded cadence while the exact latch
+     * remains owned. Destroy rejects registered timeouts; the catch keeps teardown silent.
+     * @protected
+     */
+    scheduleSortDragProjection() {
+        let me = this;
+
+        if (!me.sortDragProjectionQueued || me.sortDragDrainScheduled) {
+            return
+        }
+
+        me.sortDragDrainScheduled = true;
+
+        me.timeout(10)
+            .catch(() => null)
+            .then(() => {
+                me.sortDragDrainScheduled = false;
+
+                if (me.isDestroyed) {
+                    return
+                }
+
+                let sortZone = me.owner.sortZone;
+
+                if (sortZone?.sortSnapshotPending || sortZone?.startIndex > -1 || sortZone?.dragEndActive) {
+                    me.scheduleSortDragProjection();
+                    return
+                }
+
+                let recapture = me.sortDragRecaptureQueued;
+
+                me.sortDragProjectionQueued = false;
+                me.sortDragRecaptureQueued  = false;
+                me.project(recapture)
+            })
+    }
+
+    /**
+     * Resolves drag-start callers after the projection and any coalesced rerun are idle.
+     * @protected
+     */
+    resolveProjectionIdle() {
+        let waiters = this.projectionIdleWaiters || [];
+
+        this.projectionIdleWaiters = null;
+        waiters.forEach(resolve => resolve())
+    }
+
+    /**
+     * Waits until an in-flight projection and its coalesced rerun have both settled.
+     * @returns {Promise<void>}
+     */
+    whenProjectionIdle() {
+        if (!this.measuring && !this.projectQueued) {
+            return Promise.resolve()
+        }
+
+        return new Promise(resolve => (this.projectionIdleWaiters ??= []).push(resolve))
     }
 
     /**
@@ -312,11 +505,21 @@ class Overflow extends Plugin {
      * @param {Boolean} recapture  Re-read natural widths (mount, or the tab set changed).
      */
     async project(recapture) {
-        let me      = this,
-            {owner} = me,
-            buttons = me.getTabButtons();
+        let me       = this,
+            {owner}  = me,
+            buttons  = me.getTabButtons(),
+            geometry = me.getMainAxisConfig();
+
+        // The tab SortZone deliberately freezes item rectangles for the gesture. A resize/action
+        // projection can otherwise hide or show members underneath that snapshot. Queue one sticky
+        // pass and drain only after dragEnd restores natural layout.
+        if (me.queueSortDragProjection(recapture)) {
+            !me.measuring && me.resolveProjectionIdle();
+            return
+        }
 
         if (!owner.mounted || buttons.length < 1) {
+            me.resolveProjectionIdle();
             return
         }
 
@@ -332,6 +535,16 @@ class Overflow extends Plugin {
         me.measuring = true;
 
         try {
+            let controlIconCls = geometry.dimension === 'height'
+                ? 'fa fa-ellipsis-vertical'
+                : 'fa fa-ellipsis';
+
+            if (me.control && me.control.iconCls !== controlIconCls) {
+                me.control.iconCls       = controlIconCls;
+                me.measuredControlWidth = null;
+                me.control.mounted && await me.control.promiseUpdate?.()
+            }
+
             // 1. Natural widths — measured once while every button is visible, then cached.
             if (recapture || !me.naturalWidths) {
                 const removedButtons = buttons.filter(button => button.hidden),
@@ -346,7 +559,9 @@ class Overflow extends Plugin {
                 // restore branch. Only ledger members are touched — a consumer-configured maxWidth is not
                 // plugin residue and measures as part of the button's real constraint set.
                 cappedButtons.forEach(button => {
-                    button.maxWidth = me.appliedCaps.get(button.id)
+                    let cap = me.appliedCaps.get(button.id);
+
+                    button[cap.maxSize] = cap.value
                 });
 
                 // A prior split removes overflowing buttons from DOM. Restore them under this method's
@@ -375,23 +590,34 @@ class Overflow extends Plugin {
                     // Keep the last positive measurement for those stable button identities; newly inserted
                     // buttons are visible on their first mutation pass and therefore still enter the cache.
                     me.naturalWidths[button.id] = Math.ceil(
-                        rects[index]?.width || previousWidths[button.id] || 0
+                        rects[index]?.[geometry.dimension] || previousWidths[button.id] || 0
                     )
                 })
             }
 
-            // 2. The strip extent — the toolbar itself never hides, so it is always measurable. When the
-            //    control is mounted, its rendered width rides the same round-trip: render truth for the
-            //    reservation costs no extra latency.
-            let controlId    = me.control?.mounted ? me.control.id : null,
-                rects        = await owner.getDomRect(controlId ? [owner.id, controlId] : [owner.id]),
-                extent       = Math.floor(rects[0]?.width || 0),
-                tabContainer = me.getTabContainer(),
-                activeButton = buttons[tabContainer?.activeIndex] || null,
-                items        = buttons.map(button => ({id: button.id, headerWidth: me.naturalWidths[button.id]}));
+            // 2. The strip extent — actions consume the same main axis but stay outside tab packing.
+            // Contextually inactive actions remain rendered, so their extent stays reserved without
+            // a focus-time repartition.
+            let actionItems   = me.getActionItems(),
+                controlId     = me.control?.mounted ? me.control.id : null,
+                ids           = [owner.id, ...actionItems.map(item => item.id), ...(controlId ? [controlId] : [])],
+                rects         = await owner.getDomRect(ids),
+                ownerRect     = rects.shift(),
+                actionRects   = rects.splice(0, actionItems.length),
+                controlRect   = controlId ? rects.shift() : null,
+                startKey      = geometry.dimension === 'width' ? 'left' : 'top',
+                coordinateKey = geometry.dimension === 'width' ? 'x' : 'y',
+                ownerStart    = Number(ownerRect?.[startKey] ?? ownerRect?.[coordinateKey]),
+                actionStart   = Number(actionRects[0]?.[startKey] ?? actionRects[0]?.[coordinateKey]),
+                extent        = Number.isFinite(ownerStart) && Number.isFinite(actionStart)
+                    ? Math.max(0, Math.floor(actionStart - ownerStart))
+                    : Math.max(0, Math.floor(ownerRect?.[geometry.dimension] || 0)),
+                tabContainer  = me.getTabContainer(),
+                activeButton  = buttons[tabContainer?.activeIndex] || null,
+                items         = buttons.map(button => ({id: button.id, headerWidth: me.naturalWidths[button.id]}));
 
-            if (controlId && rects[1]?.width > 0) {
-                me.measuredControlWidth = Math.ceil(rects[1].width)
+            if (controlRect?.[geometry.dimension] > 0) {
+                me.measuredControlWidth = Math.ceil(controlRect[geometry.dimension])
             }
 
             // 3. The pure decision: active-never-hidden packing, overflow-only control reservation.
@@ -404,13 +630,21 @@ class Overflow extends Plugin {
                     items
                 });
 
-            me.applySplit(hidden, buttons, tabContainer, {
-                activeButton,
-                // The degenerate branch keeps an over-wide active visible past `usable` — cap its box so
-                // every geometry derived from the button (the persistent per-button indicator, the strip's
-                // crossfade indicator, the label itself) ends where the control begins.
-                usable: hidden.length > 0 ? Math.max(0, extent - controlWidth) : null
-            })
+            // A drag can begin while either DOM round-trip above is in flight. Recheck at the
+            // mutation boundary so a pre-gesture measurement cannot hide/show members beneath the
+            // SortZone snapshot captured in the meantime.
+            if (!me.queueSortDragProjection(recapture, false)) {
+                me.applySplit(hidden, buttons, tabContainer, {
+                    activeButton,
+                    maxSize: geometry.maxSize,
+                    // The degenerate branch keeps an over-wide active visible past `usable` — cap its box so
+                    // every geometry derived from the button (the persistent per-button indicator, the strip's
+                    // crossfade indicator, the label itself) ends where the control begins.
+                    usable: hidden.length > 0
+                        ? Math.max(0, extent - controlWidth)
+                        : activeButton && me.naturalWidths[activeButton.id] > extent ? extent : null
+                })
+            }
         } catch (error) {
             // getDomRect losing a race with teardown (owner unmounting mid-measure) is the ONE expected
             // failure: it must neither reject a fire-and-forget handler nor skip the drain below, and the
@@ -434,6 +668,8 @@ class Overflow extends Plugin {
             me.projectQueued   = false;
             me.queuedRecapture = false;
             me.project(queuedRecapture)
+        } else {
+            me.resolveProjectionIdle()
         }
     }
 
@@ -442,17 +678,17 @@ class Overflow extends Plugin {
      * over-wide active button to the usable extent, and reflects the remainder through the overflow
      * control.
      *
-     * The cap is horizontal-only by design: this plugin packs widths against a horizontal strip extent
-     * (`tabBarPosition: 'top'` / `'bottom'` compositions); a vertical tab bar never mounts it, so the
-     * vertical indicator branch has no overflow control to collide with.
+     * Packing and active-button capping follow the toolbar's main axis: width for top/bottom and
+     * height for left/right.
      * @param {String[]} hidden  Overflowing button ids, in header order.
      * @param {Neo.tab.header.Button[]} buttons
      * @param {Neo.tab.Container} tabContainer
      * @param {Object}  activeCap
      * @param {Neo.tab.header.Button|null} activeCap.activeButton
+     * @param {String} [activeCap.maxSize='maxWidth'] Main-axis max-size config.
      * @param {Number|null} activeCap.usable  Cap for the active button while overflowing; `null` clears.
      */
-    applySplit(hidden, buttons, tabContainer, {activeButton, usable} = {}) {
+    applySplit(hidden, buttons, tabContainer, {activeButton, maxSize='maxWidth', usable} = {}) {
         let me         = this,
             hiddenSet  = new Set(hidden),
             hiddenMeta = [];
@@ -461,6 +697,17 @@ class Overflow extends Plugin {
             let isHidden = hiddenSet.has(button.id),
                 needsCap = button === activeButton && usable !== null && usable !== undefined
                     && me.naturalWidths?.[button.id] > usable;
+
+            // Dock orientation can change while an active tab is capped. Retire ownership on the
+            // old axis before deciding the new one, or a maxWidth ledger entry would authorize a
+            // maxHeight write that destroy/clear can never restore.
+            if (me.appliedCaps?.has(button.id) && me.appliedCaps.get(button.id).maxSize !== maxSize) {
+                let priorCap = me.appliedCaps.get(button.id);
+
+                button[priorCap.maxSize] = priorCap.value;
+                button.removeCls('neo-tab-overflow-capped');
+                me.appliedCaps.delete(button.id)
+            }
 
             // Neo's built-in `hidden` (removeDom) rather than a cls needing an external stylesheet rule —
             // the natural-width cache (captured while every button was visible) survives the DOM removal,
@@ -484,14 +731,19 @@ class Overflow extends Plugin {
             // clearing restores the exact caller value recorded at cap time.
             if (needsCap) {
                 if (!me.appliedCaps?.has(button.id)) {
-                    (me.appliedCaps ??= new Map()).set(button.id, button.maxWidth ?? null);
+                    (me.appliedCaps ??= new Map()).set(button.id, {
+                        maxSize,
+                        value: button[maxSize] ?? null
+                    });
                     button.addCls('neo-tab-overflow-capped')
                 }
 
-                button.maxWidth = usable
+                button[maxSize] = usable
             } else if (me.appliedCaps?.has(button.id)) {
+                let cap = me.appliedCaps.get(button.id);
+
                 button.removeCls('neo-tab-overflow-capped');
-                button.maxWidth = me.appliedCaps.get(button.id);
+                button[cap.maxSize] = cap.value;
                 me.appliedCaps.delete(button.id)
             }
 
@@ -583,35 +835,38 @@ class Overflow extends Plugin {
             }
         } else {
             // OUT-OF-COLLECTION mount: a floating button rooted directly at document.body, NOT a trailing
-            // toolbar item. The dock sets `dragResortable: true` (DockLayoutAdapter), so the header toolbar
-            // wires a SortZone that marks EVERY `owner.items` entry draggable — a trailing control there
-            // would be drag-reorderable and would corrupt the committed dock tab order via the `moveTo` the
-            // container fires on drop. Keeping the control OUT of `owner.items` preserves the collection
-            // invariant (`owner.items` === exactly the real tabs) so the SortZone never sees it.
+            // toolbar item. Ordinary toolbar actions are members of `owner.items` but excluded through the
+            // tab toolbar's semantic subset; the independently mounted overflow embodiment stays outside
+            // both collections.
             //
             // `Neo.create` with `floating:true` + `parentId:'document.body'` roots at document.body directly
             // (verified: `Container.createItem` is the only path that injects `parentId=owner.id`, and we
-            // bypass it). The parentless `initVnode(true)` autoMount reaches the DOM via the merged
+            // bypass it). `parentComponent` restores logical TabContainer focus ancestry while the physical
+            // root stays on document.body. The `initVnode(true)` autoMount reaches the DOM via the merged
             // hidden-document render-queue drain — before it, the insertNode reply parked behind a
             // suspended requestAnimationFrame in an offscreen / hidden document.
             me.control = Neo.create({
-                module       : Button,
-                // Align to the owner toolbar's right edge — the reserved overflow slot (the pure core keeps
-                // `controlWidth` free there when anything overflows). Without an `align.target` a floating
-                // component stays at its off-screen default (`left/top: -10000px`): it renders but is not
-                // visible/clickable. `r0-r0` puts the control's right edge at the toolbar's right edge.
-                align        : {edgeAlign: 'r0-r0', target: me.owner.id},
+                module         : Button,
+                // Align to the main-axis slot immediately before actions (or the owner edge without actions).
+                // Without an align target a floating component stays at its off-screen default.
+                align        : me.getControlAlign(),
                 appName      : me.owner.appName,
                 autoInitVnode: true,
                 autoMount    : true,
                 cls          : ['neo-tab-overflow-control'],
                 floating     : true,
-                iconCls      : 'fa fa-ellipsis',
-                menu         : menuConfig,
-                parentId     : 'document.body',
-                theme        : me.owner.getTheme(),
-                windowId     : me.owner.windowId
+                iconCls      : me.getMainAxisConfig().dimension === 'height'
+                    ? 'fa fa-ellipsis-vertical'
+                    : 'fa fa-ellipsis',
+                menu           : menuConfig,
+                parentComponent: me.owner,
+                parentId       : 'document.body',
+                role           : 'button',
+                theme          : me.owner.getTheme(),
+                vdom           : {'aria-label': 'More tabs'},
+                windowId       : me.owner.windowId
             });
+            me.control.addDomListeners?.({resize: me.onControlResize, scope: me});
 
             // The reservation's render-truth EDGE: the pass that creates the control computed its split
             // with the pre-creation estimate — the rendered width does not exist yet, and no external
@@ -628,11 +883,15 @@ class Overflow extends Plugin {
         me.hiddenSignature = signature;
 
         // RA-13: re-align against the CURRENT owner rect. A floating component aligns once at mount and does
-        // NOT re-align when its target moves — and a sync-driven projection change (tabs hidden/shown) moves
-        // the toolbar's right edge without resizing the toolbar element, so neither the initial align nor the
-        // offsetParent ResizeObserver re-fires. Re-aligning on each sync (control mounted) re-pins it to the
-        // current edge — cheap + idempotent. The e2e owner-exact geometry assertion falsifies its absence.
-        me.control?.mounted && me.control.alignTo()
+        // NOT re-align when its target moves. Re-aligning on each sync re-pins it to the current action or
+        // owner edge — cheap + idempotent. The e2e owner-exact geometry assertion falsifies its absence.
+        if (me.control?.mounted) {
+            me.control.align   = me.getControlAlign();
+            me.control.iconCls = me.getMainAxisConfig().dimension === 'height'
+                ? 'fa fa-ellipsis-vertical'
+                : 'fa fa-ellipsis';
+            me.control.alignTo()
+        }
     }
 
     /**
@@ -644,16 +903,19 @@ class Overflow extends Plugin {
 
         // A dying plugin must not strand its caps (a dock rebuild replaces the plugin, not the
         // buttons): restore each recorded caller value through the same channel the cap used.
-        me.appliedCaps?.forEach((priorMaxWidth, buttonId) => {
+        me.appliedCaps?.forEach((cap, buttonId) => {
             const button = me.getTabButtons().find(item => item.id === buttonId);
 
             if (button && !button.isDestroyed) {
                 button.removeCls?.('neo-tab-overflow-capped');
-                button.maxWidth = priorMaxWidth
+                button[cap.maxSize] = cap.value
             }
         });
 
         me.appliedCaps = null;
+        me.resolveProjectionIdle();
+        me.sortDragZone?.un('dragEnd', me.onSortDragEnd, me);
+        me.sortDragZone = null;
         me.control?.destroy(true);
         me.control = null;
         super.destroy(...args)

--- a/src/tab/plugin/Overflow.mjs
+++ b/src/tab/plugin/Overflow.mjs
@@ -211,6 +211,11 @@ class Overflow extends Plugin {
      * @member {Function[]|null} projectionIdleWaiters=null
      */
     projectionIdleWaiters = null
+    /**
+     * A dock-axis change needs its next rendered owner resize to recapture tab main-axis extents.
+     * @member {Boolean} dockRecapturePending=false
+     */
+    dockRecapturePending = false
 
     /**
      * @param {Object} config
@@ -237,7 +242,7 @@ class Overflow extends Plugin {
             });
             if (me.owner.getConfig?.('dock')) {
                 me.observeConfig(me.owner, 'dock', () => {
-                    queueMicrotask(() => !me.isDestroyed && me.project(true))
+                    me.dockRecapturePending = true
                 })
             }
         }
@@ -464,7 +469,11 @@ class Overflow extends Plugin {
      * @param {Object} data
      */
     onResize(data) {
-        this.project(false)
+        let me        = this,
+            recapture = me.dockRecapturePending;
+
+        me.dockRecapturePending = false;
+        me.project(recapture)
     }
 
     /**

--- a/src/toolbar/Base.mjs
+++ b/src/toolbar/Base.mjs
@@ -1,8 +1,9 @@
-import Button    from '../button/Base.mjs';
-import Component from '../component/Base.mjs';
-import Container from '../container/Base.mjs';
-import Label     from '../component/Label.mjs';
-import NeoArray  from '../util/Array.mjs';
+import Button         from '../button/Base.mjs';
+import Component      from '../component/Base.mjs';
+import Container      from '../container/Base.mjs';
+import Label          from '../component/Label.mjs';
+import NeoArray       from '../util/Array.mjs';
+import {isDescriptor} from '../core/ConfigSymbols.mjs';
 
 /**
  * @class Neo.toolbar.Base
@@ -18,6 +19,30 @@ class Toolbar extends Container {
 
     static config = {
         /**
+         * Named action config factories. Subclasses can provide reusable action vocabularies while
+         * instance-level action objects remain fully customisable.
+         * @member {Object|null} actionMap=null
+         */
+        actionMap: null,
+        /**
+         * Defaults applied to every materialised action before its own config. A caller-provided
+         * handler deliberately wins over the toolbar's generic intent emitter.
+         * @member {Object|null} actionDefaults=null
+         */
+        actionDefaults: null,
+        /**
+         * Optional flat action configs appended after one toolbar-owned flex spacer.
+         * @member {Object[]|String[]|null} actions=null
+         * @reactive
+         */
+        actions_: {
+            [isDescriptor]: true,
+            clone         : 'shallow',
+            cloneOnGet    : 'none',
+            isEqual       : () => false,
+            value         : null
+        },
+        /**
          * @member {String} className='Neo.toolbar.Base'
          * @protected
          */
@@ -31,6 +56,13 @@ class Toolbar extends Container {
          * @member {String[]} baseCls=['neo-toolbar']
          */
         baseCls: ['neo-toolbar'],
+        /**
+         * Whether focus-contextual actions are currently exposed. Inactive contextual actions keep
+         * their layout extent but leave pointer, keyboard, and accessibility navigation.
+         * @member {Boolean} contextualActionsVisible=false
+         * @reactive
+         */
+        contextualActionsVisible_: false,
         /**
          * @member {String|null} dock_=null
          * @reactive
@@ -53,6 +85,28 @@ class Toolbar extends Container {
             direction: 'row',
             pack     : 'start'
         }
+    }
+
+    /**
+     * Reconciles a live action-collection replacement after construction. Initial materialisation
+     * stays inside createItems() so the toolbar still commits one child tree.
+     * @param {Object[]|String[]|null} value
+     * @param {Object[]|String[]|null} oldValue
+     * @protected
+     */
+    afterSetActions(value, oldValue) {
+        oldValue !== undefined && this.isConstructed && this.syncActions(value)
+    }
+
+    /**
+     * Applies focus-context visibility without changing each action's consumer-owned hidden or
+     * disabled state.
+     * @param {Boolean} value
+     * @param {Boolean} oldValue
+     * @protected
+     */
+    afterSetContextualActionsVisible(value, oldValue) {
+        oldValue !== undefined && this.isConstructed && this.applyContextualActionState()
     }
 
     /**
@@ -99,13 +153,230 @@ class Toolbar extends Container {
      *
      */
     createItems() {
-        let items = this._items;
+        let me    = this,
+            items = me._items;
 
         if (Array.isArray(items)) {
-            this._items = items.map(item => this.replaceSpacer(item))
+            me._items = [
+                ...items.map(item => me.replaceSpacer(item)),
+                ...me.createActionItemConfigs()
+            ]
         }
 
-        return super.createItems()
+        super.createItems();
+
+        me.bindActionItems();
+        me.applyContextualActionState(true)
+    }
+
+    /**
+     * Reserves or releases contextual action interactivity while preserving layout geometry.
+     * @param {Boolean} [silent=false]
+     */
+    applyContextualActionState(silent=false) {
+        let me      = this,
+            visible = me.contextualActionsVisible;
+
+        me.getActionItems().forEach(item => {
+            if (item.contextual !== true) {
+                return
+            }
+
+            let cls      = [...(item.cls || [])],
+                inactive = !visible,
+                vdom     = item.vdom;
+
+            NeoArray.toggle(cls, 'neo-toolbar-action-context-inactive', inactive);
+            item.setSilent({cls});
+
+            if (inactive) {
+                if (!Object.hasOwn(item, '_toolbarActionTabIndex')) {
+                    item._toolbarActionTabIndex = Object.hasOwn(vdom, 'tabIndex') ? vdom.tabIndex : null
+                }
+
+                vdom['aria-hidden'] = 'true';
+                vdom.inert         = true;
+                vdom.tabIndex      = -1
+            } else {
+                delete vdom['aria-hidden'];
+                delete vdom.inert;
+
+                if (item._toolbarActionTabIndex === null) {
+                    delete vdom.tabIndex
+                } else {
+                    vdom.tabIndex = item._toolbarActionTabIndex
+                }
+
+                delete item._toolbarActionTabIndex
+            }
+
+            !silent && item.update()
+        })
+    }
+
+    /**
+     * Observes availability changes whose geometry can alter a consumer such as tab overflow.
+     * @protected
+     */
+    bindActionItems() {
+        let me = this;
+
+        me.getActionItems().forEach(item => {
+            item.addDomListeners({resize: me.onActionResize, scope: me});
+            item.on('hiddenChange', () => {
+                me.fire('actionVisibilityChange', {action: item.action, component: item})
+            }, me)
+        })
+    }
+
+    /**
+     * Publishes post-render action-root geometry changes for consumers whose available extent is
+     * independent of the toolbar's own border box.
+     * @param {Object} data
+     * @protected
+     */
+    onActionResize(data) {
+        let {component} = data;
+
+        this.fire('actionGeometryChange', {
+            action: component.action,
+            component
+        })
+    }
+
+    /**
+     * Builds one action button config while preserving explicit-handler precedence.
+     * @param {Object|String} action
+     * @returns {Object}
+     * @protected
+     */
+    createActionItemConfig(action) {
+        let me       = this,
+            resolved = action,
+            cls,
+            vdom;
+
+        if (Neo.typeOf(action) !== 'Object') {
+            let factory = me.actionMap?.[action];
+
+            if (!Neo.isFunction(factory)) {
+                throw new Error(me.className + ': unknown toolbar action "' + action + '"')
+            }
+
+            resolved = factory()
+        }
+
+        resolved = {...resolved};
+        cls      = Array.isArray(resolved.cls) ? [...resolved.cls] : resolved.cls ? [resolved.cls] : [];
+        vdom     = {...(resolved.vdom || {})};
+
+        NeoArray.add(cls, 'neo-toolbar-action');
+
+        if (resolved.iconCls && !resolved.text && !vdom['aria-label'] && !vdom['aria-labelledby']) {
+            if (!resolved.action) {
+                throw new Error(me.className + ': icon-only toolbar actions require an action or accessible name')
+            }
+
+            vdom['aria-label'] = String(resolved.action).replace(/[-_]+/g, ' ')
+        }
+
+        return {
+            role: 'button',
+            ...(me.actionDefaults || {}),
+            handler: me.fireAction.bind(me),
+            ...resolved,
+            cls,
+            isToolbarAction: true,
+            ...(Object.keys(vdom).length > 0 && {vdom})
+        }
+    }
+
+    /**
+     * Materialises the toolbar-owned spacer plus action configs.
+     * @param {Object[]|String[]|null} [actions=this.actions]
+     * @returns {Object[]}
+     * @protected
+     */
+    createActionItemConfigs(actions=this.actions) {
+        if (!Array.isArray(actions) || actions.length === 0) {
+            return []
+        }
+
+        return [{
+            module               : Component,
+            cls                  : ['neo-toolbar-action-spacer'],
+            flex                 : 1,
+            isToolbarActionSpacer: true
+        }, ...actions.map(action => this.createActionItemConfig(action))]
+    }
+
+    /**
+     * Emits generic action intent. Specialised toolbars can override this method to retain an
+     * established event contract.
+     * @param {Object} data
+     */
+    fireAction(data) {
+        let {component} = data;
+
+        this.fire('action', {
+            action: component.action,
+            component,
+            scope : this
+        })
+    }
+
+    /**
+     * Returns the stable action component instances owned by this toolbar.
+     * @returns {Neo.component.Base[]}
+     */
+    getActionItems() {
+        return (this.items || []).filter(item => item.isToolbarAction === true)
+    }
+
+    /**
+     * Returns a stable action instance by semantic action name.
+     * @param {String} action
+     * @returns {Neo.component.Base|null}
+     */
+    getActionItem(action) {
+        return this.getActionItems().find(item => item.action === action) || null
+    }
+
+    /**
+     * Returns the spacer owned by the action group.
+     * @returns {Neo.component.Base|null}
+     * @protected
+     */
+    getActionSpacer() {
+        return (this.items || []).find(item => item.isToolbarActionSpacer === true) || null
+    }
+
+    /**
+     * Replaces only the toolbar-owned action group while preserving every ordinary item.
+     * @param {Object[]|String[]|null} actions
+     * @protected
+     */
+    syncActions(actions) {
+        let me      = this,
+            owned   = [me.getActionSpacer(), ...me.getActionItems()].filter(Boolean),
+            configs = me.createActionItemConfigs(actions);
+
+        owned
+            .map(item => me.items.indexOf(item))
+            .filter(index => index > -1)
+            .sort((a, b) => b - a)
+            .forEach(index => me.removeAt(index, true, true));
+
+        if (configs.length > 0) {
+            me.insert(me.items.length, configs);
+            me.bindActionItems();
+            me.applyContextualActionState(true)
+        } else {
+            me.updateDepth = -1;
+            me.update()
+        }
+
+        me.fire('actionsChange', {actions: me.getActionItems()})
     }
 
     /**
@@ -151,16 +422,17 @@ class Toolbar extends Container {
      * @param {Number} index
      * @param {Array|Object} item
      * @param {Boolean} [silent=false]
+     * @param {Boolean} [removeFromPreviousParent=true]
      * @returns {Neo.component.Base|Neo.component.Base[]}
      */
-    insert(index, item, silent=false) {
+    insert(index, item, silent=false, removeFromPreviousParent=true) {
         if (Array.isArray(item)) {
             item = item.map(item => this.replaceSpacer(item))
         } else {
             item = this.replaceSpacer(item)
         }
 
-        return super.insert(index, item, silent)
+        return super.insert(index, item, silent, removeFromPreviousParent)
     }
 
     /**

--- a/test/playwright/e2e/tab/TabHeaderActionsNL.spec.mjs
+++ b/test/playwright/e2e/tab/TabHeaderActionsNL.spec.mjs
@@ -187,6 +187,14 @@ test.describe('TabContainer flat header actions (Neural Link)', () => {
         const menuItem = page.locator('.neo-tab-overflow-menu:visible .neo-list-item').first();
 
         await expect(menuItem).toBeVisible({timeout: 10000});
+
+        const menuId         = await menuItem.evaluate(node => node.closest('.neo-tab-overflow-menu')?.id),
+              menuProperties = await app.getComponent(menuId, ['parentComponent', 'parentId']);
+
+        expect(menuProperties.parentId).toBe('document.body');
+        expect(menuProperties.parentComponent?.id,
+            'the generated menu retains the floating control as its logical owner').toBe(controlId);
+
         await menuItem.focus();
         expect(await page.evaluate(() => document.activeElement?.id),
             'focus moves off the control and into its generated popup').not.toBe(controlId);

--- a/test/playwright/e2e/tab/TabHeaderActionsNL.spec.mjs
+++ b/test/playwright/e2e/tab/TabHeaderActionsNL.spec.mjs
@@ -144,16 +144,18 @@ test.describe('TabContainer flat header actions (Neural Link)', () => {
             await app.setProperties(tabId, horizontal ? {width: 250} : {height: 200});
             await expect(overflowControl).toHaveCount(1, {timeout: 10000});
 
-            const controlRect = await overflowControl.boundingBox(),
-                  actionRect  = await nextAction.boundingBox();
+            // The same floating control survives axis changes, so count=1 can already be true while
+            // the owner ResizeObserver is still projecting its new alignment. Poll the rendered
+            // boundary itself — the contract under test — rather than sampling that transition.
+            await expect.poll(async () => {
+                const controlRect = await overflowControl.boundingBox(),
+                      actionRect  = await nextAction.boundingBox();
 
-            if (horizontal) {
-                expect(Math.abs(controlRect.x + controlRect.width - actionRect.x),
-                    `${position}: Overflow aligns before the action rail`).toBeLessThanOrEqual(2)
-            } else {
-                expect(Math.abs(controlRect.y + controlRect.height - actionRect.y),
-                    `${position}: Overflow aligns before the action rail`).toBeLessThanOrEqual(2)
-            }
+                return horizontal
+                    ? Math.abs(controlRect.x + controlRect.width - actionRect.x)
+                    : Math.abs(controlRect.y + controlRect.height - actionRect.y)
+            }, {message: `${position}: Overflow aligns before the action rail`, timeout: 10000})
+                .toBeLessThanOrEqual(2);
 
             await app.setProperties(tabId, {height: 300, width: 500});
             await expect(overflowControl).toHaveCount(0, {timeout: 10000})
@@ -277,6 +279,42 @@ test.describe('TabContainer flat header actions (Neural Link)', () => {
 
         expect(mismatches, 'post-drag items, VDOM, and DOM remain exact').toEqual([]);
         expect(await app.callMethod(tabId, 'getCount')).toBe(3);
+
+        // Runtime host replacement enters Toolbar#syncActions rather than the construction path.
+        // Contextual defaults are applied after the structural insert there, so pin their physical
+        // DOM/a11y state rather than accepting the worker VDOM as proof that the insert flush carried it.
+        await outsideField.click();
+        await expect(previousAction).toHaveCSS('visibility', 'hidden');
+        await app.setProperties(tabId, {
+            headerActions: [{action: 'runtime-contextual', iconCls: 'fa fa-bolt'}]
+        });
+
+        const runtimeActionRecord = await app.callMethod(tabId, 'getActionItem', ['runtime-contextual']),
+              runtimeActionId     = runtimeActionRecord?.id,
+              runtimeAction       = page.locator(`#${runtimeActionId}`);
+
+        expect(runtimeActionId, 'runtime replacement materialises the new semantic action').toBeTruthy();
+        await expect(runtimeAction).toHaveCount(1);
+        await expect(runtimeAction,
+            'syncActions commits contextual inactivity to the rendered root').toHaveCSS('visibility', 'hidden');
+        await expect(page.getByRole('button', {name: 'runtime contextual', exact: true})).toHaveCount(0);
+        expect(await runtimeAction.evaluate(node => ({
+            ariaHidden: node.getAttribute('aria-hidden'),
+            inert     : node.inert,
+            tabIndex  : node.tabIndex
+        }))).toEqual({ariaHidden: 'true', inert: true, tabIndex: -1});
+
+        await card.click();
+        await expect(runtimeAction).toHaveCSS('visibility', 'visible');
+        await expect(page.getByRole('button', {name: 'runtime contextual', exact: true})).toHaveCount(1);
+        expect(await runtimeAction.evaluate(node => ({
+            ariaHidden: node.getAttribute('aria-hidden'),
+            inert     : node.inert,
+            tabIndex  : node.tabIndex
+        }))).toEqual({ariaHidden: null, inert: false, tabIndex: 0});
+
+        expect(await app.callMethod(tabId, 'getCount'),
+            'runtime action replacement never changes the semantic tab count').toBe(3);
         expect(pageErrors, 'the complete action/focus/overflow/drag journey emits no page errors').toEqual([])
     })
 });

--- a/test/playwright/e2e/tab/TabHeaderActionsNL.spec.mjs
+++ b/test/playwright/e2e/tab/TabHeaderActionsNL.spec.mjs
@@ -1,0 +1,274 @@
+import {test, expect} from '../../fixtures.mjs';
+
+const asArray = value => Array.isArray(value) ? value : value ? [value] : [];
+const valueOf = (record, key) => record?.properties?.[key] ?? record?.[key];
+
+/**
+ * @summary Whitebox journey for flat TabContainer actions across focus, accessibility,
+ * orientation, Overflow, and SortZone gesture boundaries.
+ */
+test.describe('TabContainer flat header actions (Neural Link)', () => {
+    test.setTimeout(120000);
+    test.use({viewport: {height: 800, width: 1000}});
+
+    test('actions stay semantic, focus-aware, overflow-safe, and outside tab sorting', async ({page, neuralLink}) => {
+        const pageErrors = [];
+
+        page.on('pageerror', error => pageErrors.push(String(error?.message || error)));
+
+        await page.goto('/examples/tab/container/index.html');
+
+        const app = await neuralLink.connectToApp('Neo.examples.tab.container');
+
+        await expect(page.locator('.neo-tab-container')).toBeVisible({timeout: 30000});
+
+        const tabRecords = asArray(await app.queryComponent(
+            {ntype: 'tab-container'},
+            ['id', 'activeIndex', 'bodyContainerId', 'tabBarId', 'tabBarPosition']
+        ));
+
+        expect(tabRecords, 'the rendered example owns one semantic TabContainer').toHaveLength(1);
+
+        const tabRecord = tabRecords[0],
+              tabId     = tabRecord.id,
+              bodyId    = valueOf(tabRecord, 'bodyContainerId'),
+              barId     = valueOf(tabRecord, 'tabBarId'),
+              bar       = page.locator(`#${barId}`);
+
+        expect(tabId, 'the example owns one semantic TabContainer').toBeTruthy();
+        expect(await app.callMethod(tabId, 'getCount'), 'actions never change the semantic tab count').toBe(3);
+
+        const actionRecords = asArray(await app.queryComponent(
+                  {isToolbarAction: true},
+                  ['id', 'action', 'contextual', 'role', 'vdom', 'wrapperCls']
+              )),
+              actionsByName = Object.fromEntries(actionRecords.map(record => [valueOf(record, 'action'), record])),
+              nextRecord    = actionsByName['next-tab'],
+              previousRecord= actionsByName['previous-tab'],
+              nextId        = nextRecord.id,
+              previousId    = previousRecord.id,
+              nextAction    = page.locator(`#${nextId}`),
+              previousAction= page.locator(`#${previousId}`);
+
+        expect(nextId).toBeTruthy();
+        expect(previousId).toBeTruthy();
+        expect(valueOf(nextRecord, 'role')).toBe('button');
+        expect(valueOf(previousRecord, 'role')).toBe('button');
+        expect(valueOf(nextRecord, 'wrapperCls')).not.toContain('neo-draggable');
+        expect(valueOf(previousRecord, 'wrapperCls')).not.toContain('neo-draggable');
+
+        const semanticNext = await app.callMethod(tabId, 'getActionItem', ['next-tab']);
+        expect(semanticNext?.id, 'semantic lookup resolves the stable action instance').toBe(nextId);
+
+        await expect(page.getByRole('button', {name: 'next tab', exact: true})).toHaveCount(1);
+        await expect(page.getByRole('button', {name: 'previous tab', exact: true})).toHaveCount(0);
+        await expect(previousAction).toHaveCSS('visibility', 'hidden');
+        expect(await previousAction.evaluate(node => ({
+            ariaHidden: node.getAttribute('aria-hidden'),
+            inert     : node.inert,
+            tabIndex  : node.tabIndex
+        }))).toEqual({ariaHidden: 'true', inert: true, tabIndex: -1});
+
+        const bodyTree = await app.getComponentTree(bodyId, 2, true),
+              cardId   = bodyTree.tree.items[0].id,
+              card     = page.locator(`#${cardId}`);
+
+        expect(cardId, 'the example exposes a naturally focusable active body').toBeTruthy();
+        await card.click();
+
+        await expect(previousAction).toHaveCSS('visibility', 'visible');
+        await expect(page.getByRole('button', {name: 'previous tab', exact: true})).toHaveCount(1);
+        expect(await previousAction.evaluate(node => ({
+            ariaHidden: node.getAttribute('aria-hidden'),
+            inert     : node.inert,
+            tabIndex  : node.tabIndex
+        }))).toEqual({ariaHidden: null, inert: false, tabIndex: 0});
+
+        // Header actions precede the body in DOM order, so the natural body → trailing-action route
+        // is one reverse-tab step (no positive tabindex reshaping).
+        await page.keyboard.press('Shift+Tab');
+        expect(await page.evaluate(() => document.activeElement?.id),
+            'the armed contextual action enters native keyboard order').toBe(previousId);
+        await expect(previousAction).toHaveCSS('visibility', 'visible');
+
+        await previousAction.click();
+        await expect.poll(async () => (await app.getComponent(tabId, ['activeIndex'])).activeIndex)
+            .toBe(2);
+
+        const outsideField = page.locator('#activeIndexField__input');
+        await outsideField.click();
+        await expect(previousAction).toHaveCSS('visibility', 'hidden');
+        await expect(page.getByRole('button', {name: 'previous tab', exact: true})).toHaveCount(0);
+
+        // Entering through a persistent header action does not arm the contextual sibling.
+        await nextAction.click();
+        await expect.poll(async () => (await app.getComponent(tabId, ['activeIndex'])).activeIndex)
+            .toBe(0);
+        await expect(previousAction).toHaveCSS('visibility', 'hidden');
+
+        const tabIds = await bar.locator('.neo-tab-header-button').evaluateAll(nodes => nodes.map(node => node.id));
+
+        expect(tabIds).toHaveLength(3);
+        await expect(bar.locator('.neo-toolbar-action.neo-draggable')).toHaveCount(0);
+        await expect(bar.locator('.neo-toolbar-action-spacer.neo-draggable')).toHaveCount(0);
+
+        const overflowControl = page.getByRole('button', {name: 'More tabs', exact: true});
+
+        for (const position of ['top', 'right', 'bottom', 'left']) {
+            const horizontal = position === 'top' || position === 'bottom';
+
+            await app.setProperties(tabId, {height: 300, tabBarPosition: position, width: 500});
+            await expect(bar).toHaveClass(new RegExp(`neo-dock-${position}`));
+
+            const [barRect, lastTabRect, firstActionRect] = await app.getDomRect([
+                barId,
+                tabIds[tabIds.length - 1],
+                nextId
+            ]);
+
+            if (horizontal) {
+                expect(firstActionRect.left,
+                    `${position}: the action rail starts after the final tab`).toBeGreaterThanOrEqual(lastTabRect.right - 1);
+                expect(firstActionRect.right,
+                    `${position}: actions remain inside the toolbar main axis`).toBeLessThanOrEqual(barRect.right + 1)
+            } else {
+                expect(firstActionRect.top,
+                    `${position}: the action rail starts after the final tab`).toBeGreaterThanOrEqual(lastTabRect.bottom - 1);
+                expect(firstActionRect.bottom,
+                    `${position}: actions remain inside the toolbar main axis`).toBeLessThanOrEqual(barRect.bottom + 1)
+            }
+
+            expect(await app.callMethod(tabId, 'getCount')).toBe(3);
+
+            // Render a real Overflow control on every axis, not only in the rect-stubbed unit core.
+            await app.setProperties(tabId, horizontal ? {width: 250} : {height: 200});
+            await expect(overflowControl).toHaveCount(1, {timeout: 10000});
+
+            const controlRect = await overflowControl.boundingBox(),
+                  actionRect  = await nextAction.boundingBox();
+
+            if (horizontal) {
+                expect(Math.abs(controlRect.x + controlRect.width - actionRect.x),
+                    `${position}: Overflow aligns before the action rail`).toBeLessThanOrEqual(2)
+            } else {
+                expect(Math.abs(controlRect.y + controlRect.height - actionRect.y),
+                    `${position}: Overflow aligns before the action rail`).toBeLessThanOrEqual(2)
+            }
+
+            await app.setProperties(tabId, {height: 300, width: 500});
+            await expect(overflowControl).toHaveCount(0, {timeout: 10000})
+        }
+
+        await app.setProperties(tabId, {height: 300, tabBarPosition: 'top', width: 250});
+        await expect(bar).toHaveClass(/neo-dock-top/);
+
+        // Re-enter through the body before focusing the logically-owned floating Overflow control.
+        await card.click();
+        await expect(previousAction).toHaveCSS('visibility', 'visible');
+
+        await expect(overflowControl).toHaveCount(1, {timeout: 10000});
+        const controlId         = await overflowControl.getAttribute('id'),
+              controlProperties = await app.getComponent(controlId, ['parentComponent', 'parentId', 'role']);
+
+        expect(await overflowControl.evaluate(node => node.parentElement === document.body),
+            'Overflow remains a physical body child').toBe(true);
+        expect(controlProperties.parentId).toBe('document.body');
+        expect(controlProperties.parentComponent?.id,
+            'Overflow retains logical toolbar ancestry for manager.Focus').toBe(barId);
+        expect(controlProperties.role).toBe('button');
+
+        const controlRect = await overflowControl.boundingBox(),
+              nextRect    = await nextAction.boundingBox();
+
+        expect(Math.abs(controlRect.x + controlRect.width - nextRect.x),
+            'Overflow aligns immediately before the action rail').toBeLessThanOrEqual(2);
+
+        await overflowControl.click();
+        const menuItem = page.locator('.neo-tab-overflow-menu:visible .neo-list-item').first();
+
+        await expect(menuItem).toBeVisible({timeout: 10000});
+        await menuItem.focus();
+        expect(await page.evaluate(() => document.activeElement?.id),
+            'focus moves off the control and into its generated popup').not.toBe(controlId);
+        await expect(previousAction,
+            'focus moving into the logically-owned Overflow/menu realm retains contextual actions').toHaveCSS('visibility', 'visible');
+
+        await outsideField.click();
+        await expect(previousAction).toHaveCSS('visibility', 'hidden');
+
+        // Start from an all-fit header. Mid-gesture action growth would overflow, but the SortZone's
+        // stable snapshot owns the gesture, so Overflow must queue until the terminal.
+        await app.setProperties(tabId, {width: 310});
+        await expect(overflowControl).toHaveCount(0, {timeout: 10000});
+        await card.click();
+        await expect(previousAction).toHaveCSS('visibility', 'visible');
+
+        await app.getDragTrace(true);
+
+        const lastTab  = page.locator(`#${tabIds[tabIds.length - 1]}`),
+              startBox = await lastTab.boundingBox(),
+              railBox  = await nextAction.boundingBox(),
+              y        = startBox.y + startBox.height / 2;
+
+        await page.mouse.move(startBox.x + startBox.width / 2, y);
+        await page.mouse.down();
+        await page.waitForTimeout(150);
+        await page.mouse.move(railBox.x + railBox.width / 2, y, {steps: 30});
+
+        await expect.poll(async () => {
+            const zones = asArray(await app.findInstances(
+                {ntype: 'tab-header-toolbar-sortzone'},
+                ['id', 'startIndex']
+            ));
+
+            return valueOf(zones[0], 'startIndex')
+        }, {message: 'the real mouse sensor armed the semantic tab snapshot'}).toBe(2);
+
+        await app.setProperties(nextId, {width: 80});
+        await page.waitForTimeout(200);
+
+        const grownRailBox   = await nextAction.boundingBox(),
+              renderedGrowth = grownRailBox.width - railBox.width;
+
+        expect(await bar.locator('.neo-tab-header-button').count(),
+            'Overflow cannot remove sortable members beneath a held geometry snapshot').toBe(3);
+        await expect(overflowControl,
+            'the action-width projection is queued for the drag terminal').toHaveCount(0);
+
+        const overflowInstances = asArray(await app.findInstances(
+            {ntype: 'plugin-tab-overflow'},
+            ['id', 'sortDragProjectionQueued']
+        ));
+        if (renderedGrowth > 1) {
+            expect(valueOf(overflowInstances[0], 'sortDragProjectionQueued'),
+                'a rendered mid-drag resize queues its projection').toBe(true)
+        }
+
+        await page.mouse.move(grownRailBox.x + grownRailBox.width / 2, y, {steps: 20});
+        await page.mouse.up();
+
+        await expect(overflowControl,
+            'the queued projection drains after SortZone restores natural layout').toHaveCount(1, {timeout: 10000});
+
+        const traceData = await app.getDragTrace(),
+              traces    = traceData?.traces || traceData?.result?.traces || [],
+              trace     = traces[traces.length - 1],
+              endEvent  = trace?.events?.find(event => event.t === 'end');
+
+        expect(trace?.items, 'the trace contains only semantic tab members').toEqual(tabIds);
+        expect(trace.items).not.toContain(nextId);
+        expect(trace.items).not.toContain(previousId);
+        expect(endEvent).toMatchObject({from: 2, noop: true, to: 2});
+
+        await app.setProperties(nextId, {width: null});
+        await app.setProperties(tabId, {width: 500});
+        await expect(overflowControl).toHaveCount(0, {timeout: 10000});
+
+        const consistency = await app.verifyComponentConsistency(barId),
+              mismatches  = consistency?.mismatches || consistency?.result?.mismatches || [];
+
+        expect(mismatches, 'post-drag items, VDOM, and DOM remain exact').toEqual([]);
+        expect(await app.callMethod(tabId, 'getCount')).toBe(3);
+        expect(pageErrors, 'the complete action/focus/overflow/drag journey emits no page errors').toEqual([])
+    })
+});

--- a/test/playwright/unit/dashboard/DockProjectionReconciler.spec.mjs
+++ b/test/playwright/unit/dashboard/DockProjectionReconciler.spec.mjs
@@ -221,6 +221,66 @@ test.describe('Neo.dashboard.DockProjectionReconciler', () => {
         }
     })
 
+    test('retained tab reconciliation preserves a flat action rail outside semantic tab exactness', async () => {
+        const
+            model = createRootTabsModel(),
+            panes = {
+                alpha: Neo.create(Component, {header: {text: 'Alpha'}}),
+                beta : Neo.create(Component, {header: {text: 'Beta'}})
+            },
+            host = Neo.create(Container, {
+                items: [DockLayoutAdapter.project(model, {
+                    resolveComponentRef: (_componentRef, _item, itemId) => panes[itemId]
+                })]
+            }),
+            tab          = host.items[0],
+            bar          = tab.getTabBar(),
+            next         = structuredClone(model),
+            placeholders = new Map();
+
+        tab.headerActions = [{action: 'pin', contextual: false, iconCls: 'fa fa-thumbtack'}];
+
+        const action = tab.getActionItem('pin'),
+              spacer = bar.getActionSpacer();
+
+        next.items.beta = {componentRef: 'beta', kind: 'panel', title: 'Beta'};
+        next.nodes['root-tabs'].items.push('beta');
+
+        try {
+            const nextConfig = DockLayoutAdapter.project(next, {
+                resolveComponentRef(_componentRef, item, itemId) {
+                    const placeholder = Neo.create(Component, {
+                        header: {text: item.title},
+                        hidden: true
+                    });
+
+                    placeholders.set(itemId, placeholder);
+
+                    return placeholder
+                }
+            });
+
+            await DockProjectionReconciler.reconcileProjection({
+                host,
+                nextConfig,
+                placeholders,
+                resolveItem: itemId => panes[itemId]
+            });
+            await new Promise(resolve => setTimeout(resolve, 10));
+
+            expect(host.items[0]).toBe(tab);
+            expect(tab.getTabButtons().map(button => button.text)).toEqual(['Alpha', 'Beta']);
+            expect(tab.getActionItem('pin'), 'the exact action instance survives projection').toBe(action);
+            expect(bar.getActionSpacer(), 'the exact spacer instance survives projection').toBe(spacer);
+            expect(bar.items.slice(-2)).toEqual([spacer, action]);
+            expect(action.wrapperCls).not.toContain('neo-draggable');
+            expect(spacer.wrapperCls).not.toContain('neo-draggable');
+            expect(bar.sortZone.getDraggableItems(bar.items)).toEqual(tab.getTabButtons())
+        } finally {
+            host.destroy()
+        }
+    })
+
     test('normalizes an absent-item config to the inserted live component exactly once', async () => {
         const
             model = createRootTabsModel(),

--- a/test/playwright/unit/dashboard/DockTabSortZone.spec.mjs
+++ b/test/playwright/unit/dashboard/DockTabSortZone.spec.mjs
@@ -230,7 +230,8 @@ test.describe('Neo.dashboard.DockTabSortZone', () => {
                 isStackHandleDrag: DockTabSortZone.prototype.isStackHandleDrag,
                 owner            : {
                     getDomRect: async () => ({x: 10, y: 20, width: 300, height: 32}),
-                    items     : [strategy, swarm]
+                    items     : [strategy, swarm],
+                    getTabButtons() { return this.items }
                 }
             };
             // Production DragDrop shape: the original nested mousedown survives as `target`,

--- a/test/playwright/unit/manager/Focus.spec.mjs
+++ b/test/playwright/unit/manager/Focus.spec.mjs
@@ -9,10 +9,12 @@ setup({
 });
 
 import {test, expect} from '@playwright/test';
-import Neo            from '../../../../src/Neo.mjs';
-import * as core      from '../../../../src/core/_export.mjs';
-import Component      from '../../../../src/component/Base.mjs';
-import FocusManager   from '../../../../src/manager/Focus.mjs';
+import Neo              from '../../../../src/Neo.mjs';
+import * as core        from '../../../../src/core/_export.mjs';
+import Component        from '../../../../src/component/Base.mjs';
+import ComponentManager from '../../../../src/manager/Component.mjs';
+import FocusManager     from '../../../../src/manager/Focus.mjs';
+import MenuList         from '../../../../src/menu/List.mjs';
 
 test.describe('Neo.manager.Focus', () => {
     let components;
@@ -80,6 +82,31 @@ test.describe('Neo.manager.Focus', () => {
         expect(parent.containsFocus).toBe(true);
         expect(root.containsFocus).toBe(true);
         expect(FocusManager.history[0].componentPath).toEqual(['focus-new-child', 'focus-parent', 'focus-root']);
+    });
+
+    test('walks a floating menu through its configured logical owner', () => {
+        const log = [];
+
+        components = [
+            createFocusComponent('focus-menu-root',  'document.body',   log),
+            createFocusComponent('focus-menu-owner', 'focus-menu-root', log)
+        ];
+
+        const menu = Neo.create(MenuList, {
+            appName,
+            id             : 'focus-floating-menu',
+            parentComponent: components[1],
+            parentId       : 'document.body'
+        });
+
+        components.push(menu);
+
+        expect(menu.parentComponent).toBe(components[1]);
+        expect(ComponentManager.getParentPath([menu.id])).toEqual([
+            'focus-floating-menu',
+            'focus-menu-owner',
+            'focus-menu-root'
+        ])
     });
 
     test('handles disjoint component paths without firing focusMove', () => {

--- a/test/playwright/unit/tab/HeaderActions.spec.mjs
+++ b/test/playwright/unit/tab/HeaderActions.spec.mjs
@@ -1,0 +1,367 @@
+import {setup} from '../../setup.mjs';
+
+const appName = 'TabHeaderActionsTest';
+
+setup({
+    appConfig: {
+        name: appName
+    }
+});
+
+import {test, expect} from '@playwright/test';
+import Neo            from '../../../../src/Neo.mjs';
+import * as core      from '../../../../src/core/_export.mjs';
+import Component      from '../../../../src/component/Base.mjs';
+import BaseContainer  from '../../../../src/container/Base.mjs';
+import DialogToolbar  from '../../../../src/dialog/header/Toolbar.mjs';
+import LivePreview    from '../../../../src/code/LivePreview.mjs';
+import TabContainer   from '../../../../src/tab/Container.mjs';
+import EffectButton   from '../../../../src/tab/header/EffectButton.mjs';
+import Toolbar        from '../../../../src/toolbar/Base.mjs';
+import '../../../../src/manager/Instance.mjs';
+
+/**
+ * @summary Pins flat toolbar action materialisation and mixed TabContainer semantics.
+ */
+test.describe.serial('Neo tab header actions', () => {
+    let dragDropSnapshot = null,
+        instances        = [];
+
+    const own = instance => {
+        instances.push(instance);
+        return instance
+    };
+
+    test.afterEach(() => {
+        instances.reverse().forEach(instance => !instance.isDestroyed && instance.destroy());
+        instances = [];
+
+        if (dragDropSnapshot) {
+            if (dragDropSnapshot.existed) {
+                Neo.main.addon.DragDrop = dragDropSnapshot.value
+            } else {
+                delete Neo.main.addon.DragDrop
+            }
+
+            dragDropSnapshot = null
+        }
+    });
+
+    test('generic actions preserve ordinary items, fresh maps, and handler precedence', () => {
+        let explicit = 0,
+            generic  = 0,
+            mapped   = 0,
+            input    = {action: 'explicit', handler: () => explicit++},
+            labelled = {
+                handler: () => {},
+                iconCls: 'fa fa-tag',
+                vdom   : {'aria-labelledby': 'external-action-label'}
+            },
+            toolbar  = own(Neo.create(Toolbar, {
+                actionMap: {
+                    mapped: () => {
+                        mapped++;
+                        return {action: 'mapped', iconCls: 'fa fa-map'}
+                    }
+                },
+                actions: [input, labelled],
+                items  : [{module: Component, flag: 'ordinary'}]
+            })),
+            ordinary = toolbar.items[0],
+            action   = toolbar.getActionItems()[0];
+
+        toolbar.on('action', () => generic++);
+        action.handler({component: action});
+
+        expect(explicit).toBe(1);
+        expect(generic, 'an explicit handler suppresses the generic event').toBe(0);
+        expect(input.isToolbarAction, 'materialisation must not mutate the caller config').toBeUndefined();
+        expect(toolbar.getActionItems()[1].vdom['aria-labelledby']).toBe('external-action-label');
+        expect(toolbar.items.filter(item => item.isToolbarActionSpacer)).toHaveLength(1);
+
+        toolbar.actions = ['mapped'];
+        action = toolbar.getActionItems()[0];
+        action.handler({component: action});
+
+        expect(mapped, 'the action map resolves one fresh config for the replacement').toBe(1);
+        expect(generic).toBe(1);
+        expect(toolbar.items[0]).toBe(ordinary);
+        expect(toolbar.items.map(item => item.isToolbarActionSpacer ? 'spacer' : item.action || item.flag))
+            .toEqual(['ordinary', 'spacer', 'mapped']);
+
+        function boundHandler() { return this.id }
+
+        const firstHandler  = boundHandler.bind({id: 1}),
+              secondHandler = boundHandler.bind({id: 2});
+
+        toolbar.actions = [{action: 'bound', handler: firstHandler}];
+        const firstBoundAction = toolbar.getActionItems()[0];
+        toolbar.actions = [{action: 'bound', handler: secondHandler}];
+        const secondBoundAction = toolbar.getActionItems()[0];
+
+        expect(secondBoundAction).not.toBe(firstBoundAction);
+        expect(secondBoundAction.handler()).toBe(2)
+    });
+
+    test('contextual inactivity reserves the instance while leaving consumer availability intact', () => {
+        const toolbar = own(Neo.create(Toolbar, {
+                  actions: [{action: 'contextual', contextual: true, iconCls: 'fa fa-eye'}]
+              })),
+              action  = toolbar.getActionItems()[0],
+              handler = action.handler;
+
+        expect(action.cls).toContain('neo-toolbar-action-context-inactive');
+        expect(action.vdom.inert).toBe(true);
+        expect(action.vdom['aria-hidden']).toBe('true');
+        expect(action.vdom['aria-label']).toBe('contextual');
+        expect(action.vdom.tabIndex).toBe(-1);
+
+        toolbar.contextualActionsVisible = true;
+
+        expect(toolbar.getActionItems()[0]).toBe(action);
+        expect(action.handler).toBe(handler);
+        expect(action.cls).not.toContain('neo-toolbar-action-context-inactive');
+        expect(action.vdom.inert).toBeUndefined();
+        expect(action.vdom['aria-hidden']).toBeUndefined();
+        expect(action.vdom.tabIndex).toBeUndefined();
+
+        action.vdom.tabIndex = 4;
+        toolbar.contextualActionsVisible = false;
+        toolbar.contextualActionsVisible = true;
+        expect(action.vdom.tabIndex, 'each inactive cycle restores the latest consumer tabIndex').toBe(4);
+
+        let geometryComponent;
+        toolbar.on('actionGeometryChange', data => {
+            geometryComponent = data.component
+        });
+        toolbar.onActionResize({component: action});
+        expect(geometryComponent, 'action-root ResizeObserver changes have a toolbar signal').toBe(action);
+
+        let removeDomAtVisibilitySignal;
+        toolbar.on('actionVisibilityChange', () => {
+            removeDomAtVisibilitySignal = action.vdom.removeDom
+        });
+
+        action.hidden = true;
+        toolbar.contextualActionsVisible = false;
+        toolbar.contextualActionsVisible = true;
+
+        expect(action.hidden, 'focus context cannot overwrite consumer-owned availability').toBe(true);
+        expect(removeDomAtVisibilitySignal, 'geometry invalidation follows the hidden DOM-state commit').toBe(true)
+    });
+
+    test('Dialog header order and headerAction payload stay compatible', () => {
+        const toolbar = own(Neo.create(DialogToolbar, {title: 'Dialog'})),
+              events  = [];
+
+        toolbar.on('headerAction', data => events.push(data));
+
+        expect(toolbar.items.map(item => item.isToolbarActionSpacer ? 'spacer' : item.action || item.flag))
+            .toEqual(['title-label', 'spacer', 'maximize', 'close']);
+
+        const close = toolbar.getActionItems().find(item => item.action === 'close');
+        close.handler({component: close});
+
+        expect(events).toHaveLength(1);
+        expect(events[0]).toMatchObject({
+            action   : 'close',
+            component: close,
+            scope    : toolbar
+        })
+    });
+
+    test('tab mutations use semantic buttons while preserving the flat action group', async () => {
+        const tabs = own(Neo.create(TabContainer, {
+                  activeIndex  : 1,
+                  headerActions: [{
+                      action    : 'custom',
+                      contextual: false,
+                      iconCls   : 'fa fa-star',
+                      module    : EffectButton
+                  }],
+                  items        : [
+                      {module: Component, header: {module: EffectButton, text: 'One'}},
+                      {module: Component, header: {text: 'Two'}}
+                  ]
+              })),
+              bar     = tabs.getTabBar(),
+              action  = tabs.getActionItems()[0];
+
+        expect(tabs.getCount()).toBe(2);
+        expect(tabs.getTabButtons()[0]).toBeInstanceOf(EffectButton);
+        expect(action).toBeInstanceOf(EffectButton);
+        expect(tabs.getTabButtons()).not.toContain(action);
+        expect(action.role, 'a tab-styled action keeps button semantics').toBe('button');
+        expect(bar.items.map(item => item.isToolbarActionSpacer ? 'spacer' : item.action || item.text))
+            .toEqual(['One', 'Two', 'spacer', 'custom']);
+
+        tabs.insert(1, {module: Component, header: {text: 'Middle'}});
+        tabs.add({module: Component, header: {text: 'Last'}});
+        tabs.moveTo(3, 0);
+        tabs.removeAt(2);
+        await Promise.resolve();
+
+        expect(tabs.getCount()).toBe(3);
+        expect(tabs.getTabButtons().map(button => button.text)).toEqual(['Last', 'One', 'Two']);
+        expect(tabs.getTabButtons().map(button => button.index)).toEqual([0, 1, 2]);
+        expect(tabs.getActionItems()).toEqual([action]);
+        expect(bar.items.slice(-2)).toEqual([bar.getActionSpacer(), action]);
+
+        expect(() => {tabs.useActiveTabIndicator = false}).not.toThrow();
+        expect(action.useActiveTabIndicator).toBe(true);
+
+        function boundHandler() { return this.id }
+
+        tabs.headerActions = [{action: 'bound', handler: boundHandler.bind({id: 1})}];
+        const firstBoundAction = tabs.getActionItems()[0];
+        tabs.headerActions = [{action: 'bound', handler: boundHandler.bind({id: 2})}];
+        const secondBoundAction = tabs.getActionItems()[0];
+
+        expect(secondBoundAction).not.toBe(firstBoundAction);
+        expect(secondBoundAction.handler()).toBe(2)
+    });
+
+    test('tab SortZone admits only tab buttons, including after runtime action replacement', async () => {
+        dragDropSnapshot = {
+            existed: Object.hasOwn(Neo.main.addon, 'DragDrop'),
+            value  : Neo.main.addon.DragDrop
+        };
+        Neo.ns('Neo.main.addon.DragDrop', true);
+        Neo.main.addon.DragDrop = {
+            setConfigs         : () => Promise.resolve({boundaryContainerRect: {bottom: 40, left: 0, right: 400, top: 0}}),
+            setDragProxyElement: () => Promise.resolve()
+        };
+
+        const tabs = own(Neo.create(TabContainer, {
+            appName,
+            dragResortable: true,
+            headerActions : [{action: 'first', iconCls: 'fa fa-one', module: EffectButton}],
+            items         : [
+                {module: Component, header: {text: 'One'}},
+                {module: Component, header: {text: 'Two'}}
+            ]
+        }));
+
+        await new Promise(resolve => setTimeout(resolve, 10));
+
+        const bar      = tabs.getTabBar(),
+              sortZone = bar.sortZone;
+
+        expect(sortZone.dragHandleSelector).toBe('.neo-tab-header-button');
+        expect(sortZone.getDraggableItems(bar.items)).toEqual(tabs.getTabButtons());
+        expect(tabs.getTabButtons().every(item => item.wrapperCls.includes('neo-draggable'))).toBe(true);
+        expect(bar.getActionItems().every(item => !item.wrapperCls.includes('neo-draggable'))).toBe(true);
+        expect(bar.getActionSpacer().wrapperCls.includes('neo-draggable')).toBe(false);
+
+        tabs.headerActions = [
+            {action: 'second', iconCls: 'fa fa-two'},
+            {action: 'third',  iconCls: 'fa fa-three'}
+        ];
+        await new Promise(resolve => setTimeout(resolve, 10));
+
+        expect(sortZone.getDraggableItems(bar.items)).toEqual(tabs.getTabButtons());
+        expect(bar.getActionItems().every(item => !item.wrapperCls.includes('neo-draggable'))).toBe(true)
+    });
+
+    test('body focus arms contextual actions and the TabContainer realm retains them', () => {
+        const tabs = own(Neo.create(TabContainer, {
+                  headerActions: [{action: 'contextual', iconCls: 'fa fa-eye'}],
+                  items        : [{module: Component, header: {text: 'One'}}]
+              })),
+              action = tabs.getActionItems()[0],
+              body   = tabs.getCardContainer(),
+              card   = tabs.getActiveCard(),
+              bar    = tabs.getTabBar();
+
+        expect(action.cls).toContain('neo-toolbar-action-context-inactive');
+
+        tabs.onFocusEnter({path: [{id: card.id}, {id: body.id}, {id: tabs.id}]});
+        expect(action.cls).not.toContain('neo-toolbar-action-context-inactive');
+
+        tabs.onFocusMove({
+            oldPath: [{id: card.id}, {id: body.id}, {id: tabs.id}],
+            path   : [{id: action.id}, {id: bar.id}, {id: tabs.id}]
+        });
+        expect(action.cls).not.toContain('neo-toolbar-action-context-inactive');
+
+        tabs.onFocusLeave({oldPath: [{id: action.id}, {id: bar.id}, {id: tabs.id}]});
+        expect(action.cls).toContain('neo-toolbar-action-context-inactive')
+    });
+
+    test('LivePreview keeps semantic actions stable across active-tab and popup lifecycles', async () => {
+        const
+            addon            = Neo.main.addon,
+            hadMonacoAddon   = Object.hasOwn(addon, 'MonacoEditor'),
+            hadResizeAddon   = Object.hasOwn(addon, 'ResizeObserver'),
+            oldGetByPath     = Neo.Main.getByPath,
+            oldMonacoAddon   = addon.MonacoEditor,
+            oldResizeAddon   = addon.ResizeObserver,
+            oldSharedWorkers = Neo.config.useSharedWorkers,
+            previousPopupApp = Neo.apps[42];
+
+        let livePreview,
+            popupMain;
+
+        Neo.config.useSharedWorkers = true;
+        addon.MonacoEditor = {destroyInstance() {}};
+        addon.ResizeObserver = {unregister() {}};
+
+        try {
+            livePreview = Neo.create(LivePreview, {enableFullscreen: true});
+
+            const tabs       = livePreview.tabContainer,
+                  fullscreen = tabs.getActionItem('fullscreen'),
+                  popout     = tabs.getActionItem('popout'),
+                  handler    = fullscreen.handler;
+
+            expect(tabs.getCount()).toBe(2);
+            expect(tabs.getTabBar().items).toHaveLength(5);
+            expect(tabs.getActionItems()).toEqual([fullscreen, popout]);
+            expect(fullscreen.vdom['aria-label']).toBe('Toggle fullscreen preview');
+            expect(popout.vdom['aria-label']).toBe('Open preview in a separate window');
+            expect(popout.hidden).toBe(true);
+
+            tabs.activeIndex = 1;
+            await new Promise(resolve => setTimeout(resolve, 0));
+
+            expect(tabs.getActionItem('fullscreen')).toBe(fullscreen);
+            expect(tabs.getActionItem('popout')).toBe(popout);
+            expect(fullscreen.handler).toBe(handler);
+            expect(popout.hidden).toBe(false);
+
+            livePreview.createPopupWindow = async () => {};
+            await popout.handler({component: popout});
+            expect(popout.disabled).toBe(true);
+
+            const previewContainer = livePreview.getReference('preview'),
+                  previewView      = previewContainer.add({module: Component});
+
+            popupMain = Neo.create(BaseContainer);
+            Neo.apps[42] = {mainView: popupMain};
+            Neo.Main.getByPath = async () => `http://localhost/preview?id=${livePreview.id}`;
+
+            await livePreview.onWindowConnect({windowId: 42});
+
+            expect(livePreview.connectedWindowId).toBe(42);
+            expect(popupMain.items).toContain(previewView);
+            expect(tabs.getTabAtIndex(1).disabled).toBe(true);
+            expect(popout.disabled).toBe(true);
+
+            await livePreview.onWindowDisconnect({windowId: 42});
+
+            expect(livePreview.connectedWindowId).toBe(null);
+            expect(previewContainer.items).toContain(previewView);
+            expect(tabs.getTabAtIndex(1).disabled).toBe(false);
+            expect(popout.disabled).toBe(false)
+        } finally {
+            livePreview?.destroy();
+            popupMain && !popupMain.isDestroyed && popupMain.destroy();
+
+            previousPopupApp === undefined ? delete Neo.apps[42] : Neo.apps[42] = previousPopupApp;
+            Neo.Main.getByPath = oldGetByPath;
+            Neo.config.useSharedWorkers = oldSharedWorkers;
+            hadMonacoAddon ? addon.MonacoEditor = oldMonacoAddon : delete addon.MonacoEditor;
+            hadResizeAddon ? addon.ResizeObserver = oldResizeAddon : delete addon.ResizeObserver
+        }
+    });
+});

--- a/test/playwright/unit/tab/plugin/Overflow.spec.mjs
+++ b/test/playwright/unit/tab/plugin/Overflow.spec.mjs
@@ -429,6 +429,28 @@ test.describe('Neo.tab.plugin.Overflow (re-entrancy contract)', () => {
             .toEqual({edgeAlign: 'b0-t0', target: action.id})
     });
 
+    test('a dock-axis change defers recapture to the post-render owner resize', async () => {
+        const plugin = createPlugin(async ids => ids[0] === 'tab-overflow-test-owner'
+            ? [{height: 300, left: 0, top: 0, width: 1000, x: 0, y: 0}]
+            : [{height: 20, width: 20}, {height: 20, width: 20}]);
+
+        await new Promise(resolve => setTimeout(resolve, 0));
+
+        let recapture;
+        plugin.project = value => {recapture = value};
+        plugin.dockRecapturePending = true;
+
+        plugin.onResize();
+
+        expect(recapture, 'the rendered resize recaptures the new main-axis tab extents').toBe(true);
+        expect(plugin.dockRecapturePending).toBe(false);
+
+        plugin.onResize();
+        expect(recapture, 'later ordinary resizes return to extent-only projection').toBe(false);
+
+        plugin.destroy()
+    });
+
     test('a projection requested during tab sorting queues until the stable snapshot is released', async () => {
         let measureCalls = 0,
             releaseDrag;

--- a/test/playwright/unit/tab/plugin/Overflow.spec.mjs
+++ b/test/playwright/unit/tab/plugin/Overflow.spec.mjs
@@ -105,14 +105,20 @@ test.describe('Neo.tab.plugin.Overflow (re-entrancy contract)', () => {
 
     /** A lean toolbar-owner stub: two header buttons, a controllable getDomRect. */
     const createPlugin = getDomRect => {
+        const items = [{id: 'b1'}, {id: 'b2'}];
+
         const plugin = Neo.create(Overflow, {
             owner: {
-                id             : 'tab-overflow-test-owner',
-                appName        : 'test-app',
-                mounted        : true,
-                theme          : 'neo-theme-neo-dark',
-                windowId       : 1,
-                items          : [{id: 'b1'}, {id: 'b2'}],
+                id            : 'tab-overflow-test-owner',
+                appName       : 'test-app',
+                dock          : 'top',
+                mounted       : true,
+                parent        : {activeIndex: 0, on() {}, un() {}},
+                theme         : 'neo-theme-neo-dark',
+                windowId      : 1,
+                items,
+                getActionItems: () => [],
+                getTabButtons() { return this.items },
                 getTheme       : function () { return this.theme },
                 getDomRect,
                 add            : () => ({}),
@@ -353,7 +359,260 @@ test.describe('Neo.tab.plugin.Overflow (re-entrancy contract)', () => {
             .toEqual(['neo-tab-overflow-menu']);
         expect(createdConfig.menu.items, 'the menu config retains the exact hidden-tab projection')
             .toHaveLength(1);
+        expect(createdConfig.parentComponent, 'the floating control keeps logical toolbar ancestry')
+            .toBe(plugin.owner);
+        expect(createdConfig.vdom['aria-label']).toBe('More tabs');
         expect(plugin.control, 'and assigns the fresh instance as the new control').not.toBeNull()
+    });
+
+    test('main-axis geometry reserves actions and maps all four toolbar orientations', async () => {
+        const action = {hidden: false, id: 'action-1'};
+        const plugin = createPlugin(async ids => ids.map(id => id === 'tab-overflow-test-owner'
+            ? {height: 300, left: 0, top: 0, width: 240, x: 0, y: 0}
+            : id === action.id
+                ? {height: 20, left: 200, top: 240, width: 20, x: 200, y: 240}
+                : {height: 130, width: 110}));
+
+        await new Promise(resolve => setTimeout(resolve, 0));
+
+        plugin.owner.getActionItems = () => [action];
+
+        const geometry = {
+            bottom: {actionAlign: 'r0-l0', dimension: 'width',  maxSize: 'maxWidth',  ownerAlign: 'r0-r0'},
+            left  : {actionAlign: 'b0-t0', dimension: 'height', maxSize: 'maxHeight', ownerAlign: 'b0-b0'},
+            right : {actionAlign: 'b0-t0', dimension: 'height', maxSize: 'maxHeight', ownerAlign: 'b0-b0'},
+            top   : {actionAlign: 'r0-l0', dimension: 'width',  maxSize: 'maxWidth',  ownerAlign: 'r0-r0'}
+        };
+
+        Object.entries(geometry).forEach(([dock, expected]) => {
+            plugin.owner.dock = dock;
+            expect(plugin.getMainAxisConfig()).toEqual(expected);
+            expect(plugin.getControlAlign()).toEqual({edgeAlign: expected.actionAlign, target: action.id})
+        });
+
+        let split;
+        plugin.applySplit = (hidden, buttons, tabContainer, activeCap) => {
+            split = {activeCap, hidden}
+        };
+
+        plugin.owner.dock = 'top';
+        plugin.naturalWidths = {b1: 110, b2: 110};
+        await plugin.project(false);
+
+        expect(split.hidden, 'the first action starts at x=200 despite its 20px width').toEqual(['b2']);
+        expect(split.activeCap).toMatchObject({maxSize: 'maxWidth', usable: 160});
+
+        const bothButtons = plugin.owner.items;
+        plugin.owner.items = [bothButtons[0]];
+        plugin.naturalWidths = {b1: 230};
+        await plugin.project(false);
+
+        expect(split.hidden, 'one over-wide active tab stays visible without creating a menu').toEqual([]);
+        expect(split.activeCap, 'the action boundary still caps that sole tab')
+            .toMatchObject({maxSize: 'maxWidth', usable: 200});
+
+        plugin.owner.items = bothButtons;
+
+        plugin.owner.dock = 'right';
+        plugin.naturalWidths = {b1: 130, b2: 130};
+        await plugin.project(false);
+
+        expect(split.hidden, 'the first action starts at y=240 despite its 20px height').toEqual(['b2']);
+        expect(split.activeCap).toMatchObject({maxSize: 'maxHeight', usable: 200});
+
+        action.hidden = true;
+        expect(plugin.getControlAlign(), 'consumer-hidden actions do not reserve or anchor the control')
+            .toEqual({edgeAlign: 'b0-b0', target: plugin.owner.id});
+
+        action.hideMode = 'visibility';
+        expect(plugin.getControlAlign(), 'visibility-hidden actions keep their reserved boundary')
+            .toEqual({edgeAlign: 'b0-t0', target: action.id})
+    });
+
+    test('a projection requested during tab sorting queues until the stable snapshot is released', async () => {
+        let measureCalls = 0,
+            releaseDrag;
+
+        const plugin = createPlugin(async ids => {
+            measureCalls++;
+            return ids[0] === 'tab-overflow-test-owner'
+                ? [{height: 300, left: 0, top: 0, width: 1000, x: 0, y: 0}]
+                : [{height: 20, width: 20}, {height: 20, width: 20}]
+        });
+
+        await new Promise(resolve => setTimeout(resolve, 0));
+
+        const beforeDragMeasures = measureCalls;
+
+        plugin.owner.sortZone = {
+            dragEndActive: false,
+            startIndex   : 1,
+            on(eventName, fn, scope) {
+                eventName === 'dragEnd' && (releaseDrag = () => fn.call(scope))
+            },
+            un() {}
+        };
+
+        await plugin.project(false);
+
+        expect(measureCalls, 'held geometry performs no new DOM measurement').toBe(beforeDragMeasures);
+        expect(plugin.sortDragProjectionQueued).toBe(true);
+        expect(plugin.sortDragRecaptureQueued).toBe(false);
+
+        plugin.owner.sortZone.dragEndActive = true;
+        plugin.owner.sortZone.startIndex    = -1;
+        releaseDrag();
+
+        // A tab mutation arrives in the terminal gap. Its recapture intent must join the already
+        // scheduled drain rather than being stranded behind the consumed dragEnd event.
+        await plugin.project(true);
+        expect(plugin.sortDragRecaptureQueued, 'the terminal-gap recapture remains sticky').toBe(true);
+
+        // Dock post-cleanup can keep the latch beyond the first timer task.
+        setTimeout(() => {plugin.owner.sortZone.dragEndActive = false}, 25);
+        await new Promise(resolve => setTimeout(resolve, 60));
+
+        expect(measureCalls, 'one projection drains after the terminal').toBeGreaterThan(beforeDragMeasures);
+        expect(plugin.sortDragProjectionQueued).toBe(false);
+        expect(plugin.sortDragRecaptureQueued).toBe(false);
+
+        plugin.destroy()
+    });
+
+    test('an in-flight measurement hands off when a sort snapshot begins before applySplit', async () => {
+        const plugin = createPlugin(async ids => ids[0] === 'tab-overflow-test-owner'
+            ? [{height: 300, left: 0, top: 0, width: 1000, x: 0, y: 0}]
+            : [{height: 20, width: 20}, {height: 20, width: 20}]);
+
+        await new Promise(resolve => setTimeout(resolve, 0));
+
+        let applyCalls = 0,
+            releaseDrag,
+            releaseMeasure,
+            signalMeasure;
+
+        const measureStarted = new Promise(resolve => {signalMeasure = resolve}),
+              measureGate    = new Promise(resolve => {releaseMeasure = resolve});
+
+        plugin.naturalWidths = {b1: 20, b2: 20};
+        plugin.applySplit = () => {applyCalls++};
+        plugin.owner.sortZone = {
+            dragEndActive: false,
+            startIndex   : -1,
+            on(eventName, fn, scope) {
+                eventName === 'dragEnd' && (releaseDrag = () => fn.call(scope))
+            },
+            un() {}
+        };
+        plugin.owner.getDomRect = async () => {
+            signalMeasure();
+            await measureGate;
+            return [{height: 300, left: 0, top: 0, width: 1000, x: 0, y: 0}]
+        };
+
+        const projection = plugin.project(false);
+
+        await measureStarted;
+        plugin.owner.sortZone.startIndex = 1;
+        releaseMeasure();
+        await projection;
+
+        expect(applyCalls, 'a pre-drag measurement cannot mutate beneath the new snapshot').toBe(0);
+        expect(plugin.sortDragProjectionQueued).toBe(true);
+
+        plugin.owner.sortZone.dragEndActive = true;
+        plugin.owner.sortZone.startIndex    = -1;
+        releaseDrag();
+        setTimeout(() => {plugin.owner.sortZone.dragEndActive = false}, 15);
+        await new Promise(resolve => setTimeout(resolve, 40));
+
+        expect(applyCalls, 'the handed-off projection drains once after the terminal').toBe(1);
+
+        plugin.destroy()
+    });
+
+    test('snapshot preparation waits for an in-flight recapture to restore its final split', async () => {
+        const plugin = createPlugin(async ids => ids[0] === 'tab-overflow-test-owner'
+            ? [{height: 25, left: 0, top: 0, width: 1000, x: 0, y: 0}]
+            : [{height: 20, width: 50}, {height: 20, width: 50}]);
+
+        await new Promise(resolve => setTimeout(resolve, 0));
+
+        let releaseUpdate,
+            signalUpdate;
+
+        const updateStarted = new Promise(resolve => {signalUpdate = resolve}),
+              updateGate    = new Promise(resolve => {releaseUpdate = resolve}),
+              makeButton    = (id, hidden=false) => ({
+                  cls     : [],
+                  hidden,
+                  id,
+                  maxWidth: null,
+                  vdom    : hidden ? {removeDom: true} : {},
+                  addCls(value) { !this.cls.includes(value) && this.cls.push(value) },
+                  removeCls(value) { this.cls = this.cls.filter(item => item !== value) },
+                  setSilent(values) { Object.assign(this, values) },
+                  show() {
+                      this.hidden = false;
+                      delete this.vdom.removeDom
+                  }
+              }),
+              buttons = [makeButton('b1'), makeButton('b2', true)];
+
+        plugin.owner.items = buttons;
+        plugin.owner.getDomRect = async ids => ids[0] === 'tab-overflow-test-owner'
+            ? [{height: 25, left: 0, top: 0, width: 70, x: 0, y: 0}]
+            : [{height: 20, width: 50}, {height: 20, width: 50}];
+        plugin.owner.promiseUpdate = async () => {
+            signalUpdate();
+            await updateGate
+        };
+        plugin.owner.update = () => {};
+        plugin.naturalWidths = {b1: 50, b2: 50};
+        plugin.syncControl = () => {};
+
+        const recapture = plugin.project(true);
+
+        await updateStarted;
+        expect(buttons[1].hidden, 'recapture temporarily restores the hidden tab').toBe(false);
+
+        plugin.owner.sortZone = {
+            dragEndActive      : false,
+            sortSnapshotPending: true,
+            startIndex         : -1,
+            on() {},
+            un() {}
+        };
+
+        const idle = plugin.whenProjectionIdle();
+
+        releaseUpdate();
+        await recapture;
+        await idle;
+
+        expect(buttons[1].hidden,
+            'the restoring split commits before snapshot preparation is released').toBe(true);
+        expect(plugin.sortDragProjectionQueued).toBe(false);
+
+        plugin.owner.sortZone.sortSnapshotPending = false;
+        plugin.destroy()
+    });
+
+    test('destroy releases projection-idle waiters without a dead-owner snapshot callback', async () => {
+        const plugin = createPlugin(async ids => ids[0] === 'tab-overflow-test-owner'
+            ? [{height: 300, left: 0, top: 0, width: 1000, x: 0, y: 0}]
+            : [{height: 20, width: 20}, {height: 20, width: 20}]);
+
+        await new Promise(resolve => setTimeout(resolve, 0));
+
+        plugin.measuring = true;
+        const waiter = plugin.whenProjectionIdle();
+
+        plugin.destroy();
+        await waiter;
+
+        expect(plugin.isDestroyed).toBe(true);
+        expect(() => plugin.onSortSnapshotReady()).not.toThrow()
     });
 
     test('re-arm: a transiently unmounted control re-mounts on the next sync — once, latched, aligned after the mount lands (#16434)', async () => {
@@ -596,13 +855,16 @@ test.describe('Neo.tab.plugin.Overflow (cap ownership + reservation lifecycle)',
         /** A toolbar-owner stub with the parent seam the active-button resolution needs. */
         createCapPlugin = ({buttons, getDomRect}) => Neo.create(Overflow, {
             owner: {
-                id      : 'cap-owner',
-                appName : 'test-app',
-                items   : buttons,
-                mounted : true,
-                parent  : {activeIndex: 0, on() {}},
-                theme   : 'neo-theme-neo-dark',
-                windowId: 1,
+                id            : 'cap-owner',
+                appName       : 'test-app',
+                items         : buttons,
+                mounted       : true,
+                parent        : {activeIndex: 0, on() {}, un() {}},
+                theme         : 'neo-theme-neo-dark',
+                windowId      : 1,
+                dock          : 'top',
+                getActionItems: () => [],
+                getTabButtons : () => buttons,
                 getDomRect,
                 getTheme() { return this.theme },
                 add            : () => ({}),
@@ -708,7 +970,8 @@ test.describe('Neo.tab.plugin.Overflow (cap ownership + reservation lifecycle)',
             await settle();
 
             // Stage 1 — capped: provenance recorded with the caller's own ceiling.
-            expect(plugin.appliedCaps?.get('b1'), 'the caller value is recorded at cap time').toBe(300);
+            expect(plugin.appliedCaps?.get('b1'), 'the caller value is recorded at cap time')
+                .toEqual({maxSize: 'maxWidth', value: 300});
             expect(b1.maxWidth, 'the cap overrides through the same public channel').toBe(236 - 40);
             expect(b1.cls, 'the cap marker is present').toContain('neo-tab-overflow-capped');
 
@@ -716,7 +979,8 @@ test.describe('Neo.tab.plugin.Overflow (cap ownership + reservation lifecycle)',
             // split re-caps; the recorded provenance survives un-overwritten.
             await plugin.project(true);
 
-            expect(plugin.appliedCaps?.get('b1'), 'recapture must not re-record the plugin cap as prior').toBe(300);
+            expect(plugin.appliedCaps?.get('b1'), 'recapture must not re-record the plugin cap as prior')
+                .toEqual({maxSize: 'maxWidth', value: 300});
             expect(b1.maxWidth, 'the re-applied cap holds after recapture').toBe(236 - 40);
 
             // Stage 3 — the overflow retires: the exact caller value returns.
@@ -732,6 +996,48 @@ test.describe('Neo.tab.plugin.Overflow (cap ownership + reservation lifecycle)',
             Neo.create = origCreate;
             control.destroy()
         }
+    })
+
+    test('a dock-axis change retires the old cap before owning the new max-size channel', async () => {
+        const
+            b1     = makeCapButton('b1', {maxHeight: 250, maxWidth: 300}),
+            plugin = createCapPlugin({
+                buttons   : [b1],
+                getDomRect: async () => [{height: 1000, width: 1000}]
+            });
+
+        await settle();
+
+        plugin.naturalWidths = {b1: 500};
+        plugin.applySplit([], [b1], plugin.owner.parent, {
+            activeButton: b1,
+            maxSize     : 'maxWidth',
+            usable      : 196
+        });
+
+        expect(b1.maxWidth).toBe(196);
+        expect(plugin.appliedCaps.get('b1')).toEqual({maxSize: 'maxWidth', value: 300});
+
+        plugin.applySplit([], [b1], plugin.owner.parent, {
+            activeButton: b1,
+            maxSize     : 'maxHeight',
+            usable      : 180
+        });
+
+        expect(b1.maxWidth, 'the retired horizontal channel returns to the caller').toBe(300);
+        expect(b1.maxHeight).toBe(180);
+        expect(plugin.appliedCaps.get('b1')).toEqual({maxSize: 'maxHeight', value: 250});
+
+        plugin.applySplit([], [b1], plugin.owner.parent, {
+            activeButton: b1,
+            maxSize     : 'maxHeight',
+            usable      : null
+        });
+
+        expect(b1.maxHeight, 'clearing restores the new-axis caller value').toBe(250);
+        expect(plugin.appliedCaps.size).toBe(0);
+
+        plugin.destroy()
     })
 });
 


### PR DESCRIPTION
Resolves #17418

Adds optional flat action groups to existing toolbar composition and makes TabContainer treat tabs, actions, and the owned spacer as explicit semantic collections. Dialog keeps its established action contract; TabContainer gains focus-contextual actions, action-safe sorting, action-exclusive Overflow geometry, and stable semantic lookup. `Neo.code.LivePreview` now consumes the generic API, and the TabContainer example demonstrates persistent/contextual actions plus native Overflow.

Evidence: L3 (canonical pointer/keyboard/popup/four-axis Overflow/held-drag/runtime-replacement Whitebox journey green 1/1 and required CI green 22/22 at exact head `13ecfc2c1a`) → L3 required (the same rendered interaction journey). Residual: none.

## Deltas from ticket

- Added `getActionItem(action)` alongside the ticket's semantic collection views so LivePreview no longer retains tree references for header actions.
- Made the tab SortZone and Overflow coordinate one stable gesture snapshot: in-flight recaptures finish before snapshot admission, new projections queue, and the latest sticky recapture drains after the exact terminal latch.
- Made dock-axis changes recapture tab extents from the post-render ResizeObserver edge; an exact-head live falsifier caught the pre-render cache reading horizontal heights during vertical layout.
- Completed `Neo.tab.header.EffectButton`'s runtime active-indicator contract because the public tab marker admits both header button implementations.
- Extended the canonical TabContainer example with naturally focusable bodies, persistent/contextual next/previous actions, and an Overflow plugin.
- Removed `Neo.menu.List`'s stale local `parentComponent` field, which shadowed the inherited reactive config and severed the generated Overflow menu's logical focus ancestry. The exact host E2E falsified this edge before the repair.
- Added the requested runtime `headerActions` replacement falsifier through `Toolbar#syncActions`; rendered visibility, role, `aria-hidden`, inertness, tab order, and semantic tab-count assertions prove the existing ordering is safe without a production change.
- Kept Dock close execution and document policy out of scope; that remains in the dependent ticket.

Related: #17419

Decision Record impact: None. This remains the low-blast feature reuse graduated from [Discussion 17415](https://github.com/neomjs/neo/discussions/17415).

## Test Evidence

- Focus/menu/action/Overflow neighborhood: `npm run test-unit -- test/playwright/unit/manager/Focus.spec.mjs test/playwright/unit/manager/domEvent/Delegation.spec.mjs test/playwright/unit/tab/HeaderActions.spec.mjs test/playwright/unit/tab/plugin/Overflow.spec.mjs` — 49/49 green after the menu-ancestry repair.
- Drag/Dock consumers: `npm run test-unit -- test/playwright/unit/draggable/DragZone.spec.mjs test/playwright/unit/draggable/container/SortZone.spec.mjs test/playwright/unit/dashboard/DockProjectionReconciler.spec.mjs test/playwright/unit/dashboard/DockTabSortZone.spec.mjs` — green; combined pre-repair battery 115/115.
- Required CI: 22/22 green at exact head `13ecfc2c1a`, including unit, components, integration-unified, integration-parity, CodeQL, and every lint/guard job.
- Whitebox: `npx playwright test test/playwright/e2e/tab/TabHeaderActionsNL.spec.mjs -c test/playwright/playwright.config.e2e.mjs --workers=1` — 1/1 passed (2.9s test, 7.8s total) on the browser-capable host at exact head `13ecfc2c1a`. The journey covers natural pointer + reverse-tab focus, generated-menu retention, all four rendered Overflow axes, action-coordinate drag traces, held-drag width mutation, and runtime contextual-action replacement through `syncActions` with rendered DOM/a11y assertions.
- Whitebox falsifier/repair: the first host run reached the generated Overflow menu and showed the contextual action becoming inactive. An executable instance probe found `menu` as a one-node logical path because the local field shadowed the inherited config; after `5f3d7ef589`, the path is `menu → overflow control → header toolbar → TabContainer`, and the same host journey is green.
- Source-mode Neural Link exploration: verified flat tab/spacer/action structure, semantic roles/names, contextual inert/visibility state, body-arm/action-retain/outside-disarm, and one main-axis-aligned Overflow control on top, right, bottom, and left with the active tab reachable and the action rail reserved.
- Build/static: `npm run build-themes -- -n -e dev -t all`, `npm run check-theme-surfaces`, `npm run check-examples-body-only`, generated-doc `npm run check-reactive-tags`, syntax checks, `git diff --check`, and check-only `agent-preflight` all completed.

## Commits

- `66b9b9dc94` — flat actions, semantic tab/drag/focus contracts, LivePreview/example migration, and coverage.
- `a86f7f084c` — post-render dock-axis Overflow recapture from the live four-axis falsifier.
- `5f3d7ef589` — retain the generated Overflow menu's logical focus ancestry and pin it in unit/Whitebox coverage.
- `13ecfc2c1a` — cover runtime contextual-action replacement and wait for rendered four-axis control alignment.

## Post-Merge Validation

None. The canonical browser journey is complete before review.

## Signal Ledger

- GPT author family: low-blast graduation and implementation.
- Claude non-author family: Discussion convergence plus three independent current-diff audit passes; all concrete findings were repaired before commit.

## Unresolved Dissent

None.

## Unresolved Liveness

None. Exact-head required CI is green and the canonical Whitebox journey is complete before re-review.

Authored by Emmy (GPT-5.6 Sol Ultra, Codex). Session 0f8b5b8e-3f01-45c8-889e-1c2fd90b0584.
