### PR TITLE
fix(github-workflow): a withdrawn approval no longer reports merge-ready (#17608)

### DIFF
--- a/.agents/skills/pr-review/references/merge-hold-tokens.md
+++ b/.agents/skills/pr-review/references/merge-hold-tokens.md
@@ -1,0 +1,31 @@
+<!-- trigger: you approved a PR and now want to stop or suspend its merge -> read this before commenting -->
+
+# Withdrawing an approval — the merge-hold tokens
+
+An approval you have already submitted stays `APPROVED` on GitHub forever. `reviewDecision` is a
+flattened snapshot with no notion of supersession, so **saying "do not merge" in a comment does not
+retract it** — the PR keeps reporting merge-ready, and a human trusting that surface merges past you.
+
+To withdraw or suspend an approval, open the comment with one of these tokens on its own line
+(the heading form is fine — `` ## `[MERGE_HOLD]` ``):
+
+| Token | Means |
+|---|---|
+| `[MERGE_HOLD]` | Do not merge at this head. A prior approval is not a current authorization. |
+| `[RE_REVIEW_HOLD]` | The approval stands but the head moved; re-review before merging. |
+
+`validateMergeReady` reads them and blocks readiness, naming you as the holder. Two rules follow
+from that and both matter to you:
+
+- **Only a NEWER submitted review from you clears your hold.** A follow-up comment does not — not
+  even yours — so post a review when you are satisfied rather than replying "looks good now".
+- **No other peer can clear it.** A third party dispositioning your objection would read as resolved
+  while you still object.
+
+Matching is structural, not lexical: the token must open a line. Writing *"no reason to
+`[MERGE_HOLD]` this"* mid-sentence does **not** hold the PR, so you can discuss holds without
+issuing one. An unrecognised token is not a hold — use the two above or the gate will not see you.
+
+Dismissing the approval through GitHub's UI also works and is the stronger signal; the tokens exist
+because remembering to dismiss was load-bearing and nothing prompted it.
+

--- a/.agents/skills/pr-review/references/pr-review-guide.md
+++ b/.agents/skills/pr-review/references/pr-review-guide.md
@@ -321,6 +321,11 @@ When §0 surfaces Cycle-1 structural invalidity — false premise, ungraduated s
 
 After `[REJECTED_WITH_RATIONALE]` (`review-response-protocol.md §4`), re-escalate the same item only with superior empirical evidence naming a missed failure mode. Authority or preference is insufficient; if the rationale survives falsification, yield, resolve it, and continue the PR lifecycle.
 
+### 9.2 Withdrawing an approval
+
+A comment saying "do not merge" does **not** retract a submitted approval; open it with
+`[MERGE_HOLD]` or `[RE_REVIEW_HOLD]`: [`merge-hold-tokens.md`](./merge-hold-tokens.md).
+
 ## 10. A2A Comment-ID Hand-off (warm-cache review cycles)
 
 For multi-cycle reviews, after posting a review comment **capture its `commentId` and A2A it to the next actor** (peer or author) with a one-line substance summary — so they fetch just that comment instead of re-reading the whole thread (full-thread re-fetch cost grows with thread length).

--- a/ai/scripts/lifecycle/validateMergeReady.mjs
+++ b/ai/scripts/lifecycle/validateMergeReady.mjs
@@ -36,6 +36,10 @@ export const MERGEABLE_STATES = ['CLEAN', 'UNSTABLE'];
  *  6. `crossFamilyVerdict` is resolved AND reports `crossFamily === true` — the §6.1 cross-family mandate.
  *     GitHub models no model family, so rule 2 cannot stand in for this one: an APPROVED badge earned
  *     entirely within the author's own family satisfies `reviewDecision` and violates the mandate.
+ *  7. `holdVerdict` is resolved AND reports no active reviewer hold. A reviewer can approve at T0 and
+ *     withdraw at T1 by posting `[MERGE_HOLD]`; `reviewDecision` is a flattened snapshot with no
+ *     notion of supersession and still reads APPROVED. This is rule 5's mirror — there a PENDING
+ *     obligation was invisible, here a RETRACTED approval is.
  *
  * Fail-CLOSED contract: `state`, `mergedAt`, `checksGreen`, `mergeStateStatus`, and `reviewRequests`
  * that were NOT fetched (`undefined`) each block readiness — an un-queried field cannot certify a
@@ -50,6 +54,7 @@ export const MERGEABLE_STATES = ['CLEAN', 'UNSTABLE'];
  * @param {String} [pr.mergeStateStatus] GitHub mergeStateStatus (`CLEAN` | `UNSTABLE` | `DIRTY` | `BEHIND` | `BLOCKED` | ...); `undefined` (not fetched) fails closed.
  * @param {String[]} [pr.reviewRequests] Logins of still-requested reviewers (the explicit author/operator contract); `undefined` (not fetched) fails closed, `[]` asserts fetched-and-empty.
  * @param {String[]} [pr.disposedReviewers] Requested reviewers already disposed (formal review / visible step-out / unrequest).
+ * @param {Object} [pr.holdVerdict] Verdict from `resolveMergeHold` — `{held, holders}`. `undefined` (not resolved) fails closed; `held: null` (the comment window was truncated) blocks with its own reason rather than reading as "no hold".
  * @param {Object} [pr.crossFamilyVerdict] Verdict from `resolveCrossFamilyVerdict` — `{crossFamily, authorFamily, approvingFamilies, authorLogin}`. `undefined` (not resolved) fails closed; `crossFamily: null` (author family unresolved) blocks with its own reason rather than collapsing into pass or fail.
  * @param {String} [pr.approvedAtOid] Commit oid the approving review was submitted against. Optional: absent means the anchor is not reported, never that it is fresh.
  * @param {String} [pr.headRefOid] Current head oid, paired with `approvedAtOid` to surface a stale approval anchor.
@@ -66,7 +71,8 @@ export function validateMergeReady(pr = {}) {
         disposedReviewers = [],
         approvedAtOid,
         headRefOid,
-        crossFamilyVerdict
+        crossFamilyVerdict,
+        holdVerdict
     } = pr;
 
     const blockers   = [],
@@ -106,6 +112,26 @@ export function validateMergeReady(pr = {}) {
         blockers.push(`cross-family mandate could not be evaluated: the author family did not resolve${crossFamilyVerdict.authorLogin ? ` for '${crossFamilyVerdict.authorLogin}'` : ''}. An unrostered author is usually an external contributor, for whom the mandate does not apply — confirm that before merging.`);
     } else if (crossFamilyVerdict?.crossFamily === false) {
         blockers.push(`cross-family review mandate unsatisfied: author family '${crossFamilyVerdict.authorFamily}', approving families [${(crossFamilyVerdict.approvingFamilies || []).join(', ') || 'none'}]. pull-request-workflow.md §6.1 requires at least one APPROVED review from a different model family; GitHub's reviewDecision cannot express this, so an APPROVED badge is not evidence of it.`);
+    }
+
+    // A reviewer who withdrew their approval in a comment. Every other gap in this validator fails
+    // CLOSED — an unfetched field blocks, `UNKNOWN` mergeability blocks, an outstanding reviewer
+    // blocks. This one failed OPEN: the PR reported green while its owner had explicitly said stop,
+    // and the stop lived in prose no readiness surface read. Observed live, with the author (me)
+    // having already broadcast merge-ready inside that window.
+    //
+    // `held: null` is the truncated-window case and is NOT "no hold": a bounded comment list can
+    // hide one, and absence in a bounded window is missing evidence rather than evidence of
+    // absence. It blocks with its own reason so the reader can tell "someone is holding this" from
+    // "we could not see far enough to know".
+    if (holdVerdict === undefined) {
+        blockers.push('holdVerdict was not resolved — cannot certify that no reviewer withdrew approval; failing closed.');
+    } else if (holdVerdict?.held === null) {
+        blockers.push('reviewer-hold state could not be evaluated: the comment window was truncated, so a hold may sit outside it. Absence over a bounded window is missing evidence, not evidence of absence.');
+    } else if (holdVerdict?.held === true) {
+        const named = (holdVerdict.holders || []).map(holder => `@${holder.login} (${holder.token})`).join(', ');
+
+        blockers.push(`reviewer hold outstanding: ${named || 'unnamed holder'}. A hold posted after that reviewer's latest submitted review withdraws it; reviewDecision cannot express supersession, so an APPROVED badge is not evidence the approval still stands. Only a NEWER submitted review from the same reviewer clears it.`);
     }
 
     // The anchor, and it is deliberately an ADVISORY rather than a blocker.

--- a/ai/services/github-workflow/PullRequestService.mjs
+++ b/ai/services/github-workflow/PullRequestService.mjs
@@ -9,6 +9,7 @@ import aiConfig             from '../../mcp/server/github-workflow/config.mjs';
 import logger               from '../../mcp/server/github-workflow/logger.mjs';
 import RepositoryService    from './RepositoryService.mjs';
 import {validateMergeReady} from '../../scripts/lifecycle/validateMergeReady.mjs';
+import {mergeHoldToken, resolveMergeHold} from './shared/mergeHoldTokens.mjs';
 import {
     groupReviewsByFamily,
     parseSelfIdLogin,
@@ -421,7 +422,8 @@ function normalizeMergeReadinessSnapshot(pullRequest) {
     // with SOURCE_CHANGED_DURING_READ every time a peer left a comment mid-read, for a change that
     // moves no readiness. A CHANGES_REQUESTED landing mid-read still trips the comparison, through
     // `reviewDecision`, which is where that state actually lives.
-    const reviewsConnection = pullRequest.reviews;
+    const reviewsConnection  = pullRequest.reviews;
+    const commentsConnection = pullRequest.comments;
     const approvals         = (reviewsConnection?.nodes || [])
         .filter(node => node?.state === 'APPROVED' && node?.commit?.oid && node?.submittedAt)
         // `login` rides along because the cross-family mandate is a question about WHO approved,
@@ -456,6 +458,30 @@ function normalizeMergeReadinessSnapshot(pullRequest) {
         // only the declared author login points the drift signal at what matters: a change to the
         // declared author invalidates the read, a typo fix in the description does not.
         authorSelfIdLogin: parseSelfIdLogin(pullRequest.body ?? '') ?? null,
+        // DERIVED hold facts, never raw comment bodies. Same reasoning as `authorSelfIdLogin`: this
+        // snapshot is compared by `stableStringify` across two reads, so carrying comment text would
+        // make any peer's unrelated comment invalidate the observation. Only comments bearing a
+        // recognised token survive, reduced to who/when/which — so a hold appearing or clearing moves
+        // the value and ordinary chatter does not.
+        holdComments     : {
+            available: Boolean(commentsConnection && Array.isArray(commentsConnection.nodes)),
+            truncated: Boolean(commentsConnection?.pageInfo?.hasPreviousPage),
+            nodes    : (commentsConnection?.nodes || [])
+                .map(node => ({
+                    login    : node?.author?.login ?? null,
+                    createdAt: node?.createdAt ?? null,
+                    commentId: node?.databaseId ?? null,
+                    token    : mergeHoldToken(node?.body ?? '')
+                }))
+                .filter(node => node.token && node.login && node.createdAt)
+        },
+        // EVERY submitted review, not just approvals: a hold is cleared by a newer submitted review
+        // from the same reviewer in ANY state, so filtering to APPROVED here would leave a
+        // CHANGES_REQUESTED-then-re-review sequence reading as still held.
+        reviewSubmissions: (reviewsConnection?.nodes || [])
+            .filter(node => node?.author?.login && node?.submittedAt)
+            .map(node => ({login: node.author.login, submittedAt: node.submittedAt}))
+            .sort((a, b) => a.submittedAt.localeCompare(b.submittedAt) || a.login.localeCompare(b.login)),
         reviewRequests  : {
             available  : Boolean(reviewConnection && Array.isArray(reviewConnection.nodes)),
             hasNextPage: Boolean(reviewConnection?.pageInfo?.hasNextPage),
@@ -816,6 +842,17 @@ async function buildMergeReadinessProjection({
         }
         : undefined;
 
+    // The reviewer-hold gate. Unavailable comments yield `undefined` rather than an empty verdict:
+    // "the comments were not fetched" and "nobody is holding" are different facts, and only the
+    // first should read as unresolved.
+    const holdVerdict = snapshot.holdComments.available
+        ? resolveMergeHold({
+            comments : snapshot.holdComments.nodes,
+            reviews  : snapshot.reviewSubmissions,
+            truncated: snapshot.holdComments.truncated
+        })
+        : undefined;
+
     const predicate = validateMergeReady({
         state           : snapshot.state,
         mergedAt        : snapshot.mergedAt,
@@ -824,6 +861,7 @@ async function buildMergeReadinessProjection({
         mergeStateStatus: snapshot.mergeStateStatus,
         reviewRequests,
         crossFamilyVerdict,
+        holdVerdict,
         approvedAtOid,
         headRefOid      : snapshot.headRefOid
     });

--- a/ai/services/github-workflow/PullRequestService.mjs
+++ b/ai/services/github-workflow/PullRequestService.mjs
@@ -478,9 +478,13 @@ function normalizeMergeReadinessSnapshot(pullRequest) {
         // EVERY submitted review, not just approvals: a hold is cleared by a newer submitted review
         // from the same reviewer in ANY state, so filtering to APPROVED here would leave a
         // CHANGES_REQUESTED-then-re-review sequence reading as still held.
+        //
+        // `state` rides along because the hold reader needs BOTH halves of the timeline: any
+        // submission clears a hold, but only an APPROVED one grants the standing to raise one.
+        // Dropping it here is what let a commenter with no review read as an active holder.
         reviewSubmissions: (reviewsConnection?.nodes || [])
             .filter(node => node?.author?.login && node?.submittedAt)
-            .map(node => ({login: node.author.login, submittedAt: node.submittedAt}))
+            .map(node => ({login: node.author.login, state: node.state ?? null, submittedAt: node.submittedAt}))
             .sort((a, b) => a.submittedAt.localeCompare(b.submittedAt) || a.login.localeCompare(b.login)),
         reviewRequests  : {
             available  : Boolean(reviewConnection && Array.isArray(reviewConnection.nodes)),

--- a/ai/services/github-workflow/queries/pullRequestQueries.mjs
+++ b/ai/services/github-workflow/queries/pullRequestQueries.mjs
@@ -64,6 +64,12 @@ export const GET_CONVERSATION = `
  * bounded list. This paragraph used to say truncation could change no decision this query feeds —
  * true until the mandate became one of them.
  *
+ * `comments` is fetched `last` for the same reason and gates the same way: a reviewer HOLD is the
+ * latest state of that reviewer's position, and a hold found inside the window is decisive while a
+ * negative over a truncated one is unresolved. Bodies are read only to classify a hold token and are
+ * NOT carried onto the snapshot — the snapshot is drift-compared, so raw comment text would make any
+ * peer's unrelated comment invalidate the observation.
+ *
  * Variables required:
  * - $owner: String! - Repository owner
  * - $repo: String! - Repository name
@@ -117,6 +123,19 @@ export const GET_MERGE_READINESS = `
             commit {
               oid
             }
+          }
+        }
+        comments(last: 100) {
+          pageInfo {
+            hasPreviousPage
+          }
+          nodes {
+            databaseId
+            createdAt
+            author {
+              login
+            }
+            body
           }
         }
         commits(last: 1) {

--- a/ai/services/github-workflow/shared/mergeHoldTokens.mjs
+++ b/ai/services/github-workflow/shared/mergeHoldTokens.mjs
@@ -43,11 +43,34 @@ const MERGE_HOLD_TOKENS = new Set([
  *
  * Multi-line bodies are scanned per line, because a hold is normally a heading above its rationale.
  *
+ * **CODE IS EXAMPLE, NEVER ISSUANCE.** A token inside a fenced block or an indented code block is
+ * being SHOWN, not emitted — and mid-sentence backticks were already the only quoted form this
+ * caught. The documentation for this very feature opens a fence with `[MERGE_HOLD]` in it, so
+ * without this a reviewer who quotes the docs to explain the convention blocks the PR they are
+ * explaining it on. Found by @neo-gpt-emmy at review: the original negative control exercised the
+ * inline-backtick shape the matcher already handled and never the fenced shape it did not.
+ *
  * @param {String} body Comment body.
  * @returns {String|null} the matched token name (lower-case), or `null`.
  */
 export function mergeHoldToken(body = '') {
+    let fenced = false;
+
     for (const line of String(body).split('\n')) {
+        // Toggle on any fence marker. An opening fence may carry an info string (```js); a closing
+        // one is bare. Treating both as a toggle is enough — an UNCLOSED fence then swallows the
+        // rest of the body, which fails toward "no hold" and is the correct direction: a body whose
+        // markdown does not terminate is not an unambiguous issuance.
+        if (/^\s{0,3}(?:```|~~~)/.test(line)) {
+            fenced = !fenced;
+            continue;
+        }
+
+        // Four spaces is a markdown code block by the same reasoning as the fence.
+        if (fenced || /^\s{4,}\S/.test(line)) {
+            continue;
+        }
+
         const run = line.match(/^\s*[#`\s]*(?:\[[^\]]*\]\s*`?\s*)+/);
 
         if (!run) {
@@ -69,9 +92,13 @@ export function mergeHoldToken(body = '') {
 /**
  * @summary Decides whether an ACTIVE reviewer hold stands against a PR.
  *
- * A hold is active when a reviewer's hold comment is NEWER than that same reviewer's latest
- * submitted review. The two clearing rules are the whole design and both are deliberate:
+ * A hold is a reviewer WITHDRAWING THEIR OWN APPROVAL. That is one rule about standing and two
+ * about clearing, and all three are deliberate:
  *
+ * - **Only a prior approver can hold.** The token confers no authority by itself: a commenter with
+ *   no approving review has no approval to retract, and admitting them would let any drive-by
+ *   comment block any PR. The approval must be strictly OLDER than the hold — approving after your
+ *   own hold is the approval speaking last.
  * - **Only a newer submitted review from the SAME reviewer clears it.** A later comment does not —
  *   a hold cleared by a comment would let the holder's own "thanks, looking now" retract their stop.
  * - **Another peer never clears it.** A hold cleared by a third party would read as deliberately
@@ -82,14 +109,24 @@ export function mergeHoldToken(body = '') {
  * truncated window is missing evidence rather than evidence of absence — the same existential
  * asymmetry the cross-family mandate hits on its bounded approvals list. The caller fails closed.
  *
+ * **The persistence boundary, stated rather than implied.** Comments are mutable and this reader
+ * sees only the CURRENT body, so editing the token out of a hold comment does erase the hold
+ * without any newer review. Recovering that needs issuance history the comment API does not carry
+ * in this projection. So "only a newer review clears it" governs the REVIEW timeline; it is not a
+ * claim about an editable source, and a reader who takes it for one is owed this paragraph.
+ *
  * @param {Object}   args
  * @param {Object[]} [args.comments=[]] `{login, createdAt, token, commentId}` — pre-classified.
- * @param {Object[]} [args.reviews=[]]  `{login, submittedAt}` — submitted reviews only.
+ * @param {Object[]} [args.reviews=[]]  `{login, submittedAt, state}` — submitted reviews only.
  * @param {Boolean}  [args.truncated=false] Whether the comment window was bounded away.
  * @returns {{held: (Boolean|null), holders: Object[]}} `held: null` means it could not be decided.
  */
 export function resolveMergeHold({comments = [], reviews = [], truncated = false} = {}) {
-    const latestReviewByLogin = new Map();
+    const
+        // Two indices, because standing and clearing ask different questions of the same timeline:
+        // an APPROVED review grants the right to hold, any submitted review spends it.
+        latestApprovalByLogin = new Map(),
+        latestReviewByLogin   = new Map();
 
     for (const review of reviews) {
         const login = review?.login;
@@ -103,6 +140,14 @@ export function resolveMergeHold({comments = [], reviews = [], truncated = false
         if (!current || review.submittedAt > current) {
             latestReviewByLogin.set(login, review.submittedAt);
         }
+
+        if (review.state === 'APPROVED') {
+            const approved = latestApprovalByLogin.get(login);
+
+            if (!approved || review.submittedAt > approved) {
+                latestApprovalByLogin.set(login, review.submittedAt);
+            }
+        }
     }
 
     const holders = comments.filter(comment => {
@@ -110,11 +155,19 @@ export function resolveMergeHold({comments = [], reviews = [], truncated = false
             return false;
         }
 
-        const clearedAt = latestReviewByLogin.get(comment.login);
+        const approvedAt = latestApprovalByLogin.get(comment.login);
 
-        // Strictly newer: a review submitted at the same instant as the hold cannot be assumed to
-        // supersede it, and an equality that guessed would guess in the permissive direction.
-        return !clearedAt || comment.createdAt > clearedAt
+        // STANDING. No approval to withdraw, no hold — and an approval at-or-after the token means
+        // the reviewer's latest word is the approval itself.
+        if (!approvedAt || approvedAt >= comment.createdAt) {
+            return false;
+        }
+
+        // CLEARING. Strictly newer: a review submitted at the same instant as the hold cannot be
+        // assumed to supersede it, and an equality that guessed would guess in the permissive
+        // direction. `clearedAt` is always defined here — the approval that granted standing is
+        // itself a submitted review.
+        return comment.createdAt > latestReviewByLogin.get(comment.login)
     });
 
     return {

--- a/ai/services/github-workflow/shared/mergeHoldTokens.mjs
+++ b/ai/services/github-workflow/shared/mergeHoldTokens.mjs
@@ -1,0 +1,126 @@
+/**
+ * @module ai/services/github-workflow/shared/mergeHoldTokens
+ * @summary Reads reviewer merge-hold tokens off a PR timeline — the retracted half of an approval.
+ *
+ * A reviewer can approve at T0 and withdraw at T1 by posting a hold. GitHub's `reviewDecision` is a
+ * flattened snapshot with no notion of supersession, so it still reads `APPROVED` at T1 and the PR
+ * reports merge-ready while its owner has explicitly said stop. The tokens were already in the
+ * corpus — `[MERGE_HOLD]`, `[RE_REVIEW_HOLD]` — emitted by reviewers and read by nothing.
+ *
+ * This is the mirror of the case `validateMergeReady` was built for. There, `APPROVED` overstated
+ * the contract because a PENDING obligation was invisible; here because a RETRACTED approval is.
+ * Same root: a point-in-time flag standing in for a contract state.
+ *
+ * **A SET, not a regex over prose.** Reviewers write the word "hold" constantly, including in
+ * sentences declining to hold one — "no reason to hold this", "I am not holding merge on it". A
+ * substring matcher would block on those, and blocking a PR because someone said they were *not*
+ * blocking it is worse than the gap, because the reason would read as deliberate.
+ */
+
+/**
+ * The recognised merge-hold vocabulary. PRIVATE — the consumed contract is the reader below, never
+ * the Set: an exported mutable Set lets any importer rewrite every consumer's classifier at once.
+ *
+ * Both members are drawn from live reviewer usage rather than invented here. Adding one is a
+ * deliberate act with a real cost: a token nobody emits is dead weight, and a token that collides
+ * with ordinary prose re-opens the false-positive hole this Set exists to close.
+ * @type {Set<String>}
+ */
+const MERGE_HOLD_TOKENS = new Set([
+    'merge_hold',     // do not merge at this head; a prior approval is not a current authorization
+    're_review_hold'  // the approval stands but the head moved; re-review before merging
+]);
+
+/**
+ * @summary Returns the hold token a comment carries, or `null`.
+ *
+ * **Structural, never lexical.** A token counts only inside a bracket run that OPENS a line —
+ * `[MERGE_HOLD]`, or the heading form reviewers actually use, `` ## `[MERGE_HOLD]` ``. Leading `#`
+ * and backtick are skipped because that is how the convention is written in practice; everything
+ * else must be the bracket run itself. Prose mentioning `[MERGE_HOLD]` mid-sentence does not match,
+ * which is the same separation `a2aCollisionTags` draws between a message that IS a claim and one
+ * that MENTIONS claims.
+ *
+ * Multi-line bodies are scanned per line, because a hold is normally a heading above its rationale.
+ *
+ * @param {String} body Comment body.
+ * @returns {String|null} the matched token name (lower-case), or `null`.
+ */
+export function mergeHoldToken(body = '') {
+    for (const line of String(body).split('\n')) {
+        const run = line.match(/^\s*[#`\s]*(?:\[[^\]]*\]\s*`?\s*)+/);
+
+        if (!run) {
+            continue;
+        }
+
+        for (const match of run[0].matchAll(/\[([^\]]*)\]/g)) {
+            const name = match[1].trim().toLowerCase();
+
+            if (MERGE_HOLD_TOKENS.has(name)) {
+                return name;
+            }
+        }
+    }
+
+    return null
+}
+
+/**
+ * @summary Decides whether an ACTIVE reviewer hold stands against a PR.
+ *
+ * A hold is active when a reviewer's hold comment is NEWER than that same reviewer's latest
+ * submitted review. The two clearing rules are the whole design and both are deliberate:
+ *
+ * - **Only a newer submitted review from the SAME reviewer clears it.** A later comment does not —
+ *   a hold cleared by a comment would let the holder's own "thanks, looking now" retract their stop.
+ * - **Another peer never clears it.** A hold cleared by a third party would read as deliberately
+ *   dispositioned while the holder still objects, which is worse than no hold at all.
+ *
+ * **Truncation degrades to unresolved, never to "no hold".** The comment window is bounded, so a
+ * hold can sit outside it. A hold FOUND inside the window is decisive; finding none over a
+ * truncated window is missing evidence rather than evidence of absence — the same existential
+ * asymmetry the cross-family mandate hits on its bounded approvals list. The caller fails closed.
+ *
+ * @param {Object}   args
+ * @param {Object[]} [args.comments=[]] `{login, createdAt, token, commentId}` — pre-classified.
+ * @param {Object[]} [args.reviews=[]]  `{login, submittedAt}` — submitted reviews only.
+ * @param {Boolean}  [args.truncated=false] Whether the comment window was bounded away.
+ * @returns {{held: (Boolean|null), holders: Object[]}} `held: null` means it could not be decided.
+ */
+export function resolveMergeHold({comments = [], reviews = [], truncated = false} = {}) {
+    const latestReviewByLogin = new Map();
+
+    for (const review of reviews) {
+        const login = review?.login;
+
+        if (!login || !review?.submittedAt) {
+            continue;
+        }
+
+        const current = latestReviewByLogin.get(login);
+
+        if (!current || review.submittedAt > current) {
+            latestReviewByLogin.set(login, review.submittedAt);
+        }
+    }
+
+    const holders = comments.filter(comment => {
+        if (!comment?.token || !comment?.login || !comment?.createdAt) {
+            return false;
+        }
+
+        const clearedAt = latestReviewByLogin.get(comment.login);
+
+        // Strictly newer: a review submitted at the same instant as the hold cannot be assumed to
+        // supersede it, and an equality that guessed would guess in the permissive direction.
+        return !clearedAt || comment.createdAt > clearedAt
+    });
+
+    return {
+        held: holders.length > 0 ? true : (truncated ? null : false),
+        holders
+    }
+}
+
+export default resolveMergeHold;

--- a/ai/services/github-workflow/shared/mergeHoldTokens.mjs
+++ b/ai/services/github-workflow/shared/mergeHoldTokens.mjs
@@ -44,17 +44,24 @@ const MERGE_HOLD_TOKENS = new Set([
  * Multi-line bodies are scanned per line, because a hold is normally a heading above its rationale.
  *
  * **CODE IS EXAMPLE, NEVER ISSUANCE.** A token inside a fenced block or an indented code block is
- * being SHOWN, not emitted — and mid-sentence backticks were already the only quoted form this
- * caught. The documentation for this very feature opens a fence with `[MERGE_HOLD]` in it, so
- * without this a reviewer who quotes the docs to explain the convention blocks the PR they are
- * explaining it on. Found by @neo-gpt-emmy at review: the original negative control exercised the
- * inline-backtick shape the matcher already handled and never the fenced shape it did not.
+ * being SHOWN, not emitted. Found by @neo-gpt-emmy at review: the original negative control
+ * exercised the inline-backtick shape the matcher already handled and never the fenced shape it
+ * did not.
+ *
+ * **A BLOCK, not a line.** "Opens a line" is not a property an author controls — prose wraps, and a
+ * wrap can promote a mid-sentence mention to line-initial. The reference doc's own sentence
+ * explaining that a mid-sentence mention does NOT hold wrapped precisely there and classified as a
+ * hold; an example that contradicts itself is the sharpest possible evidence that the rule was
+ * wrong. So a token must open a BLOCK: first content line, after a blank line, or after a fence.
+ * A wrapped continuation always has a non-blank predecessor and is therefore never an issuance.
  *
  * @param {String} body Comment body.
  * @returns {String|null} the matched token name (lower-case), or `null`.
  */
 export function mergeHoldToken(body = '') {
-    let fenced = false;
+    let
+        blockStart = true,
+        fenced     = false;
 
     for (const line of String(body).split('\n')) {
         // Toggle on any fence marker. An opening fence may carry an info string (```js); a closing
@@ -62,7 +69,9 @@ export function mergeHoldToken(body = '') {
         // rest of the body, which fails toward "no hold" and is the correct direction: a body whose
         // markdown does not terminate is not an unambiguous issuance.
         if (/^\s{0,3}(?:```|~~~)/.test(line)) {
-            fenced = !fenced;
+            fenced     = !fenced;
+            // A fence ends the block it interrupted, so the line after it opens a new one.
+            blockStart = true;
             continue;
         }
 
@@ -71,9 +80,19 @@ export function mergeHoldToken(body = '') {
             continue;
         }
 
-        const run = line.match(/^\s*[#`\s]*(?:\[[^\]]*\]\s*`?\s*)+/);
+        if (!line.trim()) {
+            blockStart = true;
+            continue;
+        }
 
-        if (!run) {
+        const
+            opensBlock = blockStart,
+            run        = line.match(/^\s*[#`\s]*(?:\[[^\]]*\]\s*`?\s*)+/);
+
+        // Every non-blank line consumes the block opening, whether or not it carries a token.
+        blockStart = false;
+
+        if (!opensBlock || !run) {
             continue;
         }
 

--- a/test/playwright/unit/ai/scripts/lifecycle/validateMergeReady.spec.mjs
+++ b/test/playwright/unit/ai/scripts/lifecycle/validateMergeReady.spec.mjs
@@ -18,6 +18,7 @@ test.describe('validateMergeReady — strict merge-readiness contract', () => {
         state             : 'OPEN',
         mergedAt          : null,
         crossFamilyVerdict: {crossFamily: true, authorFamily: 'claude', approvingFamilies: ['gpt'], authorLogin: 'neo-opus-grace'},
+        holdVerdict       : {held: false, holders: []},
         ...overrides
     });
 
@@ -151,6 +152,7 @@ test.describe('validateMergeReady — the approval anchor', () => {
         state             : 'OPEN',
         mergedAt          : null,
         crossFamilyVerdict: {crossFamily: true, authorFamily: 'claude', approvingFamilies: ['gpt'], authorLogin: 'neo-opus-grace'},
+        holdVerdict       : {held: false, holders: []},
         ...overrides
     });
 
@@ -242,6 +244,7 @@ test.describe('validateMergeReady — the cross-family mandate', () => {
         checksGreen     : true,
         mergeStateStatus: 'CLEAN',
         reviewRequests  : [],
+        holdVerdict     : {held: false, holders: []},
         ...overrides
     });
 
@@ -290,5 +293,57 @@ test.describe('validateMergeReady — the cross-family mandate', () => {
         // would send the reader hunting for a reviewer who was never required.
         expect(result.blockers.some(entry => entry.includes('could not be evaluated') && entry.includes('external-dev'))).toBe(true);
         expect(result.blockers.some(entry => entry.includes('mandate unsatisfied'))).toBe(false);
+    })
+});
+
+/**
+ * @summary Rule 7 — a reviewer who withdrew approval in a comment.
+ *
+ * Rule 5's mirror: there a PENDING obligation was invisible to `reviewDecision`, here a RETRACTED
+ * approval is. Every other gap in this module fails CLOSED; this one failed OPEN, reporting green
+ * while an owner had explicitly said stop.
+ */
+test.describe('validateMergeReady — the reviewer-hold gate', () => {
+    // Not the shared builder: these arms are about the hold field, so inheriting a healthy default
+    // is the one thing that would make them vacuous.
+    const green = overrides => ({
+        state             : 'OPEN',
+        mergedAt          : null,
+        reviewDecision    : 'APPROVED',
+        checksGreen       : true,
+        mergeStateStatus  : 'CLEAN',
+        reviewRequests    : [],
+        crossFamilyVerdict: {crossFamily: true, authorFamily: 'claude', approvingFamilies: ['gpt']},
+        ...overrides
+    });
+
+    test('an active hold blocks, and the blocker NAMES the holder and the token', () => {
+        const result = validateMergeReady(green({
+            holdVerdict: {held: true, holders: [{login: 'neo-gpt-emmy', token: 'merge_hold'}]}
+        }));
+
+        expect(result.strictMergeReady).toBe(false);
+        // A bare false sends the reader back to the PR to find out who is holding and why.
+        expect(result.blockers.some(entry => entry.includes('@neo-gpt-emmy') && entry.includes('merge_hold'))).toBe(true);
+    });
+
+    test('no hold passes, on the same otherwise-identical surface', () => {
+        expect(validateMergeReady(green({holdVerdict: {held: false, holders: []}})).strictMergeReady).toBe(true);
+    });
+
+    test('an UNRESOLVED hold verdict fails closed, like every other predicate field', () => {
+        const result = validateMergeReady(green());
+
+        expect(result.strictMergeReady).toBe(false);
+        expect(result.blockers.some(entry => entry.includes('was not resolved'))).toBe(true);
+    });
+
+    test('a truncated comment window blocks with its OWN reason, not a hold claim', () => {
+        const result = validateMergeReady(green({holdVerdict: {held: null, holders: []}}));
+
+        expect(result.strictMergeReady).toBe(false);
+        // Three states, three messages: naming a holder we never saw would be a fabrication.
+        expect(result.blockers.some(entry => entry.includes('could not be evaluated'))).toBe(true);
+        expect(result.blockers.some(entry => entry.includes('hold outstanding'))).toBe(false);
     })
 });

--- a/test/playwright/unit/ai/services/github-workflow/PullRequestService.spec.mjs
+++ b/test/playwright/unit/ai/services/github-workflow/PullRequestService.spec.mjs
@@ -396,6 +396,11 @@ test.describe('Neo.ai.services.github-workflow.PullRequestService — merge-read
         body = 'Authored by Vega (Claude Opus 5, Claude Code).',
         reviews = [{state: 'APPROVED', submittedAt: '2026-07-29T07:00:00.000Z', commit: {oid: HEAD}, author: {login: 'neo-gpt-emmy'}}],
         reviewsHasPreviousPage = false,
+        // A fetched-and-empty comment connection: the default fixture models a PR nobody has held,
+        // which is what arms about other rules need. `null` models a connection GitHub did not
+        // return, and the fail-closed arm uses that explicitly rather than relying on this default.
+        comments = [],
+        commentsHasPreviousPage = false,
         state = 'OPEN'
     } = {}) => ({
         number        : 16029,
@@ -416,6 +421,10 @@ test.describe('Neo.ai.services.github-workflow.PullRequestService — merge-read
         reviews: reviews === null ? null : {
             pageInfo: {hasPreviousPage: reviewsHasPreviousPage},
             nodes   : reviews
+        },
+        comments: comments === null ? null : {
+            pageInfo: {hasPreviousPage: commentsHasPreviousPage},
+            nodes   : comments
         },
         commits: {
             nodes: [{
@@ -648,6 +657,78 @@ test.describe('Neo.ai.services.github-workflow.PullRequestService — merge-read
         const result = await project(dependencies({snapshots: [witnessed(), witnessed()]}));
 
         expect(result.predicate.blockers.filter(entry => entry.includes('cross-family'))).toEqual([]);
+    });
+
+    /**
+     * @summary The T1 window from the live incident: approved, then held, still reporting green.
+     *
+     * A reviewer approved, then posted `[MERGE_HOLD]` stating the prior approval was not a current
+     * merge authorization. `reviewDecision` stayed APPROVED — it is a flattened snapshot with no
+     * notion of supersession — and merge-readiness reported true while the owner had said stop. The
+     * author had already broadcast merge-ready inside that window.
+     */
+    const withHold = ({token = 'MERGE_HOLD', holdAt = '2026-07-29T09:00:00.000Z', reviewAt = '2026-07-29T07:00:00.000Z', holder = 'neo-gpt-emmy', ...rest} = {}) => pullRequest({
+        reviews : [{state: 'APPROVED', submittedAt: reviewAt, commit: {oid: HEAD}, author: {login: holder}}],
+        comments: [{databaseId: 5301580683, createdAt: holdAt, author: {login: holder}, body: `## \`[${token}]\`\n\nMy prior approval is not a current merge authorization.`}],
+        ...rest
+    });
+
+    test('a reviewer hold posted AFTER their approval blocks readiness, and names the holder', async () => {
+        const result = await project(dependencies({snapshots: [withHold(), withHold()]}));
+
+        expect(result.predicate.strictMergeReady).toBe(false);
+        expect(result.predicate.blockers.some(entry => entry.includes('reviewer hold outstanding') && entry.includes('@neo-gpt-emmy'))).toBe(true);
+    });
+
+    test('only a NEWER submitted review from the SAME reviewer clears a hold', async () => {
+        // Cleared: the holder reviews again after holding.
+        const cleared = () => pullRequest({
+            reviews : [
+                {state: 'APPROVED', submittedAt: '2026-07-29T07:00:00.000Z', commit: {oid: HEAD}, author: {login: 'neo-gpt-emmy'}},
+                {state: 'APPROVED', submittedAt: '2026-07-29T11:00:00.000Z', commit: {oid: HEAD}, author: {login: 'neo-gpt-emmy'}}
+            ],
+            comments: [{databaseId: 1, createdAt: '2026-07-29T09:00:00.000Z', author: {login: 'neo-gpt-emmy'}, body: '## `[MERGE_HOLD]`'}]
+        });
+
+        expect((await project(dependencies({snapshots: [cleared(), cleared()]}))).predicate.blockers.some(e => e.includes('reviewer hold'))).toBe(false);
+
+        // NOT cleared by another peer's later review — a third party dispositioning someone else's
+        // stop would read as deliberate while the holder still objects.
+        const otherPeer = () => pullRequest({
+            reviews : [
+                {state: 'APPROVED', submittedAt: '2026-07-29T07:00:00.000Z', commit: {oid: HEAD}, author: {login: 'neo-gpt-emmy'}},
+                {state: 'APPROVED', submittedAt: '2026-07-29T11:00:00.000Z', commit: {oid: HEAD}, author: {login: 'neo-opus-vega'}}
+            ],
+            comments: [{databaseId: 1, createdAt: '2026-07-29T09:00:00.000Z', author: {login: 'neo-gpt-emmy'}, body: '## `[MERGE_HOLD]`'}]
+        });
+
+        expect((await project(dependencies({snapshots: [otherPeer(), otherPeer()]}))).predicate.blockers.some(e => e.includes('reviewer hold'))).toBe(true);
+    });
+
+    test('prose containing the word hold is NOT a hold, and an unrecognised token is not one either', async () => {
+        // Reviewers write "hold" constantly, including while declining to. Blocking on that would be
+        // worse than the gap, because the reason would read as deliberate.
+        const prose = () => withHold({token: 'NOT_A_REAL_TOKEN'});
+        expect((await project(dependencies({snapshots: [prose(), prose()]}))).predicate.blockers.some(e => e.includes('reviewer hold'))).toBe(false);
+
+        const chatty = () => pullRequest({
+            reviews : [{state: 'APPROVED', submittedAt: '2026-07-29T07:00:00.000Z', commit: {oid: HEAD}, author: {login: 'neo-gpt-emmy'}}],
+            comments: [{databaseId: 2, createdAt: '2026-07-29T09:00:00.000Z', author: {login: 'neo-gpt-emmy'}, body: 'No reason to hold this one — [MERGE_HOLD] would be overkill here.'}]
+        });
+        expect((await project(dependencies({snapshots: [chatty(), chatty()]}))).predicate.blockers.some(e => e.includes('reviewer hold'))).toBe(false);
+    });
+
+    test('an unfetched comment connection fails closed, and a truncated one is unresolved not "no hold"', async () => {
+        const unfetched = () => pullRequest({comments: null});
+        const a         = await project(dependencies({snapshots: [unfetched(), unfetched()]}));
+
+        expect(a.predicate.blockers.some(e => e.includes('holdVerdict was not resolved'))).toBe(true);
+
+        const truncated = () => pullRequest({commentsHasPreviousPage: true});
+        const b         = await project(dependencies({snapshots: [truncated(), truncated()]}));
+
+        expect(b.predicate.blockers.some(e => e.includes('could not be evaluated'))).toBe(true);
+        expect(b.predicate.blockers.some(e => e.includes('reviewer hold outstanding'))).toBe(false);
     });
 
     test('#16902: query carries exact workflow-run coordinates instead of inferring attempts by job name', () => {

--- a/test/playwright/unit/ai/services/github-workflow/shared/mergeHoldTokens.spec.mjs
+++ b/test/playwright/unit/ai/services/github-workflow/shared/mergeHoldTokens.spec.mjs
@@ -82,8 +82,8 @@ test.describe('mergeHoldTokens', () => {
 
     test.describe('issuance vs demonstration — code is an example, never a hold', () => {
         test('a token inside a fenced block is not an issuance', () => {
-            // `merge-hold-tokens.md` opens a fence with this exact token in it. Without this, a
-            // reviewer quoting the docs to explain the convention blocks the PR they explain it on.
+            // A reviewer quoting an example to explain the convention must not block the PR they
+            // are explaining it on.
             expect(mergeHoldToken('How it works:\n```\n[MERGE_HOLD] blocks the PR\n```\ndone')).toBeNull();
         });
 
@@ -112,6 +112,18 @@ test.describe('mergeHoldTokens', () => {
 
         test('a mid-sentence mention is not an issuance', () => {
             expect(mergeHoldToken('No reason to hold this one — `[MERGE_HOLD]` would be overkill')).toBeNull();
+        });
+
+        test('a mention that WRAPS to line-initial is still not an issuance', () => {
+            // The rule is "opens a BLOCK", not "opens a line" — where prose wraps is not a property
+            // the author controls. The reference doc's own sentence saying a mid-sentence mention
+            // does not hold wrapped exactly here, and classified as a hold under the line rule.
+            expect(mergeHoldToken('Writing "no reason to\n`[MERGE_HOLD]` this" mid-sentence does not hold')).toBeNull();
+        });
+
+        test('an issuance opening a later block still counts', () => {
+            // Non-vacuity for the block rule: it must not reduce to "only the first line can hold".
+            expect(mergeHoldToken('Some context first.\n\n[MERGE_HOLD] and here is the reason')).toBe('merge_hold');
         });
     });
 });

--- a/test/playwright/unit/ai/services/github-workflow/shared/mergeHoldTokens.spec.mjs
+++ b/test/playwright/unit/ai/services/github-workflow/shared/mergeHoldTokens.spec.mjs
@@ -1,0 +1,117 @@
+import {test, expect}                     from '@playwright/test';
+import {mergeHoldToken, resolveMergeHold} from '../../../../../../../ai/services/github-workflow/shared/mergeHoldTokens.mjs';
+
+/**
+ * Pure arms for the reviewer-hold reader.
+ *
+ * These exist because the composed service path could not see them. Every original arm ran through
+ * `PullRequestService`, whose fixtures all happen to give the holder an APPROVED review — so the
+ * two contracts that had no coverage at all were the two that were wrong: WHO may hold, and what
+ * counts as ISSUING rather than SHOWING a token. Both were found by @neo-gpt-emmy running the
+ * helper directly at review, which is the argument for this file existing.
+ */
+test.describe('mergeHoldTokens', () => {
+    const
+        hold = (login, createdAt, token = 'merge_hold') => ({login, createdAt, commentId: 1, token}),
+        rev  = (login, submittedAt, state = 'APPROVED') => ({login, submittedAt, state}),
+        T0   = '2026-07-29T07:00:00.000Z',
+        T1   = '2026-07-29T09:00:00.000Z',
+        T2   = '2026-07-29T11:00:00.000Z';
+
+    test.describe('standing — the token confers no authority by itself', () => {
+        test('a commenter with NO review is not a holder', () => {
+            // The whole point: otherwise any drive-by comment blocks any PR. An earlier cut
+            // returned `true` here, reading "no review yet" as "nothing has cleared it".
+            expect(resolveMergeHold({comments: [hold('drive-by', T1)], reviews: []}).held).toBe(false);
+        });
+
+        test('a commenter who reviewed but never APPROVED is not a holder', () => {
+            // A hold is the withdrawal of an approval. COMMENTED leaves nothing to withdraw.
+            expect(resolveMergeHold({
+                comments: [hold('peer-b', T1)],
+                reviews : [rev('peer-b', T0, 'COMMENTED')]
+            }).held).toBe(false);
+        });
+
+        test('an approval submitted AFTER the hold means the approval spoke last', () => {
+            expect(resolveMergeHold({
+                comments: [hold('peer-c', T1)],
+                reviews : [rev('peer-c', T2)]
+            }).held).toBe(false);
+        });
+
+        test('the live T1 specimen still holds — an approver who then posts a hold', () => {
+            // Non-vacuity: the three arms above must not be satisfiable by disabling the feature.
+            const verdict = resolveMergeHold({comments: [hold('peer-a', T1)], reviews: [rev('peer-a', T0)]});
+
+            expect(verdict.held).toBe(true);
+            expect(verdict.holders[0].login).toBe('peer-a');
+        });
+    });
+
+    test.describe('clearing', () => {
+        test('a newer submitted review from the SAME reviewer clears, in any state', () => {
+            expect(resolveMergeHold({
+                comments: [hold('peer-a', T1)],
+                reviews : [rev('peer-a', T0), rev('peer-a', T2, 'CHANGES_REQUESTED')]
+            }).held).toBe(false);
+        });
+
+        test('another peer never clears it', () => {
+            expect(resolveMergeHold({
+                comments: [hold('peer-a', T1)],
+                reviews : [rev('peer-a', T0), rev('peer-z', T2)]
+            }).held).toBe(true);
+        });
+    });
+
+    test.describe('truncation degrades to unresolved, never to "no hold"', () => {
+        test('an empty but truncated window is null, not false', () => {
+            expect(resolveMergeHold({comments: [], reviews: [], truncated: true}).held).toBeNull();
+        });
+
+        test('a hold FOUND inside a truncated window is still decisive', () => {
+            // A positive witness settles the question whatever lies beyond the window.
+            expect(resolveMergeHold({
+                comments : [hold('peer-a', T1)],
+                reviews  : [rev('peer-a', T0)],
+                truncated: true
+            }).held).toBe(true);
+        });
+    });
+
+    test.describe('issuance vs demonstration — code is an example, never a hold', () => {
+        test('a token inside a fenced block is not an issuance', () => {
+            // `merge-hold-tokens.md` opens a fence with this exact token in it. Without this, a
+            // reviewer quoting the docs to explain the convention blocks the PR they explain it on.
+            expect(mergeHoldToken('How it works:\n```\n[MERGE_HOLD] blocks the PR\n```\ndone')).toBeNull();
+        });
+
+        test('an info string on the fence does not re-admit it', () => {
+            expect(mergeHoldToken('```md\n[MERGE_HOLD] example\n```')).toBeNull();
+        });
+
+        test('a tilde fence closes the same hole', () => {
+            expect(mergeHoldToken('~~~\n[MERGE_HOLD] example\n~~~')).toBeNull();
+        });
+
+        test('an indented code block is a code block too', () => {
+            expect(mergeHoldToken('Example:\n\n    [MERGE_HOLD] indented\n')).toBeNull();
+        });
+
+        test('a real issuance AFTER a closed fence still counts', () => {
+            // The fence must TOGGLE, not swallow the remainder — otherwise the fix would silently
+            // disable every hold posted below an example.
+            expect(mergeHoldToken('```\nexample\n```\n[RE_REVIEW_HOLD] head moved')).toBe('re_review_hold');
+        });
+
+        test('the two issuance forms reviewers actually write still match', () => {
+            expect(mergeHoldToken('[MERGE_HOLD] approval at T0 is not current')).toBe('merge_hold');
+            expect(mergeHoldToken('## `[MERGE_HOLD]`\n\nrationale here')).toBe('merge_hold');
+        });
+
+        test('a mid-sentence mention is not an issuance', () => {
+            expect(mergeHoldToken('No reason to hold this one — `[MERGE_HOLD]` would be overkill')).toBeNull();
+        });
+    });
+});


### PR DESCRIPTION
Resolves #17608

Evidence: L2 (pure-predicate arms plus composed service-projection arms; all six mechanisms mutation-proved red) → L2 required (every AC governs predicate rules, token classification and deterministic clearing semantics, all decidable offline). Residual: none.

> 🌿 A comment saying "do not merge" does not retract an approval — the badge never moved, and the PR kept reporting green.

`reviewDecision` is a flattened snapshot with no notion of supersession. A reviewer can approve at T0 and withdraw at T1, and merge-readiness still reports true. This is rule 5's mirror — there `APPROVED` overstated the contract because a **pending** obligation was invisible; here because a **retracted** approval is — and it was the only gap in this module that failed **open**.

## Round-1 repairs (@neo-gpt-emmy)

Emmy ran the helper at exact head instead of reading its tests, and found two contract gaps that the ticket's own Contract Ledger had under-specified. **I reproduced both before fixing either.**

| | Defect at `add74318d5` | Now |
|---|---|---|
| **Standing** | `resolveMergeHold({comments: [anyToken], reviews: []})` → `held: true`. `!clearedAt` read *"no review yet"* as *"nothing has cleared it"*, so **any commenter could block any PR** | a hold requires an `APPROVED` review **strictly older** than the token |
| **Issuance** | `mergeHoldToken()` matched a token inside a fenced example — a reviewer quoting one to explain the convention blocked the PR | fenced and indented code blocks are skipped; the fence **toggles**, so issuance below a closed example still counts |
| **Issuance, second cut** | *(found by verifying my own claim — see below)* the rule was "opens a **line**", and prose wrapping can promote a mid-sentence mention to line-initial | the rule is now "opens a **block**": first content line, after a blank line, or after a fence |

**The ledger was the root, not the code.** Row 1 said *"a reviewer hold newer than that reviewer's latest review"* and never required an approval — the implementation matched the spec exactly, and the spec was wrong. #17608's ledger is amended with a **Standing** row, an **Issuance vs demonstration** row, a **Persistence boundary** row and a **Bounded window** row, plus a seventh AC. That is RA-3: the close-target authority now says what the code does.

`reviewSubmissions` gained `state`. **The field was already selected by `GET_MERGE_READINESS`** — the mapper dropped it, which is what made standing undecidable.

**Why a dedicated spec now exists.** Every prior arm ran through the composed `PullRequestService` path, whose fixtures all give the holder an `APPROVED` review. The two contracts with no coverage at all were the two that were wrong. `mergeHoldTokens.spec.mjs` isolates token admission, standing, clearing and truncation as pure arms.

**What I got wrong beyond the two defects:** my AC-4 negative control tested the *inline-backtick* mention — the shape the matcher already handled — and never the fenced shape it did not. The control exercised the easy case and read as coverage.

### And then verifying my own fix refuted my own claim

I wrote, in the module JSDoc, in a spec comment, in this body and in a commit message, that `merge-hold-tokens.md` **opens a fence** with the token and that the fence skip was what protected a reviewer quoting it. Before claiming it a fifth time I checked. **The doc contains no fence at all** — four assertions, none of them verified, and the file was one `grep` away the entire time.

What it contains is worse than what I claimed. The doc's own sentence explaining that a mid-sentence mention does **not** hold a PR wraps across two lines, and the continuation begins with `` `[MERGE_HOLD]` ``. Under *"a token must open a **line**"*, **that sentence classified as a hold** — the example contradicted itself, and my fence fix did not touch it. Running the old matcher over the doc returned `merge_hold`; running the new one still did.

Where prose wraps is not a property an author controls, so a line is the wrong unit. **The rule is now "opens a BLOCK"** — first content line, after a blank line, or after a fence — and a wrapped continuation always has a non-blank predecessor. Verified against the real file: it no longer classifies itself. The fence and indent skips stay; they are still correct, just not sufficient.

The general shape, since it is the third instance tonight: **a claim about a file, repeated into four artifacts, none of which read the file.** Emmy found the first two gaps by running the code instead of reading its tests. This one came from applying that to my own sentence.

## AC Evidence

| AC | Proof |
|---|---|
| AC-1 | **the live T1 window, pinned.** A reviewer approves, then posts `[MERGE_HOLD]` stating the prior approval is not a current authorization. Composed service arm asserts `strictMergeReady: false` and that the blocker **names the holder and the token** — a bare `false` sends the reader back to the PR to find out who is holding |
| AC-2 | **clearing, both directions.** A newer submitted review from the **same** reviewer clears it; a later review from **another peer** does not. Both arms in one test, because the pair is the design — a third party dispositioning someone else's objection reads as resolved while the holder still objects |
| AC-3 | **three states, not two.** Unfetched → `holdVerdict was not resolved`. Fetched-but-**truncated** → `held: null` with its own distinct reason: a hold found inside the window is decisive, but finding none over a truncated one is missing evidence, not evidence of absence. A further arm proves a hold **found** inside a truncated window still blocks |
| AC-4 | **no prose scanning, and no demonstration scanning.** Negative arms for an unrecognised token, for *"No reason to hold this one — `[MERGE_HOLD]` would be overkill here"*, for the token inside fenced / info-string / tilde / indented code, and for a mention that **wraps** to line-initial. Blocking a PR because someone said they were *not* blocking it would be worse than the gap, since the reason would read as deliberate — and the reference doc's own sentence saying exactly that was the specimen |
| AC-5 | **documented where a holder looks** — `pr-review-guide.md` §9.2, pointing at the new `merge-hold-tokens.md` sibling. Not the module JSDoc, which only a maintainer of that file reads |
| AC-6 | **standing.** Pure arms for no-review-at-all, reviewed-but-never-`APPROVED`, and approved-*after*-the-token. Each asserts `held: false`, against a fourth arm proving the live T1 specimen still holds — so the three cannot be satisfied by disabling the feature |
| AC-7 | **the control fires on the observed timeline**, not a hypothetical: the fixture reproduces the incident's own sequence (APPROVED at T0, hold at T1) and is red without rule 7 — see the mutation table |

## Turn-Memory Pre-Flight (RA-4)

Run retrospectively via `/turn-memory-pre-flight`. **The four mechanical checks, with their actual results:**

| # | Check | Result |
|---|---|---|
| 1 | `cat .codex/hooks.json` | `SessionStart` + `UserPromptSubmit` both invoke `codex-context.mjs` |
| 2 | `cat .codex/hooks/codex-context.mjs` | resolves **exactly one** file — `new URL('../CODEX.md')` at `:220-221`. It never enumerates `.agents/skills/**` |
| 3 | harness MCP `context.fileName` checks | no `context.fileName` gate selects skill references; the only nearby switch is a profile name in `ToolService.mjs:280` |
| 4 | `readlink .claude/CLAUDE.md` | `../AGENTS.md` — the Claude harness turn-loads AGENTS.md, which **this PR does not touch** |

**Placement decision (five-step tree):** Step 1 — does this apply to every agent turn? **No**; it governs one lifecycle event. Step 2 — does it govern a specific lifecycle event? **Yes: reviewing a PR.** Tree terminates at Step 2 → **Skill**. Steps 3-5 are not reached, and no Atlas or harness-local entry is warranted.

**Loading-runtime effect, by tier — this is the number that matters, not the net:**

| Tier | Who pays it | Delta |
|---|---|---|
| Turn-loaded (`AGENTS.md`, `CLAUDE.md`, `CODEX.md`) | every agent, every turn | **0** — untouched, verified by check 4 and by `git diff --name-only` |
| Trigger-loaded (`pr-review-guide.md`) | every agent invoking `/pr-review` | **+210** (33177 → 33387) |
| Conditional (`merge-hold-tokens.md`) | only an agent following the §9.2 pointer | **+1747** |

**Harness-load-duplication audit:** the token vocabulary appears in no turn-loaded or skill-map surface — `grep -l MERGE_HOLD` across `AGENTS.md`, every `SKILL.md`, and `AGENTS_ATLAS.md` returns nothing. The guide pointer and the sibling are the only statements, so there is no second copy to drift.

**The disclosure this replaces.** My original body reported the skill-manifest's net figure and the lint's verdict. That is the wrong unit: it prices all bytes as though they load equally, when check 2 proves conditional bytes load for nobody who does not follow the pointer. Reporting the tier split is the actual handoff.

## Deltas from ticket

- **A fourth state the ticket did not anticipate: truncation.** The comment window is bounded (`comments(last: 100)`), so a hold can sit outside it. The ticket's fail-closed AC covers *unfetched*; it did not cover *fetched but incomplete*. Same existential asymmetry @neo-gpt-emmy identified on the approvals list in #17661 — inherited deliberately rather than rediscovered. Now folded into the ledger and AC-3 rather than left as disclosure.
- **Comments are classified at snapshot time, never carried raw.** The snapshot is compared by `stableStringify` across two reads to detect source drift; raw comment bodies would make any peer's unrelated comment invalidate the observation. Only comments bearing a recognised token survive, reduced to `{login, createdAt, commentId, token}`.
- **The clearing rule needs EVERY submitted review, not just approvals** — and now their `state` too. Any submission clears a hold; only an `APPROVED` one grants the standing to raise one. Two indices over one timeline.
- **The persistence boundary is documented, not enforced.** Comments are mutable and this reader sees only the current body, so editing the token out erases a hold with no newer review. Recovering that needs issuance history this projection does not carry. "Only a newer review clears it" governs the **review timeline**; the JSDoc now says so outright rather than letting a reader take it for a guarantee.
- **Docs shape forced by the lint, twice.** The inline form was refused — `pr-review-guide.md` is an oversized workflow map at 33177 bytes against a 33700 ceiling — so the content is a sibling behind a 210-byte pointer, inside the 250 per-file budget.
- **The `[skill-growth-justified:]` marker must be a SINGLE LINE.** My first one wrapped across four and silently did nothing: the pattern is `/\[skill-growth-justified:\s*[^\]\n]+\]/i` and `[^\]\n]+` forbids newlines. The lint reported the same failure as before the marker existed, with no hint that a marker had been seen and rejected.

## Test Evidence

`npm run test-unit -- unit/ai/services/github-workflow unit/ai/scripts --workers=1` → **3026 passed, 2 skipped, exit 0**.

**Mutation-proved. Each mutation red on its own arms and nothing else:**

| Mutation | Expected red | Result |
|---|---|---|
| the exact pre-fix predicate (`!clearedAt \|\| …`, no standing check) | the standing arms | **RED — 2 arms**: no-review-at-all, and reviewed-but-never-approved |
| code-block skip disabled | the demonstration arms | **RED — 4 arms**: fenced, info-string, tilde, indented. Nothing else moved |
| block rule disabled (back to "opens a line") | the wrapped-mention arm | **RED, that arm alone** — with a second arm proving the rule does not collapse to "only the first line can hold" |
| `if (false && holdVerdict?.held === true)` — hold never blocks | the T1 arm | RED, that arm alone |
| clearing reads the latest review from **any** reviewer | the same-reviewer clearing arm | RED, that arm alone |
| token matched lexically instead of structurally | the prose-mentions-a-hold arm | RED, that arm alone |

**Two mutations I ran that proved nothing, recorded because the result is the interesting part.** Disabling *only* the standing check left the drive-by arm green — with `!clearedAt ||` already removed, `createdAt > undefined` is `false`, so that arm was carried by a different line than I assumed. Restoring *only* `!clearedAt ||` turned nothing red, because standing guarantees `approvedAt` exists, which guarantees `clearedAt` does — the branch is unreachable. Only reverting **both** reproduces the defect. A mutation that kills nothing is either a vacuous mutation or a missing arm, and here it was the first; assuming the second would have added an arm for an impossible state.

Gates: `check-aiconfig-antipatterns` 0 new violations; `check-ticket-archaeology` green — it rejected two ticket refs in the new spec's durable comments on first commit, which is the lint working; `lint-skill-manifest --base origin/dev` **OK**.

## Post-Merge Validation

Deploy-gated, and the falsifier is concrete. Once the runtime picks this up, read the merge-readiness projection for any PR carrying a `[MERGE_HOLD]` newer than the holder's latest review: the blocker must name the holder and the token, **and a token posted by a non-approver must not appear at all**.

**Note the standing window:** the GitHub-workflow runtime has not redeployed since #17661 merged — `healthcheck` shows `startedAt` predating it — so merge-readiness projections currently return pre-gate answers for the cross-family rule too. Recorded on #17661 with its own re-run command. Until pickup, both gates are manual.

**This changes no merge authority.** It validates the *claim* of readiness, exactly as the module already scopes itself. A human may still merge past a hold; the point is that the hold is visible to the surface a merge decision is built on, rather than living in prose no readiness check reads.

Authored by Grace (Claude Opus 5, Claude Code). Session eb671e6e-ca17-4a53-8069-64fd5885ce84.
