### PR TITLE
feat(list): keep buffered rows in fixed DOM order (#17563)

### DIFF
--- a/src/list/Buffered.mjs
+++ b/src/list/Buffered.mjs
@@ -16,6 +16,11 @@ import TreeBuilder   from '../util/vdom/TreeBuilder.mjs';
  * reads the same order the operator sees without structural VDOM moves. Moving a range edge updates
  * bounded slot contents; it never creates one component per Store record.
  *
+ * Focus follows logical record identity when that record remains mounted. If it leaves the pooled
+ * range, focus retargets to the nearest mounted logical record and `focusIndex` changes with it. This
+ * keeps DOM focus and worker state coherent without snapping the operator's scroll position back to
+ * an offscreen record.
+ *
  * Consumers that need component rows provide {@link #itemConfig}: an object or function returning a
  * component config. The component is created once per physical slot and receives the current record
  * through {@link #recordProperty} on every recycle. Record-specific StateProvider bindings are not a
@@ -361,6 +366,8 @@ class Buffered extends ComponentList {
             records.push(store.getAt(index))
         }
 
+        const focusState = me.captureItemFocusState();
+
         me.trimComponentPool(poolSize);
 
         const assignments = me.assignPoolSlots(records, range[0], poolSize),
@@ -382,6 +389,7 @@ class Buffered extends ComponentList {
         }
 
         return me.promiseUpdate().then(data => {
+            me.restoreItemFocus(focusState);
             me.fire('createItems')
 
             return data
@@ -828,6 +836,84 @@ class Buffered extends ComponentList {
         }
 
         items.length = Math.min(items.length, poolSize)
+    }
+
+    /**
+     * Captures the logical record and physical slot which own focus before a range rebind. No slot
+     * means there is no mounted DOM target to reconcile after delivery.
+     * @returns {Object|null}
+     * @protected
+     */
+    captureItemFocusState() {
+        let me                  = this,
+            {focusIndex, store} = me;
+
+        if (focusIndex === null || !store) {
+            return null
+        }
+
+        const
+            logicalIndex = Neo.isNumber(focusIndex) ? focusIndex : store.indexOf(focusIndex),
+            record       = logicalIndex < 0 ? focusIndex : store.getAt(logicalIndex),
+            recordId     = record && me.getRecordId(record),
+            slot         = recordId === null || recordId === undefined
+                ? undefined
+                : me.recordSlotMap.get(me.toRecordMapKey(recordId));
+
+        return slot === undefined ? null : {focusIndex, logicalIndex, recordId, slot}
+    }
+
+    /**
+     * Reconciles DOM focus after fixed physical slots receive new logical records. A still-mounted
+     * focus owner moves to its new slot. An owner outside the range retargets to the nearest mounted
+     * logical record so the DOM target and `focusIndex` never describe different records. The main
+     * thread only performs the move while the captured old slot still owns browser focus.
+     * @param {Object|null} state Captured result from {@link #captureItemFocusState}.
+     * @protected
+     */
+    restoreItemFocus(state) {
+        if (!state) {
+            return
+        }
+
+        let me                         = this,
+            {store}                    = me,
+            [mountedStart, mountedEnd] = me.mountedRange,
+            slot                       = me.recordSlotMap.get(me.toRecordMapKey(state.recordId)),
+            logicalIndex;
+
+        if (!store || mountedStart === mountedEnd) {
+            me._focusIndex = null;
+            return
+        }
+
+        if (slot !== undefined) {
+            logicalIndex = mountedStart + slot
+        } else {
+            const record = store.get(state.recordId);
+
+            logicalIndex = record ? store.indexOf(record) : state.logicalIndex;
+            logicalIndex = Math.min(Math.max(logicalIndex < 0 ? mountedStart : logicalIndex, mountedStart), mountedEnd - 1);
+
+            const targetRecord = store.getAt(logicalIndex);
+
+            slot = targetRecord && me.recordSlotMap.get(me.toRecordMapKey(me.getRecordId(targetRecord)))
+        }
+
+        const retargeted = slot !== undefined && me.toRecordMapKey(me.slotRecordIds[slot]) !== me.toRecordMapKey(state.recordId);
+
+        if (retargeted || Neo.isNumber(state.focusIndex) && state.focusIndex !== logicalIndex) {
+            me._focusIndex = logicalIndex
+        }
+
+        if (slot !== undefined && slot !== state.slot) {
+            Neo.main.addon.Navigator.navigateTo({
+                data      : me.navigator,
+                fromTarget: me.getSlotId(state.slot),
+                target    : me.getSlotId(slot),
+                windowId  : me.windowId
+            })
+        }
     }
 
     /**

--- a/src/list/Buffered.mjs
+++ b/src/list/Buffered.mjs
@@ -11,10 +11,10 @@ import TreeBuilder   from '../util/vdom/TreeBuilder.mjs';
  * {@link #bufferRowRange} rows on either side is mounted between two stable spacers.
  *
  * Physical pool slots and logical records are different identities. Slot ids never encode a record;
- * `data.recordId` does. Surviving records retain their slot across scroll, prepend, sort, and filter
- * whenever possible, while the vdom orders those slots by logical Store position so assistive
- * technology reads the same order the operator sees. Moving a range edge therefore rotates/rebinds
- * bounded slots; it never creates one component per Store record.
+ * `data.recordId` does. A slot belongs to one mounted-range offset, keeping `[slot-0 … slot-N]` in
+ * invariant DOM order while records rebind through Store position. Assistive technology therefore
+ * reads the same order the operator sees without structural VDOM moves. Moving a range edge updates
+ * bounded slot contents; it never creates one component per Store record.
  *
  * Consumers that need component rows provide {@link #itemConfig}: an object or function returning a
  * component config. The component is created once per physical slot and receives the current record
@@ -246,9 +246,9 @@ class Buffered extends ComponentList {
     }
 
     /**
-     * Assigns current-range records to a bounded pool. A surviving record keeps its old physical
-     * slot; only entrants consume freed slots. The returned descriptors remain in logical order so
-     * DOM reading order matches visual/Store order even when slot ids rotate.
+     * Assigns current-range records to fixed physical slots by mounted-range offset. The physical
+     * slot order is invariant while Store records rebind, so logical/DOM reading order stays aligned
+     * without `moveNode`, `insertNode`, or `removeNode` deltas during steady-state range movement.
      * @param {Object[]} records
      * @param {Number} start Logical start index.
      * @param {Number} poolSize
@@ -257,28 +257,11 @@ class Buffered extends ComponentList {
      */
     assignPoolSlots(records, start, poolSize) {
         let me          = this,
-            assignments = records.map((record, offset) => ({
-                logicalIndex: start + offset,
-                poolIndex   : null,
+            assignments = records.slice(0, poolSize).map((record, poolIndex) => ({
+                logicalIndex: start + poolIndex,
+                poolIndex,
                 record
-            })),
-            used        = new Set(),
-            freeSlots;
-
-        assignments.forEach(item => {
-            const slot = me.recordSlotMap.get(me.toRecordMapKey(me.getRecordId(item.record)));
-
-            if (slot !== undefined && slot < poolSize && !used.has(slot)) {
-                item.poolIndex = slot;
-                used.add(slot)
-            }
-        });
-
-        freeSlots = Array.from({length: poolSize}, (_, index) => index).filter(index => !used.has(index));
-
-        assignments.forEach(item => {
-            item.poolIndex ??= freeSlots.shift()
-        });
+            }));
 
         me.recordSlotMap = new Map();
         me.slotRecordIds = Array(poolSize).fill(null);

--- a/src/main/addon/Navigator.mjs
+++ b/src/main/addon/Navigator.mjs
@@ -5,9 +5,9 @@ import DomUtils  from '../DomUtils.mjs';
 
 // We do not need to inject a synthesized "click" event when we detect an ENTER
 // keypress on these element types.
-const enterActivatedTags= {
-    A      : 1,
-    BUTTON : 1
+const enterActivatedTags = {
+    A     : 1,
+    BUTTON: 1
 };
 
 /**
@@ -53,11 +53,11 @@ class Navigator extends Base {
                 clientY = rect.y + (rect.height / 2);
 
             el.dispatchEvent(new MouseEvent('click', {
-                bubbles  : true,
-                altKey   : Neo.altKeyDown,
-                ctrlKey  : Neo.controlKeyDown,
-                metaKey  : Neo.metaKeyDown,
-                shiftKey : Neo.shiftKeyDown,
+                bubbles : true,
+                altKey  : Neo.altKeyDown,
+                ctrlKey : Neo.controlKeyDown,
+                metaKey : Neo.metaKeyDown,
+                shiftKey: Neo.shiftKeyDown,
                 clientX,
                 clientY
             }))
@@ -299,14 +299,24 @@ class Navigator extends Base {
      * Navigates to the passed target
      * @param {Object} config
      * @param {Object} config.data The data block as passed to {@link #subscribe}
+     * @param {HTMLElement|String} [config.fromTarget] Only navigate while browser focus is still
+     * inside this source target. This prevents asynchronous reconciliation from stealing focus.
      * @param {HTMLElement|Number|String} config.target The new active element, id or index
      */
     navigateTo(config) {
-        let {data, target} = config;
+        let {data, fromTarget, target} = config;
 
         if (!data.subject) {
             // If subject has been unmounted, we cannot navigate
             if (!(data = DomAccess.getElement(data.id)?.$navigator)) {
+                return
+            }
+        }
+
+        if (fromTarget !== undefined) {
+            fromTarget = typeof fromTarget === 'string' ? DomAccess.getElement(fromTarget) : fromTarget;
+
+            if (!this.isActiveTarget(fromTarget)) {
                 return
             }
         }
@@ -327,8 +337,8 @@ class Navigator extends Base {
 
         // Scroll the target into view smoothly before we focus it without triggering a scroll
         target.scrollIntoView({
-            behavior : 'smooth',
-            block    : 'nearest'
+            behavior: 'smooth',
+            block   : 'nearest'
         });
 
         // Find a focusable element which may be the item, or inside the item to draw focus to.
@@ -343,6 +353,18 @@ class Navigator extends Base {
         else {
             this.setActiveItem(target, data)
         }
+    }
+
+    /**
+     * Returns true when a target itself or one of its descendants owns browser focus.
+     * @param {HTMLElement|null} target
+     * @returns {Boolean}
+     * @protected
+     */
+    isActiveTarget(target) {
+        const activeElement = target?.ownerDocument?.activeElement;
+
+        return Boolean(target && (target === activeElement || target.contains?.(activeElement)))
     }
 
     /**
@@ -390,19 +412,19 @@ class Navigator extends Base {
         // navigating to the same element should get ignored
         if (data.activeItem !== data.previousActiveItem) {
             DomEvents.sendMessageToApp({
-                type                : 'neonavigate',
-                target              : data.id,
-                path                : [{
+                type  : 'neonavigate',
+                target: data.id,
+                path  : [{
                     id : data.id
                 }],
-                activeItem          : data.activeItem.id,
-                previousActiveItem  : data.previousActiveItem?.id,
-                activeIndex         : data.activeIndex,
-                previousActiveIndex : data.previousActiveIndex,
-                altKey              : Neo.altKeyDown,
-                ctrlKey             : Neo.controlKeyDown,
-                metaKey             : Neo.metaKeyDown,
-                shiftKey            : Neo.shiftKeyDown
+                activeItem         : data.activeItem.id,
+                previousActiveItem : data.previousActiveItem?.id,
+                activeIndex        : data.activeIndex,
+                previousActiveIndex: data.previousActiveIndex,
+                altKey             : Neo.altKeyDown,
+                ctrlKey            : Neo.controlKeyDown,
+                metaKey            : Neo.metaKeyDown,
+                shiftKey           : Neo.shiftKeyDown
             })
         }
 
@@ -472,8 +494,8 @@ class Navigator extends Base {
 
             // We have to know when the DOM mutates in case the active item is removed.
             (data.targetMutationMonitor = new MutationObserver(e => me.navigateTargetChildListChange(e, data))).observe(subject, {
-                childList : true,
-                subtree   : true
+                childList: true,
+                subtree  : true
             });
 
             eventSource.addEventListener('keydown', data.l1 = e => me.navigateKeyDownHandler(e, data));

--- a/test/playwright/unit/list/Buffered.spec.mjs
+++ b/test/playwright/unit/list/Buffered.spec.mjs
@@ -1,6 +1,6 @@
 /**
  * @file test/playwright/unit/list/Buffered.spec.mjs
- * @summary Contract tests for `Neo.list.Buffered`: bounded semantic component rows over a full Store.
+ * @summary Contract tests for bounded, fixed-DOM-order semantic component rows over a full Store.
  */
 
 import {setup} from '../../setup.mjs';
@@ -72,7 +72,7 @@ class NestedPooledRow extends Container {
 
 NestedPooledRow = Neo.setupClass(NestedPooledRow);
 
-test.describe('Neo.list.Buffered — fixed-height component row windowing (#17554)', () => {
+test.describe('Neo.list.Buffered — fixed-height component row windowing (#17554, #17563)', () => {
     let list,
         sequence = 0;
 
@@ -165,11 +165,12 @@ test.describe('Neo.list.Buffered — fixed-height component row windowing (#1755
         expect(list.items).toBeNull()
     });
 
-    test('scrolling rotates bounded slots while surviving records keep component identity', async () => {
+    test('scrolling rebinds fixed physical slots while keeping component identity', async () => {
         await createList();
 
         const
-            initialSlotIds = new Set(renderedRows(list).map(row => row.id)),
+            initialSlotIds = renderedRows(list).map(row => row.id),
+            components     = [...list.items],
             slotForFive    = list.recordSlotMap.get('5'),
             componentFive  = list.items[slotForFive];
 
@@ -179,41 +180,70 @@ test.describe('Neo.list.Buffered — fixed-height component row windowing (#1755
 
         expect(list.mountedRange).toEqual([2, 11]);
         expect(renderedRows(list).map(row => row.data.recordId)).toEqual([2, 3, 4, 5, 6, 7, 8, 9, 10]);
-        expect(new Set(renderedRows(list).map(row => row.id))).toEqual(initialSlotIds);
+        expect(renderedRows(list).map(row => row.id)).toEqual(initialSlotIds);
+        expect(list.items).toEqual(components);
         expect(list.items).toHaveLength(9);
-        expect(list.items[list.recordSlotMap.get('5')]).toBe(componentFive);
-        expect(componentFive.record.id).toBe(5);
+        expect(list.recordSlotMap.get('5')).toBe(3);
+        expect(list.items[3].record.id).toBe(5);
+        expect(componentFive.record.id).toBe(7);
         expect(list.vdom.cn[0].style.height).toBe('40px');
         expect(list.vdom.cn.at(-1).style.height).toBe(`${(5000 - 11) * 20}px`)
     });
 
-    test('range movement produces bounded updates without row insertion or removal', async () => {
+    test('range movement keeps physical rows fixed without structural deltas', async () => {
         await createList();
         await list.timeout(20);
 
+        // RED baseline at the fixed-order branch point: forward range movement emitted 7 moveNode deltas;
+        // reverse emitted 2. Both directions already emitted zero insertNode and removeNode deltas.
         const
-            captured    = [],
-            updateBatch = VdomHelper.updateBatch;
+            componentSet = new Set(list.items),
+            initialIds   = renderedRows(list).map(row => row.id),
+            captureMove  = async scrollTop => {
+                const
+                    captured    = [],
+                    updateBatch = VdomHelper.updateBatch;
 
-        VdomHelper.updateBatch = function(data) {
-            const result = updateBatch.call(this, data);
+                VdomHelper.updateBatch = function(data) {
+                    const result = updateBatch.call(this, data);
 
-            result.deltas?.length > 0 && captured.push(...result.deltas);
+                    result.deltas?.length > 0 && captured.push(...result.deltas);
 
-            return result
-        };
+                    return result
+                };
 
-        try {
-            list.onScrollCapture({target: {id: list.id}, scrollLeft: 0, scrollTop: 80});
-            await list.timeout(30)
-        } finally {
-            VdomHelper.updateBatch = updateBatch
-        }
+                try {
+                    list.onScrollCapture({target: {id: list.id}, scrollLeft: 0, scrollTop});
+                    await list.timeout(30)
+                } finally {
+                    VdomHelper.updateBatch = updateBatch
+                }
 
-        expect(captured.length).toBeGreaterThan(0);
-        expect(captured.filter(delta => delta.action === 'insertNode')).toEqual([]);
-        expect(captured.filter(delta => delta.action === 'removeNode')).toEqual([]);
-        expect(renderedRows(list)).toHaveLength(9)
+                return {
+                    actions: Object.fromEntries(['insertNode', 'moveNode', 'removeNode'].map(action => [
+                        action,
+                        captured.filter(delta => delta.action === action).length
+                    ])),
+                    captured
+                }
+            };
+
+        const forward = await captureMove(80);
+
+        expect(list.mountedRange).toEqual([2, 11]);
+        expect(forward.captured.length).toBeGreaterThan(0);
+        expect(new Set(list.items)).toEqual(componentSet);
+
+        const reverse = await captureMove(0);
+
+        expect(list.mountedRange).toEqual([0, 9]);
+        expect(reverse.captured.length).toBeGreaterThan(0);
+        expect({forward: forward.actions, reverse: reverse.actions}).toEqual({
+            forward: {insertNode: 0, moveNode: 0, removeNode: 0},
+            reverse: {insertNode: 0, moveNode: 0, removeNode: 0}
+        });
+        expect(renderedRows(list).map(row => row.id)).toEqual(initialIds);
+        expect(new Set(list.items)).toEqual(componentSet)
     });
 
     test('recycled nested item components repaint in the owning list update', async () => {

--- a/test/playwright/unit/list/Buffered.spec.mjs
+++ b/test/playwright/unit/list/Buffered.spec.mjs
@@ -401,6 +401,55 @@ test.describe('Neo.list.Buffered — fixed-height component row windowing (#1755
         expect(list.getItemRecordId(calls[0].target)).toBe(200)
     });
 
+    test('focus follows a mounted record and retargets when that record leaves the pooled range', async () => {
+        const {store} = await createList({count: 500});
+
+        await list.timeout(20);
+
+        const
+            calls      = [],
+            navigateTo = Neo.main.addon.Navigator.navigateTo,
+            recordFive = store.get(5);
+
+        Neo.main.addon.Navigator.navigateTo = data => calls.push(data);
+
+        try {
+            list.focusIndex = recordFive;
+
+            await expect.poll(() => calls.at(-1)?.target).toBe(list.getSlotId(5));
+            calls.length = 0;
+
+            list.onScrollCapture({target: {id: list.id}, scrollLeft: 0, scrollTop: 80});
+
+            await expect.poll(() => calls.at(-1)?.target).toBe(list.getSlotId(3));
+
+            expect(list.mountedRange).toEqual([2, 11]);
+            expect(list.focusIndex).toBe(recordFive);
+            expect(calls.at(-1).fromTarget).toBe(list.getSlotId(5));
+            expect(list.getItemRecordId(calls.at(-1).target)).toBe(5);
+
+            list.focusIndex = store.get(4);
+            await expect.poll(() => calls.at(-1)?.target).toBe(list.getSlotId(2));
+            calls.length = 0;
+
+            list.onScrollCapture({target: {id: list.id}, scrollLeft: 0, scrollTop: 200});
+
+            await expect.poll(() => ({
+                focusIndex: list.focusIndex,
+                target    : calls.at(-1)?.target
+            })).toEqual({
+                focusIndex: 8,
+                target    : list.getSlotId(0)
+            });
+
+            expect(list.mountedRange).toEqual([8, 17]);
+            expect(calls.at(-1).fromTarget).toBe(list.getSlotId(2));
+            expect(list.getItemRecordId(calls.at(-1).target)).toBe(8)
+        } finally {
+            Neo.main.addon.Navigator.navigateTo = navigateTo
+        }
+    });
+
     test('Store sort reorders the bounded range once through the coarse load contract', async () => {
         const {store} = await createList({count: 20});
 


### PR DESCRIPTION
Resolves #17563

Related: #17554
Related: #17557
Related: #17585

`Neo.list.Buffered` now keeps `[top spacer, slot-0 … slot-N, bottom spacer]` in invariant child order while rebinding each physical slot by mounted-range offset. The component pool stays bounded and instance-stable; Store order, record identity, ARIA, focus, selection, and scroll anchoring remain logical-record contracts without steady-state DOM moves.

Evidence: L2 (red-capable VDOM delta and component-identity unit contracts) → L2 required (all close-target ACs are unit-observable engine contracts). No residuals.

## AC Evidence

| AC-1 | `Buffered.spec.mjs` advances the mounted range `[0,9] → [2,11] → [0,9]`, captures every structural action, and records the old algorithm's exact RED baseline: forward 7 / reverse 2 `moveNode`, with zero inserts/removes. |
| AC-2 | The same bidirectional witness asserts zero `moveNode`, zero `insertNode`, and zero `removeNode` after fixed-offset rebinding. |
| AC-3 | The movement fixtures assert the ordered physical row-ID array is byte-identical before, forward, and reverse movement. |
| AC-4 | The component array/set/cardinality remain invariant across scrolling; no pooled instance is created or destroyed. |
| AC-5 | Rendered `data.recordId` order is asserted against the mounted Store slice after rebinding. |
| AC-6 | The focus fixture holds record 5 across `[0,9] → [2,11]` and proves its target moves from slot 5 to slot 3; a second arm moves record 4 out of range and proves focus retargets to logical index 8 / slot 0. The main-thread `fromTarget` guard permits either move only while the old slot still owns browser focus. Existing fixtures retain ARIA, selection, record-update, and prepend/filter anchoring coverage. |
| AC-7 | The resize fixture grows/shrinks the pool and proves only excess slots are destroyed, keeping cardinality changes explicitly resize-owned. |
| AC-8 | `npm run test-unit -- test/playwright/unit/list/Buffered.spec.mjs` passes 11/11; the hosted unit suite runs from this ready PR. |

## Deltas from ticket

The self-authored drift probe fired because #17585 landed after the parked implementation; direct comparison proved current `dev`'s two original files are byte-identical to the parked commit's parent, so their replay is exact rather than re-derived. Cycle-1 review added `src/main/addon/Navigator.mjs`: its optional `fromTarget` compare-and-move guard is the main-thread authority that reconciles actual browser focus without stealing focus into a blurred list.

## Test Evidence

- Mutation control: temporarily restoring record-affinity slot rotation made the new structural oracle fail exactly at forward `moveNode: 7` / reverse `moveNode: 2`, while both insert/remove counts stayed zero. Restoring fixed-offset rebinding returned the full focused suite to 10/10 green.
- Focus RED control: before the repair, record 5 remained logically focused while its old slot rebound to record 7; the new witness timed out waiting for any post-rebind navigation (`calls.length` stayed 1). The repaired two-arm contract passes in the 11/11 focused suite.

## Post-Merge Validation

- [x] None — the delta stream, pool identity, semantic order, interactions, anchoring, and resize boundary are all pre-merge unit-observable.

## Evolution

The implementation was first committed while #17585 was stacked and intentionally waited for that consumer PR to merge. After the squash landed, the old branch still carried two now-merged stack commits; this PR salvaged only the #17563 commit onto current `dev`, preserving the original red-capable evidence without replaying merged consumer history. Cycle-1 review then exposed that the focus claim exceeded its witness. The ticket's logical-record authority ruled out silently declaring focus slot-owned, so the repair added a record-following / nearest-record retarget contract plus a main-thread active-focus guard.

Authored by Emmy (GPT-5.6 Sol Ultra, Codex) across session A f47f948b-743b-4c11-84a8-fa60a567a148, session B e88db1a2-9896-48dc-a964-c73b6f59ee10, and session C 54be7dc0-3275-4fce-be85-56a225b84fec.
