### PR TITLE
fix(ai): the graph mounts on first readiness await, not at construction (#17383)

### DIFF
--- a/ai/services/memory-core/GraphService.mjs
+++ b/ai/services/memory-core/GraphService.mjs
@@ -119,11 +119,41 @@ class GraphService extends Base {
     }
 
     /**
-     * Initializes the SQLite Database and Native Edge database structures.
+     * @summary Completes construction WITHOUT touching the database.
+     *
+     * `core.Base` schedules `initAsync()` unconditionally from every constructor, and this class is
+     * a `singleton`, so `Neo.setupClass` constructs it during module evaluation. Mounting storage
+     * here therefore meant that *importing* the Brain barrel opened the graph — a native module
+     * load, a `mkdir`, a SQLite handle and a WAL writer — in every process that touched
+     * `ai/services.mjs`, whether or not it ever read a node.
      */
     async initAsync() {
-        await super.initAsync();
+        await super.initAsync()
+    }
 
+    /**
+     * @summary Mounts the graph on first readiness await, then memoizes.
+     *
+     * The open moves here rather than disappearing, because ~20 call sites already treat
+     * `await GraphService.ready()` as "the graph is usable" and would otherwise be handed a null
+     * database. Deferring to `ready()` keeps that contract exactly and only changes *when* the cost
+     * is paid: a process that imports the barrel without awaiting readiness never opens the file.
+     * @returns {Promise<void>}
+     */
+    async ready() {
+        await super.ready();
+        await this.mountGraph()
+    }
+
+    /**
+     * @summary Opens the SQLite database and native edge structures, once.
+     *
+     * Split out of `initAsync()` verbatim so the mount sequence stays one reviewable unit. The
+     * `_initPromise` guard is the memoization: concurrent `ready()` awaits share one mount, and a
+     * mount that already failed is not retried — `graphInitError` stays the record of why.
+     * @returns {Promise<void>}
+     */
+    async mountGraph() {
         if (this.db || this._initPromise) {
             if (this._initPromise) {
                 await this._initPromise;

--- a/ai/services/memory-core/WakeSubscriptionService.mjs
+++ b/ai/services/memory-core/WakeSubscriptionService.mjs
@@ -202,15 +202,39 @@ class WakeSubscriptionService extends Base {
     liveCursorStateFile = AiConfig.wakeDaemon.wakeSubscriptionLiveCursorPath
 
     /**
-     * Sets the initial live cursor to the current graph log head to prevent
-     * replaying historical events on boot.
+     * @member {Boolean} _liveCursorSeeded=false
+     * @protected
      */
-    async init() {
+    _liveCursorSeeded = false
+
+    /**
+     * @summary Seeds the live cursor to the current graph log head, once, before the first pump.
+     *
+     * This was `init()` — a `core.Base` construction hook — on a `singleton`. So constructing the
+     * service awaited `GraphService.ready()` and mounted the graph, and because `Neo.setupClass`
+     * instantiates singletons during module evaluation, *importing* `ai/services.mjs` opened the
+     * SQLite database in every process on the barrel path.
+     *
+     * Deferring to the first pump preserves the guarantee this exists for — a boot must not replay
+     * historical events — because there is no replay before the first pump. It is idempotent via
+     * `_liveCursorSeeded`, which is set BEFORE the await so a concurrent pump cannot double-seed
+     * and rewind the cursor over events the first pass already claimed.
+     * @returns {Promise<void>}
+     */
+    async ensureLiveCursor() {
+        if (this._liveCursorSeeded) {
+            return;
+        }
+
+        this._liveCursorSeeded = true;
+
         await GraphService.ready();
+
         if (!GraphService.db) {
             const reason = GraphService.graphInitError?.message || 'graph database is not mounted';
             throw new Error(`GraphService unavailable: ${reason}`);
         }
+
         const storage = GraphService.db?.storage;
         if (storage?.db) {
             try {
@@ -255,6 +279,12 @@ class WakeSubscriptionService extends Base {
     async pump() {
         this._pumpRequested = true;
         if (this._pumping) return;
+
+        // Seeds the cursor to the log head on the first pump only. It used to happen in the
+        // construction hook, which is what made importing the Brain barrel open the graph.
+        // It must run BEFORE the delta read below, or that read would replay history from cursor 0 —
+        // the exact outcome the original boot-time seeding existed to prevent.
+        await this.ensureLiveCursor();
 
         try {
             this._pumping = true;

--- a/test/playwright/unit/ai/services/memory-core/GraphService.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/GraphService.spec.mjs
@@ -1256,7 +1256,28 @@ test.describe('Neo.ai.services.memory-core.GraphService', () => {
         expect(ready).toBe(true);
     });
 
-    test('should auto-provision all identity roots at boot via initAsync', async () => {
+    test('initAsync does NOT mount the graph — importing the barrel must not open SQLite', async () => {
+        GraphService._initPromise = null;
+        GraphService.db          = null;
+
+        await GraphService.initAsync();
+
+        // The whole point: construction completes with no database. core.Base schedules initAsync
+        // from every constructor and this class is a singleton, so anything mounted here is mounted
+        // by a bare `import`.
+        expect(GraphService.db).toBeNull();
+    });
+
+    test('CONTROL: mountGraph DOES mount — without this the arm above passes on a broken mount', async () => {
+        GraphService._initPromise = null;
+        GraphService.db          = null;
+
+        await GraphService.mountGraph();
+
+        expect(GraphService.db).toBeTruthy();
+    });
+
+    test('should auto-provision all identity roots on first readiness await', async () => {
         // Guarantee pristine isolated boundary baseline natively
         if (GraphService.db) {
             GraphService.db.nodes.clear();
@@ -1274,8 +1295,10 @@ test.describe('Neo.ai.services.memory-core.GraphService', () => {
         GraphService._initPromise = null;
         GraphService.db = null;
 
-        // Run the boot sequence
-        await GraphService.initAsync();
+        // Run the boot sequence. The mount moved out of initAsync so that importing the Brain
+        // barrel no longer opens SQLite; provisioning still runs before any consumer can read,
+        // because every consumer reaches the graph through a readiness await.
+        await GraphService.mountGraph();
 
         // Assert the system sender plus core identities are present with correct types
         const system = await GraphService.getNode({id: '@system'});


### PR DESCRIPTION
Resolves #17450 · Refs #17383

**Close-target is deliberately #17450, not #17383.** This removes two of three eager mounts. The third is a boot contract rather than a defect, so #17383 keeps the architectural fork and #17450 carries exactly what this PR delivers — a `Resolves #17383` here would auto-close a ticket whose remaining question this does not answer.

Importing `ai/services.mjs` opened SQLite with WAL in every process on the Brain barrel path — a native module load, a `mkdir` and a WAL writer paid by processes that never read a node.

Evidence: L2 (instrumented import probe before/after, plus 11,456-arm Brain unit suite) → L2 achieved. Residual: the barrel still opens the graph via `SystemLifecycleService`, which this PR does not touch — see below.

## Deltas from ticket

**The ticket's own falsifier killed my recommendation's naive form.** I proposed "`initAsync` stops opening storage", with *enumerate `ready()` callers* as the falsifier. Enumerating found **~20 call sites** that already `await GraphService.ready()` and treat it as "the graph is usable", plus **25+ modules** (`MailboxService` 25 sites, `IssueIngestor` 11, `MemoryService` 10) that call graph methods with no readiness await at all. Removing the open would have resolved `ready()` on a null database. So the mount **moved** into `ready()` — the contract is preserved exactly; only *when* the cost is paid changes.

**Three triggers, each found by re-running the probe after the previous fix** rather than trusting a green parse:

| | trigger | this PR |
|---|---|---|
| 1 | `GraphService` singleton — `core/Base.mjs:314-316` schedules `initAsync` from every constructor | mount moved to `ready()` |
| 2 | `WakeSubscriptionService.init()` — a `core.Base` construction hook awaiting readiness | cursor seeds on first `pump()` |
| 3 | `SystemLifecycleService.initAsync():49` | **untouched, deliberately** |

**Why trigger 3 is out of scope.** Its own comment states *"awaiting `ready()` is the whole boot contract"* — it boots Chroma, Inference, GraphService and StorageRouter on purpose. Importing the barrel boots memory-core **by design**. Deleting that while calling it a bug fix is not a repair, so the ticket carries the architectural fork instead.

## Test Evidence

**11,456 Brain arms green.** Two failures on the base run: `GraphService.spec.mjs:1259`, which pinned the old `initAsync` mount and is re-pointed here, and `McpServersHealth.spec.mjs:34`, which asserts `unhealthy` while this seat has a live neural-link bridge — environment-sensitive, unrelated, and recorded previously by `@neo-opus-grace` as pre-existing. Reporting both rather than the greener number.

**New arm, with its control:**
- `initAsync does NOT mount the graph` — asserts `GraphService.db` is null after `initAsync`.
- `CONTROL: mountGraph DOES mount` — without it the arm above also passes on a mount that is simply broken.

**Import probe, before and after:**

| import | before | after |
|---|---|---|
| `ai/services.mjs` (Brain) | 1 mount | 1 mount *(trigger 3)* |
| `ai/services.host.mjs` (host) | 0 | 0 |

The observable is unchanged **on the barrel** while trigger 3 stands — stated plainly rather than buried. What changes is that two of the three paths that mounted it no longer do, so any consumer reaching `GraphService` or `WakeSubscriptionService` outside the full boot no longer pays a database open.

## Post-Merge Validation

Construct `GraphService` without awaiting readiness and assert no `.neo-ai-data/sqlite/*.sqlite-wal` appears. Before this change the WAL existed as soon as the class was constructed.

## Evolution

The `SQLite.mjs:49` dynamic-import mitigation was never wrong — a method-scoped dynamic import is inert until called. The defect was that construction hooks called it. Worth carrying: `core.Base` schedules `initAsync` from **every** constructor, so on a `singleton` any I/O in `initAsync` is I/O at `import`.

Authored by Ada (Claude Opus 5, Claude Code). Session 43441f60-7f2a-4734-82da-22b609b115f9.
