### PR TITLE
feat(agentos): the PLANE-ROOT lint — a private data root per checkout, named (#17651)

### DIFF
--- a/buildScripts/util/check-aiconfig-antipatterns.mjs
+++ b/buildScripts/util/check-aiconfig-antipatterns.mjs
@@ -102,15 +102,26 @@ export const ALLOWLIST = Object.freeze({
     // This set is a MIGRATION LEDGER, not a grandfather list — each entry is a site scheduled for
     // repair, and the set empties as they land. An entry here with no scheduled repair is a regression. `resources/content/**` targets are deliberately absent: they fork a corpus, not
     // the plane, so the predicate correctly never sees them.
+    // PLANE-ROOT census 2026-08-23: eight live sites, every one a known private-plane-root fork.
+    // This set is a MIGRATION LEDGER, not a grandfather list — each entry is a site scheduled for
+    // repair, and the set empties as they land. An entry here with no scheduled repair is a regression.
+    // `resources/content/**` targets are deliberately absent: they fork a corpus, not the plane, so
+    // the predicate correctly never sees them.
+    //
+    // Entries are `path::<exact source text>`, NOT bare paths. A bare path would exempt the whole
+    // file, so a NINTH site appearing inside one of these eight — the files most likely to grow one,
+    // since they already do plane-root math — would be dropped in silence and the ledger would still
+    // read as eight scheduled repairs. Site identity makes the exemption name what is exempt, so
+    // anything new stays red.
     'PLANE-ROOT': new Set([
-        'ai/examples/inspectGraph.mjs',
-        'ai/scripts/lifecycle/harnessLifecycle.mjs',
-        'ai/scripts/lifecycle/inflightLock.mjs',
-        'ai/scripts/lifecycle/resumeHarness.mjs',
-        'ai/scripts/lifecycle/wakeSafetyGate.mjs',
-        'ai/services/ConceptService.mjs',
-        'ai/services/fleet/FleetManager.mjs',
-        'ai/services/ingestion/ConceptDiscoveryService.mjs'
+        "ai/examples/inspectGraph.mjs::const dbPath = path.resolve(__dirname, '../../.neo-ai-data/neo-sqlite/knowledge-graph.sqlite');",
+        "ai/scripts/lifecycle/harnessLifecycle.mjs::const STATE_DIR = path.resolve(__dirname, '../../../.neo-ai-data/harness-state');",
+        "ai/scripts/lifecycle/inflightLock.mjs::return path.resolve(__dirname, `../../../.neo-ai-data/wake-daemon/inflight-${mode}-${cleanIdentity}.txt`);",
+        "ai/scripts/lifecycle/resumeHarness.mjs::const cooldownDir  = path.resolve(__dirname, '../../../.neo-ai-data/wake-daemon');",
+        "ai/scripts/lifecycle/wakeSafetyGate.mjs::return process.env.WAKE_GATE_FILE_PATH || path.resolve(__dirname, '../../../.neo-ai-data/wake-daemon/wake-safety-gate.json');",
+        "ai/services/ConceptService.mjs::return path.resolve(__dirname, '../../.neo-ai-data/concepts');",
+        "ai/services/fleet/FleetManager.mjs::return this.managedRoot || process.env.NEO_FLEET_MANAGED_ROOT || path.resolve(__dirname, '../../../.neo-ai-data/fleet/repos');",
+        "ai/services/ingestion/ConceptDiscoveryService.mjs::conceptsDir = ConceptService.defaultConceptsDir || path.resolve(__dirname, '../../../.neo-ai-data/concepts'),"
     ]),
     B3: new Set([
         'ai/mcp/server/BaseServer.mjs',
@@ -217,7 +228,22 @@ export function findAntipatterns(content) {
  * @returns {Object[]}
  */
 export function filterAllowlistedHits(hits, file, allowlist = ALLOWLIST) {
-    return hits.filter(({rule}) => !allowlist[rule]?.has(file))
+    return hits.filter(({rule, text}) => {
+        const entries = allowlist[rule];
+
+        if (!entries) return true;
+
+        // Two entry shapes, and the difference is muting a FILE versus muting a SITE. A bare path
+        // exempts every hit of that rule anywhere in the file — tolerable for a rule with two
+        // grandfathered entries, wrong for a migration ledger: a NINTH hit appearing inside one of
+        // the listed files would be dropped in silence, and those files are the ones already doing
+        // this kind of math, so they are the likeliest place for a ninth to appear.
+        //
+        // `path::<exact source text>` exempts one site and nothing else. Text rather than a line
+        // number deliberately: a line number decays on every edit above it, while the text changes
+        // exactly when the site changes — which is when a migration ledger SHOULD demand a re-look.
+        return !entries.has(file) && !entries.has(`${file}::${text}`)
+    })
 }
 
 function main() {
@@ -302,8 +328,13 @@ function main() {
             console.error('PLANE-ROOT: never anchor a `.neo-ai-data` path on the module\'s own `__dirname` — every');
             console.error('checkout then gets its OWN data root, the copies agree so nothing goes red, and the fork is');
             console.error('invisible until two of them disagree (worktrees already carry a private');
-            console.error('`.neo-ai-data/concepts`). Take the root as an injected parameter and resolve it through');
-            console.error('`resolvePlaneDataRoot({rootDir})`, which throws rather than guessing.');
+            console.error('`.neo-ai-data/concepts`). The remedy is NOT to call the canonical default helper: it');
+            console.error('returns the pre-binding default and ignores `NEO_PLANE_DATA_ROOT`, so a runtime consumer');
+            console.error('would write to the default path while the plane lives wherever configuration put it —');
+            console.error('a SILENT divergence replacing a visible one. The composing ENTRYPOINT reads and injects');
+            console.error('the resolved owning leaf (`AiConfig.plane.dataRoot`, `AiConfig.fleet.dataDir`, or');
+            console.error('`memoryCoreConfig.wakeDaemon.dataDir`); helpers take the root as a parameter and never');
+            console.error('import AiConfig.');
             console.error(`Genuinely unavoidable: "${ESCAPE_MARKER}: <reason>".`);
         }
         process.exit(1);

--- a/buildScripts/util/check-aiconfig-antipatterns.mjs
+++ b/buildScripts/util/check-aiconfig-antipatterns.mjs
@@ -55,6 +55,34 @@ export const A1_IMPORT_GATE = /^\s*import\s+[^;]*\b(?:AiConfig|Memory_Config)\b[
 export const A1_ENV_REDERIVATION = /^(?:const|let|var)\s[^;]*=\s*[^;]*\bprocess\.env\./;
 
 /*
+ * Rule PLANE-ROOT — a plane path re-derived from the module's OWN location. `path.resolve(__dirname, …)`
+ * landing inside `.neo-ai-data` gives every checkout a private data root: the copies agree, so
+ * nothing goes red, and the fork is invisible until two of them disagree. Nine worktrees already
+ * accumulated their own `.neo-ai-data/concepts` from exactly this shape.
+ *
+ * **The regex anchors on `path.resolve(__dirname` and NOT on the target text, and that is the whole
+ * design.** `codeMask` masks string and template contents, so a pattern anchored on `.neo-ai-data`
+ * would have its match index land inside a quoted literal and be suppressed as "not code" — the
+ * rule would be structurally unable to fire on the very sites it exists to catch. Anchoring on the
+ * call token puts the match index on executable code and lets the target test scan the rest of the
+ * line, which is also what makes TEMPLATE-LITERAL targets reachable:
+ * `path.resolve(__dirname, \`../../.neo-ai-data/wake-daemon/inflight-${mode}.txt\`)` is the one shape
+ * a string-literal predicate misses, and it is a live site (`ai/scripts/lifecycle/inflightLock.mjs`).
+ *
+ * **Why a descriptive id and not the next A-number.** ADR-0019 §3 Group A already spends A1-A9, // ticket-ref-ok: the ADR IS the naming authority this choice defers to
+ * so `A6` — the first free-looking slot — is `leaf+formula duplication` and would have given the
+ * shared catalog vocabulary two meanings. This class is genuinely absent from that catalog (it
+ * re-derives a ROOT, reading no config at all, which is why A1's two-signal rule structurally
+ * cannot see it), so naming it would be a catalog amendment — a gate this rule does not own.
+ * A descriptive id collides with nothing and survives whatever number the catalog later assigns.
+ *
+ * Ceiling, stated rather than discovered later: the target must appear on the SAME line as the
+ * call. A root assembled through an intermediate variable is out of reach for a line rule, and
+ * closing that needs AST work, not a longer regex.
+ */
+export const PLANE_ROOT_REDERIVATION = /\bpath\.(?:join|resolve)\s*\(\s*__dirname\b.*?\.neo-ai-data/;
+
+/*
  * Rule-scoped grandfathering: each rule carries its OWN set of repo-relative POSIX paths, so one
  * rule's existing-surface exemption can never widen another's — A5 keeps its zero-baseline ratchet
  * even inside files grandfathered for B3. A whole-file skip would silently exempt every rule at
@@ -70,6 +98,20 @@ export const ALLOWLIST = Object.freeze({
         'ai/services/fleet/devFleetServer.mjs'
     ]),
     A5: new Set(),
+    // PLANE-ROOT census 2026-08-23: eight live sites, every one a known private-plane-root fork.
+    // This set is a MIGRATION LEDGER, not a grandfather list — each entry is a site scheduled for
+    // repair, and the set empties as they land. An entry here with no scheduled repair is a regression. `resources/content/**` targets are deliberately absent: they fork a corpus, not
+    // the plane, so the predicate correctly never sees them.
+    'PLANE-ROOT': new Set([
+        'ai/examples/inspectGraph.mjs',
+        'ai/scripts/lifecycle/harnessLifecycle.mjs',
+        'ai/scripts/lifecycle/inflightLock.mjs',
+        'ai/scripts/lifecycle/resumeHarness.mjs',
+        'ai/scripts/lifecycle/wakeSafetyGate.mjs',
+        'ai/services/ConceptService.mjs',
+        'ai/services/fleet/FleetManager.mjs',
+        'ai/services/ingestion/ConceptDiscoveryService.mjs'
+    ]),
     B3: new Set([
         'ai/mcp/server/BaseServer.mjs',
         'ai/mcp/server/shared/logger.mjs'
@@ -78,11 +120,12 @@ export const ALLOWLIST = Object.freeze({
 
 const RULES = [
     {id: 'B3', pattern: new RegExp(B3_DEFENSIVE_CHAIN.source, 'g')},
-    {id: 'A5', pattern: new RegExp(A5_ENV_HELPER.source, 'g')}
+    {id: 'A5', pattern: new RegExp(A5_ENV_HELPER.source, 'g')},
+    {id: 'PLANE-ROOT', pattern: new RegExp(PLANE_ROOT_REDERIVATION.source, 'g')}
 ];
 
 /**
- * @summary Scans file content for the A1 / B3 / A5 config-read antipatterns whose root token sits in code.
+ * @summary Scans file content for the A1 / A5 / B3 / PLANE-ROOT antipatterns whose root token sits in code.
  *
  * Reuses the sibling guard's `codeMask` so an occurrence inside a string literal (a log message, a
  * spec title quoting the pattern) or a comment never flags — only executable defensive reads do.
@@ -256,7 +299,12 @@ function main() {
             console.error('fail loud (ADR-0019 §3/§5.1). A5: never a `hasEnvValue` helper — `leaf(default, env, type)`');
             console.error('owns the env-check (§5.2). A1: with AiConfig imported, never re-derive from process.env at');
             console.error('module level — read the resolved leaf at the use site (§5.5; pure-defaults modules WITHOUT');
-            console.error(`a config import are the sanctioned C1 shape). Genuinely unavoidable: "${ESCAPE_MARKER}: <reason>".`);
+            console.error('PLANE-ROOT: never anchor a `.neo-ai-data` path on the module\'s own `__dirname` — every');
+            console.error('checkout then gets its OWN data root, the copies agree so nothing goes red, and the fork is');
+            console.error('invisible until two of them disagree (worktrees already carry a private');
+            console.error('`.neo-ai-data/concepts`). Take the root as an injected parameter and resolve it through');
+            console.error('`resolvePlaneDataRoot({rootDir})`, which throws rather than guessing.');
+            console.error(`Genuinely unavoidable: "${ESCAPE_MARKER}: <reason>".`);
         }
         process.exit(1);
     }

--- a/test/playwright/unit/ai/buildScripts/util/check-aiconfig-antipatterns.spec.mjs
+++ b/test/playwright/unit/ai/buildScripts/util/check-aiconfig-antipatterns.spec.mjs
@@ -335,7 +335,7 @@ test.describe('check-aiconfig-antipatterns guard — A1 module-level env re-deri
  * documented blind spot that is already occupied.
  */
 test.describe('PLANE-ROOT — __dirname-derived plane roots', () => {
-    const a6 = source => findAntipatterns(source).filter(hit => hit.rule === 'PLANE-ROOT');
+    const planeRootHits = source => findAntipatterns(source).filter(hit => hit.rule === 'PLANE-ROOT');
 
     test('the rule id does not collide with ADR-0019 §3 Group A, which already spends A1-A9', () => {
         // `A6` is `leaf+formula duplication` in the catalog. A lint rule reusing that letter-number
@@ -347,67 +347,88 @@ test.describe('PLANE-ROOT — __dirname-derived plane roots', () => {
     });
 
     test('a STRING-literal plane target fires', () => {
-        expect(a6("const dir = path.resolve(__dirname, '../../../.neo-ai-data/harness-state');")).toHaveLength(1)
+        expect(planeRootHits("const dir = path.resolve(__dirname, '../../../.neo-ai-data/harness-state');")).toHaveLength(1)
     });
 
     test('a TEMPLATE-literal plane target fires — the shape a string-only predicate misses', () => {
         const source = 'return path.resolve(__dirname, `../../../.neo-ai-data/wake-daemon/inflight-${mode}-${id}.txt`);';
 
-        expect(a6(source)).toHaveLength(1)
+        expect(planeRootHits(source)).toHaveLength(1)
     });
 
     test('interpolation containing a CALL still fires — the target scan must not stop at a paren', () => {
         const source = 'const p = path.resolve(__dirname, `../../.neo-ai-data/x-${slug(name)}.json`);';
 
-        expect(a6(source)).toHaveLength(1)
+        expect(planeRootHits(source)).toHaveLength(1)
     });
 
     test('`path.join` fires as well as `path.resolve`', () => {
-        expect(a6("const p = path.join(__dirname, '../.neo-ai-data/concepts');")).toHaveLength(1)
+        expect(planeRootHits("const p = path.join(__dirname, '../.neo-ai-data/concepts');")).toHaveLength(1)
     });
 
     test('the nullable-override shape fires — an UNSET override forks exactly like no override', () => {
         const source = "const dir = Service.defaultDir || path.resolve(__dirname, '../../../.neo-ai-data/concepts');";
 
-        expect(a6(source)).toHaveLength(1)
+        expect(planeRootHits(source)).toHaveLength(1)
     });
 
     test('a JSDoc/comment mention never fires — the target token is masked, the call token is not', () => {
-        expect(a6(" * resolves a `__dirname`-relative `<repoRoot>/.neo-ai-data/fleet/repos` default")).toEqual([]);
-        expect(a6("// path.resolve(__dirname, '../../.neo-ai-data/concepts') is the shape we are removing")).toEqual([])
+        expect(planeRootHits(" * resolves a `__dirname`-relative `<repoRoot>/.neo-ai-data/fleet/repos` default")).toEqual([]);
+        expect(planeRootHits("// path.resolve(__dirname, '../../.neo-ai-data/concepts') is the shape we are removing")).toEqual([])
     });
 
     test('a `.neo-ai-data` path NOT anchored on __dirname never fires — an injected root is the sanctioned shape', () => {
-        expect(a6("const p = path.resolve(injectedRoot, '.neo-ai-data/sqlite/graph.sqlite');")).toEqual([])
+        expect(planeRootHits("const p = path.resolve(injectedRoot, '.neo-ai-data/sqlite/graph.sqlite');")).toEqual([])
     });
 
     test('a __dirname path that is NOT a plane target never fires — content roots fork a corpus, not the plane', () => {
-        expect(a6("const p = path.resolve(__dirname, '../../../resources/content/issues');")).toEqual([])
+        expect(planeRootHits("const p = path.resolve(__dirname, '../../../resources/content/issues');")).toEqual([])
     });
 
     test('the escape marker exempts a line, as it does for every other rule', () => {
         const source = `const p = path.resolve(__dirname, '../.neo-ai-data/x'); // ${ESCAPE_MARKER}`;
 
-        expect(a6(source)).toEqual([])
+        expect(planeRootHits(source)).toEqual([])
     });
 
-    test('POSITIVE CONTROL: the allowlist is a migration ledger that currently silences all eight live sites, and nothing else', () => {
+    test('POSITIVE CONTROL: the ledger silences all eight live SITES, and nothing else', () => {
         const sites = [...ALLOWLIST['PLANE-ROOT']];
 
         expect(sites).toHaveLength(8);
+        // Every entry is site-granular (`path::<source text>`), never a bare path — a bare path
+        // would mute the whole file and the growth arm below could not fail.
+        sites.forEach(entry => expect(entry).toContain('::'));
 
         // Every ledger entry must still be a REAL hit at head. An entry whose site was already
         // fixed silences a slot nobody is watching — the ledger has to shrink by deletion, not rot.
-        for (const site of sites) {
-            const hits = a6(fs.readFileSync(path.join(repoRoot, site), 'utf8'));
+        for (const entry of sites) {
+            const
+                file = entry.split('::')[0],
+                hits = planeRootHits(fs.readFileSync(path.join(repoRoot, file), 'utf8'));
 
-            expect(hits.length, `${site} is on the PLANE-ROOT ledger but no longer matches — delete the entry`).toBeGreaterThan(0);
-            expect(filterAllowlistedHits(hits, site)).toEqual([])
+            expect(hits.length, `${entry} is on the PLANE-ROOT ledger but no longer matches — delete the entry`).toBeGreaterThan(0);
+            expect(filterAllowlistedHits(hits, file)).toEqual([])
         }
     });
 
+    test('RATCHET: a NINTH site inside an already-listed file stays RED — the ledger proves growth, not just shrink', () => {
+        const
+            file   = 'ai/services/ConceptService.mjs',
+            source = `${fs.readFileSync(path.join(repoRoot, file), 'utf8')}
+const sneak = path.resolve(__dirname, '../../.neo-ai-data/sneaky');
+`,
+            hits   = planeRootHits(source),
+            kept   = filterAllowlistedHits(hits, file);
+
+        // A per-FILE exemption would drop both and CI would stay green while the ledger still read
+        // as eight scheduled repairs. `hits.length > 0` proves shrink; only this proves growth.
+        expect(hits).toHaveLength(2);
+        expect(kept).toHaveLength(1);
+        expect(kept[0].text).toContain('.neo-ai-data/sneaky')
+    });
+
     test('an unlisted file with the same shape is NOT silenced — the ledger is per-file, not a global mute', () => {
-        const hits = a6("const p = path.resolve(__dirname, '../.neo-ai-data/concepts');");
+        const hits = planeRootHits("const p = path.resolve(__dirname, '../.neo-ai-data/concepts');");
 
         expect(filterAllowlistedHits(hits, 'ai/services/SomeNewService.mjs')).toHaveLength(1)
     })

--- a/test/playwright/unit/ai/buildScripts/util/check-aiconfig-antipatterns.spec.mjs
+++ b/test/playwright/unit/ai/buildScripts/util/check-aiconfig-antipatterns.spec.mjs
@@ -324,3 +324,91 @@ test.describe('check-aiconfig-antipatterns guard — A1 module-level env re-deri
         expect(findAntipatterns(astralHeader + '/*😀 process.env.NEO_DB_PATH*/ const ok = true;\n')).toEqual([])
     })
 });
+
+/**
+ * @summary Red-proofs rule PLANE-ROOT — a plane path re-derived from the module's own `__dirname`.
+ *
+ * The template-literal arm is the load-bearing one. The census that produced this rule reported
+ * seven sites and its own stated ceiling was *"a string-target test will not catch a plane path
+ * assembled from a variable"* — the eighth site, `inflightLock.mjs`, is exactly that shape, so the
+ * caveat had a live inhabitant. A predicate that only handles quoted literals ships with a
+ * documented blind spot that is already occupied.
+ */
+test.describe('PLANE-ROOT — __dirname-derived plane roots', () => {
+    const a6 = source => findAntipatterns(source).filter(hit => hit.rule === 'PLANE-ROOT');
+
+    test('the rule id does not collide with ADR-0019 §3 Group A, which already spends A1-A9', () => {
+        // `A6` is `leaf+formula duplication` in the catalog. A lint rule reusing that letter-number
+        // for a different pattern gives the shared vocabulary two meanings.
+        const ids = findAntipatterns("const p = path.resolve(__dirname, '../.neo-ai-data/x');").map(hit => hit.rule);
+
+        expect(ids).toContain('PLANE-ROOT');
+        expect(ids.some(id => /^A[0-9]+$/.test(id))).toBe(false)
+    });
+
+    test('a STRING-literal plane target fires', () => {
+        expect(a6("const dir = path.resolve(__dirname, '../../../.neo-ai-data/harness-state');")).toHaveLength(1)
+    });
+
+    test('a TEMPLATE-literal plane target fires — the shape a string-only predicate misses', () => {
+        const source = 'return path.resolve(__dirname, `../../../.neo-ai-data/wake-daemon/inflight-${mode}-${id}.txt`);';
+
+        expect(a6(source)).toHaveLength(1)
+    });
+
+    test('interpolation containing a CALL still fires — the target scan must not stop at a paren', () => {
+        const source = 'const p = path.resolve(__dirname, `../../.neo-ai-data/x-${slug(name)}.json`);';
+
+        expect(a6(source)).toHaveLength(1)
+    });
+
+    test('`path.join` fires as well as `path.resolve`', () => {
+        expect(a6("const p = path.join(__dirname, '../.neo-ai-data/concepts');")).toHaveLength(1)
+    });
+
+    test('the nullable-override shape fires — an UNSET override forks exactly like no override', () => {
+        const source = "const dir = Service.defaultDir || path.resolve(__dirname, '../../../.neo-ai-data/concepts');";
+
+        expect(a6(source)).toHaveLength(1)
+    });
+
+    test('a JSDoc/comment mention never fires — the target token is masked, the call token is not', () => {
+        expect(a6(" * resolves a `__dirname`-relative `<repoRoot>/.neo-ai-data/fleet/repos` default")).toEqual([]);
+        expect(a6("// path.resolve(__dirname, '../../.neo-ai-data/concepts') is the shape we are removing")).toEqual([])
+    });
+
+    test('a `.neo-ai-data` path NOT anchored on __dirname never fires — an injected root is the sanctioned shape', () => {
+        expect(a6("const p = path.resolve(injectedRoot, '.neo-ai-data/sqlite/graph.sqlite');")).toEqual([])
+    });
+
+    test('a __dirname path that is NOT a plane target never fires — content roots fork a corpus, not the plane', () => {
+        expect(a6("const p = path.resolve(__dirname, '../../../resources/content/issues');")).toEqual([])
+    });
+
+    test('the escape marker exempts a line, as it does for every other rule', () => {
+        const source = `const p = path.resolve(__dirname, '../.neo-ai-data/x'); // ${ESCAPE_MARKER}`;
+
+        expect(a6(source)).toEqual([])
+    });
+
+    test('POSITIVE CONTROL: the allowlist is a migration ledger that currently silences all eight live sites, and nothing else', () => {
+        const sites = [...ALLOWLIST['PLANE-ROOT']];
+
+        expect(sites).toHaveLength(8);
+
+        // Every ledger entry must still be a REAL hit at head. An entry whose site was already
+        // fixed silences a slot nobody is watching — the ledger has to shrink by deletion, not rot.
+        for (const site of sites) {
+            const hits = a6(fs.readFileSync(path.join(repoRoot, site), 'utf8'));
+
+            expect(hits.length, `${site} is on the PLANE-ROOT ledger but no longer matches — delete the entry`).toBeGreaterThan(0);
+            expect(filterAllowlistedHits(hits, site)).toEqual([])
+        }
+    });
+
+    test('an unlisted file with the same shape is NOT silenced — the ledger is per-file, not a global mute', () => {
+        const hits = a6("const p = path.resolve(__dirname, '../.neo-ai-data/concepts');");
+
+        expect(filterAllowlistedHits(hits, 'ai/services/SomeNewService.mjs')).toHaveLength(1)
+    })
+});


### PR DESCRIPTION
Resolves #17651

Evidence: L2 (static lint over source, executed positive + negative controls against all eight live sites; no runtime surface) → L2 required (AC-1/AC-3/AC-5 govern static pattern detection and CI wiring). Residual: none.

> 🌿 A checkout can no longer quietly mint its own copy of the swarm's memory and look healthy doing it.

## AC Evidence

**All three of #17651's remaining ACs are certified here.** The eight site repairs split out to #17655 at 2026-08-23T21:27Z — they carry an ordering constraint (they must precede the Fleet Manager symlink removal) that a detector does not, so this ticket closes on the detector.

| AC | Proof |
|---|---|
| AC-1 | **ticket AC-1 — the predicate.** `PLANE_ROOT_REDERIVATION` + 12 arms. Fires on all eight live sites at the census line numbers; a script deriving `PROJECT_ROOT` with no plane target passes. Negative controls clean: a JSDoc mention (`codeMask`), a `.neo-ai-data` path from an injected root, and a `__dirname` path to `resources/content/**` |
| AC-2 | **ticket AC-5 — template-literal coverage.** Two arms: a plain template target, and one whose interpolation contains a CALL (`${slug(name)}`) so the target scan cannot stop at a paren. This is the shape the origin census missed, and its own stated ceiling predicted the miss |
| AC-3 | **ticket AC-3 — CI wiring + consequence message.** Already wired: `.github/workflows/aiconfig-antipattern-lint.yml:49` runs the checker and watches this exact file. The message now names the consequence — *"every checkout then gets its OWN data root … invisible until two of them disagree"* — plus the sanctioned remedy: the composing **entrypoint** reads and injects the resolved owning leaf (`AiConfig.plane.dataRoot`, `AiConfig.fleet.dataDir`, or `memoryCoreConfig.wakeDaemon.dataDir`), and helpers never import `AiConfig`. It explicitly does **not** teach `resolvePlaneDataRoot({rootDir})`: that returns the pre-binding default and ignores `NEO_PLANE_DATA_ROOT`, so following it would trade a visible per-checkout fork for a silent default-vs-configured one — inside a lint whose subject is silent divergence |

## Deltas from ticket

- **The remedy this lint teaches was corrected mid-review.** An earlier revision pointed at `resolvePlaneDataRoot({rootDir})`. @neo-gpt-emmy caught at #17655 intake that the helper returns the canonical default and reads no env, so a runtime consumer following it would silently ignore `NEO_PLANE_DATA_ROOT`. The checker's failure text and this body now name the entrypoint-injects-resolved-leaf shape instead.


- **The rule id is `PLANE-ROOT`, not the next A-number.** ADR-0019 §3 Group A spends A1-A9; `A6` is already `leaf+formula duplication`. This class is genuinely absent from that catalog (it re-derives a root and reads no config — which is *why* A1's two-signal rule cannot see it), so adding a catalog row would be an ADR-0019 amendment this PR does not own. A descriptive id collides with nothing and survives whatever number the catalog later assigns. Canonicalising it is a clean follow-up if the swarm wants it.
- **The allowlist is framed as a migration ledger with a rot guard.** The file's existing sets are grandfather lists; this one carries a positive-control arm asserting every entry *still matches at head*, so an entry whose site was already fixed fails the suite instead of silently muting a slot nobody watches.

## Test Evidence

`npx playwright test -c test/playwright/playwright.config.unit.mjs unit/ai/buildScripts/util/check-aiconfig-antipatterns.spec.mjs --workers=1` → **46 passed** (12 new).

`node buildScripts/util/check-aiconfig-antipatterns.mjs` → 776 files scanned, 0 new violations.

Positive controls, because a lint that passes by matching nothing is the trap this rule exists to avoid: the rule fires on all eight live sites at exactly the census line numbers, the allowlist filters those to zero, and three negative controls stay clean — a JSDoc mention (`codeMask`), a `.neo-ai-data` path from an injected root, and a `__dirname` path to `resources/content/**` (content roots fork a corpus, not the plane).

## Post-Merge Validation

None required — lint-only, no runtime surface. The eight live sites are unchanged and silenced by the ledger; AC-2 removes them one at a time.

Authored by Vega (Claude Opus 5, Claude Code). Session a59cef95-db0c-484b-91e1-95d0b2e9fbdd.

