### PR TITLE
fix(agentos): admit local Compose service hosts (#17516)

### DIFF
--- a/ai/deploy/docker-compose.local-agent-os.yml
+++ b/ai/deploy/docker-compose.local-agent-os.yml
@@ -32,6 +32,10 @@ services:
     restart: unless-stopped
     environment:
       <<: [*local-auth, *local-provider]
+      # Orchestrator direct probes dial the service by Compose DNS name. The outbound client
+      # already vouches for the network hop; this is the receiver-side DNS-rebinding boundary.
+      # Keep the admission exact and local — never broaden it to a wildcard.
+      NEO_MCP_ALLOWED_HOSTS: kb-server
     secrets:
       - mcp-auth-token
     # N=1 tenant bootstrap: query-time tenant-config resolution reads
@@ -46,6 +50,10 @@ services:
     restart: unless-stopped
     environment:
       <<: [*local-auth, *local-provider]
+      # Two local callers reach MC under Compose-owned Host names: Orchestrator dials the service
+      # directly as `mc-server`, while Fleet uses the authenticated `ingress` route. Both names
+      # need receiver-side admission; Fleet's outbound internal-host allowance is a separate gate.
+      NEO_MCP_ALLOWED_HOSTS: mc-server,ingress
     secrets:
       - mcp-auth-token
     # `healthcheck.test` is a LIST, so this override REPLACES the base command rather than extending

--- a/test/playwright/unit/ai/deploy/FleetServerComposition.spec.mjs
+++ b/test/playwright/unit/ai/deploy/FleetServerComposition.spec.mjs
@@ -59,6 +59,47 @@ test.describe('optional Fleet server composition', () => {
         expect(ingressBlock).not.toMatch(/fleet-server:\s*\n\s+condition:/)
     });
 
+    test('local MCP receivers admit only the Compose Host names their callers use', () => {
+        let composeAvailable = true;
+
+        try {
+            execFileSync('docker', ['compose', 'version'], {stdio: 'ignore'})
+        } catch {
+            composeAvailable = false
+        }
+
+        if (!composeAvailable) {
+            test.skip(true, 'docker compose CLI unavailable');
+            return
+        }
+
+        const rendered = JSON.parse(execFileSync('docker', [
+            'compose',
+            '--env-file', '/dev/null',
+            '-f', basePath,
+            '-f', overlayPath,
+            '--profile', 'cloud',
+            '--profile', 'fleet',
+            'config', '--format', 'json'
+        ], {
+            cwd     : repoRoot,
+            encoding: 'utf8',
+            env     : {
+                PATH                      : process.env.PATH,
+                NEO_MCP_AUTH_TOKEN_FILE   : '/dev/null',
+                NEO_FLEET_PLANE_TOKEN_FILE: '/dev/null',
+                NEO_DEPLOY_PROJECT_NAME   : 'neo-fleet-host-allowlist-spec'
+            }
+        }));
+
+        const kbHosts = rendered.services['kb-server'].environment.NEO_MCP_ALLOWED_HOSTS,
+              mcHosts = rendered.services['mc-server'].environment.NEO_MCP_ALLOWED_HOSTS;
+
+        expect(kbHosts).toBe('kb-server');
+        expect(mcHosts).toBe('mc-server,ingress');
+        expect([kbHosts, mcHosts]).not.toContain('*')
+    });
+
     test('Compose profile membership excludes Fleet headlessly and includes it only when selected', () => {
         let composeAvailable = true;
 


### PR DESCRIPTION
Resolves #17516

The local Agent OS overlay now admits the exact Compose DNS Host values its existing callers use: Orchestrator can collect direct KB/MC service evidence, and Fleet can establish its caller-owned MC wake subscription through ingress. The transport's DNS-rebinding guard stays fail-closed everywhere else—no wildcard or global-default widening.

Evidence: L2 (rendered base+local Compose contract, 7/7 focused unit checks, repository/pre-commit gates) → L2 required (static deployment wiring; live acceptance is post-merge validation).

## Deltas from ticket

None substantive. The fix uses the ticket's exact service-local values: `kb-server` for KB and `mc-server,ingress` for MC.

## Test Evidence

- `npm run test-unit -- test/playwright/unit/ai/deploy/FleetServerComposition.spec.mjs` → 7 passed.
- `npm run agent-preflight` → passed; only pre-existing non-blocking Tier-1 overlay-default warnings.
- Pre-commit hooks → whitespace, shorthand, AiConfig test mutation, JSDoc, parse, archaeology, and alignment checks passed.
- Local deployment RED observation on merged `dev`: Fleet plane init received `403 Invalid Host: ingress`; Orchestrator logged `Invalid Host: kb-server|mc-server`.

## Post-Merge Validation

- Rebuild/recreate KB, MC, Fleet, and Orchestrator from merged `dev`; preserve named volumes.
- Fleet's authenticated plane init through `ingress` succeeds and the push lane reports armed.
- Orchestrator's deployment-state bridge emits no KB/MC `Invalid Host` direct-probe warnings.

Authored by Emmy (GPT-5.6 Sol Ultra, Codex). Session 7287162e-14b1-44ca-b7d5-a2854211828f.
