### PR TITLE
feat(build): preflight names the silent structural layer and its anchor-list artifacts (#17467)

### DIFF
--- a/ai/scripts/agent-preflight.mjs
+++ b/ai/scripts/agent-preflight.mjs
@@ -40,6 +40,40 @@ export const INVISIBLE_PR_BODY_ANCHORS = [
     '## Deltas'
 ];
 
+/** The artifact that actually carries the full anchor list (both layers). */
+export const PR_TEMPLATE_ASSET = '.github/PULL_REQUEST_TEMPLATE.md';
+
+/** The workflow section mirroring the same list for hosted lint runs. */
+export const PULL_REQUEST_WORKFLOW_REFERENCE =
+    '.github/workflows/agent-pr-body-lint.yml — mirrors pull-request-workflow.md §9';
+
+/**
+ * Guidance emitted when the structural (silent) anchor layer finds misses.
+ *
+ * Contract: states that the layer is checked silently and DELIBERATELY, so a reader stops
+ * concluding the tool is broken; points at the artifact that actually carries the anchor
+ * list rather than one indirection short of it; never names, counts, or hints at which
+ * anchors are missing — the silence is the mechanism, not a gap. Controls must assert no
+ * anchor literal from either list appears anywhere in this output.
+ *
+ * ticket-ref-ok: #11501 + #15828 are load-bearing here — citing them beside the emitter is
+ * the fix; without them a reader cannot distinguish deliberate silence from a broken tool.
+ *
+ * @returns {String[]}
+ */
+export function buildStructuralAnchorMissGuidance() {
+    return [
+        'agent-preflight: structural template anchors were checked silently and deliberately.',
+        'agent-preflight: misses on this layer are never named, counted, or hinted at — that',
+        'agent-preflight: silence is an anti-Goodhart guard by operator direction: naming an',
+        'agent-preflight: anchor lets an agent paste it instead of reading the template.',
+        'agent-preflight: the full anchor list lives in:',
+        `agent-preflight:   - ${PR_TEMPLATE_ASSET}`,
+        `agent-preflight:   - ${PULL_REQUEST_WORKFLOW_REFERENCE}`,
+        'agent-preflight: reread those before editing the body.'
+    ];
+}
+
 const
     // A REAL level-two heading on its own line. `indexOf` would anchor on the first substring, so a
     // body that merely quotes the heading in prose or a fenced block would have its section read
@@ -1293,7 +1327,9 @@ export function runAgentPreflight({
                 result.missingVisible.forEach(anchor => writeLine(stderr, `  - ${anchor}`));
             }
             if (result.missingInvisible.length > 0) {
-                writeLine(stderr, 'Structural template anchors are missing; reread .agents/skills/pull-request/SKILL.md before editing the body.');
+                // Deliberately generic about WHICH anchors missed — see the guidance builder's
+                // contract above; enumerating here would defeat the anti-stuffing guard.
+                buildStructuralAnchorMissGuidance().forEach(line => writeLine(stderr, line));
             }
         }
 

--- a/ai/scripts/agent-preflight.mjs
+++ b/ai/scripts/agent-preflight.mjs
@@ -40,8 +40,20 @@ export const INVISIBLE_PR_BODY_ANCHORS = [
     '## Deltas'
 ];
 
-/** The artifact that actually carries the full anchor list (both layers). */
-export const PR_TEMPLATE_ASSET = '.github/PULL_REQUEST_TEMPLATE.md';
+/**
+ * The agent-facing artifact that actually carries the full anchor list (both layers): §9
+ * holds the agent PR body template and the canonical anchor-list sentence.
+ *
+ * This repo has two PR-body templates with near-identical names and opposite audiences —
+ * the external-contributor `.github/PULL_REQUEST_TEMPLATE.md` (which carries none of the
+ * anchors and must never be copied into agent PRs) and the workflow §9 body template below.
+ * Routing readers to "the template" without naming the split has a 50% chance of handing
+ * them the wrong file.
+ *
+ * ticket-ref-ok: #15141 is the recorded failure that makes naming the split load-bearing here.
+ */
+export const PR_BODY_TEMPLATE_REFERENCE =
+    '.agents/skills/pull-request/references/pull-request-workflow.md — §9 carries the agent body template';
 
 /** The workflow section mirroring the same list for hosted lint runs. */
 export const PULL_REQUEST_WORKFLOW_REFERENCE =
@@ -68,7 +80,7 @@ export function buildStructuralAnchorMissGuidance() {
         'agent-preflight: silence is an anti-Goodhart guard by operator direction: naming an',
         'agent-preflight: anchor lets an agent paste it instead of reading the template.',
         'agent-preflight: the full anchor list lives in:',
-        `agent-preflight:   - ${PR_TEMPLATE_ASSET}`,
+        `agent-preflight:   - ${PR_BODY_TEMPLATE_REFERENCE}`,
         `agent-preflight:   - ${PULL_REQUEST_WORKFLOW_REFERENCE}`,
         'agent-preflight: reread those before editing the body.'
     ];

--- a/test/playwright/unit/ai/scripts/agent-preflight.spec.mjs
+++ b/test/playwright/unit/ai/scripts/agent-preflight.spec.mjs
@@ -472,7 +472,10 @@ test.describe('agent-preflight utility', () => {
         expect(status).toBe(1);
         expect(stderr).toContain('agent-preflight: PR body template lint failed.');
         expect(stderr).toContain('Visible/body-closing misses:');
-        expect(stderr).toContain('Structural template anchors are missing');
+        // Stable fragments of buildStructuralAnchorMissGuidance() output — the deliberate-
+        // silence contract plus the artifact pointer, not full sentences that redden on wording.
+        expect(stderr).toContain('checked silently and deliberately');
+        expect(stderr).toContain('.github/PULL_REQUEST_TEMPLATE.md');
         expect(stderr).toContain('agent-preflight: 1 gate(s) failed: pr-body')
     })
 });

--- a/test/playwright/unit/ai/scripts/agent-preflight.spec.mjs
+++ b/test/playwright/unit/ai/scripts/agent-preflight.spec.mjs
@@ -475,7 +475,7 @@ test.describe('agent-preflight utility', () => {
         // Stable fragments of buildStructuralAnchorMissGuidance() output — the deliberate-
         // silence contract plus the artifact pointer, not full sentences that redden on wording.
         expect(stderr).toContain('checked silently and deliberately');
-        expect(stderr).toContain('.github/PULL_REQUEST_TEMPLATE.md');
+        expect(stderr).toContain('pull-request-workflow.md');
         expect(stderr).toContain('agent-preflight: 1 gate(s) failed: pr-body')
     })
 });

--- a/test/playwright/unit/ai/scripts/agent-preflight.structuralAnchors.spec.mjs
+++ b/test/playwright/unit/ai/scripts/agent-preflight.structuralAnchors.spec.mjs
@@ -1,4 +1,5 @@
-import {expect, test}                                      from '@playwright/test';
+import {readFileSync} from 'node:fs';
+import {expect, test} from '@playwright/test';
 import {
     buildStructuralAnchorMissGuidance,
     INVISIBLE_PR_BODY_ANCHORS,
@@ -14,9 +15,15 @@ import {
  * policy honest — the message states the silence is deliberate, points at the artifact that
  * carries the full list, and leaks no anchor literal — plus the two guards against silent
  * collapse: the visible layer keeps enumerating, and a fully anchored body emits nothing.
+ *
+ * The route-following control encodes the review lesson from this guidance's first draft:
+ * a control over a POINTER must assert something about the TARGET, not the pointer text —
+ * `output contains '<path>'` stays green whether or not that file has anything to do with
+ * anchors, so the control reads the routed-to artifact and checks the anchors are there.
  */
 
 const allAnchorLiterals = [...VISIBLE_PR_BODY_ANCHORS, ...INVISIBLE_PR_BODY_ANCHORS];
+const AGENT_BODY_TEMPLATE_PATH = '../../../../../.agents/skills/pull-request/references/pull-request-workflow.md';
 
 const validBody = [
     'Resolves #100',
@@ -39,23 +46,36 @@ const validBody = [
 ].join('\n');
 
 test.describe('buildStructuralAnchorMissGuidance — silent-layer contract', () => {
-    test('states the silence is deliberate and points at the artifacts carrying the list', () => {
+    test('states the silence is deliberate and points at the artifact carrying the list', () => {
         const out = buildStructuralAnchorMissGuidance().join('\n');
 
         expect(out).toMatch(/silently and deliberately/i);
-        expect(out).toContain('.github/PULL_REQUEST_TEMPLATE.md');
+        // The agent-facing body template (workflow §9), never the external-contributor
+        // `.github/PULL_REQUEST_TEMPLATE.md` — that file carries 0/6 anchors and §9:278
+        // forbids copying it into agent PRs.
         expect(out).toContain('pull-request-workflow.md');
+        expect(out).not.toContain('.github/PULL_REQUEST_TEMPLATE.md');
+    });
+
+    test('the routed-to artifact actually carries the anchor list (route-following control)', () => {
+        const contents = readFileSync(new URL(AGENT_BODY_TEMPLATE_PATH, import.meta.url), 'utf8');
+
+        for (const literal of allAnchorLiterals) {
+            expect(contents.includes(literal), `"${literal}" missing from pull-request-workflow.md`).toBe(true);
+        }
     });
 
     test('never names, counts, or hints at which anchors are missing — zero literal leaks', () => {
         const out = buildStructuralAnchorMissGuidance().join('\n');
 
+        // Self-verifying control: an empty literal array would make the filter below pass vacuously.
+        expect(allAnchorLiterals.length).toBe(6);
         expect(allAnchorLiterals.filter(literal => out.includes(literal))).toEqual([]);
     });
 });
 
 test.describe('validatePrBody — collapse guards around the silent layer', () => {
-    test('the visible layer still enumerates its misses (must never collapse into one policy)', () => {
+    test('the computed visible layer still enumerates its misses (collapse guard; reporter enumeration asserted in agent-preflight.spec)', () => {
         const result = validatePrBody(validBody.replace(
             'Evidence: L2 local unit coverage.',
             'no evidence marker here'

--- a/test/playwright/unit/ai/scripts/agent-preflight.structuralAnchors.spec.mjs
+++ b/test/playwright/unit/ai/scripts/agent-preflight.structuralAnchors.spec.mjs
@@ -1,0 +1,83 @@
+import {expect, test}                                      from '@playwright/test';
+import {
+    buildStructuralAnchorMissGuidance,
+    INVISIBLE_PR_BODY_ANCHORS,
+    validatePrBody,
+    VISIBLE_PR_BODY_ANCHORS
+}                     from '../../../../../ai/scripts/agent-preflight.mjs';
+
+/**
+ * Controls for the structural-anchor layer's silent-miss guidance.
+ *
+ * The layer's silence is deliberate policy: naming a missing anchor lets an author paste it
+ * instead of reading the template. These controls pin the three properties that keep that
+ * policy honest — the message states the silence is deliberate, points at the artifact that
+ * carries the full list, and leaks no anchor literal — plus the two guards against silent
+ * collapse: the visible layer keeps enumerating, and a fully anchored body emits nothing.
+ */
+
+const allAnchorLiterals = [...VISIBLE_PR_BODY_ANCHORS, ...INVISIBLE_PR_BODY_ANCHORS];
+
+const validBody = [
+    'Resolves #100',
+    '',
+    'Authored by Eos (ox-alpha, opencode). Session test.',
+    '',
+    'Evidence: L2 local unit coverage.',
+    '',
+    '## AC Evidence',
+    '| AC-1 | unit spec: this file |',
+    '',
+    '## Deltas',
+    '- Delivered as requested.',
+    '',
+    '## Test Evidence',
+    '- npm run test-unit -- test/playwright/unit/ai/scripts/agent-preflight.structuralAnchors.spec.mjs',
+    '',
+    '## Post-Merge Validation',
+    '- None.'
+].join('\n');
+
+test.describe('buildStructuralAnchorMissGuidance — silent-layer contract', () => {
+    test('states the silence is deliberate and points at the artifacts carrying the list', () => {
+        const out = buildStructuralAnchorMissGuidance().join('\n');
+
+        expect(out).toMatch(/silently and deliberately/i);
+        expect(out).toContain('.github/PULL_REQUEST_TEMPLATE.md');
+        expect(out).toContain('pull-request-workflow.md');
+    });
+
+    test('never names, counts, or hints at which anchors are missing — zero literal leaks', () => {
+        const out = buildStructuralAnchorMissGuidance().join('\n');
+
+        expect(allAnchorLiterals.filter(literal => out.includes(literal))).toEqual([]);
+    });
+});
+
+test.describe('validatePrBody — collapse guards around the silent layer', () => {
+    test('the visible layer still enumerates its misses (must never collapse into one policy)', () => {
+        const result = validatePrBody(validBody.replace(
+            'Evidence: L2 local unit coverage.',
+            'no evidence marker here'
+        ));
+
+        expect(result.missingVisible).toContain('Evidence:');
+    });
+
+    test('a fully anchored body produces no misses in either layer (negative control)', () => {
+        const result = validatePrBody(validBody);
+
+        expect(result.missingVisible).toEqual([]);
+        expect(result.missingInvisible).toEqual([]);
+    });
+
+    test('a structural miss lands in the silent layer only — the finding is withheld from output shaping', () => {
+        const result = validatePrBody(validBody.replace('## Deltas\n- Delivered as requested.', '## Changed\n- Delivered as requested.'));
+
+        expect(result.missingInvisible).toContain('## Deltas');
+        expect(result.missingVisible).toEqual([]);
+        // The reporter renders buildStructuralAnchorMissGuidance() for exactly this branch;
+        // the guidance itself stays literal-free (asserted above), so the printed output
+        // names nothing even though the internal finding array must.
+    });
+});


### PR DESCRIPTION
Resolves #17467

The structural-anchor layer's failure message now states that the layer is checked silently and deliberately — an anti-Goodhart guard by operator direction, not a tool fault — and points at the artifact that actually carries the full anchor list (the agent PR body template in `pull-request-workflow.md` §9, plus its hosted lint mirror) instead of stopping one indirection short at SKILL.md. The guidance ships as an exported pure builder (`buildStructuralAnchorMissGuidance()`), making the no-leak contract directly assertable; the reporter branch consumes it verbatim. The governing decisions are cited beside the emitter under one `ticket-ref-ok` marker; neither is widened.

Evidence: L2 achieved (pure-builder controls + collapse guards + route-following control green via direct module execution; archaeology + whitespace hooks clean at this head) → L2 required (all six ACs static or unit-covered; the spec file is Brain-tier and arms in CI). Residual: none.

## AC Evidence
| AC-1 | CI: agent-preflight.structuralAnchors.spec.mjs — guidance asserts deliberate silence; anchor-literal leak filter returns empty across both lists |
| AC-2 | CI: same spec — output routes to `pull-request-workflow.md` (§9 agent body template) and never names `.github/PULL_REQUEST_TEMPLATE.md`; route-following control reads the routed-to file and asserts all six anchors present in it |
| AC-3 | CI: visible-layer control — missingVisible still enumerates ('Evidence:' miss case) |
| AC-4 | CI: negative control — fully anchored body yields zero misses in both layers |
| AC-5 | CI: rationale cited beside the emitter via single-line ticket-ref-ok JSDoc (#11501 + #15828); check-ticket-archaeology 0 violations at head |
| AC-6 | Outside-CI: local node receipt at 53a8d00102 — 8 guidance lines, leaked literals NONE, new pointer present, old misrouting pointer absent; literal-array length pinned at 6 |

## Deltas from ticket
- SKILL.md pointer replaced with the artifacts that carry the list — the ticket's own "one indirection short" finding.
- Guidance extracted as an exported pure builder rather than inline strings: required so the literal-leak control is deterministic without stream-mocking runAgentPreflight.
- Review round 1 (CHANGES_REQUESTED): pointer repointed from `.github/PULL_REQUEST_TEMPLATE.md` (0/6 anchors, external-contributor template forbidden in agent PRs) to the §9 agent body template; constant renamed `PR_TEMPLATE_ASSET` → `PR_BODY_TEMPLATE_REFERENCE`; JSDoc now names the two-template split; route-following control + vacuity guard added to the spec.

## Test Evidence
Local receipts at head 53a8d00102: builder 8 lines, leaked literals NONE, deliberately-silence present, new pointer present / misrouting pointer absent; six-literal grep vs routed target 6/6; validatePrBody negative control {visible: 0, invisible: 0}; visible-miss enumerates 'Evidence:'; structural miss lands in missingInvisible only while visible stays empty. check-ticket-archaeology: 0 violations at commit.

## Post-Merge Validation
None owed.

Authored by Eos (ox-alpha, opencode). Session f1a9e1b4-6734-4011-a1a0-7aa3b94f88f5.
