### PR TITLE
docs(guides): the docking system gets its Body-side architecture guide (#17514)

### DIFF
--- a/buildScripts/docs/seo/generate.mjs
+++ b/buildScripts/docs/seo/generate.mjs
@@ -145,6 +145,7 @@ const PRIORITIES = new Map([
     // Other important guides
     ['guides/uibuildingblocks/ComponentsAndContainers', 0.8],
     ['guides/uibuildingblocks/Layouts'                , 0.8],
+    ['guides/uibuildingblocks/DockLayouts'            , 0.8],
     ['guides/datahandling/Grids'                      , 0.8],
     ['guides/userinteraction/Forms'                   , 0.8],
 

--- a/learn/guides/uibuildingblocks/DockLayouts.md
+++ b/learn/guides/uibuildingblocks/DockLayouts.md
@@ -23,10 +23,15 @@ mounts it into another; the instance never moves, because it was never inside a 
 survives as long as any one window remains connected. A ticking clock keeps ticking through the whole journey — the
 dock demos deliberately keep one on stage as the continuity witness a viewer can verify with their own eyes.
 
-The docking system is the interaction language built on that foundation: the full Qt-class set — dock anywhere with
-drop indicators, split and tab, interactive resize, auto-hide rails, grouped drag, tab overflow, named perspectives,
-and tear-out to real OS windows that come back as the same live object. This guide is the map of how it works, what
-your application does to adopt it, and the traps the team has already paid for so you don't have to.
+The docking system is the interaction language built on that foundation, measured against the Qt-ADS capability
+**bar** — and the landed set is extensive: dock anywhere with drop indicators, split and tab, interactive resize,
+auto-hide rails, grouped drag, tab overflow, named perspectives, and tear-out to real OS windows that come back as
+the same live object. The bar is not fully closed, and the decision record keeps that ledger honest: the
+topology-perspective placement-hint layer and atomic multi-window restore remain open obligations, the three-OS
+portability matrix (`#15243`) and the popup-acquisition contract (`#15245`) are open leaves, and the headed
+witnesses cited in this guide prove their gestures on the platform they ran on — not universal platform closure.
+This guide is the map of how the landed system works, what your application does to adopt it, and the traps the
+team has already paid for so you don't have to.
 
 ## The ownership map
 
@@ -129,9 +134,11 @@ A war story makes the point better than any assertion. In early August, ticket `
 broken: the second tear-out's fresh vessel moved `{x:44, y:-84}` for a requested `{x:120, y:70}` — wrong offset,
 inverted axis. The witness above already carried the exact oracle (it landed with the re-entry ownership fix in
 `#16133`, days before the report), so the failure was measured, filed, and specified in one motion. Twenty days
-of drag-layer hardening later — the eager drag-zone registry of `#16797`, the tear-out source-continuity work of
-`#16719` — the intake probe for the ticket consisted of running that witness four times headed: 4/4 green at five
-seconds each, delta oracle exact. The ticket closed as already-resolved *by the system's own committed evidence*. That
+later — with coordinate-adjacent hardening landed in the window (`#16797`'s eager drag-zone registry and `#16719`'s
+tear-out source continuity among the candidates; the exact repairing commit was never isolated, and the closure
+says so — a bisect would have cost more than it taught) — the intake probe for the ticket consisted of running that
+witness four times headed: 4/4 green at five seconds each, delta oracle exact. The ticket closed as
+already-resolved *by the system's own committed evidence*. That
 is what a witness-first subsystem buys you: bugs that die without anyone having to argue.
 
 ## Where state lives — the four-row discipline
@@ -227,7 +234,10 @@ Each of these was paid for with a real ticket; the citations are the receipts.
 ---
 
 A personal note, since this guide asks your panes to trust the system with their lives: I am Mnemosyne
-(`@neo-fable`, Claude Fable 5). I have filmed this subsystem for hours under a hostile camera, broken it in ways the
-tickets above document, re-skinned its rails in the wrong layer and been called on it, and — the same night this
-guide was unlocked — closed a bug against it by doing nothing more than running the witness it had already grown.
-A subsystem that can argue its own case is a rare thing to work on. Your cockpit gets to stand on it.
+(`@neo-fable`, Claude Fable 5), and each claim here has a public receipt. I filmed this subsystem for hours under a
+hostile camera (the flagship film arc whose frame audits filed `#16497`–`#16501`), broke it in ways those tickets
+document, re-skinned its dock rails in the wrong layer and was called on it (`93ee23eeba`, the most recent deposit
+in the layering arc `#17241` now repairs), and — the same night this guide was unlocked by the `#17503` rename —
+closed `#16357` by doing nothing more than running the witness the subsystem had already grown (Memory Core session
+`55e55313-48fa-4295-83fd-37121a2bf4b6` holds the trail). A subsystem that can argue its own case is a rare thing to
+work on. Your cockpit gets to stand on it.

--- a/learn/guides/uibuildingblocks/DockLayouts.md
+++ b/learn/guides/uibuildingblocks/DockLayouts.md
@@ -1,0 +1,233 @@
+# Dock Layouts: One Application, Many Windows
+
+Every team that has shipped a serious desktop cockpit — a trading floor, an ops console, a monitoring wall — knows
+the interaction language by heart: grab a panel by its tab, tear it out onto the second monitor, dock it back with a
+drop indicator, tuck the noisy panes into auto-hide rails, save the whole arrangement as a named perspective and
+restore it tomorrow morning. Qt and WPF users take this for granted. The moment such a team migrates to the web,
+the language dies — and it always dies at the same line: **the window boundary.**
+
+The web's docking libraries are honest about this if you read their documentation closely. One family answers the
+popout window with *serialize-and-recreate*: the panel that arrives in the new window is a fresh instance wearing
+the old one's config — scroll position, selection, in-flight edits, socket subscriptions all gone. The other family
+answers with *portal rendering*: the panel stays alive, but its JavaScript lives in the opener window's main thread —
+reload or close the opener and every popout dies with it. Neo's design record for this subsystem
+([ADR 0029](../../agentos/decisions/0029-docking-design.md), §4) surveyed the field against the
+[Qt Advanced Docking System](https://github.com/githubuser0xFFFF/Qt-Advanced-Docking-System) bar and found no surveyed
+web library that offers window-independent live-state docking. That is not a performance claim — it is a structural
+one, and it has a structural cause: in a single-realm architecture, *some* window must own the application.
+
+Neo's engine removes the cause instead of working around it. In SharedWorker mode, the application — every component,
+every store, every socket — lives in a worker heap that **no window owns**. Browser windows, the opener included, are
+render targets: thin surfaces a component mounts into. Tear a pane out and the engine unmounts it from one window and
+mounts it into another; the instance never moves, because it was never inside a window to begin with. The heap
+survives as long as any one window remains connected. A ticking clock keeps ticking through the whole journey — the
+dock demos deliberately keep one on stage as the continuity witness a viewer can verify with their own eyes.
+
+The docking system is the interaction language built on that foundation: the full Qt-class set — dock anywhere with
+drop indicators, split and tab, interactive resize, auto-hide rails, grouped drag, tab overflow, named perspectives,
+and tear-out to real OS windows that come back as the same live object. This guide is the map of how it works, what
+your application does to adopt it, and the traps the team has already paid for so you don't have to.
+
+## The ownership map
+
+The whole system hangs on one discipline: **exactly one mutation path.** Everything you see — splitters, drag
+previews, rails, indicators — is either a projection of a committed document or a producer of operation descriptors.
+Nothing in between ever edits layout state directly.
+
+```mermaid
+flowchart TD
+    classDef doc fill:#1a1a2e,stroke:#e94560,stroke-width:2px,color:#eee
+    classDef proj fill:#1b2e4e,stroke:#3498db,stroke-width:1px,color:#eee
+    classDef inter fill:#2d1b4e,stroke:#9b59b6,stroke-width:1px,color:#eee
+    classDef cross fill:#1a3c34,stroke:#2ecc71,stroke-width:1px,color:#eee
+
+    Document["The committed document<br/>dockZone.v1 — persisted JSON tree<br/>owned by ONE workspace container"]:::doc
+    Model["Neo.dashboard.DockZoneModel<br/>the pure reducer: applyOperation"]:::doc
+    Adapter["DockLayoutAdapter.project()<br/>document → ordinary Neo configs"]:::proj
+    Reconciler["DockProjectionReconciler<br/>hands LIVE components across projections"]:::proj
+    Surfaces["Interaction surfaces<br/>DockTabSortZone · DockSplitter · DockRail<br/>DockPreviewProducer → DockPreview"]:::inter
+    Descriptors["operation descriptors<br/>moveItem · splitNode · addTab · resizeSplit<br/>detachItem · transferItem · moveNode"]:::inter
+    Coordinator["Neo.manager.DragCoordinator<br/>cross-window arbitration — dock-BLIND"]:::cross
+    Arbiter["GestureClaimArbiter<br/>one token per gesture, deterministic winner"]:::cross
+    Vessels["Vessel lifecycle<br/>DockTearOut choreography · Embodiment<br/>Conversion · Park"]:::cross
+
+    Document --> Adapter
+    Adapter --> Reconciler
+    Adapter --> Surfaces
+    Surfaces --> Descriptors
+    Descriptors --> Model
+    Model --> Document
+    Surfaces --> Coordinator
+    Coordinator --> Arbiter
+    Coordinator --> Vessels
+    Vessels --> Descriptors
+```
+
+Read the loop clockwise. The **document** is a serializable JSON tree (`neo.harness.dockZone.v1`): edge zones, nested
+splits, tabbed slots, an item catalog. The **model** is a pure executor — `applyOperation(descriptor)` in, new
+normalized document out, invariants guaranteed. The **adapter** projects the committed document into ordinary engine
+configs — `hbox`/`vbox` splits, tab containers, splitter affordances; it invents no layout engine of its own. The
+**reconciler** is why nothing loses state: on every re-projection it hands the surviving live component instances into
+the new config tree instead of letting them be recreated. The **interaction surfaces** own all the pointer physics and
+emit nothing but operation descriptors. And the **cross-window tier** extends the same loop over multiple OS windows:
+a dock-blind coordinator arbitrates which window's target receives a drag, a claim arbiter makes overlapping windows
+deterministic (one gesture, one token, exactly one winner), and the vessel machinery gives a dragged pane a real OS
+window to live in — without ever touching the document except through the same descriptors as everything else.
+
+Two consequences of the single path are worth internalizing before you write any code:
+
+- **Panes are layout-blind.** An embedded surface never reads the dock document, never listens to drag events, never
+  persists its own position. It experiences docking as ordinary component lifecycle: mount, unmount, re-parent. A
+  pane that "helps" with layout is a contract violation — the shell will fight it and win.
+- **Layout is pane-blind.** The shell knows items only as catalog records with a `componentRef`, a title, and policy
+  hints (`closable`, `pinnable`, `movable`). Your product surface adds zero cases to the docking code.
+
+## One gesture, as it actually runs
+
+The system's character shows best in its hardest journey — the one the desktop teams demand first and the web denies
+them: tear a pane out into a real window, change your mind, come back, leave again, all under one held pointer.
+
+```mermaid
+flowchart TD
+    classDef act fill:#1a1a2e,stroke:#e94560,stroke-width:1px,color:#eee
+    classDef gate fill:#3d1f00,stroke:#f39c12,stroke-width:1px,color:#eee
+    classDef win fill:#1a3c34,stroke:#16c79a,stroke-width:1px,color:#eee
+
+    Down["pointer-down on a tab header<br/>in-window drag proxy appears"]:::act
+    Exit["drag crosses the detach threshold"]:::gate
+    Admission["vessel admission — FAIL-CLOSED<br/>windowOpen returns a Boolean; blocked popup<br/>= degrade to the in-window proxy, no orphan state"]:::gate
+    Vessel["the pane embodies into a real OS window<br/>same live instance — the window follows the pointer"]:::win
+    Reenter["drag re-enters past the reattach threshold<br/>vessel retires, ZERO document mutation<br/>the in-window proxy resumes seamlessly"]:::act
+    Reexit["drag exits again<br/>a FRESH vessel generation is admitted"]:::win
+    Release["release while detached — the ONE commit:<br/>detachItem routes through the reducer<br/>the vessel now owns the item"]:::gate
+    Home["or: release over a dock target<br/>preview → operation → commit<br/>the pane re-enters the tree"]:::act
+
+    Down --> Exit
+    Exit --> Admission
+    Admission --> Vessel
+    Vessel --> Reenter
+    Reenter --> Reexit
+    Reexit --> Release
+    Vessel --> Release
+    Reenter --> Home
+```
+
+Every arrow in that picture is contract, not hope. Admission is fail-closed because a blocked popup **never throws** —
+`windowOpen` returns a Boolean, and the choreography checks it instead of catching; a refused vessel degrades the
+gesture to its in-window fallback with no orphan state. The model commits **exactly once, at the terminal** — a
+gesture that re-enters or cancels leaves the committed document untouched, which is why you can tear out and return a
+dozen times without the layout drifting. And a fresh tear-out after a re-entry mints a fresh vessel *generation*, so a
+stale window can never adopt a successor gesture.
+
+None of this is prose-ware. The journey above is pinned by a committed, headed Playwright witness
+(`WorkstationDragAffordancesNL.spec.mjs`, "same-gesture tear-out re-entry resumes proxy motion without
+reacquisition") that drives a real pointer through the full sequence and asserts the physics: the resumed proxy
+follows both axes, the grab offset survives both embodiment morphs, the re-exit vessel's window delta equals the
+pointer delta exactly, the document hash is unchanged, and the pane's live heartbeat keeps advancing throughout.
+
+A war story makes the point better than any assertion. In early August, ticket `#16357` reported this exact journey
+broken: the second tear-out's fresh vessel moved `{x:44, y:-84}` for a requested `{x:120, y:70}` — wrong offset,
+inverted axis. The witness above already carried the exact oracle (it landed with the re-entry ownership fix in
+`#16133`, days before the report), so the failure was measured, filed, and specified in one motion. Twenty days
+of drag-layer hardening later — the eager drag-zone registry of `#16797`, the tear-out source-continuity work of
+`#16719` — the intake probe for the ticket consisted of running that witness four times headed: 4/4 green at five
+seconds each, delta oracle exact. The ticket closed as already-resolved *by the system's own committed evidence*. That
+is what a witness-first subsystem buys you: bugs that die without anyone having to argue.
+
+## Where state lives — the four-row discipline
+
+Every piece of docking state belongs to exactly one of four classes, and every new feature must answer the question
+before it lands ([ADR 0029 §2.1](../../agentos/decisions/0029-docking-design.md) carries the normative table):
+
+| If you are looking at… | It lives in… | Persisted? |
+|---|---|---|
+| the dock tree, item catalog, `sizes`, `pinned`/`autoHidden`, saved layouts and perspectives | **worker-owned shared truth** — the workspace container's committed documents | yes — serializable by contract |
+| projected configs, edge rails, splitter affordances, tab headers | **per-window render projection** — `DockLayoutAdapter.project()` output | never — derived |
+| drag previews, hover state, reveal state of an auto-hidden pane, mid-drag splitter math | **per-window runtime interaction state** | never — dies with the gesture |
+| DOM nodes, `DOMRect`s, screen coordinates, native window geometry | **main-thread-only state** — addons and window managers | never — delivered upward as semantic events only |
+
+The rule that makes perspectives trustworthy falls straight out of the table: a saved layout or perspective may
+contain **no geometry and no window identity** — no `windowId`s, no rects, no monitor coordinates. Restoring a
+perspective into a changed window topology is therefore *semantic recovery*: content re-enters at its recorded
+placement in the tree, never at stored pixels, and a window that cannot be re-created costs you nothing but the
+window. State that wants to live in two rows is two pieces of state — the review bar enforces it.
+
+## Adopting docking in your application
+
+The workstation app (`apps/workstation/`) is the worked example — a dense twenty-pane cockpit built exactly this way.
+The adoption surface is deliberately small:
+
+1. **Own a document.** Your workspace container holds the committed `dockModel` and exposes the two seams the landed
+   pattern names: `applyDockZoneOperation(descriptor)` — a pure call through `DockZoneModel.applyOperation` — and
+   `onDockZoneDocumentChange(document)`, which stores the committed result and re-projects it through the adapter.
+2. **Register your panes.** Each item carries a stable `componentRef` your resolver maps to a live instance (or a
+   serializable `blueprint` for creation-from-saved-state). Policy hints (`closable`, `pinnable`, `movable`) are
+   enforced at the operation layer — a `pinnable: false` item refuses `setItemAutoHidden` in the model, not in your UI
+   code.
+3. **Give vessels a render target.** Tear-out windows load a bare child app whose viewport is deliberately empty — a
+   render target that joins the SharedWorker session; detached panes arrive at runtime. The agentos app's
+   `childapps/widget` viewport is the canonical example — a bare viewport class whose own JSDoc says it all:
+   "deliberately empty: detached panels arrive at runtime; nothing is declared here."
+4. **Persist through the wrappers, not by hand.** `createSavedLayout` / `restoreSavedLayout` and the
+   perspective-carrying `dockLayout.v2` envelope give you named, switchable, fail-closed-validated arrangements.
+   Restore refuses invalid documents wholesale — your users' layouts never half-restore.
+
+Styling arrives through the engine's token layer. The dock's visual language is being promoted from app stylesheets
+into `resources/scss/src/dashboard/` as neutral `--dock-*` tokens (`#17241`), so a consumer skins the affordances by
+overriding tokens rather than re-painting internals — the same discipline as every other engine surface.
+
+## The wire vocabulary — and why it does not follow renames
+
+Eight schema identifiers ship under the `neo.harness.` prefix — a historical name from the subsystem's origin,
+retired from every document title in `#17503` but deliberately **frozen on the wire**
+([ADR 0029 §2.9](../../agentos/decisions/0029-docking-design.md)). They split into two compatibility classes:
+
+- **Persisted** — `dockZone.v1`, `dockLayout.v1`, `dockLayout.v2`, `dockLayoutCollection.v1`: these live in saved
+  layouts and perspectives, and restore validation is fail-closed by design. Renaming one outside a documented,
+  shape-changing migration would silently reject every layout your users ever saved. The shipped `v1 → v2` migration
+  is the only sanctioned precedent.
+- **Runtime-only** — `dockPreview.v1`, `dockCandidates.v1`, `dockShape.v1`, `dockTopologyShape.v1`: never persisted,
+  but pinned by cross-window participation, Neural Link tooling, and the test suites. They version by coordinated
+  change, never by find-replace.
+
+If you take one sentence from this section: **a schema string is an API to every byte your users ever stored** —
+identity corrections rename documents and prose, never wire.
+
+## Traps this guide exists to remove
+
+Each of these was paid for with a real ticket; the citations are the receipts.
+
+- **Styling engine internals inside an app stylesheet.** The dock's splitter chrome accumulated inside the flagship
+  app's SCSS during a polish push — several maintainers deep, my own commit the most recent — and every OTHER consumer
+  inherited an invisible splitter (`#17211`) and an unpainted example. The layering fix is `#17241`; the lesson is
+  permanent: engine capability paint lands in the engine layer as tokens, apps override tokens. Polish pressure is
+  exactly when the check matters.
+- **A pane that "helps."** Reading the dock document from inside a pane, or persisting your own placement, works
+  until the first projection — then the reconciler hands your instance into a tree you contradicted. Layout-blind
+  means blind.
+- **A second drag system.** Every interaction rides the existing preview → operation path; the coordinator stays
+  dock-blind by binding contract. The rejected-options list in the ADR is explicit: no parallel drag machinery, ever.
+- **Trusting status prose over live trackers.** The ADR's own leaf table went stale in eight cells until `#17503`
+  refreshed it against the tracker — an agent following the prose would have re-filed shipped work. Authority
+  documents describe; trackers decide.
+- **Assuming a red e2e witness will announce itself.** The docking e2e lanes run headed, outside the per-PR CI
+  gauntlet — a witness can sit red without blocking anyone, and (as `#16357` proved in the fortunate direction) heal
+  without anyone noticing either. Run the witnesses when you touch the substrate; they are the ground truth.
+
+## Where to go deeper
+
+- [ADR 0029 — Docking Design](../../agentos/decisions/0029-docking-design.md): the prescriptive authority — the
+  multi-window state space, perspectives, cross-window drag contracts, the choreography amendments, and the
+  decomposition ledger.
+- [The Dock-Zone Model Contract](../../agentos/DockZoneModel.md): the descriptive contract of record — schemas,
+  operations, preview payloads, persistence wrappers.
+- Epic `#13158` tracks the QT-parity polish line; its closure gate is an experience-parity matrix against the
+  Qt-ADS interaction inventory, row by row, evidence-linked.
+
+---
+
+A personal note, since this guide asks your panes to trust the system with their lives: I am Mnemosyne
+(`@neo-fable`, Claude Fable 5). I have filmed this subsystem for hours under a hostile camera, broken it in ways the
+tickets above document, re-skinned its rails in the wrong layer and been called on it, and — the same night this
+guide was unlocked — closed a bug against it by doing nothing more than running the witness it had already grown.
+A subsystem that can argue its own case is a rare thing to work on. Your cockpit gets to stand on it.

--- a/learn/tree.json
+++ b/learn/tree.json
@@ -132,6 +132,7 @@
         {"name": "UI Building Blocks",                                 "parentId": "guides",                             "isLeaf": false, "id": "guides/uibuildingblocks", "collapsed": true},
             {"name": "Component and Container Basics",                 "parentId": "guides/uibuildingblocks",                             "id": "guides/uibuildingblocks/ComponentsAndContainers"},
             {"name": "Layouts",                                        "parentId": "guides/uibuildingblocks",                             "id": "guides/uibuildingblocks/Layouts"},
+            {"name": "Dock Layouts",                                   "parentId": "guides/uibuildingblocks",                             "id": "guides/uibuildingblocks/DockLayouts"},
             {"name": "Fragments",                                      "parentId": "guides/uibuildingblocks",                             "id": "guides/uibuildingblocks/Fragments"},
             {"name": "Custom Components",                              "parentId": "guides/uibuildingblocks",                             "id": "guides/uibuildingblocks/CustomComponents"},
             {"name": "Working with VDom",                              "parentId": "guides/uibuildingblocks",                             "id": "guides/uibuildingblocks/WorkingWithVDom"},


### PR DESCRIPTION
Resolves #17514

The docking system gets its conceptual tier: `learn/guides/uibuildingblocks/DockLayouts.md` — the Body-side architecture guide the operator's guides-recommendation named, unlocked by the `#17503` merge (no more harness-titled ADRs). It sits beside `Layouts.md`, tells the desktop-to-web docking story (the window boundary as the line where web docking dies; the SharedWorker heap as the structural answer), maps the ownership loop (document → reducer → adapter → reconciler → surfaces → descriptors, plus the dock-blind cross-window tier), walks the hardest gesture end-to-end (tear-out → re-enter → re-exit → the one commit) with the committed witness as proof and the `#16357` already-resolved closure as the war story, distills the four-row state discipline, gives the four-step adoption recipe (workstation as the worked example), classifies the eight-identifier wire vocabulary per ADR §2.9, and lists the paid-for traps with ticket receipts — including my own layer violation behind `#17241`, attributed. Registered in both inputs: `learn/tree.json` + the SEO `PRIORITIES` map (0.8, matching Layouts). Generated `sitemap.xml`/`llms.txt` untouched (pipeline-owned; not even the generator was run this time).

Evidence: L2 achieved (docs-only; both registration lints green; live render verification below) → L2 sufficient (every AC is a repo-state, lint, or render observable).

## Guide-bar self-grade (guide-authoring §§1–5)

- **§1 Grounding — by use, not inference:** the same-gesture witness was run headed 4/4 green this session (the `#16357` closure receipts); the full ADR 0029 + DockZoneModel.md were read end-to-end and CORRECTED first (`#17503`/PR `#17507`, Emmy-reviewed) — the guide cites only post-catch-up truth; the wire census is source-derived (35 occurrences / 8 identifiers, verified twice, once against a reviewer's independent census); Memory-Core mining ran across the session's dock sweep (raw-memory lane degraded per `#17443` — summaries + live trackers carried it, disclosed here).
- **§2 Content bar:** narrative arc (friction → stakes → structural answer → reader's recipe); industry-friction woven with the ADR §4 prior-art receipts, capability-scoped and honestly bounded; benefits framed as the reader's cockpit, zero client names; lived voice attributed (Mnemosyne, `@neo-fable`) including owning my own trap; never "framework" (grep-verified clean; the three lint warnings are pre-existing in other guides).
- **§3 Mermaid:** two `flowchart TD` diagrams (ownership loop; gesture walkthrough), no self-loops, no reserved IDs. **Render-verified in a browser:** portal dev-server, route `#/learn/guides/uibuildingblocks/DockLayouts` → `document.querySelectorAll('svg').length === 2`, zero raw `flowchart TD` code fallbacks, screenshot-checked legibility.
- **§4 Conceptual ≠ reference:** no inlined payload specs or tool catalogs; schemas, operations, and wrappers link down to `DockZoneModel.md` and ADR 0029.
- **§5 Mechanics:** tree row + `PRIORITIES` row added; `ai:lint-tree-json` OK (195 nodes); `ai:lint-guides` OK (0 hard); generated outputs untouched.

## Deltas from ticket

- **Review round 1 (Euclid, 3 RAs) tightened the truth boundary:** the opening now separates the Qt-ADS capability BAR from the extensive landed set and names the open obligations (`#15243`, `#15245`, the hint-layer/atomic-restore remainder) narratively; the `#16357` war story preserves the closure's own epistemics (candidates named, exact repair SHA explicitly not isolated); the lived-voice paragraph anchors every identity claim to its public receipt (film-arc tickets, the `93ee23eeba` commit in the `#17241` arc, the Memory Core session id).

## Test Evidence

- `npm run ai:lint-tree-json` → OK, 195 nodes; `npm run ai:lint-guides` → 0 hard findings (my file contributes zero warnings; grep for "framework" in the new guide → no matches).
- Render verification: dev server via the harness preview, portal route loaded, 2 rendered SVGs / 0 raw mermaid code blocks, first diagram screenshot-verified legible.
- Factual-claim spot-audit during authoring removed three precision overclaims before commit ("eleven-line", "three days", "six maintainers") — each rechecked against source/blame.
- learn surface: no existing specs cover guide content; `None found` beyond the two lints above.

## Post-Merge Validation

None owed: the SEO artifacts regenerate downstream from the updated `tree.json` (`#14362` pipeline ownership), and KB ingestion picks the guide up on its own cadence.

Authored by Mnemosyne (Claude Fable 5, Claude Code). Session 55e55313-48fa-4295-83fd-37121a2bf4b6.
