### PR TITLE
feat(kb): make resumed slice settlement cumulative (#17439)

### DIFF
--- a/ai/daemons/orchestrator/services/TenantRepoSyncService.mjs
+++ b/ai/daemons/orchestrator/services/TenantRepoSyncService.mjs
@@ -5,12 +5,11 @@ import Base                      from '../../../../src/core/Base.mjs';
 import AiConfig                  from '../../../config.mjs';
 import GitMirror                 from '../../../services/knowledge-base/helpers/gitMirror.mjs';
 import TextEmbeddingService      from '../../../services/memory-core/TextEmbeddingService.mjs';
-// The outstanding-chunk observable is derived from the run's OWN totals rather than recomputed here.
-// A second implementation of "which chunks are missing" can disagree with the embedder that produced
-// them, and a backlog figure that disagrees with the embedder is worse than none.
+// Settlement comes from the Vector result chain. Reconstructing it from current-call embeddings
+// forgets durable ids landed by prior slices — the exact resumed-slice defect this consumer reports.
 import {
-    deriveOutstanding,
-    describeCorpusOutstanding
+    describeCorpusOutstanding,
+    normalizeSettlementCounts
 }                                from '../../../services/knowledge-base/helpers/corpusOutstanding.mjs';
 import {createBoundedRetryGate}   from '../../../services/shared/boundedRetryGate.mjs';
 import {writeFileAtomic}          from '../../../services/shared/atomicFileWrite.mjs';
@@ -482,18 +481,9 @@ function createProviderTimeoutCircuitError() {
 /**
  * @summary Builds one repo's corpus-outstanding observation from the run's own ingestion summary.
  *
- * ## Why the mapping is not one-to-one with the summary's field names
- *
- * The summary carries primitives, not the derived pair: `ingested` (chunks accepted into the run),
- * `skippedOversized` (guardrail rejections that will never embed), and `embeddingsGenerated` (chunks
- * that actually landed). The progress projection derives `totalChunks` / `embeddedChunks` from those,
- * but that projection is a KB-server-process surface and cannot answer for this lane — so the mapping
- * happens here, from the primitives, once.
- *
- * `skippedOversized` appears on BOTH sides — inside the total and as the skip — so it cancels, and the
- * remainder is exactly "accepted minus embedded". Passing it explicitly rather than pre-subtracting it
- * keeps the intent legible: an oversized chunk is declined work, not outstanding work, and a backlog
- * that silently counted it could never reach zero.
+ * `remaining` is already derived from durable collection ids, closed fences, terminal skips, and
+ * current-call landings. Recomputing it as `ingested - embeddingsGenerated` is wrong on every resumed
+ * slice because the second term is intentionally per-call while the first is the full accepted corpus.
  *
  * @param {Object}      options
  * @param {Object}      options.summary   Ingestion summary returned by the run.
@@ -502,19 +492,17 @@ function createProviderTimeoutCircuitError() {
  * @returns {Object} The `describeCorpusOutstanding` observation.
  */
 function buildCorpusOutstandingObservation({summary, priorState, observedAt}) {
-    const
-        accepted = summary?.ingested,
-        skipped  = summary?.skippedOversized ?? 0,
-        embedded = summary?.embeddingsGenerated,
-        // Number.isFinite guards rather than `?? 0`: a summary missing these fields is UNMEASURED, and
-        // defaulting it to zero would publish "nothing outstanding" for a run nobody observed — the
-        // empty-is-not-success defect this observable exists to close.
-        total    = Number.isFinite(accepted) && Number.isFinite(skipped) ? accepted + skipped : undefined;
+    const counts = normalizeSettlementCounts({
+        accepted : summary?.ingested,
+        settled  : summary?.settled,
+        remaining: summary?.remaining
+    });
 
     return describeCorpusOutstanding({
-        outstanding: deriveOutstanding({total, embedded, skipped}),
+        settled  : counts?.settled ?? null,
+        remaining: counts?.remaining ?? null,
         observedAt,
-        previous   : priorState?.corpusOutstanding ?? null
+        previous : priorState?.corpusOutstanding ?? null
     })
 }
 

--- a/ai/daemons/orchestrator/services/tenantRepoCheckpointValidity.mjs
+++ b/ai/daemons/orchestrator/services/tenantRepoCheckpointValidity.mjs
@@ -230,12 +230,15 @@ function normalizeCorpusOutstanding(value) {
     // null/undefined/negative to `0`, which destroys the exact distinction this field exists to carry.
     // Built on it, the coherence check below could neither DETECT a missing count (a torn
     // `{state:'complete', observable:true}` laundered to `complete/0` — a finished corpus asserted from
-    // an absent number) nor RECOGNISE a legitimate `outstanding: null`, so every valid `unobservable`
-    // the producer emits was rejected and could never round-trip. One helper, both residuals.
+    // an absent number) nor RECOGNISE a legitimate all-null settlement tuple, so every valid
+    // `unobservable` the producer emits was rejected and could never round-trip. One helper, both
+    // residuals.
     const
         {state}     = value,
         observable  = value.observable === true,
-        outstanding = Number.isFinite(value.outstanding) && value.outstanding >= 0 ? value.outstanding : null,
+        settled     = Number.isSafeInteger(value.settled) && value.settled >= 0 ? value.settled : null,
+        remaining   = Number.isSafeInteger(value.remaining) && value.remaining >= 0 ? value.remaining : null,
+        outstanding = Number.isSafeInteger(value.outstanding) && value.outstanding >= 0 ? value.outstanding : null,
         observedAt  = Number.isFinite(value.observedAt)  && value.observedAt  >  0 ? value.observedAt  : null;
 
     // CLOSED vocabulary. An arbitrary string was previously admitted, which let a hand-edited or
@@ -246,21 +249,28 @@ function normalizeCorpusOutstanding(value) {
         return null;
     }
 
-    // An observation claiming to be observable must carry both the count and the moment it was taken;
-    // one without the other cannot support either the number or its staleness, so it degrades whole.
-    if (observable && !(outstanding !== null && observedAt !== null)) {
+    // An observation claiming to be observable must carry the complete partition, its compatibility
+    // alias, and the moment it was taken. A partial tuple cannot support either the number or its
+    // staleness, so it degrades whole.
+    if (observable && !(
+        settled !== null
+        && remaining !== null
+        && outstanding === remaining
+        && observedAt !== null
+    )) {
         return null;
     }
 
     // COHERENCE, not merely presence. Each state admits exactly one tuple, so a record whose fields
     // contradict each other degrades WHOLE rather than being published field-by-field. The dangerous
-    // specimen is `{state:'complete', observable:true, outstanding:42}`: every field is individually
-    // well-typed, and together they assert a finished corpus with 42 chunks left. Repairing that to a
-    // count would invent an observation; rejecting it is the only honest reading.
+    // specimen is `{state:'complete', observable:true, settled:0, remaining:42, outstanding:42}`:
+    // every field is individually well-typed, and together they assert a finished corpus with 42
+    // chunks left. Repairing that to a count would invent an observation; rejecting it is the only
+    // honest reading.
     const coherent = state === OUTSTANDING_STATE.unobservable
-        ? (!observable && outstanding === null)
+        ? (!observable && settled === null && remaining === null && outstanding === null)
         : (observable && outstanding !== null
-            && (state === OUTSTANDING_STATE.complete ? outstanding === 0 : outstanding > 0));
+            && (state === OUTSTANDING_STATE.complete ? remaining === 0 : remaining > 0));
 
     if (!coherent) {
         return null;
@@ -269,6 +279,8 @@ function normalizeCorpusOutstanding(value) {
     return {
         state,
         observable,
+        settled        : observable ? settled : null,
+        remaining      : observable ? remaining : null,
         outstanding    : observable ? outstanding : null,
         lastDecreasedAt: Number.isFinite(value.lastDecreasedAt) && value.lastDecreasedAt > 0 ? value.lastDecreasedAt : null,
         observedAt

--- a/ai/mcp/server/knowledge-base/openapi.yaml
+++ b/ai/mcp/server/knowledge-base/openapi.yaml
@@ -1242,13 +1242,25 @@ components:
       properties:
         ingested:
           type: integer
-          description: Count of chunks embedded/upserted.
+          description: Count of embeddable chunks accepted for this ingestion run.
         deleted:
           type: integer
           description: Count of Chroma rows removed via deletion signaling.
         embeddingsGenerated:
           type: integer
-          description: Count of embeddings generated for this push.
+          description: Count of embeddings newly landed during this invocation; never cumulative across resumed slices.
+        settled:
+          type: integer
+          nullable: true
+          description: >-
+            Cumulative accepted chunks requiring no provider work on an identical next sweep.
+            Null when any repository group used a legacy/unobservable or invalid settlement producer.
+        remaining:
+          type: integer
+          nullable: true
+          description: >-
+            Cumulative accepted chunks still requiring provider work on an identical next sweep.
+            Null when any repository group used a legacy/unobservable or invalid settlement producer.
         skippedOversized:
           type: integer
           description: Count of local-provider over-budget chunks skipped before embedding.
@@ -1343,6 +1355,11 @@ components:
           type: integer
         remaining:
           type: integer
+          nullable: true
+          description: >-
+            Authoritative cumulative remaining count when the current/last Vector producer supplied
+            a coherent settlement tuple; null when settlement was unobserved. Legacy in-memory
+            ledgers created before this field fall back to accepted minus newly embedded.
         deletedRows:
           type: integer
         errorCount:

--- a/ai/services/knowledge-base/IngestionService.mjs
+++ b/ai/services/knowledge-base/IngestionService.mjs
@@ -13,6 +13,8 @@ import SourceRegistry     from './source/_export.mjs';
 import {loadTenantParser} from './source/tenantParserLoader.mjs';
 import {normalizeTenantRepoConfig}
                             from './helpers/tenantRepoAccessContract.mjs';
+import {normalizeSettlementCounts}
+                            from './helpers/corpusOutstanding.mjs';
 import {createTenantRepoMaterializationDigest}
                             from './helpers/tenantRepoIngestEnvelopeBuilder.mjs';
 import {isChromaConnectionError}
@@ -252,7 +254,7 @@ class IngestionService extends Base {
      * @param {Object} [controls={}] Internal non-MCP execution controls.
      * @param {AbortSignal} [controls.signal] Shared tenant-sweep provider circuit signal.
      * @param {Function} [controls.onProviderTimeout] Synchronous native-provider timeout hook.
-     * @returns {Promise<{ingested: Number, deleted: Number, embeddingsGenerated: Number, errors: Array, tenantId: String, durationMs: Number}>}
+     * @returns {Promise<{ingested: Number, settled: Number|null, remaining: Number|null, deleted: Number, embeddingsGenerated: Number, errors: Array, tenantId: String, durationMs: Number}>}
      */
     async ingestSourceFiles(payload = {}, controls = {}) {
         const startedAt = Date.now();
@@ -293,9 +295,16 @@ class IngestionService extends Base {
             });
 
             const embeddableChunks = this.filterEmbeddingInputBudget({chunks, tenantContext, summary});
+
+            // The accepted corpus is known before provider work starts. Remaining begins as the
+            // whole accepted set, then each observed group replaces its accepted contribution with
+            // the producer's authoritative remainder. A missing/malformed group nulls BOTH counts.
+            summary.remaining = embeddableChunks.length;
             this.updateIngestionProgress({
                 embeddableChunks: embeddableChunks.length,
                 errorCount      : summary.errors.length,
+                remainingChunks : summary.remaining,
+                settledChunks   : summary.settled,
                 skippedChunks   : summary.skippedOversized
             });
 
@@ -466,7 +475,8 @@ class IngestionService extends Base {
         replayEmbeddingPoison = false,
         shouldYield
     }) {
-        const groups = new Map();
+        const groups               = new Map();
+        let   settlementObservable = true;
 
         for (const chunk of chunks) {
             const repoSlug = chunk.repoSlug || tenantContext.repoSlug;
@@ -490,6 +500,44 @@ class IngestionService extends Base {
                     viaMcp
                 });
 
+                const
+                    hasSettled   = Object.hasOwn(result || {}, 'settled'),
+                    hasRemaining = Object.hasOwn(result || {}, 'remaining');
+
+                if (!hasSettled && !hasRemaining) {
+                    // Legacy producer: absence is unobserved, not a reassuring zero and not an
+                    // error. Sticky across the remaining groups because a partial aggregate has no
+                    // honest corpus meaning.
+                    settlementObservable = false;
+                    summary.settled       = null;
+                    summary.remaining     = null
+                } else {
+                    const counts = normalizeSettlementCounts({
+                        accepted : group.length,
+                        settled  : result?.settled,
+                        remaining: result?.remaining
+                    });
+
+                    if (!counts) {
+                        settlementObservable = false;
+                        summary.settled       = null;
+                        summary.remaining     = null;
+                        summary.errors.push(this.createError({
+                            code   : 'KB_VECTOR_EMBED_SETTLEMENT_INVALID',
+                            message: 'VectorService returned a malformed or inconsistent settlement tuple.',
+                            details: {
+                                repoSlug,
+                                accepted : group.length,
+                                settled  : Number.isFinite(result?.settled) ? result.settled : null,
+                                remaining: Number.isFinite(result?.remaining) ? result.remaining : null
+                            }
+                        }))
+                    } else if (settlementObservable) {
+                        summary.settled   += counts.settled;
+                        summary.remaining += counts.remaining - group.length
+                    }
+                }
+
                 if (result?.error) {
                     summary.errors.push(this.createError({
                         // Classified rather than defaulted. A provider code is truthy, so the old
@@ -501,8 +549,10 @@ class IngestionService extends Base {
                         details: result
                     }));
                     this.updateIngestionProgress({
-                        embeddedChunks: summary.embeddingsGenerated,
-                        errorCount    : summary.errors.length
+                        embeddedChunks : summary.embeddingsGenerated,
+                        errorCount     : summary.errors.length,
+                        remainingChunks: summary.remaining,
+                        settledChunks  : summary.settled
                     });
                     continue;
                 }
@@ -546,12 +596,13 @@ class IngestionService extends Base {
 
                 // `result.embedded` or nothing — never `group.length`. The old fallback credited the
                 // ENTIRE group as landed whenever the field was absent, which is the one direction
-                // this counter must never round: `embeddingsGenerated` is the `embedded` term in
-                // `deriveOutstanding`, so over-crediting it reports a corpus as fully embedded while
-                // chunks are still outstanding, and the checkpoint settles over work that never
-                // landed. Under-counting is recoverable — the next sweep re-selects; over-counting
-                // is not, because nothing goes looking again.
-                summary.embeddingsGenerated += Number.isSafeInteger(result?.embedded) ? result.embedded : 0;
+                // this per-call counter must never round: over-crediting makes telemetry claim work
+                // landed when it did not. Cumulative completion now comes from the independently
+                // validated settlement tuple above, so `embeddingsGenerated` remains exactly what
+                // its name promises. Under-counting is recoverable; over-counting is not.
+                summary.embeddingsGenerated += Number.isSafeInteger(result?.embedded) && result.embedded >= 0
+                    ? result.embedded
+                    : 0;
 
                 // A slice that stopped early is not a corpus that finished. Sticky across groups:
                 // one yielded group means the run as a whole did not exhaust its work, and a later
@@ -561,10 +612,15 @@ class IngestionService extends Base {
                 }
 
                 this.updateIngestionProgress({
-                    embeddedChunks: summary.embeddingsGenerated,
-                    errorCount    : summary.errors.length
+                    embeddedChunks : summary.embeddingsGenerated,
+                    errorCount     : summary.errors.length,
+                    remainingChunks: summary.remaining,
+                    settledChunks  : summary.settled
                 });
             } catch (error) {
+                settlementObservable = false;
+                summary.settled       = null;
+                summary.remaining     = null;
                 const residencyDisposition = classifyEmbedResidencyDisposition(error);
                 // The graduation receipt travels ON the original timeout rather than replacing it:
                 // the code below still names the timeout, and this bounded evidence — a hash and
@@ -592,8 +648,10 @@ class IngestionService extends Base {
                     }
                 }));
                 this.updateIngestionProgress({
-                    embeddedChunks: summary.embeddingsGenerated,
-                    errorCount    : summary.errors.length
+                    embeddedChunks : summary.embeddingsGenerated,
+                    errorCount     : summary.errors.length,
+                    remainingChunks: null,
+                    settledChunks  : null
                 });
             } finally {
                 await fs.remove(tempFile);
@@ -744,6 +802,8 @@ class IngestionService extends Base {
     createSummary({startedAt}) {
         return {
             ingested           : 0,
+            settled            : 0,
+            remaining          : 0,
             deleted            : 0,
             embeddingsGenerated: 0,
             skippedOversized   : 0,
@@ -862,6 +922,8 @@ class IngestionService extends Base {
             totalChunks     : 0,
             embeddableChunks: 0,
             embeddedChunks  : 0,
+            settledChunks   : null,
+            remainingChunks : null,
             skippedChunks   : 0,
             deletedRows     : 0,
             errorCount      : 0
@@ -911,9 +973,13 @@ class IngestionService extends Base {
             lastProgressAt: now,
             completedAt   : now,
             embeddedChunks: summary.embeddingsGenerated,
-            skippedChunks : summary.skippedOversized,
-            deletedRows   : summary.deleted,
-            errorCount    : summary.errors.length
+            ...(Object.hasOwn(summary, 'settled') && Object.hasOwn(summary, 'remaining') ? {
+                settledChunks  : summary.settled,
+                remainingChunks: summary.remaining
+            } : {}),
+            skippedChunks: summary.skippedOversized,
+            deletedRows  : summary.deleted,
+            errorCount   : summary.errors.length
         };
 
         this.activeIngestionProgress = null;
@@ -934,10 +1000,14 @@ class IngestionService extends Base {
         const embeddedChunks   = progress.embeddedChunks || 0;
         const skippedChunks    = progress.skippedChunks || 0;
         const targetChunks     = embeddableChunks > 0 || skippedChunks > 0 ? embeddableChunks : totalChunks;
-        const remaining        = Math.max(0, targetChunks - embeddedChunks);
-        const stalled          = active && staleAfterMs > 0 && now - progress.lastProgressAt > staleAfterMs;
-        const chunksPerSecond  = durationMs > 0 ? embeddedChunks / (durationMs / 1000) : 0;
-        const etaMs            = active && chunksPerSecond > 0 ? Math.ceil((remaining / chunksPerSecond) * 1000) : null;
+        const remaining        = Object.hasOwn(progress, 'remainingChunks')
+            ? progress.remainingChunks
+            : Math.max(0, targetChunks - embeddedChunks);
+        const stalled         = active && staleAfterMs > 0 && now - progress.lastProgressAt > staleAfterMs;
+        const chunksPerSecond = durationMs > 0 ? embeddedChunks / (durationMs / 1000) : 0;
+        const etaMs           = active && Number.isSafeInteger(remaining) && chunksPerSecond > 0
+            ? Math.ceil((remaining / chunksPerSecond) * 1000)
+            : null;
 
         return {
             status        : progress.status,

--- a/ai/services/knowledge-base/VectorService.mjs
+++ b/ai/services/knowledge-base/VectorService.mjs
@@ -168,9 +168,9 @@ function resolveFailedRequestChunks({error, batchToEmbed, persistedCount = 0}) {
 }
 
 
-const TENANT_GUARDED_FIELDS             = ['tenantId', 'repoSlug', 'visibility', 'originAgentIdentity', 'tenantConfigVersion', 'ingestedAt'];
-const STALE_STRATEGIES                  = Object.freeze(new Set(['delete-upfront', 'shadow-swap']));
-const STALE_STRATEGY_SKIP               = 'skip';
+const TENANT_GUARDED_FIELDS = ['tenantId', 'repoSlug', 'visibility', 'originAgentIdentity', 'tenantConfigVersion', 'ingestedAt'];
+const STALE_STRATEGIES      = Object.freeze(new Set(['delete-upfront', 'shadow-swap']));
+const STALE_STRATEGY_SKIP   = 'skip';
 /**
  * Family prefix for the embedding input-strategy coordinate.
  *
@@ -694,7 +694,7 @@ class VectorService extends Base {
             return [chunk];
         }
 
-        const maxInputBytes   = Math.max(1, estimateBandTokens * 3),
+        const maxInputBytes = Math.max(1, estimateBandTokens * 3),
               // MEASURED from the header the provider will receive, never a restatement of its format.
               // A planner that carries its own copy budgets against a string that may not be the one
               // sent, and the two cannot be kept in step by review.
@@ -852,8 +852,8 @@ class VectorService extends Base {
      * @returns {{skip: Boolean, measured: Boolean, inputBytes: Number, inputTokensEstimate: Number, estimateBandTokens: Number|null, admissionCeilingTokens: Number|null}}
      */
     measureEmbeddingInput({text, guardrail}) {
-        const inputBytes          = Buffer.byteLength(text || '', 'utf8'),
-              inputTokensEstimate = bytesToTokens(inputBytes),
+        const inputBytes                                             = Buffer.byteLength(text || '', 'utf8'),
+              inputTokensEstimate                                    = bytesToTokens(inputBytes),
               {resolved, admissionCeilingTokens, estimateBandTokens} = resolveEmbeddingAdmissionBand(guardrail);
 
         if (!resolved) {
@@ -912,8 +912,8 @@ class VectorService extends Base {
             // has to re-derive the drift factor to understand why.
             admissionCeilingTokens,
             estimateBandTokens,
-            serviceDomain            : 'other',
-            note                     : unmeasurable
+            serviceDomain: 'other',
+            note         : unmeasurable
                 ? 'Embedding safe-processing band is unresolvable; refusing to send an unmeasured input.'
                 : 'KB embedding input exceeds safe processing band; split or reduce the source chunk before embedding.'
         });
@@ -1224,7 +1224,12 @@ class VectorService extends Base {
      *     through so one sweep's strikes, suspicions, and durable dispositions share one generation;
      *     absent, it is resolved once at entry from the same leaves.
      * @param {Function} [options.now] Clock seam for bounded poison receipts.
-     * @returns {Promise<{embedded: Number, skipped: Number, yielded: Boolean, failedBatches: Object[], poisonedChunks: Object[], deathGraduations: Object[], deathStrikeProgress: Object[]}>}
+     * @returns {Promise<{embedded: Number, settled: Number, remaining: Number, skipped: Number, yielded: Boolean, failedBatches: Object[], poisonedChunks: Object[], deathGraduations: Object[], deathStrikeProgress: Object[]}>}
+     *     `embedded` is newly landed work from THIS invocation. `settled` / `remaining` form the
+     *     cumulative partition of the unique accepted ids offered here: durable vectors, durable
+     *     poison fences and terminal guardrail skips are settled; failed, yielded and undispatched
+     *     ids remain. Keeping the two axes separate is what lets a resumed slice report prior
+     *     progress without inflating newly generated embeddings.
      *     `poisonedChunks` reports what was already fenced when the sweep started; `deathGraduations`
      *     reports what THIS sweep fenced on death-class evidence and why; `deathStrikeProgress` reports
      *     unfinished death evidence, with `pending` separating a recorded-but-unproven observation from
@@ -1250,13 +1255,20 @@ class VectorService extends Base {
         poisonGenerationId,
         now = Date.now
     }) {
+        const acceptedIds = new Set([
+            ...chunksToProcess.map(chunk => chunk.id),
+            ...knownPoisonEntries.map(entry => entry.chunkId)
+        ]);
+
         if (chunksToProcess.length === 0) {
             if (knownPoisonEntries.length === 0) {
-                return {embedded: 0, skipped: 0, yielded: false}
+                return {embedded: 0, settled: 0, remaining: 0, skipped: 0, yielded: false}
             }
 
             return {
                 embedded      : 0,
+                settled       : acceptedIds.size,
+                remaining     : 0,
                 skipped       : 0,
                 yielded       : false,
                 failedBatches : [],
@@ -1275,12 +1287,14 @@ class VectorService extends Base {
         // what this sweep fenced and on what evidence, so convergence is visible in the summary instead
         // of only as a repo-level failure count climbing with no stated reason.
         const deathGraduations = [];
-        const poisonedChunks                                                                  = knownPoisonEntries.map(entry => ({...entry}));
-        const poisonIds                                                                       = new Set(poisonedChunks.map(entry => entry.chunkId));
-        const preEmbeddedIds                                                                  = new Set();
-        let   embeddedCount                                                                   = 0;
-        let   skippedCount                                                                    = 0;
-        let   yielded                                                                         = false;
+        const poisonedChunks   = knownPoisonEntries.map(entry => ({...entry}));
+        const poisonIds        = new Set(poisonedChunks.map(entry => entry.chunkId));
+        const preEmbeddedIds   = new Set();
+        const landedIds        = new Set();
+        const skippedIds       = new Set();
+        let   embeddedCount    = 0;
+        let   skippedCount     = 0;
+        let   yielded          = false;
 
         // The undeliverable automaton's coordinates, resolved ONCE per sweep. Transient strike and
         // suspicion evidence must live under the same generation as the durable disposition it can
@@ -1387,6 +1401,7 @@ class VectorService extends Base {
 
                 if (result.skip) {
                     skippedCount++;
+                    skippedIds.add(input.chunk.id);
                 } else {
                     embeddable.push(input);
                 }
@@ -1474,6 +1489,7 @@ class VectorService extends Base {
                 }
 
                 embeddedCount += partialChunks.length;
+                partialChunks.forEach(chunk => landedIds.add(chunk.id));
 
                 return partialChunks.length
             };
@@ -1552,6 +1568,7 @@ class VectorService extends Base {
                     });
 
                     embeddedCount += batchToEmbed.length;
+                    batchToEmbed.forEach(chunk => landedIds.add(chunk.id));
                     logger.log(`Processed and embedded batch ${batchNumber} of ${Math.ceil(chunksToProcess.length / batchSize)} (${batchToEmbed.length} embedded, ${guardrailSkipped} skipped).`);
                     success = true;
                 } catch (err) {
@@ -1981,7 +1998,27 @@ class VectorService extends Base {
             pending: entry.pendingSeq !== null
         }));
 
-        return {embedded: embeddedCount, skipped: skippedCount, yielded, failedBatches, poisonedChunks, deathGraduations, deathStrikeProgress};
+        const
+            settledIds  = new Set([
+                ...landedIds,
+                ...preEmbeddedIds,
+                ...poisonIds,
+                ...skippedIds
+            ]),
+            settled     = [...acceptedIds].reduce((count, id) => count + Number(settledIds.has(id)), 0),
+            remaining   = acceptedIds.size - settled;
+
+        return {
+            embedded: embeddedCount,
+            settled,
+            remaining,
+            skipped : skippedCount,
+            yielded,
+            failedBatches,
+            poisonedChunks,
+            deathGraduations,
+            deathStrikeProgress
+        };
     }
 
     /**
@@ -2027,6 +2064,7 @@ class VectorService extends Base {
         onPoisonEntries,
         poisonGenerationId
     }) {
+        const acceptedIds = new Set(knowledgeBase.map(chunk => chunk.id));
         const stateDir    = this.getResumeStateDir();
         const fingerprint = computeCorpusFingerprint(knowledgeBase);
         const resumeState = await readResumeState({dir: stateDir});
@@ -2119,10 +2157,14 @@ class VectorService extends Base {
                 // (preserved-not-promoted), so githubWorkflowSync can write resources/content/ freely while we
                 // are yielded; the resumed run re-reads the updated corpus. Torn-read-free by the same shadow
                 // isolation that protects a normal run.
-                logger.log(`Yielded embedding work mid shadow-swap; preserving shadow '${shadowName}' for resume (${embedResult.embedded + alreadyEmbedded} embedded so far).`);
+                const settled = acceptedIds.size - embedResult.remaining;
+
+                logger.log(`Yielded embedding work mid shadow-swap; preserving shadow '${shadowName}' for resume (${settled} settled, ${embedResult.remaining} remaining).`);
                 return {
-                    message         : `KB embedding yielded at a cooperative boundary after ${embedResult.embedded + alreadyEmbedded} chunk(s); the next sweep resumes from the preserved shadow.`,
-                    embedded        : embedResult.embedded + alreadyEmbedded,
+                    message         : `KB embedding yielded at a cooperative boundary after ${settled} chunk(s) settled; the next sweep resumes ${embedResult.remaining} remaining chunk(s) from the preserved shadow.`,
+                    embedded        : embedResult.embedded,
+                    settled,
+                    remaining       : embedResult.remaining,
                     deleted         : idsToDeleteCount,
                     staleStrategy   : 'shadow-swap',
                     yielded         : true,
@@ -2157,7 +2199,9 @@ class VectorService extends Base {
                 logger.warn(`[VectorService] ${message}`);
                 return {
                     message,
-                    embedded        : embedResult.embedded + alreadyEmbedded,
+                    embedded        : embedResult.embedded,
+                    settled         : acceptedIds.size - embedResult.remaining,
+                    remaining       : embedResult.remaining,
                     deleted         : idsToDeleteCount,
                     staleStrategy   : 'shadow-swap',
                     shadowCollection: shadowName,
@@ -2199,7 +2243,9 @@ class VectorService extends Base {
 
             return {
                 message,
-                embedded           : embedResult.embedded + alreadyEmbedded,
+                embedded           : embedResult.embedded,
+                settled            : acceptedIds.size,
+                remaining          : 0,
                 deleted            : idsToDeleteCount,
                 staleStrategy      : 'shadow-swap',
                 shadowCollection   : shadowName,
@@ -2557,7 +2603,10 @@ class VectorService extends Base {
             return {
                 message,
                 embedded      : 0,
+                settled       : allIds.size,
+                remaining     : 0,
                 deleted       : 0,
+                yielded       : false,
                 poisonedChunks: knownPoisonEntries.map(entry => ({...entry}))
             };
         }
@@ -2612,8 +2661,13 @@ class VectorService extends Base {
         // that cannot see it reports a clean sync over a corpus with a hole in it.
         return {
             message,
-            embedded: embedResult.embedded,
-            deleted : idsToDelete.length,
+            embedded : embedResult.embedded,
+            // `embedded` is this call's newly landed delta. These two are the cumulative corpus
+            // partition: rows already in Chroma and durable poison fences were removed from
+            // `chunksToProcess` before the provider call, but still count as settled here.
+            settled  : allIds.size - embedResult.remaining,
+            remaining: embedResult.remaining,
+            deleted  : idsToDelete.length,
             failedBatches,
             poisonedChunks,
             // The discriminator between "this corpus is done" and "this slice stopped early". Dropping

--- a/ai/services/knowledge-base/helpers/corpusOutstanding.mjs
+++ b/ai/services/knowledge-base/helpers/corpusOutstanding.mjs
@@ -1,7 +1,7 @@
 /**
  * @module ai/services/knowledge-base/helpers/corpusOutstanding
- * @summary Pure decision for the corpus-outstanding observable — how many chunks of a corpus are known
- * but not yet embedded, plus the movement stamp a consumer needs to judge whether that backlog is moving.
+ * @summary Pure decisions for cumulative corpus settlement — how many accepted chunks are settled,
+ * how many remain, and the movement stamp a consumer needs to judge whether that remainder is moving.
  * It reports a state, never a trend. The number this answers with
  * already exists inside every ingest run (`VectorService` derives `chunksToProcess` from the parsed corpus
  * against the ids present in Chroma, and the lease-yield path logs the remainder) and is then discarded
@@ -26,10 +26,9 @@
  *
  * ## The unknown/zero distinction is the whole safety property
  *
- * An unmeasurable backlog MUST NOT render as `0`. A zero means "every known chunk is embedded"; an unknown
- * means "nobody asked". Collapsing them recreates the empty-is-not-success defect one layer up — a caller
- * trusting a number that actually means nothing was observed. `observable: false` carries null counts and
- * its own state rather than a reassuring number.
+ * An unmeasurable backlog MUST NOT render as `0`. A zero means "every accepted chunk is settled"; an
+ * unknown means "nobody established the tuple". Collapsing them recreates the empty-is-not-success defect
+ * one layer up. `observable: false` carries null counts and its own state rather than a reassuring number.
  */
 
 /**
@@ -46,11 +45,11 @@
  *
  * Each state has exactly one coherent tuple, enforced at both trust boundaries:
  *
- * | state          | outstanding | observable |
- * |----------------|-------------|------------|
- * | `complete`     | `0`         | `true`     |
- * | `outstanding`  | `> 0`       | `true`     |
- * | `unobservable` | `null`      | `false`    |
+ * | state          | settled | remaining / outstanding | observable |
+ * |----------------|---------|-------------------------|------------|
+ * | `complete`     | `>= 0`  | `0`                     | `true`     |
+ * | `outstanding`  | `>= 0`  | `> 0`                   | `true`     |
+ * | `unobservable` | `null`  | `null`                  | `false`    |
  *
  * @type {Object}
  */
@@ -61,44 +60,25 @@ export const OUTSTANDING_STATE = Object.freeze({
 });
 
 /**
- * @summary Derives the outstanding-chunk count for a completed ingest run from the delta the run already had.
+ * @summary Validates one exact partition of an accepted corpus into settled and remaining chunks.
  *
- * Deliberately takes the run's own numbers rather than recomputing a delta: a second implementation of
- * "which chunks are missing" can disagree with the one that did the embedding, and a backlog figure that
- * disagrees with the embedder is worse than none. `total` is the post-delta work volume the run started with
- * (`chunksToProcess.length`), not the corpus size.
+ * This is the consumed boundary between Vector and Ingestion. Safe integers are required because these
+ * values persist into operator state; exact equality is required because either under- or over-crediting
+ * changes whether a repo is retried. Missing legacy fields and malformed present fields are distinguished
+ * by the caller — this helper answers only whether a present tuple is coherent.
  *
- * A run that yields its lease mid-way leaves a real remainder; a run that completes leaves zero, because the
- * next sweep's delta is recomputed from scratch against Chroma.
- *
- * @param {Object}  options
- * @param {Number}  options.total     Chunks this run set out to embed (the post-delta work volume).
- * @param {Number}  options.embedded  Chunks this run durably embedded.
- * @param {Number} [options.skipped=0] Chunks the run deliberately declined (guardrail rejections) — these are
- *     NOT outstanding: nothing further will embed them, and counting them as backlog produces a figure that
- *     never reaches zero.
- * @returns {Number|null} Remaining chunks, or null when the inputs cannot support a count.
+ * @param {Object} options
+ * @param {Number} options.accepted Accepted unique embeddable chunks in this group.
+ * @param {Number} options.settled Chunks requiring no provider work on an identical next sweep.
+ * @param {Number} options.remaining Chunks still requiring provider work on an identical next sweep.
+ * @returns {{settled: Number, remaining: Number}|null}
  */
-export function deriveOutstanding({total, embedded, skipped = 0} = {}) {
-    if (!Number.isFinite(total) || !Number.isFinite(embedded) || !Number.isFinite(skipped)) {
-        return null;
+export function normalizeSettlementCounts({accepted, settled, remaining} = {}) {
+    if (![accepted, settled, remaining].every(value => Number.isSafeInteger(value) && value >= 0)) {
+        return null
     }
 
-    if (total < 0 || embedded < 0 || skipped < 0) {
-        return null;
-    }
-
-    // INCOHERENT INPUTS ARE UNMEASURABLE, NOT COMPLETE. An earlier revision clamped this with
-    // `Math.max(0, …)` and justified it as "degrading toward the claim the numbers are closest to
-    // supporting". That was wrong, and it built the exact defect this module exists to prevent: a run
-    // reporting more embedded-plus-skipped than it ever accepted is a run whose numbers disagree with
-    // themselves, and `0` would publish that as a FINISHED corpus. There is no reading of contradictory
-    // arithmetic that supports "nothing left to do" — only "this cannot be trusted".
-    if (embedded + skipped > total) {
-        return null;
-    }
-
-    return total - embedded - skipped;
+    return settled + remaining === accepted ? {settled, remaining} : null
 }
 
 /**
@@ -114,19 +94,22 @@ export function deriveOutstanding({total, embedded, skipped = 0} = {}) {
  * that here would require a threshold no producer on this path can own.
  *
  * @param {Object}      options
- * @param {Number|null} options.outstanding Current outstanding count (from `deriveOutstanding`).
+ * @param {Number|null} options.settled Cumulative settled count.
+ * @param {Number|null} options.remaining Authoritative remaining count.
  * @param {Number}      options.observedAt  Epoch ms for this observation — passed in, never read from a
  *     clock here, so the decision stays pure and testable.
  * @param {Object|null} [options.previous]  The previously persisted observation, if any.
- * @returns {{state: String, outstanding: Number|null, observable: Boolean, lastDecreasedAt: Number|null,
- *     observedAt: Number|null}}
+ * @returns {{state: String, settled: Number|null, remaining: Number|null, outstanding: Number|null,
+ *     observable: Boolean, lastDecreasedAt: Number|null, observedAt: Number|null}}
  */
-export function describeCorpusOutstanding({outstanding, observedAt, previous = null} = {}) {
+export function describeCorpusOutstanding({settled, remaining, observedAt, previous = null} = {}) {
     if (!Number.isFinite(observedAt)) {
         // Without a timestamp there is no movement axis at all, so the observation cannot be composed even
         // if the count itself is sound. Reported as unobservable rather than dated with a substitute clock.
         return {
             state          : OUTSTANDING_STATE.unobservable,
+            settled        : null,
+            remaining      : null,
             outstanding    : null,
             observable     : false,
             lastDecreasedAt: null,
@@ -134,9 +117,12 @@ export function describeCorpusOutstanding({outstanding, observedAt, previous = n
         };
     }
 
-    if (!Number.isFinite(outstanding) || outstanding < 0) {
+    if (!Number.isSafeInteger(settled) || settled < 0
+        || !Number.isSafeInteger(remaining) || remaining < 0) {
         return {
             state      : OUTSTANDING_STATE.unobservable,
+            settled    : null,
+            remaining  : null,
             outstanding: null,
             observable : false,
             // The previous movement stamp survives an unobservable reading. Losing it would let a single
@@ -146,16 +132,23 @@ export function describeCorpusOutstanding({outstanding, observedAt, previous = n
         };
     }
 
-    const previousOutstanding = Number.isFinite(previous?.outstanding) ? previous.outstanding : null,
-          decreased           = previousOutstanding === null || outstanding < previousOutstanding,
-          lastDecreasedAt     = decreased
-              ? observedAt
-              : (Number.isFinite(previous?.lastDecreasedAt) ? previous.lastDecreasedAt : observedAt);
+    const
+        previousRemaining = Number.isSafeInteger(previous?.remaining)
+            ? previous.remaining
+            : (Number.isSafeInteger(previous?.outstanding) ? previous.outstanding : null),
+        decreased       = previousRemaining === null || remaining < previousRemaining,
+        lastDecreasedAt = decreased
+            ? observedAt
+            : (Number.isFinite(previous?.lastDecreasedAt) ? previous.lastDecreasedAt : observedAt);
 
     return {
-        state     : outstanding === 0 ? OUTSTANDING_STATE.complete : OUTSTANDING_STATE.outstanding,
-        outstanding,
-        observable: true,
+        state     : remaining === 0 ? OUTSTANDING_STATE.complete : OUTSTANDING_STATE.outstanding,
+        settled,
+        remaining,
+        // Backward-compatible operator field. New writers keep it byte-equal to the authoritative
+        // remaining count; old persisted observations are rejected by the checkpoint normalizer.
+        outstanding: remaining,
+        observable : true,
         lastDecreasedAt,
         observedAt
     };

--- a/learn/agentos/cloud-deployment/TenantIngestionModel.md
+++ b/learn/agentos/cloud-deployment/TenantIngestionModel.md
@@ -360,6 +360,15 @@ Per-repo freshness is surfaced through the existing Memory Core healthcheck orch
             status               : 'active',      // also partial-progress, lease-yield-deferred, degraded, or another bounded lane state
             checkpointStatus     : 'complete',    // 'pending' | 'failed' | 'complete' | 'uninitialized' | 'unsupported'
             lastSyncDeletedCount : 0,
+            corpusOutstanding    : {
+                state          : 'outstanding',   // 'complete' | 'outstanding' | 'unobservable'
+                observable     : true,
+                settled        : 250,             // cumulative accepted work already settled
+                remaining      : 618,             // authoritative provider work left
+                outstanding    : 618,             // compatibility alias; always === remaining
+                lastDecreasedAt: 1787300000000,
+                observedAt     : 1787300300000
+            },
             lastErrorCode        : null,          // present only when status !== 'active'
             lastSourceErrorCode  : null           // optional bounded source code, e.g. KB_GITMIRROR_FETCH_FAILED
         }
@@ -368,6 +377,14 @@ Per-repo freshness is surfaced through the existing Memory Core healthcheck orch
 ```
 
 The operator readiness endpoint reads this shape from `HealthService` — there is no need to read Chroma rows for freshness checks. `leaseYielded: true` means the outer hold bound was observed. When a clean cohort leaves work behind, each suppressed row is reported as `lease-yield-deferred`, `leaseDeferredCount` carries the total, and the task outcome is `yielded`. An ordinary failure or deferral retains its stronger `failed` / `deferred` status; if the final active repo had already exhausted the corpus and no tail remained, the outcome stays `completed`. `partialProgressCount` remains distinct because a slice-caused rotation continues the same sweep and does not return the outer lease. Empty `tenantRepos[]` produces `repos: []`, not an omission.
+
+`corpusOutstanding` is cumulative across resumed slices. `settled` includes durable vectors,
+closed durable fences, and terminal provider skips; `remaining` is the exact accepted id set an
+identical next sweep would still offer to provider work. The legacy `outstanding` field remains as
+an alias and must equal `remaining`. A legacy or malformed producer cannot establish that
+partition, so all three counts surface as `null` under `state: 'unobservable'` rather than as a
+reassuring zero. `lastDecreasedAt` advances only when `remaining` decreases; repeated observation
+alone does not make a stalled corpus look fresh.
 
 For authenticated remote MCP diagnostics, the deployment-state bridge also projects a redacted
 `tenantRepoSync` section into `inspect_deployment` / `get_deployment_state_snapshot`. Use that

--- a/test/playwright/unit/ai/daemons/orchestrator/services/DeploymentStateBridgeService.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/services/DeploymentStateBridgeService.spec.mjs
@@ -1617,6 +1617,8 @@ test.describe('Neo.ai.daemons.services.DeploymentStateBridgeService', () => {
             corpusOutstanding: {
                 state          : 'outstanding',
                 observable     : true,
+                settled        : 10_000,
+                remaining      : 40_000,
                 outstanding    : 40_000,
                 lastDecreasedAt: OBSERVED_AT - 5_000,
                 observedAt     : OBSERVED_AT - 1_000
@@ -1628,6 +1630,8 @@ test.describe('Neo.ai.daemons.services.DeploymentStateBridgeService', () => {
         expect(measuredSnapshot.repos[0].corpusOutstanding).toEqual({
             state          : 'outstanding',
             observable     : true,
+            settled        : 10_000,
+            remaining      : 40_000,
             outstanding    : 40_000,
             lastDecreasedAt: OBSERVED_AT - 5_000,
             observedAt     : OBSERVED_AT - 1_000
@@ -1658,10 +1662,13 @@ test.describe('Neo.ai.daemons.services.DeploymentStateBridgeService', () => {
         // with 42 chunks left. Presence-validation admits this; only coherence rejects it. Repairing it
         // to a count would invent an observation nobody made, so it degrades WHOLE.
         for (const incoherent of [
-            {state: 'complete',     observable: true,  outstanding: 42, observedAt: OBSERVED_AT - 1_000},
-            {state: 'outstanding',  observable: true,  outstanding: 0,  observedAt: OBSERVED_AT - 1_000},
-            {state: 'unobservable', observable: true,  outstanding: 7,  observedAt: OBSERVED_AT - 1_000},
-            {state: 'converging',   observable: true,  outstanding: 7,  observedAt: OBSERVED_AT - 1_000}
+            {state: 'complete',     observable: true, settled: 8, remaining: 42, outstanding: 42, observedAt: OBSERVED_AT - 1_000},
+            {state: 'outstanding',  observable: true, settled: 8, remaining: 0,  outstanding: 0,  observedAt: OBSERVED_AT - 1_000},
+            {state: 'outstanding',  observable: true, settled: 8, remaining: 7,  outstanding: 6,  observedAt: OBSERVED_AT - 1_000},
+            {state: 'outstanding',  observable: true, settled: 1.5, remaining: 7, outstanding: 7,  observedAt: OBSERVED_AT - 1_000},
+            {state: 'outstanding',  observable: true, settled: 8, remaining: -1, outstanding: -1, observedAt: OBSERVED_AT - 1_000},
+            {state: 'unobservable', observable: true, settled: 8, remaining: 7,  outstanding: 7,  observedAt: OBSERVED_AT - 1_000},
+            {state: 'converging',   observable: true, settled: 8, remaining: 7,  outstanding: 7,  observedAt: OBSERVED_AT - 1_000}
         ]) {
             const svc  = makeService({...baseCheckpoint, corpusOutstanding: incoherent}),
                   snap = await svc.collectTenantRepoSyncSnapshot({observedAt: OBSERVED_AT});
@@ -1688,24 +1695,26 @@ test.describe('Neo.ai.daemons.services.DeploymentStateBridgeService', () => {
         // readerOfProducerBlind — the ROUND TRIP. A valid `unobservable` straight from the producer was
         // rejected, because `outstanding: null` laundered to 0 and `Number.isFinite(0)` is true. The
         // reader was blind to its own writer's output, which no amount of incoherent-input testing finds.
-        const producerUnobservable = describeCorpusOutstanding({outstanding: null, observedAt: OBSERVED_AT - 1_000}),
+        const producerUnobservable = describeCorpusOutstanding({settled: null, remaining: null, observedAt: OBSERVED_AT - 1_000}),
               roundTrip            = makeService({...baseCheckpoint, corpusOutstanding: producerUnobservable}),
               roundTripSnap        = await roundTrip.collectTenantRepoSyncSnapshot({observedAt: OBSERVED_AT});
 
         expect(roundTripSnap.repos[0].corpusOutstanding).toMatchObject({
             state      : 'unobservable',
             observable : false,
+            settled    : null,
+            remaining  : null,
             outstanding: null
         });
         roundTrip.destroy();
 
         // …and the positive round trip, so the reader is not merely permissive.
-        const producerOutstanding = describeCorpusOutstanding({outstanding: 618, observedAt: OBSERVED_AT - 1_000}),
+        const producerOutstanding = describeCorpusOutstanding({settled: 250, remaining: 618, observedAt: OBSERVED_AT - 1_000}),
               positive            = makeService({...baseCheckpoint, corpusOutstanding: producerOutstanding}),
               positiveSnap        = await positive.collectTenantRepoSyncSnapshot({observedAt: OBSERVED_AT});
 
         expect(positiveSnap.repos[0].corpusOutstanding).toMatchObject({
-            state: 'outstanding', observable: true, outstanding: 618
+            state: 'outstanding', observable: true, settled: 250, remaining: 618, outstanding: 618
         });
         positive.destroy();
 
@@ -3752,10 +3761,10 @@ test.describe('Neo.ai.daemons.services.DeploymentStateBridgeService — identity
  */
 test.describe('Neo.ai.daemons.services.DeploymentStateBridgeService — startup log head', () => {
     const
-        STARTED = '2026-08-18T10:00:00.000Z',
-        WINDOW  = 60_000,
+        STARTED   = '2026-08-18T10:00:00.000Z',
+        WINDOW    = 60_000,
         MAX_LINES = 10_000,
-        cfg     = overrides => ({
+        cfg       = overrides => ({
             includeLogs       : true, logMaxBytes: 32 * 1024, logTail: 120, startupLogWindowMs: WINDOW,
             startupLogMaxLines: MAX_LINES, ...overrides
         }),

--- a/test/playwright/unit/ai/daemons/orchestrator/services/TenantRepoSyncService.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/services/TenantRepoSyncService.spec.mjs
@@ -4625,6 +4625,330 @@ test.describe('TenantRepoSyncService (#11790)', () => {
         expect(errLine).toBeDefined();
     });
 
+    test('#17439 K=2 composes real Vector resume and cumulative settlement through completion', async () => {
+        const
+            SDK                                                                  = await import('../../../../../../../ai/services.mjs'),
+            {default: VectorService}                                             = await import('../../../../../../../ai/services/knowledge-base/VectorService.mjs'),
+            {KB_ChromaManager, KB_Config, KB_IngestionService: IngestionService} = SDK,
+            slugs                                                                = ['org/a', 'org/b', 'org/c', 'org/d'],
+            rows                                                                 = new Map(),
+            graphRows                                                            = new Map(),
+            upsertedIds                                                          = [],
+            ingestionCalls                                                       = [],
+            ingestionSummaries                                                   = [],
+            events                                                               = [],
+            taskStateService                                                     = createInMemoryTaskStateService(),
+            original                                                             = {
+                batchConfig: {
+                    batchDelay: KB_Config.data.batchDelay,
+                    batchSize : KB_Config.data.batchSize,
+                    maxRetries: KB_Config.data.maxRetries
+                },
+                chromaManager                 : IngestionService.chromaManager,
+                embedTexts                    : TextEmbeddingService.embedTexts,
+                getKnowledgeBaseCollection    : KB_ChromaManager.getKnowledgeBaseCollection,
+                getTenantConfig               : IngestionService.getTenantConfig,
+                graphService                  : IngestionService.graphService,
+                recorderService               : IngestionService.recorderService,
+                requestContextService         : IngestionService.requestContextService,
+                resolveEmbeddingGuardrail     : VectorService.resolveEmbeddingGuardrail,
+                resolveEmbeddingInputGuardrail: IngestionService.resolveEmbeddingInputGuardrail,
+                resumeStateDir                : VectorService.resumeStateDir,
+                revisionResolver              : IngestionService.revisionResolver,
+                sourceRegistry                : IngestionService.sourceRegistry,
+                vectorService                 : IngestionService.vectorService
+            };
+
+        TenantRepoSyncService.concurrencyLimit = 2;
+
+        const matchesWhere = (metadata, where) => {
+            if (!where) return true;
+            if (Array.isArray(where.$and)) {
+                return where.$and.every(clause => matchesWhere(metadata, clause))
+            }
+
+            return Object.entries(where).every(([field, condition]) => {
+                const expected = condition && typeof condition === 'object' && '$eq' in condition
+                    ? condition.$eq
+                    : condition;
+
+                return metadata[field] === expected
+            })
+        };
+        const collection = {
+            name: 'tenant-slice-composition',
+            async get({ids, where, limit = 2000, offset = 0, include = []} = {}) {
+                const idFilter = Array.isArray(ids) ? new Set(ids) : null;
+                const selected = [...rows.values()]
+                    .filter(row => (!idFilter || idFilter.has(row.id)) && matchesWhere(row.metadata, where))
+                    .slice(offset, offset + limit);
+
+                return {
+                    ids      : selected.map(row => row.id),
+                    metadatas: include.includes('metadatas') ? selected.map(row => row.metadata) : [],
+                    documents: include.includes('documents') ? selected.map(row => row.document || '') : []
+                }
+            },
+            async upsert({ids, embeddings, metadatas}) {
+                ids.forEach((id, index) => {
+                    const metadata = metadatas[index];
+
+                    rows.set(id, {id, embedding: embeddings[index], metadata});
+                    upsertedIds.push({id, repoSlug: metadata.repoSlug});
+                });
+            },
+            async delete({ids}) {
+                ids.forEach(id => rows.delete(id));
+            },
+            async count() {
+                return rows.size
+            }
+        };
+        const graphService = {
+            async ready() {},
+            getNodeRecord({id}) {
+                return graphRows.get(id) || null
+            },
+            listNodeRecordsByType({type, idPrefix}) {
+                return {
+                    records: [...graphRows.values()]
+                        .filter(record => record.type === type && (!idPrefix || record.id.startsWith(idPrefix)))
+                }
+            },
+            async upsertNode({id, type, properties}) {
+                graphRows.set(id, {id, type, properties: {...properties}});
+            }
+        };
+        const embeddingGuardrail = () => ({
+            recognized               : true,
+            embeddingProvider        : 'openAiCompatible',
+            contextLimitTokens       : 1_000_000,
+            safeProcessingLimitTokens: 800_000,
+            model                    : 'tenant-slice-composition-model'
+        });
+        const envelopeBuilder = async ({tenantId, repoSlug, lastIngestedRev}) => {
+            const count  = repoSlug === 'org/a' ? 3 : 1;
+            const chunks = Array.from({length: count}, (_, index) => ({
+                schemaVersion: '1.0.0',
+                tenantId,
+                repoSlug,
+                rootKind     : 'bare-repo',
+                sourcePath   : `${repoSlug}/chunk-${index}.mjs`,
+                content      : `export const value${index} = '${repoSlug}';`,
+                hashInputs   : ['kind', 'name', 'content', 'sourcePath', 'parserId', 'parserVersion'],
+                parserId     : 'client-parser',
+                parserVersion: '1.0.0',
+                kind         : 'module-context',
+                name         : `${repoSlug}/chunk-${index}.mjs - [Module]`
+            }));
+
+            return {
+                tenantId,
+                repoSlug,
+                files: [{
+                    sourcePath  : `${repoSlug}/fixture.mjs`,
+                    repoSlug,
+                    parsedChunks: chunks
+                }],
+                deleted         : [],
+                headRevision    : `sha-head-${repoSlug}`,
+                manifestSnapshot: {
+                    repoSlug,
+                    pathsAfterPush: chunks.map(chunk => chunk.sourcePath)
+                },
+                ...(lastIngestedRev ? {baseRevision: lastIngestedRev} : {})
+            }
+        };
+
+        let resolveTailStarted;
+        const
+            tailStarted      = new Promise(resolve => { resolveTailStarted = resolve; }),
+            realIngest       = IngestionService.ingestSourceFilesForTenantSync.bind(IngestionService),
+            ingestionService = {
+                getTenantManifest: IngestionService.getTenantManifest.bind(IngestionService),
+                async ingestSourceFilesForTenantSync(payload, controls) {
+                    const slug = payload.repoSlug;
+
+                    ingestionCalls.push(slug);
+                    events.push(`start:${slug}`);
+
+                    if (slug === 'org/a') {
+                        // Expire A's one-millisecond repo budget before Vector starts. Vector must
+                        // still land its first complete batch (forward-progress floor), then the
+                        // production predicate is true at the next safe point.
+                        // fixed-sleep-justification: deterministic precondition, not outcome polling.
+                        await new Promise(resolve => setTimeout(resolve, 5))
+                    }
+
+                    // B deliberately occupies the second real runTask slot. C can be admitted only
+                    // after A returns from VectorService's safe point, and then releases B so the
+                    // tail finishes through the same production ingestion path.
+                    if (slug === 'org/b') {
+                        await tailStarted;
+                    } else if (slug === 'org/c' || slug === 'org/d') {
+                        resolveTailStarted();
+                    }
+
+                    const summary = await realIngest(payload, controls);
+
+                    ingestionSummaries.push({slug, summary});
+                    events.push(`end:${slug}:${summary.yielded ? 'partial-progress' : 'complete'}`);
+                    return summary
+                }
+            },
+            options = {
+                reason           : 'periodic-sweep:60000',
+                taskStateService,
+                tenantReposConfig: {tenantRepos: slugs.map(repoSlug => ({
+                    tenantId: 't1', repoSlug, mirrorRoot, cadenceMs: 1, cloneUrl: `https://github.com/neomjs/${repoSlug.split('/')[1]}.git`
+                }))},
+                gitMirror                    : makeFakeGitMirror(),
+                envelopeBuilder,
+                knowledgeBaseIngestionService: ingestionService,
+                revisionsFilePath            : revisionsFile,
+                leaseGuard                   : async () => {},
+                globalCadenceMs              : 60 * 60 * 1000,
+                jitterRatio                  : 0,
+                sliceBudgetMs                : 1,
+                seedBootstrap                : false
+            };
+
+        try {
+            Object.assign(KB_Config.data, {batchDelay: 5, batchSize: 1, maxRetries: 1});
+            KB_ChromaManager.getKnowledgeBaseCollection = async () => collection;
+            TextEmbeddingService.embedTexts = async texts => texts.map(() => new Array(384).fill(0));
+            VectorService.resumeStateDir = path.join(tmpDir, 'tenant-slice-vector-state');
+            VectorService.resolveEmbeddingGuardrail = embeddingGuardrail;
+
+            IngestionService.chromaManager                  = KB_ChromaManager;
+            IngestionService.getTenantConfig                = async () => ({version: 0});
+            IngestionService.graphService                   = graphService;
+            IngestionService.recorderService                = {recordIngestionMetric() {}};
+            IngestionService.requestContextService          = {
+                getAgentIdentityNodeId: () => '@neo-gpt',
+                getUserId             : () => 't1'
+            };
+            IngestionService.resolveEmbeddingInputGuardrail = embeddingGuardrail;
+            IngestionService.revisionResolver               = null;
+            IngestionService.sourceRegistry                 = {getParserIds: () => [], getParsers: () => []};
+            IngestionService.vectorService                  = VectorService;
+            IngestionService.activeIngestionProgress        = null;
+            IngestionService.lastIngestionProgress          = null;
+
+            const first             = await TenantRepoSyncService.syncTenantRepos(options);
+            const firstAlphaSummary = ingestionSummaries.find(item => item.slug === 'org/a')?.summary;
+
+            expect(firstAlphaSummary, 'the real Vector/Ingestion path must hit a resumable boundary')
+                .toMatchObject({ingested: 3, embeddingsGenerated: 1, yielded: true});
+
+            expect(first.status).toBe('completed');
+            expect(first.details).toMatchObject({
+                completedCount      : 3,
+                partialProgressCount: 1,
+                failedCount         : 0
+            });
+
+            const partial = first.details.repos.find(row => row.repoSlug === 'org/a');
+            const rowsFor = repoSlug => [...rows.values()].filter(row => row.metadata.repoSlug === repoSlug);
+
+            expect(partial).toMatchObject({
+                status           : 'partial-progress',
+                corpusOutstanding: {
+                    state      : 'outstanding',
+                    observable : true,
+                    settled    : 1,
+                    remaining  : 2,
+                    outstanding: 2
+                }
+            });
+            expect(rowsFor('org/a')).toHaveLength(1);
+            expect(events.indexOf('end:org/a:partial-progress')).toBeLessThan(events.indexOf('start:org/c'));
+            expect(rowsFor('org/c')).toHaveLength(1);
+            expect(rowsFor('org/d')).toHaveLength(1);
+            expect((await IngestionService.getTenantManifest({tenantId: 't1', repoSlug: 'org/a'})).materializationReceipt)
+                .toBeNull();
+
+            const firstPersisted = (await fs.readJson(revisionsFile)).revisions;
+
+            expect(firstPersisted['t1/org/a'], 'partial progress persists observation without advancing the revision checkpoint')
+                .toMatchObject({
+                    lastIngestedRev  : null,
+                    corpusOutstanding: {settled: 1, remaining: 2, outstanding: 2}
+                });
+            expect(firstPersisted['t1/org/b'].consecutiveFailures).toBe(0);
+
+            const second        = await TenantRepoSyncService.syncTenantRepos(options);
+            const secondPartial = second.details.repos.find(row => row.repoSlug === 'org/a');
+            const aUpserts      = upsertedIds.filter(row => row.repoSlug === 'org/a');
+
+            expect(second.details.partialProgressCount).toBe(1);
+            expect(secondPartial.corpusOutstanding).toMatchObject({
+                state      : 'outstanding',
+                observable : true,
+                settled    : 2,
+                remaining  : 1,
+                outstanding: 1
+            });
+            expect(ingestionCalls.filter(slug => slug === 'org/a')).toHaveLength(2);
+            expect(rowsFor('org/a')).toHaveLength(2);
+            expect(aUpserts).toHaveLength(2);
+            expect(new Set(aUpserts.map(row => row.id)).size,
+                'the second slice must select a new durable id instead of repurchasing the first').toBe(2);
+            expect((await IngestionService.getTenantManifest({tenantId: 't1', repoSlug: 'org/a'})).materializationReceipt,
+                'a partial slice must never create the retry-receipt shortcut').toBeNull();
+            const secondPersisted = (await fs.readJson(revisionsFile)).revisions['t1/org/a'];
+
+            expect(secondPersisted.lastIngestedRev ?? null).toBeNull();
+            expect(secondPersisted.corpusOutstanding).toMatchObject({
+                settled: 2, remaining: 1, outstanding: 1
+            });
+
+            const third          = await TenantRepoSyncService.syncTenantRepos(options);
+            const thirdCompleted = third.details.repos.find(row => row.repoSlug === 'org/a');
+            const finalUpserts   = upsertedIds.filter(row => row.repoSlug === 'org/a');
+
+            expect(thirdCompleted).toMatchObject({
+                status           : 'active',
+                lastIngestedRev  : 'sha-head',
+                corpusOutstanding: {
+                    state      : 'complete',
+                    observable : true,
+                    settled    : 3,
+                    remaining  : 0,
+                    outstanding: 0
+                }
+            });
+            expect(rowsFor('org/a')).toHaveLength(3);
+            expect(finalUpserts).toHaveLength(3);
+            expect(new Set(finalUpserts.map(row => row.id)).size).toBe(3);
+
+            const finalPersisted = (await fs.readJson(revisionsFile)).revisions['t1/org/a'];
+
+            expect(finalPersisted.lastIngestedRev).toBe('sha-head-org/a');
+            expect(finalPersisted.corpusOutstanding).toMatchObject({
+                settled: 3, remaining: 0, outstanding: 0
+            });
+            expect((await IngestionService.getTenantManifest({tenantId: 't1', repoSlug: 'org/a'})).materializationReceipt,
+                'only the corpus-exhausting slice may publish the positive materialization proof').toBeTruthy();
+        } finally {
+            Object.assign(KB_Config.data, original.batchConfig);
+            KB_ChromaManager.getKnowledgeBaseCollection       = original.getKnowledgeBaseCollection;
+            TextEmbeddingService.embedTexts                   = original.embedTexts;
+            VectorService.resolveEmbeddingGuardrail           = original.resolveEmbeddingGuardrail;
+            VectorService.resumeStateDir                      = original.resumeStateDir;
+            IngestionService.chromaManager                    = original.chromaManager;
+            IngestionService.getTenantConfig                  = original.getTenantConfig;
+            IngestionService.graphService                     = original.graphService;
+            IngestionService.recorderService                  = original.recorderService;
+            IngestionService.requestContextService            = original.requestContextService;
+            IngestionService.resolveEmbeddingInputGuardrail   = original.resolveEmbeddingInputGuardrail;
+            IngestionService.revisionResolver                 = original.revisionResolver;
+            IngestionService.sourceRegistry                   = original.sourceRegistry;
+            IngestionService.vectorService                    = original.vectorService;
+        }
+    });
+
+
     test('concurrency-gate: concurrencyLimit=1 serializes per-repo work (#11942 AC2)', async () => {
         TenantRepoSyncService.concurrencyLimit = 1;
 
@@ -7003,16 +7327,14 @@ test.describe('TenantRepoSyncService (#11790)', () => {
                 summaryFactory() {
                     ingestCallCount++;
 
-                    // Run 1: 100 embeddable accepted, 10 DISJOINT guardrail rejections, 30 embedded
-                    // before the provider gave out -> 70 outstanding. Run 2: the corpus fully embedded.
-                    //
-                    // 110 total - 30 embedded - 10 declined = 70, which is identically 100 - 30:
-                    // `ingested` and `skippedOversized` are disjoint (the progress projection sums
-                    // them for its total), so the declined chunks cancel out instead of inflating a
-                    // backlog that could never reach zero.
+                    // Run 1: 100 unique accepted, 30 cumulatively settled, 70 remaining. Run 2:
+                    // the identical accepted corpus is fully settled. `embeddingsGenerated` stays
+                    // the newly-landed term and is deliberately not used to reconstruct remainder.
                     return ingestCallCount === 1
                         ? {
                             ingested           : 100,
+                            settled            : 30,
+                            remaining          : 70,
                             skippedOversized   : 10,
                             embeddingsGenerated: 30,
                             deleted            : 0,
@@ -7020,6 +7342,8 @@ test.describe('TenantRepoSyncService (#11790)', () => {
                         }
                         : {
                             ingested           : 100,
+                            settled            : 100,
+                            remaining          : 0,
                             skippedOversized   : 10,
                             embeddingsGenerated: 100,
                             deleted            : 0,
@@ -7040,6 +7364,8 @@ test.describe('TenantRepoSyncService (#11790)', () => {
         expect(deferredRun.status).toBe('deferred');
 
         expect(deferredState.corpusOutstanding.outstanding).toBe(70);
+        expect(deferredState.corpusOutstanding.remaining).toBe(70);
+        expect(deferredState.corpusOutstanding.settled).toBe(30);
         expect(deferredState.corpusOutstanding.observable).toBe(true);
         expect(deferredState.corpusOutstanding.state).toBe('outstanding');
 
@@ -7056,6 +7382,8 @@ test.describe('TenantRepoSyncService (#11790)', () => {
 
         expect(completedRun.status).toBe('completed');
         expect(completedState.corpusOutstanding.outstanding).toBe(0);
+        expect(completedState.corpusOutstanding.remaining).toBe(0);
+        expect(completedState.corpusOutstanding.settled).toBe(100);
         expect(completedState.corpusOutstanding.state).toBe('complete');
 
         const completedProjection = completedRun.details.repos.find(row => row.repoSlug === slug);
@@ -7063,46 +7391,61 @@ test.describe('TenantRepoSyncService (#11790)', () => {
         expect(completedProjection.corpusOutstanding.outstanding).toBe(0);
     });
 
-    test('a summary that never reported embeddings publishes UNKNOWN, never a reassuring zero', async () => {
+    test('a summary that never reported settlement publishes UNKNOWN, never a reassuring zero', async () => {
         // The empty-is-not-success guard, at the surface rather than in the helper. A run whose
-        // summary omits `embeddingsGenerated` was not measured; publishing `0` there would claim a
-        // finished corpus on the strength of a missing field, which is the exact defect this ticket
-        // family exists to close — and it would be indistinguishable from the completed case above.
+        // summary omits `settled` / `remaining` was not measured; publishing `0` there would claim
+        // a finished corpus on the strength of missing fields, which is the exact defect this ticket
+        // closes. The second run supplies an internally impossible tuple; present-but-invalid is no
+        // more authoritative than absent.
         const
             taskStateService = createInMemoryTaskStateService(),
             slug             = 'org/unmeasured-outstanding',
-            repoLabel        = `t1/${slug}`;
+            repoLabel        = `t1/${slug}`,
+            options          = {
+                reason           : 'periodic-sweep:60000',
+                taskStateService,
+                tenantReposConfig: {tenantRepos: [
+                    {tenantId: 't1', repoSlug: slug, mirrorRoot, cloneUrl: 'https://github.com/neomjs/unmeasured.git'}
+                ]},
+                gitMirror                    : makeFakeGitMirror(),
+                envelopeBuilder              : makeFakeEnvelopeBuilder(),
+                knowledgeBaseIngestionService: makeFakeIngestionService({
+                    summaryFactory: () => ++summaryCallCount === 1
+                        ? {ingested: 5, embeddingsGenerated: 5, deleted: 0, errors: [{code: 'KB_VECTOR_EMBED_CONNECTION_REFUSED'}]}
+                        : {ingested: 5, embeddingsGenerated: 5, settled: 6, remaining: 0, deleted: 0, errors: [{code: 'KB_VECTOR_EMBED_CONNECTION_REFUSED'}]}
+                }),
+                revisionsFilePath: revisionsFile,
+                globalCadenceMs  : 0,
+                jitterRatio      : 0,
+                backoffCapMs     : 7_200_000,
+                seedBootstrap    : false
+            };
+
+        let summaryCallCount = 0;
 
         await provisionMirrorDir({tenantId: 't1', repoSlug: slug});
 
-        const run = await TenantRepoSyncService.runTask({
-            reason           : 'periodic-sweep:60000',
-            taskStateService,
-            tenantReposConfig: {tenantRepos: [
-                {tenantId: 't1', repoSlug: slug, mirrorRoot, cloneUrl: 'https://github.com/neomjs/unmeasured.git'}
-            ]},
-            gitMirror      : makeFakeGitMirror(),
-            envelopeBuilder: makeFakeEnvelopeBuilder(),
-            // No `embeddingsGenerated` — the shape every pre-existing fixture in this file uses.
-            knowledgeBaseIngestionService: makeFakeIngestionService({
-                summaryFactory: () => ({ingested: 5, deleted: 0, errors: [{code: 'KB_VECTOR_EMBED_CONNECTION_REFUSED'}]})
-            }),
-            revisionsFilePath: revisionsFile,
-            globalCadenceMs  : 0,
-            jitterRatio      : 0,
-            backoffCapMs     : 7_200_000,
-            seedBootstrap    : false
-        });
+        const run = await TenantRepoSyncService.runTask(options);
 
         const state = (await fs.readJson(revisionsFile)).revisions[repoLabel];
 
         expect(run.status).toBe('deferred');
         expect(state.corpusOutstanding.observable).toBe(false);
+        expect(state.corpusOutstanding.settled).toBeNull();
+        expect(state.corpusOutstanding.remaining).toBeNull();
         expect(state.corpusOutstanding.outstanding).toBeNull();
         expect(state.corpusOutstanding.state).toBe('unobservable');
         // The discrimination stated as a comparison, so a future change that collapses unknown into
         // zero fails here rather than passing quietly on a plausible-looking number.
         expect(state.corpusOutstanding.outstanding).not.toBe(0);
+
+        await TenantRepoSyncService.runTask(options);
+
+        const malformedState = (await fs.readJson(revisionsFile)).revisions[repoLabel];
+
+        expect(malformedState.corpusOutstanding).toMatchObject({
+            state: 'unobservable', observable: false, settled: null, remaining: null, outstanding: null
+        });
     });
 
     /*

--- a/test/playwright/unit/ai/services/knowledge-base/IngestionService.spec.mjs
+++ b/test/playwright/unit/ai/services/knowledge-base/IngestionService.spec.mjs
@@ -170,7 +170,13 @@ test.describe('IngestionService.ingestSourceFiles', () => {
             embed                       : async (filePath, options) => {
                 const lines = (await fs.readFile(filePath, 'utf8')).trim().split('\n').filter(Boolean);
                 vectorCalls.push({filePath, options, records: lines.map(line => JSON.parse(line))});
-                return {message: 'Embedding complete. Collection now contains 1 items.', embedded: lines.length, deleted: 0};
+                return {
+                    message  : 'Embedding complete. Collection now contains 1 items.',
+                    embedded : lines.length,
+                    settled  : lines.length,
+                    remaining: 0,
+                    deleted  : 0
+                };
             }
         };
         Service.activeIngestionProgress = null;
@@ -215,6 +221,83 @@ test.describe('IngestionService.ingestSourceFiles', () => {
         });
     });
 
+    test('#17439 aggregates cumulative settlement across repo groups without redefining accepted or newly landed', async () => {
+        Service.vectorService.embed = async filePath => {
+            const records  = (await fs.readFile(filePath, 'utf8')).trim().split('\n').filter(Boolean).map(line => JSON.parse(line)),
+                  repoSlug = records[0].repoSlug;
+
+            return repoSlug === 'repo-a'
+                ? {message: 'slice stopped', embedded: 1, settled: 1, remaining: 1, deleted: 0, yielded: true}
+                : {message: 'already durable', embedded: 0, settled: 1, remaining: 0, deleted: 0, yielded: false}
+        };
+
+        const summary = await Service.ingestSourceFiles({
+            tenantId: 'tenant-a',
+            files   : [{parsedChunks: [
+                validParsedChunk({sourcePath: 'src/a.js', name: 'a', content: 'a'}),
+                validParsedChunk({sourcePath: 'src/b.js', name: 'b', content: 'b'}),
+                validParsedChunk({repoSlug: 'repo-b', sourcePath: 'src/c.js', name: 'c', content: 'c'})
+            ]}]
+        });
+
+        expect(summary).toMatchObject({
+            ingested           : 3,
+            embeddingsGenerated: 1,
+            settled            : 2,
+            remaining          : 1,
+            yielded            : true
+        });
+        expect(summary.settled + summary.remaining, 'the partition stays anchored to accepted').toBe(summary.ingested)
+    });
+
+    test('#17439 one missing legacy producer makes the multi-group aggregate unobserved without inventing an error', async () => {
+        Service.vectorService.embed = async filePath => {
+            const records = (await fs.readFile(filePath, 'utf8')).trim().split('\n').filter(Boolean).map(line => JSON.parse(line));
+
+            return records[0].repoSlug === 'repo-a'
+                ? {message: 'observed', embedded: 1, settled: 1, remaining: 0, deleted: 0}
+                : {message: 'legacy producer', embedded: 1, deleted: 0}
+        };
+
+        const summary = await Service.ingestSourceFiles({
+            tenantId: 'tenant-a',
+            files   : [{parsedChunks: [
+                validParsedChunk({sourcePath: 'src/a.js', name: 'a', content: 'a'}),
+                validParsedChunk({repoSlug: 'repo-b', sourcePath: 'src/b.js', name: 'b', content: 'b'})
+            ]}]
+        });
+
+        expect(summary.embeddingsGenerated).toBe(2);
+        expect(summary.settled).toBeNull();
+        expect(summary.remaining).toBeNull();
+        expect(summary.errors).toEqual([]);
+        expect(Service.getIngestionProgress().lastRunSummary.remaining,
+            'the diagnostics surface preserves unobserved instead of falling back to accepted minus per-call embedded').toBeNull()
+    });
+
+    test('#17439 malformed present settlement fields fail loud and can never project zero remaining', async () => {
+        const invalidTuples = [
+            {settled: 1},
+            {remaining: 0},
+            {settled: -1, remaining: 2},
+            {settled: 0.5, remaining: 0.5},
+            {settled: 2, remaining: 0}
+        ];
+
+        for (const tuple of invalidTuples) {
+            Service.vectorService.embed = async () => ({message: 'invalid tuple', embedded: 0, deleted: 0, ...tuple});
+
+            const summary = await Service.ingestSourceFiles({
+                tenantId: 'tenant-a',
+                files   : [{parsedChunks: [validParsedChunk()]}]
+            });
+
+            expect(summary.settled, JSON.stringify(tuple)).toBeNull();
+            expect(summary.remaining, JSON.stringify(tuple)).toBeNull();
+            expect(summary.errors.some(error => error.code === 'KB_VECTOR_EMBED_SETTLEMENT_INVALID'), JSON.stringify(tuple)).toBe(true)
+        }
+    });
+
     test('#16995: the unwrapped tenant-sync entry preserves circuit controls outside OpenAPI', async () => {
         const controller        = new AbortController(),
               onProviderTimeout = () => {};
@@ -252,6 +335,8 @@ test.describe('IngestionService.ingestSourceFiles', () => {
             return {
                 message       : 'Embedding completed with one poison fenced.',
                 embedded      : 0,
+                settled       : 1,
+                remaining     : 0,
                 deleted       : 0,
                 poisonedChunks: [{
                     chunkId,
@@ -270,6 +355,7 @@ test.describe('IngestionService.ingestSourceFiles', () => {
 
         expect(vectorCalls[0].options.replayEmbeddingPoison).toBe(true);
         expect(summary.embeddingsGenerated).toBe(0);
+        expect(summary).toMatchObject({ingested: 1, settled: 1, remaining: 0});
         expect(summary.errors).toEqual([{
             code   : 'KB_VECTOR_EMBED_CONNECTION_REFUSED',
             message: 'A proven embedding poison remains fenced pending changed content, generation, or explicit replay.',
@@ -405,6 +491,16 @@ test.describe('IngestionService.ingestSourceFiles', () => {
         expect(summaryLine).toBeTruthy();
         expect(summaryLine).toMatch(/THIS PROCESS/);
         expect(summaryLine.split('x-neo-tool-summary:')[1].trim().length).toBeLessThanOrEqual(120);
+
+        const ingestSchema = spec.slice(
+            spec.indexOf('IngestSourceFilesResponse:'),
+            spec.indexOf('IngestionProgressResponse:')
+        );
+
+        expect(ingestSchema).toMatch(/settled:\n\s+type: integer\n\s+nullable: true/);
+        expect(ingestSchema).toMatch(/remaining:\n\s+type: integer\n\s+nullable: true/);
+        expect(ingestSchema).toMatch(/ingested:[\s\S]*accepted/);
+        expect(schema.slice(0, 5000)).toMatch(/remaining:\n\s+type: integer\n\s+nullable: true/)
     });
 
     test('reports active ingestion progress and preserves the last-run summary (#14028)', async () => {
@@ -417,7 +513,13 @@ test.describe('IngestionService.ingestSourceFiles', () => {
             vectorCalls.push({filePath, options, records: lines.map(line => JSON.parse(line))});
             activeSnapshot = Service.getIngestionProgress({staleAfterMs: 60000});
             await embedGate;
-            return {message: 'Embedding complete.', embedded: lines.length, deleted: 0};
+            return {
+                message  : 'Embedding complete.',
+                embedded : lines.length,
+                settled  : lines.length,
+                remaining: 0,
+                deleted  : 0
+            };
         };
 
         const ingestPromise = Service.ingestSourceFiles({
@@ -445,7 +547,9 @@ test.describe('IngestionService.ingestSourceFiles', () => {
         releaseEmbed();
 
         const summary = await ingestPromise;
+        expect(summary.ingested, 'accepted stays distinct from newly landed').toBe(1);
         expect(summary.embeddingsGenerated).toBe(1);
+        expect(summary).toMatchObject({settled: 1, remaining: 0});
 
         const idle = Service.getIngestionProgress();
         expect(idle).toMatchObject({

--- a/test/playwright/unit/ai/services/knowledge-base/VectorService.WorkVolumeBranching.spec.mjs
+++ b/test/playwright/unit/ai/services/knowledge-base/VectorService.WorkVolumeBranching.spec.mjs
@@ -313,6 +313,7 @@ test.describe('VectorService.embed — work-volume branching (#10572)', () => {
 
         expect(result.message).toContain('No changes detected');
         expect('error' in result).toBe(false);
+        expect(result).toMatchObject({embedded: 0, settled: 3, remaining: 0, yielded: false});
         expect(spy.calls.upsert).toBe(0); // no embedding work attempted
     });
 
@@ -327,6 +328,7 @@ test.describe('VectorService.embed — work-volume branching (#10572)', () => {
 
         expect('error' in result).toBe(false);
         expect(result.message).toContain('Embedding complete');
+        expect(result).toMatchObject({embedded: 3, settled: 3, remaining: 0});
         expect(spy.calls.upsert).toBeGreaterThan(0); // embedding actually happened
     });
 
@@ -359,6 +361,7 @@ test.describe('VectorService.embed — work-volume branching (#10572)', () => {
             const firstPoisonId = first.poisonedChunks[0].chunkId;
 
             expect(first.embedded).toBe(2);
+            expect(first).toMatchObject({settled: 3, remaining: 0});
             expect(first.poisonedChunks).toHaveLength(1);
             expect(providerCalls).toBe(4);
             expect(JSON.stringify(first.poisonedChunks)).not.toContain('private provider detail');
@@ -368,6 +371,7 @@ test.describe('VectorService.embed — work-volume branching (#10572)', () => {
 
             expect(providerCalls, 'unchanged poison is never re-offered').toBe(beforeSecondSweep);
             expect(second.embedded).toBe(0);
+            expect(second).toMatchObject({settled: 3, remaining: 0});
             expect(second.poisonedChunks).toEqual(first.poisonedChunks);
             expect(second.message).toContain('proven poison');
 
@@ -558,6 +562,7 @@ test.describe('VectorService.embed — work-volume branching (#10572)', () => {
         const result = await KB_VectorService.embed(fixturePath);
 
         expect(result.embedded).toBe(0);
+        expect(result).toMatchObject({settled: 1, remaining: 0});
         expect(explicitProviders).toEqual([]); // the provider was never called
         expect(spy.calls.upsert).toBe(0);
     });
@@ -588,6 +593,7 @@ test.describe('VectorService.embed — work-volume branching (#10572)', () => {
         const result = await KB_VectorService.embed(fixturePath);
 
         expect(result.embedded).toBe(1);
+        expect(result).toMatchObject({settled: 1, remaining: 0});
         expect(explicitProviders).toEqual(['gemini']);
         expect(spy.calls.upsert).toBe(1);
     });
@@ -627,7 +633,7 @@ test.describe('VectorService.embed — work-volume branching (#10572)', () => {
 
         expect('error' in result).toBe(false);
         expect(result.staleStrategy).toBe('shadow-swap');
-        expect(result.embedded).toBe(3);
+        expect(result).toMatchObject({embedded: 3, settled: 3, remaining: 0});
         expect(result.deleted).toBe(1);
         expect(result.shadowCollection).toContain(`${KB_Config.data.collectionName}-shadow-`);
         expect(result.parkedCollection).toContain(`${KB_Config.data.collectionName}-parking-`);
@@ -795,41 +801,63 @@ test.describe('VectorService.embed — work-volume branching (#10572)', () => {
         }
     });
 
-    test('shadow-swap PRESERVES the shadow on a cooperative lease YIELD — no promote, marker intact', async () => {
-        const live                = createSpyCollection({existingIds: [], name: KB_Config.data.collectionName});
-        const originalEmbedChunks = KB_VectorService.embedChunks.bind(KB_VectorService);
+    test('#17439 shadow-swap resume keeps embedded per-call while settlement advances cumulatively', async () => {
+        const
+            live          = createSpyCollection({existingIds: [], name: KB_Config.data.collectionName}),
+            originalBatch = {
+                batchDelay: KB_Config.data.batchDelay,
+                batchSize : KB_Config.data.batchSize,
+                maxRetries: KB_Config.data.maxRetries
+            };
+
         let shadow;
 
         KB_ChromaManager.client = {
+            getCollection: async ({name}) => {
+                if (shadow?.name === name) return shadow;
+                throw new Error(`Collection ${name} does not exist.`)
+            },
             createCollection: async ({name}) => {
                 shadow = createSpyCollection({name});
                 return shadow;
             }
         };
-        // Simulate embedChunks yielding mid-corpus — the embedChunks-level yield mechanism (between-batch,
-        // forward-progress) is covered in VectorService.leaseYield.spec.mjs; here we assert embedViaShadowSwap's
-        // yield HANDLING reuses the same preserve-not-promote path as a transient failure.
-        KB_VectorService.embedChunks = async () => ({embedded: 1, skipped: 0, yielded: true});
+        KB_ChromaManager.getKnowledgeBaseCollection = async () => {
+            return shadow?.name === KB_Config.data.collectionName ? shadow : live
+        };
+        Object.assign(KB_Config.data, {batchDelay: 0, batchSize: 1, maxRetries: 1});
+        writeFixtureJsonl(fixturePath, 3);
 
         try {
-            const result = await KB_VectorService.embedViaShadowSwap({
-                liveCollection  : live,
-                knowledgeBase   : [{id: 'chunk-0', type: 'method', name: 'method0'}],
-                idsToDeleteCount: 0,
-                shouldYield     : () => true
+            const first = await KB_VectorService.embed(fixturePath, {
+                staleStrategy: 'shadow-swap',
+                shouldYield  : () => true
             });
 
-            // On yield: a {yielded:true} envelope (the lease holder releases on it), the shadow is preserved-
-            // not-promoted (NEITHER collection renamed), and the write-ahead resume marker is NOT cleared — so
-            // the next sweep re-acquires and resumes from the completed batches instead of rebuilding.
-            expect(result.yielded).toBe(true);
+            expect(first).toMatchObject({embedded: 1, settled: 1, remaining: 2, yielded: true});
             expect(live.calls.modify).toEqual([]);
             expect(shadow.calls.modify).toEqual([]);
 
             const resumeState = await readResumeState({dir: KB_VectorService.resumeStateDir});
             expect(resumeState?.shadowName).toBe(shadow.name);
+
+            const second = await KB_VectorService.embed(fixturePath, {
+                staleStrategy: 'shadow-swap',
+                shouldYield  : () => true
+            });
+
+            expect(second).toMatchObject({embedded: 1, settled: 2, remaining: 1, yielded: true});
+
+            const completed = await KB_VectorService.embed(fixturePath, {
+                staleStrategy: 'shadow-swap',
+                shouldYield  : () => false
+            });
+
+            expect(completed).toMatchObject({embedded: 1, settled: 3, remaining: 0});
+            expect(shadow.rows.size).toBe(3);
+            expect(shadow.name).toBe(KB_Config.data.collectionName)
         } finally {
-            KB_VectorService.embedChunks = originalEmbedChunks;
+            Object.assign(KB_Config.data, originalBatch)
         }
     });
 

--- a/test/playwright/unit/ai/services/knowledge-base/VectorService.batchFailureIsolation.spec.mjs
+++ b/test/playwright/unit/ai/services/knowledge-base/VectorService.batchFailureIsolation.spec.mjs
@@ -136,7 +136,7 @@ test.describe('VectorService.embedChunks — one failing batch must not strand t
 
         expect(providerCalls, 'nothing to embed must reach the provider zero times').toBe(0);
         expect(spy.upsertedIds, 'and nothing may be written').toEqual([]);
-        expect(result).toEqual({embedded: 0, skipped: 0, yielded: false});
+        expect(result).toEqual({embedded: 0, settled: 0, remaining: 0, skipped: 0, yielded: false});
     });
 
     test('a poisoned batch is skipped and every LATER batch still embeds', async () => {
@@ -158,6 +158,7 @@ test.describe('VectorService.embedChunks — one failing batch must not strand t
 
         // The remainder is the whole point: batch 3 must not be collateral damage from batch 2.
         expect(result.embedded).toBe(100);
+        expect(result).toMatchObject({settled: 100, remaining: 50});
         expect(spy.upsertedIds).toContain('chunk-0');
         expect(spy.upsertedIds).toContain('chunk-149');
         expect(spy.upsertedIds).not.toContain('chunk-50');
@@ -195,6 +196,7 @@ test.describe('VectorService.embedChunks — one failing batch must not strand t
 
         expect(providerCalls).toBe(7);
         expect(result.embedded).toBe(3);
+        expect(result).toMatchObject({settled: 4, remaining: 0});
         expect(spy.upsertedIds.sort()).toEqual(['chunk-1', 'chunk-2', 'chunk-3']);
         expect(result.failedBatches).toEqual([]);
         expect(result.poisonedChunks).toEqual([{
@@ -254,6 +256,7 @@ test.describe('VectorService.embedChunks — one failing batch must not strand t
 
         expect(providerCalls).toBe(3);
         expect(result.embedded).toBe(2);
+        expect(result).toMatchObject({settled: 2, remaining: 0});
         expect(result.poisonedChunks).toEqual([]);
         expect(poisonWrites).toBe(0);
         expect(spy.upsertedIds.sort()).toEqual(['chunk-0', 'chunk-1']);
@@ -388,6 +391,7 @@ test.describe('VectorService.embedChunks — one failing batch must not strand t
         const result = await KB_VectorService.embedChunks({collection: spy, chunksToProcess: chunks});
 
         expect(result.embedded).toBe(150);
+        expect(result).toMatchObject({settled: 150, remaining: 0});
         expect(result.failedBatches).toHaveLength(0);
         expect(spy.calls.upsert).toBe(3);
     });
@@ -590,6 +594,8 @@ test.describe('VectorService.embedChunks — one failing batch must not strand t
 
             const poisonResult = await runWith({
                 embedded      : 2,
+                settled       : 3,
+                remaining     : 0,
                 skipped       : 0,
                 yielded       : false,
                 failedBatches : [],
@@ -601,6 +607,7 @@ test.describe('VectorService.embedChunks — one failing batch must not strand t
             });
 
             expect(poisonResult.poisonedChunks).toHaveLength(1);
+            expect(poisonResult).toMatchObject({embedded: 2, settled: 3, remaining: 0});
             expect(poisonResult.message).toContain('preserved without promotion');
             expect(renames, 'poison-bearing shadow remains preserved and never promotes').toEqual([]);
 
@@ -611,8 +618,10 @@ test.describe('VectorService.embedChunks — one failing batch must not strand t
             };
             shadow.get = async () => ({ids: [restoredPoison.chunkId]});
 
-            await runWith({
+            const restoredResult = await runWith({
                 embedded      : 2,
+                settled       : 2,
+                remaining     : 0,
                 skipped       : 0,
                 yielded       : false,
                 failedBatches : [],
@@ -622,6 +631,9 @@ test.describe('VectorService.embedChunks — one failing batch must not strand t
             expect(observedKnownPoisonEntries,
                 'a vector already restored in the resumable shadow is not an unresolved poison hole')
                 .toEqual([]);
+            expect(restoredResult,
+                'the existing shadow row is cumulative settlement, never newly embedded work')
+                .toMatchObject({embedded: 2, settled: 3, remaining: 0});
         } finally {
             KB_VectorService.embedChunks                        = originalEmbedChunks;
             ChromaManager.client                                = originalClient;

--- a/test/playwright/unit/ai/services/knowledge-base/VectorService.leaseYield.spec.mjs
+++ b/test/playwright/unit/ai/services/knowledge-base/VectorService.leaseYield.spec.mjs
@@ -135,6 +135,7 @@ test.describe('VectorService.embedChunks — cooperative lease yield-point', () 
         // Only the i=0 batch embedded before the i>0 checkpoint yielded — never zero (no livelock).
         expect(result.yielded).toBe(true);
         expect(result.embedded).toBe(50);
+        expect(result).toMatchObject({settled: 50, remaining: 100});
         expect(spy.calls.upsert).toBe(1);
         expect(spy.upsertedIds).toHaveLength(50);
     });
@@ -153,6 +154,7 @@ test.describe('VectorService.embedChunks — cooperative lease yield-point', () 
 
         expect(result.yielded).toBe(true);
         expect(result.embedded).toBe(100); // the i=0 and i=50 batches landed
+        expect(result).toMatchObject({settled: 100, remaining: 100});
         expect(spy.calls.upsert).toBe(2);
     });
 
@@ -180,6 +182,7 @@ test.describe('VectorService.embedChunks — cooperative lease yield-point', () 
 
             expect(result.yielded).toBe(true);
             expect(result.embedded, 'the delay completed before batch 2, so only batch 1 may land').toBe(2);
+            expect(result).toMatchObject({settled: 2, remaining: 4});
             expect(spy.calls.upsert).toBe(1);
         } finally {
             KB_VectorService.timeout = originalTimeout
@@ -194,6 +197,7 @@ test.describe('VectorService.embedChunks — cooperative lease yield-point', () 
 
         expect(result.yielded).toBe(false);
         expect(result.embedded).toBe(150);
+        expect(result).toMatchObject({settled: 150, remaining: 0});
         expect(spy.calls.upsert).toBe(3);
     });
 
@@ -245,6 +249,7 @@ test.describe('VectorService.embedChunks — cooperative lease yield-point', () 
         // Progress made before the yield is durable and is what `selectResumableChunks` skips next sweep:
         // batch 1 in full, plus the 5 inputs batch 2 completed before releasing.
         expect(result.embedded).toBe(55);
+        expect(result).toMatchObject({settled: 55, remaining: 95});
         expect(spy.calls.upsert).toBe(2);
         expect(spy.upsertedIds).toHaveLength(55);
     });
@@ -281,6 +286,7 @@ test.describe('VectorService.embedChunks — cooperative lease yield-point', () 
         expect(embedCalls, 'batches 3 and 4 must not run').toBe(2);
         expect(result.yielded).toBe(true);
         expect(result.embedded, 'batch 1 in full, plus the 5 inputs batch 2 completed before releasing').toBe(55);
+        expect(result).toMatchObject({settled: 55, remaining: 145});
         expect(spy.calls.upsert).toBe(2);
     });
 
@@ -309,6 +315,7 @@ test.describe('VectorService.embedChunks — cooperative lease yield-point', () 
         expect(embedCalls).toBe(3);
         expect(result.yielded).toBe(false);
         expect(result.embedded).toBe(50);
+        expect(result).toMatchObject({settled: 50, remaining: 0});
     });
 
     test('an inner yield PERSISTS the chunks it already paid for (#16822)', async () => {
@@ -336,6 +343,7 @@ test.describe('VectorService.embedChunks — cooperative lease yield-point', () 
         // worse than the livelock.
         expect(result.yielded).toBe(true);
         expect(result.embedded, 'completed provider work must count as embedded').toBe(10);
+        expect(result).toMatchObject({settled: 10, remaining: 40});
         expect(spy.upsertedIds).toEqual(chunks.slice(0, 10).map(chunk => chunk.id));
 
         // Each id must carry ITS OWN vector. With an all-zero embedder the assertion above passes under a

--- a/test/playwright/unit/ai/services/knowledge-base/helpers/corpusOutstanding.spec.mjs
+++ b/test/playwright/unit/ai/services/knowledge-base/helpers/corpusOutstanding.spec.mjs
@@ -3,8 +3,8 @@ import Neo            from '../../../../../../../src/Neo.mjs';
 import * as core      from '../../../../../../../src/core/_export.mjs';
 import {
     OUTSTANDING_STATE,
-    deriveOutstanding,
-    describeCorpusOutstanding
+    describeCorpusOutstanding,
+    normalizeSettlementCounts
 } from '../../../../../../../ai/services/knowledge-base/helpers/corpusOutstanding.mjs';
 
 /**
@@ -15,81 +15,56 @@ import {
  * third case is the one that recreates the original defect if it collapses into the first.
  */
 
-test.describe('deriveOutstanding — the run leaves a real remainder', () => {
-    test('a completed run leaves nothing outstanding', () => {
-        expect(deriveOutstanding({total: 868, embedded: 868})).toBe(0);
+test.describe('normalizeSettlementCounts — cumulative settlement stays coherent', () => {
+    test('accepts exact non-negative safe-integer partitions', () => {
+        expect(normalizeSettlementCounts({accepted: 868, settled: 250, remaining: 618}))
+            .toEqual({settled: 250, remaining: 618});
+        expect(normalizeSettlementCounts({accepted: 3, settled: 3, remaining: 0}))
+            .toEqual({settled: 3, remaining: 0});
+        expect(normalizeSettlementCounts({accepted: 0, settled: 0, remaining: 0}))
+            .toEqual({settled: 0, remaining: 0});
     });
 
-    test('a lease-yielded run leaves exactly what it did not reach', () => {
-        // The specimen from the live plane: 18 batches of 50, yielded after 5.
-        expect(deriveOutstanding({total: 868, embedded: 250})).toBe(618);
-    });
-
-    test('deliberately skipped chunks are NOT outstanding', () => {
-        // Guardrail rejections will never embed. Counting them as backlog produces a figure that can never
-        // reach zero, so `complete` would become unreachable for any corpus carrying one oversized chunk.
-        expect(deriveOutstanding({total: 100, embedded: 90, skipped: 10})).toBe(0);
-
-        // …and the skip must subtract exactly once. Asserted at a NON-ZERO remainder because the zero case
-        // above passes identically against a stub that ignores its inputs and returns 0 — which a mutation
-        // run proved: `return 0` survived four of the five cases in this block.
-        expect(deriveOutstanding({total: 100, embedded: 60, skipped: 10})).toBe(30);
-    });
-
-    test('ARITHMETIC PIN: the remainder tracks each input independently', () => {
-        // Every case here has a distinct non-zero expectation, so no constant-returning implementation and
-        // no single-input implementation can satisfy the set.
-        expect(deriveOutstanding({total: 868, embedded: 0}))              .toBe(868);
-        expect(deriveOutstanding({total: 868, embedded: 50}))             .toBe(818);
-        expect(deriveOutstanding({total: 868, embedded: 0,  skipped: 8})) .toBe(860);
-        expect(deriveOutstanding({total: 500, embedded: 100, skipped: 25})).toBe(375);
-        expect(deriveOutstanding({total: 1,   embedded: 0}))              .toBe(1);
-    });
-
-    test('THE RA-1 SPECIMEN: contradictory arithmetic is UNMEASURABLE, never complete', () => {
-        // This spec previously asserted the defect. It expected `0` and called it "clamping toward the
-        // claim the numbers are closest to supporting" — publishing a FINISHED corpus for a run whose
-        // own numbers disagree with themselves. There is no reading of `embedded + skipped > total`
-        // that supports "nothing left to do"; the only honest answer is "this cannot be trusted".
-        expect(deriveOutstanding({total: 10, embedded: 12})).toBeNull();
-        expect(deriveOutstanding({total: 10, embedded: 5, skipped: 8})).toBeNull();
-        expect(deriveOutstanding({total: 0,  embedded: 1})).toBeNull();
-
-        // The boundary itself stays measurable — exact exhaustion is a real, coherent zero.
-        expect(deriveOutstanding({total: 10, embedded: 6, skipped: 4})).toBe(0);
-    });
-
-    test('unusable inputs return null, never a reassuring zero', () => {
-        expect(deriveOutstanding({total: NaN, embedded: 0})).toBeNull();
-        expect(deriveOutstanding({total: 10, embedded: undefined})).toBeNull();
-        expect(deriveOutstanding({total: -1, embedded: 0})).toBeNull();
-        expect(deriveOutstanding({})).toBeNull();
+    test('refuses malformed, negative, fractional, and internally inconsistent tuples', () => {
+        for (const candidate of [
+            {accepted: 3, settled: 1, remaining: 1},
+            {accepted: 3, settled: 4, remaining: -1},
+            {accepted: 3, settled: 1.5, remaining: 1.5},
+            {accepted: 3, settled: undefined, remaining: 3},
+            {accepted: Number.MAX_SAFE_INTEGER + 1, settled: 0, remaining: 0}
+        ]) {
+            expect(normalizeSettlementCounts(candidate), JSON.stringify(candidate)).toBeNull()
+        }
     });
 });
 
 test.describe('describeCorpusOutstanding — empty-at-rest vs empty-mid-progress vs never-measured', () => {
     test('zero outstanding is complete', () => {
-        const result = describeCorpusOutstanding({outstanding: 0, observedAt: 1_000});
+        const result = describeCorpusOutstanding({settled: 868, remaining: 0, observedAt: 1_000});
 
         expect(result.state).toBe(OUTSTANDING_STATE.complete);
         expect(result.observable).toBe(true);
         expect(result.outstanding).toBe(0);
+        expect(result.remaining).toBe(0);
+        expect(result.settled).toBe(868);
     });
 
     test('a backlog with no prior observation reports outstanding and stamps its first observation', () => {
-        const result = describeCorpusOutstanding({outstanding: 618, observedAt: 1_000});
+        const result = describeCorpusOutstanding({settled: 250, remaining: 618, observedAt: 1_000});
 
         expect(result.state).toBe(OUTSTANDING_STATE.outstanding);
         expect(result.lastDecreasedAt).toBe(1_000);
     });
 
     test('THE DISCRIMINATION: an unmeasurable backlog is not a complete corpus', () => {
-        const unknown  = describeCorpusOutstanding({outstanding: null, observedAt: 1_000}),
-              complete = describeCorpusOutstanding({outstanding: 0,    observedAt: 1_000});
+        const unknown  = describeCorpusOutstanding({settled: null, remaining: null, observedAt: 1_000}),
+              complete = describeCorpusOutstanding({settled: 1,    remaining: 0,    observedAt: 1_000});
 
         expect(unknown.state).toBe(OUTSTANDING_STATE.unobservable);
         expect(unknown.observable).toBe(false);
         expect(unknown.outstanding).toBeNull();
+        expect(unknown.remaining).toBeNull();
+        expect(unknown.settled).toBeNull();
 
         // The two must not be confusable on any field a caller would branch on.
         expect(unknown.state).not.toBe(complete.state);
@@ -98,9 +73,9 @@ test.describe('describeCorpusOutstanding — empty-at-rest vs empty-mid-progress
     });
 
     test('a shrinking backlog stamps the movement and stays outstanding', () => {
-        const previous = describeCorpusOutstanding({outstanding: 618, observedAt: 1_000}),
+        const previous = describeCorpusOutstanding({settled: 250, remaining: 618, observedAt: 1_000}),
               next     = describeCorpusOutstanding({
-                  outstanding: 300, observedAt: 9_000, previous
+                  settled: 568, remaining: 300, observedAt: 9_000, previous
               });
 
         expect(next.state).toBe(OUTSTANDING_STATE.outstanding);
@@ -108,9 +83,9 @@ test.describe('describeCorpusOutstanding — empty-at-rest vs empty-mid-progress
     });
 
     test('a non-decreasing backlog keeps its ORIGINAL movement stamp', () => {
-        const previous = describeCorpusOutstanding({outstanding: 618, observedAt: 1_000}),
+        const previous = describeCorpusOutstanding({settled: 250, remaining: 618, observedAt: 1_000}),
               next     = describeCorpusOutstanding({
-                  outstanding: 618, observedAt: 2_000, previous
+                  settled: 250, remaining: 618, observedAt: 2_000, previous
               });
 
         expect(next.state).toBe(OUTSTANDING_STATE.outstanding);
@@ -120,10 +95,10 @@ test.describe('describeCorpusOutstanding — empty-at-rest vs empty-mid-progress
     test('re-observing an unmoved backlog does not refresh its movement stamp', () => {
         // The reason the companion measures DECREASE and not observation: a stuck backlog polled every
         // minute for six hours would otherwise report as freshly-moved on every single poll.
-        let state = describeCorpusOutstanding({outstanding: 618, observedAt: 1_000});
+        let state = describeCorpusOutstanding({settled: 250, remaining: 618, observedAt: 1_000});
 
         for (const observedAt of [2_000, 3_000, 4_000, 5_000]) {
-            state = describeCorpusOutstanding({outstanding: 618, observedAt, previous: state});
+            state = describeCorpusOutstanding({settled: 250, remaining: 618, observedAt, previous: state});
         }
 
         expect(state.state).toBe(OUTSTANDING_STATE.outstanding);
@@ -132,9 +107,9 @@ test.describe('describeCorpusOutstanding — empty-at-rest vs empty-mid-progress
     });
 
     test('a growing backlog is not a decrease', () => {
-        const previous = describeCorpusOutstanding({outstanding: 100, observedAt: 1_000}),
+        const previous = describeCorpusOutstanding({settled: 400, remaining: 100, observedAt: 1_000}),
               next     = describeCorpusOutstanding({
-                  outstanding: 400, observedAt: 2_000, previous
+                  settled: 100, remaining: 400, observedAt: 2_000, previous
               });
 
         expect(next.lastDecreasedAt).toBe(1_000);
@@ -144,16 +119,16 @@ test.describe('describeCorpusOutstanding — empty-at-rest vs empty-mid-progress
     test('a failed measurement preserves the prior movement stamp', () => {
         // Otherwise one unreadable poll resets a long-stuck backlog's clock, and the next successful read
         // reports it as recently-moved.
-        const previous = describeCorpusOutstanding({outstanding: 618, observedAt: 1_000}),
-              failed   = describeCorpusOutstanding({outstanding: null, observedAt: 2_000, previous});
+        const previous = describeCorpusOutstanding({settled: 250, remaining: 618, observedAt: 1_000}),
+              failed   = describeCorpusOutstanding({settled: null, remaining: null, observedAt: 2_000, previous});
 
         expect(failed.state).toBe(OUTSTANDING_STATE.unobservable);
         expect(failed.lastDecreasedAt).toBe(1_000);
     });
 
     test('RA-2: a long-unmoved backlog still reports the NEUTRAL state — the producer never claims a trend', () => {
-        const previous = describeCorpusOutstanding({outstanding: 618, observedAt: 1_000}),
-              next     = describeCorpusOutstanding({outstanding: 618, observedAt: 9_999_000, previous});
+        const previous = describeCorpusOutstanding({settled: 250, remaining: 618, observedAt: 1_000}),
+              next     = describeCorpusOutstanding({settled: 250, remaining: 618, observedAt: 9_999_000, previous});
 
         // RA-2 (@neo-gpt): a 618 backlog observed nearly three hours later still reports the NEUTRAL
         // state — the producer makes no motion claim. The honest companion is that `lastDecreasedAt`
@@ -164,7 +139,7 @@ test.describe('describeCorpusOutstanding — empty-at-rest vs empty-mid-progress
     });
 
     test('a missing observedAt is unobservable rather than dated with a substitute clock', () => {
-        const result = describeCorpusOutstanding({outstanding: 618});
+        const result = describeCorpusOutstanding({settled: 250, remaining: 618});
 
         expect(result.state).toBe(OUTSTANDING_STATE.unobservable);
         expect(result.observedAt).toBeNull();
@@ -173,11 +148,13 @@ test.describe('describeCorpusOutstanding — empty-at-rest vs empty-mid-progress
     test('NON-VACUITY CONTROL: the composed shape carries every field a surface branches on', () => {
         // Guards against a stub that returns a plausible-looking object with fields absent — which would let
         // every assertion above pass against a decision that reports nothing.
-        const result = describeCorpusOutstanding({outstanding: 42, observedAt: 7_000});
+        const result = describeCorpusOutstanding({settled: 58, remaining: 42, observedAt: 7_000});
 
-        for (const key of ['state', 'outstanding', 'observable', 'lastDecreasedAt', 'observedAt']) {
+        for (const key of ['state', 'settled', 'remaining', 'outstanding', 'observable', 'lastDecreasedAt', 'observedAt']) {
             expect(result).toHaveProperty(key);
         }
+        expect(result.settled).toBe(58);
+        expect(result.remaining).toBe(42);
         expect(result.outstanding).toBe(42);
         expect(result.state).toBe(OUTSTANDING_STATE.outstanding);
     });


### PR DESCRIPTION
Resolves #17439

Resumed tenant-repository slices now report one cumulative settlement partition instead of reconstructing backlog from the current call's newly generated embeddings. VectorService returns `embedded` as the newly landed delta and `settled` / `remaining` as the cumulative unique-id partition for both incremental and shadow-swap strategies; IngestionService validates and aggregates every repo group; tenant checkpoints persist the same observation with `outstanding === remaining`; and the deployment projection, OpenAPI schema, progress surface, and cloud guide carry the additive contract without introducing another store.

Evidence: L2 (459 focused unit tests, including real Vector → Ingestion → TenantRepo composition with controlled provider/Chroma seams) → L2 required (all #17439 ACs are repository-local accounting and projection contracts). No residuals.

## Deltas from ticket

- The production-composition witness runs three one-batch slices so it proves the full sequence `1 settled / 2 remaining` → `2 / 1` → `3 / 0`, plus checkpoint/receipt behavior at exhaustion; the ticket's minimum two-slice decrease remains covered inside that stronger arm.
- The branch was re-anchored after #17444 landed. Settlement tracking composes with its canonical `buildChunkRowMetadata()` producer and keeps the new `kbEmbeddingInputFormat` stamp on full, carried-prefix, and isolation writes.
- Shadow-swap's historical cumulative `embedded` value is intentionally narrowed to newly landed work, matching the existing Ingestion summary contract; cumulative progress now lives only in `settled` / `remaining`.
- No new persistence authority, queue, or store was added. Legacy/missing producers project null counts; present malformed tuples create a bounded ingestion error and cannot publish a reassuring zero.

## Test Evidence

- `npm run test-unit -- test/playwright/unit/ai/services/knowledge-base/helpers/corpusOutstanding.spec.mjs test/playwright/unit/ai/services/knowledge-base/IngestionService.spec.mjs test/playwright/unit/ai/services/knowledge-base/VectorService.WorkVolumeBranching.spec.mjs test/playwright/unit/ai/services/knowledge-base/VectorService.batchFailureIsolation.spec.mjs test/playwright/unit/ai/services/knowledge-base/VectorService.leaseYield.spec.mjs test/playwright/unit/ai/services/knowledge-base/VectorService.tenantStamping.spec.mjs test/playwright/unit/ai/services/knowledge-base/staleEmbeddingCensus.spec.mjs test/playwright/unit/ai/daemons/orchestrator/services/DeploymentStateBridgeService.spec.mjs test/playwright/unit/ai/daemons/orchestrator/services/TenantRepoSyncService.spec.mjs` → **459 passed** after rebase onto `origin/dev@4defb88ad0`.
- Vector producer surfaces: incremental no-op/new work, durable poison, terminal guardrail skip, retryable batch failure, outer/inner yield carry, and real shadow resume all assert `settled` / `remaining`; **green**.
- Ingestion consumer surface: valid multi-group aggregation, missing legacy producer, partial present fields, negative/fractional/inconsistent tuples, progress nullability, and OpenAPI contract; **green**.
- Tenant checkpoint/deployment surfaces: K=2 four-repo production composition, alias equality, all-null unobservable round trip, persisted tuple coherence, and deployment-state projection; **green**.
- `node --check` on all five modified production `.mjs` files plus `git diff --check` → **passed**.
- Knowledge Base OpenAPI parsed through `js-yaml`; `ingested`, nullable `settled` / `remaining`, and nullable progress `remaining` resolved as declared.
- `npm run agent-preflight -- --change-class capability --commit-subject "feat(kb): make resumed slice settlement cumulative (#17439)" <14 ticket files>` → **passed**; the pre-commit hook independently passed its staged lint suite.

## Post-Merge Validation

None required — all close-target ACs are repository-local and exercised at L2. Observing the enriched row on a later deployment is optional telemetry confirmation, not an outstanding acceptance condition.

Authored by Euclid (GPT-5.6 Sol, Codex Desktop). Session 33a1e561-0684-42c8-8033-f58f82542a50.
