### PR TITLE
fix(orchestrator): expose probe sweep disagreement (#17501)

### DIFF
--- a/ai/daemons/orchestrator/services/DeploymentStateBridgeService.mjs
+++ b/ai/daemons/orchestrator/services/DeploymentStateBridgeService.mjs
@@ -2945,9 +2945,11 @@ export function deriveEmbeddingProbeSweepDisagreementInterval({probeCadenceMs, s
  * @summary Names a healthy-probe / repo-failure timestamp contradiction without changing the probe verdict.
  *
  * The probe is process-global while checkpoints are per repo, so this projection exposes only the
- * contradiction class—never the repository identity. A repo participates only while its last error
- * remains inside BOTH current authorities: the sweep's probe-demand cadence and that repo's own
- * zero-streak scheduling floor. Outside either window, a later healthy probe can be a genuine recovery.
+ * contradiction class—never the repository identity. A repo participates only while the absolute
+ * distance between its last error and the healthy check remains inside BOTH current authorities:
+ * the sweep's probe-demand cadence and that repo's own zero-streak scheduling floor. An earlier
+ * error outside either window permits a later healthy check to be a genuine recovery; a later error
+ * inside the window means the healthy evidence was already overtaken when this snapshot joined them.
  *
  * @param {Object} options
  * @param {Object} options.probeSnapshot Sanitized process-owned probe projection.

--- a/ai/daemons/orchestrator/services/DeploymentStateBridgeService.mjs
+++ b/ai/daemons/orchestrator/services/DeploymentStateBridgeService.mjs
@@ -2199,9 +2199,18 @@ export class DeploymentStateBridgeService extends Base {
             errors.push(summarizeDiagnosticError(error, 'tenant-repo-revision-state-read-failed'));
         }
 
-        const embeddingRecoveryProbe = summarizeEmbeddingRecoveryProbe(
+        const baseEmbeddingRecoveryProbe = summarizeEmbeddingRecoveryProbe(
             readEmbeddingRecoveryProbeSnapshot(this.tenantRepoSyncService)
         );
+        const embeddingRecoveryProbe = annotateEmbeddingProbeSweepDisagreement({
+            probeSnapshot  : baseEmbeddingRecoveryProbe,
+            probeCadenceMs : scheduler.sweepCadenceMs,
+            repos,
+            persistedRevisions,
+            globalCadenceMs: scheduler.globalCadenceMs,
+            jitterRatio    : scheduler.jitterRatio,
+            backoffCapMs   : scheduler.backoffCapMs
+        });
 
         const repoStates = repos.map(repo => summarizeTenantRepoState({
             repo,
@@ -2915,6 +2924,84 @@ function summarizeEmbeddingRecoveryProbe(candidate) {
             : null,
         probeSized: candidate?.probeSized === true
     };
+}
+
+/**
+ * @summary Derives the current probe/sweep disagreement window from the two existing scheduler
+ * authorities; no third threshold is introduced.
+ * @param {Object} options
+ * @param {Number} options.probeCadenceMs Fastest cadence at which the sweep can provide new probe evidence.
+ * @param {Number} options.sweepBackoffFloorMs Repo zero-streak cadence, including jitter and cap.
+ * @returns {Number|null} The narrower positive authority, or null when either answer is unavailable.
+ */
+export function deriveEmbeddingProbeSweepDisagreementInterval({probeCadenceMs, sweepBackoffFloorMs}) {
+    return Number.isFinite(probeCadenceMs) && probeCadenceMs > 0
+        && Number.isFinite(sweepBackoffFloorMs) && sweepBackoffFloorMs > 0
+        ? Math.min(probeCadenceMs, sweepBackoffFloorMs)
+        : null
+}
+
+/**
+ * @summary Names a healthy-probe / repo-failure timestamp contradiction without changing the probe verdict.
+ *
+ * The probe is process-global while checkpoints are per repo, so this projection exposes only the
+ * contradiction class—never the repository identity. A repo participates only while its last error
+ * remains inside BOTH current authorities: the sweep's probe-demand cadence and that repo's own
+ * zero-streak scheduling floor. Outside either window, a later healthy probe can be a genuine recovery.
+ *
+ * @param {Object} options
+ * @param {Object} options.probeSnapshot Sanitized process-owned probe projection.
+ * @param {Number} options.probeCadenceMs Tenant-repo sweep cadence.
+ * @param {Object[]} options.repos Effective repository configs.
+ * @param {Object} options.persistedRevisions Per-repo checkpoint map.
+ * @param {Number} options.globalCadenceMs Global repo cadence fallback.
+ * @param {Number} options.jitterRatio Deterministic repo jitter ratio.
+ * @param {Number} options.backoffCapMs Repo backoff cap.
+ * @returns {Object} Original probe or an error-classified copy; `status` is never changed.
+ */
+function annotateEmbeddingProbeSweepDisagreement({
+    probeSnapshot,
+    probeCadenceMs,
+    repos,
+    persistedRevisions,
+    globalCadenceMs,
+    jitterRatio,
+    backoffCapMs
+}) {
+    if (probeSnapshot?.status !== 'healthy' || !Number.isFinite(probeSnapshot.checkedAt)) {
+        return probeSnapshot
+    }
+
+    const disagreement = repos.some(repo => {
+        if (isTenantRepoDisabled(repo)) return false;
+
+        const checkpoint = normalizeTenantRepoCheckpointState(
+            persistedRevisions[createTenantRepoLabel(repo)] || null
+        );
+        const lastErrorAt = checkpoint?.lastErrorAt;
+
+        if (!Number.isFinite(lastErrorAt)) return false;
+
+        const floorState = isRepoDue({
+            repo,
+            persistedRepoState: {lastRunAttemptAt: 0, consecutiveFailures: 0},
+            now               : probeSnapshot.checkedAt,
+            globalCadenceMs,
+            jitterRatio,
+            backoffCapMs
+        });
+        const intervalMs = deriveEmbeddingProbeSweepDisagreementInterval({
+            probeCadenceMs,
+            sweepBackoffFloorMs: floorState.effectiveCadenceMs
+        });
+
+        return intervalMs !== null && Math.abs(probeSnapshot.checkedAt - lastErrorAt) <= intervalMs
+    });
+
+    return disagreement ? {
+        ...probeSnapshot,
+        errorClassification: 'probe-sweep-disagreement'
+    } : probeSnapshot
 }
 
 /**

--- a/test/playwright/unit/ai/daemons/orchestrator/services/DeploymentStateBridgeService.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/services/DeploymentStateBridgeService.spec.mjs
@@ -10,6 +10,7 @@ import AiConfig                    from '../../../../../../../ai/config.template
 import {
     classifyDirectProbeOutcome,
     DeploymentStateBridgeService,
+    deriveEmbeddingProbeSweepDisagreementInterval,
     summarizeProbeReliability
 } from '../../../../../../../ai/daemons/orchestrator/services/DeploymentStateBridgeService.mjs';
 import {ContainerHealthDiagnosisService} from '../../../../../../../ai/daemons/orchestrator/services/ContainerHealthDiagnosisService.mjs';
@@ -1578,6 +1579,97 @@ test.describe('Neo.ai.daemons.services.DeploymentStateBridgeService', () => {
         });
         expect(JSON.stringify(retryPendingSnapshot)).not.toContain(generationId);
         service.destroy();
+    });
+
+    test('healthy probe names a same-window repo failure without changing its verdict (#17501)', async () => {
+        const makeService = (lastErrorAt, cadenceMs = 120_000) => createService({
+            taskStateService: {
+                getTaskState() {
+                    return {running: false, lastCompletion: null}
+                }
+            },
+            tenantRepoSyncService: {
+                async resolveTenantReposConfig() {
+                    return {tenantRepos: [{
+                        tenantId  : 'tenant-observer',
+                        repoSlug  : 'private/observer',
+                        cloneUrl  : 'https://git.example/private/observer.git',
+                        cadenceMs,
+                        configTier: 'yaml'
+                    }]}
+                },
+                defaultRevisionsFilePath() {
+                    return '/state/revisions.json'
+                },
+                async readPersistedRevisions() {
+                    return {'tenant-observer/private/observer': {
+                        lastIngestedRev    : null,
+                        lastRunAttemptAt   : OBSERVED_AT - 2_000,
+                        consecutiveFailures: 1,
+                        lastErrorCode      : 'KB_TENANT_REPO_SYNC_SYNC_FAILED',
+                        lastErrorAt
+                    }}
+                },
+                getEmbeddingRecoveryProbeSnapshot() {
+                    return {
+                        status             : 'healthy',
+                        checkedAt          : OBSERVED_AT,
+                        lastDemandCached   : false,
+                        failureStreak      : 0,
+                        backoffMs          : 0,
+                        nextAttemptAt      : null,
+                        terminal           : false,
+                        stopReason         : null,
+                        errorClassification: null,
+                        errorCode          : null
+                    }
+                }
+            },
+            tenantRepoSyncEnabledReader: () => true
+        });
+
+        // Exact recorded red-proof: the two-second disagreement was previously projected as plain healthy.
+        const disagreementService  = makeService(OBSERVED_AT - 2_000),
+              disagreementSnapshot = await disagreementService.collectTenantRepoSyncSnapshot({observedAt: OBSERVED_AT});
+
+        expect(disagreementSnapshot.embeddingRecoveryProbe).toMatchObject({
+            status             : 'healthy',
+            failureStreak      : 0,
+            errorClassification: 'probe-sweep-disagreement'
+        });
+
+        // CONTROL: a genuine recovery outside the ZERO-STREAK floor stays plain healthy. With one
+        // persisted failure the current backoff is 40s+; using that wider value would wrongly flag
+        // this 30s-old error, while the actual 20s zero-streak floor does not.
+        const recoveryService  = makeService(OBSERVED_AT - 30_000, 20_000),
+              recoverySnapshot = await recoveryService.collectTenantRepoSyncSnapshot({observedAt: OBSERVED_AT});
+
+        expect(recoverySnapshot.embeddingRecoveryProbe).toMatchObject({
+            status             : 'healthy',
+            errorClassification: null
+        });
+
+        disagreementService.destroy();
+        recoveryService.destroy()
+    });
+
+    test('the disagreement interval changes with either existing authority and needs both (#17501)', () => {
+        expect(deriveEmbeddingProbeSweepDisagreementInterval({
+            probeCadenceMs     : 60_000,
+            sweepBackoffFloorMs: 120_000
+        })).toBe(60_000);
+        expect(deriveEmbeddingProbeSweepDisagreementInterval({
+            probeCadenceMs     : 30_000,
+            sweepBackoffFloorMs: 120_000
+        })).toBe(30_000);
+        expect(deriveEmbeddingProbeSweepDisagreementInterval({
+            probeCadenceMs     : 60_000,
+            sweepBackoffFloorMs: 20_000
+        })).toBe(20_000);
+        expect(deriveEmbeddingProbeSweepDisagreementInterval({
+            probeCadenceMs     : null,
+            sweepBackoffFloorMs: 20_000
+        })).toBeNull();
     });
 
     test('the outstanding-work count reaches the snapshot, and an unmeasured repo does not read as finished', async () => {

--- a/test/playwright/unit/ai/daemons/orchestrator/services/DeploymentStateBridgeService.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/services/DeploymentStateBridgeService.spec.mjs
@@ -1638,6 +1638,23 @@ test.describe('Neo.ai.daemons.services.DeploymentStateBridgeService', () => {
             errorClassification: 'probe-sweep-disagreement'
         });
 
+        // The predicate is symmetric: a repo failure moments AFTER the probe means its healthy
+        // evidence was overtaken before this joined snapshot could publish it unqualified.
+        const laterErrorService  = makeService(OBSERVED_AT + 2_000),
+              laterErrorSnapshot = await laterErrorService.collectTenantRepoSyncSnapshot({observedAt: OBSERVED_AT});
+
+        expect(laterErrorSnapshot.embeddingRecoveryProbe.errorClassification)
+            .toBe('probe-sweep-disagreement');
+
+        // The window is inclusive. Make the repo floor deliberately wider so the probe cadence is
+        // the exact minimum, then place the later error on that boundary.
+        const probeCadenceMs   = AiConfig.orchestrator.tenantRepoSync.sweepCadenceMs,
+              boundaryService  = makeService(OBSERVED_AT + probeCadenceMs, probeCadenceMs * 4),
+              boundarySnapshot = await boundaryService.collectTenantRepoSyncSnapshot({observedAt: OBSERVED_AT});
+
+        expect(boundarySnapshot.embeddingRecoveryProbe.errorClassification)
+            .toBe('probe-sweep-disagreement');
+
         // CONTROL: a genuine recovery outside the ZERO-STREAK floor stays plain healthy. With one
         // persisted failure the current backoff is 40s+; using that wider value would wrongly flag
         // this 30s-old error, while the actual 20s zero-streak floor does not.
@@ -1650,6 +1667,8 @@ test.describe('Neo.ai.daemons.services.DeploymentStateBridgeService', () => {
         });
 
         disagreementService.destroy();
+        laterErrorService.destroy();
+        boundaryService.destroy();
         recoveryService.destroy()
     });
 


### PR DESCRIPTION
Resolves neomjs/neo#17501

The deployment-state bridge now qualifies a process-global `healthy` embedding probe with `errorClassification: "probe-sweep-disagreement"` when a non-disabled repository checkpoint carries a failure in the same bounded window. The window is the narrower of the sweep/probe-demand cadence and that repository's zero-streak cadence computed by the existing scheduler primitive, so the projection adds no threshold, exposes no repository identity, and never rewrites the probe verdict.

Evidence: L2 (exact bridge execution through the production cadence primitive, including a mutation red) → L2 required (AC-1–AC-5 observer contract). No residuals.

Related: neomjs/neo-agent-brain#54

## AC Evidence

| AC-1 | CI-covered: the exact `healthy` at `08:30:22Z` / repo `lastErrorAt 08:30:20Z` specimen projects `probe-sweep-disagreement`. |
| AC-2 | CI-covered: a 30-second-old error stays unclassified against the repo's 20-second zero-streak floor; the persisted one-failure cadence would be wider and would falsely flag it. |
| AC-3 | CI-covered: the exported pure derivation changes when either cadence authority changes and returns `null` when either authority is absent. |
| AC-4 | Outside CI: deleting only the classification return made the exact specimen fail with received `errorClassification: null`; restoring it returned the focused run to 3/3 green. |
| AC-5 | CI-covered: the disagreement specimen retains `status: "healthy"` and `failureStreak: 0`; the annotator changes only `errorClassification`. |

## Deltas from ticket

- Selected `errorClassification` rather than `stopReason`, preserving the process-owned probe shape while naming the cross-producer contradiction.
- The sweep backoff floor is computed with `isRepoDue()` at `consecutiveFailures: 0`, including the existing repo override, deterministic jitter, and cap. Using the checkpoint's current failure streak would widen the window and misclassify a genuine recovery.
- This closes only the observer obligation. It does not mint recovery authorization or make the permanently refused recovery generation reachable; that outcome remains owned by neomjs/neo-agent-brain#54.

## Test Evidence

- Full exact-head bridge suite: 126/126 passed.
- Mutation red: suppressing only the new classification returned `null` for the exact two-second specimen and failed its assertion; restoring the classifier returned the focused run to 3/3 green.
- Independent read-only falsifier confirmed the concrete zero-streak/current-failure split (23,604 ms versus 47,208 ms), verdict preservation, and absence of raw repository identity.

## Post-Merge Validation

No close-target residual. A later production snapshot containing a same-window healthy probe and repository failure should expose `probe-sweep-disagreement` while retaining `status: "healthy"`; recovery authorization remains explicitly outside this PR.

Authored by Euclid (OpenAI GPT-5, Codex Desktop). Session 01a02ead-f0db-7b30-b4e2-54189808ab54.
