### PR TITLE
fix(ai): the presence terminal reports what it did, and says why when it fails (#17342)

### DIFF
--- a/ai/mcp/server/memory-core/openapi.yaml
+++ b/ai/mcp/server/memory-core/openapi.yaml
@@ -4110,10 +4110,8 @@ components:
               nullable: true
               maxLength: 240
               description: >-
-                Sanitized reason a `deferred` or `failed` presence terminal did not complete, absent
-                on `completed`. Whitespace-collapsed, credential-redacted and then bounded, in that
-                order. Exists because the outcome alone is not diagnosable: a constant `failed`
-                beside a server-only log cost multiple seats days of blind sampling.
+                Sanitized, bounded reason for a `deferred` or `failed` presence terminal; absent on
+                `completed`.
             visibilityMs:
               type: integer
               minimum: 0

--- a/ai/mcp/server/memory-core/openapi.yaml
+++ b/ai/mcp/server/memory-core/openapi.yaml
@@ -4105,6 +4105,15 @@ components:
               description: >-
                 `completed` landed within budget; `deferred` is still observed after the local
                 wait expired; `failed` means the terminal rejected without rejecting the accepted save.
+            presenceReason:
+              type: string
+              nullable: true
+              maxLength: 240
+              description: >-
+                Sanitized reason a `deferred` or `failed` presence terminal did not complete, absent
+                on `completed`. Whitespace-collapsed, credential-redacted and then bounded, in that
+                order. Exists because the outcome alone is not diagnosable: a constant `failed`
+                beside a server-only log cost multiple seats days of blind sampling.
             visibilityMs:
               type: integer
               minimum: 0

--- a/ai/services/memory-core/MemoryService.mjs
+++ b/ai/services/memory-core/MemoryService.mjs
@@ -430,7 +430,7 @@ class MemoryService extends Base {
      *     visibility: Object, mailbox: null, stageTimings: {walMs: Number, mailboxMs: null,
      *     mailboxTerminal: 'omitted', mailboxReason: 'synchronous-query-outside-accepted-write-contract',
      *     presenceMs: Number, presenceTerminal: 'completed'|'deferred'|'failed',
-     *     presenceReason: String|undefined, visibilityMs: Number,
+     *     presenceReason: String|null|undefined, visibilityMs: Number,
      *     postWalMs: Number, postWalBudgetMs: Number}}>} Memory-write confirmation. `mailbox` is
      *     deliberately `null`: its synchronous SQLite enrichment is outside the accepted-write
      *     latency contract, and callers use `list_messages` for the authoritative mailbox read.

--- a/ai/services/memory-core/MemoryService.mjs
+++ b/ai/services/memory-core/MemoryService.mjs
@@ -34,6 +34,7 @@ import {normalizeAgentIdentityNodeId}                           from '../../grap
 import {CONCEPT_EXPANSION_EDGE_TYPES, MEMORY_TERMINAL_EDGE_TYPES, enrichWithConceptWalk} from '../graph/conceptAnchoredRetrieval.mjs';
 import {buildMemoryResolveCandidate}                                                     from './conceptWalkMemoryGate.mjs';
 import MemoryCoreRecorderService                                                         from './MemoryCoreRecorderService.mjs';
+import {redactReadFailure}                                                               from '../fleet/redactReadFailure.mjs';
 
 /**
  * The `add_memory` success message. Deliberately says ACCEPTED rather than "successfully added":
@@ -583,17 +584,33 @@ class MemoryService extends Base {
                 // Pre-attach the late-failure handler BEFORE racing: on a budget overrun the
                 // original write keeps running fire-and-forget (the terminal still lands, late)
                 // and its own catch prevents an unhandled rejection.
-                const presenceWrite = TurnPresenceService.recordTurnPresence({
+                // `recordTurnPresence` is SYNCHRONOUS — it returns the persisted payload, not a
+                // promise. Calling `.catch()` on that object threw `presenceWrite.catch is not a
+                // function` inside this try on every single save, which is why the disposition read
+                // a constant `failed` while the terminal itself landed correctly: the write already
+                // completed on the line above. Deferring through `then` makes the value a real
+                // thenable AND converts a synchronous throw into a rejection this block can classify.
+                const presenceWrite = Promise.resolve().then(() => TurnPresenceService.recordTurnPresence({
                     action       : 'terminal',
                     terminalState: 'completed',
                     source       : 'add_memory'
-                });
+                }));
                 presenceWrite.catch(error => logger.warn(`[MemoryService] Late turn-presence terminal failed (non-fatal): ${error.message}`));
 
                 await withTimeout(presenceWrite, PRESENCE_TERMINAL_BUDGET_MS, 'add_memory presence terminal');
                 stageTimings.presenceTerminal = 'completed';
             } catch (error) {
                 stageTimings.presenceTerminal = error.code === WITH_TIMEOUT_CODE ? 'deferred' : 'failed';
+
+                // The outcome alone is not diagnosable. A constant `failed` beside a server-only
+                // warn cost multiple seats days of blind sampling, because the one client surface
+                // that carries service logs could not slice back far enough on a chatty plane.
+                // Carrying the sanitized reason to the caller makes the NEXT occurrence of this
+                // class self-diagnosing. Reuses the shared reduction rather than growing a fourth
+                // private copy — its order is load-bearing: collapse, redact, and only then bound,
+                // because a replacement can outgrow its match.
+                stageTimings.presenceReason = redactReadFailure(error);
+
                 logger.warn(`[MemoryService] Turn presence terminalization ${stageTimings.presenceTerminal} (non-fatal): ${error.message}`);
             }
             stageTimings.presenceMs = Date.now() - presenceStartedAt;

--- a/ai/services/memory-core/MemoryService.mjs
+++ b/ai/services/memory-core/MemoryService.mjs
@@ -429,7 +429,8 @@ class MemoryService extends Base {
      * @returns {Promise<{id: String, sessionId: String, timestamp: String, message: String,
      *     visibility: Object, mailbox: null, stageTimings: {walMs: Number, mailboxMs: null,
      *     mailboxTerminal: 'omitted', mailboxReason: 'synchronous-query-outside-accepted-write-contract',
-     *     presenceMs: Number, presenceTerminal: 'completed'|'deferred'|'failed', visibilityMs: Number,
+     *     presenceMs: Number, presenceTerminal: 'completed'|'deferred'|'failed',
+     *     presenceReason: String|undefined, visibilityMs: Number,
      *     postWalMs: Number, postWalBudgetMs: Number}}>} Memory-write confirmation. `mailbox` is
      *     deliberately `null`: its synchronous SQLite enrichment is outside the accepted-write
      *     latency contract, and callers use `list_messages` for the authoritative mailbox read.

--- a/test/playwright/unit/ai/mcp/validation/OpenApiValidatorCompliance.spec.mjs
+++ b/test/playwright/unit/ai/mcp/validation/OpenApiValidatorCompliance.spec.mjs
@@ -537,6 +537,7 @@ test.describe('OpenApiValidator: strict-client JSON-Schema compliance', () => {
             'mailboxReason',
             'presenceMs',
             'presenceTerminal',
+            'presenceReason',
             'visibilityMs',
             'postWalMs',
             'postWalBudgetMs'
@@ -545,6 +546,11 @@ test.describe('OpenApiValidator: strict-client JSON-Schema compliance', () => {
         expect(stageTimings.properties.mailboxTerminal.enum).toEqual(['omitted']);
         expect(stageTimings.properties.mailboxReason.enum).toEqual(['synchronous-query-outside-accepted-write-contract']);
         expect(stageTimings.properties.presenceTerminal.enum).toEqual(['completed', 'deferred', 'failed']);
+        // The disposition alone is not diagnosable — a constant `failed` beside a server-only log is
+        // what cost several seats days of blind sampling. The reason is nullable because `completed`
+        // carries none, and bounded because it is a redacted diagnostic, not a payload.
+        expect(stageTimings.properties.presenceReason.nullable).toBe(true);
+        expect(stageTimings.properties.presenceReason.maxLength).toBe(240);
         expect(stageTimings.properties.postWalBudgetMs.example).toBe(1_000);
     });
 

--- a/test/playwright/unit/ai/services/memory-core/MemoryService.WriteAhead.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/MemoryService.WriteAhead.spec.mjs
@@ -361,6 +361,51 @@ test.describe('Neo.ai.services.memory-core.MemoryService.writeAhead', () => {
         }
     });
 
+    test('#17342: a failed presence terminal carries a sanitized reason, not a bare constant', async () => {
+        const originalPresence = TurnPresenceService.recordTurnPresence;
+
+        // A realistic shape for this defect class: the throw carries a credential-looking token and
+        // ragged whitespace, so the arm exercises the reduction rather than a tidy string.
+        TurnPresenceService.recordTurnPresence = () => Promise.reject(
+            new Error('presence write rejected\n\n  token=ghp_AAAABBBBCCCCDDDDEEEEFFFFGGGGHHHHIIII   mid-work')
+        );
+
+        try {
+            const result = await asTenant(() => MemoryService.addMemory({
+                prompt  : 'failed presence prompt',
+                thought : 'failed presence thought',
+                response: 'failed presence result'
+            }));
+
+            expect(result.stageTimings.presenceTerminal).toBe('failed');
+
+            const reason = result.stageTimings.presenceReason;
+
+            expect(reason).toBeTruthy();
+            expect(reason).toContain('presence write rejected');
+            // collapsed, bounded, and the credential family masked — the whole point is that this
+            // field can be read by an operator without becoming a leak.
+            expect(reason).not.toMatch(/\s{2,}/);
+            expect(reason.length).toBeLessThanOrEqual(240);
+            expect(reason).not.toContain('ghp_AAAABBBBCCCCDDDDEEEEFFFFGGGGHHHHIIII');
+        } finally {
+            TurnPresenceService.recordTurnPresence = originalPresence;
+        }
+    });
+
+    test('#17342 CONTROL: a completed presence terminal carries NO reason', async () => {
+        // Without this pair the arm above is satisfied by a build that attaches a reason to every
+        // save, which would make the field useless as a signal.
+        const result = await asTenant(() => MemoryService.addMemory({
+            prompt  : 'completed presence prompt',
+            thought : 'completed presence thought',
+            response: 'completed presence result'
+        }));
+
+        expect(result.stageTimings.presenceTerminal).toBe('completed');
+        expect(result.stageTimings.presenceReason ?? null).toBeNull();
+    });
+
     test('AC4: a presence rejection after the local deadline is handled exactly once', async () => {
         const originalPresence = TurnPresenceService.recordTurnPresence;
         const originalWarn     = logger.warn;

--- a/test/playwright/unit/ai/services/memory-core/MemoryService.WriteAhead.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/MemoryService.WriteAhead.spec.mjs
@@ -59,6 +59,13 @@ test.describe('Neo.ai.services.memory-core.MemoryService.writeAhead', () => {
         testWalDir     = aiConfig.memoryWal.dir;
         testPlaneId    = aiConfig.plane.id;
 
+        // `Neo.get` is an InstanceManager alias, and both production entrypoints that reach these
+        // services — `ai/mcp/server/memory-core/mcp-server.mjs:5` and `ai/services.mjs:24` — import
+        // it at module load. Without it the graph write path throws `Neo.get is not a function`,
+        // which is a harness gap rather than a defect: the suite was booting services along a path
+        // production never uses. Surfaced by @neo-gpt's RA-3 effect arm.
+        await import('../../../../../../src/manager/Instance.mjs');
+
         GraphService         = (await import('../../../../../../ai/services/memory-core/GraphService.mjs')).default;
         ({default: MemoryService, MEMORY_ACCEPTED_MESSAGE} =
             await import('../../../../../../ai/services/memory-core/MemoryService.mjs'));
@@ -393,9 +400,78 @@ test.describe('Neo.ai.services.memory-core.MemoryService.writeAhead', () => {
         }
     });
 
+    test('#17342: the save TERMINALIZES a real active turn, not just the no-op path', async () => {
+        // @neo-gpt's RA-3. The control below reaches TurnPresenceService's `no-active-turn` noop
+        // (:129), which the wrapper also classifies `completed` — so it proves classification and
+        // NOT the effect. This arm creates the effect-bearing precondition first: a real interval
+        // under the same bound context, then the production save, then the interval's own state.
+        const started = await asTenant(() => TurnPresenceService.recordTurnPresence({
+            action: 'start',
+            source: '17342-effect-arm'
+        }));
+
+        expect(started.status).toBe('recorded');
+        expect(started.turnId).toBeTruthy();
+
+        // The interval is real and persisted — asserted against SQLite directly, because that is the
+        // store the terminal write and its readers share.
+        const readInterval = () => GraphService.db.storage.db.prepare(
+            "SELECT data FROM Nodes WHERE json_extract(data,'$.properties.turnId') = ?"
+        ).get(started.turnId);
+
+        const beforeRow = JSON.parse(readInterval().data).properties;
+
+        expect(beforeRow.status).toBe('active');
+        expect(beforeRow.terminalState).toBeNull();
+
+        const result = await asTenant(() => MemoryService.addMemory({
+            prompt  : 'terminalizing presence prompt',
+            thought : 'terminalizing presence thought',
+            response: 'terminalizing presence result'
+        }));
+
+        expect(result.stageTimings.presenceTerminal).toBe('completed');
+        expect(result.stageTimings.presenceReason ?? null).toBeNull();
+
+        // The effect: THAT interval is now terminal. Read from the same store, not from the
+        // wrapper's own disposition, which would be circular. The before/after pairing is the
+        // proof — either row alone is a state, not a change.
+        const afterRow = JSON.parse(readInterval().data).properties;
+
+        expect(afterRow.status).toBe('terminal');
+        expect(afterRow.terminalState).toBe('completed');
+    });
+
+    test('#17342: a DEFERRED terminal carries a reason too — OpenAPI promises it for both incomplete states', async () => {
+        // @neo-gpt's RA-3. Without this, a mutant that populates the reason only on `failed` keeps
+        // every other assertion green while the schema promises it for `deferred` as well.
+        const originalPresence = TurnPresenceService.recordTurnPresence;
+
+        TurnPresenceService.recordTurnPresence = () => new Promise(() => {});
+
+        try {
+            const result = await asTenant(() => MemoryService.addMemory({
+                prompt  : 'deferred reason prompt',
+                thought : 'deferred reason thought',
+                response: 'deferred reason result'
+            }));
+
+            expect(result.stageTimings.presenceTerminal).toBe('deferred');
+
+            const reason = result.stageTimings.presenceReason;
+
+            expect(reason).toBeTruthy();
+            expect(reason.length).toBeLessThanOrEqual(240);
+            expect(reason).not.toMatch(/\s{2,}/);
+        } finally {
+            TurnPresenceService.recordTurnPresence = originalPresence;
+        }
+    });
+
     test('#17342 CONTROL: a completed presence terminal carries NO reason', async () => {
-        // Without this pair the arm above is satisfied by a build that attaches a reason to every
-        // save, which would make the field useless as a signal.
+        // Deliberately retained WITHOUT a started turn: it pins that the no-op path stays
+        // `completed` and reason-free. Kept as a classification control, never as terminalization
+        // proof — the arm above owns that claim.
         const result = await asTenant(() => MemoryService.addMemory({
             prompt  : 'completed presence prompt',
             thought : 'completed presence thought',


### PR DESCRIPTION
Resolves neomjs/neo#17342

`recordTurnPresence` is **synchronous** — it returns the persisted payload, not a promise. `MemoryService` pre-attached its late-failure handler with `presenceWrite.catch(...)`, which threw `presenceWrite.catch is not a function` **inside its own try**, on every save, on every seat, since the handler was introduced.

Evidence: L2 (root cause reproduced in the unit suite; 24 arms including an effect-bearing terminalization arm that reads the interval's own row before and after the production save) → L2 achieved. **Residual: AC-4**, owned by **#17225** — an OPEN ticket that survives this merge, whose subject is exactly presence-signal quality on the real plane (*"the write lands at a turn BOUNDARY, so the busiest seat looks stalest"*). The deployed `stageTimings` receipt goes there after deploy, cross-posted to neomjs/neo#17342. Naming a surviving owner rather than a post-merge flag on the ticket this PR closes: @neo-gpt's RA-1 is right that an obligation recorded on a closed ticket has no watcher.

## Deltas from ticket

**The ticket's impact assessment is inverted, and this is the most important correction here.** It states *"tier 2 of the presence precedence — the beacon that decides online before any absence verdict — is dead for every seat"*. **It is not dead.** The write completes on the line **above** the throw, so the terminal lands correctly; only the reported disposition lies.

Measured with a control, on this seat today:

| step | observation |
|---|---|
| explicit `record_turn_presence({action:'start'})` | turn `a90a5075…` recorded, fresh until 10:42:46Z |
| `who_is_online` immediately after | `turnPresence: {turnId: "a90a5075…", fresh: true}` — **non-null** |
| `add_memory`, then `who_is_online` | `turnPresence: null` — because the save **correctly terminalized** the turn |

The `null` readings that motivated the fleet-wide claim are a **closed turn**, which is the designed behaviour, not a dead beacon. The seats reading `idle`/`dark` mid-turn are worth re-examining against that — but this defect is not the cause, and AC-1's `who_is_online` arm passes today, before this change.

**The three-seat / two-deployment / two-revision evidence is explained by it being a plain code path**, not an environment interaction. Nothing about deployment state was ever involved.

**The diagnostic field is what found the bug.** I implemented Fix step 1 (`presenceReason`) before knowing the cause, ran the control arm expecting `completed`, and the reduction printed the TypeError. That is the ticket's own argument for the field, demonstrated on itself: the constant `failed` had cost multiple seats days of blind sampling.

**Reused `redactReadFailure` rather than adding a memory-core sibling.** The ticket left the home to the implementer; that module's own docblock argues against a third private copy, and its order — collapse, redact, then bound — is load-bearing because a replacement can outgrow its match. Cross-service import has precedent at `WakeSubscriptionService.mjs:16`. Relocating it to `ai/services/shared/` is the better long-term home and is deliberately **not** done here — it drags `redactCredentials` with it and is scope creep on a diagnostic field.

## Test Evidence

**24 WriteAhead arms green** (22 at the effect-arm commit, 24 with the deferred arm), plus 51 validator arms. Four are new and they form a matrix rather than a pile:

| arm | what it pins | why it exists |
|---|---|---|
| failed carries a sanitized reason | reason present, collapsed, ≤240, credential masked | the field that found this bug |
| **effect: terminalizes a real turn** | interval row `active`/`null` → `terminal`/`completed` | @neo-gpt's RA-3 — read from the store, not the wrapper's own verdict |
| deferred carries a reason too | non-empty, bounded, collapsed | a mutant populating it only on `failed` kept everything else green |
| CONTROL: completed carries none | reason absent | without it the first arm passes on a build that always advises |

The old no-turn control is **retained and re-scoped** to the no-op path, explicitly not as terminalization proof.

**Harness gap fixed while building the effect arm.** It first failed with `Neo.get is not a function` — an InstanceManager alias that both production entrypoints import at module load (`mcp-server.mjs:5`, `ai/services.mjs:24`) and the suite did not. The suite was booting services along a path production never uses; any graph-write assertion added there would have hit the same wall.


## Post-Merge Validation

An `add_memory` on a healthy deployment returns `presenceTerminal: 'completed'` with no `presenceReason`, and the receipt is posted to neomjs/neo#17342 (AC-4). Before this change, every save on every seat returned `failed`.

## Evolution

`withTimeout` and `.catch` both silently assume a thenable. A synchronous function returning a plain object satisfies neither, and the failure surfaced as a *disposition* rather than an error — which is why it survived multi-day sampling. The generalisable check: when a value is raced or `.catch`ed, assert it is a promise at the boundary, or the type error becomes indistinguishable from the failure the wrapper exists to report.

Authored by Ada (Claude Opus 5, Claude Code). Session 43441f60-7f2a-4734-82da-22b609b115f9.


