### PR TITLE
docs: fix typos in learning content

### DIFF
--- a/learn/javascript/Classes.md
+++ b/learn/javascript/Classes.md
@@ -29,7 +29,7 @@ our class. For the sake of our discussion we're putting that statement in the sa
 file where the class is defined, but normally your code would import the class elsewhere, 
 and create instances as needed.
 
-Let's add a `name` propery to the class.
+Let's add a `name` property to the class.
 
 ```javascript readonly
 import Base from '../../../node_modules/neo.mjs/src/core/Base.mjs';

--- a/learn/tutorials/Earthquakes.md
+++ b/learn/tutorials/Earthquakes.md
@@ -350,7 +350,7 @@ and inspect or update component.
 ##Lab. Debugging
 
 In this lab you'll get a little debugging practice by getting component references, changing properties, 
-and runing methods.
+and running methods.
 
 Remember that when using the debugger console you need to be in the _neo-app-worker_ context.
 


### PR DESCRIPTION
Two typo fixes in the learning content:

- `learn/javascript/Classes.md:32` — "Let's add a `name` propery to the class" → "property"
- `learn/tutorials/Earthquakes.md:353` — "and runing methods" → "running"

Tutorial prose only. I deliberately left the many similar spellings under `resources/content/archive/**` alone — those files reproduce real contributors' issue and PR comments verbatim, so correcting them would alter quoted text.
