### PR TITLE
feat: tenant-sync concurrency knobs become AiConfig leaves (#17158)

### DIFF
--- a/ai/configBase.mjs
+++ b/ai/configBase.mjs
@@ -2193,13 +2193,34 @@ class ConfigBase extends ConfigProvider {
                  *
                  * @type {Object}
                  */
+                /**
+                 * Tenant-repo sync scheduling + concurrency knobs. Operators tune via gitignored
+                 * `ai/config.mjs` or the env vars named on each leaf.
+                 *
+                 * - `concurrencyLimit`: cap on simultaneous tenant-repo git/ingest work within one
+                 *   sweep — it sizes the per-sweep semaphore and the legacy-checkpoint revalidation
+                 *   cohort. Default `2` is conservative for multi-tenant cloud deployments. Set `1`
+                 *   to serialize all work when deployment capacity is constrained; set higher when
+                 *   network/CPU headroom permits. Positive integer only: `0` would create a
+                 *   never-acquirable semaphore, so consumption asserts reject it rather than
+                 *   reading it as "unlimited".
+                 * - `concurrencyGateTimeoutMs`: maximum time a per-repo task waits to acquire a
+                 *   concurrency slot before `KB_TENANT_REPO_SYNC_CONCURRENCY_GATE_TIMEOUT`.
+                 *   Default `0` keeps ordinary work in the FIFO until a slot is released — timing
+                 *   out a waiter cannot bound the sweep while the active holder is still pending,
+                 *   and recording that waiter as failed creates backoff without an attempt. A
+                 *   positive value remains an explicit fail-fast override.
+                 * @type {Object}
+                 */
                 tenantRepoSync: {
-                    backoffCapMs     : leaf(2 * 60 * 60 * 1000, 'NEO_ORCHESTRATOR_TENANT_REPO_SYNC_BACKOFF_CAP_MS', 'number'),
-                    jitterRatio      : leaf(0.20, 'NEO_ORCHESTRATOR_TENANT_REPO_SYNC_JITTER_RATIO', 'number'),
-                    leaseStaleAfterMs: leaf(6 * 60 * 60 * 1000, 'NEO_ORCHESTRATOR_TENANT_REPO_SYNC_LEASE_STALE_AFTER_MS', 'number'),
-                    sliceBudgetMs    : leaf(5 * 60 * 1000, 'NEO_ORCHESTRATOR_TENANT_REPO_SYNC_SLICE_BUDGET_MS', 'number'),
-                    starvedAfterMs   : leaf(6 * 60 * 60 * 1000, 'NEO_ORCHESTRATOR_TENANT_REPO_SYNC_STARVED_AFTER_MS', 'number'),
-                    sweepCadenceMs   : leaf(60 * 1000, 'NEO_ORCHESTRATOR_TENANT_REPO_SYNC_SWEEP_CADENCE_MS', 'number')
+                    backoffCapMs            : leaf(2 * 60 * 60 * 1000, 'NEO_ORCHESTRATOR_TENANT_REPO_SYNC_BACKOFF_CAP_MS', 'number'),
+                    concurrencyGateTimeoutMs: leaf(0, 'NEO_ORCHESTRATOR_TENANT_REPO_SYNC_CONCURRENCY_GATE_TIMEOUT_MS', 'number'),
+                    concurrencyLimit        : leaf(2, 'NEO_ORCHESTRATOR_TENANT_REPO_SYNC_CONCURRENCY_LIMIT', 'number'),
+                    jitterRatio             : leaf(0.20, 'NEO_ORCHESTRATOR_TENANT_REPO_SYNC_JITTER_RATIO', 'number'),
+                    leaseStaleAfterMs       : leaf(6 * 60 * 60 * 1000, 'NEO_ORCHESTRATOR_TENANT_REPO_SYNC_LEASE_STALE_AFTER_MS', 'number'),
+                    sliceBudgetMs           : leaf(5 * 60 * 1000, 'NEO_ORCHESTRATOR_TENANT_REPO_SYNC_SLICE_BUDGET_MS', 'number'),
+                    starvedAfterMs          : leaf(6 * 60 * 60 * 1000, 'NEO_ORCHESTRATOR_TENANT_REPO_SYNC_STARVED_AFTER_MS', 'number'),
+                    sweepCadenceMs          : leaf(60 * 1000, 'NEO_ORCHESTRATOR_TENANT_REPO_SYNC_SWEEP_CADENCE_MS', 'number')
                 },
                 /**
                  * Orchestrator-owned MLX inference server config. Operators tune via gitignored

--- a/ai/daemons/orchestrator/scheduling/tenantRepoSync.mjs
+++ b/ai/daemons/orchestrator/scheduling/tenantRepoSync.mjs
@@ -1,4 +1,6 @@
 import {
+    KB_TENANT_REPO_SYNC_INVALID_CONCURRENCY_GATE_TIMEOUT,
+    KB_TENANT_REPO_SYNC_INVALID_CONCURRENCY_LIMIT,
     KB_TENANT_REPO_SYNC_INVALID_SLICE_BUDGET,
     KB_TENANT_REPO_SYNC_REPO_NOT_CONFIGURED,
     TenantRepoSyncError
@@ -54,13 +56,14 @@ export function resolveUnknownRepoSelectorFailure({onlyRepoSlugs, knownSlugs = [
 /**
  * @summary Rejects a `tenantRepoSync.sliceBudgetMs` that cannot bound anything.
  *
- * Mirrors the gate shape `beforeSetConcurrencyLimit` uses — positive integer, nothing else — but
- * THROWS where that one substitutes. The asymmetry is deliberate and is about what each value can
- * do when wrong: a bad concurrency limit degrades throughput and the sweep still finishes, while a
- * bad slice budget removes the only bound on how long one repo may hold a slot. Substituting a
- * working number there would leave an operator believing they had tuned fairness while the shipped
- * guarantee was something else, and the symptom — a starved tail — is indistinguishable from the
- * defect this budget exists to remove.
+ * Positive integer, nothing else. Historically this THREW where the concurrency knobs' class-config
+ * hooks substituted a working value — a deliberate asymmetry while those hooks existed, because a
+ * bad slice budget removes the only bound on how long one repo may hold a slot. Since the
+ * concurrency knobs' own move onto AiConfig leaves the asymmetry is gone: all three resolve with no
+ * construction-time hook, and every consumption assert in this family throws, because a
+ * consumption-site substitute is a hidden default (the SSOT ADR's antipattern catalog) — an
+ * operator who mistuned a knob would believe it took effect while the shipped guarantee was
+ * something else.
  *
  * `0` is rejected like any other invalid value rather than read as a disable. A disable sentinel
  * would mean "unlimited slot hold", spelled as though it were an off switch.
@@ -78,6 +81,60 @@ export function assertSliceBudgetMs(value) {
         throw new TenantRepoSyncError(
             KB_TENANT_REPO_SYNC_INVALID_SLICE_BUDGET,
             `tenantRepoSync.sliceBudgetMs must be a positive integer in ms; received ${JSON.stringify(value)}. There is no disable value — express effectively-unbounded as a large number.`,
+            {phase: 'config-validation', received: value}
+        )
+    }
+
+    return value
+}
+
+/**
+ * @summary Rejects a `tenantRepoSync.concurrencyLimit` that cannot admit work correctly.
+ *
+ * Positive integer, nothing else — the same bounds the retired `beforeSetConcurrencyLimit`
+ * class-config hook enforced, relocated here because the value now resolves from an
+ * AiConfig leaf and the consumption site is the only gate every layer passes through: env, operator
+ * overlay, and per-call injection alike. `0` is rejected rather than read as "unlimited" — it would
+ * size a semaphore no acquirer can enter, hanging the sweep on its first repo. Fractional values
+ * produce ambiguous `active < limit` semantics (1.5 admits two slots).
+ *
+ * Lives beside {@link assertSliceBudgetMs} for the same reason it does: a validator that cannot be
+ * exercised without booting the class system is a validator whose own contract goes untested. The
+ * service reads the leaf at its use site and passes the resolved value in.
+ * @param {*} value Resolved `AiConfig.data.orchestrator.tenantRepoSync.concurrencyLimit` or an explicit per-call override.
+ * @returns {Number} The validated limit.
+ * @throws {TenantRepoSyncError} `KB_TENANT_REPO_SYNC_INVALID_CONCURRENCY_LIMIT` when not a positive integer.
+ */
+export function assertConcurrencyLimit(value) {
+    if (!Number.isInteger(value) || value < 1) {
+        throw new TenantRepoSyncError(
+            KB_TENANT_REPO_SYNC_INVALID_CONCURRENCY_LIMIT,
+            `tenantRepoSync.concurrencyLimit must be a positive integer; received ${JSON.stringify(value)}. 0 is not "unlimited" — it sizes a semaphore no acquirer can enter. Express effectively-unbounded as a large number.`,
+            {phase: 'config-validation', received: value}
+        )
+    }
+
+    return value
+}
+
+/**
+ * @summary Rejects a `tenantRepoSync.concurrencyGateTimeoutMs` outside `[0, finite)`.
+ *
+ * Unlike its two siblings above, `0` is VALID here — the FIFO-wait sentinel: queued acquirers wait
+ * until a slot is released instead of failing fast. Timing out a waiter cannot bound the sweep
+ * while the active holder is still pending, and recording that waiter as failed creates backoff
+ * without an attempt — so indefinite waiting is the safe default and a positive value is an
+ * explicit fail-fast override. Only negatives and non-finite values are refused; the same bounds
+ * the retired `beforeSetConcurrencyGateTimeoutMs` class-config hook enforced.
+ * @param {*} value Resolved `AiConfig.data.orchestrator.tenantRepoSync.concurrencyGateTimeoutMs` or an explicit per-call override.
+ * @returns {Number} The validated timeout in ms (`0` = wait in FIFO indefinitely).
+ * @throws {TenantRepoSyncError} `KB_TENANT_REPO_SYNC_INVALID_CONCURRENCY_GATE_TIMEOUT` when negative or non-finite.
+ */
+export function assertConcurrencyGateTimeoutMs(value) {
+    if (!Number.isFinite(value) || value < 0) {
+        throw new TenantRepoSyncError(
+            KB_TENANT_REPO_SYNC_INVALID_CONCURRENCY_GATE_TIMEOUT,
+            `tenantRepoSync.concurrencyGateTimeoutMs must be a finite number >= 0 in ms; received ${JSON.stringify(value)}. 0 waits in FIFO indefinitely; a positive value is an explicit fail-fast override.`,
             {phase: 'config-validation', received: value}
         )
     }

--- a/ai/daemons/orchestrator/services/TenantRepoSyncErrors.mjs
+++ b/ai/daemons/orchestrator/services/TenantRepoSyncErrors.mjs
@@ -110,6 +110,14 @@ export const TENANT_REPO_SYNC_ERROR_CODES = Object.freeze([
     KB_TENANT_REPO_SYNC_TENANT_NOT_FOUND,
     KB_TENANT_REPO_SYNC_MANIFEST_UPDATE_FAILED,
     KB_TENANT_REPO_SYNC_CONCURRENCY_GATE_TIMEOUT,
+    // Membership here is the PRESERVATION mechanism, not bookkeeping: `runTask()` keeps a thrown
+    // code only when `isTenantRepoSyncErrorCode` says it is a member and wraps everything else as
+    // the unspecific SYNC_FAILED — so a typed config refusal that is not listed dies at the public
+    // boundary and the operator reads a generic failure. (The sibling INVALID_SLICE_BUDGET is NOT
+    // a member and shares that wrap today; changing its public behavior is follow-up territory,
+    // deliberately not smuggled into this concurrency lane.)
+    KB_TENANT_REPO_SYNC_INVALID_CONCURRENCY_LIMIT,
+    KB_TENANT_REPO_SYNC_INVALID_CONCURRENCY_GATE_TIMEOUT,
     KB_TENANT_REPO_SYNC_EMPTY_MATERIALIZATION,
     KB_TENANT_REPO_SYNC_MATERIALIZATION_UNPROVEN,
     KB_TENANT_REPO_SYNC_CONTENT_NOT_EMBEDDABLE,

--- a/ai/daemons/orchestrator/services/TenantRepoSyncErrors.mjs
+++ b/ai/daemons/orchestrator/services/TenantRepoSyncErrors.mjs
@@ -29,6 +29,18 @@ export const KB_TENANT_REPO_SYNC_CONCURRENCY_GATE_TIMEOUT = 'KB_TENANT_REPO_SYNC
 // this budget exists to remove, spelled as though it were an off switch. Effectively-unbounded is
 // expressed as a large number, visibly, and there is no value that turns the bound off.
 export const KB_TENANT_REPO_SYNC_INVALID_SLICE_BUDGET = 'KB_TENANT_REPO_SYNC_INVALID_SLICE_BUDGET';
+// A resolved `tenantRepoSync.concurrencyLimit` that is not a positive integer. `0` is rejected
+// rather than read as "unlimited": it would size a semaphore no acquirer can ever enter, so the
+// sweep would hang on its first repo — the never-acquirable-semaphore case. Fractional values are
+// rejected because `active < limit` semantics become ambiguous (1.5 admits two slots). Refusal over
+// substitution: the value resolves from an AiConfig leaf with no construction-time hook, and a
+// consumption-site fallback would be a hidden default (the SSOT ADR's antipattern catalog) — an
+// operator who mistyped the knob must see the refusal, not a silently different concurrency.
+export const KB_TENANT_REPO_SYNC_INVALID_CONCURRENCY_LIMIT = 'KB_TENANT_REPO_SYNC_INVALID_CONCURRENCY_LIMIT';
+// A resolved `tenantRepoSync.concurrencyGateTimeoutMs` that is not a finite number >= 0. Unlike the
+// two codes above, `0` is VALID here — it is the FIFO-wait sentinel (queued acquirers wait until a
+// slot frees), not a disable-the-bound footgun. Only negatives and non-finite values are refused.
+export const KB_TENANT_REPO_SYNC_INVALID_CONCURRENCY_GATE_TIMEOUT = 'KB_TENANT_REPO_SYNC_INVALID_CONCURRENCY_GATE_TIMEOUT';
 export const KB_TENANT_REPO_SYNC_EMPTY_MATERIALIZATION = 'KB_TENANT_REPO_SYNC_EMPTY_MATERIALIZATION';
 // The OTHER half of what `EMPTY_MATERIALIZATION` used to carry, and the opposite instruction.
 // A full materialization DID take effect — rows were ingested or deleted — but no receipt proves

--- a/ai/daemons/orchestrator/services/TenantRepoSyncService.mjs
+++ b/ai/daemons/orchestrator/services/TenantRepoSyncService.mjs
@@ -39,6 +39,8 @@ import {
     TenantRepoAccessStatus
 } from '../../../services/knowledge-base/helpers/tenantRepoAccessContract.mjs';
 import {
+    assertConcurrencyGateTimeoutMs,
+    assertConcurrencyLimit,
     assertSliceBudgetMs,
     createSliceBudgetPredicate,
     createYieldCauseResolver,
@@ -118,9 +120,9 @@ const
  * acquirers reject with `KB_TENANT_REPO_SYNC_CONCURRENCY_GATE_TIMEOUT` after the
  * configured duration.
  *
- * Lifecycle is bounded to a single `runTask` invocation — a fresh semaphore is
- * created per call from the current reactive `concurrencyLimit` /
- * `concurrencyGateTimeoutMs` config values, so live config edits take effect
+ * Lifecycle is bounded to a single sweep — a fresh semaphore is created per call
+ * from the resolved `tenantRepoSync.concurrencyLimit` / `concurrencyGateTimeoutMs`
+ * AiConfig leaves (or explicit per-call overrides), so a config edit takes effect
  * on the next cycle.
  *
  * @param {Object} options
@@ -860,27 +862,7 @@ class TenantRepoSyncService extends Base {
          * @member {Boolean} singleton=true
          * @protected
          */
-        singleton: true,
-        /**
-         * Concurrency cap on simultaneous tenant-repo git/ingest work within one
-         * `runTask` invocation. Default `2` is conservative for multi-tenant
-         * cloud deployments. Set to `1` to serialize all work when deployment
-         * capacity is constrained. Set higher when network/CPU headroom permits.
-         * @member {Number} concurrencyLimit_=2
-         * @reactive
-         */
-        concurrencyLimit_: 2,
-        /**
-         * Maximum time a per-repo task waits to acquire a concurrency slot before
-         * surfacing `KB_TENANT_REPO_SYNC_CONCURRENCY_GATE_TIMEOUT`. Default `0`
-         * keeps ordinary work in the FIFO until a slot is released: timing out a
-         * waiter cannot bound `runTask` while the active holder is still pending,
-         * and recording that waiter as failed creates backoff without an attempt.
-         * A positive value remains an explicit fail-fast override.
-         * @member {Number} concurrencyGateTimeoutMs_=0
-         * @reactive
-         */
-        concurrencyGateTimeoutMs_: 0
+        singleton: true
     }
 
     /**
@@ -921,34 +903,6 @@ class TenantRepoSyncService extends Base {
      * @protected
      */
     embeddingRecoveryClock = Date.now
-
-    /**
-     * Rejects non-positive-integer `concurrencyLimit` values. `0` would create a
-     * never-acquirable semaphore; negatives and fractional values produce ambiguous
-     * `active < limit` semantics (1.5 admits two slots, etc.). Invalid values fall
-     * back to the previous valid value, or the template default if no prior value.
-     *
-     * @param {*} value
-     * @param {Number} oldValue
-     * @returns {Number}
-     */
-    beforeSetConcurrencyLimit(value, oldValue) {
-        if (!Number.isInteger(value) || value < 1) return oldValue ?? 2;
-        return value;
-    }
-
-    /**
-     * Rejects non-finite or negative `concurrencyGateTimeoutMs` values. `0` is a
-     * valid sentinel meaning "no timeout — slots wait indefinitely until release".
-     *
-     * @param {*} value
-     * @param {Number} oldValue
-     * @returns {Number}
-     */
-    beforeSetConcurrencyGateTimeoutMs(value, oldValue) {
-        if (!Number.isFinite(value) || value < 0) return oldValue ?? 0;
-        return value;
-    }
 
     /**
      * @summary Returns a bounded readiness result for one effective repository.
@@ -1203,14 +1157,20 @@ class TenantRepoSyncService extends Base {
      * @param {Object} [options.gitMirror=GitMirror] GitMirror-compatible primitive.
      * @param {Function} [options.writeLog] Optional orchestrator logger.
      * @param {Number} [options.globalCadenceMs] Global per-repo cadence fallback.
+     * @param {Number} [options.concurrencyLimit] Probe-concurrency cap; defaults to the resolved `tenantRepoSync.concurrencyLimit` leaf.
      * @returns {Promise<void>}
      */
     async refreshTenantRepoAccessReadiness({
         repos = [],
         gitMirror = GitMirror,
         writeLog,
-        globalCadenceMs = AiConfig.data.orchestrator.intervals.tenantRepoSyncMs
+        globalCadenceMs  = AiConfig.data.orchestrator.intervals.tenantRepoSyncMs,
+        concurrencyLimit = AiConfig.data.orchestrator.tenantRepoSync.concurrencyLimit
     } = {}) {
+        // Validated before the readiness cache is touched: an invalid limit must refuse the whole
+        // refresh, not evict cache entries first and then fail at the semaphore.
+        assertConcurrencyLimit(concurrencyLimit);
+
         const enabledRepos = repos.filter(repo => !isTenantRepoDisabled(repo));
         const activeKeys   = new Set(enabledRepos.map(createTenantRepoAccessKey));
 
@@ -1221,7 +1181,7 @@ class TenantRepoSyncService extends Base {
         }
 
         const semaphore = createConcurrencySemaphore({
-            limit: this.concurrencyLimit
+            limit: concurrencyLimit
         });
 
         await Promise.all(enabledRepos.map(async repo => {
@@ -1475,6 +1435,12 @@ class TenantRepoSyncService extends Base {
         leaseStaleAfterMs = AiConfig.data.orchestrator.tenantRepoSync.leaseStaleAfterMs,
         backoffCapMs      = AiConfig.data.orchestrator.tenantRepoSync.backoffCapMs,
         starvedAfterMs    = AiConfig.data.orchestrator.tenantRepoSync.starvedAfterMs,
+        // Deliberately NO leaf-read defaults on these two: `runTask` never consumes them itself,
+        // so it relays only an explicit per-call override (undefined otherwise) and the consuming
+        // method (`syncTenantRepos`) resolves the leaves at its own use site — exactly one SSOT
+        // read per consumption site, no pass-along of a resolved value.
+        concurrencyLimit,
+        concurrencyGateTimeoutMs,
         leaseRenewalIntervalMs,
         seedBootstrap     = true,
         embeddingRecoveryProbe,
@@ -1637,6 +1603,7 @@ class TenantRepoSyncService extends Base {
                 leasePath        : resolvedLeasePath,
                 revisionsFilePath: resolvedRevisionsPath,
                 globalCadenceMs, jitterRatio, backoffCapMs, starvedAfterMs, seedBootstrap,
+                concurrencyLimit, concurrencyGateTimeoutMs,
                 embeddingRecoveryProbe,
                 embeddingRecoveryClock,
                 embeddingRecoveryProbeTimeoutMs,
@@ -1716,6 +1683,8 @@ class TenantRepoSyncService extends Base {
         backoffCapMs       = AiConfig.data.orchestrator.tenantRepoSync.backoffCapMs,
         sliceBudgetMs      = AiConfig.data.orchestrator.tenantRepoSync.sliceBudgetMs,
         starvedAfterMs     = AiConfig.data.orchestrator.tenantRepoSync.starvedAfterMs,
+        concurrencyLimit         = AiConfig.data.orchestrator.tenantRepoSync.concurrencyLimit,
+        concurrencyGateTimeoutMs = AiConfig.data.orchestrator.tenantRepoSync.concurrencyGateTimeoutMs,
         healEventLedgerDir = revisionsFilePath ? path.join(path.dirname(revisionsFilePath), 'heal-events') : null,
         seedBootstrap      = true,
         embeddingRecoveryProbe,
@@ -1735,8 +1704,12 @@ class TenantRepoSyncService extends Base {
         // Validated BEFORE any repo is admitted, not at the first yield check. A budget that only
         // fails once a slice is already running would refuse the sweep midway through a repo that
         // had already acquired a slot — the operator sees a partial sweep and a config error at the
-        // same time and has to work out which caused which.
+        // same time and has to work out which caused which. The concurrency pair is gated at the
+        // same boundary for the same reason: these three resolved values jointly shape the sweep,
+        // and a sweep must be refused whole or admitted whole.
         assertSliceBudgetMs(sliceBudgetMs);
+        assertConcurrencyLimit(concurrencyLimit);
+        assertConcurrencyGateTimeoutMs(concurrencyGateTimeoutMs);
 
         const resolvedConfig = tenantReposConfig || await this.resolveTenantReposConfig({ingestionService: knowledgeBaseIngestionService});
         const allRepos       = resolvedConfig.tenantRepos || [];
@@ -1827,11 +1800,15 @@ class TenantRepoSyncService extends Base {
             return {status: 'skipped', details};
         }
 
+        // Passes the sweep's resolved limit explicitly so one sweep's phases share one concurrency
+        // posture — a per-call override on this method governs the probes too. Standalone callers
+        // of `refreshTenantRepoAccessReadiness` still get its own leaf-read default.
         await this.refreshTenantRepoAccessReadiness({
             repos: allRepos,
             gitMirror,
             writeLog,
-            globalCadenceMs
+            globalCadenceMs,
+            concurrencyLimit
         });
 
         const resolvedRevisionsPath          = revisionsFilePath || this.defaultRevisionsFilePath();
@@ -2149,13 +2126,14 @@ class TenantRepoSyncService extends Base {
             })
         };
 
-        // Per-runTask concurrency gate caps simultaneous git/ingest work.
-        // Fresh instance per call so live `concurrencyLimit` / `concurrencyGateTimeoutMs`
-        // config edits take effect on the next cycle. JS is single-threaded so the shared
-        // mutable counters (`completedCount` / `failedCount`) and `repoStates` array are safe.
+        // Per-sweep concurrency gate caps simultaneous git/ingest work.
+        // Fresh instance per call from the resolved `tenantRepoSync.concurrencyLimit` /
+        // `concurrencyGateTimeoutMs` leaves (or explicit per-call overrides), so a config edit
+        // takes effect on the next cycle. JS is single-threaded so the shared mutable counters
+        // (`completedCount` / `failedCount`) and `repoStates` array are safe.
         const semaphore = createConcurrencySemaphore({
-            limit    : this.concurrencyLimit,
-            timeoutMs: this.concurrencyGateTimeoutMs
+            limit    : concurrencyLimit,
+            timeoutMs: concurrencyGateTimeoutMs
         });
 
         let notDueCount               = 0;
@@ -2228,7 +2206,7 @@ class TenantRepoSyncService extends Base {
                     (a.priorState?.lastRunAttemptAt ?? 0) - (b.priorState?.lastRunAttemptAt ?? 0)
                     || a.repoLabel.localeCompare(b.repoLabel)
                 )
-                .slice(0, this.concurrencyLimit);
+                .slice(0, concurrencyLimit);
 
             for (const {repoLabel} of dueLegacyRepos) {
                 revalidationAdmissionLabels.add(repoLabel);

--- a/ai/scripts/lint/config-leaf-parity.json
+++ b/ai/scripts/lint/config-leaf-parity.json
@@ -467,6 +467,8 @@
         "orchestrator.tenantRepoMirrorRoot",
         "orchestrator.tenantRepoSync",
         "orchestrator.tenantRepoSync.backoffCapMs",
+        "orchestrator.tenantRepoSync.concurrencyGateTimeoutMs",
+        "orchestrator.tenantRepoSync.concurrencyLimit",
         "orchestrator.tenantRepoSync.jitterRatio",
         "orchestrator.tenantRepoSync.leaseStaleAfterMs",
         "orchestrator.tenantRepoSync.sliceBudgetMs",

--- a/test/playwright/unit/ai/daemons/orchestrator/scheduling/tenantRepoSync.concurrencyAsserts.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/scheduling/tenantRepoSync.concurrencyAsserts.spec.mjs
@@ -1,0 +1,50 @@
+import {test, expect} from '@playwright/test';
+import {
+    assertConcurrencyGateTimeoutMs,
+    assertConcurrencyLimit
+} from '../../../../../../../ai/daemons/orchestrator/scheduling/tenantRepoSync.mjs';
+
+// Pure-function bounds for the two concurrency asserts — the consumption-boundary
+// replacement for the retired `beforeSetConcurrencyLimit` / `beforeSetConcurrencyGateTimeoutMs`
+// class-config hooks, which substituted invalid values; these throw, because a consumption-site
+// substitute is a hidden default (the SSOT ADR's antipattern catalog). The WIRING — that `syncTenantRepos` and
+// `refreshTenantRepoAccessReadiness` call these before any work — is proven in
+// services/TenantRepoSyncService.spec.mjs; these arms pin the bounds themselves, exercisable
+// without booting the class system (the same reason assertSliceBudgetMs lives beside them).
+test.describe('tenantRepoSync concurrency asserts (#17158)', () => {
+    test('assertConcurrencyLimit returns valid positive integers unchanged', () => {
+        expect(assertConcurrencyLimit(1)).toBe(1);
+        expect(assertConcurrencyLimit(2)).toBe(2);
+        expect(assertConcurrencyLimit(10)).toBe(10);
+    });
+
+    test('assertConcurrencyLimit throws its typed code for every invalid shape — 0 is not "unlimited"', () => {
+        for (const bad of [0, -1, 1.5, NaN, Infinity, '3', null, undefined, {}, []]) {
+            let thrown = null;
+
+            try { assertConcurrencyLimit(bad) } catch (error) { thrown = error }
+
+            expect(thrown?.code, `${JSON.stringify(bad)} must be rejected`)
+                .toBe('KB_TENANT_REPO_SYNC_INVALID_CONCURRENCY_LIMIT');
+            expect(thrown?.meta).toMatchObject({phase: 'config-validation'});
+        }
+    });
+
+    test('assertConcurrencyGateTimeoutMs keeps 0 as the valid FIFO-wait sentinel', () => {
+        expect(assertConcurrencyGateTimeoutMs(0)).toBe(0);
+        expect(assertConcurrencyGateTimeoutMs(50)).toBe(50);
+        expect(assertConcurrencyGateTimeoutMs(60_000)).toBe(60_000);
+    });
+
+    test('assertConcurrencyGateTimeoutMs throws its typed code for negatives and non-finite values', () => {
+        for (const bad of [-1, -100, NaN, Infinity, -Infinity, '5000', null, undefined]) {
+            let thrown = null;
+
+            try { assertConcurrencyGateTimeoutMs(bad) } catch (error) { thrown = error }
+
+            expect(thrown?.code, `${JSON.stringify(bad)} must be rejected`)
+                .toBe('KB_TENANT_REPO_SYNC_INVALID_CONCURRENCY_GATE_TIMEOUT');
+            expect(thrown?.meta).toMatchObject({phase: 'config-validation'});
+        }
+    });
+});

--- a/test/playwright/unit/ai/daemons/orchestrator/services/TenantRepoSyncErrors.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/services/TenantRepoSyncErrors.spec.mjs
@@ -7,6 +7,8 @@ import {
     KB_TENANT_REPO_SYNC_TENANT_NOT_FOUND,
     KB_TENANT_REPO_SYNC_MANIFEST_UPDATE_FAILED,
     KB_TENANT_REPO_SYNC_CONCURRENCY_GATE_TIMEOUT,
+    KB_TENANT_REPO_SYNC_INVALID_CONCURRENCY_GATE_TIMEOUT,
+    KB_TENANT_REPO_SYNC_INVALID_CONCURRENCY_LIMIT,
     KB_TENANT_REPO_SYNC_EMPTY_MATERIALIZATION,
     KB_TENANT_REPO_SYNC_CONTENT_NOT_EMBEDDABLE,
     KB_TENANT_REPO_SYNC_MATERIALIZATION_UNPROVEN,
@@ -36,7 +38,7 @@ test.describe('TenantRepoSyncErrors taxonomy (#11942 AC3+AC4)', () => {
 
     test('TENANT_REPO_SYNC_ERROR_CODES array contains exactly the exported codes', () => {
         expect(Array.isArray(TENANT_REPO_SYNC_ERROR_CODES)).toBe(true);
-        expect(TENANT_REPO_SYNC_ERROR_CODES.length).toBe(11);
+        expect(TENANT_REPO_SYNC_ERROR_CODES.length).toBe(13);
         expect(TENANT_REPO_SYNC_ERROR_CODES).toContain(KB_TENANT_REPO_SYNC_SYNC_FAILED);
         expect(TENANT_REPO_SYNC_ERROR_CODES).toContain(KB_TENANT_REPO_SYNC_LEASE_HELD);
         expect(TENANT_REPO_SYNC_ERROR_CODES).toContain(KB_TENANT_REPO_SYNC_LEASE_LOST);
@@ -44,6 +46,10 @@ test.describe('TenantRepoSyncErrors taxonomy (#11942 AC3+AC4)', () => {
         expect(TENANT_REPO_SYNC_ERROR_CODES).toContain(KB_TENANT_REPO_SYNC_TENANT_NOT_FOUND);
         expect(TENANT_REPO_SYNC_ERROR_CODES).toContain(KB_TENANT_REPO_SYNC_MANIFEST_UPDATE_FAILED);
         expect(TENANT_REPO_SYNC_ERROR_CODES).toContain(KB_TENANT_REPO_SYNC_CONCURRENCY_GATE_TIMEOUT);
+        // Membership is the runTask preservation mechanism: a typed config refusal outside this
+        // list is wrapped to SYNC_FAILED at the public boundary.
+        expect(TENANT_REPO_SYNC_ERROR_CODES).toContain(KB_TENANT_REPO_SYNC_INVALID_CONCURRENCY_LIMIT);
+        expect(TENANT_REPO_SYNC_ERROR_CODES).toContain(KB_TENANT_REPO_SYNC_INVALID_CONCURRENCY_GATE_TIMEOUT);
         expect(TENANT_REPO_SYNC_ERROR_CODES).toContain(KB_TENANT_REPO_SYNC_EMPTY_MATERIALIZATION);
         // The effect-bearing sibling. Bumping the count alone would let a new code pass the guard
         // without ever being named — the count is a tripwire, membership is the actual assertion.
@@ -62,7 +68,7 @@ test.describe('TenantRepoSyncErrors taxonomy (#11942 AC3+AC4)', () => {
         expect(() => TENANT_REPO_SYNC_ERROR_CODES.push('KB_TENANT_REPO_SYNC_MUTATED')).toThrow(TypeError);
         expect(() => { TENANT_REPO_SYNC_ERROR_CODES[TENANT_REPO_SYNC_ERROR_CODES.length] = 'KB_TENANT_REPO_SYNC_MUTATED'; }).toThrow(TypeError);
         expect(() => { TENANT_REPO_SYNC_ERROR_CODES.length = 0; }).toThrow(TypeError);
-        expect(TENANT_REPO_SYNC_ERROR_CODES.length).toBe(11);
+        expect(TENANT_REPO_SYNC_ERROR_CODES.length).toBe(13);
         expect(TENANT_REPO_SYNC_ERROR_CODES).not.toContain('KB_TENANT_REPO_SYNC_MUTATED');
         expect(isTenantRepoSyncErrorCode('KB_TENANT_REPO_SYNC_MUTATED')).toBe(false);
     });

--- a/test/playwright/unit/ai/daemons/orchestrator/services/TenantRepoSyncService.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/services/TenantRepoSyncService.spec.mjs
@@ -66,6 +66,11 @@ import {
 } from '../../../../../../../ai/services/knowledge-base/helpers/embedFailureClassification.mjs';
 import TextEmbeddingService from '../../../../../../../ai/services/memory-core/TextEmbeddingService.mjs';
 import {snapshotAiConfig}   from '../../../services/memory-core/util.mjs';
+// The SAME singleton instance the service imports (module cache): required by the joined
+// leaf-wiring witnesses, which drive resolution through `setEnvOverride` (the provider's own
+// sanctioned env-layer API, capture/restore in finally — never a raw data mutation) and observe
+// the semaphore.
+import AiConfig             from '../../../../../../../ai/config.mjs';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname  = path.dirname(__filename);
@@ -5232,6 +5237,145 @@ test.describe('TenantRepoSyncService (#11790)', () => {
         } catch (error) { thrown = error }
 
         expect(thrown?.code).toBe('KB_TENANT_REPO_SYNC_INVALID_CONCURRENCY_LIMIT');
+    });
+
+    test('concurrency-gate: runTask preserves both typed config-refusal codes through the public boundary (#17158 RA-2)', async () => {
+        const baseOptions = () => ({
+            reason           : 'periodic',
+            taskStateService : createInMemoryTaskStateService(),
+            tenantReposConfig: {tenantRepos: [{
+                tenantId: 't1', repoSlug: 'org/r1', mirrorRoot, cloneUrl: 'https://github.com/neomjs/r1.git'
+            }]},
+            gitMirror                    : makeFakeGitMirror(),
+            envelopeBuilder              : makeFakeEnvelopeBuilder(),
+            knowledgeBaseIngestionService: makeFakeIngestionService(),
+            revisionsFilePath            : revisionsFile,
+            seedBootstrap                : false
+        });
+
+        // Without taxonomy membership, runTask's catch wraps these as the unspecific
+        // KB_TENANT_REPO_SYNC_SYNC_FAILED and the operator loses the actionable reason.
+        const limitResult = await TenantRepoSyncService.runTask({...baseOptions(), concurrencyLimit: 0});
+
+        expect(limitResult.status).toBe('failed');
+        expect(limitResult.details.reasonCode).toBe('KB_TENANT_REPO_SYNC_INVALID_CONCURRENCY_LIMIT');
+
+        const timeoutResult = await TenantRepoSyncService.runTask({...baseOptions(), concurrencyGateTimeoutMs: -1});
+
+        expect(timeoutResult.status).toBe('failed');
+        expect(timeoutResult.details.reasonCode).toBe('KB_TENANT_REPO_SYNC_INVALID_CONCURRENCY_GATE_TIMEOUT');
+    });
+
+    test('concurrency-gate: the resolved concurrencyLimit leaf drives standalone refreshTenantRepoAccessReadiness — no injection (#17158 RA-1)', async () => {
+        const
+            envName       = 'NEO_ORCHESTRATOR_TENANT_REPO_SYNC_CONCURRENCY_LIMIT',
+            originalValue = AiConfig.data.orchestrator.tenantRepoSync.concurrencyLimit,
+            inFlightLog   = [];
+        let inFlight = 0;
+
+        // `inspectCredentialReadiness` is the instrumented slot the per-repo semaphore wraps;
+        // `probeRemoteAccess` exists only to pass the entry's probe-shape check. Returning null
+        // degrades each repo gracefully AFTER the tracked window — readiness outcomes are
+        // irrelevant here, only concurrency is.
+        const trackingMirror = {
+            async inspectCredentialReadiness() {
+                inFlight++;
+                inFlightLog.push(inFlight);
+                await new Promise(resolve => setTimeout(resolve, 15));
+                inFlight--;
+                return null;
+            },
+            async probeRemoteAccess() { return null; }
+        };
+
+        // `credentialRef` is required: without it `hashTenantRepoAccessConfig` throws and every repo
+        // degrades BEFORE the probe — the semaphore would wrap zero tracked calls.
+        const repos = ['org/r1', 'org/r2', 'org/r3'].map(repoSlug => ({
+            tenantId     : 't1', repoSlug, mirrorRoot,
+            cloneUrl     : `https://github.com/neomjs/${repoSlug.split('/')[1]}.git`,
+            credentialRef: 'env:TENANT_REPO_TOKEN'
+        }));
+
+        try {
+            // The provider's own sanctioned env-layer API (capture/restore in finally — never a raw
+            // data mutation). This witness crosses override → resolved leaf → default parameter →
+            // semaphore with NO explicit concurrency argument anywhere: replacing the use-site
+            // default with a literal turns it red (the reviewer's round-1 mutation falsifier).
+            AiConfig.setEnvOverride(envName, 1);
+
+            await TenantRepoSyncService.refreshTenantRepoAccessReadiness({repos, gitMirror: trackingMirror});
+
+            expect(inFlightLog.length).toBe(3);
+            expect(Math.max(...inFlightLog)).toBe(1);
+        } finally {
+            AiConfig.setEnvOverride(envName, originalValue);
+            TenantRepoSyncService.clearTenantRepoAccessReadiness();
+        }
+    });
+
+    test('concurrency-gate: env-resolved limit + gate timeout drive the sweep — a queued repo times out typed with no injection (#17158 RA-1)', async () => {
+        const
+            limitEnv    = 'NEO_ORCHESTRATOR_TENANT_REPO_SYNC_CONCURRENCY_LIMIT',
+            timeoutEnv  = 'NEO_ORCHESTRATOR_TENANT_REPO_SYNC_CONCURRENCY_GATE_TIMEOUT_MS',
+            origLimit   = AiConfig.data.orchestrator.tenantRepoSync.concurrencyLimit,
+            origTimeout = AiConfig.data.orchestrator.tenantRepoSync.concurrencyGateTimeoutMs;
+        let releaseFirstRepo;
+        const firstRepoGate  = new Promise(resolve => { releaseFirstRepo = resolve; });
+        let   cloneCallCount = 0;
+
+        const slowMirror = {
+            async cloneIfMissing() {
+                cloneCallCount++;
+                if (cloneCallCount === 1) {
+                    // First repo holds the only slot until the test releases it.
+                    await firstRepoGate;
+                }
+            },
+            async fetch()            {},
+            async resolveHead({ref}) { return `sha-for-${ref}`; },
+            async isAncestor()       { return true; },
+            async diffRevisions()    { return {addedOrChanged: [], deleted: []}; }
+        };
+
+        for (const slug of ['org/slow', 'org/queued']) {
+            await provisionMirrorDir({tenantId: 't1', repoSlug: slug});
+        }
+
+        try {
+            AiConfig.setEnvOverride(limitEnv, 1);
+            AiConfig.setEnvOverride(timeoutEnv, 50);
+
+            const resultPromise = TenantRepoSyncService.runTask({
+                reason           : 'periodic',
+                taskStateService : createInMemoryTaskStateService(),
+                tenantReposConfig: {tenantRepos: [
+                    {tenantId: 't1', repoSlug: 'org/slow',   mirrorRoot, cloneUrl: 'https://github.com/neomjs/slow.git'},
+                    {tenantId: 't1', repoSlug: 'org/queued', mirrorRoot, cloneUrl: 'https://github.com/neomjs/queued.git'}
+                ]},
+                gitMirror                    : slowMirror,
+                envelopeBuilder              : makeFakeEnvelopeBuilder(),
+                knowledgeBaseIngestionService: makeFakeIngestionService(),
+                revisionsFilePath            : revisionsFile,
+                seedBootstrap                : false
+            });
+
+            // Wait past the 50ms env-resolved slot timeout, then release the holder.
+            await new Promise(resolve => setTimeout(resolve, 150));
+            releaseFirstRepo();
+            const result = await resultPromise;
+
+            // Both env-resolved values are load-bearing: at the literal defaults (2/0) nothing
+            // queues and nothing times out — the reviewer's mutation falsifier goes red here.
+            const queuedState = result.details.repos.find(r => r.repoSlug === 'org/queued');
+
+            expect(queuedState).toBeDefined();
+            expect(queuedState.status).toBe('degraded');
+            expect(queuedState.lastErrorCode).toBe('KB_TENANT_REPO_SYNC_CONCURRENCY_GATE_TIMEOUT');
+        } finally {
+            releaseFirstRepo?.();
+            AiConfig.setEnvOverride(limitEnv, origLimit);
+            AiConfig.setEnvOverride(timeoutEnv, origTimeout);
+        }
     });
 
     test('jitter+backoff: skips not-due repo with prior recent lastRunAttemptAt (#11942 AC1)', async () => {

--- a/test/playwright/unit/ai/daemons/orchestrator/services/TenantRepoSyncService.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/services/TenantRepoSyncService.spec.mjs
@@ -66,11 +66,12 @@ import {
 } from '../../../../../../../ai/services/knowledge-base/helpers/embedFailureClassification.mjs';
 import TextEmbeddingService from '../../../../../../../ai/services/memory-core/TextEmbeddingService.mjs';
 import {snapshotAiConfig}   from '../../../services/memory-core/util.mjs';
-// The SAME singleton instance the service imports (module cache): required by the joined
-// leaf-wiring witnesses, which drive resolution through `setEnvOverride` (the provider's own
-// sanctioned env-layer API, capture/restore in finally — never a raw data mutation) and observe
-// the semaphore.
-import AiConfig             from '../../../../../../../ai/config.mjs';
+// The CANONICAL template (C3: tests never import the overlay). The joined leaf-wiring witnesses
+// drive `setEnvOverride` here — the provider's own sanctioned env-layer API, capture/restore in
+// finally, never a raw data mutation — and the override reaches the service's reads through the
+// provider hierarchy: reads resolve override-else-inherit, and the overlay carries no delta for
+// these leaves.
+import AiConfig             from '../../../../../../../ai/config.template.mjs';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname  = path.dirname(__filename);

--- a/test/playwright/unit/ai/daemons/orchestrator/services/TenantRepoSyncService.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/services/TenantRepoSyncService.spec.mjs
@@ -229,10 +229,9 @@ test.describe('TenantRepoSyncService (#11790)', () => {
 
     test.afterEach(async () => {
         await fs.remove(tmpDir);
-        // Restore the singleton's reactive config to default values so
-        // concurrency tests cannot leak opt-in timeouts / serial-limit to siblings.
-        TenantRepoSyncService.concurrencyLimit         = 2;
-        TenantRepoSyncService.concurrencyGateTimeoutMs = 0;
+        // The concurrency knobs resolve from AiConfig leaves per call since their class-config
+        // retirement — no singleton config state exists to leak between tests; non-default widths
+        // are injected per call.
         TenantRepoSyncService.clearTenantRepoAccessReadiness();
         TenantRepoSyncService.clearEmbeddingRecoveryProbeState();
     });
@@ -3260,7 +3259,6 @@ test.describe('TenantRepoSyncService (#11790)', () => {
         const bothEntered = new Promise(resolve => signalBothEntered = resolve);
 
         MemoryCoreConfig.ollama.maxInFlightEmbeddings = 1;
-        TenantRepoSyncService.concurrencyLimit        = 2;
 
         TextEmbeddingService.ollamaProvider = {
             embed(inputs) {
@@ -3450,8 +3448,6 @@ test.describe('TenantRepoSyncService (#11790)', () => {
             id           : embeddingConfig.openAiCompatible.embeddingModel,
             contextLength: embeddingConfig.localModels.embedding.contextLimitTokens
         }];
-        TenantRepoSyncService.concurrencyLimit = 2;
-
         ingestionService.ingestSourceFilesForTenantSync = async (payload, controls) => {
             const embeddingPromise = TextEmbeddingService.embedTexts([payload.repoSlug], 'openAiCompatible', {
                 ...controls,
@@ -3882,8 +3878,6 @@ test.describe('TenantRepoSyncService (#11790)', () => {
             currentSlug      = 'org/current',
             envelopeCalls    = [];
 
-        TenantRepoSyncService.concurrencyLimit = 2;
-
         await fs.writeJson(revisionsFile, {
             revisions: {
                 't1/org/legacy-a': {lastIngestedRev: 'sha-a', lastRunAttemptAt: 0, consecutiveFailures: 0},
@@ -3927,7 +3921,9 @@ test.describe('TenantRepoSyncService (#11790)', () => {
             revisionsFilePath            : revisionsFile,
             globalCadenceMs              : 0,
             jitterRatio                  : 0,
-            seedBootstrap                : false
+            seedBootstrap                : false,
+            // The cohort width this test's assertions are built around (was a class-config set).
+            concurrencyLimit             : 2
         };
 
         const firstSweep = await TenantRepoSyncService.runTask(options);
@@ -3972,9 +3968,6 @@ test.describe('TenantRepoSyncService (#11790)', () => {
             legacySlug       = 'org/legacy-starvation',
             mirrorCalls      = [],
             envelopeCalls    = [];
-
-        TenantRepoSyncService.concurrencyLimit         = 1;
-        TenantRepoSyncService.concurrencyGateTimeoutMs = 15;
 
         await fs.writeJson(revisionsFile, {
             revisions: {
@@ -4063,9 +4056,6 @@ test.describe('TenantRepoSyncService (#11790)', () => {
             legacySlug       = 'org/legacy-slow',
             envelopeCalls    = [];
 
-        TenantRepoSyncService.concurrencyLimit         = 1;
-        TenantRepoSyncService.concurrencyGateTimeoutMs = 15;
-
         await fs.writeJson(revisionsFile, {
             revisions: {
                 [`t1/${currentSlug}`]: {
@@ -4118,7 +4108,9 @@ test.describe('TenantRepoSyncService (#11790)', () => {
             revisionsFilePath            : revisionsFile,
             globalCadenceMs              : 0,
             jitterRatio                  : 0,
-            seedBootstrap                : false
+            seedBootstrap                : false,
+            concurrencyLimit             : 1,
+            concurrencyGateTimeoutMs     : 15
         });
 
         expect(result).toMatchObject({
@@ -4796,8 +4788,6 @@ test.describe('TenantRepoSyncService (#11790)', () => {
                 vectorService                 : IngestionService.vectorService
             };
 
-        TenantRepoSyncService.concurrencyLimit = 2;
-
         const matchesWhere = (metadata, where) => {
             if (!where) return true;
             if (Array.isArray(where.$and)) {
@@ -5087,8 +5077,6 @@ test.describe('TenantRepoSyncService (#11790)', () => {
 
 
     test('concurrency-gate: concurrencyLimit=1 serializes per-repo work (#11942 AC2)', async () => {
-        TenantRepoSyncService.concurrencyLimit = 1;
-
         const inFlightLog = [];
         let   inFlight    = 0;
 
@@ -5119,7 +5107,8 @@ test.describe('TenantRepoSyncService (#11790)', () => {
             envelopeBuilder              : makeFakeEnvelopeBuilder(),
             knowledgeBaseIngestionService: makeFakeIngestionService(),
             revisionsFilePath            : revisionsFile,
-            seedBootstrap                : false
+            seedBootstrap                : false,
+            concurrencyLimit             : 1
         });
 
         expect(result.status).toBe('completed');
@@ -5130,8 +5119,6 @@ test.describe('TenantRepoSyncService (#11790)', () => {
     });
 
     test('concurrency-gate: concurrencyLimit=2 caps in-flight work at 2 with 4 repos (#11942 AC2)', async () => {
-        TenantRepoSyncService.concurrencyLimit = 2;
-
         const inFlightLog = [];
         let   inFlight    = 0;
 
@@ -5162,7 +5149,8 @@ test.describe('TenantRepoSyncService (#11790)', () => {
             envelopeBuilder              : makeFakeEnvelopeBuilder(),
             knowledgeBaseIngestionService: makeFakeIngestionService(),
             revisionsFilePath            : revisionsFile,
-            seedBootstrap                : false
+            seedBootstrap                : false,
+            concurrencyLimit             : 2
         });
 
         expect(result.status).toBe('completed');
@@ -5173,36 +5161,77 @@ test.describe('TenantRepoSyncService (#11790)', () => {
         expect(inFlightLog.every(n => n <= 2)).toBe(true);
     });
 
-    test('concurrency-gate: beforeSetConcurrencyLimit rejects invalid values (0/negative/fractional/non-integer) (#11942 AC2)', () => {
-        // Baseline: set to a known valid value.
-        TenantRepoSyncService.concurrencyLimit = 2;
-        expect(TenantRepoSyncService.concurrencyLimit).toBe(2);
+    // The retired class-config hooks substituted invalid values back to the previous valid one.
+    // Both knobs now resolve from AiConfig leaves and are validated at the consumption
+    // boundary, which THROWS: a consumption-site substitute would be a hidden default (the SSOT
+    // ADR's antipattern catalog), leaving an operator believing a mistyped knob took effect.
+    // `undefined` is deliberately NOT in
+    // the invalid lists — an absent argument now means "resolve the leaf", which is the default path
+    // every other test in this file exercises. Pure-function bounds coverage for both asserts lives
+    // in scheduling/tenantRepoSync.concurrencyAsserts.spec.mjs; these arms prove the WIRING.
+    test('concurrency-gate: an invalid concurrencyLimit refuses the sweep before any repo work (#17158)', async () => {
+        for (const invalid of [0, -1, 1.5, NaN, Infinity, '3', null, {}, []]) {
+            let thrown        = null,
+                mirrorTouched = false;
 
-        // Invalid values fall back to the previous valid value (2).
-        for (const invalid of [0, -1, 1.5, NaN, Infinity, '3', null, undefined, {}, []]) {
-            TenantRepoSyncService.concurrencyLimit = invalid;
-            expect(TenantRepoSyncService.concurrencyLimit).toBe(2);
+            try {
+                await TenantRepoSyncService.syncTenantRepos({
+                    taskStateService : createInMemoryTaskStateService(),
+                    leaseGuard       : async () => {},
+                    tenantReposConfig: {tenantRepos: [{
+                        tenantId: 't1', repoSlug: 'org/r1', mirrorRoot, cloneUrl: 'https://github.com/neomjs/r1.git'
+                    }]},
+                    gitMirror                    : {async cloneIfMissing() { mirrorTouched = true }},
+                    envelopeBuilder              : makeFakeEnvelopeBuilder(),
+                    knowledgeBaseIngestionService: makeFakeIngestionService(),
+                    revisionsFilePath            : revisionsFile,
+                    seedBootstrap                : false,
+                    concurrencyLimit             : invalid
+                });
+            } catch (error) { thrown = error }
+
+            expect(thrown?.code, `${JSON.stringify(invalid)} must refuse with the typed code`)
+                .toBe('KB_TENANT_REPO_SYNC_INVALID_CONCURRENCY_LIMIT');
+            expect(mirrorTouched, 'the refusal must precede any repo work').toBe(false);
         }
-
-        // Valid integer values are accepted.
-        TenantRepoSyncService.concurrencyLimit = 1;
-        expect(TenantRepoSyncService.concurrencyLimit).toBe(1);
-        TenantRepoSyncService.concurrencyLimit = 10;
-        expect(TenantRepoSyncService.concurrencyLimit).toBe(10);
     });
 
-    test('concurrency-gate: beforeSetConcurrencyGateTimeoutMs defaults to FIFO waiting and accepts an opt-in timeout (#11942 AC2)', () => {
-        expect(TenantRepoSyncService.concurrencyGateTimeoutMs).toBe(0);
+    test('concurrency-gate: an invalid concurrencyGateTimeoutMs refuses the sweep with its typed code (#17158)', async () => {
+        for (const invalid of [-1, -100, NaN, Infinity, -Infinity, '5000', null]) {
+            let thrown = null;
 
-        // Invalid values fall back to the previous valid value.
-        for (const invalid of [-1, -100, NaN, Infinity, -Infinity, '5000', null, undefined]) {
-            TenantRepoSyncService.concurrencyGateTimeoutMs = invalid;
-            expect(TenantRepoSyncService.concurrencyGateTimeoutMs).toBe(0);
+            try {
+                await TenantRepoSyncService.syncTenantRepos({
+                    taskStateService             : createInMemoryTaskStateService(),
+                    leaseGuard                   : async () => {},
+                    tenantReposConfig            : {tenantRepos: []},
+                    gitMirror                    : makeFakeGitMirror(),
+                    envelopeBuilder              : makeFakeEnvelopeBuilder(),
+                    knowledgeBaseIngestionService: makeFakeIngestionService(),
+                    revisionsFilePath            : revisionsFile,
+                    seedBootstrap                : false,
+                    concurrencyGateTimeoutMs     : invalid
+                });
+            } catch (error) { thrown = error }
+
+            expect(thrown?.code, `${JSON.stringify(invalid)} must refuse with the typed code`)
+                .toBe('KB_TENANT_REPO_SYNC_INVALID_CONCURRENCY_GATE_TIMEOUT');
         }
+        // `0` stays the valid FIFO-wait sentinel — every default-path sweep in this file runs with
+        // it, and the queued-repos-wait FIFO test below proves what it means at the semaphore.
+    });
 
-        // Positive finite values are accepted.
-        TenantRepoSyncService.concurrencyGateTimeoutMs = 60000;
-        expect(TenantRepoSyncService.concurrencyGateTimeoutMs).toBe(60000);
+    test('concurrency-gate: refreshTenantRepoAccessReadiness validates its own limit before touching the readiness cache (#17158 second-call-site arm)', async () => {
+        let thrown = null;
+
+        try {
+            await TenantRepoSyncService.refreshTenantRepoAccessReadiness({
+                repos           : [{tenantId: 't1', repoSlug: 'org/r1', mirrorRoot, cloneUrl: 'https://github.com/neomjs/r1.git'}],
+                concurrencyLimit: 0
+            });
+        } catch (error) { thrown = error }
+
+        expect(thrown?.code).toBe('KB_TENANT_REPO_SYNC_INVALID_CONCURRENCY_LIMIT');
     });
 
     test('jitter+backoff: skips not-due repo with prior recent lastRunAttemptAt (#11942 AC1)', async () => {
@@ -5634,8 +5663,6 @@ test.describe('TenantRepoSyncService (#11790)', () => {
     });
 
     test('concurrency-gate: queued repos wait for the default FIFO slot instead of acquiring failure backoff (#16780 O3)', async () => {
-        TenantRepoSyncService.concurrencyLimit = 1;
-
         const
             nativeSetTimeout = globalThis.setTimeout,
             ingestOrder      = [];
@@ -5669,6 +5696,7 @@ test.describe('TenantRepoSyncService (#11790)', () => {
                 ]},
                 gitMirror                    : makeFakeGitMirror(),
                 envelopeBuilder              : makeFakeEnvelopeBuilder(),
+                concurrencyLimit             : 1,
                 knowledgeBaseIngestionService: makeFakeIngestionService({
                     summaryFactory: async payload => {
                         ingestOrder.push(payload.repoSlug);
@@ -5728,9 +5756,6 @@ test.describe('TenantRepoSyncService (#11790)', () => {
     });
 
     test('concurrency-gate: explicit queued slot timeout surfaces KB_TENANT_REPO_SYNC_CONCURRENCY_GATE_TIMEOUT (#11942 AC2)', async () => {
-        TenantRepoSyncService.concurrencyLimit         = 1;
-        TenantRepoSyncService.concurrencyGateTimeoutMs = 50;
-
         let releaseFirstRepo;
         const firstRepoGate  = new Promise(resolve => { releaseFirstRepo = resolve; });
         let   cloneCallCount = 0;
@@ -5763,7 +5788,9 @@ test.describe('TenantRepoSyncService (#11790)', () => {
             envelopeBuilder              : makeFakeEnvelopeBuilder(),
             knowledgeBaseIngestionService: makeFakeIngestionService(),
             revisionsFilePath            : revisionsFile,
-            seedBootstrap                : false
+            seedBootstrap                : false,
+            concurrencyLimit             : 1,
+            concurrencyGateTimeoutMs     : 50
         });
 
         // Wait long enough for the queued repo's slot acquisition to time out (~50ms).
@@ -7589,7 +7616,7 @@ test.describe('TenantRepoSyncService (#11790)', () => {
      * The slice-budget witness, driven through `syncTenantRepos` rather than `syncRepo`.
      *
      * A fixture calling one repo directly proves the branch and not the FAIRNESS, which only exists
-     * as a property of the sweep: four due repos at the live `concurrencyLimit = 2`, where the head
+     * as a property of the sweep: four due repos at the injected `concurrencyLimit = 2`, where the head
      * repo yields on its budget. What must be observable is that repos beyond the first two admitted
      * are ingested IN THE SAME SWEEP — the tail no longer waits for a head repo to complete.
      *
@@ -7699,9 +7726,8 @@ test.describe('TenantRepoSyncService (#11790)', () => {
         let signalSliceObserved;
         const sliceObserved = new Promise(resolve => { signalSliceObserved = resolve });
 
-        TenantRepoSyncService.concurrencyLimit = 2;
-
         const sliceResult = await TenantRepoSyncService.syncTenantRepos({
+            concurrencyLimit             : 2,
             taskStateService             : createInMemoryTaskStateService(),
             revisionsFilePath            : revisionsFile,
             leaseGuard                   : async () => {},
@@ -7901,8 +7927,6 @@ test.describe('TenantRepoSyncService (#11790)', () => {
             tailStarted     = new Promise(resolve => { signalTailEntered = resolve }),
             firstVoteOnly   = {cause: YIELD_CAUSE_LEASE, vote: () => ++voteCalls === 1};
 
-        TenantRepoSyncService.concurrencyLimit = 2;
-
         for (const repoSlug of repoSlugs) {
             await provisionMirrorDir({tenantId: 't1', repoSlug});
         }
@@ -7946,7 +7970,8 @@ test.describe('TenantRepoSyncService (#11790)', () => {
         };
 
         const run = TenantRepoSyncService.runTask({
-            reason       : 'periodic-sweep:60000',
+            reason          : 'periodic-sweep:60000',
+            concurrencyLimit: 2,
             taskStateService,
             healthService: {
                 recordTaskOutcome(taskName, status, details) {
@@ -7984,10 +8009,8 @@ test.describe('TenantRepoSyncService (#11790)', () => {
             .filter(call => call.op === 'ingestSourceFiles')
             .map(call => call.payload.repoSlug);
 
-        expect(
-            TenantRepoSyncService.concurrencyLimit,
-            'the fixture needs a repo beyond the active cohort'
-        ).toBeLessThan(repoSlugs.length);
+        // 2 = the concurrencyLimit injected into this sweep (the class knob is retired).
+        expect(2, 'the fixture needs a repo beyond the active cohort').toBeLessThan(repoSlugs.length);
 
         expect(tailEnteredBeforeObserverSettled, 'the shared latch must publish before any active sibling releases').toBe(false);
         expect([...ingested].sort()).toEqual(repoSlugs.slice(0, 2).sort());
@@ -8028,9 +8051,6 @@ test.describe('TenantRepoSyncService (#11790)', () => {
                 lastAttemptedIngestContractVersion: TENANT_REPO_INGEST_CONTRACT_VERSION
             }]));
 
-        TenantRepoSyncService.concurrencyLimit         = 1;
-        TenantRepoSyncService.concurrencyGateTimeoutMs = 500;
-
         for (const repoSlug of repoSlugs) {
             await provisionMirrorDir({tenantId: 't1', repoSlug});
         }
@@ -8058,9 +8078,11 @@ test.describe('TenantRepoSyncService (#11790)', () => {
         };
 
         const result = await TenantRepoSyncService.syncTenantRepos({
-            taskName         : 'tenant-repo-sync',
-            taskStateService : createInMemoryTaskStateService(),
-            leaseGuard       : async () => {},
+            taskName                : 'tenant-repo-sync',
+            concurrencyLimit        : 1,
+            concurrencyGateTimeoutMs: 500,
+            taskStateService        : createInMemoryTaskStateService(),
+            leaseGuard              : async () => {},
             tenantReposConfig: {tenantRepos: repoSlugs.map(repoSlug => ({
                 tenantId: 't1', repoSlug, mirrorRoot,
                 cloneUrl: `https://github.com/neomjs/${repoSlug.split('/')[1]}.git`
@@ -8109,8 +8131,6 @@ test.describe('TenantRepoSyncService (#11790)', () => {
         let activeEntered = 0,
             releaseActive;
         const activeReady = new Promise(resolve => { releaseActive = resolve });
-
-        TenantRepoSyncService.concurrencyLimit = 3;
 
         for (const repoSlug of repoSlugs) {
             await provisionMirrorDir({tenantId: 't1', repoSlug});
@@ -8162,6 +8182,7 @@ test.describe('TenantRepoSyncService (#11790)', () => {
             globalCadenceMs              : 0,
             jitterRatio                  : 0,
             seedBootstrap                : false,
+            concurrencyLimit             : 3,
             leaseYieldVoter              : {cause: YIELD_CAUSE_LEASE, vote: () => true}
         });
 

--- a/test/playwright/unit/ai/daemons/orchestrator/tenantRepoSyncLeaves.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/tenantRepoSyncLeaves.spec.mjs
@@ -29,3 +29,41 @@ test.describe('tenantRepoSync leaf defaults — the starved ordering pin (#16312
             .toBeGreaterThan(tier1Root.data.orchestrator.tenantRepoSync.backoffCapMs);
     });
 });
+
+// The concurrency knobs left their class-config home for this subtree; a deployment that
+// sets nothing must be byte-for-byte unchanged, so the defaults pin the retired class values.
+// Env projection is asserted on a FRESH root created after the env write — the leaf applies its
+// env layer at construct time — never by mutating a shared instance (the singleton-mutation ban).
+test.describe('tenantRepoSync concurrency leaves (#17158)', () => {
+    test('the canonical defaults preserve the retired class-config values', () => {
+        const root = Neo.create(RootConfigBase);
+
+        try {
+            const {concurrencyGateTimeoutMs, concurrencyLimit} = root.data.orchestrator.tenantRepoSync;
+
+            expect(concurrencyLimit).toBe(2);
+            expect(concurrencyGateTimeoutMs).toBe(0);
+        } finally {
+            root.destroy()
+        }
+    });
+
+    test('each env var projects onto its resolved leaf', () => {
+        process.env.NEO_ORCHESTRATOR_TENANT_REPO_SYNC_CONCURRENCY_LIMIT          = '5';
+        process.env.NEO_ORCHESTRATOR_TENANT_REPO_SYNC_CONCURRENCY_GATE_TIMEOUT_MS = '2500';
+
+        try {
+            const root = Neo.create(RootConfigBase);
+
+            try {
+                expect(root.data.orchestrator.tenantRepoSync.concurrencyLimit).toBe(5);
+                expect(root.data.orchestrator.tenantRepoSync.concurrencyGateTimeoutMs).toBe(2500);
+            } finally {
+                root.destroy()
+            }
+        } finally {
+            delete process.env.NEO_ORCHESTRATOR_TENANT_REPO_SYNC_CONCURRENCY_LIMIT;
+            delete process.env.NEO_ORCHESTRATOR_TENANT_REPO_SYNC_CONCURRENCY_GATE_TIMEOUT_MS;
+        }
+    });
+});


### PR DESCRIPTION
Resolves neomjs/neo#17158

🌿 The docs told operators to turn a knob no deployment could reach. Now the knob the docs name is the knob the env sets — and a mistyped value refuses out loud instead of silently staying 2.

`concurrencyLimit` and `concurrencyGateTimeoutMs` leave their class-config home (declarations + both `beforeSet` substitution hooks retired) and become AiConfig leaves under `orchestrator.tenantRepoSync`, consumed as default parameters at the use sites — the `sliceBudgetMs` shape already merged in this file. Validation moves to the consumption boundary as two throwing asserts beside `assertSliceBudgetMs` (a consumption-site substitute would be a hidden default; the retired hooks' exact bounds are preserved, including `0` staying valid FIFO-wait for the gate timeout and invalid for the limit). `syncTenantRepos` resolves both leaves and gates the sweep whole-or-not-at-all; `refreshTenantRepoAccessReadiness` resolves its own limit for standalone callers while the sweep passes its resolved value through for phase-coherence; `runTask` relays explicit overrides only (no leaf read of its own — exactly one SSOT read per consumption site). ~26 spec sites migrate from singleton sets to per-call injection; the two `beforeSet` gate tests become wired-at-boundary refusal arms plus a pure-bounds spec.

Evidence: L2 achieved (unit + lint receipts, all close-target ACs unit-provable) → L2 required. Residual: none.

## AC Evidence
| AC-1 | CI: `tenantRepoSyncLeaves.spec.mjs` — defaults arm pins `2` / `0`, byte-identical to the retired class values |
| AC-2 | CI: JOINED witnesses (RA-1) — `setEnvOverride` → resolved leaf → default parameter → semaphore with NO explicit concurrency argument: standalone-refresh width arm (3 repos, max in-flight 1) + sweep arm (queued repo times out typed at the env-resolved 1/50). Mutation-convicted: replacing the three use-site defaults with literals `2/0` turns both arms red (run and receipted below). Fresh-root env-projection + injected-width arms remain as the separable halves |
| AC-3 | CI: both consumers resolve the leaves; second-call-site refusal arm (`refresh… validates its own limit before touching the readiness cache`) + the standalone-refresh JOINED arm proving refresh's own default-param resolution end-to-end |
| AC-4 | CI: all width-dependent specs use per-call injection; local receipt: `check-aiconfig-test-mutation` — 1275 test files scanned, 0 new violations |
| AC-5 | CI: `tenantRepoSync.concurrencyAsserts.spec.mjs` pure bounds (0-never-acquirable rejected; `0` timeout valid FIFO sentinel) + wired refusal arms proving no repo work precedes the throw |
| AC-6 | Both declared paths added to `config-leaf-parity.json`; local receipt: `ai:lint-config-template-ssot` OK |
| AC-7 | Class configs + `beforeSet` hooks removed; `grep "this\.concurrencyLimit\|concurrencyLimit_"` over the service returns zero — one declaration per value |

## Deltas from ticket
- `runTask` gained bare relay params (`concurrencyLimit, concurrencyGateTimeoutMs` — no leaf-read defaults): the ticket left injection-through-`runTask` unspecified; existing concurrency specs drive through `runTask`, and a relay keeps one SSOT read per consumption site.
- The sweep passes its resolved `concurrencyLimit` into the internal `refreshTenantRepoAccessReadiness` call so one sweep's phases share one concurrency posture; standalone refresh callers still get the leaf default.
- Ticket mechanical constraint 2 (`_TIMEOUT_MS` behavior-binding-clock projection) is **verified inapplicable** at current dev: the projection is namespace-scoped to `NEO_MEMORY_SATURATION_` / `NEO_OPENAI_COMPATIBLE_` / `NEO_STORE_MEMORY_SATURATION_` in `docker-compose.provider-lanes.yml`; `NEO_ORCHESTRATOR_*` is outside its scan set.
- Comment prose carries reasons without ticket/ADR ref tokens (`check-ticket-archaeology` hook); provenance lives here and in the commit subject.
- **RA-2 (round 1):** both typed refusal codes joined `TENANT_REPO_SYNC_ERROR_CODES` — membership is the `runTask` wrap-preservation mechanism (`isTenantRepoSyncErrorCode ? preserve : SYNC_FAILED`); a `runTask`-level witness proves each `reasonCode` survives the public boundary. **Follow-up flagged, deliberately not smuggled in:** the sibling `INVALID_SLICE_BUDGET` is also a non-member and shares the wrap today; changing its public behavior belongs to its own lane.

## Test Evidence
Outside-CI receipts:
- **Round-1 mutation conviction (the reviewer's own falsifier, re-run at the repaired head):** replacing the three use-site leaf-read defaults with literals (`refresh: 2`; `sync: 2/0`) turns the standalone-refresh joined arm RED (in-flight observed 2, expected 1) and the sweep joined arm RED (nothing queues, no typed timeout) — each mutant run receipted, then reverted; the unmutated head runs **177/177** across the four-target scope.
- **RA-2 falsifier now inverts:** both codes are members of `TENANT_REPO_SYNC_ERROR_CODES` (13-count tripwire + named membership), and the `runTask` witness observes `details.reasonCode` carrying each typed code instead of `KB_TENANT_REPO_SYNC_SYNC_FAILED`.
- Two pre-existing environmental timeouts on this host (`#11790`-family deferred-observable tests) fail **identically on unmodified `origin/dev`** — dev-control runs executed for each before attributing; hypothesis (unverified): this host's currently-wedged embedding provider engages the recovery-probe machinery on the deferred path.

All remaining coverage runs in CI: 177/177 targeted scope (excluding the two environmental tests), 163/163 configBase-importer set, `ai:lint-config-template-ssot` OK, `check-aiconfig-test-mutation` 0 new violations.

## Post-Merge Validation
- [ ] First constrained-plane use: a deployment setting `NEO_ORCHESTRATOR_TENANT_REPO_SYNC_CONCURRENCY_LIMIT=1` observes serialized tenant-repo sweeps (the ticket's motivating operator instruction, now followable).
  - Residual-Owner: neomjs/neo-agent-brain#38

## Commits
- `feat(ai): tenant-sync concurrency knobs become AiConfig leaves` — the migration: leaves, asserts, three consumption sites, spec injection migration, parity census
- `fix(ai): joined leaf-wiring witnesses + typed refusal preservation` — round-1 repairs: RA-1 joined witnesses (mutation-convicted) + RA-2 taxonomy membership and `runTask` boundary witness

Related: neomjs/neo-agent-brain#23 (parent epic — embedding lane consolidation), neomjs/neo-agent-brain#38 (constrained CPU-plane reliability), neomjs/neo#17132 (the blocker whose merge unblocked this lane)

Authored by Vega (Claude Fable 5, Claude Code). Session 9cd02a1c-1e51-4c53-a361-84adbc5daa4f.

🌿
