### PR TITLE
fix(portal): restore Calendar example identity (#17438)

### DIFF
--- a/apps/portal/resources/data/examples_dist_prod.json
+++ b/apps/portal/resources/data/examples_dist_prod.json
@@ -43,7 +43,7 @@
     "sourceUrl"   : "examples/grid/bigData",
     "url"         : "dist/production/examples/grid/bigData/index.html"
 }, {
-    "id"       : 22,
+    "id"       : 26,
     "image"    : "devmode/calendar-preview.png",
     "name"     : "Calendar",
     "sourceUrl": "src/calendar",

--- a/test/playwright/unit/apps/portal/view/examples/TabContainerController.spec.mjs
+++ b/test/playwright/unit/apps/portal/view/examples/TabContainerController.spec.mjs
@@ -17,26 +17,9 @@ import ExamplesTabContainer   from '../../../../../../../apps/portal/view/exampl
 import TabContainerController from '../../../../../../../apps/portal/view/examples/TabContainerController.mjs';
 
 const
-    directory       = path.dirname(fileURLToPath(import.meta.url)),
-    repoRoot        = path.resolve(directory, '../../../../../../../'),
-    dataRoot        = path.join(repoRoot, 'apps/portal/resources/data'),
-    registryConfigs = [{
-        file       : 'examples_devmode.json',
-        devIndexUrl: 'apps/devindex/index.html',
-        dockDemoUrl: 'apps/agentos/childapps/dockdemo/index.html'
-    }, {
-        file       : 'examples_dist_dev.json',
-        devIndexUrl: 'dist/development/apps/devindex/index.html',
-        dockDemoUrl: 'dist/development/apps/agentos/childapps/dockdemo/index.html'
-    }, {
-        file       : 'examples_dist_esm.json',
-        devIndexUrl: 'dist/esm/apps/devindex/index.html',
-        dockDemoUrl: 'dist/esm/apps/agentos/childapps/dockdemo/index.html'
-    }, {
-        file       : 'examples_dist_prod.json',
-        devIndexUrl: 'dist/production/apps/devindex/index.html',
-        dockDemoUrl: 'dist/production/apps/agentos/childapps/dockdemo/index.html'
-    }];
+    directory = path.dirname(fileURLToPath(import.meta.url)),
+    repoRoot  = path.resolve(directory, '../../../../../../../'),
+    dataRoot  = path.join(repoRoot, 'apps/portal/resources/data');
 
 /**
  * The examples tab routes resolve `activeIndex` through the controller's `tabItems` array.
@@ -114,7 +97,13 @@ test.describe('Portal.view.examples.TabContainerController — route → activeI
         // These four tracked files are the build authority. `dist/**` copies are ignored generated
         // output and do not exist in a fresh checkout, so they are verified through the owning build
         // receipt rather than a conditional unit arm that would pass vacuously when they are absent.
-        const registries = Object.fromEntries(registryConfigs.map(({file}) => [
+        const registryFiles = [
+            'examples_devmode.json',
+            'examples_dist_dev.json',
+            'examples_dist_esm.json',
+            'examples_dist_prod.json'
+        ];
+        const registries = Object.fromEntries(registryFiles.map(file => [
             file,
             JSON.parse(fs.readFileSync(path.join(dataRoot, file), 'utf8'))
         ]));
@@ -155,7 +144,25 @@ test.describe('Portal.view.examples.TabContainerController — route → activeI
     });
 
     test('release-gates DockDemo while retaining the visible DevIndex flagship card', () => {
-        registryConfigs.forEach(({file, devIndexUrl, dockDemoUrl}) => {
+        const registries = [{
+            file       : 'examples_devmode.json',
+            devIndexUrl: 'apps/devindex/index.html',
+            dockDemoUrl: 'apps/agentos/childapps/dockdemo/index.html'
+        }, {
+            file       : 'examples_dist_dev.json',
+            devIndexUrl: 'dist/development/apps/devindex/index.html',
+            dockDemoUrl: 'dist/development/apps/agentos/childapps/dockdemo/index.html'
+        }, {
+            file       : 'examples_dist_esm.json',
+            devIndexUrl: 'dist/esm/apps/devindex/index.html',
+            dockDemoUrl: 'dist/esm/apps/agentos/childapps/dockdemo/index.html'
+        }, {
+            file       : 'examples_dist_prod.json',
+            devIndexUrl: 'dist/production/apps/devindex/index.html',
+            dockDemoUrl: 'dist/production/apps/agentos/childapps/dockdemo/index.html'
+        }];
+
+        registries.forEach(({file, devIndexUrl, dockDemoUrl}) => {
             const
                 records   = JSON.parse(fs.readFileSync(path.join(dataRoot, file), 'utf8')),
                 dockDemo  = records.find(record => record.name === 'Dock Layouts'),

--- a/test/playwright/unit/apps/portal/view/examples/TabContainerController.spec.mjs
+++ b/test/playwright/unit/apps/portal/view/examples/TabContainerController.spec.mjs
@@ -12,13 +12,31 @@ import path                   from 'node:path';
 import {fileURLToPath}        from 'node:url';
 import Neo                    from '../../../../../../../src/Neo.mjs';
 import * as core              from '../../../../../../../src/core/_export.mjs';
+import ExamplesStore          from '../../../../../../../apps/portal/store/Examples.mjs';
 import ExamplesTabContainer   from '../../../../../../../apps/portal/view/examples/TabContainer.mjs';
 import TabContainerController from '../../../../../../../apps/portal/view/examples/TabContainerController.mjs';
 
 const
-    directory = path.dirname(fileURLToPath(import.meta.url)),
-    repoRoot  = path.resolve(directory, '../../../../../../../'),
-    dataRoot  = path.join(repoRoot, 'apps/portal/resources/data');
+    directory       = path.dirname(fileURLToPath(import.meta.url)),
+    repoRoot        = path.resolve(directory, '../../../../../../../'),
+    dataRoot        = path.join(repoRoot, 'apps/portal/resources/data'),
+    registryConfigs = [{
+        file       : 'examples_devmode.json',
+        devIndexUrl: 'apps/devindex/index.html',
+        dockDemoUrl: 'apps/agentos/childapps/dockdemo/index.html'
+    }, {
+        file       : 'examples_dist_dev.json',
+        devIndexUrl: 'dist/development/apps/devindex/index.html',
+        dockDemoUrl: 'dist/development/apps/agentos/childapps/dockdemo/index.html'
+    }, {
+        file       : 'examples_dist_esm.json',
+        devIndexUrl: 'dist/esm/apps/devindex/index.html',
+        dockDemoUrl: 'dist/esm/apps/agentos/childapps/dockdemo/index.html'
+    }, {
+        file       : 'examples_dist_prod.json',
+        devIndexUrl: 'dist/production/apps/devindex/index.html',
+        dockDemoUrl: 'dist/production/apps/agentos/childapps/dockdemo/index.html'
+    }];
 
 /**
  * The examples tab routes resolve `activeIndex` through the controller's `tabItems` array.
@@ -92,26 +110,52 @@ test.describe('Portal.view.examples.TabContainerController — route → activeI
         controller.destroy()
     });
 
-    test('release-gates DockDemo while retaining the visible DevIndex flagship card', () => {
-        const registries = [{
-            file       : 'examples_devmode.json',
-            devIndexUrl: 'apps/devindex/index.html',
-            dockDemoUrl: 'apps/agentos/childapps/dockdemo/index.html'
-        }, {
-            file       : 'examples_dist_dev.json',
-            devIndexUrl: 'dist/development/apps/devindex/index.html',
-            dockDemoUrl: 'dist/development/apps/agentos/childapps/dockdemo/index.html'
-        }, {
-            file       : 'examples_dist_esm.json',
-            devIndexUrl: 'dist/esm/apps/devindex/index.html',
-            dockDemoUrl: 'dist/esm/apps/agentos/childapps/dockdemo/index.html'
-        }, {
-            file       : 'examples_dist_prod.json',
-            devIndexUrl: 'dist/production/apps/devindex/index.html',
-            dockDemoUrl: 'dist/production/apps/agentos/childapps/dockdemo/index.html'
-        }];
+    test('keeps real example-registry ids unique without aligning environment-local numbering', () => {
+        // These four tracked files are the build authority. `dist/**` copies are ignored generated
+        // output and do not exist in a fresh checkout, so they are verified through the owning build
+        // receipt rather than a conditional unit arm that would pass vacuously when they are absent.
+        const registries = Object.fromEntries(registryConfigs.map(({file}) => [
+            file,
+            JSON.parse(fs.readFileSync(path.join(dataRoot, file), 'utf8'))
+        ]));
 
-        registries.forEach(({file, devIndexUrl, dockDemoUrl}) => {
+        Object.entries(registries).forEach(([file, records]) => {
+            const ids = records.map(record => record.id);
+
+            expect(new Set(ids).size, `${file}: every record id is unique`).toBe(ids.length)
+        });
+
+        // Cross-file id equality is deliberately NOT an invariant. Pin the three clean siblings so
+        // this one-file repair cannot drift into "aligning" their environment-local ids.
+        expect(Object.fromEntries(Object.entries(registries).map(([file, records]) => [
+            file,
+            records.find(record => record.name === 'Calendar')?.id
+        ]))).toEqual({
+            'examples_devmode.json'  : 22,
+            'examples_dist_dev.json' : 22,
+            'examples_dist_esm.json' : 21,
+            'examples_dist_prod.json': 26
+        });
+
+        const productionIds = registries['examples_dist_prod.json']
+            .map(record => record.id)
+            .sort((a, b) => a - b);
+
+        expect(productionIds, 'dist/prod keeps the shift-created 1–28 sequence contiguous')
+            .toEqual(Array.from({length: 28}, (unused, index) => index + 1));
+
+        const productionStore = Neo.create(ExamplesStore, {
+            data: registries['examples_dist_prod.json']
+        });
+
+        expect(productionStore.count, 'all 28 shipped rows survive the keyed Store load').toBe(28);
+        expect(productionStore.get(26)?.name, 'Calendar remains reachable by its repaired id').toBe('Calendar');
+
+        productionStore.destroy()
+    });
+
+    test('release-gates DockDemo while retaining the visible DevIndex flagship card', () => {
+        registryConfigs.forEach(({file, devIndexUrl, dockDemoUrl}) => {
             const
                 records   = JSON.parse(fs.readFileSync(path.join(dataRoot, file), 'utf8')),
                 dockDemo  = records.find(record => record.name === 'Dock Layouts'),


### PR DESCRIPTION
Resolves #17438

Evidence: L2 (real tracked registries, real `Portal.store.Examples` load, mutation-sensitive controls, and all three owning builds) → L2 required (static shipped-data repair; no live-only AC). No residual.

Release-note disposition: **include in v13.2** — the production examples registry again retains and exposes the Calendar card; the duplicate key previously dropped it during Store load.

## Deltas

- Changes only Calendar's `examples_dist_prod.json` id from the duplicated `22` to the shift-created hole `26`. Buffered Data Grid keeps 22; the resulting dist/prod sequence is contiguous 1–28.
- The three sibling registries remain environment-local authorities, not ids to align: Calendar stays 22 / 22 / 21 in devmode / dist-dev / dist-ESM.
- The ticket's initial built-copy requirement was retracted after V-B-A: `/dist` is ignored and untracked, and the observed copies were stale generated output. The guard therefore reads the four tracked source registries; official builds provide the non-vacuous generated-output receipt.
- The new identity guard owns only the four tracked registry filenames. The pre-existing DockDemo config matrix remains local to its retiring release-gating test; this PR does not promote the `apps/agentos/childapps/dockdemo` path into shared authority. Its relocation is owned by `#16322`.

## Test Evidence

- **RED before data change:** focused suite failed only the new guard: `examples_dist_prod.json` expected 28 unique ids, received 27; the other four tests passed.
- **Mutation diagonal:** changing repaired Calendar `26 → 29` keeps uniqueness but reddens the environment-local-id/contiguity arm; restored 26.
- **Final focused after current-`dev` rebase:** `npm run test-unit -- test/playwright/unit/apps/portal/view/examples/TabContainerController.spec.mjs` — 5/5 passed.
- **Real Store outcome:** all 28 dist/prod rows survive `Portal.store.Examples`, and `store.get(26).name === 'Calendar'`.
- **Generated outputs:** official development app-worker build, production app-worker build, and `npm run build-dist-esm` all exited 0. Each generated registry reports `{total:28, unique:28, calendar:26, contiguous:true, semanticEqual:true}` against the tracked source.
- **Full unit run:** 14,336 passed, 31 failed, 11 skipped, 39 did not run. Every failure is outside the changed Portal/data surface and belongs to the known host-capability/state set on this sandboxed seat (`EPERM` on canonical `.neo-ai-data`, Docker/deploy shell probes, Neural Link health, and whole-tree diagnostics reading machine-local backup state); the focused changed surface is green.
- `npm run check-examples-body-only` — PASS.
- Staged `npm run agent-preflight` and commit hooks — PASS; only the known non-blocking local AiConfig overlay warning remains.

## Post-Merge Validation

None gating. The three generated environments are causally derived from the tracked registry and were regenerated through their owning builds at this exact implementation state; generated `/dist` remains intentionally absent from the PR diff.

## Decision Record impact

`none` — this restores one existing registry identity and adds a regression guard; no architectural decision changes.

## Evolution

The important correction was establishing artifact status before assigning meaning to a census. A real duplicate in an ignored, stale build tree did not prove a shipped surface or a valid CI input. The tracked source registry is the authority; generated copies are evidence only after the owning build has recreated them from that source.

Authored by Emmy (GPT-5.6 Sol Ultra, Codex). Session fc673aab-2ed6-4592-9cb6-8da7588720ed.
