### PR TITLE
fix(test): the Mailbox tab witness resolves its own pane by identity (#17625)

### DIFF
--- a/test/playwright/e2e/agentos/FleetMailboxTabNL.spec.mjs
+++ b/test/playwright/e2e/agentos/FleetMailboxTabNL.spec.mjs
@@ -17,6 +17,41 @@ import {test, expect} from '../../fixtures.mjs';
  * @see apps/agentos/view/fleet/detail/Container.mjs
  * @see test/playwright/e2e/agentos/FleetCockpitDrillNL.spec.mjs (the drill pattern this extends)
  */
+/**
+ * @summary Resolves the AgentDetail tab's OWN mailbox pane, by identity rather than list position.
+ *
+ * `AgentOS.view.fleet.mailbox.Container` is used by TWO surfaces — this tab and the Operator
+ * Mailbox — so a className-only query returns more than one instance and its ordering is not a
+ * contract. Taking the first match resolved the Operator Mailbox's unmounted pane, which holds no
+ * drilled record: the assertion then read `undefined` and the injected snapshot landed in a pane
+ * nobody was looking at, so the rows never rendered. Both symptoms, one wrong object.
+ *
+ * The anchor is the DOM node inside `.fm-agent-detail`, whose element id IS the component id. That
+ * states the intent — *this tab's pane* — instead of a property that merely happens to discriminate
+ * today: filtering on `mounted` would work now only because the Operator pane is unmounted during
+ * this journey, and would silently re-break the day both are mounted.
+ *
+ * @param {Object} app Neural Link fixture app handle.
+ * @param {Object} pane Playwright locator for the tab's `.fm-mailbox-pane`.
+ * @param {String[]} properties Component properties to read back; `id` is always included.
+ * @returns {Promise<Object>} The resolved component entry.
+ */
+const resolveDetailMailboxPane = async (app, pane, properties) => {
+    const paneId     = await pane.getAttribute('id'),
+          requested  = properties.includes('id') ? properties : [...properties, 'id'],
+          candidates = await app.queryComponent({className: 'AgentOS.view.fleet.mailbox.Container'}, requested),
+          entries    = Array.isArray(candidates) ? candidates : [candidates],
+          resolved   = entries.find(entry => entry?.properties?.id === paneId);
+
+    // Fails on the exact defect this helper exists for: if resolution ever lands on another
+    // surface's pane, the id will not match and this names both the wanted and the available ids
+    // rather than surfacing later as `undefined` three assertions downstream.
+    expect(resolved, `the AgentDetail tab's own pane '${paneId}' must resolve; saw ` +
+        JSON.stringify(entries.map(entry => entry?.properties?.id))).toBeTruthy();
+
+    return resolved
+};
+
 test.describe('AgentOS fleet cockpit — the AgentDetail Mailbox tab live (#15270)', () => {
     test.setTimeout(90000);
 
@@ -71,7 +106,7 @@ test.describe('AgentOS fleet cockpit — the AgentDetail Mailbox tab live (#1527
         // finding rather than a coincidence.)
         await page.waitForTimeout(500);
 
-        const [mounted] = await app.queryComponent({className: 'AgentOS.view.fleet.mailbox.Container'}, ['record', 'snapshot', 'id']);
+        const mounted = await resolveDetailMailboxPane(app, pane, ['record', 'snapshot']);
         expect(mounted?.properties?.record?.agentId, 'the pane record follows the drill').toBe(expectedAgentId);
         expect(mounted?.properties?.snapshot ?? null, 'a fail-closed read assigns NOTHING — never a fabricated snapshot').toBe(null);
 
@@ -226,7 +261,7 @@ test.describe('AgentOS fleet cockpit — the AgentDetail Mailbox tab live (#1527
         const pane = detail.locator('.fm-mailbox-pane');
         await expect(pane).toBeVisible({timeout: 15000});
 
-        const [mounted] = await app.queryComponent({className: 'AgentOS.view.fleet.mailbox.Container'}, ['id']);
+        const mounted = await resolveDetailMailboxPane(app, pane, ['id']);
         expect(mounted?.properties?.id, 'the mailbox pane is mounted and addressable').toBeTruthy();
 
         // A FULL page. The subject lines are deliberately long: intrinsic WIDTH is what drove the


### PR DESCRIPTION
Resolves neomjs/neo#17625

Two rows of the neomjs/neo-agent-brain#17 census failed with `Received: undefined` and a row count of zero, and were classified — by me, and independently corroborated by @neo-gpt from the same failure text — as a real product defect. **They are not.** The possession hand-off works; the witness was holding the wrong object.

Related: neomjs/neo-agent-brain#17 · neomjs/neo#17598

Evidence: L3 (live drill on the real cockpit, component census read through Neural Link, mutation-verified both directions) → L3 required (the claim is about which mounted instance a running journey resolves). No residuals. ⚠️ The e2e layer does not gate in CI — neomjs/neo-agent-brain#17 owns that finding — so these receipts are local-run.

## AC Evidence

| Acceptance criterion | Evidence |
|---|---|
| AC-1 | `FleetMailboxTabNL:58` and `:237` pass on `dev`, resolving the AgentDetail tab's pane by **identity**: the DOM node inside `.fm-agent-detail`, whose element id is the component id (verified live — `neo-fm-mailbox-pane-2`). |
| AC-2 | **Load-bearing control, mutation-verified.** Reverting resolution to first-match reproduces the original failure on both rows (`Expected: "neo-opus-ada"`, row count `0`). The helper additionally fails naming *wanted vs available* ids rather than letting `undefined` surface three assertions downstream. |
| AC-3 | Resolution does not depend on `queryComponent` ordering — it matches an id obtained from the tab's own DOM subtree. |
| AC-4 | **No production change.** One spec file. |
| AC-5 | The corrected classification is posted on neomjs/neo-agent-brain#17 ([comment](https://github.com/neomjs/neo-agent-brain/issues/17#issuecomment-5387169609)) so the next reader does not re-inherit "real product defect". |

## Deltas from ticket

**The drift probe changed what I trusted before I wrote a line.** neomjs/neo-agent-brain#17's diagnosis predates two merges that touched this exact surface — neomjs/neo#17593 (the roster *animate and select* PR) and neomjs/neo#17594. Since the failing assertion is about a *selection* hand-off and a *selection* PR landed after the census, I re-measured rather than inherit. Both rows still failed, but one recorded detail had already gone stale: the expected agent had moved from `neo-gemini-pro` to `neo-opus-ada` while the failure *shape* held. That is why the single-seam reading survived and the recorded owner did not.

**I checked for a leak before concluding "spec defect".** `pane-1` (unmounted, parent `neo-fm-operator-mailbox-1`) and `pane-2` (mounted, holding the drilled record) — a leaked instance and two legitimate instances are different defects with opposite owners, and the error text cannot tell them apart. `pane-1` is the Operator Mailbox's own pane, legitimately mounted elsewhere; "fixing" it by destroying it would break that surface.

**Rejected the cheaper fix.** Filtering on `mounted === true` passes today only because the Operator pane happens to be unmounted during this journey. That is a coincidence the spec would then depend on, and it would silently re-break the day both surfaces are mounted. Identity states the intent.

## Test Evidence

- `agentos/FleetMailboxTabNL` — 2/2 green at this head.
- **Mutation both ways:** first-match → both rows red with the original signatures; identity → green.
- **Instance census, read live during the drill** (the measurement that inverted the diagnosis): `[{id: neo-fm-mailbox-pane-1, agentId: null, mounted: false, parentId: neo-fm-operator-mailbox-1}, {id: neo-fm-mailbox-pane-2, agentId: "neo-opus-ada", mounted: true}]`.
- **Full directory re-run** — `npm run test-e2e -- test/playwright/e2e/agentos --workers=1`: **43 passed, 0 failed** (no Playwright failure artifacts written). Stated carefully: this is **not** evidence that these two rows caused the census's 17 reds. neomjs/neo#17598/PR neomjs/neo#17599 and several other PRs merged between the census and now, and the test count itself differs from the census's 62 — the surface moved. What this run supports is that the directory is green at this head, not an attribution.

## Post-Merge Validation

None required — every acceptance property is asserted at this head.

Authored by Grace (Claude Opus 5, Claude Code). Session eb671e6e-ca17-4a53-8069-64fd5885ce84.
