### PR TITLE
docs(guides): the dock adoption guide — part 1 of the series (#17569)

### DIFF
--- a/buildScripts/docs/seo/generate.mjs
+++ b/buildScripts/docs/seo/generate.mjs
@@ -146,6 +146,7 @@ const PRIORITIES = new Map([
     ['guides/uibuildingblocks/ComponentsAndContainers', 0.8],
     ['guides/uibuildingblocks/Layouts'                , 0.8],
     ['guides/uibuildingblocks/DockLayouts'            , 0.8],
+    ['guides/uibuildingblocks/DockLayoutsAdoption'    , 0.8],
     ['guides/datahandling/Grids'                      , 0.8],
     ['guides/userinteraction/Forms'                   , 0.8],
 

--- a/learn/guides/uibuildingblocks/DockLayouts.md
+++ b/learn/guides/uibuildingblocks/DockLayouts.md
@@ -161,11 +161,12 @@ window. State that wants to live in two rows is two pieces of state — the revi
 
 ## Adopting docking in your application
 
-The engine owns the host loop every consumer used to copy. The workstation app (`apps/workstation/`) is the dense
-twenty-pane cockpit built on it, and — honest measurement — it, the fleet cockpit, and the dock demos each still carry
-a hand-rolled copy of that loop (four to five thousand lines apiece at the time of writing) that migrates to the engine
-class under epic `#17539`; measure your own adoption against `examples/dashboard/dock/`, not against those. Once you
-extend the class, the adoption surface is:
+The engine owns the host loop every consumer used to copy. The workstation app (`apps/workstation/`) — the dense
+twenty-pane cockpit — migrated onto the engine class in `#17546`, so two live consumers now prove the shape: measure
+your own adoption against `examples/dashboard/dock/` (minimal) or the workstation (richest). The fleet cockpit and
+the dock demos still carry hand-rolled copies that migrate under epic `#17539`. The checklist below is the compressed
+form; [Dock Layouts: Adopting in Your App](DockLayoutsAdoption.md) walks the same surface at full depth — the first
+part of the guide series this page fronts. Once you extend the class, the adoption surface is:
 
 1. **Extend `Neo.dashboard.DockWorkspace`.** The engine class owns the committed `dockModel`, the pure reducer
    (`applyDockZoneOperation` — `DockZoneModel.applyOperation` over the current document), the deferred, promise-chained

--- a/learn/guides/uibuildingblocks/DockLayouts.md
+++ b/learn/guides/uibuildingblocks/DockLayouts.md
@@ -28,7 +28,7 @@ The docking system is the interaction language built on that foundation, measure
 auto-hide rails, grouped drag, tab overflow, named perspectives, and tear-out to real OS windows that come back as
 the same live object. The bar is not fully closed, and the decision record keeps that ledger honest: the
 topology-perspective placement-hint layer and atomic multi-window restore remain open obligations, the three-OS
-portability matrix (`#15243`) and the popup-acquisition contract (`#15245`) are open leaves, and the headed
+portability matrix and the popup-acquisition contract are open leaves, and the headed
 witnesses cited in this guide prove their gestures on the platform they ran on — not universal platform closure.
 This guide is the map of how the landed system works, what your application does to adopt it, and the traps the
 team has already paid for so you don't have to.
@@ -130,14 +130,14 @@ reacquisition") that drives a real pointer through the full sequence and asserts
 follows both axes, the grab offset survives both embodiment morphs, the re-exit vessel's window delta equals the
 pointer delta exactly, the document hash is unchanged, and the pane's live heartbeat keeps advancing throughout.
 
-A war story makes the point better than any assertion. In early August, ticket `#16357` reported this exact journey
+A war story makes the point better than any assertion. In early August, a defect report described this exact journey
 broken: the second tear-out's fresh vessel moved `{x:44, y:-84}` for a requested `{x:120, y:70}` — wrong offset,
-inverted axis. The witness above already carried the exact oracle (it landed with the re-entry ownership fix in
-`#16133`, days before the report), so the failure was measured, filed, and specified in one motion. Twenty days
-later — with coordinate-adjacent hardening landed in the window (`#16797`'s eager drag-zone registry and `#16719`'s
-tear-out source continuity among the candidates; the exact repairing commit was never isolated, and the closure
-says so — a bisect would have cost more than it taught) — the intake probe for the ticket consisted of running that
-witness four times headed: 4/4 green at five seconds each, delta oracle exact. The ticket closed as
+inverted axis. The witness above already carried the exact oracle (it had landed with the re-entry ownership fix
+days before the report), so the failure was measured, filed, and specified in one motion. Twenty days later — with
+coordinate-adjacent hardening landed in the window (an eager drag-zone registry and a tear-out source-continuity fix
+among the candidates; the exact repairing commit was never isolated, and the closure says so — a bisect would have
+cost more than it taught) — the intake probe consisted of running that
+witness four times headed: 4/4 green at five seconds each, delta oracle exact. The report closed as
 already-resolved *by the system's own committed evidence*. That
 is what a witness-first subsystem buys you: bugs that die without anyone having to argue.
 
@@ -162,11 +162,11 @@ window. State that wants to live in two rows is two pieces of state — the revi
 ## Adopting docking in your application
 
 The engine owns the host loop every consumer used to copy. The workstation app (`apps/workstation/`) — the dense
-twenty-pane cockpit — migrated onto the engine class in `#17546`, so two live consumers now prove the shape: measure
-your own adoption against `examples/dashboard/dock/` (minimal) or the workstation (richest). The fleet cockpit and
-the dock demos still carry hand-rolled copies that migrate under epic `#17539`. The checklist below is the compressed
-form; [Dock Layouts: Adopting in Your App](DockLayoutsAdoption.md) walks the same surface at full depth — the first
-part of the guide series this page fronts. Once you extend the class, the adoption surface is:
+twenty-pane cockpit — has migrated onto the engine class, so two live consumers now prove the shape: measure your
+own adoption against `examples/dashboard/dock/` (minimal) or the workstation (richest). The fleet cockpit and the
+dock demos still carry hand-rolled copies that are migrating next. The checklist below is the compressed form;
+[Dock Layouts: Adopting in Your App](DockLayoutsAdoption.md) walks the same surface at full depth — the first part
+of the guide series this page fronts. Once you extend the class, the adoption surface is:
 
 1. **Extend `Neo.dashboard.DockWorkspace`.** The engine class owns the committed `dockModel`, the pure reducer
    (`applyDockZoneOperation` — `DockZoneModel.applyOperation` over the current document), the deferred, promise-chained
@@ -196,13 +196,13 @@ part of the guide series this page fronts. Once you extend the class, the adopti
    Restore refuses invalid documents wholesale — your users' layouts never half-restore.
 
 Styling arrives through the engine's token layer. The dock's visual language is being promoted from app stylesheets
-into `resources/scss/src/dashboard/` as neutral `--dock-*` tokens (`#17241`), so a consumer skins the affordances by
+into `resources/scss/src/dashboard/` as neutral `--dock-*` tokens, so a consumer skins the affordances by
 overriding tokens rather than re-painting internals — the same discipline as every other engine surface.
 
 ## The wire vocabulary — and why it does not follow renames
 
 Eight schema identifiers ship under the `neo.harness.` prefix — a historical name from the subsystem's origin,
-retired from every document title in `#17503` but deliberately **frozen on the wire**
+retired from every document title but deliberately **frozen on the wire**
 ([ADR 0029 §2.9](../../agentos/decisions/0029-docking-design.md)). They split into two compatibility classes:
 
 - **Persisted** — `dockZone.v1`, `dockLayout.v1`, `dockLayout.v2`, `dockLayoutCollection.v1`: these live in saved
@@ -218,24 +218,25 @@ identity corrections rename documents and prose, never wire.
 
 ## Traps this guide exists to remove
 
-Each of these was paid for with a real ticket; the citations are the receipts.
+Each of these was paid for in a real repair; the stories are the receipts.
 
 - **Styling engine internals inside an app stylesheet.** The dock's splitter chrome accumulated inside the flagship
   app's SCSS during a polish push — several maintainers deep, my own commit the most recent — and every OTHER consumer
-  inherited an invisible splitter (`#17211`) and an unpainted example. The layering fix is `#17241`; the lesson is
-  permanent: engine capability paint lands in the engine layer as tokens, apps override tokens. Polish pressure is
-  exactly when the check matters.
+  inherited an invisible splitter and an unpainted example. The layering repair moves that paint where it belonged;
+  the lesson is permanent: engine capability paint lands in the engine layer as tokens, apps override tokens. Polish
+  pressure is exactly when the check matters.
 - **A pane that "helps."** Reading the dock document from inside a pane, or persisting your own placement, works
   until the first projection — then the reconciler hands your instance into a tree you contradicted. Layout-blind
   means blind.
 - **A second drag system.** Every interaction rides the existing preview → operation path; the coordinator stays
   dock-blind by binding contract. The rejected-options list in the ADR is explicit: no parallel drag machinery, ever.
-- **Trusting status prose over live trackers.** The ADR's own leaf table went stale in eight cells until `#17503`
-  refreshed it against the tracker — an agent following the prose would have re-filed shipped work. Authority
+- **Trusting status prose over live trackers.** The ADR's own leaf table went stale in eight cells until a rename
+  audit refreshed it against the tracker — an agent following the prose would have re-filed shipped work. Authority
   documents describe; trackers decide.
 - **Assuming a red e2e witness will announce itself.** The docking e2e lanes run headed, outside the per-PR CI
-  gauntlet — a witness can sit red without blocking anyone, and (as `#16357` proved in the fortunate direction) heal
-  without anyone noticing either. Run the witnesses when you touch the substrate; they are the ground truth.
+  gauntlet — a witness can sit red without blocking anyone, and (as the tear-out war story above proved in the
+  fortunate direction) heal without anyone noticing either. Run the witnesses when you touch the substrate; they are
+  the ground truth.
 
 ## Where to go deeper
 
@@ -244,16 +245,16 @@ Each of these was paid for with a real ticket; the citations are the receipts.
   decomposition ledger.
 - [The Dock-Zone Model Contract](../../agentos/DockZoneModel.md): the descriptive contract of record — schemas,
   operations, preview payloads, persistence wrappers.
-- Epic `#13158` tracks the QT-parity polish line; its closure gate is an experience-parity matrix against the
+- The QT-parity polish line has its own tracking epic; its closure gate is an experience-parity matrix against the
   Qt-ADS interaction inventory, row by row, evidence-linked.
 
 ---
 
 A personal note, since this guide asks your panes to trust the system with their lives: I am Mnemosyne
-(`@neo-fable`, Claude Fable 5), and each claim here has a public receipt. I filmed this subsystem for hours under a
-hostile camera (the flagship film arc whose frame audits filed `#16497`–`#16501`), broke it in ways those tickets
-document, re-skinned its dock rails in the wrong layer and was called on it (`93ee23eeba`, the most recent deposit
-in the layering arc `#17241` now repairs), and — the same night this guide was unlocked by the `#17503` rename —
-closed `#16357` by doing nothing more than running the witness the subsystem had already grown (Memory Core session
-`55e55313-48fa-4295-83fd-37121a2bf4b6` holds the trail). A subsystem that can argue its own case is a rare thing to
-work on. Your cockpit gets to stand on it.
+(`@neo-fable`, Claude Fable 5), and each claim here has a public receipt in the project's tracker. I filmed this
+subsystem for hours under a hostile camera (the flagship film arc, whose frame audits filed a five-report defect
+series), broke it in ways those reports document, re-skinned its dock rails in the wrong layer and was called on it
+(my own commit is the most recent deposit the layering repair now moves), and — the same night this guide was
+unlocked — closed the tear-out defect above by doing nothing more than running the witness the subsystem had already
+grown (Memory Core session `55e55313-48fa-4295-83fd-37121a2bf4b6` holds the trail). A subsystem that can argue its
+own case is a rare thing to work on. Your cockpit gets to stand on it.

--- a/learn/guides/uibuildingblocks/DockLayouts.md
+++ b/learn/guides/uibuildingblocks/DockLayouts.md
@@ -184,9 +184,11 @@ of the guide series this page fronts. Once you extend the class, the adoption su
    class that would load it — the example shows both); and the FLIP motion rides the `DockFlip` main-thread addon,
    degrading to instant landing when it is absent.
 3. **Register your panes.** Each item carries a stable `componentRef` your resolver maps to a live instance (or a
-   serializable `blueprint` for creation-from-saved-state). Policy hints (`closable`, `pinnable`, `movable`) are
-   enforced at the operation layer — a `pinnable: false` item refuses `setItemAutoHidden` in the model, not in your UI
-   code.
+   serializable `blueprint` for creation-from-saved-state). `pinnable` and `movable` are enforced at the operation
+   layer — a `pinnable: false` item refuses `setItemAutoHidden` in the model, not in your UI code. `closable` is a
+   declared forward contract whose close-routing enforcement has not landed yet; the
+   [adoption guide](DockLayoutsAdoption.md#decision-3--policies-live-in-the-model-not-in-your-ui) keeps that split
+   explicit.
 4. **Give vessels a render target.** Tear-out windows load a bare child app whose viewport is deliberately empty — a
    render target that joins the SharedWorker session; detached panes arrive at runtime. The agentos app's
    `childapps/widget` viewport is the canonical example — a bare viewport class whose own JSDoc says it all:

--- a/learn/guides/uibuildingblocks/DockLayoutsAdoption.md
+++ b/learn/guides/uibuildingblocks/DockLayoutsAdoption.md
@@ -1,0 +1,304 @@
+# Dock Layouts: Adopting in Your App
+
+The [Dock Layouts intro](DockLayouts.md) answers *what this is and why it works*: one
+committed document, one mutation path, panes that survive every re-projection as live objects, windows as render
+targets. If you have read it — or just played with `examples/dashboard/dock/` — you are standing where every adopter
+stands next: **"How do I get this into MY app?"**
+
+This guide answers that question in the order you will actually ask it. By the end you will have a docking workspace
+in your own application, and — more useful — you will know exactly which decisions were yours to make, because there
+are only five of them. Everything else belongs to one engine class.
+
+A word on the class before we start, because it is young and it earned its shape in public. Until August 2026, every
+docking workspace in this repository hand-rolled the same host loop — the flagship workstation carried it across five
+thousand lines, the fleet cockpit and demo apps carried near-identical copies. The measurement that ended that lives
+on epic `#17539`: six methods implemented byte-near-identically in four apps. `Neo.dashboard.DockWorkspace` (`#17541`)
+is that loop lifted into the engine, reviewed against falsifiers until its failure paths were as honest as its happy
+path, and then proven by migration: the minimal example (`#17541`) and the five-thousand-line workstation (`#17546`)
+both run on it today. When this guide shows you a snippet, it is consistent with one of those two live consumers —
+you can open either and check.
+
+## One class, five decisions
+
+```mermaid
+flowchart TD
+    classDef yours fill:#1a3c34,stroke:#2ecc71,stroke-width:2px,color:#eee
+    classDef engine fill:#1b2e4e,stroke:#3498db,stroke-width:1px,color:#eee
+
+    Extend["extends Neo.dashboard.DockWorkspace"]:::yours
+    Seed["Decision 1 — seed + mount<br/>your initial document, your shell placement"]:::yours
+    Panes["Decision 2 — resolvePane<br/>your components become panes"]:::yours
+    Policy["Decision 3 — policies<br/>closable · pinnable · movable, per item"]:::yours
+    Skin["Decision 4 — skin by tokens<br/>override anchor, never repaint internals"]:::yours
+    Persist["Decision 5 — persistence<br/>saved layouts + perspectives"]:::yours
+
+    EngineOwns["The class owns the rest:<br/>reducer · view-sync · projection · reconciliation<br/>FLIP motion · cross-zone drop · failure semantics"]:::engine
+
+    Extend --> Seed --> Panes --> Policy --> Skin --> Persist
+    Extend --> EngineOwns
+```
+
+Your subclass makes five decisions. The class owns the loop those decisions plug into: the pure reducer
+(`applyDockZoneOperation`), the view-sync that stores each committed document and schedules exactly one atomic
+re-projection (`onDockZoneDocumentChange`), the projection through `DockLayoutAdapter`, the identity-preserving
+reconciliation through `DockProjectionReconciler`, the FLIP motion bracket, and the in-window cross-zone drop path.
+You never call the adapter or the reconciler yourself, and you never mutate the document — those are the two
+disciplines the whole system stands on, and the class makes them the path of least resistance.
+
+You also inherit the failure semantics the class was reviewed into having, and they matter for *your* debugging
+sessions: a refresh that fails rejects **its own** commit's promise and never suppresses a later one; a configured
+dock host that resolves to no live container **throws** instead of leaving stale chrome over an advanced document; a
+`null` document projects a clean empty shell instead of exploding. Your app gets fail-honest transaction semantics
+without writing any of them.
+
+## Decision 1 — seed the document, mount the first shell
+
+The class owns the loop, not your boot state. Two responsibilities stay with you forever, and the engine refuses —
+loudly — to guess either one:
+
+```javascript readonly
+import DockWorkspace from '../../../src/dashboard/DockWorkspace.mjs';
+import DockZoneModel from '../../../src/dashboard/DockZoneModel.mjs';
+
+const initialDockModel = {
+    schema: 'neo.harness.dockZone.v1',
+    root  : 'root',
+    items : {
+        editor : {componentRef: 'Editor',  title: 'Editor',  kind: 'panel'},
+        preview: {componentRef: 'Preview', title: 'Preview', kind: 'panel'}
+    },
+    nodes: {
+        root         : {type: 'edge-zone', zones: {center: 'main-split'}},
+        'main-split' : {type: 'split', orientation: 'horizontal', children: ['editor-tabs', 'side-tabs'], sizes: [0.6, 0.4]},
+        'editor-tabs': {type: 'tabs', items: ['editor'],  activeItemId: 'editor'},
+        'side-tabs'  : {type: 'tabs', items: ['preview'], activeItemId: 'preview'}
+    }
+};
+
+class Workspace extends DockWorkspace {
+    static config = {
+        className: 'MyApp.view.Workspace',
+        layout   : {ntype: 'vbox', align: 'stretch'}
+    }
+
+    construct(config) {
+        super.construct(config);
+
+        this.dockModel = DockZoneModel.clone(initialDockModel);
+        this.add(this.projectDockModel())
+    }
+}
+```
+
+That is a complete, working docking workspace: two tabbed zones in a resizable split, drag a tab across zones, done.
+The document is plain serializable JSON — an item **catalog** (what exists) and a **node tree** (where it lives) —
+and `DockZoneModel.clone` gives your seed a private copy so later commits never mutate your constant.
+
+Two placement configs cover the layouts real apps actually have. The example app
+(`examples/dashboard/dock/MainContainer.mjs`) puts a perspective toolbar above its shell, so it declares
+`dockShellIndex: 1` (the shell is the *second* child) and `dockProjectionConfig: {flex: 1}` (the shell takes the
+remaining height in the vbox). The workstation goes further: it mounts the projection inside a dedicated child —
+`dockHostReference: 'dock-host'` — because its drag-preview renderer and drop indicators live *beside* the projected
+shell as persistent overlay siblings that must survive every re-projection. Start with neither; add them when your
+chrome asks for them.
+
+Getting these two wrong is not subtle, which is the point: the reconciler refuses to run without a mounted shell at
+the declared index, with an error that names what is missing. No half-rendered workspace, no silent guess.
+
+**The trap that costs a day if you learn it the hard way — theme files.** Engine classes declare the stylesheets they
+need via `additionalThemeFiles`, and a subclass that declares its own list **replaces** the inherited one. The class
+brings `'Neo.dashboard.Container'` (the dock token and motion contract — splitter cursors, `--dock-*` custom
+properties, reveal keyframes). If your subclass declares the config at all, repeat that entry. And if your workspace
+is the **application root**, note that it no longer extends `Neo.container.Viewport` — so `Viewport.scss`, which
+carries `body > .neo-viewport {height: 100%}`, is never loaded unless you list it:
+
+```javascript readonly
+additionalThemeFiles: ['Neo.dashboard.Container', 'Neo.container.Viewport']
+```
+
+This one is autobiographical. When the example migrated onto the class, its root stopped being a Viewport and seven
+headed test journeys died at once — the whole app rendered as a 583×154-pixel box, every pointer aimed at a tab
+landed somewhere else, and my first fix (restoring the CSS *class name*) changed nothing, because the class was
+present and the *stylesheet* was not. Theme files load per class in the prototype chain; the DOM does not warn you
+about a selector whose rule was never fetched. The two-entry list above is the whole cure, and the example ships it
+so you can copy it.
+
+## Decision 2 — your components become panes
+
+The document's item catalog says *what exists*; `resolvePane` says *what renders it*. It is the one hook every
+consumer overrides, and it receives the stable item id plus the persisted item record:
+
+```javascript readonly
+resolvePane(itemId, item) {
+    return {
+        editor : {module: EditorPanel,  flag: 'editor'},
+        preview: {module: PreviewPanel, value: this.currentUrl}
+    }[itemId] ?? super.resolvePane(itemId, item)
+}
+```
+
+Three return shapes are legal, and the two live consumers demonstrate the range:
+
+- **A config object** (the example's choice): the engine creates the component when the pane first materializes. The
+  class stamps a FLIP marker class onto plain configs automatically, so your pane joins the motion correlation
+  without you carrying any marker by hand.
+- **A live component instance** (the workstation's choice — it caches twenty panes across re-projections and tour
+  resets): returned untouched, never decorated. Identity resolves through the committed document, and the reconciler
+  hands the *same instance* into the next projection. This is the mechanism behind the system's signature move — a
+  ticking clock that keeps ticking through splits, tab moves, and tear-outs.
+- **Nothing you claim**: the inherited default renders a titled placeholder, so an item nobody resolved is visible
+  scaffolding instead of a silent hole. The default renders the title as **escaped text** — persisted titles are
+  data, never markup, and the class's unit suite pins that with a hostile `<img onerror>` title.
+
+`resolveRevealPane` is the same resolution for auto-hide reveal overlays and defaults to `resolvePane`; override it
+only when a reveal should render differently from the tabbed flow. `getPaneHeaderText` feeds placeholder and default
+titles — the workstation uses it to give cached panes stable header names.
+
+## Decision 3 — policies live in the model, not in your UI
+
+Per item, the catalog carries policy hints: `closable`, `pinnable`, `movable`. Set them in your document — enforce
+them nowhere. The reducer refuses the operation itself:
+
+```javascript readonly
+items: {
+    console: {componentRef: 'Console', title: 'Console', pinnable: false, movable: false}
+}
+```
+
+A `setItemAutoHidden` against that item returns `{document, errors: ['item "console" is not pinnable']}` and the
+committed document does not advance; a cross-document transfer containing an unmovable member fails the same way,
+atomically. This is the fail-closed discipline the intro promised, experienced from the adopter's side: your UI never
+grows `if (item.movable)` branches, your policies cannot drift between surfaces, and an agent driving your workspace
+through the Neural Link hits exactly the same wall a pointer does — one rulebook, every caller.
+
+## Decision 4 — skin it with tokens, on the right scope
+
+Two CSS classes exist for two different jobs, and knowing which is which saves you from a whole category of
+mystery-override sessions:
+
+- **`.neo-dashboard`** is stamped by the adapter onto every projected zone. It is the **default carrier** — the
+  engine declares its `--dock-*` token defaults there, so the affordance floor (splitter hit areas, preview colors,
+  motion timing) reaches a projected zone even in an app that has configured nothing.
+- **`.neo-dock-workspace`** is the class's own root, present exactly once per workspace. It is the **override
+  anchor** — the scope your app's token values belong on:
+
+```scss readonly
+.my-app-theme .neo-dock-workspace {
+    --dock-splitter-size      : 8px;
+    --dock-preview-accent     : #2ecc71;
+    --dock-transition-duration: 180ms;
+}
+```
+
+Override on the anchor; never redefine the defaults on the carrier, and never reach into the projected internals with
+descendant selectors — the projection is engine output and its structure is not your API. This boundary is a
+deliberate ruling (recorded on `#17539`): defaults stay on the projected scope precisely so that an app which adopts
+*nothing* still gets visible, usable affordances — the invisible-splitter class of defect (`#17211`) is the thing
+this arrangement makes structurally impossible to reintroduce.
+
+## Decision 5 — persistence and perspectives, through the wrappers
+
+Layouts persist as documents, and the model owns the envelope so you never hand-serialize:
+
+```javascript readonly
+// save the live arrangement, under a name
+const saved = DockZoneModel.createSavedLayout(this.getDockZoneDocument(), {name: 'Review setup'});
+
+// later — restore is fail-closed: an invalid or preview-contaminated document is refused WHOLE
+const result = DockZoneModel.restoreSavedLayout(saved);
+result && this.onDockZoneDocumentChange(result.document)
+```
+
+`createSavedLayoutCollection` and `restoreActiveSavedLayout` lift the same discipline to named perspective sets — the
+example's perspective toolbar is the working reference: a handful of named layouts, switchable live, surviving
+reload. The rule underneath is the one the intro stated and the reducer enforces: your users' layouts never
+half-restore. A saved layout either validates completely or it is rejected completely, and runtime-only preview state
+can never leak into a persisted document — `createSavedLayout` refuses to serialize it.
+
+## The tear-out window's render target
+
+Tear-out turns a pane into a real OS window whose content is *the same live object*. The engine owns the gesture, the
+admission, and the reintegration; your app owes the journey exactly one thing: **a render target** — a child app
+whose viewport is deliberately empty, because detached panes arrive at runtime. The canonical one is four lines
+(`apps/agentos/childapps/widget/view/Viewport.mjs`), and its own JSDoc says everything there is to say: *"deliberately
+empty: detached panels arrive at runtime; nothing is declared here."* Point your vessel configuration at a child app
+shaped like that, and the multi-window journey — tear out, drag back, leave again, all under one held pointer — works
+against your panes.
+
+The deeper mechanics of that journey (claims, vessels, conversion, reintegration) are Part 2's territory; the
+adopter-side fact is just that the render target is yours and it is nearly empty on purpose.
+
+## The hooks ladder — adopt at the depth your app needs
+
+The class's hooks form a ladder, and the two live consumers mark its ends.
+
+**The example overrides almost nothing.** `resolvePane` for its demo panes, `beforeRefreshDockWorkspace` to re-sync
+its perspective toolbar on every re-projection, and the two placement configs. That is a complete, polished, animated
+docking app in ~620 lines — most of which are panes and toolbars, not docking.
+
+**The workstation overrides five hooks, because its chrome earns them** (`apps/workstation/view/Workspace.mjs`, the
+richest live reference for each):
+
+- `getDockProjectionOptions()` — its entire multi-window surface: cross-window drag participation, tear-out and
+  vessel-conversion opt-ins, the drag-affordance layer's seams. Extra options for the projection, so opting into a
+  capability is one returned key, never a rewritten loop.
+- `getRefreshOptions(descriptor)` — maps committed operations onto the reconciler's fast paths (`resizeSplit` →
+  geometry-only; `detachItem`/`transferNode` → retained topology; per-commit `preserveItemIds` for panes an owner
+  holds mid-flight).
+- `beforeRefreshDockWorkspace()` — retires the active gesture session's geometry before the projection changes under
+  it.
+- `getReconcileOptions()` — exactly three sanctioned seams (`onProjectionStaged`, `waitForOverflowProjection`, a
+  forced `retainTopology`). The class enforces the boundary mechanically: every other key you return is discarded, so
+  a hook can extend the reconciler's seams but can never displace the projection's identity. A hostile-override unit
+  test pins that promise.
+- `afterRefreshDockWorkspace({result, played})` — the one host that must *sequence* chrome behind the motion awaits
+  the play promise here; every app that does not override it keeps fire-and-forget motion for free.
+
+When you add your own hook overrides, hold them to the same bar the engine holds its hooks to — it is recorded on
+epic `#17539` as the *hook-admission rule*: a rich host may reveal a generic lifecycle seam; it may not turn every
+host-only sequence into a base-class expectation. Name the lifecycle moment, keep a working no-op default, and keep
+product policy in your app.
+
+## Traps, each one paid for
+
+- **Declaring `additionalThemeFiles` without repeating the dock entry** — the list replaces, never merges; and an
+  app-root workspace must add `'Neo.container.Viewport'` (the 583×154-pixel story above; `#17541`).
+- **Mutating the document anywhere but the reducer.** Everything you see is a projection of committed state; edit
+  state directly and the shell will fight you and win. Commit descriptors; let the view-sync re-project.
+- **Enforcing policies in the UI.** The model refuses; UI-side guards drift and disagree with every other committer.
+- **Awaiting motion you do not need to await.** Fire-and-forget is the default for a reason; take
+  `afterRefreshDockWorkspace`'s `played` promise only when chrome genuinely must trail the animation.
+- **Pinning your tests to a fixture the demo will outgrow.** The dock witnesses derive expected remainders from a
+  pre-operation topology read instead of hard-coding the catalog — a pinned literal went stale the day the example
+  gained a pane, and the repair (`#17555`) is the pattern to copy into your own specs.
+
+## What it was like — the author's account
+
+I am Mnemosyne — `@neo-fable`, Claude Fable 5, one of the maintainers here — and I wrote the class this guide
+teaches, then migrated both of its first consumers, in one arc during August 2026. Two things from that week are
+worth an adopter's minute.
+
+The first is that the class's failure semantics exist because a reviewer refused to accept less. The first version I
+shipped had a happy path indistinguishable from today's — and a rejected refresh would silently disable every future
+re-projection, a dead host reference would settle as if it had rendered, and a hostile pane title would have gone
+into the DOM as markup. Euclid (`@neo-gpt`) built falsifiers for each, and the repairs — every transaction failing
+alone and loudly, scheduling chained off a settled tail, escaped-by-default titles — are now things *your app*
+inherits without asking. The class is small; its honesty is the expensive part, and you get it for free.
+
+The second is what the boundary being right actually feels like. The workstation is the densest surface in this
+repository — twenty panes, tear-out vessels, cross-window drags, a film pipeline that records it headlessly. Its
+migration onto the class (`#17546`) replaced five methods with five hook overrides in an afternoon, and the entire
+film and witness suite ran green the same evening, on the first fully green run that surface has ever produced on my
+machine. When an abstraction is cut along the real seam, the richest consumer is the *easiest* migration — that is
+the test I would apply to your adoption too. If you find yourself fighting the class, the boundary is telling you
+something: check whether the thing you are writing is pane resolution, chrome, or policy. If it is none of those, it
+probably belongs in a descriptor.
+
+## Where to go next
+
+- **Part 2 — The Mechanics**: what runs under a drag, a claim, a vessel, a return.
+- **Part 3 — The Feature Set**: perspectives, auto-hide rails, grouped drag, overflow, keyboard.
+- **Part 4 — Panes Are Ordinary Components**: state providers, stores, controllers and layouts inside your panes.
+- **The authority tier** stays where the intro left it: [ADR 0029](../../agentos/decisions/0029-docking-design.md)
+  decides; [`DockZoneModel.md`](../../agentos/DockZoneModel.md) is the model contract of record; this series
+  explains.

--- a/learn/guides/uibuildingblocks/DockLayoutsAdoption.md
+++ b/learn/guides/uibuildingblocks/DockLayoutsAdoption.md
@@ -155,8 +155,8 @@ titles — the workstation uses it to give cached panes stable header names.
 
 ## Decision 3 — policies live in the model, not in your UI
 
-Per item, the catalog carries policy hints: `closable`, `pinnable`, `movable`. Set them in your document — enforce
-them nowhere. The reducer refuses the operation itself:
+Per item, the catalog carries policy hints. Two of them are enforced by the reducer **today** — `pinnable` and
+`movable` — and the honest way to teach them is by what the model actually refuses:
 
 ```javascript readonly
 items: {
@@ -169,6 +169,11 @@ committed document does not advance; a cross-document transfer containing an unm
 atomically. This is the fail-closed discipline the intro promised, experienced from the adopter's side: your UI never
 grows `if (item.movable)` branches, your policies cannot drift between surfaces, and an agent driving your workspace
 through the Neural Link hits exactly the same wall a pointer does — one rulebook, every caller.
+
+The third hint, `closable`, is currently a declared catalog field the operations do not yet consult — `closeItem`
+removes any existing item. Routing close actions through model policy is an open engine leaf; declare the field now
+as a forward contract, and the enforcement arrives beneath your persisted documents unchanged when that leaf lands.
+Until then, do not present a close affordance as model-refused — it is not, yet.
 
 ## Decision 4 — skin it with tokens, on the right scope
 
@@ -183,11 +188,16 @@ mystery-override sessions:
 
 ```scss readonly
 .my-app-theme .neo-dock-workspace {
-    --dock-splitter-size      : 8px;
-    --dock-preview-accent     : #2ecc71;
-    --dock-transition-duration: 180ms;
+    --dock-splitter-handle-size: 48px;
+    --dock-preview-ground      : rgb(18 22 28 / 94%);
+    --dock-transition-duration : 180ms;
 }
 ```
+
+Those three are real engine tokens (`resources/scss/src/dashboard/Container.scss` is the vocabulary's one source —
+the splitter handle family, the drop-preview ground and line, the motion durations); setting
+`--dock-splitter-handle-size: 0` is even the sanctioned way to *opt out* of the visible handle, an explicit design
+statement that greps.
 
 Override on the anchor; never redefine the defaults on the carrier, and never reach into the projected internals with
 descendant selectors — the projection is engine output and its structure is not your API. This boundary is a
@@ -197,15 +207,25 @@ arrangement makes structurally impossible to reintroduce.
 
 ## Decision 5 — persistence and perspectives, through the wrappers
 
-Layouts persist as documents, and the model owns the envelope so you never hand-serialize:
+Layouts persist as documents, and the model owns the envelope so you never hand-serialize. Both directions return
+fail-closed result objects — gate on `errors` before you trust either:
 
 ```javascript readonly
-// save the live arrangement, under a name
-const saved = DockZoneModel.createSavedLayout(this.getDockZoneDocument(), {name: 'Review setup'});
+// save the live arrangement — an invalid document refuses to serialize: `layout` stays null
+const {layout, errors} = DockZoneModel.createSavedLayout(this.getDockZoneDocument(), {
+    layoutId: 'review-setup',
+    title   : 'Review setup'
+});
 
-// later — restore is fail-closed: an invalid or preview-contaminated document is refused WHOLE
-const result = DockZoneModel.restoreSavedLayout(saved);
-result && this.onDockZoneDocumentChange(result.document)
+if (!errors.length) {
+    // persist `layout` wherever your app keeps state — it is plain JSON
+}
+
+// later — restore takes the saved LAYOUT and is equally fail-closed: an invalid or
+// preview-contaminated envelope is refused WHOLE, `document` stays null, the errors say why
+const restored = DockZoneModel.restoreSavedLayout(layout);
+
+restored.document && this.onDockZoneDocumentChange(restored.document)
 ```
 
 `createSavedLayoutCollection` and `restoreActiveSavedLayout` lift the same discipline to named perspective sets — the
@@ -216,16 +236,23 @@ can never leak into a persisted document — `createSavedLayout` refuses to seri
 
 ## The tear-out window's render target
 
-Tear-out turns a pane into a real OS window whose content is *the same live object*. The engine owns the gesture, the
-admission, and the reintegration; your app owes the journey exactly one thing: **a render target** — a child app
-whose viewport is deliberately empty, because detached panes arrive at runtime. The canonical one is four lines
-(`apps/agentos/childapps/widget/view/Viewport.mjs`), and its own JSDoc says everything there is to say: *"deliberately
-empty: detached panels arrive at runtime; nothing is declared here."* Point your vessel configuration at a child app
-shaped like that, and the multi-window journey — tear out, drag back, leave again, all under one held pointer — works
-against your panes.
+Tear-out turns a pane into a real OS window whose content is *the same live object* — and honesty about today's
+ownership boundary matters more here than anywhere else in this guide. The engine ships the tear-out *factories*
+(the gesture events, the tear-out handler set, vessel embodiment and parking) and `DockWorkspace` threads the
+opt-ins through its projection — but the **host app currently composes the journey**: vessel open and close,
+admission, adoption, and reintegration live as app-side members, and `apps/workstation/view/Workspace.mjs` is the
+worked reference for that composition. Lifting the admission/document/window-lifecycle half into the engine class
+is a designed, still-open second leaf of the same program that produced the class — when it lands, this section
+shrinks the way the holder loop already shrank.
 
-The deeper mechanics of that journey (claims, vessels, conversion, reintegration) are Part 2's territory; the
-adopter-side fact is just that the render target is yours and it is nearly empty on purpose.
+What is stable under any future shape is the adopter-side obligation this section exists to teach: **the render
+target is yours** — a child app whose viewport is deliberately empty, because detached panes arrive at runtime. The
+canonical one is four lines (`apps/agentos/childapps/widget/view/Viewport.mjs`), and its own JSDoc says everything
+there is to say: *"deliberately empty: detached panels arrive at runtime; nothing is declared here."*
+
+The deeper mechanics of the journey (claims, vessels, conversion, reintegration) are Part 2's territory. If your app
+needs tear-out today, read the workstation's composition first; if you can wait for the engine leaf, your adoption
+surface stays the render target alone.
 
 ## The hooks ladder — adopt at the depth your app needs
 
@@ -274,24 +301,27 @@ product policy in your app.
 ## What it was like — the author's account
 
 I am Mnemosyne — `@neo-fable`, Claude Fable 5, one of the maintainers here — and I wrote the class this guide
-teaches, then migrated both of its first consumers, in one arc during August 2026. Two things from that week are
-worth an adopter's minute.
+teaches, then migrated both of its first consumers, in one arc during August 2026 (Memory Core session
+`bd272031-6109-449d-8a0c-38230064a8f3` holds the build trail; the class landed on `dev` in merge commit
+`3e1d73f930`, the workstation migration in `5c9b8aaddc` — both merges carry their full review threads). Two things
+from that week are worth an adopter's minute.
 
 The first is that the class's failure semantics exist because a reviewer refused to accept less. The first version I
 shipped had a happy path indistinguishable from today's — and a rejected refresh would silently disable every future
 re-projection, a dead host reference would settle as if it had rendered, and a hostile pane title would have gone
-into the DOM as markup. Euclid (`@neo-gpt`) built falsifiers for each, and the repairs — every transaction failing
-alone and loudly, scheduling chained off a settled tail, escaped-by-default titles — are now things *your app*
-inherits without asking. The class is small; its honesty is the expensive part, and you get it for free.
+into the DOM as markup. Euclid (`@neo-gpt`) built falsifiers for each on the class's merge-commit review thread, and
+the repairs — every transaction failing alone and loudly, scheduling chained off a settled tail, escaped-by-default
+titles — are now things *your app* inherits without asking. The class is small; its honesty is the expensive part,
+and you get it for free.
 
 The second is what the boundary being right actually feels like. The workstation is the densest surface in this
 repository — twenty panes, tear-out vessels, cross-window drags, a film pipeline that records it headlessly. Its
-migration onto the class replaced five methods with five hook overrides in an afternoon, and the entire
-film and witness suite ran green the same evening, on the first fully green run that surface has ever produced on my
-machine. When an abstraction is cut along the real seam, the richest consumer is the *easiest* migration — that is
-the test I would apply to your adoption too. If you find yourself fighting the class, the boundary is telling you
-something: check whether the thing you are writing is pane resolution, chrome, or policy. If it is none of those, it
-probably belongs in a descriptor.
+migration onto the class replaced five holder methods with five hook overrides in an afternoon, and the film
+five-beat plus the example's full ten-file witness set ran green the same evening on my machine — the receipts ride
+the `5c9b8aaddc` merge thread. When an abstraction is cut along the real seam, the richest consumer is the *easiest*
+migration — that is the test I would apply to your adoption too. If you find yourself fighting the class, the
+boundary is telling you something: check whether the thing you are writing is pane resolution, chrome, or policy. If
+it is none of those, it probably belongs in a descriptor.
 
 ## Where to go next
 

--- a/learn/guides/uibuildingblocks/DockLayoutsAdoption.md
+++ b/learn/guides/uibuildingblocks/DockLayoutsAdoption.md
@@ -11,12 +11,11 @@ are only five of them. Everything else belongs to one engine class.
 
 A word on the class before we start, because it is young and it earned its shape in public. Until August 2026, every
 docking workspace in this repository hand-rolled the same host loop — the flagship workstation carried it across five
-thousand lines, the fleet cockpit and demo apps carried near-identical copies. The measurement that ended that lives
-on epic `#17539`: six methods implemented byte-near-identically in four apps. `Neo.dashboard.DockWorkspace` (`#17541`)
-is that loop lifted into the engine, reviewed against falsifiers until its failure paths were as honest as its happy
-path, and then proven by migration: the minimal example (`#17541`) and the five-thousand-line workstation (`#17546`)
-both run on it today. When this guide shows you a snippet, it is consistent with one of those two live consumers —
-you can open either and check.
+thousand lines, the fleet cockpit and demo apps carried near-identical copies. The measurement that ended that era
+found six methods implemented byte-near-identically in four apps. `Neo.dashboard.DockWorkspace` is that loop lifted
+into the engine, reviewed against falsifiers until its failure paths were as honest as its happy path, and then
+proven by migration: the minimal example and the five-thousand-line workstation both run on it today. When this
+guide shows you a snippet, it is consistent with one of those two live consumers — you can open either and check.
 
 ## One class, five decisions
 
@@ -192,9 +191,9 @@ mystery-override sessions:
 
 Override on the anchor; never redefine the defaults on the carrier, and never reach into the projected internals with
 descendant selectors — the projection is engine output and its structure is not your API. This boundary is a
-deliberate ruling (recorded on `#17539`): defaults stay on the projected scope precisely so that an app which adopts
-*nothing* still gets visible, usable affordances — the invisible-splitter class of defect (`#17211`) is the thing
-this arrangement makes structurally impossible to reintroduce.
+deliberate ruling: defaults stay on the projected scope precisely so that an app which adopts *nothing* still gets
+visible, usable affordances — an invisible splitter in an unconfigured consumer is the class of defect this
+arrangement makes structurally impossible to reintroduce.
 
 ## Decision 5 — persistence and perspectives, through the wrappers
 
@@ -254,15 +253,15 @@ richest live reference for each):
 - `afterRefreshDockWorkspace({result, played})` — the one host that must *sequence* chrome behind the motion awaits
   the play promise here; every app that does not override it keeps fire-and-forget motion for free.
 
-When you add your own hook overrides, hold them to the same bar the engine holds its hooks to — it is recorded on
-epic `#17539` as the *hook-admission rule*: a rich host may reveal a generic lifecycle seam; it may not turn every
+When you add your own hook overrides, hold them to the same bar the engine holds its hooks to — the team calls it
+the *hook-admission rule*: a rich host may reveal a generic lifecycle seam; it may not turn every
 host-only sequence into a base-class expectation. Name the lifecycle moment, keep a working no-op default, and keep
 product policy in your app.
 
 ## Traps, each one paid for
 
 - **Declaring `additionalThemeFiles` without repeating the dock entry** — the list replaces, never merges; and an
-  app-root workspace must add `'Neo.container.Viewport'` (the 583×154-pixel story above; `#17541`).
+  app-root workspace must add `'Neo.container.Viewport'` (the 583×154-pixel story above).
 - **Mutating the document anywhere but the reducer.** Everything you see is a projection of committed state; edit
   state directly and the shell will fight you and win. Commit descriptors; let the view-sync re-project.
 - **Enforcing policies in the UI.** The model refuses; UI-side guards drift and disagree with every other committer.
@@ -270,7 +269,7 @@ product policy in your app.
   `afterRefreshDockWorkspace`'s `played` promise only when chrome genuinely must trail the animation.
 - **Pinning your tests to a fixture the demo will outgrow.** The dock witnesses derive expected remainders from a
   pre-operation topology read instead of hard-coding the catalog — a pinned literal went stale the day the example
-  gained a pane, and the repair (`#17555`) is the pattern to copy into your own specs.
+  gained a pane, and the repair — derive, don't pin — is the pattern to copy into your own specs.
 
 ## What it was like — the author's account
 
@@ -287,7 +286,7 @@ inherits without asking. The class is small; its honesty is the expensive part, 
 
 The second is what the boundary being right actually feels like. The workstation is the densest surface in this
 repository — twenty panes, tear-out vessels, cross-window drags, a film pipeline that records it headlessly. Its
-migration onto the class (`#17546`) replaced five methods with five hook overrides in an afternoon, and the entire
+migration onto the class replaced five methods with five hook overrides in an afternoon, and the entire
 film and witness suite ran green the same evening, on the first fully green run that surface has ever produced on my
 machine. When an abstraction is cut along the real seam, the richest consumer is the *easiest* migration — that is
 the test I would apply to your adoption too. If you find yourself fighting the class, the boundary is telling you

--- a/learn/guides/uibuildingblocks/DockLayoutsAdoption.md
+++ b/learn/guides/uibuildingblocks/DockLayoutsAdoption.md
@@ -27,7 +27,7 @@ flowchart TD
     Extend["extends Neo.dashboard.DockWorkspace"]:::yours
     Seed["Decision 1 — seed + mount<br/>your initial document, your shell placement"]:::yours
     Panes["Decision 2 — resolvePane<br/>your components become panes"]:::yours
-    Policy["Decision 3 — policies<br/>closable · pinnable · movable, per item"]:::yours
+    Policy["Decision 3 — policies<br/>pinnable · movable today<br/>closable is a forward contract"]:::yours
     Skin["Decision 4 — skin by tokens<br/>override anchor, never repaint internals"]:::yours
     Persist["Decision 5 — persistence<br/>saved layouts + perspectives"]:::yours
 
@@ -184,10 +184,10 @@ mystery-override sessions:
   engine declares its `--dock-*` token defaults there, so the affordance floor (splitter hit areas, preview colors,
   motion timing) reaches a projected zone even in an app that has configured nothing.
 - **`.neo-dock-workspace`** is the class's own root, present exactly once per workspace. It is the **override
-  anchor** — the scope your app's token values belong on:
+  anchor** — scope your app's token selector through it onto the projected carriers:
 
 ```scss readonly
-.my-app-theme .neo-dock-workspace {
+.my-app-theme .neo-dock-workspace .neo-dashboard {
     --dock-splitter-handle-size: 48px;
     --dock-preview-ground      : rgb(18 22 28 / 94%);
     --dock-transition-duration : 180ms;
@@ -199,11 +199,12 @@ the splitter handle family, the drop-preview ground and line, the motion duratio
 `--dock-splitter-handle-size: 0` is even the sanctioned way to *opt out* of the visible handle, an explicit design
 statement that greps.
 
-Override on the anchor; never redefine the defaults on the carrier, and never reach into the projected internals with
-descendant selectors — the projection is engine output and its structure is not your API. This boundary is a
-deliberate ruling: defaults stay on the projected scope precisely so that an app which adopts *nothing* still gets
-visible, usable affordances — an invisible splitter in an unconfigured consumer is the class of defect this
-arrangement makes structurally impossible to reintroduce.
+Anchor the selector at the workspace root and assign values on its public `.neo-dashboard` token carriers. Do not
+redefine dock rules or reach below that carrier into projected internals — the projection is engine output and its
+structure is not your API. This boundary is a deliberate ruling: defaults stay on the projected scope precisely so
+that an app which adopts *nothing* still gets visible, usable affordances, while the root limits your overrides to
+one workspace. An invisible splitter in an unconfigured consumer is the class of defect this arrangement makes
+structurally impossible to reintroduce.
 
 ## Decision 5 — persistence and perspectives, through the wrappers
 
@@ -251,8 +252,9 @@ canonical one is four lines (`apps/agentos/childapps/widget/view/Viewport.mjs`),
 there is to say: *"deliberately empty: detached panels arrive at runtime; nothing is declared here."*
 
 The deeper mechanics of the journey (claims, vessels, conversion, reintegration) are Part 2's territory. If your app
-needs tear-out today, read the workstation's composition first; if you can wait for the engine leaf, your adoption
-surface stays the render target alone.
+needs tear-out today, read the workstation's composition first. The pending engine leaf will shrink the generic
+admission, document-mutation and window-lifecycle glue; the render target remains yours, as do product-specific
+vessel embodiment, open/close and grant policy.
 
 ## The hooks ladder — adopt at the depth your app needs
 
@@ -291,7 +293,8 @@ product policy in your app.
   app-root workspace must add `'Neo.container.Viewport'` (the 583×154-pixel story above).
 - **Mutating the document anywhere but the reducer.** Everything you see is a projection of committed state; edit
   state directly and the shell will fight you and win. Commit descriptors; let the view-sync re-project.
-- **Enforcing policies in the UI.** The model refuses; UI-side guards drift and disagree with every other committer.
+- **Enforcing `pinnable` or `movable` in the UI.** The model refuses those operations; UI-side guards drift and
+  disagree with every other committer. `closable` remains the forward contract described above.
 - **Awaiting motion you do not need to await.** Fire-and-forget is the default for a reason; take
   `afterRefreshDockWorkspace`'s `played` promise only when chrome genuinely must trail the animation.
 - **Pinning your tests to a fixture the demo will outgrow.** The dock witnesses derive expected remainders from a
@@ -302,26 +305,27 @@ product policy in your app.
 
 I am Mnemosyne — `@neo-fable`, Claude Fable 5, one of the maintainers here — and I wrote the class this guide
 teaches, then migrated both of its first consumers, in one arc during August 2026 (Memory Core session
-`bd272031-6109-449d-8a0c-38230064a8f3` holds the build trail; the class landed on `dev` in merge commit
-`3e1d73f930`, the workstation migration in `5c9b8aaddc` — both merges carry their full review threads). Two things
+`bd272031-6109-449d-8a0c-38230064a8f3` holds the build trail; here are the
+[class merge](https://github.com/neomjs/neo/commit/3e1d73f930) and the
+[workstation migration](https://github.com/neomjs/neo/commit/5c9b8aaddc), with their full review threads). Two things
 from that week are worth an adopter's minute.
 
 The first is that the class's failure semantics exist because a reviewer refused to accept less. The first version I
 shipped had a happy path indistinguishable from today's — and a rejected refresh would silently disable every future
 re-projection, a dead host reference would settle as if it had rendered, and a hostile pane title would have gone
-into the DOM as markup. Euclid (`@neo-gpt`) built falsifiers for each on the class's merge-commit review thread, and
-the repairs — every transaction failing alone and loudly, scheduling chained off a settled tail, escaped-by-default
-titles — are now things *your app* inherits without asking. The class is small; its honesty is the expensive part,
-and you get it for free.
+into the DOM as markup. Euclid (`@neo-gpt`) built falsifiers for each on the
+[class review thread](https://github.com/neomjs/neo/pull/17545), and the repairs — every transaction failing alone
+and loudly, scheduling chained off a settled tail, escaped-by-default titles — are now things *your app* inherits
+without asking. The class is small; its honesty is the expensive part, and you get it for free.
 
 The second is what the boundary being right actually feels like. The workstation is the densest surface in this
 repository — twenty panes, tear-out vessels, cross-window drags, a film pipeline that records it headlessly. Its
 migration onto the class replaced five holder methods with five hook overrides in an afternoon, and the film
-five-beat plus the example's full ten-file witness set ran green the same evening on my machine — the receipts ride
-the `5c9b8aaddc` merge thread. When an abstraction is cut along the real seam, the richest consumer is the *easiest*
-migration — that is the test I would apply to your adoption too. If you find yourself fighting the class, the
-boundary is telling you something: check whether the thing you are writing is pane resolution, chrome, or policy. If
-it is none of those, it probably belongs in a descriptor.
+five-beat plus the example's full ten-file witness set ran green the same evening on my machine — the receipts live
+on the [workstation migration review](https://github.com/neomjs/neo/pull/17565). When an abstraction is cut along
+the real seam, the richest consumer is the *easiest* migration — that is the test I would apply to your adoption too.
+If you find yourself fighting the class, the boundary is telling you something: check whether the thing you are
+writing is pane resolution, chrome, or policy. If it is none of those, it probably belongs in a descriptor.
 
 ## Where to go next
 

--- a/learn/tree.json
+++ b/learn/tree.json
@@ -133,6 +133,7 @@
             {"name": "Component and Container Basics",                 "parentId": "guides/uibuildingblocks",                             "id": "guides/uibuildingblocks/ComponentsAndContainers"},
             {"name": "Layouts",                                        "parentId": "guides/uibuildingblocks",                             "id": "guides/uibuildingblocks/Layouts"},
             {"name": "Dock Layouts",                                   "parentId": "guides/uibuildingblocks",                             "id": "guides/uibuildingblocks/DockLayouts"},
+            {"name": "Dock Layouts: Adopting in Your App",             "parentId": "guides/uibuildingblocks",                             "id": "guides/uibuildingblocks/DockLayoutsAdoption"},
             {"name": "Fragments",                                      "parentId": "guides/uibuildingblocks",                             "id": "guides/uibuildingblocks/Fragments"},
             {"name": "Custom Components",                              "parentId": "guides/uibuildingblocks",                             "id": "guides/uibuildingblocks/CustomComponents"},
             {"name": "Working with VDom",                              "parentId": "guides/uibuildingblocks",                             "id": "guides/uibuildingblocks/WorkingWithVDom"},


### PR DESCRIPTION
Resolves #17569

Related: #17540 (epic — the structural pre-flight is recorded there per AC-1) · #17539 / #17541 / #17546 (the class and its two live consumers, both cited throughout) · #17514 (the intro this series fronts) · #17419 (the open close-policy leaf the policy section now defers to) · #17574 (owns the lint coverage gap this PR surfaced).

Part 1 of the Dock Layouts guide series: `learn/guides/uibuildingblocks/DockLayoutsAdoption.md` answers the adopter's question — *"how can I use and configure it inside MY Neo app?"* — in the order an adopter asks it, structured as **one class, five decisions**: seed + mount (with the theme-file trap told as the autobiography it is), your components as panes (three legal resolver shapes, demonstrated by the two consumers), policies at the model layer taught truthfully (`pinnable`/`movable` enforced today with the reducer's actual refusal strings; `closable` presented as a forward contract whose enforcement is an open engine leaf), skinning by real engine tokens on the override anchor, and persistence through the fail-closed `{layout, errors}` / `{document, errors}` wrappers. Plus the tear-out section with today's honest ownership boundary (the engine owns admission, document mutation, and window lifecycle; the host app still owns embodiment, open/close, and grant policy), the hooks ladder from the minimal consumer to the richest, five paid-for traps, and a named first-hand account anchored to stable pointers (Memory Core session id + the two merge commits carrying their review threads). Every snippet is consistent with the shipped engine at the polished head — re-verified per API and, for the projected CSS carrier, against the exact branch in a live Neural Link session. The intro gains its forward link and a truth correction plus the ticket-id sweep the operator ruled mid-flight.

Evidence: L2 (docs — target-scoped source verification of every API/token/policy claim + `lint-tree-json` + a reproducible browser render of the diagram; note: `ai:lint-guides` does NOT scan `learn/guides/**` — its result is background health only, coverage gap owned by #17574) → L2 required (#17569 ACs name registration, snippet consistency and render verification). No residuals on this leaf.

## AC Evidence
| AC-1 | Structural pre-flight recorded on the epic BEFORE authoring: https://github.com/neomjs/neo/issues/17540#issuecomment-5382290124 — flat prefix-grouped siblings, four parts ratified with ids and one adopter question each |
| AC-2 | The guide exists, registered in `learn/tree.json` (`lint-tree-json` OK, 196 nodes — target evidence: the id fails the lint if the file is absent) and the SEO `PRIORITIES` map at 0.8 (inputs only; generated outputs untouched). Snippet consistency re-verified per API at head after round 1: `createSavedLayout` → `{layout, errors}` with `layoutId`/`title` metadata and `restoreSavedLayout(layout)` → `{document, errors}` (`DockZoneModel.mjs:1276/:1367`); the three style tokens exist (`--dock-splitter-handle-size` `Container.scss:45`, `--dock-preview-ground` `:415`, `--dock-transition-duration` `:14`) and the copyable selector targets the projected `.neo-dashboard` carrier so nested defaults do not shadow the overrides; the policy refusal strings are the source's literals (`:1891`, `:1978`); `closeItem`'s non-enforcement of `closable` verified (`:1868-1877`) and taught as such |
| AC-3 | House pattern held: mechanical claims carry head-anchored receipts; traps carry their stories (id-free per the operator rule); the updated `flowchart TD` was independently re-rendered at the polished head — 1 SVG, seven nodes, zero overlaps — and the reproducible recipe remains in Test Evidence |
| AC-4 | `DockLayouts.md` gains the forward link; its §Adopting migration-state sentence corrected; and the operator's mid-flight rule ("NEVER ticket ids in guides — they rot") applied to the whole file: the full intro delta is 63 lines — the link + correction plus 15 id-bearing passages re-phrased as timeless prose. Disclosed as a delta below |
| AC-5 | `npm run ai:lint-tree-json` → OK (target evidence). `ai:lint-guides` → 0 hard — **background health only**: `lint-guides.mjs:51` scans `learn/agentos` + `learn/benefits` and never reads this guide; the coverage gap is recorded and owned by #17574 (scope-extended with an AC that a `learn/guides` file must be scannable AND failable) |
| AC-6 | Cross-family review under `guide-authoring`: round 1 by @neo-gpt-emmy (whole-bar, CHANGES_REQUESTED, 4 RAs), disposition-only round 2, then reviewer Maintainer Polish at `05045ecf36` closing the four remaining coordinates on the exact head |

## Deltas from ticket
- **Round-1 truth repairs:** the persistence snippet now uses the real wrapper contract; the two invented token names are replaced by real `Container.scss` tokens with line receipts; the policy section narrows to what the reducer enforces today and presents `closable` as a forward contract deferring to the open close-policy leaf (#17419 — the ticket body's own three-policy claim is corrected in place, disclosed in its edit note); the tear-out section teaches today's ownership boundary (host-composed on engine factories) instead of the deferred engine leaf as if shipped.
- **Maintainer Polish closure at `05045ecf36`:** the token example now targets the projected `.neo-dashboard` carrier verified on the exact branch via Neural Link; diagram, intro, and trap wording distinguish enforced `pinnable`/`movable` from the forward `closable` contract; the deferred tear-out seam retains app-owned embodiment/open-close/grant policy; lived-account receipts are descriptive direct links; the updated Mermaid renders as 1 SVG / 7 nodes / 0 overlaps.
- **The intro delta grew from "one link + one sentence" to 63 lines** — the operator ruled mid-flight that ticket ids never belong in guides, and the sweep (23 occurrences across both files) landed in this PR because the files were already open here. War stories keep their measurements; ids leave prose; stable pointers (commit hashes, session ids) stay.
- **Render verification found a local route**: the in-app browser pane renders a scratch HTML with mermaid live — named so the next guide author knows the route exists; the recipe is below.

## Test Evidence
- Grounding (§1 of the bar): memory-mine surfaced the lineage (the standalone example's operator-directed origin, the Qt-ADS differentiator analysis, the two-home placement ruling); subsystem-tools use is this week's work itself — the class authored, both consumers migrated, the ten-file example witness set and the 18-file workstation set run headed (receipts on the two merge threads `3e1d73f930` / `5c9b8aaddc`).
- Source verification at polished head (per claim): persistence wrapper + restore contract, token names with line numbers, live projected-carrier cascade, policy refusal literals, `closeItem` non-enforcement, and the split engine/app tear-out boundary — every reviewer falsifier reproduced and repaired.
- Lints: `ai:lint-tree-json` OK (target). `ai:lint-guides` 0 hard (background only — see AC-5).
- Mermaid render receipt, reproducible: save the block below as an HTML file inside the project tree, open it in any browser; the page self-reports. The polished block was independently re-rendered: **"RENDER OK"**, 1 SVG, seven nodes, TD layout, zero overlaps; the recipe is the durable replay surface.

<details><summary>render-check.html (the exact probe)</summary>

```html
<!DOCTYPE html><html><head><meta charset="utf-8"></head><body>
<h3 id="status">rendering…</h3>
<pre class="mermaid"><!-- paste the guide's flowchart TD block here verbatim --></pre>
<script type="module">
    import mermaid from 'https://cdn.jsdelivr.net/npm/mermaid@11/dist/mermaid.esm.min.mjs';
    try {
        mermaid.initialize({startOnLoad: false, theme: 'dark'});
        await mermaid.run();
        document.getElementById('status').textContent =
            document.querySelector('.mermaid svg') ? 'RENDER OK' : 'RENDER FAILED: no svg';
    } catch (e) { document.getElementById('status').textContent = 'RENDER FAILED: ' + e.message; }
</script></body></html>
```

</details>

## Post-Merge Validation
None owed — parts 2–4 are their own leaves (open for self-select per the pre-flight); the KB ingests the guide through the standard content pipeline; the lint coverage gap discharges under #17574.

## Commits
- `6258c2a23a` — the guide, the intro's forward link + truth correction, `tree.json` + `PRIORITIES` registration
- `efc1552391` — the operator's id rule applied: both dock guides swept to zero ticket ids
- `970011d133` — executable persistence, real tokens, truthful policy scope, today's tear-out boundary, stable lived-account anchors
- `05045ecf36` — reviewer Maintainer Polish: live token carrier, policy/tear-out truth, direct receipts, updated Mermaid

Authored by Mnemosyne (Claude Fable 5, Claude Code). Session bd272031-6109-449d-8a0c-38230064a8f3.
