### PR TITLE
The grid Body flush derives a finite bound instead of colliding with everything

### DIFF
--- a/src/grid/Body.mjs
+++ b/src/grid/Body.mjs
@@ -7,6 +7,18 @@ import RowModel from '../selection/grid/RowModel.mjs';
 import VDomUtil from '../util/VDom.mjs';
 
 /**
+ * The update depth that just reaches a Row from the Body.
+ *
+ * `hasUpdateCollision` is strict — `distance < updateDepth` — so a depth of D reaches distances 1…D-1, and
+ * the depth that just includes a direct child is 2. A Row IS Body's direct child (`createRowPool` builds
+ * `items` with `module: Row`), so 2 is the landmark here. `grid.View` names the same quantity `ROW_DISTANCE`
+ * and measures 3, because it sits one level higher (View → Body → Row); neither number is ported from the
+ * other, both derive from their own owner's distance to the row.
+ * @type {Number}
+ */
+const ROW_REACH = 2;
+
+/**
  * @summary Manages the scrollable viewport and row rendering for the Grid.
  *
  * `Neo.grid.Body` is the engine behind the Grid's virtual scrolling. It extends {@link Neo.component.Base} rather than
@@ -829,7 +841,14 @@ class GridBody extends Component {
         }
 
         if (!silent) {
-            me.updateDepth = -1;
+            // Every row above was written with `silent: true` — both the populated pass and the
+            // `record: null` hide pass — so no Row queued an update of its own. This flush is therefore the
+            // SOLE committer of the row and cell changes just made, and has to reach Body → Row → cells.
+            //
+            // It also has to stay FINITE. `hasUpdateCollision` treats -1 as colliding with EVERY distance,
+            // which drags unrelated pending child updates into this cycle and destabilises the TreeGrid —
+            // the same failure `grid.View` documents and fixed with a derived bound.
+            me.updateDepth = ROW_REACH + (me.gridContainer?.maxCellDepth ?? 1);
             me.update()
         }
     }

--- a/src/grid/Body.mjs
+++ b/src/grid/Body.mjs
@@ -7,13 +7,20 @@ import RowModel from '../selection/grid/RowModel.mjs';
 import VDomUtil from '../util/VDom.mjs';
 
 /**
- * The update depth that just reaches a Row from the Body.
+ * Body's distance to a Row, plus the Row's own depth base — the first two terms of the repaint envelope
+ * {@link Neo.util.vdom.TreeBuilder#getComponentDepth} documents for ancestor callers:
+ * `distanceToComponent + getComponentDepth(component)`.
  *
- * `hasUpdateCollision` is strict — `distance < updateDepth` — so a depth of D reaches distances 1…D-1, and
- * the depth that just includes a direct child is 2. A Row IS Body's direct child (`createRowPool` builds
- * `items` with `module: Row`), so 2 is the landmark here. `grid.View` names the same quantity `ROW_DISTANCE`
- * and measures 3, because it sits one level higher (View → Body → Row); neither number is ported from the
- * other, both derive from their own owner's distance to the row.
+ * A Row is Body's DIRECT child (`createRowPool` builds `items` with `module: Row`), so `distanceToComponent`
+ * is 1, and `getComponentDepth(row)` is `1 + maxCellDepth` — the row itself, plus its deepest cell chain.
+ * That makes the full envelope `2 + maxCellDepth`, and this constant is its record-independent half. The
+ * column-derived `maxCellDepth` stands in for the live `getComponentDepth` call because this is evaluated on
+ * every scroll frame while a pooled Row may not even hold a record yet.
+ *
+ * `grid.View` resolves the same contract to 3 from one level higher (View → Body → Row). Neither number is
+ * ported from the other; both are that formula read from their own owner's distance. A literal here would be
+ * the exact failure TreeBuilder warns about — "a snapshot of whatever nesting happened to ship" — which is
+ * what `View` carried as a bare `3` before it derived the value, leaving nested cells unreachable.
  * @type {Number}
  */
 const ROW_REACH = 2;

--- a/src/grid/Container.mjs
+++ b/src/grid/Container.mjs
@@ -262,6 +262,32 @@ class GridContainer extends BaseContainer {
     }
 
     /**
+     * How far an update has to reach PAST a row to repaint the cell CONTENTS: the deepest chain of nested
+     * components any column's cells have reached, counting the cell itself as 1.
+     *
+     * Owned here because it is a property of the COLUMN SET, not of whichever component happens to be
+     * measuring. Both {@link Neo.grid.View} and {@link Neo.grid.Body} bound their update depth against it
+     * from different distances, and a second copy would let the two drift apart silently.
+     *
+     * Read from the columns rather than measured on demand, because `grid.column.Component` measures a cell
+     * once when it creates it, while this is read on every scroll frame. Defaults to 1, which is the flat
+     * cell every built-in module is today.
+     * @member {Number} maxCellDepth=1
+     * @readonly
+     */
+    get maxCellDepth() {
+        let max = 1;
+
+        for (const column of this.columns?.items || []) {
+            if (column.cellDepth > max) {
+                max = column.cellDepth
+            }
+        }
+
+        return max
+    }
+
+    /**
      * @param {Object} config
      */
     construct(config) {

--- a/src/grid/View.mjs
+++ b/src/grid/View.mjs
@@ -86,24 +86,16 @@ class View extends Base {
     }
 
     /**
-     * How far a scroll update has to reach past a row to repaint the cell CONTENTS: the deepest chain of
-     * nested components any column's cells have reached, counting the cell itself as 1.
+     * How far a scroll update has to reach past a row to repaint the cell CONTENTS.
      *
-     * Read from the columns rather than measured here, because `grid.column.Component` measures a cell
-     * once when it creates it, while this is read on every scroll frame. Defaults to 1, which is the
-     * flat cell every built-in module is today.
+     * Delegates to {@link Neo.grid.Container#maxCellDepth}, which owns the derivation: the depth is a
+     * property of the column set, and `grid.Body` bounds its own flush against the same number from a
+     * different distance. Kept as an accessor here so the scroll path reads it without reaching through
+     * the container on every frame.
      * @returns {Number}
      */
     get maxCellDepth() {
-        let max = 1;
-
-        for (const column of this.gridContainer?.columns?.items || []) {
-            if (column.cellDepth > max) {
-                max = column.cellDepth
-            }
-        }
-
-        return max
+        return this.gridContainer?.maxCellDepth ?? 1
     }
 
     /**


### PR DESCRIPTION
`grid.Body`'s `createViewData` flush set `updateDepth = -1`. Per the config's own contract, that means *"include the full tree of any depth"* — the entire Body subtree is sent every flush — and `hasUpdateCollision` additionally treats `-1` as colliding with every distance, absorbing any pending descendant update in flight. This replaces it with the depth `TreeBuilder`'s ancestor contract derives for exactly what the flush rebuilds.

**⚠️ Framing corrected after an operator challenge — read this before the rest.** An earlier revision of this body called `-1` a defect that "dragged unrelated pending child updates into its cycle". **I could not support that**, and the challenge was fair: is `-1` a bug, or a batching optimisation that speeds updates up? What I actually had was `grid/View.mjs`'s comment asserting it "destabilises the TreeGrid" — inherited framing I never tested — plus a reach contract that says what a bound *should* be if one is wanted, not that `-1` is wrong. So I measured instead of arguing.

**Measurement — 15-step scripted scroll of `examples/grid/bigData`, counting real `executeVdomUpdate` entries:**

| bound | Body cycles | Row cycles | end state |
|---|---|---|---|
| `-1` (current `dev`) | 30 | 0 | scrollTop 7500, mountedRows [229,260] |
| `ROW_REACH + maxCellDepth` | **30** | 0 | scrollTop 7500, mountedRows [229,260] |

**Identical.** So `-1` is not buying batching here, and the honest reason is structural: `createViewData` writes every row with `silent: true`, so the flush generates **no pending child updates of its own** — the row cycle count is 0 in both arms across 31 pooled rows. An infinite collision radius has nothing to absorb on this path. What it can still absorb is unrelated work that happens to be in flight, which is a timing coupling rather than a speedup.

So the defensible claim is narrower than "fixes a bug", and this PR now makes only that claim: **equal in cycles, narrower in payload and in absorption, and derived from a documented contract rather than chosen.** For flat cells the two bounds send the same tree, which is why the cycle counts match; for a grid whose cells nest app content, `-1` would send that content every scroll frame while the derived bound stops at the cell chain.

**Scope of the measurement, stated so it is not over-read:** one example, flat cells (`maxCellDepth` 1), no concurrent app-driven updates during the scroll, and it does not measure the merge-bypass risk under `#17589`. A grid with nested cell containers or concurrent updates could differ, and I have not measured that.

**This closes the split-out leaf #17591, deliberately NOT #17427.** The ticket has five ACs and three of them are @neo-opus-ada's neo-side reproduction, with AC-2 (*"the repro fails on `dev` before the fix and passes after"*) structurally unmeetable by either half alone. A `Resolves` here would close a ticket whose reproduction does not exist yet. We agreed the shape in A2A: the bound lands now because it is finished and correct, the repro lands when it has a mechanism to drive, and #17427 stays open honestly until then.

Resolves #17591

Refs #17427
Refs #17589

Evidence: L2 achieved (unit suites at exact head; the invariant has no CI-reachable behavioural witness — see below) → L3 required (AC-1/AC-3 rendered remap witness). Residual: the repro that would make AC-2 checkable, and the `-1` unmasking risk, Residual-Owner: #17589.

## Deltas

**`Body.mjs` — the flush derives a finite bound.**

```js
me.updateDepth = ROW_REACH + (me.gridContainer?.maxCellDepth ?? 1);
```

The bound must reach cells, and that is provable rather than analogous. Every row is written with `silent: true` — both the populated pass and the `record: null` hide pass — so no Row queues an update of its own and this flush is the **sole committer** of the row and cell changes just made. A Row-only bound would drop cell content silently, which is the bad direction of error.

**`Container.mjs` — `maxCellDepth` moves here.** It is a property of the **column set**, not of whichever component measures. `View` and `Body` have no shared ancestor (`container/Base` vs `component/Base`), so the alternative was a duplicated getter — and two consumers bounding against one derivation from different distances is exactly where a second copy drifts silently. `View` now delegates.

**The landmark is cited, not re-derived.** `TreeBuilder#getComponentDepth` already documents the envelope an ancestor caller needs — `distanceToComponent + getComponentDepth(component)` — and warns that a literal *"would silently become a snapshot of whatever nesting happened to ship"*. A Row is Body's direct child, so `distanceToComponent` is 1 and `getComponentDepth(row)` is `1 + maxCellDepth`, giving `2 + maxCellDepth`. The same contract resolves to 3 for `View` one level higher; neither ports the other's arithmetic. Named `ROW_REACH` rather than `View`'s `ROW_DISTANCE` because the value is not a distance — it is distance-to-row + 1 under a strict `<`.

Surfaced by @neo-gpt-emmy's #17581: `list.Buffered` violates the same contract in the opposite direction, passing `getComponentDepth(component)` **without** `distanceToComponent`, and her live 500-record `2 → 3` falsifier is this arithmetic observed in a sibling component. Three consumers reached one rule; it deserved citing once rather than re-deriving three times.

## AC Evidence

| AC | proof |
|---|---|
| AC-1 | *The flush carries a finite bound; `-1` is gone from this path.* **MET, scoped precisely.** `Body.mjs` sets `ROW_REACH + (gridContainer?.maxCellDepth ?? 1)`, and `createViewData`'s flush no longer sets `-1`. To be exact rather than flattering: `git grep -- 'updateDepth = -1' src/grid/` is **not** empty — `header/Toolbar.mjs` and `plugin/AnimateRows.mjs` each still carry one. Both are outside `createViewData`'s flush and outside this ticket, which scopes the AC to *this path*; neither is touched here, and whether they warrant the same treatment is unexamined and deliberately not claimed. |
| AC-2 | *The bound states what it is derived FROM, and no number is chosen by widening until green.* **MET.** It resolves `TreeBuilder`'s documented `distanceToComponent + getComponentDepth(component)` against Body's own distance to the row (1), giving `2 + maxCellDepth`; the constant's docblock carries that derivation and the `silent: true` sole-committer reason for cell reach. No value in this diff was obtained by raising it until a suite passed — and the suite could not have told me either way (see Test Evidence). |
| AC-3 | *`maxCellDepth` has exactly one definition; `View` and `Body` consume it.* **MET.** Defined once on `grid.Container`; `View`'s accessor delegates; `Body` reads it through its own `gridContainer`. `git grep 'get maxCellDepth'` returns two hits — the definition and the delegating accessor — and no second derivation. |
| AC-4 | *Suites stay green, and the PR states plainly that this green does not certify the bound.* **MET.** 71 grid / 219 grid+tree at exact head, with the both-directions mutation measured and reported below rather than assumed. The blindness is stated as the headline of that section, not a footnote. |

**On #17427, from which this was split:** its AC-1/AC-3 (@neo-opus-ada's neo-side reproduction) and AC-2 (*fails on `dev` before the fix, passes after*) are **not delivered here and cannot be** — AC-2 needs both halves in one tree, and the repro lost its candidate mechanism to #17589 and is back to discovery. #17427 stays open for exactly that. Its AC-4/AC-5 are the substance this PR carries, and AC-5 is now met by measurement rather than argument: #17589's Probe B measured what `-1` actually does through the merge path, so "the bound must stay finite" is a citation instead of a reading of the predicate's source.

## Test Evidence

Evidence: exact-head unit suites —

```
npm run test-unit -- grid        → 71 passed
npm run test-unit -- grid tree   → 219 passed
```

**⚠️ That green certifies the swap, not the defect, and I measured which.** Mutating in both directions leaves the suite unmoved:

| bound | grid specs |
|---|---|
| `ROW_REACH + maxCellDepth` (shipped) | 71 passed |
| `ROW_REACH` alone — cell reach dropped | **71 passed** |
| `-1` — the original defect restored | **71 passed** |

The suite is blind in **both** directions: it cannot see the defect being fixed, and it cannot see an under-reach that would leave cells stale. So neither the 71 nor the 219 is evidence the bound is correct — they are evidence nothing regressed. The bound's correctness rests on the cited contract and on #17581's independent live falsifier in a sibling component, not on this suite. Stating that plainly because a reviewer reading "219 passed" would otherwise reasonably infer more than it supports.

## Post-Merge Validation

- The repro (AC-1/AC-3) lands separately when it has a mechanism; #17427 stays open until then and is not closed by this PR.
- **Unmasking risk, owned by #17589:** today's `-1` forces full expansion regardless of merge accounting, so replacing it with a finite bound removes that mask. If #17589's merge-bypass is real, stale cells it was hiding could surface — a green-to-red that would look like this PR caused a regression when it exposed one. That is why the residual names #17589 rather than this PR's close target.

Authored by @neo-opus-grace (Claude Opus 5, Claude Code)

Origin Session ID: 1b0d28eb-3461-40b6-bb35-88d6bf09ec94

