### PR TITLE
feat(wake): the manifest names a wake-eligible seat that no route serves (#17615)

### DIFF
--- a/ai/daemons/wake/buildReceiverManifest.mjs
+++ b/ai/daemons/wake/buildReceiverManifest.mjs
@@ -54,7 +54,6 @@ import path            from 'node:path';
 import {pathToFileURL} from 'node:url';
 
 import {loadWakeReceiverManifest} from './receiver.mjs';
-import {collectUnroutedEligibleIdentities} from './wakeTargetEligibility.mjs';
 import {withOutboxLock}           from './outboxLock.mjs';
 import {
     DEFAULT_CONTEXT_GATE_MAX_TOKENS,
@@ -539,7 +538,14 @@ export function parseManifestBuilderArgs(argv = process.argv.slice(2)) {
         adapterConfigPath: read('--adapter-config'),
         attemptTimeoutMs : attemptTimeoutRaw ? Number(attemptTimeoutRaw) : undefined,
         instanceType     : read('--instance'),
-        instanceAddress  : read('--instance-address')
+        instanceAddress  : read('--instance-address'),
+        // Comma-separated canonical `@handle`s. Absent ⇒ no expectation, hence no unrouted warning:
+        // a host-edge box legitimately has no roster to compare against, and inventing one there
+        // would make this guard cry on exactly the hosts it knows least about.
+        expectedSeatIdentities: (read('--expected-seats') || '')
+            .split(',')
+            .map(entry => entry.trim())
+            .filter(Boolean)
     }
 }
 
@@ -589,8 +595,9 @@ export async function runManifestBuilder({
     attemptTimeoutMs,
     instanceType,
     instanceAddress,
-    lockOptions = {},
-    logger      = console
+    expectedSeatIdentities = [],
+    lockOptions            = {},
+    logger                 = console
 }) {
     if (!subscriptionsPath || !manifestPath) {
         throw new Error('Usage: --subscriptions <file|-> --manifest <absolute path> [--identity <@handle>] [--adapter-config <file.json>] [--attempt-timeout-ms <n>] [--instance pid|userDataDir --instance-address <value>]');
@@ -678,12 +685,19 @@ export async function runManifestBuilder({
     // unprovisioned. It also cannot self-heal: `manage_wake_subscription` acts on the CALLER, so a
     // seat's row can only be minted by that seat — which is why the line says so rather than
     // sending the reader to a tool that cannot act for them.
-    const unrouted = collectUnroutedEligibleIdentities({
-        routedIdentities: Object.values(manifest.routes).map(route => route?.agentIdentity)
-    });
+    //
+    // `expectedSeatIdentities` arrives as PLAIN DATA and both sides are compared as given. That is
+    // this module's graphless boundary, not an oversight: it imports nothing from the graph so
+    // host-edge tooling stays runnable without the plane, exactly as subscription records already
+    // arrive from whoever queried them. The caller derives the census (`wakeSeatIdentities` in
+    // `wakeTargetEligibility.mjs` is the canonical source) and hands it over canonical.
+    const routedIdentities = new Set(
+              Object.values(manifest.routes).map(route => route?.agentIdentity).filter(Boolean)
+          ),
+          unroutedSeats    = expectedSeatIdentities.filter(seat => seat && !routedIdentities.has(seat)).sort();
 
-    for (const identity of unrouted) {
-        logger.log(`  WARN ${identity}: wake-eligible with no route — that seat must run ` +
+    for (const seat of unroutedSeats) {
+        logger.log(`  WARN ${seat}: expected wake seat with no route — that seat must run ` +
                    `manage_wake_subscription({action:'subscribe'}) itself; the tool acts on the caller`);
     }
 

--- a/ai/daemons/wake/buildReceiverManifest.mjs
+++ b/ai/daemons/wake/buildReceiverManifest.mjs
@@ -54,6 +54,7 @@ import path            from 'node:path';
 import {pathToFileURL} from 'node:url';
 
 import {loadWakeReceiverManifest} from './receiver.mjs';
+import {collectUnroutedEligibleIdentities} from './wakeTargetEligibility.mjs';
 import {withOutboxLock}           from './outboxLock.mjs';
 import {
     DEFAULT_CONTEXT_GATE_MAX_TOKENS,
@@ -663,6 +664,27 @@ export async function runManifestBuilder({
         if (route?.harnessTargetMetadata?.addressType === 'pid') {
             logger.log(`  WARN ${id}: carried pid tuple is ephemeral — re-run with --instance userDataDir to make it durable`);
         }
+    }
+
+    // The same reasoning as the skip loop below, one scope wider. That loop surfaces a seat whose
+    // route was ATTEMPTED and produced nothing; this surfaces a seat that was never attempted at
+    // all, because no subscription for it exists. Nothing else in this process would ever say so:
+    // a manifest missing a seat is simply smaller than the roster, and a smaller set reads as
+    // information to nobody. That silence is how a live seat spent its whole existence receiving
+    // another seat's wakes and none of its own.
+    //
+    // Never fails the build. A missing route is a provisioning gap, not a manifest defect, and
+    // failing closed here would block route generation for every other seat because one is
+    // unprovisioned. It also cannot self-heal: `manage_wake_subscription` acts on the CALLER, so a
+    // seat's row can only be minted by that seat — which is why the line says so rather than
+    // sending the reader to a tool that cannot act for them.
+    const unrouted = collectUnroutedEligibleIdentities({
+        routedIdentities: Object.values(manifest.routes).map(route => route?.agentIdentity)
+    });
+
+    for (const identity of unrouted) {
+        logger.log(`  WARN ${identity}: wake-eligible with no route — that seat must run ` +
+                   `manage_wake_subscription({action:'subscribe'}) itself; the tool acts on the caller`);
     }
 
     // Skips are printed, never swallowed: a seat that silently produces no route is indistinguishable

--- a/ai/daemons/wake/daemon.mjs
+++ b/ai/daemons/wake/daemon.mjs
@@ -89,7 +89,7 @@ import {
     filterEventsByWatermark,
     maxLogId
 } from './wokenWatermark.mjs';
-import {IDENTITIES} from '../../graph/identityRoots.mjs';
+import {isWakeTargetEligible} from './wakeTargetEligibility.mjs';
 
 // Config-derived paths + PID_FILE (below) are declared here but ASSIGNED in initConfigDerivedState()
 // (called from the guarded main(), never at module-load): a stale memory-core overlay would otherwise
@@ -112,15 +112,6 @@ const CODEX_TURN_START_PROOF_TIMEOUT_MS = Number(process.env.WAKE_CODEX_TURN_STA
 const CODEX_TURN_START_PROOF_POLL_MS    = Number(process.env.WAKE_CODEX_TURN_START_PROOF_POLL_MS) || 1000;
 const CODEX_WAKE_SUBMIT_NONCE_PREFIX    = 'NEO_WAKE_SUBMIT_NONCE:';
 const WOKEN_MESSAGE_IDS_STATE_KEY       = '__messageIdsByIdentity';
-
-const identityParticipationById = new Map(
-    IDENTITIES
-        .filter(identity => identity.type === 'AgentIdentity')
-        .map(identity => [
-            normalizeAgentIdentityNodeId(identity.id),
-            identity.properties?.participationStatus || 'active'
-        ])
-);
 
 /**
  * @summary Loads durable GraphLog watermarks plus stable per-identity message wake claims.
@@ -685,23 +676,6 @@ function evaluateSubscription(sub, trace, entity, nodesMap, edgesMap) {
         default:
             return null;
     }
-}
-
-/**
- * @summary True when a wake subscription target may receive wake delivery.
- *
- * Unknown identities stay eligible for forks/local custom agents. Known repo
- * identities with non-active participationStatus are filtered before coalescing
- * so they never create delivery attempts or retries.
- * @param {String} identity Agent identity.
- * @returns {Boolean}
- */
-function isWakeTargetEligible(identity) {
-    if (!identity) return true;
-    const normalizedIdentity  = normalizeAgentIdentityNodeId(identity),
-          participationStatus = identityParticipationById.get(normalizedIdentity);
-
-    return !participationStatus || participationStatus === 'active';
 }
 
 /**

--- a/ai/daemons/wake/wakeTargetEligibility.mjs
+++ b/ai/daemons/wake/wakeTargetEligibility.mjs
@@ -1,0 +1,73 @@
+import {IDENTITIES}                   from '../../graph/identityRoots.mjs';
+import {normalizeAgentIdentityNodeId} from '../../graph/normalizeAgentIdentityNodeId.mjs';
+
+/**
+ * @module Neo.ai.daemons.wake.wakeTargetEligibility
+ * @summary The single definition of "may this identity receive a wake", plus the roster-versus-
+ * manifest difference that detects a seat nobody routed.
+ *
+ * Extracted from the wake daemon rather than copied into the manifest builder. Both need the same
+ * participation rule, and a second copy would drift — the builder would eventually warn about seats
+ * the daemon is happily serving, or stay silent about ones it refuses. The daemon is an entry point
+ * and exports nothing, so sharing required a module; this is that module and nothing more.
+ */
+
+/**
+ * @summary Canonical identity → participation status, built from the repo's identity roster.
+ * @member {Map<String,String>} identityParticipationById
+ */
+export const identityParticipationById = new Map(
+    IDENTITIES
+        .filter(identity => identity.type === 'AgentIdentity')
+        .map(identity => [
+            normalizeAgentIdentityNodeId(identity.id),
+            identity.properties?.participationStatus || 'active'
+        ])
+);
+
+/**
+ * @summary True when a wake subscription target may receive wake delivery.
+ *
+ * Unknown identities stay eligible for forks/local custom agents. Known repo identities with
+ * non-active participationStatus are filtered before coalescing so they never create delivery
+ * attempts or retries.
+ * @param {String} identity Agent identity.
+ * @param {Map<String,String>} [participation=identityParticipationById] Injectable for tests.
+ * @returns {Boolean}
+ */
+export function isWakeTargetEligible(identity, participation=identityParticipationById) {
+    if (!identity) return true;
+    const normalizedIdentity  = normalizeAgentIdentityNodeId(identity),
+          participationStatus = participation.get(normalizedIdentity);
+
+    return !participationStatus || participationStatus === 'active';
+}
+
+/**
+ * @summary Canonical, wake-eligible identities that no route serves.
+ *
+ * The absence this exists to make visible has no error state of its own: a manifest missing a seat
+ * is simply smaller than the roster, and nothing reads a smaller set as information. That is how a
+ * live seat spent its whole existence receiving another seat's wakes and none of its own — no
+ * warning fired, because none was ever written.
+ *
+ * Anchored to {@link isWakeTargetEligible} on purpose. Most roster entries legitimately have no
+ * route at any moment — benched, dark, never-connected — and warning about those would make this
+ * noise on every build and get it ignored inside a week. Reusing the daemon's own predicate means
+ * the warning fires for exactly the seats the daemon would try to deliver to, and for no others.
+ *
+ * Pure over its inputs (the roster is injectable) so the difference is testable without a live
+ * plane, matching `collectThemeCoverageFailures`'s shape in the theme-coverage guard.
+ *
+ * @param {Object} options
+ * @param {String[]} options.routedIdentities Identities the manifest actually carries a route for.
+ * @param {Map<String,String>} [options.participation=identityParticipationById] Roster to test against.
+ * @returns {String[]} Canonical ids, sorted, that are eligible and unrouted.
+ */
+export function collectUnroutedEligibleIdentities({routedIdentities=[], participation=identityParticipationById}={}) {
+    const routed = new Set(routedIdentities.filter(Boolean).map(normalizeAgentIdentityNodeId));
+
+    return [...participation.keys()]
+        .filter(identity => !routed.has(identity) && isWakeTargetEligible(identity, participation))
+        .sort()
+}

--- a/ai/daemons/wake/wakeTargetEligibility.mjs
+++ b/ai/daemons/wake/wakeTargetEligibility.mjs
@@ -3,17 +3,29 @@ import {normalizeAgentIdentityNodeId} from '../../graph/normalizeAgentIdentityNo
 
 /**
  * @module Neo.ai.daemons.wake.wakeTargetEligibility
- * @summary The single definition of "may this identity receive a wake", plus the roster-versus-
- * manifest difference that detects a seat nobody routed.
+ * @summary Two different questions about a wake identity, kept apart on purpose: may it RECEIVE a
+ * wake, and should it HOLD a route.
  *
- * Extracted from the wake daemon rather than copied into the manifest builder. Both need the same
- * participation rule, and a second copy would drift — the builder would eventually warn about seats
- * the daemon is happily serving, or stay silent about ones it refuses. The daemon is an entry point
- * and exports nothing, so sharing required a module; this is that module and nothing more.
+ * Extracted from the wake daemon rather than copied. Both the daemon and route tooling need the
+ * participation rule, a second copy would drift, and the daemon is an entry point that exports
+ * nothing. This module owns the graph read so the manifest builder does not have to — that builder
+ * documents itself as importing nothing from the graph, and honouring it is what keeps host-edge
+ * tooling runnable without the plane it is being wired to.
+ *
+ * **Conflating the two questions was a real defect.** Receive-permission is deliberately permissive:
+ * an unknown identity stays eligible so forks and local custom agents keep working. Route-population
+ * is a census of seats that ought to exist. Reusing the permission predicate as the census warned
+ * about the human owner — permitted to receive a wake, and not a seat. It surfaced only when the
+ * collector was run against the real roster: a fixture containing agents alone cannot reproduce it,
+ * which is why the controls here read the live roster rather than a hand-built map.
  */
 
 /**
- * @summary Canonical identity → participation status, built from the repo's identity roster.
+ * @summary Canonical identity → participation status, over every roster entry.
+ *
+ * Permission, not census. This deliberately includes humans and system accounts, because
+ * {@link isWakeTargetEligible} answers *may this receive a wake*, which is not *should this have a
+ * route*. Do not reuse it as a route expectation.
  * @member {Map<String,String>} identityParticipationById
  */
 export const identityParticipationById = new Map(
@@ -26,11 +38,33 @@ export const identityParticipationById = new Map(
 );
 
 /**
+ * @summary The identities expected to hold a wake route: active agent seats, canonical and sorted.
+ *
+ * `accountType` is the discriminator the roster already carries — `agent` for seats, `human` for the
+ * owner, `system` for service accounts. Both filters are load-bearing: a retired agent is a seat
+ * that should NOT be routed, and an active human is not a seat at all.
+ *
+ * Exported as canonical ids so a consumer can compare without normalising, which is what lets the
+ * manifest builder stay free of graph imports.
+ * @member {String[]} wakeSeatIdentities
+ */
+export const wakeSeatIdentities = IDENTITIES
+    .filter(identity =>
+        identity.type === 'AgentIdentity' &&
+        identity.properties?.accountType === 'agent' &&
+        (identity.properties?.participationStatus || 'active') === 'active')
+    .map(identity => normalizeAgentIdentityNodeId(identity.id))
+    .sort();
+
+/**
  * @summary True when a wake subscription target may receive wake delivery.
  *
  * Unknown identities stay eligible for forks/local custom agents. Known repo identities with
  * non-active participationStatus are filtered before coalescing so they never create delivery
  * attempts or retries.
+ *
+ * Semantics unchanged from the daemon's original — deliberately. Tightening delivery permission is a
+ * different decision from tightening a route census, and only the second is in scope here.
  * @param {String} identity Agent identity.
  * @param {Map<String,String>} [participation=identityParticipationById] Injectable for tests.
  * @returns {Boolean}
@@ -41,33 +75,4 @@ export function isWakeTargetEligible(identity, participation=identityParticipati
           participationStatus = participation.get(normalizedIdentity);
 
     return !participationStatus || participationStatus === 'active';
-}
-
-/**
- * @summary Canonical, wake-eligible identities that no route serves.
- *
- * The absence this exists to make visible has no error state of its own: a manifest missing a seat
- * is simply smaller than the roster, and nothing reads a smaller set as information. That is how a
- * live seat spent its whole existence receiving another seat's wakes and none of its own — no
- * warning fired, because none was ever written.
- *
- * Anchored to {@link isWakeTargetEligible} on purpose. Most roster entries legitimately have no
- * route at any moment — benched, dark, never-connected — and warning about those would make this
- * noise on every build and get it ignored inside a week. Reusing the daemon's own predicate means
- * the warning fires for exactly the seats the daemon would try to deliver to, and for no others.
- *
- * Pure over its inputs (the roster is injectable) so the difference is testable without a live
- * plane, matching `collectThemeCoverageFailures`'s shape in the theme-coverage guard.
- *
- * @param {Object} options
- * @param {String[]} options.routedIdentities Identities the manifest actually carries a route for.
- * @param {Map<String,String>} [options.participation=identityParticipationById] Roster to test against.
- * @returns {String[]} Canonical ids, sorted, that are eligible and unrouted.
- */
-export function collectUnroutedEligibleIdentities({routedIdentities=[], participation=identityParticipationById}={}) {
-    const routed = new Set(routedIdentities.filter(Boolean).map(normalizeAgentIdentityNodeId));
-
-    return [...participation.keys()]
-        .filter(identity => !routed.has(identity) && isWakeTargetEligible(identity, participation))
-        .sort()
 }

--- a/test/playwright/unit/ai/daemons/wake/buildReceiverManifest.spec.mjs
+++ b/test/playwright/unit/ai/daemons/wake/buildReceiverManifest.spec.mjs
@@ -749,8 +749,15 @@ test.describe('runManifestBuilder — strict-lock + boot truths', () => {
             adapterConfigPath: 'adapters.json',
             attemptTimeoutMs : 15000,
             instanceType     : 'userDataDir',
-            instanceAddress  : '/seat/path'
+            instanceAddress  : '/seat/path',
+            // Absent `--expected-seats` parses to an empty census, which the builder reads as "no
+            // expectation" rather than "no seats" — the distinction that keeps a host-edge build quiet.
+            expectedSeatIdentities: []
         });
+
+        expect(parseManifestBuilderArgs(['--expected-seats', '@a, @b ,,@c']).expectedSeatIdentities,
+            'the flag trims and drops empties rather than emitting blank identities'
+        ).toEqual(['@a', '@b', '@c']);
 
         expect(parseManifestBuilderArgs([]).attemptTimeoutMs).toBeUndefined()
     });
@@ -844,4 +851,91 @@ test.describe('readPublishedRoutes', () => {
             await rm(dir, {force: true, recursive: true})
         }
     });
+});
+
+test.describe('runManifestBuilder — the unrouted-seat warning at the consumer seam', () => {
+    /**
+     * The pure difference is trivial; what needed witnessing is that the BUILDER emits it, with the
+     * exact identity and an actionable instruction, and that publication is unaffected. A helper-only
+     * suite proves the arithmetic and says nothing about the shipped effect. Citing a green suite as
+     * proof of lines no spec asserts is exactly the over-claim these arms exist to close.
+     *
+     * `expectedSeatIdentities` arrives as plain data on purpose: this module imports nothing from the
+     * graph so host-edge tooling stays runnable without the plane. Absent input therefore means "no
+     * expectation", not "no seats" — asserted below, because a guard that invents an expectation on a
+     * host it knows nothing about is worse than one that stays quiet.
+     */
+    const runWithExpectations = async (dir, expectedSeatIdentities) => {
+        const manifestPath = path.join(dir, 'routes.json'),
+              input        = path.join(dir, 'subs.json'),
+              lines        = [],
+              logger       = {log: line => lines.push(line)};
+
+        await writeFile(input, JSON.stringify({subscriptions: [webhookSubscription]}));
+
+        const result = await runManifestBuilder({
+            subscriptionsPath: input,
+            manifestPath,
+            instanceType     : INSTANCE.type,
+            instanceAddress  : INSTANCE.address,
+            expectedSeatIdentities,
+            logger
+        });
+
+        return {lines, manifestPath, result}
+    };
+
+    test('one missing seat emits its exact identity and an actionable instruction; publication still succeeds', async () => {
+        const dir = await tempDir();
+
+        try {
+            // `webhookSubscription` routes @neo-opus-ada; @neo-opus-vega is expected and absent.
+            const {lines, manifestPath, result} = await runWithExpectations(
+                dir, ['@neo-opus-ada', '@neo-opus-vega']
+            );
+
+            const warn = lines.find(line => line.includes('@neo-opus-vega'));
+
+            expect(warn, 'the missing seat is named').toBeTruthy();
+            expect(warn, 'and the line says who can fix it, since the tool acts on the caller')
+                .toContain('manage_wake_subscription');
+
+            expect(lines.some(line => line.includes('@neo-opus-ada') && line.includes('expected wake seat')),
+                'the ROUTED seat must not be warned about').toBe(false);
+
+            // Detection only: a provisioning gap must never block route generation for everyone else.
+            expect(Object.keys(await readPublishedRoutes(manifestPath)),
+                'publication still succeeds alongside the warning').toHaveLength(1);
+            expect(result?.published, 'the builder still publishes').toBeTruthy();
+            expect(result?.routeSummaries, 'and still reports its routes').toHaveLength(1)
+        } finally {
+            await rm(dir, {force: true, recursive: true})
+        }
+    });
+
+    test('a fully routed expectation set emits nothing', async () => {
+        const dir = await tempDir();
+
+        try {
+            const {lines} = await runWithExpectations(dir, ['@neo-opus-ada']);
+
+            expect(lines.some(line => line.includes('expected wake seat')),
+                'every expected seat is routed ⇒ silence').toBe(false)
+        } finally {
+            await rm(dir, {force: true, recursive: true})
+        }
+    });
+
+    test('no expectation input emits nothing — absence is not an empty census', async () => {
+        const dir = await tempDir();
+
+        try {
+            const {lines} = await runWithExpectations(dir, undefined);
+
+            expect(lines.some(line => line.includes('expected wake seat')),
+                'a host-edge build with no roster must stay quiet rather than invent one').toBe(false)
+        } finally {
+            await rm(dir, {force: true, recursive: true})
+        }
+    })
 });

--- a/test/playwright/unit/ai/daemons/wake/wakeTargetEligibility.spec.mjs
+++ b/test/playwright/unit/ai/daemons/wake/wakeTargetEligibility.spec.mjs
@@ -1,0 +1,107 @@
+import {test, expect} from '@playwright/test';
+
+import {
+    collectUnroutedEligibleIdentities,
+    identityParticipationById,
+    isWakeTargetEligible
+} from '../../../../../../ai/daemons/wake/wakeTargetEligibility.mjs';
+
+/**
+ * The roster-versus-manifest difference that makes an unrouted seat visible.
+ *
+ * The defect it answers had no error state of its own: a manifest missing a seat is simply smaller
+ * than the roster, and nothing read a smaller set as information. A live seat therefore spent its
+ * whole existence receiving another seat's wakes and none of its own, with no warning anywhere.
+ *
+ * The arms below are shaped around the two ways this guard dies. It fails OPEN if the difference is
+ * wrong — the seat stays invisible, which is the original defect. It fails NOISY if eligibility is
+ * wrong — every benched, dark and never-connected roster entry warns on every build, and within a
+ * week nobody reads the output. The negative control is therefore load-bearing, not decoration.
+ */
+
+const roster = () => new Map([
+    ['@active-routed',   'active'],
+    ['@active-unrouted', 'active'],
+    ['@benched',         'operator_benched'],
+    ['@dark',            'retired'],
+    ['@implicit',        'active']
+]);
+
+test.describe('collectUnroutedEligibleIdentities', () => {
+    test('names an eligible identity that no route serves', () => {
+        expect(collectUnroutedEligibleIdentities({
+            routedIdentities: ['@active-routed', '@benched', '@dark', '@implicit'],
+            participation   : roster()
+        })).toEqual(['@active-unrouted'])
+    });
+
+    test('NEGATIVE CONTROL: a non-active identity with no route is silent', () => {
+        // The guard's whole value is that its output stays readable. Most roster entries
+        // legitimately have no route at any moment, so warning about them would make this noise on
+        // every build. `@benched` and `@dark` are unrouted here and must NOT appear.
+        const unrouted = collectUnroutedEligibleIdentities({
+            routedIdentities: ['@active-routed', '@active-unrouted', '@implicit'],
+            participation   : roster()
+        });
+
+        expect(unrouted).toEqual([]);
+        expect(unrouted).not.toContain('@benched');
+        expect(unrouted).not.toContain('@dark')
+    });
+
+    test('NON-VACUITY, both directions: a matching set is empty, a diverging set names exactly its members', () => {
+        const everything = ['@active-routed', '@active-unrouted', '@benched', '@dark', '@implicit'];
+
+        expect(collectUnroutedEligibleIdentities({routedIdentities: everything, participation: roster()}),
+            'every eligible identity routed ⇒ nothing to say'
+        ).toEqual([]);
+
+        // Two missing rather than one: a difference that returned only its first member would pass
+        // a single-member arm and under-report every real multi-seat gap.
+        expect(collectUnroutedEligibleIdentities({routedIdentities: ['@benched'], participation: roster()}),
+            'two eligible identities unrouted ⇒ both named, sorted'
+        ).toEqual(['@active-routed', '@active-unrouted', '@implicit'])
+    });
+
+    test('routed identities match regardless of `@` spelling', () => {
+        // The manifest and the roster have disagreed on this before — a bare-vs-prefixed mismatch
+        // would report every routed seat as unrouted, i.e. the guard screaming about a healthy
+        // plane, which is the fastest way to get it ignored.
+        expect(collectUnroutedEligibleIdentities({
+            routedIdentities: ['active-routed', 'active-unrouted', 'implicit'],
+            participation   : roster()
+        })).toEqual([])
+    });
+
+    test('an empty roster yields nothing; the no-arg call reads the LIVE roster against no routes', () => {
+        expect(collectUnroutedEligibleIdentities({routedIdentities: [], participation: new Map()}),
+            'an empty roster has nothing to be unrouted'
+        ).toEqual([]);
+
+        // Corrected after this arm first asserted `[]` here. The no-arg call is not "empty input" —
+        // `participation` defaults to the live roster, so with nothing routed EVERY eligible
+        // identity is unrouted. Asserting non-empty is both the true semantics and a live check
+        // that the default map resolves at all.
+        expect(collectUnroutedEligibleIdentities().length,
+            'no routes against the live roster ⇒ every eligible identity is unrouted'
+        ).toBeGreaterThan(0)
+    })
+});
+
+test.describe('isWakeTargetEligible — the shared predicate the daemon and the manifest both read', () => {
+    test('unknown identities stay eligible, non-active known ones do not', () => {
+        const participation = roster();
+
+        expect(isWakeTargetEligible('@active-routed', participation), 'active is eligible').toBe(true);
+        expect(isWakeTargetEligible('@benched',       participation), 'benched is not').toBe(false);
+        expect(isWakeTargetEligible('@dark',          participation), 'retired is not').toBe(false);
+        expect(isWakeTargetEligible('@a-fork',        participation), 'unknown stays eligible for forks').toBe(true);
+        expect(isWakeTargetEligible(null,             participation), 'a null target is not filtered here').toBe(true)
+    });
+
+    test('the live roster is populated, so the default participation map is not vacuously permissive', () => {
+        // Without this the two suites above could pass against a real map that failed to build,
+        // and every identity would silently read as "unknown, therefore eligible".
+        expect(identityParticipationById.size).toBeGreaterThan(5)
+    })
+});

--- a/test/playwright/unit/ai/daemons/wake/wakeTargetEligibility.spec.mjs
+++ b/test/playwright/unit/ai/daemons/wake/wakeTargetEligibility.spec.mjs
@@ -1,107 +1,111 @@
 import {test, expect} from '@playwright/test';
 
+import {IDENTITIES}   from '../../../../../../ai/graph/identityRoots.mjs';
+
 import {
-    collectUnroutedEligibleIdentities,
     identityParticipationById,
-    isWakeTargetEligible
+    isWakeTargetEligible,
+    wakeSeatIdentities
 } from '../../../../../../ai/daemons/wake/wakeTargetEligibility.mjs';
 
 /**
- * The roster-versus-manifest difference that makes an unrouted seat visible.
+ * Two questions that look like one and are not: may an identity RECEIVE a wake, and should it HOLD
+ * a route.
  *
- * The defect it answers had no error state of its own: a manifest missing a seat is simply smaller
- * than the roster, and nothing read a smaller set as information. A live seat therefore spent its
- * whole existence receiving another seat's wakes and none of its own, with no warning anywhere.
+ * The first is deliberately permissive — an unknown identity stays eligible so forks and local
+ * custom agents keep working. The second is a census of seats that ought to exist. The first
+ * version of this module used the permission predicate as the census, which warned about `@tobiu`:
+ * a human owner who is permitted to receive a wake and is not a seat. @neo-gpt found it by running
+ * the collector against the real roster instead of a fixture — the fixtures all passed, because
+ * every fixture I wrote contained only agents.
  *
- * The arms below are shaped around the two ways this guard dies. It fails OPEN if the difference is
- * wrong — the seat stays invisible, which is the original defect. It fails NOISY if eligibility is
- * wrong — every benched, dark and never-connected roster entry warns on every build, and within a
- * week nobody reads the output. The negative control is therefore load-bearing, not decoration.
+ * So the arms below run against the LIVE roster, not a hand-built map. A fixture cannot reproduce
+ * the defect that motivated them.
  */
 
-const roster = () => new Map([
-    ['@active-routed',   'active'],
-    ['@active-unrouted', 'active'],
-    ['@benched',         'operator_benched'],
-    ['@dark',            'retired'],
-    ['@implicit',        'active']
-]);
+const identityOfType = accountType => IDENTITIES.find(identity =>
+    identity.type === 'AgentIdentity' && identity.properties?.accountType === accountType);
 
-test.describe('collectUnroutedEligibleIdentities', () => {
-    test('names an eligible identity that no route serves', () => {
-        expect(collectUnroutedEligibleIdentities({
-            routedIdentities: ['@active-routed', '@benched', '@dark', '@implicit'],
-            participation   : roster()
-        })).toEqual(['@active-unrouted'])
+test.describe('wakeSeatIdentities — the route census', () => {
+    test('excludes the human owner, who is wake-permitted but is not a seat', () => {
+        // The exact regression. `@tobiu` is `accountType: 'human'` and active, so the permission
+        // predicate admits him; a census that reuses it reports the owner as an unrouted seat.
+        expect(isWakeTargetEligible('@tobiu'), 'the owner may receive a wake — permission is permissive')
+            .toBe(true);
+
+        expect(wakeSeatIdentities, 'and is still not an expected route holder').not.toContain('@tobiu')
     });
 
-    test('NEGATIVE CONTROL: a non-active identity with no route is silent', () => {
-        // The guard's whole value is that its output stays readable. Most roster entries
-        // legitimately have no route at any moment, so warning about them would make this noise on
-        // every build. `@benched` and `@dark` are unrouted here and must NOT appear.
-        const unrouted = collectUnroutedEligibleIdentities({
-            routedIdentities: ['@active-routed', '@active-unrouted', '@implicit'],
-            participation   : roster()
-        });
+    test('excludes system senders — and they are caught by `type`, not by `accountType`', () => {
+        const system = IDENTITIES.find(identity => identity.properties?.accountType === 'system');
 
-        expect(unrouted).toEqual([]);
-        expect(unrouted).not.toContain('@benched');
-        expect(unrouted).not.toContain('@dark')
+        expect(system, 'the roster must still carry a system account, or this control proves nothing').toBeTruthy();
+        expect(wakeSeatIdentities).not.toContain(system.id);
+
+        // Worth pinning which filter does the work: `@system` is `type: 'System'`, so the
+        // AgentIdentity filter already excludes it and the accountType check never sees it. That
+        // makes `@tobiu` — an AgentIdentity whose accountType is `human` — the ONLY case where the
+        // accountType filter is load-bearing, and therefore the only real regression control here.
+        expect(system.type, 'system senders are excluded by type before accountType is consulted')
+            .not.toBe('AgentIdentity')
     });
 
-    test('NON-VACUITY, both directions: a matching set is empty, a diverging set names exactly its members', () => {
-        const everything = ['@active-routed', '@active-unrouted', '@benched', '@dark', '@implicit'];
+    test('includes active agent seats, and the census is non-empty', () => {
+        const agent = identityOfType('agent');
 
-        expect(collectUnroutedEligibleIdentities({routedIdentities: everything, participation: roster()}),
-            'every eligible identity routed ⇒ nothing to say'
-        ).toEqual([]);
+        expect(agent, 'the roster must carry at least one agent seat').toBeTruthy();
+        expect(wakeSeatIdentities.length, 'an empty census would make every downstream arm vacuous')
+            .toBeGreaterThan(3);
 
-        // Two missing rather than one: a difference that returned only its first member would pass
-        // a single-member arm and under-report every real multi-seat gap.
-        expect(collectUnroutedEligibleIdentities({routedIdentities: ['@benched'], participation: roster()}),
-            'two eligible identities unrouted ⇒ both named, sorted'
-        ).toEqual(['@active-routed', '@active-unrouted', '@implicit'])
+        for (const seat of wakeSeatIdentities) {
+            const entry = IDENTITIES.find(identity => identity.id === seat);
+
+            expect(entry?.properties?.accountType, `${seat} is in the census`).toBe('agent');
+            expect(entry?.properties?.participationStatus ?? 'active', `${seat} is active`).toBe('active')
+        }
     });
 
-    test('routed identities match regardless of `@` spelling', () => {
-        // The manifest and the roster have disagreed on this before — a bare-vs-prefixed mismatch
-        // would report every routed seat as unrouted, i.e. the guard screaming about a healthy
-        // plane, which is the fastest way to get it ignored.
-        expect(collectUnroutedEligibleIdentities({
-            routedIdentities: ['active-routed', 'active-unrouted', 'implicit'],
-            participation   : roster()
-        })).toEqual([])
+    test('excludes a non-active agent: retired seats should not be expected to hold routes', () => {
+        const retiredAgents = IDENTITIES.filter(identity =>
+            identity.type === 'AgentIdentity' &&
+            identity.properties?.accountType === 'agent' &&
+            (identity.properties?.participationStatus || 'active') !== 'active');
+
+        // Not asserting the roster HAS one — that would couple this spec to fleet composition. When
+        // one exists it must be absent from the census; when none exists the arm is a no-op and says so.
+        for (const retired of retiredAgents) {
+            expect(wakeSeatIdentities, `${retired.id} is a non-active agent`).not.toContain(retired.id)
+        }
     });
 
-    test('an empty roster yields nothing; the no-arg call reads the LIVE roster against no routes', () => {
-        expect(collectUnroutedEligibleIdentities({routedIdentities: [], participation: new Map()}),
-            'an empty roster has nothing to be unrouted'
-        ).toEqual([]);
-
-        // Corrected after this arm first asserted `[]` here. The no-arg call is not "empty input" —
-        // `participation` defaults to the live roster, so with nothing routed EVERY eligible
-        // identity is unrouted. Asserting non-empty is both the true semantics and a live check
-        // that the default map resolves at all.
-        expect(collectUnroutedEligibleIdentities().length,
-            'no routes against the live roster ⇒ every eligible identity is unrouted'
-        ).toBeGreaterThan(0)
+    test('every census entry is canonical, so a consumer can compare without normalising', () => {
+        // Load-bearing: the manifest builder compares as-given precisely so it can stay free of
+        // graph imports. A bare handle here would make every routed seat read as unrouted.
+        for (const seat of wakeSeatIdentities) {
+            expect(seat.startsWith('@'), `${seat} must be canonical`).toBe(true)
+        }
     })
 });
 
-test.describe('isWakeTargetEligible — the shared predicate the daemon and the manifest both read', () => {
+test.describe('isWakeTargetEligible — receive permission, unchanged from the daemon', () => {
     test('unknown identities stay eligible, non-active known ones do not', () => {
-        const participation = roster();
+        const participation = new Map([
+            ['@active',  'active'],
+            ['@benched', 'operator_benched'],
+            ['@retired', 'retired']
+        ]);
 
-        expect(isWakeTargetEligible('@active-routed', participation), 'active is eligible').toBe(true);
-        expect(isWakeTargetEligible('@benched',       participation), 'benched is not').toBe(false);
-        expect(isWakeTargetEligible('@dark',          participation), 'retired is not').toBe(false);
-        expect(isWakeTargetEligible('@a-fork',        participation), 'unknown stays eligible for forks').toBe(true);
-        expect(isWakeTargetEligible(null,             participation), 'a null target is not filtered here').toBe(true)
+        expect(isWakeTargetEligible('@active',  participation)).toBe(true);
+        expect(isWakeTargetEligible('@benched', participation)).toBe(false);
+        expect(isWakeTargetEligible('@retired', participation)).toBe(false);
+        expect(isWakeTargetEligible('@a-fork',  participation), 'unknown stays eligible for forks').toBe(true);
+        expect(isWakeTargetEligible(null,       participation), 'a null target is not filtered here').toBe(true)
     });
 
-    test('the live roster is populated, so the default participation map is not vacuously permissive', () => {
-        // Without this the two suites above could pass against a real map that failed to build,
-        // and every identity would silently read as "unknown, therefore eligible".
-        expect(identityParticipationById.size).toBeGreaterThan(5)
+    test('the live participation map is populated, so the default is not vacuously permissive', () => {
+        // Without this, an empty map would make every identity read as "unknown, therefore eligible"
+        // and both suites above would pass against a module that failed to build its roster.
+        expect(identityParticipationById.size).toBeGreaterThan(5);
+        expect(identityParticipationById.has('@tobiu'), 'permission covers humans too').toBe(true)
     })
 });


### PR DESCRIPTION
Resolves neomjs/neo#17615

A seat received another seat's wakes and none of its own for its entire existence, because nothing ever created a route for it — and **nothing anywhere reported it**. `buildReceiverManifest` now emits one WARN per expected wake seat with no route.

Related: neomjs/neo-agent-brain#19 · neomjs/neo#16233

Evidence: L2 (pure difference over plain inputs, plus builder-seam witnesses that drive `runManifestBuilder` and assert its logger output and published manifest) → L2 required (every AC is a static contract; no runtime plane effect is claimed). No residuals.

## AC Evidence

| Acceptance criterion | Evidence |
|---|---|
| AC-1 | The builder warns per expected seat absent from the routed set. Witnessed **at the builder seam**, not inferred: `buildReceiverManifest.spec.mjs` drives `runManifestBuilder` and asserts the emitted line names the missing identity. |
| AC-2 | **Extracted, not duplicated.** `daemon.mjs` exports nothing, so `isWakeTargetEligible` moved to `wakeTargetEligibility.mjs` and the daemon imports what it used to define. Its permission semantics are unchanged — verified by the full wake suite (311 passed) rather than asserted. |
| AC-3 | **Negative controls, against the LIVE roster.** The human owner is wake-permitted (`isWakeTargetEligible` → `true`) and absent from the census; non-active agents are excluded; system senders are excluded by `type` before `accountType` is consulted — which is asserted, because it makes the human owner the *only* case where the accountType filter is load-bearing. |
| AC-4 | **Non-vacuity, both directions, at the seam.** One missing seat emits exactly its identity while the routed seat emits nothing; a fully routed expectation set emits nothing; publication still succeeds in both. Plus census-shape guards (non-empty, every entry canonical, every entry an active agent). |
| AC-5 | The warn names the seat **and** states that only that seat can create its own row, since `manage_wake_subscription` acts on the caller — asserted on the emitted string, not just written. |
| AC-6 | Detection only: publication succeeds alongside the warning, asserted (`published` route count and `routeSummaries` both intact). |
| AC-7 | Reproduced against controlled input rather than live data: an expected-but-unrouted seat is named while a routed one is not. |

## Deltas from ticket

**Two review findings changed the design, and both made it better.**

**1. Receive permission is not route population.** The first version reused `isWakeTargetEligible` as the census — and that predicate is *deliberately* permissive, so unknown identities stay eligible and forks keep working. Run against the real roster it warned about the human owner: wake-permitted, and not a seat. **My fixtures could not have caught it, because every fixture I wrote contained only agents.** The census is now `wakeSeatIdentities` — active agent seats, keyed on the `accountType` discriminator the roster already carries — and the controls read the live roster instead of a hand-built map.

**2. The builder's graphless boundary is restored.** Its module docblock states it imports nothing from the graph, Memory Core or a database path, *"so host-edge tooling stays runnable without the container plane it is being wired to"* — and the first version crossed that by importing the roster transitively. I had read the file's warn section and its routed-set computation, and never the paragraph governing what it may import.

Expected seats now arrive as **plain data** (`expectedSeatIdentities`, plus an `--expected-seats` flag), exactly as subscription records already arrive from whoever queried them. Both sides compare as given, which is why the census exports canonical ids. **Absent input means "no expectation", not "no seats"** — a host-edge box legitimately has no roster, and a guard that invents one there would cry loudest on the hosts it knows least about.

**Deliberately not wired into `armSeatWakeRoute`:** arming a single seat is the wrong moment for a fleet census. The flag is the seam; automatic invocation is a separate decision and not smuggled in here.

**A correction to my own earlier evidence claim.** The first body cited "308 passed" as support for the WARN integration. That suite proves the **extraction** is behaviour-preserving and asserts nothing about the added lines — citing it for the integration was the same over-claim shape as citing any green for an effect no spec asserts. The builder-seam witnesses in this round are what actually carry AC-1/5/6.

## Test Evidence

- `wakeTargetEligibility.spec.mjs` — census and permission contracts, run against the **live roster** because a fixture cannot reproduce the defect that motivated them.
- `buildReceiverManifest.spec.mjs` — three new arms at the consumer seam: one missing seat named with an actionable instruction and publication intact; a fully routed set silent; **no expectation input silent**. Plus the CLI flag's parse pinned, including that it trims and drops empties rather than emitting blank identities.
- `test/playwright/unit/ai/daemons/wake/` — **311 passed**, which is the evidence that the extraction preserved the daemon's behaviour. It is *not* offered as evidence of the WARN integration; that is what the seam arms above are for.
- Boundary re-verified after the change: the builder imports only node builtins and three wake-local modules, none of which reach `ai/graph` or Memory Core.
- Deliberately not asserted: anything about live plane state. Pinning a live roster would make the spec fail whenever the fleet changes.

## Post-Merge Validation

None required — every acceptance property is a static contract asserted at this head.

Authored by Grace (Claude Opus 5, Claude Code). Session eb671e6e-ca17-4a53-8069-64fd5885ce84.
