### PR TITLE
The dock splitter's visual language lives in apps, not the engine

### DIFF
--- a/resources/scss/src/apps/agentos/fleet/FleetCockpit.scss
+++ b/resources/scss/src/apps/agentos/fleet/FleetCockpit.scss
@@ -224,14 +224,17 @@
 
     /* the zone splitter gains a visible affordance (the operator-reported invisible splitter):
        a soft nut at rest, the signal under the pointer — the drag hit-zone keeps its full width */
+    /* Values only. FM's splitter is deliberately FLAT: `handle-size: 0` is a design statement,
+       not an omission — it greps, and it survives the engine gaining a real handle. Whether flat
+       remains right now that a discoverable handle exists is an FM design-language question, not
+       an engine one. */
     .neo-dashboard-dock-splitter {
-        background: color-mix(in srgb, var(--fm-line-soft) 55%, transparent);
-        transition: background var(--fm-motion-fast) var(--ease-out-soft);
-
-        &:hover,
-        &:active {
-            background: color-mix(in srgb, var(--fm-signal) 45%, transparent);
-        }
+        --dock-splitter-background       : color-mix(in srgb, var(--fm-line-soft) 55%, transparent);
+        --dock-splitter-background-hover : color-mix(in srgb, var(--fm-signal) 45%, transparent);
+        --dock-splitter-background-active: color-mix(in srgb, var(--fm-signal) 45%, transparent);
+        --dock-splitter-handle-size      : 0;
+        --dock-splitter-radius           : 0;
+        --dock-transition-duration-fast  : var(--fm-motion-fast);
     }
 
     /* Vessel-narrow mode: below the width where two zones can sit beside each other honestly

--- a/resources/scss/src/apps/workstation/Workspace.scss
+++ b/resources/scss/src/apps/workstation/Workspace.scss
@@ -41,15 +41,12 @@
         --dock-splitter-background-active : color-mix(in srgb, var(--workstation-signal) 30%, transparent);
         --dock-splitter-handle-color      : color-mix(in srgb, var(--workstation-signal) 42%, var(--workstation-line));
         --dock-splitter-handle-color-hover: color-mix(in srgb, var(--workstation-signal) 78%, var(--workstation-ink));
+        --dock-splitter-handle-color-active: var(--workstation-signal);
         --dock-splitter-handle-glow-hover : 0 0 9px color-mix(in srgb, var(--workstation-signal) 48%, transparent);
         --dock-splitter-ring              : inset 0 0 0 1px color-mix(in srgb, var(--workstation-signal) 18%, transparent);
         --dock-splitter-ring-hover        : inset 0 0 0 1px color-mix(in srgb, var(--workstation-signal) 38%, transparent);
         --dock-splitter-ring-active       : inset 0 0 0 1px var(--workstation-signal),
                                             0 0 12px color-mix(in srgb, var(--workstation-signal) 32%, transparent);
-
-        &:active::after {
-            background: var(--workstation-signal);
-        }
     }
 
     // The band is dock chrome and stays; `.neo-tab-container` was grouped with it and is pane

--- a/resources/scss/src/apps/workstation/Workspace.scss
+++ b/resources/scss/src/apps/workstation/Workspace.scss
@@ -28,57 +28,28 @@
 
     // DockLayoutAdapter already projects one real DockSplitter per split boundary. Paint that
     // exact six-pixel interaction target instead of adding a disconnected decorative handle.
+    /* Values only. Ring and glow are workstation SIGNAL language — they were born reading
+       `--workstation-signal` — so they live here rather than in the engine's affordance floor.
+       The band, the 36x2 handle and the hover/active behaviour are engine capability.
+
+       The `opacity: 1 !important` this block used to carry is gone rather than moved: it was
+       fighting a competing rule, and the engine now owns the active state at its own
+       specificity, so there is nothing left to fight. */
     .neo-dashboard-dock-splitter {
-        background-color: color-mix(in srgb, var(--workstation-signal) 9%, transparent);
-        border-radius   : 999px;
-        box-shadow      : inset 0 0 0 1px color-mix(in srgb, var(--workstation-signal) 18%, transparent);
-        position  : relative;
-        transition: background-color var(--dock-transition-duration-fast) var(--dock-transition-easing),
-                          box-shadow var(--dock-transition-duration-fast) var(--dock-transition-easing);
-        z-index         : 1;
+        --dock-splitter-background        : color-mix(in srgb, var(--workstation-signal) 9%, transparent);
+        --dock-splitter-background-hover  : color-mix(in srgb, var(--workstation-signal) 18%, transparent);
+        --dock-splitter-background-active : color-mix(in srgb, var(--workstation-signal) 30%, transparent);
+        --dock-splitter-handle-color      : color-mix(in srgb, var(--workstation-signal) 42%, var(--workstation-line));
+        --dock-splitter-handle-color-hover: color-mix(in srgb, var(--workstation-signal) 78%, var(--workstation-ink));
+        --dock-splitter-handle-glow-hover : 0 0 9px color-mix(in srgb, var(--workstation-signal) 48%, transparent);
+        --dock-splitter-ring              : inset 0 0 0 1px color-mix(in srgb, var(--workstation-signal) 18%, transparent);
+        --dock-splitter-ring-hover        : inset 0 0 0 1px color-mix(in srgb, var(--workstation-signal) 38%, transparent);
+        --dock-splitter-ring-active       : inset 0 0 0 1px var(--workstation-signal),
+                                            0 0 12px color-mix(in srgb, var(--workstation-signal) 32%, transparent);
 
-        &::after {
-            background   : color-mix(in srgb, var(--workstation-signal) 42%, var(--workstation-line));
-            border-radius: 999px;
-            content   : '';
-            left      : 50%;
-            position  : absolute;
-            top       : 50%;
-            transform : translate(-50%, -50%);
-            transition: background-color var(--dock-transition-duration-fast) var(--dock-transition-easing),
-                           box-shadow var(--dock-transition-duration-fast) var(--dock-transition-easing);
+        &:active::after {
+            background: var(--workstation-signal);
         }
-
-        &:hover {
-            background-color: color-mix(in srgb, var(--workstation-signal) 18%, transparent);
-            box-shadow      : inset 0 0 0 1px color-mix(in srgb, var(--workstation-signal) 38%, transparent);
-
-            &::after {
-                background: color-mix(in srgb, var(--workstation-signal) 78%, var(--workstation-ink));
-                box-shadow: 0 0 9px color-mix(in srgb, var(--workstation-signal) 48%, transparent);
-            }
-        }
-
-        &:active {
-            background-color: color-mix(in srgb, var(--workstation-signal) 30%, transparent);
-            box-shadow      : inset 0 0 0 1px var(--workstation-signal),
-                              0 0 12px color-mix(in srgb, var(--workstation-signal) 32%, transparent);
-            opacity         : 1 !important;
-
-            &::after {
-                background: var(--workstation-signal);
-            }
-        }
-    }
-
-    .neo-dashboard-dock-splitter-horizontal::after {
-        height: 36px;
-        width : 2px;
-    }
-
-    .neo-dashboard-dock-splitter-vertical::after {
-        height: 2px;
-        width : 36px;
     }
 
     // The band is dock chrome and stays; `.neo-tab-container` was grouped with it and is pane

--- a/resources/scss/src/dashboard/Container.scss
+++ b/resources/scss/src/dashboard/Container.scss
@@ -46,6 +46,10 @@
     --dock-splitter-handle-thickness : 2px;
     --dock-splitter-handle-color     : color-mix(in srgb, currentColor 45%, transparent);
     --dock-splitter-handle-color-hover: currentColor;
+    // Dragging must never read as LESS engaged than hovering, so the floor inherits the hover
+    // value rather than re-deriving one. An app that sets only the hover colour still gets a
+    // coherent active state; one with its own accent overrides this slot alone.
+    --dock-splitter-handle-color-active: var(--dock-splitter-handle-color-hover);
 
     // Identity slots, empty by default. An app fills them; the engine never does.
     --dock-splitter-ring             : none;
@@ -222,6 +226,14 @@
     &:active {
         background-color: var(--dock-splitter-background-active);
         box-shadow      : var(--dock-splitter-ring-active);
+
+        // The handle takes the active slot HERE, in the engine. Without this rule the token has no
+        // consumer, and an app that wants a distinct drag colour has nowhere to put it except a
+        // direct `&:active::after { background: … }` in its own stylesheet — which is exactly the
+        // app-layer paint this promotion exists to end.
+        &::after {
+            background: var(--dock-splitter-handle-color-active);
+        }
     }
 }
 

--- a/resources/scss/src/dashboard/Container.scss
+++ b/resources/scss/src/dashboard/Container.scss
@@ -18,6 +18,40 @@
     // affordance hover) that must read faster than panel movement. Same governance: call sites
     // read the token, the motion-standards vocabulary owns the value through the indirection.
     --dock-transition-duration-fast: var(--motion-fast, 120ms);
+
+    // ── Splitter affordance floor ────────────────────────────────────────────────────────
+    // The engine's duty here is DISCOVERABILITY; aesthetics are the consumer's. A host that
+    // sets nothing must still get a findable drag target — an invisible splitter is the
+    // reported defect this floor exists to answer, not a neutral starting point.
+    //
+    // Values resolve through `currentColor` on purpose: the engine cannot know a host's
+    // palette, and a literal grey would be a guess that reads wrong on half of them. Mixing
+    // against inherited ink gives a modest band on any ground.
+    //
+    // What is deliberately NOT here: the pill ring and the outer glow. Those are consumer
+    // SIGNAL language — they were born reading an app's accent token — so they ship as
+    // `none` and an app re-adds them by value. Putting them in the floor would push one
+    // app's identity onto every other consumer, which is this promotion's own defect
+    // pointed the other way.
+    --dock-splitter-background       : color-mix(in srgb, currentColor 9%, transparent);
+    --dock-splitter-background-hover : color-mix(in srgb, currentColor 16%, transparent);
+    --dock-splitter-background-active: color-mix(in srgb, currentColor 26%, transparent);
+    --dock-splitter-radius           : 999px;
+
+    // The grab handle. `size` is the long axis, `thickness` the short one; the axis classes
+    // map them so one pair of tokens serves both orientations. A consumer opts OUT of the
+    // handle with `--dock-splitter-handle-size: 0` — an explicit design statement that greps,
+    // rather than an absence that reads as an oversight.
+    --dock-splitter-handle-size      : 36px;
+    --dock-splitter-handle-thickness : 2px;
+    --dock-splitter-handle-color     : color-mix(in srgb, currentColor 45%, transparent);
+    --dock-splitter-handle-color-hover: currentColor;
+
+    // Identity slots, empty by default. An app fills them; the engine never does.
+    --dock-splitter-ring             : none;
+    --dock-splitter-ring-hover       : none;
+    --dock-splitter-ring-active      : none;
+    --dock-splitter-handle-glow-hover: none;
 }
 
 @media (prefers-reduced-motion: reduce) {
@@ -111,10 +145,21 @@
 }
 
 .neo-dashboard-dock-splitter {
-    flex-shrink: 0;
-    position     : relative;
-    touch-action : none;
-    z-index      : 2;
+    // Structure, then the affordance floor. Declarations stay ABOVE the nested rules: Sass
+    // emits trailing declarations as a second same-selector block, which is valid, invisible
+    // in behaviour and confusing to read in the built output.
+    flex-shrink     : 0;
+    position        : relative;
+    touch-action    : none;
+    z-index         : 2;
+
+    // Every value reads a token, so a consumer skins by overriding and never by re-declaring —
+    // and a consumer that overrides nothing still gets something it can see and aim at.
+    background-color: var(--dock-splitter-background);
+    border-radius   : var(--dock-splitter-radius);
+    box-shadow      : var(--dock-splitter-ring);
+    transition      : background-color var(--dock-transition-duration-fast) var(--dock-transition-easing),
+                      box-shadow var(--dock-transition-duration-fast) var(--dock-transition-easing);
 
     // The visible handle stays `size`-thin while its hit target expands past the rail:
     // a near-handle miss used to fall through into a text-selection sweep across the
@@ -132,6 +177,51 @@
 
     &.neo-dashboard-dock-splitter-vertical::before {
         margin: -4px 0;
+    }
+
+
+    // The grab handle: a centred bar on the long axis. Sized entirely from tokens so
+    // `--dock-splitter-handle-size: 0` collapses it without the consumer touching this rule.
+    &::after {
+        background   : var(--dock-splitter-handle-color);
+        border-radius: var(--dock-splitter-radius);
+        content      : '';
+        left         : 50%;
+        position     : absolute;
+        top          : 50%;
+        transform    : translate(-50%, -50%);
+        transition   : background var(--dock-transition-duration-fast) var(--dock-transition-easing),
+                       box-shadow var(--dock-transition-duration-fast) var(--dock-transition-easing);
+    }
+
+    &.neo-dashboard-dock-splitter-horizontal::after {
+        height: var(--dock-splitter-handle-size);
+        width : var(--dock-splitter-handle-thickness);
+    }
+
+    &.neo-dashboard-dock-splitter-vertical::after {
+        height: var(--dock-splitter-handle-thickness);
+        width : var(--dock-splitter-handle-size);
+    }
+
+    &:hover {
+        background-color: var(--dock-splitter-background-hover);
+        box-shadow      : var(--dock-splitter-ring-hover);
+
+        &::after {
+            background: var(--dock-splitter-handle-color-hover);
+            box-shadow: var(--dock-splitter-handle-glow-hover);
+        }
+    }
+
+    // No `!important` here, and that is deliberate. The workstation layer carried
+    // `opacity: 1 !important` on this state, which means a competing rule was being fought
+    // rather than resolved. The engine owns this selector at its own specificity, so the
+    // conflict does not exist at this layer — carrying the escape hatch across would have
+    // laundered a specificity defect into the engine under a no-visual-change banner.
+    &:active {
+        background-color: var(--dock-splitter-background-active);
+        box-shadow      : var(--dock-splitter-ring-active);
     }
 }
 

--- a/test/playwright/component/apps/dock-splitter/app.mjs
+++ b/test/playwright/component/apps/dock-splitter/app.mjs
@@ -1,0 +1,20 @@
+import Viewport from '../../../../../src/container/Viewport.mjs';
+
+/**
+ * A viewport pinned to the NEO themes.
+ *
+ * `empty-viewport` inherits `DefaultConfig.themes`, which is
+ * `['neo-theme-light', 'neo-theme-dark', 'neo-theme-neo-light']` — the legacy pair plus one neo
+ * theme. Pinning both neo themes here keeps the witness measuring the documents the dock actually
+ * ships into, rather than a legacy one where half the variables the engine floor mixes against were
+ * never loaded.
+ *
+ * @see test/playwright/component/dashboard/DockSplitterPaint.spec.mjs
+ */
+export const onStart = () => Neo.app({
+    mainView: {
+        module: Viewport,
+        id    : 'dock-splitter-test-viewport'
+    },
+    name: 'DockSplitterTestApp'
+});

--- a/test/playwright/component/apps/dock-splitter/index.html
+++ b/test/playwright/component/apps/dock-splitter/index.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Neo.mjs Component Test App</title>
+</head>
+<body>
+    <script src="../../../../../src/MicroLoader.mjs" type="module"></script>
+</body>
+</html>

--- a/test/playwright/component/apps/dock-splitter/neo-config.json
+++ b/test/playwright/component/apps/dock-splitter/neo-config.json
@@ -1,0 +1,7 @@
+{
+    "appPath"    : "test/playwright/component/apps/dock-splitter/app.mjs",
+    "basePath"   : "../../../../../",
+    "environment": "development",
+    "mainPath"   : "./Main.mjs",
+    "themes"     : ["neo-theme-neo-dark", "neo-theme-neo-light"]
+}

--- a/test/playwright/component/dashboard/DockSplitterPaint.spec.mjs
+++ b/test/playwright/component/dashboard/DockSplitterPaint.spec.mjs
@@ -217,7 +217,8 @@ test.describe('Neo.dashboard.DockSplitter — the rendered affordance floor', ()
     }];
 
     /** Resting, hover and active readings of the band and its handle, under one app identity. */
-    const measureStates = async (page, {rootCls, hrefs}) => {
+    /** Freezes transitions, links the given stylesheets, and wears the app's root class. */
+    const loadStylesheets = async (page, {rootCls, hrefs}) => {
         await page.evaluate(async ({rootCls, hrefs}) => {
             const freeze = document.createElement('style');
 
@@ -241,7 +242,11 @@ test.describe('Neo.dashboard.DockSplitter — the rendered affordance floor', ()
             }
 
             document.querySelector('.neo-dashboard').classList.add(rootCls)
-        }, {rootCls, hrefs});
+        }, {rootCls, hrefs})
+    };
+
+    const measureStates = async (page, identity) => {
+        await loadStylesheets(page, identity);
 
         const read = () => page.evaluate(() => {
             const el = document.querySelector('.neo-dashboard-dock-splitter');
@@ -348,6 +353,125 @@ test.describe('Neo.dashboard.DockSplitter — the rendered affordance floor', ()
         }
     }
 
+    /**
+     * The workstation's paint as `Workspace.scss` declared it BEFORE the promotion, verbatim from
+     * `git show origin/dev:resources/scss/src/apps/workstation/Workspace.scss`.
+     *
+     * This is what "values meant to stay unchanged" means concretely. Every entry was a direct
+     * declaration on an app-owned rule; each is now a token value the engine consumes. Comparing
+     * the rendered result against these EXPRESSIONS — resolved in the same document, so
+     * `--workstation-signal` means the same thing on both sides — is a real before/after test,
+     * not a restatement of the current stylesheet.
+     */
+    const PRE_PROMOTION_WORKSTATION = {
+        active: {
+            band  : 'color-mix(in srgb, var(--workstation-signal) 30%, transparent)',
+            handle: 'var(--workstation-signal)',
+            ring  : 'inset 0 0 0 1px var(--workstation-signal), 0 0 12px color-mix(in srgb, var(--workstation-signal) 32%, transparent)'
+        },
+        hover: {
+            band  : 'color-mix(in srgb, var(--workstation-signal) 18%, transparent)',
+            handle: 'color-mix(in srgb, var(--workstation-signal) 78%, var(--workstation-ink))',
+            ring  : 'inset 0 0 0 1px color-mix(in srgb, var(--workstation-signal) 38%, transparent)'
+        },
+        resting: {
+            band  : 'color-mix(in srgb, var(--workstation-signal) 9%, transparent)',
+            handle: 'color-mix(in srgb, var(--workstation-signal) 42%, var(--workstation-line))',
+            ring  : 'inset 0 0 0 1px color-mix(in srgb, var(--workstation-signal) 18%, transparent)'
+        }
+    };
+
+    for (const theme of THEMES) {
+        test(`workstation paint is UNCHANGED against its pre-promotion declarations — ${theme}`, async ({page}) => {
+            await applyTheme(page, theme);
+            await loadStylesheets(page, {
+                hrefs  : [APP_IDENTITIES[0].tokens(theme), APP_IDENTITIES[0].rule],
+                rootCls: APP_IDENTITIES[0].rootCls
+            });
+
+            const box = await page.locator('.neo-dashboard-dock-splitter').boundingBox();
+
+            /**
+             * Reads the splitter's paint, and — in the SAME document and scope — resolves the
+             * pre-promotion expressions through a probe element.
+             *
+             * Resolving them here rather than hard-coding hex is what makes this a comparison
+             * rather than a transcription: the probe evaluates the old expression against the live
+             * palette, so a theme whose `--workstation-signal` changed would move BOTH sides and the
+             * arm would keep testing the relationship instead of a frozen colour.
+             */
+            const read = state => page.evaluate(expected => {
+                const el    = document.querySelector('.neo-dashboard-dock-splitter'),
+                      probe = document.createElement('div');
+
+                // Inside the scoped subtree, or `--workstation-signal` is undefined and every
+                // expression collapses to the same invalid value on both sides — which would make
+                // the arm pass by matching nothing against nothing.
+                el.parentElement.appendChild(probe);
+
+                // camelCase assignment, not `setProperty`, which expects the kebab-case name and
+                // silently ignores `backgroundColor` — a no-op there would leave the probe reading
+                // its inherited value and the comparison would be against the wrong thing entirely.
+                const resolve = (property, value) => {
+                    probe.style[property] = value;
+
+                    const resolved = getComputedStyle(probe)[property];
+
+                    probe.style[property] = '';
+
+                    return resolved
+                };
+
+                const result = {
+                    actual: {
+                        band  : getComputedStyle(el).backgroundColor,
+                        handle: getComputedStyle(el, '::after').backgroundColor,
+                        ring  : getComputedStyle(el).boxShadow
+                    },
+                    expected: {
+                        band  : resolve('backgroundColor', expected.band),
+                        handle: resolve('backgroundColor', expected.handle),
+                        ring  : resolve('boxShadow', expected.ring)
+                    },
+                    isActive: el.matches(':active'),
+                    isHover : el.matches(':hover')
+                };
+
+                probe.remove();
+
+                return result
+            }, PRE_PROMOTION_WORKSTATION[state]);
+
+            await page.mouse.move(box.x + box.width + 100, box.y + box.height / 2);
+
+            const resting = await read('resting');
+
+            await page.mouse.move(box.x + box.width / 2, box.y + box.height / 2);
+
+            const hover = await read('hover');
+
+            await page.mouse.down();
+
+            const active = await read('active');
+
+            await page.mouse.up();
+
+            expect(resting.isHover, 'precondition: resting is measured outside the element').toBe(false);
+            expect(hover.isHover, 'precondition: the pointer is over the splitter').toBe(true);
+            expect(active.isActive, 'precondition: the pointer press registers').toBe(true);
+
+            for (const [state, reading] of Object.entries({resting, hover, active})) {
+                expect(reading.actual, `${state} paint matches what Workspace.scss used to declare`)
+                    .toEqual(reading.expected);
+
+                // Non-vacuity: an unresolvable expression computes to the same empty-ish value on
+                // both sides, so equality alone could be two nothings matching.
+                expect(reading.expected.band, `${state} expectation actually resolved to a colour`)
+                    .toMatch(/^(rgb|color)/)
+            }
+        })
+    }
+
     test('the flat opt-out collapses the handle and keeps the band', async ({page}) => {
         await applyTheme(page, 'neo-theme-neo-light');
 
@@ -381,5 +505,78 @@ test.describe('Neo.dashboard.DockSplitter — the rendered affordance floor', ()
         expect(measured.after.handle, 'the opt-out collapses the handle').toBe('0px');
         expect(measured.after.band, 'and the band survives it — flat is not invisible')
             .toBe(measured.before.band)
+    })
+});
+
+/**
+ * The NAMED consumer, driven as a page rather than as classes.
+ *
+ * The suite above mounts `Neo.dashboard.Container` + `DockSplitter` directly, which is the right
+ * instrument for token mechanics but leaves one question open: the close target names
+ * `examples/dashboard/dock` specifically, because that is the app the invisible-splitter defect was
+ * reported against. A witness that assembles its own consumer cannot answer whether THAT page got
+ * fixed — it can only show the parts work when someone wires them correctly.
+ *
+ * The example needs no interaction: its initial dock document commits two splits, so both splitter
+ * orientations render on load. And it sets no `themes` in its config, so it boots under the LEGACY
+ * `neo-theme-light` — which makes this the strongest available statement of the floor. A consumer
+ * that opted into nothing, not even a neo theme, still gets a findable drag target.
+ */
+test.describe('examples/dashboard/dock — the consumer the defect was reported against', () => {
+    test('gets a visible splitter with no app tokens at all', async ({page}) => {
+        await page.goto('examples/dashboard/dock/index.html');
+        await page.waitForSelector('.neo-dashboard-dock-splitter', {state: 'attached'});
+
+        const measured = await page.evaluate(() => {
+            const splitters = [...document.querySelectorAll('.neo-dashboard-dock-splitter')],
+                  control   = document.createElement('div');
+
+            document.body.appendChild(control);
+
+            const read = el => ({
+                band       : getComputedStyle(el).backgroundColor,
+                handleBg   : getComputedStyle(el, '::after').backgroundColor,
+                handleShort: getComputedStyle(el, '::after').width,
+                handleLong : getComputedStyle(el, '::after').height,
+                horizontal : el.classList.contains('neo-dashboard-dock-splitter-horizontal')
+            });
+
+            const result = {
+                controlBackground: getComputedStyle(control).backgroundColor,
+                splitters        : splitters.map(read),
+                theme            : document.body.className,
+                // The app declares no splitter token anywhere; if it ever did, this arm would be
+                // measuring an app override while claiming to measure the engine floor.
+                appSetsTokens    : splitters.some(el =>
+                    ['--dock-splitter-background', '--dock-splitter-handle-color']
+                        .some(name => getComputedStyle(el).getPropertyValue(name).includes('workstation')))
+            };
+
+            control.remove();
+
+            return result
+        });
+
+        expect(measured.splitters.length, 'the example commits two splits, so both orientations render')
+            .toBe(2);
+        expect(measured.theme, 'and it boots under the legacy theme it never opted out of')
+            .toContain('neo-theme-light');
+        expect(measured.appSetsTokens, 'precondition: no app override is in play').toBe(false);
+
+        for (const splitter of measured.splitters) {
+            expect(splitter.band, 'the band is painted, not transparent')
+                .not.toBe(measured.controlBackground);
+            expect(splitter.handleBg, 'and so is the handle').not.toBe('rgba(0, 0, 0, 0)');
+
+            // Exact token-derived geometry, per orientation. "Non-zero" would also pass on a
+            // stylesheet that failed to load and left the pseudo-element at its `auto` default —
+            // which is exactly what this page rendered before the promotion.
+            const [long, short] = splitter.horizontal
+                ? [splitter.handleLong, splitter.handleShort]
+                : [splitter.handleShort, splitter.handleLong];
+
+            expect(long, 'the handle long axis is --dock-splitter-handle-size').toBe('36px');
+            expect(short, 'the short axis is --dock-splitter-handle-thickness').toBe('2px')
+        }
     })
 });

--- a/test/playwright/component/dashboard/DockSplitterPaint.spec.mjs
+++ b/test/playwright/component/dashboard/DockSplitterPaint.spec.mjs
@@ -191,6 +191,163 @@ test.describe('Neo.dashboard.DockSplitter — the rendered affordance floor', ()
             .not.toBe(withToken.handle)
     });
 
+    /**
+     * The two real consuming apps, loaded as the COMPILED stylesheets they ship as.
+     *
+     * The synthetic-token arm above proves the engine consumes the token. It cannot prove that
+     * either app's own rule reaches it, because a rule written in the spec is a rule nobody ships.
+     * These link `dist/**\/css/**` — the same artifacts Neo itself loads at runtime — and wear the
+     * app's real root class, so what is measured is the shipped cascade.
+     */
+    const APP_IDENTITIES = [{
+        name   : 'workstation',
+        rootCls: 'workstation-workspace',
+        rule   : '/dist/development/css/src/apps/workstation/Workspace.css',
+        // The palette the rule's values REFERENCE, and it is theme-scoped: `--workstation-signal`
+        // is declared under `:root .neo-theme-neo-*`, not in the app rule. Without it every
+        // `color-mix(… var(--workstation-signal) …)` is an invalid substitution and the band
+        // computes to transparent — which is how the first version of this arm failed, and why
+        // loading the rule alone would have measured a document the app never ships.
+        tokens   : theme => `/dist/development/css/${theme.replace('neo-theme-', 'theme-')}/apps/workstation/Viewport.css`
+    }, {
+        name   : 'FM',
+        rootCls: 'fm-fleet-cockpit',
+        rule   : '/dist/development/css/src/apps/agentos/fleet/FleetCockpit.css',
+        tokens : theme => `/dist/development/css/${theme.replace('neo-theme-', 'theme-')}/apps/agentos/Viewport.css`
+    }];
+
+    /** Resting, hover and active readings of the band and its handle, under one app identity. */
+    const measureStates = async (page, {rootCls, hrefs}) => {
+        await page.evaluate(async ({rootCls, hrefs}) => {
+            const freeze = document.createElement('style');
+
+            freeze.textContent = '*, *::after, *::before { transition: none !important }';
+            document.head.appendChild(freeze);
+
+            for (const href of hrefs) {
+                const link = document.createElement('link');
+
+                link.rel  = 'stylesheet';
+                link.href = href;
+
+                // A missing artifact must be a loud red here. Silently skipping it would leave the
+                // app's tokens undefined and the arm would then measure the ENGINE floor while
+                // reporting on the app.
+                await new Promise((resolve, reject) => {
+                    link.onload  = resolve;
+                    link.onerror = () => reject(new Error(`stylesheet did not load: ${href}`));
+                    document.head.appendChild(link)
+                })
+            }
+
+            document.querySelector('.neo-dashboard').classList.add(rootCls)
+        }, {rootCls, hrefs});
+
+        const read = () => page.evaluate(() => {
+            const el = document.querySelector('.neo-dashboard-dock-splitter');
+
+            return {
+                band       : getComputedStyle(el).backgroundColor,
+                handle     : getComputedStyle(el, '::after').backgroundColor,
+                handleSize : getComputedStyle(el, '::after').height,
+                isActive   : el.matches(':active'),
+                isHover    : el.matches(':hover'),
+                signalToken: resolveColor(getComputedStyle(el).getPropertyValue('--workstation-signal').trim())
+            };
+
+            /**
+             * The browser's own serialisation of a colour, so a comparison is apples-to-apples.
+             *
+             * A custom property's value comes back verbatim — `#0f766e` — while `backgroundColor`
+             * comes back as `rgb(15, 118, 110)`. String-comparing those two reports a parity
+             * FAILURE on identical colours, which is a false red as misleading as a false green.
+             */
+            function resolveColor(value) {
+                if (!value) return '';
+
+                const probe = document.createElement('div');
+
+                probe.style.color = value;
+                document.body.appendChild(probe);
+
+                const resolved = getComputedStyle(probe).color;
+
+                probe.remove();
+
+                return resolved
+            }
+        });
+
+        const box = await page.locator('.neo-dashboard-dock-splitter').boundingBox();
+
+        // Derived from the box, never a fixed corner. The splitter renders at (0, 0) at 6x720, so
+        // parking the pointer at the origin leaves it INSIDE the element — the first version of
+        // this arm read `resting` while hovering, and only FM's identical hover/active values made
+        // that visible. `isHover` is asserted below so the same mistake cannot return silently.
+        await page.mouse.move(box.x + box.width + 100, box.y + box.height / 2);
+
+        const resting = await read();
+
+        await page.mouse.move(box.x + box.width / 2, box.y + box.height / 2);
+
+        const hover = await read();
+
+        await page.mouse.down();
+
+        const active = await read();
+
+        await page.mouse.up();
+
+        return {active, hover, resting}
+    };
+
+    for (const identity of APP_IDENTITIES) {
+        for (const theme of THEMES) {
+            test(`${identity.name} identity reaches all three states through tokens — ${theme}`, async ({page}) => {
+                await applyTheme(page, theme);
+
+                const {resting, hover, active} = await measureStates(page, {
+                    hrefs  : [identity.tokens(theme), identity.rule],
+                    rootCls: identity.rootCls
+                });
+
+                // Non-vacuity first, and all three states, because each comparison below is a
+                // comparison of one reading with itself if the pointer state was not what the name
+                // says. Reading `resting` while hovering is not hypothetical — it happened here.
+                expect(resting.isHover, 'precondition: resting must be measured OUTSIDE the element').toBe(false);
+                expect(hover.isHover, 'precondition: the pointer must actually be over the splitter').toBe(true);
+                expect(active.isActive, 'precondition: the pointer press must put it in :active').toBe(true);
+
+                // The state ladder is live at the boundary both apps agree on. Only workstation
+                // declares three DISTINCT band values; FM deliberately gives hover and active the
+                // same `--fm-signal 45%`, so asserting a three-step ladder for it would be
+                // asserting a design it does not have.
+                expect(resting.band, 'the app identity separates resting from hover').not.toBe(hover.band);
+
+                identity.name === 'workstation'
+                    // PARITY, on the one value this PR moved. Before the promotion Workspace.scss
+                    // painted `&:active::after { background: var(--workstation-signal) }` directly.
+                    // The active handle must still compute to exactly that colour — now arriving
+                    // through `--dock-splitter-handle-color-active` instead of an app paint rule.
+                    ? (
+                        expect(active.handle, 'the active handle still resolves to --workstation-signal')
+                            .toBe(resting.signalToken),
+                        expect(hover.band, 'and workstation does declare a distinct active band')
+                            .not.toBe(active.band)
+                    )
+                    // FM's opt-out, from its real shipped rule rather than a spec-authored one.
+                    : expect(active.handleSize, 'FM ships flat — the handle is collapsed by token')
+                        .toBe('0px');
+
+                // And the affordance survives either identity: a band a user can see, in every state.
+                for (const [state, reading] of Object.entries({resting, hover, active})) {
+                    expect(reading.band, `the ${state} band stays visible under ${identity.name}`)
+                        .not.toBe('rgba(0, 0, 0, 0)')
+                }
+            })
+        }
+    }
+
     test('the flat opt-out collapses the handle and keeps the band', async ({page}) => {
         await applyTheme(page, 'neo-theme-neo-light');
 

--- a/test/playwright/component/dashboard/DockSplitterPaint.spec.mjs
+++ b/test/playwright/component/dashboard/DockSplitterPaint.spec.mjs
@@ -1,0 +1,228 @@
+import {test, expect} from '@playwright/test';
+
+/**
+ * The splitter's affordance, measured on a rendered splitter rather than on stylesheet text.
+ *
+ * The sibling `dockSplitterLayering.spec.mjs` censuses SCSS source: it proves no application
+ * stylesheet paints a splitter and that the engine's identity slots ship empty. That is the
+ * ownership question. It cannot answer the one this ticket is actually about — whether a consumer
+ * that sets nothing gets a *findable* drag target — because a source guard sees declarations, not
+ * resolved values, and the reported defect was a splitter whose declarations all existed and
+ * resolved to nothing a user could see.
+ *
+ * **The controls are the point.** Every arm asserts an exact token-derived value (`36px`, `2px`)
+ * rather than "not zero", and pairs each measurement with a probe that must move when the token
+ * moves. A stylesheet that failed to load cannot produce 36px by accident, and a value identical
+ * before and after an override proves the override never arrived — which is the shape a
+ * comfortable green takes here.
+ *
+ * @see https://github.com/neomjs/neo/issues/17538
+ */
+
+const THEMES = ['neo-theme-neo-dark', 'neo-theme-neo-light'];
+
+let dashboardId, splitterId;
+
+test.beforeEach(async ({page}) => {
+    await page.goto('test/playwright/component/apps/dock-splitter/index.html');
+    await page.waitForSelector('#dock-splitter-test-viewport', {state: 'attached'});
+
+    const ids = await page.evaluate(async () => {
+        // The REAL dashboard container, not a plain one wearing `.neo-dashboard`. Neo loads a
+        // class's stylesheet when the class is instantiated, so faking the ancestor class leaves
+        // `src/dashboard/Container.css` — the file carrying every rule under test — out of the
+        // document entirely, and each arm below then measures an unstyled div.
+        const dashboard = await Neo.worker.App.createNeoInstance({
+            importPath: '../dashboard/Container.mjs',
+            // `createNeoInstance` imports the module but resolves the class through the ntype
+            // registry — a config without one reaches `parent.add()` with nothing to construct.
+            ntype   : 'dashboard',
+            parentId: 'dock-splitter-test-viewport'
+        });
+
+        if (!dashboard.success) throw new Error(`dashboard: ${dashboard.error.message}`);
+
+        const splitter = await Neo.worker.App.createNeoInstance({
+            importPath : '../dashboard/DockSplitter.mjs',
+            ntype      : 'dashboard-dock-splitter',
+            orientation: 'horizontal',
+            parentId   : dashboard.id
+        });
+
+        if (!splitter.success) throw new Error(`splitter: ${splitter.error.message}`);
+
+        return {dashboardId: dashboard.id, splitterId: splitter.id}
+    });
+
+    ({dashboardId, splitterId} = ids);
+
+    await page.waitForSelector('.neo-dashboard-dock-splitter', {state: 'attached'})
+});
+
+test.afterEach(async ({page}) => {
+    await page.evaluate(async ids => {
+        for (const id of ids) id && await Neo.worker.App.destroyNeoInstance(id)
+    }, [splitterId, dashboardId])
+});
+
+/** Swap the active theme class on the document element and read back what took effect. */
+const applyTheme = (page, theme) => page.evaluate(name => {
+    for (const el of [document.body, document.documentElement]) {
+        el.classList.forEach(c => c.startsWith('neo-theme-') && el.classList.remove(c))
+    }
+
+    document.body.classList.add(name);
+
+    return document.body.className
+}, theme);
+
+test.describe('Neo.dashboard.DockSplitter — the rendered affordance floor', () => {
+    for (const theme of THEMES) {
+        test(`a consumer that sets NO tokens gets a findable splitter — ${theme}`, async ({page}) => {
+            await applyTheme(page, theme);
+
+            const measured = await page.evaluate(() => {
+                const splitter = document.querySelector('.neo-dashboard-dock-splitter'),
+                      band     = getComputedStyle(splitter),
+                      handle   = getComputedStyle(splitter, '::after');
+
+                // A plain div in the same document and theme, with no dock class. It fixes what
+                // "unpainted" computes to here, so the band's value is read against a real zero
+                // rather than an assumption about how this browser serialises transparency.
+                const control = document.createElement('div');
+
+                document.body.appendChild(control);
+
+                const result = {
+                    bandBackground   : band.backgroundColor,
+                    controlBackground: getComputedStyle(control).backgroundColor,
+                    handleBackground : handle.backgroundColor,
+                    handleContent    : handle.content,
+                    handleHeight     : handle.height,
+                    handleWidth      : handle.width
+                };
+
+                control.remove();
+
+                return result
+            });
+
+            // The invisible-splitter defect stated as a measurement: before the promotion the engine
+            // declared no paint at all, so this value WAS the control's value.
+            expect(measured.bandBackground,
+                'the engine floor must paint a band a consumer can see')
+                .not.toBe(measured.controlBackground);
+
+            // The handle exists as a real box, at exactly the token defaults. Asserting the exact
+            // 36/2 pair rather than "non-zero" is what makes an unloaded stylesheet impossible to
+            // mistake for a pass — nothing else in the document produces that pair.
+            expect(measured.handleContent, 'the grab handle is rendered').toBe('""');
+            expect(measured.handleHeight, 'the long axis is --dock-splitter-handle-size').toBe('36px');
+            expect(measured.handleWidth, 'the short axis is --dock-splitter-handle-thickness').toBe('2px');
+            expect(measured.handleBackground,
+                'and the handle is painted, not merely present').not.toBe('rgba(0, 0, 0, 0)')
+        })
+    }
+
+    test('the ACTIVE handle colour comes from the engine token an app sets', async ({page}) => {
+        await applyTheme(page, 'neo-theme-neo-dark');
+
+        // The rendered half of RA-2. Before this change the engine had `--dock-splitter-handle-color`
+        // and `-hover` but no `-active`, so an app wanting a distinct drag colour had nowhere to put
+        // it except `&:active::after { background: ... }` in its own stylesheet — precisely the
+        // app-layer paint this promotion exists to end. If the engine consumer is missing, the token
+        // has no effect and `withToken` below equals `withoutToken`.
+        await page.evaluate(() => {
+            // The engine rule TRANSITIONS `background`. Reading straight after a state change
+            // returns the start value and a frame later returns a blend — both green-looking wrong
+            // answers, and a fixed sleep would only make the flake slower.
+            const freeze = document.createElement('style');
+
+            freeze.id          = 'freeze-transitions';
+            freeze.textContent = '*, *::after, *::before { transition: none !important }';
+            document.head.appendChild(freeze)
+        });
+
+        const box = await page.locator('.neo-dashboard-dock-splitter').boundingBox();
+
+        const activeHandle = async () => {
+            await page.mouse.move(box.x + box.width / 2, box.y + box.height / 2);
+            await page.mouse.down();
+
+            const value = await page.evaluate(() => {
+                const el = document.querySelector('.neo-dashboard-dock-splitter');
+
+                return {
+                    handle  : getComputedStyle(el, '::after').backgroundColor,
+                    isActive: el.matches(':active')
+                }
+            });
+
+            await page.mouse.up();
+
+            return value
+        };
+
+        const withoutToken = await activeHandle();
+
+        // Shaped the way a consuming app writes one: the token lands on the SPLITTER's own selector
+        // under an app-root class, which is what `Workspace.scss` and `FleetCockpit.scss` both do.
+        // Setting it on an ancestor instead would test a mechanism no app uses — and would not even
+        // work, because the engine re-declares its token defaults on every `.neo-dashboard`.
+        await page.evaluate(() => {
+            const style = document.createElement('style');
+
+            style.textContent =
+                '.test-app-a .neo-dashboard-dock-splitter { --dock-splitter-handle-color-active: rgb(255, 0, 0) }';
+            document.head.appendChild(style);
+            document.querySelector('.neo-dashboard').classList.add('test-app-a')
+        });
+
+        const withToken = await activeHandle();
+
+        // Precondition: without a live `:active` both reads return the resting value for a reason
+        // that has nothing to do with the token, and the comparison below is vacuous.
+        expect(withoutToken.isActive, 'precondition: the pointer press must put the splitter in :active').toBe(true);
+        expect(withToken.isActive, 'precondition: and again for the second read').toBe(true);
+
+        expect(withToken.handle, 'the app token must reach the active handle').toBe('rgb(255, 0, 0)');
+        expect(withoutToken.handle,
+            'and the engine floor must differ from it — equal values would mean the token never arrived')
+            .not.toBe(withToken.handle)
+    });
+
+    test('the flat opt-out collapses the handle and keeps the band', async ({page}) => {
+        await applyTheme(page, 'neo-theme-neo-light');
+
+        // `--dock-splitter-handle-size: 0` is a design statement that greps, not an omission. It
+        // must remove the HANDLE without removing the affordance: a consumer opting out of the grip
+        // still gets a visible band, or the opt-out would silently re-ship the invisible-splitter
+        // defect this floor exists to end.
+        const measured = await page.evaluate(() => {
+            const splitter = document.querySelector('.neo-dashboard-dock-splitter'),
+                  read     = () => ({
+                      band  : getComputedStyle(splitter).backgroundColor,
+                      handle: getComputedStyle(splitter, '::after').height
+                  });
+
+            const before = read(),
+                  style  = document.createElement('style');
+
+            style.textContent =
+                '.test-app-fm .neo-dashboard-dock-splitter { --dock-splitter-handle-size: 0 }';
+            document.head.appendChild(style);
+            document.querySelector('.neo-dashboard').classList.add('test-app-fm');
+
+            const after = read();
+
+            style.remove();
+
+            return {before, after}
+        });
+
+        expect(measured.before.handle, 'precondition: the handle was there to opt out of').toBe('36px');
+        expect(measured.after.handle, 'the opt-out collapses the handle').toBe('0px');
+        expect(measured.after.band, 'and the band survives it — flat is not invisible')
+            .toBe(measured.before.band)
+    })
+});

--- a/test/playwright/unit/buildScripts/dockSplitterLayering.spec.mjs
+++ b/test/playwright/unit/buildScripts/dockSplitterLayering.spec.mjs
@@ -1,0 +1,143 @@
+import {test, expect}              from '@playwright/test';
+import {readFileSync, readdirSync} from 'node:fs';
+import {join}                      from 'node:path';
+
+/**
+ * The layering invariant for the dock splitter: the ENGINE ships a discoverable affordance, apps
+ * supply identity values.
+ *
+ * The splitter is the sharper half of the dock promotion. The engine previously had **no paint** —
+ * `flex-shrink`, `position`, `touch-action`, `z-index` and a hit-target `::before` — so both apps
+ * owned the entire visual language and a consumer that adopted the dock got an *invisible* drag
+ * target. That is a reported defect, not a neutral default, and it is why the engine's floor here
+ * is discoverability rather than blankness.
+ *
+ * Three layers, and the middle one is the whole design: structure (engine, untokened) → affordance
+ * floor (engine token DEFAULTS) → identity (app token values). The pill ring and outer glow live in
+ * the third, not the second: they were born reading an app's accent token, so shipping them as the
+ * engine default would push one consumer's identity onto every other.
+ *
+ * Asserted on SCSS source so the guard holds without a build step.
+ *
+ * @see https://github.com/neomjs/neo/issues/17241
+ */
+test.describe('dock splitter — the engine ships the affordance, apps set identity', () => {
+    const
+        APP_SCSS_ROOT = 'resources/scss/src/apps',
+        ENGINE_RULE   = 'resources/scss/src/dashboard/Container.scss',
+        // `padding` and per-axis geometry are absent on purpose: rail orientation is an app concern.
+        SPLITTER_PAINT = ['background', 'background-color', 'border-radius', 'box-shadow', 'opacity'];
+
+    const scssFiles = (dir, out = []) => {
+        for (const entry of readdirSync(dir, {withFileTypes: true})) {
+            const path = join(dir, entry.name);
+
+            entry.isDirectory() ? scssFiles(path, out) : entry.name.endsWith('.scss') && out.push(path)
+        }
+
+        return out
+    };
+
+    /**
+     * Declarations belonging to a splitter block itself, excluding nested descendant blocks.
+     *
+     * A depth scan rather than a regex: `/[^{}]*\{[^{}]*\}/` looks equivalent and swallows the
+     * declarations PRECEDING a nested block, so a `background` sitting above an `&:hover { … }`
+     * disappears before inspection — a guard written that way passes its own mutation.
+     */
+    const splitterOwnDeclarations = source => {
+        const found = [];
+
+        for (const match of source.matchAll(/([^\n{}]*neo-dashboard-dock-splitter[^\n{}]*)\{/g)) {
+            let depth = 1, i = match.index + match[0].length, body = '';
+
+            while (i < source.length && depth > 0) {
+                const ch = source[i];
+
+                if (ch === '{') depth++;
+                if (ch === '}') depth--;
+                if (depth > 0) body += ch;
+                i++
+            }
+
+            let own = '', d = 0;
+
+            for (const ch of body) {
+                if (ch === '{') { d++; continue }
+                if (ch === '}') { d--; continue }
+                if (d === 0) own += ch
+            }
+
+            for (const line of own.split('\n').map(entry => entry.trim())) {
+                const property = line.includes(':') ? line.split(':')[0].trim() : '';
+
+                property && found.push({selector: match[1].trim(), property})
+            }
+        }
+
+        return found
+    };
+
+    test('no application stylesheet paints a splitter — it may only set tokens', () => {
+        const offenders = [];
+
+        for (const file of scssFiles(APP_SCSS_ROOT)) {
+            for (const {selector, property} of splitterOwnDeclarations(readFileSync(file, 'utf8'))) {
+                if (!property.startsWith('--') && SPLITTER_PAINT.includes(property)) {
+                    offenders.push(`${file.replace(`${APP_SCSS_ROOT}/`, '')} → ${property} on ${selector}`)
+                }
+            }
+        }
+
+        expect(offenders, 'the splitter affordance is engine capability; apps set values').toEqual([])
+    });
+
+    test('the engine floor is DISCOVERABLE with no app tokens set', () => {
+        // The criterion option 2 failed. A consumer that overrides nothing must get a findable
+        // target, not a transparent one. `currentColor` mixes rather than a literal grey: the engine
+        // cannot know the host palette, and a guess reads wrong on half of them.
+        const engine = readFileSync(ENGINE_RULE, 'utf8');
+
+        expect(engine, 'a visible band by default')
+            .toMatch(/--dock-splitter-background\s*:\s*color-mix[^;]*currentColor/);
+        expect(engine, 'a real grab handle by default')
+            .toMatch(/--dock-splitter-handle-size\s*:\s*36px/);
+        expect(engine, 'the handle is painted by default')
+            .toMatch(/--dock-splitter-handle-color\s*:\s*color-mix[^;]*currentColor/);
+    });
+
+    test('identity slots ship EMPTY — the engine never fills them', () => {
+        // Ring and glow are consumer signal-language. Defaulting them to a value would make one
+        // app's identity every consumer's default, which is this promotion's own defect inverted.
+        const engine = readFileSync(ENGINE_RULE, 'utf8');
+
+        for (const slot of ['--dock-splitter-ring', '--dock-splitter-ring-hover',
+                            '--dock-splitter-ring-active', '--dock-splitter-handle-glow-hover']) {
+            expect(engine, `${slot} is an identity slot and must default to none`)
+                .toMatch(new RegExp(`${slot}\\s*:\\s*none`))
+        }
+    });
+
+    test('opting OUT of the handle is expressible without re-declaring the rule', () => {
+        // FM is flat by choice. `--dock-splitter-handle-size: 0` makes that a design statement that
+        // greps, instead of an absence that reads as an oversight — and it survives the engine
+        // gaining a handle, which is what just happened.
+        const fm = readFileSync('resources/scss/src/apps/agentos/fleet/FleetCockpit.scss', 'utf8');
+
+        expect(fm, 'FM declares flat rather than omitting the handle')
+            .toMatch(/--dock-splitter-handle-size\s*:\s*0/)
+    });
+
+    test('the promoted rule carries no !important', () => {
+        // The workstation active state used `opacity: 1 !important` — something was being fought.
+        // The engine owns this selector at its own specificity, so the conflict does not exist at
+        // this layer; carrying the escape hatch across would launder a specificity defect into the
+        // engine under a no-visual-change banner.
+        const engine = readFileSync(ENGINE_RULE, 'utf8')
+            .split('\n')
+            .filter(line => !line.trim().startsWith('//'))
+            .join('\n');
+
+        expect(engine, 'the engine default must never need !important').not.toContain('!important')
+    });
+});

--- a/test/playwright/unit/buildScripts/dockSplitterLayering.spec.mjs
+++ b/test/playwright/unit/buildScripts/dockSplitterLayering.spec.mjs
@@ -24,9 +24,23 @@ import {join}                      from 'node:path';
 test.describe('dock splitter — the engine ships the affordance, apps set identity', () => {
     const
         APP_SCSS_ROOT = 'resources/scss/src/apps',
-        ENGINE_RULE   = 'resources/scss/src/dashboard/Container.scss',
-        // `padding` and per-axis geometry are absent on purpose: rail orientation is an app concern.
-        SPLITTER_PAINT = ['background', 'background-color', 'border-radius', 'box-shadow', 'opacity'];
+        ENGINE_RULE   = 'resources/scss/src/dashboard/Container.scss';
+
+    /**
+     * The only non-custom properties an application may declare on a splitter surface, each with
+     * the deviation it documents.
+     *
+     * An ALLOWLIST, not a denylist, and that inversion is the point. The first version named five
+     * paint properties — `background`, `background-color`, `border-radius`, `box-shadow`,
+     * `opacity` — so `filter`, `outline`, `color` and every property nobody had thought of yet
+     * could re-enter undetected. A guard that only catches what its author enumerated cannot
+     * catch a regression; it can only confirm a memory.
+     */
+    const STRUCTURAL_DEVIATIONS = {
+        // FleetCockpit's vessel-narrow container query stacks a horizontal split, which makes the
+        // splitter's drag axis wrong — so it leaves the flow. Layout, not paint.
+        display: 'takes the splitter out of flow when its drag axis no longer applies'
+    };
 
     const scssFiles = (dir, out = []) => {
         for (const entry of readdirSync(dir, {withFileTypes: true})) {
@@ -38,58 +52,184 @@ test.describe('dock splitter — the engine ships the affordance, apps set ident
         return out
     };
 
+    const withoutComments = source => source
+        .replace(/\/\*[\s\S]*?\*\//g, '')
+        .replace(/(^|[^:])\/\/[^\n]*/g, '$1');
+
     /**
-     * Declarations belonging to a splitter block itself, excluding nested descendant blocks.
+     * The `{ selector, body }` pairs at one nesting level, brace-matched rather than regex-matched.
      *
-     * A depth scan rather than a regex: `/[^{}]*\{[^{}]*\}/` looks equivalent and swallows the
-     * declarations PRECEDING a nested block, so a `background` sitting above an `&:hover { … }`
-     * disappears before inspection — a guard written that way passes its own mutation.
+     * `/[^{}]*\{[^{}]*\}/` looks equivalent and swallows the declarations PRECEDING a nested
+     * block, so a `background` sitting above an `&:hover { … }` disappears before inspection — a
+     * guard written that way passes its own mutation.
      */
-    const splitterOwnDeclarations = source => {
-        const found = [];
+    const blocksIn = source => {
+        const blocks = [];
 
-        for (const match of source.matchAll(/([^\n{}]*neo-dashboard-dock-splitter[^\n{}]*)\{/g)) {
-            let depth = 1, i = match.index + match[0].length, body = '';
+        let i = 0, selectorStart = 0;
 
-            while (i < source.length && depth > 0) {
-                const ch = source[i];
+        while (i < source.length) {
+            const ch = source[i];
 
-                if (ch === '{') depth++;
-                if (ch === '}') depth--;
-                if (depth > 0) body += ch;
-                i++
+            if (ch === '{') {
+                let depth = 1, j = i + 1;
+
+                while (j < source.length && depth > 0) {
+                    if (source[j] === '{') depth++;
+                    if (source[j] === '}') depth--;
+                    j++
+                }
+
+                blocks.push({
+                    selector: source.slice(selectorStart, i).trim(),
+                    body    : source.slice(i + 1, j - 1),
+                    start   : selectorStart,
+                    end     : j
+                });
+
+                i = selectorStart = j;
+                continue
             }
 
-            let own = '', d = 0;
+            if (ch === '}' || ch === ';') selectorStart = i + 1;
+            i++
+        }
 
-            for (const ch of body) {
-                if (ch === '{') { d++; continue }
-                if (ch === '}') { d--; continue }
-                if (d === 0) own += ch
-            }
+        return blocks
+    };
 
-            for (const line of own.split('\n').map(entry => entry.trim())) {
-                const property = line.includes(':') ? line.split(':')[0].trim() : '';
+    /**
+     * The property names declared directly in `body`, with nested blocks excised BY INDEX.
+     *
+     * Reconstructing `selector{body}` to string-replace it does not work: the source carries
+     * whitespace between the selector and its brace, the replace silently misses, and the nested
+     * block's own text is then read as declarations of the parent.
+     *
+     * Split on `;` rather than newlines — that is the declaration separator, so a value wrapped
+     * across lines stays one declaration instead of becoming a phantom second one.
+     */
+    const declarationsOf = body => {
+        let own = '', cursor = 0;
 
-                property && found.push({selector: match[1].trim(), property})
-            }
+        for (const block of blocksIn(body)) {
+            own   += body.slice(cursor, block.start);
+            cursor = block.end
+        }
+
+        return (own + body.slice(cursor))
+            .split(';')
+            .map(chunk => chunk.split(':')[0].trim())
+            .filter(property => /^(--)?[a-z][a-z\d-]*$/i.test(property))
+    };
+
+    const isSplitterSelector = selector => selector.includes('neo-dashboard-dock-splitter');
+
+    /**
+     * A nested block that is still the SAME element: `&:hover`, `&::after`, `&:active::after`.
+     *
+     * `&:active::after` is a state of the splitter itself, not a descendant, and the first version
+     * of this census discarded every nested block wholesale — so an app could paint the handle in
+     * its active state while the "no app paint" arm stayed green. That exact shape shipped in
+     * `Workspace.scss` and CI called it clean. A part carrying a descendant combinator (whitespace,
+     * `>`, `+`, `~`) addresses a different element and correctly stays out of scope.
+     */
+    const isSelfState = selector => selector.length > 0 && selector.split(',').every(part => {
+        const trimmed = part.trim();
+
+        return trimmed.startsWith('&') && !/[\s>+~]/.test(trimmed.slice(1))
+    });
+
+    /** Every property declared on the splitter's own surface, own block and self-states alike. */
+    const surfaceDeclarations = (body, selector, found = []) => {
+        for (const property of declarationsOf(body)) found.push({selector, property});
+
+        for (const nested of blocksIn(body)) {
+            isSelfState(nested.selector) &&
+                surfaceDeclarations(nested.body, `${selector} ${nested.selector}`, found)
         }
 
         return found
     };
 
+    /** Splitter surfaces at any depth, so an at-rule or ancestor block never hides one. */
+    const splitterSurfaces = (source, found = []) => {
+        for (const {selector, body} of blocksIn(source)) {
+            isSplitterSelector(selector) ? surfaceDeclarations(body, selector, found)
+                                         : splitterSurfaces(body, found);
+        }
+
+        return found
+    };
+
+    const offendersIn = source => splitterSurfaces(withoutComments(source))
+        .filter(({property}) => !property.startsWith('--') && !(property in STRUCTURAL_DEVIATIONS))
+        .map(({selector, property}) => `${property} on ${selector}`);
+
     test('no application stylesheet paints a splitter — it may only set tokens', () => {
         const offenders = [];
 
         for (const file of scssFiles(APP_SCSS_ROOT)) {
-            for (const {selector, property} of splitterOwnDeclarations(readFileSync(file, 'utf8'))) {
-                if (!property.startsWith('--') && SPLITTER_PAINT.includes(property)) {
-                    offenders.push(`${file.replace(`${APP_SCSS_ROOT}/`, '')} → ${property} on ${selector}`)
-                }
+            for (const offender of offendersIn(readFileSync(file, 'utf8'))) {
+                offenders.push(`${file.replace(`${APP_SCSS_ROOT}/`, '')} → ${offender}`)
             }
         }
 
         expect(offenders, 'the splitter affordance is engine capability; apps set values').toEqual([])
+    });
+
+    test('the census SEES nested self-state paint — the instrument proves itself', () => {
+        // The arm above means nothing unless a violation would actually redden it. This is the
+        // exact shape @neo-gpt found live at `Workspace.scss:50` while the guard passed.
+        expect(offendersIn(`
+            .neo-dashboard-dock-splitter {
+                --dock-splitter-background: red;
+
+                &:active::after {
+                    background: var(--workstation-signal);
+                }
+            }`), 'nested active paint is app-layer paint')
+            .toEqual(['background on .neo-dashboard-dock-splitter &:active::after']);
+
+        // The paired control, without which the rule above could simply be "flag everything
+        // nested": a real descendant is a different element and stays out of scope.
+        expect(offendersIn(`
+            .neo-dashboard-dock-splitter {
+                .neo-button { background: red }
+            }`), 'a descendant element is not the splitter surface').toEqual([]);
+
+        // And a declaration sitting ABOVE a nested block still survives the walk.
+        expect(offendersIn(`
+            .neo-dashboard-dock-splitter {
+                outline: 1px solid red;
+
+                &:hover { --dock-splitter-ring: none }
+            }`), 'a declaration preceding a nested block is not swallowed')
+            .toEqual(['outline on .neo-dashboard-dock-splitter']);
+    });
+
+    test('an unlisted property is an offence even when nobody enumerated it', () => {
+        expect(offendersIn('.neo-dashboard-dock-splitter { filter: blur(2px) }'), 'filter was on no denylist')
+            .toEqual(['filter on .neo-dashboard-dock-splitter']);
+        expect(offendersIn('.neo-dashboard-dock-splitter { color: red }'), 'nor was color')
+            .toEqual(['color on .neo-dashboard-dock-splitter']);
+
+        // Custom properties are the sanctioned channel, and the one documented structural
+        // deviation stays legal — an allowlist that rejected it would just be a broken guard.
+        expect(offendersIn('.neo-dashboard-dock-splitter { --dock-splitter-radius: 0 }')).toEqual([]);
+        expect(offendersIn('.neo-dashboard-dock-splitter { display: none }')).toEqual([]);
+    });
+
+    test('a splitter nested under an at-rule is still censused', () => {
+        // FleetCockpit's real shape: the only current structural deviation lives inside a
+        // `@container` query. A census that walked only top-level blocks would never reach it —
+        // and would report the file clean whatever it contained.
+        expect(offendersIn(`
+            @container fm-cockpit (max-width: 570px) {
+                .neo-dashboard-dock-split-horizontal {
+                    > .neo-dashboard-dock-splitter-horizontal { box-shadow: none }
+                }
+            }`), 'depth does not confer immunity')
+            .toEqual(['box-shadow on > .neo-dashboard-dock-splitter-horizontal']);
     });
 
     test('the engine floor is DISCOVERABLE with no app tokens set', () => {


### PR DESCRIPTION
Resolves #17538

Related: #17241 (parent, stays open) · #17522 · #17211 · #17514

🌿 *The engine had no splitter paint at all, so a consumer who adopted the dock got an invisible drag target.*

Evidence: L1 (SCSS-source census) **+ L3** (live browser probe: the named consumer page, real compiled app stylesheets, computed styles in three pointer states) → L3 required, because the close target is a *rendered* affordance and a source guard cannot see one. Residual: named below, not "none".

## The close target moved — read this first

This PR previously declared #17241 as its close target. @neo-gpt was right that it over-closed: the head delivers the splitter half only, while #17241 additionally retains the edge/band/rail chrome, the dark-theme home decision, and its cross-cutting LOC criterion. It also made merge here depend on PR #17524, which is still open.

So #17241 is now a **two-leaf parent** — #17522 (rail) and **#17538 (splitter, this PR)** — and each leaf owns its own Contract Ledger. #17241's body records the split, the retained scope, and the taxonomy question its closeout must answer.

Three claims in the old body were false and are withdrawn rather than softened:

| withdrawn claim | what was true |
|---|---|
| "both apps emit only custom properties" | `Workspace.scss:50` painted `&:active::after { background: var(--workstation-signal) }`. **Now true** — the engine gained `--dock-splitter-handle-color-active` and the app sets a value. |
| "the rail-tab half, which landed as #17522 / PR #17524" | PR #17524 was open with `CHANGES_REQUESTED`. It is still open. Nothing here depends on it any more. |
| "Verified on **compiled** CSS" | The guard reads SCSS source and says so in its own header. There is now a real compiled/rendered instrument, and the source census is described as what it is. |

## The design, and it is not mine

@neo-fable's answer, recorded on #17241: the engine ships a **discoverable** affordance and an app opts out by token. Three layers — structure (engine, untokened) → affordance floor (engine token defaults) → identity (app token values). Ring and glow stay app-side: they were born reading `--workstation-signal`, so shipping them as the engine default would make one consumer's identity every consumer's default.

## What changed since the review

**The escaped state.** The engine had `--dock-splitter-handle-color` and `-hover` but no `-active`, so an app wanting a distinct drag colour had nowhere to put it except its own stylesheet. The token now exists, defaults to the hover value — dragging must never read as *less* engaged than hovering — and the engine's `:active` block consumes it.

**The census could not see the violation.** It discarded every nested block, and `&:active::after` is a state of the splitter *itself*, not a descendant. Green CI was positive proof of the blind spot. It now descends into self-state and pseudo blocks, skips real descendants, and walks at-rules — FM's only structural deviation lives inside a `@container` query, and a top-level-only walk would report that file clean whatever it held.

**The denylist became an allowlist.** Five paint properties were the ones someone had thought of; `filter`, `outline` and `color` were not. Every non-custom property is now an offence unless it is a documented structural deviation — currently one: FM's `display: none`.

## AC Evidence

| AC | proof |
|---|---|
| AC-1 | **`DockSplitterPaint.spec.mjs` drives `examples/dashboard/dock` as a page** — the consumer the defect was reported against. Its initial document commits two splits, so both orientations render on load, and it sets no `themes`, so it boots under the LEGACY `neo-theme-light`: a consumer that opted into nothing, not even a neo theme, still gets a painted band and a 36×2 handle. Exact token geometry per orientation, because "non-zero" also passes on a stylesheet that failed to load and left the pseudo-element at `auto` — what this page rendered before. No-app-override asserted first. Arms 1–2 additionally hold the floor on mounted engine classes in both neo themes. |
| AC-2 | `dockSplitterLayering.spec.mjs` — the floor arm pins `--dock-splitter-background` / `-handle-color` to `currentColor` mixes and `handle-size` to `36px`; the identity-slot arm pins ring, ring-hover, ring-active and glow-hover to `none`. |
| AC-3 | `dockSplitterLayering.spec.mjs` arm 1 over every `resources/scss/src/apps/**` file, with the census descending into self-state and pseudo blocks. Instrument control: a descendant stays out of scope, and a declaration *preceding* a nested block is not swallowed. |
| AC-4 | `dockSplitterLayering.spec.mjs` — `filter` and `color` are offences though no denylist named them; `--*` and the one documented `display` deviation stay legal. |
| AC-5 | `Container.scss` declares and consumes `--dock-splitter-handle-color-active`; `Workspace.scss` sets a value and declares no `background`. Rendered: `DockSplitterPaint.spec.mjs` arm 3 (app-shaped rule reaches the active handle) and the workstation identity arms (the **real** compiled `Workspace.css`). |
| AC-6 | `dockSplitterLayering.spec.mjs` greps FM's explicit `--dock-splitter-handle-size: 0`; `DockSplitterPaint.spec.mjs` measures it — the FM identity arms read `0px` from the real compiled `FleetCockpit.css`, and the opt-out arm proves the band survives it (flat is not invisible), gated on a precondition that the handle was `36px` first. |
| AC-7 | `dockSplitterLayering.spec.mjs` — no `!important` in the promoted engine rule, comments stripped before the check. The workstation's `opacity: 1 !important` is gone rather than moved: it was fighting a competing rule, and the engine owns the state at its own specificity. |
| AC-8 | Two families. **Parity**: `PRE_PROMOTION_WORKSTATION` carries the band, ring and handle declarations verbatim from `git show origin/dev:…/Workspace.scss` for resting, hover and active; each is resolved through a probe in the same scoped subtree — a comparison, not a transcription, so a theme whose `--workstation-signal` moved would move both sides. All nine match, both neo themes. **Reach**: 4 arms load the compiled `Workspace.css` / `FleetCockpit.css` plus their theme-scoped token layers and assert both identities reach all three states, including FM's flat opt-out. Every reading asserts its own pointer state. |
| AC-9 | Mutation on the real tree: restoring the `Workspace.scss` block reds the file-scan arm with `workstation/Workspace.scss → background on .neo-dashboard-dock-splitter &:active::after`. Under the previous census that same tree was green. |
| AC-10 | Mutation: removing `background-color: var(--dock-splitter-background)` reds the engine-only floor arm in **both** themes — the pre-promotion state restated as a measurement. Removing the `:active` `&::after` consumer reds the active arm *and* both workstation parity arms, so the result is caused by the engine floor rather than an app override. |

## Test Evidence

Two instruments, because neither can answer the other's question.

| command | result |
|---|---|
| `npm run test-unit -- test/playwright/unit/buildScripts/` | **139 passed** (was 136; the splitter census gained 3 instrument arms) |
| `npx playwright test -c test/playwright/playwright.config.component.mjs test/playwright/component/dashboard/DockSplitterPaint.spec.mjs` | **11 passed** |

**Scope bound, stated rather than implied:** the named consumer is now navigated directly; the mounted-class arms remain alongside it because they can isolate token mechanics a whole page cannot. The previous body's "50 component specs (real rendering)" was suite adjacency and is withdrawn; the corpus contained no dock spec at all.

**Three fixture defects were found while building this**, each of which had produced a green or a red for the wrong reason, and each is now guarded in place:

- Loading the app's rule without its **theme-scoped token layer** left every `color-mix(… var(--workstation-signal) …)` an invalid substitution and the band computed to transparent. Both layers load, and a failed `<link>` rejects loudly — silently missing tokens would measure the ENGINE floor while reporting on the app.
- `resting` was measured **while hovering**: the splitter renders at (0, 0) at 6×720, so the origin is inside it. The away point is derived from the box, and all three readings assert their own pointer state. It surfaced only because FM gives hover and active the same value — which is also why the three-step ladder is asserted for workstation only.
- A custom property returns verbatim (`#0f766e`) while `backgroundColor` returns serialised (`rgb(15, 118, 110)`). String-comparing them reported a parity **failure on identical colours**; the token is now resolved through the browser first.

## Net SCSS LOC

**+73** (134 added, 61 deleted), and the composition is the explanation:

| layer | delta |
|---|---|
| `apps/workstation/Workspace.scss` | −32 |
| `apps/agentos/fleet/FleetCockpit.scss` | +3 |
| **apps subtotal** | **−29** |
| `src/dashboard/Container.scss` | +102 |

Paint leaves two app stylesheets and arrives once in the layer that owns it, carrying a token contract and the rationale for each default. #17241's criterion expected a negative total; that assumed a relocation. This is a promotion **plus** the neutral-default layer the relocation never had, and the increase is the layer.

## Deltas from ticket

- **The active token defaults to the hover value** rather than deriving its own neutral. #17538's ledger names the fallback but not the reasoning: dragging must never read as *less* engaged than hovering, and an app that sets only a hover colour still gets a coherent active state. One slot, overridable alone.
- **Parity is asserted against the base tree's own source, not against a remembered value.** The pre-promotion declarations are lifted verbatim from `origin/dev` and resolved live, which is how a test in this tree can see the other one.
- **The rendered arms load compiled `dist/**` artifacts.** The ticket's ACs did not anticipate a build-output dependency. It is the honest instrument — those are the files Neo loads at runtime — and a failed `<link>` rejects loudly rather than silently measuring the engine floor while reporting on the app.
- **The example is navigated, and that turned out to be the stronger reading.** It boots under the legacy `neo-theme-light`, so the floor is demonstrated on a consumer that opted into nothing at all — a better result than the neo-theme-only claim the earlier arms could make.

## Residual

- **Parity covers workstation's nine paint values across three states; FM's are not swept the same way.** FM's pre-promotion splitter block was a partial override rather than a full identity, so there is no equivalent nine-value baseline to compare against. Its opt-out and state reach are asserted instead.
- **The dark-theme home decision stays on #17241** and is untouched here; `resources/scss/theme-neo-dark/dashboard/` still does not exist for any dashboard component.

## Out of Scope

- Whether FM should keep a flat splitter — FM design language, @neo-fable-clio's call. The engine answer does not depend on it.
- The rail-tab half (#17522 / PR #17524), the dock edge chrome, and the dark-theme home — all retained by #17241.

## Post-Merge Validation

None gating. Both apps resolve to their previous appearance through token values — asserted, not assumed, for the one value that moved — and `examples/dashboard/dock` gains a visible splitter it previously lacked.

Authored by Grace (Claude Opus 5, Claude Code). Session cb3eb9c7-875a-4eac-a716-02878fa535c5.

