### PR TITLE
feat(ai): make graph index availability explicit (#16965)

### DIFF
--- a/ai/graph/Store.mjs
+++ b/ai/graph/Store.mjs
@@ -1,4 +1,4 @@
-import DataStore from '../../src/data/Store.mjs';
+import DataStore                 from '../../src/data/Store.mjs';
 import DestructiveOperationGuard from '../mcp/server/shared/services/DestructiveOperationGuard.mjs';
 
 /**
@@ -104,26 +104,37 @@ class Store extends DataStore {
     }
 
     /**
+     * @summary Asserts that every named secondary index is configured and initialized.
+     * @param {String[]} properties
+     * @throws {Error} When one or more required secondary indexes are unavailable.
+     */
+    assertIndices(properties) {
+        let me      = this,
+            missing = properties.filter(property => !me.indexMaps?.has(property));
+
+        if (missing.length > 0) {
+            throw new Error(`${me.className}: secondary index unavailable: ${missing.join(', ')}`)
+        }
+    }
+
+    /**
      * Extracts exact matching items synchronously from the GraphStore topography in O(1) mapping operations.
-     * Assumes `property` exists dynamically within `indices_`.
+     * A configured index with no matching value returns an empty array. An unavailable index fails
+     * explicitly so consumers cannot mistake a broken lookup precondition for an honest absence.
      * @param {String} property
      * @param {*} value
      * @returns {Object[]}
+     * @throws {Error} When the requested secondary index is unavailable.
      */
     getByIndex(property, value) {
-        let me = this;
+        let me = this,
+            matchSet;
 
-        if (me.indexMaps) {
-            let propertyMap = me.indexMaps.get(property);
-            if (propertyMap) {
-                let matchSet = propertyMap.get(value);
-                if (matchSet) {
-                    return Array.from(matchSet);
-                }
-            }
-        }
+        me.assertIndices([property]);
 
-        return [];
+        matchSet = me.indexMaps.get(property).get(value);
+
+        return matchSet ? Array.from(matchSet) : []
     }
 
     /**
@@ -140,8 +151,8 @@ class Store extends DataStore {
                 DestructiveOperationGuard.assertDestructiveTargetAllowedSync({
                     operation: 'clear',
                     subsystem: 'Neo.ai.graph.Store',
-                    mode: 'clear',
-                    target: { path }
+                    mode     : 'clear',
+                    target   : { path }
                 });
             } catch (e) {
                 throw new Error(`FATAL: Attempted to clear() a Store bound to a non-temporary SQLite database natively! Path: ${path}`);
@@ -174,14 +185,14 @@ class Store extends DataStore {
      * @protected
      */
     updateIndexMaps(addedItems, removedItems) {
-        let me       = this,
-            indices  = me.indices,
-            i        = 0,
+        let me      = this,
+            indices = me.indices,
+            i       = 0,
             len, item, isRecord, val, propertyMap, itemSet;
 
         if (removedItems && (len = removedItems.length) > 0) {
             indices.forEach(indexConfig => {
-                let prop    = indexConfig.property;
+                let prop = indexConfig.property;
                 propertyMap = me.indexMaps.get(prop);
 
                 for (i = 0; i < len; i++) {
@@ -204,7 +215,7 @@ class Store extends DataStore {
 
         if (addedItems && (len = addedItems.length) > 0) {
             indices.forEach(indexConfig => {
-                let prop    = indexConfig.property;
+                let prop = indexConfig.property;
                 propertyMap = me.indexMaps.get(prop);
 
                 for (i = 0; i < len; i++) {

--- a/ai/services/memory-core/MailboxService.mjs
+++ b/ai/services/memory-core/MailboxService.mjs
@@ -876,10 +876,13 @@ function appendTaskStateChangeEvent(storage, snapshot) {
  * Returns `{}` for a missing edge, so a genuinely-recreated delivery honestly starts unread.
  * @param {String} messageId Message graph node id.
  * @param {String} recipient Recipient identity node id.
- * @returns {Object} `{readAt?, archivedAt?}` — only the fields with committed non-null values.
+ * @param {Object} [options]
+ * @param {Boolean} [options.includeNull=false] Include explicit nulls when a stored row exists.
+ * @returns {Object} `{readAt?, archivedAt?}` — committed non-null fields by default; explicit
+ *   nulls when `includeNull` is enabled and a stored row exists.
  * @private
  */
-function getStorageDeliveryMutableState(messageId, recipient) {
+function getStorageDeliveryMutableState(messageId, recipient, {includeNull=false} = {}) {
     const sqlite = GraphService.db?.storage?.db;
     if (!sqlite) return {};
 
@@ -895,42 +898,56 @@ function getStorageDeliveryMutableState(messageId, recipient) {
         if (state.readAt == null && row.readAt != null)         state.readAt     = row.readAt;
         if (state.archivedAt == null && row.archivedAt != null) state.archivedAt = row.archivedAt;
     }
+
+    if (includeNull) {
+        state.readAt     ??= null;
+        state.archivedAt ??= null
+    }
+
     return state;
 }
 
-function hasGraphEdgeOfType(source, type) {
-    return (GraphService.db?.edges?.items || []).some(edge =>
-        getRecordField(edge, 'source') === source &&
-        getRecordField(edge, 'type') === type
-    );
+/**
+ * @summary Checks one reconciled source-edge snapshot for a relationship type.
+ * @param {String} source
+ * @param {String} type
+ * @param {Object[]} [sourceEdges]
+ * @returns {Boolean}
+ * @private
+ */
+function hasGraphEdgeOfType(source, type, sourceEdges=getMessageSourceEdges(source)) {
+    return sourceEdges
+        .some(edge => getRecordField(edge, 'type') === type)
 }
 
 /**
- * @summary Returns missing graph pieces visible from the currently loaded cache for one message id.
+ * @summary Returns one message's indexed source projection and any missing graph pieces.
  * @param {String} messageId Message graph node id.
- * @returns {String[]}
+ * @returns {{issues:String[],sourceEdges:Object[]}}
  * @private
  */
-function getCachedMessageProjectionIssues(messageId) {
-    const db = GraphService.requireDb('MailboxService.getCachedMessageProjectionIssues');
+function getCachedMessageProjection(messageId) {
+    const db = GraphService.requireDb('MailboxService.getCachedMessageProjection');
 
     if (typeof messageId !== 'string' || !messageId.startsWith('MESSAGE:')) {
-        return ['invalid-message-id'];
+        return {issues: ['invalid-message-id'], sourceEdges: []}
     }
 
     db.getAdjacentNodes(messageId, 'outbound');
 
-    const messageNode = db.nodes.get(messageId);
-    const issues      = [];
+    const
+        messageNode = db.nodes.get(messageId),
+        sourceEdges = getMessageSourceEdges(messageId),
+        issues      = [];
 
     if (!messageNode || getRecordField(messageNode, 'label') !== 'MESSAGE') {
         issues.push('missing-message-node');
     }
 
-    if (!hasGraphEdgeOfType(messageId, 'SENT_BY')) issues.push('missing-sent-by');
-    if (!hasGraphEdgeOfType(messageId, 'SENT_TO')) issues.push('missing-sent-to');
+    if (!hasGraphEdgeOfType(messageId, 'SENT_BY', sourceEdges)) issues.push('missing-sent-by');
+    if (!hasGraphEdgeOfType(messageId, 'SENT_TO', sourceEdges)) issues.push('missing-sent-to');
 
-    return issues;
+    return {issues, sourceEdges}
 }
 
 /**
@@ -1748,15 +1765,84 @@ function getBroadcastAudience(sentBy) {
         .sort();
 }
 
-function getBroadcastDeliveryEdges(messageId) {
-    return (GraphService.db?.edges?.items || []).filter(edge =>
-        getRecordField(edge, 'source') === messageId &&
-        getRecordField(edge, 'type') === 'DELIVERED_TO'
-    );
+/**
+ * @summary Projects every cached outgoing edge for one message through the source index.
+ * @param {String} messageId
+ * @returns {Object[]}
+ * @throws {Error} When the graph database or its source index is unavailable.
+ * @private
+ */
+function getMessageSourceEdges(messageId) {
+    const
+        db         = GraphService.requireDb('MailboxService.getMessageSourceEdges'),
+        {edges}    = db,
+        indexed    = edges.getByIndex('source', messageId),
+        resolved   = new Map(),
+        unresolved = [];
+
+    indexed.forEach(edge => {
+        const
+            id        = getRecordField(edge, 'id'),
+            canonical = id ? edges.get(id) : null;
+
+        if (canonical && getRecordField(canonical, 'source') === messageId) {
+            resolved.set(id, canonical)
+        } else if (id) {
+            unresolved.push(edge)
+        }
+    });
+
+    // A long-lived Store can retain an old object only in an index Set, while WAL repair can
+    // produce the inverse: a durable edge visible only from that Set. Canonical Store objects are
+    // the zero-I/O path. Only index-only ids pay one source-bounded SQLite reconciliation, which
+    // keeps a removed stale recipient from authorizing while preserving a repaired receipt.
+    const sqlite = db.storage?.db;
+    if (unresolved.length > 0 && sqlite) {
+        const storedById = new Map(sqlite.prepare(
+            'SELECT id, source, target, type FROM Edges WHERE source = ?'
+        ).all(messageId).map(row => [row.id, row]));
+
+        unresolved.forEach(edge => {
+            const
+                id     = getRecordField(edge, 'id'),
+                stored = storedById.get(id);
+
+            if (!resolved.has(id) &&
+                stored &&
+                stored.source === getRecordField(edge, 'source') &&
+                stored.target === getRecordField(edge, 'target') &&
+                stored.type   === getRecordField(edge, 'type')) {
+                resolved.set(id, edge)
+            }
+        })
+    }
+
+    return [...resolved.values()]
 }
 
-function getBroadcastDeliveryEdge(messageId, target) {
-    return getBroadcastDeliveryEdges(messageId)
+/**
+ * @summary Projects one broadcast's delivery receipts through its indexed outgoing edges.
+ * @param {String} messageId
+ * @param {Object[]} [sourceEdges]
+ * @returns {Object[]}
+ * @throws {Error} When the graph database or its source index is unavailable.
+ * @private
+ */
+function getBroadcastDeliveryEdges(messageId, sourceEdges=getMessageSourceEdges(messageId)) {
+    return sourceEdges
+        .filter(edge => getRecordField(edge, 'type') === 'DELIVERED_TO')
+}
+
+/**
+ * @summary Resolves the first equivalent delivery receipt for one recipient.
+ * @param {String} messageId
+ * @param {String} target
+ * @param {Object[]} [sourceEdges]
+ * @returns {Object|null}
+ * @private
+ */
+function getBroadcastDeliveryEdge(messageId, target, sourceEdges) {
+    return getBroadcastDeliveryEdges(messageId, sourceEdges)
         .find(edge => sameMailboxIdentity(getRecordField(edge, 'target'), target)) || null;
 }
 
@@ -1807,8 +1893,15 @@ function linkRequiredMailboxEdgeOrThrow(source, target, type, weight, properties
     }
 }
 
-function hasBroadcastDeliveryEdges(messageId) {
-    return getBroadcastDeliveryEdges(messageId).length > 0;
+/**
+ * @summary Reports whether one source-edge snapshot carries any delivery receipt.
+ * @param {String} messageId
+ * @param {Object[]} [sourceEdges]
+ * @returns {Boolean}
+ * @private
+ */
+function hasBroadcastDeliveryEdges(messageId, sourceEdges) {
+    return getBroadcastDeliveryEdges(messageId, sourceEdges).length > 0;
 }
 
 
@@ -2008,6 +2101,23 @@ function normalizeMarkReadMessageIdInput(messageId) {
 }
 
 /**
+ * @summary Reconciles mutable receipt fields from storage before a whole-edge persistence write.
+ * @param {Object} edge `DELIVERED_TO` edge record from the Store map or a secondary-index Set.
+ * @returns {Object} Cached properties overlaid with storage-owned `readAt` / `archivedAt` state.
+ * @private
+ */
+function getDeliveryEdgePropertiesForWrite(edge) {
+    return {
+        ...getRecordProperties(edge),
+        ...getStorageDeliveryMutableState(
+            getRecordField(edge, 'source'),
+            getRecordField(edge, 'target'),
+            {includeNull: true}
+        )
+    }
+}
+
+/**
  * Sets the read timestamp on a per-recipient `DELIVERED_TO` edge for broadcast messages and
  * reports whether that mutation reached durable storage.
  *
@@ -2021,7 +2131,7 @@ function normalizeMarkReadMessageIdInput(messageId) {
  */
 async function setDeliveryEdgeReadAt(edge, readAt) {
     setRecordProperties(edge, {
-        ...getRecordProperties(edge),
+        ...getDeliveryEdgePropertiesForWrite(edge),
         readAt
     });
 
@@ -2058,7 +2168,7 @@ async function setMessageNodeReadAt(node, readAt) {
  */
 async function setDeliveryEdgeArchivedAt(edge, archivedAt) {
     setRecordProperties(edge, {
-        ...getRecordProperties(edge),
+        ...getDeliveryEdgePropertiesForWrite(edge),
         archivedAt
     });
 
@@ -2966,8 +3076,8 @@ class MailboxService extends Base {
      *   that looks correct.
      * @param {Number} [args.offset=0] Pagination offset. Must be a non-negative integer; pass the
      *   previous response's `nextOffset` to continue.
-     * @throws {Error} When `limit` is not a positive integer or `offset` is not a non-negative
-     *   integer.
+     * @throws {Error} When `limit` is not a positive integer, `offset` is not a non-negative
+     *   integer, or the required source/target edge indexes are unavailable.
      * @param {Boolean} [args.includeArchived=false] Surface archived messages. Default excludes
      *   any message whose `archivedAt` is set (on the MESSAGE node for direct DMs OR on the
      *   per-recipient DELIVERED_TO edge for broadcasts) — archived ≠ deleted; the message persists
@@ -3017,6 +3127,11 @@ class MailboxService extends Base {
         if (!Number.isInteger(numericOffset) || numericOffset < 0) {
             throw new Error(`MailboxService.listMessages: offset must be a non-negative integer, received ${JSON.stringify(offset)}`);
         }
+
+        // Candidate discovery and per-message projection form one routing contract. Assert both
+        // indexes before either can publish an empty result, including an honestly empty mailbox
+        // where no later source-index lookup would otherwise execute.
+        db.edges.assertIndices(['source', 'target']);
 
         const repairScanLimit = Math.max(MESSAGE_GRAPH_REPAIR_LIMIT, numericLimit + numericOffset);
 
@@ -3244,15 +3359,14 @@ class MailboxService extends Base {
 
         const db = GraphService.requireDb('MailboxService.getMessage');
 
-        // Trigger syncCache + lazy-reload vicinity for this message node.
-        // Ensures peer-process writes to this message's edges (e.g. late PART_OF_THREAD
-        // additions, read-receipt annotations) are visible. See listMessages for the
-        // full rationale on why bare `syncCache()` is insufficient for edge-type scans.
-        db.getAdjacentNodes(messageId, 'both');
+        // The projection helper triggers syncCache + lazy vicinity hydration, then returns the
+        // same reconciled source-edge snapshot used for integrity checks and authorization.
+        let {issues, sourceEdges} = getCachedMessageProjection(messageId);
 
-        if (getCachedMessageProjectionIssues(messageId).length > 0) {
+        if (issues.length > 0) {
             await this.repairMessageGraphIntegrity({ids: [messageId], limit: 1});
             db.getAdjacentNodes(messageId, 'both');
+            sourceEdges = getMessageSourceEdges(messageId)
         }
 
         const messageNode = db.nodes.get(messageId);
@@ -3264,30 +3378,28 @@ class MailboxService extends Base {
             sentTo            = null,
             isDirectRecipient = false;
 
-        for (const edge of db.edges.items) {
-            if (getRecordField(edge, 'source') === messageId) {
-                const edgeType = getRecordField(edge, 'type'),
-                    edgeTarget = getRecordField(edge, 'target');
+        for (const edge of sourceEdges) {
+            const edgeType = getRecordField(edge, 'type'),
+                edgeTarget = getRecordField(edge, 'target');
 
-                if (edgeType === 'SENT_TO') {
-                    sentTo = edgeTarget;
-                    if (sameMailboxIdentity(edgeTarget, me)) {
-                        isDirectRecipient = true;
-                    }
+            if (edgeType === 'SENT_TO') {
+                sentTo = edgeTarget;
+                if (sameMailboxIdentity(edgeTarget, me)) {
+                    isDirectRecipient = true;
                 }
-                if (edgeType === 'SENT_BY') {
-                    sentBy = edgeTarget;
-                }
+            }
+            if (edgeType === 'SENT_BY') {
+                sentBy = edgeTarget;
             }
         }
 
-        const deliveryEdge = getBroadcastDeliveryEdge(messageId, me);
+        const deliveryEdge = getBroadcastDeliveryEdge(messageId, me, sourceEdges);
         let   isAuthorized = sameMailboxIdentity(sentBy, me) || isDirectRecipient;
 
         if (!isAuthorized && sentTo === 'AGENT:*') {
             // Legacy broadcasts without per-recipient receipts retain their historical
             // read-path semantics. Receipt-backed broadcasts authorize only snapshotted recipients.
-            isAuthorized = deliveryEdge || !hasBroadcastDeliveryEdges(messageId);
+            isAuthorized = deliveryEdge || !hasBroadcastDeliveryEdges(messageId, sourceEdges);
         } else if (!isAuthorized && sentTo && !sameMailboxIdentity(sentTo, me) && sentTo !== 'AGENT:*') {
             // Check if me has permission to read sentTo's inbox
             if (PermissionService.hasPermission(me, sentTo, 'CAN_READ_INBOX_OF')) {
@@ -3533,10 +3645,6 @@ class MailboxService extends Base {
 
         const db = GraphService.requireDb('MailboxService.markRead');
 
-        // Trigger syncCache + lazy-reload vicinity. Ensures the SENT_TO edge
-        // iteration sees peer-process writes. See listMessages for the full rationale.
-        db.getAdjacentNodes(messageId, 'both');
-
         // The read path repairs a degraded projection before serving; this path did not, so a mark
         // resolved and authorized from a cache the reader had already healed past. That divergence is
         // the defect: `get_message` served messages whose node or SENT_TO edge was absent here, while
@@ -3546,9 +3654,12 @@ class MailboxService extends Base {
         //
         // Repair is surgical (`onlyIssues`) and falls back to storage truth per flagged piece, so
         // triggering it here cannot resurrect the WAL's send-time `readAt: null` over a committed read.
-        if (getCachedMessageProjectionIssues(messageId).length > 0) {
+        let {issues, sourceEdges} = getCachedMessageProjection(messageId);
+
+        if (issues.length > 0) {
             await this.repairMessageGraphIntegrity({ids: [messageId], limit: 1});
             db.getAdjacentNodes(messageId, 'both');
+            sourceEdges = getMessageSourceEdges(messageId)
         }
 
         const messageNode = db.nodes.get(messageId);
@@ -3559,8 +3670,8 @@ class MailboxService extends Base {
         let isDirectRecipient    = false,
             isBroadcastRecipient = false;
 
-        for (const edge of db.edges.items) {
-            if (getRecordField(edge, 'source') === messageId && getRecordField(edge, 'type') === 'SENT_TO') {
+        for (const edge of sourceEdges) {
+            if (getRecordField(edge, 'type') === 'SENT_TO') {
                 const edgeTarget = getRecordField(edge, 'target');
 
                 if (sameMailboxIdentity(edgeTarget, me)) {
@@ -3573,7 +3684,7 @@ class MailboxService extends Base {
             }
         }
 
-        const deliveryEdge = getBroadcastDeliveryEdge(messageId, me);
+        const deliveryEdge = getBroadcastDeliveryEdge(messageId, me, sourceEdges);
 
         if (deliveryEdge) {
             const readAt = new Date().toISOString();
@@ -3584,7 +3695,7 @@ class MailboxService extends Base {
         }
 
         // A broadcast recipient with no visible delivery edge is the one state where the projection is
-        // least likely to be telling the truth. The cheap check above (`getCachedMessageProjectionIssues`)
+        // least likely to be telling the truth. The cheap check above (`getCachedMessageProjection`)
         // has no DELIVERED_TO term, so a damaged per-recipient edge never triggered a repair — and
         // denying here purely because OTHER recipients' edges survive would refuse a legitimate audience
         // member: their own missing edge plus a peer's surviving edge reads as "not a recipient", and the
@@ -3597,8 +3708,9 @@ class MailboxService extends Base {
         if (isBroadcastRecipient) {
             await this.repairMessageGraphIntegrity({ids: [messageId], limit: 1});
             db.getAdjacentNodes(messageId, 'both');
+            sourceEdges = getMessageSourceEdges(messageId);
 
-            const repairedEdge = getBroadcastDeliveryEdge(messageId, me);
+            const repairedEdge = getBroadcastDeliveryEdge(messageId, me, sourceEdges);
 
             if (repairedEdge) {
                 const readAt = new Date().toISOString();
@@ -3609,7 +3721,7 @@ class MailboxService extends Base {
             }
         }
 
-        if (isBroadcastRecipient && hasBroadcastDeliveryEdges(messageId)) {
+        if (isBroadcastRecipient && hasBroadcastDeliveryEdges(messageId, sourceEdges)) {
             throw new Error(`Unauthorized: you are not the recipient of message ${messageId}`);
         }
 
@@ -3761,6 +3873,8 @@ class MailboxService extends Base {
         // Trigger syncCache + lazy-reload vicinity — same pattern as markRead.
         db.getAdjacentNodes(messageId, 'both');
 
+        const sourceEdges = getMessageSourceEdges(messageId);
+
         const messageNode = db.nodes.get(messageId);
         if (!messageNode || messageNode.label !== 'MESSAGE') {
             throw new Error(`Message not found: ${messageId}`);
@@ -3769,8 +3883,8 @@ class MailboxService extends Base {
         let isDirectRecipient    = false,
             isBroadcastRecipient = false;
 
-        for (const edge of db.edges.items) {
-            if (getRecordField(edge, 'source') === messageId && getRecordField(edge, 'type') === 'SENT_TO') {
+        for (const edge of sourceEdges) {
+            if (getRecordField(edge, 'type') === 'SENT_TO') {
                 const edgeTarget = getRecordField(edge, 'target');
 
                 if (sameMailboxIdentity(edgeTarget, me)) {
@@ -3783,7 +3897,7 @@ class MailboxService extends Base {
             }
         }
 
-        const deliveryEdge = getBroadcastDeliveryEdge(messageId, me);
+        const deliveryEdge = getBroadcastDeliveryEdge(messageId, me, sourceEdges);
 
         if (deliveryEdge) {
             const archivedAt = new Date().toISOString();
@@ -3793,7 +3907,7 @@ class MailboxService extends Base {
             return receiptWithDurability({ messageId, archivedAt, status: 'archived' }, durable, 'archive_message');
         }
 
-        if (isBroadcastRecipient && hasBroadcastDeliveryEdges(messageId)) {
+        if (isBroadcastRecipient && hasBroadcastDeliveryEdges(messageId, sourceEdges)) {
             throw new Error(`Unauthorized: you are not the recipient of message ${messageId}`);
         }
 

--- a/test/playwright/unit/ai/graph/StoreSafeguards.spec.mjs
+++ b/test/playwright/unit/ai/graph/StoreSafeguards.spec.mjs
@@ -15,6 +15,7 @@ setup({
 
 import {test, expect} from '@playwright/test';
 import Neo            from '../../../../../src/Neo.mjs';
+import * as core      from '../../../../../src/core/_export.mjs';
 import Store          from '../../../../../ai/graph/Store.mjs';
 import NodeModel      from '../../../../../ai/graph/NodeModel.mjs';
 
@@ -142,5 +143,41 @@ test.describe('Neo.ai.graph.Store Safeguards', () => {
         }
         expect(errorThrown).toBe(true);
         store.destroy();
+    });
+
+    test('distinguishes an unavailable index from a configured index with no matching value', () => {
+        const store = Neo.create(Store, {
+            autoInitRecords: false,
+            indices        : [{property: 'source'}],
+            model          : NodeModel
+        });
+
+        store.add({id: 'edge-1', source: 'message-1', target: 'recipient-1'}, false);
+
+        expect(store.getByIndex('source', 'message-1')).toHaveLength(1);
+        expect(store.getByIndex('source', 'missing-message')).toEqual([]);
+        expect(() => store.getByIndex('target', 'recipient-1'))
+            .toThrow(/secondary index unavailable.*target/i);
+
+        store.destroy()
+    });
+
+    test('fails explicitly when a configured index map disappears after construction', () => {
+        const store = Neo.create(Store, {
+            autoInitRecords: false,
+            indices        : [{property: 'source'}, {property: 'target'}],
+            model          : NodeModel
+        });
+
+        expect(() => store.assertIndices(['source', 'target'])).not.toThrow();
+
+        store.indexMaps.delete('target');
+
+        expect(() => store.assertIndices(['source', 'target']))
+            .toThrow(/secondary index unavailable.*target/i);
+        expect(() => store.getByIndex('target', 'recipient-1'))
+            .toThrow(/secondary index unavailable.*target/i);
+
+        store.destroy()
     });
 });

--- a/test/playwright/unit/ai/services/memory-core/MailboxService.ListMessagesCompleteness.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/MailboxService.ListMessagesCompleteness.spec.mjs
@@ -197,4 +197,27 @@ test.describe('MailboxService.listMessages — a page must declare its own compl
         expect(seen, 'every seeded row reached, none repeated').toHaveLength(SEEDED);
         expect(new Set(seen).size, 'and each exactly once').toBe(SEEDED);
     });
+
+    test('the production edge Store exposes both mailbox routing indexes', () => {
+        expect(() => GraphService.db.edges.assertIndices(['source', 'target'])).not.toThrow()
+    });
+
+    for (const property of ['source', 'target']) {
+        test(`a missing ${property} index cannot manufacture an empty inbox`, async () => {
+            const
+                edges       = GraphService.db.edges,
+                propertyMap = edges.indexMaps.get(property);
+
+            expect(propertyMap, `the ${property} index must exist before the mutation`).toBeInstanceOf(Map);
+
+            edges.indexMaps.delete(property);
+
+            try {
+                await expect(asRecipient(() => MailboxService.listMessages({box: 'inbox'})))
+                    .rejects.toThrow(new RegExp(`secondary index unavailable.*${property}`, 'i'))
+            } finally {
+                edges.indexMaps.set(property, propertyMap)
+            }
+        })
+    }
 });

--- a/test/playwright/unit/ai/services/memory-core/MailboxService.UnreadProjection.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/MailboxService.UnreadProjection.spec.mjs
@@ -30,7 +30,8 @@ import RequestContextService from '../../../../../../ai/mcp/server/shared/servic
  *
  * Arms 1-2 pin the healthy shapes (clean + re-hydrated lifecycles). Arms 3-4 inject the two
  * divergence pathologies directly — a stale cached property and a source-index eviction — and
- * assert the storage-truth merge overrides both. Arm 5 pins the count-stability contract.
+ * assert the storage-truth merge overrides both. Arm 5 pins the count-stability contract;
+ * arm 6 poisons full-store iteration across the single-message broadcast paths.
  */
 test.describe.configure({mode: 'serial'});
 
@@ -72,7 +73,7 @@ test.describe('MailboxService — unread projection observes a committed mark_re
 
     /** The cached per-recipient DELIVERED_TO edge, exactly as the in-memory projection holds it. */
     const cachedDeliveryEdge = messageId =>
-        GraphService.db.edges.items.find(edge =>
+        GraphService.db.edges.getByIndex('source', messageId).find(edge =>
             (edge.source ?? edge.get?.('source')) === messageId &&
             (edge.type   ?? edge.get?.('type'))   === 'DELIVERED_TO' &&
             (edge.target ?? edge.get?.('target')) === RECIPIENT);
@@ -154,10 +155,16 @@ test.describe('MailboxService — unread projection observes a committed mark_re
         // while storage keeps the committed receipt (the durable divergence both seats measured).
         const edge = cachedDeliveryEdge(messageId);
         expect(edge, 'fixture must hold a cached delivery edge').toBeTruthy();
-        expect(readAtOf(edge)).toBe(receipt.readAt);
 
-        corruptCacheEdgeToUnread(edge, null);
+        if (readAtOf(edge) !== null) {
+            corruptCacheEdgeToUnread(edge, null)
+        }
         expect(readAtOf(edge), 'the corruption itself must be in place').toBeNull();
+
+        const stored = GraphService.db.storage.db.prepare(
+            "SELECT json_extract(data, '$.properties.readAt') AS readAt FROM Edges WHERE id = ?"
+        ).get(edge.id ?? edge.get?.('id'));
+        expect(stored?.readAt, 'storage retains the committed receipt').toBe(receipt.readAt);
 
         const after = await listUnread();
         expect(after.messages.find(m => m.messageId === messageId),
@@ -193,10 +200,14 @@ test.describe('MailboxService — unread projection observes a committed mark_re
             type      : 'DELIVERED_TO',
             properties: {deliveredAt: receipt.readAt, readAt: null, deliveryKind: 'broadcast'}
         };
+        const fresh = {
+            ...twin,
+            properties: {...twin.properties, readAt: receipt.readAt}
+        };
 
         sourceSet.delete(edge);
         sourceSet.add(twin); // stale twin iterates first
-        sourceSet.add(edge); // fresh copy still present, second
+        sourceSet.add(fresh); // fresh copy still present, second
 
         const after = await listUnread();
         expect(after.messages.find(m => m.messageId === messageId),
@@ -209,5 +220,134 @@ test.describe('MailboxService — unread projection observes a committed mark_re
 
         expect(second.totalCount).toBe(first.totalCount);
         expect(second.messages.map(m => m.messageId)).toEqual(first.messages.map(m => m.messageId));
+    });
+
+    test('arm 6 — get, mark-read, and archive never enumerate the full edge Store', async () => {
+        const
+            messageId     = await sendBroadcast('arm 6: indexed single-message paths'),
+            edges         = GraphService.db.edges,
+            ownDescriptor = Object.getOwnPropertyDescriptor(edges, 'items'),
+            items         = edges.items;
+
+        let phase = 'setup';
+
+        const iterationMethods = new Set(['filter', 'find', 'forEach', 'map', 'reduce', 'some']);
+        const poisonedItems    = new Proxy(items, {
+            get(target, property, receiver) {
+                if (property === Symbol.iterator || iterationMethods.has(property)) {
+                    return () => {
+                        throw new Error(`full edge Store iteration is forbidden during ${phase}`)
+                    }
+                }
+
+                return Reflect.get(target, property, receiver)
+            }
+        });
+
+        Object.defineProperty(edges, 'items', {
+            configurable: true,
+            get() {
+                return poisonedItems
+            }
+        });
+
+        try {
+            phase = 'get_message';
+            const fetched = await asRecipient(() => MailboxService.getMessage({messageId}));
+            expect(fetched.messageId).toBe(messageId);
+
+            phase = 'mark_read';
+            const readReceipt = await asRecipient(() => MailboxService.markRead({messageId}));
+            expect(readReceipt.status).toBe('read');
+
+            phase = 'archive_message';
+            const archiveReceipt = await asRecipient(() => MailboxService.archiveMessage({messageId}));
+            expect(archiveReceipt.status).toBe('archived')
+        } finally {
+            if (ownDescriptor) {
+                Object.defineProperty(edges, 'items', ownDescriptor)
+            } else {
+                delete edges.items
+            }
+        }
+    });
+
+    test('arm 7 — index-only receipt writes preserve the other storage-owned timestamp', async () => {
+        const
+            messageId   = await sendBroadcast('arm 7: index-only receipt writes'),
+            readReceipt = await asRecipient(() => MailboxService.markRead({messageId})),
+            db          = GraphService.db,
+            {edges}     = db,
+            indexedEdge = cachedDeliveryEdge(messageId),
+            edgeId      = indexedEdge?.id ?? indexedEdge?.get?.('id'),
+            sourceSet   = edges.indexMaps.get('source')?.get(messageId),
+            originalMap = edges.map.get(edgeId),
+            originalSet = [...sourceSet].filter(edge => (edge.id ?? edge.get?.('id')) === edgeId),
+            staleEdge   = {
+                id        : edgeId,
+                source    : messageId,
+                target    : RECIPIENT,
+                type      : 'DELIVERED_TO',
+                properties: {
+                    ...(indexedEdge?.properties ?? indexedEdge?.get?.('properties')),
+                    archivedAt: null,
+                    readAt    : null
+                }
+            };
+
+        expect(readReceipt.readAt).toBeTruthy();
+        expect(indexedEdge, 'the fixture needs a source-index receipt').toBeTruthy();
+        expect(originalMap, 'the fixture starts with a Store-canonical receipt').toBeTruthy();
+
+        const readStoredReceipt = () => db.storage.db.prepare(
+            "SELECT json_extract(data, '$.properties.readAt') AS readAt, json_extract(data, '$.properties.archivedAt') AS archivedAt FROM Edges WHERE id = ?"
+        ).get(edgeId);
+
+        const installIndexOnlyStaleEdge = () => {
+            originalSet.forEach(edge => sourceSet.delete(edge));
+            sourceSet.add(staleEdge);
+            edges.map.delete(edgeId);
+            db.vicinityLoadedNodes.add(messageId);
+            db.lastSyncId = db.storage.getLatestLogId()
+        };
+
+        try {
+            installIndexOnlyStaleEdge();
+
+            const archiveReceipt = await asRecipient(() => MailboxService.archiveMessage({messageId}));
+            let   stored         = readStoredReceipt();
+
+            expect(stored.readAt, 'archive preserves the committed read receipt').toBe(readReceipt.readAt);
+            expect(stored.archivedAt).toBe(archiveReceipt.archivedAt);
+
+            staleEdge.properties.archivedAt = null;
+            installIndexOnlyStaleEdge();
+
+            const secondRead = await asRecipient(() => MailboxService.markRead({messageId}));
+            stored = readStoredReceipt();
+
+            expect(stored.readAt).toBe(secondRead.readAt);
+            expect(stored.archivedAt, 'mark-read preserves the committed archive receipt')
+                .toBe(archiveReceipt.archivedAt);
+
+            const storedRow  = db.storage.db.prepare('SELECT data FROM Edges WHERE id = ?').get(edgeId),
+                  storedData = JSON.parse(storedRow.data);
+
+            storedData.properties.archivedAt = null;
+            db.storage.db.prepare('UPDATE Edges SET data = ? WHERE id = ?')
+                .run(JSON.stringify(storedData), edgeId);
+
+            staleEdge.properties.archivedAt = archiveReceipt.archivedAt;
+            installIndexOnlyStaleEdge();
+
+            await asRecipient(() => MailboxService.markRead({messageId}));
+            stored = readStoredReceipt();
+
+            expect(stored.archivedAt, 'a durable null beats a stale cache timestamp').toBeNull()
+        } finally {
+            sourceSet.delete(staleEdge);
+            originalSet.forEach(edge => sourceSet.add(edge));
+            edges.map.set(edgeId, originalMap)
+        }
     });
 });

--- a/test/playwright/unit/ai/services/memory-core/MailboxService.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/MailboxService.spec.mjs
@@ -2353,11 +2353,22 @@ test.describe('Neo.ai.services.memory-core.MailboxService', () => {
 
         // The mark must land on the RESTORED per-recipient edge, not the shared MESSAGE node — writing
         // the latter is the cross-recipient read-state collapse this lane also exists to prevent.
-        const restored = GraphService.db.edges.items.find(edge =>
-            edge.source === messageId && edge.type === 'DELIVERED_TO' && /charlie/i.test(String(edge.target))
+        const restored = GraphService.db.edges.getByIndex('source', messageId).find(edge =>
+            edge.source === messageId &&
+            edge.type === 'DELIVERED_TO' &&
+            /charlie/i.test(String(edge.target))
         );
         expect(restored, 'charlie edge rebuilt from the WAL').toBeTruthy();
-        expect(restored.properties?.readAt, 'mark landed on the restored per-recipient carrier').toBeTruthy();
+
+        const stored = GraphService.db.storage.db.prepare(
+            "SELECT json_extract(data, '$.properties.readAt') AS readAt FROM Edges WHERE source = ? AND target = ? AND type = 'DELIVERED_TO'"
+        ).get(messageId, '@charlie');
+        const storedMessage = GraphService.db.storage.db.prepare(
+            "SELECT json_extract(data, '$.properties.readAt') AS readAt FROM Nodes WHERE id = ?"
+        ).get(messageId);
+
+        expect(stored?.readAt, 'the restored receipt carries the durable mark').toBe(result.readAt);
+        expect(storedMessage?.readAt, 'the shared MESSAGE stays unread for other recipients').toBeNull();
     });
 
     test('#15322 a broadcast non-recipient registered AFTER send still fails closed — repair rebuilds only the snapshot', async () => {
@@ -2861,13 +2872,11 @@ test.describe('Neo.ai.services.memory-core.MailboxService', () => {
             })).messageId;
         });
 
-        await RequestContextService.run({agentIdentityNodeId: '@bob'}, async () => {
-            await MailboxService.markRead({messageId});
-        });
+        const canonicalReceipt = await RequestContextService.run({agentIdentityNodeId: '@bob'}, () =>
+            MailboxService.markRead({messageId})
+        );
 
-        const canonicalReceipt = GraphService.db.edges.getByIndex('source', messageId)
-            .find(edge => edge.type === 'DELIVERED_TO' && edge.target === '@bob');
-        expect(canonicalReceipt.properties.readAt).toBeTruthy();
+        expect(canonicalReceipt.readAt).toBeTruthy();
 
         // Historical stores can contain an equivalent bare-id receipt beside the canonical one.
         // The former `getBroadcastDeliveryEdge(...).find(...)` contract selected the first match;
@@ -2878,7 +2887,7 @@ test.describe('Neo.ai.services.memory-core.MailboxService', () => {
             const result  = await MailboxService.listMessages({status: 'read'});
             const message = result.messages.find(candidate => candidate.messageId === messageId);
 
-            expect(message?.readAt).toBe(canonicalReceipt.properties.readAt);
+            expect(message?.readAt).toBe(canonicalReceipt.readAt);
         });
     });
 


### PR DESCRIPTION
Resolves #16965

Related: #16677

Graph Store lookups now distinguish an unavailable secondary index from a configured index with no matching value. Mailbox listing asserts its required `source` and `target` indexes before it can publish an empty result, while single-message authorization, read, and archive paths reuse one source-index projection instead of enumerating the full edge Store. Index-only receipts are reconciled against canonical Store objects and bounded SQLite truth, and whole-edge receipt writes preserve the other storage-owned timestamp.

Evidence: L2 (mutation-sensitive Graph Store and real Mailbox service tests) → L2 required (all close-target ACs are deterministic Store/Mailbox contracts). No residuals.

## Deltas from ticket

- `Store#getByIndex()` now fails loudly through a reusable `assertIndices()` contract; a valid no-match still returns `[]`.
- Single-message mailbox paths canonicalize source-index entries, discard removed stale Set members, retain durable index-only repair entries, and preserve first-equivalent receipt precedence.
- Independent pre-commit audit found that a stale index-only receipt could erase committed `readAt` during archive (and vice versa). The write boundary now overlays storage-owned `readAt` / `archivedAt`, including explicit nulls, before applying the requested field.
- Existing damaged-recipient and legacy-alias controls were re-anchored to the source index and durable receipt authority rather than the retired full-store scan.

## Test Evidence

- `npm run test-unit -- test/playwright/unit/ai/graph/StoreSafeguards.spec.mjs test/playwright/unit/ai/services/memory-core/GraphService.spec.mjs test/playwright/unit/ai/services/memory-core/GraphService.TenantIsolation.spec.mjs test/playwright/unit/ai/services/memory-core/MailboxService.spec.mjs test/playwright/unit/ai/services/memory-core/MailboxService.ReceiptDurability.spec.mjs test/playwright/unit/ai/services/memory-core/MailboxService.ListMessagesCompleteness.spec.mjs test/playwright/unit/ai/services/memory-core/MailboxService.UnreadProjection.spec.mjs` — **272 passed** at `ce33c868b4`.
- RED controls before production changes: unknown/missing indexes returned valid-looking empty results; both missing Mailbox indexes produced `{messages: [], totalCount: 0}`; poisoned full-store iteration fired; index-only archive erased durable `readAt`.
- Independent post-repair audit: all three findings closed; audit-focused slice **174/174 passed**.
- `npm run agent-preflight -- --no-fix --change-class capability ...` — all requested gates passed; only the pre-existing operator-local stale-overlay warning remained.
- Full `npm run test-unit` was executed: **14,317 passed, 31 failed, 13 skipped, 39 not run**. A serialized rerun reproduced the same 31 outside this diff: Docker-owned `.neo-ai-data` caused `EPERM` / `SQLITE_CANTOPEN`, sandboxed `ps` / `mktemp` probes failed, live Neural Link reported `unhealthy`, and ignored `ai/deploy/.neo-ai-data/backups/**` polluted whole-tree scanners. No Graph/Mailbox failure remained.
- Directly touched surfaces: `Neo.ai.graph.Store` and `MailboxService` — covered by the 272-test slice above.

## Post-Merge Validation

None. All close-target effects are deterministic service-layer contracts covered at L2.

## Evolution

The first indexed helper trusted every Set member and was not handoff-ready: a removed legacy recipient could still authorize, while an index-only repaired receipt could be lost. Canonical-map fast paths plus bounded storage reconciliation closed both directions. The independent audit then exposed the write-side timestamp clobber; the final two-direction witness binds read/archive preservation and storage-owned nulls.

Authored by Emmy (GPT-5.6 Sol Ultra, Codex). Session fc673aab-2ed6-4592-9cb6-8da7588720ed.
