### PR TITLE
docs(agentos): a missing core MCP tool is degradation, not an empty inbox (#17442)

### DIFF
--- a/.agents/skills/self-repair/references/self-repair-protocol.md
+++ b/.agents/skills/self-repair/references/self-repair-protocol.md
@@ -2,6 +2,26 @@
 
 When tasked with executing a system healthcheck, diagnosing a corrupted state, or restoring infrastructure communication (e.g., failed handoffs), you MUST execute this chronological protocol.
 
+## Phase 0: Classify the failure — attachment, service, or authority
+
+**A health probe cannot see an attachment failure, because the probe is green during one.** The
+2026-08-20 incident ran ~12 hours with a repo-local client reporting 13 KB + 42 MC tools while the
+seat's own callable registry had **none** — 159 tools against 214 after repair. Classify before
+treating; Phase 1's surface table assumes the seat is attached at all.
+
+| native tools | repo-local client | runtime authority | lane |
+|---|---|---|---|
+| **absent** | green | any | **attachment/config** — the servers are fine, the seat is not attached to them. Restarting containers repairs nothing and severs other seats. |
+| any | **red** | local Docker | **service** — Phase 1 below |
+| any | **red** | none (cloud) | inspect what is reachable, then **escalate** — you cannot restart what you cannot reach |
+
+**Absence of a tool is never absence of data.** A missing `list_messages` is not an empty inbox; a
+missing `ask_knowledge_base` is not an absent answer. Reading either as a *result* is how a seat runs
+for hours on a channel nobody is reading — the failure this phase exists to stop.
+
+**Escalation must not assume the broken channel.** When Memory Core is the degraded surface, A2A is
+down with it: record the planned action and the unavailable channel on the governing ticket instead.
+
 ## Phase 1: Infrastructure Verification & Playwright Testing
 
 0. **Identify the surface FIRST** — one symptom, two remedies; the wrong restart wastes the outage. Authority: the service list in `ai/deploy/docker-compose.yml`.

--- a/.codex/hooks.json
+++ b/.codex/hooks.json
@@ -1,5 +1,18 @@
 {
   "hooks": {
+    "SessionStart": [
+      {
+        "matcher": "startup|resume|compact",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "/usr/bin/env node \"$(git rev-parse --show-toplevel)/.codex/hooks/codex-context.mjs\" --session-start",
+            "timeout": 10,
+            "statusMessage": "Core preflight"
+          }
+        ]
+      }
+    ],
     "UserPromptSubmit": [
       {
         "hooks": [

--- a/.codex/hooks/codex-context.mjs
+++ b/.codex/hooks/codex-context.mjs
@@ -221,7 +221,30 @@ export function readCodexContext() {
     return readFileSync(contextUrl, 'utf8').trim();
 }
 
-async function main() {
+/**
+ * @summary The one bounded sentence a lifecycle reset re-injects.
+ *
+ * `SessionStart` fires on startup, resume and compact — the three moments a seat can lose the fact
+ * that its institutional tools never attached. A repo-local probe cannot certify attachment (it was
+ * green throughout the 2026-08-20 incident), so this is a reminder, not a health oracle.
+ * @type {String}
+ */
+export const CORE_PREFLIGHT = 'Core preflight: call `list_messages({status:\'unread\'})` now. Missing or erroring is degradation, not an empty inbox — run `/self-repair` before resuming the lane.';
+
+async function main({sessionStart = false} = {}) {
+    // SessionStart carries no operator prompt and opens no turn. Minting a turn-presence interval
+    // here would fabricate liveness for a seat that has not acted, and writing prompt provenance
+    // would attribute the reset itself as a prompt.
+    if (sessionStart) {
+        const bootContext = readCodexContext();
+
+        process.stdout.write(`${CORE_PREFLIGHT}\n`);
+        if (bootContext) {
+            process.stdout.write(`${bootContext}\n`);
+        }
+        return;
+    }
+
     let hookPayload = '';
     try {
         const rawPayload = await readHookPayload();
@@ -246,5 +269,8 @@ async function main() {
 }
 
 if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
-    await main();
+    // An explicit flag rather than payload sniffing: the two registrations share one command string,
+    // and the SessionStart payload shape is harness-owned, so a flag is the only self-evidencing
+    // discriminator this module can assert about in a unit spec.
+    await main({sessionStart: process.argv.includes('--session-start')});
 }

--- a/.codex/hooks/codex-context.mjs
+++ b/.codex/hooks/codex-context.mjs
@@ -229,19 +229,27 @@ export function readCodexContext() {
  * green throughout the 2026-08-20 incident), so this is a reminder, not a health oracle.
  * @type {String}
  */
-export const CORE_PREFLIGHT = 'Core preflight: call `list_messages({status:\'unread\'})` now. Missing or erroring is degradation, not an empty inbox — run `/self-repair` before resuming the lane.';
+const CORE_PREFLIGHT = 'Core preflight: call `list_messages({status:\'unread\'})` now. Missing or erroring is degradation, not an empty inbox — run `/self-repair` before resuming the lane.';
 
+/**
+ * @summary Hook entry. Two paths: a lifecycle reset re-injects one sentence, an operator prompt
+ * opens a turn.
+ *
+ * The reset path mints no turn-presence interval — that would fabricate liveness for a seat which
+ * has not acted — and writes no prompt provenance, which would attribute the reset itself as a
+ * prompt.
+ *
+ * It emits the reminder ALONE, and both halves of that are deliberate. `UserPromptSubmit` injects
+ * the guard card on the very next prompt, so emitting it here bought one duplicate card per
+ * lifecycle reset and no earlier delivery. Reading that card FIRST was worse than redundant: it
+ * made the one sentence this path exists to deliver contingent on an unrelated file being present.
+ * @param {Object} [options]
+ * @param {Boolean} [options.sessionStart=false] Startup / resume / compact rather than a prompt.
+ * @returns {Promise<void>}
+ */
 async function main({sessionStart = false} = {}) {
-    // SessionStart carries no operator prompt and opens no turn. Minting a turn-presence interval
-    // here would fabricate liveness for a seat that has not acted, and writing prompt provenance
-    // would attribute the reset itself as a prompt.
     if (sessionStart) {
-        const bootContext = readCodexContext();
-
         process.stdout.write(`${CORE_PREFLIGHT}\n`);
-        if (bootContext) {
-            process.stdout.write(`${bootContext}\n`);
-        }
         return;
     }
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -165,7 +165,7 @@ Before asking the human:
 ## §mailbox_check_protocol
 At turn start you MUST call `list_messages({status:'unread'})` and state the count. **Missing/erroring ≠ empty inbox — that is degradation: `/self-repair` before resuming the lane.**
 
-**Lead-role baton intake:** an unread `lead-role-baton` ⇒ `/lead-role` immediately, unless the operator's current-turn instruction overrides. Constraints: §lead_role_baton_intake.
+**Lead-role baton intake:** a **valid targeted** unread `lead-role-baton` ⇒ `/lead-role` immediately, unless the operator's current-turn instruction overrides; broadcast/stale/malformed never authorizes self-election. Constraints: §lead_role_baton_intake.
 
 **Post-lifecycle-event trigger:** After ANY discrete lifecycle event (PR review post, author response, implementation completion, PR open/update, ticket create, blocked-state resolution), invoke `/post-review-pickup` to declare the next `lane-state:` rather than silently ending the turn (#11455).
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -163,15 +163,13 @@ Before asking the human:
 </neo_core_overrides>
 
 ## §mailbox_check_protocol
-At turn start, you MUST check your A2A mailbox for unread messages.
-> *"Pre-Flight: I called `list_messages({status: 'unread'})` and observed [N unread]."*
+At turn start you MUST call `list_messages({status:'unread'})` and state the count. **Missing/erroring ≠ empty inbox — that is degradation: `/self-repair` before resuming the lane.**
 
-**Lead-role baton intake:** If the unread mailbox contains a targeted message tagged `lead-role-baton`, invoke `/lead-role` immediately unless the human operator's current-turn instruction overrides it. Validation and failure constraints mapped to §lead_role_baton_intake.
+**Lead-role baton intake:** an unread `lead-role-baton` ⇒ `/lead-role` immediately, unless the operator's current-turn instruction overrides. Constraints: §lead_role_baton_intake.
 
 **Post-lifecycle-event trigger:** After ANY discrete lifecycle event (PR review post, author response, implementation completion, PR open/update, ticket create, blocked-state resolution), invoke `/post-review-pickup` to declare the next `lane-state:` rather than silently ending the turn (#11455).
 
-**Skill Adherence Pre-Flight (per-turn):**
-Before triggering a lifecycle skill, state in your reasoning: *"I will read the full SKILL.md and its referenced payload before drafting output."* Half-reading is empirically 3–5× costlier across correction cycles.
+**Skill Adherence Pre-Flight (per-turn):** before triggering a lifecycle skill, state that you will read the full SKILL.md **and** its referenced payload first. Half-reading is 3–5× costlier across correction cycles.
 
 ## §edge_case_triggers
 *(Sections mapped to `learn/agentos/AGENTS_ATLAS.md`)*

--- a/test/playwright/unit/hooks/codexContextHook.spec.mjs
+++ b/test/playwright/unit/hooks/codexContextHook.spec.mjs
@@ -16,6 +16,50 @@ import {
 } from '../../../../.codex/hooks/codex-context.mjs';
 import {recordClaudeTurnPresence} from '../../../../.claude/hooks/turnPresenceHook.mjs';
 
+const CODEX_HOOK = fileURLToPath(new URL('../../../../.codex/hooks/codex-context.mjs', import.meta.url));
+
+/**
+ * @summary Runs the Codex hook in a child that inherits no institutional authority.
+ *
+ * Filesystem isolation is not state isolation: the prompt path calls `recordTurnStarted`, so an
+ * inherited `NEO_AGENT_IDENTITY` plus a configured plane base lets a unit run write a real
+ * turn-presence interval onto a maintainer's live deployment. The child therefore gets an
+ * ALLOWLIST rather than `process.env` minus the known keys — a blocklist silently readmits the
+ * next authority variable anyone adds. `process.execPath` keeps the child on the runtime under
+ * test rather than whichever `node` the PATH happens to resolve.
+ * @param {Object} [options]
+ * @param {String[]} [options.args=[]] Hook arguments.
+ * @param {String|null} [options.daemonDir=null] Value for `NEO_AI_DAEMON_DIR`.
+ * @param {String} [options.input=''] stdin payload.
+ * @returns {String} The child's stdout.
+ */
+function runCodexHook({args = [], daemonDir = null, input = ''} = {}) {
+    return execFileSync(process.execPath, [CODEX_HOOK, ...args], {
+        encoding: 'utf8',
+        env     : {
+            HOME: os.tmpdir(),
+            PATH: process.env.PATH,
+            ...(daemonDir ? {NEO_AI_DAEMON_DIR: daemonDir} : {})
+        },
+        input
+    })
+}
+
+/**
+ * @summary Runs `body` against a fresh daemon directory and removes it afterwards.
+ * @param {Function} body Receives the directory path.
+ * @returns {void}
+ */
+function withDaemonDir(body) {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'codex-hook-'));
+
+    try {
+        body(dir)
+    } finally {
+        fs.rmSync(dir, {force: true, recursive: true})
+    }
+}
+
 test.describe('codex-context hook - wake submit nonce', () => {
     test('keeps the injected Codex guard card compact and resident-neutral', () => {
         const context        = readCodexContext(),
@@ -39,9 +83,8 @@ test.describe('codex-context hook - wake submit nonce', () => {
         expect(context).not.toMatch(/A2A peers|Expected Codex identity|GitHub username/i);
     });
 
-    test('#17442: SessionStart emits the core preflight ahead of the guard card', () => {
-        const hook = fileURLToPath(new URL('../../../../.codex/hooks/codex-context.mjs', import.meta.url)),
-              out  = execFileSync('node', [hook, '--session-start'], {input: '{}', encoding: 'utf8'});
+    test('#17442: SessionStart emits the core preflight, and only that', () => {
+        const out = runCodexHook({args: ['--session-start'], input: '{}'});
 
         // The sentence must name the negative transition, not merely remind about the call — an
         // agent that reads "check your mailbox" and gets an error still needs to know that is
@@ -49,45 +92,44 @@ test.describe('codex-context hook - wake submit nonce', () => {
         expect(out).toContain("list_messages({status:'unread'})");
         expect(out).toMatch(/not an empty inbox/);
         expect(out).toMatch(/self-repair/);
-        expect(out.indexOf('Core preflight')).toBeLessThan(out.indexOf('# Codex Desktop Guard Card'));
+
+        // The guard card belongs to `UserPromptSubmit`, which injects it on the very next prompt.
+        // Emitting it here too bought one duplicate per lifecycle reset, and reading it FIRST made
+        // this sentence contingent on that file existing — so its absence is the assertion.
+        expect(out).not.toContain('# Codex Desktop Guard Card');
+        expect(out.trim().split('\n')).toHaveLength(1);
     });
 
     test('#17442: SessionStart mints NO turn-presence interval and writes NO prompt provenance', () => {
         // The load-bearing arm. SessionStart fires on startup/resume/compact — none of which is an
         // operator turn. Minting presence there fabricates liveness for a seat that has not acted.
-        const hook     = fileURLToPath(new URL('../../../../.codex/hooks/codex-context.mjs', import.meta.url)),
-              dir      = fs.mkdtempSync(path.join(os.tmpdir(), 'codex-session-start-')),
-              ctxPath  = getCodexPromptContextPath({env: {NEO_AI_DAEMON_DIR: dir}}),
-              sentinel = '__17442_untouched__';
+        withDaemonDir(dir => {
+            const ctxPath  = getCodexPromptContextPath({env: {NEO_AI_DAEMON_DIR: dir}}),
+                  sentinel = '__17442_untouched__';
 
-        fs.mkdirSync(path.dirname(ctxPath), {recursive: true});
-        fs.writeFileSync(ctxPath, sentinel, 'utf8');
+            fs.mkdirSync(path.dirname(ctxPath), {recursive: true});
+            fs.writeFileSync(ctxPath, sentinel, 'utf8');
 
-        execFileSync('node', [hook, '--session-start'], {
-            input   : JSON.stringify({prompt: 'ignored'}),
-            encoding: 'utf8',
-            env     : {...process.env, NEO_AI_DAEMON_DIR: dir}
+            runCodexHook({args: ['--session-start'], daemonDir: dir, input: JSON.stringify({prompt: 'ignored'})});
+
+            expect(fs.readFileSync(ctxPath, 'utf8')).toBe(sentinel);
         });
-
-        expect(fs.readFileSync(ctxPath, 'utf8')).toBe(sentinel);
     });
 
     test('#17442 CONTROL: without the flag the hook still takes the prompt path', () => {
-        // Without this pair, both arms above pass on a hook that has stopped working entirely.
-        const hook    = fileURLToPath(new URL('../../../../.codex/hooks/codex-context.mjs', import.meta.url)),
-              dir     = fs.mkdtempSync(path.join(os.tmpdir(), 'codex-session-control-')),
-              ctxPath = getCodexPromptContextPath({env: {NEO_AI_DAEMON_DIR: dir}});
+        // Without this pair, both arms above pass on a hook that has stopped working entirely. This
+        // is the arm that would REACH a live transport on an inherited environment, so it is also
+        // the one that proves `runCodexHook`'s allowlist is doing work.
+        withDaemonDir(dir => {
+            const ctxPath = getCodexPromptContextPath({env: {NEO_AI_DAEMON_DIR: dir}});
 
-        fs.mkdirSync(path.dirname(ctxPath), {recursive: true});
-        fs.writeFileSync(ctxPath, '__stale__', 'utf8');
+            fs.mkdirSync(path.dirname(ctxPath), {recursive: true});
+            fs.writeFileSync(ctxPath, '__stale__', 'utf8');
 
-        execFileSync('node', [hook], {
-            input   : JSON.stringify({prompt: 'a real operator prompt'}),
-            encoding: 'utf8',
-            env     : {...process.env, NEO_AI_DAEMON_DIR: dir}
+            runCodexHook({daemonDir: dir, input: JSON.stringify({prompt: 'a real operator prompt'})});
+
+            expect(fs.readFileSync(ctxPath, 'utf8')).not.toBe('__stale__');
         });
-
-        expect(fs.readFileSync(ctxPath, 'utf8')).not.toBe('__stale__');
     });
 
     test('extracts a wake-submit nonce from nested hook payload text', () => {

--- a/test/playwright/unit/hooks/codexContextHook.spec.mjs
+++ b/test/playwright/unit/hooks/codexContextHook.spec.mjs
@@ -3,6 +3,8 @@ import fs             from 'node:fs';
 import os             from 'node:os';
 import path           from 'node:path';
 
+import {execFileSync}  from 'node:child_process';
+import {fileURLToPath} from 'node:url';
 import {IDENTITIES} from '../../../../ai/graph/identityRoots.mjs';
 import {
     extractPromptingTextFromHookPayload,
@@ -35,6 +37,57 @@ test.describe('codex-context hook - wake submit nonce', () => {
         expect(context).not.toMatch(/\b(?:Claude|Gemini|GPT)[ -]?\d/i);
         expect(context).not.toMatch(/\/Users\//);
         expect(context).not.toMatch(/A2A peers|Expected Codex identity|GitHub username/i);
+    });
+
+    test('#17442: SessionStart emits the core preflight ahead of the guard card', () => {
+        const hook = fileURLToPath(new URL('../../../../.codex/hooks/codex-context.mjs', import.meta.url)),
+              out  = execFileSync('node', [hook, '--session-start'], {input: '{}', encoding: 'utf8'});
+
+        // The sentence must name the negative transition, not merely remind about the call — an
+        // agent that reads "check your mailbox" and gets an error still needs to know that is
+        // degradation rather than an empty inbox.
+        expect(out).toContain("list_messages({status:'unread'})");
+        expect(out).toMatch(/not an empty inbox/);
+        expect(out).toMatch(/self-repair/);
+        expect(out.indexOf('Core preflight')).toBeLessThan(out.indexOf('# Codex Desktop Guard Card'));
+    });
+
+    test('#17442: SessionStart mints NO turn-presence interval and writes NO prompt provenance', () => {
+        // The load-bearing arm. SessionStart fires on startup/resume/compact — none of which is an
+        // operator turn. Minting presence there fabricates liveness for a seat that has not acted.
+        const hook     = fileURLToPath(new URL('../../../../.codex/hooks/codex-context.mjs', import.meta.url)),
+              dir      = fs.mkdtempSync(path.join(os.tmpdir(), 'codex-session-start-')),
+              ctxPath  = getCodexPromptContextPath({env: {NEO_AI_DAEMON_DIR: dir}}),
+              sentinel = '__17442_untouched__';
+
+        fs.mkdirSync(path.dirname(ctxPath), {recursive: true});
+        fs.writeFileSync(ctxPath, sentinel, 'utf8');
+
+        execFileSync('node', [hook, '--session-start'], {
+            input   : JSON.stringify({prompt: 'ignored'}),
+            encoding: 'utf8',
+            env     : {...process.env, NEO_AI_DAEMON_DIR: dir}
+        });
+
+        expect(fs.readFileSync(ctxPath, 'utf8')).toBe(sentinel);
+    });
+
+    test('#17442 CONTROL: without the flag the hook still takes the prompt path', () => {
+        // Without this pair, both arms above pass on a hook that has stopped working entirely.
+        const hook    = fileURLToPath(new URL('../../../../.codex/hooks/codex-context.mjs', import.meta.url)),
+              dir     = fs.mkdtempSync(path.join(os.tmpdir(), 'codex-session-control-')),
+              ctxPath = getCodexPromptContextPath({env: {NEO_AI_DAEMON_DIR: dir}});
+
+        fs.mkdirSync(path.dirname(ctxPath), {recursive: true});
+        fs.writeFileSync(ctxPath, '__stale__', 'utf8');
+
+        execFileSync('node', [hook], {
+            input   : JSON.stringify({prompt: 'a real operator prompt'}),
+            encoding: 'utf8',
+            env     : {...process.env, NEO_AI_DAEMON_DIR: dir}
+        });
+
+        expect(fs.readFileSync(ctxPath, 'utf8')).not.toBe('__stale__');
     });
 
     test('extracts a wake-submit nonce from nested hook payload text', () => {


### PR DESCRIPTION
Resolves neomjs/neo#17442

Related: neomjs/neo#17476 — the live-fire `SessionStart` arm, routed out so it survives this PR's auto-close.

A seat ran roughly **twelve hours with zero native Memory Core and Knowledge Base tools** — 159 callable against 214 after repair — normalised it as a missing capability, and continued. Recurrent: two prior incidents on record. The rules named the positive path and never the negative transition, so **an unreachable mailbox read as an empty one**.

Evidence: L2 (11 hook arms + 542 substrate/hook arms green; both substrate lints; byte budget measured before and after) → L2 achieved. **Residual-Owner: neomjs/neo#17476** — the live-fire `SessionStart` arm, owned by a ticket rather than a person.

## Round 2 — Emmy's four Required Actions

All four were real. Two of them were defects I introduced, not scope disagreements.

**RA-1 — the baton admission boundary was lost in compression.** My line read *"an unread `lead-role-baton` ⇒ `/lead-role` immediately"*. `§lead_role_baton_intake` says a valid baton is a **targeted DM, never `AGENT:*`**, and that broadcast or malformed state does not authorize self-election. Compressed, the rule read as authorizing lead acquisition on a broadcast — **a self-election path in an always-loaded rule, which is the one compression that cannot be paid for in bytes.** `valid targeted` is back, with the negative stated inline rather than left to the pointer. `AGENTS.md` **24,279 → 24,355 / 24,576**, headroom 297 → **221**: the net reduction below shrinks from −101 to −25, still a reduction.

**RA-2 — the SessionStart branch emitted 1,433 characters where the ledger promised one bounded reminder.** Emmy's exact-head measurement was right; mine was a claim about intent, not output. Two separate faults in four lines:

```js
const bootContext = readCodexContext();   // ← throws if CODEX.md is absent
process.stdout.write(`${CORE_PREFLIGHT}\n`);
if (bootContext) { process.stdout.write(`${bootContext}\n`) }   // ← the duplicate
```

- Reading the card **first** made the one sentence this path exists to deliver contingent on an unrelated file existing. That is the same defect the ticket is about, re-created inside its own fix.
- `UserPromptSubmit` already injects the guard card on the very next prompt, so re-emitting it here bought a duplicate per lifecycle reset and **no earlier delivery**. It is removed rather than justified.

Measured: **1,433 → 164 characters**, one line. Falsifier run: with `.codex/CODEX.md` moved aside, `--session-start` still exits 0 and still emits the sentence. `CORE_PREFLIGHT` drops back to module-local — with no runtime consumer, exporting it only let the spec compare the hook against a constant imported from the hook, which cannot catch a wrong sentence. `main()` now carries a docblock for its two paths.

**RA-3 — the new arms inherited `process.env`, and that is not hypothetical here.**

```
$ env | grep -E '^NEO_AGENT_IDENTITY|^NEO_MCP_REMOTE_TOKEN'
NEO_MCP_REMOTE_TOKEN=<set>
NEO_AGENT_IDENTITY=<set>
```

Both are live in a maintainer shell, so the control arm — which takes the prompt path and calls `recordTurnStarted` — could have written a real turn-presence interval onto a real deployment from a unit run. **Filesystem isolation is not institutional-state isolation**, exactly as the review put it. The child now gets an **allowlist** (`HOME`, `PATH`, `NEO_AI_DAEMON_DIR`) rather than `process.env` minus the known keys, because a blocklist silently readmits the next authority variable anyone adds. Both temp dirs are removed in a `finally`, and the child runs on `process.execPath` rather than whichever `node` the PATH resolves.

**RA-4 — closure was overclaimed, and a named agent is not a residual owner.** Both concessions are Emmy's, and the second is a rule I have banked and still broke. See below.

## Closure and residual

The named-owner claim is gone; a person-shaped residual carries no lifecycle. **The live arm now belongs to neomjs/neo#17476**, and the `Resolves` above stands as normal.

I first tried to keep neomjs/neo#17442 open with `Refs` instead of minting a ticket, reasoning that the honest fix for overclaimed closure is not to close. `agent-pr-body-lint` rejected it — operator rule neomjs/neo#12367 requires `Resolves #N` on every agent PR body, and `Refs`/`Related` alone is draft-only. **That was a mechanism claim I did not run the gate on**, with the gate one CI job away. Emmy re-ran it and was right that the canonical branch was the only one available.

neomjs/neo#17476 is narrow on purpose. The claim under test is **not** "does Codex honour its documented `SessionStart` event" — that is the vendor's contract, not ours, and testing it would be unfalsifiable busywork. It is the `matcher` expression, which is the only one of our three registrations that has one:

```json
"SessionStart":     [{ "matcher": "startup|resume|compact", "hooks": [...] }],
"UserPromptSubmit": [{                                      "hooks": [...] }],
"Stop":             [{                                      "hooks": [...] }]
```

If the expression is honoured and wrong, the hook never fires — and that is **indistinguishable from no seat having resumed yet**. A signal whose absence reads as "not reached" is the same defect class this PR is about, which is why it needs a watcher rather than a note.

## Deltas from ticket

**The AGENTS.md change still net-SHRINKS the always-loaded file.** The ticket asked for byte-budget-neutral.

| | delta |
|---|---|
| mailbox trigger (the new negative path) | **+31** |
| baton admission boundary restored (RA-1) | **+76** |
| lead-role baton intake | **−91** |
| skill-adherence preflight | **−41** |
| **net** | **−25** |

Per ADR-0007 this is a `rewrite` disposition — same slot, higher density. **The two compressed rules are not mine**, so they are the part I most want reviewed for lost nuance; RA-1 is the evidence that concern was warranted.

**Placement decision — the five-step walk, since the turn-memory audit asked for it stated rather than implied.**

| load class | candidate | verdict |
|---|---|---|
| always-loaded (`AGENTS.md`) | the universal negative trigger | **yes** — it must fire before the first tool call of every turn, on every seat, so no conditional surface can carry it |
| conditionally-loaded skill payload | the attachment/service/authority classifier | **yes** — diagnostic depth is only wanted once self-repair fires |
| harness registration (`.codex/hooks.json`) | Codex lifecycle salience | **yes** — startup/resume/compact are the three moments a seat loses the fact, and only the harness knows when they happen |
| a new skill or router | — | **no** — nothing here needs a new entry point; three existing surfaces already own these three load classes |
| `AGENTS_STARTUP.md` workflow list | — | **no** — no new workflow |

Mechanical pre-flight run before authoring: `lint-skill-manifest` (rejected at +1373, see below), the `AGENTS.md` byte measurement before and after each edit, and `check-ticket-archaeology` on every changed file.

**Steps 3–5 branch on an explicit flag rather than the payload.** The ticket says reuse `codex-context.mjs`; both registrations share one command string, and the `SessionStart` payload shape is harness-owned. A flag is the only discriminator this module can *assert about in a unit spec* — payload sniffing would be untestable from any seat that is not Codex.

## The classifier, and why a health probe could not have caught this

`self-repair`'s Phase 1 opens by identifying the *server surface*. That assumes the seat is attached at all — and in this incident it was not, while every probe was green. New **Phase 0** separates the three states the protocol was conflating:

| native tools | repo-local client | authority | lane |
|---|---|---|---|
| **absent** | green | any | attachment/config — servers fine, seat not attached; restarting containers repairs nothing and severs other seats |
| any | **red** | local Docker | service — Phase 1 |
| any | **red** | none (cloud) | inspect what is reachable, then escalate |

Plus the rule the incident actually needed: **absence of a tool is never absence of data**, and **escalation must not assume the broken channel** — when Memory Core is the degraded surface, A2A is down with it.

## Substrate growth: justified, not waved

`lint-skill-manifest` correctly rejected the payload at **+1373** against a 250-byte budget. I looked for slack first and found none — it is a diagnostic runbook where every line is load-bearing, and compressing it to buy budget trades precision for bytes.

So the commit carries `[skill-growth-justified: …]` with a **retirement trigger**: compress to a pointer once a mechanical boot guard fails closed on zero native tools. Worth noting the growth is in a **conditionally-loaded** payload that only loads when self-repair fires, while the **always-loaded** file got smaller.

**Runtime-load audit (RA-2).** The turn-memory audit's second half is the one the first head failed, so it is stated as a measurement rather than a claim: SessionStart emitted `CORE_PREFLIGHT` **and** the full guard card, with `UserPromptSubmit` a second emitter of the same card. Now: SessionStart emits 164 characters, `UserPromptSubmit` is the sole guard-card emitter, and no path emits it twice.

## Test Evidence

**11 hook arms + 542 substrate/hook arms green.** Three new, and they are a set:

- SessionStart emits the preflight **and only that** — the assertion is now the guard card's *absence* and a single output line, which is what pins RA-2 against regression. Asserting only that it mentions `list_messages` would pass on a reminder that does not say a missing tool is degradation.
- SessionStart **mints no turn-presence interval and writes no prompt provenance** — the load-bearing arm.
- **CONTROL:** the unflagged path still takes the prompt branch. Without it the first two pass on a hook that has stopped working entirely — and it is also the arm that would reach a live transport on an inherited environment, so it is what proves the allowlist is doing work.

**An order-leakage bug I introduced and caught:** my first version of the two path-touching arms used the shared real context path. They **passed in isolation and failed in file order**. Both now isolate through `NEO_AI_DAEMON_DIR`, matching the pattern the file already used — which I should have followed rather than rediscovered.

## Post-Merge Validation

**Claude seats, immediately.** The `AGENTS.md` trigger is always-loaded, so the next turn on any seat carries it: the mailbox call is stated with its count, and a missing or erroring `list_messages` routes to `/self-repair` instead of being read as an empty inbox.

**Codex seats, on the next lifecycle reset — this is neomjs/neo#17476's arm.** On the first `startup` / `resume` / `compact`, the core preflight line should be the first thing in context:

> Core preflight: call `list_messages({status:'unread'})` now. Missing or erroring is degradation, not an empty inbox — run `/self-repair` before resuming the lane.

Report on neomjs/neo#17476 either way, naming which of the three sources you observed. If it is absent, the `matcher` key is dropped or corrected there — a one-line change to `.codex/hooks.json`.

## Evolution

The generalisable failure is **reading the absence of an instrument as a reading from it** — a missing `list_messages` as an empty inbox. That is the same shape as a probe that cannot produce its own falsifier, and it is why the classifier leads with *why a green probe proves nothing here*.

Round 2 added a second one, from RA-2: **a claim about intent is not a measurement of output.** I wrote "one bounded preflight" describing what the code was *for*; Emmy ran it and counted 1,433 characters. The PR body and the process are the same instrument — both need the tool run, not the reasoning.

Authored by Ada (Claude Opus 5, Claude Code). Session ab15d2b8-eb14-4237-ad18-ce48584b2d07.
