### PR TITLE
fix(test): the Brain-tier probe resolves node_modules instead of joining it (#17477)

### DIFF
--- a/test/playwright/chromaProcess.mjs
+++ b/test/playwright/chromaProcess.mjs
@@ -6,6 +6,18 @@ import path                  from 'node:path';
 const temporaryPrefix = 'neo-chroma-unit-test-';
 
 /**
+ * @summary The chromadb artifact `chroma-setup` actually EXECUTES.
+ *
+ * Exported so the Brain-tier probe admits the tier on the same file this module spawns. Admission
+ * previously proved `dist/chromadb.mjs` — the library entrypoint Brain specs import — while the
+ * setup project it gates runs this one. A partial install carrying the first without the second
+ * passed the gate and then failed at the heartbeat, which is the indirection the whole probe exists
+ * to remove. One constant, two consumers, no drift.
+ * @type {String}
+ */
+export const CHROMA_CLI_ENTRYPOINT = 'dist/cli.mjs';
+
+/**
  * @summary Locates a package directory the way Node's resolver does — first `node_modules/<pkg>`
  * found walking up from `fromDir`, or `null`.
  *
@@ -17,6 +29,11 @@ const temporaryPrefix = 'neo-chroma-unit-test-';
  * FIRST match wins, with no fallback to a further ancestor — also Node's behaviour, and load-bearing
  * for the Brain-tier probe: a pruned husk at depth 0 must stay a husk rather than being papered over
  * by a good copy higher up.
+ *
+ * A candidate must be a DIRECTORY. `existsSync` answers "is there an entry at this path", which a
+ * regular file satisfies — and every caller then joins entrypoints beneath it and gets a confusing
+ * miss instead of a clean "not installed here". `statSync` follows symlinks, so a symlinked package
+ * directory stays valid; a broken link stats as an error and is treated as absent.
  *
  * It lives here rather than in the config because this module already owns *where the chromadb
  * package is*; the config imports it so one answer serves both the probe and the spawn.
@@ -30,8 +47,12 @@ export function resolvePackageDir(fromDir, pkg) {
     for (;;) {
         const candidate = path.join(current, 'node_modules', pkg);
 
-        if (fs.existsSync(candidate)) {
-            return candidate
+        try {
+            if (fs.statSync(candidate).isDirectory()) {
+                return candidate
+            }
+        } catch {
+            // Absent, or a broken symlink. Both are "not installed here"; keep walking.
         }
 
         const parent = path.dirname(current);
@@ -165,6 +186,8 @@ export function readChromaLogTail(logPath, maximumLength = 4000) {
  * @param {Number} [options.timeoutMs=120000]
  * @param {Function} [options.spawnFn=spawn]
  * @param {Function} [options.probeFn=probeChromaHeartbeat]
+ * @param {Function} [options.resolveFn=resolvePackageDir] Injected so a spec can control the walk
+ *     instead of letting the host filesystem above `repoRoot` decide the result.
  * @returns {Promise<Number>} The detached process-group leader PID.
  */
 export async function startChromaProcess({
@@ -175,7 +198,8 @@ export async function startChromaProcess({
     logPath,
     timeoutMs = 120000,
     spawnFn   = spawn,
-    probeFn   = probeChromaHeartbeat
+    probeFn   = probeChromaHeartbeat,
+    resolveFn = resolvePackageDir
 }) {
     if (await probeFn({host, port})) {
         throw new Error(`Refusing to reuse a Chroma server already listening at ${host}:${port}`)
@@ -185,13 +209,22 @@ export async function startChromaProcess({
     // winning. From a linked worktree `repoRoot/node_modules` does not exist, so a joined path spawns
     // a CLI that is not there — the child dies immediately and the failure reports "Chroma exited
     // before its heartbeat became ready", naming the symptom two layers from the missing file.
-    const packageDir = resolvePackageDir(repoRoot, 'chromadb');
+    const packageDir = resolveFn(repoRoot, 'chromadb');
 
     if (packageDir === null) {
         throw new Error(`Cannot locate the chromadb package from ${repoRoot} — is the Brain tier installed?`)
     }
 
-    const cliPath = path.join(packageDir, 'dist', 'cli.mjs');
+    const cliPath = path.join(packageDir, CHROMA_CLI_ENTRYPOINT);
+
+    // Locating a package and proving the capability are separate checks, and only the second one is
+    // what this function is about to execute. `hasBrainTier` admits the tier on `dist/chromadb.mjs`;
+    // a partial install carrying that file without this one passes admission and then dies at the
+    // heartbeat — the same indirection the resolution fix removed, one artifact over. `CHROMA_CLI_
+    // ENTRYPOINT` is exported so the probe and the spawn cannot drift apart again.
+    if (!fs.existsSync(cliPath)) {
+        throw new Error(`chromadb is installed at ${packageDir} but ${CHROMA_CLI_ENTRYPOINT} is missing — the Brain tier install is partial`)
+    }
 
     fs.mkdirSync(dataDir, {recursive: true});
     fs.mkdirSync(path.dirname(logPath), {recursive: true});

--- a/test/playwright/chromaProcess.mjs
+++ b/test/playwright/chromaProcess.mjs
@@ -6,6 +6,45 @@ import path                  from 'node:path';
 const temporaryPrefix = 'neo-chroma-unit-test-';
 
 /**
+ * @summary Locates a package directory the way Node's resolver does — first `node_modules/<pkg>`
+ * found walking up from `fromDir`, or `null`.
+ *
+ * `path.join(fromDir, 'node_modules', pkg)` is not that algorithm, and the gap is a linked git
+ * worktree: `npm install` runs in the main clone, so a worktree has no `node_modules` of its own
+ * while every import from it resolves fine against the clone's. A joined path therefore reports
+ * absent for packages that demonstrably load, and spawns a CLI path that does not exist.
+ *
+ * FIRST match wins, with no fallback to a further ancestor — also Node's behaviour, and load-bearing
+ * for the Brain-tier probe: a pruned husk at depth 0 must stay a husk rather than being papered over
+ * by a good copy higher up.
+ *
+ * It lives here rather than in the config because this module already owns *where the chromadb
+ * package is*; the config imports it so one answer serves both the probe and the spawn.
+ * @param {String} fromDir Directory to start the upward walk at.
+ * @param {String} pkg Package name, scoped names included.
+ * @returns {String|null}
+ */
+export function resolvePackageDir(fromDir, pkg) {
+    let current = path.resolve(fromDir);
+
+    for (;;) {
+        const candidate = path.join(current, 'node_modules', pkg);
+
+        if (fs.existsSync(candidate)) {
+            return candidate
+        }
+
+        const parent = path.dirname(current);
+
+        if (parent === current) {
+            return null
+        }
+
+        current = parent
+    }
+}
+
+/**
  * @summary Resolves after the bounded polling delay used by readiness and teardown loops.
  * @param {Number} milliseconds
  * @returns {Promise<void>}
@@ -138,11 +177,21 @@ export async function startChromaProcess({
     spawnFn   = spawn,
     probeFn   = probeChromaHeartbeat
 }) {
-    const cliPath = path.join(repoRoot, 'node_modules', 'chromadb', 'dist', 'cli.mjs');
-
     if (await probeFn({host, port})) {
         throw new Error(`Refusing to reuse a Chroma server already listening at ${host}:${port}`)
     }
+
+    // Resolved, not joined, and AFTER the reuse guard: that guard is a safety refusal and must keep
+    // winning. From a linked worktree `repoRoot/node_modules` does not exist, so a joined path spawns
+    // a CLI that is not there — the child dies immediately and the failure reports "Chroma exited
+    // before its heartbeat became ready", naming the symptom two layers from the missing file.
+    const packageDir = resolvePackageDir(repoRoot, 'chromadb');
+
+    if (packageDir === null) {
+        throw new Error(`Cannot locate the chromadb package from ${repoRoot} — is the Brain tier installed?`)
+    }
+
+    const cliPath = path.join(packageDir, 'dist', 'cli.mjs');
 
     fs.mkdirSync(dataDir, {recursive: true});
     fs.mkdirSync(path.dirname(logPath), {recursive: true});

--- a/test/playwright/playwright.config.unit.mjs
+++ b/test/playwright/playwright.config.unit.mjs
@@ -1,9 +1,10 @@
 import './configTemplateResolver.mjs';
 
-import {defineConfig}  from '@playwright/test';
-import {existsSync}    from 'node:fs';
-import path            from 'path';
-import {fileURLToPath} from 'url';
+import {defineConfig}      from '@playwright/test';
+import {existsSync}        from 'node:fs';
+import path                from 'path';
+import {fileURLToPath}     from 'url';
+import {resolvePackageDir} from './chromaProcess.mjs';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname  = path.dirname(__filename);
@@ -76,14 +77,19 @@ export const memoryCoreConfigTemplateTestMatch =
 export const brainHookTestMatch = /[\\/]hooks[\\/](codexContextHook|kimiTurnPresenceHook)\.spec\.mjs$/;
 
 /**
- * @summary Probes whether the Brain-tier set is installed AND consumable under `rootDir/node_modules`.
+ * @summary Probes whether the Brain-tier set is installed AND consumable, as resolved from `rootDir`.
  * Directory names alone lie: a pruned or corrupt install can leave three empty husks that
  * false-green CI. The probe therefore checks each root's consumable entrypoint — for
  * `better-sqlite3` including the compiled native artifact (the thing a broken build actually
  * loses). It deliberately stops at artifact presence rather than `require()`: loading the
  * default embedder pulls `@huggingface/transformers` (seconds at every config load), while the
  * only artifact that realistically breaks without leaving a file-level trace is the native one.
- * @param {String} rootDir Repository root containing `node_modules`.
+ *
+ * The husk check is why this cannot simply become `require.resolve`: resolution answers "is there an
+ * entrypoint", never "did the native build produce its artifact", so it would report armed for
+ * exactly the broken install this probe exists to catch. Resolution is used to find the package
+ * DIRECTORY ({@link resolvePackageDir}); the file checks inside it are unchanged.
+ * @param {String} rootDir Directory to resolve `node_modules` from — a repo root or a worktree.
  * @returns {Boolean}
  */
 export function hasBrainTier(rootDir) {
@@ -91,9 +97,11 @@ export function hasBrainTier(rootDir) {
         ['better-sqlite3', 'lib/index.js', 'build/Release/better_sqlite3.node'],
         ['chromadb', 'dist/chromadb.mjs'],
         ['@chroma-core/default-embed', 'dist/default-embed.mjs']
-    ].every(([pkg, ...entrypoints]) =>
-        entrypoints.every(entry => existsSync(path.join(rootDir, 'node_modules', pkg, entry)))
-    )
+    ].every(([pkg, ...entrypoints]) => {
+        const packageDir = resolvePackageDir(rootDir, pkg);
+
+        return packageDir !== null && entrypoints.every(entry => existsSync(path.join(packageDir, entry)))
+    })
 }
 
 /**

--- a/test/playwright/playwright.config.unit.mjs
+++ b/test/playwright/playwright.config.unit.mjs
@@ -4,7 +4,7 @@ import {defineConfig}      from '@playwright/test';
 import {existsSync}        from 'node:fs';
 import path                from 'path';
 import {fileURLToPath}     from 'url';
-import {resolvePackageDir} from './chromaProcess.mjs';
+import {CHROMA_CLI_ENTRYPOINT, resolvePackageDir} from './chromaProcess.mjs';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname  = path.dirname(__filename);
@@ -89,13 +89,19 @@ export const brainHookTestMatch = /[\\/]hooks[\\/](codexContextHook|kimiTurnPres
  * entrypoint", never "did the native build produce its artifact", so it would report armed for
  * exactly the broken install this probe exists to catch. Resolution is used to find the package
  * DIRECTORY ({@link resolvePackageDir}); the file checks inside it are unchanged.
+ *
+ * **The entrypoint list is what each project ACTUALLY executes, not what the package advertises.**
+ * `chromadb` carries two: Brain specs import `dist/chromadb.mjs`, and the `chroma-setup` dependency
+ * this gate admits spawns {@link CHROMA_CLI_ENTRYPOINT}. Admitting on the first alone let a partial
+ * install pass the gate and die at the heartbeat — an admission gate that proves a different
+ * artifact from the one its dependent runs is not an admission gate.
  * @param {String} rootDir Directory to resolve `node_modules` from — a repo root or a worktree.
  * @returns {Boolean}
  */
 export function hasBrainTier(rootDir) {
     return [
         ['better-sqlite3', 'lib/index.js', 'build/Release/better_sqlite3.node'],
-        ['chromadb', 'dist/chromadb.mjs'],
+        ['chromadb', 'dist/chromadb.mjs', CHROMA_CLI_ENTRYPOINT],
         ['@chroma-core/default-embed', 'dist/default-embed.mjs']
     ].every(([pkg, ...entrypoints]) => {
         const packageDir = resolvePackageDir(rootDir, pkg);

--- a/test/playwright/unit/test/chromaProcess.spec.mjs
+++ b/test/playwright/unit/test/chromaProcess.spec.mjs
@@ -6,6 +6,7 @@ import {
     cleanupChromaArtifacts,
     isDetachedProcessAlive,
     ownsChromaDataDir,
+    resolvePackageDir,
     startChromaProcess,
     stopDetachedProcess
 } from '../../chromaProcess.mjs';
@@ -124,6 +125,78 @@ test.describe('playwright.config.unit — Chroma capability admission', () => {
             fs.rmSync(root, {force: true, recursive: true})
         }
     });
+
+    test('the tier resolves from a directory holding no node_modules of its own', () => {
+        // The linked-worktree shape: `npm install` ran one level up, so imports from here resolve
+        // against the parent while a joined `here/node_modules/...` does not exist at all.
+        const parent = fs.mkdtempSync(path.join(os.tmpdir(), 'brain-tier-parent-')),
+              nested = path.join(parent, 'worktree'),
+              mk     = (root, pkg, ...files) => files.forEach(file => {
+                  const full = path.join(root, 'node_modules', pkg, file);
+                  fs.mkdirSync(path.dirname(full), {recursive: true});
+                  fs.writeFileSync(full, '{}')
+              });
+
+        try {
+            fs.mkdirSync(nested);
+            mk(parent, 'better-sqlite3', 'lib/index.js', 'build/Release/better_sqlite3.node');
+            mk(parent, 'chromadb', 'dist/chromadb.mjs');
+            mk(parent, '@chroma-core/default-embed', 'dist/default-embed.mjs');
+
+            expect(fs.existsSync(path.join(nested, 'node_modules'))).toBe(false);
+            expect(hasBrainTier(nested)).toBe(true);
+            expect(resolvePackageDir(nested, 'chromadb')).toBe(path.join(parent, 'node_modules', 'chromadb'));
+            // Scoped names are a separate path-join shape and worth pinning once.
+            expect(resolvePackageDir(nested, '@chroma-core/default-embed'))
+                .toBe(path.join(parent, 'node_modules', '@chroma-core/default-embed'));
+        } finally {
+            fs.rmSync(parent, {force: true, recursive: true})
+        }
+    });
+
+    test('CONTROL: the nearest node_modules wins, so a husk is never papered over from above', () => {
+        // The half that keeps the husk probe meaningful. Resolving upward must not become
+        // "search until something works" — a pruned install beside you is still a pruned install,
+        // and falling through to an intact copy in an ancestor would report the tier armed on the
+        // exact broken state the entrypoint checks exist to catch.
+        const parent = fs.mkdtempSync(path.join(os.tmpdir(), 'brain-tier-shadow-')),
+              nested = path.join(parent, 'worktree'),
+              mk     = (root, pkg, ...files) => files.forEach(file => {
+                  const full = path.join(root, 'node_modules', pkg, file);
+                  fs.mkdirSync(path.dirname(full), {recursive: true});
+                  fs.writeFileSync(full, '{}')
+              });
+
+        try {
+            fs.mkdirSync(nested);
+            // Intact one level up …
+            mk(parent, 'better-sqlite3', 'lib/index.js', 'build/Release/better_sqlite3.node');
+            mk(parent, 'chromadb', 'dist/chromadb.mjs');
+            mk(parent, '@chroma-core/default-embed', 'dist/default-embed.mjs');
+            // … husked right here. The nearer one is what Node would load, so it is what decides.
+            mk(nested, 'better-sqlite3', 'lib/index.js');
+            mk(nested, 'chromadb', 'dist/chromadb.mjs');
+            mk(nested, '@chroma-core/default-embed', 'dist/default-embed.mjs');
+
+            expect(hasBrainTier(nested)).toBe(false);
+            expect(resolvePackageDir(nested, 'chromadb')).toBe(path.join(nested, 'node_modules', 'chromadb'));
+            // The ancestor is genuinely armed — so this arm fails if the walk ever falls through.
+            expect(hasBrainTier(parent)).toBe(true);
+        } finally {
+            fs.rmSync(parent, {force: true, recursive: true})
+        }
+    });
+
+    test('resolvePackageDir gives up at the filesystem root rather than looping', () => {
+        const root = fs.mkdtempSync(path.join(os.tmpdir(), 'brain-tier-absent-'));
+
+        try {
+            expect(resolvePackageDir(root, 'a-package-that-is-not-installed-17477')).toBeNull();
+            expect(hasBrainTier(path.parse(root).root)).toBe(false);
+        } finally {
+            fs.rmSync(root, {force: true, recursive: true})
+        }
+    });
 });
 
 test.describe('test/playwright/chromaProcess — run-scoped Chroma lifecycle', () => {
@@ -150,6 +223,63 @@ test.describe('test/playwright/chromaProcess — run-scoped Chroma lifecycle', (
         })).rejects.toThrow(/Refusing to reuse a Chroma server already listening/);
 
         expect(spawnCalled).toBe(false);
+    });
+
+    test('the CLI path is RESOLVED from repoRoot, so a worktree spawns the real binary', async () => {
+        // The second half of the same defect. Fixing only the tier probe arms the projects and then
+        // fails at `chroma-setup` with "Chroma exited before its heartbeat became ready" — a
+        // symptom two layers away from `node …/never-existed/dist/cli.mjs`.
+        const parent = fs.mkdtempSync(path.join(os.tmpdir(), 'chroma-cli-resolve-')),
+              nested = path.join(parent, 'worktree'),
+              cliDir = path.join(parent, 'node_modules', 'chromadb', 'dist');
+
+        let spawnedArgs = null;
+
+        try {
+            fs.mkdirSync(nested);
+            fs.mkdirSync(cliDir, {recursive: true});
+            fs.writeFileSync(path.join(cliDir, 'cli.mjs'), '');
+
+            await expect(startChromaProcess({
+                dataDir : path.join(parent, 'data'),
+                host    : '127.0.0.1',
+                logPath : path.join(parent, 'chroma.log'),
+                port    : 18191,
+                probeFn : async () => false,
+                repoRoot: nested,
+                spawnFn : (_command, args) => {
+                    spawnedArgs = args;
+                    throw new Error('stop here — the spawn argument is the whole assertion')
+                }
+            })).rejects.toThrow(/stop here/);
+
+            // Asserted BEFORE the comparisons below, because `not.toBe(...)` against an unset
+            // capture passes vacuously — a control that cannot fail proves nothing.
+            expect(spawnedArgs).not.toBeNull();
+            expect(spawnedArgs[0]).toBe(path.join(cliDir, 'cli.mjs'));
+            // CONTROL: a joined path would have produced this instead, and it does not exist.
+            expect(spawnedArgs[0]).not.toBe(path.join(nested, 'node_modules', 'chromadb', 'dist', 'cli.mjs'));
+        } finally {
+            fs.rmSync(parent, {force: true, recursive: true})
+        }
+    });
+
+    test('an unlocatable chromadb names itself rather than dying at the heartbeat', async () => {
+        const root = fs.mkdtempSync(path.join(os.tmpdir(), 'chroma-cli-absent-'));
+
+        try {
+            await expect(startChromaProcess({
+                dataDir : path.join(root, 'data'),
+                host    : '127.0.0.1',
+                logPath : path.join(root, 'chroma.log'),
+                port    : 18192,
+                probeFn : async () => false,
+                repoRoot: path.parse(root).root,
+                spawnFn : () => { throw new Error('must not reach spawn') }
+            })).rejects.toThrow(/Cannot locate the chromadb package/);
+        } finally {
+            fs.rmSync(root, {force: true, recursive: true})
+        }
     });
 
     test('SIGINT settles a detached POSIX process group without escalation', async () => {

--- a/test/playwright/unit/test/chromaProcess.spec.mjs
+++ b/test/playwright/unit/test/chromaProcess.spec.mjs
@@ -3,6 +3,7 @@ import fs             from 'node:fs';
 import os             from 'node:os';
 import path           from 'node:path';
 import {
+    CHROMA_CLI_ENTRYPOINT,
     cleanupChromaArtifacts,
     isDetachedProcessAlive,
     ownsChromaDataDir,
@@ -120,7 +121,34 @@ test.describe('playwright.config.unit — Chroma capability admission', () => {
             mk('@chroma-core/default-embed', 'dist/default-embed.mjs');
             expect(hasBrainTier(root)).toBe(false);
             mk('better-sqlite3', 'build/Release/better_sqlite3.node');
+            // Still false: `chromadb` is admitted on the LIBRARY entrypoint above, and the
+            // `chroma-setup` project this gate admits spawns the CLI one. Proving a different
+            // artifact from the one the dependent runs is not an admission gate — a partial install
+            // in exactly this shape passed and then died at the heartbeat.
+            expect(hasBrainTier(root)).toBe(false);
+            mk('chromadb', CHROMA_CLI_ENTRYPOINT);
             expect(hasBrainTier(root)).toBe(true);
+        } finally {
+            fs.rmSync(root, {force: true, recursive: true})
+        }
+    });
+
+    test('a regular file named like a package does not satisfy the resolver', () => {
+        // `existsSync` answers "is there an entry at this path", which a FILE satisfies. Callers then
+        // join entrypoints beneath it and get a confusing miss instead of "not installed here", and
+        // the walk stops at a candidate that can never hold anything.
+        // A name no real install can carry, so the upward walk past the rejected candidate cannot
+        // reach a host package and decide this result — the fixture owns the whole answer.
+        const pkg  = '@neo-fixture-17477/not-a-real-package',
+              root = fs.mkdtempSync(path.join(os.tmpdir(), 'brain-tier-file-')),
+              full = path.join(root, 'node_modules', pkg);
+
+        try {
+            fs.mkdirSync(path.dirname(full), {recursive: true});
+            fs.writeFileSync(full, 'not a package');
+
+            expect(fs.existsSync(full)).toBe(true);
+            expect(resolvePackageDir(root, pkg)).toBeNull()
         } finally {
             fs.rmSync(root, {force: true, recursive: true})
         }
@@ -140,7 +168,7 @@ test.describe('playwright.config.unit — Chroma capability admission', () => {
         try {
             fs.mkdirSync(nested);
             mk(parent, 'better-sqlite3', 'lib/index.js', 'build/Release/better_sqlite3.node');
-            mk(parent, 'chromadb', 'dist/chromadb.mjs');
+            mk(parent, 'chromadb', 'dist/chromadb.mjs', CHROMA_CLI_ENTRYPOINT);
             mk(parent, '@chroma-core/default-embed', 'dist/default-embed.mjs');
 
             expect(fs.existsSync(path.join(nested, 'node_modules'))).toBe(false);
@@ -171,11 +199,11 @@ test.describe('playwright.config.unit — Chroma capability admission', () => {
             fs.mkdirSync(nested);
             // Intact one level up …
             mk(parent, 'better-sqlite3', 'lib/index.js', 'build/Release/better_sqlite3.node');
-            mk(parent, 'chromadb', 'dist/chromadb.mjs');
+            mk(parent, 'chromadb', 'dist/chromadb.mjs', CHROMA_CLI_ENTRYPOINT);
             mk(parent, '@chroma-core/default-embed', 'dist/default-embed.mjs');
             // … husked right here. The nearer one is what Node would load, so it is what decides.
             mk(nested, 'better-sqlite3', 'lib/index.js');
-            mk(nested, 'chromadb', 'dist/chromadb.mjs');
+            mk(nested, 'chromadb', 'dist/chromadb.mjs', CHROMA_CLI_ENTRYPOINT);
             mk(nested, '@chroma-core/default-embed', 'dist/default-embed.mjs');
 
             expect(hasBrainTier(nested)).toBe(false);
@@ -191,8 +219,11 @@ test.describe('playwright.config.unit — Chroma capability admission', () => {
         const root = fs.mkdtempSync(path.join(os.tmpdir(), 'brain-tier-absent-'));
 
         try {
-            expect(resolvePackageDir(root, 'a-package-that-is-not-installed-17477')).toBeNull();
-            expect(hasBrainTier(path.parse(root).root)).toBe(false);
+            // The name is unique on purpose: the walk genuinely runs to the filesystem root, and no
+            // real `node_modules` anywhere above can carry it, so termination is what is proven and
+            // not the host's contents. An assertion against `path.parse(root).root` would let a
+            // machine that happens to have `/node_modules` decide a unit result.
+            expect(resolvePackageDir(root, '@neo-fixture-17477/absent-everywhere')).toBeNull()
         } finally {
             fs.rmSync(root, {force: true, recursive: true})
         }
@@ -274,9 +305,67 @@ test.describe('test/playwright/chromaProcess — run-scoped Chroma lifecycle', (
                 logPath : path.join(root, 'chroma.log'),
                 port    : 18192,
                 probeFn : async () => false,
-                repoRoot: path.parse(root).root,
-                spawnFn : () => { throw new Error('must not reach spawn') }
+                repoRoot: root,
+                // Injected rather than walked. A real walk from a temp dir reads whatever the host
+                // has above it, so the assertion would be about this machine — the same class of
+                // uncontrolled read as the `path.parse(root).root` fixtures this replaces.
+                resolveFn: () => null,
+                spawnFn  : () => { throw new Error('must not reach spawn') }
             })).rejects.toThrow(/Cannot locate the chromadb package/);
+        } finally {
+            fs.rmSync(root, {force: true, recursive: true})
+        }
+    });
+
+    test('a located-but-partial chromadb names the missing CLI, and never reaches spawn', async () => {
+        // The admission gate and the process it enables checked DIFFERENT artifacts: `hasBrainTier`
+        // proved `dist/chromadb.mjs`, `chroma-setup` spawns the CLI. An install carrying the first
+        // without the second passed the gate and then failed as "Chroma exited before its heartbeat
+        // became ready" — the same indirection the resolution fix removed, one artifact over.
+        const root       = fs.mkdtempSync(path.join(os.tmpdir(), 'chroma-cli-partial-')),
+              packageDir = path.join(root, 'node_modules', 'chromadb');
+
+        let spawnCalled = false;
+
+        try {
+            fs.mkdirSync(path.join(packageDir, 'dist'), {recursive: true});
+            fs.writeFileSync(path.join(packageDir, 'dist', 'chromadb.mjs'), '');
+
+            // Admission refuses it, so the projects are never armed …
+            expect(hasBrainTier(root)).toBe(false);
+
+            // … and the spawn refuses it too, by name. Both halves, because either one alone leaves
+            // the other free to disagree again.
+            await expect(startChromaProcess({
+                dataDir : path.join(root, 'data'),
+                host    : '127.0.0.1',
+                logPath : path.join(root, 'chroma.log'),
+                port    : 18193,
+                probeFn : async () => false,
+                repoRoot: root,
+                spawnFn : () => { spawnCalled = true }
+            })).rejects.toThrow(new RegExp(`${CHROMA_CLI_ENTRYPOINT.replace('.', '\\.')} is missing`));
+
+            expect(spawnCalled).toBe(false);
+
+            // CONTROL: same fixture, one file added, and the spawn is now reached. Without this the
+            // arm above is satisfied by a build that refuses every install it is handed.
+            fs.writeFileSync(path.join(packageDir, CHROMA_CLI_ENTRYPOINT), '');
+
+            await expect(startChromaProcess({
+                dataDir : path.join(root, 'data'),
+                host    : '127.0.0.1',
+                logPath : path.join(root, 'chroma.log'),
+                port    : 18193,
+                probeFn : async () => false,
+                repoRoot: root,
+                spawnFn : () => {
+                    spawnCalled = true;
+                    throw new Error('reached spawn')
+                }
+            })).rejects.toThrow(/reached spawn/);
+
+            expect(spawnCalled).toBe(true)
         } finally {
             fs.rmSync(root, {force: true, recursive: true})
         }


### PR DESCRIPTION
Resolves #17477

`hasBrainTier` asked `existsSync(path.join(rootDir, 'node_modules', pkg, entry))`. A linked git worktree has no `node_modules` of its own — `npm install` runs once, in the main clone — while every import from that worktree resolves fine against the clone's. So the probe reported the tier **absent for packages that demonstrably load**, printed a banner saying so, and dropped the whole Brain matrix from the project list.

Evidence: L2 required → **L2 achieved, no residual** (18 arms green; four mutation runs, one per claim; a three-state before/after measured from a bare worktree).

## Round 2 — @neo-gpt-emmy found the gate proving a different artifact than it admits

Both RAs were real, and RA-1 is this PR's own defect one artifact over.

**RA-1 — admission and execution checked different files.** `hasBrainTier` admitted `chromadb` on `dist/chromadb.mjs`, the library entrypoint Brain specs import. The `chroma-setup` dependency it admits spawns **`dist/cli.mjs`**. So an install carrying the first without the second **passes the gate and then dies as "Chroma exited before its heartbeat became ready"** — the exact indirection the resolution fix in this PR removes, reached by a different route. Emmy's phrasing is the one to keep: *"locating a package and proving the capability are separate checks."*

`CHROMA_CLI_ENTRYPOINT` is now one exported constant with two consumers, so probe and spawn cannot drift apart again, and `startChromaProcess` verifies the artifact **before** `spawnFn` rather than letting a missing file surface as a child exit.

**RA-2 — two real test-isolation defects I introduced.**

- `resolvePackageDir` returned any existing entry. `existsSync` is true for a **regular file**, so a file named `node_modules/chromadb` satisfied it; callers then joined entrypoints beneath something that can never hold them, and the walk stopped at a dead candidate. It now requires a directory, `statSync` following symlinks so a symlinked package stays valid.
- Two fixtures asserted against `path.parse(root).root`. **A machine with a real `/node_modules` would have changed a unit result.** Termination is now proven with a package name no install can carry, and the unlocatable-CLI arm injects its resolver through the same seam `spawnFn` and `probeFn` already use.

The `startChromaProcess` surface and both new exports are now rows in #17477's Contract Ledger.

## Measured, from a worktree with no local `node_modules`

```
BEFORE                 [playwright.config.unit] Brain-tier set not installed … Run `npm run install-brain` to arm them.
                       Error: Project(s) "unit-brain" not found. Available projects: "unit"

AFTER layer 1 only     Running 4 tests using 2 workers
                       1) [chroma-setup] Error: Chroma exited before its heartbeat became ready

AFTER both layers      Running 4 tests using 2 workers
                       4 passed
```

The banner is falsifiable in one line — the three packages it names load from that same directory:

```
$ node -e "import('chromadb').then(()=>console.log('ok'))"                   # ok
$ node -e "import('better-sqlite3').then(()=>console.log('ok'))"             # ok
$ node -e "import('@chroma-core/default-embed').then(()=>console.log('ok'))" # ok
```

And `npm run install-brain`, which is what the banner tells you to run, reports the tier already armed. Nothing was missing; only the lookup was wrong.

**Why this is worth a fix rather than a symlink in a README.** `assertBrainTierForEnvironment` **throws** on this condition under CI, and its docblock says why: *"a skipped brain matrix on a green CI run is silent coverage loss, so it must fail before collection."* The condition is already understood to be serious enough to fail a run — and the guard is armed only where nobody is watching. Locally the same state is one `console.info` above a plausible-looking pass count.

## Deltas from ticket: my own proposed fix was wrong, and the specs said so

The ticket's Fix section proposed `createRequire(...).resolve(pkg + '/' + entry)`. **That would have silently deleted the guard this probe exists for**, and I only found it by reading `chromaProcess.spec.mjs` before implementing my own acceptance criterion.

The existing spec pins a four-state husk ladder:

| state | expected |
|---|---|
| three bare directories | `false` |
| entrypoints present, **no** `build/Release/better_sqlite3.node` | `false` |
| native artifact added | `true` |

Resolution answers *"is there an entrypoint"*, never *"did the native build produce its artifact"* — so `require.resolve` reports **armed** for exactly the broken-build case the docblock calls *"the thing a broken build actually loses"*. The ticket body now carries the correction with the wrong version struck rather than rewritten clean, since anyone implementing the original would ship the regression.

**The fix that works: resolve the package DIRECTORY, keep the file checks inside it.** `resolvePackageDir` does Node's upward walk; `hasBrainTier`'s entrypoint checks are byte-identical, just rooted at the resolved directory instead of a joined one. Husk detection unchanged, worktrees fixed, `rootDir` still injected so the existing pure-by-injection specs keep exercising both tiers.

## First match wins, and that is the load-bearing half

`resolvePackageDir` returns the **first** `node_modules/<pkg>` it finds and never falls through to a further ancestor. That is Node's behaviour, and here it is what keeps the husk ladder meaningful: a pruned copy beside you must stay pruned rather than being papered over by an intact copy one level up.

Without that constraint, "resolve upward" degrades into "search until something works" — and it degrades **silently**, because every husk assertion above would still pass in a synthetic root that has no armed ancestor. A dedicated CONTROL arm builds exactly that adversarial shape: husked at depth 0, intact at depth 1, and asserts `false` — plus `hasBrainTier(parent) === true`, so the arm fails if the walk ever falls through rather than passing on a coincidence.

## The second layer, found by the failure the first layer exposed

`chromaProcess.mjs:141` joined the same way for the CLI it spawns:

```js
const cliPath = path.join(repoRoot, 'node_modules', 'chromadb', 'dist', 'cli.mjs');
```

Fixing only the probe arms the projects and then dies at `chroma-setup` with *"Chroma exited before its heartbeat became ready"* — a symptom **two layers** from `node <path-that-does-not-exist>`. That is the middle row of the table above; I did not predict it, the run did.

Both layers share the one helper. It lives in `chromaProcess.mjs` because that module already owns *where the chromadb package is*, and there is no cycle — `chromaProcess.mjs` imports only node builtins. The resolution is placed **after** the reuse guard, so *"Refusing to reuse a Chroma server already listening"* keeps winning; that is a safety refusal and a missing package is a setup error.

## Test Evidence

**18 arms green.** Seven new, plus two rungs added to the existing husk ladder:

| arm | pins |
|---|---|
| the tier resolves from a directory holding no `node_modules` of its own | the worktree shape, plus a scoped package name (`@chroma-core/…` is a different join) |
| **CONTROL:** the nearest `node_modules` wins | a husk is never papered over from above |
| a regular file named like a package does not satisfy the resolver | `existsSync` accepts a file; a package must be a directory |
| `resolvePackageDir` gives up at the filesystem root | terminates rather than looping, with a package name no install can carry |
| the CLI path is RESOLVED from `repoRoot` | the spawn argument, with the joined path asserted *not* taken |
| an unlocatable `chromadb` names itself | the setup error stops being a heartbeat timeout |
| a located-but-partial `chromadb` names the missing CLI, and never reaches spawn | admission and spawn agree, **+ CONTROL** that adding the one file reaches spawn |

**Four mutation runs, one per claim:**

| mutation | reddens |
|---|---|
| `resolvePackageDir` → plain `path.join` | **4 arms**; the husk ladder stays green, correctly — it guards a different regression |
| `hasBrainTier` falls through a husk to an intact ancestor | **exactly the nearest-wins CONTROL**, nothing else |
| drop `CHROMA_CLI_ENTRYPOINT` from admission *(RA-1's defect restored)* | the husk-ladder arm, at the new rung |
| `resolvePackageDir` back to `existsSync` *(RA-2's defect restored)* | the regular-file arm |

**One arm I had to fix before it could fail.** My first version of the CLI-path arm did not `await`, so `spawnedArgs` was `undefined` and the control read `expect(undefined).not.toBe(joinedPath)` — which passes for the wrong reason. It now asserts the capture is non-null *before* comparing.

## Post-Merge Validation

From any linked worktree with no `node_modules` of its own: `--project=unit-brain` resolves, no skip banner appears, and `chroma-setup` boots. On a genuinely pruned install the banner returns and CI still throws.

## Out of Scope

Running the config **without** `--project` fails from a worktree at `configTemplateResolver.mjs:96` — traced to `Cannot find module '<worktree>/dist/parse5.mjs'`. A worktree has no built `dist/`, which is a missing **build artifact**, not a resolution defect, and it needs a different remedy. It is left out rather than folded in: it means the plain no-`--project` invocation could not be exercised here, so what this PR measures is the `--project=unit-brain` path.

## Evolution

**When a detector and a resolver disagree about the same dependency, the detector is the one hard-coding a path.** Imports walking up is the default; `path.join(root, 'node_modules', …)` is a choice, and it is invisible until the root stops being where you stand.

The part worth keeping is smaller and sharper: **I wrote an acceptance criterion that would have deleted a guard, and the only reason it did not ship is that I read the consumer spec before implementing my own AC.** A ticket I authored is not evidence. It is the same lesson as the corrections in this PR's siblings today, arriving from the direction I was least watching — my own prescription.

Round 2 sharpened it again, and the shape is worth naming: **a gate must prove the artifact its dependent EXECUTES, not the one the package advertises.** I fixed "the detector looks in the wrong place" and left "the detector looks at the wrong file" standing one line away, in the same function, having just written the docblock explaining why entrypoint checks matter. Knowing the failure mode does not locate its next instance.

Authored by Ada (Claude Opus 5, Claude Code). Session ab15d2b8-eb14-4237-ad18-ce48584b2d07.
