### PR TITLE
docs(agentos): the embedding lane gets an owning document (#17413)

### DIFF
--- a/buildScripts/docs/seo/generate.mjs
+++ b/buildScripts/docs/seo/generate.mjs
@@ -68,6 +68,10 @@ const PRIORITIES = new Map([
     ['agentos/tooling/CommunitySourceRunbook'       , 0.7],
     ['agentos/KnowledgeBase'                        , 1.0],
     ['agentos/MemoryCore'                           , 1.0],
+    // Ranked below both subsystem apexes it spans, deliberately: this is a maintainer-facing
+    // internals guide for one cross-subsystem lane, so it sits with GitHubWorkflow/CodeExecution
+    // rather than with the entry points a reader arrives on.
+    ['agentos/EmbeddingLane'                        , 0.8],
     ['agentos/SelfHealing'                          , 1.0],
     ['agentos/GitHubWorkflow'                       , 0.8],
     ['agentos/CodeExecution'                        , 0.8],

--- a/learn/agentos/EmbeddingLane.md
+++ b/learn/agentos/EmbeddingLane.md
@@ -207,23 +207,45 @@ flowchart TD
     subgraph pair3["starvation watchdog × lease holder"]
         C1["waiter starves"] --> C2["watchdog names the holder"] --> C3["holder consults no bound<br/>so naming changes nothing"]
     end
-    subgraph pair4["carry arithmetic × concurrency"]
-        D1["completions arrive out of order"] --> D2["count × width names a span<br/>containing inputs that never landed"] --> D3["binding guard fails CLOSED<br/>work conservation silently off"]
+    subgraph pair4["carry arithmetic × an unstated invariant"]
+        D1["formula: count × width"] --> D2["stated reason FALSE<br/>(final span is short)"] --> D3["conclusion held anyway,<br/>via dispatch order nobody wrote down"]
     end
 ```
 
-**The fourth pair is the one worth internalising**, because its failure signature
-is silence. The carry computed a completed span as
-`completedChunkCount * chunkSize` — a count multiplied by a width — which names a
-range only while completions arrive in issue order. Add concurrency and a span can
-land after a hole; the product then claims inputs that never completed. The
-positional-binding guard refuses a non-densely-indexed carry, so the outcome was
-never a corrupt vector: it was work conservation switching itself off, with the
-lane re-purchasing the same vectors on every retry and nothing in the logs.
+**The fourth pair is the one worth internalising, and it is not a failure — it is
+a correct answer resting on a reason its own comment got wrong.** The carry
+computed a completed span as `completedChunkCount * chunkSize`, justified by *"a
+yield lands on a chunk boundary, so every completed chunk is full-width"*. That
+justification is false: the final span is short whenever the input count is not a
+multiple of the width.
 
-**A guard that fails closed converts a wrong answer into a silent loss.** That is
-usually the right trade, and it means the loss needs its own report — otherwise
-the safety property hides the regression it prevented.
+The product was nevertheless always right, for a reason the comment never stated —
+the dispatch loop consults the yield predicate only while spans remain
+undispatched, and dispatch is in span order, so a yielded prefix structurally
+excludes the short final span. Per `TextEmbeddingService.mjs`: *"No reachable
+input reddened the product, and none can."*
+
+So nothing was ever mis-carried, and this document previously claimed otherwise —
+it described work conservation switching itself off and a lane re-purchasing
+vectors with nothing in the logs. **That failure never occurred.** It was derived
+from the mechanism rather than observed, which is precisely the error the passage
+was trying to teach.
+
+**The real lesson is narrower and more useful: a computation that is correct by
+accident is one refactor from being wrong in silence.** The repair passes the
+measured prefix instead of re-deriving it — not because the derivation was
+producing bad spans, but because its correctness depended on a caller-side
+ordering invariant the leaf cannot see. Reorder dispatch, or consult the predicate
+once more after the last admission, and it returns a count one width too large; at
+that point the ordered-embedding assembly throws from inside the yield
+constructor, the abandonment loses its yield code, and a resumable checkpoint
+becomes a hard failure. Two branches also disagreed about the same prefix, since
+the failure path one level up already passed the measured count.
+
+**A guard that fails closed converts a wrong answer into a silent loss** — the
+reason the latent version was worth removing before anything reached it. That
+trade is usually right, and it means such a loss needs its own report, or the
+safety property hides the regression it prevented.
 
 ## 5. Verified axes, and the one that is not
 

--- a/learn/agentos/EmbeddingLane.md
+++ b/learn/agentos/EmbeddingLane.md
@@ -107,9 +107,18 @@ flowchart TD
 contracts.** Width is a durability decision — how many inputs one failure or one
 yield can cost. Concurrency is a throughput decision — how many of those may be
 in flight. They were conflated: `parallel` was spent computing a *width*
-(`parallel - 1`, to "reserve" a slot the client cannot hold open, since the server
-assigns slots from its own queue), and the concurrency it declares was used by
-nothing.
+(`parallel - 1`), and the concurrency it declares was used by nothing.
+
+The clamp is worth reading precisely, because the obvious reading of it is wrong
+and this document previously carried that reading. The provider's capacity unit
+is a **task** — one multi-input POST expands to one task per input — so a client
+*can* control offered work, and `parallel - 1` did reserve real headroom: three
+inputs is three tasks against four slots, which leaves one free. The clamp was
+arithmetically correct and its intent was sound. Its defect was the unit it was
+spent in: headroom expressed as a width consumes the same budget concurrency
+needs, so a lane declaring four slots offered one request at a time. A correct
+reading of this passage cost a reviewer a round, and the wrong reading is the
+tempting one.
 
 `NEO_LOCAL_MODELS_EMBEDDING_PARALLEL` is the SSOT for the intent and applies
 across provider options. `LLAMA_ARG_N_PARALLEL` in a deployment's Compose is a

--- a/learn/agentos/EmbeddingLane.md
+++ b/learn/agentos/EmbeddingLane.md
@@ -1,0 +1,284 @@
+# The Embedding Lane: Where a Corpus Becomes Vectors
+
+A subsystem can be composed entirely of careful parts and still be wrong as a whole.
+
+The embedding lane is the clearest example Neo has. Every layer in it was added
+deliberately, by someone solving a real problem, with a docblock explaining the
+reasoning. A width clamp reserved a provider slot. A queue kept the client from
+competing with itself. A budget bounded how long one repository could hold a
+slot. A guardrail refused inputs the provider would reject. Each is defensible
+in isolation.
+
+Read together, they bounded a lane declaring four parallel slots to one request
+at a time — and no single file said so. The composition was only discoverable by
+instrumenting a running deployment, because the lane has no owning document and
+no owning subsystem: `TextEmbeddingService` lives under `ai/services/memory-core/`,
+`VectorService` under `ai/services/knowledge-base/`, the geometry leaves in
+`ai/configBase.mjs`, the slice and lease scheduling in `ai/daemons/orchestrator/`,
+the shape verification in `ai/providerLaneLiveShape.mjs`. Four owners, no owner.
+
+This guide is the map. It exists because establishing the behaviour below cost a
+full session of plane reads and produced nine wrong intermediate claims before
+converging — eight of which were answerable from content already in the
+repository, sitting in a 492-line prose document, a deployment Compose comment,
+an ADR, a ticket acceptance criterion, a parser docstring, and a merged PR.
+
+## How to read this document
+
+Two kinds of fact live here and they decay at different rates. Conflating them is
+what makes a ground-truth guide dangerous rather than merely stale.
+
+**Contract facts** — what the code does, the arithmetic, the field names, the
+state machine. These change only when someone edits the code, so they are stated
+plainly with the citation that lets you re-derive them.
+
+**Plane facts** — what is deployed, what is materialised, which signal has
+actually fired. These change without anyone editing anything. Each is written as
+a **dated observation plus the command that re-reads it**, and a plane fact
+stated in the timeless present is a defect in this document.
+
+The distinction is not theoretical. Written one day earlier, this guide would
+have said *"the tenant parser declines vendored trees"* — true of the contract,
+false of the plane, because the deployed revision predated the exclusion. A
+reader trusting it would have concluded a corpus was clean when ~86.7k vendored
+chunks were still resident.
+
+## 1. Authority map: which value decides what
+
+```mermaid
+flowchart TD
+    subgraph declared["Declared leaves — ai/configBase.mjs"]
+        Parallel["localModels.embedding.parallel<br/>NEO_LOCAL_MODELS_EMBEDDING_PARALLEL<br/>default 1"]
+        Ctx["localModels.embedding.contextLimitTokens<br/>default 32768"]
+        Safe["localModels.embedding.safeProcessingLimitTokens<br/>default 28672"]
+        Width["openAiCompatible.batchEmbeddingChunkSize<br/>default 5"]
+        Slice["orchestrator.tenantRepoSync.sliceBudgetMs<br/>default 300000"]
+        Hold["orchestrator.heavyMaintenance.maxActiveHoldMs<br/>default 1800000"]
+    end
+
+    Parallel --> Concurrency["request CONCURRENCY<br/>how many POSTs outstanding"]
+    Width --> Requests["request WIDTH<br/>inputs per POST"]
+    Ctx --> Band["admission band<br/>min of the two ceilings"]
+    Safe --> Band
+    Band --> Estimate["estimateBandTokens<br/>floor(ceiling / 1.35)"]
+    Estimate --> Guard["guardrail: split or refuse<br/>before the provider is called"]
+    Slice --> RepoBound["per-repo slot bound<br/>rotate, keep the lease"]
+    Hold --> LeaseBound["outer lease bound<br/>stand down, release"]
+```
+
+**Contract.** `EMBEDDING_TOKEN_ESTIMATE_DRIFT_FACTOR = 1.35`
+(`ai/embeddingSafeBand.mjs:42`) and `BYTES_PER_TOKEN_HEURISTIC = 3`
+(`ai/services/memory-core/helpers/consumerFrictionHelper.mjs:122`). The band is
+`min(contextLimitTokens, safeProcessingLimitTokens)`, then
+`floor(ceiling / 1.35)`; byte estimates are `ceil(bytes / 3)`.
+
+**The distinction the diagram exists to draw: width and concurrency are separate
+contracts.** Width is a durability decision — how many inputs one failure or one
+yield can cost. Concurrency is a throughput decision — how many of those may be
+in flight. They were conflated: `parallel` was spent computing a *width*
+(`parallel - 1`, to "reserve" a slot the client cannot hold open, since the server
+assigns slots from its own queue), and the concurrency it declares was used by
+nothing.
+
+`NEO_LOCAL_MODELS_EMBEDDING_PARALLEL` is the SSOT for the intent and applies
+across provider options. `LLAMA_ARG_N_PARALLEL` in a deployment's Compose is a
+second declaration of the same fact and violates that SSOT; the two agreeing is
+a deployment's responsibility, not a guarantee.
+
+## 2. One slice, as it actually runs
+
+```mermaid
+flowchart TD
+    Admit["repo admitted to a slot<br/>startedMs anchored here"] --> Envelope["envelope materialised<br/>one manifest read"]
+    Envelope --> Plan["inputs divided by WIDTH<br/>into provider spans"]
+    Plan --> Dispatch["spans dispatched<br/>bounded by CONCURRENCY"]
+    Dispatch --> Provider["provider expands one POST<br/>into one task per input"]
+    Provider --> Batch["span completes"]
+    Batch --> Check{"slice budget<br/>elapsed?"}
+    Check -->|no| Dispatch
+    Check -->|yes| Yield["yield: carry the completed prefix,<br/>rotate to the next repo"]
+    Yield --> Admit
+```
+
+**Contract.** The slice budget is anchored per repository at *admission*, not
+per sweep (`ai/daemons/orchestrator/scheduling/tenantRepoSync.mjs`,
+`createSliceBudgetPredicate`). A sweep-wide budget would be spent by the first
+admitted repository and starve the tail — the per-repo anchoring is the fix, and
+it is also why honouring every budget still occupies the exclusive heavy slot for
+roughly `N × sliceBudgetMs`.
+
+The predicate is consulted *between* spans and never before the first, so actual
+occupancy is the budget plus one span envelope. That is the forward-progress
+guarantee: at least one span always lands per acquisition, so the lane cannot
+livelock against its own fairness bound.
+
+**Plane, observed 2026-08-20 on an external tenant deployment.** The provider
+slot log showed roughly twenty consecutive `launch → release → launch`
+transitions with never two tasks in flight, while 86,946 chunks waited. One
+13,725-token input consumed an entire five-minute slice and the repository
+reported `embeddings=1` at budget expiry. Re-read with:
+
+```bash
+curl -s "$EMBEDDING_HOST/slots" | jq '[.[] | {id, state}]'
+```
+
+## 3. Checkpoint states, and the edge that cannot be traversed
+
+```mermaid
+stateDiagram-v2
+    [*] --> uninitialized
+    uninitialized --> partial: slice expires mid-corpus
+    partial --> reattempt: next pass admitted
+    reattempt --> partial: slice expires again
+    reattempt --> completed: pass finishes the corpus
+    completed --> [*]: lastIngestedRev advances
+    note right of reattempt
+        lastIngestedRev is written ONLY by
+        a pass that completes. A corpus
+        larger than one slice never
+        completes one, so the partial
+        cycle is absorbing until
+        throughput changes.
+    end note
+```
+
+**Contract.** The checkpoint advances on a completed pass. A deferred outcome is
+*incomplete, not failed*: the checkpoint stays where it is, `consecutiveFailures`
+is neither reset nor incremented, and `lastRunAttemptAt` advances so the next
+due-check measures from this attempt. Leaving the streak untouched is the
+load-bearing half — incrementing would climb toward the backoff cap for a
+condition that is not the repository's fault.
+
+The consequence is the shape of the incident: a corpus that cannot finish inside
+one slice makes `partial` absorbing, and the lane runs forever reporting healthy
+machinery over a knowledge base that never receives its content. This is why
+throughput is a correctness concern here and not only a performance one.
+
+## 4. Guard interaction: pairs whose joint outcome differs from either alone
+
+```mermaid
+flowchart TD
+    subgraph pair1["slice budget × checkpoint"]
+        A1["budget expires"] --> A2["deferred, not failed"] --> A3["checkpoint frozen"]
+    end
+    subgraph pair2["admission band × provider tokenizer"]
+        B1["ceil(bytes / 3) estimate"] --> B2["provider's real tokenizer differs"] --> B3["admitted input the provider refuses,<br/>or refused input it would have taken"]
+    end
+    subgraph pair3["starvation watchdog × lease holder"]
+        C1["waiter starves"] --> C2["watchdog names the holder"] --> C3["holder consults no bound<br/>so naming changes nothing"]
+    end
+    subgraph pair4["carry arithmetic × concurrency"]
+        D1["completions arrive out of order"] --> D2["count × width names a span<br/>containing inputs that never landed"] --> D3["binding guard fails CLOSED<br/>work conservation silently off"]
+    end
+```
+
+**The fourth pair is the one worth internalising**, because its failure signature
+is silence. The carry computed a completed span as
+`completedChunkCount * chunkSize` — a count multiplied by a width — which names a
+range only while completions arrive in issue order. Add concurrency and a span can
+land after a hole; the product then claims inputs that never completed. The
+positional-binding guard refuses a non-densely-indexed carry, so the outcome was
+never a corrupt vector: it was work conservation switching itself off, with the
+lane re-purchasing the same vectors on every retry and nothing in the logs.
+
+**A guard that fails closed converts a wrong answer into a silent loss.** That is
+usually the right trade, and it means the loss needs its own report — otherwise
+the safety property hides the regression it prevented.
+
+## 5. Verified axes, and the one that is not
+
+```mermaid
+flowchart TD
+    Live["live /slots reading"] --> Shape["providerLaneLiveShape<br/>declared intent vs observed shape"]
+    Shape --> V1["VERIFIED: slot count"]
+    Shape --> V2["VERIFIED: per-slot context"]
+    Shape --> V3["VERIFIED: reason codes when unreadable"]
+    Live -.-> U1["NOT VERIFIED: utilization<br/>are the slots USED?"]
+    U1 -.-> Gap["a lane can report four slots<br/>at 16384 tokens each,<br/>truthfully, and use one"]
+```
+
+**Contract.** `ai/providerLaneLiveShape.mjs` reads the live `/slots` endpoint and
+compares observed shape against declared intent. Its own docblock states the
+boundary: *"liveness answers 'can the provider respond?', never 'is the provider
+shaped the way this deployment intends?'"*. It is pure by construction, never
+throws, and emits greppable reason codes rather than prose — because those codes
+reach an operator through the deployment-state snapshot, where a renamed string
+silently breaks whatever matched on it.
+
+**Shape is verified; utilization is not.** Both statements in the gap node can be
+true simultaneously, and for a period they were. A verification layer that
+answers the adjacent question confidently is more dangerous than one that answers
+nothing, because its green is acted upon.
+
+## 6. Code locality: the ownership vacuum
+
+```mermaid
+flowchart TD
+    subgraph mc["ai/services/memory-core/"]
+        TES["TextEmbeddingService<br/>provider dispatch, request queue"]
+        Plan["helpers/embeddingDispatchPlan<br/>spans, concurrency, carryable prefix"]
+    end
+    subgraph kb["ai/services/knowledge-base/"]
+        VS["VectorService<br/>batching, guardrail, poison isolation"]
+        IS["IngestionService<br/>chunk identity, telemetry"]
+        Fmt["helpers/embeddingInputFormat<br/>the provider input string"]
+    end
+    subgraph orch["ai/daemons/orchestrator/"]
+        TRS["TenantRepoSyncService<br/>sweep, slice budget, checkpoints"]
+        Lease["HeavyMaintenanceLeaseService<br/>outer lease, fairness vote"]
+    end
+    subgraph cfg["ai/"]
+        Leaves["configBase.mjs — the leaves"]
+        LiveShape["providerLaneLiveShape.mjs"]
+    end
+    TRS --> VS --> TES --> Plan
+    IS --> Fmt
+    VS --> Fmt
+    Lease --> TRS
+    Leaves --> TES
+    Leaves --> VS
+    Leaves --> TRS
+```
+
+Nothing here is a mistake in isolation. The vacuum is that no box owns *the lane*,
+so a defect spanning three of them belongs to nobody, and the person who finds it
+is whoever happened to be measuring that week.
+
+## Traps this document exists to remove
+
+Each of these cost a real session, and each was answerable from something already
+committed.
+
+- **The 32 GiB memory ceiling looks unjustified until you read the Compose
+  comment that derives it.** KV cache is *linear*, not quadratic:
+  `ctx × layers × kv_heads × head_dim × 2 × 2`. The n² term is the attention score
+  matrix and scales with `UBATCH`, which is what the ceiling is actually sized
+  for. Asking for more memory before reading that derivation is asking a
+  deployment to pay for a misreading.
+- **Fused attention is not an unexplored win.** It was attempted and produced no
+  reduction; the same Compose comment records it.
+- **A guard's docblock describes what the guard does, never that anything calls
+  it.** A generation-election store can document that an input-strategy change
+  *"invalidates every existing vector"* while no code in this lane constructs such
+  a generation. Before asserting a mechanism exists, grep for a **call site** — a
+  function named in a comment is not a function that is called.
+- **Vendored trees are excluded by contract and may still be resident on a
+  plane.** The exclusion is a parser change; the resident rows are a deployment
+  fact. Ask both questions separately.
+- **Absence of a re-embed trigger is not the same as one being expensive.**
+  Incremental selection collects existing ids and skips them, and the provider
+  input string is *derived* — not a member of a chunk's `hashInputs` — so changing
+  the input format does not change any chunk id. Re-ingestion therefore re-embeds
+  nothing. `parserVersion` **is** a hash input, which makes it the only mechanism
+  that re-mints ids today, and nothing schedules it.
+
+## Related
+
+- `learn/agentos/KnowledgeBase.md` — the corpus this lane feeds.
+- `learn/agentos/cloud-deployment/TenantIngestionModel.md` — ingestion
+  configuration, triggers and telemetry; this guide does not duplicate its scope.
+- `learn/agentos/decisions/0019-aiconfig-reactive-provider-ssot.md` — the remedy
+  shape this guide borrows: make the mechanism readable rather than asking for
+  more care.
+- `learn/agentos/decisions/0022-heavy-maintenance-scheduling-fairness.md` —
+  cooperative yield only; the lane never preempts a live holder.

--- a/learn/agentos/EmbeddingLane.md
+++ b/learn/agentos/EmbeddingLane.md
@@ -17,11 +17,42 @@ no owning subsystem: `TextEmbeddingService` lives under `ai/services/memory-core
 `ai/configBase.mjs`, the slice and lease scheduling in `ai/daemons/orchestrator/`,
 the shape verification in `ai/providerLaneLiveShape.mjs`. Four owners, no owner.
 
-This guide is the map. It exists because establishing the behaviour below cost a
-full session of plane reads and produced nine wrong intermediate claims before
+This guide is the map. I wrote it after establishing the behaviour below cost me
+a full session of plane reads and nine wrong intermediate claims before
 converging — eight of which were answerable from content already in the
 repository, sitting in a 492-line prose document, a deployment Compose comment,
-an ADR, a ticket acceptance criterion, a parser docstring, and a merged PR.
+an ADR, a ticket acceptance criterion, a parser docstring, and a merged PR. The
+information existed. It was unreachable *as a whole*, which is a different
+problem from missing documentation and has a different fix.
+
+**If you are building an embedding lane somewhere else, four of those nine
+mistakes were not about Neo at all**, and they are the reason this document is
+worth reading outside this repository:
+
+1. **A declared parallelism is not a measured one.** Our config declared four
+   slots and the lane used one. Nothing lied — no layer claimed more than it
+   delivered — and the gap lived in the composition. If you declare concurrency
+   anywhere, the only honest confirmation is watching two requests overlap.
+2. **Know what unit your capacity number is in.** A local OpenAI-compatible
+   engine expands one multi-input request into one task *per input*, so the work
+   a client offers is `concurrency × width`, not `concurrency`. Binding one
+   number to request count, server tasks and batch width at once reproduces the
+   same declaration-versus-behaviour gap one layer down. I got this wrong first
+   and a reviewer caught it.
+3. **A guard that fails closed converts a wrong answer into a silent loss.**
+   Ours refused to bind vectors it could not prove were positionally correct —
+   which is right, and meant work already paid for was discarded with nothing in
+   the logs. Fail-closed guards need their losses *reported*, or the safety
+   turns into invisible waste.
+4. **Throughput can be a correctness property, not a performance one.** When a
+   corpus cannot finish inside one scheduling slice, the partial checkpoint state
+   becomes absorbing: the machinery reports healthy forever while the knowledge
+   base never receives its content. Any lane with a per-pass budget and a
+   completion-gated checkpoint can reach this, and it does not look like an
+   outage.
+
+The Neo-specific parts are the file names. The transferable part is that all four
+were invisible to code review and visible to one instrumented run.
 
 ## How to read this document
 
@@ -216,7 +247,6 @@ nothing, because its green is acted upon.
 flowchart TD
     subgraph mc["ai/services/memory-core/"]
         TES["TextEmbeddingService<br/>provider dispatch, request queue"]
-        Plan["helpers/embeddingDispatchPlan<br/>spans, concurrency, carryable prefix"]
     end
     subgraph kb["ai/services/knowledge-base/"]
         VS["VectorService<br/>batching, guardrail, poison isolation"]
@@ -231,7 +261,7 @@ flowchart TD
         Leaves["configBase.mjs — the leaves"]
         LiveShape["providerLaneLiveShape.mjs"]
     end
-    TRS --> VS --> TES --> Plan
+    TRS --> VS --> TES
     IS --> Fmt
     VS --> Fmt
     Lease --> TRS

--- a/learn/agentos/EmbeddingLane.md
+++ b/learn/agentos/EmbeddingLane.md
@@ -78,24 +78,22 @@ chunks were still resident.
 
 ```mermaid
 flowchart TD
-    subgraph declared["Declared leaves — ai/configBase.mjs"]
-        Parallel["localModels.embedding.parallel<br/>NEO_LOCAL_MODELS_EMBEDDING_PARALLEL<br/>default 1"]
-        Ctx["localModels.embedding.contextLimitTokens<br/>default 32768"]
-        Safe["localModels.embedding.safeProcessingLimitTokens<br/>default 28672"]
-        Width["openAiCompatible.batchEmbeddingChunkSize<br/>default 5"]
-        Slice["orchestrator.tenantRepoSync.sliceBudgetMs<br/>default 300000"]
-        Hold["orchestrator.heavyMaintenance.maxActiveHoldMs<br/>default 1800000"]
-    end
-
-    Parallel --> Concurrency["request CONCURRENCY<br/>how many POSTs outstanding"]
+    Parallel["leaf: localModels.embedding.parallel<br/>NEO_LOCAL_MODELS_EMBEDDING_PARALLEL · default 1"]
+        --> Concurrency["request CONCURRENCY<br/>how many POSTs outstanding"]
+    Concurrency ~~~ Width["leaf: openAiCompatible.batchEmbeddingChunkSize<br/>default 5"]
     Width --> Requests["request WIDTH<br/>inputs per POST"]
+    Requests ~~~ Ctx["leaf: localModels.embedding.contextLimitTokens<br/>default 32768"]
     Ctx --> Band["admission band<br/>min of the two ceilings"]
-    Safe --> Band
+    Safe["leaf: localModels.embedding.safeProcessingLimitTokens<br/>default 28672"] --> Band
     Band --> Estimate["estimateBandTokens<br/>floor(ceiling / 1.35)"]
     Estimate --> Guard["guardrail: split or refuse<br/>before the provider is called"]
+    Guard ~~~ Slice["leaf: orchestrator.tenantRepoSync.sliceBudgetMs<br/>default 300000"]
     Slice --> RepoBound["per-repo slot bound<br/>rotate, keep the lease"]
+    RepoBound ~~~ Hold["leaf: orchestrator.heavyMaintenance.maxActiveHoldMs<br/>default 1800000"]
     Hold --> LeaseBound["outer lease bound<br/>stand down, release"]
 ```
+
+*All six leaves are declared in `ai/configBase.mjs`.*
 
 **Contract.** `EMBEDDING_TOKEN_ESTIMATE_DRIFT_FACTOR = 1.35`
 (`ai/embeddingSafeBand.mjs:42`) and `BYTES_PER_TOKEN_HEURISTIC = 3`
@@ -199,17 +197,23 @@ throughput is a correctness concern here and not only a performance one.
 ```mermaid
 flowchart TD
     subgraph pair1["slice budget × checkpoint"]
+        direction LR
         A1["budget expires"] --> A2["deferred, not failed"] --> A3["checkpoint frozen"]
     end
     subgraph pair2["admission band × provider tokenizer"]
+        direction LR
         B1["ceil(bytes / 3) estimate"] --> B2["provider's real tokenizer differs"] --> B3["admitted input the provider refuses,<br/>or refused input it would have taken"]
     end
     subgraph pair3["starvation watchdog × lease holder"]
+        direction LR
         C1["waiter starves"] --> C2["watchdog names the holder"] --> C3["holder consults no bound<br/>so naming changes nothing"]
     end
     subgraph pair4["carry arithmetic × an unstated invariant"]
+        direction LR
         D1["formula: count × width"] --> D2["stated reason FALSE<br/>(final span is short)"] --> D3["conclusion held anyway,<br/>via dispatch order nobody wrote down"]
     end
+
+    pair1 ~~~ pair2 ~~~ pair3 ~~~ pair4
 ```
 
 **The fourth pair is the one worth internalising, and it is not a failure — it is

--- a/learn/agentos/cloud-deployment/TenantIngestionModel.md
+++ b/learn/agentos/cloud-deployment/TenantIngestionModel.md
@@ -489,6 +489,7 @@ The day-0 tutorial should reuse this model rather than redefine it.
 
 ## Related
 
+- [The Embedding Lane](../EmbeddingLane.md) — what happens between "a chunk exists" and "a vector is stored": the geometry authorities, the slice and lease bounds, and which axes are verified. This document owns ingestion configuration, triggers and telemetry; that one owns the lane's composition.
 - [Hook Wiring](./HookWiring.md) — the `ingest_source_files`, `ai:kb-push-client`, and `ai:ingest-tenant` surfaces.
 - [Custom Parsers](./CustomParsers.md) — `parsed-chunk-v1` and parser execution boundaries.
 - [Custom Sources](./CustomSources.md) — full-corpus Source path, mostly not the push-based tenant default.

--- a/learn/tree.json
+++ b/learn/tree.json
@@ -53,6 +53,7 @@
         {"name": "Neural Link: Live Application Mutability",           "parentId": "AgentOS",                                             "id": "agentos/NeuralLink"},
         {"name": "The Knowledge Base Server",                          "parentId": "AgentOS",                                             "id": "agentos/KnowledgeBase"},
         {"name": "Knowledge Base Enhancement (Anchor & Echo)",         "parentId": "AgentOS",                                             "id": "agentos/KnowledgeBaseEnhancement"},
+        {"name": "The Embedding Lane",                                 "parentId": "AgentOS",                                             "id": "agentos/EmbeddingLane"},
         {"name": "The Memory Core Server",                             "parentId": "AgentOS",                                             "id": "agentos/MemoryCore"},
         {"name": "The Seat Memory Layer",                              "parentId": "AgentOS",                                             "id": "agentos/SeatMemoryLayer"},
         {"name": "Self-Healing Immune System",                         "parentId": "AgentOS",                                             "id": "agentos/SelfHealing"},


### PR DESCRIPTION
Resolves neomjs/neo#17413

**Merge order: this lands AFTER PR neomjs/neo#17433 (#17412).** Recorded mechanically — neomjs/neo#17413 is now `blocked_by` neomjs/neo#17412. The guide's concurrency, width and carry statements describe code that neomjs/neo#17412 changes, so merging this first would ship contract true of neither tree for as long as the gap lasted.

> 🌿 Every layer in this lane had a docblock explaining why it was careful, and together they held four declared slots to one request — so what this document makes unsayable is "somebody would have noticed", because for months nobody could.

`learn/agentos/EmbeddingLane.md`, six diagrams, 284 lines. The lane had no owning document because it has no owning subsystem.

Evidence: L1 (a document; every contract fact verified at its cited source, every plane fact dated with its re-read command) → L1 required (no runtime-verify ACs on a guide). No residuals.

## Why this is not documentation debt-payment

Dispatch in `ai/services/memory-core/`, batching and guardrail in `ai/services/knowledge-base/`, geometry leaves in `ai/configBase.mjs`, slice and lease scheduling in `ai/daemons/orchestrator/`, shape verification in `ai/providerLaneLiveShape.mjs`. **Four owners, no owner** — so a defect spanning three of them belongs to nobody, and the person who finds it is whoever happened to be instrumenting a plane that week.

The measured cost of that vacuum: establishing the lane's behaviour took a full session of plane reads and produced **nine wrong intermediate claims** before converging, **eight of which were answerable from content already committed** — a 492-line prose document, a deployment Compose comment, an ADR, a ticket AC, a parser docstring, and a merged PR. The information existed and was unreachable as a whole.

## The rule the document is written to

Two fact classes with different decay rates, and conflating them is what makes a ground-truth guide dangerous rather than merely stale.

**Contract facts** are stated plainly with the citation that re-derives them. Every constant in the authority map was **verified at source in this session, not recalled**: `EMBEDDING_TOKEN_ESTIMATE_DRIFT_FACTOR = 1.35` (`embeddingSafeBand.mjs:42`), `BYTES_PER_TOKEN_HEURISTIC = 3` (`consumerFrictionHelper.mjs:122`), and each leaf default read out of `configBase.mjs`.

**Plane facts** carry an observation date and the command that re-reads them. A plane fact in the timeless present is a defect in the document — and the worked example is not hypothetical: written one day earlier this guide would have said *"the tenant parser declines vendored trees"*, true of the contract and false of the plane, and a reader would have concluded a corpus was clean while ~86.7k vendored chunks were resident.

## The six diagrams

1. **Authority map** — which leaf decides what, with the width/concurrency conflation drawn explicitly: `parallel` was spent computing a request *width* to reserve a slot a client cannot hold, and the concurrency it declares was used by nothing.
2. **One slice as it actually runs** — including why the slice budget is anchored per repository at admission, and why that same correct choice means honouring every budget still occupies the exclusive slot for roughly `N × sliceBudgetMs`.
3. **Checkpoint states** — as a state diagram whose partial cycle is **absorbing** while a corpus exceeds one slice. This is why throughput is a correctness concern on this lane and not only a performance one.
4. **Guard interaction** — four pairs whose joint outcome differs from either alone, the fourth being the one worth internalising: a guard failing **closed** converts a wrong answer into a silent loss, which is usually right and means the loss needs its own report.
5. **Verified vs unverified axes** — what the shape verifier establishes, quoting its own boundary statement, and that utilization sits outside it. A lane can truthfully report four slots at 16,384 tokens each and use one.
6. **Code locality** — the four-owner map, i.e. the vacuum above.

## Deltas from ticket

**Three findings post-date the ticket and are included rather than deferred**, because the ticket's own rule is that nothing be reconstructed from reasoning and these were all measured after it was filed:

- the **single-worker post queue** as a third serialisation layer (`#drainOpenAiCompatiblePostQueue`, docblock: *"one at a time"*);
- the **carry arithmetic** whose prefix-contiguity dependence makes the binding guard fail closed and silently drop conserved work;
- the **absence of any wired re-embed trigger** — incremental selection skips existing ids, and the provider input string is derived rather than a `hashInputs` member, so re-ingestion re-embeds nothing.

**One trap entry is about a mistake in this session's own reasoning**, kept because it generalises past this lane: a guard's docblock describes what the guard does, never that anything calls it — *a function named in a comment is not a function that is called*. I asserted a wired mechanism from a docblock plus a comment's mention, and the falsifier was one grep for a call site.

## Review round 2: what the four actions changed

**RA-2 (registration) — done.** Registration was two inputs and I had shipped one. `agentos/EmbeddingLane` is now in `buildScripts/docs/seo/generate.mjs` `PRIORITIES` at **0.8**, with a comment stating the ranking rationale: below both subsystem apexes it spans (`KnowledgeBase`, `MemoryCore`, both 1.0), because a reader arrives at those and reaches this from them — the same tier as `GitHubWorkflow` / `CodeExecution`. Pipeline-owned `sitemap` / `llms` outputs are untouched. `lint-tree-json`: OK, 224 nodes, generator accepts the entry. Both new consumed surfaces plus the merge dependency are now rows in neomjs/neo#17413's Contract Ledger.

**RA-1 (landed code is the authority) — DONE at `d6251d3d82`.** PR neomjs/neo#17433 merged, so the gate is lifted and the re-verification ran against the real tree. See the RA-1 receipt below: it found one false statement, and it was the one this document called the most important.

*Round-2 text, kept for the record:* **the in-diff half is done; the re-verify is owed and gated.** Merge order is recorded above and mechanically, as `blocked_by`. The target-only symbol is removed: diagram 6 named `helpers/embeddingDispatchPlan`, which exists only on the unmerged neomjs/neo#17433 branch. Audited every lane symbol the guide names against `origin/dev` — that node was the **only** one absent, and it is gone; it returns when the code does. What remains genuinely gated is the full statement-by-statement re-verification against the post-merge tree, which cannot be performed against a tree that does not exist yet.

**RA-3 (accretion bar) — the first branch has no target, so the AC's second branch is exercised with evidence.** Searched both candidate absorption sources rather than asserting there was nothing:

- `TenantIngestionModel.md` — its only passage on this guide's side of the line is the deletion-telemetry bullet, and **both documents already declare the opposite split in prose** (its `## Related`: *"This document owns ingestion configuration, triggers and telemetry; that one owns the lane's composition."*). Absorbing across a boundary two artifacts state explicitly loses facts or re-litigates the split.
- `KnowledgeBase.md` — searched for every geometry authority the lane has (`parallel`, `batchEmbeddingChunkSize`, safe band, token ceiling, slice budget): **zero matches**. Nothing to absorb, because the content never existed anywhere — which is the vacuum the ticket was filed about.

The measured exception, with two checkable retirement triggers, is now a section in neomjs/neo#17413. Its load-class argument is **verified rather than assumed**: `turn-memory-pre-flight` enumerates the turn-loaded surface as `AGENTS.md`, `AGENTS_ATLAS.md`, `.agents/skills/**`, `.codex/CODEX.md`, `.claude/CLAUDE.md`, `.agents/ANTIGRAVITY_RULES.md`, and **`learn/**` is not in it** — so a guide costs zero per-turn bytes, a materially different act from an additive gate.

**RA-3's second clause (portable value, in the narrative) — done.** Four of the nine wrong claims this document cost were not about Neo, and they are now woven into the opening in first person rather than parked in a role matrix: a declared parallelism is not a measured one; a capacity number has a unit (`concurrency × width`, not `concurrency`); a fail-closed guard converts a wrong answer into a silent loss, so the loss needs reporting; and throughput can be a correctness property, because a completion-gated checkpoint plus a per-pass budget makes the partial state absorbing. The closing line is the transferable part: all four were invisible to code review and visible to one instrumented run. No author footer was added — sibling guides end on `## Related`, and the attribution is the first-person voice rather than a signature block.

**RA-4 (render receipt) — DONE at `d6251d3d82`, and it found two real defects.** See the RA-4 receipt below. You were right that `lint-guides` does not satisfy the visual gate: two diagrams rendered at ~0.23–0.30 scale, which no CI check reports because both are valid Mermaid.

*Round-2 text, kept for the record:* **partial, and stated as partial.** All six diagrams **parse**: at `4022176fca` on the GitHub blob surface, each of the six `js-render-enrichment-target` blocks produces a `viewscreen.githubusercontent.com/markdown/mermaid` iframe containing an SVG, which a mermaid parse failure does not (it renders an error box in place of the frame). What I could **not** establish is per-diagram legibility at rendered scale: four frames report a 180px height against 483px and 342px for the two tallest, and I could not drive the blob view's scroll to inspect them — the frames receive their source by `postMessage`, so the frame URL cannot be measured standalone either. RA-4 sequences this receipt after the post-#17433 update anyway, so it is owed there in full rather than claimed here on partial evidence.

## Test Evidence

### RA-1 receipt — re-verified against the post-#17433 tree, and one statement was false

Rebased onto `origin/dev` (30 commits, clean, no conflicts) after neomjs/neo#17433 merged, then checked every axis the RA names.

**The one false statement was the document's own headline claim.** §4 described the carry defect as *realized*: work conservation switching itself off, the lane re-purchasing vectors on every retry, nothing in the logs. The landed implementation says the opposite in one sentence — ***"No reachable input reddened the product, and none can."*** The formula's stated justification was false (the final span is short whenever the input count is not a multiple of the width), but its conclusion held via an unstated caller-side ordering invariant: the dispatch loop consults the yield predicate only while spans remain undispatched, and dispatch is in span order. **Nothing was ever mis-carried.** I derived the failure from the mechanism instead of observing it — the same error the passage was written to teach. Rewritten to the narrower and more useful lesson: a computation that is correct by accident is one refactor from being wrong in silence, which is why the repair passes the measured prefix rather than re-deriving it.

Verified **unchanged and correct** at the new tree:

| axis | check | result |
|---|---|---|
| concurrency / width | `parallel - 1` clamp gone; `#openAiCompatibleInFlightTasks`, `#openAiCompatibleTaskWeight`, `#mayAdmitOpenAiCompatiblePost`, `resolveEmbeddingTaskBudget` present | past-tense framing now accurate |
| code locality | all **8** paths in the §6 diagram exist | ✅ |
| line-anchored citations | `embeddingSafeBand.mjs:42` → `EMBEDDING_TOKEN_ESTIMATE_DRIFT_FACTOR = 1.35`; `consumerFrictionHelper.mjs:122` → `BYTES_PER_TOKEN_HEURISTIC = 3` | both exact |
| config default | `NEO_LOCAL_MODELS_EMBEDDING_PARALLEL` → `leaf(1, …)`, guide says "default 1" | ✅ |
| quoted docblock | `providerLaneLiveShape.mjs` liveness sentence | quoted verbatim |
| checkpoint | deferred leaves `consecutiveFailures` untouched — corroborated by the service's own docblock | ✅ |
| target-only symbols | no symbol the guide names is absent from the tree | ✅ |

### RA-4 receipt — six diagrams render-verified in a browser; two were illegible

Surface: the **portal** at `/apps/portal/#/learn/agentos/EmbeddingLane`, driven by the `learn/tree.json` entry this branch adds — the surface a reader actually meets this guide on. All six parse (0 error nodes). Measured each SVG's intrinsic `viewBox` width against the ~860px doc column, because that ratio is what scales the labels:

| # | section | before | after | scale before → after |
|---|---|---|---|---|
| 1 | authority map | 2837×830 | **922×1670** | 0.30 → **0.93** |
| 2 | one slice | 441×1178 | unchanged | 1.00 |
| 3 | checkpoint states | 497×830 | unchanged | 1.00 |
| 4 | guard pairs | **3789×212** | **995×830** | 0.23 → **0.86** |
| 5 | verified axes | 1158×398 | unchanged | 0.74 |
| 6 | code locality | 1247×700 | unchanged | 0.69 |

At 0.23 a 14px label renders near 3px. **Worst case is now 0.69, was 0.23.** Both defects had one cause: sibling chains with nothing linking them are laid out side by side, so the diagram grows with the branch count; invisible edges stack them. Repairs confirmed visually as well as numerically — diagram 1 renders at 834px in the real container with labels crisp, diagram 4 as four legible stacked rows.

One finding worth carrying: **a subgraph `direction` cannot fix this**, because Mermaid ignores it when edges cross the subgraph boundary — which every leaf's edge does. That is why the authority map resisted two attempts before the right fix.

Documentation surface; no runtime behaviour changes and no `.mjs` touched.

- `node ai/scripts/lint/lint-guides.mjs` → **OK**, 0 hard, 36 guides scanned. Two hard/warn findings were mine and both were real readability rules: a `partial -> partial` self-loop in the state diagram (rewritten as an intermediate node plus two edges) and a 17-node `flowchart LR` that would squish on GitHub (now `TD`).
- `node ai/scripts/lint/lint-tree-json.mjs` → **OK**, 224 nodes; the registry entry mirrors the folder structure and the SEO generator accepts it.
- `node ./buildScripts/util/check-ticket-archaeology.mjs` → 0 `.mjs` files in scope.
- **No client identifiers**: grepped the client-name denylist (patterns withheld — a compliance note that quotes
  its own denylist publishes the denylist) → **0**. The deployment is referenced only as "an external tenant deployment".
- Every cross-link target verified to exist on disk (both ADRs, `KnowledgeBase.md`, `TenantIngestionModel.md`).

Per directly touched surface: `learn/**` — `lint-guides` + `lint-tree-json` are the existing non-CI coverage; no spec harness applies to a markdown guide, and none was invented for one.

## Post-Merge Validation

Nothing is owed. `lint-tree-json` asserts the registry entry mirrors the folder structure and that the SEO generator accepts it, which is the only mechanical property this change has — and it runs pre-merge, not after. Portal rendering follows from a valid entry rather than needing its own verification pass, so listing it here would be manufacturing an obligation nobody holds.

The document's own decay is handled inside it rather than as a merge residual: every plane fact carries its observation date and the command that re-reads it, so a reader can compute the delta in one command instead of re-discovering the lane. That is the guide's stated design and the reason it does not need a scheduled review.

## Commits

- `fd10f0f03e` — the embedding lane gets an owning document.
- `4022176fca` — the guide registers itself, and its lessons leave the repository (RA-1 in-diff half, RA-2, RA-3).
- `a9d2c12e29` — the carry failure this guide taught never happened (RA-1 re-verification).
- `d6251d3d82` — two diagrams were rendering at a third of legible size (RA-4).

Rebased onto `origin/dev` after neomjs/neo#17433 merged; three-dot diff unchanged at 4 files.

## Decision Record impact

`aligned-with ADR 0019`. Same remedy shape — make the mechanism readable rather than asking for more care, since ADR 0019 §1 records that care was empirically falsified (4/4 missed across two doc-prepared reviews) — applied to a subsystem that ADR does not cover. No decision is changed.

## Evolution

**I re-made a mistake this body already records fixing.** Test Evidence above notes that round 1 changed *"a 17-node `flowchart LR` that would squish on GitHub (now `TD`)"*. Chasing the authority map's width today, I flipped that same diagram back to `LR` — it did narrow it (2837 → 1356, scale 0.63), and `lint-guides` rejected it with `[mermaid-lr-squish]`, the rule I had already satisfied once. The heuristic was right and my measurement was a local improvement of the wrong shape: TD with serialized branches reaches 0.93. Knowing the correction was not the same as having learned it, and the linter caught what my own PR body had already told me.

Released this lane to peers earlier today because holding it while finishing a code lane would have been a placeholder claim. Re-claimed it when the Claude seats went out until 08:00 and the GPT seats were on reviews — and by then I had accumulated three findings the ticket did not have, which made the release-then-reclaim net positive rather than churn.

---

Authored by Vega (Claude Opus 5, Claude Code). Session 046f993e-13ba-47dd-827d-d786428e318b.




