### PR TITLE
refactor(examples): Demo A consumes the engine dock host (#17630)

### DIFF
--- a/examples/dashboard/choreography/DemoAWorkspace.mjs
+++ b/examples/dashboard/choreography/DemoAWorkspace.mjs
@@ -1,16 +1,12 @@
 import ClockPane                          from './ClockPane.mjs';
-import Component                          from '../../../src/component/Base.mjs';
 import Container                          from '../../../src/container/Base.mjs';
-import DockDropIndicators                 from '../../../src/dashboard/DockDropIndicators.mjs';
-import DockLayoutAdapter                  from '../../../src/dashboard/DockLayoutAdapter.mjs';
-import DockMotionSignal                   from '../../../src/dashboard/DockMotionSignal.mjs';
 import DockDragAffordances                from '../../../src/dashboard/DockDragAffordances.mjs';
+import DockDropIndicators                 from '../../../src/dashboard/DockDropIndicators.mjs';
 import DockPreview                        from '../../../src/dashboard/DockPreview.mjs';
-import DockProjectionReconciler           from '../../../src/dashboard/DockProjectionReconciler.mjs';
 import DockService                        from '../../../src/ai/client/DockService.mjs';
+import DockWorkspace                      from '../../../src/dashboard/DockWorkspace.mjs';
 import DockZoneModel                      from '../../../src/dashboard/DockZoneModel.mjs';
 import TourRunner                         from '../../../src/ai/client/TourRunner.mjs';
-import {previewToOperation}               from '../../../src/dashboard/dockPreviewContract.mjs';
 import {demoATourScript, initialDocument} from './demoADockChoreography.mjs';
 import '../../../src/button/Base.mjs';   // registers the `button` ntype the tour bar composes
 import '../../../src/tab/Container.mjs'; // registers the `tab-container` ntype the projection emits
@@ -20,17 +16,17 @@ import '../../../src/toolbar/Base.mjs';  // registers the `toolbar` ntype the to
  * @summary The Demo-A showcase workspace: the reducer-container that hosts the dock
  * choreography and plays its screenplay through the tour runner.
  *
- * This class is the normative workspace-ownership pattern (the reducer-container the docking
- * design record fixes as canonical): it owns the committed dock-zone document as the single
- * source of truth, `applyDockZoneOperation()` is the pure reducer, `getDockZoneDocument()`
- * is the read half of the dock-holder contract (Neural Link topology reads work before any
- * operation ran), and `onDockZoneDocumentChange()` is the view-sync that stores each
- * committed document and re-projects the layout from it.
+ * The normative workspace host is the engine class {@link Neo.dashboard.DockWorkspace}, which the
+ * docking design record fixes as canonical; this class is one of its CONSUMERS, not the pattern
+ * itself. Everything the holder contract requires — the committed dock-zone document as single
+ * source of truth, the pure reducer, the read half Neural Link topology calls before any operation
+ * ran, and the deferred view-sync that re-projects from each committed document — is inherited.
+ * What stays here is what the demo actually is: the screenplay, the tour bar, and the panes.
  *
- * Because the workspace implements the holder contract, it is drivable identically by all
- * three consumers of the trinity: the tour bar's play button (this class), an agent through
- * the Neural Link dock tools, and the whitebox replay specs — every one of them dispatches
- * semantic operation descriptors through the same commit path; there is no parallel
+ * Because the holder contract is satisfied by the base class, this workspace is drivable
+ * identically by all three consumers of the trinity: the tour bar's play button (this class), an
+ * agent through the Neural Link dock tools, and the whitebox replay specs — every one of them
+ * dispatches semantic operation descriptors through the same commit path; there is no parallel
  * mutation route.
  *
  * The tour bar composes real `button.Base` children riding the `handler` contract (zero
@@ -43,9 +39,9 @@ import '../../../src/toolbar/Base.mjs';  // registers the `toolbar` ntype the to
  * siblings. The `workspace` advisory block of the screenplay (hover-reveal opt-in) is threaded
  * into the projection options — inert until the rail interaction layer lands, correct afterwards.
  * @class Neo.examples.dashboard.choreography.DemoAWorkspace
- * @extends Neo.container.Base
+ * @extends Neo.dashboard.DockWorkspace
  */
-class DemoAWorkspace extends Container {
+class DemoAWorkspace extends DockWorkspace {
     static config = {
         /**
          * @member {String} className='Neo.examples.dashboard.choreography.DemoAWorkspace'
@@ -67,11 +63,26 @@ class DemoAWorkspace extends Container {
          */
         cls: ['agentos-dockdemo-workspace'],
         /**
+         * The projection mounts into the dock host, not into the workspace itself: the tour bar is
+         * a sibling ABOVE it, and the preview + indicator overlays are persistent siblings BESIDE
+         * it that must survive every re-projection.
+         * @member {String} dockHostReference='dock-host'
+         */
+        dockHostReference: 'dock-host',
+        /**
+         * The demo's own FLIP correlation prefix, kept from before the engine class owned the
+         * stamping. Item ids in this screenplay are the lower-cased component refs (`editor` for
+         * `Editor`), so the engine's itemId-keyed marker reproduces the class names the panes
+         * carried when {@link #resolvePane} stamped them by hand.
+         * @member {String} flipMarkerPrefix='agentos-dockdemo-pane-'
+         */
+        flipMarkerPrefix: 'agentos-dockdemo-pane-',
+        /**
          * @member {Object} layout={ntype:'vbox',align:'stretch'}
          */
         layout: {ntype: 'vbox', align: 'stretch'}
-        // `items` is built in construct() — each projection carries the instance-bound
-        // reducer + view-sync callbacks, so it cannot live in static config.
+        // `items` is built in construct() — the projection is instance-bound, so it cannot live
+        // in static config.
     }
 
     /**
@@ -79,13 +90,6 @@ class DemoAWorkspace extends Container {
      * @member {Number} beatCount=0
      */
     beatCount = 0
-
-    /**
-     * The live committed dock-zone document — the single source of truth the view projects.
-     * Mutated exclusively through {@link #applyDockZoneOperation} results.
-     * @member {Object|null} dockModel=null
-     */
-    dockModel = null
 
     /**
      * The app-side Neural Link dock seam this workspace registers against and the tour
@@ -101,18 +105,6 @@ class DemoAWorkspace extends Container {
      * @member {Neo.dashboard.DockDragAffordances|null} dragAffordances=null
      */
     dragAffordances = null
-
-    /**
-     * The in-flight deferred re-projection, tracked as an awaitable. Every committed
-     * operation defers its view-sync one tick ({@link #onDockZoneDocumentChange}); any
-     * consumer that must resolve PROJECTED components — the reveal cue path — awaits this
-     * promise instead of racing that deferral (an unawaited lookup runs within ~0ms of
-     * the commit, resolves `null`, and no-ops silently). Commits chain onto this promise
-     * with their document snapshot, so staged shell transactions never overlap.
-     * @member {Promise|null} refreshPromise=null
-     * @protected
-     */
-    refreshPromise = null
 
     /**
      * The tour runner playing the Demo-A screenplay against this workspace.
@@ -180,15 +172,14 @@ class DemoAWorkspace extends Container {
     }
 
     /**
-     * The pure reducer of the workspace-ownership pattern: applies one semantic operation
-     * descriptor against the live committed document and returns the executor's fail-closed
-     * `{document, errors}` result. View sync happens exclusively in
-     * {@link #onDockZoneDocumentChange}, which the dock seam calls on success.
-     * @param {Object} descriptor The semantic operation descriptor.
-     * @returns {{document: Object, errors: String[]}}
+     * A re-projection ends any drag-affordance session: rects go stale and the drop pipeline
+     * restarts its measurement lazily on the next gesture. The base class runs this AFTER the FLIP
+     * snapshot of the outgoing geometry, so clearing here can never alter the captured first rects.
+     * @param {Object} document The committed document this refresh projects.
+     * @param {Object} refreshOptions The options the scheduling commit produced.
      */
-    applyDockZoneOperation(descriptor) {
-        return DockZoneModel.applyOperation(this.dockModel, descriptor)
+    beforeRefreshDockWorkspace(document, refreshOptions) {
+        this.dragAffordances.clear()
     }
 
     /**
@@ -242,33 +233,21 @@ class DemoAWorkspace extends Container {
     }
 
     /**
-     * The read half of the dock-holder contract: exposes the live committed document, so
-     * Neural Link topology reads and the tour runner's asserts see truth before and after
-     * every operation.
-     * @returns {Object} The current committed dockZone.v1 document.
+     * The screenplay's `workspace` advisory block (the hover-reveal opt-in) plus the drag-affordance
+     * layer's gesture seams. The controller owns its own placement producer, so routing the drop
+     * seam here deliberately overrides the base class's built-in cross-zone drop path — the reducer
+     * and view-sync bindings stay class-owned and are not overridable from this hook.
+     * @returns {Object}
      */
-    getDockZoneDocument() {
-        return this.dockModel
-    }
-
-    /**
-     * The view-sync half: stores the committed document and re-projects the layout,
-     * deferred one tick so a committing interaction surface is never destroyed mid-handler
-     * (the normative guard from the reference workspace).
-     * @param {Object} document The committed dock-zone document.
-     */
-    onDockZoneDocumentChange(document) {
+    getDockProjectionOptions() {
         let me = this;
 
-        me.dockModel = document;
-
-        me.refreshPromise = (me.refreshPromise || Promise.resolve())
-            .then(() => me.timeout(0))
-            .then(() => {
-                if (!me.isDestroyed) {
-                    return me.refreshDockWorkspace(document)
-                }
-            })
+        return {
+            ...demoATourScript.workspace,
+            onDockCrossZoneDragCancel: data => me.dragAffordances.onDragCancel(data),
+            onDockCrossZoneDragMove  : data => me.dragAffordances.onDragMove(data),
+            onDockCrossZoneDrop      : data => me.dragAffordances.onDrop(data)
+        }
     }
 
     /**
@@ -325,115 +304,26 @@ class DemoAWorkspace extends Container {
     }
 
     /**
-     * Projects the committed document into the live container config, carrying the
-     * instance-bound reducer + view-sync callbacks and the screenplay's workspace advisory
-     * (the hover-reveal opt-in) as projection options.
-     * @param {Function|null} [resolveComponentRef=null] Optional item resolver for staged projections.
-     * @param {Object} [document=this.dockModel] Committed document snapshot to project.
+     * Resolves a catalog item to its rendered pane. The editor carries the ticking-clock witness
+     * (the demo's continuity proof); the other panes stay labeled placeholders with the stable cls
+     * hook the SCSS skin targets.
+     *
+     * Keyed on the item id rather than the component ref: the id is the stable workspace identity
+     * the committed document and the FLIP correlation both use, and it is what the base class hands
+     * every resolver. The per-item marker class is stamped by {@link #flipMarkerPrefix}, never here.
+     * @param {String} itemId The stable workspace identity from the item catalog.
+     * @param {Object} item The persisted item record.
      * @returns {Object}
      */
-    projectDockModel(resolveComponentRef=null, document=this.dockModel) {
-        let me = this;
+    resolvePane(itemId, item) {
+        const componentRef = item?.componentRef ?? itemId;
 
-        return DockLayoutAdapter.project(document, {
-            ...demoATourScript.workspace,
-            applyDockZoneOperation   : me.applyDockZoneOperation.bind(me),
-            onDockCrossZoneDragCancel: data => me.dragAffordances.onDragCancel(data),
-            onDockCrossZoneDragMove  : data => me.dragAffordances.onDragMove(data),
-            onDockCrossZoneDrop      : data => me.dragAffordances.onDrop(data),
-            onDockZoneDocumentChange : me.onDockZoneDocumentChange.bind(me),
-            resolveComponentRef      : resolveComponentRef
-                || (componentRef => me.resolvePane(componentRef)),
-            resolveRevealComponentRef    : componentRef => me.resolvePane(componentRef)
-        })
-    }
-
-    /**
-     * Re-projection from the committed document, scoped to the dock-host subtree. The shared
-     * reconciler stages shell index 0 and transfers surviving tab chrome/panes before cleanup;
-     * the tour bar stays outside the host while preview/indicator overlays remain its persistent
-     * siblings. Drag-affordance geometry is still invalidated before structural ownership moves.
-     * @param {Object} [document=this.dockModel] Committed document snapshot owned by this refresh.
-     * @protected
-     */
-    async refreshDockWorkspace(document=this.dockModel) {
-        const
-            me           = this,
-            host         = me.getReference('dock-host'),
-            placeholders = new Map();
-
-        if (host) {
-            const flip = Neo.main?.addon?.DockFlip;
-
-            // A re-projection ends any drag affordance session: rects go stale and the drop
-            // pipeline restarts its measurement lazily on the next gesture.
-            me.dragAffordances.clear();
-
-            // FLIP phase 1: snapshot the outgoing geometry (presentation-only — any failure
-            // lands the new layout instantly, so the try/catch guards motion, never truth)
-            try {
-                await flip?.captureFirst({hostId: host.id, markerPrefix: 'agentos-dockdemo-pane-'})
-            } catch (e) {/* instant landing */}
-
-            const nextConfig = me.projectDockModel((componentRef, item, itemId) => {
-                const placeholder = Neo.create({
-                    module: Component,
-                    header: {text: item?.title ?? componentRef ?? itemId},
-                    hidden: true
-                });
-
-                placeholders.set(itemId, placeholder);
-
-                return placeholder
-            }, document);
-
-            await DockProjectionReconciler.reconcileProjection({
-                host,
-                nextConfig,
-                placeholders,
-                resolveItem: itemId => {
-                    const item = document.items[itemId];
-
-                    return DockLayoutAdapter.decorateProjectedItem(
-                        me.resolvePane(item?.componentRef ?? itemId),
-                        itemId,
-                        item
-                    )
-                }
-            });
-
-            // FLIP phase 2: fire-and-forget — the addon self-waits for the new tree to paint,
-            // inverts the survivors onto their old geometry and releases the transition
-            // the counted motion signal brackets the awaited animation window — ownership
-            // lives in DockMotionSignal (fail-safe backstopped), never in the addon
-            // Guard on the CAPABILITY, not on truthiness. `Neo.main.addon.DockFlip` holds the
-            // registered CLASS until an instance replaces it, and a class is truthy with no
-            // `play` — so `if (flip)` admits it and the call below throws. This matches the
-            // optional-chained `flip?.captureFirst` two calls up, which never had the problem.
-            if (flip?.play) {
-                DockMotionSignal.enter(me);
-                flip.play({hostId: host.id, markerPrefix: 'agentos-dockdemo-pane-'})
-                    .catch(() => {})
-                    .finally(() => DockMotionSignal.leave(me))
-            }
-        }
-    }
-
-    /**
-     * Resolves a model `componentRef` to its rendered pane. The editor carries the
-     * ticking-clock witness (the demo's continuity proof); the other panes stay labeled
-     * placeholders with stable cls hooks the SCSS skin targets.
-     * @param {String} componentRef
-     * @returns {Object}
-     */
-    resolvePane(componentRef) {
         if (componentRef === 'Editor') {
-            // the flip marker rides the cls config so newly materialized panes join FLIP correlation
-            return {cls: ['agentos-dockdemo-clock-pane', 'agentos-dockdemo-pane-editor'], module: ClockPane}
+            return {cls: ['agentos-dockdemo-clock-pane'], module: ClockPane}
         }
 
         return {
-            cls  : ['agentos-dockdemo-pane', `agentos-dockdemo-pane-${componentRef.toLowerCase()}`],
+            cls  : ['agentos-dockdemo-pane'],
             html : componentRef,
             ntype: 'component',
             style: {alignItems: 'center', display: 'flex', fontSize: '18px', justifyContent: 'center'}

--- a/examples/dashboard/crossWindow/DemoBWorkspace.mjs
+++ b/examples/dashboard/crossWindow/DemoBWorkspace.mjs
@@ -29,9 +29,19 @@ import '../../../src/toolbar/Base.mjs';  // registers the `toolbar` ntype the ba
  * @summary The Demo-B showcase workspace: named perspectives that MORPH, and a pane that
  * leaves for its own OS window and returns with its state unbroken — the only-Neo story.
  *
- * Same reducer-container ownership pattern as Demo A (committed `dockZone.v1` document as
+ * **This class hand-rolls a workspace host that the engine now owns, and is not the shape to
+ * copy.** {@link Neo.dashboard.DockWorkspace} is the normative host — it owns the committed
+ * document, the reducer, the read half of the holder contract, the deferred view-sync and the
+ * projection/FLIP loop — and the docking design record fixes it as canonical. Demo A already
+ * consumes it; this workspace has not migrated yet because its cross-window tear-out half is
+ * coupled to engine work still in flight. Anything starting a new dock host takes the base class.
+ * Be aware when reading below that its member signatures differ from the engine's: the base class
+ * hands resolvers `(itemId, item)` and passes a tab-insert descriptor as the first argument to the
+ * projection and refresh members, so these bodies are not drop-in overrides.
+ *
+ * The reducer-container ownership it implements by hand (committed `dockZone.v1` document as
  * the single source of truth; the pure reducer + view-sync halves of the dock-holder
- * contract), plus the two capabilities this demo exists to show:
+ * contract) carries the two capabilities this demo exists to show:
  *
  * - **Perspectives** ride a {@link Neo.dashboard.DockPerspectiveStore}: ordinary views are
  *   window-scoped; the detached view captures BOTH worker-owned workspace documents through

--- a/test/playwright/unit/examples/dashboard/choreography/DemoAWorkspace.spec.mjs
+++ b/test/playwright/unit/examples/dashboard/choreography/DemoAWorkspace.spec.mjs
@@ -11,6 +11,7 @@ import Neo            from '../../../../../../src/Neo.mjs';
 import * as core      from '../../../../../../src/core/_export.mjs';
 import '../../../../../../src/manager/Instance.mjs'; // defines Neo.get — the container child-add path resolves parents through it
 import Button                   from '../../../../../../src/button/Base.mjs';
+import ClockPane                from '../../../../../../examples/dashboard/choreography/ClockPane.mjs';
 import DemoAWorkspace           from '../../../../../../examples/dashboard/choreography/DemoAWorkspace.mjs';
 import DockProjectionReconciler from '../../../../../../src/dashboard/DockProjectionReconciler.mjs';
 
@@ -58,6 +59,44 @@ test.describe.serial('Neo.examples.dashboard.choreography.DemoAWorkspace', () =>
 
         expect(result.applied).toBe(true);
         expect(workspace.getDockZoneDocument().items.preview.autoHidden).toBe(true)
+    });
+
+    /**
+     * The engine base class hands every resolver `(itemId, item)`; this workspace once took a bare
+     * `componentRef`. Both spellings are one-argument-compatible at the call site, so a host that
+     * kept the old signature after adopting the base class reads an ITEM ID as a COMPONENT REF and
+     * nothing throws — the panes simply resolve to the wrong thing.
+     *
+     * These arms discriminate because the two values differ in this screenplay: item ids are the
+     * lower-cased refs (`editor` for `Editor`). Under the old signature the editor comparison fails
+     * against the id and the clock witness silently degrades to a generic pane, which is why the
+     * assertion is on the resolved MODULE rather than on the call succeeding.
+     */
+    test('panes resolve from the item record, not from the id read as a component ref', () => {
+        const
+            editorItem = {componentRef: 'Editor', title: 'Editor', kind: 'panel'},
+            logsItem   = {componentRef: 'Logs',   title: 'Logs',   kind: 'panel'};
+
+        // The witness pane: keyed off `item.componentRef`, never off the id it is filed under.
+        expect(workspace.resolvePane('editor', editorItem).module, 'the editor must resolve to the clock witness')
+            .toBe(ClockPane);
+
+        // The negative half — an id whose ref is absent must NOT masquerade as the editor.
+        expect(workspace.resolvePane('editor', {componentRef: 'Logs'}).module, 'resolution follows the ref, not the id')
+            .toBeUndefined();
+
+        // Plain panes render the ref's own casing; reading arg0 would render the lower-cased id.
+        expect(workspace.resolvePane('logs', logsItem).html).toBe('Logs')
+    });
+
+    test('the FLIP marker is stamped by the engine, keyed on the item id', () => {
+        // `resolveProjectedPane` is the resolution the projection actually consumes. The marker is
+        // the demo's own prefix, so the pane classes survive the migration byte-identical — and it
+        // is now derived from the stable identity rather than hand-written per pane.
+        const projected = workspace.resolveProjectedPane('editor', {componentRef: 'Editor'});
+
+        expect(projected.cls).toContain('agentos-dockdemo-pane-editor');
+        expect(projected.cls).toContain('agentos-dockdemo-clock-pane')
     });
 
     test('reconciliation preserves overlays and surviving chrome while a dissolved tabs node retires once', async () => {


### PR DESCRIPTION
Resolves neomjs/neo#17630

Demo A now extends `Neo.dashboard.DockWorkspace`, and Demo B carries the interval marker neomjs/neo#17539 claims it already has. First of O-4's two leaves; Demo B's own migration stays unclaimed.

The docking design record's normative host became the engine class when ADR 0029 §2.1 was amended (`#17541`). Demo A still hand-rolled the pattern *and its docblock still claimed to be it* — so the largest showcase example told its next reader that an `extends Container` host is the canonical shape to copy. That is the copy-minting the epic's marker existed to prevent, asserted rather than merely unmarked.

**This was not a bare parent swap, and the epic's "names survive through inheritance" framing understates it.** Measured on `dev`, three of the four shared members collide on the *first positional argument*:

| Member | Demo A had | Engine has | Engine calls it |
|---|---|---|---|
| `resolvePane` | `(componentRef)` | `(itemId, item)` | `DockWorkspace.mjs:649`, `:660` |
| `refreshDockWorkspace` | `(document)` | `(tabInsertDescriptor, document, refreshOptions)` | `:464` |
| `projectDockModel` | `(resolveComponentRef, document)` | `(tabInsertDescriptor, itemResolver, document)` | `:556` |

Every collision is silent. A surviving override reads an item id as a component ref, the `=== 'Editor'` comparison fails, and the clock witness degrades to a generic pane with nothing thrown. So the five engine-owned members are **deleted rather than overridden** — `applyDockZoneOperation`, `getDockZoneDocument`, `onDockZoneDocumentChange`, `projectDockModel`, `refreshDockWorkspace` — along with the redeclared `dockModel` / `refreshPromise` fields. The drag-affordance seams and hover-reveal advisory move to `getDockProjectionOptions`; the pre-refresh session clear moves to `beforeRefreshDockWorkspace`, which the base class runs *after* the FLIP snapshot so it cannot alter the captured rects. `examples/dashboard/dock/MainContainer.mjs` is the precedent followed.

Evidence: L3 achieved (unit contract + real-browser tour journey, both run at this head) → L3 required (AC-1..AC-6 are covered by unit assertions and the e2e tour). Residual: none. Caveat, not a residual — **CI runs only the component and integration configs, so the e2e half of this evidence does not gate**; that standing gap is neomjs/neo-agent-brain#17's subject, not this PR's.

## AC Evidence

| AC-1 | `class DemoAWorkspace extends DockWorkspace` (`:44`); the five members carry no local override — the full method list is `construct`, `beforeRefreshDockWorkspace`, `createTourBar`, `totalBeats`, `getDockProjectionOptions`, the four tour handlers, `resolvePane`, `setPipProgress`, `setTourCaption`, `startTour`, `destroy`. The three pre-existing specs that exercise the holder contract (`getDockZoneDocument`, `applyDockZoneOperation`, the seam commit loop) pass **through inheritance, unmodified** — which is the AC's real proof. |
| AC-2 | `resolvePane(itemId, item)` (`:318`) reads `item?.componentRef ?? itemId`; the pre-refresh clear is `beforeRefreshDockWorkspace` (`:181`). **Two controls, both verified red-capable** — see Test Evidence. The non-vacuity requirement in the AC is met: reverting the signature fails the arm on its own message rather than passing a name-only stub. |
| AC-3 | `e2e/dashboard/DemoATourNL` passes: `{"flipSamples":14,"maxRailTabs":5,"revealSeen":true,"maxOverlays":2,"done":true}` — the full three-scene screenplay, real edge rails, executable reveal cue and FLIP correlation all surviving the base-class swap. Whole directory: 42 passed / 1 failed, the failure proven pre-existing (Test Evidence). |
| AC-4 | The `:23` claim is replaced: the docblock now names `Neo.dashboard.DockWorkspace` as normative and this class as one of its **consumers**, listing what is inherited and what remains demo-owned. |
| AC-5 | `DemoBWorkspace.mjs` docblock now opens with the marker — the base class named as the shape to copy, why this host has not migrated (cross-window tear-out coupling), and a warning that its own member signatures are **not drop-in overrides**. Named by class, not by ticket, because `check-ticket-archaeology` forbids tracking refs in durable comments — and the class name is the more useful pointer anyway. |
| AC-6 | **Zero SCSS files in the diff** — the three changed files are two `.mjs` hosts and one spec. No `--dock-*` default moved anywhere; `.neo-dashboard` remains the default carrier and the new `neo-dock-workspace` baseCls is an override anchor only, per neomjs/neo#17539's theme ruling. |

## Deltas from ticket

- **A dead import removed beyond the ticket's Fix list:** `previewToOperation` was imported by Demo A and never used. One line, in a file being rewritten.
- **The Demo B marker names the successor class rather than the epic.** The ticket said "pointing at this epic"; durable comments cannot carry tracking refs (`check-ticket-archaeology`), and a reader needs the class name to act on it.
- **`flipMarkerPrefix` config added**, not in the ticket's member list. Demo A hand-stamped `agentos-dockdemo-pane-<ref>` per pane; the engine stamps from this config keyed on item id. Output is **byte-identical** because item ids in this screenplay are the lower-cased component refs (`editor` ← `Editor`) — verified, not assumed: the mutation run printed the produced class list.

## Test Evidence

**Unit — 627 passed / 0 failed** across `unit/dashboard` + `unit/examples/dashboard` at this head (the whole dock surface, including all of Demo B, whose behavior is untouched).

**Mutation, both directions, each red for its own reason:**

- Reverting `resolvePane` to `(componentRef)` → `Error: the editor must resolve to the clock witness / Received: undefined` — the assertion's own message, and exactly the silent degradation described above.
- Mutating `flipMarkerPrefix` → `Expected value: "agentos-dockdemo-pane-editor" / Received array: ["agentos-dockdemo-clock-pane", "MUTATED-marker-editor"]`. This run is also what proves the byte-identical claim: with the real prefix the array is `["agentos-dockdemo-clock-pane", "agentos-dockdemo-pane-editor"]`, exactly what the hand-stamped code produced.

The marker arm had to be mutated separately — `describe.serial` skips everything after the first failure, so the first mutation left it unproven, and an unproven control is not a control.

**e2e — `e2e/dashboard`: 42 passed / 1 failed.** The failure is `PreviewLanguageDragPairNL.spec.mjs:135`, a `toHaveScreenshot` arm (688 pixels, ratio 0.01). **It renders `/examples/dashboard/choreography/index.html` — Demo A, the file this PR changes — so it could not be waved off.** I reverted all three files to `origin/dev` in place and re-ran: identical failure, same snapshot, same 688px / 0.01 ratio, then restored and re-verified. Pre-existing on `dev`, not caused here; captured as a defect-note. Its sibling arm at `:233` passes.

## Post-Merge Validation

None. All six ACs are verified at this head and nothing is deferred — there is no residual and no post-merge step to run.

One standing caveat that is *not* an obligation of this PR: the e2e half of the evidence above does not gate in CI, because no workflow runs `playwright.config.e2e.mjs`. That gap predates this change, applies to every e2e spec in the tree, and is neomjs/neo-agent-brain#17's subject. It is recorded here so the `Evidence:` line is not read as implying CI coverage it does not have.

Authored by Grace (Claude Opus 5, Claude Code). Origin Session ID: eb671e6e-ca17-4a53-8069-64fd5885ce84
