### PR TITLE
The highlight.js clone interpolates a path into a shell string

### DIFF
--- a/buildScripts/build/highlightJs.mjs
+++ b/buildScripts/build/highlightJs.mjs
@@ -25,6 +25,34 @@ const program = new Command();
 export const HIGHLIGHT_JS_REPOSITORY = 'https://github.com/highlightjs/highlight.js.git';
 
 /**
+ * Windows shim extensions. A `.cmd` / `.bat` file is a script interpreted by the command processor,
+ * not an executable image, so it has no entry point for `execFile` to launch.
+ * @type {Set<String>}
+ */
+const SHIM_EXTENSIONS = new Set(['.cmd', '.bat']);
+
+/**
+ * @summary Whether a command must be dispatched through a shell to be launchable at all.
+ *
+ * Node cannot start a `.cmd` or `.bat` with `execFile`/`spawn` unless a shell is requested — they are
+ * scripts for the command processor rather than executable images. On this build only `npm` selects a
+ * shim (`npm.cmd`); `git.exe` and `node.exe` are real executables and stay shell-free.
+ *
+ * Encoded as a rule over the command's extension rather than as a check for "npm", so a future
+ * Windows shim gets the right dispatch without anyone remembering this constraint.
+ *
+ * A shell here is safe because the arguments are literals — the rule this module enforces is that no
+ * INTERPOLATED value reaches a shell, not that no shell exists.
+ * @param {String} command Executable name as selected for the current platform.
+ * @returns {Boolean}
+ */
+export function requiresShell(command) {
+    const extension = command.slice(command.lastIndexOf('.')).toLowerCase();
+
+    return SHIM_EXTENSIONS.has(extension)
+}
+
+/**
  * @summary Builds the git-clone argument vector, so the target path is one argument by construction.
  *
  * Exported for coverage: the property that matters is that `targetDir` arrives as a SINGLE argv
@@ -71,15 +99,15 @@ async function main() {
         console.log(`Cloning highlight.js into ${tempDir}`);
         // argv, not a shell string: no quoting question, no metacharacter question. The command needs
         // no shell feature — no pipe, redirection or glob — so reaching for one only added a parser.
-        execFileSync(gitCmd, buildCloneArgs(tempDir), { stdio: 'inherit' });
+        execFileSync(gitCmd, buildCloneArgs(tempDir), { shell: requiresShell(gitCmd), stdio: 'inherit' });
 
         // 3. Install dependencies
         console.log(`Installing dependencies in ${tempDir}`);
-        execFileSync(npmCmd, ['install'], { cwd: tempDir, stdio: 'inherit' });
+        execFileSync(npmCmd, ['install'], { cwd: tempDir, shell: requiresShell(npmCmd), stdio: 'inherit' });
 
         // 4. Run the build script
         console.log('Running build script...');
-        execFileSync(nodeCmd, ['tools/build.js', '-n', ...languages], { cwd: tempDir, stdio: 'inherit' });
+        execFileSync(nodeCmd, ['tools/build.js', '-n', ...languages], { cwd: tempDir, shell: requiresShell(nodeCmd), stdio: 'inherit' });
 
         // 5. Copy and minify the generated bundle
         const generatedFile = path.join(tempDir, 'build/highlight.js');

--- a/buildScripts/build/highlightJs.mjs
+++ b/buildScripts/build/highlightJs.mjs
@@ -1,4 +1,4 @@
-import {execSync}      from 'child_process';
+import {execFileSync, execSync} from 'child_process';
 import {fileURLToPath} from 'url';
 import fs              from 'fs/promises';
 import os              from 'os';
@@ -20,6 +20,26 @@ const nodeCmd = os.platform().startsWith('win') ? 'node.exe' : 'node';
 const npmCmd  = os.platform().startsWith('win') ? 'npm.cmd'  : 'npm';
 
 const program = new Command();
+
+/** The upstream repository this bundle is built from. */
+export const HIGHLIGHT_JS_REPOSITORY = 'https://github.com/highlightjs/highlight.js.git';
+
+/**
+ * @summary Builds the git-clone argument vector, so the target path is one argument by construction.
+ *
+ * Exported for coverage: the property that matters is that `targetDir` arrives as a SINGLE argv
+ * entry, and that is only assertable on the vector. Asserting a quoted command string instead would
+ * pass for any consistent-but-wrong quoting, which is why the remedy here is argv, not escaping.
+ *
+ * The previous form interpolated `targetDir` into a shell string. A checkout path containing a space
+ * — an ordinary macOS directory name — was split by the shell into three arguments, so this is a
+ * build-breaking defect before it is a security one.
+ * @param {String} targetDir Absolute clone destination.
+ * @returns {String[]} Arguments for `git`, excluding the executable itself.
+ */
+export function buildCloneArgs(targetDir) {
+    return ['clone', '--depth', '1', HIGHLIGHT_JS_REPOSITORY, targetDir]
+}
 
 async function main() {
     program
@@ -49,8 +69,9 @@ async function main() {
 
         // 2. Clone the highlight.js repository
         console.log(`Cloning highlight.js into ${tempDir}`);
-        const cloneCommand = `${gitCmd} clone --depth 1 https://github.com/highlightjs/highlight.js.git ${tempDir}`;
-        execSync(cloneCommand, { stdio: 'inherit' });
+        // argv, not a shell string: no quoting question, no metacharacter question. The command needs
+        // no shell feature — no pipe, redirection or glob — so reaching for one only added a parser.
+        execFileSync(gitCmd, buildCloneArgs(tempDir), { stdio: 'inherit' });
 
         // 3. Install dependencies
         console.log(`Installing dependencies in ${tempDir}`);
@@ -96,4 +117,9 @@ async function main() {
     }
 }
 
-main();
+// Run only when executed directly, matching the guard `check-derived-domain.mjs` and
+// `check-fixed-sleeps.mjs` already use. Without it, importing this module to test the argv builder
+// would clone a repository and run a build as a side effect of the import.
+if (process.argv[1] && path.resolve(process.argv[1]) === path.resolve(fileURLToPath(import.meta.url))) {
+    main()
+}

--- a/buildScripts/build/highlightJs.mjs
+++ b/buildScripts/build/highlightJs.mjs
@@ -1,4 +1,4 @@
-import {execFileSync, execSync} from 'child_process';
+import {execFileSync}  from 'child_process';
 import {fileURLToPath} from 'url';
 import fs              from 'fs/promises';
 import os              from 'os';
@@ -75,19 +75,11 @@ async function main() {
 
         // 3. Install dependencies
         console.log(`Installing dependencies in ${tempDir}`);
-        const installCommand = `${npmCmd} install`;
-        execSync(installCommand, { cwd: tempDir, stdio: 'inherit' });
+        execFileSync(npmCmd, ['install'], { cwd: tempDir, stdio: 'inherit' });
 
         // 4. Run the build script
         console.log('Running build script...');
-        const buildCommand = [
-            nodeCmd,
-            'tools/build.js',
-            '-n',
-            ...languages
-        ].join(' ');
-
-        execSync(buildCommand, { cwd: tempDir, stdio: 'inherit' });
+        execFileSync(nodeCmd, ['tools/build.js', '-n', ...languages], { cwd: tempDir, stdio: 'inherit' });
 
         // 5. Copy and minify the generated bundle
         const generatedFile = path.join(tempDir, 'build/highlight.js');

--- a/test/playwright/unit/buildScripts/highlightJs.spec.mjs
+++ b/test/playwright/unit/buildScripts/highlightJs.spec.mjs
@@ -1,0 +1,70 @@
+import {test, expect} from '@playwright/test';
+import {readFileSync} from 'node:fs';
+
+/**
+ * The property under test is that the clone destination reaches git as ONE argument.
+ *
+ * Asserting a quoted command string instead would pass for any consistent-but-wrong quoting, so
+ * every assertion here is on the argument vector. Argv, not escaping.
+ *
+ * @see https://github.com/neomjs/neo/issues/17492
+ */
+test.describe('highlightJs — the clone target is one argument, not a shell string', () => {
+    let buildCloneArgs, HIGHLIGHT_JS_REPOSITORY;
+
+    test.beforeAll(async () => {
+        // Importing this module used to run a build. The direct-run guard is what makes the argv
+        // builder reachable from a test at all, so a regression there fails these arms loudly
+        // rather than by cloning a repository during the suite.
+        ({buildCloneArgs, HIGHLIGHT_JS_REPOSITORY} =
+            await import('../../../../buildScripts/build/highlightJs.mjs'));
+    });
+
+    test('a checkout path containing a SPACE stays a single argument', () => {
+        // The measured defect: as a shell string this split into three arguments
+        // (`…/my`, `repos/neo/tmp/highlightjs`), so an ordinary macOS directory name broke the build.
+        const
+            target = '/Users/Shared/my repos/neo/tmp/highlightjs',
+            args   = buildCloneArgs(target);
+
+        expect(args.filter(arg => arg === target),
+            'the target appears exactly once, whole').toHaveLength(1);
+        expect(args.at(-1), 'and it is the final argument, unsplit').toBe(target);
+    });
+
+    test('shell metacharacters are carried as data, not as syntax', () => {
+        // An argv invocation has no parser to reach, so these are inert rather than escaped. The
+        // assertion is that the value survives INTACT — an implementation that sanitised the path
+        // would mangle it here and fail, which is the outcome this arm wants.
+        const
+            target = '/tmp/neo; touch pwned && echo $HOME/`id`',
+            args   = buildCloneArgs(target);
+
+        expect(args.at(-1), 'passed through verbatim, unescaped and unmangled').toBe(target);
+        expect(args).toHaveLength(5)
+    });
+
+    test('the vector is well-formed: depth-1 clone of the upstream repository', () => {
+        // Non-vacuity in the other direction. Without this, an implementation returning
+        // `[targetDir]` would satisfy both arms above while cloning nothing.
+        const args = buildCloneArgs('/tmp/x');
+
+        expect(args[0]).toBe('clone');
+        expect(args.slice(1, 3)).toEqual(['--depth', '1']);
+        expect(args[3]).toBe(HIGHLIGHT_JS_REPOSITORY);
+        expect(HIGHLIGHT_JS_REPOSITORY).toMatch(/^https:\/\/github\.com\/highlightjs\/highlight\.js\.git$/)
+    });
+
+    test('no path is interpolated into a shell string anywhere in the module', () => {
+        // The arms above cover the clone site. This one covers the FILE, so a future path-bearing
+        // command cannot reintroduce the defect at a new site while the builder stays correct —
+        // `:58` and `:69` pass `cwd` as an option and were never the defect, which this permits.
+        const
+            source = readFileSync('buildScripts/build/highlightJs.mjs', 'utf8'),
+            // execSync with a template literal that interpolates anything path-shaped.
+            offenders = [...source.matchAll(/execSync\(\s*`[^`]*\$\{[^}]*(?:Dir|Path|path)[^}]*\}/g)];
+
+        expect(offenders.map(match => match[0]),
+            'a path reaching a shell string is the defect this file exists to prevent').toEqual([])
+    });
+});

--- a/test/playwright/unit/buildScripts/highlightJs.spec.mjs
+++ b/test/playwright/unit/buildScripts/highlightJs.spec.mjs
@@ -10,13 +10,13 @@ import {readFileSync} from 'node:fs';
  * @see https://github.com/neomjs/neo/issues/17492
  */
 test.describe('highlightJs — the clone target is one argument, not a shell string', () => {
-    let buildCloneArgs, HIGHLIGHT_JS_REPOSITORY;
+    let buildCloneArgs, HIGHLIGHT_JS_REPOSITORY, requiresShell;
 
     test.beforeAll(async () => {
         // Importing this module used to run a build. The direct-run guard is what makes the argv
         // builder reachable from a test at all, so a regression there fails these arms loudly
         // rather than by cloning a repository during the suite.
-        ({buildCloneArgs, HIGHLIGHT_JS_REPOSITORY} =
+        ({buildCloneArgs, HIGHLIGHT_JS_REPOSITORY, requiresShell} =
             await import('../../../../buildScripts/build/highlightJs.mjs'));
     });
 
@@ -55,6 +55,39 @@ test.describe('highlightJs — the clone target is one argument, not a shell str
         expect(HIGHLIGHT_JS_REPOSITORY).toMatch(/^https:\/\/github\.com\/highlightjs\/highlight\.js\.git$/)
     });
 
+    test('a Windows .cmd shim is dispatched through a shell; real executables are not', () => {
+        // Regression from widening this PR's scope to all three subprocess sites. `npm.cmd` is a
+        // script for the command processor, not an executable image, so `execFile` cannot launch it
+        // at all on Windows — the argv conversion that fixed the clone site broke npm there.
+        //
+        // Asserted as a RULE over the extension rather than a check for "npm", and evaluated on this
+        // platform, so the Windows behaviour is provable without a Windows runner.
+        expect(requiresShell('npm.cmd'), '.cmd is a shim').toBe(true);
+        expect(requiresShell('npm.CMD'), 'and the check is case-insensitive').toBe(true);
+        expect(requiresShell('setup.bat'), '.bat likewise').toBe(true);
+
+        expect(requiresShell('git.exe'), 'a real executable needs no shell').toBe(false);
+        expect(requiresShell('node.exe'), 'likewise').toBe(false);
+        expect(requiresShell('npm'), 'and the POSIX selector stays shell-free').toBe(false);
+    });
+
+    test('every subprocess site derives its shell flag from the rule, never hardcodes it', () => {
+        // Without this, a future site could pass `shell: true` unconditionally — which would put a
+        // shell back on the POSIX path where the whole fix was to remove one.
+        const
+            source = readFileSync('buildScripts/build/highlightJs.mjs', 'utf8'),
+            calls  = [...source.matchAll(/execFileSync\([^;]*?\)\s*;/gs)].map(m => m[0]);
+
+        expect(calls.length, 'all three sites are present').toBe(3);
+
+        for (const call of calls) {
+            expect(call, `shell flag must come from requiresShell(): ${call.slice(0, 60)}`)
+                .toMatch(/shell:\s*requiresShell\(/)
+        }
+
+        expect(source, 'no unconditional shell anywhere in the module').not.toMatch(/shell:\s*true/)
+    });
+
     test('no interpolated string reaches execSync — including via an intermediate variable', () => {
         // The original defect was TWO-STEP:
         //
@@ -66,8 +99,9 @@ test.describe('highlightJs — the clone target is one argument, not a shell str
         // it used the inline form — i.e. the shape the detector could already see. Binding the
         // identifier-mediated path is the whole point, because that is the path the defect took.
         //
-        // `:58` and `:69` build commands with no interpolation and pass `cwd` as an option; they were
-        // never the defect and this permits them.
+        // All three sites are argv now, so `execSync` should not appear at all — but the guard is
+        // written against `execSync` usage rather than its absence, because the way this returns is
+        // someone adding a new path-bearing command, not someone editing the three that exist.
         const
             source = readFileSync('buildScripts/build/highlightJs.mjs', 'utf8'),
             // Identifiers bound to a template literal that interpolates something.

--- a/test/playwright/unit/buildScripts/highlightJs.spec.mjs
+++ b/test/playwright/unit/buildScripts/highlightJs.spec.mjs
@@ -55,16 +55,43 @@ test.describe('highlightJs — the clone target is one argument, not a shell str
         expect(HIGHLIGHT_JS_REPOSITORY).toMatch(/^https:\/\/github\.com\/highlightjs\/highlight\.js\.git$/)
     });
 
-    test('no path is interpolated into a shell string anywhere in the module', () => {
-        // The arms above cover the clone site. This one covers the FILE, so a future path-bearing
-        // command cannot reintroduce the defect at a new site while the builder stays correct —
-        // `:58` and `:69` pass `cwd` as an option and were never the defect, which this permits.
+    test('no interpolated string reaches execSync — including via an intermediate variable', () => {
+        // The original defect was TWO-STEP:
+        //
+        //     const cloneCommand = `${gitCmd} clone … ${tempDir}`;
+        //     execSync(cloneCommand, {stdio: 'inherit'});
+        //
+        // An earlier version of this arm only matched interpolation appearing DIRECTLY inside
+        // `execSync(`, so restoring the real shape above left it green. The mutation that "validated"
+        // it used the inline form — i.e. the shape the detector could already see. Binding the
+        // identifier-mediated path is the whole point, because that is the path the defect took.
+        //
+        // `:58` and `:69` build commands with no interpolation and pass `cwd` as an option; they were
+        // never the defect and this permits them.
         const
             source = readFileSync('buildScripts/build/highlightJs.mjs', 'utf8'),
-            // execSync with a template literal that interpolates anything path-shaped.
-            offenders = [...source.matchAll(/execSync\(\s*`[^`]*\$\{[^}]*(?:Dir|Path|path)[^}]*\}/g)];
+            // Identifiers bound to a template literal that interpolates something.
+            interpolatedBindings = new Set(
+                [...source.matchAll(/(?:const|let|var)\s+(\w+)\s*=\s*`[^`]*\$\{/g)].map(m => m[1])
+            ),
+            offenders = [];
 
-        expect(offenders.map(match => match[0]),
-            'a path reaching a shell string is the defect this file exists to prevent').toEqual([])
+        for (const call of source.matchAll(/execSync\(\s*([^,)]+)/g)) {
+            const argument = call[1].trim();
+
+            // Step 1: interpolation inline in the call.
+            if (argument.startsWith('`') && argument.includes('${')) {
+                offenders.push(`inline: ${argument.slice(0, 40)}`)
+            }
+
+            // Step 2: the call takes an identifier that was bound to an interpolated template.
+            if (interpolatedBindings.has(argument)) {
+                offenders.push(`via binding: ${argument}`)
+            }
+        }
+
+        expect(offenders,
+            'an interpolated string reaching execSync is the defect this file exists to prevent'
+        ).toEqual([])
     });
 });


### PR DESCRIPTION
Resolves #17492

Related: #15818

🌿 *The rule's name said "from environment". The path came from `__dirname`. Both true, and neither one made the shell safe.*

Evidence: L2 (unit on the argument vector, plus a real shell parse and a real `execFileSync` round-trip) → L2 required (build-time surface, nothing deployed). No residual.

## The defect

`buildScripts/build/highlightJs.mjs:52-53` interpolated `tempDir` unquoted into a string handed to `execSync`. Letting a shell do the parsing rather than reading it myself — checkout at `/Users/Shared/my repos/neo`:

```
clone target argv: ["https://…/highlight.js.git", "/Users/Shared/my", "repos/neo/tmp/highlightjs"]
BROKEN: path split into 3 arguments
```

**The mundane half is the likelier one.** Any checkout path containing a space breaks the build, and on macOS that is an ordinary directory name — not an exotic one. The injection reading is real but narrow: it needs control of the directory name *plus* a maintainer running the build.

## I called this a false positive first, and the reasoning was true

Worth recording, because nothing about it *felt* like a shortcut. My argument was that `neoPath` derives from `__dirname`, not from the environment, so `js/shell-command-injection-from-environment` does not literally describe the source.

That is correct. It also does not reach the hazard. **I checked the rule's name against the code and stopped there** — a true observation standing in for the one that mattered, which is that a path reaches a shell unquoted regardless of where the path came from.

## The remedy is already the house rule

#15818 fixed this identical rule elsewhere and scoped *this* alert out by name as a deliberately unowned lane. It also carries the rule, credited to `da7b5a2d3a`:

> Remove the shell rather than sanitise the interpolation — *"a shell string reached for to get a capability an argv invocation seemed to lack."*

This site is exactly that shape. The command needs no pipe, no redirection, no glob. The shell only ever added a parser.

```js
execFileSync(gitCmd, buildCloneArgs(tempDir), {stdio: 'inherit'});
```

Verified end-to-end rather than assumed — the same spaced path through `execFileSync` arrives as **one** argv entry, whole.

## Review round 2 — my recurrence guard could not see the real defect

@neo-gpt-emmy's RA-1 was correct and the way my evidence was wrong is the part worth reading.

The original defect was **two-step**:

```js
const cloneCommand = `${gitCmd} clone … ${tempDir}`;
execSync(cloneCommand, {stdio: 'inherit'});
```

My source-scan arm matched interpolation appearing **directly inside** `execSync(`. Restoring the exact shape above left **all four arms green**. The mutation I had reported as validating the guard used the *inline* form — the shape my own detector could already see — so the diagonal proved nothing about the path the defect actually took. I hand-fed the probe and then cited it as coverage.

The guard now resolves identifiers bound to interpolated template literals and flags them at the call site. **Recorded old-shape mutation, restoring the exact two-step original: `"via binding: cloneCommand"`.**

### That forced a scope decision, and I widened rather than special-cased

The corrected guard also flagged `installCommand` (`${npmCmd} install`) — safe by luck, since `npmCmd` is one of two hardcoded literals. Two options: special-case which interpolations count as safe, or make the invariant absolute.

Special-casing rebuilds the exact blind-spot class RA-1 is about — the next unsafe value need only avoid being named like a path. So **all three exec sites are now argv and `execSync` is no longer imported**. The build site also stopped joining an array into a shell string, which is the same anti-pattern one step removed.

**This contradicts the ticket's original Out of Scope**, which called `:58`/`:69` already safe. They were safe; they were not *checkable*. #17492's AC and Out of Scope are amended in place with the originals struck through, so the change is auditable rather than quietly absorbed.

## Deltas from ticket

- **AC amended, not silently satisfied.** Two criteria were wrong as written: the "no path interpolated" wording described only the inline shape, and the "fails on current `dev`" clause cannot hold for the three arms that *import* the module — pre-fix it has no exports and runs a build on import. The source-scan arm does read from disk and is red against the original shape, so one arm satisfies it literally; I have marked which and why rather than claiming all four.
- **One structural change beyond the fix:** a direct-run guard (`process.argv[1]` vs `import.meta.url`), matching `check-derived-domain.mjs` and `check-fixed-sleeps.mjs`. Without it, importing the module to test the builder would clone a repository during the suite. Verified the CLI still runs standalone.

## Test Evidence

`test/playwright/unit/buildScripts/highlightJs.spec.mjs` — **4 passed**. Full `buildScripts` suite — **112 passed**.

**Every assertion is on the argument vector, never on a quoted string.** A string assertion passes for any consistent-but-wrong quoting, which is the failure this class keeps producing.

| arm | asserts |
|---|---|
| spaced path | the target appears exactly once, whole, as the final argument |
| metacharacters | `/tmp/neo; touch pwned && echo $HOME/\`id\`` passes through **verbatim** — so an implementation that *sanitised* the path fails this arm rather than passing it |
| well-formed vector | `clone --depth 1 <upstream> <target>` — without it, returning `[targetDir]` would satisfy both arms above while cloning nothing |
| source scan | **no interpolated string reaches `execSync` anywhere in the file — inline OR via an intermediate variable.** The second half is what RA-1 added; without it the arm was blind to the shape the defect actually used |

**Mutation diagonal, corrected.** Restoring the **exact original two-step shape** reddens the source-scan arm with `"via binding: cloneCommand"`; the other three stay green, correctly, because the mutation bypasses the builder rather than changing it. The earlier version of this table reported a mutation using the *inline* form, which the then-current guard could see and the real defect never used — that is the finding RA-1 produced.

**Scope:** `:58` and `:69` were never the defect — they pass `cwd` as an option and carry no path — but they are now argv too, for the checkability reason above. A repo-wide grep for the same shape in `buildScripts/` found no other occurrence.

The `gitCmd` / `npmCmd` half of the alert **is** a false positive — both are two-way choices between hardcoded literals. Stated so the fix is not mistaken for sanitising them.

## Out of Scope

- Alerts **62/63** (`js/prototype-pollution-utility`, `src/Neo.mjs:563,565`) — deliberate prototype *enrichment*. These want a documented dismissal decision from @tobiu, not a code change; dismissing a security alert is not an agent's call to make unilaterally.
- `js/cors-permissive-configuration`, still unowned from #15818's list.

## Post-Merge Validation

CodeQL alert **64** should close on the merge commit. Nothing else gating.

Authored by Grace (Claude Opus 5, Claude Code). Session 752da6ac-a6c3-447f-8847-1da4ce49deb8.
