### PR TITLE
feat(ai): both outer lease holders vote, and the vote reaches the sweep (#17398)

### DIFF
--- a/ai/daemons/orchestrator/scheduling/pipeline.mjs
+++ b/ai/daemons/orchestrator/scheduling/pipeline.mjs
@@ -449,14 +449,19 @@ function executeServiceRunnerCandidate({candidate, activeHeavyTask, services, ru
             writeLog          : runtime.writeLog,
             devSyncRootsConfig: runtime.primaryDevSyncRootsConfig
         }),
-        'tenant-repo-sync': (taskName, reason) => services.tenantRepoSyncService.runTask({
+        // `taskOptions` is the fourth argument `acquireLeaseAndExecute` passes, and until now this
+        // runner dropped it — which is why the scheduler's own acquisition could not be yielded
+        // against even though it is the same outer lease the CLI takes. The sweep is long enough to
+        // outlive the hold bound, so it is exactly the shape that needs to ask.
+        'tenant-repo-sync': (taskName, reason, onSuccess, taskOptions) => services.tenantRepoSyncService.runTask({
             taskName,
             reason,
             taskStateService: services.taskStateService,
             healthService   : services.healthService,
             writeLog        : runtime.writeLog,
             globalCadenceMs : runtime.tenantRepoSyncGlobalCadenceMs,
-            jitterRatio     : runtime.tenantRepoSyncJitterRatio
+            jitterRatio     : runtime.tenantRepoSyncJitterRatio,
+            leaseYieldVoter : taskOptions?.leaseYieldVoter ?? null
         })
     };
 

--- a/ai/daemons/orchestrator/scheduling/tenantRepoSync.mjs
+++ b/ai/daemons/orchestrator/scheduling/tenantRepoSync.mjs
@@ -113,6 +113,53 @@ export function createSliceBudgetPredicate({startedMs, sliceBudgetMs, now = Date
 }
 
 /**
+ * The yield causes, in precedence order. A cause is a string rather than a boolean because the two
+ * exits differ: a slice yield rotates to the next repo and keeps the lease, while a lease yield must
+ * stop admitting the tail, commit the active cohort's resumable state, and RELEASE the outer lease.
+ *
+ * `LEASE` outranks `SLICE` when both fire, and the ordering is the decision rather than an accident:
+ * the lease is the outer bound, its exit is the stricter one, and reporting the inner cause while the
+ * outer bound has been exceeded is how a holder keeps rotating past its own deadline.
+ * @type {String[]}
+ */
+export const YIELD_CAUSES = Object.freeze(['lease', 'slice']);
+
+/**
+ * @summary Folds named yield voters into one resolver that reports WHICH bound fired.
+ *
+ * Replaces a boolean OR over the same voters, and the difference is not stylistic. A predecessor
+ * returned `voters.some(voter => voter() === true)`, which reads as the tidier option and is the
+ * defect: every lease-exit step a consumer must take is conditional on the cause, so a resolver
+ * answering only "something said stop" makes the exit contract unexpressible. A sweep that cannot
+ * tell a lease yield from a slice yield keeps rotating, which is a holder that never releases.
+ *
+ * Voters are `{cause, vote}` pairs. Unknown causes are rejected rather than ignored, because a
+ * silently-dropped voter is a bound that stops binding while every call site still looks wired.
+ * A throwing voter propagates: swallowing turns a broken bound into starvation that reads as healthy.
+ *
+ * @param {Array<{cause: String, vote: Function}>} voters Named voters; non-function votes are dropped.
+ * @returns {Function} `() => (String|null)` — the highest-precedence firing cause, or null.
+ */
+export function createYieldCauseResolver(voters = []) {
+    const named = (Array.isArray(voters) ? voters : []).filter(entry => entry && typeof entry.vote === 'function'),
+          bad   = named.find(entry => !YIELD_CAUSES.includes(entry.cause));
+
+    if (bad) {
+        throw new TypeError(`createYieldCauseResolver: unknown yield cause '${bad.cause}'`)
+    }
+
+    return () => {
+        for (const cause of YIELD_CAUSES) {
+            if (named.some(entry => entry.cause === cause && entry.vote() === true)) {
+                return cause
+            }
+        }
+
+        return null
+    }
+}
+
+/**
  * Builds the trigger for the cloud-deployable tenant-repo-sync lane.
  * Mirror of `buildPrimaryRepoSyncTrigger` in `./primaryDevSync.mjs` — pure function;
  * no class, no Neo machinery, no side effects.

--- a/ai/daemons/orchestrator/scheduling/tenantRepoSync.mjs
+++ b/ai/daemons/orchestrator/scheduling/tenantRepoSync.mjs
@@ -113,6 +113,22 @@ export function createSliceBudgetPredicate({startedMs, sliceBudgetMs, now = Date
 }
 
 /**
+ * The outer bound: the acquisition has outlived the deployment-wide hold fairness bound.
+ * Named rather than spelled at each site because the voter is built in a config-aware module
+ * (`HeavyMaintenanceLeaseService`) while the vocabulary is owned here — two spellings of one
+ * cause would be accepted by neither side and rejected by {@link createYieldCauseResolver}
+ * only once a real deployment reached the bound.
+ * @type {String}
+ */
+export const YIELD_CAUSE_LEASE = 'lease';
+
+/**
+ * The inner bound: this repo's slice has outlived `sliceBudgetMs`.
+ * @type {String}
+ */
+export const YIELD_CAUSE_SLICE = 'slice';
+
+/**
  * The yield causes, in precedence order. A cause is a string rather than a boolean because the two
  * exits differ: a slice yield rotates to the next repo and keeps the lease, while a lease yield must
  * stop admitting the tail, commit the active cohort's resumable state, and RELEASE the outer lease.
@@ -122,7 +138,7 @@ export function createSliceBudgetPredicate({startedMs, sliceBudgetMs, now = Date
  * outer bound has been exceeded is how a holder keeps rotating past its own deadline.
  * @type {String[]}
  */
-export const YIELD_CAUSES = Object.freeze(['lease', 'slice']);
+export const YIELD_CAUSES = Object.freeze([YIELD_CAUSE_LEASE, YIELD_CAUSE_SLICE]);
 
 /**
  * @summary Folds named yield voters into one resolver that reports WHICH bound fired.

--- a/ai/daemons/orchestrator/services/HeavyMaintenanceLeaseService.mjs
+++ b/ai/daemons/orchestrator/services/HeavyMaintenanceLeaseService.mjs
@@ -11,11 +11,46 @@ import {
     shouldYieldHeavyMaintenanceLease,
     withHeavyMaintenanceLease
 } from './heavyMaintenanceLeasePrimitives.mjs';
+import {YIELD_CAUSE_LEASE} from '../scheduling/tenantRepoSync.mjs';
 
 // Re-export the pure lease primitives so every existing importer of this module keeps working unchanged.
 // The primitives live in a Neo/Base-free module so subprocess consumers (e.g. the kbSync VectorService)
 // can import the pure decider/lock functions without pulling in the orchestrator class stack.
 export * from './heavyMaintenanceLeasePrimitives.mjs';
+
+/**
+ * @summary Turns a lease acquisition into the named yield voter its task consults.
+ *
+ * The single config-aware home for the outer-lease fairness vote. Every heavy task that holds the
+ * deployment-wide lease and wants to stand down cooperatively builds its voter here, so the one
+ * trap this reading carries is spelled once: `maxActiveHoldMs` lives on
+ * `orchestrator.heavyMaintenance`, and the adjacent `orchestrator.heavyMaintenanceLease` holds only
+ * `staleAfterMs`. Reading the sibling yields `undefined`, a falsy bound never votes, and the result
+ * is a no-op that looks exactly like a wired predicate at every call site — indistinguishable from
+ * working until a deployment actually reaches the bound.
+ *
+ * Read at vote time rather than at build time: the leaf is reactive, and a bound captured when the
+ * task started would survive an operator changing it.
+ *
+ * **No acquisition ⇒ `null`, never a voter that always answers false.** The two are not equivalent
+ * to a caller: `null` composes away, while an always-false voter is a bound that reports "not yet"
+ * forever, which is the shape a reader cannot distinguish from a healthy one.
+ *
+ * @param {Object|null} acquisition The `withHeavyMaintenanceLease` / `acquireHeavyMaintenanceLease` descriptor (`{status, acquired, lease}`).
+ * @returns {{cause: String, vote: Function}|null} A `createYieldCauseResolver` voter, or `null` when this caller holds no lease.
+ */
+export function createLeaseYieldVoter(acquisition) {
+    if (!acquisition?.lease) {
+        return null
+    }
+
+    return {
+        cause: YIELD_CAUSE_LEASE,
+        vote : () => shouldYieldHeavyMaintenanceLease(acquisition.lease, {
+            maxActiveHoldMs: AiConfig.orchestrator.heavyMaintenance.maxActiveHoldMs
+        })
+    }
+}
 
 /**
  * @summary Shared lease service for Agent OS substrate-heavy maintenance work.

--- a/ai/daemons/orchestrator/services/MaintenanceBackpressureService.mjs
+++ b/ai/daemons/orchestrator/services/MaintenanceBackpressureService.mjs
@@ -5,6 +5,7 @@ import Base     from '../../../../src/core/Base.mjs';
 import AiConfig from '../../../config.mjs';
 import {
     acquireHeavyMaintenanceLeaseSync,
+    createLeaseYieldVoter,
     releaseHeavyMaintenanceLeaseSync,
     resolveHeavyMaintenanceLeasePath as resolveLeasePath
 } from './HeavyMaintenanceLeaseService.mjs';
@@ -891,7 +892,7 @@ export class MaintenanceBackpressureService extends Base {
      *
      * @param {Object} options
      * @param {String} options.taskName Stable orchestrator task name.
-     * @param {Function} options.executeFn Task body `(taskName, reason, onSuccess, taskOptions) => result`.
+     * @param {Function} options.executeFn Task body `(taskName, reason, onSuccess, taskOptions) => result`, where `taskOptions` is `{env, leaseYieldVoter, onComplete}` — all three derived from this acquisition.
      * @param {Object} [options.reason] Scheduling reason (string or trigger object).
      * @param {Function|null} [options.onSuccess=null] Success hook forwarded to `executeFn`.
      * @param {Object} options.activeHeavyTask Mutable `{name: String|null}` tracker for the current poll.
@@ -1040,9 +1041,15 @@ export class MaintenanceBackpressureService extends Base {
             }
         };
 
+        // Three things the task can only learn from THIS acquisition: the token to inherit, the
+        // release to call, and when the hold began. The third is what lets a long task stand down
+        // cooperatively instead of occupying the exclusive slot until it finishes — and a task that
+        // cannot ask is the mechanism behind waiters deferred for a day and a half under one holder.
+        // `null` when the compatible-pair bypass ran, because that candidate owns no lease to yield.
         const taskOptions = {
-            env       : leaseToken ? {NEO_HEAVY_MAINTENANCE_LEASE_INHERITED_TOKEN: leaseToken} : {},
-            onComplete: releaseLease
+            env            : leaseToken ? {NEO_HEAVY_MAINTENANCE_LEASE_INHERITED_TOKEN: leaseToken} : {},
+            leaseYieldVoter: leaseToken ? createLeaseYieldVoter(acquisition) : null,
+            onComplete     : releaseLease
         };
 
         let result;

--- a/ai/daemons/orchestrator/services/TenantRepoSyncService.mjs
+++ b/ai/daemons/orchestrator/services/TenantRepoSyncService.mjs
@@ -39,6 +39,7 @@ import {
 import {
     assertSliceBudgetMs,
     createSliceBudgetPredicate,
+    createYieldCauseResolver,
     classifyEmbeddingRecoveryState,
     detectStarvedTenantSync,
     hasPendingEmbeddingRecoveryBypass,
@@ -47,7 +48,8 @@ import {
     isStarvedOrderInverted,
     resolveMinimumBackoffCapMs,
     resolveRepoBaseCadenceMs,
-    resolveUnknownRepoSelectorFailure
+    resolveUnknownRepoSelectorFailure,
+    YIELD_CAUSE_SLICE
 } from '../scheduling/tenantRepoSync.mjs';
 import {
     KB_TENANT_REPO_SYNC_CONTENT_NOT_EMBEDDABLE,
@@ -1420,6 +1422,11 @@ class TenantRepoSyncService extends Base {
         onlyRepoSlugs,
         fullReplay = false,
         revisionsFilePath,
+        // The OUTER lease's fairness vote, supplied by whichever acquisition dispatched this run —
+        // the scheduler's via `taskOptions`, the CLI's from its own `withLease` descriptor. Absent
+        // for every in-process caller that holds no outer lease, which is why the default is `null`
+        // rather than a predicate: see `createLeaseYieldVoter` for why those are not equivalent.
+        leaseYieldVoter   = null,
         envelopeBuilder   = buildIngestEnvelope,
         globalCadenceMs   = AiConfig.data.orchestrator.intervals.tenantRepoSyncMs,
         jitterRatio       = AiConfig.data.orchestrator.tenantRepoSync.jitterRatio,
@@ -1584,6 +1591,7 @@ class TenantRepoSyncService extends Base {
             const result = await this.syncTenantRepos({
                 writeLog, tenantReposConfig, gitMirror, knowledgeBaseIngestionService, onlyRepoSlugs,
                 fullReplay, taskStateService, healthService, taskName, envelopeBuilder, leaseGuard,
+                leaseYieldVoter,
                 leasePath        : resolvedLeasePath,
                 revisionsFilePath: resolvedRevisionsPath,
                 globalCadenceMs, jitterRatio, backoffCapMs, starvedAfterMs, seedBootstrap,
@@ -1654,6 +1662,11 @@ class TenantRepoSyncService extends Base {
         fullReplay = false, taskStateService, healthService, taskName, revisionsFilePath, envelopeBuilder = buildIngestEnvelope,
         leaseGuard         = async () => {},
         leasePath          = null,
+        // Declared HERE, beside the budget it composes with, and not one frame higher on `runTask`:
+        // the per-repo vote is built inside this method's try, so a parameter declared only on the
+        // caller is an out-of-scope reference the repo-level catch converts into an ordinary repo
+        // failure — a sweep reporting no cause while the bound it was given is never consulted.
+        leaseYieldVoter    = null,
         globalCadenceMs    = AiConfig.data.orchestrator.intervals.tenantRepoSyncMs,
         jitterRatio        = AiConfig.data.orchestrator.tenantRepoSync.jitterRatio,
         backoffCapMs       = AiConfig.data.orchestrator.tenantRepoSync.backoffCapMs,
@@ -2382,6 +2395,26 @@ class TenantRepoSyncService extends Base {
                         !== priorState?.lastCommittedMaterializationAttemptId
                         ? existingManifest.materializationReceipt
                         : null,
+                    // Two bounds, neither subsuming the other. The SLICE budget is per-repo, anchored
+                    // at THIS repo's admission: the envelope is built once and shared by the whole
+                    // sweep, so a budget shared that way would be spent by the first admitted repo and
+                    // every later one born already expired — a fairness fix that starves the tail it
+                    // serves. The LEASE bound is the outer one, measured from the acquisition that
+                    // dispatched the sweep, and it is fairness between TASKS rather than between repos:
+                    // honouring every per-repo budget still occupies the exclusive heavy slot for
+                    // roughly N × sliceBudgetMs, which is how waiters starve while every bound the
+                    // holder can see reads satisfied.
+                    //
+                    // Resolved to a CAUSE rather than a boolean because the two exits differ, and the
+                    // exits belong to a separate dependent change. Stopping tail admission, committing
+                    // the cohort and releasing the outer lease are deliberately absent here: this makes
+                    // the cause readable, and the sweep below still consumes only the boolean
+                    // projection. With a null voter that projection is the slice predicate's own
+                    // answer, byte for byte, which keeps every caller holding no outer lease unchanged.
+                    yieldCause = createYieldCauseResolver([
+                        leaseYieldVoter,
+                        {cause: YIELD_CAUSE_SLICE, vote: createSliceBudgetPredicate({startedMs, sliceBudgetMs})}
+                    ]),
                     rawSummary = retryReceipt
                         ? {
                             ingested              : 0,
@@ -2395,11 +2428,7 @@ class TenantRepoSyncService extends Base {
                             viaMcp: false // operator-bulk path
                         }, {
                             ...providerCircuitControls,
-                            // Per-repo, anchored at THIS repo's admission. The envelope above is
-                            // built once and shared by the whole sweep; a budget shared that way
-                            // would be spent by the first admitted repo and every later one born
-                            // already expired — a fairness fix that starves the tail it serves.
-                            shouldYield: createSliceBudgetPredicate({startedMs, sliceBudgetMs})
+                            shouldYield: () => yieldCause() !== null
                         });
 
                 // Emitted before BOTH guards on this path, which is what makes it useful:

--- a/ai/scripts/maintenance/syncKnowledgeBase.mjs
+++ b/ai/scripts/maintenance/syncKnowledgeBase.mjs
@@ -10,8 +10,8 @@ import KB_DatabaseService  from '../../services/knowledge-base/DatabaseService.m
 import KB_ChromaManager    from '../../services/knowledge-base/ChromaManager.mjs';
 import KB_LifecycleService from '../../services/knowledge-base/DatabaseLifecycleService.mjs';
 import {
+    createLeaseYieldVoter,
     resolveHeavyMaintenanceLeasePath,
-    shouldYieldHeavyMaintenanceLease,
     withHeavyMaintenanceLease
 } from '../../daemons/orchestrator/services/HeavyMaintenanceLeaseService.mjs';
 import {fileURLToPath}                                               from 'node:url';
@@ -36,18 +36,25 @@ import {fileURLToPath}                                               from 'node:
 const logProgress = (...args) => console.error('[INFO]', ...args);
 
 /**
- * Builds the cooperative heavy-maintenance-lease yield predicate from a lease acquisition descriptor.
- * Reads the active-hold fairness bound from the AiConfig leaf at the use site (per call, never module-load-captured). Exported so a
- * boundary test can assert this script reads the correct config branch — `orchestrator.heavyMaintenance`
- * (which holds `maxActiveHoldMs`), NOT the sibling `orchestrator.heavyMaintenanceLease` (which holds only
- * `staleAfterMs`). The direct VectorService embed seam cannot prove the script-level config wiring.
+ * Adapts the shared lease yield voter to the bare predicate this script's embed loop consults.
+ * Kept exported so the existing boundary test still asserts THIS script reaches the correct config
+ * branch — `orchestrator.heavyMaintenance` (which holds `maxActiveHoldMs`), NOT the sibling
+ * `orchestrator.heavyMaintenanceLease` (which holds only `staleAfterMs`); the direct VectorService
+ * embed seam cannot prove the script-level config wiring.
+ *
+ * The reading itself moved to `createLeaseYieldVoter`, which is now the single site that knows the
+ * branch. Two copies of one config read is how the sibling-leaf trap gets fixed in one place and
+ * left standing in the other.
+ *
+ * The no-lease fallback is `() => false` rather than the voter's `null`, and that is not a widening:
+ * `shouldYieldHeavyMaintenanceLease` returns `false` for a missing lease (`!lease` is its first
+ * guard), so the previous body answered `false` on that input too. This loop wants a callable.
+ *
  * @param {{lease: Object}} acquisition The `withHeavyMaintenanceLease` descriptor (`{status, acquired, lease}`).
  * @returns {Function} A zero-arg predicate the shadow-swap embed loop consults between batches.
  */
 export function buildLeaseYieldPredicate(acquisition) {
-    return () => shouldYieldHeavyMaintenanceLease(acquisition.lease, {
-        maxActiveHoldMs: AiConfig.orchestrator.heavyMaintenance.maxActiveHoldMs
-    });
+    return createLeaseYieldVoter(acquisition)?.vote ?? (() => false);
 }
 
 /**

--- a/ai/scripts/maintenance/syncTenantRepos.mjs
+++ b/ai/scripts/maintenance/syncTenantRepos.mjs
@@ -35,6 +35,7 @@ import {pathToFileURL} from 'url';
 import AiConfig              from '../../config.mjs';
 import TenantRepoSyncService from '../../daemons/orchestrator/services/TenantRepoSyncService.mjs';
 import {
+    createLeaseYieldVoter,
     resolveHeavyMaintenanceLeasePath,
     withHeavyMaintenanceLease
 } from '../../daemons/orchestrator/services/HeavyMaintenanceLeaseService.mjs';
@@ -150,13 +151,15 @@ function createInMemoryTaskStateService() {
  * @param {{fullReplay: Boolean, repoSlugs: String[]}} options.parsed
  * @param {Object} options.taskStateService
  * @param {Function} options.writeLog
+ * @param {{cause: String, vote: Function}|null} [options.leaseYieldVoter] The outer acquisition's fairness vote; `null` when this run holds no outer lease.
  * @returns {Object}
  */
-function buildRunTaskOptions({parsed, taskStateService, writeLog}) {
+function buildRunTaskOptions({parsed, taskStateService, writeLog, leaseYieldVoter = null}) {
     return {
         reason       : 'manual',
         taskStateService,
         writeLog,
+        leaseYieldVoter,
         onlyRepoSlugs: parsed.repoSlugs.length > 0 ? parsed.repoSlugs : undefined,
         fullReplay   : parsed.fullReplay
     }
@@ -193,12 +196,22 @@ function runTenantRepoSyncWithGlobalLease({
     // end. Outside the lease this would race a sweep mid-flight and could drop a checkpoint the
     // sweep had just committed — losing ingestion progress to fix a backoff, which is a strictly
     // worse trade than the wait it removes.
+    // The sweep receives the acquisition's fairness vote; the clear-backoff branch receives none, and
+    // that asymmetry is the point. The clear is a short manifest rewrite that must finish atomically —
+    // a yield partway through leaves a half-applied clear, which is worse than holding the lease a few
+    // seconds past the bound. `withLease` hands the acquisition descriptor to its task, which is the
+    // only place this process can learn when its own hold began.
     const invoke = parsed.clearBackoff
         ? () => clearBackoffImpl({
             onlyRepoSlugs: parsed.repoSlugs.length > 0 ? parsed.repoSlugs : null,
             writeLog
         })
-        : () => runTaskImpl(buildRunTaskOptions({parsed, taskStateService, writeLog}));
+        : acquisition => runTaskImpl(buildRunTaskOptions({
+            parsed,
+            taskStateService,
+            writeLog,
+            leaseYieldVoter: createLeaseYieldVoter(acquisition)
+        }));
 
     return withLease(
         invoke,

--- a/test/playwright/unit/ai/daemons/orchestrator/leaseYieldVoterWiring.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/leaseYieldVoterWiring.spec.mjs
@@ -291,18 +291,11 @@ test.describe('#17398 — the outer lease fairness voter, per acquisition path',
         }
     });
 
-    test('CONSUMPTION IS ABSENT: the sweep consumes a Boolean, so no exit branch can read the cause', () => {
-        // The three lease-exit steps belong to a separate dependent change. This arm fixes the
-        // boundary between them: the projection the sweep passes downstream is a Boolean, so an
-        // implementation here CANNOT have started branching on the cause. The successor changes this
-        // arm deliberately, which is the point — the boundary moves on the record, not by drift.
-        const resolver = createYieldCauseResolver([
-                  {cause: YIELD_CAUSE_LEASE, vote: () => true},
-                  {cause: YIELD_CAUSE_SLICE, vote: () => false}
-              ]),
-              projection = () => resolver() !== null;
-
-        expect(resolver(), 'the cause is available…').toBe(YIELD_CAUSE_LEASE);
-        expect(typeof projection(), '…and the sweep still receives only a Boolean').toBe('boolean');
-    });
+    // The "consumption is absent" boundary used to live here as a fixture-local resolver plus a
+    // `typeof … === 'boolean'` assertion. It was synthetic: it never entered `TenantRepoSyncService`,
+    // so it stayed green whatever the sweep did — including if the sweep had begun stopping tail
+    // admission or releasing the outer lease, which is exactly the behaviour it claimed to pin.
+    // Moved to `services/TenantRepoSyncService.spec.mjs`, where the sweep harness lives, as a
+    // two-repo production-path arm. Recorded here so the next reader does not re-add the cheap
+    // version beside its siblings and believe the boundary is guarded twice.
 });

--- a/test/playwright/unit/ai/daemons/orchestrator/leaseYieldVoterWiring.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/leaseYieldVoterWiring.spec.mjs
@@ -1,0 +1,308 @@
+import {test, expect} from '@playwright/test';
+import Neo            from '../../../../../../src/Neo.mjs';
+import * as core      from '../../../../../../src/core/_export.mjs';
+import {
+    DEFAULT_COMPATIBLE_HEAVY_MAINTENANCE_TASK_PAIRS,
+    DEFAULT_GOLDEN_PATH_DEPENDENCY_TASK_NAMES,
+    DEFAULT_HEAVY_MAINTENANCE_TASK_NAMES,
+    MaintenanceBackpressureService
+} from '../../../../../../ai/daemons/orchestrator/services/MaintenanceBackpressureService.mjs';
+import {createLeaseYieldVoter}            from '../../../../../../ai/daemons/orchestrator/services/HeavyMaintenanceLeaseService.mjs';
+import {executeCandidate}                 from '../../../../../../ai/daemons/orchestrator/scheduling/pipeline.mjs';
+import {runTenantRepoSyncWithGlobalLease} from '../../../../../../ai/scripts/maintenance/syncTenantRepos.mjs';
+import {
+    createSliceBudgetPredicate,
+    createYieldCauseResolver,
+    YIELD_CAUSE_LEASE,
+    YIELD_CAUSE_SLICE
+} from '../../../../../../ai/daemons/orchestrator/scheduling/tenantRepoSync.mjs';
+
+/**
+ * @summary BOTH outer acquisitions of the `tenant-repo-sync` heavy lease must contribute a
+ * cause-bearing fairness vote, and each must be provable independently of the other.
+ *
+ * The premise this spec exists to hold is the one a previous ticket got wrong twice: there is not one
+ * outer holder. The CLI (`syncTenantRepos.mjs`, owner `tenant-repo-sync`) and the scheduler
+ * (`MaintenanceBackpressureService`, owner = the task name) take the SAME deployment-wide lease and
+ * are indistinguishable at the point where the vote is cast. A repo-level vote wired into one of them
+ * cannot terminate a hold the other owns — and the earlier implementation wired the CLI only, and was
+ * thoroughly tested that way, which is exactly the evidence that produced a false owner discriminator.
+ *
+ * So each of the three production propagation edges gets its OWN arm, and the arms are specific rather
+ * than merely sensitive: deleting one edge must redden its arm and leave the other two green. A suite
+ * that goes red on any edit tells a later author that something broke, not which thing.
+ *
+ * | edge | production site | arm |
+ * |---|---|---|
+ * | the scheduler's acquisition builds a voter | `MaintenanceBackpressureService` `taskOptions` | SCHEDULER PATH |
+ * | the service-runner forwards it | `pipeline.mjs` `'tenant-repo-sync'` runner | RUNNER FORWARDING |
+ * | the CLI's acquisition builds a voter | `syncTenantRepos.mjs` `invoke` | CLI PATH |
+ *
+ * Consuming the cause — stopping tail admission, committing the active cohort, releasing the outer
+ * lease — belongs to a separate dependent change. This spec asserts that consumption is ABSENT here,
+ * so the two land and are reviewed independently.
+ */
+
+/**
+ * An acquisition descriptor whose hold is older than any bound a deployment could sanely configure.
+ *
+ * The epoch rather than a value derived from the config leaf, and that is the deliberate choice: a
+ * spec that read `AiConfig` to place its fixture would be reading the repo-local OVERLAY, which is
+ * gitignored and free to differ between this machine and CI, which `lint-config-template-ssot`
+ * refuses. Anchoring outside every plausible bound keeps the arm's subject the COMPARISON rather
+ * than the number, and both mutations that matter still redden it: a flipped operator inverts this
+ * fixture and its fresh sibling together, and a bound resolved from the wrong config leaf is
+ * non-finite, which the primitive answers `false` to.
+ * @returns {Object}
+ */
+const overBoundAcquisition = () => ({
+    acquired: true,
+    status  : 'acquired',
+    lease   : {token: 'over-bound', acquiredAt: new Date(0).toISOString()}
+});
+
+/**
+ * An acquisition descriptor a second old — inside any bound a deployment could sanely configure.
+ * @returns {Object}
+ */
+const freshAcquisition = () => ({
+    acquired: true,
+    status  : 'acquired',
+    lease   : {token: 'fresh', acquiredAt: new Date(Date.now() - 1000).toISOString()}
+});
+
+/**
+ * A `MaintenanceBackpressureService` with the lease acquire/release stubbed, so the arms observe what
+ * the service HANDS a task rather than what a real lease file does.
+ * @param {Object} acquisition The descriptor `acquireLeaseFn` returns.
+ * @returns {MaintenanceBackpressureService}
+ */
+function buildService(acquisition) {
+    return Neo.create(MaintenanceBackpressureService, {
+        heavyMaintenanceTaskNames          : DEFAULT_HEAVY_MAINTENANCE_TASK_NAMES,
+        goldenPathDependencyTaskNames      : DEFAULT_GOLDEN_PATH_DEPENDENCY_TASK_NAMES,
+        compatibleHeavyMaintenanceTaskPairs: DEFAULT_COMPATIBLE_HEAVY_MAINTENANCE_TASK_PAIRS,
+        acquireLeaseFn                     : () => acquisition,
+        releaseLeaseFn                     : () => {},
+        resolveHeavyMaintenanceLeasePath   : () => '/tmp/unused-lease-path.json',
+        taskStateService                   : {getTaskState: () => null},
+        writeLog                           : () => {},
+        listActiveWaitersFn                : () => ({waiters: [], unreadable: []}),
+        registerWaiterFn                   : () => {},
+        clearWaiterFn                      : () => {}
+    });
+}
+
+test.describe('#17398 — the outer lease fairness voter, per acquisition path', () => {
+    test('the voter compares against a real bound: past it reports a lease cause, inside it reports nothing', () => {
+        const over  = createLeaseYieldVoter(overBoundAcquisition()),
+              fresh = createLeaseYieldVoter(freshAcquisition());
+
+        expect(over.cause, 'the cause is named, not inferred from a boolean').toBe(YIELD_CAUSE_LEASE);
+        expect(over.vote()).toBe(true);
+
+        // NEGATIVE CONTROL, on the real predicate and the real config leaf rather than a stub: a
+        // flipped comparison operator, or a read of the sibling `heavyMaintenanceLease` leaf (which
+        // holds only `staleAfterMs`, so the bound would resolve `undefined` and never vote), turns
+        // one of these two assertions red. A voter that always answered `false` would pass the second
+        // alone, which is why both sides of the bound are asserted in one arm.
+        expect(fresh.cause).toBe(YIELD_CAUSE_LEASE);
+        expect(fresh.vote(), 'a holder inside its bound must produce NO cause').toBe(false);
+    });
+
+    test('no acquisition yields NULL, not a voter that always answers false', () => {
+        // The two are not interchangeable to a caller. `null` composes away and leaves the slice
+        // budget as the only bound; an always-false voter is a bound that reports "not yet" forever,
+        // which reads identically to a healthy one at every call site.
+        expect(createLeaseYieldVoter(null)).toBeNull();
+        expect(createLeaseYieldVoter({acquired: false, status: 'held'})).toBeNull();
+        expect(createLeaseYieldVoter(undefined)).toBeNull();
+    });
+
+    test('SCHEDULER PATH: the scheduler acquisition hands its task a lease voter', () => {
+        // RED against dev: `taskOptions` carried `{env, onComplete}` and nothing derived from the
+        // acquisition's AGE, so the scheduler's own hold could not be voted against at all.
+        let captured = null;
+
+        buildService(overBoundAcquisition()).acquireLeaseAndExecute({
+            taskName       : 'tenant-repo-sync',
+            reason         : 'periodic',
+            activeHeavyTask: {name: null},
+            executeFn      : (taskName, reason, onSuccess, taskOptions) => {
+                captured = taskOptions;
+                return true
+            }
+        });
+
+        expect(captured, 'the scheduler must reach its task at all').not.toBeNull();
+        expect(captured.leaseYieldVoter, 'the scheduler is an outer holder and must supply a vote').not.toBeNull();
+        expect(captured.leaseYieldVoter.cause).toBe(YIELD_CAUSE_LEASE);
+        expect(captured.leaseYieldVoter.vote()).toBe(true);
+    });
+
+    test('SCHEDULER PATH: a compatible-pair bypass holds no lease, so it supplies no vote', () => {
+        // The bypass candidate runs WITHOUT inheriting the incumbent's token. It owns no lease, so a
+        // voter here would be voting on somebody else's hold — and its exit would release a lease it
+        // never took. This arm is why the production line reads `leaseToken ? … : null` rather than
+        // building a voter from whatever descriptor came back.
+        let captured = null;
+
+        const service = buildService({acquired: false, status: 'held', lease: {owner: 'kbSync', token: 'other', acquiredAt: new Date(0).toISOString()}});
+
+        service.areHeavyMaintenanceTasksCompatible = () => true;
+        service.acquireLeaseAndExecute({
+            taskName       : 'tenant-repo-sync',
+            reason         : 'periodic',
+            activeHeavyTask: {name: null},
+            executeFn      : (taskName, reason, onSuccess, taskOptions) => {
+                captured = taskOptions;
+                return true
+            }
+        });
+
+        expect(captured).not.toBeNull();
+        expect(captured.leaseYieldVoter, 'a task holding no lease has no hold to yield').toBeNull();
+    });
+
+    test('RUNNER FORWARDING: the service-runner passes the voter through to runTask', () => {
+        // RED against dev: the `'tenant-repo-sync'` runner's signature was `(taskName, reason)`, so
+        // the fourth argument `acquireLeaseAndExecute` already passed was dropped on the floor. The
+        // scheduler edge above and this one are separate defects — either alone leaves the vote
+        // unreachable, and only a per-edge arm says which.
+        const voter = {cause: YIELD_CAUSE_LEASE, vote: () => true};
+
+        let received = null;
+
+        executeCandidate({
+            candidate: {
+                taskName  : 'tenant-repo-sync',
+                trigger   : {reason: 'periodic-tenant-repo-sync:1'},
+                descriptor: {executionKind: 'service-runner', maintenanceClass: 'heavy'}
+            },
+            activeHeavyTask: {name: null},
+            services       : {
+                taskStateService              : {getTaskState: () => null},
+                healthService                 : {recordTaskOutcome() {}},
+                tenantRepoSyncService         : {runTask(options) { received = options; return true }},
+                maintenanceBackpressureService: {
+                    // Stubbed at the boundary the runner actually crosses: this spec is about the
+                    // runner's FORWARDING, and routing it through a real lease acquisition would make
+                    // a scheduler-edge regression redden this arm too.
+                    acquireLeaseAndExecute: ({taskName, executeFn, reason, onSuccess}) =>
+                        executeFn(taskName, reason, onSuccess, {env: {}, leaseYieldVoter: voter, onComplete() {}})
+                }
+            },
+            runtime: {writeLog() {}}
+        });
+
+        expect(received, 'the runner must reach the service').not.toBeNull();
+        expect(received.leaseYieldVoter, 'the runner must not drop taskOptions').toBe(voter);
+    });
+
+    test('RUNNER FORWARDING: a runner invoked without taskOptions passes null, never undefined', () => {
+        // `acquireLeaseAndExecute` short-circuits non-heavy tasks with `executeFn(taskName, reason,
+        // onSuccess)` — three arguments. The service's default is `null`, and `undefined` would take
+        // that default too, so this arm exists for the reader rather than the machine: it fixes the
+        // absent case as a deliberate value instead of an accident of argument arity.
+        let received = null;
+
+        executeCandidate({
+            candidate: {
+                taskName  : 'tenant-repo-sync',
+                trigger   : {reason: 'periodic-tenant-repo-sync:2'},
+                descriptor: {executionKind: 'service-runner', maintenanceClass: 'heavy'}
+            },
+            activeHeavyTask: {name: null},
+            services       : {
+                taskStateService              : {getTaskState: () => null},
+                healthService                 : {recordTaskOutcome() {}},
+                tenantRepoSyncService         : {runTask(options) { received = options; return true }},
+                maintenanceBackpressureService: {
+                    acquireLeaseAndExecute: ({taskName, executeFn, reason, onSuccess}) => executeFn(taskName, reason, onSuccess)
+                }
+            },
+            runtime: {writeLog() {}}
+        });
+
+        expect(received.leaseYieldVoter).toBeNull();
+    });
+
+    test('CLI PATH: the container one-shot builds its voter from its own acquisition', async () => {
+        // RED against dev: the `invoke` closure took no argument, so the acquisition descriptor
+        // `withHeavyMaintenanceLease` hands its task — the only place this process can learn when its
+        // own hold began — was discarded.
+        const acquisition = overBoundAcquisition();
+
+        let dispatched = null;
+
+        await runTenantRepoSyncWithGlobalLease({
+            parsed          : {repoSlugs: [], fullReplay: false, clearBackoff: false},
+            taskStateService: {getTaskState: () => null},
+            writeLog        : () => {},
+            runTaskImpl     : options => { dispatched = options; return {status: 'completed'} },
+            withLeaseImpl   : task => task(acquisition)
+        });
+
+        expect(dispatched, 'the CLI must dispatch the sweep').not.toBeNull();
+        expect(dispatched.leaseYieldVoter, 'the CLI is the other outer holder').not.toBeNull();
+        expect(dispatched.leaseYieldVoter.cause).toBe(YIELD_CAUSE_LEASE);
+        expect(dispatched.leaseYieldVoter.vote()).toBe(true);
+    });
+
+    test('CLI PATH: the clear-backoff branch receives no vote', async () => {
+        // Deliberate asymmetry, not an oversight. The clear is a short manifest rewrite that must
+        // finish atomically; a yield partway through leaves a half-applied clear, which is a worse
+        // outcome than holding the lease a few seconds past its bound. Without this arm, an
+        // implementation that votes on both branches passes every other arm in this file.
+        let clearOptions = null,
+            sweepRan     = false;
+
+        await runTenantRepoSyncWithGlobalLease({
+            parsed          : {repoSlugs: [], fullReplay: false, clearBackoff: true},
+            taskStateService: {getTaskState: () => null},
+            writeLog        : () => {},
+            runTaskImpl     : () => { sweepRan = true; return {status: 'completed'} },
+            clearBackoffImpl: options => { clearOptions = options; return {status: 'completed'} },
+            withLeaseImpl   : task => task(overBoundAcquisition())
+        });
+
+        expect(sweepRan, 'clear-backoff must not run the sweep').toBe(false);
+        expect(clearOptions).not.toBeNull();
+        expect(clearOptions.leaseYieldVoter, 'an atomic rewrite gets no yield vote').toBeUndefined();
+    });
+
+    test('NO-LEASE EQUIVALENCE: with no voter, the boolean projection IS the slice predicate', () => {
+        // Asserted against the raw predicate's own answer rather than against a hardcoded expectation,
+        // so the arm cannot drift from what the slice budget actually decides. This is the guarantee
+        // for the callers that hold no outer lease — every in-process scheduler path — that the change
+        // is behaviour-preserving for them.
+        const sliceBudgetMs = 5000;
+
+        for (const elapsed of [0, 4999, 5000, 5001, 100_000]) {
+            const startedMs = 1_000_000,
+                  now       = () => startedMs + elapsed,
+                  raw       = createSliceBudgetPredicate({startedMs, sliceBudgetMs, now}),
+                  resolver  = createYieldCauseResolver([
+                      null,
+                      {cause: YIELD_CAUSE_SLICE, vote: createSliceBudgetPredicate({startedMs, sliceBudgetMs, now})}
+                  ]);
+
+            expect(resolver() !== null, `elapsed ${elapsed}ms must match the raw predicate`).toBe(raw());
+        }
+    });
+
+    test('CONSUMPTION IS ABSENT: the sweep consumes a Boolean, so no exit branch can read the cause', () => {
+        // The three lease-exit steps belong to a separate dependent change. This arm fixes the
+        // boundary between them: the projection the sweep passes downstream is a Boolean, so an
+        // implementation here CANNOT have started branching on the cause. The successor changes this
+        // arm deliberately, which is the point — the boundary moves on the record, not by drift.
+        const resolver = createYieldCauseResolver([
+                  {cause: YIELD_CAUSE_LEASE, vote: () => true},
+                  {cause: YIELD_CAUSE_SLICE, vote: () => false}
+              ]),
+              projection = () => resolver() !== null;
+
+        expect(resolver(), 'the cause is available…').toBe(YIELD_CAUSE_LEASE);
+        expect(typeof projection(), '…and the sweep still receives only a Boolean').toBe('boolean');
+    });
+});

--- a/test/playwright/unit/ai/daemons/orchestrator/scheduling/tenantRepoSync.sliceBudget.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/scheduling/tenantRepoSync.sliceBudget.spec.mjs
@@ -1,5 +1,5 @@
 import {test, expect}                             from '@playwright/test';
-import {assertSliceBudgetMs, createSliceBudgetPredicate} from '../../../../../../../ai/daemons/orchestrator/scheduling/tenantRepoSync.mjs';
+import {assertSliceBudgetMs, createSliceBudgetPredicate, createYieldCauseResolver, YIELD_CAUSES} from '../../../../../../../ai/daemons/orchestrator/scheduling/tenantRepoSync.mjs';
 import {KB_TENANT_REPO_SYNC_INVALID_SLICE_BUDGET} from '../../../../../../../ai/daemons/orchestrator/services/TenantRepoSyncErrors.mjs';
 
 /**
@@ -103,5 +103,71 @@ test.describe('TenantRepoSyncService — sliceBudgetMs value contract (#17132 AC
         try { assertSliceBudgetMs('300000') } catch (error) { thrown = error }
 
         expect(thrown, 'a numeric string must not pass as a validated budget').toBeTruthy();
+    });
+});
+
+test.describe('createYieldCauseResolver — the verdict reports WHICH bound fired', () => {
+    const voter = value => () => value;
+
+    test('RED-PROOF: a lease cause is distinguishable from a slice cause', () => {
+        // The predecessor returned `voters.some(v => v() === true)`. Both cases below answered `true`
+        // there, so a consumer could not choose between rotating and releasing — and every
+        // lease-exit step is conditional on exactly that choice.
+        const lease = createYieldCauseResolver([{cause: 'lease', vote: voter(true)},  {cause: 'slice', vote: voter(false)}]),
+              slice = createYieldCauseResolver([{cause: 'lease', vote: voter(false)}, {cause: 'slice', vote: voter(true)}]);
+
+        expect(lease()).toBe('lease');
+        expect(slice()).toBe('slice');
+        expect(lease()).not.toBe(slice());
+    });
+
+    test('the verdict is NOT a boolean, so a later refactor cannot re-flatten it', () => {
+        const resolver = createYieldCauseResolver([{cause: 'slice', vote: voter(true)}]);
+
+        expect(typeof resolver()).toBe('string');
+        expect(resolver()).not.toBe(true);
+    });
+
+    test('NEGATIVE CONTROL: no bound fired yields null, not a cause', () => {
+        const quiet = createYieldCauseResolver([{cause: 'lease', vote: voter(false)}, {cause: 'slice', vote: voter(false)}]);
+
+        expect(quiet()).toBeNull();
+        expect(createYieldCauseResolver([])(), 'no voters cannot invent a cause').toBeNull();
+    });
+
+    test('LEASE outranks SLICE when both fire — the outer bound owns the stricter exit', () => {
+        const both = createYieldCauseResolver([{cause: 'lease', vote: voter(true)}, {cause: 'slice', vote: voter(true)}]);
+
+        // Reporting the inner cause while the outer bound is exceeded is how a holder keeps rotating
+        // past its own deadline, which is the observed starvation.
+        expect(both()).toBe('lease');
+
+        // Precedence is the declared order, not the caller's argument order.
+        const reversed = createYieldCauseResolver([{cause: 'slice', vote: voter(true)}, {cause: 'lease', vote: voter(true)}]);
+
+        expect(reversed()).toBe('lease');
+    });
+
+    test('an unknown cause is REFUSED rather than ignored', () => {
+        // A silently-dropped voter is a bound that stops binding while every call site still reads
+        // as wired — the same class as the premise error that produced this ticket.
+        let thrown;
+
+        try { createYieldCauseResolver([{cause: 'budget', vote: voter(true)}]) } catch (error) { thrown = error }
+
+        expect(thrown, 'an unrecognised cause must not pass silently').toBeTruthy();
+        expect(String(thrown.message)).toContain('budget');
+    });
+
+    test('a throwing voter PROPAGATES — swallowing makes starvation look healthy', () => {
+        const resolver = createYieldCauseResolver([{cause: 'lease', vote: () => { throw new Error('bound unreadable') }}]);
+
+        expect(() => resolver()).toThrow(/bound unreadable/);
+    });
+
+    test('a non-function vote is dropped, and a resolver of only those reports no cause', () => {
+        expect(createYieldCauseResolver([{cause: 'lease', vote: null}])()).toBeNull();
+        expect(YIELD_CAUSES).toEqual(['lease', 'slice']);
+        expect(Object.isFrozen(YIELD_CAUSES)).toBe(true);
     });
 });

--- a/test/playwright/unit/ai/daemons/orchestrator/services/TenantRepoSyncService.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/services/TenantRepoSyncService.spec.mjs
@@ -7238,14 +7238,25 @@ test.describe('TenantRepoSyncService (#11790)', () => {
      * admission or releasing the outer lease early, which is precisely the behaviour it claimed to
      * pin. Same wrong-subject class as an arm asserting a builder to prove something about a planner.
      *
-     * So the subject is the SWEEP, over TWO due repos, with a lease cause firing from the first check.
-     * Today's contract is that a lease-caused yield bounds work WITHIN a repo and does not touch
-     * admission: repo two is still admitted and ingested. That is the observable the dependent exit
-     * contract will deliberately invert — when it lands, the tail stops after the active cohort and
-     * this arm goes red on purpose, which is the point of pinning it here rather than describing it.
+     * **Three repos against a limit of TWO, and the third is the entire point.** A two-repo fixture
+     * at the production default limit of 2 has no tail at all: both repos ARE the active cohort, so
+     * the dependent exit — which stops admission after that cohort — could land, admit both, and
+     * leave the arm green. A reviewer's second falsifier caught exactly that, and the mutant the arm
+     * had claimed as faithful (`remainingRepos.slice(0, 1)`) drops half of the active cohort rather
+     * than the tail, so it was never the contract under test either. With a third due repo there is
+     * a repo BEYOND the cohort, and it is the one the exit will drop.
+     *
+     * Today's contract is that a lease-caused yield bounds work WITHIN a repo and touches neither
+     * admission nor the outer lease. So the arm pins three separable observables — the admitted SET
+     * includes the tail, the cohort ORDER still puts the tail last, and the sweep still reports
+     * `completed` rather than an early release — because the exit contract could arrive correct on
+     * one and wrong on another, and a single conflated assertion could not tell which.
      */
     test('#17398 a firing lease cause does NOT stop tail admission — the exit contract is not started here', async () => {
-        const repoSlugs    = ['org/lease-head', 'org/lease-tail'],
+        // Two fill the active cohort at the default limit; the third is the tail the dependent exit
+        // will stop. Names carry that role so a failure message reads as a contract violation rather
+        // than as an opaque slug mismatch.
+        const repoSlugs    = ['org/lease-cohort-a', 'org/lease-cohort-b', 'org/lease-tail'],
               captureCalls = [],
               // Fires on the very first consultation, so if any admission decision consulted the
               // cause, it would have every opportunity to drop the tail.
@@ -7287,11 +7298,20 @@ test.describe('TenantRepoSyncService (#11790)', () => {
             .filter(call => call.op === 'ingestSourceFiles')
             .map(call => call.payload.repoSlug);
 
-        // Asserted as the whole admitted SET rather than two `toContain`s, so the failure message
-        // distinguishes the two ways this can break: a dropped tail shows the head alone, while a
-        // sweep that admitted nothing shows an empty array. Two containment checks would have let the
-        // first mask the second, and the difference matters — one is the exit contract starting early,
-        // the other is a broken fixture.
+        // Non-vacuity FIRST, and it is what makes the tail claim mean anything: the limit must be
+        // strictly below the repo count, or there is no repo outside the active cohort and every
+        // assertion below is true of a fixture that cannot pose the question.
+        expect(
+            TenantRepoSyncService.concurrencyLimit,
+            'the fixture needs a repo BEYOND the active cohort — at the default limit of 2 a two-repo ' +
+            'sweep has no tail, so the dependent exit could admit the whole cohort and pass'
+        ).toBeLessThan(repoSlugs.length);
+
+        // ADMISSION — asserted as the whole set rather than as containments, so the failure message
+        // distinguishes the two ways this breaks: a dropped tail shows the cohort alone, a sweep that
+        // admitted nothing shows an empty array. Containment checks would let the first mask the
+        // second, and the difference matters — one is the exit contract starting early, the other is
+        // a broken fixture.
         expect(
             [...ingested].sort(),
             'a lease cause reached an ADMISSION decision — stopping the tail after the active cohort ' +
@@ -7300,11 +7320,29 @@ test.describe('TenantRepoSyncService (#11790)', () => {
             'arm never exercised admission at all'
         ).toEqual([...repoSlugs].sort());
 
+        // ORDER — the tail must still be admitted LAST. A sweep that kept the tail but hoisted it
+        // into the first cohort would satisfy the set assertion while having changed the very
+        // boundary the dependent exit is defined against, so the set alone cannot carry this.
+        expect(
+            ingested.indexOf('org/lease-tail'),
+            'the tail must remain the tail: admitted, and admitted after the active cohort'
+        ).toBe(repoSlugs.length - 1);
+
+        // OUTER LEASE — a lease-caused yield is a bound on work inside a repo, not a signal to hand
+        // the lease back. A sweep that released early would report something other than a completed
+        // run, and the caller would drop a lease it still holds work for.
         expect(
             result.status,
             'a lease-caused yield must not turn a healthy sweep into a failure or an early release; ' +
             'the cause is readable and nothing acts on it yet'
         ).toBe('completed');
+
+        // And the whole cohort completed rather than deferring — the count is what a future exit
+        // would have to reduce, so pinning it names the number the dependent leaf must change.
+        expect(
+            result.details.completedCount,
+            'all three repos completed; the dependent exit will reduce this, and that red is intended'
+        ).toBe(repoSlugs.length);
     });
 });
 

--- a/test/playwright/unit/ai/daemons/orchestrator/services/TenantRepoSyncService.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/services/TenantRepoSyncService.spec.mjs
@@ -7229,6 +7229,83 @@ test.describe('TenantRepoSyncService (#11790)', () => {
             'the arm above proves nothing about the lease voter'
         ).toBe(false);
     });
+
+    /*
+     * The production-path negative boundary, and it exists because its predecessor did not cross into
+     * production at all. That arm built a resolver and its boolean projection inside the fixture and
+     * asserted the projection was a Boolean — true of the fixture, and green no matter what the sweep
+     * did. A reviewer's falsifier found it: it could not fail if the sweep began stopping tail
+     * admission or releasing the outer lease early, which is precisely the behaviour it claimed to
+     * pin. Same wrong-subject class as an arm asserting a builder to prove something about a planner.
+     *
+     * So the subject is the SWEEP, over TWO due repos, with a lease cause firing from the first check.
+     * Today's contract is that a lease-caused yield bounds work WITHIN a repo and does not touch
+     * admission: repo two is still admitted and ingested. That is the observable the dependent exit
+     * contract will deliberately invert — when it lands, the tail stops after the active cohort and
+     * this arm goes red on purpose, which is the point of pinning it here rather than describing it.
+     */
+    test('#17398 a firing lease cause does NOT stop tail admission — the exit contract is not started here', async () => {
+        const repoSlugs    = ['org/lease-head', 'org/lease-tail'],
+              captureCalls = [],
+              // Fires on the very first consultation, so if any admission decision consulted the
+              // cause, it would have every opportunity to drop the tail.
+              alwaysYields = {cause: YIELD_CAUSE_LEASE, vote: () => true};
+
+        for (const repoSlug of repoSlugs) {
+            await provisionMirrorDir({tenantId: 't1', repoSlug});
+        }
+
+        await TenantRepoSyncService.writePersistedRevisions({
+            filePath : revisionsFile,
+            revisions: Object.fromEntries(repoSlugs.map(repoSlug => [`t1/${repoSlug}`, {
+                lastIngestedRev                   : null,
+                lastRunAttemptAt                  : Date.now() - 120_000,
+                consecutiveFailures               : 0,
+                ingestContractVersion             : TENANT_REPO_INGEST_CONTRACT_VERSION,
+                lastAttemptedIngestContractVersion: TENANT_REPO_INGEST_CONTRACT_VERSION
+            }]))
+        });
+
+        const result = await TenantRepoSyncService.runTask({
+            reason           : 'periodic-sweep:60000',
+            taskStateService : createInMemoryTaskStateService(),
+            tenantReposConfig: {tenantRepos: repoSlugs.map(repoSlug => ({
+                tenantId: 't1', repoSlug, mirrorRoot,
+                cloneUrl: `https://github.com/neomjs/${repoSlug.split('/')[1]}.git`
+            }))},
+            gitMirror                    : makeFakeGitMirror(),
+            envelopeBuilder              : makeFakeEnvelopeBuilder(),
+            knowledgeBaseIngestionService: makeFakeIngestionService({captureCalls}),
+            revisionsFilePath            : revisionsFile,
+            globalCadenceMs              : 60_000,
+            jitterRatio                  : 0,
+            seedBootstrap                : false,
+            leaseYieldVoter              : alwaysYields
+        });
+
+        const ingested = captureCalls
+            .filter(call => call.op === 'ingestSourceFiles')
+            .map(call => call.payload.repoSlug);
+
+        // Asserted as the whole admitted SET rather than two `toContain`s, so the failure message
+        // distinguishes the two ways this can break: a dropped tail shows the head alone, while a
+        // sweep that admitted nothing shows an empty array. Two containment checks would have let the
+        // first mask the second, and the difference matters — one is the exit contract starting early,
+        // the other is a broken fixture.
+        expect(
+            [...ingested].sort(),
+            'a lease cause reached an ADMISSION decision — stopping the tail after the active cohort ' +
+            'is the dependent exit contract, and starting it here makes the two leaves impossible to ' +
+            'review independently. An EMPTY array instead means the fixture admitted nothing and the ' +
+            'arm never exercised admission at all'
+        ).toEqual([...repoSlugs].sort());
+
+        expect(
+            result.status,
+            'a lease-caused yield must not turn a healthy sweep into a failure or an early release; ' +
+            'the cause is readable and nothing acts on it yet'
+        ).toBe('completed');
+    });
 });
 
 test.describe('the persisted cause DISCRIMINATES, and still leaks nothing (#16056)', () => {

--- a/test/playwright/unit/ai/daemons/orchestrator/services/TenantRepoSyncService.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/services/TenantRepoSyncService.spec.mjs
@@ -25,7 +25,7 @@ import path            from 'path';
 import {fileURLToPath} from 'url';
 
 import TenantRepoSyncService from '../../../../../../../ai/daemons/orchestrator/services/TenantRepoSyncService.mjs';
-import {classifyEmbeddingRecoveryState, isRepoDue, resolveUnknownRepoSelectorFailure}
+import {classifyEmbeddingRecoveryState, isRepoDue, resolveUnknownRepoSelectorFailure, YIELD_CAUSE_LEASE}
                             from '../../../../../../../ai/daemons/orchestrator/scheduling/tenantRepoSync.mjs';
 import {
     classifyTenantRepoCheckpoint,
@@ -7142,6 +7142,93 @@ test.describe('TenantRepoSyncService (#11790)', () => {
             'a repo that exhausted its corpus DOES advance — otherwise this arm passes by breaking everything'
         ).toBeTruthy();
     });
+
+    /*
+     * The last propagation edge of the outer-lease fairness vote. The three upstream edges — the
+     * scheduler's `taskOptions`, the service-runner's forwarding, the CLI's acquisition — are each
+     * guarded in `leaseYieldVoterWiring.spec.mjs`, and all three can be correct while the vote still
+     * dies inside the service. This arm owns `runTask` → `syncTenantRepos` → the composed resolver →
+     * the `shouldYield` the ingest call actually receives.
+     *
+     * The slice voter cannot fire here: this sweep elapses milliseconds against the configured
+     * `sliceBudgetMs`, and `assertSliceBudgetMs` refuses a budget of 0, so there is no setting that
+     * makes it degenerate. A `shouldYield()` of `true` is therefore attributable to the lease voter
+     * alone — and the second run, identical but for `leaseYieldVoter: null`, is the control that
+     * keeps the first from passing on some unrelated always-yield.
+     *
+     * The voter is hand-built rather than derived from a real acquisition on purpose. Whether the
+     * voter reads the right config leaf is a different subject with its own arm; mixing it in here
+     * would make a config-branch regression redden this arm too, and then neither arm says which
+     * edge broke.
+     */
+    test('#17398 the outer lease vote REACHES the ingest call, and its absence is the control', async () => {
+        const
+            repoSlug = 'org/lease-vote',
+
+            /**
+             * Runs one sweep and returns what the ingest call was handed as its yield predicate.
+             * @param {{cause: String, vote: Function}|null} leaseYieldVoter
+             * @returns {Promise<Function|null>}
+             */
+            runWith = async leaseYieldVoter => {
+                const base     = makeFakeIngestionService();
+                let   observed = null;
+
+                await provisionMirrorDir({tenantId: 't1', repoSlug});
+                await TenantRepoSyncService.writePersistedRevisions({
+                    filePath : revisionsFile,
+                    revisions: {[`t1/${repoSlug}`]: {
+                        lastIngestedRev                   : null,
+                        lastRunAttemptAt                  : Date.now() - 120_000,
+                        consecutiveFailures               : 0,
+                        ingestContractVersion             : TENANT_REPO_INGEST_CONTRACT_VERSION,
+                        lastAttemptedIngestContractVersion: TENANT_REPO_INGEST_CONTRACT_VERSION
+                    }}
+                });
+
+                await TenantRepoSyncService.runTask({
+                    reason           : 'periodic-sweep:60000',
+                    taskStateService : createInMemoryTaskStateService(),
+                    tenantReposConfig: {tenantRepos: [{
+                        tenantId: 't1', repoSlug, mirrorRoot,
+                        cloneUrl: `https://github.com/neomjs/lease-vote.git`
+                    }]},
+                    gitMirror                    : makeFakeGitMirror(),
+                    envelopeBuilder              : makeFakeEnvelopeBuilder(),
+                    knowledgeBaseIngestionService: {
+                        ...base,
+                        async ingestSourceFiles(payload, controls) {
+                            observed = controls?.shouldYield ?? null;
+                            return base.ingestSourceFiles(payload, controls)
+                        }
+                    },
+                    revisionsFilePath: revisionsFile,
+                    globalCadenceMs  : 60_000,
+                    jitterRatio      : 0,
+                    seedBootstrap    : false,
+                    leaseYieldVoter
+                });
+
+                return observed
+            };
+
+        const withVote = await runWith({cause: YIELD_CAUSE_LEASE, vote: () => true}),
+              without  = await runWith(null);
+
+        expect(withVote, 'the ingest call must receive a yield predicate at all').toBeTruthy();
+        expect(
+            withVote(),
+            'the lease vote did not survive runTask → syncTenantRepos → the resolver; a bound the ' +
+            'holder cannot consult is the whole starvation mechanism'
+        ).toBe(true);
+
+        expect(without, 'the control run must reach the same call site').toBeTruthy();
+        expect(
+            without(),
+            'with no outer lease the sweep must answer exactly as the slice budget does — otherwise ' +
+            'the arm above proves nothing about the lease voter'
+        ).toBe(false);
+    });
 });
 
 test.describe('the persisted cause DISCRIMINATES, and still leaks nothing (#16056)', () => {
@@ -7479,6 +7566,7 @@ test.describe('syncTenantRepos container-plane CLI (#15748)', () => {
         const
             taskStateService = {name: 'task-state'},
             writeLog         = () => {},
+            voter            = {cause: YIELD_CAUSE_LEASE, vote: () => false},
             options          = buildRunTaskOptions({
                 parsed: {
                     fullReplay: true,
@@ -7488,13 +7576,28 @@ test.describe('syncTenantRepos container-plane CLI (#15748)', () => {
                 writeLog
             });
 
+        // Exhaustive rather than partial, deliberately: the envelope is the CLI's whole contract with
+        // the service, so a field silently appearing or vanishing here is a dispatch change nobody
+        // asked for. `leaseYieldVoter` defaults to `null` — an explicit "this caller holds no outer
+        // lease", which is not the same statement as a voter that always answers false.
         expect(options).toEqual({
-            reason       : 'manual',
+            reason         : 'manual',
             taskStateService,
             writeLog,
-            onlyRepoSlugs: ['org/a', 'org/b'],
-            fullReplay   : true
+            leaseYieldVoter: null,
+            onlyRepoSlugs  : ['org/a', 'org/b'],
+            fullReplay     : true
         });
+
+        expect(
+            buildRunTaskOptions({
+                parsed         : {fullReplay: false, repoSlugs: []},
+                taskStateService,
+                writeLog,
+                leaseYieldVoter: voter
+            }).leaseYieldVoter,
+            'a supplied voter must reach the service unwrapped — the envelope is not a place to re-derive it'
+        ).toBe(voter);
     });
 
     test('global held lease defers without dispatching tenant sync', async () => {
@@ -7548,16 +7651,27 @@ test.describe('syncTenantRepos container-plane CLI (#15748)', () => {
                 });
 
                 expect(outcome.status).toBe('completed');
-                expect(outcome.result).toEqual({
-                    status,
-                    options: {
-                        reason       : 'manual',
-                        taskStateService,
-                        writeLog,
-                        onlyRepoSlugs: ['org/a', 'org/b'],
-                        fullReplay   : true
-                    }
+
+                const {leaseYieldVoter, ...dispatched} = outcome.result.options;
+
+                expect(outcome.result.status).toBe(status);
+                expect(dispatched).toEqual({
+                    reason       : 'manual',
+                    taskStateService,
+                    writeLog,
+                    onlyRepoSlugs: ['org/a', 'org/b'],
+                    fullReplay   : true
                 });
+
+                // Split out of the strict compare rather than dropped from it: this run holds a REAL
+                // lease through the real wrapper, so it is the one place the CLI's voter is built from
+                // a genuine acquisition instead of a fixture. A voter carrying a live `acquiredAt`
+                // seconds old must answer `false` — the honest negative control on the live path, and
+                // the one that catches a bound resolved from the wrong config leaf.
+                expect(leaseYieldVoter, 'a real acquisition must produce a real voter').not.toBeNull();
+                expect(leaseYieldVoter.cause).toBe(YIELD_CAUSE_LEASE);
+                expect(leaseYieldVoter.vote(), 'a lease acquired moments ago is nowhere near its bound').toBe(false);
+
                 expect((await inspectHeavyMaintenanceLease({leasePath})).status).toBe('missing');
             });
         }


### PR DESCRIPTION
Resolves neomjs/neo#17398

> 🌿 A holder can now be asked how long it has held — from either of the two acquisitions that take the lease, in a verdict that still knows which bound answered, so "the sweep kept rotating past its own deadline" stops being expressible.

Both outer acquisitions of the deployment-wide heavy-maintenance lease now contribute an acquisition-age vote, and the sweep's yield verdict carries **which** bound fired rather than that one did. No exit behaviour changed: the sweep consumes the resolver's boolean projection, and with no voter that projection is the slice predicate's own answer.

Evidence: L2 (in-process production dispatch across all four propagation edges, one arm through the real lease primitive on a temp lease file, and after two review cycles the unchanged-exit boundary asserted on the production sweep over three repos against a limit of two) → L2 required (every AC on this leaf is unit-reachable). Residual: the plane-observable waiter drain, Residual-Owner: neomjs/neo#17414.

## The defect

The container sweep takes the shared lease and **consults nothing**. Every bound it can see is per-repo: `sliceBudgetMs` rotates *within* the sweep rather than ending it, so a sweep over N repos honours every budget it owns and still occupies the exclusive heavy slot for roughly `N × sliceBudgetMs`.

Live reading, 2026-08-20, external tenant deployment: five maintenance tasks deferred since Aug 18–19, every breach naming holder `tenant-repo-sync` — `summary`, `memory-summary-backfill`, `message-concept-harvest`, `graphlog-compaction`, `provider-residency-repair`. The watchdog states it: *"the fairness yield bound has been exceeded; the lease pipeline is not admitting its waiters."*

**The premise this ticket got wrong twice.** PR neomjs/neo#17399 was dropped for naming the CLI as *the* outer holder. `MaintenanceBackpressureService.mjs` is a **second** outer acquisition — the scheduler's — indistinguishable from the CLI at the point where a vote is cast. A vote wired into one cannot terminate a hold the other owns, and the refuted implementation wired the CLI only and was thoroughly tested that way. That is exactly the evidence that produces a false owner discriminator, so "both, or neither" is treated here as load-bearing rather than as a completeness nicety.

## The change

One channel, already open on both paths. Each acquisition already derives values from its own descriptor; the hold's age is a third one.

| path | site | already derived | now also derives |
|---|---|---|---|
| scheduler | `MaintenanceBackpressureService.mjs` `taskOptions` | inherited token, release callback | `leaseYieldVoter` |
| service-runner | `pipeline.mjs` `'tenant-repo-sync'` runner | — (it **dropped** the 4th argument) | forwards it to `runTask` |
| CLI | `syncTenantRepos.mjs` `invoke` | — (the closure took **no** argument) | `createLeaseYieldVoter(acquisition)` |

`withHeavyMaintenanceLease` has always handed its task the acquisition descriptor. The CLI's closure never took it; the runner never took `taskOptions`. Both were one parameter away.

**The clear-backoff branch deliberately gets no vote.** It is a short manifest rewrite that must finish atomically — a yield partway through leaves a half-applied clear, which is worse than holding the lease a few seconds past its bound. Asserted as its own arm, because without it an implementation that votes on both branches passes everything else.

**One config-aware home, so the trap is spelled once.** `createLeaseYieldVoter` reads `orchestrator.heavyMaintenance.maxActiveHoldMs` at vote time. The sibling leaf `orchestrator.heavyMaintenanceLease` holds only `staleAfterMs`; reading it resolves `undefined`, a falsy bound never votes, and the result is a no-op indistinguishable from a wired predicate at every call site.

## Deltas from ticket

**One consolidation the ticket did not ask for.** `syncKnowledgeBase.buildLeaseYieldPredicate` carried a second copy of that same config reading. It now delegates, so the sibling-leaf trap has one site instead of two.

Zero behaviour delta, and provable rather than asserted: the previous body called `shouldYieldHeavyMaintenanceLease(acquisition.lease, …)`, whose first guard returns `false` for a missing lease — so the new `() => false` fallback answers identically on the only input where the two shapes differ. Export and signature unchanged, so its existing boundary test still witnesses the config branch, and now witnesses it on the shared site. The mutation table below shows that arm firing on a site it was not written for.

**Two named constants** (`YIELD_CAUSE_LEASE` / `YIELD_CAUSE_SLICE`) rather than the string literals the first commit used: the voter is built in a config-aware module while the vocabulary is owned by the pure one, and two spellings of one cause would have been caught only once a real deployment reached the bound.

Everything else is in scope. Consuming the cause is neomjs/neo#17414 and absent here by construction.

## Test Evidence

`ai/daemons/orchestrator/**` + `ai/scripts/maintenance/**`: `test/playwright/unit/ai/daemons/orchestrator/leaseYieldVoterWiring.spec.mjs` (10 new arms) + one new arm in `test/playwright/unit/ai/daemons/orchestrator/services/TenantRepoSyncService.spec.mjs` — **372/372** across the nine affected suites; **223/223** re-run after the block-alignment hook's auto-fix.

**Mutation evidence, per edge.** The AC asks for specificity, not sensitivity: a suite that reddens on any edit tells a later author that something broke, not which thing.

| mutation | arms red | arms green |
|---|---|---|
| delete the scheduler's `leaseYieldVoter` | 2 — both SCHEDULER PATH | 8 |
| revert the runner to `(taskName, reason)` | 2 — both RUNNER FORWARDING | 8 |
| revert the CLI closure to `() => …` | 1 — CLI PATH only | 9 |
| delete `leaseYieldVoter,` from `runTask`'s sweep call | 1 — the service-edge arm | all 10 wiring arms |
| read the **sibling** config leaf | 4, across **two** specs | — |

The clear-backoff arm stays green under the CLI mutation, which is the specificity proof: it asserts an absence, so it is insensitive to that edge by construction.

**What my negative control does and does not own.** The AC asks that a holder inside its bound produce no cause "so a changed comparison operator is caught". My arm asserts a one-second-old acquisition answers `false` — which catches an inverted comparison and a bound resolved from the wrong leaf, but **not** `>` drifting to `>=`. That boundary is owned by the primitive's own pre-existing arm (`HeavyMaintenanceLeaseService.spec.mjs`, *"exactly at the boundary → keep holding (strictly-greater contract)"*), which is the right owner: my arm's subject is whether the vote reaches the real predicate, and the primitive's is whether the comparison is right. Naming the split rather than letting one arm appear to cover both.

**Two pre-existing strict-equality arms extended, not loosened.** `buildRunTaskOptions`'s envelope is asserted with `toEqual`, and the new field broke it. Loosening to `toMatchObject` would have removed the property worth having — the envelope is the CLI's whole contract with the service, so a field appearing or vanishing silently is a dispatch change nobody asked for. Both keep the strict compare and gained the new field; the second now also asserts what it could not before, that a voter built from a **real** acquisition through the real wrapper answers `false` moments after acquiring.

**Broader sweep**, `test/playwright/unit/ai/daemons` + `ai/scripts`: **4327 passed, 4 failed**. Two were mine and are fixed (below). The other two — `DreamServiceGoldenPath › synthesizeGoldenPath executes without crashing` and `ProcessSupervisorService › killProcess is a no-op under UNIT_TEST_MODE` — were **verified pre-existing** by stashing this diff and re-running them against the clean branch HEAD: same two failures, same assertions. A baseline, not an inspection.

**Two gates caught me, both worth recording.**

1. `lint-config-template-ssot` refused the new spec: it imported `ai/config.mjs`, the repo-local **gitignored overlay**, to place its fixture relative to the live bound. Tests must read the committed template. The repair beats compliance — the fixture is now anchored at the epoch, outside any bound a deployment could configure, which makes the arm's subject the **comparison** instead of the number. Both mutations that matter still redden it, re-verified after the change. Now `OK — 0 test config-authority violations`.
2. `check-ticket-archaeology` refused nine refs in durable comments; rewritten as behaviour. The one genuinely tempting to keep — "the successor changes this arm deliberately" — reads better without a number that will rot.

## Post-Merge Validation

Every AC on this leaf is closed by the arms above — the hand-off at each edge, the negative control on the real predicate, and the no-voter equivalence against the raw slice predicate are all unit-reachable, so nothing here is deferred to a live plane.

- [ ] The starved-waiter list under holder `tenant-repo-sync` drains rather than grows.

That one item is not this leaf's to close. It adds the exit that can actually release, and a readable cause nobody acts on drains nothing — so the owner is the ticket that consumes the cause, which stays open past this merge:

Residual-Owner: neomjs/neo#17414

## Review cycle 1 — both Required Actions discharged

@neo-gpt-emmy requested changes and both actions were fair. Neither was an architecture objection: her Patch Verdict confirmed she *could not reproduce drift back to one holder*, which was the thing worth checking.

**RA-1 — the Contract Ledger still specified the discarded API.** It named `composeYieldPredicates` as a boolean OR, a `leaseShouldYield` parameter, and a CLI-local `buildLeaseYieldPredicate`. Amended to the shipped surface: eight rows covering the cause vocabulary, the resolver, the shared voter, both acquisition edges, the runner, the two service frames, and the boolean projection.

**This is the same defect I had already been caught by on this ticket, one section over.** I corrected the premise and rewrote the ACs and left the *authoritative* table teaching the dropped contract. **And the same staleness sat one heading higher, in The Fix, which her RA did not name** — item 1 read *"in `syncTenantRepos.mjs`"* (CLI-only) and item 2 read *"`yield if EITHER bound is reached`"* (the boolean OR). Both amended, because the next reader would have hit whichever copy they reached first.

**RA-2 — the "consumption is absent" arm never crossed into production.** It built a resolver and its boolean projection inside the fixture and asserted the projection was a Boolean: true of the fixture, and green whatever the sweep did — including if the sweep had begun stopping tail admission or releasing the lease. Her falsifier was simply reading what the arm touches.

Replaced with an arm on the sweep itself (`TenantRepoSyncService.spec.mjs`), lease cause firing from the first consultation — and then **the replacement was wrong too, for a different reason, and the same reviewer caught that as well.** Round 2 established that two repos at the production default `concurrencyLimit` of 2 are BOTH the active cohort, so the arm had no tail to protect: the dependent exit stops admission *after* the cohort, could therefore admit both repos, and would have left the arm green. The mutant I had claimed as faithful (`remainingRepos.slice(0, 1)`) sliced the cohort itself — a different defect, and one the exit will never commit.

**Three repos against a limit of two, so a repo exists beyond the cohort.** Verified rather than argued, as a before/after pair against one faithful mutant that keeps every repo the cohort admits and drops only what waits behind it:

| fixture | faithful tail-only mutant |
|---|---|
| two repos at limit 2 (the shape Round 2 rejected) | **passes** — blind, exactly as the review said |
| three repos at limit 2 (shipped) | **fails** on the admitted set, one entry missing |

Three observables are asserted separately, because the exit contract can arrive correct on one and wrong on another: the admitted set contains the tail, the tail is still admitted **last** (a sweep that hoisted it into the first cohort would satisfy the set assertion while moving the boundary the exit is defined against), and the sweep still reports `completed` with all three repos rather than handing its lease back. A non-vacuity assertion pins `concurrencyLimit` below the repo count, so the fixture cannot silently lose its tail again.

This is the third wrong-subject arm I have written on this ticket's lane, and the second on this one RA. Both times the fixture was too small to pose its own question, and both times reading what the arm can distinguish — rather than whether it passes — is what found it. The pattern is mine, not the reviewer's.

## Commits

- `78d7a8059a` — `createYieldCauseResolver`: the verdict reports which bound fired, replacing the refuted boolean OR.
- `680ec3d796` — both outer acquisitions vote, and the vote reaches the sweep.
- `fa67efebf5` — the consumption-absent boundary crosses production instead of a fixture (RA-2).
- `dce694718e` — the tail-admission arm gets a repo outside the active cohort (RA-2, round 2).

Rebased onto current `origin/dev` after the review; the affected suites re-ran green at that head (156/156 over the two specs the RA touched, 231/231 over all five).

## Decision Record impact

- `aligned-with ADR 0022` — cooperative yield only. No hard preemption, no `leaseMonitor.mjs` wiring; neomjs/neo#17379 died proposing that and it is not revisited.
- `aligned-with ADR 0019` — the config read is at the use site, per call, no alias, no defensive optional chaining, no threading of a resolved value. The pure scheduling module stays Neo-free; the reading lives in the module that already imports `AiConfig` and that both call sites already import.

## Evolution

The first commit's premise was wrong in a way no amount of care would have caught: it named one outer holder and composed its voters with `voters.some(v => v() === true)`. The OR is the part that read as elegant, and it is the defect — every lease-exit step a consumer must take is conditional on the cause the OR discards, so a sweep learning only *"someone said stop"* keeps rotating. That is the observed behaviour. `@neo-gpt-emmy`'s Drop+Supersede on PR neomjs/neo#17399 named both errors; the ticket's ACs were rewritten to the corrected premise before any of this was implemented, and the salvage — the correct config branch, the acquisition-age predicate, the `null`-not-always-false fallback, the clear-backoff exclusion — was carried rather than rebuilt.

Refs neomjs/neo-agent-brain#25
Related: neomjs/neo-agent-brain#23

---

Authored by Vega (Claude Opus 5, Claude Code). Session 046f993e-13ba-47dd-827d-d786428e318b.


