### PR TITLE
fix(agentos): authenticate DeploymentStateBridge direct probes with the plane credential (#17668)

### DIFF
--- a/ai/configBase.mjs
+++ b/ai/configBase.mjs
@@ -1579,6 +1579,20 @@ class ConfigBase extends ConfigProvider {
                      */
                     directProbeUrls             : leaf([], 'NEO_DEPLOYMENT_STATE_BRIDGE_DIRECT_PROBE_URLS', 'csv'),
                     /**
+                     * Bearer-token FILE the direct probes authenticate with. The probe targets
+                     * (`kb-server`, `mc-server`) reject unauthenticated healthchecks, so a probe
+                     * without this credential can never produce service evidence — it fails as
+                     * `invalid_token` every sweep while reading like a transport problem.
+                     *
+                     * Empty by default: deployments whose probe targets accept anonymous reads are
+                     * unaffected. When set, the file must exist and be readable at probe time; an
+                     * unreadable configured file is a loud, named warn on the bridge log rather than
+                     * a silent skip, because evidence that cannot authenticate and evidence that was
+                     * never collected look identical downstream.
+                     * @type {string}
+                     */
+                    bearerTokenFile             : leaf('', 'NEO_DEPLOYMENT_STATE_BRIDGE_BEARER_TOKEN_FILE', 'string'),
+                    /**
                      * Statuses the direct probe accepts as SERVING. `degraded` is included deliberately and
                      * is the whole reason this leaf is not hardcoded: a Memory Core answering correctly
                      * while its provider-dependent canary fails reports `degraded`, and a probe that

--- a/ai/daemons/orchestrator/services/DeploymentStateBridgeService.mjs
+++ b/ai/daemons/orchestrator/services/DeploymentStateBridgeService.mjs
@@ -544,13 +544,27 @@ export class DeploymentStateBridgeService extends Base {
 
         const probe = this.directProbeFn || runHealthcheck;
 
+        // The probe targets reject unauthenticated healthchecks. A configured-but-unreadable
+        // token file is a loud, NAMED warn — evidence that cannot authenticate must not render
+        // identically to a transport failure downstream, and the file's contents never reach the log.
+        let bearerToken = null;
+        if (bridgeConfig.bearerTokenFile) {
+            try {
+                bearerToken = (await fs.readFile(bridgeConfig.bearerTokenFile, 'utf8')).trim();
+                if (!bearerToken) throw new Error('bearer-token file contains no credential');
+            } catch (error) {
+                this.writeLog?.('WARN', `[DeploymentStateBridge] bearer-token file '${bridgeConfig.bearerTokenFile}' unusable for ${serviceKey}: ${error.message}`);
+            }
+        }
+
         try {
             await probe({
                 url,
                 clientName    : 'neo-orchestrator-direct-probe',
                 expectedStatus: bridgeConfig.directProbeExpectedStatus,
                 identity      : 'neo-orchestrator-direct-probe',
-                timeoutMs     : bridgeConfig.directProbeTimeoutMs
+                timeoutMs     : bridgeConfig.directProbeTimeoutMs,
+                bearerToken
             });
 
             return {ok: true, name: 'direct-endpoint-probe', message: null};

--- a/ai/deploy/docker-compose.yml
+++ b/ai/deploy/docker-compose.yml
@@ -464,6 +464,11 @@ services:
       # them would be a fault in this configuration reported as a fault in the service. They therefore
       # get no direct probe and are never restarted on the runtime's verdict alone — the safe default.
       - NEO_DEPLOYMENT_STATE_BRIDGE_DIRECT_PROBE_URLS=http://kb-server:3000,http://mc-server:3001
+      # The direct probes authenticate against kb/mc like any MCP client; without the carrier they
+      # fail `invalid_token` on every sweep while reading like a transport fault.
+      - NEO_DEPLOYMENT_STATE_BRIDGE_BEARER_TOKEN_FILE=/run/secrets/mcp-auth-token
+    secrets:
+      - mcp-auth-token
     volumes:
       # Scheduler cadence, tenant-repo revisions, recovery ledgers, logs, and
       # process-epoch files share AiConfig.orchestrator.dataDir. Persist the

--- a/ai/scripts/lint/config-leaf-parity.json
+++ b/ai/scripts/lint/config-leaf-parity.json
@@ -121,6 +121,7 @@
                 "NEO_AUTH_PAT_VALIDATION_TIMEOUT_MS",
                 "NEO_AUTH_PORT",
                 "NEO_AUTH_REALM",
+                "NEO_DEPLOYMENT_STATE_BRIDGE_BEARER_TOKEN_FILE",
                 "NEO_DEPLOYMENT_STATE_BRIDGE_DIRECT_PROBE_URLS",
                 "NEO_EMBEDDING_PROVIDER",
                 "NEO_GRAPH_PROVIDER",

--- a/ai/scripts/lint/config-leaf-parity.json
+++ b/ai/scripts/lint/config-leaf-parity.json
@@ -346,6 +346,7 @@
         "orchestrator.deploymentRuntimeAccess.timeoutMs",
         "orchestrator.deploymentStateBridge",
         "orchestrator.deploymentStateBridge.allowedServices",
+        "orchestrator.deploymentStateBridge.bearerTokenFile",
         "orchestrator.deploymentStateBridge.directProbeExpectedStatus",
         "orchestrator.deploymentStateBridge.directProbeTimeoutMs",
         "orchestrator.deploymentStateBridge.directProbeUrls",

--- a/ai/scripts/lint/config-leaf-parity.json
+++ b/ai/scripts/lint/config-leaf-parity.json
@@ -85,7 +85,7 @@
         "census": {
             "profile": "ai/deploy/docker-compose.yml",
             "baselineUniqueKeys": 45,
-            "remainingUniqueKeys": 72,
+            "remainingUniqueKeys": 73,
             "requiredDeploymentInputs": [
                 "NEO_AI_ORCHESTRATOR_AUTHORITY_PROFILE",
                 "NEO_AUTH_MODE",

--- a/test/playwright/unit/ai/daemons/orchestrator/services/DeploymentStateBridgeService.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/services/DeploymentStateBridgeService.spec.mjs
@@ -4665,13 +4665,16 @@ test.describe('direct-probe bearer credential — evidence that cannot authentic
         restoreConfig?.();
     });
 
-    test('a configured token file is read and its credential threaded into the probe', async () => {
+    test('a configured token file is threaded into the probe and NEVER disclosed to any log sink', async () => {
         const dir  = fs.mkdtempSync(path.join(os.tmpdir(), 'bridge-token-'));
         const file = path.join(dir, 'token');
-        fs.writeFileSync(file, '  secret-token-value\n');
+        const TOKEN = 'secret-token-value-high-entropy-material';
+        fs.writeFileSync(file, `  ${TOKEN}\n`);
 
+        const logged = [];
         let captured;
         const bridge = createService({
+            writeLog     : (level, message) => { logged.push(level + ': ' + message); },
             directProbeFn: async options => {
                 captured = options;
                 return {ok: true, name: 'direct-endpoint-probe', message: null};
@@ -4682,7 +4685,10 @@ test.describe('direct-probe bearer credential — evidence that cannot authentic
         const outcome = await bridge.collectDirectProbe({serviceKey: 'kb-server'});
 
         expect(outcome.ok).toBe(true);
-        expect(captured.bearerToken).toBe('secret-token-value');
+        expect(captured.bearerToken).toBe(TOKEN);
+        // Privacy-negative arm with REAL material flowing: a success path that logs the credential
+        // must turn this red (mutation: log the successfully read token).
+        expect(logged.some(l => l.includes(TOKEN)), 'credential must never reach any log sink').toBe(false);
     });
 
     test('a configured-but-unreadable token file fails open, warns with the path, never leaks contents', async () => {
@@ -4709,25 +4715,40 @@ test.describe('direct-probe bearer credential — evidence that cannot authentic
         expect(logged.some(l => l.toLowerCase().includes('secret-token'))).toBe(false);
     });
 
-    test('an unset leaf changes nothing: no credential, no warn about tokens', async () => {
+    test('an unset leaf changes nothing: no credential, and NO token-related warn through an observed sink', async () => {
+        // Observed sink is load-bearing: without it, a mutant that emits a bearer-token WARN on
+        // every unset sweep passes silently while re-noising the channel this fix silences.
         const logged = [];
 
         let captured;
-        const bridge = createService({ directProbeFn: async options => {
+        const bridge = createService({
+            writeLog     : (level, message) => { logged.push(level + ': ' + message); },
+            directProbeFn: async options => {
                 captured = options;
                 throw new Error('invalid_token: Missing Authorization header');
-            }});
+            }
+        });
         delete AiConfig.orchestrator.deploymentStateBridge.bearerTokenFile;
 
         await bridge.collectDirectProbe({serviceKey: 'kb-server'});
 
         expect(captured.bearerToken).toBeNull();
-        expect(logged.some(l => l.toLowerCase().includes('bearer-token file'))).toBe(false);
+        expect(logged.filter(l => l.toLowerCase().includes('bearer-token'))).toEqual([]);
     });
 
-    test('compose wires the orchestrator to the same secret carrier fleet-server uses', () => {
+    test('compose wires the orchestrator to the same secret carrier fleet-server uses — BOTH halves', () => {
+        // Paired-contract assertion scoped to the ORCHESTRATOR BLOCK ONLY. A whole-file match is
+        // decorative here: fleet-server carries the identical secret, so a global regex stays green
+        // even when the orchestrator's own mount is deleted (measured — that false-green shipped).
         const compose = readFileSync(new URL('../../../../../../../ai/deploy/docker-compose.yml', import.meta.url), 'utf8');
 
-        expect(compose).toMatch(/NEO_DEPLOYMENT_STATE_BRIDGE_BEARER_TOKEN_FILE=\/run\/secrets\/mcp-auth-token/);
+        const orchestratorBlock = compose
+            .split(/^ {2}(?=\w[\w-]*:[ \t]*$)/m)
+            .find(chunk => chunk.startsWith('orchestrator:'));
+
+        expect(orchestratorBlock, 'orchestrator service block found').toBeTruthy();
+
+        expect(orchestratorBlock).toMatch(/NEO_DEPLOYMENT_STATE_BRIDGE_BEARER_TOKEN_FILE=\/run\/secrets\/mcp-auth-token/);
+        expect(orchestratorBlock).toMatch(/^ {4}secrets:\n {6}- mcp-auth-token$/m);
     });
 });

--- a/test/playwright/unit/ai/daemons/orchestrator/services/DeploymentStateBridgeService.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/services/DeploymentStateBridgeService.spec.mjs
@@ -37,6 +37,8 @@ const OBSERVED_AT = 1710000000000;
  */
 const BRIDGE_CONFIG_PATHS = [
     'orchestrator.deploymentStateBridge.allowedServices',
+    'orchestrator.deploymentStateBridge.bearerTokenFile',
+    'orchestrator.deploymentStateBridge.directProbeUrls',
     'orchestrator.deploymentStateBridge.includeLogs',
     'orchestrator.deploymentStateBridge.logTail',
     'orchestrator.deploymentStateBridge.logMaxBytes',
@@ -110,6 +112,7 @@ function createService({
     taskStateService = null,
     tenantRepoSyncService = null,
     tenantRepoSyncEnabledReader = null,
+    writeLog = null,
     nowFn = () => OBSERVED_AT
 } = {}) {
     return Neo.create(DeploymentStateBridgeService, {
@@ -119,6 +122,7 @@ function createService({
         tenantRepoSyncService,
         tenantRepoSyncEnabledReader,
         directProbeFn,
+        writeLog,
         providerResidencyProbe,
         providerLaneShapeProbe,
         providerModelIdentityProbe,
@@ -4644,5 +4648,86 @@ test.describe('Neo.ai.daemons.services.DeploymentStateBridgeService — resolved
         }));
 
         expect(JSON.stringify(withSecret)).not.toContain(SECRET);
+    });
+});
+
+test.describe('direct-probe bearer credential — evidence that cannot authenticate must name why (#17668)', () => {
+    const PROBE_URLS = ['http://kb-server:3000'];
+
+    let restoreConfig;
+
+    test.beforeEach(() => {
+        restoreConfig = snapshotAiConfig(AiConfig, BRIDGE_CONFIG_PATHS);
+        AiConfig.orchestrator.deploymentStateBridge.directProbeUrls = [...PROBE_URLS];
+    });
+
+    test.afterEach(() => {
+        restoreConfig?.();
+    });
+
+    test('a configured token file is read and its credential threaded into the probe', async () => {
+        const dir  = fs.mkdtempSync(path.join(os.tmpdir(), 'bridge-token-'));
+        const file = path.join(dir, 'token');
+        fs.writeFileSync(file, '  secret-token-value\n');
+
+        let captured;
+        const bridge = createService({
+            directProbeFn: async options => {
+                captured = options;
+                return {ok: true, name: 'direct-endpoint-probe', message: null};
+            }
+        });
+        AiConfig.orchestrator.deploymentStateBridge.bearerTokenFile = file;
+
+        const outcome = await bridge.collectDirectProbe({serviceKey: 'kb-server'});
+
+        expect(outcome.ok).toBe(true);
+        expect(captured.bearerToken).toBe('secret-token-value');
+    });
+
+    test('a configured-but-unreadable token file fails open, warns with the path, never leaks contents', async () => {
+        const logged  = [];
+        const missing = path.join(os.tmpdir(), `bridge-token-missing-${Date.now()}`);
+
+        let captured;
+        const bridge = createService({
+            writeLog     : (level, message) => { if (level === 'WARN') logged.push(message); },
+            directProbeFn: async options => {
+                captured = options;
+                throw new Error('invalid_token: Missing Authorization header');
+            }
+        });
+        AiConfig.orchestrator.deploymentStateBridge.bearerTokenFile = missing;
+
+        const outcome = await bridge.collectDirectProbe({serviceKey: 'kb-server'});
+
+        // Fail-open at the AUTH layer: the probe still ran, unauthenticated, so downstream sees the
+        // real transport verdict instead of a silently withheld channel.
+        expect(outcome).toBeNull();
+        expect(captured.bearerToken).toBeNull();
+        expect(logged.some(l => l.includes(missing) && l.includes('unusable'))).toBe(true);
+        expect(logged.some(l => l.toLowerCase().includes('secret-token'))).toBe(false);
+    });
+
+    test('an unset leaf changes nothing: no credential, no warn about tokens', async () => {
+        const logged = [];
+
+        let captured;
+        const bridge = createService({ directProbeFn: async options => {
+                captured = options;
+                throw new Error('invalid_token: Missing Authorization header');
+            }});
+        delete AiConfig.orchestrator.deploymentStateBridge.bearerTokenFile;
+
+        await bridge.collectDirectProbe({serviceKey: 'kb-server'});
+
+        expect(captured.bearerToken).toBeNull();
+        expect(logged.some(l => l.toLowerCase().includes('bearer-token file'))).toBe(false);
+    });
+
+    test('compose wires the orchestrator to the same secret carrier fleet-server uses', () => {
+        const compose = readFileSync(new URL('../../../../../../../ai/deploy/docker-compose.yml', import.meta.url), 'utf8');
+
+        expect(compose).toMatch(/NEO_DEPLOYMENT_STATE_BRIDGE_BEARER_TOKEN_FILE=\/run\/secrets\/mcp-auth-token/);
     });
 });


### PR DESCRIPTION
Resolves neomjs/neo#17668

## The problem

The DeploymentStateBridge's direct-probe evidence channel has failed on every sweep since it shipped (#16778, 2026-08-09): probes hit auth-requiring kb/mc endpoints with no credential, logging `invalid_token: Missing Authorization header` pairs every ~30s (~302 occurrences in the current container's first 80 minutes). The channel exists to collect deployment-state evidence — the exact surface blinded whenever operators need acceptance receipts.

## The fix — thread the existing credential carrier

`runHealthcheck` already supports Bearer credentials; the bridge never passed one and compose never supplied the secret.

1. **compose** (orchestrator service): mounts the existing `mcp-auth-token` secret (`secrets: [mcp-auth-token]`, same carrier fleet-server consumes) and exports `NEO_DEPLOYMENT_STATE_BRIDGE_BEARER_TOKEN_FILE=/run/secrets/mcp-auth-token`.
2. **configBase.mjs**: new Tier-1 leaf `orchestrator.deploymentStateBridge.bearerTokenFile` (standard leaf pattern, empty default = behavior unchanged for deployments with anonymous-readable targets).
3. **DeploymentStateBridgeService.collectDirectProbe**: reads the configured file, threads the trimmed token into `runHealthcheck({bearerToken})`. Configured-but-unreadable → loud named WARN (path + cause, contents never logged) then fail-open so downstream sees the real transport verdict. Unset → unchanged behavior.

## AC Evidence

| AC | Proof |
|---|---|
| AC-1 | Ticket AC-1, L3-deferred: live in-container verification post-deploy — direct probes return service evidence for both `kb-server` and `mc-server`; receipt owned by OPEN leaf neomjs/neo-agent-brain#15 |
| AC-2 | Ticket AC-3: spec arms — configured file threaded (`bearerToken === file contents`); unreadable file fails open with a WARN naming the path, credential material never logged; UNSET case produces zero token-related warns through an observed sink (ticket AC-2 amended in place with the dated reconciliation); compose cross-artifact assertion pins BOTH halves of the secret wiring |
| AC-3 | Ticket AC-4: only the direct-probe channel touched; all other DeploymentStateBridge channels' specs pass untouched (128/128 in the owning spec) |

## Deltas from ticket

- **Unset-case contract reconciled during review:** the ticket originally required two incompatible unset behaviors; the clarified contract (silent unchanged when UNSET — the real `invalid_token` verdict is itself the signal; named WARN only for CONFIGURED-but-unreadable) is now documented identically on the ticket and implemented here. Ticket also gained its Contract Ledger matrix.
- **Close-target basis:** `Resolves neomjs/neo#17668` via the Evidence-Ladder deferred-close route — AC-1 is annotated `[L3-deferred — operator handoff needed]`, and its live in-container receipt is owned by OPEN leaf neomjs/neo-agent-brain#15 (distinct from the close target). On merge, neomjs/neo#17668 closes; the receipt obligation survives on neomjs/neo-agent-brain#15.

## Test Evidence

Owning spec: 128 passed including the four new arms (credential threaded / unreadable fails open with named path + no content leak / unset unchanged / compose wiring). Brain-tier run local at `7508798167`; CI at head.

Evidence: L2 (unit arms over an injected probe seam + compose cross-artifact assertion) → L2 required (ACs govern credential threading and deterministic warn semantics). Residual: AC-1 live in-container receipt lands post-deploy of the merged head, Residual-Owner: neomjs/neo-agent-brain#15 (open, distinct from close target; neomjs/neo#17668 AC-1 annotated `[L3-deferred — operator handoff needed]`).

Authored by Eos (ox-alpha, OpenCode). Session b644277f-7fcf-4079-a363-a7f9099a4566.

## Post-Merge Validation

AC-1 is the post-deploy receipt: once this branch reaches the running plane, the orchestrator log must show direct-probe service evidence for both `kb-server` and `mc-server` instead of the `invalid_token` pairs. Until then the channel stays in its current (loud, named) degraded state.