### PR TITLE
fix(agentos): the lock had no leaf, so cwd became one

### DIFF
--- a/ai/configBase.mjs
+++ b/ai/configBase.mjs
@@ -266,6 +266,24 @@ class ConfigBase extends ConfigProvider {
              */
             wakeDaemonHeartbeatAlivePath: leaf(path.resolve(planeDataRootDefault, 'wake-daemon/heartbeat.alive'), 'NEO_HEARTBEAT_ALIVE_PATH', 'string', {planeMember: true}),
             /**
+             * Path to the heartbeat CONCURRENCY lock — the mutex `withHeartbeatLock` creates while
+             * expensive Agent OS work runs, and the absolute skip barrier the swarm-heartbeat lane
+             * honours until the stale-lock TTL expires. Distinct from the liveness sentinel above:
+             * that one is touched every pulse, this one only while work is in flight.
+             *
+             * A concurrency lock is only a lock while every contender addresses the same file, so
+             * this leaf exists to make that coordinate declared rather than ambient. Its consumer
+             * used a bare `.neo-ai-data/…` literal resolved against `process.cwd()`, which forked
+             * the mutex per launch directory — two runs of one checkout stopped serializing. The
+             * plane root is deliberately not its own member (see the anchor's note), so the lock
+             * needed a leaf of its own before the default could be removed.
+             *
+             * The default resolves to the same file the literal did for a repo-root invocation, so
+             * no live lock relocates; every other working directory is corrected.
+             * @type {string}
+             */
+            heartbeatConcurrencyLockPath: leaf(path.resolve(planeDataRootDefault, 'heartbeat-concurrency.lock'), 'NEO_HEARTBEAT_LOCK_PATH', 'string', {planeMember: true}),
+            /**
              * Fleet Manager supervision leaves: where per-agent harness instance homes live and
              * which binary each harness family launches. The lifecycle service reads these at the
              * use site (`FleetLifecycleService.getInstanceRoot` / `getHarnessBinaryPath`) — the
@@ -2548,6 +2566,7 @@ class ConfigBase extends ConfigProvider {
 export const PLANE_MEMBER_PATHS = Object.freeze([
     'auth.seatTokenRegistryPath',
     'wakeDaemonHeartbeatAlivePath',
+    'heartbeatConcurrencyLockPath',
     'fleet.dataDir',
     'fleet.instanceRoot',
     'engines.chroma.dataDirProd',

--- a/ai/daemons/orchestrator/services/SwarmHeartbeatService.mjs
+++ b/ai/daemons/orchestrator/services/SwarmHeartbeatService.mjs
@@ -22,8 +22,7 @@ import {
 } from '../../../scripts/lifecycle/wakeSafetyGate.mjs';
 import {
     inspectHeartbeatLock,
-    releaseHeartbeatLock,
-    HEARTBEAT_LOCK_PATH
+    releaseHeartbeatLock
 } from '../../../scripts/lifecycle/heartbeatLock.mjs';
 import {checkSunsetted as checkSunsettedScript} from '../../../scripts/lifecycle/checkSunsetted.mjs';
 import {normalizeAgentIdentityNodeId}           from '../../../graph/normalizeAgentIdentityNodeId.mjs';
@@ -65,6 +64,20 @@ const PUSH_CAPABLE_TARGETS     = Object.freeze(['mcp-notifications', 'a2a-webhoo
  */
 function heartbeatAlivePath() {
     return AiConfig.wakeDaemonHeartbeatAlivePath;
+}
+
+/**
+ * @summary Resolves the heartbeat CONCURRENCY lock path — the skip barrier, not the liveness file.
+ *
+ * `heartbeatLock.mjs` is deliberately Neo-free, so this entrypoint-side service supplies the
+ * coordinate it no longer defaults. Both contenders — the producer wrapping expensive work and this
+ * lane inspecting/clearing it — must read the same leaf, or the mutex stops being one.
+ *
+ * @returns {String}
+ * @see ai/scripts/lifecycle/heartbeatLock.mjs
+ */
+function heartbeatLockPath() {
+    return AiConfig.heartbeatConcurrencyLockPath;
 }
 
 /**
@@ -495,7 +508,7 @@ class SwarmHeartbeatService extends Base {
      * @protected
      */
     async checkHeartbeatLock() {
-        return inspectHeartbeatLock()
+        return inspectHeartbeatLock({lockPath: heartbeatLockPath()})
     }
 
     /**
@@ -504,7 +517,7 @@ class SwarmHeartbeatService extends Base {
      * @protected
      */
     async clearHeartbeatLock() {
-        return releaseHeartbeatLock()
+        return releaseHeartbeatLock({lockPath: heartbeatLockPath()})
     }
 
     /**
@@ -1273,9 +1286,9 @@ class SwarmHeartbeatService extends Base {
 export default Neo.setupClass(SwarmHeartbeatService);
 
 export {
-    HEARTBEAT_LOCK_PATH,
     DEFAULT_POLL_INTERVAL_MS,
     heartbeatAlivePath,
+    heartbeatLockPath,
     githubNotificationWakeStatePath,
     isGitHubRemoteUrl,
     extractPullRequestNumberFromNotificationUrl

--- a/ai/deploy/docker-compose.dev.yml
+++ b/ai/deploy/docker-compose.dev.yml
@@ -57,6 +57,7 @@ x-plane-env: &plane-env
   # Tier-1 members (ai/configBase.mjs PLANE_MEMBER_PATHS)
   NEO_AUTH_SEAT_TOKEN_REGISTRY_PATH: /app/.neo-ai-data-parity/seat-tokens/registry.json
   NEO_HEARTBEAT_ALIVE_PATH: /app/.neo-ai-data-parity/wake-daemon/heartbeat.alive
+  NEO_HEARTBEAT_LOCK_PATH: /app/.neo-ai-data-parity/heartbeat-concurrency.lock
   NEO_FLEET_DATA_DIR: /app/.neo-ai-data-parity/fleet
   NEO_FLEET_INSTANCE_ROOT: /app/.neo-ai-data-parity/fleet/instances
   NEO_CHROMA_DATA_DIR: /app/.neo-ai-data-parity/chroma/unified

--- a/ai/scripts/lifecycle/heartbeatLock.mjs
+++ b/ai/scripts/lifecycle/heartbeatLock.mjs
@@ -20,6 +20,11 @@
  * `AiConfig.heartbeatConcurrencyLockPath`. This module imports neither the class system nor the
  * config Provider, so its non-entrypoint consumers keep taking the coordinate as an argument.
  *
+ * **Upgrade window:** runs launched from a non-repo-root directory before this change wrote a lock
+ * under *that* directory. Nothing resolves those paths any more, so they are orphaned rather than
+ * stale — no reader means no TTL sweep, and they simply persist. A `.neo-ai-data/` tree sitting in
+ * an unexpected working directory is that archaeology, not a live lock, and is safe to delete.
+ *
  * @example
  *   node ai/scripts/lifecycle/heartbeatLock.mjs -- npx playwright test test/playwright/unit/foo.spec.mjs
  *

--- a/ai/scripts/lifecycle/heartbeatLock.mjs
+++ b/ai/scripts/lifecycle/heartbeatLock.mjs
@@ -4,25 +4,53 @@
  *
  * The fallback heartbeat is a watchdog, not a work scheduler. When an agent is already
  * executing expensive work, overlapping heartbeat pulses should skip rather than queue.
- * This helper owns the producer side of `.neo-ai-data/heartbeat-concurrency.lock`: create
- * the lock before the work starts and remove it in a `finally` block after the work ends.
+ * This helper owns the producer side of the heartbeat concurrency lock: create the lock
+ * before the work starts and remove it in a `finally` block after the work ends.
  *
  * The companion consumer is the Orchestrator swarm-heartbeat lane
  * (`ai/daemons/SwarmHeartbeatService.mjs`), which treats the lock as an absolute skip
  * barrier until the configured stale-lock TTL expires.
  *
+ * **`lockPath` is required, and that is the contract rather than an inconvenience.** A mutex only
+ * serializes while every contender addresses the same file, so the coordinate must be declared by
+ * whoever composes the call. The previous default was a bare `.neo-ai-data/…` literal resolved
+ * against `process.cwd()`: a run launched from a subdirectory, a worktree, or a scheduler with its
+ * own working directory took a *different* lock and overlapped the work this module exists to keep
+ * apart — silently, because both sides succeeded. The resolved coordinate is
+ * `AiConfig.heartbeatConcurrencyLockPath`. This module imports neither the class system nor the
+ * config Provider, so its non-entrypoint consumers keep taking the coordinate as an argument.
+ *
  * @example
  *   node ai/scripts/lifecycle/heartbeatLock.mjs -- npx playwright test test/playwright/unit/foo.spec.mjs
  *
  * @see ai/daemons/SwarmHeartbeatService.mjs
+ * @see ai/configBase.mjs `heartbeatConcurrencyLockPath`
  */
 import {spawn} from 'child_process';
 import fs      from 'fs-extra';
 import path    from 'path';
 import {fileURLToPath} from 'url';
 
-export const HEARTBEAT_LOCK_PATH = '.neo-ai-data/heartbeat-concurrency.lock';
 export const DEFAULT_STALE_LOCK_MS = 10 * 60 * 1000;
+
+/**
+ * @summary Fails a lock operation before it touches the filesystem when no coordinate was injected.
+ *
+ * Validation, not resolution: this module holds no fallback to fall back to. Throwing here rather
+ * than at the `fs` call keeps a missing injection a loud composition error instead of a lock
+ * quietly taken somewhere nobody else is looking.
+ * @param {String} lockPath
+ * @param {String} operation Name reported in the error, so the failing seam is identifiable.
+ * @returns {String} The validated lock path.
+ * @private
+ */
+function assertLockPath(lockPath, operation) {
+    if (!lockPath) {
+        throw new Error(`heartbeatLock: ${operation} requires an injected lockPath (AiConfig.heartbeatConcurrencyLockPath) — a cwd-relative default forks the mutex per launch directory`)
+    }
+
+    return lockPath
+}
 
 /**
  * @summary Creates the heartbeat concurrency lock before expensive Agent OS work starts.
@@ -32,14 +60,17 @@ export const DEFAULT_STALE_LOCK_MS = 10 * 60 * 1000;
  * heartbeat semantics.
  *
  * @param {object} [options]
- * @param {string} [options.lockPath=HEARTBEAT_LOCK_PATH] Lock file path consumed by the heartbeat.
+ * @param {string} options.lockPath Resolved lock file path consumed by the heartbeat. Required.
  * @param {object} [options.metadata] Diagnostic metadata for operators inspecting the lock.
  * @returns {Promise<string>} The created lock path.
+ * @throws {Error} When `lockPath` is absent — before any filesystem access.
  */
 export async function acquireHeartbeatLock({
-    lockPath = HEARTBEAT_LOCK_PATH,
+    lockPath,
     metadata = {}
 } = {}) {
+    assertLockPath(lockPath, 'acquireHeartbeatLock');
+
     await fs.ensureDir(path.dirname(lockPath));
     await fs.writeJson(lockPath, {
         createdAt: new Date().toISOString(),
@@ -57,10 +88,13 @@ export async function acquireHeartbeatLock({
  * signal handling, or prior cleanup by a stale-lock recovery path.
  *
  * @param {object} [options]
- * @param {string} [options.lockPath=HEARTBEAT_LOCK_PATH] Lock file path to remove.
+ * @param {string} options.lockPath Resolved lock file path to remove. Required.
  * @returns {Promise<void>}
+ * @throws {Error} When `lockPath` is absent — before any filesystem access.
  */
-export async function releaseHeartbeatLock({lockPath = HEARTBEAT_LOCK_PATH} = {}) {
+export async function releaseHeartbeatLock({lockPath} = {}) {
+    assertLockPath(lockPath, 'releaseHeartbeatLock');
+
     await fs.remove(lockPath)
 }
 
@@ -71,16 +105,21 @@ export async function releaseHeartbeatLock({lockPath = HEARTBEAT_LOCK_PATH} = {}
  * the same 30-minute recovery contract without relying on shell `stat` portability.
  *
  * @param {object} [options]
- * @param {string} [options.lockPath=HEARTBEAT_LOCK_PATH] Lock file path to inspect.
+ * @param {string} options.lockPath Resolved lock file path to inspect. Required.
  * @param {number} [options.staleAfterMs=DEFAULT_STALE_LOCK_MS] Stale-lock TTL.
  * @param {Date}   [options.now=new Date()] Time source for deterministic tests.
  * @returns {Promise<{active: Boolean, stale: Boolean, ageMs: Number|null}>}
+ * @throws {Error} When `lockPath` is absent — before any filesystem access. An inspect that
+ * silently reported `{active: false}` for a missing coordinate is the worst failure here: the
+ * caller reads "no lock held" and starts the work the lock exists to prevent.
  */
 export async function inspectHeartbeatLock({
-    lockPath = HEARTBEAT_LOCK_PATH,
+    lockPath,
     staleAfterMs = DEFAULT_STALE_LOCK_MS,
     now = new Date()
 } = {}) {
+    assertLockPath(lockPath, 'inspectHeartbeatLock');
+
     const stat = await fs.stat(lockPath).catch(() => null);
 
     if (!stat) {
@@ -159,6 +198,23 @@ function printUsage() {
     console.error('Usage: node ai/scripts/lifecycle/heartbeatLock.mjs -- <command> [args...]')
 }
 
+/**
+ * @summary Reads the resolved lock coordinate for the CLI entrypoint.
+ *
+ * Bootstraps Neo before `ai/config.mjs` because the Provider needs the class system, matching the
+ * order every other lifecycle entrypoint uses.
+ * @returns {Promise<String>} `AiConfig.heartbeatConcurrencyLockPath`.
+ * @private
+ */
+async function resolveConfiguredLockPath() {
+    await import('../../../src/Neo.mjs');
+    await import('../../../src/core/_export.mjs');
+
+    const {default: AiConfig} = await import('../../config.mjs');
+
+    return AiConfig.heartbeatConcurrencyLockPath
+}
+
 const isMain = process.argv[1] && fileURLToPath(import.meta.url) === path.resolve(process.argv[1]);
 
 if (isMain) {
@@ -171,7 +227,12 @@ if (isMain) {
         process.exit(2)
     }
 
-    runCommandWithHeartbeatLock(command, args).then(code => {
+    // The CLI IS the composing entrypoint, so it — and only it — resolves the member. The import is
+    // dynamic on purpose: a module-scope `import AiConfig` would load the Provider for every library
+    // consumer of this file, and those consumers are not entrypoints.
+    resolveConfiguredLockPath().then(lockPath =>
+        runCommandWithHeartbeatLock(command, args, {lockPath})
+    ).then(code => {
         process.exit(code)
     }).catch(error => {
         console.error(`heartbeatLock failed: ${error.message}`);

--- a/ai/scripts/lifecycle/swarmWakeCooldown.mjs
+++ b/ai/scripts/lifecycle/swarmWakeCooldown.mjs
@@ -19,23 +19,41 @@ import AiConfig                                 from '../../config.mjs';
 import memoryCoreConfig                         from '../../mcp/server/memory-core/config.mjs';
 import { writeInflightLock, clearInflightLock } from './inflightLock.mjs';
 
-const COOLDOWN_STATE_PATH = '.neo-ai-data/wake-daemon/swarm-wake-cooldown.json';
-const COOLDOWN_LOCK_PATH  = '.neo-ai-data/wake-daemon/swarm-wake-cooldown.lock';
+const COOLDOWN_STATE_FILE = 'swarm-wake-cooldown.json';
+const COOLDOWN_LOCK_FILE  = 'swarm-wake-cooldown.lock';
 
 /**
  * @summary Dispatch the cooldown-bounded swarm-wide wake for an all-agent-idle signal.
+ *
+ * `wakeDaemonDir` is required. A swarm-wide cooldown is shared state by definition, so the two
+ * files below must land in the resolved wake-daemon member and nowhere else: the previous
+ * cwd-relative literals gave every launch directory its own cooldown record, which does not
+ * enforce a cooldown — it enforces one per invocation site, and the suppression the TTL exists to
+ * produce silently stops happening.
+ *
  * @param {Object} signal All-agent-idle detector signal.
  * @param {Object} options
- * @param {String} options.wakeDaemonDir Resolved wake-daemon data member.
+ * @param {String} options.wakeDaemonDir Resolved wake-daemon data member. Required.
  * @returns {Promise<Object|void>} Dispatch outcome when the heartbeat lock implementation returns it.
+ * @throws {Error} When `wakeDaemonDir` is absent — before any filesystem access.
  */
 export async function swarmWakeCooldown(signal, {wakeDaemonDir}={}) {
+    // Ahead of the signal guards deliberately: a missing injection is a composition error, and one
+    // that only surfaces on the rare all-idle branch would stay invisible through every ordinary
+    // call — the same "silently wrong until it matters" shape the cwd-relative literals had.
+    if (!wakeDaemonDir) {
+        throw new Error('swarmWakeCooldown: wake-daemon directory must be injected by the composing entrypoint')
+    }
+
     if (!signal) {
         return {fired: false, reason: 'missing-signal'};
     }
     if (signal.allIdle !== true) {
         return {fired: false, reason: 'not-all-idle'};
     }
+
+    const cooldownStatePath = path.join(wakeDaemonDir, COOLDOWN_STATE_FILE),
+          cooldownLockPath  = path.join(wakeDaemonDir, COOLDOWN_LOCK_FILE);
 
     return withHeartbeatLock(async () => {
         // Cooldown TTL resolved from the wake-policy leaf (env NEO_SWARM_WAKE_COOLDOWN_SECONDS, 600s default).
@@ -44,8 +62,8 @@ export async function swarmWakeCooldown(signal, {wakeDaemonDir}={}) {
         const now        = Date.now();
 
         let state = {};
-        if (await fs.pathExists(COOLDOWN_STATE_PATH)) {
-            state = await fs.readJson(COOLDOWN_STATE_PATH).catch(() => ({}));
+        if (await fs.pathExists(cooldownStatePath)) {
+            state = await fs.readJson(cooldownStatePath).catch(() => ({}));
         }
 
         const lastFireAt        = state.last_fire_at_iso ? new Date(state.last_fire_at_iso).getTime() : 0;
@@ -92,11 +110,11 @@ export async function swarmWakeCooldown(signal, {wakeDaemonDir}={}) {
             ttl_seconds       : ttlSeconds
         };
 
-        await fs.ensureDir(path.dirname(COOLDOWN_STATE_PATH));
-        await fs.writeJson(COOLDOWN_STATE_PATH, state, { spaces: 2 });
+        await fs.ensureDir(path.dirname(cooldownStatePath));
+        await fs.writeJson(cooldownStatePath, state, { spaces: 2 });
 
         return {fired: true, coordinator, cycle_id: signal.cycle_id};
-    }, { lockPath: COOLDOWN_LOCK_PATH });
+    }, { lockPath: cooldownLockPath });
 }
 
 async function main() {

--- a/ai/scripts/lint/config-leaf-parity.json
+++ b/ai/scripts/lint/config-leaf-parity.json
@@ -246,6 +246,7 @@
         "heapObservation.maxSkewMs",
         "heapObservation.staleAfterMs",
         "heapObservation.writeIntervalMs",
+        "heartbeatConcurrencyLockPath",
         "knowledgeBase",
         "localModels",
         "localModels.chat",

--- a/buildScripts/util/check-aiconfig-antipatterns.mjs
+++ b/buildScripts/util/check-aiconfig-antipatterns.mjs
@@ -83,6 +83,45 @@ export const A1_ENV_REDERIVATION = /^(?:const|let|var)\s[^;]*=\s*[^;]*\bprocess\
 export const PLANE_ROOT_REDERIVATION = /\bpath\.(?:join|resolve)\s*\(\s*__dirname\b.*?\.neo-ai-data/;
 
 /*
+ * Rule PLANE-LITERAL — the sibling class PLANE-ROOT is structurally unable to see. A bare
+ * `'.neo-ai-data/…'` assigned straight to a name resolves against `process.cwd()`, so the fork is
+ * per LAUNCH DIRECTORY rather than per checkout: two runs of the SAME checkout disagree when one is
+ * started from a subdirectory, a worktree, an editor, or a scheduler with its own cwd. PLANE-ROOT
+ * requires the `path.join|resolve(__dirname` prefix by design, so no amount of ledger discipline on
+ * its population would ever surface these — the migration ledger empties, the rule reports clean,
+ * and the class survives.
+ *
+ * **Anchored on the ASSIGNMENT, not on the literal, for the reason PLANE-ROOT documents above.**
+ * Measured rather than assumed: across every `.neo-ai-data` occurrence in `ai/` + `buildScripts/`,
+ * the mask reports the opening quote as string in 100% of cases, so a predicate anchored on the
+ * quote or on the target text can never fire. The declaration keyword or the assigned name is the
+ * nearest preceding token that is real code.
+ *
+ * **Why the trailing slash is required.** It is the line between the plane's NAME and a plane PATH.
+ * `PLANE_DIR_NAME = '.neo-ai-data'` and `dataRootRelative: '.neo-ai-data'` are the canonical
+ * definitions this rule defers to — they are the authority, not a re-derivation of it. Requiring
+ * the separator excludes both by construction rather than by grandfathering, which keeps the ledger
+ * holding only genuine exceptions.
+ *
+ * **What it deliberately does NOT convict**, verified against the live population: anything joined
+ * onto an already-resolved root (`path.join(PROJECT_ROOT, …)`, `path.resolve(neoRoot, …)`,
+ * `os.homedir()`) — the literal is a fragment under an explicit anchor, which is the sanctioned
+ * shape; ignore-pattern list elements and classifier prefixes, which are not paths at all.
+ *
+ * **Ownership decides, not shape** — the one judgment this predicate cannot make. A cwd-relative
+ * path is CORRECT when the state it addresses is checkout-owned: `nightlyE2eRunner` is bound to one
+ * checkout by its own LaunchAgent plist, and moving its lock into a shared plane member would
+ * couple independent test runs across revisions. Those sites carry exact-site ledger entries with
+ * their reason, because the alternative — widening the predicate until it acquits them — would
+ * acquit the defects too.
+ *
+ * Ceiling, stated rather than discovered later: the literal must be the direct right-hand side of
+ * an assignment or default parameter. A literal reaching the filesystem through an object property,
+ * an array element, or a function argument is out of reach for this shape.
+ */
+export const PLANE_LITERAL_ASSIGNMENT = /(?:\b(?:const|let|var)\s+[\w$]+|[\w$]+\s*)=\s*['"`]\.neo-ai-data\//;
+
+/*
  * Rule-scoped grandfathering: each rule carries its OWN set of repo-relative POSIX paths, so one
  * rule's existing-surface exemption can never widen another's — A5 keeps its zero-baseline ratchet
  * even inside files grandfathered for B3. A whole-file skip would silently exempt every rule at
@@ -98,9 +137,30 @@ export const ALLOWLIST = Object.freeze({
         'ai/services/fleet/devFleetServer.mjs'
     ]),
     A5: new Set(),
-    // Zero baseline: all measured sites are repaired. A future migration may add only temporary,
-    // exact-site entries (`path::<source text>`), never a whole-file mute.
+    // Zero baseline for THIS rule's population — the `__dirname`-derived roots, and nothing wider.
+    // An empty set here is not evidence that the plane is unforked; PLANE-LITERAL below covers a
+    // class this rule is structurally unable to see, and neither rule reaches a root assembled
+    // through an intermediate variable. A future migration may add only temporary, exact-site
+    // entries (`path::<source text>`), never a whole-file mute.
     'PLANE-ROOT': new Set(),
+    // NOT a migration ledger — these three are PERMANENT acquittals, and the distinction matters
+    // because a shrinking ledger is a progress signal while these must never shrink to zero. Each
+    // addresses checkout-owned or explicitly-injected state, where a cwd-relative default is the
+    // correct shape; the entries are exact-site so the surrounding file keeps full coverage.
+    'PLANE-LITERAL': new Set([
+        // Bound to ONE checkout by `com.neomjs.nightly-e2e.plist` (`__NEO_REPO_ROOT__/.neo-ai-data/
+        // nightly-e2e/…`), its activation README's `git rev-parse --show-toplevel`, and repo-relative
+        // Playwright config + reporter outputs. Two checkouts hold different code and different
+        // results, so a shared plane lock would couple independent test runs across revisions.
+        "ai/scripts/lifecycle/nightlyE2eRunner.mjs::const STATE_DIR     = '.neo-ai-data/nightly-e2e',",
+        // A relative FRAGMENT under an explicit root, not an ambient path: `buildProbePaths` throws
+        // `Missing projectRoot.` when the root is absent and resolves via `path.resolve(projectRoot,
+        // sqliteDir)`; the CLI passes `resolveCliProjectRoot()`.
+        "ai/scripts/diagnostics/bootstrapCodexSandbox.mjs::export const DEFAULT_SQLITE_DIR = '.neo-ai-data/sqlite';",
+        // Documented-deliberate: the configured builder injects the resolved `engines.chroma.dataDir`
+        // leaf (JSDoc at the parameter), and the literal default keeps direct callers launch-resilient.
+        "ai/daemons/orchestrator/taskDefinitions.mjs::chromaDataDir = '.neo-ai-data/chroma/unified',"
+    ]),
     B3: new Set([
         'ai/mcp/server/BaseServer.mjs',
         'ai/mcp/server/shared/logger.mjs'
@@ -110,11 +170,12 @@ export const ALLOWLIST = Object.freeze({
 const RULES = [
     {id: 'B3', pattern: new RegExp(B3_DEFENSIVE_CHAIN.source, 'g')},
     {id: 'A5', pattern: new RegExp(A5_ENV_HELPER.source, 'g')},
-    {id: 'PLANE-ROOT', pattern: new RegExp(PLANE_ROOT_REDERIVATION.source, 'g')}
+    {id: 'PLANE-ROOT', pattern: new RegExp(PLANE_ROOT_REDERIVATION.source, 'g')},
+    {id: 'PLANE-LITERAL', pattern: new RegExp(PLANE_LITERAL_ASSIGNMENT.source, 'g')}
 ];
 
 /**
- * @summary Scans file content for the A1 / A5 / B3 / PLANE-ROOT antipatterns whose root token sits in code.
+ * @summary Scans file content for the A1 / A5 / B3 / PLANE-ROOT / PLANE-LITERAL antipatterns whose root token sits in code.
  *
  * Reuses the sibling guard's `codeMask` so an occurrence inside a string literal (a log message, a
  * spec title quoting the pattern) or a comment never flags — only executable defensive reads do.

--- a/test/playwright/unit/ai/buildScripts/util/check-aiconfig-antipatterns.spec.mjs
+++ b/test/playwright/unit/ai/buildScripts/util/check-aiconfig-antipatterns.spec.mjs
@@ -417,3 +417,126 @@ test.describe('PLANE-ROOT — __dirname-derived plane roots', () => {
         expect(filterAllowlistedHits(hits, 'ai/services/SomeNewService.mjs')).toHaveLength(1)
     })
 });
+
+/**
+ * @summary Red-proofs rule PLANE-LITERAL — a bare `.neo-ai-data/…` literal resolved against cwd.
+ *
+ * The sibling above requires a `path.join|resolve(__dirname` prefix, so it is structurally unable
+ * to see this class: its ledger could empty, its arms could all pass, and the plane would still
+ * fork. The blast radius is worse, too — a `__dirname` fork is stable per checkout, so two runs
+ * from one clone agree; a cwd fork means two runs of the SAME clone disagree.
+ *
+ * The acquittal arms carry as much weight as the conviction arms here. A widened rule's first
+ * failure mode is convicting the cases the census just cleared, and three live sites are correct
+ * as written because the state they address is checkout-owned rather than plane-owned.
+ */
+test.describe('PLANE-LITERAL — cwd-relative plane literals', () => {
+    const planeLiteralHits = source => findAntipatterns(source).filter(hit => hit.rule === 'PLANE-LITERAL');
+
+    test('the pre-repair source of BOTH #17660 repair sites fires', () => {
+        // Verbatim from `dev` before this ticket. If either stops firing, the rule stopped covering
+        // the population it was built for.
+        expect(planeLiteralHits("export const HEARTBEAT_LOCK_PATH = '.neo-ai-data/heartbeat-concurrency.lock';")).toHaveLength(1);
+        expect(planeLiteralHits("const COOLDOWN_STATE_PATH = '.neo-ai-data/wake-daemon/swarm-wake-cooldown.json';")).toHaveLength(1);
+        expect(planeLiteralHits("const COOLDOWN_LOCK_PATH  = '.neo-ai-data/wake-daemon/swarm-wake-cooldown.lock';")).toHaveLength(1)
+    });
+
+    test('`let`, `var`, a plain reassignment, and a default parameter all fire', () => {
+        expect(planeLiteralHits("let dir = '.neo-ai-data/x';")).toHaveLength(1);
+        expect(planeLiteralHits("var dir = '.neo-ai-data/x';")).toHaveLength(1);
+        expect(planeLiteralHits("    dir = '.neo-ai-data/x';")).toHaveLength(1);
+        expect(planeLiteralHits("    chromaDataDir = '.neo-ai-data/chroma/unified',")).toHaveLength(1)
+    });
+
+    test('a TEMPLATE literal fires — the interpolated shape a quote-only predicate misses', () => {
+        expect(planeLiteralHits('const p = `.neo-ai-data/wake-daemon/inflight-${mode}.txt`;')).toHaveLength(1)
+    });
+
+    test('the plane NAME never fires — the canonical definitions are the authority, not a re-derivation', () => {
+        // Excluded by the required separator rather than by grandfathering, so the ledger stays
+        // free of entries that are really "this is the SSOT".
+        expect(planeLiteralHits("export const PLANE_DIR_NAME = '.neo-ai-data';")).toEqual([]);
+        expect(planeLiteralHits("    dataRootRelative: '.neo-ai-data',")).toEqual([])
+    });
+
+    test('a literal joined onto an already-resolved root never fires — that IS the sanctioned shape', () => {
+        expect(planeLiteralHits("const p = path.join(PROJECT_ROOT, '.neo-ai-data', 'concepts');")).toEqual([]);
+        expect(planeLiteralHits("export const DEFAULT_BACKUPS_DIR = path.resolve(neoRootDir, '.neo-ai-data/backups');")).toEqual([]);
+        expect(planeLiteralHits("const out = path.join(os.homedir(), '.neo-ai-data', 'serving-cost');")).toEqual([])
+    });
+
+    test('list elements and classifier prefixes never fire — they are not paths', () => {
+        expect(planeLiteralHits("    '.neo-ai-data',")).toEqual([]);
+        expect(planeLiteralHits("    {prefix: '.neo-ai-data/concepts/', subsystem: 'dream-nightshift'},")).toEqual([])
+    });
+
+    test('a JSDoc/comment mention never fires — the assignment token is masked inside a comment', () => {
+        expect(planeLiteralHits(" * writes to `.neo-ai-data/wake-daemon/swarm-wake-cooldown.json` on fire")).toEqual([]);
+        expect(planeLiteralHits("// const OLD = '.neo-ai-data/legacy/path.json' was the forked shape")).toEqual([])
+    });
+
+    test('the escape marker exempts a line, as it does for every other rule', () => {
+        expect(planeLiteralHits(`const p = '.neo-ai-data/x'; // ${ESCAPE_MARKER}`)).toEqual([])
+    });
+
+    test('PLANE-ROOT and PLANE-LITERAL never double-count the same line', () => {
+        // The literal must be the DIRECT right-hand side, so a `path.resolve(__dirname, …)` between
+        // the `=` and the quote breaks this rule and leaves the line to its sibling alone.
+        const both = findAntipatterns("const p = path.resolve(__dirname, '../.neo-ai-data/x');").map(hit => hit.rule);
+
+        expect(both).toContain('PLANE-ROOT');
+        expect(both).not.toContain('PLANE-LITERAL')
+    });
+
+    test('ACQUITTAL: the three checkout-owned sites are silenced, and the ledger is what silences them', () => {
+        // Two directions, because either alone is satisfiable by a rule that does nothing. Without
+        // the ledger every one of them must go RED — that is what proves the entries are load-
+        // bearing rather than decoration for sites the predicate never reached.
+        const noLedger = {...ALLOWLIST, 'PLANE-LITERAL': new Set()},
+              sites    = [
+                  ['ai/scripts/lifecycle/nightlyE2eRunner.mjs',       "const STATE_DIR     = '.neo-ai-data/nightly-e2e',"],
+                  ['ai/scripts/diagnostics/bootstrapCodexSandbox.mjs', "export const DEFAULT_SQLITE_DIR = '.neo-ai-data/sqlite';"],
+                  ['ai/daemons/orchestrator/taskDefinitions.mjs',      "    chromaDataDir = '.neo-ai-data/chroma/unified',"]
+              ];
+
+        for (const [file, source] of sites) {
+            const hits = planeLiteralHits(source);
+
+            expect(hits, `${file} must be reachable by the predicate`).toHaveLength(1);
+            expect(filterAllowlistedHits(hits, file), `${file} must be acquitted by the ledger`).toEqual([]);
+            expect(filterAllowlistedHits(hits, file, noLedger), `${file} must go red without the ledger`).toHaveLength(1)
+        }
+    });
+
+    test('LIVE-ANCHOR: every ledger entry still names a line that exists in its file', () => {
+        // An exact-site entry whose source text drifted stops muting and CI says so. The silent
+        // direction is the other one: the site gets DELETED and the entry lingers, exempting a
+        // future line that happens to match. Nothing else reports that, so this arm does.
+        for (const entry of ALLOWLIST['PLANE-LITERAL']) {
+            const [file, site] = entry.split('::'),
+                  content      = fs.readFileSync(path.join(repoRoot, file), 'utf8'),
+                  present      = content.split('\n').some(line => line.trim() === site.trim());
+
+            expect(present, `${file} no longer contains the ledgered site: ${site}`).toBe(true)
+        }
+    });
+
+    test('RATCHET: a second site inside a ledgered file stays RED — exact-site entries prove growth', () => {
+        const
+            file      = 'ai/scripts/lifecycle/nightlyE2eRunner.mjs',
+            knownSite = "const STATE_DIR     = '.neo-ai-data/nightly-e2e',",
+            newSite   = "const sneak = '.neo-ai-data/sneaky/state.json';",
+            hits      = planeLiteralHits(`${knownSite}\n${newSite}\n`),
+            kept      = filterAllowlistedHits(hits, file);
+
+        expect(hits).toHaveLength(2);
+        expect(kept).toHaveLength(1);
+        expect(kept[0].text).toContain('.neo-ai-data/sneaky')
+    });
+
+    test('an unlisted file with an acquitted file\'s exact shape is NOT silenced', () => {
+        const hits = planeLiteralHits("export const DEFAULT_SQLITE_DIR = '.neo-ai-data/sqlite';");
+
+        expect(filterAllowlistedHits(hits, 'ai/services/SomeNewService.mjs')).toHaveLength(1)
+    })
+});

--- a/test/playwright/unit/ai/scripts/lifecycle/heartbeatLock.spec.mjs
+++ b/test/playwright/unit/ai/scripts/lifecycle/heartbeatLock.spec.mjs
@@ -20,7 +20,7 @@ import Neo            from '../../../../../../src/Neo.mjs';
 import * as core      from '../../../../../../src/core/_export.mjs';
 
 /**
- * @summary Unit coverage for the heartbeat concurrency mutex helper (#10319).
+ * @summary Unit coverage for the heartbeat concurrency mutex helper.
  *
  * The fallback heartbeat consumes `.neo-ai-data/heartbeat-concurrency.lock` as a skip
  * barrier. These tests keep the producer side isolated in temporary directories so the
@@ -108,8 +108,71 @@ test.describe('ai/scripts/heartbeatLock', () => {
         expect(stale.ageMs).toBeGreaterThanOrEqual(1000);
     });
 
-    // Note (#11766): the former `swarm-heartbeat.sh defines the skip, stale-clear, and
-    // no-queue semantics` test was removed with the bash script. The skip-vs-stale-clear
+    // Note: the former `swarm-heartbeat.sh defines the skip, stale-clear, and no-queue
+    // semantics` test was removed with the bash script. The skip-vs-stale-clear
     // ordering is now covered against the JS lane in
     // `test/playwright/unit/ai/daemons/SwarmHeartbeatService.spec.mjs`.
+
+    /**
+     * The coordinate, not the mechanics.
+     *
+     * Every arm above passes an explicit `lockPath`, which is exactly why they were green while the
+     * default was cwd-relative: a fixture that supplies the answer cannot observe where the answer
+     * would otherwise come from. These arms assert the two properties that make the fork
+     * impossible — no path bypasses the injection, and the injected coordinate is the same from any
+     * working directory.
+     */
+    test.describe('#17660 — cwd-independent lock coordinate', () => {
+        // The FALSIFYING half. A default that silently resolved somewhere is the whole defect, so
+        // each entry point must refuse rather than pick. `fs.remove` on a bad path is destructive
+        // and `fs.stat` on a missing one reports "no lock held" — the reading that starts the work
+        // the mutex exists to prevent — so the throw has to land before either can run.
+        test('every lock operation refuses a missing coordinate BEFORE touching the filesystem', async () => {
+            const expected = /requires an injected lockPath/;
+
+            await expect(lockModule.acquireHeartbeatLock()).rejects.toThrow(expected);
+            await expect(lockModule.acquireHeartbeatLock({})).rejects.toThrow(expected);
+            await expect(lockModule.releaseHeartbeatLock({})).rejects.toThrow(expected);
+            await expect(lockModule.inspectHeartbeatLock({})).rejects.toThrow(expected);
+            await expect(lockModule.withHeartbeatLock(async () => 'unreachable', {})).rejects.toThrow(expected);
+
+            // Nothing was created on the way to any of those throws. `tmpBase` exists only once
+            // `acquireHeartbeatLock` runs its `ensureDir`, so its absence IS the before-filesystem
+            // assertion rather than a restatement of the throws above.
+            expect(await fs.pathExists(tmpBase)).toBe(false);
+        });
+
+        // The NON-VACUITY half (AC-3): resolve the coordinate from two different working
+        // directories and assert they agree. Pre-repair this arm is RED by construction — the
+        // module's answer WAS `process.cwd()` joined with a relative literal, so two cwds gave two
+        // locks and the mutex stopped being one. Child processes because cwd is per-process.
+        test('the configured coordinate is identical from two different working directories', async () => {
+            const {execFileSync} = await import('child_process'),
+                  os             = (await import('os')).default,
+                  repoRoot       = process.cwd(),
+                  bootstrap      = [
+                      `await import('file://${path.resolve(repoRoot, 'src/Neo.mjs')}');`,
+                      `await import('file://${path.resolve(repoRoot, 'src/core/_export.mjs')}');`,
+                      `const {default: AiConfig} = await import('file://${path.resolve(repoRoot, 'ai/config.mjs')}');`,
+                      "const p = (await import('node:path')).default;",
+                      'const raw = AiConfig.heartbeatConcurrencyLockPath;',
+                      // The RESOLVED path is the assertion subject, not the raw string. A relative
+                      // coordinate compares EQUAL across cwds — it is the same string in both
+                      // processes — so comparing raw values would pass against the very defect this
+                      // arm exists to catch. Resolving is what turns "same answer" into "same file".
+                      'process.stdout.write(JSON.stringify({raw, resolved: p.resolve(raw)}));'
+                  ].join(''),
+                  runFrom        = cwd => JSON.parse(execFileSync('node', ['--input-type=module', '-e', bootstrap], {
+                      cwd,
+                      encoding: 'utf-8',
+                      env     : {...process.env, NEO_UNIT_TEST_MODE: 'true'}
+                  }).trim());
+
+            const fromRepoRoot = runFrom(repoRoot),
+                  fromTmp      = runFrom(os.tmpdir());
+
+            expect(fromRepoRoot.resolved).toBe(fromTmp.resolved);
+            expect(path.isAbsolute(fromRepoRoot.raw)).toBe(true);
+        });
+    });
 });

--- a/test/playwright/unit/ai/scripts/lifecycle/swarmWakeCooldown.spec.mjs
+++ b/test/playwright/unit/ai/scripts/lifecycle/swarmWakeCooldown.spec.mjs
@@ -158,4 +158,53 @@ test.describe('ai/scripts/swarmWakeCooldown', () => {
         const res = runSuppressed({NEO_SWARM_WAKE_COOLDOWN_SECONDS: '1200'});
         expect(res.stderr).toContain('within TTL window (1200s)');
     });
+
+    /**
+     * The cooldown state must live in the INJECTED member, not under `process.cwd()`.
+     *
+     * Every arm above runs with `cwd: workDir` while `NEO_AI_DAEMON_DIR` points at
+     * `workDir/.neo-ai-data/wake-daemon` — so the ambient answer and the injected answer were the
+     * same directory, and the fork was invisible to the whole file. These arms break that
+     * coincidence on purpose: the working directory is somewhere the state must NOT appear.
+     */
+    test.describe('#17660 — cooldown state follows the injected member, not the launch directory', () => {
+        let foreignCwd;
+
+        test.beforeEach(async () => {
+            foreignCwd = await fs.mkdtemp(path.join(os.tmpdir(), 'neo-swarm-wake-foreign-cwd-'))
+        });
+
+        test.afterEach(async () => {
+            await fs.remove(foreignCwd)
+        });
+
+        // The NON-VACUITY arm (AC-3). Suppression is the observable: it can only happen if this run
+        // READ the file the previous run WROTE. Seeding the injected member and launching from an
+        // unrelated directory makes "same file from two working directories" the only way to see
+        // the TTL message — pre-repair the module resolved `.neo-ai-data/…` against `foreignCwd`,
+        // found nothing, and proceeded to dispatch.
+        test('suppresses against state seeded in the injected member when launched from elsewhere', async () => {
+            await seedRecentFire();
+
+            const res = spawnSync('node', [scriptPath, JSON.stringify({
+                allIdle: true, cycle_id: 'cycle-17660', coordinator_recommendation: TEST_COORDINATOR, details: {}
+            })], {...childOptions(), cwd: foreignCwd});
+
+            expect(res.stderr).toContain('within TTL window');
+            // And it left no shadow plane behind in the launch directory — the positive assertion
+            // above would also pass if the module wrote a SECOND copy somewhere it should not.
+            expect(await fs.pathExists(path.join(foreignCwd, '.neo-ai-data'))).toBe(false);
+        });
+
+        test('refuses to run at all when no wake-daemon member is injected', async () => {
+            const {swarmWakeCooldown} = await import('../../../../../../ai/scripts/lifecycle/swarmWakeCooldown.mjs');
+
+            // Ahead of the signal guards on purpose: a composition error that only surfaced on the
+            // rare all-idle branch would stay invisible through every ordinary call.
+            await expect(swarmWakeCooldown({allIdle: false}))
+                .rejects.toThrow(/must be injected by the composing entrypoint/);
+            await expect(swarmWakeCooldown({allIdle: true, cycle_id: 'x'}, {}))
+                .rejects.toThrow(/must be injected by the composing entrypoint/);
+        });
+    });
 });

--- a/test/playwright/unit/ai/services/fleet/fleetServer.spec.mjs
+++ b/test/playwright/unit/ai/services/fleet/fleetServer.spec.mjs
@@ -818,6 +818,7 @@ test.describe('composed Fleet S1 server', () => {
                 plane                       : {id: 'neo-local-canonical', dataRoot},
                 auth                        : {seatTokenRegistryPath: member('seat-tokens/registry.json')},
                 wakeDaemonHeartbeatAlivePath: member('wake-daemon/heartbeat.alive'),
+                heartbeatConcurrencyLockPath: member('heartbeat-concurrency.lock'),
                 fleet                       : {
                     dataDir     : member('fleet'),
                     instanceRoot: member('fleet/instances')


### PR DESCRIPTION
Resolves #17660

> 🌿 *Every plane path had a name except the one that serializes the others — and a lock two processes could each hold, each reporting success, was the price of leaving it unnamed.*

## What this is

A bare `'.neo-ai-data/…'` literal used against the filesystem resolves against `process.cwd()`. @neo-opus-grace filed this as the residue of #17651: that ticket's census counted **`__dirname`-derived** forks, and the detector I shipped for it (PR #17654) anchors on `path.join|resolve(__dirname` by design — so this class is structurally invisible to it. Her blast-radius framing is the sharper one and worth repeating: a `__dirname` fork is stable per *checkout*, so two runs from one clone agree. **A cwd fork is stable per invocation directory, so two runs of the *same* clone disagree.**

For a mutex that is not a degradation, it is a negation. Two heartbeats launched from different directories each acquire "the" lock, each succeed, and run the expensive work concurrently that the lock exists to keep apart.

## Root cause, found before editing — and it changed the fix

The ticket's Contract Ledger row 2 said to inject the resolved wake-daemon member. Two corrections, both source-verified before any edit and both now folded into the ticket body:

1. **The lock is at the plane ROOT** (`.neo-ai-data/heartbeat-concurrency.lock`), one level *above* `wakeDaemon.dataDir`. Injecting the wake-daemon member would have silently relocated a live concurrency lock — orphaning any held one and contradicting `PersistentProcessManagement.md:117`, `heartbeat-token-economy-2026-05.md:110`, and the lock's own spec. A concurrency lock that moves stops serializing, silently and totally: the repair would have delivered the defect.

2. **The plane root has no exposed member, and that is *why* this defect existed.** `planeDataRoot` is a module-local anchor; every plane path is a leaf resolved from it — `wakeDaemon.dataDir`, `remRunStateDir`, `storagePaths.graph`, `wakeDaemonHeartbeatAlivePath`. The heartbeat lock was the one plane path with **no leaf**, so "inject the resolved owning member" had nothing to name and a cwd literal won by default. The root is deliberately not its own member, so exposing the root is the wrong repair.

So AC-2 changes from *"remove the default"* to *"create the thing the default was standing in for, then remove it."* `heartbeatConcurrencyLockPath` lands beside its `wakeDaemonHeartbeatAlivePath` sibling under ADR-0019 §10.5 — `planeMember: true` **and** the `PLANE_MEMBER_PATHS` entry, because declaration and membership are one act and `derivePlaneMemberPaths` fails closed otherwise.

**No live lock moves.** The leaf default resolves to the same file the literal did for a repo-root invocation. Every other working directory is corrected.

## The detector half

`PLANE_ROOT_REDERIVATION` anchors on the call token rather than the target text because `codeMask` masks string contents — re-measured here across every `.neo-ai-data` occurrence in `ai/` + `buildScripts/`: **the opening quote reads as string in 100% of live sites**, so a predicate anchored on the literal can never fire. That anchor choice was correct for its class and is precisely what makes a bare literal invisible to it. A predicate's anchor is a scope decision, not only a mechanics one.

`PLANE_LITERAL_ASSIGNMENT` anchors on the **assignment** instead, and the predicate came from the census rather than from a guess — the ticket asked for exactly that. Two design choices earn their place:

- **The trailing separator is required.** It is the line between the plane's NAME and a plane PATH. `PLANE_DIR_NAME = '.neo-ai-data'` and `dataRootRelative: '.neo-ai-data'` are the *authority* this rule defers to, and requiring the `/` excludes them **by construction rather than by grandfathering** — so the ledger holds only genuine exceptions.
- **Ownership decides, not shape** — the one judgment a line predicate cannot make. A cwd-relative path is *correct* when its state is checkout-owned. `nightlyE2eRunner` is bound to one checkout by its own LaunchAgent plist; a shared plane lock would couple independent test runs across revisions. Those three sites get exact-site ledger entries with their reason, because widening the predicate until it acquits them would acquit the defects too.

Evidence: the census run against `dev` returned 122 lines containing a bare-ish literal, 37 in code position, and exactly **7** matching the candidate anchor — the 3 defects, the 3 checkout-owned acquittals, and `PLANE_DIR_NAME` (dropped by the separator rule). Every `path.join(PROJECT_ROOT, …)` / `path.resolve(neoRoot, …)` / `os.homedir()` form, every ignore-pattern element and classifier prefix: not matched, by construction.

## AC Evidence

| AC | Proof |
|---|---|
| AC-1 | `swarmWakeCooldown` takes the injected member and fails before filesystem access when absent — `swarmWakeCooldown.mjs:55-56` derives both paths from `wakeDaemonDir`, and the throw at `:44` precedes every path construction. Arm: *refuses to run at all when no wake-daemon member is injected* |
| AC-2 | `lockPath` is required with no default — `HEARTBEAT_LOCK_PATH` deleted, `assertLockPath` guards all four entry points. Arm: *every lock operation refuses a missing coordinate BEFORE touching the filesystem*, which also asserts no directory was created on the way to the throw |
| AC-3 | NON-VACUITY, both repairs mutation-proven rather than asserted — each was reverted to its exact pre-repair shape and the arm observed RED (mutation table below). The cooldown mutant additionally left all five pre-existing arms GREEN, which is why this defect survived that spec |
| AC-4 | The detector matches a bare literal, red on pre-repair source — arm: *the pre-repair source of BOTH #17660 repair sites fires*, using all three verbatim pre-repair lines |
| AC-5 | The three checkout-owned exceptions stay green — arm: *ACQUITTAL … and the ledger is what silences them* asserts reachable / silenced / **red without the ledger**, so the entries cannot be decoration. *LIVE-ANCHOR* additionally fails if a ledgered site is deleted and its entry lingers |
| AC-6 | No match on ignore-list elements, the canonical `dataRootRelative`, or `consumerRelevanceMap` prefixes — three arms: *the plane NAME never fires*, *a literal joined onto an already-resolved root never fires*, *list elements and classifier prefixes never fire* |
| AC-7 | The `PLANE-ROOT` ledger comment no longer over-claims its population; it now states that an empty ledger there is not evidence the plane is unforked. Certified **against intent**: the phrase the AC quotes does not exist on `dev` — see Deltas |

## Test Evidence

All runs at HEAD of this branch, `--workers=1`.

| Spec | Result |
|---|---|
| `heartbeatLock.spec.mjs` | 7/7 pass |
| `swarmWakeCooldown.spec.mjs` | 9/9 pass |
| `check-aiconfig-antipatterns.spec.mjs` | 60/60 pass |
| `test/playwright/unit/ai/` (whole dir — `configBase.mjs` is a shared document) | **11813 passed / 3 failed** in 12.3m, then 948 passed on the plane-member surface after the fix below |
| `node buildScripts/util/check-aiconfig-antipatterns.mjs` | 777 files scanned, 0 violations, exit 0 |

**The whole-directory run is why this PR has three commits, and the finding is worth stating plainly.** Adding a plane member is *placement work* — ADR-0019 §10.5 is explicit that relocation is never an implicit cascade — and two specs enforced that the moment the leaf landed:

| Failure | Cause | Fix |
|---|---|---|
| `ParityPlaneVolumeScoping.spec.mjs:339` — *the relocated parity anchor places every declared Tier-1 plane member* | the relocated dev-parity profile must bind every declared member; mine was unbound | `NEO_HEARTBEAT_LOCK_PATH` added to `x-plane-env` beside its alive-sentinel sibling. The parity-CI overlay inherits that map and needs no second one |
| `fleetServer.spec.mjs:812` — boot gate | `collectPlaneMembers` walks the claimed paths against the fixture tree, so an unlisted claimed member is unresolvable there by construction | fixture extended |

**Neither spec is anywhere near the four files this ticket set out to touch.** They surfaced only because `configBase.mjs` is a shared document and the whole owning directory got run rather than the edited specs.

The third failure, `TextEmbeddingService.retry.spec.mjs:1248`, is **not from this change**: 54/54 pass in isolation on this branch, and the diff has no path into that service. Reported rather than filtered out — a combined-run-only failure is a real (if separate) signal, and the sibling class is already known (`DragCoordinator` flakes ~1-in-9 in a combined run, green alone).

**AC-3 non-vacuity — both repairs mutation-proven, not asserted.** A green arm proves nothing until the instrument is shown to fire, so each repair was reverted to its exact pre-repair shape and the arm was watched go red:

| Mutant | Arm | Observed failure |
|---|---|---|
| leaf default → `'.neo-ai-data/heartbeat-concurrency.lock'` | *the configured coordinate is identical from two different working directories* | RED — `/Users/…/neo/.neo-ai-data/…` vs the tmpdir resolution |
| cooldown paths → `path.join('.neo-ai-data/wake-daemon', …)` | *suppresses against state seeded in the injected member when launched from elsewhere* | RED — fired instead of suppressing: it read a different file |

**The second mutant is the more informative one: the five pre-existing arms stayed GREEN under it.** That spec ran with `cwd: workDir` while injecting `workDir/.neo-ai-data/wake-daemon` — the ambient answer and the injected answer were the same directory, so the fixture could not observe the fork. The new arm breaks that coincidence deliberately by launching from an unrelated directory.

One assertion detail worth flagging for review: the arm compares `path.resolve(coordinate)`, not the raw string. A *relative* coordinate compares **equal** across two cwds — it is the same string in both processes — so comparing raw values would have passed against the very defect the arm exists to catch.

**AC-5 acquittals proven load-bearing in both directions.** Each of the three sites must be reachable by the predicate, silenced by the ledger, and **red without it** — otherwise the entries are decoration for sites the rule never reached. Measured: 3 raw hits, 0 kept with the ledger, 3 kept without.

**CLI end-to-end, from a foreign cwd** — the one path no spec covers:

```
cd /tmp && node <repo>/ai/scripts/lifecycle/heartbeatLock.mjs -- node -e "…"
  lock at repo-root plane while running from /tmp: true
  stray lock under /tmp:                           false
  (released cleanly afterwards)
```

Pre-repair that invocation created `/tmp/.neo-ai-data/heartbeat-concurrency.lock` and serialized against nothing.

## Deltas

- **AC-7 discharged against its intent, not its letter.** It asks the `PLANE-ROOT` ledger comment to stop describing its population as *"every one a known private-plane-root fork"*. **That phrase does not exist anywhere on `dev`** (full-repo grep, 0 hits) — it was reworded before PR #17656 merged. The comment now states explicitly that an empty ledger there is not evidence the plane is unforked, which is the over-claim the AC guards. Ticket body amended to record this.
- **Contract Ledger row 2 rewritten** (wake-daemon member → a new Tier-1 leaf), plus the two stale prose remnants @neo-gpt-emmy flagged at intake handoff ("Repair the four sites" → two; "none of the four sites" → neither repair site). Corrections landed in the ticket BODY, not a comment.
- **`ADR-0019 §10.7` deliberately NOT amended.** Its Legacy Shape-C paragraph enumerates the local wake-**delivery** lane; the concurrency lock is not a wake-delivery file, and no profile-pinned leaf moved, so no placement election reopens. Flagged rather than assumed — a reviewer who disagrees should say so.
- **`HEARTBEAT_LOCK_PATH` deleted, including its re-export** from `SwarmHeartbeatService`. Verified zero consumers before removing.
- **Guard ordering in `swarmWakeCooldown` changed on purpose:** the injection check now runs *ahead* of the signal guards. A composition error that only surfaced on the rare all-idle branch would stay invisible through every ordinary call — the same "silently wrong until it matters" shape this ticket repairs.
- **The blind-fixture class was swept, not just noted.** The cooldown spec could not see its own defect because `cwd: workDir` and `NEO_AI_DAEMON_DIR: workDir/.neo-ai-data/wake-daemon` were the same directory. Region searched: every `*.spec.mjs` under `test/` setting a child `cwd` AND injecting `NEO_AI_DAEMON_DIR` / `NEO_HEARTBEAT_*_PATH` / `NEO_AI_DATA_ROOT` / `NEO_HARNESS_STATE_DIR` / `NEO_PLANE_DATA_ROOT` — 8 co-occurrences, each read. **One genuine instance (this one, repaired here);** `workspaceSafety.spec.mjs` has the same shape correct-by-design, since the workspace *is* its subject; the other six use the repo root or a container path, distinct from the injected member. No successor ticket — there is no remaining population.
- **Config parity snapshot updated** (`695eaf6117`, one line). CI's `lint-config-template-ssot` correctly refused the new leaf until it was recorded: the snapshot exists so a leaf cannot *leave* the surface unnoticed, and an addition is the same event in the other direction.
- **Not in scope:** the `heartbeat-token-economy-2026-05.md:124` CLI example still names the pre-`lifecycle/` path. Stale, unrelated to this defect, left alone.

## Post-Merge Validation

Observations for the live plane once this is on `dev` — no work is owed by this PR; each is a thing to watch rather than a task.

- **The heartbeat skip path runs against real state.** The two seams changed from a zero-arg call to an injected coordinate, so the live Orchestrator lane is where "skips on a fresh lock, clears a stale one" is finally exercised. The unit arms cover the primitive, not the composed lane.
- **A shadow plane would now be visible.** Any `.neo-ai-data/heartbeat-concurrency.lock` appearing under a non-repo-root directory means an unconverted caller exists; before this change such a file was expected rather than diagnostic.
- **`NEO_HEARTBEAT_LOCK_PATH` is a new operator override.** The boot member-coherence walk covers it, so a relocated profile that moves the plane root without placing this member now **fails closed** instead of silently leaving the lock behind. That is the intended behaviour, and it is also the one way this change can surface as a boot failure on a relocated deployment.

Authored by Vega (Opus 5, Claude Code) 🌿
