### PR TITLE
test(dashboard): DockOperationsNL derives remainders from the seeded document (#17555)

### DIFF
--- a/test/playwright/e2e/dashboard/DockOperationsNL.spec.mjs
+++ b/test/playwright/e2e/dashboard/DockOperationsNL.spec.mjs
@@ -12,9 +12,12 @@ import { test, expect } from '../../fixtures.mjs';
  * Structural half of the op-suite ticket only — animation assertions land once the motion-contract
  * disposition settles, and the tour-replay spec waits on the Demo-A tour surface.
  *
- * Seeded workspace (examples/dashboard/dock): root edge-zone {center: root-split, right: inspector-tabs};
- * root-split = horizontal [main-tabs{strategy,swarm}, side-split]; side-split = vertical
- * [terminal-tabs{terminal}, logs-tabs{logs}]; inspector-tabs{inspector}.
+ * Seeded workspace (examples/dashboard/dock — `initialDockModel` in the example is the live authority):
+ * root edge-zone {center: root-split, right: inspector-tabs}; root-split = horizontal [main-tabs, side-split];
+ * side-split = vertical [terminal-tabs{terminal}, logs-tabs{logs}]; inspector-tabs{inspector}. `main-tabs`
+ * carries the demo's grown tab catalog (strategy, swarm, metrics, …) and may keep growing — a spec that
+ * asserts a post-operation remainder DERIVES it from a pre-operation topology read; a pinned remainder
+ * literal goes stale the day the demo gains a pane, while the operations under test stay correct.
  *
  * Run: NEO_E2E_PORT=8093 npx playwright test dashboard/DockOperationsNL -c test/playwright/playwright.config.e2e.mjs --workers=1
  */
@@ -65,14 +68,24 @@ test.describe('Dock semantic operations (Neural Link, structural)', () => {
     test('tab-move class: moveItem relocates across tabs nodes; delta and independent read agree', async ({ page, neuralLink }) => {
         const { app, holderId } = await connect(page, neuralLink);
 
+        // derive the expected remainders from the seeded document itself — exact, and growth-proof
+        const before         = await readTopology(app, holderId);
+        const mainBefore     = before.nodes['main-tabs'].items;
+        const terminalBefore = before.nodes['terminal-tabs'].items;
+
+        expect(mainBefore, 'seed: swarm must start in main-tabs').toContain('swarm');
+
         const result = await app.executeDockOperation(holderId, {
             operation: 'moveItem', itemId: 'swarm', targetNodeId: 'terminal-tabs', index: 1
         });
 
+        const expectedTerminal = [...terminalBefore];
+        expectedTerminal.splice(1, 0, 'swarm');
+
         expect(result.errors).toEqual([]);
         expect(result.applied).toBe(true);
-        expect(result.document.nodes['terminal-tabs'].items).toEqual(['terminal', 'swarm']);
-        expect(result.document.nodes['main-tabs'].items).toEqual(['strategy']);
+        expect(result.document.nodes['terminal-tabs'].items).toEqual(expectedTerminal);
+        expect(result.document.nodes['main-tabs'].items).toEqual(mainBefore.filter(id => id !== 'swarm'));
 
         const topo = await readTopology(app, holderId);
         expect(JSON.stringify(topo), 'independent read must agree with the returned delta').toBe(JSON.stringify(result.document));
@@ -81,6 +94,12 @@ test.describe('Dock semantic operations (Neural Link, structural)', () => {
 
     test('split class: splitNode wraps the item and splits the target; delta and independent read agree', async ({ page, neuralLink }) => {
         const { app, holderId } = await connect(page, neuralLink);
+
+        // derive the expected remainder from the seeded document itself — exact, and growth-proof
+        const before     = await readTopology(app, holderId);
+        const mainBefore = before.nodes['main-tabs'].items;
+
+        expect(mainBefore, 'seed: swarm must start in main-tabs').toContain('swarm');
 
         const result = await app.executeDockOperation(holderId, {
             operation: 'splitNode', itemId: 'swarm', targetNodeId: 'terminal-tabs', orientation: 'horizontal', edge: 'right'
@@ -94,7 +113,7 @@ test.describe('Dock semantic operations (Neural Link, structural)', () => {
 
         // swarm left main-tabs and lives in a NEW single-tab node inside a NEW horizontal split
         // whose children are [terminal-tabs, newTabs] (edge 'right' trails)
-        expect(topo.nodes['main-tabs'].items).toEqual(['strategy']);
+        expect(topo.nodes['main-tabs'].items).toEqual(mainBefore.filter(id => id !== 'swarm'));
 
         const swarmTabs = tabsNodeHolding(topo, 'swarm');
         expect(swarmTabs).not.toBe('main-tabs');


### PR DESCRIPTION
Resolves #17555

Related: #17541 / PR #17545 — their AC-7 residual points at #17555 and discharges when this merges. Parent lane: #13158.

The two `DockOperationsNL` exact-remainder assertions encoded the pre-growth example seed (`main-tabs{strategy,swarm}`); the live boot document has held seven `main-tabs` items since the demo grew, so both cases failed on unmodified `dev` while the operations under test behaved correctly — the commit delta and the independent topology read agreed with each other in every failing run (diagnosis with receipts on #17555). The repair keeps the witnesses exact without re-pinning the fixture: each case reads the topology before its operation and derives the expected remainder from that read (`mainBefore.filter(id => id !== 'swarm')`; the moveItem case also derives the spliced target list), guarded by a seed assertion (`swarm` must start in `main-tabs`). The spec header now names the example's `initialDockModel` as the live authority and records the discipline: a pinned remainder literal goes stale the day the demo gains a pane, while the operations stay correct.

Evidence: L3 (headed Neural Link journeys on the author host at the exact head) → L3 required (#17555 AC names the witness green on the measured host). No residuals.

## AC Evidence
| AC-1 | Cause diagnosed with a falsifying receipt on #17555 before this PR: spec-fixture drift, environment ruled out — the seven-item document ships on unmodified `dev` (`examples/dashboard/dock/MainContainer.mjs`), and the assertion diffs show the received arrays are exactly the grown document minus the moved item |
| AC-2 | Witness corrected with the reason recorded: derived remainders + seed guards in both cases, the discipline in the spec header; pre-fix red receipts: 16/2 at `origin/dev` `f57af55b47` (detached worktree) and 29/31 at PR #17545's `7c5a97af92` — the same two cases both times; post-fix 6/6 headed at this head |
| AC-3 | The #17541 AC-7 residual annotation names #17555 and discharges at this merge — noted at its close-out |

## Deltas from ticket
None — the diff implements the fix shape the ticket's diagnosis comment named (derived remainders over pinned literals, header refresh), with one addition in the same spirit: the moveItem case also derives its spliced target-list expectation, so neither side of that assertion pins the fixture.

## Test Evidence
- Headed, author host, Chromium, `npx playwright test test/playwright/e2e/dashboard/DockOperationsNL.spec.mjs -c test/playwright/playwright.config.e2e.mjs --retries=0` at the exact head: **6 passed** (21.4s) — the file's first full green on this host in the measured window.
- Pre-fix red control: the identical two cases (`:65` moveItem, `:82` splitNode) failed on unmodified `origin/dev` (`f57af55b47`) and at PR #17545's head with the same received arrays — the drift, not the branch, was the cause.
- Structural assertions unchanged: delta/read JSON agreement, new-split membership and ordering, single-tab node identity, seed guards added.

## Post-Merge Validation
None owed — the witness file is its own consumer; the #17541 AC-7 residual discharge is annotated at its close-out, not deferred work.

## Commits
- the single test commit: derived remainders + seed guards + the header authority note

Authored by Mnemosyne (Claude Fable 5, Claude Code). Session bd272031-6109-449d-8a0c-38230064a8f3.
