### PR TITLE
fix(mcp): drop the schema defaults that shadow add_message's computed ones (#17648)

### DIFF
--- a/ai/mcp/server/memory-core/openapi.yaml
+++ b/ai/mcp/server/memory-core/openapi.yaml
@@ -2123,7 +2123,7 @@ paths:
                 priority:
                   type: string
                   enum: [low, normal, high]
-                  default: "normal"
+                  description: "Delivery priority. Omit to let the server set it from sender class: normal for an agent, high for an operator (turn-start drain ordering)."
                 partOfThread:
                   type: string
                 taggedConcepts:
@@ -2132,8 +2132,7 @@ paths:
                     type: string
                 wakeSuppressed:
                   type: boolean
-                  default: false
-                  description: "Persist + deliver the message but emit NO wake event — the recipient sees it on their next list_messages rather than via an interrupt. Use for awareness/FYI (e.g. PR-opened-you're-not-the-reviewer, lane-progress, acks) or session-sunset self-DM handovers. Do NOT suppress actionable messages (you're the reviewer, a lane was claimed on you, REQUEST_CHANGES) — those must wake. Known-actionable direct lifecycle messages are rejected when wakeSuppressed is true. In autonomous mode a suppressed message stays unseen until the recipient next lists/boots. Default: omit (= false)."
+                  description: "Persist + deliver but emit NO wake: the recipient sees it on their next list_messages, not as an interrupt — in autonomous mode, not until they next list or boot. Use for awareness/FYI (PR-opened-you're-not-the-reviewer, lane-progress, acks) and sunset self-DM handovers. Never suppress actionable messages — you're the reviewer, a lane was claimed on you, REQUEST_CHANGES; those subjects are rejected. Omit and the server decides: claim-class AGENT:* broadcasts and operator-sent messages are quiet, everything else wakes."
                 task:
                   type: object
                   additionalProperties: true

--- a/ai/services/memory-core/MailboxService.mjs
+++ b/ai/services/memory-core/MailboxService.mjs
@@ -2414,6 +2414,14 @@ class MailboxService extends Base {
         // taxed every active seat per claim. Explicit `wakeSuppressed: false` still wakes — the
         // contested-lane escalation stays a sender election, never a default. Scoped to `AGENT:*`
         // fan-out; direct messages keep the plain default.
+        //
+        // Both this line and the `priority` one above depend on the field arriving ABSENT, and that
+        // is a contract with the tool schema, not a local property: `buildZodSchema` compiles a
+        // declared OpenAPI `default` through `zodSchema.default()`, and Zod applies it even under
+        // `.optional()`. A declared default therefore materializes into the parsed request, the
+        // value is never nullish, and `??` cannot reach either branch — silently, since the injected
+        // value is a legal one. So `add_message` declares no default for either field: a request
+        // field may carry a schema default OR a service-side contextual default, never both.
         wakeSuppressed = wakeSuppressed ?? (operatorSteering || (to === 'AGENT:*' && !!collisionPreventionTag({subject, taggedConcepts})));
 
         // Canonicalize addressing to match the seeded AgentIdentity graph-node IDs. Upstream tool-

--- a/test/playwright/unit/ai/mcp/validation/OpenApiValidatorCompliance.spec.mjs
+++ b/test/playwright/unit/ai/mcp/validation/OpenApiValidatorCompliance.spec.mjs
@@ -506,9 +506,18 @@ test.describe('OpenApiValidator: strict-client JSON-Schema compliance', () => {
               coalesceWindow     = wakeSchema.properties.harnessTargetMetadata.properties.coalesceWindow;
 
         expect(addMessageSchema.properties.priority.enum).toEqual(['low', 'normal', 'high']);
-        expect(addMessageSchema.properties.priority.default).toBe('normal');
-        expect(addMessageSchema.properties.wakeSuppressed.default).toBe(false);
 
+        // `priority` and `wakeSuppressed` deliberately declare NO default, unlike every other field
+        // in this test. A declared default is materialized into the parsed request, so the field
+        // never arrives absent — and both of these have a SERVICE-side default computed from sender
+        // class and target that only runs when the value is nullish. Declaring both meant the schema
+        // silently won and the contextual branch was dead code.
+        expect(addMessageSchema.properties.priority).not.toHaveProperty('default');
+        expect(addMessageSchema.properties.wakeSuppressed).not.toHaveProperty('default');
+
+        // The contrast is the point: these four have no competing service-side default, so their
+        // declared defaults are correct and must survive. A fix that stripped defaults wholesale
+        // would pass the two arms above and break the contract this test was written for.
         expect(listMessagesSchema.properties.box.enum).toEqual(['inbox', 'outbox', 'all']);
         expect(listMessagesSchema.properties.box.default).toBe('inbox');
         expect(listMessagesSchema.properties.status.enum).toEqual(['all', 'read', 'unread']);
@@ -521,6 +530,53 @@ test.describe('OpenApiValidator: strict-client JSON-Schema compliance', () => {
         expect(coalesceWindow.type).toBe('integer');
         expect(coalesceWindow.minimum).toBe(0);
         expect(coalesceWindow.maximum).toBe(300);
+    });
+
+    /**
+     * The defect this pins is one layer down from the schema shape: what the PARSER produces.
+     * `buildZodSchema` compiles a declared `default` through `zodSchema.default(...)`, and Zod 4
+     * applies that inner default even under `.optional()`. So an omitted field reaches the handler
+     * as its declared value, never as `undefined`, and a service that layers its own contextual
+     * default with `??` is unreachable — `false ?? true` is `false`.
+     *
+     * Asserted through the repository's own `add_message` operation rather than a hand-built Zod
+     * control. A synthetic `z.object({x: z.boolean().default(false).optional()})` reproduces the
+     * mechanism but not our document, and the contract at risk is our document's.
+     */
+    test('an omitted contextual-default field is absent after parsing, so the service can compute it', () => {
+        const
+            doc    = yaml.load(fs.readFileSync(path.join(repoRoot, 'ai/mcp/server/memory-core/openapi.yaml'), 'utf8')),
+            parsed = buildZodSchema(doc, doc.paths['/mailbox/messages'].post).parse({
+                body   : 'probe',
+                subject: '[lane-claim][probe] omitted-default parse',
+                to     : 'AGENT:*'
+            });
+
+        // The two fields whose default the SERVICE owns must not be materialized.
+        expect(parsed).not.toHaveProperty('wakeSuppressed');
+        expect(parsed).not.toHaveProperty('priority');
+
+        // Non-vacuity: the parse must actually have run and kept what was sent. Without this the
+        // arm above passes against a parser that returned an empty object.
+        expect(parsed.to).toBe('AGENT:*');
+        expect(parsed.subject).toContain('[lane-claim]');
+    });
+
+    test('an explicitly sent value still reaches the handler — the fix removes a default, not the field', () => {
+        const
+            doc    = yaml.load(fs.readFileSync(path.join(repoRoot, 'ai/mcp/server/memory-core/openapi.yaml'), 'utf8')),
+            parsed = buildZodSchema(doc, doc.paths['/mailbox/messages'].post).parse({
+                body          : 'probe',
+                priority      : 'high',
+                subject       : '[lane-claim][probe] explicit values survive',
+                to            : 'AGENT:*',
+                wakeSuppressed: false
+            });
+
+        // `false` specifically: it is the value the removed default used to inject, so a fix that
+        // stripped falsy values rather than the default would pass the previous arm and fail here.
+        expect(parsed.wakeSuppressed).toBe(false);
+        expect(parsed.priority).toBe('high');
     });
 
     test('memory-core add_memory output declares the bounded post-WAL dispositions (#16896)', () => {


### PR DESCRIPTION
Resolves #17648

`buildZodSchema` compiles a declared OpenAPI `default` through `zodSchema.default()`, and Zod 4 applies that inner default **even under `.optional()`**. An omitted field therefore reaches the handler as its declared value, never as `undefined` — so a service layering its own contextual default with `??` is unreachable, because `false ?? true` is `false`.

Two live instances, both in `add_message`:

| field | declared | service intent | was |
|---|---|---|---|
| `wakeSuppressed` | `default: false` | `MailboxService.mjs:2417` — claim-class `AGENT:*` broadcasts quiet | never ran; every claim broadcast woke every seat |
| `priority` | `default: "normal"` | `:2410` — `operatorSteering ? 'high' : 'normal'` | never ran; **operator messages never got their high priority** |

The `priority` one had no reporter. Its symptom is a *missing escalation* rather than a visible fault, and a fix aimed only at the reported field would have left it live — which is how this defect's predecessor (#15987) survived.

Evidence: L2 achieved (spec-driven contract tests parse the repository's own `add_message` operation through `buildZodSchema`; both arms verified red under mutation) → L2 required (every AC on the close target is parser- or schema-observable). Residual: none.

**L2, not L3, after @neo-gpt-emmy's RA-2.** The ladder reserves L3 for a live non-destructive probe against the real surface; this is `spec-driven contract tests pass`, which L2 names exactly and which explicitly excludes an MCP connection being established. I had claimed L3 for a unit-level parser receipt — an evidence-class overclaim of the kind a reviewer should never have to catch twice.

## AC Evidence

| AC-1 | `an omitted contextual-default field is absent after parsing` — parses through `buildZodSchema(doc, doc.paths['/mailbox/messages'].post)` over the real document and asserts `wakeSuppressed` is absent. Carries a non-vacuity check that `to`/`subject` survived, so it cannot pass against a parser returning `{}`. |
| AC-2 | The same arm asserts `priority` absent. |
| AC-3 | **`priority` reaches its service-side branch.** Its precondition — the field arriving absent — is what AC-2 proves; the sender-class branch itself is `MailboxService.mjs:2410`, unchanged here and already covered by that service's own suite. The source comment added at `:2417` records why both branches depend on the schema declaring no default. |
| AC-4 | `an explicitly sent value still reaches the handler` — asserts `wakeSuppressed: false` and `priority: 'high'` survive parsing. **`false` specifically**, since it is the value the removed default injected: a fix that stripped falsy values instead of the declaration would pass AC-1 and fail this. |
| AC-5 | #10531's `list_messages` rows (`box`, `status`, `limit`, `offset`) are kept and newly commented as the deliberate contrast — those four have no competing service-side default, so their declared defaults are correct and must survive. A wholesale default-strip would pass AC-1/AC-2 and break them. |

## Deltas from ticket

- **#10531's test needed inverting, which the ticket did not anticipate.** `OpenApiValidatorCompliance.spec.mjs:509-510` asserted both removed defaults *as contract*. I inverted those two rows to assert absence with the reason attached, rather than deleting them — the test's general property ("declared defaults survive the Zod round-trip") is still right, and still asserted for the four fields where it belongs.
- No change to `openApiValidator.mjs`, as the ticket prescribed. Suppressing default materialisation globally would alter 31 other declared defaults to repair 2, and materialising a default is correct wherever no contextual default competes.

## Test Evidence

**Mutation, verified red by restoring both declarations:**

- shape arm → `Expected path: not "default" / Received value: "normal"`
- parse arm → `Expected path: not "wakeSuppressed" / Received value: false` — which is the materialisation itself, observed

**2597 passed** across `unit/ai/mcp` + `unit/ai/services/memory-core` after reverting the mutation. Both new arms and the inverted #10531 rows green.

## Post-Merge Validation

None. All five ACs on the close target are verified at this head and nothing is deferred.

The end-to-end observation — that a claim-class `AGENT:*` broadcast is *actually* stored suppressed — was **removed from #17648's Acceptance Criteria**, not deferred with a pointer. It cannot be observed from a merge, because the MC server runs from a built image and the parser change only takes effect after a deploy-home update and recreate. A close target whose ACs cannot all be met by its own PR either gets auto-closed dishonestly or blocks a correct fix indefinitely. It is the wake-noise *outcome*, which #17646's AC-1 already owns at a broader scope; this ticket owns the parser-observable cause.


Authored by Grace (Claude Opus 5, Claude Code). Origin Session ID: eb671e6e-ca17-4a53-8069-64fd5885ce84
