### PR TITLE
feat(agent-os): honor lease-caused tenant sync yields (#17414)

### DIFF
--- a/ai/daemons/orchestrator/services/TenantRepoSyncService.mjs
+++ b/ai/daemons/orchestrator/services/TenantRepoSyncService.mjs
@@ -2462,12 +2462,6 @@ class TenantRepoSyncService extends Base {
                     )
                 }
 
-                if (observedYieldCause === YIELD_CAUSE_LEASE) {
-                    // Set before any outcome branch can return. `finally` releases the semaphore slot,
-                    // and the next queued repo reads this latch immediately after acquiring it.
-                    leaseYielded = true;
-                }
-
                 // Emitted before BOTH guards on this path, which is what makes it useful:
                 // `classifyIngestionOutcome` throws on a rejected error-bearing summary, and
                 // `assertFullMaterializationEffect` throws on a zero-effect one. Between them they
@@ -3038,18 +3032,21 @@ class TenantRepoSyncService extends Base {
                 : (attemptedCount === 0
                     ? 'completed' // all repos were not-due; cycle ran cleanly
                     : (failedCount === 0 ? 'completed' : (completedCount > 0 ? 'completed' : 'failed'))));
-        // Error-bearing outcomes retain their stronger status. On a CLEAN active cohort, `yielded`
-        // is reserved for an observed lease cause that leaves actual work behind: a partial repo or
-        // a queued tail. Merely observing the bound after the final one-batch repo completed is still
-        // an ordinary completed sweep — there is nothing to resume and the wrapper releases on
-        // natural settlement. The sweep never receives nor invokes a release callback itself.
+        // Failure and ordinary deferral retain their stronger status even when the lease bound also
+        // fired: both already mean non-completed work and keep their existing markFailed/markSkipped
+        // task-state semantics. On a CLEAN active cohort, `yielded` is reserved for an observed lease
+        // cause that leaves actual work behind: a partial repo or a queued tail. Merely observing the
+        // bound after the final one-batch repo completed is still an ordinary completed sweep — there
+        // is nothing to resume and the wrapper releases on natural settlement. The sweep never
+        // receives nor invokes a release callback itself.
         const cleanLeaseYieldWithRemainder = leaseYielded
             && failedCount === 0
-            && deferredCount === 0
             && (partialProgressCount > 0 || leaseDeferredCount > 0);
         const status = leaseYielded && failedCount > 0
             ? 'failed'
-            : (cleanLeaseYieldWithRemainder ? 'yielded' : ordinaryStatus);
+            : (leaseYielded && deferredCount > 0
+                ? 'deferred'
+                : (cleanLeaseYieldWithRemainder ? 'yielded' : ordinaryStatus));
 
         // Record-with-diagnosis: exactly one durable heal-ledger record per starved
         // episode (the detector's marker flows through the lane's completion metadata), once

--- a/ai/daemons/orchestrator/services/TenantRepoSyncService.mjs
+++ b/ai/daemons/orchestrator/services/TenantRepoSyncService.mjs
@@ -51,6 +51,7 @@ import {
     resolveMinimumBackoffCapMs,
     resolveRepoBaseCadenceMs,
     resolveUnknownRepoSelectorFailure,
+    YIELD_CAUSE_LEASE,
     YIELD_CAUSE_SLICE
 } from '../scheduling/tenantRepoSync.mjs';
 import {
@@ -1357,7 +1358,7 @@ class TenantRepoSyncService extends Base {
      * @param {Number} [options.embeddingRecoveryProbeTimeoutMs=30000] Canary provider deadline.
      * @param {Number} [options.embeddingRecoveryFailureTtlMs=30000] Canary backoff floor.
      * @param {Number} [options.embeddingRecoveryFailureTtlMaxMs=600000] Canary backoff ceiling.
-     * @returns {Promise<Object>} `{status, details}` — status ∈ {`completed`, `failed`, `skipped`, `starved`}.
+     * @returns {Promise<Object>} `{status, details}` — status ∈ {`completed`, `deferred`, `failed`, `skipped`, `starved`, `yielded`}.
      */
     async runTask({
         taskName = 'tenant-repo-sync',
@@ -1557,9 +1558,11 @@ class TenantRepoSyncService extends Base {
                 ...result.details
             };
 
-            if (status === 'completed' || status === 'starved') {
+            if (status === 'completed' || status === 'starved' || status === 'yielded') {
                 // A starved reading is a CLEAN sweep reporting a starved lane — the machinery
-                // ran, so the run bookkeeping (lastSuccessAt) must still advance.
+                // ran, so the run bookkeeping (lastSuccessAt) must still advance. A yielded
+                // reading is likewise clean: its active cohort committed before the outer wrapper
+                // released, while `lastCompletion.status` preserves that the corpus is unfinished.
                 taskStateService.markCompleted(taskName, lastCompletion);
             } else if (status === 'failed') {
                 taskStateService.markFailed(taskName, null, lastCompletion);
@@ -1604,7 +1607,7 @@ class TenantRepoSyncService extends Base {
      * Iterates configured tenantRepos and refreshes each via GitMirror → envelope → KB.
      *
      * @param {Object} options Forwarded from `runTask`.
-     * @returns {Promise<Object>} `{status, details: {repoCount, completedCount, deferredCount, partialProgressCount, failedCount, results}}`.
+     * @returns {Promise<Object>} `{status, details: {repoCount, completedCount, deferredCount, partialProgressCount, failedCount, leaseYielded, leaseDeferredCount, repos}}`.
      */
     async syncTenantRepos({
         writeLog, tenantReposConfig, gitMirror, knowledgeBaseIngestionService, onlyRepoSlugs,
@@ -2010,6 +2013,36 @@ class TenantRepoSyncService extends Base {
         // Folding them would make the two indistinguishable in the one number an operator reads.
         let partialProgressCount = 0;
         let abortedCount         = 0;
+        // A lease cause belongs to the SWEEP rather than to one repo. Once any active repo observes
+        // it, queued repos must not enter protected work; repos already holding a semaphore slot are
+        // the active cohort and finish normally so their resumable state can be committed together.
+        let leaseYielded       = false;
+        let leaseDeferredCount = 0;
+
+        /**
+         * @summary Records a due repo that never entered protected work because the active cohort
+         * yielded the outer lease. Shared by ordinary semaphore hand-off and an opt-in queue timeout
+         * that expires after the cause is known; neither path mutates the repo checkpoint/backoff.
+         * @param {Object} options
+         * @param {Object} options.repo Configured tenant repo.
+         * @param {String} options.repoLabel Stable tenant/repo label.
+         * @param {Object|null} options.priorState Persisted state before this sweep.
+         * @param {String} options.checkpointStatus Classified prior checkpoint.
+         * @returns {void}
+         */
+        const recordLeaseYieldDeferral = ({repo, repoLabel, priorState, checkpointStatus}) => {
+            leaseDeferredCount++;
+            writeLog?.('INFO', `[TenantRepoSync] ${repoLabel} deferred because the active cohort yielded the outer lease.`);
+            repoStates.push({
+                tenantId           : repo.tenantId,
+                repoSlug           : repo.repoSlug,
+                lastIngestedRev    : priorState?.lastIngestedRev ? priorState.lastIngestedRev.slice(0, 8) : null,
+                lastSyncAt         : priorState?.lastRunAttemptAt ? new Date(priorState.lastRunAttemptAt).toISOString() : null,
+                status             : 'lease-yield-deferred',
+                checkpointStatus,
+                consecutiveFailures: priorState?.consecutiveFailures ?? 0
+            })
+        };
 
         // Per-runTask concurrency gate caps simultaneous git/ingest work.
         // Fresh instance per call so live `concurrencyLimit` / `concurrencyGateTimeoutMs`
@@ -2206,6 +2239,17 @@ class TenantRepoSyncService extends Base {
             try {
                 await semaphore.acquire();
                 slotAcquired = true;
+
+                // Checked only AFTER admission to the semaphore queue. Every repo promise is created
+                // up front, so checking before `acquire()` would let the whole tail observe `false`
+                // before either active repo had a chance to publish the lease cause. The active repo
+                // latches the cause before its `finally` releases this slot, making this boundary a
+                // deterministic hand-off rather than a timing convention.
+                if (leaseYielded) {
+                    recordLeaseYieldDeferral({repo, repoLabel, priorState, checkpointStatus});
+                    return
+                }
+
                 // The actual attempt begins when capacity is admitted, not when the repo joined
                 // the FIFO. Otherwise a long legitimate wait is persisted as work time and can
                 // make a just-completed repo immediately due again.
@@ -2354,31 +2398,75 @@ class TenantRepoSyncService extends Base {
                     // roughly N × sliceBudgetMs, which is how waiters starve while every bound the
                     // holder can see reads satisfied.
                     //
-                    // Resolved to a CAUSE rather than a boolean because the two exits differ, and the
-                    // exits belong to a separate dependent change. Stopping tail admission, committing
-                    // the cohort and releasing the outer lease are deliberately absent here: this makes
-                    // the cause readable, and the sweep below still consumes only the boolean
-                    // projection. With a null voter that projection is the slice predicate's own
-                    // answer, byte for byte, which keeps every caller holding no outer lease unchanged.
+                    // Resolved to a CAUSE rather than a boolean because the two exits differ. The
+                    // resolver's boolean projection still drives the vector loop, while the retained
+                    // cause below decides whether this sweep rotates one repo or settles its active
+                    // cohort. With a null outer voter, the projection remains exactly the slice
+                    // predicate's answer and callers holding no outer lease stay unchanged.
                     yieldCause = createYieldCauseResolver([
                         leaseYieldVoter,
                         {cause: YIELD_CAUSE_SLICE, vote: createSliceBudgetPredicate({startedMs, sliceBudgetMs})}
-                    ]),
-                    rawSummary = retryReceipt
-                        ? {
-                            ingested              : 0,
-                            deleted               : 0,
-                            errors                : [],
-                            materializationReceipt: retryReceipt
-                        }
-                        : await ingestSourceFilesForTenantSync({
-                            ...envelope,
-                            ...(materializationAttempt ? {materializationAttempt} : {}),
-                            viaMcp: false // operator-bulk path
-                        }, {
-                            ...providerCircuitControls,
-                            shouldYield: () => yieldCause() !== null
-                        });
+                    ]);
+
+                // Preserve the strongest cause seen anywhere below this boundary. A downstream
+                // provider may consult the voter several times, and a later slice reading must not
+                // overwrite an earlier lease reading — the outer bound has precedence by contract.
+                let   observedYieldCause = null;
+                const resolveYieldCause  = () => {
+                    const cause = yieldCause();
+
+                    if (cause === YIELD_CAUSE_LEASE) {
+                        observedYieldCause = cause;
+                        // Publish at the exact observation, not after this repo's ingestion call
+                        // returns. An active sibling can finish and release its semaphore slot while
+                        // this repo is still unwinding; the queued tail must see the latch before that
+                        // hand-off or one repo slips past an already-observed outer bound.
+                        leaseYielded = true;
+                    } else if (cause !== null && observedYieldCause === null) {
+                        observedYieldCause = cause;
+                    }
+
+                    return cause
+                };
+
+                const rawSummary = retryReceipt
+                    ? {
+                        ingested              : 0,
+                        deleted               : 0,
+                        errors                : [],
+                        materializationReceipt: retryReceipt
+                    }
+                    : await ingestSourceFilesForTenantSync({
+                        ...envelope,
+                        ...(materializationAttempt ? {materializationAttempt} : {}),
+                        viaMcp: false // operator-bulk path
+                    }, {
+                        ...providerCircuitControls,
+                        shouldYield: () => resolveYieldCause() !== null
+                    });
+
+                // A one-batch or receipt-only repo may never ask the vector loop for another batch.
+                // Re-consult at the repo boundary so an expired OUTER lease still ends this sweep.
+                // The call also gives a lease vote that crossed while the provider drained precedence
+                // over an earlier slice vote.
+                resolveYieldCause();
+
+                if (rawSummary?.yielded === true && observedYieldCause === null) {
+                    // Fail this repo loudly while preserving per-repo isolation. The safe ambiguity
+                    // policy is to keep sweeping and refuse the OUTER exit; treating an unattributed
+                    // yield as `lease` would stand the holder down on a cause no acquisition supplied.
+                    throw new TenantRepoSyncError(
+                        KB_TENANT_REPO_SYNC_SYNC_FAILED,
+                        `Tenant-repo-sync received an unattributed yield from ${repoLabel}; continuing the sweep without returning an outer lease-yield outcome.`,
+                        {phase: 'yield-cause', repoLabel}
+                    )
+                }
+
+                if (observedYieldCause === YIELD_CAUSE_LEASE) {
+                    // Set before any outcome branch can return. `finally` releases the semaphore slot,
+                    // and the next queued repo reads this latch immediately after acquiring it.
+                    leaseYielded = true;
+                }
 
                 // Emitted before BOTH guards on this path, which is what makes it useful:
                 // `classifyIngestionOutcome` throws on a rejected error-bearing summary, and
@@ -2734,6 +2822,19 @@ class TenantRepoSyncService extends Base {
                     checkpointStatus: TenantRepoCheckpointStatus.COMPLETE
                 });
             } catch (e) {
+                // An opt-in queue timeout is ordinarily a repo failure. Once the active cohort has
+                // already observed the OUTER lease cause, however, this repo is exactly the tail the
+                // sweep must leave untouched. It timed out before slot hand-off rather than reading
+                // the latch after hand-off; both paths have the same lease-yield-deferred outcome.
+                if (
+                    !slotAcquired
+                    && leaseYielded
+                    && e.code === KB_TENANT_REPO_SYNC_CONCURRENCY_GATE_TIMEOUT
+                ) {
+                    recordLeaseYieldDeferral({repo, repoLabel, priorState, checkpointStatus});
+                    return
+                }
+
                 // Lease loss is a RUN-level abort, not a repo failure: leave the
                 // repo's checkpoint, attempt timestamp, and backoff state untouched
                 // (the successor owns forward progress now), record an 'aborted'
@@ -2899,7 +3000,10 @@ class TenantRepoSyncService extends Base {
         }
 
         await leaseGuard();
-        await this.writePersistedRevisions({filePath: resolvedRevisionsPath, revisions: persistedRevisions});
+        await this.writePersistedRevisions({
+            filePath : resolvedRevisionsPath,
+            revisions: persistedRevisions
+        });
 
         // Status logic: not-due repos don't change the success/failure tally — a cycle
         // where ALL repos were not-due is still 'completed' (the cycle ran successfully;
@@ -2927,13 +3031,25 @@ class TenantRepoSyncService extends Base {
         // A mixed sweep stays `completed` deliberately — real repos did advance, and the deferred
         // ones are reported per-repo. `deferred` routes to `markSkipped` through the existing
         // consumer branch, so `lastSuccessAt` does not advance on a cycle that ingested nothing.
-        const status = detection.starved
+        const ordinaryStatus = detection.starved
             ? 'starved'
             : (completedCount === 0 && failedCount === 0 && deferredCount > 0
                 ? 'deferred'
                 : (attemptedCount === 0
                     ? 'completed' // all repos were not-due; cycle ran cleanly
                     : (failedCount === 0 ? 'completed' : (completedCount > 0 ? 'completed' : 'failed'))));
+        // Error-bearing outcomes retain their stronger status. On a CLEAN active cohort, `yielded`
+        // is reserved for an observed lease cause that leaves actual work behind: a partial repo or
+        // a queued tail. Merely observing the bound after the final one-batch repo completed is still
+        // an ordinary completed sweep — there is nothing to resume and the wrapper releases on
+        // natural settlement. The sweep never receives nor invokes a release callback itself.
+        const cleanLeaseYieldWithRemainder = leaseYielded
+            && failedCount === 0
+            && deferredCount === 0
+            && (partialProgressCount > 0 || leaseDeferredCount > 0);
+        const status = leaseYielded && failedCount > 0
+            ? 'failed'
+            : (cleanLeaseYieldWithRemainder ? 'yielded' : ordinaryStatus);
 
         // Record-with-diagnosis: exactly one durable heal-ledger record per starved
         // episode (the detector's marker flows through the lane's completion metadata), once
@@ -2958,7 +3074,7 @@ class TenantRepoSyncService extends Base {
             });
         }
 
-        writeLog?.('INFO', `[TenantRepoSync] Cycle summary: ${repos.length} repos, ${completedCount} completed, ${deferredCount} deferred, ${failedCount} failed, ${notDueCount} not-due, ${revalidationDeferredCount} revalidation-deferred${detection.starved ? ` — STARVED (oldest suppression ${detection.evidence.oldestSuppressedAt})` : ''}.`);
+        writeLog?.('INFO', `[TenantRepoSync] Cycle summary: ${repos.length} repos, ${completedCount} completed, ${deferredCount} deferred, ${failedCount} failed, ${partialProgressCount} partial-progress, ${notDueCount} not-due, ${revalidationDeferredCount} revalidation-deferred, ${leaseDeferredCount} lease-yield-deferred${status === 'yielded' ? ' — OUTER LEASE YIELDED' : (leaseYielded ? ' — OUTER LEASE BOUND OBSERVED' : '')}${detection.starved ? ` — STARVED (oldest suppression ${detection.evidence.oldestSuppressedAt})` : ''}.`);
 
         return {
             status,
@@ -2975,6 +3091,8 @@ class TenantRepoSyncService extends Base {
                 partialProgressCount,
                 notDueCount,
                 revalidationDeferredCount,
+                leaseYielded,
+                leaseDeferredCount,
                 ...(detection.starved ? {starved: true, starvedEvidence: detection.evidence} : {}),
                 starvedEventAt: detection.starvedEventAt,
                 repos         : repoStates
@@ -3285,7 +3403,8 @@ class TenantRepoSyncService extends Base {
      * @param {String} options.filePath
      * @param {Object<String, String>} options.revisions
      * @param {Object} [options.fsModule=fs] File-system implementation seam (fault-injection test seam).
-     * @returns {Promise<void>}
+     * @returns {Promise<Object>} Commit receipt with `committed`; `false` is reserved for a lost
+     *     optional ownership fence and carries a bounded `reason`.
      */
     async writePersistedRevisions({filePath, revisions, fsModule = fs, assertOwnership = null}) {
         const tmpPath = `${filePath}.tmp-${process.pid}`;

--- a/ai/scripts/maintenance/syncTenantRepos.mjs
+++ b/ai/scripts/maintenance/syncTenantRepos.mjs
@@ -13,8 +13,8 @@
  *   node ./ai/scripts/maintenance/syncTenantRepos.mjs --repo-slug a/b --repo-slug c/d  # multiple
  *   node ./ai/scripts/maintenance/syncTenantRepos.mjs --full --repo-slug <slug>  # scoped full replay
  *
- * Exit code: 0 on `completed`, 1 on `failed` or `skipped`
- * (no-tenant-repos-configured), 2 on argument error, 3 when a selected
+ * Exit code: 0 on `completed`; 1 on another non-completed task outcome (`yielded`,
+ * `deferred`, `starved`, `failed`, or `skipped`); 2 on argument error; 3 when a selected
  * repo slug is not configured, and 4 when another heavy-maintenance task or
  * tenant-repo-sync process holds either cross-process lease. The outer global
  * lease prevents overlap with Dream/REM and other heavy lanes; the existing inner
@@ -113,7 +113,8 @@ outage would otherwise suppress a lane that now works.
 
 Exit codes:
   0  completed (or partial-completed with at least one repo successful)
-  1  failed (all repos failed) or skipped (no configured tenantRepos)
+  1  non-completed task outcome: yielded (active cohort committed; rerun to resume),
+     deferred, starved, failed, or skipped (no configured tenantRepos)
   3  --repo-slug requested but the named repo is not configured (KB_TENANT_REPO_SYNC_REPO_NOT_CONFIGURED)
   4  another heavy task or tenant sync holds a required lease — retry after it finishes
   2  argument-parse error`);
@@ -277,7 +278,7 @@ async function main() {
  * pipelines branch on these codes, so changes here are contract changes.
  *
  * @param {Object} result `{status, details}` shape returned by `runTask`.
- * @returns {Number} 0 completed · 4 cross-process lease held · 3 requested repo not configured · 1 failed/skipped otherwise.
+ * @returns {Number} 0 completed · 4 cross-process lease held · 3 requested repo not configured · 1 any other task outcome.
  */
 function resolveExitCode(result) {
     if (result.status === 'completed') {

--- a/ai/services/knowledge-base/VectorService.mjs
+++ b/ai/services/knowledge-base/VectorService.mjs
@@ -1218,11 +1218,11 @@ class VectorService extends Base {
      * @param {Object}   options
      * @param {Object}   options.collection      Chroma collection target.
      * @param {Object[]} options.chunksToProcess Tenant-stamped chunks to embed.
-     * @param {Function} [options.shouldYield]   Cooperative heavy-maintenance-lease yield predicate,
+     * @param {Function} [options.shouldYield]   Cooperative work-yield predicate,
      *     consulted BETWEEN batches here AND between provider chunks inside `TextEmbeddingService.embedTexts`.
-     *     Returns truthy once the lease holder has exceeded the fairness bound
-     *     (`HeavyMaintenanceLeaseService.shouldYield`); the loop then stops so a starved heavy task can
-     *     interleave. Defaults to never-yield, so callers that do not hold the lease are unaffected.
+     *     The caller retains the cause: tenant-repo sync uses the same boolean projection for a
+     *     per-repo slice and the outer lease bound, then decides whether to rotate or end the sweep.
+     *     Defaults to never-yield, so callers with no cooperative bound are unaffected.
      *
      *     The inner consultation is what makes the bound reachable: this loop alone checks at most once per
      *     `maxRetries * ceil(batchSize / batchEmbeddingChunkSize) * (1 + unloadRetryCount) *
@@ -1353,20 +1353,26 @@ class VectorService extends Base {
         };
 
         while (cursor < chunksToProcess.length) {
-            // Cooperative heavy-maintenance-lease yield-point: BETWEEN batches (never before the
-            // first — so at least one batch lands per lease acquisition: a forward-progress guarantee, never a
-            // livelock), if the lease holder has exceeded the fairness bound, stop embedding so a starved heavy
-            // task (e.g. githubWorkflowSync) can interleave. The completed batches are already durably upserted
-            // into the shadow and indexed by the write-ahead resume marker, so the next sweep resumes here
-            // (decideResume -> selectResumableChunks). The caller releases the lease on the `yielded` signal.
-            if (cursor > 0 && shouldYield()) {
-                yielded = true;
-                logger.log(`Yielding the heavy-maintenance lease after ${cursor} chunk(s) (${embeddedCount} embedded); ${chunksToProcess.length - cursor} remaining will resume on the next sweep.`);
-                break;
+            // Cooperative work-yield checkpoint: BETWEEN batches (never before the first, so at
+            // least one batch lands per embedding invocation — a forward-progress guarantee, never
+            // a livelock). When the caller's bound fires, stop embedding. The completed batches are
+            // already durably upserted into the shadow and indexed by the write-ahead resume marker,
+            // so the next sweep resumes here
+            // (decideResume -> selectResumableChunks). The caller retains the cause separately: a
+            // slice yield rotates repos, while an outer-lease yield ends the sweep so its wrapper releases.
+            let yieldRequested = cursor > 0 && shouldYield();
+
+            if (!yieldRequested && cursor > 0 && batchDelay) {
+                await this.timeout(batchDelay);
+                // The fairness bound can be crossed while sleeping. Rechecking before slicing the
+                // next stride keeps the delay from purchasing one unbounded extra complete batch.
+                yieldRequested = shouldYield()
             }
 
-            if (cursor > 0 && batchDelay) {
-                await this.timeout(batchDelay);
+            if (yieldRequested) {
+                yielded = true;
+                logger.log(`Cooperative embedding yield after ${cursor} chunk(s) (${embeddedCount} embedded); ${chunksToProcess.length - cursor} remaining will resume on the next sweep.`);
+                break;
             }
 
             const stride        = chunksToProcess.slice(cursor, cursor + batchSize);
@@ -1596,7 +1602,7 @@ class VectorService extends Base {
 
                         await persistCarriedPrefix(carried, err.completedTextCount, 'Yielded');
 
-                        logger.log(`Yielding the heavy-maintenance lease inside batch ${batchNumber} after ${err.completedChunkCount}/${err.totalChunkCount} provider chunk(s); ${carried.length} partial embedding(s) persisted (${embeddedCount} embedded total). This batch is not retried; the next sweep resumes after the persisted prefix.`);
+                        logger.log(`Cooperative embedding yield inside batch ${batchNumber} after ${err.completedChunkCount}/${err.totalChunkCount} provider chunk(s); ${carried.length} partial embedding(s) persisted (${embeddedCount} embedded total). This batch is not retried; the next sweep resumes after the persisted prefix.`);
                         break;
                     }
 
@@ -2015,13 +2021,14 @@ class VectorService extends Base {
      * @param {Object}   options.liveCollection Existing canonical collection handle.
      * @param {Object[]} options.knowledgeBase   Full tenant-stamped corpus.
      * @param {Number}   options.idsToDeleteCount Logical stale-id count removed from the canonical view.
-     * @param {Function} [options.shouldYield]   Cooperative heavy-maintenance-lease yield predicate,
+     * @param {Function} [options.shouldYield]   Cooperative work-yield predicate,
      *     threaded to `embedChunks`. On a between-batch yield the shadow is preserved-not-promoted (the
-     *     write-ahead resume marker already indexes it) and a `{yielded: true}` envelope is returned so the
-     *     lease holder releases; the next sweep resumes from the preserved shadow.
+     *     write-ahead resume marker already indexes it) and a `{yielded: true}` envelope is returned. The
+     *     caller retains the cause and decides whether to rotate work or release its outer lease; the next
+     *     sweep resumes from the preserved shadow.
      * @param {AbortSignal} [options.signal] Shared tenant-sweep provider circuit signal.
      * @param {Function} [options.onProviderTimeout] Synchronous native-provider timeout hook.
-     * @returns {Promise<Object>} Embedding result (carries `yielded: true` when the lease was cooperatively released).
+     * @returns {Promise<Object>} Embedding result (carries `yielded: true` when work stopped at a cooperative boundary).
      */
     async embedViaShadowSwap({
         liveCollection,
@@ -2120,15 +2127,15 @@ class VectorService extends Base {
             });
 
             if (embedResult.yielded) {
-                // Cooperative lease-yield: the shadow holds the completed batches and the write-ahead
+                // Cooperative embedding yield: the shadow holds the completed batches and the write-ahead
                 // resume marker already indexes it, so DO NOT promote and DO NOT clear the marker — the next
                 // sweep resumes (decideResume -> selectResumableChunks). The live collection is untouched
                 // (preserved-not-promoted), so githubWorkflowSync can write resources/content/ freely while we
                 // are yielded; the resumed run re-reads the updated corpus. Torn-read-free by the same shadow
                 // isolation that protects a normal run.
-                logger.log(`Yielded the heavy-maintenance lease mid shadow-swap; preserving shadow '${shadowName}' for resume (${embedResult.embedded + alreadyEmbedded} embedded so far).`);
+                logger.log(`Yielded embedding work mid shadow-swap; preserving shadow '${shadowName}' for resume (${embedResult.embedded + alreadyEmbedded} embedded so far).`);
                 return {
-                    message         : `KB embedding yielded the heavy-maintenance lease after ${embedResult.embedded + alreadyEmbedded} chunk(s); the next sweep resumes from the preserved shadow.`,
+                    message         : `KB embedding yielded at a cooperative boundary after ${embedResult.embedded + alreadyEmbedded} chunk(s); the next sweep resumes from the preserved shadow.`,
                     embedded        : embedResult.embedded + alreadyEmbedded,
                     deleted         : idsToDeleteCount,
                     staleStrategy   : 'shadow-swap',
@@ -2353,11 +2360,11 @@ class VectorService extends Base {
      *                                             preserves the historical behavior;
      *                                             `shadow-swap` rebuilds into a fresh collection
      *                                             before promoting it to the canonical name.
-     * @param {Function} [opts.shouldYield]        Cooperative heavy-maintenance-lease yield predicate
-     *                                             threaded to the shadow-swap embed loop so a long
-     *                                             re-embed releases the lease at a batch boundary for a starved
-     *                                             heavy task, then resumes from the preserved shadow. Default
-     *                                             never yields, so non-lease-held callers are unaffected.
+     * @param {Function} [opts.shouldYield]        Cooperative work-yield predicate threaded to the
+     *                                             shadow-swap embed loop. The caller retains the cause
+     *                                             and decides whether the boundary rotates local work or
+     *                                             ends an outer lease-held sweep; resume uses the preserved
+     *                                             shadow. Defaults to never-yield.
      * @param {AbortSignal} [opts.signal]          Shared tenant-sweep provider circuit signal.
      * @param {Function} [opts.onProviderTimeout]  Synchronous native-provider timeout hook.
      * @param {Boolean} [opts.replayEmbeddingPoison=false] Explicit operator replay clears the

--- a/learn/agentos/cloud-deployment/TenantIngestionModel.md
+++ b/learn/agentos/cloud-deployment/TenantIngestionModel.md
@@ -367,7 +367,7 @@ Per-repo freshness is surfaced through the existing Memory Core healthcheck orch
 }
 ```
 
-The operator readiness endpoint reads this shape from `HealthService` — there is no need to read Chroma rows for freshness checks. `leaseYielded: true` means the outer hold bound was observed. When work remains, each suppressed row is reported as `lease-yield-deferred`, `leaseDeferredCount` carries the total, and the task outcome is `yielded`; if the final active repo had already exhausted the corpus and no tail remained, the outcome stays `completed`. `partialProgressCount` remains distinct because a slice-caused rotation continues the same sweep and does not return the outer lease. Empty `tenantRepos[]` produces `repos: []`, not an omission.
+The operator readiness endpoint reads this shape from `HealthService` — there is no need to read Chroma rows for freshness checks. `leaseYielded: true` means the outer hold bound was observed. When a clean cohort leaves work behind, each suppressed row is reported as `lease-yield-deferred`, `leaseDeferredCount` carries the total, and the task outcome is `yielded`. An ordinary failure or deferral retains its stronger `failed` / `deferred` status; if the final active repo had already exhausted the corpus and no tail remained, the outcome stays `completed`. `partialProgressCount` remains distinct because a slice-caused rotation continues the same sweep and does not return the outer lease. Empty `tenantRepos[]` produces `repos: []`, not an omission.
 
 For authenticated remote MCP diagnostics, the deployment-state bridge also projects a redacted
 `tenantRepoSync` section into `inspect_deployment` / `get_deployment_state_snapshot`. Use that

--- a/learn/agentos/cloud-deployment/TenantIngestionModel.md
+++ b/learn/agentos/cloud-deployment/TenantIngestionModel.md
@@ -256,7 +256,7 @@ returns an error-free ingestion summary. Current releases automatically revalida
 checkpoints through the periodic lane; use `--full` only to accelerate or explicitly repeat one
 selected repo after correcting its underlying failure. Do not delete the revisions file.
 
-Exit code: `0` on `completed`, `1` on `failed` or `skipped` (no-tenant-repos-configured), `2` on argument error, `3` when a requested repo slug is not configured, and `4` when either the deployment-wide heavy-maintenance lease or the narrower tenant-repo-sync lease is held. A global deferral writes `Deferred: heavy-maintenance lease held by <owner>` to stderr; a same-lane deferral returns `KB_TENANT_REPO_SYNC_LEASE_HELD`, so the diagnostic — not the shared exit code — identifies the holder class. Global holders such as Dream/REM or backup can legitimately be long-lived (up to the configured heavy-maintenance stale bound; six hours by default), so wait for the named task rather than retrying on the shorter tenant-sync cadence. The CLI uses an in-memory `TaskStateService` stand-in so it works without an orchestrator-daemon state-dir; both leases, not task state, provide cross-process serialization — a held lease is a bounded busy exit, never a silent race.
+Exit code: `0` on `completed`; `1` on another non-completed task outcome (`yielded`, `deferred`, `starved`, `failed`, or `skipped`); `2` on argument error; `3` when a requested repo slug is not configured; and `4` when either the deployment-wide heavy-maintenance lease or the narrower tenant-repo-sync lease is held. `yielded` is healthy but intentionally incomplete: the active cohort's resumable state was committed, the outer lease was returned so another heavy task can interleave, and rerunning resumes the remaining repos. A global deferral writes `Deferred: heavy-maintenance lease held by <owner>` to stderr; a same-lane deferral returns `KB_TENANT_REPO_SYNC_LEASE_HELD`, so the diagnostic — not the shared exit code — identifies the holder class. Global holders such as Dream/REM or backup can legitimately be long-lived (up to the configured heavy-maintenance stale bound; six hours by default), so wait for the named task rather than retrying on the shorter tenant-sync cadence. The CLI uses an in-memory `TaskStateService` stand-in so it works without an orchestrator-daemon state-dir; both leases, not task state, provide cross-process serialization — a held lease is a bounded busy exit, never a silent race.
 
 ### Mirror Volume
 
@@ -344,16 +344,20 @@ Per-repo freshness is surfaced through the existing Memory Core healthcheck orch
 {
     reason                       : 'periodic-sweep:60000' | 'manual' | 'no-tenant-repos-configured',
     repoCount                    : 3,
-    completedCount               : 3,
+    completedCount               : 1,
+    deferredCount                : 0,
+    partialProgressCount         : 1,
     failedCount                  : 0,
-    revalidationDeferredCount     : 0,
+    revalidationDeferredCount    : 0,
+    leaseYielded                 : true,
+    leaseDeferredCount           : 1,
     repos: [
         {
             tenantId             : 'neomjs',
             repoSlug             : 'neomjs/create-app',
             lastIngestedRev      : 'a1b2c3d4',    // short SHA from the most recent successful ingest
             lastSyncAt           : '2026-05-25T05:30:00.000Z',
-            status               : 'active',      // also degraded, revalidation-deferred, quarantined, or disabled
+            status               : 'active',      // also partial-progress, lease-yield-deferred, degraded, or another bounded lane state
             checkpointStatus     : 'complete',    // 'pending' | 'failed' | 'complete' | 'uninitialized' | 'unsupported'
             lastSyncDeletedCount : 0,
             lastErrorCode        : null,          // present only when status !== 'active'
@@ -363,7 +367,7 @@ Per-repo freshness is surfaced through the existing Memory Core healthcheck orch
 }
 ```
 
-The operator readiness endpoint reads this shape from `HealthService` — there is no need to read Chroma rows for freshness checks. Empty `tenantRepos[]` produces `repos: []`, not an omission.
+The operator readiness endpoint reads this shape from `HealthService` — there is no need to read Chroma rows for freshness checks. `leaseYielded: true` means the outer hold bound was observed. When work remains, each suppressed row is reported as `lease-yield-deferred`, `leaseDeferredCount` carries the total, and the task outcome is `yielded`; if the final active repo had already exhausted the corpus and no tail remained, the outcome stays `completed`. `partialProgressCount` remains distinct because a slice-caused rotation continues the same sweep and does not return the outer lease. Empty `tenantRepos[]` produces `repos: []`, not an omission.
 
 For authenticated remote MCP diagnostics, the deployment-state bridge also projects a redacted
 `tenantRepoSync` section into `inspect_deployment` / `get_deployment_state_snapshot`. Use that
@@ -392,6 +396,8 @@ usernames, fingerprints, Git output, and stacks never enter the snapshot.
 | Status | Meaning | Transition |
 |---|---|---|
 | `active` | Last cycle succeeded; lane is on its normal cadence | Successful sync from any non-`disabled` status |
+| `partial-progress` | A clean repo slice committed durable vector progress but retained its head checkpoint because work remains | Slice budget fired; the next repo is admitted in the same sweep |
+| `lease-yield-deferred` | Repo was due but remained queued after an active repo observed the outer lease bound | Next sweep after the wrapper releases and later reacquires the outer lease |
 | `degraded` | Last cycle failed but retry budget remains; lane will retry on next tick | First non-success after `active` |
 | `quarantined` | Consecutive failures exceeded the backoff threshold; operator action needed | Implementation tracked in [#11942](https://github.com/neomjs/neo/issues/11942) (per-repo backoff state). Until that lands, repeated failure surfaces as `degraded` with the same operator-runbook guidance |
 | `disabled` | Operator explicitly disabled the repo in `tenantRepos[]` config | Config flag; not a runtime transition |
@@ -449,7 +455,7 @@ Each `runTask` cycle emits per-repo log lines in this shape:
 [TenantRepoSync] Refreshing neomjs/create-app.
 [TenantRepoSync] neomjs/create-app completed: head=a1b2c3d4 ingested=12 deleted=1 (842ms)
 [TenantRepoSync] neomjs/create-app failed: KB_TENANT_REPO_SYNC_SYNC_FAILED (auth failed) [redacted]
-[TenantRepoSync] Cycle summary: 3 repos, 2 completed, 1 failed.
+[TenantRepoSync] Cycle summary: 3 repos, 1 completed, 0 deferred, 0 failed, 1 partial-progress, 0 not-due, 0 revalidation-deferred, 1 lease-yield-deferred — OUTER LEASE YIELDED.
 ```
 
 All credential material and raw git stderr passes through `redactTenantRepoSecrets()` before logging. The deployment log MUST NOT carry `https://user:token@...` URLs, resolved secrets, or stderr that includes the secret material.

--- a/test/playwright/unit/ai/daemons/orchestrator/services/MaintenanceBackpressureService.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/services/MaintenanceBackpressureService.spec.mjs
@@ -795,6 +795,35 @@ test.describe('Neo.ai.daemons.orchestrator.services.MaintenanceBackpressureServi
         expect(activeHeavyTask.name).toBe('kbSync');
     });
 
+    test('#17414 a yielded tenant-repo sweep releases the scheduler-owned outer lease exactly once', async () => {
+        const releases = [];
+        let   settleSweep;
+        const sweep   = new Promise(resolve => { settleSweep = resolve });
+        const service = buildService({
+            taskStateService: buildTaskStateService({}),
+            acquireLeaseFn  : () => ({acquired: true, lease: {token: 'tok-yield'}}),
+            releaseLeaseFn  : opts => releases.push(opts.token)
+        });
+
+        const result = service.acquireLeaseAndExecute({
+            taskName       : 'tenant-repo-sync',
+            executeFn      : () => sweep,
+            reason         : 'periodic-sweep:60000',
+            activeHeavyTask: {name: null}
+        });
+
+        expect(releases, 'the wrapper must retain ownership while the active cohort is unsettled').toEqual([]);
+
+        settleSweep({status: 'yielded'});
+        await expect(result).resolves.toEqual({status: 'yielded'});
+        expect(releases).toEqual(['tok-yield']);
+
+        // A second microtask turn catches a release wired both to the promise and to an imagined
+        // sweep callback. The outer wrapper is the only owner and must discharge exactly once.
+        await Promise.resolve();
+        expect(releases).toEqual(['tok-yield']);
+    });
+
     test('acquireLeaseAndExecute releases on async settle (reject) without swallowing rejection', async () => {
         const releases = [];
         const service  = buildService({

--- a/test/playwright/unit/ai/daemons/orchestrator/services/TenantRepoSyncService.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/services/TenantRepoSyncService.spec.mjs
@@ -144,10 +144,10 @@ test.describe('TenantRepoSyncService (#11790)', () => {
                     materializationReceipt: materializationReceipts.get(`${tenantId}/${repoSlug}`) || null
                 }
             },
-            async ingestSourceFiles(payload) {
+            async ingestSourceFiles(payload, controls) {
                 captureCalls.push({op: 'ingestSourceFiles', payload});
 
-                const summary = summaryFactory ? await summaryFactory(payload) : {
+                const summary = summaryFactory ? await summaryFactory(payload, controls) : {
                     ingested           : payload.files?.length || 0,
                     deleted            : payload.deleted?.length || 0,
                     embeddingsGenerated: 0,
@@ -4581,7 +4581,7 @@ test.describe('TenantRepoSyncService (#11790)', () => {
         }
     });
 
-    test('runTask propagates TenantRepoSyncError code + meta through outer details when syncTenantRepos throws', async () => {
+    test('#17414 a lease-yield outcome is refused when the active-cohort manifest commit fails', async () => {
         const taskStateService = createInMemoryTaskStateService();
         const logLines         = [];
         await provisionMirrorDir({tenantId: 't1', repoSlug: 'org/repo-a'});
@@ -4593,6 +4593,13 @@ test.describe('TenantRepoSyncService (#11790)', () => {
         const directoryAsTarget = path.join(manifestDir, 'revisions.json');
         await fs.ensureDir(`${directoryAsTarget}.tmp-${process.pid}`);
 
+        const ingestionService = makeFakeIngestionService();
+        ingestionService.ingestSourceFiles = async (payload, controls) => ({
+            ingested: 1, deleted: 0, embeddingsGenerated: 1, errors: [],
+            tenantId: payload.tenantId,
+            yielded : controls.shouldYield()
+        });
+
         const result = await TenantRepoSyncService.runTask({
             reason           : 'periodic-sweep:60000',
             taskStateService,
@@ -4602,14 +4609,18 @@ test.describe('TenantRepoSyncService (#11790)', () => {
             ]},
             gitMirror                    : makeFakeGitMirror(),
             envelopeBuilder              : makeFakeEnvelopeBuilder(),
-            knowledgeBaseIngestionService: makeFakeIngestionService(),
-            revisionsFilePath            : directoryAsTarget
+            knowledgeBaseIngestionService: ingestionService,
+            revisionsFilePath            : directoryAsTarget,
+            seedBootstrap                : false,
+            leaseYieldVoter              : {cause: YIELD_CAUSE_LEASE, vote: () => true}
         });
 
         expect(result.status).toBe('failed');
+        expect(result.status).not.toBe('yielded');
         expect(result.details.reasonCode).toBe('KB_TENANT_REPO_SYNC_MANIFEST_UPDATE_FAILED');
         expect(result.details.meta?.phase).toBe('manifest-update');
         expect(result.details.meta?.filePath).toContain('revisions.json');
+        expect(await fs.pathExists(directoryAsTarget), 'the failed commit must not publish a checkpoint').toBe(false);
         const errLine = logLines.find(l => l.level === 'ERROR' && l.msg.includes('KB_TENANT_REPO_SYNC_MANIFEST_UPDATE_FAILED'));
         expect(errLine).toBeDefined();
     });
@@ -7131,9 +7142,10 @@ test.describe('TenantRepoSyncService (#11790)', () => {
             }
         });
 
-        await TenantRepoSyncService.runTask({
-            reason           : 'periodic-sweep:60000',
+        await TenantRepoSyncService.syncTenantRepos({
             taskStateService,
+            taskName         : 'tenant-repo-sync',
+            leaseGuard       : async () => {},
             tenantReposConfig: {tenantRepos: [
                 {tenantId: 't1', repoSlug: 'org/rotating', mirrorRoot, cloneUrl: 'https://github.com/neomjs/rotating.git'},
                 {tenantId: 't1', repoSlug: 'org/failing',  mirrorRoot, cloneUrl: 'https://github.com/neomjs/failing.git'}
@@ -7141,23 +7153,32 @@ test.describe('TenantRepoSyncService (#11790)', () => {
             gitMirror                    : makeFakeGitMirror(),
             envelopeBuilder              : makeFakeEnvelopeBuilder(),
             knowledgeBaseIngestionService: makeFakeIngestionService({
-                summaryFactory: payload => ({
-                    ingested           : 5916,
-                    deleted            : 0,
-                    embeddingsGenerated: 55,
+                async summaryFactory(payload, controls) {
+                    const rotating = payload.repoSlug === 'org/rotating';
+
+                    if (rotating) {
+                        await new Promise(resolve => setTimeout(resolve, 5))
+                    }
+
+                    return {
+                        ingested           : 5916,
+                        deleted            : 0,
+                        embeddingsGenerated: 55,
                     // The discriminator is NOT an error count on a partial slice — an error-bearing
                     // summary is classified as a failure before the `yielded` check is ever reached,
                     // so `partial-progress` is a clean run by construction. The two arms below are
                     // therefore different OUTCOMES, not two flavours of one.
-                    errors             : payload.repoSlug === 'org/failing'
-                        ? [{code: 'KB_VECTOR_EMBED_INPUT_TRUNCATED', message: 'oversized chunk'}]
-                        : [],
-                    yielded   : payload.repoSlug === 'org/rotating',
-                    tenantId  : payload.tenantId,
-                    durationMs: 1
-                })
+                        errors: payload.repoSlug === 'org/failing'
+                            ? [{code: 'KB_VECTOR_EMBED_INPUT_TRUNCATED', message: 'oversized chunk'}]
+                            : [],
+                        yielded   : rotating ? controls.shouldYield() : false,
+                        tenantId  : payload.tenantId,
+                        durationMs: 1
+                    }
+                }
             }),
             revisionsFilePath: revisionsFile,
+            sliceBudgetMs    : 1,
             seedBootstrap    : false
         });
 
@@ -7188,17 +7209,19 @@ test.describe('TenantRepoSyncService (#11790)', () => {
         ).toBe('sha-rotating');
     });
 
-    test('a yielded head repo rotates its slot and the tail is admitted in the SAME sweep, with zero failure accounting (#17132 AC2/AC6)', async () => {
+    test('a slice-caused yield rotates its slot and admits the tail without ending the sweep (#17132 AC2/AC6, #17414)', async () => {
         const
             captureCalls = [],
             repos        = ['org/alpha', 'org/beta', 'org/gamma', 'org/delta'].map(repoSlug => ({
                 tenantId: 't1', repoSlug, mirrorRoot,
                 cloneUrl: `https://github.com/neomjs/${repoSlug.split('/')[1]}.git`
             }));
+        let signalSliceObserved;
+        const sliceObserved = new Promise(resolve => { signalSliceObserved = resolve });
 
         TenantRepoSyncService.concurrencyLimit = 2;
 
-        await TenantRepoSyncService.syncTenantRepos({
+        const sliceResult = await TenantRepoSyncService.syncTenantRepos({
             taskStateService             : createInMemoryTaskStateService(),
             revisionsFilePath            : revisionsFile,
             leaseGuard                   : async () => {},
@@ -7210,18 +7233,36 @@ test.describe('TenantRepoSyncService (#11790)', () => {
                 // Only the head repo outruns its budget. The others exhaust their corpus normally,
                 // which is what makes the sweep a MIXED one rather than a uniformly-yielding
                 // fixture that could pass without the rotation working.
-                summaryFactory: payload => ({
-                    ingested           : 1,
-                    deleted            : 0,
-                    embeddingsGenerated: 1,
-                    errors             : [],
-                    yielded            : payload.repoSlug === 'org/alpha',
-                    tenantId           : payload.tenantId,
-                    durationMs         : 1
-                })
+                async summaryFactory(payload, controls) {
+                    const head    = payload.repoSlug === 'org/alpha',
+                          sibling = payload.repoSlug === 'org/beta';
+                    let   yielded = false;
+
+                    if (head) {
+                        await new Promise(resolve => setTimeout(resolve, 5));
+                        yielded = controls.shouldYield();
+                        signalSliceObserved()
+                    } else if (sibling) {
+                        // Do not free a slot until the slice cause has actually been observed. If
+                        // the sweep wrongly latches every cause as `lease`, gamma/delta are still
+                        // queued at that instant and this arm turns red.
+                        await sliceObserved
+                    }
+
+                    return {
+                        ingested           : 1,
+                        deleted            : 0,
+                        embeddingsGenerated: 1,
+                        errors             : [],
+                        yielded,
+                        tenantId           : payload.tenantId,
+                        durationMs         : 1
+                    }
+                }
             }),
             globalCadenceMs: 0,
             jitterRatio    : 0,
+            sliceBudgetMs  : 1,
             seedBootstrap  : false
         });
 
@@ -7232,6 +7273,14 @@ test.describe('TenantRepoSyncService (#11790)', () => {
         // Tail admission: with K=2 and a yielding head, all four still reach ingestion this sweep.
         expect(ingested.length, 'every due repo must be admitted within the sweep').toBe(4);
         expect(new Set(ingested).size).toBe(4);
+        expect(sliceResult).toMatchObject({
+            status : 'completed',
+            details: {
+                partialProgressCount: 1,
+                leaseYielded        : false,
+                leaseDeferredCount  : 0
+            }
+        });
 
         const revisions = (await fs.readJson(revisionsFile)).revisions;
 
@@ -7345,37 +7394,34 @@ test.describe('TenantRepoSyncService (#11790)', () => {
         ).toBe(false);
     });
 
-    /*
-     * The production-path negative boundary, and it exists because its predecessor did not cross into
-     * production at all. That arm built a resolver and its boolean projection inside the fixture and
-     * asserted the projection was a Boolean — true of the fixture, and green no matter what the sweep
-     * did. A reviewer's falsifier found it: it could not fail if the sweep began stopping tail
-     * admission or releasing the outer lease early, which is precisely the behaviour it claimed to
-     * pin. Same wrong-subject class as an arm asserting a builder to prove something about a planner.
-     *
-     * **Three repos against a limit of TWO, and the third is the entire point.** A two-repo fixture
-     * at the production default limit of 2 has no tail at all: both repos ARE the active cohort, so
-     * the dependent exit — which stops admission after that cohort — could land, admit both, and
-     * leave the arm green. A reviewer's second falsifier caught exactly that, and the mutant the arm
-     * had claimed as faithful (`remainingRepos.slice(0, 1)`) drops half of the active cohort rather
-     * than the tail, so it was never the contract under test either. With a third due repo there is
-     * a repo BEYOND the cohort, and it is the one the exit will drop.
-     *
-     * Today's contract is that a lease-caused yield bounds work WITHIN a repo and touches neither
-     * admission nor the outer lease. So the arm pins three separable observables — the admitted SET
-     * includes the tail, the cohort ORDER still puts the tail last, and the sweep still reports
-     * `completed` rather than an early release — because the exit contract could arrive correct on
-     * one and wrong on another, and a single conflated assertion could not tell which.
-     */
-    test('#17398 a firing lease cause does NOT stop tail admission — the exit contract is not started here', async () => {
-        // Two fill the active cohort at the default limit; the third is the tail the dependent exit
-        // will stop. Names carry that role so a failure message reads as a contract violation rather
-        // than as an opaque slug mismatch.
-        const repoSlugs    = ['org/lease-cohort-a', 'org/lease-cohort-b', 'org/lease-tail'],
-              captureCalls = [],
-              // Fires on the very first consultation, so if any admission decision consulted the
-              // cause, it would have every opportunity to drop the tail.
-              alwaysYields = {cause: YIELD_CAUSE_LEASE, vote: () => true};
+    test('#17414 a lease cause settles the active cohort, commits it, and suppresses only the tail', async () => {
+        const
+            repoSlugs        = ['org/lease-observer', 'org/active-sibling', 'org/lease-tail'],
+            captureCalls     = [],
+            taskStateService = createInMemoryTaskStateService(),
+            seededRevisions  = Object.fromEntries(repoSlugs.map(repoSlug => [`t1/${repoSlug}`, {
+                lastIngestedRev                   : null,
+                lastRunAttemptAt                  : Date.now() - 120_000,
+                consecutiveFailures               : 0,
+                ingestContractVersion             : TENANT_REPO_INGEST_CONTRACT_VERSION,
+                lastAttemptedIngestContractVersion: TENANT_REPO_INGEST_CONTRACT_VERSION
+            }]));
+
+        let voteCalls = 0,
+            releaseObserver,
+            signalLeaseObserved,
+            signalSiblingReturned,
+            signalTailEntered,
+            tailEntered = false;
+
+        const
+            observerRelease = new Promise(resolve => { releaseObserver = resolve }),
+            leaseObserved   = new Promise(resolve => { signalLeaseObserved = resolve }),
+            siblingReturned = new Promise(resolve => { signalSiblingReturned = resolve }),
+            tailStarted     = new Promise(resolve => { signalTailEntered = resolve }),
+            firstVoteOnly   = {cause: YIELD_CAUSE_LEASE, vote: () => ++voteCalls === 1};
+
+        TenantRepoSyncService.concurrencyLimit = 2;
 
         for (const repoSlug of repoSlugs) {
             await provisionMirrorDir({tenantId: 't1', repoSlug});
@@ -7383,14 +7429,206 @@ test.describe('TenantRepoSyncService (#11790)', () => {
 
         await TenantRepoSyncService.writePersistedRevisions({
             filePath : revisionsFile,
-            revisions: Object.fromEntries(repoSlugs.map(repoSlug => [`t1/${repoSlug}`, {
+            revisions: seededRevisions
+        });
+        const canonicalSeed = await TenantRepoSyncService.readPersistedRevisions({
+            filePath: revisionsFile,
+            strict  : true
+        });
+
+        const ingestionService = makeFakeIngestionService({captureCalls});
+
+        ingestionService.ingestSourceFiles = async (payload, controls) => {
+            captureCalls.push({op: 'ingestSourceFiles', payload});
+
+            if (payload.repoSlug === 'org/lease-observer') {
+                const yielded = controls.shouldYield();
+                signalLeaseObserved();
+                await observerRelease;
+
+                return {
+                    ingested: 1, deleted: 0, embeddingsGenerated: 1, errors: [], yielded
+                }
+            }
+
+            if (payload.repoSlug === 'org/active-sibling') {
+                await leaseObserved;
+                return {
+                    ingested: 1, deleted: 0, embeddingsGenerated: 1, errors: [], yielded: false
+                }
+            }
+
+            tailEntered = true;
+            signalTailEntered();
+            return {
+                ingested: 1, deleted: 0, embeddingsGenerated: 1, errors: [], yielded: false
+            }
+        };
+
+        const run = TenantRepoSyncService.runTask({
+            reason       : 'periodic-sweep:60000',
+            taskStateService,
+            healthService: {
+                recordTaskOutcome(taskName, status, details) {
+                    if (status === 'completed' && details?.repo === 't1/org/active-sibling') {
+                        signalSiblingReturned()
+                    }
+                }
+            },
+            tenantReposConfig: {tenantRepos: repoSlugs.map(repoSlug => ({
+                tenantId: 't1', repoSlug, mirrorRoot,
+                cloneUrl: `https://github.com/neomjs/${repoSlug.split('/')[1]}.git`
+            }))},
+            gitMirror                    : makeFakeGitMirror(),
+            envelopeBuilder              : makeFakeEnvelopeBuilder(),
+            knowledgeBaseIngestionService: ingestionService,
+            revisionsFilePath            : revisionsFile,
+            globalCadenceMs              : 60_000,
+            jitterRatio                  : 0,
+            seedBootstrap                : false,
+            leaseYieldVoter              : firstVoteOnly
+        });
+
+        // The sibling returns while the repo that actually observed the lease cause is still held
+        // open. A repo-local latch lets the tail acquire the sibling's released slot here.
+        await siblingReturned;
+        const tailEnteredBeforeObserverSettled = await Promise.race([
+            tailStarted.then(() => true),
+            new Promise(resolve => setTimeout(() => resolve(false), 250))
+        ]);
+
+        releaseObserver();
+        const result = await run;
+
+        const ingested = captureCalls
+            .filter(call => call.op === 'ingestSourceFiles')
+            .map(call => call.payload.repoSlug);
+
+        expect(
+            TenantRepoSyncService.concurrencyLimit,
+            'the fixture needs a repo beyond the active cohort'
+        ).toBeLessThan(repoSlugs.length);
+
+        expect(tailEnteredBeforeObserverSettled, 'the shared latch must publish before any active sibling releases').toBe(false);
+        expect([...ingested].sort()).toEqual(repoSlugs.slice(0, 2).sort());
+        expect(ingested).not.toContain('org/lease-tail');
+        expect(result.status).toBe('yielded');
+        expect(result.details).toMatchObject({
+            completedCount      : 1,
+            partialProgressCount: 1,
+            leaseDeferredCount  : 1,
+            leaseYielded        : true
+        });
+        expect(result.details.repos.find(row => row.repoSlug === 'org/lease-tail'))
+            .toMatchObject({status: 'lease-yield-deferred'});
+        expect(taskStateService.getTaskState('tenant-repo-sync')).toMatchObject({
+            running       : false,
+            lastCompletion: {status: 'yielded', leaseYielded: true}
+        });
+        expect(taskStateService.getTaskState('tenant-repo-sync').completedAt).toBeGreaterThan(0);
+        expect(taskStateService.getTaskState('tenant-repo-sync').skippedAt).toBeUndefined();
+
+        const persisted = (await fs.readJson(revisionsFile)).revisions;
+        expect(persisted['t1/org/lease-observer'].lastRunAttemptAt)
+            .toBeGreaterThan(seededRevisions['t1/org/lease-observer'].lastRunAttemptAt);
+        expect(persisted['t1/org/active-sibling'].lastRunAttemptAt)
+            .toBeGreaterThan(seededRevisions['t1/org/active-sibling'].lastRunAttemptAt);
+        expect(persisted['t1/org/lease-tail']).toEqual(canonicalSeed['t1/org/lease-tail']);
+    });
+
+    test('#17414 a queued tail timeout after lease observation remains a clean lease deferral', async () => {
+        const
+            repoSlugs       = ['org/timeout-observer', 'org/timeout-tail'],
+            captureCalls    = [],
+            seededRevisions = Object.fromEntries(repoSlugs.map(repoSlug => [`t1/${repoSlug}`, {
                 lastIngestedRev                   : null,
                 lastRunAttemptAt                  : Date.now() - 120_000,
                 consecutiveFailures               : 0,
                 ingestContractVersion             : TENANT_REPO_INGEST_CONTRACT_VERSION,
                 lastAttemptedIngestContractVersion: TENANT_REPO_INGEST_CONTRACT_VERSION
-            }]))
+            }]));
+
+        TenantRepoSyncService.concurrencyLimit         = 1;
+        TenantRepoSyncService.concurrencyGateTimeoutMs = 500;
+
+        for (const repoSlug of repoSlugs) {
+            await provisionMirrorDir({tenantId: 't1', repoSlug});
+        }
+
+        await TenantRepoSyncService.writePersistedRevisions({
+            filePath : revisionsFile,
+            revisions: seededRevisions
         });
+        const canonicalSeed = await TenantRepoSyncService.readPersistedRevisions({
+            filePath: revisionsFile,
+            strict  : true
+        });
+
+        const ingestionService = makeFakeIngestionService({captureCalls});
+        ingestionService.ingestSourceFiles = async (payload, controls) => {
+            captureCalls.push({op: 'ingestSourceFiles', payload});
+
+            if (payload.repoSlug === 'org/timeout-observer') {
+                const yielded = controls.shouldYield();
+                await new Promise(resolve => setTimeout(resolve, 650));
+                return {ingested: 1, deleted: 0, embeddingsGenerated: 1, errors: [], yielded}
+            }
+
+            return {ingested: 1, deleted: 0, embeddingsGenerated: 1, errors: [], yielded: false}
+        };
+
+        const result = await TenantRepoSyncService.syncTenantRepos({
+            taskName         : 'tenant-repo-sync',
+            taskStateService : createInMemoryTaskStateService(),
+            leaseGuard       : async () => {},
+            tenantReposConfig: {tenantRepos: repoSlugs.map(repoSlug => ({
+                tenantId: 't1', repoSlug, mirrorRoot,
+                cloneUrl: `https://github.com/neomjs/${repoSlug.split('/')[1]}.git`
+            }))},
+            gitMirror                    : makeFakeGitMirror(),
+            envelopeBuilder              : makeFakeEnvelopeBuilder(),
+            knowledgeBaseIngestionService: ingestionService,
+            revisionsFilePath            : revisionsFile,
+            globalCadenceMs              : 0,
+            jitterRatio                  : 0,
+            seedBootstrap                : false,
+            leaseYieldVoter              : {cause: YIELD_CAUSE_LEASE, vote: () => true}
+        });
+
+        expect(captureCalls.filter(call => call.op === 'ingestSourceFiles').map(call => call.payload.repoSlug))
+            .toEqual(['org/timeout-observer']);
+        expect(result).toMatchObject({
+            status : 'yielded',
+            details: {
+                failedCount         : 0,
+                partialProgressCount: 1,
+                leaseYielded        : true,
+                leaseDeferredCount  : 1
+            }
+        });
+        expect(result.details.repos.find(row => row.repoSlug === 'org/timeout-tail'))
+            .toMatchObject({status: 'lease-yield-deferred', consecutiveFailures: 0});
+
+        const persisted = (await fs.readJson(revisionsFile)).revisions;
+        expect(persisted['t1/org/timeout-tail']).toEqual(canonicalSeed['t1/org/timeout-tail']);
+    });
+
+    test('#17414 an unattributed yield fails loud for that repo while the tail keeps sweeping', async () => {
+        const repoSlugs    = ['org/unattributed-head', 'org/unattributed-peer', 'org/unattributed-tail'],
+              captureCalls = [];
+
+        for (const repoSlug of repoSlugs) {
+            await provisionMirrorDir({tenantId: 't1', repoSlug});
+        }
+
+        const service = makeFakeIngestionService({captureCalls});
+        service.ingestSourceFiles = async payload => {
+            captureCalls.push({op: 'ingestSourceFiles', payload});
+            return {
+                ingested: 1, deleted: 0, embeddingsGenerated: 1, errors: [],
+                yielded : payload.repoSlug === 'org/unattributed-head'
+            }
+        };
 
         const result = await TenantRepoSyncService.runTask({
             reason           : 'periodic-sweep:60000',
@@ -7401,63 +7639,59 @@ test.describe('TenantRepoSyncService (#11790)', () => {
             }))},
             gitMirror                    : makeFakeGitMirror(),
             envelopeBuilder              : makeFakeEnvelopeBuilder(),
-            knowledgeBaseIngestionService: makeFakeIngestionService({captureCalls}),
+            knowledgeBaseIngestionService: service,
             revisionsFilePath            : revisionsFile,
-            globalCadenceMs              : 60_000,
+            globalCadenceMs              : 0,
             jitterRatio                  : 0,
             seedBootstrap                : false,
-            leaseYieldVoter              : alwaysYields
+            leaseYieldVoter              : null
         });
 
-        const ingested = captureCalls
-            .filter(call => call.op === 'ingestSourceFiles')
-            .map(call => call.payload.repoSlug);
+        expect(captureCalls.filter(call => call.op === 'ingestSourceFiles').map(call => call.payload.repoSlug).sort())
+            .toEqual([...repoSlugs].sort());
+        // Mixed-cycle policy remains unchanged: the two clean repos keep the sweep-level status
+        // completed, while the unattributed repo is an explicit degraded row and failed count.
+        expect(result.status).toBe('completed');
+        expect(result.details).toMatchObject({
+            completedCount    : 2,
+            failedCount       : 1,
+            leaseYielded      : false,
+            leaseDeferredCount: 0
+        });
+        expect(result.details.repos.find(row => row.repoSlug === 'org/unattributed-head'))
+            .toMatchObject({status: 'degraded', lastErrorCode: 'KB_TENANT_REPO_SYNC_SYNC_FAILED'});
+    });
 
-        // Non-vacuity FIRST, and it is what makes the tail claim mean anything: the limit must be
-        // strictly below the repo count, or there is no repo outside the active cohort and every
-        // assertion below is true of a fixture that cannot pose the question.
-        expect(
-            TenantRepoSyncService.concurrencyLimit,
-            'the fixture needs a repo BEYOND the active cohort — at the default limit of 2 a two-repo ' +
-            'sweep has no tail, so the dependent exit could admit the whole cohort and pass'
-        ).toBeLessThan(repoSlugs.length);
+    test('#17414 a completed final one-batch repo observes the bound without inventing remaining work', async () => {
+        const repoSlug = 'org/one-batch-lease';
+        await provisionMirrorDir({tenantId: 't1', repoSlug});
 
-        // ADMISSION — asserted as the whole set rather than as containments, so the failure message
-        // distinguishes the two ways this breaks: a dropped tail shows the cohort alone, a sweep that
-        // admitted nothing shows an empty array. Containment checks would let the first mask the
-        // second, and the difference matters — one is the exit contract starting early, the other is
-        // a broken fixture.
-        expect(
-            [...ingested].sort(),
-            'a lease cause reached an ADMISSION decision — stopping the tail after the active cohort ' +
-            'is the dependent exit contract, and starting it here makes the two leaves impossible to ' +
-            'review independently. An EMPTY array instead means the fixture admitted nothing and the ' +
-            'arm never exercised admission at all'
-        ).toEqual([...repoSlugs].sort());
+        const result = await TenantRepoSyncService.runTask({
+            reason           : 'periodic-sweep:60000',
+            taskStateService : createInMemoryTaskStateService(),
+            tenantReposConfig: {tenantRepos: [{
+                tenantId: 't1', repoSlug, mirrorRoot,
+                cloneUrl: 'https://github.com/neomjs/one-batch-lease.git'
+            }]},
+            gitMirror                    : makeFakeGitMirror(),
+            envelopeBuilder              : makeFakeEnvelopeBuilder(),
+            knowledgeBaseIngestionService: makeFakeIngestionService(),
+            revisionsFilePath            : revisionsFile,
+            globalCadenceMs              : 0,
+            jitterRatio                  : 0,
+            seedBootstrap                : false,
+            leaseYieldVoter              : {cause: YIELD_CAUSE_LEASE, vote: () => true}
+        });
 
-        // ORDER — the tail must still be admitted LAST. A sweep that kept the tail but hoisted it
-        // into the first cohort would satisfy the set assertion while having changed the very
-        // boundary the dependent exit is defined against, so the set alone cannot carry this.
-        expect(
-            ingested.indexOf('org/lease-tail'),
-            'the tail must remain the tail: admitted, and admitted after the active cohort'
-        ).toBe(repoSlugs.length - 1);
-
-        // OUTER LEASE — a lease-caused yield is a bound on work inside a repo, not a signal to hand
-        // the lease back. A sweep that released early would report something other than a completed
-        // run, and the caller would drop a lease it still holds work for.
-        expect(
-            result.status,
-            'a lease-caused yield must not turn a healthy sweep into a failure or an early release; ' +
-            'the cause is readable and nothing acts on it yet'
-        ).toBe('completed');
-
-        // And the whole cohort completed rather than deferring — the count is what a future exit
-        // would have to reduce, so pinning it names the number the dependent leaf must change.
-        expect(
-            result.details.completedCount,
-            'all three repos completed; the dependent exit will reduce this, and that red is intended'
-        ).toBe(repoSlugs.length);
+        expect(result).toMatchObject({
+            status : 'completed',
+            details: {
+                completedCount      : 1,
+                partialProgressCount: 0,
+                leaseYielded        : true,
+                leaseDeferredCount  : 0
+            }
+        });
     });
 });
 
@@ -7998,6 +8232,9 @@ test.describe('syncTenantRepos container-plane CLI (#15748)', () => {
         expect(resolveExitCode({status: 'skipped', details: {reasonCode: 'KB_TENANT_REPO_SYNC_LEASE_HELD'}})).toBe(4);
         expect(resolveExitCode({status: 'failed', details: {reasonCode: 'KB_TENANT_REPO_SYNC_REPO_NOT_CONFIGURED'}})).toBe(3);
         expect(resolveExitCode({status: 'failed', details: {reasonCode: 'KB_TENANT_REPO_SYNC_SYNC_FAILED'}})).toBe(1);
+        expect(resolveExitCode({status: 'yielded', details: {leaseYielded: true}})).toBe(1);
+        expect(resolveExitCode({status: 'deferred', details: {deferredCount: 1}})).toBe(1);
+        expect(resolveExitCode({status: 'starved', details: {starved: true}})).toBe(1);
         expect(resolveExitCode({status: 'skipped', details: {reason: 'no-tenant-repos-configured'}})).toBe(1);
     });
 

--- a/test/playwright/unit/ai/daemons/orchestrator/services/TenantRepoSyncService.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/services/TenantRepoSyncService.spec.mjs
@@ -7613,6 +7613,101 @@ test.describe('TenantRepoSyncService (#11790)', () => {
         expect(persisted['t1/org/timeout-tail']).toEqual(canonicalSeed['t1/org/timeout-tail']);
     });
 
+    test('#17414 an ordinary deferral outranks a lease yield without reporting completed', async () => {
+        const
+            repoSlugs        = ['org/mixed-observer', 'org/mixed-complete', 'org/mixed-deferred', 'org/mixed-tail'],
+            captureCalls     = [],
+            taskStateService = createInMemoryTaskStateService(),
+            seededRevisions  = Object.fromEntries(repoSlugs.map(repoSlug => [`t1/${repoSlug}`, {
+                lastIngestedRev                   : null,
+                lastRunAttemptAt                  : Date.now() - 120_000,
+                consecutiveFailures               : 0,
+                ingestContractVersion             : TENANT_REPO_INGEST_CONTRACT_VERSION,
+                lastAttemptedIngestContractVersion: TENANT_REPO_INGEST_CONTRACT_VERSION
+            }]));
+
+        let activeEntered = 0,
+            releaseActive;
+        const activeReady = new Promise(resolve => { releaseActive = resolve });
+
+        TenantRepoSyncService.concurrencyLimit = 3;
+
+        for (const repoSlug of repoSlugs) {
+            await provisionMirrorDir({tenantId: 't1', repoSlug});
+        }
+
+        await TenantRepoSyncService.writePersistedRevisions({
+            filePath : revisionsFile,
+            revisions: seededRevisions
+        });
+
+        const ingestionService = makeFakeIngestionService({captureCalls});
+        ingestionService.ingestSourceFiles = async (payload, controls) => {
+            captureCalls.push({op: 'ingestSourceFiles', payload});
+
+            if (payload.repoSlug === 'org/mixed-tail') {
+                return {ingested: 1, deleted: 0, embeddingsGenerated: 1, errors: [], yielded: false}
+            }
+
+            activeEntered++;
+            if (activeEntered === 3) releaseActive();
+            await activeReady;
+
+            const yielded = controls.shouldYield();
+
+            if (payload.repoSlug === 'org/mixed-deferred') {
+                return {
+                    ingested: 1, deleted: 0, embeddingsGenerated: 0,
+                    errors  : [{code: 'KB_VECTOR_EMBED_FAILED'}], yielded
+                }
+            }
+
+            return {
+                ingested: 1, deleted: 0, embeddingsGenerated: 1, errors: [],
+                yielded : payload.repoSlug === 'org/mixed-observer' && yielded
+            }
+        };
+
+        const result = await TenantRepoSyncService.runTask({
+            reason           : 'periodic-sweep:60000',
+            taskStateService,
+            tenantReposConfig: {tenantRepos: repoSlugs.map(repoSlug => ({
+                tenantId: 't1', repoSlug, mirrorRoot,
+                cloneUrl: `https://github.com/neomjs/${repoSlug.split('/')[1]}.git`
+            }))},
+            gitMirror                    : makeFakeGitMirror(),
+            envelopeBuilder              : makeFakeEnvelopeBuilder(),
+            knowledgeBaseIngestionService: ingestionService,
+            revisionsFilePath            : revisionsFile,
+            globalCadenceMs              : 0,
+            jitterRatio                  : 0,
+            seedBootstrap                : false,
+            leaseYieldVoter              : {cause: YIELD_CAUSE_LEASE, vote: () => true}
+        });
+
+        expect(captureCalls.filter(call => call.op === 'ingestSourceFiles').map(call => call.payload.repoSlug).sort())
+            .toEqual(repoSlugs.slice(0, 3).sort());
+        expect(result).toMatchObject({
+            status : 'deferred',
+            details: {
+                completedCount      : 1,
+                deferredCount       : 1,
+                partialProgressCount: 1,
+                failedCount         : 0,
+                leaseYielded        : true,
+                leaseDeferredCount  : 1
+            }
+        });
+        expect(result.details.repos.find(row => row.repoSlug === 'org/mixed-tail'))
+            .toMatchObject({status: 'lease-yield-deferred'});
+        expect(taskStateService.getTaskState('tenant-repo-sync')).toMatchObject({
+            running       : false,
+            lastCompletion: {status: 'deferred', leaseYielded: true}
+        });
+        expect(taskStateService.getTaskState('tenant-repo-sync').skippedAt).toBeGreaterThan(0);
+        expect(taskStateService.getTaskState('tenant-repo-sync').completedAt).toBeUndefined();
+    });
+
     test('#17414 an unattributed yield fails loud for that repo while the tail keeps sweeping', async () => {
         const repoSlugs    = ['org/unattributed-head', 'org/unattributed-peer', 'org/unattributed-tail'],
               captureCalls = [];

--- a/test/playwright/unit/ai/services/knowledge-base/VectorService.leaseYield.spec.mjs
+++ b/test/playwright/unit/ai/services/knowledge-base/VectorService.leaseYield.spec.mjs
@@ -156,6 +156,36 @@ test.describe('VectorService.embedChunks — cooperative lease yield-point', () 
         expect(spy.calls.upsert).toBe(2);
     });
 
+    test('rechecks AFTER batchDelay before purchasing another complete batch (#17414)', async () => {
+        const spy             = createSpyCollection(),
+              chunks          = makeChunks(6),
+              originalTimeout = KB_VectorService.timeout;
+
+        Object.assign(KB_Config.data, {batchSize: 2, batchDelay: 50});
+
+        let delayCompleted = false;
+
+        // Deterministic delay seam: the first between-batch vote is false, the delay then moves the
+        // lease across its bound. A loop that votes only BEFORE waiting buys one extra full batch.
+        KB_VectorService.timeout = async () => {
+            delayCompleted = true
+        };
+
+        try {
+            const result = await KB_VectorService.embedChunks({
+                collection     : spy,
+                chunksToProcess: chunks,
+                shouldYield    : () => delayCompleted
+            });
+
+            expect(result.yielded).toBe(true);
+            expect(result.embedded, 'the delay completed before batch 2, so only batch 1 may land').toBe(2);
+            expect(spy.calls.upsert).toBe(1);
+        } finally {
+            KB_VectorService.timeout = originalTimeout
+        }
+    });
+
     test('default (no predicate) embeds every batch — unchanged behavior, never yields', async () => {
         const spy    = createSpyCollection();
         const chunks = makeChunks(150);


### PR DESCRIPTION
Resolves neomjs/neo#17414

Related: neomjs/neo-agent-brain#25

Refs neomjs/neo#17398

Tenant repository sync now consumes the cause-bearing yield verdict instead of flattening it back to a boolean. A lease cause is published to sweep-shared state at the exact observation, lets the already-active semaphore cohort settle, suppresses only queued tail repositories, commits the cohort's resumable manifest, and returns a truthful `yielded` outcome only when work remains. Slice causes still rotate through the same sweep, and the existing scheduler/CLI wrappers remain the sole outer-lease release owners.

Evidence: L2 (232 production-path, wrapper, voter-wiring, cause-precedence, and vector-loop unit tests plus syntax/diff and guide lint) → L3 required (AC7 deployed-plane waiter-drain and resume observation). Residual: AC7, Residual-Owner: neomjs/neo-agent-brain#25.

## Deltas from ticket

- The shared lease latch is written synchronously when the cause is observed, not after the observing repo returns. This closes the concurrent sibling-release race where one queued repo could otherwise enter after the bound fired.
- A configured semaphore timeout that expires after lease observation is classified through the same `lease-yield-deferred` path, leaving the queued repo's checkpoint and failure streak untouched.
- A terminal one-batch vote can stop a real queued tail, but a fully exhausted final cohort remains `completed`; merely observing the bound does not invent resumable work or a non-zero CLI result.
- When the active cohort also contains an ordinary deferral, that stronger `deferred` status outranks the lease yield. It preserves exit 1 plus `markSkipped` semantics instead of weakening the mixed sweep to `completed` or advancing `lastSuccessAt` through `yielded`.
- Vector-layer logs and JSDoc are cause-neutral. The cause-aware tenant-sync caller decides slice rotation versus outer handoff; embedding no longer claims every cooperative boundary releases a lease.
- The container CLI's complete existing non-completed status set is now documented and pinned while adding `yielded` (`yielded`, `deferred`, `starved`, `failed`, and `skipped` map to exit 1).

Decision Record impact: aligned with ADR 0022. This is cooperative holder stand-down only; no hard preemption and no lease-monitor wiring.

## Test Evidence

- `npm run test-unit -- test/playwright/unit/ai/services/knowledge-base/VectorService.leaseYield.spec.mjs test/playwright/unit/ai/daemons/orchestrator/scheduling/tenantRepoSync.sliceBudget.spec.mjs test/playwright/unit/ai/daemons/orchestrator/leaseYieldVoterWiring.spec.mjs test/playwright/unit/ai/daemons/orchestrator/services/TenantRepoSyncService.spec.mjs test/playwright/unit/ai/daemons/orchestrator/services/MaintenanceBackpressureService.spec.mjs` — 232 passed on rebased head `f760bcb43c`.
- `npm run ai:lint-guides` — 0 hard errors; 27 pre-existing repository warnings.
- `node --check` on all touched `.mjs` production/spec files plus `git diff --check` — passed.
- Tenant sweep exit: asymmetric active-cohort latch, supported queue-timeout, ordinary-deferral precedence, unattributed cause, slice control, terminal one-batch, checkpoint-failure, and task-state arms pass.
- Outer release ownership: the production scheduler wrapper retains the lease before settlement and releases exactly once after `{status: 'yielded'}`.
- Vector batch boundary: deleting the post-`batchDelay` recheck purchases an extra complete batch and turns the dedicated arm red.
- Cloud ingestion guide/CLI help: `ai:lint-guides` plus the `resolveExitCode` unit contract cover the edited reference surface.

## Post-Merge Validation

- [ ] On the deployed plane, observe a real `tenant-repo-sync` hold cross `maxActiveHoldMs`; verify the task reports `yielded`, the outer lease stops naming `tenant-repo-sync`, the watchdog's starved-waiter list decreases or drains, and the next acquisition resumes `lease-yield-deferred` repositories from committed state. Record the receipt on neomjs/neo-agent-brain#25.

Residual-Owner: neomjs/neo-agent-brain#25

## Substrate Slot Rationale

`TenantIngestionModel.md` is an ordinary operator/reference guide, not turn-loaded instruction substrate. It remains in its existing `keep` slot and was updated in place because runtime status, CLI exit behavior, and health telemetry changed together; no new loaded slot or generated artifact was added.

## Evolution

Prior art from session `090a68e6-1a28-4b20-a5fd-842ebac3e729` supplied the proven cooperative boundary: end the sweep, let the caller release, and resume from durable progress. Session `8cbd588b-be06-4a56-9997-1058f2a3a07b` supplied the trap: a boolean OR erased the cause and made the exit inexpressible. Implementation falsifiers then widened the ticket in three bounded ways: publish the latch before sibling release, protect timeout-before-handoff, and distinguish bound observation from an actually incomplete yielded outcome. Grace's exact-head mixed-cohort falsifier added the final reporting edge: an ordinary deferral must retain `deferred` rather than collapse a lease-observed incomplete sweep to `completed`.

Authored by Euclid (GPT-5.6 Sol, Codex Desktop) consuming Vega's handoff — session A fb387768-e68f-4a71-9b6a-3cf9ad4a9e7e, session B 343d05b2-e149-4c69-b824-7a64a1753826.
