### PR TITLE
refactor(dashboard): the edge rail paints from engine tokens (#17633)

### DIFF
--- a/resources/scss/src/apps/workstation/Workspace.scss
+++ b/resources/scss/src/apps/workstation/Workspace.scss
@@ -56,12 +56,17 @@
         min-width : 0;
     }
 
+    /* Values only. The rail's structural paint moved to `src/dashboard/Container.scss`, where the
+       engine declares it against these tokens — this block used to be the only place in the tree
+       that answered "what does a dock rail look like", so a second consumer could reach that answer
+       only by copying it. `overflow` rides along because it is what clips the tabs to the 7px
+       corners: it belongs to the radius decision made here, not to every rail. */
     .neo-dashboard-dock-edge-rail {
-        background: color-mix(in srgb, var(--workstation-signal) 18%, var(--workstation-rail));
-        border    : 1px solid color-mix(in srgb, var(--workstation-signal) 52%, var(--workstation-line));
-        border-radius : 7px;
-        box-shadow    : 0 0 22px color-mix(in srgb, var(--workstation-signal) 12%, transparent);
-        overflow      : hidden;
+        --dock-edge-rail-background: color-mix(in srgb, var(--workstation-signal) 18%, var(--workstation-rail));
+        --dock-edge-rail-border    : 1px solid color-mix(in srgb, var(--workstation-signal) 52%, var(--workstation-line));
+        --dock-edge-rail-radius    : 7px;
+        --dock-edge-rail-shadow    : 0 0 22px color-mix(in srgb, var(--workstation-signal) 12%, transparent);
+        --dock-edge-rail-overflow  : hidden;
 
         // The stock theme floors every `.neo-button` at `min-width: var(--cmp-button-height)` (48px)
         // through `:root .neo-theme-* .neo-button` — a (0,3,0) selector that TIES the shared rail

--- a/resources/scss/src/dashboard/Container.scss
+++ b/resources/scss/src/dashboard/Container.scss
@@ -96,6 +96,31 @@
     // strip, rendering as cramped rotated text). What the strip should measure is a per-consumer
     // decision, which is exactly why it is a value and not a constant.
     --dock-edge-rail-size           : 14px;
+
+    // ── Edge-rail paint ──────────────────────────────────────────────────────────────────
+    // Identity slots, empty by default — the same class of token as `--dock-splitter-ring`
+    // above, and for the same reason: an app fills them, the engine never does. The strip is
+    // not the affordance here. Its TABS are, and they already carry an engine-owed visible
+    // active state; a rail whose surface is transparent still reads as navigation because the
+    // tabs on it do. So unlike the splitter floor, discoverability does not oblige a default.
+    //
+    // What this buys is the layer, not a new look: the whole rail identity used to exist once,
+    // as four declarations inside `apps/workstation/Workspace.scss`, so a second consumer could
+    // only reproduce it by copying CSS out of another app. Every shipped consumer renders
+    // byte-identically after this — the workstation because it now sets these values, everyone
+    // else because bare was already what they resolved.
+    --dock-edge-rail-background     : transparent;
+    --dock-edge-rail-border         : 0;
+    --dock-edge-rail-radius         : 0;
+    --dock-edge-rail-shadow         : none;
+
+    // Clipping is coupled to the RADIUS, not to the labels: a rounded strip needs its children
+    // clipped to the corners, and a square one does not. That coupling is why this is a value
+    // rather than a structural declaration — a consumer that rounds the rail sets `hidden` in
+    // the same block where it sets the radius, and one that does not is left exactly as it renders
+    // today. Defaulting to `hidden` would have been a silent rendering change for every square
+    // rail, which is a redesign wearing a promotion's clothes.
+    --dock-edge-rail-overflow       : visible;
 }
 
 @media (prefers-reduced-motion: reduce) {
@@ -298,12 +323,20 @@
     }
 }
 
-// Demo-consumable minimal hooks only — the real visual language lands with the F-tranche.
 // Flow direction comes from the rail's layout (vbox/vertical, hbox/horizontal edges); the
-// buttons bring their own base theming — these hooks only shape the strip.
+// buttons bring their own base theming — these rules shape and paint the strip.
 .neo-dashboard-dock-edge-rail {
     flex-shrink: 0;
     gap        : 2px;
+
+    // Every value reads a token, so a consumer skins by overriding and never by re-declaring.
+    // Re-declaring is what put an app rule in an equal-specificity tie with the engine's on the
+    // rail tab (see the note above the tab block) — the same trap one element out.
+    background   : var(--dock-edge-rail-background);
+    border       : var(--dock-edge-rail-border);
+    border-radius: var(--dock-edge-rail-radius);
+    box-shadow   : var(--dock-edge-rail-shadow);
+    overflow     : var(--dock-edge-rail-overflow);
 
     &-left,
     &-right {

--- a/test/playwright/e2e/dashboard/DockEdgeRailPaintNL.spec.mjs
+++ b/test/playwright/e2e/dashboard/DockEdgeRailPaintNL.spec.mjs
@@ -1,0 +1,112 @@
+import {test, expect} from '../../fixtures.mjs';
+
+/**
+ * Whitebox-e2e: the dock edge rail's paint is engine capability, skinned by token.
+ *
+ * The rail's whole visual identity used to exist once, as four declarations inside
+ * `apps/workstation/Workspace.scss`. A second consumer could reach that look only by copying CSS
+ * out of another application — there was no layer that answered "what does a dock rail look like".
+ *
+ * The promotion is deliberately NOT a redesign: the engine's defaults are empty identity slots
+ * (`transparent` / `0` / `0` / `none`), the same class of token as `--dock-splitter-ring`, so every
+ * shipped consumer renders byte-identically. That makes the naive control useless — removing the
+ * engine defaults cannot change a bare consumer, because those defaults ARE the CSS initial values.
+ *
+ * So the two arms observe the two halves of what actually changed:
+ *
+ *   1. PRESERVATION — the workstation's rail is byte-identical to its pre-promotion reading. Its
+ *      values now travel token → engine rule instead of being declared in the app; a token that
+ *      resolved differently, or an app declaration that survived and shadowed the engine, fails here.
+ *   2. CAPABILITY — a consumer that ships NO rail paint (the cockpit) can be skinned by setting the
+ *      tokens alone. This is the arm that is red before the change: with no engine rule reading
+ *      them, setting these four custom properties resolves to nothing and the strip stays bare.
+ *
+ * The capability arm mutates in-page rather than asserting a shipped value, for the reason the
+ * rail-size coupling control records: one reading cannot tell "the engine reads this token" from
+ * "these two happen to agree today".
+ *
+ * Run: npm run test-e2e -- e2e/dashboard/DockEdgeRailPaintNL --workers=1
+ */
+
+// The workstation's pre-promotion reading, captured on `dev` before the engine rule existed.
+// Pinned as literals on purpose: a value re-derived from the same tokens the change introduced
+// would agree with itself no matter what the promotion did to it.
+const WORKSTATION_BASELINE = {
+    background: 'color(srgb 0.111373 0.226275 0.233255)',
+    border    : '1px solid color(srgb 0.263216 0.565647 0.547137)',
+    radius    : '7px',
+    shadow    : 'color(srgb 0.368627 0.917647 0.831373 / 0.12) 0px 0px 22px 0px',
+    overflow  : 'hidden'
+};
+
+const readRail = () => {
+    const rail = document.querySelector('.neo-dashboard-dock-edge-rail');
+
+    if (!rail) return null;
+
+    const s = getComputedStyle(rail);
+
+    return {
+        background: s.backgroundColor,
+        border    : `${s.borderTopWidth} ${s.borderTopStyle} ${s.borderTopColor}`,
+        radius    : s.borderTopLeftRadius,
+        shadow    : s.boxShadow,
+        overflow  : s.overflow
+    }
+};
+
+test.describe('Neo.dashboard.Container — the edge rail paints from engine tokens', () => {
+    test.setTimeout(120000);
+
+    test('preservation: the workstation rail is unchanged by the promotion', async ({page}) => {
+        await page.goto('/apps/workstation/index.html');
+        await expect(page.locator('.neo-dashboard-dock-splitter').first(), 'the workstation must boot')
+            .toBeVisible({timeout: 60000});
+
+        const rail = await page.evaluate(readRail);
+
+        expect(rail, 'the workstation must render an edge rail, or this arm proves nothing').toBeTruthy();
+        expect(rail).toEqual(WORKSTATION_BASELINE)
+    });
+
+    test('capability: a consumer with no rail paint skins the strip by token alone', async ({page}) => {
+        await page.goto('/apps/agentos/index.html');
+        await expect(page.locator('.agent-shell'), 'the cockpit must boot').toBeVisible({timeout: 60000});
+
+        const before = await page.evaluate(readRail);
+
+        expect(before, 'the cockpit must render an edge rail').toBeTruthy();
+        // Non-vacuity: the arm below is only meaningful because the strip starts bare. If the
+        // cockpit ever adopts rail paint, this fails loudly instead of silently proving nothing.
+        expect(before.background, 'the cockpit rail must start unpainted').toBe('rgba(0, 0, 0, 0)');
+        expect(before.shadow).toBe('none');
+
+        const after = await page.evaluate(() => {
+            const rail = document.querySelector('.neo-dashboard-dock-edge-rail');
+
+            rail.style.setProperty('--dock-edge-rail-background', 'rgb(10, 20, 30)');
+            rail.style.setProperty('--dock-edge-rail-border',     '2px solid rgb(40, 50, 60)');
+            rail.style.setProperty('--dock-edge-rail-radius',      '5px');
+            rail.style.setProperty('--dock-edge-rail-shadow',      'rgb(70, 80, 90) 0px 0px 11px 0px');
+            rail.style.setProperty('--dock-edge-rail-overflow',    'hidden');
+
+            const s = getComputedStyle(rail);
+
+            return {
+                background: s.backgroundColor,
+                border    : `${s.borderTopWidth} ${s.borderTopStyle} ${s.borderTopColor}`,
+                radius    : s.borderTopLeftRadius,
+                shadow    : s.boxShadow,
+                overflow  : s.overflow
+            }
+        });
+
+        // Each property is asserted separately: a single object compare would let one unread token
+        // hide behind four that resolved, and "which one did not travel" is the useful failure.
+        expect(after.background, 'background must resolve from the token').toBe('rgb(10, 20, 30)');
+        expect(after.border,     'border must resolve from the token').toBe('2px solid rgb(40, 50, 60)');
+        expect(after.radius,     'radius must resolve from the token').toBe('5px');
+        expect(after.shadow,     'shadow must resolve from the token').toBe('rgb(70, 80, 90) 0px 0px 11px 0px');
+        expect(after.overflow,   'overflow must resolve from the token').toBe('hidden')
+    })
+});


### PR DESCRIPTION
Resolves neomjs/neo#17633

Third and final paint leaf of neomjs/neo#17241, after neomjs/neo#17522 (rail-tab structural paint) and neomjs/neo#17538 (splitter affordance floor). The engine gave `.neo-dashboard-dock-edge-rail` geometry and nothing else; its entire visual identity lived in five declarations inside `apps/workstation/Workspace.scss`, so a second consumer could reach that look only by copying CSS out of another application. The engine now declares the paint against `--dock-edge-rail-*` tokens and the workstation sets values.

**The defaults are the empty identity slots, not an affordance floor.** The strip is not the affordance — its *tabs* are, and they have carried an engine-owed visible active state since neomjs/neo#17522. That is the same distinction the splitter tokens already draw between a `currentColor` floor and a slot an app fills (`--dock-splitter-ring: none` — *"An app fills them; the engine never does"*). So this is a capability, not a redesign: every shipped consumer renders byte-identically, and the `F-tranche` marker comment this element still carried is retired rather than reworded.

Evidence: L3 achieved (both real consumer hosts measured before and after in a real browser, plus a red-verified mutation) → L3 required (every AC is a computed-style property or a grep). Residual: none. Standing caveat, not a residual — CI runs no e2e config, so this evidence does not gate; that gap is neomjs/neo-agent-brain#17's subject.

## AC Evidence

| AC-1 | Measured on `dev` at `6f0b6619c8` before any edit and recorded on the ticket ([comment](https://github.com/neomjs/neo/issues/17633#issuecomment-5387599344)): workstation `background color(srgb 0.111373 0.226275 0.233255)` / `border 1px solid color(srgb 0.263216 0.565647 0.547137)` / `radius 7px` / `shadow … 0px 0px 22px 0px` / `overflow hidden`; cockpit `rgba(0, 0, 0, 0)` / `0px none` / `0px` / `none` / `visible`; example renders no rail at rest. The cockpit is bare on all four — nobody chose transparency, so this is not a deliberate neutral. |
| AC-2 | `background`, `border`, `border-radius`, `box-shadow` on `.neo-dashboard-dock-edge-rail` all read `var(--dock-edge-rail-*)` in `src/dashboard/Container.scss`. Grep across the whole of `resources/scss/src/apps/**` returns three hits: the workstation's token-value block and two `-top`/`-bottom` tab-padding selectors (out of scope, no paint). No paint declaration survives anywhere under that directory. |
| AC-3 | Re-measured after the change: workstation identical on all five properties, character for character against the AC-1 reading. Cockpit likewise unchanged. |
| AC-4 | **Preservation** arm in `DockEdgeRailPaintNL.spec.mjs`: the workstation's pre-promotion reading pinned as literals — deliberately not re-derived from the new tokens, since a value derived from the thing under test agrees with itself regardless. Green; red across all five properties when the engine application is removed. |
| AC-5 | **Capability** arm: the cockpit, which ships no rail paint, is skinned by setting the four tokens in-page and every property follows. This is the arm that is red *before* the change — with no engine rule reading them the properties resolve to nothing, verified as `Received: "rgba(0, 0, 0, 0)"` under mutation. Carries a non-vacuity precondition asserting the strip starts bare, so it fails loudly rather than silently if the cockpit ever adopts rail paint. |
| AC-6 | `overflow` reads `var(--dock-edge-rail-overflow)` in the engine and the workstation still resolves `hidden`, clipping its tabs to the 7px corners. Shipped as a token rather than moved — see Deltas. |
| AC-7 | The `// Demo-consumable minimal hooks only — the real visual language lands with the F-tranche.` comment at `Container.scss:305` is deleted. neomjs/neo#17538 removed the splitter's copy; this was the last one. |

**One criterion was retired, not skipped.** The original AC-4 asked for an arm that goes red when the engine token block is removed *for a bare consumer*. Once AC-1's reading settled the defaults as empty identity slots, those defaults became the CSS initial values — removing them changes nothing a bare consumer resolves, so the arm would have been green against a deleted promotion: vacuous by construction, which is the fault it existed to prevent. It is struck in the ticket body with the reasoning attached, and replaced by the two arms above.

## Deltas from ticket

- **`overflow` is a token, not relocated structure — the ticket body was wrong about why it exists.** It reads as clipping the rotated vertical labels; it is actually coupled to the `border-radius`, clipping tabs to the workstation's rounded corners. A square rail neither needs nor currently has it, and the cockpit resolves `visible` today. Moving it in unconditionally would have been a silent rendering change to every square rail — a redesign wearing a promotion's clothes. It ships as `--dock-edge-rail-overflow`, defaulting to `visible`.
- **AC-4 replaced rather than satisfied**, as above. The ticket body carries the correction with the original struck through, so the reasoning survives for the next reader.
- Nothing else deviates: edge-zone / edge-row gap, edge-band min sizing and the rail-tab padding stay in the app layer exactly as the ticket scoped them.

## Test Evidence

**New durable control** — `test/playwright/e2e/dashboard/DockEdgeRailPaintNL.spec.mjs`, 2 arms, both green at this head.

**Mutation, verified red-capable.** Removing the five `var(--dock-edge-rail-*)` applications from the engine rule and rebuilding themes:

- Preservation → red, five properties differ, the workstation rail losing its paint entirely. This is what proves its values now genuinely travel token → engine rule rather than through a surviving app declaration.
- Capability → red on its own message: `background must resolve from the token / Expected: "rgb(10, 20, 30)" / Received: "rgba(0, 0, 0, 0)"`.

**Regression sweep** — `e2e/dashboard`: **44 passed / 1 failed**. The failure is `PreviewLanguageDragPairNL.spec.mjs:135`, a `toHaveScreenshot` arm reporting **688 pixels, ratio 0.01, `drag-pair-default-dark.png`** — character-identical to the reading I took earlier today against a clean `origin/dev` worktree while working neomjs/neo#17630, where I reverted the changed files in place to confirm it. Pre-existing, already defect-noted, and re-checked here by pixel count rather than by matching test name.

Themes rebuilt (`build-themes -n -e dev -t all`) before every measurement; `dist/` is gitignored and not in the diff.

## Post-Merge Validation

None. All **seven active** ACs are verified at this head — five by measurement or control, two by grep — and nothing is deferred. (Seven, not eight: the retired arm is replaced by preservation + capability, not added to them.)

The standing caveat, which is not an obligation of this PR: no workflow runs `playwright.config.e2e.mjs`, so the control above does not gate in CI. That predates this change and applies to every e2e spec in the tree (#17596). It is recorded so the `Evidence:` line is not read as implying CI coverage it does not have.

Authored by Grace (Claude Opus 5, Claude Code). Origin Session ID: eb671e6e-ca17-4a53-8069-64fd5885ce84
