### PR TITLE
fix(dashboard): the splitter's drag proxy carries the paint it was cloned from (#17616)

### DIFF
--- a/src/dashboard/DockSplitter.mjs
+++ b/src/dashboard/DockSplitter.mjs
@@ -17,6 +17,33 @@ import NeoArray      from '../util/Array.mjs';
  * @see learn/agentos/DockZoneModel.md
  */
 class DockSplitter extends Component {
+    /**
+     * @summary The `--dock-splitter-*` contract, projected onto the drag proxy by
+     * {@link Neo.dashboard.DockSplitter#projectProxyTokens}.
+     *
+     * The SSOT is the `.neo-dashboard` token block in `resources/scss/src/dashboard/Container.scss`;
+     * this is a restatement, and a restatement drifts. The guard is the parity spec, which parses
+     * that block and fails when the two sets diverge — so an engine token added without a line here
+     * turns a test red instead of silently dropping out of every drag proxy.
+     * @member {String[]} proxyProjectedTokens
+     * @static
+     */
+    static proxyProjectedTokens = [
+        '--dock-splitter-background',
+        '--dock-splitter-background-active',
+        '--dock-splitter-background-hover',
+        '--dock-splitter-handle-color',
+        '--dock-splitter-handle-color-active',
+        '--dock-splitter-handle-color-hover',
+        '--dock-splitter-handle-glow-hover',
+        '--dock-splitter-handle-size',
+        '--dock-splitter-handle-thickness',
+        '--dock-splitter-radius',
+        '--dock-splitter-ring',
+        '--dock-splitter-ring-active',
+        '--dock-splitter-ring-hover'
+    ]
+
     static config = {
         /**
          * @member {String} className='Neo.dashboard.DockSplitter'
@@ -121,6 +148,62 @@ class DockSplitter extends Component {
             windowId           : me.windowId,
             ...me.dragZoneConfig
         })
+    }
+
+    /**
+     * @summary Carries the splitter's resolved paint onto its drag proxy, which mounts outside the
+     * cascade that produced it.
+     *
+     * The proxy is a clone mounted at `document.body` ({@link Neo.draggable.DragZone#proxyParentId}),
+     * so it keeps the splitter's classes and loses every ancestor. That breaks the paint twice over:
+     * the engine declares its `--dock-splitter-*` defaults on `.neo-dashboard`, and each consumer
+     * declares its values as a DESCENDANT rule (`.fm-fleet-cockpit .neo-dashboard-dock-splitter`,
+     * `.workstation-workspace .neo-dashboard-dock-splitter`). Detached from both, every token
+     * resolves empty and the proxy renders transparent with a zero-sized handle — the affordance
+     * disappears at exactly the moment it is telling the user they are moving something.
+     *
+     * Reading the SOURCE element's computed values is what makes this consumer-agnostic: the source
+     * has already been through the real cascade, so the projection never needs to know which class
+     * carried a value or how deeply it was nested. A scope class cannot do this — it would restore
+     * the engine floor and leave every consumer value absent, which paints the proxy WRONG rather
+     * than not at all, and wrong is the harder failure to notice.
+     *
+     * Best-effort by contract: a failed read must never block a drag. Losing the paint costs an
+     * affordance; throwing here would cost the gesture.
+     *
+     * @returns {Promise<void>}
+     * @protected
+     */
+    async projectProxyTokens() {
+        let me = this;
+
+        try {
+            const styles = await Neo.main.DomAccess.getComputedStyle({
+                id   : me.id,
+                style: DockSplitter.proxyProjectedTokens
+            });
+
+            const projected = Object.entries(styles || {}).reduce((acc, [token, value]) => {
+                // An unresolved custom property reads as an empty string. Projecting it would pin
+                // the proxy to "explicitly nothing" and shadow the engine floor it could otherwise
+                // still inherit, so an absent value must stay absent.
+                value?.trim() && (acc[token] = value.trim());
+                return acc
+            }, {});
+
+            Object.keys(projected).length > 0 && me.dragZone?.set({
+                dragProxyConfig: {
+                    ...(me.dragZone.dragProxyConfig || {}),
+                    style: {
+                        ...(me.dragZone.dragProxyConfig?.style || {}),
+                        ...projected
+                    }
+                }
+            })
+        } catch {
+            // Unmounted, destroyed, or a main-thread round trip that lost its node: the drag
+            // proceeds unpainted rather than not at all.
+        }
     }
 
     /**
@@ -364,6 +447,7 @@ class DockSplitter extends Component {
         });
 
         await me.captureDragStart(data);
+        await me.projectProxyTokens();
         await me.dragZone.dragStart(data);
 
         me.style = {

--- a/test/playwright/e2e/dashboard/DockSplitterProxyPaintNL.spec.mjs
+++ b/test/playwright/e2e/dashboard/DockSplitterProxyPaintNL.spec.mjs
@@ -1,0 +1,102 @@
+import {test, expect} from '../../fixtures.mjs';
+
+/**
+ * Whitebox-e2e: the splitter's DRAG PROXY renders its affordance while the gesture is live.
+ *
+ * The defect this pins shipped because every existing arm stopped at `mouse.down()`. A splitter is
+ * painted correctly at rest and the proxy is a different element entirely — a clone mounted at
+ * `document.body`, outside the cascade that painted the source. Detached from it, the engine's
+ * `--dock-splitter-*` defaults (declared on `.neo-dashboard`) and each consumer's values (declared
+ * as descendant rules under an app root) all resolve empty, and the affordance disappears at the
+ * one moment it exists to say "you are moving something".
+ *
+ * So this witness is only meaningful if it CROSSES the drag threshold and inspects while the
+ * gesture is still held. A resting assertion here would re-certify the surface that was never
+ * broken — which is precisely how the defect passed review.
+ *
+ * Both real consumer shapes run, for the reason recorded at HOSTS below.
+ *
+ * Run: NEO_E2E_PORT=49241 NEO_TEST_SKIP_CI=true npx playwright test dashboard/DockSplitterProxyPaintNL -c test/playwright/playwright.config.e2e.mjs --workers=1
+ */
+/**
+ * Both real consumer shapes, because the two fail for DIFFERENT reasons if the fix is wrong.
+ * The example carries no application dock CSS, so it proves the ENGINE floor travels; AgentOS
+ * declares its values as a descendant rule under an app root, which is the half a scope-class
+ * fix would silently drop. A green on one alone leaves the other's failure mode untested.
+ */
+const HOSTS = [
+    {name: 'the example (engine floor, no app dock CSS)', url: '/examples/dashboard/dock/',   ready: '.neo-dashboard-dock-splitter'},
+    {name: 'AgentOS (consumer values under an app root)', url: '/apps/agentos/index.html',    ready: '.fm-fleet-cockpit .neo-dashboard-dock-splitter'}
+];
+
+test.describe('Neo.dashboard.DockSplitter — the drag proxy carries its paint', () => {
+    test.setTimeout(90000);
+
+    for (const host of HOSTS) {
+    test(`a live drag proxy resolves the splitter tokens it was cloned from — ${host.name}`, async ({page}) => {
+        await page.goto(host.url);
+        page.on('pageerror', error => console.error('BROWSER JS ERROR:', error.message));
+
+        const splitter = page.locator(host.ready).first();
+        await expect(splitter, 'the host must render a splitter to drag').toBeVisible({timeout: 60000});
+
+        // The source's own resolved paint, read BEFORE the gesture. This is the comparison target:
+        // the proxy is correct when it matches what the cascade gave the element it cloned, which
+        // is a stronger statement than "not transparent" and holds for any consumer.
+        const source = await splitter.evaluate(el => {
+            const style = getComputedStyle(el);
+            return {
+                background: style.backgroundColor,
+                handleSize: style.getPropertyValue('--dock-splitter-handle-size').trim()
+            }
+        });
+
+        expect(source.background, 'the resting splitter must itself be painted, or the comparison is vacuous')
+            .not.toBe('rgba(0, 0, 0, 0)');
+
+        const box = await splitter.boundingBox();
+        const sx  = box.x + box.width  / 2,
+              sy  = box.y + box.height / 2;
+
+        await page.mouse.move(sx, sy);
+        await page.mouse.down();
+        // Two moves: the first crosses the drag threshold that creates the proxy, the second is a
+        // real displacement so the proxy is genuinely in flight rather than mid-initialisation.
+        await page.mouse.move(sx + 12, sy, {steps: 4});
+        await page.mouse.move(sx + 60, sy, {steps: 15});
+
+        const proxy = page.locator('body > .neo-dragproxy.neo-dashboard-dock-splitter').first();
+
+        try {
+            await expect(proxy, 'crossing the drag threshold must create a splitter proxy').toBeVisible({timeout: 10000});
+
+            const measured = await proxy.evaluate(el => {
+                const style = getComputedStyle(el);
+                return {
+                    background: style.backgroundColor,
+                    handleSize: style.getPropertyValue('--dock-splitter-handle-size').trim()
+                }
+            });
+
+            // The regression state, named explicitly so a failure reads as the defect rather than
+            // as a generic mismatch: an unscoped proxy computes a transparent background.
+            expect(measured.background,
+                `the proxy must not fall back to transparent — measured ${measured.background}, source ${source.background}`
+            ).not.toBe('rgba(0, 0, 0, 0)');
+
+            expect(measured.background,
+                'the proxy resolves the same background the cascade gave its source'
+            ).toBe(source.background);
+
+            // The handle is the half that fails silently: a 0px handle still renders a band, so a
+            // background-only assertion would pass a proxy whose grip had vanished.
+            expect(measured.handleSize,
+                `the proxy resolves the handle metric too — measured '${measured.handleSize}', source '${source.handleSize}'`
+            ).toBe(source.handleSize);
+        } finally {
+            // Always release: a held button leaks into every later test in the worker.
+            await page.mouse.up()
+        }
+    })
+    }
+});

--- a/test/playwright/e2e/dashboard/DockSplitterProxyPaintNL.spec.mjs
+++ b/test/playwright/e2e/dashboard/DockSplitterProxyPaintNL.spec.mjs
@@ -25,8 +25,13 @@ import {test, expect} from '../../fixtures.mjs';
  * fix would silently drop. A green on one alone leaves the other's failure mode untested.
  */
 const HOSTS = [
-    {name: 'the example (engine floor, no app dock CSS)', url: '/examples/dashboard/dock/',   ready: '.neo-dashboard-dock-splitter'},
-    {name: 'AgentOS (consumer values under an app root)', url: '/apps/agentos/index.html',    ready: '.fm-fleet-cockpit .neo-dashboard-dock-splitter'}
+    // `handleDiscriminates` records where the handle assertion actually has teeth. AgentOS opts OUT
+    // of the grip (`--dock-splitter-handle-size: 0`, a deliberate FM design statement), so comparing
+    // proxy-to-source there is `0 === 0` — it passes whether or not the metric travelled. Naming
+    // that keeps it from reading as coverage it is not, and the example host, which inherits the
+    // engine's 36px default, is what genuinely covers the axis.
+    {name: 'the example (engine floor, no app dock CSS)', url: '/examples/dashboard/dock/', ready: '.neo-dashboard-dock-splitter',                    handleDiscriminates: true},
+    {name: 'AgentOS (consumer values under an app root)', url: '/apps/agentos/index.html',  ready: '.fm-fleet-cockpit .neo-dashboard-dock-splitter', handleDiscriminates: false}
 ];
 
 test.describe('Neo.dashboard.DockSplitter — the drag proxy carries its paint', () => {
@@ -53,6 +58,12 @@ test.describe('Neo.dashboard.DockSplitter — the drag proxy carries its paint',
 
         expect(source.background, 'the resting splitter must itself be painted, or the comparison is vacuous')
             .not.toBe('rgba(0, 0, 0, 0)');
+
+        // Guards the flag above rather than trusting it: if a consumer's handle opt-out changed,
+        // this fails instead of silently turning a real assertion into `0 === 0` or the reverse.
+        host.handleDiscriminates
+            ? expect(source.handleSize, `${host.name} is declared to cover the handle axis, so its source handle must be non-zero`).not.toBe('0')
+            : expect(source.handleSize, `${host.name} is declared to opt out of the handle, so its source handle must be zero`).toBe('0');
 
         const box = await splitter.boundingBox();
         const sx  = box.x + box.width  / 2,
@@ -90,6 +101,9 @@ test.describe('Neo.dashboard.DockSplitter — the drag proxy carries its paint',
 
             // The handle is the half that fails silently: a 0px handle still renders a band, so a
             // background-only assertion would pass a proxy whose grip had vanished.
+            // Asserted on both hosts, but only DISCRIMINATING where the source handle is non-zero —
+            // see `handleDiscriminates`. On a zero-handle consumer this is a consistency check, not
+            // evidence that the metric travelled.
             expect(measured.handleSize,
                 `the proxy resolves the handle metric too — measured '${measured.handleSize}', source '${source.handleSize}'`
             ).toBe(source.handleSize);

--- a/test/playwright/unit/dashboard/DockSplitter.spec.mjs
+++ b/test/playwright/unit/dashboard/DockSplitter.spec.mjs
@@ -233,3 +233,44 @@ test.describe('Neo.dashboard.DockSplitter', () => {
         expect(rejected).toHaveLength(1)                                         // the rejection event fired instead
     });
 });
+
+test.describe('Neo.dashboard.DockSplitter — drag-proxy token projection', () => {
+    /**
+     * The projection restates the `--dock-splitter-*` contract in JS, and a restatement drifts.
+     * This is the guard that makes the restatement safe: it parses the engine's own `.neo-dashboard`
+     * block and fails when the two sets diverge, so a token added to the stylesheet without a line
+     * in `proxyProjectedTokens` turns this red instead of silently vanishing from every drag proxy.
+     *
+     * Parsing the SSOT rather than pinning a count on purpose — a count arm would pass whenever an
+     * addition and a removal cancelled out.
+     */
+    test('the projected token list matches the engine stylesheet exactly, in both directions', async () => {
+        const fs   = await import('node:fs/promises'),
+              path = await import('node:path'),
+              url  = await import('node:url');
+
+        const scssPath = path.resolve(
+            path.dirname(url.fileURLToPath(import.meta.url)),
+            '../../../../resources/scss/src/dashboard/Container.scss'
+        );
+
+        const source = await fs.readFile(scssPath, 'utf8'),
+              open   = source.indexOf('.neo-dashboard {'),
+              block  = source.slice(open, source.indexOf('\n}', open));
+
+        expect(open, 'the .neo-dashboard token block must be locatable').toBeGreaterThan(-1);
+
+        const declared = [...new Set(
+            [...block.matchAll(/(--dock-splitter-[a-z-]+)\s*:/g)].map(match => match[1])
+        )].sort();
+
+        // Non-vacuity: a regex that matched nothing would make the comparison below trivially
+        // satisfiable by an empty projection list.
+        expect(declared.length, 'the parse must find the engine tokens, not silently match nothing')
+            .toBeGreaterThan(5);
+
+        expect([...DockSplitter.proxyProjectedTokens].sort(),
+            'every engine splitter token is projected, and nothing is projected that the engine does not declare'
+        ).toEqual(declared)
+    })
+});


### PR DESCRIPTION
Resolves neomjs/neo#17616

The splitter's drag proxy renders unpainted — transparent background, 0×0 handle — so the affordance vanishes at exactly the moment it exists to say "you are moving something". Found by @neo-gpt-emmy at `origin/dev` `17d41fd622`, reproduced in **both** AgentOS and `examples/dashboard/dock`, which is what makes it engine-tier rather than an app defect.

The tokens do not fail to apply; they have nothing to inherit from. `DragZone` mounts the proxy at `document.body`, so the clone keeps the splitter's classes and loses every ancestor — and the paint is scoped to ancestors twice over: the engine declares `--dock-splitter-*` on `.neo-dashboard`, and each consumer declares its values as a **descendant rule** (`.fm-fleet-cockpit .neo-dashboard-dock-splitter`).

`DockSplitter#projectProxyTokens()` reads the SOURCE element's computed values at drag start and sets them inline on the proxy. Reading the source is what makes it consumer-agnostic: the source has already been through the real cascade, so the projection never needs to know which class carried a value.

Related: neomjs/neo#17538 · PR neomjs/neo#17531 · neomjs/neo#17211

Evidence: L3 (real pointer drag crossing `drag:start`/`createDragProxy`, computed-style comparison against the source while the gesture is held, on both consumer shapes) → L3 required (AC-1 through AC-4 are rendered effects). No residuals. ⚠️ The e2e half does not gate in CI — no workflow runs `playwright.config.e2e.mjs` (#17596 owns that gap) — so the parity control was placed in the CI-running unit suite deliberately.

## AC Evidence

| Acceptance criterion | Evidence |
|---|---|
| AC-1 | **AC narrowed on review — it claimed more than this diff delivers.** It read "background, handle, and the active state"; the operator's oracle is a VISIBILITY contract (*the source may fade, the proxy must remain visible*) and "active state" was scope added on top, never implemented and never evidenced — the witness compares against the **pre-gesture resting** paint, not a drag-active palette. Narrowed in neomjs/neo#17616 to the contract actually held: the in-flight proxy stays visible carrying its source's resolved `--dock-splitter-*`. Asserted as `proxy === source` for background and handle, never against a literal. |
| AC-2 | The witness crosses the threshold: `mouse.down()` then two moves (12px to create the proxy, 60px so it is genuinely in flight), and inspects **while held**. This is the AC that exists because the shipped arms stopped at `mouse.down()`. |
| AC-3 | **Non-vacuity, mutation-verified.** Removing `projectProxyTokens()` reproduces the reported state exactly: `measured rgba(0, 0, 0, 0), source color(srgb 0 0 0 / 0.09)` — Emmy's independent measurement, from a different instrument. Restored: green. |
| AC-4 | **Both consumers, and they fail differently if the fix is wrong.** `examples/dashboard/dock` carries no app dock CSS, so a green proves the ENGINE floor travels; AgentOS declares values under an app root, the half a scope-class fix would silently drop. 2/2 green. **Handle-axis honesty:** AgentOS opts out of the grip (`--dock-splitter-handle-size: 0`), so its handle comparison is `0 === 0` and does not discriminate — the host table records which arm does, and a precondition guards that flag (example source handle must be non-zero, AgentOS's must be zero) so a changed opt-out fails loudly instead of turning a real assertion into a tautology. |
| AC-5 | Source splitter behaviour during drag untouched — no change to fade, cursor, or geometry paths. |
| AC-6 | N/A by disposition: the scope class is rejected, so the `.neo-dashboard` token-only measurement is no longer a precondition of anything. The reversal and its evidence are recorded in neomjs/neo#17616's body. |

## Deltas from ticket

**The ticket's AC-1 was narrowed rather than the behaviour widened.** @neo-gpt-emmy's review found it certifying a rendered active state that neither the operator's oracle nor this diff contains. Implementing one would have been new scope inheriting authority it was never granted; narrowing states what is true. A rendered proxy active state remains a legitimate future ask.

**The ticket's own recommendation was inverted before implementation, and neomjs/neo#17616 records the reversal rather than editing it away.** The first candidate — add a dock scope class to the proxy, extending the idiom `DragZone` already uses for the theme class — is wrong: consumers scope splitter values as descendant selectors, so a scope class restores the engine floor and leaves every consumer value absent. That paints the proxy **wrong** rather than not at all, and wrong is the harder failure to notice.

Worth recording *how* that was nearly shipped: I ran the falsifier I had promised — *does `.neo-dashboard` carry non-token rules that would misbehave on a body-mounted proxy?* — and it came back clean, custom properties only. The control was correctly designed and correctly executed, and it answered **"is it harmful?"** when the deciding question was **"is it enough?"**

`DockTabSortZone#getDragProxyConfig` (`:906-928`) solves the same class of problem for the preview palette by walking the parent chain for the nearest-ancestor theme. It does not transfer: those values are theme-scoped, splitter values are app-root-scoped, and `fm-fleet-cockpit` / `workstation-workspace` share no prefix a walk can match. **The precedent was real and the transfer was not.**

Placement follows from the same reading: `DockSplitter` creates a plain `DragZone` (the `getDragProxyConfig` overrides are on tab **sort** zones), so this lives on the splitter's own proxy config. Generic `DragZone` must not learn about `--dock-*` tokens.

## Test Evidence

- `dashboard/DockSplitterProxyPaintNL` — 2/2 green, one arm per consumer shape.
- **Mutation control on the fix**: projection removed → `rgba(0, 0, 0, 0)` vs source `color(srgb 0 0 0 / 0.09)`, i.e. the reported defect reproduced by the witness. Restored → green.
- **Mutation control on the parity spec**: dropping one token from `proxyProjectedTokens` turns it red. The JS list is a restatement of the stylesheet contract and a restatement drifts, so the spec parses the engine's `.neo-dashboard` block and compares **both directions** — a count arm would pass whenever an addition and a removal cancelled out.
- `test/playwright/unit/dashboard/` — 551 passed, no regression.
- Deliberately not asserted: any literal colour. The comparison is proxy-against-source, so the witness stays correct when a consumer restyles.

## Post-Merge Validation

None required — every acceptance property is asserted at this head on both consumer shapes.

Authored by Grace (Claude Opus 5, Claude Code). Session eb671e6e-ca17-4a53-8069-64fd5885ce84.

