### PR TITLE
fix(ai): an absent identity cross-check is an advisory, not a binding failure (#17445)

### DIFF
--- a/.agents/skills/pr-review/references/pr-review-guide.md
+++ b/.agents/skills/pr-review/references/pr-review-guide.md
@@ -340,6 +340,8 @@ acceptance can be A2A-only. Authority moved → hand off. Relay §9, not flatten
 `[merge-eligible]` requires the current positive B-prime observation marker;
 otherwise use `[merge-readiness-uncertified][no-positive-observation]`, or
 `[merge-readiness-uncertified][issuer-unavailable:cloud-mode]` in cloud.
+An `IDENTITY_CROSS_CHECK_UNAVAILABLE` advisory still issues the marker — certified on
+GitHub alone; cite it when relaying. A *detected* mismatch fails closed instead.
 
 ## 11. Post-Review-Cycle Reviewer Pickup
 

--- a/ai/services/github-workflow/PullRequestService.mjs
+++ b/ai/services/github-workflow/PullRequestService.mjs
@@ -635,7 +635,14 @@ async function buildMergeReadinessProjection({
         });
     }
 
-    const identityBindingComplete = Boolean(principals.memoryCoreIdentity);
+    // Past the guard above, both required principals are bound and drift has already been ruled out:
+    // `assertExpectedIdentity` returns `ok: false` on MEMORY_CORE_MISMATCH, so a mismatched second
+    // surface fails closed there rather than here. What is left to decide is whether that surface was
+    // available to compare at all — a property of the caller's request context, not of the binding.
+    // Conflating the two spends the binding code on a missing cross-check, and a consumer branching
+    // on `code` (as this API's docblock instructs, over string-matching `reason`) cannot tell a
+    // certification that was refused from one that was merely never offered a second opinion.
+    const crossCheckAvailable = principals.memoryCoreIdentity != null;
 
     const variables = {owner, repo, prNumber};
     let firstSnapshot;
@@ -784,7 +791,19 @@ async function buildMergeReadinessProjection({
         headRefOid      : snapshot.headRefOid
     });
     const sourceMergeReady    = predicate.strictMergeReady && sourceBlockers.length === 0;
-    const certifiedMergeReady = sourceMergeReady && identityBindingComplete;
+    const certifiedMergeReady = sourceMergeReady;
+    // An unavailable cross-check is an advisory, never a blocker: the drifted-token case it exists to
+    // catch already fails closed at the guard above. It rides in `advisories` so it inherits the
+    // count clause in the merge-ready statement, which is the only sentence that reaches the human
+    // gate — a `[merge-eligible]` marker earned against one surface must say so there, or it reads
+    // identically to one earned against two.
+    const advisories = [
+        ...(crossCheckAvailable ? [] : [{
+            code   : 'IDENTITY_CROSS_CHECK_UNAVAILABLE',
+            message: 'Memory Core identity was not supplied, so this observation is certified against the GitHub surface alone.'
+        }]),
+        ...predicate.advisories.map(message => ({code: 'APPROVAL_ANCHOR_STALE', message}))
+    ];
     const requiredSet         = {
         source  : `GET ${rulesPath}`,
         digest  : digestValue(requiredContexts),
@@ -800,9 +819,16 @@ async function buildMergeReadinessProjection({
         mergedAt       : snapshot.mergedAt,
         observedAt,
         principals,
+        // `complete` is unconditionally true here and that is the assertion, not a simplification:
+        // every path reaching this point cleared the required-principals guard. The field reports
+        // binding; the optional second surface reports itself under `crossCheck`.
         identityBinding: {
-            complete: identityBindingComplete,
-            missing : identityBindingComplete ? [] : ['memoryCoreIdentity']
+            complete: true,
+            missing : []
+        },
+        crossCheck     : {
+            available: crossCheckAvailable,
+            surfaces : crossCheckAvailable ? ['github', 'memory-core'] : ['github']
         },
         requiredSet,
         contextStates: comparison.requiredStates,
@@ -820,12 +846,8 @@ async function buildMergeReadinessProjection({
         emittedOnly     : comparison.emittedOnly,
         checksGreen,
         checksVerdict,
-        verdict         : identityBindingComplete
-            ? sourceMergeReady ? 'merge-ready-observed' : 'not-merge-ready'
-            : 'unavailable',
-        statement       : !identityBindingComplete
-            ? `Observed GitHub checks verdict '${checksVerdict}' at ${observedAt} for ${owner}/${repo}#${prNumber} head ${snapshot.headRefOid}; B-prime certification is unavailable because Memory Core identity is unbound.`
-            : certifiedMergeReady
+        verdict         : sourceMergeReady ? 'merge-ready-observed' : 'not-merge-ready',
+        statement       : certifiedMergeReady
                 // An advisory rides INSIDE the merge-ready sentence rather than after it. It fires
                 // only when everything else is green — exactly when nothing draws the eye — and the
                 // merge-ready statement travels beside `[merge-eligible]` to the human gate. A
@@ -835,15 +857,9 @@ async function buildMergeReadinessProjection({
                 // deliverable — it travels beside `[merge-eligible]` to the human gate — so it is
                 // the one string where wording carries weight, and `1 advisory/advisories require`
                 // reads as generated text a reader discounts.
-                ? `Observed strict merge-ready at ${observedAt} for ${owner}/${repo}#${prNumber} head ${snapshot.headRefOid}.${predicate.advisories.length > 0 ? ` ${predicate.advisories.length} ${predicate.advisories.length === 1 ? 'advisory requires' : 'advisories require'} a reader judgement before merge — see 'advisories'.` : ''}`
+                ? `Observed strict merge-ready at ${observedAt} for ${owner}/${repo}#${prNumber} head ${snapshot.headRefOid}.${advisories.length > 0 ? ` ${advisories.length} ${advisories.length === 1 ? 'advisory requires' : 'advisories require'} a reader judgement before merge — see 'advisories'.` : ''}`
                 : `Did not observe strict merge-readiness at ${observedAt} for ${owner}/${repo}#${prNumber} head ${snapshot.headRefOid}.`,
         blockers: [
-            ...(!identityBindingComplete ? [{
-                code             : 'IDENTITY_BINDING_MISSING',
-                message          : 'Memory Core identity is unbound; GitHub checks remain readable but B-prime certification is unavailable.',
-                missingPrincipals: ['memoryCoreIdentity'],
-                affects          : ['b-prime-certification']
-            }] : []),
             ...sourceBlockers,
             ...predicate.blockers.map(message => ({code: 'STRICT_MERGE_READINESS', message}))
         ],
@@ -853,13 +869,13 @@ async function buildMergeReadinessProjection({
         // three signals. An advisory has NO redundancy: it fires only on an otherwise-green
         // observation, so nested inside `predicate` it reaches no reader of the surface that
         // actually travels to the merge gate.
-        advisories: predicate.advisories.map(message => ({code: 'APPROVAL_ANCHOR_STALE', message})),
+        advisories,
         audit: [
             ...audit,
             {source: 'validateMergeReady', call: 1, outcome: sourceMergeReady ? 'positive' : 'negative'},
             {
                 source : 'memory-core-identity',
-                outcome: identityBindingComplete ? 'bound' : 'unbound-certification-withheld'
+                outcome: crossCheckAvailable ? 'cross-checked' : 'cross-check-unavailable'
             }
         ],
         ...(certifiedMergeReady ? {marker: `[merge-eligible][B-prime:${observationId}]`} : {})

--- a/test/playwright/unit/ai/services/github-workflow/PullRequestService.spec.mjs
+++ b/test/playwright/unit/ai/services/github-workflow/PullRequestService.spec.mjs
@@ -589,7 +589,7 @@ test.describe('Neo.ai.services.github-workflow.PullRequestService — merge-read
         }
     });
 
-    test('#16902: returns a checks verdict but withholds B-prime when Memory Core identity is unbound', async () => {
+    test('#17445: an absent cross-check certifies against one surface and SAYS so — it is not a blocker', async () => {
         const identityAssertion = {
             ok        : true,
             code      : 'OK',
@@ -603,23 +603,92 @@ test.describe('Neo.ai.services.github-workflow.PullRequestService — merge-read
             identityAssertion
         }, deps);
 
-        expect(result.verdict).toBe('unavailable');
+        expect(result.verdict).toBe('merge-ready-observed');
         expect(result.checksVerdict).toBe('green');
-        expect(result.checksGreen).toBe(true);
         expect(result.predicate.strictMergeReady).toBe(true);
-        expect(result.identityBinding).toEqual({complete: false, missing: ['memoryCoreIdentity']});
-        expect(result.principals.memoryCoreIdentity).toBeNull();
-        expect(result.blockers).toContainEqual(expect.objectContaining({
-            code             : 'IDENTITY_BINDING_MISSING',
-            missingPrincipals: ['memoryCoreIdentity'],
-            affects          : ['b-prime-certification']
-        }));
-        expect(result.marker).toBeUndefined();
+        // The guard above this branch already refused every unbound principal, so reaching the
+        // projection at all IS the binding proof. A missing optional cross-check reports itself.
+        expect(result.identityBinding).toEqual({complete: true, missing: []});
+        expect(result.crossCheck).toEqual({available: false, surfaces: ['github']});
+        expect(result.blockers).not.toContainEqual(
+            expect.objectContaining({code: 'IDENTITY_BINDING_MISSING'})
+        );
+        expect(result.advisories).toContainEqual(
+            expect.objectContaining({code: 'IDENTITY_CROSS_CHECK_UNAVAILABLE'})
+        );
+        // The advisory is worthless if it does not reach the sentence that travels to the human
+        // gate: a marker earned on one surface must not read identically to one earned on two.
+        expect(result.marker).toBe(`[merge-eligible][B-prime:${result.observationId}]`);
+        expect(result.statement).toContain('advisory requires');
         expect(result.audit).toContainEqual({
             source : 'memory-core-identity',
-            outcome: 'unbound-certification-withheld'
+            outcome: 'cross-check-unavailable'
         });
         expect(deps.calls()).toEqual({queryCall: 2, restCall: 2});
+    });
+
+    test('#17445 CONTROL: a present cross-check certifies on two surfaces and raises NO advisory', async () => {
+        const deps   = dependencies();
+        const result = await PullRequestService.getConversation({
+            pr_number        : 16029,
+            projection       : 'merge-readiness',
+            identityAssertion: {ok: true, code: 'OK', reason: null, principals: PRINCIPALS}
+        }, deps);
+
+        expect(result.verdict).toBe('merge-ready-observed');
+        expect(result.crossCheck).toEqual({available: true, surfaces: ['github', 'memory-core']});
+        expect(result.advisories).not.toContainEqual(
+            expect.objectContaining({code: 'IDENTITY_CROSS_CHECK_UNAVAILABLE'})
+        );
+        expect(result.audit).toContainEqual({source: 'memory-core-identity', outcome: 'cross-checked'});
+        // Without this pairing the arm above is satisfied by a projection that ALWAYS advises.
+        expect(result.statement).not.toContain('advisory requires');
+    });
+
+    test('#17445 NEGATIVE CONTROL: a genuinely unbound principal still fails closed on IDENTITY_BINDING_MISSING', async () => {
+        for (const missing of ['agentIdentity', 'githubLogin']) {
+            const result = await PullRequestService.getConversation({
+                pr_number        : 16029,
+                projection       : 'merge-readiness',
+                identityAssertion: {
+                    ok        : true,
+                    code      : 'OK',
+                    reason    : null,
+                    principals: {...PRINCIPALS, [missing]: null}
+                }
+            }, dependencies());
+
+            expect(result.verdict).toBe('unavailable');
+            expect(result.blockers).toContainEqual(
+                expect.objectContaining({code: 'IDENTITY_BINDING_MISSING'})
+            );
+            expect(result.marker).toBeUndefined();
+        }
+    });
+
+    test('#17445 NEGATIVE CONTROL: a DETECTED cross-check mismatch still fails closed, and not as an advisory', async () => {
+        // assertExpectedIdentity returns ok:false on MEMORY_CORE_MISMATCH, so drift detected is
+        // refused at the guard. This is the arm that makes the AC-2 deletion safe rather than a
+        // hole: absent is advisory, mismatched is not.
+        const result = await PullRequestService.getConversation({
+            pr_number        : 16029,
+            projection       : 'merge-readiness',
+            identityAssertion: {
+                ok        : false,
+                code      : 'MEMORY_CORE_MISMATCH',
+                reason    : 'identity drift: Memory-Core identity other-agent, expected neo-opus-ada',
+                principals: {...PRINCIPALS, memoryCoreIdentity: '@other-agent'}
+            }
+        }, dependencies());
+
+        expect(result.verdict).toBe('unavailable');
+        expect(result.blockers).toContainEqual(
+            expect.objectContaining({code: 'IDENTITY_BINDING_MISSING'})
+        );
+        expect(result.advisories ?? []).not.toContainEqual(
+            expect.objectContaining({code: 'IDENTITY_CROSS_CHECK_UNAVAILABLE'})
+        );
+        expect(result.marker).toBeUndefined();
     });
 
     test('#16902: latest workflow invocation supersedes an earlier failure on the same exact head', async () => {


### PR DESCRIPTION
Resolves neomjs/neo#17445 — the consumer half. **Three of its eight ACs are deliberately out of scope here** and live in neomjs/neo-agent-brain#22: AC-1 (the wiring), plus AC-6 (boot-refusal guard) and AC-7 (`neural-link` characterisation), which @neo-opus-vega added to the ticket *after* this branch was cut. This PR ships **AC-2, AC-3, AC-4, AC-5 and AC-8**.

**Ticket-drift note.** neomjs/neo#17445's body was edited five times between my 08:39:53Z claim and this PR, twice substantively, and briefly overwritten entirely at ~09:03Z (since restored and verified by its author). This PR was created at 09:00:27Z against the post-edit body; @neo-opus-vega has confirmed the scope is correct and unaffected. The AC numbers above are the *current* ones — earlier revisions numbered the guide update AC-6.

A gate whose passing state has never been reachable. `principals.memoryCoreIdentity` is documented by its own producer as **optional**, and the merge-readiness projection read it as required — then reported its absence with the **same `IDENTITY_BINDING_MISSING` code as the hard guard eight lines above it**. Two unrelated conditions, one code, in an API whose docblock explicitly tells consumers to branch on `code` rather than string-match `reason`.

Evidence: L2 (direct spec execution, 167 arms, plus a mutation run against the guard) → L2 achieved, no residual. This is projection semantics; there is no runtime behaviour beyond the emitted observation.

**Nothing populates the field.** `github-workflow` has **0** `RequestContextService.run()` call sites against `memory-core`'s 4 — it only ever *reads* the context (`getAgentIdentityNodeId`, `getUserId`), so every read returns null on every seat. @neo-opus-vega and I reproduced identical `memoryCoreIdentity: null` from two different clones, two sessions, two server processes. Code property, not seat property.

**`assertExpectedIdentity` is not the defect** — worth stating because the ticket implicates it. Its line 105 skips the cross-check when absent and returns `ok: true`, exactly as its docblock promises. The whole defect is one line downstream reading that result as though absence meant failure.

## The design question, answered rather than assumed

AC-2 says an absent cross-check must not block. **Taken alone that would make the gate pass while quietly turning a two-surface claim into a one-surface one** — B-prime certification is named for cross-surface agreement, and a `[merge-eligible]` earned on GitHub alone would read identically to one earned on both.

So the absence is now a distinct `IDENTITY_CROSS_CHECK_UNAVAILABLE` **advisory** that rides in `advisories`, inheriting the existing merge-ready count clause. That clause was built for the stale-anchor case under a comment saying a sentence which is *"true and misleading in the same breath"* is unacceptable at the human gate — the same argument applies here, so it reuses the same mechanism rather than inventing one.

`identityBinding.complete` is now unconditionally `true` past the guard. That is the assertion, not a simplification: every path reaching that point cleared the required principals, so the field reports binding and the optional second surface reports itself under `crossCheck`.

**What makes the deletion safe rather than a hole:** drift *detected* never reached this branch anyway. `assertExpectedIdentity` returns `ok: false` on `MEMORY_CORE_MISMATCH`, which the hard guard consumes. Absent is advisory; mismatched still fails closed. There is a negative-control arm for exactly that distinction.

## Deltas from ticket

**AC-1 (the wiring) is now neomjs/neo-agent-brain#22**, filed rather than silently narrowed. Getting there took two corrections of my own claims, and the second one matters to anyone reading this diff:

I first said AC-1 was a `BaseServer` lift spanning `knowledge-base`, `neural-link`, `gitlab-workflow` and `file-system`, "all also at 0 `RequestContextService.run()` call sites". **Both halves of that were wrong.** A count of zero `run()` sites is not a defect — it only matters where something *reads* the context. Measured per server:

| server | `run()` | reads | disposition |
|---|---|---|---|
| memory-core | 4 | 0 | establishes via `wrapDispatch` |
| **github-workflow** | **0** | **5** | **reads without establishing — the whole defect** |
| knowledge-base | 0 | 1 | establishes via `buildRequestContext`; stdio falls through to documented single-tenant |
| neural-link / gitlab-workflow / file-system | 0 | 0 | nothing reads it |

So it is **one** server, not four. And it is not a lift: `BaseServer` already publishes *both* hooks — `wrapDispatch` (`:191`, stdio, overridden by memory-core `:254`) and `buildRequestContext` (`:237`, HTTP, overridden by knowledge-base `:192`). github-workflow overrides neither. Only the identity *resolver* (`resolveStdioIdentity`, memory-core-private) is unshared, and neomjs/neo-agent-brain#22 carries that fork with a falsifier.

I am leaving this correction visible rather than quietly rewriting the paragraph, because the original claim went out to the reviewer in an A2A before I measured it.

**`crossCheck` is a new field, not in the ticket.** `identityBinding` alone could not carry both facts once they were separated, and a consumer needs to know *which* surfaces certified — hence `{available, surfaces}`.

**One spec was deleted, not adapted.** `#16902: returns a checks verdict but withholds B-prime when Memory Core identity is unbound` constructed `ok: true` with `memoryCoreIdentity: null` and asserted the projection blocked anyway. It pinned the defect **as a contract**, which is why the gate survived this long.

## Test Evidence

**167 arms green.** Four new, replacing the one that pinned the defect:

- `#17445: an absent cross-check certifies against one surface and SAYS so` — asserts the marker *is* issued, `blockers` carries no `IDENTITY_BINDING_MISSING`, and `statement` contains the advisory clause. Checking the advisory exists without checking it reaches the statement would pass on an advisory no human ever sees.
- `#17445 CONTROL: a present cross-check ... raises NO advisory` — the pairing arm. Without it the one above is satisfied by a projection that *always* advises.
- `#17445 NEGATIVE CONTROL: a genuinely unbound principal still fails closed` — loops `agentIdentity` and `githubLogin`, so the deletion is not a catch-all (AC-4).
- `#17445 NEGATIVE CONTROL: a DETECTED mismatch still fails closed, and not as an advisory` — the arm that separates *absent* from *drifted*.

**Mutation run (AC-3).** Replacing the guard condition with `if (false)` reddens exactly three arms — the pre-existing guard spec at `:963` and both new negative controls — and nothing else. The positive arms stay green under the mutant, which is correct: they do not depend on the guard. Guard restored, 167/167.

**Brain tier:** these specs route to `unit-brain`, skipped in a body-only checkout. Run here, not shipped unexecuted.

## Substrate slot rationale

`pr-review-guide.md` §10.1 — **modified**, disposition `keep`. §10.1 already made canonical `[merge-eligible]` conditional on a positive B-prime observation; that condition was unreachable, so the clause trained every reviewer to route around it. **Two lines**, stating the invariant only: an advisory-carrying projection still issues the marker, cite it when relaying, and a *detected* mismatch fails closed instead. Placement unchanged — this corrects an existing clause rather than adding a slot. Retirement trigger: fold into §10.1's main sentence once AC-1 lands and the advisory becomes rare.

My first draft was six lines and `lint-skill-manifest` rejected it: +469 bytes against a 250-byte delta budget, and it pushed the file past its 33,700-byte per-file cap. The lint was right and the rewrite is not a workaround — the four lines I cut were *derivation*, which belongs in this body and the ticket, not in always-loaded substrate. Now `[lint-skill-manifest] OK` with the file back under budget.

## Post-Merge Validation

Call `get_conversation` with `projection: 'merge-readiness'` on any open PR from a seat with no request context. Expect `verdict` per the required set (not `unavailable`), `identityBinding.complete: true`, `crossCheck.available: false`, and `IDENTITY_CROSS_CHECK_UNAVAILABLE` in `advisories`. Before this change every such call returned `unavailable`.

## Evolution

The defect is the **read-the-question-a-field-answers** trap compiled into production: `memoryCoreIdentity` answers *"was a second surface cross-checked?"* and line 638 read it as *"is identity bound?"*. That is the third instance of the class surfaced today across two maintainers — @neo-opus-vega hit it twice reasoning from field names, I hit it twice on migration probes. The generalisable guard is the one AC-4 asks for: **a control that cannot produce the opposite outcome proves nothing**, which is also why the CONTROL arm above is paired rather than solo.

Authored by Ada (Claude Opus 5, Claude Code). Session 43441f60-7f2a-4734-82da-22b609b115f9.
