### PR TITLE
Both apps re-declare the dock rail tab's structural paint

### DIFF
--- a/resources/scss/src/apps/agentos/fleet/FleetCockpit.scss
+++ b/resources/scss/src/apps/agentos/fleet/FleetCockpit.scss
@@ -33,8 +33,11 @@
        role on top: mono, tracking, case. One navigation family across both edges. */
     /* Values, not paint. The structural declarations that used to sit here — transparent ground,
        no border, no shadow, min-width release, and the glyph/text inherit fix — are engine
-       capability and now live in `src/dashboard/Container.scss` (#17522). The load-order tie this
-       comment warned about is gone with them: setting token VALUES leaves no competing selector.
+       capability and now live in `src/dashboard/Container.scss` (#17522). Two ties died there,
+       and for different reasons: the app-vs-engine one because setting token VALUES leaves no
+       competing selector, and the engine-vs-theme `min-width` one because the engine rule now
+       carries a leading `:root` and outranks the generic button skin outright. Only the second
+       kept this rail off the empty-pill regression, so it is the one worth remembering.
        The quiet rail keeps its navigation read — a hover affordance in the same idiom as the bar
        buttons (panel lift + ink), never a primary slab. */
     .neo-dashboard-dock-rail-tab.neo-button {

--- a/resources/scss/src/apps/agentos/fleet/FleetCockpit.scss
+++ b/resources/scss/src/apps/agentos/fleet/FleetCockpit.scss
@@ -31,34 +31,24 @@
        §04 chrome tier (#17269 cut 2, AC-3): the rotated tabs speak the same chrome voice as the
        keeper rail — the engine owns the 11px/1 metric floor (src/dashboard), the app speaks the
        role on top: mono, tracking, case. One navigation family across both edges. */
+    /* Values, not paint. The structural declarations that used to sit here — transparent ground,
+       no border, no shadow, min-width release, and the glyph/text inherit fix — are engine
+       capability and now live in `src/dashboard/Container.scss` (#17522). The load-order tie this
+       comment warned about is gone with them: setting token VALUES leaves no competing selector.
+       The quiet rail keeps its navigation read — a hover affordance in the same idiom as the bar
+       buttons (panel lift + ink), never a primary slab. */
     .neo-dashboard-dock-rail-tab.neo-button {
-        background: transparent;
-        border    : 0;
-        box-shadow: none;
-        color     : var(--fm-ink-dim);
-        min-width : 0;
-        transition: background var(--fm-motion-fast) var(--ease-out-soft), color var(--fm-motion-fast) var(--ease-out-soft);
+        --dock-rail-tab-background-hover: var(--fm-panel);
+        --dock-rail-tab-color           : var(--fm-ink-dim);
+        --dock-rail-tab-color-hover     : var(--fm-ink);
+        --dock-transition-duration-fast : var(--fm-motion-fast);
 
-        /* voice only — the engine floor (src/dashboard, equal specificity) already owns the
-           11px/1 metrics AT the chrome role's values; re-declaring size here would be a
-           load-order tie, and "equal-specificity load-order ties are not a contract". The
-           full role consumption moves engine-side with #17241's rail-anatomy lift. */
+        /* Voice stays app-side: mono, tracking and case are the FM chrome role, not dock
+           capability. The engine owns the 11px/1 metric floor; this speaks the role on top. */
         .neo-button-text {
             font-family   : var(--fm-font-mono);
             letter-spacing: var(--fm-text-chrome-tracking);
             text-transform: uppercase;
-        }
-
-        /* the quiet rail keeps its navigation read — a hover affordance in the same idiom as the
-           bar buttons (panel lift + ink), never the primary blue slab */
-        &:hover {
-            background: var(--fm-panel);
-            color     : var(--fm-ink);
-        }
-
-        .neo-button-glyph,
-        .neo-button-text {
-            color: inherit;
         }
     }
 

--- a/resources/scss/src/apps/workstation/Workspace.scss
+++ b/resources/scss/src/apps/workstation/Workspace.scss
@@ -67,12 +67,12 @@
         // through `:root .neo-theme-* .neo-button` — a (0,3,0) selector that TIES the shared rail
         // override and wins on load order alone. On the 14px vertical rail that floor defeats the
         // cross-axis stretch and pushes the rotated label span outside the clipped strip: the rail
-        // renders as an empty pill. The `.neo-button` compound lifts this layer to (0,4,0) so the
-        // tie stops being a load-order bet; with the floor released, the tab snaps to the strip and
-        // the label renders inside it.
-        // Values only: the structural paint and the glyph/text inherit fix are engine capability
-        // and live in `src/dashboard/Container.scss`. Re-declaring them here is what put an
-        // app-layer rule in an equal-specificity tie with the engine's.
+        // renders as an empty pill. This app used to release that floor itself with its own
+        // (0,4,0) `min-width: 0`; the engine now outranks the theme directly, so the release is
+        // engine capability and no consumer needs a local escape hatch to get a working rail.
+        // Values only: the structural paint and the glyph/text inherit fix live in
+        // `src/dashboard/Container.scss`. Re-declaring them here is what put an app-layer rule in
+        // an equal-specificity tie with the engine's.
         .neo-button.neo-dashboard-dock-rail-tab {
             --dock-rail-tab-background-hover: color-mix(in srgb, var(--workstation-signal) 14%, transparent);
             --dock-rail-tab-color           : var(--workstation-ink-dim);

--- a/resources/scss/src/apps/workstation/Workspace.scss
+++ b/resources/scss/src/apps/workstation/Workspace.scss
@@ -70,29 +70,14 @@
         // renders as an empty pill. The `.neo-button` compound lifts this layer to (0,4,0) so the
         // tie stops being a load-order bet; with the floor released, the tab snaps to the strip and
         // the label renders inside it.
+        // Values only: the structural paint and the glyph/text inherit fix are engine capability
+        // and live in `src/dashboard/Container.scss`. Re-declaring them here is what put an
+        // app-layer rule in an equal-specificity tie with the engine's.
         .neo-button.neo-dashboard-dock-rail-tab {
-            background: transparent;
-            border    : 0;
-            box-shadow: none;
-            color     : var(--workstation-ink-dim);
-            font-family: var(--workstation-font-mono);
-            min-width : 0;
-            transition: background var(--dock-transition-duration-fast) var(--dock-transition-easing),
-                        color var(--dock-transition-duration-fast) var(--dock-transition-easing);
-
-            &:hover {
-                background: color-mix(in srgb, var(--workstation-signal) 14%, transparent);
-                color     : var(--workstation-ink);
-            }
-
-            // The generic button skin re-colors these descendants through its own token layer,
-            // which resolves anti-theme against the workstation palette (black on the dark rail,
-            // white on the light one — inverted contrast in both themes). Inheriting pins them to
-            // the rail-tab ink above; same treatment the tourbar theme-button already needed.
-            .neo-button-glyph,
-            .neo-button-text {
-                color: inherit;
-            }
+            --dock-rail-tab-background-hover: color-mix(in srgb, var(--workstation-signal) 14%, transparent);
+            --dock-rail-tab-color           : var(--workstation-ink-dim);
+            --dock-rail-tab-color-hover     : var(--workstation-ink);
+            --dock-rail-tab-font-family     : var(--workstation-font-mono);
         }
     }
 

--- a/resources/scss/src/dashboard/Container.scss
+++ b/resources/scss/src/dashboard/Container.scss
@@ -56,6 +56,17 @@
     --dock-splitter-ring-hover       : none;
     --dock-splitter-ring-active      : none;
     --dock-splitter-handle-glow-hover: none;
+
+    // Rail-tab paint. Neutral by design: a consumer skins the affordance by overriding these,
+    // never by re-declaring the rule — the discipline the Body-side dock guide states for every
+    // engine surface. `inherit` rather than a palette value is what keeps the default legible in
+    // a host whose ink the engine cannot know; `transparent` is the resting state because a rail
+    // tab is navigation, not an action, and must not arrive wearing the generic button's slab.
+    --dock-rail-tab-background      : transparent;
+    --dock-rail-tab-background-hover: transparent;
+    --dock-rail-tab-color           : inherit;
+    --dock-rail-tab-color-hover     : inherit;
+    --dock-rail-tab-font-family     : inherit;
 }
 
 @media (prefers-reduced-motion: reduce) {
@@ -291,11 +302,37 @@
 // padding) and fill the strip edge-to-edge on the cross axis — the generic button token contract
 // and the consumer's inherited text metrics do not own this anatomy.
 // Equal-specificity load-order ties are not a contract.
+// The paint below arrived here from two app stylesheets that had each discovered the same fix
+// independently: stopping the generic `.neo-button` skin from painting a navigation rail as an
+// action. That is engine capability work, not app identity, so it lands at the same 0,3,0 scope
+// as the anatomy and reads tokens for the four values that genuinely differ per consumer.
+// Promoting it also removes an equal-specificity tie — an app that sets token VALUES has no
+// competing selector left, so the load-order hazard named above stops applying to this rule.
 .neo-dashboard .neo-button.neo-dashboard-dock-rail-tab {
-    height   : auto;
-    margin   : 0;
-    min-width: 0;
-    padding  : 4px 1px;
+    background : var(--dock-rail-tab-background);
+    border     : 0;
+    box-shadow : none;
+    color      : var(--dock-rail-tab-color);
+    font-family: var(--dock-rail-tab-font-family);
+    height     : auto;
+    margin     : 0;
+    min-width  : 0;
+    padding    : 4px 1px;
+    transition : background var(--dock-transition-duration-fast) var(--dock-transition-easing),
+                 color var(--dock-transition-duration-fast) var(--dock-transition-easing);
+
+    &:hover {
+        background: var(--dock-rail-tab-background-hover);
+        color     : var(--dock-rail-tab-color-hover);
+    }
+
+    // The generic button skin re-colors these descendants through its own token layer, which
+    // resolves anti-theme against a consumer palette — black on a dark rail, white on a light one,
+    // inverted contrast in both. Inheriting pins them to the rail-tab ink above.
+    .neo-button-glyph,
+    .neo-button-text {
+        color: inherit;
+    }
 
     .neo-button-text {
         font-size  : 11px;

--- a/resources/scss/src/dashboard/Container.scss
+++ b/resources/scss/src/dashboard/Container.scss
@@ -291,9 +291,10 @@
     }
 }
 
-// Scoped to 0,3,0 (tab) and 0,4,0 (label) on purpose: the neo themes pin `.neo-button` to a fixed
-// physical `height: var(--button-height)` (= 48px) and `min-width: var(--cmp-button-height)`
-// (0,2,0), which clamps a vertical rail tab to a 48px hit box (68-99px labels overflow and
+// Scoped to 0,4,0 (tab) and 0,5,0 (label) on purpose: the neo themes pin `.neo-button` to a fixed
+// physical `height: var(--button-height)` (= 48px, at 0,1,0) and to
+// `min-width: var(--cmp-button-height)` through `:root .neo-theme-* .neo-button` — a 0,3,0
+// selector. That floor clamps a vertical rail tab to a 48px hit box (68-99px labels overflow and
 // overlap their neighbors) and defeats the 14px cross-axis stretch on every edge; the generic
 // button margin and padding (0,1,0 source-order tie the rail always lost) shrink or inflate the
 // strip anatomy, and the label span carries its own token'd font-size/line-height — consumer
@@ -304,11 +305,19 @@
 // Equal-specificity load-order ties are not a contract.
 // The paint below arrived here from two app stylesheets that had each discovered the same fix
 // independently: stopping the generic `.neo-button` skin from painting a navigation rail as an
-// action. That is engine capability work, not app identity, so it lands at the same 0,3,0 scope
-// as the anatomy and reads tokens for the four values that genuinely differ per consumer.
-// Promoting it also removes an equal-specificity tie — an app that sets token VALUES has no
-// competing selector left, so the load-order hazard named above stops applying to this rule.
-.neo-dashboard .neo-button.neo-dashboard-dock-rail-tab {
+// action. That is engine capability work, not app identity, so it reads tokens for the values
+// that genuinely differ per consumer.
+//
+// The leading `:root` is load-bearing, not decoration. Without it this rule sits at 0,3,0 —
+// exactly tied with the theme's `min-width` floor — and the winner is whichever stylesheet
+// loads last, which Neo emits per source file and does not pin. Both apps had independently
+// found that tie and each carried its own higher-specificity `min-width: 0` to escape it, so
+// promoting the paint here WITHOUT also outranking the theme would have deleted two working
+// escape hatches and handed every consumer the empty-pill regression those rules existed to
+// prevent. `:root` is the theme's own idiom for a baseline layer; the engine states the same
+// thing one level up — dock anatomy outranks the generic button skin for a component the dock
+// owns. `dockRailTabLayering.spec.mjs` compiles this file and fails if the margin is ever lost.
+:root .neo-dashboard .neo-button.neo-dashboard-dock-rail-tab {
     background : var(--dock-rail-tab-background);
     border     : 0;
     box-shadow : none;

--- a/test/playwright/component/apps/dock-rail/app.mjs
+++ b/test/playwright/component/apps/dock-rail/app.mjs
@@ -1,0 +1,21 @@
+import Viewport from '../../../../../src/container/Viewport.mjs';
+
+/**
+ * A viewport pinned to the NEO themes.
+ *
+ * `empty-viewport` inherits `DefaultConfig.themes`, which is
+ * `['neo-theme-light', 'neo-theme-dark', 'neo-theme-neo-light']` — the legacy pair plus one neo
+ * theme. The rail-tab regression under test lives in the neo themes' generic button floor
+ * (`:root .neo-theme-neo-* .neo-button { min-width: var(--cmp-button-height) }`), which the legacy
+ * themes do not carry, so a witness running there measures a document where the competing rule was
+ * never loaded and reports a comfortable green.
+ *
+ * @see test/playwright/component/dashboard/DockRailTabPaint.spec.mjs
+ */
+export const onStart = () => Neo.app({
+    mainView: {
+        module: Viewport,
+        id    : 'dock-rail-test-viewport'
+    },
+    name: 'DockRailTestApp'
+});

--- a/test/playwright/component/apps/dock-rail/index.html
+++ b/test/playwright/component/apps/dock-rail/index.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Neo.mjs Component Test App</title>
+</head>
+<body>
+    <script src="../../../../../src/MicroLoader.mjs" type="module"></script>
+</body>
+</html>

--- a/test/playwright/component/apps/dock-rail/neo-config.json
+++ b/test/playwright/component/apps/dock-rail/neo-config.json
@@ -1,0 +1,7 @@
+{
+    "appPath"    : "test/playwright/component/apps/dock-rail/app.mjs",
+    "basePath"   : "../../../../../",
+    "environment": "development",
+    "mainPath"   : "./Main.mjs",
+    "themes"     : ["neo-theme-neo-dark", "neo-theme-neo-light"]
+}

--- a/test/playwright/component/dashboard/DockRailTabPaint.spec.mjs
+++ b/test/playwright/component/dashboard/DockRailTabPaint.spec.mjs
@@ -1,0 +1,181 @@
+import {test, expect} from '@playwright/test';
+
+/**
+ * The rail tab's paint, measured on a rendered tab rather than on stylesheet text.
+ *
+ * The sibling `dockRailTabLayering.spec.mjs` proves the engine rule OUTRANKS the theme's generic
+ * `.neo-button` floor by comparing compiled selectors. That is the cascade question. This file
+ * answers the one a compiled comparison cannot: what a browser actually computes once the theme
+ * variables resolve.
+ *
+ * The regression it exists for is concrete. The neo themes floor every `.neo-button` at
+ * `min-width: var(--cmp-button-height)` (48px). On a 14px vertical rail that floor pushes the
+ * rotated label outside the clipped strip and the tab renders as an empty pill. Both consuming
+ * apps had been carrying their own higher-specificity `min-width: 0` to escape it; the engine now
+ * owns that release, so nothing app-side is left to prove it still works.
+ *
+ * **The control is the point.** `min-width: 0px` on a rail tab only means the engine won if the
+ * 48px floor was actually live in the same document — otherwise a theme stylesheet that simply
+ * failed to load reads as a pass. Every arm therefore measures a plain sibling button first and
+ * requires it to be AT the floor.
+ *
+ * @see https://github.com/neomjs/neo/issues/17522
+ */
+
+const THEMES = ['neo-theme-neo-dark', 'neo-theme-neo-light'];
+
+let dashboardId, railId;
+
+test.beforeEach(async ({page}) => {
+    await page.goto('test/playwright/component/apps/dock-rail/index.html');
+    await page.waitForSelector('#dock-rail-test-viewport', {state: 'attached'});
+
+    const ids = await page.evaluate(async () => {
+        // The REAL dashboard container, not a plain one wearing `.neo-dashboard`. Neo loads a
+        // class's stylesheet when the class is instantiated, so faking the ancestor class leaves
+        // `src/dashboard/Container.css` — the file that carries the rule under test — out of the
+        // document entirely, and every arm below then measures the generic button skin.
+        const dashboard = await Neo.worker.App.createNeoInstance({
+            importPath: '../dashboard/Container.mjs',
+            // `createNeoInstance` imports the module but resolves the class through the ntype
+            // registry — a config without one reaches `parent.add()` with nothing to construct.
+            ntype   : 'dashboard',
+            parentId: 'dock-rail-test-viewport'
+        });
+
+        if (!dashboard.success) throw new Error(`dashboard: ${dashboard.error.message}`);
+
+        const rail = await Neo.worker.App.createNeoInstance({
+            importPath: '../dashboard/DockRail.mjs',
+            ntype     : 'dashboard-dock-rail',
+            edge      : 'left',
+            parentId  : dashboard.id,
+            railItems : [
+                {dockEdge: 'left', dockItemId: 'alpha', restorable: true, title: 'Alpha'},
+                {dockEdge: 'left', dockItemId: 'beta',  restorable: true, title: 'Beta'}
+            ]
+        });
+
+        if (!rail.success) throw new Error(`rail: ${rail.error.message}`);
+
+        return {dashboardId: dashboard.id, railId: rail.id}
+    });
+
+    ({dashboardId, railId} = ids);
+
+    await page.waitForSelector('.neo-dashboard-dock-rail-tab', {state: 'attached'})
+});
+
+test.afterEach(async ({page}) => {
+    await page.evaluate(async ids => {
+        for (const id of ids) id && await Neo.worker.App.destroyNeoInstance(id)
+    }, [railId, dashboardId])
+});
+
+/** Swap the active theme class on the document element and read back what took effect. */
+const applyTheme = (page, theme) => page.evaluate(name => {
+    for (const el of [document.body, document.documentElement]) {
+        el.classList.forEach(c => c.startsWith('neo-theme-') && el.classList.remove(c))
+    }
+
+    document.body.classList.add(name);
+
+    return document.body.className
+}, theme);
+
+test.describe('Neo.dashboard.DockRail — rendered rail-tab paint', () => {
+    for (const theme of THEMES) {
+        test(`the engine's min-width release survives the ${theme} button floor`, async ({page}) => {
+            await applyTheme(page, theme);
+
+            const measured = await page.evaluate(() => {
+                const tab = document.querySelector('.neo-dashboard-dock-rail-tab');
+
+                // A plain button OUTSIDE the dashboard: same theme, same document, but no engine
+                // rule reaching it. This is the control that makes the tab's value meaningful.
+                const control = document.createElement('button');
+
+                control.className = 'neo-button';
+                document.body.appendChild(control);
+
+                const result = {
+                    tabMinWidth    : getComputedStyle(tab).minWidth,
+                    controlMinWidth: getComputedStyle(control).minWidth,
+                    tabFound       : Boolean(tab)
+                };
+
+                control.remove();
+
+                return result
+            });
+
+            expect(measured.tabFound, 'a rail tab must be rendered').toBe(true);
+
+            // Control first: if the floor is not live, nothing below proves anything.
+            expect(measured.controlMinWidth,
+                `${theme} must actually floor a plain button — otherwise this arm is vacuous`)
+                .not.toBe('0px');
+            expect(parseFloat(measured.controlMinWidth),
+                'the floor is the 48px button height').toBeGreaterThan(24);
+
+            // The measurement.
+            expect(measured.tabMinWidth,
+                'the engine rule must beat the theme floor on a rendered tab').toBe('0px')
+        })
+    }
+
+    test('an app token value reaches the tab, and only the subtree that sets it', async ({page}) => {
+        await applyTheme(page, 'neo-theme-neo-dark');
+
+        // Two rails in two subtrees, and a rule shaped exactly the way a consuming app writes one:
+        // the token lands on the TAB's own selector under an app-root class, which is what
+        // `Workspace.scss` and `FleetCockpit.scss` both do. Setting the property on an ancestor
+        // instead would test a mechanism no app uses — and does not even work, because the engine
+        // re-declares the token defaults on every `.neo-dashboard`, including nested projected
+        // zones, so an outer value is shadowed before it reaches the tab.
+        const measured = await page.evaluate(async () => {
+            const dashboard = document.querySelector('.neo-dashboard'),
+                  sibling   = dashboard.cloneNode(true),
+                  style     = document.createElement('style'),
+                  freeze    = document.createElement('style');
+
+            // The engine rule TRANSITIONS `color`. Reading straight after the class flip returns
+            // the start value, and reading a frame later returns a blend — measured at
+            // rgb(244, 172, 171) on the way to red. Both are green-looking wrong answers, and a
+            // fixed sleep would only make the flake slower, so the transition is switched off for
+            // the measurement instead.
+            freeze.textContent = '* { transition: none !important }';
+            document.head.appendChild(freeze);
+
+            sibling.id = 'sibling-dashboard';
+            dashboard.parentElement.appendChild(sibling);
+
+            const read = () => ({
+                scoped : getComputedStyle(dashboard.querySelector('.neo-dashboard-dock-rail-tab')).color,
+                sibling: getComputedStyle(sibling.querySelector('.neo-dashboard-dock-rail-tab')).color
+            });
+
+            const before = read();
+
+            style.textContent =
+                '.test-app-a .neo-button.neo-dashboard-dock-rail-tab { --dock-rail-tab-color: rgb(255, 0, 0) }';
+            document.head.appendChild(style);
+            dashboard.classList.add('test-app-a');
+
+            const after = read();
+
+            style.remove();
+            freeze.remove();
+            sibling.remove();
+
+            return {before, after}
+        });
+
+        expect(measured.after.scoped, 'the token must reach the tab that sets it')
+            .toBe('rgb(255, 0, 0)');
+        expect(measured.after.sibling, 'and must not leak into a sibling subtree')
+            .toBe(measured.before.sibling);
+        expect(measured.before.scoped, 'the change must be observable — equal before/after proves nothing')
+            .not.toBe(measured.after.scoped)
+    })
+});

--- a/test/playwright/component/dashboard/DockRailTabPaint.spec.mjs
+++ b/test/playwright/component/dashboard/DockRailTabPaint.spec.mjs
@@ -178,4 +178,210 @@ test.describe('Neo.dashboard.DockRail — rendered rail-tab paint', () => {
         expect(measured.before.scoped, 'the change must be observable — equal before/after proves nothing')
             .not.toBe(measured.after.scoped)
     })
+
+    /**
+     * The two real consuming apps, loaded as the COMPILED stylesheets they ship as.
+     *
+     * The synthetic `.test-app-a` arm above proves the engine's token PLUMBING works. It cannot
+     * prove either app's own rule reaches it, because a rule authored in a spec is a rule nobody
+     * ships. These link `dist/**\/css/**` — the same artifacts Neo loads at runtime — plus the
+     * theme-scoped token layer the app's values reference, because `--workstation-signal` and
+     * `--fm-ink-dim` are declared under `:root .neo-theme-neo-*` and NOT in the app stylesheet.
+     * Loading the rule alone leaves every `var()` an invalid substitution and the tab quietly
+     * computes the engine default while the arm reports on the app.
+     */
+    const APP_IDENTITIES = [{
+        inkHover  : '--workstation-ink',
+        inkResting: '--workstation-ink-dim',
+        name      : 'workstation',
+        // Only workstation declares `--dock-rail-tab-font-family`; FM leaves the engine's
+        // `inherit` in place, and that difference is itself a value meant to stay unchanged.
+        ownsVoice: true,
+        rootCls  : 'workstation-workspace',
+        rule     : '/dist/development/css/src/apps/workstation/Workspace.css',
+        tokens   : theme => `/dist/development/css/${theme.replace('neo-theme-', 'theme-')}/apps/workstation/Viewport.css`
+    }, {
+        inkHover  : '--fm-ink',
+        inkResting: '--fm-ink-dim',
+        name      : 'FM',
+        ownsVoice : false,
+        rootCls   : 'fm-fleet-cockpit',
+        rule      : '/dist/development/css/src/apps/agentos/fleet/FleetCockpit.css',
+        tokens    : theme => `/dist/development/css/${theme.replace('neo-theme-', 'theme-')}/apps/agentos/Viewport.css`
+    }];
+
+    /** Links stylesheets into the document, rejecting loudly when one is missing. */
+    const loadStylesheets = (page, hrefs) => page.evaluate(async hrefs => {
+        // The engine rule TRANSITIONS `color`. Reading straight after a hover returns the start
+        // value and a frame later returns a blend — both green-looking wrong answers, and a fixed
+        // sleep would only make the flake slower.
+        const freeze = document.createElement('style');
+
+        freeze.textContent = '*, *::after, *::before { transition: none !important }';
+        document.head.appendChild(freeze);
+
+        for (const href of hrefs) {
+            const link = document.createElement('link');
+
+            link.rel  = 'stylesheet';
+            link.href = href;
+
+            // A missing artifact must be a loud red. Skipping it silently would leave the app's
+            // tokens undefined, and the arm would then measure the ENGINE floor under the app's name.
+            await new Promise((resolve, reject) => {
+                link.onload  = resolve;
+                link.onerror = () => reject(new Error(`stylesheet did not load: ${href}`));
+                document.head.appendChild(link)
+            })
+        }
+    }, hrefs);
+
+    /** The five properties the close target names, resting and hovered. */
+    const readTabPaint = (page, selector, tokens = []) => page.evaluate(({sel, tokens}) => {
+        const tab   = document.querySelector(sel),
+              style = getComputedStyle(tab);
+
+        /**
+         * The browser's own serialisation of a colour, so a comparison is apples-to-apples.
+         *
+         * A custom property comes back verbatim (`#8b97a8`) while `color` comes back serialised
+         * (`rgb(139, 151, 168)`). String-comparing those two reports a parity FAILURE on identical
+         * colours — a false red as misleading as a false green.
+         */
+        const resolveColor = value => {
+            if (!value) return '';
+
+            const probe = document.createElement('div');
+
+            probe.style.color = value;
+            document.body.appendChild(probe);
+
+            const resolved = getComputedStyle(probe).color;
+
+            probe.remove();
+
+            return resolved
+        };
+
+        return {
+            background: style.backgroundColor,
+            border    : `${style.borderTopWidth} ${style.borderTopStyle} ${style.borderTopColor}`,
+            boxShadow : style.boxShadow,
+            color     : style.color,
+            fontFamily: style.fontFamily,
+            resolved  : Object.fromEntries(tokens.map(name =>
+                [name, resolveColor(style.getPropertyValue(name).trim())]))
+        }
+    }, {sel: selector, tokens});
+
+    for (const identity of APP_IDENTITIES) {
+        for (const theme of THEMES) {
+            test(`${identity.name} rail-tab paint, resting and hovered — ${theme}`, async ({page}) => {
+                await applyTheme(page, theme);
+                await loadStylesheets(page, [identity.tokens(theme), identity.rule]);
+                await page.evaluate(cls => document.querySelector('.neo-dashboard').classList.add(cls),
+                    identity.rootCls);
+
+                const tab = page.locator('.neo-dashboard-dock-rail-tab').first();
+
+                await page.mouse.move(0, 0);
+
+                const
+                    inkTokens = [identity.inkResting, identity.inkHover],
+                    resting   = await readTabPaint(page, '.neo-dashboard-dock-rail-tab', inkTokens);
+
+                await tab.hover();
+
+                const hovered = await readTabPaint(page, '.neo-dashboard-dock-rail-tab', inkTokens);
+
+                // PARITY, per state, against the app's OWN palette token — which is what these
+                // tabs computed before the promotion, when the app declared `color` directly.
+                //
+                // An earlier version asserted only `resting.color !== hovered.color` and called
+                // that "the app's ink reaches the tab". It did not: deleting the engine's resting
+                // `color: var(--dock-rail-tab-color)` left the arm GREEN, because the separate
+                // hover rule still moved the value. Two states differing proves neither of them
+                // came from where the arm claims.
+                expect(resting.color, `${identity.name} resting ink is ${identity.inkResting}`)
+                    .toBe(resting.resolved[identity.inkResting]);
+                expect(hovered.color, `${identity.name} hover ink is ${identity.inkHover}`)
+                    .toBe(hovered.resolved[identity.inkHover]);
+
+                // The hover affordance is the rail's whole navigation read.
+                expect(hovered.background, 'hover lifts the tab out of the strip')
+                    .not.toBe(resting.background);
+
+                // Values meant to stay UNCHANGED by identity: structural paint stays engine-neutral
+                // in both states. An app that re-declared border or shadow would be back in the
+                // equal-specificity tie this promotion dissolved.
+                for (const [state, reading] of Object.entries({resting, hovered})) {
+                    expect(reading.border, `${state} border stays engine-neutral`).toBe('0px none ' + reading.color);
+                    expect(reading.boxShadow, `${state} box-shadow stays engine-neutral`).toBe('none')
+                }
+
+                // Voice is app-owned and asymmetric on purpose: only workstation declares the mono
+                // family. Asserting the same font for both would assert a design neither has.
+                identity.ownsVoice
+                    ? expect(resting.fontFamily, 'workstation speaks mono through the token')
+                        .toMatch(/mono/i)
+                    : expect(resting.fontFamily, 'FM leaves the engine inherit in place')
+                        .not.toMatch(/mono/i)
+            })
+        }
+    }
+
+    test('mutating ONE app token moves that app only — both real consumers, side by side', async ({page}) => {
+        await applyTheme(page, 'neo-theme-neo-dark');
+        await loadStylesheets(page, [
+            APP_IDENTITIES[0].tokens('neo-theme-neo-dark'), APP_IDENTITIES[0].rule,
+            APP_IDENTITIES[1].tokens('neo-theme-neo-dark'), APP_IDENTITIES[1].rule
+        ]);
+
+        // Two subtrees in ONE document, each wearing a real app root class, so the isolation claim
+        // is measured across the two shipped rules rather than across two spec-authored ones.
+        await page.evaluate(() => {
+            const dashboard = document.querySelector('.neo-dashboard'),
+                  sibling   = dashboard.cloneNode(true);
+
+            sibling.id = 'sibling-dashboard';
+            dashboard.parentElement.appendChild(sibling);
+
+            dashboard.classList.add('workstation-workspace');
+            sibling.classList.add('fm-fleet-cockpit')
+        });
+
+        const
+            wsTab = '.workstation-workspace .neo-dashboard-dock-rail-tab',
+            fmTab = '.fm-fleet-cockpit .neo-dashboard-dock-rail-tab';
+
+        const before = {
+            fm: await readTabPaint(page, fmTab),
+            ws: await readTabPaint(page, wsTab)
+        };
+
+        // Non-vacuity: the two subtrees must be genuinely different consumers, or "only one moved"
+        // is unfalsifiable. It is anchored on VOICE rather than ink, because the two apps really do
+        // share `#8b97a8` for dim ink in the dark theme — an equal-colour assertion here would have
+        // been asserting a difference the design does not have, and it failed exactly that way
+        // first. Voice is the axis where they genuinely diverge: only workstation sets the family.
+        expect(before.ws.fontFamily, 'precondition: the two subtrees are different consumers')
+            .not.toBe(before.fm.fontFamily);
+
+        await page.evaluate(() => {
+            const style = document.createElement('style');
+
+            style.textContent =
+                '.workstation-workspace .neo-dashboard-dock-edge-rail .neo-button.neo-dashboard-dock-rail-tab ' +
+                '{ --dock-rail-tab-color: rgb(255, 0, 0) }';
+            document.head.appendChild(style)
+        });
+
+        const after = {
+            fm: await readTabPaint(page, fmTab),
+            ws: await readTabPaint(page, wsTab)
+        };
+
+        expect(after.ws.color, 'the mutated token moves the app that sets it').toBe('rgb(255, 0, 0)');
+        expect(after.fm, 'and the other real consumer is untouched, on every property').toEqual(before.fm)
+    })
 });

--- a/test/playwright/unit/buildScripts/dockRailTabLayering.spec.mjs
+++ b/test/playwright/unit/buildScripts/dockRailTabLayering.spec.mjs
@@ -1,29 +1,60 @@
-import {test, expect} from '@playwright/test';
-import {readFileSync} from 'node:fs';
-import {readdirSync}  from 'node:fs';
-import {join}         from 'node:path';
+import {test, expect}              from '@playwright/test';
+import {readFileSync, readdirSync} from 'node:fs';
+import {join}                      from 'node:path';
+import * as sass                   from 'sass';
 
 /**
  * The layering invariant for the dock rail tab: the ENGINE paints it, apps supply values.
- *
- * Asserted on SCSS **source** rather than built CSS, so the guard holds without a build step and
- * fails in review rather than after a theme rebuild someone may not run.
  *
  * Why this is a guard and not a one-off: both apps independently discovered the same fix for the
  * generic button skin and each wrote it into its own stylesheet. That is the shape that recurs —
  * the next app to adopt the dock will hit the identical problem and reach for the identical local
  * patch. The rule below is what makes the engine the obvious place to look instead.
  *
+ * **The first version of this file asserted on SCSS source only, and that was not enough.** Source
+ * text cannot see the cascade. Moving a declaration to the correct owner does not preserve its
+ * winning specificity, and the promotion this guard protects did exactly that: both apps had been
+ * carrying a higher-specificity `min-width: 0` to escape a tie with the theme's 48px button floor,
+ * and lifting the paint engine-side without also outranking the theme would have handed every
+ * consumer the empty-pill regression those app rules existed to prevent. @neo-gpt-emmy caught it
+ * in review on [PR 17524](https://github.com/neomjs/neo/pull/17524); the compiled arm below is
+ * the oracle that would have caught it here.
+ *
+ * The compilation is done in-process rather than read from `dist/`: CI never runs `build-themes`,
+ * so a `dist/`-reading guard would find no files, match nothing, and report green.
+ *
  * @see https://github.com/neomjs/neo/issues/17522
  */
 test.describe('dock rail tab — the engine paints it, apps only set values', () => {
     const
-        APP_SCSS_ROOT = 'resources/scss/src/apps',
-        ENGINE_RULE   = 'resources/scss/src/dashboard/Container.scss',
-        // Paint the engine owns. `padding` is deliberately absent: rail orientation genuinely
-        // differs per app (the workstation's horizontal rails need caption breathing room), so it
-        // stays an app concern and this guard must not forbid it.
-        ENGINE_PAINT  = ['background', 'background-color', 'border', 'box-shadow', 'color', 'min-width'];
+        SCSS_ROOT   = 'resources/scss',
+        ENGINE_FILE = 'resources/scss/src/dashboard/Container.scss',
+        // Every root an application stylesheet can live under. The first version scanned only
+        // `src/apps` and would not have seen a rail tab repainted from `theme-neo-dark/apps`.
+        APP_ROOTS   = ['resources/scss/src/apps',      'resources/scss/theme-dark/apps',
+                       'resources/scss/theme-light/apps', 'resources/scss/theme-neo-dark/apps',
+                       'resources/scss/theme-neo-light/apps'],
+        TOKENS      = ['--dock-rail-tab-background', '--dock-rail-tab-background-hover',
+                       '--dock-rail-tab-color',      '--dock-rail-tab-color-hover',
+                       '--dock-rail-tab-font-family'],
+        // Paint the engine owns. `padding` is deliberately absent from the app denylist: rail
+        // orientation genuinely differs per app (the workstation's horizontal rails need caption
+        // breathing room), so it stays an app concern and this guard must not forbid it.
+        ENGINE_PAINT = ['background', 'background-color', 'border', 'box-shadow', 'color',
+                        'font-family', 'min-width', 'transition'],
+        // Longhands collapse into the shorthand that would override them. Without this the guard
+        // compares `background` against `background-color` as if they were unrelated properties.
+        FAMILY = {
+            'background-color': 'background', 'background-image': 'background',
+            'border-color'    : 'border', 'border-style': 'border', 'border-width': 'border',
+            'font'            : 'font-family', 'transition-property': 'transition'
+        },
+        // Classes the tab element itself carries, and the ancestors it sits under.
+        OWN_CLASSES = ['neo-button', 'neo-dashboard-dock-rail-tab'],
+        ANCESTORS   = ['neo-dashboard', 'neo-theme-neo-dark', 'neo-theme-neo-light',
+                       'neo-theme-dark', 'neo-theme-light',
+                       'neo-dashboard-dock-edge-rail-left',  'neo-dashboard-dock-edge-rail-right',
+                       'neo-dashboard-dock-edge-rail-top',   'neo-dashboard-dock-edge-rail-bottom'];
 
     /** Every `.scss` under a root, recursively. */
     const scssFiles = (dir, out = []) => {
@@ -34,6 +65,76 @@ test.describe('dock rail tab — the engine paints it, apps only set values', ()
         }
 
         return out
+    };
+
+    /** [ids, classes, types] for the flat selectors Sass emits here. */
+    const specificity = selector => {
+        const s = selector.replace(/::[\w-]+/g, '');
+
+        return [
+            (s.match(/#[\w-]+/g)                   || []).length,
+            (s.match(/\.[\w-]+/g)                  || []).length +
+            (s.match(/:(?!:)[\w-]+/g)              || []).length +
+            (s.match(/\[[^\]]+\]/g)                || []).length,
+            (s.match(/(^|[\s>+~])[a-zA-Z][\w-]*/g) || []).length
+        ]
+    };
+
+    const rank   = spec => spec[0] * 10000 + spec[1] * 100 + spec[2],
+          show   = spec => `(${spec.join(',')})`,
+          family = property => FAMILY[property] || property;
+
+    /**
+     * Could this selector's rightmost compound match a rail tab, with every ancestor reachable?
+     * Descendant targets (`… .neo-button-text`) are excluded — they are a different element.
+     */
+    const canReachRailTab = selector => {
+        const parts   = selector.trim().split(/\s*[>\s+~]\s*/).filter(Boolean),
+              last    = parts.at(-1),
+              lastCls = (last.match(/\.[\w-]+/g) || []).map(c => c.slice(1));
+
+        if (!lastCls.length || !lastCls.every(c => OWN_CLASSES.includes(c))) return false;
+        if (/::(?:before|after)/.test(last))                                 return false;
+
+        return parts.slice(0, -1).every(part => {
+            if (part === ':root') return true;
+
+            const cls = (part.match(/\.[\w-]+/g) || []).map(c => c.slice(1));
+
+            return cls.length > 0 && cls.every(c => OWN_CLASSES.includes(c) || ANCESTORS.includes(c))
+        })
+    };
+
+    /** Compile every stylesheet that mentions a button, and collect the rules reaching a rail tab. */
+    const reachingRules = () => {
+        const rules = [];
+
+        for (const file of scssFiles(SCSS_ROOT)) {
+            const source = readFileSync(file, 'utf8');
+
+            if (!/neo-button|neo-dashboard-dock-rail-tab/.test(source)) continue;
+
+            const css = sass.compile(file, {
+                silenceDeprecations: ['import', 'global-builtin', 'color-functions', 'slash-div']
+            }).css;
+
+            for (const block of css.matchAll(/([^{}]+)\{([^{}]*)\}/g)) {
+                for (const selector of block[1].split(',').map(s => s.trim().replace(/\s+/g, ' ')).filter(Boolean)) {
+                    if (!canReachRailTab(selector)) continue;
+
+                    for (const declaration of block[2].split(';')) {
+                        const property = declaration.split(':')[0]?.trim();
+
+                        property && !property.startsWith('--') && rules.push({
+                            file, selector, property, family: family(property),
+                            spec: specificity(selector), isEngine: file === ENGINE_FILE
+                        })
+                    }
+                }
+            }
+        }
+
+        return rules
     };
 
     /**
@@ -68,9 +169,6 @@ test.describe('dock rail tab — the engine paints it, apps only set values', ()
                 if (d === 0) own += ch
             }
 
-            // A nested block leaves its selector behind at depth 0; a selector carries no colon
-            // before the brace, so the property split below discards it naturally — except when it
-            // trails a declaration, hence the newline-aware split.
             own = own.split('\n').map(line => line.trim()).filter(line => line.includes(':')).join(';');
 
             for (const decl of own.split(';')) {
@@ -83,14 +181,59 @@ test.describe('dock rail tab — the engine paints it, apps only set values', ()
         return found
     };
 
+    test('the engine outranks every other rule that can reach a rail tab', () => {
+        const rules  = reachingRules(),
+              engine = rules.filter(r => r.isEngine),
+              others = rules.filter(r => !r.isEngine);
+
+        // Non-vacuity, both directions. A selector bug that matched nothing would otherwise sail
+        // through this arm reporting a clean cascade, and a competitor list of zero would make the
+        // comparison below trivially true.
+        expect(engine.length, 'the engine rule must be found at all').toBeGreaterThan(0);
+        expect(others.length, 'competitors must be found — a census of one proves nothing')
+            .toBeGreaterThan(0);
+        expect(others.some(r => r.family === 'min-width'),
+            "the theme's button min-width floor is the competitor this guard exists for")
+            .toBe(true);
+
+        // The engine's own resting rule is the floor every competitor must sit below.
+        const engineBase = {};
+
+        for (const rule of engine) {
+            const current = engineBase[rule.family];
+
+            if (!current || rank(rule.spec) < rank(current)) engineBase[rule.family] = rule.spec
+        }
+
+        const losses = [];
+
+        for (const rule of others) {
+            const base = engineBase[rule.family];
+
+            if (base && rank(rule.spec) >= rank(base)) {
+                losses.push(
+                    `${rule.family}: ${rule.selector} ${show(rule.spec)} ties or beats the engine ` +
+                    `${show(base)}  [${rule.file}]`
+                )
+            }
+        }
+
+        // An equal-specificity load-order bet is a loss, not a draw: Neo emits one CSS file per
+        // source file and does not pin their order, so a tie is a regression waiting for a
+        // rebuild to surface it.
+        expect(losses, 'every engine-owned property must win outright').toEqual([])
+    });
+
     test('no application stylesheet paints a rail tab — it may only set tokens', () => {
         const offenders = [];
 
-        for (const file of scssFiles(APP_SCSS_ROOT)) {
-            for (const {selector, property} of railTabOwnDeclarations(readFileSync(file, 'utf8'))) {
-                // A custom property IS the sanctioned mechanism; anything else is re-painting.
-                if (!property.startsWith('--') && ENGINE_PAINT.includes(property)) {
-                    offenders.push(`${file.replace(`${APP_SCSS_ROOT}/`, '')} → ${property} on ${selector}`)
+        for (const root of APP_ROOTS) {
+            for (const file of scssFiles(root)) {
+                for (const {selector, property} of railTabOwnDeclarations(readFileSync(file, 'utf8'))) {
+                    // A custom property IS the sanctioned mechanism; anything else is re-painting.
+                    if (!property.startsWith('--') && ENGINE_PAINT.includes(property)) {
+                        offenders.push(`${file} → ${property} on ${selector}`)
+                    }
                 }
             }
         }
@@ -101,15 +244,14 @@ test.describe('dock rail tab — the engine paints it, apps only set values', ()
     test('the engine declares that paint, reading tokens for the per-consumer values', () => {
         // Non-vacuity: without this, deleting the engine rule outright would satisfy the arm above
         // while leaving every consumer unpainted.
-        const engine = readFileSync(ENGINE_RULE, 'utf8');
+        const engine = readFileSync(ENGINE_FILE, 'utf8');
 
         for (const property of ['background', 'border', 'box-shadow', 'color', 'min-width']) {
             expect(engine, `engine must own ${property}`)
                 .toMatch(new RegExp(`\\n\\s*${property}\\s*:`))
         }
 
-        for (const token of ['--dock-rail-tab-background', '--dock-rail-tab-color',
-                             '--dock-rail-tab-color-hover', '--dock-rail-tab-font-family']) {
+        for (const token of TOKENS) {
             // The block-alignment linter pads declarations, so the colon is not adjacent.
             expect(engine, `${token} must be declared with a neutral default`)
                 .toMatch(new RegExp(`${token}\\s*:`));
@@ -120,11 +262,41 @@ test.describe('dock rail tab — the engine paints it, apps only set values', ()
     test('a consumer that sets no tokens still gets a legible tab', () => {
         // The neutral default must not be "invisible". `inherit` keeps the tab readable against
         // whatever ground the host provides — a palette value here would be the engine guessing.
-        const engine = readFileSync(ENGINE_RULE, 'utf8');
+        const engine = readFileSync(ENGINE_FILE, 'utf8');
 
         expect(engine).toMatch(/--dock-rail-tab-color\s*:\s*inherit/);
         expect(engine).toMatch(/--dock-rail-tab-font-family\s*:\s*inherit/);
         expect(engine, 'resting ground stays transparent — a rail tab is navigation, not an action')
             .toMatch(/--dock-rail-tab-background\s*:\s*transparent/)
+    });
+
+    test('an app token value cannot escape the app that sets it', () => {
+        // "Only that app changes" is the property the token layering exists to buy. It holds
+        // because every app-side declaration sits under that app's own root class — assert that,
+        // rather than the weaker fact that the declarations are custom properties.
+        const escapees = [];
+
+        for (const root of APP_ROOTS) {
+            for (const file of scssFiles(root)) {
+                const css = sass.compile(file, {
+                    silenceDeprecations: ['import', 'global-builtin', 'color-functions', 'slash-div']
+                }).css;
+
+                for (const block of css.matchAll(/([^{}]+)\{([^{}]*)\}/g)) {
+                    if (!TOKENS.some(t => block[2].includes(`${t}:`))) continue;
+
+                    for (const selector of block[1].split(',').map(s => s.trim())) {
+                        // `:root`-only or bare-element scoping would leak an app's identity into
+                        // every other consumer sharing the document.
+                        const classes = (selector.match(/\.[\w-]+/g) || []).map(c => c.slice(1)),
+                              scoped  = classes.some(c => !OWN_CLASSES.includes(c) && !ANCESTORS.includes(c));
+
+                        scoped || escapees.push(`${file} → ${selector}`)
+                    }
+                }
+            }
+        }
+
+        expect(escapees, 'app token values must sit under an app-owned ancestor').toEqual([])
     });
 });

--- a/test/playwright/unit/buildScripts/dockRailTabLayering.spec.mjs
+++ b/test/playwright/unit/buildScripts/dockRailTabLayering.spec.mjs
@@ -1,0 +1,130 @@
+import {test, expect} from '@playwright/test';
+import {readFileSync} from 'node:fs';
+import {readdirSync}  from 'node:fs';
+import {join}         from 'node:path';
+
+/**
+ * The layering invariant for the dock rail tab: the ENGINE paints it, apps supply values.
+ *
+ * Asserted on SCSS **source** rather than built CSS, so the guard holds without a build step and
+ * fails in review rather than after a theme rebuild someone may not run.
+ *
+ * Why this is a guard and not a one-off: both apps independently discovered the same fix for the
+ * generic button skin and each wrote it into its own stylesheet. That is the shape that recurs —
+ * the next app to adopt the dock will hit the identical problem and reach for the identical local
+ * patch. The rule below is what makes the engine the obvious place to look instead.
+ *
+ * @see https://github.com/neomjs/neo/issues/17522
+ */
+test.describe('dock rail tab — the engine paints it, apps only set values', () => {
+    const
+        APP_SCSS_ROOT = 'resources/scss/src/apps',
+        ENGINE_RULE   = 'resources/scss/src/dashboard/Container.scss',
+        // Paint the engine owns. `padding` is deliberately absent: rail orientation genuinely
+        // differs per app (the workstation's horizontal rails need caption breathing room), so it
+        // stays an app concern and this guard must not forbid it.
+        ENGINE_PAINT  = ['background', 'background-color', 'border', 'box-shadow', 'color', 'min-width'];
+
+    /** Every `.scss` under a root, recursively. */
+    const scssFiles = (dir, out = []) => {
+        for (const entry of readdirSync(dir, {withFileTypes: true})) {
+            const path = join(dir, entry.name);
+
+            entry.isDirectory() ? scssFiles(path, out) : entry.name.endsWith('.scss') && out.push(path)
+        }
+
+        return out
+    };
+
+    /**
+     * Declarations inside a rail-tab selector block, excluding nested descendant blocks — a
+     * `.neo-button-text { font-family }` inside is app VOICE and legitimate, while a
+     * `font-family` on the tab itself is engine paint.
+     */
+    const railTabOwnDeclarations = source => {
+        const found = [];
+
+        for (const match of source.matchAll(/([^\n{}]*neo-dashboard-dock-rail-tab[^\n{}]*)\{/g)) {
+            let depth = 1, i = match.index + match[0].length, body = '';
+
+            while (i < source.length && depth > 0) {
+                const ch = source[i];
+
+                if (ch === '{') depth++;
+                if (ch === '}') depth--;
+                if (depth > 0) body += ch;
+                i++
+            }
+
+            // Keep only depth-0 text. A regex like /[^{}]*\{[^{}]*\}/ looks equivalent and is not:
+            // its leading `[^{}]*` swallows the declarations that PRECEDE a nested block, so a
+            // `color` sitting above a `.neo-button-text { … }` disappears before inspection. That
+            // version passed its own mutation, which is how this scan came to exist.
+            let own = '', d = 0;
+
+            for (const ch of body) {
+                if (ch === '{') { d++; continue }
+                if (ch === '}') { d--; continue }
+                if (d === 0) own += ch
+            }
+
+            // A nested block leaves its selector behind at depth 0; a selector carries no colon
+            // before the brace, so the property split below discards it naturally — except when it
+            // trails a declaration, hence the newline-aware split.
+            own = own.split('\n').map(line => line.trim()).filter(line => line.includes(':')).join(';');
+
+            for (const decl of own.split(';')) {
+                const property = decl.split(':')[0]?.trim();
+
+                property && found.push({selector: match[1].trim(), property})
+            }
+        }
+
+        return found
+    };
+
+    test('no application stylesheet paints a rail tab — it may only set tokens', () => {
+        const offenders = [];
+
+        for (const file of scssFiles(APP_SCSS_ROOT)) {
+            for (const {selector, property} of railTabOwnDeclarations(readFileSync(file, 'utf8'))) {
+                // A custom property IS the sanctioned mechanism; anything else is re-painting.
+                if (!property.startsWith('--') && ENGINE_PAINT.includes(property)) {
+                    offenders.push(`${file.replace(`${APP_SCSS_ROOT}/`, '')} → ${property} on ${selector}`)
+                }
+            }
+        }
+
+        expect(offenders, 'apps override tokens; they do not re-declare engine paint').toEqual([])
+    });
+
+    test('the engine declares that paint, reading tokens for the per-consumer values', () => {
+        // Non-vacuity: without this, deleting the engine rule outright would satisfy the arm above
+        // while leaving every consumer unpainted.
+        const engine = readFileSync(ENGINE_RULE, 'utf8');
+
+        for (const property of ['background', 'border', 'box-shadow', 'color', 'min-width']) {
+            expect(engine, `engine must own ${property}`)
+                .toMatch(new RegExp(`\\n\\s*${property}\\s*:`))
+        }
+
+        for (const token of ['--dock-rail-tab-background', '--dock-rail-tab-color',
+                             '--dock-rail-tab-color-hover', '--dock-rail-tab-font-family']) {
+            // The block-alignment linter pads declarations, so the colon is not adjacent.
+            expect(engine, `${token} must be declared with a neutral default`)
+                .toMatch(new RegExp(`${token}\\s*:`));
+            expect(engine, `${token} must be consumed`).toContain(`var(${token})`)
+        }
+    });
+
+    test('a consumer that sets no tokens still gets a legible tab', () => {
+        // The neutral default must not be "invisible". `inherit` keeps the tab readable against
+        // whatever ground the host provides — a palette value here would be the engine guessing.
+        const engine = readFileSync(ENGINE_RULE, 'utf8');
+
+        expect(engine).toMatch(/--dock-rail-tab-color\s*:\s*inherit/);
+        expect(engine).toMatch(/--dock-rail-tab-font-family\s*:\s*inherit/);
+        expect(engine, 'resting ground stays transparent — a rail tab is navigation, not an action')
+            .toMatch(/--dock-rail-tab-background\s*:\s*transparent/)
+    });
+});


### PR DESCRIPTION
Resolves #17522

Related: #17241 · #17514

🌿 *Two apps discovered the same fix independently and each wrote it down locally. That is the engine's job going unclaimed — but one of those local rules was load-bearing, and I deleted it before the engine could carry it.*

Evidence: L2 (compiled-cascade oracle + rendered computed styles, both mutation-checked) → L2 required (build-time styling with a rendered surface). No residual.

## What moved and why

`Workspace.scss:105` and `FleetCockpit.scss:34` both declared, identically:

```scss
background: transparent;
border    : 0;
box-shadow: none;
min-width : 0;

.neo-button-glyph,
.neo-button-text { color: inherit }
```

That is not app identity — it is the work of stopping the generic `.neo-button` skin from painting a **navigation rail** as an **action**. Engine capability, discovered twice and written down twice.

Four values genuinely differ, and those become tokens:

| token | workstation | FM |
|---|---|---|
| `--dock-rail-tab-color` | `--workstation-ink-dim` | `--fm-ink-dim` |
| `--dock-rail-tab-color-hover` | `--workstation-ink` | `--fm-ink` |
| `--dock-rail-tab-background-hover` | `color-mix(--workstation-signal 14%…)` | `--fm-panel` |
| `--dock-rail-tab-font-family` | `--workstation-font-mono` | *(unset)* |

Follows the discipline the Body-side dock guide states (#17514): *consumers skin the affordance by overriding tokens, never by re-painting internals.*

## There were TWO ties. The first head dissolved one and re-opened the other.

@neo-gpt-emmy's review caught this and it was the right call.

`min-width: 0` looked like the sharpest instance of duplication — `Container.scss` already declared it, so both apps appeared to be re-stating something they inherit. **They were not.** The engine rule sat at `(0,3,0)`, and the neo themes floor every button through `:root .neo-theme-neo-* .neo-button` — also `(0,3,0)`, setting `min-width: var(--cmp-button-height)` = 48px. A tie, decided by load order, which Neo does not pin because it emits CSS per source file.

Both apps had independently found that tie and each carried a **higher-specificity** `min-width: 0` to escape it. Workstation's comment named the mechanism and the symptom outright:

> the rail renders as an empty pill. The `.neo-button` compound lifts this layer to (0,4,0) so the tie stops being a load-order bet

I deleted the rule that comment was attached to, and wrote prose claiming the tie was gone. It was gone for **app vs engine**. The one that actually kept the rail working — **engine vs theme** — I handed back to the coin flip.

**The fix is a leading `:root`**, lifting the engine rule to `(0,4,0)` so it outranks the generic button skin outright. No consumer needs a local escape hatch for a working rail. `:root` is the theme's own idiom for a baseline layer; the engine says the same thing one level up.

Stale prose corrected in all three files, including an inherited comment in `Container.scss` that miscounted the theme selector as `(0,2,0)` — `Workspace.scss` had it right at `(0,3,0)` all along.

## What deliberately stayed app-side

Clio's chrome voice — mono, tracking, uppercase on `.neo-button-text` — is FM's design role, not dock capability. Her in-file note deferred exactly this lift to #17241, and it is untouched. FM also keeps its own motion timing by overriding `--dock-transition-duration-fast` rather than re-declaring a transition.

The workstation's horizontal-rail padding stays too: rail orientation genuinely differs per app, so the guard deliberately does **not** forbid `padding`.

## AC Evidence

| AC | proof |
|---|---|
| AC-1 | `dockRailTabLayering.spec.mjs` arm 3 — the engine declares all five `--dock-rail-tab-*` tokens AND consumes each via `var()`; arm 4 pins the neutral defaults to `inherit` / `transparent`. Mutation: dropping the hover-background token reds arm 3. |
| AC-2 | `dockRailTabLayering.spec.mjs` arm 2 — scans **all five** app roots (`src/apps` plus `theme-{dark,light,neo-dark,neo-light}/apps`), rejects `background`/`border`/`box-shadow`/`color`/`min-width` and now `font-family`/`transition` on a rail tab's own block. Mutation: re-adding `min-width` to `Workspace.scss` reds it. |
| AC-3 | `DockRailTabPaint.spec.mjs` arms 1–2 — computed `min-width` on a **rendered** tab, both neo themes, each gated on a control button proving the 48px floor is live in that document. Mutation: dropping the `:root` reds both with `Received: "48px"`. **Extended for @neo-gpt-emmy's RA-2:** four further arms load the **compiled** `Workspace.css` / `FleetCockpit.css` plus the theme-scoped token layer their values reference, and assert background, color, border, box-shadow and font-family resting *and* hovered, per app per theme. The earlier scope note — measured on engine classes rather than the real apps — no longer applies to those arms. |
| AC-4 | `dockRailTabLayering.spec.mjs` arm 1 — compiled-selector census over every button-bearing stylesheet; fails when any non-engine rule ties or beats the engine on an engine-owned property. `min-width` was the one real tie and is now engine-only at `(0,4,0)`. |
| AC-5 | `dockRailTabLayering.spec.mjs` arm 4 — neutral defaults are `inherit` / `transparent`, never a palette value the engine cannot know. |
| AC-6 | `DockRailTabPaint.spec.mjs` — the two REAL consumers side by side in one document, both compiled stylesheets loaded: mutating workstation's `--dock-rail-tab-color` turns its tab red and leaves FM byte-identical on **every** measured property. Non-vacuity is anchored on voice, not ink — the two apps genuinely share `#8b97a8` for dim ink in the dark theme, so an equal-colour precondition would have asserted a difference the design does not have, and it failed exactly that way first. Structural counterpart: `dockRailTabLayering.spec.mjs` arm 5 reds on a top-level `:root` token in an app file. |

**@neo-gpt-emmy's RA-2 remainder — DISCHARGED, now at `bf67ffa547`** (was `7409980d43`; the branch was rebased onto `dev` after PR #17531 merged — see the rebase note below). Her disposition was exact: the compiled-selector and source-guard clauses were addressed, but the runtime file checked only `min-width` and then injected a synthetic `.test-app-a` rule, which proved the engine's token plumbing and nothing about either app. Five arms now load the compiled artifacts instead.

One of those arms began green for the wrong reason and is worth recording, because it is the failure this whole RA is about. The first version asserted `resting.color !== hovered.color` and called it *"the app's ink reaches the tab"*. Deleting the engine's resting `color: var(--dock-rail-tab-color)` left **all four arms green** — the separate hover rule still moved the value, so two states differing proved neither came from where the arm claimed. Parity is now asserted per state against the app's own palette token, and that same mutation reds all four.

**Rebased onto `dev` at `bf67ffa547`.** PR #17531 (the splitter half of the same promotion) merged first and touched the same three SCSS files, so this branch went `DIRTY`. One conflict, in `Container.scss`, and it was purely additive: `dev` carried the `--dock-splitter-*` token block, this branch carried `--dock-rail-tab-*`, and both are kept. Verified rather than assumed — `git diff origin/dev...HEAD` removes **no** splitter line, and both witnesses pass together on the rebased tree: `buildScripts` **144 passed** (139 + the merged splitter guard), `component/dashboard/` **19 passed** (8 rail-tab + 11 splitter).

## Test Evidence

Two instruments, because the previous single one could not see the defect.

### 1. Compiled-cascade oracle — `dockRailTabLayering.spec.mjs`, 5 arms

Compiles every stylesheet mentioning a button **in-process**, finds each rule that can reach a rail tab, and fails when any non-engine rule ties or beats the engine on an engine-owned property.

In-process rather than reading `dist/`: **CI never runs `build-themes`**, so a `dist/`-reading guard would find no files, match nothing, and report green.

| mutation | reds |
|---|---|
| drop the `:root` (the defect itself) | cascade arm |
| an app re-declares `min-width` | no-paint arm |
| engine drops the hover-background token | token arm |
| top-level `:root` token in an app file | escape arm |

The escape arm's *first* mutation stayed green — a nested `:root` still compiles under the app class, so it never produced a leak. The arm was fine; my mutation was not. Re-run with a genuine top-level leak, it reds.

### 2. Rendered witness — `DockRailTabPaint.spec.mjs`, 3 arms

Mounts a real `Neo.dashboard.Container` with a real `DockRail` and measures what a browser paints. This is AC-3 and AC-6.

Dropping the `:root` reds both theme arms with **`Received: "48px"`** — the empty-pill regression itself, on a rendered tab.

**Every arm measures a plain sibling button first and requires it to be AT the 48px floor.** `min-width: 0px` only means the engine won if the floor was live in the same document. That control earned its place three times over — each of these was a green-looking wrong answer:

1. `empty-viewport` inherits `DefaultConfig.themes`, which is the **legacy** pair plus one neo theme. The floor exists only in the neo themes, so the witness was measuring a document where the competing rule was never loaded. New `dock-rail` fixture app pins both neo themes.
2. Mounting a plain container *wearing* `.neo-dashboard` leaves `src/dashboard/Container.css` unloaded — Neo loads a class's stylesheet when the class is instantiated — so the rule under test was absent entirely.
3. The engine rule **transitions `color`**. Reading right after a class flip returns the start value; a frame later returns a blend (measured at `rgb(244,172,171)` en route to red). Transitions are switched off for the measurement — a sleep would only have made the flake slower.

Suites: `test-components` **53 passed**, unit `buildScripts` + `core` **171 passed**.

## Deltas from ticket

- **The previous head de-scoped AC-3 and argued the substitute was stronger.** It was not stronger, it was blind to the cascade — and the de-scoping is what let the regression through. Both AC-3 and AC-6 are implemented above.
- **FM's transition moved to a token override** rather than being deleted — it uses `--fm-motion-fast`, which differs from the engine default, so removing it would have been a silent timing change.
- **`prototype` is in no denylist here** — unrelated; noting only that the two open PRs on my branch stack are independent.

## Out of Scope

- **The splitter promotion** — stays on #17241 / PR #17531.

## Post-Merge Validation

None gating. Both apps' rail tabs resolve to the values they did before; the engine gains a default no current consumer relied on, and any new consumer gets a working rail without discovering the theme floor for itself.

Authored by Grace (Claude Opus 5, Claude Code). Session 59f57b1e-c42a-4e66-9e86-66f62cdc2b6a.


