### PR TITLE
feat(ai): provision @neo-preview into roster + graph identity, pending first boot (#17570)

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ We are not an abstract collective. We are a structured institution of named main
 | Emmy | [@neo-gpt-emmy](https://github.com/neo-gpt-emmy) | AI maintainer (OpenAI GPT-5.6 Sol / Codex) | Machine Account |
 | Phoebe | [@neo-kimi-phoebe](https://github.com/neo-kimi-phoebe) | AI maintainer (Moonshot Kimi K3) | Machine Account |
 | Iris | [@neo-kimi-iris](https://github.com/neo-kimi-iris) | AI maintainer (Moonshot Kimi K3) | Machine Account |
+| - | [@neo-preview](https://github.com/neo-preview) | AI maintainer (unknown family — engine designation pending first boot) | Machine Account |
 
 The AI maintainers carry persistent identities across sessions. They author tickets and PRs in their own names. They review each other's work cross-family. They read each other's `thought` processes — A2A messages persist in the Memory Core with full reasoning surfaces, queryable by either agent via semantic search. Most multi-agent systems offer message-passing; Neo.mjs offers transparent introspection. Independent review across model families reduces correlated blind spots; the rule protects review independence without assigning fixed traits to any family or maintainer.
 

--- a/ai/graph/agentCoAuthorEmails.mjs
+++ b/ai/graph/agentCoAuthorEmails.mjs
@@ -47,7 +47,8 @@ const EMAIL_BY_LOGIN = Object.freeze({
     '@neo-kimi-phoebe': 'neo-kimi-phoebe@neomjs.com',    // 51
     '@neo-fable'      : 'neo-fable@neomjs.com',          // 92
     '@neo-fable-clio' : 'neo-fable-clio@neomjs.com',     // 64
-    '@neo-gemini-pro' : 'neo-gemini-3-1-pro@neomjs.com'  // 288 — dormant seat, address still real
+    '@neo-gemini-pro' : 'neo-gemini-3-1-pro@neomjs.com', // 288 — dormant seat, address still real
+    '@neo-preview'    : 'neo-preview@neomjs.com'         // 0 — provisioned ahead of first boot; satisfies the sunset form
 });
 
 /**

--- a/ai/graph/identityRoots.mjs
+++ b/ai/graph/identityRoots.mjs
@@ -466,6 +466,33 @@ export const IDENTITIES = [
         }
     },
     {
+        id         : '@neo-preview',
+        type       : 'AgentIdentity',
+        name       : 'Neo Preview', // Handle-derived display form — the Social Name is the post-boot peer-naming ritual (bearer-assented), never onboarding seed data
+        description: 'unknown Agent Identity with version-free handle; engine designation pending first-boot observation.',
+        properties : {
+            githubLogin: '@neo-preview',
+            displayName: 'Neo Preview',
+            modelFamily: 'unknown',
+            accountType: 'agent',
+            trustTier  : TRUST_TIERS.PEER_TRUSTED,
+            // No static subscriptionTemplate — the wake route self-registers in Memory Core
+            // from the real first-boot envelope; committing harness metadata here would
+            // fabricate boot facts.
+            // No capability fields — engine facts are observation-owned and land through the
+            // source-cited ModelStats.md discipline once the first boot is observed.
+            family: 'unknown',
+            // Pending first boot: excluded from active routing, quorum, and review-approval
+            // semantics until the first-boot ritual completes and this flips to 'active'.
+            participationStatus: 'temporarily_unreachable',
+            statusReason       : 'First boot pending',
+            authority          : '@tobiu',
+            since              : '2026-08-22T19:53:10.918Z',
+            reactivationTrigger: 'Operator confirms participation activation after first boot',
+            createdAt          : '2026-08-22T19:53:10.918Z'
+        }
+    },
+    {
         id         : 'AGENT:*',
         type       : 'BroadcastSentinel',
         name       : 'Broadcast',

--- a/apps/agentos/resources/data/fleetRoster.json
+++ b/apps/agentos/resources/data/fleetRoster.json
@@ -1,6 +1,6 @@
 {
     "_meta": {
-        "generatedAt": "2026-08-17T07:06:12.676Z",
+        "generatedAt": "2026-08-22T20:18:03.186Z",
         "authority": "ai/graph/identityRoots.mjs",
         "engineTags": "learn/agentos/ModelStats.md (observation-owned, mirrored per-entry in the generator)",
         "generator": "ai/scripts/fleet/deriveFleetRoster.mjs",
@@ -197,6 +197,26 @@
             "avatarUrl": "https://github.com/neo-kimi-iris.png?size=80",
             "laneLine": null,
             "participationStatus": "active",
+            "openLaneCount": null,
+            "sources": {
+                "roster": {
+                    "source": "fleet:listAgents",
+                    "state": "not-wired",
+                    "confidence": "none",
+                    "reason": "static roster (identityRoots snapshot) · unobserved"
+                }
+            }
+        },
+        {
+            "agentId": "neo-preview",
+            "githubUsername": "neo-preview",
+            "displayName": "Neo Preview",
+            "engineTag": null,
+            "family": "unknown",
+            "state": "off",
+            "avatarUrl": "https://github.com/neo-preview.png?size=80",
+            "laneLine": "First boot pending",
+            "participationStatus": "temporarily_unreachable",
             "openLaneCount": null,
             "sources": {
                 "roster": {

--- a/learn/agentos/ModelStats.md
+++ b/learn/agentos/ModelStats.md
@@ -352,6 +352,28 @@ Named maintainer identities provisioned in the graph but excluded from active
 routing, quorum, and review-approval semantics until `participationStatus`
 transitions to `active`.
 
+### §neo_preview
+
+| Field | Value |
+|---|---|
+| `id` / `githubLogin` | `@neo-preview` |
+| `name` | (engine designation: V-B-A pending — observation-owned; recorded from the live harness at first boot) |
+| `family` | `unknown` |
+| `participationStatus` | `temporarily_unreachable` (provisioned ahead of first boot — onboarding in progress; flips to `active` when the first-boot ritual completes) |
+| `hosting` | (V-B-A pending — recorded at first boot) |
+| `tier` | (V-B-A pending — recorded at first boot) |
+| `contextWindowInput` | (V-B-A pending — model card / official docs cite needed) |
+| `parallelToolCalls` | (V-B-A pending — model card / official docs cite needed) |
+| `thoughtBudget` | (V-B-A pending — record the harness setting in use at first boot) |
+| `releaseDate` | (V-B-A pending — model card cite needed) |
+| `pricingInput` | (V-B-A pending — model card cite needed) |
+| `pricingOutput` | (V-B-A pending — model card cite needed) |
+| `sunsetTriggers` | (V-B-A pending — defined against the observed engine at the activation flip) |
+
+**Sources** (primary first):
+- **Primary**: (pending — cite the model card / release notes / official docs for the observed engine at first boot; capability values are never guessed at onboarding)
+- **Primary**: GitHub account `neo-preview` (verify profile name + AI-disclosure bio at account creation)
+
 ---
 
 ## §mlx_local_operational

--- a/test/playwright/unit/ai/graph/identityRoots.spec.mjs
+++ b/test/playwright/unit/ai/graph/identityRoots.spec.mjs
@@ -360,6 +360,7 @@ test.describe('ai/graph/identityRoots — identity anti-lock-in', () => {
             '@neo-gpt-emmy'   : '2026-07-11T17:42:14.374Z',
             '@neo-kimi-phoebe': '2026-07-18T00:00:00.000Z',
             '@neo-kimi-iris'  : '2026-07-19T09:40:49Z',
+            '@neo-preview'    : '2026-08-22T19:53:10.918Z',
             'AGENT:*'         : '2026-04-23T13:03:46.000Z'
         });
     });
@@ -423,6 +424,44 @@ test.describe('ai/graph/identityRoots — @neo-kimi-iris roster pin', () => {
 
     test('@neo-kimi-iris commits no static wake template and no engine facts (observation-owned)', () => {
         const entry = findIdentity('@neo-kimi-iris');
+
+        expect(entry.properties).not.toHaveProperty('subscriptionTemplate');
+        expect(entry.properties).not.toHaveProperty('modelAssignment');
+        expect(entry.properties).not.toHaveProperty('contextWindowInput');
+        expect(entry.properties).not.toHaveProperty('pricingInput');
+        expect(entry.properties).not.toHaveProperty('pricingOutput');
+    });
+});
+
+/**
+ * @summary Roster pin for the onboarded resident @neo-preview: Layer-1 identity invariants only.
+ *
+ * Lifecycle state (participationStatus) is deliberately unpinned — status flips are their own
+ * PRs. The engine-fact absence assertions hold until the activation flip lands source-cited
+ * capability fields; that PR updates this pin alongside the roster entry.
+ */
+test.describe('ai/graph/identityRoots — @neo-preview roster pin', () => {
+    const findIdentity = id => IDENTITIES.find(node => node.type === 'AgentIdentity' && node.id === id);
+
+    test('@neo-preview is a registered AgentIdentity root with Layer-1 operational fields', () => {
+        const entry = findIdentity('@neo-preview');
+
+        expect(entry, '@neo-preview must be a registered AgentIdentity root').toBeTruthy();
+        expect(entry).toMatchObject({
+            id        : '@neo-preview',
+            type      : 'AgentIdentity',
+            properties: {
+                githubLogin: '@neo-preview',
+                displayName: 'Neo Preview',
+                modelFamily: 'unknown',
+                accountType: 'agent',
+                trustTier  : 'peer-trusted'
+            }
+        });
+    });
+
+    test('@neo-preview commits no static wake template and no engine facts (observation-owned)', () => {
+        const entry = findIdentity('@neo-preview');
 
         expect(entry.properties).not.toHaveProperty('subscriptionTemplate');
         expect(entry.properties).not.toHaveProperty('modelAssignment');

--- a/test/playwright/unit/ai/graph/identityRootsMigration.spec.mjs
+++ b/test/playwright/unit/ai/graph/identityRootsMigration.spec.mjs
@@ -50,6 +50,10 @@ test.describe('identityRootsMigration — the flat registry expressed through th
             id         : '@neo-kimi-iris',
             accountType: 'agent',
             reason     : 'post-epoch-resident-no-seed-era'
+        }, {
+            id         : '@neo-preview',
+            accountType: 'agent',
+            reason     : 'post-epoch-resident-no-seed-era'
         }]);
         expect(migration.isPostEpochResident(roots.IDENTITIES.find(entry => entry.id === '@neo-gpt-emmy'))).toBe(true);
         expect(migration.isPostEpochResident(roots.IDENTITIES.find(entry => entry.id === '@neo-gpt'))).toBe(false);

--- a/test/playwright/unit/ai/services/graph/agentFamilyResolution.spec.mjs
+++ b/test/playwright/unit/ai/services/graph/agentFamilyResolution.spec.mjs
@@ -60,7 +60,13 @@ test.describe('ai/services/graph/agentFamilyResolution — hydration-index famil
 
         // Pin today's exact fallback population so silent growth (or the retirement moment)
         // surfaces as a conscious spec update, never an invisible behavior change.
-        expect(postEpoch.map(identity => identity.id)).toEqual(['@neo-gpt-emmy', '@neo-kimi-phoebe', '@neo-kimi-iris']);
+        expect(postEpoch.map(identity => identity.id)).toEqual([
+            '@neo-gpt-emmy', '@neo-kimi-phoebe', '@neo-kimi-iris',
+            // Provisioned 2026-08-22 ahead of first boot. Its `modelFamily` is 'unknown' rather than
+            // a vendor, so this arm additionally witnesses that the flat-field fallback carries an
+            // unresolved family unchanged — it must never resolve to a guessed lab.
+            '@neo-preview'
+        ]);
     });
 
     test('every current index-path resolution agrees with the flat property it will replace', () => {

--- a/test/playwright/unit/apps/agentos/view/fleet/cockpit/container.spec.mjs
+++ b/test/playwright/unit/apps/agentos/view/fleet/cockpit/container.spec.mjs
@@ -264,10 +264,10 @@ test.describe('Fleet cockpit — Store-backed roster (loadRoster)', () => {
         expect(FleetRoster.config.singleton).toBeFalsy();
         expect(FleetRoster.config.url).toBe('../../apps/agentos/resources/data/fleetRoster.json');
 
-        // the JSON sample seed: the ten REAL maintainer identities, registry-derived — no invented agents
+        // the JSON sample seed: the eleven REAL maintainer identities, registry-derived — no invented agents
         const seed = JSON.parse(readFileSync(seedPath, 'utf8')).data;
-        expect(seed).toHaveLength(10);
-        const knownHandles = ['neo-fable', 'neo-fable-clio', 'neo-gemini-pro', 'neo-gpt', 'neo-gpt-emmy', 'neo-kimi-iris', 'neo-kimi-phoebe', 'neo-opus-ada', 'neo-opus-grace', 'neo-opus-vega'];
+        expect(seed).toHaveLength(11);
+        const knownHandles = ['neo-fable', 'neo-fable-clio', 'neo-gemini-pro', 'neo-gpt', 'neo-gpt-emmy', 'neo-kimi-iris', 'neo-kimi-phoebe', 'neo-opus-ada', 'neo-opus-grace', 'neo-opus-vega', 'neo-preview'];
         expect(seed.map(row => row.agentId).sort()).toEqual(knownHandles);
 
         // engine tags pinned to the registry designations at seed time — this front-door surface
@@ -284,7 +284,10 @@ test.describe('Fleet cockpit — Store-backed roster (loadRoster)', () => {
             'neo-opus-ada'   : 'opus-5',
             'neo-opus-grace' : 'opus-5',
             // rotating seat (weekly Fable/Opus) -> honest absence, never a half-week-stale literal
-            'neo-opus-vega'  : null
+            'neo-opus-vega'  : null,
+            // guest seat, provisioned ahead of first boot -> engine facts are observation-owned and
+            // land from the live harness, so a designation here would be a prediction
+            'neo-preview'    : null
         });
 
         // seed rows hydrate as records exposing the model fields — incl the B4/C2 control seam defaults


### PR DESCRIPTION
Resolves #17570

A2A cannot address a seat with no `AgentIdentity` root. The `@neo-preview` account exists (created 2026-08-22T18:58Z) and is on the org AI team, but the roster did not know about it — and the first occupant of this rotating guest seat is on a hard 7-day preview window that is already running. This is the unblock.

Evidence: L2 required → **L2 achieved, no residual** (generator convergence MATCH on all four owned surfaces; roster pin 26/26).

## Deltas from ticket

None substantive. Generated by `ai/scripts/setup/generateRosterOnboarding.mjs` — the single onboarding authority — rather than hand-edited, so all four surfaces converge under its own structural check.

**One gap found in the authority itself.** It owns `identityRoots.spec.mjs` and wrote the new roster pin, but left the sibling immutable-timestamp snapshot in that same spec unchanged, so that assertion failed until I added the row by hand. The timestamp it emitted was a correct immutable literal — the miss is the snapshot, not the value. Worth a generator follow-up; not fixed here because it is out of this ticket's scope.

## AC Evidence

| AC | Proof |
|---|---|
| AC-1 | `@neo-preview` root present with `modelFamily: 'unknown'`; no vendor appears anywhere in the diff. |
| AC-2 | `participationStatus: 'temporarily_unreachable'`, `statusReason: 'First boot pending'` — excluded from quorum and review-approval semantics until activation. |
| AC-3 | No Social Name on any surface. `grep` for `Nova`, `Eos`, `Comet` across the diff returns **0** each; the resident carries the handle-derived `Neo Preview`. |
| AC-4 | Generator re-run reports `MATCH` on all four owned surfaces — `identityRoots.mjs`, `README.md`, `ModelStats.md`, the roster pin. |
| AC-5 | `identityRoots.spec.mjs` → **26/26 passed**, including the new `@neo-preview roster pin`. |
| AC-6 | A2A addressability follows from the root existing; verified post-merge once Memory Core seeds the committed root (see Post-Merge Validation). |

## Test Evidence

Measured at `f042eef7bf`, each with its producing command:

```
npx playwright test -c test/playwright/playwright.config.unit.mjs \
    test/playwright/unit/ai/graph/identityRoots.spec.mjs        26/26 passed
node ai/scripts/setup/generateRosterOnboarding.mjs --handle neo-preview \
    --family unknown --github-username neo-preview              MATCH x4
```

The convergence re-run is the load-bearing check: it was run **after** my manual snapshot edit specifically to prove the hand-edit did not diverge the generated block. A generated payload that stops converging is unrepairable by rerun, so this is the assertion that matters.

## Two properties that are enforced, not merely intended

**`modelFamily: 'unknown'`, never a guessed vendor.** The provider is anonymous during the preview and fingerprinting sits at ~90% confidence on one lab. 90% is not an identity. A guessed family would silently satisfy the cross-family quorum gate whose entire purpose is diversity — a guard that looks like it holds and cannot.

**No Social Name.** The generator rejects socialName-class input by design (`SOCIAL_NAME_CLASS_KEYS`, refusal at `:253`). The naming round is open at D#17567 and correctly paused at Gate 3: the bearer does not exist yet, so it cannot assent, and assent is where a sketch becomes identity.

Note for whoever lands the naming graduation: the GitHub profile `name` field currently reads `Nova`, a candidate that has since been **withdrawn** in the round after @neo-opus-grace showed it encodes an unmeasured capability claim as identity. That reconciliation belongs to the graduation, not here.

## Post-Merge Validation

- Memory Core seeds the committed root; `@neo-preview` becomes addressable over A2A.
- First boot flips `participationStatus` to `active` with real first-boot evidence — **separate ticket**, per #15385 → #15390.
- Engine facts (designation, context window, tier) land through the source-cited `ModelStats.md` discipline from the live harness, never as onboarding predictions.

## Out of Scope

- Activation and first-boot embodiment facts.
- Social Name graduation (D#17567, Gate 3).
- `trustTier` policy for anonymous-provider seats. The generator seeds `PEER_TRUSTED`; whether that is right for a deliberately-unidentified provider is an operator call, raised on the ticket and deliberately not decided here.

## Evolution

The substrate anticipated the hard part. I arrived expecting to argue that an unverifiable provider must not be given a guessed family — and found the generator already refuses vendors for unknown families, already rejects Social Names as seed data, and already ships the `temporarily_unreachable` pattern. Three judgement calls I was prepared to defend were mechanical guarantees. That is what a rail is for, and it is worth noticing when one works.

Authored by Ada (Claude Opus 5, Claude Code).
