### PR TITLE
feat(fleet): unify the status-chip family on the token geometry contract (#17264)

### DIFF
--- a/apps/agentos/TOKENS.md
+++ b/apps/agentos/TOKENS.md
@@ -44,7 +44,7 @@ The SSOT's live pulse (`@keyframes pulse`, 2.4s) is **decoration, not informatio
 
 ## The §04 token contract (type · spacing · chip geometry · FM motion aliases)
 
-The token appendix the design-bar section (SSOT §06) points at: four new groups, values included, binding rules stated. Values land in the theme twins (`theme-neo-{dark,light}/apps/agentos/Viewport.scss`) per the standing extraction rule; the light twin derives the same roles against its surfaces and is re-measured on landing. Semantics already landed elsewhere (state/kind color, ink tiers) are **consumed**, never re-minted here.
+The token appendix the design-bar section (SSOT §06) points at: four new groups, values included, binding rules stated. COLOR values land in the theme twins (`theme-neo-{dark,light}/apps/agentos/Viewport.scss`) per the standing extraction rule; the light twin derives the same roles against its surfaces and is re-measured on landing. Mode-INVARIANT values — the chip geometry set and the FM motion aliases — land exactly once at the shell root (`resources/scss/src/apps/agentos/Viewport.scss`): duplicating identical numbers into two skins buys no theme distinction and doubles the drift surface. Both homes carry a closed census in `check-theme-surfaces` (skin members in `CONTRACTED_FM_TOKENS`, shell-root members in `STRUCTURAL_FM_TOKENS`), so deleting a contracted member fails mechanically even while unconsumed. Semantics already landed elsewhere (state/kind color, ink tiers) are **consumed**, never re-minted here.
 
 | Token group | Tokens + values | Binding rule |
 |---|---|---|

--- a/buildScripts/util/check-theme-surfaces.mjs
+++ b/buildScripts/util/check-theme-surfaces.mjs
@@ -79,11 +79,20 @@ const __dirname      = path.dirname(fileURLToPath(import.meta.url)),
           '--fm-kind-pr', '--fm-kind-a2a', '--fm-kind-review', '--fm-kind-alert', '--fm-kind-neutral',
           '--fm-font-mono', '--fm-font-sans'
       ]),
+      // The closed STRUCTURAL vocabulary — the chip-family geometry/motion contract is mode-invariant
+      // by design and therefore lives exactly once at the shell root, never in the skins. Check 2's
+      // component-local-alias exemption deliberately ignores these declarations, so without this census
+      // a deletion of a contracted-but-unconsumed member would false-green every other check.
+      STRUCTURAL_FM_TOKENS = new Set([
+          '--fm-chip-mark-w', '--fm-chip-pad-y', '--fm-chip-pad-x', '--fm-chip-radius', '--fm-chip-gap',
+          '--fm-motion-pulse'
+      ]),
       // Real-tree paths; the exported collector takes overrides so the guard is testable in isolation.
       DEFAULT_PATHS = {
-          darkPath : path.join(repoRoot, 'resources/scss/theme-neo-dark/apps/agentos/Viewport.scss'),
-          lightPath: path.join(repoRoot, 'resources/scss/theme-neo-light/apps/agentos/Viewport.scss'),
-          viewDir  : path.join(repoRoot, 'resources/scss/src/apps/agentos')
+          darkPath      : path.join(repoRoot, 'resources/scss/theme-neo-dark/apps/agentos/Viewport.scss'),
+          lightPath     : path.join(repoRoot, 'resources/scss/theme-neo-light/apps/agentos/Viewport.scss'),
+          structuralPath: path.join(repoRoot, 'resources/scss/src/apps/agentos/Viewport.scss'),
+          viewDir       : path.join(repoRoot, 'resources/scss/src/apps/agentos')
       },
       // check 5 — the drawer shell/pane frame seam. Frame properties are the reveal SLOT's to own; a
       // pane skin ROOT re-declaring one re-creates the every-author-must-remember defect the shell
@@ -246,8 +255,12 @@ function stripVarCalls(text) {
 export function collectThemeSurfaceFailures({
     darkPath         = DEFAULT_PATHS.darkPath,
     lightPath        = DEFAULT_PATHS.lightPath,
+    structuralPath   = DEFAULT_PATHS.structuralPath,
     viewDir          = DEFAULT_PATHS.viewDir,
     contractedTokens = CONTRACTED_FM_TOKENS,
+    // opt-in per surface (the registry sets it): a surface without a structural contract must not
+    // inherit another surface's vocabulary — the workstation false-failed on the FM set otherwise.
+    structuralTokens = new Set(),
     modeInvariant    = MODE_INVARIANT,
     tokenPattern     = FM_TOKEN_RE
 } = {}) {
@@ -299,6 +312,15 @@ export function collectThemeSurfaceFailures({
     for (const token of contractedTokens) {
         if (!dark.has(token))  failures.push(`[contract] ${token} is a contracted --fm-* token but undefined in the dark skin`);
         if (!light.has(token)) failures.push(`[contract] ${token} is a contracted --fm-* token but undefined in the light skin`);
+    }
+
+    // check 1c — closed structural vocabulary: the mode-invariant geometry/motion contract lives ONCE
+    // at the shell root. Same census rule as 1b — every member stays DEFINED even while momentarily
+    // unconsumed — because check 2 exempts shell-root declarations as component-local aliases, and the
+    // completeness check therefore never notices a structural member disappearing.
+    const structural = structuralTokens.size ? extractFmTokens(structuralPath, tokenPattern) : new Map();
+    for (const token of structuralTokens) {
+        if (!structural.has(token)) failures.push(`[structural-contract] ${token} is contracted to the shell root (mode-invariant geometry/motion) but undefined in ${path.relative(repoRoot, structuralPath)}`);
     }
 
     // check 2 — token-only consumption; also collects the consumed + component-local token sets
@@ -661,10 +683,14 @@ const SURFACES = [
         name            : 'agentos',
         darkPath        : DEFAULT_PATHS.darkPath,
         lightPath       : DEFAULT_PATHS.lightPath,
+        structuralPath  : DEFAULT_PATHS.structuralPath,
         viewDir         : DEFAULT_PATHS.viewDir,
         tokenPattern    : FM_TOKEN_RE,
         modeInvariant   : MODE_INVARIANT,
         contractedTokens: CONTRACTED_FM_TOKENS,
+        // the chip-family geometry/motion census (check 1c) is agentos's contract, like 1b above —
+        // a surface opts in by naming its own structural vocabulary, never by inheriting this one
+        structuralTokens: STRUCTURAL_FM_TOKENS,
         // check 5 applies to agentos only: the drawer shell/pane seam is the FM cockpit's contract
         shellSeam       : AGENTOS_SHELL_SEAM
     },

--- a/resources/scss/src/apps/agentos/Viewport.scss
+++ b/resources/scss/src/apps/agentos/Viewport.scss
@@ -6,6 +6,21 @@
        only; the framework token itself is untouched). */
     --tab-indicator-background-color-active: var(--fm-signal);
 
+    /* The chip-family geometry contract (TOKENS.md §04): ONE anatomy for every status/kind
+       idiom — telltale, spine banner, viewer-wake, event chips, state dots. The family owns
+       GEOMETRY only; color value-authority stays with the theme twins (--fm-state-* / --fm-kind-*),
+       and each idiom binds it through one local indirection. Theme-neutral by construction, so
+       both skins inherit the same anatomy for free. */
+    --fm-chip-mark-w: 3px;
+    --fm-chip-pad-y : 2px;
+    --fm-chip-pad-x : 8px;
+    --fm-chip-radius: 4px;
+    --fm-chip-gap   : 8px;
+
+    /* The liveness pulse period (motion ladder): decoration only — the hue + word carry the
+       fact, and the animation exists only under no-preference (the StateDot inclusion-gate). */
+    --fm-motion-pulse: 2400ms;
+
     /* HEIGHT CONTAINMENT FOR THE SHELL'S FLEX SPINE.
        A flex item's automatic minimum size is its CONTENT size, and `min-height: auto` only
        resolves to zero when the item's overflow is not `visible`. Every box listed here sits in the

--- a/resources/scss/src/apps/agentos/fleet/ActorChip.scss
+++ b/resources/scss/src/apps/agentos/fleet/ActorChip.scss
@@ -1,7 +1,10 @@
-/* AgentOS.view.fleet.ActorChip — the actor-identity badge on feed rows: avatar-first, handle
-   always, canonical id on the title. Sized for the one-line row contract — the chip may never
-   add a second text line to the density-frozen window. Colors read from the --fm-* token layer;
-   the chip family reconciliation (one designed system) owns any future anatomy change. */
+/* class: always-rendered — a chip-family-ADJACENT identity badge (see Chips.scss): it names WHO,
+   never a status, so it carries no mark, no severity, and no state class. The actor-identity
+   badge on feed rows: avatar-first, handle always, canonical id on the title. Sized for the
+   one-line row contract — the chip may never add a second text line to the density-frozen window.
+   Recorded exceptions (deliberate, not drift): the 4px internal gap (sub-chip spacing between a
+   14px avatar and micro text — the family gap token is inter-chip rhythm) and the plate-less
+   anatomy (an identity is furniture, not an observation to tint). */
 .fm-actor-chip {
     display    : inline-flex;
     align-items: center;

--- a/resources/scss/src/apps/agentos/fleet/AgentCard.scss
+++ b/resources/scss/src/apps/agentos/fleet/AgentCard.scss
@@ -186,16 +186,23 @@
     }
 
     /* the S2 telltale chip — hidden while nominal; any pixels mean a deviation on ≥1 axis */
+    /* class: exception-only — chip-family member (see Chips.scss): the per-agent telltale renders
+       only on an enumerated deviation (telltale.mjs owns the semantics), so it must read as ONE
+       object, not loose text. Geometry consumes the family tokens; color binds through one local
+       indirection on the EventChip plate pattern — a future severity class rebinds the one
+       property, an unmatched class renders quiet. */
     .fm-card-telltale {
+        --fm-telltale-mark: var(--fm-state-limited);
+
         flex         : none;
         font-family  : var(--fm-font-mono);
         font-size    : 10px;
         line-height  : 1;
-        color        : var(--fm-state-limited);
-        background    : color-mix(in srgb, var(--fm-state-limited) 12%, transparent);
-        border       : 1px solid color-mix(in srgb, var(--fm-state-limited) 30%, transparent);
-        border-radius: 999px;
-        padding      : 2px 7px;
+        color        : var(--fm-telltale-mark);
+        background   : color-mix(in srgb, var(--fm-telltale-mark) 12%, transparent);
+        border       : 1px solid color-mix(in srgb, var(--fm-telltale-mark) 30%, transparent);
+        border-radius: var(--fm-chip-radius);
+        padding      : var(--fm-chip-pad-y) var(--fm-chip-pad-x);
         white-space  : nowrap;
     }
 

--- a/resources/scss/src/apps/agentos/fleet/Chips.scss
+++ b/resources/scss/src/apps/agentos/fleet/Chips.scss
@@ -1,7 +1,22 @@
-/* The selector-chip primitive: registry-derived pick-one rows (harness types on the config card +
-   the add-agent form). Selection state is structural (border + weight + a signal wash) — never
-   hue-alone (WCAG 1.4.1); every color reads from the token layer. Distinct from EventChip (kind-
-   colored stream facts): a selector chip is an affordance, an event chip is an observation. */
+/* THE CHIP FAMILY — one designed anatomy (mark + text + optional detail affordance) for every
+   status/kind surface, on one class axis with three members:
+     exception-only   — nominal earns zero pixels (spine banner = reference; per-agent telltale)
+     always-rendered  — furniture that must be findable before it matters (viewer-wake = reference;
+                        event chips = the kind-axis reference; state dot = the mark-only member)
+     affordance       — an action, never an observation (THIS file's selector chip = reference)
+   The shared parts are the geometry tokens (--fm-chip-mark-w/pad-y/pad-x/radius/gap, declared at
+   the shell root); each idiom binds COLOR through one local indirection (--fm-spine-mark /
+   --fm-viewer-wake-mark / --fm-chip / --fm-telltale-mark / --fm-dot) — a state/kind class rebinds
+   that one property, an unmatched class renders quiet, never a borrowed severity.
+   Family laws: never hue-alone (WCAG 1.4.1 — every chip carries text or geometry beside color);
+   motion is decoration, never information (reduced-motion loses zero signal). */
+
+/* class: affordance — the selector-chip primitive: registry-derived pick-one rows (harness types
+   on the config card + the add-agent form). Selection state is structural (border + weight + a
+   signal wash) — never hue-alone; every color reads from the token layer. Distinct from EventChip
+   (kind-colored stream facts): a selector chip is an affordance, an event chip is an observation.
+   Recorded affordance-class distinctions (deliberate, not drift): 6px radius and its own 3px/9px
+   padding — a pressable control earns a visibly different plate from an observation chip. */
 /* the doubled selector out-cascades the stock .neo-button skin, which loads after this file on
    button-composed chips (same-specificity order would let the slab win — the .neo-button.fm-*
    discipline every fleet surface uses) */

--- a/resources/scss/src/apps/agentos/fleet/EventChip.scss
+++ b/resources/scss/src/apps/agentos/fleet/EventChip.scss
@@ -1,11 +1,13 @@
-/* Event-kind chip — a tinted-outline plate colored entirely by the kind token (--fm-chip): text,
-   border, and faint fill are all color-mixed from that one custom property, so a growing kind set never
-   adds a hand-rolled color and an unknown kind reads as neutral. The token binds from the chip's
-   fm-kind-* class (kindRegistry's kindClass resolver — the chip swaps a class, never writes a style). */
+/* class: always-rendered — the chip family's KIND-AXIS reference member (see Chips.scss for the
+   family contract). A tinted-outline plate colored entirely by the kind token (--fm-chip): text,
+   border, and faint fill are all color-mixed from that one custom property, so a growing kind set
+   never adds a hand-rolled color and an unknown kind reads as neutral. The token binds from the
+   chip's fm-kind-* class (kindRegistry's kindClass resolver — the chip swaps a class, never writes
+   a style). Geometry consumes the family tokens; the uppercase kind word is the non-hue channel. */
 .fm-event-chip {
     display       : inline-block;
-    padding       : 1px 6px;
-    border-radius : 4px;
+    padding       : var(--fm-chip-pad-y) var(--fm-chip-pad-x);
+    border-radius : var(--fm-chip-radius);
     font-family   : var(--fm-font-mono);
     font-size     : 10px;
     font-weight   : 600;

--- a/resources/scss/src/apps/agentos/fleet/SpineBanner.scss
+++ b/resources/scss/src/apps/agentos/fleet/SpineBanner.scss
@@ -1,15 +1,15 @@
-/* The spine's honesty line: names WHY the surface is showing sample or last-known data. Exception-only
-   chrome — a live spine sets `hidden`, and the default `hideMode: 'removeDom'` takes the element out of
-   the DOM entirely, so nominal state costs zero pixels without this file guarding against it. That
-   inverts the usual styling brief: this element is only ever on screen when something is wrong, so it
-   has to read as an exception rather than as toolbar furniture, which is exactly what unstyled inline
-   text reads as.
+/* class: exception-only — the chip family's EXCEPTION-CLASS reference member (see Chips.scss for
+   the family contract). The spine's honesty line: names WHY the surface is showing sample or
+   last-known data. A live spine sets `hidden`, and the default `hideMode: 'removeDom'` takes the
+   element out of the DOM entirely, so nominal state costs zero pixels without this file guarding
+   against it. That inverts the usual styling brief: this element is only ever on screen when
+   something is wrong, so it has to read as an exception rather than as toolbar furniture.
 
-   Color is supplemental and token-only, per the SourceHealthMarker discipline: the text already carries
-   the whole message (cause AND remedy for cold), and the accent bar carries severity in geometry — so
-   neither channel is load-bearing alone, and the line survives a viewer who cannot separate the two
-   state hues. Both-theme adaptation is automatic: every value resolves through --fm-* tokens, which
-   theme-neo-{light,dark}/apps/agentos/Viewport.scss defines per theme. */
+   Color is supplemental and token-only, per the SourceHealthMarker discipline: the text already
+   carries the whole message (cause AND remedy for cold), and the accent bar carries severity in
+   geometry — so neither channel is load-bearing alone, and the line survives a viewer who cannot
+   separate the two state hues. Geometry consumes the family tokens; both-theme adaptation is
+   automatic through the --fm-* token layer. */
 .fm-spine-banner {
     /* Local indirection so the state classes rebind ONE token instead of restating the ruleset —
        the StateDot / SourceHealthMarker pattern. The default is the neutral ink: if a future `kind`
@@ -25,9 +25,9 @@
     flex         : 0 1 auto;
     min-width    : 0;
     max-width    : 100%;
-    padding      : 2px 8px;
-    border-left  : 3px solid var(--fm-spine-mark);
-    border-radius: 2px;
+    padding      : var(--fm-chip-pad-y) var(--fm-chip-pad-x);
+    border-left  : var(--fm-chip-mark-w) solid var(--fm-spine-mark);
+    border-radius: var(--fm-chip-radius);
     background: color-mix(in srgb, var(--fm-spine-mark) 10%, transparent);
     color     : var(--fm-ink);
     font-family  : var(--fm-font-mono);

--- a/resources/scss/src/apps/agentos/fleet/StateDot.scss
+++ b/resources/scss/src/apps/agentos/fleet/StateDot.scss
@@ -24,7 +24,7 @@
 
     @media (prefers-reduced-motion: no-preference) {
         &.fm-live {
-            animation: fm-state-pulse var(--fm-motion-pulse, 2400ms) ease-in-out infinite;
+            animation: fm-state-pulse var(--fm-motion-pulse) ease-in-out infinite;
         }
     }
 }

--- a/resources/scss/src/apps/agentos/fleet/StateDot.scss
+++ b/resources/scss/src/apps/agentos/fleet/StateDot.scss
@@ -1,6 +1,9 @@
-/* Session-state dot — geometry + the reduced-motion-gated pulse, scoped under the component root.
-   COLOR binds via the fm-state-* class → --fm-dot mapping below (the component swaps a class, never
-   writes a style); the pulse is decoration, the color carries the signal. */
+/* class: always-rendered — the chip family's MARK-ONLY member (see Chips.scss for the family
+   contract): geometry + the reduced-motion-gated pulse, scoped under the component root. COLOR
+   binds via the fm-state-* class → --fm-dot mapping below (the component swaps a class, never
+   writes a style); the dot alone NEVER carries state — it holds hue, the adjacent state WORD is
+   the WCAG 1.4.1 channel (the two-channel rule). The pulse is decoration on the family's motion
+   token; its absence under reduced motion loses zero signal. */
 .fm-state-dot {
     width        : 8px;
     height       : 8px;
@@ -21,7 +24,7 @@
 
     @media (prefers-reduced-motion: no-preference) {
         &.fm-live {
-            animation: fm-state-pulse 2.4s ease-in-out infinite;
+            animation: fm-state-pulse var(--fm-motion-pulse, 2400ms) ease-in-out infinite;
         }
     }
 }

--- a/resources/scss/src/apps/agentos/fleet/ViewerWakeTelltale.scss
+++ b/resources/scss/src/apps/agentos/fleet/ViewerWakeTelltale.scss
@@ -1,13 +1,15 @@
-/* The per-viewer wake-push telltale: the quiet chrome readout of MY push lane's health (#17130
-   leg 2). Unlike the spine banner it is ALWAYS rendered — the nominal state is one token wide
-   ("wake: live · 12s ago") and must read as toolbar furniture, while a degraded push carries the
-   consumer's reason and must read as a quiet exception, never an alarm: push is latency, poll is
-   truth, so a dead push lane degrades comfort, not correctness.
+/* class: always-rendered — the chip family's FURNITURE-CLASS reference member (see Chips.scss for
+   the family contract). The per-viewer wake-push telltale: the quiet chrome readout of MY push
+   lane's health. The nominal state is one token wide ("wake: live · 12s ago") and must read as
+   toolbar furniture, while a degraded push carries the consumer's reason and must read as a quiet
+   exception, never an alarm: push is latency, poll is truth, so a dead push lane degrades comfort,
+   not correctness — the family's quiet-exception tone rule.
 
    Color is supplemental and token-only, per the SpineBanner / SourceHealthMarker discipline: the
    text carries the whole message (the consumer's own absence-of-signal reason), the accent mark
-   carries state in geometry, and neither channel is load-bearing alone. Both-theme adaptation is
-   automatic through the --fm-* tokens. */
+   carries state in geometry, and neither channel is load-bearing alone. Geometry consumes the
+   family tokens (the mark width migrated 2px → the family's 3px); both-theme adaptation is
+   automatic through the --fm-* token layer. */
 .fm-viewer-wake {
     /* Local indirection so the state classes rebind ONE token instead of restating the ruleset —
        the SpineBanner pattern. The default is the dim ink: an unknown state renders quiet and
@@ -19,9 +21,9 @@
     flex         : 0 1 auto;
     min-width    : 0;
     max-width    : 40ch;
-    padding      : 2px 8px;
-    border-left  : 2px solid var(--fm-viewer-wake-mark);
-    border-radius: 2px;
+    padding      : var(--fm-chip-pad-y) var(--fm-chip-pad-x);
+    border-left  : var(--fm-chip-mark-w) solid var(--fm-viewer-wake-mark);
+    border-radius: var(--fm-chip-radius);
     color        : var(--fm-ink-dim);
     font-family  : var(--fm-font-mono);
     font-size    : 11px;

--- a/test/playwright/unit/ai/buildScripts/util/check-theme-surfaces.spec.mjs
+++ b/test/playwright/unit/ai/buildScripts/util/check-theme-surfaces.spec.mjs
@@ -27,20 +27,24 @@ test.describe('check-theme-surfaces.mjs', () => {
         fs.rmSync(tempDir, {recursive: true, force: true});
     });
 
-    // Materialize a skin/view fixture set in the temp dir and run the collector against it.
-    const run = ({dark, light, views = {}, contractedTokens = new Set(), ...rest}) => {
-        const darkPath  = path.join(tempDir, 'dark.scss'),
-              lightPath = path.join(tempDir, 'light.scss'),
-              viewDir   = path.join(tempDir, 'views');
+    // Materialize a skin/view fixture set in the temp dir and run the collector against it. The
+    // structural shell-root file is always materialized (possibly empty) so the census check reads
+    // fixture state, never the real tree; the empty-set default keeps pre-census tests untouched.
+    const run = ({dark, light, views = {}, contractedTokens = new Set(), structural = '', structuralTokens = new Set(), ...rest}) => {
+        const darkPath       = path.join(tempDir, 'dark.scss'),
+              lightPath      = path.join(tempDir, 'light.scss'),
+              structuralPath = path.join(tempDir, 'structural.scss'),
+              viewDir        = path.join(tempDir, 'views');
 
         fs.writeFileSync(darkPath, dark, 'utf8');
         fs.writeFileSync(lightPath, light, 'utf8');
+        fs.writeFileSync(structuralPath, structural, 'utf8');
         fs.mkdirSync(viewDir, {recursive: true}); // idempotent — a test may call run() more than once
         for (const [name, content] of Object.entries(views)) {
             fs.writeFileSync(path.join(viewDir, name), content, 'utf8');
         }
 
-        return collectThemeSurfaceFailures({darkPath, lightPath, viewDir, contractedTokens, ...rest});
+        return collectThemeSurfaceFailures({darkPath, lightPath, structuralPath, viewDir, contractedTokens, structuralTokens, ...rest});
     };
 
     // A surface is a TOKEN LANGUAGE, so these drive the collector under a foreign namespace.
@@ -196,6 +200,31 @@ test.describe('check-theme-surfaces.mjs', () => {
     test('bare hex literal fails token-only', () => {
         const failures = run({dark: DARK, light: LIGHT, views: {'a.scss': '.a { color: #ff0000; }\n'}});
         expect(failures.some(m => m.startsWith('[token-only]'))).toBe(true);
+    });
+
+    test('#17264: a structural census member vanishing fails even while unconsumed — the alias-exemption false-green', () => {
+        // The shell root defines mark-w but the contracted gap member was deleted; nothing consumes
+        // gap, so parity/completeness/token-only all stay silent — exactly the mutation the census owns.
+        const failures = run({
+            dark            : DARK,
+            light           : LIGHT,
+            structural      : '.shell {\n    --fm-chip-mark-w: 3px;\n}\n',
+            structuralTokens: new Set(['--fm-chip-mark-w', '--fm-chip-gap'])
+        });
+
+        expect(failures.filter(m => m.startsWith('[structural-contract]'))).toHaveLength(1);
+        expect(failures.some(m => m.startsWith('[structural-contract]') && m.includes('--fm-chip-gap'))).toBe(true);
+    });
+
+    test('#17264: the full structural set defined at the shell root passes the census', () => {
+        const failures = run({
+            dark            : DARK,
+            light           : LIGHT,
+            structural      : '.shell {\n    --fm-chip-mark-w: 3px;\n    --fm-chip-gap: 8px;\n}\n',
+            structuralTokens: new Set(['--fm-chip-mark-w', '--fm-chip-gap'])
+        });
+
+        expect(failures.some(m => m.startsWith('[structural-contract]'))).toBe(false);
     });
 
     test('component-local --fm-* alias is exempt from completeness', () => {


### PR DESCRIPTION
Resolves neomjs/neo#17264

Related: neomjs/neo-agent-institution#10 · neomjs/neo#17263 (the spec this implements) · neomjs/neo-agent-institution#11 (the evidence instrument)

The five cockpit status idioms — per-agent telltale, spine banner, viewer-wake telltale, event chips, state dots — now consume ONE geometry contract instead of five ad-hoc dialects. The family's shared parts live once as shell-root tokens (`--fm-chip-mark-w/pad-y/pad-x/radius/gap` + `--fm-motion-pulse` — the TOKENS.md §04 VALUES verbatim, at a deliberately different PLACEMENT than the appendix originally prescribed: mode-invariant geometry/motion lands once at the structural shell root instead of duplicated into both theme twins. Review round 1 caught that this delta had moved the definition without moving the authority — TOKENS.md now states the two-home rule explicitly, and the guard's new `[structural-contract]` census in `STRUCTURAL_FM_TOKENS` mechanically requires every member at the shell root, deletion-of-unconsumed included). Each idiom binds color through its one local indirection exactly as before (color value-authority stays with the theme twins), and every idiom's SCSS header now states its family class — exception-only / always-rendered / affordance — turning the current discipline into contract. Rendering derivations are untouched: zero `.mjs` changes, the existing class-swap mechanisms stay the binding surface, and all five VDOM pin suites pass unmodified. The sharing mechanism is deliberately token-consumption, not cross-file mixins — the fleet skin layer has zero `@use`/`@mixin` precedent, and custom properties are its established sharing idiom.

Visible value migrations (each one the spec's own migration note): viewer-wake mark 2px → the family 3px; spine + viewer-wake radius 2px → 4px; event-chip padding 1px 6px → 2px 8px (measured against the density contract: chip 18px inside a 35px activity row — the window holds); the card telltale drops its 999px pill for the family plate (radius 4px, pad 2px/8px) and gains the `--fm-telltale-mark` indirection on the EventChip plate pattern; the state-dot pulse period is tokenized as bare `var(--fm-motion-pulse)` — no consumer fallback literal, per the zero-call-site-literal motion rule; the shell root guarantees the token for every declared AgentOS viewport — with the reduced-motion inclusion-gate untouched. The `.fm-chip` selector chip is documented as the affordance-class reference with its recorded distinctions (6px radius, 3px/9px padding — a pressable control earns a different plate from an observation).

Evidence: L1-flavored live receipt on this deployment (computed-style probe in the running cockpit: shell tokens resolve 3px/2px/4px/2400ms; event chip renders 2px 8px/4px; spine 3px mark/4px radius; viewer-wake mark migrated to 3px) on top of L2 (theme guard + full owning unit tree + the five VDOM pin suites) → sufficient for every close-target AC except the visual-regression capture, which is neomjs/neo-agent-institution#11's instrument. Residual: AC4's baseline capture (and the hue-removal legibility pass it carries).

Residual-Owner: neomjs/neo-agent-institution#11

The capture list this PR leaves ready for neomjs/neo-agent-institution#11: spine banner cold + degraded · viewer-wake live + degraded · card telltale on an enumerated deviation · one event chip per `--fm-kind-*` class incl. neutral-on-unknown · state dot per `fm-state-*` class with the pulse frame · the `.fm-chip` selector in idle/selected/focus — each captured in both themes, plus the gray-filter (hue-removal) pass over the same set.

## Deltas from ticket
`ActorChip` (landed with the activity actor-identity PR after the spec was written) is documented as a sixth, family-ADJACENT member: an identity badge that names WHO, never a status — no mark, no severity, its 4px internal gap and plate-less anatomy recorded as deliberate exceptions. Geometry unchanged; classification only.

## Test Evidence
- `npm run check-theme-surfaces` → parity + token-only + completeness + text-safe ink + shell-seam all pass — and since round 1 the guard also carries the new structural closed-token census (check 1c, agentos-registered): deleting the unconsumed `--fm-chip-gap` from the shell root now exits 1 with `[structural-contract] --fm-chip-gap …` (the reviewer's exact-head mutation, re-run and caught), while the workstation surface stays census-free by explicit opt-in.
- `check-theme-surfaces.spec.mjs` → 48 tests green, including the two new census arms (vanishing-member failure + full-set pass) on isolated fixtures.
- `npx playwright test -c test/playwright/playwright.config.unit.mjs test/playwright/unit/apps/agentos` → **766 passed** (includes the five idiom pin suites: `eventChip.spec.mjs`, `spineBanner.spec.mjs`, `stateDot.spec.mjs`, `telltale.spec.mjs`, `viewerWakeTelltale.spec.mjs` — all unmodified).
- Live cockpit verification (dev server on this checkout, foreign-8080 trap checked and avoided): computed styles confirm every token value and migration listed above; screenshot witnessed the cold-state spine banner + degraded wake telltale rendering the shared anatomy.
- Fleet cockpit surface: covered by the suites above; no e2e touches needed (skin-only change).

## Post-Merge Validation
- [ ] The neomjs/neo-agent-institution#11 baseline captures the family set per the capture list above (both themes + the gray-filter legibility pass).

Residual-Owner: neomjs/neo-agent-institution#11

Authored by Clio (Claude Fable 5, Claude Code). Session 1d9a2e33-2b0d-4185-9296-4b32559e2825.
