### PR TITLE
test(workstation): the red-control proves its restore by its own instrument (#16734)

### DIFF
--- a/test/playwright/e2e/workstation/WorkstationFiveBeatNL.spec.mjs
+++ b/test/playwright/e2e/workstation/WorkstationFiveBeatNL.spec.mjs
@@ -1842,6 +1842,27 @@ test.describe('Workstation — the five-beat multi-window journey', () => {
             );
 
             expect(restoredOpacity, 'the staged clear must leave no residue on the host').toBe('1');
+
+            // The untargeted-surface discipline: the restore is proven by the SAME instrument that
+            // proved the clear, never by reading back the one property the fixture itself wrote. A
+            // plausible-but-wrong restore — a pane re-rendered broken, content lost, while the
+            // host's own opacity reads '1' — must red HERE. The cross-capture guard is load-bearing:
+            // the second capture's OWN baseline must measure baseline-class against the first, or a
+            // degraded-but-stable restore would normalise itself away inside its own capture.
+            const restored = await captureWorkspaceContinuity(page, () => page.waitForTimeout(600));
+
+            expect(restored.baselineEntropy,
+                'the post-restore workspace measures baseline-class against the pre-clear room')
+                .toBeGreaterThanOrEqual(continuity.baselineEntropy * 0.65);
+
+            await assertWorkspaceContinuity({
+                continuity     : restored,
+                expectedCleared: false,
+                label          : 'red-control-post-restore-continuity',
+                receipt        : {postRestore: 'second capture over a 600ms settle window after the staged clear restored'},
+                testInfo
+            });
+
             expect(pageErrors).toEqual([])
         }
     );


### PR DESCRIPTION
Resolves #16734

The red-control fixture now proves its restore by the same instrument that proved its clear. After the staged whole-body clear convicts (`expectedCleared: true`, unchanged), the test runs a SECOND `captureWorkspaceContinuity` over a 600ms settle window and asserts it green through the shipped helper (`expectedCleared: false` — the measured 0.65 floor with its provenance comment), so a plausible-but-wrong restore — a pane re-rendered broken, content lost, while the host's own opacity reads `'1'` — reds the fixture instead of passing a read-back of the one property the fixture itself wrote (the `#15178` plausible-but-wrong law, applied). One load-bearing addition beyond the ticket's prescription: a **cross-capture baseline guard** (`restored.baselineEntropy ≥ 0.65 × first capture's baseline`) — without it, a degraded-but-stable restore would normalise itself inside its own capture, since the second capture's baseline IS the post-restore state. The cheap opacity residue check stays (the ticket asked for "not only", not "not").

Evidence: L2 achieved (headed runs below — the fixture's own tier; it is headed-only by design) → L2 sufficient (all three ACs are observables of this run class).

## Deltas from ticket

- The cross-capture baseline guard described above — the ticket's formula compared the second capture's minimum to its own baseline; the guard additionally pins that baseline to the pre-clear room, closing the self-normalisation hole the formula alone leaves open.
- Drift probe at pickup (self-authored earlier-session ticket, carve case 3): the only intersection commits on the witness file since filing are the ticket's own founding pair (`#16703` / `#16726`, merged the day it was filed) — zero drift underneath the premise.

## Test Evidence

- `NEO_E2E_PORT=8099 npx playwright test WorkstationFiveBeatNL -c test/playwright/playwright.config.e2e.mjs --workers=1 --headed -g "red-control" --repeat-each 2` → **2/2 passed** (2.5s / 2.5s test time).
- Receipts (both repeats): staged clear convicts at `minEntropy 1.4576` vs baseline `≈5.30` (the ticket's exact measured population); post-restore capture `baselineEntropy 5.3017/5.3041`, `minEntropy 5.3003/5.3007` across 37 frames — baseline-class with ~8× margin above the floor; cross-capture guard 5.30-vs-5.30.
- Film-take self-exclusion untouched (`test.skip(filmTake, …)` stands); the staged clear still never enters take footage.
- No other test or runtime file changed.

## Post-Merge Validation

None owed: the fixture is headed-local by design (outside the PR CI gauntlet); the receipts above are its evidence tier.

Authored by Mnemosyne (Claude Fable 5, Claude Code). Session 55e55313-48fa-4295-83fd-37121a2bf4b6.
