### PR TITLE
feat(memory-core): record seen at the model-visible MCP boundary, not on caller identity (#17321)

### DIFF
--- a/ai/graph/storage/Base.mjs
+++ b/ai/graph/storage/Base.mjs
@@ -35,6 +35,33 @@ class Base extends NeoBase {
     addEdges(edges) {}
 
     /**
+     * @summary Sets ONE property on an existing record, only when it is currently absent.
+     *
+     * The narrow counterpart to {@link addNodes} / {@link addEdges}, which replace the whole document
+     * and therefore erase any field another process committed between this process's read and its
+     * write. Receipt timestamps are exactly the fields two processes legitimately write at once — a
+     * listing, a drain and an archive are independent operations on one row — so they need a write
+     * that cannot carry a stale copy of its neighbours.
+     *
+     * Write-once is enforced in SQL rather than by a read-then-check in the caller, because a caller
+     * -side guard reads cache and races the same window it is trying to close.
+     *
+     * @param {String} table `'Nodes'` or `'Edges'`.
+     * @param {String} id Record id.
+     * @param {String} property Property name under `$.properties`.
+     * @param {*} value Value to set.
+     * @returns {Boolean} `true` when this call performed the write; `false` when the property was
+     *   already set or the row does not exist — the caller cannot distinguish, and must not care.
+     *
+     * An adapter that does not override this returns `false`, meaning "no durable write happened".
+     * Callers treat that as a retryable non-write rather than as success, so an unimplemented adapter
+     * degrades to never recording the property instead of claiming a durability it does not have.
+     */
+    setRecordPropertyIfAbsent(table, id, property, value) {
+        return false
+    }
+
+    /**
      * Purges specific Nodes array data natively resolving cascade anomalies internally at the driver stratum.
      * @param {Object[]} nodes
      */

--- a/ai/graph/storage/SQLite.mjs
+++ b/ai/graph/storage/SQLite.mjs
@@ -417,6 +417,46 @@ class SQLite extends Base {
     }
 
     /**
+     * @summary Sets ONE property under `$.properties`, in SQL, only when it is currently absent.
+     *
+     * `json_set` rewrites a single path instead of replacing the document, so a field another process
+     * committed between our read and our write survives. The `IS NULL` predicate makes write-once an
+     * atomic property of the statement rather than a caller-side read-then-check, which would race the
+     * very window it is meant to close.
+     *
+     * `table` and `property` are interpolated (neither a table name nor a JSON path can be a bound
+     * parameter), so both are validated against strict shapes first. `value` is bound.
+     *
+     * @param {String} table `'Nodes'` or `'Edges'`.
+     * @param {String} id Record id.
+     * @param {String} property Property name under `$.properties`; identifier characters only.
+     * @param {*} value Value to set.
+     * @returns {Boolean} `true` only when this statement wrote.
+     */
+    setRecordPropertyIfAbsent(table, id, property, value) {
+        if (!this.db) return false;
+        if (!this.db.open) throw new Error('SQLite connection is closed (lifecycle violation).');
+        this.assertTestWriteIsolated();
+
+        if (table !== 'Nodes' && table !== 'Edges') {
+            throw new Error(`setRecordPropertyIfAbsent supports 'Nodes' and 'Edges'. Received: ${String(table)}`);
+        }
+
+        if (!/^[A-Za-z_][A-Za-z0-9_]*$/.test(property)) {
+            throw new Error(`setRecordPropertyIfAbsent property must be a plain identifier. Received: ${String(property)}`);
+        }
+
+        const path = `$.properties.${property}`;
+
+        return this.db.prepare(`
+            UPDATE ${table}
+            SET   data = json_set(data, '${path}', ?)
+            WHERE id = ?
+              AND json_extract(data, '${path}') IS NULL
+        `).run(value, id).changes > 0;
+    }
+
+    /**
      * Injects complex Edge topologies capturing mapping source/target configurations mapped across WAL schema blocks rigidly.
      * @param {Object[]} edges
      */

--- a/ai/mcp/server/memory-core/openapi.yaml
+++ b/ai/mcp/server/memory-core/openapi.yaml
@@ -2371,7 +2371,11 @@ paths:
                       items: {type: string}
                 all:
                   type: boolean
-                  description: Set true instead of messageId to mark the current unread, unarchived snapshot.
+                  description: Set true instead of messageId to mark the unread, unarchived messages you have been shown.
+                includeUnseen:
+                  type: boolean
+                  default: false
+                  description: Used with `all`, also sweeps messages you were never shown. For clearing a backlog you do not intend to read; it can discard a directed message you have never seen. The receipt's `withheldUnseenCount` reports what the default drain held back.
       responses:
         '200':
           description: OK

--- a/ai/mcp/server/memory-core/openapi.yaml
+++ b/ai/mcp/server/memory-core/openapi.yaml
@@ -2352,9 +2352,11 @@ paths:
       operationId: mark_read
       x-neo-tool-tier: write
       x-pass-as-object: true
-      x-neo-tool-summary: Mark selected or all current unread A2A messages read.
+      x-neo-tool-summary: Mark selected A2A messages read, or drain the unread messages you were actually shown.
       description: |
-        Marks selected messages or the caller's entire current unread inbox snapshot as read. Pass exactly one of `messageId` (a string or array) and `all: true`. Array mode returns per-id results and one stale or unauthorized id never fails the batch. All mode snapshots every currently unread, unarchived message before mutation; messages arriving after snapshot capture remain unread.
+        Marks selected messages read, or drains a snapshot of the caller's unread inbox. Pass exactly one of `messageId` (a string or array) and `all: true`. Array mode returns per-id results and one stale or unauthorized id never fails the batch.
+
+        All mode drains only messages you have SEEN — rows a previous `list_messages` call actually surfaced to you. Mail that arrived but was never displayed is withheld and counted in `withheldUnseenCount`, so a bulk drain cannot silently clear a directed request you never read. Pass `includeUnseen: true` to widen the snapshot back to every unread row. The snapshot is captured before mutation; messages arriving after capture remain unread.
       tags: [Mailbox]
       requestBody:
         required: true

--- a/ai/mcp/server/memory-core/toolService.mjs
+++ b/ai/mcp/server/memory-core/toolService.mjs
@@ -338,6 +338,28 @@ export function composeMemoryCoreHealthcheck({
  */
 const addMessageTool = args => MailboxService.addMessage(args, {deferProjection: true});
 
+/**
+ * @summary The model-visible mailbox boundary — the only place a listing records `seenAt`.
+ *
+ * `MailboxService.listMessages` defaults `recordSeen` to false, so a direct service read cannot
+ * stamp by omission. That is the whole safety argument, and it replaces an earlier design that
+ * keyed on caller identity: `SwarmHeartbeatService` binds the polled agent as the request identity
+ * before reading that agent's own inbox, so an owner-identity test ADMITS the background sweep
+ * rather than excluding it. Caller identity proves mailbox authority, not display authority.
+ *
+ * Arming it here means the heartbeat and the diagnostics scripts are safe by construction — they
+ * never cross this boundary — instead of safe because a predicate happened to exclude them.
+ *
+ * Passed as the SECOND argument rather than folded into `args`, matching `addMessageTool` directly
+ * above. Two reasons, and the first is mechanical: the Zod facade strips keys the operation schema
+ * does not declare, so an options key smuggled through `args` would read `undefined` in production
+ * while every unit test that constructs the call directly still passed. The second is that seen is
+ * not a caller decision — an agent must not be able to suppress or forge it from the wire.
+ * @param {Object} args
+ * @returns {Promise<Object>}
+ */
+const listMessagesTool = args => MailboxService.listMessages(args, {recordSeen: true});
+
 const serviceMapping = {
     add_memory           : MemoryService          .addMemory               .bind(MemoryService),
     get_mcp_tool_handbook: toolId => toolService.getToolHandbook(toolId),
@@ -394,7 +416,7 @@ const serviceMapping = {
     get_memory_core_tool_metrics:
                               MemoryCoreRecorderService.getMemoryCoreToolMetrics.bind(MemoryCoreRecorderService),
     add_message           : addMessageTool,
-    list_messages         : MailboxService         .listMessages            .bind(MailboxService),
+    list_messages         : listMessagesTool,
     get_message           : MailboxService         .getMessage              .bind(MailboxService),
     get_rem_pipeline_state: HealthService          .getRemPipelineState     .bind(HealthService),
     get_sqlite_holder_diagnostics:

--- a/ai/services/memory-core/MailboxService.mjs
+++ b/ai/services/memory-core/MailboxService.mjs
@@ -2160,19 +2160,12 @@ async function setMessageNodeReadAt(node, readAt) {
  * `seenAt` is the state between *arrived* and *explicitly marked read* — the distinction a bulk
  * drain needs, because without it `all: true` can only mean "every unread message that exists".
  *
- * Persisted through `persistReceiptNode`, the same path `readAt` and `archivedAt` already use.
- *
- * **The cache is rolled back when the write fails, and that is not symmetric with `readAt`.** The
- * caller's write-once guard reads the cached `seenAt`, so a cache-first write that then fails to
- * persist would mark the row seen for the rest of the process without ever storing it — and every
- * later listing would skip it, because the guard sees the value its own failed attempt left behind.
- * `readAt` tolerates the same shape only because it is user-driven and can simply be re-issued;
- * `seenAt` is automatic and write-once, so a poisoned cache is permanent. Restoring the prior value
- * is what makes the next listing retry.
+ * Direct DMs carry receipts on the node. Durability, write-once and cache ordering all belong to
+ * {@link setReceiptSeenAt}; this wrapper only chooses the carrier.
  *
  * @param {Object} node Direct-DM `MESSAGE` node.
  * @param {String} seenAt ISO timestamp.
- * @returns {Promise<Boolean>}
+ * @returns {Promise<Boolean>} Whether THIS call performed the durable write.
  */
 async function setMessageNodeSeenAt(node, seenAt) {
     return setReceiptSeenAt(node, 'Nodes', seenAt)
@@ -2232,12 +2225,12 @@ async function setReceiptSeenAt(record, table, seenAt) {
  * same carrier. On the node instead, one recipient's listing would mark the broadcast seen for the
  * entire audience.
  *
- * Rolls the cache back on failure for the same reason as `setMessageNodeSeenAt` — the write-once
- * guard reads the cached value, so a failed persist must not leave the row looking already-seen.
+ * Durability, write-once and cache ordering all belong to {@link setReceiptSeenAt}; this wrapper
+ * only chooses the carrier.
  *
  * @param {Object} edge Per-recipient `DELIVERED_TO` edge.
  * @param {String} seenAt ISO timestamp.
- * @returns {Promise<Boolean>}
+ * @returns {Promise<Boolean>} Whether THIS call performed the durable write.
  */
 async function setDeliveryEdgeSeenAt(edge, seenAt) {
     return setReceiptSeenAt(edge, 'Edges', seenAt)

--- a/ai/services/memory-core/MailboxService.mjs
+++ b/ai/services/memory-core/MailboxService.mjs
@@ -2155,6 +2155,48 @@ async function setMessageNodeReadAt(node, readAt) {
 }
 
 /**
+ * @summary Stamps the SEEN timestamp on a direct-DM `MESSAGE` node.
+ *
+ * `seenAt` is the state between *arrived* and *explicitly marked read* — the distinction a bulk
+ * drain needs, because without it `all: true` can only mean "every unread message that exists".
+ *
+ * Persisted through `persistReceiptNode`, the same path `readAt` and `archivedAt` already use. That
+ * path replaces the whole record, so a concurrent receipt write can race — a real hazard, and a
+ * PRE-EXISTING one shared by every receipt on this surface rather than introduced here. Giving
+ * `seenAt` a stronger durability guarantee than `readAt` would be the wrong asymmetry to add; the
+ * race is filed separately so it can be fixed for all three at once.
+ *
+ * @param {Object} node Direct-DM `MESSAGE` node.
+ * @param {String} seenAt ISO timestamp.
+ * @returns {Promise<Boolean>}
+ */
+async function setMessageNodeSeenAt(node, seenAt) {
+    getRecordProperties(node).seenAt = seenAt;
+
+    return persistReceiptNode(node);
+}
+
+/**
+ * @summary Stamps the SEEN timestamp on a per-recipient `DELIVERED_TO` edge.
+ *
+ * Broadcasts carry per-recipient read state on the edge, so `seenAt` follows `readAt` to exactly the
+ * same carrier. On the node instead, one recipient's listing would mark the broadcast seen for the
+ * entire audience.
+ *
+ * @param {Object} edge Per-recipient `DELIVERED_TO` edge.
+ * @param {String} seenAt ISO timestamp.
+ * @returns {Promise<Boolean>}
+ */
+async function setDeliveryEdgeSeenAt(edge, seenAt) {
+    setRecordProperties(edge, {
+        ...getRecordProperties(edge),
+        seenAt
+    });
+
+    return persistReceiptEdge(edge);
+}
+
+/**
  * Sets the archive timestamp on a per-recipient DELIVERED_TO edge for broadcast
  * messages. Mirrors `setDeliveryEdgeReadAt` exactly — both delegate to
  * `persistReceiptEdge`, so broadcast archive state participates in the same durability
@@ -3091,7 +3133,7 @@ class MailboxService extends Base {
      *   `totalCount` is `0` — an empty `messages` array on its own means "nothing in this window",
      *   which for a newest-first listing over a deep mailbox is a statement about the window.
      */
-    async listMessages({ box = 'inbox', status = 'all', to, threadId, fromIdentity, taggedConcepts, limit = 50, offset = 0, includeArchived = false } = {}) {
+    async listMessages({ box = 'inbox', status = 'all', to, threadId, fromIdentity, taggedConcepts, limit = 50, offset = 0, includeArchived = false } = {}, { recordSeen = false } = {}) {
         const boundIdentity = RequestContextService.getAgentIdentityNodeId();
         if (!boundIdentity) {
             throw RequestContextService.unboundIdentityError('list messages');
@@ -3324,6 +3366,14 @@ class MailboxService extends Base {
         messages = messages.slice(appliedOffset, appliedOffset + appliedLimit);
         await this.attachRelatedPullRequestStates(messages);
 
+        // Only the MCP adapter passes `recordSeen`. A direct service call cannot stamp by omission,
+        // which is what makes `SwarmHeartbeatService` safe: it binds the polled agent as the request
+        // identity and reads that agent's own inbox, so any owner-identity test would ADMIT it.
+        // Stamped after the slice, because only these rows were surfaced.
+        if (recordSeen) {
+            await this._recordSeenForSurfacedRows({messages, me});
+        }
+
         // `truncated` states whether rows remain BEYOND this page, which is deliberately not the
         // `messages.length === limit` heuristic it replaces: a full page that exactly exhausts the
         // filter has nothing after it. Reporting `true` there would be a false positive AND would
@@ -3350,6 +3400,71 @@ class MailboxService extends Base {
      * @param {String} args.messageId The ID of the message to retrieve
      * @returns {Promise<Object>}
      */
+    /**
+     * @summary Records `seenAt` on rows this call surfaced INBOUND to the caller.
+     *
+     * Two guards, and they are independent:
+     *
+     * **1. The caller must be the MCP adapter** — enforced by the caller, not here: `recordSeen`
+     * defaults false, so a direct service read is non-stamping by omission. That is the correction
+     * to the previous attempt, which keyed on caller identity and was falsified by
+     * `SwarmHeartbeatService` binding the polled agent as the request identity before reading that
+     * agent's own inbox. Caller identity proves mailbox AUTHORITY; it does not prove that anything
+     * was displayed to a model.
+     *
+     * **2. Per ROW, the message must be inbound to the caller.** `box: 'all'` returns outbox rows in
+     * the same array, and a message you SENT was never surfaced *to* you. Testing the call's `box`
+     * rather than each row is how an Alice→Bob DM would get stamped on Bob's shared node from
+     * Alice's own listing.
+     *
+     * Write-once: `seenAt` records FIRST surfacing. Re-stamping would silently turn it into a
+     * last-listed timestamp. Failure is logged, never thrown — an unstamped row stays unseen, and an
+     * unseen row is never bulk-swept, so the failure direction costs a redundant listing rather than
+     * a lost directed message.
+     *
+     * @param {Object} options
+     * @param {Object[]} options.messages The page actually returned.
+     * @param {String} options.me Normalized bound caller identity.
+     * @returns {Promise<void>}
+     * @private
+     */
+    async _recordSeenForSurfacedRows({messages, me}) {
+        const
+            db     = GraphService.db,
+            seenAt = new Date().toISOString();
+
+        for (const message of messages) {
+            const {messageId, to} = message;
+
+            if (!messageId) continue;
+
+            // Per-row inbound test. A broadcast is addressed to the sentinel and delivered per
+            // recipient; a DM is addressed to the recipient directly.
+            const inboundToMe = to === 'AGENT:*' || sameMailboxIdentity(to, me);
+
+            if (!inboundToMe) continue;
+
+            try {
+                const deliveryEdge = getBroadcastDeliveryEdge(messageId, me);
+
+                if (deliveryEdge) {
+                    if (!getRecordProperties(deliveryEdge).seenAt) {
+                        await setDeliveryEdgeSeenAt(deliveryEdge, seenAt)
+                    }
+                    continue
+                }
+
+                const node = db?.nodes?.get(messageId);
+
+                if (node && !getRecordProperties(node).seenAt) {
+                    await setMessageNodeSeenAt(node, seenAt)
+                }
+            } catch (error) {
+                logger.warn(`[MailboxService] Could not record seenAt on ${messageId}: ${error.message}`)
+            }
+        }
+    }
+
     async getMessage({ messageId }) {
         const boundIdentity = RequestContextService.getAgentIdentityNodeId();
         if (!boundIdentity) {
@@ -3606,13 +3721,19 @@ class MailboxService extends Base {
      *   `{durable: false, warning}` when storage is absent); array form: `{results: [...]}`;
      *   all form: compact aggregate counts plus exceptional rows.
      */
-    async markRead({messageId, all = false} = {}) {
+    async markRead({messageId, all = false, includeUnseen = false} = {}) {
+        // Validated with the same boolean strictness `all` already uses, and BEFORE the `all` branch,
+        // so a caller who fat-fingers the widening flag is told rather than silently handed the
+        // narrow drain they were trying to opt out of.
+        if (includeUnseen !== true && includeUnseen !== false) {
+            throw new TypeError('mark_read includeUnseen must be a boolean.');
+        }
         if (all === true) {
             if (messageId !== undefined) {
                 throw new TypeError('mark_read accepts either messageId or all: true, not both.');
             }
 
-            return this._markUnreadSnapshotRead();
+            return this._markUnreadSnapshotRead({includeUnseen});
         }
         if (all !== false) {
             throw new TypeError('mark_read all must be a boolean.');
@@ -3755,7 +3876,7 @@ class MailboxService extends Base {
      * @returns {Promise<Object>} Aggregate snapshot receipt with matched/read/durable/failure counts.
      * @private
      */
-    async _markUnreadSnapshotRead() {
+    async _markUnreadSnapshotRead({includeUnseen = false} = {}) {
         const boundIdentity = RequestContextService.getAgentIdentityNodeId();
         if (!boundIdentity) {
             throw RequestContextService.unboundIdentityError('mark all messages read');
@@ -3782,6 +3903,13 @@ class MailboxService extends Base {
         const
             placeholders = targetStorageVariants.map(() => '?').join(', '),
             snapshotAt   = new Date().toISOString(),
+            // What makes a bulk drain discriminating. Each arm tests `seenAt` in the SAME carrier its
+            // own `readAt` lives in — node-side for directed mail, edge-side for per-recipient
+            // broadcast delivery — so the two states can never disagree about which recipient they
+            // describe. `includeUnseen` widens both arms back to the historical set. Interpolated
+            // rather than bound because it selects a clause, not a value, and both branches are
+            // literals in this file.
+            seenClause   = includeUnseen ? '' : "AND json_extract(%SOURCE%.data, '$.properties.seenAt') IS NOT NULL",
             rows         = sqlite.prepare(`
                 WITH unread_messages AS (
                     SELECT n.id AS messageId
@@ -3792,6 +3920,7 @@ class MailboxService extends Base {
                       AND json_extract(n.data, '$.label') = 'MESSAGE'
                       AND json_extract(n.data, '$.properties.readAt') IS NULL
                       AND json_extract(n.data, '$.properties.archivedAt') IS NULL
+                      ${seenClause.replace('%SOURCE%', 'n')}
 
                     UNION
 
@@ -3803,6 +3932,7 @@ class MailboxService extends Base {
                       AND json_extract(n.data, '$.label') = 'MESSAGE'
                       AND json_extract(e.data, '$.properties.readAt') IS NULL
                       AND json_extract(e.data, '$.properties.archivedAt') IS NULL
+                      ${seenClause.replace('%SOURCE%', 'e')}
                 )
                 SELECT DISTINCT messageId
                 FROM unread_messages
@@ -3826,6 +3956,36 @@ class MailboxService extends Base {
                     ? 'read'
                     : 'partial';
 
+        // A narrower drain that says nothing reads exactly like "everything cleared" — the same
+        // failure this change exists to remove, one level up. Counted only on the default path;
+        // with `includeUnseen` nothing is withheld by construction.
+        const withheldUnseenCount = includeUnseen ? 0 : sqlite.prepare(`
+            WITH unseen_unread AS (
+                SELECT n.id AS messageId
+                FROM Edges e
+                JOIN Nodes n ON n.id = e.source
+                WHERE e.type = 'SENT_TO'
+                  AND e.target IN (${placeholders})
+                  AND json_extract(n.data, '$.label') = 'MESSAGE'
+                  AND json_extract(n.data, '$.properties.readAt') IS NULL
+                  AND json_extract(n.data, '$.properties.archivedAt') IS NULL
+                  AND json_extract(n.data, '$.properties.seenAt') IS NULL
+
+                UNION
+
+                SELECT n.id AS messageId
+                FROM Edges e
+                JOIN Nodes n ON n.id = e.source
+                WHERE e.type = 'DELIVERED_TO'
+                  AND e.target IN (${placeholders})
+                  AND json_extract(n.data, '$.label') = 'MESSAGE'
+                  AND json_extract(e.data, '$.properties.readAt') IS NULL
+                  AND json_extract(e.data, '$.properties.archivedAt') IS NULL
+                  AND json_extract(e.data, '$.properties.seenAt') IS NULL
+            )
+            SELECT COUNT(DISTINCT messageId) AS count FROM unseen_unread
+        `).get(...targetStorageVariants, ...targetStorageVariants)?.count ?? 0;
+
         return {
             status,
             snapshotAt,
@@ -3834,6 +3994,7 @@ class MailboxService extends Base {
             durableCount,
             failureCount   : failures.length,
             nonDurableCount: nonDurable.length,
+            withheldUnseenCount,
             failures,
             nonDurable
         };

--- a/ai/services/memory-core/MailboxService.mjs
+++ b/ai/services/memory-core/MailboxService.mjs
@@ -2160,20 +2160,33 @@ async function setMessageNodeReadAt(node, readAt) {
  * `seenAt` is the state between *arrived* and *explicitly marked read* — the distinction a bulk
  * drain needs, because without it `all: true` can only mean "every unread message that exists".
  *
- * Persisted through `persistReceiptNode`, the same path `readAt` and `archivedAt` already use. That
- * path replaces the whole record, so a concurrent receipt write can race — a real hazard, and a
- * PRE-EXISTING one shared by every receipt on this surface rather than introduced here. Giving
- * `seenAt` a stronger durability guarantee than `readAt` would be the wrong asymmetry to add; the
- * race is filed separately so it can be fixed for all three at once.
+ * Persisted through `persistReceiptNode`, the same path `readAt` and `archivedAt` already use.
+ *
+ * **The cache is rolled back when the write fails, and that is not symmetric with `readAt`.** The
+ * caller's write-once guard reads the cached `seenAt`, so a cache-first write that then fails to
+ * persist would mark the row seen for the rest of the process without ever storing it — and every
+ * later listing would skip it, because the guard sees the value its own failed attempt left behind.
+ * `readAt` tolerates the same shape only because it is user-driven and can simply be re-issued;
+ * `seenAt` is automatic and write-once, so a poisoned cache is permanent. Restoring the prior value
+ * is what makes the next listing retry.
  *
  * @param {Object} node Direct-DM `MESSAGE` node.
  * @param {String} seenAt ISO timestamp.
  * @returns {Promise<Boolean>}
  */
 async function setMessageNodeSeenAt(node, seenAt) {
-    getRecordProperties(node).seenAt = seenAt;
+    const
+        properties = getRecordProperties(node),
+        previous   = properties.seenAt ?? null;
 
-    return persistReceiptNode(node);
+    properties.seenAt = seenAt;
+
+    try {
+        return await persistReceiptNode(node)
+    } catch (error) {
+        properties.seenAt = previous;
+        throw error
+    }
 }
 
 /**
@@ -2183,17 +2196,30 @@ async function setMessageNodeSeenAt(node, seenAt) {
  * same carrier. On the node instead, one recipient's listing would mark the broadcast seen for the
  * entire audience.
  *
+ * Rolls the cache back on failure for the same reason as `setMessageNodeSeenAt` — the write-once
+ * guard reads the cached value, so a failed persist must not leave the row looking already-seen.
+ *
  * @param {Object} edge Per-recipient `DELIVERED_TO` edge.
  * @param {String} seenAt ISO timestamp.
  * @returns {Promise<Boolean>}
  */
 async function setDeliveryEdgeSeenAt(edge, seenAt) {
+    const previous = getRecordProperties(edge).seenAt ?? null;
+
     setRecordProperties(edge, {
         ...getRecordProperties(edge),
         seenAt
     });
 
-    return persistReceiptEdge(edge);
+    try {
+        return await persistReceiptEdge(edge)
+    } catch (error) {
+        setRecordProperties(edge, {
+            ...getRecordProperties(edge),
+            seenAt: previous
+        });
+        throw error
+    }
 }
 
 /**
@@ -3126,6 +3152,15 @@ class MailboxService extends Base {
      *   but is hidden from the default inbox view. Retracted messages (sender-side `deleteMessage`)
      *   are NOT filtered — they surface with the `'[retracted by sender]'` placeholder so thread
      *   context remains coherent.
+     * @param {Object} [callerOptions] Adapter-owned options, deliberately a SECOND argument so they
+     *   cannot arrive over the wire. The MCP request schema never declares them, and the Zod facade
+     *   strips undeclared keys — so folding them into `args` would read `undefined` in production
+     *   while every test passed.
+     * @param {Boolean} [callerOptions.recordSeen=false] Stamp `seenAt` on the rows this call
+     *   surfaces inbound to the caller. Only the model-visible MCP adapter passes it; a direct
+     *   service read is non-stamping BY OMISSION, which is what keeps the background heartbeat from
+     *   marking a roster's mail as shown. Caller identity cannot substitute for this — it proves
+     *   mailbox authority, not that anything was displayed to a model.
      * @returns {Promise<Object>} A PAGE, never a set. `messages` carries at most `limit` rows,
      *   newest-first, and the completeness of that page is established by `totalCount` (rows
      *   matching the filter before pagination), `truncated` (rows remain beyond this page) and
@@ -3395,12 +3430,6 @@ class MailboxService extends Base {
     }
 
     /**
-     * Retrieves a single message.
-     * @param {Object} args
-     * @param {String} args.messageId The ID of the message to retrieve
-     * @returns {Promise<Object>}
-     */
-    /**
      * @summary Records `seenAt` on rows this call surfaced INBOUND to the caller.
      *
      * Two guards, and they are independent:
@@ -3465,6 +3494,12 @@ class MailboxService extends Base {
         }
     }
 
+    /**
+     * Retrieves a single message.
+     * @param {Object} args
+     * @param {String} args.messageId The ID of the message to retrieve
+     * @returns {Promise<Object>}
+     */
     async getMessage({ messageId }) {
         const boundIdentity = RequestContextService.getAgentIdentityNodeId();
         if (!boundIdentity) {
@@ -3716,7 +3751,13 @@ class MailboxService extends Base {
      * advertised input schema.
      * @param {Object} args
      * @param {String|String[]} [args.messageId] The ID of the message to mark read, or an array of IDs
-     * @param {Boolean} [args.all=false] Mark the current unread, unarchived snapshot.
+     * @param {Boolean} [args.all=false] Mark the current unread, unarchived snapshot. By default
+     *   the snapshot covers only rows already SEEN by the caller — mail that was never surfaced to
+     *   a model is withheld and reported as `withheldUnseenCount` rather than swept.
+     * @param {Boolean} [args.includeUnseen=false] Widen the `all` snapshot back to every unread row
+     *   regardless of `seenAt`, reproducing the historical drain. The escape hatch for a caller who
+     *   genuinely wants the old semantics; validated with the same boolean strictness as `all`, and
+     *   BEFORE the `all` branch, so a fat-fingered value is reported rather than silently ignored.
      * @returns {Promise<Object>} Single form: `{messageId, readAt, status}` (plus
      *   `{durable: false, warning}` when storage is absent); array form: `{results: [...]}`;
      *   all form: compact aggregate counts plus exceptional rows.
@@ -3873,7 +3914,12 @@ class MailboxService extends Base {
      * intentionally compact: successful rows become counts; only failures and non-durable receipts
      * retain per-message detail.
      *
-     * @returns {Promise<Object>} Aggregate snapshot receipt with matched/read/durable/failure counts.
+     * @param {Object} [args]
+     * @param {Boolean} [args.includeUnseen=false] Widen the snapshot to every unread row regardless
+     *   of `seenAt`. The default narrows to seen rows only, so a bulk drain cannot clear directed
+     *   mail the caller was never shown.
+     * @returns {Promise<Object>} Aggregate snapshot receipt with matched/read/durable/failure counts,
+     *   plus `withheldUnseenCount` naming what the narrow default held back.
      * @private
      */
     async _markUnreadSnapshotRead({includeUnseen = false} = {}) {

--- a/ai/services/memory-core/MailboxService.mjs
+++ b/ai/services/memory-core/MailboxService.mjs
@@ -2175,18 +2175,54 @@ async function setMessageNodeReadAt(node, readAt) {
  * @returns {Promise<Boolean>}
  */
 async function setMessageNodeSeenAt(node, seenAt) {
-    const
-        properties = getRecordProperties(node),
-        previous   = properties.seenAt ?? null;
+    return setReceiptSeenAt(node, 'Nodes', seenAt)
+}
 
-    properties.seenAt = seenAt;
+/**
+ * @summary Writes `seenAt` through the storage-owned narrow path, then reflects cache only on success.
+ *
+ * Shared by both carriers so node and `DELIVERED_TO` receipts cannot drift apart. Three properties,
+ * and each one exists because the obvious implementation loses it:
+ *
+ * 1. **Narrow.** `setRecordPropertyIfAbsent` rewrites one JSON path instead of replacing the record,
+ *    so a field another process committed between our read and our write survives. The whole-record
+ *    path is still correct for `readAt`/`archivedAt` today; they are expected to migrate onto this
+ *    same primitive, which is what ends the asymmetry rather than entrenching it.
+ * 2. **Write-once in SQL.** The `IS NULL` predicate is part of the statement, so two concurrent
+ *    listings cannot both win. A caller-side read-then-check races the window it is closing.
+ * 3. **Cache last.** The caller's fast-path guard reads the cached value, so reflecting a write that
+ *    did not land would mark the row seen for the life of the process and no later listing would
+ *    retry. Only a confirmed write updates cache.
+ *
+ * When the narrow write reports `false` the row already carries a `seenAt` we did not author, and
+ * cache is deliberately left alone: the next listing re-attempts one cheap idempotent `UPDATE` that
+ * matches nothing. Cheaper than reading the row back, and it cannot invent a timestamp.
+ *
+ * @param {Object} record `MESSAGE` node or `DELIVERED_TO` edge.
+ * @param {String} table `'Nodes'` or `'Edges'`.
+ * @param {String} seenAt ISO timestamp.
+ * @returns {Promise<Boolean>} Whether THIS call performed the durable write.
+ * @private
+ */
+async function setReceiptSeenAt(record, table, seenAt) {
+    const db = GraphService.db;
 
-    try {
-        return await persistReceiptNode(node)
-    } catch (error) {
-        properties.seenAt = previous;
-        throw error
+    if (!db?.storage) {
+        // No durable surface to protect; cache-only mode keeps the in-memory contract intact.
+        getRecordProperties(record).seenAt = seenAt;
+        return false
     }
+
+    const wrote = db.storage.setRecordPropertyIfAbsent(
+        table, getRecordField(record, 'id'), 'seenAt', seenAt
+    );
+
+    if (wrote) {
+        getRecordProperties(record).seenAt = seenAt;
+        db.acknowledgeLocalMutations?.()
+    }
+
+    return wrote
 }
 
 /**
@@ -2204,22 +2240,7 @@ async function setMessageNodeSeenAt(node, seenAt) {
  * @returns {Promise<Boolean>}
  */
 async function setDeliveryEdgeSeenAt(edge, seenAt) {
-    const previous = getRecordProperties(edge).seenAt ?? null;
-
-    setRecordProperties(edge, {
-        ...getRecordProperties(edge),
-        seenAt
-    });
-
-    try {
-        return await persistReceiptEdge(edge)
-    } catch (error) {
-        setRecordProperties(edge, {
-            ...getRecordProperties(edge),
-            seenAt: previous
-        });
-        throw error
-    }
+    return setReceiptSeenAt(edge, 'Edges', seenAt)
 }
 
 /**

--- a/test/playwright/unit/ai/services/memory-core/MailboxService.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/MailboxService.spec.mjs
@@ -2088,6 +2088,18 @@ test.describe('Neo.ai.services.memory-core.MailboxService', () => {
             MailboxService.archiveMessage({messageId: archivedId})
         );
 
+        // The drain now sweeps only mail the agent was SHOWN, so this listing is the precondition
+        // the flow always had in practice. Routed through `callTool` deliberately: that is the
+        // model-visible boundary where seen is recorded, and a direct service read would correctly
+        // stamp nothing. This test's subject — bob's delivery edge marked, charlie's untouched — is
+        // orthogonal to seen-state, so it keeps every assertion on the DEFAULT drain path rather
+        // than moving to `includeUnseen`.
+        const {callTool: listTool} = await import('../../../../../../ai/mcp/server/memory-core/toolService.mjs');
+
+        await RequestContextService.run({agentIdentityNodeId: '@bob'}, () =>
+            listTool('list_messages', {box: 'inbox', status: 'unread'})
+        );
+
         const receipt = await RequestContextService.run({agentIdentityNodeId: '@bob'}, () =>
             MailboxService.markRead({all: true})
         );
@@ -2147,13 +2159,22 @@ test.describe('Neo.ai.services.memory-core.MailboxService', () => {
         }
     });
 
-    test('#15913 markRead all mode drains beyond the list_messages 100-row page size', async () => {
+    /**
+     * The uncapped-depth guarantee was relocated, not removed. These 125 carriers are seeded straight
+     * into the graph and never surfaced through the model-visible boundary, so under the default
+     * drain they are unseen and correctly withheld. "Everything, listed or not" is now precisely what
+     * the explicit widening flag means, so that is where the property lives.
+     *
+     * The default path keeps its own depth coverage: the backlog arm lists 120 messages through
+     * `list_messages` and clears all of them in one call. Asserted twice, once per meaning.
+     */
+    test('#15913 markRead all+includeUnseen drains beyond the list_messages 100-row page size', async () => {
         for (let index = 0; index < 125; index++) {
             seedReadStateCarrier({messageId: `MESSAGE:read-all-depth-${index}`});
         }
 
         const receipt = await RequestContextService.run({agentIdentityNodeId: '@bob'}, () =>
-            MailboxService.markRead({all: true})
+            MailboxService.markRead({all: true, includeUnseen: true})
         );
 
         expect(receipt).toMatchObject({
@@ -2182,6 +2203,18 @@ test.describe('Neo.ai.services.memory-core.MailboxService', () => {
                 ids.push(messageId);
             }
         });
+
+        // The three seeded messages must be SHOWN before a default drain will sweep them, and the
+        // model-visible boundary is where that is recorded. This test's subject — post-snapshot
+        // arrivals excluded, exceptional rows reported — is orthogonal to seen-state, so the listing
+        // is a precondition rather than a change of subject. It also strengthens the arm: the late
+        // arrival is now excluded for two independent reasons, and the assertions still isolate the
+        // snapshot one.
+        const {callTool: seedListTool} = await import('../../../../../../ai/mcp/server/memory-core/toolService.mjs');
+
+        await RequestContextService.run({agentIdentityNodeId: '@bob'}, () =>
+            seedListTool('list_messages', {box: 'inbox', status: 'unread'})
+        );
 
         const originalMarkRead = MailboxService.markRead;
         let lateMessageId;
@@ -2239,6 +2272,109 @@ test.describe('Neo.ai.services.memory-core.MailboxService', () => {
         expect(unread.messages.map(message => message.messageId)).toEqual(
             expect.arrayContaining([ids[1], ids[2], lateMessageId])
         );
+    });
+
+    /**
+     * `seenAt` is the state between *arrived* and *explicitly marked read*, and it is what lets a
+     * bulk drain be discriminating. The authority question is where it may be recorded.
+     *
+     * **A previous attempt keyed it on caller identity — "the mailbox owner is reading" — and that
+     * is falsified by the production caller.** `SwarmHeartbeatService.getRecentActivityTimestamps`
+     * binds the polled agent as the request identity and then reads that agent's own inbox, so an
+     * owner-identity test admits the daemon rather than excluding it, and the background sweep would
+     * mark up to 100 rows per identity as seen for the whole roster on every pass. The verifying test
+     * for that attempt bound a DIFFERENT identity and read under a permission grant, so it never
+     * traversed the branch it claimed to protect.
+     *
+     * Caller identity proves mailbox AUTHORITY, not DISPLAY authority. Seen is therefore armed at the
+     * model-visible MCP adapter boundary: direct service calls are non-stamping by construction, so
+     * the heartbeat is safe because it never crosses that boundary — not because a predicate happens
+     * to exclude it.
+     */
+    const seedFor = async (subjects, {sender = '@alice', recipient = '@bob'} = {}) => {
+        await RequestContextService.run({agentIdentityNodeId: recipient}, () =>
+            PermissionService.grantPermission({to: sender, scope: 'CAN_REPLY_TO'}));
+
+        return RequestContextService.run({agentIdentityNodeId: sender}, async () => {
+            const ids = [];
+
+            for (const subject of subjects) {
+                const {messageId} = await MailboxService.addMessage({to: recipient, subject, body: subject});
+                ids.push(messageId)
+            }
+
+            return ids
+        })
+    };
+
+    const seenAtOf = messageId => GraphService.db.nodes.get(messageId)?.properties?.seenAt ?? null;
+
+    test('#17321 the production heartbeat shape stamps NOTHING — owner-bound, own inbox, direct service call', async () => {
+        const [directed] = await seedFor(['heartbeat must not see this']);
+
+        // EXACTLY SwarmHeartbeatService.getRecentActivityTimestamps: bind the polled agent as the
+        // request identity, then read that same agent's inbox. An owner-identity guard reads this as
+        // "the owner is looking at their own mail" and stamps. It is a background poll.
+        await RequestContextService.run({agentIdentityNodeId: '@bob'}, () =>
+            MailboxService.listMessages({box: 'inbox', to: '@bob', limit: 100, includeArchived: false}));
+
+        expect(seenAtOf(directed), 'a direct service read is non-stamping by construction').toBeNull();
+
+        // And the consequence that matters: the drain must still withhold it.
+        await RequestContextService.run({agentIdentityNodeId: '@bob'}, () =>
+            MailboxService.markRead({all: true}));
+
+        expect(GraphService.db.nodes.get(directed).properties.readAt,
+            'mail the agent was never shown survives the drain').toBeNull()
+    });
+
+    test('#17321 the MCP adapter path DOES stamp — the paired control', async () => {
+        // Without this, "stamp nothing anywhere" passes the arm above and the feature does nothing.
+        const {callTool} = await import('../../../../../../ai/mcp/server/memory-core/toolService.mjs');
+        const [directed] = await seedFor(['the agent actually saw this']);
+
+        await RequestContextService.run({agentIdentityNodeId: '@bob'}, () =>
+            callTool('list_messages', {box: 'inbox', status: 'unread'}));
+
+        expect(seenAtOf(directed), 'crossing the model-visible boundary is what records seen').toBeTruthy();
+
+        await RequestContextService.run({agentIdentityNodeId: '@bob'}, () =>
+            MailboxService.markRead({all: true}));
+
+        expect(GraphService.db.nodes.get(directed).properties.readAt,
+            'and a seen message IS swept').toBeTruthy()
+    });
+
+    test('#17321 listing a 120-message backlog still clears it in ONE call — the motivating case', async () => {
+        // The flow any fix must not break: back after a day, cleared in one swipe with no paging.
+        // Clearing already begins by listing, so every one of them is genuinely shown.
+        const {callTool: backlogTool} = await import('../../../../../../ai/mcp/server/memory-core/toolService.mjs');
+
+        await seedFor(Array.from({length: 120}, (unused, index) => `aged ${index}`));
+
+        await RequestContextService.run({agentIdentityNodeId: '@bob'}, () =>
+            backlogTool('list_messages', {box: 'inbox', status: 'unread', limit: 200}));
+
+        const receipt = await RequestContextService.run({agentIdentityNodeId: '@bob'}, () =>
+            MailboxService.markRead({all: true}));
+
+        expect(receipt.readCount, 'all 120 clear in a single call').toBe(120);
+        expect(receipt.withheldUnseenCount, 'and nothing was withheld').toBe(0)
+    });
+
+    test('#17321 the receipt reports what it withheld, so a narrower drain is never silent', async () => {
+        const {callTool: withheldTool} = await import('../../../../../../ai/mcp/server/memory-core/toolService.mjs');
+
+        await seedFor(['shown']);
+        await RequestContextService.run({agentIdentityNodeId: '@bob'}, () =>
+            withheldTool('list_messages', {box: 'inbox', status: 'unread'}));
+        await seedFor(['never shown one', 'never shown two']);
+
+        const receipt = await RequestContextService.run({agentIdentityNodeId: '@bob'}, () =>
+            MailboxService.markRead({all: true}));
+
+        expect(receipt.readCount, 'the shown message cleared').toBe(1);
+        expect(receipt.withheldUnseenCount, 'the two unshown are counted, not hidden').toBe(2)
     });
 
     test('#15913 markRead all mode returns an explicit compact no-op and rejects ambiguous input', async () => {

--- a/test/playwright/unit/ai/services/memory-core/MailboxService.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/MailboxService.spec.mjs
@@ -2377,6 +2377,77 @@ test.describe('Neo.ai.services.memory-core.MailboxService', () => {
         expect(receipt.withheldUnseenCount, 'the two unshown are counted, not hidden').toBe(2)
     });
 
+    /** Storage-side truth, so a cache-only assertion cannot stand in for durability. */
+    const storedSeenAtOf = messageId => {
+        const row = GraphService.db.storage.db
+            .prepare('SELECT data FROM Nodes WHERE id = ?').get(messageId);
+
+        return row ? (JSON.parse(row.data).properties?.seenAt ?? null) : null
+    };
+
+    test('#17321 a FAILED seen write leaves cache and storage coherent, and the next listing RETRIES', async () => {
+        // The defect this arm exists for is one the boundary correction introduced, not a
+        // pre-existing one: the write-once guard reads the CACHED `seenAt`, so a cache-first write
+        // that then fails to persist marks the row seen for the life of the process while storage
+        // still says null — and every later listing skips it, because the guard sees the value its
+        // own failed attempt left behind. Rolling the cache back is what makes the retry possible.
+        const
+            {callTool}  = await import('../../../../../../ai/mcp/server/memory-core/toolService.mjs'),
+            [directed]  = await seedFor(['the persist fails the first time']),
+            storage     = GraphService.db.storage,
+            originalAdd = storage.addNodes.bind(storage);
+
+        let failNext = true;
+
+        storage.addNodes = async nodes => {
+            if (failNext) {
+                failNext = false;
+                throw new Error('simulated storage failure');
+            }
+
+            return originalAdd(nodes)
+        };
+
+        try {
+            await RequestContextService.run({agentIdentityNodeId: '@bob'}, () =>
+                callTool('list_messages', {box: 'inbox', status: 'unread'}));
+
+            // Coherent, not merely unset: cache must not claim a durability storage does not have.
+            expect(seenAtOf(directed), 'the cache is rolled back when the persist throws').toBeNull();
+            expect(storedSeenAtOf(directed), 'and storage never got it either').toBeNull();
+
+            // The retry — the half that a rollback-free implementation fails.
+            await RequestContextService.run({agentIdentityNodeId: '@bob'}, () =>
+                callTool('list_messages', {box: 'inbox', status: 'unread'}));
+
+            expect(seenAtOf(directed), 'the next listing retries the write').toBeTruthy();
+            expect(storedSeenAtOf(directed), 'and this time it is durable').toBeTruthy()
+        } finally {
+            storage.addNodes = originalAdd
+        }
+    });
+
+    test('#17321 first-seen is write-once — a second listing does not restamp', async () => {
+        // Without this, the rollback above could be "correct" by simply rewriting `seenAt` on every
+        // listing, which would make the timestamp mean "last listed" instead of "first shown".
+        const
+            {callTool} = await import('../../../../../../ai/mcp/server/memory-core/toolService.mjs'),
+            [directed] = await seedFor(['stamped exactly once']);
+
+        await RequestContextService.run({agentIdentityNodeId: '@bob'}, () =>
+            callTool('list_messages', {box: 'inbox', status: 'unread'}));
+
+        const firstSeenAt = seenAtOf(directed);
+
+        expect(firstSeenAt).toBeTruthy();
+
+        await RequestContextService.run({agentIdentityNodeId: '@bob'}, () =>
+            callTool('list_messages', {box: 'inbox', status: 'unread'}));
+
+        expect(seenAtOf(directed), 'seenAt means FIRST shown, not last listed').toBe(firstSeenAt);
+        expect(storedSeenAtOf(directed), 'and storage agrees').toBe(firstSeenAt)
+    });
+
     test('#15913 markRead all mode returns an explicit compact no-op and rejects ambiguous input', async () => {
         const {callTool} = await import('../../../../../../ai/mcp/server/memory-core/toolService.mjs');
         const receipt    = await RequestContextService.run({agentIdentityNodeId: '@bob'}, () =>

--- a/test/playwright/unit/ai/services/memory-core/MailboxService.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/MailboxService.spec.mjs
@@ -2387,10 +2387,11 @@ test.describe('Neo.ai.services.memory-core.MailboxService', () => {
 
     test('#17321 a FAILED seen write leaves cache and storage coherent, and the next listing RETRIES', async () => {
         // The defect this arm exists for is one the boundary correction introduced, not a
-        // pre-existing one: the write-once guard reads the CACHED `seenAt`, so a cache-first write
+        // pre-existing one: the write-once guard reads the CACHED `seenAt`, so a cache-FIRST write
         // that then fails to persist marks the row seen for the life of the process while storage
         // still says null — and every later listing skips it, because the guard sees the value its
-        // own failed attempt left behind. Rolling the cache back is what makes the retry possible.
+        // own failed attempt left behind. Writing cache only AFTER a confirmed durable write is what
+        // keeps the retry possible: there is no state to undo, because none was published.
         const
             {callTool}  = await import('../../../../../../ai/mcp/server/memory-core/toolService.mjs'),
             [directed]  = await seedFor(['the persist fails the first time']),
@@ -2414,10 +2415,10 @@ test.describe('Neo.ai.services.memory-core.MailboxService', () => {
                 callTool('list_messages', {box: 'inbox', status: 'unread'}));
 
             // Coherent, not merely unset: cache must not claim a durability storage does not have.
-            expect(seenAtOf(directed), 'the cache is rolled back when the persist throws').toBeNull();
+            expect(seenAtOf(directed), 'cache is not published when the write fails').toBeNull();
             expect(storedSeenAtOf(directed), 'and storage never got it either').toBeNull();
 
-            // The retry — the half that a rollback-free implementation fails.
+            // The retry — the half a cache-first implementation fails.
             await RequestContextService.run({agentIdentityNodeId: '@bob'}, () =>
                 callTool('list_messages', {box: 'inbox', status: 'unread'}));
 
@@ -2520,8 +2521,8 @@ test.describe('Neo.ai.services.memory-core.MailboxService', () => {
     });
 
     test('#17321 first-seen is write-once — a second listing does not restamp', async () => {
-        // Without this, the rollback above could be "correct" by simply rewriting `seenAt` on every
-        // listing, which would make the timestamp mean "last listed" instead of "first shown".
+        // Without this, the cache-last ordering above could be "correct" by simply rewriting `seenAt`
+        // on every listing, which would make the timestamp mean "last listed" instead of "first shown".
         const
             {callTool} = await import('../../../../../../ai/mcp/server/memory-core/toolService.mjs'),
             [directed] = await seedFor(['stamped exactly once']);

--- a/test/playwright/unit/ai/services/memory-core/MailboxService.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/MailboxService.spec.mjs
@@ -2395,17 +2395,18 @@ test.describe('Neo.ai.services.memory-core.MailboxService', () => {
             {callTool}  = await import('../../../../../../ai/mcp/server/memory-core/toolService.mjs'),
             [directed]  = await seedFor(['the persist fails the first time']),
             storage     = GraphService.db.storage,
-            originalAdd = storage.addNodes.bind(storage);
+            originalSet = storage.setRecordPropertyIfAbsent.bind(storage);
 
         let failNext = true;
 
-        storage.addNodes = async nodes => {
+        // The seam is the NARROW writer, not `addNodes` — the seen path no longer replaces the record.
+        storage.setRecordPropertyIfAbsent = (...args) => {
             if (failNext) {
                 failNext = false;
                 throw new Error('simulated storage failure');
             }
 
-            return originalAdd(nodes)
+            return originalSet(...args)
         };
 
         try {
@@ -2423,7 +2424,98 @@ test.describe('Neo.ai.services.memory-core.MailboxService', () => {
             expect(seenAtOf(directed), 'the next listing retries the write').toBeTruthy();
             expect(storedSeenAtOf(directed), 'and this time it is durable').toBeTruthy()
         } finally {
-            storage.addNodes = originalAdd
+            storage.setRecordPropertyIfAbsent = originalSet
+        }
+    });
+
+    test('#17321 an interposed storage field SURVIVES the seen write — node carrier', async () => {
+        // The whole-record hazard. The interposition MUST happen inside the write seam, not before
+        // the listing: an earlier version of this arm interposed up front and passed even against a
+        // document-replacing write, because the listing refreshes cache from storage and the field
+        // was simply back in the record before the write ran. Vacuous, and it looked correct.
+        //
+        // Interposing at the seam pins the one ordering that matters — committed AFTER this process
+        // last read the row, BEFORE it writes — which is exactly the cross-process race.
+        const
+            {callTool}  = await import('../../../../../../ai/mcp/server/memory-core/toolService.mjs'),
+            [directed]  = await seedFor(['an interposed field must survive']),
+            storage     = GraphService.db.storage,
+            sqlite      = storage.db,
+            originalSet = storage.setRecordPropertyIfAbsent.bind(storage);
+
+        let interposed = false;
+
+        storage.setRecordPropertyIfAbsent = (...args) => {
+            if (!interposed) {
+                interposed = true;
+                sqlite.prepare(
+                    `UPDATE Nodes SET data = json_set(data, '$.properties.concurrentProbe', 'interposed') WHERE id = ?`
+                ).run(directed)
+            }
+
+            return originalSet(...args)
+        };
+
+        try {
+            await RequestContextService.run({agentIdentityNodeId: '@bob'}, () =>
+                callTool('list_messages', {box: 'inbox', status: 'unread'}));
+        } finally {
+            storage.setRecordPropertyIfAbsent = originalSet
+        }
+
+        const stored = JSON.parse(
+            sqlite.prepare('SELECT data FROM Nodes WHERE id = ?').get(directed).data
+        ).properties;
+
+        expect(interposed, 'precondition: the seam must actually have been reached').toBe(true);
+        expect(stored.seenAt, 'the seen write landed').toBeTruthy();
+        expect(stored.concurrentProbe, 'and it did not erase the interposed field').toBe('interposed')
+    });
+
+    test('#17321 the DELIVERED_TO carrier has the same failure/retry diagonal as the node', async () => {
+        // Broadcasts carry seen state on the per-recipient edge, so the edge needs its own proof —
+        // a node-only arm would leave the broadcast path free to regress independently.
+        const
+            {callTool}  = await import('../../../../../../ai/mcp/server/memory-core/toolService.mjs'),
+            storage     = GraphService.db.storage,
+            originalSet = storage.setRecordPropertyIfAbsent.bind(storage);
+
+        await RequestContextService.run({agentIdentityNodeId: '@alice'}, () =>
+            MailboxService.addMessage({
+                to: 'AGENT:*', subject: 'broadcast seen state', body: 'edge carrier'
+            }));
+
+        const edgeSeenAt = () => {
+            const row = storage.db.prepare(
+                `SELECT data FROM Edges WHERE type = 'DELIVERED_TO' AND target = ? LIMIT 1`
+            ).get('@bob');
+
+            return row ? (JSON.parse(row.data).properties?.seenAt ?? null) : null
+        };
+
+        let failNext = true;
+
+        storage.setRecordPropertyIfAbsent = (...args) => {
+            if (failNext) {
+                failNext = false;
+                throw new Error('simulated edge storage failure');
+            }
+
+            return originalSet(...args)
+        };
+
+        try {
+            await RequestContextService.run({agentIdentityNodeId: '@bob'}, () =>
+                callTool('list_messages', {box: 'inbox', status: 'unread'}));
+
+            expect(edgeSeenAt(), 'the failed edge write left storage clean').toBeNull();
+
+            await RequestContextService.run({agentIdentityNodeId: '@bob'}, () =>
+                callTool('list_messages', {box: 'inbox', status: 'unread'}));
+
+            expect(edgeSeenAt(), 'and the next listing retries it on the edge too').toBeTruthy()
+        } finally {
+            storage.setRecordPropertyIfAbsent = originalSet
         }
     });
 


### PR DESCRIPTION
Resolves #17321

Related: #16748 · Residual owner: #17486

🌿 *Caller identity proves mailbox authority. It does not prove that anything was shown to a model.*

Evidence: L2 (unit, real graph projection, production adapter path, storage-level interposition) → L2 required (no deployed surface ships). Residual: #17486 — migrating `readAt` and `archivedAt` onto the narrow primitive this PR introduces. The `seenAt` writer itself is no longer residual; it is fixed here.

Successor to the Drop+Supersede on PR #17471 — [review 4994298359](https://github.com/neomjs/neo/pull/17471#pullrequestreview-4994298359) by @neo-gpt-emmy, which is the salvage-map authority and whose falsifiers I verified at source before accepting.

## What the superseded head got wrong

It stamped `seenAt` when the **mailbox owner** read their own inbox. `SwarmHeartbeatService.getRecentActivityTimestamps` falsifies that:

```js
RequestContextService.run({agentIdentityNodeId: identity}, () =>
    MailboxService.listMessages({box: 'inbox', to: identity, limit: 100, …}))
```

It binds the polled agent as the request identity **and** targets that agent — so an owner-identity guard **admits** the background sweep instead of excluding it. 100 rows per identity, whole roster, every pass, after which each agent's next `all: true` sweeps mail they were never shown. Strictly worse than the defect.

Its verifying test bound a *different* identity under a permission grant, so `target !== me` and the early return fired for the wrong reason — green without ever reaching the branch it claimed to protect.

## The corrected boundary

`seenAt` is armed at the **model-visible MCP adapter**, not on identity:

- `MailboxService.listMessages(args, {recordSeen = false})` — a direct service read is non-stamping **by omission**.
- Only `listMessagesTool` passes it. The heartbeat and `defectObservations` are safe **by construction**, because they never cross that boundary — not because a predicate happens to exclude them.

**Per-ROW inbound ownership** replaces the per-call `box` test: `box: 'all'` returns outbox rows in the same array (`:3080`, `:3108`), so testing the call would stamp an Alice→Bob DM on Bob's node from Alice's own listing.

## Deltas from ticket

- **The ticket's step-1 prescription is superseded** — #17321's body is amended in place with the falsifiers, the salvage/discard split, and the adapter boundary. Steps 2–3 (drain bound, `includeUnseen`) stand as written.
- **Seen persistence is narrower than the ticket described.** #17321 assumed `seenAt` would follow `readAt` onto the whole-record `persistReceiptNode` path. It does not: it uses a new narrow `setRecordPropertyIfAbsent` primitive. That divergence is the subject of RA-1 below.
- **`readAt` and `archivedAt` are deliberately NOT migrated here** — they keep the whole-record path, and the residual is owned by #17486.

## Review round 2 — what changed and what I got wrong

@neo-gpt-emmy's [review 4995131088](https://github.com/neomjs/neo/pull/17482#pullrequestreview-4995131088) raised three actions. All three verified at source and accepted; **RA-1 found a real defect that was mine, not pre-existing**, and my deferral argument did not cover it.

**RA-1 — the seen write is now narrow, conditional and retryable.** Round 2 held this open after a partial fix, correctly. Two separate defects were hiding under one name and only one of them was mine:

*The non-retry, which was mine.* The write-once guard reads the *cached* `seenAt`, so a cache-first write that then failed to persist marked the row seen for the life of the process while storage said null — and every later listing skipped it, because the guard saw the value its own failed attempt had left behind. My earlier answer, "the whole-record race is pre-existing across all three receipts", is true and **does not answer this**: `readAt` tolerates the same cache-first shape only because it is user-driven and re-issuable, while `seenAt` is automatic and write-once, so a poisoned cache is permanent. That asymmetry runs against me, not for me.

*The whole-record clobber, which pre-exists.* Now also fixed here rather than deferred, because the reviewer's point stands: a follow-up filing does not remove risk this PR incrementally adds. `Storage.setRecordPropertyIfAbsent` does a `json_set` on one JSON path guarded by `json_extract(...) IS NULL`, so the write cannot carry a stale copy of its neighbours and write-once is a property of the statement rather than a caller-side read-then-check that races the window it is closing. Cache is reflected only after a confirmed durable write.

**RA-2 — the operation-level contract still taught the superseded semantics.** `mark_read`'s `x-neo-tool-summary` and description promised the historical "entire current unread inbox snapshot" while the property-level text taught the new seen-only default, so tool enumeration and parameter docs disagreed. Both now state the narrowed default and name `includeUnseen`. The uncited "filed separately / No residual" is replaced by #17486.

**RA-3 — Contextual Completeness.** `getMessage`'s docblock had been orphaned above `_recordSeenForSurfacedRows` by the insertion; moved back. `recordSeen`, and `includeUnseen` on both `markRead` and `_markUnreadSnapshotRead`, had no `@param` at all.

**RA-3, round 3 — the narrow-write fix staled its own documentation.** Both seen wrappers still described persistence "through `persistReceiptNode`" and a cache rolled back on failure. Neither survives the new mechanism, and the rollback sentence is the worse of the two: it sends a reader looking for undo code that was never written, when the design publishes cache only after a confirmed write and so has no state to undo. Both wrappers now carry only what is carrier-specific and point at `setReceiptSeenAt`, which owns the mechanism narrative alone.

Sweeping the same class turned up four more in the spec beyond the two the reviewer named — and those matter more per byte, because a stale assertion message is what a future reader meets first on a failure. `'the cache is rolled back when the persist throws'` described undo that does not happen, and `'the half a rollback-free implementation fails'` had inverted outright: the shipped implementation IS rollback-free.

**What is still out, and why that is now a smaller claim:** `readAt` and `archivedAt` keep the whole-record path, owned by #17486. I argued in round 1 that fixing `seenAt` alone would create the wrong asymmetry, and I still think the end state is one mechanism for all three — but the reviewer is right that this PR does not get to defer a risk it incrementally adds. So `seenAt` is fixed here and the primitive is shaped for the other two to migrate onto, which turns the asymmetry into a migration step rather than an inconsistency.

One distinction worth keeping on the record, since it shaped the design: the two carriers were never equally exposed. The edge writers rebuilt state from a possibly-stale index-Set member — an in-process hazard, and the one #17483 fixes with `getDeliveryEdgePropertiesForWrite`. The node writers mutate the canonical `db.nodes.get()` record and were exposed only to the genuine cross-process race. Verified by reading both writers, not inferred from the shape.

## Test Evidence

`test/playwright/unit/ai/services/memory-core/MailboxService.spec.mjs` — **167 passed**. Broader `memory-core` + `graph` — **2023 passed**.

**The paired arms that decide this design:**

| arm | asserts |
|---|---|
| production heartbeat shape — owner-bound, own inbox, **direct service call** | stamps nothing, and the drain still withholds |
| MCP adapter path — `callTool('list_messages')` | stamps, and the drain sweeps |

**Mutation diagonal:** restoring the owner-identity guard (`recordSeen \|\| (box !== 'outbox' && sameMailboxIdentity(target, me))`) **reddens the heartbeat arm**. That is the arm the superseded head had no coverage for, and it is what makes this a premise fix rather than a relabel.

**The four RA-1 controls, all mutation-checked:**

| arm | asserts |
|---|---|
| a failed persist, node | cache and storage **coherent** — cache never claims a durability storage lacks — and the **next listing retries** |
| a failed persist, `DELIVERED_TO` | the same diagonal on the edge, so the broadcast carrier cannot regress independently |
| an interposed storage field | a field committed **inside the write seam** survives the seen write |
| a second listing | `seenAt` still means FIRST shown, not last listed |

Reverting the cache ordering reddens the retry arm at `Received: "2026-08-21T16:09:27.831Z"` — the cache claiming a durability storage never had. Reverting to a document-replacing write reddens the interposition arm at `Expected: "interposed" / Received: undefined`.

**The interposition arm is worth reading, because my first version of it was vacuous and looked correct.** It interposed the concurrent field *before* the listing, and passed even against a whole-record write — the listing refreshes cache from storage, so the field was simply back in the record before the write ran. I only caught it by running the mutation. Interposing inside the write seam pins the one ordering that matters: committed after this process last read the row, before it writes. The arm now carries an explicit `expect(interposed).toBe(true)` precondition so it cannot silently stop reaching the seam.

The write-once arm exists because the durability fix could otherwise be "satisfied" by restamping on every listing, which would silently redefine the field from *first shown* to *last listed*.

Plus the salvaged controls: the 120-message backlog still clears in one call, `withheldUnseenCount` reports what the default drain held back, and `includeUnseen` reproduces the historical set.

**Two guard catches worth recording, because unit tests could not have found either:**

1. The parity lint caught `recordSeen` folded into `args` — the Zod facade strips undeclared keys, so it would have read `undefined` in production while every test passed. **The feature would have shipped silently inert.** Fixed by the second-argument pattern `addMessageTool` already uses.
2. The same lint caught `includeUnseen` missing from the `mark_read` schema — the escape hatch would have been inert the same way.

Two existing `#15913` arms were updated, not bent: the carrier-ownership arm gains a `callTool` listing (its subject is orthogonal, and it stays on the **default** drain path), and the beyond-the-100-row arm moves to `includeUnseen` (its subject *was* the removed behaviour). The default path keeps its own depth coverage via the 120-message arm.

## Merge order

Done. #17483 merged as `b99334f82d`; this branch is rebased onto that head and CI reran. The rebase was clean and both changes coexist — verified rather than assumed: `getDeliveryEdgePropertiesForWrite`, `assertIndices`, my second-argument signature and the seen path are all present on the rebased head.

## Post-Merge Validation

None gating. Existing mailboxes carry no `seenAt` until their next listing, which is the fail-safe direction: unshown mail is withheld from a bulk drain rather than swept.

Authored by Grace (Claude Opus 5, Claude Code). Session 752da6ac-a6c3-447f-8847-1da4ce49deb8.
