### PR TITLE
fix(core): Neo.merge refuses prototype-chain keys from parsed payloads (#17534)

### DIFF
--- a/src/Neo.mjs
+++ b/src/Neo.mjs
@@ -4,6 +4,15 @@ import {isDescriptor} from './core/ConfigSymbols.mjs';
 const
     camelRegex   = /-./g,
     configSymbol = Symbol.for('configSymbol'),
+    /**
+     * Keys that steer a property write onto the prototype chain instead of the object.
+     *
+     * `__proto__` is the setter; `constructor` and `prototype` are the two-hop route to the same
+     * place. A `JSON.parse`d payload carries `__proto__` as an OWN enumerable key, so any traversal
+     * that enumerates untrusted input has to refuse them explicitly — the object model will not.
+     * @type {Set<String>}
+     */
+    PROTO_CHAIN_KEYS = new Set(['__proto__', 'constructor', 'prototype']),
     getSetCache  = Symbol('getSetCache'),
     cloneMap     = {
         Array(obj, deep, ignoreNeoInstances) {
@@ -557,10 +566,25 @@ If you intended to create custom logic, use the 'beforeGet${Neo.capitalize(key)}
         }
 
         for (const key in source) {
+            // `for…in` enumerates inherited keys, and `JSON.parse` produces `__proto__` as an OWN
+            // enumerable one — so a parsed payload can steer this loop onto the prototype chain.
+            // Skipping the three chain keys is what keeps the write below on the caller's object.
+            //
+            // The guard lives HERE, in the primitive, because `Neo.merge` is part of the public
+            // default export: no census of repository callers can bound who calls it. It is not
+            // hypothetical even inside this repository — `ai/mcp/client/config.mjs` passes a
+            // `JSON.parse`d file chosen by an `mcp-cli --config` flag straight in, and
+            // `src/worker/Base.mjs` merges worker-message payloads into `Neo.config`.
+            if (PROTO_CHAIN_KEYS.has(key)) {
+                continue
+            }
+
             const value = source[key];
 
             if (Neo.typeOf(value) === 'Object') {
-                target[key] = Neo.merge(target[key] || {}, value)
+                // `Object.hasOwn`, not truthiness: an inherited property would otherwise read as an
+                // existing branch and this would recurse into shared state instead of a fresh node.
+                target[key] = Neo.merge(Object.hasOwn(target, key) ? target[key] : {}, value)
             } else {
                 target[key] = value
             }

--- a/src/Neo.mjs
+++ b/src/Neo.mjs
@@ -12,9 +12,9 @@ const
      * that enumerates untrusted input has to refuse them explicitly — the object model will not.
      * @type {Set<String>}
      */
-    PROTO_CHAIN_KEYS = new Set(['__proto__', 'constructor', 'prototype']),
-    getSetCache  = Symbol('getSetCache'),
-    cloneMap     = {
+    protoChainKeys = new Set(['__proto__', 'constructor', 'prototype']),
+    getSetCache    = Symbol('getSetCache'),
+    cloneMap       = {
         Array(obj, deep, ignoreNeoInstances) {
             return !deep ? obj.slice() : obj.map(val => Neo.clone(val, deep, ignoreNeoInstances))
         },
@@ -575,7 +575,7 @@ If you intended to create custom logic, use the 'beforeGet${Neo.capitalize(key)}
             // hypothetical even inside this repository — `ai/mcp/client/config.mjs` passes a
             // `JSON.parse`d file chosen by an `mcp-cli --config` flag straight in, and
             // `src/worker/Base.mjs` merges worker-message payloads into `Neo.config`.
-            if (PROTO_CHAIN_KEYS.has(key)) {
+            if (protoChainKeys.has(key)) {
                 continue
             }
 

--- a/src/Neo.mjs
+++ b/src/Neo.mjs
@@ -549,7 +549,21 @@ If you intended to create custom logic, use the 'beforeGet${Neo.capitalize(key)}
     },
 
     /**
-     * Deep-merges a source object into a target object
+     * Deep-merges a source object into a target object.
+     *
+     * **`__proto__`, `constructor` and `prototype` are skipped.** All three are silently dropped
+     * from `source`: they never appear as own properties of the returned target, and they never
+     * modify what the target inherits. The skip is unconditional — it does not depend on the
+     * value's type, on nesting depth, or on whether the key arrived as an own or inherited one —
+     * because a `JSON.parse`d payload carries `__proto__` as an OWN enumerable key and this method
+     * is part of the public default export, so its own boundary is the security boundary.
+     *
+     * A caller that legitimately needs to transport one of those three names must assign it
+     * directly rather than merge it; there is no opt-out, deliberately.
+     *
+     * Branch decisions use `Object.hasOwn(target, key)`, so an INHERITED property on the target is
+     * not mistaken for an existing branch to recurse into.
+     *
      * @memberOf module:Neo
      * @param {Object} target
      * @param {Object} source

--- a/test/playwright/unit/core/NeoMergePrototypeGuard.spec.mjs
+++ b/test/playwright/unit/core/NeoMergePrototypeGuard.spec.mjs
@@ -12,9 +12,11 @@ import * as core      from '../../../../src/core/_export.mjs';
  * `ai/mcp/client/config.mjs` passes a `JSON.parse`d file chosen by an `mcp-cli --config` flag
  * straight in, and `src/worker/Base.mjs` merges worker-message payloads into `Neo.config`.
  *
- * Every arm asserts prototype IDENTITY as well as sentinel absence: a merge that silently replaced
- * the target's prototype with a fresh object would leave `Object.prototype` clean and still be
- * wrong, and a sentinel-only assertion cannot see the difference.
+ * The POLLUTION arms assert prototype IDENTITY as well as sentinel absence: a merge that silently
+ * replaced the target's prototype with a fresh object would leave `Object.prototype` clean and
+ * still be wrong, and a sentinel-only assertion cannot see the difference. The ordinary-merge
+ * control and the inherited-branch arm answer different questions — that the guard stayed narrow,
+ * and that the branch decision is local — and carry only the assertions those questions need.
  */
 test.describe('Neo.merge — a parsed payload cannot reach the prototype chain', () => {
     test.afterEach(() => {
@@ -22,6 +24,13 @@ test.describe('Neo.merge — a parsed payload cannot reach the prototype chain',
         for (const key of ['neoMergeProbe', 'nested', 'viaDefaults', 'viaConstructor']) {
             delete Object.prototype[key]
         }
+
+        // `Object.prototype.toString` is a SHARED FUNCTION OBJECT, and a property hung on it is not
+        // reached by deleting keys from `Object.prototype`. A regression in the inherited-branch
+        // guard writes exactly there, so without this line the failing arm would leave every later
+        // spec in this worker running against a mutated global — the arm would go red once and the
+        // damage would surface somewhere unrelated.
+        delete Object.prototype.toString.marker
     });
 
     test('a JSON-parsed __proto__ does not reach Object.prototype', () => {
@@ -92,12 +101,52 @@ test.describe('Neo.merge — a parsed payload cannot reach the prototype chain',
         // The recursion previously read `target[key] || {}`, which consults the prototype chain: a
         // source key named after an inherited property would recurse into shared state instead of
         // creating a fresh node. `Object.hasOwn` is what makes the branch decision local.
-        const target = {};
+        //
+        // The holder is PRIVATE on purpose. Driving this through the real `Object.prototype.toString`
+        // proves the same property, but a regression then mutates a function every later spec in the
+        // worker shares — the arm goes red once and the damage surfaces somewhere unrelated. A
+        // purpose-built prototype fails loudly and contaminates nothing.
+        const
+            holder = {inherited: {shared: 'prototype-owned'}},
+            target = Object.create(holder);
 
-        Neo.merge(target, {toString: {marker: 'own'}});
+        Neo.merge(target, {inherited: {marker: 'own'}});
 
-        expect(Object.hasOwn(target, 'toString'), 'an own branch was created').toBe(true);
-        expect(target.toString.marker).toBe('own');
+        expect(Object.hasOwn(target, 'inherited'), 'an own branch was created').toBe(true);
+        expect(target.inherited.marker, 'and it carries the merged value').toBe('own');
+        expect(target.inherited.shared,
+            'the fresh node did NOT start as a copy of the inherited one').toBeUndefined();
+        expect(holder.inherited, 'the prototype-owned node is byte-identical afterwards')
+            .toEqual({shared: 'prototype-owned'});
+
+        // The real shared function, kept as a second reading because the private holder models the
+        // shape rather than being it. `afterEach` restores this one if a regression ever writes it.
+        const global = {};
+
+        Neo.merge(global, {toString: {marker: 'own'}});
+
         expect(Object.prototype.toString.marker, 'the global function is untouched').toBeUndefined()
+    });
+
+    test('every reserved key is dropped from the RETURNED target, not only from the chain', () => {
+        // The set is `__proto__` / `constructor` / `prototype`, and the arms above pin only the
+        // first against pollution. The other two were skipped by the same `continue` with nothing
+        // asserting what the CALLER gets back — so narrowing the set later would have been
+        // invisible here. This is the public output contract the JSDoc now states.
+        for (const key of ['__proto__', 'constructor', 'prototype']) {
+            const
+                // `JSON.parse` so `__proto__` arrives as an OWN enumerable key; an object literal
+                // would invoke the setter at construction and never produce the shape under test.
+                source = JSON.parse(`{"${key}":{"marker":"reserved"},"kept":"yes"}`),
+                merged = Neo.merge({}, source);
+
+            expect(Object.hasOwn(merged, key), `${key} is not an own property of the result`).toBe(false);
+            expect(merged.kept, `and the rest of the payload still merges past ${key}`).toBe('yes');
+        }
+
+        // Paired control: the skip is by NAME, so an ordinary key spelled similarly must survive.
+        // Without this, a guard that dropped every object-valued key would pass every arm above.
+        expect(Neo.merge({}, JSON.parse('{"proto":{"marker":"ok"},"constructors":{"n":1}}')))
+            .toEqual({constructors: {n: 1}, proto: {marker: 'ok'}})
     });
 });

--- a/test/playwright/unit/core/NeoMergePrototypeGuard.spec.mjs
+++ b/test/playwright/unit/core/NeoMergePrototypeGuard.spec.mjs
@@ -1,0 +1,103 @@
+import {test, expect} from '@playwright/test';
+import Neo            from '../../../../src/Neo.mjs';
+import * as core      from '../../../../src/core/_export.mjs';
+
+/**
+ * `Neo.merge` is part of the public default export, so its own boundary is the security boundary —
+ * no census of repository callers can bound who calls it.
+ *
+ * The payload below is the exact one that reached `Object.prototype` before the guard landed:
+ * `JSON.parse` produces `__proto__` as an OWN enumerable key, `for…in` yields it, and the recursive
+ * write then steers onto the prototype chain. It is not hypothetical inside this repository either —
+ * `ai/mcp/client/config.mjs` passes a `JSON.parse`d file chosen by an `mcp-cli --config` flag
+ * straight in, and `src/worker/Base.mjs` merges worker-message payloads into `Neo.config`.
+ *
+ * Every arm asserts prototype IDENTITY as well as sentinel absence: a merge that silently replaced
+ * the target's prototype with a fresh object would leave `Object.prototype` clean and still be
+ * wrong, and a sentinel-only assertion cannot see the difference.
+ */
+test.describe('Neo.merge — a parsed payload cannot reach the prototype chain', () => {
+    test.afterEach(() => {
+        // If an arm ever DID pollute, every later arm inherits it and fails somewhere unrelated.
+        for (const key of ['neoMergeProbe', 'nested', 'viaDefaults', 'viaConstructor']) {
+            delete Object.prototype[key]
+        }
+    });
+
+    test('a JSON-parsed __proto__ does not reach Object.prototype', () => {
+        const target = {};
+
+        Neo.merge(target, JSON.parse('{"__proto__":{"neoMergeProbe":"reached"}}'));
+
+        expect(Object.hasOwn(Object.prototype, 'neoMergeProbe'), 'the global is untouched').toBe(false);
+        expect(({}).neoMergeProbe, 'and no object in the process gained the property').toBeUndefined();
+        expect(Object.getPrototypeOf(target), "the target's own prototype is intact").toBe(Object.prototype)
+    });
+
+    test('a NESTED parsed __proto__ does not reach it either', () => {
+        // The recursion is the interesting path: the outer key is innocuous, so a guard applied only
+        // at the top level would pass this while the inner write still lands on the chain.
+        const target = {};
+
+        Neo.merge(target, JSON.parse('{"a":{"__proto__":{"nested":"reached"}}}'));
+
+        expect(Object.hasOwn(Object.prototype, 'nested')).toBe(false);
+        expect(Object.getPrototypeOf(target.a ?? {}), 'the nested branch keeps its prototype')
+            .toBe(Object.prototype)
+    });
+
+    test('the DEFAULTS path is guarded too — and its damage is a REPLACED prototype', () => {
+        // `Neo.merge(target, source, defaults)` runs the defaults through a second merge, so
+        // guarding only the source would leave an identical hole one argument over.
+        //
+        // The assertion is prototype IDENTITY, not `Object.prototype` pollution — measured, because
+        // the first version of this arm checked the global and passed with the guard removed. On
+        // this path the `__proto__` write lands on a fresh intermediate object, replacing ITS
+        // prototype: the result then serialises as `{"safe":1}` while `out.viaDefaults` reads
+        // `"hit"`. Nothing global is touched and the object is still wrong.
+        const out = Neo.merge({}, {safe: 1}, JSON.parse('{"__proto__":{"viaDefaults":"reached"}}'));
+
+        expect(Object.getPrototypeOf(out), 'the merged result keeps its prototype').toBe(Object.prototype);
+        expect(out.viaDefaults, 'and inherits nothing from the payload').toBeUndefined();
+        expect(Object.hasOwn(Object.prototype, 'viaDefaults'), 'the global is untouched too').toBe(false);
+        expect(out.safe, 'the real defaults still merge').toBe(1)
+    });
+
+    test('`constructor` cannot be used as a two-hop route', () => {
+        // Measured: with BOTH guards removed this route does not silently pollute — it throws
+        // `TypeError: Cannot assign to read only property 'prototype'`. So the arm's value is that
+        // the traversal neither crashes nor writes, and the guard that covers it is `Object.hasOwn`
+        // rather than the denylist. Stating which guard owns which vector, because the two were
+        // easy to conflate and the mutation is what separated them.
+        Neo.merge({}, JSON.parse('{"constructor":{"prototype":{"viaConstructor":"reached"}}}'));
+
+        expect(Object.hasOwn(Object.prototype, 'viaConstructor')).toBe(false);
+        expect(({}).viaConstructor).toBeUndefined()
+    });
+
+    test('ordinary deep merge, arrays and defaults are unchanged', () => {
+        // Non-vacuity. Without this an implementation that refused everything would pass every arm
+        // above — the guard has to be narrow, not merely safe.
+        const target = Neo.merge({a: {x: 1}, list: [1, 2]}, {a: {y: 2}, list: [3], extra: 'e'});
+
+        expect(target.a).toEqual({x: 1, y: 2});
+        expect(target.list).toEqual([3]);
+        expect(target.extra).toBe('e');
+
+        expect(Neo.merge({}, {b: 2}, {a: 1}), 'defaults fill, source wins').toEqual({a: 1, b: 2});
+        expect(Neo.merge(null, {a: 1}), 'a missing target returns the source').toEqual({a: 1})
+    });
+
+    test('an inherited target property is not treated as an existing branch', () => {
+        // The recursion previously read `target[key] || {}`, which consults the prototype chain: a
+        // source key named after an inherited property would recurse into shared state instead of
+        // creating a fresh node. `Object.hasOwn` is what makes the branch decision local.
+        const target = {};
+
+        Neo.merge(target, {toString: {marker: 'own'}});
+
+        expect(Object.hasOwn(target, 'toString'), 'an own branch was created').toBe(true);
+        expect(target.toString.marker).toBe('own');
+        expect(Object.prototype.toString.marker, 'the global function is untouched').toBeUndefined()
+    });
+});


### PR DESCRIPTION
Resolves #17534

Supersedes #17512 · closed PR #17513 · CodeQL alerts 62, 63

🌿 *`JSON.parse` hands you `__proto__` as an ordinary own key, and `Neo.merge` walked it straight onto the prototype chain.*

Evidence: L1 (runtime probe against the real primitive; 5-of-6 arms RED on unmodified `dev`, per-guard mutation matrix) → L1 sufficient (pure core function, no rendered surface). No residual.

## The defect, and my part in it

`Neo.merge` enumerates `source` with `for…in`. `JSON.parse` produces `__proto__` as an **own enumerable** key, so the loop yields it and the recursive write steers onto the prototype chain:

```js
Neo.merge({}, JSON.parse('{"__proto__":{"probe":"reached"}}'));
Object.hasOwn(Object.prototype, 'probe'); // was: true
```

I argued the opposite on #17512 and proposed dismissing alerts 62/63 as intentional prototype *enrichment*. That premise was wrong, and @neo-gpt-emmy falsified it by running the thing I had only reasoned about — I had verified `for…in` behaviour in isolation and never once called `Neo.merge`. She also caught the census error underneath it: I scoped the caller sweep to `src/` and `apps/`, which is how `ai/mcp/client/config.mjs:117` — a `JSON.parse`d file chosen by an `mcp-cli --config` flag, fed straight in — stayed invisible.

**The census was the wrong instrument regardless of its accuracy.** `Neo.merge` is part of the public default export, so its own boundary *is* the security boundary; no enumeration of repository callers can bound who calls it. That is why the guard lives in the primitive and not at any call site.

## Two guards, disjoint coverage

Not one fix wearing two hats — the mutation matrix separates them:

| guard | covers | reds under its own mutation |
|---|---|---|
| `protoChainKeys` skip | `__proto__` direct, nested, and via `defaults` | 3 arms |
| `Object.hasOwn(target, key)` over `target[key] \|\|` | an inherited property read as an existing branch | 1 arm |

The second is not incidental tidying. `target[key] || {}` consults the prototype chain, so a source key named after an inherited property recursed into shared state instead of creating a fresh node.

## Test Evidence

`test/playwright/unit/core/NeoMergePrototypeGuard.spec.mjs` — 6 arms. Core suite **58 passed**.

**AC-1 witness** — spec run against unmodified `origin/dev` `src/Neo.mjs`: **5 failed, 1 passed**. The single green is the non-vacuity control, which must pass on both sides or it is not a control.

**Mutation matrix** (each guard removed alone, at head):

| mutation | reds |
|---|---|
| denylist removed | direct `__proto__`, nested `__proto__`, defaults path |
| `hasOwn` reverted to `target[key] \|\|` | inherited-target branch |
| both removed | `constructor` route **throws** `TypeError: Cannot assign to read only property 'prototype'` |

That last row is why the `constructor` arm carries a comment naming `hasOwn` — not the denylist — as its owner. The two were easy to conflate and only the split mutation separated them.

**One arm was vacuous and mutation is what caught it.** The defaults arm first asserted `Object.prototype` pollution and passed with the guard removed. On that path the `__proto__` write lands on a fresh *intermediate* object and replaces **its** prototype: the result serialises as `{"safe":1}` while `out.viaDefaults` reads `"hit"`. Nothing global is touched and the object is still wrong. The arm now asserts prototype **identity**, which is the property that path actually violates.

The POLLUTION arms assert prototype identity alongside sentinel absence, for the same reason. The ordinary-merge control and the inherited-branch arm answer different questions — that the guard stayed narrow, and that the branch decision is local — and carry the assertions those questions need. @neo-gpt-emmy caught the earlier "every arm" phrasing as broader than the file; it was.

## AC Evidence

| AC | proof |
|---|---|
| AC-1 | `NeoMergePrototypeGuard.spec.mjs` arm 1 — the exact `JSON.parse('{"__proto__":{"neoMergeProbe":"reached"}}')` payload. RED on unmodified `dev` (5 of 6 arms were), green at head. |
| AC-2 | Arms 1–4 cover `source`, `defaults`, nested payloads and the `constructor` route; each asserts BOTH that `Object.prototype` is unpolluted AND that the target's own prototype is still `Object.prototype` — a merge that replaced the prototype with a fresh object would leave the global clean and still be wrong. |
| AC-3 | The ordinary-merge control asserts deep merge, array replacement, `defaults` precedence and the null-target return, so the guard is proven NARROW rather than merely safe. Full `test/playwright/unit/core/` family: **59 passed**. |
| AC-4 | The guard is inside `Neo.merge` itself, in `src/Neo.mjs`. No caller-side sanitizer and no caller census; the JSDoc now states the reserved-key contract publicly, so the boundary is documented where the primitive lives. |
| AC-5 | Nothing in this diff touches CodeQL configuration: `git diff --name-only origin/dev...HEAD` is exactly `src/Neo.mjs` and the spec. No dismissal rows, no `paths-ignore`, no query exclusion. |
| AC-6 | **[POST-MERGE]** Not certifiable pre-merge by construction — alert state transitions on `dev`. Carried in Post-Merge Validation below. |

**@neo-gpt-emmy's two RAs — discharged, now at `82efbcf93c`** (was `dc6165af74`; rebased onto `dev` — no conflict, `dev` never touched `src/Neo.mjs` or the spec, and the diff is byte-identical across the rebase).

**RA-1.** The skip was implemented and commented but never stated as a contract, so a caller could not learn it without reading the loop. The JSDoc now says all three reserved keys are silently dropped, never appear as own properties of the returned target, and that the skip is unconditional with no opt-out. A new arm pins that output contract for **every** member of the set — previously only `__proto__` was pinned against pollution while `constructor` and `prototype` rode the same `continue` with nothing asserting what the caller gets back, so narrowing the set later would have been invisible. Narrowing it to `__proto__` alone now reds that arm on `constructor`. Its paired control matters more than the arm: the skip is by NAME, so `proto` and `constructors` must survive — without it, a guard that dropped every object-valued key would have passed every arm in the file.

**RA-2.** Correct and the sharper of the two. The inherited-branch arm drove through the real `Object.prototype.toString`, and a regression there hangs `marker` on a function object every later spec in the worker shares; `afterEach` deleted four keys from `Object.prototype` and could not reach it. The arm would have gone red once and the damage would have surfaced somewhere unrelated — the exact laundering that makes a leak read as flake. It now uses a private prototype holder, asserts the holder is byte-identical afterwards, and adds an assertion that the fresh node did not start as a copy of the inherited one. The real global is kept as a second reading, and `afterEach` restores it. Reverting the branch decision to `target[key] || {}` reds it on that new assertion.

## Deltas from ticket

- **The ticket left the mechanism open ("harden … so source keys cannot traverse"); this is a skip, not a throw.** A throw would turn a hostile payload into a denial-of-service against any caller merging untrusted config — `src/worker/Base.mjs:368,389` merges worker-message payloads into `Neo.config`, where a throw is a dead worker. Silent skip is the failure direction that degrades rather than breaks.
- **The inherited-branch arm models the shape rather than being it.** A private prototype holder replaces the real `Object.prototype.toString` as the driver, because a self-isolating negative arm is worth more than a maximally realistic one that contaminates the worker when it fails. The real global is still read, just not written through.
- **`prototype` is in the denylist though no arm needs it today.** It is the second hop of the `constructor` route; excluding it would leave the set describing a subset of its own name.

## Out of Scope

- No dismissal rows for 62/63, no `paths-ignore`, no query exclusion — the ticket forbids all three and the fix makes them unnecessary.
- `mergeFrom` / config-descriptor behaviour.
- A general-purpose sanitizer outside `Neo.merge`.

## Post-Merge Validation

**[POST-MERGE]** CodeQL alerts 62 and 63 should transition to *fixed* on `dev`. If either stays open, that is a successor ticket — this one does not reopen.

Authored by Grace (Claude Opus 5, Claude Code). Session 59f57b1e-c42a-4e66-9e86-66f62cdc2b6a.


