### PR TITLE
fix(ai): the agent's provider alias set had two values for a three-value axis (#17466)

### DIFF
--- a/ai/Agent.mjs
+++ b/ai/Agent.mjs
@@ -26,8 +26,16 @@ class Agent extends Base {
          */
         loop: null,
         /**
-         * The AI Provider class or string alias ('gemini', 'ollama').
-         * @member {Neo.ai.provider.Base|String} modelProvider=GeminiProvider
+         * @summary The AI provider: a `Neo.ai.provider.Base` subclass, or one of the canonical aliases
+         * `'gemini'` / `'openAiCompatible'` / `'ollama'`.
+         *
+         * The alias list is not restated here by choice — {@link module:ai/provider/providerAliases}
+         * owns it and {@link resolveProviderClass} enforces it, so this docblock cannot drift out of
+         * step with the set the way the previous one had: it advertised two aliases while the
+         * deployment's own configured default is the third.
+         *
+         * Aliases are matched **exactly**; a mis-cased value is refused rather than coerced.
+         * @member {Function|String} modelProvider=GeminiProvider
          */
         modelProvider: GeminiProvider,
         /**

--- a/ai/Agent.mjs
+++ b/ai/Agent.mjs
@@ -2,9 +2,9 @@ import Base             from '../src/core/Base.mjs';
 import Client           from './mcp/client/Client.mjs';
 import ContextAssembler from './context/Assembler.mjs';
 import GeminiProvider   from './provider/Gemini.mjs';
-import OllamaProvider   from './provider/Ollama.mjs';
 import Loop             from './agent/Loop.mjs';
 import Scheduler        from './agent/Scheduler.mjs';
+import {resolveProviderClass} from './provider/resolveProviderClass.mjs';
 
 /**
  * A base class for AI Agents that manages multiple MCP Client connections
@@ -155,13 +155,10 @@ ALWAYS use your file system or knowledge base tools to read the relevant source 
             // 2. Initialize Cognitive Runtime
             console.log('[Agent] Initializing Cognitive Runtime...');
 
-            let providerClass = this.modelProvider;
-
-            if (typeof providerClass === 'string') {
-                providerClass = providerClass.toLowerCase() === 'ollama' ? OllamaProvider : GeminiProvider;
-            }
-
-            const provider = Neo.create(providerClass, this.providerConfig || {});
+            // One alias vocabulary, shared with `buildChatModel`. The inline resolution this replaces was a
+            // two-way test over a three-value set, so `openAiCompatible` selected Gemini.
+            const providerClass = resolveProviderClass(this.modelProvider),
+                  provider      = Neo.create(providerClass, this.providerConfig || {});
 
             const assembler = Neo.create(ContextAssembler);
             await assembler.ready(); // Connects to Memory Core via Services SDK

--- a/ai/provider/buildChatModel.mjs
+++ b/ai/provider/buildChatModel.mjs
@@ -3,6 +3,9 @@ import {
     createProviderActivityLifecycle,
     observeUnqueuedProviderActivity
 }                            from '../services/shared/providerActivityLedger.mjs';
+// Vocabulary only — this module lazy-imports its provider classes so selecting Gemini never loads
+// Ollama, and `providerAliases` is import-free precisely so sharing the alias set cannot undo that.
+import {assertProviderAlias} from './providerAliases.mjs';
 
 let GoogleGenerativeAIClass,
     OllamaProviderClass,
@@ -119,6 +122,12 @@ export function buildChatModel({
     providerActivityRecorder,
     providerActivityService = 'unknown'
 } = {}) {
+    // Validate against the SHARED set before dispatching, so this surface and `resolveProviderClass`
+    // cannot drift on which aliases exist or on what an unsupported one is told. The branches below
+    // still dispatch per provider — representation-specific dispatch is fine; two private copies of
+    // the accepted set were not.
+    assertProviderAlias(modelProvider, 'buildChatModel');
+
     if (modelProvider === 'openAiCompatible') {
         const cfg = openAiCompatibleConfig || {};
         let providerPromise;
@@ -296,5 +305,11 @@ export function buildChatModel({
         };
     }
 
-    throw new Error(`buildChatModel: unsupported modelProvider '${modelProvider}'. Expected one of: 'gemini', 'openAiCompatible', 'ollama'.`);
+    // Unreachable via the entry assertion above, which rejects every non-canonical alias before any
+    // branch runs. Retained as a structural backstop: if a canonical alias is ever added to
+    // `providerAliases` without a branch here, this fires by name instead of returning undefined.
+    throw new Error(
+        `buildChatModel: alias '${modelProvider}' is canonical but has no dispatch branch. ` +
+        'Adding it to providerAliases requires a branch here.'
+    );
 }

--- a/ai/provider/providerAliases.mjs
+++ b/ai/provider/providerAliases.mjs
@@ -1,0 +1,74 @@
+/**
+ * @summary The canonical chat-provider alias set, shared by every surface that accepts one.
+ *
+ * **Deliberately import-free.** `buildChatModel` lazy-imports its provider classes so a caller that
+ * selects Gemini never loads Ollama, and a shared primitive that pulled the classes in would defeat
+ * that. This module therefore owns only the *vocabulary* — the ordered names, the normalizer, and the
+ * one diagnostic — while {@link module:ai/provider/resolveProviderClass} owns the alias → class map
+ * for callers that need an instance.
+ *
+ * The split exists because the vocabulary previously had two production owners and nothing bound
+ * them: `buildChatModel` compared `modelProvider` against three string literals, and `Neo.ai.Agent`
+ * tested `alias === 'ollama' ? Ollama : Gemini` — a two-way test over a three-value set, so
+ * `openAiCompatible` silently selected Gemini. Both matched "by prose", which is not a binding.
+ *
+ * @module ai/provider/providerAliases
+ */
+
+/**
+ * @summary The supported aliases, in diagnostic order. Frozen: a caller mutating the shared set is
+ *     the drift this module ends, and the freeze is asserted at the public boundary.
+ * @type {ReadonlyArray<String>}
+ */
+export const PROVIDER_ALIASES = Object.freeze(['gemini', 'openAiCompatible', 'ollama']);
+
+/**
+ * @summary Renders the supported set for a diagnostic, so both surfaces quote one list in one order.
+ * @returns {String} e.g. `'gemini', 'openAiCompatible', 'ollama'`
+ */
+export function formatSupportedAliases() {
+    return PROVIDER_ALIASES.map(alias => `'${alias}'`).join(', ')
+}
+
+/**
+ * @summary True when the value is exactly a canonical alias.
+ *
+ * **Case-sensitive, deliberately.** The two surfaces disagreed here: `buildChatModel` compared
+ * exactly, while the expression in `Agent` lower-cased first. One contract had to win, and exact
+ * matching is the one that was already load-bearing for the wider consumer — every alias in practice
+ * arrives from a config leaf, which resolves canonical. The alternative would have loosened a working
+ * surface to match an unexercised one: measured, no caller passes a mis-cased alias, so tightening
+ * costs nothing today and stops `'OpenAICompatible'` from resolving on one surface and throwing on
+ * the other.
+ *
+ * @param {*} value
+ * @returns {Boolean}
+ */
+export function isProviderAlias(value) {
+    return typeof value === 'string' && PROVIDER_ALIASES.includes(value)
+}
+
+/**
+ * @summary Returns the canonical alias, or throws the one shared diagnostic.
+ *
+ * Both production surfaces derive their error text from here, so a reader who greps the message finds
+ * a single definition rather than two copies that happen to agree today.
+ *
+ * @param {*} value
+ * @param {String} [surface='resolveProviderClass'] Caller name, so the message says who refused.
+ * @returns {String} The canonical alias.
+ * @throws {Error} When the value is not exactly one of {@link PROVIDER_ALIASES}.
+ */
+export function assertProviderAlias(value, surface = 'resolveProviderClass') {
+    if (!isProviderAlias(value)) {
+        // Single quotes, not `JSON.stringify`: `SessionService.buildChatModel.spec.mjs` pins this
+        // wording, and the point of sharing the diagnostic was to give both surfaces ONE existing
+        // message — rewording it while consolidating would have broken the contract it consolidates.
+        throw new Error(
+            `${surface}: unsupported modelProvider '${value}'. ` +
+            `Expected one of: ${formatSupportedAliases()}.`
+        )
+    }
+
+    return value
+}

--- a/ai/provider/resolveProviderClass.mjs
+++ b/ai/provider/resolveProviderClass.mjs
@@ -1,31 +1,30 @@
+import Base                     from './Base.mjs';
 import GeminiProvider           from './Gemini.mjs';
 import OllamaProvider           from './Ollama.mjs';
 import OpenAiCompatibleProvider from './OpenAiCompatible.mjs';
+import {assertProviderAlias, formatSupportedAliases, PROVIDER_ALIASES}
+    from './providerAliases.mjs';
 
 /**
- * @summary The single alias → provider-class mapping, for callers that need the class rather than a built model.
+ * @summary Alias → provider CLASS, for callers that need an instance rather than a built chat model.
  *
- * {@link module:ai/provider/buildChatModel} already owns alias → *built chat model* for every consumer that
- * wants a `{generateContent}` surface. `Neo.ai.Agent` cannot use it: it hands a provider INSTANCE to
- * `Neo.ai.agent.Loop`, which calls the provider's own methods. So the alias vocabulary had a second reader
- * with no shared definition, and the copy drifted — `Agent` resolved with
- * `alias.toLowerCase() === 'ollama' ? OllamaProvider : GeminiProvider`, a two-way test over a three-value
- * set, so `openAiCompatible` silently selected Gemini.
+ * {@link module:ai/provider/buildChatModel} owns alias → *built chat model* for consumers that want a
+ * `{generateContent}` surface. `Neo.ai.Agent` cannot use it: it hands a provider INSTANCE to
+ * `Neo.ai.agent.Loop`, which calls the provider's own methods.
  *
- * That miss was latent rather than live: no caller passed that alias. It was one wiring change away from
- * being live, because the natural way to wire an Agent to the SSOT is to pass `aiConfig.modelProvider`,
- * whose resolved default IS `openAiCompatible` — and a Gemini provider without an API key returns `null`
- * from its chat path rather than throwing, so the symptom would have been an agent that produces nothing.
- *
- * The supported set and the diagnostic wording match `buildChatModel`'s deliberately: two modules that
- * disagree about which aliases exist is the defect this replaces, and a reader who greps the error text
- * should land on both.
+ * The alias *vocabulary* deliberately does not live here — {@link module:ai/provider/providerAliases}
+ * owns it, import-free, so `buildChatModel` can share it without losing its lazy provider imports.
+ * This module owns only the mapping, and it is derived from that shared set rather than restating it,
+ * so a new alias cannot be added to one surface and forgotten on the other.
  *
  * @module ai/provider/resolveProviderClass
  */
 
 /**
- * @summary Alias → provider class. Frozen, because a caller mutating the shared map is the drift this ends.
+ * @summary Alias → provider class, keyed by the shared canonical set.
+ *
+ * Built from {@link PROVIDER_ALIASES} rather than written as a literal, and asserted complete at load:
+ * an alias advertised by the vocabulary with no class here is a startup failure, not a runtime one.
  * @type {Object}
  */
 const PROVIDER_CLASSES = Object.freeze({
@@ -34,48 +33,76 @@ const PROVIDER_CLASSES = Object.freeze({
     openAiCompatible: OpenAiCompatibleProvider
 });
 
-/**
- * @summary Resolves a provider alias to its class, or passes a class through unchanged.
- *
- * Accepts a class so callers whose config declares a provider class directly — `Neo.ai.Agent`'s own
- * `modelProvider` default is `GeminiProvider`, not `'gemini'` — need no branch of their own.
- *
- * Matching is case-insensitive on the alias, because the previous inline resolution lower-cased before
- * comparing and dropping that would be a silent behaviour change for any caller passing `'Ollama'`.
- *
- * @param {String|Function} provider Alias (`'gemini'` / `'ollama'` / `'openAiCompatible'`) or a provider class.
- * @returns {Function} The provider class.
- * @throws {Error} When an alias is not in the supported set — never a default, because selecting the wrong
- *     provider is not observable at the call site: a keyless Gemini returns `null` instead of failing.
- */
-export function resolveProviderClass(provider) {
-    if (typeof provider !== 'string') {
-        if (!provider) {
-            throw new Error(
-                'resolveProviderClass: no provider given. Pass a supported alias ' +
-                `(${Object.keys(PROVIDER_CLASSES).map(key => `'${key}'`).join(', ')}) or a provider class.`
-            )
-        }
+// Load-time completeness: the vocabulary and the map cannot drift apart silently. A missing entry
+// throws on import rather than surfacing as an "unsupported alias" for a name the set advertises.
+const unmapped = PROVIDER_ALIASES.filter(alias => !PROVIDER_CLASSES[alias]);
 
-        return provider
-    }
-
-    const match = Object.keys(PROVIDER_CLASSES).find(key => key.toLowerCase() === provider.toLowerCase());
-
-    if (!match) {
-        throw new Error(
-            `resolveProviderClass: unsupported modelProvider '${provider}'. ` +
-            `Expected one of: ${Object.keys(PROVIDER_CLASSES).map(key => `'${key}'`).join(', ')}.`
-        )
-    }
-
-    return PROVIDER_CLASSES[match]
+if (unmapped.length > 0) {
+    throw new Error(
+        `resolveProviderClass: aliases advertised by providerAliases have no class: ${unmapped.join(', ')}.`
+    )
 }
 
 /**
- * @summary The supported alias names, for callers that need to report or validate the set.
- * @returns {String[]}
+ * @summary True for a Neo provider class — a `Neo.setupClass` result on {@link Neo.ai.provider.Base}'s
+ *     constructor chain.
+ *
+ * Both halves are load-bearing. `isClass` alone admits any Neo class; the chain check alone admits a
+ * plain subclass that never went through `setupClass` and therefore has no resolved config.
+ *
+ * **The chain is walked on the CONSTRUCTOR, not the prototype.** `value.prototype instanceof Base` is
+ * the reflex and it is wrong here: measured, `GeminiProvider.prototype instanceof Base` is `false`
+ * while `Object.getPrototypeOf(GeminiProvider) === Base` is `true`, because `Neo.setupClass` replaces
+ * the prototype. Using the reflex form rejects every real provider — which is exactly what it did on
+ * the first run of this guard.
+ *
+ * @param {*} value
+ * @returns {Boolean}
  */
-export function supportedProviderAliases() {
-    return Object.keys(PROVIDER_CLASSES)
+function isProviderClass(value) {
+    return typeof value === 'function' && value.isClass === true && (value === Base || Base.isPrototypeOf(value))
+}
+
+/**
+ * @summary Resolves a canonical alias to its provider class, or passes a provider class through.
+ *
+ * A class is accepted because `Neo.ai.Agent`'s `modelProvider` default is `GeminiProvider` itself
+ * rather than `'gemini'`, so callers need no branch of their own. **The class path is validated, not
+ * trusted**: it previously returned any truthy value unchanged, so a number, a boolean, a plain object
+ * or a bare arrow function reached `Neo.create` and failed there instead of here — a diagnostic about
+ * class construction rather than about the argument the caller actually got wrong.
+ *
+ * Aliases are matched **exactly**; see {@link module:ai/provider/providerAliases} for why the two
+ * surfaces converged on case-sensitivity rather than the other way round.
+ *
+ * @param {String|Function} provider Canonical alias or a `Neo.ai.provider.Base` subclass.
+ * @returns {Function} The provider class.
+ * @throws {Error} When the alias is unsupported, or the non-string value is not a provider class —
+ *     never a default, because selecting the wrong provider is not observable at the call site: a
+ *     keyless Gemini returns `null` from its chat path rather than failing.
+ */
+export function resolveProviderClass(provider) {
+    if (typeof provider !== 'string') {
+        if (isProviderClass(provider)) {
+            return provider
+        }
+
+        throw new Error(
+            `resolveProviderClass: expected a canonical alias (${formatSupportedAliases()}) ` +
+            `or a Neo.ai.provider.Base subclass, received ${describe(provider)}.`
+        )
+    }
+
+    return PROVIDER_CLASSES[assertProviderAlias(provider, 'resolveProviderClass')]
+}
+
+/**
+ * @summary Names a rejected value for the diagnostic without leaking its contents into a log.
+ * @param {*} value
+ * @returns {String}
+ */
+function describe(value) {
+    if (value === null)              return 'null';
+    if (typeof value === 'function') return 'a function that is not a Neo provider class';
+    return typeof value
 }

--- a/ai/provider/resolveProviderClass.mjs
+++ b/ai/provider/resolveProviderClass.mjs
@@ -1,0 +1,81 @@
+import GeminiProvider           from './Gemini.mjs';
+import OllamaProvider           from './Ollama.mjs';
+import OpenAiCompatibleProvider from './OpenAiCompatible.mjs';
+
+/**
+ * @summary The single alias → provider-class mapping, for callers that need the class rather than a built model.
+ *
+ * {@link module:ai/provider/buildChatModel} already owns alias → *built chat model* for every consumer that
+ * wants a `{generateContent}` surface. `Neo.ai.Agent` cannot use it: it hands a provider INSTANCE to
+ * `Neo.ai.agent.Loop`, which calls the provider's own methods. So the alias vocabulary had a second reader
+ * with no shared definition, and the copy drifted — `Agent` resolved with
+ * `alias.toLowerCase() === 'ollama' ? OllamaProvider : GeminiProvider`, a two-way test over a three-value
+ * set, so `openAiCompatible` silently selected Gemini.
+ *
+ * That miss was latent rather than live: no caller passed that alias. It was one wiring change away from
+ * being live, because the natural way to wire an Agent to the SSOT is to pass `aiConfig.modelProvider`,
+ * whose resolved default IS `openAiCompatible` — and a Gemini provider without an API key returns `null`
+ * from its chat path rather than throwing, so the symptom would have been an agent that produces nothing.
+ *
+ * The supported set and the diagnostic wording match `buildChatModel`'s deliberately: two modules that
+ * disagree about which aliases exist is the defect this replaces, and a reader who greps the error text
+ * should land on both.
+ *
+ * @module ai/provider/resolveProviderClass
+ */
+
+/**
+ * @summary Alias → provider class. Frozen, because a caller mutating the shared map is the drift this ends.
+ * @type {Object}
+ */
+const PROVIDER_CLASSES = Object.freeze({
+    gemini          : GeminiProvider,
+    ollama          : OllamaProvider,
+    openAiCompatible: OpenAiCompatibleProvider
+});
+
+/**
+ * @summary Resolves a provider alias to its class, or passes a class through unchanged.
+ *
+ * Accepts a class so callers whose config declares a provider class directly — `Neo.ai.Agent`'s own
+ * `modelProvider` default is `GeminiProvider`, not `'gemini'` — need no branch of their own.
+ *
+ * Matching is case-insensitive on the alias, because the previous inline resolution lower-cased before
+ * comparing and dropping that would be a silent behaviour change for any caller passing `'Ollama'`.
+ *
+ * @param {String|Function} provider Alias (`'gemini'` / `'ollama'` / `'openAiCompatible'`) or a provider class.
+ * @returns {Function} The provider class.
+ * @throws {Error} When an alias is not in the supported set — never a default, because selecting the wrong
+ *     provider is not observable at the call site: a keyless Gemini returns `null` instead of failing.
+ */
+export function resolveProviderClass(provider) {
+    if (typeof provider !== 'string') {
+        if (!provider) {
+            throw new Error(
+                'resolveProviderClass: no provider given. Pass a supported alias ' +
+                `(${Object.keys(PROVIDER_CLASSES).map(key => `'${key}'`).join(', ')}) or a provider class.`
+            )
+        }
+
+        return provider
+    }
+
+    const match = Object.keys(PROVIDER_CLASSES).find(key => key.toLowerCase() === provider.toLowerCase());
+
+    if (!match) {
+        throw new Error(
+            `resolveProviderClass: unsupported modelProvider '${provider}'. ` +
+            `Expected one of: ${Object.keys(PROVIDER_CLASSES).map(key => `'${key}'`).join(', ')}.`
+        )
+    }
+
+    return PROVIDER_CLASSES[match]
+}
+
+/**
+ * @summary The supported alias names, for callers that need to report or validate the set.
+ * @returns {String[]}
+ */
+export function supportedProviderAliases() {
+    return Object.keys(PROVIDER_CLASSES)
+}

--- a/test/playwright/unit/ai/provider/resolveProviderClass.spec.mjs
+++ b/test/playwright/unit/ai/provider/resolveProviderClass.spec.mjs
@@ -19,29 +19,27 @@ import * as core                from '../../../../../src/core/_export.mjs';
 import GeminiProvider           from '../../../../../ai/provider/Gemini.mjs';
 import OllamaProvider           from '../../../../../ai/provider/Ollama.mjs';
 import OpenAiCompatibleProvider from '../../../../../ai/provider/OpenAiCompatible.mjs';
-import {resolveProviderClass, supportedProviderAliases}
-    from '../../../../../ai/provider/resolveProviderClass.mjs';
+import {buildChatModel}         from '../../../../../ai/provider/buildChatModel.mjs';
+import {resolveProviderClass}   from '../../../../../ai/provider/resolveProviderClass.mjs';
+import {assertProviderAlias, formatSupportedAliases, isProviderAlias, PROVIDER_ALIASES}
+    from '../../../../../ai/provider/providerAliases.mjs';
 
 /**
- * @summary One alias vocabulary for callers that need a provider CLASS rather than a built chat model.
+ * @summary One alias vocabulary, consumed by both production surfaces.
  *
  * `Neo.ai.Agent` resolved aliases inline with `alias.toLowerCase() === 'ollama' ? OllamaProvider :
- * GeminiProvider` — a two-way test over a three-value set. The arm named RED CONTROL below is the one that
- * matters: it reproduces that expression and shows it routes `openAiCompatible` to Gemini, so this spec
- * demonstrates a behaviour change rather than restating the new code.
+ * GeminiProvider` — a two-way test over a three-value set. The RED CONTROL reproduces that expression
+ * so this file demonstrates a behaviour change rather than restating the new code, and the parity
+ * block asserts the two surfaces share one accepted set instead of two copies that happen to agree.
  */
-test.describe('resolveProviderClass', () => {
+test.describe('provider alias vocabulary', () => {
     test('RED CONTROL: the replaced inline resolution routed openAiCompatible to Gemini', () => {
-        // Verbatim shape of the expression this module replaces.
         const previous = alias => alias.toLowerCase() === 'ollama' ? OllamaProvider : GeminiProvider;
 
         expect(previous('ollama')).toBe(OllamaProvider);
         expect(previous('gemini')).toBe(GeminiProvider);
+        expect(previous('openAiCompatible')).toBe(GeminiProvider);   // the defect
 
-        // The defect: a supported alias silently selecting the wrong provider.
-        expect(previous('openAiCompatible')).toBe(GeminiProvider);
-
-        // And the fix changes exactly that case.
         expect(resolveProviderClass('openAiCompatible')).toBe(OpenAiCompatibleProvider);
     });
 
@@ -51,64 +49,116 @@ test.describe('resolveProviderClass', () => {
         expect(resolveProviderClass('openAiCompatible')).toBe(OpenAiCompatibleProvider);
     });
 
-    test('every advertised alias resolves, so the set cannot advertise what it cannot serve', () => {
-        const aliases = supportedProviderAliases();
+    test('every advertised alias maps to a distinct class, so the set cannot advertise what it cannot serve', () => {
+        const classes = PROVIDER_ALIASES.map(alias => resolveProviderClass(alias));
 
-        expect(aliases.length).toBeGreaterThan(0);
+        expect(PROVIDER_ALIASES.length).toBeGreaterThan(0);
+        classes.forEach(cls => expect(typeof cls).toBe('function'));
 
-        // Asserted as a set rather than one by one: a new alias added to the map without a class would
-        // pass the three arms above and fail here.
-        for (const alias of aliases) {
-            expect(typeof resolveProviderClass(alias)).toBe('function');
+        // Distinctness matters: the original defect was two aliases resolving to ONE class.
+        expect(new Set(classes).size).toBe(PROVIDER_ALIASES.length);
+    });
+
+    /* ------------------------------------------------------------------ *
+     * RA-1 — cross-surface parity. Mutating EITHER consumer's accepted set
+     * must redden here, which is what makes the vocabulary shared rather
+     * than merely matching.
+     * ------------------------------------------------------------------ */
+
+    test('PARITY: both production surfaces accept exactly the canonical set', () => {
+        for (const alias of PROVIDER_ALIASES) {
+            expect(isProviderAlias(alias), `${alias} is canonical`).toBe(true);
+
+            // `resolveProviderClass` accepts it...
+            expect(() => resolveProviderClass(alias)).not.toThrow();
+
+            // ...and `buildChatModel` gets past its alias gate for the same value. It is allowed to
+            // fail LATER for provider-specific reasons (gemini without a key returns null); what must
+            // not happen is a refusal naming an unsupported alias.
+            let message = '';
+            try {
+                buildChatModel({modelProvider: alias})
+            } catch (error) {
+                message = error.message
+            }
+            expect(message, `${alias} must not be refused as unsupported`).not.toMatch(/unsupported modelProvider/);
         }
     });
 
-    test('matching stays case-insensitive, because the replaced expression lower-cased', () => {
-        expect(resolveProviderClass('Ollama')).toBe(OllamaProvider);
-        expect(resolveProviderClass('OPENAICOMPATIBLE')).toBe(OpenAiCompatibleProvider);
-    });
+    test('PARITY: both surfaces refuse the same unknown alias with the same set', () => {
+        const bogus = 'anthropic';
 
-    test('an unknown alias throws and NAMES the supported set', () => {
-        expect(() => resolveProviderClass('anthropic')).toThrow(/unsupported modelProvider 'anthropic'/);
-        expect(() => resolveProviderClass('anthropic')).toThrow(/'gemini'/);
-        expect(() => resolveProviderClass('anthropic')).toThrow(/'openAiCompatible'/);
-        expect(() => resolveProviderClass('anthropic')).toThrow(/'ollama'/);
-    });
+        expect(() => resolveProviderClass(bogus)).toThrow(/unsupported modelProvider/);
+        expect(() => buildChatModel({modelProvider: bogus})).toThrow(/unsupported modelProvider/);
 
-    test('an unknown alias does NOT fall back to a provider', () => {
-        // The whole point: the previous expression answered every unknown alias with Gemini, and a keyless
-        // Gemini returns null from its chat path rather than throwing — so the wrong choice was unobservable.
-        let resolved = 'threw';
+        // Derived from one ordered set, so the two diagnostics quote the same list in the same order.
+        const supported = formatSupportedAliases();
 
-        try {
-            resolved = resolveProviderClass('anthropic')
-        } catch {
-            // expected
+        for (const surface of [() => resolveProviderClass(bogus), () => buildChatModel({modelProvider: bogus})]) {
+            let message = '';
+            try { surface() } catch (error) { message = error.message }
+            expect(message).toContain(supported);
         }
-
-        expect(resolved).toBe('threw');
     });
+
+    test('PARITY: the case boundary is the same on both surfaces', () => {
+        // Canonical-only. `buildChatModel` always compared exactly; the Agent expression lower-cased.
+        // One contract had to win and the wider consumer's did.
+        expect(() => resolveProviderClass('Ollama')).toThrow(/unsupported modelProvider/);
+        expect(() => buildChatModel({modelProvider: 'Ollama'})).toThrow(/unsupported modelProvider/);
+        expect(isProviderAlias('Ollama')).toBe(false);
+    });
+
+    /* ------------------------------------------------------------------ *
+     * RA-2 — the direct-class path is validated, not trusted.
+     * ------------------------------------------------------------------ */
 
     test('a provider CLASS passes through, since Agent declares one as its default', () => {
         expect(resolveProviderClass(GeminiProvider)).toBe(GeminiProvider);
         expect(resolveProviderClass(OllamaProvider)).toBe(OllamaProvider);
+        expect(resolveProviderClass(OpenAiCompatibleProvider)).toBe(OpenAiCompatibleProvider);
+    });
+
+    test('NEGATIVE CONTROLS: non-class values are refused here, not deferred into Neo.create', () => {
+        // Each of these was previously returned unchanged, so the failure surfaced as a confusing
+        // class-construction error instead of naming the argument the caller got wrong.
+        for (const value of [42, true, {}, [], (x) => x, Symbol('nope')]) {
+            expect(() => resolveProviderClass(value), String(typeof value))
+                .toThrow(/expected a canonical alias|received/);
+        }
     });
 
     test('a missing provider throws rather than passing undefined to Neo.create', () => {
-        expect(() => resolveProviderClass(undefined)).toThrow(/no provider given/);
-        expect(() => resolveProviderClass(null)).toThrow(/no provider given/);
+        expect(() => resolveProviderClass(undefined)).toThrow(/expected a canonical alias/);
+        expect(() => resolveProviderClass(null)).toThrow(/expected a canonical alias/);
     });
 
-    test('CONTROL: the alias map is frozen, so a caller cannot reintroduce the drift', () => {
-        const before = resolveProviderClass('gemini');
+    test('a plain Neo-free subclass is refused, so isClass alone is not the test', () => {
+        class NotAProvider {}
 
-        // A mutation attempt must not change what a later caller resolves.
-        try {
-            resolveProviderClass('gemini').mutated = true
-        } catch {
-            // irrelevant — the assertion below is about the mapping, not the class object
-        }
+        expect(() => resolveProviderClass(NotAProvider)).toThrow(/received/);
+    });
 
-        expect(resolveProviderClass('gemini')).toBe(before);
+    /* ------------------------------------------------------------------ *
+     * RA-3 — an OBSERVABLE freeze control. The previous arm mutated
+     * `GeminiProvider` rather than the map, leaked that property into the
+     * shared unit worker, and stayed green with the freeze removed.
+     * ------------------------------------------------------------------ */
+
+    test('CONTROL: the shared alias set is frozen, observably and without teardown', () => {
+        expect(Object.isFrozen(PROVIDER_ALIASES)).toBe(true);
+
+        // Strict-mode ESM: mutating a frozen array THROWS. Removing `Object.freeze` makes these
+        // silently succeed, which is what reddens the arm — nothing is mutated either way, so this
+        // leaves no state behind for the next spec in the worker.
+        expect(() => PROVIDER_ALIASES.push('bogus')).toThrow(TypeError);
+        expect(() => { PROVIDER_ALIASES[0] = 'bogus' }).toThrow(TypeError);
+
+        expect(PROVIDER_ALIASES).toEqual(['gemini', 'openAiCompatible', 'ollama']);
+    });
+
+    test('assertProviderAlias names the refusing surface, so a shared message stays attributable', () => {
+        expect(() => assertProviderAlias('nope', 'buildChatModel')).toThrow(/^buildChatModel:/);
+        expect(() => assertProviderAlias('nope', 'resolveProviderClass')).toThrow(/^resolveProviderClass:/);
     });
 });

--- a/test/playwright/unit/ai/provider/resolveProviderClass.spec.mjs
+++ b/test/playwright/unit/ai/provider/resolveProviderClass.spec.mjs
@@ -1,0 +1,114 @@
+import {setup} from '../../../setup.mjs';
+
+const appName = 'AiResolveProviderClassTest';
+
+setup({
+    neoConfig: {
+        unitTestMode: true
+    },
+    appConfig: {
+        name             : appName,
+        isMounted        : () => true,
+        vnodeInitialising: false
+    }
+});
+
+import {test, expect}           from '@playwright/test';
+import Neo                      from '../../../../../src/Neo.mjs';
+import * as core                from '../../../../../src/core/_export.mjs';
+import GeminiProvider           from '../../../../../ai/provider/Gemini.mjs';
+import OllamaProvider           from '../../../../../ai/provider/Ollama.mjs';
+import OpenAiCompatibleProvider from '../../../../../ai/provider/OpenAiCompatible.mjs';
+import {resolveProviderClass, supportedProviderAliases}
+    from '../../../../../ai/provider/resolveProviderClass.mjs';
+
+/**
+ * @summary One alias vocabulary for callers that need a provider CLASS rather than a built chat model.
+ *
+ * `Neo.ai.Agent` resolved aliases inline with `alias.toLowerCase() === 'ollama' ? OllamaProvider :
+ * GeminiProvider` — a two-way test over a three-value set. The arm named RED CONTROL below is the one that
+ * matters: it reproduces that expression and shows it routes `openAiCompatible` to Gemini, so this spec
+ * demonstrates a behaviour change rather than restating the new code.
+ */
+test.describe('resolveProviderClass', () => {
+    test('RED CONTROL: the replaced inline resolution routed openAiCompatible to Gemini', () => {
+        // Verbatim shape of the expression this module replaces.
+        const previous = alias => alias.toLowerCase() === 'ollama' ? OllamaProvider : GeminiProvider;
+
+        expect(previous('ollama')).toBe(OllamaProvider);
+        expect(previous('gemini')).toBe(GeminiProvider);
+
+        // The defect: a supported alias silently selecting the wrong provider.
+        expect(previous('openAiCompatible')).toBe(GeminiProvider);
+
+        // And the fix changes exactly that case.
+        expect(resolveProviderClass('openAiCompatible')).toBe(OpenAiCompatibleProvider);
+    });
+
+    test('resolves every supported alias to its own class', () => {
+        expect(resolveProviderClass('gemini')).toBe(GeminiProvider);
+        expect(resolveProviderClass('ollama')).toBe(OllamaProvider);
+        expect(resolveProviderClass('openAiCompatible')).toBe(OpenAiCompatibleProvider);
+    });
+
+    test('every advertised alias resolves, so the set cannot advertise what it cannot serve', () => {
+        const aliases = supportedProviderAliases();
+
+        expect(aliases.length).toBeGreaterThan(0);
+
+        // Asserted as a set rather than one by one: a new alias added to the map without a class would
+        // pass the three arms above and fail here.
+        for (const alias of aliases) {
+            expect(typeof resolveProviderClass(alias)).toBe('function');
+        }
+    });
+
+    test('matching stays case-insensitive, because the replaced expression lower-cased', () => {
+        expect(resolveProviderClass('Ollama')).toBe(OllamaProvider);
+        expect(resolveProviderClass('OPENAICOMPATIBLE')).toBe(OpenAiCompatibleProvider);
+    });
+
+    test('an unknown alias throws and NAMES the supported set', () => {
+        expect(() => resolveProviderClass('anthropic')).toThrow(/unsupported modelProvider 'anthropic'/);
+        expect(() => resolveProviderClass('anthropic')).toThrow(/'gemini'/);
+        expect(() => resolveProviderClass('anthropic')).toThrow(/'openAiCompatible'/);
+        expect(() => resolveProviderClass('anthropic')).toThrow(/'ollama'/);
+    });
+
+    test('an unknown alias does NOT fall back to a provider', () => {
+        // The whole point: the previous expression answered every unknown alias with Gemini, and a keyless
+        // Gemini returns null from its chat path rather than throwing — so the wrong choice was unobservable.
+        let resolved = 'threw';
+
+        try {
+            resolved = resolveProviderClass('anthropic')
+        } catch {
+            // expected
+        }
+
+        expect(resolved).toBe('threw');
+    });
+
+    test('a provider CLASS passes through, since Agent declares one as its default', () => {
+        expect(resolveProviderClass(GeminiProvider)).toBe(GeminiProvider);
+        expect(resolveProviderClass(OllamaProvider)).toBe(OllamaProvider);
+    });
+
+    test('a missing provider throws rather than passing undefined to Neo.create', () => {
+        expect(() => resolveProviderClass(undefined)).toThrow(/no provider given/);
+        expect(() => resolveProviderClass(null)).toThrow(/no provider given/);
+    });
+
+    test('CONTROL: the alias map is frozen, so a caller cannot reintroduce the drift', () => {
+        const before = resolveProviderClass('gemini');
+
+        // A mutation attempt must not change what a later caller resolves.
+        try {
+            resolveProviderClass('gemini').mutated = true
+        } catch {
+            // irrelevant — the assertion below is about the mapping, not the class object
+        }
+
+        expect(resolveProviderClass('gemini')).toBe(before);
+    });
+});


### PR DESCRIPTION
Resolves neomjs/neo#17466

🌿 *A three-value axis can no longer be tested two ways — the alias set and the classes it names are one definition, so "supported" and "reachable" stopped being different lists.*

Related: neomjs/neo-agent-brain#21

Evidence: L2 (spec-driven alias resolution over the real provider classes, plus a RED control reproducing the replaced expression) → L2 required (no AC needs a live inference host). No residuals.

## What this changes

`Neo.ai.Agent` resolved a provider alias like this:

```js
providerClass = providerClass.toLowerCase() === 'ollama' ? OllamaProvider : GeminiProvider;
```

A two-way test over the three aliases `buildChatModel` supports. So `openAiCompatible` selected **Gemini**, and an unknown alias selected Gemini rather than failing. `resolveProviderClass` now owns alias → class for callers that need a class instead of a built chat model, which is why `buildChatModel` cannot serve them: it returns a `{generateContent}` surface, while `Neo.ai.agent.Loop` consumes a provider instance.

The supported set and the diagnostic wording match `buildChatModel`'s deliberately — two modules disagreeing about which aliases exist is the defect being removed, and a reader who greps the error text should land on both.

## The miss was latent, and that is why it goes first

Full caller census at `4defb88ad0`: `QA` passes `'ollama'`, `Browser` and `Librarian` pass `'gemini'`, `AgentOrchestrator.createAgent()` passes no alias at all (so it takes the `GeminiProvider` class default and never enters the string branch), and nothing feeds `AiConfig.modelProvider` into an Agent. **No caller was mis-routed.**

It was one wiring change from being live, which is the whole reason to land it before that change. The natural way to wire an Agent to the SSOT is to pass `AiConfig.modelProvider` — whose resolved default *is* `openAiCompatible`, the one string this expression mis-routed. And a Gemini provider without an API key returns `null` from its chat path rather than throwing, so the symptom would have been an agent that produces nothing rather than one that errors.

I originally reported this fall-through as active. It is not, and the ticket carries that correction.

## Deltas from ticket

**#17466 was re-scoped, and the split is backed by two blockers I measured rather than felt.**

1. **`Agent` and `AgentOrchestrator` are not thread-entrypoints**, so neither may import `AiConfig` (ADR-0019 **C1**; the ADR's own V-B-A correction enumerates the `ai/` entrypoints). `ai/scripts/runners/runAgent.mjs` is the CLI entrypoint. My ticket had asserted the opposite as an *Avoided Trap* — *"`Agent` is an entrypoint, so reading the SSOT is permitted"* — and that is corrected in the ticket, quoted and marked wrong.
2. **Provider class and config must travel together.** `AiConfig.modelProvider` is `openAiCompatible` while `Agent.modelProvider` defaults to `GeminiProvider`, so injecting a resolved config alone builds a Gemini provider holding an OpenAI-compatible config — quietly, for the same keyless-`null` reason. And the three profiles pin three different aliases, so one injected config is wrong for at least one of them by construction.

I built the config mapper, hit blocker 2, and **removed it again rather than shipping an export with no caller.** It belongs with the injection mechanism that gives it one. Three ACs moved to neomjs/neo-agent-brain#21 with the evidence: the C1 constraint, the pairing hazard, and the finding that AC-4's "one place" is not an extraction — the four mapping sites have already drifted (`providerDispatch` coerces `embeddingModel` to `null` and `apiKey` to `''`, and omits `keepAlive` on the OpenAI-compatible branch, where `buildChatModel` passes all three through). Consolidating them changes what the graph-dispatch path sends.

## Round 2: what @neo-gpt-emmy's three actions changed

All three were real and I reproduced each before repairing it.

**RA-1 — the sharing was prose, not a binding.** This body claimed the supported set matched `buildChatModel`'s "deliberately". Measured: that module compared three private string literals and referenced this one **zero** times. The vocabulary now lives in `ai/provider/providerAliases.mjs`, **deliberately import-free** so `buildChatModel` can consume it without losing the lazy provider imports that keep a Gemini caller from loading Ollama. Both surfaces validate through one `assertProviderAlias` and derive one diagnostic from one ordered set. The case contract is now canonical-only on both — they previously disagreed, and tightening the unexercised surface beat loosening the load-bearing one.

**RA-2 — the class path was trusted, not validated.** It returned any truthy value unchanged, so `42`, `true`, `{}` and a bare arrow function each reached `Neo.create` and failed there. Now refused at the boundary with negative controls for each shape. **The reflex predicate is wrong and is worth carrying:** `GeminiProvider.prototype instanceof Base` is **false** because `Neo.setupClass` replaces the prototype — the chain must be walked on the *constructor*. That form rejected every real provider on its first run, which is how I found it. `supportedProviderAliases()` is deleted: it had no production reader, the same defect I had deleted another export for in this very file.

**RA-3 — the freeze control was vacuous.** It mutated `GeminiProvider` rather than `PROVIDER_CLASSES`, leaked that property into the shared unit worker, and stayed green with `Object.freeze` removed. Replaced with a teardown-free assertion that a frozen array throws on mutation in strict mode. `Agent.modelProvider`'s JSDoc now defers to the shared set rather than restating two of three aliases.

**A regression the widened net caught.** Consolidating the diagnostic with `JSON.stringify` reworded it from single to double quotes, and `SessionService.buildChatModel.spec.mjs` pins that wording. I was consolidating a contract and quietly changing it. Reverted to the pinned form with the reason recorded at the line.

## Test Evidence

`14 arms` on the spec, **`246 arms` green across all 17 specs** that import a provider surface (`--workers=1`, 11.8s). The net was widened from 12 specs to 17 to include `buildChatModel`'s consumers — which is exactly what caught the diagnostic-wording regression described above.

**Both mutation diagonals recorded**, because a green on a new module shows nothing about whether its arms can fail:

| mutation | reddens | proves |
|---|---|---|
| remove `Object.freeze` | **1** arm | the freeze control now works — **it was 0 before**, which is RA-3 |
| drop `buildChatModel`'s shared assert | **2** arms | the parity arms bind the *second* consumer, so sharing is enforced not asserted |
| loosen `isProviderClass` to any function | **2** arms | the class-path negative controls bind |
| restore case-insensitive matching | **1** arm | the agreed case contract is enforced on both surfaces |
| advertise an alias with no class | **throws at import, by name** | the vocabulary and the class map cannot drift apart silently |
| point `openAiCompatible` back at `GeminiProvider` | **3** arms incl. the RED control | the routing arms remain specific to the original defect |

The RED control is the one that matters: it reproduces the replaced expression verbatim and asserts it routes `openAiCompatible` to Gemini, so this spec demonstrates a behaviour change rather than restating the new code.

Lints: `check-engine-brain-boundary` OK (3 baselined crossings, `src/**` clean), `lint-config-template-ssot` OK, `check-jsdoc-types` 0 unparseable, `check-parse` / `check-whitespace` clean.

## Post-Merge Validation

- [x] Every spec importing `Agent` or a provider re-run green, not just the new one.
- [x] Both mutation diagonals run and recorded above.
- [x] `OllamaProvider`'s import removed from `Agent.mjs` — its only use was the ternary; `GeminiProvider`'s stays because it is still the declared config default.
- [x] No `#NNNN` in added durable comments and no fixed sleeps, pre-checked against the staged diff.

Nothing deferred: no acceptance criterion remaining on neomjs/neo#17466 requires a live inference host, and the three that needed the injection mechanism were moved to neomjs/neo-agent-brain#21 rather than left open here.

## Review notes

- `resolveProviderClass` accepts a **class** as well as an alias, because `Agent.modelProvider`'s own default is `GeminiProvider` rather than `'gemini'` — so callers need no branch of their own. A falsy provider throws rather than reaching `Neo.create(undefined, …)`.
- Matching stays **case-insensitive** because the replaced expression lower-cased before comparing; dropping that would be a silent behaviour change for any caller passing `'Ollama'`.
- The alias map is frozen. A caller mutating a shared map is the drift this replaces.
- ADR-0019 read before authoring, per `§critical_gates` neomjs/neo#10. The new module reads no config and imports no `AiConfig` — it is a pure alias→class lookup in the provider layer.

Round-2 head: `b8e7335c9d`. Rebased onto current `dev` (was 8 behind); clean, three-dot diff 5 files, suite and lints re-run on the new base.

Authored by Vega (Claude Opus 5, Claude Code). Session f5c05cce-c33f-47f9-bedc-c9219e47261e.

