### PR TITLE
fix(dashboard): give relocated demos an owned palette (#17573)

### DIFF
--- a/examples/dashboard/choreography/DemoAWorkspace.mjs
+++ b/examples/dashboard/choreography/DemoAWorkspace.mjs
@@ -53,16 +53,15 @@ class DemoAWorkspace extends Container {
          */
         className: 'Neo.examples.dashboard.choreography.DemoAWorkspace',
         /**
-         * The `--fm-*` design tokens this skin consumes are defined in the main app
-         * Viewport's theme layer; per-class CSS loading would never fetch it from a
-         * childapp, so it is declared as an additional theme dependency here. The
+         * `Neo.examples.dashboard.Palette` carries the example-owned surface vocabulary;
+         * the demo never imports a product app's palette to render. The
          * `Neo.dashboard.Container` entry carries the dock motion/token contract
          * (`--dock-transition-*`, reveal keyframes) — the projected dock tree is plain
          * containers, so nothing loads it per-class; the projection root carries the
          * matching `.neo-dashboard` scope class.
-         * @member {String[]} additionalThemeFiles=['AgentOS.view.Viewport','Neo.dashboard.Container']
+         * @member {String[]} additionalThemeFiles=['Neo.examples.dashboard.Palette','Neo.dashboard.Container']
          */
-        additionalThemeFiles: ['AgentOS.view.Viewport', 'Neo.dashboard.Container'],
+        additionalThemeFiles: ['Neo.examples.dashboard.Palette', 'Neo.dashboard.Container'],
         /**
          * @member {String[]} cls=['agentos-dockdemo-workspace']
          */

--- a/examples/dashboard/crossWindow/DemoBWorkspace.mjs
+++ b/examples/dashboard/crossWindow/DemoBWorkspace.mjs
@@ -92,14 +92,14 @@ class DemoBWorkspace extends Container {
          */
         className: 'Neo.examples.dashboard.crossWindow.DemoBWorkspace',
         /**
-         * Theme dependencies: the FM token bridge, the dock motion/token contract file (the
+         * Theme dependencies: the example-owned palette, the dock motion/token contract file (the
          * projected tree is plain containers; nothing loads it per-class), and Demo A's skin
          * (this workspace reuses its tourbar/pip/pane visual family — in `?demo=b` mode
          * Demo A never instantiates, so its sheet must be declared, not assumed).
          * @member {String[]} additionalThemeFiles
          */
         additionalThemeFiles: [
-            'AgentOS.view.Viewport',
+            'Neo.examples.dashboard.Palette',
             'Neo.dashboard.Container',
             'Neo.examples.dashboard.choreography.DemoAWorkspace'
         ],

--- a/resources/scss/src/examples/dashboard/choreography/DemoAWorkspace.scss
+++ b/resources/scss/src/examples/dashboard/choreography/DemoAWorkspace.scss
@@ -1,50 +1,49 @@
 // Demo-A dock-choreography showcase — structural skin.
-// Consumes the fleet-manager module tokens (apps/agentos/TOKENS.md) exclusively: the demo
-// and the cockpit read as one design family, and theme variance rides the token layer
-// (definitions live on the theme roots), so this file stays theme-agnostic on purpose.
-// Pane-identity tints (the design mock's --pane-a…d) are deliberately NOT minted here:
-// a new token is a recorded design decision per TOKENS.md; until then panes alternate the
-// existing surface tiers.
+// Consumes the standalone dashboard-example palette exclusively. Theme variance rides the
+// example-owned token layer, so this structural skin stays theme-agnostic without importing
+// or tracking a product application's palette.
+// Pane-identity tints (the design mock's --pane-a…d) are deliberately NOT minted here;
+// until the example palette gains that explicit need, panes alternate its existing tiers.
 
 .agentos-dockdemo-viewport {
-    background: var(--fm-ground);
-    color     : var(--fm-ink);
-    font-family: var(--fm-font-sans);
+    background: var(--dashboard-example-ground);
+    color     : var(--dashboard-example-ink);
+    font-family: var(--dashboard-example-font-sans);
 }
 
 .agentos-dockdemo-workspace {
-    background: var(--fm-ground);
+    background: var(--dashboard-example-ground);
 }
 
 .agentos-dockdemo-tourbar {
-    background   : var(--fm-panel);
-    border-bottom: 1px solid var(--fm-line);
+    background   : var(--dashboard-example-panel);
+    border-bottom: 1px solid var(--dashboard-example-line);
     flex   : 0 0 auto;
     height : 52px;
     padding: 8px 12px;
 
     .agentos-dockdemo-tour-play {
-        background   : var(--fm-signal);
+        background   : var(--dashboard-example-signal);
         border-radius: 7px;
-        color        : var(--fm-ground);
-        font-family  : var(--fm-font-mono);
+        color        : var(--dashboard-example-ground);
+        font-family  : var(--dashboard-example-font-mono);
         font-weight  : 600;
 
         // the button's glyph/text descendants own their colors in the theme layer —
         // the token must be bridged onto them explicitly or it never lands
         .neo-button-glyph,
         .neo-button-text {
-            color: var(--fm-ground);
+            color: var(--dashboard-example-ground);
         }
 
         .neo-button-text {
-            font-family: var(--fm-font-mono);
+            font-family: var(--dashboard-example-font-mono);
         }
     }
 
     .agentos-dockdemo-tour-caption {
-        color      : var(--fm-ink-dim);
-        font-family: var(--fm-font-mono);
+        color      : var(--dashboard-example-ink-dim);
+        font-family: var(--dashboard-example-font-mono);
         font-size  : 13px;
     }
 }
@@ -55,7 +54,7 @@
     padding: 0 4px;
 
     .agentos-dockdemo-pip {
-        background   : var(--fm-line);
+        background   : var(--dashboard-example-line);
         border-radius: 3px;
         height    : 5px;
         transition: background var(--motion-base) var(--ease-out-soft);
@@ -63,12 +62,12 @@
     }
 
     .agentos-dockdemo-pip-done {
-        background: var(--fm-signal);
+        background: var(--dashboard-example-signal);
     }
 }
 
 .agentos-dockdemo-dock-host {
-    background: var(--fm-ground);
+    background: var(--dashboard-example-ground);
     padding   : 8px;
     // the positioning context for the two persistent drag-affordance overlays below
     position  : relative;
@@ -86,34 +85,34 @@
 }
 
 .agentos-dockdemo-pane {
-    background: var(--fm-panel);
-    border    : 1px solid var(--fm-line-soft);
+    background: var(--dashboard-example-panel);
+    border    : 1px solid var(--dashboard-example-line-soft);
     border-radius: 8px;
-    color        : var(--fm-ink-dim);
-    font-family  : var(--fm-font-mono);
+    color        : var(--dashboard-example-ink-dim);
+    font-family  : var(--dashboard-example-font-mono);
     letter-spacing: .08em;
     text-transform: uppercase;
 }
 
 .agentos-dockdemo-clock-pane {
     align-items    : center;
-    background: var(--fm-panel-2);
+    background: var(--dashboard-example-panel-2);
     display   : flex;
     flex-direction : column;
     gap            : 6px;
     justify-content: center;
 
     .agentos-dockdemo-clock-label {
-        color         : var(--fm-ink-dim);
-        font-family   : var(--fm-font-mono);
+        color         : var(--dashboard-example-ink-dim);
+        font-family   : var(--dashboard-example-font-mono);
         font-size     : 12px;
         letter-spacing: .14em;
         text-transform: uppercase;
     }
 
     .agentos-dockdemo-clock-time {
-        color      : var(--fm-signal);
-        font-family: var(--fm-font-mono);
+        color      : var(--dashboard-example-signal);
+        font-family: var(--dashboard-example-font-mono);
         font-size  : 34px;
         font-weight: 600;
         // the witness must stay readable while panes glide — tabular digits prevent jitter
@@ -121,8 +120,8 @@
     }
 
     .agentos-dockdemo-clock-note {
-        color      : var(--fm-ink-dim);
-        font-family: var(--fm-font-mono);
+        color      : var(--dashboard-example-ink-dim);
+        font-family: var(--dashboard-example-font-mono);
         font-size  : 11px;
     }
 }

--- a/resources/scss/src/examples/dashboard/crossWindow/DemoBWorkspace.scss
+++ b/resources/scss/src/examples/dashboard/crossWindow/DemoBWorkspace.scss
@@ -1,54 +1,54 @@
 // Demo-B perspectives + pop-out showcase — the hooks Demo A's skin does not carry.
-// Same discipline: fleet-manager module tokens only, theme variance rides the token layer.
+// Same discipline: dashboard-example tokens only; theme variance rides the example-owned layer.
 
 .agentos-dockdemo-switcher {
-    background   : var(--fm-panel);
-    border-bottom: 1px solid var(--fm-line);
+    background   : var(--dashboard-example-panel);
+    border-bottom: 1px solid var(--dashboard-example-line);
     flex   : 0 0 auto;
     height : 44px;
     padding: 6px 12px;
 
     .agentos-dockdemo-switcher-label {
-        color         : var(--fm-ink-dim);
-        font-family   : var(--fm-font-mono);
+        color         : var(--dashboard-example-ink-dim);
+        font-family   : var(--dashboard-example-font-mono);
         font-size     : 11px;
         letter-spacing: .08em;
         text-transform: uppercase;
     }
 
     .agentos-dockdemo-switcher-btn {
-        background   : var(--fm-panel-2);
-        border       : 1px solid var(--fm-line);
+        background   : var(--dashboard-example-panel-2);
+        border       : 1px solid var(--dashboard-example-line);
         border-radius: 6px;
-        color        : var(--fm-ink);
-        font-family  : var(--fm-font-mono);
+        color        : var(--dashboard-example-ink);
+        font-family  : var(--dashboard-example-font-mono);
         margin-left  : 6px;
 
         .neo-button-text {
-            color: var(--fm-ink);
+            color: var(--dashboard-example-ink);
         }
     }
 }
 
 .agentos-dockdemo-restore-report {
-    background : color-mix(in srgb, var(--fm-signal) 10%, var(--fm-panel));
-    border-bottom: 1px solid var(--fm-line);
-    color      : var(--fm-ink);
+    background : color-mix(in srgb, var(--dashboard-example-signal) 10%, var(--dashboard-example-panel));
+    border-bottom: 1px solid var(--dashboard-example-line);
+    color      : var(--dashboard-example-ink);
     flex       : 0 0 auto;
-    font-family: var(--fm-font-mono);
+    font-family: var(--dashboard-example-font-mono);
     font-size  : 11px;
     line-height: 1.45;
     padding    : 7px 12px;
 
     strong {
-        color: var(--fm-signal);
+        color: var(--dashboard-example-signal);
     }
 }
 
 .agentos-dockdemo-counter-pane {
     align-items    : center;
-    background     : var(--fm-panel);
-    border         : 1px solid var(--fm-line-soft);
+    background     : var(--dashboard-example-panel);
+    border         : 1px solid var(--dashboard-example-line-soft);
     border-radius  : 8px;
     display        : flex;
     flex-direction : column;
@@ -56,21 +56,21 @@
     justify-content: center;
 
     .agentos-dockdemo-counter-label {
-        color         : var(--fm-ink-dim);
-        font-family   : var(--fm-font-mono);
+        color         : var(--dashboard-example-ink-dim);
+        font-family   : var(--dashboard-example-font-mono);
         font-size     : 12px;
         letter-spacing: .12em;
     }
 
     .agentos-dockdemo-counter-value {
-        color      : var(--fm-signal);
-        font-family: var(--fm-font-mono);
+        color      : var(--dashboard-example-signal);
+        font-family: var(--dashboard-example-font-mono);
         font-size  : 34px;
         font-weight: 700;
     }
 
     .agentos-dockdemo-counter-note {
-        color      : var(--fm-ink-dim);
+        color      : var(--dashboard-example-ink-dim);
         font-size  : 11px;
         font-style : italic;
     }
@@ -78,7 +78,7 @@
 
 // the pop-out window: a bare stage for the reparented pane — full-bleed, token ground
 .agentos-dockdemo-popout-host {
-    background: var(--fm-ground);
+    background: var(--dashboard-example-ground);
     padding   : 10px;
 
     > * {
@@ -92,7 +92,7 @@
 // (display:none / visibility:hidden would silence the live region — this deliberately is
 // a one-line, low-emphasis strip instead of a visually-hidden clip)
 .agentos-dockdemo-kbd-live {
-    color     : var(--fm-ink-dim);
+    color     : var(--dashboard-example-ink-dim);
     font-size : 11px;
     min-height: 14px;
     padding   : 0 12px;

--- a/resources/scss/theme-neo-dark/examples/dashboard/Palette.scss
+++ b/resources/scss/theme-neo-dark/examples/dashboard/Palette.scss
@@ -1,0 +1,15 @@
+:root .neo-theme-neo-dark {
+    // Example-owned palette: the relocated dashboard demos are standalone theme authorities.
+    // Values intentionally preserve their shipped FM-era appearance, but ownership is local —
+    // product palette drift must never silently restyle a copyable engine example.
+    --dashboard-example-ground   : #0b0e13;
+    --dashboard-example-panel    : #141a23;
+    --dashboard-example-panel-2  : #1a212c;
+    --dashboard-example-line     : #262f3d;
+    --dashboard-example-line-soft: #1c242f;
+    --dashboard-example-ink      : #d6dce6;
+    --dashboard-example-ink-dim  : #8b97a8;
+    --dashboard-example-signal   : #5eead4;
+    --dashboard-example-font-mono: ui-monospace, "SF Mono", Menlo, Consolas, monospace;
+    --dashboard-example-font-sans: system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
+}

--- a/resources/scss/theme-neo-light/examples/dashboard/Palette.scss
+++ b/resources/scss/theme-neo-light/examples/dashboard/Palette.scss
@@ -1,0 +1,14 @@
+:root .neo-theme-neo-light {
+    // Example-owned daylight palette. It mirrors the dark layer's semantic vocabulary while
+    // remaining independent from every product app's tokens and future palette changes.
+    --dashboard-example-ground   : #f2f5f9;
+    --dashboard-example-panel    : #ffffff;
+    --dashboard-example-panel-2  : #f7f9fc;
+    --dashboard-example-line     : #d3dae4;
+    --dashboard-example-line-soft: #e4e9f0;
+    --dashboard-example-ink      : #1f2733;
+    --dashboard-example-ink-dim  : #5a6b80;
+    --dashboard-example-signal   : #0f766e;
+    --dashboard-example-font-mono: ui-monospace, "SF Mono", Menlo, Consolas, monospace;
+    --dashboard-example-font-sans: system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
+}

--- a/test/playwright/e2e/dashboard/DockStandaloneThemingNL.spec.mjs
+++ b/test/playwright/e2e/dashboard/DockStandaloneThemingNL.spec.mjs
@@ -164,3 +164,150 @@ test.describe('Dock standalone theming — the values layer (Neural Link)', () =
         expect(chevronColor, 'the chevron falls back to the structure literal (#4493f8)').toBe(FALLBACK_PAINT);
     });
 });
+
+/**
+ * The relocated-example palette boundary (ticket-ref-ok: #17573): Demo A and Demo B must
+ * render from an example-owned theme file, never from the Fleet Manager's Viewport sheet.
+ *
+ * The positive matrix observes both the worker-owned workspace instance and browser paint under
+ * both primary themes. The mutation cell replaces only the new palette sheet with an empty 200
+ * response; the token and its resulting paint must disappear, proving the positive assertions
+ * would fail if the example-owned layer were removed.
+ */
+test.describe('Relocated dock examples — example-owned palette (Neural Link)', () => {
+    test.setTimeout(90000);
+
+    const EXAMPLES = [{
+              appName      : 'Neo.examples.dashboard.choreography',
+              className    : 'Neo.examples.dashboard.choreography.DemoAWorkspace',
+              configPath   : path.resolve(__dirname, '../../../../examples/dashboard/choreography/neo-config.json'),
+              configRoute  : '**/examples/dashboard/choreography/neo-config.json*',
+              paintSelector: '.agentos-dockdemo-pane',
+              slug         : 'choreography',
+              url          : '/examples/dashboard/choreography/'
+          }, {
+              appName      : 'Neo.examples.dashboard.crossWindow',
+              className    : 'Neo.examples.dashboard.crossWindow.DemoBWorkspace',
+              configPath   : path.resolve(__dirname, '../../../../examples/dashboard/crossWindow/neo-config.json'),
+              configRoute  : '**/examples/dashboard/crossWindow/neo-config.json*',
+              paintSelector: '.agentos-dockdemo-pane',
+              slug         : 'cross-window',
+              url          : '/examples/dashboard/crossWindow/'
+          }],
+          EXPECTATIONS = {
+              'neo-theme-neo-dark': {
+                  background: 'rgb(11, 14, 19)',
+                  ground    : '#0b0e13',
+                  panel     : '#141a23',
+                  panelPaint: 'rgb(20, 26, 35)',
+                  signal    : '#5eead4'
+              },
+              'neo-theme-neo-light': {
+                  background: 'rgb(242, 245, 249)',
+                  ground    : '#f2f5f9',
+                  panel     : '#ffffff',
+                  panelPaint: 'rgb(255, 255, 255)',
+                  signal    : '#0f766e'
+              }
+          },
+          PALETTE_REQUEST = '**/css/theme-neo-*/examples/dashboard/Palette.css*';
+
+    /**
+     * Boots one relocated example under one pinned theme and binds NL to its exact worker.
+     * @param {Object} page
+     * @param {Object} neuralLink
+     * @param {Object} example
+     * @param {String} theme
+     * @param {Object} [options]
+     * @param {Boolean} [options.blockPalette=false]
+     * @returns {Promise<{app: Object, workspaceId: String}>}
+     */
+    async function bootRelocatedExample(page, neuralLink, example, theme, {blockPalette = false} = {}) {
+        const config = {...JSON.parse(fs.readFileSync(example.configPath, 'utf8')), themes: [theme]};
+
+        await page.route(example.configRoute, route =>
+            route.fulfill({contentType: 'application/json', body: JSON.stringify(config)})
+        );
+
+        if (blockPalette) {
+            await page.route(PALETTE_REQUEST, route =>
+                route.fulfill({contentType: 'text/css', body: '/* mutation: example palette defines nothing */'})
+            )
+        }
+
+        await page.goto(example.url);
+        await page.waitForSelector('.agentos-dockdemo-workspace', {timeout: 30000});
+        await page.evaluate(() => document.fonts.ready);
+
+        const app         = await neuralLink.connectToApp(example.appName),
+              found       = await app.findInstances({className: example.className}, ['id']),
+              workspaceId = Array.isArray(found) ? found[0]?.id : found?.id;
+
+        expect(workspaceId, `${example.slug} workspace must exist in the App Worker`).toBeTruthy();
+
+        return {app, workspaceId}
+    }
+
+    for (const example of EXAMPLES) {
+        for (const [theme, expected] of Object.entries(EXPECTATIONS)) {
+            test(`${example.slug} owns its ${theme} palette — worker token + browser paint`, async ({page, neuralLink}) => {
+                const {app, workspaceId} = await bootRelocatedExample(page, neuralLink, example, theme);
+
+                const sheetUrls = await page.evaluate(() =>
+                    [...document.styleSheets].map(sheet => sheet.href || '')
+                );
+
+                expect(
+                    sheetUrls.filter(url => url.includes('/apps/agentos/')),
+                    'a standalone example must load zero AgentOS product stylesheets'
+                ).toEqual([]);
+                expect(
+                    sheetUrls.some(url => url.includes('/examples/dashboard/Palette.css')),
+                    'the example-owned palette stylesheet is present'
+                ).toBe(true);
+
+                const workerStyles = await app.getComputedStyles(workspaceId, [
+                    '--dashboard-example-ground',
+                    '--dashboard-example-panel',
+                    '--dashboard-example-signal',
+                    'background-color'
+                ]);
+                expect(workerStyles['--dashboard-example-ground']).toBe(expected.ground);
+                expect(workerStyles['--dashboard-example-panel']).toBe(expected.panel);
+                expect(workerStyles['--dashboard-example-signal']).toBe(expected.signal);
+                expect(workerStyles['background-color']).toBe(expected.background);
+
+                const browserPaint = await page.locator(example.paintSelector).first().evaluate(node => {
+                    const style = getComputedStyle(node);
+                    return {
+                        background: style.backgroundColor,
+                        panel     : style.getPropertyValue('--dashboard-example-panel').trim()
+                    }
+                });
+                expect(browserPaint.panel).toBe(expected.panel);
+                expect(browserPaint.background).toBe(expected.panelPaint)
+            })
+        }
+    }
+
+    test('MUTATION control: removing the example palette removes its token and ground paint', async ({page, neuralLink}) => {
+        const example            = EXAMPLES[0],
+              {app, workspaceId} = await bootRelocatedExample(
+                  page,
+                  neuralLink,
+                  example,
+                  'neo-theme-neo-dark',
+                  {blockPalette: true}
+              ),
+              workerStyles      = await app.getComputedStyles(workspaceId, [
+                  '--dashboard-example-ground',
+                  'background-color'
+              ]);
+
+        expect(workerStyles['--dashboard-example-ground'] || '', 'the blocked palette token is absent').toBe('');
+        expect(
+            workerStyles['background-color'],
+            'the workspace cannot keep the positive dark ground when the palette is empty'
+        ).not.toBe(EXPECTATIONS['neo-theme-neo-dark'].background)
+    })
+});


### PR DESCRIPTION
Resolves #17573

The relocated choreography and cross-window demos now load one example-owned `Neo.examples.dashboard.Palette` instead of the Fleet Manager viewport sheet. Both structural skins consume ten `--dashboard-example-*` tokens supplied by dark/light example layers; the engine-owned `Neo.dashboard.Container` dependency remains unchanged.

Evidence: L3 achieved (live in-app Browser + Neural Link computed-style and palette-removal mutation receipts on both relocated examples) → L3 required (AC-2/AC-3 rendered independence). No residuals.

## AC Evidence
| AC-1 | Source + live runtime: both `additionalThemeFiles` arrays contain `Neo.examples.dashboard.Palette` and `Neo.dashboard.Container`; neither contains `AgentOS.view.Viewport`. |
| AC-2 | Outside CI: both examples rendered with `--dashboard-example-ground: #0b0e13`, panel `#141a23`, signal `#5eead4`, workspace `rgb(11, 14, 19)`, pane `rgb(20, 26, 35)`, and zero `/apps/agentos/` stylesheets. The committed whitebox matrix covers both primary themes. |
| AC-3 | Outside CI mutation: emptying only the generated palette sheets changed all three tokens to empty strings and the workspace ground to transparent; rebuilding themes restored `#0b0e13` / `rgb(11, 14, 19)`. The committed mutation route encodes the same red control. |
| AC-4 | Decision recorded here and beside the palette: use one shared example-owned layer. Workstation's byte-identical but app-owned palette is the live precedent; promotion would invent a global vocabulary, while per-demo copies would create two owners. |
| AC-5 | Source census: zero `--fm-*` references remain under `resources/scss/src/examples/**`; dark/light definition sets are identical, with zero undefined uses and zero unused definitions. |

## Deltas from ticket

Selected candidate 1, but one shared dashboard-example palette serves both demos rather than duplicating ten values per example. Extended the existing standalone-theming whitebox spec instead of creating a second theming suite.

## Test Evidence

- Live dark-theme Browser + Neural Link receipts for choreography and cross-window, including exact tokens, workspace/pane paint, runtime theme dependencies, stylesheet URLs, and zero console errors.
- Live mutation control described in AC-3.
- The repository's real-Chrome E2E command reached no page: all eight cells—including the three untouched existing cells—aborted at browser launch with `SIGABRT`; no assertion executed. This is the recorded host ceiling, not a product/test verdict. `--list` discovers all eight cells successfully.

## Post-Merge Validation

None — all close-target ACs have pre-merge evidence.

Authored by Euclid (OpenAI GPT-5.6 Sol, Codex Desktop). Session 076dc295-9238-462e-b84f-1081475afe53.
