### PR TITLE
feat(dashboard): add model-authoritative dock close actions (#17419)

### DIFF
--- a/examples/dashboard/dock/MainContainer.mjs
+++ b/examples/dashboard/dock/MainContainer.mjs
@@ -127,6 +127,11 @@ class MainContainer extends DockWorkspace {
          */
         dockProjectionConfig: {flex: 1},
         /**
+         * The standalone example opts into the engine-owned, model-authoritative close action.
+         * @member {Boolean} enableDockCloseAction=true
+         */
+        enableDockCloseAction: true,
+        /**
          * The perspective toolbar sits at index 0; the projected shell follows it.
          * @member {Number} dockShellIndex=1
          */

--- a/src/dashboard/DockLayoutAdapter.mjs
+++ b/src/dashboard/DockLayoutAdapter.mjs
@@ -342,6 +342,10 @@ class DockLayoutAdapter extends Base {
      *     conversion policy. Consumers keep this false until their physical lifecycle is ready.
      * @param {Boolean} [options.enableStackDrag=false] Decorate the model-resolved stack root
      *     with one runtime-only whole-stack grip and arm its existing dock SortZone.
+     * @param {Boolean} [options.enableDockCloseAction=false] Projects one persistent close action
+     *     into every tabs header. The workspace owns the effect and policy synchronization.
+     * @param {Function} [options.onDockActiveIndexChange] Runtime active-item signal for action policy.
+     * @param {Function} [options.onDockHeaderAction] Runtime Dock action intent; never persisted.
      * @param {Function} [options.onDockVesselConversionIn] Source-owned strict park admission.
      * @param {Function} [options.onDockVesselConversionOut] Source-owned strict re-show admission.
      * @param {Function} [options.onDockVesselConversionTerminal] Source-owned parked-vessel
@@ -393,6 +397,7 @@ class DockLayoutAdapter extends Base {
             // terminal; the projection only threads the opt-in + the closure seams. Absent = fully
             // in-window, the unchanged default.
             dockTearOutBoundaryContainerId   : options.dockTearOutBoundaryContainerId ?? null,
+            enableDockCloseAction            : options.enableDockCloseAction === true,
             enableDockTearOut                : options.enableDockTearOut === true,
             enableVesselConversion           : options.enableVesselConversion === true,
             items                            : model.items || {},
@@ -400,6 +405,8 @@ class DockLayoutAdapter extends Base {
             onDockCrossZoneDragCancel        : options.onDockCrossZoneDragCancel,
             onDockCrossZoneDragMove          : options.onDockCrossZoneDragMove,
             onDockCrossZoneDrop              : options.onDockCrossZoneDrop,
+            onDockActiveIndexChange          : options.onDockActiveIndexChange,
+            onDockHeaderAction               : options.onDockHeaderAction,
             onDockStackDragTerminal          : options.onDockStackDragTerminal,
             onDockTearOutCancel              : options.onDockTearOutCancel,
             onDockTearOutEntry               : options.onDockTearOutEntry,
@@ -820,11 +827,14 @@ class DockLayoutAdapter extends Base {
                 ? allItems.filter(itemId => !context.railedItemIds.has(itemId))
                 : allItems,
             activeIndex = items.length ? items.indexOf(node.activeItemId) : null,
-            projectedItems;
+            projectedItems,
+            activeItemId;
 
         if (activeIndex < 0) {
             activeIndex = items.length ? 0 : null
         }
+
+        activeItemId = Number.isInteger(activeIndex) ? items[activeIndex] : null;
 
         // One-use operation correlation: only a real addTab's exact target header receives
         // the dashboard-owned producer. Whole-stack projection additionally overlays the active
@@ -846,6 +856,17 @@ class DockLayoutAdapter extends Base {
             cls         : ['neo-dashboard-dock-tabs'],
             dockNodeId  : nodeId,
             dockNodeType: 'tabs',
+            ...(context.enableDockCloseAction && {
+                headerActions: [{
+                    action    : 'close',
+                    contextual: false,
+                    hidden    : !activeItemId || context.items[activeItemId]?.closable === false,
+                    iconCls   : 'fa fa-times'
+                }],
+                // The empty-tabs fallback receives focus after its last close. A plain div cannot
+                // own programmatic focus, so the opt-in makes the projected root focusable.
+                vdom: {tabIndex: -1}
+            }),
             // Reuse the EXISTING tab-header SortZone for the gesture — no parallel drag system:
             // `dragResortable` makes the headers draggable, and the `moveTo` the container fires on drop
             // commits the reorder into the COMMITTED dock model through the landed operation seam. The
@@ -900,6 +921,16 @@ class DockLayoutAdapter extends Base {
             },
             items    : projectedItems,
             listeners: {
+                activeIndexChange: data => context.onDockActiveIndexChange?.({
+                    ...data,
+                    dockNodeId  : nodeId,
+                    tabContainer: data.item?.parent?.parent ?? null
+                }),
+                headerAction: data => {
+                    if (data.action === 'close') {
+                        context.onDockHeaderAction?.({...data, dockNodeId: nodeId})
+                    }
+                },
                 // Cancel is a gesture lifecycle signal, not a synthetic drop: the workspace clears
                 // transient affordances while the sort zone restores its captured layout.
                 dockCrossZoneDragCancel: data => context.onDockCrossZoneDragCancel?.(data),

--- a/src/dashboard/DockWorkspace.mjs
+++ b/src/dashboard/DockWorkspace.mjs
@@ -106,6 +106,12 @@ class DockWorkspace extends Container {
          */
         dockProjectionConfig: null,
         /**
+         * Projects one persistent close action into each Dock tab header. Disabled by default;
+         * applications opt into model-authoritative close semantics explicitly.
+         * @member {Boolean} enableDockCloseAction=false
+         */
+        enableDockCloseAction: false,
+        /**
          * Index of the projected shell inside the dock host — `1` when one toolbar precedes it.
          * @member {Number} dockShellIndex=0
          */
@@ -154,6 +160,13 @@ class DockWorkspace extends Container {
      */
     construct(config) {
         super.construct(config);
+
+        if (this.enableDockCloseAction) {
+            // Closing a node's last item prunes its empty TabContainer. The surviving workspace
+            // root is therefore the semantic focus fallback and must accept programmatic focus.
+            this.vdom.tabIndex = -1
+        }
+
         this.dockPreviewProducer = Neo.create(DockPreviewProducer)
     }
 
@@ -279,6 +292,134 @@ class DockWorkspace extends Container {
      */
     getDockProjectionOptions() {
         return {}
+    }
+
+    /**
+     * Resolves the current Dock item from live tab order, never a closure-captured model index.
+     * The reconciler owns `dockItemIds`; the TabContainer owns `activeIndex`.
+     * @param {Neo.tab.Container|null} tabContainer
+     * @returns {String|null}
+     * @protected
+     */
+    getActiveDockItemId(tabContainer) {
+        let itemIds = tabContainer?.getTabBar()?.sortZoneConfig?.dockItemIds,
+            index   = tabContainer?.activeIndex;
+
+        return Array.isArray(itemIds) && Number.isInteger(index) ? itemIds[index] ?? null : null
+    }
+
+    /**
+     * Synchronizes one retained close action against the live active item and committed policy.
+     * Hidden-state changes stay on the stable action instance so Overflow receives its existing
+     * `actionVisibilityChange` signal instead of an action-group replacement.
+     * @param {Neo.tab.Container|null} tabContainer
+     * @protected
+     */
+    syncDockCloseAction(tabContainer) {
+        let action = tabContainer?.getActionItem?.('close'),
+            itemId = this.getActiveDockItemId(tabContainer),
+            hidden = !itemId || this.dockModel?.items?.[itemId]?.closable === false;
+
+        action && action.hidden !== hidden && (action.hidden = hidden)
+    }
+
+    /**
+     * Synchronizes every projected close action after reconciliation, including retained tabs
+     * whose action instance outlived a model-policy or active-item change.
+     * @param {Map<String,Neo.tab.Container>|null} [tabs=null]
+     * @protected
+     */
+    syncDockCloseActions(tabs=null) {
+        let projectedTabs = tabs;
+
+        if (!projectedTabs) {
+            let shell = this.getDockHost()?.items?.[this.dockShellIndex];
+
+            projectedTabs = shell ? DockProjectionReconciler.collectProjectedTabs(shell) : new Map()
+        }
+
+        projectedTabs?.forEach?.(tab => this.syncDockCloseAction(tab))
+    }
+
+    /**
+     * Updates close availability when the user changes the live active tab without committing a
+     * Dock document operation.
+     * @param {Object} data
+     * @param {Neo.component.Base|null} [data.item]
+     * @param {Neo.tab.Container|null} [data.tabContainer]
+     */
+    onDockActiveIndexChange({item, tabContainer}={}) {
+        this.syncDockCloseAction(tabContainer || item?.parent?.parent || null)
+    }
+
+    /**
+     * Routes one persistent header action through the model and the class-owned projection chain.
+     * Live reconciled order owns the close target at dispatch time. The current model locates that
+     * item's semantic tabs node, and the committed result owns its focus successor. Successful focus
+     * is chained onto `refreshPromise`, so it cannot reach chrome the reconciler retires.
+     * @param {Object} data
+     * @param {String} data.action
+     * @param {String} data.dockNodeId
+     * @param {Neo.tab.Container} data.tabContainer
+     * @returns {{document:Object,errors:String[]}|null}
+     */
+    onDockHeaderAction({action, dockNodeId, tabContainer}={}) {
+        if (action !== 'close' || !this.enableDockCloseAction) return null;
+
+        let me     = this,
+            itemId = me.getActiveDockItemId(tabContainer);
+
+        if (!itemId) {
+            return {document: me.dockModel, errors: ['Dock close action requires an active item']}
+        }
+
+        if (!me.dockModel) {
+            return {document: me.dockModel, errors: ['Dock close action requires a committed document']}
+        }
+
+        let modelNodeId = DockZoneModel.findContainingTabsId(me.dockModel, itemId) || dockNodeId,
+            descriptor  = {operation: 'closeItem', itemId},
+            result      = me.applyDockZoneOperation(descriptor);
+
+        if (result && !result.errors?.length && result.document) {
+            let focusId = result.document.nodes?.[modelNodeId]?.activeItemId ?? null;
+
+            me.onDockZoneDocumentChange(result.document, descriptor, tabContainer);
+            me.refreshPromise = me.refreshPromise.then(() => {
+                me.focusDockCloseTarget({dockNodeId: modelNodeId, itemId: focusId})
+            })
+        }
+
+        return result
+    }
+
+    /**
+     * Focuses the committed close successor after reconciliation. The exact item id is resolved
+     * back through the reconciled `dockItemIds`; an empty tabs node focuses its own root.
+     * @param {Object} data
+     * @param {String} data.dockNodeId
+     * @param {String|null} data.itemId
+     * @protected
+     */
+    focusDockCloseTarget({dockNodeId, itemId}={}) {
+        let tabContainer = this.getDockHost()?.down?.({dockNodeId});
+
+        if (!tabContainer) {
+            this.focus();
+            return
+        }
+
+        if (itemId) {
+            let itemIds = tabContainer.getTabBar()?.sortZoneConfig?.dockItemIds || [],
+                index   = itemIds.indexOf(itemId);
+
+            if (index > -1) {
+                tabContainer.getTabButtons()[index]?.focus();
+                return
+            }
+        }
+
+        tabContainer.focus()
     }
 
     /**
@@ -490,6 +631,9 @@ class DockWorkspace extends Container {
             config = DockLayoutAdapter.project(document, {
                 onDockCrossZoneDrop: me.onDockCrossZoneDrop.bind(me),
                 ...me.getDockProjectionOptions(),
+                enableDockCloseAction    : me.enableDockCloseAction,
+                onDockActiveIndexChange  : me.onDockActiveIndexChange.bind(me),
+                onDockHeaderAction       : me.onDockHeaderAction.bind(me),
                 applyDockZoneOperation   : me.applyDockZoneOperation.bind(me),
                 onDockZoneDocumentChange : me.onDockZoneDocumentChange.bind(me),
                 resolveComponentRef      : itemResolver || ((componentRef, item, itemId) => me.resolveProjectedPane(itemId, item)),
@@ -591,6 +735,8 @@ class DockWorkspace extends Container {
             shellIndex    : me.dockShellIndex,
             waitForOverflowProjection
         });
+
+        me.syncDockCloseActions(result?.currentTabs);
 
         // FLIP phase 2: fire-and-forget by default — the addon self-waits for the swap, inverts and
         // plays; the counted motion signal brackets the awaited animation window. Gate on the

--- a/src/dashboard/DockWorkspace.mjs
+++ b/src/dashboard/DockWorkspace.mjs
@@ -631,9 +631,11 @@ class DockWorkspace extends Container {
             config = DockLayoutAdapter.project(document, {
                 onDockCrossZoneDrop: me.onDockCrossZoneDrop.bind(me),
                 ...me.getDockProjectionOptions(),
-                enableDockCloseAction    : me.enableDockCloseAction,
-                onDockActiveIndexChange  : me.onDockActiveIndexChange.bind(me),
-                onDockHeaderAction       : me.onDockHeaderAction.bind(me),
+                ...(me.enableDockCloseAction && {
+                    enableDockCloseAction  : true,
+                    onDockActiveIndexChange: me.onDockActiveIndexChange.bind(me),
+                    onDockHeaderAction     : me.onDockHeaderAction.bind(me)
+                }),
                 applyDockZoneOperation   : me.applyDockZoneOperation.bind(me),
                 onDockZoneDocumentChange : me.onDockZoneDocumentChange.bind(me),
                 resolveComponentRef      : itemResolver || ((componentRef, item, itemId) => me.resolveProjectedPane(itemId, item)),

--- a/src/dashboard/DockZoneModel.mjs
+++ b/src/dashboard/DockZoneModel.mjs
@@ -1858,19 +1858,33 @@ class DockZoneModel extends Base {
     }
 
     /**
-     * @summary Removes `itemId` from both the tree and the `items` catalog, per the contract's
-     * `closeItem`.
+     * @summary Removes a closeable `itemId` from the tree and catalog, then activates the item at
+     * its former index or the preceding item. An explicit `closable:false` fails closed.
      * @param {Object} document
      * @param {Object} args {itemId}
      * @returns {{document:Object, errors:String[]}}
      * @static
      */
     static closeItem(document, {itemId} = {}) {
-        if (!document.items?.[itemId]) return {document, errors: [`unknown item "${itemId}"`]};
+        let item = document.items?.[itemId];
 
-        let doc = DockZoneModel.clone(document);
+        if (!item) return {document, errors: [`unknown item "${itemId}"`]};
+        if (item.closable === false) return {document, errors: [`item "${itemId}" is not closable`]};
+
+        let tabsNodeId  = DockZoneModel.findContainingTabsId(document, itemId),
+            closedIndex = tabsNodeId ? document.nodes[tabsNodeId].items.indexOf(itemId) : -1,
+            doc         = DockZoneModel.clone(document);
 
         DockZoneModel.detachFromTabs(doc, itemId);
+
+        if (tabsNodeId && doc.nodes[tabsNodeId]?.type === 'tabs') {
+            let node = doc.nodes[tabsNodeId];
+
+            // The item now occupying the closed slot wins; closing the last item falls back to
+            // its preceding sibling. This is semantic model policy, not a projected-index guess.
+            node.activeItemId = node.items[Math.min(closedIndex, node.items.length - 1)] ?? null
+        }
+
         delete doc.items[itemId];
 
         return DockZoneModel.commit(document, doc)

--- a/src/dashboard/DockZoneModel.mjs
+++ b/src/dashboard/DockZoneModel.mjs
@@ -1858,8 +1858,9 @@ class DockZoneModel extends Base {
     }
 
     /**
-     * @summary Removes a closeable `itemId` from the tree and catalog, then activates the item at
-     * its former index or the preceding item. An explicit `closable:false` fails closed.
+     * @summary Removes a closeable `itemId` from the tree and catalog. When the item was active,
+     * activates the item at its former index or the preceding item; closing a non-active item
+     * preserves the surviving activation. An explicit `closable:false` fails closed.
      * @param {Object} document
      * @param {Object} args {itemId}
      * @returns {{document:Object, errors:String[]}}
@@ -1873,15 +1874,17 @@ class DockZoneModel extends Base {
 
         let tabsNodeId  = DockZoneModel.findContainingTabsId(document, itemId),
             closedIndex = tabsNodeId ? document.nodes[tabsNodeId].items.indexOf(itemId) : -1,
+            wasActive   = tabsNodeId ? document.nodes[tabsNodeId].activeItemId === itemId : false,
             doc         = DockZoneModel.clone(document);
 
         DockZoneModel.detachFromTabs(doc, itemId);
 
-        if (tabsNodeId && doc.nodes[tabsNodeId]?.type === 'tabs') {
+        if (wasActive && tabsNodeId && doc.nodes[tabsNodeId]?.type === 'tabs') {
             let node = doc.nodes[tabsNodeId];
 
-            // The item now occupying the closed slot wins; closing the last item falls back to
-            // its preceding sibling. This is semantic model policy, not a projected-index guess.
+            // When the closed item owned activation, the item now occupying its slot wins;
+            // closing the last item falls back to its preceding sibling. A surviving active item
+            // is left untouched. This is semantic model policy, not a projected-index guess.
             node.activeItemId = node.items[Math.min(closedIndex, node.items.length - 1)] ?? null
         }
 

--- a/src/tab/plugin/Overflow.mjs
+++ b/src/tab/plugin/Overflow.mjs
@@ -168,20 +168,26 @@ class Overflow extends Plugin {
      */
     hiddenSignature = null
     /**
+     * Header ids in the last committed visible/hidden split. Recapture may temporarily restore
+     * them; an opening menu reasserts this partition before parking the in-flight projection.
+     * @member {String[]|null} appliedHiddenIds=null
+     */
+    appliedHiddenIds = null
+    /**
      * The floating menu list whose mounted edge drains a deferred partition update.
      * @member {Neo.menu.List|null} observedMenuList=null
      */
     observedMenuList = null
     /**
-     * Latest hidden signature waiting for the open menu to unmount.
-     * @member {String|null} pendingHiddenSignature=null
+     * A projection requested while the Overflow menu owns a clickable rendered partition.
+     * @member {Boolean} menuProjectionQueued=false
      */
-    pendingHiddenSignature = null
+    menuProjectionQueued = false
     /**
-     * Latest menu records waiting for the open menu to unmount.
-     * @member {Object[]|null} pendingMenuItems=null
+     * Sticky recapture intent for the projection queued behind an open menu.
+     * @member {Boolean} menuRecaptureQueued=false
      */
-    pendingMenuItems = null
+    menuRecaptureQueued = false
     /**
      * A project() call arrived while a measure pass was in flight; drained once the pass releases the
      * latch, so a coalesced resize / activation / tab-set change still applies against current extents.
@@ -472,7 +478,7 @@ class Overflow extends Plugin {
      * @returns {Promise<void>}
      */
     whenProjectionIdle() {
-        if (!this.measuring && !this.projectQueued) {
+        if (!this.measuring && !this.projectQueued && !this.menuProjectionQueued) {
             return Promise.resolve()
         }
 
@@ -541,6 +547,10 @@ class Overflow extends Plugin {
             !me.measuring && me.resolveProjectionIdle();
             return
         }
+
+        // An open menu and its rendered tab split are one addressable partition. A projection may
+        // neither clear the menu's record store nor change header visibility underneath it.
+        if (me.queueOpenMenuProjection(recapture)) return;
 
         if (!owner.mounted || buttons.length < 1) {
             me.resolveProjectionIdle();
@@ -657,7 +667,7 @@ class Overflow extends Plugin {
             // A drag can begin while either DOM round-trip above is in flight. Recheck at the
             // mutation boundary so a pre-gesture measurement cannot hide/show members beneath the
             // SortZone snapshot captured in the meantime.
-            if (!me.queueSortDragProjection(recapture, false)) {
+            if (!me.queueSortDragProjection(recapture, false) && !me.queueOpenMenuProjection(recapture)) {
                 me.applySplit(hidden, buttons, tabContainer, {
                     activeButton,
                     maxSize: geometry.maxSize,
@@ -692,7 +702,7 @@ class Overflow extends Plugin {
             me.projectQueued   = false;
             me.queuedRecapture = false;
             me.project(queuedRecapture)
-        } else {
+        } else if (!me.menuProjectionQueued) {
             me.resolveProjectionIdle()
         }
     }
@@ -776,12 +786,42 @@ class Overflow extends Plugin {
             }
         });
 
+        me.appliedHiddenIds = [...hidden];
         me.syncControl(hiddenMeta, tabContainer)
     }
 
     /**
-     * Observes one generated menu list so a changed partition cannot clear the record store while
-     * its rendered nodes are still clickable. A replacement list supersedes the old observer.
+     * Restores the last committed header partition when the menu opens during a recapture pass.
+     * The recapture path may already have made every header measurable; parking its new decision
+     * without this rollback would leave those temporary headers visible beside stale menu records.
+     * @protected
+     */
+    restoreOpenMenuPartition() {
+        let me = this;
+
+        if (!me.appliedHiddenIds) return;
+
+        let hidden = new Set(me.appliedHiddenIds);
+
+        me.getTabButtons().forEach(button => {
+            let isHidden = hidden.has(button.id);
+
+            button.setSilent({hidden: isHidden});
+
+            if (isHidden) {
+                button.vdom.removeDom = true
+            } else {
+                delete button.vdom.removeDom
+            }
+        });
+
+        me.owner.updateDepth = -1;
+        me.owner.update()
+    }
+
+    /**
+     * Observes one generated menu list so its unmount edge can drain a queued projection. A
+     * replacement list supersedes the old observer.
      * @param {Neo.menu.List|null} menuList
      * @protected
      */
@@ -794,25 +834,47 @@ class Overflow extends Plugin {
 
         if (Neo.typeOf(menuList) === 'NeoInstance') {
             me.observeConfig(menuList, 'mounted', value => {
-                !value && me.observedMenuList === menuList && me.flushPendingMenuItems()
+                if (me.observedMenuList === menuList) {
+                    value ? me.restoreOpenMenuPartition() : me.drainOpenMenuProjection()
+                }
             })
         }
     }
 
     /**
-     * Applies the latest deferred menu partition once no rendered node addresses the old store.
+     * Queues a projection while the generated menu owns a clickable visible/hidden partition.
+     * @param {Boolean} recapture
+     * @returns {Boolean} True when the current projection must stop.
      * @protected
      */
-    flushPendingMenuItems() {
+    queueOpenMenuProjection(recapture) {
         let me       = this,
-            menuList = me.observedMenuList;
+            menuList = me.control?.menuList;
 
-        if (!menuList || menuList.mounted || !me.pendingMenuItems) return;
+        me.observeMenuListLifecycle(menuList);
 
-        menuList.items            = me.pendingMenuItems;
-        me.hiddenSignature        = me.pendingHiddenSignature;
-        me.pendingHiddenSignature = null;
-        me.pendingMenuItems       = null
+        if (!menuList?.mounted) return false;
+
+        me.menuProjectionQueued = true;
+        me.menuRecaptureQueued  = me.menuRecaptureQueued || recapture;
+
+        return true
+    }
+
+    /**
+     * Drains the latest sticky projection after the menu unmounts and releases its record store.
+     * @protected
+     */
+    drainOpenMenuProjection() {
+        let me = this;
+
+        if (!me.menuProjectionQueued || me.observedMenuList?.mounted) return;
+
+        let recapture = me.menuRecaptureQueued;
+
+        me.menuProjectionQueued = false;
+        me.menuRecaptureQueued  = false;
+        me.project(recapture)
     }
 
     /**
@@ -836,11 +898,12 @@ class Overflow extends Plugin {
                 let control = me.control;
 
                 me.control                = null;
+                me.appliedHiddenIds       = null;
                 me.hiddenSignature        = null;
                 me.measuredControlWidth   = null;
+                me.menuProjectionQueued   = false;
+                me.menuRecaptureQueued    = false;
                 me.observedMenuList       = null;
-                me.pendingHiddenSignature = null;
-                me.pendingMenuItems       = null;
                 // The measurement belongs to the torn-down embodiment; the next control re-measures.
                 control.destroy(true)
             }
@@ -868,25 +931,12 @@ class Overflow extends Plugin {
             // Idempotence gate: a projection that did not change the partition must not touch the
             // menu — rewriting identical items rebuilds the dropdown and closes it mid-interaction
             // (the render-truth edges made no-op projections routine, so this is load-bearing).
-            if (signature === me.hiddenSignature) {
-                me.pendingHiddenSignature = null;
-                me.pendingMenuItems       = null
-            } else if (menuList?.mounted) {
-                // The rendered menu nodes address the current store record ids. Replacing items now
-                // clears that store before an already-emitted click reaches the worker. Keep the old
-                // records stable and let the menu's unmount edge apply only the latest partition.
-                me.pendingHiddenSignature = signature;
-                me.pendingMenuItems       = menuItems
-            } else {
+            if (signature !== me.hiddenSignature) {
                 if (menuList) {
                     menuList.items = menuItems
                 } else {
                     me.control.menu = menuConfig
                 }
-
-                me.hiddenSignature        = signature;
-                me.pendingHiddenSignature = null;
-                me.pendingMenuItems       = null
             }
 
             // Re-arm a transiently unmounted control. A floating instance mounts once at
@@ -949,8 +999,6 @@ class Overflow extends Plugin {
                 windowId       : me.owner.windowId
             });
             me.control.addDomListeners?.({resize: me.onControlResize, scope: me});
-            me.hiddenSignature = signature;
-
             // The reservation's render-truth EDGE: the pass that creates the control computed its split
             // with the pre-creation estimate — the rendered width does not exist yet, and no external
             // event is owed. Re-project when the mount lands (and on any later re-mount — idempotent, and
@@ -962,6 +1010,8 @@ class Overflow extends Plugin {
                 })
             }
         }
+
+        me.hiddenSignature = signature;
 
         // RA-13: re-align against the CURRENT owner rect. A floating component aligns once at mount and does
         // NOT re-align when its target moves. Re-aligning on each sync re-pins it to the current action or
@@ -994,12 +1044,13 @@ class Overflow extends Plugin {
         });
 
         me.appliedCaps = null;
+        me.appliedHiddenIds = null;
         me.resolveProjectionIdle();
         me.sortDragZone?.un('dragEnd', me.onSortDragEnd, me);
         me.sortDragZone           = null;
+        me.menuProjectionQueued   = false;
+        me.menuRecaptureQueued    = false;
         me.observedMenuList       = null;
-        me.pendingHiddenSignature = null;
-        me.pendingMenuItems       = null;
         me.control?.destroy(true);
         me.control = null;
         super.destroy(...args)

--- a/src/tab/plugin/Overflow.mjs
+++ b/src/tab/plugin/Overflow.mjs
@@ -168,6 +168,21 @@ class Overflow extends Plugin {
      */
     hiddenSignature = null
     /**
+     * The floating menu list whose mounted edge drains a deferred partition update.
+     * @member {Neo.menu.List|null} observedMenuList=null
+     */
+    observedMenuList = null
+    /**
+     * Latest hidden signature waiting for the open menu to unmount.
+     * @member {String|null} pendingHiddenSignature=null
+     */
+    pendingHiddenSignature = null
+    /**
+     * Latest menu records waiting for the open menu to unmount.
+     * @member {Object[]|null} pendingMenuItems=null
+     */
+    pendingMenuItems = null
+    /**
      * A project() call arrived while a measure pass was in flight; drained once the pass releases the
      * latch, so a coalesced resize / activation / tab-set change still applies against current extents.
      * @member {Boolean} projectQueued=false
@@ -765,6 +780,42 @@ class Overflow extends Plugin {
     }
 
     /**
+     * Observes one generated menu list so a changed partition cannot clear the record store while
+     * its rendered nodes are still clickable. A replacement list supersedes the old observer.
+     * @param {Neo.menu.List|null} menuList
+     * @protected
+     */
+    observeMenuListLifecycle(menuList) {
+        let me = this;
+
+        if (!menuList || me.observedMenuList === menuList) return;
+
+        me.observedMenuList = menuList;
+
+        if (Neo.typeOf(menuList) === 'NeoInstance') {
+            me.observeConfig(menuList, 'mounted', value => {
+                !value && me.observedMenuList === menuList && me.flushPendingMenuItems()
+            })
+        }
+    }
+
+    /**
+     * Applies the latest deferred menu partition once no rendered node addresses the old store.
+     * @protected
+     */
+    flushPendingMenuItems() {
+        let me       = this,
+            menuList = me.observedMenuList;
+
+        if (!menuList || menuList.mounted || !me.pendingMenuItems) return;
+
+        menuList.items            = me.pendingMenuItems;
+        me.hiddenSignature        = me.pendingHiddenSignature;
+        me.pendingHiddenSignature = null;
+        me.pendingMenuItems       = null
+    }
+
+    /**
      * Creates / updates / tears down the single overflow control. A menu selection sets the
      * tab.Container's `activeIndex` (the ordinary activation path); the follow-up measure pass then
      * surfaces the now-active tab by construction (active-never-hidden), so the selected tab is never
@@ -782,11 +833,16 @@ class Overflow extends Plugin {
 
         if (hiddenMeta.length < 1) {
             if (me.control) {
-                me.control.destroy(true);
-                me.control              = null;
-                me.hiddenSignature      = null;
+                let control = me.control;
+
+                me.control                = null;
+                me.hiddenSignature        = null;
+                me.measuredControlWidth   = null;
+                me.observedMenuList       = null;
+                me.pendingHiddenSignature = null;
+                me.pendingMenuItems       = null;
                 // The measurement belongs to the torn-down embodiment; the next control re-measures.
-                me.measuredControlWidth = null
+                control.destroy(true)
             }
             return
         }
@@ -805,15 +861,32 @@ class Overflow extends Plugin {
             };
 
         if (me.control) {
+            let {menuList} = me.control;
+
+            me.observeMenuListLifecycle(menuList);
+
             // Idempotence gate: a projection that did not change the partition must not touch the
             // menu — rewriting identical items rebuilds the dropdown and closes it mid-interaction
             // (the render-truth edges made no-op projections routine, so this is load-bearing).
-            if (signature !== me.hiddenSignature) {
-                if (me.control.menuList) {
-                    me.control.menuList.items = menuItems
+            if (signature === me.hiddenSignature) {
+                me.pendingHiddenSignature = null;
+                me.pendingMenuItems       = null
+            } else if (menuList?.mounted) {
+                // The rendered menu nodes address the current store record ids. Replacing items now
+                // clears that store before an already-emitted click reaches the worker. Keep the old
+                // records stable and let the menu's unmount edge apply only the latest partition.
+                me.pendingHiddenSignature = signature;
+                me.pendingMenuItems       = menuItems
+            } else {
+                if (menuList) {
+                    menuList.items = menuItems
                 } else {
                     me.control.menu = menuConfig
                 }
+
+                me.hiddenSignature        = signature;
+                me.pendingHiddenSignature = null;
+                me.pendingMenuItems       = null
             }
 
             // Re-arm a transiently unmounted control. A floating instance mounts once at
@@ -876,6 +949,7 @@ class Overflow extends Plugin {
                 windowId       : me.owner.windowId
             });
             me.control.addDomListeners?.({resize: me.onControlResize, scope: me});
+            me.hiddenSignature = signature;
 
             // The reservation's render-truth EDGE: the pass that creates the control computed its split
             // with the pre-creation estimate — the rendered width does not exist yet, and no external
@@ -888,8 +962,6 @@ class Overflow extends Plugin {
                 })
             }
         }
-
-        me.hiddenSignature = signature;
 
         // RA-13: re-align against the CURRENT owner rect. A floating component aligns once at mount and does
         // NOT re-align when its target moves. Re-aligning on each sync re-pins it to the current action or
@@ -924,7 +996,10 @@ class Overflow extends Plugin {
         me.appliedCaps = null;
         me.resolveProjectionIdle();
         me.sortDragZone?.un('dragEnd', me.onSortDragEnd, me);
-        me.sortDragZone = null;
+        me.sortDragZone           = null;
+        me.observedMenuList       = null;
+        me.pendingHiddenSignature = null;
+        me.pendingMenuItems       = null;
         me.control?.destroy(true);
         me.control = null;
         super.destroy(...args)

--- a/test/playwright/e2e/dashboard/DockOperationsNL.spec.mjs
+++ b/test/playwright/e2e/dashboard/DockOperationsNL.spec.mjs
@@ -65,6 +65,102 @@ test.describe('Dock semantic operations (Neural Link, structural)', () => {
         expect(JSON.stringify(topo)).toBe(JSON.stringify(committed));
     });
 
+    test('close action resolves reordered live identity, retains chrome and restores successor or root focus', async ({ page, neuralLink }) => {
+        const { app, holderId } = await connect(page, neuralLink);
+        const pageErrors        = [];
+
+        page.on('pageerror', error => pageErrors.push(String(error?.message || error)));
+
+        const seeded = await readTopology(app, holderId);
+
+        const mainRecords = await app.queryComponent({dockNodeId: 'main-tabs'}, ['id', 'ntype']);
+        const mainRecord  = Array.isArray(mainRecords) ? mainRecords[0] : mainRecords;
+        const mainId      = mainRecord?.id ?? mainRecord?.properties?.id;
+
+        expect(mainId, 'the main projected TabContainer must retain its semantic node id').toBeTruthy();
+
+        await expect.poll(async () => (await app.callMethod(mainId, 'getActionItem', ['close']))?.id, {
+            message: 'the opt-in projection materialises one persistent close action',
+            timeout: 10000
+        }).toBeTruthy();
+
+        const beforeItems = seeded.nodes['main-tabs'].items,
+              targetId    = beforeItems[1];
+
+        expect(targetId, 'the seeded main stack must expose a reorder target').toBeTruthy();
+
+        const moved = await app.executeDockOperation(holderId, {
+            operation: 'moveItem', itemId: targetId, targetNodeId: 'main-tabs', index: 0
+        });
+
+        expect(moved.errors).toEqual([]);
+        expect(moved.document.nodes['main-tabs'].items[0]).toBe(targetId);
+
+        const target = await app.findInstances(
+            {className: 'Neo.tab.header.Button', dockItemId: targetId},
+            ['id', 'dockItemId']
+        );
+        const targetRecord   = Array.isArray(target) ? target[0] : target,
+              targetButtonId = targetRecord?.id ?? targetRecord?.properties?.id;
+
+        expect(targetButtonId, 'the reordered item owns a live tab header').toBeTruthy();
+        await page.locator(`#${targetButtonId}`).click();
+        await expect.poll(async () => (await app.getComponent(mainId, ['activeIndex'])).activeIndex, {
+            message: 'the real tab click activates the reordered live index',
+            timeout: 10000
+        }).toBe(0);
+
+        const actionBefore = await app.callMethod(mainId, 'getActionItem', ['close']),
+              closeButton  = page.locator(`#${actionBefore.id}`),
+              successorId  = moved.document.nodes['main-tabs'].items[1];
+
+        await expect(closeButton).toBeVisible({timeout: 10000});
+        await closeButton.click();
+
+        await expect.poll(async () => (await readTopology(app, holderId)).items[targetId], {
+            message: 'the real header action commits the active reordered item through the model',
+            timeout: 10000
+        }).toBeUndefined();
+
+        const after       = await readTopology(app, holderId),
+              actionAfter = await app.callMethod(mainId, 'getActionItem', ['close']),
+              successor   = await app.findInstances(
+                  {className: 'Neo.tab.header.Button', dockItemId: successorId},
+                  ['id', 'dockItemId']
+              ),
+              successorRecord = Array.isArray(successor) ? successor[0] : successor,
+              successorButtonId = successorRecord?.id ?? successorRecord?.properties?.id;
+
+        expect(after.nodes['main-tabs'].items).toEqual(
+            moved.document.nodes['main-tabs'].items.filter(itemId => itemId !== targetId)
+        );
+        expect(after.nodes['main-tabs'].activeItemId).toBe(successorId);
+        expect(after.items[successorId]).toBeTruthy();
+        expect(actionAfter.id, 'retained topology keeps the exact action instance').toBe(actionBefore.id);
+        expect(successorButtonId, 'the model-selected successor owns a live tab header').toBeTruthy();
+        await expect.poll(() => page.evaluate(() => document.activeElement?.id), {
+            message: 'focus settles on the successor header after reconciliation',
+            timeout: 10000
+        }).toBe(successorButtonId);
+
+        const terminalRecords = await app.queryComponent({dockNodeId: 'terminal-tabs'}, ['id', 'ntype']),
+              terminalRecord  = Array.isArray(terminalRecords) ? terminalRecords[0] : terminalRecords,
+              terminalId      = terminalRecord?.id ?? terminalRecord?.properties?.id,
+              terminalAction  = await app.callMethod(terminalId, 'getActionItem', ['close']);
+
+        expect(terminalId, 'the single-item terminal stack must remain projected').toBeTruthy();
+        await page.locator(`#${terminalAction.id}`).click();
+        await expect.poll(async () => (await readTopology(app, holderId)).nodes['terminal-tabs'], {
+            message: 'closing the only item lets normalization prune its tabs node',
+            timeout: 10000
+        }).toBeUndefined();
+        await expect.poll(() => page.evaluate(() => document.activeElement?.id), {
+            message: 'the surviving DockWorkspace root receives focus after node pruning',
+            timeout: 10000
+        }).toBe(holderId);
+        expect(pageErrors).toEqual([])
+    });
+
     test('tab-move class: moveItem relocates across tabs nodes; delta and independent read agree', async ({ page, neuralLink }) => {
         const { app, holderId } = await connect(page, neuralLink);
 

--- a/test/playwright/e2e/dashboard/DockTabOverflowNL.spec.mjs
+++ b/test/playwright/e2e/dashboard/DockTabOverflowNL.spec.mjs
@@ -65,17 +65,28 @@ test.describe('dock tab-overflow floating control', () => {
 
         // Partition: the visible headers + the hidden (menu) headers together are the full tab set — nothing
         // is lost or duplicated across the visible/hidden split.
-        const normalize      = values => values.map(value => value.trim()).filter(Boolean),
-              visibleHeaders = normalize(await page.locator('.neo-tab-header-button:visible').allTextContents()),
-              hiddenHeaders  = normalize(await menuItems.allTextContents());
-        expect([...visibleHeaders, ...hiddenHeaders].sort()).toEqual(
-            ['Agents', 'Alerts', 'History', 'Inspector', 'Logs', 'Metrics', 'Strategy', 'Swarm', 'Terminal', 'Timeline'].sort());
+        const normalize       = values => values.map(value => value.trim()).filter(Boolean),
+              expectedHeaders = ['Agents', 'Alerts', 'History', 'Inspector', 'Logs', 'Metrics', 'Strategy', 'Swarm', 'Terminal', 'Timeline'].sort();
+
+        await expect.poll(async () => {
+            const visibleHeaders = normalize(await page.locator('.neo-tab-header-button:visible').allTextContents()),
+                  hiddenHeaders  = normalize(await menuItems.allTextContents());
+
+            return [...visibleHeaders, ...hiddenHeaders].sort()
+        }, {
+            message: 'visible headers and the Overflow menu settle into one exact partition',
+            timeout: 10000
+        }).toEqual(expectedHeaders);
 
         // Selection: picking a hidden tab activates it and surfaces it into the header (pressed + visible),
         // via the ordinary activeIndex path (active-never-hidden), so the picked tab is never left in the menu.
-        const selectedText = (await menuItems.first().innerText()).trim();
-        await menuItems.first().click();
-        await expect(page.locator('.neo-tab-header-button.pressed:visible').filter({ hasText: selectedText })).toHaveCount(1);
+        const selectedText = (await menuItems.first().innerText()).trim(),
+              selectedItem = menuItems.filter({hasText: selectedText});
+
+        await expect(selectedItem, 'the selected semantic menu item remains unique while Overflow settles').toHaveCount(1);
+        await selectedItem.click();
+        await expect(page.locator('.neo-tab-header-button.pressed:visible').filter({hasText: selectedText}))
+            .toHaveCount(1, {timeout: 10000});
 
         // No unexpected browser errors across the journey — notably, a fixed-positioned align must NOT trip
         // `ResizeObserver.observe(null)` (offsetParent is null for `position: fixed`), which the DomAccess

--- a/test/playwright/e2e/dashboard/DockTabOverflowNL.spec.mjs
+++ b/test/playwright/e2e/dashboard/DockTabOverflowNL.spec.mjs
@@ -38,16 +38,25 @@ test.describe('dock tab-overflow floating control', () => {
         // It carries the ellipsis affordance.
         await expect(control.locator('.fa-ellipsis')).toHaveCount(1);
 
-        // Owner-EXACT geometry: the control's right edge + top align (within 2px) to its owner toolbar — the
-        // one carrying 'Strategy' — NOT a stale pre-settle position. This requires the
-        // `.neo-button.neo-floating { position: fixed }` cascade fix; without it the control is pinned to its
-        // offsetParent instead of the viewport and lands at the wrong coordinates.
+        // Owner-EXACT geometry: the control's right edge aligns (within 2px) immediately before the
+        // persistent Dock close-action rail, and its top aligns to that action inside the toolbar
+        // carrying 'Strategy' — NOT a stale pre-settle position. This requires the
+        // `.neo-button.neo-floating { position: fixed }` cascade fix; without it the control is pinned
+        // to its offsetParent instead
+        // of the viewport and lands at the wrong coordinates.
         const mainToolbar = page.locator('.neo-tab-header-toolbar').filter({ hasText: 'Strategy' }).first(),
-              controlBox  = await control.boundingBox(),
-              toolbarBox  = await mainToolbar.boundingBox();
-        expect(Math.abs((controlBox.x + controlBox.width) - (toolbarBox.x + toolbarBox.width)),
-            'control right edge aligns to the toolbar right edge').toBeLessThanOrEqual(2);
-        expect(Math.abs(controlBox.y - toolbarBox.y), 'control top aligns to the toolbar top').toBeLessThanOrEqual(2);
+              closeAction = mainToolbar.getByRole('button', {name: 'close', exact: true});
+
+        await expect(closeAction).toBeVisible();
+
+        const controlBox = await control.boundingBox(),
+              actionBox  = await closeAction.boundingBox();
+
+        expect(Math.abs((controlBox.x + controlBox.width) - actionBox.x),
+            'control right edge aligns immediately before the Dock action rail').toBeLessThanOrEqual(2);
+        expect(Math.abs(controlBox.y - actionBox.y),
+            'control top aligns to the adjacent Dock action').toBeLessThanOrEqual(2);
+        await expect(mainToolbar.locator('.neo-toolbar-action.neo-draggable')).toHaveCount(0);
 
         // Clicking the control opens its dropdown menu of hidden tabs.
         await control.click();

--- a/test/playwright/unit/dashboard/DockLayoutAdapter.spec.mjs
+++ b/test/playwright/unit/dashboard/DockLayoutAdapter.spec.mjs
@@ -179,6 +179,50 @@ test.describe('Neo.dashboard.DockLayoutAdapter', () => {
         expect(sideChildren.map(item => item.flex)).toEqual([0.55, 0.45]);
     });
 
+    test('projects the opt-in persistent Dock close action and forwards runtime intent only', () => {
+        const model = createModel();
+
+        model.items.swarm.closable = false;
+
+        const
+            closeIntents  = [],
+            activeChanges = [],
+            disabled      = DockLayoutAdapter.project(model, {
+                resolveComponentRef: componentRef => ({ntype: 'dashboard-panel', reference: componentRef})
+            }),
+            enabled       = DockLayoutAdapter.project(model, {
+                enableDockCloseAction  : true,
+                onDockActiveIndexChange: data => activeChanges.push(data),
+                onDockHeaderAction     : data => closeIntents.push(data),
+                resolveComponentRef    : componentRef => ({ntype: 'dashboard-panel', reference: componentRef})
+            }),
+            disabledMain = getProjectedChildren(disabled)[0],
+            enabledMain  = getProjectedChildren(enabled)[0],
+            closeAction  = enabledMain.headerActions[0];
+
+        expect(disabledMain.headerActions).toBeUndefined();
+        expect(disabledMain.vdom).toBeUndefined();
+
+        expect(closeAction).toMatchObject({
+            action    : 'close',
+            contextual: false,
+            hidden    : true
+        });
+        expect(closeAction.iconCls).toBeTruthy();
+        expect(enabledMain.vdom.tabIndex).toBe(-1);
+
+        const tabContainer = {id: 'live-tabs'};
+
+        enabledMain.listeners.headerAction({action: 'custom', tabContainer});
+        expect(closeIntents).toEqual([]);
+
+        enabledMain.listeners.headerAction({action: 'close', tabContainer});
+        enabledMain.listeners.activeIndexChange({item: {id: 'live-card'}, value: 0});
+
+        expect(closeIntents).toEqual([{action: 'close', dockNodeId: 'main-tabs', tabContainer}]);
+        expect(activeChanges).toEqual([{dockNodeId: 'main-tabs', item: {id: 'live-card'}, tabContainer: null, value: 0}])
+    });
+
     test('split children release the flexbox min-content floor: committed sizes stay the sole geometry authority', () => {
         let result = DockLayoutAdapter.project(createModel(), {
                 resolveComponentRef: componentRef => ({

--- a/test/playwright/unit/dashboard/DockWorkspace.spec.mjs
+++ b/test/playwright/unit/dashboard/DockWorkspace.spec.mjs
@@ -192,6 +192,138 @@ test.describe('Neo.dashboard.DockWorkspace', () => {
         expect(JSON.stringify(document)).toBe(before)
     });
 
+    test('the opt-in close action resolves live identity, commits once, preserves its instance and focuses after refresh', async () => {
+        const document = createDocument();
+
+        document.items.terminal.closable = false;
+
+        workspace = Neo.create(PlainWorkspace, {
+            dockModel            : document,
+            enableDockCloseAction: true
+        });
+
+        const
+            tabs         = tabsOf(workspace.items[0]),
+            side         = tabs.get('side-tabs'),
+            closeAction  = side.getActionItem('close'),
+            terminalTab  = side.getTabButtons()[1],
+            focusTargets = [],
+            commits      = [],
+            apply        = workspace.applyDockZoneOperation.bind(workspace);
+
+        workspace.applyDockZoneOperation = descriptor => {
+            commits.push(descriptor);
+            return apply(descriptor)
+        };
+        terminalTab.focus = () => focusTargets.push('terminal');
+
+        expect(closeAction).toBeTruthy();
+        expect(closeAction.hidden).toBe(false);
+
+        await side.set({activeIndex: 1});
+        expect(closeAction.hidden, 'explicit false is projected into live availability').toBe(true);
+
+        const refused = workspace.onDockHeaderAction({action: 'close', dockNodeId: 'side-tabs', tabContainer: side});
+
+        expect(refused.errors).toEqual(['item "terminal" is not closable']);
+        expect(workspace.getDockZoneDocument()).toBe(document);
+        expect(workspace.refreshPromise).toBeNull();
+        expect(side.activeIndex).toBe(1);
+        expect(side.getActionItem('close')).toBe(closeAction);
+        expect(focusTargets).toEqual([]);
+
+        workspace.dockModel = null;
+
+        const noDocument = workspace.onDockHeaderAction({action: 'close', dockNodeId: 'side-tabs', tabContainer: side});
+
+        expect(noDocument.errors).toEqual(['Dock close action requires a committed document']);
+        expect(workspace.refreshPromise).toBeNull();
+        expect(focusTargets).toEqual([]);
+
+        workspace.dockModel = document;
+
+        await side.set({activeIndex: 0});
+        expect(closeAction.hidden).toBe(false);
+
+        closeAction.handler({component: closeAction});
+        await workspace.refreshPromise;
+
+        const retainedSide = tabsOf(workspace.items[0]).get('side-tabs');
+
+        expect(commits.map(item => item.itemId)).toEqual(['terminal', 'preview']);
+        expect(workspace.getDockZoneDocument().nodes['side-tabs'].items).toEqual(['terminal']);
+        expect(retainedSide).toBe(side);
+        expect(retainedSide.getActionItem('close')).toBe(closeAction);
+        expect(closeAction.hidden).toBe(true);
+        expect(focusTargets).toEqual(['terminal'])
+    });
+
+    test('a model-ahead close targets live chrome but focuses the model-selected successor', async () => {
+        const document = createDocument();
+
+        document.items.aux = {componentRef: 'Aux', title: 'Aux', kind: 'panel'};
+        document.nodes['side-tabs'].items.push('aux');
+
+        workspace = Neo.create(PlainWorkspace, {
+            dockModel            : document,
+            enableDockCloseAction: true
+        });
+
+        const
+            side       = tabsOf(workspace.items[0]).get('side-tabs'),
+            modelAhead = workspace.applyDockZoneOperation({
+                operation: 'moveItem', itemId: 'preview', targetNodeId: 'side-tabs', index: 2
+            }),
+            focusTargets = [];
+
+        expect(side.getTabBar().sortZoneConfig.dockItemIds).toEqual(['preview', 'terminal', 'aux']);
+        expect(modelAhead.document.nodes['side-tabs'].items).toEqual(['terminal', 'aux', 'preview']);
+
+        // Model commits are synchronous while projection is deferred. Preserve that exact window:
+        // live chrome still targets preview, while semantic successor policy already lives in the
+        // reordered document.
+        workspace.dockModel = modelAhead.document;
+        workspace.focusDockCloseTarget = data => focusTargets.push(data.itemId);
+
+        const closed = workspace.onDockHeaderAction({
+            action: 'close', dockNodeId: 'side-tabs', tabContainer: side
+        });
+
+        await workspace.refreshPromise;
+
+        expect(closed.errors).toEqual([]);
+        expect(closed.document.items.preview).toBeUndefined();
+        expect(closed.document.nodes['side-tabs'].activeItemId).toBe('aux');
+        expect(focusTargets).toEqual(['aux'])
+    });
+
+    test('closing a node\'s only item focuses the surviving DockWorkspace root after normalization prunes the tab shell', async () => {
+        const document = createDocument();
+
+        document.nodes['side-tabs'].items        = ['terminal'];
+        document.nodes['side-tabs'].activeItemId = 'terminal';
+
+        workspace = Neo.create(PlainWorkspace, {
+            dockModel            : document,
+            enableDockCloseAction: true
+        });
+
+        const
+            side         = tabsOf(workspace.items[0]).get('side-tabs'),
+            closeAction  = side.getActionItem('close'),
+            focusTargets = [];
+
+        workspace.focus = () => focusTargets.push('workspace');
+
+        closeAction.handler({component: closeAction});
+        await workspace.refreshPromise;
+
+        expect(workspace.getDockZoneDocument().nodes['side-tabs']).toBeUndefined();
+        expect(tabsOf(workspace.items[0]).has('side-tabs')).toBe(false);
+        expect(focusTargets).toEqual(['workspace']);
+        expect(workspace.vdom.tabIndex).toBe(-1)
+    });
+
     test('rapid commits advance the document synchronously and stage one transaction at a time', async () => {
         workspace = Neo.create(PlainWorkspace, {dockModel: createDocument()});
 

--- a/test/playwright/unit/dashboard/DockZoneModel.spec.mjs
+++ b/test/playwright/unit/dashboard/DockZoneModel.spec.mjs
@@ -1269,6 +1269,51 @@ test.describe('Neo.dashboard.DockZoneModel', () => {
             const {document, errors} = DockZoneModel.closeItem(doc(), {itemId: 'terminal'});
             expect(errors).toEqual([]);
             expect(document.items.terminal).toBeUndefined()
+        });
+
+        test('closeItem rejects explicit non-closable policy without changing one byte', () => {
+            const input = doc();
+
+            input.items.swarm.closable = false;
+
+            const snapshot           = JSON.stringify(input),
+                  {document, errors} = DockZoneModel.closeItem(input, {itemId: 'swarm'});
+
+            expect(errors).toEqual(['item "swarm" is not closable']);
+            expect(document).toBe(input);
+            expect(JSON.stringify(input)).toBe(snapshot)
+        });
+
+        test('closeItem selects the item at the closed index, then the preceding item, then null', () => {
+            const createCloseDocument = () => {
+                const input = doc();
+
+                input.nodes['main-tabs'].items        = ['strategy', 'swarm', 'inspector'];
+                input.nodes['main-tabs'].activeItemId = 'strategy';
+
+                return input
+            };
+
+            const first = DockZoneModel.closeItem(createCloseDocument(), {itemId: 'strategy'});
+            expect(first.errors).toEqual([]);
+            expect(first.document.nodes['main-tabs'].items).toEqual(['swarm', 'inspector']);
+            expect(first.document.nodes['main-tabs'].activeItemId).toBe('swarm');
+
+            const middle = DockZoneModel.closeItem(createCloseDocument(), {itemId: 'swarm'});
+            expect(middle.errors).toEqual([]);
+            expect(middle.document.nodes['main-tabs'].items).toEqual(['strategy', 'inspector']);
+            expect(middle.document.nodes['main-tabs'].activeItemId).toBe('inspector');
+
+            const last = DockZoneModel.closeItem(createCloseDocument(), {itemId: 'inspector'});
+            expect(last.errors).toEqual([]);
+            expect(last.document.nodes['main-tabs'].items).toEqual(['strategy', 'swarm']);
+            expect(last.document.nodes['main-tabs'].activeItemId).toBe('swarm');
+
+            const only = DockZoneModel.closeItem(doc(), {itemId: 'terminal'});
+            expect(only.errors).toEqual([]);
+            expect(only.document.items.terminal).toBeUndefined();
+            expect(only.document.nodes['side-tabs']).toBeUndefined();
+            expect(only.document.nodes.root.zones.right).toBeUndefined()
         })
     });
 

--- a/test/playwright/unit/dashboard/DockZoneModel.spec.mjs
+++ b/test/playwright/unit/dashboard/DockZoneModel.spec.mjs
@@ -1284,12 +1284,12 @@ test.describe('Neo.dashboard.DockZoneModel', () => {
             expect(JSON.stringify(input)).toBe(snapshot)
         });
 
-        test('closeItem selects the item at the closed index, then the preceding item, then null', () => {
-            const createCloseDocument = () => {
+        test('closeItem selects a successor only for the active item and preserves other activation', () => {
+            const createCloseDocument = (activeItemId='strategy') => {
                 const input = doc();
 
                 input.nodes['main-tabs'].items        = ['strategy', 'swarm', 'inspector'];
-                input.nodes['main-tabs'].activeItemId = 'strategy';
+                input.nodes['main-tabs'].activeItemId = activeItemId;
 
                 return input
             };
@@ -1302,12 +1302,22 @@ test.describe('Neo.dashboard.DockZoneModel', () => {
             const middle = DockZoneModel.closeItem(createCloseDocument(), {itemId: 'swarm'});
             expect(middle.errors).toEqual([]);
             expect(middle.document.nodes['main-tabs'].items).toEqual(['strategy', 'inspector']);
-            expect(middle.document.nodes['main-tabs'].activeItemId).toBe('inspector');
+            expect(middle.document.nodes['main-tabs'].activeItemId).toBe('strategy');
 
             const last = DockZoneModel.closeItem(createCloseDocument(), {itemId: 'inspector'});
             expect(last.errors).toEqual([]);
             expect(last.document.nodes['main-tabs'].items).toEqual(['strategy', 'swarm']);
-            expect(last.document.nodes['main-tabs'].activeItemId).toBe('swarm');
+            expect(last.document.nodes['main-tabs'].activeItemId).toBe('strategy');
+
+            const activeMiddle = DockZoneModel.closeItem(createCloseDocument('swarm'), {itemId: 'swarm'});
+            expect(activeMiddle.errors).toEqual([]);
+            expect(activeMiddle.document.nodes['main-tabs'].items).toEqual(['strategy', 'inspector']);
+            expect(activeMiddle.document.nodes['main-tabs'].activeItemId).toBe('inspector');
+
+            const activeLast = DockZoneModel.closeItem(createCloseDocument('inspector'), {itemId: 'inspector'});
+            expect(activeLast.errors).toEqual([]);
+            expect(activeLast.document.nodes['main-tabs'].items).toEqual(['strategy', 'swarm']);
+            expect(activeLast.document.nodes['main-tabs'].activeItemId).toBe('swarm');
 
             const only = DockZoneModel.closeItem(doc(), {itemId: 'terminal'});
             expect(only.errors).toEqual([]);

--- a/test/playwright/unit/tab/plugin/Overflow.spec.mjs
+++ b/test/playwright/unit/tab/plugin/Overflow.spec.mjs
@@ -269,14 +269,15 @@ test.describe('Neo.tab.plugin.Overflow (re-entrancy contract)', () => {
         expect(plugin.control, 'the reference is cleared, so the next overflow builds a fresh control').toBe(null)
     });
 
-    test('an open menu retains its clickable record store until unmount, then receives the latest partition', async () => {
+    test('an open menu queues the latest complete projection until its clickable partition unmounts', async () => {
         const plugin = createPlugin(async ids => ids[0] === 'tab-overflow-test-owner' ? [{width: 1000}] : [{width: 10}, {width: 10}]);
 
         await new Promise(resolve => setTimeout(resolve, 0));
 
         const
             originalItems = [{text: 'Agents', handler() {}}],
-            menuList      = Neo.create(MountableMenuList, {items: originalItems, mounted: true});
+            menuList      = Neo.create(MountableMenuList, {items: originalItems, mounted: true}),
+            projections   = [];
 
         plugin.control = {
             alignTo() {},
@@ -286,19 +287,55 @@ test.describe('Neo.tab.plugin.Overflow (re-entrancy contract)', () => {
             mounted: true
         };
         plugin.hiddenSignature = '0:Agents:fa fa-users';
+        plugin.project = recapture => projections.push(recapture);
 
-        plugin.syncControl([{text: 'History', iconCls: 'fa fa-history', index: 1}], {activeIndex: 0});
-        plugin.syncControl([{text: 'Metrics', iconCls: 'fa fa-chart-line', index: 2}], {activeIndex: 0});
+        expect(plugin.queueOpenMenuProjection(false)).toBe(true);
+        expect(plugin.queueOpenMenuProjection(true)).toBe(true);
 
         expect(menuList.items.map(item => item.text),
             'a mounted menu keeps the records its rendered nodes address').toEqual(['Agents']);
+        expect(plugin.menuProjectionQueued).toBe(true);
+        expect(plugin.menuRecaptureQueued).toBe(true);
+        expect(projections).toEqual([]);
 
         menuList.mounted = false;
 
-        expect(menuList.items.map(item => item.text)).toEqual(['Metrics']);
-        expect(plugin.hiddenSignature).toBe('2:Metrics:fa fa-chart-line');
+        expect(projections).toEqual([true]);
+        expect(plugin.menuProjectionQueued).toBe(false);
+        expect(plugin.menuRecaptureQueued).toBe(false);
 
         menuList.destroy();
+        plugin.destroy()
+    });
+
+    test('opening a menu restores the last committed header partition after recapture visibility', async () => {
+        const plugin = createPlugin(async ids => ids[0] === 'tab-overflow-test-owner' ? [{width: 1000}] : [{width: 10}, {width: 10}]);
+
+        await new Promise(resolve => setTimeout(resolve, 0));
+
+        const
+            makeButton = id => ({
+                hidden: false,
+                id,
+                setSilent(values) { Object.assign(this, values) },
+                vdom: {}
+            }),
+            buttons = [makeButton('b1'), makeButton('b2')];
+
+        let updates = 0;
+
+        plugin.appliedHiddenIds       = ['b2'];
+        plugin.owner.getTabButtons    = () => buttons;
+        plugin.owner.update           = () => updates++;
+        plugin.restoreOpenMenuPartition();
+
+        expect(buttons[0].hidden).toBe(false);
+        expect(buttons[0].vdom.removeDom).toBeUndefined();
+        expect(buttons[1].hidden).toBe(true);
+        expect(buttons[1].vdom.removeDom).toBe(true);
+        expect(updates).toBe(1);
+        expect(plugin.owner.updateDepth).toBe(-1);
+
         plugin.destroy()
     });
 

--- a/test/playwright/unit/tab/plugin/Overflow.spec.mjs
+++ b/test/playwright/unit/tab/plugin/Overflow.spec.mjs
@@ -88,6 +88,19 @@ class MountableControl extends Neo.core.Base {
 MountableControl = Neo.setupClass(MountableControl);
 
 /**
+ * @summary Reactive menu fixture for proving that an open Overflow menu keeps its record store
+ * stable until the floating list unmounts.
+ */
+class MountableMenuList extends Neo.core.Base {
+    static config = {
+        className: 'Test.Unit.Tab.Plugin.Overflow.MountableMenuList',
+        items_   : null,
+        mounted_ : false
+    }
+}
+MountableMenuList = Neo.setupClass(MountableMenuList);
+
+/**
  * @summary Focused tests for the Neo.tab.plugin.Overflow re-entrancy contract — the part of
  * the runtime overflow plugin that must survive a resize / activation storm without stranding state.
  *
@@ -254,6 +267,39 @@ test.describe('Neo.tab.plugin.Overflow (re-entrancy contract)', () => {
 
         expect(destroyed, 'the control is destroyed when the overflow set empties').toBe(true);
         expect(plugin.control, 'the reference is cleared, so the next overflow builds a fresh control').toBe(null)
+    });
+
+    test('an open menu retains its clickable record store until unmount, then receives the latest partition', async () => {
+        const plugin = createPlugin(async ids => ids[0] === 'tab-overflow-test-owner' ? [{width: 1000}] : [{width: 10}, {width: 10}]);
+
+        await new Promise(resolve => setTimeout(resolve, 0));
+
+        const
+            originalItems = [{text: 'Agents', handler() {}}],
+            menuList      = Neo.create(MountableMenuList, {items: originalItems, mounted: true});
+
+        plugin.control = {
+            alignTo() {},
+            destroy() {},
+            iconCls: 'fa fa-ellipsis',
+            menuList,
+            mounted: true
+        };
+        plugin.hiddenSignature = '0:Agents:fa fa-users';
+
+        plugin.syncControl([{text: 'History', iconCls: 'fa fa-history', index: 1}], {activeIndex: 0});
+        plugin.syncControl([{text: 'Metrics', iconCls: 'fa fa-chart-line', index: 2}], {activeIndex: 0});
+
+        expect(menuList.items.map(item => item.text),
+            'a mounted menu keeps the records its rendered nodes address').toEqual(['Agents']);
+
+        menuList.mounted = false;
+
+        expect(menuList.items.map(item => item.text)).toEqual(['Metrics']);
+        expect(plugin.hiddenSignature).toBe('2:Metrics:fa fa-chart-line');
+
+        menuList.destroy();
+        plugin.destroy()
     });
 
     test('an owner theme change is carried onto the live out-of-tree control', async () => {


### PR DESCRIPTION
Resolves #17419

Adds an opt-in, model-authoritative close action to projected Dock tab headers. `DockZoneModel` now enforces explicit `closable:false` and selects the semantic successor; `DockWorkspace` resolves the live target, commits once, synchronizes the retained action, and restores focus only after reconciliation. The standalone Dock example opts in. Sequence testing also exposed and repairs an open-menu Overflow race by keeping header visibility and rendered menu records atomic until unmount.

Evidence: L3 (cross-seat branded-Chrome close/reorder/successor/root-focus and open-menu Overflow sequence, 2/2 at exact head `7eb990fc62`) + exact-head L2 (237 focused units and a red-capable non-active activation mutation) → L3 required (AC2, AC5, AC8, AC9, AC11 runtime UI effects). The author seat aborted before browser creation under `EMFILE`; Grace's positive visual-render seat supplied the exact-head receipt. No residuals.

## AC Evidence

| AC-1 | CI-covered: `DockLayoutAdapter.spec.mjs` proves the disabled projection emits neither an action nor a focus carrier; `DockWorkspace` defaults the feature off. |
| AC-2 | L3 + CI-covered: `DockOperationsNL.spec.mjs` clicks the persistent non-contextual action; adapter/workspace specs prove one stable action per projected tabs node. |
| AC-3 | CI-covered: `DockZoneModel.spec.mjs` proves absent `closable` remains allowed and explicit false returns the named refusal with the input byte-identical. |
| AC-4 | CI-covered: `DockWorkspace.spec.mjs` switches between closeable/non-closeable active items and forges the direct call; model policy still refuses it. |
| AC-5 | L3 + CI-covered: the E2E reorders then activates through real chrome before clicking close; the workspace spec records one semantic `closeItem` reduction. |
| AC-6 | CI-covered: refusal preserves document identity, active index, action identity, refresh state, and focus; successful chrome changes run only through the refresh chain. |
| AC-7 | L3 + CI-covered: model specs cover active first/middle/last/only successors and prove non-active middle/last closes preserve the surviving activation; the E2E covers reordered active-item dispatch without a stale target. |
| AC-8 | L3: the E2E asserts `document.activeElement` becomes the successor header, then closes a single-item stack and asserts the surviving `DockWorkspace` root. |
| AC-9 | L3 + CI-covered: `DockTabOverflowNL.spec.mjs` proves action-rail geometry and selection; `Overflow.spec.mjs` covers four axes/open-menu lifecycle; generic action, same-strip, cross-zone, and tear-out projection suites own the remaining boundaries. |
| AC-10 | CI-covered: topology reads remain JSON-equal to committed documents, while adapter callbacks live only in projection listeners. |
| AC-11 | Exact-head receipts at `7eb990fc62`: 237 focused units passed, including the hosted-CI falsifiers and RA-1 preservation arms; Grace independently verified the close→Overflow branded-Chrome pair 2/2 green. |

## Deltas from ticket

- The standalone Dock example is the explicit opt-in consumer, leaving the engine default disabled.
- The required Overflow-active journey exposed a changed-partition race: replacing an open menu's items cleared records still addressed by rendered nodes. Overflow now parks the entire projection while the menu owns a clickable partition, restores the last committed header visibility if an in-flight recapture had exposed measurement state, and drains the latest projection on unmount.

## Test Evidence

- `NEO_E2E_PORT=8093 NEO_E2E_RUN_ID=17419-rebased-atomic-exact-head npx playwright test dashboard/DockOperationsNL dashboard/DockTabOverflowNL -c test/playwright/playwright.config.e2e.mjs --workers=1 --grep "close action|floating overflow control"` → 2 passed at `a313acf980`; RA-1 changes only non-active direct-op activation, while both browser journeys close active items.
- Exact-head RA evidence at `7eb990fc62`: 237/237 focused units passed. Removing the `wasActive` gate makes the non-active middle arm red (`strategy` expected, `inspector` received); active first/middle/last/only successor arms remain green.
- Cross-seat exact-head L3: Grace verified `git rev-parse` against full SHA `7eb990fc62209041ce36cc75dcb01f1b20709401`, then ran the same close/Overflow pair 2/2 green (`DockOperationsNL` 3.3s; `DockTabOverflowNL` 588ms).
- Author-seat exact-head Chrome retry `17419-ra1-rebased-exact-head` aborted before any browser object existed (`EMFILE` watcher pressure, Chrome `SIGABRT`); this is the declared author-host ceiling that the cross-seat receipt closes.
- Diagonal receipt: the pre-repair sequence first threw `TypeError: Cannot read properties of null (reading 'handler')`, then exposed missing/duplicated visible+menu members when only the record store was deferred. The whole-projection transaction passed three consecutive browser sequences before the exact-head run.

## Post-Merge Validation

- [x] None required; every close-target runtime effect now has exact-head L3 evidence, and the RA-1 model delta has exact-head L2 plus a red-capable mutation. No post-merge step remains.

## Commits

- `00997575fd` — model policy, Dock projection/workspace integration, example opt-in, and close/focus coverage.
- `791ed5aaa1` — semantic Overflow partition/selection witness stabilization.
- `62480f566c` — preserve open Overflow menu records until unmount.
- `b40236bb94` — bind Dock close callbacks only for opted-in projections; keeps disabled duck-typed owners inert.
- `fe6f0ad0a5` — keep header visibility and Overflow menu records atomic while the menu is open.
- `7eb990fc62` — preserve activation for non-active closes while retaining deterministic active-item successors.

## Evolution

Live sequential validation changed the diagnosis from a locator-only flake to an engine race once the page emitted the null-handler exception. A store-only deferral then falsified itself by letting header visibility advance independently. The final repair stays at the generic Overflow ownership boundary and treats header visibility plus menu records as one projection transaction.

Authored by Emmy (GPT-5.6 Sol Ultra, Codex). Session 01a02ed8-9cf8-74c3-bfa5-9cc57bc10166.
