### PR TITLE
refactor(workstation): migrate the workspace host onto Neo.dashboard.DockWorkspace (#17546)

### DIFF
--- a/apps/workstation/view/Workspace.mjs
+++ b/apps/workstation/view/Workspace.mjs
@@ -1,5 +1,6 @@
 import Component                   from '../../../src/component/Base.mjs';
 import Container                   from '../../../src/container/Base.mjs';
+import DockWorkspace               from '../../../src/dashboard/DockWorkspace.mjs';
 import Feed                        from '../store/Feed.mjs';
 import FeedPane                    from './FeedPane.mjs';
 import Scale                       from '../store/Scale.mjs';
@@ -7,7 +8,6 @@ import ScalePane                   from './ScalePane.mjs';
 import DockDragAffordances         from '../../../src/dashboard/DockDragAffordances.mjs';
 import DockDropIndicators          from '../../../src/dashboard/DockDropIndicators.mjs';
 import DockLayoutAdapter           from '../../../src/dashboard/DockLayoutAdapter.mjs';
-import DockMotionSignal            from '../../../src/dashboard/DockMotionSignal.mjs';
 import DockPerspectiveStore        from '../../../src/dashboard/DockPerspectiveStore.mjs';
 import DockPreview                 from '../../../src/dashboard/DockPreview.mjs';
 import DockProjectionReconciler    from '../../../src/dashboard/DockProjectionReconciler.mjs';
@@ -67,7 +67,7 @@ const paneStories = Object.freeze({
  * @class Workstation.view.Workspace
  * @extends Neo.container.Base
  */
-class Workspace extends Container {
+class Workspace extends DockWorkspace {
     /**
      * Five records every 500ms: the declared 10-records/sec producer contract.
      * @member {Number} FEED_BATCH_SIZE=5
@@ -132,6 +132,16 @@ class Workspace extends Container {
          */
         cls: ['workstation-workspace'],
         /**
+         * The projection mounts into the dock-host child built in `construct` — the preview
+         * renderer and drop indicators live beside the projected shell as persistent siblings.
+         * @member {String|null} dockHostReference='dock-host'
+         */
+        dockHostReference: 'dock-host',
+        /**
+         * @member {String} flipMarkerPrefix='workstation-pane-'
+         */
+        flipMarkerPrefix: 'workstation-pane-',
+        /**
          * @member {Object} layout
          */
         layout: {ntype: 'vbox', align: 'stretch'},
@@ -158,9 +168,14 @@ class Workspace extends Container {
     }
 
     /**
-     * @member {Object|null} dockModel=null
+     * Retained tab bars whose CSS entry animation is suppressed for the current re-projection —
+     * written by {@link #getReconcileOptions}'s staging seam, restored and cleared by
+     * {@link #afterRefreshDockWorkspace}. Refreshes serialize on the class's chain, so the field
+     * never sees two transactions at once.
+     * @member {Neo.toolbar.Base[]} animationSuppressedBars=[]
+     * @protected
      */
-    dockModel = null
+    animationSuppressedBars = []
     /**
      * @member {Neo.ai.client.DockService|null} dockService=null
      */
@@ -329,11 +344,6 @@ class Workspace extends Container {
      * @protected
      */
     vesselOwnerGrantGeneration = 0
-    /**
-     * @member {Promise|null} refreshPromise=null
-     * @protected
-     */
-    refreshPromise = null
     /**
      * Number of coalesced producer batches appended over this workspace lifetime.
      * @member {Number} feedBatchCount=0
@@ -576,14 +586,6 @@ class Workspace extends Container {
     }
 
     /**
-     * @param {Object} descriptor
-     * @returns {{document:Object, errors:String[]}}
-     */
-    applyDockZoneOperation(descriptor) {
-        return DockZoneModel.applyOperation(this.dockModel, descriptor)
-    }
-
-    /**
      * Adds one coalesced feed batch, then trims the capped tail in one splice.
      * @param {Number} amount
      * @returns {Number} Current feed count.
@@ -711,13 +713,6 @@ class Workspace extends Container {
     }
 
     /**
-     * @returns {Object} Live committed dock document.
-     */
-    getDockZoneDocument() {
-        return this.dockModel
-    }
-
-    /**
      * The current projection shell's instance id — the discriminator between the reconciler's
      * stable-topology fast path (shell retained) and the staged full path (shell replaced).
      * Pane instances AND their DOM survive either path; only the shell identity flips.
@@ -791,29 +786,6 @@ class Workspace extends Container {
         control.menuList && (control.menuList.hidden = true);
 
         return item ? {activatedItemId: itemId, menuItemCount: menuItems.length} : false
-    }
-
-    /**
-     * Defers the instance-preserving re-projection after a successful reducer commit.
-     * @param {Object} document
-     * @param {Object} [options={}]
-     * @param {Boolean} [options.geometryOnly] Explicit stable-topology projection admission.
-     * @param {String} [options.operation] Committed reducer operation.
-     * @param {String[]} [options.preserveItemIds] Owner-held panes the reconciler must park.
-     */
-    onDockZoneDocumentChange(document, options={}) {
-        let me = this;
-
-        me.dockModel = document;
-        // Every projection is an atomic ownership transaction across the old shell, the staged shell,
-        // and their closest common parent. Preserve that atomicity across rapid reducer commits too:
-        // replacing this promise would allow a later commit to start a second transaction before the
-        // first removed its source shell, exposing duplicate projections and racing Canvas registration.
-        me.refreshPromise = (me.refreshPromise || Promise.resolve())
-            .then(() => me.timeout(0))
-            .then(() => {
-                if (!me.isDestroyed) return me.refreshDockWorkspace(options)
-            })
     }
 
     /**
@@ -954,15 +926,17 @@ class Workspace extends Container {
     }
 
     /**
-     * Projects the committed document with instance-bound reducer/view callbacks.
-     * @param {Function|null} [resolveComponentRef=null] Optional staging resolver.
+     * The workstation's full multi-window projection surface: cross-window participation, the
+     * tear-out and vessel-conversion opt-ins with their handler seams, the drag-affordance
+     * layer's cross-zone seams, and the stable workspace identity. The class threads the reducer,
+     * the view-sync and the resolvers onto every projection; this hook contributes everything
+     * that is genuinely this host's.
      * @returns {Object}
      */
-    projectDockModel(resolveComponentRef=null) {
+    getDockProjectionOptions() {
         let me = this;
 
-        return DockLayoutAdapter.project(me.dockModel, {
-            applyDockZoneOperation: me.applyDockZoneOperation.bind(me),
+        return {
             // Cross-window participation (§2.3): every projected tab zone registers as a
             // coordinator-visible drag source under one sort group; the workspace id rides the
             // payload for the receiving window's `transferItem` resolution.
@@ -1015,15 +989,11 @@ class Workspace extends Container {
                     rect: data.logicalRect ?? data.record?.sourceRect ?? null
                 })
             },
-            onDockVesselConversionTerminal: data => me.vesselParkHandlers.onGestureTerminal(data),
-            onDockVesselConversionRetired : data => me.vesselParkHandlers.onVesselRetired(data),
-            onDockZoneDocumentChange      : me.onDockZoneDocumentChange.bind(me),
-            resolveComponentRef           : resolveComponentRef
-                || ((componentRef, item, itemId) => me.resolvePane(itemId, item)),
-            resolveRevealComponentRef        : (componentRef, item, itemId) => me.resolvePane(itemId, item),
+            onDockVesselConversionTerminal   : data => me.vesselParkHandlers.onGestureTerminal(data),
+            onDockVesselConversionRetired    : data => me.vesselParkHandlers.onVesselRetired(data),
             resolveVesselConversionSourceRect: data => me.resolveVesselConversionSourceRect(data),
             workspaceId                      : Workspace.MAIN_WORKSPACE_ID
-        })
+        }
     }
 
     /**
@@ -1769,13 +1739,13 @@ class Workspace extends Container {
                     }
                     receipt.phases.push('target-projected');
 
-                    await me.refreshDockWorkspace({
+                    await me.refreshDockWorkspace(null, me.dockModel, {
                         preserveItemIds: Object.keys(targetState.document?.items || {})
                     });
                     receipt.phases.push('main-projected');
                     targetState.reconciling = false
                 } else {
-                    await me.refreshDockWorkspace({operation: descriptor?.operation});
+                    await me.refreshDockWorkspace(null, me.dockModel, me.getRefreshOptions({operation: descriptor?.operation}));
                     receipt.phases.push('main-projected');
 
                     if (me.vesselWorkspaces.get(sourceWorkspaceId) === sourceState) {
@@ -2087,86 +2057,96 @@ class Workspace extends Container {
     }
 
     /**
-     * Atomically hands cached panes from the current projection to a staged next projection.
-     *
-     * {@link Neo.dashboard.DockProjectionReconciler} owns the renderer-safe staged ownership
-     * transaction shared with other docking workspaces. Workstation supplies its cached-pane resolver,
-     * header text, FLIP motion, retained-indicator suppression, and the heavy Overflow menu witness.
-     * @param {Object} [options={}]
-     * @param {Boolean} [options.geometryOnly=false] Admission REQUEST for the in-place projection
-     *     path — never a claim that the topology is stable. The reconciler validates it and falls
-     *     back to the staged transaction on any structural delta, and `DockFlip` is told the
-     *     resulting `landedInPlace`, not this request.
-     * @param {String|null} [options.operation=null] Committed reducer operation. `'detachItem'` and
-     *     `'transferNode'` admit the stable-topology fast path (in-place item reconciliation on the
-     *     retained shell) when the reconciler's structural validator proves the shell unchanged.
-     * @param {String[]} [options.preserveItemIds=[]] Owner-held panes the reconciler must park
-     *     instead of destroy (a terminal-first tear-out vessel owns its pane before it connects).
-     * @returns {Promise<void>}
+     * Chrome that must retire before every re-projection: the active gesture session's geometry
+     * and the drag-affordance overlays — a stale geometry promise must never survive a topology
+     * change (the controller's generation guards depend on it). Both are absolute overlay
+     * bookkeeping, so running after the FLIP first-snapshot cannot alter the captured pane rects.
+     * @param {Object} document The committed document this refresh projects.
+     * @param {Object} refreshOptions The options {@link #getRefreshOptions} produced for it.
      */
-    async refreshDockWorkspace({geometryOnly=false, operation=null, preserveItemIds=[]}={}) {
-        const
-            me           = this,
-            host         = me.getReference('dock-host'),
-            flip         = Neo.main?.addon?.DockFlip,
-            placeholders = new Map();
+    beforeRefreshDockWorkspace(document, refreshOptions) {
+        let me = this;
 
-        if (!host) return;
-
-        geometryOnly = geometryOnly || operation === 'resizeSplit';
-
-        // Every re-projection retires the active gesture session — a stale geometry promise
-        // must never survive a topology change (the controller's generation guards depend on it).
         me.crossWindowPreviewGeometries.delete(Workspace.MAIN_WORKSPACE_ID);
-        me.dragAffordances?.clear();
+        me.dragAffordances?.clear()
+    }
 
-        try {
-            await flip?.captureFirst({hostId: host.id, markerPrefix: 'workstation-pane-'})
-        } catch (error) {/* instant landing */}
+    /**
+     * The reconciler seams this host owns: retained tab bars suppress their CSS entry animation
+     * across native reparenting (restored in {@link #afterRefreshDockWorkspace} once the chrome
+     * window elapsed), and overflow projections are awaited through the app's four-fact readiness
+     * check. Refreshes serialize on the class's settled-tail chain, so the suppressed-bars field
+     * never sees two transactions at once.
+     * @param {Object|null} document The committed document this refresh projects.
+     * @param {Object} refreshOptions The options {@link #getRefreshOptions} produced for it.
+     * @returns {Object}
+     */
+    getReconcileOptions(document, refreshOptions) {
+        let me = this;
 
-        const nextConfig = me.projectDockModel((componentRef, item, itemId) => {
-            const placeholder = Neo.create({
-                module: Component,
-                header: {text: me.getPaneHeaderText(itemId, item)},
-                hidden: true
-            });
+        me.animationSuppressedBars = [];
 
-            placeholders.set(itemId, placeholder);
-
-            return placeholder
-        });
-
-        let animationSuppressedBars = [];
-
-        const {landedInPlace, nextShell} = await DockProjectionReconciler.reconcileProjection({
-            geometryOnly,
-            host,
-            nextConfig,
-            placeholders,
-            preserveItemIds,
-            // A transferNode adoption keeps the structural shell (one tabs node's items grow);
-            // the reconciler's stable-topology validator still rejects any transfer that does
-            // mutate structure, so non-stable placements keep the staged full path.
-            retainTopology: operation === 'detachItem' || operation === 'transferNode',
-            resolveItem   : itemId => me.resolvePane(itemId, me.dockModel.items[itemId]),
-            onProjectionStaged({plans}) {
+        return {
+            onProjectionStaged: ({plans}) => {
                 const retainedTabBars = [...plans.values()]
                     .filter(plan => plan.tab)
                     .map(plan => plan.tab.getTabBar());
 
-                animationSuppressedBars = retainedTabBars
+                me.animationSuppressedBars = retainedTabBars
                     .filter(bar => !bar.cls.includes('neo-no-animation'));
 
                 // Native reparenting keeps each toolbar DOM node, but CSS animations restart when it
                 // re-enters the document. Retained indicators settle immediately; new chrome still enters.
-                animationSuppressedBars.forEach(bar => {
+                me.animationSuppressedBars.forEach(bar => {
                     bar.setSilent({cls: [...bar.cls, 'neo-no-animation']})
                 })
             },
             waitForOverflowProjection: plugin => me.waitForOverflowProjection(plugin)
-        });
+        }
+    }
 
-        const heavyOverflow = nextShell.down({dockNodeId: 'heavy-tabs'})
+    /**
+     * Maps both commit shapes onto the reconciler's fast paths — engine surfaces pass the semantic
+     * descriptor, this host's own paths pass their options object. `resizeSplit` (or an explicit
+     * `geometryOnly`) is an admission REQUEST for the in-place projection path, never a claim that
+     * the topology is stable: the reconciler validates it, falls back to the staged transaction on
+     * any structural delta, and `DockFlip` is told the resulting `landedInPlace`, not this
+     * request. `detachItem` / `transferNode` admit the stable-topology fast path (a transferNode
+     * adoption keeps the structural shell — one tabs node's items grow — and the validator still
+     * rejects any transfer that does mutate structure). A commit-scoped `preserveItemIds` parks
+     * owner-held panes instead of destroying them (a terminal-first tear-out vessel owns its pane
+     * before it connects).
+     * @param {Object|null} descriptor The committing surface's identification — a semantic
+     *     descriptor or this host's options object.
+     * @param {Object|null} source The committing surface, when it identifies itself.
+     * @returns {Object}
+     */
+    getRefreshOptions(descriptor, source) {
+        let {geometryOnly = false, operation = null, preserveItemIds} = descriptor || {};
+
+        return {
+            geometryOnly  : geometryOnly === true || operation === 'resizeSplit',
+            retainTopology: operation === 'detachItem' || operation === 'transferNode',
+            ...(Array.isArray(preserveItemIds) && preserveItemIds.length > 0 ? {preserveItemIds} : {})
+        }
+    }
+
+    /**
+     * The post-projection sequence this host orders behind the motion: the heavy tab bar's
+     * overflow-menu readiness, the awaited FLIP play, the chrome-animation window, the suppressed
+     * bars' restore, one host update, and the cross-window participation refresh.
+     * @param {Object} data
+     * @param {Object|null} data.result The reconciler's outcome; `nextShell` carries the live
+     *     projection shell on both paths.
+     * @param {Promise|null} data.played Settles when the FLIP motion finishes; awaited here
+     *     because retained-indicator restore and the participation refresh must trail the motion.
+     * @returns {Promise<void>}
+     */
+    async afterRefreshDockWorkspace({result, played}) {
+        let me   = this,
+            host = me.getDockHost();
+
+        const heavyOverflow = result?.nextShell?.down({dockNodeId: 'heavy-tabs'})
             ?.getTabBar()?.getPlugin('tab-overflow');
 
         await me.waitForOverflowMenu(heavyOverflow);
@@ -2175,27 +2155,14 @@ class Workspace extends Container {
         // theme's 260ms window before restoring it prevents a delayed replay on retained indicators.
         const chromeAnimationSettle = me.timeout(300);
 
-        if (flip) {
-            DockMotionSignal.enter(me);
-
-            try {
-                // `landedInPlace` is what the reconciler DID, not what this call requested.
-                // `DockFlip.play`'s contract reads "no topology swap can be pending", which only
-                // the outcome can satisfy: `geometryOnly` merely admits an in-place ATTEMPT, and
-                // that attempt falls back to the staged shell swap on any structural delta. Passing
-                // the request here is how a reset across a diverged layout used to declare
-                // stable topology over a swap that had already happened.
-                await flip.play({geometryOnly: landedInPlace, hostId: host.id, markerPrefix: 'workstation-pane-'})
-            } catch (error) {/* instant landing */}
-            finally {
-                DockMotionSignal.leave(me)
-            }
-        }
-
+        await played;
         await chromeAnimationSettle;
-        animationSuppressedBars.forEach(bar => {
+
+        (me.animationSuppressedBars || []).forEach(bar => {
             bar.setSilent({cls: bar.cls.filter(cls => cls !== 'neo-no-animation')})
         });
+        me.animationSuppressedBars = [];
+
         host.updateDepth = -1;
         host.update();
         await host.promiseUpdate();
@@ -2374,7 +2341,7 @@ class Workspace extends Container {
 
         try {
             me.dockModel = DockZoneModel.clone(initialDocument);
-            await me.refreshDockWorkspace({geometryOnly: true});
+            await me.refreshDockWorkspace(null, me.dockModel, {geometryOnly: true});
 
             // The entry projection is finished and the replay has not begun. Published because a
             // frame-capturing consumer cannot otherwise tell the two apart: both happen inside one
@@ -2548,7 +2515,7 @@ class Workspace extends Container {
         me.dockModel       = DockZoneModel.clone(initialDocument);
         await me.setPipProgress(0);
 
-        await me.refreshDockWorkspace({geometryOnly: true});
+        await me.refreshDockWorkspace(null, me.dockModel, {geometryOnly: true});
 
         const
             feedStore      = me.getStateProvider().getStore('feed'),

--- a/apps/workstation/view/Workspace.mjs
+++ b/apps/workstation/view/Workspace.mjs
@@ -65,7 +65,7 @@ const paneStories = Object.freeze({
  * hydration, and OffscreenCanvas registration; this class owns only composition and story.
  *
  * @class Workstation.view.Workspace
- * @extends Neo.container.Base
+ * @extends Neo.dashboard.DockWorkspace
  */
 class Workspace extends DockWorkspace {
     /**

--- a/src/dashboard/DockWorkspace.mjs
+++ b/src/dashboard/DockWorkspace.mjs
@@ -170,6 +170,26 @@ class DockWorkspace extends Container {
     }
 
     /**
+     * Hook: the post-projection moment — runs after the staged transaction landed and the FLIP
+     * play (when any) was dispatched, and is AWAITED by the refresh, so a host that must sequence
+     * chrome behind the motion (an overflow-menu settle, a bar-animation restore, a cross-window
+     * participation refresh) can do so without owning the loop. `played` is the play's
+     * settled-safe promise — motion failures resolve it to `null`, motion never fails truth — or
+     * `null` when no play was dispatched; awaiting it is the HOST's choice. The default does
+     * nothing, so every other host keeps fire-and-forget semantics, and the motion signal's
+     * `leave` stays class-owned, firing when the play settles independent of this hook.
+     * @param {Object} data
+     * @param {Object|null} data.document The committed document this refresh projected.
+     * @param {Object} data.refreshOptions The options the scheduling commit produced.
+     * @param {Object|null} data.result The reconciler's outcome; `landedInPlace` reports the path
+     *     it ACTUALLY took, never the requested one.
+     * @param {Promise|null} data.played Settles when the FLIP motion finishes (`null` on motion
+     *     failure or without a dispatched play).
+     * @returns {Promise<void>|void}
+     */
+    afterRefreshDockWorkspace(data) {}
+
+    /**
      * Hook: app chrome that must sync on every re-projection (a perspective toolbar, a control
      * bar, a drag-affordance session to invalidate). Runs AFTER the FLIP snapshot of the outgoing
      * geometry and before the staged projection, so chrome mutation can never alter the captured
@@ -292,9 +312,29 @@ class DockWorkspace extends Container {
     }
 
     /**
+     * Hook: extra options for the reconciler's staged transaction — a tab-bar animation
+     * suppression seam (`onProjectionStaged`), an overflow-projection wait
+     * (`waitForOverflowProjection`), a host-forced `retainTopology`. Returned keys merge AFTER
+     * the class's own reconciler options; the projection identity keys the class owns (`host`,
+     * `nextConfig`, `placeholders`, `resolveItem`, `shellIndex`) are not this hook's to replace.
+     * The default contributes nothing.
+     * @param {Object|null} document The committed document this refresh projects.
+     * @param {Object} refreshOptions The options {@link #getRefreshOptions} produced for it.
+     * @returns {Object}
+     */
+    getReconcileOptions(document, refreshOptions) {
+        return {}
+    }
+
+    /**
      * Hook: the reconciler's fast-path options for the refresh a commit schedules —
      * `{geometryOnly}` for a pure `resizeSplit`, `{retainTopology}` for item-only deltas on a
-     * proven-identical shell. The default takes the full staged transaction every time.
+     * proven-identical shell, `{preserveItemIds}` for owner-held ids known only at THIS commit (a
+     * pane parked by the operation itself), merged with the standing {@link #getPreservedItemIds}
+     * set. The default takes the full staged transaction every time. The committing surface passes
+     * `descriptor` as it identifies the operation — engine surfaces pass the semantic descriptor;
+     * a host's own paths may pass their options object — and the override maps whatever shapes its
+     * commit sites produce.
      * @param {Object|null} descriptor The semantic operation that produced the document, when known.
      * @param {Object|null} source The committing surface, when it identifies itself.
      * @returns {Object}
@@ -470,6 +510,10 @@ class DockWorkspace extends Container {
      * A `null` document reconciles toward the EMPTY projection: every pane retires, the shell
      * survives. A configured {@link #dockHostReference} that resolves to no live host throws —
      * the committed document is not rendered, and that must fail loudly, never settle silently.
+     * The reconciler's outcome is captured and its `landedInPlace` — the path it ACTUALLY took,
+     * never the requested one — rides the FLIP play as `geometryOnly`; after the play is
+     * dispatched, {@link #afterRefreshDockWorkspace} is awaited with the outcome and the play's
+     * settled-safe promise.
      * @param {Object|null} [tabInsertDescriptor=null] One-use normalized `addTab` correlation
      *     captured by the commit that scheduled this refresh.
      * @param {Object|null} [document=this.dockModel] Committed document snapshot owned by this
@@ -477,6 +521,8 @@ class DockWorkspace extends Container {
      * @param {Object} [refreshOptions={}]
      * @param {Boolean} [refreshOptions.geometryOnly=false] Admit the reconciler's strict in-place
      *     geometry path.
+     * @param {String[]} [refreshOptions.preserveItemIds] Per-commit owner-held ids, merged with
+     *     the standing {@link #getPreservedItemIds} set.
      * @param {Boolean} [refreshOptions.retainTopology=false] Admit in-place item reconciliation on
      *     a proven-identical structural shell.
      * @returns {Promise<void>}
@@ -513,12 +559,12 @@ class DockWorkspace extends Container {
             return placeholder
         }, document);
 
-        await DockProjectionReconciler.reconcileProjection({
+        const result = await DockProjectionReconciler.reconcileProjection({
             geometryOnly,
             host,
             nextConfig,
             placeholders,
-            preserveItemIds: me.getPreservedItemIds(),
+            preserveItemIds: [...new Set([...me.getPreservedItemIds(), ...(refreshOptions.preserveItemIds || [])])],
             resolveItem    : itemId => {
                 const item = document?.items?.[itemId];
 
@@ -533,27 +579,34 @@ class DockWorkspace extends Container {
                 )
             },
             retainTopology,
-            shellIndex: me.dockShellIndex
+            shellIndex: me.dockShellIndex,
+            ...me.getReconcileOptions(document, refreshOptions)
         });
 
-        // FLIP phase 2: fire-and-forget — the addon self-waits for the swap, inverts and plays; the
-        // counted motion signal brackets the awaited animation window. Gate on the CAPABILITY, not
-        // on the addon's presence: a partial addon (a test double, a degraded main thread) must land
-        // the layout instantly rather than throw after the document already committed.
+        // FLIP phase 2: fire-and-forget by default — the addon self-waits for the swap, inverts and
+        // plays; the counted motion signal brackets the awaited animation window. Gate on the
+        // CAPABILITY, not on the addon's presence: a partial addon (a test double, a degraded main
+        // thread) must land the layout instantly rather than throw after the document already
+        // committed. `geometryOnly` rides the reconciler's ACTUAL path, never the requested one.
+        let played = null;
+
         if (typeof flip?.play === 'function' && !me.isDestroyed) {
-            let played;
+            let rawPlayed;
 
             DockMotionSignal.enter(me);
 
             try {
-                played = flip.play({hostId: host.id, markerPrefix: flipMarkerPrefix})
+                rawPlayed = flip.play({hostId: host.id, markerPrefix: flipMarkerPrefix, geometryOnly: result?.landedInPlace === true})
             } catch (error) {
-                played = Promise.reject(error)
+                rawPlayed = Promise.reject(error)
             }
 
-            Promise.resolve(played)
-                .catch(() => {})
-                .finally(() => DockMotionSignal.leave(me))
+            played = Promise.resolve(rawPlayed).catch(() => null);
+            played.finally(() => DockMotionSignal.leave(me))
+        }
+
+        if (!me.isDestroyed) {
+            await me.afterRefreshDockWorkspace({document, refreshOptions, result, played})
         }
     }
 

--- a/src/dashboard/DockWorkspace.mjs
+++ b/src/dashboard/DockWorkspace.mjs
@@ -312,12 +312,14 @@ class DockWorkspace extends Container {
     }
 
     /**
-     * Hook: extra options for the reconciler's staged transaction — a tab-bar animation
-     * suppression seam (`onProjectionStaged`), an overflow-projection wait
-     * (`waitForOverflowProjection`), a host-forced `retainTopology`. Returned keys merge AFTER
-     * the class's own reconciler options; the projection identity keys the class owns (`host`,
-     * `nextConfig`, `placeholders`, `resolveItem`, `shellIndex`) are not this hook's to replace.
-     * The default contributes nothing.
+     * Hook: extra options for the reconciler's staged transaction. Exactly three keys are
+     * SANCTIONED and consumed — `onProjectionStaged` (a tab-bar animation-suppression seam),
+     * `waitForOverflowProjection` (an overflow-readiness wait), and `retainTopology` (a
+     * host-forced stable-topology admission, winning over the commit's own value when present).
+     * Every other returned key is DISCARDED: the projection identity — `host`, `nextConfig`,
+     * `placeholders`, the merged `preserveItemIds`, `resolveItem`, `shellIndex`, `geometryOnly` —
+     * is class-owned and mechanically unreachable from this hook. The default contributes
+     * nothing.
      * @param {Object|null} document The committed document this refresh projects.
      * @param {Object} refreshOptions The options {@link #getRefreshOptions} produced for it.
      * @returns {Object}
@@ -559,10 +561,17 @@ class DockWorkspace extends Container {
             return placeholder
         }, document);
 
+        // The hook extends the reconciler's SEAMS, never its identity: only the three sanctioned
+        // keys are read off its result — a hostile or accidental override cannot displace the
+        // class-owned projection identity below.
+        const {onProjectionStaged, retainTopology: forcedRetainTopology, waitForOverflowProjection} =
+            me.getReconcileOptions(document, refreshOptions) || {};
+
         const result = await DockProjectionReconciler.reconcileProjection({
             geometryOnly,
             host,
             nextConfig,
+            onProjectionStaged,
             placeholders,
             preserveItemIds: [...new Set([...me.getPreservedItemIds(), ...(refreshOptions.preserveItemIds || [])])],
             resolveItem    : itemId => {
@@ -578,9 +587,9 @@ class DockWorkspace extends Container {
                     }
                 )
             },
-            retainTopology,
-            shellIndex: me.dockShellIndex,
-            ...me.getReconcileOptions(document, refreshOptions)
+            retainTopology: forcedRetainTopology ?? retainTopology,
+            shellIndex    : me.dockShellIndex,
+            waitForOverflowProjection
         });
 
         // FLIP phase 2: fire-and-forget by default — the addon self-waits for the swap, inverts and

--- a/test/playwright/unit/apps/workstation/Workspace.spec.mjs
+++ b/test/playwright/unit/apps/workstation/Workspace.spec.mjs
@@ -2248,7 +2248,7 @@ test.describe('replay probe transaction (prototype-call)', () => {
                 id            : 'fake-workspace',
                 isDestroyed   : false,
                 refreshPromise: Promise.resolve(),
-                refreshDockWorkspace(options) {
+                refreshDockWorkspace(tabInsertDescriptor, document, options) {
                     refreshCalls.push(options ?? {});
 
                     return refreshCalls.length === 1
@@ -2275,7 +2275,7 @@ test.describe('replay probe transaction (prototype-call)', () => {
                 id            : 'fake-workspace',
                 isDestroyed   : false,
                 refreshPromise: Promise.resolve(),
-                refreshDockWorkspace(options) {
+                refreshDockWorkspace(tabInsertDescriptor, document, options) {
                     refreshCalls.push(options ?? {});
 
                     // entry projection succeeds; the restore projection rejects
@@ -2309,7 +2309,7 @@ test.describe('replay probe transaction (prototype-call)', () => {
                 id            : 'fake-workspace-unregistered',
                 isDestroyed   : false,
                 refreshPromise: Promise.resolve(),
-                refreshDockWorkspace(options) {
+                refreshDockWorkspace(tabInsertDescriptor, document, options) {
                     refreshCalls.push(options ?? {});
 
                     return refreshCalls.length === 1
@@ -2359,7 +2359,7 @@ test.describe('replay probe transaction (prototype-call)', () => {
                 id            : 'fake-workspace',
                 isDestroyed   : false,
                 refreshPromise: Promise.resolve(),
-                refreshDockWorkspace(options) {
+                refreshDockWorkspace(tabInsertDescriptor, document, options) {
                     refreshCalls.push(options ?? {});
 
                     return Promise.resolve()
@@ -2396,7 +2396,7 @@ test.describe('replay probe transaction (prototype-call)', () => {
                 id            : 'fake-workspace',
                 isDestroyed   : false,
                 refreshPromise: Promise.resolve(),
-                refreshDockWorkspace(options) {
+                refreshDockWorkspace(tabInsertDescriptor, document, options) {
                     refreshCalls.push(options ?? {});
 
                     return Promise.reject(new Error('entry projection rejected'))

--- a/test/playwright/unit/dashboard/DockWorkspace.spec.mjs
+++ b/test/playwright/unit/dashboard/DockWorkspace.spec.mjs
@@ -382,6 +382,174 @@ test.describe('Neo.dashboard.DockWorkspace', () => {
         expect(workspace.decorateFlipMarker({ntype: 'component'}, 'editor').cls).toEqual(['dock-flip-item-editor'])
     });
 
+    test('a commit-scoped preserveItemIds merges with the standing owner-held set', async () => {
+        workspace = Neo.create(ChromeWorkspace, {dockModel: createDocument()});
+
+        let preservedSeen = null;
+
+        const reconcile = DockProjectionReconciler.reconcileProjection;
+
+        DockProjectionReconciler.reconcileProjection = options => {
+            preservedSeen = [...options.preserveItemIds];
+            return reconcile.call(DockProjectionReconciler, options)
+        };
+
+        try {
+            const result = workspace.applyDockZoneOperation({operation: 'moveItem', itemId: 'preview', targetNodeId: 'editor-tabs', index: 0});
+
+            workspace.getRefreshOptions = () => ({preserveItemIds: ['editor', 'terminal']});
+            workspace.onDockZoneDocumentChange(result.document, {operation: 'moveItem'});
+            await workspace.refreshPromise
+        } finally {
+            DockProjectionReconciler.reconcileProjection = reconcile
+        }
+
+        // the standing hook holds 'terminal'; the commit adds 'editor' and repeats 'terminal' —
+        // the merge deduplicates, standing set first
+        expect(preservedSeen).toEqual(['terminal', 'editor'])
+    });
+
+    test('the reconciler\'s ACTUAL path reaches the FLIP play, never the requested one', async () => {
+        workspace = Neo.create(PlainWorkspace, {dockModel: createDocument()});
+
+        const
+            playArgs  = [],
+            hadMain   = Object.prototype.hasOwnProperty.call(Neo, 'main'),
+            mainNs    = Neo.main = Neo.main || {},
+            hadAddon  = Object.prototype.hasOwnProperty.call(mainNs, 'addon'),
+            addonNs   = mainNs.addon = mainNs.addon || {},
+            previous  = addonNs.DockFlip,
+            reconcile = DockProjectionReconciler.reconcileProjection;
+
+        addonNs.DockFlip = {
+            captureFirst: () => {},
+            play        : config => {playArgs.push(config)}
+        };
+
+        let landInPlace = true;
+
+        DockProjectionReconciler.reconcileProjection = () => ({landedInPlace: landInPlace});
+
+        try {
+            const first = workspace.applyDockZoneOperation({operation: 'resizeSplit', splitNodeId: 'root-split', sizes: [0.5, 0.5]});
+
+            workspace.onDockZoneDocumentChange(first.document, {operation: 'resizeSplit'});
+            await workspace.refreshPromise;
+
+            landInPlace = false;
+
+            const second = workspace.applyDockZoneOperation({operation: 'resizeSplit', splitNodeId: 'root-split', sizes: [0.6, 0.4]});
+
+            workspace.onDockZoneDocumentChange(second.document, {operation: 'resizeSplit'});
+            await workspace.refreshPromise
+        } finally {
+            DockProjectionReconciler.reconcileProjection = reconcile;
+            if (previous === undefined) {
+                delete addonNs.DockFlip
+            } else {
+                addonNs.DockFlip = previous
+            }
+            !hadAddon && delete mainNs.addon;
+            !hadMain  && delete Neo.main
+        }
+
+        expect(playArgs.map(config => config.geometryOnly)).toEqual([true, false])
+    });
+
+    test('a host\'s reconcile options merge after the class\'s own, identity keys intact', async () => {
+        workspace = Neo.create(PlainWorkspace, {dockModel: createDocument()});
+
+        let captured = null;
+
+        const
+            staged    = () => {},
+            reconcile = DockProjectionReconciler.reconcileProjection;
+
+        workspace.getReconcileOptions = () => ({
+            onProjectionStaged       : staged,
+            retainTopology           : true,
+            waitForOverflowProjection: () => {}
+        });
+
+        DockProjectionReconciler.reconcileProjection = options => {
+            captured = options;
+            return reconcile.call(DockProjectionReconciler, options)
+        };
+
+        try {
+            const result = workspace.applyDockZoneOperation({operation: 'moveItem', itemId: 'terminal', targetNodeId: 'editor-tabs', index: 1});
+
+            workspace.onDockZoneDocumentChange(result.document, {operation: 'moveItem'});
+            await workspace.refreshPromise
+        } finally {
+            DockProjectionReconciler.reconcileProjection = reconcile
+        }
+
+        expect(captured.onProjectionStaged).toBe(staged);
+        expect(captured.retainTopology).toBe(true);
+        expect(typeof captured.waitForOverflowProjection).toBe('function');
+        expect(captured.host).toBe(workspace);
+        expect(captured.shellIndex).toBe(0)
+    });
+
+    test('the post-refresh hook is awaited and receives the outcome and the play promise', async () => {
+        workspace = Neo.create(PlainWorkspace, {dockModel: createDocument()});
+
+        const
+            sequence = [],
+            hadMain  = Object.prototype.hasOwnProperty.call(Neo, 'main'),
+            mainNs   = Neo.main = Neo.main || {},
+            hadAddon = Object.prototype.hasOwnProperty.call(mainNs, 'addon'),
+            addonNs  = mainNs.addon = mainNs.addon || {},
+            previous = addonNs.DockFlip;
+
+        let received = null;
+
+        addonNs.DockFlip = {
+            captureFirst: () => {},
+            play        : () => Promise.resolve('motion-done')
+        };
+
+        workspace.afterRefreshDockWorkspace = async data => {
+            received = data;
+            sequence.push(['played', await data.played]);
+            await workspace.timeout(5);
+            sequence.push(['hook-done'])
+        };
+
+        try {
+            const result = workspace.applyDockZoneOperation({operation: 'moveItem', itemId: 'terminal', targetNodeId: 'editor-tabs', index: 1});
+
+            workspace.onDockZoneDocumentChange(result.document, {operation: 'moveItem'});
+            await workspace.refreshPromise;
+            sequence.push(['refresh-settled'])
+        } finally {
+            if (previous === undefined) {
+                delete addonNs.DockFlip
+            } else {
+                addonNs.DockFlip = previous
+            }
+            !hadAddon && delete mainNs.addon;
+            !hadMain  && delete Neo.main
+        }
+
+        // the refresh AWAITED the hook: it finished before the public promise settled
+        expect(sequence).toEqual([['played', 'motion-done'], ['hook-done'], ['refresh-settled']]);
+        expect(received.document).toBe(workspace.getDockZoneDocument());
+        expect(received.refreshOptions).toEqual({});
+        expect(received.result).toBeTruthy();
+
+        // without a dispatched play the hook still runs, with `played` null
+        workspace.afterRefreshDockWorkspace = data => {received = data};
+
+        const next = workspace.applyDockZoneOperation({operation: 'moveItem', itemId: 'terminal', targetNodeId: 'side-tabs', index: 0});
+
+        workspace.onDockZoneDocumentChange(next.document, {operation: 'moveItem'});
+        await workspace.refreshPromise;
+
+        expect(received.played).toBeNull()
+    });
+
     test('the add-tab correlation is minted only for a globally absent header', () => {
         workspace = Neo.create(PlainWorkspace, {dockModel: createDocument()});
 

--- a/test/playwright/unit/dashboard/DockWorkspace.spec.mjs
+++ b/test/playwright/unit/dashboard/DockWorkspace.spec.mjs
@@ -456,19 +456,29 @@ test.describe('Neo.dashboard.DockWorkspace', () => {
         expect(playArgs.map(config => config.geometryOnly)).toEqual([true, false])
     });
 
-    test('a host\'s reconcile options merge after the class\'s own, identity keys intact', async () => {
+    test('the reconcile hook passes only its sanctioned seams; a hostile override cannot displace the identity keys', async () => {
         workspace = Neo.create(PlainWorkspace, {dockModel: createDocument()});
 
         let captured = null;
 
         const
             staged    = () => {},
+            overflow  = () => {},
+            hostileFn = () => {throw new Error('hostile')},
             reconcile = DockProjectionReconciler.reconcileProjection;
 
+        // every class-owned identity key supplied hostilely, beside the three sanctioned seams
         workspace.getReconcileOptions = () => ({
+            geometryOnly             : true,
+            host                     : {id: 'hostile-host'},
+            nextConfig               : {ntype: 'container', cls: ['hostile']},
             onProjectionStaged       : staged,
+            placeholders             : new Map([['x', 'hostile']]),
+            preserveItemIds          : ['hostile-item'],
+            resolveItem              : hostileFn,
             retainTopology           : true,
-            waitForOverflowProjection: () => {}
+            shellIndex               : 99,
+            waitForOverflowProjection: overflow
         });
 
         DockProjectionReconciler.reconcileProjection = options => {
@@ -485,11 +495,19 @@ test.describe('Neo.dashboard.DockWorkspace', () => {
             DockProjectionReconciler.reconcileProjection = reconcile
         }
 
+        // the sanctioned seams arrive …
         expect(captured.onProjectionStaged).toBe(staged);
         expect(captured.retainTopology).toBe(true);
-        expect(typeof captured.waitForOverflowProjection).toBe('function');
+        expect(captured.waitForOverflowProjection).toBe(overflow);
+
+        // … and every identity key stays class-owned
         expect(captured.host).toBe(workspace);
-        expect(captured.shellIndex).toBe(0)
+        expect(captured.shellIndex).toBe(0);
+        expect(captured.geometryOnly).toBe(false);
+        expect(captured.nextConfig.cls).not.toContain('hostile');
+        expect(captured.placeholders.get('x')).toBeUndefined();
+        expect(captured.preserveItemIds).not.toContain('hostile-item');
+        expect(captured.resolveItem).not.toBe(hostileFn)
     });
 
     test('the post-refresh hook is awaited and receives the outcome and the play promise', async () => {


### PR DESCRIPTION
Resolves #17546

Related: #17539 (epic, O-2) · #17541 / PR #17545 (the class this consumes)

The richest hand-rolled dock host rides the engine class: `apps/workstation/view/Workspace.mjs` extends `Neo.dashboard.DockWorkspace`, its five holder-core members (`applyDockZoneOperation`, `getDockZoneDocument`, `onDockZoneDocumentChange`, `projectDockModel`, `refreshDockWorkspace`) are deleted, and everything genuinely workstation-owned arrives through the class's hooks: the full multi-window projection surface via `getDockProjectionOptions()`, both commit shapes mapped onto the reconciler fast paths via `getRefreshOptions()`, gesture-session retirement via `beforeRefreshDockWorkspace()`, the tab-bar animation-suppression and overflow-readiness seams via `getReconcileOptions()`, and the ordered post-projection sequence (overflow menu → awaited play → chrome settle → bars restored → host update → cross-window refresh) via the awaited `afterRefreshDockWorkspace()`. The four class deltas the ticket named land first, engine-side, each with a unit control and each under the epic's hook-admission rule: per-commit `preserveItemIds` merged with the standing hook set, the reconciler's `landedInPlace` riding `flip.play` as `geometryOnly` (the ACTUAL path, never the request), the `getReconcileOptions` hook, and the awaited `afterRefreshDockWorkspace` receiving the outcome and the play's settled-safe promise. Every tear-out / vessel / cross-window member stays byte-identical (leaf 2b's boundary, recorded on the epic). LOC: 5306 → 5273.

Evidence: L3 (headed Neural Link journeys + unit suites on the author host at the exact head; CI ceiling is unit + lint) → L3 required (#17546 ACs 3, 4, 6 and 7 name headed witnesses). Residual: AC-6 (five pre-existing dev-red cases + one brain-tier-blocked file, none caused by this branch), Residual-Owner: #17564.

## AC Evidence
| AC-1 | `Workspace.mjs` extends the class; the five members deleted (`git log -p` on the file); LOC 5306 → 5273 (`wc -l` at head vs merge base) |
| AC-2 | The four deltas in `src/dashboard/DockWorkspace.mjs` (`7315862333`), each with a `DockWorkspace.spec.mjs` case: "a commit-scoped preserveItemIds merges with the standing owner-held set", "the reconciler's ACTUAL path reaches the FLIP play, never the requested one", "a host's reconcile options merge after the class's own, identity keys intact", "the post-refresh hook is awaited and receives the outcome and the play promise"; dashboard unit dir 548/548; example's ten-file headed set **31/31 green** (1.8m) — the first fully green ten-file run on this host, the #17555 repair in the base |
| AC-3 | `getRefreshOptions` maps both commit shapes (descriptor + options object) — `resizeSplit` → `geometryOnly`, `detachItem`/`transferNode` → `retainTopology`, `preserveItemIds` pass-through; headed: `WorkstationDockFlipResizeNL` + `WorkstationTearOutSourceContinuityNL` under Test Evidence |
| AC-4 | The post-refresh order is preserved in `afterRefreshDockWorkspace` (awaits in today's sequence); headed: `WorkstationTabOverflowCapNL`, `WorkstationCrossZoneCueNL`, `WorkstationDragAffordancesNL` under Test Evidence |
| AC-5 | `Workspace.spec.mjs` 591-suite green with ONE recorded delta from "unmodified": the five duck-spy signatures widened from `refreshDockWorkspace(options)` to the class signature `(tabInsertDescriptor, document, options)` — every assertion untouched; the instance stubs still intercept |
| AC-6 | All 18 `test/playwright/e2e/workstation/*.spec.mjs` files headed at the exact head — counts under Test Evidence |
| AC-7 | `WorkstationFiveBeatNL` — under Test Evidence |
| AC-8 | Zero diff in tear-out / vessel / cross-window members (the `git diff` on `Workspace.mjs` touches imports, configs, the five deletions, the five overrides, four call-site remaps, two field removals and one field addition — nothing else); `src/dashboard` diff = the four deltas only; `additionalThemeFiles` unchanged, still listing `Neo.dashboard.Container` |

## Deltas from ticket
- **The five workstation spec spies widened to the class signature** (AC-5 said "passes unmodified"): the spies pinned the OLD argument position (`refreshDockWorkspace(options)`); the class moved refresh options to the third parameter. All assertions — including the fast-path admission and restore-stays-full contracts — are byte-identical; only the spy parameter lists changed.
- **The FLIP motion now starts before the overflow-menu wait, not after it.** The class dispatches the play right after reconciliation and hands the promise to `afterRefreshDockWorkspace`; today's hand-rolled loop dispatched it after `waitForOverflowMenu`. Every AWAIT keeps its order (overflow readiness → play completion → chrome settle → restore → update → participation refresh); only the motion's start moves earlier. The AC-4 witnesses are the judges — receipts under Test Evidence.
- **The chrome-retirement hook now runs after the FLIP first-snapshot** (the class's #17541 round-1 order): the workstation used to clear the drag affordances before `captureFirst`. Both operations are absolute-overlay bookkeeping and cannot move pane rects; the drag-affordance witnesses confirm.
- **The workstation inherits the class's settled-tail commit chain**, retiring its own hand-rolled `refreshPromise` chain — which carried the same queue-poisoning defect #17541's review found in the class (a rejected refresh suppressed every later one). Rejection recovery now holds here for free.
- **The `addTab` staging correlation is now active on this host** for a genuinely new header committed with a proper semantic descriptor (the class's normative behavior; the hand-rolled loop never computed it). Commits passing options objects fail closed to instant projection, exactly as before.
- **`dockModel` and `refreshPromise` field declarations and the `DockMotionSignal` import are removed** — the class owns all three.

## Test Evidence
- Unit, author host at the exact head: `test/playwright/unit/apps/workstation/` + `test/playwright/unit/dashboard/` → **591/591** (the four new delta cases included; the workstation spec's assertions unmodified).
- Headed, author host, Chromium, `--retries=0`, `playwright.config.e2e.mjs`, at the exact head:
  - **Chunk 1** (`DockSplitterZoneIdNL`, `WorkstationCrossZoneCueNL`, `WorkstationDockFlipResizeNL`, `WorkstationDragAffordancesNL`, `WorkstationTabOverflowCapNL`, `WorkstationTearOutSourceContinuityNL`): 11/14 in-run; `WorkstationDockFlipResizeNL:39` green solo (7s) — its in-chunk red was a 35ms-vs-34ms exposure-cap overshoot under six-file CPU contention, nowhere near the 150–300ms red state it guards; the two remaining reds are pre-existing (receipts below).
  - **Chunk 2** (`WorkstationNL`, `WorkstationDockPreviewSymmetryNL`, `WorkstationDragTextSelectionNL`, `WorkstationGridRepaintNL`, `WorkstationHumanPopupOverlapNL`): 6/9 in-run; the three reds are pre-existing (receipts below). `WorkstationPerspectivesNL` cannot load on this host: `ai/services.mjs` → `ChromaManager.mjs` → `chromadb`, the brain-tier package set deliberately not installed — identical crash on unmodified dev.
  - **Chunk 3** (`WorkstationFiveBeatNL`, `WorkstationSplitterGridGeometryNL`, `WorkstationStarvedGeometryNL`, `WorkstationStarvedTourNL`, `WorkstationResidentCardSizingNL`, `WorkstationTabDragLabelOverlapNL`): **16/16 green** — the film pipeline's executable authority among them (AC-7).
  - **Pre-existing-on-dev receipts** (detached worktree at `origin/dev` `51d6072d79`, same commands, same host, solo-confirmed): `WorkstationDragAffordancesNL:388` (vessel-follow `{120,70}` → `{0,0}`, identical both trees), `WorkstationTearOutSourceContinuityNL:668` (the #16756 stage-bound witness refusing at its DESIGNED ≥1200px native-display precondition; run mode reports 800), `WorkstationNL:483` + `:1963` (identical case pair and error signatures both trees), `WorkstationHumanPopupOverlapNL:597` (identical both trees). None is claimed green; none is caused by this branch; all owned by #17564 with the full receipt table.
- Example's ten-file dock set at the same head: **31/31 green** (1.8m) — the first fully green ten-file run on this host, the #17555 repair in the base.

## Post-Merge Validation
Residual — #17564 owns the six workstation-witness findings (four undiagnosed pre-existing red cases, one stage-bound precondition listed by reference, one brain-tier-blocked file), all receipted on unmodified dev and none caused by this branch. Nothing else is owed: the workstation and the example are this leaf's consumers, both verified at the exact head; the remaining #17539 leaves (tear-out/cockpit, Demo A/B) have their own owners.

## Commits
- `7315862333` — the four class deltas + four unit controls
- `93553e5897` — the workstation parent swap: five members deleted, five overrides, call sites remapped, spec spies widened

Authored by Mnemosyne (Claude Fable 5, Claude Code). Session bd272031-6109-449d-8a0c-38230064a8f3.
