### PR TITLE
test(workstation): the post-restore floor binds to the original baseline, not a composed one (#16734)

### DIFF
--- a/test/playwright/e2e/workstation/WorkstationFiveBeatNL.spec.mjs
+++ b/test/playwright/e2e/workstation/WorkstationFiveBeatNL.spec.mjs
@@ -1844,15 +1844,21 @@ test.describe('Workstation — the five-beat multi-window journey', () => {
             expect(restoredOpacity, 'the staged clear must leave no residue on the host').toBe('1');
 
             // The untargeted-surface discipline: the restore is proven by the SAME instrument that
-            // proved the clear, never by reading back the one property the fixture itself wrote. A
-            // plausible-but-wrong restore — a pane re-rendered broken, content lost, while the
-            // host's own opacity reads '1' — must red HERE. The cross-capture guard is load-bearing:
-            // the second capture's OWN baseline must measure baseline-class against the first, or a
-            // degraded-but-stable restore would normalise itself away inside its own capture.
+            // proved the clear, never by reading back the one property the fixture itself wrote.
+            // Scope honestly held: grayscale visual-density entropy proves the workspace still
+            // RENDERS a baseline-class dense room — pane identity/content semantics belong to the
+            // semantic witnesses, not this fixture. The cross-capture guard alone is NOT enough:
+            // the helper floors the second capture's minimum against its OWN baseline, so two 0.65s
+            // would compose to 0.4225x of the original (5.30 → 3.445 → 2.239 passes both) — the
+            // direct bind below pins the post-restore minimum to the ORIGINAL baseline's floor.
             const restored = await captureWorkspaceContinuity(page, () => page.waitForTimeout(600));
 
             expect(restored.baselineEntropy,
                 'the post-restore workspace measures baseline-class against the pre-clear room')
+                .toBeGreaterThanOrEqual(continuity.baselineEntropy * 0.65);
+
+            expect(restored.minEntropy,
+                'the post-restore minimum holds the ORIGINAL baseline-class floor — composed 0.65s must not pass')
                 .toBeGreaterThanOrEqual(continuity.baselineEntropy * 0.65);
 
             await assertWorkspaceContinuity({


### PR DESCRIPTION
Resolves #16734

The post-merge reviewer correction on PR `#17526` (`IC_kwDODSospM8AAAABQHe08Q`) repaired: the shipped pair of predicates composed — the helper floors the second capture's minimum against its OWN baseline, so the cross-capture guard's 0.65 and the helper's 0.65 multiplied to a `0.4225×` effective floor (`5.30 → 3.445 → 2.239` passed both while sitting under the true baseline-class bound). The bounded fix is exactly the reopen prescription: `restored.minEntropy` now binds DIRECTLY to `continuity.baselineEntropy * 0.65` (the ORIGINAL baseline's floor), with the existing guard and helper call retained. Verified by re-derivation before adoption — the counterexample is arithmetic, not observed: both live receipt sets sat at ~1.0× throughout.

The prose is narrowed in the same breath: grayscale visual-density entropy proves the workspace still renders a baseline-class dense room; pane identity/content semantics are named as belonging to the semantic witnesses, out of this fixture's scope — and the comment now carries the composed-floor counterexample so the next editor cannot reintroduce it.

Evidence: L2 achieved (headed receipts below, the fixture's own tier) → L2 sufficient.

## Deltas from ticket

None — this PR is the reopen's bounded repair, verbatim.

## Test Evidence

- `NEO_E2E_PORT=8101 npx playwright test WorkstationFiveBeatNL -c test/playwright/playwright.config.e2e.mjs --workers=1 --headed -g "red-control" --repeat-each 2` → **2/2 passed** (9.0s).
- Receipts: post-restore `minEntropy 5.3010 / 5.3015` vs the direct original-baseline floor `≈3.448` — 1.54× margin; the clear-conviction leg unchanged.
- The composed counterexample (`baseline 3.445, min 2.239`) now fails the new assertion by construction.

## Post-Merge Validation

None owed.

Authored by Mnemosyne (Claude Fable 5, Claude Code). Session 55e55313-48fa-4295-83fd-37121a2bf4b6.
