### PR TITLE
fix(memory-core): wake liveness distinguishes unreadable from not-running (#17647)

### DIFF
--- a/ai/services/memory-core/HealthService.mjs
+++ b/ai/services/memory-core/HealthService.mjs
@@ -419,9 +419,18 @@ export function buildProviderPrerequisiteBlock(cfg, env = process.env) {
  *   (we surface "I don't know" instead of conflating it with operator-tripped state).
  * - `gateTrippedAt` / `gateTrippedBy`: pass-through from the gate state file when
  *   present (null otherwise).
- * - `daemonRunning`: boolean. `true` when the heartbeat-liveness file mtime is within
- *   `heartbeatLivenessStaleMs()` (2× POLL_INTERVAL). `false` when missing or stale.
- * - `lastPulseAt`: ISO timestamp of the liveness file mtime, or `null` if absent.
+ * - `daemonRunning`: **tri-state**, the same discipline `subscription.armed` below applies. `true`
+ *   when the heartbeat-liveness file mtime is within `heartbeatLivenessStaleMs()` (2× POLL_INTERVAL);
+ *   `false` when the file is missing or stale — a measured negative; `null` when the file could not
+ *   be READ at all, which is not an answer and must never render as "not running".
+ * - `livenessReason`: `'observed'` | `'no-pulse-file'` | `'unreadable'`. Reports the OBSERVATION,
+ *   never a configuration verdict — this block reads one file and nothing else. `'no-pulse-file'`
+ *   is exactly `ENOENT`: the liveness file is absent. It does NOT mean the lane is disabled, and
+ *   cannot: `swarmHeartbeatEnabled` is never consulted here, so a configured-off lane and an
+ *   enabled lane that has not pulsed yet are the same absent file and stay indistinguishable in
+ *   this payload. What this field DOES separate is a read that answered from a read that could not
+ *   happen — previously both rendered as a measured `false`.
+ * - `lastPulseAt`: ISO timestamp of the liveness file mtime, or `null` if absent or unreadable.
  * - `secondsSinceLastPulse`: derived seconds since last pulse. Surfaces "alive but stalled" when
  *   `daemonRunning` is `false` but a previous mtime exists.
  *
@@ -433,9 +442,11 @@ export function buildProviderPrerequisiteBlock(cfg, env = process.env) {
  * producer is the Orchestrator's swarm-heartbeat lane. Present-and-fresh means the Orchestrator
  * daemon is polling.
  *
- * **Defensive defaults:** missing files / unreadable state surfaces sensible defaults
- * (`gateState: 'unknown'`, `daemonRunning: false`, `lastPulseAt: null`) WITHOUT throwing.
- * Aligns with the "surface, don't obscure" principle.
+ * **Defensive defaults:** missing files / unreadable state degrade WITHOUT throwing, but they
+ * degrade to DISTINGUISHABLE values — `gateState: 'unknown'`, and `daemonRunning: null` with
+ * `livenessReason: 'unreadable'` rather than a measured-looking `false`. "Surface, don't obscure"
+ * is only satisfied if the surfaced value cannot be mistaken for an observation; a defensive
+ * default that reads identically to a real reading obscures precisely when it matters most.
  *
  * - `subscription`: the caller-scoped arming verdict — whether THIS identity holds a wake
  *   subscription the receiver-manifest build would accept. `armed` is tri-state: `null` means the
@@ -446,7 +457,8 @@ export function buildProviderPrerequisiteBlock(cfg, env = process.env) {
  *
  * @param {Number|Date} [now=Date.now()] Time source for deterministic tests
  * @returns {Promise<{gateState: String, gateTrippedAt: String|null,
- *     gateTrippedBy: String|null, daemonRunning: Boolean, lastPulseAt: String|null,
+ *     gateTrippedBy: String|null, daemonRunning: Boolean|null, livenessReason: String,
+ *     lastPulseAt: String|null,
  *     secondsSinceLastPulse: Number|null,
  *     subscription: {armed: Boolean|null, reason: String}}>}
  * @see ai/scripts/lifecycle/wakeSafetyGate.mjs
@@ -476,9 +488,13 @@ export async function buildWakeFeaturesBlock(now = Date.now()) {
         // healthcheck observability surface even when the gate-state read path fails.
     }
 
+    // The absent-file case: `ENOENT` and nothing more. `false` is a measured answer — the file was
+    // looked for and is not there — but it says nothing about WHY, because no configuration is read
+    // here. Do not restate this as "the lane is disabled".
     let livenessBlock = {
         daemonRunning        : false,
         lastPulseAt          : null,
+        livenessReason       : 'no-pulse-file',
         secondsSinceLastPulse: null
     };
 
@@ -489,11 +505,25 @@ export async function buildWakeFeaturesBlock(now = Date.now()) {
         livenessBlock = {
             daemonRunning        : ageMs < heartbeatLivenessStaleMs(),
             lastPulseAt          : stat.mtime.toISOString(),
+            livenessReason       : 'observed',
             secondsSinceLastPulse: Math.floor(ageMs / 1000)
         };
     } catch (e) {
-        // ENOENT is the expected case when the daemon hasn't been started locally.
-        // Other errors (permission, etc.) also degrade gracefully to defaults.
+        // Only ENOENT means the file is absent. Anything else — a permission wall, a path that
+        // belongs to another container's realm — means the question could not be ASKED, and
+        // reporting that as `daemonRunning: false` is the same conflation `gateState` and
+        // `subscription.armed` already refuse: it renders an unobservable value as a measured
+        // negative. Separating "I looked and found nothing" from "I could not look" is the whole
+        // scope of this branch; WHY nothing is there needs a configuration read that does not
+        // happen in this block.
+        if (e?.code !== 'ENOENT') {
+            livenessBlock = {
+                daemonRunning        : null,
+                lastPulseAt          : null,
+                livenessReason       : 'unreadable',
+                secondsSinceLastPulse: null
+            }
+        }
     }
 
     return {...gateBlock, ...livenessBlock, subscription: await buildSubscriptionArmingBlock()};

--- a/test/playwright/unit/ai/services/memory-core/HealthService.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/HealthService.spec.mjs
@@ -2424,8 +2424,41 @@ test.describe('HealthService #10783 — buildWakeFeaturesBlock', () => {
 
         expect(result.gateState).toBe('enabled');
         expect(result.daemonRunning).toBe(false);
+        // `false` is the right answer here and must stay one: the file was looked for and is not
+        // there. It says nothing about WHY — no configuration is read in this block — so a
+        // configured-off lane and an enabled lane that has not pulsed are the same ENOENT. The arm
+        // below covers the case this one must NOT be confused with: a read that could not happen.
+        expect(result.livenessReason).toBe('no-pulse-file');
         expect(result.lastPulseAt).toBeNull();
         expect(result.secondsSinceLastPulse).toBeNull();
+    });
+
+    test('liveness path UNREADABLE → daemonRunning null, never a measured false', async () => {
+        const fs   = await import('fs/promises');
+        const path = await import('path');
+
+        await fs.writeFile(process.env.WAKE_GATE_FILE_PATH, JSON.stringify({
+            state: 'enabled', reason: '', trippedAt: null, trippedBy: null
+        }));
+
+        // A path whose PARENT is a regular file raises ENOTDIR — a non-ENOENT read failure needing
+        // no permission games and portable across CI hosts. Previously this rendered identically to
+        // the absent-file arm above, so "I looked and found nothing" and "I could not look" were one
+        // payload. That ambiguity sent a live wake-noise investigation down the wrong path:
+        // `daemonRunning: false` was read as exonerating the heartbeat, from an instrument that
+        // would have said the same thing had it been unable to see the heartbeat at all.
+        const blocker = path.join(tmpDir, `not-a-dir-${Date.now()}`);
+
+        await fs.writeFile(blocker, '');
+        AiConfig.setEnvOverride('NEO_HEARTBEAT_ALIVE_PATH', path.join(blocker, 'heartbeat.alive'));
+
+        const result = await buildWakeFeaturesBlock();
+
+        expect(result.daemonRunning).toBeNull();
+        expect(result.livenessReason).toBe('unreadable');
+        expect(result.lastPulseAt).toBeNull();
+        // The gate still reads: one unreadable field must not collapse the rest of the block.
+        expect(result.gateState).toBe('enabled')
     });
 
     test('liveness file stalled (mtime > 10min) → daemonRunning false, lastPulseAt populated', async () => {
@@ -2457,6 +2490,11 @@ test.describe('HealthService #10783 — buildWakeFeaturesBlock', () => {
             gateTrippedAt        : null,
             gateTrippedBy        : null,
             daemonRunning        : false,
+            // Names what the read actually did. `no-pulse-file` is exactly ENOENT — never a claim
+            // about configuration, which this block does not consult. It separates a read that
+            // answered from one that could not happen, the same conflation the subscription note
+            // below refuses, one field over.
+            livenessReason       : 'no-pulse-file',
             lastPulseAt          : null,
             secondsSinceLastPulse: null,
             // Arming reports `null`, never `false`, when it cannot determine: a healthcheck with no


### PR DESCRIPTION
Resolves #17647

`healthcheck.features.wake` reported `gateState: 'unknown', daemonRunning: false, lastPulseAt: null` for three different worlds — a heartbeat **deliberately disabled** (the default), one **enabled and dead**, and one whose liveness file simply **cannot be read** from the reader's realm. The `catch` swallowed every `fs.stat` failure into the same measured-looking `false`.

`daemonRunning` is now tri-state, with a `livenessReason` naming which world produced it: `observed` | `no-pulse-file` | `unreadable`. An absent file still reports `false` — that *is* the answer when a lane never pulsed — and only a genuine read failure reports `null`.

**This is not a new discipline; it is the one already in the same function.** `subscription.armed` three lines below is tri-state, and the existing shape test's own comment says claiming *"not armed"* when the question cannot be answered *"would manufacture an alarm out of a missing instrument rather than a real condition."* `gateState` makes the same distinction for its own sentinel. `daemonRunning` was the one field in the block that did not.

**Why it mattered:** the ambiguity made the swarm heartbeat a plausible cause of A2A wake noise it had nothing to do with, and the payload could not settle it either way. Reading `daemonRunning: false` as exonerating was correct *by luck* — the instrument would have reported identically had the heartbeat been the cause. The real answer came from config defaults, `docker inspect`, and the orchestrator's logs.

Evidence: L2 achieved (spec-driven contract test over the real `buildWakeFeaturesBlock`, verified red under mutation) → L2 required (every AC is unit-observable). Residual: none.

## AC Evidence

| AC-1 | An unreadable liveness path reports `daemonRunning: null`, never `false` — asserted by **making the path unreadable**, not by reading the code branch. Uses `ENOTDIR` (a path under a regular file): a non-`ENOENT` failure needing no permission games and portable across hosts. |
| AC-2 | The payload names what the read did — `observed` \| `no-pulse-file` \| `unreadable` — and `no-pulse-file` is defined as exactly `ENOENT` in the docblock, the inline comment and the absent-file arm's comment. |
| AC-3 | **The non-vacuity control already existed** and is kept: `gate enabled + liveness fresh → daemonRunning true` in the same suite. Without a passing `true`, every other arm passes against a block that is permanently and uninformatively "off". |
| AC-4 | No durable prose claims the payload separates a configured-off lane from an enabled-but-silent one. Verified by grep across the changed source and spec: zero hits for the earlier "disabled on purpose" / "three worlds" framing. |

## Deltas from ticket

**The ticket was narrowed rather than the PR widened** (@neo-gpt-emmy's RA-1). #17647 originally asked for four things, of which this delivers one plus its honesty constraints; a `Resolves` target cannot be shrunk by a Deltas paragraph, so the ticket's title, Problem, Fix, Contract Ledger and ACs were rewritten to the observation contract this code actually ships, and the configuration surface was **dropped with its reasoning recorded** — not parked behind a pointer.

**RA-2 removed a real overclaim, and it was the same class of error this ticket exists to fix.** My first draft said `livenessReason` distinguishes *disabled*, *dead* and *unreadable*. It does not: the block reads one file and no configuration, so a configured-off lane and an enabled lane that has never pulsed are the same `ENOENT`. I had asserted a distinction my own instrument does not make — in a change whose entire subject is a payload asserting a distinction it does not make. Corrected in the docblock, the inline comments, both test comments and the commit body.

## Test Evidence

**Mutation, verified red** by removing the `e?.code !== 'ENOENT'` guard so every failure falls through to the default:

```
Error: expect(received).toBeNull()
Received: false
```

That is the defect observed directly, not a proxy for it.

**2598 passed** across `unit/ai/services/memory-core` + `unit/ai/mcp` after restoring.

No consumer reads `daemonRunning` as a boolean — a whole-tree grep returns one docblock mention in `SwarmHeartbeatService.mjs:58` and no code path — so the tri-state widening breaks nothing downstream.

## Post-Merge Validation

None. All ACs are verified at this head and nothing is deferred.

Authored by Grace (Claude Opus 5, Claude Code). Origin Session ID: eb671e6e-ca17-4a53-8069-64fd5885ce84
