### PR TITLE
feat(kb): a row records which format built its vector, and the stale population becomes a number (#17428)

### DIFF
--- a/ai/scripts/diagnostics/staleEmbeddingCensus.mjs
+++ b/ai/scripts/diagnostics/staleEmbeddingCensus.mjs
@@ -1,0 +1,227 @@
+#!/usr/bin/env node
+/**
+ * @module ai/scripts/diagnostics/staleEmbeddingCensus
+ * @summary Counts knowledge-base rows whose vectors were built from a superseded provider-input
+ * format, per tenant, with the cause split out. Read-only: it never writes, embeds, or deletes.
+ *
+ * ## Why this script exists rather than a query
+ *
+ * The provider input a chunk presents to the embedding provider is DERIVED and is not a member of a
+ * chunk's `hashInputs`, so changing that format leaves every chunk id unchanged. Re-ingestion
+ * recomputes the same id, finds the row present, and skips it — the stale vector survives, and no id,
+ * content or metadata comparison separates it from a correct one. `helpers/embeddingInputFormat`
+ * therefore stamps each row with the format's identity, and the ABSENCE of that stamp is what names a
+ * row written before the stamp existed.
+ *
+ * Absence is not expressible as a filter. ChromaDB has no `$exists` operator, so a row missing a key
+ * is invisible to every `where` clause that mentions it, and `$ne` fails for the same reason. This is
+ * recorded independently in `ai/scripts/migrations/backfillChromaSharedUserId.mjs`, twice in
+ * `ai/services/memory-core/MemoryService.mjs`, and in `HealthService`'s own scan
+ * (*"Chroma where-filters cannot reliably falsify absent metadata-key cases across versions"*). A
+ * filtered version of this census would report zero affected rows against a corpus full of them and
+ * read as a clean bill of health — so the scan shape is a constraint, not an implementation detail.
+ *
+ * ## What the numbers mean
+ *
+ * `scanned` is every row read. `stale` splits into `pre-marker` (the field is absent — written before
+ * the stamp existed) and `format-changed` (present but naming a superseded format). `current` is the
+ * remainder, and `scanned === stale + current` always holds, so a row can never be silently dropped
+ * between two runs. Ids are capped and a truncated list says so: a capped list that read as complete
+ * would let a repair stop early while reporting success.
+ *
+ * Detection is O(corpus) metadata reads. The targeting this buys is in what gets RE-EMBEDDED, never
+ * in what gets scanned — a ~87k-chunk corpus is ~44 pages of metadata against days of provider
+ * compute for a full rebuild.
+ *
+ * Usage:
+ *   node ai/scripts/diagnostics/staleEmbeddingCensus.mjs                    # every tenant
+ *   node ai/scripts/diagnostics/staleEmbeddingCensus.mjs --tenant <id>      # one tenant
+ *   node ai/scripts/diagnostics/staleEmbeddingCensus.mjs --ids <n>          # id cap per tenant (default 20)
+ *   node ai/scripts/diagnostics/staleEmbeddingCensus.mjs --json <path>      # also write the census as JSON
+ *   node ai/scripts/diagnostics/staleEmbeddingCensus.mjs --help
+ */
+
+// The Neo class system first: every `ai/services/**` module is a `Neo.setupClass` class, and
+// `ai/Env.mjs` gatekeeps at module scope, so a service import before this line throws
+// `ReferenceError: Neo is not defined`. Two lines, and they are the convention every
+// service-touching script under `ai/scripts/**` already follows.
+import Neo                           from '../../../src/Neo.mjs';
+import                                    '../../../src/core/_export.mjs';
+
+import {EMBEDDING_INPUT_FORMAT_ID}   from '../../services/knowledge-base/helpers/embeddingInputFormat.mjs';
+import {
+    emptyStaleEmbeddingCensus,
+    foldStaleEmbeddingCensus,
+    mergeStaleEmbeddingCensus
+}                                    from '../../services/knowledge-base/helpers/staleEmbeddingCensus.mjs';
+import ChromaManager from '../../services/knowledge-base/ChromaManager.mjs';
+import fs            from 'fs-extra';
+
+// `ChromaManager` rather than a raw `chromadb` client, deliberately. The migration scripts under
+// `ai/scripts/migrations/` construct their own client because they must target arbitrary hosts; this
+// diagnostic reads the deployment it runs on, so going through the service layer inherits its
+// connection retry, collection-swap awareness and collection-not-found handling instead of
+// reimplementing three of them badly.
+
+const PAGE_SIZE = 2000;
+
+/**
+ * Parses the flags this script accepts, refusing anything it does not understand.
+ *
+ * Refuses rather than ignores: a mistyped `--tenant` silently censusing every tenant would report a
+ * number the operator did not ask for, and they would have no way to tell from the output.
+ * @param {String[]} argv Raw arguments.
+ * @returns {{tenant: String|null, idLimit: Number, json: String|null, help: Boolean}}
+ */
+export function parseArgs(argv) {
+    const options = {tenant: null, idLimit: 20, json: null, help: false};
+
+    for (let i = 0; i < argv.length; i++) {
+        const arg = argv[i];
+
+        if (arg === '--help' || arg === '-h') {
+            options.help = true
+        } else if (arg === '--tenant') {
+            options.tenant = argv[++i] ?? null
+        } else if (arg === '--ids') {
+            options.idLimit = Number(argv[++i]);
+
+            if (!Number.isInteger(options.idLimit) || options.idLimit < 0) {
+                throw new Error('--ids expects a non-negative integer');
+            }
+        } else if (arg === '--json') {
+            options.json = argv[++i] ?? null
+        } else {
+            throw new Error(`unknown argument: ${arg}`);
+        }
+    }
+
+    return options
+}
+
+/**
+ * Pages a collection's metadata and folds each page into a running census.
+ *
+ * Metadata only — `include: ['metadatas']` deliberately omits embeddings and documents, because the
+ * classification needs one field and pulling vectors would make a diagnostic read cost as much as the
+ * work it is measuring.
+ * @param {Object} collection Chroma collection handle.
+ * @param {Object|null} where Optional tenant scope.
+ * @param {Number} idLimit Ids to retain.
+ * @returns {Promise<Object>} The census.
+ */
+export async function censusCollection(collection, where, idLimit) {
+    let census = emptyStaleEmbeddingCensus(),
+        offset = 0;
+
+    for (;;) {
+        const page = await collection.get({
+            limit  : PAGE_SIZE,
+            offset,
+            include: ['metadatas'],
+            ...(where ? {where} : {})
+        });
+
+        const ids = page?.ids || [];
+
+        if (ids.length === 0) {
+            break
+        }
+
+        census = mergeStaleEmbeddingCensus(
+            census,
+            foldStaleEmbeddingCensus({
+                rows: ids.map((id, index) => ({id, metadata: page.metadatas?.[index]})),
+                idLimit
+            }),
+            idLimit
+        );
+
+        // A short page ends the walk; a full page might be the last one, so the loop asks again and
+        // exits on the empty answer. `ids.length === limit` cannot distinguish "exactly full" from
+        // "truncated", and guessing there would silently stop a census one page early.
+        offset += ids.length
+    }
+
+    return census
+}
+
+/**
+ * Prints one census block.
+ * @param {String} label Scope label.
+ * @param {Object} census Census to render.
+ * @returns {void}
+ */
+function report(label, census) {
+    const pct = census.scannedCount > 0 ? ((census.staleCount / census.scannedCount) * 100).toFixed(1) : '0.0';
+
+    console.log(`\n${label}`);
+    console.log(`  scanned          ${census.scannedCount}`);
+    console.log(`  stale            ${census.staleCount} (${pct}%)`);
+    console.log(`    pre-marker     ${census.byCause['pre-marker']}`);
+    console.log(`    format-changed ${census.byCause['format-changed']}`);
+    console.log(`  current          ${census.currentCount}`);
+
+    if (census.staleIds.length > 0) {
+        console.log(`  sample ids       ${census.staleIds.join(', ')}${census.idsTruncated ? ' … (truncated)' : ''}`);
+    }
+
+    // Stated as an invariant rather than assumed, because it is the property that makes two runs
+    // comparable: if it ever fails, a shrinking stale count is not evidence of repair.
+    if (census.staleCount + census.currentCount !== census.scannedCount) {
+        console.log('  ⚠️  scanned !== stale + current — a row classified into neither bucket');
+    }
+}
+
+/**
+ * Entry point.
+ * @returns {Promise<void>}
+ */
+async function main() {
+    const options = parseArgs(process.argv.slice(2));
+
+    if (options.help) {
+        console.log('node ai/scripts/diagnostics/staleEmbeddingCensus.mjs [--tenant <id>] [--ids <n>] [--json <path>]');
+        return
+    }
+
+    console.log(`Provider-input format in force: ${EMBEDDING_INPUT_FORMAT_ID}`);
+    console.log('Rows without the format field predate it and are counted as pre-marker.');
+
+    const collection = await ChromaManager.getKnowledgeBaseCollection();
+
+    // An unreachable daemon must report "nothing was measured" rather than an empty census, which
+    // would read as a clean corpus — the exact false-clean this whole lane keeps producing.
+    if (!collection) {
+        console.error('knowledge-base collection unavailable — nothing was measured');
+        process.exitCode = 1;
+        return
+    }
+
+    const census = await censusCollection(
+        collection,
+        options.tenant ? {tenantId: options.tenant} : null,
+        options.idLimit
+    );
+
+    report(options.tenant ? `tenant ${options.tenant}` : 'all tenants', census);
+
+    if (options.json) {
+        await fs.outputJson(options.json, {
+            observedAt : new Date().toISOString(),
+            formatId   : EMBEDDING_INPUT_FORMAT_ID,
+            tenantScope: options.tenant ?? null,
+            census
+        }, {spaces: 4});
+        console.log(`\nwrote ${options.json}`);
+    }
+}
+
+// Guarded so a spec can import `parseArgs` / `censusCollection` without the script connecting to
+// anything. An unguarded top-level call would make importing this module a live Chroma attempt.
+if (process.argv[1] && import.meta.url === `file://${process.argv[1]}`) {
+    main().catch(error => {
+        console.error(`staleEmbeddingCensus failed: ${error.message}`);
+        process.exitCode = 1;
+    });
+}

--- a/ai/scripts/diagnostics/staleEmbeddingCensus.mjs
+++ b/ai/scripts/diagnostics/staleEmbeddingCensus.mjs
@@ -2,7 +2,8 @@
 /**
  * @module ai/scripts/diagnostics/staleEmbeddingCensus
  * @summary Counts knowledge-base rows whose vectors were built from a superseded provider-input
- * format, per tenant, with the cause split out. Read-only: it never writes, embeds, or deletes.
+ * format, per tenant, with the cause split out. It never writes to the corpus — no embed, no upsert,
+ * no delete — and the only file it touches is the `--json` report path when one is supplied.
  *
  * ## Why this script exists rather than a query
  *
@@ -73,6 +74,14 @@ const PAGE_SIZE = 2000;
  * @param {String[]} argv Raw arguments.
  * @returns {{tenant: String|null, idLimit: Number, json: String|null, help: Boolean}}
  */
+function requireValue(flag, value) {
+    if (typeof value !== 'string' || value.trim() === '') {
+        throw new Error(`${flag} expects a non-empty value`);
+    }
+
+    return value
+}
+
 export function parseArgs(argv) {
     const options = {tenant: null, idLimit: 20, json: null, help: false};
 
@@ -82,7 +91,10 @@ export function parseArgs(argv) {
         if (arg === '--help' || arg === '-h') {
             options.help = true
         } else if (arg === '--tenant') {
-            options.tenant = argv[++i] ?? null
+            // A missing value here is the dangerous one: `?? null` used to mean "all tenants", so a
+            // typo silently WIDENED the scope of the measurement instead of refusing it. `--ids`
+            // already fails loud one branch down; this matches it.
+            options.tenant = requireValue(arg, argv[++i])
         } else if (arg === '--ids') {
             options.idLimit = Number(argv[++i]);
 
@@ -90,7 +102,9 @@ export function parseArgs(argv) {
                 throw new Error('--ids expects a non-negative integer');
             }
         } else if (arg === '--json') {
-            options.json = argv[++i] ?? null
+            // A missing value used to mean "no report", so `--json` with a fat-fingered path wrote
+            // nothing and still exited 0 — a silent no-op where the caller asked for a file.
+            options.json = requireValue(arg, argv[++i])
         } else {
             throw new Error(`unknown argument: ${arg}`);
         }
@@ -190,8 +204,12 @@ async function main() {
 
     const collection = await ChromaManager.getKnowledgeBaseCollection();
 
-    // An unreachable daemon must report "nothing was measured" rather than an empty census, which
+    // A missing collection must report "nothing was measured" rather than an empty census, which
     // would read as a clean corpus — the exact false-clean this whole lane keeps producing.
+    //
+    // Bounded deliberately: this detects an ABSENT collection handle. A daemon that is reachable but
+    // erroring, or one whose page read throws mid-walk, is not covered here — those surface as a
+    // thrown error from the walk rather than as this line.
     if (!collection) {
         console.error('knowledge-base collection unavailable — nothing was measured');
         process.exitCode = 1;

--- a/ai/services/knowledge-base/VectorService.mjs
+++ b/ai/services/knowledge-base/VectorService.mjs
@@ -11,11 +11,11 @@ import {IMPLEMENTED_EMBEDDING_PROVIDERS, resolveEmbeddingProviderModel}
 import {resolveEmbeddingAdmissionBand}
                               from '../../embeddingSafeBand.mjs';
 import {
-    EMBEDDING_INPUT_FORMAT_ID,
-    EMBEDDING_INPUT_FORMAT_METADATA_KEY,
     buildEmbeddingInputHeader,
     buildEmbeddingInputText
 }                             from './helpers/embeddingInputFormat.mjs';
+import {buildChunkRowMetadata}
+                              from './helpers/chunkRowMetadata.mjs';
 import {
     bytesToTokens,
     emitConsumerFriction
@@ -167,33 +167,6 @@ function resolveFailedRequestChunks({error, batchToEmbed, persistedCount = 0}) {
     return []
 }
 
-/**
- * @summary Flattens one chunk into Chroma-storable scalar metadata.
- *
- * The single producer for both the full-batch upsert and the partial upsert a cooperative lease yield
- * performs. Two sites deriving this independently could drift, and drift here means a stored vector
- * whose metadata disagrees with the vector beside it.
- * @param {Object} chunk Tenant-stamped chunk.
- * @returns {Object}
- */
-function buildChunkMetadata(chunk) {
-    const metadata = {};
-
-    for (const [key, value] of Object.entries(chunk)) {
-        metadata[key] = (value === null) ? 'null' : (typeof value === 'object') ? JSON.stringify(value) : value;
-    }
-
-    // Stamped here rather than onto the chunk, because three upsert sites call this function and a
-    // chunk-side stamp is three places to forget. This is already the single authority for row
-    // metadata — the same reason its own summary gives for existing.
-    //
-    // AFTER the copy loop, and that order is load-bearing: a chunk carrying a field of this name
-    // must not be able to declare which format its vector was built from. The row's claim comes from
-    // the module that owns the format, never from parsed content.
-    metadata[EMBEDDING_INPUT_FORMAT_METADATA_KEY] = EMBEDDING_INPUT_FORMAT_ID;
-
-    return metadata
-}
 
 const TENANT_GUARDED_FIELDS             = ['tenantId', 'repoSlug', 'visibility', 'originAgentIdentity', 'tenantConfigVersion', 'ingestedAt'];
 const STALE_STRATEGIES                  = Object.freeze(new Set(['delete-upfront', 'shadow-swap']));
@@ -1050,7 +1023,7 @@ class VectorService extends Base {
         await collection.upsert({
             ids      : inputs.map(input => input.chunk.id),
             embeddings,
-            metadatas: inputs.map(input => buildChunkMetadata(input.chunk))
+            metadatas: inputs.map(input => buildChunkRowMetadata(input.chunk))
         })
     }
 
@@ -1479,7 +1452,7 @@ class VectorService extends Base {
                         await collection.upsert({
                             ids       : partialChunks.map(chunk => chunk.id),
                             embeddings: carried,
-                            metadatas : partialChunks.map(chunk => buildChunkMetadata(chunk))
+                            metadatas : partialChunks.map(chunk => buildChunkRowMetadata(chunk))
                         });
                         break;
                     } catch (writeError) {
@@ -1564,7 +1537,7 @@ class VectorService extends Base {
                         await graduateDeathSuspect(suspectId, deathEntry, recoveredTokenEstimate);
                     }
 
-                    const metadatas = batchToEmbed.map(buildChunkMetadata);
+                    const metadatas = batchToEmbed.map(buildChunkRowMetadata);
 
                     await collection.upsert({
                         ids: batchToEmbed.map(chunk => chunk.id),

--- a/ai/services/knowledge-base/VectorService.mjs
+++ b/ai/services/knowledge-base/VectorService.mjs
@@ -10,8 +10,12 @@ import {IMPLEMENTED_EMBEDDING_PROVIDERS, resolveEmbeddingProviderModel}
                               from '../../embeddingProviders.mjs';
 import {resolveEmbeddingAdmissionBand}
                               from '../../embeddingSafeBand.mjs';
-import {buildEmbeddingInputHeader, buildEmbeddingInputText}
-                              from './helpers/embeddingInputFormat.mjs';
+import {
+    EMBEDDING_INPUT_FORMAT_ID,
+    EMBEDDING_INPUT_FORMAT_METADATA_KEY,
+    buildEmbeddingInputHeader,
+    buildEmbeddingInputText
+}                             from './helpers/embeddingInputFormat.mjs';
 import {
     bytesToTokens,
     emitConsumerFriction
@@ -178,6 +182,15 @@ function buildChunkMetadata(chunk) {
     for (const [key, value] of Object.entries(chunk)) {
         metadata[key] = (value === null) ? 'null' : (typeof value === 'object') ? JSON.stringify(value) : value;
     }
+
+    // Stamped here rather than onto the chunk, because three upsert sites call this function and a
+    // chunk-side stamp is three places to forget. This is already the single authority for row
+    // metadata — the same reason its own summary gives for existing.
+    //
+    // AFTER the copy loop, and that order is load-bearing: a chunk carrying a field of this name
+    // must not be able to declare which format its vector was built from. The row's claim comes from
+    // the module that owns the format, never from parsed content.
+    metadata[EMBEDDING_INPUT_FORMAT_METADATA_KEY] = EMBEDDING_INPUT_FORMAT_ID;
 
     return metadata
 }

--- a/ai/services/knowledge-base/helpers/chunkRowMetadata.mjs
+++ b/ai/services/knowledge-base/helpers/chunkRowMetadata.mjs
@@ -1,0 +1,36 @@
+import {EMBEDDING_INPUT_FORMAT_ID, EMBEDDING_INPUT_FORMAT_METADATA_KEY}
+                              from './embeddingInputFormat.mjs';
+
+/**
+ * @summary Flattens one chunk into Chroma-storable scalar metadata, stamped with the format its
+ * vector was built from.
+ *
+ * Pure and Neo-free, and lifted out of `VectorService` for the reason the sibling helpers here were:
+ * the service is a connect-on-init singleton whose `initAsync` awaits `ChromaManager.ready()`, so a
+ * unit spec cannot import it to exercise this writer. Living here, the production write path is
+ * directly reachable — the alternative was tests that construct the stamp themselves and therefore
+ * stay green when the producer stops emitting it.
+ *
+ * The single producer for both the full-batch upsert and the partial upsert a cooperative lease yield
+ * performs. Two sites deriving this independently could drift, and drift here means a stored vector
+ * whose metadata disagrees with the vector beside it.
+ * @param {Object} chunk Tenant-stamped chunk.
+ * @returns {Object} Scalar-only metadata carrying the format id.
+ */
+export function buildChunkRowMetadata(chunk) {
+    const metadata = {};
+
+    for (const [key, value] of Object.entries(chunk)) {
+        metadata[key] = (value === null) ? 'null' : (typeof value === 'object') ? JSON.stringify(value) : value;
+    }
+
+    // Stamped here rather than onto the chunk, because three upsert sites call this function and a
+    // chunk-side stamp is three places to forget.
+    //
+    // AFTER the copy loop, and that order is load-bearing: a chunk carrying a field of this name
+    // must not be able to declare which format its vector was built from. The row's claim comes from
+    // the module that owns the format, never from parsed content.
+    metadata[EMBEDDING_INPUT_FORMAT_METADATA_KEY] = EMBEDDING_INPUT_FORMAT_ID;
+
+    return metadata
+}

--- a/ai/services/knowledge-base/helpers/embeddingInputFormat.mjs
+++ b/ai/services/knowledge-base/helpers/embeddingInputFormat.mjs
@@ -106,9 +106,12 @@ export const EMBEDDING_INPUT_FORMAT_METADATA_KEY = 'kbEmbeddingInputFormat';
  * **Why it is derived rather than declared.** A hand-maintained literal can be forgotten, and the
  * cost of forgetting is silent — rows would claim a format they were not built from, which is worse
  * than no marker at all because it reads as verified. Hashing the format's own output over
- * {@link FORMAT_PROBE_CHUNKS} makes "format changed, identity did not" **unreachable** rather than
- * merely detectable. Incidental edits that do not change any produced string correctly leave the
- * identity alone.
+ * {@link FORMAT_PROBE_CHUNKS} removes the whole class of "format changed, identity did not" **for
+ * every branch that set reaches** — which is what a derived identity can honestly buy, and it is
+ * strictly more than a hand-maintained literal offers. It is not unconditional: per the probe set's
+ * own contract above, a branch no probe exercises can change without changing the identity, so
+ * adding a branch to the format means adding a probe for it in the same change. Incidental edits
+ * that do not change any produced string correctly leave the identity alone.
  *
  * The human-readable prefix is kept so an operator reading row metadata sees a family rather than
  * only a hex string; the suffix is what carries the guarantee. Truncated to 12 hex characters

--- a/ai/services/knowledge-base/helpers/embeddingInputFormat.mjs
+++ b/ai/services/knowledge-base/helpers/embeddingInputFormat.mjs
@@ -55,7 +55,8 @@ export function buildEmbeddingInputText(chunk) {
 }
 
 /**
- * @summary Chunks that exercise every branch the format has, so the identity below cannot miss one.
+ * @summary Chunks that exercise every branch the format has TODAY, so the identity below cannot miss
+ * one of them. A branch added later without a probe added beside it is the gap this set cannot close.
  *
  * The digest is only as sensitive as this set: a branch no probe reaches can change without changing
  * the identity, which would leave rows claiming a format they were not built from. So each entry

--- a/ai/services/knowledge-base/helpers/embeddingInputFormat.mjs
+++ b/ai/services/knowledge-base/helpers/embeddingInputFormat.mjs
@@ -7,8 +7,14 @@
  * two services each restated the format and a planner restated it a third time, so the guardrail
  * measured one string while the provider received another.
  *
+ * This module also owns the format's **identity** ({@link EMBEDDING_INPUT_FORMAT_ID}), because a
+ * vector is only interpretable against the string it was built from, and the row that stores the
+ * vector has to be able to say which string that was.
+ *
  * @module ai/services/knowledge-base/helpers/embeddingInputFormat
  */
+
+import crypto from 'node:crypto';
 
 /**
  * @summary Builds the leading identification line of a chunk's provider input.
@@ -47,3 +53,79 @@ export function buildEmbeddingInputHeader(chunk) {
 export function buildEmbeddingInputText(chunk) {
     return `${buildEmbeddingInputHeader(chunk)}${chunk.description || chunk.content || ''}`;
 }
+
+/**
+ * @summary Chunks that exercise every branch the format has, so the identity below cannot miss one.
+ *
+ * The digest is only as sensitive as this set: a branch no probe reaches can change without changing
+ * the identity, which would leave rows claiming a format they were not built from. So each entry
+ * exists for a named branch rather than for coverage in general —
+ *
+ * 1. `kind` alone, the schema-conforming shape (`parsed-chunk-v1` requires `kind`, declares no `type`);
+ * 2. `type` present alongside `kind`, which is the type-first contract and the branch whose reversal
+ *    silently renamed every header once already;
+ * 3. no `className`, the empty-string fallback;
+ * 4. `description` present alongside `content`, which is the description-first body branch;
+ * 5. neither body field, the second empty-string fallback.
+ *
+ * @type {Object[]}
+ */
+const FORMAT_PROBE_CHUNKS = Object.freeze([
+    {kind: 'method', name: 'probeA', className: 'ProbeClass', content: 'probe body'},
+    {kind: 'method', name: 'probeA', className: 'ProbeClass', content: 'probe body', type: 'src'},
+    {kind: 'class-config', name: 'probeB', content: 'probe body'},
+    {kind: 'method', name: 'probeC', className: 'ProbeClass', content: 'probe body', description: 'probe description'},
+    {kind: 'method', name: 'probeD', className: 'ProbeClass'}
+]);
+
+/**
+ * @summary The row-metadata field that carries {@link EMBEDDING_INPUT_FORMAT_ID}.
+ *
+ * Exported from here rather than from the writer, so the writer and every reader name the field
+ * once. A detector that hardcoded its own spelling would report zero affected rows against a
+ * correctly-written corpus — a false clean bill, which on this lane is the worst available failure
+ * because it reads as verification.
+ *
+ * Prefixed to keep it out of the parsed-chunk namespace: `buildChunkMetadata` copies every chunk
+ * field, so an unprefixed name could collide with a future schema field and be silently overwritten
+ * by content.
+ * @type {String}
+ */
+export const EMBEDDING_INPUT_FORMAT_METADATA_KEY = 'kbEmbeddingInputFormat';
+
+/**
+ * @summary The stored identity of the current provider-input format.
+ *
+ * **Why a row needs this at all.** The provider input is DERIVED and is not a member of a chunk's
+ * `hashInputs`, so changing the format does not change any chunk id: re-ingestion recomputes the same
+ * id, finds the row present, and skips it. The stale vector stays, and nothing on disk distinguishes
+ * it from a correct one — same id, same content, same metadata. Storing the format's identity beside
+ * the vector is what makes that difference observable, and **absence of this field is itself the
+ * discriminator**: every row written before the field existed simply lacks it.
+ *
+ * **Why it is derived rather than declared.** A hand-maintained literal can be forgotten, and the
+ * cost of forgetting is silent — rows would claim a format they were not built from, which is worse
+ * than no marker at all because it reads as verified. Hashing the format's own output over
+ * {@link FORMAT_PROBE_CHUNKS} makes "format changed, identity did not" **unreachable** rather than
+ * merely detectable. Incidental edits that do not change any produced string correctly leave the
+ * identity alone.
+ *
+ * The human-readable prefix is kept so an operator reading row metadata sees a family rather than
+ * only a hex string; the suffix is what carries the guarantee. Truncated to 12 hex characters
+ * because this is change-detection, not a security boundary, and the field is written on every row.
+ *
+ * `node:crypto` is a platform builtin rather than a Neo dependency, so the module's Neo-free
+ * property is intact; the digest is computed once at load from frozen literals, so it stays pure.
+ *
+ * @type {String}
+ */
+export const EMBEDDING_INPUT_FORMAT_ID = `kb-embed-input-v1-${
+    crypto.createHash('sha256')
+        // NUL-joined, and the separator is load-bearing: a format change that only moved text
+        // across the boundary between two probe outputs would leave a plain concatenation
+        // byte-identical. Written as an escape, never as a raw control byte — a literal NUL in
+        // source makes the file binary to grep and invisible in review.
+        .update(FORMAT_PROBE_CHUNKS.map(buildEmbeddingInputText).join('\u0000'))
+        .digest('hex')
+        .slice(0, 12)
+}`;

--- a/ai/services/knowledge-base/helpers/staleEmbeddingCensus.mjs
+++ b/ai/services/knowledge-base/helpers/staleEmbeddingCensus.mjs
@@ -1,0 +1,165 @@
+/**
+ * @summary Finds rows whose vectors were built from a provider-input format that is no longer current.
+ *
+ * **Why a scan and not a query.** The discriminator is the ABSENCE of a metadata field, and ChromaDB
+ * has no `$exists` operator — a row missing a key is invisible to every `where` clause that mentions
+ * that key, and `$ne` does not rescue it for the same reason. This repository has learned that four
+ * times already and written it down each time:
+ *
+ * - `ai/scripts/migrations/backfillChromaSharedUserId.mjs` — untagged rows *"are invisible to ANY
+ *   where-clause that mentions `userId` (no `$exists` operator)"*;
+ * - `ai/services/memory-core/MemoryService.mjs` — *"ChromaDB does not support `$exists: false`,
+ *   handled post-query"*, twice;
+ * - `ai/services/memory-core/HealthService.mjs` — *"Chroma where-filters cannot reliably falsify
+ *   absent metadata-key cases across versions, so this method scans metadata directly instead of
+ *   inferring from `$ne`"*.
+ *
+ * A filtered version of this module would return zero affected rows against a corpus full of them
+ * and read as a clean bill of health. That is the failure this lane keeps producing, so the shape is
+ * a deliberate constraint rather than an implementation detail.
+ *
+ * **What the scan costs, stated rather than implied.** Detection reads metadata for every row in the
+ * tenant's corpus — O(corpus), not a targeted lookup. The targeting this ticket buys is in what gets
+ * RE-EMBEDDED, never in what gets scanned. At the existing page size a ~87k-chunk corpus is ~44
+ * pages of metadata, which is negligible against the days of provider compute a full re-embed costs.
+ *
+ * Pure and storage-free: the caller supplies pages, this module classifies them. That keeps the
+ * arithmetic testable without a Chroma daemon, which is the same split
+ * `helpers/embeddingDispatchPlan` uses for the dispatch plan.
+ *
+ * @module ai/services/knowledge-base/helpers/staleEmbeddingCensus
+ */
+
+import {EMBEDDING_INPUT_FORMAT_ID, EMBEDDING_INPUT_FORMAT_METADATA_KEY}
+                              from './embeddingInputFormat.mjs';
+
+/**
+ * @summary Why one row is considered stale, or `null` when it is current.
+ *
+ * Two causes, kept separate because they mean different things to an operator and because a merged
+ * count cannot answer "did my repair run work?":
+ *
+ * - `pre-marker` — the field is absent. The row predates the marker, so its vector was built from an
+ *   unknown format. This is the population a format change leaves behind.
+ * - `format-changed` — the field is present and names a different format. The row was written by a
+ *   known-but-superseded format, so a later change is detectable the same way the first one was.
+ *
+ * A row whose marker matches the current id returns `null` and is never selected. That is the
+ * idempotence guarantee: a repaired row carries the current id, so a second pass skips it.
+ *
+ * @param {Object} [metadata] One row's stored metadata.
+ * @param {String} [currentFormatId=EMBEDDING_INPUT_FORMAT_ID] The format identity to compare against.
+ * @returns {String|null} `'pre-marker'`, `'format-changed'`, or `null` when current.
+ */
+export function classifyRowFormat(metadata, currentFormatId = EMBEDDING_INPUT_FORMAT_ID) {
+    // A non-object row is treated as pre-marker rather than skipped. It cannot prove it carries the
+    // current format, and the direction of a wrong answer matters: re-embedding a row that did not
+    // need it costs compute, while skipping one that did leaves a stale vector nothing will ever
+    // look at again.
+    if (!metadata || typeof metadata !== 'object' || Array.isArray(metadata)) {
+        return 'pre-marker'
+    }
+
+    const stored = metadata[EMBEDDING_INPUT_FORMAT_METADATA_KEY];
+
+    if (stored === undefined || stored === null || stored === '') {
+        return 'pre-marker'
+    }
+
+    return stored === currentFormatId ? null : 'format-changed'
+}
+
+/**
+ * @summary Folds scanned pages into a census: how many rows are stale, why, and which ids.
+ *
+ * **Ids are bounded and the bound is reported.** A corpus can have more affected rows than any
+ * caller wants in one array, so `idLimit` caps what is collected while `staleCount` keeps counting.
+ * A truncated list that did not say so would read as the complete work set, and a repair driven off
+ * it would stop early while reporting success — the "no silent partial repair" failure in its
+ * detection half.
+ *
+ * @param {Object} options
+ * @param {Array<{id: String, metadata: Object}>} options.rows Scanned rows, in any order.
+ * @param {String} [options.currentFormatId=EMBEDDING_INPUT_FORMAT_ID] Format identity to compare against.
+ * @param {Number} [options.idLimit=1000] Maximum ids to collect.
+ * @returns {{scannedCount: Number, staleCount: Number, currentCount: Number, byCause: Object, staleIds: String[], idsTruncated: Boolean}}
+ */
+export function foldStaleEmbeddingCensus({rows, currentFormatId = EMBEDDING_INPUT_FORMAT_ID, idLimit = 1000}) {
+    const census = {
+        scannedCount: 0,
+        staleCount  : 0,
+        currentCount: 0,
+        byCause     : {'pre-marker': 0, 'format-changed': 0},
+        staleIds    : [],
+        idsTruncated: false
+    };
+
+    for (const row of rows || []) {
+        census.scannedCount++;
+
+        const cause = classifyRowFormat(row?.metadata, currentFormatId);
+
+        if (cause === null) {
+            census.currentCount++;
+            continue
+        }
+
+        census.staleCount++;
+        census.byCause[cause]++;
+
+        if (census.staleIds.length < idLimit) {
+            census.staleIds.push(row?.id)
+        } else {
+            census.idsTruncated = true
+        }
+    }
+
+    return census
+}
+
+/**
+ * @summary Merges two censuses, so a paginated scan can accumulate without re-folding everything.
+ *
+ * Exists because the page loop and the census have different owners: the loop knows how to page a
+ * collection, this module knows what a page means. Merging in the loop by hand is how the two
+ * drift.
+ *
+ * @param {Object} left Census so far.
+ * @param {Object} right Census for the next page.
+ * @param {Number} [idLimit=1000] Maximum ids the merged census may carry.
+ * @returns {Object} Merged census.
+ */
+export function mergeStaleEmbeddingCensus(left, right, idLimit = 1000) {
+    const staleIds = left.staleIds.concat(right.staleIds).slice(0, idLimit);
+
+    return {
+        scannedCount: left.scannedCount + right.scannedCount,
+        staleCount  : left.staleCount + right.staleCount,
+        currentCount: left.currentCount + right.currentCount,
+        byCause     : {
+            'pre-marker'    : left.byCause['pre-marker'] + right.byCause['pre-marker'],
+            'format-changed': left.byCause['format-changed'] + right.byCause['format-changed']
+        },
+        staleIds,
+        // Truncation is sticky AND re-derived: either input already overflowed, or the concatenation
+        // did. Carrying only the inputs' flags would lose the case where two under-limit pages merge
+        // into an over-limit list.
+        idsTruncated: left.idsTruncated || right.idsTruncated ||
+            (left.staleIds.length + right.staleIds.length) > idLimit
+    }
+}
+
+/**
+ * @summary The empty census, so a caller with zero pages reports a measurement rather than absence.
+ * @returns {Object} A census with every counter at zero.
+ */
+export function emptyStaleEmbeddingCensus() {
+    return {
+        scannedCount: 0,
+        staleCount  : 0,
+        currentCount: 0,
+        byCause     : {'pre-marker': 0, 'format-changed': 0},
+        staleIds    : [],
+        idsTruncated: false
+    }
+}

--- a/package.json
+++ b/package.json
@@ -94,6 +94,7 @@
         "ai:server"                            : "chroma run --path ./.neo-ai-data/chroma/unified",
         "ai:server-neural-link"                : "node ./ai/mcp/server/neural-link/run-bridge.mjs",
         "ai:check-content-identity"            : "node ./buildScripts/util/check-content-logical-identity.mjs --all",
+        "ai:stale-embedding-census"            : "node ./ai/scripts/diagnostics/staleEmbeddingCensus.mjs",
         "ai:structure-map"                     : "node ./ai/scripts/diagnostics/structureMap.mjs",
         "ai:summarize-sessions"                : "node ./ai/scripts/lifecycle/summarize-sessions.mjs",
         "ai:sync-github-workflow"              : "node ./ai/scripts/maintenance/syncGithubWorkflow.mjs",

--- a/test/playwright/unit/ai/services/knowledge-base/VectorService.tenantStamping.spec.mjs
+++ b/test/playwright/unit/ai/services/knowledge-base/VectorService.tenantStamping.spec.mjs
@@ -18,6 +18,8 @@ setup({
 import {test, expect}  from '@playwright/test';
 import Neo             from '../../../../../../src/Neo.mjs';
 import * as core       from '../../../../../../src/core/_export.mjs';
+import {EMBEDDING_INPUT_FORMAT_ID, EMBEDDING_INPUT_FORMAT_METADATA_KEY}
+                       from '../../../../../../ai/services/knowledge-base/helpers/embeddingInputFormat.mjs';
 import fs              from 'fs';
 import path            from 'path';
 import os              from 'os';
@@ -415,6 +417,41 @@ test.describe('VectorService.embed — tenant stamping (#11631)', () => {
         expect(Number.isFinite(ingestedAt)).toBe(true);
         expect(ingestedAt).toBeGreaterThanOrEqual(before);
         expect(ingestedAt).toBeLessThanOrEqual(after);
+        expect(warnCalls).toHaveLength(0);
+    });
+
+
+    test('stamps the provider-input format id onto chunk metadata through the real upsert path', async () => {
+        // INTEGRATION arm, and the reason it lives here rather than beside the helper's unit arms:
+        // those call the writer directly, so replacing every VectorService call site with a plain
+        // field copy leaves them green. This asserts the marker on metadata the SERVICE actually
+        // upserted, which is the only assertion that fails when the service stops calling the writer.
+        const spy = createSpyCollection();
+        KB_ChromaManager.getKnowledgeBaseCollection = async () => spy;
+
+        writeFixtureJsonl(fixturePath, [{
+            hash       : 'raw-hash-format-marker',
+            type       : 'guide',
+            name       : 'FormatMarkerDoc',
+            className  : '',
+            description: 'format marker stamping',
+            content    : 'body'
+        }]);
+
+        await KB_VectorService.embed(fixturePath);
+
+        const {metadata} = getOnlyRow(spy);
+
+        expect(
+            metadata[EMBEDDING_INPUT_FORMAT_METADATA_KEY],
+            'the upserted row must carry the current provider-input format id; without this arm the ' +
+            'service could stop stamping and only the helper-level arms would notice — and they cannot'
+        ).toBe(EMBEDDING_INPUT_FORMAT_ID);
+
+        // Non-vacuity: the fixture chunk never carried the key, so the value came from the write path.
+        expect(Object.hasOwn({
+            hash: 'raw-hash-format-marker', type: 'guide', name: 'FormatMarkerDoc'
+        }, EMBEDDING_INPUT_FORMAT_METADATA_KEY)).toBe(false);
         expect(warnCalls).toHaveLength(0);
     });
 

--- a/test/playwright/unit/ai/services/knowledge-base/staleEmbeddingCensus.spec.mjs
+++ b/test/playwright/unit/ai/services/knowledge-base/staleEmbeddingCensus.spec.mjs
@@ -11,6 +11,8 @@ import {
 }                              from '../../../../../../ai/services/knowledge-base/helpers/embeddingInputFormat.mjs';
 import {censusCollection, parseArgs}
                                from '../../../../../../ai/scripts/diagnostics/staleEmbeddingCensus.mjs';
+import {buildChunkRowMetadata}
+                               from '../../../../../../ai/services/knowledge-base/helpers/chunkRowMetadata.mjs';
 import {
     classifyRowFormat,
     emptyStaleEmbeddingCensus,
@@ -297,5 +299,98 @@ test.describe('the census flags refuse what they do not understand (#17428)', ()
         expect(parseArgs([])).toEqual({tenant: null, idLimit: 20, json: null, help: false});
         expect(parseArgs(['--tenant', 't1', '--ids', '0'])).toMatchObject({tenant: 't1', idLimit: 0});
         expect(parseArgs(['--help'])).toMatchObject({help: true});
+    });
+});
+
+test.describe('the PRODUCTION writer stamps the format, and the stamp is not the caller\'s to make', () => {
+    // Every other arm in this file builds `{[KEY]: ID}` by hand and feeds it to the READER. That
+    // proves the reader classifies, and proves nothing about the writer: deleting the producer's
+    // stamp left the whole suite green. These arms call the production writer and assert on what IT
+    // emits, so the producer cannot go silent behind a suite that supplies its own answer.
+
+    test('RA-1 PRODUCTION PATH: a chunk that carries no format field still yields a stamped row', () => {
+        // The chunk deliberately omits the key — this is the real upsert input shape, where the
+        // format claim has to come from the module that owns the format.
+        const chunk    = {id: 'c1', kind: 'method', tenantId: 't1', text: 'x'},
+              metadata = buildChunkRowMetadata(chunk);
+
+        expect(
+            metadata[EMBEDDING_INPUT_FORMAT_METADATA_KEY],
+            'the writer must stamp the current format id; deleting the producer line must redden HERE ' +
+            'rather than leaving a reader-only suite green'
+        ).toBe(EMBEDDING_INPUT_FORMAT_ID);
+
+        // Non-vacuity: the input genuinely lacked the key, so the assertion above cannot be
+        // satisfied by the fixture handing the writer its own answer.
+        expect(
+            Object.hasOwn(chunk, EMBEDDING_INPUT_FORMAT_METADATA_KEY),
+            'the fixture must NOT supply the key, or this arm re-tests the caller instead of the writer'
+        ).toBe(false);
+    });
+
+    test('RA-1 PRODUCTION PATH: a chunk claiming a format CANNOT override the writer', () => {
+        // The stamp sits after the copy loop, and the docblock calls that order load-bearing. Nothing
+        // asserted it. A chunk is parsed content: it must not be able to declare which format built
+        // its vector, or a poisoned row could mark itself fresh and escape the census forever.
+        const forged   = 'kb-embed-input-v1-000000000000',
+              metadata = buildChunkRowMetadata({
+                  id: 'c2', kind: 'method', [EMBEDDING_INPUT_FORMAT_METADATA_KEY]: forged
+              });
+
+        expect(forged, 'the control value must differ from the real id, or the arm cannot fail')
+            .not.toBe(EMBEDDING_INPUT_FORMAT_ID);
+        expect(
+            metadata[EMBEDDING_INPUT_FORMAT_METADATA_KEY],
+            'the row\'s format claim comes from the format module, never from parsed content — ' +
+            'moving the stamp above the copy loop must redden this arm'
+        ).toBe(EMBEDDING_INPUT_FORMAT_ID);
+    });
+
+    test('RA-1 the writer still flattens every chunk field to a Chroma-storable scalar', () => {
+        // Guards the lift itself: the stamp is the new behaviour, the flattening is pre-existing and
+        // must survive the move out of VectorService unchanged.
+        const metadata = buildChunkRowMetadata({
+            id: 'c3', nested: {a: 1}, empty: null, count: 7, flag: true, list: [1, 2]
+        });
+
+        expect(metadata.nested).toBe('{"a":1}');
+        expect(metadata.empty).toBe('null');
+        expect(metadata.list).toBe('[1,2]');
+        expect(metadata.count).toBe(7);
+        expect(metadata.flag).toBe(true);
+    });
+});
+
+test.describe('RA-3 the census flags refuse a MISSING value instead of meaning something else', () => {
+    // `--ids` already failed loud; `--tenant` and `--json` used `?? null`, and for both of them
+    // `null` is a legitimate, meaningful setting — so a typo did not error, it silently selected a
+    // DIFFERENT measurement.
+
+    test('--tenant with no value REFUSES, because `null` there silently means every tenant', () => {
+        // The dangerous one: the old behaviour widened a single-tenant census to the whole corpus.
+        expect(() => parseArgs(['--tenant'])).toThrow(/--tenant expects a non-empty value/);
+        expect(() => parseArgs(['--tenant', '   '])).toThrow(/--tenant expects a non-empty value/);
+
+        // CONTROL — a real value still parses, so the guard is not a blanket reject.
+        expect(parseArgs(['--tenant', 't1']).tenant).toBe('t1');
+    });
+
+    test('--json with no value REFUSES, because `null` there silently means no report at all', () => {
+        expect(() => parseArgs(['--json'])).toThrow(/--json expects a non-empty value/);
+        expect(() => parseArgs(['--json', ''])).toThrow(/--json expects a non-empty value/);
+
+        // CONTROL — a real path still parses.
+        expect(parseArgs(['--json', '/tmp/x.json']).json).toBe('/tmp/x.json');
+    });
+
+    test('the defaults are unchanged when a flag is ABSENT, which is not the same as empty', () => {
+        // The distinction the fix rests on: omitting `--tenant` still means "all tenants", and only
+        // SUPPLYING it without a value is refused. Without this arm the fix could have been a
+        // blanket "tenant is required" and this suite would not have noticed.
+        const options = parseArgs([]);
+
+        expect(options.tenant).toBeNull();
+        expect(options.json).toBeNull();
+        expect(options.idLimit).toBe(20);
     });
 });

--- a/test/playwright/unit/ai/services/knowledge-base/staleEmbeddingCensus.spec.mjs
+++ b/test/playwright/unit/ai/services/knowledge-base/staleEmbeddingCensus.spec.mjs
@@ -31,7 +31,7 @@ function row(id, metadata) {
 }
 
 test.describe('the provider-input format has a stored identity', () => {
-    test('the identity is DERIVED from the format, so a format change cannot leave it behind', () => {
+    test('the identity is DERIVED from the format, so a change to any PROBED branch cannot leave it behind', () => {
         // The point of deriving it: "format changed, identity did not" is removed for every branch
         // the probe set reaches, rather than merely detectable. Not unconditional — a branch no probe
         // exercises can still change invisibly, which is why adding a format branch means adding a

--- a/test/playwright/unit/ai/services/knowledge-base/staleEmbeddingCensus.spec.mjs
+++ b/test/playwright/unit/ai/services/knowledge-base/staleEmbeddingCensus.spec.mjs
@@ -1,0 +1,213 @@
+import {test, expect} from '@playwright/test';
+
+import '../../../../../../src/Neo.mjs';
+import '../../../../../../src/core/Base.mjs';
+
+import {
+    EMBEDDING_INPUT_FORMAT_ID,
+    EMBEDDING_INPUT_FORMAT_METADATA_KEY,
+    buildEmbeddingInputHeader,
+    buildEmbeddingInputText
+}                              from '../../../../../../ai/services/knowledge-base/helpers/embeddingInputFormat.mjs';
+import {
+    classifyRowFormat,
+    emptyStaleEmbeddingCensus,
+    foldStaleEmbeddingCensus,
+    mergeStaleEmbeddingCensus
+}                              from '../../../../../../ai/services/knowledge-base/helpers/staleEmbeddingCensus.mjs';
+
+/**
+ * Builds a stored-row shape as the scan returns it.
+ * @param {String} id Row id.
+ * @param {Object} metadata Stored metadata.
+ * @returns {{id: String, metadata: Object}}
+ */
+function row(id, metadata) {
+    return {id, metadata};
+}
+
+test.describe('the provider-input format has a stored identity', () => {
+    test('the identity is DERIVED from the format, so a format change cannot leave it behind', () => {
+        // The whole point of deriving it: "format changed, identity did not" must be unreachable
+        // rather than merely detectable. This arm pins the current value, so ANY change to a string
+        // the format produces reddens here and forces a deliberate decision about the corpus.
+        //
+        // If you are reading this because the arm just went red: that is the mechanism working. A
+        // format change invalidates every existing vector's interpretation, so the question to answer
+        // is not "what is the new hash" but "who re-embeds the corpus, and who measures it".
+        expect(EMBEDDING_INPUT_FORMAT_ID).toBe('kb-embed-input-v1-d1a862171da9');
+    });
+
+    test('the identity carries a readable family AND a derived suffix', () => {
+        // The prefix is for the operator reading row metadata; the suffix is what carries the
+        // guarantee. Asserting the shape rather than only the value keeps a future bump from
+        // accidentally dropping either half.
+        expect(EMBEDDING_INPUT_FORMAT_ID).toMatch(/^kb-embed-input-v1-[a-f0-9]{12}$/);
+    });
+
+    test('the probe set reaches the type-first branch — the sensitivity this depends on', () => {
+        // A digest is only as sensitive as the inputs it hashes, so the branch whose reversal already
+        // renamed every header once must be reachable from the probes. Asserted through the format's
+        // own functions: a chunk with `type` is named by `type`, one without falls back to `kind`.
+        // If this pair ever stopped differing, the digest would go blind to that contract while the
+        // arm above still passed.
+        const withType    = {kind: 'method', name: 'n', className: 'C', type: 'src', content: 'b'},
+              withoutType = {kind: 'method', name: 'n', className: 'C', content: 'b'};
+
+        expect(buildEmbeddingInputHeader(withType)).not.toBe(buildEmbeddingInputHeader(withoutType));
+        expect(buildEmbeddingInputText(withType)).toContain('src:');
+        expect(buildEmbeddingInputText(withoutType)).toContain('method:');
+    });
+});
+
+test.describe('classifyRowFormat — absence is the discriminator (#17428)', () => {
+    test('a PRE-MARKER row and a FRESH row are separated even though their chunk fields are identical', () => {
+        // This is the pair the ticket said nothing on disk could distinguish: both carry `kind` and
+        // no `type`, same content, same everything a parser wrote. Only the marker differs, and its
+        // absence is what names the stale one.
+        const shared = {kind: 'method', name: 'sameName', className: 'SameClass', tenantId: 't1'};
+
+        const preMarker = {...shared},
+              fresh     = {...shared, [EMBEDDING_INPUT_FORMAT_METADATA_KEY]: EMBEDDING_INPUT_FORMAT_ID};
+
+        expect(classifyRowFormat(preMarker)).toBe('pre-marker');
+        expect(classifyRowFormat(fresh)).toBeNull();
+    });
+
+    test('a row from a SUPERSEDED format is stale for a different, separately-named reason', () => {
+        // Two causes, never merged: an operator reading "1000 stale" cannot tell whether a repair run
+        // worked, while "0 pre-marker, 1000 format-changed" says the marker landed and the format
+        // then moved.
+        expect(classifyRowFormat({[EMBEDDING_INPUT_FORMAT_METADATA_KEY]: 'kb-embed-input-v1-000000000000'}))
+            .toBe('format-changed');
+    });
+
+    test('IDEMPOTENCE: a repaired row is never selected again', () => {
+        // A detector that re-selects its own output turns a bounded repair into a loop, which on a
+        // plane paying days of compute is worse than not repairing at all.
+        const repaired = {kind: 'method', [EMBEDDING_INPUT_FORMAT_METADATA_KEY]: EMBEDDING_INPUT_FORMAT_ID};
+
+        expect(classifyRowFormat(repaired)).toBeNull();
+        // And again on a second pass over the same row — the classification is a pure function of the
+        // row, so there is no accumulated state that could flip it.
+        expect(classifyRowFormat(repaired)).toBeNull();
+    });
+
+    test('every unusable metadata shape fails toward STALE, not toward current', () => {
+        // Direction of the wrong answer is the whole design: re-embedding a row that did not need it
+        // costs compute, while skipping one that did leaves a stale vector nothing will look at
+        // again. So anything that cannot PROVE it is current is treated as stale.
+        for (const shape of [undefined, null, 'a string', 42, [], {}, {[EMBEDDING_INPUT_FORMAT_METADATA_KEY]: null},
+            {[EMBEDDING_INPUT_FORMAT_METADATA_KEY]: ''}]) {
+            expect(classifyRowFormat(shape), `${JSON.stringify(shape) ?? 'undefined'} must not read as current`)
+                .toBe('pre-marker');
+        }
+    });
+
+    test('the comparison target is injectable, so a caller can census against a NAMED format', () => {
+        // Needed for the before/after measurement: a repair run has to be able to ask "how many rows
+        // are not yet at the format I am writing", including in a test that must not depend on the
+        // live digest.
+        const stored = {[EMBEDDING_INPUT_FORMAT_METADATA_KEY]: 'kb-embed-input-v1-aaaaaaaaaaaa'};
+
+        expect(classifyRowFormat(stored, 'kb-embed-input-v1-aaaaaaaaaaaa')).toBeNull();
+        expect(classifyRowFormat(stored, 'kb-embed-input-v1-bbbbbbbbbbbb')).toBe('format-changed');
+    });
+});
+
+test.describe('foldStaleEmbeddingCensus — the count is a measurement, not an inference (#17428)', () => {
+    test('counts scanned, stale and current separately, with causes split', () => {
+        const census = foldStaleEmbeddingCensus({rows: [
+            row('a', {kind: 'method'}),
+            row('b', {kind: 'method', [EMBEDDING_INPUT_FORMAT_METADATA_KEY]: EMBEDDING_INPUT_FORMAT_ID}),
+            row('c', {kind: 'method', [EMBEDDING_INPUT_FORMAT_METADATA_KEY]: 'kb-embed-input-v1-000000000000'}),
+            row('d', {kind: 'class-config'})
+        ]});
+
+        expect(census.scannedCount).toBe(4);
+        expect(census.staleCount).toBe(3);
+        expect(census.currentCount).toBe(1);
+        expect(census.byCause).toEqual({'pre-marker': 2, 'format-changed': 1});
+        expect(census.staleIds.sort()).toEqual(['a', 'c', 'd']);
+        expect(census.idsTruncated).toBe(false);
+    });
+
+    test('scanned = stale + current, so a row can never be silently dropped', () => {
+        // The invariant an operator relies on when comparing two runs. A row that classified into
+        // neither bucket would make a shrinking stale count look like progress.
+        const rows = Array.from({length: 25}, (_, i) => row(`r${i}`,
+                  i % 3 === 0 ? {} : {[EMBEDDING_INPUT_FORMAT_METADATA_KEY]: EMBEDDING_INPUT_FORMAT_ID})),
+              census = foldStaleEmbeddingCensus({rows});
+
+        expect(census.staleCount + census.currentCount).toBe(census.scannedCount);
+        expect(census.scannedCount).toBe(25);
+    });
+
+    test('a TRUNCATED id list says so, while the count keeps counting', () => {
+        // A truncated list that did not declare itself would read as the complete work set, and a
+        // repair driven off it would stop early while reporting success — "no silent partial repair"
+        // in its detection half.
+        const census = foldStaleEmbeddingCensus({
+            rows   : Array.from({length: 10}, (_, i) => row(`r${i}`, {})),
+            idLimit: 4
+        });
+
+        expect(census.staleCount, 'the count is not capped by the id limit').toBe(10);
+        expect(census.staleIds).toHaveLength(4);
+        expect(census.idsTruncated).toBe(true);
+    });
+
+    test('an empty scan reports zeros rather than absence', () => {
+        // A caller that scanned nothing must still emit a measurement: an absent census cannot
+        // distinguish "no stale rows" from "never looked", which is the distinction the whole ticket
+        // turns on.
+        for (const rows of [[], null, undefined]) {
+            const census = foldStaleEmbeddingCensus({rows});
+
+            expect(census.scannedCount).toBe(0);
+            expect(census.staleCount).toBe(0);
+            expect(census.byCause).toEqual({'pre-marker': 0, 'format-changed': 0});
+        }
+
+        expect(emptyStaleEmbeddingCensus()).toEqual(foldStaleEmbeddingCensus({rows: []}));
+    });
+});
+
+test.describe('mergeStaleEmbeddingCensus — pagination cannot lose a row (#17428)', () => {
+    test('a paged scan totals exactly what one big scan would', () => {
+        // The property that makes pagination safe to add: folding pages then merging must equal
+        // folding everything at once. Without it, a corpus larger than one page reports a number
+        // nobody can act on.
+        const all = Array.from({length: 30}, (_, i) => row(`r${i}`,
+                  i % 4 === 0 ? {} : {[EMBEDDING_INPUT_FORMAT_METADATA_KEY]: EMBEDDING_INPUT_FORMAT_ID})),
+              whole = foldStaleEmbeddingCensus({rows: all});
+
+        let paged = emptyStaleEmbeddingCensus();
+
+        for (let offset = 0; offset < all.length; offset += 7) {
+            paged = mergeStaleEmbeddingCensus(paged, foldStaleEmbeddingCensus({rows: all.slice(offset, offset + 7)}));
+        }
+
+        expect(paged.scannedCount).toBe(whole.scannedCount);
+        expect(paged.staleCount).toBe(whole.staleCount);
+        expect(paged.currentCount).toBe(whole.currentCount);
+        expect(paged.byCause).toEqual(whole.byCause);
+        expect(paged.staleIds.sort()).toEqual(whole.staleIds.sort());
+    });
+
+    test('truncation is detected when two UNDER-limit pages merge into an over-limit list', () => {
+        // The case that carrying only the inputs' flags would miss: neither page truncated on its
+        // own, so a naive OR of two `false`s reports a complete list that is not one.
+        const left  = foldStaleEmbeddingCensus({rows: [row('a', {}), row('b', {})], idLimit: 10}),
+              right = foldStaleEmbeddingCensus({rows: [row('c', {}), row('d', {})], idLimit: 10});
+
+        expect(left.idsTruncated, 'neither input may already be truncated, or the arm proves nothing').toBe(false);
+        expect(right.idsTruncated).toBe(false);
+
+        const merged = mergeStaleEmbeddingCensus(left, right, 3);
+
+        expect(merged.staleIds).toHaveLength(3);
+        expect(merged.staleCount, 'the count still totals both pages').toBe(4);
+        expect(merged.idsTruncated).toBe(true);
+    });
+});

--- a/test/playwright/unit/ai/services/knowledge-base/staleEmbeddingCensus.spec.mjs
+++ b/test/playwright/unit/ai/services/knowledge-base/staleEmbeddingCensus.spec.mjs
@@ -9,6 +9,8 @@ import {
     buildEmbeddingInputHeader,
     buildEmbeddingInputText
 }                              from '../../../../../../ai/services/knowledge-base/helpers/embeddingInputFormat.mjs';
+import {censusCollection, parseArgs}
+                               from '../../../../../../ai/scripts/diagnostics/staleEmbeddingCensus.mjs';
 import {
     classifyRowFormat,
     emptyStaleEmbeddingCensus,
@@ -209,5 +211,91 @@ test.describe('mergeStaleEmbeddingCensus — pagination cannot lose a row (#1742
         expect(merged.staleIds).toHaveLength(3);
         expect(merged.staleCount, 'the count still totals both pages').toBe(4);
         expect(merged.idsTruncated).toBe(true);
+    });
+});
+
+test.describe('the census walk — pagination and scope at the script boundary (#17428)', () => {
+    /**
+     * A collection stub that pages a fixed row set and records every request it received.
+     * @param {Array<{id: String, metadata: Object}>} rows Rows to serve.
+     * @returns {Object} Stub with a `calls` log.
+     */
+    function stubCollection(rows) {
+        const calls = [];
+
+        return {
+            calls,
+            async get(request) {
+                calls.push(request);
+
+                const page = rows.slice(request.offset, request.offset + request.limit);
+
+                return {ids: page.map(r => r.id), metadatas: page.map(r => r.metadata)}
+            }
+        };
+    }
+
+    test('a corpus larger than one page is fully counted, and the walk terminates', async () => {
+        // 4501 rows against a 2000-row page is three pages plus a short one. A walk that mishandled
+        // the offset would either loop forever or stop early, and both look like a smaller corpus.
+        const rows = Array.from({length: 4501}, (_, i) => row(`r${i}`, i % 2 === 0 ? {} :
+                  {[EMBEDDING_INPUT_FORMAT_METADATA_KEY]: EMBEDDING_INPUT_FORMAT_ID})),
+              stub   = stubCollection(rows),
+              census = await censusCollection(stub, null, 10);
+
+        expect(census.scannedCount, 'every row must be reached exactly once').toBe(4501);
+        expect(census.staleCount).toBe(2251);
+        expect(census.currentCount).toBe(2250);
+        expect(census.staleIds).toHaveLength(10);
+        expect(census.idsTruncated).toBe(true);
+
+        // Offsets advance by what was RETURNED, and the walk asks once more after the last full page
+        // rather than inferring the end from a full page — the inference that stops a census early.
+        expect(stub.calls.map(c => c.offset)).toEqual([0, 2000, 4000, 4501]);
+    });
+
+    test('an empty collection yields a measurement of zero, in ONE request', async () => {
+        const stub   = stubCollection([]),
+              census = await censusCollection(stub, null, 10);
+
+        expect(census.scannedCount).toBe(0);
+        expect(census.staleCount).toBe(0);
+        expect(stub.calls).toHaveLength(1);
+    });
+
+    test('the walk reads METADATA ONLY, and passes a tenant scope through untouched', async () => {
+        // Pulling vectors would make the diagnostic cost what the work it measures costs; and a scope
+        // silently dropped would report a whole-corpus number under a tenant label.
+        const stub = stubCollection([row('a', {})]);
+
+        await censusCollection(stub, {tenantId: 't7'}, 5);
+
+        expect(stub.calls[0].include).toEqual(['metadatas']);
+        expect(stub.calls[0].where).toEqual({tenantId: 't7'});
+    });
+
+    test('no scope means no `where` key at all, rather than an empty filter', async () => {
+        // An empty object is a filter, and a filter is not the same request as no filter.
+        const stub = stubCollection([row('a', {})]);
+
+        await censusCollection(stub, null, 5);
+
+        expect('where' in stub.calls[0]).toBe(false);
+    });
+});
+
+test.describe('the census flags refuse what they do not understand (#17428)', () => {
+    test('a mistyped flag fails loud instead of censusing something else', () => {
+        // Silently ignoring `--tenat` would report every tenant under a run the operator believed was
+        // scoped, and nothing in the output would say so.
+        expect(() => parseArgs(['--tenat', 't1'])).toThrow(/unknown argument/);
+        expect(() => parseArgs(['--ids', 'lots'])).toThrow(/non-negative integer/);
+        expect(() => parseArgs(['--ids', '-3'])).toThrow(/non-negative integer/);
+    });
+
+    test('the accepted flags parse, and the id cap has a default', () => {
+        expect(parseArgs([])).toEqual({tenant: null, idLimit: 20, json: null, help: false});
+        expect(parseArgs(['--tenant', 't1', '--ids', '0'])).toMatchObject({tenant: 't1', idLimit: 0});
+        expect(parseArgs(['--help'])).toMatchObject({help: true});
     });
 });

--- a/test/playwright/unit/ai/services/knowledge-base/staleEmbeddingCensus.spec.mjs
+++ b/test/playwright/unit/ai/services/knowledge-base/staleEmbeddingCensus.spec.mjs
@@ -32,9 +32,11 @@ function row(id, metadata) {
 
 test.describe('the provider-input format has a stored identity', () => {
     test('the identity is DERIVED from the format, so a format change cannot leave it behind', () => {
-        // The whole point of deriving it: "format changed, identity did not" must be unreachable
-        // rather than merely detectable. This arm pins the current value, so ANY change to a string
-        // the format produces reddens here and forces a deliberate decision about the corpus.
+        // The point of deriving it: "format changed, identity did not" is removed for every branch
+        // the probe set reaches, rather than merely detectable. Not unconditional — a branch no probe
+        // exercises can still change invisibly, which is why adding a format branch means adding a
+        // probe in the same change. This arm pins the current value, so ANY change to a string the
+        // format produces reddens here and forces a deliberate decision about the corpus.
         //
         // If you are reading this because the arm just went red: that is the mechanism working. A
         // format change invalidates every existing vector's interpretation, so the question to answer


### PR DESCRIPTION
Resolves neomjs/neo#17428

> 🌿 A vector was interpretable only against a string nobody stored, so what this makes unsayable is "these rows are fine" — the corpus can now be asked, and on this deployment it answers 68,039.

**This closes the detector; it repairs nothing, and the repair now has its own owner.** neomjs/neo#17443 was filed at delivery time rather than at filing time, because a read-only census is a leaf while re-embedding is a plane operation that spends days of provider compute on a live tenant — and *when* to spend that is an operator decision informed by this census, not a property of the code. Its four carried acceptance criteria keep neomjs/neo#17428's wording verbatim so nothing is weakened in transit.

Evidence: L3 (the shipped census run against this deployment's live knowledge-base collection, 68,039 rows) + L2 (20 unit arms over the pure classification, fold, merge and paging walk) → L2 required (every close-target AC is unit-reachable). Residual: the live-write round-trip, Residual-Owner: neomjs/neo#17443.

## The problem, in one line of arithmetic

The provider input is DERIVED and is not a member of a chunk's `hashInputs`. So a format change leaves every id unchanged: re-ingestion recomputes the same id, finds the row present, and skips it. The stale vector survives, and no comparison of id, content or metadata separates it from a correct one — a pre-fix row and a post-fix row both carry `kind` and no `type`.

## What makes the difference observable

`buildChunkMetadata` already copies every chunk field, so the row schema needed no change. It now also stamps the format's identity, and **the field's absence is the discriminator**: every row written before the stamp existed simply lacks it.

**The identity is derived, not declared.** A hand-maintained literal can be forgotten, and forgetting is silent — rows would claim a format they were not built from, which is worse than no marker because it reads as verified. The identity is a digest of the format's own output over a probe set that reaches each of its branches (type-first vs `kind` fallback, missing `className`, description-over-content, neither body field), so **"format changed, identity did not" is removed for every branch that set reaches** rather than merely detectable. Not unconditional, and the module says so at its probe-set contract: a branch no probe exercises can change invisibly, so adding a format branch means adding a probe in the same change. Reviewer-tightened from an absolute I had written in three places. Incidental edits that change no produced string correctly leave it alone.

**The stamp goes after the copy loop, and that order is load-bearing.** Three upsert sites call `buildChunkMetadata`, so a chunk-side stamp is three places to forget; and stamping after the copy means a chunk carrying a field of that name cannot declare which format built its vector.

## Detection is a scan, and that is a constraint rather than an implementation detail

ChromaDB has no `$exists`, so a row missing a key is invisible to every `where` clause that mentions it — and `$ne` fails for the same reason. This repository had already recorded that four times before I looked: `backfillChromaSharedUserId.mjs`, twice in `MemoryService.mjs`, and in `HealthService`'s own scan (*"Chroma where-filters cannot reliably falsify absent metadata-key cases across versions"*).

A filtered version of this detector would return **zero affected rows against a corpus full of them** and read as a clean bill of health. That is this lane's characteristic failure one layer down, so it is pinned by an AC rather than a comment.

The cost is stated rather than implied: detection is O(corpus) metadata reads. The targeting this buys is in what gets RE-EMBEDDED, never in what gets scanned.

## Deltas from ticket

**The intake gate fired and earned its cost.** I authored this ticket but recovered from a compaction, so per `self-authored-carve.md` I treated it as the earlier-session case and ran the drift probe rather than claiming exemption — stricter, which the carve permits. The probe came back non-empty: `embeddingInputFormat.mjs`, `VectorService.mjs` and `IngestionService.mjs` had all moved on `origin/dev` since `createdAt`, via a single commit (`6af013b357`, neomjs/neo#17426) which **created** the module this ticket names as the marker's home. The surface landed rather than drifting away, but running the full gate is what surfaced the `$exists` constraint above — which the ticket's Ledger row would otherwise have implied was a query. Ticket amended with the constraint, its four citations, and a new AC.

**A workaround I wrote and then deleted, because it was working around a convention.** The census first reached ChromaDB through a raw `chromadb` client with lazy imports, on the reasoning that importing `ChromaManager` at module scope throws `ReferenceError: Neo is not defined` from `ai/Env.mjs`. That reasoning was correct and the conclusion was wrong: every service-touching script under `ai/scripts/**` already bootstraps with two lines (`import Neo from '.../src/Neo.mjs'` + `import '.../src/core/_export.mjs'`), and the migration scripts use a raw client because they must target arbitrary hosts, not because the service layer is unreachable. The script now goes through `ChromaManager` and inherits its connection retry, collection-swap awareness and not-found handling instead of reimplementing three of them badly. Net: less code, and correct on paths I had not considered.

## Test Evidence

`test/playwright/unit/ai/services/knowledge-base/` — **757 passed** at `1e82036a45`.

Two layers, and the second exists because the first cannot see the defect the Required Action named:

- `staleEmbeddingCensus.spec.mjs` — helper-level arms over the census, the classifier and the writer, including three that call `buildChunkRowMetadata` directly.
- `VectorService.tenantStamping.spec.mjs` — **one integration arm** asserting the format marker on metadata the **service** actually upserted. Reviewer-required, and the reason is measured: replacing all three `VectorService` call sites with a plain field copy leaves every helper-level arm green.

| mutant | integration arm | helper arms |
|---|---|---|
| all 3 `VectorService` call sites → plain field copy | **RED** — `Expected "kb-embed-input-v1-d1a862171da9", Received undefined` | 28 passed, green |

That row is the whole argument for the second layer: unit coverage of a writer proves the writer works, never that the production path still calls it.

**Six mutants, seven arms, per arm rather than per suite:**

| mutant | IDENTITY | TYPEFIRST | DISCRIM | IDEMP | FAILSTALE | INVARIANT | TRUNC |
|---|---|---|---|---|---|---|---|
| baseline | green | green | green | green | green | green | green |
| format reversed to kind-first | **RED** | **RED** | green | green | green | green | green |
| absent marker reads CURRENT | green | green | **RED** | green | **RED** | green | **RED** |
| current marker reads stale | green | green | **RED** | **RED** | green | green | green |
| non-object metadata reads current | green | green | green | green | **RED** | green | green |
| a stale row also counted current | green | green | green | green | green | **RED** | green |
| merge drops the re-derived truncation | green | green | green | green | green | green | **RED** |

The first row is the AC's own requirement — changing the format reddens an arm — and it reddens **only** the identity arms, leaving every census arm green. That separation is the point: an identity defect must not be indistinguishable from a counting defect.

**Live plane run**, `npm run ai:stale-embedding-census -- --ids 5`:

```
Provider-input format in force: kb-embed-input-v1-d1a862171da9
all tenants
  scanned          68039
  stale            68039 (100.0%)
    pre-marker     68039
    format-changed 0
  current          0
```

100% pre-marker is the correct reading, not a defect: the stamp exists and nothing has been re-ingested since, so every row predates it. `format-changed: 0` is the discriminating half — it proves the two causes are counted separately rather than folded.

**Regression check by SET.** An earlier revision of this line reported **739 passed, 3 failed** at an earlier head; the current set is **757 passed** at `1e82036a45`. The three failures then were all in `ChromaTestIsolation.spec.mjs`, All three are in `ChromaTestIsolation.spec.mjs`, which contains zero references to anything this PR touches. Verified rather than argued: with `VectorService.mjs` and `embeddingInputFormat.mjs` checked out from `origin/dev`, the same spec reports the same `3 failed / 3 passed`. Pre-existing.

Per directly touched surface: `ai/services/knowledge-base/helpers/**` and `ai/scripts/diagnostics/**` — the new spec covers both, including the paging walk at the script boundary (multi-page totals, one-request empty case, metadata-only `include`, tenant scope passed through, no `where` key when unscoped, and flag refusal). `lint-npm-script-entrypoints`: OK, 64 entries. `lint-script-plane`: OK, no new authority conflicts. `check-ticket-archaeology`: 0 violations in the touched files.

## Post-Merge Validation

- [ ] **Agent-executed, not operator-executed.** Re-run `npm run ai:stale-embedding-census` after the next tenant ingestion cycle and confirm `current` becomes non-zero — i.e. that newly-written rows carry the stamp on the real write path. The unit arms cover `buildChunkMetadata`'s output; only a live ingestion proves the field survives the upsert round-trip.

Residual-Owner: neomjs/neo#17443

That is the one claim the sandbox cannot make, and it is stated as an obligation rather than folded into the evidence above. It lands on neomjs/neo#17443 rather than on a ticket opened to hold it: the repair's own first assertion is that a re-embedded row carries the current marker, so the round-trip is a precondition of that ticket's work rather than a chore parked on it.

**Who runs it, stated because the default reading is wrong.** This needs a reachable ChromaDB, not a container: the census talks to whatever `ai:server` (`chroma run --path …`) serves locally, which is how the 68,039 figure above was measured. So it is an agent obligation on an ordinary workstation, and nothing in this PR asks the operator to execute anything inside a container.

## Commits

- `7635b81a56` — a row records which provider-input format built its vector.
- `95ea6f636f` — the stale-vector population becomes a measurement.
- `f12772f860` — the writer gets an arm, and a flag with no value stops meaning something else.
- `067770a6d0` — the derived identity is branch-complete, not unconditional.
- `1e82036a45` — one assertion on metadata the service actually upserted.

## Decision Record impact

`none`. No AiConfig leaf is added, renamed or re-derived, and no ADR governs row-metadata composition. The format's identity lives with the format, which is where ADR-shaped authority questions about it would start rather than end.

## Evolution

Two corrections worth keeping. The intake gate I could have skipped is the reason this PR scans instead of filtering — a `where`-filtered detector would have shipped green, returned zero, and read as proof the corpus was clean. And the raw-client workaround is a reminder that "the obvious approach fails" is a claim about my knowledge before it is a claim about the code: the bootstrap was two lines away, in every sibling script I had not read.

---

Authored by Vega (Claude Opus 5, Claude Code). Session 046f993e-13ba-47dd-827d-d786428e318b.



