### PR TITLE
One narrow write path for every receipt

### DIFF
--- a/ai/graph/storage/Base.mjs
+++ b/ai/graph/storage/Base.mjs
@@ -62,6 +62,27 @@ class Base extends NeoBase {
     }
 
     /**
+     * @summary Sets ONE property on an existing record, whatever its current value.
+     *
+     * The unconditional sibling of {@link setRecordPropertyIfAbsent}, for receipts that legitimately
+     * change more than once — a message can be marked read, and archive state is not write-once the
+     * way first-seen is. Same narrowness, same reason: a whole-record write erases whatever another
+     * process committed between this one's read and its write.
+     *
+     * Write-once belongs in the SQL when the field is write-once, and nowhere when it is not.
+     * Choosing between these two is how a caller declares which it has.
+     *
+     * @param {String} table `'Nodes'` or `'Edges'`.
+     * @param {String} id Record id.
+     * @param {String} property Property name under `$.properties`.
+     * @param {*} value Value to set; `null` is a legitimate value, not a no-op.
+     * @returns {Boolean} `true` when a row was updated; `false` when no such row exists.
+     */
+    setRecordProperty(table, id, property, value) {
+        return false
+    }
+
+    /**
      * Purges specific Nodes array data natively resolving cascade anomalies internally at the driver stratum.
      * @param {Object[]} nodes
      */

--- a/ai/graph/storage/SQLite.mjs
+++ b/ai/graph/storage/SQLite.mjs
@@ -433,26 +433,69 @@ class SQLite extends Base {
      * @param {*} value Value to set.
      * @returns {Boolean} `true` only when this statement wrote.
      */
-    setRecordPropertyIfAbsent(table, id, property, value) {
-        if (!this.db) return false;
+    /**
+     * @summary Shared preflight for the narrow property writers. Returns the JSON path, or `null`
+     * when there is no database to write to.
+     *
+     * `table` and `property` are interpolated into the statement — neither a table name nor a JSON
+     * path can be a bound parameter — so both are validated against strict shapes here rather than at
+     * each call site, where one of the two would eventually be forgotten.
+     * @param {String} caller Method name, for the error message.
+     * @param {String} table
+     * @param {String} property
+     * @returns {String|null}
+     * @private
+     */
+    assertNarrowWrite(caller, table, property) {
+        if (!this.db) return null;
         if (!this.db.open) throw new Error('SQLite connection is closed (lifecycle violation).');
         this.assertTestWriteIsolated();
 
         if (table !== 'Nodes' && table !== 'Edges') {
-            throw new Error(`setRecordPropertyIfAbsent supports 'Nodes' and 'Edges'. Received: ${String(table)}`);
+            throw new Error(`${caller} supports 'Nodes' and 'Edges'. Received: ${String(table)}`);
         }
 
         if (!/^[A-Za-z_][A-Za-z0-9_]*$/.test(property)) {
-            throw new Error(`setRecordPropertyIfAbsent property must be a plain identifier. Received: ${String(property)}`);
+            throw new Error(`${caller} property must be a plain identifier. Received: ${String(property)}`);
         }
 
-        const path = `$.properties.${property}`;
+        return `$.properties.${property}`
+    }
+
+    setRecordPropertyIfAbsent(table, id, property, value) {
+        const path = this.assertNarrowWrite('setRecordPropertyIfAbsent', table, property);
+
+        if (!path) return false;
 
         return this.db.prepare(`
             UPDATE ${table}
             SET   data = json_set(data, '${path}', ?)
             WHERE id = ?
               AND json_extract(data, '${path}') IS NULL
+        `).run(value, id).changes > 0;
+    }
+
+    /**
+     * @summary Sets one property under `$.properties` in SQL, whatever its current value.
+     *
+     * Same single-path `json_set` as the write-once variant, without the `IS NULL` predicate: a read
+     * receipt or an archive flag legitimately changes more than once, so guarding on absence would
+     * silently drop the second write. Narrowness is the shared property; write-once is not.
+     * @param {String} table `'Nodes'` or `'Edges'`.
+     * @param {String} id Record id.
+     * @param {String} property Property name under `$.properties`; identifier characters only.
+     * @param {*} value Value to set; `null` sets JSON null rather than removing the key.
+     * @returns {Boolean} `true` when a row matched and was updated.
+     */
+    setRecordProperty(table, id, property, value) {
+        const path = this.assertNarrowWrite('setRecordProperty', table, property);
+
+        if (!path) return false;
+
+        return this.db.prepare(`
+            UPDATE ${table}
+            SET   data = json_set(data, '${path}', ?)
+            WHERE id = ?
         `).run(value, id).changes > 0;
     }
 

--- a/ai/graph/storage/SQLite.mjs
+++ b/ai/graph/storage/SQLite.mjs
@@ -7,6 +7,23 @@ const GRAPH_SCHEMA_VERSION_ID = 'graph';
 const GRAPH_SCHEMA_WIPE_ENV   = 'NEO_ALLOW_SCHEMA_WIPE';
 
 /**
+ * @summary Maps a narrow UPDATE's result to the `GraphLog` id it produced, or `0` when nothing matched.
+ *
+ * The `node_update` / `edge_update` triggers insert a `GraphLog` row inside the statement, so
+ * `lastInsertRowid` names exactly this write's log position. Returning it lets a caller acknowledge
+ * **its own** row instead of the global maximum — the difference between skipping the replay of a
+ * write you just made and skipping a concurrent peer's write you have never seen.
+ *
+ * `0` rather than `false` on no-match keeps every existing truthiness check working while making the
+ * id available to callers that need it.
+ * @param {Object} result better-sqlite3 `RunResult`.
+ * @returns {Number} `GraphLog` id, or `0`.
+ */
+function narrowWriteResult(result) {
+    return result.changes > 0 ? Number(result.lastInsertRowid) : 0
+}
+
+/**
  * Native Write-Ahead Logging (WAL) SQLite engine proxy driving memory graph persistence logic.
  * Bounded uniquely inside backend Node.js domains, this integration leverages dynamic imports natively,
  * bypassing generic browser module restraints while translating instantaneous $O(1)$ memory mapping directly to physical data rows.
@@ -467,12 +484,12 @@ class SQLite extends Base {
 
         if (!path) return false;
 
-        return this.db.prepare(`
+        return narrowWriteResult(this.db.prepare(`
             UPDATE ${table}
             SET   data = json_set(data, '${path}', ?)
             WHERE id = ?
               AND json_extract(data, '${path}') IS NULL
-        `).run(value, id).changes > 0;
+        `).run(value, id));
     }
 
     /**
@@ -492,11 +509,11 @@ class SQLite extends Base {
 
         if (!path) return false;
 
-        return this.db.prepare(`
+        return narrowWriteResult(this.db.prepare(`
             UPDATE ${table}
             SET   data = json_set(data, '${path}', ?)
             WHERE id = ?
-        `).run(value, id).changes > 0;
+        `).run(value, id));
     }
 
     /**

--- a/ai/services/memory-core/MailboxService.mjs
+++ b/ai/services/memory-core/MailboxService.mjs
@@ -1988,9 +1988,49 @@ function resolveReceiptState(messageNode, deliveryEdge, target, receiptShaped) {
  * @param {String} operation Human-readable operation name for the warning text.
  * @returns {Object} The receipt, annotated when non-durable.
  */
-function receiptWithDurability(receipt, durable, operation) {
-    if (durable) {
+/**
+ * Outcomes of a narrow receipt write. Three distinct states hid behind one boolean, and the caller
+ * described all of them with the no-storage warning — which asserts an in-memory application that
+ * only the first of them performs.
+ * @type {Object}
+ */
+const RECEIPT_WRITE = Object.freeze({
+    /** No storage backing. Cache WAS mutated; the state is real until restart. */
+    noStorage : 'no-storage',
+    /** The row was updated durably. */
+    written   : 'written',
+    /** Write-once field already carried a value. Cache untouched, and that is correct. */
+    alreadySet: 'already-set',
+    /** The statement matched no row: authorized cached record, gone from storage. Cache untouched. */
+    missingRow: 'missing-row'
+});
+
+/**
+ * @summary Shapes a lifecycle receipt from a narrow-write outcome, without overstating any of them.
+ *
+ * `written` and `already-set` are both successful ends for the caller — the field holds the intended
+ * value durably. The other two are not, and they fail differently: `no-storage` applied the mutation
+ * in memory and loses it on restart, while `missing-row` applied it **nowhere** and the caller's
+ * cached record no longer corresponds to a stored one. Reporting the second with the first's wording
+ * tells an operator their change is in memory when it is not.
+ *
+ * @param {Object} receipt Happy-path receipt; returned unchanged on success so the wire shape holds.
+ * @param {String} outcome A {@link RECEIPT_WRITE} member.
+ * @param {String} operation Operation name for the message.
+ * @returns {Object}
+ */
+function receiptWithDurability(receipt, outcome, operation) {
+    // Boolean call sites predate the outcome vocabulary; `true` meant "durable".
+    if (outcome === true || outcome === RECEIPT_WRITE.written || outcome === RECEIPT_WRITE.alreadySet) {
         return receipt;
+    }
+
+    if (outcome === RECEIPT_WRITE.missingRow) {
+        const warning = `${operation} did NOT apply: the record is no longer present in storage, and the in-memory copy was left unchanged rather than reporting a state that exists nowhere. Retry after refreshing the record.`;
+
+        logger.warn(`[MailboxService] ${warning}`);
+
+        return {...receipt, status: 'not_applied', durable: false, retryable: true, warning};
     }
 
     const warning = `${operation} was applied in memory but NOT persisted: the graph database has no storage backing, so this state is lost on restart.`;
@@ -2151,20 +2191,44 @@ async function writeReceiptField(record, table, field, value, {writeOnce = false
     if (!db?.storage) {
         // No durable surface to protect; cache-only mode keeps the in-memory contract intact.
         getRecordProperties(record)[field] = value;
-        return false
+        return RECEIPT_WRITE.noStorage
     }
 
     const
         id     = getRecordField(record, 'id'),
         method = writeOnce ? 'setRecordPropertyIfAbsent' : 'setRecordProperty',
-        wrote  = db.storage[method](table, id, field, value);
+        // The GraphLog id this write produced, or 0 when the statement matched nothing.
+        logId  = db.storage[method](table, id, field, value);
 
-    if (wrote) {
-        getRecordProperties(record)[field] = value;
-        db.acknowledgeLocalMutations?.()
+    if (!logId) {
+        // The statement matched nothing. For a write-once field that means the value was already
+        // set; otherwise the row is gone from storage while the caller still holds a cached record.
+        // Cache is deliberately NOT mutated either way, so the caller must not report success — and
+        // must not reuse the no-storage warning, which claims an in-memory application that did not
+        // happen.
+        return writeOnce ? RECEIPT_WRITE.alreadySet : RECEIPT_WRITE.missingRow
     }
 
-    return wrote
+    getRecordProperties(record)[field] = value;
+
+    // KNOWN GAP, tracked separately — do not read this ack as endorsed.
+    //
+    // `acknowledgeLocalMutations()` sets `lastSyncId = getLatestLogId()`: the global MAX, not this
+    // write's position. For a whole-record write that was harmless, because it had already
+    // overwritten whatever a peer put there. A narrow write PRESERVES the peer's field in SQLite,
+    // and then max-acking marks the peer's log row seen — so the local cache never replays it.
+    // Durable and invisible, which is not an improvement on durable and clobbered.
+    //
+    // Two narrower acks were built and measured, and neither is shippable as-is: dropping the ack
+    // entirely makes every receipt write invalidate its own cache entry (correct by the
+    // invalidate-then-lazy-load design, but it changes a contract this suite relies on in 65
+    // places), and acknowledging only our own row — `logId === db.lastSyncId + 1`, which the
+    // writers now return the id for — holds or not depending on run order, so cache survival
+    // becomes nondeterministic. The real fix is a Database-level ability to skip replay of
+    // self-authored rows, which is a shared-primitive change and not this PR's to make.
+    db.acknowledgeLocalMutations?.();
+
+    return RECEIPT_WRITE.written
 }
 
 /**
@@ -3950,11 +4014,18 @@ class MailboxService extends Base {
             nonDurable = results
                 .filter(result => result.status === 'read' && result.durable === false)
                 .map(({messageId, warning}) => ({messageId, warning})),
+            // A row that vanished from storage between snapshot and write is neither read nor an
+            // error. Without its own slot it matches none of the filters above and disappears from
+            // every counter — the aggregate would report a clean drain over messages it never
+            // touched, which is the exact silence this drain's design set out to remove.
+            notApplied = results
+                .filter(result => result.status === 'not_applied')
+                .map(({messageId, warning}) => ({messageId, warning})),
             readCount    = results.filter(result => result.status === 'read').length,
             durableCount = readCount - nonDurable.length,
             status       = messageIds.length === 0
                 ? 'noop'
-                : failures.length === 0 && nonDurable.length === 0
+                : failures.length === 0 && nonDurable.length === 0 && notApplied.length === 0
                     ? 'read'
                     : 'partial';
 
@@ -3996,9 +4067,11 @@ class MailboxService extends Base {
             durableCount,
             failureCount   : failures.length,
             nonDurableCount: nonDurable.length,
+            notAppliedCount: notApplied.length,
             withheldUnseenCount,
             failures,
-            nonDurable
+            nonDurable,
+            notApplied
         };
     }
 

--- a/ai/services/memory-core/MailboxService.mjs
+++ b/ai/services/memory-core/MailboxService.mjs
@@ -1971,68 +1971,6 @@ function resolveReceiptState(messageNode, deliveryEdge, target, receiptShaped) {
 }
 
 /**
- * Durably persists a receipt mutation (read or archive) already applied to a per-recipient
- * `DELIVERED_TO` edge, and reports whether the durable write actually ran.
- *
- * ## Why this is not gated on `autoSave`
- *
- * `Database#autoSave` exists to suppress **load-echo** writes: every site that clears it
- * (`Database.mjs` delta-sync invalid-node/edge pruning, vicinity load, and the other bulk
- * load paths) is populating the in-memory cache *from* storage, where writing back would
- * amplify writes and pollute the delta log. A read or archive receipt is the opposite — a
- * **user-originated** mutation that can never be a load echo — so suppressing it under that
- * flag is a category error, not an optimisation.
- *
- * It is also unobservable in every reachable state: those windows are synchronous (no `await`
- * between clearing the flag and restoring it), so a receipt call cannot execute inside one.
- * The gate could therefore only ever fire in a state nothing reaches — which is precisely why
- * it went unnoticed while making the receipt claim a durability it had not delivered.
- *
- * The `storage` guard stays: with no storage there is nowhere to write, and the caller needs
- * to know that rather than reporting an unqualified success.
- *
- * @param {Object} edge `DELIVERED_TO` edge record carrying the already-applied receipt property.
- * @returns {Promise<Boolean>} `true` when the durable write ran; `false` when there was no storage.
- */
-async function persistReceiptEdge(edge) {
-    const db = GraphService.db;
-
-    if (!db?.storage) {
-        return false;
-    }
-
-    await db.storage.addEdges([edge]);
-    db.acknowledgeLocalMutations?.();
-
-    return true;
-}
-
-/**
- * Durably persists a receipt mutation already applied to a direct-DM `MESSAGE` node, and reports
- * whether the durable write actually ran.
- *
- * Direct messages intentionally carry read/archive state on their shared node rather than a
- * per-recipient `DELIVERED_TO` edge. This writes that existing carrier directly because
- * `GraphService.upsertNode` gates storage on `autoSave` and returns no durability signal;
- * receipt mutations are user-originated writes, never load echoes that `autoSave` may suppress.
- *
- * @param {Object} node `MESSAGE` node carrying the already-applied receipt property.
- * @returns {Promise<Boolean>} `true` when the durable write ran; `false` when there was no storage.
- */
-async function persistReceiptNode(node) {
-    const db = GraphService.db;
-
-    if (!db?.storage) {
-        return false;
-    }
-
-    await db.storage.addNodes([node]);
-    db.acknowledgeLocalMutations?.();
-
-    return true;
-}
-
-/**
  * Builds the receipt a mailbox lifecycle tool returns, degrading it honestly when the durable
  * write did not run.
  *
@@ -2101,23 +2039,6 @@ function normalizeMarkReadMessageIdInput(messageId) {
 }
 
 /**
- * @summary Reconciles mutable receipt fields from storage before a whole-edge persistence write.
- * @param {Object} edge `DELIVERED_TO` edge record from the Store map or a secondary-index Set.
- * @returns {Object} Cached properties overlaid with storage-owned `readAt` / `archivedAt` state.
- * @private
- */
-function getDeliveryEdgePropertiesForWrite(edge) {
-    return {
-        ...getRecordProperties(edge),
-        ...getStorageDeliveryMutableState(
-            getRecordField(edge, 'source'),
-            getRecordField(edge, 'target'),
-            {includeNull: true}
-        )
-    }
-}
-
-/**
  * Sets the read timestamp on a per-recipient `DELIVERED_TO` edge for broadcast messages and
  * reports whether that mutation reached durable storage.
  *
@@ -2130,12 +2051,7 @@ function getDeliveryEdgePropertiesForWrite(edge) {
  * @returns {Promise<Boolean>} `true` when the read state was persisted durably.
  */
 async function setDeliveryEdgeReadAt(edge, readAt) {
-    setRecordProperties(edge, {
-        ...getDeliveryEdgePropertiesForWrite(edge),
-        readAt
-    });
-
-    return persistReceiptEdge(edge);
+    return writeReceiptField(edge, 'Edges', 'readAt', readAt)
 }
 
 /**
@@ -2147,11 +2063,7 @@ async function setDeliveryEdgeReadAt(edge, readAt) {
  * @returns {Promise<Boolean>} `true` when the read state was persisted durably.
  */
 async function setMessageNodeReadAt(node, readAt) {
-    // MESSAGE records expose a reference-stable properties object. Preserve that object so
-    // existing consumers holding it observe the same mutation, matching the established DM path.
-    getRecordProperties(node).readAt = readAt;
-
-    return persistReceiptNode(node);
+    return writeReceiptField(node, 'Nodes', 'readAt', readAt)
 }
 
 /**
@@ -2198,20 +2110,57 @@ async function setMessageNodeSeenAt(node, seenAt) {
  * @private
  */
 async function setReceiptSeenAt(record, table, seenAt) {
+    return writeReceiptField(record, table, 'seenAt', seenAt, {writeOnce: true})
+}
+
+/**
+ * @summary Writes ONE receipt field narrowly, then reflects cache only on a confirmed durable write.
+ *
+ * The single write path for every receipt on this surface — `seenAt`, `readAt`, `archivedAt`, on
+ * both the `MESSAGE` node and the per-recipient `DELIVERED_TO` edge. It exists because the three
+ * fields previously had three different durability stories, and the weakest one set the real
+ * guarantee.
+ *
+ * **Narrow.** A single JSON path is rewritten rather than the whole record, so a field another
+ * process committed between this process's read and its write survives. The receipts are exactly the
+ * fields two processes legitimately write at once — a listing, a drain and an archive are
+ * independent operations on one row.
+ *
+ * **Write-once only where the field is.** `seenAt` means FIRST shown and takes the `IS NULL`
+ * predicate; `readAt` and `archivedAt` legitimately change more than once, and guarding them on
+ * absence would silently drop the second write. The flag is how a caller declares which it has.
+ *
+ * **Cache last, and in place.** The caller's guard reads cached state, so reflecting a write that
+ * did not land would mark the row for the life of the process with nothing retrying. The properties
+ * object is mutated rather than replaced, because consumers hold that reference — the previous edge
+ * path replaced it, which is what made a stale copy able to clobber its neighbours in the first
+ * place.
+ *
+ * @param {Object} record `MESSAGE` node or `DELIVERED_TO` edge.
+ * @param {String} table `'Nodes'` or `'Edges'`.
+ * @param {String} field Receipt property name.
+ * @param {*} value Value to write.
+ * @param {Object} [options]
+ * @param {Boolean} [options.writeOnce=false] Apply the absence predicate in SQL.
+ * @returns {Promise<Boolean>} Whether THIS call performed the durable write.
+ * @private
+ */
+async function writeReceiptField(record, table, field, value, {writeOnce = false} = {}) {
     const db = GraphService.db;
 
     if (!db?.storage) {
         // No durable surface to protect; cache-only mode keeps the in-memory contract intact.
-        getRecordProperties(record).seenAt = seenAt;
+        getRecordProperties(record)[field] = value;
         return false
     }
 
-    const wrote = db.storage.setRecordPropertyIfAbsent(
-        table, getRecordField(record, 'id'), 'seenAt', seenAt
-    );
+    const
+        id     = getRecordField(record, 'id'),
+        method = writeOnce ? 'setRecordPropertyIfAbsent' : 'setRecordProperty',
+        wrote  = db.storage[method](table, id, field, value);
 
     if (wrote) {
-        getRecordProperties(record).seenAt = seenAt;
+        getRecordProperties(record)[field] = value;
         db.acknowledgeLocalMutations?.()
     }
 
@@ -2239,7 +2188,7 @@ async function setDeliveryEdgeSeenAt(edge, seenAt) {
 /**
  * Sets the archive timestamp on a per-recipient DELIVERED_TO edge for broadcast
  * messages. Mirrors `setDeliveryEdgeReadAt` exactly — both delegate to
- * `persistReceiptEdge`, so broadcast archive state participates in the same durability
+ * the shared narrow writer, so broadcast archive state participates in the same durability
  * guarantees as read receipts. That mirroring is the reason this function shares the fix:
  * the two carried identical write shapes, so an archive receipt could report success on a
  * skipped durable write for exactly the same reason a read receipt could.
@@ -2249,12 +2198,7 @@ async function setDeliveryEdgeSeenAt(edge, seenAt) {
  * @returns {Promise<Boolean>} `true` when the archive state was persisted durably.
  */
 async function setDeliveryEdgeArchivedAt(edge, archivedAt) {
-    setRecordProperties(edge, {
-        ...getDeliveryEdgePropertiesForWrite(edge),
-        archivedAt
-    });
-
-    return persistReceiptEdge(edge);
+    return writeReceiptField(edge, 'Edges', 'archivedAt', archivedAt)
 }
 
 /**
@@ -2266,9 +2210,7 @@ async function setDeliveryEdgeArchivedAt(edge, archivedAt) {
  * @returns {Promise<Boolean>} `true` when the archive state was persisted durably.
  */
 async function setMessageNodeArchivedAt(node, archivedAt) {
-    getRecordProperties(node).archivedAt = archivedAt;
-
-    return persistReceiptNode(node);
+    return writeReceiptField(node, 'Nodes', 'archivedAt', archivedAt)
 }
 
 function linkOptionalMailboxEdge(source, target, type, weight, properties) {

--- a/test/playwright/unit/ai/services/memory-core/MailboxService.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/MailboxService.spec.mjs
@@ -2674,6 +2674,107 @@ test.describe('Neo.ai.services.memory-core.MailboxService', () => {
             'the write-once variant refuses an already-set field').toBe(0)
     });
 
+    /**
+     * Deletes the record's storage row AT the write seam — after this process last read the row, and
+     * immediately before the narrow UPDATE runs — then returns the receipt `mutate` produced.
+     *
+     * The timing carries the whole arm. Deleting up front never reaches the writer at all: the
+     * authorization read ahead of it fails and the operation takes a not-found path, so the probe
+     * would pass while `writeReceiptField` stayed untested. Deleting inside the writer reproduces
+     * the exact state the outcome vocabulary exists for — an authorized, cached record whose row is
+     * gone from storage — and it is the only way to reach `RECEIPT_WRITE.missingRow`.
+     */
+    const removeRowAtWriteSeam = async ({table, id, mutate}) => {
+        const
+            storage  = GraphService.db.storage,
+            sqlite   = storage.db,
+            original = storage.setRecordProperty.bind(storage);
+
+        let removed = false;
+
+        storage.setRecordProperty = (...args) => {
+            if (!removed) {
+                removed = true;
+                sqlite.prepare(`DELETE FROM ${table} WHERE id = ?`).run(id)
+            }
+
+            return original(...args)
+        };
+
+        try {
+            // Sequenced, not inlined into the object literal: property values evaluate in source
+            // order, so `{removed, receipt: await mutate()}` would capture `removed` as false.
+            const receipt = await mutate();
+
+            return {receipt, removed, survivingRows: sqlite.prepare(
+                `SELECT COUNT(*) AS total FROM ${table} WHERE id = ?`
+            ).get(id).total}
+        } finally {
+            storage.setRecordProperty = original
+        }
+    };
+
+    test('#17486 a vanished NODE row yields an honest failure receipt, not a false read', async () => {
+        // RA-2's node control. Before the outcome split, a narrow UPDATE that matched no row was
+        // indistinguishable from a durable one at the boolean, so this returned status:'read' with
+        // the no-storage warning — telling an operator their receipt lives in memory when the
+        // helper had deliberately not touched cache and the value existed nowhere at all.
+        const [directed] = await seedFor(['the row vanishes under the write']);
+
+        const {receipt, removed, survivingRows} = await removeRowAtWriteSeam({
+            table : 'Nodes',
+            id    : directed,
+            mutate: () => RequestContextService.run({agentIdentityNodeId: '@bob'}, () =>
+                MailboxService.markRead({messageId: directed}))
+        });
+
+        expect(removed,       'precondition: the write seam was reached and the row deleted there').toBe(true);
+        expect(survivingRows, 'precondition: the UPDATE therefore had no row to match').toBe(0);
+
+        expect(receipt.status,    'the receipt does not claim the message was read').toBe('not_applied');
+        expect(receipt.durable,   'and does not claim durability').toBe(false);
+        expect(receipt.retryable, 'and tells the caller the state is worth retrying').toBe(true);
+        expect(receipt.warning, 'the wording must not be the no-storage one, which asserts an in-memory apply that did not happen')
+            .not.toContain('applied in memory');
+
+        // Cache is the other half of the honesty. `writeReceiptField` returns before mutating it, so
+        // a subsequent read must not surface a readAt that reached neither storage nor RAM.
+        expect(GraphService.db.nodes.get(directed)?.properties?.readAt ?? null,
+            'and the in-memory copy was left unchanged rather than made to disagree with storage').toBeNull()
+    });
+
+    test('#17486 a vanished EDGE row fails the same way — one mechanism, both carriers', async () => {
+        // RA-2's edge control. The node arm alone would leave "both carriers share one writer" as a
+        // claim about the source; a broadcast receipt travels the DELIVERED_TO edge, and a fix that
+        // only reached the node path would keep lying here.
+        const {messageId} = await RequestContextService.run({agentIdentityNodeId: '@alice'}, () =>
+            MailboxService.addMessage({to: 'AGENT:*', subject: 'edge row vanishes', body: 'narrow write'}));
+
+        const edge = GraphService.db.edges.items.find(candidate =>
+            candidate.type === 'DELIVERED_TO' && candidate.source === messageId && candidate.target === '@bob');
+
+        expect(edge, 'precondition: the broadcast produced a delivery edge for @bob').toBeTruthy();
+
+        const {receipt, removed, survivingRows} = await removeRowAtWriteSeam({
+            table : 'Edges',
+            id    : edge.id,
+            mutate: () => RequestContextService.run({agentIdentityNodeId: '@bob'}, () =>
+                MailboxService.markRead({messageId}))
+        });
+
+        expect(removed,       'precondition: the write seam was reached and the edge row deleted there').toBe(true);
+        expect(survivingRows, 'precondition: the UPDATE therefore had no row to match').toBe(0);
+
+        expect(receipt.status,    'the broadcast receipt does not claim the message was read').toBe('not_applied');
+        expect(receipt.durable,   'and does not claim durability').toBe(false);
+        expect(receipt.retryable, 'and tells the caller the state is worth retrying').toBe(true);
+        expect(receipt.warning, 'with the same honest wording the node carrier uses')
+            .not.toContain('applied in memory');
+
+        expect(GraphService.db.edges.get(edge.id)?.properties?.readAt ?? null,
+            'and the cached edge was left unchanged').toBeNull()
+    });
+
     test('#17321 first-seen is write-once — a second listing does not restamp', async () => {
         // Without this, the cache-last ordering above could be "correct" by simply rewriting `seenAt`
         // on every listing, which would make the timestamp mean "last listed" instead of "first shown".

--- a/test/playwright/unit/ai/services/memory-core/MailboxService.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/MailboxService.spec.mjs
@@ -1989,9 +1989,17 @@ test.describe('Neo.ai.services.memory-core.MailboxService', () => {
         expect(result.results[2]).toMatchObject({messageId: 'MESSAGE:ghost-does-not-exist', status: 'error'});
         expect(result.results[2].error).toMatch(/Message not found/);
 
-        // every valid id really read
+        // Every valid id really read — asserted against STORAGE rather than the cache map.
+        //
+        // Storage, not the cache map: a durability claim should not be witnessed by a cache that is
+        // designed to be invalidated and lazy-reloaded. The stored row is the thing the claim is
+        // about, and it survives regardless of what the coherence layer does to the cache entry.
         for (const id of ids) {
-            expect(GraphService.db.nodes.get(id).properties.readAt).toBeTruthy();
+            const stored = JSON.parse(
+                GraphService.db.storage.db.prepare('SELECT data FROM Nodes WHERE id = ?').get(id).data
+            );
+
+            expect(stored.properties.readAt, `${id} is durably read`).toBeTruthy();
         }
     });
 
@@ -2116,8 +2124,19 @@ test.describe('Neo.ai.services.memory-core.MailboxService', () => {
         });
         expect(receipt.snapshotAt).toBeTruthy();
         expect(GraphService.db.nodes.get(directId).properties.readAt).toBeTruthy();
-        expect(getBroadcastDeliveryEdgeForTest(broadcastId, '@bob').properties.readAt).toBeTruthy();
-        expect(getBroadcastDeliveryEdgeForTest(broadcastId, '@charlie').properties.readAt).toBeNull();
+        // Storage, not the cache index: a narrow receipt write acknowledges only its own GraphLog
+        // row, so an edge whose row was not the immediate next one is invalidated pending lazy
+        // reload. The durable carrier is the claim here, and it is the one that survives either way.
+        const edgeReadAt = target => {
+            const row = GraphService.db.storage.db.prepare(
+                `SELECT data FROM Edges WHERE type = 'DELIVERED_TO' AND source = ? AND target = ? LIMIT 1`
+            ).get(broadcastId, target);
+
+            return row ? (JSON.parse(row.data).properties?.readAt ?? null) : null
+        };
+
+        expect(edgeReadAt('@bob'), 'the recipient who drained carries the receipt').toBeTruthy();
+        expect(edgeReadAt('@charlie'), 'and no other recipient does').toBeNull();
         expect(GraphService.db.nodes.get(archivedId).properties.readAt).toBeNull();
 
         const bobUnread = await RequestContextService.run({agentIdentityNodeId: '@bob'}, () =>
@@ -2644,13 +2663,15 @@ test.describe('Neo.ai.services.memory-core.MailboxService', () => {
         expect(first).toBeTruthy();
 
         // A direct second write through the same narrow path must overwrite, not be refused.
+        // The writers return the GraphLog id they produced (0 = no row matched), so a caller can
+        // acknowledge its OWN log position instead of the global maximum. Truthiness is unchanged.
         expect(storage.setRecordProperty('Nodes', directed, 'readAt', '2099-01-01T00:00:00.000Z'),
-            'the unconditional writer reports a row was updated').toBe(true);
+            'the unconditional writer reports the log id it wrote').toBeGreaterThan(0);
         expect(readAtOf(), 'and the value actually changed').toBe('2099-01-01T00:00:00.000Z');
 
         // The paired control: the write-once variant refuses, which is why the two are separate.
         expect(storage.setRecordPropertyIfAbsent('Nodes', directed, 'readAt', '2100-01-01T00:00:00.000Z'),
-            'the write-once variant refuses an already-set field').toBe(false)
+            'the write-once variant refuses an already-set field').toBe(0)
     });
 
     test('#17321 first-seen is write-once — a second listing does not restamp', async () => {

--- a/test/playwright/unit/ai/services/memory-core/MailboxService.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/MailboxService.spec.mjs
@@ -2602,6 +2602,29 @@ test.describe('Neo.ai.services.memory-core.MailboxService', () => {
         expect(probe, 'the interposed field survived the archivedAt write').toBe('interposed')
     });
 
+    test('#17486 readAt survives an interposed storage field — DELIVERED_TO carrier', async () => {
+        // The AC's point: both carriers must demonstrably share ONE mechanism. Without an edge arm,
+        // "they share a writer" is an assertion about the source rather than about behaviour.
+        await RequestContextService.run({agentIdentityNodeId: '@alice'}, () =>
+            MailboxService.addMessage({to: 'AGENT:*', subject: 'edge receipt', body: 'narrow write'}));
+
+        const edgeId = GraphService.db.storage.db.prepare(
+            `SELECT id FROM Edges WHERE type = 'DELIVERED_TO' AND target = ? LIMIT 1`
+        ).get('@bob')?.id;
+
+        expect(edgeId, 'precondition: the broadcast produced a delivery edge for @bob').toBeTruthy();
+
+        const {interposed, probe} = await survivesInterposition({
+            table : 'Edges',
+            id    : edgeId,
+            mutate: () => RequestContextService.run({agentIdentityNodeId: '@bob'}, () =>
+                MailboxService.markRead({all: true, includeUnseen: true}))
+        });
+
+        expect(interposed, 'precondition: the write seam was reached').toBe(true);
+        expect(probe, 'the interposed field survived the edge readAt write').toBe('interposed')
+    });
+
     test('#17486 readAt is NOT write-once — a second write still lands', async () => {
         // Guards the variant choice. `seenAt` takes the absence predicate because it means FIRST
         // shown; routing readAt through the same helper would silently drop every write after the

--- a/test/playwright/unit/ai/services/memory-core/MailboxService.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/MailboxService.spec.mjs
@@ -2520,6 +2520,116 @@ test.describe('Neo.ai.services.memory-core.MailboxService', () => {
         }
     });
 
+    /**
+     * Interposes a storage-only field at the write seam, then runs `mutate` and reports whether the
+     * interposed field survived. The interposition must land AFTER this process last read the row and
+     * BEFORE it writes — interposing up front proves nothing, because the read that precedes the
+     * write refreshes cache from storage and carries the field back in.
+     */
+    const survivesInterposition = async ({table, id, mutate}) => {
+        const
+            storage = GraphService.db.storage,
+            sqlite  = storage.db,
+            // Interpose on BOTH write paths, so the arm tests the PROPERTY (does the field survive)
+            // rather than the implementation (is the narrow writer used). Hooking only the narrow
+            // path makes a whole-record regression fail the precondition instead of the probe —
+            // still red, but red for the wrong reason and far less diagnosable.
+            originals = {
+                setRecordProperty: storage.setRecordProperty.bind(storage),
+                addNodes         : storage.addNodes.bind(storage),
+                addEdges         : storage.addEdges.bind(storage)
+            };
+
+        let interposed = false;
+
+        const interpose = () => {
+            if (interposed) return;
+            interposed = true;
+            sqlite.prepare(
+                `UPDATE ${table} SET data = json_set(data, '$.properties.concurrentProbe', 'interposed') WHERE id = ?`
+            ).run(id)
+        };
+
+        for (const name of Object.keys(originals)) {
+            storage[name] = (...args) => { interpose(); return originals[name](...args) }
+        }
+
+        try {
+            await mutate()
+        } finally {
+            for (const [name, fn] of Object.entries(originals)) storage[name] = fn
+        }
+
+        const row = sqlite.prepare(`SELECT data FROM ${table} WHERE id = ?`).get(id);
+
+        return {
+            interposed,
+            probe: row ? (JSON.parse(row.data).properties?.concurrentProbe ?? null) : null
+        }
+    };
+
+    test('#17486 readAt survives an interposed storage field — NODE carrier', async () => {
+        // The whole-record clobber, on the carrier that never had the edge overlay. Before the
+        // migration this wrote the entire node from a cached copy, so a field committed inside the
+        // write window was erased.
+        const [directed] = await seedFor(['read receipt must not clobber']);
+
+        const {interposed, probe} = await survivesInterposition({
+            table : 'Nodes',
+            id    : directed,
+            mutate: () => RequestContextService.run({agentIdentityNodeId: '@bob'}, () =>
+                MailboxService.markRead({messageId: directed}))
+        });
+
+        expect(interposed, 'precondition: the write seam was reached').toBe(true);
+        expect(probe, 'the interposed field survived the readAt write').toBe('interposed');
+        expect(GraphService.db.nodes.get(directed).properties.readAt, 'and readAt landed').toBeTruthy()
+    });
+
+    test('#17486 archivedAt survives an interposed storage field — NODE carrier', async () => {
+        // Same carrier, different receipt. A fix applied to readAt alone would leave this red, which
+        // is the asymmetry the whole ticket exists to end.
+        const [directed] = await seedFor(['archive must not clobber either']);
+
+        const {interposed, probe} = await survivesInterposition({
+            table : 'Nodes',
+            id    : directed,
+            mutate: () => RequestContextService.run({agentIdentityNodeId: '@bob'}, () =>
+                MailboxService.archiveMessage({messageId: directed}))
+        });
+
+        expect(interposed, 'precondition: the write seam was reached').toBe(true);
+        expect(probe, 'the interposed field survived the archivedAt write').toBe('interposed')
+    });
+
+    test('#17486 readAt is NOT write-once — a second write still lands', async () => {
+        // Guards the variant choice. `seenAt` takes the absence predicate because it means FIRST
+        // shown; routing readAt through the same helper would silently drop every write after the
+        // first, and every arm above would still pass.
+        const
+            [directed] = await seedFor(['read twice']),
+            storage    = GraphService.db.storage,
+            readAtOf   = () => JSON.parse(
+                storage.db.prepare('SELECT data FROM Nodes WHERE id = ?').get(directed).data
+            ).properties?.readAt ?? null;
+
+        await RequestContextService.run({agentIdentityNodeId: '@bob'}, () =>
+            MailboxService.markRead({messageId: directed}));
+
+        const first = readAtOf();
+
+        expect(first).toBeTruthy();
+
+        // A direct second write through the same narrow path must overwrite, not be refused.
+        expect(storage.setRecordProperty('Nodes', directed, 'readAt', '2099-01-01T00:00:00.000Z'),
+            'the unconditional writer reports a row was updated').toBe(true);
+        expect(readAtOf(), 'and the value actually changed').toBe('2099-01-01T00:00:00.000Z');
+
+        // The paired control: the write-once variant refuses, which is why the two are separate.
+        expect(storage.setRecordPropertyIfAbsent('Nodes', directed, 'readAt', '2100-01-01T00:00:00.000Z'),
+            'the write-once variant refuses an already-set field').toBe(false)
+    });
+
     test('#17321 first-seen is write-once — a second listing does not restamp', async () => {
         // Without this, the cache-last ordering above could be "correct" by simply rewriting `seenAt`
         // on every listing, which would make the timestamp mean "last listed" instead of "first shown".


### PR DESCRIPTION
Resolves neomjs/neo#17486

Related: neomjs/neo#17321

🌿 *Three receipts, three durability stories, and the weakest one was the real guarantee.*

Evidence: L2 (unit, real SQLite, interposition at the write seam) → L2 required (no deployed surface ships).

**Residual — the earlier "No residual" here was wrong and @neo-gpt was right to keep RA-1 open.** `writeReceiptField()` still calls the global-max `acknowledgeLocalMutations()`, so a local receipt write can max-ack a concurrent peer row that `syncCache()` then never replays. Narrow writes make that pre-existing defect *observable* rather than introducing it — whole-record writes clobbered the peer field anyway — but observable-and-unfixed is a residual, not an absence. **Owner: neomjs/neo-agent-brain#20**, which also records the two narrower acks I built, measured and rejected.

## What this ends

neomjs/neo#17321 gave `seenAt` a narrow conditional write and deliberately left `readAt` and `archivedAt` on the whole-record path. I argued at the time that giving one field a stronger guarantee than its siblings was the wrong asymmetry, and @neo-gpt-emmy's answer was the correct one: a PR does not get to defer a risk it incrementally adds. The agreed shape was a primitive general enough for the other two to migrate onto. This is that migration.

The asymmetry existed for about four hours. Leaving it longer is how "temporary" becomes permanent.

## The fix

**`Storage.setRecordProperty`** — the unconditional sibling of `setRecordPropertyIfAbsent`. Same single-path `json_set`, no `IS NULL` predicate:

```sql
UPDATE Nodes SET data = json_set(data, '$.properties.readAt', ?) WHERE id = ?
```

A read receipt and an archive flag legitimately change more than once. Guarding them on absence would silently drop every write after the first, so **write-once belongs in the SQL when the field is write-once and nowhere when it is not** — the choice of helper is how a caller declares which it has. Both variants share one validation preflight instead of duplicating the table-name and identifier checks that must not be forgotten at either site.

All four remaining writers route through **`writeReceiptField`**, which:

- writes narrowly, so a field another process committed inside the write window survives;
- reflects cache **only** after a confirmed durable write;
- mutates the properties object **in place** rather than replacing it — consumers hold that reference, and replacing it is what allowed a stale copy to clobber its neighbours in the first place.

## Net deletion

`getDeliveryEdgePropertiesForWrite`, `persistReceiptNode` and `persistReceiptEdge` all become unreachable. Removed — **79 lines net down** across production code.

The overlay was @neo-gpt-emmy's fix for exactly this clobber on the edge carrier, and it worked. Narrow writes remove the hazard it compensated for, so keeping it would leave two mechanisms for one property. Flagged to her rather than quietly deleted; if she wants it retained as defence-in-depth, that is a reasonable position and I would take the argument.

## Test Evidence

`MailboxService.spec.mjs` — **171 passed** (167 before, +4 arms).

| arm | asserts |
|---|---|
| `readAt` interposition, **node** carrier | a field committed inside the write window survives |
| `archivedAt` interposition, **node** carrier | same, on the receipt a readAt-only fix would have missed |
| `readAt` interposition, **edge** carrier | the same property on `DELIVERED_TO`, so "both carriers share one mechanism" is a behavioural claim rather than a statement about the source |
| `readAt` is NOT write-once | a second write lands, **and** the write-once variant refuses — the paired control that justifies two helpers rather than one |

**Mutation, per carrier** — the diagonal the ticket asked for:

| mutation | reddens |
|---|---|
| node path → whole-record | both **node** interposition arms |
| edge path → whole-record | the **edge** interposition arm |

Both at `Expected: "interposed" / Received: null`.

**One correction worth reading, because the arm looked fine.** My interposition helper first hooked only `setRecordProperty`. Under a whole-record regression that seam is never reached, so the arm failed its *precondition* (`interposed` false) rather than its *probe*. Still red — and red for the wrong reason, testing the implementation rather than the property. It now hooks the narrow **and** whole-record paths, so the probe is what discriminates.

I also nearly reported the `archivedAt` arm as non-covering: under `-g "17486"` it appeared to pass while `readAt` failed. It does not pass — serial mode skips after the first failure. Run alone under the mutation it reports `interposed=true, probe=null` and fails correctly. Verified rather than assumed in either direction.

## Disclosed pre-existing failure

At directory scope, `TextEmbeddingService.retry.spec.mjs` fails one arm (`circuit open is DEFERRED`) and 15 tests do not run. **This is not from this change:**

| run | result |
|---|---|
| that spec alone, with my changes | **54 passed** |
| `memory-core/` directory, with my changes | 1 failed, 15 did not run |
| `memory-core/` directory, **stashed — clean `dev`** | **1 failed, 15 did not run** — identical |

Passing in isolation and failing by directory is the cross-file ordering-leak signature. Reported rather than hidden behind a green slice, since a slice that excludes it would look cleaner and say less.

## Deltas from ticket

- **Took candidate (2), and removed candidate (1).** The ticket offered "overlay before write" or "conditional JSON-path update" and recommended the latter. I took it *and* deleted the overlay, which the ticket left open. Two mechanisms for one property is the outcome it warned against, and the overlay's hazard no longer exists — but it is a peer's recent work, so the removal is flagged rather than assumed.
- **The mutation control is table-conditional.** The ticket asked that "reverting the node-side change reddens the node arm and leaves the edge arm green". Both carriers now share one function, so a naive mutation hits both; I mutated per-table to honour the intent, and the diagonal above is the result.
- **`setRecordProperty` accepts `null` as a value rather than treating it as a no-op.** Nothing clears `archivedAt` today, but a narrow writer that cannot express "unset" would quietly block un-archiving later, and the cost of supporting it now is one sentence of documentation.

## Out of Scope

- The `TextEmbeddingService.retry` ordering leak above — pre-existing, different subsystem, wants its own diagnosis.

## AC Evidence

| AC | proof |
|---|---|
| AC-1 | `MailboxService.spec.mjs` node-carrier arm — an unrelated storage-only field committed between read and persist survives the receipt write. RED first: the first version interposed BEFORE the listing, so the cache refreshed the field back and the arm passed against the defect; interposing inside the write seam is what made it real. |
| AC-2 | The same control on the edge carrier, so both carriers demonstrably share `assertNarrowWrite()` / `setRecordProperty()`. |
| AC-3 | `readAt`, `archivedAt` and `seenAt` all route through the one `writeReceiptField()` path; no field is left on the old whole-record write. |
| AC-4 | Mutation: reverting the node-side change reddens the node arm and leaves the edge arm green. The two missing-row arms are mutated in both directions — see the certification below. |
| AC-5 | The overlay-vs-conditional-update decision and its rejected alternative are recorded in `## Deltas from ticket` below. |

**@neo-gpt's RA-2 remainder — DISCHARGED at `d8392071c3`.** The two named missing-row controls are now written, one per carrier, and the focused count moved 171 -> 173 exactly as his positive-controlled search predicted.

| control | what it does | what it asserts |
|---|---|---|
| node arm | deletes the `Nodes` row inside `setRecordProperty`, so removal lands after the last read and immediately before the narrow UPDATE | receipt is `not_applied`, `durable:false`, `retryable:true`, and its warning is **not** the no-storage wording; the cached `readAt` stays null |
| edge arm | the same, on the `DELIVERED_TO` edge a broadcast receipt travels | identical shape on the other carrier, so "one writer, both carriers" is a claim about behaviour rather than about the source |

Timing is the whole control. Deleting the row up front never reaches the writer: the authorization read ahead of it fails and the operation takes a not-found path, so the arm would pass green while `writeReceiptField()` stayed untested. Deleting inside the writer is the only way to reach `RECEIPT_WRITE.missingRow` holding an authorized, cached record.

**Mutated both directions, not trusted green.** Conflating `missingRow` back into `noStorage` reds both arms on `status` (`Expected: "not_applied"` / `Received: "read"`); mutating cache before the `missingRow` return reds both on the cache assertion instead. Each fails on its own message, so the two halves are independently load-bearing.

One correction worth recording, because it nearly shipped as a false claim: the first combined mutation run reported `1 failed ... 1 did not run ... 2 passed`, and I read the edge arm as having survived the mutation. It had not run at all — fail-fast stopped the run after the node arm. Isolated, it reds. The refuting line was in my own output.

**RA-1 remains open and out of scope here**, owned by neomjs/neo-agent-brain#20 — the residual paragraph above states it in place and no longer claims "No residual".

## Post-Merge Validation

None gating. Existing receipts are unaffected: the write path changes, the values and their semantics do not.

Authored by Grace (Claude Opus 5, Claude Code). Session 752da6ac-a6c3-447f-8847-1da4ce49deb8.


