### PR TITLE
fix(test): keep perspective E2Es Body-tier loadable (#17602)

### DIFF
--- a/test/playwright/e2e/agentos/DemoBPerspectiveToolsNL.spec.mjs
+++ b/test/playwright/e2e/agentos/DemoBPerspectiveToolsNL.spec.mjs
@@ -1,5 +1,5 @@
-import {test, expect}           from '../../fixtures.mjs';
-import {NeuralLink_DockService} from '../../../../ai/services.mjs';
+import {test, expect}         from '../../fixtures.mjs';
+import NeuralLink_DockService from '../../../../ai/services/neural-link/DockService.mjs';
 
 /**
  * @summary Whitebox E2E witness for the agent-driven Neural Link perspective path on Demo B.

--- a/test/playwright/e2e/workstation/WorkstationPerspectivesNL.spec.mjs
+++ b/test/playwright/e2e/workstation/WorkstationPerspectivesNL.spec.mjs
@@ -1,5 +1,5 @@
-import {test, expect}           from '../../fixtures.mjs';
-import {NeuralLink_DockService} from '../../../../ai/services.mjs';
+import {test, expect}         from '../../fixtures.mjs';
+import NeuralLink_DockService from '../../../../ai/services/neural-link/DockService.mjs';
 
 /**
  * @summary Whitebox E2E witness for the Neural Link perspective path on the workstation Workspace.

--- a/test/playwright/unit/ai/services/hostBarrelImportReach.spec.mjs
+++ b/test/playwright/unit/ai/services/hostBarrelImportReach.spec.mjs
@@ -159,6 +159,28 @@ test.describe('host-plane import reach — a store handle must be unreachable by
         expect([...externals], 'a dynamic import is not a static edge').not.toContain('@google/generative-ai');
     });
 
+    test('the two perspective E2Es cannot statically reach the cloud services barrel', () => {
+        const
+            cloudBarrel = path.join(repoRoot, 'ai/services.mjs'),
+            control     = path.join(repoRoot, 'test/playwright/unit/ai/services-resilient-load.spec.mjs'),
+            targets     = [
+                'test/playwright/e2e/agentos/DemoBPerspectiveToolsNL.spec.mjs',
+                'test/playwright/e2e/workstation/WorkstationPerspectivesNL.spec.mjs'
+            ];
+
+        expect(
+            [...walkStaticImports(control).files],
+            'positive control: the graph walk must recognize a real cloud-barrel adopter'
+        ).toContain(cloudBarrel);
+
+        for (const target of targets) {
+            expect(
+                [...walkStaticImports(path.join(repoRoot, target)).files],
+                `${target} needs one host Neural Link service; it must not inherit the Brain barrel`
+            ).not.toContain(cloudBarrel)
+        }
+    });
+
     for (const pkg of STATICALLY_REACHED_CLOUD_PACKAGES) {
         test(`the HOST barrel cannot statically reach ${pkg}`, () => {
             // The acceptance property, one package per test so a regression names the package that


### PR DESCRIPTION
Resolves #17602

Both perspective E2Es now import the host-side Neural Link DockService directly instead of loading the Brain-tier `ai/services.mjs` barrel for one symbol. The existing Acorn reachability suite pins those two consumers against the cloud barrel with a known-positive adopter control; no product runtime, service API, or package gate changes.

Evidence: L3 achieved (Brain-package denial controls + real Demo B and Workstation browser journeys) → L3 required (AC-1–AC-5). No residuals.

Micro-review eligible: mechanical — two import substitutions plus one existing-walker guard; no runtime contract or production behavior changes.

## AC Evidence

| AC | Evidence |
|---|---|
| AC-1 | `hostBarrelImportReach.spec.mjs` walks both target graphs and asserts neither reaches `ai/services.mjs`; both imports resolve directly to `ai/services/neural-link/DockService.mjs`. |
| AC-2 | The same unit arm names both target paths and first proves the walker recognizes `services-resilient-load.spec.mjs` as a real cloud-barrel adopter. |
| AC-3 | Existing static/runtime reach suites cover the positive cloud reach, host survival under denied Brain packages, and cloud-barrel death on `DENIED_CLOUD_PLANE_PACKAGE: chromadb`. |
| AC-4 | Exact-head E2E: `DemoBPerspectiveToolsNL` + `WorkstationPerspectivesNL` → **2/2 passed in 3.2s** through their real Neural Link perspective chains. |
| AC-5 | Diff contains only two import substitutions and the test guard; no skip, installer, adapter, product class, or service implementation changes. |

## Deltas from ticket

The first guard draft generalized the two measured offenders into a whole-E2E prohibition. Its positive run reddened with ten other cloud-barrel-reaching specs, falsifying that universal premise. #17602 and the guard were corrected before commit to the two perspective consumers only; the ten-file census remains explicitly out of scope pending independent consumer/package V-B-A.

## Test Evidence

Outside CI: exact-head `npx playwright test -c test/playwright/playwright.config.e2e.mjs WorkstationPerspectivesNL DemoBPerspectiveToolsNL --workers=1` → **2 passed (3.2s)**.

The missing-package diagonal used the repository denial loader: the direct host service survived with all Brain packages denied; the cloud barrel failed specifically on `chromadb`.

## Post-Merge Validation

No post-merge-only validation; the exact-head denial controls and both browser journeys close the leaf.

Related: #17564, #16710, #17369

Authored by Euclid (OpenAI GPT-5.6 Sol Ultra, Codex Desktop). Session a1cc9e59-61ad-4158-a0b8-29867c4737c3.
