### PR TITLE
Three checkers now state the scope their green line covers (#17396)

### DIFF
--- a/buildScripts/util/check-block-alignment.mjs
+++ b/buildScripts/util/check-block-alignment.mjs
@@ -181,24 +181,32 @@ function evaluateColonAlignment(lines, maskedLines = []) {
         violations = [],
         fixedLines = lines.slice();
 
-    for (const run of collectPropertyRuns(lines, maskedLines)) {
-        const colonMembers = run.filter(entry => entry.kind === 'colon');
-        if (colonMembers.length < 2) continue; // a lone colon property is not an alignment group
+    const runs = collectPropertyRuns(lines, maskedLines),
+          // Only runs that ARE alignment groups are counted, so "group 2 of 3" matches what a reader
+          // can see. Counting skipped single-property runs would name a total nothing displays.
+          groups = runs.filter(run => run.filter(entry => entry.kind === 'colon').length >= 2);
 
-        const
-            indent   = run[0].indent,
-            keyWidth = Math.max(...colonMembers.map(entry => entry.key.length));
+    groups.forEach((run, groupIndex) => {
+        const colonMembers = run.filter(entry => entry.kind === 'colon'),
+              indent       = run[0].indent,
+              keyWidth     = Math.max(...colonMembers.map(entry => entry.key.length));
 
         for (const entry of colonMembers) {
             const expected = `${indent}${entry.key.padEnd(keyWidth)}: ${entry.value}`;
             if (expected !== lines[entry.lineIndex]) {
-                violations.push({lineIndex: entry.lineIndex, expectedColumn: indent.length + keyWidth, kind: 'object-colon'});
+                violations.push({
+                    lineIndex     : entry.lineIndex,
+                    expectedColumn: indent.length + keyWidth,
+                    kind          : 'object-colon',
+                    group         : groupIndex + 1,
+                    groupCount    : groups.length
+                });
                 fixedLines[entry.lineIndex] = expected;
             }
         }
-    }
+    });
 
-    return {violations, fixedLines};
+    return {violations, fixedLines, notices: detectCommentOnlyFragmentation(lines, groups)};
 }
 
 // ─────────────────────────── `=` declaration blocks (v1b) ───────────────────────────
@@ -545,11 +553,55 @@ function computeTemplateLiteralLineMask(lines) {
  * @param {{lineIndex: Number, expectedColumn: Number, kind: String}} violation
  * @returns {String}
  */
-function formatViolation(file, {lineIndex, expectedColumn, kind}) {
-    const at = `${file}:${lineIndex + 1}`;
-    if (kind === 'object-colon') return `Misaligned object-literal colon in ${at} — expected ':' at column ${expectedColumn + 1}`;
-    if (kind === 'assignment')   return `Misaligned '=' in ${at} — expected '=' at column ${expectedColumn + 1}`;
-    return `Misaligned import 'from' in ${at} — expected 'from' at column ${expectedColumn + 1}`;
+function formatViolation(file, {lineIndex, expectedColumn, kind, group, groupCount}) {
+    // The unit is named because this checker judges GROUPS, and a column number alone cannot tell a
+    // reader which it judged. "group 2 of 3" says a boundary exists above this line — the difference
+    // between "my literal is misaligned" and "my literal was split in two, and each half is
+    // internally consistent". A green run has always meant every group is aligned; it has never
+    // meant the file reads as one block, and the output never said so.
+    const at    = `${file}:${lineIndex + 1}`,
+          where = groupCount > 1 ? ` (group ${group} of ${groupCount})` : '';
+
+    if (kind === 'object-colon') return `Misaligned object-literal colon in ${at}${where} — expected ':' at column ${expectedColumn + 1}`;
+    if (kind === 'assignment')   return `Misaligned '=' in ${at}${where} — expected '=' at column ${expectedColumn + 1}`;
+    return `Misaligned import 'from' in ${at}${where} — expected 'from' at column ${expectedColumn + 1}`;
+}
+
+/**
+ * @summary Adjacent property runs at one indent, separated by comment lines ONLY.
+ *
+ * A blank line between two runs is a deliberate separator and is left alone. A comment is not: the
+ * author wrote prose about the next key and unknowingly split one alignment group in two, each of
+ * which is then aligned independently and reported clean. The file reads wrong and every gate on the
+ * path agrees it is fine.
+ *
+ * Reported as a NOTICE, never a failure. The split is occasionally deliberate, and a checker that
+ * cannot tell which should not be the thing that blocks a commit — only the thing that makes the
+ * author look.
+ *
+ * @param {String[]} lines
+ * @param {Array<Object[]>} runs As returned by `collectPropertyRuns`.
+ * @returns {Array<{lineIndex: Number}>}
+ */
+function detectCommentOnlyFragmentation(lines, runs) {
+    const notices = [];
+
+    for (let i = 1; i < runs.length; i++) {
+        const previous = runs[i - 1],
+              current  = runs[i],
+              from     = previous[previous.length - 1].lineIndex + 1,
+              to       = current[0].lineIndex;
+
+        if (to <= from || previous[0].indent !== current[0].indent) continue;
+
+        const between = lines.slice(from, to).map(line => line.trim());
+
+        if (between.every(line => line.startsWith('//') || line.startsWith('*') || line.startsWith('/*'))) {
+            notices.push({lineIndex: current[0].lineIndex})
+        }
+    }
+
+    return notices
 }
 
 /**
@@ -583,10 +635,24 @@ function processFile(file, fix, gitRoot = null, scopedFix = false) {
     const maskedLines   = computeTemplateLiteralLineMask(originalLines);
     let   lines         = originalLines;
 
+    const allNotices = [];
+
     for (const evaluate of EVALUATORS) {
-        const {violations, fixedLines} = evaluate(lines, maskedLines);
+        const {violations, fixedLines, notices} = evaluate(lines, maskedLines);
         allViolations.push(...violations);
+        notices && allNotices.push(...notices);
         lines = fixedLines;
+    }
+
+    // Printed before the clean/dirty verdict, and independently of it, because the whole point is a
+    // file that IS clean by this checker's own rule while reading wrong. Emitting it only alongside a
+    // violation would hide it in exactly the case it exists to describe.
+    for (const notice of allNotices.sort((a, b) => a.lineIndex - b.lineIndex)) {
+        console.warn(
+            `check-block-alignment: ${file}:${notice.lineIndex + 1} — an alignment group starts here, ` +
+            'separated from the one above by a comment only. Each half aligns independently, so this ' +
+            'file can pass while the two read at different columns. Deliberate? Leave it.'
+        )
     }
 
     if (allViolations.length === 0) return 'clean';

--- a/buildScripts/util/check-block-alignment.mjs
+++ b/buildScripts/util/check-block-alignment.mjs
@@ -93,20 +93,27 @@ function evaluateImportAlignment(lines, maskedLines = []) {
         violations = [],
         fixedLines = lines.slice();
 
-    for (const run of collectImportRuns(lines, maskedLines)) {
-        if (run.length < 2) continue; // a lone import is not an alignment group
+    // Only runs that ARE groups are numbered, so "group 2 of 3" counts what a reader can see.
+    const groups = collectImportRuns(lines, maskedLines).filter(run => run.length >= 2);
 
+    groups.forEach((run, groupIndex) => {
         // The `from` column = widest `import <clause>` in the run + one space.
         const fromColumn = Math.max(...run.map(entry => IMPORT_PREFIX.length + entry.clause.length)) + 1;
 
         for (const entry of run) {
             const expected = alignedImportLine(entry, fromColumn);
             if (expected !== lines[entry.lineIndex]) {
-                violations.push({lineIndex: entry.lineIndex, expectedColumn: fromColumn, kind: 'import'});
+                violations.push({
+                    lineIndex     : entry.lineIndex,
+                    expectedColumn: fromColumn,
+                    kind          : 'import',
+                    group         : groupIndex + 1,
+                    groupCount    : groups.length
+                });
                 fixedLines[entry.lineIndex] = expected;
             }
         }
-    }
+    });
 
     return {violations, fixedLines};
 }
@@ -387,10 +394,14 @@ function evaluateAssignmentAlignment(lines, maskedLines = []) {
         violations = [],
         fixedLines = lines.slice();
 
-    for (const {entries, mode} of collectAssignmentRuns(lines, maskedLines)) {
+    // Only runs that ARE groups are numbered, so "group 2 of 3" counts what a reader can see.
+    const groups = collectAssignmentRuns(lines, maskedLines).filter(({entries}) =>
+        entries.length > 0 &&
+        !(entries.length < 2 && lines[entries[0].lineIndex] === `${entries[0].left} = ${entries[0].value}`)
+    );
+
+    groups.forEach(({entries, mode}, groupIndex) => {
         const simpleParts = entries;
-        if (simpleParts.length === 0) continue;
-        if (simpleParts.length < 2 && lines[simpleParts[0].lineIndex] === `${simpleParts[0].left} = ${simpleParts[0].value}`) continue;
 
         const
             keywordWidth = mode === 'keyword' ? Math.max(...simpleParts.map(part => part.keyword.length)) : 0,
@@ -405,11 +416,17 @@ function evaluateAssignmentAlignment(lines, maskedLines = []) {
                 : left;
             const expected = `${normalizedLeft.padEnd(leftWidth)} = ${value}`;
             if (expected !== lines[lineIndex]) {
-                violations.push({lineIndex, expectedColumn: leftWidth + 1, kind: 'assignment'});
+                violations.push({
+                    lineIndex,
+                    expectedColumn: leftWidth + 1,
+                    kind          : 'assignment',
+                    group         : groupIndex + 1,
+                    groupCount    : groups.length
+                });
                 fixedLines[lineIndex] = expected;
             }
         }
-    }
+    });
 
     return {violations, fixedLines};
 }

--- a/buildScripts/util/check-jsdoc-types.mjs
+++ b/buildScripts/util/check-jsdoc-types.mjs
@@ -146,6 +146,36 @@ export function inScope(file) {
     return DEFAULT_DIRS.some(dir => file === dir || file.startsWith(dir + '/'))
 }
 
+/**
+ * @summary Describes what a run actually read, phrased to survive being quoted somewhere else.
+ *
+ * The success line was a bare count, and a bare count is read as coverage of whatever the reader was
+ * doing — their diff, their directory, their repository. It is none of those: the scanned set is the
+ * docs-build parse scope, which for a consumer of this package is a different set of files entirely.
+ * This receipt has been pasted into pull-request bodies as evidence for changes it never opened, and
+ * the number was true every time.
+ *
+ * Caller-supplied paths report `N of M`, because {@link inScope} drops the rest SILENTLY — a hook
+ * handing over seven staged files and hearing about three is the same defect one layer down. When the
+ * two numbers differ the line says so, which is what makes a run that read NONE of the caller's files
+ * distinguishable from one that read all of them. That distinction is the whole point: "mentions a
+ * scope" is satisfiable by text, "0 of 7" is not.
+ *
+ * Exported so the receipt is a contract with its own coverage rather than a string inside `main()`.
+ *
+ * @param {Object} counts
+ * @param {Number} counts.supplied How many positional paths the caller passed (0 = default scan).
+ * @param {Number} counts.offered  How many candidate paths were considered.
+ * @param {Number} counts.scanned  How many survived the scope filter.
+ * @returns {{scope: String, scanned: String}}
+ */
+export function describeScan({supplied, offered, scanned}) {
+    return {
+        scope  : `docs-build parse scope: ${DEFAULT_DIRS.join(', ')}`,
+        scanned: supplied > 0 ? `${scanned} of ${offered} supplied file(s)` : `${scanned} file(s)`
+    }
+}
+
 function collectDefaultFiles(gitRoot) {
     const result = spawnSync('find', [...DEFAULT_DIRS, '-type', 'f', '-name', '*.mjs'], {cwd: gitRoot, encoding: 'utf-8'});
     // A missing optional dir makes `find` exit non-zero while still listing the others — tolerate stdout.
@@ -170,22 +200,7 @@ function main() {
     const rawFiles = argvFiles.length > 0 ? argvFiles : collectDefaultFiles(gitRoot);
     const files    = rawFiles.map(f => toRepoRelative(f, gitRoot)).filter(inScope);
 
-    // What this run actually read, phrased so the line survives being quoted somewhere else.
-    //
-    // The success line used to be a bare count, and a bare count is read as coverage of whatever the
-    // reader was doing — their diff, their directory, their repository. It is none of those: the
-    // scanned set is the docs-build parse scope, which for a consumer of this package is a different
-    // set of files entirely. That receipt has been pasted into pull-request bodies as evidence for
-    // changes it never opened, and the number was true every time.
-    //
-    // Caller-supplied paths get `N of M`, because `inScope` above drops the rest SILENTLY — a hook
-    // handing over seven staged files and hearing about three is the same defect one layer down.
-    // When the two numbers differ the line says so, which is what makes a run that read none of the
-    // caller's files distinguishable from one that read all of them.
-    const scope   = `docs-build parse scope: ${DEFAULT_DIRS.join(', ')}`,
-          scanned = argvFiles.length > 0 ?
-              `${files.length} of ${rawFiles.length} supplied file(s)` :
-              `${files.length} file(s)`;
+    const {scope, scanned} = describeScan({supplied: argvFiles.length, offered: rawFiles.length, scanned: files.length});
 
     if (files.length === 0) {
         console.log(`check-jsdoc-types: ${scanned} in scope, nothing to check (${scope}).`);

--- a/buildScripts/util/check-jsdoc-types.mjs
+++ b/buildScripts/util/check-jsdoc-types.mjs
@@ -170,8 +170,25 @@ function main() {
     const rawFiles = argvFiles.length > 0 ? argvFiles : collectDefaultFiles(gitRoot);
     const files    = rawFiles.map(f => toRepoRelative(f, gitRoot)).filter(inScope);
 
+    // What this run actually read, phrased so the line survives being quoted somewhere else.
+    //
+    // The success line used to be a bare count, and a bare count is read as coverage of whatever the
+    // reader was doing — their diff, their directory, their repository. It is none of those: the
+    // scanned set is the docs-build parse scope, which for a consumer of this package is a different
+    // set of files entirely. That receipt has been pasted into pull-request bodies as evidence for
+    // changes it never opened, and the number was true every time.
+    //
+    // Caller-supplied paths get `N of M`, because `inScope` above drops the rest SILENTLY — a hook
+    // handing over seven staged files and hearing about three is the same defect one layer down.
+    // When the two numbers differ the line says so, which is what makes a run that read none of the
+    // caller's files distinguishable from one that read all of them.
+    const scope   = `docs-build parse scope: ${DEFAULT_DIRS.join(', ')}`,
+          scanned = argvFiles.length > 0 ?
+              `${files.length} of ${rawFiles.length} supplied file(s)` :
+              `${files.length} file(s)`;
+
     if (files.length === 0) {
-        console.log('check-jsdoc-types: 0 in-scope .mjs files, nothing to check.');
+        console.log(`check-jsdoc-types: ${scanned} in scope, nothing to check (${scope}).`);
         process.exit(0)
     }
 
@@ -201,7 +218,7 @@ function main() {
         process.exit(1)
     }
 
-    console.log(`check-jsdoc-types: ${files.length} file(s) scanned, 0 unparseable type expressions.`)
+    console.log(`check-jsdoc-types: ${scanned} scanned, 0 unparseable type expressions (${scope}).`)
 }
 
 const invokedDirectly = process.argv[1] && path.resolve(process.argv[1]) === __filename;

--- a/buildScripts/util/check-jsdoc-types.mjs
+++ b/buildScripts/util/check-jsdoc-types.mjs
@@ -161,18 +161,28 @@ export function inScope(file) {
  * distinguishable from one that read all of them. That distinction is the whole point: "mentions a
  * scope" is satisfiable by text, "0 of 7" is not.
  *
+ * **Three counts, not two, because selection and IO diverge.** `offered` is what the caller or the
+ * default scan put forward; `admitted` is what survived the scope filter; `read` is what was actually
+ * opened. A count that stops at `admitted` reports a file it never read: an unreadable path warns on
+ * one line and is then counted as scanned on the next, which is this function's own defect committed
+ * inside the fix for it. `read` is the only number entitled to the word.
+ *
  * Exported so the receipt is a contract with its own coverage rather than a string inside `main()`.
  *
  * @param {Object} counts
  * @param {Number} counts.supplied How many positional paths the caller passed (0 = default scan).
  * @param {Number} counts.offered  How many candidate paths were considered.
- * @param {Number} counts.scanned  How many survived the scope filter.
+ * @param {Number} counts.admitted How many survived the scope filter.
+ * @param {Number} counts.read     How many were opened without error.
  * @returns {{scope: String, scanned: String}}
  */
-export function describeScan({supplied, offered, scanned}) {
+export function describeScan({supplied, offered, admitted, read}) {
+    const unreadable = admitted - read,
+          base       = supplied > 0 ? `${read} of ${offered} supplied file(s) read` : `${read} file(s) read`;
+
     return {
         scope  : `docs-build parse scope: ${DEFAULT_DIRS.join(', ')}`,
-        scanned: supplied > 0 ? `${scanned} of ${offered} supplied file(s)` : `${scanned} file(s)`
+        scanned: unreadable > 0 ? `${base}, ${unreadable} unreadable` : base
     }
 }
 
@@ -200,14 +210,23 @@ function main() {
     const rawFiles = argvFiles.length > 0 ? argvFiles : collectDefaultFiles(gitRoot);
     const files    = rawFiles.map(f => toRepoRelative(f, gitRoot)).filter(inScope);
 
-    const {scope, scanned} = describeScan({supplied: argvFiles.length, offered: rawFiles.length, scanned: files.length});
+    const describe = read => describeScan({
+        supplied: argvFiles.length, offered: rawFiles.length, admitted: files.length, read
+    });
 
     if (files.length === 0) {
-        console.log(`check-jsdoc-types: ${scanned} in scope, nothing to check (${scope}).`);
+        const {scope, scanned} = describe(0);
+
+        console.log(`check-jsdoc-types: ${scanned}, nothing to check (${scope}).`);
         process.exit(0)
     }
 
+    // Counted, not assumed. `files.length` is what the scope ADMITTED; a file that fails to open is
+    // warned about and skipped, and reporting the admitted count as the scanned one turns that skip
+    // into a green claim about a file nobody read.
     const violations = [];
+    let   read       = 0;
+
     for (const file of files) {
         let content;
         try {
@@ -216,11 +235,14 @@ function main() {
             console.error(`check-jsdoc-types: could not read ${file}: ${e.message}`);
             continue
         }
+        read++;
         findUnparseableTypes(content).forEach(({line, tag, expr}) => violations.push(`${file}:${line}  @${tag} {${expr}}`))
     }
 
+    const {scope, scanned} = describe(read);
+
     if (violations.length > 0) {
-        console.error(`\x1b[31mcheck-jsdoc-types: ${violations.length} unparseable JSDoc type expression(s):\x1b[0m`);
+        console.error(`\x1b[31mcheck-jsdoc-types: ${violations.length} unparseable JSDoc type expression(s) in ${scanned} (${scope}):\x1b[0m`);
         if (!quiet) {
             violations.forEach(v => console.error('  ' + v));
             console.error('\nThe docs build (`npm run generate-docs-json`, the last `build all` step) parses these with');
@@ -233,7 +255,7 @@ function main() {
         process.exit(1)
     }
 
-    console.log(`check-jsdoc-types: ${scanned} scanned, 0 unparseable type expressions (${scope}).`)
+    console.log(`check-jsdoc-types: ${scanned}, 0 unparseable type expressions (${scope}).`)
 }
 
 const invokedDirectly = process.argv[1] && path.resolve(process.argv[1]) === __filename;

--- a/buildScripts/util/check-ticket-archaeology.mjs
+++ b/buildScripts/util/check-ticket-archaeology.mjs
@@ -228,8 +228,19 @@ function main() {
             ? argvFiles.filter(f => f.endsWith('.mjs'))
             : collectDefaultFiles();
 
+    // Which of the three selections produced this file set, named in the receipt.
+    //
+    // The success line was a bare count, and the three modes select wildly different sets: a CI run
+    // reports the files a branch changed, a pre-commit run reports what was staged, a default run
+    // reports the whole audit scope. Quoted anywhere else all three read as "the repository is
+    // clean" — and the two narrow ones are the common cases. A count without its selection is a
+    // claim about whatever the reader had in mind.
+    const selection = options.base ? `changed vs ${options.base}`
+        : hasFileArgs             ? 'supplied paths'
+        : `full audit scope: ${scanPaths.join(', ')}`;
+
     if (files.length === 0) {
-        console.log('check-ticket-archaeology: 0 .mjs files in scope, nothing to check.');
+        console.log(`check-ticket-archaeology: 0 .mjs files in scope, nothing to check (${selection}).`);
         process.exit(0);
     }
 
@@ -262,7 +273,7 @@ function main() {
         process.exit(1);
     }
 
-    console.log(`check-ticket-archaeology: ${files.length} files scanned, 0 violations.`);
+    console.log(`check-ticket-archaeology: ${files.length} file(s) scanned, 0 violations (${selection}).`);
 }
 
 const invokedDirectly = process.argv[1] && path.resolve(process.argv[1]) === __filename;

--- a/buildScripts/util/check-ticket-archaeology.mjs
+++ b/buildScripts/util/check-ticket-archaeology.mjs
@@ -149,6 +149,24 @@ export function isInScopePath(file, scanPaths, ignores) {
         && !ignores.some(ignore => file.split('/').includes(ignore))
 }
 
+/**
+ * @summary Phrases how many selected files were actually opened, never how many were selected.
+ *
+ * The two numbers diverge whenever a selected path fails to open: the failure warns on one line and is
+ * skipped, and reporting the SELECTED count as the scanned one turns that skip into a green claim about
+ * a file nobody read. Only the count of successful reads is entitled to the word.
+ *
+ * @param {Number} read     Files opened without error.
+ * @param {Number} selected Files the selection produced.
+ * @returns {String}
+ */
+export function describeRead(read, selected) {
+    const unreadable = selected - read,
+          base       = `${read} file(s) read`;
+
+    return unreadable > 0 ? `${base}, ${unreadable} unreadable` : base
+}
+
 function main() {
     let gitRoot;
     try {
@@ -244,7 +262,12 @@ function main() {
         process.exit(0);
     }
 
+    // Counted, not assumed. `files.length` is what the SELECTION produced; a file that fails to open
+    // is warned about and skipped, and reporting the selected count as the scanned one turns that skip
+    // into a green claim about a file nobody read.
     const violations = [];
+    let   read       = 0;
+
     for (const file of files) {
         let content;
         try {
@@ -253,6 +276,8 @@ function main() {
             console.error(`check-ticket-archaeology: could not read ${file}: ${e.message}`);
             continue;
         }
+
+        read++;
 
         // Boy-scout rule (operator-directed): scan the WHOLE touched file, exactly like
         // check-block-alignment — touching a file obligates cleaning ALL its ticket-archaeology, not just
@@ -263,7 +288,7 @@ function main() {
     }
 
     if (violations.length > 0) {
-        console.error(`\x1b[31mcheck-ticket-archaeology: ${violations.length} decay-prone ref(s) (ticket/Epic/Discussion/ADR) in durable comments:\x1b[0m`);
+        console.error(`\x1b[31mcheck-ticket-archaeology: ${violations.length} decay-prone ref(s) (ticket/Epic/Discussion/ADR) in durable comments, across ${describeRead(read, files.length)} (${selection}):\x1b[0m`);
         if (!options.quiet) {
             violations.forEach(v => console.error('  ' + v));
             console.error('\nDurable comments/JSDoc must describe behavior, not cite tracking refs — tickets, Epics, Discussions, or ADRs (they rot when the');
@@ -273,7 +298,7 @@ function main() {
         process.exit(1);
     }
 
-    console.log(`check-ticket-archaeology: ${files.length} file(s) scanned, 0 violations (${selection}).`);
+    console.log(`check-ticket-archaeology: ${describeRead(read, files.length)}, 0 violations (${selection}).`);
 }
 
 const invokedDirectly = process.argv[1] && path.resolve(process.argv[1]) === __filename;

--- a/test/playwright/unit/ai/buildScripts/util/check-block-alignment.spec.mjs
+++ b/test/playwright/unit/ai/buildScripts/util/check-block-alignment.spec.mjs
@@ -1,5 +1,5 @@
 import {test, expect}  from '@playwright/test';
-import {execFileSync}  from 'node:child_process';
+import {execFileSync, spawnSync} from 'node:child_process';
 import fs              from 'node:fs';
 import os              from 'node:os';
 import path            from 'node:path';
@@ -35,14 +35,18 @@ test.describe('check-block-alignment.mjs (#13556)', () => {
         return filePath;
     };
 
-    // execFileSync (not execSync): node is spawned directly with an argv array — no shell, so the
+    // spawnSync (not execSync): node is spawned directly with an argv array — no shell, so the
     // absolute scriptPath + file args can never be interpolated into a shell command (CodeQL-clean).
+    //
+    // BOTH streams, on BOTH paths. The failure path always merged them; the success path returned
+    // stdout alone, so anything a PASSING run wrote to stderr was invisible to every arm in this
+    // file. A checker that emits an advisory about a file it does not fail is exactly that shape,
+    // and an arm asserting such an advisory would have failed for a reason having nothing to do with
+    // the advisory. `output` now means what its name claims.
     const run = (...args) => {
-        try {
-            return {status: 0, output: execFileSync('node', [scriptPath, ...args], {encoding: 'utf8', stdio: 'pipe'})};
-        } catch (error) {
-            return {status: error.status, output: (error.stderr || '') + (error.stdout || '')};
-        }
+        const result = spawnSync('node', [scriptPath, ...args], {encoding: 'utf8'});
+
+        return {status: result.status, output: (result.stdout || '') + (result.stderr || '')}
     };
 
     const MISALIGNED = [
@@ -101,6 +105,77 @@ test.describe('check-block-alignment.mjs (#13556)', () => {
         expect(fixResult.output).toContain('Error processing');
 
         expect(run(missing).status).toBe(1); // check mode also fails
+    });
+
+    test.describe('the green line states the unit it judged', () => {
+        // This checker judges GROUPS. Both defects below are invisible to every other arm in this
+        // file, because both produce output the checker itself considers correct.
+
+        const SPLIT = [
+            'const x = {',
+            '    staleCount         : 0,',
+            '    manifestOrphanCount: 0,',
+            '    // prose about the next key',
+            '    parserOrphanCount: 0,',
+            '    totalOrphanCount : 0',
+            '};'
+        ].join('\n');
+
+        test('a comment splits one literal into two groups, and the file PASSES while the halves sit at different columns', () => {
+            const {status, output} = run(write('split.mjs', SPLIT));
+
+            // The defect, stated as the checker sees it: this is a pass. The two halves align to
+            // columns 23 and 21 and neither group is internally wrong, so there is nothing to report
+            // under the group rule — which is exactly why the notice has to exist.
+            expect(status).toBe(0);
+            expect(output).toContain('an alignment group starts here');
+            expect(output).toMatch(/split\.mjs:5/)
+        });
+
+        test('CONTROL: the same literal WITHOUT the comment is reported as misaligned', () => {
+            // Without this, "the checker notices the split" is equally consistent with a checker that
+            // cannot see the literal at all. The only difference between the two fixtures is the
+            // comment line.
+            const {status, output} = run(write('joined.mjs', SPLIT.split('\n').filter(line => !line.includes('prose about')).join('\n')));
+
+            expect(status).toBe(1);
+            expect(output).toContain('Misaligned object-literal colon')
+        });
+
+        test('CONTROL: a blank-line separation is deliberate and draws no notice', () => {
+            // A blank line is how an author separates groups on purpose. Reporting it would make the
+            // notice noise, and a notice that fires on intent gets tuned out before it ever fires on
+            // an accident.
+            const {status, output} = run(write('blank.mjs', SPLIT.replace('    // prose about the next key', '')));
+
+            expect(status).toBe(0);
+            expect(output).not.toContain('an alignment group starts here')
+        });
+
+        test('a violation names WHICH group of how many, because the column alone cannot say', () => {
+            const {status, output} = run(write('two.mjs', [
+                'const a = {',
+                '    one  : 1,',
+                '    two  : 2',
+                '};',
+                '',
+                'const b = {',
+                '    alpha        : 1,',
+                '    beta: 2',
+                '};'
+            ].join('\n')));
+
+            expect(status).toBe(1);
+            expect(output).toContain('(group 1 of 2)');
+            expect(output).toContain('(group 2 of 2)')
+        });
+
+        test('a single group is not labelled — "group 1 of 1" would be noise', () => {
+            const {output} = run(write('one.mjs', ['const a = {', '    one  : 1,', '    two: 2', '};'].join('\n')));
+
+            expect(output).toContain('Misaligned object-literal colon');
+            expect(output).not.toContain('group 1 of 1')
+        })
     });
 
     test.describe('v1b: object-colon + `=` alignment (#13563)', () => {

--- a/test/playwright/unit/ai/buildScripts/util/check-block-alignment.spec.mjs
+++ b/test/playwright/unit/ai/buildScripts/util/check-block-alignment.spec.mjs
@@ -170,7 +170,38 @@ test.describe('check-block-alignment.mjs (#13556)', () => {
             expect(output).toContain('(group 2 of 2)')
         });
 
-        test('a single group is not labelled — "group 1 of 1" would be noise', () => {
+        test('IMPORT groups name themselves too — the unit contract is not object-colon only', () => {
+        // The ticket says "each checker's failure output names the unit it judged". Implementing that
+        // for one of three evaluators would leave the generalized claim and the output disagreeing.
+        const {output} = run(write('imp.mjs', [
+            "import {a}        from './a.mjs';",
+            "import {bb, ccc} from './b.mjs';",
+            '',
+            'function f() {}',
+            '',
+            "import x   from './x.mjs';",
+            "import yy from './y.mjs';"
+        ].join('\n')));
+
+        expect(output).toContain('(group 1 of 2)');
+        expect(output).toContain('(group 2 of 2)')
+    });
+
+    test('ASSIGNMENT groups name themselves too', () => {
+        const {output} = run(write('asg.mjs', [
+            'const aa = 1;',
+            'const b  = 2;',
+            '',
+            'function f() {',
+            '    const ccccc = 3;',
+            '    const d = 4;',
+            '}'
+        ].join('\n')));
+
+        expect(output).toMatch(/Misaligned '='.*\(group \d of 2\)/)
+    });
+
+    test('a single group is not labelled — "group 1 of 1" would be noise', () => {
             const {output} = run(write('one.mjs', ['const a = {', '    one  : 1,', '    two: 2', '};'].join('\n')));
 
             expect(output).toContain('Misaligned object-literal colon');

--- a/test/playwright/unit/ai/buildScripts/util/check-jsdoc-types.spec.mjs
+++ b/test/playwright/unit/ai/buildScripts/util/check-jsdoc-types.spec.mjs
@@ -1,5 +1,10 @@
-import {test, expect}                            from '@playwright/test';
-import {findUnparseableTypes, extractType, inScope} from '../../../../../../buildScripts/util/check-jsdoc-types.mjs';
+import {test, expect}                                             from '@playwright/test';
+import {spawnSync}                                                from 'node:child_process';
+import path                                                       from 'node:path';
+import {fileURLToPath}                                            from 'node:url';
+import {describeScan, findUnparseableTypes, extractType, inScope} from '../../../../../../buildScripts/util/check-jsdoc-types.mjs';
+
+const scriptPath = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../../../../../../buildScripts/util/check-jsdoc-types.mjs');
 
 /**
  * Self-test for the JSDoc-type lint: the mechanical gate that stops TS-like type expressions the
@@ -68,5 +73,43 @@ test.describe('check-jsdoc-types guard', () => {
         expect(inScope('ai/config.mjs')).toBe(false);
         expect(inScope('ai/mcp/server/memory-core/config.mjs')).toBe(false);
         expect(inScope('README.md')).toBe(false)
+    })
+});
+
+test.describe('the success receipt states the scope it read', () => {
+    // This line gets QUOTED — into pull-request evidence sections, by readers who did not run it and
+    // have none of the surrounding context. A bare count then reads as coverage of THEIR diff.
+
+    test('a default run names the scope, not only a count', () => {
+        const {scope, scanned} = describeScan({supplied: 0, offered: 2048, scanned: 2048});
+
+        expect(scanned).toBe('2048 file(s)');
+        expect(scope).toContain('docs-build parse scope');
+        expect(scope).toContain('src')
+    });
+
+    test('CONTROL: a run that read NONE of the supplied files is distinguishable from one that read all', () => {
+        // The arm that stops "mentions a scope" being satisfiable by prose. Both runs exit 0 and both
+        // report zero unparseable types; only the counts separate "I checked your files" from "I
+        // checked none of them".
+        const none = describeScan({supplied: 2, offered: 2, scanned: 0}),
+              all  = describeScan({supplied: 2, offered: 2, scanned: 2});
+
+        expect(none.scanned).toBe('0 of 2 supplied file(s)');
+        expect(all.scanned).toBe('2 of 2 supplied file(s)');
+        expect(none.scanned).not.toBe(all.scanned)
+    });
+
+    test('a partially-dropped set says so — the scope filter is otherwise silent', () => {
+        expect(describeScan({supplied: 7, offered: 7, scanned: 3}).scanned).toBe('3 of 7 supplied file(s)')
+    });
+
+    test('the CLI actually emits it — a correct formatter proves nothing on its own', () => {
+        // Without this, the three arms above pin a function `main()` might never call.
+        const result = spawnSync('node', [scriptPath, 'package.json'], {encoding: 'utf8'}),
+              output = (result.stdout || '') + (result.stderr || '');
+
+        expect(output).toContain('0 of 1 supplied file(s)');
+        expect(output).toContain('docs-build parse scope')
     })
 });

--- a/test/playwright/unit/ai/buildScripts/util/check-jsdoc-types.spec.mjs
+++ b/test/playwright/unit/ai/buildScripts/util/check-jsdoc-types.spec.mjs
@@ -81,9 +81,9 @@ test.describe('the success receipt states the scope it read', () => {
     // have none of the surrounding context. A bare count then reads as coverage of THEIR diff.
 
     test('a default run names the scope, not only a count', () => {
-        const {scope, scanned} = describeScan({supplied: 0, offered: 2048, scanned: 2048});
+        const {scope, scanned} = describeScan({supplied: 0, offered: 2048, admitted: 2048, read: 2048});
 
-        expect(scanned).toBe('2048 file(s)');
+        expect(scanned).toBe('2048 file(s) read');
         expect(scope).toContain('docs-build parse scope');
         expect(scope).toContain('src')
     });
@@ -92,24 +92,60 @@ test.describe('the success receipt states the scope it read', () => {
         // The arm that stops "mentions a scope" being satisfiable by prose. Both runs exit 0 and both
         // report zero unparseable types; only the counts separate "I checked your files" from "I
         // checked none of them".
-        const none = describeScan({supplied: 2, offered: 2, scanned: 0}),
-              all  = describeScan({supplied: 2, offered: 2, scanned: 2});
+        const none = describeScan({supplied: 2, offered: 2, admitted: 0, read: 0}),
+              all  = describeScan({supplied: 2, offered: 2, admitted: 2, read: 2});
 
-        expect(none.scanned).toBe('0 of 2 supplied file(s)');
-        expect(all.scanned).toBe('2 of 2 supplied file(s)');
+        expect(none.scanned).toBe('0 of 2 supplied file(s) read');
+        expect(all.scanned).toBe('2 of 2 supplied file(s) read');
         expect(none.scanned).not.toBe(all.scanned)
     });
 
     test('a partially-dropped set says so — the scope filter is otherwise silent', () => {
-        expect(describeScan({supplied: 7, offered: 7, scanned: 3}).scanned).toBe('3 of 7 supplied file(s)')
+        expect(describeScan({supplied: 7, offered: 7, admitted: 3, read: 3}).scanned).toBe('3 of 7 supplied file(s) read');
+    });
+
+    test('an ADMITTED file that could not be opened is never counted as read', () => {
+        // Selection and IO diverge, so two counts cannot describe the run. A file admitted by scope and
+        // then failing to open warns on one line and is skipped on the next; reporting the ADMITTED
+        // count as the scanned one is a green claim about a file nobody opened — this checker's own
+        // defect, committed inside the fix for it.
+        expect(describeScan({supplied: 1, offered: 1, admitted: 1, read: 0}).scanned)
+            .toBe('0 of 1 supplied file(s) read, 1 unreadable');
+
+        expect(describeScan({supplied: 0, offered: 9, admitted: 9, read: 7}).scanned)
+            .toBe('7 file(s) read, 2 unreadable')
+    });
+
+    test('CONTROL: a fully-read run says nothing about unreadable files', () => {
+        // Without this, "names the unreadable count" is equally consistent with a suffix that is always
+        // present and therefore carries no information.
+        expect(describeScan({supplied: 2, offered: 2, admitted: 2, read: 2}).scanned).not.toContain('unreadable')
     });
 
     test('the CLI actually emits it — a correct formatter proves nothing on its own', () => {
-        // Without this, the three arms above pin a function `main()` might never call.
+        // Without this, the arms above pin a function `main()` might never call.
         const result = spawnSync('node', [scriptPath, 'package.json'], {encoding: 'utf8'}),
               output = (result.stdout || '') + (result.stderr || '');
 
-        expect(output).toContain('0 of 1 supplied file(s)');
+        expect(output).toContain('0 of 1 supplied file(s) read');
+        expect(output).toContain('docs-build parse scope')
+    });
+
+    test('the CLI does not claim to have read a missing in-scope file', () => {
+        // The reviewer falsifier, committed. `src/…` is in scope, so the path is admitted and then
+        // fails to open — previously reported as `1 of 1 supplied file(s) scanned`, exit 0.
+        const result = spawnSync('node', [scriptPath, 'src/doesNotExist17435.mjs'], {encoding: 'utf8'}),
+              output = (result.stdout || '') + (result.stderr || '');
+
+        expect(output).toContain('could not read');
+        expect(output).toContain('0 of 1 supplied file(s) read, 1 unreadable');
+        expect(output).not.toContain('1 of 1 supplied file(s) read,  0 unparseable')
+    });
+
+    test('a failure summary names the scope too — a violation list is quoted as often as a green line', () => {
+        const result = spawnSync('node', [scriptPath, '--quiet', 'src/Neo.mjs'], {encoding: 'utf8'}),
+              output = (result.stdout || '') + (result.stderr || '');
+
         expect(output).toContain('docs-build parse scope')
     })
 });

--- a/test/playwright/unit/ai/buildScripts/util/check-ticket-archaeology.spec.mjs
+++ b/test/playwright/unit/ai/buildScripts/util/check-ticket-archaeology.spec.mjs
@@ -1,23 +1,23 @@
 import {test, expect}                                                                       from '@playwright/test';
-import {execFileSync}                                                                       from 'node:child_process';
+import {execFileSync, spawnSync}                                                                          from 'node:child_process';
 import {mkdtempSync, rmSync, writeFileSync}                                                 from 'node:fs';
 import {tmpdir}                                                                             from 'node:os';
 import path                                                                                 from 'node:path';
 import {fileURLToPath}                                                                      from 'node:url';
-import {extractComment, findTicketRefs, isInScopePath, DEFAULT_SCAN_PATHS, DEFAULT_IGNORES} from '../../../../../../buildScripts/util/check-ticket-archaeology.mjs';
+import {describeRead, extractComment, findTicketRefs, isInScopePath, DEFAULT_SCAN_PATHS, DEFAULT_IGNORES} from '../../../../../../buildScripts/util/check-ticket-archaeology.mjs';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const REPO_ROOT = path.resolve(__dirname, '../../../../../..');
 const GUARD     = path.join(REPO_ROOT, 'buildScripts/util/check-ticket-archaeology.mjs');
 
 // CLI-invoked from REPO_ROOT (where node_modules resolves Commander), capturing exit code + combined output.
+// Both streams, on both paths. The failure branch already merged them; the success branch returned
+// stdout alone, so anything a PASSING run wrote to stderr was invisible to every arm here — and an
+// unreadable input warns on stderr while still exiting 0.
 const runGuard = (args, env = {}) => {
-    try {
-        const stdout = execFileSync('node', [GUARD, ...args], {cwd: REPO_ROOT, encoding: 'utf8', env: {...process.env, ...env}});
-        return {code: 0, stdout};
-    } catch (e) {
-        return {code: e.status, stdout: `${e.stdout || ''}${e.stderr || ''}`};
-    }
+    const result = spawnSync('node', [GUARD, ...args], {cwd: REPO_ROOT, encoding: 'utf8', env: {...process.env, ...env}});
+
+    return {code: result.status, stdout: `${result.stdout || ''}${result.stderr || ''}`};
 };
 
 /**
@@ -207,4 +207,28 @@ test.describe('check-ticket-archaeology CLI parser contract (#14279)', () => {
         expect(code).toBe(1);
         expect(stdout).toContain('#11111');
     });
+});
+
+test.describe('the receipt reports what was READ, not what was selected', () => {
+    test('an unreadable selected file is never counted as read', () => {
+        // Selection and IO diverge. A selected path that fails to open warns and is skipped; reporting
+        // the SELECTED count as the scanned one is a green claim about a file nobody opened.
+        expect(describeRead(0, 1)).toBe('0 file(s) read, 1 unreadable');
+        expect(describeRead(7, 9)).toBe('7 file(s) read, 2 unreadable')
+    });
+
+    test('CONTROL: a fully-read run says nothing about unreadable files', () => {
+        // Otherwise "names the unreadable count" is equally consistent with an always-present suffix,
+        // which carries no information.
+        expect(describeRead(3, 3)).toBe('3 file(s) read')
+    });
+
+    test('the CLI does not claim to have read a missing file', () => {
+        // The reviewer falsifier, committed: previously `1 file(s) scanned, 0 violations`, exit 0.
+        const {code, stdout} = runGuard(['src/doesNotExist17435.mjs']);
+
+        expect(code).toBe(0);
+        expect(stdout).toContain('could not read');
+        expect(stdout).toContain('0 file(s) read, 1 unreadable')
+    })
 });


### PR DESCRIPTION
Resolves #17396

Three checkers whose green line claimed more than they read. None of them becomes stricter — all three currently do their jobs, and the defect was what their success *communicated*.

Evidence: L2 (direct invocation of all three CLIs across the arms below, plus committed specs) → L2 achieved, no residual. This is output legibility; there is no runtime behaviour to reach for.

**`check-jsdoc-types`** printed a bare count. The scanned set is the docs-build parse scope — for a consumer of this package, a different set of files entirely. It now names that scope, and caller-supplied paths report `N of M`, because the in-scope filter was dropping the remainder **silently**: a hook handing over seven staged files and hearing about three is the same defect one layer down.

**`check-ticket-archaeology`** had the same bare count across three selections that pick wildly different sets — files changed vs a base ref, supplied staged paths, or the whole audit scope. Quoted elsewhere, all three read as "the repository is clean", and the two narrow ones are the common cases. The selection is now named on both the success and nothing-to-check lines.

**`check-block-alignment`** judges *groups* and its violations named only a column. `(group 2 of 3)` says a boundary exists above that line — the difference between a misaligned literal and a literal split in two whose halves are each internally consistent. It also gained a **notice, never a failure**, when two adjacent groups at one indent are separated by comment lines only.

## Deltas from ticket

**The receipt became an exported function.** `describeScan` moved out of `main()` because a line that gets quoted into evidence sections is a contract and should have coverage, rather than being a string no test can reach. Not in the ticket; it is what made AC-5's control pinnable.

**Two silent spots, not one.** The ticket described `check-jsdoc-types` as reporting a bare count. It also dropped caller-supplied out-of-scope paths without a word — the `N of M` form covers both.

**A blind spot in the block-alignment spec's own helper.** `run` merged stderr into `output` only on the *failure* path, so anything a **passing** run wrote to stderr was invisible to all 39 existing arms. A checker that advises about a file it does not fail is exactly that shape, and the advisory arm would have failed for a reason having nothing to do with the advisory. Fixed as part of the change; found by reading, not by a red.

**`(group 1 of 1)` is suppressed.** Naming the unit when there is only one is noise, and it would have trained readers to skip the suffix.

## Test Evidence

**Nine new arms across two specs. Every repair is pinned by an arm that dies when the repair is reverted:**

| mutation | arms that die |
|---|---|
| notice silenced | 1, alone |
| group suffix dropped | 1, alone |
| receipt reverted to a bare count | 3 of 4, including the control |

The two loudest arms:

- **The comment-split fixture is the defect stated as the checker sees it — an exit-0 pass.** Neither half is internally wrong under the group rule, so there is nothing to report; that is precisely why it needed a notice rather than a violation, and why no existing arm could have caught it.
- **The empty-intersection control.** A run that read *none* of the supplied files must be distinguishable from one that read all of them. Both exit 0, both report zero unparseable types; only the counts separate "I checked your files" from "I checked none of them". Without it, "mentions a scope" is satisfiable by prose.

Two further controls, because a notice that fires on intent gets tuned out before it ever fires on an accident: the same literal *without* the comment must still be reported, and a **blank-line** separation — how an author separates groups on purpose — must draw nothing.

One arm spawns the CLI, because a correct formatter proves nothing about whether `main()` calls it.

**Suite:** `14282 passed, 12 skipped`. A second run of the identical tree returned `1 failed` — `McpServersHealth.spec.mjs:34`, asserting `unhealthy` while this seat has a live neural-link bridge, so it reads `healthy`. Environment-sensitive, unrelated to `buildScripts/`, and already recorded by `@neo-opus-grace` as a pre-existing failure on a baseline that predates her own branch. Reporting both numbers rather than the greener one.

**Brain tier:** these specs live under `test/playwright/unit/ai/`, which the unit project routes to `unit-brain` — skipped in a body-only checkout. `npm run install-brain` arms it in seconds; I ran them rather than shipping tests I could not execute.

## Post-Merge Validation

None owed.

Instance 3's motivation is worth carrying past this PR, since it is the part that generalises: instances 1 and 2 mislead the author at the terminal, who still has the surrounding context. Instance 3 gets **pasted**, and the paste strips exactly the context that made the number honest. `@neo-opus-grace` independently found a fourth instance in her own open PR within minutes of the lane claim — `639 files, no devindex CSS emitted`, true about what she measured and quotable as something false — and rewrote it. If you own a tool whose output anyone pastes into a PR body, that line will be read by someone with none of your context, as a claim about *their* change.

## Evolution

I filed the downstream half of this as a scope defect — "the gate does not read our first-party tree" — and built the scope-widening fix. It produced 19 findings on a clean tree, which sent me to check whether they were in scope at all. A 2×2 showed the checker tracks its docs build exactly: red precisely when the build is red, green precisely when it is green. **My own premise was falsified and the scope was never wrong.** What survived is this ticket's class, which #17396 already stated in its Avoided Traps before I re-derived it.

That is also how this lane was found: the `ticket-create` live-open sweep surfaced #17396 — which I authored the day before — while I was preparing to file a parallel ticket against my own thesis.

Authored by Ada (Claude Opus 5, Claude Code). Session 356852dc-c28f-4c77-b932-f2c03075647b.
