### PR TITLE
fix(test): assert the versioned fleet wire envelope in lifecycle e2e specs

### DIFF
--- a/test/playwright/e2e/agentos/FleetCardLifecycleNL.spec.mjs
+++ b/test/playwright/e2e/agentos/FleetCardLifecycleNL.spec.mjs
@@ -1,6 +1,6 @@
-import {test, expect}           from '../../fixtures.mjs';
-import {NeuralLink_DataService} from '../../../../ai/services.mjs';
-import {FLEET_WIRE_METHODS}     from '../../../../apps/agentos/config/fleetWireMethods.mjs';
+import {test, expect}                             from '../../fixtures.mjs';
+import {NeuralLink_DataService}                   from '../../../../ai/services.mjs';
+import {createFleetWireOffer, FLEET_WIRE_METHODS} from '../../../../apps/agentos/config/fleetWireMethods.mjs';
 import {
     authenticatedFleetOptions,
     fleetE2EFailure,
@@ -100,6 +100,12 @@ async function startLifecycleFleetBridge({rejectStart = false} = {}) {
  * @summary The retired panel spec's minimal-payload contract, re-homed onto the card path: a
  * lifecycle click crosses the fleet wire as the minimal agent-id operation — a registered wire
  * method carrying ONE string param, with no credential-shaped bytes.
+ *
+ * Minimal describes the PAYLOAD, never the envelope. Every browser-mode request also carries this
+ * realm's versioned protocol offer (`installFleetBridge` sends the full `createFleetWireRequest`
+ * result; only shell mode strips it back to method/params), so the offer is asserted through the
+ * exported builder rather than a literal — exact equality still rejects any extra key, and the next
+ * contract revision moves this expectation without touching the spec.
  * @param {Object} request The recorded loopback fleet request.
  * @param {String} [method='startAgent'] The expected registered lifecycle wire method.
  */
@@ -107,7 +113,8 @@ function expectMinimalLifecyclePayload(request, method = 'startAgent') {
     expect(FLEET_WIRE_METHODS).toContain(request.method);
     expect(request).toEqual({
         method,
-        params: TEST_AGENT_ID
+        params  : TEST_AGENT_ID,
+        protocol: createFleetWireOffer()
     });
     expect(typeof request.params).toBe('string');
     expect(JSON.stringify(request.params)).not.toMatch(/credential|pat|token/i)

--- a/test/playwright/e2e/agentos/FleetGridKeyboardA11y.spec.mjs
+++ b/test/playwright/e2e/agentos/FleetGridKeyboardA11y.spec.mjs
@@ -1,5 +1,6 @@
 import {test, expect}           from '../../fixtures.mjs';
 import {NeuralLink_DataService} from '../../../../ai/services.mjs';
+import {createFleetWireOffer}   from '../../../../apps/agentos/config/fleetWireMethods.mjs';
 import {
     authenticatedFleetOptions,
     fleetE2EFailure,
@@ -312,12 +313,21 @@ test.describe('AgentOS fleet roster — semantic list selection + stable animate
             selectedDisplay       = focusedRecord.displayName,
             bravoToggle           = bravoCard.locator('.fm-card-control-verbs button').first();
 
+        // ── LIFECYCLE ISOLATION: activating a control Button fires its lifecycle intent WITHOUT drilling ──
+        // Bravo is 'ok' → its toggle is the STOP verb. The test-owned bridge records exactly one
+        // minimal stop request and rejects it with a named reason; the detail must stay on the
+        // record selected before the control ran (no drill leakage), while Bravo renders the honest
+        // terminal rejection.
+        //
+        // Minimal is about the PAYLOAD: one agent id, no drill-shaped extras. The browser-mode
+        // envelope carries this realm's versioned protocol offer, asserted through the exported
+        // builder, so exact equality keeps rejecting stray keys without freezing a contract literal.
         await bravoToggle.focus();
         await page.keyboard.press('Enter');
         await expect.poll(
             () => fleet.requests.filter(request => ['startAgent', 'stopAgent', 'restartAgent'].includes(request.method)),
             {message: 'the lifecycle Button emits exactly one minimal Stop request'}
-        ).toEqual([{method: 'stopAgent', params: 'a11y-b'}]);
+        ).toEqual([{method: 'stopAgent', params: 'a11y-b', protocol: createFleetWireOffer()}]);
         expect((await selectionState()).selectedAgentId, 'control activation cannot change selection').toBe(selectedBeforeControl);
         await expect(page.locator('.fm-agent-detail')).toContainText(selectedDisplay);
         await expect(bravoCard.locator('.fm-card-control-status')).toContainText(


### PR DESCRIPTION
Resolves neomjs/neo#17598

Three AgentOS cockpit e2e tests failed on `dev` for one reason: the client wire contract grew a versioned `protocol` offer, and two lifecycle specs still asserted the pre-envelope request shape with `toEqual` exact equality. Both now assert the offer through the exported `createFleetWireOffer()` builder, so the expectation tracks the contract instead of freezing a snapshot of it.

Evidence: L3 achieved (the three affected tests run red→green on this branch, plus a mutation control proving the assertion reaches envelope **content** on the `versions` diff) → L3 required (a browser-capable seat re-runs the three specs on `dev` after merge as L3 **confirmation** of the same class of evidence; no e2e job exists in CI to do it). Residual: **none for neomjs/neo#17598** — all four ACs are met and verified. The 17 other AgentOS e2e reds are unrelated causes owned by tracker neomjs/neo-agent-brain#17; they are not residuals of this change.

**Why the builder and not a literal.** `installFleetBridge` sends the full `createFleetWireRequest` result in browser mode and strips it back to `{method, params}` only in shell mode, so any spec wiring an HTTP loopback observes the envelope. Exact equality is deliberately **kept** — it is what enforces the minimal-payload guarantee those specs exist for, and it still rejects any stray key. Absolute contract values stay owned by `lint-fleet-vocabulary-parity.mjs` and `fleetVocabularyParity.spec.mjs`, which compare the `ai/services/fleet` authority against the `apps/agentos/config` twin and already prove an insufficient offer fails closed via `unsupportedCapability`. Hardcoding capability strings here would duplicate that guard brittlely rather than add one.

## AC Evidence

| AC | Requirement | Evidence |
|---|---|---|
| AC-1 | The three tests pass on `dev` | `FleetCardLifecycleNL` (×2) + `FleetGridKeyboardA11y` — **3 failed → 3 passed** (7.9s). Confirmed again in the full-directory run, where neither spec appears among the 17 failures. |
| AC-2 | The assertions still reject a stray key — not weakened into `toMatchObject` permissiveness | `toEqual` is retained at both sites; only the expected value changed. `expectMinimalLifecyclePayload` still asserts exact equality plus `typeof params === 'string'` and the credential-shape guard, and `FleetGridKeyboardA11y` still asserts the whole recorded-request array. |
| AC-3 | A control proves the greened assertion can fail on envelope **content**, not merely presence | Mutated the expectation to `{...createFleetWireOffer(), versions: [99]}` → **1 failed**, with the reported diff on `"versions"`. Reverted. Presence-only sensitivity would not have produced that diff. |
| AC-4 | Both sites explain in-source that *minimal* describes the payload, not the envelope | `FleetCardLifecycleNL.spec.mjs` helper docblock and the `FleetGridKeyboardA11y.spec.mjs` assertion comment. Both describe the browser-mode/shell-mode split as the mechanism, with no ticket refs — `check-ticket-archaeology` rejects decay-prone refs in durable comments, so the ref lives in the commit subject and here. |

## Deltas from ticket

- **AC-4 wording.** The ticket asks both sites to explain in-source that *minimal* describes the payload, not the envelope. They do — but without citing the originating ticket number, because `check-ticket-archaeology` correctly rejects decay-prone refs in durable comments. The mechanism is described instead; the ref lives here and in the commit subject.
- **No other delta.** All four ACs are met as written.

## Test Evidence

Run locally with `npm run test-e2e -- <spec> --workers=1`; there is no e2e job in CI, so these numbers cannot be reproduced by a pipeline.

| arm | command scope | result |
|---|---|---|
| before | `FleetCardLifecycleNL` + `FleetGridKeyboardA11y` | **3 failed** |
| after | same | **3 passed** (7.9s) |
| non-vacuity control | `FleetGridKeyboardA11y` with the expectation mutated to `versions: [99]` | **1 failed**, diff on `"versions"` |
| full directory | `test/playwright/e2e/agentos` (45 spec files, 62 tests) | **45 passed, 17 failed** — neither fixed spec among the failures |

The control matters because presence-only sensitivity would not be enough: the mutated arm reddens on envelope *content*, so the assertion is not merely checking that a `protocol` key exists.

The 17 remaining failures are pre-existing and unrelated to this change; they are the corrected census now recorded on neomjs/neo-agent-brain#17 (which had listed five).

## Post-Merge Validation

- **L3 confirmation, not a handoff of unfinished work:** a browser-capable seat re-runs `npm run test-e2e -- FleetCardLifecycleNL FleetGridKeyboardA11y --workers=1` on `dev` and sees 3/3 — the same evidence class already achieved here, repeated against the merged tree because no CI job covers this layer.
- neomjs/neo-agent-brain#17 stays open and keeps the remaining AgentOS reds; this PR closes only the wire-envelope cause. The parent's own AC-1 prescribes exactly this carve.
- If a future revision changes `FLEET_WIRE_CAPABILITIES` or `FLEET_WIRE_PROTOCOL_VERSIONS`, these specs should need **no** edit. If they do, the builder-based expectation has been re-frozen somewhere and that is the regression to look for.

Authored by Grace (Claude Opus 5, Claude Code). Session 1b0d28eb-3461-40b6-bb35-88d6bf09ec94.
