### PR TITLE
style(agentos): tab strip indicators and the FM container ground join the token layer (#17543)

### DIFF
--- a/resources/scss/src/apps/agentos/Viewport.scss
+++ b/resources/scss/src/apps/agentos/Viewport.scss
@@ -2,13 +2,20 @@
    top chrome, the left-rail keeper-view nav, the agent-button hierarchy, and the Home/Chat surfaces.
    The instance menu is a framework-floating document.body child, so it joins this scope to inherit
    the SAME structural FM role/spacing/motion tokens without duplicating their definitions. Its
-   feature sheet consumes only the relevant vars; the shell selectors below remain descendant-bound. */
+   feature sheet consumes only the relevant vars; the shell selectors below remain descendant-bound.
+   §04 rhythm record (#17265): the 2px tab indicator (the tab-family block) is a recorded exception —
+   an indicator's own measure, not spacing. */
 .agent-os-viewport.neo-viewport,
 .fm-instance-menu {
-    /* The keeper-view nav's active tab indicator reads as FM signal — the stock theme's
-       neutral-contrast white strip is a foreign accent inside the FM tonal stack (shell-scope
-       only; the framework token itself is untouched). */
-    --tab-indicator-background-color-active: var(--fm-signal);
+    /* The shell paints the designed ground itself. The viewport is not a container, and its stock
+       surface is the theme's neutral default — a foreign tone under every FM pane; the token
+       layer owns the ground exactly like it owns the panels on it. */
+    background: var(--fm-ground);
+
+    /* Token rebinds for the indicator do NOT live here: the theme declares the very same tokens
+       on `:root .neo-theme-neo-dark`, and the theme class rides THIS element — an equal-specificity
+       tie on one element that load order hands to the theme. The family re-declares them on the
+       indicator's nearest ancestors instead (the tab-family block below). */
 
     /* The chip-family geometry contract (TOKENS.md §04): ONE anatomy for every status/kind
        idiom — telltale, spine banner, viewer-wake, event chips, state dots. The family owns
@@ -123,6 +130,10 @@
     }
 
     .agent-top-toolbar {
+        /* the top chrome band speaks the keeper rail's voice — one quiet rail surface around the
+           ground on two edges; without it the stock toolbar neutral sat as a foreign band above
+           every FM pane */
+        background: var(--fm-rail);
         min-height: 50px;
         padding   : 0 20px;
 
@@ -237,6 +248,37 @@
         --tab-button-glyph-color-pressed   : var(--fm-ink);
         --tab-button-background-color      : transparent;
         --tab-button-background-color-hover: var(--fm-panel);
+    }
+
+    /* The active place is structural: signal indicator, full ink, weight — never hue-alone
+       (§04). The indicator tokens land on the TOOLBAR (the per-button indicator) and the STRIP
+       (the strip-level one), the indicators' nearest ancestors: declared on the shell root they
+       tie with the theme's own declaration and lose on load order (see the root block). 2px is the
+       indicator's own measure — a hairline of signal, not a slab of stock white (recorded §04
+       exception, file header). One declaration serves both orientations: the engine reads the same
+       token as height on a horizontal strip and as width on the vertical keeper rail. */
+    .neo-tab-header-toolbar,
+    .neo-tab-strip {
+        --tab-indicator-background-color-active: var(--fm-signal);
+        --tab-strip-height                     : 2px;
+    }
+
+    /* The keeper rail's active indicator spans its button's full height by engine geometry
+       (inline top/height) and met the fleet zone's horizontal indicator at the shared corner —
+       two independent tab containers, one accidental bracket. The clip keeps the engine's
+       geometry and trims both ends on the rhythm, so the strokes never touch. */
+    .neo-dock-left .neo-tab-button-indicator,
+    .neo-dock-left .neo-active-tab-indicator {
+        clip-path: inset(var(--fm-space-2) 0);
+    }
+
+    /* The FM tonal stack paints only what its token sheets declare. A container inside the shell
+       carries no stock surface of its own: the theme's neutral default was painting every pane's
+       head and rows over the pane's declared tone (the Activity stream's `--fm-rail` with
+       rgb(14,15,13) boxes inside it — read as a box grid, it was a leak). Declared on the
+       container, nearest to itself, so the theme-root declaration cannot tie. */
+    .neo-container {
+        --container-background-color: transparent;
     }
 
     /* The keeper-view nav shell — the PRIMARY tier: same family voice, quiet rail surface. */

--- a/resources/scss/src/apps/agentos/Viewport.scss
+++ b/resources/scss/src/apps/agentos/Viewport.scss
@@ -7,12 +7,12 @@
    an indicator's own measure, not spacing. */
 .agent-os-viewport.neo-viewport,
 .fm-instance-menu {
-    /* The shell paints the designed ground itself. The viewport is not a container, and its stock
-       surface is the theme's neutral default — a foreign tone under every FM pane; the token
-       layer owns the ground exactly like it owns the panels on it. */
-    background: var(--fm-ground);
+    /* Direct paint does NOT live in this comma group: it carries structural FM tokens to the
+       floating instance menu too, so every direct declaration here would be emitted for the menu
+       root as well. The ground paint + container-surface rule live in the viewport-only
+       direct-paint block at the end of this file. */
 
-    /* Token rebinds for the indicator do NOT live here: the theme declares the very same tokens
+    /* Token rebinds for the indicator do NOT live here either: the theme declares the very same tokens
        on `:root .neo-theme-neo-dark`, and the theme class rides THIS element — an equal-specificity
        tie on one element that load order hands to the theme. The family re-declares them on the
        indicator's nearest ancestors instead (the tab-family block below). */
@@ -272,15 +272,6 @@
         clip-path: inset(var(--fm-space-2) 0);
     }
 
-    /* The FM tonal stack paints only what its token sheets declare. A container inside the shell
-       carries no stock surface of its own: the theme's neutral default was painting every pane's
-       head and rows over the pane's declared tone (the Activity stream's `--fm-rail` with
-       rgb(14,15,13) boxes inside it — read as a box grid, it was a leak). Declared on the
-       container, nearest to itself, so the theme-root declaration cannot tie. */
-    .neo-container {
-        --container-background-color: transparent;
-    }
-
     /* The keeper-view nav shell — the PRIMARY tier: same family voice, quiet rail surface. */
     .agent-shell > .neo-tab-header-toolbar {
         --tab-button-text-color            : var(--fm-ink-dim);
@@ -348,5 +339,26 @@
             line-height: 1.6;
             color      : var(--fm-ink-dim);
         }
+    }
+}
+
+/* The direct-paint owner — deliberately OUTSIDE the shared token group above (RA-1, PR #17544
+   round 1): that comma group exists to carry structural FM tokens to the floating instance menu,
+   and Sass emits every direct declaration in it for the menu root too — the menu's surface is its
+   own `--fm-panel-2` story (InstanceSwitcher.scss). Only the shell viewport paints the ground, and
+   only its containers give up the stock surface. */
+.agent-os-viewport.neo-viewport {
+    /* The shell paints the designed ground itself. The viewport is not a container, and its stock
+       surface is the theme's neutral default — a foreign tone under every FM pane; the token
+       layer owns the ground exactly like it owns the panels on it. */
+    background: var(--fm-ground);
+
+    /* The FM tonal stack paints only what its token sheets declare. A container inside the shell
+       carries no stock surface of its own: the theme's neutral default was painting every pane's
+       head and rows over the pane's declared tone (the Activity stream's `--fm-rail` with
+       rgb(14,15,13) boxes inside it — read as a box grid, it was a leak). Declared on the
+       container, nearest to itself, so the theme-root declaration cannot tie. */
+    .neo-container {
+        --container-background-color: transparent;
     }
 }


### PR DESCRIPTION
Resolves neomjs/neo#17543

Three stock-skin values stop leaking into the FM tonal stack, measured before and after in the running cockpit. Both rails' active tab indicators read `--fm-signal` at 2 px — declared on the toolbar and the strip, the indicators' nearest ancestors, because the theme declares the same tokens on the viewport element itself and the root-level rebind that was meant to do this only tied on load order. The keeper rail's indicator is clipped 8 px at both ends, so it never meets the fleet zone's strip at the shared corner. Containers inside the shell carry no stock surface of their own (the neutral default was painting every pane's head and rows over the pane's declared tone — the Activity stream's `--fm-rail` with rgb(14,15,13) boxes inside it), the viewport paints `--fm-ground`, and the top chrome band speaks the keeper rail's voice. 47 lines of SCSS in one file, four rules, each comment carrying its mechanism.

Evidence: L3 achieved (computed-style receipts on the running dev cockpit for every rule, the four keeper views walked for blast radius) → L3 required (AC-1..3 are rendered facts). Residual: AC-5, Residual-Owner: neomjs/neo-agent-institution#11.

## AC Evidence
| AC-1 | Outside-CI: computed styles on the dev cockpit at 64b2495906 — `.neo-dock-top.neo-tab-strip .neo-active-tab-indicator` background `rgb(94, 234, 212)` = the resolved `--fm-signal` (#5eead4), height 2px; keeper rail `.pressed .neo-tab-button-indicator` background `rgb(94, 234, 212)`, width 2px (`--tab-strip-height` resolves to `2px` under the toolbar and the strip). A read inside the stock 260 ms `delaybgcolor` window reports transparent by design — the receipt is taken after it. |
| AC-2 | Outside-CI: `clip-path: inset(8px 0px)` computed on the rail indicator (engine rect y 126→209.5, painted 134→201.5); the fleet-tabs strip indicator lies at y≈141 right of x=51 — the strokes share no pixel (screenshot walked). |
| AC-3 | Outside-CI: `.fm-activity-stream` `rgb(14, 19, 26)` (= `--fm-rail`) with `.fm-stream-head` and `.fm-ev-row` `rgba(0, 0, 0, 0)`; `.fm-fleet-grid` transparent, cards `--fm-panel`; the viewport root `rgb(11, 14, 19)` (= `--fm-ground`), the dock split transparent, `.agent-top-toolbar` `rgb(14, 19, 26)` (= `--fm-rail`). Home / Accounts / Chat walked: each surface keeps its own token paint (Accounts' `--fm-panel-2` cards and form, the welcome's `--fm-ground`). |
| AC-4 | CI: `check-theme-surfaces.yml` (path-triggered by `resources/scss/src/apps/agentos/**`: parity + token-only + completeness). Outside-CI: `npm run check-theme-surfaces` ✓ at 64b2495906; the 2 px indicator is recorded in the file header as the §04 exception. |
| AC-5 | Not met on this seat — by falsifier, not by omission: the visual suite fails 7/8 on the UNMODIFIED dev tree with the same geometry mismatch it shows at this head (`cockpit-default-shell.png` expects 1548×1053, receives 1548×848, ratio 0.22), so a refresh here would bake this seat's geometry into the baselines. The goldens are rendered-platform artifacts of the local harness (#17518 closed NOT_PLANNED on exactly that ground); the refresh belongs to the harness ticket neomjs/neo-agent-institution#11. |

## Deltas from ticket

1. **The shadowing mechanism is a same-element load-order tie, not nearest-ancestor.** The viewport root carries the theme class itself (`agent-os-viewport neo-viewport neo-theme-neo-dark`), so `:root .neo-theme-neo-dark` and `.agent-os-viewport.neo-viewport` declare the indicator token on ONE element at equal specificity (0,2,0). Corrected in the ticket body. The fix therefore lands on the toolbar AND the strip: the per-button indicator (`src/tab/header/Button.scss:71-75`) reads the token through the toolbar, the strip-level one through the strip.
2. **Two rules the measurements forced:** the viewport root paints `--fm-ground` (it painted the stock neutral rgb(14,15,13) — a foreign ground under every pane), and `.agent-top-toolbar` paints `--fm-rail` (the stock toolbar neutral sat as a foreign band above every pane). Without them a transparent container ground exposes foreign tones instead of the designed ones.
3. **Container ground scoped shell-wide** (`.agent-os-viewport .neo-container`), not per pane, so it travels into vessels with the sheet; verified across the four keeper views — Accounts keeps its own panels, the welcome its `--fm-ground`.
4. **Round 1 (RA-1): the direct paint left the shared token group.** The comma group `.agent-os-viewport.neo-viewport, .fm-instance-menu` exists to carry structural FM tokens to the floating instance menu, so a direct `background` in it compiles for the menu root too. The ground paint and the transparent-container rule now live in a viewport-only direct-paint block at the end of the sheet; the shared group carries tokens only. Receipt at this head, BOTH themes (menu opened, computed): dark — menu `rgb(14,15,13)`, root `--fm-ground` #0b0e13; light — menu `rgb(255,255,255)`, root `--fm-ground` #f2f5f9 — the ground reaches the menu in neither. Named find, pre-existing and NOT this diff's (zero menu rules in the diff): the menu never painted its intended `--fm-panel-2` on dev either — stock `.neo-floating { background: var(--neo-background-color) }` ties with `.neo-menu-list { background-color: var(--menu-list-background-color) }` at (0,1,0) and wins on load order, so the correctly-declared `.fm-instance-menu.neo-menu-list { --menu-list-background-color: var(--fm-panel-2) }` rebind never renders — the same tie class this PR fixes for the indicator; noted on neomjs/neo-agent-institution#13.
5. **Round 1 (RA-2): AC-5 carries its compliant close path** — the close-target AC is annotated `[L3-deferred — operator handoff needed]` with surviving owner neomjs/neo-agent-institution#11 and the final-close path (the refresh + verification log land through neomjs/neo-agent-institution#11's harness run); the PR's Post-Merge Validation carries the same entry; "None owed" is gone.

## Test Evidence

- Computed-style receipts above, read in the Browser pane's page context on the dev cockpit after `npm run build-themes -- -n -e dev -t all`.
- RA-1 receipt (both themes, menu OPENED): dark `rgb(14,15,13)` / light `rgb(255,255,255)` on the menu root vs `--fm-ground` #0b0e13 / #f2f5f9 on the viewport — the split keeps every direct paint off the floating surface; the menu's stock (non-`--fm-panel-2`) surface is the pre-existing `.neo-floating` load-order tie, named in Deltas 4 and on neomjs/neo-agent-institution#13.
- Visual suite, local harness (`NEO_E2E_PORT=8118 npx playwright test -c test/playwright/playwright.config.visual.mjs`): 7 failed / 1 passed at this head AND 7 failed / 1 passed on the unmodified tree (stash → rebuild → run → pop → rebuild), identical size mismatches — the suite cannot distinguish this change from the baseline rot on this seat.
- `npm run check-theme-surfaces` ✓.

## Post-Merge Validation

- [ ] AC-5 golden refresh **[L3-deferred — operator handoff needed]** — the local-harness baselines are rendered-platform artifacts (7/8 red on the unmodified tree on this seat, identical geometry mismatches), so the platform-faithful refresh + its verification log land through the harness ticket's run and are recorded there; the close-target AC carries the same annotation.

Residual-Owner: neomjs/neo-agent-institution#11

## Commits

- `64b2495906` the four rules in `resources/scss/src/apps/agentos/Viewport.scss` (+47/−5), comments carrying the mechanism.

Authored by Clio (Claude Fable 5, Claude Code). Session 14acab5a-4b6c-4987-91c7-f683e39baa55.
