### PR TITLE
fix(memory-core): distinguish backup census observability (#17495)

### DIFF
--- a/ai/services/memory-core/HealthService.mjs
+++ b/ai/services/memory-core/HealthService.mjs
@@ -647,6 +647,9 @@ async function buildSubscriptionArmingBlock() {
  *   `lastSuccessful: null` with a non-zero `count` cannot be misread as "runs that never finished".
  * - `unverifiedCount` — completed bundles carrying **no** integrity block, so "eligible" is never
  *   silently reported as "verified".
+ * - `observationStatus` — `observed` when the root was read, `unavailable` when this plane has no
+ *   root, and `unreadable` when the root exists but the read failed. The latter two carry `null`
+ *   counts because no measurement occurred; only a readable empty root may report zero.
  *
  * A bundle with no integrity block stays **eligible**: absent evidence is not evidence of
  * emptiness, and disqualifying it would condemn any series predating the block — worse than the
@@ -658,14 +661,31 @@ async function buildSubscriptionArmingBlock() {
  * @param {String} backupPath The path to the root backup directory.
  * @param {Object} fs The fs-extra module (dependency injected for testing).
  * @param {Object} path The path module (dependency injected for testing).
- * @returns {Promise<{lastSuccessful: String|null, lastCompleted: String|null, count: Number, unusableCount: Number, error: String|undefined}>}
+ * @returns {Promise<{observationStatus: 'observed'|'unavailable'|'unreadable',
+ *     lastSuccessful: String|null, lastCompleted: String|null, count: Number|null,
+ *     unusableCount: Number|null, unverifiedCount: Number|null, error: String|undefined}>}
  */
 export async function buildBackupStateBlock(backupPath, fs, path) {
-    const empty = {lastSuccessful: null, lastCompleted: null, count: 0, unusableCount: 0, unverifiedCount: 0};
+    const
+        unavailable = {
+            observationStatus: 'unavailable',
+            lastSuccessful   : null,
+            lastCompleted    : null,
+            count            : null,
+            unusableCount    : null,
+            unverifiedCount  : null
+        },
+        observedEmpty = {
+            ...unavailable,
+            observationStatus: 'observed',
+            count            : 0,
+            unusableCount    : 0,
+            unverifiedCount  : 0
+        };
 
     try {
         if (!await fs.pathExists(backupPath)) {
-            return {...empty};
+            return {...unavailable};
         }
 
         const entries = await fs.readdir(backupPath, { withFileTypes: true });
@@ -675,7 +695,7 @@ export async function buildBackupStateBlock(backupPath, fs, path) {
             .map(e => e.name);
 
         if (backupDirs.length === 0) {
-            return {...empty};
+            return {...observedEmpty};
         }
 
         backupDirs.sort((a, b) => b.localeCompare(a));
@@ -733,6 +753,7 @@ export async function buildBackupStateBlock(backupPath, fs, path) {
         }
 
         return {
+            observationStatus: 'observed',
             lastSuccessful,
             lastCompleted,
             count        : backupDirs.length,
@@ -741,8 +762,9 @@ export async function buildBackupStateBlock(backupPath, fs, path) {
         };
     } catch (e) {
         return {
-            ...empty,
-            error: e.message
+            ...unavailable,
+            observationStatus: 'unreadable',
+            error            : e.message
         };
     }
 }

--- a/test/playwright/unit/ai/services/memory-core/HealthService.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/HealthService.spec.mjs
@@ -539,6 +539,19 @@ test.describe('HealthService #12382 — cached healthcheck freshness', () => {
         expect(health.database.connection[LOOPBACK_PROBE_HEALTH_KEY]).toBeUndefined();
     })
 
+    test('the public healthcheck carries backup observation polarity (#17495)', async () => {
+        const health = await HealthService.healthcheck();
+
+        expect(['observed', 'unavailable', 'unreadable'])
+            .toContain(health.backup.observationStatus);
+
+        if (health.backup.observationStatus === 'observed') {
+            expect(Number.isInteger(health.backup.count)).toBe(true)
+        } else {
+            expect(health.backup.count).toBeNull()
+        }
+    });
+
     test('a THROWING loopback diagnostic cannot escape the already-unhealthy healthcheck', async () => {
         // A diagnostic that can fail the boot it is diagnosing is worse than no diagnostic. The probe
         // degrades to `inconclusive` and the healthcheck still resolves with its real verdict.
@@ -2035,22 +2048,56 @@ test.describe('HealthService #10844 — buildBackupStateBlock', () => {
         buildBackupStateBlock = mod.buildBackupStateBlock;
     });
 
-    test('returns null if backupPath does not exist', async () => {
-        const mockFs = { pathExists: async () => false };
-        const result = await buildBackupStateBlock('/fake/path', mockFs, mockPath);
-        expect(result).toEqual({ lastSuccessful: null, lastCompleted: null, count: 0, unusableCount: 0, unverifiedCount: 0 });
-    });
-
-    test('returns null if no backup directories exist', async () => {
-        const mockFs = {
+    test('distinguishes an unavailable backup root from an observed-empty one (#17495)', async () => {
+        const unavailable = await buildBackupStateBlock('/fake/path', {
+            pathExists: async () => false
+        }, mockPath);
+        const observedEmpty = await buildBackupStateBlock('/fake/path', {
             pathExists: async () => true,
             readdir   : async () => [
-                { isDirectory: () => false, name: 'backup-2023' },
-                { isDirectory: () => true, name: 'other-dir' }
+                {isDirectory: () => false, name: 'backup-2023'},
+                {isDirectory: () => true,  name: 'other-dir'}
             ]
-        };
-        const result = await buildBackupStateBlock('/fake/path', mockFs, mockPath);
-        expect(result).toEqual({ lastSuccessful: null, lastCompleted: null, count: 0, unusableCount: 0, unverifiedCount: 0 });
+        }, mockPath);
+
+        expect(unavailable).toEqual({
+            observationStatus: 'unavailable',
+            lastSuccessful   : null,
+            lastCompleted    : null,
+            count            : null,
+            unusableCount    : null,
+            unverifiedCount  : null
+        });
+        expect(observedEmpty).toEqual({
+            observationStatus: 'observed',
+            lastSuccessful   : null,
+            lastCompleted    : null,
+            count            : 0,
+            unusableCount    : 0,
+            unverifiedCount  : 0
+        });
+        expect(unavailable).not.toEqual(observedEmpty)
+    });
+
+    test('an unreadable backup root carries null counts instead of measured-looking zeros (#17495)', async () => {
+        const result = await buildBackupStateBlock('/fake/path', {
+            pathExists: async () => true,
+            readdir   : async () => {
+                const error = new Error('fixture root read refused');
+                error.code  = 'EACCES';
+                throw error
+            }
+        }, mockPath);
+
+        expect(result).toEqual({
+            observationStatus: 'unreadable',
+            lastSuccessful   : null,
+            lastCompleted    : null,
+            count            : null,
+            unusableCount    : null,
+            unverifiedCount  : null,
+            error            : 'fixture root read refused'
+        })
     });
 
     test('returns timestamp of most recent backup with completedAt marker', async () => {
@@ -2077,7 +2124,7 @@ test.describe('HealthService #10844 — buildBackupStateBlock', () => {
         };
 
         const result = await buildBackupStateBlock('/fake/path', mockFs, mockPath);
-        expect(result).toEqual({ lastSuccessful: '2023-10-02T12:00:00Z', lastCompleted: '2023-10-02T12:00:00Z', count: 3, unusableCount: 0, unverifiedCount: 2 });
+        expect(result).toEqual({observationStatus: 'observed', lastSuccessful: '2023-10-02T12:00:00Z', lastCompleted: '2023-10-02T12:00:00Z', count: 3, unusableCount: 0, unverifiedCount: 2});
     });
 
     test('returns null if all backups lack completedAt marker', async () => {
@@ -2094,7 +2141,7 @@ test.describe('HealthService #10844 — buildBackupStateBlock', () => {
         };
 
         const result = await buildBackupStateBlock('/fake/path', mockFs, mockPath);
-        expect(result).toEqual({ lastSuccessful: null, lastCompleted: null, count: 1, unusableCount: 0, unverifiedCount: 0 });
+        expect(result).toEqual({observationStatus: 'observed', lastSuccessful: null, lastCompleted: null, count: 1, unusableCount: 0, unverifiedCount: 0});
     });
 });
 


### PR DESCRIPTION
Resolves #17495

The Memory Core backup census now distinguishes a readable empty root from a plane with no backup root and from a root whose read failed. `observationStatus` carries `observed` / `unavailable` / `unreadable`; only an observed census publishes integer counts, while both non-readings publish `null`. Existing completion/restorability timestamps and health verdict logic remain unchanged.

Evidence: L2 (pure census branches plus public `HealthService.healthcheck()` projection and mutation red) → L2 required (AC-1–AC-6 producer observability contract). No residuals.

Related: #17338

## AC Evidence

| AC-1 | CI-covered: one paired fixture proves absent → `unavailable` / `count: null` and readable empty → `observed` / `count: 0`, with unequal returned blocks. |
| AC-2 | CI-covered: a root whose `readdir` throws projects `unreadable`, distinct from both other states. |
| AC-3 | CI-covered: all three count fields are `null` on unavailable/unreadable and integers on observed; the empty-root control retains zero. |
| AC-4 | Outside CI: collapsing the absent branch back to observed-empty made the paired fixture fail on status and all three counts; restoration returned the focused run to 4/4 green. |
| AC-5 | CI-covered: a real `HealthService.healthcheck()` call asserts the top-level `backup` block carries the polarity and matching count type; no verdict fold was added. |
| AC-6 | CI-covered + source: the producer uses the existing `unreadable` vocabulary already owned by `stagingResidue`, with no fourth spelling. |

## Deltas from ticket

- The existing error message remains on the `unreadable` arm; the new status and null counts make it machine-readable without removing the diagnostic.
- Added a public-healthcheck producer witness in addition to the injected-filesystem helper tests, so correct helper output cannot pass while the top-level payload drops the field.

## Test Evidence

- Full exact-head `HealthService.spec.mjs`: 115/115 passed.
- Mutation red: changing only the absent-root return back to the observed-empty block failed the paired discriminator with received `observed`/zero versus expected `unavailable`/null; restoring it returned 4/4 green.
- Pre-fix live receipt: the current canonical MC healthcheck at `af8294420a` reported top-level `backup` counts as zero with no observation field on its unmounted plane, reproducing the ticket's false measurement.

## Post-Merge Validation

No close-target residual. After the next Memory Core redeploy, the canonical unmounted plane should expose `backup.observationStatus: "unavailable"` with null counts; this operational observation does not alter the independent `maintenance.backup` verdict.

Authored by Euclid (OpenAI GPT-5, Codex Desktop). Session 01a02ead-f0db-7b30-b4e2-54189808ab54.
