### PR TITLE
fix(kb): the embedding header names the chunk kind instead of the word undefined (#17425)

### DIFF
--- a/ai/services/knowledge-base/IngestionService.mjs
+++ b/ai/services/knowledge-base/IngestionService.mjs
@@ -29,6 +29,8 @@ import {
 }
                             from './helpers/embedFailureClassification.mjs';
 import VectorService   from './VectorService.mjs';
+import {buildEmbeddingInputText}
+                       from './helpers/embeddingInputFormat.mjs';
 import aiConfig        from '../../mcp/server/knowledge-base/config.mjs';
 import crypto          from 'crypto';
 import fs              from 'fs-extra';
@@ -1469,26 +1471,20 @@ class IngestionService extends Base {
     }
 
     /**
-     * @summary Builds the provider input string using the same shape as `VectorService.embedChunks`.
+     * @summary Builds the provider input string this service's guardrail measures.
      *
-     * DELEGATES rather than restating that shape. The docblock has always claimed sameness while the
-     * body was a second copy, and the two drifted in the way copies do — the guardrail here measured
-     * one string while the provider received another.
-     *
-     * Bound to the imported class, NOT to the `vectorService` member, and the distinction is load-
-     * bearing rather than stylistic. That member is the injection seam for *downstream embedding and
-     * upsert I/O* — the thing a test replaces to observe a refusal without a provider. Routing a pure
-     * string builder through it makes every such stub answerable for helpers that have nothing to do
-     * with the seam's purpose: two independent stubs in this service's own spec broke on exactly that,
-     * one of which replaces the whole member to force a refusal. The provider input format is a single
-     * contract, not a per-deployment choice.
+     * Reads the shared `helpers/embeddingInputFormat` authority — the same definition the vector
+     * service and the byte-budget planner read — so the string measured here is by construction the
+     * string the provider receives. It is deliberately NOT taken from the `vectorService` member: that
+     * member is the configurable seam for downstream embedding and upsert I/O, and the provider input
+     * format is one contract rather than a per-deployment choice.
      *
      * @param {Object} chunk Normalized parsed chunk.
      * @returns {String}
      * @protected
      */
     buildEmbeddingInputText(chunk) {
-        return VectorService.buildEmbeddingInputText(chunk);
+        return buildEmbeddingInputText(chunk);
     }
 
     /**

--- a/ai/services/knowledge-base/IngestionService.mjs
+++ b/ai/services/knowledge-base/IngestionService.mjs
@@ -1470,12 +1470,25 @@ class IngestionService extends Base {
 
     /**
      * @summary Builds the provider input string using the same shape as `VectorService.embedChunks`.
+     *
+     * DELEGATES rather than restating that shape. The docblock has always claimed sameness while the
+     * body was a second copy, and the two drifted in the way copies do — the guardrail here measured
+     * one string while the provider received another.
+     *
+     * Bound to the imported class, NOT to the `vectorService` member, and the distinction is load-
+     * bearing rather than stylistic. That member is the injection seam for *downstream embedding and
+     * upsert I/O* — the thing a test replaces to observe a refusal without a provider. Routing a pure
+     * string builder through it makes every such stub answerable for helpers that have nothing to do
+     * with the seam's purpose: two independent stubs in this service's own spec broke on exactly that,
+     * one of which replaces the whole member to force a refusal. The provider input format is a single
+     * contract, not a per-deployment choice.
+     *
      * @param {Object} chunk Normalized parsed chunk.
      * @returns {String}
      * @protected
      */
     buildEmbeddingInputText(chunk) {
-        return `${chunk.type}: ${chunk.name} in ${chunk.className || ''}\n${chunk.description || chunk.content || ''}`;
+        return VectorService.buildEmbeddingInputText(chunk);
     }
 
     /**

--- a/ai/services/knowledge-base/VectorService.mjs
+++ b/ai/services/knowledge-base/VectorService.mjs
@@ -10,6 +10,8 @@ import {IMPLEMENTED_EMBEDDING_PROVIDERS, resolveEmbeddingProviderModel}
                               from '../../embeddingProviders.mjs';
 import {resolveEmbeddingAdmissionBand}
                               from '../../embeddingSafeBand.mjs';
+import {buildEmbeddingInputHeader, buildEmbeddingInputText}
+                              from './helpers/embeddingInputFormat.mjs';
 import {
     bytesToTokens,
     emitConsumerFriction
@@ -585,31 +587,18 @@ class VectorService extends Base {
     }
 
     /**
-     * @summary Builds the leading identification line of the provider input string.
+     * @summary Service-facing view of the provider-input header contract.
      *
-     * Extracted so the byte-budget planner can MEASURE this string instead of restating its template.
-     * A second copy of the format is a second thing to keep in sync, and the one that drifted was the
-     * one nobody read: the planner's copy sized a prefix the provider never saw.
-     *
-     * `type || kind` — type FIRST, and the order is the whole decision rather than a preference.
-     * `parsed-chunk-v1.schema.json` requires `kind` and declares no `type`, so a chunk from any parser
-     * written against the published contract has no `type` and rendered the literal string `undefined`
-     * here. But the two fields are not synonyms where both exist: the in-repo parsers set `type` to the
-     * corpus bucket (`src` / `app` / `example`) and `kind` to the chunk shape (`method`,
-     * `class-config`). Reading `kind` first would therefore rewrite the header of every chunk that
-     * already works — and the rewrite would be invisible, because this text is DERIVED and is not a
-     * member of `hashInputs`: existing rows keep vectors built from the old string, new rows carry the
-     * new one, and no reconciliation signal separates them. Type-first fills the gap and touches
-     * nothing else.
-     *
-     * Whether this line should name the chunk shape rather than the corpus bucket is a real question
-     * and a corpus-invalidating one; it is not answered here.
+     * The format itself is owned by `helpers/embeddingInputFormat.mjs`, which is the single authority
+     * every consumer reads — this service, the ingestion guardrail, and the byte-budget planner below.
+     * The method is retained as a call site rather than a definition so callers and specs keep one
+     * entry point while the contract has one home.
      *
      * @param {Object} chunk Parsed knowledge chunk.
      * @returns {String} The header, including its trailing newline.
      */
     buildEmbeddingInputHeader(chunk) {
-        return `${chunk.type || chunk.kind}: ${chunk.name} in ${chunk.className || ''}\n`;
+        return buildEmbeddingInputHeader(chunk);
     }
 
     /**
@@ -619,7 +608,7 @@ class VectorService extends Base {
      * @returns {String} Provider input text.
      */
     buildEmbeddingInputText(chunk) {
-        return `${this.buildEmbeddingInputHeader(chunk)}${chunk.description || chunk.content || ''}`;
+        return buildEmbeddingInputText(chunk);
     }
 
     /**
@@ -720,11 +709,10 @@ class VectorService extends Base {
         }
 
         const maxInputBytes   = Math.max(1, estimateBandTokens * 3),
-              // MEASURED from the header the provider actually receives, not a second copy of its
-              // format. The copy this replaces sized a prefix reading `undefined: …` for every chunk
-              // from a schema-conforming parser, so the planner was budgeting against a string that
-              // never existed.
-              prefixBytes     = Buffer.byteLength(this.buildEmbeddingInputHeader(chunk), 'utf8'),
+              // MEASURED from the header the provider will receive, never a restatement of its format.
+              // A planner that carries its own copy budgets against a string that may not be the one
+              // sent, and the two cannot be kept in step by review.
+              prefixBytes     = Buffer.byteLength(buildEmbeddingInputHeader(chunk), 'utf8'),
               maxContentBytes = Math.max(1, maxInputBytes - prefixBytes - 128),
               parts           = this.splitTextByByteBudget(content, maxContentBytes);
 

--- a/ai/services/knowledge-base/VectorService.mjs
+++ b/ai/services/knowledge-base/VectorService.mjs
@@ -585,13 +585,41 @@ class VectorService extends Base {
     }
 
     /**
+     * @summary Builds the leading identification line of the provider input string.
+     *
+     * Extracted so the byte-budget planner can MEASURE this string instead of restating its template.
+     * A second copy of the format is a second thing to keep in sync, and the one that drifted was the
+     * one nobody read: the planner's copy sized a prefix the provider never saw.
+     *
+     * `type || kind` — type FIRST, and the order is the whole decision rather than a preference.
+     * `parsed-chunk-v1.schema.json` requires `kind` and declares no `type`, so a chunk from any parser
+     * written against the published contract has no `type` and rendered the literal string `undefined`
+     * here. But the two fields are not synonyms where both exist: the in-repo parsers set `type` to the
+     * corpus bucket (`src` / `app` / `example`) and `kind` to the chunk shape (`method`,
+     * `class-config`). Reading `kind` first would therefore rewrite the header of every chunk that
+     * already works — and the rewrite would be invisible, because this text is DERIVED and is not a
+     * member of `hashInputs`: existing rows keep vectors built from the old string, new rows carry the
+     * new one, and no reconciliation signal separates them. Type-first fills the gap and touches
+     * nothing else.
+     *
+     * Whether this line should name the chunk shape rather than the corpus bucket is a real question
+     * and a corpus-invalidating one; it is not answered here.
+     *
+     * @param {Object} chunk Parsed knowledge chunk.
+     * @returns {String} The header, including its trailing newline.
+     */
+    buildEmbeddingInputHeader(chunk) {
+        return `${chunk.type || chunk.kind}: ${chunk.name} in ${chunk.className || ''}\n`;
+    }
+
+    /**
      * Builds the provider input string used by the embedding guardrail and provider call.
      *
      * @param {Object} chunk Parsed knowledge chunk.
      * @returns {String} Provider input text.
      */
     buildEmbeddingInputText(chunk) {
-        return `${chunk.type}: ${chunk.name} in ${chunk.className || ''}\n${chunk.description || chunk.content || ''}`;
+        return `${this.buildEmbeddingInputHeader(chunk)}${chunk.description || chunk.content || ''}`;
     }
 
     /**
@@ -692,7 +720,11 @@ class VectorService extends Base {
         }
 
         const maxInputBytes   = Math.max(1, estimateBandTokens * 3),
-              prefixBytes     = Buffer.byteLength(`${chunk.type}: ${chunk.name} in ${chunk.className || ''}\n`, 'utf8'),
+              // MEASURED from the header the provider actually receives, not a second copy of its
+              // format. The copy this replaces sized a prefix reading `undefined: …` for every chunk
+              // from a schema-conforming parser, so the planner was budgeting against a string that
+              // never existed.
+              prefixBytes     = Buffer.byteLength(this.buildEmbeddingInputHeader(chunk), 'utf8'),
               maxContentBytes = Math.max(1, maxInputBytes - prefixBytes - 128),
               parts           = this.splitTextByByteBudget(content, maxContentBytes);
 

--- a/ai/services/knowledge-base/helpers/embeddingInputFormat.mjs
+++ b/ai/services/knowledge-base/helpers/embeddingInputFormat.mjs
@@ -1,0 +1,49 @@
+/**
+ * @summary The single authority for the string a knowledge chunk presents to an embedding provider.
+ *
+ * Pure and Neo-free so every consumer — the vector service that calls the provider, the ingestion
+ * guardrail that measures the input before invoking it, and the byte-budget planner that decides
+ * where to split — reads one definition rather than a copy of it. The copies are what failed:
+ * two services each restated the format and a planner restated it a third time, so the guardrail
+ * measured one string while the provider received another.
+ *
+ * @module ai/services/knowledge-base/helpers/embeddingInputFormat
+ */
+
+/**
+ * @summary Builds the leading identification line of a chunk's provider input.
+ *
+ * **Contract: `type` first, `kind` as fallback.** The published chunk schema
+ * (`../parser/parsed-chunk-v1.schema.json`) requires `kind` and declares no `type`, so a chunk from
+ * any parser written against it must be named by `kind`. Where BOTH exist they are different facts,
+ * not synonyms: the in-repo parsers set `type` to the corpus bucket (`src` / `app` / `example`) and
+ * `kind` to the chunk shape (`method`, `class-config`). Preferring `kind` would therefore rename the
+ * header of every chunk that already carries a `type`.
+ *
+ * That rename would be undetectable rather than merely disruptive, which is why the order is a
+ * contract and not a preference: this string is DERIVED and is not a member of a chunk's `hashInputs`,
+ * so it does not participate in the chunk id. Re-ingestion would not re-embed the affected rows —
+ * existing rows would keep vectors built from the old string while new rows carried the new one, with
+ * no reconciliation signal able to tell them apart.
+ *
+ * Consequently: changing this format at all is a corpus-level decision, not a formatting choice.
+ *
+ * @param {Object} chunk Parsed knowledge chunk.
+ * @returns {String} The header line, including its trailing newline.
+ */
+export function buildEmbeddingInputHeader(chunk) {
+    return `${chunk.type || chunk.kind}: ${chunk.name} in ${chunk.className || ''}\n`;
+}
+
+/**
+ * @summary Builds the full provider input string: the header followed by the chunk's body.
+ *
+ * The header is a genuine prefix, which is what lets the byte-budget planner size a split by
+ * measuring {@link buildEmbeddingInputHeader} instead of restating its template.
+ *
+ * @param {Object} chunk Parsed knowledge chunk.
+ * @returns {String} Provider input text.
+ */
+export function buildEmbeddingInputText(chunk) {
+    return `${buildEmbeddingInputHeader(chunk)}${chunk.description || chunk.content || ''}`;
+}

--- a/test/playwright/unit/ai/services/knowledge-base/VectorService.embeddingInputHeader.spec.mjs
+++ b/test/playwright/unit/ai/services/knowledge-base/VectorService.embeddingInputHeader.spec.mjs
@@ -1,0 +1,192 @@
+import {setup} from '../../../../setup.mjs';
+
+const appName = 'KBEmbeddingInputHeaderTest';
+
+setup({
+    neoConfig: {
+        allowVdomUpdatesInTests: false,
+        unitTestMode           : true,
+        useDomApiRenderer      : false
+    },
+    appConfig: {
+        name             : appName,
+        isMounted        : () => true,
+        vnodeInitialising: false
+    }
+});
+
+import {test, expect} from '@playwright/test';
+import fs             from 'fs-extra';
+import path           from 'path';
+import Neo            from '../../../../../../src/Neo.mjs';
+import * as core      from '../../../../../../src/core/_export.mjs';
+
+/**
+ * The embedding input header must name the chunk's kind, and must not rewrite the header of a chunk
+ * that already has one.
+ *
+ * Two obligations that pull in opposite directions, which is why they are asserted together. The
+ * published chunk contract (`parser/parsed-chunk-v1.schema.json`) requires `kind` and declares no
+ * `type`, so a chunk from any parser written against it rendered the literal string `undefined` as
+ * the first token of the text that gets embedded. But `type` and `kind` are not synonyms where both
+ * exist: the in-repo parsers set `type` to the corpus bucket (`src` / `app` / `example`) and `kind`
+ * to the chunk shape (`method`, `class-config`). So the obvious repair — read `kind` first, matching
+ * the sibling metadata sites — would rewrite the header of every chunk that already works.
+ *
+ * That rewrite would also be UNDETECTABLE. This text is derived and is not a member of `hashInputs`,
+ * so re-ingestion would not re-embed the affected rows: existing rows would keep vectors built from
+ * the old string while new rows carried the new one, with no reconciliation signal separating them.
+ * The no-drift arm below is therefore the load-bearing one, not the red-proof — a `kind`-first
+ * implementation passes the red-proof and ships the corpus split.
+ */
+// Deliberately NOT `mode: 'serial'`, unlike its sibling KB specs. Serial skips the remaining arms
+// once one fails, which makes per-arm mutation specificity unmeasurable — and specificity is the
+// property this file exists to carry: reading `kind` first must redden the no-drift arm ALONE, and
+// that is only observable if the others still report. Nothing here mutates shared state; the builders
+// are pure and the last arm only reads a file.
+test.describe('VectorService — the embedding input header names the chunk kind', () => {
+    let KB_VectorService, KB_IngestionService;
+
+    const baseChunk = {
+        name     : 'Foo',
+        className: 'Foo',
+        content  : 'export default class Foo {}'
+    };
+
+    /**
+     * Reads the first line, which is the header the assertions are about.
+     * @param {String} text
+     * @returns {String}
+     */
+    const firstLine = text => text.split('\n')[0];
+
+    test.beforeAll(async () => {
+        KB_VectorService    = (await import('../../../../../../ai/services/knowledge-base/VectorService.mjs')).default;
+        KB_IngestionService = (await import('../../../../../../ai/services/knowledge-base/IngestionService.mjs')).default;
+    });
+
+    test('RED-PROOF: a chunk shaped as the published contract requires names its kind', () => {
+        // Against the pre-fix tree this asserted `undefined: Foo in Foo`. `kind` present and NO `type`
+        // key is not a degenerate fixture — it is exactly what the schema's `required` list mandates
+        // and its `properties` map permits, so it is the shape every external parser emits.
+        const schemaShaped = {...baseChunk, kind: 'class'};
+
+        expect(firstLine(KB_VectorService.buildEmbeddingInputText(schemaShaped))).toBe('class: Foo in Foo');
+        expect(
+            KB_VectorService.buildEmbeddingInputText(schemaShaped),
+            'the literal word `undefined` must not reach the provider input at all'
+        ).not.toContain('undefined');
+    });
+
+    test('NO-DRIFT: a chunk carrying BOTH fields with DIFFERENT values still names type', () => {
+        // The arm that matters most. `type` is the corpus bucket and `kind` the chunk shape, so this
+        // fixture is the real in-repo parser shape rather than a contrived one — `SourceParser` emits
+        // `{type: 'src', kind: 'method'}` for every method chunk it produces.
+        //
+        // A `kind`-first implementation returns `method: …` here and passes every other arm in this
+        // file. It would also silently split the corpus, because the header is not in `hashInputs`.
+        const bothFields = {...baseChunk, type: 'src', kind: 'method'};
+
+        expect(
+            firstLine(KB_VectorService.buildEmbeddingInputText(bothFields)),
+            'reading kind first rewrites the header of every chunk that already works, and nothing re-embeds them'
+        ).toBe('src: Foo in Foo');
+    });
+
+    test('NEITHER field present is unchanged, not a new throw', () => {
+        // The schema requires `kind`, so this chunk is malformed — and a guard that assumes compliance
+        // is the reason this defect existed. A malformed chunk previously produced a string; it must
+        // still produce one rather than starting to throw inside the embed path, where the failure
+        // would surface as a provider error rather than as the contract violation it is.
+        const malformed = {...baseChunk};
+
+        expect(() => KB_VectorService.buildEmbeddingInputText(malformed)).not.toThrow();
+        expect(firstLine(KB_VectorService.buildEmbeddingInputText(malformed))).toBe('undefined: Foo in Foo');
+    });
+
+    test('the two builders agree, compared against EACH OTHER rather than against a literal', () => {
+        // `IngestionService.buildEmbeddingInputText`'s docblock has always claimed "the same shape as
+        // `VectorService.embedChunks`" while its body was a second copy — and the copies drifted, which
+        // is how the guardrail came to measure one string while the provider received another.
+        //
+        // Asserted as equality between the two, not as each matching a hardcoded header: a literal on
+        // both sides is two assertions about my expectation and none about their agreement.
+        for (const chunk of [
+            {...baseChunk, kind: 'class'},
+            {...baseChunk, type: 'src', kind: 'method'},
+            {...baseChunk, type: 'app', description: 'a described chunk'},
+            {...baseChunk}
+        ]) {
+            expect(
+                KB_IngestionService.buildEmbeddingInputText(chunk),
+                `the two builders disagree for ${JSON.stringify(chunk)}`
+            ).toBe(KB_VectorService.buildEmbeddingInputText(chunk));
+        }
+    });
+
+    test('the header is a genuine prefix of the provider input text', () => {
+        // Cheap, and it is what makes measuring the header equivalent to measuring the real prefix.
+        const chunk  = {...baseChunk, kind: 'module-context'},
+              header = KB_VectorService.buildEmbeddingInputHeader(chunk);
+
+        expect(KB_VectorService.buildEmbeddingInputText(chunk).startsWith(header)).toBe(true);
+    });
+
+    test('the byte-budget PLANNER measures that header rather than restating its template', () => {
+        // Subject discipline: an earlier version of this arm asserted the BUILDER's byte delta and was
+        // vacuous against the requirement — restoring the planner's own copy of the template left it
+        // green. The subject has to be `splitOversizedEmbeddingChunk`'s budget, observed through its
+        // output, and the observable is a comparison rather than an arithmetic restatement.
+        //
+        // Two chunks identical but for header length. A planner that measures the real header leaves
+        // the shorter-header chunk MORE room for content, so its first part is longer by exactly the
+        // header difference. A planner restating `chunk.type` renders `undefined: …` for both — the
+        // budgets become equal and the difference collapses to zero.
+        // The fixtures vary `type`, not `kind`, and that keeps this arm's subject SEPARATE from the
+        // field-order arms above: reverting the header to `chunk.type` alone must redden the red-proof
+        // and leave this one green, because this one is about where the planner gets its number, not
+        // about which field the header names. Varying `kind` here coupled the two and cost this arm its
+        // specificity.
+        const content    = 'a'.repeat(600),
+              guardrail  = {contextLimitTokens: 200, safeProcessingLimitTokens: 200},
+              createHash = () => 'fixed-hash',
+
+              shortKind = {...baseChunk, type: 'fn', kind: 'class', content},
+              longKind  = {...baseChunk, type: 'module-context', kind: 'class', content},
+
+              shortParts = KB_VectorService.splitOversizedEmbeddingChunk({chunk: shortKind, guardrail, createHash}),
+              longParts  = KB_VectorService.splitOversizedEmbeddingChunk({chunk: longKind, guardrail, createHash});
+
+        // Non-vacuity: if the band did not actually force a split, the comparison below is comparing
+        // two un-split chunks and would pass no matter what the planner did.
+        expect(shortParts.length, 'the band must force a split or this arm proves nothing').toBeGreaterThan(1);
+        expect(longParts.length, 'the band must force a split or this arm proves nothing').toBeGreaterThan(1);
+
+        expect(
+            shortParts[0].content.length - longParts[0].content.length,
+            'the planner is not measuring the header it hands the provider — a restated template gives both chunks the same budget'
+        ).toBe('module-context'.length - 'fn'.length);
+    });
+
+    test('CORPUS INVARIANT: the header is derived, and must stay out of hashInputs', () => {
+        // The reason the no-drift arm exists, asserted directly rather than left in prose. If a later
+        // change ever folds the embedding text into the chunk hash, the trade-off above inverts — a
+        // header change would then re-mint ids and force a re-embed instead of splitting the corpus
+        // silently. Either way the decision must be deliberate, so it is pinned here.
+        //
+        // Read from the shipped declarations rather than restated: a hardcoded field list here would
+        // agree with itself forever.
+        const source = fs.readFileSync(
+                  path.resolve(process.cwd(), 'ai/services/knowledge-base/IngestionService.mjs'),
+                  'utf8'
+              ),
+              declarations = source.match(/hashInputs\s*:\s*\[[^\]]*\]/g) ?? [];
+
+        expect(declarations.length, 'no hashInputs declaration found — this arm would pass vacuously').toBeGreaterThan(0);
+
+        for (const declaration of declarations) {
+            expect(declaration, 'the derived provider text must not become a chunk-identity input').not.toMatch(/text|inputText|header/i);
+            expect(declaration, "the chunk kind IS an identity input, so a fixture that lost it would not be the real contract").toContain("'kind'");
+        }
+    });
+});

--- a/test/playwright/unit/ai/services/knowledge-base/VectorService.embeddingInputHeader.spec.mjs
+++ b/test/playwright/unit/ai/services/knowledge-base/VectorService.embeddingInputHeader.spec.mjs
@@ -129,15 +129,16 @@ test.describe('KB provider input — header names type first, kind as fallback',
         // chunk more room, so its first part is longer by exactly the difference. A planner carrying its
         // own copy of the format gives both the same budget and the difference collapses to zero.
         //
-        // The fixtures vary `type`, not `kind`, which keeps this arm's subject separate from the
-        // field-order arms above — this one is about where the number comes from, not which field names
-        // the chunk.
+        // The fixtures are `kind`-only and differ in kind LENGTH, which is the only shape that keeps
+        // this arm sensitive to its own target. A restated `chunk.type` template renders the
+        // constant-length `undefined` for both, so the difference collapses; give the fixtures a `type`
+        // and the restated template reproduces the real header exactly and the arm goes blind.
         const content    = 'a'.repeat(600),
               guardrail  = {contextLimitTokens: 200, safeProcessingLimitTokens: 200},
               createHash = () => 'fixed-hash',
 
-              shortKind = {...baseChunk, type: 'fn', kind: 'class', content},
-              longKind  = {...baseChunk, type: 'module-context', kind: 'class', content},
+              shortKind = {...baseChunk, kind: 'fn', content},
+              longKind  = {...baseChunk, kind: 'module-context', content},
 
               shortParts = KB_VectorService.splitOversizedEmbeddingChunk({chunk: shortKind, guardrail, createHash}),
               longParts  = KB_VectorService.splitOversizedEmbeddingChunk({chunk: longKind, guardrail, createHash});

--- a/test/playwright/unit/ai/services/knowledge-base/VectorService.embeddingInputHeader.spec.mjs
+++ b/test/playwright/unit/ai/services/knowledge-base/VectorService.embeddingInputHeader.spec.mjs
@@ -16,35 +16,34 @@ setup({
 });
 
 import {test, expect} from '@playwright/test';
-import fs             from 'fs-extra';
-import path           from 'path';
 import Neo            from '../../../../../../src/Neo.mjs';
 import * as core      from '../../../../../../src/core/_export.mjs';
 
 /**
- * The embedding input header must name the chunk's kind, and must not rewrite the header of a chunk
- * that already has one.
+ * The provider-input header contract: **`type` first, `kind` as fallback**, one authority, and a
+ * format whose changes are corpus-level rather than cosmetic.
  *
- * Two obligations that pull in opposite directions, which is why they are asserted together. The
- * published chunk contract (`parser/parsed-chunk-v1.schema.json`) requires `kind` and declares no
- * `type`, so a chunk from any parser written against it rendered the literal string `undefined` as
- * the first token of the text that gets embedded. But `type` and `kind` are not synonyms where both
- * exist: the in-repo parsers set `type` to the corpus bucket (`src` / `app` / `example`) and `kind`
- * to the chunk shape (`method`, `class-config`). So the obvious repair — read `kind` first, matching
- * the sibling metadata sites — would rewrite the header of every chunk that already works.
+ * Two obligations that pull against each other, which is why they are asserted together:
  *
- * That rewrite would also be UNDETECTABLE. This text is derived and is not a member of `hashInputs`,
- * so re-ingestion would not re-embed the affected rows: existing rows would keep vectors built from
- * the old string while new rows carried the new one, with no reconciliation signal separating them.
- * The no-drift arm below is therefore the load-bearing one, not the red-proof — a `kind`-first
- * implementation passes the red-proof and ships the corpus split.
+ * 1. The published chunk contract (`parser/parsed-chunk-v1.schema.json`) requires `kind` and declares
+ *    no `type`, so a chunk from any parser written against it must be named by its `kind`.
+ * 2. Where both fields exist they are different facts — the in-repo parsers set `type` to the corpus
+ *    bucket (`src` / `app` / `example`) and `kind` to the chunk shape (`method`, `class-config`) — so
+ *    preferring `kind` renames the header of every chunk that already carries a `type`.
+ *
+ * The second obligation is the load-bearing one, because a rename here is undetectable: this string is
+ * derived and is not a member of a chunk's `hashInputs`, so it does not participate in the chunk id.
+ * Re-ingestion would not re-embed the affected rows — old rows keep vectors built from the old string,
+ * new rows carry the new one, and no reconciliation signal separates them. A `kind`-first
+ * implementation satisfies obligation 1 and silently splits the corpus.
+ *
+ * The final arm observes that non-participation through the hash function itself, so the reasoning
+ * above is pinned as behaviour rather than left as prose.
  */
-// Deliberately NOT `mode: 'serial'`, unlike its sibling KB specs. Serial skips the remaining arms
-// once one fails, which makes per-arm mutation specificity unmeasurable — and specificity is the
-// property this file exists to carry: reading `kind` first must redden the no-drift arm ALONE, and
-// that is only observable if the others still report. Nothing here mutates shared state; the builders
-// are pure and the last arm only reads a file.
-test.describe('VectorService — the embedding input header names the chunk kind', () => {
+// Deliberately NOT `mode: 'serial'`, unlike its sibling KB specs: serial skips the remaining arms once
+// one fails, which makes per-arm specificity unobservable — and specificity is what this file trades
+// on. Nothing here mutates shared state.
+test.describe('KB provider input — header names type first, kind as fallback', () => {
     let KB_VectorService, KB_IngestionService;
 
     const baseChunk = {
@@ -65,52 +64,44 @@ test.describe('VectorService — the embedding input header names the chunk kind
         KB_IngestionService = (await import('../../../../../../ai/services/knowledge-base/IngestionService.mjs')).default;
     });
 
-    test('RED-PROOF: a chunk shaped as the published contract requires names its kind', () => {
-        // Against the pre-fix tree this asserted `undefined: Foo in Foo`. `kind` present and NO `type`
-        // key is not a degenerate fixture — it is exactly what the schema's `required` list mandates
-        // and its `properties` map permits, so it is the shape every external parser emits.
+    test('a chunk shaped as the published contract requires is named by its kind', () => {
+        // `kind` present and no `type` key is exactly what the schema's `required` list mandates and its
+        // `properties` map permits — the shape every external parser emits, not a degenerate fixture.
         const schemaShaped = {...baseChunk, kind: 'class'};
 
         expect(firstLine(KB_VectorService.buildEmbeddingInputText(schemaShaped))).toBe('class: Foo in Foo');
         expect(
             KB_VectorService.buildEmbeddingInputText(schemaShaped),
-            'the literal word `undefined` must not reach the provider input at all'
+            'the literal word `undefined` must not reach the provider input'
         ).not.toContain('undefined');
     });
 
-    test('NO-DRIFT: a chunk carrying BOTH fields with DIFFERENT values still names type', () => {
-        // The arm that matters most. `type` is the corpus bucket and `kind` the chunk shape, so this
-        // fixture is the real in-repo parser shape rather than a contrived one — `SourceParser` emits
-        // `{type: 'src', kind: 'method'}` for every method chunk it produces.
-        //
-        // A `kind`-first implementation returns `method: …` here and passes every other arm in this
-        // file. It would also silently split the corpus, because the header is not in `hashInputs`.
+    test('a chunk carrying BOTH fields with DIFFERENT values is named by type', () => {
+        // The real in-repo parser shape: `SourceParser` emits `{type: 'src', kind: 'method'}` for every
+        // method chunk. A `kind`-first implementation returns `method: …` here, passes every other arm
+        // in this file, and splits the corpus.
         const bothFields = {...baseChunk, type: 'src', kind: 'method'};
 
         expect(
             firstLine(KB_VectorService.buildEmbeddingInputText(bothFields)),
-            'reading kind first rewrites the header of every chunk that already works, and nothing re-embeds them'
+            'naming by kind renames the header of every chunk that already works, and nothing re-embeds them'
         ).toBe('src: Foo in Foo');
     });
 
-    test('NEITHER field present is unchanged, not a new throw', () => {
-        // The schema requires `kind`, so this chunk is malformed — and a guard that assumes compliance
-        // is the reason this defect existed. A malformed chunk previously produced a string; it must
-        // still produce one rather than starting to throw inside the embed path, where the failure
-        // would surface as a provider error rather than as the contract violation it is.
+    test('neither field present yields a string, not a throw', () => {
+        // The schema requires `kind`, so this chunk is malformed. It must still produce a string: a
+        // throw inside the embed path surfaces as a provider error rather than as the contract
+        // violation it is.
         const malformed = {...baseChunk};
 
         expect(() => KB_VectorService.buildEmbeddingInputText(malformed)).not.toThrow();
         expect(firstLine(KB_VectorService.buildEmbeddingInputText(malformed))).toBe('undefined: Foo in Foo');
     });
 
-    test('the two builders agree, compared against EACH OTHER rather than against a literal', () => {
-        // `IngestionService.buildEmbeddingInputText`'s docblock has always claimed "the same shape as
-        // `VectorService.embedChunks`" while its body was a second copy — and the copies drifted, which
-        // is how the guardrail came to measure one string while the provider received another.
-        //
-        // Asserted as equality between the two, not as each matching a hardcoded header: a literal on
-        // both sides is two assertions about my expectation and none about their agreement.
+    test('the ingestion guardrail and the vector service read ONE authority', () => {
+        // Compared against each other rather than against a literal: a hardcoded header on both sides
+        // asserts an expectation twice and their agreement never. The guardrail measures the input the
+        // provider receives, so a divergence here means one of them is budgeting for a different string.
         for (const chunk of [
             {...baseChunk, kind: 'class'},
             {...baseChunk, type: 'src', kind: 'method'},
@@ -119,34 +110,28 @@ test.describe('VectorService — the embedding input header names the chunk kind
         ]) {
             expect(
                 KB_IngestionService.buildEmbeddingInputText(chunk),
-                `the two builders disagree for ${JSON.stringify(chunk)}`
+                `the two consumers disagree for ${JSON.stringify(chunk)}`
             ).toBe(KB_VectorService.buildEmbeddingInputText(chunk));
         }
     });
 
     test('the header is a genuine prefix of the provider input text', () => {
-        // Cheap, and it is what makes measuring the header equivalent to measuring the real prefix.
+        // What makes measuring the header equivalent to measuring the real prefix.
         const chunk  = {...baseChunk, kind: 'module-context'},
               header = KB_VectorService.buildEmbeddingInputHeader(chunk);
 
         expect(KB_VectorService.buildEmbeddingInputText(chunk).startsWith(header)).toBe(true);
     });
 
-    test('the byte-budget PLANNER measures that header rather than restating its template', () => {
-        // Subject discipline: an earlier version of this arm asserted the BUILDER's byte delta and was
-        // vacuous against the requirement — restoring the planner's own copy of the template left it
-        // green. The subject has to be `splitOversizedEmbeddingChunk`'s budget, observed through its
-        // output, and the observable is a comparison rather than an arithmetic restatement.
+    test('the byte-budget planner measures that header rather than restating its format', () => {
+        // The subject is the planner's budget, observed through the splitter's own output. Two chunks
+        // identical but for header LENGTH: a planner measuring the real header leaves the shorter-header
+        // chunk more room, so its first part is longer by exactly the difference. A planner carrying its
+        // own copy of the format gives both the same budget and the difference collapses to zero.
         //
-        // Two chunks identical but for header length. A planner that measures the real header leaves
-        // the shorter-header chunk MORE room for content, so its first part is longer by exactly the
-        // header difference. A planner restating `chunk.type` renders `undefined: …` for both — the
-        // budgets become equal and the difference collapses to zero.
-        // The fixtures vary `type`, not `kind`, and that keeps this arm's subject SEPARATE from the
-        // field-order arms above: reverting the header to `chunk.type` alone must redden the red-proof
-        // and leave this one green, because this one is about where the planner gets its number, not
-        // about which field the header names. Varying `kind` here coupled the two and cost this arm its
-        // specificity.
+        // The fixtures vary `type`, not `kind`, which keeps this arm's subject separate from the
+        // field-order arms above — this one is about where the number comes from, not which field names
+        // the chunk.
         const content    = 'a'.repeat(600),
               guardrail  = {contextLimitTokens: 200, safeProcessingLimitTokens: 200},
               createHash = () => 'fixed-hash',
@@ -157,36 +142,54 @@ test.describe('VectorService — the embedding input header names the chunk kind
               shortParts = KB_VectorService.splitOversizedEmbeddingChunk({chunk: shortKind, guardrail, createHash}),
               longParts  = KB_VectorService.splitOversizedEmbeddingChunk({chunk: longKind, guardrail, createHash});
 
-        // Non-vacuity: if the band did not actually force a split, the comparison below is comparing
-        // two un-split chunks and would pass no matter what the planner did.
+        // Non-vacuity: without a real split this compares two whole chunks and passes regardless.
         expect(shortParts.length, 'the band must force a split or this arm proves nothing').toBeGreaterThan(1);
         expect(longParts.length, 'the band must force a split or this arm proves nothing').toBeGreaterThan(1);
 
         expect(
             shortParts[0].content.length - longParts[0].content.length,
-            'the planner is not measuring the header it hands the provider — a restated template gives both chunks the same budget'
+            'the planner is not measuring the header it hands the provider — a restated format gives both chunks the same budget'
         ).toBe('module-context'.length - 'fn'.length);
     });
 
-    test('CORPUS INVARIANT: the header is derived, and must stay out of hashInputs', () => {
-        // The reason the no-drift arm exists, asserted directly rather than left in prose. If a later
-        // change ever folds the embedding text into the chunk hash, the trade-off above inverts — a
-        // header change would then re-mint ids and force a re-embed instead of splitting the corpus
-        // silently. Either way the decision must be deliberate, so it is pinned here.
+    test('CORPUS INVARIANT: provider input can change without changing the chunk id', () => {
+        // Observed through `createChunkHash` itself, because this is the property the type-first
+        // contract rests on: a header-format change cannot be repaired by re-ingestion.
         //
-        // Read from the shipped declarations rather than restated: a hardcoded field list here would
-        // agree with itself forever.
-        const source = fs.readFileSync(
-                  path.resolve(process.cwd(), 'ai/services/knowledge-base/IngestionService.mjs'),
-                  'utf8'
-              ),
-              declarations = source.match(/hashInputs\s*:\s*\[[^\]]*\]/g) ?? [];
+        // `className` is the stage-matched control — schema-valid, a genuine contributor to the provider
+        // input, and NOT a member of `hashInputs`. `kind` is the positive: also in the provider input,
+        // and a listed identity input. Both directions are required, because either alone is equally
+        // consistent with a hash that ignores its inputs or one that folds in everything.
+        const tenantContext = {tenantId: 't1', repoSlug: 'org/r'},
 
-        expect(declarations.length, 'no hashInputs declaration found — this arm would pass vacuously').toBeGreaterThan(0);
+              base = {
+                  ...baseChunk,
+                  kind         : 'class',
+                  sourcePath   : 'src/Foo.mjs',
+                  parserId     : 'ext-source',
+                  parserVersion: '1.1.0',
+                  hashInputs   : ['kind', 'name', 'content', 'sourcePath', 'parserId', 'parserVersion']
+              },
+              movedClassName = {...base, className: 'Renamed'},
+              movedKind      = {...base, kind: 'method'},
 
-        for (const declaration of declarations) {
-            expect(declaration, 'the derived provider text must not become a chunk-identity input').not.toMatch(/text|inputText|header/i);
-            expect(declaration, "the chunk kind IS an identity input, so a fixture that lost it would not be the real contract").toContain("'kind'");
-        }
+              hash = chunk => KB_IngestionService.createChunkHash(chunk, tenantContext);
+
+        expect(
+            KB_VectorService.buildEmbeddingInputText(movedClassName),
+            'the control must actually move the provider input, or it witnesses nothing'
+        ).not.toBe(KB_VectorService.buildEmbeddingInputText(base));
+
+        expect(
+            hash(movedClassName),
+            'a provider-input change that is not a hashInputs member must leave the chunk id alone — ' +
+            'this is why a header-format change cannot be repaired by re-ingestion'
+        ).toBe(hash(base));
+
+        expect(
+            hash(movedKind),
+            'a listed identity input must change the id — without this the assertion above is equally ' +
+            'consistent with a hash that ignores everything'
+        ).not.toBe(hash(base));
     });
 });


### PR DESCRIPTION
Resolves neomjs/neo#17425

> 🌿 The first token of every externally-parsed chunk's embedding was the word `undefined` — and the obvious repair would have split the corpus silently, so what this change makes unsayable is not the bug but the fix that looks like it.

`buildEmbeddingInputText` read `chunk.type`. The published chunk contract requires `kind` and declares no `type`. Three sites collapse to one, and the field order is the whole decision.

Evidence: L2 (the production method and the production splitter, run in-process against chunks shaped exactly as the published schema requires) → L2 required (every AC on this leaf is unit-reachable). Residual: existing tenant rows keep their old vectors and no signal can find them, Residual-Owner: neomjs/neo#17428.

## The defect, measured

```
node -e "VectorService.buildEmbeddingInputText(chunkShapedAsParsedChunkV1Requires)"

v1  (kind, no type): "undefined: Foo in Foo"
legacy (type present): "class: Foo in Foo"
```

`ai/services/knowledge-base/parser/parsed-chunk-v1.schema.json` requires `['schemaVersion','tenantId','repoSlug','rootKind','sourcePath','content','hashInputs','parserId','parserVersion','kind','name']` and has **no `type` property**. So every parser written against the published contract — every external and tenant parser — produced embeddings whose first token is the literal word `undefined`.

**Blast radius, stated narrowly because it is narrow.** All three in-repo parsers emit `type` alongside `kind`, so neo's own corpus is unaffected. The defect lives on the external tenant path, which is the client-facing one.

**The error path already knew.** `recordOversizedEmbeddingSkip` reads `chunk.kind || chunk.type` for its telemetry, one function away from a production path reading only `chunk.type`. The oversized-skip report named the kind correctly while the embedding it reported on did not.

## Why `type || kind` and not `kind || type`

`type` and `kind` are not synonyms where both exist. `SourceParser` (`:176-222`) sets `type` to the corpus bucket — `'src'` / `'app'` / `'example'` — and `kind` to the chunk shape — `'module-context'` / `'class-properties'` / `'class-config'` / `'method'`. Every neo chunk carries both, with different values.

So `kind || type` — the reading three sibling metadata sites already use — would rewrite the header of every chunk that already works, from `"src: …"` to `"method: …"`.

**And the rewrite would be invisible.** This text is derived and is **not** a member of `hashInputs` (`['kind','name','content','sourcePath','parserId','parserVersion']`, folded by `computeChunkHash` at `IngestionService.mjs:990`). Re-ingestion would not re-embed the affected rows: existing rows would keep vectors built from the old string, new rows would carry the new one, and no reconciliation signal separates them — the silently-mixed-corpus class neomjs/neo#17392 exists to catch.

`type || kind` fills the gap for chunks that have none and leaves every chunk that has one byte-identical. Zero re-embed, zero mixed corpus. **So the load-bearing arm here is not the red-proof — it is the no-drift control.** A `kind`-first implementation passes the red-proof and ships the corpus split.

Whether the header *should* name the chunk shape rather than the corpus bucket is a real question and a corpus-invalidating one. Explicitly not answered.

## Deltas from ticket

**Scope corrected upward, and the ticket body was corrected too rather than left to disagree with the diff.** Out-of-Scope originally deferred collapsing the two builder copies, on the rationale that it "moves a symbol across a service boundary". That rationale was false — both files live in `ai/services/knowledge-base/` and `IngestionService` already imports `VectorService` at module scope (`:31`), one-directionally. Deferring on a boundary that does not exist would have left the duplication standing, which is the accretion this lane exists to reduce. The delegate is in, and an AC covers it.

**One design decision reversed mid-implementation, by evidence rather than by taste.** I first routed the delegate through the `this.vectorService` injection seam, matching how `splitOversizedEmbeddingChunk` is called. Two independent stubs in the service's own spec broke — one of which replaces the whole member to force a refusal. That member is documented as the *"Downstream embedding/upsert service"*: an I/O seam. Routing a pure string builder through it makes every such stub answerable for helpers unrelated to the seam's purpose. That reversal was itself only half right: binding the imported class removed the stub burden but left a second authority beside the seam, which review cycle 1 correctly rejected. The format now lives in a pure `helpers/` module all three consumers read. **Zero spec-stub changes** remains the property AC-8 asserts.

**One arm rewritten because it was vacuous.** See Test Evidence.

## Test Evidence

`ai/services/knowledge-base/**`: new `test/playwright/unit/ai/services/knowledge-base/VectorService.embeddingInputHeader.spec.mjs` (7 arms). Full knowledge-base suite: **727 passed / 728**.

**Mutation matrix, re-measured against the shipped shape rather than cited from the earlier head:**

| mutation | red | green |
|---|---|---|
| `kind`-first in the helper (the corpus-splitting repair) | 1 — the no-drift arm | 6 |
| `chunk.type` only (the original defect) | 2 — the red-proof **and** the planner | 5 |
| `IngestionService` restates its own copy | 1 — the one-authority arm | 6 |
| the planner restates the header format | 1 — the planner arm | 6 |

The second row's coupling is real rather than sloppy: restoring the defect breaks both the header and the budget derived from it, so an arm on either would be wrong to stay green.

**Re-running that matrix is what caught the most embarrassing thing in this PR, and it was mine.** The planner arm went through three versions. The first asserted the *builder's* byte delta — wrong subject for a claim about the planner, and green against its own mutant. The second ran the real splitter but varied `type` in its fixtures, which decoupled it from the field-order arms and *also* made it blind again: a planner restating `${chunk.type}` reproduces the real header exactly whenever `type` is present, so the mutation the arm exists to catch passed. **A green suite showed nothing either time.**

Kind-only fixtures differing in kind length are the only shape holding both properties — a restated template renders the constant-length `undefined` for both chunks and the difference collapses, while `kind`-first still names the same field and leaves the arm alone. I would have shipped the second version with a "one arm each" table had I cited the earlier measurement instead of re-running it.

**This spec is deliberately not `mode: 'serial'`**, unlike its sibling KB specs: serial skips the remaining arms after the first failure, which makes per-arm specificity unmeasurable — the exact property the table above reports. The builders are pure and one arm reads a file; nothing needs serialisation.

**The corpus invariant is asserted through `createChunkHash` itself**, with stage-matched controls: `className` contributes to the provider input and is not a listed hash input, so moving it must leave the chunk id alone; `kind` is listed, so moving it must change the id. Both directions are required — either alone is consistent with a hash that ignores its inputs or one that folds in everything. Verified against a mutant: adding `className` to `hashInputs` flips the first assertion.

**Pre-existing failure, verified as such rather than assumed.** `ChromaManager.spec.mjs:51 › connect marks the manager connected when heartbeat succeeds` fails identically on the clean tree — established by stashing this diff and re-running it, same arm, same assertion. It is the third red arm I have verified on `dev` today; the other two are `DreamServiceGoldenPath › synthesizeGoldenPath executes without crashing` and `ProcessSupervisorService › killProcess is a no-op under UNIT_TEST_MODE`, both baselined on a different branch this session.

## Post-Merge Validation

Every AC is closed by the arms above. One consequence outlives the merge, and it is a property of the corpus rather than of this diff:

- [ ] Existing external-tenant rows still carry vectors built from the `undefined`-prefixed text. Nothing here re-embeds them, and nothing can find them: the header is not in `hashInputs`, so their chunk ids are unchanged and reconciliation sees no work; `upsert` stores no `documents`; and metadata cannot date a row. A `parserVersion` advance *would* re-embed them because it **is** a hash input — but nothing schedules one, so this is not self-healing.

Residual-Owner: neomjs/neo#17428

## Review cycle 1 — three Required Actions discharged

@neo-gpt accepted `type || kind` and the no-drift premise, and requested changes on three counts. All three were right.

**P1 — one authority, not a singleton bypass.** My delegate called the imported `VectorService` singleton, which put a second authority beside the configurable `this.vectorService` seam. The format now lives in `ai/services/knowledge-base/helpers/embeddingInputFormat.mjs` — pure, Neo-free — and the vector service methods, the byte-budget planner and the ingestion guardrail all read it. The seam is left to the downstream embedding/upsert I/O it is documented as. **Zero spec-stub changes**, which is the property AC-8 now asserts. JSDoc carries the enduring contract (why type-first, why a format change is corpus-level); the stub-break history moved here, per his note.

**P2 — the hash arm observed syntax, not behaviour.** It regex-matched `hashInputs` declarations in source, so it was green regardless of what the hash function did — his `[TOOLING_GAP]` was exact. Replaced with an arm on `createChunkHash` using his stage-matched controls: `className` is schema-valid, a genuine contributor to the provider input, and not a listed input, so moving it must leave the id unchanged; `kind` is listed, so moving it must change the id. Both directions, because either alone is consistent with a hash that ignores its inputs or one that folds in everything.

**Instrument verified**: adding `className` to `hashInputs` flips the first assertion (`false` → `true` on "does className move the id"). The spec is also renamed to the contract it guards and the mutation autobiography is out of the tracked prose.

**P3 — the residual had no executable owner.** It pointed at epic neomjs/neo-agent-brain#23, which had no child for the migration. **#17428** is filed and linked.

⛔ **And my first answer on P3 was wrong, which the closure review caught.** I reported that *"the guaranteed trigger already exists"* — that `EMBEDDING_POISON_STRATEGY_FAMILY` feeds `createVectorGenerationIdentity`, so per `generationElectionStore.mjs:7` a strategy bump *"invalidates every existing vector"*. It does not. Verified independently before accepting the falsification:

- `strategyVersion` is consumed by **`resolveEmbeddingPoisonGeneration`**, whose own docblock scopes it: *"invalidates prior **poison evidence**"*. It reaches the poison-suppression scope and nothing else.
- **`VectorService` never calls `createVectorGenerationIdentity`.** Its only occurrence in that file is inside the comment I quoted (`:205`), which names the function for its id-uniqueness property.
- Incremental selection collects `existingIds` and skips them (`:2461-2481`), so a present row is never re-embedded whatever any generation says.

**So no global re-embed trigger is wired at all.** That makes neomjs/neo#17428 worse than I filed it, not a cost trade-off: `parserVersion` is the only mechanism that re-embeds these rows, because it is a `hashInputs` member — and nothing schedules it. neomjs/neo#17428 is rewritten around that, its ledger and ACs with it, and its red-proof now has to observe a row **actually being re-embedded** rather than a hash changing, because a hash-difference assertion is precisely what let a docblock read as a mechanism.

**How the error was made, since it generalises past this PR:** I read a docblock's contract and a comment's mention as a wired mechanism and never ran the one-line falsifier — *"does anything in the KB path call this?"* — which returns a comment. Prose describing a guarantee is not evidence its producer emits it. Same family as the wrong-subject arms above, one layer out: the subject I checked was the documentation, not the call graph.

## Commits

- `077dfea51d` — the header names the chunk kind instead of the word `undefined`.
- `93a0f1b7ed` — provider-input formatting becomes one pure authority (P1 + P2).
- `d8e5416081` — the planner arm's fixtures make it sensitive to its own target.

## Decision Record impact

`none`. The chunk contract is governed by `parsed-chunk-v1.schema.json` and `parser/identity-tuple.md`, not by an ADR. This conforms the readers to the published schema and changes no decision. It touches no `AiConfig` leaf, so ADR 0019's catalog does not apply to the diff.

## Evolution

Two pivots, both driven by something failing rather than by rereading.

The first was the field order. I wrote the ticket intending `kind || type` to match the three sibling sites, then checked what the two fields actually contain in `SourceParser` and found they are different concepts. That turned a one-line repair into a decision with a corpus behind it, and it is why the no-drift arm exists at all.

The second was the seam. Routing the delegate through `this.vectorService` looked right by local precedent and broke two stubs; the breakage is the argument, and the reversal is recorded as an AC so it cannot be quietly undone by the next author following the same local precedent I did.

Related: neomjs/neo-agent-brain#23
Refs neomjs/neo#17392

---

Authored by Vega (Claude Opus 5, Claude Code). Session 046f993e-13ba-47dd-827d-d786428e318b.
