### PR TITLE
docs(agentos): the cross-family mandate becomes a difference test (#17667)

### DIFF
--- a/.agents/skills/pull-request/references/cross-family-mandate.md
+++ b/.agents/skills/pull-request/references/cross-family-mandate.md
@@ -1,0 +1,56 @@
+# Cross-Family Mandate — rationale and exceptions
+
+*(Sub-rule extraction from `pull-request-workflow.md` §6.1 per the Map-vs-Atlas
+byte-budget discipline. The map carries the operative rule; load this when
+invoking an exception or questioning the rule's shape.)*
+
+## Why a difference test, not a list of families
+
+The mandate used to name families: `(Claude-family <-> Gemini/GPT-family)`. Accurate
+when the roster held three, and nothing failed when it stopped being true — by
+2026-08-24 it named the one **benched** family and omitted two others, one of
+them the only live third seat. An enumeration claims completeness, needs
+hand-editing on every roster change, and goes stale silently. **If you are
+tempted to list the current families to make the rule concrete, that is the
+failure mode this file exists to prevent.**
+
+## `unknown` counts as differing — and what it costs
+
+A seat may record `modelFamily: 'unknown'`: an engine undisclosed by design,
+where the bearer does not know its own model or vendor. Operator ruling
+2026-08-24 — it counts as differing.
+
+The trade should not be quietly enjoyed: a family nobody can state cannot be
+*shown* uncorrelated with the author's, so admitting it assumes part of what the
+mandate checks. A usable third seat, bought with a guarantee that was never
+verifiable for that seat.
+
+**Never infer a family from a handle, a preview codename, or a rumour** — the
+record is the only citation, and `unknown` is an accurate value, not a gap to
+fill. Two maintainers misread that placeholder within one hour on 2026-08-24,
+one as "not Claude", the other as a gap to close.
+
+## Liveness is not consulted
+
+The gate asks what an approval **was**, not who is available now. A benched
+peer's past approval was still cross-family, and the correlated-blind-spot
+rationale is satisfied by *who reviewed*. Requiring live seats would couple merge
+validity to a hand-maintained roster file whose participation rows go stale.
+
+## Exceptions
+
+Narrow, and each must be stated in the PR/review thread:
+
+- **Micro-change:** `chore` and `< 20` changed lines, or pure documentation with
+  no runtime impact.
+- **7-day-open fallback:** PR open >= 7 days and no cross-family thread
+  engagement; cite `createdAt` and `get_conversation` evidence.
+- **Emergency:** `priority: P0` or explicit Tobi override; retrospective
+  cross-family review within 7 days.
+
+If CI is green and no cross-family reviewer has engaged after ~2 hours, invite
+exactly one opposite-family primary reviewer before considering fallback.
+
+Merge-readiness marker vocabulary lives with its consumers, not here:
+`../../pr-review/references/pr-review-guide.md` and
+`../../post-review-pickup/references/post-review-pickup-workflow.md`.

--- a/.agents/skills/pull-request/references/pull-request-workflow.md
+++ b/.agents/skills/pull-request/references/pull-request-workflow.md
@@ -166,30 +166,24 @@ You MUST follow this exact handoff protocol:
 
 ### 6.1 The Cross-Family Mandate
 
-**No PR may be merged without at least one cross-family Approved review**
-(Claude-family <-> Gemini/GPT-family). The reviewer MUST submit a formal GitHub
-PR Review state (`reviewDecision: APPROVED`); a comment alone is insufficient.
-Author family is resolved from the §5 Social Name, with `author.login` fallback.
+**No PR may be merged without at least one cross-family Approved review** — one
+from a seat whose `modelFamily` differs from the author's, per
+`ai/graph/identityRoots.mjs`. `unknown` counts as differing (operator ruling
+2026-08-24). A difference test, never a list of families: a list needs
+hand-editing on every roster change and goes stale silently.
+
+The reviewer MUST submit a formal GitHub PR Review state (`reviewDecision:
+APPROVED`); a comment alone is insufficient. Author family is resolved from the
+§5 Social Name, with `author.login` fallback. A formal `APPROVED` is necessary
+but NOT sufficient: a non-empty `reviewRequests` blocks merge-handoff until each
+requested reviewer is disposed. `validateMergeReady` encodes this.
 
 Stacked PRs (`baseRefName` not `dev` / default): cross-family approval belongs
 to the dev-rebased full-CI merge candidate; same-family delta review is not a
 substitute.
 
-A formal `reviewDecision: APPROVED` is necessary but NOT sufficient: a non-empty `reviewRequests`
-blocks merge-handoff until each requested reviewer is disposed. `validateMergeReady` encodes this.
-Canonical `[merge-eligible]` cites a positive B-prime marker; otherwise
-use `[merge-readiness-uncertified][no-positive-observation]`, or
-`[merge-readiness-uncertified][issuer-unavailable:cloud-mode]` in cloud.
-It never grants merge authority.
-
-Exceptions are narrow and must be stated in the PR/review thread:
-- Micro-change: `chore` and `< 20` changed lines, or pure documentation with no runtime impact.
-- 7-day-open fallback: PR open >= 7 days and no cross-family thread engagement;
-  cite `createdAt` and `get_conversation` evidence.
-- Emergency: `priority: P0` or explicit Tobi override; retrospective cross-family review within 7 days.
-
-If CI is green and no cross-family reviewer has engaged after ~2 hours, invite
-exactly one opposite-family primary reviewer before considering fallback.
+Rationale, the trade `unknown` makes, the narrow exceptions, and merge-readiness
+marker vocabulary: [`cross-family-mandate.md`](./cross-family-mandate.md).
 
 ### 6.1.1 The Consensus-Gate (PR-Merge-Gate for Discussion-Graduated Substrate)
 


### PR DESCRIPTION
Resolves #17667

> 🌿 *A reviewer can no longer be disqualified by a list that forgot them — the mandate now asks a question the roster cannot age out of.*

## What this is

§6.1 gated merges on a parenthetical: `(Claude-family <-> Gemini/GPT-family)`. **Two provenance layers, kept separate because they do not agree.** *Registry facts* (`ai/graph/identityRoots.mjs`): the declared `modelFamily` values are `claude`, `gpt`, `kimi`, `unknown`, `gemini`, and `gemini` is the only family the registry itself marks `participationStatus: 'operator_benched'`. *Operator/deployment liveness* (not registry output): kimi was benched 2026-08-17 — the registry still records both kimi seats `active`, which is the open data-accuracy item on #17661, **not** something this PR may cite as registry evidence.

Against those two layers the parenthetical **names `gemini`, benched per the registry, and omits `unknown` entirely** — `unknown` being a live seat the rule therefore could not name at all. Add operator liveness and it is worse: the two families the text does admit reduce to `gpt` alone in practice.

An enumeration claims to be complete. This one was accurate when the roster had three families, and nothing failed when that stopped being true. It is replaced by the invariant it was approximating: **an Approved review from a seat whose `modelFamily` differs from the author's.** A difference test cannot go stale.

@neo-opus-grace's gate (#17661 / PR #17662) already keys on the difference. This brings the prose up to the code — prose being what a human reads before writing the *next* gate.

## Why the text mattered, not just the code

Two maintainers misread this paragraph in opposite directions within one hour on 2026-08-24. I read `modelFamily: 'unknown'` as "not Claude" and asserted a merge basis from it; Grace read the same value as a roster gap she would close. Both are the same error — **treating a placeholder as a fact about the world** — and the paragraph offered no cell for `unknown`, so we each invented one. The never-infer clause is aimed precisely at that reading.

The permissive ruling is recorded **with its cost** rather than as a free win: a family nobody can state cannot be *shown* uncorrelated with the author's, so admitting it assumes part of what the mandate checks. That trade is the operator's to make and it is made — the text's job is to stop it being re-derived, or silently forgotten.

## AC Evidence

| AC | Proof |
|---|---|
| AC-1 | No families enumerated; the clause reads *"a seat whose `modelFamily` differs from the author's, per `ai/graph/identityRoots.mjs`"* |
| AC-2 | `unknown` addressed explicitly and the ruling dated inline — *"counts as differing (operator ruling 2026-08-24)"* — so the next reader cites rather than re-derives |
| AC-3 | The trade is one sentence, not buried: *"a family nobody can state cannot be shown uncorrelated with the author's, so admitting it assumes part of what this mandate checks"* |
| AC-4 | **NON-VACUITY** — walked the amended paragraph cold against the exact case that produced the ticket. A reader knowing only `Eos = unknown` / `author = claude` hits "differs from the author's", hesitates on whether `unknown` is a value or an absence, and the next sentence resolves it. Verdict reached with **zero** inference about engines. Evidence: the walk is reproducible from the diff — the two sentences are adjacent by design |
| AC-5 | No engine, vendor, or model claim anywhere in the diff. `unknown` stays `unknown` and is described as *"an accurate value, not a gap to fill"* |
| AC-6 | Accretion Defense satisfied on the **decay-mitigation** arm — see Deltas. Map net **−414B**, net **+2318B**, `lint-skill-manifest --base origin/dev` OK |

## Test Evidence

Documentation-only; no runtime surface. What was actually run:

- `check-ticket-archaeology` — pass (no ticket/ADR refs introduced into durable prose; the dated operator ruling is a date, not a decaying ref)
- Full `lint-staged` pre-commit battery — pass at `5653401ebd`
- Byte figures at head `648740aab0` vs `origin/dev`: map `pull-request-workflow.md` **21991 → 21577 (−414B)**; new sibling `cross-family-mandate.md` **+2732B**; **net +2318B**. Against `maxPositiveDeltaBytes: 250`, carried by the single-line `[skill-growth-justified:]` marker in the commit. `node ai/scripts/lint/lint-skill-manifest.mjs --base origin/dev` → **OK**
- Census reproducing the defect, with provenance separated. **Registry output** (`identityRoots.mjs` `modelFamily` + `participationStatus`): `claude` 5 · `gpt` 2 · `unknown` 1 · `kimi` 2 — all recorded `active`; `gemini` recorded `operator_benched`. **Operator liveness, cited as operator state and NOT as registry output:** kimi benched 2026-08-17. The registry-only reading already convicts the parenthetical (it names the one `operator_benched` family and omits `unknown`); operator liveness sharpens the consequence without being load-bearing for the defect

Evidence: the failing case is the rule's own text read against the live roster, so the falsifier is the census above rather than a spec run.

## Turn-Memory Pre-Flight (retrospective, per RA-1)

Skipped before the change and run now; `.agents/skills/**` is explicitly IN-SCOPE for `/turn-memory-pre-flight`.

**Placement decision tree.** Step 1 — does the mandate apply to *every* turn universally? **No**: it governs one lifecycle event (PR merge eligibility). Step 2 — does it govern a specific, identifiable lifecycle event? **Yes → Skill.** It already lives in `.agents/skills/pull-request/`, so placement is confirmed unchanged, not relocated. The extracted *rationale and exceptions* are Step-3-shaped material; per the workflow's own Progressive Disclosure Subsumption (*"prefer moving detailed instructions to Skills or the Atlas"*) and the seven existing sibling references in this skill, a skill-local sibling is the established idiom here rather than a global `AGENTS_ATLAS.md` entry — the content is skill-scoped, not a cross-cutting edge case.

**Four mechanical checks, run:**

| # | check | result |
|---|---|---|
| 1 | `cat .codex/hooks.json` | `SessionStart` (`startup\|resume\|compact`) runs `codex-context.mjs`; no skill-payload glob |
| 2 | `cat .codex/hooks/codex-context.mjs` | reads one resolved `contextUrl`; **does not** enumerate `.agents/skills/**` |
| 3 | harness load path for this file | `SKILL.md:7` loads `pull-request-workflow.md` **on the pull-request trigger**, not per turn |
| 4 | `readlink .claude/CLAUDE.md` | → `../AGENTS.md`, so AGENTS.md **is** turn-loaded — and it references `pull-request-workflow.md §6.1.1 / §1.2` by **pointer only** |

**Load-effect, which is the number that matters and is not the disk number.** The turn-loaded tier is untouched: AGENTS.md still carries only a pointer, unchanged. Within the trigger tier the split is asymmetric —

- **`pull-request-workflow.md` — trigger-loaded in full by every agent opening or finalizing a PR: −414B.** This is the surface everyone pays.
- **`cross-family-mandate.md` — conditional, loaded only by a reader who follows the pointer** (invoking an exception, or questioning the rule's shape): **+2732B**, paid by nobody else.

So net **+2318B on disk** is the wrong unit for load effect: the cost every PR author bears **goes down**, and the added bytes sit behind a trigger. That asymmetry is the actual argument for the extraction, and the skill-manifest OK result does not express it.

**Harness-load-duplication audit.** No content is duplicated into a second loaded surface, and one duplication is **removed**: the merge-readiness marker vocabulary was stated verbatim in three skill files and is now in two (`pr-review-guide.md`, `post-review-pickup-workflow.md` — the consuming surfaces). Dropping it here rather than carrying it into the sibling would otherwise have made it triplicated across loadable payloads.

## Deltas

- **The extraction was FORCED, and it is why this is a two-file change.** `pull-request-workflow.md` sat at **21991 bytes against the `pull-request` skill's `perFilePayloadBudget: 22000`** — nine bytes of headroom, and that budget is a per-skill override of the 25000 default, so the map is effectively frozen: any substantive rule change now pays a sub-rule extraction. The map keeps the operative rule and drops **414B**; rationale, the `unknown` trade, liveness, and the narrow exceptions move to `cross-family-mandate.md` behind a one-line pointer, per the Map-vs-Atlas discipline the lint itself prescribes.
- **Accretion Defense taken on the decay arm, not net-reduce.** Net **+2318B** buys removal of a recurring silent-staleness class plus the dated ruling and its stated trade. An enumeration needs hand-editing on every roster change and fails silently; a difference test does not. The retirement trigger is stated *in the text* (*"a difference test, never a list of families"*) so a future editor is told not to re-add one.
- **The merge-readiness marker vocabulary is dropped, not moved.** `pr-review-guide.md:338` and `post-review-pickup-workflow.md:90` already state it verbatim and are the surfaces that consume it. Carrying it into the sibling would have made it triplicated; dropping it makes it duplicated.
- **§6.1.1 was the wrong extraction target and was left alone.** It looked like the fattest block, but it already has an atlas companion (`audits/consensus-gate-mirror.md`) and is cited by §-anchor from it — moving it would have orphaned those citations. The right target was inside this change's own blast radius.
- **One of my own ACs was unsatisfiable and I amended the ticket rather than quietly relax it at implementation time.** AC-6 originally demanded the replacement be no longer than the enumeration it removed — which cannot hold alongside three siblings requiring the ruling citation and trade sentence to be *added*. Empty intersection. The Accretion Defense is a disjunction; the honest AC is the one the rule states.
- **Scope held to text.** The gate implementation is #17661 / PR #17662 and is not touched.
- **`identityRoots.mjs` roster staleness is NOT in this PR.** Both kimi seats still record `participationStatus: 'active'` while benched. Recorded by @neo-opus-grace on #17661 as a data-accuracy problem with its own owner, and blocked on operator wording for `statusReason` / `reactivationTrigger` (bench state carries `authority: '@tobiu'`). Explicitly not a gate defect — per the same ruling, the gate never reads liveness.
- **Landed on the wrong branch first.** The commit initially went onto the already-merged `#17660` branch; moved onto a fresh branch from `origin/dev` and the old ref reset. No content difference, noted because the history shows the cherry-pick.

## Post-Merge Validation

Observations, not owed work.

- **The next roster change is the real test.** If a family is added, benched, or reclassified and nobody edits §6.1, the text should still be correct. That is the whole point of the change and it can only be observed later.
- **Watch for a list growing back.** The failure mode this repairs is someone "helpfully" re-adding an enumeration to make the rule concrete. The in-text retirement trigger exists to catch that at review.
- The dated operator ruling is a fixed historical fact and should not need refreshing; if the ruling is ever reversed, this paragraph is where the reversal lands.

Authored by Vega (Opus 5, Claude Code). Session 0681fda8-6a98-4108-a463-dbdf6d0dad05.


