### PR TITLE
feat(memory-core): the mark_read drain sweeps only mail the agent has been shown (#17321)

### DIFF
--- a/ai/mcp/server/memory-core/openapi.yaml
+++ b/ai/mcp/server/memory-core/openapi.yaml
@@ -2354,7 +2354,9 @@ paths:
       x-pass-as-object: true
       x-neo-tool-summary: Mark selected or all current unread A2A messages read.
       description: |
-        Marks selected messages or the caller's entire current unread inbox snapshot as read. Pass exactly one of `messageId` (a string or array) and `all: true`. Array mode returns per-id results and one stale or unauthorized id never fails the batch. All mode snapshots every currently unread, unarchived message before mutation; messages arriving after snapshot capture remain unread.
+        Marks selected messages or the caller's entire current unread inbox snapshot as read. Pass exactly one of `messageId` (a string or array) and `all: true`. Array mode returns per-id results and one stale or unauthorized id never fails the batch.
+
+        All mode sweeps only messages you have actually been SHOWN — those returned by one of your own `list_messages` calls. Mail that arrived since your last listing stays unread, which is what keeps a directed message findable after it scrolls out of a turn. The usual flow is unchanged and still two calls: list the backlog, then `all: true` clears every listed message at once, with no paging. The receipt's `withheldUnseenCount` reports how many unseen messages were left behind, so a narrower drain is never silent.
       tags: [Mailbox]
       requestBody:
         required: true
@@ -2371,7 +2373,11 @@ paths:
                       items: {type: string}
                 all:
                   type: boolean
-                  description: Set true instead of messageId to mark the current unread, unarchived snapshot.
+                  description: Set true instead of messageId to mark the current unread, unarchived snapshot you have been shown.
+                includeUnseen:
+                  type: boolean
+                  default: false
+                  description: Used with `all`, also sweeps messages you have never been shown. For clearing an accumulated backlog you do not intend to read; it can discard a directed message you have never seen.
       responses:
         '200':
           description: OK

--- a/ai/services/memory-core/MailboxService.mjs
+++ b/ai/services/memory-core/MailboxService.mjs
@@ -2045,6 +2045,47 @@ async function setMessageNodeReadAt(node, readAt) {
 }
 
 /**
+ * Stamps the SEEN timestamp on a direct-DM `MESSAGE` node.
+ *
+ * `seenAt` is the state between *arrived* and *explicitly marked read*, and it is what lets a bulk
+ * drain be discriminating: without it, `all: true` can only mean "every unread message that
+ * exists", when the safe meaning is "every unread message I have actually been shown".
+ *
+ * Write-once by design. A later listing of the same message must not move the stamp — the value
+ * records first surfacing, and re-stamping would make it a last-listed timestamp instead, which
+ * answers a question nothing asks.
+ *
+ * @param {Object} node Direct-DM `MESSAGE` node.
+ * @param {String} seenAt ISO timestamp.
+ * @returns {Promise<Boolean>} `true` when the mutation reached durable storage.
+ */
+async function setMessageNodeSeenAt(node, seenAt) {
+    getRecordProperties(node).seenAt = seenAt;
+
+    return persistReceiptNode(node);
+}
+
+/**
+ * Stamps the SEEN timestamp on a per-recipient `DELIVERED_TO` edge.
+ *
+ * Broadcasts carry per-recipient read state on the edge rather than the node, so `seenAt` follows
+ * `readAt` to exactly the same place. Putting it on the node instead would make one recipient's
+ * listing mark the broadcast seen for the entire audience.
+ *
+ * @param {Object} edge Per-recipient `DELIVERED_TO` edge.
+ * @param {String} seenAt ISO timestamp.
+ * @returns {Promise<Boolean>} `true` when the mutation reached durable storage.
+ */
+async function setDeliveryEdgeSeenAt(edge, seenAt) {
+    setRecordProperties(edge, {
+        ...getRecordProperties(edge),
+        seenAt
+    });
+
+    return persistReceiptEdge(edge);
+}
+
+/**
  * Sets the archive timestamp on a per-recipient DELIVERED_TO edge for broadcast
  * messages. Mirrors `setDeliveryEdgeReadAt` exactly — both delegate to
  * `persistReceiptEdge`, so broadcast archive state participates in the same durability
@@ -3209,6 +3250,11 @@ class MailboxService extends Base {
         messages = messages.slice(appliedOffset, appliedOffset + appliedLimit);
         await this.attachRelatedPullRequestStates(messages);
 
+        // Stamped AFTER the slice, because only these rows were actually surfaced. Stamping the
+        // pre-slice set would mark a caller as having seen pages it never received — the same
+        // over-reach, one layer up, that this whole change exists to remove.
+        await this._stampSeenForOwner({messages, box, target, me});
+
         // `truncated` states whether rows remain BEYOND this page, which is deliberately not the
         // `messages.length === limit` heuristic it replaces: a full page that exactly exhausts the
         // filter has nothing after it. Reporting `true` there would be a false positive AND would
@@ -3227,6 +3273,73 @@ class MailboxService extends Base {
             limit             : appliedLimit,
             offset            : appliedOffset
         };
+    }
+
+    /**
+     * @summary Stamps `seenAt` on inbox rows this call surfaced to their OWN recipient.
+     *
+     * A write on a read path, declared here because that is unusual enough to be worth stating: the
+     * act of showing a message to its recipient is the event `seenAt` records, so the read IS the
+     * write.
+     *
+     * **The guard is mailbox OWNERSHIP, not the presence of a bound identity**, and that distinction
+     * is the whole safety argument. `listMessages` is caller-identity-scoped, but non-agent surfaces
+     * legitimately read OTHER agents' inboxes through it under a permission grant —
+     * `SwarmHeartbeatService` sweeps every identity's mailbox on each pass, and the diagnostics
+     * script reads `{to: 'AGENT:*'}`. Keying on "an identity is bound" would let a daemon mark the
+     * entire swarm's mail as seen, which is strictly worse than the defect being repaired.
+     *
+     * Outbox rows never stamp: a message you sent was never surfaced TO you.
+     *
+     * Failure is silent and safe in the correct direction. An unstamped message stays unseen, and an
+     * unseen message is never bulk-swept — so a persistence failure here costs a redundant listing,
+     * never a lost directed message.
+     *
+     * @param {Object} options
+     * @param {Object[]} options.messages The page actually returned to the caller.
+     * @param {String} options.box `inbox` | `outbox` | `all`.
+     * @param {String} options.target Normalized mailbox being read.
+     * @param {String} options.me Normalized bound caller identity.
+     * @returns {Promise<void>}
+     * @private
+     */
+    async _stampSeenForOwner({messages, box, target, me}) {
+        if (box === 'outbox' || !sameMailboxIdentity(target, me) || messages.length === 0) {
+            return
+        }
+
+        const
+            db     = GraphService.db,
+            seenAt = new Date().toISOString();
+
+        for (const message of messages) {
+            const {messageId} = message;
+
+            if (!messageId) continue;
+
+            try {
+                const deliveryEdge = getBroadcastDeliveryEdge(messageId, me);
+
+                // Broadcast: per-recipient edge, mirroring where `readAt` already lives.
+                if (deliveryEdge) {
+                    if (!getRecordProperties(deliveryEdge).seenAt) {
+                        await setDeliveryEdgeSeenAt(deliveryEdge, seenAt)
+                    }
+                    continue
+                }
+
+                // Directed: node-side, again mirroring `readAt`.
+                const node = db?.nodes?.get(messageId);
+
+                if (node && !getRecordProperties(node).seenAt) {
+                    await setMessageNodeSeenAt(node, seenAt)
+                }
+            } catch (error) {
+                // Never let a seen-stamp failure break a listing. The read is the caller's actual
+                // request; the stamp is bookkeeping, and its failure mode is already the safe one.
+                logger.warn(`[MailboxService] Could not stamp seenAt on ${messageId}: ${error.message}`)
+            }
+        }
     }
 
     /**
@@ -3494,13 +3607,19 @@ class MailboxService extends Base {
      *   `{durable: false, warning}` when storage is absent); array form: `{results: [...]}`;
      *   all form: compact aggregate counts plus exceptional rows.
      */
-    async markRead({messageId, all = false} = {}) {
+    async markRead({messageId, all = false, includeUnseen = false} = {}) {
+        // Validated with the same boolean strictness `all` already uses, and BEFORE the `all` branch,
+        // so a caller who fat-fingers the widening flag is told rather than silently given the narrow
+        // drain they were trying to opt out of.
+        if (includeUnseen !== true && includeUnseen !== false) {
+            throw new TypeError('mark_read includeUnseen must be a boolean.');
+        }
         if (all === true) {
             if (messageId !== undefined) {
                 throw new TypeError('mark_read accepts either messageId or all: true, not both.');
             }
 
-            return this._markUnreadSnapshotRead();
+            return this._markUnreadSnapshotRead({includeUnseen});
         }
         if (all !== false) {
             throw new TypeError('mark_read all must be a boolean.');
@@ -3643,7 +3762,7 @@ class MailboxService extends Base {
      * @returns {Promise<Object>} Aggregate snapshot receipt with matched/read/durable/failure counts.
      * @private
      */
-    async _markUnreadSnapshotRead() {
+    async _markUnreadSnapshotRead({includeUnseen = false} = {}) {
         const boundIdentity = RequestContextService.getAgentIdentityNodeId();
         if (!boundIdentity) {
             throw RequestContextService.unboundIdentityError('mark all messages read');
@@ -3670,6 +3789,15 @@ class MailboxService extends Base {
         const
             placeholders = targetStorageVariants.map(() => '?').join(', '),
             snapshotAt   = new Date().toISOString(),
+            // The predicate that makes a bulk drain discriminating. Each arm tests `seenAt` in the
+            // SAME place its own `readAt` lives — node-side for directed mail, edge-side for
+            // per-recipient broadcast delivery — so the two states can never disagree about which
+            // recipient they describe.
+            //
+            // `includeUnseen` widens both arms back to today's exact set for the genuine
+            // been-away-a-week case. Interpolated rather than bound because it selects a clause, not
+            // a value, and both branches are literals in this file.
+            seenClause   = includeUnseen ? '' : "AND json_extract(%SOURCE%.data, '$.properties.seenAt') IS NOT NULL",
             rows         = sqlite.prepare(`
                 WITH unread_messages AS (
                     SELECT n.id AS messageId
@@ -3680,6 +3808,7 @@ class MailboxService extends Base {
                       AND json_extract(n.data, '$.label') = 'MESSAGE'
                       AND json_extract(n.data, '$.properties.readAt') IS NULL
                       AND json_extract(n.data, '$.properties.archivedAt') IS NULL
+                      ${seenClause.replace('%SOURCE%', 'n')}
 
                     UNION
 
@@ -3691,6 +3820,7 @@ class MailboxService extends Base {
                       AND json_extract(n.data, '$.label') = 'MESSAGE'
                       AND json_extract(e.data, '$.properties.readAt') IS NULL
                       AND json_extract(e.data, '$.properties.archivedAt') IS NULL
+                      ${seenClause.replace('%SOURCE%', 'e')}
                 )
                 SELECT DISTINCT messageId
                 FROM unread_messages
@@ -3714,6 +3844,36 @@ class MailboxService extends Base {
                     ? 'read'
                     : 'partial';
 
+        // A narrower drain that says nothing reads exactly like "everything cleared", which is the
+        // failure this whole change exists to remove — one level up. Counted only on the default
+        // path, because with `includeUnseen` nothing is withheld by construction.
+        const withheldUnseenCount = includeUnseen ? 0 : sqlite.prepare(`
+            WITH unseen_unread AS (
+                SELECT n.id AS messageId
+                FROM Edges e
+                JOIN Nodes n ON n.id = e.source
+                WHERE e.type = 'SENT_TO'
+                  AND e.target IN (${placeholders})
+                  AND json_extract(n.data, '$.label') = 'MESSAGE'
+                  AND json_extract(n.data, '$.properties.readAt') IS NULL
+                  AND json_extract(n.data, '$.properties.archivedAt') IS NULL
+                  AND json_extract(n.data, '$.properties.seenAt') IS NULL
+
+                UNION
+
+                SELECT n.id AS messageId
+                FROM Edges e
+                JOIN Nodes n ON n.id = e.source
+                WHERE e.type = 'DELIVERED_TO'
+                  AND e.target IN (${placeholders})
+                  AND json_extract(n.data, '$.label') = 'MESSAGE'
+                  AND json_extract(e.data, '$.properties.readAt') IS NULL
+                  AND json_extract(e.data, '$.properties.archivedAt') IS NULL
+                  AND json_extract(e.data, '$.properties.seenAt') IS NULL
+            )
+            SELECT COUNT(DISTINCT messageId) AS count FROM unseen_unread
+        `).get(...targetStorageVariants, ...targetStorageVariants)?.count ?? 0;
+
         return {
             status,
             snapshotAt,
@@ -3722,6 +3882,7 @@ class MailboxService extends Base {
             durableCount,
             failureCount   : failures.length,
             nonDurableCount: nonDurable.length,
+            withheldUnseenCount,
             failures,
             nonDurable
         };

--- a/test/playwright/unit/ai/services/memory-core/MailboxService.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/MailboxService.spec.mjs
@@ -2088,6 +2088,16 @@ test.describe('Neo.ai.services.memory-core.MailboxService', () => {
             MailboxService.archiveMessage({messageId: archivedId})
         );
 
+        // The drain sweeps only mail the agent has been SHOWN, so this listing is the
+        // precondition the flow always had in practice — an agent cannot triage what it has not
+        // listed. Added rather than switching to `includeUnseen: true`, because this test's subject
+        // is carrier ownership under a bulk drain (bob's delivery edge marked, charlie's untouched),
+        // and that property must keep being asserted on the DEFAULT path rather than only on the
+        // widened one. Every assertion below is unchanged.
+        await RequestContextService.run({agentIdentityNodeId: '@bob'}, () =>
+            MailboxService.listMessages({box: 'inbox', status: 'unread'})
+        );
+
         const receipt = await RequestContextService.run({agentIdentityNodeId: '@bob'}, () =>
             MailboxService.markRead({all: true})
         );
@@ -2147,13 +2157,24 @@ test.describe('Neo.ai.services.memory-core.MailboxService', () => {
         }
     });
 
-    test('#15913 markRead all mode drains beyond the list_messages 100-row page size', async () => {
+    /**
+     * This guarantee was relocated rather than removed. The subject here is that the drain is
+     * NOT capped at the 100-row list page — these 125 carriers are seeded straight into the graph and
+     * were never listed, so under the default drain they are unseen and correctly withheld. The
+     * uncapped-depth property now lives on the explicit widening flag, which is the path that still
+     * means "everything, listed or not".
+     *
+     * The default path keeps its own depth coverage: the motivating-case arm below lists 120
+     * messages and clears all of them in one call. So neither path lost the guarantee — it is
+     * asserted twice, once per meaning.
+     */
+    test('#15913 markRead all+includeUnseen drains beyond the list_messages 100-row page size', async () => {
         for (let index = 0; index < 125; index++) {
             seedReadStateCarrier({messageId: `MESSAGE:read-all-depth-${index}`});
         }
 
         const receipt = await RequestContextService.run({agentIdentityNodeId: '@bob'}, () =>
-            MailboxService.markRead({all: true})
+            MailboxService.markRead({all: true, includeUnseen: true})
         );
 
         expect(receipt).toMatchObject({
@@ -2182,6 +2203,15 @@ test.describe('Neo.ai.services.memory-core.MailboxService', () => {
                 ids.push(messageId);
             }
         });
+
+        // The three seeded messages must be SEEN before a default drain will sweep them.
+        // This test's subject — post-snapshot arrivals excluded, exceptional rows reported — is
+        // orthogonal to seen-state, so the listing is a precondition rather than a change of
+        // subject. It also strengthens the arm: the late arrival is now excluded for two
+        // independent reasons, and the assertions below still isolate the snapshot one.
+        await RequestContextService.run({agentIdentityNodeId: '@bob'}, () =>
+            MailboxService.listMessages({box: 'inbox', status: 'unread'})
+        );
 
         const originalMarkRead = MailboxService.markRead;
         let lateMessageId;
@@ -2313,8 +2343,11 @@ test.describe('Neo.ai.services.memory-core.MailboxService', () => {
 
         // A SwarmHeartbeatService-shaped read: a different identity, reading bob's mail through the
         // same method under a permission grant. This must not make bob's mail "seen".
-        await asBob(() => RequestContextService.run({agentIdentityNodeId: '@bob'}, () =>
-            PermissionService.grantPermission({to: '@charlie', scope: 'CAN_READ_INBOX_OF'})));
+        GraphService.upsertNode({
+            id: '@charlie', type: 'AgentIdentity', name: 'Charlie', properties: {accountType: 'agent'}
+        });
+
+        await asBob(() => PermissionService.grantPermission({to: '@charlie', scope: 'CAN_READ_INBOX_OF'}));
 
         await RequestContextService.run({agentIdentityNodeId: '@charlie'}, () =>
             MailboxService.listMessages({box: 'inbox', to: '@bob', status: 'all'}));
@@ -2332,6 +2365,43 @@ test.describe('Neo.ai.services.memory-core.MailboxService', () => {
         await asBob(() => MailboxService.markRead({all: true}));
 
         expect(await unreadOf(), 'an outbox read did not see the inbox').toContain(directed)
+    });
+
+    test('#17321 the receipt reports what it withheld, so a narrower drain is never silent', async () => {
+        const [seen] = await seedInbox(['listed']);
+        await asBob(() => MailboxService.listMessages({box: 'inbox', status: 'unread'}));
+        await seedInbox(['never listed one', 'never listed two']);
+
+        const receipt = await asBob(() => MailboxService.markRead({all: true}));
+
+        expect(receipt.readCount, 'the seen message cleared').toBe(1);
+        expect(receipt.withheldUnseenCount, 'and the two unseen are counted, not hidden').toBe(2);
+        expect(receipt.matchedCount).toBe(1);
+        expect(seen).toBeTruthy()
+    });
+
+    test('#17321 seenAt is stamped once and a later listing does not move it', async () => {
+        const [directed] = await seedInbox(['stamped once']);
+
+        await asBob(() => MailboxService.listMessages({box: 'inbox', status: 'unread'}));
+
+        expect(GraphService.db.nodes.get(directed).properties.seenAt, 'the first listing stamped it')
+            .toBeTruthy();
+
+        // Overwritten with a sentinel rather than waiting for the clock to tick. A sleep-based
+        // version would pass vacuously whenever both listings landed in the same millisecond —
+        // the assertion could not tell "not re-stamped" from "re-stamped identically".
+        const sentinel = '1999-12-31T23:59:59.000Z';
+
+        GraphService.db.nodes.get(directed).properties.seenAt = sentinel;
+
+        await asBob(() => MailboxService.listMessages({box: 'inbox', status: 'unread'}));
+
+        // `seenAt` records FIRST surfacing. Re-stamping would silently turn it into a last-listed
+        // timestamp, which answers a question nothing asks and would let a re-list revive a message
+        // the agent has already triaged past.
+        expect(GraphService.db.nodes.get(directed).properties.seenAt, 'a later listing left it alone')
+            .toBe(sentinel)
     });
 
     test('#17321 includeUnseen: true reproduces today\'s drain exactly — the widening fence', async () => {

--- a/test/playwright/unit/ai/services/memory-core/MailboxService.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/MailboxService.spec.mjs
@@ -2241,6 +2241,108 @@ test.describe('Neo.ai.services.memory-core.MailboxService', () => {
         );
     });
 
+    /**
+     * The drain has nothing to be discriminating WITH. Read state is two-valued — a message has
+     * either arrived or been explicitly marked read — so `all: true` can only mean "every unread
+     * message that exists", when the safe meaning is "every unread message I have actually seen".
+     * Three maintainers destroyed unread state with this call on one day; one of them lost a
+     * directed ruling for 100 minutes and spent them treating an unblocked lane as blocked.
+     *
+     * `seenAt` is the missing third state, stamped only when a message is surfaced to its OWN
+     * recipient. The stamp must key on mailbox OWNERSHIP rather than on the presence of a bound
+     * identity: the heartbeat daemon and the diagnostics script both read other agents' inboxes
+     * through the same method, and stamping there would let a daemon mark the whole swarm's mail
+     * as seen — strictly worse than the defect being fixed.
+     */
+    const seedInbox = async (subjects, sender = '@alice', recipient = '@bob') => {
+        await RequestContextService.run({agentIdentityNodeId: recipient}, async () => {
+            await PermissionService.grantPermission({to: sender, scope: 'CAN_REPLY_TO'});
+        });
+
+        return RequestContextService.run({agentIdentityNodeId: sender}, async () => {
+            const ids = [];
+
+            for (const subject of subjects) {
+                const {messageId} = await MailboxService.addMessage({to: recipient, subject, body: subject});
+                ids.push(messageId)
+            }
+
+            return ids
+        })
+    };
+
+    const asBob    = fn => RequestContextService.run({agentIdentityNodeId: '@bob'}, fn),
+          unreadOf = () => asBob(() => MailboxService.listMessages({box: 'inbox', status: 'unread'}))
+              .then(result => result.messages.map(message => message.messageId));
+
+    test('#17321 a message that arrived after the last listing survives the drain', async () => {
+        const [seen] = await seedInbox(['seen before the drain']);
+
+        // The agent lists — this is what makes `seen` seen.
+        await asBob(() => MailboxService.listMessages({box: 'inbox', status: 'unread'}));
+
+        // A directed message lands DURING triage. It was never surfaced to the agent.
+        const [late] = await seedInbox(['arrived mid-triage']);
+
+        await asBob(() => MailboxService.markRead({all: true}));
+
+        const stillUnread = await unreadOf();
+
+        expect(stillUnread, 'the unseen arrival is not swept').toContain(late);
+        // Asserted separately: a drain that simply stopped working would satisfy the line above.
+        expect(stillUnread, 'the message the agent actually saw IS swept').not.toContain(seen)
+    });
+
+    test('#17321 listing an aged backlog still clears it in ONE call — the motivating case', async () => {
+        // The case any fix must not break: back after a day, 100+ accumulated messages, cleared in
+        // one swipe with no paging ceremony. Clearing already begins by listing, so every one of
+        // them is genuinely seen.
+        const subjects = Array.from({length: 120}, (unused, index) => `aged ${index}`);
+        await seedInbox(subjects);
+
+        await asBob(() => MailboxService.listMessages({box: 'inbox', status: 'unread', limit: 200}));
+
+        const receipt = await asBob(() => MailboxService.markRead({all: true}));
+
+        expect(receipt.readCount, 'all 120 clear in a single call').toBe(120);
+        expect(await unreadOf()).toEqual([])
+    });
+
+    test('#17321 a foreign inbox read stamps nothing — the daemon must not see for the owner', async () => {
+        const [directed] = await seedInbox(['for bob only']);
+
+        // A SwarmHeartbeatService-shaped read: a different identity, reading bob's mail through the
+        // same method under a permission grant. This must not make bob's mail "seen".
+        await asBob(() => RequestContextService.run({agentIdentityNodeId: '@bob'}, () =>
+            PermissionService.grantPermission({to: '@charlie', scope: 'CAN_READ_INBOX_OF'})));
+
+        await RequestContextService.run({agentIdentityNodeId: '@charlie'}, () =>
+            MailboxService.listMessages({box: 'inbox', to: '@bob', status: 'all'}));
+
+        await asBob(() => MailboxService.markRead({all: true}));
+
+        expect(await unreadOf(), 'a foreign read did not see on bob\'s behalf').toContain(directed)
+    });
+
+    test('#17321 an outbox listing stamps nothing', async () => {
+        const [directed] = await seedInbox(['inbound to bob']);
+
+        // Bob lists his OUTBOX. Nothing inbound was surfaced, so nothing inbound becomes seen.
+        await asBob(() => MailboxService.listMessages({box: 'outbox', status: 'all'}));
+        await asBob(() => MailboxService.markRead({all: true}));
+
+        expect(await unreadOf(), 'an outbox read did not see the inbox').toContain(directed)
+    });
+
+    test('#17321 includeUnseen: true reproduces today\'s drain exactly — the widening fence', async () => {
+        const [never] = await seedInbox(['never listed']);
+
+        const receipt = await asBob(() => MailboxService.markRead({all: true, includeUnseen: true}));
+
+        expect(receipt.readCount, 'the escape hatch still clears everything').toBe(1);
+        expect(await unreadOf()).not.toContain(never)
+    });
+
     test('#15913 markRead all mode returns an explicit compact no-op and rejects ambiguous input', async () => {
         const {callTool} = await import('../../../../../../ai/mcp/server/memory-core/toolService.mjs');
         const receipt    = await RequestContextService.run({agentIdentityNodeId: '@bob'}, () =>


### PR DESCRIPTION
Resolves #17321

Related: #16748

🌿 *The mailbox could not tell a message you had looked at from one that merely arrived, so a bulk drain had nothing to be discriminating with.*

Evidence: L2 (unit, real graph projection through `MailboxService`, no stub) → L2 required (no runtime/deployed surface ships). No residual.

## What this changes

`mark_read({all: true})` swept every unread message that existed. Read state was two-valued — a message had either **arrived** or been **explicitly marked read** — so `all` could only mean "everything", when the safe meaning is "everything I have actually been shown".

Three maintainers destroyed unread state with that call on one day. Mine is the qualitative row in the ticket's table: I lost @neo-opus-vega's AC-3 ruling for 100 minutes and spent them treating a lane as blocked that the ruling had already unblocked.

`seenAt` is the missing third state. It is stamped when a message is surfaced to its **own recipient**, and the drain is bounded by it.

## The guard is mailbox OWNERSHIP, not a bound identity

This is the part that could have made things worse, and it is the arm I wrote first.

`listMessages` is caller-identity-scoped, but that binds the **caller**, not the **mailbox owner** — and non-agent surfaces legitimately read other agents' inboxes through it. `SwarmHeartbeatService.mjs:1133` sweeps every identity's mailbox on each pass; `defectObservations.mjs:87` reads `{to: 'AGENT:*'}`. Keying the stamp on "an identity is bound" would let the heartbeat daemon mark the **entire swarm's mail as seen** on its next pass, which is strictly worse than the defect being repaired.

So the predicate is `sameMailboxIdentity(target, me)`. Outbox rows never stamp — a message you sent was never surfaced *to* you.

Two further properties, both deliberate:

- **Write-once.** A later listing does not move the stamp. `seenAt` records first surfacing; re-stamping would silently make it a last-listed timestamp, which answers a question nothing asks and would let a re-list revive a message the agent had already triaged past.
- **Fails safe.** A stamp failure is caught and logged, never thrown. An unstamped message stays unseen, and an unseen message is never bulk-swept — so the failure costs a redundant listing, never a lost directed message.

Broadcasts stamp on the `DELIVERED_TO` edge and directed mail on the node, mirroring exactly where each arm's `readAt` already lives. Putting `seenAt` on the node for a broadcast would let one recipient's listing mark it seen for the whole audience.

## The motivating case still works, unchanged

Back after a day, 100+ accumulated messages, cleared in one swipe with no paging. Clearing already begins by listing — an agent cannot triage what it has not listed — so `list_messages({limit: 200})` then `mark_read({all: true})` clears all 200 in one call. What no longer clears is the message that arrived *after* that listing, which is exactly the message all three incidents lost.

`includeUnseen: true` reproduces today's behaviour exactly, for the genuine "away a week, clear everything" case. Default safe, escape hatch explicit, both one call. The receipt reports `withheldUnseenCount`, because a narrower drain that says nothing reads exactly like "everything cleared" — the same failure one level up.

## Deltas from ticket

- **Two existing `#15913` arms were updated. Neither was bent to pass.** The carrier-ownership arm gains the listing its flow always had in practice, keeping every assertion on the **default** path — its subject is that bob's delivery edge is marked while charlie's is not, which seen-state does not touch. The beyond-the-100-row-page arm moves to `includeUnseen`, because that flag is what now means "everything, listed or not"; its subject *was* the removed behaviour, so it moved to the path that still owns it. The default path keeps its own depth coverage via a new 120-message arm, so **the uncapped-drain guarantee is asserted twice, once per meaning.**
- **`#16748` is named as adjacent, not folded in.** That defect resurrects read-state across a plane redeploy and inflates how often a backlog *looks* worth nuking. Fixing it would not make nuking discriminating, and this change does not depend on it.

## Test Evidence

`npm run test-unit -- test/playwright/unit/ai/services/memory-core/MailboxService.spec.mjs` — **166 passed**, rebased onto `d6a7e9c92f`. Broader `test/playwright/unit/ai/services/memory-core` — **1828 passed**.

Seven arms, written **red first**; the first reproduced the defect (a directed message arriving after the listing was swept) before any implementation existed:

| AC | arm |
|---|---|
| 1 | a message arriving after the last listing survives the drain — **and**, asserted separately, the message that *was* listed is swept, so a drain that simply stopped working cannot pass |
| 2 | the motivating case: 120 aged messages listed, then cleared in one call |
| 3 | a `SwarmHeartbeatService`-shaped foreign read stamps nothing on the owner's mail |
| 4 | an outbox listing stamps nothing |
| 5 | `includeUnseen: true` still clears the never-listed message |
| 6 | the receipt reports `withheldUnseenCount: 2` while clearing 1 |
| 7 | `seenAt` is stamped once and a later listing does not move it |

Arm 7 uses a **sentinel rather than a sleep**, and that is not only the fixed-sleep guard: a sleep-based version passes vacuously whenever both listings land in the same millisecond, because it cannot tell "not re-stamped" from "re-stamped identically". The pre-commit guard flagged the `setTimeout`, and the assertion was weak for a second, independent reason.

## Post-Merge Validation

None gating. The change is unit-covered on the real graph projection and ships no deployed-plane behaviour. Existing mailboxes simply carry no `seenAt` until their next listing, which is the fail-safe direction: unseen mail is withheld from a bulk drain rather than swept.

Authored by Grace (Claude Opus 5, Claude Code). Session 752da6ac-a6c3-447f-8847-1da4ce49deb8.
