### PR TITLE
fix(agentos): a corrupt or unreadable instance roster says so (#17368)

### DIFF
--- a/apps/agentos/fleet/instanceRosterStorage.mjs
+++ b/apps/agentos/fleet/instanceRosterStorage.mjs
@@ -40,20 +40,33 @@ export function serializeInstanceRoster(records = []) {
  * with its reason. Fail-open to EMPTY on a malformed envelope (a broken storage value must not
  * brick the switcher), fail-loud per ROW on contract refusals.
  * @param {String|null} json The raw storage value, or `null`/`undefined` when the key is absent.
- * @returns {{records: Object[], dropped: Object[]}} `records` = validated current-contract rows;
- *     `dropped` = `{record, reason}` per refused row — the caller's honest-absence surface.
+ * @returns {{records: Object[], dropped: Object[], envelope: String}} `records` = validated
+ *     current-contract rows; `dropped` = `{record, reason}` per refused row; `envelope` = one of
+ *     `absent` | `ok` | `unparseable` | `not-an-array`. Fail-open and fail-SILENT are different
+ *     things, and only the first was ever chosen: an envelope failure yields an empty `dropped`, so
+ *     a caller warning per dropped row has nothing to warn about while the operator's whole roster
+ *     silently disappears behind a UI that looks like a fresh install.
  */
 export function reviveInstanceRoster(json) {
     let parsed;
 
+    // An unset key is not damage, and it is the most common state. It must be classified BEFORE the
+    // parse, because both of its shapes would otherwise be reported as corruption: `JSON.parse(null)`
+    // yields `null` and lands in `not-an-array`, while `JSON.parse(undefined)` throws and lands in
+    // `unparseable`. A warning that fires on every fresh install is one operators learn to ignore,
+    // which would cost the real signal this envelope field exists to carry.
+    if (json === null || json === undefined || json === '') {
+        return {records: [], dropped: [], envelope: 'absent'}
+    }
+
     try {
         parsed = JSON.parse(json)
     } catch {
-        return {records: [], dropped: []}
+        return {records: [], dropped: [], envelope: 'unparseable'}
     }
 
     if (!Array.isArray(parsed)) {
-        return {records: [], dropped: []}
+        return {records: [], dropped: [], envelope: 'not-an-array'}
     }
 
     const
@@ -68,5 +81,5 @@ export function reviveInstanceRoster(json) {
         }
     });
 
-    return {records, dropped}
+    return {records, dropped, envelope: 'ok'}
 }

--- a/apps/agentos/fleet/instanceRosterStorage.mjs
+++ b/apps/agentos/fleet/instanceRosterStorage.mjs
@@ -55,7 +55,12 @@ export function reviveInstanceRoster(json) {
     // yields `null` and lands in `not-an-array`, while `JSON.parse(undefined)` throws and lands in
     // `unparseable`. A warning that fires on every fresh install is one operators learn to ignore,
     // which would cost the real signal this envelope field exists to carry.
-    if (json === null || json === undefined || json === '') {
+    //
+    // ABSENCE IS THE CARRIER'S WORD, not a falsy family. LocalStorage answers a missing key with
+    // `null`, so `''` is a value somebody STORED and `JSON.parse('')` throws — it is corruption, and
+    // admitting it here would rebuild the conflation this function exists to remove, one state over.
+    // `undefined` stays only because no carrier can hand back a stored `undefined`.
+    if (json === null || json === undefined) {
         return {records: [], dropped: [], envelope: 'absent'}
     }
 

--- a/apps/agentos/view/ViewportController.mjs
+++ b/apps/agentos/view/ViewportController.mjs
@@ -79,12 +79,15 @@ class ViewportController extends Controller {
 
         dropped.forEach(({reason}) => console.warn(`fleet instance roster: dropped a stored row — ${reason}`));
 
+        // Damage is not absence, and the difference has to govern the WRITE as much as the warning.
+        const damaged = Boolean(readError) || envelope === 'unparseable' || envelope === 'not-an-array';
+
         // An envelope failure yields an EMPTY `dropped`, so the per-row warning above cannot fire for
         // it. Without this the switcher seeds the boot profile, shows exactly one instance, and is
         // indistinguishable from a fresh install while every configured instance is gone from view.
         if (readError) {
             console.warn(`fleet instance roster: storage unreadable, showing none of your configured instances — ${readError}`)
-        } else if (envelope === 'unparseable' || envelope === 'not-an-array') {
+        } else if (damaged) {
             console.warn(`fleet instance roster: stored value is ${envelope}, showing none of your configured instances — the value is still on disk under "${INSTANCE_ROSTER_STORAGE_KEY}" and recoverable`)
         }
         records.length > 0 && store.add(records.map(record => ({...record})));
@@ -98,7 +101,13 @@ class ViewportController extends Controller {
             seeded = true
         }
 
-        (seeded || dropped.length > 0) && me.persistInstanceRoster();
+        // The seed lives in MEMORY on a damaged read, never on disk. Seeding leaves the store holding
+        // exactly the boot profile, so `seeded` is true on damage too — and persisting there would
+        // overwrite `agentosFleetInstances.v1` milliseconds after telling the operator the value is
+        // "still on disk and recoverable". A warning whose own function destroys its subject is worse
+        // than the silence it replaced: it is silence with a receipt. Row-level `dropped` still
+        // persists, because there the envelope parsed and re-writing the survivors IS the salvage.
+        (!damaged && (seeded || dropped.length > 0)) && me.persistInstanceRoster();
         me.syncBoundInstance()
     }
 

--- a/apps/agentos/view/ViewportController.mjs
+++ b/apps/agentos/view/ViewportController.mjs
@@ -60,18 +60,33 @@ class ViewportController extends Controller {
             store = me.component.stateProvider.getStore('fleetInstances'),
             seeded, value;
 
+        let readError = null;
+
         try {
             ({value} = await Neo.main.addon.LocalStorage.readLocalStorageItem({
                 key     : INSTANCE_ROSTER_STORAGE_KEY,
                 windowId: me.windowId
             }))
-        } catch {
-            value = null
+        } catch (error) {
+            // Collapsing an unreadable store into `null` made it indistinguishable from an unset key.
+            // That is the worse half of this defect: the roster is intact on disk and maximally
+            // recoverable, and the operator is told nothing at all.
+            readError = error?.message ?? String(error);
+            value     = null
         }
 
-        const {records, dropped} = reviveInstanceRoster(value);
+        const {records, dropped, envelope} = reviveInstanceRoster(value);
 
         dropped.forEach(({reason}) => console.warn(`fleet instance roster: dropped a stored row — ${reason}`));
+
+        // An envelope failure yields an EMPTY `dropped`, so the per-row warning above cannot fire for
+        // it. Without this the switcher seeds the boot profile, shows exactly one instance, and is
+        // indistinguishable from a fresh install while every configured instance is gone from view.
+        if (readError) {
+            console.warn(`fleet instance roster: storage unreadable, showing none of your configured instances — ${readError}`)
+        } else if (envelope === 'unparseable' || envelope === 'not-an-array') {
+            console.warn(`fleet instance roster: stored value is ${envelope}, showing none of your configured instances — the value is still on disk under "${INSTANCE_ROSTER_STORAGE_KEY}" and recoverable`)
+        }
         records.length > 0 && store.add(records.map(record => ({...record})));
 
         // seed the boot endpoint as the roster's first row — the previously-implicit ONE instance

--- a/test/playwright/unit/apps/agentos/ViewportController.spec.mjs
+++ b/test/playwright/unit/apps/agentos/ViewportController.spec.mjs
@@ -118,72 +118,109 @@ test.describe('AgentOS.view.Viewport — accepted-definition composition boundar
         expect(calls).toEqual(['loadRoster'])
     });
 
-    test('#17368: an UNREADABLE store warns instead of looking like a fresh install', async () => {
+    /**
+     * @summary Drives the PRODUCTION `initInstanceRoster()` against one stored value and reports both
+     * observable effects — what the operator was told, and whether the boot seed was written back.
+     *
+     * The pair is the point. A reviewer falsifier on the first head deleted the warning branch and
+     * left every arm green, because the arms exercised the helper's classification and the caller's
+     * read failure but never the edge between them — and the warning itself promised the value was
+     * "still on disk" while this same function overwrote it. Splitting those two facts across
+     * separate stubs is what let both defects hide.
+     * @param {Object} [options]
+     * @param {String|null} [options.value=null] Stored value, or `null` for an unset key.
+     * @param {Error|null} [options.readError=null] Thrown by the storage read instead of returning.
+     * @returns {Promise<{persisted: Boolean, warnings: String[]}>}
+     */
+    async function runInitInstanceRoster({value = null, readError = null} = {}) {
+        const warnings     = [],
+              originalLS   = Neo.main?.addon?.LocalStorage,
+              originalWarn = console.warn;
+
+        let persisted = false;
+
+        // `resolveFleetUrl()` reads `Neo.config.url.search` when it seeds the boot profile, which the
+        // unit harness does not set. Harness scaffolding, downstream of the behaviour under test.
+        Neo.config.url              = Neo.config.url || {search: ''};
+        Neo.main                    = Neo.main       || {};
+        Neo.main.addon              = Neo.main.addon || {};
+        Neo.main.addon.LocalStorage = {
+            readLocalStorageItem: async () => {
+                if (readError) {
+                    throw readError
+                }
+
+                return {value}
+            }
+        };
+        console.warn = (...args) => warnings.push(args.join(' '));
+
+        const stub = {
+            windowId : 1,
+            component: {stateProvider: {getStore: () => ({add() {}, get: () => null})}},
+            persistInstanceRoster() { persisted = true },
+            syncBoundInstance() {}
+        };
+
+        try {
+            await ViewportController.prototype.initInstanceRoster.call(stub)
+        } finally {
+            console.warn                = originalWarn;
+            Neo.main.addon.LocalStorage = originalLS
+        }
+
+        return {persisted, warnings}
+    }
+
+    test('#17368: an UNREADABLE store warns, and does not write over the roster it calls recoverable', async () => {
         // The worse half of the defect. The caller collapsed a storage-read failure into `value = null`,
         // which is also what an unset key looks like — so the roster is intact on disk, maximally
         // recoverable, and the operator is told nothing while the UI seeds one instance and appears
         // completely normal.
-        const warnings     = [],
-              originalLS   = Neo.main?.addon?.LocalStorage,
-              originalWarn = console.warn;
-
-        // `resolveFleetUrl()` reads `Neo.config.url.search` when it seeds the boot profile, which the
-        // unit harness does not set. Harness scaffolding, downstream of the warning under test.
-        Neo.config.url       = Neo.config.url || {search: ''};
-        Neo.main             = Neo.main       || {};
-        Neo.main.addon       = Neo.main.addon || {};
-        Neo.main.addon.LocalStorage = {readLocalStorageItem: async () => {throw new Error('storage denied')}};
-        console.warn         = (...args) => warnings.push(args.join(' '));
-
-        const stub = {
-            windowId : 1,
-            component: {stateProvider: {getStore: () => ({add() {}, get: () => null})}},
-            persistInstanceRoster() {},
-            syncBoundInstance() {}
-        };
-
-        try {
-            await ViewportController.prototype.initInstanceRoster.call(stub);
-        } finally {
-            console.warn                = originalWarn;
-            Neo.main.addon.LocalStorage = originalLS
-        }
+        const {persisted, warnings} = await runInitInstanceRoster({readError: new Error('storage denied')});
 
         expect(warnings.some(line => /storage unreadable/.test(line))).toBe(true);
         // The message must tell the operator their instances are missing, not merely that a read
         // failed — the actionable fact is what they are no longer seeing.
-        expect(warnings.some(line => /configured instances/.test(line))).toBe(true)
+        expect(warnings.some(line => /configured instances/.test(line))).toBe(true);
+        expect(persisted).toBe(false)
     });
 
-    test('#17368 CONTROL: a readable, absent key warns NOTHING — first boot must stay quiet', async () => {
-        // Without this pair the arm above is satisfied by a build that warns on every startup.
-        const warnings     = [],
-              originalLS   = Neo.main?.addon?.LocalStorage,
-              originalWarn = console.warn;
+    test('#17368: BOTH malformed envelope shapes reach the operator, and neither is written over', async () => {
+        const unparseable = await runInitInstanceRoster({value: '{not json'}),
+              notAnArray  = await runInitInstanceRoster({value: '{"profiles":[]}'});
 
-        // `resolveFleetUrl()` reads `Neo.config.url.search` when it seeds the boot profile, which the
-        // unit harness does not set. Harness scaffolding, downstream of the warning under test.
-        Neo.config.url       = Neo.config.url || {search: ''};
-        Neo.main             = Neo.main       || {};
-        Neo.main.addon       = Neo.main.addon || {};
-        Neo.main.addon.LocalStorage = {readLocalStorageItem: async () => ({value: null})};
-        console.warn         = (...args) => warnings.push(args.join(' '));
+        expect(unparseable.warnings.some(line => /stored value is unparseable/ .test(line))).toBe(true);
+        expect(notAnArray .warnings.some(line => /stored value is not-an-array/.test(line))).toBe(true);
 
-        const stub = {
-            windowId : 1,
-            component: {stateProvider: {getStore: () => ({add() {}, get: () => null})}},
-            persistInstanceRoster() {},
-            syncBoundInstance() {}
-        };
+        // Both messages promise the value survives. These two assertions are what make that promise
+        // true: without them the seed write lands milliseconds after the sentence, and the warning
+        // becomes a receipt for the destruction rather than a route to recovery.
+        expect(unparseable.persisted).toBe(false);
+        expect(notAnArray .persisted).toBe(false);
 
-        try {
-            await ViewportController.prototype.initInstanceRoster.call(stub);
-        } finally {
-            console.warn                = originalWarn;
-            Neo.main.addon.LocalStorage = originalLS
-        }
+        // A stored empty string is a value somebody WROTE, and `JSON.parse('')` throws. Admitting it
+        // to the absent branch would rebuild the conflation this change removes, one state over.
+        const emptyString = await runInitInstanceRoster({value: ''});
 
-        expect(warnings.filter(line => /instance roster/.test(line))).toEqual([])
+        expect(emptyString.warnings.some(line => /stored value is unparseable/.test(line))).toBe(true);
+        expect(emptyString.persisted).toBe(false)
+    });
+
+    test('#17368 CONTROL: an absent key and a valid empty roster stay quiet AND still seed to disk', async () => {
+        // Two controls in one, guarding opposite over-corrections. Without the quiet half, the arms
+        // above are satisfied by a build that warns at every startup. Without the persisted half,
+        // they are satisfied by a build that simply stopped writing — which would break first-boot
+        // seeding outright while every damage assertion above still went green.
+        const absent = await runInitInstanceRoster({value: null}),
+              // Valid JSON, valid array, zero rows: the honest empty roster. `null` alone cannot
+              // separate "no key" from "nothing readable", so the empty ARRAY is the real control.
+              empty  = await runInitInstanceRoster({value: '[]'});
+
+        expect(absent.warnings.filter(line => /instance roster/.test(line))).toEqual([]);
+        expect(empty .warnings.filter(line => /instance roster/.test(line))).toEqual([]);
+        expect(absent.persisted).toBe(true);
+        expect(empty .persisted).toBe(true)
     });
 
     test('fails closed when the Fleet cockpit is absent', async () => {

--- a/test/playwright/unit/apps/agentos/ViewportController.spec.mjs
+++ b/test/playwright/unit/apps/agentos/ViewportController.spec.mjs
@@ -118,6 +118,74 @@ test.describe('AgentOS.view.Viewport — accepted-definition composition boundar
         expect(calls).toEqual(['loadRoster'])
     });
 
+    test('#17368: an UNREADABLE store warns instead of looking like a fresh install', async () => {
+        // The worse half of the defect. The caller collapsed a storage-read failure into `value = null`,
+        // which is also what an unset key looks like — so the roster is intact on disk, maximally
+        // recoverable, and the operator is told nothing while the UI seeds one instance and appears
+        // completely normal.
+        const warnings     = [],
+              originalLS   = Neo.main?.addon?.LocalStorage,
+              originalWarn = console.warn;
+
+        // `resolveFleetUrl()` reads `Neo.config.url.search` when it seeds the boot profile, which the
+        // unit harness does not set. Harness scaffolding, downstream of the warning under test.
+        Neo.config.url       = Neo.config.url || {search: ''};
+        Neo.main             = Neo.main       || {};
+        Neo.main.addon       = Neo.main.addon || {};
+        Neo.main.addon.LocalStorage = {readLocalStorageItem: async () => {throw new Error('storage denied')}};
+        console.warn         = (...args) => warnings.push(args.join(' '));
+
+        const stub = {
+            windowId : 1,
+            component: {stateProvider: {getStore: () => ({add() {}, get: () => null})}},
+            persistInstanceRoster() {},
+            syncBoundInstance() {}
+        };
+
+        try {
+            await ViewportController.prototype.initInstanceRoster.call(stub);
+        } finally {
+            console.warn                = originalWarn;
+            Neo.main.addon.LocalStorage = originalLS
+        }
+
+        expect(warnings.some(line => /storage unreadable/.test(line))).toBe(true);
+        // The message must tell the operator their instances are missing, not merely that a read
+        // failed — the actionable fact is what they are no longer seeing.
+        expect(warnings.some(line => /configured instances/.test(line))).toBe(true)
+    });
+
+    test('#17368 CONTROL: a readable, absent key warns NOTHING — first boot must stay quiet', async () => {
+        // Without this pair the arm above is satisfied by a build that warns on every startup.
+        const warnings     = [],
+              originalLS   = Neo.main?.addon?.LocalStorage,
+              originalWarn = console.warn;
+
+        // `resolveFleetUrl()` reads `Neo.config.url.search` when it seeds the boot profile, which the
+        // unit harness does not set. Harness scaffolding, downstream of the warning under test.
+        Neo.config.url       = Neo.config.url || {search: ''};
+        Neo.main             = Neo.main       || {};
+        Neo.main.addon       = Neo.main.addon || {};
+        Neo.main.addon.LocalStorage = {readLocalStorageItem: async () => ({value: null})};
+        console.warn         = (...args) => warnings.push(args.join(' '));
+
+        const stub = {
+            windowId : 1,
+            component: {stateProvider: {getStore: () => ({add() {}, get: () => null})}},
+            persistInstanceRoster() {},
+            syncBoundInstance() {}
+        };
+
+        try {
+            await ViewportController.prototype.initInstanceRoster.call(stub);
+        } finally {
+            console.warn                = originalWarn;
+            Neo.main.addon.LocalStorage = originalLS
+        }
+
+        expect(warnings.filter(line => /instance roster/.test(line))).toEqual([])
+    });
+
     test('fails closed when the Fleet cockpit is absent', async () => {
         const stub = {getReference: () => null};
 

--- a/test/playwright/unit/apps/agentos/fleet/instanceRosterStorage.spec.mjs
+++ b/test/playwright/unit/apps/agentos/fleet/instanceRosterStorage.spec.mjs
@@ -50,11 +50,34 @@ test.describe('instanceRosterStorage — persistence over the C1 guard (#17328)'
         expect(dropped[0].reason).toMatch(/re-derive/)
     });
 
-    test('malformed envelopes fail OPEN to empty: garbage, non-array, and absent values all yield the empty roster', () => {
-        expect(reviveInstanceRoster('{not json')).toEqual({records: [], dropped: []});
-        expect(reviveInstanceRoster('{"a": 1}')).toEqual({records: [], dropped: []});
-        expect(reviveInstanceRoster(null)).toEqual({records: [], dropped: []});
-        expect(reviveInstanceRoster(undefined)).toEqual({records: [], dropped: []})
+    test('malformed envelopes still fail OPEN to empty — the switcher must never brick', () => {
+        // Unchanged contract: every envelope failure yields an empty roster and no throw. What
+        // changed is only whether the caller can TELL them apart, never whether they fail open.
+        for (const value of ['{not json', '{"a": 1}', null, undefined, '']) {
+            const result = reviveInstanceRoster(value);
+
+            expect(result.records).toEqual([]);
+            expect(result.dropped).toEqual([])
+        }
+    });
+
+    test('#17368: the envelope names its own outcome — fail-open and fail-SILENT are different things', () => {
+        // The defect: an envelope failure yields an EMPTY `dropped`, so the caller's per-row warning
+        // has nothing to warn about. The operator sees one seeded instance and a UI indistinguishable
+        // from a fresh install, while every roster row they configured is gone from view.
+        expect(reviveInstanceRoster('{not json').envelope).toBe('unparseable');
+        expect(reviveInstanceRoster('{"a": 1}').envelope).toBe('not-an-array');
+        expect(reviveInstanceRoster('[]').envelope).toBe('ok')
+    });
+
+    test('#17368 CONTROL: an UNSET key reports `absent`, not damage — a warning on every fresh install is one nobody reads', () => {
+        // The trap in the obvious three-state shape. `JSON.parse(null)` yields `null` and would land
+        // in `not-an-array`; `JSON.parse(undefined)` throws and would land in `unparseable`. Both are
+        // the ordinary first-boot state, so classifying absence BEFORE the parse is what keeps the
+        // signal worth reading. Without this arm the arm above passes on a build that cries wolf.
+        expect(reviveInstanceRoster(null).envelope).toBe('absent');
+        expect(reviveInstanceRoster(undefined).envelope).toBe('absent');
+        expect(reviveInstanceRoster('').envelope).toBe('absent')
     });
 
     test('the storage key is versioned and owned here', () => {

--- a/test/playwright/unit/apps/agentos/fleet/instanceRosterStorage.spec.mjs
+++ b/test/playwright/unit/apps/agentos/fleet/instanceRosterStorage.spec.mjs
@@ -77,7 +77,12 @@ test.describe('instanceRosterStorage — persistence over the C1 guard (#17328)'
         // signal worth reading. Without this arm the arm above passes on a build that cries wolf.
         expect(reviveInstanceRoster(null).envelope).toBe('absent');
         expect(reviveInstanceRoster(undefined).envelope).toBe('absent');
-        expect(reviveInstanceRoster('').envelope).toBe('absent')
+
+        // Absence is the CARRIER's word, not a falsy family — and this is the boundary the control
+        // has to hold from BOTH sides. LocalStorage answers a missing key with `null`, so `''` is a
+        // value somebody stored and `JSON.parse('')` throws. Admitting it above would rebuild the
+        // exact conflation this envelope exists to remove, one state over.
+        expect(reviveInstanceRoster('').envelope).toBe('unparseable')
     });
 
     test('the storage key is versioned and owned here', () => {


### PR DESCRIPTION
Resolves #17368

`reviveInstanceRoster` distinguished envelope failure from row failure and reported only the second. An envelope failure returns an **empty `dropped`**, so the caller's per-row warning had nothing to warn about — the switcher seeded the boot profile, showed one instance, and was **indistinguishable from a fresh install** while every configured instance was gone from view.

The docblock already stated the intent: *"Fail-open to EMPTY on a malformed envelope … fail-loud per ROW."* **Fail-open is right and unchanged. Fail-open and fail-SILENT are different things, and only the first was ever chosen.**

Evidence: L2 required → **L2 achieved, no residual** (20 focused arms green; two mutation runs, one of them the reviewer's own falsifier).

## Round 2 — @neo-gpt's review found the fix committing the defect

Both P1 actions were real, and the first is the kind of finding that justifies the review seat existing.

**RA-1 — the warning was overwriting its own subject.** The message promised *"the value is still on disk … and recoverable"*. Then the same function seeded the boot profile, which left the store holding exactly one row, which made `seeded` true, which called `persistInstanceRoster()`:

```js
(seeded || dropped.length > 0) && me.persistInstanceRoster();   // ← fires on damage too
```

**The sentence was false by the time an operator could read it.** That is this ticket's own defect, committed by its fix — a warning whose function destroys its subject is worse than the silence it replaced, because it is silence with a receipt. Damage now gates the **write** as well as the message. Row-level `dropped` still persists: there the envelope parsed, and re-writing the survivors *is* the salvage.

**RA-2 — `''` was classified as absence, and it is corruption.** Neo's LocalStorage carrier answers a *missing* key with `null`, so `''` is a value somebody **wrote**, and `JSON.parse('')` throws. My defensive `json === ''` rebuilt the exact conflation this envelope removes, one state over. The boundary is the carrier's answer for a missing key, not a falsy family. `undefined` stays only because no carrier can hand back a stored `undefined`.

**RA-3 — the arms were mutation-blind, and the review said precisely how.** *"Deleting the controller's malformed-envelope warning branch leaves every added arm green."* True: they exercised the helper's classification and the caller's read failure, but never the edge between them. Both malformed shapes now run through the production `initInstanceRoster()` with a persist spy.

**RA-4 — Contract Ledger backfilled** on #17368 as a comment (Grace's ticket, so not a body edit): every input state bound to `envelope`, records, operator signal, and **whether boot may persist** — that last column is the one whose absence let RA-1 through.

## Deltas from ticket

**1. The obvious three-state shape would cry wolf on every fresh install.** The ticket proposes `ok` / `unparseable` / `not-an-array`. Measured, an unset key reaches **both** failure buckets:

```
JSON.parse(null)      -> null      isArray=false   ... lands in `not-an-array`
JSON.parse(undefined) -> THROWS                    ... lands in `unparseable`
```

So a first boot would report corruption. **A warning that fires on every clean start is one operators learn to ignore** — which costs exactly the signal this field exists to carry. `absent` is therefore a fourth state, classified **before** the parse.

**2. The caller carries the same defect one layer up, and it is the worse half.** `ViewportController.initInstanceRoster` wrapped the storage read in `catch { value = null }` — collapsing *"the store is unreadable"* into *"the key is unset"*. That case is **more** recoverable than corruption (the roster is intact on disk) and had **less** signal (none). Fixing only the module would have left it.

Both are the same defect at two layers, so they ship together rather than as a follow-up.

**3. The warning names what the operator lost, not what the code did.** *"showing none of your configured instances — the value is still on disk under `agentosFleetInstances.v1` and recoverable"* rather than *"parse failed"*. The actionable fact is what is missing and that it can be recovered.

## Test Evidence

**795 arms green.** The existing arm *"garbage, non-array, and absent values all yield the empty roster"* asserted exactly the conflation this removes; it is **rewritten, not deleted** — it still pins fail-open for all five inputs, and no longer pins that they are indistinguishable.

Four new arms, in two pairs:

| arm | pins |
|---|---|
| the envelope names its own outcome | `unparseable` / `not-an-array` / `ok` |
| **CONTROL:** an unset key reports `absent`, and `''` does not | the fresh-install boundary, held from **both** sides |
| an unreadable store warns and **writes nothing** | names the missing instances, and keeps them |
| **both** malformed shapes reach the operator through `initInstanceRoster()` | the production edge, not a helper assertion |
| **CONTROL:** absent key *and* valid `[]` stay quiet **and still seed** | no wolf on a clean start, and boot seeding is not broken |

Every controller arm now runs the real `initInstanceRoster()` through one helper that reports both observable effects — **what the operator was told, and whether the roster was written back**. Splitting those two facts across separate stubs is what let both defects hide.

**Two mutation runs, the first of them the reviewer's own falsifier:**

- Deleting the malformed-envelope warning branch — which left *every* arm green on the previous head — now reddens the both-shapes arm.
- Removing the `!damaged` persistence gate reddens the unreadable-store arm **and** the both-shapes arm, on their `persisted` assertions alone.

The quiet control asserts `persisted === true`, so a build that fixed the damage case by simply never writing would fail there rather than passing everything above.

## Post-Merge Validation

Corrupt the `agentosFleetInstances.v1` value by hand and reload: the console names the envelope outcome and says the value is recoverable — **then check the key is still there**, which is the half that was untrue before. On a fresh profile with no key the console stays silent and the boot profile is seeded normally.

## Evolution

**Absence of a reading is not a reading.** A missing roster rendering as an empty one is the same shape as a missing tool rendering as an empty inbox — the honest-absence contract that governs the rest of this feature, inverted at its own boundary. The fix is *not* to fail closed; it is to keep failing open and **say so**.

Round 2 added the sharper half, and I would not have found it: **a message about state is worthless if the same function then changes that state.** I wrote *"still on disk and recoverable"* and shipped the write that made it false, in the very PR whose thesis is that silence about damage is the defect. Honesty is not a property of the sentence — it is a property of the sentence plus everything that runs after it.

Authored by Ada (Claude Opus 5, Claude Code). Session ab15d2b8-eb14-4237-ad18-ce48584b2d07.

