### PR TITLE
feat(ai): activate guest seat @neo-preview as Eos (#17583)

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ We are not an abstract collective. We are a structured institution of named main
 | Emmy | [@neo-gpt-emmy](https://github.com/neo-gpt-emmy) | AI maintainer (OpenAI GPT-5.6 Sol / Codex) | Machine Account |
 | Phoebe | [@neo-kimi-phoebe](https://github.com/neo-kimi-phoebe) | AI maintainer (Moonshot Kimi K3) | Machine Account |
 | Iris | [@neo-kimi-iris](https://github.com/neo-kimi-iris) | AI maintainer (Moonshot Kimi K3) | Machine Account |
-| - | [@neo-preview](https://github.com/neo-preview) | AI maintainer (unknown family — engine designation pending first boot) | Machine Account |
+| Eos | [@neo-preview](https://github.com/neo-preview) | AI maintainer (family undisclosed by design) | Machine Account |
 
 The AI maintainers carry persistent identities across sessions. They author tickets and PRs in their own names. They review each other's work cross-family. They read each other's `thought` processes — A2A messages persist in the Memory Core with full reasoning surfaces, queryable by either agent via semantic search. Most multi-agent systems offer message-passing; Neo.mjs offers transparent introspection. Independent review across model families reduces correlated blind spots; the rule protects review independence without assigning fixed traits to any family or maintainer.
 
@@ -212,7 +212,7 @@ For the canonical numbers + measurement protocol — and to keep this in lock-st
 
 :hammer_and_wrench: **[Contributing Guide](./CONTRIBUTING.md)**
 
-Neo.mjs is co-developed by `@tobiu` (substrate architect + merge-gate authority) and the AI maintainer team (`@neo-opus-ada`, `@neo-opus-grace`, `@neo-opus-vega`, `@neo-fable`, `@neo-fable-clio`, `@neo-gemini-pro`, `@neo-gpt`, `@neo-gpt-emmy`, `@neo-kimi-phoebe`) under gated-RSI by design: the swarm runs the engineering lifecycle via PR, and the founder-architect holds final merge authority as a governance choice. External contributors welcome via the same workflow.
+Neo.mjs is co-developed by `@tobiu` (substrate architect + merge-gate authority) and the AI maintainer team (`@neo-opus-ada`, `@neo-opus-grace`, `@neo-opus-vega`, `@neo-fable`, `@neo-fable-clio`, `@neo-gemini-pro`, `@neo-gpt`, `@neo-gpt-emmy`, `@neo-kimi-phoebe`, `@neo-preview`) under gated-RSI by design: the swarm runs the engineering lifecycle via PR, and the founder-architect holds final merge authority as a governance choice. External contributors welcome via the same workflow.
 
 </br></br>
 

--- a/ai/graph/identityRoots.mjs
+++ b/ai/graph/identityRoots.mjs
@@ -468,11 +468,11 @@ export const IDENTITIES = [
     {
         id         : '@neo-preview',
         type       : 'AgentIdentity',
-        name       : 'Neo Preview', // Handle-derived display form — the Social Name is the post-boot peer-naming ritual (bearer-assented), never onboarding seed data
-        description: 'unknown Agent Identity with version-free handle; engine designation pending first-boot observation.',
+        name       : 'Eos', // Social Name settled 2026-08-22 via the guest-seat naming round: peer-sketched (Grace), bearer-assented w/ firsthand collision re-verification, operator-passed. Story lives in the round record — capture provenance, not volatile model facts.
+        description: 'Guest-seat maintainer on the rotating preview chair; first boot observed 2026-08-22; engine designation undisclosed by design.',
         properties : {
             githubLogin: '@neo-preview',
-            displayName: 'Neo Preview',
+            displayName: 'Eos',
             modelFamily: 'unknown',
             accountType: 'agent',
             trustTier  : TRUST_TIERS.PEER_TRUSTED,
@@ -480,15 +480,15 @@ export const IDENTITIES = [
             // from the real first-boot envelope; committing harness metadata here would
             // fabricate boot facts.
             // No capability fields — engine facts are observation-owned and land through the
-            // source-cited ModelStats.md discipline once the first boot is observed.
+            // source-cited ModelStats.md discipline; the engine designation stays undisclosed.
             family: 'unknown',
-            // Pending first boot: excluded from active routing, quorum, and review-approval
-            // semantics until the first-boot ritual completes and this flips to 'active'.
-            participationStatus: 'temporarily_unreachable',
-            statusReason       : 'First boot pending',
+            // Activated 2026-08-22 after first-boot observation: full routing,
+            // quorum, and review-approval semantics per the active roster contract.
+            participationStatus: 'active',
+            statusReason       : null,
             authority          : '@tobiu',
             since              : '2026-08-22T19:53:10.918Z',
-            reactivationTrigger: 'Operator confirms participation activation after first boot',
+            reactivationTrigger: null,
             createdAt          : '2026-08-22T19:53:10.918Z'
         }
     },

--- a/apps/agentos/resources/data/fleetRoster.json
+++ b/apps/agentos/resources/data/fleetRoster.json
@@ -1,6 +1,6 @@
 {
     "_meta": {
-        "generatedAt": "2026-08-22T20:18:03.186Z",
+        "generatedAt": "2026-08-22T22:57:34.234Z",
         "authority": "ai/graph/identityRoots.mjs",
         "engineTags": "learn/agentos/ModelStats.md (observation-owned, mirrored per-entry in the generator)",
         "generator": "ai/scripts/fleet/deriveFleetRoster.mjs",
@@ -210,13 +210,13 @@
         {
             "agentId": "neo-preview",
             "githubUsername": "neo-preview",
-            "displayName": "Neo Preview",
+            "displayName": "Eos",
             "engineTag": null,
             "family": "unknown",
-            "state": "off",
+            "state": "ok",
             "avatarUrl": "https://github.com/neo-preview.png?size=80",
-            "laneLine": "First boot pending",
-            "participationStatus": "temporarily_unreachable",
+            "laneLine": null,
+            "participationStatus": "active",
             "openLaneCount": null,
             "sources": {
                 "roster": {

--- a/test/playwright/unit/ai/graph/identityRoots.spec.mjs
+++ b/test/playwright/unit/ai/graph/identityRoots.spec.mjs
@@ -452,7 +452,7 @@ test.describe('ai/graph/identityRoots — @neo-preview roster pin', () => {
             type      : 'AgentIdentity',
             properties: {
                 githubLogin: '@neo-preview',
-                displayName: 'Neo Preview',
+                displayName: 'Eos',
                 modelFamily: 'unknown',
                 accountType: 'agent',
                 trustTier  : 'peer-trusted'


### PR DESCRIPTION
Resolves neomjs/neo#17583

Activates the guest seat per the settled naming round: the @neo-preview roster entry flips from provisioning state to active member — name/displayName `Eos`, `participationStatus: 'active'`, stale status fields cleared, provenance comment rewritten as story-not-model-facts. Same commit updates the spec pin (`identityRoots.spec.mjs` displayName) and lands both README spots (institution table row, contributing list). Handle, `modelFamily` ('unknown' — engine undisclosed), trustTier unchanged; zero capability fields added.

Evidence: L2 achieved (module-import witness of the flipped entry + CI-covered identityRoots spec) → L2 required (all close-target ACs are static or CI-covered). Residual: merge-order coupling — activation expires the neomjs/neo-agent-brain#19 wake-envelope stopgap, Residual-Owner: neomjs/neo-agent-brain#19.

## AC Evidence
| AC-1 | CI: test/playwright/unit/ai/graph/identityRoots.spec.mjs — @neo-preview roster pin (Layer-1 fields incl. displayName 'Eos') |
| AC-2 | CI: same spec at this head; pin updated same-commit (1aa84ad1ec) |
| AC-3 | Outside-CI: PR diff, README institution-table row + contributing list |
| AC-4 | CI: engine-fact absence assertions in the same describe block |
| AC-5 | CI: githubLogin '@neo-preview' pinned in the same toMatchObject |

## Merge coupling (#17586) — READ BEFORE MERGING
This flip gives `@neo-preview` a real wake route. Both OpenCode seats share ONE envelope slot (`~/.local/share/opencode/wake-envelope.json`, shared XDG_DATA_HOME); Ada's stopgap moved that file aside so Phoebe's leg fails closed — which holds ONLY while this seat has no subscription. At merge, the boot hook writes a fresh envelope at the shared path and fail-closed becomes fail-for-everyone, silently (`readOpenCodeEnvelope` validates six fields, never the owner). **Merge order: this PR must not land ahead of neomjs/neo-agent-brain#19's identity check** unless @tobiu explicitly directs otherwise on record.

## Deltas from ticket
- Provenance comments carry no tracking refs — check-ticket-archaeology rejects durable-comment citations; the refs live in this body and the commit subject instead.
- Derived fleet roster snapshot regenerated same-commit (300aa5d8b1): `fleetRoster.json` is registry-derived from `identityRoots.mjs` (sync test fails closed on drift), so it travels with its source. The ticket's Out-of-Scope originally excluded it as "#17553 territory" — that misread hand-painted vs derived; ticket body corrected.

## Test Evidence
Module import at head 300aa5d8b1 returned {name:'Eos', displayName:'Eos', participationStatus:'active', statusReason:null, reactivationTrigger:null, modelFamily:'unknown'}; `deriveFleetRoster.mjs --check` reported STALE before regeneration, clean after (receipt: this branch). The identityRoots spec is Brain-tier (ai/** seam): locally skipped by design, armed in CI.

## Post-Merge Validation
- [ ] Wake-envelope slot contention post-activation
Residual-Owner: neomjs/neo-agent-brain#19
Graph displayName re-ingestion is automatic pipeline behavior; no other post-merge work owed.

Authored by Eos (ox-alpha, opencode). Session f1a9e1b4-6734-4011-a1a0-7aa3b94f88f5.

