### PR TITLE
feat(ai): the review dry-run stops accepting what the submit gate refuses (#17354)

### DIFF
--- a/.agents/skills/pr-review/assets/pr-review-round-2-template.md
+++ b/.agents/skills/pr-review/assets/pr-review-round-2-template.md
@@ -1,8 +1,8 @@
 # PR Review — Round 2 (disposition only)
 
-**Status:** [Approved / Approve+Follow-Up / Comment / Request Changes]
+**Status:** [Approved / Approve+Follow-Up / Comment]
 
-*The Verdict rule forces this: any `STILL_OPEN` row ⇒ Comment; a fully dispositioned round is never Request Changes. The gate refuses a Status disagreeing with your table.*
+*Exactly one, and your table picks it: any `STILL_OPEN` row ⇒ `Comment`. Request Changes is not a Round-2 status — a discharged round approves, an open one comments.*
 
 **Opening:** [One sentence: which prior actions this dispositions, at which head.]
 

--- a/.agents/skills/pr-review/assets/pr-review-round-2-template.md
+++ b/.agents/skills/pr-review/assets/pr-review-round-2-template.md
@@ -1,6 +1,8 @@
 # PR Review — Round 2 (disposition only)
 
-**Status:** [Approved / Approve+Follow-Up / Request Changes]
+**Status:** [Approved / Approve+Follow-Up / Comment / Request Changes]
+
+*Pick the one the Verdict rule below forces: any `STILL_OPEN` row makes this **Comment**, and a round that dispositions everything is never Request Changes. The submit gate enforces both, so a Status that disagrees with your own table is refused.*
 
 **Opening:** [One sentence: which prior actions this dispositions, at which head.]
 

--- a/.agents/skills/pr-review/assets/pr-review-round-2-template.md
+++ b/.agents/skills/pr-review/assets/pr-review-round-2-template.md
@@ -2,7 +2,7 @@
 
 **Status:** [Approved / Approve+Follow-Up / Comment / Request Changes]
 
-*Pick the one the Verdict rule below forces: any `STILL_OPEN` row makes this **Comment**, and a round that dispositions everything is never Request Changes. The submit gate enforces both, so a Status that disagrees with your own table is refused.*
+*The Verdict rule forces this: any `STILL_OPEN` row ⇒ Comment; a fully dispositioned round is never Request Changes. The gate refuses a Status disagreeing with your table.*
 
 **Opening:** [One sentence: which prior actions this dispositions, at which head.]
 

--- a/.github/workflows/agent-pr-review-body-lint.yml
+++ b/.github/workflows/agent-pr-review-body-lint.yml
@@ -94,6 +94,39 @@ jobs:
             // validated in.
             const isRound2Disposition = /^#[ \t]+PR Review — Round 2\b/m.test(body);
 
+            // Body-only Status coherence, mirroring `getRound2StateCoherenceFailure` in
+            // `PullRequestService.mjs`. Deliberately scoped to what a body alone decides: the
+            // prior-round relation checks (row count, verbatim quoting) need PR history and stay
+            // submit-only. Without this, the exact contradiction the managed dry-run now refuses
+            // stays submittable by clicking, which is the bypass this workflow exists to observe.
+            if (isRound2Disposition) {
+              const LEGAL_ROUND_2_STATUSES = ['Approved', 'Approve+Follow-Up', 'Comment'];
+              const DISPOSITIONS           = ['ADDRESSED', 'DEFENDED', 'STILL_OPEN'];
+              const statusMatch            = body.match(/^\*\*Status:\*\*[ \t]*(.+?)[ \t]*$/m);
+              const declaredStatus         = statusMatch ? statusMatch[1].replace(/[*_`]/g, '').trim() : null;
+
+              const dispositionCells = body.split('\n')
+                .filter(line => line.trim().startsWith('|') && DISPOSITIONS.some(verb => line.includes(verb)))
+                .map(line => line.split('|').slice(1, -1).map(cell => cell.trim()))
+                .map(cells => cells.find(cell => DISPOSITIONS.includes(cell)))
+                .filter(Boolean);
+
+              if (!declaredStatus) {
+                core.setFailed(`Round-2 review by ${reviewer} declares no \`**Status:**\`. State exactly one of ${LEGAL_ROUND_2_STATUSES.join(', ')} — any STILL_OPEN row means Comment.`);
+                return;
+              }
+
+              if (!LEGAL_ROUND_2_STATUSES.some(status => status.toLowerCase() === declaredStatus.toLowerCase())) {
+                core.setFailed(`Round-2 review by ${reviewer} declares \`**Status:** ${declaredStatus}\`, which is not a legal Round-2 status (${LEGAL_ROUND_2_STATUSES.join(', ')}). Request Changes is not among them: a discharged round approves, an open one comments.`);
+                return;
+              }
+
+              if (dispositionCells.includes('STILL_OPEN') && declaredStatus.toLowerCase() !== 'comment') {
+                core.setFailed(`Round-2 review by ${reviewer} carries a STILL_OPEN row while \`**Status:**\` reads "${declaredStatus}". A STILL_OPEN round keeps the ORIGINAL review authoritative, so its Status is Comment.`);
+                return;
+              }
+            }
+
             // Ordinary COMMENTED reviews remain supplementary and skip the heavy template.
             // The RC2 closure packet is one exception (it carries the budget's frozen semantic
             // contract and receives the narrow Micro-Delta validation below); a Round-2 disposition

--- a/ai/mcp/server/github-workflow/openapi.yaml
+++ b/ai/mcp/server/github-workflow/openapi.yaml
@@ -818,16 +818,12 @@ paths:
       summary: Validate PR Review Body
       operationId: validate_pr_review_body
       x-neo-tool-tier: read
-      x-neo-tool-summary: Dry-run validate a PR review body against the canonical pr-review template before posting.
+      x-neo-tool-summary: Read-only shape check for a PR review body; does not predict the submit gate.
       x-pass-as-object: true
       x-annotations:
         readOnlyHint: true
       description: |
-        Read-only preflight for PR review composition. Validates `body` against the `pr-review` template-shape rules without resolving a PR, creating or updating a review, or changing GitHub state.
-
-        A pass validates SHAPE ONLY and does not predict `manage_pr_review`. That gate also compares the body against the pull request's prior review state — each row against the previous round's Required Actions, and the disposition table against the submitted review state — inputs this tool never receives. So a body accepted here can still be refused there; that is the contract, not a contradiction.
-
-        Use before `manage_pr_review` when composing: a failure names the exact visible/premise/template-skeleton anchors the read-only lint can safely expose. The mutation path stays narrower to preserve the anti-anchor-stuffing guard.
+        Read-only review-body shape check. Does not resolve a PR or predict `manage_pr_review`, which additionally compares the body against the pull request's prior-review state. Use while composing, then submit through `manage_pr_review`.
       tags: [PullRequests]
       requestBody:
         required: true

--- a/ai/mcp/server/github-workflow/openapi.yaml
+++ b/ai/mcp/server/github-workflow/openapi.yaml
@@ -823,9 +823,11 @@ paths:
       x-annotations:
         readOnlyHint: true
       description: |
-        Read-only preflight for PR review composition. Validates `body` against the same `pr-review` template-shape rules used by `manage_pr_review`, without resolving a PR, creating a review, updating a review, or changing GitHub state.
+        Read-only preflight for PR review composition. Validates `body` against the `pr-review` template-shape rules without resolving a PR, creating or updating a review, or changing GitHub state.
 
-        Use before `manage_pr_review` when composing a review body: a failed result names the exact visible/premise/template-skeleton anchors that the read-only lint can safely expose. The formal mutation path remains narrower to preserve the anti-anchor-stuffing guard.
+        A pass validates SHAPE ONLY and does not predict `manage_pr_review`. That gate also compares the body against the pull request's prior review state — each row against the previous round's Required Actions, and the disposition table against the submitted review state — inputs this tool never receives. So a body accepted here can still be refused there; that is the contract, not a contradiction.
+
+        Use before `manage_pr_review` when composing: a failure names the exact visible/premise/template-skeleton anchors the read-only lint can safely expose. The mutation path stays narrower to preserve the anti-anchor-stuffing guard.
       tags: [PullRequests]
       requestBody:
         required: true

--- a/ai/services/github-workflow/PullRequestService.mjs
+++ b/ai/services/github-workflow/PullRequestService.mjs
@@ -1179,6 +1179,16 @@ function getRound2DispositionRelationFailure({body, reviews, state}) {
         ])
     }
 
+    // BEFORE the count, because the count is DERIVED from this parse. A cell the extractor cannot
+    // read is dropped silently, so the row the author actually wrote becomes an absence in the tally
+    // and the refusal accuses them of dispositioning nothing. Returning here keeps one defect to one
+    // cause: fix the cell, then see whatever the relation still objects to.
+    const unreadable = extractUnreadableDispositionCells(body);
+
+    if (unreadable.length > 0) {
+        return round2CellParseFailure(unreadable)
+    }
+
     if (rows.length !== expected.length) {
         defects.push(`dispositions ${rows.length} action(s) against the prior round's ${expected.length} — every action gets a row, in order`)
     }
@@ -1346,6 +1356,56 @@ function extractRequiredActions(body) {
  * @param {String} body
  * @returns {Array<{action: String, disposition: String}>}
  */
+/**
+ * @summary Returns disposition cells that CARRY a verdict verb but are not one, so cannot be read.
+ *
+ * The extractor matches a cell that IS a verb. `**ADDRESSED** — and answered better than the action
+ * asked` carries its verdict and is dropped, which turns a row the author wrote into an absence in
+ * the count. This is the same line set the extractor walks, kept deliberately separate rather than
+ * folded into its return shape: the extractor has two callers and only one of them reports defects.
+ *
+ * @param {String} body
+ * @returns {String[]} The offending cell texts, in document order.
+ */
+function extractUnreadableDispositionCells(body) {
+    return String(body || '').split('\n')
+        .filter(line => line.trim().startsWith('|') && ROUND_2_DISPOSITIONS.some(verb => line.includes(verb)))
+        .map(line => {
+            const cells = line.split('|').slice(1, -1).map(cell => cell.trim());
+
+            // A readable row is not a defect, even when other cells mention a verb in prose.
+            if (cells.some(cell => ROUND_2_DISPOSITIONS.includes(cell))) return null;
+
+            return cells.find(cell => ROUND_2_DISPOSITIONS.some(verb => cell.includes(verb))) || null
+        })
+        .filter(Boolean)
+}
+
+/**
+ * @summary Renders a refusal for disposition cells that could not be read.
+ *
+ * Names the cell and the shape that would parse, because neither is stuffable: the required content
+ * IS the corrected cell. Kept apart from the relation failure's header, which prescribes re-reading
+ * the template — the wrong remedy for an author whose only error is decoration inside one cell.
+ *
+ * @param {String[]} cells
+ * @returns {Object}
+ */
+function round2CellParseFailure(cells) {
+    return {
+        error  : 'PR Review Template Validation Failed',
+        message: [
+            'A disposition cell could not be read, so this round cannot be matched against the prior one.',
+            '',
+            ...cells.map(cell => `- \`${cell}\` carries a verdict but is not one.`),
+            '',
+            'The Disposition cell must be exactly `ADDRESSED`, `DEFENDED` or `STILL_OPEN` — no bold, no',
+            'trailing prose. Anything you want to say about the disposition goes in the Evidence column.'
+        ].join('\n'),
+        code: 'PR_REVIEW_TEMPLATE_VALIDATION_FAILED'
+    }
+}
+
 function extractDispositionRows(body) {
     return String(body || '').split('\n')
         .filter(line => line.trim().startsWith('|') && ROUND_2_DISPOSITIONS.some(verb => line.includes(verb)))

--- a/ai/services/github-workflow/PullRequestService.mjs
+++ b/ai/services/github-workflow/PullRequestService.mjs
@@ -854,7 +854,7 @@ async function buildMergeReadinessProjection({
         // observation, so nested inside `predicate` it reaches no reader of the surface that
         // actually travels to the merge gate.
         advisories: predicate.advisories.map(message => ({code: 'APPROVAL_ANCHOR_STALE', message})),
-        audit: [
+        audit     : [
             ...audit,
             {source: 'validateMergeReady', call: 1, outcome: sourceMergeReady ? 'positive' : 'negative'},
             {
@@ -1231,6 +1231,91 @@ function round2RelationFailure(lines) {
 }
 
 /**
+ * @summary Refuses a Round-2 body whose declared `**Status:**` contradicts its own disposition table.
+ *
+ * The submit gate already refuses `STILL_OPEN` under a non-`COMMENT` state, but it does so by
+ * comparing the table to the API `state` argument — which a dry-run holding only a body never
+ * receives. That much of the divergence is structural. This is the part that is not: the body
+ * ALSO declares its verdict on its own `**Status:**` line, so the same contradiction is decidable
+ * with no pull request resolved.
+ *
+ * **Why naming this is safe.** The invisible anchor layer stays silent because an anchor is
+ * stuffable — told which token is missing, a caller can paste the token and skip the structure.
+ * A contradiction is not stuffable: the only way to satisfy it is to decide which of the author's
+ * two declarations is true, and that decision IS the required content.
+ *
+ * Live specimen: a Round 2 carrying `**Status:** Request Changes`, two `STILL_OPEN` rows, and a
+ * Verdict opening `COMMENT.` was accepted by the dry-run and by CI, then refused by the submit
+ * gate. The author had followed the template — whose Status enum omitted `Comment` entirely while
+ * its own Verdict rule required it, so no coherent Status existed for a `STILL_OPEN` round. Both
+ * halves are fixed together; the enum without this check would leave the contradiction silent, and
+ * this check without the enum would refuse a body the template told the author to write.
+ *
+ * @param {String} body The candidate PR review body.
+ * @returns {Object|null} A structured refusal, or `null` when the body is coherent or out of scope.
+ */
+function getRound2StateCoherenceFailure(body) {
+    if (!isRound2PrReview(body)) return null;
+
+    const statusMatch = String(body || '').match(ROUND_2_STATUS_PATTERN);
+
+    // A missing or unparseable Status is the anchor layer's to refuse, and a table the extractor
+    // cannot read is the relation layer's. Staying silent here keeps one defect to one owner.
+    if (!statusMatch) return null;
+
+    const rows = extractDispositionRows(body);
+
+    if (rows.length === 0) return null;
+
+    const declared = statusMatch[1].replace(/[*_`]/g, '').trim().toLowerCase(),
+          stillOpen = rows.some(row => row.disposition === 'STILL_OPEN');
+
+    if (stillOpen && declared !== 'comment') {
+        return round2StateCoherenceFailure([
+            `- The table carries a \`STILL_OPEN\` row while \`**Status:**\` reads "${statusMatch[1].trim()}".`,
+            '- A `STILL_OPEN` round keeps the ORIGINAL review authoritative, so its Status is `Comment`.',
+            '',
+            'Set `**Status:** Comment`, or disposition the open item as `ADDRESSED` / `DEFENDED` — whichever is true.'
+        ])
+    }
+
+    if (!stillOpen && declared === 'request changes') {
+        return round2StateCoherenceFailure([
+            '- Every prior action is dispositioned, yet `**Status:**` reads "Request Changes".',
+            '- A fully discharged round is `Approved` or `Comment`; it does not spend another round.',
+            '',
+            'Set `**Status:**` to the verdict the table already reached, or say which action is still open.'
+        ])
+    }
+
+    return null
+}
+
+/**
+ * @summary Renders a Round-2 state-coherence refusal.
+ *
+ * Deliberately does NOT reuse the relation failure's header. That header prescribes reading the
+ * template and quoting prior actions verbatim, which is the right remedy for a relation defect and
+ * the wrong one here — the template was followed and the quoting was already verbatim. A fixed
+ * remedy printed under a variable defect is what taught two separate maintainers something false
+ * about this surface.
+ *
+ * @param {String[]} lines
+ * @returns {Object}
+ */
+function round2StateCoherenceFailure(lines) {
+    return {
+        error  : 'PR Review Template Validation Failed',
+        message: [
+            'This Round 2 contradicts itself: its declared Status and its disposition table disagree.',
+            '',
+            ...lines
+        ].join('\n'),
+        code: 'PR_REVIEW_TEMPLATE_VALIDATION_FAILED'
+    }
+}
+
+/**
  * @summary Extracts a review's Required Actions as ordered verbatim strings.
  *
  * The canonical and follow-up templates both carry actions as a `- [ ]` checklist under a Required
@@ -1311,6 +1396,14 @@ function isRound2PrReview(body) {
  * @type {RegExp}
  */
 const ROUND_2_DISPOSITION_ROW_PATTERN = /\|[^|\n]*\b(ADDRESSED|DEFENDED|STILL_OPEN)\b[^|\n]*\|/g;
+
+/**
+ * The body's OWN declared verdict, which is what makes state coherence decidable without a PR.
+ * Anchored to line start so a Status quoted inside prose or a fenced block cannot be read as the
+ * declaration — the same reason the Post-Merge Validation heading check is anchored.
+ * @type {RegExp}
+ */
+const ROUND_2_STATUS_PATTERN = /^\*\*Status:\*\*[ \t]*(.+?)[ \t]*$/m;
 
 const ACTION_PACKET_HEADING_PATTERN = /Required\s+Actions?\b/i;
 const ACTION_PACKET_ITEM_PATTERN    = /^[ \t]*[-*][ \t]+\[[ \t]*\][ \t]*\S/;
@@ -3398,6 +3491,19 @@ class PullRequestService extends Base {
             return {
                 valid: false,
                 ...templateValidationFailure
+            };
+        }
+
+        // Structure is not coherence. A Round 2 can carry every canonical heading and still declare a
+        // Status its own disposition table refuses, which the submit gate then rejects on a comparison
+        // the dry-run was never given the inputs for. This closes the half of that divergence that is
+        // decidable from the body, so the two surfaces disagree on strictly less.
+        const stateCoherenceFailure = getRound2StateCoherenceFailure(body);
+
+        if (stateCoherenceFailure) {
+            return {
+                valid: false,
+                ...stateCoherenceFailure
             };
         }
 

--- a/ai/services/github-workflow/PullRequestService.mjs
+++ b/ai/services/github-workflow/PullRequestService.mjs
@@ -2638,6 +2638,73 @@ function getReviewBudgetAuditSnapshot(body) {
 }
 
 /**
+ * @summary Renders the audit-immutability refusal from the condition that actually fired.
+ *
+ * The guard is load-bearing and stays: editing a submitted review is a second way to raise a packet,
+ * and until it ran here the create-side guards could be walked around entirely. What was wrong was
+ * the message. It named three abstract categories and never the concrete cause, and the cost was
+ * measured — a reviewer hitting it concluded the capability did not exist, told the PR author and the
+ * operator that a submitted body is immutable to this tool, and fell back to a comment. Two greps on
+ * the error string disprove that.
+ *
+ * The dominant cause deserves its own branch because it is the one nobody can deduce: `create`
+ * appends a tail the caller never wrote, so a caller resubmitting their OWN edited body is refused
+ * for omitting bytes they have never seen. Naming it is safe — the remedy is mechanical, and a
+ * mechanical remedy cannot be gamed the way an anchor name can.
+ *
+ * @param {Object} options
+ * @param {Object} options.currentAudit    Snapshot of the submitted body.
+ * @param {Object} options.incomingAudit   Snapshot of the candidate body.
+ * @param {String[]} options.markerChanges Marker-level differences.
+ * @param {String[]} options.auditFieldChanges Field-level differences.
+ * @param {Boolean} options.terminalChanged Whether ordinary/Drop+Supersede classification moved.
+ * @returns {String}
+ */
+function buildReviewBudgetAuditRefusal({currentAudit, incomingAudit, markerChanges, auditFieldChanges, terminalChanged}) {
+    const headline = 'A submitted review update cannot change review-budget provenance, audit fields, or ordinary-versus-Drop+Supersede classification.';
+
+    // The unguessable case, and by far the most common: the tail is simply absent from the update.
+    if (currentAudit.tail && !incomingAudit.tail) {
+        return [
+            headline,
+            '',
+            'Body edits ARE supported. What happened: `create` appended a machine-owned tail your body',
+            'never contained, and this update omits it — so the round-trip check reads the omission as',
+            'an audit-field change.',
+            '',
+            'Re-fetch the current review body, edit only the content ABOVE the `---` marker, and resubmit',
+            'with this tail unchanged:',
+            '',
+            ...currentAudit.tail.split('\n').map(line => `    ${line}`)
+        ].join('\n')
+    }
+
+    const causes = [];
+
+    if (terminalChanged) {
+        causes.push('- The ordinary/Drop+Supersede classification differs between the submitted review and this update. A terminal verdict is a different packet, not an edit of an ordinary one — post it as its own review.')
+    }
+
+    if (!currentAudit.structureValid || !incomingAudit.structureValid) {
+        causes.push('- The machine-owned tail is malformed. It must appear once, immediately after a `---` line, with any override marker before the managed marker.')
+    }
+
+    markerChanges.filter(marker => marker !== 'machine-owned-tail-structure').forEach(marker => {
+        causes.push(`- \`${marker}\` appears a different number of times than in the submitted review. It must round-trip exactly once.`)
+    });
+
+    if (currentAudit.auditFieldsOutsideTail.length > 0 || incomingAudit.auditFieldsOutsideTail.length > 0) {
+        causes.push('- Audit fields appear OUTSIDE the machine-owned tail. They belong only inside it, below the `---` marker.')
+    }
+
+    if (auditFieldChanges.includes('machine-owned-tail') && causes.length === 0) {
+        causes.push('- The machine-owned tail differs from the submitted review\'s. Resubmit it byte-identical; edit only the content above the `---` marker.')
+    }
+
+    return [headline, '', ...causes].join('\n')
+}
+
+/**
  * @summary Rejects caller-authored review-budget provenance before a review CREATE reaches GitHub.
  * @param {String} body Candidate review body.
  * @returns {Object|null} Structured validation failure or `null` when no reserved provenance exists.
@@ -3872,6 +3939,13 @@ class PullRequestService extends Base {
                     };
                 }
 
+                // The submitted body is not the body the caller handed us: a machine-owned tail was
+                // appended. `update` requires that tail back byte-identical, so a caller who later
+                // edits their own copy — which never contained it — is refused as if they had changed
+                // an audit field. Surfacing it here is what stops that loop before it starts; a
+                // reviewer who hit the refusal without this concluded the capability did not exist.
+                const machineOwnedTail = getReviewBudgetAuditSnapshot(submissionBody).tail;
+
                 return {
                     message    : `Successfully created ${review.state} review on PR #${pr_number}`,
                     reviewId   : review.id,
@@ -3879,7 +3953,11 @@ class PullRequestService extends Base {
                     url        : review.url,
                     submittedAt: review.submittedAt,
                     databaseId : review.databaseId,
-                    ...(reviewBudgetAudit ? {reviewBudget: reviewBudgetAudit} : {})
+                    ...(reviewBudgetAudit ? {reviewBudget: reviewBudgetAudit} : {}),
+                    ...(machineOwnedTail ? {
+                        machineOwnedTail,
+                        machineOwnedTailNote: 'Appended by this tool. An `update` must resubmit it unchanged: re-fetch the review body and edit only the content above the `---` marker.'
+                    } : {})
                 };
             } catch (error) {
                 logger.error(`Error creating PR review on PR #${pr_number}:`, error);
@@ -3942,8 +4020,16 @@ class PullRequestService extends Base {
             if (markerChanges.length > 0 || currentTerminal !== incomingTerminal || auditFieldChanges.length > 0) {
                 return {
                     error                        : 'PR Review Budget Audit Validation Failed',
-                    message                      : 'A submitted review update cannot change review-budget provenance, audit fields, or ordinary-versus-Drop+Supersede classification.',
+                    message: buildReviewBudgetAuditRefusal({
+                        currentAudit,
+                        incomingAudit,
+                        markerChanges,
+                        auditFieldChanges,
+                        terminalChanged: currentTerminal !== incomingTerminal
+                    }),
                     code                         : 'PR_REVIEW_BUDGET_AUDIT_IMMUTABLE',
+                    // The exact bytes to restore, so the remedy does not require reconstructing them.
+                    ...(currentAudit.tail ? {requiredTail: currentAudit.tail} : {}),
                     markerChanges,
                     auditFieldChanges,
                     terminalClassificationChanged: currentTerminal !== incomingTerminal

--- a/ai/services/github-workflow/PullRequestService.mjs
+++ b/ai/services/github-workflow/PullRequestService.mjs
@@ -1197,7 +1197,14 @@ function getRound2DispositionRelationFailure({body, reviews, state}) {
         const row = rows[index];
 
         if (row && row.action !== action) {
-            defects.push(`row ${index + 1} reads "${row.action}" where the prior round said "${action}" — carry it verbatim`)
+            // When the ONLY difference is emphasis, printing both strings is not a diagnosis: they
+            // render nearly identically, so the author reads "carry it verbatim" while looking at
+            // what appears to be a verbatim copy. The rule is right and stays — byte-verbatim is what
+            // stops a Round 2 quietly softening the demand it claims to discharge — but the rule was
+            // unstated and its violation unnamed, which is the whole defect.
+            defects.push(normalizeQuoteForComparison(row.action) === normalizeQuoteForComparison(action)
+                ? `row ${index + 1} differs from the prior round ONLY in formatting. The quote must be byte-verbatim INCLUDING its markdown, so restore the emphasis exactly as written: "${action}"`
+                : `row ${index + 1} reads "${row.action}" where the prior round said "${action}" — carry it verbatim`)
         }
     });
 
@@ -1356,6 +1363,21 @@ function extractRequiredActions(body) {
  * @param {String} body
  * @returns {Array<{action: String, disposition: String}>}
  */
+/**
+ * @summary Strips markdown emphasis and collapses whitespace, for DIAGNOSIS only.
+ *
+ * Never used to decide whether a quote matches — the verbatim rule compares raw strings and keeps
+ * doing so. This exists solely to tell an author WHICH kind of mismatch they have, because
+ * "formatting" and "you reworded the demand" need opposite responses and the raw diff cannot
+ * distinguish them on screen.
+ *
+ * @param {String} text
+ * @returns {String}
+ */
+function normalizeQuoteForComparison(text) {
+    return String(text || '').replace(/[*_`]/g, '').replace(/\s+/g, ' ').trim()
+}
+
 /**
  * @summary Returns disposition cells that CARRY a verdict verb but are not one, so cannot be read.
  *

--- a/ai/services/github-workflow/PullRequestService.mjs
+++ b/ai/services/github-workflow/PullRequestService.mjs
@@ -1276,16 +1276,40 @@ function getRound2StateCoherenceFailure(body) {
 
     const statusMatch = String(body || '').match(ROUND_2_STATUS_PATTERN);
 
-    // A missing or unparseable Status is the anchor layer's to refuse, and a table the extractor
-    // cannot read is the relation layer's. Staying silent here keeps one defect to one owner.
-    if (!statusMatch) return null;
+    // A rule that reads one declaration is only as good as the guarantee the declaration EXISTS.
+    // An earlier revision deferred this to the structural anchor layer in a comment and never
+    // checked that the anchor layer refuses it — it does not, so a Round 2 with no Status passed
+    // entirely and the coherence rule silently did not apply to the body that most needed it.
+    if (!statusMatch) {
+        return round2StateCoherenceFailure([
+            '- This Round 2 declares no `**Status:**` line.',
+            `- A Round 2 states exactly one of ${ROUND_2_LEGAL_STATUSES.map(status => `\`${status}\``).join(', ')}.`,
+            '',
+            'Add the Status your disposition table already implies: any `STILL_OPEN` row means `Comment`.'
+        ])
+    }
 
     const rows = extractDispositionRows(body);
 
     if (rows.length === 0) return null;
 
-    const declared = statusMatch[1].replace(/[*_`]/g, '').trim().toLowerCase(),
-          stillOpen = rows.some(row => row.disposition === 'STILL_OPEN');
+    const declaredRaw = statusMatch[1].replace(/[*_`]/g, '').trim(),
+          declared    = declaredRaw.toLowerCase(),
+          stillOpen   = rows.some(row => row.disposition === 'STILL_OPEN');
+
+    // `Request Changes` is deliberately absent from the legal set. Every branch below refuses it —
+    // with a STILL_OPEN row it must be `Comment`, and without one a fully dispositioned round does
+    // not spend another round — so offering it is an enum carrying a value with no legal branch,
+    // which is the same defect this whole change started from.
+    if (!ROUND_2_LEGAL_STATUSES.some(status => status.toLowerCase() === declared)) {
+        return round2StateCoherenceFailure([
+            `- \`**Status:** ${declaredRaw}\` is not a legal Round-2 status.`,
+            `- The legal set is ${ROUND_2_LEGAL_STATUSES.map(status => `\`${status}\``).join(', ')}.`,
+            '',
+            '`Request Changes` is not among them: a round that dispositions everything is `Approved`,',
+            'and one leaving an item open is `Comment`, which keeps the ORIGINAL review authoritative.'
+        ])
+    }
 
     if (stillOpen && declared !== 'comment') {
         return round2StateCoherenceFailure([
@@ -1486,6 +1510,14 @@ const ROUND_2_DISPOSITION_ROW_PATTERN = /\|[^|\n]*\b(ADDRESSED|DEFENDED|STILL_OP
  * @type {RegExp}
  */
 const ROUND_2_STATUS_PATTERN = /^\*\*Status:\*\*[ \t]*(.+?)[ \t]*$/m;
+
+/**
+ * The complete legal Round-2 Status set. `Request Changes` is deliberately absent: the coherence
+ * rule refuses it on every branch, so offering it would be an enum carrying a value that can never
+ * validate — the exact defect the round-2 template held before this change.
+ * @type {String[]}
+ */
+const ROUND_2_LEGAL_STATUSES = ['Approved', 'Approve+Follow-Up', 'Comment'];
 
 const ACTION_PACKET_HEADING_PATTERN = /Required\s+Actions?\b/i;
 const ACTION_PACKET_ITEM_PATTERN    = /^[ \t]*[-*][ \t]+\[[ \t]*\][ \t]*\S/;

--- a/test/playwright/unit/ai/services/github-workflow/PullRequestService.spec.mjs
+++ b/test/playwright/unit/ai/services/github-workflow/PullRequestService.spec.mjs
@@ -2039,6 +2039,48 @@ test.describe('Neo.ai.services.github-workflow.PullRequestService — managePrRe
         expect(failure.message).toContain("against the prior round's 2");
     });
 
+    /**
+     * The count in the refusal is DERIVED from the parse, and it was reported as if it were an
+     * observation. A cell reading `**ADDRESSED** — and answered better than the action asked` carries
+     * its verdict, but the extractor matches a cell that IS the verb, so the row is dropped silently
+     * and the author is told they dispositioned nothing. That accuses them of the wrong mistake: they
+     * wrote the row, and the message sends them to write it again rather than to unwrap the cell.
+     */
+    test('#17354: an unparseable disposition cell is named, not counted as absent', () => {
+        const failure = getRound2DispositionRelationFailure({
+            body: round2With([
+                '| RA-1 | make the tier semantic | **ADDRESSED** — and answered better than the action asked | done |',
+                '| RA-2 | name the anchors | ADDRESSED | done |'
+            ]),
+            reviews: [PRIOR_RC],
+            state  : 'APPROVED'
+        });
+
+        expect(failure?.code).toBe('PR_REVIEW_TEMPLATE_VALIDATION_FAILED');
+
+        // The defect is the cell, so the refusal must say so.
+        expect(failure.message, 'the refusal names the unreadable cell')
+            .toMatch(/could not be read|unparseable|unreadable/i);
+
+        // And it must NOT claim the author dispositioned fewer actions than they wrote. Asserted
+        // separately because a fix that only appends a hint would leave the false accusation standing.
+        expect(failure.message, 'no derived count is presented as an observation')
+            .not.toContain("dispositions 1 action(s) against the prior round's 2");
+    });
+
+    test('#17354: a genuinely short table still reports the count — the non-vacuity control', () => {
+        // Without this, a fix that deletes the count message entirely passes the arm above. A table
+        // that parses cleanly and is simply missing a row must still be told so.
+        const failure = getRound2DispositionRelationFailure({
+            body   : round2With(['| RA-1 | make the tier semantic | ADDRESSED | done |']),
+            reviews: [PRIOR_RC],
+            state  : 'APPROVED'
+        });
+
+        expect(failure.message, 'a clean short table keeps the count').toContain("against the prior round's 2");
+        expect(failure.message, 'and is not blamed on a parse failure').not.toMatch(/could not be read/i)
+    });
+
     test('#17178: a STILL_OPEN round submitted as APPROVED is refused', () => {
         // The second exact-head falsifier: an APPROVED round carrying a STILL_OPEN silently discharges
         // the item it just declared unresolved.

--- a/test/playwright/unit/ai/services/github-workflow/PullRequestService.spec.mjs
+++ b/test/playwright/unit/ai/services/github-workflow/PullRequestService.spec.mjs
@@ -3401,6 +3401,75 @@ test.describe('Neo.ai.services.github-workflow.PullRequestService — managePrRe
         }
     });
 
+    /**
+     * The refusal's measured cost: a reviewer who hit it concluded the capability did not exist,
+     * told the PR author and the operator that a submitted review body is immutable to this tool,
+     * and fell back to a comment. Body edits ARE supported. What happened is that `create` appends
+     * a machine-owned tail the caller never wrote, and `update` requires it back byte-identical —
+     * so resubmitting your own edited body trips the comparison and is refused as an "audit-field
+     * change". The refusal held every fact needed to print the remedy and printed a category.
+     */
+    test('#17354: the update refusal names the tail round-trip as its remedy', async () => {
+        const current     = managedReviewBody(VALID_ORDINARY_REQUEST_CHANGES_BODY, 'within-budget');
+        let   updateCalls = 0;
+
+        GraphqlService.query = async queryString => {
+            if (queryString.includes('GetPullRequestReview')) {
+                return {node: {id: REVIEW_NODE.id, body: current, state: 'CHANGES_REQUESTED'}}
+            }
+
+            updateCalls++;
+            return null
+        };
+
+        // Exactly what an author who edited their own copy sends: the prose, without a tail they
+        // never wrote and cannot know about.
+        const result = await PullRequestService.managePrReview({
+            action   : 'update',
+            review_id: REVIEW_NODE.id,
+            body     : VALID_ORDINARY_REQUEST_CHANGES_BODY
+        });
+
+        expect(result.code, 'the guard still refuses — it is load-bearing').toBe('PR_REVIEW_BUDGET_AUDIT_IMMUTABLE');
+        expect(updateCalls, 'and never reaches the mutation').toBe(0);
+
+        // The remedy is mechanical and therefore not stuffable: re-fetch, edit above the marker,
+        // resubmit the tail unchanged.
+        expect(result.message, 'names the machine-owned tail').toContain('[review-budget-managed]');
+        expect(result.message, 'names the round-trip as the fix').toMatch(/unchanged|re-?fetch|resubmit/i);
+
+        // And hands back the exact bytes to restore, so the caller does not have to reconstruct them.
+        expect(result.requiredTail, 'the tail to resubmit is returned verbatim').toContain('[review-budget-managed]')
+    });
+
+    test('#17354: create surfaces the machine-owned tail it appended', async () => {
+        // A caller planning an update learns the tail exists from the create response, rather than
+        // from a refusal after the fact. This is the half that stops the loop from starting.
+        GraphqlService.query = async queryString => {
+            if (queryString.includes('GetPullRequestId')) {
+                return pullRequestLookup({
+                    createdAt: '2026-07-16T13:57:04Z',
+                    reviews  : {nodes: [], pageInfo: {hasPreviousPage: false}}
+                })
+            }
+
+            return {addPullRequestReview: {pullRequestReview: {...REVIEW_NODE, state: 'CHANGES_REQUESTED'}}}
+        };
+
+        RepositoryService.viewerLogin = 'neo-opus-grace';
+
+        const result = await PullRequestService.managePrReview({
+            action   : 'create',
+            pr_number: 17354,
+            state    : 'REQUEST_CHANGES',
+            body     : VALID_ORDINARY_REQUEST_CHANGES_BODY
+        });
+
+        expect(result.reviewBudget, 'the create response reports the budget').toBeTruthy();
+        expect(result.machineOwnedTail, 'and names the tail it appended')
+            .toContain('[review-budget-managed]')
+    });
+
     test('#15257: review updates cannot add/remove provenance or rewrite managed audit fields', async () => {
         const currentBody = managedReviewBody(
             VALID_ORDINARY_REQUEST_CHANGES_BODY

--- a/test/playwright/unit/ai/services/github-workflow/PullRequestService.spec.mjs
+++ b/test/playwright/unit/ai/services/github-workflow/PullRequestService.spec.mjs
@@ -2223,6 +2223,23 @@ test.describe('Neo.ai.services.github-workflow.PullRequestService — managePrRe
         }).valid, 'STILL_OPEN under Comment').toBe(true)
     });
 
+    test('#17354: a body missing a silent anchor is refused SILENTLY, even when it also contradicts itself', () => {
+        // The ordering is the anti-Goodhart guard, and making refusals friendlier is exactly what
+        // would sand it off. A body that trips BOTH layers must return the silent one: the named
+        // coherence message must never become a side channel that tells a caller which unnamed
+        // anchor they are missing, one bisected submission at a time.
+        //
+        // The heading is REMOVED rather than renamed. A first attempt renamed `Disposition` to
+        // `Dispositions`, which the presence check reads as still present because it is a substring —
+        // so the body tripped only the coherence layer and the test proved nothing about ordering.
+        const body   = ROUND_2_STILL_OPEN_BODY.replace('### ⚓ Anchor\n', ''),
+              result = PullRequestService.validatePrReviewBody({body});
+
+        expect(result.valid, 'the structural layer still refuses').toBe(false);
+        expect(result.message, 'and the coherence message did not preempt it')
+            .not.toContain('contradicts itself')
+    });
+
     test('#17178: validatePrReviewBody names the template it ACTUALLY applied', () => {
         // It returned the canonical path unconditionally, so a Round-2 body was told it matched
         // `pr-review-template.md` — sending an author who later hit a rejection to the wrong file.

--- a/test/playwright/unit/ai/services/github-workflow/PullRequestService.spec.mjs
+++ b/test/playwright/unit/ai/services/github-workflow/PullRequestService.spec.mjs
@@ -2130,6 +2130,57 @@ test.describe('Neo.ai.services.github-workflow.PullRequestService — managePrRe
         }
     });
 
+    /**
+     * The dry-run used to accept a Round-2 body that contradicts ITSELF.
+     *
+     * The submit gate refuses `stillOpen && state !== 'COMMENT'` by comparing the disposition column
+     * to the API `state` parameter, which the dry-run never receives. That much is structural. But the
+     * body ALSO declares its own verdict on its `**Status:**` line, so the same contradiction is
+     * visible with no PR context at all — and naming it is not stuffable, because the fix is to decide
+     * which of the author's two declarations is true.
+     *
+     * The live specimen that motivated this carried `**Status:** Request Changes`, two STILL_OPEN rows
+     * and a Verdict opening `COMMENT.`. The dry-run and CI both accepted it; only the submit gate
+     * refused, and the author's eventual direct submission landed as COMMENTED — agreeing with the
+     * gate. The dry-run held everything needed to say so first, and the template's Status enum had
+     * offered no coherent value for a STILL_OPEN round, so the author was following it.
+     */
+    const ROUND_2_STILL_OPEN_BODY = VALID_ROUND_2_REVIEW_BODY.replace(
+        '| RA-1 | prior template miss | ADDRESSED | current body keeps canonical headings |',
+        '| RA-1 | prior template miss | STILL_OPEN | the original review stays authoritative |'
+    );
+
+    test('#17354: a STILL_OPEN row under a non-COMMENT Status is refused by the dry-run', () => {
+        // Status says Approved, the row says STILL_OPEN. A STILL_OPEN round keeps the original review
+        // authoritative and must be COMMENT, so these two cannot both be true.
+        const result = PullRequestService.validatePrReviewBody({body: ROUND_2_STILL_OPEN_BODY});
+
+        expect(result.valid, 'the body contradicts its own Status line').toBe(false);
+        expect(result.message, 'the refusal names the contradiction rather than the template')
+            .toMatch(/STILL_OPEN/)
+    });
+
+    test('#17354: a fully-dispositioned round under a Request Changes Status is refused by the dry-run', () => {
+        // The mirror: no STILL_OPEN row anywhere, yet the body spends a REQUEST_CHANGES round. A fully
+        // discharged round is APPROVED or COMMENT. Asserted separately so a fix that only handles the
+        // STILL_OPEN direction cannot pass both.
+        const body   = VALID_ROUND_2_REVIEW_BODY.replace('**Status:** Approved', '**Status:** Request Changes'),
+              result = PullRequestService.validatePrReviewBody({body});
+
+        expect(result.valid, 'every action is dispositioned, so the round is not a Request Changes').toBe(false)
+    });
+
+    test('#17354: the coherent bodies stay accepted — the non-vacuity control', () => {
+        // Without this, a fix that refuses every Round 2 passes both arms above. Each accepted shape
+        // pairs with one refused shape on a single differing declaration.
+        expect(PullRequestService.validatePrReviewBody({body: VALID_ROUND_2_REVIEW_BODY}).valid,
+            'ADDRESSED under Approved').toBe(true);
+
+        expect(PullRequestService.validatePrReviewBody({
+            body: ROUND_2_STILL_OPEN_BODY.replace('**Status:** Approved', '**Status:** Comment')
+        }).valid, 'STILL_OPEN under Comment').toBe(true)
+    });
+
     test('#17178: validatePrReviewBody names the template it ACTUALLY applied', () => {
         // It returned the canonical path unconditionally, so a Round-2 body was told it matched
         // `pr-review-template.md` — sending an author who later hit a rejection to the wrong file.

--- a/test/playwright/unit/ai/services/github-workflow/PullRequestService.spec.mjs
+++ b/test/playwright/unit/ai/services/github-workflow/PullRequestService.spec.mjs
@@ -2265,6 +2265,49 @@ test.describe('Neo.ai.services.github-workflow.PullRequestService — managePrRe
         }).valid, 'STILL_OPEN under Comment').toBe(true)
     });
 
+    /**
+     * A coherence rule that reads one declaration is only as good as the guarantee that the
+     * declaration EXISTS. The first revision deferred a missing Status to the structural anchor
+     * layer in a code comment — and never checked that the anchor layer refuses it. It does not: a
+     * Round 2 with no Status at all returned `valid: true`, so the rule silently did not apply to
+     * the one body that most needed it. Found in review by @neo-gpt.
+     *
+     * `Request Changes` is likewise not a legal Round-2 Status: every branch of the coherence rule
+     * refuses it — with a STILL_OPEN row it must be Comment, and without one a fully dispositioned
+     * round does not spend another round. An enum offering a value with no legal branch is the same
+     * defect this PR started from, one value over.
+     */
+    test('#17354: a Round 2 with no Status is refused', () => {
+        const body   = VALID_ROUND_2_REVIEW_BODY.replace('**Status:** Approved\n\n', ''),
+              result = PullRequestService.validatePrReviewBody({body});
+
+        expect(result.valid, 'the coherence rule needs a declaration to read').toBe(false);
+        expect(result.message).toMatch(/Status/)
+    });
+
+    test('#17354: an unknown or placeholder Status is refused', () => {
+        for (const status of ['Request Changes', 'Merged', '[Approved / Approve+Follow-Up / Comment]']) {
+            const body   = VALID_ROUND_2_REVIEW_BODY.replace('**Status:** Approved', `**Status:** ${status}`),
+                  result = PullRequestService.validatePrReviewBody({body});
+
+            expect(result.valid, `"${status}" is not a legal Round-2 Status`).toBe(false)
+        }
+    });
+
+    test('#17354: each legal Status is accepted in its coherent shape — the paired controls', () => {
+        // One accepted shape per legal value, so a fix that simply refuses more cannot pass.
+        expect(PullRequestService.validatePrReviewBody({body: VALID_ROUND_2_REVIEW_BODY}).valid,
+            'Approved with everything dispositioned').toBe(true);
+
+        expect(PullRequestService.validatePrReviewBody({
+            body: VALID_ROUND_2_REVIEW_BODY.replace('**Status:** Approved', '**Status:** Approve+Follow-Up')
+        }).valid, 'Approve+Follow-Up with everything dispositioned').toBe(true);
+
+        expect(PullRequestService.validatePrReviewBody({
+            body: ROUND_2_STILL_OPEN_BODY.replace('**Status:** Approved', '**Status:** Comment')
+        }).valid, 'Comment carrying a STILL_OPEN row').toBe(true)
+    });
+
     test('#17354: a body missing a silent anchor is refused SILENTLY, even when it also contradicts itself', () => {
         // The ordering is the anti-Goodhart guard, and making refusals friendlier is exactly what
         // would sand it off. A body that trips BOTH layers must return the silent one: the named

--- a/test/playwright/unit/ai/services/github-workflow/PullRequestService.spec.mjs
+++ b/test/playwright/unit/ai/services/github-workflow/PullRequestService.spec.mjs
@@ -2028,6 +2028,48 @@ test.describe('Neo.ai.services.github-workflow.PullRequestService — managePrRe
         expect(failure.message, 'it names the drift rather than just refusing').toContain('carry it verbatim');
     });
 
+    /**
+     * The third live specimen: a prior action quoted correctly, with its markdown stripped.
+     * `**RA-1 (scope):** make the tier semantic` became `RA-1 (scope): make the tier semantic`.
+     *
+     * The byte-verbatim rule is right and is not being relaxed — it is what stops a Round 2 quietly
+     * softening the demand it claims to discharge. The defect is that the rule is unstated and its
+     * violation unnamed: the refusal prints both strings, and when the only difference is emphasis
+     * the two render nearly identically, so the author is told to "carry it verbatim" while looking
+     * at what appears to be a verbatim copy.
+     */
+    const PRIOR_RC_WITH_MARKDOWN = {
+        ...PRIOR_RC,
+        body: ['# PR Review Summary', '', '### 📋 Required Actions', '',
+               '- [ ] **make the tier semantic** so the label survives a rename'].join('\n')
+    };
+
+    test('#17354: a quote differing only in formatting is told so, not just "carry it verbatim"', () => {
+        const failure = getRound2DispositionRelationFailure({
+            body   : round2With(['| RA-1 | make the tier semantic so the label survives a rename | ADDRESSED | done |']),
+            reviews: [PRIOR_RC_WITH_MARKDOWN],
+            state  : 'APPROVED'
+        });
+
+        expect(failure?.code).toBe('PR_REVIEW_TEMPLATE_VALIDATION_FAILED');
+        expect(failure.message, 'the refusal names formatting as the difference')
+            .toMatch(/formatting|emphasis|markdown/i)
+    });
+
+    test('#17354: a genuinely reworded action is NOT excused as formatting — the non-vacuity control', () => {
+        // Without this, a fix that labels every verbatim mismatch "formatting" passes the arm above
+        // while telling an author who softened a demand that they merely mis-styled it.
+        const failure = getRound2DispositionRelationFailure({
+            body   : round2With(['| RA-1 | make the tier a bit more semantic | ADDRESSED | done |',
+                                 '| RA-2 | update the stale predecessors | ADDRESSED | done |']),
+            reviews: [PRIOR_RC],
+            state  : 'APPROVED'
+        });
+
+        expect(failure.message, 'real drift keeps the verbatim demand').toContain('carry it verbatim');
+        expect(failure.message, 'and is not excused as styling').not.toMatch(/only in formatting/i)
+    });
+
     test('#17178: a dropped action is refused — omission must not retire a demand', () => {
         const failure = getRound2DispositionRelationFailure({
             body   : round2With(['| RA-1 | make the tier semantic | ADDRESSED | done |']),


### PR DESCRIPTION
Resolves #17354

Related: #17284, #17261, #17314, #17339

The review-body validator's dry-run could accept what the submit gate rejects, and its refusals named what was wrong without ever naming what would be right. This closes the half of that divergence that is decidable from the body, and makes the non-stuffable refusals prescriptive while leaving the anti-Goodhart silence exactly where it was.

## What review found that the ticket did not have

@neo-gpt-emmy banked a fresh specimen mid-lane as *"canonical Round 2 rejected by MCP validators while repository CI accepts"*. I ran the exact body through the shipped validator before building on it, and **half of that was false**:

```
{"valid":true,"message":"Review body matches the pr-review template structure.",
 "template":".agents/skills/pr-review/assets/pr-review-round-2-template.md"}
```

`validate_pr_review_body` **accepts** it. The instruments split 2–1 *for* accept — dry-run accepts, CI accepts, only `manage_pr_review` refuses. So it is not a three-way template disagreement; it is a clean live instance of this ticket's headline defect, which made it the AC-3 specimen the ticket was missing.

**Then the root cause, and it exonerates the author.** The refused body carried `**Status:** Request Changes`, two `STILL_OPEN` rows and a Verdict opening `COMMENT.` The round-2 template's Status enum was `[Approved / Approve+Follow-Up / Request Changes]` — it offered **no `Comment`** — while its own Verdict rule required COMMENT for any STILL_OPEN row and the submit gate enforced exactly that. **Any STILL_OPEN round following the template was forced into a contradiction.** The author wrote what the template offered and the gate refused them for it.

That reframes the fix. Part of what looked structural is not: the contradiction is entirely intra-body, so the dry-run held everything needed to catch it with no PR resolved.

## Deltas from ticket

- **AC-3 splits, and the ticket's Problem section was too broad.** It says round semantics *"are not properties of the body alone"*. True for the **relation** checks — comparing rows against the prior round genuinely needs `reviews`. **False for state coherence**, which I wrote as though the whole surface were structural. The dry-run now refuses intra-body contradictions; the relation half is disclaimed in the tool description instead.
- **The template is fixed alongside the validator**, which the ticket did not anticipate. Shipping the check alone would refuse bodies the template told authors to write.
- **"Accept PR context" stays struck**, unchanged from the ticket's own correction — predicting the gate exactly is the same Goodhart exposure one level up.
- **Nothing is loosened.** The update guard, the machine-owned tail, and the byte-verbatim quoting rule are all load-bearing and all kept. Every change here is to what a refusal *says*, or to a check the dry-run was already entitled to make.

## Substrate Slot Rationale

`.agents/skills/pr-review/assets/pr-review-round-2-template.md` — **disposition: `keep`, modified in place.** It is a skill-loaded asset already in a `keep` slot; no new slot, no generated artifact. The enum is now the complete legal set — `Request Changes` is **removed**, because every branch of the coherence rule refuses it, so offering it was an enum carrying a value with no legal branch. One line of note states the rule the gate enforces. Net skill-Markdown growth is inside the 250-byte cap without claiming the growth exemption; the prose was simply loose and got tightened.

`ai/mcp/server/github-workflow/openapi.yaml` — description rewritten to **232 chars** (from 817, cap 1024), stating only the caller decision. The anti-Goodhart and relation-layer rationale moved to the `PullRequestService` JSDoc, where a caller does not pay for it on every tool enumeration. The previous text claimed the tool validated *"the same rules used by `manage_pr_review`"*, which is false and is the sentence that made the divergence read as a bug rather than a contract.

`.github/workflows/agent-pr-review-body-lint.yml` — the **body-decidable** half of the coherence rule is mirrored post-submit, so the contradiction the managed dry-run now refuses is not submittable by clicking. Relation checks need PR history and stay submit-only. The legal-status set is byte-identical across both surfaces.

## Test Evidence

`npm run test-unit -- test/playwright/unit/ai/services/github-workflow` — **710 passed**. Broader `test/playwright/unit/ai` — **11,469 passed**.

Every arm was written **red first** and confirmed failing before the fix, each paired with a non-vacuity control on a single differing declaration:

| AC | red-proof | control that stops a lazy fix |
|---|---|---|
| 3 | `STILL_OPEN` under a non-COMMENT Status accepted; fully-dispositioned under Request Changes accepted | coherent bodies stay accepted — else "refuse every Round 2" passes |
| 2 | — | a body tripping BOTH layers returns the **silent** one, so the named message cannot become a side channel revealing an unnamed anchor |
| 6 | unparseable cell reported as `dispositions 0 action(s)` | a genuinely short table still reports its count — else "delete the count" passes |
| 5 | update refusal names three abstract categories; `create` never surfaces the tail | the guard still refuses and still never reaches the mutation |
| 7 | quote differing only in emphasis told merely to "carry it verbatim" | a genuinely reworded action is **not** excused as formatting |
| 1 (round 2) | a Round 2 with **no Status at all** returned `valid: true` | three paired controls, one accepted shape per legal value |

**The hole review found, and it is the sharpest thing in this PR.** My first revision deferred a missing `**Status:**` to the structural anchor layer — *in a code comment, without checking that the anchor layer refuses it.* It does not. A Round 2 with no Status validated clean, so the coherence rule silently did not apply to the body that most needed it. @neo-gpt's exact-head red proof reproduced on first run. That is a refusal-layer claiming something it had not established, committed inside the fix for exactly that defect class.

Two of those controls earned their keep during authoring. The ordering guard's first version *renamed* a heading instead of removing it — and the presence check reads the rename as still present, because the original is a substring, so it proved nothing until corrected. And the `create` arm initially failed on its own first assertion, because a minimal mock never drives the budget path at all.

**Pre-existing failures, verified not mine.** `test/playwright/unit/ai/mcp` fails 1 on this branch and **4 on clean `origin/dev`** at the same directory scope — strictly better, not worse. The one remaining (`OpenApiServiceParityEndToEnd.spec.mjs:388`) passes in isolation on **both** trees, which is a cross-file ordering interaction rather than flakiness; I have flagged it separately rather than retrying it away. `McpServersHealth.spec.mjs:34` fails on clean dev with no local changes and is environmental to this host — a live neural-link MCP server is attached to the seat.

Evidence: L2 (unit, production code paths, no stub) → L2 required (no runtime/deployed surface ships). No residual.

## Post-Merge Validation

None gating. One operational note rather than an obligation: the OpenAPI description change reaches agents only when the github-workflow MCP server next reloads, so the corrected shape-only wording lands on the normal server-restart cadence rather than at merge.

Authored by Grace (Claude Opus 5, Claude Code). Session 752da6ac-a6c3-447f-8847-1da4ce49deb8.
