### PR TITLE
fix(ai): the Round-2 cell parse stops losing the bytes it demands verbatim (#17284)

### DIFF
--- a/ai/services/github-workflow/PullRequestService.mjs
+++ b/ai/services/github-workflow/PullRequestService.mjs
@@ -1207,7 +1207,16 @@ function getRound2DispositionRelationFailure({body, reviews, state}) {
             // instruction they can follow and one they cannot: both known parse causes collapse a
             // pipe into whitespace, so when the two strings agree once pipes and spaces are
             // normalised away, the row is telling us about our own reconstruction.
-            const pipeShaped = collapsePipesAndSpace(row.action) === collapsePipesAndSpace(action);
+            //
+            // The pipe in the EXPECTED text is the cause witness, and it is required rather than
+            // implied. `collapsePipesAndSpace` also removes spaces, so "observed partial" and
+            // "observedpartial" compare equal with no pipe anywhere in either — and the branch below
+            // would then instruct an author to escape a pipe their text does not contain. That is
+            // the unfollowable-instruction class this gate exists to remove, reintroduced by the
+            // diagnosis instead of by the rule. Similarity cannot prove which byte the parser lost;
+            // only the presence of that byte can.
+            const pipeShaped = action.includes('|')
+                && collapsePipesAndSpace(row.action) === collapsePipesAndSpace(action);
 
             defects.push(normalizeQuoteForComparison(row.action) === normalizeQuoteForComparison(action)
                 ? `row ${index + 1} differs from the prior round ONLY in formatting. The quote must be byte-verbatim INCLUDING its markdown, so restore the emphasis exactly as written: "${action}"`
@@ -1509,6 +1518,18 @@ function splitTableRow(line) {
 // silently drops a genuine first cell.
 const ROUND_2_ROW_LABEL_PATTERN = /^(?:§|#)?[ \t]*(?:RA[ _-]?)?\d+[a-z]?\.?$/i;
 
+/**
+ * @summary Reads the Round-2 disposition table out of a review body.
+ *
+ * Selection is deliberately loose and extraction strict. A candidate line is any table row carrying
+ * one of the disposition verbs, because a body that got the table's SHAPE wrong still needs to reach
+ * the validator and be told so — filtering on a well-formed table here would turn a reportable
+ * template error into silence, and the round would then pass by producing no rows to check.
+ *
+ * @param {String} body Review body markdown.
+ * @returns {Object[]} One entry per disposition row, in document order.
+ * @private
+ */
 function extractDispositionRows(body) {
     return String(body || '').split('\n')
         .filter(line => line.trim().startsWith('|') && ROUND_2_DISPOSITIONS.some(verb => line.includes(verb)))

--- a/ai/services/github-workflow/PullRequestService.mjs
+++ b/ai/services/github-workflow/PullRequestService.mjs
@@ -1397,15 +1397,6 @@ function extractRequiredActions(body) {
 }
 
 /**
- * @summary Extracts a Round-2 body's disposition table as `{action, disposition}` rows, in order.
- *
- * Reads the SECOND-to-last cell as the verb and everything before it as the carried action, so a
- * table with or without a trailing Evidence column parses the same way. Separator rows (`|---|`) and
- * the header are dropped by requiring a known verb.
- * @param {String} body
- * @returns {Array<{action: String, disposition: String}>}
- */
-/**
  * @summary Collapses pipes and surrounding whitespace, so a parse-caused mismatch is recognisable.
  *
  * Both known cell-parse defects end the same way: a literal `|` inside a cell is treated as a
@@ -1519,15 +1510,18 @@ function splitTableRow(line) {
 const ROUND_2_ROW_LABEL_PATTERN = /^(?:§|#)?[ \t]*(?:RA[ _-]?)?\d+[a-z]?\.?$/i;
 
 /**
- * @summary Reads the Round-2 disposition table out of a review body.
+ * @summary Extracts a Round-2 body's disposition table as `{action, disposition}` rows, in order.
  *
- * Selection is deliberately loose and extraction strict. A candidate line is any table row carrying
- * one of the disposition verbs, because a body that got the table's SHAPE wrong still needs to reach
- * the validator and be told so — filtering on a well-formed table here would turn a reportable
- * template error into silence, and the round would then pass by producing no rows to check.
+ * Reads the SECOND-to-last cell as the verb and everything before it as the carried action, so a
+ * table with or without a trailing Evidence column parses the same way. Separator rows (`|---|`) and
+ * the header are dropped by requiring a known verb.
  *
+ * Selection is deliberately loose and extraction strict: a candidate line is any table row carrying
+ * one of the verbs, because a body that got the table's SHAPE wrong still has to reach the validator
+ * and be told so. Filtering on a well-formed table here would turn a reportable template error into
+ * silence, and the round would pass by producing no rows to check.
  * @param {String} body Review body markdown.
- * @returns {Object[]} One entry per disposition row, in document order.
+ * @returns {Array<{action: String, disposition: String}>} One entry per row, in document order.
  * @private
  */
 function extractDispositionRows(body) {
@@ -1877,12 +1871,6 @@ function getMicroDeltaPrReviewTemplateMisses(body) {
 }
 
 /**
- * @summary Returns a structured validation failure for malformed Micro-Delta review bodies.
- *
- * @param {String} body The candidate Micro-Delta PR review body.
- * @returns {Object|null} Validation failure payload or `null` when valid.
- */
-/**
  * @summary Validates an ordinary Round-2 disposition review against its own minimal floor.
  *
  * Round 2 gets its OWN tier rather than routing through the canonical path, for the same reason
@@ -1966,6 +1954,12 @@ function getRound2PrReviewTemplateValidationFailure(body) {
     }
 }
 
+/**
+ * @summary Returns a structured validation failure for malformed Micro-Delta review bodies.
+ *
+ * @param {String} body The candidate Micro-Delta PR review body.
+ * @returns {Object|null} Validation failure payload or `null` when valid.
+ */
 function getMicroDeltaPrReviewTemplateValidationFailure(body) {
     const missingMicroDelta = getMicroDeltaPrReviewTemplateMisses(body);
 

--- a/ai/services/github-workflow/PullRequestService.mjs
+++ b/ai/services/github-workflow/PullRequestService.mjs
@@ -1202,9 +1202,18 @@ function getRound2DispositionRelationFailure({body, reviews, state}) {
             // what appears to be a verbatim copy. The rule is right and stays — byte-verbatim is what
             // stops a Round 2 quietly softening the demand it claims to discharge — but the rule was
             // unstated and its violation unnamed, which is the whole defect.
+            // A mismatch the PARSE caused is not a mismatch the author can fix by carrying the text
+            // more carefully — they already did. Naming the mechanism is the difference between an
+            // instruction they can follow and one they cannot: both known parse causes collapse a
+            // pipe into whitespace, so when the two strings agree once pipes and spaces are
+            // normalised away, the row is telling us about our own reconstruction.
+            const pipeShaped = collapsePipesAndSpace(row.action) === collapsePipesAndSpace(action);
+
             defects.push(normalizeQuoteForComparison(row.action) === normalizeQuoteForComparison(action)
                 ? `row ${index + 1} differs from the prior round ONLY in formatting. The quote must be byte-verbatim INCLUDING its markdown, so restore the emphasis exactly as written: "${action}"`
-                : `row ${index + 1} reads "${row.action}" where the prior round said "${action}" — carry it verbatim`)
+                : pipeShaped
+                    ? `row ${index + 1} differs from the prior round ONLY where a pipe sits. A literal \`|\` inside a table cell must be escaped as \`\\|\` — unescaped, it ends the cell, so the byte is lost before this comparison sees it. Escape every pipe in: "${action}"`
+                    : `row ${index + 1} reads "${row.action}" where the prior round said "${action}" — carry it verbatim`)
         }
     });
 
@@ -1388,6 +1397,25 @@ function extractRequiredActions(body) {
  * @returns {Array<{action: String, disposition: String}>}
  */
 /**
+ * @summary Collapses pipes and surrounding whitespace, so a parse-caused mismatch is recognisable.
+ *
+ * Both known cell-parse defects end the same way: a literal `|` inside a cell is treated as a
+ * delimiter, the byte disappears, and the halves rejoin across a space. Normalising pipes AND
+ * whitespace to nothing therefore makes the author's text and our reconstruction of it compare
+ * equal exactly when the difference is ours — which is the only signal that separates "you reworded
+ * it" from "we lost a byte reading it".
+ *
+ * Deliberately NOT used for the verbatim rule itself. Byte-verbatim is what stops a Round 2 quietly
+ * softening the demand it discharges; this is a diagnosis of the failure, never a relaxation of it.
+ * @param {String} text
+ * @returns {String}
+ * @private
+ */
+function collapsePipesAndSpace(text) {
+    return String(text || '').replace(/[|\s]+/g, '')
+}
+
+/**
  * @summary Strips markdown emphasis and collapses whitespace, for DIAGNOSIS only.
  *
  * Never used to decide whether a quote matches — the verbatim rule compares raw strings and keeps
@@ -1452,21 +1480,46 @@ function round2CellParseFailure(cells) {
     }
 }
 
+/**
+ * @summary Splits one Markdown table row into cells, honouring escaped pipes.
+ *
+ * `split('|')` splits on EVERY pipe, so a pipe inside a cell's content becomes a cell boundary: the
+ * byte is deleted, its halves rejoin with a space, and every later column shifts left. A reviewer
+ * carrying a Required Action containing `observed|partial` then had it compared as
+ * `observed partial` and was told to carry it verbatim — which it already was.
+ *
+ * **Escaping was worse than not escaping.** `\|` is the Markdown way to put a pipe in a cell, and
+ * the old split cut it too, leaving the backslash in the compared text. So the author who did the
+ * correct thing got a stranger mismatch than the one who did not, and no wording got them out.
+ * @param {String} line
+ * @returns {String[]} Cell contents, outer delimiters dropped, `\|` restored to `|`.
+ * @private
+ */
+function splitTableRow(line) {
+    return line.split(/(?<!\\)\|/).slice(1, -1).map(cell => cell.trim().replace(/\\\|/g, '|'))
+}
+
+// The template's first column is `#`, carrying the row's LABEL. It is the row's number, not part of
+// the carried action, and folding it in made every row compare as reworded against a prior round
+// that never contained it — the verbatim check failing on the one thing legitimately not verbatim.
+//
+// Widened from digits-only after `RA-1a` and `§0` were folded in. Deliberately still a SHAPE and not
+// "whatever sits in column one": a label is a bare ordinal token, so anything carrying whitespace or
+// prose stays part of the action. That boundary is what stops the repair from becoming a rule that
+// silently drops a genuine first cell.
+const ROUND_2_ROW_LABEL_PATTERN = /^(?:§|#)?[ \t]*(?:RA[ _-]?)?\d+[a-z]?\.?$/i;
+
 function extractDispositionRows(body) {
     return String(body || '').split('\n')
         .filter(line => line.trim().startsWith('|') && ROUND_2_DISPOSITIONS.some(verb => line.includes(verb)))
         .map(line => {
-            const cells = line.split('|').slice(1, -1).map(cell => cell.trim()),
+            const cells = splitTableRow(line),
                   index = cells.findIndex(cell => ROUND_2_DISPOSITIONS.includes(cell));
 
             if (index === -1) return null;
 
-            // The template's first column is `#`, carrying a label like `RA-1`. It is the row's
-            // NUMBER, not part of the carried action, and folding it into the text made every row
-            // compare as reworded against a prior round that never contained it — the verbatim check
-            // failing on the one thing that is legitimately not verbatim.
             const carried  = cells.slice(0, index).filter(Boolean),
-                  labelled = /^(?:RA[ _-]?)?#?\d+\.?$/i.test(carried[0] || '');
+                  labelled = ROUND_2_ROW_LABEL_PATTERN.test(carried[0] || '');
 
             return {
                 action     : carried.slice(labelled ? 1 : 0).join(' ').trim(),

--- a/test/playwright/unit/ai/services/github-workflow/PullRequestService.spec.mjs
+++ b/test/playwright/unit/ai/services/github-workflow/PullRequestService.spec.mjs
@@ -2234,6 +2234,89 @@ test.describe('Neo.ai.services.github-workflow.PullRequestService — managePrRe
         '| RA-1 | prior template miss | STILL_OPEN | the original review stays authoritative |'
     );
 
+    /**
+     * A mismatch the PARSE caused is not one the author can fix by carrying the text more carefully.
+     *
+     * `@neo-gpt` was BLOCKED posting a Round-2 disposition on PR #17475: the prior Required Action
+     * contained the literal token `observed|partial`, `split('|')` cut the cell there, the byte was
+     * replaced by a space, and the gate rejected the row as non-verbatim. Escaping was worse — the
+     * backslash survived into the compared text and the pipe still split — so the author doing the
+     * correct Markdown thing got a stranger mismatch, with no wording that got them out.
+     */
+    const PIPED_PRIOR_ACTION = 'Record the observed|partial contract distinct from bridge readability',
+          // Only `GetPullRequestId` is overridden; the mutation branches stay on the suite default,
+          // so a body that passes validation actually submits rather than dying in the mock.
+          withPriorAction    = action => {
+              const base = GraphqlService.query;
+
+              GraphqlService.query = async queryString => queryString.includes('GetPullRequestId')
+                  ? pullRequestLookup({
+                      reviewDecision: 'CHANGES_REQUESTED',
+                      reviews       : {
+                          nodes: [priorRequestChanges({
+                              body: ['# PR Review Summary', '', '### 📋 Required Actions', '', `- [ ] ${action}`].join('\n')
+                          })],
+                          pageInfo: {hasPreviousPage: false}
+                      }
+                  })
+                  : base(queryString)
+          },
+          pipedRoundTwo      = cell => VALID_ROUND_2_REVIEW_BODY.replace(
+              '| RA-1 | prior template miss | ADDRESSED | current body keeps canonical headings |',
+              `| RA-1 | ${cell} | ADDRESSED | escaped per markdown |`
+          ),
+          submitRoundTwo     = body => PullRequestService.managePrReview({
+              action: 'create', pr_number: 11273, state: 'APPROVED', body
+          });
+
+    test('#17284: an ESCAPED pipe survives the cell parse as a literal pipe', async () => {
+        withPriorAction(PIPED_PRIOR_ACTION);
+
+        const result = await submitRoundTwo(pipedRoundTwo(PIPED_PRIOR_ACTION.replace('|', '\\|')));
+
+        expect(result.code, 'the escaped row carries the action verbatim').not.toBe('PR_REVIEW_TEMPLATE_VALIDATION_FAILED');
+    });
+
+    test('#17284: an UNESCAPED pipe is refused by naming the escape, not by repeating "verbatim"', async () => {
+        withPriorAction(PIPED_PRIOR_ACTION);
+
+        const result = await submitRoundTwo(pipedRoundTwo(PIPED_PRIOR_ACTION));
+
+        expect(result.code).toBe('PR_REVIEW_TEMPLATE_VALIDATION_FAILED');
+        // The old message told the author to carry verbatim text they had already carried verbatim.
+        // Naming the mechanism is the difference between an instruction they can follow and one they
+        // cannot — the refusal is correct either way, and only one of them is actionable.
+        expect(result.message, 'the refusal names the pipe').toMatch(/must be escaped as/);
+        expect(result.message).toContain('ends the cell');
+    });
+
+    test('#17284: sub-lettered and section labels are stripped, and a real first cell is NOT', async () => {
+        // The original defect. `RA-1a` / `§0` were folded into the carried action, so the row compared
+        // as reworded against a prior round that never contained the label.
+        const withLabel = label => VALID_ROUND_2_REVIEW_BODY.replace(
+            '| RA-1 | prior template miss |', `| ${label} | prior template miss |`
+        );
+
+        for (const label of ['§0', 'RA-1a', 'RA-1b', 'RA-1B', '1', '#3', 'RA-2.', 'RA-10']) {
+            withPriorAction('prior template miss');
+
+            const result = await submitRoundTwo(withLabel(label));
+
+            expect(result.code, `${label} is a label, not part of the action`).not.toBe('PR_REVIEW_TEMPLATE_VALIDATION_FAILED');
+        }
+
+        // CONTROL, and it is the half that keeps the widening honest: a first cell that is genuinely
+        // part of an action must still be compared. Without it, "recognise more labels" degrades into
+        // "strip whatever sits in column one", which discharges every row by construction.
+        withPriorAction('prior template miss');
+
+        const genuine = await submitRoundTwo(VALID_ROUND_2_REVIEW_BODY.replace(
+            '| RA-1 | prior template miss |', '| something the prior round never said | prior template miss |'
+        ));
+
+        expect(genuine.code, 'a prose first cell is still compared').toBe('PR_REVIEW_TEMPLATE_VALIDATION_FAILED');
+    });
+
     test('#17354: a STILL_OPEN row under a non-COMMENT Status is refused by the dry-run', () => {
         // Status says Approved, the row says STILL_OPEN. A STILL_OPEN round keeps the original review
         // authoritative and must be COMMENT, so these two cannot both be true.

--- a/test/playwright/unit/ai/services/github-workflow/PullRequestService.spec.mjs
+++ b/test/playwright/unit/ai/services/github-workflow/PullRequestService.spec.mjs
@@ -2237,13 +2237,18 @@ test.describe('Neo.ai.services.github-workflow.PullRequestService — managePrRe
     /**
      * A mismatch the PARSE caused is not one the author can fix by carrying the text more carefully.
      *
-     * `@neo-gpt` was BLOCKED posting a Round-2 disposition on PR #17475: the prior Required Action
-     * contained the literal token `observed|partial`, `split('|')` cut the cell there, the byte was
-     * replaced by a space, and the gate rejected the row as non-verbatim. Escaping was worse — the
-     * backslash survived into the compared text and the pipe still split — so the author doing the
-     * correct Markdown thing got a stranger mismatch, with no wording that got them out.
+     * A Required Action carrying a literal `|` — an enum like `observed|partial` is the ordinary
+     * case — was cut at that byte, its halves rejoined across a space, and the row rejected as
+     * non-verbatim. Escaping was worse: `\|` was cut too, so the backslash survived into the
+     * compared text and the author doing the correct Markdown thing got a stranger mismatch. There
+     * was no wording that got them out; the only escape was rewording the Round-1 action to contain
+     * no pipe, which makes Round-1 text a function of the Round-2 parser.
      */
-    const PIPED_PRIOR_ACTION = 'Record the observed|partial contract distinct from bridge readability',
+    // TWO pipes, not one. CodeQL flagged the single-pipe fixture's `replace('|', …)` as incomplete
+    // sanitization, and it was right about more than the idiom: with one pipe, a non-global escape
+    // and a global one are indistinguishable, so the arm could not tell whether every pipe survives
+    // or only the first. The second pipe is what makes the assertion mean what it says.
+    const PIPED_PRIOR_ACTION = 'Record the observed|partial contract, not the stale|fresh one',
           // Only `GetPullRequestId` is overridden; the mutation branches stay on the suite default,
           // so a body that passes validation actually submits rather than dying in the mock.
           withPriorAction    = action => {
@@ -2272,7 +2277,7 @@ test.describe('Neo.ai.services.github-workflow.PullRequestService — managePrRe
     test('#17284: an ESCAPED pipe survives the cell parse as a literal pipe', async () => {
         withPriorAction(PIPED_PRIOR_ACTION);
 
-        const result = await submitRoundTwo(pipedRoundTwo(PIPED_PRIOR_ACTION.replace('|', '\\|')));
+        const result = await submitRoundTwo(pipedRoundTwo(PIPED_PRIOR_ACTION.replaceAll('|', '\\|')));
 
         expect(result.code, 'the escaped row carries the action verbatim').not.toBe('PR_REVIEW_TEMPLATE_VALIDATION_FAILED');
     });

--- a/test/playwright/unit/ai/services/github-workflow/PullRequestService.spec.mjs
+++ b/test/playwright/unit/ai/services/github-workflow/PullRequestService.spec.mjs
@@ -2295,6 +2295,27 @@ test.describe('Neo.ai.services.github-workflow.PullRequestService — managePrRe
         expect(result.message).toContain('ends the cell');
     });
 
+    test('#17284: a no-pipe difference is NOT diagnosed as a pipe — the byte is the witness', async () => {
+        // Emmy's falsifier, RA-1 on the round-2 review. `collapsePipesAndSpace` removes spaces as
+        // well as pipes, so "observed partial" and "observedpartial" compare equal with no pipe
+        // anywhere in either string. Similarity alone was enough to reach the pipe branch, which then
+        // told an author to escape a pipe their text does not contain -- the exact unfollowable
+        // instruction this gate exists to remove, reintroduced by the diagnosis rather than the rule.
+        //
+        // The discriminating half is the SECOND assertion. Refusing is right either way; refusing
+        // with the wrong mechanism is the defect, so an arm that only checked for rejection would
+        // have passed against the broken code.
+        const spacedPrior = 'Record the observed partial contract';
+
+        withPriorAction(spacedPrior);
+
+        const result = await submitRoundTwo(pipedRoundTwo('Record the observedpartial contract'));
+
+        expect(result.code).toBe('PR_REVIEW_TEMPLATE_VALIDATION_FAILED');
+        expect(result.message, 'no pipe in the expected text means no pipe diagnosis').not.toMatch(/must be escaped as/);
+        expect(result.message, 'it falls through to the ordinary verbatim demand').toContain('carry it verbatim')
+    });
+
     test('#17284: sub-lettered and section labels are stripped, and a real first cell is NOT', async () => {
         // The original defect. `RA-1a` / `§0` were folded into the carried action, so the row compared
         // as reworded against a prior round that never contained the label.


### PR DESCRIPTION
Resolves #17284

Two defects in one function, with one symptom: **the gate tells an author to carry text verbatim that they already carried verbatim.**

Evidence: L2 required → **L2 achieved, no residual** (196 arms green in the owning suite, 5 new; two mutation runs, one per defect).

## This shipped because it blocked a live reviewer

@neo-gpt could not post a Round-2 disposition on PR #17475:

> *"The managed submit gate requires every Round-1 action byte-verbatim in a pipe-delimited Round-2 table. RA-2 itself contains the literal token `observed|partial`; the gate splits on every pipe, deletes that byte, and then rejects the row as non-verbatim. Escaping the pipe also rejects."*

Reproduced against the shipped parse:

```
prior         : "Record the observed|partial contract distinct from bridge readability"
parsed        : "Record the observed partial contract distinct from bridge readability"
escaped parse : "Record the observed\ partial contract distinct from bridge readability"
```

**Escaping was worse than not escaping.** `\|` is the Markdown way to put a pipe in a cell; the old split cut it too, leaving the backslash in the compared text. So the author who did the correct thing got a *stranger* mismatch than the one who did not, and **no wording got them out** — the only escape was to reword the Round-1 Required Action so it contained no pipe, which makes Round-1 text a function of the Round-2 parser.

## Deltas from ticket

**The ticket grew a second specimen rather than a sibling.** #17284 was filed for the label case; this is the same function reconstructing the author's cells wrongly, one column over, producing the same unfollowable instruction. A separate ticket would have split one repair across two PRs touching the same twelve lines.

**A raw, unescaped pipe still yields an ambiguous row — deliberately.** Markdown cannot express it, so the author must escape. What changed is that escaping now *works*, and the refusal says so. Making a bare `|` parse would require guessing which pipes are delimiters.

**The label pattern stays a SHAPE, not "column one".** Widened from digits-only to a bare ordinal token — `§0`, `RA-1a`, `RA-1B`, `RA-2.`, `#3`, `RA-10`. Anything carrying whitespace or prose stays part of the action, which is what stops "recognise more labels" from degrading into "strip whatever sits in column one" and discharging every row by construction. That negative case is an AC and an arm.

**The byte-verbatim rule is untouched.** `collapsePipesAndSpace` diagnoses the failure; it is never used for the comparison itself. Byte-verbatim is what stops a Round 2 quietly softening the demand it claims to discharge — the defect was that its violation was unnamed, not that the rule was wrong.

## Test Evidence

**196 arms green** in `PullRequestService.spec.mjs`. Five new:

| arm | pins |
|---|---|
| an ESCAPED pipe survives as a literal pipe | the round trip, byte-for-byte, and the round submits |
| an UNESCAPED pipe is refused by naming the escape | the message says *"must be escaped as"* and *"ends the cell"*, not *"carry it verbatim"* |
| sub-lettered and section labels are stripped | `§0` · `RA-1a` · `RA-1b` · `RA-1B` · `1` · `#3` · `RA-2.` · `RA-10` |
| **CONTROL:** a prose first cell is still compared | the widening cannot become "strip column one" |
| *(the label arm carries both halves)* | a label passes **and** a real first cell fails, in one arm so neither can be satisfied alone |

**Two mutation runs, one per defect:**

| mutation | reddens |
|---|---|
| revert to `split('|')` | exactly the escaped-pipe arm |
| revert the label regex to digits-only | exactly the label arm |
| revert the fixture escape to non-global `replace` | exactly the escaped-pipe arm — the CodeQL case |

**CodeQL found a control that could not fail, and it was right about more than the idiom.** It flagged the fixture's `replace('|', …)` as incomplete sanitization. With **one** pipe in the prior action, a non-global escape and a global one are indistinguishable — so the arm could not tell whether *every* pipe survives the round trip or only the first, and would have kept passing while testing less than it claimed. The fixture now carries **two** pipes and escapes globally; reverting to `replace` reddens the arm, which it could not have done before. A security finding that improves a test's discriminating power is worth taking rather than suppressing.

**One fixture I had to fix before it could fail.** My first version mocked `PullRequestService.githubGraphQL`; the suite's seam is `GraphqlService.query` with a `GetPullRequestId` shape. The arms "failed" for the wrong reason — no prior review found — which would have read as the defect if I had not opened the error. The arms now override only `GetPullRequestId` and delegate the mutation branches to the suite default, so a body that passes validation actually submits.

## Post-Merge Validation

@neo-gpt's blocked Round-2 on PR #17475 becomes postable: RA-2 carries `observed|partial`, escaped as `observed\|partial` in the disposition table, and the verbatim comparison succeeds. That is the receipt for this change and it is one attempt, not a soak.

## Out of Scope

- Parsing a **raw** pipe inside a cell. Markdown cannot express it; the fix is escaping, and the message now says so.
- The Round-2 template's own example rows — #17284 AC-4 asks that the template show a label form that passes, which it already does (`| RA-1 |`); the mismatch it names is with the Round-1 checkbox form, and changing a skill asset is a substrate edit with its own gate.

## Evolution

**A gate that misparses its input and then blames the author is worse than one that rejects everything**, because the instruction it gives is unfollowable and looks like the author's fault. Both defects here produced the identical message — *"carry it verbatim"* — against text that was already verbatim.

The generalisable rule: **when a validator compares author text against a reconstruction of author text, a mismatch is ambiguous between "they changed it" and "we lost it", and the message must not assume the first.** Naming the mechanism costs one comparison and converts an impasse into a fix.

Authored by Ada (Claude Opus 5, Claude Code). Session ab15d2b8-eb14-4237-ad18-ce48584b2d07.
