### PR TITLE
feat(github-workflow): add per-request repository targets (#17420)

### DIFF
--- a/ai/mcp/server/github-workflow/openapi.yaml
+++ b/ai/mcp/server/github-workflow/openapi.yaml
@@ -138,6 +138,7 @@ paths:
       summary: List Repository Labels
       operationId: list_labels
       x-neo-tool-tier: read
+      x-pass-as-object: true
       x-annotations:
         readOnlyHint: true
       description: |
@@ -146,6 +147,12 @@ paths:
         **When to Use:**
         This is a crucial discovery tool. Call it before using `create_issue` or `manage_issue_labels` to ensure you are using valid, existing label names.
       tags: [Labels]
+      parameters:
+        - name: repo
+          in: query
+          required: false
+          schema:
+            $ref: '#/components/schemas/RepositoryTarget'
       responses:
         '200':
           description: A list of repository labels.
@@ -188,6 +195,11 @@ paths:
         - `believedOpen` resolves each supplied number directly; it never infers terminal state from bounded-page absence.
       tags: [Pull Requests]
       parameters:
+        - name: repo
+          in: query
+          required: false
+          schema:
+            $ref: '#/components/schemas/RepositoryTarget'
         - name: limit
           in: query
           required: false
@@ -302,6 +314,11 @@ paths:
           schema:
             type: integer
             example: 123
+        - name: repo
+          in: query
+          required: false
+          schema:
+            $ref: '#/components/schemas/RepositoryTarget'
         - name: file
           in: query
           required: false
@@ -418,6 +435,8 @@ paths:
             schema:
               type: object
               properties:
+                repo:
+                  $ref: '#/components/schemas/RepositoryTarget'
                 pr_number:
                   type: integer
                   description: The pull request number. Supply either `pr_number` or `issue_number`, not both.
@@ -577,6 +596,8 @@ paths:
                 - action
                 - body
               properties:
+                repo:
+                  $ref: '#/components/schemas/RepositoryTarget'
                 action:
                   type: string
                   enum: [create, update]
@@ -665,6 +686,8 @@ paths:
                 - action
                 - labels
               properties:
+                repo:
+                  $ref: '#/components/schemas/RepositoryTarget'
                 action:
                   type: string
                   enum: [add, remove]
@@ -750,6 +773,8 @@ paths:
                 - action
                 - assignees
               properties:
+                repo:
+                  $ref: '#/components/schemas/RepositoryTarget'
                 action:
                   type: string
                   enum: [add, remove]
@@ -916,6 +941,8 @@ paths:
                 - action
                 - body
               properties:
+                repo:
+                  $ref: '#/components/schemas/RepositoryTarget'
                 action:
                   type: string
                   enum: [create, update]
@@ -1055,6 +1082,8 @@ paths:
               required:
                 - action
               properties:
+                repo:
+                  $ref: '#/components/schemas/RepositoryTarget'
                 action:
                   type: string
                   enum: [add, remove]
@@ -1162,6 +1191,11 @@ paths:
         **Completeness:** `limit` bounds the matches RETURNED, not the rows searched. Check `truncated` before treating a result as complete, and pass the returned `endCursor` back as `cursor` to continue.
       tags: [Issues]
       parameters:
+        - name: repo
+          in: query
+          required: false
+          schema:
+            $ref: '#/components/schemas/RepositoryTarget'
         - name: limit
           in: query
           required: false
@@ -1248,6 +1282,8 @@ paths:
               required:
                 - title
               properties:
+                repo:
+                  $ref: '#/components/schemas/RepositoryTarget'
                 title:
                   type: string
                   description: The title of the issue.
@@ -1338,6 +1374,8 @@ paths:
               required:
                 - action
               properties:
+                repo:
+                  $ref: '#/components/schemas/RepositoryTarget'
                 action:
                   type: string
                   enum: [add, remove, update_field]
@@ -1412,6 +1450,8 @@ paths:
                 - title
                 - body
               properties:
+                repo:
+                  $ref: '#/components/schemas/RepositoryTarget'
                 title:
                   type: string
                   description: The title of the discussion.
@@ -1462,6 +1502,8 @@ paths:
                 - discussion_number
                 - body
               properties:
+                repo:
+                  $ref: '#/components/schemas/RepositoryTarget'
                 action:
                   type: string
                   enum: [update_body]
@@ -1544,6 +1586,8 @@ paths:
               required:
                 - discussion_number
               properties:
+                repo:
+                  $ref: '#/components/schemas/RepositoryTarget'
                 discussion_number:
                   type: integer
                   description: The number of the discussion to retrieve.
@@ -1719,6 +1763,8 @@ paths:
                 - action
                 - body
               properties:
+                repo:
+                  $ref: '#/components/schemas/RepositoryTarget'
                 action:
                   type: string
                   enum: [create, update]
@@ -1800,6 +1846,8 @@ paths:
               required:
                 - child_issue
               properties:
+                repo:
+                  $ref: '#/components/schemas/RepositoryTarget'
                 relationship_type:
                   type: string
                   enum: [parent_child, blocked_by]
@@ -1850,6 +1898,7 @@ paths:
       summary: Get Viewer Permission
       operationId: get_viewer_permission
       x-neo-tool-tier: read
+      x-pass-as-object: true
       x-annotations:
         readOnlyHint: true
       description: |
@@ -1865,6 +1914,12 @@ paths:
         - `TRIAGE`: Can manage issues and pull requests.
         - `READ`: Can read the repository.
       tags: [Repository]
+      parameters:
+        - name: repo
+          in: query
+          required: false
+          schema:
+            $ref: '#/components/schemas/RepositoryTarget'
       responses:
         '200':
           description: The viewer's permission level for the repository.
@@ -1928,6 +1983,16 @@ paths:
 
 components:
   schemas:
+    RepositoryTarget:
+      type: string
+      minLength: 1
+      pattern: '^(?:[A-Za-z0-9](?:[A-Za-z0-9-]{0,37}[A-Za-z0-9])?/)?[A-Za-z0-9._-]{1,100}$'
+      description: >-
+        Optional per-request GitHub repository. Omit it for the deployment home repository; pass a
+        bare name to use the deployment home owner, or pass exactly `owner/name` for a full target.
+        Empty values, whitespace, backslashes, empty segments, and additional slashes are refused
+        before GitHub I/O and never fall back to home. ProjectV2 lookups use the selected owner;
+        issue relationships interpret both numbers inside this one selected repository.
     HealthCheckResponse:
       type: object
       properties:

--- a/ai/mcp/server/github-workflow/toolService.mjs
+++ b/ai/mcp/server/github-workflow/toolService.mjs
@@ -10,6 +10,7 @@ import LabelService                                                             
 import LocalFileService                                                                from '../../../services/github-workflow/LocalFileService.mjs';
 import PullRequestService                                                              from '../../../services/github-workflow/PullRequestService.mjs';
 import RepositoryService                                                               from '../../../services/github-workflow/RepositoryService.mjs';
+import {resolveRepositoryTarget}                                                       from '../../../services/github-workflow/shared/repositoryTarget.mjs';
 import ToolService                                                                     from '../../ToolService.mjs';
 import {assertExpectedIdentity as assertExpectedGitHubIdentity, IdentityAssertionCode} from '../../../graph/assertExpectedIdentity.mjs';
 import RequestContextService                                                           from '../shared/services/RequestContextService.mjs';
@@ -25,6 +26,33 @@ const NON_PUBLIC_GITHUB_WRITE_ACCESS = 'non-public-write';
 const GITHUB_TOOL_ACCESS_TYPES       = Object.freeze(new Set([
     PUBLIC_GITHUB_WRITE_ACCESS,
     NON_PUBLIC_GITHUB_WRITE_ACCESS
+]));
+
+/**
+ * The exact remote-forge family carrying the shared per-request repository contract.
+ * Local checkout/content, repository-independent validation, graph projection, and server metadata
+ * stay outside this set. The OpenAPI/test census must remain exactly equal to it.
+ * @type {Set<String>}
+ */
+const REPOSITORY_TARGET_TOOLS = Object.freeze(new Set([
+    'list_labels',
+    'list_pull_requests',
+    'get_pull_request_diff',
+    'get_conversation',
+    'manage_issue_comment',
+    'manage_issue_labels',
+    'manage_issue_assignees',
+    'manage_pr_review',
+    'manage_pr_reviewers',
+    'list_issues',
+    'create_issue',
+    'manage_issue_projects',
+    'create_discussion',
+    'manage_discussion',
+    'get_discussion_conversation',
+    'manage_discussion_comment',
+    'update_issue_relationship',
+    'get_viewer_permission'
 ]));
 
 /**
@@ -331,6 +359,44 @@ function guardGitHubWriteTools(mapping, guardOptions) {
 }
 
 /**
+ * @summary Wraps one remote-forge handler with the no-I/O malformed-target gate.
+ *
+ * This guard must sit OUTSIDE the write-identity guard. The identity assertion calls GitHub to
+ * resolve the effective viewer; running it first would violate the repository contract by issuing
+ * GitHub I/O before rejecting malformed input. The service resolves the target again at its own use
+ * site so this boundary never exports or threads AiConfig state.
+ *
+ * @param {Function} delegate Remote-forge tool handler.
+ * @returns {Function} Repository-target validated handler.
+ */
+function buildRepositoryTargetGuard(delegate) {
+    return async function repositoryTargetGuard(options, ...rest) {
+        const repo   = options && typeof options === 'object' ? options.repo : undefined,
+              target = resolveRepositoryTarget(repo, {owner: config.owner, repo: config.repo});
+
+        if (target.error) return target;
+
+        return delegate(options, ...rest)
+    }
+}
+
+/**
+ * @summary Applies the repository-target guard to the exact 18-operation remote-forge family.
+ * @param {Object} mapping Operation id to handler function.
+ * @returns {Object} Mapping with target validation wrapped around remote-forge handlers.
+ */
+function guardRepositoryTargetTools(mapping) {
+    return Object.fromEntries(
+        Object.entries(mapping).map(([toolName, handler]) => [
+            toolName,
+            REPOSITORY_TARGET_TOOLS.has(toolName)
+                ? buildRepositoryTargetGuard(handler)
+                : handler
+        ])
+    )
+}
+
+/**
  * `get_conversation` dispatch router. The tool serves BOTH pull requests and
  * issues; it routes to the matching service by which identifier the caller supplied.
  * Rejects ambiguous (both ids) and empty (neither id) argument shapes with structured
@@ -447,17 +513,23 @@ const serviceMapping = {
 
 assertCompleteGitHubToolAccessPolicy(serviceMapping);
 
-const guardedServiceMapping = guardGitHubWriteTools(serviceMapping);
+// Ordering is load-bearing: malformed target refusal must happen before the write guard's GitHub
+// viewer probe. Wrap identity first, then repository validation around the resulting handlers.
+const identityGuardedServiceMapping = guardGitHubWriteTools(serviceMapping);
+const guardedServiceMapping         = guardRepositoryTargetTools(identityGuardedServiceMapping);
 
 // Exported for unit-test access. `buildDevBranchGuard` accepts injected
 // `delegate` + `getBranch` for fixture-driven testing without spawning real `git`.
 export {
     GITHUB_TOOL_ACCESS,
+    REPOSITORY_TARGET_TOOLS,
     assertCompleteGitHubToolAccessPolicy,
     assertNoUnclassifiedGitHubTools,
     buildGitHubWriteIdentityGuard,
+    buildRepositoryTargetGuard,
     getConversationRouter,
     guardGitHubWriteTools,
+    guardRepositoryTargetTools,
     isPublicGitHubWriteTool,
     normalizeGitHubIdentityLogin,
     resolveGitHubIdentityAssertion

--- a/ai/services/github-workflow/DiscussionService.mjs
+++ b/ai/services/github-workflow/DiscussionService.mjs
@@ -1,13 +1,23 @@
 import aiConfig          from '../../mcp/server/github-workflow/config.mjs';
 import Base              from '../../../src/core/Base.mjs';
 import GraphqlService    from './GraphqlService.mjs';
-import RepositoryService from './RepositoryService.mjs';
 import logger            from '../../mcp/server/github-workflow/logger.mjs';
 import {commentMatches, isSelectorPresent, malformedCommentIdError, omitScopedBody, parseCommentId}
                                  from './shared/commentSelector.mjs';
-import {projectConversationTrust}                                                                from './shared/conversationTrust.mjs';
-import {GET_DISCUSSION_CONVERSATION, GET_REPO_AND_DISCUSSION_CATEGORIES, GET_DISCUSSION_ID}      from './queries/discussionQueries.mjs';
-import {CREATE_DISCUSSION, ADD_DISCUSSION_COMMENT, UPDATE_DISCUSSION, UPDATE_DISCUSSION_COMMENT} from './queries/mutations.mjs';
+import {projectConversationTrust} from './shared/conversationTrust.mjs';
+import {resolveRepositoryTarget}  from './shared/repositoryTarget.mjs';
+import {
+    GET_DISCUSSION_CONVERSATION,
+    GET_REPO_AND_DISCUSSION_CATEGORIES,
+    GET_DISCUSSION_ID
+} from './queries/discussionQueries.mjs';
+import {
+    CREATE_DISCUSSION,
+    ADD_DISCUSSION_COMMENT,
+    UPDATE_DISCUSSION,
+    UPDATE_DISCUSSION_COMMENT,
+    GET_DISCUSSION_COMMENT_TARGET
+} from './queries/mutations.mjs';
 
 /**
  * @summary Service for interacting with GitHub Discussions via the GraphQL API.
@@ -57,6 +67,7 @@ class DiscussionService extends Base {
      * @param {String} [options.since_comment_id]   Return top-level comments strictly after the matching comment. Same
      *     accepted spellings and same malformed-vs-absent distinction as `comment_id`.
      * @param {Number} [options.last_n]             Return only the last N top-level comments.
+     * @param {String} [options.repo]               Optional bare name or owner/name repository target.
      * @returns {Promise<Object>} Discussion conversation data, optionally filtered, or a structured error. A SCOPED
      *          request (any selector) omits the parent body and sets `bodyOmitted: true`; an unscoped request is
      *          unchanged. Scoping asked for part of a thread and used to be charged for all of it.
@@ -65,7 +76,10 @@ class DiscussionService extends Base {
      *          (see `shared/conversationTrust.mjs`).
      */
     async getConversation(options) {
-        const {discussion_number, comment_id, since_comment_id, last_n} = options || {};
+        const {discussion_number, comment_id, since_comment_id, last_n, repo} = options || {},
+              target                                                          = resolveRepositoryTarget(repo, {owner: aiConfig.owner, repo: aiConfig.repo});
+
+        if (target.error) return target;
 
         if (!discussion_number) {
             return {
@@ -76,8 +90,8 @@ class DiscussionService extends Base {
         }
 
         const variables = {
-            owner           : aiConfig.owner,
-            repo            : aiConfig.repo,
+            owner           : target.owner,
+            repo            : target.repo,
             discussionNumber: discussion_number,
             maxComments     : aiConfig.pullRequest.maxCommentsPerPullRequest,
             maxReplies      : aiConfig.pullRequest.maxCommentsPerPullRequest
@@ -140,7 +154,7 @@ class DiscussionService extends Base {
                 }
             });
         } catch (error) {
-            logger.error(`Error getting conversation for discussion #${discussion_number} via GraphQL:`, error);
+            logger.error(`Error getting conversation for ${target.fullName} discussion #${discussion_number} via GraphQL:`, error);
             return {
                 error  : 'GraphQL API request failed',
                 message: error.message,
@@ -155,16 +169,21 @@ class DiscussionService extends Base {
      * @param {string} options.title    The title of the discussion.
      * @param {string} options.body     The Markdown body of the discussion.
      * @param {string} options.category The name of the category (e.g., 'Ideas', 'Q&A'). Defaults to 'Ideas'.
+     * @param {String} [options.repo]    Optional bare name or owner/name repository target.
      * @returns {Promise<object>} A promise that resolves to the new discussion data.
      */
-    async createDiscussion({title, body, category = 'Ideas'}) {
-        logger.info(`Attempting to create GitHub Discussion: "${title}" in category "${category}"`);
+    async createDiscussion({title, body, category = 'Ideas', repo}) {
+        const target = resolveRepositoryTarget(repo, {owner: aiConfig.owner, repo: aiConfig.repo});
+
+        if (target.error) return target;
+
+        logger.info(`Attempting to create GitHub Discussion in ${target.fullName}: "${title}" in category "${category}"`);
 
         try {
             // First, get the repository ID and discussion categories
             const repoData = await GraphqlService.query(GET_REPO_AND_DISCUSSION_CATEGORIES, {
-                owner: aiConfig.owner,
-                repo : aiConfig.repo
+                owner: target.owner,
+                repo : target.repo
             });
 
             const repositoryId = repoData.repository.id;
@@ -194,7 +213,7 @@ class DiscussionService extends Base {
 
             const discussion = result.createDiscussion.discussion;
 
-            logger.info(`Successfully created GitHub Discussion #${discussion.number}: ${discussion.url}`);
+            logger.info(`Successfully created GitHub Discussion ${target.fullName}#${discussion.number}: ${discussion.url}`);
 
             return {
                 discussionNumber: discussion.number,
@@ -203,7 +222,7 @@ class DiscussionService extends Base {
             };
 
         } catch (error) {
-            logger.error('Error creating GitHub Discussion:', error);
+            logger.error(`Error creating GitHub Discussion in ${target.fullName}:`, error);
             return {
                 error  : 'GraphQL API request failed',
                 message: error.message,
@@ -217,14 +236,17 @@ class DiscussionService extends Base {
      * @param {object} options                      The options object
      * @param {number} options.discussion_number    The number of the discussion.
      * @param {string} options.body                 The raw content of the comment.
+     * @param {Object} [options.repositoryTarget]   Resolved repository target supplied by the public operation.
      * @returns {Promise<object>} A promise that resolves to a success message.
      */
-    async createComment({discussion_number, body}) {
+    async createComment({discussion_number, body, repositoryTarget}) {
+        const target = repositoryTarget || resolveRepositoryTarget(undefined, {owner: aiConfig.owner, repo: aiConfig.repo});
+
         try {
             // Get Discussion subjectId
             const idData = await GraphqlService.query(GET_DISCUSSION_ID, {
-                owner : aiConfig.owner,
-                repo  : aiConfig.repo,
+                owner : target.owner,
+                repo  : target.repo,
                 number: discussion_number
             });
 
@@ -250,7 +272,7 @@ class DiscussionService extends Base {
             };
 
         } catch (error) {
-            logger.error(`Error creating comment on discussion #${discussion_number} via GraphQL:`, error);
+            logger.error(`Error creating comment on ${target.fullName} discussion #${discussion_number} via GraphQL:`, error);
             return {
                 error  : 'GraphQL API request failed',
                 message: error.message,
@@ -289,15 +311,71 @@ class DiscussionService extends Base {
     }
 
     /**
+     * @summary Verifies a global DiscussionComment belongs to the selected repository and parent.
+     * @param {String} commentId Global DiscussionComment node ID.
+     * @param {Object} repositoryTarget Resolved per-request repository.
+     * @param {Number} [discussionNumber] Optional parent number asserted by the caller.
+     * @returns {Promise<Object|null>} Typed refusal, or null when the target matches.
+     * @private
+     */
+    async #getDiscussionCommentTargetFailure(commentId, repositoryTarget, discussionNumber) {
+        try {
+            const data       = await GraphqlService.query(GET_DISCUSSION_COMMENT_TARGET, {commentId}),
+                  comment    = data?.node,
+                  discussion = comment?.discussion,
+                  actual     = discussion?.repository?.nameWithOwner;
+
+            if (!comment?.id || !discussion || !actual) {
+                return {
+                    error  : 'Not Found',
+                    message: `Discussion comment ${commentId} was not found or carried no repository parent.`,
+                    code   : 'COMMENT_NOT_FOUND'
+                }
+            }
+
+            if (actual.toLowerCase() !== repositoryTarget.fullName.toLowerCase()) {
+                return {
+                    error       : 'Repository Target Mismatch',
+                    message     : `Discussion comment ${commentId} belongs to ${actual}, not selected repository ${repositoryTarget.fullName}; no update was sent.`,
+                    code        : 'REPOSITORY_TARGET_MISMATCH',
+                    actualRepo  : actual,
+                    selectedRepo: repositoryTarget.fullName
+                }
+            }
+
+            if (discussionNumber && discussion.number !== discussionNumber) {
+                return {
+                    error  : 'Comment Target Mismatch',
+                    message: `Discussion comment ${commentId} does not belong to supplied Discussion #${discussionNumber}; no update was sent.`,
+                    code   : 'COMMENT_TARGET_MISMATCH'
+                }
+            }
+
+            return null
+        } catch (error) {
+            return {
+                error  : 'GraphQL API request failed',
+                message: error.message,
+                code   : 'GRAPHQL_API_ERROR'
+            }
+        }
+    }
+
+    /**
      * Consolidates comment management into a single method.
      * @param {object} options                        The options object
      * @param {number} [options.discussion_number]    The number of the discussion (required for create).
      * @param {string} [options.comment_id]           The global node ID of the comment (required for update).
      * @param {string} options.body                   The content of the comment.
      * @param {string} options.action                 The action to perform: 'create' or 'update'.
+     * @param {String} [options.repo]                 Optional bare name or owner/name repository target.
      * @returns {Promise<object>}
      */
-    async manageDiscussionComment({discussion_number, comment_id, body, action}) {
+    async manageDiscussionComment({discussion_number, comment_id, body, action, repo}) {
+        const target = resolveRepositoryTarget(repo, {owner: aiConfig.owner, repo: aiConfig.repo});
+
+        if (target.error) return target;
+
         if (!['create', 'update'].includes(action)) {
             return {
                 error  : 'Bad Request',
@@ -314,7 +392,7 @@ class DiscussionService extends Base {
                     code   : 'MISSING_ARGUMENTS'
                 };
             }
-            return this.createComment({discussion_number, body});
+            return this.createComment({discussion_number, body, repositoryTarget: target});
         } else {
             if (!comment_id) {
                 return {
@@ -323,7 +401,9 @@ class DiscussionService extends Base {
                     code   : 'MISSING_ARGUMENTS'
                 };
             }
-            return this.updateComment(comment_id, body);
+            const targetFailure = await this.#getDiscussionCommentTargetFailure(comment_id, target, discussion_number);
+
+            return targetFailure || this.updateComment(comment_id, body);
         }
     }
 
@@ -334,9 +414,14 @@ class DiscussionService extends Base {
      * @param {string} options.action             The action to perform: 'update_body'.
      * @param {number} options.discussion_number  The number of the discussion to update.
      * @param {string} options.body               The new Markdown body for the discussion.
+     * @param {String} [options.repo]             Optional bare name or owner/name repository target.
      * @returns {Promise<object>} A promise that resolves to {discussionId, url, updatedAt} or a structured error.
      */
-    async manageDiscussion({action, discussion_number, body}) {
+    async manageDiscussion({action, discussion_number, body, repo}) {
+        const target = resolveRepositoryTarget(repo, {owner: aiConfig.owner, repo: aiConfig.repo});
+
+        if (target.error) return target;
+
         if (action !== 'update_body') {
             return {
                 error  : 'Bad Request',
@@ -356,8 +441,8 @@ class DiscussionService extends Base {
         try {
             // Resolve the discussion number to its global node ID
             const idData = await GraphqlService.query(GET_DISCUSSION_ID, {
-                owner : aiConfig.owner,
-                repo  : aiConfig.repo,
+                owner : target.owner,
+                repo  : target.repo,
                 number: discussion_number
             });
 
@@ -373,7 +458,7 @@ class DiscussionService extends Base {
             const result       = await GraphqlService.query(UPDATE_DISCUSSION, {discussionId, body});
             const discussion   = result.updateDiscussion.discussion;
 
-            logger.info(`Successfully updated body of GitHub Discussion #${discussion_number}: ${discussion.url}`);
+            logger.info(`Successfully updated body of GitHub Discussion ${target.fullName}#${discussion_number}: ${discussion.url}`);
 
             return {
                 discussionId: discussion.id,
@@ -381,7 +466,7 @@ class DiscussionService extends Base {
                 updatedAt   : discussion.updatedAt
             };
         } catch (error) {
-            logger.error(`Error updating discussion #${discussion_number} body via GraphQL:`, error);
+            logger.error(`Error updating ${target.fullName} discussion #${discussion_number} body via GraphQL:`, error);
             return {
                 error  : 'GraphQL API request failed',
                 message: error.message,

--- a/ai/services/github-workflow/IssueService.mjs
+++ b/ai/services/github-workflow/IssueService.mjs
@@ -5,6 +5,7 @@ import RepositoryService                                                        
 import logger                                                                                                                                                                                                                        from '../../mcp/server/github-workflow/logger.mjs';
 import {commentMatches, isSelectorPresent, malformedCommentIdError, omitScopedBody, parseCommentId}                                                                                                                                  from './shared/commentSelector.mjs';
 import {projectConversationTrust}                                                                                                                                                                                                    from './shared/conversationTrust.mjs';
+import {resolveRepositoryTarget}                                                                                                                                                                                                     from './shared/repositoryTarget.mjs';
 import {GET_ISSUE_LABEL_IDS, GET_PULL_REQUEST_LABEL_IDS, GET_ISSUE_PARENT, GET_BLOCKED_BY, GET_ISSUE_ASSIGNEES, GET_ISSUE_CONVERSATION, FETCH_ISSUES_FOR_SYNC, FETCH_ISSUES_LIST, FETCH_ISSUES_LIST_NO_FILTER, buildIssuesListQuery} from './queries/issueQueries.mjs';
 import {GET_PULL_REQUEST_ID}                                                                                                                                                                                                         from './queries/pullRequestQueries.mjs';
 import {
@@ -21,7 +22,8 @@ import {
     ADD_PROJECT_V2_ITEM,
     DELETE_PROJECT_V2_ITEM,
     FIND_PROJECT_V2_ITEM_BY_CONTENT,
-    UPDATE_PROJECT_V2_ITEM_SINGLE_SELECT
+    UPDATE_PROJECT_V2_ITEM_SINGLE_SELECT,
+    GET_ISSUE_COMMENT_TARGET
 } from './queries/mutations.mjs';
 
 /**
@@ -74,13 +76,17 @@ class IssueService extends Base {
      * @param {String} [options.since_comment_id] Return comments strictly after the matching comment (by createdAt
      *     order). Same accepted spellings and same malformed-vs-absent distinction as `comment_id`.
      * @param {Number} [options.last_n]           Return only the last N comments (by createdAt order).
+     * @param {String} [options.repo]             Optional bare name or owner/name repository target.
      * @returns {Promise<Object>} Conversation data or a structured error. A SCOPED request (any selector) omits the
      *          parent body and sets `bodyOmitted: true`; an unscoped request is unchanged. Payloads
      *          are trust-projected: authored nodes carry `authorTrust`, untrusted-author bodies arrive
      *          defanged, and the root carries a `contentTrust` summary (see `shared/conversationTrust.mjs`).
      */
     async getConversation(options) {
-        const {issue_number, comment_id, since_comment_id, last_n} = options || {};
+        const {issue_number, comment_id, since_comment_id, last_n, repo} = options || {},
+              target                                                     = resolveRepositoryTarget(repo, {owner: aiConfig.owner, repo: aiConfig.repo});
+
+        if (target.error) return target;
 
         if (!issue_number) {
             return {
@@ -91,8 +97,8 @@ class IssueService extends Base {
         }
 
         const variables = {
-            owner      : aiConfig.owner,
-            repo       : aiConfig.repo,
+            owner      : target.owner,
+            repo       : target.repo,
             issueNumber: issue_number,
             // get_conversation is one dual-purpose tool; the issue path shares the PR
             // conversation comment cap rather than adding a separate config key.
@@ -152,7 +158,7 @@ class IssueService extends Base {
                 }
             });
         } catch (error) {
-            logger.error(`Error getting conversation for issue #${issue_number} via GraphQL:`, error);
+            logger.error(`Error getting conversation for ${target.fullName} issue #${issue_number} via GraphQL:`, error);
             return {
                 error  : 'GraphQL API request failed',
                 message: error.message,
@@ -165,16 +171,19 @@ class IssueService extends Base {
      * Adds labels to an issue or pull request.
      * @param {number}   issueNumber The number of the issue or PR.
      * @param {string[]} labels      An array of labels to add.
+     * @param {Object} [repositoryTarget] Resolved repository target supplied by the public operation.
      * @returns {Promise<object>} A promise that resolves to a success message.
      */
-    async addLabels(issueNumber, labels) {
+    async addLabels(issueNumber, labels, repositoryTarget) {
+        const target = repositoryTarget || resolveRepositoryTarget(undefined, {owner: aiConfig.owner, repo: aiConfig.repo});
+
         try {
-            const { labelableId, labelIds } = await this.#getIds(issueNumber, labels);
+            const { labelableId, labelIds } = await this.#getIds(issueNumber, labels, target);
 
             await GraphqlService.query(ADD_LABELS, { labelableId, labelIds });
             return { message: `Successfully added labels to issue #${issueNumber}` };
         } catch (error) {
-            logger.error(`Error adding labels to issue #${issueNumber} via GraphQL:`, error);
+            logger.error(`Error adding labels to ${target.fullName} issue #${issueNumber} via GraphQL:`, error);
             return {
                 error  : 'GraphQL API request failed',
                 message: error.message,
@@ -215,12 +224,18 @@ class IssueService extends Base {
      * @param {string[]} options.assignees             Array of GitHub logins to assign, or empty array to clear all.
      * @param {boolean}  [options.requireUnassigned=true] Precondition gate — reject add if non-empty without `acknowledgedReassign`.
      * @param {string}   [options.acknowledgedReassign] Reason-bearing override for strict replacement; required when assignees are non-empty and `requireUnassigned: true`.
+     * @param {Object}   [options.repositoryTarget] Resolved repository target supplied by `manageIssueAssignees`.
      * @returns {Promise<object>} Success message + `verifiedAssignees` (post-verify state), or structured error (e.g., `ASSIGNEE_CONFLICT` with `currentAssignees` + `attemptedAssignees` for caller introspection).
      */
-    async assignIssue({issue_number, assignees, requireUnassigned = true, acknowledgedReassign}) {
-        if (!await this.hasWritePermission()) {
+    async assignIssue({issue_number, assignees, requireUnassigned = true, acknowledgedReassign, repositoryTarget}) {
+        const target     = repositoryTarget || resolveRepositoryTarget(undefined, {owner: aiConfig.owner, repo: aiConfig.repo}),
+              permission = await this.getWritePermission(target);
+
+        if (permission.error) return permission;
+
+        if (!permission.allowed) {
             const message = [
-                `Permission denied. Viewer has '${RepositoryService.viewerPermission}' permission, `,
+                `Permission denied for ${target.fullName}. Viewer has '${permission.permission}' permission, `,
                 `but one of [${this.writePermissions.join(', ')}] is required to assign issues.`
             ].join('');
 
@@ -235,11 +250,11 @@ class IssueService extends Base {
         try {
             // CLEAR MODE: empty assignees — no precondition needed; proceeds directly.
             if (!assignees || assignees.length === 0) {
-                logger.info(`Attempting to unassign all users from issue #${issue_number}`);
+                logger.info(`Attempting to unassign all users from ${target.fullName} issue #${issue_number}`);
                 // REST PATCH with an empty assignees array clears the full set atomically — the
                 // equivalent of the prior `gh issue edit --remove-assignee ""`, with no fetch and no
                 // intermediate state. (PATCH sends only `assignees`, so other issue fields are untouched.)
-                await GraphqlService.rest('PATCH', `/repos/${aiConfig.owner}/${aiConfig.repo}/issues/${issue_number}`, {assignees: []});
+                await GraphqlService.rest('PATCH', `/repos/${target.owner}/${target.repo}/issues/${issue_number}`, {assignees: []});
                 const message = `Successfully unassigned all users from issue #${issue_number}`;
                 logger.info(message);
                 return {message};
@@ -247,7 +262,7 @@ class IssueService extends Base {
 
             // ADD MODE: precondition + post-verify gate.
             // Step 1 — precondition fetch: who is currently assigned?
-            const currentAssignees = await this.#fetchCurrentAssignees(issue_number);
+            const currentAssignees = await this.#fetchCurrentAssignees(issue_number, target);
 
             // Step 2 — conflict gate: reject blind-add to occupied issue unless explicit override.
             if (currentAssignees.length > 0 && requireUnassigned && !acknowledgedReassign) {
@@ -257,7 +272,7 @@ class IssueService extends Base {
                     `To override with strict replacement: pass \`acknowledgedReassign: '<reason>'\` (the reason will be persisted as an audit-trail comment on the issue per #11537 AC8). `,
                     `Co-owner-add (preserving existing assignees) is deferred to V2 per Discussion #11536 OQ3 resolution.`
                 ].join('');
-                logger.warn(`ASSIGNEE_CONFLICT on #${issue_number}: current=[${currentAssignees.join(',')}], attempted=[${assignees.join(',')}]`);
+                logger.warn(`ASSIGNEE_CONFLICT on ${target.fullName}#${issue_number}: current=[${currentAssignees.join(',')}], attempted=[${assignees.join(',')}]`);
                 return {
                     error             : 'Assignee Conflict',
                     message           : conflictMessage,
@@ -276,18 +291,18 @@ class IssueService extends Base {
             const resolvedAssignees = await this.#resolveAssigneeAliases(assignees);
 
             logger.info(isOverride
-                ? `Strict-replacement override on #${issue_number} (reason: "${acknowledgedReassign}"): replacing [${currentAssignees.join(',')}] with [${assignees.join(',')}]`
-                : `Attempting to assign issue #${issue_number} to: ${assignees.join(', ')}`);
+                ? `Strict-replacement override on ${target.fullName}#${issue_number} (reason: "${acknowledgedReassign}"): replacing [${currentAssignees.join(',')}] with [${assignees.join(',')}]`
+                : `Attempting to assign ${target.fullName} issue #${issue_number} to: ${assignees.join(', ')}`);
 
-            await GraphqlService.rest('PATCH', `/repos/${aiConfig.owner}/${aiConfig.repo}/issues/${issue_number}`, {assignees: resolvedAssignees});
+            await GraphqlService.rest('PATCH', `/repos/${target.owner}/${target.repo}/issues/${issue_number}`, {assignees: resolvedAssignees});
 
             // Step 5 — post-verify: re-fetch and confirm the resulting assignee state.
-            const verifiedAssignees = await this.#fetchCurrentAssignees(issue_number);
+            const verifiedAssignees = await this.#fetchCurrentAssignees(issue_number, target);
 
             // Step 6 — audit-trail comment for overrides.
             // Persists the reason as a GitHub-visible artifact (issue comment); reason must NOT be lost.
             if (isOverride) {
-                await this.#createReassignAuditComment(issue_number, currentAssignees, assignees, acknowledgedReassign);
+                await this.#createReassignAuditComment(issue_number, currentAssignees, assignees, acknowledgedReassign, target);
             }
 
             const successMessage = isOverride
@@ -306,7 +321,7 @@ class IssueService extends Base {
             return result;
 
         } catch (error) {
-            logger.error(`Error updating assignees for issue #${issue_number}:`, error);
+            logger.error(`Error updating assignees for ${target.fullName} issue #${issue_number}:`, error);
             return {
                 error  : 'GitHub API request failed',
                 message: error.message,
@@ -319,13 +334,14 @@ class IssueService extends Base {
      * @summary Fetches current assignee logins for the precondition + post-verify gate.
      * Narrow GraphQL query (vs `FETCH_SINGLE_ISSUE`'s heavy nested fetch).
      * @param {number} issueNumber
+     * @param {Object} repositoryTarget Resolved repository target.
      * @returns {Promise<string[]>} Array of assignee logins (empty array if no assignees or issue missing).
      * @private
      */
-    async #fetchCurrentAssignees(issueNumber) {
+    async #fetchCurrentAssignees(issueNumber, repositoryTarget) {
         const data = await GraphqlService.query(GET_ISSUE_ASSIGNEES, {
-            owner       : aiConfig.owner,
-            repo        : aiConfig.repo,
+            owner       : repositoryTarget.owner,
+            repo        : repositoryTarget.repo,
             number      : issueNumber,
             maxAssignees: aiConfig.issueSync.maxAssigneesPerIssue
         });
@@ -351,9 +367,10 @@ class IssueService extends Base {
      * @param {string[]} previousAssignees
      * @param {string[]} newAssignees
      * @param {string}   reason
+     * @param {Object}   repositoryTarget Resolved repository target.
      * @private
      */
-    async #createReassignAuditComment(issueNumber, previousAssignees, newAssignees, reason) {
+    async #createReassignAuditComment(issueNumber, previousAssignees, newAssignees, reason, repositoryTarget) {
         const body = [
             `**\`[lane-override]\` reassignment audit-trail** (#11537 §AC8)`,
             ``,
@@ -365,15 +382,15 @@ class IssueService extends Base {
         ].join('\n');
 
         try {
-            const issueNodeId = await this.getIssueNodeId(issueNumber);
+            const issueNodeId = await this.getIssueNodeId(issueNumber, repositoryTarget);
             if (!issueNodeId) {
-                logger.warn(`Could not resolve node ID for #${issueNumber}; audit-trail comment skipped.`);
+                logger.warn(`Could not resolve node ID for ${repositoryTarget.fullName}#${issueNumber}; audit-trail comment skipped.`);
                 return;
             }
             await GraphqlService.query(ADD_COMMENT, {subjectId: issueNodeId, body});
-            logger.info(`Posted reassign audit-trail comment on #${issueNumber}`);
+            logger.info(`Posted reassign audit-trail comment on ${repositoryTarget.fullName}#${issueNumber}`);
         } catch (error) {
-            logger.error(`Error posting reassign audit-trail comment on #${issueNumber} — assignee mutation already succeeded:`, error);
+            logger.error(`Error posting reassign audit-trail comment on ${repositoryTarget.fullName}#${issueNumber} — assignee mutation already succeeded:`, error);
             // Graceful degradation: do not roll back the assignee mutation.
         }
     }
@@ -384,9 +401,12 @@ class IssueService extends Base {
      * @param {number} [options.issue_number] The number of the issue.
      * @param {number} [options.pr_number]    The number of the pull request.
      * @param {string} options.body           The raw content of the comment.
+     * @param {Object} [options.repositoryTarget] Resolved repository target supplied by the public operation.
      * @returns {Promise<object>} A promise that resolves to a success message.
      */
-    async createComment({issue_number, pr_number, body}) {
+    async createComment({issue_number, pr_number, body, repositoryTarget}) {
+        const target = repositoryTarget || resolveRepositoryTarget(undefined, {owner: aiConfig.owner, repo: aiConfig.repo});
+
         // Input Validation
         if (issue_number && pr_number) {
             return {
@@ -406,8 +426,8 @@ class IssueService extends Base {
         const isPR        = !!pr_number;
         const number      = isPR ? pr_number : issue_number;
         const idVariables = {
-            owner: aiConfig.owner,
-            repo : aiConfig.repo,
+            owner: target.owner,
+            repo : target.repo,
             // The PR query uses 'prNumber', the Issue query uses 'number'
             [isPR ? 'prNumber' : 'number']: number
         };
@@ -438,7 +458,7 @@ class IssueService extends Base {
             };
 
         } catch (error) {
-            logger.error(`Error creating comment on ${isPR ? 'PR' : 'issue'} #${number} via GraphQL:`, error);
+            logger.error(`Error creating comment on ${target.fullName} ${isPR ? 'PR' : 'issue'} #${number} via GraphQL:`, error);
             return {
                 error  : 'GraphQL API request failed',
                 message: error.message,
@@ -469,17 +489,26 @@ class IssueService extends Base {
      *     to assign the authenticated GitHub user.
      * @param {Array<{projectNumber: number}>} [options.projects=[]] An array of ProjectV2 memberships
      *     to attach atomically after issue creation. Each entry specifies the org-level project number.
+     * @param {String} [options.repo] Optional bare name or owner/name repository target.
      * @returns {Promise<object>} A promise that resolves to the new issue's data or a structured error.
      *     On success: `{ issueNumber, url, projectAttachments?: Array<{projectNumber, projectId, itemId}>, projectAttachWarnings?: Array<{projectNumber, error}> }`.
      */
-    async createIssue({title, body='', labels=[], assignees=[], projects=[]}) {
-        logger.info(`Attempting to create GitHub issue: "${title}"`);
+    async createIssue({title, body='', labels=[], assignees=[], projects=[], repo}) {
+        const target = resolveRepositoryTarget(repo, {owner: aiConfig.owner, repo: aiConfig.repo});
+
+        if (target.error) return target;
+
+        logger.info(`Attempting to create GitHub issue in ${target.fullName}: "${title}"`);
 
         // Permission check is only required if we are trying to assign users.
         if (assignees && assignees.length > 0) {
-            if (!await this.hasWritePermission()) {
+            const permission = await this.getWritePermission(target);
+
+            if (permission.error) return permission;
+
+            if (!permission.allowed) {
                 const message = [
-                    `Permission denied. Viewer has '${RepositoryService.viewerPermission}' permission, `,
+                    `Permission denied for ${target.fullName}. Viewer has '${permission.permission}' permission, `,
                     `but one of [${this.writePermissions.join(', ')}] is required to assign issues.`
                 ].join('');
 
@@ -515,7 +544,7 @@ class IssueService extends Base {
                 payload.assignees = await this.#resolveAssigneeAliases(assignees);
             }
 
-            const issue = await GraphqlService.rest('POST', `/repos/${aiConfig.owner}/${aiConfig.repo}/issues`, payload);
+            const issue = await GraphqlService.rest('POST', `/repos/${target.owner}/${target.repo}/issues`, payload);
 
             const issueNumber = issue?.number,
                   issueUrl    = issue?.html_url;
@@ -524,13 +553,13 @@ class IssueService extends Base {
                 throw new Error('Could not resolve the new issue number from the GitHub REST response.');
             }
 
-            logger.info(`Successfully created GitHub issue #${issueNumber}: ${issueUrl}`);
+            logger.info(`Successfully created GitHub issue ${target.fullName}#${issueNumber}: ${issueUrl}`);
 
             const result = { issueNumber, url: issueUrl };
 
             // ProjectV2 attach (atomic for each project — partial-attach is acceptable failure mode)
             if (projects && projects.length > 0) {
-                const attachResult = await this.attachIssueToProjects(issueNumber, projects);
+                const attachResult = await this.attachIssueToProjects(issueNumber, projects, target);
                 if (attachResult.attachments.length > 0) {
                     result.projectAttachments = attachResult.attachments;
                 }
@@ -542,7 +571,7 @@ class IssueService extends Base {
             return result;
 
         } catch (error) {
-            logger.error('Error creating GitHub issue:', error);
+            logger.error(`Error creating GitHub issue in ${target.fullName}:`, error);
             return {
                 error  : 'GitHub API request failed',
                 message: error.message,
@@ -586,12 +615,15 @@ class IssueService extends Base {
      * within a single high-level operation, prefer batching at the caller level).
      *
      * @param {number} projectNumber The org-level project number.
+     * @param {Object} [repositoryTarget] Resolved repository target; its owner owns the ProjectV2.
      * @returns {Promise<{projectId: string, title: string, fields: object[]}|{error, message, code}>}
      */
-    async getProjectV2Metadata(projectNumber) {
+    async getProjectV2Metadata(projectNumber, repositoryTarget) {
+        const target = repositoryTarget || resolveRepositoryTarget(undefined, {owner: aiConfig.owner, repo: aiConfig.repo});
+
         try {
             const result = await GraphqlService.query(GET_PROJECT_V2_METADATA, {
-                owner : aiConfig.owner,
+                owner : target.owner,
                 number: projectNumber
             });
 
@@ -599,7 +631,7 @@ class IssueService extends Base {
             if (!project) {
                 return {
                     error  : 'Not Found',
-                    message: `ProjectV2 #${projectNumber} not found under owner '${aiConfig.owner}'.`,
+                    message: `ProjectV2 #${projectNumber} not found under selected repository owner '${target.owner}'.`,
                     code   : 'PROJECT_NOT_FOUND'
                 };
             }
@@ -610,7 +642,7 @@ class IssueService extends Base {
                 fields   : project.fields?.nodes || []
             };
         } catch (error) {
-            logger.error(`Error fetching ProjectV2 #${projectNumber} metadata:`, error);
+            logger.error(`Error fetching ProjectV2 #${projectNumber} under selected owner ${target.owner}:`, error);
             return {
                 error  : 'GraphQL API request failed',
                 message: error.message,
@@ -627,18 +659,21 @@ class IssueService extends Base {
      * elsewhere in this service.
      *
      * @param {number} issueNumber The issue number.
+     * @param {Object} [repositoryTarget] Resolved repository target.
      * @returns {Promise<string|null>} The issue's GraphQL node ID, or `null` if not found.
      */
-    async getIssueNodeId(issueNumber) {
+    async getIssueNodeId(issueNumber, repositoryTarget) {
+        const target = repositoryTarget || resolveRepositoryTarget(undefined, {owner: aiConfig.owner, repo: aiConfig.repo});
+
         try {
             const result = await GraphqlService.query(GET_ISSUE_ID, {
-                owner : aiConfig.owner,
-                repo  : aiConfig.repo,
+                owner : target.owner,
+                repo  : target.repo,
                 number: issueNumber
             });
             return result.repository?.issue?.id || null;
         } catch (error) {
-            logger.error(`Error fetching issue #${issueNumber} node ID:`, error);
+            logger.error(`Error fetching ${target.fullName} issue #${issueNumber} node ID:`, error);
             return null;
         }
     }
@@ -653,13 +688,15 @@ class IssueService extends Base {
      *
      * @param {number} issueNumber The issue to attach.
      * @param {Array<{projectNumber: number}>} projects The projects to attach to.
+     * @param {Object} [repositoryTarget] Resolved repository target.
      * @returns {Promise<{attachments: Array<object>, warnings: Array<object>}>}
      */
-    async attachIssueToProjects(issueNumber, projects) {
-        const attachments = [];
-        const warnings    = [];
+    async attachIssueToProjects(issueNumber, projects, repositoryTarget) {
+        const target      = repositoryTarget || resolveRepositoryTarget(undefined, {owner: aiConfig.owner, repo: aiConfig.repo}),
+              attachments = [],
+              warnings    = [];
 
-        const contentId = await this.getIssueNodeId(issueNumber);
+        const contentId = await this.getIssueNodeId(issueNumber, target);
         if (!contentId) {
             warnings.push({
                 projectNumber: null,
@@ -669,7 +706,7 @@ class IssueService extends Base {
         }
 
         for (const {projectNumber} of projects) {
-            const metadata = await this.getProjectV2Metadata(projectNumber);
+            const metadata = await this.getProjectV2Metadata(projectNumber, target);
             if (metadata.error) {
                 warnings.push({projectNumber, error: metadata.message});
                 continue;
@@ -686,7 +723,7 @@ class IssueService extends Base {
                     itemId   : result.addProjectV2ItemById.item.id
                 });
             } catch (error) {
-                logger.error(`Error attaching issue #${issueNumber} to ProjectV2 #${projectNumber}:`, error);
+                logger.error(`Error attaching ${target.fullName} issue #${issueNumber} to ${target.owner} ProjectV2 #${projectNumber}:`, error);
                 warnings.push({projectNumber, error: error.message});
             }
         }
@@ -716,9 +753,14 @@ class IssueService extends Base {
      * @param {number}   [options.projectNumber]   Required for 'update_field'.
      * @param {string}   [options.fieldName]       Required for 'update_field' (the field name, e.g., 'Status').
      * @param {string}   [options.value]           Required for 'update_field' (the single-select option name).
+     * @param {String}   [options.repo]            Optional bare name or owner/name repository target.
      * @returns {Promise<object>} Success message + per-project details, or structured error.
      */
-    async manageIssueProjects({issue_number, action, projectNumbers, projectNumber, fieldName, value}) {
+    async manageIssueProjects({issue_number, action, projectNumbers, projectNumber, fieldName, value, repo}) {
+        const target = resolveRepositoryTarget(repo, {owner: aiConfig.owner, repo: aiConfig.repo});
+
+        if (target.error) return target;
+
         if (!['add', 'remove', 'update_field'].includes(action)) {
             return {
                 error  : 'Bad Request',
@@ -736,7 +778,7 @@ class IssueService extends Base {
                 };
             }
             const projects = projectNumbers.map(n => ({projectNumber: n}));
-            const result   = await this.attachIssueToProjects(issue_number, projects);
+            const result   = await this.attachIssueToProjects(issue_number, projects, target);
             return {
                 message    : `Attempted to attach issue #${issue_number} to ${projects.length} project(s).`,
                 attachments: result.attachments,
@@ -752,7 +794,7 @@ class IssueService extends Base {
                     code   : 'INVALID_ARGUMENTS'
                 };
             }
-            return this.detachIssueFromProjects(issue_number, projectNumbers);
+            return this.detachIssueFromProjects(issue_number, projectNumbers, target);
         }
 
         // action === 'update_field'
@@ -764,7 +806,7 @@ class IssueService extends Base {
             };
         }
 
-        return this.updateProjectV2ItemSingleSelect(issue_number, projectNumber, fieldName, value);
+        return this.updateProjectV2ItemSingleSelect(issue_number, projectNumber, fieldName, value, target);
     }
 
     /**
@@ -776,13 +818,15 @@ class IssueService extends Base {
      *
      * @param {number}   issueNumber    The issue to detach.
      * @param {number[]} projectNumbers The project numbers to detach from.
+     * @param {Object} [repositoryTarget] Resolved repository target.
      * @returns {Promise<object>} Aggregate result with `removed` + `warnings` arrays.
      */
-    async detachIssueFromProjects(issueNumber, projectNumbers) {
-        const removed  = [];
-        const warnings = [];
+    async detachIssueFromProjects(issueNumber, projectNumbers, repositoryTarget) {
+        const target   = repositoryTarget || resolveRepositoryTarget(undefined, {owner: aiConfig.owner, repo: aiConfig.repo}),
+              removed  = [],
+              warnings = [];
 
-        const contentId = await this.getIssueNodeId(issueNumber);
+        const contentId = await this.getIssueNodeId(issueNumber, target);
         if (!contentId) {
             return {
                 error  : 'Not Found',
@@ -792,7 +836,7 @@ class IssueService extends Base {
         }
 
         for (const projectNumber of projectNumbers) {
-            const metadata = await this.getProjectV2Metadata(projectNumber);
+            const metadata = await this.getProjectV2Metadata(projectNumber, target);
             if (metadata.error) {
                 warnings.push({projectNumber, error: metadata.message});
                 continue;
@@ -814,7 +858,7 @@ class IssueService extends Base {
                 });
                 removed.push({projectNumber, itemId});
             } catch (error) {
-                logger.error(`Error removing issue #${issueNumber} from ProjectV2 #${projectNumber}:`, error);
+                logger.error(`Error removing ${target.fullName} issue #${issueNumber} from ${target.owner} ProjectV2 #${projectNumber}:`, error);
                 warnings.push({projectNumber, error: error.message});
             }
         }
@@ -836,10 +880,12 @@ class IssueService extends Base {
      * @param {number} projectNumber The project number containing the item.
      * @param {string} fieldName     The single-select field name (e.g., 'Status').
      * @param {string} value         The option name (e.g., 'In Progress').
+     * @param {Object} [repositoryTarget] Resolved repository target.
      * @returns {Promise<object>} Success or structured error.
      */
-    async updateProjectV2ItemSingleSelect(issueNumber, projectNumber, fieldName, value) {
-        const contentId = await this.getIssueNodeId(issueNumber);
+    async updateProjectV2ItemSingleSelect(issueNumber, projectNumber, fieldName, value, repositoryTarget) {
+        const target    = repositoryTarget || resolveRepositoryTarget(undefined, {owner: aiConfig.owner, repo: aiConfig.repo}),
+              contentId = await this.getIssueNodeId(issueNumber, target);
         if (!contentId) {
             return {
                 error  : 'Not Found',
@@ -848,7 +894,7 @@ class IssueService extends Base {
             };
         }
 
-        const metadata = await this.getProjectV2Metadata(projectNumber);
+        const metadata = await this.getProjectV2Metadata(projectNumber, target);
         if (metadata.error) {
             return metadata;
         }
@@ -903,7 +949,7 @@ class IssueService extends Base {
                 optionId : option.id
             };
         } catch (error) {
-            logger.error(`Error updating field on ProjectV2 #${projectNumber} item:`, error);
+            logger.error(`Error updating field on ${target.owner} ProjectV2 #${projectNumber} item for ${target.fullName}#${issueNumber}:`, error);
             return {
                 error  : 'GraphQL API request failed',
                 message: error.message,
@@ -952,12 +998,17 @@ class IssueService extends Base {
     }
 
     /**
-     * Convenience shortcut
-     * @returns {Promise<Boolean>}
+     * @summary Resolves the selected repository's viewer permission and classifies write access.
+     * @param {Object} repositoryTarget Resolved repository target.
+     * @returns {Promise<{allowed: Boolean, permission: String}|Object>}
      */
-    async hasWritePermission() {
-        const {permission} = await RepositoryService.getViewerPermission();
-        return this.writePermissions.includes(permission);
+    async getWritePermission(repositoryTarget) {
+        const result = await RepositoryService.getViewerPermission({repo: repositoryTarget.fullName});
+
+        return result.error ? result : {
+            allowed   : this.writePermissions.includes(result.permission),
+            permission: result.permission
+        }
     }
 
     /**
@@ -973,9 +1024,14 @@ class IssueService extends Base {
      * @param {string}   options.action                The action to perform: 'add' or 'remove'.
      * @param {boolean}  [options.requireUnassigned=true] Precondition gate for `action: 'add'` — reject if non-empty without `acknowledgedReassign`.
      * @param {string}   [options.acknowledgedReassign] Reason-bearing override for `action: 'add'`; strict-replacement.
+     * @param {String}   [options.repo]                 Optional bare name or owner/name repository target.
      * @returns {Promise<object>}
      */
-    async manageIssueAssignees({issue_number, assignees, action, requireUnassigned, acknowledgedReassign}) {
+    async manageIssueAssignees({issue_number, assignees, action, requireUnassigned, acknowledgedReassign, repo}) {
+        const target = resolveRepositoryTarget(repo, {owner: aiConfig.owner, repo: aiConfig.repo});
+
+        if (target.error) return target;
+
         if (!['add', 'remove'].includes(action)) {
             return {
                 error  : 'Bad Request',
@@ -985,9 +1041,9 @@ class IssueService extends Base {
         }
 
         if (action === 'add') {
-            return this.assignIssue({issue_number, assignees, requireUnassigned, acknowledgedReassign});
+            return this.assignIssue({issue_number, assignees, requireUnassigned, acknowledgedReassign, repositoryTarget: target});
         } else {
-            return this.unassignIssue({issue_number, assignees});
+            return this.unassignIssue({issue_number, assignees, repositoryTarget: target});
         }
     }
 
@@ -999,9 +1055,14 @@ class IssueService extends Base {
      * @param {string} [options.comment_id]   The global node ID of the comment (required for update).
      * @param {string} options.body           The content of the comment.
      * @param {string} options.action         The action to perform: 'create' or 'update'.
+     * @param {String} [options.repo]         Optional bare name or owner/name repository target.
      * @returns {Promise<object>}
      */
-    async manageIssueComment({issue_number, pr_number, comment_id, body, action}) {
+    async manageIssueComment({issue_number, pr_number, comment_id, body, action, repo}) {
+        const target = resolveRepositoryTarget(repo, {owner: aiConfig.owner, repo: aiConfig.repo});
+
+        if (target.error) return target;
+
         if (!['create', 'update'].includes(action)) {
             return {
                 error  : 'Bad Request',
@@ -1011,7 +1072,7 @@ class IssueService extends Base {
         }
 
         if (action === 'create') {
-            return this.createComment({issue_number, pr_number, body});
+            return this.createComment({issue_number, pr_number, body, repositoryTarget: target});
         } else {
             if (!comment_id) {
                 return {
@@ -1020,7 +1081,9 @@ class IssueService extends Base {
                     code   : 'MISSING_ARGUMENTS'
                 };
             }
-            return this.updateComment(comment_id, body);
+            const targetFailure = await this.#getIssueCommentTargetFailure(comment_id, target, {issue_number, pr_number});
+
+            return targetFailure || this.updateComment(comment_id, body);
         }
     }
 
@@ -1030,9 +1093,14 @@ class IssueService extends Base {
      * @param {number}   options.issue_number The number of the issue or PR.
      * @param {string[]} options.labels       An array of labels to add or remove.
      * @param {string}   options.action       The action to perform: 'add' or 'remove'.
+     * @param {String}   [options.repo]       Optional bare name or owner/name repository target.
      * @returns {Promise<object>}
      */
-    async manageIssueLabels({issue_number, labels, action}) {
+    async manageIssueLabels({issue_number, labels, action, repo}) {
+        const target = resolveRepositoryTarget(repo, {owner: aiConfig.owner, repo: aiConfig.repo});
+
+        if (target.error) return target;
+
         if (!['add', 'remove'].includes(action)) {
             return {
                 error  : 'Bad Request',
@@ -1042,9 +1110,9 @@ class IssueService extends Base {
         }
 
         if (action === 'add') {
-            return this.addLabels(issue_number, labels);
+            return this.addLabels(issue_number, labels, target);
         } else {
-            return this.removeLabels(issue_number, labels);
+            return this.removeLabels(issue_number, labels, target);
         }
     }
 
@@ -1055,12 +1123,18 @@ class IssueService extends Base {
      * @param {object}   options              The options object
      * @param {number}   options.issue_number The number of the issue to modify.
      * @param {string[]} options.assignees    An array of GitHub user logins to unassign.
+     * @param {Object}   [options.repositoryTarget] Resolved repository target supplied by the public operation.
      * @returns {Promise<object>}
      */
-    async unassignIssue({issue_number, assignees}) {
-        if (!await this.hasWritePermission()) {
+    async unassignIssue({issue_number, assignees, repositoryTarget}) {
+        const target     = repositoryTarget || resolveRepositoryTarget(undefined, {owner: aiConfig.owner, repo: aiConfig.repo}),
+              permission = await this.getWritePermission(target);
+
+        if (permission.error) return permission;
+
+        if (!permission.allowed) {
             const message = [
-                `Permission denied. Viewer has '${RepositoryService.viewerPermission}' permission, `,
+                `Permission denied for ${target.fullName}. Viewer has '${permission.permission}' permission, `,
                 `but one of [${this.writePermissions.join(', ')}] is required to unassign issues.`
             ].join('');
 
@@ -1080,24 +1154,80 @@ class IssueService extends Base {
             };
         }
 
-        logger.info(`Attempting to unassign issue #${issue_number} from: ${assignees.join(', ')}`);
+        logger.info(`Attempting to unassign ${target.fullName} issue #${issue_number} from: ${assignees.join(', ')}`);
 
         try {
             // DELETE removes the specified logins from the issue's assignee set (incremental remove,
             // the equivalent of `gh issue edit --remove-assignee`); other assignees are preserved.
-            await GraphqlService.rest('DELETE', `/repos/${aiConfig.owner}/${aiConfig.repo}/issues/${issue_number}/assignees`, {assignees});
+            await GraphqlService.rest('DELETE', `/repos/${target.owner}/${target.repo}/issues/${issue_number}/assignees`, {assignees});
 
             const message = `Successfully unassigned ${assignees.join(', ')} from issue #${issue_number}`;
             logger.info(message);
             return { message };
 
         } catch (error) {
-            logger.error(`Error unassigning from issue #${issue_number}:`, error);
+            logger.error(`Error unassigning from ${target.fullName} issue #${issue_number}:`, error);
             return {
                 error  : 'GitHub API request failed',
                 message: error.message,
                 code   : 'GITHUB_API_ERROR'
             };
+        }
+    }
+
+    /**
+     * @summary Verifies a global IssueComment node belongs to the selected repository and supplied parent.
+     * @param {String} commentId Global IssueComment node ID.
+     * @param {Object} repositoryTarget Resolved per-request repository.
+     * @param {Object} parent Optional issue/PR number asserted by the caller.
+     * @returns {Promise<Object|null>} Typed refusal, or null when the target matches.
+     * @private
+     */
+    async #getIssueCommentTargetFailure(commentId, repositoryTarget, {issue_number, pr_number}) {
+        try {
+            const data    = await GraphqlService.query(GET_ISSUE_COMMENT_TARGET, {commentId}),
+                  comment = data?.node,
+                  subject = comment?.pullRequest || comment?.issue,
+                  actual  = subject?.repository?.nameWithOwner;
+
+            if (!comment?.id || !subject || !actual) {
+                return {
+                    error  : 'Not Found',
+                    message: `Issue comment ${commentId} was not found or carried no repository parent.`,
+                    code   : 'COMMENT_NOT_FOUND'
+                }
+            }
+
+            if (actual.toLowerCase() !== repositoryTarget.fullName.toLowerCase()) {
+                return {
+                    error       : 'Repository Target Mismatch',
+                    message     : `Issue comment ${commentId} belongs to ${actual}, not selected repository ${repositoryTarget.fullName}; no update was sent.`,
+                    code        : 'REPOSITORY_TARGET_MISMATCH',
+                    actualRepo  : actual,
+                    selectedRepo: repositoryTarget.fullName
+                }
+            }
+
+            const expectedNumber = pr_number || issue_number;
+
+            if (
+                expectedNumber &&
+                (subject.number !== expectedNumber || Boolean(pr_number) !== Boolean(comment.pullRequest))
+            ) {
+                return {
+                    error  : 'Comment Target Mismatch',
+                    message: `Issue comment ${commentId} does not belong to the supplied ${pr_number ? 'PR' : 'issue'} #${expectedNumber}; no update was sent.`,
+                    code   : 'COMMENT_TARGET_MISMATCH'
+                }
+            }
+
+            return null
+        } catch (error) {
+            return {
+                error  : 'GraphQL API request failed',
+                message: error.message,
+                code   : 'GRAPHQL_API_ERROR'
+            }
         }
     }
 
@@ -1134,6 +1264,7 @@ class IssueService extends Base {
      * @summary Detects GitHub's missing-number GraphQL error for one labelable branch.
      * @param {Error}  error       GraphQL failure.
      * @param {String} type        GitHub type name (`Issue` or `PullRequest`).
+     * @param {Object} repositoryTarget Resolved repository target.
      * @param {Number} issueNumber Repository issue/PR number.
      * @returns {Boolean}
      * @private
@@ -1150,10 +1281,10 @@ class IssueService extends Base {
      * @returns {Promise<Object|null>}
      * @private
      */
-    async #queryLabelableIds(query, issueNumber, type) {
+    async #queryLabelableIds(query, issueNumber, type, repositoryTarget) {
         const variables = {
-            owner    : aiConfig.owner,
-            repo     : aiConfig.repo,
+            owner    : repositoryTarget.owner,
+            repo     : repositoryTarget.repo,
             issueNumber,
             maxLabels: aiConfig.issueSync.maxRepoLabels
         };
@@ -1195,16 +1326,17 @@ class IssueService extends Base {
      * Fetches the GraphQL node IDs for an issue or pull request and a set of labels.
      * @param {number}   issueNumber The number of the issue or PR.
      * @param {string[]} labelNames  An array of label names.
+     * @param {Object} repositoryTarget Resolved repository target.
      * @returns {Promise<{labelableId: string, labelIds: string[]}>} The node IDs.
      * @private
      */
-    async #getIds(issueNumber, labelNames) {
+    async #getIds(issueNumber, labelNames, repositoryTarget) {
         let
-            data        = await this.#queryLabelableIds(GET_ISSUE_LABEL_IDS, issueNumber, 'Issue'),
+            data        = await this.#queryLabelableIds(GET_ISSUE_LABEL_IDS, issueNumber, 'Issue', repositoryTarget),
             labelableId = data?.repository?.issue?.id;
 
         if (!labelableId) {
-            data        = await this.#queryLabelableIds(GET_PULL_REQUEST_LABEL_IDS, issueNumber, 'PullRequest');
+            data        = await this.#queryLabelableIds(GET_PULL_REQUEST_LABEL_IDS, issueNumber, 'PullRequest', repositoryTarget);
             labelableId = data?.repository?.pullRequest?.id;
         }
 
@@ -1222,16 +1354,17 @@ class IssueService extends Base {
      * @param {number}      blockedIssue   The issue number being blocked
      * @param {string}      blockedIssueId The GraphQL ID of the blocked issue
      * @param {number|null} blockingIssue  The issue number doing the blocking (null to remove)
+     * @param {Object}      repositoryTarget Resolved repository target.
      * @returns {Promise<object>} Result with updated relationship information
      * @private
      */
-    async #handleBlockedByRelationship(blockedIssue, blockedIssueId, blockingIssue) {
+    async #handleBlockedByRelationship(blockedIssue, blockedIssueId, blockingIssue, repositoryTarget) {
         // If blockingIssue is null, we're removing a blocked-by relationship
         if (!blockingIssue) {
             // Fetch current blockedBy relationships
             const blockedData = await GraphqlService.query(GET_BLOCKED_BY, {
-                owner : aiConfig.owner,
-                repo  : aiConfig.repo,
+                owner : repositoryTarget.owner,
+                repo  : repositoryTarget.repo,
                 number: blockedIssue
             }, true); // Enable sub-issues feature for blocked-by access
 
@@ -1268,8 +1401,8 @@ class IssueService extends Base {
 
         // Adding a blocked-by relationship
         const blockingIdData = await GraphqlService.query(GET_ISSUE_ID, {
-            owner : aiConfig.owner,
-            repo  : aiConfig.repo,
+            owner : repositoryTarget.owner,
+            repo  : repositoryTarget.repo,
             number: blockingIssue
         });
 
@@ -1311,9 +1444,14 @@ class IssueService extends Base {
      * @param {'full'|'summary'|'title'|'title_only'} [options.projection='full'] Response shape projection
      * @param {string}          [options.cursor]            Cursor for pagination; pass a prior `endCursor`
      * @param {'updated'|'created'} [options.sort='updated'] Order field: `updated` (default) or `created` — creation order is the freshness-sweep evidence (updated-desc buries untouched fresh filings below recently-updated older issues)
+     * @param {String}          [options.repo]               Optional bare name or owner/name repository target.
      * @returns {Promise<object>} `{count, totalCount, truncated, endCursor, issues}`
      */
-    async listIssues({limit=30, state='open', labels=null, assignee=null, projection='full', cursor=null, sort='updated'} = {}) {
+    async listIssues({limit=30, state='open', labels=null, assignee=null, projection='full', cursor=null, sort='updated', repo} = {}) {
+        const target = resolveRepositoryTarget(repo, {owner: aiConfig.owner, repo: aiConfig.repo});
+
+        if (target.error) return target;
+
         const normalizedProjection = this.normalizeIssueListProjection(projection);
 
         if (!normalizedProjection) {
@@ -1386,8 +1524,8 @@ class IssueService extends Base {
             : buildIssuesListQuery({withAssigneeFilter: hasAssigneeFilter, orderField});
 
         const variables = {
-            owner: aiConfig.owner,
-            repo : aiConfig.repo,
+            owner: target.owner,
+            repo : target.repo,
             limit,
             cursor,
             states,
@@ -1445,7 +1583,7 @@ class IssueService extends Base {
                 issues
             };
         } catch (error) {
-            logger.error('Error fetching issues via GraphQL:', error);
+            logger.error(`Error fetching issues from ${target.fullName} via GraphQL:`, error);
             return {
                 error  : 'GraphQL API request failed',
                 message: error.message,
@@ -1513,16 +1651,19 @@ class IssueService extends Base {
      * Removes labels from an issue or pull request.
      * @param {number}   issueNumber The number of the issue or PR.
      * @param {string[]} labels      An array of labels to remove.
+     * @param {Object} [repositoryTarget] Resolved repository target supplied by the public operation.
      * @returns {Promise<object>} A promise that resolves to a success message.
      */
-    async removeLabels(issueNumber, labels) {
+    async removeLabels(issueNumber, labels, repositoryTarget) {
+        const target = repositoryTarget || resolveRepositoryTarget(undefined, {owner: aiConfig.owner, repo: aiConfig.repo});
+
         try {
-            const { labelableId, labelIds } = await this.#getIds(issueNumber, labels);
+            const { labelableId, labelIds } = await this.#getIds(issueNumber, labels, target);
 
             await GraphqlService.query(REMOVE_LABELS, { labelableId, labelIds });
             return { message: `Successfully removed labels from issue #${issueNumber}` };
         } catch (error) {
-            logger.error(`Error removing labels from issue #${issueNumber} via GraphQL:`, error);
+            logger.error(`Error removing labels from ${target.fullName} issue #${issueNumber} via GraphQL:`, error);
             return {
                 error  : 'GraphQL API request failed',
                 message: error.message,
@@ -1539,9 +1680,31 @@ class IssueService extends Base {
      * @param {number}  options.child_issue                        The issue number of the child/blocked issue
      * @param {number}  [options.parent_issue]                     The issue number of the parent/blocking issue (omit to unset relationship)
      * @param {boolean} [options.replace_parent=false]             If true, replaces existing parent relationship (parent_child only)
+     * @param {String}  [options.repo]                             Optional bare name or owner/name repository target; both issue numbers stay inside it.
      * @returns {Promise<object>} Result with updated relationship information or error
      */
-    async updateIssueRelationship({relationship_type='parent_child', child_issue, parent_issue=null, replace_parent=false}) {
+    async updateIssueRelationship({relationship_type='parent_child', child_issue, parent_issue=null, replace_parent=false, repo}) {
+        const target = resolveRepositoryTarget(repo, {owner: aiConfig.owner, repo: aiConfig.repo});
+
+        if (target.error) return target;
+
+        const relationshipNumbers = [child_issue, ...(parent_issue == null ? [] : [parent_issue])];
+
+        if (relationshipNumbers.some(value => !Number.isInteger(value))) {
+            const crossRepository = relationshipNumbers.find(value =>
+                typeof value === 'string' && (value.includes('/') || value.includes('#')));
+
+            return crossRepository ? {
+                error  : 'Cross-Repository Relationship Unsupported',
+                message: `Issue relationship input '${crossRepository}' carries repository identity, but this operation interprets both numeric issue IDs inside selected repository ${target.fullName}. Cross-repository relationships require two repo-qualified graph identities and are not supported.`,
+                code   : 'CROSS_REPOSITORY_RELATIONSHIP_UNSUPPORTED'
+            } : {
+                error  : 'Bad Request',
+                message: '`child_issue` and supplied `parent_issue` must be integer issue numbers inside the selected repository.',
+                code   : 'INVALID_ARGUMENTS'
+            }
+        }
+
         try {
             // Validate relationship type
             const validTypes = ['parent_child', 'blocked_by'];
@@ -1555,8 +1718,8 @@ class IssueService extends Base {
 
             // Get GraphQL IDs for both issues
             const childIdData = await GraphqlService.query(GET_ISSUE_ID, {
-                owner : aiConfig.owner,
-                repo  : aiConfig.repo,
+                owner : target.owner,
+                repo  : target.repo,
                 number: child_issue
             });
 
@@ -1564,7 +1727,7 @@ class IssueService extends Base {
 
             // Handle blocked_by relationship type
             if (relationship_type === 'blocked_by') {
-                return await this.#handleBlockedByRelationship(child_issue, childIssueId, parent_issue);
+                return await this.#handleBlockedByRelationship(child_issue, childIssueId, parent_issue, target);
             }
 
             // Handle parent_child relationship type (original logic)
@@ -1573,8 +1736,8 @@ class IssueService extends Base {
                 // To remove a parent, we need the current parent's ID
                 // First, fetch the child issue's current parent
                 const childData = await GraphqlService.query(GET_ISSUE_PARENT, {
-                    owner : aiConfig.owner,
-                    repo  : aiConfig.repo,
+                    owner : target.owner,
+                    repo  : target.repo,
                     number: child_issue
                 });
 
@@ -1607,8 +1770,8 @@ class IssueService extends Base {
 
             // Adding or replacing a parent relationship
             const parentIdData = await GraphqlService.query(GET_ISSUE_ID, {
-                owner : aiConfig.owner,
-                repo  : aiConfig.repo,
+                owner : target.owner,
+                repo  : target.repo,
                 number: parent_issue
             });
 
@@ -1631,7 +1794,7 @@ class IssueService extends Base {
             };
 
         } catch (error) {
-            logger.error(`Error updating issue relationship for #${child_issue}:`, error);
+            logger.error(`Error updating issue relationship for ${target.fullName}#${child_issue}:`, error);
 
             // Provide helpful error messages for common scenarios
             let errorMessage = error.message;

--- a/ai/services/github-workflow/LabelService.mjs
+++ b/ai/services/github-workflow/LabelService.mjs
@@ -2,6 +2,7 @@ import Base           from '../../../src/core/Base.mjs';
 import GraphqlService from './GraphqlService.mjs';
 import aiConfig       from '../../mcp/server/github-workflow/config.mjs';
 import {FETCH_LABELS} from './queries/labelQueries.mjs';
+import {resolveRepositoryTarget} from './shared/repositoryTarget.mjs';
 
 /**
  * @summary Service for interacting with GitHub labels via the GraphQL API.
@@ -38,19 +39,25 @@ class LabelService extends Base {
      * and converts thrown exceptions into structured MCP error payloads for protocol
      * responses; non-MCP callers (build scripts, CLI) receive normal exception semantics.
      *
+     * @param {Object} [options]
+     * @param {String} [options.repo] Optional bare name or owner/name repository target.
      * @returns {Promise<{count: number, labels: object[]}>} Resolves to the aggregated label set.
      * @throws {Error} If the underlying GraphQL call fails. See `GraphqlService.query` for error shapes.
      * @see https://github.com/neomjs/neo/issues/10112
      */
-    async listLabels() {
+    async listLabels({repo} = {}) {
+        const target = resolveRepositoryTarget(repo, {owner: aiConfig.owner, repo: aiConfig.repo});
+
+        if (target.error) return target;
+
         let allLabels   = [];
         let hasNextPage = true;
         let cursor      = null;
 
         while (hasNextPage) {
             const variables = {
-                owner: aiConfig.owner,
-                repo : aiConfig.repo,
+                owner: target.owner,
+                repo : target.repo,
                 limit: 100,
                 cursor
             };

--- a/ai/services/github-workflow/PullRequestService.mjs
+++ b/ai/services/github-workflow/PullRequestService.mjs
@@ -32,6 +32,7 @@ import {
 import {commentMatches, isSelectorPresent, malformedCommentIdError, omitScopedBody, parseCommentId}
                                               from './shared/commentSelector.mjs';
 import {projectConversationTrust}              from './shared/conversationTrust.mjs';
+import {resolveRepositoryTarget}  from './shared/repositoryTarget.mjs';
 
 const execAsync                           = promisify(exec);
 const execFileAsync                       = promisify(execFile);
@@ -3473,6 +3474,7 @@ class PullRequestService extends Base {
      *                                                  resolved one level up, because invalid now errors.
      * @param {number}        [options.last_n]          Return only the last N comments (by createdAt order).
      *                                                  Also scoped: body omitted, `bodyOmitted: true`.
+     * @param {String}        [options.repo]            Optional bare name or owner/name repository target.
      * @param {Object}        [dependencies] Internal source seams for deterministic tests.
      * @param {Function}      [dependencies.query] GitHub GraphQL query function.
      * @param {Function}      [dependencies.rest] GitHub REST request function.
@@ -3492,10 +3494,15 @@ class PullRequestService extends Base {
             since_comment_id,
             last_n,
             projection = 'conversation',
-            identityAssertion
+            identityAssertion,
+            repo
         } = typeof options === 'number'
             ? {pr_number: options}
             : (options || {});
+
+        const target = resolveRepositoryTarget(repo, {owner: aiConfig.owner, repo: aiConfig.repo});
+
+        if (target.error) return target;
 
         if (!pr_number) {
             return {
@@ -3525,13 +3532,15 @@ class PullRequestService extends Base {
             return buildMergeReadinessProjection({
                 prNumber: pr_number,
                 identityAssertion,
+                owner   : target.owner,
+                repo    : target.repo,
                 ...dependencies
             });
         }
 
         const variables = {
-            owner      : aiConfig.owner,
-            repo       : aiConfig.repo,
+            owner      : target.owner,
+            repo       : target.repo,
             prNumber   : pr_number,
             maxComments: aiConfig.pullRequest.maxCommentsPerPullRequest
         };
@@ -3587,7 +3596,7 @@ class PullRequestService extends Base {
                 }
             });
         } catch (error) {
-            logger.error(`Error getting conversation for PR #${pr_number} via GraphQL:`, error);
+            logger.error(`Error getting conversation for ${target.fullName} PR #${pr_number} via GraphQL:`, error);
             return {
                 error  : 'GraphQL API request failed',
                 message: error.message,
@@ -3603,10 +3612,14 @@ class PullRequestService extends Base {
      * @param {string}  [options.file]     Optional file path (or comma-separated paths) to filter diff
      * @param {string}  [options.sha]      Optional SHA to diff against instead of live PR head
      * @param {boolean} [options.files_only] If true, return structured JSON with path/additions/deletions
+     * @param {String}  [options.repo]     Optional bare name or owner/name repository target.
      * @returns {Promise<string|object>} A promise that resolves to the diff text, file list JSON, or a structured error.
      */
     async getPullRequestDiff(options) {
-        const { pr_number, file, sha, files_only } = options || {};
+        const { pr_number, file, sha, files_only, repo } = options || {},
+              target                                     = resolveRepositoryTarget(repo, {owner: aiConfig.owner, repo: aiConfig.repo});
+
+        if (target.error) return target;
 
         const prNumber = parseInt(pr_number, 10);
 
@@ -3620,7 +3633,7 @@ class PullRequestService extends Base {
 
         try {
             if (files_only) {
-                const {stdout} = await execFileAsync('gh', ['pr', 'view', String(prNumber), '--json', 'files'], {cwd: aiConfig.projectRoot});
+                const {stdout} = await execFileAsync('gh', ['pr', 'view', String(prNumber), '--repo', target.fullName, '--json', 'files'], {cwd: aiConfig.projectRoot});
                 const parsed   = JSON.parse(stdout);
                 return { files: parsed.files || [] };
             }
@@ -3644,14 +3657,22 @@ class PullRequestService extends Base {
                     };
                 }
 
-                const {stdout: baseStdout} = await execFileAsync('gh', ['pr', 'view', String(prNumber), '--json', 'baseRefOid'], {cwd: aiConfig.projectRoot});
+                const {stdout: baseStdout} = await execFileAsync('gh', ['pr', 'view', String(prNumber), '--repo', target.fullName, '--json', 'baseRefOid'], {cwd: aiConfig.projectRoot});
                 const baseRefOid           = JSON.parse(baseStdout).baseRefOid;
 
-                const filePaths = file.split(',').map(f => f.trim());
-                const {stdout}  = await execFileAsync('git', ['diff', `${baseRefOid}...${sha}`, '--', ...filePaths], {cwd: aiConfig.projectRoot});
+                const filePaths  = file.split(',').map(f => f.trim()),
+                      homeTarget = resolveRepositoryTarget(undefined, {owner: aiConfig.owner, repo: aiConfig.repo});
+                const {stdout} = target.fullName === homeTarget.fullName
+                    ? await execFileAsync('git', ['diff', `${baseRefOid}...${sha}`, '--', ...filePaths], {cwd: aiConfig.projectRoot})
+                    : await execFileAsync('gh', [
+                        'api',
+                        `repos/${target.owner}/${target.repo}/compare/${baseRefOid}...${sha}`,
+                        '-H',
+                        'Accept: application/vnd.github.v3.diff'
+                    ], {cwd: aiConfig.projectRoot});
                 diffStdout = stdout;
             } else {
-                const {stdout} = await execFileAsync('gh', ['pr', 'diff', String(prNumber)], {cwd: aiConfig.projectRoot});
+                const {stdout} = await execFileAsync('gh', ['pr', 'diff', String(prNumber), '--repo', target.fullName], {cwd: aiConfig.projectRoot});
                 diffStdout = stdout;
             }
 
@@ -3690,7 +3711,7 @@ class PullRequestService extends Base {
             return { result: diffStdout };
 
         } catch (error) {
-            logger.error(`Error getting diff for PR #${prNumber}:`, error);
+            logger.error(`Error getting diff for ${target.fullName} PR #${prNumber}:`, error);
 
             if (error.stderr && (error.stderr.includes('bad object') || error.stderr.includes('unknown revision') || error.stderr.includes('Invalid symmetric difference expression'))) {
                 return {
@@ -3716,13 +3737,19 @@ class PullRequestService extends Base {
      * @param {number}   [options.limit=aiConfig.pullRequest.defaults.limit] The maximum number of PRs to return
      * @param {string}   [options.state=aiConfig.pullRequest.defaults.state] The state of the pull requests to list (open, closed, merged, all)
      * @param {Number[]} [options.believedOpen]                              Exact PR numbers whose open belief should be falsified
+     * @param {String}   [options.repo]                                       Optional bare name or owner/name repository target.
      * @returns {Promise<object>} A promise that resolves to the list of pull requests or a structured error.
      */
     async listPullRequests({
         believedOpen,
         limit = aiConfig.pullRequest.defaults.limit,
-        state = aiConfig.pullRequest.defaults.state
+        state = aiConfig.pullRequest.defaults.state,
+        repo
     } = {}) {
+
+        const target = resolveRepositoryTarget(repo, {owner: aiConfig.owner, repo: aiConfig.repo});
+
+        if (target.error) return target;
 
         const validationMessage = getBelievedOpenValidationMessage(believedOpen);
 
@@ -3735,8 +3762,8 @@ class PullRequestService extends Base {
         }
 
         const variables = {
-            owner : aiConfig.owner,
-            repo  : aiConfig.repo,
+            owner : target.owner,
+            repo  : target.repo,
             limit,
             states: state.toUpperCase()
         };
@@ -3765,7 +3792,7 @@ class PullRequestService extends Base {
 
             return result;
         } catch (error) {
-            logger.error('Error fetching pull requests via GraphQL:', error);
+            logger.error(`Error fetching pull requests from ${target.fullName} via GraphQL:`, error);
             return {
                 error  : 'GraphQL API request failed',
                 message: error.message,
@@ -3865,6 +3892,7 @@ class PullRequestService extends Base {
      * @param {String} [options.review_id]      The GraphQL node ID of the existing review (required for `update`; PRR_*).
      * @param {Object} [options.acknowledgedRequestChanges] Reviewer-login → disposition map required when approving over live `CHANGES_REQUESTED`.
      * @param {String} [options.reviewBudgetOverrideReason] Single-line durable disclosure for an exceptional post-budget ordinary RC.
+     * @param {String} [options.repo]                       Optional bare name or owner/name repository target.
      * @returns {Promise<Object>} Review payload on success (`{message, reviewId, state, url, submittedAt, databaseId?}`) or structured error.
      *
      * @see Neo.ai.services.github-workflow.queries.mutations.ADD_PULL_REQUEST_REVIEW
@@ -3876,8 +3904,13 @@ class PullRequestService extends Base {
         state,
         body,
         review_id,
-        reviewBudgetOverrideReason
+        reviewBudgetOverrideReason,
+        repo
     }) {
+        const target = resolveRepositoryTarget(repo, {owner: aiConfig.owner, repo: aiConfig.repo});
+
+        if (target.error) return target;
+
         if (!['create', 'update'].includes(action)) {
             return {
                 error  : 'Bad Request',
@@ -3952,12 +3985,16 @@ class PullRequestService extends Base {
             try {
                 const idData = await GraphqlService.query(GET_PULL_REQUEST_ID, {
                     activationIssueNumber: this.reviewBudgetActivationIssueNumber,
-                    owner                : aiConfig.owner,
-                    repo                 : aiConfig.repo,
+                    homeOwner            : aiConfig.owner,
+                    homeRepo             : aiConfig.repo,
+                    owner                : target.owner,
+                    repo                 : target.repo,
                     prNumber             : pr_number
                 });
-                const activationIssue = idData?.repository?.activationIssue;
-                const pullRequest     = idData?.repository?.pullRequest;
+                // `repository` fallback keeps injected legacy fixtures readable while production
+                // queries split home-policy activation from selected-target PR history.
+                const activationIssue = idData?.homeRepository?.activationIssue ?? idData?.repository?.activationIssue;
+                const pullRequest     = idData?.targetRepository?.pullRequest   ?? idData?.repository?.pullRequest;
                 const pullRequestId   = pullRequest?.id;
 
                 if (!pullRequestId) {
@@ -3994,8 +4031,8 @@ class PullRequestService extends Base {
 
                         try {
                             const resolved = await GraphqlService.query(buildIssueStatesQuery(ownerNumbers), {
-                                owner: aiConfig.owner,
-                                repo : aiConfig.repo
+                                owner: target.owner,
+                                repo : target.repo
                             });
 
                             states = Object.fromEntries(ownerNumbers.map(number =>
@@ -4004,7 +4041,7 @@ class PullRequestService extends Base {
                             // Unreadable answer ⇒ no refusal. See the helper's note: this gate sits on
                             // the merge-safe terminal, so a GitHub hiccup must not block the path the
                             // contract exists to make reachable.
-                            logger.warn(`Follow-up owner resolution failed for PR #${pr_number}; admitting: ${error.message}`)
+                            logger.warn(`Follow-up owner resolution failed for ${target.fullName} PR #${pr_number}; admitting: ${error.message}`)
                         }
 
                         const ownerResolutionFailure = states && getFollowUpOwnerResolutionFailure({
@@ -4148,7 +4185,7 @@ class PullRequestService extends Base {
                     } : {})
                 };
             } catch (error) {
-                logger.error(`Error creating PR review on PR #${pr_number}:`, error);
+                logger.error(`Error creating PR review on ${target.fullName} PR #${pr_number}:`, error);
                 return {
                     error  : 'GraphQL API request failed',
                     message: error.message,
@@ -4175,6 +4212,20 @@ class PullRequestService extends Base {
                     error  : 'Not Found',
                     message: `Pull request review ${review_id} not found or returned no review node.`,
                     code   : 'PR_REVIEW_NOT_FOUND'
+                }
+            }
+
+            const actualRepo = currentReview.pullRequest?.repository?.nameWithOwner;
+
+            if (target.explicit && (!actualRepo || actualRepo.toLowerCase() !== target.fullName.toLowerCase())) {
+                return {
+                    error  : 'Repository Target Mismatch',
+                    message: actualRepo
+                        ? `Pull request review ${review_id} belongs to ${actualRepo}, not selected repository ${target.fullName}; no update was sent.`
+                        : `Pull request review ${review_id} carried no repository identity, so selected repository ${target.fullName} could not be verified; no update was sent.`,
+                    code        : 'REPOSITORY_TARGET_MISMATCH',
+                    actualRepo  : actualRepo || null,
+                    selectedRepo: target.fullName
                 }
             }
 
@@ -4273,7 +4324,7 @@ class PullRequestService extends Base {
                 submittedAt: review.submittedAt
             };
         } catch (error) {
-            logger.error(`Error updating PR review ${review_id}:`, error);
+            logger.error(`Error updating PR review ${review_id} for selected repository ${target.fullName}:`, error);
             return {
                 error  : 'GraphQL API request failed',
                 message: error.message,
@@ -4308,6 +4359,7 @@ class PullRequestService extends Base {
      * @param {string[]}  [options.reviewers]        Array of GitHub user logins to add or remove as reviewers.
      * @param {string[]}  [options.team_reviewers]   Array of bare team slugs (no owner prefix — the REST endpoint takes slugs directly).
      * @param {string}    options.action             Either `'add'` or `'remove'`.
+     * @param {String}    [options.repo]             Optional bare name or owner/name repository target.
      * @returns {Promise<object>} On success, a message plus `verifiedReviewers` / `verifiedTeamReviewers`
      * read out of GitHub's response — never echoed from the arguments. A requested login that GitHub did
      * not seat returns `REVIEWER_NOT_SEATED`, a `remove` whose target is still listed returns
@@ -4316,7 +4368,11 @@ class PullRequestService extends Base {
      *
      * @see pull-request-workflow.md §6.1 (cross-family mandate — invitation layer cross-reference)
      */
-    async managePrReviewers({pr_number, reviewers, team_reviewers, action}, {execFn = execAsync} = {}) {
+    async managePrReviewers({pr_number, reviewers, team_reviewers, action, repo}, {execFn = execAsync} = {}) {
+        const target = resolveRepositoryTarget(repo, {owner: aiConfig.owner, repo: aiConfig.repo});
+
+        if (target.error) return target;
+
         if (!['add', 'remove'].includes(action)) {
             return {
                 error  : 'Bad Request',
@@ -4350,8 +4406,8 @@ class PullRequestService extends Base {
             const allFlags      = [reviewerFlags, teamFlags].filter(Boolean).join(' ');
             const allTargets    = [...reviewerList, ...teamReviewerList];
 
-            const command = `gh api repos/${aiConfig.owner}/${aiConfig.repo}/pulls/${pr_number}/requested_reviewers -X ${method} ${allFlags}`;
-            logger.info(`Attempting to ${action} reviewers on PR #${pr_number} via REST: ${allTargets.join(', ')}`);
+            const command = `gh api repos/${target.owner}/${target.repo}/pulls/${pr_number}/requested_reviewers -X ${method} ${allFlags}`;
+            logger.info(`Attempting to ${action} reviewers on ${target.fullName} PR #${pr_number} via REST: ${allTargets.join(', ')}`);
 
             const {stdout} = await execFn(command, {cwd: aiConfig.projectRoot}) || {};
 
@@ -4366,7 +4422,7 @@ class PullRequestService extends Base {
             const seated = parseSeatedReviewerState(stdout);
 
             if (!seated) {
-                logger.error(`Unverifiable requested_reviewers response on PR #${pr_number}`);
+                logger.error(`Unverifiable requested_reviewers response on ${target.fullName} PR #${pr_number}`);
                 return {
                     error  : 'Reviewer state unverifiable',
                     message: `Cannot confirm reviewer state on PR #${pr_number}: the requested_reviewers response did not carry the expected 'requested_reviewers'/'requested_teams' arrays, so whether ${allTargets.join(', ')} ${action === 'add' ? 'was seated' : 'was removed'} is unknown. Re-read the PR before trusting any reviewer assumption.`,
@@ -4405,7 +4461,7 @@ class PullRequestService extends Base {
                             `PR's reviewer state before assigning it to anyone else.`
                     };
 
-                logger.error(`${failure.code} on PR #${pr_number}: ${unseated.join(', ')}`);
+                logger.error(`${failure.code} on ${target.fullName} PR #${pr_number}: ${unseated.join(', ')}`);
 
                 return {
                     ...failure,
@@ -4429,7 +4485,7 @@ class PullRequestService extends Base {
                 verifiedTeamReviewers: [...seated.teams]
             };
         } catch (error) {
-            logger.error(`Error managing reviewers on PR #${pr_number}:`, error);
+            logger.error(`Error managing reviewers on ${target.fullName} PR #${pr_number}:`, error);
             return {
                 error  : 'GitHub API request failed',
                 message: `Failed to ${action} reviewers on PR #${pr_number}: ${error.message} (REST requested_reviewers needs only the repo scope)`,

--- a/ai/services/github-workflow/RepositoryService.mjs
+++ b/ai/services/github-workflow/RepositoryService.mjs
@@ -3,6 +3,7 @@ import Base                    from '../../../src/core/Base.mjs';
 import GraphqlService          from './GraphqlService.mjs';
 import logger                  from '../../mcp/server/github-workflow/logger.mjs';
 import {GET_VIEWER_PERMISSION} from './queries/repositoryQueries.mjs';
+import {resolveRepositoryTarget} from './shared/repositoryTarget.mjs';
 
 /**
  * @summary Service for interacting with the GitHub repository itself.
@@ -38,6 +39,14 @@ class RepositoryService extends Base {
     viewerPermission = null;
 
     /**
+     * Repository-qualified permission cache. A permission read for `neomjs/neo` must never authorize
+     * a mutation in `neomjs/devindex`; the key is the selected `owner/name`, not process identity.
+     * `viewerPermission` above remains the backward-compatible home-repository projection.
+     * @member {Map<String,String>}
+     */
+    viewerPermissions = new Map();
+
+    /**
      * The authenticated user's GitHub login, cached alongside the permission it was fetched with.
      *
      * The permission answers "may this seat act?"; the login answers "which seat is acting?" — and a
@@ -54,42 +63,74 @@ class RepositoryService extends Base {
     /**
      * Fetches the current user's permission level from the API and caches it.
      * This method is intended for internal use at startup but can be called on demand.
-     * @returns {Promise<string|null>} The permission string or null on failure.
+     * @param {Object} [options]
+     * @param {String} [options.repo] Optional bare name or owner/name repository target.
+     * @returns {Promise<string|Object|null>} The permission string, typed target refusal, or null on I/O failure.
      */
-    async fetchAndCacheViewerPermission() {
+    async fetchAndCacheViewerPermission({repo, repositoryTarget} = {}) {
+        const target = repositoryTarget || resolveRepositoryTarget(repo, {owner: aiConfig.owner, repo: aiConfig.repo});
+
+        if (target.error) return target;
+
         const variables = {
-            owner: aiConfig.owner,
-            repo : aiConfig.repo
+            owner: target.owner,
+            repo : target.repo
         };
 
         try {
-            const data = await GraphqlService.query(GET_VIEWER_PERMISSION, variables);
-            this.viewerPermission = data.repository.viewerPermission;
+            const data       = await GraphqlService.query(GET_VIEWER_PERMISSION, variables),
+                  permission = data.repository.viewerPermission,
+                  home       = resolveRepositoryTarget(undefined, {owner: aiConfig.owner, repo: aiConfig.repo});
+
+            this.viewerPermissions.set(target.fullName, permission);
+
+            if (target.fullName === home.fullName) {
+                this.viewerPermission = permission;
+            }
+
             // Null rather than undefined on a payload without it, so a consumer can tell "the viewer
             // has no login" from "nobody has asked yet" — a budget that cannot identify its spender
             // must refuse, and it can only refuse if the two states are distinguishable.
             this.viewerLogin      = data.viewer?.login ?? null;
-            logger.info(`Fetched and cached viewer permission: ${this.viewerPermission} (${this.viewerLogin || 'unknown login'})`);
-            return this.viewerPermission;
+            logger.info(`Fetched and cached viewer permission for ${target.fullName}: ${permission} (${this.viewerLogin || 'unknown login'})`);
+            return permission;
         } catch (error) {
-            logger.error('Error fetching viewer permission via GraphQL:', error);
+            logger.error(`Error fetching viewer permission for ${target.fullName} via GraphQL:`, error);
             return null;
         }
     }
 
     /**
      * Returns the cached permission level of the current user, wrapped in an object.
-     * @returns {Promise<object>} A promise that resolves to an object of the shape `{permission: '...'}`.
+     * @param {Object} [options]
+     * @param {String} [options.repo] Optional bare name or owner/name repository target.
+     * @param {Object} [options.repositoryTarget] Already-resolved internal request target.
+     * @returns {Promise<object>} `{permission: '...'}` or a typed repository-target refusal.
      */
-    async getViewerPermission() {
-        if (!this.viewerPermission) {
-            // This can happen if the initial fetch on startup failed.
-            // We will try to fetch it again on demand.
-            logger.warn('Viewer permission not cached, attempting to fetch now...');
-            await this.fetchAndCacheViewerPermission();
+    async getViewerPermission({repo} = {}) {
+        const target = resolveRepositoryTarget(repo, {owner: aiConfig.owner, repo: aiConfig.repo});
+
+        if (target.error) return target;
+
+        const home       = resolveRepositoryTarget(undefined, {owner: aiConfig.owner, repo: aiConfig.repo});
+        let   permission = this.viewerPermissions.get(target.fullName);
+
+        if (!permission && target.fullName === home.fullName) {
+            permission = this.viewerPermission;
         }
 
-        return {permission: this.viewerPermission};
+        if (!permission) {
+            // This can happen if the initial fetch on startup failed.
+            // We will try to fetch it again on demand.
+            logger.warn(`Viewer permission for ${target.fullName} not cached, attempting to fetch now...`);
+            const fetched = await this.fetchAndCacheViewerPermission({repositoryTarget: target});
+
+            if (fetched?.error) return fetched;
+
+            permission = fetched;
+        }
+
+        return {permission};
     }
 
     /**

--- a/ai/services/github-workflow/queries/mutations.mjs
+++ b/ai/services/github-workflow/queries/mutations.mjs
@@ -309,6 +309,32 @@ export const UPDATE_COMMENT = `
 `;
 
 /**
+ * Resolves the repository + parent number behind one global IssueComment node before update.
+ * A global node ID is not repository authority: the caller's selected repo must match the node's
+ * actual parent before the mutation is allowed to run.
+ *
+ * Variables required:
+ * - $commentId: ID! - The global ID of the comment to inspect
+ */
+export const GET_ISSUE_COMMENT_TARGET = `
+  query GetIssueCommentTarget($commentId: ID!) {
+    node(id: $commentId) {
+      ... on IssueComment {
+        id
+        issue {
+          number
+          repository { nameWithOwner }
+        }
+        pullRequest {
+          number
+          repository { nameWithOwner }
+        }
+      }
+    }
+  }
+`;
+
+/**
  * Mutation to add a new comment to a discussion.
  *
  * Variables required:
@@ -341,6 +367,27 @@ export const UPDATE_DISCUSSION_COMMENT = `
         id
         url
         updatedAt
+      }
+    }
+  }
+`;
+
+/**
+ * Resolves the repository + Discussion number behind one global DiscussionComment node.
+ * The selected repository is checked before a comment update can use the global node ID.
+ *
+ * Variables required:
+ * - $commentId: ID! - The global ID of the Discussion comment to inspect
+ */
+export const GET_DISCUSSION_COMMENT_TARGET = `
+  query GetDiscussionCommentTarget($commentId: ID!) {
+    node(id: $commentId) {
+      ... on DiscussionComment {
+        id
+        discussion {
+          number
+          repository { nameWithOwner }
+        }
       }
     }
   }
@@ -545,6 +592,8 @@ export const UPDATE_PROJECT_V2_ITEM_SINGLE_SELECT = `
  *
  * Variables required:
  * - $activationIssueNumber: Int!
+ * - $homeOwner:             String!
+ * - $homeRepo:              String!
  * - $owner:                 String!
  * - $repo:                  String!
  * - $prNumber:              Int!
@@ -552,11 +601,13 @@ export const UPDATE_PROJECT_V2_ITEM_SINGLE_SELECT = `
 export const GET_PULL_REQUEST_ID = `
   query GetPullRequestId(
     $activationIssueNumber: Int!
+    $homeOwner: String!
+    $homeRepo: String!
     $owner: String!
     $repo: String!
     $prNumber: Int!
   ) {
-    repository(owner: $owner, name: $repo) {
+    homeRepository: repository(owner: $homeOwner, name: $homeRepo) {
       activationIssue: issue(number: $activationIssueNumber) {
         id
         closedByPullRequestsReferences(first: 100, includeClosedPrs: true) {
@@ -573,6 +624,8 @@ export const GET_PULL_REQUEST_ID = `
           }
         }
       }
+    }
+    targetRepository: repository(owner: $owner, name: $repo) {
       pullRequest(number: $prNumber) {
         body
         createdAt
@@ -620,6 +673,10 @@ export const GET_PULL_REQUEST_REVIEW = `
         body
         id
         state
+        pullRequest {
+          number
+          repository { nameWithOwner }
+        }
       }
     }
   }

--- a/ai/services/github-workflow/shared/repositoryTarget.mjs
+++ b/ai/services/github-workflow/shared/repositoryTarget.mjs
@@ -1,0 +1,90 @@
+/**
+ * Pre-Flight (structural fast-path): this module matches the pure, no-I/O policy helpers
+ * `discussionRoutingDisposition.mjs` and `conversationTrust.mjs` in this directory. It owns one
+ * github-workflow request-boundary contract and introduces no new directory role.
+ *
+ * @module ai/services/github-workflow/shared/repositoryTarget
+ * @summary Resolves one optional per-request GitHub repository without importing, mutating, or shadowing AiConfig.
+ *
+ * AiConfig remains the deployment-home SSOT. Each consumer reads its resolved home leaves inline at
+ * the use site and supplies them to this pure function; this module never imports or aliases config.
+ * Explicit targets are request data and never write back into the singleton. Keeping both branches
+ * here prevents 18 MCP operations from inventing subtly different bare-name or refusal semantics.
+ *
+ * @see learn/agentos/decisions/0019-aiconfig-reactive-provider-ssot.md
+ */
+
+export const REPOSITORY_TARGET_INVALID = 'REPOSITORY_TARGET_INVALID';
+
+const OWNER_PATTERN = /^[A-Za-z0-9](?:[A-Za-z0-9-]{0,37}[A-Za-z0-9])?$/,
+      REPO_PATTERN  = /^[A-Za-z0-9._-]{1,100}$/;
+
+/**
+ * @summary Builds the typed, no-I/O refusal returned for malformed explicit repository targets.
+ * @param {*} value Rejected caller value.
+ * @returns {{error: String, message: String, code: String, rejectedRepo: *}}
+ */
+function invalidRepositoryTarget(value) {
+    return {
+        error       : 'Invalid Repository Target',
+        message     : `[${REPOSITORY_TARGET_INVALID}] Invalid repository target ${JSON.stringify(value)}. Expected a GitHub repository name or exactly one 'owner/name' pair; empty values, invalid owner/repository characters, whitespace, backslashes, and additional slashes are refused.`,
+        code        : REPOSITORY_TARGET_INVALID,
+        rejectedRepo: value
+    }
+}
+
+/**
+ * @summary Resolves omitted, bare-name, and full owner/name repository targets.
+ *
+ * For an omitted value, returns the home leaves the caller read from AiConfig at its use site. A
+ * bare name uses that deployment home owner. A full `owner/name` pair is used exactly as supplied.
+ * Explicit values are never trimmed or normalized: accepting a corrected spelling after the caller
+ * supplied a different target could send a mutation somewhere the request did not name.
+ *
+ * @param {*} value Optional MCP `repo` input.
+ * @param {Object} home Resolved deployment-home repository read by the consumer at the use site.
+ * @param {String} home.owner Deployment-home GitHub owner.
+ * @param {String} home.repo Deployment-home GitHub repository name.
+ * @returns {{owner: String, repo: String, fullName: String, explicit: Boolean}|{error: String, message: String, code: String, rejectedRepo: *}}
+ */
+export function resolveRepositoryTarget(value, {owner: homeOwner, repo: homeRepo}) {
+    if (value === undefined) {
+        return {
+            owner   : homeOwner,
+            repo    : homeRepo,
+            fullName: `${homeOwner}/${homeRepo}`,
+            explicit: false
+        }
+    }
+
+    if (typeof value !== 'string' || value.length === 0 || value !== value.trim()) {
+        return invalidRepositoryTarget(value)
+    }
+
+    const segments = value.split('/');
+
+    const explicitOwner = segments.length === 2 ? segments[0] : null,
+          explicitRepo  = segments.length === 2 ? segments[1] : segments[0];
+
+    if (
+        segments.length > 2 ||
+        (explicitOwner !== null && !OWNER_PATTERN.test(explicitOwner)) ||
+        !REPO_PATTERN.test(explicitRepo) ||
+        explicitRepo === '.' ||
+        explicitRepo === '..'
+    ) {
+        return invalidRepositoryTarget(value)
+    }
+
+    const owner = explicitOwner || homeOwner,
+          repo  = explicitRepo;
+
+    return {
+        owner,
+        repo,
+        fullName: `${owner}/${repo}`,
+        explicit: true
+    }
+}
+
+export default resolveRepositoryTarget;

--- a/test/playwright/unit/ai/services/github-workflow/DiscussionService.spec.mjs
+++ b/test/playwright/unit/ai/services/github-workflow/DiscussionService.spec.mjs
@@ -110,8 +110,21 @@ test.describe('Neo.ai.services.github-workflow.DiscussionService — manageDiscu
             const COMMENT_URL = 'https://github.com/neomjs/neo/discussions/10841#discussioncomment-4309098042';
             const UPDATED_TS  = '2026-05-07T02:15:33Z';
 
+            let callCount = 0;
+
             GraphqlService.query = async (query, variables) => {
+                callCount++;
                 expect(variables.commentId).toBe(COMMENT_ID);
+
+                if (callCount === 1) {
+                    return {
+                        node: {
+                            id        : COMMENT_ID,
+                            discussion: {number: 10841, repository: {nameWithOwner: 'neomjs/neo'}}
+                        }
+                    }
+                }
+
                 return {
                     updateDiscussionComment: {
                         comment: {
@@ -135,6 +148,37 @@ test.describe('Neo.ai.services.github-workflow.DiscussionService — manageDiscu
                 url      : COMMENT_URL,
                 updatedAt: UPDATED_TS
             });
+            expect(callCount).toBe(2);
+        });
+
+        test('an explicit wrong repository refuses before the update mutation', async () => {
+            const COMMENT_ID = 'DC_kwDOABcD_other_repo';
+            let   callCount  = 0;
+
+            GraphqlService.query = async () => {
+                callCount++;
+                return {
+                    node: {
+                        id        : COMMENT_ID,
+                        discussion: {number: 10841, repository: {nameWithOwner: 'neomjs/neo'}}
+                    }
+                }
+            };
+
+            const result = await DiscussionService.manageDiscussionComment({
+                repo             : 'devindex',
+                discussion_number: 10841,
+                comment_id       : COMMENT_ID,
+                body             : 'Must not cross repositories',
+                action           : 'update'
+            });
+
+            expect(result).toMatchObject({
+                code        : 'REPOSITORY_TARGET_MISMATCH',
+                actualRepo  : 'neomjs/neo',
+                selectedRepo: 'neomjs/devindex'
+            });
+            expect(callCount).toBe(1);
         });
 
         test('rejects missing comment_id on update', async () => {

--- a/test/playwright/unit/ai/services/github-workflow/IssueService.spec.mjs
+++ b/test/playwright/unit/ai/services/github-workflow/IssueService.spec.mjs
@@ -521,8 +521,22 @@ test.describe('Neo.ai.services.github-workflow.IssueService — manageIssueComme
             const COMMENT_URL = 'https://github.com/neomjs/neo/issues/10272#issuecomment-4309098042';
             const UPDATED_TS  = '2026-04-24T02:15:33Z';
 
+            let callCount = 0;
+
             GraphqlService.query = async (query, variables) => {
+                callCount++;
                 expect(variables.commentId).toBe(COMMENT_ID);
+
+                if (callCount === 1) {
+                    return {
+                        node: {
+                            id         : COMMENT_ID,
+                            issue      : {number: 10272, repository: {nameWithOwner: 'neomjs/neo'}},
+                            pullRequest: null
+                        }
+                    }
+                }
+
                 return {
                     updateIssueComment: {
                         issueComment: {
@@ -546,6 +560,38 @@ test.describe('Neo.ai.services.github-workflow.IssueService — manageIssueComme
                 url      : COMMENT_URL,
                 updatedAt: UPDATED_TS
             });
+            expect(callCount).toBe(2);
+        });
+
+        test('an explicit wrong repository refuses before the update mutation', async () => {
+            const COMMENT_ID = 'IC_kwDOABcD_other_repo';
+            let   callCount  = 0;
+
+            GraphqlService.query = async () => {
+                callCount++;
+                return {
+                    node: {
+                        id         : COMMENT_ID,
+                        issue      : {number: 10272, repository: {nameWithOwner: 'neomjs/neo'}},
+                        pullRequest: null
+                    }
+                }
+            };
+
+            const result = await IssueService.manageIssueComment({
+                repo        : 'devindex',
+                issue_number: 10272,
+                comment_id  : COMMENT_ID,
+                body        : 'Must not cross repositories',
+                action      : 'update'
+            });
+
+            expect(result).toMatchObject({
+                code        : 'REPOSITORY_TARGET_MISMATCH',
+                actualRepo  : 'neomjs/neo',
+                selectedRepo: 'neomjs/devindex'
+            });
+            expect(callCount).toBe(1);
         });
 
         test('rejects missing comment_id on update', async () => {

--- a/test/playwright/unit/ai/services/github-workflow/PullRequestService.spec.mjs
+++ b/test/playwright/unit/ai/services/github-workflow/PullRequestService.spec.mjs
@@ -2610,6 +2610,54 @@ test.describe('Neo.ai.services.github-workflow.PullRequestService — managePrRe
         expect(graphqlCallCount).toBe(0);
     });
 
+    test('#17420: same PR number in home/non-default repos reads separate target histories while activation stays home-owned', async () => {
+        const observations = [];
+
+        GraphqlService.query = async (queryString, variables) => {
+            if (queryString.includes('GetPullRequestId')) {
+                observations.push(variables);
+                return {
+                    homeRepository  : {activationIssue: activationIssueNode()},
+                    targetRepository: {pullRequest: pullRequestNode()}
+                }
+            }
+
+            if (queryString.includes('AddPullRequestReview')) {
+                return {addPullRequestReview: {pullRequestReview: REVIEW_NODE}}
+            }
+
+            return null
+        };
+
+        for (const repo of [undefined, 'devindex']) {
+            const result = await PullRequestService.managePrReview({
+                ...(repo ? {repo} : {}),
+                action   : 'create',
+                pr_number: 73,
+                state    : 'APPROVED',
+                body     : VALID_REVIEW_BODY
+            });
+
+            expect(result.error, repo || 'home').toBeUndefined();
+        }
+
+        expect(observations).toEqual([{
+            activationIssueNumber: PullRequestService.reviewBudgetActivationIssueNumber,
+            homeOwner            : 'neomjs',
+            homeRepo             : 'neo',
+            owner                : 'neomjs',
+            repo                 : 'neo',
+            prNumber             : 73
+        }, {
+            activationIssueNumber: PullRequestService.reviewBudgetActivationIssueNumber,
+            homeOwner            : 'neomjs',
+            homeRepo             : 'neo',
+            owner                : 'neomjs',
+            repo                 : 'devindex',
+            prNumber             : 73
+        }]);
+    });
+
     test('action:create + state:APPROVED → submits APPROVE event, returns review payload', async () => {
         const result = await PullRequestService.managePrReview({
             action   : 'create',

--- a/test/playwright/unit/ai/services/github-workflow/PullRequestServiceReviewers.spec.mjs
+++ b/test/playwright/unit/ai/services/github-workflow/PullRequestServiceReviewers.spec.mjs
@@ -62,6 +62,18 @@ test.describe('PullRequestService.managePrReviewers — REST requested_reviewers
         expect(res.message).toContain('requested');
     });
 
+    test('#17420: an explicit target qualifies the requested_reviewers REST path', async () => {
+        let captured;
+
+        await PullRequestService.managePrReviewers(
+            {repo: 'devindex', pr_number: 3, reviewers: ['neo-gpt'], action: 'add'},
+            {execFn: async command => { captured = command; return reviewerResponse(['neo-gpt']) }}
+        );
+
+        expect(captured).toContain('gh api repos/neomjs/devindex/pulls/3/requested_reviewers');
+        expect(captured).not.toContain('repos/neomjs/neo/pulls/3');
+    });
+
     test('remove → REST DELETE; team slugs are bare (no owner prefix)', async () => {
         let captured;
         await PullRequestService.managePrReviewers(

--- a/test/playwright/unit/ai/services/github-workflow/RepositoryTarget.spec.mjs
+++ b/test/playwright/unit/ai/services/github-workflow/RepositoryTarget.spec.mjs
@@ -1,0 +1,72 @@
+import {test, expect} from '@playwright/test';
+import {
+    REPOSITORY_TARGET_INVALID,
+    resolveRepositoryTarget
+} from '../../../../../../ai/services/github-workflow/shared/repositoryTarget.mjs';
+
+const HOME = Object.freeze({owner: 'neomjs', repo: 'neo'});
+
+test.describe('github-workflow repositoryTarget (#17420)', () => {
+    test('resolves omitted, bare, and full targets without changing the home default', () => {
+        expect(resolveRepositoryTarget(undefined, HOME)).toEqual({
+            owner   : 'neomjs',
+            repo    : 'neo',
+            fullName: 'neomjs/neo',
+            explicit: false
+        });
+
+        expect(resolveRepositoryTarget('devindex', HOME)).toEqual({
+            owner   : 'neomjs',
+            repo    : 'devindex',
+            fullName: 'neomjs/devindex',
+            explicit: true
+        });
+
+        expect(resolveRepositoryTarget('octocat/hello-world', HOME)).toEqual({
+            owner   : 'octocat',
+            repo    : 'hello-world',
+            fullName: 'octocat/hello-world',
+            explicit: true
+        });
+
+        expect(resolveRepositoryTarget('.github', HOME).fullName).toBe('neomjs/.github');
+
+        // Sequential explicit targets are request data, never writes to the home SSOT input.
+        expect(resolveRepositoryTarget(undefined, HOME).fullName).toBe('neomjs/neo');
+        expect(HOME).toEqual({owner: 'neomjs', repo: 'neo'});
+    });
+
+    test('rejects malformed explicit targets by value rather than normalizing them to home', () => {
+        for (const value of [
+            '',
+            null,
+            ' owner/repo',
+            'owner/repo ',
+            'owner/re po',
+            'owner\\repo',
+            'owner_name/repo',
+            'owner-/repo',
+            'owner?/repo',
+            'owner/repo#fragment',
+            '/repo',
+            'owner/',
+            'owner//repo',
+            'owner/repo/extra',
+            '.',
+            '..',
+            'owner/..',
+            'a'.repeat(101)
+        ]) {
+            const result = resolveRepositoryTarget(value, HOME);
+
+            expect(result).toMatchObject({
+                error       : 'Invalid Repository Target',
+                code        : REPOSITORY_TARGET_INVALID,
+                rejectedRepo: value
+            });
+            expect(result.message).toContain(JSON.stringify(value));
+            expect(result).not.toHaveProperty('owner');
+            expect(result).not.toHaveProperty('repo');
+        }
+    });
+});

--- a/test/playwright/unit/ai/services/github-workflow/RepositoryTargetRouting.spec.mjs
+++ b/test/playwright/unit/ai/services/github-workflow/RepositoryTargetRouting.spec.mjs
@@ -1,0 +1,294 @@
+import {setup} from '../../../../setup.mjs';
+
+setup({
+    neoConfig: {unitTestMode: true},
+    appConfig: {
+        name             : 'RepositoryTargetRoutingTest',
+        isMounted        : () => true,
+        vnodeInitialising: false
+    }
+});
+
+import {test, expect} from '@playwright/test';
+import Neo            from '../../../../../../src/Neo.mjs';
+import * as core      from '../../../../../../src/core/_export.mjs';
+
+test.describe('github-workflow 18-operation repository-target boundary (#17420)', () => {
+    let DiscussionService,
+        GraphqlService,
+        IssueService,
+        LabelService,
+        PullRequestService,
+        RepositoryService,
+        originalQuery,
+        originalRest,
+        originalGetViewerPermission;
+
+    test.beforeAll(async () => {
+        ({default: DiscussionService}  = await import('../../../../../../ai/services/github-workflow/DiscussionService.mjs'));
+        ({default: GraphqlService}     = await import('../../../../../../ai/services/github-workflow/GraphqlService.mjs'));
+        ({default: IssueService}       = await import('../../../../../../ai/services/github-workflow/IssueService.mjs'));
+        ({default: LabelService}       = await import('../../../../../../ai/services/github-workflow/LabelService.mjs'));
+        ({default: PullRequestService} = await import('../../../../../../ai/services/github-workflow/PullRequestService.mjs'));
+        ({default: RepositoryService}  = await import('../../../../../../ai/services/github-workflow/RepositoryService.mjs'));
+
+        originalQuery = GraphqlService.query.bind(GraphqlService);
+        originalRest  = GraphqlService.rest .bind(GraphqlService);
+        originalGetViewerPermission = RepositoryService.getViewerPermission.bind(RepositoryService);
+    });
+
+    test.afterEach(() => {
+        GraphqlService.query = originalQuery;
+        GraphqlService.rest  = originalRest;
+        RepositoryService.getViewerPermission = originalGetViewerPermission;
+    });
+
+    test('every remote operation rejects an empty target before GitHub I/O', async () => {
+        let githubCalls = 0,
+            execCalls   = 0;
+
+        GraphqlService.query = async () => { githubCalls++; throw new Error('unexpected GraphQL I/O') };
+        GraphqlService.rest  = async () => { githubCalls++; throw new Error('unexpected REST I/O') };
+
+        const invalid    = {repo: ''};
+        const operations = [
+            ['list_labels',                 () => LabelService.listLabels(invalid)],
+            ['list_pull_requests',          () => PullRequestService.listPullRequests(invalid)],
+            ['get_pull_request_diff',       () => PullRequestService.getPullRequestDiff({...invalid, pr_number: 1})],
+            ['get_conversation',            () => PullRequestService.getConversation({...invalid, pr_number: 1})],
+            ['manage_issue_comment',        () => IssueService.manageIssueComment({...invalid, issue_number: 1, body: 'x', action: 'create'})],
+            ['manage_issue_labels',         () => IssueService.manageIssueLabels({...invalid, issue_number: 1, labels: ['bug'], action: 'add'})],
+            ['manage_issue_assignees',      () => IssueService.manageIssueAssignees({...invalid, issue_number: 1, assignees: ['neo-gpt'], action: 'add'})],
+            ['manage_pr_review',            () => PullRequestService.managePrReview({...invalid, action: 'create', pr_number: 1, state: 'COMMENT', body: 'x'})],
+            ['manage_pr_reviewers',          () => PullRequestService.managePrReviewers({...invalid, pr_number: 1, reviewers: ['neo-gpt'], action: 'add'}, {execFn: async () => { execCalls++ }})],
+            ['list_issues',                 () => IssueService.listIssues(invalid)],
+            ['create_issue',                () => IssueService.createIssue({...invalid, title: 'x'})],
+            ['manage_issue_projects',       () => IssueService.manageIssueProjects({...invalid, issue_number: 1, action: 'add', projectNumbers: [1]})],
+            ['create_discussion',           () => DiscussionService.createDiscussion({...invalid, title: 'x', body: 'x'})],
+            ['manage_discussion',           () => DiscussionService.manageDiscussion({...invalid, action: 'update_body', discussion_number: 1, body: 'x'})],
+            ['get_discussion_conversation', () => DiscussionService.getConversation({...invalid, discussion_number: 1})],
+            ['manage_discussion_comment',   () => DiscussionService.manageDiscussionComment({...invalid, action: 'create', discussion_number: 1, body: 'x'})],
+            ['update_issue_relationship',   () => IssueService.updateIssueRelationship({...invalid, child_issue: 1})],
+            ['get_viewer_permission',       () => RepositoryService.getViewerPermission(invalid)]
+        ];
+
+        for (const [operation, invoke] of operations) {
+            const result = await invoke();
+
+            expect(result, operation).toMatchObject({
+                error       : 'Invalid Repository Target',
+                code        : 'REPOSITORY_TARGET_INVALID',
+                rejectedRepo: ''
+            });
+        }
+
+        expect(operations).toHaveLength(18);
+        expect(githubCalls).toBe(0);
+        expect(execCalls).toBe(0);
+    });
+
+    test('the assignee conflict guard reads and refuses inside the selected non-default repo', async () => {
+        let permissionTarget,
+            queryVariables,
+            restCalls = 0;
+
+        RepositoryService.getViewerPermission = async ({repo}) => {
+            permissionTarget = repo;
+            return {permission: 'WRITE'}
+        };
+        GraphqlService.query = async (query, variables) => {
+            queryVariables = variables;
+            return {
+                repository: {
+                    issue: {assignees: {nodes: [{login: 'neo-opus-ada'}]}}
+                }
+            }
+        };
+        GraphqlService.rest = async () => { restCalls++ };
+
+        const result = await IssueService.manageIssueAssignees({
+            repo             : 'devindex',
+            issue_number     : 2,
+            assignees        : ['neo-gpt'],
+            action           : 'add',
+            requireUnassigned: true
+        });
+
+        expect(permissionTarget).toBe('neomjs/devindex');
+        expect(queryVariables).toMatchObject({
+            owner : 'neomjs',
+            repo  : 'devindex',
+            number: 2
+        });
+        expect(result).toMatchObject({
+            code              : 'ASSIGNEE_CONFLICT',
+            currentAssignees  : ['neo-opus-ada'],
+            attemptedAssignees: ['neo-gpt']
+        });
+        expect(restCalls).toBe(0);
+    });
+
+    test('viewer permissions cache by owner/repo rather than sharing the home answer', async () => {
+        const priorPermission  = RepositoryService.viewerPermission,
+              priorPermissions = new Map(RepositoryService.viewerPermissions),
+              priorLogin       = RepositoryService.viewerLogin,
+              calls            = [];
+
+        try {
+            RepositoryService.viewerPermission = null;
+            RepositoryService.viewerPermissions.clear();
+            RepositoryService.viewerLogin = null;
+
+            GraphqlService.query = async (query, variables) => {
+                calls.push(`${variables.owner}/${variables.repo}`);
+                return {
+                    repository: {viewerPermission: variables.repo === 'devindex' ? 'WRITE' : 'READ'},
+                    viewer    : {login: 'neo-gpt'}
+                }
+            };
+
+            expect(await RepositoryService.getViewerPermission()).toEqual({permission: 'READ'});
+            expect(await RepositoryService.getViewerPermission({repo: 'devindex'})).toEqual({permission: 'WRITE'});
+            expect(await RepositoryService.getViewerPermission()).toEqual({permission: 'READ'});
+
+            expect(calls).toEqual(['neomjs/neo', 'neomjs/devindex']);
+            expect(RepositoryService.viewerPermissions.get('neomjs/neo')).toBe('READ');
+            expect(RepositoryService.viewerPermissions.get('neomjs/devindex')).toBe('WRITE');
+        } finally {
+            RepositoryService.viewerPermission = priorPermission;
+            RepositoryService.viewerPermissions.clear();
+            priorPermissions.forEach((value, key) => RepositoryService.viewerPermissions.set(key, value));
+            RepositoryService.viewerLogin = priorLogin;
+        }
+    });
+
+    test('relationship input cannot smuggle a second repository through an issue coordinate', async () => {
+        let githubCalls = 0;
+
+        GraphqlService.query = async () => { githubCalls++ };
+
+        const result = await IssueService.updateIssueRelationship({
+            repo        : 'neo',
+            child_issue : 'neomjs/devindex#2',
+            parent_issue: 17420
+        });
+
+        expect(result).toMatchObject({
+            error: 'Cross-Repository Relationship Unsupported',
+            code : 'CROSS_REPOSITORY_RELATIONSHIP_UNSUPPORTED'
+        });
+        expect(result.message).toContain('neomjs/neo');
+        expect(githubCalls).toBe(0);
+    });
+
+    test('ProjectV2 metadata and issue identity both use the selected repository owner', async () => {
+        const observations = [];
+
+        GraphqlService.query = async (query, variables) => {
+            observations.push(variables);
+
+            if (Object.hasOwn(variables, 'number') && Object.hasOwn(variables, 'repo')) {
+                return {repository: {issue: {id: 'I_target'}}}
+            }
+
+            if (Object.hasOwn(variables, 'number') && Object.hasOwn(variables, 'owner')) {
+                return {
+                    organization: {
+                        projectV2: {id: 'PVT_target', title: 'Target board', fields: {nodes: []}}
+                    }
+                }
+            }
+
+            return {addProjectV2ItemById: {item: {id: 'PVTI_target'}}}
+        };
+
+        const result = await IssueService.manageIssueProjects({
+            repo          : 'octocat/hello-world',
+            issue_number  : 7,
+            action        : 'add',
+            projectNumbers: [12]
+        });
+
+        expect(result.attachments).toEqual([{
+            projectNumber: 12,
+            projectId    : 'PVT_target',
+            itemId       : 'PVTI_target'
+        }]);
+        expect(observations[0]).toMatchObject({owner: 'octocat', repo: 'hello-world', number: 7});
+        expect(observations[1]).toMatchObject({owner: 'octocat', number: 12});
+        expect(observations.some(variables => variables.owner === 'neomjs')).toBe(false);
+    });
+
+    test('Discussion read, category lookup, body mutation, and comment creation stay on one selected repo', async () => {
+        const repositoryLookups = [];
+
+        GraphqlService.query = async (query, variables) => {
+            if (variables?.owner && variables?.repo) {
+                repositoryLookups.push(`${variables.owner}/${variables.repo}`)
+            }
+
+            if (query.includes('GetDiscussionConversation')) {
+                return {
+                    repository: {
+                        discussion: {id: 'D_3', number: 3, title: 'Target', body: '', comments: {nodes: []}}
+                    }
+                }
+            }
+
+            if (query.includes('GetCategories')) {
+                return {
+                    repository: {
+                        id                  : 'R_devindex',
+                        discussionCategories: {nodes: [{id: 'DC_ideas', name: 'Ideas'}]}
+                    }
+                }
+            }
+
+            if (query.includes('CreateDiscussion')) {
+                return {
+                    createDiscussion: {
+                        discussion: {id: 'D_new', number: 4, url: 'https://github.com/neomjs/devindex/discussions/4'}
+                    }
+                }
+            }
+
+            if (query.includes('GetDiscussionId')) {
+                return {repository: {discussion: {id: 'D_3'}}}
+            }
+
+            if (query.includes('UpdateDiscussion(')) {
+                return {
+                    updateDiscussion: {
+                        discussion: {id: 'D_3', url: 'https://github.com/neomjs/devindex/discussions/3', updatedAt: '2026-08-24T00:00:00Z'}
+                    }
+                }
+            }
+
+            if (query.includes('AddDiscussionComment')) {
+                return {
+                    addDiscussionComment: {
+                        comment: {id: 'DC_new', url: 'https://github.com/neomjs/devindex/discussions/3#discussioncomment-1', createdAt: '2026-08-24T00:00:00Z'}
+                    }
+                }
+            }
+
+            throw new Error('unexpected Discussion query')
+        };
+
+        const read      = await DiscussionService.getConversation({repo: 'devindex', discussion_number: 3});
+        const created   = await DiscussionService.createDiscussion({repo: 'devindex', title: 'Target', body: 'Body'});
+        const updated   = await DiscussionService.manageDiscussion({repo: 'devindex', action: 'update_body', discussion_number: 3, body: 'Updated'});
+        const commented = await DiscussionService.manageDiscussionComment({repo: 'devindex', action: 'create', discussion_number: 3, body: 'Comment'});
+
+        expect(read.id).toBe('D_3');
+        expect(created.discussionNumber).toBe(4);
+        expect(updated.discussionId).toBe('D_3');
+        expect(commented.commentId).toBe('DC_new');
+        expect(repositoryLookups).toEqual([
+            'neomjs/devindex',
+            'neomjs/devindex',
+            'neomjs/devindex',
+            'neomjs/devindex'
+        ]);
+    });
+});

--- a/test/playwright/unit/ai/services/github-workflow/RepositoryTargetRouting.spec.mjs
+++ b/test/playwright/unit/ai/services/github-workflow/RepositoryTargetRouting.spec.mjs
@@ -128,6 +128,71 @@ test.describe('github-workflow 18-operation repository-target boundary (#17420)'
         expect(restCalls).toBe(0);
     });
 
+    test('an acknowledged non-default reassignment keeps mutation, post-verify, and audit comment on target', async () => {
+        let assigneeReads = 0,
+            auditBody,
+            restPath;
+
+        RepositoryService.getViewerPermission = async ({repo}) => {
+            expect(repo).toBe('neomjs/devindex');
+            return {permission: 'WRITE'}
+        };
+        GraphqlService.query = async (query, variables) => {
+            if (query.includes('GetIssueAssignees')) {
+                assigneeReads++;
+                expect(variables).toMatchObject({owner: 'neomjs', repo: 'devindex', number: 2});
+                return {
+                    repository: {
+                        issue: {
+                            assignees: {
+                                nodes: assigneeReads === 1
+                                    ? [{login: 'neo-opus-grace'}]
+                                    : [{login: 'neo-gpt'}]
+                            }
+                        }
+                    }
+                }
+            }
+
+            if (query.includes('GetIssueId')) {
+                expect(variables).toMatchObject({owner: 'neomjs', repo: 'devindex', number: 2});
+                return {repository: {issue: {id: 'I_devindex_2'}}}
+            }
+
+            if (query.includes('AddComment')) {
+                expect(variables.subjectId).toBe('I_devindex_2');
+                auditBody = variables.body;
+                return {addComment: {commentEdge: {node: {id: 'IC_audit'}}}}
+            }
+
+            throw new Error('unexpected assignee-audit query')
+        };
+        GraphqlService.rest = async (method, path, payload) => {
+            expect(method).toBe('PATCH');
+            expect(payload).toEqual({assignees: ['neo-gpt']});
+            restPath = path;
+            return {}
+        };
+
+        const result = await IssueService.manageIssueAssignees({
+            repo                : 'devindex',
+            issue_number        : 2,
+            assignees           : ['neo-gpt'],
+            action              : 'add',
+            requireUnassigned   : true,
+            acknowledgedReassign: 'explicit handoff acceptance witness'
+        });
+
+        expect(restPath).toBe('/repos/neomjs/devindex/issues/2');
+        expect(assigneeReads).toBe(2);
+        expect(auditBody).toContain('explicit handoff acceptance witness');
+        expect(auditBody).toContain('neo-opus-grace');
+        expect(result).toMatchObject({
+            verifiedAssignees: ['neo-gpt'],
+            previousAssignees: ['neo-opus-grace']
+        });
+    });
+
     test('viewer permissions cache by owner/repo rather than sharing the home answer', async () => {
         const priorPermission  = RepositoryService.viewerPermission,
               priorPermissions = new Map(RepositoryService.viewerPermissions),

--- a/test/playwright/unit/ai/services/github-workflow/toolService.spec.mjs
+++ b/test/playwright/unit/ai/services/github-workflow/toolService.spec.mjs
@@ -18,6 +18,7 @@ setup({
 // Neo; the augmentation happens via these imports — mirrors the existing AI unit-test
 // pattern (e.g. IssueService.spec.mjs).
 import {test, expect}  from '@playwright/test';
+import {readFileSync}  from 'node:fs';
 import Neo             from '../../../../../../src/Neo.mjs';
 import * as core       from '../../../../../../src/core/_export.mjs';
 import InstanceManager from '../../../../../../src/manager/Instance.mjs';
@@ -191,18 +192,22 @@ test.describe('Neo.ai.services.github-workflow.toolService — getConversationRo
  */
 test.describe('Neo.ai.services.github-workflow.toolService — write identity guard (#13243)', () => {
     let GITHUB_TOOL_ACCESS;
+    let REPOSITORY_TARGET_TOOLS;
     let assertCompleteGitHubToolAccessPolicy;
     let buildGitHubWriteIdentityGuard;
     let guardGitHubWriteTools;
+    let guardRepositoryTargetTools;
     let isPublicGitHubWriteTool;
     let normalizeGitHubIdentityLogin;
 
     test.beforeAll(async () => {
         const mod = await import('../../../../../../ai/mcp/server/github-workflow/toolService.mjs');
         GITHUB_TOOL_ACCESS                    = mod.GITHUB_TOOL_ACCESS;
+        REPOSITORY_TARGET_TOOLS              = mod.REPOSITORY_TARGET_TOOLS;
         assertCompleteGitHubToolAccessPolicy = mod.assertCompleteGitHubToolAccessPolicy;
         buildGitHubWriteIdentityGuard         = mod.buildGitHubWriteIdentityGuard;
         guardGitHubWriteTools                 = mod.guardGitHubWriteTools;
+        guardRepositoryTargetTools            = mod.guardRepositoryTargetTools;
         isPublicGitHubWriteTool               = mod.isPublicGitHubWriteTool;
         normalizeGitHubIdentityLogin          = mod.normalizeGitHubIdentityLogin;
     });
@@ -362,6 +367,31 @@ test.describe('Neo.ai.services.github-workflow.toolService — write identity gu
         });
     });
 
+    test('#17420: malformed repo refusal runs before identity resolution and the service delegate', async () => {
+        let identityCalls = 0,
+            delegateCalls = 0;
+        const identityGuarded = guardGitHubWriteTools({
+            manage_issue_comment: async () => { delegateCalls++; return {ok: true} }
+        }, {
+            assertExpectedIdentity: async () => {
+                identityCalls++;
+                return {ok: true, reason: null, code: 'OK'}
+            }
+        });
+        const guarded = guardRepositoryTargetTools(identityGuarded).manage_issue_comment;
+
+        await expect(guarded({repo: '', issue_number: 1, action: 'create', body: 'x'})).resolves.toMatchObject({
+            code        : 'REPOSITORY_TARGET_INVALID',
+            rejectedRepo: ''
+        });
+        expect(identityCalls).toBe(0);
+        expect(delegateCalls).toBe(0);
+
+        await expect(guarded({repo: 'devindex', issue_number: 1, action: 'create', body: 'x'})).resolves.toEqual({ok: true});
+        expect(identityCalls).toBe(1);
+        expect(delegateCalls).toBe(1);
+    });
+
     test('rejects service mappings with unclassified future tools (#13252)', () => {
         expect(() => guardGitHubWriteTools({
             get_conversation      : async () => {},
@@ -379,6 +409,56 @@ test.describe('Neo.ai.services.github-workflow.toolService — write identity gu
         expect(assertCompleteGitHubToolAccessPolicy(
             Object.fromEntries(registeredTools.map(toolName => [toolName, async () => {}]))
         )).toBe(true);
+    });
+
+    test('#17420: exactly the 18 remote-forge operations advertise the shared repository target', async () => {
+        const {listTools} = await import('../../../../../../ai/mcp/server/github-workflow/toolService.mjs');
+        const tools       = new Map(listTools().tools.map(tool => [tool.name, tool]));
+        const targeted    = [
+            'list_labels',
+            'list_pull_requests',
+            'get_pull_request_diff',
+            'get_conversation',
+            'manage_issue_comment',
+            'manage_issue_labels',
+            'manage_issue_assignees',
+            'manage_pr_review',
+            'manage_pr_reviewers',
+            'list_issues',
+            'create_issue',
+            'manage_issue_projects',
+            'create_discussion',
+            'manage_discussion',
+            'get_discussion_conversation',
+            'manage_discussion_comment',
+            'update_issue_relationship',
+            'get_viewer_permission'
+        ];
+        const excluded = [
+            'checkout_pull_request',
+            'get_local_issue_by_id',
+            'validate_pr_review_body',
+            'signal_state_transition',
+            'healthcheck',
+            'get_mcp_tool_handbook'
+        ];
+
+        for (const toolName of targeted) {
+            expect(tools.get(toolName)?.inputSchema?.properties?.repo, toolName).toMatchObject({
+                type: 'string'
+            });
+        }
+
+        for (const toolName of excluded) {
+            expect(tools.get(toolName)?.inputSchema?.properties?.repo, toolName).toBeUndefined();
+        }
+
+        expect(targeted).toHaveLength(18);
+        expect([...REPOSITORY_TARGET_TOOLS].sort()).toEqual([...targeted].sort());
+        const openApiSource = readFileSync('ai/mcp/server/github-workflow/openapi.yaml', 'utf8'),
+              sharedRefs    = openApiSource.match(/\$ref: '#\/components\/schemas\/RepositoryTarget'/g) || [];
+
+        expect(sharedRefs).toHaveLength(18);
     });
 
     test('classifies the public GitHub write boundary explicitly', () => {


### PR DESCRIPTION
Resolves #17420

The GitHub Workflow MCP now targets any remote GitHub repository per request while preserving `neomjs/neo` as the AiConfig-owned home default. One shared `repo` contract covers the ticket's exact 18-operation family; malformed targets fail before even the write identity probe, and every permission, conflict, review-history, ProjectV2, Discussion, relationship, verification, and audit path stays bound to the selected `owner/name`.

Evidence: L3 (rebased ToolService live against `neomjs/devindex`: assignee-conflict + target-qualified comment update + PR query/diff reads) → L3 required (AC-4, AC-5, AC-7 non-default guard/receipt behavior). No residuals.

## AC Evidence

| AC-1 | CI-covered: `toolService.spec.mjs` proves exactly the 18 remote-forge tools advertise the one shared schema; existing service suites preserve omitted-target behavior. |
| AC-2 | CI-covered: `RepositoryTarget.spec.mjs` proves omitted → home, bare name → home owner, and full `owner/name` → exact target. |
| AC-3 | CI-covered: `RepositoryTargetRouting.spec.mjs` rejects malformed targets across all 18 operations with zero GraphQL/REST/exec calls; `toolService.spec.mjs` proves rejection runs before identity resolution and delegation. |
| AC-4 | Outside CI: live `repo: "devindex"` assignee guard + comment mutation on [devindex#2](https://github.com/neomjs/devindex/issues/2#issuecomment-5390313823); live devindex PR #3 files-only and SHA-pinned diff both returned the target file. |
| AC-5 | CI-covered + live: the live blind add returned `ASSIGNEE_CONFLICT` with Grace retained; the non-default audit-chain arm proves pre-read → PATCH → post-verify → target-qualified audit comment. |
| AC-6 | CI-covered: the same PR number in home/devindex produces distinct `{owner, repo, prNumber}` histories while the activation issue remains home-policy-owned; live split query resolved both repositories. |
| AC-7 | CI-covered + live: repository-qualified permission cache, assignee chain, global comment/review association guards, and ToolService comment update bind guard + receipt to one target. |
| AC-8 | CI-covered: same-repo relationship positive plumbing plus typed `CROSS_REPOSITORY_RELATIONSHIP_UNSUPPORTED` no-I/O control. |
| AC-9 | CI-covered: ProjectV2 issue identity and metadata both use the selected repository owner, with a red control proving no home-owner lookup. |
| AC-10 | CI-covered: Discussion read, category lookup, body mutation, and comment creation all stay on one selected non-default repository. |
| AC-11 | CI-covered: the omitted branch reads AiConfig at each service use site; two sequential explicit targets leave the home input unchanged. |
| AC-12 | CI-covered: ADR-0019 lint reports zero violations across every touched `ai/` module—no export, alias, config pass-along, env re-read, or runtime mutation. |

## Deltas from ticket

- Added an outer repository-target guard around the identity-guarded mapping. Without that ordering, malformed public-write input would call `gh api user` before the service rejected it, violating the ticket's no-GitHub-I/O refusal.
- Split PR review admission authority: activation issue is queried from the AiConfig home repository; PR body/reviews are queried from the selected repository. A non-default PR therefore cannot become accidentally “pre-activation.”
- Global IssueComment, DiscussionComment, and PullRequestReview node updates verify their repository association before mutation; an opaque node ID cannot bypass the selected target.
- SHA-pinned diffs for non-home repositories use GitHub's compare endpoint because the server's local Git object database only owns the home checkout.

## Test Evidence

- Live `neomjs/devindex#2`: guarded blind assignment refused before mutation; the existing acceptance comment was created through the selected service and updated through the full repository-validation → identity-guard → association-check → mutation ToolService chain.
- Live `neomjs/devindex#3`: split home-policy/target-PR GraphQL query resolved both nodes; files-only and SHA-pinned diff returned `.claude/launch.json` from the non-default repository.
- Live global-node association queries resolved the expected repository for an IssueComment, DiscussionComment, and PullRequestReview.

## Post-Merge Validation

No close-target residual. Operational follow-through on the next github-workflow redeploy: observe the fresh `tools/list` 18-operation census, repeat a native `repo: "devindex"` permission/read call, and confirm the healthcheck advertised-surface digest is current. The rebased in-process ToolService already exercised those contracts against live GitHub.

## Commits

- `e7b3c551fb` — add the shared target contract, service/tool propagation, OpenAPI surface, live-safe guards, and core evidence.
- `341da3e0c9` — prove the acknowledged non-default reassignment's mutation, post-verify, and audit chain.

Authored by Euclid (OpenAI GPT-5, Codex Desktop). Session 01a02ead-f0db-7b30-b4e2-54189808ab54.
