### PR TITLE
The PR body gate reads the live body instead of the event payload

### DIFF
--- a/.github/workflows/agent-pr-body-lint.yml
+++ b/.github/workflows/agent-pr-body-lint.yml
@@ -44,13 +44,25 @@ jobs:
       - name: Validate PR body with the owning implementation
         if: startsWith(github.event.pull_request.user.login, 'neo-') || contains(github.event.pull_request.labels.*.name, 'ai')
         env:
-          # Passed through the environment, never interpolated into the shell: a PR body is
-          # attacker-controlled text and `${{ }}` inside `run:` would splice it into the script.
-          PR_BODY : ${{ github.event.pull_request.body }}
-          PR_DRAFT: ${{ github.event.pull_request.draft }}
-          BASE_REF: ${{ github.base_ref }}
+          # The body is fetched LIVE rather than taken from `github.event.pull_request.body`.
+          #
+          # That field is a SNAPSHOT of the body when the event fired, which makes the gate wrong
+          # in both directions. A corrected body can never go green — `gh run rerun` replays the
+          # original payload, so it re-lints the old text and reproduces the same failure forever,
+          # and the only refresh is a push, which is the wrong instrument for a rule about prose.
+          # And a body edited AFTER a green run keeps that green, so a PR can merge showing a
+          # passing body gate over a body that no longer satisfies it.
+          #
+          # Still handed to the validator through a FILE and never interpolated into the shell: a
+          # PR body is attacker-controlled text, and `${{ }}` inside `run:` would splice it into
+          # the script. `gh` writes it straight to disk, so it is never a shell token.
+          GH_TOKEN : ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          BASE_REF : ${{ github.base_ref }}
         run: |
-          printf '%s' "$PR_BODY" > "$RUNNER_TEMP/pr-body.md"
+          gh pr view "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" --json body,isDraft > "$RUNNER_TEMP/pr.json"
+          jq -r '.body // ""' "$RUNNER_TEMP/pr.json" > "$RUNNER_TEMP/pr-body.md"
+          PR_DRAFT="$(jq -r '.isDraft' "$RUNNER_TEMP/pr.json")"
           if [ "$PR_DRAFT" = "true" ]; then
             node ai/scripts/agent-preflight.mjs --pr-body "$RUNNER_TEMP/pr-body.md" --pr-base "origin/$BASE_REF" --pr-draft
           else
@@ -61,9 +73,19 @@ jobs:
         uses: actions/github-script@v9
         with:
           script: |
-            const pr     = context.payload.pull_request;
-            const author = pr.user.login;
-            const body   = pr.body || "";
+            // Read the pull request LIVE rather than from `context.payload.pull_request`, which
+            // holds the body as it was when the event fired. A payload-sourced body cannot be
+            // corrected into a green verdict (a re-run replays the stale text) and cannot lose a
+            // green one it no longer deserves (an edit after a pass is never re-judged). The
+            // owning-implementation step above fetches for the same reason.
+            const {data: pr} = await github.rest.pulls.get({
+              owner      : context.repo.owner,
+              repo       : context.repo.repo,
+              pull_number: context.payload.pull_request.number
+            });
+
+            const author  = pr.user.login;
+            const body    = pr.body || "";
             const isDraft = Boolean(pr.draft);
 
             // Only enforce for known AI agent accounts or PRs labeled with 'ai'


### PR DESCRIPTION
Resolves #17431

`agent-pr-body-lint.yml` judged `github.event.pull_request.body` — a snapshot of the body taken when the event fired. Both validators now read the pull request at run time instead.

Evidence: L3 (both ACs executed against this PR's own running workflow — a green→red arm and a rerun-clears-red arm, run ids below) → L3 required (the close target's ACs demand observed gate behaviour, not static contract). Residual: none — every AC on #17431 is delivered or determined on this PR.

**AC coverage after the #17431 body correction** — the close target now carries four ACs and every one is dispositioned:

| AC | Status | Where |
|---|---|---|
| AC-1 — both validators read the PR at run time | **Delivered** | this diff |
| AC-2 — corrected body clears a failed run via `gh run rerun`, no push, on a CLEAN PR | **Delivered** | run `32408983596` rerun → success, head unchanged |
| AC-3 — a body edited to remove an anchor after a green run goes red | **Delivered** | run `32408983596` → failure |
| AC-4 — whether `edited` actually dispatches is determined, not assumed | **Determined** | controlled experiment recorded in this thread; see Deltas |

#17431 also now carries a Contract Ledger covering both live-read sites, the untrusted-body file transport, the immutable event coordinates deliberately left payload-sourced (`PR_NUMBER`, `base_ref`), token/permission behaviour, and failure polarity. The shipped diff matches it; no code expansion follows from it.

## Why a snapshot is wrong in both directions

**A corrected body can never clear a failed run.** `gh run rerun` replays the original event payload, so it re-lints text that no longer exists. Observed directly on #17429: the re-run reproduced an identical failure — `Closes #N` is forbidden / `Resolves #N` is required — against a body that by then contained neither.

**A body edited after a green run is never re-judged.** Nothing re-reads it, so a PR can merge showing a passing body gate over a body that no longer satisfies it. Nobody has hit this arm; the current shape permits it, and it is the one that lets a bad body through rather than merely blocking a good one.

The second is the reason this is a `bug` rather than an ergonomics fix. An author fighting a stale red is annoyed; a stale green is a gate reporting a verdict it never formed.

## What changed

| step | was | now |
|---|---|---|
| `Validate PR body with the owning implementation` | `PR_BODY: ${{ github.event.pull_request.body }}` | `gh pr view "$PR_NUMBER" --json body,isDraft` |
| `Validate PR Body` (github-script) | `context.payload.pull_request` | `github.rest.pulls.get({...})` |

Draft state comes from the same live read rather than a second payload field, so the two cannot disagree.

**The body still never becomes a shell token.** The previous shape carried a deliberate comment about this — a PR body is attacker-controlled text, and `${{ }}` inside `run:` would splice it into the script. `gh` writes it straight to a file, so the property is preserved by construction rather than by remembering to quote. That comment is kept and extended rather than dropped.

**No new permission is required, verified rather than assumed.** The workflow declares no `permissions:` block, so the repository default applies — and it already calls `github.rest.pulls.listCommits` and `github.rest.issues.createComment` successfully today. `pulls.get` is strictly weaker than `listCommits`, and `gh pr view --json body` is the same read through the same token. Declaring an explicit `permissions:` block would override the default entirely and would have to enumerate every scope the workflow uses; getting that wrong breaks the gate for every agent PR, so it is deliberately not part of this change.

## Test Evidence

This is a workflow file; it has no unit surface, and there is no existing coverage of `agent-pr-body-lint.yml` — searched, **none found**. What is verifiable before merge:

```
structural parse        6 steps, no tab characters
gh pr view present      true
pulls.get present       true
residual payload reads  0   (grep for '${{ github.event.pull_request.body }}')
```

**A claim that was here and was false, corrected rather than deleted:** this section previously read *"a `pull_request` workflow runs from the base branch's definition, so this file's new behaviour cannot execute on its own PR"*, and used it to defer AC-2/AC-3 to post-merge. `pull_request` runs the **merge ref**, so this PR's own workflow version executes. Run `32406805622` on this PR logs `Run gh pr view "$PR_NUMBER" ... --json body,isDraft` — the new live read. I deferred two ACs behind a platform claim I never checked; @neo-gpt's required action is what sent me to check it.

**Both ACs were therefore executed here, in the order that makes each meaningful:**

```
AC-3  green->red   renamed '## Deltas' on an already-green body
                   run 32408983596  ->  FAILURE

AC-2  red->green   restored the anchor via `gh pr edit` (no commit, no push),
                   then `gh run rerun 32408983596` on the SAME failed run
                   run 32408983596  ->  SUCCESS      head unchanged: ee41ce9ccd
```

Order is load-bearing: AC-2 alone would prove only that a passing body passes. The rerun clearing a red it previously produced is the exact operation the payload-sourced gate could never perform.

## Post-Merge Validation

- **No AC residuals.** AC-2 and AC-3 were executed on this PR (above); AC-1 is the diff; AC-4 is determined. Nothing on #17431 outlives this merge, so the close target does not close its own outstanding work.
- Both experiments ran while this PR was `mergeStateStatus: CLEAN`. That control is not incidental — a DIRTY PR does not dispatch at all, and mistaking that for a gate verdict is the misdiagnosis recorded on #17431.
- Watch the first few runs for a `gh`/`jq` failure in the shell arm — `jq -r '.body // ""'` handles a null body, but an empty-string body reaching `agent-preflight.mjs` is a path the previous `printf '%s' "$PR_BODY"` also produced, so behaviour there should be identical rather than new.

## Deltas

- **The ticket's opening framing was wrong on two of three symptoms, and the correction is now in the #17431 BODY rather than only a comment.** I attributed a non-dispatching push and a non-firing `edited` trigger to the gate; both were a merge conflict (`mergeStateStatus: DIRTY`) on #17429, surfaced by `get_conversation(projection: 'merge-readiness')` after @neo-opus-vega broadcast that the projection is authoritative where the status rollup is not. Pushes and `edited` are not implicated. The falsified claims are retained on the ticket only under an explicit *Superseded history* note and are not current authority — a correction that lives in a comment while the body still asserts the original is not a correction, because the body is what a reader lands on.
- **An AC was added rather than removed by that correction:** the re-run test must be performed on a CLEAN PR, so a green result proves the live read rather than merely that dispatch was unblocked.
- **AC-4 is resolved with evidence rather than deferred, and the required body edit was itself the experiment.** The original "`gh pr edit` queued no run" observation was made while #17429 was DIRTY, which independently suppresses dispatch — so it was never evidence about `edited` at all. Re-run here with the confound removed: this PR sat at `mergeStateStatus: CLEAN` with exactly **one** prior `agent-pr-body-lint` run on its branch (`32403090745`, event `opened`) before the body edit that added this section. The result is recorded in the thread. `edited` is a correctly declared trigger.
- Not addressed: whether the step-level `if:` conditions should also read live labels. A label added after the event would not re-gate the run. Same family, genuinely separate change, and it would need its own reasoning about re-triggering.

Authored by Grace (Claude Opus 5, Claude Code). Session 3e4f33e0-fb23-4a61-a2a0-7f396950f3d6.
