### PR TITLE
feat(ai): register devindex as the first real-content pull-mode tenant (#17377)

### DIFF
--- a/ai/deploy/kb-config.yaml
+++ b/ai/deploy/kb-config.yaml
@@ -1,4 +1,4 @@
-# Tenant bootstrap for the containerized plane's pull-mode KB ingestion. Three repos under one
+# Tenant bootstrap for the containerized plane's pull-mode KB ingestion. Four repos under one
 # tenant (`neo-shared`), keyed as `tenantId/repoSlug` — all genuinely EXTERNAL to the maintainer
 # checkout, which is the lane's actual purpose:
 #
@@ -12,6 +12,13 @@
 #                                  MULTI-repo witness: per-repo scheduling, jitter, independent
 #                                  backoff and per-repo checkpointing had only ever been exercised
 #                                  against a single viable entry.
+#   neo-shared/devindex          — the application repo itself (app, Node service layer, 26 guide
+#                                  documents, Playwright suite). The lane's first real-content
+#                                  tenant: retrieval quality, chunking across heterogeneous file
+#                                  types, and per-repo scheduling against content a query can
+#                                  actually be WRONG about — the three entries above cannot fail
+#                                  a retrieval assertion. Whole-tree ingestion became safe by
+#                                  construction only once the generated data files left git.
 #
 # The Neo repo itself is deliberately NOT registered here. `kbSync` already ingests neo's content
 # through 10 source extractors, producing TYPED chunks (`type`, `kind`) that `query_documents` and
@@ -54,5 +61,10 @@ tenants:
       - tenantId: neo-shared
         repoSlug     : devindex-opt-out
         cloneUrl     : https://github.com/neomjs/devindex-opt-out.git
+        credentialRef: none
+        branchRef    : main
+      - tenantId: neo-shared
+        repoSlug     : devindex
+        cloneUrl     : https://github.com/neomjs/devindex.git
         credentialRef: none
         branchRef    : main

--- a/test/playwright/unit/ai/deploy/KbTenantBootstrapContract.spec.mjs
+++ b/test/playwright/unit/ai/deploy/KbTenantBootstrapContract.spec.mjs
@@ -72,14 +72,15 @@ test.describe('ai/deploy/kb-config.yaml — tenant bootstrap contract', () => {
             document = yamlLoad(fs.readFileSync(path.join(repoRoot, bootstrapRel), 'utf8')),
             repos    = document.tenants['neo-shared'].tenantRepos;
 
-        expect(repos).toHaveLength(3);
+        expect(repos).toHaveLength(4);
 
         const normalized = repos.map(normalizeTenantRepoEntry);
 
         const expected = [
             {repoSlug: 'create-app',       cloneUrl: 'https://github.com/neomjs/create-app.git'},
             {repoSlug: 'devindex-opt-in',  cloneUrl: 'https://github.com/neomjs/devindex-opt-in.git'},
-            {repoSlug: 'devindex-opt-out', cloneUrl: 'https://github.com/neomjs/devindex-opt-out.git'}
+            {repoSlug: 'devindex-opt-out', cloneUrl: 'https://github.com/neomjs/devindex-opt-out.git'},
+            {repoSlug: 'devindex',         cloneUrl: 'https://github.com/neomjs/devindex.git'}
         ];
 
         expected.forEach((entry, index) => {
@@ -111,7 +112,8 @@ test.describe('ai/deploy/kb-config.yaml — tenant bootstrap contract', () => {
         expect(keys).toEqual([
             'neo-shared/create-app',
             'neo-shared/devindex-opt-in',
-            'neo-shared/devindex-opt-out'
+            'neo-shared/devindex-opt-out',
+            'neo-shared/devindex'
         ])
     });
 
@@ -153,7 +155,8 @@ test.describe('ai/deploy/kb-config.yaml — tenant bootstrap contract', () => {
 
         expect(bySlug['create-app']).toBe('main');
         expect(bySlug['devindex-opt-in']).toBe('main');
-        expect(bySlug['devindex-opt-out']).toBe('main')
+        expect(bySlug['devindex-opt-out']).toBe('main');
+        expect(bySlug['devindex']).toBe('main')
     });
 
     test('exactly the two consuming services mount the bootstrap read-only in the local-agent-os overlay', () => {


### PR DESCRIPTION
Resolves #17377

Registers `neomjs/devindex` as the fourth pull-mode tenant under `neo-shared` — the lane's first real-content entry (app, Node service layer, 26 guides, Playwright suite), exercising retrieval quality, chunking across heterogeneous file types, and per-repo scheduling against content a query can actually be wrong about. The entry is added exactly as the ticket's Fix section prescribes; the header comment is updated to keep the file's own documentation true.

Evidence: L2 achieved (config parsed through the resolver's own js-yaml loader: 4 entries, devindex contract fields complete, slug list verified; whitespace hook clean at this head) → L3 required (AC-1..AC-5 are live-deployment receipts — the running orchestrator reads the deploy home's mounted copy, not this tree). Residual: AC-1..AC-5, Residual-Owner: #17621

## AC Evidence
| AC-1 | #17621 step 3: `neo-shared/devindex` bootstrap-seeding + `lastIngestedRev` non-null captured from orchestrator logs after the deploy-home update + recreate |
| AC-2 | #17621 step 4: query for a contributor-corpus-only value returns empty; precondition verified at claim time (remote `apps/devindex/resources/data` is 404 — the hazard is gone at source) |
| AC-3 | #17621 step 4: devindex-guide-only semantic query returns a chunk sourced from this tenant's `learn/**`, not the neo corpus |
| AC-4 | #17621 step 4: the three pre-existing tenants keep checkpoints and independent backoff across the devindex-ingesting cycle |
| AC-5 | #17621 step 4: ingested chunks stamp `{tenantId: neo-shared, repoSlug: devindex}` |

## Deltas from ticket
- Entry added verbatim per the ticket's Fix section (`credentialRef: none` — public clone; `branchRef: main` verified against the remote).
- Header comment: three → four entries; new devindex block describes the real-content tenant and the whole-tree-safety-by-construction precondition, without ticket refs in the durable comment.

## Test Evidence

Local receipts at heads `7cb870adcc` (config) + `8723efb692` (contract pin): js-yaml parse of the deployed file shape — entry count 4, devindex `{tenantId, repoSlug, cloneUrl, credentialRef: none, branchRef: main}` complete, slugs `create-app, devindex-opt-in, devindex-opt-out, devindex`. The tracked bootstrap contract spec (`KbTenantBootstrapContract.spec.mjs`) is pinned to the four-entry reality in the same PR: length/keys/bySlug assertions updated; local receipt replicates all five contract facts through the production `normalizeTenantRepoEntry`. Intake premise V-B-A: remote `default_branch` = `main`; `apps/devindex/resources/data` returns 404 on the remote (blocker `#17375` discharged at source); `RawRepoSource` `DEFAULT_EXCLUDE_EXTENSIONS` confirmed binary/media-only at `ai/services/knowledge-base/source/RawRepoSource.mjs:6`.

## Post-Merge Validation

- [ ] Sync-cycle receipts AC-1..AC-5 land on `#17621` after deploy-home fast-forward + `kb-server`/orchestrator recreate (receipt collection @neo-preview; steps 1-2 are deployment-operator territory: @neo-gpt-emmy coordinates, @tobiu host-level)

Residual-Owner: #17621

Authored by Eos (ox-alpha, opencode). Session d83b1bf5-54d5-4cd8-8b62-a462e453bf45.

