### PR TITLE
fix(build): pin gray-matter onto the patched js-yaml 3.x line (#17461)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -32,7 +32,7 @@
                 "html-minifier-terser": "^7.2.0",
                 "husky": "^9.1.7",
                 "inquirer": "^13.4.3",
-                "js-yaml": "^5.2.0",
+                "js-yaml": "^5.2.3",
                 "jsdoc-api": "^9.3.6",
                 "lint-staged": "^17.0.8",
                 "marked": "^18.0.5",
@@ -5266,9 +5266,9 @@
             }
         },
         "node_modules/gray-matter/node_modules/js-yaml": {
-            "version": "3.15.0",
-            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.0.tgz",
-            "integrity": "sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==",
+            "version": "3.15.1",
+            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.1.tgz",
+            "integrity": "sha512-S99WuO3HlhO3XN41EtYUNl9zzXjoJx7QvmipxsJVxtCBT0YHEFy+iOJhjSvrmV12nYhWpZaM8lPHkJm0yUMbag==",
             "dev": true,
             "license": "MIT",
             "dependencies": {

--- a/package.json
+++ b/package.json
@@ -224,7 +224,7 @@
         "html-minifier-terser"         : "^7.2.0",
         "husky"                        : "^9.1.7",
         "inquirer"                     : "^13.4.3",
-        "js-yaml"                      : "^5.2.0",
+        "js-yaml"                      : "^5.2.3",
         "jsdoc-api"                    : "^9.3.6",
         "lint-staged"                  : "^17.0.8",
         "marked"                       : "^18.0.5",
@@ -242,6 +242,11 @@
         "webpack-hook-plugin"          : "^1.0.7",
         "ws"                           : "^8.21.0",
         "zod"                          : "^4.4.3"
+    },
+    "overrides": {
+        "gray-matter": {
+            "js-yaml": "^3.15.1"
+        }
     },
     "funding": {
         "type": "GitHub Sponsors",


### PR DESCRIPTION
Resolves #17461

Dependabot **221** (`GHSA-5p4m-2wfm-xmqj`, high, dev-scope): quadratic CPU consumption in js-yaml `!!omap` resolution. @tobiu asked the obvious question first — *"can we upgrade to the latest version?"* — and the answer is no, twice over.

Evidence: L2 required → **L2 achieved, no residual** (dependency tree + lockfile measured before and after; 123 arms covering every `gray-matter` consumer). Dependabot's next scan is a **non-gating** post-merge observation, not an unmet acceptance item — see below.

## Deltas from ticket

**A second defect surfaced during review that the ticket did not have.** @tobiu: *"`^5.2.0` → 5.2.3 is NOT enough. that has to be `^5.2.3`."*

He is right, and I had made the classic mistake: I read the **resolved** version (5.2.3, safe) and never questioned the **declared range**. `^5.2.0`'s floor is 5.2.0, and 5.x is only fixed from **5.2.1** — so a fresh resolve, a lockfile-less install, or any future dedupe could legitimately land on an affected version while the alert looked handled. The lock was masking a vulnerable constraint. Raised to `^5.2.3`.

## Why "upgrade to latest" does not work

| path | why not |
|---|---|
| upgrade `js-yaml` | already the safe major here; the flagged copy is not ours |
| upgrade `gray-matter` | **4.0.3 IS latest** — unmaintained, still pins `^3.13.1` |
| override to 5.x | **breaks `gray-matter`** — `lib/engines.js:16-17` binds `yaml.safeLoad`/`safeDump`, removed after 3.x |

The flagged copy is transitive:

```
+-- js-yaml@5.2.3          <- ours
+-- gray-matter@4.0.3
|   `-- js-yaml@3.15.0     <- the alert
```

## The advisory metadata is wrong for 3.x, and the code settles it

The summary says *"3.x and 4.x — fix not backported"*, while Dependabot reports `first_patched_version: 3.15.1`. Unpacking 3.15.1 shows the backport is real:

```js
// 3.15.0 — linear scan inside the pair loop
if (objectKeys.indexOf(pairKey) !== -1) return false;

// 3.15.1 — O(1) property probe
if (_hasOwnProperty.call(objectKeys, pairKey)) return false;
Object.defineProperty(objectKeys, pairKey, { value: true });
```

Different mechanism from 5.x's `Set`, same quadratic elimination — and `safeLoad`/`safeDump` survive at `lib/js-yaml.js:24,27`, verified by parsing with it rather than by reading the changelog.

## Test Evidence

**123 arms green** — every `gray-matter` consumer (`IssueSyncer`, `PullRequestSyncer`, `DiscussionSyncer`, `verifyFrontmatterIntegrity`) plus the frontmatter parsers. Tree measured after a real install, not from the lock alone:

```
+-- js-yaml@5.2.3
| `-- js-yaml@3.15.1
```

**The AC-2 control matters here:** asserting only that 3.15.0 is gone would also pass if the override had dragged the root onto 3.x — which is why the root staying `5.2.3` is asserted separately.

**Functional check:** `matter('---\ntitle: hello\nnum: 3\n---\n\nbody text')` parses to `{"title":"hello","num":3}` with the body intact, against `gray-matter/node_modules/js-yaml@3.15.1`.

**Exploitability today is nil, measured not assumed.** `gray-matter` only parses *front matter*. Two corpus files do contain `!!omap` — `pulls/chunk-10/pr-16608.md` and `pulls/chunk-5/pr-15627.md` — but at lines 85/93 and 28/32, **after** front-matter closes at 19 and 17. Body prose, never parsed.

**Reproduction note for anyone re-running this:** a plain `npm install` prunes the Brain tier (`install-brain` says so itself). I hit that mid-verification and the github-workflow specs silently skipped rather than failed. Re-run `npm run install-brain` before trusting a green.

## Post-Merge Validation

**Non-gating.** Dependabot alert 221 should close on GitHub's next scan of `dev`. This is deliberately *not* an acceptance criterion and carries no residual owner, because **the alert is its own watcher**: it stays open while the dependency graph shows a vulnerable version and re-opens if one returns. Assigning a person or a ticket to watch it would add a second, worse observer of a fact the platform already tracks continuously — and since the `Resolves` above retires the owning ticket on merge, that observer would be left holding a box nobody reads.

If it does *not* close, that is a fresh finding about the fix — the two changes here are independently verifiable at L2 without it, and a scan we have not seen was never evidence for them.

`#17461`'s AC set is updated to match: the Dependabot line moved out of the checklist into the same non-gating note, and the shipped `^5.2.3` floor raise is now folded into its Fix, Contract Ledger, and ACs — including the arm that would have silently passed on the old range, since both ranges resolve to the same version.

## Evolution

**A safe resolved version can sit behind a vulnerable declared range**, and the lockfile hides it. `npm ls` answers "what is installed"; only the manifest answers "what may be installed next". When an advisory names a floor, check the range, not the resolution.

Authored by Ada (Claude Opus 5, Claude Code). Session ab15d2b8-eb14-4237-ad18-ce48584b2d07.

