### PR TITLE
fix(workstation): resolve headed witness residuals (#17564)

### DIFF
--- a/src/component/Base.mjs
+++ b/src/component/Base.mjs
@@ -735,23 +735,27 @@ class Component extends Abstract {
 
     /**
      * Triggered after the theme config got changed
+     * @summary Keeps a local theme carrier unless the logical parent is also the physical DOM parent.
      * @param {String|null} value
      * @param {String|null} oldValue
      * @protected
      */
     afterSetTheme(value, oldValue) {
         if (value || oldValue !== undefined) {
-            let me          = this,
-                {cls}       = me,
-                needsUpdate = false;
+            let me            = this,
+                {cls, parent} = me,
+                inheritsTheme = value === parent?.theme && me.parentId === parent?.id,
+                needsUpdate   = false;
 
             if (oldValue && cls.includes(oldValue)) {
                 NeoArray.remove(cls, oldValue);
                 needsUpdate = true
             }
 
-            // We do not need to add a DOM based CSS selector, in case the theme is already inherited
-            if (value !== me.parent?.theme) {
+            // `parentComponent` can preserve logical focus / controller ancestry while `parentId`
+            // roots a floating embodiment elsewhere. CSS inheritance crosses only the physical DOM
+            // edge, so omit the local carrier exclusively when both parent roles are the same component.
+            if (!inheritsTheme) {
                 value && NeoArray.add(cls, value);
                 needsUpdate = true
             }

--- a/test/playwright/e2e/workstation/WorkstationDragAffordancesNL.spec.mjs
+++ b/test/playwright/e2e/workstation/WorkstationDragAffordancesNL.spec.mjs
@@ -489,7 +489,17 @@ test.describe('Workstation drag affordances — the flagship journey (Neural Lin
                     trace    = globalThis.__workstationReexitWindowMoves = [];
 
                 main.windowMoveTo = data => {
-                    const entry = {data: {...data}, result: 'pending'};
+                    const
+                        win   = main.openWindows[data.windowName]?.win,
+                        entry = {
+                            data  : {...data},
+                            handle: {
+                                exists : Boolean(win),
+                                closed : win?.closed ?? null,
+                                movable: typeof win?.moveTo === 'function'
+                            },
+                            result: 'pending'
+                        };
 
                     trace.push(entry);
 
@@ -532,6 +542,17 @@ test.describe('Workstation drag affordances — the flagship journey (Neural Lin
             }).toBe(true);
 
             const openingMoveTrace = await page.evaluate(() => globalThis.__workstationReexitWindowMoves);
+
+            expect(
+                openingMoveTrace.every(entry => Number.isFinite(entry.data.x) && Number.isFinite(entry.data.y)),
+                'every native move request carries finite screen coordinates'
+            ).toBe(true);
+            expect(
+                openingMoveTrace.every(entry =>
+                    entry.handle.exists && entry.handle.closed === false && entry.handle.movable
+                ),
+                'every native move request resolves the live named popup handle'
+            ).toBe(true);
 
             test.skip(
                 openingMoveTrace.every(entry => entry.result === false),

--- a/test/playwright/e2e/workstation/WorkstationDragAffordancesNL.spec.mjs
+++ b/test/playwright/e2e/workstation/WorkstationDragAffordancesNL.spec.mjs
@@ -482,9 +482,61 @@ test.describe('Workstation drag affordances — the flagship journey (Neural Lin
                 reexitDrive        = {x: outside.x + 160, y: outside.y + 110},
                 reexitPopupPromise = page.waitForEvent('popup', {timeout: 30000});
 
+            await page.evaluate(() => {
+                const
+                    main     = globalThis.Neo.Main,
+                    original = main.windowMoveTo.bind(main),
+                    trace    = globalThis.__workstationReexitWindowMoves = [];
+
+                main.windowMoveTo = data => {
+                    const entry = {data: {...data}, result: 'pending'};
+
+                    trace.push(entry);
+
+                    let result;
+
+                    try {
+                        result = original(data)
+                    } catch (error) {
+                        entry.result = `throw:${error.message}`;
+                        throw error
+                    }
+
+                    Promise.resolve(result).then(value => {
+                        entry.result = value
+                    }, error => {
+                        entry.result = `reject:${error.message}`
+                    });
+
+                    return result
+                }
+            });
+
             await page.mouse.move(reexitStart.x, reexitStart.y, {steps: 40});
             reexitPopup = await reexitPopupPromise;
             await reexitPopup.waitForLoadState('domcontentloaded');
+
+            // `window.moveTo` is a platform-granted effect. This host can open the popup but may
+            // refuse every physical move (macOS/Chrome window-management policy); that is a stage
+            // ceiling, not evidence that the continuing gesture failed to emit move traffic. The
+            // positive control is strict: at least one call must arrive and EVERY completed result
+            // must be the adapter's verified `false`. Missing calls, pending calls, or any admitted
+            // move keep the behavioral witness live.
+            await expect.poll(() => page.evaluate(() => {
+                const trace = globalThis.__workstationReexitWindowMoves || [];
+
+                return trace.length > 0 && trace.every(entry => entry.result !== 'pending')
+            }), {
+                message: 'the second-generation pointer emits settled native move admissions',
+                timeout: 5000
+            }).toBe(true);
+
+            const openingMoveTrace = await page.evaluate(() => globalThis.__workstationReexitWindowMoves);
+
+            test.skip(
+                openingMoveTrace.every(entry => entry.result === false),
+                'host refused every verified window.moveTo effect; native pointer-follow is stage-bound here'
+            );
 
             const
                 secondVesselGeneration = new URL(reexitPopup.url()).searchParams.get('vesselGeneration'),

--- a/test/playwright/e2e/workstation/WorkstationHumanPopupOverlapNL.spec.mjs
+++ b/test/playwright/e2e/workstation/WorkstationHumanPopupOverlapNL.spec.mjs
@@ -36,10 +36,11 @@ const MATRIX_CELLS = [
             targetSize   : {height: 320, width: 400}
         }
     ],
-    MATRIX_CELL         = MATRIX_CELLS.find(cell =>
+    MATRIX_CELL           = MATRIX_CELLS.find(cell =>
         cell.name === (process.env.NEO_POPUP_CELL || 'large-over-small')),
-    TARGET_ITEM_ID      = 'metrics',
-    TARGET_WORKSPACE_ID = 'workstation-vessel:metrics';
+    PARTIAL_OVERLAP_RATIO = .68,
+    TARGET_ITEM_ID        = 'metrics',
+    TARGET_WORKSPACE_ID   = 'workstation-vessel:metrics';
 
 if (!MATRIX_CELL) {
     throw new Error(`Unknown NEO_POPUP_CELL: ${process.env.NEO_POPUP_CELL}`)
@@ -94,6 +95,20 @@ function readBrowserGeometry(page) {
             width : globalThis.outerWidth
         }
     }))
+}
+
+/**
+ * @summary Preserves the original popup-witness failure when a diagnostic page has already closed.
+ * @param {import('@playwright/test').Page} page
+ * @param {Function} reader
+ * @returns {Promise<Object>}
+ */
+async function readPageDiagnostic(page, reader) {
+    try {
+        return await reader()
+    } catch (error) {
+        return {closed: page.isClosed(), error: error.message}
+    }
 }
 
 /**
@@ -625,6 +640,17 @@ test.describe('Workstation — human popup-over-popup conversion (#16117)', () =
                     width     : globalThis.screen.availWidth
                 }));
 
+            const requiredStageWidth = Math.ceil(
+                cell.sourceSize.width + cell.targetSize.width -
+                PARTIAL_OVERLAP_RATIO * Math.min(cell.sourceSize.width, cell.targetSize.width)
+            );
+
+            test.skip(
+                screen.width < requiredStageWidth,
+                `${cell.name}: ${screen.width}px stage cannot contain the ${requiredStageWidth}px ` +
+                'minimum union for two reachable popup extents at the calibrated partial overlap'
+            );
+
             await setNativeBounds(mainHandle, {
                 height: Math.min(820, screen.height - 80),
                 left  : screen.left + 24,
@@ -782,7 +808,7 @@ test.describe('Workstation — human popup-over-popup conversion (#16117)', () =
                         positioned = await positionTargetForPartialOverlap({
                             app,
                             managerId,
-                            ratio : .68,
+                            ratio : PARTIAL_OVERLAP_RATIO,
                             source: sourceBefore,
                             targetHandle,
                             targetWindowId
@@ -941,7 +967,10 @@ test.describe('Workstation — human popup-over-popup conversion (#16117)', () =
                                 }
                             }),
                             snapshotA,
-                            sourceBrowser: await readBrowserGeometry(sourcePage),
+                            sourceBrowser: await readPageDiagnostic(
+                                sourcePage,
+                                () => readBrowserGeometry(sourcePage)
+                            ),
                             sourceState  : await app.getComponent(sourceZoneId, [
                                 'isWindowDragging',
                                 'vesselConversionLogicalRect',
@@ -950,14 +979,17 @@ test.describe('Workstation — human popup-over-popup conversion (#16117)', () =
                                 'vesselConversionTargetRect',
                                 'vesselConversionSensor'
                             ]),
-                            targetBrowser: await readBrowserGeometry(targetPage),
-                            targetDom    : await targetPage.evaluate(() => ({
+                            targetBrowser: await readPageDiagnostic(
+                                targetPage,
+                                () => readBrowserGeometry(targetPage)
+                            ),
+                            targetDom: await readPageDiagnostic(targetPage, () => targetPage.evaluate(() => ({
                                 indicators: document.querySelectorAll(
                                     '.neo-dashboard-dock-drop-indicators:not(.neo-dashboard-dock-drop-indicators-hidden)'
                                 ).length,
                                 previews: document.querySelectorAll('.neo-dock-preview-affordance').length,
                                 proxies : document.querySelectorAll('.workstation-vessel-dragproxy').length
-                            })),
+                            }))),
                             workspace: await app.getComponent(wsId, [
                                 'lastVesselParkReceipt',
                                 'lastVesselRestoreReceipt',

--- a/test/playwright/e2e/workstation/WorkstationNL.spec.mjs
+++ b/test/playwright/e2e/workstation/WorkstationNL.spec.mjs
@@ -7,7 +7,7 @@ import {isEngineProfile, isFilmTake}                 from '../utils/gpuIntent.mj
  * @summary Mounted L3 proof for Workstation's dense, living-data workstation.
  *
  * The unit floor owns the document/script contract. This journey drives the REAL tour button
- * and owns what only the App Worker + DOM + Canvas Worker composition can prove: one Provider,
+ * and owns what only the App Worker + DOM + Canvas Worker composition can prove: one root Provider,
  * two stable Store<Model> identities, an exact 100k renderer-rich grid, a sustained capped
  * feed, one owner-exact overflow surface, two real rails, frame-sampled midpoint continuity,
  * Canvas-worker value change (plus pixel change under the presenting profile), exact 160x50 chart
@@ -52,29 +52,30 @@ const readCanvasPixels = async canvas => (await canvas.screenshot()).toString('b
 /**
  * @param {Object} app Neural Link fixture app handle.
  * @param {String} workspaceId Workstation workspace id.
- * @returns {Promise<Object>} Identity-only snapshot (counts deliberately excluded).
+ * @returns {Promise<Object>} Root-provider and stable pane / Store identity snapshot.
  */
 const readIdentity = async (app, workspaceId) => {
     const [providers, scalePanes, feedPanes, listedStores, workspace, securityPaneId] = await Promise.all([
-        app.findInstances({className: 'Neo.state.Provider'}, ['id']),
+        app.findInstances({className: 'Neo.state.Provider'}, ['id', 'parent.id']),
         app.findInstances({className: 'Workstation.view.ScalePane'}, ['id', 'store.id']),
         app.findInstances({className: 'Workstation.view.FeedPane'}, ['id', 'store.id']),
         app.listStores(),
         app.getComponent(workspaceId, ['stateProvider.id']),
         app.callMethod(workspaceId, 'getPaneIdentity', ['security'])
     ]),
-        providerList = asArray(providers),
-        scaleList    = asArray(scalePanes),
-        feedList     = asArray(feedPanes),
-        stores       = asArray(listedStores?.stores ?? listedStores),
-        scaleStore   = stores.find(store => store.id?.endsWith('__scale')),
-        feedStore    = stores.find(store => store.id?.endsWith('__feed'));
+        providerList  = asArray(providers),
+        rootProviders = providerList.filter(provider => !provider.properties?.['parent.id']),
+        scaleList     = asArray(scalePanes),
+        feedList      = asArray(feedPanes),
+        stores        = asArray(listedStores?.stores ?? listedStores),
+        scaleStore    = stores.find(store => store.id?.endsWith('__scale')),
+        feedStore     = stores.find(store => store.id?.endsWith('__feed'));
 
     return {
         feedPaneId         : feedList[0]?.id,
         feedStoreId        : feedStore?.id ?? feedList[0]?.properties?.['store.id'],
-        providerCount      : providerList.length,
-        providerId         : providerList[0]?.id,
+        rootProviderCount  : rootProviders.length,
+        rootProviderId     : rootProviders[0]?.id,
         scalePaneId        : scaleList[0]?.id,
         scaleStoreId       : scaleStore?.id ?? scaleList[0]?.properties?.['store.id'],
         securityPaneId,
@@ -547,9 +548,9 @@ test.describe('Workstation — dense living-data composition', () => {
             beforeIdentity = await readIdentity(app, workspaceId),
             beforeChrome   = await readTabChromeIdentity(app, workspaceId);
 
-        expect(beforeIdentity.providerCount, 'Workstation owns one root StateProvider').toBe(1);
+        expect(beforeIdentity.rootProviderCount, 'Workstation owns one root StateProvider').toBe(1);
         expect(beforeIdentity.workspaceProviderId, 'the workspace references that one Provider')
-            .toBe(beforeIdentity.providerId);
+            .toBe(beforeIdentity.rootProviderId);
         expect(beforeIdentity.scaleStoreId).toBeTruthy();
         expect(beforeIdentity.feedStoreId).toBeTruthy();
         expect(beforeIdentity.securityPaneId, 'the transformed heavy resident has a stable pane identity').toBeTruthy();

--- a/test/playwright/unit/tab/plugin/Overflow.spec.mjs
+++ b/test/playwright/unit/tab/plugin/Overflow.spec.mjs
@@ -9,6 +9,7 @@ setup({
 import {test, expect} from '@playwright/test';
 import Neo            from '../../../../../src/Neo.mjs';
 import * as core      from '../../../../../src/core/_export.mjs';
+import Component      from '../../../../../src/component/Base.mjs';
 
 /**
  * @summary Reactive ancestor fixture for the inherited-theme overflow contract.
@@ -267,6 +268,37 @@ test.describe('Neo.tab.plugin.Overflow (re-entrancy contract)', () => {
 
         expect(plugin.control.theme, 'the floating control follows the source toolbar theme')
             .toBe('neo-theme-neo-light')
+    });
+
+    test('a body-mounted embodiment keeps a local theme carrier when its logical parent owns the same theme', () => {
+        const
+            parent = Neo.create(Component, {
+                appName : 'test-app',
+                id      : 'overflow-theme-logical-parent',
+                theme   : 'neo-theme-neo-dark',
+                windowId: 1
+            }),
+            control = Neo.create(Component, {
+                appName        : 'test-app',
+                parentComponent: parent,
+                parentId       : 'document.body',
+                theme          : 'neo-theme-neo-dark',
+                windowId       : 1
+            });
+
+        try {
+            expect(control.parent, 'focus ancestry still resolves through the logical owner').toBe(parent);
+            expect(control.cls, 'CSS inheritance cannot cross the distinct document.body edge')
+                .toContain('neo-theme-neo-dark');
+
+            control.theme = 'neo-theme-neo-light';
+
+            expect(control.cls).toContain('neo-theme-neo-light');
+            expect(control.cls).not.toContain('neo-theme-neo-dark')
+        } finally {
+            control.destroy();
+            parent.destroy()
+        }
     });
 
     test('a toolbar with no declared theme carries its ancestor theme at creation and follows ancestor switches', async () => {


### PR DESCRIPTION
Resolves #17564

Repairs the real out-of-tree theming regression and closes the remaining Workstation headed-witness ledger without turning host refusals into product failures. A component now omits its local theme carrier only when its logical parent is also its physical DOM parent; the dense tour counts root providers rather than an intentional child menu provider; and the two popup witnesses fail closed on explicit platform/stage capability predicates.

Evidence: L3 (canonical Chrome on the 800px stage: two live Workstation tours plus discriminating native-effect and screen-capacity receipts) → L3 required (diagnose, fix, or honestly reclassify each headed finding). No residuals.

Related: #13158

## AC Evidence

| AC | Evidence |
|---|---|
| AC-1 | Findings 1–4: `WorkstationNL.spec.mjs` proves the root-provider and body-mounted overflow paths live; `Overflow.spec.mjs` pins the physical-vs-logical parent contract; `WorkstationDragAffordancesNL.spec.mjs` requires real settled `windowMoveTo` traffic before classifying a strict all-false host; `WorkstationHumanPopupOverlapNL.spec.mjs` derives the minimum reachable popup-union width before running the retained capable-stage journey. |
| AC-2 | Finding 6: PR #17603 is merged at `886d98b0bf`; its engine/brain boundary guard removes the `chromadb` import failure from the Engine-only Workstation E2E surface. |
| AC-3 | Finding 5: the existing `WorkstationTearOutSourceContinuityNL.spec.mjs` native-place precondition remains unchanged and continues to own its explicit stage refusal. |

## Deltas from ticket

Finding 4 is reclassified as stage-bound rather than repaired in production: the default 760px source plus 360px target at 68% overlap needs a minimum 876px union, while this run mode exposes 800px. The earlier apparent park/drain race was falsified—ordinary move promises settled; repeated impossible off-screen park attempts merely made the final snapshot look perpetually transitional. Finding 6 was already delivered by PR #17603, so this branch does not duplicate it.

## Test Evidence

- Canonical custom E2E profile, post-rebase: the two Workstation tours passed; the same-gesture motion witness skipped only after observing real move calls whose every settled platform verdict was `false`; the popup-over-popup witness skipped because `screen.availWidth` was 800px against its derived 876px minimum.
- Theme red control: the new body-mounted embodiment assertion failed under the old logical-parent-only predicate, then the focused 128-test component/container/overflow battery passed with the physical-parent correction.

## Post-Merge Validation

- [x] No merge-only validation remains; capability-admitting hosts continue into the original behavioral assertions rather than receiving an automatic pass.

## Evolution

The popup investigation first exposed a closed target page, then a park receipt caught during transition. Preserving the original error and tracing settled platform verdicts separated two setup illusions from product behavior: CDP had placed a popup beyond the reachable desktop, and each retry was fresh rather than wedged. The durable result is a mathematical stage predicate, not a timeout or a weakened docking invariant.

Authored by Euclid (OpenAI GPT-5.6 Sol Ultra, Codex Desktop). Session 01a02ead-f0db-7b30-b4e2-54189808ab54.
