### PR TITLE
fix(ai): let fence-only completion retain materialization proof (#17440)

### DIFF
--- a/ai/daemons/orchestrator/services/TenantRepoSyncService.mjs
+++ b/ai/daemons/orchestrator/services/TenantRepoSyncService.mjs
@@ -22,6 +22,7 @@ import {
     BOUNDED_KB_ERROR_CODE_PATTERN,
     EMBED_DISPOSITION,
     KB_VECTOR_EMBED_PROVIDER_CIRCUIT_OPEN,
+    TENANT_AWARE_CHUNK_ID_PATTERN,
     classifyEmbedDisposition,
     isDurableFenceRow,
     isEmbedFailureCode
@@ -329,12 +330,6 @@ function getAccessReadinessMaxAgeMs(repo, globalCadenceMs) {
 }
 
 /**
- * @summary Tenant-aware chunk hash, the shape a fence row's `chunkId` must carry.
- * @type {RegExp}
- */
-const CHUNK_ID_PATTERN = /^[a-f0-9]{64}$/u;
-
-/**
  * @summary Decides whether an ingestion run COMPLETED, DEFERRED, or FAILED.
  *
  * `KnowledgeBaseIngestionService.ingestSourceFiles()` is intentionally fail-soft: failures are
@@ -567,7 +562,7 @@ function buildFenceCensus(summary, dispositionValue) {
 
     const ids = [...new Set(
         rows.map(item => item.details.chunkId)
-            .filter(id => typeof id === 'string' && CHUNK_ID_PATTERN.test(id))
+            .filter(id => typeof id === 'string' && TENANT_AWARE_CHUNK_ID_PATTERN.test(id))
     )].sort();
 
     return {

--- a/ai/daemons/orchestrator/services/TenantRepoSyncService.mjs
+++ b/ai/daemons/orchestrator/services/TenantRepoSyncService.mjs
@@ -23,6 +23,7 @@ import {
     EMBED_DISPOSITION,
     KB_VECTOR_EMBED_PROVIDER_CIRCUIT_OPEN,
     classifyEmbedDisposition,
+    isDurableFenceRow,
     isEmbedFailureCode
 }                                from '../../../services/knowledge-base/helpers/embedFailureClassification.mjs';
 import {
@@ -334,54 +335,6 @@ function getAccessReadinessMaxAgeMs(repo, globalCadenceMs) {
 const CHUNK_ID_PATTERN = /^[a-f0-9]{64}$/u;
 
 /**
- * @summary The closed vocabulary of durable fence dispositions the ingestion writer emits.
- *
- * Two families share the poison store and assert DIFFERENT things — `proven-content-poison` is bad
- * content to fix, `undeliverable-at-geometry` is healthy content the current geometry cannot deliver.
- * Both are durable: no amount of coming back changes either at the current generation. They stay
- * separately named here for the same reason `IngestionService` writes them separately — telling an
- * operator to fix a file whose only fault is the plane's ceiling is the confusion worth preventing.
- * @type {Set<String>}
- */
-const FENCE_DISPOSITIONS = Object.freeze(new Set(['proven-content-poison', 'undeliverable-at-geometry']));
-
-/**
- * @summary Decides whether one error row is a DURABLE FENCE rather than live work.
- *
- * **The code alone cannot answer this, which is why the row's details are read at all.** An
- * undeliverable fence could be recognised by its code because that code is minted only at
- * graduation; a content poison carries the ORIGINAL embed-domain code it failed with, so
- * `KB_VECTOR_EMBED_TIMEOUT` is a fence row on one sweep and a live failure on the next. The
- * disposition is the writer's own assertion about which, and it is the only thing that knows.
- *
- * **`classifyIngestionOutcome` reads codes only, deliberately — `details` is unvalidated free
- * shape.** So this read takes the same gate a code gets, and all three clauses are load-bearing:
- * a closed vocabulary (not merely "a string is present"), coherence between `details.reasonCode`
- * and the top-level `code` (the writer assigns both from one local, so disagreement means the row
- * did not come from this contract), and the same bounded id gate the census applies.
- *
- * Every clause fails toward LIVE. A missing, malformed, unknown, or incoherent row keeps its run
- * deferring exactly as today — the direction where a wrong answer costs a wasted sweep rather than
- * a checkpoint advanced over work that never landed.
- *
- * @param {Object} item One `summary.errors` row.
- * @returns {Boolean}
- * @private
- */
-function isDurableFenceRow(item) {
-    const details = item?.details;
-
-    if (!details || typeof details !== 'object' || Array.isArray(details)) {
-        return false;
-    }
-
-    return FENCE_DISPOSITIONS.has(details.disposition)
-        && details.reasonCode === item.code
-        && typeof details.chunkId === 'string'
-        && CHUNK_ID_PATTERN.test(details.chunkId);
-}
-
-/**
  * @summary Decides whether an ingestion run COMPLETED, DEFERRED, or FAILED.
  *
  * `KnowledgeBaseIngestionService.ingestSourceFiles()` is intentionally fail-soft: failures are
@@ -601,7 +554,7 @@ export const UNDELIVERABLE_CENSUS_MAX_IDS = 32;
  * no signal at all. `null` means "no census observed" (no rows of this family), never "zero measured".
  *
  * @param {Object}   summary   Ingestion summary returned by the run.
- * @param {String}   dispositionValue The {@link FENCE_DISPOSITIONS} member selecting one family.
+ * @param {String}   dispositionValue One closed durable-fence disposition selecting a family.
  * @returns {{count: Number, ids: String[]}|null}
  */
 function buildFenceCensus(summary, dispositionValue) {
@@ -673,7 +626,8 @@ function isMatchingMaterializationReceipt(receipt, expectedDigest) {
  * Incremental envelopes have no manifest and may remain healthy zero-delta checkpoints.
  *
  * @param {Object} envelope Tenant-repo ingestion envelope.
- * @param {Object} summary Validated error-free ingestion summary.
+ * @param {Object} summary Validated completion-compatible ingestion summary. May carry coherent
+ *     durable-fence rows; those remain operator evidence while no longer representing live work.
  * @param {Object|null} priorState Previous durable checkpoint.
  * @param {Object|null} materializationAttempt Current opaque full-attempt identity.
  * @returns {Object|null} Receipt to acknowledge in the final checkpoint.
@@ -2047,7 +2001,7 @@ class TenantRepoSyncService extends Base {
         // healthy and making progress, while a sweep where every repo deferred is a lane in trouble.
         // Folding them would make the two indistinguishable in the one number an operator reads.
         let partialProgressCount = 0;
-        let   abortedCount   = 0;
+        let abortedCount         = 0;
 
         // Per-runTask concurrency gate caps simultaneous git/ingest work.
         // Fresh instance per call so live `concurrencyLimit` / `concurrencyGateTimeoutMs`

--- a/ai/services/knowledge-base/IngestionService.mjs
+++ b/ai/services/knowledge-base/IngestionService.mjs
@@ -25,6 +25,7 @@ import {
     classifyEmbedFailureCode,
     classifyEmbedFailureError,
     classifyEmbedResidencyDisposition,
+    isDurableFenceRow,
     isEmbedFailureCode
 }
                             from './helpers/embedFailureClassification.mjs';
@@ -320,10 +321,10 @@ class IngestionService extends Base {
                     // `embedChunks` on its `() => false` default, so a caller that supplies no
                     // budget behaves exactly as it does today.
                     shouldYield: controls.shouldYield,
-                    signal               : controls.signal,
+                    signal     : controls.signal,
                     tenantContext,
                     summary,
-                    viaMcp               : payload.viaMcp !== false
+                    viaMcp     : payload.viaMcp !== false
                 });
             }
 
@@ -751,9 +752,9 @@ class IngestionService extends Base {
             // not yield" from "this summary predates the field" — an absent boolean reads as false
             // and would let a stale producer look like a complete run.
             yielded   : false,
-            errors             : [],
-            tenantId           : aiConfig.defaultTenantId,
-            durationMs         : Date.now() - startedAt
+            errors    : [],
+            tenantId  : aiConfig.defaultTenantId,
+            durationMs: Date.now() - startedAt
         };
     }
 
@@ -1202,6 +1203,18 @@ class IngestionService extends Base {
         // whether a prior receipt existed to fall back on — the branch that distinguishes
         // "first materialization" from "retry whose prior proof did not match".
         let priorReceiptPresent = false;
+        // Method-scoped because the no-receipt diagnostic below must report the same decision that
+        // gated mint/reuse. Computing it once before the attempt block keeps every no-receipt path
+        // attributable before `setTenantManifest` clears stale proof.
+        const
+            durableFenceOnly      = summary.errors.length > 0
+                && summary.errors.every(isDurableFenceRow),
+            receiptErrorsComplete = summary.errors.length === 0 || durableFenceOnly,
+            // Preserve the pre-existing clean-summary retry behavior, including its yielded shape.
+            // The new fence-only extension is narrower: a yielded fence summary is still incomplete
+            // and must not borrow prior full-materialization proof.
+            receiptReuseCompatible = summary.errors.length === 0
+                || (durableFenceOnly && summary.yielded !== true);
 
         if (attempt) {
             const
@@ -1225,7 +1238,7 @@ class IngestionService extends Base {
                 //
                 // This does NOT weaken crash-after-complete recovery: a run that exhausted its
                 // corpus reports `yielded: false` and mints exactly as before.
-                hasEffect      = summary.errors.length === 0
+                hasEffect      = receiptErrorsComplete
                     && summary.yielded !== true
                     && [summary.ingested, summary.deleted]
                         .some(value => Number.isSafeInteger(value) && value > 0);
@@ -1240,7 +1253,7 @@ class IngestionService extends Base {
                     recordedAt           : Date.now()
                 };
             } else if (
-                summary.errors.length === 0
+                receiptReuseCompatible
                 && existing.materializationReceipt?.ingestContractVersion === attempt.ingestContractVersion
                 && existing.materializationReceipt.envelopeDigest === envelopeDigest
             ) {
@@ -1295,6 +1308,7 @@ class IngestionService extends Base {
                 ingested                     : summary.ingested,
                 deleted                      : summary.deleted,
                 errorCount                   : summary.errors.length,
+                durableFenceOnly,
                 priorReceiptPresent
             });
         }

--- a/ai/services/knowledge-base/IngestionService.mjs
+++ b/ai/services/knowledge-base/IngestionService.mjs
@@ -22,6 +22,7 @@ import {resolveEmbeddingAdmissionBand}
 import {
     KB_VECTOR_EMBED_UNCLASSIFIED,
     KB_VECTOR_EMBED_UNDELIVERABLE_AT_GEOMETRY,
+    TENANT_AWARE_CHUNK_ID_PATTERN,
     classifyEmbedFailureCode,
     classifyEmbedFailureError,
     classifyEmbedResidencyDisposition,
@@ -81,7 +82,6 @@ export function resolveIdleProgressStatus(lastRunSummary) {
 
 const MATERIALIZATION_ATTEMPT_ID_PATTERN = /^[a-f0-9]{32}$/u;
 const MATERIALIZATION_DIGEST_PATTERN     = /^[a-f0-9]{64}$/u;
-const TENANT_AWARE_CHUNK_ID_PATTERN      = /^[a-f0-9]{64}$/u;
 
 /**
  * @summary Re-validates a graduation receipt carried on an embed failure into exactly four bounded fields.

--- a/ai/services/knowledge-base/helpers/embedFailureClassification.mjs
+++ b/ai/services/knowledge-base/helpers/embedFailureClassification.mjs
@@ -99,10 +99,14 @@ const DURABLE_FENCE_DISPOSITIONS = Object.freeze(new Set([
 ]));
 
 /**
- * @summary Tenant-aware chunk hash carried by every durable fence row.
+ * @summary Canonical serialized shape of a tenant-aware chunk id at fence writer/reader boundaries.
+ *
+ * `IngestionService.createChunkHash()` puts tenant awareness inside the hash inputs; the serialized
+ * id remains one bare SHA-256 hex. Keeping that rule beside the durable-fence contract gives its
+ * writers and readers one authority.
  * @type {RegExp}
  */
-const DURABLE_FENCE_CHUNK_ID_PATTERN = /^[a-f0-9]{64}$/u;
+export const TENANT_AWARE_CHUNK_ID_PATTERN = /^[a-f0-9]{64}$/u;
 
 /**
  * @summary Decides whether one ingestion error row is a validated durable fence rather than live work.
@@ -132,7 +136,7 @@ export function isDurableFenceRow(item) {
         && DURABLE_FENCE_DISPOSITIONS.has(details.disposition)
         && details.reasonCode === item.code
         && typeof details.chunkId === 'string'
-        && DURABLE_FENCE_CHUNK_ID_PATTERN.test(details.chunkId);
+        && TENANT_AWARE_CHUNK_ID_PATTERN.test(details.chunkId);
 }
 
 /**

--- a/ai/services/knowledge-base/helpers/embedFailureClassification.mjs
+++ b/ai/services/knowledge-base/helpers/embedFailureClassification.mjs
@@ -86,6 +86,56 @@ export const KB_VECTOR_EMBED_PROVIDER_CIRCUIT_OPEN = 'KB_VECTOR_EMBED_PROVIDER_C
 export const KB_VECTOR_EMBED_UNDELIVERABLE_AT_GEOMETRY = 'KB_VECTOR_EMBED_UNDELIVERABLE_AT_GEOMETRY';
 
 /**
+ * @summary The writer-owned durable-fence vocabulary carried by ingestion error rows.
+ *
+ * These values are dispositions, not causes: a content poison and a geometry fence retain their
+ * original bounded failure code so diagnostics still explain WHY the chunk was fenced. The
+ * disposition is what says the row is no longer live work at the current generation.
+ * @type {Set<String>}
+ */
+const DURABLE_FENCE_DISPOSITIONS = Object.freeze(new Set([
+    'proven-content-poison',
+    'undeliverable-at-geometry'
+]));
+
+/**
+ * @summary Tenant-aware chunk hash carried by every durable fence row.
+ * @type {RegExp}
+ */
+const DURABLE_FENCE_CHUNK_ID_PATTERN = /^[a-f0-9]{64}$/u;
+
+/**
+ * @summary Decides whether one ingestion error row is a validated durable fence rather than live work.
+ *
+ * The code alone cannot answer this: content-poison rows retain an ordinary embed-domain cause that
+ * can also describe a live failure. Reading the writer-owned disposition is safe only with all four
+ * gates applied together: embed-domain membership, closed disposition vocabulary, reason-code
+ * coherence, and the tenant-aware chunk-id shape. Every malformed or foreign row fails toward LIVE
+ * work, so neither outcome classification nor materialization proof can silently complete an
+ * ambiguous corpus.
+ *
+ * This predicate is shared by the tenant outcome classifier and the materialization-receipt writer.
+ * Two spellings could otherwise classify one summary complete while withholding the proof that
+ * completion requires.
+ *
+ * @param {*} item Candidate `summary.errors` row.
+ * @returns {Boolean} True only for a coherent writer-owned durable fence row.
+ */
+export function isDurableFenceRow(item) {
+    const details = item?.details;
+
+    if (!details || typeof details !== 'object' || Array.isArray(details)) {
+        return false;
+    }
+
+    return isEmbedFailureCode(item?.code)
+        && DURABLE_FENCE_DISPOSITIONS.has(details.disposition)
+        && details.reasonCode === item.code
+        && typeof details.chunkId === 'string'
+        && DURABLE_FENCE_CHUNK_ID_PATTERN.test(details.chunkId);
+}
+
+/**
  * @summary Bounded cause for a transport that closed mid-request — the provider stopped answering
  * rather than answering slowly.
  *
@@ -134,8 +184,8 @@ const INTERNAL_EMBED_ERROR_CODES = Object.freeze(new Set([
  * @type {Object}
  */
 const PROVIDER_ERROR_CODE_MAP = Object.freeze({
-    ABORT_ERR                        : 'KB_VECTOR_EMBED_ABORTED',
-    ECONNREFUSED                     : 'KB_VECTOR_EMBED_CONNECTION_REFUSED',
+    ABORT_ERR   : 'KB_VECTOR_EMBED_ABORTED',
+    ECONNREFUSED: 'KB_VECTOR_EMBED_CONNECTION_REFUSED',
     // Three vocabularies for one event: the peer reset the connection (`ECONNRESET`), we wrote to a
     // socket the peer had already closed (`EPIPE`), or undici observed the socket end mid-request
     // (`UND_ERR_SOCKET`). All three mean a live process took the request and stopped existing, which

--- a/test/playwright/unit/ai/daemons/orchestrator/services/TenantRepoSyncService.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/services/TenantRepoSyncService.spec.mjs
@@ -683,6 +683,121 @@ test.describe('TenantRepoSyncService (#11790)', () => {
         expect(bothRowOut.undeliverableChunks).toEqual({count: 1, ids: [monsterId]});
     });
 
+    test('a fence-only REAL receipt writer proves completion through runTask (#17440)', async () => {
+        const
+            {default: IngestionService} = await import(
+                '../../../../../../../ai/services/knowledge-base/IngestionService.mjs'
+            ),
+            taskStateService = createInMemoryTaskStateService(),
+            manifests        = new Map(),
+            repoSlug         = 'org/real-fence-receipt',
+            poisonId         = '9'.repeat(64),
+            monsterId        = '8'.repeat(64),
+            poisonRow        = {
+                code   : 'KB_VECTOR_EMBED_TIMEOUT',
+                message: 'A proven embedding poison remains fenced.',
+                details: {
+                    chunkId    : poisonId,
+                    reasonCode : 'KB_VECTOR_EMBED_TIMEOUT',
+                    disposition: 'proven-content-poison'
+                }
+            },
+            geometryRow      = {
+                code   : 'KB_VECTOR_EMBED_UNDELIVERABLE_AT_GEOMETRY',
+                message: 'A chunk remains fenced at the current geometry.',
+                details: {
+                    chunkId    : monsterId,
+                    reasonCode : 'KB_VECTOR_EMBED_UNDELIVERABLE_AT_GEOMETRY',
+                    disposition: 'undeliverable-at-geometry'
+                }
+            },
+            receiptWriter = {
+                normalizeManifestSnapshot      : IngestionService.normalizeManifestSnapshot.bind(IngestionService),
+                normalizeMaterializationAttempt: IngestionService.normalizeMaterializationAttempt.bind(IngestionService),
+                async getTenantManifest({tenantId, repoSlug}) {
+                    return manifests.get(`${tenantId}/${repoSlug}`) || {
+                        tenantId, repoSlug, materializationReceipt: null
+                    }
+                },
+                async setTenantManifest({tenantId, repoSlug, pathsAfterPush, materializationReceipt}) {
+                    const value = {tenantId, repoSlug, pathsAfterPush, materializationReceipt};
+
+                    manifests.set(`${tenantId}/${repoSlug}`, value);
+                    return value
+                }
+            },
+            ingestionService = {
+                getTenantManifest: receiptWriter.getTenantManifest.bind(receiptWriter),
+                async ingestSourceFiles(payload) {
+                    const summary = {
+                        ingested           : 1,
+                        deleted            : 0,
+                        embeddingsGenerated: 1,
+                        errors             : [{...poisonRow}, {...geometryRow}],
+                        tenantId           : payload.tenantId,
+                        durationMs         : 1,
+                        yielded            : false
+                    };
+
+                    await IngestionService.persistManifestSnapshot.call(receiptWriter, {
+                        manifestSnapshot      : payload.manifestSnapshot,
+                        files                 : payload.files,
+                        headRevision          : payload.headRevision,
+                        materializationAttempt: payload.materializationAttempt,
+                        tenantContext         : {tenantId: payload.tenantId, repoSlug: payload.repoSlug},
+                        summary
+                    });
+
+                    return summary
+                }
+            };
+
+        await provisionMirrorDir({tenantId: 't1', repoSlug});
+
+        const result = await TenantRepoSyncService.runTask({
+            reason           : 'periodic-sweep:60000',
+            taskStateService,
+            tenantReposConfig: {tenantRepos: [{
+                tenantId: 't1', repoSlug, mirrorRoot, cloneUrl: 'https://github.com/neomjs/real-fence-receipt.git'
+            }]},
+            gitMirror                    : makeFakeGitMirror(),
+            envelopeBuilder              : makeFakeEnvelopeBuilder({includeManifest: true}),
+            knowledgeBaseIngestionService: ingestionService,
+            revisionsFilePath            : revisionsFile,
+            globalCadenceMs              : 60_000,
+            jitterRatio                  : 0,
+            backoffCapMs                 : 60_000,
+            seedBootstrap                : false
+        });
+
+        const
+            persisted = (await fs.readJson(revisionsFile)).revisions[`t1/${repoSlug}`],
+            manifest  = manifests.get(`t1/${repoSlug}`);
+
+        expect(result).toMatchObject({
+            status : 'completed',
+            details: {
+                completedCount: 1,
+                failedCount   : 0,
+                repos         : [{
+                    repoSlug,
+                    status             : 'active',
+                    contentPoisonChunks: {count: 1, ids: [poisonId]},
+                    undeliverableChunks: {count: 1, ids: [monsterId]}
+                }]
+            }
+        });
+        expect(persisted.lastIngestedRev).toBe(`sha-head-${repoSlug}`);
+        expect(persisted.contentPoisonChunks).toEqual({count: 1, ids: [poisonId]});
+        expect(persisted.undeliverableChunks).toEqual({count: 1, ids: [monsterId]});
+        expect(manifest.materializationReceipt).toMatchObject({
+            ingestContractVersion: TENANT_REPO_INGEST_CONTRACT_VERSION,
+            envelopeDigest       : expect.stringMatching(/^[a-f0-9]{64}$/u)
+        });
+        expect(persisted.lastCommittedMaterializationAttemptId)
+            .toBe(manifest.materializationReceipt.attemptId);
+    });
+
     test('a live row sharing a fence code still defers, and the retained cause is the LIVE one (#17139)', async () => {
         const
             taskStateService = createInMemoryTaskStateService(),

--- a/test/playwright/unit/ai/services/knowledge-base/IngestionService.spec.mjs
+++ b/test/playwright/unit/ai/services/knowledge-base/IngestionService.spec.mjs
@@ -20,6 +20,10 @@ import Neo            from '../../../../../../src/Neo.mjs';
 import * as core      from '../../../../../../src/core/_export.mjs';
 import fs             from 'fs-extra';
 import aiConfig       from '../../../../../../ai/mcp/server/knowledge-base/config.template.mjs';
+import {
+    KB_VECTOR_EMBED_UNDELIVERABLE_AT_GEOMETRY,
+    classifyEmbedFailureCode
+} from '../../../../../../ai/services/knowledge-base/helpers/embedFailureClassification.mjs';
 import {createTenantRepoMaterializationDigest}
     from '../../../../../../ai/services/knowledge-base/helpers/tenantRepoIngestEnvelopeBuilder.mjs';
 
@@ -1252,6 +1256,13 @@ test.describe('IngestionService.ingestSourceFiles', () => {
 test.describe('IngestionService.persistManifestSnapshot receipt-absence diagnostic', () => {
     let Service, logger, originalWarn, warnings;
 
+    const chunkId = 'a'.repeat(64);
+
+    const durableFence = (disposition, code=classifyEmbedFailureCode('EMBEDDING_PROBE_TIMEOUT')) => ({
+        code,
+        details: {chunkId, disposition, reasonCode: code}
+    });
+
     test.beforeAll(async () => {
         Service = (await import('../../../../../../ai/services/knowledge-base/IngestionService.mjs')).default;
         logger  = (await import('../../../../../../ai/mcp/server/knowledge-base/logger.mjs')).default;
@@ -1362,6 +1373,148 @@ test.describe('IngestionService.persistManifestSnapshot receipt-absence diagnost
             afterComplete?.materializationReceipt ?? null,
             'a run that exhausted its corpus must still mint — the veto is scoped to yielded runs'
         ).toBeTruthy();
+    });
+
+    test('validated fence-only summaries mint positive-effect proof for both fence families (#17440)', async () => {
+        const cases = [
+            ['content-poison', durableFence('proven-content-poison')],
+            ['undeliverable', durableFence(
+                'undeliverable-at-geometry',
+                KB_VECTOR_EMBED_UNDELIVERABLE_AT_GEOMETRY
+            )]
+        ];
+
+        for (const [repoSlug, error] of cases) {
+            const attempt = {
+                attemptId            : (repoSlug === 'content-poison' ? 'd' : 'e').repeat(32),
+                ingestContractVersion: 2
+            };
+
+            await Service.persistManifestSnapshot({
+                manifestSnapshot      : {repoSlug, pathsAfterPush: ['fenced.txt']},
+                files                 : [{sourcePath: 'fenced.txt', repoSlug, content: 'fenced'}],
+                headRevision          : `sha-${repoSlug}`,
+                materializationAttempt: attempt,
+                tenantContext         : {tenantId: 'fence-tenant', repoSlug},
+                summary               : {ingested: 1, deleted: 0, errors: [error], yielded: false}
+            });
+
+            const stored = await Service.getTenantManifest({tenantId: 'fence-tenant', repoSlug});
+
+            expect(stored.materializationReceipt).toMatchObject(attempt);
+            expect(stored.materializationReceipt.envelopeDigest).toMatch(/^[a-f0-9]{64}$/u);
+        }
+    });
+
+    test('a live or malformed row beside durable fences vetoes proof (#17440)', async () => {
+        const cases = [
+            ['mixed-live', [
+                durableFence('proven-content-poison'),
+                {code: classifyEmbedFailureCode('EMBEDDING_PROBE_TIMEOUT')}
+            ]],
+            ['malformed-fence', [{
+                ...durableFence('proven-content-poison'),
+                details: {
+                    ...durableFence('proven-content-poison').details,
+                    reasonCode: 'KB_VECTOR_EMBED_PROVIDER_TIMEOUT'
+                }
+            }]],
+            ['unknown-disposition', [{
+                ...durableFence('proven-content-poison'),
+                details: {...durableFence('proven-content-poison').details, disposition: 'foreign-fence'}
+            }]],
+            ['invalid-chunk-id', [{
+                ...durableFence('proven-content-poison'),
+                details: {...durableFence('proven-content-poison').details, chunkId: 'not-a-hash'}
+            }]],
+            ['missing-details', [{code: classifyEmbedFailureCode('EMBEDDING_PROBE_TIMEOUT')}]]
+        ];
+
+        for (const [repoSlug, errors] of cases) {
+            await Service.persistManifestSnapshot({
+                manifestSnapshot      : {repoSlug, pathsAfterPush: ['blocked.txt']},
+                files                 : [{sourcePath: 'blocked.txt', repoSlug, content: 'blocked'}],
+                headRevision          : `sha-${repoSlug}`,
+                materializationAttempt: {attemptId: 'f'.repeat(32), ingestContractVersion: 2},
+                tenantContext         : {tenantId: 'fence-tenant', repoSlug},
+                summary               : {ingested: 1, deleted: 0, errors, yielded: false}
+            });
+
+            const stored = await Service.getTenantManifest({tenantId: 'fence-tenant', repoSlug});
+
+            expect(stored.materializationReceipt ?? null).toBeNull();
+        }
+    });
+
+    test('yield remains a hard receipt veto for a validated fence-only summary (#17440)', async () => {
+        const
+            repoSlug = 'yielded-fence',
+            envelope = {
+                manifestSnapshot: {repoSlug, pathsAfterPush: ['pending.txt']},
+                files           : [{sourcePath: 'pending.txt', repoSlug, content: 'pending'}],
+                headRevision    : 'sha-yielded-fence',
+                tenantContext   : {tenantId: 'fence-tenant', repoSlug}
+            };
+
+        // Seed matching complete proof. Without this setup, the second call can only test fresh
+        // mint; deleting the fence-only REUSE veto would stay green.
+        await Service.persistManifestSnapshot({
+            ...envelope,
+            materializationAttempt: {attemptId: '0'.repeat(32), ingestContractVersion: 2},
+            summary               : {ingested: 1, deleted: 0, errors: [], yielded: false}
+        });
+
+        expect((await Service.getTenantManifest({
+            tenantId: 'fence-tenant', repoSlug
+        })).materializationReceipt).toBeTruthy();
+
+        await Service.persistManifestSnapshot({
+            ...envelope,
+            materializationAttempt: {attemptId: '1'.repeat(32), ingestContractVersion: 2},
+            summary               : {
+                ingested: 1,
+                deleted : 0,
+                errors  : [durableFence('proven-content-poison')],
+                yielded : true
+            }
+        });
+
+        const stored = await Service.getTenantManifest({tenantId: 'fence-tenant', repoSlug});
+
+        expect(stored.materializationReceipt ?? null).toBeNull();
+    });
+
+    test('a fence-only retry reuses matching completed proof (#17440)', async () => {
+        const
+            repoSlug = 'fence-retry',
+            envelope = {
+                manifestSnapshot: {repoSlug, pathsAfterPush: ['settled.txt']},
+                files           : [{sourcePath: 'settled.txt', repoSlug, content: 'settled'}],
+                headRevision    : 'sha-fence-retry',
+                tenantContext   : {tenantId: 'fence-tenant', repoSlug}
+            },
+            firstAttempt = {attemptId: '2'.repeat(32), ingestContractVersion: 2};
+
+        await Service.persistManifestSnapshot({
+            ...envelope,
+            materializationAttempt: firstAttempt,
+            summary               : {ingested: 1, deleted: 0, errors: [], yielded: false}
+        });
+
+        await Service.persistManifestSnapshot({
+            ...envelope,
+            materializationAttempt: {attemptId: '3'.repeat(32), ingestContractVersion: 2},
+            summary               : {
+                ingested: 0,
+                deleted : 0,
+                errors  : [durableFence('proven-content-poison')],
+                yielded : false
+            }
+        });
+
+        const stored = await Service.getTenantManifest({tenantId: 'fence-tenant', repoSlug});
+
+        expect(stored.materializationReceipt).toMatchObject(firstAttempt);
     });
 });
 

--- a/test/playwright/unit/ai/services/knowledge-base/embedFailureClassification.spec.mjs
+++ b/test/playwright/unit/ai/services/knowledge-base/embedFailureClassification.spec.mjs
@@ -12,10 +12,12 @@ import {
     EMBED_DISPOSITION,
     KB_VECTOR_EMBED_PROVIDER_CIRCUIT_OPEN,
     KB_VECTOR_EMBED_UNCLASSIFIED,
+    KB_VECTOR_EMBED_UNDELIVERABLE_AT_GEOMETRY,
     classifyEmbedDisposition,
     classifyEmbedFailureCode,
     classifyEmbedFailureError,
     classifyEmbedResidencyDisposition,
+    isDurableFenceRow,
     isEmbedFailureCode,
     KB_VECTOR_EMBED_TRANSPORT_CLOSED,
     isProviderDeathError
@@ -215,6 +217,40 @@ test.describe('embed failure classification (#16647)', () => {
 
         // Non-vacuity: if the list above were ever emptied, the loop would pass by iterating nothing.
         expect(providerCodes.length).toBeGreaterThan(0);
+    });
+});
+
+test.describe('isDurableFenceRow (#17139, #17440)', () => {
+    const chunkId = 'a'.repeat(64);
+
+    const fence = (disposition, code='KB_VECTOR_EMBED_TIMEOUT') => ({
+        code,
+        details: {chunkId, disposition, reasonCode: code}
+    });
+
+    test('accepts both writer-owned durable fence families', () => {
+        expect(isDurableFenceRow(fence('proven-content-poison'))).toBe(true);
+        expect(isDurableFenceRow(fence(
+            'undeliverable-at-geometry',
+            KB_VECTOR_EMBED_UNDELIVERABLE_AT_GEOMETRY
+        ))).toBe(true);
+    });
+
+    test('every malformed or incoherent clause fails toward live work', () => {
+        const valid = fence('proven-content-poison');
+
+        for (const candidate of [
+            null,
+            {},
+            {...valid, details: null},
+            {...valid, details: []},
+            {details: {chunkId, disposition: 'proven-content-poison'}},
+            {...valid, details: {...valid.details, disposition: 'foreign-fence'}},
+            {...valid, details: {...valid.details, reasonCode: 'KB_VECTOR_EMBED_PROVIDER_TIMEOUT'}},
+            {...valid, details: {...valid.details, chunkId: 'not-a-tenant-aware-hash'}}
+        ]) {
+            expect(isDurableFenceRow(candidate)).toBe(false);
+        }
     });
 });
 


### PR DESCRIPTION
Resolves #17440

Fence-only tenant materializations now retain the digest-bound proof that the completion classifier requires. The receipt writer and tenant outcome classifier consume one fail-closed durable-fence predicate, while live, malformed, ambiguous, and newly extended yielded fence rows still veto completion proof. The production `runTask` composition now demonstrates that both fence censuses remain visible while the checkpoint advances with a matching receipt.

Evidence: L2 (real `IngestionService.persistManifestSnapshot()` plus tenant `runTask` composition in the focused Brain unit harness) → L2 required (all close-target ACs are service-level behavior reachable in that harness). No residuals.

Related: #17139

## Deltas from ticket

None substantive. Extracting the predicate made the predecessor classifier's implicit embed-domain precondition explicit so the helper remains fail-closed when consumed independently. Authoritative empty-manifest minting stays clean-only, and the pre-existing clean-summary retry contract is unchanged; the new fence-only mint/reuse path is non-yielded only.

## Test Evidence

- `npm run test-unit -- test/playwright/unit/ai/services/knowledge-base/embedFailureClassification.spec.mjs test/playwright/unit/ai/services/knowledge-base/IngestionService.spec.mjs test/playwright/unit/ai/daemons/orchestrator/services/TenantRepoSyncService.spec.mjs` — 267 passed.
- `node --check` on all three changed source modules and all three changed specs — passed.
- `npm run agent-preflight -- --no-fix --change-class restoration --commit-subject "fix(ai): let fence-only completion retain materialization proof (#17440)" --pr-title "fix(ai): let fence-only completion retain materialization proof (#17440)" <six changed files>` — passed before commit; pre-commit hooks also passed parse, JSDoc types, OpenAPI parity, atomic-write shape, derived-domain, ticket-archaeology, and block-alignment gates.
- `git diff --check` — passed.
- Red controls observed and restored before the final 267-test run:
  - reverting fence-compatible receipt eligibility to `errors.length === 0` failed both the direct positive-effect receipt arm and real `runTask` composition;
  - removing the embed-domain gate made the missing-code hostile row pass and failed the helper spec;
  - allowing yielded fence-only receipt reuse preserved seeded stale proof and failed the retry veto spec.
  - narrowing the sole exported tenant chunk-id authority from 64 to 63 hex characters failed the valid-fence-family arm (1 failed / 42 passed); restoring 64 left exactly one definition across both consumers and returned the full 267-test composition to green.

Directly touched surfaces:

- durable-fence predicate: both writer-owned families plus independent malformed/incoherent clause arms;
- receipt mint/reuse: both families, mixed live row, unknown disposition, reason mismatch, invalid chunk id, missing details, yielded stale-proof clearing, and matching retry reuse;
- tenant completion: real receipt writer through `TenantRepoSyncService.runTask`, checkpoint advance, both censuses, digest proof, and committed-attempt identity.

## Post-Merge Validation

- [x] None required beyond the ordinary required-CI and cross-family merge gates.

## Commits

- `409c6c1043` — compose fence-only completion with digest-bound materialization proof.
- `75c1126849` — address Cycle-1 RA by giving both fence consumers one tenant chunk-id authority.

Authored by Euclid (GPT-5.6 Sol Ultra, Codex Desktop). Session 5227e910-6f64-46da-a0d1-d6fb1cdfbb9f.
