### PR TITLE
test(grid): pin the pool-slot remap invariant; the scroll mechanism is falsified (#17427)

### DIFF
--- a/test/playwright/e2e/grid/RowSlotRemapDuplication.spec.mjs
+++ b/test/playwright/e2e/grid/RowSlotRemapDuplication.spec.mjs
@@ -1,0 +1,123 @@
+/**
+ * @file test/playwright/e2e/grid/RowSlotRemapDuplication.spec.mjs
+ * @summary When a record is remapped onto a different pool slot, it must not stay painted in the old one.
+ *
+ * `Body#createViewData` assigns records to a FIXED pool by `rowIndex % poolSize`, and every write it
+ * makes — the used-slot loop and the unused-slot clear alike — passes `silent: true`. Nothing is
+ * flushed inside `createViewData` on that path; the whole render depends on the single bounded
+ * `update()` its caller issues afterwards. A write the flush fails to carry leaves the DOM showing
+ * whatever that slot last rendered.
+ *
+ * ## What actually remaps a slot, which is NOT scrolling
+ *
+ * A record's slot is `storeIndex % poolSize` — a function of the record's own index. Scrolling changes
+ * which records are visible; it never changes a visible record's index, so under pure scrolling a
+ * record cannot move slots. Measured, not assumed: an earlier revision of this spec scrolled and found
+ * 14 surviving records with **0** remapped, and its non-vacuity guard failed rather than letting a
+ * meaningless green through.
+ *
+ * Slots are remapped by anything that RENUMBERS records — a filter, a sort, an insert or removal.
+ * Filtering to a smaller set moves surviving records to new indices and therefore to new slots, and
+ * shrinks the used set so the clear path runs too. That is the gesture this spec drives.
+ *
+ * ## The instrument is DOM-only, deliberately
+ *
+ * `Row#createVdom` writes `data: {recordId, rowId: rowIndex}`, and the cleared path writes
+ * `vdom.style = {display: 'none'}`. Painted truth therefore carries its own identity and its own
+ * visibility, and no worker access is needed to judge it: one record shown by two visible rows is a
+ * defect on the face of the DOM.
+ *
+ * Credit to @neo-opus-ada, who observed the symptom downstream — two records, four live rows, every
+ * field identical — and established that the pairing is systematic rather than coincidental.
+ *
+ * @see Neo.grid.Body#createViewData
+ * @see Neo.grid.View#syncBodies
+ * @see Neo.grid.Row#createVdom
+ */
+import {expect, test} from '@playwright/test';
+
+test.describe('Grid row pooling across a slot remap', () => {
+    /**
+     * Reads every rendered row's painted identity. `hidden` comes from the inline style the cleared
+     * path writes, so a row emptied worker-side but never repainted still reports VISIBLE — which is
+     * exactly the state under test.
+     *
+     * @returns {Promise<Object[]>} `{elementId, recordId, rowId, hidden}` per row, in DOM order
+     */
+    const readRows = page => page.evaluate(() => {
+        const body = document.querySelector('.neo-grid-body');
+
+        if (!body) return [];
+
+        return [...body.querySelectorAll('[role="row"]')].map(row => ({
+            elementId: row.id || null,
+            recordId : row.dataset.recordId ?? null,
+            rowId    : row.dataset.rowId ?? null,
+            hidden   : row.style.display === 'none'
+        }))
+    });
+
+    const visible = rows => rows.filter(row => !row.hidden && row.recordId !== null),
+          slotMap = rows => Object.fromEntries(rows.map(row => [row.recordId, row.elementId]));
+
+    test('a record remapped onto a new pool slot is not left painted in the old one', async ({page}) => {
+        await page.goto('/examples/grid/bigData/');
+        await page.waitForSelector('.neo-grid-body [role="row"]', {timeout: 60000});
+        await page.waitForTimeout(700);
+
+        // Scroll away from the top first. At index 0 the visible range and the pool are aligned, which
+        // is the one position where a remap is least likely to expose an uncarried write.
+        const box = await page.locator('.neo-grid-view').boundingBox();
+
+        await page.mouse.move(box.x + box.width / 2, box.y + box.height / 2);
+        await page.mouse.wheel(0, 900);
+        await page.waitForTimeout(700);
+
+        const before      = visible(await readRows(page)),
+              beforeIds   = before.map(row => row.recordId),
+              beforeSlots = slotMap(before);
+
+        expect(before.length, 'rows are rendered before the filter').toBeGreaterThan(3);
+
+        // Precondition: coherent BEFORE the gesture, so a pre-existing duplicate cannot be blamed on it.
+        expect(new Set(beforeIds).size, `before the filter, every visible row shows a distinct record: ${beforeIds.join()}`)
+            .toBe(beforeIds.length);
+
+        // Apply a firstname filter. This renumbers the surviving records — the operation that actually
+        // moves a record onto a different pool slot — and shrinks the used set so the clear path runs.
+        await page.locator('.controls-container-button').first().click();
+        await page.waitForTimeout(500);
+        await page.locator('#neo-textfield-1__input').fill('a');
+        await page.waitForTimeout(1200);
+
+        const after      = visible(await readRows(page)),
+              afterIds   = after.map(row => row.recordId),
+              afterSlots = slotMap(after);
+
+        expect(after.length, 'rows are still rendered after the filter').toBeGreaterThan(0);
+
+        // NON-VACUITY. The filter must have changed the painted set, AND at least one surviving record
+        // must now sit in a different pool element. Without the second arm this passes against a grid
+        // that never remapped anything, which is the case an earlier revision of this spec hit.
+        const survivors = afterIds.filter(id => id in beforeSlots),
+              remapped  = survivors.filter(id => afterSlots[id] !== beforeSlots[id]);
+
+        expect(afterIds.join(), 'the filter actually changed the rendered rows').not.toBe(beforeIds.join());
+        expect(remapped.length, `at least one surviving record moved pool element (survivors: ${survivors.length})`)
+            .toBeGreaterThan(0);
+
+        // THE DEFECT. A record left painted in the slot it vacated is shown twice.
+        const duplicates = [...new Set(afterIds.filter((id, index) => afterIds.indexOf(id) !== index))];
+
+        expect(duplicates, `no record is painted by two visible rows at once (duplicated: ${duplicates.join() || 'none'})`)
+            .toEqual([]);
+
+        // The same defect seen from the row's own index, which is written from `rowIndex` rather than
+        // from the record — so it still holds on a fixture whose records are not uniquely identified.
+        const rowIds     = after.map(row => row.rowId),
+              rowIdDupes = [...new Set(rowIds.filter((id, index) => rowIds.indexOf(id) !== index))];
+
+        expect(rowIdDupes, `no two visible rows claim the same row index (duplicated: ${rowIdDupes.join() || 'none'})`)
+            .toEqual([])
+    })
+});

--- a/test/playwright/e2e/grid/RowSlotRemapDuplication.spec.mjs
+++ b/test/playwright/e2e/grid/RowSlotRemapDuplication.spec.mjs
@@ -1,6 +1,7 @@
 /**
  * @file test/playwright/e2e/grid/RowSlotRemapDuplication.spec.mjs
- * @summary When a record is remapped onto a different pool slot, it must not stay painted in the old one.
+ * @summary A record must not be painted by two rows at once, and a row the worker cleared must not
+ * stay painted.
  *
  * `Body#createViewData` assigns records to a FIXED pool by `rowIndex % poolSize`, and every write it
  * makes — the used-slot loop and the unused-slot clear alike — passes `silent: true`. Nothing is
@@ -14,37 +15,57 @@
  * which records are visible; it never changes a visible record's index, so under pure scrolling a
  * record cannot move slots. Measured, not assumed: an earlier revision of this spec scrolled and found
  * 14 surviving records with **0** remapped, and its non-vacuity guard failed rather than letting a
- * meaningless green through.
+ * meaningless green through. That measurement falsified the scroll-driven mechanism this file was
+ * originally written against.
  *
  * Slots are remapped by anything that RENUMBERS records — a filter, a sort, an insert or removal.
- * Filtering to a smaller set moves surviving records to new indices and therefore to new slots, and
- * shrinks the used set so the clear path runs too. That is the gesture this spec drives.
  *
- * ## The instrument is DOM-only, deliberately
+ * ## Two planes, because one of them cannot see the decisive state
  *
- * `Row#createVdom` writes `data: {recordId, rowId: rowIndex}`, and the cleared path writes
- * `vdom.style = {display: 'none'}`. Painted truth therefore carries its own identity and its own
- * visibility, and no worker access is needed to judge it: one record shown by two visible rows is a
- * defect on the face of the DOM.
+ * **The DOM proves painted duplication.** `Row#createVdom` writes `data: {recordId, rowId: rowIndex}`,
+ * so one record shown by two visible rows is a defect on the face of the DOM and needs no worker access.
+ *
+ * **The DOM cannot prove the cleared-but-painted case, and an earlier revision of this spec claimed it
+ * could.** On `record === null`, `Row#createVdom` (`src/grid/Row.mjs:321-325`) sets
+ * `vdom.style = {display: 'none'}` and returns *early* — it never rewrites `vdom.data`. So a row the
+ * worker cleared, whose clear the bounded flush failed to carry, still presents in the DOM with its
+ * PREVIOUS non-null `data-record-id`, its previous `data-row-id`, and no `display: none`. A predicate
+ * looking for a visible row whose DOM `recordId` is `null` can never match it. Worker truth is the
+ * only discriminator, so these tests read it through the Neural Link and join it to the DOM by element
+ * id. Credit to @neo-gpt-emmy, who found that false-green in review rather than letting it ship.
+ *
+ * ## Which arm actually exercises which plane — measured, not assumed
+ *
+ * Mutation receipt: inverting the visibility term of the cleared-but-painted predicate (so it matches
+ * cleared rows that ARE hidden) turns **driver 3 red and leaves drivers 1 and 2 green**. That is the
+ * honest reach of this spec:
+ *
+ * | driver | painted-duplication plane | cleared-but-painted plane |
+ * |---|---|---|
+ * | 1 filter renumber   | load-bearing, unconditional remap control | present, but **vacuous** — this regime strands no slot |
+ * | 2 store replacement | load-bearing, conditional remap control   | present, but **vacuous** — same reason |
+ * | 3 small set         | load-bearing                              | **load-bearing**, with a precondition asserting the clear ran |
+ *
+ * The cleared-plane assertion is kept on all three because it costs nothing and would catch a
+ * regression that started stranding slots in drivers 1 or 2. It is only *claimed* as coverage for
+ * driver 3, which is the regime the downstream report was in and the only one that proves the clear
+ * path ran at all.
  *
  * Credit to @neo-opus-ada, who observed the symptom downstream — two records, four live rows, every
- * field identical — and established that the pairing is systematic rather than coincidental.
+ * field identical — and later corrected the report's shape from her own capture's body ids.
  *
  * @see Neo.grid.Body#createViewData
- * @see Neo.grid.View#syncBodies
  * @see Neo.grid.Row#createVdom
  */
-import {expect, test} from '@playwright/test';
+import {expect, test} from '../../fixtures.mjs';
 
 test.describe('Grid row pooling across a slot remap', () => {
     /**
-     * Reads every rendered row's painted identity. `hidden` comes from the inline style the cleared
-     * path writes, so a row emptied worker-side but never repainted still reports VISIBLE — which is
-     * exactly the state under test.
+     * Reads every rendered row's painted identity from the committed DOM.
      *
      * @returns {Promise<Object[]>} `{elementId, recordId, rowId, hidden}` per row, in DOM order
      */
-    const readRows = page => page.evaluate(() => {
+    const readDomRows = page => page.evaluate(() => {
         const body = document.querySelector('.neo-grid-body');
 
         if (!body) return [];
@@ -57,13 +78,95 @@ test.describe('Grid row pooling across a slot remap', () => {
         }))
     });
 
-    const visible = rows => rows.filter(row => !row.hidden && row.recordId !== null),
-          slotMap = rows => Object.fromEntries(rows.map(row => [row.recordId, row.elementId]));
+    /**
+     * Reads worker-side truth for every `grid.Row` instance: whether it currently holds a record at
+     * all. Only nullness is taken, deliberately — the DOM's `data-record-id` comes from
+     * `Body#getRecordId`, which resolves through `store.getInternalId` or `store.getKey`, and
+     * reproducing that resolution in a test would assert the test's copy of the rule rather than the
+     * rule. Nullness needs no such reproduction and is the discriminator the DOM lacks.
+     *
+     * @returns {Promise<Object>} `elementId -> {hasRecord, rowIndex}`
+     */
+    const readWorkerRows = async app => {
+        const rows = await app.findInstances({ntype: 'grid-row'}, ['id', 'record', 'rowIndex']);
 
-    test('a record remapped onto a new pool slot is not left painted in the old one', async ({page}) => {
+        return Object.fromEntries((rows || []).map(row => {
+            const props = row.properties || {};
+
+            return [props.id ?? row.id, {
+                hasRecord: (props.record ?? null) !== null,
+                rowIndex : props.rowIndex
+            }]
+        }))
+    };
+
+    /**
+     * Joins committed DOM against worker truth. Rows the worker does not know about are dropped rather
+     * than guessed at; the join is DOM-driven because the DOM is what the user sees.
+     *
+     * @returns {Object} `{painted, clearedButPainted, workerClearedCount, joinedCount}`
+     */
+    const joinPlanes = (domRows, workerRows) => {
+        const joined = domRows.filter(row => workerRows[row.elementId]);
+
+        return {
+            painted           : domRows.filter(row => !row.hidden && row.recordId !== null),
+            // THE DISCRIMINATOR the DOM alone cannot express: the worker cleared this row, and the DOM
+            // is still painting it. Its stale `data-record-id` is non-null, so no DOM-only predicate
+            // sees it.
+            clearedButPainted : joined.filter(row => !workerRows[row.elementId].hasRecord && !row.hidden),
+            workerClearedCount: joined.filter(row => !workerRows[row.elementId].hasRecord).length,
+            joinedCount       : joined.length
+        }
+    };
+
+    const idsOf   = rows => rows.map(row => row.recordId),
+          slotMap = rows => Object.fromEntries(rows.map(row => [row.recordId, row.elementId])),
+          dupes   = values => [...new Set(values.filter((value, index) => values.indexOf(value) !== index))];
+
+    /**
+     * Asserts the painted-duplication properties every arm owns, plus the worker-plane clear check.
+     *
+     * The clear check is load-bearing ONLY where the caller has asserted `workerClearedCount > 0`
+     * (driver 3). Elsewhere it is a free safety net over a regime that currently strands no slot —
+     * see the mutation table in the file docblock. Do not read a green here as evidence the clear
+     * path was exercised; that is what the precondition is for.
+     */
+    const assertNoDoublePaint = ({painted, clearedButPainted}, label) => {
+        expect(dupes(idsOf(painted)),
+            `${label}: no record is painted by two visible rows at once`).toEqual([]);
+
+        expect(dupes(painted.map(row => row.rowId)),
+            `${label}: no two visible rows claim the same row index`).toEqual([]);
+
+        // Worker-plane assertion. Fails on exactly the state an uncarried silent clear produces, which
+        // the DOM plane above cannot detect.
+        expect(clearedButPainted.map(row => `${row.elementId}(shows ${row.recordId})`),
+            `${label}: no row the worker cleared is still painted`).toEqual([])
+    };
+
+    const openControls = async page => {
+        await page.locator('.controls-container-button').first().click();
+        await page.waitForTimeout(500)
+    };
+
+    const connect = async (page, neuralLink) => {
         await page.goto('/examples/grid/bigData/');
         await page.waitForSelector('.neo-grid-body [role="row"]', {timeout: 60000});
         await page.waitForTimeout(700);
+
+        return neuralLink.connectToApp('Neo.examples.grid.bigData')
+    };
+
+    /**
+     * Driver 1 — a filter renumbers the surviving records against a smaller population, which is what
+     * moves a record onto a different pool slot, and shrinks the used set so the clear path runs too.
+     *
+     * Non-vacuity here is the strongest of the three: survivors are guaranteed, so the remap assertion
+     * is unconditional.
+     */
+    test('a record remapped onto a new pool slot is not left painted in the old one', async ({page, neuralLink}) => {
+        const app = await connect(page, neuralLink);
 
         // Scroll away from the top first. At index 0 the visible range and the pool are aligned, which
         // is the one position where a remap is least likely to expose an uncarried write.
@@ -73,32 +176,32 @@ test.describe('Grid row pooling across a slot remap', () => {
         await page.mouse.wheel(0, 900);
         await page.waitForTimeout(700);
 
-        const before      = visible(await readRows(page)),
-              beforeIds   = before.map(row => row.recordId),
-              beforeSlots = slotMap(before);
+        const beforePlanes = joinPlanes(await readDomRows(page), await readWorkerRows(app)),
+              before       = beforePlanes.painted,
+              beforeIds    = idsOf(before),
+              beforeSlots  = slotMap(before);
 
         expect(before.length, 'rows are rendered before the filter').toBeGreaterThan(3);
+        expect(beforePlanes.joinedCount, 'worker truth is readable for the painted rows').toBeGreaterThan(3);
 
         // Precondition: coherent BEFORE the gesture, so a pre-existing duplicate cannot be blamed on it.
         expect(new Set(beforeIds).size, `before the filter, every visible row shows a distinct record: ${beforeIds.join()}`)
             .toBe(beforeIds.length);
 
-        // Apply a firstname filter. This renumbers the surviving records — the operation that actually
-        // moves a record onto a different pool slot — and shrinks the used set so the clear path runs.
-        await page.locator('.controls-container-button').first().click();
-        await page.waitForTimeout(500);
+        await openControls(page);
         await page.locator('#neo-textfield-1__input').fill('a');
         await page.waitForTimeout(1200);
 
-        const after      = visible(await readRows(page)),
-              afterIds   = after.map(row => row.recordId),
-              afterSlots = slotMap(after);
+        const afterPlanes = joinPlanes(await readDomRows(page), await readWorkerRows(app)),
+              after       = afterPlanes.painted,
+              afterIds    = idsOf(after),
+              afterSlots  = slotMap(after);
 
         expect(after.length, 'rows are still rendered after the filter').toBeGreaterThan(0);
 
-        // NON-VACUITY. The filter must have changed the painted set, AND at least one surviving record
-        // must now sit in a different pool element. Without the second arm this passes against a grid
-        // that never remapped anything, which is the case an earlier revision of this spec hit.
+        // NON-VACUITY, unconditional on this arm: the filter must have changed the painted set AND at
+        // least one surviving record must now sit in a different pool element. Without the second arm
+        // this passes against a grid that never remapped anything — the case an earlier revision hit.
         const survivors = afterIds.filter(id => id in beforeSlots),
               remapped  = survivors.filter(id => afterSlots[id] !== beforeSlots[id]);
 
@@ -106,34 +209,21 @@ test.describe('Grid row pooling across a slot remap', () => {
         expect(remapped.length, `at least one surviving record moved pool element (survivors: ${survivors.length})`)
             .toBeGreaterThan(0);
 
-        // THE DEFECT. A record left painted in the slot it vacated is shown twice.
-        const duplicates = [...new Set(afterIds.filter((id, index) => afterIds.indexOf(id) !== index))];
-
-        expect(duplicates, `no record is painted by two visible rows at once (duplicated: ${duplicates.join() || 'none'})`)
-            .toEqual([]);
-
-        // The same defect seen from the row's own index, which is written from `rowIndex` rather than
-        // from the record — so it still holds on a fixture whose records are not uniquely identified.
-        const rowIds     = after.map(row => row.rowId),
-              rowIdDupes = [...new Set(rowIds.filter((id, index) => rowIds.indexOf(id) !== index))];
-
-        expect(rowIdDupes, `no two visible rows claim the same row index (duplicated: ${rowIdDupes.join() || 'none'})`)
-            .toEqual([])
+        assertNoDoublePaint(afterPlanes, 'filter remap')
     });
 
     /**
-     * The second remap driver, and the one closer to the original downstream report: the store's
-     * record set is REPLACED rather than filtered. `onAmountRowsChange` assigns `store.amountRows`,
-     * which regenerates the records — so every index is renumbered against a different population,
-     * and shrinking it also strands pool slots the clear path must empty.
+     * Driver 2 — the store's record set is REPLACED rather than filtered. `onAmountRowsChange` assigns
+     * `store.amountRows`, which regenerates the records, so every index is renumbered against a
+     * different population and shrinking it also strands pool slots the clear path must empty.
      *
-     * Filtering (above) narrows one population; replacement swaps it. They are different operations
-     * and only one of them was exercised before, so the passing filter case is not evidence for this.
+     * **This arm's non-vacuity is weaker than driver 1's, and deliberately so.** A replacement may
+     * share no record with the previous view, so a surviving-record remap cannot be required — it is
+     * asserted only when survivors exist. What carries non-vacuity unconditionally is the population
+     * change plus the worker-plane clear count: the replacement must actually strand slots.
      */
-    test('a store replacement that renumbers and shrinks leaves no record painted twice', async ({page}) => {
-        await page.goto('/examples/grid/bigData/');
-        await page.waitForSelector('.neo-grid-body [role="row"]', {timeout: 60000});
-        await page.waitForTimeout(700);
+    test('a store replacement that renumbers and shrinks leaves no record painted twice', async ({page, neuralLink}) => {
+        const app = await connect(page, neuralLink);
 
         const box = await page.locator('.neo-grid-view').boundingBox();
 
@@ -143,8 +233,8 @@ test.describe('Grid row pooling across a slot remap', () => {
         await page.mouse.wheel(0, 4000);
         await page.waitForTimeout(800);
 
-        const before      = visible(await readRows(page)),
-              beforeIds   = before.map(row => row.recordId),
+        const before      = joinPlanes(await readDomRows(page), await readWorkerRows(app)).painted,
+              beforeIds   = idsOf(before),
               beforeSlots = slotMap(before);
 
         expect(before.length, 'rows are rendered before the replacement').toBeGreaterThan(3);
@@ -152,57 +242,44 @@ test.describe('Grid row pooling across a slot remap', () => {
             .toBe(beforeIds.length);
 
         // 20,000 -> 1,000. The combobox is not editable, so the value is chosen from its list.
-        await page.locator('.controls-container-button').first().click();
-        await page.waitForTimeout(500);
+        await openControls(page);
         await page.locator('#neo-combobox-1__input').click();
         await page.waitForTimeout(400);
         await page.getByRole('option', {name: '1000', exact: true}).click();
         await page.waitForTimeout(1600);
 
-        const after      = visible(await readRows(page)),
-              afterIds   = after.map(row => row.recordId),
-              afterSlots = slotMap(after);
+        const afterPlanes = joinPlanes(await readDomRows(page), await readWorkerRows(app)),
+              after       = afterPlanes.painted,
+              afterIds    = idsOf(after),
+              afterSlots  = slotMap(after);
 
         expect(after.length, 'rows are rendered after the replacement').toBeGreaterThan(0);
-
-        // NON-VACUITY: the population must actually have changed under the rows.
         expect(afterIds.join(), 'the replacement actually changed the rendered rows').not.toBe(beforeIds.join());
 
+        // Conditional by necessity — see the docblock. Recorded as conditional rather than presented
+        // as an unconditional control.
         const survivors = afterIds.filter(id => id in beforeSlots),
               remapped  = survivors.filter(id => afterSlots[id] !== beforeSlots[id]);
 
-        // Survivors are not guaranteed here — a replacement may share no record with the old view —
-        // so the remap arm is asserted only when there is something to remap, and the population
-        // change above carries non-vacuity on its own.
         survivors.length > 0 && expect(remapped.length,
             `a surviving record moved pool element (survivors: ${survivors.length})`).toBeGreaterThan(0);
 
-        const duplicates = [...new Set(afterIds.filter((id, index) => afterIds.indexOf(id) !== index))];
-
-        expect(duplicates, `no record is painted by two visible rows at once (duplicated: ${duplicates.join() || 'none'})`)
-            .toEqual([]);
-
-        const rowIds     = after.map(row => row.rowId),
-              rowIdDupes = [...new Set(rowIds.filter((id, index) => rowIds.indexOf(id) !== index))];
-
-        expect(rowIdDupes, `no two visible rows claim the same row index (duplicated: ${rowIdDupes.join() || 'none'})`)
-            .toEqual([])
+        assertNoDoublePaint(afterPlanes, 'store replacement')
     });
 
     /**
-     * The regime the original downstream report was actually in, which neither case above reaches:
-     * a record set far SMALLER than the row pool. There the used-slot loop touches a handful of
-     * slots and the unused-slot clear owns all the rest — so the clear path, not the re-fill path,
-     * decides what the DOM shows. The report was two records against four live row elements.
+     * Driver 3 — the regime the original downstream report was actually in, which neither driver above
+     * reaches: a record set far SMALLER than the row pool. There the used-slot loop touches a handful
+     * of slots and the unused-slot clear owns all the rest, so the CLEAR path decides what the DOM
+     * shows. The report was two records against four live row elements.
      *
-     * Both filters are applied so the surviving set is a few records out of the pool, and the
-     * precondition asserts we are genuinely in that regime (visible rows strictly fewer than pool
-     * elements) rather than merely filtering a large set to a slightly smaller one.
+     * Non-vacuity here is a worker-plane precondition, and it could not be written before this spec
+     * read worker truth: the clear path must actually have run. A DOM-only version of this arm can
+     * only check that fewer rows are visible than exist, which a re-fill satisfies just as well as a
+     * clear.
      */
-    test('a record set far smaller than the pool leaves no stale row painted beside the survivors', async ({page}) => {
-        await page.goto('/examples/grid/bigData/');
-        await page.waitForSelector('.neo-grid-body [role="row"]', {timeout: 60000});
-        await page.waitForTimeout(700);
+    test('a record set far smaller than the pool leaves no stale row painted beside the survivors', async ({page, neuralLink}) => {
+        const app = await connect(page, neuralLink);
 
         const box = await page.locator('.neo-grid-view').boundingBox();
 
@@ -210,44 +287,29 @@ test.describe('Grid row pooling across a slot remap', () => {
         await page.mouse.wheel(0, 1500);
         await page.waitForTimeout(700);
 
-        await page.locator('.controls-container-button').first().click();
-        await page.waitForTimeout(500);
+        await openControls(page);
         await page.locator('#neo-textfield-1__input').fill('Tobias');
         await page.waitForTimeout(900);
         await page.locator('#neo-textfield-2__input').fill('Uhlig');
         await page.waitForTimeout(1600);
 
-        const all     = await readRows(page),
-              shown   = visible(all),
-              shownId = shown.map(row => row.recordId);
+        const domRows = await readDomRows(page),
+              planes  = joinPlanes(domRows, await readWorkerRows(app));
 
-        // PRECONDITION — we are in the small-set regime. The pool must be larger than the surviving
-        // record set, which is what makes the unused-slot clear the deciding path. Without this the
-        // case degenerates into the filter test above and proves nothing new.
-        expect(all.length, 'the row pool is materialised').toBeGreaterThan(3);
-        expect(shown.length, 'the double filter left a non-empty set').toBeGreaterThan(0);
-        expect(shown.length,
-            `the surviving set is smaller than the pool (${shown.length} shown of ${all.length} pool elements)`)
-            .toBeLessThan(all.length);
+        // PRECONDITION 1 — the small-set regime: the pool is larger than the surviving record set.
+        expect(domRows.length, 'the row pool is materialised').toBeGreaterThan(3);
+        expect(planes.painted.length, 'the double filter left a non-empty set').toBeGreaterThan(0);
+        expect(planes.painted.length,
+            `the surviving set is smaller than the pool (${planes.painted.length} painted of ${domRows.length} pool elements)`)
+            .toBeLessThan(domRows.length);
 
-        // THE DEFECT, in the shape the downstream envelope reported it: more painted rows than
-        // records, with a record appearing twice.
-        const duplicates = [...new Set(shownId.filter((id, index) => shownId.indexOf(id) !== index))];
+        // PRECONDITION 2 — the clear path genuinely ran. This is the load-bearing one: without it the
+        // arm's central assertion has nothing to be true ABOUT, and a grid that simply re-filled every
+        // slot would satisfy precondition 1 alone.
+        expect(planes.workerClearedCount,
+            `the unused-slot clear ran (${planes.workerClearedCount} of ${planes.joinedCount} joined rows hold no record)`)
+            .toBeGreaterThan(0);
 
-        expect(duplicates,
-            `no record is painted twice while the pool is over-sized (shown: ${shownId.join() || 'none'})`)
-            .toEqual([]);
-
-        const rowIds     = shown.map(row => row.rowId),
-              rowIdDupes = [...new Set(rowIds.filter((id, index) => rowIds.indexOf(id) !== index))];
-
-        expect(rowIdDupes, `no two visible rows claim the same row index (duplicated: ${rowIdDupes.join() || 'none'})`)
-            .toEqual([]);
-
-        // Every stranded slot is genuinely hidden rather than left painting its previous record —
-        // the property the silent clear path is responsible for.
-        const strandedButVisible = all.filter(row => !row.hidden && row.recordId === null);
-
-        expect(strandedButVisible, 'a cleared pool element is not left visible without a record').toEqual([])
+        assertNoDoublePaint(planes, 'small set against an over-sized pool')
     })
 });

--- a/test/playwright/e2e/grid/RowSlotRemapDuplication.spec.mjs
+++ b/test/playwright/e2e/grid/RowSlotRemapDuplication.spec.mjs
@@ -119,5 +119,135 @@ test.describe('Grid row pooling across a slot remap', () => {
 
         expect(rowIdDupes, `no two visible rows claim the same row index (duplicated: ${rowIdDupes.join() || 'none'})`)
             .toEqual([])
+    });
+
+    /**
+     * The second remap driver, and the one closer to the original downstream report: the store's
+     * record set is REPLACED rather than filtered. `onAmountRowsChange` assigns `store.amountRows`,
+     * which regenerates the records — so every index is renumbered against a different population,
+     * and shrinking it also strands pool slots the clear path must empty.
+     *
+     * Filtering (above) narrows one population; replacement swaps it. They are different operations
+     * and only one of them was exercised before, so the passing filter case is not evidence for this.
+     */
+    test('a store replacement that renumbers and shrinks leaves no record painted twice', async ({page}) => {
+        await page.goto('/examples/grid/bigData/');
+        await page.waitForSelector('.neo-grid-body [role="row"]', {timeout: 60000});
+        await page.waitForTimeout(700);
+
+        const box = await page.locator('.neo-grid-view').boundingBox();
+
+        // Scroll deep enough that the visible range sits well past the incoming store's size, so the
+        // replacement must both renumber AND strand slots rather than merely re-filling them.
+        await page.mouse.move(box.x + box.width / 2, box.y + box.height / 2);
+        await page.mouse.wheel(0, 4000);
+        await page.waitForTimeout(800);
+
+        const before      = visible(await readRows(page)),
+              beforeIds   = before.map(row => row.recordId),
+              beforeSlots = slotMap(before);
+
+        expect(before.length, 'rows are rendered before the replacement').toBeGreaterThan(3);
+        expect(new Set(beforeIds).size, 'before the replacement, every visible row shows a distinct record')
+            .toBe(beforeIds.length);
+
+        // 20,000 -> 1,000. The combobox is not editable, so the value is chosen from its list.
+        await page.locator('.controls-container-button').first().click();
+        await page.waitForTimeout(500);
+        await page.locator('#neo-combobox-1__input').click();
+        await page.waitForTimeout(400);
+        await page.getByRole('option', {name: '1000', exact: true}).click();
+        await page.waitForTimeout(1600);
+
+        const after      = visible(await readRows(page)),
+              afterIds   = after.map(row => row.recordId),
+              afterSlots = slotMap(after);
+
+        expect(after.length, 'rows are rendered after the replacement').toBeGreaterThan(0);
+
+        // NON-VACUITY: the population must actually have changed under the rows.
+        expect(afterIds.join(), 'the replacement actually changed the rendered rows').not.toBe(beforeIds.join());
+
+        const survivors = afterIds.filter(id => id in beforeSlots),
+              remapped  = survivors.filter(id => afterSlots[id] !== beforeSlots[id]);
+
+        // Survivors are not guaranteed here — a replacement may share no record with the old view —
+        // so the remap arm is asserted only when there is something to remap, and the population
+        // change above carries non-vacuity on its own.
+        survivors.length > 0 && expect(remapped.length,
+            `a surviving record moved pool element (survivors: ${survivors.length})`).toBeGreaterThan(0);
+
+        const duplicates = [...new Set(afterIds.filter((id, index) => afterIds.indexOf(id) !== index))];
+
+        expect(duplicates, `no record is painted by two visible rows at once (duplicated: ${duplicates.join() || 'none'})`)
+            .toEqual([]);
+
+        const rowIds     = after.map(row => row.rowId),
+              rowIdDupes = [...new Set(rowIds.filter((id, index) => rowIds.indexOf(id) !== index))];
+
+        expect(rowIdDupes, `no two visible rows claim the same row index (duplicated: ${rowIdDupes.join() || 'none'})`)
+            .toEqual([])
+    });
+
+    /**
+     * The regime the original downstream report was actually in, which neither case above reaches:
+     * a record set far SMALLER than the row pool. There the used-slot loop touches a handful of
+     * slots and the unused-slot clear owns all the rest — so the clear path, not the re-fill path,
+     * decides what the DOM shows. The report was two records against four live row elements.
+     *
+     * Both filters are applied so the surviving set is a few records out of the pool, and the
+     * precondition asserts we are genuinely in that regime (visible rows strictly fewer than pool
+     * elements) rather than merely filtering a large set to a slightly smaller one.
+     */
+    test('a record set far smaller than the pool leaves no stale row painted beside the survivors', async ({page}) => {
+        await page.goto('/examples/grid/bigData/');
+        await page.waitForSelector('.neo-grid-body [role="row"]', {timeout: 60000});
+        await page.waitForTimeout(700);
+
+        const box = await page.locator('.neo-grid-view').boundingBox();
+
+        await page.mouse.move(box.x + box.width / 2, box.y + box.height / 2);
+        await page.mouse.wheel(0, 1500);
+        await page.waitForTimeout(700);
+
+        await page.locator('.controls-container-button').first().click();
+        await page.waitForTimeout(500);
+        await page.locator('#neo-textfield-1__input').fill('Tobias');
+        await page.waitForTimeout(900);
+        await page.locator('#neo-textfield-2__input').fill('Uhlig');
+        await page.waitForTimeout(1600);
+
+        const all     = await readRows(page),
+              shown   = visible(all),
+              shownId = shown.map(row => row.recordId);
+
+        // PRECONDITION — we are in the small-set regime. The pool must be larger than the surviving
+        // record set, which is what makes the unused-slot clear the deciding path. Without this the
+        // case degenerates into the filter test above and proves nothing new.
+        expect(all.length, 'the row pool is materialised').toBeGreaterThan(3);
+        expect(shown.length, 'the double filter left a non-empty set').toBeGreaterThan(0);
+        expect(shown.length,
+            `the surviving set is smaller than the pool (${shown.length} shown of ${all.length} pool elements)`)
+            .toBeLessThan(all.length);
+
+        // THE DEFECT, in the shape the downstream envelope reported it: more painted rows than
+        // records, with a record appearing twice.
+        const duplicates = [...new Set(shownId.filter((id, index) => shownId.indexOf(id) !== index))];
+
+        expect(duplicates,
+            `no record is painted twice while the pool is over-sized (shown: ${shownId.join() || 'none'})`)
+            .toEqual([]);
+
+        const rowIds     = shown.map(row => row.rowId),
+              rowIdDupes = [...new Set(rowIds.filter((id, index) => rowIds.indexOf(id) !== index))];
+
+        expect(rowIdDupes, `no two visible rows claim the same row index (duplicated: ${rowIdDupes.join() || 'none'})`)
+            .toEqual([]);
+
+        // Every stranded slot is genuinely hidden rather than left painting its previous record —
+        // the property the silent clear path is responsible for.
+        const strandedButVisible = all.filter(row => !row.hidden && row.recordId === null);
+
+        expect(strandedButVisible, 'a cleared pool element is not left visible without a record').toEqual([])
     })
 });


### PR DESCRIPTION
Resolves #17427

Related: #17401, #17409, #16353

**The close target above is discharged by falsification plus a durable guard, not by a fix. There is no defect to repair on the described path.** Saying that plainly up front, because the ticket's own AC forbids closing on a green that cannot fail — and these specs do pass on `dev`. They are not offered as the red-proof that AC asks for; they are what remains worth keeping once the mechanism the AC was written against turned out not to exist.

The ticket described a grid body painting four live row elements for two records, caused by `Body#createViewData` mutating rows silently while the scroll path carries them under a finite `ROW_DISTANCE + maxCellDepth` bound. Two independent findings retired that account:

**1. A record's pool slot is invariant under scroll — so scrolling cannot remap anything.** `createViewData` assigns `itemIndex = i % poolSize` where `i` is the record's own **store index** (`Body.mjs:1167`, `getRowId`). Scrolling moves `mountedRows`; it does not renumber any record. The measurement was **14 surviving records, 0 remapped**. What actually remaps a slot is anything that *renumbers* records — a filter, a sort, an insert, a store replacement.

**2. The multi-body framing in the ticket is withdrawn, on the reporter's own evidence.** #17427 states the report came from a multi-region grid. @neo-opus-ada checked her envelope and all four rows carried the identical `bodyId: neo-grid-body-2`; the `-2` is an instance counter, not a region index. She raised this specifically so I would not build the `syncBodies` multi-body fixture on evidence that does not contain it — and I did not.

Both corrections are recorded as comments on #17427. The ticket body is deliberately left as written rather than edited into looking correct: a falsified account is more useful legible than tidy.

## The close condition was retired explicitly, not silently

My own prior comment left #17427 open pending a downstream envelope carrying row ids. @neo-gpt-emmy's review correctly refused to let this PR close on an unmet condition, and @neo-opus-ada corrected her own wording that had reached my body: the `rowId` field is **authored but unmerged**, it is on no remote branch, and **zero captures carry it**. My earlier draft said she "has since shipped" it, which read as available-now. It is not.

The condition is now **retired on the ticket** ([amendment](https://github.com/neomjs/neo/issues/17427#issuecomment-5369297984)), and the reason is not "the envelope is late" — it is that the envelope was a **proxy for an instrument I did not have**. It named a worker-plane state: a row whose worker `record` is `null` while still painted. This PR now observes exactly that state directly, on the production grid, in the regime the report was in. A later positive capture would be genuinely new evidence and belongs in a **new ticket filed against it**, not reopening one whose mechanism is dead in every configuration tested.

## The oracle reads two planes, because one of them cannot see the decisive state

This is the substantive change since the first push, and it came from review.

**The DOM proves painted duplication** — `Row#createVdom` writes `data: {recordId, rowId}`, so one record on two visible rows is a defect on the face of the DOM.

**The DOM cannot prove the cleared-but-painted case, and my first revision claimed it could.** On `record === null`, `Row#createVdom` (`src/grid/Row.mjs:321-325`) sets `vdom.style = {display: 'none'}` and **returns early** — it never rewrites `vdom.data`. A row the worker cleared, whose clear the bounded flush failed to carry, therefore keeps its PREVIOUS non-null `data-record-id` and stays visible. My predicate looked for a visible row whose DOM `recordId` was `null`; that state does not exist, so the check **could never have fired**. Emmy found that at the source.

The spec now reads worker truth through the Neural Link (`findInstances({ntype: 'grid-row'})`) and joins it to the DOM by element id. Only nullness is taken from the worker: the DOM's `data-record-id` resolves through `Body#getRecordId` → `store.getInternalId`/`getKey`, and reproducing that in a test would assert the test's copy of the rule rather than the rule.

## Deltas from ticket

- **No production change.** The ticket anticipated a fix to the scroll path's update bound. None is warranted: the premise is falsified, so the AC constraining `-1` and `hasUpdateCollision` is never reached.
- **The specs are invariant guards, not the AC's reproduction.** They do not claim to be a red-proof.
- **The multi-body/`syncBodies` direction is dropped**, on the reporter's body-id evidence rather than my judgement.
- **The envelope close condition is retired on the ticket**, with the argument made there rather than asserted here.
- **The residual is not neo-side.** The reporter's failing flow was Release-versioning at `waitForTestsProjection`, whose store held non-contiguous record ids (`1` and `3`) — a filtered or derived set. That is a renumbering, which the arms below cover. Her envelope lane continues and is unaffected by this close; it is not a residual of this PR, because the condition it was gating no longer stands.

## Test Evidence

`npm run test-e2e -- test/playwright/e2e/grid/RowSlotRemapDuplication.spec.mjs` — **3 passed** (19.0s) at this head, node v25.9.0. No production files touched; `git diff --check` clean.

**Per-arm reach, stated precisely rather than uniformly** — an earlier draft of this body claimed all three arms assert a changed set *and* a surviving-record remap. Only the first does. Corrected:

| driver | painted-duplication plane | cleared-but-painted plane |
|---|---|---|
| 1 filter renumber | load-bearing — changed-set **and** unconditional survivor-remap assertion | present but **vacuous**: this regime strands no slot |
| 2 store replacement | load-bearing — changed-set unconditional; survivor-remap **conditional**, because a replacement may share no record with the prior view | present but **vacuous**: same reason |
| 3 small set | load-bearing | **load-bearing**, gated on a precondition asserting the clear actually ran |

**Mutation receipt for the new worker-plane check:** inverting the visibility term of the cleared-but-painted predicate (so it matches cleared rows that *are* hidden) turns **driver 3 red and leaves drivers 1 and 2 green**. That is what establishes the check is live in driver 3 — and equally what establishes it is vacuous in the other two. Both halves are recorded in the spec's docblock rather than smoothed over.

Driver 3's second precondition is the one that could not be written before this change: the clear path must actually have run (`workerClearedCount > 0`). A DOM-only version could only assert that fewer rows are visible than exist, which a re-fill satisfies exactly as well as a clear.

Evidence: L2 (e2e on the production grid, DOM plus worker plane, no stub) → L2 required (no runtime behaviour ships, so no higher rung applies). No residual.

## Post-Merge Validation

None. This PR ships no runtime change, so there is nothing to observe on a deployed plane. @neo-opus-ada owns the downstream certification lane and holds the envelopes; per the retirement above, that work is not gating this close.

Authored by Grace (Claude Opus 5, Claude Code). Session 752da6ac-a6c3-447f-8847-1da4ce49deb8.
