### PR TITLE
feat(agentos): govern runtime probe eligibility (#17634)

### DIFF
--- a/ai/scripts/diagnostics/agentOsExtractionInventory.json
+++ b/ai/scripts/diagnostics/agentOsExtractionInventory.json
@@ -1,8 +1,281 @@
 {
     "$schema": {
         "description": "Source-owned judgments for the C-prime AgentOS extraction inventory.",
-        "schemaVersion": "agentos-extraction-inventory.v1"
+        "schemaVersion": "agentos-extraction-inventory.v2",
+        "runtimeProbeEligibility": "eligible means import and eager evaluation settle safely inside the disposable denial child; ineligible rows name the exact unguarded or external-work boundary"
     },
+    "runtimeProbeEligibility": [
+        {
+            "identity": "ai/scripts/agent-preflight.mjs",
+            "eligibility": "eligible",
+            "source": "ai/scripts/agent-preflight.mjs:1388-1390",
+            "reason": "the direct-run guard contains the only CLI invocation; subprocess and config work stays function-scoped"
+        },
+        {
+            "identity": "ai/scripts/benchmark/gemma4-rem-benchmark.mjs",
+            "eligibility": "ineligible",
+            "source": "ai/scripts/benchmark/gemma4-rem-benchmark.mjs:256-259",
+            "reason": "unguarded main constructs a live provider, streams model requests, writes output, and exits on failure"
+        },
+        {
+            "identity": "ai/scripts/benchmark/keep-alive-probe.mjs",
+            "eligibility": "ineligible",
+            "source": "ai/scripts/benchmark/keep-alive-probe.mjs:163-166",
+            "reason": "unguarded main immediately runs live provider probes and may call process.exit"
+        },
+        {
+            "identity": "ai/scripts/benchmark/provider-lane-election.mjs",
+            "eligibility": "eligible",
+            "source": "ai/scripts/benchmark/provider-lane-election.mjs:2771-2778",
+            "reason": "the direct-run guard contains main; Docker, subprocess, timer, and wait work stays function-scoped"
+        },
+        {
+            "identity": "ai/scripts/diagnostics/analyzeNlTelemetry.mjs",
+            "eligibility": "ineligible",
+            "source": "ai/scripts/diagnostics/analyzeNlTelemetry.mjs:27-43",
+            "reason": "import validates argv, may exit, opens and queries SQLite, and can write output with no entry guard"
+        },
+        {
+            "identity": "ai/scripts/diagnostics/audit-discussion-lifecycle.mjs",
+            "eligibility": "eligible",
+            "source": "ai/scripts/diagnostics/audit-discussion-lifecycle.mjs:770-779",
+            "reason": "the direct-run guard contains main and exits; filesystem and git acquisition stays function-scoped"
+        },
+        {
+            "identity": "ai/scripts/diagnostics/bootstrapCodexSandbox.mjs",
+            "eligibility": "eligible",
+            "source": "ai/scripts/diagnostics/bootstrapCodexSandbox.mjs:263-265",
+            "reason": "the direct-run guard contains the probe; SQLite construction and filesystem mutation stay inside guarded functions"
+        },
+        {
+            "identity": "ai/scripts/diagnostics/check-identity-facts.mjs",
+            "eligibility": "eligible",
+            "source": "ai/scripts/diagnostics/check-identity-facts.mjs:445-447",
+            "reason": "bounded constants evaluate eagerly; file reads and exits stay behind the direct-run guard"
+        },
+        {
+            "identity": "ai/scripts/diagnostics/check-retired-primitives.mjs",
+            "eligibility": "ineligible",
+            "source": "ai/scripts/diagnostics/check-retired-primitives.mjs:217-227,295",
+            "reason": "unguarded main synchronously spawns grep, scans repository state, and calls process.exit"
+        },
+        {
+            "identity": "ai/scripts/diagnostics/check-substrate-size.mjs",
+            "eligibility": "ineligible",
+            "source": "ai/scripts/diagnostics/check-substrate-size.mjs:56-137",
+            "reason": "the complete diagnostic executes at module scope and unconditionally reaches process.exit"
+        },
+        {
+            "identity": "ai/scripts/diagnostics/defectObservations.mjs",
+            "eligibility": "ineligible",
+            "source": "ai/scripts/diagnostics/defectObservations.mjs:140-224",
+            "reason": "top-level await connects to Fleet or initializes local graph services and then exits without an import guard"
+        },
+        {
+            "identity": "ai/scripts/diagnostics/fleetHealthcheck.mjs",
+            "eligibility": "eligible",
+            "source": "ai/scripts/diagnostics/fleetHealthcheck.mjs:171-179",
+            "reason": "network probes, waits, and exits are direct-run guarded; eager environment loading is finite and child-local"
+        },
+        {
+            "identity": "ai/scripts/diagnostics/gemini-incident-cost-ledger.mjs",
+            "eligibility": "eligible",
+            "source": "ai/scripts/diagnostics/gemini-incident-cost-ledger.mjs:507-509",
+            "reason": "log acquisition and exits stay behind the direct-run guard; eager imports are declarative"
+        },
+        {
+            "identity": "ai/scripts/diagnostics/genesisProbe.mjs",
+            "eligibility": "eligible",
+            "source": "ai/scripts/diagnostics/genesisProbe.mjs:1635-1642",
+            "reason": "spawn, polling, signal handling, database access, and exits occur only through guarded main"
+        },
+        {
+            "identity": "ai/scripts/diagnostics/mcpHealthcheck.mjs",
+            "eligibility": "eligible",
+            "source": "ai/scripts/diagnostics/mcpHealthcheck.mjs:490-492",
+            "reason": "MCP connections and timers are direct-run guarded; eager environment loading is bounded in the probe child"
+        },
+        {
+            "identity": "ai/scripts/diagnostics/providerLaneComposition.mjs",
+            "eligibility": "eligible",
+            "source": "ai/scripts/diagnostics/providerLaneComposition.mjs:783-788",
+            "reason": "stdin, file reads, dynamic config imports, output, and exit handling occur only in guarded main"
+        },
+        {
+            "identity": "ai/scripts/diagnostics/seatCostReport.mjs",
+            "eligibility": "eligible",
+            "source": "ai/scripts/diagnostics/seatCostReport.mjs:442-497",
+            "reason": "database construction and ledger reads are lazy inside functions; main and exits are directly guarded"
+        },
+        {
+            "identity": "ai/scripts/diagnostics/structureMap.mjs",
+            "eligibility": "eligible",
+            "source": "ai/scripts/diagnostics/structureMap.mjs:331-342",
+            "reason": "filesystem traversal and dynamic lint loading occur only through guarded main; eager evaluation is constants"
+        },
+        {
+            "identity": "ai/scripts/fleet/devCockpit.mjs",
+            "eligibility": "eligible",
+            "source": "ai/scripts/fleet/devCockpit.mjs:576-623",
+            "reason": "HTTP probes, GitHub subprocesses, webpack and Fleet spawns, listeners, and exits stay behind guarded main"
+        },
+        {
+            "identity": "ai/scripts/lifecycle/postReleaseSync.mjs",
+            "eligibility": "eligible",
+            "source": "ai/scripts/lifecycle/postReleaseSync.mjs:191-203; ai/services.host.mjs:110",
+            "reason": "destructive release work is guarded and the eager host barrel disables auto-connect before bounded singleton initialization"
+        },
+        {
+            "identity": "ai/scripts/lifecycle/revalidationSweep.mjs",
+            "eligibility": "eligible",
+            "source": "ai/scripts/lifecycle/revalidationSweep.mjs:294-322",
+            "reason": "CLI and network work is guarded; eager identity, config, and logger evaluation is finite and starts no waiter"
+        },
+        {
+            "identity": "ai/scripts/lint/check-commit-authorship.mjs",
+            "eligibility": "ineligible",
+            "source": "ai/scripts/lint/check-commit-authorship.mjs:158-306",
+            "reason": "import runs git commands, reads stdin which can wait, scans commits, and calls process.exit with no entry guard"
+        },
+        {
+            "identity": "ai/scripts/lint/check-front-door-fingerprint.mjs",
+            "eligibility": "eligible",
+            "source": "ai/scripts/lint/check-front-door-fingerprint.mjs:116-142",
+            "reason": "file reads, writes, and exits occur only inside functions invoked by the direct-run guard"
+        },
+        {
+            "identity": "ai/scripts/lint/lint-adr-seam-table.mjs",
+            "eligibility": "eligible",
+            "source": "ai/scripts/lint/lint-adr-seam-table.mjs:118-136",
+            "reason": "ADR traversal and exits are deferred behind the direct-run guard; eager state is paths and constants"
+        },
+        {
+            "identity": "ai/scripts/lint/lint-agents.mjs",
+            "eligibility": "eligible",
+            "source": "ai/scripts/lint/lint-agents.mjs:326-328",
+            "reason": "git acquisition and process exits occur only through guarded main"
+        },
+        {
+            "identity": "ai/scripts/lint/lint-config-template-ssot.mjs",
+            "eligibility": "eligible",
+            "source": "ai/scripts/lint/lint-config-template-ssot.mjs:2457-2459",
+            "reason": "scans, template imports, writes, and exits stay behind the guard; eager evaluation is in-memory constants"
+        },
+        {
+            "identity": "ai/scripts/lint/lint-fleet-vocabulary-parity.mjs",
+            "eligibility": "eligible",
+            "source": "ai/scripts/lint/lint-fleet-vocabulary-parity.mjs:310-312",
+            "reason": "eager imports are frozen vocabulary and pure helpers; comparison and exit run only from guarded main"
+        },
+        {
+            "identity": "ai/scripts/lint/lint-guard-ci-parity.mjs",
+            "eligibility": "eligible",
+            "source": "ai/scripts/lint/lint-guard-ci-parity.mjs:430-435",
+            "reason": "top level derives path constants only; file and YAML reads plus exit stay inside guarded runLint"
+        },
+        {
+            "identity": "ai/scripts/lint/lint-guides.mjs",
+            "eligibility": "eligible",
+            "source": "ai/scripts/lint/lint-guides.mjs:451-453",
+            "reason": "guide, OpenAPI, and script reads plus exits stay behind the direct-run guard"
+        },
+        {
+            "identity": "ai/scripts/lint/lint-identity-engine-coherence.mjs",
+            "eligibility": "eligible",
+            "source": "ai/scripts/lint/lint-identity-engine-coherence.mjs:266-268",
+            "reason": "the imported roster generator is guarded; model reads and target exit remain behind this target guard"
+        },
+        {
+            "identity": "ai/scripts/lint/lint-identity-vocabulary.mjs",
+            "eligibility": "eligible",
+            "source": "ai/scripts/lint/lint-identity-vocabulary.mjs:156-158",
+            "reason": "only built-ins and bounded constants evaluate eagerly; scanning runs through guarded main"
+        },
+        {
+            "identity": "ai/scripts/lint/lint-mcp-test-locations.mjs",
+            "eligibility": "eligible",
+            "source": "ai/scripts/lint/lint-mcp-test-locations.mjs:125-127",
+            "reason": "filesystem census and exit handling are contained by the direct-entry guard"
+        },
+        {
+            "identity": "ai/scripts/lint/lint-npm-script-entrypoints.mjs",
+            "eligibility": "eligible",
+            "source": "ai/scripts/lint/lint-npm-script-entrypoints.mjs:193-223",
+            "reason": "AST and filesystem lint execution plus exitCode assignment occur only under the isMain guard"
+        },
+        {
+            "identity": "ai/scripts/lint/lint-openapi-service-parity.mjs",
+            "eligibility": "eligible",
+            "source": "ai/scripts/lint/lint-openapi-service-parity.mjs:877-916",
+            "reason": "parity scanning is guarded; the eager census-helper dependency is declarative and independently guarded"
+        },
+        {
+            "identity": "ai/scripts/lint/lint-retry-bounds.mjs",
+            "eligibility": "eligible",
+            "source": "ai/scripts/lint/lint-retry-bounds.mjs:662-664",
+            "reason": "repository traversal and exits occur through guarded main; eager evaluation is finite registries and constants"
+        },
+        {
+            "identity": "ai/scripts/lint/lint-script-plane.mjs",
+            "eligibility": "eligible",
+            "source": "ai/scripts/lint/lint-script-plane.mjs:499-501",
+            "reason": "closure and task-authority imports are declarative; scanning and exit occur only under the direct-run guard"
+        },
+        {
+            "identity": "ai/scripts/lint/lint-skill-manifest.mjs",
+            "eligibility": "eligible",
+            "source": "ai/scripts/lint/lint-skill-manifest.mjs:1329-1334",
+            "reason": "git and filesystem scans plus exit handling stay inside guarded main"
+        },
+        {
+            "identity": "ai/scripts/lint/lint-tree-json.mjs",
+            "eligibility": "eligible",
+            "source": "ai/scripts/lint/lint-tree-json.mjs:438-443",
+            "reason": "tree and SEO generation is guarded and the imported SEO generator has its own direct-entry guard"
+        },
+        {
+            "identity": "ai/scripts/maintenance/communityBatchPushClient.mjs",
+            "eligibility": "eligible",
+            "source": "ai/scripts/maintenance/communityBatchPushClient.mjs:242-244",
+            "reason": "MCP construction, connection, retry, payload reads, and close occur only through guarded CLI functions"
+        },
+        {
+            "identity": "ai/scripts/maintenance/kbPushClient.mjs",
+            "eligibility": "eligible",
+            "source": "ai/scripts/maintenance/kbPushClient.mjs:311-313",
+            "reason": "MCP construction, connection, and payload acquisition occur only inside guarded functions"
+        },
+        {
+            "identity": "ai/scripts/maintenance/probeBusinessMetrics.mjs",
+            "eligibility": "ineligible",
+            "source": "ai/scripts/maintenance/probeBusinessMetrics.mjs:15; ai/services/memory-core/GraphService.mjs:124-151",
+            "reason": "eager Cloud barrel import constructs GraphService whose scheduled initAsync opens and loads SQLite"
+        },
+        {
+            "identity": "ai/scripts/maintenance/probeCommunityActivityShadow.mjs",
+            "eligibility": "eligible",
+            "source": "ai/scripts/maintenance/probeCommunityActivityShadow.mjs:106-115",
+            "reason": "GitHub acquisition and report writes are guarded; eager GraphqlService starts no external-work initializer"
+        },
+        {
+            "identity": "ai/scripts/maintenance/syncGithubWorkflow.mjs",
+            "eligibility": "eligible",
+            "source": "ai/scripts/maintenance/syncGithubWorkflow.mjs:38,161-163; ai/services/github-workflow/SyncService.mjs:74-89",
+            "reason": "module scope disables syncOnStartup before singleton init; CLI sync, lease, and exit work stays guarded"
+        },
+        {
+            "identity": "ai/scripts/migrations/bootstrapWorktree.mjs",
+            "eligibility": "eligible",
+            "source": "ai/scripts/migrations/bootstrapWorktree.mjs:147-201,1530-1784",
+            "reason": "top-level work is finite template enumeration and an in-memory invariant; mutation and subprocesses stay under isMain"
+        },
+        {
+            "identity": "ai/scripts/runners/runAgent.mjs",
+            "eligibility": "eligible",
+            "source": "ai/scripts/runners/runAgent.mjs:12-26",
+            "reason": "orchestration, timers, and process exit are reachable only from guarded startOrchestrator; the class is non-singleton"
+        }
+    ],
     "overrides": [
         {
             "surface": "script-module",

--- a/ai/scripts/diagnostics/agentOsExtractionInventory.mjs
+++ b/ai/scripts/diagnostics/agentOsExtractionInventory.mjs
@@ -50,16 +50,17 @@ import {censusPlaneOpeners}           from './planePlacementCensus.mjs';
  */
 
 const
-    __filename            = fileURLToPath(import.meta.url),
-    PROJECT_ROOT          = path.resolve(path.dirname(__filename), '../../..'),
-    DEFAULT_REGISTRY_PATH = path.join(PROJECT_ROOT, 'ai/scripts/diagnostics/agentOsExtractionInventory.json'),
-    SCRIPT_PATH_RE        = /\bai\/scripts\/[A-Za-z0-9_./-]+\.mjs\b/g,
-    WORKFLOW_ARTIFACT_RE  = /\b(?:test\/playwright\/unit\/)?ai\/scripts\/[A-Za-z0-9_./-]+\.(?:json|mjs)\b/g,
-    VALID_DISPOSITIONS    = new Set(['cloud', 'edge', 'retire', 'shared', 'stays-engine']),
-    LAUNCH_CALLEES        = new Set([
+    __filename              = fileURLToPath(import.meta.url),
+    PROJECT_ROOT            = path.resolve(path.dirname(__filename), '../../..'),
+    DEFAULT_REGISTRY_PATH   = path.join(PROJECT_ROOT, 'ai/scripts/diagnostics/agentOsExtractionInventory.json'),
+    SCRIPT_PATH_RE          = /\bai\/scripts\/[A-Za-z0-9_./-]+\.mjs\b/g,
+    WORKFLOW_ARTIFACT_RE    = /\b(?:test\/playwright\/unit\/)?ai\/scripts\/[A-Za-z0-9_./-]+\.(?:json|mjs)\b/g,
+    VALID_DISPOSITIONS      = new Set(['cloud', 'edge', 'retire', 'shared', 'stays-engine']),
+    VALID_PROBE_ELIGIBILITY = new Set(['eligible', 'ineligible']),
+    LAUNCH_CALLEES          = new Set([
         'exec', 'execFile', 'execFileSync', 'execSync', 'fork', 'runCommand', 'spawn', 'spawnSync'
     ]),
-    SUBPROCESS_SCAN_ROOTS = ['.agents', '.claude', '.codex', 'ai', 'buildScripts', 'test'];
+    SUBPROCESS_SCAN_ROOTS   = ['.agents', '.claude', '.codex', 'ai', 'buildScripts', 'test'];
 
 /**
  * Stable surface names in the machine receipt.
@@ -89,6 +90,18 @@ export const PLANE_DISPOSITIONS = Object.freeze({
     'container-plane' : 'cloud',
     'host-edge'       : 'edge',
     'shared-primitive': 'cloud'
+});
+
+/**
+ * Stable runtime-probe eligibility vocabulary consumed by the paired AgentOS boundary proof.
+ * `eligible` licenses bounded evaluation inside the disposable child, not side-effect purity:
+ * finite child-local env/config reads are allowed. Entrypoints that can run their CLI, exit, wait,
+ * spawn persistent work, or acquire durable state merely by import are `ineligible` with a reason.
+ * @type {Object}
+ */
+export const RUNTIME_PROBE_ELIGIBILITY = Object.freeze({
+    eligible  : 'eligible',
+    ineligible: 'ineligible'
 });
 
 /**
@@ -686,6 +699,108 @@ export function reconcileInventory(derivedRows, registry, parseFailures = []) {
 }
 
 /**
+ * @summary Derives the unique Host-Edge launch-target population governed by runtime-probe
+ * eligibility. Custody remains authoritative in the reconciled script rows; launch-root shape
+ * merely selects which owned modules the paired proof may need to evaluate.
+ * @param {Object} [options]
+ * @param {Object[]} [options.launchRoots=[]]
+ * @param {Object[]} [options.scriptRows=[]] Reconciled inventory rows.
+ * @returns {String[]}
+ */
+export function deriveRuntimeProbeTargets({launchRoots = [], scriptRows = []} = {}) {
+    const dispositionByIdentity = new Map(scriptRows
+        .filter(row => row.surface === SURFACE.scriptModule)
+        .map(row => [row.identity, row.disposition]));
+
+    return [...new Set(launchRoots.map(row => row.rel).filter(Boolean))]
+        .filter(identity => dispositionByIdentity.get(identity) === 'edge')
+        .sort()
+}
+
+/**
+ * @summary Reconciles exact Edge launch targets against identity-scoped runtime-probe judgments.
+ * No status is inferred: missing and stale identities remain distinct residue, while invalid or
+ * explanation-free authority stays visible as typed errors.
+ * @param {String[]} targets Derived unique Edge launch-target identities.
+ * @param {Object} registry Source-owned extraction registry.
+ * @returns {Object}
+ */
+export function reconcileRuntimeProbeEligibility(targets, registry) {
+    const
+        governed  = [...new Set(targets)].sort(),
+        authority = Array.isArray(registry?.runtimeProbeEligibility)
+            ? registry.runtimeProbeEligibility
+            : [],
+        errors       = [],
+        authorityMap = new Map(),
+        targetSet    = new Set(governed);
+
+    if (!Array.isArray(registry?.runtimeProbeEligibility)) {
+        errors.push({kind: 'invalid-runtime-probe-registry', key: 'runtimeProbeEligibility'})
+    }
+
+    authority.forEach(entry => {
+        const identity = entry?.identity;
+
+        if (typeof identity !== 'string' || !identity.trim()) {
+            errors.push({kind: 'missing-runtime-probe-identity', key: 'runtimeProbeEligibility'});
+            return
+        }
+
+        if (authorityMap.has(identity)) {
+            errors.push({kind: 'duplicate-runtime-probe-eligibility', key: identity});
+            return
+        }
+
+        authorityMap.set(identity, entry);
+
+        if (!VALID_PROBE_ELIGIBILITY.has(entry.eligibility)) {
+            errors.push({kind: 'invalid-runtime-probe-eligibility', key: identity})
+        }
+        if (typeof entry.reason !== 'string' || entry.reason.trim().length < 12) {
+            errors.push({kind: 'missing-runtime-probe-reason', key: identity})
+        }
+        if (typeof entry.source !== 'string' || !entry.source.trim()) {
+            errors.push({kind: 'missing-runtime-probe-source', key: identity})
+        }
+    });
+
+    const
+        targetsWithoutAuthority = governed.filter(identity => !authorityMap.has(identity)),
+        authorityWithoutTargets = [...authorityMap.keys()].filter(identity => !targetSet.has(identity)).sort(),
+        rows                    = governed.filter(identity => authorityMap.has(identity)).map(identity => {
+            const entry = authorityMap.get(identity);
+
+            return {
+                identity,
+                eligibility: VALID_PROBE_ELIGIBILITY.has(entry.eligibility) ? entry.eligibility : null,
+                reason     : typeof entry.reason === 'string' ? entry.reason : null,
+                source     : typeof entry.source === 'string' ? entry.source : null
+            }
+        });
+
+    if (governed.length === 0) {
+        errors.push({kind: 'empty-runtime-probe-population', key: 'runtimeProbeEligibility'})
+    }
+    targetsWithoutAuthority.forEach(key => errors.push({kind: 'missing-runtime-probe-eligibility', key}));
+    authorityWithoutTargets.forEach(key => errors.push({kind: 'stale-runtime-probe-eligibility', key}));
+
+    const byEligibility = {
+        eligible  : rows.filter(row => row.eligibility === RUNTIME_PROBE_ELIGIBILITY.eligible).length,
+        ineligible: rows.filter(row => row.eligibility === RUNTIME_PROBE_ELIGIBILITY.ineligible).length
+    };
+
+    return {
+        total  : governed.length,
+        byEligibility,
+        rows,
+        residue: {targetsWithoutAuthority, authorityWithoutTargets},
+        errors : errors.sort((a, b) => `${a.kind}:${a.key}`.localeCompare(`${b.kind}:${b.key}`)),
+        ok     : errors.length === 0
+    }
+}
+
+/**
  * @summary Stable row comparator used by human and JSON outputs.
  * @param {Object} a
  * @param {Object} b
@@ -718,6 +833,14 @@ export function buildInventory({
             resolveFallback: closureResolve
         }),
         preliminary                                  = reconcileInventory(scriptRows, registry),
+        runtimeProbeTargets                          = deriveRuntimeProbeTargets({
+            launchRoots,
+            scriptRows: preliminary.rows
+        }),
+        runtimeProbeEligibility                      = reconcileRuntimeProbeEligibility(
+            runtimeProbeTargets,
+            registry
+        ),
         scriptRowsByIdentity                         = new Map(preliminary.rows
             .filter(row => row.surface === SURFACE.scriptModule)
             .map(row => [row.identity, row])),
@@ -745,6 +868,10 @@ export function buildInventory({
         ).trim(),
         counts                               = {};
 
+    reconciled.errors.push(...runtimeProbeEligibility.errors);
+    reconciled.errors.sort((a, b) => `${a.kind}:${a.key}`.localeCompare(`${b.kind}:${b.key}`));
+    reconciled.ok &&= runtimeProbeEligibility.ok;
+
     const bindingError = sourceBindingError(status, allowDirty);
 
     if (bindingError) {
@@ -761,7 +888,7 @@ export function buildInventory({
     });
 
     return {
-        schemaVersion: 'agentos-extraction-inventory.v1',
+        schemaVersion: 'agentos-extraction-inventory.v2',
         capturedAt,
         git          : {
             sha,
@@ -773,6 +900,7 @@ export function buildInventory({
             byVia: Object.fromEntries(Object.entries(Object.groupBy(launchRoots, row => row.via))
                 .map(([via, rows]) => [via, rows.length]))
         },
+        runtimeProbeEligibility,
         counts,
         ...reconciled
     }
@@ -792,6 +920,14 @@ export function formatInventory(report) {
 
         lines.push(`${surface.padEnd(22)} ${String(data.total).padStart(4)}  ${detail}`)
     });
+
+    const probe = report.runtimeProbeEligibility;
+
+    lines.push('', `runtime-probe targets: ${probe.total} · eligible ${probe.byEligibility.eligible} · ` +
+        `ineligible ${probe.byEligibility.ineligible}`);
+    probe.rows.forEach(row => lines.push(
+        `  ${String(row.eligibility).padEnd(10)} ${row.identity} — ${row.reason}`
+    ));
 
     lines.push('', `disk - authority: ${report.residue.diskMinusAuthority.length}`);
     report.residue.diskMinusAuthority.forEach(key => lines.push(`  + ${key}`));

--- a/test/playwright/unit/ai/scripts/diagnostics/agentOsExtractionInventory.spec.mjs
+++ b/test/playwright/unit/ai/scripts/diagnostics/agentOsExtractionInventory.spec.mjs
@@ -5,12 +5,15 @@ import {fileURLToPath} from 'node:url';
 
 import {
     buildInventory,
+    deriveRuntimeProbeTargets,
     discoverSubprocessLaunches,
     discoverWorkflowReferences,
     listTrackedFiles,
     reconcileInventory,
+    reconcileRuntimeProbeEligibility,
     resolveTrackedConfigSpecifier,
     rowKey,
+    RUNTIME_PROBE_ELIGIBILITY,
     sourceBindingError,
     SURFACE
 }                       from '../../../../../../ai/scripts/diagnostics/agentOsExtractionInventory.mjs';
@@ -208,6 +211,119 @@ test.describe('agentOsExtractionInventory — exact population × explicit autho
         })
     });
 
+    test('runtime-probe targets are the unique launch roots whose explicit custody is Edge', () => {
+        const targets = deriveRuntimeProbeTargets({
+            launchRoots: [
+                {rel: 'ai/scripts/edge.mjs'},
+                {rel: 'ai/scripts/cloud.mjs'},
+                {rel: 'ai/scripts/edge.mjs'}
+            ],
+            scriptRows: [{
+                surface: SURFACE.scriptModule, identity: 'ai/scripts/edge.mjs', disposition: 'edge'
+            }, {
+                surface: SURFACE.scriptModule, identity: 'ai/scripts/cloud.mjs', disposition: 'cloud'
+            }, {
+                surface: SURFACE.scriptModule, identity: 'ai/scripts/unlaunched.mjs', disposition: 'edge'
+            }]
+        });
+
+        expect(targets).toEqual(['ai/scripts/edge.mjs'])
+    });
+
+    test('runtime-probe authority reconciles one exact judgment per target', () => {
+        const result = reconcileRuntimeProbeEligibility([
+            'ai/scripts/a.mjs', 'ai/scripts/b.mjs'
+        ], {
+            runtimeProbeEligibility: [{
+                identity   : 'ai/scripts/a.mjs',
+                eligibility: RUNTIME_PROBE_ELIGIBILITY.eligible,
+                reason     : 'entrypoint work is guarded and eager imports are bounded',
+                source     : 'fixture:a'
+            }, {
+                identity   : 'ai/scripts/b.mjs',
+                eligibility: RUNTIME_PROBE_ELIGIBILITY.ineligible,
+                reason     : 'module starts a persistent process at import time',
+                source     : 'fixture:b'
+            }]
+        });
+
+        expect(result.ok).toBe(true);
+        expect(result.byEligibility).toEqual({eligible: 1, ineligible: 1});
+        expect(result.rows.map(row => row.identity)).toEqual(['ai/scripts/a.mjs', 'ai/scripts/b.mjs'])
+    });
+
+    test('RED: same-count eligibility substitution names missing and stale identities', () => {
+        const result = reconcileRuntimeProbeEligibility(['ai/scripts/a.mjs'], {
+            runtimeProbeEligibility: [{
+                identity   : 'ai/scripts/b.mjs',
+                eligibility: 'eligible',
+                reason     : 'different identity at the same population count',
+                source     : 'fixture substitution'
+            }]
+        });
+
+        expect(result.ok).toBe(false);
+        expect(result.residue).toEqual({
+            targetsWithoutAuthority: ['ai/scripts/a.mjs'],
+            authorityWithoutTargets: ['ai/scripts/b.mjs']
+        });
+        expect(result.errors).toEqual(expect.arrayContaining([{
+            kind: 'missing-runtime-probe-eligibility', key: 'ai/scripts/a.mjs'
+        }, {
+            kind: 'stale-runtime-probe-eligibility', key: 'ai/scripts/b.mjs'
+        }]))
+    });
+
+    test('RED: added and removed Edge targets fail independently by identity', () => {
+        const shared = {
+                  identity   : 'ai/scripts/a.mjs',
+                  eligibility: 'eligible',
+                  reason     : 'the stable target is explicitly safe to evaluate',
+                  source     : 'fixture stable target'
+              },
+              added  = reconcileRuntimeProbeEligibility([
+                  'ai/scripts/a.mjs', 'ai/scripts/new.mjs'
+              ], {runtimeProbeEligibility: [shared]}),
+              removed = reconcileRuntimeProbeEligibility(['ai/scripts/a.mjs'], {
+                  runtimeProbeEligibility: [shared, {
+                      identity   : 'ai/scripts/removed.mjs',
+                      eligibility: 'ineligible',
+                      reason     : 'the former target started persistent work on import',
+                      source     : 'fixture removed target'
+                  }]
+              });
+
+        expect(added.errors).toContainEqual({
+            kind: 'missing-runtime-probe-eligibility', key: 'ai/scripts/new.mjs'
+        });
+        expect(added.errors.some(error => error.kind === 'stale-runtime-probe-eligibility')).toBe(false);
+        expect(removed.errors).toContainEqual({
+            kind: 'stale-runtime-probe-eligibility', key: 'ai/scripts/removed.mjs'
+        });
+        expect(removed.errors.some(error => error.kind === 'missing-runtime-probe-eligibility')).toBe(false)
+    });
+
+    test('RED: duplicate, invalid, and explanation-free probe authority stays visible', () => {
+        const result = reconcileRuntimeProbeEligibility(['ai/scripts/a.mjs'], {
+            runtimeProbeEligibility: [{
+                identity: 'ai/scripts/a.mjs', eligibility: 'unknown', reason: '', source: ''
+            }, {
+                identity   : 'ai/scripts/a.mjs',
+                eligibility: 'eligible',
+                reason     : 'duplicate authority must not replace the first row',
+                source     : 'duplicate fixture'
+            }]
+        });
+
+        expect(result.ok).toBe(false);
+        expect(result.errors.map(error => error.kind)).toEqual(expect.arrayContaining([
+            'duplicate-runtime-probe-eligibility',
+            'invalid-runtime-probe-eligibility',
+            'missing-runtime-probe-reason',
+            'missing-runtime-probe-source'
+        ]))
+    });
+
     test('the committed receipt is zero-residue, exhaustive, and independent of rendered overlays', () => {
         const overlayHiddenResolve = (specifier, fromFile) => {
                   const requested = path.resolve(path.dirname(fromFile), specifier),
@@ -247,6 +363,20 @@ test.describe('agentOsExtractionInventory — exact population × explicit autho
         expect(first.counts[SURFACE.rootScript].total).toBe(packageScripts.length);
         expect(first.counts[SURFACE.workflowReference].total).toBe(workflowReferences.length);
         expect(first.counts[SURFACE.planeOpener].total).toBe(censusPlaneOpeners({projectRoot: REPO_ROOT}).total);
+        expect(first.schemaVersion).toBe('agentos-extraction-inventory.v2');
+        expect(first.runtimeProbeEligibility.ok).toBe(true);
+        expect(first.runtimeProbeEligibility.total).toBe(
+            first.runtimeProbeEligibility.rows.length
+        );
+        expect(first.runtimeProbeEligibility.byEligibility.eligible +
+            first.runtimeProbeEligibility.byEligibility.ineligible).toBe(
+            first.runtimeProbeEligibility.total
+        );
+        first.runtimeProbeEligibility.rows.forEach(row => {
+            expect(['eligible', 'ineligible']).toContain(row.eligibility);
+            expect(row.reason).toBeTruthy();
+            expect(row.source).toBeTruthy()
+        });
 
         const keys = first.rows.map(row => rowKey(row.surface, row.identity));
 


### PR DESCRIPTION
Resolves #17634

Proof 2 can now decide which Host-Edge launch targets it may safely import instead of choosing between blind execution and silent omission. The v2 extraction inventory derives the governed set from live launch roots plus explicit custody, then reconciles 45 identity-scoped judgments: 37 bounded probe targets and 8 entrypoints whose unguarded CLI, stdin wait, live provider work, or eager SQLite lifecycle makes import unsafe.

Evidence: L2 achieved (source-derived exact population + identity-scoped registry + positive/exhaustive unit receipt + live missing/same-count red mutations) → L2 required (this child changes the machine authority consumed by #17533's runtime proof, but does not itself execute that proof). Residual: none. Parent continuation, not a residual: #17533's H3/H4 composer consumes this authority.

## AC Evidence

| AC | Evidence |
|---|---|
| AC-1 | `deriveRuntimeProbeTargets()` deduplicates `launchRoots[].rel` and joins only reconciled `script-module` rows whose custody is `edge`. Current output is 74 total launch targets / 45 Edge, but no literal count participates in the decision. |
| AC-2 | Registry v2 adds 45 identity-scoped `runtimeProbeEligibility` rows with `eligible`/`ineligible`, source anchor, and reason; current census is 37/8. |
| AC-3 | Eligibility reconciles against the derived target set rather than the existing grouped 95-module Edge custody override; extra authority is `stale-runtime-probe-eligibility`. |
| AC-4 | `reconcileRuntimeProbeEligibility()` emits distinct typed errors; focused unit arms cover duplicate, invalid, missing source/reason, added, removed, and same-count substitution. |
| AC-5 | The added/removed unit arm separates missing from stale; the substitution arm produces both at unchanged count. A live mutation over the 45-row registry named `agent-preflight.mjs` missing and `not-a-target.mjs` stale. |
| AC-6 | `agentos-extraction-inventory.v2` exposes total, eligible/ineligible counts, exact sorted identities, reasons, sources, and residue; the human formatter prints every judgment. |
| AC-7 | The new implementation is static/registry reconciliation only; it imports no candidate script. Eligibility means bounded evaluation in the future disposable child, not filename/guard inference or side-effect purity. |
| AC-8 | Post-rebase focused unit target: 16 expected, 0 unexpected, 0 flaky. Native parent relationship #17533 → #17634 is live; all required current-head checks are green and the H2 receipt is linked at [#17533 comment 5387739195](https://github.com/neomjs/neo/issues/17533#issuecomment-5387739195). |

## Deltas from ticket

- The current source measurement corrected the offered H2 snapshot from 38 to 45 Edge launch targets. The implementation treats both as observations, never authority.
- Eligibility semantics were tightened during the 45-file audit: finite child-local environment/config/YAML reads remain eligible; entrypoints that can execute CLI work, exit, wait, spawn persistent work, or acquire durable state on import are ineligible.
- The additive machine receipt and source-owned registry move from schema v1 to v2 rather than smuggling a new consumer field into v1.

## Test Evidence

- `npm run test-unit -- test/playwright/unit/ai/scripts/diagnostics/agentOsExtractionInventory.spec.mjs` at rebased head `aedbe9b717`: 16 expected, 0 unexpected, 0 flaky (`test-results.json`).
- Live registry deletion mutation: exactly one `missing-runtime-probe-eligibility` for `ai/scripts/agent-preflight.mjs`.
- Live same-count substitution mutation: the same missing identity plus one `stale-runtime-probe-eligibility` for `ai/scripts/not-a-target.mjs`.
- Current committed-source build with the dirty-receipt bypass used only for local development: `ok: true`, 45 total, 37 eligible, 8 ineligible, zero eligibility residue/errors.
- Current-head GitHub CI: all required checks green, including clean-checkout [unit job 97239390529](https://github.com/neomjs/neo/actions/runs/32657863676/job/97239390529).
- `git diff --cached --check`, parse/JSDoc/whitespace/shorthand/fixed-sleep/ticket-archaeology/atomic-write pre-commit guards: passed.
- The standalone CLI correctly refused to call this local checkout clean because nine pre-existing user-owned untracked artifacts remain preserved. No clean-receipt claim is made from that run.

## Post-Merge Validation

None for #17634. Parent continuation: #17533's runtime composer consumes registry v2 and probes only the 37 eligible identities while reporting the 8 ineligible reasons as owned exclusions.

## Commits

- `aedbe9b717` — derive and reconcile runtime-probe eligibility, classify the live population, and red-proof identity drift

## Evolution

The offered count moved from 38 to 45 before implementation began; deriving the population made that drift harmless. The source audit also falsified the tempting “guarded means eligible” shortcut in both directions: some guarded modules still schedule eager durable work, while some finite child-local config reads are safe. The registry therefore records the judgment and its source for each identity instead of promoting syntax into policy.

Authored by Euclid (OpenAI GPT-5.6 Sol, Codex Desktop). Session 01a02ead-f0db-7b30-b4e2-54189808ab54.
