### PR TITLE
fix(manager): unregister evicts only its own sort-zone registration (#17642)

### DIFF
--- a/src/manager/DragCoordinator.mjs
+++ b/src/manager/DragCoordinator.mjs
@@ -1120,10 +1120,23 @@ class DragCoordinator extends Manager {
 
         if (sortGroup && me.sortZones.has(sortGroup)) {
             let group = me.sortZones.get(sortGroup);
-            group.delete(windowId);
 
-            if (group.size === 0) {
-                me.sortZones.delete(sortGroup)
+            // Evict only THIS zone's own registration. The key is `[sortGroup, windowId]` and
+            // `register` overwrites it, so a window whose zone is REPLACED briefly has two objects
+            // contending for one key. That happens on a staged structural re-projection, which
+            // builds the successor shell before retiring the predecessor — not on an in-place
+            // geometry or retained-topology refresh, which reconciles the existing shell and
+            // replaces no zone at all. An unconditional delete lets the retiring zone evict the
+            // live successor, and then prune the whole group as empty, leaving
+            // `resolveClaimedTarget` to return before its loop runs. Nothing throws and the
+            // surviving zone still answers `acceptsRemoteDrag`, so an app-side reconstruction
+            // reports a target the coordinator can no longer see.
+            if (group.get(windowId) === sortZone) {
+                group.delete(windowId);
+
+                if (group.size === 0) {
+                    me.sortZones.delete(sortGroup)
+                }
             }
         }
 

--- a/test/playwright/unit/manager/DragCoordinator.spec.mjs
+++ b/test/playwright/unit/manager/DragCoordinator.spec.mjs
@@ -182,6 +182,60 @@ test.describe('Neo.manager.DragCoordinator — teardown hygiene (#15248)', () =>
         expect(DragCoordinator.sortZones.get('dock').get(2)).toBe(target)
     });
 
+    /**
+     * The registry is keyed by `[sortGroup, windowId]`, and `register` OVERWRITES that key. So a
+     * window whose zone is REPLACED briefly has two zone objects claiming one key, and the order
+     * they resolve in decides what the coordinator can see.
+     *
+     * Replacement is not universal: an in-place geometry or retained-topology refresh reconciles
+     * the existing shell and swaps no zone. A staged structural re-projection builds the successor
+     * before retiring the predecessor, so the live sequence there is
+     * register(new) → destroy(old) → unregister(old). A `delete(windowId)` that does not check
+     * WHICH zone it is evicting therefore removes the zone that just replaced it.
+     *
+     * The failure is silent and remote: nothing throws, the surviving zone is perfectly healthy and
+     * still answers `acceptsRemoteDrag`, but `resolveClaimedTarget` iterates the coordinator's map
+     * and never reaches it — so a cross-window drag finds no candidate while every app-side
+     * reconstruction of "would this zone accept?" says yes.
+     *
+     * The sibling guard below it is already identity-scoped ("leaves an UNRELATED live target
+     * alone"); this is the same discipline one line up, on the registry rather than on
+     * `activeTargetZone`.
+     */
+    test('unregister evicts only ITS OWN registration — a replaced zone must not delete its successor', () => {
+        const
+            retiring  = createTargetZone({type: 'transferItem'}),
+            successor = createTargetZone({type: 'transferItem'});
+
+        // Same identity, as a re-projection produces: one window, one sort group, two objects.
+        expect(retiring.windowId, 'the two zones must contend for one key, or this proves nothing')
+            .toBe(successor.windowId);
+        expect(retiring).not.toBe(successor);
+
+        DragCoordinator.register(retiring);
+        DragCoordinator.register(successor);
+
+        expect(DragCoordinator.sortZones.get('dock').get(2), 'the successor owns the key after registering')
+            .toBe(successor);
+
+        DragCoordinator.unregister(retiring);
+
+        expect(DragCoordinator.sortZones.get('dock').get(2),
+            'the retiring zone must not evict the successor that replaced it'
+        ).toBe(successor)
+    });
+
+    test('unregister of the LAST holder still clears the key, and prunes an empty group', () => {
+        // The guard above must not turn into "never delete": a zone that genuinely still owns its
+        // key has to be removed, or a departed window stays reachable as a drag target forever.
+        const departing = createTargetZone({type: 'transferItem'});
+
+        DragCoordinator.register(departing);
+        DragCoordinator.unregister(departing);
+
+        expect(DragCoordinator.sortZones.has('dock'), 'the emptied group is pruned').toBe(false)
+    });
+
     test('every terminal is idempotent — a second invocation is a witnessed no-op, not a second commit', () => {
         const
             source = createSourceZone(),


### PR DESCRIPTION
Resolves #17642

`DragCoordinator.unregister` deleted whatever held `[sortGroup, windowId]` without checking it was the zone being destroyed. `register` overwrites that key, so a window whose sort zone is **replaced** briefly has two objects contending for one key — and because `SortZone` registers in `construct` / unregisters in `destroy`, the eviction order decides which one survives.

**Replacement is not every re-projection**, and the first version of this body said it was. `DockProjectionReconciler` branches at `:313`: `geometryOnly || retainTopology` routes to `reconcileStableTopology`, which reconciles the existing shell in place and swaps no zone. Only the **staged structural** path (`:356-446`) builds the successor before retiring the predecessor (`:273`), so it is **each staged structural re-projection** that runs `register(successor)` → `unregister(predecessor)`. The predecessor evicted the successor, and being the last entry, pruned the whole sort group with it.

One line, identity-scoped, matching the discipline already present directly below it on `activeTargetZone`.

Evidence: L3 achieved (red-first unit arms plus the full three-directory unit surface) → L3 required (both ACs are unit-observable). Residual: none.

## AC Evidence

| AC-1 | `unregister evicts only ITS OWN registration — a replaced zone must not delete its successor`. **Verified red on the unfixed code**, and the red was worse than predicted: `TypeError: Cannot read properties of undefined (reading 'get')`, because the eviction emptied the group and the group-prune then removed `sortZones.get('dock')` entirely. Green after the guard. |
| AC-2 | `unregister of the LAST holder still clears the key, and prunes an empty group` — the arm that stops the fix degenerating into "never delete", which would leave a departed window permanently droppable. Green. |
| AC-3 | `unit/manager` + `unit/dashboard` + `unit/draggable`: **666 passed**. |

## Deltas from ticket

None. The fix is the ticket's stated one-line guard; both ACs shipped as written.

## Test Evidence

Red-first, then green: the successor arm fails on `dev`'s code with the `TypeError` above and passes with the guard. The non-degeneracy arm was written specifically because a guard is trivially satisfiable by removing the delete.

**On an intermittent I saw once and chased down rather than shipped past.** One combined `unit/manager unit/dashboard unit/draggable` run went red on `DragCoordinator.spec.mjs` *"THE OVERLAP FALSIFIER"*. I did not assume it was pre-existing:

- `dev` baseline: **4 combined runs, 4 green**
- this branch: **8 combined green / 1 red over 9**, and **8/8 green** running that test in isolation

Sampling alone could not separate those, so the disposition rests on mechanism instead: **no coordinator terminal calls `unregister`** — only `SortZone.destroy()` does — so a test that only registers, moves and ends a drag never enters the function this PR changes. Its three zones also hold distinct `windowId`s, so the guard would be inert even if it ran. The change is unreachable from that test by code path, not by run count. The intermittent is real and pre-existing; captured as a defect-note rather than left in a PR body.

## Post-Merge Validation

None. Both ACs are verified at this head and nothing is deferred.

Authored by Grace (Claude Opus 5, Claude Code). Origin Session ID: eb671e6e-ca17-4a53-8069-64fd5885ce84
