### PR TITLE
feat(fleet): south reading-surface tabs, preset de-costume, Review default (#17451)

### DIFF
--- a/apps/agentos/view/fleet/CatchUpPane.mjs
+++ b/apps/agentos/view/fleet/CatchUpPane.mjs
@@ -25,7 +25,7 @@ export function resolveCitationTarget(citation) {
 }
 
 /**
- * The invoked S3 Fleet catch-up surface.
+ * The resident S3 Fleet catch-up reading surface (a south-strip tab).
  *
  * @summary Renders two source-owned `notAuthority` Bird View envelopes without synthesizing,
  * ranking, merging, or caching them. The pane owns only local projection Stores: one record per

--- a/apps/agentos/view/fleet/CatchUpPane.mjs
+++ b/apps/agentos/view/fleet/CatchUpPane.mjs
@@ -196,8 +196,11 @@ class CatchUpPane extends Container {
     partitionStore = null
 
     /**
-     * @summary Create the two pane-local Stores, render held owner state, then request history. An
-     * auto-hidden pane is constructed only when revealed, so this is invoked-not-ambient by layout.
+     * @summary Create the two pane-local Stores, render held owner state, then request history. A
+     * resident south-tab pane constructs at projection time, so this first request can fire BEFORE
+     * the fleet bridge wires; the owning cockpit re-drives history at bridge arrival (and via the
+     * Reconnect affordance), so the cold-before-bridge ordering recovers instead of pinning the
+     * unavailable envelope.
      * @param {...*} args
      */
     onConstructed(...args) {

--- a/apps/agentos/view/fleet/FleetCockpit.mjs
+++ b/apps/agentos/view/fleet/FleetCockpit.mjs
@@ -845,14 +845,33 @@ class FleetCockpit extends Container {
             return {errors, switched: false}
         }
 
-        if (!document.items.detail?.autoHidden && !me.detailRecord) {
-            me.detailRecord = me.getReference('fleet-grid')?.store?.first() ?? null
+        const revealsInspector = me.isInspectorRevealed(document);
+
+        if (revealsInspector && !me.detailRecord) {
+            me.detailRecord = me.resolveFleetRosterStore()?.first() ?? null
         }
 
         me.presetError = null;
         me.onDockZoneDocumentChange(document);
-        me.detailRecord && me.getAgentDetailPane()?.set({record: me.detailRecord});
+        revealsInspector && me.detailRecord && me.getAgentDetailPane()?.set({record: me.detailRecord});
         return {errors: [], switched: true}
+    }
+
+    /**
+     * @summary TRUE only when a document actually REVEALS the inspector: the detail item sits in a
+     * tabs node of the tree (absence fails — a valid no-detail document must never read as
+     * revealed), is not auto-hidden to the rail, and is its node's active tab or the node's only
+     * member. `!items.detail?.autoHidden` alone is TRUE for an absent item, so an unrelated valid
+     * perspective would mutate the owner-held selection — the round-1 falsifier.
+     * @param {Object} document A committed `dockZone.v1` document.
+     * @returns {Boolean}
+     */
+    isInspectorRevealed(document) {
+        const tabsId = DockZoneModel.findContainingTabsId(document, 'detail'),
+              node   = tabsId ? document.nodes[tabsId] : null;
+
+        return !!node && !document.items.detail?.autoHidden
+            && (node.activeItemId === 'detail' || node.items.length === 1)
     }
 
     /**
@@ -1248,6 +1267,23 @@ class FleetCockpit extends Container {
     }
 
     /**
+     * @summary Resolve the provider-hosted `fleetRoster` Store — the sanctioned
+     * `getStateProvider().getStore()` access ({@link #resolveAgentDefinitionsStore}'s pattern).
+     * The roster's value authority is the root provider, never the projected grid child: resident
+     * panes resolve BEFORE the grid exists in the projection order, and the inspector must be able
+     * to default a selection while the grid is torn out or absent. Bare unit mounts degrade to
+     * `null` — consumers render their honest empty options.
+     * @returns {Neo.data.Store|null}
+     */
+    resolveFleetRosterStore() {
+        try {
+            return this.getStateProvider()?.getStore('fleetRoster') ?? null
+        } catch {
+            return null
+        }
+    }
+
+    /**
      * @summary Resolves a dock item's `componentRef` to its pane config — the cockpit's keeper
      * surfaces for the live refs, honest placeholders for panes whose views are sibling leaves.
      *
@@ -1396,7 +1432,7 @@ class FleetCockpit extends Container {
                     reference: 'catch-up'
                 };
             case 'memories':
-                // invoked per-agent session-summary recall: the pane renders the owner-held
+                // resident per-agent session-summary recall (a south reading-surface tab): the pane renders the owner-held
                 // source envelope and fires intent; this cockpit owns the authenticated bridge.
                 // The selected target travels WITH the snapshot (one coherent state key), so a
                 // rematerialized pane never shows cards no selection points at. Agent choices
@@ -1536,6 +1572,17 @@ class FleetCockpit extends Container {
     }
 
     /**
+     * @summary Resolve the live {@link AgentOS.view.fleet.CatchUpPane} instance whether it is
+     * docked or gesture-torn into a vessel — the {@link #getOperatorMailboxPane} contract for the
+     * catch-up reading surface, so roster-driven option refreshes and the bridge-arrival history
+     * re-drive reach a torn pane too.
+     * @returns {Neo.container.Base|null} The catch-up pane, or `null` before materialization.
+     */
+    getCatchUpPane() {
+        return this.tearOutPaneHandles?.catchUp || this.getReference('catch-up')
+    }
+
+    /**
      * @summary Resolve the live {@link AgentOS.view.fleet.MemoriesPane} instance whether it is
      * docked, revealed, or vesseled — the click pop-out ({@link #popOutMemories}) and the gesture
      * tear-out share one pathway, so one handle map answers both. Owner-side pushes (snapshot
@@ -1563,8 +1610,9 @@ class FleetCockpit extends Container {
      * @param {String} request.itemId
      * @param {Object} request.proxyRect
      * @param {Boolean} [request.requireProjectedPane=true] The gesture needs a LIVE projected pane
-     *     (you tear what you can see); the click pop-out ({@link #popOutMemories}) materializes a
-     *     rail-lazy pane from owner-held state itself, so it opts out of this precondition only.
+     *     (you tear what you can see); the click pop-out ({@link #popOutMemories}) can materialize
+     *     a not-yet-projected pane from owner-held state itself (rail-lazy chrome, or a resident
+     *     item a custom document dropped), so it opts out of this precondition only.
      * @returns {Promise<{popupHeight: Number, popupWidth: Number, windowName: String}|null>}
      * @protected
      */
@@ -2128,8 +2176,9 @@ class FleetCockpit extends Container {
         }
 
         // capture the live pane synchronously before the commit's re-projection can destroy it
-        // (the gesture order); a rail-lazy pane that was never projected materializes from
-        // owner-held state instead — same resolver, vessel-bound rather than projection-bound
+        // (the gesture order); a pane that was never projected (rail-lazy chrome — resident tabs
+        // always project) materializes from owner-held state instead — same resolver,
+        // vessel-bound rather than projection-bound
         me.captureTearOutPane(itemId);
 
         if (!me.tearOutPaneHandles[itemId]) {
@@ -2599,10 +2648,24 @@ class FleetCockpit extends Container {
             // "no one is online" operator falsifier), and a recovered producer clears it on the
             // next poll. Absent/malformed envelopes plumb null — the chip claims nothing.
             grid.presenceCapability = capabilities?.presence ?? null;
-            me.getReference('catch-up')?.set({partitionOptions: me.buildCatchUpPartitionOptions()});
+            me.getCatchUpPane()?.set({partitionOptions: me.buildCatchUpPartitionOptions()});
             me.getMemoriesPane()?.set({agentOptions: me.buildMemoriesAgentOptions()});
             // the activity rows' actor chips join the same roster truth (avatar + display name)
             me.getReference('activity-stream')?.set({actorDirectory: me.buildActivityActorDirectory()});
+            // resident panes snapshot their roster-derived options at projection time, which can
+            // precede this first live answer — every consumer refreshes here, the mailbox included
+            // (recipients grow beyond the boot-time AGENT:* sentinel), and the seat-conflation
+            // posture re-derives against the roster that can now actually judge it.
+            me.getOperatorMailboxPane()?.set({recipientOptions: me.buildOperatorRecipientOptions()});
+            if (me.operatorRecord) {
+                me.operatorIdentityPosture = me.deriveOperatorIdentityPosture(me.operatorRecord.agentIdentityNodeId);
+                me.getOperatorMailboxPane()?.set({identityPosture: me.operatorIdentityPosture})
+            }
+            // a resident CatchUp can emit its construction-time history request BEFORE the bridge
+            // wires (the cold-before-bridge ordering); that one-shot miss recovers the moment the
+            // bridge answers, through the pane's own guarded refresh path — the Reconnect
+            // affordance's documented re-drive, fired automatically at bridge arrival.
+            me.catchUpSnapshot?.capability?.state === 'unavailable' && me.getCatchUpPane()?.onRefreshClick();
             me.clearDegradedReason('grid')
         } catch (error) {
             // fenced: a slow failure must not overwrite a newer success (see the stream twin)
@@ -2628,7 +2691,7 @@ class FleetCockpit extends Container {
      * @returns {Object}
      */
     buildActivityActorDirectory() {
-        const rows = this.getReference('fleet-grid')?.store?.items ?? [];
+        const rows = this.resolveFleetRosterStore()?.items ?? [];
 
         return Object.fromEntries(rows
             .filter(row => row.agentId)
@@ -2647,7 +2710,7 @@ class FleetCockpit extends Container {
      * @returns {Object[]}
      */
     buildOperatorRecipientOptions() {
-        const rows = this.getReference('fleet-grid')?.store?.items ?? [];
+        const rows = this.resolveFleetRosterStore()?.items ?? [];
 
         return [
             {id: 'AGENT:*', name: 'All agents (broadcast)'},
@@ -2663,7 +2726,7 @@ class FleetCockpit extends Container {
      * @returns {Object[]}
      */
     buildCatchUpPartitionOptions() {
-        const rows = this.getReference('fleet-grid')?.store?.items ?? [];
+        const rows = this.resolveFleetRosterStore()?.items ?? [];
 
         return rows
             .filter(row => row.githubUsername)
@@ -2682,7 +2745,7 @@ class FleetCockpit extends Container {
      * @returns {Object[]}
      */
     buildMemoriesAgentOptions() {
-        const rows = this.getReference('fleet-grid')?.store?.items ?? [];
+        const rows = this.resolveFleetRosterStore()?.items ?? [];
 
         return rows
             .filter(row => row.githubUsername)
@@ -2947,15 +3010,33 @@ class FleetCockpit extends Container {
     /**
      * @summary Focus the existing bounded live Activity surface as adjacency. No history citation is
      * injected into it and no alternate historical authority is implied.
+     *
+     * The stream is a resident south tab, so adjacency ACTIVATES its tab first: the jump usually
+     * originates from a sibling reading surface (catch-up) whose tab is active, and focusing the
+     * inactive card's unmounted DOM would be a silent no-op.
      * @param {Object} request `{target}`
-     * @returns {{opened: Boolean, target: String}}
+     * @returns {Promise<{opened: Boolean, target: String}>}
      */
-    openCatchUpLiveSurface({target} = {}) {
-        const stream = target === 'activity-stream' ? this.getReference('activity-stream') : null;
+    async openCatchUpLiveSurface({target} = {}) {
+        const me     = this,
+              stream = target === 'activity-stream' ? me.getReference('activity-stream') : null;
 
-        stream?.focus(stream.id, false, true);
+        if (!stream) {
+            return {opened: false, target: target || 'unknown'}
+        }
 
-        return {opened: Boolean(stream), target: target || 'unknown'}
+        const strip = me.down({dockNodeId: 'stream-tabs'}),
+              index = me.dockModel?.nodes?.['stream-tabs']?.items?.indexOf('stream') ?? -1;
+
+        if (strip && index > -1 && strip.activeIndex !== index) {
+            strip.activeIndex = index;
+            // the card layout mounts the newly active item asynchronously; focus needs the DOM
+            await me.timeout(50)
+        }
+
+        stream.focus(stream.id, false, true);
+
+        return {opened: true, target}
     }
 
     /**
@@ -3054,8 +3135,9 @@ class FleetCockpit extends Container {
             // already holds knows every registered agent identity, and a viewer claim matching one
             // means sends are attributed to that seat — a truth the pane must render, not swallow
             me.operatorIdentityPosture = me.deriveOperatorIdentityPosture(nodeId);
-            // a materialized pane picks up the identity live and reads; an autoHidden one materializes from
-            // the held record on reveal
+            // a materialized pane picks up the identity live and reads; when this resolution loses
+            // the boot race instead, the resident pane already projected without a record and takes
+            // the identity through this same live set — both orderings land exactly one first read
             me.getOperatorMailboxPane()?.set({record: me.operatorRecord, identityPosture: me.operatorIdentityPosture})
         }
     }
@@ -3072,7 +3154,7 @@ class FleetCockpit extends Container {
      * @returns {{conflated: Boolean, seatIdentity: String}|null}
      */
     deriveOperatorIdentityPosture(viewerIdentity) {
-        const rows = this.getReference('fleet-grid')?.store?.items ?? [];
+        const rows = this.resolveFleetRosterStore()?.items ?? [];
 
         if (typeof viewerIdentity !== 'string' || !viewerIdentity.trim() || rows.length < 1) {
             return null
@@ -3379,7 +3461,7 @@ class FleetCockpit extends Container {
         // manual pane action — the dead-pane gap. Each pane's own refresh handler carries its
         // guards (active agent / partition), so re-driving through it is exactly the button's path.
         me.getMemoriesPane()?.onRefreshClick();
-        me.getReference('catch-up')?.onRefreshClick();
+        me.getCatchUpPane()?.onRefreshClick();
         me.getReference('wakeRoutes')?.onRefreshClick()
     }
 

--- a/apps/agentos/view/fleet/FleetCockpit.mjs
+++ b/apps/agentos/view/fleet/FleetCockpit.mjs
@@ -929,7 +929,9 @@ class FleetCockpit extends Container {
 
         let me = this;
 
-        me.getReference('fleet-grid')?.store?.on({load: me.onRosterStoreLoad, recordChange: me.onDetailRecordChange, scope: me});
+        // the listener authority is the provider-owned Store, same as every roster read/write —
+        // it exists (and keeps reconciling) whether or not the grid projection currently does
+        me.resolveFleetRosterStore()?.on({load: me.onRosterStoreLoad, recordChange: me.onDetailRecordChange, scope: me});
 
         me.loadActivity();
         me.loadRoster();
@@ -1540,7 +1542,7 @@ class FleetCockpit extends Container {
             me.reconcilingRoster = true;
 
             try {
-                me.reconcileRoster(me.getReference('fleet-grid').store, me.lastLiveRows)
+                me.reconcileRoster(me.resolveFleetRosterStore(), me.lastLiveRows)
             } finally {
                 me.reconcilingRoster = false
             }
@@ -1592,7 +1594,7 @@ class FleetCockpit extends Container {
      * @returns {Neo.container.Base|null} The memories pane, or `null` before materialization.
      */
     getMemoriesPane() {
-        // returningTearOutPanes covers the vessel-death parking window: the rail's lazy reveal may
+        // returningTearOutPanes covers the vessel-death parking window: the next projection may
         // not adopt the returning pane for a while, and an owner push landing in that window must
         // still reach the LIVE instance — otherwise the eventual adoption renders a stale snapshot.
         return this.tearOutPaneHandles?.memories || this.returningTearOutPanes?.memories || this.getReference('memories')
@@ -2128,11 +2130,12 @@ class FleetCockpit extends Container {
      * `?detail=agent-detail` shape loads; {@link #onWindowConnect}'s tear-out branch adopts it.
      * The dock document stays the layout SSOT: {@link #applyTearOutOperation} captures the exact
      * `{tabsNodeId, index}` placement before the `detachItem` commit, so the vessel-death return
-     * ({@link #reintegrateTearOutItem}) restores the item at its stored rail position.
+     * ({@link #reintegrateTearOutItem}) restores the item at its stored home position.
      *
      * Selection travel is BY IDENTITY: the vessel hosts the LIVE pane instance (or one
-     * materialized from the owner-held `memoriesTarget`/`memoriesSnapshot` when the rail's lazy
-     * reveal never projected it), so the active agent and cards move with the window — stronger
+     * materialized from the owner-held `memoriesTarget`/`memoriesSnapshot` when a custom
+     * document dropped it from the tree — resident tabs otherwise always project), so the active
+     * agent and cards move with the window — stronger
      * than a URL parameter, and exactly the rematerialization contract the memories source
      * documents. A blocked popup (`windowOpen` resolves `false`, it never throws) refuses before
      * any document mutation — commit-or-neither.
@@ -2194,7 +2197,7 @@ class FleetCockpit extends Container {
     /**
      * @summary Bring the vesseled Memories pane home by closing its OS window: vessel death IS
      * the return path — {@link #onWindowDisconnect}'s tear-out branch correlates the close and
-     * {@link #reintegrateTearOutItem} restores the same live instance at its stored rail
+     * {@link #reintegrateTearOutItem} restores the same live instance at its stored home
      * position. Closing by the immutable window NAME covers the not-yet-connected window too.
      * @returns {Promise<{returned: Boolean, errors: String[]}>}
      */
@@ -2380,7 +2383,7 @@ class FleetCockpit extends Container {
         }
 
         const
-            store   = me.getReference('fleet-grid')?.store,
+            store   = me.resolveFleetRosterStore(),
             current = store?.get(me.detailRecord.agentId) ?? null;
 
         if (current !== me.detailRecord) {
@@ -2409,7 +2412,7 @@ class FleetCockpit extends Container {
         me.viewerWakeConsumer = null;
         me.viewerWakeBridge   = null;
 
-        me.getReference('fleet-grid')?.store?.un({load: me.onRosterStoreLoad, recordChange: me.onDetailRecordChange, scope: me});
+        me.resolveFleetRosterStore()?.un({load: me.onRosterStoreLoad, recordChange: me.onDetailRecordChange, scope: me});
 
         Neo.currentWorker.un({
             connect   : me.onWindowConnect,
@@ -2563,7 +2566,10 @@ class FleetCockpit extends Container {
      * @protected
      */
     async loadRoster() {
-        let me     = this,
+        let me = this,
+            // the WRITE authority is the provider-owned Store — a torn/absent grid must not stop
+            // live ingest (round-2 RA-1: the projected child renders, it never owns the roster)
+            store  = me.resolveFleetRosterStore(),
             grid   = me.getReference('fleet-grid'),
             bridge = globalThis.AgentOS?.fleet?.registryBridge;
 
@@ -2571,7 +2577,7 @@ class FleetCockpit extends Container {
         // read. See {@link #gridReadGeneration}.
         const generation = ++me.gridReadGeneration;
 
-        if (!grid?.store || typeof bridge?.fleetRoster !== 'function') {
+        if (!store || typeof bridge?.fleetRoster !== 'function') {
             // no bridge/verb IS the cold truth — the spine banner must say so. Absence is a
             // DISTINCT transition from a thrown call, and it owns the same retraction duty: a
             // never-wired surface's retained ANSWERED cause ("server connected · registry
@@ -2631,10 +2637,10 @@ class FleetCockpit extends Container {
             me.rosterSourceMode = 'selected';
 
             if (me.rosterWired) {
-                me.reconcileRoster(grid.store, mapped)
+                me.reconcileRoster(store, mapped)
             } else {
-                grid.store.clear();
-                mapped.length > 0 && grid.store.add(mapped);
+                store.clear();
+                mapped.length > 0 && store.add(mapped);
                 me.rosterWired = true;
                 // the first live snapshot replaces the sample seed wholesale — re-seat or clear a
                 // selection made against a now-removed sample record (reconcileRoster owns the later reconciles)
@@ -2642,12 +2648,14 @@ class FleetCockpit extends Container {
             }
 
             me.gridAdapterState = 'live';
-            grid.adapterState   = 'live';
+            // rendering-only writes: the grid is a PROJECTION of the store's truth — torn/absent,
+            // it simply has nothing to paint, and the ingest above happened regardless
+            grid && (grid.adapterState = 'live');
             // the presence-CAPABILITY envelope rides every admitted snapshot onto the grid's chip:
             // a degraded producer gets NAMED at roster level (every band correctly vanished — the
             // "no one is online" operator falsifier), and a recovered producer clears it on the
             // next poll. Absent/malformed envelopes plumb null — the chip claims nothing.
-            grid.presenceCapability = capabilities?.presence ?? null;
+            grid && (grid.presenceCapability = capabilities?.presence ?? null);
             me.getCatchUpPane()?.set({partitionOptions: me.buildCatchUpPartitionOptions()});
             me.getMemoriesPane()?.set({agentOptions: me.buildMemoriesAgentOptions()});
             // the activity rows' actor chips join the same roster truth (avatar + display name)
@@ -3105,8 +3113,8 @@ class FleetCockpit extends Container {
      * (never a viewer-default — a self-default at a trust boundary is spoof-adjacent), so the cockpit first
      * learns its own @-id via `resolveViewerIdentity`, then the pane passes it and the mirror's admission
      * re-stamps + proves it. Pushing the record to a materialized pane drives its first read (the pane fires
-     * `inboxPageRequest` on a newly-bound identity); an autoHidden pane materializes from the held record on
-     * reveal. Fail-closed: an unwired source / unbound context / absent bridge leaves `operatorRecord` null,
+     * `inboxPageRequest` on a newly-bound identity); a pane a custom document dropped materializes from the
+     * held record at its next projection. Fail-closed: an unwired source / unbound context / absent bridge leaves `operatorRecord` null,
      * so the pane stays honestly unobserved — never a fabricated or fallback identity.
      * @protected
      */

--- a/apps/agentos/view/fleet/FleetCockpit.mjs
+++ b/apps/agentos/view/fleet/FleetCockpit.mjs
@@ -827,6 +827,11 @@ class FleetCockpit extends Container {
      * Pane continuity across a switch preserves component identity when the item already exists;
      * genuinely absent surfaces materialize from OWNER-held state ({@link #resolveDockComponentRef}),
      * while the provider-owned roster store never restarts.
+     *
+     * A perspective that reveals the inspector must not land on the empty state: a cold
+     * entry (nothing inspected yet) defaults {@link #detailRecord} to the roster's first resident
+     * BEFORE the commit re-projects, so the pane materializes loaded; a prior selection stays the
+     * owner-held truth. A live pane updates in place through the select seam's owner accessor.
      * @param {String} name The preset's `perspectiveName` (or technical `layoutId`).
      * @returns {{switched: Boolean, errors: String[]}}
      */
@@ -840,8 +845,13 @@ class FleetCockpit extends Container {
             return {errors, switched: false}
         }
 
+        if (!document.items.detail?.autoHidden && !me.detailRecord) {
+            me.detailRecord = me.getReference('fleet-grid')?.store?.first() ?? null
+        }
+
         me.presetError = null;
         me.onDockZoneDocumentChange(document);
+        me.detailRecord && me.getAgentDetailPane()?.set({record: me.detailRecord});
         return {errors: [], switched: true}
     }
 

--- a/apps/agentos/view/fleet/MemoriesPane.mjs
+++ b/apps/agentos/view/fleet/MemoriesPane.mjs
@@ -160,8 +160,8 @@ class MemoriesPane extends Container {
 
     /**
      * @summary Create the pane-local Store and render held owner state. No read fires here:
-     * choosing an agent is the explicit first act, so an auto-hidden pane construction never
-     * queries the plane on its own.
+     * choosing an agent is the explicit first act, so pane construction never queries the plane
+     * on its own — a resident tab constructs at projection time, before any operator intent.
      * @param {...*} args
      */
     onConstructed(...args) {

--- a/apps/agentos/view/fleet/OperatorMailbox.mjs
+++ b/apps/agentos/view/fleet/OperatorMailbox.mjs
@@ -129,9 +129,11 @@ class OperatorMailbox extends Container {
      *
      * The flush is load-bearing: `afterSetRecord`/`afterSetSnapshot`/`afterSetRecipientOptions` all return
      * early while `!isConstructed`, so `record`/`snapshot`/`recipientOptions` supplied as construction
-     * configs (the normal reveal-after-boot path, when the cockpit already holds the resolved operator
-     * identity) never reached the children — the pane materialized empty and could not pass possession.
-     * Flush them here, then a construction-time identity kicks its first read exactly as a live set does.
+     * configs (the identity-before-pane ordering, when the cockpit already holds the resolved operator
+     * identity as the resident pane projects) never reached the children — the pane materialized empty
+     * and could not pass possession. Flush them here, then a construction-time identity kicks its first
+     * read exactly as a live set does; the opposite ordering (pane projects first) lands its single
+     * first read through the cockpit's later live identity set instead.
      * @param {...*} args
      */
     onConstructed(...args) {
@@ -153,7 +155,7 @@ class OperatorMailbox extends Container {
         me.applyIdentityPosture();
 
         // a construction-time identity lands its first inbox read without a page gesture (afterSetRecord
-        // was skipped pre-construct, so this is the single fire for the reveal path)
+        // was skipped pre-construct, so this is the single fire for the identity-before-pane ordering)
         me.record && me.onInboxPageRequest({offset: 0})
     }
 

--- a/apps/agentos/view/fleet/cockpitDockDocument.mjs
+++ b/apps/agentos/view/fleet/cockpitDockDocument.mjs
@@ -1,11 +1,18 @@
 /**
  * The Fleet Cockpit's default dock layout, expressed as pure `neo.harness.dockZone.v1` data.
  *
- * @summary The SSOT §01 mission-control split — the **fleet zone** (~1.55fr: the density-ranked
- * agent-card roster + the scale-to-a-glance health bar) above the live **activity stream** (1fr),
- * which docks to the bottom, with secondary chrome panes declared `autoHidden` (the input the
- * edge-rail auto-hide contract consumes). Roster-agnostic — the fleet zone is a `componentRef`,
- * never a per-agent item list, so the document holds for any fleet size.
+ * @summary The SSOT §01 mission-control split under the shell's one-navigation-vocabulary model —
+ * the **fleet zone** (~1.55fr: the density-ranked agent-card roster + the scale-to-a-glance health
+ * bar) above the **south reading-surface tabs** (1fr: Activity · Memories · Mailbox · Catch-up —
+ * the fleet-scoped continuous reading surfaces an operator returns to many times per session),
+ * with the right edge reserved for selection-scoped inspection (agent detail) and invoked tools,
+ * declared `autoHidden` (the input the edge-rail auto-hide contract consumes). Roster-agnostic —
+ * the fleet zone is a `componentRef`, never a per-agent item list, so the document holds for any
+ * fleet size.
+ *
+ * The region jobs follow that model: south tabs are resident reading surfaces (never
+ * rail-squeezed), the rail carries the inspector plus invoked tools only. The Tasks surface joins
+ * the south family when it lands.
  *
  * This is a **data leaf only**. The projection / render + resize-commit wiring is the sibling leaf;
  * nothing here reads a `DOMRect`, mounts a component, or touches the drag lifecycle. The document
@@ -24,33 +31,31 @@ export function cockpitDockDocument() {
         schema: 'neo.harness.dockZone.v1',
         root  : 'cockpit-root',
         items : {
-            fleet       : {componentRef: 'fleet-grid',       title: 'Fleet',        kind: 'panel'},
-            stream      : {componentRef: 'activity-stream',   title: 'Activity',     kind: 'panel'},
+            fleet : {componentRef: 'fleet-grid',       title: 'Fleet',        kind: 'panel'},
+            stream: {componentRef: 'activity-stream',   title: 'Activity',     kind: 'panel'},
+            // south reading surfaces: per-agent session-summary recall, the operator's own
+            // mailbox + compose surface, and the historical Bird-View complement to the
+            // bounded Activity stream — resident tabs beside it, never rail-squeezed
+            memories    : {componentRef: 'memories',          title: 'Memories',     kind: 'panel'},
+            operator    : {componentRef: 'operator-mailbox',  title: 'Mailbox',      kind: 'panel'},
+            catchUp     : {componentRef: 'catch-up',          title: 'Catch up',     kind: 'panel'},
             detail      : {componentRef: 'agent-detail',      title: 'Agent detail', kind: 'inspector', autoHidden: true},
             perspectives: {componentRef: 'perspectives',      title: 'Perspectives', kind: 'tool',      autoHidden: true},
             // S5 define-agent (design ruling on record: rail placement, invoked-not-ambient) —
             // the add-agent flow rides the same autoHidden tool chrome as perspectives
-            defineAgent : {componentRef: 'define-agent',      title: 'Add agent',    kind: 'tool',      autoHidden: true},
-            // invoked historical complement to the bounded Activity stream — source-owned Bird
-            // Views, Fleet-owned runtime anchor, never ambient cockpit density
-            catchUp     : {componentRef: 'catch-up',          title: 'Catch up',     kind: 'tool',      autoHidden: true},
-            // invoked per-agent session-summary recall — the memory complement to catch-up's
-            // window digests; team-visible summary corpus, never ambient cockpit density
-            memories  : {componentRef: 'memories',          title: 'Memories',     kind: 'tool',      autoHidden: true},
-            wakeRoutes: {componentRef: 'wakeRoutes',        title: 'Wake routes',  kind: 'tool',      autoHidden: true},
-            // the operator's own mailbox + compose surface — a secondary tool pane like
-            // perspectives, so it rides the auto-hide rail and never crowds the split
-            operator    : {componentRef: 'operator-mailbox',  title: 'Operator',     kind: 'tool',      autoHidden: true}
+            defineAgent: {componentRef: 'define-agent',      title: 'Add agent',    kind: 'tool',      autoHidden: true},
+            wakeRoutes : {componentRef: 'wakeRoutes',        title: 'Wake routes',  kind: 'tool',      autoHidden: true}
         },
         nodes: {
             // Root edge-zone: the primary split in the center, the auto-hidden chrome on the right rail.
             'cockpit-root'  : {type: 'edge-zone', zones: {center: 'primary-split', right: 'secondary-rail'}},
-            // SSOT §01: fleet zone (~1.55fr) on top, activity stream (1fr) docked at the bottom — vertical split, normalized to sum 1.
+            // SSOT §01: fleet zone (~1.55fr) on top, the reading-surface tabs (1fr) docked at the bottom — vertical split, normalized to sum 1.
             'primary-split': {type: 'split', orientation: 'vertical', children: ['fleet-tabs', 'stream-tabs'], sizes: [0.6078, 0.3922]},
-            'fleet-tabs'   : {type: 'tabs', items: ['fleet'],  activeItemId: 'fleet'},
-            'stream-tabs'  : {type: 'tabs', items: ['stream'], activeItemId: 'stream'},
-            // Secondary panes collapse to this edge's rail (§2.7): their item records carry `autoHidden`.
-            'secondary-rail': {type: 'tabs', items: ['detail', 'perspectives', 'defineAgent', 'catchUp', 'memories', 'wakeRoutes', 'operator'], activeItemId: 'detail'}
+            'fleet-tabs'   : {type: 'tabs', items: ['fleet'], activeItemId: 'fleet'},
+            // the south reading-surface family: Activity active by default; the Tasks surface joins here.
+            'stream-tabs'  : {type: 'tabs', items: ['stream', 'memories', 'operator', 'catchUp'], activeItemId: 'stream'},
+            // Secondary panes collapse to this edge's rail (§2.7): inspector + invoked tools only; their item records carry `autoHidden`.
+            'secondary-rail': {type: 'tabs', items: ['detail', 'perspectives', 'defineAgent', 'wakeRoutes'], activeItemId: 'detail'}
         }
     }
 }

--- a/apps/agentos/view/fleet/cockpitPresets.mjs
+++ b/apps/agentos/view/fleet/cockpitPresets.mjs
@@ -5,7 +5,9 @@ import cockpitDockDocument from './cockpitDockDocument.mjs';
  * The Fleet Cockpit's seeded perspective presets — the §01 duty variants as pure
  * `dockLayoutCollection.v1` data over the landed saved-layout wrappers:
  *
- * - **Fleet** — the default mission-control split (the authored dock document, unchanged).
+ * - **Overview** — the default mission-control split (the authored dock document, unchanged).
+ *   Named so the preset reads as a LAYOUT control: the former "Fleet" name collided with the
+ *   Fleet keeper tab while meaning something else entirely.
  * - **Focus** — the fleet zone dominant: the ranked roster takes nearly the full column, the
  *   activity stream stays a thin live strip (watching the fleet, not the feed).
  * - **Review** — one agent under review: the right chrome band opens on the agent-detail pane
@@ -19,10 +21,10 @@ import cockpitDockDocument from './cockpitDockDocument.mjs';
  * thrown loudly (an authored preset that fails validation is a build-time defect, not a
  * runtime condition).
  *
- * @returns {Object} a fresh `neo.harness.dockLayoutCollection.v1` collection, `fleet` active
+ * @returns {Object} a fresh `neo.harness.dockLayoutCollection.v1` collection, `overview` active
  */
 export function cockpitPresetCollection() {
-    const fleetDoc = cockpitDockDocument();
+    const overviewDoc = cockpitDockDocument();
 
     const focusDoc = cockpitDockDocument();
     focusDoc.nodes['primary-split'].sizes = [0.85, 0.15];
@@ -32,9 +34,9 @@ export function cockpitPresetCollection() {
     reviewDoc.items.detail.autoHidden      = false;
 
     const layouts = [
-        {document: fleetDoc,  layoutId: 'fleet',  perspectiveName: 'Fleet',  title: 'Fleet — mission control'},
-        {document: focusDoc,  layoutId: 'focus',  perspectiveName: 'Focus',  title: 'Focus — roster dominant'},
-        {document: reviewDoc, layoutId: 'review', perspectiveName: 'Review', title: 'Review — one agent + the trail'}
+        {document: overviewDoc, layoutId: 'overview', perspectiveName: 'Overview', title: 'Overview — mission control'},
+        {document: focusDoc,    layoutId: 'focus',    perspectiveName: 'Focus',    title: 'Focus — roster dominant'},
+        {document: reviewDoc,   layoutId: 'review',   perspectiveName: 'Review',   title: 'Review — one agent + the trail'}
     ].map(({document, layoutId, perspectiveName, title}) => {
         const {layout, errors} = DockZoneModel.createSavedLayout(document, {
             layoutId,
@@ -51,7 +53,7 @@ export function cockpitPresetCollection() {
     });
 
     const {collection, errors} = DockZoneModel.createSavedLayoutCollection(layouts, {
-        activeLayoutId: 'fleet',
+        activeLayoutId: 'overview',
         metadata      : {owner: 'fm-cockpit'}
     });
 

--- a/test/playwright/e2e/agentos/FleetCatchUpNL.spec.mjs
+++ b/test/playwright/e2e/agentos/FleetCatchUpNL.spec.mjs
@@ -120,18 +120,19 @@ async function startCatchUpFleet() {
 }
 
 /**
- * @summary Native Fleet catch-up journey: the real auto-hide rail invokes the pane; the App Worker
- * crosses the authenticated allowlisted bridge; a first-use choice yields two source-owned
- * `notAuthority` envelopes; per-agent partitioning changes the Memory read intent; the exact rendered
- * end advances the runtime-only anchor; and Live Activity focuses the existing bounded adjacency.
+ * @summary Native Fleet catch-up journey: activating the resident south-strip tab shows the pane;
+ * the App Worker crosses the authenticated allowlisted bridge; a first-use choice yields two
+ * source-owned `notAuthority` envelopes; per-agent partitioning changes the Memory read intent;
+ * the exact rendered end advances the runtime-only anchor; and Live Activity re-activates the
+ * stream tab and focuses the existing bounded adjacency.
  *
  * Run: NEO_E2E_PORT=49221 NEO_TEST_SKIP_CI=true npx playwright test agentos/FleetCatchUpNL -c test/playwright/playwright.config.e2e.mjs --workers=1
  */
-test.describe('AgentOS Fleet catch-up — authenticated rail journey (#14620)', () => {
+test.describe('AgentOS Fleet catch-up — authenticated resident-tab journey (#14620)', () => {
     test.setTimeout(120000);
     test.use({viewport: {width: 1600, height: 1000}});
 
-    test('rail → explicit window → independent envelopes → partition → mark → live adjacency', async ({page, neuralLink}) => {
+    test('tab → explicit window → independent envelopes → partition → mark → live adjacency', async ({page, neuralLink}) => {
         const fleet = await startCatchUpFleet();
 
         try {

--- a/test/playwright/e2e/agentos/FleetCatchUpNL.spec.mjs
+++ b/test/playwright/e2e/agentos/FleetCatchUpNL.spec.mjs
@@ -5,6 +5,10 @@ import {
     fleetE2ESuccess,
     wireAuthenticatedFleetBridge
 } from './authenticatedFleetHarness.mjs';
+// the human-facing instant renders viewer-local through the ONE shared helper (TOKENS.md T5) —
+// the expectation imports the same helper instead of hard-coding either the UTC wire form or a
+// zone-dependent literal (browser and runner share the host zone)
+import {formatViewerTime} from '../../../../apps/agentos/view/fleet/viewerTime.mjs';
 
 const WINDOW = {
     semantics  : 'half-open',
@@ -141,9 +145,10 @@ test.describe('AgentOS Fleet catch-up — authenticated rail journey (#14620)', 
             expect(cockpit?.properties?.id).toBeTruthy();
             await app.callMethod(cockpit.properties.id, 'loadRoster');
 
-            const rail = page.locator('.neo-dashboard-dock-rail-tab', {hasText: 'Catch up'});
-            await expect(rail).toHaveCount(1);
-            await rail.click();
+            // resident south reading-surface tab (the navigation model): activate, never rail-reveal
+            const tab = page.getByRole('tab', {name: 'Catch up', exact: true});
+            await expect(tab).toHaveCount(1);
+            await tab.click();
 
             const pane = page.locator('.fm-catch-up-pane');
             await expect(pane).toBeVisible({timeout: 10000});
@@ -165,7 +170,7 @@ test.describe('AgentOS Fleet catch-up — authenticated rail journey (#14620)', 
             await expect(pane.locator('.fm-catch-up-source').nth(0)).toContainText('Memory history for @neo-opus-ada');
 
             await pane.getByRole('button', {name: 'Mark caught up'}).click();
-            await expect(pane).toContainText('Caught up through 2026-07-18 12:00Z');
+            await expect(pane).toContainText(`Caught up through ${formatViewerTime(WINDOW.windowEnd).text}`);
 
             await pane.getByRole('button', {name: 'Live activity'}).click();
             await expect.poll(() => page.locator('.fm-activity-stream').evaluate(element => document.activeElement === element))

--- a/test/playwright/e2e/agentos/FleetCockpitDockNL.spec.mjs
+++ b/test/playwright/e2e/agentos/FleetCockpitDockNL.spec.mjs
@@ -268,7 +268,7 @@ test.describe('AgentOS Fleet cockpit — dock projection commit loop (Neural Lin
 
         // ...and back to the default duty
         await NeuralLink_InstanceService.callMethod({
-            sessionId: app.sessionId, id: holderId, method: 'activatePerspective', args: ['Fleet']
+            sessionId: app.sessionId, id: holderId, method: 'activatePerspective', args: ['Overview']
         });
 
         await expect.poll(primarySizes, {message: 'the Fleet switch must restore the default split', timeout: 10000, intervals: [100]})

--- a/test/playwright/e2e/agentos/FleetCockpitNWindowNL.spec.mjs
+++ b/test/playwright/e2e/agentos/FleetCockpitNWindowNL.spec.mjs
@@ -204,16 +204,10 @@ test.describe('AgentOS Fleet Cockpit — N-window mailbox film beat (#15650)', (
             await app.callMethod(cockpitId, 'loadActivity');
             await app.callMethod(cockpitId, 'loadOperatorIdentity');
 
-            // Materialize the operator pane through the production reducer/commit pair. The pane
-            // stays ordinary dock content; no film-only product control or executor is introduced.
-            const pinResult = await app.callMethod(cockpitId, 'applyDockZoneOperation', [{
-                operation : 'setItemAutoHidden',
-                itemId    : 'operator',
-                autoHidden: false
-            }]);
-
-            expect(pinResult.errors).toEqual([]);
-            await app.callMethod(cockpitId, 'onDockZoneDocumentChange', [pinResult.document]);
+            // The operator pane is a resident south tab (the navigation model): activating its tab
+            // mounts the body through the production tab machinery. The pane stays ordinary dock
+            // content; no film-only product control or executor is introduced.
+            await page.getByRole('tab', {name: 'Mailbox', exact: true}).click();
 
             await expect.poll(async () => first(await app.queryComponent(
                 {className: 'AgentOS.view.fleet.OperatorMailbox'},

--- a/test/playwright/e2e/agentos/FleetMemoriesNL.spec.mjs
+++ b/test/playwright/e2e/agentos/FleetMemoriesNL.spec.mjs
@@ -1,4 +1,7 @@
 import {expect, test}                                            from '../../fixtures.mjs';
+// the human-facing instant renders viewer-local through the ONE shared helper (TOKENS.md T5) —
+// the expectation imports it instead of hard-coding the UTC wire form or a zone-dependent literal
+import {formatViewerTime} from '../../../../apps/agentos/view/fleet/viewerTime.mjs';
 import {
     authenticatedFleetOptions,
     fleetE2EFailure,
@@ -148,9 +151,28 @@ test.describe('AgentOS Fleet memories — authenticated rail journey (#16398)', 
             expect(cockpit?.properties?.id).toBeTruthy();
             await app.callMethod(cockpit.properties.id, 'loadRoster');
 
-            const rail = page.locator('.neo-dashboard-dock-rail-tab', {hasText: 'Memories'});
-            await expect(rail).toHaveCount(1);
-            await rail.click();
+            // resident south reading-surface tab (the navigation model): activate, never rail-reveal
+            const tab = page.getByRole('tab', {name: 'Memories', exact: true});
+            await expect(tab).toHaveCount(1);
+            await tab.click();
+
+            // True-absence removal for the rematerialization variants: a resident tab SWITCH only
+            // hides the inactive card (the instance survives), so the old rail-switch removal no
+            // longer destroys the pane. Drop the item through a committed document (the wire hands
+            // back a clone; committing it is the production reducer path), then re-add + activate.
+            const cockpitId      = cockpit.properties.id,
+                  removeMemories = async () => {
+                      const doc = await app.callMethod(cockpitId, 'getDockZoneDocument');
+                      doc.nodes['stream-tabs'].items = doc.nodes['stream-tabs'].items.filter(id => id !== 'memories');
+                      await app.callMethod(cockpitId, 'onDockZoneDocumentChange', [doc]);
+                      await expect(page.locator('.fm-memories-pane')).toHaveCount(0)
+                  },
+                  restoreMemories = async () => {
+                      const readd = await app.callMethod(cockpitId, 'applyDockZoneOperation', [{operation: 'addTab', itemId: 'memories', tabsNodeId: 'stream-tabs'}]);
+                      expect(readd.errors).toEqual([]);
+                      await app.callMethod(cockpitId, 'onDockZoneDocumentChange', [readd.document]);
+                      await page.getByRole('tab', {name: 'Memories', exact: true}).click()
+                  };
 
             const pane = page.locator('.fm-memories-pane');
             await expect(pane).toBeVisible({timeout: 10000});
@@ -161,16 +183,16 @@ test.describe('AgentOS Fleet memories — authenticated rail journey (#16398)', 
             await expect(pane.locator('.fm-memories-card')).toHaveCount(0);
 
             // ── rematerialization VARIANT B: pending first-ever read, NO prior snapshot ──
-            // Gate Ada's page zero, select her, remove the pane mid-flight (rail switch), return.
+            // Gate Ada's page zero, select her, remove the pane mid-flight (true document
+            // absence), return.
             let releaseAda;
             fleet.gates['@neo-opus-ada'] = new Promise(resolve => { releaseAda = resolve });
 
             await pane.getByRole('button', {name: 'Ada'}).click();
             await expect(pane).toContainText('Reading @neo-opus-ada…');
 
-            await page.locator('.neo-dashboard-dock-rail-tab', {hasText: 'Catch up'}).click();
-            await expect(page.locator('.fm-memories-pane')).toHaveCount(0);
-            await rail.click();
+            await removeMemories();
+            await restoreMemories();
 
             const paneB = page.locator('.fm-memories-pane');
             await expect(paneB).toBeVisible({timeout: 10000});
@@ -186,7 +208,7 @@ test.describe('AgentOS Fleet memories — authenticated rail journey (#16398)', 
             // the in-flight response lands in the REBUILT pane (write-time pane resolve), with
             // the selection attached — variant B's "renders with activeAgent: null" is dead
             await expect(paneB.locator('.fm-memories-card')).toHaveCount(2, {timeout: 10000});
-            await expect(pane).toContainText('@neo-opus-ada · 2 of 3 sessions · captured 2026-08-03 08:00Z');
+            await expect(pane).toContainText(`@neo-opus-ada · 2 of 3 sessions · captured ${formatViewerTime(CAPTURED_AT).text}`);
             await expect(pane.locator('.fm-memories-card').nth(0)).toContainText('Wake transport and integrity contracts');
             await expect(pane.locator('.fm-memories-card').nth(0)).toContainText('feature · 61 memories · quality 95');
             // multi-agent session: attribution beyond the selected target renders explicitly
@@ -221,11 +243,10 @@ test.describe('AgentOS Fleet memories — authenticated rail journey (#16398)', 
             await expect(pane).toContainText('Waiting for this agent’s first page.');
 
             // ── rematerialization VARIANT A: pending switch WITH a prior (Ada) snapshot held ──
-            // Remove + rebuild the pane mid-flight: it must reopen on the PENDING selection,
-            // never on the stale accepted snapshot's target, cards, or continuation.
-            await page.locator('.neo-dashboard-dock-rail-tab', {hasText: 'Catch up'}).click();
-            await expect(page.locator('.fm-memories-pane')).toHaveCount(0);
-            await rail.click();
+            // Remove + rebuild the pane mid-flight (true document absence): it must reopen on the
+            // PENDING selection, never on the stale accepted snapshot's target, cards, or continuation.
+            await removeMemories();
+            await restoreMemories();
             await expect(pane).toBeVisible({timeout: 10000});
             await expect(pane).toContainText('Reading @neo-gpt-bob…');
             await expect(pane).not.toContainText('@neo-opus-ada · 3 of 3');

--- a/test/playwright/e2e/agentos/FleetMemoriesNL.spec.mjs
+++ b/test/playwright/e2e/agentos/FleetMemoriesNL.spec.mjs
@@ -125,19 +125,21 @@ async function startMemoriesFleet() {
 }
 
 /**
- * @summary Native Fleet memories journey over session summaries: the real auto-hide rail invokes
- * the pane; choosing an agent is the explicit first act; the App Worker crosses the authenticated
- * allowlisted bridge; summary cards render with honest multi-agent attribution; the offset pages
- * older sessions as an append against the corpus total; guarded non-string titles/summaries are
- * named; and the wire carries only the explicit target — never a viewer claim, never a projection.
+ * @summary Native Fleet memories journey over session summaries: activating the resident
+ * south-strip tab shows the pane; choosing an agent is the explicit first act; the App Worker
+ * crosses the authenticated allowlisted bridge; summary cards render with honest multi-agent
+ * attribution; the offset pages older sessions as an append against the corpus total; guarded
+ * non-string titles/summaries are named; and the wire carries only the explicit target — never a
+ * viewer claim, never a projection. The rematerialization variants create TRUE document absence
+ * (committed clones) — a resident tab switch only hides the inactive card.
  *
  * Run: NEO_E2E_PORT=49223 NEO_TEST_SKIP_CI=true npx playwright test agentos/FleetMemoriesNL -c test/playwright/playwright.config.e2e.mjs --workers=1
  */
-test.describe('AgentOS Fleet memories — authenticated rail journey (#16398)', () => {
+test.describe('AgentOS Fleet memories — authenticated resident-tab journey (#16398)', () => {
     test.setTimeout(120000);
     test.use({viewport: {width: 1600, height: 1000}});
 
-    test('rail → explicit agent choice → summary cards → offset append → guarded non-string card', async ({page, neuralLink}) => {
+    test('tab → explicit agent choice → summary cards → offset append → guarded non-string card', async ({page, neuralLink}) => {
         const fleet = await startMemoriesFleet();
 
         try {

--- a/test/playwright/e2e/agentos/OperatorMailboxNL.spec.mjs
+++ b/test/playwright/e2e/agentos/OperatorMailboxNL.spec.mjs
@@ -70,12 +70,14 @@ test.describe('AgentOS operator mailbox mounted delivery journey (#15377)', () =
             await app.callMethod(cockpit.properties.id, 'loadRoster');
             await app.callMethod(cockpit.properties.id, 'loadOperatorIdentity');
 
-            const operatorRail = page.locator('.neo-dashboard-dock-rail-tab', {hasText: 'Operator'});
-            await expect(operatorRail).toHaveCount(1);
-            await operatorRail.click();
-            const overlay = page.locator('.neo-dashboard-dock-reveal-overlay');
-            await expect(overlay).toBeVisible({timeout: 10000});
-            await expect(overlay).toContainText('No active messages for @e2e-operator');
+            // resident south tab titled "Mailbox" (the navigation model): activate the tab and the
+            // pane renders in the strip's body — no rail reveal, no overlay
+            const mailboxTab = page.getByRole('tab', {name: 'Mailbox', exact: true});
+            await expect(mailboxTab).toHaveCount(1);
+            await mailboxTab.click();
+            const mailboxPane = page.locator('.fm-operator-mailbox');
+            await expect(mailboxPane).toBeVisible({timeout: 10000});
+            await expect(mailboxPane).toContainText('No active messages for @e2e-operator');
 
             const [mailbox] = await app.queryComponent({className: 'AgentOS.view.fleet.OperatorMailbox'}, ['id', 'record', 'snapshot']),
                   [form]    = await app.queryComponent({className: 'AgentOS.view.fleet.OperatorComposeForm'}, ['id', 'recipientOptions', 'composeOutcome']),
@@ -91,7 +93,7 @@ test.describe('AgentOS operator mailbox mounted delivery journey (#15377)', () =
                   message          = page.getByRole('textbox', {name: 'Message'}),
                   send             = page.getByRole('button', {name: 'Send'}),
                   choose           = async name => {
-                      const row = overlay
+                      const row = mailboxPane
                           .locator('.fm-operator-compose-recipients-list')
                           .getByRole('listitem')
                           .filter({hasText: name});
@@ -119,8 +121,8 @@ test.describe('AgentOS operator mailbox mounted delivery journey (#15377)', () =
                     {to: '@review-peer-a', outcome: expect.objectContaining({messageId: expect.any(String)})},
                     {to: '@review-peer-b', outcome: {status: 'rejected', reason: 'fixture rejection'}}
                 ]});
-            await expect(overlay).toContainText('@review-peer-a — sent');
-            await expect(overlay).toContainText('@review-peer-b — fixture rejection');
+            await expect(mailboxPane).toContainText('@review-peer-a — sent');
+            await expect(mailboxPane).toContainText('@review-peer-b — fixture rejection');
 
             await clearRecipients();
             await choose('All agents (broadcast)');
@@ -148,8 +150,12 @@ test.describe('AgentOS operator mailbox mounted delivery journey (#15377)', () =
                 }
             });
             expect(fit.overflowY).toBe('auto');
-            expect(fit.scrollHeight).toBeGreaterThan(fit.clientHeight);
-            const finalOutcome = overlay.getByText('AGENT:* — sent', {exact: true});
+            // The reachability contract: the scroll MECHANIC is armed (overflowY above) and the
+            // final outcome is reachable below. The old rail overlay was short enough that this
+            // fixture always overflowed; the resident south-tab body is taller, so content may
+            // legitimately FIT — never assert overflow itself, only that nothing is clipped away.
+            expect(fit.scrollHeight).toBeGreaterThanOrEqual(fit.clientHeight);
+            const finalOutcome = mailboxPane.getByText('AGENT:* — sent', {exact: true});
             await finalOutcome.scrollIntoViewIfNeeded();
             await expect(finalOutcome).toBeVisible();
 

--- a/test/playwright/unit/apps/agentos/cockpitDockDocument.spec.mjs
+++ b/test/playwright/unit/apps/agentos/cockpitDockDocument.spec.mjs
@@ -36,15 +36,19 @@ test.describe('AgentOS.view.fleet cockpit dock document — dockZone.v1 default 
         expect(fleetSize / streamSize).toBeCloseTo(1.55, 1) // ~1.55 : 1
     });
 
-    test('declares the secondary chrome panes autoHidden (the #14617 rail input); primaries are not', () => {
+    test('declares the inspector + tool chrome autoHidden (the #14617 rail input); primaries and reading surfaces are not', () => {
         const {items} = cockpitDockDocument();
 
         const autoHidden = Object.entries(items).filter(([, i]) => i.autoHidden === true).map(([id]) => id);
-        expect(autoHidden.length).toBeGreaterThan(0);
-        expect(autoHidden).toEqual(expect.arrayContaining(['detail', 'perspectives', 'defineAgent', 'catchUp']));
+        expect(autoHidden.sort()).toEqual(['defineAgent', 'detail', 'perspectives', 'wakeRoutes']);
 
         expect(items.fleet.autoHidden).toBeUndefined();
-        expect(items.stream.autoHidden).toBeUndefined()
+        expect(items.stream.autoHidden).toBeUndefined();
+
+        // reading surfaces are resident south tabs, never rail-collapsed
+        expect(items.memories.autoHidden).toBeUndefined();
+        expect(items.operator.autoHidden).toBeUndefined();
+        expect(items.catchUp.autoHidden).toBeUndefined()
     });
 
     test('carries the S5 define-agent zone: rail-resident, invoked-not-ambient tool chrome (the design ruling)', () => {
@@ -64,18 +68,19 @@ test.describe('AgentOS.view.fleet cockpit dock document — dockZone.v1 default 
         expect(doc.nodes['stream-tabs'].items).not.toContain('defineAgent')
     });
 
-    test('carries S3 catch-up as invoked rail chrome, never ambient cockpit density', () => {
+    test('carries the south reading-surface family: resident tabs beside Activity, Activity active', () => {
         const doc = cockpitDockDocument();
 
-        expect(doc.items.catchUp).toEqual({
-            componentRef: 'catch-up',
-            title       : 'Catch up',
-            kind        : 'tool',
-            autoHidden  : true
-        });
-        expect(doc.nodes['secondary-rail'].items).toContain('catchUp');
-        expect(doc.nodes['fleet-tabs'].items).not.toContain('catchUp');
-        expect(doc.nodes['stream-tabs'].items).not.toContain('catchUp')
+        expect(doc.items.memories).toEqual({componentRef: 'memories',         title: 'Memories', kind: 'panel'});
+        expect(doc.items.operator).toEqual({componentRef: 'operator-mailbox', title: 'Mailbox',  kind: 'panel'});
+        expect(doc.items.catchUp).toEqual({componentRef: 'catch-up',          title: 'Catch up', kind: 'panel'});
+
+        expect(doc.nodes['stream-tabs'].items).toEqual(['stream', 'memories', 'operator', 'catchUp']);
+        expect(doc.nodes['stream-tabs'].activeItemId).toBe('stream');
+
+        // the rail is inspector + invoked tools only — reading surfaces never squeeze onto it
+        expect(doc.nodes['secondary-rail'].items).toEqual(['detail', 'perspectives', 'defineAgent', 'wakeRoutes']);
+        expect(doc.nodes['fleet-tabs'].items).toEqual(['fleet'])
     });
 
     test('is pure data — a fresh, equal document each call (no shared mutable singleton)', () => {

--- a/test/playwright/unit/apps/agentos/view/fleet/fleetCatchUpCockpit.spec.mjs
+++ b/test/playwright/unit/apps/agentos/view/fleet/fleetCatchUpCockpit.spec.mjs
@@ -85,20 +85,30 @@ test.describe('FleetCockpit — catch-up owner routing', () => {
         expect(pane.snapshot).toEqual({id: 'new'})
     });
 
-    test('partition choices come from roster mailbox identities; live adjacency focuses the real stream', () => {
+    test('partition choices come from roster mailbox identities; live adjacency activates the stream TAB, then focuses', async () => {
         const focused = [],
               rows    = [
                   {agentId: 'ada', githubUsername: 'neo-opus-ada', displayName: 'Ada'},
                   {agentId: 'guest', githubUsername: null, displayName: 'Guest'}
               ],
               stream = {id: 'stream-1', focus: (...args) => focused.push(args)},
-              cockpit = {getReference: ref => ref === 'fleet-grid' ? {store: {items: rows}} : ref === 'activity-stream' ? stream : null};
+              // the resident south strip: catch-up is the active tab when the jump fires, so the
+              // adjacency must re-activate the stream's tab before focus can reach mounted DOM
+              strip   = {activeIndex: 3},
+              cockpit = {
+                  dockModel              : {nodes: {'stream-tabs': {items: ['stream', 'memories', 'operator', 'catchUp']}}},
+                  down                   : config => config.dockNodeId === 'stream-tabs' ? strip : null,
+                  getReference           : ref => ref === 'activity-stream' ? stream : null,
+                  resolveFleetRosterStore: () => ({items: rows}),
+                  timeout                : () => Promise.resolve()
+              };
 
         expect(FleetCockpit.prototype.buildCatchUpPartitionOptions.call(cockpit)).toEqual([
             {id: 'catch-up-ada', label: 'Ada', partition: '@neo-opus-ada'}
         ]);
-        expect(FleetCockpit.prototype.openCatchUpLiveSurface.call(cockpit, {target: 'activity-stream'}))
-            .toEqual({opened: true, target: 'activity-stream'});
+        await expect(FleetCockpit.prototype.openCatchUpLiveSurface.call(cockpit, {target: 'activity-stream'}))
+            .resolves.toEqual({opened: true, target: 'activity-stream'});
+        expect(strip.activeIndex, 'the stream tab is active again').toBe(0);
         expect(focused).toEqual([['stream-1', false, true]])
     })
 });

--- a/test/playwright/unit/apps/agentos/view/fleet/fleetCockpit.spec.mjs
+++ b/test/playwright/unit/apps/agentos/view/fleet/fleetCockpit.spec.mjs
@@ -213,10 +213,15 @@ test.describe('Fleet cockpit — Store-backed roster (loadRoster)', () => {
     const makeCockpit = (grid, rosterWired = false, gridAdapterState = 'sample', rosterSourceMode = 'sample') => ({
         clearDegradedReason: FleetCockpit.prototype.clearDegradedReason,
         degradeWiredSurface: FleetCockpit.prototype.degradeWiredSurface,
-        // the memories owner push routes through the phase-blind accessor; an
+        // the resident-pane owner pushes route through the phase-blind accessors; an
         // unmaterialized pane resolves null — the same silence contract as getReference
-        getMemoriesPane: () => null,
-        getReference   : reference => reference === 'fleet-grid' ? grid : null,
+        getCatchUpPane        : () => null,
+        getMemoriesPane       : () => null,
+        getOperatorMailboxPane: () => null,
+        getReference          : reference => reference === 'fleet-grid' ? grid : null,
+        // the provider-owned roster authority: in this fixture the grid's bound store IS the
+        // provider store, so the builders read the same truth the reconcile writes
+        resolveFleetRosterStore: () => grid?.store ?? null,
         // mirrors the class field default — the loss edge reads it to keep a never-wired surface
         // on its honest sample seed instead of claiming last-known data
         gridAdapterState,
@@ -1276,17 +1281,21 @@ test.describe('Fleet cockpit — controller re-polls the roster on a settled lif
         const cockpit = {
             clearDegradedReason: FleetCockpit.prototype.clearDegradedReason,
             degradeWiredSurface: FleetCockpit.prototype.degradeWiredSurface,
-            // the memories owner push routes through the phase-blind accessor; an
+            // the resident-pane owner pushes route through the phase-blind accessors; an
             // unmaterialized pane resolves null — the same silence contract as getReference
-            getMemoriesPane   : () => null,
-            getReference      : reference => reference === 'fleet-grid' ? {adapterState: 'sample', store} : null,
-            gridAdapterState  : 'sample',
-            gridReadGeneration: 0,
-            mapRosterRow      : FleetCockpit.prototype.mapRosterRow,
-            reconcileRoster   : FleetCockpit.prototype.reconcileRoster,
-            reconcileSelection: FleetCockpit.prototype.reconcileSelection,
-            loadRoster        : FleetCockpit.prototype.loadRoster,
-            rosterWired       : false,
+            getCatchUpPane        : () => null,
+            getMemoriesPane       : () => null,
+            getOperatorMailboxPane: () => null,
+            getReference          : reference => reference === 'fleet-grid' ? {adapterState: 'sample', store} : null,
+            // the provider-owned roster authority — the same REAL store the grid binds
+            resolveFleetRosterStore: () => store,
+            gridAdapterState       : 'sample',
+            gridReadGeneration     : 0,
+            mapRosterRow           : FleetCockpit.prototype.mapRosterRow,
+            reconcileRoster        : FleetCockpit.prototype.reconcileRoster,
+            reconcileSelection     : FleetCockpit.prototype.reconcileSelection,
+            loadRoster             : FleetCockpit.prototype.loadRoster,
+            rosterWired            : false,
             // the real banner sync: null getReference for the slot → guarded no-op, no stub drift
             syncSpineBanner    : FleetCockpit.prototype.syncSpineBanner
         };
@@ -1607,8 +1616,9 @@ test.describe('Fleet cockpit — the spine-banner slot sync (syncSpineBanner)', 
             loadBrainHealth       : () => driven.push('brainHealth'),
             loadRoster            : () => driven.push('roster'),
             ensureViewerWakeStream: () => driven.push('viewerWake'),
-            // the memories re-drive routes through the phase-blind accessor: a vesseled
+            // the resident-pane re-drives route through the phase-blind accessors: a vesseled
             // pane must receive the reconnect re-drive too, so the seam is the accessor, not the raw reference
+            getCatchUpPane : () => panes['catch-up'],
             getMemoriesPane: () => panes.memories,
             getReference   : reference => panes[reference] ?? null
         });
@@ -1626,6 +1636,7 @@ test.describe('Fleet cockpit — the spine-banner slot sync (syncSpineBanner)', 
             loadBrainHealth       : () => driven.push('brainHealth'),
             loadRoster            : () => driven.push('roster'),
             ensureViewerWakeStream: () => driven.push('viewerWake'),
+            getCatchUpPane        : () => null,
             getMemoriesPane       : () => null,
             getReference          : () => null
         });
@@ -2687,8 +2698,8 @@ test.describe('Fleet cockpit — operator mailbox (compose · recipients · own-
 
     // --- buildOperatorRecipientOptions: the live roster → @githubUsername identity mapping -------------
 
-    test('recipients · no roster grid yet → only the broadcast sentinel', () => {
-        const owner = {getReference: () => null};
+    test('recipients · no provider roster yet → only the broadcast sentinel', () => {
+        const owner = {resolveFleetRosterStore: () => null};
 
         expect(FleetCockpit.prototype.buildOperatorRecipientOptions.call(owner)).toEqual([
             {id: 'AGENT:*', name: 'All agents (broadcast)'}
@@ -2703,7 +2714,7 @@ test.describe('Fleet cockpit — operator mailbox (compose · recipients · own-
             {agentId: 'grace', githubUsername: 'neo-claude-opus'},
             {agentId: 'guest'}
         ];
-        const owner = {getReference: reference => reference === 'fleet-grid' ? {store: {items}} : null};
+        const owner = {resolveFleetRosterStore: () => ({items})};
 
         expect(FleetCockpit.prototype.buildOperatorRecipientOptions.call(owner)).toEqual([
             {id: 'AGENT:*',          name: 'All agents (broadcast)'},
@@ -2830,7 +2841,8 @@ test.describe('Fleet cockpit — operator mailbox (compose · recipients · own-
                   operatorRecord               : null,
                   deriveOperatorIdentityPosture: FleetCockpit.prototype.deriveOperatorIdentityPosture,
                   getReference                 : () => null,
-                  getOperatorMailboxPane       : () => pane
+                  getOperatorMailboxPane       : () => pane,
+                  resolveFleetRosterStore      : () => null
               };
 
         await FleetCockpit.prototype.loadOperatorIdentity.call(cockpit);
@@ -2855,17 +2867,20 @@ test.describe('Fleet cockpit — operator mailbox (compose · recipients · own-
         expect(cockpit.operatorRecord, 'a refusal leaves the pane honestly unobserved, never a fallback identity').toBe(null)
     });
 
-    test('identity · an autoHidden pane (not materialized at boot) still seeds the record for a reveal-time read', async () => {
+    test('identity · a not-yet-materialized pane (torn, or dropped by a custom document) still seeds the record for a projection-time read', async () => {
         setBridge({resolveViewerIdentity: async () => ({ok: true, agentIdentityNodeId: '@neo-opus-grace'})});
 
-        // the pane is not materialized yet (accessor → null); the `?.set` no-ops but the record is held
-        // owner-side (with the possession authority), so a later projection materializes the pane and reads.
-        // The posture derive rides the same resolution over the cockpit surface (an absent grid → null posture).
+        // the pane resolves null (the resident tab normally exists at identity time, but a torn
+        // vessel mid-flight or a memories-less custom document leaves the accessor empty); the
+        // `?.set` no-ops but the record is held owner-side (with the possession authority), so the
+        // next projection materializes the pane and reads. The posture derive rides the same
+        // resolution over the cockpit surface (an empty provider roster → null posture).
         const cockpit = {
             operatorRecord               : null,
             deriveOperatorIdentityPosture: FleetCockpit.prototype.deriveOperatorIdentityPosture,
             getReference                 : () => null,
-            getOperatorMailboxPane       : () => null
+            getOperatorMailboxPane       : () => null,
+            resolveFleetRosterStore      : () => null
         };
 
         await FleetCockpit.prototype.loadOperatorIdentity.call(cockpit);
@@ -2883,7 +2898,7 @@ test.describe('Fleet cockpit — operator-seat identity posture (the conflation 
     });
 
     const derive = (viewerIdentity, rows) => FleetCockpit.prototype.deriveOperatorIdentityPosture.call(
-        {getReference: reference => reference === 'fleet-grid' ? {store: {items: rows}} : null},
+        {resolveFleetRosterStore: () => ({items: rows})},
         viewerIdentity
     );
 
@@ -2905,7 +2920,7 @@ test.describe('Fleet cockpit — operator-seat identity posture (the conflation 
               me     = {
                   isDestroyed                  : false,
                   deriveOperatorIdentityPosture: FleetCockpit.prototype.deriveOperatorIdentityPosture,
-                  getReference                 : reference => reference === 'fleet-grid' ? {store: {items: ROWS}} : null,
+                  resolveFleetRosterStore      : () => ({items: ROWS}),
                   getOperatorMailboxPane       : () => ({set: config => pushes.push(config)})
               },
               previousNs = globalThis.AgentOS;

--- a/test/playwright/unit/apps/agentos/view/fleet/fleetCockpit.spec.mjs
+++ b/test/playwright/unit/apps/agentos/view/fleet/fleetCockpit.spec.mjs
@@ -626,7 +626,13 @@ test.describe('Fleet cockpit — Store-backed roster (loadRoster)', () => {
             reconcileRoster   : FleetCockpit.prototype.reconcileRoster,
             reconcileSelection: FleetCockpit.prototype.reconcileSelection,
             reconcilingRoster : false,
-            rosterWired       : false,
+            // the provider-owned roster authority — the SAME store the grid fake binds, so the
+            // write path, the listener latch and the selection re-seat all read one truth
+            resolveFleetRosterStore: () => store,
+            // resident-pane accessors: unmaterialized here — the same silence contract as getReference
+            getCatchUpPane        : () => null,
+            getOperatorMailboxPane: () => null,
+            rosterWired           : false,
             // the real banner sync: null getReference for the slot → guarded no-op, no stub drift
             syncSpineBanner    : FleetCockpit.prototype.syncSpineBanner
         };
@@ -813,10 +819,9 @@ test.describe('Fleet cockpit — Store-backed roster (loadRoster)', () => {
             makeHost = (detailRecord, storeGet) => {
                 const host = Object.create(FleetCockpit.prototype);
 
-                host.detailRecord = detailRecord;
-                host.getReference = name =>
-                    name === 'fleet-grid'   ? {store: {get: storeGet}} :
-                    name === 'agent-detail' ? detail : null;
+                host.detailRecord            = detailRecord;
+                host.resolveFleetRosterStore = () => ({get: storeGet});
+                host.getReference            = name => name === 'agent-detail' ? detail : null;
 
                 return host
             };

--- a/test/playwright/unit/apps/agentos/view/fleet/fleetCockpitPopOut.spec.mjs
+++ b/test/playwright/unit/apps/agentos/view/fleet/fleetCockpitPopOut.spec.mjs
@@ -224,7 +224,7 @@ test.describe.serial('AgentOS.view.fleet.FleetCockpit — detail pop-out state m
 
         // the placement truth: `addTab` appends by default — the restore must land the item back
         // at its STORED index (0, before the rest of the rail), not at the tail
-        expect(cockpit.getDockZoneDocument().nodes['secondary-rail'].items).toEqual(['detail', 'perspectives', 'defineAgent', 'catchUp', 'memories', 'wakeRoutes', 'operator']);
+        expect(cockpit.getDockZoneDocument().nodes['secondary-rail'].items).toEqual(['detail', 'perspectives', 'defineAgent', 'wakeRoutes']);
 
         // same instance re-adopted by the projection; the vessel was closed by name
         expect(cockpit.getReference('agent-detail')).toBe(pane);
@@ -259,7 +259,7 @@ test.describe.serial('AgentOS.view.fleet.FleetCockpit — detail pop-out state m
 
             // the SAME instance is docked again at its exact home; nothing was closed (nothing opened)
             expect(cockpit.getReference('agent-detail')).toBe(pane);
-            expect(cockpit.getDockZoneDocument().nodes['secondary-rail'].items).toEqual(['detail', 'perspectives', 'defineAgent', 'catchUp', 'memories', 'wakeRoutes', 'operator']);
+            expect(cockpit.getDockZoneDocument().nodes['secondary-rail'].items).toEqual(['detail', 'perspectives', 'defineAgent', 'wakeRoutes']);
             expect(vessel.closeCalls).toHaveLength(0)
         } finally {
             console.warn = origWarn
@@ -494,16 +494,19 @@ test.describe.serial('AgentOS.view.fleet.FleetCockpit — detail pop-out state m
 /**
  * Contract specs for the Memories click pop-out: the shell verb rides the GENERIC
  * tear-out substrate — no second vessel state machine. The pins: document truth + the established
- * `?tearout=` param shape, selection-carry BY IDENTITY (live and rail-lazy materialization paths),
+ * `?tearout=` param shape, selection-carry BY IDENTITY (live and re-materialization paths),
  * owner-push routing through {@link getMemoriesPane} in every phase (vesseled, returning-parked),
  * intent routing from the vessel (the explicit listener scope — a vesseled pane has no controller
  * chain), exact-position reintegration on vessel death, the blocked-popup refusal before any
  * document mutation, and toggle routing incl. the mid-gesture guard.
+ *
+ * The memories pane is a RESIDENT south reading-surface tab (stream-tabs), no longer
+ * rail-collapsed chrome — its home truth and the reveal pre-state reflect that residency.
  */
 test.describe.serial('AgentOS.view.fleet.FleetCockpit — memories click pop-out (#17315)', () => {
     let cockpit, vessel;
 
-    const RAIL_HOME = ['detail', 'perspectives', 'defineAgent', 'catchUp', 'memories', 'wakeRoutes', 'operator'];
+    const SOUTH_HOME = ['stream', 'memories', 'operator', 'catchUp'];
 
     /**
      * A minimal wired memories envelope for owner-held state and push assertions.
@@ -524,15 +527,11 @@ test.describe.serial('AgentOS.view.fleet.FleetCockpit — memories click pop-out
     }
 
     /**
-     * Reveals the auto-hidden memories pane through the standard commit loop — the materialized
-     * pre-state of the "live pane" pop-out path.
+     * Resolves the resident south-tab memories pane (projected with the strip — resident tabs
+     * need no rail reveal step) — the materialized pre-state of the "live pane" pop-out path.
      * @returns {Promise<Neo.container.Base>} the projected MemoriesPane instance
      */
     async function revealMemories() {
-        const result = cockpit.applyDockZoneOperation({operation: 'setItemAutoHidden', itemId: 'memories', autoHidden: false});
-
-        expect(result.errors).toEqual([]);
-        cockpit.onDockZoneDocumentChange(result.document);
         await cockpit.refreshPromise;
 
         const pane = cockpit.getReference('memories');
@@ -590,11 +589,11 @@ test.describe.serial('AgentOS.view.fleet.FleetCockpit — memories click pop-out
 
         expect(result).toEqual({detached: true, errors: []});
 
-        // document truth: the item left the rail but keeps its catalog record
+        // document truth: the item left the south strip but keeps its catalog record
         const doc = cockpit.getDockZoneDocument();
 
         expect(doc.items.memories).toBeTruthy();
-        expect(doc.nodes['secondary-rail'].items).not.toContain('memories');
+        expect(doc.nodes['stream-tabs'].items).not.toContain('memories');
 
         // the LIVE pane is vessel-owned — same instance, never a recreation
         expect(cockpit.tearOutPaneHandles.memories).toBe(pane);
@@ -610,29 +609,38 @@ test.describe.serial('AgentOS.view.fleet.FleetCockpit — memories click pop-out
         expect(cockpit.getReference('memories-window-toggle').text).toBe('Return memories')
     });
 
-    test('pop-out of the RAIL-LAZY pane materializes from owner-held state — selection carries', async () => {
-        vessel = installWindowVessel({popupUrl: memoriesVesselUrl()});
+    test('re-materialization after true absence carries owner-held selection', async () => {
+        // memories is a RESIDENT tab, so the projection holds a live pane from boot — the old
+        // rail-lazy pre-state ("in the tree, no pane") no longer exists for it. The owner-held
+        // materialization path still does: a document that drops the item destroys the pane
+        // (true absence), and its return must reopen AT the owner-held selection.
+        await cockpit.refreshPromise;
+        expect(cockpit.getReference('memories')).toBeTruthy();
 
-        // never revealed: the rail's lazy projection holds no live pane
+        const doc = cockpit.getDockZoneDocument();
+
+        doc.nodes['stream-tabs'].items = doc.nodes['stream-tabs'].items.filter(id => id !== 'memories');
+        cockpit.onDockZoneDocumentChange(doc);
+        await cockpit.refreshPromise;
+
+        // true absence: the catalog keeps the item, the tree and the projection do not
+        expect(cockpit.getDockZoneDocument().items.memories).toBeTruthy();
         expect(cockpit.getReference('memories')).toBeFalsy();
 
         cockpit.memoriesTarget   = '@neo-fable-clio';
         cockpit.memoriesSnapshot = wiredEnvelope('@neo-fable-clio', 'owner-held');
 
-        const result = await cockpit.popOutMemories();
+        const readd = cockpit.applyDockZoneOperation({operation: 'addTab', itemId: 'memories', tabsNodeId: 'stream-tabs'});
 
-        expect(result).toEqual({detached: true, errors: []});
+        expect(readd.errors).toEqual([]);
+        cockpit.onDockZoneDocumentChange(readd.document);
+        await cockpit.refreshPromise;
 
-        const pane = cockpit.tearOutPaneHandles.memories;
+        const pane = cockpit.getReference('memories');
 
         expect(pane).toBeTruthy();
         expect(pane.activeAgent).toBe('@neo-fable-clio');
-        expect(pane.snapshot?.sessions?.[0]?.title).toBe('owner-held');
-
-        // the vessel adopts the materialized pane on connect
-        const mainView = await simulateConnect('mem-vessel-lazy');
-
-        expect(mainView.items).toContain(pane)
+        expect(pane.snapshot?.sessions?.[0]?.title).toBe('owner-held')
     });
 
     test('owner pushes reach the vesseled pane; vessel-fired intents reach the controller', async () => {
@@ -674,7 +682,7 @@ test.describe.serial('AgentOS.view.fleet.FleetCockpit — memories click pop-out
         }
     });
 
-    test('vessel death brings the pane home at its exact rail position — state intact', async () => {
+    test('vessel death brings the pane home at its exact south-strip position — state intact', async () => {
         vessel = installWindowVessel({popupUrl: memoriesVesselUrl()});
 
         const pane = await revealMemories();
@@ -687,8 +695,8 @@ test.describe.serial('AgentOS.view.fleet.FleetCockpit — memories click pop-out
         cockpit.onWindowDisconnect({windowId: 'mem-vessel-home'});
         await cockpit.refreshPromise;
 
-        // exact-position restore: memories back at its stored rail index, full order preserved
-        await expect.poll(() => cockpit.getDockZoneDocument().nodes['secondary-rail'].items, {timeout: 2000}).toEqual(RAIL_HOME);
+        // exact-position restore: memories back at its stored south-strip index, full order preserved
+        await expect.poll(() => cockpit.getDockZoneDocument().nodes['stream-tabs'].items, {timeout: 2000}).toEqual(SOUTH_HOME);
 
         // the same live instance survived the return; owner pushes still reach it while parked
         expect(pane.isDestroyed).toBeFalsy();
@@ -716,8 +724,8 @@ test.describe.serial('AgentOS.view.fleet.FleetCockpit — memories click pop-out
             expect(result.detached).toBe(false);
             expect(result.errors[0]).toContain('popup blocked');
 
-            // zero mutation: the rail still holds the item, nothing is vessel-owned, nothing closed
-            expect(cockpit.getDockZoneDocument().nodes['secondary-rail'].items).toEqual(RAIL_HOME);
+            // zero mutation: the south strip still holds the item, nothing is vessel-owned, nothing closed
+            expect(cockpit.getDockZoneDocument().nodes['stream-tabs'].items).toEqual(SOUTH_HOME);
             expect(cockpit.tearOutPanes.memories).toBeFalsy();
             expect(cockpit.tearOutPaneHandles.memories).toBeFalsy();
             expect(vessel.closeCalls).toHaveLength(0);

--- a/test/playwright/unit/apps/agentos/view/fleet/fleetCockpitPopOut.spec.mjs
+++ b/test/playwright/unit/apps/agentos/view/fleet/fleetCockpitPopOut.spec.mjs
@@ -617,7 +617,9 @@ test.describe.serial('AgentOS.view.fleet.FleetCockpit — memories click pop-out
         await cockpit.refreshPromise;
         expect(cockpit.getReference('memories')).toBeTruthy();
 
-        const doc = cockpit.getDockZoneDocument();
+        // absence through a committed CLONE — never a mutation of the live document reference
+        // (the commit loop's purity contract): clone, drop the item, commit the new document.
+        const doc = structuredClone(cockpit.getDockZoneDocument());
 
         doc.nodes['stream-tabs'].items = doc.nodes['stream-tabs'].items.filter(id => id !== 'memories');
         cockpit.onDockZoneDocumentChange(doc);

--- a/test/playwright/unit/apps/agentos/view/fleet/fleetCockpitProjection.spec.mjs
+++ b/test/playwright/unit/apps/agentos/view/fleet/fleetCockpitProjection.spec.mjs
@@ -429,6 +429,70 @@ test.describe('Fleet cockpit — perspective presets (the switch through the com
         host.perspectiveStore.destroy()
     });
 
+    test('#17451: a Review switch on a cold seat defaults the selection from the PROVIDER roster before the commit, and lands it on the live pane', async () => {
+        const record = {agentId: 'vega', githubUsername: 'neo-opus-vega'},
+              sets   = [],
+              host   = await makePresetHost({
+                  detailRecord      : null,
+                  getAgentDetailPane: () => ({set: values => sets.push(values)}),
+                  getStateProvider  : () => ({getStore: name => name === 'fleetRoster' ? {first: () => record} : null}),
+                  refreshDockWorkspace() {}
+              });
+
+        const verdict = FleetCockpit.prototype.activatePerspective.call(host, 'Review');
+
+        expect(verdict).toEqual({errors: [], switched: true});
+        // held owner-side BEFORE the deferred re-projection — the materializing resolver reads it
+        expect(host.detailRecord).toBe(record);
+        // and the live docked/popped pane updates through the select seam's owner accessor
+        expect(sets).toEqual([{record}]);
+
+        host.perspectiveStore.destroy()
+    });
+
+    test('#17451: a prior selection survives a Review switch untouched — the cold default never overwrites', async () => {
+        const prior = {agentId: 'ada', githubUsername: 'neo-opus-ada'},
+              sets  = [],
+              host  = await makePresetHost({
+                  detailRecord      : prior,
+                  getAgentDetailPane: () => ({set: values => sets.push(values)}),
+                  getStateProvider  : () => ({getStore: () => ({first() { throw new Error('the default path must not consult the roster while a selection exists') }})}),
+                  refreshDockWorkspace() {}
+              });
+
+        FleetCockpit.prototype.activatePerspective.call(host, 'Review');
+
+        expect(host.detailRecord).toBe(prior);
+        expect(sets).toEqual([{record: prior}]);
+
+        host.perspectiveStore.destroy()
+    });
+
+    test('#17451: non-revealing and detail-ABSENT documents never mutate the selection', async () => {
+        const host = await makePresetHost({
+            detailRecord      : null,
+            getAgentDetailPane() { throw new Error('a non-revealing switch must not touch the pane') },
+            getStateProvider  : () => ({getStore: () => ({first: () => ({agentId: 'vega'})})}),
+            refreshDockWorkspace() {}
+        });
+
+        // Focus keeps the inspector rail-hidden — a valid, non-revealing switch stays selection-silent
+        FleetCockpit.prototype.activatePerspective.call(host, 'Focus');
+        expect(host.detailRecord).toBe(null);
+
+        // the round-1 falsifier, pinned at the predicate: a VALIDATOR-CLEAN document with the
+        // detail item absent must not read as revealed — `!items.detail?.autoHidden` alone did
+        const doc = host.perspectiveStore.loadPerspective('Overview').document;
+
+        doc.nodes['secondary-rail'].items = doc.nodes['secondary-rail'].items.filter(id => id !== 'detail');
+        doc.nodes['secondary-rail'].activeItemId = doc.nodes['secondary-rail'].items[0];
+        delete doc.items.detail;
+        expect(DockZoneModel.validate(doc)).toEqual([]);
+        expect(FleetCockpit.prototype.isInspectorRevealed.call(host, doc)).toBe(false);
+
+        host.perspectiveStore.destroy()
+    });
+
     test('the persistent control bar keeps identities while preset and refusal state change', async () => {
         const
             buttons = ['overview', 'focus', 'review'].map(layoutId => ({

--- a/test/playwright/unit/apps/agentos/view/fleet/fleetCockpitProjection.spec.mjs
+++ b/test/playwright/unit/apps/agentos/view/fleet/fleetCockpitProjection.spec.mjs
@@ -27,7 +27,7 @@ import * as core      from '../../../../../../../src/core/_export.mjs';
  * docking design's pane contract, and owner-held pane state surviving re-projection.
  */
 test.describe('Fleet cockpit — dock projection wiring (the resize commit loop)', () => {
-    let ActivityStream, AgentDetail, DockProjectionReconciler, DockZoneModel, FleetCockpit, FleetGrid, cockpitDockDocument;
+    let ActivityStream, AgentDetail, CatchUpPane, DockProjectionReconciler, DockZoneModel, FleetCockpit, FleetGrid, MemoriesPane, OperatorMailbox, cockpitDockDocument;
 
     // a projection-capable spy owner: the REAL prototype methods over controlled state, without
     // provider/store/bridge wiring (their routing has its own suite in fleetCockpit.spec.mjs)
@@ -38,6 +38,11 @@ test.describe('Fleet cockpit — dock projection wiring (the resize commit loop)
                 // the stream resolver joins roster actor facts; this host owns no roster, and
                 // the honest empty directory is exactly what an unmaterialized grid yields
                 buildActivityActorDirectory: () => ({}),
+                // the resident reading surfaces resolve their option lists through the
+                // projected tree and bind their listener scope to the owning controller; this
+                // host projects no tree and owns no controller — null is that honest answer
+                getController     : () => null,
+                getReference      : () => null,
                 dockModel         : cockpitDockDocument(),
                 gridAdapterState  : 'sample',
                 isDestroyed       : false,
@@ -67,6 +72,9 @@ test.describe('Fleet cockpit — dock projection wiring (the resize commit loop)
     test.beforeAll(async () => {
         ActivityStream      = (await import('../../../../../../../apps/agentos/view/fleet/ActivityStream.mjs')).default;
         AgentDetail         = (await import('../../../../../../../apps/agentos/view/fleet/AgentDetail.mjs')).default;
+        CatchUpPane         = (await import('../../../../../../../apps/agentos/view/fleet/CatchUpPane.mjs')).default;
+        MemoriesPane        = (await import('../../../../../../../apps/agentos/view/fleet/MemoriesPane.mjs')).default;
+        OperatorMailbox     = (await import('../../../../../../../apps/agentos/view/fleet/OperatorMailbox.mjs')).default;
         DockProjectionReconciler = (await import('../../../../../../../src/dashboard/DockProjectionReconciler.mjs')).default;
         DockZoneModel       = (await import('../../../../../../../src/dashboard/DockZoneModel.mjs')).default;
         FleetCockpit        = (await import('../../../../../../../apps/agentos/view/fleet/FleetCockpit.mjs')).default;
@@ -164,12 +172,12 @@ test.describe('Fleet cockpit — dock projection wiring (the resize commit loop)
         const
             document = cockpitDockDocument(),
             original = DockProjectionReconciler.reconcileProjection,
-            preset   = {reference: 'fleet-preset-fleet', set(values) { Object.assign(this, values) }},
+            preset   = {reference: 'fleet-preset-overview', set(values) { Object.assign(this, values) }},
             error    = {set(values) { Object.assign(this, values) }},
             host     = makeHost({
                 id              : 'fleet-test-host',
                 items           : [{items: [preset]}],
-                perspectiveStore: {collection: {activeLayoutId: 'fleet'}},
+                perspectiveStore: {collection: {activeLayoutId: 'overview'}},
                 presetError     : null,
                 getReference(reference) {
                     return reference === 'fleet-preset-error' ? error : null
@@ -278,12 +286,17 @@ test.describe('Fleet cockpit — dock projection wiring (the resize commit loop)
         expect(perspectives.html).toContain('Perspectives')
     });
 
-    test('the projected tree renders the document\'s zones: both live panes present, exactly once each', () => {
+    test('the projected tree renders the document\'s zones: every live pane present, exactly once each', () => {
         const host  = makeHost(),
               nodes = collect(FleetCockpit.prototype.projectDockModel.call(host));
 
         expect(nodes.filter(node => node.module === FleetGrid).length).toBe(1);
         expect(nodes.filter(node => node.module === ActivityStream).length).toBe(1);
+
+        // the south reading surfaces are resident tabs — projected exactly once each
+        expect(nodes.filter(node => node.module === MemoriesPane).length).toBe(1);
+        expect(nodes.filter(node => node.module === OperatorMailbox).length).toBe(1);
+        expect(nodes.filter(node => node.module === CatchUpPane).length).toBe(1);
 
         // the auto-hidden chrome (detail + perspectives) must NOT render as full panes — the
         // document declares them rail material (their reveal chain is the shipped machinery)
@@ -297,10 +310,7 @@ test.describe('Fleet cockpit — dock projection wiring (the resize commit loop)
             'detail',
             'perspectives',
             'defineAgent',
-            'catchUp',
-            'memories',
-            'wakeRoutes',
-            'operator'
+            'wakeRoutes'
         ])
     });
 });
@@ -324,6 +334,11 @@ test.describe('Fleet cockpit — perspective presets (the switch through the com
                 // the stream resolver joins roster actor facts; the preset host owns no roster,
                 // and the honest empty directory is exactly what an unmaterialized grid yields
                 buildActivityActorDirectory: () => ({}),
+                // the resident reading surfaces resolve their option lists through the
+                // projected tree and bind their listener scope to the owning controller; this
+                // host projects no tree and owns no controller — null is that honest answer
+                getController     : () => null,
+                getReference      : () => null,
                 dockModel         : (await import('../../../../../../../apps/agentos/view/fleet/cockpitDockDocument.mjs')).default(),
                 gridAdapterState  : 'sample',
                 isDestroyed       : false,
@@ -353,15 +368,15 @@ test.describe('Fleet cockpit — perspective presets (the switch through the com
         cockpitPresetCollection = (await import('../../../../../../../apps/agentos/view/fleet/cockpitPresets.mjs')).default
     });
 
-    test('the seeded library validates whole and lists the three duty presets, Fleet active', () => {
+    test('the seeded library validates whole and lists the three duty presets, Overview active', () => {
         const collection = cockpitPresetCollection();
 
         expect(DockZoneModel.validateSavedLayoutCollection(collection)).toEqual([]);
-        expect(collection.activeLayoutId).toBe('fleet');
+        expect(collection.activeLayoutId).toBe('overview');
 
         const store = Neo.create(DockPerspectiveStore, {collection});
 
-        expect(store.list().map(preset => preset.perspectiveName)).toEqual(['Fleet', 'Focus', 'Review']);
+        expect(store.list().map(preset => preset.perspectiveName)).toEqual(['Overview', 'Focus', 'Review']);
         store.destroy()
     });
 
@@ -416,7 +431,7 @@ test.describe('Fleet cockpit — perspective presets (the switch through the com
 
     test('the persistent control bar keeps identities while preset and refusal state change', async () => {
         const
-            buttons = ['fleet', 'focus', 'review'].map(layoutId => ({
+            buttons = ['overview', 'focus', 'review'].map(layoutId => ({
                 pressed  : false,
                 reference: `fleet-preset-${layoutId}`,
                 set(values) { Object.assign(this, values) }

--- a/test/playwright/unit/apps/agentos/view/fleet/fleetCockpitResidentBoot.spec.mjs
+++ b/test/playwright/unit/apps/agentos/view/fleet/fleetCockpitResidentBoot.spec.mjs
@@ -1,0 +1,142 @@
+import {setup} from '../../../../../setup.mjs';
+
+setup({
+    appConfig: {
+        name: 'AgentOSFleetCockpitResidentBootTest'
+    }
+});
+
+import {test, expect} from '@playwright/test';
+import Neo            from '../../../../../../../src/Neo.mjs';
+import * as core      from '../../../../../../../src/core/_export.mjs';
+import '../../../../../../../src/manager/Instance.mjs'; // defines Neo.get — the container child-add path resolves parents through it
+import FleetCockpit  from '../../../../../../../apps/agentos/view/fleet/FleetCockpit.mjs';
+import FleetRoster   from '../../../../../../../apps/agentos/store/FleetRoster.mjs';
+import StateProvider from '../../../../../../../src/state/Provider.mjs';
+
+/**
+ * Resident-boot lifecycle contracts for the south reading-surface tabs: the panes construct at
+ * projection time — BEFORE the fleet grid child and usually before the bridge — so their
+ * roster-derived options must boot from the PROVIDER-owned Store (never through the projected
+ * grid), refresh when the live roster answers, and the construction-time CatchUp history request
+ * must recover from the cold-before-bridge ordering instead of pinning its unavailable envelope.
+ */
+test.describe.serial('AgentOS.view.fleet.FleetCockpit — resident boot lifecycle (#17451)', () => {
+    let cockpit, prevFleet;
+
+    test.beforeEach(() => {
+        prevFleet = globalThis.AgentOS?.fleet;
+        cockpit   = Neo.create(FleetCockpit, {
+            stateProvider: {
+                module: StateProvider,
+                stores: {fleetRoster: {module: FleetRoster, autoLoad: false}}
+            }
+        })
+    });
+
+    test.afterEach(() => {
+        cockpit?.destroy();
+        cockpit = null;
+        // stub only the `fleet` key and restore it — never delete the AgentOS namespace
+        // (it is the app CLASS NAMESPACE root; deleting it unregisters every AgentOS.* class)
+        prevFleet === undefined ? delete globalThis.AgentOS?.fleet : globalThis.AgentOS.fleet = prevFleet
+    });
+
+    test('cold boot: resident panes exist before the grid answers, with honest provider-truth options', async () => {
+        await cockpit.refreshPromise;
+
+        const mailbox = cockpit.getOperatorMailboxPane(),
+              catchUp = cockpit.getCatchUpPane();
+
+        // resident tabs project at boot — the accessors resolve live instances, no reveal step
+        expect(mailbox).toBeTruthy();
+        expect(catchUp).toBeTruthy();
+        expect(cockpit.getMemoriesPane()).toBeTruthy();
+
+        // cold truth, not breakage: an unanswered roster yields the broadcast sentinel alone —
+        // and empty option lists — never a throw and never a stale hand-mapped list
+        expect(mailbox.recipientOptions.map(option => option.id)).toEqual(['AGENT:*']);
+        expect(cockpit.buildMemoriesAgentOptions()).toEqual([]);
+        expect(cockpit.buildCatchUpPartitionOptions()).toEqual([])
+    });
+
+    test('the builders read the PROVIDER Store, never the projected grid — options resolve with no grid at all', () => {
+        const rows = [{agentId: 'vega', githubUsername: 'neo-opus-vega', displayName: 'Vega'}],
+              host = {
+                  resolveFleetRosterStore: () => ({items: rows}),
+                  getReference           : () => null // the grid does not exist — torn, absent, or not yet projected
+              };
+
+        expect(FleetCockpit.prototype.buildOperatorRecipientOptions.call(host).map(option => option.id))
+            .toEqual(['AGENT:*', '@neo-opus-vega']);
+        expect(FleetCockpit.prototype.buildMemoriesAgentOptions.call(host).map(option => option.agentIdentity))
+            .toEqual(['@neo-opus-vega']);
+        expect(FleetCockpit.prototype.buildCatchUpPartitionOptions.call(host).map(option => option.partition))
+            .toEqual(['@neo-opus-vega'])
+    });
+
+    test('the first live roster answer refreshes EVERY resident consumer — the mailbox recipients included', async () => {
+        await cockpit.refreshPromise;
+
+        const mailbox = cockpit.getOperatorMailboxPane();
+
+        expect(mailbox.recipientOptions.map(option => option.id)).toEqual(['AGENT:*']);
+
+        globalThis.AgentOS.fleet = {registryBridge: {
+            selected   : true,
+            fleetRoster: async () => ({capabilities: {}, rows: [{id: 'vega', githubUsername: 'neo-opus-vega', displayName: 'Vega'}]})
+        }};
+
+        await cockpit.loadRoster();
+
+        expect(mailbox.recipientOptions.map(option => option.id)).toEqual(['AGENT:*', '@neo-opus-vega']);
+        expect(cockpit.getMemoriesPane().agentOptions.map(option => option.agentIdentity)).toEqual(['@neo-opus-vega']);
+        expect(cockpit.getCatchUpPane().partitionOptions.map(option => option.partition)).toEqual(['@neo-opus-vega'])
+    });
+
+    test('cold-before-bridge CatchUp recovers exactly once at bridge arrival; a healthy snapshot never re-drives', async () => {
+        await cockpit.refreshPromise;
+
+        // the construction-time historyRequest ran with no bridge → the unavailable envelope
+        expect(cockpit.catchUpSnapshot?.capability?.state).toBe('unavailable');
+
+        let redrives = 0;
+        cockpit.getCatchUpPane().onRefreshClick = () => {
+            redrives++;
+            // the guarded refresh path lands a healthy snapshot (what the real handler achieves
+            // once the bridge answers) — so the NEXT live load must not re-drive again
+            cockpit.catchUpSnapshot = {capability: {state: 'wired'}}
+        };
+
+        globalThis.AgentOS.fleet = {registryBridge: {
+            selected   : true,
+            fleetRoster: async () => ({capabilities: {}, rows: [{id: 'vega', githubUsername: 'neo-opus-vega'}]})
+        }};
+
+        await cockpit.loadRoster();
+        expect(redrives, 'the one-shot cold miss recovers at bridge arrival').toBe(1);
+
+        await cockpit.loadRoster();
+        expect(redrives, 'a healthy snapshot is never re-driven — the recovery is need-gated, not periodic').toBe(1)
+    });
+
+    test('pane-before-identity: the resident mailbox boots read-free and lands exactly ONE first read at identity resolution', async () => {
+        await cockpit.refreshPromise;
+
+        let reads = 0;
+        cockpit.loadOperatorInbox = () => { reads++ };
+
+        // resident projection happened with no identity — no read may have fired, and none may
+        // fire until the identity resolves
+        expect(cockpit.operatorRecord).toBe(null);
+
+        globalThis.AgentOS.fleet = {registryBridge: {
+            resolveViewerIdentity: async () => ({ok: true, agentIdentityNodeId: '@neo-fable-clio'})
+        }};
+
+        await cockpit.loadOperatorIdentity();
+
+        expect(cockpit.operatorRecord?.githubUsername).toBe('neo-fable-clio');
+        expect(reads, 'the opposite ordering to the construction-flush: one live set, one read').toBe(1)
+    })
+});

--- a/test/playwright/unit/apps/agentos/view/fleet/fleetCockpitResidentBoot.spec.mjs
+++ b/test/playwright/unit/apps/agentos/view/fleet/fleetCockpitResidentBoot.spec.mjs
@@ -94,6 +94,52 @@ test.describe.serial('AgentOS.view.fleet.FleetCockpit — resident boot lifecycl
         expect(cockpit.getCatchUpPane().partitionOptions.map(option => option.partition)).toEqual(['@neo-opus-vega'])
     });
 
+    test('loadRoster ingests into the PROVIDER Store with NO grid at all — the projected child renders, it never owns the roster', async () => {
+        const store = Neo.create(FleetRoster, {autoLoad: false}),
+              sets  = {catchUp: [], mailbox: [], memories: []},
+              host  = {
+                  buildActivityActorDirectory  : FleetCockpit.prototype.buildActivityActorDirectory,
+                  buildCatchUpPartitionOptions : FleetCockpit.prototype.buildCatchUpPartitionOptions,
+                  buildMemoriesAgentOptions    : FleetCockpit.prototype.buildMemoriesAgentOptions,
+                  buildOperatorRecipientOptions: FleetCockpit.prototype.buildOperatorRecipientOptions,
+                  clearDegradedReason          : FleetCockpit.prototype.clearDegradedReason,
+                  degradeWiredSurface          : FleetCockpit.prototype.degradeWiredSurface,
+                  getCatchUpPane               : () => ({set: values => sets.catchUp.push(values), onRefreshClick() {}}),
+                  getMemoriesPane              : () => ({set: values => sets.memories.push(values)}),
+                  getOperatorMailboxPane       : () => ({set: values => sets.mailbox.push(values)}),
+                  getReference                 : () => null, // NO grid, NO activity stream — torn or absent
+                  gridAdapterState             : 'sample',
+                  gridReadGeneration           : 0,
+                  mapRosterRow                 : FleetCockpit.prototype.mapRosterRow,
+                  reconcileRoster              : FleetCockpit.prototype.reconcileRoster,
+                  reconcileSelection           : FleetCockpit.prototype.reconcileSelection,
+                  resolveFleetRosterStore      : () => store,
+                  rosterSourceMode             : 'sample',
+                  rosterWired                  : false,
+                  syncSpineBanner              : () => {}
+              };
+
+        globalThis.AgentOS.fleet = {registryBridge: {
+            selected   : true,
+            fleetRoster: async () => ({capabilities: {}, rows: [{id: 'vega', githubUsername: 'neo-opus-vega', displayName: 'Vega'}]})
+        }};
+
+        await FleetCockpit.prototype.loadRoster.call(host);
+
+        // the live rows landed in the PROVIDER Store despite the missing projection
+        expect(store.getCount()).toBe(1);
+        expect(store.getAt(0).githubUsername).toBe('neo-opus-vega');
+        expect(host.gridAdapterState).toBe('live');
+        expect(host.rosterWired).toBe(true);
+
+        // and every resident consumer refreshed from that same truth
+        expect(sets.mailbox.some(values => values.recipientOptions?.some(option => option.id === '@neo-opus-vega'))).toBe(true);
+        expect(sets.memories.some(values => values.agentOptions?.some(option => option.agentIdentity === '@neo-opus-vega'))).toBe(true);
+        expect(sets.catchUp.some(values => values.partitionOptions?.some(option => option.partition === '@neo-opus-vega'))).toBe(true);
+
+        store.destroy()
+    });
+
     test('cold-before-bridge CatchUp recovers exactly once at bridge arrival; a healthy snapshot never re-drives', async () => {
         await cockpit.refreshPromise;
 

--- a/test/playwright/unit/apps/agentos/view/fleet/fleetCockpitTearOut.spec.mjs
+++ b/test/playwright/unit/apps/agentos/view/fleet/fleetCockpitTearOut.spec.mjs
@@ -304,24 +304,26 @@ test.describe.serial('AgentOS.view.fleet.FleetCockpit — gesture tear-out seam 
     test('vessel death brings the item HOME — same instance, no orphan under the dead view, semantic fallback placement', async () => {
         vessel = installWindowVessel();
 
-        const streamPane = cockpit.getReference('activity-stream');
-        const zone       = await tearOutExit('stream');
+        // 'fleet' lives ALONE in fleet-tabs — detaching it empties and collapses its node,
+        // which is exactly the pre-state the semantic-fallback return path exists for
+        const fleetPane = cockpit.getReference('fleet-grid');
+        const zone      = await tearOutExit('fleet');
 
-        cockpit.tearOutHandlers.onDockTearOutTerminal({itemId: 'stream', sortZone: zone});
+        cockpit.tearOutHandlers.onDockTearOutTerminal({itemId: 'fleet', sortZone: zone});
 
-        // capture rode the detach commit: 'stream' lived alone in stream-tabs at index 0
-        expect(cockpit.tearOutPlacements.stream).toEqual({tabsNodeId: 'stream-tabs', index: 0});
+        // capture rode the detach commit: 'fleet' lived alone in fleet-tabs at index 0
+        expect(cockpit.tearOutPlacements.fleet).toEqual({tabsNodeId: 'fleet-tabs', index: 0});
 
         vessel.restore();
-        vessel = installWindowVessel({popupUrl: `https://unit.test/widget/index.html?tearout=stream&cockpitId=${cockpit.id}`});
+        vessel = installWindowVessel({popupUrl: `https://unit.test/widget/index.html?tearout=fleet&cockpitId=${cockpit.id}`});
 
         const mainView = Neo.create(Container, {});
         Neo.apps ??= {};
         Neo.apps['tearout-win-3'] = {mainView};
 
         await cockpit.onWindowConnect({windowId: 'tearout-win-3'});
-        expect(cockpit.tearOutPanes.stream.windowId).toBe('tearout-win-3');
-        expect(mainView.items).toContain(streamPane);
+        expect(cockpit.tearOutPanes.fleet.windowId).toBe('tearout-win-3');
+        expect(mainView.items).toContain(fleetPane);
 
         cockpit.onWindowDisconnect({windowId: 'tearout-win-3'});
         await cockpit.refreshPromise;
@@ -329,50 +331,39 @@ test.describe.serial('AgentOS.view.fleet.FleetCockpit — gesture tear-out seam 
         // A window disconnect does NOT destroy the popup application or its view tree — the
         // worker only fires the event — so the captured pane survives LIVE and comes HOME:
         // the same instance, out of the dead vessel's view, back in the projection. The
-        // emptied stream-tabs node collapsed at detach, so placement recovery is the SEMANTIC
+        // emptied fleet-tabs node collapsed at detach, so placement recovery is the SEMANTIC
         // fallback (a surviving tabs node), never a resurrected node, never geometry.
-        expect(mainView.items, 'the dead vessel view keeps no pane').not.toContain(streamPane);
-        expect(streamPane.isDestroyed, 'same-instance return: the pane is never destroyed').toBeFalsy();
-        expect(cockpit.getReference('activity-stream'), 'the projection resolves the ORIGINAL instance').toBe(streamPane);
-        expect(DockZoneModel.findContainingTabsId(cockpit.dockModel, 'stream'), 'the item is back in the tree').toBeTruthy();
+        expect(mainView.items, 'the dead vessel view keeps no pane').not.toContain(fleetPane);
+        expect(fleetPane.isDestroyed, 'same-instance return: the pane is never destroyed').toBeFalsy();
+        expect(cockpit.getReference('fleet-grid'), 'the projection resolves the ORIGINAL instance').toBe(fleetPane);
+        expect(DockZoneModel.findContainingTabsId(cockpit.dockModel, 'fleet'), 'the item is back in the tree').toBeTruthy();
 
         // every record is consumed exact-once
-        expect(cockpit.tearOutPanes.stream).toBeUndefined();
-        expect(cockpit.tearOutConnects.stream).toBeUndefined();
-        expect(cockpit.tearOutPaneHandles.stream).toBeUndefined();
-        expect(cockpit.tearOutPlacements.stream).toBeUndefined();
-        expect(cockpit.returningTearOutPanes.stream).toBeUndefined()
+        expect(cockpit.tearOutPanes.fleet).toBeUndefined();
+        expect(cockpit.tearOutConnects.fleet).toBeUndefined();
+        expect(cockpit.tearOutPaneHandles.fleet).toBeUndefined();
+        expect(cockpit.tearOutPlacements.fleet).toBeUndefined();
+        expect(cockpit.returningTearOutPanes.fleet).toBeUndefined()
     });
 
     test('a surviving home node gets the EXACT stored position back — not append order', async () => {
         vessel = installWindowVessel();
 
-        // pre-arrange a two-item strip so the emptied-node collapse cannot hide append-shaped
-        // returns: 'stream' at index 0 AHEAD of 'perspectives'
-        const arrange = cockpit.applyDockZoneOperation({operation: 'addTab', itemId: 'perspectives', tabsNodeId: 'stream-tabs'});
-
-        expect(arrange.errors).toEqual([]);
-        cockpit.onDockZoneDocumentChange(arrange.document);
-        await cockpit.refreshPromise;
-
-        const move = cockpit.applyDockZoneOperation({operation: 'moveItem', itemId: 'stream', targetNodeId: 'stream-tabs', index: 0});
-
-        expect(move.errors).toEqual([]);
-        cockpit.onDockZoneDocumentChange(move.document);
-        await cockpit.refreshPromise;
-        expect(cockpit.dockModel.nodes['stream-tabs'].items).toEqual(['stream', 'perspectives']);
+        // the south strip ships 'stream' at index 0 AHEAD of three reading-surface
+        // siblings — the surviving-node pre-state where an append-shaped return cannot hide
+        expect(cockpit.dockModel.nodes['stream-tabs'].items).toEqual(['stream', 'memories', 'operator', 'catchUp']);
 
         const zone = await tearOutExit('stream');
 
         cockpit.tearOutHandlers.onDockTearOutTerminal({itemId: 'stream', sortZone: zone});
         expect(cockpit.tearOutPlacements.stream).toEqual({tabsNodeId: 'stream-tabs', index: 0});
-        expect(cockpit.dockModel.nodes['stream-tabs'].items).toEqual(['perspectives']);
+        expect(cockpit.dockModel.nodes['stream-tabs'].items).toEqual(['memories', 'operator', 'catchUp']);
 
         cockpit.tearOutPanes.stream = {windowName: `fm-tearout-stream-${cockpit.id}`, windowId: 'tearout-win-5'};
         cockpit.onWindowDisconnect({windowId: 'tearout-win-5'});
         await cockpit.refreshPromise;
 
-        expect(cockpit.dockModel.nodes['stream-tabs'].items, 'identical order, not append order').toEqual(['stream', 'perspectives'])
+        expect(cockpit.dockModel.nodes['stream-tabs'].items, 'identical order, not append order').toEqual(['stream', 'memories', 'operator', 'catchUp'])
     });
 
     test('the no-home terminal still settles ownership: a closed-out item\'s pane is destroyed, never orphaned', async () => {

--- a/test/playwright/unit/apps/agentos/view/fleet/operatorMailbox.spec.mjs
+++ b/test/playwright/unit/apps/agentos/view/fleet/operatorMailbox.spec.mjs
@@ -152,21 +152,25 @@ test.describe('AgentOS OperatorMailbox — the operator mailbox surface (#15377)
         box.destroy()
     });
 
-    test('reveal-after-boot: state injected as CONSTRUCTION configs reaches the children (real component, review RA-1)', () => {
-        // the normal reveal path: the projection materializes the pane with the operator identity, its
-        // snapshot, and recipient options ALREADY resolved owner-side, supplied as construction configs.
-        // Before the onConstructed flush, afterSet* skipped these (isConstructed false) and the children
-        // materialized EMPTY — the pane could not pass possession. This is the real composed component,
-        // not a spy or a post-construction assignment.
+    test('identity-before-pane: CONSTRUCTION configs reach the children AND land exactly ONE boot read', () => {
+        // the identity-before-pane ordering: the resident pane projects while the cockpit already
+        // holds the resolved operator identity, so record/snapshot/options arrive as construction
+        // configs. Before the onConstructed flush, afterSet* skipped these (isConstructed false)
+        // and the children materialized EMPTY — the pane could not pass possession. This is the
+        // real composed component; the counter pins the exactly-once boot read for THIS ordering
+        // (the pane-before-identity twin is counted cockpit-side in fleetCockpitResidentBoot).
         const record   = {agentIdentityNodeId: '@neo-opus-grace', githubUsername: 'neo-opus-grace'},
               snapshot = {capability: {state: 'wired'}, admission: {state: 'granted', subjectAgentId: '@neo-opus-grace'}, rows: [], page: {limit: 10, offset: 0, count: 0}},
               options  = [{id: '@neo-opus-ada', name: 'Ada'}, {id: 'AGENT:*', name: 'All agents'}];
 
-        const box = createBox({record, snapshot, recipientOptions: options});
+        let reads = 0;
+
+        const box = createBox({record, snapshot, recipientOptions: options, listeners: {inboxPageRequest: () => {reads++}}});
 
         expect(box.getReference('operator-inbox-pane').record).toEqual(record);
         expect(box.getReference('operator-inbox-pane').snapshot).toStrictEqual(snapshot);
         expect(box.getReference('operator-compose-form').recipientOptions).toEqual(options);
+        expect(reads, 'one construction-flush read, never zero, never a double').toBe(1);
 
         box.destroy()
     })

--- a/test/playwright/unit/apps/agentos/view/fleet/operatorSeatConflationParity.spec.mjs
+++ b/test/playwright/unit/apps/agentos/view/fleet/operatorSeatConflationParity.spec.mjs
@@ -1,4 +1,9 @@
 import {expect, test}                   from '@playwright/test';
+// Neo + core MUST load before any Neo-class import (unit-test rule 1): FleetCockpit's transitive
+// graph reaches gatekept core modules, and without this pair the file only booted when ANOTHER
+// spec in the same worker had initialized the namespace first — worker-scheduling luck, not order.
+import Neo                              from '../../../../../../../src/Neo.mjs';
+import * as core                        from '../../../../../../../src/core/_export.mjs';
 import {describeOperatorSeatConflation} from '../../../../../../../ai/services/fleet/operatorSeatConflation.mjs';
 import FleetCockpit                     from '../../../../../../../apps/agentos/view/fleet/FleetCockpit.mjs';
 
@@ -38,9 +43,7 @@ test.describe('operatorSeatConflation — cross-boundary parity pin (leaf ↔ co
     const
         leafDecision    = viewer => describeOperatorSeatConflation({viewerIdentity: viewer, registeredIds: REGISTERED}),
         cockpitDecision = viewer => FleetCockpit.prototype.deriveOperatorIdentityPosture.call(
-            {getReference: reference => reference === 'fleet-grid'
-                ? {store: {items: REGISTERED.map(id => ({agentId: String(id).replace(/^@/, '')}))}}
-                : null},
+            {resolveFleetRosterStore: () => ({items: REGISTERED.map(id => ({agentId: String(id).replace(/^@/, '')}))})},
             viewer
         );
 
@@ -54,7 +57,7 @@ test.describe('operatorSeatConflation — cross-boundary parity pin (leaf ↔ co
     test('the empty-list null contract holds on both sides — absence of truth is not a clean bill', () => {
         expect(describeOperatorSeatConflation({viewerIdentity: '@tobiu', registeredIds: []})).toBeNull();
         expect(FleetCockpit.prototype.deriveOperatorIdentityPosture.call(
-            {getReference: reference => reference === 'fleet-grid' ? {store: {items: []}} : null},
+            {resolveFleetRosterStore: () => ({items: []})},
             '@tobiu'
         )).toBeNull()
     })


### PR DESCRIPTION
Resolves neomjs/neo#17451

Refs neomjs/neo#17269 · Related: neomjs/neo-agent-institution#10

Cut 1 of the approved navigation model shipped: the three proven reading surfaces — Memories, the operator Mailbox (retitled from "Operator"), Catch-up — moved from squeezed edge-rail chrome into resident south tabs beside Activity (`stream-tabs: ['stream','memories','operator','catchUp']`), the rail now carries inspector + invoked tools only (4 of 7 items remain), the "Fleet" preset became "Overview" (`layoutId: 'overview'`, collection active id follows — the preset/keeper-tab name collision is resolved), and `activatePerspective` into an inspector-revealing document with no prior selection now defaults `detailRecord` to the roster's first resident before the commit re-projects, so the Review preset lands loaded instead of on "Select an agent to inspect". Dock mechanics are untouched. The landed change grew beyond the original data+preset framing through two review rounds: it also carries the provider-owned roster authority (`resolveFleetRosterStore` for writes, listeners, re-seat and all option builders), the real `isInspectorRevealed` predicate, the resident-boot lifecycle (need-gated CatchUp bridge-arrival recovery, exactly-once boot reads in both identity/pane orderings, the live-adjacency tab activation), and the full journey migration — see Deltas.

Evidence: L2 (full owning unit tree, 775 green — document truth, projection, preset switch, resident boot lifecycle, tear-out/pop-out home semantics) **plus the six affected NL journeys executed green at this head** (CatchUp, Memories, OperatorMailbox, NWindow, DockNL ×2 — the round-1 gap closed; suite runs outside CI, receipts in Test Evidence) → sufficient for every neomjs/neo#17451 close-target AC; the designed §04 anatomy stays on neomjs/neo#17269 cuts 2. Residual: none carried by this PR beyond the standing neomjs/neo-agent-brain#28 witness items.

## Deltas from ticket
Round 1 (Euclid) proved the "2-file cut" framing wrong — the resident shift is a LIFECYCLE change, and this head now carries its full repair set: (1) a provider-owned `resolveFleetRosterStore` accessor replaces every projected-grid roster read (five call sites incl. the seat-conflation posture), with all resident consumers — mailbox recipients included — refreshed at the first live roster answer and the posture re-derived; (2) `isInspectorRevealed` derives reveal from actual tree placement + active tab + non-auto-hidden (the absent-detail falsifier is pinned in a validator-clean test); (3) the construction-time CatchUp history request recovers exactly once at bridge arrival (need-gated on the unavailable envelope — the RA-4 clarification's cold-before-bridge ordering), and `openCatchUpLiveSurface` now activates the stream TAB before focusing (the live-adjacency journey caught the inactive-card no-op — a real product hole the executed journeys surfaced); (4) stale rail-lazy/reveal wording repaired across `CatchUpPane`, `OperatorMailbox`, `FleetCockpit`; (5) the Contract Ledger is backfilled on neomjs/neo#17451. Journey execution also surfaced two pre-existing stale expectations from the neomjs/neo#17302 viewer-local time merge (CatchUp + Memories asserted the UTC wire form) — both now import the T5 `viewerTime` helper — and the mailbox fit probe's overlay-era forced-overflow assertion is relaxed to the reachability contract (the taller south-tab body legitimately fits this fixture).

## Test Evidence
- `npx playwright test -c test/playwright/playwright.config.unit.mjs test/playwright/unit/apps/agentos` → **775 passed** (full owning tree at the final head; includes `fleetCockpitResidentBoot.spec.mjs` — 6 production-shaped lifecycle arms, the no-grid ingest arm among them — the three neomjs/neo#17451 preset-suite selection arms, and the identity-before-pane exactly-once counter added inside `operatorMailbox.spec.mjs`'s existing construction-flush test).
- `cd test/playwright && npx playwright test -c playwright.config.e2e.mjs e2e/agentos/FleetCatchUpNL.spec.mjs e2e/agentos/OperatorMailboxNL.spec.mjs e2e/agentos/FleetMemoriesNL.spec.mjs e2e/agentos/FleetCockpitNWindowNL.spec.mjs e2e/agentos/FleetCockpitDockNL.spec.mjs` → **6 passed** — ALL affected journeys executed, DockNL's renamed-preset legs included (own free-port server per the neomjs/neo#15367-hardened config).
- `npm run agent-preflight -- --change-class capability ...` → all gates passed (ticket-archaeology clean after comment rewrite).
- Fleet cockpit dock document: `test/playwright/unit/apps/agentos/cockpitDockDocument.spec.mjs` — south family + rail truth asserted, green.
- Cockpit projection/presets: `fleetCockpitProjection.spec.mjs` — Overview naming, resident panes exactly-once, switch seams, green.
- Tear-out/pop-out: `fleetCockpitTearOut.spec.mjs` (semantic-fallback re-anchored on the genuinely-collapsing `fleet` node; exact-index return now proven against native siblings), `fleetCockpitPopOut.spec.mjs` (memories home = south strip; obsolete rail-lazy pre-state converted into a sharper re-materialization-after-true-absence spec for the owner-held selection path), green.
- e2e (outside CI): `test/playwright/e2e/agentos/FleetCockpitDockNL.spec.mjs` — preset activation updated to `Overview` and **executed green** (both DockNL legs are part of the 6-passed run above; the round-0 "unexecuted" residual is closed).

## Post-Merge Validation
- [ ] Browser witness: south strip shows Activity · Memories · Mailbox · Catch-up; rail shows 4 items; top control reads "Overview"; Review preset opens the detail pane loaded on a cold seat.
- [ ] Observe the one-time CatchUp warm-load at boot on the operator seat (named behavior shift, acceptable for a reading surface).

Residual-Owner: neomjs/neo-agent-brain#28

Both items are recorded on neomjs/neo-agent-brain#28 as the witness session's sixth resident, beside the five it already holds.

## Evolution
The reviewer-facing surprise during implementation was fixture-shaped, not product-shaped: the projection suite's `Object.create(FleetCockpit.prototype)` hosts began projecting the three new resident panes, whose resolvers walk `getReference`/`getController` — the fixtures now stub both to `null` (the same honesty pattern the suite already used for `buildActivityActorDirectory`), and the tear-out "semantic fallback" scenario moved from `stream` (no longer alone in its node) to `fleet` (still alone), preserving the collapse-path coverage instead of silently losing it.

Authored by Clio (Claude Fable 5, Claude Code). Session 1d9a2e33-2b0d-4185-9296-4b32559e2825.

