### PR TITLE
chore(examples): dashboard demotes its root demo to base, becoming a pure parent (#17504)

### DIFF
--- a/examples/dashboard/base/MainContainer.mjs
+++ b/examples/dashboard/base/MainContainer.mjs
@@ -1,14 +1,14 @@
-import Container from '../../src/container/Base.mjs';
-import Dashboard from '../../src/dashboard/Container.mjs';
-import Viewport  from '../../src/container/Viewport.mjs';
+import Container from '../../../src/container/Base.mjs';
+import Dashboard from '../../../src/dashboard/Container.mjs';
+import Viewport  from '../../../src/container/Viewport.mjs';
 
 /**
- * @class Neo.examples.dashboard.MainContainer
+ * @class Neo.examples.dashboard.base.MainContainer
  * @extends Neo.container.Viewport
  */
 class MainContainer extends Viewport {
     static config = {
-        className: 'Neo.examples.dashboard.MainContainer',
+        className: 'Neo.examples.dashboard.base.MainContainer',
         layout   : {ntype: 'fit'},
         style    : {padding: '10px'},
 

--- a/examples/dashboard/base/app.mjs
+++ b/examples/dashboard/base/app.mjs
@@ -2,5 +2,5 @@ import MainContainer from './MainContainer.mjs';
 
 export const onStart = () => Neo.app({
     mainView: MainContainer,
-    name    : 'Neo.examples.dashboard'
+    name    : 'Neo.examples.dashboard.base'
 });

--- a/examples/dashboard/base/index.html
+++ b/examples/dashboard/base/index.html
@@ -6,6 +6,6 @@
     <title>Neo Dashboard</title>
 </head>
 <body>
-    <script src="../../src/MicroLoader.mjs" type="module"></script>
+    <script src="../../../src/MicroLoader.mjs" type="module"></script>
 </body>
 </html>

--- a/examples/dashboard/base/neo-config.json
+++ b/examples/dashboard/base/neo-config.json
@@ -1,0 +1,6 @@
+{
+    "appPath"    : "examples/dashboard/base/app.mjs",
+    "basePath"   : "../../../",
+    "environment": "development",
+    "mainPath"   : "./Main.mjs"
+}

--- a/examples/dashboard/neo-config.json
+++ b/examples/dashboard/neo-config.json
@@ -1,6 +1,0 @@
-{
-    "appPath"    : "examples/dashboard/app.mjs",
-    "basePath"   : "../../",
-    "environment": "development",
-    "mainPath"   : "./Main.mjs"
-}


### PR DESCRIPTION
Resolves #17504

`examples/dashboard` stops being the tree's only hybrid leaf+parent: the legacy color-box demo moves to `examples/dashboard/base/` (the `examples/button/base` · `container/base` · `list/base` precedent, applied verbatim — folder, app name `Neo.examples.dashboard.base`, className, `basePath` depth), and `examples/dashboard/` becomes a pure parent of `base/` + `dock/` + `crossWindowWitness/` — the clean destination shape the `#16322` dockdemo arrivals land into as siblings. Four files moved via `git mv`, four content touches (loader path, app name, `neo-config.json` appPath/basePath, imports + className). A pre-move consumer sweep found ZERO external references to the root example's identity — the URL, app name, and className were self-referencing only.

Evidence: L2 achieved (live dev-server load receipts + spec runs below) → L2 sufficient (every AC is a load, census, or spec observable).

## Deltas from ticket

None substantive.

## Test Evidence

- **Dev-mode load receipt (AC-1):** `examples/dashboard/base/index.html` served by the dev server renders the dashboard (1 mounted container, the five styled boxes) with **zero console errors**.
- **Unchanged-URL control (AC-2):** `examples/dashboard/dock/index.html` loads healthy post-move (12 dock nodes rendered); the two e2e/core consumers of that URL run green: `RefreshDomCorpseRepro` + `DragSensorDispatch` → **8/8 passed** (48.9s).
- **Census (AC-4):** the hybrid leaf+parent walk over `examples/*/` returns **zero** — the class is extinct, not just the instance.
- **Registry/walker (AC-3):** the SEO generator enumerates examples from `index.html` presence, so `base/` enters its walk structurally; generated outputs stay pipeline-owned per `#14362` and are not committed here (the next pipeline run picks the new path up from the tree itself).

## Post-Merge Validation

None owed: the SEO/example listings regenerate downstream from the moved files' presence; `#16322`'s relocation lands its arrivals on this normalized shape.

Authored by Mnemosyne (Claude Fable 5, Claude Code). Session 55e55313-48fa-4295-83fd-37121a2bf4b6.
