### PR TITLE
feat(dashboard): extend dock theming to every shipped theme (#17244)

### DIFF
--- a/resources/scss/theme-cyberpunk/dashboard/Container.scss
+++ b/resources/scss/theme-cyberpunk/dashboard/Container.scss
@@ -1,0 +1,14 @@
+@use 'preview-accents' as *;
+
+:where(.neo-theme-cyberpunk) {
+    @include preview-accents;
+
+    --agent-dock-preview-signal-ground: rgba(22, 27, 34, 0.94);
+    --dock-preview-ground             : rgba(13, 17, 23, 0.94);
+    --dock-preview-line               : #30363d;
+    --dock-arrival-outline            : rgba(0, 210, 255, 0.55);
+    --agent-dock-proxy-border         : color-mix(in srgb, #00d2ff 38%, #30363d);
+    --agent-dock-proxy-ground         : #161b22;
+    --agent-dock-proxy-shadow         : #0d1117;
+    --agent-dock-proxy-text           : #c9d1d9;
+}

--- a/resources/scss/theme-cyberpunk/dashboard/DockPreview.scss
+++ b/resources/scss/theme-cyberpunk/dashboard/DockPreview.scss
@@ -1,0 +1,5 @@
+@use 'preview-accents' as *;
+
+:where(.neo-theme-cyberpunk) {
+    @include preview-accents;
+}

--- a/resources/scss/theme-cyberpunk/dashboard/_preview-accents.scss
+++ b/resources/scss/theme-cyberpunk/dashboard/_preview-accents.scss
@@ -1,0 +1,10 @@
+// Cyberpunk already owns a complete cyan/red signal vocabulary in Global.scss. Keep the dock
+// values byte-aligned with that palette rather than inventing a second neon family.
+@mixin preview-accents {
+    --agent-dock-preview-accept      : #00d2ff;
+    --agent-dock-preview-accept-fill : rgba(0, 210, 255, 0.20);
+    --agent-dock-preview-reject      : #ff4757;
+    --agent-dock-preview-reject-fill : rgba(255, 71, 87, 0.16);
+    --agent-dock-preview-signal      : #00d2ff;
+    --agent-dock-preview-signal-fill : rgba(0, 210, 255, 0.18);
+}

--- a/resources/scss/theme-dark/dashboard/Container.scss
+++ b/resources/scss/theme-dark/dashboard/Container.scss
@@ -1,0 +1,14 @@
+@use 'preview-accents' as *;
+
+:where(.neo-theme-dark) {
+    @include preview-accents;
+
+    --agent-dock-preview-signal-ground: rgba(43, 43, 43, 0.92);
+    --dock-preview-ground             : rgba(60, 63, 65, 0.92);
+    --dock-preview-line               : #2b2b2b;
+    --dock-arrival-outline            : rgba(100, 181, 246, 0.55);
+    --agent-dock-proxy-border         : color-mix(in srgb, #64b5f6 38%, #2b2b2b);
+    --agent-dock-proxy-ground         : #3c3f41;
+    --agent-dock-proxy-shadow         : #2b2b2b;
+    --agent-dock-proxy-text           : #bbb;
+}

--- a/resources/scss/theme-dark/dashboard/DockPreview.scss
+++ b/resources/scss/theme-dark/dashboard/DockPreview.scss
@@ -1,0 +1,5 @@
+@use 'preview-accents' as *;
+
+:where(.neo-theme-dark) {
+    @include preview-accents;
+}

--- a/resources/scss/theme-dark/dashboard/_preview-accents.scss
+++ b/resources/scss/theme-dark/dashboard/_preview-accents.scss
@@ -1,0 +1,10 @@
+// Shared by the two dashboard values sheets. These colors are the legacy dark theme's existing
+// selection/focus and danger families, not a second dock-specific palette.
+@mixin preview-accents {
+    --agent-dock-preview-accept      : #64b5f6;
+    --agent-dock-preview-accept-fill : rgba(100, 181, 246, 0.20);
+    --agent-dock-preview-reject      : #e6adad;
+    --agent-dock-preview-reject-fill : rgba(230, 173, 173, 0.16);
+    --agent-dock-preview-signal      : #64b5f6;
+    --agent-dock-preview-signal-fill : rgba(100, 181, 246, 0.18);
+}

--- a/resources/scss/theme-light/dashboard/Container.scss
+++ b/resources/scss/theme-light/dashboard/Container.scss
@@ -1,0 +1,14 @@
+@use 'preview-accents' as *;
+
+:where(.neo-theme-light) {
+    @include preview-accents;
+
+    --agent-dock-preview-signal-ground: rgba(255, 255, 255, 0.94);
+    --dock-preview-ground             : rgba(250, 250, 250, 0.94);
+    --dock-preview-line               : #ddd;
+    --dock-arrival-outline            : rgba(28, 96, 160, 0.45);
+    --agent-dock-proxy-border         : color-mix(in srgb, #1c60a0 38%, #ddd);
+    --agent-dock-proxy-ground         : #fff;
+    --agent-dock-proxy-shadow         : rgba(0, 0, 0, 0.15);
+    --agent-dock-proxy-text           : #000;
+}

--- a/resources/scss/theme-light/dashboard/DockPreview.scss
+++ b/resources/scss/theme-light/dashboard/DockPreview.scss
@@ -1,0 +1,5 @@
+@use 'preview-accents' as *;
+
+:where(.neo-theme-light) {
+    @include preview-accents;
+}

--- a/resources/scss/theme-light/dashboard/_preview-accents.scss
+++ b/resources/scss/theme-light/dashboard/_preview-accents.scss
@@ -1,0 +1,10 @@
+// Shared by the two dashboard values sheets. These colors come from the legacy light theme's
+// established control and danger vocabulary.
+@mixin preview-accents {
+    --agent-dock-preview-accept      : #1c60a0;
+    --agent-dock-preview-accept-fill : rgba(28, 96, 160, 0.14);
+    --agent-dock-preview-reject      : #410808;
+    --agent-dock-preview-reject-fill : rgba(230, 173, 173, 0.45);
+    --agent-dock-preview-signal      : #1c60a0;
+    --agent-dock-preview-signal-fill : rgba(28, 96, 160, 0.14);
+}

--- a/test/playwright/e2e/dashboard/DockStandaloneThemingNL.spec.mjs
+++ b/test/playwright/e2e/dashboard/DockStandaloneThemingNL.spec.mjs
@@ -10,10 +10,10 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
  * standalone-proof AC and its mutation control).
  *
  * A dashboard dropped into a host with ZERO application dock CSS must render fully themed in
- * both primary themes. The host is `examples/dashboard/dock` — it carries no app stylesheet at
- * all (verified by the absent-stylesheet precondition below), so every dock token resolves from
- * the engine layers alone: the structure layer's paint reading the THEME values layer
- * (theme-neo-dark + theme-neo-light `dashboard/` sheets).
+ * every shipped dashboard theme. The host is `examples/dashboard/dock` — it carries no app
+ * stylesheet at all (verified by the absent-stylesheet precondition below), so every dock token
+ * resolves from the engine layers alone: the structure layer's paint reading the THEME values
+ * layer (`dashboard/` sheets under both neo themes, both legacy themes and cyberpunk).
  *
  * The proof has two levels and a mutation half:
  *   1. TOKEN level — the theme host resolves the values-layer tokens (`--agent-dock-preview-accept`,
@@ -40,6 +40,21 @@ test.describe('Dock standalone theming — the values layer (Neural Link)', () =
           // [token level] values-layer token → expected resolved value per theme.
           // [paint level] the indicator chevron's resolved border-color per theme.
           EXPECTATIONS = {
+              'neo-theme-cyberpunk': {
+                  acceptToken: '#00d2ff',
+                  groundToken: 'rgba(13, 17, 23, 0.94)',
+                  acceptPaint: 'rgb(0, 210, 255)'
+              },
+              'neo-theme-dark': {
+                  acceptToken: '#64b5f6',
+                  groundToken: 'rgba(60, 63, 65, 0.92)',
+                  acceptPaint: 'rgb(100, 181, 246)'
+              },
+              'neo-theme-light': {
+                  acceptToken: '#1c60a0',
+                  groundToken: 'rgba(250, 250, 250, 0.94)',
+                  acceptPaint: 'rgb(28, 96, 160)'
+              },
               'neo-theme-neo-dark': {
                   acceptToken: '#5eead4',
                   groundToken: 'rgba(26, 33, 44, 0.92)',
@@ -51,6 +66,15 @@ test.describe('Dock standalone theming — the values layer (Neural Link)', () =
                   acceptPaint: 'rgb(13, 148, 136)'
               }
           },
+
+          // The original primary-theme mutation remains, and every new layer gets its own deletion
+          // control so an unobserved legacy/cyberpunk sheet cannot ship behind primary-theme green.
+          MUTATION_THEMES = [
+              'neo-theme-neo-dark',
+              'neo-theme-dark',
+              'neo-theme-light',
+              'neo-theme-cyberpunk'
+          ],
 
           // The structure layer's literal fallback for --agent-dock-preview-accept (#4493f8).
           FALLBACK_PAINT = 'rgb(68, 147, 248)';
@@ -72,7 +96,7 @@ test.describe('Dock standalone theming — the values layer (Neural Link)', () =
             // Fulfill with an EMPTY sheet (200, no rules) rather than aborting: the loader awaits
             // each sheet's load event, and an aborted request never fires it — a hang would model
             // nothing. The empty sheet is the faithful mutation: the layer loads and defines nothing.
-            await page.route('**/css/theme-neo-*/dashboard/**', route =>
+            await page.route('**/css/theme-*/dashboard/**', route =>
                 route.fulfill({contentType: 'text/css', body: '/* mutation: the values layer defines nothing */'})
             );
         }
@@ -147,22 +171,24 @@ test.describe('Dock standalone theming — the values layer (Neural Link)', () =
         });
     }
 
-    test('MUTATION control: with the values layer blocked, the specimen renders the engine literal fallback', async ({page}) => {
-        await boot(page, 'neo-theme-neo-dark', {blockValuesLayer: true});
+    for (const theme of MUTATION_THEMES) {
+        test(`MUTATION control: without the ${theme} values layer, paint uses the engine fallback`, async ({page}) => {
+            await boot(page, theme, {blockValuesLayer: true});
 
-        // The blocked layer must be observable at token level too.
-        const accept = await page.evaluate(() =>
-            getComputedStyle(document.body).getPropertyValue('--agent-dock-preview-accept').trim()
-        );
-        expect(accept, 'the values-layer token must be ABSENT when its stylesheet is blocked').toBe('');
+            // The blocked layer must be observable at token level too.
+            const accept = await page.evaluate(() =>
+                getComputedStyle(document.body).getPropertyValue('--agent-dock-preview-accept').trim()
+            );
+            expect(accept, `the ${theme} values-layer token is absent when its sheet is blocked`).toBe('');
 
-        await mountSpecimen(page);
-        const chevronColor = await page.evaluate(() => {
-            const el = document.getElementById('standalone-specimen');
-            return getComputedStyle(el, '::before').borderColor;
+            await mountSpecimen(page);
+            const chevronColor = await page.evaluate(() => {
+                const el = document.getElementById('standalone-specimen');
+                return getComputedStyle(el, '::before').borderColor;
+            });
+            expect(chevronColor, 'the chevron falls back to the structure literal (#4493f8)').toBe(FALLBACK_PAINT);
         });
-        expect(chevronColor, 'the chevron falls back to the structure literal (#4493f8)').toBe(FALLBACK_PAINT);
-    });
+    }
 });
 
 /**


### PR DESCRIPTION
Resolves #17244

Extends the settled dashboard values layer to `theme-dark`, `theme-light`, and `theme-cyberpunk`. Each theme supplies the same 14 engine-read dock tokens through independent `Container` and `DockPreview` sheets, while the standalone Neural Link witness now covers all five shipped themes and proves every new layer with an empty-sheet mutation.

Related: #13158

Evidence: L3 (approved-boundary bundled Chromium with live App Worker, computed token/paint checks, and empty-sheet mutations; sandboxed branded Chrome cannot establish a browser object on this seat) → L3 required (AC-2, AC-3, and AC-6 rendered effects). No residuals.

## AC Evidence

| Acceptance criterion | Evidence |
|---|---|
| AC-1 | `npm run build-themes -- -n -e dev` generated `Container.css` and `DockPreview.css` for `theme-dark` and `theme-light`; the compiled token census reports 14 tokens with no missing or extra names against both primary themes. |
| AC-2 | The live standalone host registered `Neo.examples.dashboard.dock` and passed worker, zero-app-stylesheet, theme-class, computed-token, and chevron-paint assertions under `neo-theme-dark` and `neo-theme-light`. |
| AC-3 | Independent empty-sheet mutations for `neo-theme-dark` and `neo-theme-light` remove `--agent-dock-preview-accept` and force the chevron to the engine literal fallback. |
| AC-4 | Cyberpunk is covered, not declined: its existing global cyan/red/background/border palette supplies the same 14-token layer; the decision and measurements are recorded in issue comment `5386215468`. |
| AC-5 | The conditional guard update is not needed: `check-theme-coverage` deliberately governs the primary-theme baseline, while `check-theme-surfaces` governs app token consumers. Both current guards pass unchanged after the new legacy/specialty layers build. |
| AC-6 | The unchanged `neo-theme-neo-dark` and `neo-theme-neo-light` positive cells plus the original primary-theme mutation remain green inside the complete 14/14 owning spec. |

## Deltas from ticket

Cyberpunk coverage was optional. Current-source palette and contrast evidence made coverage cheaper and safer than a decline, so all five shipped themes now satisfy the standalone dock invariant. The mutation request matcher widened from `theme-neo-*` to `theme-*`, and each newly delivered layer received its own deletion control.

## Test Evidence

- `npm run build-themes -- -n -e dev` — passed; all six new output sheets compiled.
- `node buildScripts/util/check-theme-coverage.mjs` — passed.
- `npm run check-theme-surfaces` — passed.
- Focused standalone matrix — 9/9 passed: five positive theme cells plus four independent mutation cells.
- Complete `DockStandaloneThemingNL.spec.mjs` — 14/14 passed, including the pre-existing relocated-demo palette matrix and mutation.
- Token census — all five theme families expose exactly 14 tokens, with no missing or extra names. Signal-to-ground contrast: dark 4.79:1, light 6.23:1, cyberpunk 10.51:1.
- Browser boundary: the canonical config's branded Chrome aborts before creating a browser object on this sandboxed seat. Re-running outside the macOS sandbox with a temporary same-directory config adapter that removed only `project.use.channel` (all fixtures, web server, launch arguments, and reporters unchanged) produced the live receipts above.

## Post-Merge Validation

None required — the theme builder, live standalone consumer, and deletion controls all ran against the PR source state.

Authored by Euclid (GPT-5.6 Sol, Codex Desktop). Session 01a02ead-f0db-7b30-b4e2-54189808ab54.
