### PR TITLE
feat(list): plugin.Animate gains resize-aware fluid geometry (#17552)

### DIFF
--- a/resources/scss/src/list/Base.scss
+++ b/resources/scss/src/list/Base.scss
@@ -79,3 +79,14 @@
         }
     }
 }
+
+/* list.plugin.Animate marks its owner with .neo-animated-list and drives item motion through a
+   per-owner #id transition rule. This single static override wins over that id-scoped rule via
+   !important, so vestibular-safe users get instant reflows from every animated list — inserted
+   here (not per-owner at runtime) because @media rules cannot be deleted by selectorText and a
+   dynamic copy would leak on every list destroy. */
+@media (prefers-reduced-motion: reduce) {
+    .neo-list.neo-animated-list .neo-list-item {
+        transition: none !important;
+    }
+}

--- a/src/list/plugin/Animate.mjs
+++ b/src/list/plugin/Animate.mjs
@@ -148,14 +148,38 @@ class Animate extends Base {
 
         me.ownerRect = rect;
 
+        // Both modes clamp to ONE column and a 1px width floor: a pane narrower than an item (or
+        // than its own outer margins) must degrade to a single squeezed column — never to
+        // `columns: 0`, whose position math (`index % 0`) is NaN, and never to a non-positive
+        // width style.
         if (minItemWidth && !me.hasFixedItemWidth) {
             me.columns      = Math.max(1, Math.floor((width - itemMargin) / (minItemWidth + itemMargin)));
-            owner.itemWidth = Math.floor((width - (me.columns + 1) * itemMargin) / me.columns)
+            owner.itemWidth = Math.max(1, Math.floor((width - (me.columns + 1) * itemMargin) / me.columns))
         } else {
-            me.columns = Math.floor(width / owner.itemWidth)
+            me.columns = Math.max(1, Math.floor(width / owner.itemWidth))
         }
 
         me.rows = Math.floor(rect.height / owner.itemHeight)
+    }
+
+    /**
+     * Triggered before the minItemWidth config gets changed — the fluid-mode domain gate:
+     * `null` (fixed mode) or a positive finite number of px. Anything else is refused with a
+     * console error and the previous value survives, so invalid input can never poison the
+     * geometry derivation.
+     * @param {Number|null} value
+     * @param {Number|null} oldValue
+     * @returns {Number|null}
+     * @protected
+     */
+    beforeSetMinItemWidth(value, oldValue) {
+        if (value === null || (Number.isFinite(value) && value > 0)) {
+            return value
+        }
+
+        console.error('list.plugin.Animate: minItemWidth must be null or a positive finite px number', value, this.owner);
+
+        return oldValue ?? null
     }
 
     /**
@@ -189,9 +213,10 @@ class Animate extends Base {
             node, position;
 
         owner.store.items.forEach((record, index) => {
-            // the record itself resolves through every id scheme (base internal-id / key ids,
-            // component index-coupled ids) — the exact id createItem stamped
-            node = map.get(owner.getItemId(record));
+            // resolve through the SAME two-step path createItem stamps ids with
+            // (getRecordId → getItemId): getRecordId handles raw/Turbo rows (no isRecord flag)
+            // exactly like real records, so a reflow can never silently skip the whole set
+            node = map.get(owner.getItemId(owner.getRecordId(record)));
 
             if (node) {
                 position = me.getItemPosition(record, index);

--- a/src/list/plugin/Animate.mjs
+++ b/src/list/plugin/Animate.mjs
@@ -14,6 +14,14 @@ class Animate extends Base {
      */
     static transitionEasings = ['ease', 'ease-in', 'ease-out', 'ease-in-out', 'linear']
 
+    /**
+     * True when the owner declared a fixed itemWidth at plugin construction — fluid geometry
+     * passes must never mistake the width they wrote themselves for a fixed one.
+     * @member {Boolean} hasFixedItemWidth=false
+     * @protected
+     */
+    hasFixedItemWidth = false
+
     static config = {
         /**
          * @member {String} className='Neo.list.plugin.Animate'
@@ -35,6 +43,16 @@ class Animate extends Base {
          * @member {Number} itemMargin=10
          */
         itemMargin: 10,
+        /**
+         * Opt-in fluid-width mode: a minimum item width in px. When set while the owner's
+         * `itemWidth` is null, the plugin derives the column count from the owner's measured
+         * width and writes the fluid per-item width back onto the owner — re-derived on every
+         * owner resize delivery. Leave null (with a fixed owner `itemWidth`) for the shipped
+         * fixed-grid behavior.
+         * @member {Number|null} minItemWidth_=null
+         * @reactive
+         */
+        minItemWidth_: null,
         /**
          * @member {DOMRect|null} ownerRect=null
          */
@@ -73,8 +91,12 @@ class Animate extends Base {
         let me      = this,
             {owner} = me;
 
-        if (!owner.itemHeight || !owner.itemWidth) {
-            console.error('list.plugin.Animate requires fixed itemHeight and itemWidth values', owner)
+        // fluid mode writes the derived width onto owner.itemWidth — remember the mode BEFORE
+        // the first write lands
+        me.hasFixedItemWidth = !!owner.itemWidth;
+
+        if (!owner.itemHeight || (!owner.itemWidth && !me.minItemWidth)) {
+            console.error('list.plugin.Animate requires a fixed itemHeight and either a fixed itemWidth or the plugin-level minItemWidth', owner)
         }
 
         me.adjustCreateItem();
@@ -82,7 +104,122 @@ class Animate extends Base {
         owner.onStoreFilter = me.onStoreFilter.bind(me);
         owner.onStoreSort   = me.onStoreSort  .bind(me);
 
+        // the absolute items anchor to the owner root: mark it and guarantee the containing block
+        // (the #id {position:relative} rule rides getOwnerRules())
+        owner.addCls('neo-animated-list');
+
+        owner.addDomListeners({resize: me.onOwnerResize, scope: me, local: true});
+
         this.updateTransitionDetails()
+    }
+
+    /**
+     * Register or unregister the owner with the main-thread ResizeObserver addon (the
+     * `Neo.component.Helix#addResizeObserver` pattern). Guarded: an environment without the
+     * addon keeps mount-time geometry — today's shipped behavior.
+     * @param {Boolean} mounted
+     * @protected
+     */
+    async addResizeObserver(mounted) {
+        let {id, windowId} = this.owner,
+            ResizeObserver;
+
+        try {
+            ResizeObserver = await Neo.currentWorker.getAddon('ResizeObserver', windowId)
+        } catch (e) {
+            return
+        }
+
+        ResizeObserver?.[mounted ? 'register' : 'unregister']({id, windowId})
+    }
+
+    /**
+     * Derive the grid geometry from an owner rect. Fixed mode divides the width by the owner's
+     * `itemWidth`; fluid mode (`minItemWidth` set while the owner declared no fixed width)
+     * derives the column count and writes the fluid per-item width back onto the owner, so every
+     * existing width consumer (`createItem`, `getItemPosition`) keeps reading one source.
+     * @param {DOMRect|Object} rect The owner's measured content rect.
+     * @protected
+     */
+    applyGeometry(rect) {
+        let me                                = this,
+            {itemMargin, minItemWidth, owner} = me,
+            {width}                           = rect;
+
+        me.ownerRect = rect;
+
+        if (minItemWidth && !me.hasFixedItemWidth) {
+            me.columns      = Math.max(1, Math.floor((width - itemMargin) / (minItemWidth + itemMargin)));
+            owner.itemWidth = Math.floor((width - (me.columns + 1) * itemMargin) / me.columns)
+        } else {
+            me.columns = Math.floor(width / owner.itemWidth)
+        }
+
+        me.rows = Math.floor(rect.height / owner.itemHeight)
+    }
+
+    /**
+     * The owner resized: re-derive the geometry and move every rendered item to the position its
+     * current store index dictates — an animated reflow (translate + fluid width), never a rebuild.
+     * @param {Object} data The delivered resize event; `data.rect` carries the content rect.
+     * @protected
+     */
+    onOwnerResize(data) {
+        let me     = this,
+            {rect} = data || {};
+
+        if (!rect?.width) {
+            return
+        }
+
+        me.applyGeometry(rect);
+        me.repositionItems()
+    }
+
+    /**
+     * One translate + width pass over the existing item nodes, mapped by item id so it stays
+     * correct for base and component lists alike — the reflow twin of `sortComponentList`.
+     * @param {Boolean} silent=false True skips the owner update (batching callers).
+     * @protected
+     */
+    repositionItems(silent=false) {
+        let me      = this,
+            {owner} = me,
+            map     = new Map(owner.getVdomRoot().cn.map(node => [node?.id, node])),
+            node, position;
+
+        owner.store.items.forEach((record, index) => {
+            // the record itself resolves through every id scheme (base internal-id / key ids,
+            // component index-coupled ids) — the exact id createItem stamped
+            node = map.get(owner.getItemId(record));
+
+            if (node) {
+                position = me.getItemPosition(record, index);
+
+                Object.assign(node.style, {
+                    transform: `translate(${position.x}px, ${position.y}px)`,
+                    width    : `${owner.itemWidth}px`
+                })
+            }
+        });
+
+        !silent && owner.update()
+    }
+
+    /**
+     * Triggered after the minItemWidth config got changed — re-derives the geometry from the
+     * last measured rect and reflows. No-op before the first measurement (mount owns that pass).
+     * @param {Number|null} value
+     * @param {Number|null} oldValue
+     * @protected
+     */
+    afterSetMinItemWidth(value, oldValue) {
+        let me = this;
+
+        if (oldValue !== undefined && me.ownerRect) {
+            me.applyGeometry(me.ownerRect);
+            me.repositionItems()
+        }
     }
 
     /**
@@ -158,7 +295,12 @@ class Animate extends Base {
      * @param {Object} args
      */
     destroy(...args) {
-        CssUtil.deleteRules(this.windowId, `#${this.owner.id} .neo-list-item`);
+        let me      = this,
+            ownerId = me.owner?.id;
+
+        me.addResizeObserver(false);
+        ownerId && CssUtil.deleteRules(me.windowId, [`#${ownerId}`, `#${ownerId} .neo-list-item`]);
+
         super.destroy(...args)
     }
 
@@ -203,12 +345,10 @@ class Animate extends Base {
         let me    = this,
             owner = me.owner;
 
+        me.addResizeObserver(true);
+
         owner.getDomRect().then(rect => {
-            Object.assign(me, {
-                columns  : Math.floor(rect.width / owner.itemWidth),
-                ownerRect: rect,
-                rows     : Math.floor(rect.height / owner.itemHeight)
-            });
+            me.applyGeometry(rect);
 
             // if the store got loaded before this plugin is ready, create the items now
             owner.store.getCount() > 0 && owner.createItems()
@@ -345,13 +485,13 @@ class Animate extends Base {
      * @param {Neo.data.Store} data.scope
      */
     sortBaseList(data) {
-        let me            = this,
-            hasChange     = false,
-            owner         = me.owner,
-            key           = owner.getKeyProperty(),
-            newVdomCn     = [],
-            previousKeys  = data.previousItems.map(e => e[key]),
-            vdom          = owner.vdom,
+        let me           = this,
+            hasChange    = false,
+            owner        = me.owner,
+            key          = owner.getKeyProperty(),
+            newVdomCn    = [],
+            previousKeys = data.previousItems.map(e => e[key]),
+            vdom         = owner.vdom,
             fromIndex;
 
         if (vdom.cn.length > 0) {
@@ -384,27 +524,37 @@ class Animate extends Base {
      * @param {Neo.data.Store} data.scope
      */
     sortComponentList(data) {
-        let me           = this,
-            owner        = me.owner,
-            key          = owner.getKeyProperty(),
+        let me    = this,
+            owner = me.owner,
+            key   = owner.getKeyProperty(),
+            // the vdom children still sit in the PREVIOUS store order — mapping each record's new
+            // index back through the previous record keys finds its node positionally, without
+            // touching component item ids (sortItems() nulls those; the earlier implementation
+            // re-read them here and crashed on any real component list)
             previousKeys = data.previousItems.map(e => e[key]),
-            vdom         = owner.vdom,
-            fromIndex, item, position;
+            vdom         = owner.getVdomRoot(),
+            fromIndex, node, position;
 
         owner.sortItems(data);
-
-        previousKeys = owner.items.map(e => owner.getItemRecordId(e[key]));
 
         if (vdom.cn.length > 0) {
             data.items.forEach((record, index) => {
                 fromIndex = previousKeys.indexOf(record[key]);
-                item      = vdom.cn[fromIndex];
-                position  = me.getItemPosition(record, index);
+                node      = vdom.cn[fromIndex];
 
-                item.style.transform = `translate(${position.x}px, ${position.y}px)`
+                if (node) {
+                    position = me.getItemPosition(record, index);
+
+                    node.style.transform = `translate(${position.x}px, ${position.y}px)`
+                }
             });
 
-            owner.update()
+            owner.update();
+
+            // settle like the base-list path: after the transition, re-create the items so the
+            // vdom order and the index-coupled component item ids re-normalize to the new store
+            // order (without this, a later reposition pass maps against stale ids)
+            me.triggerTransitionCallback()
         }
     }
 
@@ -427,20 +577,34 @@ class Animate extends Base {
      * @protected
      */
     async updateTransitionDetails(deleteRule=false) {
+        let me   = this,
+            {id} = me.owner;
+
+        if (deleteRule) {
+            await CssUtil.deleteRules(me.windowId, [`#${id}`, `#${id} .neo-list-item`])
+        }
+
+        CssUtil.insertRules(me.windowId, me.getOwnerRules())
+    }
+
+    /**
+     * The per-owner dynamic rules: the containing-block guarantee on the root and the item
+     * transition — pure, so specs can witness the exact inserted payload. The reduced-motion
+     * override is intentionally NOT here: it lives as ONE static rule in the list stylesheet
+     * (`resources/scss/src/list/Base.scss`), because `@media` rules cannot be deleted by
+     * selectorText and a per-owner copy would leak on every destroy.
+     * @returns {String[]}
+     */
+    getOwnerRules() {
         let me       = this,
             duration = me.transitionDuration,
             easing   = me.transitionEasing,
             {id}     = me.owner;
 
-        if (deleteRule) {
-            await CssUtil.deleteRules(me.windowId, `#${id} .neo-list-item`)
-        }
-
-        CssUtil.insertRules(me.windowId, [
-            `#${id} .neo-list-item {`,
-                `transition: opacity ${duration}ms ${easing}, transform ${duration}ms ${easing}`,
-            '}'
-        ].join(''))
+        return [
+            `#${id} {position:relative}`,
+            `#${id} .neo-list-item {transition: opacity ${duration}ms ${easing}, transform ${duration}ms ${easing}}`
+        ]
     }
 }
 

--- a/test/playwright/unit/list/animatePlugin.spec.mjs
+++ b/test/playwright/unit/list/animatePlugin.spec.mjs
@@ -30,13 +30,29 @@ import VdomHelper         from '../../../../src/vdom/Helper.mjs';
 
 // The setup() mock set carries no Stylesheet addon — recording it here makes the plugin's
 // inserted/deleted rule payloads the witness surface for the containing-block + transition rules.
+// Installed in beforeAll and restored in afterAll, so nothing leaks past this file.
 const
     insertedRules = [],
     deletedRules  = [];
 
-Neo.ns('Neo.main.addon.Stylesheet', true);
-Neo.main.addon.Stylesheet.insertCssRules = ({rules}) => insertedRules.push(...rules);
-Neo.main.addon.Stylesheet.deleteCssRules = ({rules}) => deletedRules.push(...rules);
+let priorInsertCssRules, priorDeleteCssRules, priorGetAddon;
+
+test.beforeAll(() => {
+    Neo.ns('Neo.main.addon.Stylesheet', true);
+
+    priorInsertCssRules = Neo.main.addon.Stylesheet.insertCssRules;
+    priorDeleteCssRules = Neo.main.addon.Stylesheet.deleteCssRules;
+    priorGetAddon       = Neo.currentWorker.getAddon;
+
+    Neo.main.addon.Stylesheet.insertCssRules = ({rules}) => insertedRules.push(...rules);
+    Neo.main.addon.Stylesheet.deleteCssRules = ({rules}) => deletedRules.push(...rules)
+});
+
+test.afterAll(() => {
+    Neo.main.addon.Stylesheet.insertCssRules = priorInsertCssRules;
+    Neo.main.addon.Stylesheet.deleteCssRules = priorDeleteCssRules;
+    Neo.currentWorker.getAddon               = priorGetAddon
+});
 
 class RosterModel extends Model {
     static config = {
@@ -121,12 +137,13 @@ class CardList extends ComponentList {
 }
 CardList = Neo.setupClass(CardList);
 
+// neutral fixture identities — never real maintainer names or statuses
 const rosterData = () => [
-    {id: 1, name: 'Ada',   online: true},
-    {id: 2, name: 'Clio',  online: true},
-    {id: 3, name: 'Emmy',  online: false},
-    {id: 4, name: 'Grace', online: true},
-    {id: 5, name: 'Vega',  online: false}
+    {id: 1, name: 'alpha',   online: true},
+    {id: 2, name: 'bravo',   online: true},
+    {id: 3, name: 'charlie', online: false},
+    {id: 4, name: 'delta',   online: true},
+    {id: 5, name: 'echo',    online: false}
 ];
 
 let runId = 0;
@@ -135,11 +152,12 @@ let runId = 0;
  * One constructed fixture: a store-fed list carrying the Animate plugin with deterministic
  * geometry (applyGeometry replaces the mount-time getDomRect pass — mount never runs here).
  */
-async function createFixture({listClass = PlainList, listConfig = {}, pluginConfig = {}, rect = {width: 935, height: 400}}) {
+async function createFixture({listClass = PlainList, listConfig = {}, pluginConfig = {}, storeConfig = {}, rect = {width: 935, height: 400}}) {
     runId++;
 
     const store = Neo.create(RosterStore, {
         autoInitRecords: true,
+        ...storeConfig,
         data           : rosterData()
     });
 
@@ -347,36 +365,132 @@ test.describe('Neo.list.plugin.Animate', () => {
     });
 
     test('mount registers the owner with the ResizeObserver addon, destroy unregisters', async () => {
-        const calls = [];
+        const
+            calls = [],
+            prior = Neo.currentWorker.getAddon;
 
-        Neo.currentWorker.getAddon = async () => ({
-            register  : data => calls.push({op: 'register',   ...data}),
-            unregister: data => calls.push({op: 'unregister', ...data})
-        });
+        try {
+            Neo.currentWorker.getAddon = async () => ({
+                register  : data => calls.push({op: 'register',   ...data}),
+                unregister: data => calls.push({op: 'unregister', ...data})
+            });
 
-        const {list} = await createFixture({listConfig: {itemWidth: 300}});
+            const {list} = await createFixture({listConfig: {itemWidth: 300}});
 
-        list.mounted = true;
-        await list.timeout(20);
+            list.mounted = true;
+            await list.timeout(20);
 
-        expect(calls.some(call => call.op === 'register' && call.id === list.id)).toBe(true);
+            expect(calls.some(call => call.op === 'register' && call.id === list.id)).toBe(true);
 
-        const {id} = list;
-        list.destroy();
-        await list.timeout(20);
+            const {id} = list;
+            list.destroy();
+            await list.timeout(20);
 
-        expect(calls.some(call => call.op === 'unregister' && call.id === id)).toBe(true)
+            expect(calls.some(call => call.op === 'unregister' && call.id === id)).toBe(true)
+        } finally {
+            Neo.currentWorker.getAddon = prior
+        }
     });
 
     test('a missing ResizeObserver addon degrades to mount-time geometry without throwing', async () => {
-        Neo.currentWorker.getAddon = async () => {
-            throw new Error('addon unavailable')
-        };
+        const prior = Neo.currentWorker.getAddon;
 
-        const {list, plugin} = await createFixture({listConfig: {itemWidth: 300}});
+        try {
+            Neo.currentWorker.getAddon = async () => {
+                throw new Error('addon unavailable')
+            };
 
-        await expect(plugin.addResizeObserver(true)).resolves.toBeUndefined();
-        expect(plugin.columns).toBe(3);
+            const {list, plugin} = await createFixture({listConfig: {itemWidth: 300}});
+
+            await expect(plugin.addResizeObserver(true)).resolves.toBeUndefined();
+            expect(plugin.columns).toBe(3);
+
+            list.destroy()
+        } finally {
+            Neo.currentWorker.getAddon = prior
+        }
+    });
+
+    test('a narrow fixed rect floors at one column — positions stay finite', async () => {
+        const {list, plugin} = await createFixture({
+            listConfig: {itemWidth: 300},
+            rect      : {width: 200, height: 400}
+        });
+
+        expect(plugin.columns).toBe(1);                       // never floor(200/300) = 0
+        expect(transformOf(list, 1)).toBe('translate(10px, 10px)');
+        expect(transformOf(list, 2)).toBe('translate(10px, 146px)');
+        itemNodes(list).forEach(node => expect(node.style.transform).not.toContain('NaN'));
+
+        list.destroy()
+    });
+
+    test('a tiny fluid rect floors both the column count and the item width', async () => {
+        const {list, plugin} = await createFixture({
+            pluginConfig: {itemMargin: 9, minItemWidth: 420},
+            rect        : {width: 10, height: 400}
+        });
+
+        expect(plugin.columns).toBe(1);
+        expect(list.itemWidth).toBe(1);                       // floor((10 - 18) / 1) would be negative
+        itemNodes(list).forEach(node => {
+            expect(node.style.width).toBe('1px');
+            expect(node.style.transform).not.toContain('NaN')
+        });
+
+        list.destroy()
+    });
+
+    test('invalid minItemWidth values are refused and the previous value survives', async () => {
+        const {list, plugin} = await createFixture({
+            pluginConfig: {minItemWidth: 300},
+            rect        : {width: 935, height: 400}
+        });
+
+        for (const bad of [-5, 0, NaN, Infinity, 'wide']) {
+            plugin.minItemWidth = bad;
+            expect(plugin.minItemWidth).toBe(300)
+        }
+
+        plugin.minItemWidth = null;                           // fixed-mode opt-out stays legal
+        expect(plugin.minItemWidth).toBeNull();
+
+        list.destroy()
+    });
+
+    test('raw-record stores (autoInitRecords: false) reflow exactly like records', async () => {
+        const {list, plugin} = await createFixture({
+            listConfig : {itemWidth: 300},
+            storeConfig: {autoInitRecords: false}
+        });
+
+        expect(itemNodes(list)).toHaveLength(5);
+
+        plugin.onOwnerResize({rect: {width: 620, height: 400}});
+
+        expect(plugin.columns).toBe(2);
+        // every node was re-addressed through getRecordId → getItemId — none silently skipped
+        const transforms = itemNodes(list).map(node => node.style.transform);
+        expect(transforms[2]).toBe('translate(10px, 146px)'); // index 2 wrapped to row 1
+        transforms.forEach(t => expect(t).toMatch(/^translate\(\d+px, \d+px\)$/));
+
+        list.destroy()
+    });
+
+    test('component-list filtering settles the component rows against the correct records', async () => {
+        const {list, store} = await createFixture({listClass: CardList, listConfig: {itemWidth: 300}});
+
+        store.filters = [{property: 'online', operator: '===', value: true}];
+        await list.timeout(200);                              // fade + settle (transitionDuration 50)
+
+        expect(itemNodes(list)).toHaveLength(3);
+        expect(list.items.slice(0, 3).map(item => item.text)).toEqual(['alpha', 'bravo', 'delta']);
+
+        store.getFilter('online').disabled = true;
+        await list.timeout(250);
+
+        expect(itemNodes(list)).toHaveLength(5);
+        expect(list.items.map(item => item.text)).toEqual(['alpha', 'bravo', 'charlie', 'delta', 'echo']);
 
         list.destroy()
     })

--- a/test/playwright/unit/list/animatePlugin.spec.mjs
+++ b/test/playwright/unit/list/animatePlugin.spec.mjs
@@ -1,0 +1,383 @@
+import {setup} from '../../setup.mjs';
+
+const appName = 'AnimatePluginTest';
+
+setup({
+    neoConfig: {
+        allowVdomUpdatesInTests: true,
+        unitTestMode           : true,
+        useDomApiRenderer      : true
+    },
+    appConfig: {
+        name             : appName,
+        isMounted        : () => true,
+        vnodeInitialising: false
+    }
+});
+
+import {test, expect}     from '@playwright/test';
+import Neo                from '../../../../src/Neo.mjs';
+import * as core          from '../../../../src/core/_export.mjs';
+import Animate            from '../../../../src/list/plugin/Animate.mjs';
+import BaseList           from '../../../../src/list/Base.mjs';
+import ComponentList      from '../../../../src/list/Component.mjs';
+import Component          from '../../../../src/component/Base.mjs';
+import InstanceManager    from '../../../../src/manager/Instance.mjs';
+import Model              from '../../../../src/data/Model.mjs';
+import Store              from '../../../../src/data/Store.mjs';
+import DomApiVnodeCreator from '../../../../src/vdom/util/DomApiVnodeCreator.mjs';
+import VdomHelper         from '../../../../src/vdom/Helper.mjs';
+
+// The setup() mock set carries no Stylesheet addon — recording it here makes the plugin's
+// inserted/deleted rule payloads the witness surface for the containing-block + transition rules.
+const
+    insertedRules = [],
+    deletedRules  = [];
+
+Neo.ns('Neo.main.addon.Stylesheet', true);
+Neo.main.addon.Stylesheet.insertCssRules = ({rules}) => insertedRules.push(...rules);
+Neo.main.addon.Stylesheet.deleteCssRules = ({rules}) => deletedRules.push(...rules);
+
+class RosterModel extends Model {
+    static config = {
+        className: 'Test.Unit.List.AnimatePlugin.RosterModel',
+        fields   : [
+            {name: 'id',     type: 'Integer'},
+            {name: 'name',   type: 'String'},
+            {name: 'online', type: 'Boolean'}
+        ]
+    }
+}
+RosterModel = Neo.setupClass(RosterModel);
+
+class RosterStore extends Store {
+    static config = {
+        className  : 'Test.Unit.List.AnimatePlugin.RosterStore',
+        keyProperty: 'id',
+        model      : RosterModel
+    }
+}
+RosterStore = Neo.setupClass(RosterStore);
+
+class PlainList extends BaseList {
+    static config = {
+        className  : 'Test.Unit.List.AnimatePlugin.PlainList',
+        itemHeight : 126,
+        itemTagName: 'div'
+    }
+}
+PlainList = Neo.setupClass(PlainList);
+
+class CardItem extends Component {
+    static config = {
+        className: 'Test.Unit.List.AnimatePlugin.CardItem',
+        cls      : ['test-animate-card']
+    }
+}
+CardItem = Neo.setupClass(CardItem);
+
+class CardList extends ComponentList {
+    static config = {
+        className  : 'Test.Unit.List.AnimatePlugin.CardList',
+        itemHeight : 126,
+        itemTagName: 'div',
+        // key-stable item ids (the FM roster consumer shape: durable agentId keys)
+        useInternalId: false
+    }
+
+    /**
+     * The calendar-List sibling pattern: create once, reuse by index on later passes.
+     * @param {Object} record
+     * @param {Number} index
+     * @returns {Object[]}
+     */
+    createItemContent(record, index) {
+        let me    = this,
+            items = me.items || [],
+            comp  = items[index],
+
+        config = {
+            id  : me.getComponentId(index),
+            text: record.name
+        };
+
+        if (comp) {
+            comp.setSilent(config)
+        } else {
+            items[index] = comp = Neo.create({
+                module  : CardItem,
+                appName : me.appName,
+                parentId: me.id,
+                windowId: me.windowId,
+                ...config
+            })
+        }
+
+        me.items       = items;
+        me.updateDepth = 2;
+
+        return [comp.createVdomReference()]
+    }
+}
+CardList = Neo.setupClass(CardList);
+
+const rosterData = () => [
+    {id: 1, name: 'Ada',   online: true},
+    {id: 2, name: 'Clio',  online: true},
+    {id: 3, name: 'Emmy',  online: false},
+    {id: 4, name: 'Grace', online: true},
+    {id: 5, name: 'Vega',  online: false}
+];
+
+let runId = 0;
+
+/**
+ * One constructed fixture: a store-fed list carrying the Animate plugin with deterministic
+ * geometry (applyGeometry replaces the mount-time getDomRect pass — mount never runs here).
+ */
+async function createFixture({listClass = PlainList, listConfig = {}, pluginConfig = {}, rect = {width: 935, height: 400}}) {
+    runId++;
+
+    const store = Neo.create(RosterStore, {
+        autoInitRecords: true,
+        data           : rosterData()
+    });
+
+    const list = Neo.create(listClass, {
+        appName,
+        id     : `test-animate-list-${runId}`,
+        store,
+        plugins: [{module: Animate, itemMargin: 10, transitionDuration: 50, ...pluginConfig}],
+        ...listConfig
+    });
+
+    const plugin = list.getPlugin('list-animate');
+
+    await list.initVnode();
+
+    plugin.applyGeometry(rect);
+    list.createItems();
+    await list.timeout(60);
+
+    return {list, plugin, store}
+}
+
+function itemNodes(list) {
+    return list.getVdomRoot().cn.filter(Boolean)
+}
+
+function transformOf(list, recordId) {
+    const
+        record = list.store.get(recordId),
+        node   = itemNodes(list).find(node => node.id === list.getItemId(record));
+
+    return node?.style?.transform
+}
+
+test.describe('Neo.list.plugin.Animate', () => {
+
+    test('fixed-mode geometry matches the shipped formula', async () => {
+        const {list, plugin} = await createFixture({listConfig: {itemWidth: 300}});
+
+        expect(plugin.hasFixedItemWidth).toBe(true);
+        expect(plugin.columns).toBe(3);            // floor(935 / 300)
+        expect(plugin.rows).toBe(3);               // floor(400 / 126)
+        expect(list.itemWidth).toBe(300);          // fixed mode never rewrites the owner width
+
+        list.destroy()
+    });
+
+    test('fluid mode derives columns and writes the owner width — the measured cockpit fixture', async () => {
+        const {list, plugin} = await createFixture({
+            pluginConfig: {itemMargin: 9, minItemWidth: 420},
+            rect        : {width: 903, height: 275}
+        });
+
+        expect(plugin.hasFixedItemWidth).toBe(false);
+        expect(plugin.columns).toBe(2);            // floor((903 - 9) / (420 + 9))
+        expect(list.itemWidth).toBe(438);          // floor((903 - 3 * 9) / 2) — outer margins included
+        expect(plugin.rows).toBe(2);
+
+        // a narrow pane floors at one column, never zero
+        plugin.applyGeometry({width: 200, height: 275});
+        expect(plugin.columns).toBe(1);
+        expect(list.itemWidth).toBe(182);          // floor((200 - 2 * 9) / 1)
+
+        // a wide pane earns the third column
+        plugin.applyGeometry({width: 1400, height: 275});
+        expect(plugin.columns).toBe(3);            // floor((1400 - 9) / 429)
+        expect(list.itemWidth).toBe(454);          // floor((1400 - 4 * 9) / 3)
+
+        list.destroy()
+    });
+
+    test('construct inserts the containing-block + transition rules and marks the owner', async () => {
+        insertedRules.length = 0;
+
+        const {list} = await createFixture({listConfig: {itemWidth: 300}});
+
+        expect(list.cls).toContain('neo-animated-list');
+        expect(insertedRules).toContain(`#${list.id} {position:relative}`);
+        expect(insertedRules).toContain(`#${list.id} .neo-list-item {transition: opacity 50ms ease-in-out, transform 50ms ease-in-out}`);
+
+        deletedRules.length = 0;
+        const {id} = list;
+        list.destroy();
+
+        expect(deletedRules).toContain(`#${id}`);
+        expect(deletedRules).toContain(`#${id} .neo-list-item`)
+    });
+
+    test('items render absolutely positioned at their grid slots', async () => {
+        const {list} = await createFixture({listConfig: {itemWidth: 300}});
+
+        // columns = 3, margin 10: index 0 → (10, 10) · index 1 → (320, 10) · index 3 → (10, 146)
+        expect(transformOf(list, 1)).toBe('translate(10px, 10px)');
+        expect(transformOf(list, 2)).toBe('translate(320px, 10px)');
+        expect(transformOf(list, 4)).toBe('translate(10px, 146px)');
+
+        const node = itemNodes(list)[0];
+        expect(node.style.position).toBe('absolute');
+        expect(node.style.height).toBe('126px');
+        expect(node.style.width).toBe('300px');
+
+        list.destroy()
+    });
+
+    test('an owner resize delivery reflows every rendered item — no rebuild', async () => {
+        const {list, plugin} = await createFixture({listConfig: {itemWidth: 300}});
+
+        const nodesBefore = itemNodes(list);
+        expect(nodesBefore).toHaveLength(5);
+        expect(plugin.columns).toBe(3);
+
+        // shrink: 620px only fits two 300px columns → index 2 wraps to row 1
+        plugin.onOwnerResize({rect: {width: 620, height: 400}});
+
+        expect(plugin.columns).toBe(2);
+        expect(transformOf(list, 1)).toBe('translate(10px, 10px)');
+        expect(transformOf(list, 3)).toBe('translate(10px, 146px)');
+
+        // the same vdom nodes were moved, not recreated
+        expect(itemNodes(list)).toHaveLength(5);
+        itemNodes(list).forEach((node, index) => expect(node).toBe(nodesBefore[index]));
+
+        list.destroy()
+    });
+
+    test('a fluid resize rewrites the owner width onto every item', async () => {
+        const {list, plugin} = await createFixture({
+            pluginConfig: {minItemWidth: 300},
+            rect        : {width: 935, height: 400}
+        });
+
+        expect(plugin.columns).toBe(2);            // floor((935 - 10) / 310)
+        expect(list.itemWidth).toBe(452);          // floor((935 - 3 * 10) / 2)
+
+        plugin.onOwnerResize({rect: {width: 1300, height: 400}});
+
+        expect(plugin.columns).toBe(4);            // floor((1300 - 10) / 310)
+        expect(list.itemWidth).toBe(312);          // floor((1300 - 5 * 10) / 4)
+        itemNodes(list).forEach(node => expect(node.style.width).toBe('312px'));
+
+        list.destroy()
+    });
+
+    test('a rect-less resize delivery is a no-op', async () => {
+        const {list, plugin} = await createFixture({listConfig: {itemWidth: 300}});
+        const columns        = plugin.columns;
+
+        plugin.onOwnerResize({});
+        plugin.onOwnerResize(null);
+
+        expect(plugin.columns).toBe(columns);
+        list.destroy()
+    });
+
+    test('component-list sort keeps the component instances and translates them', async () => {
+        const {list, store} = await createFixture({listClass: CardList, listConfig: {itemWidth: 300}});
+
+        const instancesBefore = new Set(list.items);
+        expect(instancesBefore.size).toBe(5);
+
+        // component-list item ids are index-coupled (`${listId}__${index}`) and mid-transition
+        // they still carry the PRE-sort order — the settle pass re-normalizes them afterwards.
+        // vdom node OBJECTS are disposable descriptors in Neo (update passes may recreate them),
+        // so the witnesses anchor on the stable li ids, and component continuity is asserted on
+        // the instances below.
+        const byId = index => itemNodes(list).find(node => node.id === `${list.id}__${index}`);
+
+        store.sorters = [{property: 'name', direction: 'DESC'}];
+        await list.timeout(20);
+
+        // geometry mid-transition (columns = 3, margin 10): Vega's li (created at index 4) now
+        // targets slot 0; Ada's li (index 0) dropped to the last slot (column 1, row 1)
+        expect(byId(4).style.transform).toBe('translate(10px, 10px)');
+        expect(byId(0).style.transform).toBe('translate(320px, 146px)');
+
+        // identity: the exact same component instances survive the sort
+        expect(list.items).toHaveLength(5);
+        list.items.forEach(item => expect(instancesBefore.has(item)).toBe(true));
+
+        // after the settle pass (transitionDuration → createItems), id-based lookups agree with
+        // the same geometry against the re-normalized vdom
+        await list.timeout(150);
+        expect(transformOf(list, 5)).toBe('translate(10px, 10px)');
+
+        list.destroy()
+    });
+
+    test('filtering fades removed items out and re-entering items in', async () => {
+        const {list, plugin, store} = await createFixture({listConfig: {itemWidth: 300}});
+
+        store.filters = [{property: 'online', operator: '===', value: true}];
+        await list.timeout(55);
+
+        // during the transition the filtered-out nodes fade (opacity 0), then the settle pass
+        // (triggerTransitionCallback → createItems) drops them from the vdom
+        await list.timeout(120);
+        expect(itemNodes(list)).toHaveLength(3);
+
+        // clearing the filter re-enters the two offline records
+        store.getFilter('online').disabled = true;
+        await list.timeout(200);
+        expect(itemNodes(list)).toHaveLength(5);
+
+        list.destroy()
+    });
+
+    test('mount registers the owner with the ResizeObserver addon, destroy unregisters', async () => {
+        const calls = [];
+
+        Neo.currentWorker.getAddon = async () => ({
+            register  : data => calls.push({op: 'register',   ...data}),
+            unregister: data => calls.push({op: 'unregister', ...data})
+        });
+
+        const {list} = await createFixture({listConfig: {itemWidth: 300}});
+
+        list.mounted = true;
+        await list.timeout(20);
+
+        expect(calls.some(call => call.op === 'register' && call.id === list.id)).toBe(true);
+
+        const {id} = list;
+        list.destroy();
+        await list.timeout(20);
+
+        expect(calls.some(call => call.op === 'unregister' && call.id === id)).toBe(true)
+    });
+
+    test('a missing ResizeObserver addon degrades to mount-time geometry without throwing', async () => {
+        Neo.currentWorker.getAddon = async () => {
+            throw new Error('addon unavailable')
+        };
+
+        const {list, plugin} = await createFixture({listConfig: {itemWidth: 300}});
+
+        await expect(plugin.addResizeObserver(true)).resolves.toBeUndefined();
+        expect(plugin.columns).toBe(3);
+
+        list.destroy()
+    })
+});


### PR DESCRIPTION
Resolves neomjs/neo#17552

Related: neomjs/neo#17553, neomjs/neo-agent-institution#10

`Neo.list.plugin.Animate` becomes dock-pane-ready: the owner registers with the main-thread ResizeObserver addon (the Helix pattern) and every delivered resize runs an animated translate/width reflow instead of fossilizing at mount-time geometry; an opt-in `minItemWidth` fluid mode derives the column count from the owner's measured width and writes the per-item width back onto the owner (fixed mode keeps its `itemWidth` value and initial-geometry formula unchanged; resize awareness is additive to both modes); the plugin now guarantees its own containing block (`neo-animated-list` cls + a `#id {position:relative}` rule from the new pure `getOwnerRules()` seam); reduced motion is honored by one static class-scoped stylesheet rule; and the first-ever component-list witnesses surfaced and repaired a shipped defect — `sortComponentList` crashed on any real `Neo.list.Component` (it re-read item ids `sortItems()` had just nulled), and now maps nodes positionally through the previous record keys plus a settle pass.

Evidence: L3 achieved (headed exact-head receipts on both demos for AC-6; L2 unit/static witnesses for every other AC) → L3 required (AC-6's demo-behavior criterion is headed by definition; every other AC requires L2). Residual: none.

## AC Evidence

| AC-1 | CI: `test/playwright/unit/list/animatePlugin.spec.mjs` — "an owner resize delivery reflows every rendered item — no rebuild" (fixed: columns 3→2, same vdom node objects survive), "a fluid resize rewrites the owner width onto every item" (2→4 columns, width rewritten), "a rect-less resize delivery is a no-op", plus the round-1 domain witnesses: "a narrow fixed rect floors at one column — positions stay finite", "a tiny fluid rect floors both the column count and the item width" (1-column / 1px floors, no NaN, no negative styles), "invalid minItemWidth values are refused and the previous value survives", and "raw-record stores (autoInitRecords: false) reflow exactly like records" (the canonical `getRecordId → getItemId` two-step). |
| AC-2 | CI: "fluid mode derives columns and writes the owner width — the measured cockpit fixture" — 903/9/420 → 2 × 438 (outer-margin geometry), 200 → 1-column floor at 182, 1400 → 3 × 454. |
| AC-3 | CI: "construct inserts the containing-block + transition rules and marks the owner" (cls witness + `#id {position:relative}` payload + destroy deletes both selectors). Outside-CI: the pre-implementation falsifier probe and the live demo scroll receipt (Test Evidence) anchor the corrected Problem-3 behavior. |
| AC-4 | CI: the rule-payload witness covers both dynamic rules incl. destroy deletion; the reduced-motion override ships as the ONE static rule in `resources/scss/src/list/Base.scss` (ticket AC amended at implementation: `deleteCssRules` matches selectorText, which `@media` rules don't carry — a per-owner dynamic copy would leak on every destroy). |
| AC-5 | CI: "component-list sort keeps the component instances and translates them" (instance-identity across the sort + mid-transition translates by stable li ids + post-settle id-normalized lookup), "component-list filtering settles the component rows against the correct records" (the round-1 falsifier: CardList filter exit/re-entry, record-correct rows post-settle — it came back GREEN, so it guards the path rather than repairing it), plus the base-list fade witness. Includes the `sortComponentList` repair (the shipped path crashed: `null.split` on ids `sortItems()` nulls). |
| AC-6 | Outside-CI: headed receipts for BOTH demos at this head (Test Evidence) — fixed mode identical. |
| AC-7 | `npm run generate-docs-json` run at this head: byte-identical tracked output (no new classes; the modified members stay within the existing class docs subset). |

## Deltas from ticket

1. **Reduced motion went static instead of dynamic** — the ticket's companion-rule prescription could not share the delete lifecycle (`@media` rules have no selectorText for `deleteCssRules`); one class-scoped `!important` rule in `Base.scss` covers every animated list with zero lifecycle. Ticket Fix 4 / ledger / AC-4 amended accordingly before this PR opened.
2. **The pre-implementation falsifier rescoped Problem 3** (recorded on the ticket before a line was written): translated absolute children DO create scrollable overflow — the real gap was the missing containing-block guarantee, not "scrolling dies". The shipped fix is the cls + rule, not a derived owner height.
3. **The `sortComponentList` repair** rides under AC-5's parity scope: the first component-list witness surfaced that the shipped branch was unreachable-without-crashing for any real component list (the calendar List dodges it by no-op'ing `sortItems`). The repair maps positionally via `data.previousItems` keys and adds the settle pass (`triggerTransitionCallback`) the base path already had, so index-coupled component item ids re-normalize after the transition.
4. Fluid width math is outer-margin-inclusive (2 × 438 in the cockpit fixture, not the CSS-grid 447) — the plugin owns ALL gutters incl. the outer ones; ticket evidence row corrected.
5. **Review round 1 (Emmy) — the geometry domain is bounded and the reflow addressing is canonical.** Both modes clamp to one column and a 1px width floor (a pane narrower than an item degrades instead of emitting `index % 0` NaN positions or negative widths); `beforeSetMinItemWidth` refuses anything but null / positive-finite px with the prior value surviving; `repositionItems` resolves nodes through the same `getRecordId → getItemId` two-step `createItem` stamps with, so raw/Turbo rows (no `isRecord` flag) reflow identically — witnessed; the component-list FILTER path gained its own falsifier (CardList exit/re-entry, record-correct rows post-settle) which came back GREEN, so it guards the path rather than repairing one; the spec is hermetic (Stylesheet + getAddon mocks save/restored, per-test `finally` restores, neutral fixture identities).

## Test Evidence

- Headed demo receipt (this head, dev server, Chrome 148): `examples/list/animate` settles to the 4-column fixed grid (1280px / 300 → 4), Lastname sort animates to Bailey · Clarkson · Ferguson · Gray · Hill · Martin, items render `position:absolute` + `translate(10px, 10px)` + 300×200; the owner carries `neo-animated-list` with computed `position: relative` via the inserted rule; scrollHeight 840 vs clientHeight 612 — translated absolute children scroll. `examples/list/circle`: 6 items, absolute + translate, marker cls + relative — identical fixed-mode behavior.
- Pre-implementation falsifier (recorded as the neomjs/neo#17552 body correction before any code): synthetic 200px `relative`+`overflow` host, child translated to y=900 → scrollHeight 1026 in both transform and top-offset variants.
- Full local unit suite at this head: 14589 passed / 15 skipped / 1 failed — the failure is `ai/mcp/client/McpServersHealth.spec.mjs` (neural-link boot), reproduced identically in isolation on this seat ("Neural Link is unhealthy" — the seat's live harness bridge occupies the environment the spec boots into); unrelated to `src/list` and outside this diff's reach.

## Post-Merge Validation

None owed: every AC is proven at this head (unit witnesses + headed receipts). The first production consumer is neomjs/neo#17553 (linked blocked-by), whose own ACs carry the dock-pane resize receipts.

## Commits

- `da3e7bc974` — the plugin (resize seam, fluid geometry, containing-block guarantee, `getOwnerRules()` seam, `sortComponentList` repair), the static reduced-motion rule, the 11-witness unit suite.
- `059e26283f` — review round 1: bounded geometry domain (1-column + 1px floors both modes, `beforeSetMinItemWidth` validation), canonical `getRecordId → getItemId` reflow addressing, five new witnesses (narrow fixed rect, tiny fluid rect, invalid config, Turbo rows, component-list filter), hermetic spec (mock save/restore, neutral fixtures).

Authored by Clio (Claude Fable 5, Claude Code). Session 28bee2e0-4dc8-4375-8514-78fcf38d0d30.

