### PR TITLE
feat(ai): the declared parallelism becomes a concurrency, and the carry stops being arithmetic (#17412)

### DIFF
--- a/ai/services/memory-core/TextEmbeddingService.mjs
+++ b/ai/services/memory-core/TextEmbeddingService.mjs
@@ -841,7 +841,7 @@ class TextEmbeddingService extends Base {
     /**
      * @summary Admits queue workers up to the declared parallelism, preferring interactive work.
      *
-     * Every worker selects through {@link #getNextOpenAiCompatiblePostQueueIndex}, so the
+     * Every worker selects through {@link #peekNextOpenAiCompatiblePostQueueIndex}, so the
      * interactive-first fairness contract is unchanged: an interactive item still overtakes queued
      * batch work, and it now becomes runnable when any worker frees rather than only the single one.
      *
@@ -856,10 +856,15 @@ class TextEmbeddingService extends Base {
      * @private
      */
     #drainOpenAiCompatiblePostQueue() {
-        // The TASK budget, used here only as a ceiling on concurrent workers. It can never be the
-        // binding constraint on batch work: the dispatch loop keeps its own offered tasks at or below
-        // `taskBudget - 1`, so a batch fan-out plus one interactive request still fits. Task
-        // accounting lives in `resolveDispatchPlan`, and this queue deliberately does not repeat it.
+        // The TASK budget bounds concurrent WORKERS here — and a worker is one POST, not one task.
+        // A post carrying N inputs is N provider tasks, so this ceiling does not bind the unit the
+        // budget is written in. Known open; the admission fix belongs beside this line.
+        // `resolveDispatchPlan` reserves headroom per `embedTexts` call, which is sound for one caller
+        // and silently false for two: each satisfies its own reservation and they jointly overshoot the
+        // budget the reservation exists to protect. An earlier revision of this comment asserted the
+        // opposite — "it can never be the binding constraint … the dispatch loop keeps ITS OWN offered
+        // tasks" — and "its own" was the defect. Measured: two callers at width 3 offered six tasks
+        // against a budget of four.
         const maxWorkers = resolveEmbeddingTaskBudget(aiConfig.localModels.embedding.parallel);
 
         while (this.#openAiCompatiblePostQueueWorkers < maxWorkers && this.#openAiCompatiblePostQueue.length > 0) {
@@ -876,8 +881,13 @@ class TextEmbeddingService extends Base {
     async #runOpenAiCompatiblePostQueueWorker() {
         try {
             while (this.#openAiCompatiblePostQueue.length > 0) {
-                const taskIndex = this.#getNextOpenAiCompatiblePostQueueIndex(),
-                      task      = this.#openAiCompatiblePostQueue.splice(taskIndex, 1)[0];
+                const {index: taskIndex, bypassedBatchIndex} = this.#peekNextOpenAiCompatiblePostQueueIndex();
+
+                if (taskIndex === -1) break;
+
+                this.#commitOpenAiCompatibleSelection(bypassedBatchIndex);
+
+                const task = this.#openAiCompatiblePostQueue.splice(taskIndex, 1)[0];
 
                 task.markDispatched();
 
@@ -924,7 +934,7 @@ class TextEmbeddingService extends Base {
      * @returns {Number}
      * @private
      */
-    #getNextOpenAiCompatiblePostQueueIndex() {
+    #peekNextOpenAiCompatiblePostQueueIndex() {
         let firstBatchIndex       = -1,
             firstInteractiveIndex = -1;
 
@@ -939,18 +949,37 @@ class TextEmbeddingService extends Base {
         }
 
         if (firstBatchIndex === -1 || firstInteractiveIndex === -1) {
-            return firstInteractiveIndex === -1 ? firstBatchIndex : firstInteractiveIndex;
+            return {index: firstInteractiveIndex === -1 ? firstBatchIndex : firstInteractiveIndex, bypassedBatchIndex: -1};
         }
 
         const oldestBatch = this.#openAiCompatiblePostQueue[firstBatchIndex];
 
         if (oldestBatch.interactiveBypassCount > 0) {
-            return firstBatchIndex;
+            return {index: firstBatchIndex, bypassedBatchIndex: -1};
         }
 
-        oldestBatch.interactiveBypassCount++;
+        // The bypass is a CONSEQUENCE of dispatching the interactive item, so it is reported here and
+        // applied by {@link #commitOpenAiCompatibleSelection} only when that dispatch actually happens.
+        // Previously the increment lived here, which made selection a state change: any caller that
+        // looked at what WOULD be selected — admission control needs exactly that, to weigh it —
+        // silently consumed a batch item's one bypass without dispatching anything.
+        return {index: firstInteractiveIndex, bypassedBatchIndex: firstBatchIndex};
+    }
 
-        return firstInteractiveIndex;
+    /**
+     * @summary Applies the fairness bookkeeping for a selection that is actually being dispatched.
+     *
+     * Split from {@link #peekNextOpenAiCompatiblePostQueueIndex} so that observing the queue is free
+     * and only dispatch costs a bypass. The pair is the reason admission can weigh a candidate before
+     * admitting it without corrupting interactive-first fairness.
+     * @param {Number} bypassedBatchIndex Index of the batch item an interactive item overtook, or -1.
+     * @returns {void}
+     * @private
+     */
+    #commitOpenAiCompatibleSelection(bypassedBatchIndex) {
+        if (bypassedBatchIndex !== -1) {
+            this.#openAiCompatiblePostQueue[bypassedBatchIndex].interactiveBypassCount++
+        }
     }
 
     /**

--- a/ai/services/memory-core/TextEmbeddingService.mjs
+++ b/ai/services/memory-core/TextEmbeddingService.mjs
@@ -749,10 +749,11 @@ class TextEmbeddingService extends Base {
      * @summary Queues OpenAI-compatible embedding posts behind an interactive-first scheduler.
      *
      * A local OpenAI-compatible engine schedules TASKS: one multi-input embedding POST expands to one
-     * task per input. This queue's job is admission ORDER, not admission volume — it lets a
-     * latency-sensitive single embedding overtake queued KB-sync batch work. How much work may be
-     * outstanding is decided upstream by `resolveDispatchPlan`, which keeps a batch's offered tasks
-     * below the declared budget; this queue deliberately does not repeat that accounting.
+     * task per input. This queue owns admission ORDER **and** admission VOLUME — it lets a
+     * latency-sensitive single embedding overtake queued KB-sync batch work, and it is the only place
+     * that can bound total outstanding tasks, because it is the only place every caller is visible.
+     * `resolveDispatchPlan` still reserves per `embedTexts` call, and that reservation is sound for
+     * one caller and insufficient for two: each satisfies its own and they jointly fill the budget.
      *
      * @param {String|String[]} inputData The text or array of texts to embed.
      * @param {Object} options The `#postOpenAiCompatible` retry/timeout options.
@@ -850,9 +851,10 @@ class TextEmbeddingService extends Base {
      *
      * No latency claim is made here. Whether that reduces interactive wait in practice depends on the
      * engine's own scheduling and has not been measured; what IS structural is the headroom, and it is
-     * enforced upstream — `resolveDispatchPlan` keeps a batch's offered tasks at or below
-     * `taskBudget - 1`, so a single-task interactive request fits inside the declared budget rather
-     * than competing for it.
+     * enforced HERE — batch posts are admitted only to `taskBudget - 1` while interactive posts may
+     * use the whole budget, so a single-task interactive request has a slot to take rather than a
+     * queue to wait behind. Enforcing it per call cannot hold: two batch callers each stay inside
+     * their own reservation and jointly leave nothing free.
      *
      * Not `await`ed: a caller enqueues and waits on its own task's promise, never on the drain.
      * @returns {void}

--- a/ai/services/memory-core/TextEmbeddingService.mjs
+++ b/ai/services/memory-core/TextEmbeddingService.mjs
@@ -5,9 +5,9 @@ import {
 import aiConfig       from '../../mcp/server/memory-core/config.mjs';
 import Base           from '../../../src/core/Base.mjs';
 import {
-    planEmbeddingSpans,
     resolveCompletedPrefix,
-    resolveEmbeddingConcurrency
+    resolveDispatchPlan,
+    resolveEmbeddingTaskBudget
 }                           from './helpers/embeddingDispatchPlan.mjs';
 import logger         from '../../mcp/server/memory-core/logger.mjs';
 import OllamaProvider from '../../provider/Ollama.mjs';
@@ -834,7 +834,11 @@ class TextEmbeddingService extends Base {
      * @private
      */
     #drainOpenAiCompatiblePostQueue() {
-        const maxWorkers = resolveEmbeddingConcurrency(aiConfig.localModels.embedding.parallel);
+        // The TASK budget, used here only as a ceiling on concurrent workers. It can never be the
+        // binding constraint on batch work: the dispatch loop keeps its own offered tasks at or below
+        // `taskBudget - 1`, so a batch fan-out plus one interactive request still fits. Task
+        // accounting lives in `resolveDispatchPlan`, and this queue deliberately does not repeat it.
+        const maxWorkers = resolveEmbeddingTaskBudget(aiConfig.localModels.embedding.parallel);
 
         while (this.#openAiCompatiblePostQueueWorkers < maxWorkers && this.#openAiCompatiblePostQueue.length > 0) {
             this.#openAiCompatiblePostQueueWorkers++;
@@ -1939,17 +1943,21 @@ class TextEmbeddingService extends Base {
             batchEmbeddingYieldMs   = 0
         } = aiConfig.openAiCompatible;
 
-        // Request WIDTH and request CONCURRENCY are separate contracts, and conflating them is the
-        // defect this replaces. Width is a durability decision: how many inputs a single failure or
-        // yield can cost. Concurrency is a throughput decision: how many of those may be outstanding.
-        // The predecessor spent the declared parallelism on width (`parallel - 1`) to reserve a
-        // provider slot, which a client cannot do — the server assigns slots from its own queue, so
-        // sending fewer inputs does not hold one open, it only guarantees one idles. The lane declared
-        // four slots and used one.
-        const chunkSize        = Math.max(1, Math.floor(batchEmbeddingChunkSize || texts.length)),
-              maxInFlight      = resolveEmbeddingConcurrency(aiConfig.localModels.embedding.parallel),
+        // The provider's capacity unit is a TASK, not a request: one multi-input POST expands to one
+        // task per input, so offered work is `concurrency × width`. Width and concurrency are still
+        // separate contracts — width bounds what one failure or yield costs, concurrency bounds
+        // throughput — but they are jointly constrained by the same budget, which is why one function
+        // resolves both. The predecessor computed a width alone and could not express the constraint;
+        // it also fell through unclamped at `parallel <= 1`, the shipped default, where a configured
+        // width of 5 offered five tasks against one declared slot.
+        const taskBudget = resolveEmbeddingTaskBudget(aiConfig.localModels.embedding.parallel),
+              plan       = resolveDispatchPlan({
+                  textCount   : texts.length,
+                  requestWidth: batchEmbeddingChunkSize,
+                  taskBudget
+              }),
+              {spans, width: chunkSize, concurrency: maxInFlight} = plan,
               requestTimeoutMs = assertPositiveTimeoutMs(batchEmbeddingTimeoutMs, 'openAiCompatible.batchEmbeddingTimeoutMs'),
-              spans            = planEmbeddingSpans({textCount: texts.length, chunkSize}),
               totalChunkCount  = spans.length,
               // Parallel to `spans`. A COUNT of completions cannot locate them once they arrive out of
               // order, and locating them is the entire carry problem — see `resolveCompletedPrefix`.
@@ -2056,37 +2064,31 @@ class TextEmbeddingService extends Base {
 
         const carried = resolveCompletedPrefix({spans, completedFlags});
 
-        // Completed-but-unbindable work is REPORTED, never dropped in silence. The consumer binds
-        // carried vectors by position (`slice(0, completedTextCount)`) and `toOrderedEmbeddings` refuses
-        // a sparse carry, so a span that landed after a hole cannot be handed over — but a lane quietly
-        // re-purchasing it on every retry, with nothing in the logs, is the failure this whole leaf is
-        // about. A zero here is an assertion that nothing was lost.
-        if (carried.droppedChunkCount > 0) {
-            operation.droppedCompletedChunkCount = carried.droppedChunkCount
-        }
+        // Completed-but-unbindable work is REPORTED, never dropped in silence: the consumer binds by
+        // position and the ordering guard refuses a sparse carry, so a span landing after a hole cannot
+        // be handed over — and a lane quietly re-purchasing it on every retry is the failure this leaf
+        // is about. The count rides the thrown envelope AND the operation record, because an internal
+        // field no consumer reads is not a report.
+        //
+        // A zero is an assertion that nothing was lost, so it is set unconditionally rather than only
+        // when non-zero: an absent field cannot distinguish "no loss" from "never measured".
+        operation.droppedCompletedChunkCount = carried.droppedChunkCount;
 
-        if (yielded) {
-            operation.phase = 'lease-yield';
-
-            throw createEmbeddingBatchYieldError({
-                completedChunkCount: carried.chunkCount,
-                totalChunkCount,
-                chunkSize,
-                data               : data.filter(entry => entry.index < carried.textCount)
-            })
-        }
-
+        // PRECEDENCE: a provider failure or caller abort outranks a cooperative yield vote observed
+        // earlier in the same batch. The yield is a decision to stop politely; a failure is the reason
+        // the batch cannot continue at all, and reporting the polite version would hand the caller a
+        // resumable checkpoint for a lane that is actually broken. Evaluated after the drain, so a
+        // failure surfacing while in-flight requests settled still wins.
         if (firstError) {
             // Work conservation on the FAILURE path. The ORIGINAL error is decorated rather than
-            // replaced: its `code` is what the caller's timeout/circuit classification reads. If the
-            // accumulated data cannot satisfy the positional-binding guard the error travels
-            // undecorated — carrying nothing beats binding vectors to the wrong ids.
+            // replaced: its `code` is what the caller's timeout/circuit classification reads.
+            firstError.droppedCompletedChunkCount = carried.droppedChunkCount;
+
             if (carried.chunkCount > 0) {
                 try {
                     // Bind BEFORE assigning anything. The guard throws on an unprovable prefix, and a
                     // field-by-field decoration would already have written `completedTextCount` by then
                     // — handing the consumer a count with no vectors, which it slices onto ids anyway.
-                    // Carrying nothing beats carrying half, so the whole decoration is one step.
                     const embeddings = toOrderedEmbeddings(
                         data.filter(entry => entry.index < carried.textCount),
                         carried.textCount
@@ -2103,6 +2105,22 @@ class TextEmbeddingService extends Base {
 
             throw firstError
         }
+
+        if (yielded) {
+            operation.phase = 'lease-yield';
+
+            const yieldError = createEmbeddingBatchYieldError({
+                completedChunkCount: carried.chunkCount,
+                totalChunkCount,
+                chunkSize,
+                data               : data.filter(entry => entry.index < carried.textCount)
+            });
+
+            yieldError.droppedCompletedChunkCount = carried.droppedChunkCount;
+
+            throw yieldError
+        }
+
 
         return toOrderedEmbeddings(data, texts.length);
     }

--- a/ai/services/memory-core/TextEmbeddingService.mjs
+++ b/ai/services/memory-core/TextEmbeddingService.mjs
@@ -4,6 +4,11 @@ import {
 }                           from '@google/generative-ai';
 import aiConfig       from '../../mcp/server/memory-core/config.mjs';
 import Base           from '../../../src/core/Base.mjs';
+import {
+    planEmbeddingSpans,
+    resolveCompletedPrefix,
+    resolveEmbeddingConcurrency
+}                           from './helpers/embeddingDispatchPlan.mjs';
 import logger         from '../../mcp/server/memory-core/logger.mjs';
 import OllamaProvider from '../../provider/Ollama.mjs';
 import {
@@ -690,8 +695,12 @@ class TextEmbeddingService extends Base {
         openAiCompatibleLoadedModelsProbe: null
     }
 
-    #openAiCompatiblePostQueue       = [];
-    #openAiCompatiblePostQueueActive = false;
+    #openAiCompatiblePostQueue        = [];
+    // A COUNT, not a boolean. The boolean it replaces was a single-worker re-entrancy guard, and it
+    // was the real concurrency bound on this path: the dispatch loop above could issue N requests and
+    // they queued behind one drain. Bounded by the declared parallelism, so the provider's own stated
+    // width is the only authority.
+    #openAiCompatiblePostQueueWorkers = 0;
 
     // Native Ollama admission control. The openAiCompatible path has been serialized since
     // `#openAiCompatiblePostQueue` existed; this path reached the provider through
@@ -813,15 +822,32 @@ class TextEmbeddingService extends Base {
     }
 
     /**
-     * @summary Runs queued OpenAI-compatible posts one at a time, preferring interactive work.
+     * @summary Admits queue workers up to the declared parallelism, preferring interactive work.
+     *
+     * Every worker selects through {@link #getNextOpenAiCompatiblePostQueueIndex}, so the
+     * interactive-first fairness contract is unchanged — and an interactive item now waits for the
+     * first of N workers to free rather than for the only one, which is strictly better for the
+     * latency this queue exists to protect.
+     *
+     * Not `await`ed: a caller enqueues and waits on its own task's promise, never on the drain.
+     * @returns {void}
+     * @private
+     */
+    #drainOpenAiCompatiblePostQueue() {
+        const maxWorkers = resolveEmbeddingConcurrency(aiConfig.localModels.embedding.parallel);
+
+        while (this.#openAiCompatiblePostQueueWorkers < maxWorkers && this.#openAiCompatiblePostQueue.length > 0) {
+            this.#openAiCompatiblePostQueueWorkers++;
+            this.#runOpenAiCompatiblePostQueueWorker()
+        }
+    }
+
+    /**
+     * @summary Drains queued posts until the queue empties, then retires.
      * @returns {Promise<void>}
      * @private
      */
-    async #drainOpenAiCompatiblePostQueue() {
-        if (this.#openAiCompatiblePostQueueActive) return;
-
-        this.#openAiCompatiblePostQueueActive = true;
-
+    async #runOpenAiCompatiblePostQueueWorker() {
         try {
             while (this.#openAiCompatiblePostQueue.length > 0) {
                 const taskIndex = this.#getNextOpenAiCompatiblePostQueueIndex(),
@@ -857,7 +883,7 @@ class TextEmbeddingService extends Base {
                 }
             }
         } finally {
-            this.#openAiCompatiblePostQueueActive = false;
+            this.#openAiCompatiblePostQueueWorkers--;
         }
     }
 
@@ -1912,110 +1938,170 @@ class TextEmbeddingService extends Base {
             batchEmbeddingTimeoutMs = DEFAULT_OPENAI_COMPATIBLE_REQUEST_TIMEOUT_MS,
             batchEmbeddingYieldMs   = 0
         } = aiConfig.openAiCompatible;
-        const configuredChunkSize = Math.max(1, Math.floor(batchEmbeddingChunkSize || texts.length)),
-              embeddingParallel   = aiConfig.localModels.embedding.parallel,
-              // llama.cpp expands a multi-input embedding POST into one task per input. Keeping one
-              // declared slot outside this request makes interleaving possible without inventing a
-              // second slot-count authority or collapsing single-slot / generic remote endpoints.
-              slotHeadroomWidth = Number.isInteger(embeddingParallel) && embeddingParallel > 1 ?
-                  embeddingParallel - 1 :
-                  configuredChunkSize,
-              chunkSize          = Math.min(configuredChunkSize, slotHeadroomWidth),
-              requestTimeoutMs   = assertPositiveTimeoutMs(batchEmbeddingTimeoutMs, 'openAiCompatible.batchEmbeddingTimeoutMs'),
-              totalChunkCount    = Math.ceil(texts.length / chunkSize),
-              data               = [];
 
-        let completedChunkCount = 0;
+        // Request WIDTH and request CONCURRENCY are separate contracts, and conflating them is the
+        // defect this replaces. Width is a durability decision: how many inputs a single failure or
+        // yield can cost. Concurrency is a throughput decision: how many of those may be outstanding.
+        // The predecessor spent the declared parallelism on width (`parallel - 1`) to reserve a
+        // provider slot, which a client cannot do — the server assigns slots from its own queue, so
+        // sending fewer inputs does not hold one open, it only guarantees one idles. The lane declared
+        // four slots and used one.
+        const chunkSize        = Math.max(1, Math.floor(batchEmbeddingChunkSize || texts.length)),
+              maxInFlight      = resolveEmbeddingConcurrency(aiConfig.localModels.embedding.parallel),
+              requestTimeoutMs = assertPositiveTimeoutMs(batchEmbeddingTimeoutMs, 'openAiCompatible.batchEmbeddingTimeoutMs'),
+              spans            = planEmbeddingSpans({textCount: texts.length, chunkSize}),
+              totalChunkCount  = spans.length,
+              // Parallel to `spans`. A COUNT of completions cannot locate them once they arrive out of
+              // order, and locating them is the entire carry problem — see `resolveCompletedPrefix`.
+              completedFlags   = new Array(totalChunkCount).fill(false),
+              inFlight         = new Set(),
+              data             = [];
 
-        for (let offset = 0; offset < texts.length; offset += chunkSize) {
-            operation.phase = 'batch-chunk';
-            throwIfEmbeddingAborted(signal, operationLabel);
+        let nextSpanIndex = 0,
+            firstError    = null,
+            yielded       = false;
 
-            // Cooperative heavy-maintenance-lease yield-point: BETWEEN provider chunks, never before the
-            // first — the same forward-progress guarantee `VectorService.embedChunks` makes between its own
-            // batches, so at least one chunk always lands per acquisition and the pair cannot livelock.
-            //
-            // The consultation has to happen HERE and not only one frame up, because the interval between two
-            // consultations up there is `maxRetries * ceil(batchSize / chunkSize) * (1 + unloadRetryCount) *
-            // batchEmbeddingTimeoutMs` — 16h40m at stock leaves, against a 30-minute `maxActiveHoldMs`. A
-            // cooperative bound whose checkpoint interval exceeds the bound is not a bound: the holder's
-            // first chance to honour it can arrive after it has already elapsed. Checking per chunk makes
-            // the worst case `(1 + unloadRetryCount) * batchEmbeddingTimeoutMs`.
-            //
-            // `completedChunkCount > 0` is a forward-progress guarantee only because the error carries the
-            // embeddings: a reached checkpoint is not a durable one. Dropping them would let an acquisition
-            // that yields at the same chunk every time re-embed the same prefix forever.
-            if (completedChunkCount > 0 && shouldYield?.()) {
-                operation.phase = 'lease-yield';
-                throw createEmbeddingBatchYieldError({completedChunkCount, totalChunkCount, chunkSize, data})
-            }
-
-            const chunk = texts.slice(offset, offset + chunkSize);
+        /**
+         * Issues one span and registers its settlement. Rejections are captured rather than thrown so
+         * the pool can drain: abandoning in-flight requests would discard provider work that has
+         * already been paid for, which is the same waste the carry exists to prevent.
+         * @param {Number} spanIndex
+         * @returns {Promise}
+         */
+        const dispatchSpan = spanIndex => {
+            const span  = spans[spanIndex],
+                  chunk = texts.slice(span.offset, span.offset + span.count);
 
             recordEmbeddingSubmissions(providerActivityRecorder, chunk);
 
-            let result;
+            const settled = this.#enqueueOpenAiCompatiblePost(chunk, {
+                unloadRetriesLeft: unloadRetryCount,
+                requestTimeoutMs,
+                signal,
+                operationLabel,
+                onProviderTimeout,
+                operation,
+                providerActivity,
+                providerActivityRecorder
+            }, 'batch').then(result => {
+                data.push(...(result.data || []).map(item => ({
+                    ...item,
+                    index: span.offset + item.index
+                })));
 
-            try {
-                result = await this.#enqueueOpenAiCompatiblePost(chunk, {
-                    unloadRetriesLeft: unloadRetryCount,
-                    requestTimeoutMs,
-                    signal,
-                    operationLabel,
-                    onProviderTimeout,
-                    operation,
-                    providerActivity,
-                    providerActivityRecorder
-                }, 'batch');
-            } catch (err) {
-                // Producer attribution for the FAILED request, decorated unconditionally: a provider
-                // timeout names the whole multi-input POST, so the consumer's undeliverable
-                // classification must know exactly which input span was in flight — assigning the
-                // failure to the first batch member when the request held five is how an innocent
-                // neighbour inherits a monster's strikes. Pure indices derived from what was SENT;
-                // unlike the carry below they need no positional-binding proof because they bind
-                // nothing — they only NAME the span.
-                err.failedTextOffset = offset;
-                err.failedTextCount  = chunk.length;
+                completedFlags[spanIndex] = true
+            }).catch(err => {
+                // Producer attribution for the FAILED request. A provider timeout names the whole
+                // multi-input POST, so the consumer's undeliverable classification must know which
+                // input span was in flight — assigning the failure to the first batch member when the
+                // request held five is how an innocent neighbour inherits a monster's strikes. Under
+                // concurrency this is why the span travels with the error rather than being re-derived
+                // from a loop variable that has already moved on.
+                err.failedTextOffset = span.offset;
+                err.failedTextCount  = span.count;
 
-                // Work conservation on the FAILURE path. The yield-point above carries its
-                // completed prefix; a provider failure mid-batch used to discard it, so the caller's
-                // retry — and every later sweep — re-purchased vectors the provider had already
-                // returned. The ORIGINAL error is decorated rather than replaced: its `code` is what
-                // the caller's timeout/circuit classification reads. Completed chunks are full-width
-                // by the same boundary argument the yield error makes (only a batch's final chunk can
-                // be short, and a completed final chunk leaves nothing to fail), so the expected count
-                // derives from what was SENT. If the accumulated data cannot satisfy the positional-
-                // binding guard, the error travels undecorated — carrying nothing beats binding
-                // vectors to the wrong ids.
-                if (completedChunkCount > 0) {
-                    try {
-                        const completedTextCount = completedChunkCount * chunkSize,
-                              embeddings         = toOrderedEmbeddings(data, completedTextCount);
+                // FIRST error wins. A later failure describes a request issued after the lane was
+                // already failing, and reporting it would name a span the caller did not stop on.
+                firstError ??= err
+            }).finally(() => {
+                inFlight.delete(settled)
+            });
 
-                        err.completedChunkCount = completedChunkCount;
-                        err.totalChunkCount     = totalChunkCount;
-                        err.completedTextCount  = completedTextCount;
-                        err.embeddings          = embeddings;
-                    } catch {
-                        // Positional binding could not be proven; the failure travels uncarried.
-                    }
+            inFlight.add(settled);
+
+            return settled
+        };
+
+        while (nextSpanIndex < totalChunkCount && !firstError && !yielded) {
+            throwIfEmbeddingAborted(signal, operationLabel);
+
+            // Cooperative heavy-maintenance-lease yield-point: between ADMISSIONS, and never before at
+            // least one span has landed — the same forward-progress guarantee `VectorService.embedChunks`
+            // makes between its own batches, so at least one span always lands per acquisition and the
+            // pair cannot livelock.
+            //
+            // The consultation has to happen HERE and not one frame up, because the interval between two
+            // consultations up there is `maxRetries * ceil(batchSize / chunkSize) * (1 + unloadRetryCount)
+            // * batchEmbeddingTimeoutMs` — 16h40m at stock leaves, against a 30-minute `maxActiveHoldMs`.
+            // A cooperative bound whose checkpoint interval exceeds the bound is not a bound.
+            //
+            // Keyed on the CARRYABLE prefix rather than on any completion: a span that landed after a
+            // hole is not durable, so treating it as forward progress would let an acquisition yield
+            // having banked nothing and re-embed the same span forever.
+            if (resolveCompletedPrefix({spans, completedFlags}).chunkCount > 0 && shouldYield?.()) {
+                yielded = true;
+                break
+            }
+
+            while (inFlight.size < maxInFlight && nextSpanIndex < totalChunkCount && !firstError) {
+                operation.phase = 'batch-chunk';
+                dispatchSpan(nextSpanIndex++);
+
+                if (batchEmbeddingYieldMs > 0 && nextSpanIndex < totalChunkCount) {
+                    operation.phase = 'batch-yield';
+                    await waitForOpenAiCompatibleBatchYield(batchEmbeddingYieldMs, signal, operationLabel)
                 }
-
-                throw err;
             }
 
-            data.push(...(result.data || []).map(item => ({
-                ...item,
-                index: offset + item.index
-            })));
-
-            completedChunkCount++;
-
-            if (offset + chunkSize < texts.length) {
-                operation.phase = 'batch-yield';
-                await waitForOpenAiCompatibleBatchYield(batchEmbeddingYieldMs, signal, operationLabel);
+            if (inFlight.size > 0) {
+                await Promise.race([...inFlight])
             }
+        }
+
+        // Drain before reporting anything. An outstanding request may still complete and extend the
+        // carryable prefix, and its work is already paid for.
+        while (inFlight.size > 0) {
+            await Promise.race([...inFlight])
+        }
+
+        const carried = resolveCompletedPrefix({spans, completedFlags});
+
+        // Completed-but-unbindable work is REPORTED, never dropped in silence. The consumer binds
+        // carried vectors by position (`slice(0, completedTextCount)`) and `toOrderedEmbeddings` refuses
+        // a sparse carry, so a span that landed after a hole cannot be handed over — but a lane quietly
+        // re-purchasing it on every retry, with nothing in the logs, is the failure this whole leaf is
+        // about. A zero here is an assertion that nothing was lost.
+        if (carried.droppedChunkCount > 0) {
+            operation.droppedCompletedChunkCount = carried.droppedChunkCount
+        }
+
+        if (yielded) {
+            operation.phase = 'lease-yield';
+
+            throw createEmbeddingBatchYieldError({
+                completedChunkCount: carried.chunkCount,
+                totalChunkCount,
+                chunkSize,
+                data               : data.filter(entry => entry.index < carried.textCount)
+            })
+        }
+
+        if (firstError) {
+            // Work conservation on the FAILURE path. The ORIGINAL error is decorated rather than
+            // replaced: its `code` is what the caller's timeout/circuit classification reads. If the
+            // accumulated data cannot satisfy the positional-binding guard the error travels
+            // undecorated — carrying nothing beats binding vectors to the wrong ids.
+            if (carried.chunkCount > 0) {
+                try {
+                    // Bind BEFORE assigning anything. The guard throws on an unprovable prefix, and a
+                    // field-by-field decoration would already have written `completedTextCount` by then
+                    // — handing the consumer a count with no vectors, which it slices onto ids anyway.
+                    // Carrying nothing beats carrying half, so the whole decoration is one step.
+                    const embeddings = toOrderedEmbeddings(
+                        data.filter(entry => entry.index < carried.textCount),
+                        carried.textCount
+                    );
+
+                    firstError.completedChunkCount = carried.chunkCount;
+                    firstError.totalChunkCount     = totalChunkCount;
+                    firstError.completedTextCount  = carried.textCount;
+                    firstError.embeddings          = embeddings
+                } catch {
+                    // Positional binding could not be proven; the failure travels uncarried.
+                }
+            }
+
+            throw firstError
         }
 
         return toOrderedEmbeddings(data, texts.length);

--- a/ai/services/memory-core/TextEmbeddingService.mjs
+++ b/ai/services/memory-core/TextEmbeddingService.mjs
@@ -942,12 +942,10 @@ class TextEmbeddingService extends Base {
                     const result = await this.#postOpenAiCompatible(task.inputData, task.options);
 
                     this.#openAiCompatibleInFlightTasks -= weight;
-                    this.#drainOpenAiCompatiblePostQueue();
                     task.lifecycle.onSettled({completedAt: Date.now(), success: true});
                     task.resolve(result);
                 } catch (err) {
                     this.#openAiCompatibleInFlightTasks -= weight;
-                    this.#drainOpenAiCompatiblePostQueue();
                     task.lifecycle.onSettled({completedAt: Date.now(), success: false});
 
                     // The queue task — not each transport attempt — owns final failure, so by the
@@ -967,6 +965,17 @@ class TextEmbeddingService extends Base {
             }
         } finally {
             this.#openAiCompatiblePostQueueWorkers--;
+
+            // Wake capacity once, on retirement, rather than after every settle. This worker's own
+            // loop already re-checks admission and picks up freed capacity itself, so a per-settle
+            // drain only ever spawned EXTRA workers — and doing that on every completed task kept
+            // creating async work during container teardown, which surfaced as a native
+            // `RemoveEnvironmentCleanupHook` assertion in the parity stack rather than as anything
+            // visible from the unit suite. Retirement is the only moment another worker is genuinely
+            // needed, and by then this one has awaited, so the count is live and cannot spin.
+            if (this.#openAiCompatiblePostQueue.length > 0) {
+                this.#drainOpenAiCompatiblePostQueue()
+            }
         }
     }
 

--- a/ai/services/memory-core/TextEmbeddingService.mjs
+++ b/ai/services/memory-core/TextEmbeddingService.mjs
@@ -716,6 +716,9 @@ class TextEmbeddingService extends Base {
     // they queued behind one drain. Bounded by the declared parallelism, so the provider's own stated
     // width is the only authority.
     #openAiCompatiblePostQueueWorkers = 0;
+    // Provider TASKS in flight, not posts. One multi-input POST is one task per input, and the budget
+    // is written in tasks, so admission has to count the same unit.
+    #openAiCompatibleInFlightTasks    = 0;
 
     // Native Ollama admission control. The openAiCompatible path has been serialized since
     // `#openAiCompatiblePostQueue` existed; this path reached the provider through
@@ -856,18 +859,36 @@ class TextEmbeddingService extends Base {
      * @private
      */
     #drainOpenAiCompatiblePostQueue() {
-        // The TASK budget bounds concurrent WORKERS here — and a worker is one POST, not one task.
-        // A post carrying N inputs is N provider tasks, so this ceiling does not bind the unit the
-        // budget is written in. Known open; the admission fix belongs beside this line.
+        // Admission lives HERE, and the placement is the fix rather than a detail.
         // `resolveDispatchPlan` reserves headroom per `embedTexts` call, which is sound for one caller
         // and silently false for two: each satisfies its own reservation and they jointly overshoot the
         // budget the reservation exists to protect. An earlier revision of this comment asserted the
         // opposite — "it can never be the binding constraint … the dispatch loop keeps ITS OWN offered
         // tasks" — and "its own" was the defect. Measured: two callers at width 3 offered six tasks
         // against a budget of four.
-        const maxWorkers = resolveEmbeddingTaskBudget(aiConfig.localModels.embedding.parallel);
+        //
+        // A worker cannot enforce it by declining after being spawned. An async function that returns
+        // before its first `await` runs synchronously to its `finally`, so the worker count is already
+        // back down when control reaches this loop — which respawns it, and the pair spins without
+        // bound. That shape reads from outside as a hang; it is measured here as the reason admission
+        // must decide BEFORE a worker exists.
+        const maxTasks = resolveEmbeddingTaskBudget(aiConfig.localModels.embedding.parallel);
 
-        while (this.#openAiCompatiblePostQueueWorkers < maxWorkers && this.#openAiCompatiblePostQueue.length > 0) {
+        while (this.#openAiCompatiblePostQueueWorkers < maxTasks && this.#openAiCompatiblePostQueue.length > 0) {
+            const {index} = this.#peekNextOpenAiCompatiblePostQueueIndex();
+
+            if (index === -1) break;
+
+            const weight = this.#openAiCompatibleTaskWeight(this.#openAiCompatiblePostQueue[index]);
+
+            // `inFlightTasks === 0` always admits, so a post wider than the whole budget still makes
+            // forward progress instead of livelocking. A slot withheld here returns the moment a
+            // settling worker re-drains.
+            if (this.#openAiCompatibleInFlightTasks > 0 &&
+                this.#openAiCompatibleInFlightTasks + weight > maxTasks) {
+                break
+            }
+
             this.#openAiCompatiblePostQueueWorkers++;
             this.#runOpenAiCompatiblePostQueueWorker()
         }
@@ -878,6 +899,16 @@ class TextEmbeddingService extends Base {
      * @returns {Promise<void>}
      * @private
      */
+    /**
+     * @summary The number of provider tasks one queued post represents.
+     * @param {Object} task Queued post.
+     * @returns {Number} One per input, minimum one.
+     * @private
+     */
+    #openAiCompatibleTaskWeight(task) {
+        return Array.isArray(task?.inputData) ? Math.max(task.inputData.length, 1) : 1
+    }
+
     async #runOpenAiCompatiblePostQueueWorker() {
         try {
             while (this.#openAiCompatiblePostQueue.length > 0) {
@@ -885,11 +916,23 @@ class TextEmbeddingService extends Base {
 
                 if (taskIndex === -1) break;
 
+                const weight = this.#openAiCompatibleTaskWeight(this.#openAiCompatiblePostQueue[taskIndex]);
+
+                // The drain admitted this worker once. A worker looping to a SECOND task re-checks,
+                // because capacity may have been taken since. Exiting is safe and cannot spin: this
+                // worker has already awaited, so its count is live when the drain next runs.
+                if (this.#openAiCompatibleInFlightTasks > 0 &&
+                    this.#openAiCompatibleInFlightTasks + weight >
+                        resolveEmbeddingTaskBudget(aiConfig.localModels.embedding.parallel)) {
+                    break
+                }
+
                 this.#commitOpenAiCompatibleSelection(bypassedBatchIndex);
 
                 const task = this.#openAiCompatiblePostQueue.splice(taskIndex, 1)[0];
 
                 task.markDispatched();
+                this.#openAiCompatibleInFlightTasks += weight;
 
                 const startedAt = Date.now();
 
@@ -898,9 +941,13 @@ class TextEmbeddingService extends Base {
                 try {
                     const result = await this.#postOpenAiCompatible(task.inputData, task.options);
 
+                    this.#openAiCompatibleInFlightTasks -= weight;
+                    this.#drainOpenAiCompatiblePostQueue();
                     task.lifecycle.onSettled({completedAt: Date.now(), success: true});
                     task.resolve(result);
                 } catch (err) {
+                    this.#openAiCompatibleInFlightTasks -= weight;
+                    this.#drainOpenAiCompatiblePostQueue();
                     task.lifecycle.onSettled({completedAt: Date.now(), success: false});
 
                     // The queue task — not each transport attempt — owns final failure, so by the

--- a/ai/services/memory-core/TextEmbeddingService.mjs
+++ b/ai/services/memory-core/TextEmbeddingService.mjs
@@ -879,13 +879,8 @@ class TextEmbeddingService extends Base {
 
             if (index === -1) break;
 
-            const weight = this.#openAiCompatibleTaskWeight(this.#openAiCompatiblePostQueue[index]);
-
-            // `inFlightTasks === 0` always admits, so a post wider than the whole budget still makes
-            // forward progress instead of livelocking. A slot withheld here returns the moment a
-            // settling worker re-drains.
-            if (this.#openAiCompatibleInFlightTasks > 0 &&
-                this.#openAiCompatibleInFlightTasks + weight > maxTasks) {
+            // A slot withheld here returns the moment a settling worker re-drains.
+            if (!this.#mayAdmitOpenAiCompatiblePost(this.#openAiCompatiblePostQueue[index])) {
                 break
             }
 
@@ -894,11 +889,6 @@ class TextEmbeddingService extends Base {
         }
     }
 
-    /**
-     * @summary Drains queued posts until the queue empties, then retires.
-     * @returns {Promise<void>}
-     * @private
-     */
     /**
      * @summary The number of provider tasks one queued post represents.
      * @param {Object} task Queued post.
@@ -909,6 +899,39 @@ class TextEmbeddingService extends Base {
         return Array.isArray(task?.inputData) ? Math.max(task.inputData.length, 1) : 1
     }
 
+    /**
+     * @summary Whether one queued post may be dispatched against the declared task budget.
+     *
+     * BATCH work is admitted only up to `budget - 1`, which is the interactive-headroom contract
+     * expressed where it can actually hold. Reserving per `embedTexts` call cannot hold it: two batch
+     * callers each satisfy their own reservation and jointly fill the budget, leaving an interactive
+     * post no slot — the falsifier a reviewer supplied against an earlier version of this guard, where
+     * admission ran to the full budget for every lane.
+     *
+     * INTERACTIVE work may use the whole budget, because the reserved slot exists FOR it.
+     *
+     * `inFlightTasks === 0` always admits, so a post wider than the budget still makes forward
+     * progress rather than livelocking, and a single-slot deployment is untouched.
+     * @param {Object} task Queued post.
+     * @returns {Boolean}
+     * @private
+     */
+    #mayAdmitOpenAiCompatiblePost(task) {
+        if (this.#openAiCompatibleInFlightTasks === 0) {
+            return true
+        }
+
+        const budget  = resolveEmbeddingTaskBudget(aiConfig.localModels.embedding.parallel),
+              ceiling = task?.priority === 'interactive' ? budget : Math.max(budget - 1, 1);
+
+        return this.#openAiCompatibleInFlightTasks + this.#openAiCompatibleTaskWeight(task) <= ceiling
+    }
+
+    /**
+     * @summary Drains queued posts until the queue empties or admission declines, then retires.
+     * @returns {Promise<void>}
+     * @private
+     */
     async #runOpenAiCompatiblePostQueueWorker() {
         try {
             while (this.#openAiCompatiblePostQueue.length > 0) {
@@ -921,9 +944,7 @@ class TextEmbeddingService extends Base {
                 // The drain admitted this worker once. A worker looping to a SECOND task re-checks,
                 // because capacity may have been taken since. Exiting is safe and cannot spin: this
                 // worker has already awaited, so its count is live when the drain next runs.
-                if (this.#openAiCompatibleInFlightTasks > 0 &&
-                    this.#openAiCompatibleInFlightTasks + weight >
-                        resolveEmbeddingTaskBudget(aiConfig.localModels.embedding.parallel)) {
+                if (!this.#mayAdmitOpenAiCompatiblePost(this.#openAiCompatiblePostQueue[taskIndex])) {
                     break
                 }
 

--- a/ai/services/memory-core/TextEmbeddingService.mjs
+++ b/ai/services/memory-core/TextEmbeddingService.mjs
@@ -207,18 +207,33 @@ function toOrderedEmbeddings(data, expectedCount) {
  * provider work AND persist nothing, so an acquisition that repeatedly yields at the same chunk
  * would re-embed the same prefix forever — the caller needs the partial to make the checkpoint a
  * durable unit rather than merely a reached one.
+ * **Takes the measured prefix; does not re-derive it.** This previously computed
+ * `completedChunkCount * chunkSize`, justified by "a yield lands on a chunk boundary, so every
+ * completed chunk is full-width". That justification is false — the final span is short whenever the
+ * input count is not a multiple of the width — while the conclusion happened to hold for a different
+ * reason the comment never stated: the dispatch loop only consults the yield predicate while spans
+ * remain UNDISPATCHED, and dispatch is in span order, so a yielded prefix structurally excludes the
+ * final span. No reachable input reddened the product, and none can.
+ *
+ * It is passed in anyway, because a leaf whose correctness depends on a caller-side ordering invariant
+ * it cannot see is one refactor away from being wrong silently: reorder dispatch, or consult the
+ * predicate once more after the last admission, and this returns a count one width too large — at
+ * which point `toOrderedEmbeddings` throws from inside the yield constructor and the abandonment loses
+ * its `EMBEDDING_BATCH_YIELDED_CODE`, downgrading a resumable checkpoint to a hard failure. The
+ * failure path one branch up already passed the measured count, so the two also disagreed about the
+ * same prefix — the divergence the single-producer rule above exists to prevent.
+ *
  * @param {Object} options
  * @param {Number} options.completedChunkCount Provider chunks that completed before the yield.
  * @param {Number} options.totalChunkCount Provider chunks the batch would otherwise have issued.
+ * @param {Number} options.completedTextCount Inputs covered by that prefix, measured by the caller.
  * @param {Object[]} options.data Accumulated `{index, embedding}` entries for the completed chunks.
  * @returns {Error}
  */
-function createEmbeddingBatchYieldError({completedChunkCount, totalChunkCount, chunkSize, data}) {
-    // Derived from the chunks SENT, not from `data.length`. A yield only ever happens at a chunk boundary,
-    // so every completed chunk is full-width — which makes this an independent expectation the response
-    // must satisfy, rather than a restatement of whatever the provider chose to return.
-    const completedTextCount = completedChunkCount * chunkSize,
-          embeddings         = toOrderedEmbeddings(data, completedTextCount),
+function createEmbeddingBatchYieldError({completedChunkCount, totalChunkCount, completedTextCount, data}) {
+    // Still an independent expectation rather than a restatement of what came back: the count is
+    // measured from the spans that were SENT and completed, never from `data.length`.
+    const embeddings = toOrderedEmbeddings(data, completedTextCount),
           error              = new Error(`openAiCompatible batch embedding yielded the heavy-maintenance lease after ${completedChunkCount}/${totalChunkCount} provider chunk(s), ${completedTextCount} embedding(s) carried`);
 
     error.code                = EMBEDDING_BATCH_YIELDED_CODE;
@@ -730,9 +745,11 @@ class TextEmbeddingService extends Base {
     /**
      * @summary Queues OpenAI-compatible embedding posts behind an interactive-first scheduler.
      *
-     * Local OpenAI-compatible embedding servers frequently serialize model requests. This queue
-     * keeps TextEmbeddingService from creating competing local-provider concurrency while allowing
-     * latency-sensitive single embeddings to run before subsequent KB-sync batch chunks.
+     * A local OpenAI-compatible engine schedules TASKS: one multi-input embedding POST expands to one
+     * task per input. This queue's job is admission ORDER, not admission volume — it lets a
+     * latency-sensitive single embedding overtake queued KB-sync batch work. How much work may be
+     * outstanding is decided upstream by `resolveDispatchPlan`, which keeps a batch's offered tasks
+     * below the declared budget; this queue deliberately does not repeat that accounting.
      *
      * @param {String|String[]} inputData The text or array of texts to embed.
      * @param {Object} options The `#postOpenAiCompatible` retry/timeout options.
@@ -825,9 +842,14 @@ class TextEmbeddingService extends Base {
      * @summary Admits queue workers up to the declared parallelism, preferring interactive work.
      *
      * Every worker selects through {@link #getNextOpenAiCompatiblePostQueueIndex}, so the
-     * interactive-first fairness contract is unchanged — and an interactive item now waits for the
-     * first of N workers to free rather than for the only one, which is strictly better for the
-     * latency this queue exists to protect.
+     * interactive-first fairness contract is unchanged: an interactive item still overtakes queued
+     * batch work, and it now becomes runnable when any worker frees rather than only the single one.
+     *
+     * No latency claim is made here. Whether that reduces interactive wait in practice depends on the
+     * engine's own scheduling and has not been measured; what IS structural is the headroom, and it is
+     * enforced upstream — `resolveDispatchPlan` keeps a batch's offered tasks at or below
+     * `taskBudget - 1`, so a single-task interactive request fits inside the declared budget rather
+     * than competing for it.
      *
      * Not `await`ed: a caller enqueues and waits on its own task's promise, never on the drain.
      * @returns {void}
@@ -1912,11 +1934,15 @@ class TextEmbeddingService extends Base {
     /**
      * @summary Embeds a text array through OpenAI-compatible chunked batch requests.
      *
-     * Local OpenAI-compatible embedding servers often serialize model requests. Sending the whole
-     * KB-sync batch as one provider call can monopolize that server for minutes. Chunking keeps
-     * batch ingestion moving while yielding between chunks so interactive single embeddings can
-     * enter the provider queue before the next batch chunk. Multi-slot lanes additionally reserve
-     * one declared slot from each batch request so another provider request remains admissible.
+     * Sending a whole KB-sync batch as one provider call can monopolize the engine for minutes, so the
+     * batch is divided into spans and the lease bound is consulted between them — that is what lets an
+     * interactive single embedding enter the queue rather than waiting out the batch.
+     *
+     * Capacity is accounted in TASKS, not requests: one multi-input POST becomes one task per input, so
+     * a batch's offered work is `concurrency × width`. `resolveDispatchPlan` resolves both against the
+     * declared budget and holds one task back where the budget allows it, which is where the
+     * interactive-headroom guarantee lives. A budget of one reserves nothing — there is nothing to
+     * reserve from — and keeps its configured width unchanged.
      *
      * @param {String[]} texts The texts to embed.
      * @param {Object} options Abort and observability context.
@@ -2112,7 +2138,7 @@ class TextEmbeddingService extends Base {
             const yieldError = createEmbeddingBatchYieldError({
                 completedChunkCount: carried.chunkCount,
                 totalChunkCount,
-                chunkSize,
+                completedTextCount : carried.textCount,
                 data               : data.filter(entry => entry.index < carried.textCount)
             });
 

--- a/ai/services/memory-core/helpers/embeddingDispatchPlan.mjs
+++ b/ai/services/memory-core/helpers/embeddingDispatchPlan.mjs
@@ -1,0 +1,89 @@
+/**
+ * @summary Pure plan arithmetic for the concurrent OpenAI-compatible embedding dispatch.
+ *
+ * Three questions the dispatch loop must answer without holding any I/O: how the inputs divide into
+ * provider requests, how many of those may be outstanding at once, and — after some subset of them
+ * has completed in an arbitrary order — exactly how much work is durably carryable.
+ *
+ * Separated from the service because the third question is the one concurrency makes hard, and it was
+ * previously answered by arithmetic (`completedChunkCount * chunkSize`) that only held while
+ * completions arrived in order. Arithmetic over a sequential index is not a contract; a function with
+ * its own fixtures is.
+ *
+ * @module ai/services/memory-core/helpers/embeddingDispatchPlan
+ */
+
+/**
+ * @summary Divides an input count into the provider requests that will carry it.
+ *
+ * Spans rather than bare offsets, because only the final span may be short and every later decision
+ * (carry width, failure attribution) needs the real count rather than a re-derivation of it. Deriving
+ * it twice is how `count * width` came to stand in for a span in the first place.
+ *
+ * @param {Object} options
+ * @param {Number} options.textCount Number of inputs to embed.
+ * @param {Number} options.chunkSize Inputs per provider request; the durability contract's width.
+ * @returns {Array<{offset: Number, count: Number}>} Spans in input order; empty when there is nothing to send.
+ */
+export function planEmbeddingSpans({textCount, chunkSize}) {
+    const spans = [],
+          width = Math.max(1, Math.floor(chunkSize));
+
+    for (let offset = 0; offset < textCount; offset += width) {
+        spans.push({offset, count: Math.min(width, textCount - offset)})
+    }
+
+    return spans
+}
+
+/**
+ * @summary Resolves how many provider requests may be outstanding at once.
+ *
+ * Reads the declared parallelism as a CONCURRENCY, which is the one thing it was never used for: the
+ * previous consumer spent it on request *width* (`parallel - 1`), reserving a slot the client cannot
+ * actually hold open — the server assigns slots from its own queue, so sending fewer inputs does not
+ * keep one free, it only guarantees one idles.
+ *
+ * Falls back to 1 rather than to the input count. An unreadable parallelism must not silently become
+ * unbounded fan-out at a provider whose real width is unknown.
+ *
+ * @param {*} embeddingParallel Resolved `localModels.embedding.parallel`.
+ * @returns {Number} A positive integer request concurrency.
+ */
+export function resolveEmbeddingConcurrency(embeddingParallel) {
+    const declared = Number(embeddingParallel);
+
+    return Number.isInteger(declared) && declared > 0 ? declared : 1
+}
+
+/**
+ * @summary Measures the durably carryable prefix from an arbitrary set of completed spans.
+ *
+ * **Why a prefix and not the whole completed set.** The consumer binds carried vectors to inputs BY
+ * POSITION (`batchToEmbed.slice(0, completedTextCount)`), and `toOrderedEmbeddings` refuses anything
+ * that is not densely indexed from 0. So a sparse carry is not expressible without changing that
+ * consumer contract; the longest contiguous prefix is the most work a caller can bind correctly.
+ *
+ * **Why `droppedChunkCount` is returned rather than ignored.** Under concurrency a span can complete
+ * after a hole, and that work is unbindable and therefore lost. Reporting the count makes the loss
+ * observable: silently discarding it is exactly the regression this function exists to prevent, in a
+ * tidier shape. A caller that logs zero is asserting no loss, not hoping for none.
+ *
+ * @param {Object} options
+ * @param {Array<{offset: Number, count: Number}>} options.spans Spans from {@link planEmbeddingSpans}.
+ * @param {Boolean[]} options.completedFlags Parallel to `spans`; `true` where that span landed.
+ * @returns {{chunkCount: Number, textCount: Number, droppedChunkCount: Number}} Carryable prefix, plus completed-but-unbindable spans.
+ */
+export function resolveCompletedPrefix({spans, completedFlags}) {
+    let chunkCount = 0,
+        textCount  = 0;
+
+    while (chunkCount < spans.length && completedFlags[chunkCount] === true) {
+        textCount += spans[chunkCount].count;
+        chunkCount++
+    }
+
+    const completedTotal = completedFlags.reduce((sum, landed) => landed === true ? sum + 1 : sum, 0);
+
+    return {chunkCount, textCount, droppedChunkCount: completedTotal - chunkCount}
+}

--- a/ai/services/memory-core/helpers/embeddingDispatchPlan.mjs
+++ b/ai/services/memory-core/helpers/embeddingDispatchPlan.mjs
@@ -1,28 +1,53 @@
 /**
- * @summary Pure plan arithmetic for the concurrent OpenAI-compatible embedding dispatch.
+ * @summary Pure plan arithmetic for the OpenAI-compatible embedding dispatch.
  *
- * Three questions the dispatch loop must answer without holding any I/O: how the inputs divide into
- * provider requests, how many of those may be outstanding at once, and — after some subset of them
- * has completed in an arbitrary order — exactly how much work is durably carryable.
+ * Four questions the dispatch loop must answer without holding any I/O: what the provider's capacity
+ * unit is, how the inputs divide into requests, how many of those may be outstanding, and — after some
+ * subset has completed in an arbitrary order — exactly how much work is durably carryable.
  *
- * Separated from the service because the third question is the one concurrency makes hard, and it was
- * previously answered by arithmetic (`completedChunkCount * chunkSize`) that only held while
- * completions arrived in order. Arithmetic over a sequential index is not a contract; a function with
- * its own fixtures is.
+ * Separated from the service because two of the four were previously answered by inline arithmetic
+ * that only held under assumptions nothing stated. Arithmetic over an implied invariant is not a
+ * contract; a function with its own fixtures is.
  *
  * @module ai/services/memory-core/helpers/embeddingDispatchPlan
  */
+
+/**
+ * @summary Resolves the provider's declared capacity in TASKS, or refuses.
+ *
+ * **The capacity unit is a task, not a request.** A local OpenAI-compatible engine expands one
+ * multi-input embedding POST into one task per input, so the work a client offers is
+ * `concurrency × width` — not `concurrency`. Treating the declared parallelism as a request count
+ * silently multiplies offered work by the width.
+ *
+ * Throws rather than substituting. The leaf's own default already covers an absent env var, so a
+ * value that reaches here and is not a positive integer is a configuration defect — and a lane that
+ * quietly falls back to 1 reports healthy while ignoring what the deployment declared.
+ *
+ * @param {*} embeddingParallel Resolved `localModels.embedding.parallel`.
+ * @returns {Number} The task budget: a positive integer.
+ * @throws {TypeError} When the resolved value is not a positive integer.
+ */
+export function resolveEmbeddingTaskBudget(embeddingParallel) {
+    const declared = Number(embeddingParallel);
+
+    if (!Number.isInteger(declared) || declared < 1) {
+        throw new TypeError(`localModels.embedding.parallel must resolve to a positive integer task budget; received ${JSON.stringify(embeddingParallel)}`)
+    }
+
+    return declared
+}
 
 /**
  * @summary Divides an input count into the provider requests that will carry it.
  *
  * Spans rather than bare offsets, because only the final span may be short and every later decision
  * (carry width, failure attribution) needs the real count rather than a re-derivation of it. Deriving
- * it twice is how `count * width` came to stand in for a span in the first place.
+ * it twice is how a count-times-width product came to stand in for a span.
  *
  * @param {Object} options
  * @param {Number} options.textCount Number of inputs to embed.
- * @param {Number} options.chunkSize Inputs per provider request; the durability contract's width.
+ * @param {Number} options.chunkSize Inputs per provider request.
  * @returns {Array<{offset: Number, count: Number}>} Spans in input order; empty when there is nothing to send.
  */
 export function planEmbeddingSpans({textCount, chunkSize}) {
@@ -37,37 +62,67 @@ export function planEmbeddingSpans({textCount, chunkSize}) {
 }
 
 /**
- * @summary Resolves how many provider requests may be outstanding at once.
+ * @summary Plans one batch against the provider's declared task capacity.
  *
- * Reads the declared parallelism as a CONCURRENCY, which is the one thing it was never used for: the
- * previous consumer spent it on request *width* (`parallel - 1`), reserving a slot the client cannot
- * actually hold open — the server assigns slots from its own queue, so sending fewer inputs does not
- * keep one free, it only guarantees one idles.
+ * Three decisions, in the order they constrain each other:
  *
- * Falls back to 1 rather than to the input count. An unreadable parallelism must not silently become
- * unbounded fan-out at a provider whose real width is unknown.
+ * 1. **Reserve one task for interactive work** when the budget allows it. This preserves the
+ *    interactive-headroom contract that the previous width clamp was reaching for: keeping offered
+ *    tasks strictly below the declared capacity does leave a slot free, because tasks are the unit
+ *    the engine schedules. The clamp's *mechanism* was wrong (it computed a width) and its *intent*
+ *    was right.
+ * 2. **Clamp the request width to what remains — but only where headroom exists.** A single request
+ *    wider than the available budget over-offers by construction, whatever the concurrency. At a
+ *    budget of 1 there is nothing to reserve, so the clamp would protect nothing while turning one
+ *    request into one-per-input; the provider queues the extra tasks regardless. The single-slot
+ *    default therefore keeps its configured width and sees no change from this plan.
+ * 3. **Then fan out.** Concurrency is whatever the remaining budget affords at that width, so
+ *    `offeredTasks` never exceeds the reserve. Concurrency therefore appears only once the budget
+ *    exceeds the width, which is a property of the deployment's leaves rather than of this code.
  *
- * @param {*} embeddingParallel Resolved `localModels.embedding.parallel`.
- * @returns {Number} A positive integer request concurrency.
+ * @param {Object} options
+ * @param {Number} options.textCount Inputs to embed.
+ * @param {Number} options.requestWidth Configured inputs per request (`batchEmbeddingChunkSize`).
+ * @param {Number} options.taskBudget From {@link resolveEmbeddingTaskBudget}.
+ * @param {Boolean} [options.reserveInteractiveTask=true] Hold one task back for latency-sensitive work when the budget allows.
+ * @returns {{spans: Array, width: Number, concurrency: Number, taskBudget: Number, reservedTasks: Number, offeredTasks: Number}}
  */
-export function resolveEmbeddingConcurrency(embeddingParallel) {
-    const declared = Number(embeddingParallel);
+export function resolveDispatchPlan({textCount, requestWidth, taskBudget, reserveInteractiveTask = true}) {
+    // Headroom exists only above a budget of 1. At a single declared task there is nothing to
+    // reserve, so clamping the width buys no protection and costs a round trip per input — the
+    // provider queues the extra tasks either way. So the single-slot default keeps its configured
+    // width and this plan changes nothing for it.
+    const hasHeadroom = reserveInteractiveTask && taskBudget > 1,
+          available   = hasHeadroom ? taskBudget - 1 : taskBudget,
+          configured  = Math.max(1, Math.floor(requestWidth) || textCount || 1),
+          width       = hasHeadroom ? Math.min(configured, available) : configured,
+          spans       = planEmbeddingSpans({textCount, chunkSize: width}),
+          // Bounded by the budget AND by the work that exists: fanning out wider than the span count
+          // would report an offer the batch cannot make.
+          concurrency = Math.max(1, Math.min(Math.floor(available / width), spans.length || 1));
 
-    return Number.isInteger(declared) && declared > 0 ? declared : 1
+    return {
+        spans,
+        width,
+        concurrency,
+        taskBudget,
+        reservedTasks: taskBudget - available,
+        offeredTasks : concurrency * width
+    }
 }
 
 /**
  * @summary Measures the durably carryable prefix from an arbitrary set of completed spans.
  *
  * **Why a prefix and not the whole completed set.** The consumer binds carried vectors to inputs BY
- * POSITION (`batchToEmbed.slice(0, completedTextCount)`), and `toOrderedEmbeddings` refuses anything
- * that is not densely indexed from 0. So a sparse carry is not expressible without changing that
- * consumer contract; the longest contiguous prefix is the most work a caller can bind correctly.
+ * POSITION (`batchToEmbed.slice(0, completedTextCount)`), and the ordering guard refuses anything not
+ * densely indexed from 0. A sparse carry is therefore not expressible without changing that consumer
+ * contract; the longest contiguous prefix is the most work a caller can bind correctly.
  *
  * **Why `droppedChunkCount` is returned rather than ignored.** Under concurrency a span can complete
  * after a hole, and that work is unbindable and therefore lost. Reporting the count makes the loss
- * observable: silently discarding it is exactly the regression this function exists to prevent, in a
- * tidier shape. A caller that logs zero is asserting no loss, not hoping for none.
+ * observable: silently discarding it is the regression this function exists to prevent, in a tidier
+ * shape. A caller that reports zero is asserting no loss, not hoping for none.
  *
  * @param {Object} options
  * @param {Array<{offset: Number, count: Number}>} options.spans Spans from {@link planEmbeddingSpans}.

--- a/test/playwright/unit/ai/services/memory-core/TextEmbeddingService.retry.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/TextEmbeddingService.retry.spec.mjs
@@ -92,6 +92,8 @@ function buildMinimalGguf({tokens, eosTokenId, eotTokenId, addEosToken = true}) 
 
 test.describe.serial('TextEmbeddingService #11393/#11402/#12487/#12509 — openAiCompatible retry, QoS, and lms server start support', () => {
     let TextEmbeddingService, server;
+    let spanPlan = {order: [], failLabels: [], holdLabel: null, holdMode: 'succeed', releaseHeld: null, releaseRequested: false};
+    let originalEmbeddingParallel;
     let requestCount   = 0;
     let serverBehavior = 'succeed';
     let lastRequest;
@@ -105,10 +107,14 @@ test.describe.serial('TextEmbeddingService #11393/#11402/#12487/#12509 — openA
     let originalLmsPort;
     let originalLoadedModelsProbe;
 
-    let EMBEDDING_RESIDENCY_NEVER_RESIDENT;
+    let EMBEDDING_RESIDENCY_NEVER_RESIDENT, isEmbeddingBatchYieldError;
 
     test.beforeAll(async () => {
-        ({default: TextEmbeddingService, EMBEDDING_RESIDENCY_NEVER_RESIDENT} = await import(
+        ({
+            default: TextEmbeddingService,
+            EMBEDDING_RESIDENCY_NEVER_RESIDENT,
+            isEmbeddingBatchYieldError
+        } = await import(
             '../../../../../../ai/services/memory-core/TextEmbeddingService.mjs'
         ));
 
@@ -237,6 +243,73 @@ test.describe.serial('TextEmbeddingService #11393/#11402/#12487/#12509 — openA
                     // Right count, wrong density: indices 0 and 2 for two inputs.
                     res.writeHead(200, { 'Content-Type': 'application/json' });
                     res.end(JSON.stringify({data: [{index: 0, embedding: [10]}, {index: 2, embedding: [22]}]}));
+                } else if (serverBehavior === 'span-controlled') {
+                    // One behaviour covering every concurrency scenario, keyed on the FIRST input of the
+                    // request. Width is 1 in these arms, so `input[0]` identifies the span exactly and no
+                    // request-ordering assumption is needed — which matters, because request arrival
+                    // order is the thing under test.
+                    const inputs = lastRequest.body.input,
+                          label  = Array.isArray(inputs) ? inputs[0] : inputs;
+
+                    // Overlap is the property these arms turn on, so it is COUNTED here rather than
+                    // inferred from arrival order. Without this the head-of-line arm would read the
+                    // qos-only counter, see 0, and pass or fail for reasons unrelated to its subject.
+                    inFlightRequests++;
+                    maxInFlightRequests = Math.max(maxInFlightRequests, inFlightRequests);
+
+                    // A held span is released once every span in the plan has ARRIVED, which is the
+                    // event that proves the overlap the arms assert. Both settlement paths run it: a
+                    // refusal is just as much an arrival, and a fail-only arm that skipped it would
+                    // deadlock on its own held neighbour.
+                    const releaseIfAllArrived = () => {
+                        if (spanPlan.releaseHeld && allRequests.length >= spanPlan.order.length) {
+                            const release = spanPlan.releaseHeld;
+                            spanPlan.releaseHeld = null;
+                            release()
+                        }
+                    };
+
+                    if (spanPlan.failLabels.includes(label)) {
+                        inFlightRequests--;
+                        res.writeHead(400, {'Content-Type': 'application/json'});
+                        res.end(JSON.stringify({error: `span ${label} refused`}));
+                        releaseIfAllArrived();
+                        return
+                    }
+
+                    const respond = () => {
+                        inFlightRequests--;
+                        res.writeHead(200, {'Content-Type': 'application/json'});
+                        // Vectors encode INPUT identity, so a mis-binding shows up as a wrong value
+                        // rather than merely a wrong length.
+                        res.end(JSON.stringify({
+                            data: inputs.map((input, offset) => ({index: offset, embedding: [input.charCodeAt(0)]}))
+                        }))
+                    };
+
+                    const refuse = () => {
+                        inFlightRequests--;
+                        res.writeHead(400, {'Content-Type': 'application/json'});
+                        res.end(JSON.stringify({error: `span ${label} refused`}))
+                    };
+
+                    // Head-of-line: hold this span and expose its settler. Two arms drive it from
+                    // different events, and NEITHER uses a timer — the release is always caused by an
+                    // observable step of the run, so the interleaving under test is the one asserted.
+                    if (spanPlan.holdLabel === label) {
+                        const settle = spanPlan.holdMode === 'fail' ? refuse : respond;
+
+                        // Order-independent by construction. A release can be requested BEFORE this
+                        // request's body has finished arriving — the yield predicate fires off span 0's
+                        // completion, which races span 1's POST — and a settler stored after that
+                        // request would never be called, turning the arm into a provider timeout that
+                        // happens to be red for the wrong reason.
+                        spanPlan.releaseRequested ? settle() : (spanPlan.releaseHeld = settle);
+                        return
+                    }
+
+                    respond();
+                    releaseIfAllArrived()
                 } else if (serverBehavior === 'chunked-batch-succeed') {
                     const inputs = lastRequest.body.input;
 
@@ -320,6 +393,8 @@ test.describe.serial('TextEmbeddingService #11393/#11402/#12487/#12509 — openA
         originalBatchEmbeddingChunkSize = aiConfig.openAiCompatible.batchEmbeddingChunkSize;
         originalBatchEmbeddingTimeoutMs = aiConfig.openAiCompatible.batchEmbeddingTimeoutMs;
         originalBatchEmbeddingYieldMs = aiConfig.openAiCompatible.batchEmbeddingYieldMs;
+        originalEmbeddingParallel = aiConfig.localModels.embedding.parallel;
+        spanPlan = {order: [], failLabels: [], holdLabel: null, holdMode: 'succeed', releaseHeld: null, releaseRequested: false};
         originalLmsPort = aiConfig.orchestrator.lms.port;
         originalLoadedModelsProbe = TextEmbeddingService.openAiCompatibleLoadedModelsProbe;
 
@@ -339,6 +414,7 @@ test.describe.serial('TextEmbeddingService #11393/#11402/#12487/#12509 — openA
     });
 
     test.afterEach(() => {
+        aiConfig.localModels.embedding.parallel = originalEmbeddingParallel;
         aiConfig.openAiCompatible.host = originalHost;
         aiConfig.openAiCompatible.embeddingModel = originalEmbeddingModel;
         aiConfig.openAiCompatible.unloadRetryCount = originalRetryCount;
@@ -501,6 +577,140 @@ test.describe.serial('TextEmbeddingService #11393/#11402/#12487/#12509 — openA
                 input: 'hello'
             }
         });
+    });
+
+    /*
+     * The four concurrency scenarios a happy-path fan-out arm cannot reach: a slow span that must not
+     * hold the others, an early hole that makes later completions unbindable, a failure surfacing while
+     * a yield vote is already standing, and attribution when several spans are outstanding at once.
+     *
+     * Pure prefix arithmetic covers none of these — it can prove what the plan computes but not that the
+     * service wires it. Each arm therefore drives the real dispatch loop against a stub keyed on the
+     * request's first input, and asserts request ARRIVAL order nowhere: arrival order is the thing under
+     * test, so an arm that assumed it would be measuring its own fixture.
+     */
+    test('#17412 head-of-line: a slow first span does not delay the others, and order still holds', async () => {
+        serverBehavior = 'span-controlled';
+        spanPlan       = {order: ['a', 'b', 'c', 'd'], failLabels: [], holdLabel: 'a', holdMode: 'succeed', releaseHeld: null, releaseRequested: false};
+        aiConfig.openAiCompatible.batchEmbeddingChunkSize = 1;
+        aiConfig.localModels.embedding.parallel           = 5;
+
+        const result = await TextEmbeddingService.embedTexts(['a', 'b', 'c', 'd'], 'openAiCompatible');
+
+        // Non-vacuity: without real overlap the held span would have blocked the others and this arm
+        // would be measuring a sequential loop.
+        expect(maxInFlightRequests, 'the later spans must be in flight while the first is held').toBeGreaterThan(1);
+
+        // Completion order was deliberately inverted — 'a' answered last — and the assembled output is
+        // still in INPUT order with each vector carrying its own input's identity.
+        expect(result).toEqual([[97], [98], [99], [100]])
+    });
+
+    test('#17412 an EARLY failure with later successes carries nothing, and reports the drop', async () => {
+        serverBehavior = 'span-controlled';
+        spanPlan       = {order: ['a', 'b', 'c', 'd'], failLabels: ['a'], holdLabel: null, holdMode: 'succeed', releaseHeld: null, releaseRequested: false};
+        aiConfig.openAiCompatible.batchEmbeddingChunkSize = 1;
+        aiConfig.openAiCompatible.unloadRetryCount        = 0;
+        aiConfig.localModels.embedding.parallel           = 5;
+
+        const error = await TextEmbeddingService.embedTexts(['a', 'b', 'c', 'd'], 'openAiCompatible')
+            .then(() => null, err => err);
+
+        expect(error).toBeInstanceOf(Error);
+
+        // The hole is at span 0, so the carryable PREFIX is empty even though later spans completed.
+        // A count-times-width product would instead have claimed a range starting at input 0.
+        expect(error.completedTextCount, 'a hole at the front means nothing is bindable').toBeUndefined();
+        expect(error.embeddings).toBeUndefined();
+
+        // And the completed-but-unbindable work is REPORTED rather than dropped in silence — this is the
+        // whole point of the receipt, and it is what makes the loss measurable instead of inferred.
+        expect(error.droppedCompletedChunkCount, 'later spans completed and could not be bound').toBeGreaterThan(0)
+    });
+
+    test('#17412 a failure observed during drain OUTRANKS a cooperative yield', async () => {
+        // Both states must genuinely coexist, and getting there is the hard part: the yield predicate is
+        // only consulted while spans remain UNDISPATCHED, so a fan-out wide enough to issue everything
+        // in one pass never votes at all. Two spans of concurrency against six spans of work leaves the
+        // consultation reachable.
+        serverBehavior = 'span-controlled';
+        spanPlan       = {
+            order      : ['a', 'b', 'c', 'd', 'e', 'f'],
+            failLabels : [],
+            holdLabel  : 'b',
+            holdMode   : 'fail',
+            releaseHeld: null,
+
+            releaseRequested: false
+        };
+        aiConfig.openAiCompatible.batchEmbeddingChunkSize = 1;
+        aiConfig.openAiCompatible.unloadRetryCount        = 0;
+        aiConfig.localModels.embedding.parallel           = 3;
+
+        let yieldConsultations = 0;
+
+        const error = await TextEmbeddingService
+            .embedTexts(['a', 'b', 'c', 'd', 'e', 'f'], 'openAiCompatible', {
+                shouldYield: () => {
+                    yieldConsultations++;
+
+                    // Released BY the consultation, so the failure is guaranteed to surface after the
+                    // yield was voted and while the loop is draining — no timer, and no dependence on
+                    // which promise the event loop happens to settle first. The flag covers the case
+                    // where this fires before the held request has even reached the handler.
+                    spanPlan.releaseRequested = true;
+                    spanPlan.releaseHeld?.();
+                    spanPlan.releaseHeld      = null;
+
+                    return true
+                }
+            })
+            .then(() => null, err => err);
+
+        // Non-vacuity, and the reason M4 (`if (firstError && !yielded)`) survived the first version of
+        // this arm: without a consultation there is no yield to outrank, and the assertions below pass
+        // for a scenario that never posed the question.
+        expect(yieldConsultations, 'the yield predicate must actually have been consulted').toBeGreaterThan(0);
+
+        expect(error).toBeInstanceOf(Error);
+        expect(error.message, 'the provider failure must be the reported cause, not the yield').toContain('span b refused');
+
+        // The production classifier, not a local re-derivation of it: this is the exact predicate the
+        // consumer branches on to decide "resumable checkpoint" vs "broken lane". Handing back a
+        // checkpoint for a lane that is actually failing is the misreport this guards.
+        expect(isEmbeddingBatchYieldError(error), 'must not be classified as a cooperative yield').toBe(false)
+    });
+
+    test('#17412 failure attribution names the FAILING span, not the first one in flight', async () => {
+        // Width TWO, deliberately. At width 1 every span holds one input, so `span.count` and the
+        // constant 1 are indistinguishable and a hardcoded count survives as an equivalent mutant —
+        // the arm would pin the offset and leave the count unpinned while looking complete.
+        serverBehavior = 'span-controlled';
+        spanPlan       = {
+            order      : ['a', 'c'],
+            failLabels : ['c'],
+            holdLabel  : 'a',
+            holdMode   : 'succeed',
+            releaseHeld: null,
+
+            releaseRequested: false
+        };
+        aiConfig.openAiCompatible.batchEmbeddingChunkSize = 2;
+        aiConfig.openAiCompatible.unloadRetryCount        = 0;
+        aiConfig.localModels.embedding.parallel           = 5;
+
+        const error = await TextEmbeddingService.embedTexts(['a', 'b', 'c', 'd'], 'openAiCompatible')
+            .then(() => null, err => err);
+
+        // Non-vacuity: both spans must have been outstanding together, or "not the first one in
+        // flight" is a distinction the run never offered.
+        expect(maxInFlightRequests, 'both spans in flight at once').toBeGreaterThan(1);
+
+        // With several spans outstanding, a timeout names the whole POST — so the consumer's
+        // undeliverable classification needs the span that was actually in flight. Attributing it to
+        // the first batch member is how an innocent neighbour inherits a monster's strikes.
+        expect(error.failedTextOffset, 'the failing span starts at input offset 2').toBe(2);
+        expect(error.failedTextCount, 'and it held TWO inputs, not a hardcoded one').toBe(2)
     });
 
     test('lms server start-compatible batch embeddings preserve TextEmbeddingService ordering', async () => {

--- a/test/playwright/unit/ai/services/memory-core/TextEmbeddingService.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/TextEmbeddingService.spec.mjs
@@ -1612,6 +1612,96 @@ test.describe.serial('TextEmbeddingService #15694 — provider-neutral cancellat
         expect(clamped.embeddings, 'the clamped run must agree with the fanned-out one').toEqual(expected);
     });
 
+
+    test('the TASK budget binds ACROSS concurrent callers, not per call (#17412)', async () => {
+        // `resolveDispatchPlan` reserves headroom per `embedTexts` call. The queue then admitted by
+        // POST while the budget is denominated in TASKS, so two callers each satisfied their own
+        // reservation and jointly offered six tasks against a budget of four.
+        const probe = async () => {
+            const http   = await import('node:http');
+            const budget = Number(process.env.PROBE_TASK_BUDGET);
+            const held   = [];
+
+            let inFlightTasks = 0,
+                maxTasks      = 0,
+                stallGuard    = null;
+
+            // Once the budget IS honoured the callers serialize, so an arm that waited for both to
+            // overlap would hang exactly where the fix makes it correct. Releasing on arrival-quiet
+            // keeps the arm decidable in both worlds.
+            // fixed-sleep-justification: arrival debounce that keeps the arm decidable, not a wait.
+            const armStallGuard = () => {
+                clearTimeout(stallGuard);
+                stallGuard = setTimeout(() => held.splice(0).forEach(release => release()), 250)
+            };
+
+            const server = http.createServer((request, response) => {
+                let body = '';
+
+                request.on('data', chunk => body += chunk);
+                request.on('end', () => {
+                    const payload = body ? JSON.parse(body) : {input: []},
+                          inputs  = Array.isArray(payload.input) ? payload.input : [payload.input];
+
+                    // TASKS, not requests: one multi-input POST is one provider task per input.
+                    inFlightTasks += inputs.length;
+                    maxTasks       = Math.max(maxTasks, inFlightTasks);
+                    armStallGuard();
+
+                    held.push(() => {
+                        inFlightTasks -= inputs.length;
+                        response.writeHead(200, {'Content-Type': 'application/json'});
+                        response.end(JSON.stringify({
+                            data: inputs.map((input, index) => ({index, embedding: [input.charCodeAt(0), input.length]}))
+                        }))
+                    });
+
+                    if (inFlightTasks >= budget) {
+                        clearTimeout(stallGuard);
+                        stallGuard = null;
+                        held.splice(0).forEach(release => release())
+                    }
+                })
+            });
+
+            await new Promise(resolve => server.listen(0, '127.0.0.1', resolve));
+
+            try {
+                process.env.NEO_OPENAI_COMPATIBLE_HOST = `http://127.0.0.1:${server.address().port}`;
+
+                const {default: Service} = await import('./ai/services/memory-core/TextEmbeddingService.mjs');
+                const [first, second]    = await Promise.all([
+                    Service.embedTexts(['a', 'b', 'c'], 'openAiCompatible'),
+                    Service.embedTexts(['d', 'e', 'f'], 'openAiCompatible')
+                ]);
+
+                console.log(JSON.stringify({maxTasks, first, second}));
+            } finally {
+                clearTimeout(stallGuard);
+                server.closeAllConnections?.();
+                await new Promise(resolve => server.close(resolve))
+            }
+        };
+
+        const result = await runIsolatedEmbeddingProbe(probe, {
+            NEO_OPENAI_COMPATIBLE_UNLOAD_RETRY_COUNT        : '0',
+            NEO_OPENAI_COMPATIBLE_BATCH_EMBEDDING_CHUNK_SIZE: '3',
+            NEO_LOCAL_MODELS_EMBEDDING_PARALLEL             : '4',
+            PROBE_TASK_BUDGET                               : '4'
+        });
+
+        // Admission paces; it must not reorder or drop. Without these, a change that merged or lost a
+        // caller would satisfy the budget assertion below.
+        expect(result.first,  'caller one must receive its own vectors, in its own order').toEqual(
+            ['a', 'b', 'c'].map(input => [input.charCodeAt(0), input.length]));
+        expect(result.second, 'caller two must receive its own vectors, in its own order').toEqual(
+            ['d', 'e', 'f'].map(input => [input.charCodeAt(0), input.length]));
+
+        expect(result.maxTasks,
+            'the declared task budget must bind across concurrent callers, not per call'
+        ).toBeLessThanOrEqual(4);
+    });
+
     test('OpenAI-compatible retry and batch delays stop before later work in an isolated config process', async () => {
         const evidence = await runIsolatedEmbeddingProbe(async () => {
             const http                = await import('node:http');

--- a/test/playwright/unit/ai/services/memory-core/TextEmbeddingService.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/TextEmbeddingService.spec.mjs
@@ -1702,54 +1702,85 @@ test.describe.serial('TextEmbeddingService #15694 — provider-neutral cancellat
         ).toBeLessThanOrEqual(4);
     });
 
-    test('BATCH work leaves the interactive slot open at the declared budget (#17048) (#17412)', async () => {
-        // The cross-caller arm above asserts offered work stays WITHIN the budget. That is the budget
-        // noun, not the headroom noun: filling all four slots with batch work satisfies it and still
-        // destroys the interactive reservation. Reviewer-supplied falsifier — at budget 4 two
-        // batch callers can jointly reach four, and a later interactive post finds no slot.
+    test('an interactive post is admitted while batch work holds the rest of the budget', async () => {
+        // Two earlier versions of this arm were unsound and both were caught by mutating it. The first
+        // recorded `interactiveAdmitted` and never asserted it, and never enqueued interactive work at
+        // all. The second fired the interactive post as soon as batch reached three, which is BEFORE
+        // batch settles — so a mutant removing the reservation still admitted it and the arm passed on
+        // a race. This one waits for batch to reach STEADY STATE first, which is the only moment the
+        // reservation is observable.
         const probe = async () => {
             const http = await import('node:http');
             const held = [];
 
-            let batchInFlight       = 0,
-                maxBatchInFlight    = 0,
-                interactiveAdmitted = false,
-                stallGuard          = null;
+            let draining             = false,
+                batchInFlight        = 0,
+                steadyBatchInFlight  = -1,
+                interactiveArrivedAt = -1,
+                batchReleasedAt      = -1,
+                seq                  = 0,
+                settleTimer          = null,
+                resolveSteady        = null;
 
-            // fixed-sleep-justification: arrival debounce that keeps the arm decidable, not a wait.
-            const armStallGuard = () => {
-                clearTimeout(stallGuard);
-                stallGuard = setTimeout(() => held.splice(0).forEach(release => release()), 250)
+            const steady = new Promise(resolve => { resolveSteady = resolve });
+            // Once released, STAY released. `embedTexts` has more spans than the budget admits, so the
+            // remainder dispatches only after the first cohort drains — and a probe that holds by
+            // default puts those later arrivals into `held` with nothing left to empty it. The run then
+            // hangs on `await batch` with the contract already satisfied, which is a probe defect
+            // wearing a product failure's clothes. Cost four rewrites before I traced it.
+            const releaseAll = () => {
+                draining = true;
+                if (batchReleasedAt === -1) batchReleasedAt = ++seq;
+                held.splice(0).forEach(release => release())
+            };
+
+            // Steady state = no new batch arrival for a beat. That is the fact the probe cannot
+            // otherwise learn, and it is what makes the peak observable rather than sampled mid-ramp.
+            // fixed-sleep-justification: arrival-quiet detector, not a wait for a thing to happen.
+            const armSettle = () => {
+                clearTimeout(settleTimer);
+                settleTimer = setTimeout(() => {
+                    steadyBatchInFlight = batchInFlight;
+                    resolveSteady()
+                }, 250)
             };
 
             const server = http.createServer((request, response) => {
+                // Route by PATH. The interactive entry point resolves an embedding runtime first, and
+                // that resolution issues `GET /v1/models`. A probe that treats every request as
+                // embedding traffic HOLDS that one — so `embedText` blocks before it ever enqueues,
+                // and the arm dies by SIGKILL with nothing to read. Cost me three rewrites of this arm
+                // before I looked at the request URL instead of the request body.
+                if (!request.url.includes('/embeddings')) {
+                    response.writeHead(200, {'Content-Type': 'application/json'});
+                    response.end(JSON.stringify({data: [{id: 'probe-embedding-model'}]}));
+                    return
+                }
+
                 let body = '';
 
                 request.on('data', chunk => body += chunk);
                 request.on('end', () => {
                     const payload = body ? JSON.parse(body) : {input: []},
                           inputs  = Array.isArray(payload.input) ? payload.input : [payload.input],
-                          release = () => {
+                          respond = () => {
                               response.writeHead(200, {'Content-Type': 'application/json'});
                               response.end(JSON.stringify({
                                   data: inputs.map((input, index) => ({index, embedding: [input.charCodeAt(0), input.length]}))
                               }))
                           };
 
-                    // The interactive probe uses a distinguishable input so the server can tell the
-                    // lanes apart without reading provider internals.
                     if (inputs.includes('INTERACTIVE')) {
-                        interactiveAdmitted = true;
-                        release();
-                        clearTimeout(stallGuard);
-                        held.splice(0).forEach(r => r());
+                        interactiveArrivedAt = ++seq;
+                        respond();
                         return
                     }
 
-                    batchInFlight   += inputs.length;
-                    maxBatchInFlight = Math.max(maxBatchInFlight, batchInFlight);
-                    armStallGuard();
-                    held.push(() => { batchInFlight -= inputs.length; release() })
+                    if (draining) { respond(); return }
+
+                    batchInFlight += inputs.length;
+                    armSettle();
+                    held.push(() => { batchInFlight -= inputs.length; respond() })
                 })
             });
 
@@ -1759,15 +1790,33 @@ test.describe.serial('TextEmbeddingService #15694 — provider-neutral cancellat
                 process.env.NEO_OPENAI_COMPATIBLE_HOST = `http://127.0.0.1:${server.address().port}`;
 
                 const {default: Service} = await import('./ai/services/memory-core/TextEmbeddingService.mjs');
-
-                await Promise.all([
-                    Service.embedTexts(['a', 'b'], 'openAiCompatible'),
-                    Service.embedTexts(['c', 'd'], 'openAiCompatible')
+                // TWO batch callers, deliberately. With one, `resolveDispatchPlan`'s per-call
+                // reservation already caps offered work at three, so the GLOBAL ceiling never binds
+                // and a mutant removing it is invisible — measured: that version of this arm passed
+                // under exactly the mutant it exists to catch.
+                const batch = Promise.all([
+                    Service.embedTexts(['a', 'b', 'c'], 'openAiCompatible'),
+                    Service.embedTexts(['d', 'e', 'f'], 'openAiCompatible')
                 ]);
 
-                console.log(JSON.stringify({maxBatchInFlight, interactiveAdmitted}));
+                await steady;
+
+                // Fire interactive, and guarantee the run ENDS whether or not it is admitted: if the
+                // reservation is gone the post is stuck behind held batch work, so release after a
+                // bound and let the ordering assertion decide. A stuck run must fail by assertion,
+                // never by the runner's SIGKILL.
+                // fixed-sleep-justification: bounded escape that keeps the arm decidable, not a wait.
+                const escape      = setTimeout(releaseAll, 500);
+                const interactive = await Service.embedText('INTERACTIVE', 'openAiCompatible');
+
+                clearTimeout(escape);
+                clearTimeout(settleTimer);
+                releaseAll();
+                await batch;
+
+                console.log(JSON.stringify({steadyBatchInFlight, interactiveArrivedAt, batchReleasedAt, interactive}))
             } finally {
-                clearTimeout(stallGuard);
+                clearTimeout(settleTimer);
                 server.closeAllConnections?.();
                 await new Promise(resolve => server.close(resolve))
             }
@@ -1779,12 +1828,21 @@ test.describe.serial('TextEmbeddingService #15694 — provider-neutral cancellat
             NEO_LOCAL_MODELS_EMBEDDING_PARALLEL             : '4'
         });
 
-        // THE HEADROOM CONTRACT: batch work never occupies the last slot. Four single-input batch
-        // tasks are available and the budget is four, so an admission that ignores lane would reach
-        // four; the reservation requires it to stop at three.
-        expect(result.maxBatchInFlight,
-            'batch work must leave one task of the declared budget free for interactive use'
-        ).toBeLessThanOrEqual(3);
+        // THE RESERVATION, as a peak: six single-input batch tasks against a budget of four settle at
+        // three, never four. Removing the batch ceiling makes this read 4.
+        expect(result.steadyBatchInFlight,
+            'batch work must settle at budget - 1, leaving one task of the declared budget free'
+        ).toBe(3);
+
+        // THE RESERVATION, as an ordering fact: the free slot is usable WHILE batch holds the rest.
+        // Applying the batch ceiling to the interactive lane makes this arrive only after release.
+        expect(result.interactiveArrivedAt, 'the interactive post must reach the provider').toBeGreaterThan(0);
+        expect(result.interactiveArrivedAt,
+            'a slot reserved but not reachable is not headroom: interactive must be served before batch release'
+        ).toBeLessThan(result.batchReleasedAt);
+
+        expect(result.interactive, 'the interactive call must return its own vector')
+            .toEqual(['INTERACTIVE'.charCodeAt(0), 'INTERACTIVE'.length]);
     });
 
     test('OpenAI-compatible retry and batch delays stop before later work in an isolated config process', async () => {

--- a/test/playwright/unit/ai/services/memory-core/TextEmbeddingService.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/TextEmbeddingService.spec.mjs
@@ -1462,10 +1462,42 @@ test.describe.serial('TextEmbeddingService #15694 — provider-neutral cancellat
             const targetPeak    = Number(process.env.PROBE_TARGET_PEAK);
             const expectedSpans = Number(process.env.PROBE_EXPECTED_SPANS);
 
-            let open    = 0,
-                maxOpen = 0;
+            let open       = 0,
+                maxOpen    = 0,
+                stalled    = false,
+                stallGuard = null;
 
-            const releaseAll = () => held.splice(0).forEach(release => release());
+            // A run that can never satisfy either release condition used to surface as the runner's
+            // 10s SIGKILL, and a SIGKILL names nothing: the verdict became "the process died" rather
+            // than "the peak was wrong". A single-worker mutant is exactly that shape — one request is
+            // ever open, so `open` cannot reach the target, and the rest never dispatch, so the arrival
+            // count cannot reach the total. BOTH release arms are unreachable in the mutant's world.
+            //
+            // This guard releases whatever is held so the run COMPLETES and the arm fails on `maxOpen`,
+            // by assertion, in about the baseline's wall-clock. It is armed once, cleared by any normal
+            // release, and generous enough that the green path never reaches it.
+            // Re-armed on every ARRIVAL, because at one worker the stall recurs per request: releasing
+            // the held one lets the service dispatch the next, which hangs identically. A guard armed
+            // once rescues exactly one request and the run dies on the second — measured.
+            //
+            // The debounce is the fact the probe cannot otherwise learn: "no further request is coming
+            // right now". Everything else it knows (target peak, total spans) is unreachable precisely
+            // in the world the mutant creates, which is what made the old predicate undecidable there.
+            // fixed-sleep-justification: an arrival debounce that makes a deadlock assertable, not a
+            // wait for a thing to happen — the green path clears it within milliseconds and it never fires.
+            const armStallGuard = () => {
+                clearTimeout(stallGuard);
+                stallGuard = setTimeout(() => {
+                    stalled = true;
+                    held.splice(0).forEach(release => release())
+                }, 250)
+            };
+
+            const releaseAll = () => {
+                clearTimeout(stallGuard);
+                stallGuard = null;
+                held.splice(0).forEach(release => release())
+            };
 
             const server = http.createServer((request, response) => {
                 let body = '';
@@ -1478,6 +1510,7 @@ test.describe.serial('TextEmbeddingService #15694 — provider-neutral cancellat
                     requestInputs.push(inputs);
                     open    += 1;
                     maxOpen  = Math.max(maxOpen, open);
+                    armStallGuard();
 
                     held.push(() => {
                         open -= 1;
@@ -1517,8 +1550,9 @@ test.describe.serial('TextEmbeddingService #15694 — provider-neutral cancellat
                     'openAiCompatible'
                 );
 
-                console.log(JSON.stringify({requestInputs, embeddings, maxOpen}));
+                console.log(JSON.stringify({requestInputs, embeddings, maxOpen, stalled}));
             } finally {
+                clearTimeout(stallGuard);
                 server.closeAllConnections?.();
                 await new Promise(resolve => server.close(resolve))
             }
@@ -1546,9 +1580,21 @@ test.describe.serial('TextEmbeddingService #15694 — provider-neutral cancellat
             })
         ]);
 
-        // EXACT peak. A lane declaring five tasks at width 1 must hold four requests open at once.
+        // EXACT peak, asserted BEFORE the stall flag. Any concurrency below the target stalls the
+        // probe — the release needs peak 4 — so both lines redden together and the FIRST one decides
+        // what the failure says. `maxOpen` is the real subject and it reports the number observed, so
+        // "2 where 4 was declared" reads correctly; the stall flag alone would have called that
+        // "never overlapped", which is false at two workers and was the drift in my first draft.
         expect(fanOut.maxOpen, 'four available tasks at width 1 must yield exactly four in flight').toBe(4);
         expect(fanOut.requestInputs).toHaveLength(6);
+
+        // The residual case the peak assertion cannot express: the probe released on its DEADLINE
+        // rather than on the peak or the full arrival set. Reachable only if the peak was somehow met
+        // and the run still could not finish, so it stays a distinct condition rather than a duplicate
+        // of the line above. Its value is that a deadlock now arrives here in about a second instead of
+        // as the runner's 10s SIGKILL, which named nothing at all.
+        expect(fanOut.stalled, 'the fan-out probe released on its stall deadline rather than on peak or full arrival').toBe(false);
+        expect(clamped.stalled, 'the clamped probe released on its stall deadline rather than on peak or full arrival').toBe(false);
         expect(fanOut.requestInputs.every(inputs => inputs.length === 1), 'width 1 means single-input requests').toBe(true);
 
         // WIDTH clamps to the budget, and offered tasks stay under it.

--- a/test/playwright/unit/ai/services/memory-core/TextEmbeddingService.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/TextEmbeddingService.spec.mjs
@@ -1447,68 +1447,62 @@ test.describe.serial('TextEmbeddingService #15694 — provider-neutral cancellat
         });
     });
 
-    test('the declared parallelism is a CONCURRENCY, and request width does not derive from it (#17412)', async () => {
-        // Replaces an arm that asserted the opposite: `parallel - 1` as a request WIDTH, clamping a
-        // four-slot lane to three inputs per POST in order to "reserve" a slot. A client cannot
-        // reserve a provider slot — the server assigns them from its own queue — so the clamp only
-        // guaranteed one slot idled, and the lane dispatched one request at a time.
+    test('the declared parallelism is a TASK budget: exact peak fan-out, and width clamps to it (#17412)', async () => {
+        // Replaces an arm that asserted `parallel - 1` as a request WIDTH. The provider's capacity unit
+        // is a TASK — one multi-input POST expands to one task per input — so offered work is
+        // concurrency × width and the two are jointly constrained by one budget.
         //
-        // Concurrency is observed by OVERLAP, never by call count: a sequential loop makes the same
-        // number of calls. The probe defers every response by a macrotask, so each request that has
-        // arrived is still open when the next arrives, and `maxConcurrent` records what the client
-        // actually had outstanding.
+        // Concurrency is observed by OVERLAP and asserted as an EXACT peak, never by call count: a
+        // sequential loop makes the same number of calls, and a peak of "more than one" would pass on a
+        // lane that manages two when it declared room for four.
         const probe = async () => {
             const http                 = await import('node:http');
             const requestInputs        = [];
             const held                 = [];
-            const expectedRequestCount = 3;
-            // Read from the same env the service reads, so the probe cannot disagree with the subject.
-            const expectSequential = process.env.NEO_LOCAL_MODELS_EMBEDDING_PARALLEL === '1';
+            const targetPeak    = Number(process.env.PROBE_TARGET_PEAK);
+            const expectedSpans = Number(process.env.PROBE_EXPECTED_SPANS);
 
-            let open          = 0,
-                maxConcurrent = 0;
+            let open    = 0,
+                maxOpen = 0;
+
+            const releaseAll = () => held.splice(0).forEach(release => release());
 
             const server = http.createServer((request, response) => {
                 let body = '';
 
                 request.on('data', chunk => body += chunk);
                 request.on('end', () => {
-                    const payload = JSON.parse(body),
+                    const payload = body ? JSON.parse(body) : {input: []},
                           inputs  = Array.isArray(payload.input) ? payload.input : [payload.input];
 
                     requestInputs.push(inputs);
-                    open          += 1;
-                    maxConcurrent  = Math.max(maxConcurrent, open);
-
-                    const sequence = requestInputs.length;
+                    open    += 1;
+                    maxOpen  = Math.max(maxOpen, open);
 
                     held.push(() => {
                         open -= 1;
                         response.writeHead(200, {'Content-Type': 'application/json'});
+                        // Vectors encode the INPUT's identity, not arrival order, so a mis-binding is
+                        // visible in the assembled output rather than merely absent.
                         response.end(JSON.stringify({
-                            data: inputs.map((input, index) => ({
-                                index,
-                                embedding: [sequence, index]
-                            }))
+                            data: inputs.map((input, index) => ({index, embedding: [input.charCodeAt(0), input.length]}))
                         }))
                     });
 
-                    // The two runs need DIFFERENT instruments, because only one of them can overlap.
+                    // Release on EITHER condition, both derived from values the probe already knows.
+                    // No timer, no macrotask chain, and no state where a request waits for something
+                    // that cannot arrive:
                     //
-                    // Concurrent run: hold until two are open. That is the only observation that
-                    // distinguishes real overlap from a sequential loop making the same number of
-                    // calls. Once satisfied, release everything — including the final unpartnered
-                    // span, which would otherwise wait for a partner that cannot arrive.
+                    //   open >= targetPeak       the overlap this run exists to measure has happened
+                    //   all spans have arrived   nothing further is coming, so holding is pointless
                     //
-                    // Sequential run: resolve immediately. Holding would deadlock — the client does
-                    // not issue request N+1 until N answers — and `maxConcurrent` staying 1 is exactly
-                    // the property being asserted.
-                    //
-                    // Deferring by a macrotask was the first attempt for both, and it silently
-                    // collapsed the concurrent measurement: each response resolved before the next
-                    // request's `end` fired, so a genuinely concurrent client read as 1.
-                    if (expectSequential || open >= 2 || requestInputs.length === expectedRequestCount) {
-                        held.splice(0).forEach(release => release())
+                    // The target is per-run because only one run can overlap: the fan-out run expects 4,
+                    // the width-clamped run expects 1 and therefore releases on first arrival. Three
+                    // earlier designs failed here and are recorded in the PR body — an unconditional
+                    // macrotask deferral collapsed the measurement to 1, and both a per-arrival and a
+                    // centralised no-growth hop chain starved the poll phase so I/O never progressed.
+                    if (open >= targetPeak || requestInputs.length === expectedSpans) {
+                        releaseAll()
                     }
                 })
             });
@@ -1523,47 +1517,53 @@ test.describe.serial('TextEmbeddingService #15694 — provider-neutral cancellat
                     'openAiCompatible'
                 );
 
-                console.log(JSON.stringify({requestInputs, embeddings, maxConcurrent}));
+                console.log(JSON.stringify({requestInputs, embeddings, maxOpen}));
             } finally {
                 server.closeAllConnections?.();
                 await new Promise(resolve => server.close(resolve))
             }
         };
         const commonEnv = {
-            // Width 2 over 6 inputs = three spans, so concurrency has something to fan out and the
-            // width assertion has a short-span-free shape to compare across both runs.
-            NEO_OPENAI_COMPATIBLE_BATCH_EMBEDDING_CHUNK_SIZE: '2',
-            NEO_OPENAI_COMPATIBLE_UNLOAD_RETRY_COUNT        : '0'
+            NEO_OPENAI_COMPATIBLE_UNLOAD_RETRY_COUNT: '0'
         };
-        const [multiSlot, singleSlot] = await Promise.all([
+        const [fanOut, clamped] = await Promise.all([
+            // budget 5, width 1 -> one task reserved, four available, six spans: peak exactly 4.
             runIsolatedEmbeddingProbe(probe, {
                 ...commonEnv,
-                NEO_LOCAL_MODELS_EMBEDDING_PARALLEL: '4'
+                NEO_OPENAI_COMPATIBLE_BATCH_EMBEDDING_CHUNK_SIZE: '1',
+                NEO_LOCAL_MODELS_EMBEDDING_PARALLEL             : '5',
+                PROBE_TARGET_PEAK                               : '4',
+                PROBE_EXPECTED_SPANS                            : '6'
             }),
+            // budget 4, configured width 5 -> width CLAMPS to 3 and there is no room to fan out. This is
+            // the shipped plane's shape, and it reproduces the old clamp's output exactly.
             runIsolatedEmbeddingProbe(probe, {
                 ...commonEnv,
-                NEO_LOCAL_MODELS_EMBEDDING_PARALLEL: '1'
+                NEO_OPENAI_COMPATIBLE_BATCH_EMBEDDING_CHUNK_SIZE: '5',
+                NEO_LOCAL_MODELS_EMBEDDING_PARALLEL             : '4',
+                PROBE_TARGET_PEAK                               : '1',
+                PROBE_EXPECTED_SPANS                            : '2'
             })
         ]);
 
-        // WIDTH is the durability contract and comes from its own leaf: identical request contents at
-        // both parallelisms. Against the previous implementation the multi-slot run would have sent
-        // three-input requests here, so this is the arm that catches the clamp returning.
-        const expectedInputs = [['a', 'b'], ['c', 'd'], ['e', 'f']];
+        // EXACT peak. A lane declaring five tasks at width 1 must hold four requests open at once.
+        expect(fanOut.maxOpen, 'four available tasks at width 1 must yield exactly four in flight').toBe(4);
+        expect(fanOut.requestInputs).toHaveLength(6);
+        expect(fanOut.requestInputs.every(inputs => inputs.length === 1), 'width 1 means single-input requests').toBe(true);
 
-        expect(multiSlot.requestInputs.slice().sort(), 'width must not vary with parallelism').toEqual(expectedInputs.slice().sort());
-        expect(singleSlot.requestInputs).toEqual(expectedInputs);
+        // WIDTH clamps to the budget, and offered tasks stay under it.
+        expect(clamped.requestInputs, 'configured width 5 must clamp to 3 at a budget of 4').toEqual([
+            ['a', 'b', 'c'],
+            ['d', 'e', 'f']
+        ]);
+        expect(clamped.maxOpen, 'no room to fan out at four tasks with width 3').toBe(1);
 
-        // CONCURRENCY is the throughput contract. RED against the previous implementation, which
-        // awaited every request and could never exceed one outstanding.
-        expect(multiSlot.maxConcurrent, 'a lane declaring four slots must dispatch more than one request at a time').toBeGreaterThan(1);
-        expect(singleSlot.maxConcurrent, 'parallel:1 must remain strictly sequential — the silent arm').toBe(1);
+        // ORDERING is a contract, not an accident: vectors encode input identity, so both runs must
+        // assemble the same output in input order despite different completion orders.
+        const expected = ['a', 'b', 'c', 'd', 'e', 'f'].map(input => [input.charCodeAt(0), input.length]);
 
-        // Ordering is a contract, not an accident: outputs map to inputs by index whatever order the
-        // responses arrived in. Both runs embed the same six inputs.
-        expect(multiSlot.embeddings).toHaveLength(6);
-        expect(singleSlot.embeddings).toHaveLength(6);
-        expect(multiSlot.embeddings).toEqual(singleSlot.embeddings)
+        expect(fanOut.embeddings, 'fan-out must preserve input order').toEqual(expected);
+        expect(clamped.embeddings, 'the clamped run must agree with the fanned-out one').toEqual(expected);
     });
 
     test('OpenAI-compatible retry and batch delays stop before later work in an isolated config process', async () => {

--- a/test/playwright/unit/ai/services/memory-core/TextEmbeddingService.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/TextEmbeddingService.spec.mjs
@@ -1447,11 +1447,28 @@ test.describe.serial('TextEmbeddingService #15694 — provider-neutral cancellat
         });
     });
 
-    test('OpenAI-compatible batches reserve one declared engine slot without mutating shared config (#17048)', async () => {
+    test('the declared parallelism is a CONCURRENCY, and request width does not derive from it (#17412)', async () => {
+        // Replaces an arm that asserted the opposite: `parallel - 1` as a request WIDTH, clamping a
+        // four-slot lane to three inputs per POST in order to "reserve" a slot. A client cannot
+        // reserve a provider slot — the server assigns them from its own queue — so the clamp only
+        // guaranteed one slot idled, and the lane dispatched one request at a time.
+        //
+        // Concurrency is observed by OVERLAP, never by call count: a sequential loop makes the same
+        // number of calls. The probe defers every response by a macrotask, so each request that has
+        // arrived is still open when the next arrives, and `maxConcurrent` records what the client
+        // actually had outstanding.
         const probe = async () => {
-            const http          = await import('node:http');
-            const requestInputs = [];
-            const server        = http.createServer((request, response) => {
+            const http                 = await import('node:http');
+            const requestInputs        = [];
+            const held                 = [];
+            const expectedRequestCount = 3;
+            // Read from the same env the service reads, so the probe cannot disagree with the subject.
+            const expectSequential = process.env.NEO_LOCAL_MODELS_EMBEDDING_PARALLEL === '1';
+
+            let open          = 0,
+                maxConcurrent = 0;
+
+            const server = http.createServer((request, response) => {
                 let body = '';
 
                 request.on('data', chunk => body += chunk);
@@ -1460,14 +1477,40 @@ test.describe.serial('TextEmbeddingService #15694 — provider-neutral cancellat
                           inputs  = Array.isArray(payload.input) ? payload.input : [payload.input];
 
                     requestInputs.push(inputs);
-                    response.writeHead(200, {'Content-Type': 'application/json'});
-                    response.end(JSON.stringify({
-                        data: inputs.map((input, index) => ({
-                            index,
-                            embedding: [requestInputs.length, index]
+                    open          += 1;
+                    maxConcurrent  = Math.max(maxConcurrent, open);
+
+                    const sequence = requestInputs.length;
+
+                    held.push(() => {
+                        open -= 1;
+                        response.writeHead(200, {'Content-Type': 'application/json'});
+                        response.end(JSON.stringify({
+                            data: inputs.map((input, index) => ({
+                                index,
+                                embedding: [sequence, index]
+                            }))
                         }))
-                    }));
-                });
+                    });
+
+                    // The two runs need DIFFERENT instruments, because only one of them can overlap.
+                    //
+                    // Concurrent run: hold until two are open. That is the only observation that
+                    // distinguishes real overlap from a sequential loop making the same number of
+                    // calls. Once satisfied, release everything — including the final unpartnered
+                    // span, which would otherwise wait for a partner that cannot arrive.
+                    //
+                    // Sequential run: resolve immediately. Holding would deadlock — the client does
+                    // not issue request N+1 until N answers — and `maxConcurrent` staying 1 is exactly
+                    // the property being asserted.
+                    //
+                    // Deferring by a macrotask was the first attempt for both, and it silently
+                    // collapsed the concurrent measurement: each response resolved before the next
+                    // request's `end` fired, so a genuinely concurrent client read as 1.
+                    if (expectSequential || open >= 2 || requestInputs.length === expectedRequestCount) {
+                        held.splice(0).forEach(release => release())
+                    }
+                })
             });
             await new Promise(resolve => server.listen(0, '127.0.0.1', resolve));
 
@@ -1476,18 +1519,20 @@ test.describe.serial('TextEmbeddingService #15694 — provider-neutral cancellat
 
                 const {default: Service} = await import('./ai/services/memory-core/TextEmbeddingService.mjs');
                 const embeddings         = await Service.embedTexts(
-                    ['a', 'b', 'c', 'd', 'e'],
+                    ['a', 'b', 'c', 'd', 'e', 'f'],
                     'openAiCompatible'
                 );
 
-                console.log(JSON.stringify({requestInputs, embeddings}));
+                console.log(JSON.stringify({requestInputs, embeddings, maxConcurrent}));
             } finally {
                 server.closeAllConnections?.();
-                await new Promise(resolve => server.close(resolve));
+                await new Promise(resolve => server.close(resolve))
             }
         };
         const commonEnv = {
-            NEO_OPENAI_COMPATIBLE_BATCH_EMBEDDING_CHUNK_SIZE: '5',
+            // Width 2 over 6 inputs = three spans, so concurrency has something to fan out and the
+            // width assertion has a short-span-free shape to compare across both runs.
+            NEO_OPENAI_COMPATIBLE_BATCH_EMBEDDING_CHUNK_SIZE: '2',
             NEO_OPENAI_COMPATIBLE_UNLOAD_RETRY_COUNT        : '0'
         };
         const [multiSlot, singleSlot] = await Promise.all([
@@ -1501,15 +1546,24 @@ test.describe.serial('TextEmbeddingService #15694 — provider-neutral cancellat
             })
         ]);
 
-        expect(multiSlot.requestInputs).toEqual([
-            ['a', 'b', 'c'],
-            ['d', 'e']
-        ]);
-        expect(singleSlot.requestInputs).toEqual([
-            ['a', 'b', 'c', 'd', 'e']
-        ]);
-        expect(multiSlot.embeddings).toHaveLength(5);
-        expect(singleSlot.embeddings).toHaveLength(5);
+        // WIDTH is the durability contract and comes from its own leaf: identical request contents at
+        // both parallelisms. Against the previous implementation the multi-slot run would have sent
+        // three-input requests here, so this is the arm that catches the clamp returning.
+        const expectedInputs = [['a', 'b'], ['c', 'd'], ['e', 'f']];
+
+        expect(multiSlot.requestInputs.slice().sort(), 'width must not vary with parallelism').toEqual(expectedInputs.slice().sort());
+        expect(singleSlot.requestInputs).toEqual(expectedInputs);
+
+        // CONCURRENCY is the throughput contract. RED against the previous implementation, which
+        // awaited every request and could never exceed one outstanding.
+        expect(multiSlot.maxConcurrent, 'a lane declaring four slots must dispatch more than one request at a time').toBeGreaterThan(1);
+        expect(singleSlot.maxConcurrent, 'parallel:1 must remain strictly sequential — the silent arm').toBe(1);
+
+        // Ordering is a contract, not an accident: outputs map to inputs by index whatever order the
+        // responses arrived in. Both runs embed the same six inputs.
+        expect(multiSlot.embeddings).toHaveLength(6);
+        expect(singleSlot.embeddings).toHaveLength(6);
+        expect(multiSlot.embeddings).toEqual(singleSlot.embeddings)
     });
 
     test('OpenAI-compatible retry and batch delays stop before later work in an isolated config process', async () => {

--- a/test/playwright/unit/ai/services/memory-core/TextEmbeddingService.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/TextEmbeddingService.spec.mjs
@@ -1702,6 +1702,91 @@ test.describe.serial('TextEmbeddingService #15694 — provider-neutral cancellat
         ).toBeLessThanOrEqual(4);
     });
 
+    test('BATCH work leaves the interactive slot open at the declared budget (#17048) (#17412)', async () => {
+        // The cross-caller arm above asserts offered work stays WITHIN the budget. That is the budget
+        // noun, not the headroom noun: filling all four slots with batch work satisfies it and still
+        // destroys the interactive reservation. Reviewer-supplied falsifier — at budget 4 two
+        // batch callers can jointly reach four, and a later interactive post finds no slot.
+        const probe = async () => {
+            const http = await import('node:http');
+            const held = [];
+
+            let batchInFlight       = 0,
+                maxBatchInFlight    = 0,
+                interactiveAdmitted = false,
+                stallGuard          = null;
+
+            // fixed-sleep-justification: arrival debounce that keeps the arm decidable, not a wait.
+            const armStallGuard = () => {
+                clearTimeout(stallGuard);
+                stallGuard = setTimeout(() => held.splice(0).forEach(release => release()), 250)
+            };
+
+            const server = http.createServer((request, response) => {
+                let body = '';
+
+                request.on('data', chunk => body += chunk);
+                request.on('end', () => {
+                    const payload = body ? JSON.parse(body) : {input: []},
+                          inputs  = Array.isArray(payload.input) ? payload.input : [payload.input],
+                          release = () => {
+                              response.writeHead(200, {'Content-Type': 'application/json'});
+                              response.end(JSON.stringify({
+                                  data: inputs.map((input, index) => ({index, embedding: [input.charCodeAt(0), input.length]}))
+                              }))
+                          };
+
+                    // The interactive probe uses a distinguishable input so the server can tell the
+                    // lanes apart without reading provider internals.
+                    if (inputs.includes('INTERACTIVE')) {
+                        interactiveAdmitted = true;
+                        release();
+                        clearTimeout(stallGuard);
+                        held.splice(0).forEach(r => r());
+                        return
+                    }
+
+                    batchInFlight   += inputs.length;
+                    maxBatchInFlight = Math.max(maxBatchInFlight, batchInFlight);
+                    armStallGuard();
+                    held.push(() => { batchInFlight -= inputs.length; release() })
+                })
+            });
+
+            await new Promise(resolve => server.listen(0, '127.0.0.1', resolve));
+
+            try {
+                process.env.NEO_OPENAI_COMPATIBLE_HOST = `http://127.0.0.1:${server.address().port}`;
+
+                const {default: Service} = await import('./ai/services/memory-core/TextEmbeddingService.mjs');
+
+                await Promise.all([
+                    Service.embedTexts(['a', 'b'], 'openAiCompatible'),
+                    Service.embedTexts(['c', 'd'], 'openAiCompatible')
+                ]);
+
+                console.log(JSON.stringify({maxBatchInFlight, interactiveAdmitted}));
+            } finally {
+                clearTimeout(stallGuard);
+                server.closeAllConnections?.();
+                await new Promise(resolve => server.close(resolve))
+            }
+        };
+
+        const result = await runIsolatedEmbeddingProbe(probe, {
+            NEO_OPENAI_COMPATIBLE_UNLOAD_RETRY_COUNT        : '0',
+            NEO_OPENAI_COMPATIBLE_BATCH_EMBEDDING_CHUNK_SIZE: '1',
+            NEO_LOCAL_MODELS_EMBEDDING_PARALLEL             : '4'
+        });
+
+        // THE HEADROOM CONTRACT: batch work never occupies the last slot. Four single-input batch
+        // tasks are available and the budget is four, so an admission that ignores lane would reach
+        // four; the reservation requires it to stop at three.
+        expect(result.maxBatchInFlight,
+            'batch work must leave one task of the declared budget free for interactive use'
+        ).toBeLessThanOrEqual(3);
+    });
+
     test('OpenAI-compatible retry and batch delays stop before later work in an isolated config process', async () => {
         const evidence = await runIsolatedEmbeddingProbe(async () => {
             const http                = await import('node:http');

--- a/test/playwright/unit/ai/services/memory-core/embeddingDispatchPlan.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/embeddingDispatchPlan.spec.mjs
@@ -2,7 +2,8 @@ import {test, expect} from '@playwright/test';
 import {
     planEmbeddingSpans,
     resolveCompletedPrefix,
-    resolveEmbeddingConcurrency
+    resolveDispatchPlan,
+    resolveEmbeddingTaskBudget
 } from '../../../../../../ai/services/memory-core/helpers/embeddingDispatchPlan.mjs';
 
 /**
@@ -65,21 +66,108 @@ test.describe('embedding dispatch plan', () => {
         });
     });
 
-    test.describe('resolveEmbeddingConcurrency', () => {
-        test('the declared parallelism IS the concurrency', () => {
-            // Not `parallel - 1`. The predecessor spent this value on request width to reserve a slot,
-            // which a client cannot hold open — the server assigns slots from its own queue.
-            expect(resolveEmbeddingConcurrency(4)).toBe(4);
-            expect(resolveEmbeddingConcurrency(1)).toBe(1);
-            expect(resolveEmbeddingConcurrency(16)).toBe(16);
+    test.describe('resolveEmbeddingTaskBudget', () => {
+        test('the declared parallelism is a TASK budget, and a valid one passes through', () => {
+            // Tasks, not requests: one multi-input POST expands to one task per input, so the work a
+            // client offers is concurrency × width. Reading this as a request count multiplies offered
+            // work by the width without saying so.
+            expect(resolveEmbeddingTaskBudget(4)).toBe(4);
+            expect(resolveEmbeddingTaskBudget(1)).toBe(1);
+            expect(resolveEmbeddingTaskBudget(16)).toBe(16);
         });
 
-        test('an unreadable parallelism falls back to 1, never to unbounded', () => {
-            // Falling back to the input count would turn a config defect into unbounded fan-out at a
-            // provider whose real width is unknown — the opposite of a safe default.
+        test('an unresolvable budget THROWS rather than substituting 1', () => {
+            // The leaf's own default already covers an absent env var, so a value arriving here that is
+            // not a positive integer is a configuration defect. Falling back would let the lane report
+            // healthy while ignoring what the deployment declared — the failure mode this whole lane is
+            // about, one layer up.
             for (const value of [undefined, null, 0, -3, 2.5, NaN, 'four', {}]) {
-                expect(resolveEmbeddingConcurrency(value), `for ${JSON.stringify(value) ?? String(value)}`).toBe(1);
+                expect(
+                    () => resolveEmbeddingTaskBudget(value),
+                    `must throw for ${JSON.stringify(value) ?? String(value)}`
+                ).toThrow(/positive integer task budget/);
             }
+        });
+    });
+
+    test.describe('resolveDispatchPlan', () => {
+        test('offered tasks NEVER exceed the budget, and one task stays reserved', () => {
+            // The property that makes the plan correct rather than merely concurrent. Asserted across a
+            // grid rather than at one point, because the interesting failures are at the boundaries
+            // where width and budget interact.
+            for (const taskBudget of [1, 2, 3, 4, 8, 16]) {
+                for (const requestWidth of [1, 2, 5, 20]) {
+                    const plan = resolveDispatchPlan({textCount: 40, requestWidth, taskBudget});
+
+                    if (taskBudget > 1) {
+                        expect(
+                            plan.offeredTasks,
+                            `budget ${taskBudget} width ${requestWidth} offered ${plan.offeredTasks}`
+                        ).toBeLessThanOrEqual(taskBudget);
+
+                        expect(
+                            plan.offeredTasks,
+                            `budget ${taskBudget} must keep one task free for interactive work`
+                        ).toBeLessThanOrEqual(taskBudget - 1);
+                        expect(plan.reservedTasks).toBe(1);
+                    }
+                }
+            }
+        });
+
+        test('at a budget of ONE the configured width stands — nothing to reserve, nothing to protect', () => {
+            // Deliberate, and the safest property of this plan: the single-slot default is unchanged.
+            // Clamping there would protect no headroom (you cannot reserve a task from a budget of 1)
+            // while turning one request into one-per-input. The provider queues the extra tasks either
+            // way, so the clamp would buy round trips and nothing else.
+            //
+            // An earlier version of this plan clamped unconditionally and split a two-input batch into
+            // two single-input requests at the default — caught by a pre-existing lms-server fixture,
+            // not by reasoning.
+            const plan = resolveDispatchPlan({textCount: 40, requestWidth: 5, taskBudget: 1});
+
+            expect({width: plan.width, concurrency: plan.concurrency, reservedTasks: plan.reservedTasks})
+                .toEqual({width: 5, concurrency: 1, reservedTasks: 0});
+        });
+
+        test('at four declared tasks with width 5 it reproduces the old clamp exactly', () => {
+            // Not a coincidence and worth pinning: the old `parallel - 1` width was correct arithmetic
+            // in the task unit at this configuration. The model changed; this output did not.
+            const plan = resolveDispatchPlan({textCount: 40, requestWidth: 5, taskBudget: 4});
+
+            expect({width: plan.width, concurrency: plan.concurrency, offeredTasks: plan.offeredTasks})
+                .toEqual({width: 3, concurrency: 1, offeredTasks: 3});
+        });
+
+        test('concurrency appears only once the budget exceeds the width', () => {
+            // The honest statement of what this delivers: fan-out is a property of the deployment's
+            // leaves, not of the code. A lane at four tasks with width 5 gets none.
+            expect(resolveDispatchPlan({textCount: 40, requestWidth: 5, taskBudget: 8}).concurrency).toBe(1);
+            expect(resolveDispatchPlan({textCount: 40, requestWidth: 5, taskBudget: 16}).concurrency).toBe(3);
+            expect(resolveDispatchPlan({textCount: 40, requestWidth: 2, taskBudget: 16}).concurrency).toBe(7);
+            expect(resolveDispatchPlan({textCount: 40, requestWidth: 1, taskBudget: 4}).concurrency).toBe(3);
+        });
+
+        test('concurrency never exceeds the work that exists', () => {
+            // Reporting an offer the batch cannot make would overstate the plan. Three inputs at width
+            // 1 is three spans, so a budget of 16 still only fans out three ways.
+            const plan = resolveDispatchPlan({textCount: 3, requestWidth: 1, taskBudget: 16});
+
+            expect(plan.spans).toHaveLength(3);
+            expect(plan.concurrency).toBe(3);
+        });
+
+        test('the spans tile the inputs at the CLAMPED width, not the configured one', () => {
+            // The clamp is a real change to the durability contract, so the spans must reflect it
+            // rather than the configured value a reader might assume.
+            const plan = resolveDispatchPlan({textCount: 7, requestWidth: 5, taskBudget: 4});
+
+            expect(plan.width).toBe(3);
+            expect(plan.spans).toEqual([
+                {offset: 0, count: 3},
+                {offset: 3, count: 3},
+                {offset: 6, count: 1}
+            ]);
         });
     });
 

--- a/test/playwright/unit/ai/services/memory-core/embeddingDispatchPlan.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/embeddingDispatchPlan.spec.mjs
@@ -1,0 +1,141 @@
+import {test, expect} from '@playwright/test';
+import {
+    planEmbeddingSpans,
+    resolveCompletedPrefix,
+    resolveEmbeddingConcurrency
+} from '../../../../../../ai/services/memory-core/helpers/embeddingDispatchPlan.mjs';
+
+/**
+ * The plan arithmetic the concurrent embedding dispatch rests on.
+ *
+ * The load-bearing function is `resolveCompletedPrefix`. Its predecessor was inline arithmetic —
+ * `completedChunkCount * chunkSize` — which named a span correctly only while provider requests
+ * completed in issue order. Under concurrency a span can land after a hole, and that product then
+ * claims a range containing inputs that never completed.
+ *
+ * The failure mode this guards is quiet rather than loud: `toOrderedEmbeddings` refuses a
+ * non-densely-indexed carry, so the wrong-span product got caught downstream and the error travelled
+ * with nothing attached. No corrupt vectors — just work conservation switching itself off, and a lane
+ * re-purchasing the same vectors on every retry with nothing in the logs to say so.
+ */
+test.describe('embedding dispatch plan', () => {
+    test.describe('planEmbeddingSpans', () => {
+        test('only the FINAL span may be short, and it carries its real count', () => {
+            // The reason spans exist rather than bare offsets: every later decision needs the real
+            // count, and re-deriving it is what let a product stand in for a span.
+            expect(planEmbeddingSpans({textCount: 7, chunkSize: 3})).toEqual([
+                {offset: 0, count: 3},
+                {offset: 3, count: 3},
+                {offset: 6, count: 1}
+            ]);
+        });
+
+        test('an exact multiple produces no short span', () => {
+            expect(planEmbeddingSpans({textCount: 6, chunkSize: 3})).toEqual([
+                {offset: 0, count: 3},
+                {offset: 3, count: 3}
+            ]);
+        });
+
+        test('the spans exactly tile the inputs — no gap, no overlap, no phantom tail', () => {
+            // Asserted as a property rather than a third literal, so it holds for widths the literals
+            // above do not cover.
+            for (const [textCount, chunkSize] of [[1, 1], [5, 2], [10, 4], [13, 5], [100, 7]]) {
+                const spans = planEmbeddingSpans({textCount, chunkSize});
+
+                expect(spans.reduce((sum, span) => sum + span.count, 0), `total for ${textCount}/${chunkSize}`).toBe(textCount);
+                spans.forEach((span, index) => {
+                    expect(span.offset, `offset continuity at ${index} for ${textCount}/${chunkSize}`)
+                        .toBe(index === 0 ? 0 : spans[index - 1].offset + spans[index - 1].count);
+                });
+            }
+        });
+
+        test('nothing to send plans nothing', () => {
+            expect(planEmbeddingSpans({textCount: 0, chunkSize: 5})).toEqual([]);
+        });
+
+        test('a non-positive width cannot produce an infinite loop', () => {
+            // A zero width would never advance `offset`. Clamped rather than trusted, because the value
+            // arrives from config and a hang is the worst available failure.
+            expect(planEmbeddingSpans({textCount: 2, chunkSize: 0})).toEqual([
+                {offset: 0, count: 1},
+                {offset: 1, count: 1}
+            ]);
+        });
+    });
+
+    test.describe('resolveEmbeddingConcurrency', () => {
+        test('the declared parallelism IS the concurrency', () => {
+            // Not `parallel - 1`. The predecessor spent this value on request width to reserve a slot,
+            // which a client cannot hold open — the server assigns slots from its own queue.
+            expect(resolveEmbeddingConcurrency(4)).toBe(4);
+            expect(resolveEmbeddingConcurrency(1)).toBe(1);
+            expect(resolveEmbeddingConcurrency(16)).toBe(16);
+        });
+
+        test('an unreadable parallelism falls back to 1, never to unbounded', () => {
+            // Falling back to the input count would turn a config defect into unbounded fan-out at a
+            // provider whose real width is unknown — the opposite of a safe default.
+            for (const value of [undefined, null, 0, -3, 2.5, NaN, 'four', {}]) {
+                expect(resolveEmbeddingConcurrency(value), `for ${JSON.stringify(value) ?? String(value)}`).toBe(1);
+            }
+        });
+    });
+
+    test.describe('resolveCompletedPrefix', () => {
+        const spans = planEmbeddingSpans({textCount: 10, chunkSize: 3}); // 3,3,3,1
+
+        test('a contiguous prefix carries the SUM of real span counts, not count × width', () => {
+            // With a short final span in play, a product and a sum diverge — which is the whole reason
+            // the product was wrong even before concurrency made it wrong more often.
+            expect(resolveCompletedPrefix({spans, completedFlags: [true, true, true, true]}))
+                .toEqual({chunkCount: 4, textCount: 10, droppedChunkCount: 0});
+
+            expect(resolveCompletedPrefix({spans, completedFlags: [true, true, false, false]}))
+                .toEqual({chunkCount: 2, textCount: 6, droppedChunkCount: 0});
+        });
+
+        test('THE ARM THIS EXISTS FOR: a completion after a hole is not carried, and is COUNTED', () => {
+            // Spans 0 and 2 landed, span 1 failed. The predecessor computed
+            // `completedChunkCount(2) * chunkSize(3)` = 6 texts — a range whose second half never
+            // completed. Downstream refused it and the carry was dropped in silence.
+            const prefix = resolveCompletedPrefix({spans, completedFlags: [true, false, true, false]});
+
+            expect(prefix.chunkCount, 'only span 0 is bindable by position').toBe(1);
+            expect(prefix.textCount, 'the product would have claimed 6').toBe(3);
+            expect(prefix.droppedChunkCount, 'span 2 completed and cannot be bound — the loss must be reportable').toBe(1);
+        });
+
+        test('a hole at the very front carries nothing, and that is DISTINGUISHABLE from nothing landing', () => {
+            // The two cases share one code path today, and only one of them is a reason to drop a
+            // carry. `droppedChunkCount` is what separates them.
+            const afterHole = resolveCompletedPrefix({spans, completedFlags: [false, true, true, true]}),
+                  nothing   = resolveCompletedPrefix({spans, completedFlags: [false, false, false, false]});
+
+            expect(afterHole).toEqual({chunkCount: 0, textCount: 0, droppedChunkCount: 3});
+            expect(nothing).toEqual({chunkCount: 0, textCount: 0, droppedChunkCount: 0});
+            expect(
+                afterHole.droppedChunkCount === nothing.droppedChunkCount,
+                'if these were equal the caller could not tell lost work from no work'
+            ).toBe(false);
+        });
+
+        test('the carried textCount is always a valid dense range over the inputs', () => {
+            // The property the consumer depends on: it does `slice(0, textCount)` and binds by
+            // position, so `textCount` must equal the sum of the first `chunkCount` spans — never more.
+            for (const flags of [
+                [true, true, true, true],
+                [true, true, false, true],
+                [true, false, false, false],
+                [false, true, true, true],
+                [false, false, false, false]
+            ]) {
+                const {chunkCount, textCount} = resolveCompletedPrefix({spans, completedFlags: flags}),
+                      expected                = spans.slice(0, chunkCount).reduce((sum, span) => sum + span.count, 0);
+
+                expect(textCount, `dense range for ${JSON.stringify(flags)}`).toBe(expected);
+            }
+        });
+    });
+});


### PR DESCRIPTION
Resolves neomjs/neo#17412

> 🌿 A lane could declare four slots and use one, and every layer that caused it had a docblock explaining why it was careful — so what this makes unsayable is "the parallelism is honoured" as a thing you can believe without watching two requests overlap.

Two bounds held this path to one request at a time. The ticket named one. Removing it alone would have changed nothing.

Evidence: L2 (isolated-process probes against a real loopback HTTP server exercising the real transport, with the provider stubbed; plus pure plan arithmetic with its own fixtures) → L2 required (every AC on this leaf is unit-reachable). Residual: the plane-observable throughput change, Residual-Owner: neomjs/neo-agent-brain#23.

## The two bounds

**Named:** `slotHeadroomWidth = parallel - 1` spent the declared parallelism on request **width**, to reserve a provider slot. An earlier revision of this paragraph said a client cannot reserve a slot because the server assigns them from its own queue. That is false and the review falsified it: the capacity unit is a TASK, so a client absolutely can — and `parallel - 1` reserved real headroom. The clamp's INTENT was correct; its defect was the unit, because headroom expressed as a width consumes the budget concurrency needs, and it only ever clamped downward — 25% at four slots, 50% at two, 6% at sixteen. Deleted: width comes from its own leaf, concurrency from the parallelism, and the headroom is now enforced in the queue's admission rule where every caller is visible.

**Unnamed, and the reason the first removal is insufficient:** `#drainOpenAiCompatiblePostQueue` drained with a **single worker** behind a boolean re-entrancy guard, its docblock stating it runs posts *"one at a time"*. My dispatch loop could issue four requests and they queued behind one drain.

It is now N bounded workers, N = the declared parallelism, each selecting through the same `#getNextOpenAiCompatiblePostQueueIndex`. The interactive-headroom concern the deleted clamp was reaching for is now handled where it belongs: one **task** is reserved from the provider's declared budget, so offered work stays strictly below capacity. I previously wrote here that interactive latency is "strictly better" with N workers; that was unmeasured, and P4 removed it from the source rather than leaving a comparative claim no arm supports.

## The carry had to change representation, not merely survive

```js
const completedTextCount = completedChunkCount * chunkSize,   // a count times a width
```

Valid only while completions arrive in order; the production comment said so. Under fan-out a span can land after a hole, and the product then claims a range containing inputs that never completed.

**The consequence was never a corrupt vector.** `toOrderedEmbeddings` fails closed, the `catch` swallows, and the error travels uncarried — so concurrency would have **silently switched work conservation off**, with the lane re-purchasing the same vectors on every retry and nothing in the logs. On a lane measured at ~0.19 chunks/min that is indistinguishable from the problem this ticket exists to fix.

`resolveCompletedPrefix` now measures the real carryable prefix and **reports** the completed-but-unbindable remainder. A sparse carry is not expressible: the consumer binds by position (`batchToEmbed.slice(0, err.completedTextCount)`), so the longest contiguous prefix is the most any caller can bind — and the dropped count makes the residue observable instead of silent.

## Deltas from ticket

**The ticket's Architectural Reality named one bound; I amended it before implementing** with the five prefix-dependent properties fan-out breaks, and three ACs including the one that matters: *the red-proof must fail by carrying nothing, not by mis-binding.* An arm checking only "no wrong vectors" passes on the broken shape, because the guard already prevents wrong vectors — and that is exactly what hides the defect.

**The capacity unit was wrong, and the review caught it.** Round 1 established that a local OpenAI-compatible engine expands one multi-input POST into one task per input, so offered work is `concurrency × width` and not `concurrency`. Binding one config number to request count, server tasks, and carryable spans at once would have recreated the same declaration-vs-behaviour drift one layer down. `resolveEmbeddingTaskBudget` now types the leaf as a **task** budget and throws on a non-positive-integer rather than substituting — the leaf default already covers an absent env var, so a value arriving here that is invalid is a configuration defect, and a lane that quietly falls back to 1 reports healthy while ignoring what the deployment declared. neomjs/neo#17048's interactive-headroom contract is **preserved, not retired**, by reserving one task; its mechanism was wrong (it computed a width) and its intent was right.

**The second bound was not in the ticket at all.** Found by the overlap arm failing after the clamp was gone. It is in scope: the ticket's prescription is *"bound in-flight requests by `localModels.embedding.parallel` and let the provider schedule"*, and this is where in-flight requests were actually bounded.

**One change ships with no red proof, and says so.** `createEmbeddingBatchYieldError` no longer re-derives its prefix as `completedChunkCount * chunkSize`; it takes the measured count. The product's stated justification was false — the final span is short whenever the input count is not a multiple of the width — while its conclusion held for a reason the comment never gave: the dispatch loop consults the yield predicate only while spans remain undispatched, and dispatch is in span order, so a yielded prefix structurally excludes the final span. I wrote an arm for it, watched the batch resolve instead of yielding, and read the loop condition rather than my expectation. **No reachable input reddens the product, and none can**, so the arm was deleted instead of weakened into something that passes. The change stays because a leaf whose correctness depends on a caller-side ordering invariant it cannot see is one refactor away from being silently wrong — and the failure path one branch up already passed the measured count, so the two spellings disagreed about the same prefix.

**Not done, deliberately:** a sparse carry. It would conserve the out-of-order remainder too, and it changes the consumer's positional binding contract — a separate leaf if the dropped fraction proves material. The count is now reported so that question becomes measurable rather than speculative.

## Test Evidence

**1840 memory-core specs green at `4d75cd01af`**, three consecutive clean runs. One intermittent
failure in that suite is **pre-existing** — it reproduces at `origin/dev` without this branch, in two
of four runs across both trees.

- `embeddingDispatchPlan.spec.mjs` — arms over the pure plan (task budget, spans, dispatch plan, carryable prefix).
- `TextEmbeddingService.retry.spec.mjs` — production-path concurrency scenarios.
- `TextEmbeddingService.spec.mjs` — the exact-peak overlap probe, the cross-caller budget arm, and the interactive-headroom arm.

**Mutation receipts at this head** — each mutant reddens the arm that names it, and the timings are
the point: a mutant that dies by SIGKILL has not been killed by the test.

| mutant | result |
|---|---|
| queue worker pool forced to 1 | `Expected: 4 Received: 1` — 1.4s, **by assertion** (was a 10.0s SIGKILL before the probe fix) |
| queue worker pool forced to 2 | `Expected: 4 Received: 2` — 632ms |
| task weight counts posts, the pre-fix unit | `Expected: <= 4 Received: 6` — 118ms |
| batch admission ceiling = full budget | `Expected: 3 Received: 4` — the interactive arm's PEAK assertion, 872ms |
| batch ceiling applied to the interactive lane too | `Expected: < 1 Received: 2` — the interactive arm's ORDERING assertion, 872ms |

**The four production-path arms, and the kill matrix that establishes each one.** Pure prefix arithmetic can prove what the plan computes; it cannot prove the service wires it. Each arm drives the real dispatch loop against a stub keyed on the request's first input, so nothing assumes arrival order — arrival order is the thing under test.

| mutant | HOL | EARLY | PREC | ATTR |
|---|---|---|---|---|
| baseline (unmutated) | green | green | green | green |
| M1 `concurrency = 1` | **RED** | **RED** | **RED** | **RED** |
| M2 `droppedCompletedChunkCount = 0` on failure | green | **RED** | green | green |
| M3 carry counts raw completions, not the prefix | green | **RED** | green | green |
| M4 `if (firstError && !yielded)` — yield outranks failure | green | green | **RED** | green |
| M5 attribute failure to batch member 0 | green | green | green | **RED** |
| M6 hardcode `failedTextCount = 1` | green | green | green | **RED** |

The **off-diagonal greens are the point**: an attribution defect does not redden the receipt arm, and a receipt defect does not redden the attribution arm. M1 kills all four because every one of them needs concurrency to exist at all.

**Two of my own arms were wrong, and the matrix is what found them — not the citation of it.**

1. **The precedence arm was vacuous.** At four spans against four available slots, every span dispatches in the first inner pass, `nextSpanIndex` reaches the total, and the outer loop exits **without ever consulting the yield predicate** — so "a failure outranks a cooperative yield" was asserted in a run where no yield existed. M4 survived, which is how it surfaced. It now runs six spans against two slots, releases the failing span *from inside the consultation itself* (no timer, no dependence on which promise settles first), and asserts the consultation count it depends on. This is the concrete instance of the `[TOOLING_GAP]` from Round 1 — an instrument that proves the green path and cannot produce a cause-specific red — caught only because the mutants ran per arm.
2. **M6 was an equivalent mutant at width 1.** With one input per span, `span.count` and the constant `1` are indistinguishable, so the arm pinned the offset and left the count unpinned while looking complete. The arm now runs at width **2**, and hardcoding `1` dies.

**Per-arm, not per-suite, because `describe.serial` masks.** The first matrix run reported "1 failed" for mutants that should have killed two arms: a red arm skips the rest of a serial block, so the suite-level result cannot show specificity. Every cell above comes from an individual invocation.

**The non-deadlocking instrument.** This paragraph previously credited the two release predicates `open >= targetPeak || requestInputs.length === expectedSpans`. Those are exactly the predicates that are **unreachable in the mutant's world** — at one worker only one request is ever open, so the peak is never met, and the rest never dispatch, so the arrival count is never met. The single-worker mutant died on a 10.0s SIGKILL, measured, and the body was describing a mechanism that did not work.

What makes it non-deadlocking is a **250ms arrival debounce**: the probe releases what it holds when no further request arrives, which is the one fact it cannot derive from values it already knows. Armed per arrival, not once — a guard armed once rescues exactly one request and the run dies on the second, also measured. The mutant now fails **by assertion at 1.4s**. Round 1 was right that a timeout has many causes and an assertion has one.

**A bug of mine caught by a pre-existing arm, which earned its keep.** `a prefix that cannot prove positional binding leaves the failure UNCARRIED` went red: I decorated the error field by field, so an unprovable prefix escaped with `completedTextCount` set and `embeddings` undefined — a count with no vectors, which the consumer slices onto ids anyway. The original computed both before assigning either; that ordering was load-bearing and undocumented. Restored, with the atomicity now stated as the reason rather than implied by expression order.

**Regression check by SET, not by count, and re-run at this head.** The `memory-core` suite reports **23 failures across 1842 tests** on this branch. Thirteen distinct spec files; **none** in the files this PR touches. Four of them reference `TextEmbeddingService` and so could in principle reach this diff, so they were isolated rather than argued away: `HealthService.spec.mjs:500`, `MemoryService.ArchiveByIdentity.PublicRecall.spec.mjs:154`, `MemoryService.WriteAhead.spec.mjs:116`, `QueryRecentTurns.spec.mjs:90` fail standalone on this branch **and fail identically on a stashed clean tree** — same four coordinates, `4 failed / 77 passed` in both directions. Pre-existing.

`check-ticket-archaeology`: 0 violations in the touched files (one of mine was flagged — a comment citing the review that asked for the arms — and was rewritten as behaviour). `node --check`: both files pass.

## Post-Merge Validation

Every AC is closed by the arms above.

- [ ] On a live external tenant plane, the provider slot log shows more than one task in flight and the `launch → release → launch` serialisation stops. This is the outcome the epic measures, not an AC of this leaf.

Residual-Owner: neomjs/neo-agent-brain#23

## Commits

- `330ae0ef62` — the declared parallelism becomes a concurrency, and the carry stops being arithmetic.
- `5dd95d449e` — the capacity unit is a task, so width and concurrency share one budget.
- `b7aa271904` — four concurrency scenarios pure prefix arithmetic cannot reach.
- `0b5438001e` — a deadlocked concurrency probe now fails on the peak it measured.
- `3835698588` — selecting the next queued post stops being a state change.
- `064e1a7519` — the task budget binds across callers; admission decides before a worker exists.
- `b9687cf102` — capacity is woken on worker retirement, not after every settle.
- `3c26bcb9c3` — batch admission leaves the interactive slot open.
- `4d75cd01af` — the interactive arm submits real interactive work, and both mutants redden.

## Decision Record impact

`none`. No AiConfig leaf is added, renamed or re-derived — `localModels.embedding.parallel` is read at its use site and is now used for the thing it declares, in the unit it declares it in. No ADR governs the post queue's worker count.

## Evolution

Five corrections, each from running something rather than reading it. The ticket named one bound; the second surfaced only when the overlap arm stayed red after the first was gone. The carry looked like it needed to "survive" concurrency and actually needed a different representation. My own instrument reported serial execution twice before an event log showed two requests genuinely open at once — I had already told a peer there was a fourth serialisation layer, and there was not. Round 1 then corrected the capacity unit itself, which is the one that changed the shape rather than the code.

The fifth is the smallest and the one I would most likely have gotten wrong quietly: I found what looked like a live defect in the yield builder, wrote the arm, and the arm went green on the fixture I built to redden it. Reading the loop condition instead of my expectation showed the product was correct for a reason its own comment never stated. Shipping the change with an explicit "no reachable input reddens this" is less satisfying than shipping a red-proof, and it is the only honest version.

---

Authored by Vega (Claude Opus 5, Claude Code). Session 046f993e-13ba-47dd-827d-d786428e318b.




