### PR TITLE
fix(dashboard): preserve reveal focus on inside clicks (#17317)

### DIFF
--- a/src/dashboard/DockRevealOverlay.mjs
+++ b/src/dashboard/DockRevealOverlay.mjs
@@ -99,7 +99,16 @@ class DockRevealOverlay extends Container {
          * @member {Object|null} revealedItem_=null
          * @reactive
          */
-        revealedItem_: null
+        revealedItem_: null,
+        /**
+         * Programmatic focus carrier for pointer interactions on non-focusable pane content. It
+         * stays outside sequential keyboard navigation while preserving the overlay subtree as the
+         * focus-containment authority.
+         * @member {Object} _vdom={tabIndex:-1}
+         * @protected
+         */
+        _vdom:
+        {tabIndex: -1}
     }
 
     /**
@@ -161,6 +170,9 @@ class DockRevealOverlay extends Container {
         super.construct(config);
 
         me.addDomListeners([
+            // `mousedown` is a GLOBAL DomEvents surface: unlike a local `pointerdown` listener, it
+            // does not preventDefault(), so native text selection inside the hosted pane survives.
+            {mousedown : me.onMouseDown,    scope: me},
             {keydown   : me.onKeyDown,      scope: me},
             {mouseenter: me.onPointerEnter, scope: me},
             {mouseleave: me.onPointerLeave, scope: me},
@@ -343,6 +355,19 @@ class DockRevealOverlay extends Container {
     }
 
     /**
+     * Keeps an inside pointer interaction inside the existing focus-hold contract even when its
+     * target (prose, whitespace, a plain container) cannot receive focus. The root is tabindex -1,
+     * so this programmatic pointer focus creates no sequential tab stop; `preventScroll` preserves
+     * the reading position. This handler rides the global mousedown path, which leaves native text
+     * selection untouched.
+     * @param {Object} data
+     * @protected
+     */
+    onMouseDown(data) {
+        this.focus(this.id, false, true, 'pointer')
+    }
+
+    /**
      * `manager.Focus` containment hook: fires only when focus genuinely ENTERS this component's
      * subtree — internal focus movement never re-triggers it, which is exactly the containment
      * guard the dismiss contract needs.
@@ -356,9 +381,9 @@ class DockRevealOverlay extends Container {
 
     /**
      * `manager.Focus` containment hook: fires only when focus genuinely LEAVES the subtree —
-     * moving focus between the pin control and the hosted pane stays silent. Clicking anywhere
-     * outside a focused overlay moves focus out, so outside-click dismissal of a focused reveal
-     * is embodied here.
+     * moving focus between the programmatically focusable root, pin control, and hosted pane stays
+     * silent. Inside mousedown refocuses the root before the focus manager's leave window settles;
+     * outside click and keyboard tab-out do not, so their genuine subtree leave still dismisses.
      * @param {Object} data
      * @protected
      */

--- a/test/playwright/e2e/dashboard/DockAutoHideRevealNL.spec.mjs
+++ b/test/playwright/e2e/dashboard/DockAutoHideRevealNL.spec.mjs
@@ -235,16 +235,18 @@ test.describe('Dock auto-hide reveal/pin journey (Neural Link)', () => {
             message: 'double-clicking the non-focusable prose must produce a native selection'
         }).toContain('Inspector');
         await expect(overlay, 'selecting prose inside must not dismiss the reveal').toBeVisible();
+        await expect.poll(() => overlay.evaluate(element => document.activeElement === element), {
+            message: 'the prose mousedown must leave the programmatic root focused'
+        }).toBe(true);
 
-        // The root is programmatic-only: the first Tab reaches the one sequential control inside;
-        // the next leaves the subtree and preserves the existing focus-leave dismissal contract.
-        await page.keyboard.press('Tab');
-        await expect(overlay, 'Tab into the pin control stays inside the reveal').toBeVisible();
-        expect(await page.evaluate(() =>
-            document.activeElement?.closest('.neo-dashboard-dock-reveal-overlay') !== null
-        ), 'the pin control is still inside the overlay subtree').toBe(true);
-        await page.keyboard.press('Tab');
-        await expect(overlay, 'Tab leaving the subtree must still dismiss').toBeHidden();
+        // The root is programmatic-only. Backward sequential navigation has no earlier focusable
+        // descendant to traverse, so Shift+Tab leaves the subtree in one deterministic keyboard
+        // step without hardcoding how many controls a hosted pane may contribute.
+        await page.keyboard.press('Shift+Tab');
+        await expect.poll(() => page.evaluate(() =>
+            document.activeElement?.closest('.neo-dashboard-dock-reveal-overlay') === null
+        ), {message: 'Shift+Tab must move browser focus outside the overlay subtree'}).toBe(true);
+        await expect(overlay, 'keyboard focus leaving the subtree must still dismiss').toBeHidden();
 
         // Independent controls: outside pointer and Escape remain distinct dismissal inputs.
         await railTab.click();

--- a/test/playwright/e2e/dashboard/DockAutoHideRevealNL.spec.mjs
+++ b/test/playwright/e2e/dashboard/DockAutoHideRevealNL.spec.mjs
@@ -201,6 +201,63 @@ test.describe('Dock auto-hide reveal/pin journey (Neural Link)', () => {
             'no overlay instance may survive the post-pin re-projection').toEqual([]);
     });
 
+    test('inside prose keeps focus-contained reveal open while native text selection survives', async ({ page, neuralLink }) => {
+        const { app, holderId } = await bootDockExample({ page, neuralLink });
+
+        await tuckInspector({ app, holderId, page });
+
+        const
+            railTab  = page.locator('.neo-dashboard-dock-rail-tab', {hasText: 'Inspector'}).first(),
+            strategy = page.locator('.neo-tab-header-button', {hasText: 'Strategy'}).first();
+
+        await expect(railTab).toBeVisible({timeout: 10000});
+        await railTab.click();
+
+        const
+            overlay  = page.locator('.neo-dashboard-dock-reveal-overlay').first(),
+            paneSlot = overlay.locator('.neo-dashboard-dock-reveal-pane-slot'),
+            prose    = paneSlot.getByText('Inspector', {exact: true}).last();
+
+        await expect(overlay).toBeVisible({timeout: 10000});
+        await expect(prose, 'the prose-bearing non-focusable pane must be rendered').toBeVisible();
+
+        // Honest reading interaction #1: whitespace in the pane slot keeps the focused reveal.
+        await paneSlot.click({position: {x: 12, y: 12}});
+        await expect(overlay, 'inside whitespace must not dismiss the reveal').toBeVisible();
+        await expect.poll(() => overlay.evaluate(element => document.activeElement === element), {
+            message: 'inside mousedown must refocus the tabindex=-1 overlay root'
+        }).toBe(true);
+
+        // Honest reading interaction #2: selection remains browser-native. A local listener would
+        // preventDefault on mousedown and make this arm red even if the overlay stayed painted.
+        await prose.dblclick();
+        await expect.poll(() => page.evaluate(() => document.getSelection()?.toString().trim() || ''), {
+            message: 'double-clicking the non-focusable prose must produce a native selection'
+        }).toContain('Inspector');
+        await expect(overlay, 'selecting prose inside must not dismiss the reveal').toBeVisible();
+
+        // The root is programmatic-only: the first Tab reaches the one sequential control inside;
+        // the next leaves the subtree and preserves the existing focus-leave dismissal contract.
+        await page.keyboard.press('Tab');
+        await expect(overlay, 'Tab into the pin control stays inside the reveal').toBeVisible();
+        expect(await page.evaluate(() =>
+            document.activeElement?.closest('.neo-dashboard-dock-reveal-overlay') !== null
+        ), 'the pin control is still inside the overlay subtree').toBe(true);
+        await page.keyboard.press('Tab');
+        await expect(overlay, 'Tab leaving the subtree must still dismiss').toBeHidden();
+
+        // Independent controls: outside pointer and Escape remain distinct dismissal inputs.
+        await railTab.click();
+        await expect(overlay).toBeVisible();
+        await strategy.click();
+        await expect(overlay, 'outside click must still dismiss').toBeHidden();
+
+        await railTab.click();
+        await expect(overlay).toBeVisible();
+        await page.keyboard.press('Escape');
+        await expect(overlay, 'Escape must still dismiss').toBeHidden()
+    });
+
     // Regression guard: a wholesale workspace refresh (removeAll + add) must remove the retired
     // affordance's DOM, not just its worker instances — a destroyed component's lingering
     // in-flight update entry once wedged the ancestor's yielded refresh forever, orphaning the

--- a/test/playwright/unit/dashboard/DockRevealOverlay.spec.mjs
+++ b/test/playwright/unit/dashboard/DockRevealOverlay.spec.mjs
@@ -159,6 +159,26 @@ test.describe('Neo.dashboard.DockRevealOverlay', () => {
         ]);
     });
 
+    test('inside mousedown focuses the programmatic root through the global listener', () => {
+        const focused = [];
+
+        overlay = Neo.create(DockRevealOverlay, {
+            edge        : 'right',
+            id          : 'dock-reveal-inside-focus',
+            revealState : 'revealed-focused',
+            revealedItem: createItem()
+        });
+
+        overlay.focus = (...args) => focused.push(args);
+
+        expect(overlay.vdom.tabIndex).toBe(-1);
+        expect(overlay.domListeners.some(listener => typeof listener.mousedown === 'function')).toBe(true);
+
+        overlay.onMouseDown({});
+
+        expect(focused).toEqual([[overlay.id, false, true, 'pointer']])
+    });
+
     test('the reveal-slide routes the motion signal: enter on hidden→visible, filtered leave on animationend', () => {
         overlay = Neo.create(DockRevealOverlay, {
             edge: 'left',


### PR DESCRIPTION
Resolves #17317

Keeps click-born Dock reveals open when the user interacts with non-focusable pane content. The overlay root becomes programmatically focusable but stays outside sequential navigation; its global `mousedown` listener refocuses the root without preventing native text selection. Genuine outside focus and keyboard tab-out still dismiss through the existing focus-leave authority.

Evidence: L3 (cross-seat exact-head whitebox 11/11 at `dbb4d8dc20142fcbce2216c212a9123ae89912d4`, corroborating a deterministic root-focus → `Shift+Tab`-out mechanism) + L2 (558 dashboard units) → L3 required (AC1–AC3 real pointer, focus, selection, and dismissal effects). The author host ceiling is declared below; no residuals.

## AC Evidence

| AC-1 | CI-covered unit arm pins the `tabIndex:-1` root plus global `mousedown` focus call; exact-head L3 clicks whitespace, double-click-selects Inspector prose, asserts native selection, and keeps the reveal open. |
| AC-2 | CI-covered reveal-machine/rail/overlay suites keep focus-leave, Escape, pointer, and Pin semantics; exact-head L3 proves deterministic keyboard focus-out, outside click, and Escape still dismiss. |
| AC-3 | Canonical unit coverage extends `DockRevealOverlay.spec.mjs`; canonical whitebox coverage extends the existing prose-bearing auto-hide journey rather than creating a parallel harness. |
| AC-4 | `onFocusLeave` JSDoc now names programmatic-root containment, inside mousedown rescue, and genuine outside/tab-out dismissal. |

## Deltas from ticket

- Selected the focus-containment direction, but deliberately used Neo's existing global `mousedown` path rather than a local `pointerdown`: local cancelable listeners call `preventDefault()` on the main thread and would make the text-selection AC impossible.
- Used the standalone Dock example's non-focusable Inspector pane as the prose-bearing fixture; the engine contract remains consumer-neutral.

## Test Evidence

- Red-first unit: before the implementation, the new arm failed with `tabIndex` expected `-1`, received `undefined`; after the repair the reveal subsystem bundle passed 39/39 and the rebased full dashboard unit surface passed 558/558.
- Browser command: `WATCHPACK_POLLING=true NEO_E2E_PORT=<free> NEO_E2E_RUN_ID=17317-inside-prose-exact-head npx playwright test test/playwright/e2e/dashboard/DockAutoHideRevealNL.spec.mjs -c test/playwright/playwright.config.e2e.mjs --workers=1 --grep "inside prose"`.
- Author attempt: Chrome exited `SIGABRT` before browser creation while the harness reported 0 GB available RAM; no product assertion executed, so this is an environment bound, not a test result.
- Cross-seat discovery at `4e1ea09c6e`: 10/11 runs passed; one real red hit the second-Tab assertion and exposed that the witness over-specified a fixed internal focusable count a hosted pane does not owe.
- Exact-head L3 at `dbb4d8dc20142fcbce2216c212a9123ae89912d4`: 11/11 green after the witness changed to root-focus poll → one `Shift+Tab` out. The mechanism removes the varying count; the runs corroborate rather than statistically prove it.

## Post-Merge Validation

- [x] None. Every runtime AC has exact-head L3 evidence; no post-merge work remains.

## Commits

- `e485e490f8` — programmatic focus root, global mousedown containment, unit + whitebox coverage.
- `dbb4d8dc20` — make the keyboard-leave control test the focus boundary instead of a fixed child count.

Authored by Emmy (GPT-5.6 Sol Ultra, Codex). Session 01a02ed8-9cf8-74c3-bfa5-9cc57bc10166.
