### PR TITLE
fix(ai): the Residual-Owner gate reads the ticket, not just the reference (#17314)

### DIFF
--- a/ai/scripts/agent-preflight.mjs
+++ b/ai/scripts/agent-preflight.mjs
@@ -385,15 +385,60 @@ function firstLiveObligation(section = '') {
     return line ? line.trim() : null
 }
 
+// The ONE signal separating "the cited ticket is not there" from "we could not look": `gh` exits 1
+// for both, so the exit code decides nothing. This repo has been bitten from the other side —
+// `gh pr checks` exits 1 for a failing check AND for an unreachable API, which read a 503 as a red
+// board. Only a 404 is an answer about the TICKET; everything else is an answer about the
+// TRANSPORT, and a gate must never convert one into the other.
+const GH_NOT_FOUND_PATTERN = /\(HTTP 404\)/;
+
+/**
+ * @summary Reads a cited issue's LIVE state, or reports that it could not be read.
+ *
+ * Three readings and one honest non-reading: `open`, `closed` and `missing` (the 404 above) are
+ * answers about the ticket; `unknown` is the absence of an answer. Callers must treat `unknown` as
+ * NOT CHECKED — never as a pass, never as a failure. An offline author, an expired token, a rate
+ * limit and an outage all land there, and none of them is evidence about the ticket.
+ *
+ * `gh` resolves `{owner}`/`{repo}` from the working directory's remote, which works from a linked
+ * worktree as well as from the clone.
+ * @param {Number|String} number Issue number, already extracted from the declaration.
+ * @param {Object} [options]
+ * @param {String} [options.cwd=process.cwd()]
+ * @param {Function} [options.execFileSyncImpl=execFileSync]
+ * @returns {'open'|'closed'|'missing'|'unknown'}
+ */
+export function resolveIssueState(number, {cwd = process.cwd(), execFileSyncImpl = execFileSync} = {}) {
+    try {
+        const state = String(execFileSyncImpl(
+            'gh',
+            ['api', `repos/{owner}/{repo}/issues/${number}`, '--jq', '.state'],
+            {cwd, encoding: 'utf8', stdio: 'pipe'}
+        )).trim();
+
+        // An unrecognised body is not a reading either: a changed API shape must not decide a gate.
+        return state === 'open' || state === 'closed' ? state : 'unknown'
+    } catch (error) {
+        return GH_NOT_FOUND_PATTERN.test(String(error?.stderr ?? '')) ? 'missing' : 'unknown'
+    }
+}
+
 /**
  * @summary Mirrors the Agent PR Body Lint workflow's local body-shape checks.
+ *
+ * `resolveOwnerState` is INJECTED and absent by default, so the validator stays pure, synchronous
+ * and offline — `npm run agent-preflight` is the author's own pre-flight and its value is that it
+ * runs anywhere. Supplied, it turns the `Residual-Owner` check from a shape check into a state
+ * check: a closed or missing owner fails, and an unreadable one produces a WARNING and no verdict.
  * @param {String} body
  * @param {Object} [options]
  * @param {Boolean} [options.draft=false]
- * @returns {Object}
+ * @param {Function|null} [options.resolveOwnerState=null] `(number) => 'open'|'closed'|'missing'|'unknown'`.
+ * @returns {{missingInvisible: String[], missingVisible: String[], valid: Boolean, warnings: String[]}}
  */
-export function validatePrBody(body, {draft = false} = {}) {
+export function validatePrBody(body, {draft = false, resolveOwnerState = null} = {}) {
     const
+        warnings               = [],
         missingVisible         = VISIBLE_PR_BODY_ANCHORS.filter(anchor => !body.includes(anchor)),
         missingInvisible       = INVISIBLE_PR_BODY_ANCHORS.filter(anchor => !body.includes(anchor)),
         forbiddenClose         = body.match(FORBIDDEN_CLOSE_PATTERN),
@@ -460,13 +505,33 @@ export function validatePrBody(body, {draft = false} = {}) {
             missingVisible.push(`This PR still owes work — "${obligation}" — with no \`Residual-Owner: #N\`. Finish it before merge, or name an EXISTING open ticket that owns it, or drop the obligation. Do not open a ticket to satisfy this.`)
         } else if (owner === closeTarget) {
             missingVisible.push(`\`Residual-Owner: #${owner}\` is this PR's own close target, so the owner disappears when the merge closes it. Name an EXISTING open ticket, or finish the work, or drop it.`)
+        } else if (resolveOwnerState) {
+            // The close-target rule above is already a SURVIVABILITY rule — a home that will not
+            // outlive the merge is refused. A ticket that closed BEFORE the citation fails that
+            // requirement more completely: the close target at least survives until merge. The
+            // pattern `#(\d+)` cannot see the difference, so a well-formed reference was read as a
+            // live one, and this is the read that separates them.
+            const state = resolveOwnerState(owner);
+
+            if (state === 'closed') {
+                missingVisible.push(`\`Residual-Owner: #${owner}\` is CLOSED. Deferred work must name a home that survives the merge. Finish it, drop the obligation, or name an OPEN ticket. Do not open a ticket to satisfy this.`)
+            } else if (state === 'missing') {
+                missingVisible.push(`\`Residual-Owner: #${owner}\` does not exist. Name an EXISTING open ticket that owns the work, finish it, or drop the obligation. Do not open a ticket to satisfy this.`)
+            } else if (state !== 'open') {
+                // Could-not-verify is not did-not-happen. An offline run, an expired token, a rate
+                // limit and an outage are all facts about the transport, and a gate that turns one
+                // into a verdict manufactures the diagnosis. Neither a pass nor a failure: the
+                // author is told which check did not run, so silence never reads as clearance.
+                warnings.push(`\`Residual-Owner: #${owner}\` was NOT state-checked — GitHub could not be read. The owner's shape is valid; whether it is still open is unverified.`)
+            }
         }
     }
 
     return {
         missingInvisible,
         missingVisible,
-        valid: missingVisible.length === 0 && missingInvisible.length === 0
+        valid: missingVisible.length === 0 && missingInvisible.length === 0,
+        warnings
     }
 }
 
@@ -712,18 +777,26 @@ function runNodeGate({args, cwd, execFileSyncImpl, name}) {
     }
 }
 
-function runPrBodyGate({cwd, existsSyncImpl, prBody, prDraft, readFileSyncImpl}) {
+function runPrBodyGate({cwd, execFileSyncImpl, existsSyncImpl, prBody, prDraft, readFileSyncImpl}) {
     const filePath = path.resolve(cwd, prBody);
 
     if (!existsSyncImpl(filePath)) {
         return {
             missingInvisible: [],
             missingVisible  : [`PR body file not found: ${prBody}`],
-            valid           : false
+            valid           : false,
+            warnings        : []
         }
     }
 
-    return validatePrBody(readFileSyncImpl(filePath, 'utf8'), {draft: prDraft})
+    return validatePrBody(readFileSyncImpl(filePath, 'utf8'), {
+        draft: prDraft,
+        // Wired unconditionally rather than behind a flag: the read only happens when a body
+        // actually declares a `Residual-Owner`, which is rare, and every failure of it degrades to
+        // `unknown` rather than to a verdict. So the gate is never network-DEPENDENT — it is
+        // network-INFORMED when it can be, and says so when it cannot.
+        resolveOwnerState: owner => resolveIssueState(owner, {cwd, execFileSyncImpl})
+    })
 }
 
 /**
@@ -851,11 +924,17 @@ export function runAgentPreflight({
     if (options.prBody) {
         const result = runPrBodyGate({
             cwd,
+            execFileSyncImpl,
             existsSyncImpl,
             prBody : options.prBody,
             prDraft: options.prDraft,
             readFileSyncImpl
         });
+
+        // Printed on BOTH paths and before the verdict: a check that did not run is news whether or
+        // not the rest passed, and burying it under a green line is how "not checked" becomes
+        // indistinguishable from "checked and fine".
+        result.warnings?.forEach(warning => writeLine(stderr, `agent-preflight: WARNING — ${warning}`));
 
         if (result.valid) {
             writeLine(stdout, 'agent-preflight: PR body contains the required template anchors.');

--- a/ai/scripts/agent-preflight.mjs
+++ b/ai/scripts/agent-preflight.mjs
@@ -393,12 +393,28 @@ function firstLiveObligation(section = '') {
 const GH_NOT_FOUND_PATTERN = /\(HTTP 404\)/;
 
 /**
- * @summary Reads a cited issue's LIVE state, or reports that it could not be read.
+ * @summary Hard deadline on the live read.
+ *
+ * The local preflight must not become network-DEPENDENT, and correct failure classification after an
+ * unbounded call does not achieve that: an offline author with a hanging resolver blocks before the
+ * graceful-degradation branch is ever reached. The bound is what makes `unknown` reachable in the
+ * case that needs it most. Short on purpose — this is one cheap metadata read, not a fetch.
+ * @type {Number}
+ */
+const GH_PROBE_TIMEOUT_MS = 5000;
+
+/**
+ * @summary Reads a cited issue's LIVE state and ENTITY KIND, or reports that it could not be read.
  *
  * Three readings and one honest non-reading: `open`, `closed` and `missing` (the 404 above) are
  * answers about the ticket; `unknown` is the absence of an answer. Callers must treat `unknown` as
  * NOT CHECKED — never as a pass, never as a failure. An offline author, an expired token, a rate
- * limit and an outage all land there, and none of them is evidence about the ticket.
+ * limit, a timeout and an outage all land there, and none of them is evidence about the ticket.
+ *
+ * **`isPullRequest` is carried rather than collapsed.** A pull request IS an issue to the REST API
+ * and reports `state: open` exactly like a ticket; only the `pull_request` key separates them, and a
+ * `--jq .state` projection throws that key away. Reducing two facts to one string here would hand
+ * the caller a reading it cannot un-collapse — the precise failure this gate exists to remove.
  *
  * `gh` resolves `{owner}`/`{repo}` from the working directory's remote, which works from a linked
  * worktree as well as from the clone.
@@ -406,21 +422,67 @@ const GH_NOT_FOUND_PATTERN = /\(HTTP 404\)/;
  * @param {Object} [options]
  * @param {String} [options.cwd=process.cwd()]
  * @param {Function} [options.execFileSyncImpl=execFileSync]
- * @returns {'open'|'closed'|'missing'|'unknown'}
+ * @param {Number} [options.timeoutMs=GH_PROBE_TIMEOUT_MS]
+ * @returns {{isPullRequest: Boolean, state: 'open'|'closed'|'missing'|'unknown'}}
  */
-export function resolveIssueState(number, {cwd = process.cwd(), execFileSyncImpl = execFileSync} = {}) {
+export function resolveIssueState(number, {
+    cwd              = process.cwd(),
+    execFileSyncImpl = execFileSync,
+    timeoutMs        = GH_PROBE_TIMEOUT_MS
+} = {}) {
+    const unreadable = {isPullRequest: false, state: 'unknown'};
+
     try {
-        const state = String(execFileSyncImpl(
+        const raw = String(execFileSyncImpl(
             'gh',
-            ['api', `repos/{owner}/{repo}/issues/${number}`, '--jq', '.state'],
-            {cwd, encoding: 'utf8', stdio: 'pipe'}
+            ['api', `repos/{owner}/{repo}/issues/${number}`, '--jq', '{state, isPullRequest: has("pull_request")}'],
+            {cwd, encoding: 'utf8', stdio: 'pipe', timeout: timeoutMs}
         )).trim();
 
+        const parsed = JSON.parse(raw);
+
         // An unrecognised body is not a reading either: a changed API shape must not decide a gate.
-        return state === 'open' || state === 'closed' ? state : 'unknown'
+        return parsed?.state === 'open' || parsed?.state === 'closed'
+            ? {isPullRequest: parsed.isPullRequest === true, state: parsed.state}
+            : unreadable
     } catch (error) {
-        return GH_NOT_FOUND_PATTERN.test(String(error?.stderr ?? '')) ? 'missing' : 'unknown'
+        // A timeout kill and a 404 both surface here. Only the 404 says anything about the ticket.
+        return GH_NOT_FOUND_PATTERN.test(String(error?.stderr ?? ''))
+            ? {isPullRequest: false, state: 'missing'}
+            : unreadable
     }
+}
+
+/**
+ * @summary Every owner number a body DECLARES, across all owing units.
+ *
+ * The shape check upstream deliberately reports on ONE section — the first unowned one, so its
+ * message names genuinely orphaned work. The state check must not inherit that selection: a body
+ * whose first owing section is correctly owned and whose second names a closed ticket would
+ * otherwise never have the second owner read.
+ *
+ * Inline code is blanked for the same reason it is upstream: a backticked `Residual-Owner: #200`
+ * documents the spelling rather than declaring an owner.
+ * @param {Object} options
+ * @param {String} options.fenceless Body with fences and HTML comments removed.
+ * @param {String[]} options.owingSections Post-Merge Validation sections that still owe work.
+ * @returns {String[]} Declared owner numbers, in body order, duplicates included.
+ * @private
+ */
+function collectDeclaredResidualOwners({fenceless, owingSections}) {
+    const owners = [];
+
+    owingSections.forEach(section => {
+        const match = withoutInlineCode(section).match(RESIDUAL_OWNER_LINE_PATTERN);
+
+        match && owners.push(match[1])
+    });
+
+    const inline = withoutInlineCode(fenceless).match(RESIDUAL_OWNER_INLINE_PATTERN);
+
+    inline && owners.push(inline[1]);
+
+    return owners
 }
 
 /**
@@ -505,25 +567,46 @@ export function validatePrBody(body, {draft = false, resolveOwnerState = null} =
             missingVisible.push(`This PR still owes work — "${obligation}" — with no \`Residual-Owner: #N\`. Finish it before merge, or name an EXISTING open ticket that owns it, or drop the obligation. Do not open a ticket to satisfy this.`)
         } else if (owner === closeTarget) {
             missingVisible.push(`\`Residual-Owner: #${owner}\` is this PR's own close target, so the owner disappears when the merge closes it. Name an EXISTING open ticket, or finish the work, or drop it.`)
-        } else if (resolveOwnerState) {
-            // The close-target rule above is already a SURVIVABILITY rule — a home that will not
-            // outlive the merge is refused. A ticket that closed BEFORE the citation fails that
-            // requirement more completely: the close target at least survives until merge. The
-            // pattern `#(\d+)` cannot see the difference, so a well-formed reference was read as a
-            // live one, and this is the read that separates them.
-            const state = resolveOwnerState(owner);
+        }
 
-            if (state === 'closed') {
-                missingVisible.push(`\`Residual-Owner: #${owner}\` is CLOSED. Deferred work must name a home that survives the merge. Finish it, drop the obligation, or name an OPEN ticket. Do not open a ticket to satisfy this.`)
-            } else if (state === 'missing') {
-                missingVisible.push(`\`Residual-Owner: #${owner}\` does not exist. Name an EXISTING open ticket that owns the work, finish it, or drop the obligation. Do not open a ticket to satisfy this.`)
-            } else if (state !== 'open') {
-                // Could-not-verify is not did-not-happen. An offline run, an expired token, a rate
-                // limit and an outage are all facts about the transport, and a gate that turns one
-                // into a verdict manufactures the diagnosis. Neither a pass nor a failure: the
-                // author is told which check did not run, so silence never reads as clearance.
-                warnings.push(`\`Residual-Owner: #${owner}\` was NOT state-checked — GitHub could not be read. The owner's shape is valid; whether it is still open is unverified.`)
-            }
+        // EVERY declared owner is state-checked, not the one section selected above for SHAPE
+        // reporting. That selection is deliberately biased toward the first UNOWNED section so the
+        // message names genuinely orphaned work — which means a body whose first owing section is
+        // correctly owned and whose second names a closed ticket would never have reached the read.
+        // The surrounding code already learned this once for the missing-owner case; the state check
+        // reintroduced the single-representative shape one dimension along.
+        if (resolveOwnerState) {
+            const
+                declared = collectDeclaredResidualOwners({fenceless, owingSections}),
+                // Deduplicated so one repeated owner costs one network read, and sorted so the
+                // failure order is the body's order rather than a Set's insertion accident.
+                unique   = [...new Set(declared)].filter(number => number !== closeTarget);
+
+            unique.forEach(number => {
+                // The close-target rule above is already a SURVIVABILITY rule — a home that will not
+                // outlive the merge is refused. A ticket that closed BEFORE the citation fails that
+                // requirement more completely: the close target at least survives until merge. The
+                // pattern `#(\d+)` cannot see the difference, and this is the read that separates them.
+                const {isPullRequest, state} = resolveOwnerState(number) ?? {};
+
+                if (state === 'closed') {
+                    missingVisible.push(`\`Residual-Owner: #${number}\` is CLOSED. Deferred work must name a home that survives the merge. Finish it, drop the obligation, or name an OPEN ticket. Do not open a ticket to satisfy this.`)
+                } else if (state === 'missing') {
+                    missingVisible.push(`\`Residual-Owner: #${number}\` does not exist. Name an EXISTING open ticket that owns the work, finish it, or drop the obligation. Do not open a ticket to satisfy this.`)
+                } else if (state === 'open' && isPullRequest) {
+                    // A pull request IS an issue to the REST API and reports `state: open` exactly
+                    // like a ticket. It is a WORSE owner than a closed one: it disappears by design,
+                    // on merge, and takes the deferral with it. Collapsing the two to the string
+                    // `open` is the same conflation this gate exists to remove.
+                    missingVisible.push(`\`Residual-Owner: #${number}\` is a PULL REQUEST, not a ticket. It closes when it merges, so the deferral dies with it. Name an EXISTING open ISSUE that owns the work, finish it, or drop the obligation.`)
+                } else if (state !== 'open') {
+                    // Could-not-verify is not did-not-happen. An offline run, an expired token, a rate
+                    // limit and an outage are all facts about the transport, and a gate that turns one
+                    // into a verdict manufactures the diagnosis. Neither a pass nor a failure: the
+                    // author is told which check did not run, so silence never reads as clearance.
+                    warnings.push(`\`Residual-Owner: #${number}\` was NOT state-checked — GitHub could not be read. The owner's shape is valid; whether it is still an open ticket is unverified.`)
+                }
+            })
         }
     }
 

--- a/ai/scripts/agent-preflight.mjs
+++ b/ai/scripts/agent-preflight.mjs
@@ -563,26 +563,30 @@ export function validatePrBody(body, {draft = false, resolveOwnerState = null} =
             closeTarget   = resolvesMatch ? resolvesMatch[0].match(/\d+/)[0] : null,
             owner         = ownerMatch ? ownerMatch[1] : null;
 
+        // EVERY declared owner is judged, not the one section selected above for SHAPE reporting.
+        // That selection is deliberately biased toward the first UNOWNED section so its message names
+        // genuinely orphaned work — which means a body whose first owing section is correctly owned
+        // and whose second names a closed ticket, or its own close target, would never have been
+        // judged at all. The surrounding code already learned this once for the missing-owner case;
+        // both the close-target rule and the state check had reintroduced the single-representative
+        // shape one dimension along. Deduplicated, so a repeated owner costs one message and one read.
+        const declaredOwners = [...new Set(collectDeclaredResidualOwners({fenceless, owingSections}))];
+
         if (!owner) {
             missingVisible.push(`This PR still owes work — "${obligation}" — with no \`Residual-Owner: #N\`. Finish it before merge, or name an EXISTING open ticket that owns it, or drop the obligation. Do not open a ticket to satisfy this.`)
-        } else if (owner === closeTarget) {
-            missingVisible.push(`\`Residual-Owner: #${owner}\` is this PR's own close target, so the owner disappears when the merge closes it. Name an EXISTING open ticket, or finish the work, or drop it.`)
         }
 
-        // EVERY declared owner is state-checked, not the one section selected above for SHAPE
-        // reporting. That selection is deliberately biased toward the first UNOWNED section so the
-        // message names genuinely orphaned work — which means a body whose first owing section is
-        // correctly owned and whose second names a closed ticket would never have reached the read.
-        // The surrounding code already learned this once for the missing-owner case; the state check
-        // reintroduced the single-representative shape one dimension along.
-        if (resolveOwnerState) {
-            const
-                declared = collectDeclaredResidualOwners({fenceless, owingSections}),
-                // Deduplicated so one repeated owner costs one network read, and sorted so the
-                // failure order is the body's order rather than a Set's insertion accident.
-                unique   = [...new Set(declared)].filter(number => number !== closeTarget);
+        // Close-target FIRST, and outside the resolver gate: it is a pure comparison between two
+        // values the body already carries, it must hold with no network at all, and its message says
+        // something no state read can — that the owner dies BECAUSE of this merge. A later section
+        // parking work on the close target is the case that slipped: the single-owner check could not
+        // see it, and the state loop below then filtered it out as "not to be read".
+        declaredOwners.filter(number => number === closeTarget).forEach(number => {
+            missingVisible.push(`\`Residual-Owner: #${number}\` is this PR's own close target, so the owner disappears when the merge closes it. Name an EXISTING open ticket, or finish the work, or drop it.`)
+        });
 
-            unique.forEach(number => {
+        if (resolveOwnerState) {
+            declaredOwners.filter(number => number !== closeTarget).forEach(number => {
                 // The close-target rule above is already a SURVIVABILITY rule — a home that will not
                 // outlive the merge is refused. A ticket that closed BEFORE the citation fails that
                 // requirement more completely: the close target at least survives until merge. The

--- a/test/playwright/unit/ai/scripts/agent-preflight.residualOwner.spec.mjs
+++ b/test/playwright/unit/ai/scripts/agent-preflight.residualOwner.spec.mjs
@@ -471,8 +471,10 @@ test.describe('validatePrBody — Residual-Owner STATE gate (#17314)', () => {
     });
 
     test('RED-PROOF: the PR #17308 incident fails now and passed silently before', () => {
-        // The specimen. `Residual-Owner: #17271` was set at 18:04 on 2026-08-17; #17271 had closed at
-        // 17:55:42Z — eight minutes earlier — and `lint-pr-body` passed the line.
+        // The specimen, and the number IS the fixture: an owner set at 18:04 on 2026-08-17 against a
+        // ticket that had closed at 17:55:42Z, eight minutes earlier, which `lint-pr-body` passed.
+        // ticket-ref-ok: the arm reproduces one dated incident; an anonymised number would make it a
+        // generic closed-owner case and lose the only evidence that this gate ever let one through.
         const body = owned(17271);
 
         // Pre-fix behaviour is still reachable, and is exactly what shipped: no resolver, shape only.

--- a/test/playwright/unit/ai/scripts/agent-preflight.residualOwner.spec.mjs
+++ b/test/playwright/unit/ai/scripts/agent-preflight.residualOwner.spec.mjs
@@ -1,5 +1,5 @@
-import {expect, test}   from '@playwright/test';
-import {validatePrBody} from '../../../../../ai/scripts/agent-preflight.mjs';
+import {expect, test}                      from '@playwright/test';
+import {resolveIssueState, validatePrBody} from '../../../../../ai/scripts/agent-preflight.mjs';
 
 /**
  * Deferred work must name a home that SURVIVES the merge.
@@ -395,5 +395,165 @@ test.describe('validatePrBody — Residual-Owner gate (#16906)', () => {
         ].join('\n');
 
         expect(residualFindings(ownerInWrongSection)).toHaveLength(1);
+    });
+});
+
+/**
+ * The gate was careful in every dimension except EXISTENCE.
+ *
+ * `#(\d+)` validates that a reference is well-FORMED and treats well-formed as ALIVE. The
+ * close-target rule beside it is already a survivability rule — a home that will not outlive the
+ * merge is refused — and a ticket that closed BEFORE the citation fails that requirement more
+ * completely, since a close target at least survives until merge.
+ *
+ * Every arm injects its resolver. A spec that reached live GitHub would be measuring the network.
+ */
+test.describe('validatePrBody — Residual-Owner STATE gate (#17314)', () => {
+    const owed  = section => withPmv(section),
+          owned = number => owed(`- [ ] run the container exit check\nResidual-Owner: #${number}`),
+          check = (body, state) => validatePrBody(body, {resolveOwnerState: () => state});
+
+    test('a CLOSED owner fails, and the message names the state it found', () => {
+        const result = check(owned(17271), 'closed');
+
+        expect(result.valid).toBe(false);
+        expect(result.missingVisible.some(entry => /`Residual-Owner: #17271` is CLOSED/.test(entry))).toBe(true);
+        // The existing messages prescribe a remedy rather than only reporting, and this one must not
+        // create pressure to mint an owner — the whole point is that the work already has a home.
+        expect(result.missingVisible.some(entry => /Do not open a ticket to satisfy this/.test(entry))).toBe(true);
+        expect(result.warnings).toEqual([]);
+    });
+
+    test('a NONEXISTENT owner fails', () => {
+        const result = check(owned(99999999), 'missing');
+
+        expect(result.valid).toBe(false);
+        expect(result.missingVisible.some(entry => /`Residual-Owner: #99999999` does not exist/.test(entry))).toBe(true);
+    });
+
+    test('CONTROL: an OPEN owner passes, so the check cannot pass by refusing everything', () => {
+        const result = check(owned(200), 'open');
+
+        expect(result.valid).toBe(true);
+        expect(result.missingVisible).toEqual([]);
+        expect(result.warnings).toEqual([]);
+    });
+
+    test('an UNRESOLVABLE read neither fails the gate nor silently passes the owner', () => {
+        // Could-not-verify is not did-not-happen. An offline author, an expired token, a rate limit
+        // and an outage are facts about the transport; a gate that turns one into a verdict
+        // manufactures the diagnosis. Both halves are asserted, because either alone is a defect:
+        // failing would make an outage look like a bad body, and passing in silence would make
+        // "not checked" indistinguishable from "checked and fine".
+        const result = check(owned(200), 'unknown');
+
+        expect(result.valid).toBe(true);
+        expect(result.missingVisible).toEqual([]);
+        expect(result.warnings.some(entry => /#200` was NOT state-checked/.test(entry))).toBe(true);
+    });
+
+    test('the Evidence-ladder INLINE form gets the same treatment as the line form', () => {
+        // `evidence-ladder.md` prescribes a 1-line declaration whose owner is mid-line. It shares the
+        // blind spot, so it has to share the fix — otherwise the shape with the documented template
+        // behind it is the one that stays unchecked.
+        const inline = [
+            'Resolves #100', '',
+            'Evidence: L2 (unit) → L4 required (AC5 live plane). Residual: AC5 live-plane observation, Residual-Owner: #17271.', '',
+            '## Deltas', 'one file', '',
+            '## Test Evidence', 'green', '',
+            '## Post-Merge Validation', 'None deferred.', '',
+            'Authored by @neo-opus-ada'
+        ].join('\n');
+
+        expect(check(inline, 'closed').valid).toBe(false);
+        expect(check(inline, 'closed').missingVisible.some(entry => /#17271` is CLOSED/.test(entry))).toBe(true);
+        expect(check(inline, 'open').valid).toBe(true);
+    });
+
+    test('RED-PROOF: the PR #17308 incident fails now and passed silently before', () => {
+        // The specimen. `Residual-Owner: #17271` was set at 18:04 on 2026-08-17; #17271 had closed at
+        // 17:55:42Z — eight minutes earlier — and `lint-pr-body` passed the line.
+        const body = owned(17271);
+
+        // Pre-fix behaviour is still reachable, and is exactly what shipped: no resolver, shape only.
+        expect(validatePrBody(body).valid).toBe(true);
+        expect(validatePrBody(body).missingVisible).toEqual([]);
+
+        // With the state read, the same body is refused.
+        expect(check(body, 'closed').valid).toBe(false);
+    });
+
+    test('a closed owner that is ALSO the close target still reports the close-target rule', () => {
+        // Ordering, not redundancy: the close-target message tells the author something the state
+        // message does not — that the owner dies BECAUSE of this merge. Reporting "it is closed"
+        // there would send them to look at a ticket that is still open until they merge.
+        const body   = [base, '', '## Post-Merge Validation', '- [ ] work', 'Residual-Owner: #100'].join('\n'),
+              result = check(body, 'open');
+
+        expect(result.valid).toBe(false);
+        expect(result.missingVisible.some(entry => /is this PR's own close target/.test(entry))).toBe(true);
+        expect(result.missingVisible.some(entry => /is CLOSED/.test(entry))).toBe(false);
+    });
+
+    test('a body owing NOTHING never reaches the resolver', () => {
+        // The read is not free and must not fire on the overwhelming majority of PRs, which carry no
+        // residual at all. A spy proves it rather than a comment claiming it.
+        let calls = 0;
+
+        const result = validatePrBody(withPmv('- [x] already done'), {resolveOwnerState: () => { calls++; return 'closed' }});
+
+        expect(result.valid).toBe(true);
+        expect(calls).toBe(0);
+    });
+});
+
+/**
+ * `gh` exits 1 for a 404 AND for every transport failure, so the exit code decides nothing. Only the
+ * 404 is an answer about the ticket; everything else is an answer about the network.
+ */
+test.describe('resolveIssueState — a reading, or the honest absence of one (#17314)', () => {
+    const withExec = impl => resolveIssueState(200, {cwd: '/repo', execFileSyncImpl: impl}),
+          throwing = stderr => () => { const error = new Error('gh failed'); error.stderr = stderr; throw error };
+
+    test('reads open and closed', () => {
+        expect(withExec(() => 'open\n')).toBe('open');
+        expect(withExec(() => 'closed\n')).toBe('closed');
+    });
+
+    test('a 404 is a reading — the ticket is missing', () => {
+        expect(withExec(throwing('gh: Not Found (HTTP 404)\n'))).toBe('missing');
+    });
+
+    test('every other failure is NOT a reading', () => {
+        // CONTROL against the exit-code trap: these all exit 1 exactly like the 404 above, and a
+        // check keying on the exit code would call every one of them "missing" and fail the gate on
+        // an outage. `401` and `403` are the ones an author hits; `503` is the one CI hits.
+        expect(withExec(throwing('gh: Bad credentials (HTTP 401)\n'))).toBe('unknown');
+        expect(withExec(throwing('gh: Forbidden (HTTP 403)\n'))).toBe('unknown');
+        expect(withExec(throwing('gh: Service Unavailable (HTTP 503)\n'))).toBe('unknown');
+        expect(withExec(throwing('dial tcp: lookup api.github.com: no such host\n'))).toBe('unknown');
+        expect(withExec(throwing(undefined))).toBe('unknown');
+        expect(withExec(() => { throw new Error('spawn gh ENOENT') })).toBe('unknown');
+    });
+
+    test('an unrecognised payload is not a reading either', () => {
+        // A changed API shape must not decide a gate. Anything that is not exactly the two known
+        // states is an absence of information, not a third state.
+        expect(withExec(() => 'OPEN\n')).toBe('unknown');
+        expect(withExec(() => '')).toBe('unknown');
+        expect(withExec(() => 'null\n')).toBe('unknown');
+    });
+
+    test('the issue number reaches gh, and the repo is resolved from the working directory', () => {
+        let seen = null;
+
+        resolveIssueState(4242, {cwd: '/repo', execFileSyncImpl: (command, args, options) => {
+            seen = {args, command, cwd: options.cwd};
+            return 'open'
+        }});
+
+        expect(seen.command).toBe('gh');
+        expect(seen.args).toEqual(['api', 'repos/{owner}/{repo}/issues/4242', '--jq', '.state']);
+        expect(seen.cwd).toBe('/repo');
     });
 });

--- a/test/playwright/unit/ai/scripts/agent-preflight.residualOwner.spec.mjs
+++ b/test/playwright/unit/ai/scripts/agent-preflight.residualOwner.spec.mjs
@@ -411,7 +411,14 @@ test.describe('validatePrBody — Residual-Owner gate (#16906)', () => {
 test.describe('validatePrBody — Residual-Owner STATE gate (#17314)', () => {
     const owed  = section => withPmv(section),
           owned = number => owed(`- [ ] run the container exit check\nResidual-Owner: #${number}`),
-          check = (body, state) => validatePrBody(body, {resolveOwnerState: () => state});
+          // The resolver's contract is an OBJECT, not a string: a pull request reports `state: open`
+          // exactly like a ticket, and collapsing the two here would hand the gate a reading it
+          // cannot un-collapse. `ticket` and `pr` are the two shapes an `open` answer can have.
+          ticket = state => ({isPullRequest: false, state}),
+          pr     = state => ({isPullRequest: true,  state}),
+          check  = (body, state) => validatePrBody(body, {
+              resolveOwnerState: typeof state === 'string' ? () => ticket(state) : () => state
+          });
 
     test('a CLOSED owner fails, and the message names the state it found', () => {
         const result = check(owned(17271), 'closed');
@@ -497,12 +504,82 @@ test.describe('validatePrBody — Residual-Owner STATE gate (#17314)', () => {
         expect(result.missingVisible.some(entry => /is CLOSED/.test(entry))).toBe(false);
     });
 
+    test('RA-1: EVERY declared owner is state-checked, not the first section selected for shape', () => {
+        // The shape check is biased toward the first UNOWNED section so its message names genuinely
+        // orphaned work. Inheriting that selection meant a body whose first owing section is
+        // correctly owned and whose second names a closed ticket never had the second owner read —
+        // the single-representative defect the surrounding code already fixed once, one dimension
+        // along.
+        const inspected = [],
+              body      = [
+                  base, '',
+                  '## Post-Merge Validation', '- [ ] first piece', 'Residual-Owner: #201', '',
+                  '## Notes', 'unrelated', '',
+                  '## Post-Merge Validation', '- [ ] second piece', 'Residual-Owner: #202'
+              ].join('\n'),
+              result    = validatePrBody(body, {
+                  resolveOwnerState: number => {
+                      inspected.push(number);
+
+                      return number === '202' ? ticket('closed') : ticket('open')
+                  }
+              });
+
+        // The ledger proves BOTH were inspected — without it the arm passes on a gate that happened
+        // to select the closed one.
+        expect(inspected.sort()).toEqual(['201', '202']);
+        expect(result.valid).toBe(false);
+        expect(result.missingVisible.some(entry => /#202` is CLOSED/.test(entry))).toBe(true);
+        expect(result.missingVisible.some(entry => /#201/.test(entry))).toBe(false);
+    });
+
+    test('RA-1 CONTROL: a repeated owner costs ONE read, and the close target is never re-read', () => {
+        const inspected = [],
+              body      = [
+                  base, '',
+                  '## Post-Merge Validation', '- [ ] a', 'Residual-Owner: #201', '',
+                  '## Post-Merge Validation', '- [ ] b', 'Residual-Owner: #201'
+              ].join('\n');
+
+        validatePrBody(body, {resolveOwnerState: number => { inspected.push(number); return ticket('open') }});
+
+        expect(inspected).toEqual(['201']);
+
+        // The close target already has its own, better message — reading it again would replace
+        // "the owner dies BECAUSE of this merge" with "it is open", which is true and useless.
+        const onCloseTarget = [];
+
+        validatePrBody([base, '', '## Post-Merge Validation', '- [ ] a', 'Residual-Owner: #100'].join('\n'), {
+            resolveOwnerState: number => { onCloseTarget.push(number); return ticket('open') }
+        });
+
+        expect(onCloseTarget).toEqual([]);
+    });
+
+    test('RA-3: an OPEN pull request is refused — it dies by design, on merge', () => {
+        // A PR IS an issue to the REST API and reports `state: open` exactly like a ticket; only the
+        // `pull_request` key separates them. It is a WORSE owner than a closed ticket, because it
+        // takes the deferral with it when it merges.
+        const asPr = check(owned(17488), pr('open'));
+
+        expect(asPr.valid).toBe(false);
+        expect(asPr.missingVisible.some(entry => /is a PULL REQUEST, not a ticket/.test(entry))).toBe(true);
+
+        // CONTROL: the same number, same `open`, as an ISSUE — passes. Without this the arm above is
+        // satisfied by a gate that refuses every open owner.
+        expect(check(owned(17488), ticket('open')).valid).toBe(true);
+
+        // A CLOSED pull request keeps the closed message: the earlier failure is the more actionable
+        // one, and re-labelling it would send the author looking for a different problem.
+        expect(check(owned(17488), pr('closed')).missingVisible.some(entry => /is CLOSED/.test(entry))).toBe(true);
+    });
+
     test('a body owing NOTHING never reaches the resolver', () => {
         // The read is not free and must not fire on the overwhelming majority of PRs, which carry no
         // residual at all. A spy proves it rather than a comment claiming it.
         let calls = 0;
 
-        const result = validatePrBody(withPmv('- [x] already done'), {resolveOwnerState: () => { calls++; return 'closed' }});
+        const result = validatePrBody(withPmv('- [x] already done'), {resolveOwnerState: () => { calls++; return ticket('closed') }});
 
         expect(result.valid).toBe(true);
         expect(calls).toBe(0);
@@ -515,47 +592,98 @@ test.describe('validatePrBody — Residual-Owner STATE gate (#17314)', () => {
  */
 test.describe('resolveIssueState — a reading, or the honest absence of one (#17314)', () => {
     const withExec = impl => resolveIssueState(200, {cwd: '/repo', execFileSyncImpl: impl}),
+          json     = value => () => `${JSON.stringify(value)}\n`,
           throwing = stderr => () => { const error = new Error('gh failed'); error.stderr = stderr; throw error };
 
-    test('reads open and closed', () => {
-        expect(withExec(() => 'open\n')).toBe('open');
-        expect(withExec(() => 'closed\n')).toBe('closed');
+    test('reads open and closed, and carries the entity kind', () => {
+        expect(withExec(json({state: 'open',   isPullRequest: false}))).toEqual({isPullRequest: false, state: 'open'});
+        expect(withExec(json({state: 'closed', isPullRequest: false}))).toEqual({isPullRequest: false, state: 'closed'});
+
+        // The fact a `--jq .state` projection destroyed. An open PR and an open ticket are the same
+        // string and different answers.
+        expect(withExec(json({state: 'open', isPullRequest: true}))).toEqual({isPullRequest: true, state: 'open'});
     });
 
     test('a 404 is a reading — the ticket is missing', () => {
-        expect(withExec(throwing('gh: Not Found (HTTP 404)\n'))).toBe('missing');
+        expect(withExec(throwing('gh: Not Found (HTTP 404)\n'))).toEqual({isPullRequest: false, state: 'missing'});
     });
 
     test('every other failure is NOT a reading', () => {
         // CONTROL against the exit-code trap: these all exit 1 exactly like the 404 above, and a
         // check keying on the exit code would call every one of them "missing" and fail the gate on
         // an outage. `401` and `403` are the ones an author hits; `503` is the one CI hits.
-        expect(withExec(throwing('gh: Bad credentials (HTTP 401)\n'))).toBe('unknown');
-        expect(withExec(throwing('gh: Forbidden (HTTP 403)\n'))).toBe('unknown');
-        expect(withExec(throwing('gh: Service Unavailable (HTTP 503)\n'))).toBe('unknown');
-        expect(withExec(throwing('dial tcp: lookup api.github.com: no such host\n'))).toBe('unknown');
-        expect(withExec(throwing(undefined))).toBe('unknown');
-        expect(withExec(() => { throw new Error('spawn gh ENOENT') })).toBe('unknown');
+        for (const stderr of [
+            'gh: Bad credentials (HTTP 401)\n',
+            'gh: Forbidden (HTTP 403)\n',
+            'gh: Service Unavailable (HTTP 503)\n',
+            'dial tcp: lookup api.github.com: no such host\n',
+            undefined
+        ]) {
+            expect(withExec(throwing(stderr)).state).toBe('unknown');
+        }
+
+        expect(withExec(() => { throw new Error('spawn gh ENOENT') }).state).toBe('unknown');
+    });
+
+    test('RA-2: the read is DEADLINE-BOUNDED, and a timeout is not a reading', () => {
+        // Correct classification after an unbounded call is not offline safety: an author with a
+        // hanging resolver blocks before the graceful-degradation branch is ever reached. The bound
+        // is what makes `unknown` reachable in the case that needs it most.
+        let seen = null;
+
+        resolveIssueState(4242, {cwd: '/repo', execFileSyncImpl: (command, args, options) => {
+            seen = options;
+            return '{"state":"open","isPullRequest":false}'
+        }});
+
+        expect(Number.isFinite(seen.timeout)).toBe(true);
+        expect(seen.timeout).toBeGreaterThan(0);
+
+        // The kill signal `execFileSync` raises on timeout carries no `(HTTP 404)`, so it lands in
+        // `unknown` — asserted rather than assumed, because that is the branch an offline author hits.
+        const killed = () => {
+            const error = new Error('spawnSync gh ETIMEDOUT');
+            error.errno  = 'ETIMEDOUT';
+            error.signal = 'SIGTERM';
+            throw error
+        };
+
+        expect(withExec(killed)).toEqual({isPullRequest: false, state: 'unknown'});
+
+        // An explicit override is honoured, so a caller can tighten it.
+        let overridden = null;
+
+        resolveIssueState(1, {cwd: '/repo', timeoutMs: 250, execFileSyncImpl: (command, args, options) => {
+            overridden = options.timeout;
+            return '{"state":"open","isPullRequest":false}'
+        }});
+
+        expect(overridden).toBe(250);
     });
 
     test('an unrecognised payload is not a reading either', () => {
         // A changed API shape must not decide a gate. Anything that is not exactly the two known
         // states is an absence of information, not a third state.
-        expect(withExec(() => 'OPEN\n')).toBe('unknown');
-        expect(withExec(() => '')).toBe('unknown');
-        expect(withExec(() => 'null\n')).toBe('unknown');
+        expect(withExec(json({state: 'OPEN', isPullRequest: false})).state).toBe('unknown');
+        expect(withExec(() => '').state).toBe('unknown');
+        expect(withExec(() => 'null\n').state).toBe('unknown');
+        expect(withExec(() => 'not json at all').state).toBe('unknown');
     });
 
-    test('the issue number reaches gh, and the repo is resolved from the working directory', () => {
+    test('the issue number reaches gh, and the query preserves the entity kind', () => {
         let seen = null;
 
         resolveIssueState(4242, {cwd: '/repo', execFileSyncImpl: (command, args, options) => {
             seen = {args, command, cwd: options.cwd};
-            return 'open'
+            return '{"state":"open","isPullRequest":false}'
         }});
 
         expect(seen.command).toBe('gh');
-        expect(seen.args).toEqual(['api', 'repos/{owner}/{repo}/issues/4242', '--jq', '.state']);
+        expect(seen.args[0]).toBe('api');
+        expect(seen.args[1]).toBe('repos/{owner}/{repo}/issues/4242');
+        // The jq projection must keep `pull_request` reachable. `.state` alone is what collapsed the
+        // two entity kinds, so the projection itself is the contract worth pinning.
+        expect(seen.args[3]).toContain('has("pull_request")');
         expect(seen.cwd).toBe('/repo');
     });
 });

--- a/test/playwright/unit/ai/scripts/agent-preflight.residualOwner.spec.mjs
+++ b/test/playwright/unit/ai/scripts/agent-preflight.residualOwner.spec.mjs
@@ -556,6 +556,33 @@ test.describe('validatePrBody — Residual-Owner STATE gate (#17314)', () => {
         expect(onCloseTarget).toEqual([]);
     });
 
+    test('RA-1 carried: a LATER section parking work on the close target still gets the better message', () => {
+        // Emmy's carried falsifier. The close-target rule ran on the single selected owner, and the
+        // state loop then filtered the close target out as "not to be read" — so a second section
+        // parking work on the PR's own close target was judged by neither. Two single-representative
+        // defects covering for each other: fixing only the state loop left the hole open.
+        const inspected = [],
+              body      = [
+                  base, '',
+                  '## Post-Merge Validation', '- [ ] first piece', 'Residual-Owner: #201', '',
+                  '## Post-Merge Validation', '- [ ] second piece', 'Residual-Owner: #100'
+              ].join('\n'),
+              result    = validatePrBody(body, {
+                  resolveOwnerState: number => { inspected.push(number); return ticket('open') }
+              });
+
+        expect(result.valid).toBe(false);
+        expect(result.missingVisible.some(entry => /#100` is this PR's own close target/.test(entry))).toBe(true);
+
+        // The close target is judged WITHOUT a read: it is a pure comparison between two values the
+        // body already carries, and it must hold with no network at all.
+        expect(inspected).toEqual(['201']);
+
+        // CONTROL: the same rule with no resolver at all — the close-target failure must still fire,
+        // otherwise the pure half silently became network-dependent.
+        expect(validatePrBody(body).missingVisible.some(entry => /own close target/.test(entry))).toBe(true);
+    });
+
     test('RA-3: an OPEN pull request is refused — it dies by design, on merge', () => {
         // A PR IS an issue to the REST API and reports `state: open` exactly like a ticket; only the
         // `pull_request` key separates them. It is a WORSE owner than a closed ticket, because it


### PR DESCRIPTION
Resolves #17314

The validator is careful in every dimension except **existence**. It anchors the declaration to its own line so prose cannot discharge an obligation, blanks inline code so a backticked example is not a declaration, checks *every* owing section rather than the first, and refuses the close target because a home that does not outlive the merge is no home.

Then `#(\d+)` accepts any well-formed number as a live ticket.

Evidence: L2 required → **L2 achieved, no residual** (45 focused arms green, 129 across the preflight family; five mutation runs, one per claim; the resolver verified against live GitHub for all four readings).

## Round 2 — @neo-gpt-emmy found three false greens and a missing contract

**RA-1 — only ONE owner was state-checked.** The shape check deliberately selects the first UNOWNED section so its message names genuinely orphaned work; the state check inherited that selection. So a body whose first owing section is correctly owned and whose second names a closed ticket **never had the second owner read**. The surrounding code already learned this once for the missing-owner case — *"EVERY owing section is checked, not the first"* is a comment three lines above mine — and I reintroduced the single-representative shape one dimension along. Every declared owner is now collected and resolved, deduplicated, close target excluded, with a **call ledger** in the arm proving both were inspected rather than one happening to be the failing one.

**RA-2 — the read had no deadline.** Correct failure classification after an unbounded synchronous call is not offline safety: an author with a hanging resolver blocks *before* the graceful-degradation branch ever runs. 5 s, overridable, and the kill maps to `unknown` like every other transport fact. The arm asserts the execution option is finite, not just that a timeout classifies well.

**RA-3 — a pull request is an issue to the REST API.** Measured:

```
#17314 → {"isPullRequest":false,"state":"open"}    ← a ticket
#17488 → {"isPullRequest":true, "state":"open"}    ← this PR
```

Same string, different answers — and `--jq .state` threw away the key that separates them. **An open PR is a worse owner than a closed ticket**: it disappears by design, on merge, and takes the deferral with it. The resolver returns `{isPullRequest, state}` rather than collapsing two facts into one string, which is the same conflation this gate exists to remove.

**I had named this in Out of Scope and Emmy was right that it is not.** #17314's AC says an open **ticket** passes; a PR is not a ticket. Calling it a new failure mode was a scope argument standing in for a reading of the AC.

**RA-4 — Contract Ledger backfilled** on #17314: `resolveIssueState`'s state and entity vocabulary and its deadline, `validatePrBody`'s options and `warnings` return, owner cardinality, the PR rule, and the CLI's warning-on-both-paths behaviour. **The gate's own contract was asserted rather than recorded** — this ticket's shape, applied to the ticket.

## Deltas from ticket

**None on scope.** The ticket delegates one design decision explicitly — *"offline behaviour is the real design decision, and it belongs to the implementer with the constraint stated"* — and that is the whole of this section.

**The exit code decides nothing, so the check cannot key on it.** Measured:

```
$ gh api repos/neomjs/neo/issues/99999999 --jq .state   # exit 1 · gh: Not Found (HTTP 404)
$ GH_TOKEN=invalid gh api …/issues/17476 --jq .state     # exit 1 · gh: Bad credentials (HTTP 401)
```

Identical exit codes for *"the ticket is not there"* and *"we could not look"*. The ticket's own Avoided Traps record this repo being bitten from the other direction — `gh pr checks` exits 1 for a failing check **and** for an unreachable API, which read a 503 as a red board. So the discrimination is `(HTTP 404)` in stderr and nothing else:

| observed | verdict |
|---|---|
| `open` / `closed` | a reading |
| `(HTTP 404)` | a reading — the ticket is missing |
| 401, 403, 503, DNS failure, `spawn gh ENOENT`, a timeout kill, no stderr at all | **not a reading** |
| a payload that is neither `open` nor `closed` | **not a reading** — a changed API shape must not decide a gate |

**`unknown` is neither a pass nor a failure, and both halves matter.** Failing would convert an outage into a verdict about the body. Passing in silence would make *"not checked"* indistinguishable from *"checked and fine"* — which is the defect class this whole gate exists in. It emits a warning instead, printed on **both** the green and the red path, before the verdict line.

**The resolver is injected and absent by default**, so `validatePrBody` stays pure, synchronous and offline — `npm run agent-preflight` is the author's own pre-flight and its value is that it runs anywhere. Every existing spec is unchanged.

**No workflow change was needed, which I checked rather than assumed.** `agent-pr-body-lint.yml:67` already invokes `node ai/scripts/agent-preflight.mjs`, and its step already exports `GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}` for the body fetch. So CI gets the live read for free, and a local author without auth gets the warning. That asymmetry is the ticket's suggested shape, arrived at without a flag.

**Wired unconditionally rather than behind an opt-in.** The read only fires when a body actually declares a `Residual-Owner`, which is rare, and every failure of it degrades to `unknown`. The gate is therefore never network-*dependent* — it is network-*informed* when it can be, and says so when it cannot. An arm proves the no-obligation path never reaches the resolver, with a call counter rather than a comment.

## Test Evidence

**45 arms green** in the file, **129** across the preflight family. Sixteen new, in two describes:

| arm | pins |
|---|---|
| a CLOSED owner fails, naming the state | AC-1, plus that the message still says *"Do not open a ticket to satisfy this"* |
| a NONEXISTENT owner fails | AC-2 |
| **CONTROL:** an OPEN owner passes | AC-3 — the check cannot pass by refusing everything |
| an UNRESOLVABLE read neither fails nor silently passes | AC-5, both halves asserted |
| the Evidence-ladder INLINE form gets the same treatment | AC-4 |
| **RED-PROOF:** the PR #17308 incident | AC-6 — fails now, and `validatePrBody` without a resolver still passes it silently, which is exactly what shipped |
| a closed owner that is also the close target reports the close-target rule | ordering: that message says the owner dies *because of this merge*, which the state message does not |
| a body owing nothing never reaches the resolver | the read does not fire on the overwhelming majority of PRs |
| `resolveIssueState` reads open / closed | the two readings |
| a 404 is a reading | the one signal that means *missing* |
| every other failure is NOT a reading | 401 · 403 · 503 · DNS · `ENOENT` · absent stderr — **all exit 1 exactly like the 404** |
| an unrecognised payload is not a reading | `OPEN` · `''` · `null` |
| the issue number reaches `gh`, and the jq projection keeps `has("pull_request")` | the argv, so a silent argument change cannot pass |
| **RA-1:** every declared owner is state-checked | a call ledger proves both were read, not that one happened to fail |
| **RA-1 CONTROL:** a repeated owner costs one read; the close target is never re-read | the dedup, and that the better close-target message is not replaced by a worse true one |
| **RA-3:** an open PR is refused, an open ISSUE with the same number passes | the entity kind, asserted apart from the state |
| **RA-2:** the read is deadline-bounded, and a kill is not a reading | the execution option is finite, and an override is honoured |

**Five mutation runs, one per claim, each reddening exactly its own arm:**

| mutation | reddens |
|---|---|
| treat any `gh` failure as `missing` *(the exit-code trap)* | *"every other failure is NOT a reading"* |
| let `unknown` pass without a warning | *"neither fails the gate nor silently passes"* |
| check only the first owner **(RA-1)** | *"EVERY declared owner is state-checked"* |
| collapse the entity kind **(RA-3)** | *"an OPEN pull request is refused"* |
| drop the deadline **(RA-2)** | *"the read is DEADLINE-BOUNDED"* |

**Verified against live GitHub**, all four readings, from a linked worktree:

```
#17314    -> {"isPullRequest":false,"state":"open"}     an open TICKET
#17442    -> {"isPullRequest":false,"state":"closed"}   closed today
#17488    -> {"isPullRequest":true, "state":"open"}     this PR — same string, different answer
#99999999 -> {"isPullRequest":false,"state":"missing"}  404
```

## Post-Merge Validation

Any agent PR declaring a `Residual-Owner` gets the live read in CI from the next run. The observable change on a healthy body is **nothing** — which is the point; the gate only speaks when the owner is closed, missing, or unreadable.

## Out of Scope

- Validating `Resolves` / `Refs` / `Related` targets the same way — the ticket excludes it, and the blast radius is different.
- ~~A PR is also an issue to the REST API, so `Residual-Owner: #<a PR>` resolves and passes while open — a new failure mode rather than one of this ticket's ACs.~~ **Withdrawn in Round 2.** The AC says an open *ticket* passes; a PR is not a ticket. Struck rather than deleted, because the reasoning was a scope argument standing in for a reading of the AC, and that is the part worth seeing.
- Rate-limit strategy or response caching beyond what the ACs require.

## Evolution

**A gate that reads a shape and reports on a state is making a claim it never checked** — the same shape as a warning that promises a value survives while the function overwrites it, and as an admission gate proving a different artifact from the one its dependent runs. This is the third instance today, and the tell is identical each time: the check ran, so the claim was assumed.

Round 2 added the sharper one: **naming something out of scope is a claim about the ticket, and it needs the same reading as any other.** I wrote a paragraph explaining why the PR case was a new failure mode without re-reading the AC that says *open ticket*. A scope argument is the easiest place to be confidently wrong, because it looks like discipline.

The half worth keeping is the restraint. The obvious implementation keys on `gh`'s exit code, which is 1 for a missing ticket and 1 for an expired token — so the obvious implementation would fail every agent's gate during a GitHub outage, on bodies that are perfectly correct. **A gate must be able to say "I did not check" out loud**, or it will eventually say "correct" about something it never read.

Authored by Ada (Claude Opus 5, Claude Code). Session ab15d2b8-eb14-4237-ad18-ce48584b2d07.
