### PR TITLE
feat(mcp): supply Neural Link client cwd (#17607)

### DIFF
--- a/ai/mcp/client/Client.mjs
+++ b/ai/mcp/client/Client.mjs
@@ -58,6 +58,12 @@ class Client extends Base {
          */
         command: null,
         /**
+         * Working directory for a stdio child process. Named built-ins may supply an explicit package
+         * root; `null` preserves the SDK's inherited-cwd behavior for existing definitions.
+         * @member {String|null} cwd=null
+         */
+        cwd: null,
+        /**
          * Path to a custom client configuration file.
          * @member {String|null} configFile=null
          */
@@ -163,7 +169,8 @@ class Client extends Base {
             return new StdioClientTransport({
                 command: me.command,
                 args   : me.args,
-                env    : me.env
+                env    : me.env,
+                cwd    : me.cwd ?? undefined
             });
 
         case 'sse':
@@ -388,6 +395,7 @@ class Client extends Base {
             throw new Error(`MCP Client: Server config not found for '${serverName}' in ai/mcp/client/config.mjs`);
         }
         me.command           = serverConfig.command           || null;
+        me.cwd               = serverConfig.cwd               ?? null;
         me.args              = serverConfig.args              || null;
         me.bearerTokenEnvVar = serverConfig.bearerTokenEnvVar || null;
         me.openApiFilePath   = serverConfig.openApiFilePath   || null;

--- a/ai/mcp/client/config.mjs
+++ b/ai/mcp/client/config.mjs
@@ -1,7 +1,43 @@
 import fs                              from 'fs/promises';
+import {readFileSync}                  from 'node:fs';
 import path                            from 'path';
+import {fileURLToPath}                 from 'node:url';
 import Base                            from '../../../src/core/Base.mjs';
 import {REMOTE_MCP_CREDENTIAL_ENV_VAR} from '../../services/fleet/mcpServers.mjs';
+
+const NEURAL_LINK_MCP_SCRIPT = 'ai:mcp-server-neural-link';
+
+/**
+ * @summary Resolves the package root owned by this built-in client configuration.
+ *
+ * The module location is stable while the caller's working directory is not: GUI launchers and
+ * absolute config-file invocations may start at `/` or any unrelated directory. Requiring the
+ * package manifest to declare the exact npm script turns the derived path into validated spawn
+ * authority rather than a plausible-looking ancestor.
+ *
+ * @returns {String}
+ * @throws {Error} When this module no longer lives under the package that owns the Neural Link MCP
+ * server script.
+ * @private
+ */
+function resolveClientPackageRoot() {
+    const candidate = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../../..');
+    let   manifest;
+
+    try {
+        manifest = JSON.parse(readFileSync(path.join(candidate, 'package.json'), 'utf8'));
+    } catch {
+        throw new Error('MCP Client config: module-derived package root has no readable package.json');
+    }
+
+    if (typeof manifest.scripts?.[NEURAL_LINK_MCP_SCRIPT] !== 'string') {
+        throw new Error(`MCP Client config: module-derived package root does not declare '${NEURAL_LINK_MCP_SCRIPT}'`);
+    }
+
+    return candidate
+}
+
+const clientPackageRoot = resolveClientPackageRoot();
 
 /**
  * Default configuration object for the MCP Client.
@@ -12,7 +48,7 @@ const defaultConfig = {
      * A map of MCP server configurations.
      * The key is the logical name of the server (e.g., 'github-workflow').
      * The value is an object with transport-specific connection properties:
-     * - `transportType: 'stdio'` uses `command` + `args`.
+     * - `transportType: 'stdio'` uses `command` + `args` and may pin the child with `cwd`.
      * - `transportType: 'sse'` or `'streamable-http'` uses `url` + optional `transportOptions`.
      * - `bearerTokenEnvVar` injects a remote Bearer credential without storing its value here.
      */
@@ -48,7 +84,11 @@ const defaultConfig = {
         "neural-link": {
             transportType: "stdio",
             command      : "npm",
-            args         : ["run", "ai:mcp-server-neural-link"]
+            // One module-derived authority drives BOTH process layers. The SDK needs `cwd` to find
+            // this package's npm script; Neural Link needs the explicit flag before it may spawn or
+            // connect its Bridge. Ambient `process.cwd()` is intentionally absent from both paths.
+            cwd : clientPackageRoot,
+            args: ["run", NEURAL_LINK_MCP_SCRIPT, "--", "--cwd", clientPackageRoot]
         }
     }
 };

--- a/test/playwright/unit/ai/mcp/client/McpClientTransportConfig.spec.mjs
+++ b/test/playwright/unit/ai/mcp/client/McpClientTransportConfig.spec.mjs
@@ -13,6 +13,10 @@ setup({
 
 import {test, expect} from '@playwright/test';
 import crypto         from 'crypto';
+import fs             from 'node:fs';
+import os             from 'node:os';
+import path           from 'node:path';
+import {spawnSync}    from 'node:child_process';
 
 import {SSEClientTransport}            from '@modelcontextprotocol/sdk/client/sse.js';
 import {StdioClientTransport}          from '@modelcontextprotocol/sdk/client/stdio.js';
@@ -63,7 +67,12 @@ test.describe('Neo.ai.mcp.client.Client transport config', () => {
         expect(client.transportType).toBe('stdio');
         expect(client.command).toBe('npm');
         expect(client.args).toEqual(['run', 'ai:mcp-server-github-workflow']);
-        expect(client.createTransport()).toBeInstanceOf(StdioClientTransport);
+        expect(client.cwd).toBe(null);
+
+        const transport = client.createTransport();
+
+        expect(transport).toBeInstanceOf(StdioClientTransport);
+        expect(transport._serverParams.cwd).toBeUndefined();
 
         client.destroy();
     });
@@ -98,6 +107,7 @@ test.describe('Neo.ai.mcp.client.Client transport config', () => {
             expect(client.bearerTokenEnvVar).toBe(REMOTE_MCP_CREDENTIAL_ENV_VAR);
             expect(client.bearerTokenEnvVar).not.toBe('GH_TOKEN');
             expect(client.command).toBe(null);
+            expect(client.cwd).toBe(null);
             expect(client.args).toBe(null);
 
             client.destroy();
@@ -113,10 +123,59 @@ test.describe('Neo.ai.mcp.client.Client transport config', () => {
 
         expect(client.transportType).toBe('stdio');
         expect(client.command).toBe('npm');
-        expect(client.args).toEqual(['run', 'ai:mcp-server-neural-link']);
+        expect(path.isAbsolute(client.cwd)).toBe(true);
+        expect(client.args).toEqual([
+            'run',
+            'ai:mcp-server-neural-link',
+            '--',
+            '--cwd',
+            client.cwd
+        ]);
         expect(client.bearerTokenEnvVar).toBe(null);
 
+        const transport = client.createTransport();
+
+        expect(transport).toBeInstanceOf(StdioClientTransport);
+        expect(transport._serverParams.cwd).toBe(client.cwd);
+
         client.destroy();
+    });
+
+    test('Neural Link derives both cwd inputs from the client module, never the invoking directory', () => {
+        const
+            foreignCwd = fs.mkdtempSync(path.join(os.tmpdir(), 'neo-mcp-client-cwd-')),
+            neoUrl     = new URL('../../../../../../src/Neo.mjs', import.meta.url).href,
+            coreUrl    = new URL('../../../../../../src/core/_export.mjs', import.meta.url).href,
+            configUrl  = new URL('../../../../../../ai/mcp/client/config.mjs', import.meta.url).href,
+            probe      = `
+                await import(${JSON.stringify(neoUrl)});
+                await import(${JSON.stringify(coreUrl)});
+                const {default: config} = await import(${JSON.stringify(configUrl)});
+                process.stdout.write(JSON.stringify(config.mcpServers['neural-link']));
+            `;
+
+        try {
+            const result = spawnSync(process.execPath, ['--input-type=module', '--eval', probe], {
+                cwd     : foreignCwd,
+                encoding: 'utf8'
+            });
+
+            expect(result.status, result.stderr).toBe(0);
+
+            const neuralLink = JSON.parse(result.stdout);
+
+            expect(neuralLink.cwd).toBe(ClientConfig.mcpServers['neural-link'].cwd);
+            expect(neuralLink.cwd).not.toBe(foreignCwd);
+            expect(neuralLink.args).toEqual([
+                'run',
+                'ai:mcp-server-neural-link',
+                '--',
+                '--cwd',
+                neuralLink.cwd
+            ]);
+        } finally {
+            fs.rmSync(foreignCwd, {recursive: true, force: true});
+        }
     });
 
     test('creates streamable HTTP transports from remote endpoint config', () => {


### PR DESCRIPTION
Resolves #17607

The generic MCP client can now pin a stdio child to an explicit `cwd`. The built-in Neural Link definition derives one validated package root from its own module location and supplies that same root to both the SDK child process and Neural Link's `--cwd` entrypoint, so a foreign invocation directory cannot leave the Bridge disconnected.

Evidence: L3 (the real npm stdio child completed a live loopback Bridge freshness handshake and healthy startup through the canonical client) → L3 required (AC-4 and AC-5 runtime health). Residual: none.

## AC Evidence

| AC-1 | Before the fix, the affected tree was byte-identical to `origin/dev`; the canonical health spec reproduced 6/7 with Neural Link `unhealthy` and `awaiting entrypoint-supplied cwd`. |
| AC-2 | `McpClientTransportConfig.spec.mjs` asserts one absolute module-derived root is both the SDK transport `cwd` and the value after `--cwd`. The resolver validates that the root manifest declares `ai:mcp-server-neural-link`. |
| AC-3 | The foreign-cwd child-process arm imports the real config from a temporary invocation directory and still resolves the repository root; replacing the resolver return with `process.cwd()` makes that arm fail. |
| AC-4 | `McpServersHealth.spec.mjs` passes 7/7 with the real built-in configuration. |
| AC-5 | The Neural Link child logged `Verified Neural Link Bridge freshness` and `Neural Link health check passed`; neither `HealthService` nor the accepted-status assertion changed. |
| AC-6 | The transport suite pins inherited `cwd` for an existing stdio definition and `null` for built-in remote definitions; only the stdio constructor receives the optional field. |
| AC-7 | Existing `bridgeAutoConnectOrdering.spec.mjs` and `ConnectionService.spec.mjs` remain green, including the unresolved-cwd defer and named spawn refusal arms. |

## Deltas from ticket

None substantive. The package-root validation is deliberately local to the existing client config owner; no new helper, directory, ambient fallback, or Bridge behavior was introduced.

## Test Evidence

- Red baseline: canonical health spec reproduced the exact 6/7 failure on an affected tree byte-identical to `origin/dev`.
- Live green: the same spec passed 7/7 and observed the real stdio child complete the Bridge freshness handshake.
- Mutation control: substituting `process.cwd()` for the module-derived return failed the foreign-cwd arm with the temporary directory as the received root.

## Post-Merge Validation

None — every close-target AC is covered before merge.

Authored by Euclid (OpenAI GPT-5.6 Sol Ultra, Codex Desktop). Session 94da50dd-d390-49ca-acff-5e3d0a644a73.
