### PR TITLE
Template escaping is a no-op, so an apostrophe emits unparseable code

### DIFF
--- a/buildScripts/util/templateBuildProcessor.mjs
+++ b/buildScripts/util/templateBuildProcessor.mjs
@@ -67,6 +67,25 @@ const
     selfClosingComponentRegex = /<((?:[A-Z][\w\.]*)|(?:neotag\d+))([^>]*?)\/?>/g;
 
 /**
+ * Wraps a static template chunk as a single-quoted JavaScript string literal for an addition chain.
+ *
+ * Order matters: backslashes are escaped BEFORE quotes, otherwise the backslash this function itself
+ * introduces in front of a quote would be escaped again on a second pass and the literal would close
+ * early. Both characters need handling, not just the quote — a chunk ending in `\` escapes the closing
+ * delimiter (a syntax error), while an interior `a\b` is reinterpreted as the `\b` escape and silently
+ * becomes a backspace character. The latter parses cleanly, so it is the one that reaches production.
+ *
+ * The text-node chain and the attribute chain both call this. They previously inlined the same
+ * expression, which is why the same defect existed twice.
+ * @param {string} value The raw static chunk.
+ * @returns {string} The chunk as a quoted, escape-safe JS string literal.
+ * @private
+ */
+function toQuotedStringLiteral(value) {
+    return `'${value.replace(/\\/g, '\\\\').replace(/'/g, "\\'")}'`;
+}
+
+/**
  * Recursively converts a single parse5 AST node into a Neo.mjs VDOM node.
  * This is the heart of the transformation process, translating the HTML structure into a JSON structure.
  * @param {object} node The parse5 AST node to process.
@@ -116,8 +135,7 @@ function convertNodeToVdom(node, values, originalString, attributeNameMap, optio
                         return `(${exprMatch[1]})`; // Wrap expression in parens for safety
                     }
                 }
-                // Escape single quotes for the string literal part of the chain.
-                return `'${part.replace(/'/g, "\'" )}'`;
+                return toQuotedStringLiteral(part);
             }).filter(p => p !== `''`).join(' + ');
 
             // The entire chain becomes a single expression placeholder.
@@ -179,7 +197,7 @@ function convertNodeToVdom(node, values, originalString, attributeNameMap, optio
                             return exprMatch ? `(${exprMatch[1]})` : JSON.stringify(value);
                         }
                     }
-                    return `'${part.replace(/'/g, "\'" )}'`;
+                    return toQuotedStringLiteral(part);
                 });
 
                 if (hasDynamicPart) {

--- a/test/playwright/unit/buildScripts/templateBuildProcessor.spec.mjs
+++ b/test/playwright/unit/buildScripts/templateBuildProcessor.spec.mjs
@@ -1,0 +1,117 @@
+import {test, expect} from '@playwright/test';
+
+/**
+ * The property under test is that emitted code **parses**, not that it matches an expected string.
+ *
+ * A string-equality assertion passes for any consistent-but-wrong escaping — it pins whatever the
+ * emitter currently does, including the identity replacement this file exists to catch. Parsing is
+ * the property a build actually depends on, so every arm below compiles the emitted expression.
+ *
+ * The two call sites are independent: `:120` builds the text-node chain, `:182` the attribute chain.
+ * They carry the same defect because the logic was inlined twice, so each gets its own arm and its
+ * own mutation control — a fix to one site must not green the other's.
+ *
+ * @see https://github.com/neomjs/neo/issues/17484
+ */
+test.describe('templateBuildProcessor — static text is escaped so the emitted chain parses', () => {
+    let processHtmlTemplateLiteral;
+
+    test.beforeAll(async () => {
+        ({processHtmlTemplateLiteral} =
+            await import('../../../../buildScripts/util/templateBuildProcessor.mjs'));
+    });
+
+    /**
+     * Extracts the generated expression from the `##__NEO_EXPR__` envelope the processor emits.
+     * Returns null when the node carries no expression, which is itself a failure for these arms:
+     * a static-only result would mean the dynamic part never made it into a chain, so the arm would
+     * be asserting on the wrong shape rather than on escaping.
+     */
+    const extractExpression = value => {
+        const match = typeof value === 'string' && value.match(/##__NEO_EXPR__(.*)##__NEO_EXPR__##/s);
+        return match ? match[1] : null
+    };
+
+    /** Compiles the expression, returning the SyntaxError message rather than throwing. */
+    const parseFailure = expression => {
+        try {
+            new Function('count', `return ${expression}`);
+            return null
+        } catch (error) {
+            return error.message
+        }
+    };
+
+    test('text node: an apostrophe in static text next to an interpolation still parses', () => {
+        // html`<div>it's ${count} here</div>` — the minimal shape that reaches the `:120` chain.
+        // An apostrophe alone is not enough: without a dynamic part there is no addition chain and
+        // the static text is never wrapped in a quoted literal.
+        const result     = processHtmlTemplateLiteral(["<div>it's ", ' here</div>'], ['count']),
+              expression = extractExpression(result?.text);
+
+        expect(expression, 'the dynamic part must produce an expression chain').not.toBeNull();
+        expect(parseFailure(expression)).toBeNull()
+    });
+
+    test('attribute: an apostrophe in a static attribute chunk still parses', () => {
+        // html`<div title="it's ${count}"></div>` — the `:182` chain, independent of the text path.
+        const result = processHtmlTemplateLiteral(['<div title="it\'s ', '"></div>'], ['count']),
+              // Attribute expressions land on the attribute, not on `text`.
+              expression = extractExpression(result?.title ?? result?.attributes?.title);
+
+        expect(expression, 'the dynamic attribute must produce an expression chain').not.toBeNull();
+        expect(parseFailure(expression)).toBeNull()
+    });
+
+    test('a TRAILING backslash does not consume the closing delimiter', () => {
+        // The defect one character over: escaping the quote but not the backslash lets a trailing
+        // `\` escape the closing quote. CodeQL named only the quote, so this arm is what keeps a
+        // literal-minded fix from closing the alert while the bug survives.
+        //
+        // The chunk must END in the backslash. An interior `a\b` emits `'a\b '`, where `\b` is a
+        // valid escape — it parses, and corrupts the value to a backspace instead. That is a real
+        // but DIFFERENT manifestation, and using it here would make this arm fail on the apostrophe
+        // or on nothing at all rather than on the backslash. Isolated deliberately.
+        const result     = processHtmlTemplateLiteral(['a\\', ' b'], ['count']),
+              expression = extractExpression(result?.text);
+
+        expect(expression, 'the dynamic part must produce an expression chain').not.toBeNull();
+        expect(parseFailure(expression)).toBeNull();
+
+        // Round-trip, so a fix cannot pass by dropping the backslash.
+        expect(new Function('count', `return ${expression}`)('X')).toBe('a\\X b')
+    });
+
+    test('an INTERIOR backslash is not silently reinterpreted as an escape', () => {
+        // `a\b` emits `'a\b '`, which parses but yields a backspace character. Parse-only coverage
+        // is blind to this, so the value is the assertion.
+        const result     = processHtmlTemplateLiteral(['a\\b ', 'c'], ['count']),
+              expression = extractExpression(result?.text);
+
+        expect(expression).not.toBeNull();
+        expect(new Function('count', `return ${expression}`)('X')).toBe('a\\b Xc')
+    });
+
+    test('escaping does not corrupt the value: the chain still evaluates to the original text', () => {
+        // Parse-only assertions accept an emitter that escapes into a *different* string — e.g. one
+        // that drops the apostrophe entirely. This arm pins the round-trip, so the fix has to
+        // preserve the text rather than merely produce something compilable.
+        const result     = processHtmlTemplateLiteral(["it's ", ' done'], ['count']),
+              expression = extractExpression(result?.text);
+
+        expect(expression).not.toBeNull();
+
+        const evaluated = new Function('count', `return ${expression}`)('X');
+
+        expect(evaluated).toBe("it's X done")
+    });
+
+    test('a static-only template is untouched — no chain, no escaping', () => {
+        // Non-vacuity control in the other direction: the escaping path must not start firing on
+        // templates that have no dynamic part, which would change output for every static node.
+        const result = processHtmlTemplateLiteral(["<div>it's here</div>"], []);
+
+        expect(extractExpression(result?.text)).toBeNull();
+        expect(result?.text).toBe("it's here")
+    });
+});


### PR DESCRIPTION
Resolves #17484

🌿 *The comment said "escape single quotes". The code replaced each apostrophe with itself.*

Evidence: L2 (unit, real exported function, emitted code compiled) → L2 required (build-time surface, nothing deployed). No residual.

## The defect

`buildScripts/util/templateBuildProcessor.mjs:120` and `:182` both did:

```js
// Escape single quotes for the string literal part of the chain.
return `'${part.replace(/'/g, "\'" )}'`;
```

`"\'"` in a double-quoted JS string is not an escape sequence — it evaluates to a bare `'`. Every apostrophe was replaced **with itself**, and had been since the line was written. Nothing noticed because the failure needs an apostrophe in static text *adjacent to an interpolation*.

Driven through the real exported `processHtmlTemplateLiteral`, not a reconstruction of it — the build-time equivalent of ``html`<div>it's ${count} here</div>` ``:

```json
{"tag":"div","text":"##__NEO_EXPR__'it's ' + (count) + ' here'##__NEO_EXPR__##"}
```

`'it's ' + (count) + ' here'` is `SyntaxError: Unexpected identifier 's'`. The correctly-escaped control parses, so the failure is attributable to the escaping rather than to the expression shape.

## The backslash is the half that actually reaches production

CodeQL named the quote. The backslash was unhandled too, and it fails in **two different ways**:

| input chunk | emitted | outcome |
|---|---|---|
| `a\` (trailing) | `'a\' + (count) + ' b'` | `SyntaxError: Unexpected identifier 'b'` — the `\` escapes the closing delimiter |
| `a\b ` (interior) | `'a\b ' + (count) + 'c'` | **parses**, evaluates to `"a·Xc"` — `\b` is reinterpreted as the backspace escape |

The interior case is the dangerous one: it compiles clean and silently corrupts the string. A fix that closed alerts 41/42 by escaping only the quote would have left it alive.

## The fix

One shared helper, escaping backslashes **before** quotes — order matters, or the backslash the helper itself introduces gets escaped again on the second pass:

```js
function toQuotedStringLiteral(value) {
    return `'${value.replace(/\\/g, '\\\\').replace(/'/g, "\\'")}'`;
}
```

Both chains call it. The defect existed in duplicate precisely because the expression was inlined at two call sites, so sharing the helper is what stops a third chain inheriting it.

## Deltas from ticket

Two, both widening:

- **The ticket's AC named one backslash case; there are two.** #17484 asked that "backslash in static text is escaped before the quote". Implementing it surfaced that trailing and interior backslashes fail *differently* — one is a syntax error, the other parses and silently corrupts — so the coverage is two arms rather than the one the AC implies. The AC is satisfied either way; the split is the part worth reading.
- **The AC asked that the emitted expression parse; two arms also assert it round-trips.** Parse-only coverage is blind to the interior-backslash corruption, so parsing alone would have let a fix through that compiles and returns the wrong string.

Nothing in the ticket's scope was dropped. Alerts 62/63/64 remain out of scope exactly as filed.

## Test Evidence

`test/playwright/unit/buildScripts/templateBuildProcessor.spec.mjs` — **6 passed**. Full `buildScripts` suite — **108 passed**.

**The assertion is that emitted code parses and round-trips, not that it matches a string.** A string-equality assertion greens for any consistent-but-wrong escaping — including the identity replacement this PR removes. Two arms additionally evaluate the chain, because parse-only coverage is blind to the interior-backslash corruption above: that arm was RED at `Received: "a Xc"` with no error raised.

Each arm was confirmed to fail on **its own distinct cause**, not merely to be red:

| arm | RED cause before the fix |
|---|---|
| text node, apostrophe | `Unexpected identifier 's'` |
| attribute, apostrophe | `Unexpected identifier 's'` (independent `:182` path) |
| trailing backslash | `Unexpected identifier 'b'` |
| interior backslash | no error — value corrupted to `"a Xc"` |
| round-trip value | `Unexpected identifier 's'` |

**Mutation diagonal** — the two sites are independent, so each is bound separately:

| mutation | result |
|---|---|
| revert text site `:120` | its 4 arms redden; **attribute arm stays green** |
| revert attribute site `:182` | **only** the attribute arm reddens |

**One correction worth recording**, because it is the kind of arm that would have shipped looking fine: my first backslash arm used the chunk `" it's"`, which contains an apostrophe. It was RED — on the *quote*, making it a silent duplicate of arm 1 rather than a backslash test. Isolating the backslash is what surfaced the interior-vs-trailing split above, and that split is most of this PR's value.

**Non-vacuity control in the other direction:** a static-only template must be untouched — no chain, no escaping — so the new path cannot start firing on every static node. Green before and after.

## Out of Scope

- Alerts **62/63** (`js/prototype-pollution-utility`, `src/Neo.mjs:563,565`) — deliberate prototype *enrichment*; these want a documented dismissal decision from @tobiu, not a code change, and I am not dismissing security alerts on my own authority.
- Alert **64** (`js/shell-command-injection-from-environment`, `highlightJs.mjs:53`) — separate rule and file, carried separately.

## Post-Merge Validation

CodeQL alerts **41** and **42** should close on the merge commit. Nothing else gating — the change is build-time only and strictly widens what compiles.

Authored by Grace (Claude Opus 5, Claude Code). Session 752da6ac-a6c3-447f-8847-1da4ce49deb8.
