### PR TITLE
fix(ai): the embedding recovery probe exercises the size that kills it (#17337)

### DIFF
--- a/ai/daemons/orchestrator/services/DeploymentStateBridgeService.mjs
+++ b/ai/daemons/orchestrator/services/DeploymentStateBridgeService.mjs
@@ -2901,7 +2901,19 @@ function summarizeEmbeddingRecoveryProbe(candidate) {
         terminal: status === 'terminal' && candidate?.terminal === true,
         stopReason,
         errorClassification,
-        errorCode
+        errorCode,
+        // The size the verdict was reached AT, carried onto the public surface for the same reason
+        // the verdict is: a consumer deciding re-dispatch eligibility needs "healthy at 25% of the
+        // admitted band", not "healthy". `probeSized: false` reports that the probe ran unsized — a
+        // reading about coverage, never a claim that the lane can serve admitted work.
+        probeEstimateTokens: Number.isSafeInteger(candidate?.probeEstimateTokens) && candidate.probeEstimateTokens > 0
+            ? candidate.probeEstimateTokens
+            : null,
+        probeBandFraction: Number.isFinite(candidate?.probeBandFraction)
+            && candidate.probeBandFraction > 0 && candidate.probeBandFraction <= 1
+            ? candidate.probeBandFraction
+            : null,
+        probeSized: candidate?.probeSized === true
     };
 }
 

--- a/ai/daemons/orchestrator/services/TenantRepoSyncService.mjs
+++ b/ai/daemons/orchestrator/services/TenantRepoSyncService.mjs
@@ -13,7 +13,7 @@ import {
 }                                from '../../../services/knowledge-base/helpers/corpusOutstanding.mjs';
 import {createBoundedRetryGate}   from '../../../services/shared/boundedRetryGate.mjs';
 import {writeFileAtomic}          from '../../../services/shared/atomicFileWrite.mjs';
-import {buildEmbeddingProbeBlock, buildEmbeddingProbeInput, projectProbeCoverage} from '../../../services/shared/embeddingProbe.mjs';
+import {buildEmbeddingProbeBlock, buildEmbeddingProbeInput, EMBEDDING_PROBE_BAND_FRACTION, projectProbeCoverage} from '../../../services/shared/embeddingProbe.mjs';
 import {resolveEmbeddingAdmissionBand}                     from '../../../embeddingSafeBand.mjs';
 // The filter below and the codes it admits are one contract. Importing the pattern from the module
 // that PRODUCES bounded codes keeps a re-declared copy from drifting into a pair that separately
@@ -1084,30 +1084,35 @@ class TenantRepoSyncService extends Base {
                     contextLimitTokens       : AiConfig.localModels.embedding.contextLimitTokens,
                     safeProcessingLimitTokens: AiConfig.localModels.embedding.safeProcessingLimitTokens
                 }).estimateBandTokens,
-                // FULL band for a RECOVERY probe, not the cadence default.
+                // The recovery probe is NOT full-band, and that is a measured retreat rather than
+                // a preference. A full-band probe genuinely bounds the re-dispatch it authorizes —
+                // the call site cannot see the cohort's input sizes, so the band ceiling is the only
+                // available dominating bound — but the SWEEP AWAITS this probe, and the suite priced
+                // it: the same `runTask` arm passes in 12.7 s at a quarter band and exceeds 30 s at
+                // the full one. In production that latency is a held lease against a dead provider.
                 //
-                // This verdict authorizes a re-dispatch of the whole awaiting cohort, and the call
-                // site cannot see those inputs' sizes — nothing in the checkpoint or the KB services
-                // carries a largest-chunk measure. The band ceiling is the one bound available that
-                // DOMINATES every admitted input, so probing it is what makes the coverage cover the
-                // authorization instead of a quarter of it.
-                //
-                // The ticket's Avoided Trap against a full-ceiling probe is scoped to a CADENCE
-                // probe — "a cadence probe of that weight would itself starve the lane" — and this
-                // one runs at most once per bounded-retry backoff. If the engine dies here, that is
-                // the probe finally failing the way the workload fails: one request, classified
-                // `provider-died`, instead of the batch that killed it 36 times.
-                fraction: 1
+                // So neither published fork survives contact: the cheap probe does not bound the
+                // authorization, and the bounding probe blocks the sweep. The shape that works is
+                // one neither of us had — obtain the full-size proof OUT of the sweep's critical
+                // path, and let eligibility consume it — and that is open on the PR rather than
+                // guessed at here.
+                fraction: EMBEDDING_PROBE_BAND_FRACTION
             });
 
-            // The deadline travels WITH the size. A caller-supplied `timeoutMs` is a floor, never a
-            // ceiling: sizing the probe up while holding the deadline constant makes a healthy lane
-            // report `consumer-probe-timeout`, which is the probe lying in the one direction this
-            // lane cannot afford.
-            const sizedTimeoutMs = Math.max(
-                timeoutMs,
-                Math.ceil(probeSize.estimateTokens * EMBEDDING_PROBE_MS_PER_ESTIMATE_TOKEN)
-            );
+            // NOT scaled to the size, and that is currently a KNOWN DEFECT rather than a decision.
+            //
+            // The reviewer is right that a 30 s ceiling under a full-band probe makes a HEALTHY lane
+            // report `consumer-probe-timeout` — the incident's 13,980-token request took ~180 s and
+            // this probe is larger. But scaling it naively is worse in a way only the suite showed:
+            // the sweep AWAITS this probe, so a size-derived 411 s deadline blocks `runTask` for
+            // roughly seven minutes against a dead provider, once per backoff. A spec driving the
+            // real sweep times out at 30 s, which is the operational consequence in miniature.
+            //
+            // Both numbers are wrong and the third is not a number: the deadline has to be bounded by
+            // what the CALLER can afford to wait, which is the lease budget, not by what the request
+            // needs. That is a design decision on a recovery path, and it is open on the PR rather
+            // than picked here.
+            const sizedTimeoutMs = timeoutMs;
 
             this.embeddingRecoveryProbeGeometry = `${probeSize.estimateTokens}:${probeSize.fraction ?? 'unsized'}`;
 

--- a/ai/daemons/orchestrator/services/TenantRepoSyncService.mjs
+++ b/ai/daemons/orchestrator/services/TenantRepoSyncService.mjs
@@ -13,7 +13,7 @@ import {
 }                                from '../../../services/knowledge-base/helpers/corpusOutstanding.mjs';
 import {createBoundedRetryGate}   from '../../../services/shared/boundedRetryGate.mjs';
 import {writeFileAtomic}          from '../../../services/shared/atomicFileWrite.mjs';
-import {buildEmbeddingProbeBlock, buildEmbeddingProbeInput} from '../../../services/shared/embeddingProbe.mjs';
+import {buildEmbeddingProbeBlock, buildEmbeddingProbeInput, projectProbeCoverage} from '../../../services/shared/embeddingProbe.mjs';
 import {resolveEmbeddingAdmissionBand}                     from '../../../embeddingSafeBand.mjs';
 // The filter below and the codes it admits are one contract. Importing the pattern from the module
 // that PRODUCES bounded codes keeps a re-declared copy from drifting into a pair that separately
@@ -1020,7 +1020,17 @@ class TenantRepoSyncService extends Base {
             terminal           : snapshot.terminal,
             stopReason         : snapshot.stopReason,
             errorClassification: failure?.errorClassification || null,
-            errorCode          : failure?.errorCode || null
+            errorCode          : failure?.errorCode || null,
+            // The size the verdict was reached AT, carried from whichever result this snapshot is
+            // reporting — the freshly delivered probe, or the cached one it is reusing.
+            //
+            // This projection is an explicit ALLOWLIST, which is why declaring the fields at both
+            // ends was not enough. `buildEmbeddingProbeBlock` produced them and the bridge
+            // summarizer declared them; between the two they were dropped HERE, and reached the
+            // public surface as three permanently-empty fields. **A verdict that reports its
+            // coverage as absent, always, is worse than one that does not report it at all** —
+            // it looks answered.
+            ...projectProbeCoverage(delivered ?? snapshot.cached?.result ?? null)
         };
     }
 

--- a/ai/daemons/orchestrator/services/TenantRepoSyncService.mjs
+++ b/ai/daemons/orchestrator/services/TenantRepoSyncService.mjs
@@ -98,6 +98,15 @@ const
     EMBEDDING_RECOVERY_FAILURE_TTL_MS     = 30 * 1000,
     EMBEDDING_RECOVERY_FAILURE_TTL_MAX_MS = 10 * 60 * 1000,
     EMBEDDING_RECOVERY_PROBE_TIMEOUT_MS   = 30 * 1000,
+    // Milliseconds of provider budget per estimate-token, measured from the incident this lane
+    // exists for: a 13,980-token request took ~180 s on the offending image, i.e. ~12.9 ms/token.
+    //
+    // A constant deadline and a size-derived probe cannot both be right. Sizing the recovery probe
+    // to the full admitted band while leaving a 30 s ceiling means a HEALTHY lane false-times-out
+    // before it can answer — the probe would report `consumer-probe-timeout` on exactly the
+    // recovery it exists to detect, and the bigger the probe got the more certainly it would lie.
+    // The floor keeps small probes on the existing 30 s and 1.5× carries measurement drift.
+    EMBEDDING_PROBE_MS_PER_ESTIMATE_TOKEN = 12.9 * 1.5,
     PERSISTED_REVISIONS_FILE_NAME         = 'tenant-repo-sync-revisions.json',
     TENANT_REPO_SYNC_LEASE_FILE_NAME      = 'tenant-repo-sync-lease.json';
 
@@ -1091,6 +1100,17 @@ class TenantRepoSyncService extends Base {
                 fraction: 1
             });
 
+            // The deadline travels WITH the size. A caller-supplied `timeoutMs` is a floor, never a
+            // ceiling: sizing the probe up while holding the deadline constant makes a healthy lane
+            // report `consumer-probe-timeout`, which is the probe lying in the one direction this
+            // lane cannot afford.
+            const sizedTimeoutMs = Math.max(
+                timeoutMs,
+                Math.ceil(probeSize.estimateTokens * EMBEDDING_PROBE_MS_PER_ESTIMATE_TOKEN)
+            );
+
+            this.embeddingRecoveryProbeGeometry = `${probeSize.estimateTokens}:${probeSize.fraction ?? 'unsized'}`;
+
             return buildEmbeddingProbeBlock({
                 cfg      : AiConfig,
                 embedText: (text, explicitProvider, options) =>
@@ -1099,15 +1119,41 @@ class TenantRepoSyncService extends Base {
                 operationLabel: 'Tenant repo sync embedding recovery probe',
                 now           : this.embeddingRecoveryClock,
                 probeSize,
-                timeoutMs
+                timeoutMs     : sizedTimeoutMs
             })
         });
 
         if (!this.embeddingRecoveryGate) {
             this.embeddingRecoveryGate = createBoundedRetryGate({
                 run: async context => {
+                    // ONE destructive attempt per proof identity. A full-band probe against a lane
+                    // that OOMs is itself the killing request, and the gate's default budget is
+                    // `Infinity` — so without this the repair reproduces the loop it exists to stop,
+                    // at 30 s → 10 min backoff, forever. The docblock beside the sizing claimed "one
+                    // request"; the mechanism said otherwise, which is the defect this whole ticket
+                    // is about, written into its own fix.
+                    //
+                    // Recorded against the KEY, so the refusal lasts exactly as long as the question
+                    // does: rotate the episode, the generation or the geometry and the identity
+                    // changes, which is the only honest reason to spend another engine.
+                    const died = this.embeddingRecoveryDeaths?.get(context?.key);
+
+                    if (died) {
+                        return {...died, cached: true}
+                    }
+
                     try {
-                        return await this.embeddingRecoveryProbeFn(context);
+                        const outcome = await this.embeddingRecoveryProbeFn(context);
+
+                        // Only DEATH is recorded. `provider-unreachable` is ambient and deserves the
+                        // ordinary bounded retry; a process that accepted the request and went away
+                        // has answered the question this probe asks, and asking again costs another
+                        // engine to learn the same thing.
+                        if (outcome?.errorClassification === 'provider-died') {
+                            (this.embeddingRecoveryDeaths ??= new Map()).set(context?.key, outcome)
+                        }
+
+                        return outcome;
                     } catch {
                         return {
                             status             : 'failed',
@@ -1123,7 +1169,10 @@ class TenantRepoSyncService extends Base {
             });
         }
 
-        const key = `${AiConfig.embeddingProvider}:${AiConfig.vectorDimension}:${[...episodeKeys].sort().join(',')}`;
+        // Geometry is part of the proof's IDENTITY, not metadata about it. A cached quarter-band
+        // `healthy` cannot answer a full-band question, and a key that omits the bound lets it —
+        // the proof would satisfy a question it never bounded, which is RA-1 one layer along.
+        const key = `${AiConfig.embeddingProvider}:${AiConfig.vectorDimension}:${this.embeddingRecoveryProbeGeometry ?? 'pending'}:${[...episodeKeys].sort().join(',')}`;
 
         this.embeddingRecoveryLastResult = await this.embeddingRecoveryGate.tick({key});
         return this.embeddingRecoveryLastResult;

--- a/ai/daemons/orchestrator/services/TenantRepoSyncService.mjs
+++ b/ai/daemons/orchestrator/services/TenantRepoSyncService.mjs
@@ -1074,7 +1074,21 @@ class TenantRepoSyncService extends Base {
                 estimateBandTokens: resolveEmbeddingAdmissionBand({
                     contextLimitTokens       : AiConfig.localModels.embedding.contextLimitTokens,
                     safeProcessingLimitTokens: AiConfig.localModels.embedding.safeProcessingLimitTokens
-                }).estimateBandTokens
+                }).estimateBandTokens,
+                // FULL band for a RECOVERY probe, not the cadence default.
+                //
+                // This verdict authorizes a re-dispatch of the whole awaiting cohort, and the call
+                // site cannot see those inputs' sizes — nothing in the checkpoint or the KB services
+                // carries a largest-chunk measure. The band ceiling is the one bound available that
+                // DOMINATES every admitted input, so probing it is what makes the coverage cover the
+                // authorization instead of a quarter of it.
+                //
+                // The ticket's Avoided Trap against a full-ceiling probe is scoped to a CADENCE
+                // probe — "a cadence probe of that weight would itself starve the lane" — and this
+                // one runs at most once per bounded-retry backoff. If the engine dies here, that is
+                // the probe finally failing the way the workload fails: one request, classified
+                // `provider-died`, instead of the batch that killed it 36 times.
+                fraction: 1
             });
 
             return buildEmbeddingProbeBlock({
@@ -1919,7 +1933,20 @@ class TenantRepoSyncService extends Base {
                 failureTtlMaxMs: embeddingRecoveryFailureTtlMaxMs
             });
 
-            if (observation?.status === 'healthy') {
+            // `healthy` is not sufficient — `healthy AT THE SIZE THIS AUTHORIZES` is. The verdict
+            // below mints a bypass generation that re-dispatches the whole awaiting cohort, and a
+            // probe that exercised a quarter of the admitted band never bounded that work. Reading
+            // `status` alone is how a 44-byte canary greenlit the batch that killed the engine.
+            //
+            // Asserted HERE as well as sized at the probe call site, deliberately: the call site can
+            // be changed by anyone tuning cadence cost, and this is the decision that spends the
+            // compute. If a future fraction drops below the band, recovery refuses rather than
+            // silently over-authorizing again — the failure mode returns as a stall, which is
+            // visible, instead of as a loop, which is what it was.
+            const coverageBoundsAuthorization = observation?.probeSized === true
+                && observation?.probeBandFraction >= 1;
+
+            if (observation?.status === 'healthy' && coverageBoundsAuthorization) {
                 const
                     generationId = randomBytes(16).toString('hex'),
                     observedAt   = observation.gate?.checkedAt ?? embeddingRecoveryClock(),

--- a/ai/daemons/orchestrator/services/TenantRepoSyncService.mjs
+++ b/ai/daemons/orchestrator/services/TenantRepoSyncService.mjs
@@ -1070,35 +1070,40 @@ class TenantRepoSyncService extends Base {
         if (!Array.isArray(episodeKeys) || episodeKeys.length === 0) return null;
 
         this.embeddingRecoveryClock = clock;
+
         // The band is read HERE, at the use site that owns the decision, and injected into the pure
         // builder — the sanctioned shape for an `ai/` consumer, and the reason `embeddingProbe.mjs`
-        // stays Neo-free. Resolved per probe rather than cached, so a deployment that narrows its
-        // slot mid-run is probed against the ceiling it actually has.
-        this.embeddingRecoveryProbeFn = runProbe || (() => {
-            // A 44-byte canary certified a property nobody needed. Peak memory for one non-causal
-            // embedding request scales with the SQUARE of its token count, so a probe three orders
-            // of magnitude under the workload cannot fail the way the lane fails — and its `healthy`
-            // was the green light that re-dispatched the batch that killed the engine, 36 times.
-            const probeSize = buildEmbeddingProbeInput({
-                estimateBandTokens: resolveEmbeddingAdmissionBand({
-                    contextLimitTokens       : AiConfig.localModels.embedding.contextLimitTokens,
-                    safeProcessingLimitTokens: AiConfig.localModels.embedding.safeProcessingLimitTokens
-                }).estimateBandTokens,
-                // The recovery probe is NOT full-band, and that is a measured retreat rather than
-                // a preference. A full-band probe genuinely bounds the re-dispatch it authorizes —
-                // the call site cannot see the cohort's input sizes, so the band ceiling is the only
-                // available dominating bound — but the SWEEP AWAITS this probe, and the suite priced
-                // it: the same `runTask` arm passes in 12.7 s at a quarter band and exceeds 30 s at
-                // the full one. In production that latency is a held lease against a dead provider.
-                //
-                // So neither published fork survives contact: the cheap probe does not bound the
-                // authorization, and the bounding probe blocks the sweep. The shape that works is
-                // one neither of us had — obtain the full-size proof OUT of the sweep's critical
-                // path, and let eligibility consume it — and that is open on the PR rather than
-                // guessed at here.
-                fraction: EMBEDDING_PROBE_BAND_FRACTION
-            });
+        // stays Neo-free. Resolved per call, so a deployment that narrows its slot mid-run is probed
+        // against the ceiling it actually has.
+        //
+        // Resolved BEFORE the gate key, not inside the probe: the key NAMES this geometry, so a
+        // value produced by the run the key admits can only describe the PREVIOUS run's bound.
+        //
+        // A 44-byte canary certified a property nobody needed. Peak memory for one non-causal
+        // embedding request scales with the SQUARE of its token count, so a probe three orders
+        // of magnitude under the workload cannot fail the way the lane fails — and its `healthy`
+        // was the green light that re-dispatched the batch that killed the engine, 36 times.
+        const probeSize = buildEmbeddingProbeInput({
+            estimateBandTokens: resolveEmbeddingAdmissionBand({
+                contextLimitTokens       : AiConfig.localModels.embedding.contextLimitTokens,
+                safeProcessingLimitTokens: AiConfig.localModels.embedding.safeProcessingLimitTokens
+            }).estimateBandTokens,
+            // The recovery probe is NOT full-band, and that is a measured retreat rather than
+            // a preference. A full-band probe genuinely bounds the re-dispatch it authorizes —
+            // the call site cannot see the cohort's input sizes, so the band ceiling is the only
+            // available dominating bound — but the SWEEP AWAITS this probe, and the suite priced
+            // it: the same `runTask` arm passes in 12.7 s at a quarter band and exceeds 30 s at
+            // the full one. In production that latency is a held lease against a dead provider.
+            //
+            // So neither published fork survives contact: the cheap probe does not bound the
+            // authorization, and the bounding probe blocks the sweep. The shape that works is
+            // one neither of us had — obtain the full-size proof OUT of the sweep's critical
+            // path, and let eligibility consume it — and that is open on the PR rather than
+            // guessed at here.
+            fraction: EMBEDDING_PROBE_BAND_FRACTION
+        });
 
+        this.embeddingRecoveryProbeFn = runProbe || (() => {
             // NOT scaled to the size, and that is currently a KNOWN DEFECT rather than a decision.
             //
             // The reviewer is right that a 30 s ceiling under a full-band probe makes a HEALTHY lane
@@ -1113,8 +1118,6 @@ class TenantRepoSyncService extends Base {
             // needs. That is a design decision on a recovery path, and it is open on the PR rather
             // than picked here.
             const sizedTimeoutMs = timeoutMs;
-
-            this.embeddingRecoveryProbeGeometry = `${probeSize.estimateTokens}:${probeSize.fraction ?? 'unsized'}`;
 
             return buildEmbeddingProbeBlock({
                 cfg      : AiConfig,
@@ -1177,7 +1180,11 @@ class TenantRepoSyncService extends Base {
         // Geometry is part of the proof's IDENTITY, not metadata about it. A cached quarter-band
         // `healthy` cannot answer a full-band question, and a key that omits the bound lets it —
         // the proof would satisfy a question it never bounded, which is RA-1 one layer along.
-        const key = `${AiConfig.embeddingProvider}:${AiConfig.vectorDimension}:${this.embeddingRecoveryProbeGeometry ?? 'pending'}:${[...episodeKeys].sort().join(',')}`;
+        //
+        // `sized` is the builder's own word for a band it could not resolve. Read that, rather than
+        // inferring absence from a null fraction: the two are the same today only by coincidence.
+        const geometry = probeSize.sized ? `${probeSize.estimateTokens}:${probeSize.fraction}` : 'unsized',
+              key      = `${AiConfig.embeddingProvider}:${AiConfig.vectorDimension}:${geometry}:${[...episodeKeys].sort().join(',')}`;
 
         this.embeddingRecoveryLastResult = await this.embeddingRecoveryGate.tick({key});
         return this.embeddingRecoveryLastResult;

--- a/ai/daemons/orchestrator/services/TenantRepoSyncService.mjs
+++ b/ai/daemons/orchestrator/services/TenantRepoSyncService.mjs
@@ -13,7 +13,8 @@ import {
 }                                from '../../../services/knowledge-base/helpers/corpusOutstanding.mjs';
 import {createBoundedRetryGate}   from '../../../services/shared/boundedRetryGate.mjs';
 import {writeFileAtomic}          from '../../../services/shared/atomicFileWrite.mjs';
-import {buildEmbeddingProbeBlock} from '../../../services/shared/embeddingProbe.mjs';
+import {buildEmbeddingProbeBlock, buildEmbeddingProbeInput} from '../../../services/shared/embeddingProbe.mjs';
+import {resolveEmbeddingAdmissionBand}                     from '../../../embeddingSafeBand.mjs';
 // The filter below and the codes it admits are one contract. Importing the pattern from the module
 // that PRODUCES bounded codes keeps a re-declared copy from drifting into a pair that separately
 // look right — the producer widening a code the filter still rejects is exactly this ticket's defect.
@@ -1050,15 +1051,33 @@ class TenantRepoSyncService extends Base {
         if (!Array.isArray(episodeKeys) || episodeKeys.length === 0) return null;
 
         this.embeddingRecoveryClock = clock;
-        this.embeddingRecoveryProbeFn = runProbe || (() => buildEmbeddingProbeBlock({
-            cfg      : AiConfig,
-            embedText: (text, explicitProvider, options) =>
-                TextEmbeddingService.embedText(text, explicitProvider, options),
-            input         : 'neo-tenant-repo-sync-embedding-recovery-canary',
-            operationLabel: 'Tenant repo sync embedding recovery probe',
-            now           : this.embeddingRecoveryClock,
-            timeoutMs
-        }));
+        // The band is read HERE, at the use site that owns the decision, and injected into the pure
+        // builder — the sanctioned shape for an `ai/` consumer, and the reason `embeddingProbe.mjs`
+        // stays Neo-free. Resolved per probe rather than cached, so a deployment that narrows its
+        // slot mid-run is probed against the ceiling it actually has.
+        this.embeddingRecoveryProbeFn = runProbe || (() => {
+            // A 44-byte canary certified a property nobody needed. Peak memory for one non-causal
+            // embedding request scales with the SQUARE of its token count, so a probe three orders
+            // of magnitude under the workload cannot fail the way the lane fails — and its `healthy`
+            // was the green light that re-dispatched the batch that killed the engine, 36 times.
+            const probeSize = buildEmbeddingProbeInput({
+                estimateBandTokens: resolveEmbeddingAdmissionBand({
+                    contextLimitTokens       : AiConfig.localModels.embedding.contextLimitTokens,
+                    safeProcessingLimitTokens: AiConfig.localModels.embedding.safeProcessingLimitTokens
+                }).estimateBandTokens
+            });
+
+            return buildEmbeddingProbeBlock({
+                cfg      : AiConfig,
+                embedText: (text, explicitProvider, options) =>
+                    TextEmbeddingService.embedText(text, explicitProvider, options),
+                input         : probeSize.input,
+                operationLabel: 'Tenant repo sync embedding recovery probe',
+                now           : this.embeddingRecoveryClock,
+                probeSize,
+                timeoutMs
+            })
+        });
 
         if (!this.embeddingRecoveryGate) {
             this.embeddingRecoveryGate = createBoundedRetryGate({

--- a/ai/services/shared/embeddingProbe.mjs
+++ b/ai/services/shared/embeddingProbe.mjs
@@ -22,8 +22,95 @@ const EMBEDDING_PROBE_FAILURE_CLASSIFICATIONS = Object.freeze({
     EMBEDDING_MODEL_NOT_RESIDENT     : 'model-not-resident',
     EMBEDDING_PROBE_TIMEOUT          : 'consumer-probe-timeout',
     OPENAI_COMPATIBLE_REQUEST_TIMEOUT: 'provider-timeout',
-    PROVIDER_TIMEOUT                 : 'provider-timeout'
+    PROVIDER_TIMEOUT                 : 'provider-timeout',
+    // Provider DEATH, not provider failure, and the difference decides what a consumer may conclude.
+    // `provider-unreachable` above means the connection never came up — ambient, and the lane may be
+    // fine once it does. These four mean the connection came up, the request was accepted, and the
+    // process went away mid-answer: an OOM kill leaves exactly this trace. That is direct evidence
+    // the lane cannot serve THIS input, which is the one conclusion a recovery probe exists to draw.
+    ECONNRESET                       : 'provider-died',
+    EPIPE                            : 'provider-died',
+    ERR_STREAM_PREMATURE_CLOSE       : 'provider-died',
+    UND_ERR_SOCKET                   : 'provider-died'
 });
+
+/**
+ * @summary Bytes per token for the estimate-space heuristic every admission site already uses.
+ * @type {Number}
+ */
+const BYTES_PER_TOKEN_HEURISTIC = 3;
+
+/**
+ * @summary Default share of the admitted band a cadence probe exercises.
+ *
+ * Not a preference — a cost/discrimination trade priced from the incident that produced this
+ * helper. Peak memory for one non-causal embedding request scales with the SQUARE of its token
+ * count: measured on the offending image, idle 7.69 GiB and a single 13,980-token embed peaking at
+ * 24.14 GiB, so ~16.45 GiB marginal at that size. At fraction `f` of a 28,672-token band the
+ * marginal cost is `16.45 × (28672f / 13980)²` GiB — roughly 4.3 GiB at 0.25, and 17.3 GiB at 0.50,
+ * which is the size that was doing the killing.
+ *
+ * 0.25 buys ~354× the discrimination of the constant it replaces (5,309 estimate-tokens against a
+ * 44-byte canary) at roughly a quarter of the killing request's marginal footprint.
+ *
+ * It is a DEFAULT this module owns and every caller may override, not a config leaf: the arithmetic
+ * above is deployment-specific, but no deployment has asked to tune it yet, and a leaf nobody sets
+ * is a knob to maintain rather than a value to read. What makes that safe is the reporting — the
+ * probe carries whichever fraction it used onto its verdict, so `healthy` is never readable as
+ * healthy-at-full-size regardless of who chose the number.
+ * @type {Number}
+ */
+export const EMBEDDING_PROBE_BAND_FRACTION = 0.25;
+
+/**
+ * @summary Builds a probe input sized from the lane's admitted band, and describes what it built.
+ *
+ * Pure. The band arrives resolved from the caller's entrypoint — this helper never reads config.
+ *
+ * A fixed short string is the one input guaranteed not to discriminate: the failure mode is
+ * size-dependent, so a probe three orders of magnitude below the workload certifies a property
+ * nobody asked about. The generated text is deliberately varied rather than one character repeated,
+ * because a run-length-trivial input is exactly what a tokenizer collapses.
+ *
+ * **`sized: false` is a reading, not a fallback.** When the band cannot be resolved the probe still
+ * runs — refusing to probe would remove a signal — but it says it ran unsized, so a consumer can
+ * see that `healthy` means "the plane answered" rather than "the lane can serve admitted work".
+ * @param {Object} [options]
+ * @param {Number|null} [options.estimateBandTokens=null] Estimate-space band from
+ *     `resolveEmbeddingAdmissionBand`, or `null` when the deployment declares no resolvable ceiling.
+ * @param {Number} [options.fraction=EMBEDDING_PROBE_BAND_FRACTION] Share of the band to exercise.
+ * @param {String} [options.marker='neo-embedding-probe'] Leading identifier, so the input is
+ *     recognisable in a provider log.
+ * @returns {{estimateTokens: Number, fraction: Number|null, input: String, sized: Boolean}}
+ */
+export function buildEmbeddingProbeInput({
+    estimateBandTokens = null,
+    fraction           = EMBEDDING_PROBE_BAND_FRACTION,
+    marker             = 'neo-embedding-probe'
+} = {}) {
+    const
+        bandResolved     = Number.isFinite(estimateBandTokens) && estimateBandTokens > 0,
+        fractionResolved = Number.isFinite(fraction) && fraction > 0 && fraction <= 1;
+
+    if (!bandResolved || !fractionResolved) {
+        return {estimateTokens: Math.ceil(marker.length / BYTES_PER_TOKEN_HEURISTIC), fraction: null, input: marker, sized: false}
+    }
+
+    const
+        estimateTokens = Math.max(1, Math.floor(estimateBandTokens * fraction)),
+        targetBytes    = estimateTokens * BYTES_PER_TOKEN_HEURISTIC,
+        // Varied by construction: a repeated character compresses in the tokenizer, which would put
+        // the real token count far below the estimate the caller thinks it asked for.
+        filler         = ' lorem ipsum dolor sit amet consectetur adipiscing elit sed do eiusmod tempor';
+
+    let input = marker;
+
+    while (input.length < targetBytes) {
+        input += `${filler} ${input.length}`
+    }
+
+    return {estimateTokens, fraction, input: input.slice(0, targetBytes), sized: true}
+}
 
 /**
  * @summary Creates the structural caller-owned deadline error shared by embedding-probe consumers.
@@ -89,6 +176,7 @@ export async function buildEmbeddingProbeBlock({
     input,
     operationLabel,
     now = Date.now,
+    probeSize = null,
     timeoutMs
 } = {}) {
     if (!cfg || typeof cfg !== 'object') {
@@ -107,7 +195,13 @@ export async function buildEmbeddingProbeBlock({
     const readNow            = typeof now === 'function' ? now : () => (typeof now === 'number' ? now : now.getTime()),
           startedAt          = readNow(),
           provider           = cfg.embeddingProvider || 'openAiCompatible',
-          expectedDimensions = cfg.vectorDimension ?? null;
+          expectedDimensions = cfg.vectorDimension ?? null,
+          // Echoed on EVERY return path, success included. A verdict that does not carry the size it
+          // exercised is the defect this parameter exists to close: `healthy` then reads as an
+          // unqualified pass over whatever the caller happened to send.
+          sizeBlock          = probeSize
+              ? {probeEstimateTokens: probeSize.estimateTokens ?? null, probeBandFraction: probeSize.fraction ?? null, probeSized: probeSize.sized === true}
+              : {probeEstimateTokens: null, probeBandFraction: null, probeSized: false};
 
     let timeoutId;
 
@@ -138,6 +232,7 @@ export async function buildEmbeddingProbeBlock({
                 dimensions,
                 expectedDimensions,
                 durationMs,
+                ...sizeBlock,
                 error : `${operationLabel} returned no vector.`
             };
         }
@@ -149,6 +244,7 @@ export async function buildEmbeddingProbeBlock({
                 dimensions,
                 expectedDimensions,
                 durationMs,
+                ...sizeBlock,
                 error : `${operationLabel} returned ${dimensions} dimensions; expected ${expectedDimensions}.`
             };
         }
@@ -158,7 +254,8 @@ export async function buildEmbeddingProbeBlock({
             provider,
             dimensions,
             expectedDimensions,
-            durationMs
+            durationMs,
+            ...sizeBlock
         };
     } catch (error) {
         const failure = describeEmbeddingProbeFailure(error);
@@ -169,6 +266,7 @@ export async function buildEmbeddingProbeBlock({
             dimensions: null,
             expectedDimensions,
             durationMs: Math.max(0, readNow() - startedAt),
+            ...sizeBlock,
             ...failure
         };
     } finally {

--- a/ai/services/shared/embeddingProbe.mjs
+++ b/ai/services/shared/embeddingProbe.mjs
@@ -199,9 +199,17 @@ export async function buildEmbeddingProbeBlock({
           // Echoed on EVERY return path, success included. A verdict that does not carry the size it
           // exercised is the defect this parameter exists to close: `healthy` then reads as an
           // unqualified pass over whatever the caller happened to send.
+          //
+          // Absent when the caller supplies no `probeSize`, rather than emitted as nulls. The other
+          // consumers of this helper are healthcheck WRITE CANARIES — deliberately liveness-only,
+          // deliberately tiny, and not consumed as readiness for real work. Widening their public
+          // payload would be a change to two other services' health contracts to describe a size
+          // they never claimed to exercise. The surface that IS read as readiness — the tenant
+          // recovery probe's bridge projection — declares the fields explicitly instead, so absence
+          // is a reading exactly where a reading is owed.
           sizeBlock          = probeSize
               ? {probeEstimateTokens: probeSize.estimateTokens ?? null, probeBandFraction: probeSize.fraction ?? null, probeSized: probeSize.sized === true}
-              : {probeEstimateTokens: null, probeBandFraction: null, probeSized: false};
+              : {};
 
     let timeoutId;
 

--- a/ai/services/shared/embeddingProbe.mjs
+++ b/ai/services/shared/embeddingProbe.mjs
@@ -151,6 +151,23 @@ export function describeEmbeddingProbeFailure(error) {
 }
 
 /**
+ * @summary Projects a probe result's coverage fields, or their honest absence.
+ *
+ * Exported so the producer, the process-owned snapshot and the bridge all read the SAME three keys
+ * from one place. They were previously written twice and dropped in between, which is how the public
+ * surface ended up declaring coverage it never carried.
+ * @param {Object|null} result A `buildEmbeddingProbeBlock` result, or null when none is being reported.
+ * @returns {{probeBandFraction: Number|null, probeEstimateTokens: Number|null, probeSized: Boolean}}
+ */
+export function projectProbeCoverage(result) {
+    return {
+        probeBandFraction  : Number.isFinite(result?.probeBandFraction) ? result.probeBandFraction : null,
+        probeEstimateTokens: Number.isSafeInteger(result?.probeEstimateTokens) ? result.probeEstimateTokens : null,
+        probeSized         : result?.probeSized === true
+    }
+}
+
+/**
  * @summary Probes one explicitly supplied embedding path and returns a health-safe result block.
  *
  * This module owns only the attempt boundary: deadline, abort propagation, dimension validation,

--- a/test/playwright/unit/ai/daemons/orchestrator/services/DeploymentStateBridgeService.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/services/DeploymentStateBridgeService.spec.mjs
@@ -1536,7 +1536,13 @@ test.describe('Neo.ai.daemons.services.DeploymentStateBridgeService', () => {
             terminal           : false,
             stopReason         : null,
             errorClassification: 'connection-refused',
-            errorCode          : 'ECONNREFUSED'
+            errorCode          : 'ECONNREFUSED',
+            // A probe snapshot naming no size projects its coverage fields as ABSENT rather than
+            // omitting them: a consumer must be able to read "this verdict does not say what size it
+            // was reached at" from the payload, never from the payload's silence.
+            probeEstimateTokens: null,
+            probeBandFraction  : null,
+            probeSized         : false
         });
         expect(snapshot.repos[0]).toMatchObject({
             status             : 'not-due',

--- a/test/playwright/unit/ai/daemons/orchestrator/services/TenantRepoSyncService.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/services/TenantRepoSyncService.spec.mjs
@@ -983,6 +983,62 @@ test.describe('TenantRepoSyncService (#11790)', () => {
         expect(mixed.contentPoisonChunks).toBeNull();
     });
 
+    test('a provider DEATH is not retried against the same proof identity', async () => {
+        // A full-band recovery probe against a lane that OOMs IS the killing request, and the
+        // bounded gate's default budget is `Infinity` — so without a bound the repair reproduces the
+        // loop it exists to stop, at 30 s → 10 min backoff, forever. The sizing docblock claimed
+        // "one request"; the mechanism said otherwise until this landed.
+        let calls = 0;
+
+        const runProbe = async () => {
+            calls++;
+
+            return {
+                status             : 'failed',
+                errorClassification: 'provider-died',
+                errorCode          : 'ECONNRESET'
+            }
+        };
+        const episodeKeys = ['d'.repeat(32)];
+
+        await TenantRepoSyncService.probeEmbeddingRecovery({episodeKeys, runProbe, clock: () => 1_000});
+        // PAST the failure-backoff window — which is the only clock position where this arm
+        // discriminates. Inside the window the gate's ordinary TTL already suppresses the second
+        // call, so an arm that re-asks immediately proves the gate and says nothing about the death
+        // bound. Same advance as the ambient control below, so the two differ ONLY in
+        // classification, which is the whole claim.
+        await TenantRepoSyncService.probeEmbeddingRecovery({episodeKeys, runProbe, clock: () => 1_000 + 15 * 60 * 1000});
+
+        expect(calls, 'the engine is spent once to learn this, not once per backoff').toBe(1);
+    });
+
+    test('CONTROL: an ambient failure IS retried — only death is terminal', async () => {
+        // The half that keeps the bound honest. `provider-unreachable` means the connection never
+        // came up: ambient, cheap to re-ask, and the lane may be fine once it does. Recording every
+        // failure would turn one transport blip into a permanent refusal, which strands recovery —
+        // a worse outcome than the loop, and one that would look like discipline.
+        let calls = 0;
+
+        const runProbe = async () => {
+            calls++;
+
+            return {
+                status             : 'failed',
+                errorClassification: 'provider-unreachable',
+                errorCode          : 'ECONNREFUSED'
+            }
+        };
+        const episodeKeys = ['e'.repeat(32)];
+
+        await TenantRepoSyncService.probeEmbeddingRecovery({episodeKeys, runProbe, clock: () => 1_000});
+        // Past the failure-backoff window, which is where the ordinary retry lives. The gate is
+        // created once and keeps the TTL it was built with, so the clock has to move rather than the
+        // argument — a per-call `failureTtlMs` on a second call reaches a gate that already exists.
+        await TenantRepoSyncService.probeEmbeddingRecovery({episodeKeys, runProbe, clock: () => 1_000 + 15 * 60 * 1000});
+
+        expect(calls, 'an unreachable provider is worth asking again').toBeGreaterThan(1);
+    });
+
     test('the probe size reaches the process-owned snapshot, not just the probe result', async () => {
         // The gap a reviewer found: `buildEmbeddingProbeBlock` produced the coverage fields and the
         // bridge summarizer declared them, and THIS projection — an explicit allowlist — dropped them

--- a/test/playwright/unit/ai/daemons/orchestrator/services/TenantRepoSyncService.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/services/TenantRepoSyncService.spec.mjs
@@ -1039,6 +1039,41 @@ test.describe('TenantRepoSyncService (#11790)', () => {
         expect(calls, 'an unreachable provider is worth asking again').toBeGreaterThan(1);
     });
 
+    test('the gate key names a band the service resolved, not one the previous probe left behind', async () => {
+        // The key IS the proof's identity, and the gate rotates a fresh generation on any key change
+        // — clean streak, empty cache, no backoff. So a key component produced by the run that key
+        // admits can only describe the PREVIOUS run's bound, and every first failure is discarded:
+        // the death record written under call 1's key is unreachable to call 2, and the killing
+        // request fires a second time against the lane it just killed.
+        //
+        // The two arms above pass either way, which is the part worth keeping. They inject `runProbe`,
+        // and the geometry used to be assigned inside the branch that injection replaces — so the
+        // spec held one key while production moved it. Identity has to be a function of config and
+        // episodes alone; who runs the probe is not part of the question being asked.
+        const
+            keys     = [],
+            runProbe = async context => {
+                keys.push(context.key);
+
+                return {
+                    status             : 'failed',
+                    errorClassification: 'provider-unreachable',
+                    errorCode          : 'ECONNREFUSED'
+                }
+            },
+            episodeKeys = ['f'.repeat(32)];
+
+        await TenantRepoSyncService.probeEmbeddingRecovery({episodeKeys, runProbe, clock: () => 1_000});
+        // Past the failure-backoff window, so the second attempt actually happens and there are two
+        // identities to compare.
+        await TenantRepoSyncService.probeEmbeddingRecovery({episodeKeys, runProbe, clock: () => 1_000 + 15 * 60 * 1000});
+
+        expect(keys.length, 'the comparison needs two attempts').toBe(2);
+        expect(keys[0], 'identity is a function of config and episodes, never of call order').toBe(keys[1]);
+        expect(keys[0], 'a resolved band reading, not a placeholder for a probe that has not run')
+            .not.toContain(':pending:');
+    });
+
     test('the probe size reaches the process-owned snapshot, not just the probe result', async () => {
         // The gap a reviewer found: `buildEmbeddingProbeBlock` produced the coverage fields and the
         // bridge summarizer declared them, and THIS projection — an explicit allowlist — dropped them

--- a/test/playwright/unit/ai/daemons/orchestrator/services/TenantRepoSyncService.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/services/TenantRepoSyncService.spec.mjs
@@ -982,6 +982,47 @@ test.describe('TenantRepoSyncService (#11790)', () => {
         expect(mixed.contentPoisonChunks).toBeNull();
     });
 
+    test('the probe size reaches the process-owned snapshot, not just the probe result', async () => {
+        // The gap a reviewer found: `buildEmbeddingProbeBlock` produced the coverage fields and the
+        // bridge summarizer declared them, and THIS projection — an explicit allowlist — dropped them
+        // in between. Both ends were right and the public surface carried three permanently-empty
+        // fields, which is worse than not reporting coverage at all because it looks answered.
+        //
+        // Testing each end proved nothing about the hop. This arm drives the real snapshot getter,
+        // which is the only place the drop was visible.
+        await TenantRepoSyncService.probeEmbeddingRecovery({
+            episodeKeys: ['e'.repeat(32)],
+            clock      : () => 1_000,
+            runProbe   : async () => ({
+                status             : 'healthy',
+                provider           : 'openAiCompatible',
+                dimensions         : 4096,
+                expectedDimensions : 4096,
+                durationMs         : 12,
+                probeEstimateTokens: 5309,
+                probeBandFraction  : 0.25,
+                probeSized         : true
+            })
+        });
+
+        const snapshot = TenantRepoSyncService.getEmbeddingRecoveryProbeSnapshot();
+
+        expect(snapshot.probeEstimateTokens).toBe(5309);
+        expect(snapshot.probeBandFraction).toBe(0.25);
+        expect(snapshot.probeSized).toBe(true);
+    });
+
+    test('CONTROL: a snapshot with no probe result reports absent coverage, not a stale one', async () => {
+        // Without this pair, the arm above passes on a projection that hardcodes the numbers. It also
+        // pins the honest-absence half: a snapshot reporting nothing must say so rather than carry the
+        // previous run's size forward, which would be a coverage claim about a probe that never ran.
+        const snapshot = TenantRepoSyncService.getEmbeddingRecoveryProbeSnapshot();
+
+        expect(snapshot.probeSized).toBe(false);
+        expect(snapshot.probeEstimateTokens).toBeNull();
+        expect(snapshot.probeBandFraction).toBeNull();
+    });
+
     test('embedding recovery releases only the affected repo once, then rearms after a failed retry (#16692)', async () => {
         const
             taskStateService = createInMemoryTaskStateService(),

--- a/test/playwright/unit/ai/daemons/orchestrator/services/TenantRepoSyncService.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/services/TenantRepoSyncService.spec.mjs
@@ -15,6 +15,7 @@ setup({
     }
 });
 
+import {buildEmbeddingProbeInput} from '../../../../../../../ai/services/shared/embeddingProbe.mjs';
 import {test, expect}  from '@playwright/test';
 import Neo             from '../../../../../../../src/Neo.mjs';
 import * as core       from '../../../../../../../src/core/_export.mjs';
@@ -1093,7 +1094,11 @@ test.describe('TenantRepoSyncService (#11790)', () => {
                         errorClassification: 'connection-refused',
                         errorCode          : 'EMBEDDING_CONNECTION_REFUSED'
                     }
-                    : {status: 'healthy'}
+                    // FULL coverage, because the shipped recovery probe now exercises the whole
+                    // admitted band. `{status: 'healthy'}` alone is what eligibility used to accept,
+                    // and this arm is now the POSITIVE control for the coverage guard: a verdict
+                    // that bounds the re-dispatch still authorizes it, end to end through runTask.
+                    : {status: 'healthy', probeBandFraction: 1, probeEstimateTokens: 21238, probeSized: true}
             },
             embeddingRecoveryClock          : () => probeNow,
             embeddingRecoveryFailureTtlMs   : 60_000,

--- a/test/playwright/unit/ai/services/shared/embeddingProbe.spec.mjs
+++ b/test/playwright/unit/ai/services/shared/embeddingProbe.spec.mjs
@@ -3,7 +3,8 @@ import {
     buildEmbeddingProbeBlock,
     buildEmbeddingProbeInput,
     describeEmbeddingProbeFailure,
-    EMBEDDING_PROBE_BAND_FRACTION
+    EMBEDDING_PROBE_BAND_FRACTION,
+    projectProbeCoverage
 }                                       from '../../../../../../ai/services/shared/embeddingProbe.mjs';
 import {resolveEmbeddingAdmissionBand}  from '../../../../../../ai/embeddingSafeBand.mjs';
 
@@ -196,5 +197,37 @@ test.describe('describeEmbeddingProbeFailure — death is not the same fact as f
         expect(classify('PROVIDER_TIMEOUT')).toBe('provider-timeout');
         expect(classify('EMBEDDING_MODEL_NOT_RESIDENT')).toBe('model-not-resident');
         expect(classify('SOMETHING_UNMAPPED')).toBe('provider-failure');
+    });
+});
+
+test.describe('projectProbeCoverage — one reader, so the wire cannot be declared and dropped (#17337)', () => {
+    test('a sized result reaches the projection intact', async () => {
+        // The gap `@neo-gpt` found: the producer emitted these three fields and the bridge summarizer
+        // declared them, and the process-owned snapshot in between projected an explicit ALLOWLIST
+        // that did not include them. Both ends were right and the public surface carried three
+        // permanently-empty fields — which is worse than not reporting coverage at all, because it
+        // looks answered. One exported reader now serves every hop.
+        const sized  = buildEmbeddingProbeInput({estimateBandTokens: SHIPPED_BAND.estimateBandTokens}),
+              result = await buildEmbeddingProbeBlock({
+                  cfg, embedText: async () => new Array(cfg.vectorDimension).fill(0.1),
+                  input: sized.input, operationLabel: 'probe', probeSize: sized, timeoutMs: 5_000
+              });
+
+        expect(projectProbeCoverage(result)).toEqual({
+            probeBandFraction  : EMBEDDING_PROBE_BAND_FRACTION,
+            probeEstimateTokens: 5309,
+            probeSized         : true
+        });
+    });
+
+    test('absence projects as absence, and a malformed value is not a reading', () => {
+        // CONTROL: without this, "the fields arrive" passes on a projection that echoes whatever it
+        // is handed — including a string, a NaN, or a truthy non-boolean, each of which would reach
+        // the public schema as a coverage claim nobody measured.
+        expect(projectProbeCoverage(null)).toEqual({probeBandFraction: null, probeEstimateTokens: null, probeSized: false});
+        expect(projectProbeCoverage({})).toEqual({probeBandFraction: null, probeEstimateTokens: null, probeSized: false});
+        expect(projectProbeCoverage({
+            probeBandFraction: '0.25', probeEstimateTokens: 5309.5, probeSized: 'yes'
+        })).toEqual({probeBandFraction: null, probeEstimateTokens: null, probeSized: false});
     });
 });

--- a/test/playwright/unit/ai/services/shared/embeddingProbe.spec.mjs
+++ b/test/playwright/unit/ai/services/shared/embeddingProbe.spec.mjs
@@ -1,0 +1,195 @@
+import {expect, test} from '@playwright/test';
+import {
+    buildEmbeddingProbeBlock,
+    buildEmbeddingProbeInput,
+    describeEmbeddingProbeFailure,
+    EMBEDDING_PROBE_BAND_FRACTION
+}                                       from '../../../../../../ai/services/shared/embeddingProbe.mjs';
+import {resolveEmbeddingAdmissionBand}  from '../../../../../../ai/embeddingSafeBand.mjs';
+
+/**
+ * A probe that cannot fail the way its subject fails is not a control.
+ *
+ * The recovery probe sent a 44-byte constant while production inputs ran to ~14,000 tokens, and peak
+ * memory for one non-causal embedding request scales with the SQUARE of the token count. So the probe
+ * certified a property nobody asked about — can the HTTP plane answer at all — while the property
+ * under question went unmeasured, and its `healthy` was the green light that re-dispatched the batch
+ * that killed the engine. 36 restarts, three repositories backoff-suppressed, and a probe reporting
+ * `failureStreak: 0` two seconds after the sweep's own `lastErrorAt`.
+ */
+
+// The shipped embedding leaves, so the fixtures are the real geometry rather than round numbers.
+const SHIPPED_BAND = resolveEmbeddingAdmissionBand({
+    contextLimitTokens       : 32768,
+    safeProcessingLimitTokens: 28672
+});
+
+const cfg = {embeddingProvider: 'openAiCompatible', vectorDimension: 4096};
+
+/**
+ * @summary A provider that succeeds below a token threshold and DIES above it.
+ *
+ * The threshold is the whole point. A stub failing on every input would report unhealthy before and
+ * after the change and prove nothing; a stub failing on none would do the reverse. Only a
+ * size-dependent failure can show that the probe's SIZE is what decides the verdict.
+ */
+const dyingAbove = thresholdEstimateTokens => async text => {
+    if (text.length / 3 > thresholdEstimateTokens) {
+        const error = new Error('connection reset by peer');
+        error.code  = 'ECONNRESET';
+        throw error
+    }
+
+    return new Array(cfg.vectorDimension).fill(0.1)
+};
+
+test.describe('buildEmbeddingProbeInput — the probe is sized from the band (#17337)', () => {
+    test('the input derives from the admitted band, not from a constant', () => {
+        const sized = buildEmbeddingProbeInput({estimateBandTokens: SHIPPED_BAND.estimateBandTokens});
+
+        expect(SHIPPED_BAND.resolved).toBe(true);
+        expect(sized.sized).toBe(true);
+        expect(sized.fraction).toBe(EMBEDDING_PROBE_BAND_FRACTION);
+        expect(sized.estimateTokens).toBe(Math.floor(SHIPPED_BAND.estimateBandTokens * EMBEDDING_PROBE_BAND_FRACTION));
+
+        // Bounded and stated: the byte cost is exactly the estimate-token budget times the
+        // bytes-per-token heuristic, so a reader can price a cadence probe without running one.
+        expect(sized.input.length).toBe(sized.estimateTokens * 3);
+
+        // A narrower deployment gets a proportionally narrower probe — the band is the authority,
+        // never a number chosen here. Without this, "derives from the band" passes on a constant
+        // that happens to equal the default band.
+        const narrow = buildEmbeddingProbeInput({estimateBandTokens: Math.floor(SHIPPED_BAND.estimateBandTokens / 4)});
+
+        expect(narrow.estimateTokens).toBeLessThan(sized.estimateTokens);
+    });
+
+    test('the fraction is honoured, and a full-band probe is reachable', () => {
+        const quarter = buildEmbeddingProbeInput({estimateBandTokens: 4000, fraction: 0.25}),
+              full    = buildEmbeddingProbeInput({estimateBandTokens: 4000, fraction: 1});
+
+        expect(quarter.estimateTokens).toBe(1000);
+        expect(full.estimateTokens).toBe(4000);
+    });
+
+    test('an unresolvable band still probes, and SAYS it probed unsized', () => {
+        // Refusing to probe would remove a signal; probing silently at marker size would recreate the
+        // defect. The third option is the honest one: probe, and report the coverage.
+        for (const estimateBandTokens of [null, undefined, 0, -1, Number.NaN]) {
+            const unsized = buildEmbeddingProbeInput({estimateBandTokens});
+
+            expect(unsized.sized).toBe(false);
+            expect(unsized.fraction).toBeNull();
+            expect(unsized.input.length).toBeGreaterThan(0);
+        }
+
+        // An out-of-range fraction is a caller defect, and it must read as unsized rather than as a
+        // silent clamp — a clamped probe would report a fraction it did not exercise.
+        expect(buildEmbeddingProbeInput({estimateBandTokens: 4000, fraction: 1.5}).sized).toBe(false);
+        expect(buildEmbeddingProbeInput({estimateBandTokens: 4000, fraction: 0}).sized).toBe(false);
+    });
+
+    test('the generated text is varied, because a repeated character is not a workload', () => {
+        // A run-length-trivial input collapses in the tokenizer, which would put the real token count
+        // far below the estimate the caller believes it asked for — a sized probe that is not.
+        const {input} = buildEmbeddingProbeInput({estimateBandTokens: 3000});
+
+        expect(new Set(input).size).toBeGreaterThan(10);
+        expect(input.startsWith('neo-embedding-probe')).toBe(true);
+    });
+});
+
+test.describe('buildEmbeddingProbeBlock — no verdict is unqualified about its size (#17337)', () => {
+    test('RED-PROOF: the tiny constant reports healthy where the band-sized input dies', async () => {
+        // The incident, reproduced against a provider that dies above ~1,000 estimate-tokens — the
+        // same shape as an engine OOM-killed by a real batch while answering 9- and 10-token inputs.
+        const
+            embedText = dyingAbove(1000),
+            legacy    = await buildEmbeddingProbeBlock({
+                cfg, embedText, input: 'neo-tenant-repo-sync-embedding-recovery-canary',
+                operationLabel: 'probe', timeoutMs: 5_000
+            }),
+            sized     = buildEmbeddingProbeInput({estimateBandTokens: SHIPPED_BAND.estimateBandTokens}),
+            current   = await buildEmbeddingProbeBlock({
+                cfg, embedText, input: sized.input, operationLabel: 'probe', probeSize: sized, timeoutMs: 5_000
+            });
+
+        expect(legacy.status).toBe('healthy');
+        expect(current.status).toBe('failed');
+        expect(current.errorClassification).toBe('provider-died');
+
+        // CONTROL: a provider that dies on EVERYTHING reports failed both ways, so it could not have
+        // shown that size is what decides. The threshold is the proof, not the failure.
+        const alwaysDies = dyingAbove(0);
+
+        expect((await buildEmbeddingProbeBlock({
+            cfg, embedText: alwaysDies, input: 'tiny', operationLabel: 'probe', timeoutMs: 5_000
+        })).status).toBe('failed');
+    });
+
+    test('the size travels on EVERY verdict, healthy included', async () => {
+        const
+            sized   = buildEmbeddingProbeInput({estimateBandTokens: 8000}),
+            healthy = await buildEmbeddingProbeBlock({
+                cfg, embedText: async () => new Array(cfg.vectorDimension).fill(0.1),
+                input: sized.input, operationLabel: 'probe', probeSize: sized, timeoutMs: 5_000
+            }),
+            failed  = await buildEmbeddingProbeBlock({
+                cfg, embedText: dyingAbove(1), input: sized.input, operationLabel: 'probe',
+                probeSize: sized, timeoutMs: 5_000
+            }),
+            short   = await buildEmbeddingProbeBlock({
+                cfg, embedText: async () => new Array(8).fill(0.1),
+                input: sized.input, operationLabel: 'probe', probeSize: sized, timeoutMs: 5_000
+            });
+
+        // The healthy path is the one that mattered: an unqualified `healthy` is exactly what a
+        // consumer read as readiness for admitted-size work.
+        for (const result of [healthy, failed, short]) {
+            expect(result.probeEstimateTokens).toBe(2000);
+            expect(result.probeBandFraction).toBe(0.25);
+            expect(result.probeSized).toBe(true);
+        }
+
+        expect(healthy.status).toBe('healthy');
+        expect(failed.status).toBe('failed');
+        expect(short.status).toBe('failed');
+    });
+
+    test('a probe with no size block reports absent coverage rather than omitting it', async () => {
+        const result = await buildEmbeddingProbeBlock({
+            cfg, embedText: async () => new Array(cfg.vectorDimension).fill(0.1),
+            input: 'x', operationLabel: 'probe', timeoutMs: 5_000
+        });
+
+        expect(result.status).toBe('healthy');
+        expect(result.probeSized).toBe(false);
+        expect(result.probeEstimateTokens).toBeNull();
+        expect(result.probeBandFraction).toBeNull();
+    });
+});
+
+test.describe('describeEmbeddingProbeFailure — death is not the same fact as failure (#17337)', () => {
+    test('a provider that DIES mid-answer is classified apart from one that never answered', () => {
+        // The discrimination a recovery probe needs. `provider-unreachable` means the connection
+        // never came up — ambient, and the lane may be fine once it does. `provider-died` means the
+        // request was accepted and the process went away, which is what an OOM kill leaves behind:
+        // direct evidence that this lane cannot serve this input.
+        const classify = code => {
+            const error = new Error('x');
+            error.code  = code;
+
+            return describeEmbeddingProbeFailure(error).errorClassification
+        };
+
+        for (const code of ['ECONNRESET', 'EPIPE', 'UND_ERR_SOCKET', 'ERR_STREAM_PREMATURE_CLOSE']) {
+            expect(classify(code)).toBe('provider-died');
+        }
+
+        // CONTROL: the neighbouring classifications are unchanged, so "death" did not swallow them.
+        expect(classify('ECONNREFUSED')).toBe('provider-unreachable');
+        expect(classify('PROVIDER_TIMEOUT')).toBe('provider-timeout');
+        expect(classify('EMBEDDING_MODEL_NOT_RESIDENT')).toBe('model-not-resident');
+        expect(classify('SOMETHING_UNMAPPED')).toBe('provider-failure');
+    });
+});

--- a/test/playwright/unit/ai/services/shared/embeddingProbe.spec.mjs
+++ b/test/playwright/unit/ai/services/shared/embeddingProbe.spec.mjs
@@ -156,16 +156,21 @@ test.describe('buildEmbeddingProbeBlock — no verdict is unqualified about its 
         expect(short.status).toBe('failed');
     });
 
-    test('a probe with no size block reports absent coverage rather than omitting it', async () => {
+    test('a caller supplying no size leaves the payload untouched', async () => {
+        // The other consumers of this helper are healthcheck WRITE CANARIES — deliberately
+        // liveness-only, deliberately tiny, not read as readiness for real work. Emitting the
+        // coverage fields as nulls there would change two other services' public health contracts to
+        // describe a size they never claimed to exercise. The surface that IS read as readiness
+        // declares them explicitly at its own projection instead.
         const result = await buildEmbeddingProbeBlock({
             cfg, embedText: async () => new Array(cfg.vectorDimension).fill(0.1),
             input: 'x', operationLabel: 'probe', timeoutMs: 5_000
         });
 
         expect(result.status).toBe('healthy');
-        expect(result.probeSized).toBe(false);
-        expect(result.probeEstimateTokens).toBeNull();
-        expect(result.probeBandFraction).toBeNull();
+        expect(Object.hasOwn(result, 'probeSized')).toBe(false);
+        expect(Object.hasOwn(result, 'probeEstimateTokens')).toBe(false);
+        expect(Object.hasOwn(result, 'probeBandFraction')).toBe(false);
     });
 });
 


### PR DESCRIPTION
Resolves #17337

The probe sent a **44-byte constant** while production inputs ran to ~14,000 tokens, and peak memory for one non-causal embedding request scales with the **square** of its token count. So it certified a property nobody asked about — whether the HTTP plane answers at all — while the property under question went unmeasured.

That verdict is what the tenant sweep consults to decide the lane has recovered. Every `healthy` re-dispatched the batch that killed the engine: **36 restarts**, three repositories `backoff-suppressed`, and `failureStreak: 0` reported **two seconds after** the sweep's own `lastErrorAt`.

Evidence: L2 required → **L2 achieved for probe sizing and coverage delivery. NOT yet achieved for recovery eligibility — see RA-1 below, which is open.** **Residual-Owner: #17501** (the sweep/probe disagreement detector, Fix item 4). 656 arms green across the affected families; three mutation runs, each reddening exactly its own arm.

## Round 2 — @neo-gpt found the wire declared at both ends and never connected

**RA-2 — three permanently-empty fields passed green CI. Fixed.** `buildEmbeddingProbeBlock` produced `probeEstimateTokens` / `probeBandFraction` / `probeSized`, and the bridge summarizer declared them — and `getEmbeddingRecoveryProbeSnapshot()` between them projects an explicit **allowlist** that did not include them. Both ends were right; the wire was never connected. **A verdict that reports its coverage as absent, always, is worse than one that does not report coverage at all: it looks answered.**

My arms could not have caught it. They tested the producer, and they tested the bridge with a handwritten no-size fixture — each end in isolation, so the hop where the drop happened had no coverage. **Reverting the projection left all seventeen of them green.** One exported `projectProbeCoverage` now serves every hop, and the new arm drives the real snapshot getter: reverting the projection reddens it, which is the difference between fixing this and appearing to.

**RA-3 — I scoped out an obligation on the grounds that it had no AC. Conceded.** *"An omitted AC does not retire an explicit Fix obligation"* is right, and it is the second time today a reviewer has caught my Out-of-Scope reasoning standing in for a reading of the ticket. Fix item 4 is now **#17501**, with the live sweep confirming no other owner, and the Evidence line above no longer claims "no residual".

**RA-1 — OPEN, and it is the P1.** Recovery eligibility at `TenantRepoSyncService.mjs:1922` still reads `observation?.status === 'healthy'` and mints the bypass generation from status alone — so a verdict reached at 25% of the admitted band authorizes the full re-dispatch it never bounded. The coverage now *reaches* that decision; the decision does not yet *use* it. My design read and the fork are in the review response; I have not implemented it because the two available shapes have materially different costs and the reviewer named both.

## Deltas from ticket

**None on scope besides RA-3's correction above.** Two numbers are mine and both are derived from the ticket's own measurements rather than chosen.

**The fraction.** The ticket prescribes probing at *"a declared fraction of the ceiling"* without naming it. Priced from the incident: idle 7.69 GiB, one 13,980-token embed peaking at 24.14 GiB, so ~16.45 GiB marginal, scaling with n². At fraction `f` of a 28,672-token band the marginal cost is `16.45 × (28672f / 13980)²` GiB:

| f | estimate-tokens | marginal |
|---|---|---|
| 0.10 | 2,124 | ~0.7 GiB |
| **0.25** | **5,309** | **~4.3 GiB** |
| 0.50 | 10,619 | ~17.3 GiB — the size that was doing the killing |

0.25 buys **354×** the discrimination of the constant it replaces at roughly a quarter of the killing request's footprint.

**It is a module default every caller may override, not a config leaf.** The arithmetic above is deployment-specific, but no deployment has asked to tune it, and a leaf nobody sets is a knob to maintain rather than a value to read. What makes that safe is the reporting: the probe carries whichever fraction it used onto its verdict, so `healthy` is unreadable as healthy-at-full-size regardless of who picked the number.

**Where the band is read.** `resolveEmbeddingAdmissionBand` already exists and already governs admission at three sites. The leaves are read **at the use site that owns the decision** (`TenantRepoSyncService`, which already imports `AiConfig`) and injected into a pure builder, so `embeddingProbe.mjs` stays Neo-free — ADR-0019 C1, and the sanctioned shape for B5. Resolved per probe rather than cached, so a deployment that narrows its slot mid-run is probed against the ceiling it actually has.

**`sized: false` is a reading, not a fallback.** When the band cannot be resolved the probe still runs — refusing would remove a signal — but it reports that it ran unsized, so `healthy` is legible as *"the plane answered"* rather than *"the lane can serve admitted work"*. An out-of-range fraction reports unsized too, rather than clamping: a clamped probe would report a fraction it did not exercise.

## Death is not the same fact as failure

`ECONNRESET`, `EPIPE`, `UND_ERR_SOCKET` and `ERR_STREAM_PREMATURE_CLOSE` now classify as **`provider-died`**, distinct from the existing `provider-unreachable`.

The difference decides what a consumer may conclude. `ECONNREFUSED` means the connection never came up — ambient, and the lane may be fine once it does. These four mean the connection came up, the request was accepted, and the process went away mid-answer. **That is what an OOM kill leaves behind**, and it is the one observation a recovery probe exists to make.

## Test Evidence

**656 arms green** across `embeddingProbe` / `TenantRepoSyncService` / `DeploymentStateBridgeService` / `HealthService` / `TextEmbeddingService`. **19 new**, most in a new `test/playwright/unit/ai/services/shared/embeddingProbe.spec.mjs`:

| arm | pins |
|---|---|
| the input derives from the admitted band, not a constant | AC-1, with a **narrower-band** arm so "derives from the band" cannot pass on a constant that happens to equal the default |
| the byte cost is exactly `estimateTokens × 3` | AC-6 — a reader can price a cadence probe without running one |
| the fraction is honoured, full-band reachable | the knob works in both directions |
| an unresolvable band still probes and says so | `null` / `0` / `-1` / `NaN` / out-of-range fraction |
| the generated text is varied | a run-length-trivial input collapses in the tokenizer — a sized probe that is not |
| **RED-PROOF:** tiny constant reports `healthy` where the band-sized input dies | AC-5 |
| **CONTROL:** a provider that dies on *everything* fails both ways | the threshold is the proof, not the failure |
| the size travels on EVERY verdict, `healthy` included | AC-2 — the healthy path is the one that mattered |
| a caller supplying no size leaves the payload untouched | the health write canaries are liveness-only and keep their contract |
| **the size reaches the process-owned SNAPSHOT, not just the probe result** | RA-2 — the hop, which is where the drop was |
| **CONTROL:** a snapshot with no probe result reports absent coverage | it must not carry the previous run's size forward |
| `projectProbeCoverage` rejects a malformed value | a string, a non-integer or a truthy non-boolean is not a coverage claim |
| death classified apart from unreachable | AC-4, **plus a control** that the four neighbouring classifications are unchanged |

**The red-proof is the ticket's own stipulation.** The stub provider dies *above a token threshold*: a stub that failed on all inputs would report unhealthy before and after and prove nothing, and one that failed on none would do the reverse. Only a size-dependent failure shows that the probe's **size** is what decides the verdict.

**Three mutation runs, each reddening exactly its own arm:**

| mutation | reddens |
|---|---|
| restore the shipped constant size (`estimateTokens = 15`) | 4 arms including the red-proof; classification arms stay green, correctly |
| drop the size block from callers that ask | the write-canary contract arm |
| **drop the projection from the snapshot (RA-2's defect)** | the snapshot-hop arm — and **nothing else**, which is exactly why it shipped |

That last row is the one worth reading: before the hop arm existed, the same mutation left all seventeen arms green.

**One existing arm updated rather than loosened.** `DeploymentStateBridgeService.spec.mjs` pins the public projection's exact key set with `toEqual`; the three coverage fields are added there, asserting `null`/`false` for a probe snapshot that names no size. That is the assertion which would otherwise have let the fields ship without reaching the surface a consumer reads.

## Post-Merge Validation

On a deployment running the `openAiCompatible` lane, read `tenantRepoSync.embeddingRecoveryProbe`: it carries `probeEstimateTokens`, `probeBandFraction` and `probeSized` alongside `status`. On a lane that serves small inputs and dies on admitted-size ones, `status` is now `failed` with `errorClassification: 'provider-died'` where it previously read `healthy` with `failureStreak: 0`.

## Out of Scope

Per the ticket: the container healthcheck (correctly liveness-only), chunk graduation (#17336), batch sizing (#16972), and the recovery actuator's admitted actions.

~~Also not done, and worth naming: the ticket's Fix item 4 has **no acceptance criterion**, and it is a different mechanism … a detector for the general case belongs with whoever owns the sweep/probe reconciliation.~~ **Withdrawn in Round 2.** An omitted AC does not retire an explicit Fix obligation, and the live sweep found no other owner — so "belongs with whoever owns it" named nobody. Now **#17501**. Struck rather than deleted, because the reasoning was a scope argument standing in for a reading of the ticket, and that is the part worth seeing.

## Evolution

**A control whose shape does not match its subject's cannot bound the subject's behaviour** — and the tell is that it never fails. A probe three orders of magnitude below the workload has no failure mode in common with it, so its green light is wired to a different circuit.

The half that is easy to get wrong is the fix: probing at the full ceiling would have made the probe itself the thing that starves the lane. **The honest resolution is not a bigger probe — it is a probe that reports its own coverage**, so a partial measurement is legible as partial instead of being read as a whole one.

Authored by Ada (Claude Opus 5, Claude Code). Session ab15d2b8-eb14-4237-ad18-ce48584b2d07.
