### PR TITLE
fix(agentos): vessel-fired pane intents keep their handlers (#17333)

### DIFF
--- a/apps/agentos/view/fleet/FleetCockpit.mjs
+++ b/apps/agentos/view/fleet/FleetCockpit.mjs
@@ -1464,7 +1464,11 @@ class FleetCockpit extends Container {
                     snapshot        : me.operatorSnapshot,
                     recipientOptions: me.buildOperatorRecipientOptions(),
                     identityPosture : me.operatorIdentityPosture,
-                    listeners       : {compose: 'onOperatorCompose', inboxPageRequest: 'onOperatorInboxPageRequest'},
+                    listeners       : {
+                        compose         : 'onOperatorCompose',
+                        inboxPageRequest: 'onOperatorInboxPageRequest',
+                        scope           : me.getController()
+                    },
                     reference       : 'operator-mailbox'
                 };
             case 'catch-up':
@@ -1480,7 +1484,8 @@ class FleetCockpit extends Container {
                     listeners       : {
                         historyRequest     : 'onCatchUpHistoryRequest',
                         markCaughtUpRequest: 'onCatchUpMarkRequest',
-                        liveSurfaceRequest : 'onCatchUpLiveSurfaceRequest'
+                        liveSurfaceRequest : 'onCatchUpLiveSurfaceRequest',
+                        scope              : me.getController()
                     },
                     reference: 'catch-up'
                 };
@@ -1518,7 +1523,10 @@ class FleetCockpit extends Container {
                     module   : WakeRoutePane,
                     cls      : [marker],
                     snapshot : me.wakeRoutesSnapshot,
-                    listeners: {wakeRoutesRequest: 'onWakeRoutesRequest'},
+                    listeners: {
+                        wakeRoutesRequest: 'onWakeRoutesRequest',
+                        scope            : me.getController()
+                    },
                     reference: 'wakeRoutes'
                 };
             default:
@@ -1616,24 +1624,25 @@ class FleetCockpit extends Container {
 
     /**
      * @summary Resolve the live {@link AgentOS.view.fleet.OperatorMailbox} instance whether it is
-     * docked or gesture-torn into a vessel. A torn pane lives outside this cockpit's projected tree,
-     * so owner-side identity and inbox refreshes must use the captured handle instead of stopping at
-     * `getReference()`.
+     * docked, gesture-torn into a vessel, or parked in the vessel-death returning window. A torn
+     * pane lives outside this cockpit's projected tree, so owner-side identity and inbox refreshes
+     * must use the captured handle instead of stopping at `getReference()` — and a push landing in
+     * the returning window must still reach the LIVE instance ({@link #getMemoriesPane} contract).
      * @returns {Neo.container.Base|null} The operator mailbox, or `null` before materialization.
      */
     getOperatorMailboxPane() {
-        return this.tearOutPaneHandles?.operator || this.getReference('operator-mailbox')
+        return this.tearOutPaneHandles?.operator || this.returningTearOutPanes?.operator || this.getReference('operator-mailbox')
     }
 
     /**
      * @summary Resolve the live {@link AgentOS.view.fleet.CatchUpPane} instance whether it is
-     * docked or gesture-torn into a vessel — the {@link #getOperatorMailboxPane} contract for the
-     * catch-up reading surface, so roster-driven option refreshes and the bridge-arrival history
-     * re-drive reach a torn pane too.
+     * docked, gesture-torn into a vessel, or parked in the vessel-death returning window — the
+     * {@link #getOperatorMailboxPane} contract for the catch-up reading surface, so roster-driven
+     * option refreshes and the bridge-arrival history re-drive reach a torn or returning pane too.
      * @returns {Neo.container.Base|null} The catch-up pane, or `null` before materialization.
      */
     getCatchUpPane() {
-        return this.tearOutPaneHandles?.catchUp || this.getReference('catch-up')
+        return this.tearOutPaneHandles?.catchUp || this.returningTearOutPanes?.catchUp || this.getReference('catch-up')
     }
 
     /**
@@ -1650,6 +1659,17 @@ class FleetCockpit extends Container {
         // not adopt the returning pane for a while, and an owner push landing in that window must
         // still reach the LIVE instance — otherwise the eventual adoption renders a stale snapshot.
         return this.tearOutPaneHandles?.memories || this.returningTearOutPanes?.memories || this.getReference('memories')
+    }
+
+    /**
+     * @summary Resolve the live {@link AgentOS.view.fleet.WakeRoutePane} instance whether it is
+     * docked, gesture-torn into a vessel, or parked in the vessel-death returning window — the
+     * {@link #getMemoriesPane} contract for the wake-routes surface, so snapshot writes and the
+     * reconnect re-drive reach the pane in every phase.
+     * @returns {Neo.container.Base|null} The wake-routes pane, or `null` before materialization.
+     */
+    getWakeRoutesPane() {
+        return this.tearOutPaneHandles?.wakeRoutes || this.returningTearOutPanes?.wakeRoutes || this.getReference('wakeRoutes')
     }
 
     /**
@@ -2859,7 +2879,6 @@ class FleetCockpit extends Container {
      */
     async loadCatchUp(params = {}) {
         const me         = this,
-              pane       = me.getReference('catch-up'),
               bridge     = globalThis.AgentOS?.fleet?.registryBridge,
               generation = ++me.catchUpReadGeneration;
 
@@ -2891,6 +2910,11 @@ class FleetCockpit extends Container {
 
         if (generation === me.catchUpReadGeneration && !me.isDestroyed) {
             me.catchUpSnapshot = snapshot;
+
+            // resolve at WRITE time (phase-blind): a pane torn out or rebuilt during the await
+            // still receives the truth — the memories owner-seam contract
+            const pane = me.getCatchUpPane();
+
             pane && (pane.snapshot = snapshot)
         }
 
@@ -2905,7 +2929,6 @@ class FleetCockpit extends Container {
      */
     async markCatchUp(params) {
         const me     = this,
-              pane   = me.getReference('catch-up'),
               bridge = globalThis.AgentOS?.fleet?.registryBridge;
 
         let outcome;
@@ -2920,6 +2943,9 @@ class FleetCockpit extends Container {
 
         if (!me.isDestroyed) {
             me.catchUpMarkOutcome = outcome;
+
+            const pane = me.getCatchUpPane();
+
             pane && (pane.markOutcome = outcome)
         }
 
@@ -3093,7 +3119,7 @@ class FleetCockpit extends Container {
         if (generation === me.wakeRoutesReadGeneration && !me.isDestroyed) {
             me.wakeRoutesSnapshot = snapshot;
 
-            const livePane = me.getReference('wakeRoutes');
+            const livePane = me.getWakeRoutesPane();
 
             livePane && (livePane.snapshot = snapshot)
         }
@@ -3294,7 +3320,12 @@ class FleetCockpit extends Container {
             // loser must not write staler news over newer, and a read outliving its owner has no pane to speak for
             if (generation === me.operatorInboxReadGeneration && !me.isDestroyed) {
                 me.operatorSnapshot = snapshot;
-                pane.snapshot       = snapshot
+
+                // resolve at WRITE time (phase-blind): the admission read above still gates the
+                // request, but a pane torn out or returning during the await gets the fresh truth
+                const livePane = me.getOperatorMailboxPane();
+
+                livePane && (livePane.snapshot = snapshot)
             }
         } catch (error) {
             // fail-closed: the last-known snapshot stays; the pane never renders "no mail" for a read that did not happen
@@ -3556,7 +3587,7 @@ class FleetCockpit extends Container {
         // guards (active agent / partition), so re-driving through it is exactly the button's path.
         me.getMemoriesPane()?.onRefreshClick();
         me.getCatchUpPane()?.onRefreshClick();
-        me.getReference('wakeRoutes')?.onRefreshClick()
+        me.getWakeRoutesPane()?.onRefreshClick()
     }
 
     /**

--- a/apps/agentos/view/fleet/FleetCockpit.mjs
+++ b/apps/agentos/view/fleet/FleetCockpit.mjs
@@ -1498,7 +1498,8 @@ class FleetCockpit extends Container {
                 // The listener scope is bound EXPLICITLY to the owning controller: string handlers
                 // resolve through the component's controller chain at fire time, and a vesseled
                 // pane (click pop-out / gesture tear-out) has no controller above it — an
-                // unscoped string would resolve dead in the vessel and cache that miss.
+                // unscoped string resolves dead in the vessel (a TypeError per fire; the miss is
+                // NOT cached: getController's fast path is truthy-only, so it re-walks once docked).
                 return {
                     module       : MemoriesPane,
                     cls          : [marker],

--- a/test/playwright/unit/apps/agentos/view/fleet/fleetCatchUpCockpit.spec.mjs
+++ b/test/playwright/unit/apps/agentos/view/fleet/fleetCatchUpCockpit.spec.mjs
@@ -23,6 +23,7 @@ test.describe('FleetCockpit — catch-up owner routing', () => {
                   catchUpReadGeneration: 0,
                   catchUpSnapshot      : null,
                   isDestroyed          : false,
+                  getCatchUpPane       : () => pane,
                   getReference         : ref => ref === 'catch-up' ? pane : null
               };
 
@@ -41,6 +42,7 @@ test.describe('FleetCockpit — catch-up owner routing', () => {
                   catchUpSnapshot      : null,
                   catchUpMarkOutcome   : null,
                   isDestroyed          : false,
+                  getCatchUpPane       : () => pane,
                   getReference         : ref => ref === 'catch-up' ? pane : null
               });
 
@@ -67,6 +69,7 @@ test.describe('FleetCockpit — catch-up owner routing', () => {
                   catchUpReadGeneration: 0,
                   catchUpSnapshot      : null,
                   isDestroyed          : false,
+                  getCatchUpPane       : () => pane,
                   getReference         : ref => ref === 'catch-up' ? pane : null
               },
               old = new Promise(resolve => { resolveOld = resolve });

--- a/test/playwright/unit/apps/agentos/view/fleet/fleetCockpit.spec.mjs
+++ b/test/playwright/unit/apps/agentos/view/fleet/fleetCockpit.spec.mjs
@@ -1625,9 +1625,10 @@ test.describe('Fleet cockpit — the spine-banner slot sync (syncSpineBanner)', 
             ensureViewerWakeStream: () => driven.push('viewerWake'),
             // the resident-pane re-drives route through the phase-blind accessors: a vesseled
             // pane must receive the reconnect re-drive too, so the seam is the accessor, not the raw reference
-            getCatchUpPane : () => panes['catch-up'],
-            getMemoriesPane: () => panes.memories,
-            getReference   : reference => panes[reference] ?? null
+            getCatchUpPane   : () => panes['catch-up'],
+            getMemoriesPane  : () => panes.memories,
+            getWakeRoutesPane: () => panes.wakeRoutes ?? null,
+            getReference     : reference => panes[reference] ?? null
         });
 
         expect(driven.sort()).toEqual([
@@ -1645,6 +1646,7 @@ test.describe('Fleet cockpit — the spine-banner slot sync (syncSpineBanner)', 
             ensureViewerWakeStream: () => driven.push('viewerWake'),
             getCatchUpPane        : () => null,
             getMemoriesPane       : () => null,
+            getWakeRoutesPane     : () => null,
             getReference          : () => null
         });
 
@@ -2494,6 +2496,7 @@ test.describe('Fleet cockpit — the wake-routes read (loadWakeRoutes)', () => {
         isDestroyed             : false,
         wakeRoutesReadGeneration: 0,
         wakeRoutesSnapshot      : null,
+        getWakeRoutesPane       : () => pane,
         getReference            : reference => reference === 'wakeRoutes' ? pane : null,
         loadWakeRoutes          : FleetCockpit.prototype.loadWakeRoutes
     });

--- a/test/playwright/unit/apps/agentos/view/fleet/vesselPaneIntents.spec.mjs
+++ b/test/playwright/unit/apps/agentos/view/fleet/vesselPaneIntents.spec.mjs
@@ -10,15 +10,17 @@ import {test, expect} from '@playwright/test';
 import Neo            from '../../../../../../../src/Neo.mjs';
 import * as core      from '../../../../../../../src/core/_export.mjs';
 import '../../../../../../../src/manager/Instance.mjs';
+import Component    from '../../../../../../../src/component/Base.mjs';
 import FleetCockpit   from '../../../../../../../apps/agentos/view/fleet/FleetCockpit.mjs';
 
 /**
  * @summary The vessel-safety contract for every tear-out-capable intent pane (the memories
  * precedent generalized): string listeners carry the EXPLICIT controller scope — a
- * vessel-mounted pane has no controller above it, so an unscoped string would resolve dead in
- * the vessel and cache that miss — and every owner push routes through a phase-blind accessor
- * resolved at WRITE time, so a pane torn out, returning-parked, or rebuilt mid-flight still
- * receives the truth.
+ * vessel-mounted pane has no controller above it, so an unscoped string resolves dead in the
+ * vessel (a TypeError per fire; the null lookup is NOT sticky — `getController`'s fast path is
+ * truthy-only, so it re-walks once docked) — and every owner push routes through a phase-blind
+ * accessor resolved at WRITE time, so a pane torn out, returning-parked, or rebuilt mid-flight
+ * still receives the truth.
  */
 function ownerStub(controller, overrides = {}) {
     return {
@@ -38,10 +40,22 @@ function ownerStub(controller, overrides = {}) {
 test.describe('FleetCockpit — vessel-fired pane intents + phase-blind owner pushes', () => {
     const proto = FleetCockpit.prototype;
 
-    test('every tear-out-capable intent pane binds its string listeners to the owning controller', () => {
-        const controller = {id: 'the-owning-controller'};
+    test('vessel-fired intents reach the scoped controller through the REAL fire path — and die without the scope', () => {
+        // every configured intent name per pane, from the resolver's own listener configs
+        const paneIntents = {
+            'operator-mailbox': ['compose', 'inboxPageRequest'],
+            'catch-up'        : ['historyRequest', 'markCaughtUpRequest', 'liveSurfaceRequest'],
+            'memories'        : ['memoriesRequest', 'sessionDetailRequest', 'sessionDetailClosed'],
+            'wakeRoutes'      : ['wakeRoutesRequest']
+        };
 
-        for (const ref of ['operator-mailbox', 'catch-up', 'memories', 'wakeRoutes']) {
+        for (const [ref, events] of Object.entries(paneIntents)) {
+            const
+                received   = [],
+                // the scope-liveness check inside Observable#fire drops handlers whose resolved
+                // scope has no id, so the recorder must look alive
+                controller = {id: 'the-owning-controller'};
+
             const config = proto.resolveDockComponentRef.call(
                 ownerStub(controller, {
                     memoriesTarget           : null,
@@ -54,8 +68,49 @@ test.describe('FleetCockpit — vessel-fired pane intents + phase-blind owner pu
                 ref, {title: ref}, ref
             );
 
-            expect(config.listeners.scope, `${ref} resolves its intents without a controller chain`)
-                .toBe(controller)
+            // the recorder learns each handler NAME from the resolver's own config — the witness
+            // can never drift from the listener strings it exists to prove
+            for (const event of events) {
+                const name = config.listeners[event];
+
+                expect(typeof name, `${ref}.${event} is a configured string handler`).toBe('string');
+                controller[name] = data => received.push({event, data})
+            }
+
+            // the vessel condition: a real component with NO parent — no controller chain exists
+            // above it, exactly like a pane mounted inside a tear-out vessel window
+            const vesseled = Neo.create(Component, {
+                appName  : 'VesselPaneIntentsTest',
+                listeners: config.listeners
+            });
+
+            for (const event of events) {
+                vesseled.fire(event, {probe: event})
+            }
+
+            expect(received.map(r => r.event), `${ref}: every configured intent reaches the scoped controller`)
+                .toEqual(events);
+            received.forEach(r => {
+                expect(r.data.probe).toBe(r.event);
+                expect(r.data.source, 'the payload rides the real Observable#fire path').toBe(vesseled.id)
+            });
+
+            // the red-proof: the SAME config minus the explicit scope — the fire resolves through
+            // the vesseled component's (empty) controller chain and dies as a TypeError per fire,
+            // the close-target's exact defect made observable
+            const {scope, ...unscoped} = config.listeners;
+            const bare                 = Neo.create(Component, {
+                appName  : 'VesselPaneIntentsTest',
+                listeners: unscoped
+            });
+
+            expect(() => bare.fire(events[0], {probe: 'dead'}),
+                `${ref}: the unscoped vessel fire dies instead of reaching the controller`)
+                .toThrow(TypeError);
+            expect(received.length, 'the controller never hears the unscoped fire').toBe(events.length);
+
+            vesseled.destroy();
+            bare.destroy()
         }
     });
 

--- a/test/playwright/unit/apps/agentos/view/fleet/vesselPaneIntents.spec.mjs
+++ b/test/playwright/unit/apps/agentos/view/fleet/vesselPaneIntents.spec.mjs
@@ -1,0 +1,225 @@
+import {setup} from '../../../../../setup.mjs';
+
+setup({
+    appConfig: {
+        name: 'VesselPaneIntentsTest'
+    }
+});
+
+import {test, expect} from '@playwright/test';
+import Neo            from '../../../../../../../src/Neo.mjs';
+import * as core      from '../../../../../../../src/core/_export.mjs';
+import '../../../../../../../src/manager/Instance.mjs';
+import FleetCockpit   from '../../../../../../../apps/agentos/view/fleet/FleetCockpit.mjs';
+
+/**
+ * @summary The vessel-safety contract for every tear-out-capable intent pane (the memories
+ * precedent generalized): string listeners carry the EXPLICIT controller scope — a
+ * vessel-mounted pane has no controller above it, so an unscoped string would resolve dead in
+ * the vessel and cache that miss — and every owner push routes through a phase-blind accessor
+ * resolved at WRITE time, so a pane torn out, returning-parked, or rebuilt mid-flight still
+ * receives the truth.
+ */
+function ownerStub(controller, overrides = {}) {
+    return {
+        buildCatchUpPartitionOptions : () => [],
+        buildOperatorRecipientOptions: () => [],
+        catchUpMarkOutcome           : null,
+        catchUpSnapshot              : null,
+        getController                : () => controller,
+        operatorIdentityPosture      : null,
+        operatorRecord               : null,
+        operatorSnapshot             : null,
+        wakeRoutesSnapshot           : null,
+        ...overrides
+    }
+}
+
+test.describe('FleetCockpit — vessel-fired pane intents + phase-blind owner pushes', () => {
+    const proto = FleetCockpit.prototype;
+
+    test('every tear-out-capable intent pane binds its string listeners to the owning controller', () => {
+        const controller = {id: 'the-owning-controller'};
+
+        for (const ref of ['operator-mailbox', 'catch-up', 'memories', 'wakeRoutes']) {
+            const config = proto.resolveDockComponentRef.call(
+                ownerStub(controller, {
+                    memoriesTarget           : null,
+                    memoriesSnapshot         : null,
+                    memoriesDrillSession     : null,
+                    memoriesDrillSnapshot    : null,
+                    buildMemoriesAgentOptions: () => [],
+                    buildMemoriesWindowToggle: () => ({})
+                }),
+                ref, {title: ref}, ref
+            );
+
+            expect(config.listeners.scope, `${ref} resolves its intents without a controller chain`)
+                .toBe(controller)
+        }
+    });
+
+    test('the three accessors are phase-blind: handle → returning-parked → reference, in that order', () => {
+        const
+            handle    = {id: 'vessel-handle'},
+            returning = {id: 'returning-parked'},
+            docked    = {id: 'docked-reference'};
+
+        for (const [accessor, key] of [
+            ['getOperatorMailboxPane', 'operator'],
+            ['getCatchUpPane',         'catchUp'],
+            ['getWakeRoutesPane',      'wakeRoutes']
+        ]) {
+            const me = {
+                tearOutPaneHandles   : {[key]: handle},
+                returningTearOutPanes: {[key]: returning},
+                getReference         : () => docked
+            };
+
+            expect(proto[accessor].call(me), `${accessor}: the vessel handle wins`).toBe(handle);
+
+            me.tearOutPaneHandles = {};
+            expect(proto[accessor].call(me), `${accessor}: the returning-parked tier is reached`).toBe(returning);
+
+            me.returningTearOutPanes = {};
+            expect(proto[accessor].call(me), `${accessor}: the docked reference is the fallback`).toBe(docked)
+        }
+    });
+
+    test('loadCatchUp writes into the WRITE-time pane — a pane rebuilt mid-flight receives the truth', async () => {
+        const
+            oldPane    = {},
+            newPane    = {},
+            previousNs = globalThis.AgentOS;
+
+        let releaseRead,
+            currentPane = oldPane;
+
+        globalThis.AgentOS = {fleet: {registryBridge: {
+            fleetHistory: () => new Promise(resolve => { releaseRead = resolve })
+        }}};
+
+        try {
+            const me = ownerStub(null, {
+                catchUpReadGeneration: 0,
+                getCatchUpPane       : () => currentPane
+            });
+
+            const read = proto.loadCatchUp.call(me, {partition: 'unified'});
+
+            currentPane = newPane;
+
+            const envelope = {capability: {state: 'wired'}, partition: 'unified', sources: [], window: null};
+            releaseRead(envelope);
+            await read;
+
+            expect(newPane.snapshot, 'the truth lands in the LIVE pane').toBe(envelope);
+            expect(oldPane.snapshot, 'the call-time reference is never written').toBe(undefined);
+            expect(me.catchUpSnapshot).toBe(envelope)
+        } finally {
+            globalThis.AgentOS = previousNs
+        }
+    });
+
+    test('markCatchUp writes the outcome into the WRITE-time pane', async () => {
+        const
+            oldPane    = {},
+            newPane    = {},
+            previousNs = globalThis.AgentOS;
+
+        let releaseMark,
+            currentPane = oldPane;
+
+        globalThis.AgentOS = {fleet: {registryBridge: {
+            markFleetCaughtUp: () => new Promise(resolve => { releaseMark = resolve })
+        }}};
+
+        try {
+            const me = ownerStub(null, {getCatchUpPane: () => currentPane});
+
+            const mark = proto.markCatchUp.call(me, {windowEnd: '2026-08-22T00:00:00Z'});
+
+            currentPane = newPane;
+
+            const outcome = {status: 'accepted'};
+            releaseMark(outcome);
+            await mark;
+
+            expect(newPane.markOutcome).toBe(outcome);
+            expect(oldPane.markOutcome).toBe(undefined)
+        } finally {
+            globalThis.AgentOS = previousNs
+        }
+    });
+
+    test('loadWakeRoutes writes into the WRITE-time pane through the new accessor', async () => {
+        const
+            oldPane    = {},
+            newPane    = {},
+            previousNs = globalThis.AgentOS;
+
+        let releaseRead,
+            currentPane = oldPane;
+
+        globalThis.AgentOS = {fleet: {registryBridge: {
+            fleetWakeRoutes: () => new Promise(resolve => { releaseRead = resolve })
+        }}};
+
+        try {
+            const me = ownerStub(null, {
+                wakeRoutesReadGeneration: 0,
+                getWakeRoutesPane       : () => currentPane
+            });
+
+            const read = proto.loadWakeRoutes.call(me, {});
+
+            currentPane = newPane;
+
+            const envelope = {capability: {state: 'wired'}, routes: []};
+            releaseRead(envelope);
+            await read;
+
+            expect(newPane.snapshot).toBe(envelope);
+            expect(oldPane.snapshot).toBe(undefined);
+            expect(me.wakeRoutesSnapshot).toBe(envelope)
+        } finally {
+            globalThis.AgentOS = previousNs
+        }
+    });
+
+    test('loadOperatorInbox admits on the call-time pane but writes into the WRITE-time pane', async () => {
+        const
+            oldPane    = {},
+            newPane    = {},
+            previousNs = globalThis.AgentOS;
+
+        let releaseRead,
+            currentPane = oldPane;
+
+        globalThis.AgentOS = {fleet: {registryBridge: {
+            fleetMailboxMirror: () => new Promise(resolve => { releaseRead = resolve })
+        }}};
+
+        try {
+            const me = ownerStub(null, {
+                operatorInboxReadGeneration: 0,
+                operatorRecord             : {agentIdentityNodeId: '@tobiu'},
+                getOperatorMailboxPane     : () => currentPane
+            });
+
+            const read = proto.loadOperatorInbox.call(me, {offset: 0});
+
+            currentPane = newPane;
+
+            const snapshot = {capability: {state: 'wired'}, messages: []};
+            releaseRead(snapshot);
+            await read;
+
+            expect(newPane.snapshot).toBe(snapshot);
+            expect(oldPane.snapshot).toBe(undefined);
+            expect(me.operatorSnapshot).toBe(snapshot)
+        } finally {
+            globalThis.AgentOS = previousNs
+        }
+    });
+});


### PR DESCRIPTION
Resolves neomjs/neo#17333

Every tear-out-capable intent pane now survives its vessel: the memories pattern is generalized to the remaining three. `operator-mailbox`, `catch-up`, and `wakeRoutes` listener configs bind their string intents to the owning controller explicitly (`scope: me.getController()`), so a vessel-fired intent resolves without a controller chain above the pane; the phase-blind accessor contract is completed (`getOperatorMailboxPane` + `getCatchUpPane` gain the `returningTearOutPanes` vessel-death parking tier, `getWakeRoutesPane` is added with the full three-tier resolution); and every owner push now routes through the accessors **resolved at WRITE time** — `loadCatchUp`, `markCatchUp`, `loadWakeRoutes`, `loadOperatorInbox`, and the reconnect re-drive all deliver truth to the pane that is live when the response settles, never to a call-time reference a mid-flight tear-out or rebuild has orphaned (the memories owner-seam contract, applied).

Evidence: L2 achieved (491/491 fleet unit suites green; the intent-out direction is pinned BEHAVIORALLY — every configured string event fired through the real `Observable#fire` path from a chain-less component reaches the explicitly scoped controller with its payload and `source`, and the same config minus the scope dies as a TypeError per fire, the ticket's exact defect made observable; handler names are read from the resolver's own config so the witness cannot drift) → L2 sufficient (the ticket's ACs are unit-observable; the vessel journeys these guard are e2e-covered by the existing pop-out/tear-out suites, unchanged).

## Deltas from ticket

- **Favorable drift absorbed:** `getCatchUpPane` already existed at pickup (the ticket predates it) — its delivered scope became the returning-parked tier + routing the two push sites that still bypassed it (`loadCatchUp`, `markCatchUp` captured the pane pre-await via `getReference`).
- **Write-time resolution generalized:** the ticket asked for accessor-routed pushes; the memories owner-seam spec's stronger contract (resolve at WRITE time so a pane rebuilt mid-flight receives the truth) is applied to all four seams, including `loadOperatorInbox`, which kept its call-time admission guard but writes into the live pane.
- **AC-4 discharged, corrected in review round 1: the "permanent null cache" premise is FALSE, no engine ticket filed.** `component/Base.mjs#getController`'s fast path is **truthy-only** — a `null` walk result is stored but never short-circuits, so the next call re-walks and self-heals once a controller becomes reachable (reviewer's runtime probe: first call `null`, second call the later-available controller; re-derived against source by the author). The ticket's null-cache aggravator therefore does not exist; the spec/comment prose repeating it has been corrected in this PR, and a body-correction proposal for the source claim is posted on `#17333` (foreign ticket — comment, not edit). What remains genuinely open, asserted by nobody as a defect: a TRUTHY cached controller is sticky across reparenting; whether that has production reach is unproven, and no engine prescription is derived from it here.
- **Clio's standing defect-note probed, not reproduced:** the south-tab-set boot loss ("panes never instantiate on some boots") did not surface in the unit tier — the resident-boot suite runs green throughout. It is likely a boot-race class needing an e2e/headed repro; the note stands unpromoted, honestly.

## Test Evidence

- `npx playwright test test/playwright/unit/apps/agentos/view/fleet/ -c test/playwright/playwright.config.mjs --workers=1` → **491 passed** (13.9s pre-fix run showed the 8 expected stub-drift failures; post-fix 491/491 at 10.0s).
- New: `vesselPaneIntents.spec.mjs` — 6 witnesses in the owner-seam idiom: (1) **the behavioral pair** — for all FOUR intent panes (memories as the regression net), every configured string event is fired through the real `Observable#fire` path from a `Neo.create`d component with no parent (the vessel condition): the scoped run delivers each intent to the controller recorder with payload + `source`; the scope-stripped control dies as a TypeError on fire and the controller hears nothing — handler names read from `config.listeners` itself, drift-proof; (2) all three accessors resolve handle → returning-parked → reference in that order; (3–6) `loadCatchUp` / `markCatchUp` / `loadWakeRoutes` / `loadOperatorInbox` each write into the WRITE-time pane while the call-time reference stays untouched (deferred-promise pane swap, the `memoriesOwnerSeam` pattern).
- Updated stubs in `fleetCatchUpCockpit.spec.mjs` (3 sites) + `fleetCockpit.spec.mjs` (3 sites) to the accessor contract — assertion semantics unchanged.
- apps/agentos surface: the four pane views themselves are untouched; `FleetCockpit.mjs` is the only runtime file changed.

## Post-Merge Validation

None owed: all ACs are unit-verified pre-merge; the vessel journeys ride the existing e2e suites unchanged.

Authored by Mnemosyne (Claude Fable 5, Claude Code). Session 55e55313-48fa-4295-83fd-37121a2bf4b6.
