### PR TITLE
feat(agentos): promote exact manifest authority (#17645)

### DIFF
--- a/ai/scripts/diagnostics/agentOsExtractionInventory.json
+++ b/ai/scripts/diagnostics/agentOsExtractionInventory.json
@@ -1,10 +1,23 @@
 {
     "$schema": {
         "description": "Source-owned judgments for the C-prime AgentOS extraction inventory.",
-        "schemaVersion": "agentos-extraction-inventory.v2",
-        "runtimeProbeEligibility": "eligible means import and eager evaluation settle safely inside the disposable denial child; ineligible rows name the exact unguarded or external-work boundary"
+        "schemaVersion": "agentos-extraction-inventory.v3",
+        "runtimeProbeEligibility": "eligible means import and eager evaluation settle safely inside the disposable denial child; ineligible rows name the exact unguarded or external-work boundary",
+        "manifestAuthority": "launch-root targets and package declarations are exact identity populations; every package row names explicit engine/edge/cloud/shared manifestTargets and never relies on workspace hoisting"
     },
     "runtimeProbeEligibility": [
+        {
+            "identity": "ai/daemons/wake/daemon.mjs",
+            "eligibility": "eligible",
+            "source": "ai/daemons/wake/daemon.mjs:2831-2862",
+            "reason": "the direct-run guard contains config validation, database acquisition, polling, locks, and process exits; eager imports do not start the daemon"
+        },
+        {
+            "identity": "ai/mcp/server/neural-link/run-bridge.mjs",
+            "eligibility": "ineligible",
+            "source": "ai/mcp/server/neural-link/run-bridge.mjs:14-52",
+            "reason": "module scope parses argv and an unguarded async IIFE validates config, starts the persistent Bridge listener, and installs signal handlers"
+        },
         {
             "identity": "ai/scripts/agent-preflight.mjs",
             "eligibility": "eligible",
@@ -277,6 +290,235 @@
         }
     ],
     "overrides": [
+        {
+            "surface": "launch-root",
+            "identities": [
+                "ai/daemons/wake/daemon.mjs",
+                "ai/mcp/server/neural-link/run-bridge.mjs",
+                "ai/scripts/agent-preflight.mjs",
+                "ai/scripts/benchmark/gemma4-rem-benchmark.mjs",
+                "ai/scripts/benchmark/keep-alive-probe.mjs",
+                "ai/scripts/benchmark/provider-lane-election.mjs",
+                "ai/scripts/diagnostics/analyzeNlTelemetry.mjs",
+                "ai/scripts/diagnostics/audit-discussion-lifecycle.mjs",
+                "ai/scripts/diagnostics/bootstrapCodexSandbox.mjs",
+                "ai/scripts/diagnostics/check-identity-facts.mjs",
+                "ai/scripts/diagnostics/check-retired-primitives.mjs",
+                "ai/scripts/diagnostics/check-substrate-size.mjs",
+                "ai/scripts/diagnostics/defectObservations.mjs",
+                "ai/scripts/diagnostics/fleetHealthcheck.mjs",
+                "ai/scripts/diagnostics/gemini-incident-cost-ledger.mjs",
+                "ai/scripts/diagnostics/genesisProbe.mjs",
+                "ai/scripts/diagnostics/mcpHealthcheck.mjs",
+                "ai/scripts/diagnostics/providerLaneComposition.mjs",
+                "ai/scripts/diagnostics/seatCostReport.mjs",
+                "ai/scripts/diagnostics/structureMap.mjs",
+                "ai/scripts/fleet/devCockpit.mjs",
+                "ai/scripts/lifecycle/postReleaseSync.mjs",
+                "ai/scripts/lifecycle/revalidationSweep.mjs",
+                "ai/scripts/lint/check-commit-authorship.mjs",
+                "ai/scripts/lint/check-front-door-fingerprint.mjs",
+                "ai/scripts/lint/lint-adr-seam-table.mjs",
+                "ai/scripts/lint/lint-agents.mjs",
+                "ai/scripts/lint/lint-config-template-ssot.mjs",
+                "ai/scripts/lint/lint-fleet-vocabulary-parity.mjs",
+                "ai/scripts/lint/lint-guard-ci-parity.mjs",
+                "ai/scripts/lint/lint-guides.mjs",
+                "ai/scripts/lint/lint-identity-engine-coherence.mjs",
+                "ai/scripts/lint/lint-identity-vocabulary.mjs",
+                "ai/scripts/lint/lint-mcp-test-locations.mjs",
+                "ai/scripts/lint/lint-npm-script-entrypoints.mjs",
+                "ai/scripts/lint/lint-openapi-service-parity.mjs",
+                "ai/scripts/lint/lint-retry-bounds.mjs",
+                "ai/scripts/lint/lint-script-plane.mjs",
+                "ai/scripts/lint/lint-skill-manifest.mjs",
+                "ai/scripts/lint/lint-tree-json.mjs",
+                "ai/scripts/maintenance/communityBatchPushClient.mjs",
+                "ai/scripts/maintenance/kbPushClient.mjs",
+                "ai/scripts/maintenance/probeBusinessMetrics.mjs",
+                "ai/scripts/maintenance/probeCommunityActivityShadow.mjs",
+                "ai/scripts/maintenance/syncGithubWorkflow.mjs",
+                "ai/scripts/migrations/bootstrapWorktree.mjs",
+                "ai/scripts/runners/runAgent.mjs"
+            ],
+            "disposition": "edge",
+            "source": "readEntrypoints plus reconciled target custody at origin/dev f47f337809",
+            "rationale": "Host-Edge launch targets form the root manifest entrypoint population"
+        },
+        {
+            "surface": "launch-root",
+            "identities": [
+                "ai/daemons/embed/daemon.mjs",
+                "ai/daemons/message/daemon.mjs",
+                "ai/scripts/diagnostics/staleEmbeddingCensus.mjs",
+                "ai/scripts/lifecycle/backfill-memory-summaries.mjs",
+                "ai/scripts/lifecycle/summarize-sessions.mjs",
+                "ai/scripts/maintenance/aggregate-temporal-summary.mjs",
+                "ai/scripts/maintenance/auditGraphIntegrity.mjs",
+                "ai/scripts/maintenance/backup.mjs",
+                "ai/scripts/maintenance/backupCorruptionTimeline.mjs",
+                "ai/scripts/maintenance/buildKbAgentFaqs.mjs",
+                "ai/scripts/maintenance/checkChromaIntegrity.mjs",
+                "ai/scripts/maintenance/checkDetectionRetentionSla.mjs",
+                "ai/scripts/maintenance/communitySourceOperator.mjs",
+                "ai/scripts/maintenance/compactGraphLog.mjs",
+                "ai/scripts/maintenance/defragChromaDB.mjs",
+                "ai/scripts/maintenance/defragSQLiteDB.mjs",
+                "ai/scripts/maintenance/downloadKnowledgeBase.mjs",
+                "ai/scripts/maintenance/graphLifecycleReport.mjs",
+                "ai/scripts/maintenance/ingestTenant.mjs",
+                "ai/scripts/maintenance/migrationCensusReport.mjs",
+                "ai/scripts/maintenance/purgeNoContentGraphMemories.mjs",
+                "ai/scripts/maintenance/purgeTestCollections.mjs",
+                "ai/scripts/maintenance/restore.mjs",
+                "ai/scripts/maintenance/syncKnowledgeBase.mjs",
+                "ai/scripts/runners/runSandman.mjs"
+            ],
+            "disposition": "cloud",
+            "source": "readEntrypoints plus reconciled target custody at origin/dev f47f337809",
+            "rationale": "Container-Cloud launch targets form the nested Cloud manifest entrypoint population"
+        },
+        {
+            "surface": "launch-root",
+            "identities": [
+                "ai/scripts/benchmark/setupClass-cold-start.mjs"
+            ],
+            "disposition": "stays-engine",
+            "source": "readEntrypoints plus reconciled target custody at origin/dev f47f337809",
+            "rationale": "the Engine class-system benchmark remains with its measured subject"
+        },
+        {
+            "surface": "launch-root",
+            "identities": [
+                "ai/scripts/diagnostics/printAiConfig.mjs"
+            ],
+            "disposition": "retire",
+            "source": "ADR 0019 plus reconciled target custody at origin/dev f47f337809",
+            "rationale": "the mixed Tier-1 config diagnostic retires with its forbidden authority"
+        },
+        {
+            "surface": "package-dependency",
+            "identities": [
+                "package.json::devDependencies::@fortawesome/fontawesome-free",
+                "package.json::devDependencies::astring",
+                "package.json::devDependencies::autoprefixer",
+                "package.json::devDependencies::chalk",
+                "package.json::devDependencies::cssnano",
+                "package.json::devDependencies::envinfo",
+                "package.json::devDependencies::esbuild",
+                "package.json::devDependencies::highlightjs-line-numbers.js",
+                "package.json::devDependencies::html-minifier-terser",
+                "package.json::devDependencies::husky",
+                "package.json::devDependencies::inquirer",
+                "package.json::devDependencies::jsdoc-api",
+                "package.json::devDependencies::lint-staged",
+                "package.json::devDependencies::marked",
+                "package.json::devDependencies::mermaid",
+                "package.json::devDependencies::monaco-editor",
+                "package.json::devDependencies::parse5",
+                "package.json::devDependencies::postcss",
+                "package.json::devDependencies::sass",
+                "package.json::devDependencies::terser",
+                "package.json::devDependencies::webpack",
+                "package.json::devDependencies::webpack-cli",
+                "package.json::devDependencies::webpack-dev-server",
+                "package.json::devDependencies::webpack-hook-plugin"
+            ],
+            "disposition": "stays-engine",
+            "manifestTargets": [
+                "engine"
+            ],
+            "source": "AST devDependency importer census plus tool-usage census at origin/dev f47f337809",
+            "rationale": "Engine build, browser asset, contributor, and Engine-owned test declarations stay with the Engine package"
+        },
+        {
+            "surface": "package-dependency",
+            "identities": [
+                "package.json::devDependencies::@playwright/test",
+                "package.json::devDependencies::semver"
+            ],
+            "disposition": "stays-engine",
+            "manifestTargets": [
+                "engine",
+                "edge"
+            ],
+            "source": "subject-based test custody plus direct GitHub Workflow importer audit at origin/dev f47f337809",
+            "rationale": "the Engine keeps its test and release tooling while the AgentOS root independently declares the same packages for moved tests and Host-Edge workflow services"
+        },
+        {
+            "surface": "package-dependency",
+            "identities": [
+                "package.json::devDependencies::fast-glob"
+            ],
+            "disposition": "stays-engine",
+            "manifestTargets": [
+                "engine",
+                "cloud"
+            ],
+            "source": "direct Engine-build and Knowledge Base importer audit at origin/dev f47f337809",
+            "rationale": "the Engine retains its build declaration and the nested Cloud manifest independently declares the Knowledge Base dependency"
+        },
+        {
+            "surface": "package-dependency",
+            "identities": [
+                "package.json::devDependencies::acorn",
+                "package.json::devDependencies::commander",
+                "package.json::devDependencies::fs-extra",
+                "package.json::devDependencies::gray-matter",
+                "package.json::devDependencies::url"
+            ],
+            "disposition": "stays-engine",
+            "manifestTargets": [
+                "engine",
+                "edge",
+                "cloud"
+            ],
+            "source": "direct Engine plus both-plane importer audit joined to launch-target custody at origin/dev f47f337809",
+            "rationale": "all three independently installed roots consume these packages; explicit target membership replaces ancestor hoisting"
+        },
+        {
+            "surface": "package-dependency",
+            "identities": [
+                "package.json::devDependencies::@google/generative-ai",
+                "package.json::devDependencies::@modelcontextprotocol/sdk",
+                "package.json::devDependencies::dotenv",
+                "package.json::devDependencies::js-yaml",
+                "package.json::devDependencies::zod"
+            ],
+            "disposition": "edge",
+            "manifestTargets": [
+                "edge",
+                "cloud"
+            ],
+            "source": "direct Host-Edge and Container-Cloud importer audit at origin/dev f47f337809",
+            "rationale": "both AgentOS package roots declare these external dependencies independently; no physical shared-package or hoist meaning is implied"
+        },
+        {
+            "surface": "package-dependency",
+            "identities": [
+                "package.json::devDependencies::ws"
+            ],
+            "disposition": "edge",
+            "manifestTargets": [
+                "edge"
+            ],
+            "source": "direct Neural Link Bridge and ConnectionService importer audit at origin/dev f47f337809",
+            "rationale": "the Host-Edge Neural Link runtime owns the WebSocket dependency"
+        },
+        {
+            "surface": "package-dependency",
+            "identities": [
+                "package.brain.json::devDependencies::@chroma-core/default-embed",
+                "package.brain.json::devDependencies::better-sqlite3",
+                "package.brain.json::devDependencies::chromadb"
+            ],
+            "disposition": "cloud",
+            "manifestTargets": [
+                "cloud"
+            ],
+            "source": "package.brain.json durable-driver tier at origin/dev f47f337809",
+            "rationale": "the independently installed nested Cloud package owns every durable driver"
+        },
         {
             "surface": "script-module",
             "identities": [

--- a/ai/scripts/diagnostics/agentOsExtractionInventory.mjs
+++ b/ai/scripts/diagnostics/agentOsExtractionInventory.mjs
@@ -431,17 +431,24 @@ export function collectScriptModules({
  * rows. The target path is stable identity; npm/workflow/task channel and source name stay
  * evidence, so a channel correction does not manufacture a different executable while a target
  * substitution still changes identity. Custody follows the already-reconciled target module when
- * one exists, but remains an explicit registry judgment for task roots outside `ai/scripts`.
+ * one exists; task roots outside `ai/scripts` must carry their classifier's explicit suggestion,
+ * because emitting a null suggestion would silently disable the later authority-conflict guard.
  * @param {Object} options
  * @param {Object[]} options.launchRoots Output of `readEntrypoints()`.
  * @param {Map<String, Object>} options.scriptRowsByIdentity Reconciled script-module rows.
  * @returns {Object[]}
+ * @throws {Error} When a launch root has neither reconciled script-module custody nor an explicit
+ *     classifier suggestion.
  */
 export function collectLaunchRoots({launchRoots = [], scriptRowsByIdentity = new Map()} = {}) {
     return launchRoots.map(({name, plane = null, rel, suggestedDisposition = null, via}) => {
         const
             target            = scriptRowsByIdentity.get(rel),
             targetDisposition = target?.disposition ?? suggestedDisposition;
+
+        if (!targetDisposition) {
+            throw new Error(`collectLaunchRoots: launch root '${rel}' has no reconciled script-module custody or explicit suggestedDisposition`)
+        }
 
         return {
             surface : SURFACE.launchRoot,
@@ -856,6 +863,14 @@ export function reconcileInventory(derivedRows, registry, parseFailures = []) {
         if (entry.surface === SURFACE.packageDependency) {
             const targets = entry.manifestTargets;
 
+            // The physical shared source package reserves `shared` custody for its inventory-proven
+            // module population. A dependency may MATERIALIZE into the shared manifest, but letting its source
+            // declaration own shared custody would keep that package's empty-population retirement
+            // trigger unreachable.
+            if (entry.disposition === 'shared') {
+                errors.push({kind: 'shared-disposition-on-dependency', key})
+            }
+
             if (!Array.isArray(targets) || (targets.length === 0 && entry.disposition !== 'retire')) {
                 errors.push({kind: 'missing-manifest-targets', key})
             } else {
@@ -869,7 +884,6 @@ export function reconcileInventory(derivedRows, registry, parseFailures = []) {
                 const dispositionTarget = {
                     cloud         : 'cloud',
                     edge          : 'edge',
-                    shared        : 'shared',
                     'stays-engine': 'engine'
                 }[entry.disposition];
 

--- a/ai/scripts/diagnostics/agentOsExtractionInventory.mjs
+++ b/ai/scripts/diagnostics/agentOsExtractionInventory.mjs
@@ -56,11 +56,18 @@ const
     SCRIPT_PATH_RE          = /\bai\/scripts\/[A-Za-z0-9_./-]+\.mjs\b/g,
     WORKFLOW_ARTIFACT_RE    = /\b(?:test\/playwright\/unit\/)?ai\/scripts\/[A-Za-z0-9_./-]+\.(?:json|mjs)\b/g,
     VALID_DISPOSITIONS      = new Set(['cloud', 'edge', 'retire', 'shared', 'stays-engine']),
+    VALID_MANIFEST_TARGETS  = new Set(['cloud', 'edge', 'engine', 'shared']),
     VALID_PROBE_ELIGIBILITY = new Set(['eligible', 'ineligible']),
     LAUNCH_CALLEES          = new Set([
         'exec', 'execFile', 'execFileSync', 'execSync', 'fork', 'runCommand', 'spawn', 'spawnSync'
     ]),
     SUBPROCESS_SCAN_ROOTS   = ['.agents', '.claude', '.codex', 'ai', 'buildScripts', 'test'];
+
+const
+    DEPENDENCY_MANIFESTS = ['package.json', 'package.brain.json'],
+    DEPENDENCY_SECTIONS  = [
+        'dependencies', 'devDependencies', 'optionalDependencies', 'peerDependencies'
+    ];
 
 /**
  * Stable surface names in the machine receipt.
@@ -70,6 +77,8 @@ export const SURFACE = Object.freeze({
     closureEdge      : 'closure-edge',
     configAuthority  : 'config-authority',
     custodyBoundary  : 'custody-boundary',
+    launchRoot       : 'launch-root',
+    packageDependency: 'package-dependency',
     planeOpener      : 'plane-opener',
     rootScript       : 'root-script',
     scriptModule     : 'script-module',
@@ -366,6 +375,13 @@ export function collectScriptModules({
             }),
             plane    = resolved.plane ?? 'unresolved';
 
+        // Keep the owning closure/authority classifier's result on the exact launch population.
+        // H1 later promotes these objects into registry rows; retaining the result here lets task
+        // roots outside `ai/scripts` receive the same authority-conflict protection as resident
+        // script modules without re-running or copying the plane classifier.
+        entry.plane                = plane;
+        entry.suggestedDisposition = PLANE_DISPOSITIONS[plane] ?? null;
+
         closure.reached.forEach(absolutePath => {
             const relative = normalizePath(path.relative(projectRoot, absolutePath));
 
@@ -408,6 +424,202 @@ export function collectScriptModules({
     });
 
     return {rows, closureRows: [...closureRows.values()].sort(compareRows), launchRoots}
+}
+
+/**
+ * @summary Promotes the owning launch-root classifier's exact target population into inventory
+ * rows. The target path is stable identity; npm/workflow/task channel and source name stay
+ * evidence, so a channel correction does not manufacture a different executable while a target
+ * substitution still changes identity. Custody follows the already-reconciled target module when
+ * one exists, but remains an explicit registry judgment for task roots outside `ai/scripts`.
+ * @param {Object} options
+ * @param {Object[]} options.launchRoots Output of `readEntrypoints()`.
+ * @param {Map<String, Object>} options.scriptRowsByIdentity Reconciled script-module rows.
+ * @returns {Object[]}
+ */
+export function collectLaunchRoots({launchRoots = [], scriptRowsByIdentity = new Map()} = {}) {
+    return launchRoots.map(({name, plane = null, rel, suggestedDisposition = null, via}) => {
+        const
+            target            = scriptRowsByIdentity.get(rel),
+            targetDisposition = target?.disposition ?? suggestedDisposition;
+
+        return {
+            surface : SURFACE.launchRoot,
+            identity: rel,
+            source  : via === 'npm'
+                ? `package.json#scripts.${name}`
+                : via === 'task'
+                    ? `ai/daemons/orchestrator/taskDefinitions.mjs#${name}`
+                    : `.github/workflows launch target ${rel}`,
+            disposition: null,
+            rationale  : null,
+            evidence   : {
+                name,
+                plane,
+                target              : rel,
+                via,
+                suggestedDisposition: targetDisposition,
+                suggestedRationale  : targetDisposition ? `follows ${rel}` : null
+            }
+        }
+    }).sort(compareRows)
+}
+
+/**
+ * @summary Derives exact dependency-declaration rows from one parsed package manifest.
+ * Identity binds manifest, declaration section, and package name; version is evidence rather than
+ * identity so a version edit remains the same owned declaration while still changing the receipt.
+ * The Brain tier supplies a Cloud suggestion only; the registry remains final custody authority.
+ * @param {Object} options
+ * @param {Object} options.manifest Parsed package manifest.
+ * @param {String} options.manifestName Repository-relative manifest path.
+ * @returns {Object[]}
+ */
+export function inspectManifestDependencies({manifest = {}, manifestName}) {
+    const errors = [];
+
+    Object.keys(manifest).filter(key => /dependencies$/i.test(key) && !DEPENDENCY_SECTIONS.includes(key))
+        .forEach(key => errors.push({
+            kind : 'unsupported-dependency-section',
+            key  : `${manifestName}::${key}`,
+            error: 'dependency-bearing sections must enter the exact manifest population explicitly'
+        }));
+
+    const rows = DEPENDENCY_SECTIONS.flatMap(section => {
+        const declarations = manifest[section];
+
+        if (declarations === undefined) return [];
+        if (!declarations || typeof declarations !== 'object' || Array.isArray(declarations)) {
+            errors.push({
+                kind : 'invalid-dependency-section',
+                key  : `${manifestName}::${section}`,
+                error: 'expected a package-name to version object'
+            });
+            return []
+        }
+
+        return Object.entries(declarations)
+        .sort(([a], [b]) => a.localeCompare(b))
+        .map(([name, version]) => ({
+            surface    : SURFACE.packageDependency,
+            identity   : `${manifestName}::${section}::${name}`,
+            source     : `${manifestName}#${section}.${name}`,
+            disposition: null,
+            rationale  : null,
+            evidence   : {
+                manifest            : manifestName,
+                name,
+                section,
+                version,
+                suggestedDisposition: manifestName === 'package.brain.json' ? 'cloud' : null,
+                suggestedRationale  : manifestName === 'package.brain.json'
+                    ? 'the Brain install tier owns durable Cloud packages'
+                    : null
+            }
+        }))
+    }).sort(compareRows);
+
+    return {
+        rows,
+        errors: errors.sort((a, b) => `${a.kind}:${a.key}`.localeCompare(`${b.kind}:${b.key}`))
+    }
+}
+
+/**
+ * @summary Convenience projection for callers that already own manifest-read error handling.
+ * @param {Object} options See `inspectManifestDependencies()`.
+ * @returns {Object[]}
+ */
+export function collectManifestDependencyRows(options) {
+    return inspectManifestDependencies(options).rows
+}
+
+/**
+ * @summary Reads every current dependency manifest and install-bearing declaration section into
+ * one exact, disposition-ready population.
+ * Missing optional manifests contribute no rows; a future declaration inside either supported
+ * section enters the population automatically and fails reconciliation until it gains authority.
+ * @param {Object} [options]
+ * @param {String[]} [options.manifestNames=DEPENDENCY_MANIFESTS]
+ * @param {String} [options.projectRoot=PROJECT_ROOT]
+ * @returns {{rows: Object[], errors: Object[]}}
+ */
+export function collectPackageDependencies({
+    manifestNames = DEPENDENCY_MANIFESTS,
+    projectRoot   = PROJECT_ROOT
+} = {}) {
+    const rows = [], errors = [];
+
+    manifestNames.forEach(manifestName => {
+        const manifestPath = path.join(projectRoot, manifestName);
+
+        if (!fs.existsSync(manifestPath)) {
+            errors.push({kind: 'missing-dependency-manifest', key: manifestName});
+            return
+        }
+
+        let manifest;
+
+        try {
+            manifest = JSON.parse(fs.readFileSync(manifestPath, 'utf8'))
+        } catch (error) {
+            errors.push({kind: 'invalid-dependency-manifest', key: manifestName, error: error.message});
+            return
+        }
+
+        const inspected = inspectManifestDependencies({manifest, manifestName});
+
+        rows.push(...inspected.rows);
+        errors.push(...inspected.errors)
+    });
+
+    return {
+        rows  : rows.sort(compareRows),
+        errors: errors.sort((a, b) => `${a.kind}:${a.key}`.localeCompare(`${b.kind}:${b.key}`))
+    }
+}
+
+/**
+ * @summary Materializes the explicit dependency membership authority into independently installable
+ * manifest maps. A package may target multiple planes, but each target is named; no `shared`
+ * disposition is overloaded to mean duplication, and conflicting versions for one target fail.
+ * @param {Object[]} rows Reconciled package-dependency inventory rows.
+ * @returns {{manifests: Object<String, Object>, errors: Object[]}}
+ */
+export function composeDependencyManifests(rows = []) {
+    const
+        errors    = [],
+        manifests = Object.fromEntries([...VALID_MANIFEST_TARGETS].sort().map(target => [target, {}]));
+
+    rows.forEach(row => {
+        const {name, version} = row.evidence ?? {};
+
+        (row.manifestTargets ?? []).forEach(target => {
+            const previous = manifests[target]?.[name];
+
+            if (previous !== undefined && previous !== version) {
+                errors.push({
+                    kind : 'manifest-target-version-conflict',
+                    key  : `${target}::${name}`,
+                    error: `${previous} != ${version}`
+                });
+                return
+            }
+            if (manifests[target]) manifests[target][name] = version
+        })
+    });
+
+    Object.values(manifests).forEach(manifest => {
+        const sorted = Object.fromEntries(Object.entries(manifest).sort(([a], [b]) => a.localeCompare(b)));
+
+        Object.keys(manifest).forEach(key => delete manifest[key]);
+        Object.assign(manifest, sorted)
+    });
+
+    return {
+        manifests,
+        errors: errors.sort((a, b) => `${a.kind}:${a.key}`.localeCompare(`${b.kind}:${b.key}`))
+    }
 }
 
 /**
@@ -641,13 +853,48 @@ export function reconcileInventory(derivedRows, registry, parseFailures = []) {
         }
         if (typeof entry.source !== 'string' || !entry.source.trim()) errors.push({kind: 'missing-source', key});
 
+        if (entry.surface === SURFACE.packageDependency) {
+            const targets = entry.manifestTargets;
+
+            if (!Array.isArray(targets) || (targets.length === 0 && entry.disposition !== 'retire')) {
+                errors.push({kind: 'missing-manifest-targets', key})
+            } else {
+                const uniqueTargets = new Set(targets);
+
+                if (uniqueTargets.size !== targets.length) errors.push({kind: 'duplicate-manifest-target', key});
+                targets.filter(target => !VALID_MANIFEST_TARGETS.has(target)).forEach(target => {
+                    errors.push({kind: 'invalid-manifest-target', key: `${key}::${target}`})
+                });
+
+                const dispositionTarget = {
+                    cloud         : 'cloud',
+                    edge          : 'edge',
+                    shared        : 'shared',
+                    'stays-engine': 'engine'
+                }[entry.disposition];
+
+                if (dispositionTarget && !uniqueTargets.has(dispositionTarget)) {
+                    errors.push({kind: 'disposition-target-mismatch', key})
+                }
+                if (entry.disposition === 'retire' && uniqueTargets.size > 0) {
+                    errors.push({kind: 'retired-dependency-targeted', key})
+                }
+            }
+        }
+
         overrideMap.set(key, entry)
     }
 
     const rows = derivedRows.map(row => {
         const override = overrideMap.get(rowKey(row.surface, row.identity));
 
-        if (override && [SURFACE.rootScript, SURFACE.subprocessLaunch, SURFACE.workflowReference].includes(row.surface)
+        if (override && [
+            SURFACE.launchRoot,
+            SURFACE.packageDependency,
+            SURFACE.rootScript,
+            SURFACE.subprocessLaunch,
+            SURFACE.workflowReference
+        ].includes(row.surface)
             && row.evidence?.suggestedDisposition
             && override.disposition !== row.evidence.suggestedDisposition
             && override.allowDivergence !== true) {
@@ -663,6 +910,9 @@ export function reconcileInventory(derivedRows, registry, parseFailures = []) {
             disposition    : override.disposition,
             rationale      : override.rationale,
             authoritySource: override.source,
+            ...(row.surface === SURFACE.packageDependency
+                ? {manifestTargets: [...new Set(override.manifestTargets ?? [])].sort()}
+                : {}),
             evidence       : {...row.evidence, override: true}
         } : row
     });
@@ -703,17 +953,18 @@ export function reconcileInventory(derivedRows, registry, parseFailures = []) {
  * eligibility. Custody remains authoritative in the reconciled script rows; launch-root shape
  * merely selects which owned modules the paired proof may need to evaluate.
  * @param {Object} [options]
- * @param {Object[]} [options.launchRoots=[]]
- * @param {Object[]} [options.scriptRows=[]] Reconciled inventory rows.
+ * @param {Object[]} options.launchRootRows Reconciled launch-root inventory rows. This is
+ * authoritative at schema v3 and includes task roots outside the resident `ai/scripts` population.
  * @returns {String[]}
  */
-export function deriveRuntimeProbeTargets({launchRoots = [], scriptRows = []} = {}) {
-    const dispositionByIdentity = new Map(scriptRows
-        .filter(row => row.surface === SURFACE.scriptModule)
-        .map(row => [row.identity, row.disposition]));
+export function deriveRuntimeProbeTargets({launchRootRows} = {}) {
+    if (!Array.isArray(launchRootRows) || launchRootRows.length === 0) {
+        throw new Error('deriveRuntimeProbeTargets: schema v3 requires non-empty reconciled launch-root rows')
+    }
 
-    return [...new Set(launchRoots.map(row => row.rel).filter(Boolean))]
-        .filter(identity => dispositionByIdentity.get(identity) === 'edge')
+    return launchRootRows
+        .filter(row => row.surface === SURFACE.launchRoot && row.disposition === 'edge')
+        .map(row => row.identity)
         .sort()
 }
 
@@ -833,17 +1084,24 @@ export function buildInventory({
             resolveFallback: closureResolve
         }),
         preliminary                                  = reconcileInventory(scriptRows, registry),
+        scriptRowsByIdentity                         = new Map(preliminary.rows
+            .filter(row => row.surface === SURFACE.scriptModule)
+            .map(row => [row.identity, row])),
+        launchRootRows                               = collectLaunchRoots({launchRoots, scriptRowsByIdentity}),
+        dependencyPopulation                         = collectPackageDependencies({projectRoot}),
+        packageDependencyRows                        = dependencyPopulation.rows,
+        manifestPreliminary                          = reconcileInventory([
+            ...scriptRows,
+            ...launchRootRows,
+            ...packageDependencyRows
+        ], registry),
         runtimeProbeTargets                          = deriveRuntimeProbeTargets({
-            launchRoots,
-            scriptRows: preliminary.rows
+            launchRootRows: manifestPreliminary.rows
         }),
         runtimeProbeEligibility                      = reconcileRuntimeProbeEligibility(
             runtimeProbeTargets,
             registry
         ),
-        scriptRowsByIdentity                         = new Map(preliminary.rows
-            .filter(row => row.surface === SURFACE.scriptModule)
-            .map(row => [row.identity, row])),
         rootRows                             = collectRootScripts({projectRoot, scriptRowsByIdentity}),
         workflowRows                         = collectWorkflowReferences({projectRoot, scriptRowsByIdentity}),
         subprocess                           = collectSubprocessLaunches({projectRoot, scriptRowsByIdentity}),
@@ -852,6 +1110,8 @@ export function buildInventory({
         allDerived                           = [
             ...scriptRows,
             ...closureRows,
+            ...launchRootRows,
+            ...packageDependencyRows,
             ...rootRows,
             ...workflowRows,
             ...subprocess.rows,
@@ -869,8 +1129,9 @@ export function buildInventory({
         counts                               = {};
 
     reconciled.errors.push(...runtimeProbeEligibility.errors);
+    reconciled.errors.push(...dependencyPopulation.errors);
     reconciled.errors.sort((a, b) => `${a.kind}:${a.key}`.localeCompare(`${b.kind}:${b.key}`));
-    reconciled.ok &&= runtimeProbeEligibility.ok;
+    reconciled.ok &&= runtimeProbeEligibility.ok && dependencyPopulation.errors.length === 0;
 
     const bindingError = sourceBindingError(status, allowDirty);
 
@@ -887,8 +1148,17 @@ export function buildInventory({
             (surface.byDisposition[row.disposition ?? 'unclassified'] ?? 0) + 1
     });
 
+    const
+        reconciledLaunchRoots  = reconciled.rows.filter(row => row.surface === SURFACE.launchRoot),
+        reconciledDependencies = reconciled.rows.filter(row => row.surface === SURFACE.packageDependency),
+        dependencyManifests    = composeDependencyManifests(reconciledDependencies);
+
+    reconciled.errors.push(...dependencyManifests.errors);
+    reconciled.errors.sort((a, b) => `${a.kind}:${a.key}`.localeCompare(`${b.kind}:${b.key}`));
+    reconciled.ok &&= dependencyManifests.errors.length === 0;
+
     return {
-        schemaVersion: 'agentos-extraction-inventory.v2',
+        schemaVersion: 'agentos-extraction-inventory.v3',
         capturedAt,
         git          : {
             sha,
@@ -896,9 +1166,19 @@ export function buildInventory({
             dirtyPaths: status ? status.split('\n').map(line => line.slice(3)).sort() : []
         },
         launchRoots: {
-            total: launchRoots.length,
+            total: reconciledLaunchRoots.length,
             byVia: Object.fromEntries(Object.entries(Object.groupBy(launchRoots, row => row.via))
-                .map(([via, rows]) => [via, rows.length]))
+                .map(([via, rows]) => [via, rows.length])),
+            rows: reconciledLaunchRoots
+        },
+        packageDependencies: {
+            total     : reconciledDependencies.length,
+            byManifest: Object.fromEntries(Object.entries(Object.groupBy(
+                reconciledDependencies,
+                row => row.evidence.manifest
+            )).map(([manifest, rows]) => [manifest, rows.length])),
+            manifests: dependencyManifests.manifests,
+            rows     : reconciledDependencies
         },
         runtimeProbeEligibility,
         counts,
@@ -922,6 +1202,17 @@ export function formatInventory(report) {
     });
 
     const probe = report.runtimeProbeEligibility;
+
+    lines.push('', `launch-root identities: ${report.launchRoots.total}`);
+    report.launchRoots.rows.forEach(row => lines.push(
+        `  ${String(row.disposition).padEnd(12)} ${row.identity} — ${row.evidence.via}:${row.evidence.name}`
+    ));
+
+    lines.push('', `package-dependency identities: ${report.packageDependencies.total}`);
+    report.packageDependencies.rows.forEach(row => lines.push(
+        `  ${String(row.disposition).padEnd(12)} ${row.identity} @ ${row.evidence.version} ` +
+        `→ ${(row.manifestTargets ?? []).join('+')}`
+    ));
 
     lines.push('', `runtime-probe targets: ${probe.total} · eligible ${probe.byEligibility.eligible} · ` +
         `ineligible ${probe.byEligibility.ineligible}`);

--- a/test/playwright/unit/ai/scripts/diagnostics/agentOsExtractionInventory.spec.mjs
+++ b/test/playwright/unit/ai/scripts/diagnostics/agentOsExtractionInventory.spec.mjs
@@ -258,10 +258,55 @@ test.describe('agentOsExtractionInventory — exact population × explicit autho
         })]))
     });
 
-    test('RED: same-count launch-root substitution names the missing and stale targets', () => {
+    test('RED: launch-root collection refuses a task root without source custody', () => {
+        expect(() => collectLaunchRoots({
+            launchRoots: [{
+                name : 'wake-daemon',
+                plane: 'host-edge',
+                rel  : 'ai/daemons/wake/daemon.mjs',
+                via  : 'task'
+            }]
+        })).toThrow(
+            "collectLaunchRoots: launch root 'ai/daemons/wake/daemon.mjs' has no reconciled script-module custody or explicit suggestedDisposition"
+        )
+    });
+
+    test('RED: task-root authority cannot contradict its classifier custody', () => {
         const rows = collectLaunchRoots({
                   launchRoots: [{
-                      name: 'replacement', rel: 'ai/scripts/replacement.mjs', via: 'workflow'
+                      name                : 'wake-daemon',
+                      plane               : 'host-edge',
+                      rel                 : 'ai/daemons/wake/daemon.mjs',
+                      suggestedDisposition: 'edge',
+                      via                 : 'task'
+                  }]
+              }),
+              result = reconcileInventory(rows, {
+                  custody  : [],
+                  overrides: [{
+                      surface    : SURFACE.launchRoot,
+                      identities : ['ai/daemons/wake/daemon.mjs'],
+                      disposition: 'cloud',
+                      source     : 'fixture task-root authority',
+                      rationale  : 'fixture deliberately contradicts task-root custody'
+                  }]
+              });
+
+        expect(result.ok).toBe(false);
+        expect(result.errors).toContainEqual({
+            kind : 'authority-conflict',
+            key  : 'launch-root::ai/daemons/wake/daemon.mjs',
+            error: 'registry says cloud; target custody says edge'
+        })
+    });
+
+    test('RED: same-count launch-root substitution names the missing and stale targets', () => {
+        const rows = collectLaunchRoots({
+              launchRoots: [{
+                      name                : 'replacement',
+                      rel                 : 'ai/scripts/replacement.mjs',
+                      suggestedDisposition: 'edge',
+                      via                 : 'workflow'
                   }]
               }),
               result = reconcileInventory(rows, {
@@ -483,6 +528,40 @@ test.describe('agentOsExtractionInventory — exact population × explicit autho
             'invalid-manifest-target',
             'disposition-target-mismatch'
         ]))
+    });
+
+    test('RED: dependency custody cannot use the physical shared-package disposition', () => {
+        const row = collectManifestDependencyRows({
+                  manifest    : {devDependencies: {'shared-package': '1'}},
+                  manifestName: 'package.json'
+              })[0],
+              sharedCustody = reconcileInventory([row], {
+                  custody  : [],
+                  overrides: [{
+                      surface        : SURFACE.packageDependency,
+                      identities     : [row.identity],
+                      disposition    : 'shared',
+                      manifestTargets: ['shared'],
+                      source         : 'fixture shared-custody authority',
+                      rationale      : 'fixture deliberately overloads physical shared custody'
+                  }]
+              }),
+              sharedTarget = reconcileInventory([row], {
+                  custody  : [],
+                  overrides: [{
+                      surface        : SURFACE.packageDependency,
+                      identities     : [row.identity],
+                      disposition    : 'edge',
+                      manifestTargets: ['edge', 'shared'],
+                      source         : 'fixture Edge dependency authority',
+                      rationale      : 'fixture keeps shared as a materialization target only'
+                  }]
+              });
+
+        expect(sharedCustody.errors).toContainEqual({
+            kind: 'shared-disposition-on-dependency', key: `package-dependency::${row.identity}`
+        });
+        expect(sharedTarget.ok).toBe(true)
     });
 
     test('runtime-probe targets are every exact launch-root row whose custody is Edge', () => {

--- a/test/playwright/unit/ai/scripts/diagnostics/agentOsExtractionInventory.spec.mjs
+++ b/test/playwright/unit/ai/scripts/diagnostics/agentOsExtractionInventory.spec.mjs
@@ -5,9 +5,15 @@ import {fileURLToPath} from 'node:url';
 
 import {
     buildInventory,
+    collectLaunchRoots,
+    collectManifestDependencyRows,
+    collectPackageDependencies,
+    composeDependencyManifests,
     deriveRuntimeProbeTargets,
     discoverSubprocessLaunches,
     discoverWorkflowReferences,
+    formatInventory,
+    inspectManifestDependencies,
     listTrackedFiles,
     reconcileInventory,
     reconcileRuntimeProbeEligibility,
@@ -211,23 +217,295 @@ test.describe('agentOsExtractionInventory — exact population × explicit autho
         })
     });
 
-    test('runtime-probe targets are the unique launch roots whose explicit custody is Edge', () => {
+    test('launch-root rows retain exact target identity plus their owning channel evidence', () => {
+        const rows = collectLaunchRoots({
+            launchRoots: [{
+                name: 'ai:edge', rel: 'ai/scripts/edge.mjs', via: 'npm'
+            }, {
+                name                : 'wake-daemon',
+                plane               : 'host-edge',
+                rel                 : 'ai/daemons/wake/daemon.mjs',
+                suggestedDisposition: 'edge',
+                via                 : 'task'
+            }],
+            scriptRowsByIdentity: new Map([['ai/scripts/edge.mjs', {
+                disposition: 'edge'
+            }]])
+        });
+
+        expect(rows.map(row => row.identity)).toEqual([
+            'ai/daemons/wake/daemon.mjs',
+            'ai/scripts/edge.mjs'
+        ]);
+        expect(rows).toEqual(expect.arrayContaining([expect.objectContaining({
+            surface : SURFACE.launchRoot,
+            identity: 'ai/scripts/edge.mjs',
+            source  : 'package.json#scripts.ai:edge',
+            evidence: expect.objectContaining({
+                name: 'ai:edge', target: 'ai/scripts/edge.mjs', via: 'npm', suggestedDisposition: 'edge'
+            })
+        }), expect.objectContaining({
+            surface : SURFACE.launchRoot,
+            identity: 'ai/daemons/wake/daemon.mjs',
+            source  : 'ai/daemons/orchestrator/taskDefinitions.mjs#wake-daemon',
+            evidence: expect.objectContaining({
+                name                : 'wake-daemon',
+                plane               : 'host-edge',
+                target              : 'ai/daemons/wake/daemon.mjs',
+                via                 : 'task',
+                suggestedDisposition: 'edge'
+            })
+        })]))
+    });
+
+    test('RED: same-count launch-root substitution names the missing and stale targets', () => {
+        const rows = collectLaunchRoots({
+                  launchRoots: [{
+                      name: 'replacement', rel: 'ai/scripts/replacement.mjs', via: 'workflow'
+                  }]
+              }),
+              result = reconcileInventory(rows, {
+                  custody  : [],
+                  overrides: [{
+                      surface    : SURFACE.launchRoot,
+                      identities : ['ai/scripts/original.mjs'],
+                      disposition: 'edge',
+                      source     : 'fixture original launch authority',
+                      rationale  : 'original fixture launch target belongs to Edge'
+                  }]
+              });
+
+        expect(result.residue).toEqual({
+            diskMinusAuthority: ['launch-root::ai/scripts/replacement.mjs'],
+            authorityMinusDisk: ['launch-root::ai/scripts/original.mjs']
+        })
+    });
+
+    test('dependency identity binds manifest, section, and name while version remains evidence', () => {
+        const rows = [
+            ...collectManifestDependencyRows({
+                manifest: {
+                    dependencies   : {'edge-package': '^1.0.0'},
+                    devDependencies: {'test-package': '2.0.0'}
+                },
+                manifestName: 'package.json'
+            }),
+            ...collectManifestDependencyRows({
+                manifest    : {devDependencies: {'cloud-package': '3.0.0'}},
+                manifestName: 'package.brain.json'
+            })
+        ];
+
+        expect(rows.map(row => row.identity)).toEqual([
+            'package.json::dependencies::edge-package',
+            'package.json::devDependencies::test-package',
+            'package.brain.json::devDependencies::cloud-package'
+        ]);
+        expect(rows.find(row => row.identity.endsWith('cloud-package')).evidence)
+            .toEqual(expect.objectContaining({
+                manifest            : 'package.brain.json',
+                section             : 'devDependencies',
+                name                : 'cloud-package',
+                version             : '3.0.0',
+                suggestedDisposition: 'cloud'
+            }));
+
+        const changed = collectManifestDependencyRows({
+            manifest    : {dependencies: {'edge-package': '^9.0.0'}},
+            manifestName: 'package.json'
+        })[0];
+
+        expect(changed.identity).toBe('package.json::dependencies::edge-package');
+        expect(changed.evidence.version).toBe('^9.0.0')
+    });
+
+    test('RED: root and Brain dependency additions fail independently by exact identity', () => {
+        const authority = {
+                  custody  : [],
+                  overrides: [{
+                      surface        : SURFACE.packageDependency,
+                      identities     : ['package.json::devDependencies::edge-package'],
+                      disposition    : 'edge',
+                      manifestTargets: ['edge'],
+                      source         : 'fixture Edge manifest authority',
+                      rationale      : 'fixture package belongs to the Edge root'
+                  }, {
+                      surface        : SURFACE.packageDependency,
+                      identities     : ['package.brain.json::devDependencies::cloud-package'],
+                      disposition    : 'cloud',
+                      manifestTargets: ['cloud'],
+                      source         : 'fixture Cloud manifest authority',
+                      rationale      : 'fixture package belongs to the nested Cloud root'
+                  }]
+              },
+              baseRows  = [
+                  ...collectManifestDependencyRows({
+                      manifest    : {devDependencies: {'edge-package': '1'}},
+                      manifestName: 'package.json'
+                  }),
+                  ...collectManifestDependencyRows({
+                      manifest    : {devDependencies: {'cloud-package': '1'}},
+                      manifestName: 'package.brain.json'
+                  })
+              ],
+              addedRoot = reconcileInventory([...baseRows,
+                  ...collectManifestDependencyRows({
+                      manifest    : {dependencies: {'new-edge-package': '1'}},
+                      manifestName: 'package.json'
+                  })
+              ], authority),
+              addedBrain = reconcileInventory([...baseRows,
+                  ...collectManifestDependencyRows({
+                      manifest    : {dependencies: {'new-cloud-package': '1'}},
+                      manifestName: 'package.brain.json'
+                  })
+              ], authority);
+
+        expect(addedRoot.residue.diskMinusAuthority)
+            .toContain('package-dependency::package.json::dependencies::new-edge-package');
+        expect(addedBrain.residue.diskMinusAuthority)
+            .toContain('package-dependency::package.brain.json::dependencies::new-cloud-package')
+    });
+
+    test('RED: same-count dependency substitution names the missing and stale identities', () => {
+        const rows = collectManifestDependencyRows({
+                  manifest    : {devDependencies: {'replacement-package': '1'}},
+                  manifestName: 'package.json'
+              }),
+              result = reconcileInventory(rows, {
+                  custody  : [],
+                  overrides: [{
+                      surface        : SURFACE.packageDependency,
+                      identities     : ['package.json::devDependencies::original-package'],
+                      disposition    : 'edge',
+                      manifestTargets: ['edge'],
+                      source         : 'fixture original authority',
+                      rationale      : 'original fixture package belongs to Edge'
+                  }]
+              });
+
+        expect(result.residue).toEqual({
+            diskMinusAuthority: ['package-dependency::package.json::devDependencies::replacement-package'],
+            authorityMinusDisk: ['package-dependency::package.json::devDependencies::original-package']
+        })
+    });
+
+    test('RED: missing manifests and unsupported dependency-bearing sections fail closed', () => {
+        const missing = collectPackageDependencies({
+                  manifestNames: ['package.brain.json'],
+                  projectRoot  : path.join(REPO_ROOT, 'not-a-real-project-root')
+              }),
+              unsupported = inspectManifestDependencies({
+                  manifest    : {
+                      bundledDependencies: ['hidden-package'],
+                      devDependencies    : {'visible-package': '1'}
+                  },
+                  manifestName: 'package.json'
+              });
+
+        expect(missing.rows).toEqual([]);
+        expect(missing.errors).toContainEqual({
+            kind: 'missing-dependency-manifest', key: 'package.brain.json'
+        });
+        expect(unsupported.rows.map(row => row.identity))
+            .toEqual(['package.json::devDependencies::visible-package']);
+        expect(unsupported.errors).toContainEqual({
+            kind : 'unsupported-dependency-section',
+            key  : 'package.json::bundledDependencies',
+            error: 'dependency-bearing sections must enter the exact manifest population explicitly'
+        })
+    });
+
+    test('dependency manifest composition names every target plane without a shared-custody alias', () => {
+        const result = composeDependencyManifests([{
+            evidence       : {name: 'both-planes', version: '1'},
+            manifestTargets: ['edge', 'cloud']
+        }, {
+            evidence       : {name: 'engine-only', version: '2'},
+            manifestTargets: ['engine']
+        }]);
+
+        expect(result.errors).toEqual([]);
+        expect(result.manifests).toEqual({
+            cloud : {'both-planes': '1'},
+            edge  : {'both-planes': '1'},
+            engine: {'engine-only': '2'},
+            shared: {}
+        });
+
+        const conflict = composeDependencyManifests([{
+            evidence       : {name: 'same-package', version: '1'},
+            manifestTargets: ['edge']
+        }, {
+            evidence       : {name: 'same-package', version: '2'},
+            manifestTargets: ['edge']
+        }]);
+
+        expect(conflict.errors).toContainEqual({
+            kind : 'manifest-target-version-conflict',
+            key  : 'edge::same-package',
+            error: '1 != 2'
+        })
+    });
+
+    test('RED: package authority requires valid, unique manifest targets aligned to custody', () => {
+        const row = collectManifestDependencyRows({
+                  manifest    : {devDependencies: {'edge-package': '1'}},
+                  manifestName: 'package.json'
+              })[0],
+              missing = reconcileInventory([row], {
+                  custody  : [],
+                  overrides: [{
+                      surface    : SURFACE.packageDependency,
+                      identities : [row.identity],
+                      disposition: 'edge',
+                      source     : 'fixture missing membership authority',
+                      rationale  : 'fixture deliberately omits manifest targets'
+                  }]
+              }),
+              result = reconcileInventory([row], {
+                  custody  : [],
+                  overrides: [{
+                      surface        : SURFACE.packageDependency,
+                      identities     : [row.identity],
+                      disposition    : 'edge',
+                      manifestTargets: ['cloud', 'cloud', 'unknown'],
+                      source         : 'fixture invalid membership authority',
+                      rationale      : 'fixture deliberately contradicts Edge custody'
+                  }]
+              });
+
+        expect(missing.errors).toContainEqual({
+            kind: 'missing-manifest-targets', key: `package-dependency::${row.identity}`
+        });
+        expect(result.errors.map(error => error.kind)).toEqual(expect.arrayContaining([
+            'duplicate-manifest-target',
+            'invalid-manifest-target',
+            'disposition-target-mismatch'
+        ]))
+    });
+
+    test('runtime-probe targets are every exact launch-root row whose custody is Edge', () => {
         const targets = deriveRuntimeProbeTargets({
-            launchRoots: [
-                {rel: 'ai/scripts/edge.mjs'},
-                {rel: 'ai/scripts/cloud.mjs'},
-                {rel: 'ai/scripts/edge.mjs'}
-            ],
-            scriptRows: [{
-                surface: SURFACE.scriptModule, identity: 'ai/scripts/edge.mjs', disposition: 'edge'
+            launchRootRows: [{
+                surface: SURFACE.launchRoot, identity: 'ai/scripts/edge.mjs', disposition: 'edge'
             }, {
-                surface: SURFACE.scriptModule, identity: 'ai/scripts/cloud.mjs', disposition: 'cloud'
+                surface: SURFACE.launchRoot, identity: 'ai/scripts/cloud.mjs', disposition: 'cloud'
             }, {
-                surface: SURFACE.scriptModule, identity: 'ai/scripts/unlaunched.mjs', disposition: 'edge'
+                surface: SURFACE.launchRoot, identity: 'ai/daemons/wake/daemon.mjs', disposition: 'edge'
             }]
         });
 
-        expect(targets).toEqual(['ai/scripts/edge.mjs'])
+        expect(targets).toEqual(['ai/daemons/wake/daemon.mjs', 'ai/scripts/edge.mjs'])
+    });
+
+    test('RED: schema v3 runtime-probe derivation refuses absent launch-root authority', () => {
+        expect(() => deriveRuntimeProbeTargets()).toThrow(
+            'schema v3 requires non-empty reconciled launch-root rows'
+        );
+        expect(() => deriveRuntimeProbeTargets({launchRootRows: []})).toThrow(
+            'schema v3 requires non-empty reconciled launch-root rows'
+        )
     });
 
     test('runtime-probe authority reconciles one exact judgment per target', () => {
@@ -350,6 +628,8 @@ test.describe('agentOsExtractionInventory — exact population × explicit autho
                       fs.readFileSync(path.join(REPO_ROOT, file), 'utf8'), file
                   ));
 
+        const packageDependencies = collectPackageDependencies({projectRoot: REPO_ROOT}).rows;
+
         expect(first).toEqual(second);
         expect(resolveTrackedConfigSpecifier(
             './config.mjs',
@@ -363,7 +643,36 @@ test.describe('agentOsExtractionInventory — exact population × explicit autho
         expect(first.counts[SURFACE.rootScript].total).toBe(packageScripts.length);
         expect(first.counts[SURFACE.workflowReference].total).toBe(workflowReferences.length);
         expect(first.counts[SURFACE.planeOpener].total).toBe(censusPlaneOpeners({projectRoot: REPO_ROOT}).total);
-        expect(first.schemaVersion).toBe('agentos-extraction-inventory.v2');
+        expect(first.schemaVersion).toBe('agentos-extraction-inventory.v3');
+        expect(first.counts[SURFACE.launchRoot].total).toBe(first.launchRoots.total);
+        expect(first.launchRoots.rows.map(row => row.identity))
+            .toEqual(first.rows.filter(row => row.surface === SURFACE.launchRoot).map(row => row.identity));
+        expect(first.launchRoots.total).toBe(
+            Object.values(first.launchRoots.byVia).reduce((total, count) => total + count, 0)
+        );
+        expect(first.counts[SURFACE.packageDependency].total).toBe(packageDependencies.length);
+        expect(first.packageDependencies.byManifest).toEqual({
+            'package.brain.json': packageDependencies.filter(
+                row => row.evidence.manifest === 'package.brain.json'
+            ).length,
+            'package.json': packageDependencies.filter(
+                row => row.evidence.manifest === 'package.json'
+            ).length
+        });
+        expect(first.packageDependencies.manifests.edge).toEqual(expect.objectContaining({
+            '@modelcontextprotocol/sdk': expect.any(String),
+            '@playwright/test'         : expect.any(String),
+            ws                         : expect.any(String)
+        }));
+        expect(first.packageDependencies.manifests.cloud).toEqual(expect.objectContaining({
+            '@modelcontextprotocol/sdk': expect.any(String),
+            chromadb                   : expect.any(String)
+        }));
+        expect(first.packageDependencies.manifests.engine).toEqual(expect.objectContaining({
+            '@playwright/test': expect.any(String),
+            'fast-glob'       : expect.any(String)
+        }));
+        expect(first.packageDependencies.manifests.cloud.ws).toBeUndefined();
         expect(first.runtimeProbeEligibility.ok).toBe(true);
         expect(first.runtimeProbeEligibility.total).toBe(
             first.runtimeProbeEligibility.rows.length
@@ -372,11 +681,31 @@ test.describe('agentOsExtractionInventory — exact population × explicit autho
             first.runtimeProbeEligibility.byEligibility.ineligible).toBe(
             first.runtimeProbeEligibility.total
         );
+        expect(first.runtimeProbeEligibility.total).toBe(
+            first.launchRoots.rows.filter(row => row.disposition === 'edge').length
+        );
+        expect(first.runtimeProbeEligibility.rows).toEqual(expect.arrayContaining([
+            expect.objectContaining({
+                identity   : 'ai/daemons/wake/daemon.mjs',
+                eligibility: 'eligible'
+            }),
+            expect.objectContaining({
+                identity   : 'ai/mcp/server/neural-link/run-bridge.mjs',
+                eligibility: 'ineligible'
+            })
+        ]));
         first.runtimeProbeEligibility.rows.forEach(row => {
             expect(['eligible', 'ineligible']).toContain(row.eligibility);
             expect(row.reason).toBeTruthy();
             expect(row.source).toBeTruthy()
         });
+
+        const human = formatInventory(first);
+
+        expect(human).toContain('launch-root identities:');
+        expect(human).toContain('ai/daemons/wake/daemon.mjs — task:bridgeDaemon');
+        expect(human).toContain('package-dependency identities:');
+        expect(human).toContain('package.brain.json::devDependencies::better-sqlite3 @');
 
         const keys = first.rows.map(row => rowKey(row.surface, row.identity));
 
@@ -391,7 +720,13 @@ test.describe('agentOsExtractionInventory — exact population × explicit autho
         first.rows.filter(row => row.evidence?.override).forEach(row => {
             expect(row.authoritySource).toBeTruthy()
         });
+        first.packageDependencies.rows.forEach(row => {
+            expect(row.manifestTargets.length).toBeGreaterThan(0);
+            expect(row.disposition).not.toBe('shared')
+        });
         [
+            SURFACE.launchRoot,
+            SURFACE.packageDependency,
             SURFACE.rootScript,
             SURFACE.scriptModule,
             SURFACE.subprocessLaunch,


### PR DESCRIPTION
Resolves #17645

Promotes launch roots and package declarations from discarded counts into exact, registry-reconciled manifest authority for the #17533 plane-boundary proof. The v3 receipt now exposes 74 launch identities and 41 dependency identities with one source-custody disposition plus typed target-manifest materialization, and closes H2's two omitted Edge task roots.

Evidence: L2 (source-derived current-head receipt plus executable positive/mutation guards; no launch candidate executed) → L2 required (all eight close-target ACs govern static authority and deterministic receipt behavior). Residual: none.

## AC Evidence

| AC | Evidence |
|---|---|
| AC-1 | Exact launch-root population — `buildInventory().launchRoots` exposes 74 sorted rows at `3b27e09f11`: 62 npm, 5 workflow, 7 task; `same-count launch-root substitution` proves identity replacement REDs. |
| AC-2 | Exact dependency population — `packageDependencies` exposes all 41 current declarations: 38 from `package.json`, 3 from `package.brain.json`, with manifest/section/name/version fidelity. |
| AC-3 | Explicit zero-residue authority — v3 reports zero disk-minus-authority and zero authority-minus-disk; source custody is `32 stays-engine / 6 edge / 3 cloud`, while typed materialization is `engine 32 / edge 13 / cloud 14 / shared 0`. |
| AC-4 | Identity mutation controls — focused spec REDs missing/stale authority, duplicate/invalid rows, added identities, and same-count substitutions for launch and dependency populations. |
| AC-5 | Independent manifest mutations — root and Brain declaration additions RED independently; version changes retain stable identity while changing receipt evidence; missing manifests and unknown dependency-bearing sections fail closed; invalid/duplicate targets and target-version conflicts RED. |
| AC-6 | Deterministic human/JSON receipts — the committed exhaustive test proves repeat builds equal, sorted unique row keys, exact rows in both top-level JSON projections, typed manifest maps, and human output carrying every launch/dependency identity. |
| AC-7 | H2 population preservation and repair — all 45 prior judgments remain; runtime authority now consumes reconciled launch rows and governs all 47 Edge roots: 38 eligible / 9 ineligible, including guarded `wake/daemon.mjs` and unguarded `run-bridge.mjs`; absent v3 launch authority throws instead of falling back. |
| AC-8 | Existing substrate only — the diff modifies only `agentOsExtractionInventory.mjs`, its JSON registry, and its existing focused spec; no parallel census or new `.mjs` placement exists. |

## Deltas from ticket

- Exact launch authority exposed a live H2 omission: two Edge task roots outside `ai/scripts` were invisible to the script-module join. The body was corrected before implementation; v3 removes that fallback.
- A dependency multi-membership fork now has two explicit axes: one disjoint source-custody disposition plus typed `manifestTargets`. ADR 0040's `shared` remains the physical source package; no external dependency inflates it.
- Independent diff audit added fail-closed missing-manifest/unknown-section arms and the typed target-map model. The parent owner first misapplied the partition rule, then corrected the public ruling in place after checking ADR 0040's empty-`shared/` retirement trigger.

## Test Evidence

All coverage runs in CI.

## Post-Merge Validation

No post-merge validation is required for #17645; downstream v3 composition remains owned by #17533.

## Evolution

The lane began as count-to-row promotion. Exact launch custody immediately falsified H2's 45-target completeness claim, while dependency classification exposed a deeper representation fork. The final shape preserves partition arithmetic for source custody, keeps physical `shared/` empty, materializes multi-root dependency needs on a separate typed axis, and turns both reviewer-discovered omission paths into typed REDs.

Related: #17533

Related: #17500

Authored by Euclid (OpenAI GPT-5.6 Sol, Codex Desktop). Session 01a02ead-f0db-7b30-b4e2-54189808ab54.
