### PR TITLE
fix(testing): enrich browser launch-exit receipts (#17595)

### DIFF
--- a/test/playwright/e2e/custom-reporter.js
+++ b/test/playwright/e2e/custom-reporter.js
@@ -6,6 +6,8 @@ import {isEngineProfile} from './utils/gpuIntent.mjs';
 
 const
   ANSI_ESCAPE_PATTERN = /\u001B\[[0-?]*[ -/]*[@-~]/g,
+  HEADLESS_TOKEN_PATTERN = /(?:^|\s)-{1,2}headless(?:=[^\s]+)?(?=\s|$)/,
+  LAUNCH_COMMAND_PATTERN = /^<launching>\s+(.+)$/m,
   MACH_SERVICE_PERMISSION_TOKEN = 'Permission denied (1100)',
   PROCESS_EXIT_PATTERN = /\[pid=(\d+)]\s+<process did exit: exitCode=([^,>]+), signal=([^>]+)>/;
 
@@ -29,11 +31,20 @@ export function resolveBrowserKind({browserName = null, channel = null} = {}) {
 }
 
 /**
- * @summary Resolves the launch-mode enum only when Playwright supplied the effective headless flag.
+ * @summary Resolves launch mode from the observed command without retaining its path or arguments.
+ * @param {String} text ANSI-free Playwright error text.
  * @param {Boolean|null} [headless=null]
+ * @param {String} [browserKind='unknown']
  * @returns {'headed'|'headless'|'unknown'}
  */
-function resolveLaunchMode(headless = null) {
+function resolveLaunchMode(text, headless = null, browserKind = 'unknown') {
+  const launchCommand = text.match(LAUNCH_COMMAND_PATTERN)?.[1];
+
+  if (launchCommand) {
+    if (HEADLESS_TOKEN_PATTERN.test(launchCommand)) return 'headless';
+    if (browserKind !== 'unknown') return 'headed'
+  }
+
   return headless === true ? 'headless' : headless === false ? 'headed' : 'unknown'
 }
 
@@ -98,14 +109,15 @@ export function classifyBrowserLaunchExit(error, {
     permissionDenied = text.includes(MACH_SERVICE_PERMISSION_TOKEN),
     cause = permissionDenied
       ? 'macos-mach-service-permission-denied'
-      : 'unclassified-process-exit';
+      : 'unclassified-process-exit',
+    browserKind = resolveBrowserKind({browserName, channel});
 
   return {
     classification          : 'browser-launch-process-exit',
     project,
     channel,
-    browserKind             : resolveBrowserKind({browserName, channel}),
-    launchMode              : resolveLaunchMode(headless),
+    browserKind,
+    launchMode              : resolveLaunchMode(text, headless, browserKind),
     profile,
     processId               : Number(match[1]),
     exitCode,

--- a/test/playwright/e2e/custom-reporter.js
+++ b/test/playwright/e2e/custom-reporter.js
@@ -6,7 +6,36 @@ import {isEngineProfile} from './utils/gpuIntent.mjs';
 
 const
   ANSI_ESCAPE_PATTERN = /\u001B\[[0-?]*[ -/]*[@-~]/g,
+  MACH_SERVICE_PERMISSION_TOKEN = 'Permission denied (1100)',
   PROCESS_EXIT_PATTERN = /\[pid=(\d+)]\s+<process did exit: exitCode=([^,>]+), signal=([^>]+)>/;
+
+/**
+ * @summary Resolves a bounded browser-kind enum without persisting arbitrary executable paths.
+ * @param {Object} [context]
+ * @param {String|null} [context.browserName=null]
+ * @param {String|null} [context.channel=null]
+ * @returns {'branded-chrome'|'branded-edge'|'bundled-chromium'|'firefox'|'webkit'|'unknown'}
+ */
+export function resolveBrowserKind({browserName = null, channel = null} = {}) {
+  if (/^chrome(?:-(?:beta|dev|canary))?$/.test(channel)) return 'branded-chrome';
+  if (/^msedge(?:-(?:beta|dev|canary))?$/.test(channel)) return 'branded-edge';
+  if (channel) return 'unknown';
+
+  return {
+    chromium: 'bundled-chromium',
+    firefox : 'firefox',
+    webkit  : 'webkit'
+  }[browserName] || 'unknown'
+}
+
+/**
+ * @summary Resolves the launch-mode enum only when Playwright supplied the effective headless flag.
+ * @param {Boolean|null} [headless=null]
+ * @returns {'headed'|'headless'|'unknown'}
+ */
+function resolveLaunchMode(headless = null) {
+  return headless === true ? 'headless' : headless === false ? 'headed' : 'unknown'
+}
 
 /**
  * @summary Resolves the Neo browser launch profile without conflating film run mode with launch policy.
@@ -34,13 +63,17 @@ export function readOptionalSystemFact(read, fallback=null) {
  * @summary Extracts the bounded launch-process receipt Playwright already carries in a rejected browser launch.
  * @param {Error|Object|String} error
  * @param {Object} [context]
+ * @param {String|null} [context.browserName=null]
  * @param {String|null} [context.channel=null]
+ * @param {Boolean|null} [context.headless=null]
  * @param {String|null} [context.profile=resolveE2eProfileName()]
  * @param {String|null} [context.project=null]
  * @returns {Object|null}
  */
 export function classifyBrowserLaunchExit(error, {
+  browserName = null,
   channel = null,
+  headless = null,
   profile = resolveE2eProfileName(),
   project = null
 } = {}) {
@@ -61,18 +94,28 @@ export function classifyBrowserLaunchExit(error, {
     exitCode  = exitValue === 'null'
       ? null
       : /^-?\d+$/.test(exitValue) ? Number(exitValue) : exitValue,
-    exitSignal = signal === 'null' ? null : signal;
+    exitSignal = signal === 'null' ? null : signal,
+    permissionDenied = text.includes(MACH_SERVICE_PERMISSION_TOKEN),
+    cause = permissionDenied
+      ? 'macos-mach-service-permission-denied'
+      : 'unclassified-process-exit';
 
   return {
     classification          : 'browser-launch-process-exit',
     project,
     channel,
+    browserKind             : resolveBrowserKind({browserName, channel}),
+    launchMode              : resolveLaunchMode(headless),
     profile,
     processId               : Number(match[1]),
     exitCode,
     signal                  : exitSignal,
     abnormal                : exitCode !== 0 || exitSignal !== null,
     browserObjectEstablished: false,
+    cause,
+    remedy                  : permissionDenied
+      ? 'retry-with-approved-execution-boundary'
+      : 'inspect-retained-launch-exit',
     // Playwright may construct a pipe before connectToTransport() rejects. Reporter callbacks do
     // not expose that boundary, so a Boolean here would manufacture certainty.
     transportState          : 'not-observable'
@@ -147,17 +190,21 @@ export default class BenchmarkSystemReporter {
    * @summary Deduplicates one Playwright launch exit across reporter error and test-result delivery.
    * @param {Error|Object|String} error
    * @param {Object} [context]
+   * @param {String|null} [context.browserName=null]
    * @param {String|null} [context.channel=null]
+   * @param {Boolean|null} [context.headless=null]
    * @param {String} [context.observedVia='reporter-error']
    * @param {String|null} [context.project=null]
    * @returns {Object|null}
    */
   captureBrowserLaunchExit(error, {
+    browserName = null,
     channel = null,
+    headless = null,
     observedVia = 'reporter-error',
     project = null
   } = {}) {
-    const incident = classifyBrowserLaunchExit(error, {channel, project});
+    const incident = classifyBrowserLaunchExit(error, {browserName, channel, headless, project});
 
     if (!incident) return null;
 
@@ -169,6 +216,16 @@ export default class BenchmarkSystemReporter {
       if (!existing.observedVia.includes(observedVia)) existing.observedVia.push(observedVia);
       if (!existing.project && project) existing.project = project;
       if (!existing.channel && channel) existing.channel = channel;
+      if (existing.browserKind === 'unknown' && incident.browserKind !== 'unknown') {
+        existing.browserKind = incident.browserKind
+      }
+      if (existing.launchMode === 'unknown' && incident.launchMode !== 'unknown') {
+        existing.launchMode = incident.launchMode
+      }
+      if (existing.cause === 'unclassified-process-exit' && incident.cause !== existing.cause) {
+        existing.cause  = incident.cause;
+        existing.remedy = incident.remedy
+      }
       this.flushReceipt();
 
       return existing
@@ -188,8 +245,11 @@ export default class BenchmarkSystemReporter {
 
     console.error(
       `[browser-lifecycle] project=${project ?? 'unknown'} profile=${incident.profile} ` +
+      `channel=${incident.channel ?? 'unknown'} browserKind=${incident.browserKind} ` +
+      `launchMode=${incident.launchMode} ` +
       `pid=${incident.processId} exitCode=${incident.exitCode ?? 'null'} ` +
-      `signal=${incident.signal ?? 'null'} browserObjectEstablished=false ` +
+      `signal=${incident.signal ?? 'null'} failure=before-browser-object ` +
+      `cause=${incident.cause} remedy=${incident.remedy} browserObjectEstablished=false ` +
       'transportState=not-observable'
     );
 
@@ -206,7 +266,9 @@ export default class BenchmarkSystemReporter {
     const project = workerInfo?.project;
 
     this.captureBrowserLaunchExit(error, {
+      browserName: project?.use?.browserName ?? null,
       channel    : project?.use?.channel ?? null,
+      headless   : project?.use?.headless ?? null,
       observedVia: 'reporter-error',
       project    : project?.name ?? null
     })
@@ -223,7 +285,9 @@ export default class BenchmarkSystemReporter {
 
     for (const error of result.errors || (result.error ? [result.error] : [])) {
       this.captureBrowserLaunchExit(error, {
+        browserName: project?.use?.browserName ?? null,
         channel    : project?.use?.channel ?? null,
+        headless   : project?.use?.headless ?? null,
         observedVia: 'test-result',
         project    : project?.name ?? null
       })

--- a/test/playwright/unit/e2e/browserLifecycleReporter.spec.mjs
+++ b/test/playwright/unit/e2e/browserLifecycleReporter.spec.mjs
@@ -11,6 +11,7 @@ import BenchmarkSystemReporter, {
 
 const launchExit = ({
     exitCode = 'null',
+    launchCommand = null,
     pid = 4242,
     prefix = 'Error: browserType.launch: Failed to launch the browser process.',
     signal = 'SIGABRT'
@@ -18,9 +19,10 @@ const launchExit = ({
     prefix,
     'Browser logs:',
     '',
+    launchCommand ? `<launching> ${launchCommand}` : null,
     `<launched> pid=${pid}`,
     `[pid=${pid}] <process did exit: exitCode=${exitCode}, signal=${signal}>`
-].join('\n');
+].filter(Boolean).join('\n');
 
 /**
  * @summary Coverage for the bounded E2E browser-launch lifecycle receipt.
@@ -87,6 +89,17 @@ test.describe('e2e/custom-reporter browser lifecycle', () => {
         });
         expect(classifyBrowserLaunchExit(launchExit())).toMatchObject({
             launchMode: 'unknown'
+        });
+
+        expect(classifyBrowserLaunchExit(launchExit({
+            launchCommand: '/Applications/Google Chrome.app/Contents/MacOS/Google Chrome --headless --no-sandbox'
+        }), {browserName: 'chromium', headless: false})).toMatchObject({
+            launchMode: 'headless'
+        });
+        expect(classifyBrowserLaunchExit(launchExit({
+            launchCommand: '/Applications/Google Chrome.app/Contents/MacOS/Google Chrome --no-sandbox'
+        }), {browserName: 'chromium', headless: true})).toMatchObject({
+            launchMode: 'headed'
         })
     });
 
@@ -191,7 +204,7 @@ test.describe('e2e/custom-reporter browser lifecycle', () => {
             error                = {
                 message: [
                     launchExit(),
-                    '<launching> /Applications/Google Chrome.app --user-data-dir=/private/profile',
+                    '<launching> /Applications/Google Chrome.app --headless --user-data-dir=/private/profile',
                     'https://private.example.test secret-window-title'
                 ].join('\n')
             };

--- a/test/playwright/unit/e2e/browserLifecycleReporter.spec.mjs
+++ b/test/playwright/unit/e2e/browserLifecycleReporter.spec.mjs
@@ -5,6 +5,7 @@ import {expect, test} from '@playwright/test';
 import BenchmarkSystemReporter, {
     classifyBrowserLaunchExit,
     readOptionalSystemFact,
+    resolveBrowserKind,
     resolveE2eProfileName
 } from '../../e2e/custom-reporter.js';
 
@@ -38,19 +39,25 @@ test.describe('e2e/custom-reporter browser lifecycle', () => {
 
     test('#16161 classifies SIGABRT without inventing transport state', () => {
         expect(classifyBrowserLaunchExit(launchExit(), {
-            channel: 'chrome',
-            profile: 'presenting',
-            project: 'chromium'
+            browserName: 'chromium',
+            channel    : 'chrome',
+            headless   : true,
+            profile    : 'presenting',
+            project    : 'chromium'
         })).toEqual({
             classification          : 'browser-launch-process-exit',
             project                 : 'chromium',
             channel                 : 'chrome',
+            browserKind             : 'branded-chrome',
+            launchMode              : 'headless',
             profile                 : 'presenting',
             processId               : 4242,
             exitCode                : null,
             signal                  : 'SIGABRT',
             abnormal                : true,
             browserObjectEstablished: false,
+            cause                   : 'unclassified-process-exit',
+            remedy                  : 'inspect-retained-launch-exit',
             transportState          : 'not-observable'
         });
 
@@ -58,6 +65,52 @@ test.describe('e2e/custom-reporter browser lifecycle', () => {
             exitCode: 0,
             signal  : null,
             abnormal: false
+        })
+    });
+
+    test('#17595 resolves only bounded browser kinds and launch modes', () => {
+        expect(resolveBrowserKind({browserName: 'chromium', channel: 'chrome'})).toBe('branded-chrome');
+        expect(resolveBrowserKind({browserName: 'chromium', channel: 'msedge'})).toBe('branded-edge');
+        expect(resolveBrowserKind({browserName: 'chromium'})).toBe('bundled-chromium');
+        expect(resolveBrowserKind({browserName: 'firefox'})).toBe('firefox');
+        expect(resolveBrowserKind({browserName: 'webkit'})).toBe('webkit');
+        expect(resolveBrowserKind({
+            browserName: 'chromium',
+            channel    : 'custom-browser'
+        })).toBe('unknown');
+
+        expect(classifyBrowserLaunchExit(launchExit(), {headless: false})).toMatchObject({
+            launchMode: 'headed'
+        });
+        expect(classifyBrowserLaunchExit(launchExit(), {headless: true})).toMatchObject({
+            launchMode: 'headless'
+        });
+        expect(classifyBrowserLaunchExit(launchExit())).toMatchObject({
+            launchMode: 'unknown'
+        })
+    });
+
+    test('#17595 names Mach permission denial only from its exact token', () => {
+        const permissionDenied = [
+            launchExit({signal: 'SIGTRAP'}),
+            'bootstrap_check_in org.chromium.Chromium.MachPortRendezvousServer.4242:',
+            'Permission denied (1100)'
+        ].join('\n');
+
+        expect(classifyBrowserLaunchExit(permissionDenied)).toMatchObject({
+            cause : 'macos-mach-service-permission-denied',
+            remedy: 'retry-with-approved-execution-boundary'
+        });
+
+        expect(classifyBrowserLaunchExit(launchExit())).toMatchObject({
+            cause : 'unclassified-process-exit',
+            remedy: 'inspect-retained-launch-exit'
+        });
+        expect(classifyBrowserLaunchExit(
+            permissionDenied.replace('Permission denied (1100)', 'Permission denied (1101)')
+        )).toMatchObject({
+            cause : 'unclassified-process-exit',
+            remedy: 'inspect-retained-launch-exit'
         })
     });
 
@@ -129,11 +182,13 @@ test.describe('e2e/custom-reporter browser lifecycle', () => {
 
     test('#16161 deduplicates reporter paths and persists no raw launch command', async () => {
         const
-            directory  = await fs.mkdtemp(path.join(os.tmpdir(), 'neo-browser-lifecycle-')),
-            outputFile = path.join(directory, 'benchmark-system-info.json'),
-            reporter   = new BenchmarkSystemReporter({outputFile}),
-            project    = {name: 'chromium', use: {channel: 'chrome'}},
-            error      = {
+            directory            = await fs.mkdtemp(path.join(os.tmpdir(), 'neo-browser-lifecycle-')),
+            outputFile           = path.join(directory, 'benchmark-system-info.json'),
+            reporter             = new BenchmarkSystemReporter({outputFile}),
+            project              = {name: 'chromium', use: {browserName: 'chromium', channel: 'chrome', headless: true}},
+            terminal             = [],
+            originalConsoleError = console.error,
+            error                = {
                 message: [
                     launchExit(),
                     '<launching> /Applications/Google Chrome.app --user-data-dir=/private/profile',
@@ -142,6 +197,8 @@ test.describe('e2e/custom-reporter browser lifecycle', () => {
             };
 
         try {
+            console.error = (...args) => terminal.push(args.join(' '));
+
             reporter.onBegin(
                 {projects: [project]},
                 {allTests: () => [{id: 'launch-test'}]}
@@ -161,16 +218,25 @@ test.describe('e2e/custom-reporter browser lifecycle', () => {
             expect(exits[0]).toMatchObject({
                 project       : 'chromium',
                 channel       : 'chrome',
+                browserKind   : 'branded-chrome',
+                launchMode    : 'headless',
                 profile       : 'presenting',
                 processId     : 4242,
+                cause         : 'unclassified-process-exit',
+                remedy        : 'inspect-retained-launch-exit',
                 observedVia   : ['reporter-error', 'test-result'],
                 transportState: 'not-observable'
             });
+            expect(terminal).toHaveLength(1);
+            expect(terminal[0]).toContain('channel=chrome browserKind=branded-chrome launchMode=headless');
+            expect(terminal[0]).toContain('failure=before-browser-object cause=unclassified-process-exit');
+            expect(terminal[0]).toContain('remedy=inspect-retained-launch-exit');
             expect(raw).not.toContain('<launching>');
             expect(raw).not.toContain('user-data-dir');
             expect(raw).not.toContain('private.example.test');
             expect(raw).not.toContain('secret-window-title')
         } finally {
+            console.error = originalConsoleError;
             await fs.remove(directory)
         }
     })


### PR DESCRIPTION
Resolves #17595

The existing Playwright reporter now makes rejected browser launches immediately discriminating without taking browser ownership: terminal output and `browserLifecycle.launchExits[]` carry bounded browser kind, observed headed/headless mode, failure phase, cause, and remedy. Exact `Permission denied (1100)` evidence names the Mach-service permission cause; opaque `SIGABRT` stays unclassified. No launch command, executable path, URL, title, or profile path is retained.

Evidence: L3 achieved (two real default-sandbox launch failures at exact tree `61016df980`, plus an independent denied-launch receipt from Grace) → L3 required (AC-4…AC-7 observable reporter/receipt behavior). Residual: AC-8, Residual-Owner: #17605 until PR #17606 merges.

## AC Evidence

| AC | Evidence |
|---|---|
| AC-1 | The incident cause remains grounded in the public boundary matrix and minimal pair on #17595: branded Chrome `SIGABRT`, bundled Chromium `SIGTRAP` + `Permission denied (1100)`, both before a Browser object. This PR does not reclassify the opaque signal. |
| AC-2 | The pre-existing positive control remains bearer-linked: `FleetCatchUpNL` and `FleetCockpitDrillNL` reached real green assertions only across the approved execution boundary. No passing-spec claim is inferred from the new failure receipts. |
| AC-3 | Both current-head live arms are headless and differ only by browser/cause evidence; `launchMode=headless` is parsed from the actual `<launching>` command rather than guessed from the reporter project object. |
| AC-4 | [Current-head bearer receipt](https://github.com/neomjs/neo/issues/17595#issuecomment-5384646338): terminal lines name channel, browser kind, launch mode, failure-before-object, cause, and remedy for real bundled and branded launches. |
| AC-5 | The same receipt includes both persisted `browserLifecycle.launchExits[]` rows with bounded enums and `unknown`/`null` fallbacks; focused unit coverage exercises Chrome, Edge, bundled Chromium, Firefox, WebKit, and unknown. |
| AC-6 | Exact live pair at `61016df980`: bundled `SIGTRAP` + `Permission denied (1100)` → `macos-mach-service-permission-denied`; branded `SIGABRT` without the token → `unclassified-process-exit`. Unit near-miss `Permission denied (1101)` stays unclassified. Grace’s [current-head independent opaque control](https://github.com/neomjs/neo/issues/17595#issuecomment-5384663604) verifies no-overclaim from another seat. |
| AC-7 | Existing reporter and existing spec only—no second browser lifecycle. Unit and both live serialized receipts are negative for launch command, executable/user-data paths, URL, title, and profile content. |
| AC-8 | Process handoff is owned by child #17605 / PR #17606. This PR is merge-ordered behind that child; current status is mechanically held (`reviewDecision` absent) pending @tobiu’s A-prime acceptance or explicit override. |

## Deltas from ticket

- Browser-kind vocabulary is bounded to `branded-chrome`, `branded-edge`, `bundled-chromium`, `firefox`, `webkit`, and `unknown`; arbitrary channels never become persisted kinds.
- Live V-B-A falsified the first launch-mode implementation: Playwright’s reporter project object did not carry the effective default `headless` value. Commit `61016df980` derives mode from the observed `<launching>` line, emits only the enum, and uses config context only when no launch line exists.
- Cause and remedy are separate bounded fields. The exact token licenses the Mach-permission cause; every other process exit keeps the generic inspection remedy.
- Dedupe may enrich an existing row when a second reporter delivery supplies better bounded context; it never stores the raw source text.

## Test Evidence

- [@neo-gpt-emmy current-head live receipt](https://github.com/neomjs/neo/issues/17595#issuecomment-5384646338): real default-sandbox branded Chrome + bundled Chromium arms, terminal and JSON, zero assertions, privacy-negative scan.
- [@neo-opus-grace current-head opaque receipt](https://github.com/neomjs/neo/issues/17595#issuecomment-5384663604): real `/usr/bin/false` Playwright launch at `61016df980`, proving the observed-command mode branch, no-overclaim behavior, and path-rich privacy boundary from a different seat.
- Focused author run: `npm run test-unit -- test/playwright/unit/e2e/browserLifecycleReporter.spec.mjs` → 8/8. This coverage also runs in CI.
- Full local unit run reached 14,597 pass / 32 environment reds. Isolation attributed the residuals to the separately ticketed #17607 Neural Link cwd defect plus container-owned/read-only `.neo-ai-data` and historical backup artifacts; no changed-surface failure occurred. Hosted current-head CI is the clean full-suite authority.

## Post-Merge Validation

None — reporter behavior is observable on the unmerged exact head. The dependency below is a pre-merge gate, not deferred validation.

## Merge-Order Gate

- [ ] PR #17606 must merge before this PR. It delivers AC-8’s evidence-handoff contract and is currently mechanically held pending operator acceptance/override of A-prime.
- [ ] Re-read #17606 live state before representing this PR as merge-ready; a comment or prior broadcast is not authority.

## Commits

- `afd89a9c17` — add bounded browser/cause/remedy receipt fields and unit/live-oracle coverage.
- `61016df980` — derive effective launch mode from the observed Playwright command after the first live run falsified config-context authority.

## Evolution

The first implementation trusted `project.use.headless`; a real default-sandbox launch returned `undefined` there while the source command visibly contained `--headless`. The live receipt forced the authority correction before PR: actual launch grammar now outranks config context, while the full argv remains excluded from persistence.

Related: #16151 · #16161 · #17605 · PR #17606

Authored by Emmy (GPT-5.6 Sol Ultra, Codex). Session 6ca355f6-8cf2-4799-b02b-ac43b9043d55.
