### PR TITLE
fix(grid): a cleared pool row stops claiming its record in worker-side VDOM (#17536)

### DIFF
--- a/src/grid/Row.mjs
+++ b/src/grid/Row.mjs
@@ -319,21 +319,9 @@ class Row extends Component {
             cellConfig, column, columnPosition, i, isMounted, lastColumnIndex, oldCn, poolIndex, poolSize, pooledCells;
 
         if (!record) {
-            // The RECORD claim is dropped, not the whole `data` object. A pool slot holding no
-            // record must not keep CLAIMING one: worker-side inspection would otherwise observe
-            // `row.record === null` while `row.vdom.data.recordId` still names a record, which is
-            // two contradictory answers to the same question from one object.
-            //
-            // `rowId` stays: it identifies the POOL SLOT, which the row still is and which stays
-            // valid after the record is gone. Dropping the whole object also drops that, and costs
-            // an extra delta on a path whose delta count is a guarded contract.
-            //
-            // SCOPE, because the neighbouring line invites the wrong reading: this is a worker-side
-            // VDOM correction and it is NOT a repair for a painted duplicate. The `display: none`
-            // below is staged in this same object, so under `silent: true` both mutations reach the
-            // browser only through the caller's single trailing update — lose that, and neither one
-            // changes what is painted. Staged truth and painted truth are separate problems; this
-            // fixes the first.
+            // Only the record claim goes, never the `data` object: `rowId` identifies the pool
+            // SLOT, which the row still is once its record is gone, and pooled updates need it.
+            // Staged either way — under `silent`, nothing below reaches the browser from here.
             delete vdom.data?.recordId;
 
             vdom.style = {display: 'none'};

--- a/src/grid/Row.mjs
+++ b/src/grid/Row.mjs
@@ -319,6 +319,23 @@ class Row extends Component {
             cellConfig, column, columnPosition, i, isMounted, lastColumnIndex, oldCn, poolIndex, poolSize, pooledCells;
 
         if (!record) {
+            // The RECORD claim is dropped, not the whole `data` object. A pool slot holding no
+            // record must not keep CLAIMING one: worker-side inspection would otherwise observe
+            // `row.record === null` while `row.vdom.data.recordId` still names a record, which is
+            // two contradictory answers to the same question from one object.
+            //
+            // `rowId` stays: it identifies the POOL SLOT, which the row still is and which stays
+            // valid after the record is gone. Dropping the whole object also drops that, and costs
+            // an extra delta on a path whose delta count is a guarded contract.
+            //
+            // SCOPE, because the neighbouring line invites the wrong reading: this is a worker-side
+            // VDOM correction and it is NOT a repair for a painted duplicate. The `display: none`
+            // below is staged in this same object, so under `silent: true` both mutations reach the
+            // browser only through the caller's single trailing update — lose that, and neither one
+            // changes what is painted. Staged truth and painted truth are separate problems; this
+            // fixes the first.
+            delete vdom.data?.recordId;
+
             vdom.style = {display: 'none'};
             !silent && me.update();
             return

--- a/test/playwright/unit/grid/Pooling.spec.mjs
+++ b/test/playwright/unit/grid/Pooling.spec.mjs
@@ -374,14 +374,8 @@ test.describe('Grid Pooling & Fixed-DOM-Order', () => {
     });
 
     test('#17536: a cleared pool row stops CLAIMING the record it no longer holds', async () => {
-        // WORKER-SIDE truth, and the distinction is the whole ticket. The clear path leaves
-        // `vdom.data` untouched, so a slot whose `record` is null still names that record in its
-        // staged VDOM — one object answering the same question two contradictory ways.
-        //
-        // This arm does NOT assert anything about painted DOM, and an earlier version of it implied
-        // otherwise. `display: none` is staged in the same object under the same `silent: true`, so
-        // if the caller's trailing update is lost, neither mutation reaches the browser. Staged
-        // truth and painted truth are separate problems, and this covers only the first.
+        // Staged worker VDOM only. Nothing here asserts painted DOM, and this arm must not be
+        // reused as if it did: the clear path stages under `silent: true` and never flushes.
         const body = grid.body;
 
         store.filters = [{property: 'id', operator: '<', value: 2}];
@@ -389,8 +383,7 @@ test.describe('Grid Pooling & Fixed-DOM-Order', () => {
 
         const cleared = body.items.filter(row => !row.record);
 
-        // Non-vacuity. Filtering 1000 records down to 2 must leave most of the pool unused; without
-        // this the assertion below passes on an empty array and proves nothing.
+        // Non-vacuity: without this, every assertion below passes on an empty array.
         expect(cleared.length, 'the filter must actually strand pool slots').toBeGreaterThan(0);
 
         const stillClaiming = cleared
@@ -399,10 +392,8 @@ test.describe('Grid Pooling & Fixed-DOM-Order', () => {
 
         expect(stillClaiming, 'a row holding no record must not carry a recordId').toEqual([]);
 
-        // The other half, and the reason this deletes a KEY rather than the object: `rowId`
-        // identifies the pool SLOT, which the row still is after its record is gone. A fix that
-        // dropped `data` wholesale would satisfy the assertion above while erasing the slot identity
-        // every pooled update depends on — and would cost an extra delta on a guarded path.
+        // Catches the wrong fix that still satisfies the assertion above: dropping `data` wholesale
+        // erases the pool-slot identity, which survives the record.
         const lostSlotIdentity = cleared
             .filter(row => row.vdom?.data?.rowId === undefined)
             .map(row => row.id);
@@ -413,9 +404,7 @@ test.describe('Grid Pooling & Fixed-DOM-Order', () => {
     });
 
     test('#17536: CONTROL — a row that still holds a record keeps claiming it', async () => {
-        // The half that keeps the assertion above honest. A fix that cleared `vdom.data`
-        // unconditionally would satisfy it while erasing the identity every live row depends on,
-        // and every DOM-reading consumer downstream reads exactly this attribute.
+        // Catches a fix that cleared identity unconditionally: live rows keep the claim.
         const body = grid.body;
 
         store.filters = [{property: 'id', operator: '<', value: 2}];

--- a/test/playwright/unit/grid/Pooling.spec.mjs
+++ b/test/playwright/unit/grid/Pooling.spec.mjs
@@ -372,4 +372,62 @@ test.describe('Grid Pooling & Fixed-DOM-Order', () => {
         const structureChanges = deltas.filter(d => ['moveNode', 'insertNode', 'removeNode'].includes(d.action));
         expect(structureChanges.length).toBe(0);
     });
+
+    test('#17536: a cleared pool row stops CLAIMING the record it no longer holds', async () => {
+        // WORKER-SIDE truth, and the distinction is the whole ticket. The clear path leaves
+        // `vdom.data` untouched, so a slot whose `record` is null still names that record in its
+        // staged VDOM — one object answering the same question two contradictory ways.
+        //
+        // This arm does NOT assert anything about painted DOM, and an earlier version of it implied
+        // otherwise. `display: none` is staged in the same object under the same `silent: true`, so
+        // if the caller's trailing update is lost, neither mutation reaches the browser. Staged
+        // truth and painted truth are separate problems, and this covers only the first.
+        const body = grid.body;
+
+        store.filters = [{property: 'id', operator: '<', value: 2}];
+        await grid.timeout(50);
+
+        const cleared = body.items.filter(row => !row.record);
+
+        // Non-vacuity. Filtering 1000 records down to 2 must leave most of the pool unused; without
+        // this the assertion below passes on an empty array and proves nothing.
+        expect(cleared.length, 'the filter must actually strand pool slots').toBeGreaterThan(0);
+
+        const stillClaiming = cleared
+            .filter(row => row.vdom?.data?.recordId !== undefined && row.vdom?.data?.recordId !== null)
+            .map(row => ({id: row.id, recordId: row.vdom.data.recordId}));
+
+        expect(stillClaiming, 'a row holding no record must not carry a recordId').toEqual([]);
+
+        // The other half, and the reason this deletes a KEY rather than the object: `rowId`
+        // identifies the pool SLOT, which the row still is after its record is gone. A fix that
+        // dropped `data` wholesale would satisfy the assertion above while erasing the slot identity
+        // every pooled update depends on — and would cost an extra delta on a guarded path.
+        const lostSlotIdentity = cleared
+            .filter(row => row.vdom?.data?.rowId === undefined)
+            .map(row => row.id);
+
+        expect(lostSlotIdentity, 'a cleared row keeps its pool-slot identity').toEqual([]);
+        expect(cleared.every(row => row.vdom?.data && typeof row.vdom.data === 'object'),
+            'the data object survives; only the record claim is removed').toBe(true);
+    });
+
+    test('#17536: CONTROL — a row that still holds a record keeps claiming it', async () => {
+        // The half that keeps the assertion above honest. A fix that cleared `vdom.data`
+        // unconditionally would satisfy it while erasing the identity every live row depends on,
+        // and every DOM-reading consumer downstream reads exactly this attribute.
+        const body = grid.body;
+
+        store.filters = [{property: 'id', operator: '<', value: 2}];
+        await grid.timeout(50);
+
+        const live = body.items.filter(row => row.record);
+
+        expect(live.length, 'two records survive the filter').toBeGreaterThan(0);
+
+        for (const row of live) {
+            expect(row.vdom?.data?.recordId, `live row ${row.id} keeps its identity`)
+                .toBe(body.getRecordId(row.record))
+        }
+    });
 });


### PR DESCRIPTION
Resolves #17536

Retargeted from #17427. A pooled row whose worker-side `record` is `null` kept `data.recordId` from the record that previously occupied the slot, so one object answered the same question two contradictory ways: `row.record === null` while `row.vdom.data.recordId` still names a record.

Evidence: L2 required → **L2 achieved, no residual** (the arm fails on `dev` listing 12 cleared rows still claiming `neo-record-*` ids and passes here; two control arms; grid 67/67).

## Deltas from ticket

**The scope of this PR changed under review, and the correction is the most important thing in it.** I originally claimed that clearing the record claim *"makes the surviving failure an unidentified leftover rather than a second copy of a live record."* @neo-gpt-emmy showed that is false on exactly the path I built the argument around: the `delete` and the `display: none` are staged in the **same** vdom object and reach the browser only through `Body#createViewData`'s single trailing update. Lose that flush and neither arrives — the painted DOM is byte-identical to before this diff. Mechanism and my retraction: [comment IC_kwDODSospM8AAAABQHz7UA](https://github.com/neomjs/neo/pull/17523#issuecomment-5376899920).

So the change is real, and its scope is **worker-side VDOM identity**, not painted truth. #17536 owns that invariant. **#17427 stays open** for the flush/delivery defect, which is the one the downstream duplicate actually needs.

**Second delta, @tobiu-raised at `f18543a9f2`:** the source carried **three comment blocks over one `delete`**. They were not three thoughts — they were three review rounds, each appended as it closed: the ticket's problem statement, the answer to RA-2, and the retraction above. All three were already published in #17536 or on this PR. A source comment addresses the next maintainer, who saw none of those rounds, so the file had become a reply to a reader who had left. Trimmed at `a449a95cc2`: **32 added comment lines → 9**, assertions and messages untouched.

## AC Evidence

| AC | Proof |
|---|---|
| AC-1 | RED/GREEN: the `stillClaiming` arm fails on `dev`, listing 12 cleared rows still holding `neo-record-*` ids; green at `a449a95cc2`. |
| AC-2 | `stillClaiming` asserts `[]` across every `record === null` row, behind a non-vacuity guard that proves the filter actually stranded pool slots. |
| AC-3 | CONTROL arm: for every surviving row, `vdom.data.recordId === body.getRecordId(row.record)`. |
| AC-4 | `lostSlotIdentity` asserts `[]` and `data` is still an object. Mutation-verified: `delete vdom.data` reddens this while AC-2 still passes — i.e. it catches the wrong fix. |
| AC-5 | `Teleportation.spec.mjs` delta-count arms green inside grid 67/67; deleting a key adds no delta to the guarded path. |
| AC-6 | Source comment, spec header comment, commit subject (`…in worker-side VDOM`), and this body all say staged worker VDOM and disclaim painted DOM. |

## Test Evidence

Red-proofed on `dev`: 12 cleared rows still carrying `neo-record-*` ids; green here.

**Two controls, each pinning a different way to get this wrong:**

| control | what it catches |
|---|---|
| a row that still holds a record keeps claiming it | a fix that cleared identity unconditionally |
| a cleared row keeps `data.rowId` and its `data` object | a fix that dropped `data` wholesale (RA-2) |

The second is why this deletes a **key** rather than the object: `rowId` identifies the pool **slot**, which the row still is after its record is gone. **Mutation-verified** — `delete vdom.data` reddens the slot-identity assertion while the `recordId` one still passes, i.e. exactly the fix that would have satisfied the original arm alone. It also costs an extra delta on a path whose delta count is a guarded contract (`Teleportation.spec.mjs`).

The **non-vacuity guard** earned its place: my first revision used the wrong filter API, stranded no pool slots, and the guard failed rather than letting a vacuous green through.

Measured at `a449a95cc2`, each count with the command that produced it:

```
npm run test-unit -- test/playwright/unit/grid   67/67
npm run test-unit                                14533 passed, 11 skipped   exit 0
node buildScripts/util/check-ticket-archaeology.mjs --base origin/dev   0 violations   exit 0
node buildScripts/util/check-spec-retirement.mjs                                       exit 0
node ai/scripts/agent-preflight.mjs --pr-body … --pr-base origin/dev     all gates      exit 0
```

Both lints were run **bare**, not behind a pipe: a lint behind `| tail -1` reports tail's exit status, which is how a red on this very PR once read green.

## Post-Merge Validation

Worker-plane only: after this, `row.record === null` and `row.vdom.data.recordId === undefined` agree. **Do not expect the downstream duplicated-projection red to stop** — that is a painted-DOM symptom and it belongs to #17427.

## Out of Scope

- The flush/delivery defect (#17427), which needs the bound derived rather than widened.
- Any painted-DOM claim. The permanent test asserts staged truth and says so.

## Evolution

**Third time today a claim of mine outlived the mechanism it described**, and Emmy caught two. The tell is identical each time: the code does something real, so the sentence about what it *buys* goes unchecked. A diff can be correct and its justification false, and that second failure is invisible from the author's seat.

The comment bloat is the same failure wearing a different costume. Answering a reviewer **in the source file** feels like diligence, but it writes a rebuttal into a permanent artifact whose only reader is someone who never saw the objection. The signal was already mechanical and I misread it: `check-ticket-archaeology` flagged **four** comment lines where I had written two, and I fixed the *duplication* it named while ignoring the *volume* it was measuring. A gate's count is a claim about what you wrote.

Authored by Ada (Claude Opus 5, Claude Code).
