### PR TITLE
fix(agentos): make planned restart counts fail closed (#16984)

### DIFF
--- a/ai/daemons/orchestrator/services/DeploymentStateBridgeService.mjs
+++ b/ai/daemons/orchestrator/services/DeploymentStateBridgeService.mjs
@@ -87,9 +87,13 @@ import {
     describeBackupMaintenanceHealth,
     describeBackupRetryState
 } from '../scheduling/backup.mjs';
-import {resolveDurabilityPosture}    from './deploymentDurabilityPosture.mjs';
-import {summarizeStagingResidue}     from '../../../scripts/maintenance/backupStagingResidueCore.mjs';
-import {readRecentRecoveryRunStates} from '../../../services/memory-core/helpers/recoveryRunStateStore.mjs';
+import {resolveDurabilityPosture} from './deploymentDurabilityPosture.mjs';
+import {summarizeStagingResidue}  from '../../../scripts/maintenance/backupStagingResidueCore.mjs';
+import {
+    ACTIVE_RECOVERY_RUN_RETENTION_CLASS,
+    readRecentRecoveryRunStates,
+    readRecentRecoveryRunStatesWithCompleteness
+} from '../../../services/memory-core/helpers/recoveryRunStateStore.mjs';
 import {
     queryHealLedger,
     readHealLedger,
@@ -142,6 +146,55 @@ const KB_CONFIG_BOOTSTRAP_FAILURE_STATUSES = new Set([
     'parse-failed',
     'invalid-shape'
 ]);
+/**
+ * Restart-bearing recovery actions whose positive settlement moves Docker's restart count.
+ * @member {Set<String>} PLANNED_RESTART_ACTIONS
+ */
+const PLANNED_RESTART_ACTIONS = new Set(['reconfigure', 'restart']);
+
+/**
+ * @summary Identifies a terminal that claims an uncertain restart settled as applied.
+ * @param {Object} entry Recovery-run entry.
+ * @param {String} serviceKey Compose service whose count is being projected.
+ * @returns {Boolean}
+ */
+function isAppliedRestartSettlementCandidate(entry, serviceKey) {
+    const details = entry?.details;
+
+    return details?.reasonCode === 'restart-effect-observed-applied' &&
+        details?.effectDisposition === 'applied' &&
+        details?.serviceKey === serviceKey &&
+        PLANNED_RESTART_ACTIONS.has(details?.action) &&
+        entry?.targetIdentity?.kind === 'compose-service' &&
+        entry.targetIdentity.id === serviceKey;
+}
+
+/**
+ * @summary Verifies the same-container StartedAt movement behind an applied settlement claim.
+ * @param {Object} entry Recovery-run entry.
+ * @param {String} serviceKey Compose service whose count is being projected.
+ * @returns {Boolean}
+ */
+function hasPositiveRestartSettlementEvidence(entry, serviceKey) {
+    if (!isAppliedRestartSettlementCandidate(entry, serviceKey)) return false;
+    if (
+        entry.status !== 'actioned' ||
+        entry.reobserveRequest !== null ||
+        entry.details?.status !== 'actioned' ||
+        !Number.isFinite(entry.completedAt)
+    ) return false;
+
+    const baseline      = entry.details?.reobservation?.baseline,
+          observed      = entry.details?.reobservation?.observed,
+          baselineAt    = Date.parse(baseline?.startedAt || ''),
+          observedAt    = Date.parse(observed?.startedAt || ''),
+          sameContainer = typeof baseline?.containerId === 'string' &&
+              baseline.containerId.length > 0 &&
+              baseline.containerId === observed?.containerId;
+
+    return sameContainer && Number.isFinite(baselineAt) && Number.isFinite(observedAt) && observedAt > baselineAt;
+}
+
 const EMBEDDING_RECOVERY_PROBE_STATUSES = new Set([
     'never-started',
     'pending',
@@ -259,6 +312,10 @@ export class DeploymentStateBridgeService extends Base {
          */
         directProbeFn: null,
         /**
+         * Recovery-run reader seam. The tolerant snapshot path consumes an entries array; the
+         * planned-restart path additionally accepts `{entries, completeness}` and its production
+         * default uses that shape. Both paths normalize the injected shape explicitly so a test
+         * cannot make one consumer correct by giving the sibling an object it cannot read.
          * @member {Function|null} recoveryRunStateReader=null
          * @protected
          */
@@ -1686,8 +1743,8 @@ export class DeploymentStateBridgeService extends Base {
             // have destroyed the line-boundary guarantee `boundUtf8Head` exists for: a truncated head
             // ends at a newline precisely so a human reading forward never meets half a value.
             lines    : countLines(bounded.text),
-            text             : bounded.text,
-            truncated        : bounded.truncated
+            text     : bounded.text,
+            truncated: bounded.truncated
         };
 
         // Same gate as the empty arm, for the same reason: a head read at t+5s holds only what
@@ -1886,9 +1943,14 @@ export class DeploymentStateBridgeService extends Base {
      * - a supervised-task recycle restarts a PROCESS, so Docker's `RestartCount` never moves for it
      *   and it must not be subtracted. It carries no lifecycle proof, so this predicate excludes it
      *   without needing a second rule.
+     * - an uncertain restart can settle later through a positive `StartedAt` movement. That terminal
+     *   is source-owned applied-effect proof rather than a replayed Docker-response proof, and carries
+     *   the original dispatch coordinate so it belongs to the same bounded count window.
      *
-     * The proof also stamps `observedAt` at the moment the restart was dispatched and carries its own
-     * `serviceKey` — the honest window bound and owner for this count, rather than the diagnosis time.
+     * The terminal lifecycle proof carries the owner (`serviceKey`) but its `observedAt` is created
+     * after Docker answers. The separately persisted `restartDispatch.requestedAt` is the honest
+     * pre-POST window coordinate; using the response-bound stamp can put a restart below a baseline
+     * that was sampled while the request was still in flight.
      *
      * @param {Object} options
      * @param {String} options.serviceKey
@@ -1919,8 +1981,74 @@ export class DeploymentStateBridgeService extends Base {
         try {
             // Same injection seam `collectRecoveryRunSnapshot` uses, rather than a second direct
             // reader — one source of recovery-run truth, and testable.
-            const reader  = this.recoveryRunStateReader || readRecentRecoveryRunStates,
-                  entries = await reader({dir: AiConfig.orchestrator.recoveryActuator.recoveryRunStateDir, limit});
+            const reader     = this.recoveryRunStateReader || readRecentRecoveryRunStatesWithCompleteness,
+                  readResult = await reader({dir: AiConfig.orchestrator.recoveryActuator.recoveryRunStateDir, limit}),
+                  // Existing tests and third-party seams may still return the legacy entries array.
+                  // Production uses the completeness-bearing reader; treating a caller-injected
+                  // array as complete preserves the dependency seam without weakening source reads.
+                  entries       = Array.isArray(readResult) ? readResult : readResult?.entries,
+                  activeEntries = Array.isArray(readResult?.activeEntries)
+                      ? readResult.activeEntries
+                      : entries?.filter(entry =>
+                          entry?.details?.retentionClass === ACTIVE_RECOVERY_RUN_RETENTION_CLASS
+                      ),
+                  completeness  = Array.isArray(readResult)
+                      ? {status: 'complete'}
+                      : readResult?.completeness;
+
+            if (!Array.isArray(entries) || completeness?.status !== 'complete') {
+                return {count: Number.MAX_SAFE_INTEGER, reason: 'recovery-run-read-incomplete', status: 'degraded'};
+            }
+
+            const activeTargetRestarts = activeEntries.filter(entry =>
+                entry?.targetIdentity?.kind === 'compose-service' &&
+                entry.targetIdentity.id === serviceKey &&
+                entry?.details?.retentionClass === ACTIVE_RECOVERY_RUN_RETENTION_CLASS
+            );
+
+            if (activeTargetRestarts.some(entry =>
+                !Number.isFinite(entry?.details?.restartDispatch?.requestedAt) ||
+                entry.details.restartDispatch.requestedAt > observedAt
+            )) {
+                return {count: Number.MAX_SAFE_INTEGER, reason: 'recovery-run-window-unbound', status: 'degraded'};
+            }
+
+            const hasUnclassifiedActiveEffect = activeTargetRestarts.some(entry => {
+                const dispatchPending = entry.status === 'pending' &&
+                          entry.details?.reasonCode === 'restart-dispatch-pending',
+                      effectUncertain = entry.status === 'reobserve-requested' &&
+                          entry.details?.reasonCode === 'restart-effect-disposition-uncertain' &&
+                          entry.reobserveRequest?.reason === 'effect-disposition-uncertain';
+
+                return !PLANNED_RESTART_ACTIONS.has(entry?.details?.action) ||
+                    entry?.details?.effectDisposition !== 'uncertain' ||
+                    !(dispatchPending || effectUncertain);
+            });
+
+            if (hasUnclassifiedActiveEffect) {
+                return {count: Number.MAX_SAFE_INTEGER, reason: 'recovery-run-effect-unclassified', status: 'degraded'};
+            }
+
+            if (activeTargetRestarts.length > 0) {
+                return {count: Number.MAX_SAFE_INTEGER, reason: 'recovery-run-effect-uncertain', status: 'degraded'};
+            }
+
+            const appliedSettlementCandidates = entries
+                .filter(entry => isAppliedRestartSettlementCandidate(entry, serviceKey))
+                .filter(entry => {
+                    const requestedAt = entry?.details?.restartDispatch?.requestedAt,
+                          terminalAt  = [entry?.updatedAt, entry?.completedAt].find(Number.isFinite) ?? null;
+
+                    return Number.isFinite(requestedAt)
+                        ? requestedAt >= baseline.observedAt
+                        : !(Number.isFinite(terminalAt) && terminalAt < baseline.observedAt)
+                });
+
+            if (appliedSettlementCandidates.some(entry =>
+                !hasPositiveRestartSettlementEvidence(entry, serviceKey)
+            )) {
+                return {count: Number.MAX_SAFE_INTEGER, reason: 'recovery-run-effect-unclassified', status: 'degraded'};
+            }
 
             // Entries arrive newest-first, so the last one is the furthest back this read reached.
             const oldest   = entries[entries.length - 1],
@@ -1933,16 +2061,38 @@ export class DeploymentStateBridgeService extends Base {
                 return {count: Number.MAX_SAFE_INTEGER, reason: 'recovery-run-window-truncated', status: 'degraded'};
             }
 
-            const count = entries.filter(entry => {
-                const proof = entry?.details?.runtimeAccess;
+            const restartEntries = entries.filter(entry => {
+                const details           = entry?.details,
+                      proof             = details?.runtimeAccess,
+                      appliedSettlement = hasPositiveRestartSettlementEvidence(entry, serviceKey);
 
-                return proof?.capabilityEnvelope === 'lifecycle-write' &&
-                    proof.operation  === 'restart'   &&
-                    proof.serviceKey === serviceKey  &&
-                    Number.isFinite(proof.observedAt) &&
-                    proof.observedAt >= baseline.observedAt &&
-                    proof.observedAt <= observedAt
-            }).length;
+                return appliedSettlement || (
+                    proof?.capabilityEnvelope === 'lifecycle-write' &&
+                    proof.operation  === 'restart' &&
+                    proof.serviceKey === serviceKey
+                );
+            }),
+                windowCandidates = restartEntries
+                    .map(entry => ({
+                        entry,
+                        requestedAt: entry?.details?.restartDispatch?.requestedAt,
+                        responseAt : entry?.details?.runtimeAccess?.observedAt
+                    }))
+                    // A response observed before the baseline proves its dispatch happened before
+                    // the baseline too. Legacy rows with no dispatch stamp can therefore age out
+                    // honestly instead of degrading every future window until retention removes them.
+                    .filter(item => Number.isFinite(item.requestedAt)
+                        ? item.requestedAt >= baseline.observedAt
+                        : !(Number.isFinite(item.responseAt) && item.responseAt < baseline.observedAt)),
+                hasUnboundWindow = windowCandidates.some(item =>
+                    !Number.isFinite(item.requestedAt) || item.requestedAt > observedAt
+                );
+
+            if (hasUnboundWindow) {
+                return {count: Number.MAX_SAFE_INTEGER, reason: 'recovery-run-window-unbound', status: 'degraded'};
+            }
+
+            const count = windowCandidates.filter(item => item.requestedAt <= observedAt).length;
 
             return {count, reason: null, status: 'available'};
         } catch {
@@ -2025,11 +2175,16 @@ export class DeploymentStateBridgeService extends Base {
         }
 
         try {
-            const reader  = this.recoveryRunStateReader || readRecentRecoveryRunStates,
-                  entries = await reader({
-                dir: AiConfig.orchestrator.recoveryActuator.recoveryRunStateDir,
-                limit
-            });
+            const reader     = this.recoveryRunStateReader || readRecentRecoveryRunStates,
+                  readResult = await reader({
+                      dir: AiConfig.orchestrator.recoveryActuator.recoveryRunStateDir,
+                      limit
+                  }),
+                  entries      = Array.isArray(readResult) ? readResult : readResult?.entries;
+
+            if (!Array.isArray(entries)) {
+                throw new TypeError('Recovery-run reader must return an entries array or {entries, completeness}');
+            }
 
             return {status: 'available', source, limit, entries, errors: []};
         } catch (error) {
@@ -2080,10 +2235,10 @@ export class DeploymentStateBridgeService extends Base {
                   events = await reader({dir: this.healLedgerDir});
 
             return {
-                status      : 'available',
+                status : 'available',
                 source,
                 limit,
-                summary     : summarizeHealLedger(events),
+                summary: summarizeHealLedger(events),
                 // `summary.currentlyFrozen` is a bare target list; this carries each freeze's escalation,
                 // verdict evidence and thaw condition, so an operator can see WHY a target is frozen and
                 // what clears it without reading the ledger.

--- a/ai/daemons/orchestrator/services/RecoveryActuatorService.mjs
+++ b/ai/daemons/orchestrator/services/RecoveryActuatorService.mjs
@@ -462,6 +462,7 @@ export class RecoveryActuatorService extends Base {
                                 action,
                                 targetIdentity   : createRecoveryTargetIdentity({kind: target.kind, id: target.id}),
                                 effectDisposition: 'uncertain',
+                                restartDispatch  : {requestedAt},
                                 restartReobserve
                             }
                         });
@@ -598,6 +599,9 @@ export class RecoveryActuatorService extends Base {
                     ...(error?.restartObservationBaseline
                         ? {
                             restartObservationBaseline: error.restartObservationBaseline,
+                            restartDispatch           : {
+                                requestedAt: restartDispatchMarker?.reobserveRequest?.requestedAt ?? null
+                            },
                             restartReobserve          : {
                                 schemaVersion        : 1,
                                 diagnosisEvent       : diagnosis,
@@ -664,6 +668,13 @@ export class RecoveryActuatorService extends Base {
                 action,
                 targetIdentity: createRecoveryTargetIdentity({kind: target.kind, id: target.id}),
                 ...(heldAfterEffect ? {} : {authorityLostAfterEffect: true}),
+                ...(restartDispatchMarker
+                    ? {
+                        restartDispatch: {
+                            requestedAt: restartDispatchMarker.reobserveRequest.requestedAt
+                        }
+                    }
+                    : {}),
                 runtimeAccess    : result.runtimeAccess || null,
                 supervisor       : result.supervisor || null,
                 recorded         : result.recorded || null,
@@ -1329,9 +1340,20 @@ export class RecoveryActuatorService extends Base {
      * @returns {Promise<Object>} Reconciliation outcome.
      */
     async reconcileUncertainRestart({pending, serviceKey, action, target, now, isAuthorityHeld = null}) {
-        const context     = pending.details?.restartReobserve || {},
-              request     = pending.reobserveRequest,
-              baseOutcome = {
+        const context              = pending.details?.restartReobserve || {},
+              request              = pending.reobserveRequest,
+              persistedRequestedAt = pending.details?.restartDispatch?.requestedAt,
+              legacyMarkerRequestedAt =
+                  Number.isFinite(context.restartTimeoutSeconds) &&
+                  Number.isFinite(context.clientTimeoutMs)
+                      ? request?.requestedAt
+                      : null,
+              restartDispatch        = {
+                  requestedAt: Number.isFinite(persistedRequestedAt)
+                      ? persistedRequestedAt
+                      : Number.isFinite(legacyMarkerRequestedAt) ? legacyMarkerRequestedAt : null
+              },
+              baseOutcome            = {
                   status           : 'deferred',
                   serviceKey,
                   action,
@@ -1412,6 +1434,7 @@ export class RecoveryActuatorService extends Base {
                 action,
                 targetIdentity   : baseOutcome.targetIdentity,
                 effectDisposition: 'uncertain',
+                restartDispatch,
                 reobservation
             };
             taskStatus = 'skipped'
@@ -1442,6 +1465,7 @@ export class RecoveryActuatorService extends Base {
                 action,
                 targetIdentity   : baseOutcome.targetIdentity,
                 effectDisposition: 'applied',
+                restartDispatch,
                 reobservation
             };
             taskStatus = 'completed'

--- a/ai/services/memory-core/helpers/recoveryRunStateStore.mjs
+++ b/ai/services/memory-core/helpers/recoveryRunStateStore.mjs
@@ -630,6 +630,9 @@ export async function readRecentRecoveryRunStates({dir, limit} = {}) {
  * answer, because skipping one retained artifact can skip the exact lifecycle proof being counted.
  * This projection therefore scans every retained JSONL artifact, returns the same newest-entry
  * population, and separately states whether every artifact was fully decodable and schema-valid.
+ * An absent directory is a complete zero: the writer creates the directory before its first append,
+ * so `ENOENT` means no recovery run has ever been persisted. That differs from an artifact that
+ * disappears after enumeration, which is retained as incomplete evidence.
  *
  * @param {Object} options
  * @param {String} options.dir Directory for per-run state files.

--- a/ai/services/memory-core/helpers/recoveryRunStateStore.mjs
+++ b/ai/services/memory-core/helpers/recoveryRunStateStore.mjs
@@ -623,6 +623,87 @@ export async function readRecentRecoveryRunStates({dir, limit} = {}) {
 }
 
 /**
+ * @summary Reads recent recovery-run states together with retained-artifact completeness.
+ *
+ * The ordinary reader above is deliberately tolerant: a torn/corrupt diagnostic artifact cannot
+ * erase every other readable run. Consumers that publish an authoritative COUNT need a different
+ * answer, because skipping one retained artifact can skip the exact lifecycle proof being counted.
+ * This projection therefore scans every retained JSONL artifact, returns the same newest-entry
+ * population, and separately states whether every artifact was fully decodable and schema-valid.
+ *
+ * @param {Object} options
+ * @param {String} options.dir Directory for per-run state files.
+ * @param {Number} options.limit Maximum entries to return.
+ * @returns {Promise<Object>} `{entries, activeEntries, completeness}`; incomplete reads retain
+ * readable entries for diagnostics but MUST NOT certify an authoritative count. `activeEntries`
+ * is retention-exempt and therefore never limited by the ordinary recency cap.
+ */
+export async function readRecentRecoveryRunStatesWithCompleteness({dir, limit} = {}) {
+    const result = (entries, {
+        activeEntries           = [],
+        artifactCount           = 0,
+        incompleteArtifactCount = 0,
+        reasonCodes             = []
+    } = {}) => ({
+        entries,
+        activeEntries,
+        completeness: {
+            artifactCount,
+            incompleteArtifactCount,
+            reasonCodes: [...new Set(reasonCodes)].sort(),
+            status     : incompleteArtifactCount > 0 ? 'incomplete' : 'complete'
+        }
+    });
+
+    if (!dir || !Number.isFinite(limit) || limit <= 0) {
+        return result([], {
+            incompleteArtifactCount: 1,
+            reasonCodes            : ['read-request-invalid']
+        });
+    }
+
+    let names;
+    try {
+        names = await fs.readdir(dir);
+    } catch (error) {
+        if (error?.code === 'ENOENT') return result([]);
+        throw error;
+    }
+
+    const files = await Promise.all(names
+        .filter(name => name.endsWith('.jsonl'))
+        .map(async name => {
+            const filePath = path.join(dir, name),
+                  stat     = await fs.stat(filePath);
+
+            return {filePath, mtimeMs: stat.mtimeMs};
+        }));
+
+    const artifacts = [];
+
+    for (const file of files.sort((a, b) => b.mtimeMs - a.mtimeMs)) {
+        artifacts.push(await readRecoveryRunArtifactWithCompleteness(file.filePath));
+    }
+
+    const allEntries = artifacts
+        .map(artifact => artifact.entry)
+        .filter(Boolean)
+        .sort((a, b) => getEntrySortTime(b) - getEntrySortTime(a)),
+        entries = allEntries.slice(0, limit),
+        activeEntries = allEntries.filter(entry =>
+            entry?.details?.retentionClass === ACTIVE_RECOVERY_RUN_RETENTION_CLASS
+        ),
+        reasonCodes = artifacts.filter(artifact => artifact.reason).map(artifact => artifact.reason);
+
+    return result(entries, {
+        activeEntries,
+        artifactCount          : artifacts.length,
+        incompleteArtifactCount: reasonCodes.length,
+        reasonCodes
+    });
+}
+
+/**
  * @summary Reads every active recovery-run interlock independently of the ordinary recency window.
  *
  * Active effect interlocks are retention-exempt until a terminal row supersedes them in the same
@@ -691,6 +772,49 @@ async function readLatestValidRecoveryRunState(filePath) {
     }
 
     return null;
+}
+
+/**
+ * @summary Reads one complete JSONL artifact without hiding invalid rows behind a valid fallback.
+ * @param {String} filePath Recovery-run JSONL path.
+ * @returns {Promise<{entry: Object|null, reason: String|null}>} Latest valid entry plus completeness reason.
+ * @private
+ */
+async function readRecoveryRunArtifactWithCompleteness(filePath) {
+    let text;
+    try {
+        text = await fs.readFile(filePath, 'utf8');
+    } catch (error) {
+        if (error?.code === 'ENOENT') return {entry: null, reason: 'artifact-missing'};
+        throw error;
+    }
+
+    const lines = text.split('\n').map(line => line.trim()).filter(Boolean);
+
+    if (!lines.length) {
+        return {entry: null, reason: 'artifact-empty'};
+    }
+
+    let entry            = null,
+        invalidLineCount = 0;
+
+    for (const line of lines) {
+        try {
+            const candidate = JSON.parse(line);
+
+            validateRecoveryRunStateEntry(candidate, 'readRecentRecoveryRunStatesWithCompleteness');
+            entry = candidate;
+        } catch {
+            invalidLineCount++;
+        }
+    }
+
+    return {
+        entry,
+        reason: invalidLineCount > 0
+            ? entry ? 'artifact-partial' : 'artifact-undecodable'
+            : null
+    };
 }
 
 function getEntrySortTime(entry) {

--- a/test/playwright/unit/ai/daemons/orchestrator/services/DeploymentStateBridgeService.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/services/DeploymentStateBridgeService.spec.mjs
@@ -17,7 +17,8 @@ import {ContainerHealthDiagnosisService} from '../../../../../../../ai/daemons/o
 import {DeploymentRuntimeAccessService}  from '../../../../../../../ai/daemons/orchestrator/services/DeploymentRuntimeAccessService.mjs';
 import {
     createRecoveryDiagnosisEvent,
-    createRecoveryRunStateEntry
+    createRecoveryRunStateEntry,
+    readRecentRecoveryRunStatesWithCompleteness
 } from '../../../../../../../ai/services/memory-core/helpers/recoveryRunStateStore.mjs';
 import {
     TENANT_REPO_INGEST_CONTRACT_VERSION
@@ -2465,7 +2466,16 @@ test.describe('restart churn reaches the deployment record', () => {
         startedAt  : at,
         updatedAt  : at,
         completedAt: at,
-        details    : {runtimeAccess: proof}
+        details    : {
+            runtimeAccess: proof,
+            ...(proof.operation === 'restart'
+                ? {
+                    restartDispatch: {
+                        requestedAt: proof.observedAt
+                    }
+                }
+                : {})
+        }
     });
 
     test.beforeEach(() => {dir = fs.mkdtempSync(path.join(os.tmpdir(), 'churn-bridge-'))});
@@ -2562,8 +2572,11 @@ test.describe('restart churn reaches the deployment record', () => {
         const churnFact = atBoundary.diagnosis.diagnosis.evidenceFacts
             .find(fact => fact.type === 'restart-churn');
 
+        expect(churnFact.authoritative).toBe(false);
         expect(churnFact.details.unplannedRestarts).toBe(3);
         expect(churnFact.details.threshold).toBe(3);
+        expect(atBoundary.diagnosis.actionClass).toBe('record');
+        expect(atBoundary.diagnosis.diagnosis.evidenceFacts.at(-1).type).toBe('restart-churn');
     });
 
     /**
@@ -2637,6 +2650,210 @@ test.describe('restart churn reaches the deployment record', () => {
         expect(unreadable.restartChurn.plannedRestarts.status).toBe('degraded');
         expect(unreadable.restartChurn.plannedRestarts.reason).toBe('recovery-run-read-failed');
         expect(unreadable.restartChurn.detecting).toBe(false);
+    });
+
+    test('#16984: retained recovery-run damage degrades planned-restart completeness', async () => {
+        await bridgeFor('c1', 0).collectServiceSnapshot({serviceKey: 'orchestrator', observedAt: OBSERVED_AT});
+        fs.writeFileSync(path.join(dir, 'corrupt-recovery-run.jsonl'), '{"broken"\n');
+
+        const reader = ({limit}) => readRecentRecoveryRunStatesWithCompleteness({dir, limit}),
+              record = await bridgeFor('c1', 3, reader)
+                  .collectServiceSnapshot({serviceKey: 'orchestrator', observedAt: OBSERVED_AT + 60000});
+
+        expect(record.restartChurn.plannedRestarts).toEqual({
+            reason: 'recovery-run-read-incomplete',
+            status: 'degraded'
+        });
+        expect(record.restartChurn.detecting).toBe(false);
+    });
+
+    test('#16984: a complete empty recovery-run store remains an available zero', async () => {
+        await bridgeFor('c1', 0).collectServiceSnapshot({serviceKey: 'orchestrator', observedAt: OBSERVED_AT});
+
+        const reader = ({limit}) => readRecentRecoveryRunStatesWithCompleteness({dir, limit}),
+              record = await bridgeFor('c1', 1, reader)
+                  .collectServiceSnapshot({serviceKey: 'orchestrator', observedAt: OBSERVED_AT + 60000});
+
+        expect(record.restartChurn.plannedRestarts).toEqual({reason: null, status: 'available'});
+        expect(record.restartChurn.detecting).toBe(true);
+    });
+
+    test('#16984: an active uncertain restart outside the recency slice still degrades', async () => {
+        await bridgeFor('c1', 0).collectServiceSnapshot({serviceKey: 'orchestrator', observedAt: OBSERVED_AT});
+
+        const uncertain = runEntry(lifecycleProof('restart', 'orchestrator', OBSERVED_AT + 30000), OBSERVED_AT + 30000);
+
+        delete uncertain.details.runtimeAccess;
+        uncertain.reobserveRequest = {reason: 'effect-disposition-uncertain'};
+        Object.assign(uncertain.details, {
+            action           : 'restart',
+            effectDisposition: 'uncertain',
+            reasonCode       : 'restart-effect-disposition-uncertain',
+            retentionClass   : 'active-effect-interlock',
+            restartDispatch  : {requestedAt: OBSERVED_AT + 30000}
+        });
+
+        const reader = async () => ({
+                  entries      : [],
+                  activeEntries: [uncertain],
+                  completeness : {
+                      artifactCount          : 1,
+                      incompleteArtifactCount: 0,
+                      reasonCodes            : [],
+                      status                 : 'complete'
+                  }
+              }),
+              record = await bridgeFor('c1', 3, reader)
+                  .collectServiceSnapshot({serviceKey: 'orchestrator', observedAt: OBSERVED_AT + 60000});
+
+        expect(record.restartChurn.plannedRestarts).toEqual({
+            reason: 'recovery-run-effect-uncertain',
+            status: 'degraded'
+        });
+        expect(record.restartChurn.detecting).toBe(false);
+    });
+
+    test('#16984: an unclassified active restart interlock cannot certify zero', async () => {
+        await bridgeFor('c1', 0).collectServiceSnapshot({serviceKey: 'orchestrator', observedAt: OBSERVED_AT});
+
+        const unclassified = runEntry(
+            lifecycleProof('restart', 'orchestrator', OBSERVED_AT + 30000),
+            OBSERVED_AT + 30000
+        );
+
+        delete unclassified.details.runtimeAccess;
+        Object.assign(unclassified.details, {
+            retentionClass : 'active-effect-interlock',
+            restartDispatch: {requestedAt: OBSERVED_AT + 30000}
+        });
+
+        const record = await bridgeFor('c1', 3, async () => ({
+            entries      : [],
+            activeEntries: [unclassified],
+            completeness : {status: 'complete'}
+        })).collectServiceSnapshot({serviceKey: 'orchestrator', observedAt: OBSERVED_AT + 60000});
+
+        expect(record.restartChurn.plannedRestarts).toEqual({
+            reason: 'recovery-run-effect-unclassified',
+            status: 'degraded'
+        });
+        expect(record.restartChurn.detecting).toBe(false);
+    });
+
+    test('#16984: applied settlement labels without positive StartedAt evidence cannot count', async () => {
+        const at      = OBSERVED_AT + 30000,
+              applied = runEntry(lifecycleProof('restart', 'orchestrator', at), at);
+
+        delete applied.details.runtimeAccess;
+        applied.status           = 'actioned';
+        applied.reobserveRequest = null;
+        Object.assign(applied.details, {
+            action           : 'restart',
+            effectDisposition: 'applied',
+            reasonCode       : 'restart-effect-observed-applied',
+            restartDispatch  : {requestedAt: at},
+            serviceKey       : 'orchestrator',
+            status           : 'actioned'
+        });
+
+        for (const reobservation of [
+            null,
+            {
+                baseline: {containerId: 'c1', startedAt: '2026-08-24T00:00:00.000Z'},
+                observed: {containerId: 'c1', startedAt: '2026-08-24T00:00:00.000Z'}
+            }
+        ]) {
+            applied.details.reobservation = reobservation;
+
+            const result = await bridgeFor('c1', 1, async () => [applied]).collectPlannedRestarts({
+                serviceKey: 'orchestrator',
+                baseline  : {observedAt: OBSERVED_AT},
+                observedAt: OBSERVED_AT + 60000
+            });
+
+            expect(result).toEqual({
+                count : Number.MAX_SAFE_INTEGER,
+                reason: 'recovery-run-effect-unclassified',
+                status: 'degraded'
+            });
+        }
+
+        applied.details.reobservation = {
+            baseline: {containerId: 'c1', startedAt: '2026-08-24T00:00:00.000Z'},
+            observed: {containerId: 'c1', startedAt: '2026-08-24T00:01:00.000Z'}
+        };
+        applied.status           = 'reobserve-requested';
+        applied.reobserveRequest = {reason: 'effect-disposition-uncertain'};
+
+        const nonterminal = await bridgeFor('c1', 1, async () => [applied]).collectPlannedRestarts({
+            serviceKey: 'orchestrator',
+            baseline  : {observedAt: OBSERVED_AT},
+            observedAt: OBSERVED_AT + 60000
+        });
+
+        expect(nonterminal).toEqual({
+            count : Number.MAX_SAFE_INTEGER,
+            reason: 'recovery-run-effect-unclassified',
+            status: 'degraded'
+        });
+    });
+
+    test('#16984: a positive restart proof without its pre-dispatch coordinate degrades', async () => {
+        await bridgeFor('c1', 0).collectServiceSnapshot({serviceKey: 'orchestrator', observedAt: OBSERVED_AT});
+
+        const unbound = runEntry(lifecycleProof('restart', 'orchestrator', OBSERVED_AT + 30000), OBSERVED_AT + 30000);
+
+        delete unbound.details.restartDispatch;
+
+        const record = await bridgeFor('c1', 3, async () => [unbound])
+            .collectServiceSnapshot({serviceKey: 'orchestrator', observedAt: OBSERVED_AT + 60000});
+
+        expect(record.restartChurn.plannedRestarts).toEqual({
+            reason: 'recovery-run-window-unbound',
+            status: 'degraded'
+        });
+        expect(record.restartChurn.detecting).toBe(false);
+    });
+
+    test('#16984: a post-inspect dispatch degrades this sample and counts in the next window', async () => {
+        const dispatchAt  = OBSERVED_AT + 60001,
+              responseAt  = OBSERVED_AT + 60002,
+              interleaved = runEntry(lifecycleProof('restart', 'orchestrator', responseAt), responseAt);
+
+        interleaved.details.restartDispatch.requestedAt = dispatchAt;
+
+        const bridge        = bridgeFor('c1', 1, async () => [interleaved]),
+              currentSample = await bridge.collectPlannedRestarts({
+                  serviceKey: 'orchestrator',
+                  baseline  : {observedAt: OBSERVED_AT},
+                  observedAt: OBSERVED_AT + 60000
+              }),
+              nextSample = await bridge.collectPlannedRestarts({
+                  serviceKey: 'orchestrator',
+                  baseline  : {observedAt: OBSERVED_AT + 60000},
+                  observedAt: OBSERVED_AT + 120000
+              });
+
+        expect(currentSample).toEqual({
+            count : Number.MAX_SAFE_INTEGER,
+            reason: 'recovery-run-window-unbound',
+            status: 'degraded'
+        });
+        expect(nextSample).toEqual({count: 1, reason: null, status: 'available'});
+    });
+
+    test('#16984 CONTROL: an unbound legacy proof already before the baseline does not poison the window', async () => {
+        await bridgeFor('c1', 0).collectServiceSnapshot({serviceKey: 'orchestrator', observedAt: OBSERVED_AT});
+
+        const old = runEntry(lifecycleProof('restart', 'orchestrator', OBSERVED_AT - 60000), OBSERVED_AT - 60000);
+
+        delete old.details.restartDispatch;
+
+        const record = await bridgeFor('c1', 1, async () => [old])
+            .collectServiceSnapshot({serviceKey: 'orchestrator', observedAt: OBSERVED_AT + 60000});
+
+        expect(record.restartChurn.plannedRestarts).toEqual({reason: null, status: 'available'});
+        expect(record.restartChurn.detecting).toBe(true);
     });
 
     /**

--- a/test/playwright/unit/ai/daemons/orchestrator/services/RecoveryActuatorService.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/services/RecoveryActuatorService.spec.mjs
@@ -12,10 +12,13 @@ import {
     isRecoveryActuatorTargetBlocked,
     normalizeRecoveryActuatorTargets
 } from '../../../../../../../ai/daemons/orchestrator/services/RecoveryActuatorService.mjs';
+import {DeploymentStateBridgeService}   from '../../../../../../../ai/daemons/orchestrator/services/DeploymentStateBridgeService.mjs';
+import {DeploymentRuntimeAccessService} from '../../../../../../../ai/daemons/orchestrator/services/DeploymentRuntimeAccessService.mjs';
 import {
     createRecoveryDiagnosisEvent,
     createRecoveryRunStateEntry,
-    createRecoveryTargetIdentity
+    createRecoveryTargetIdentity,
+    readRecentRecoveryRunStatesWithCompleteness
 } from '../../../../../../../ai/services/memory-core/helpers/recoveryRunStateStore.mjs';
 import {RECOVERY_OVERRIDE_FILENAME} from '../../../../../../../ai/services/memory-core/helpers/recoveryOverrideStore.mjs';
 import {readHealLedger}             from '../../../../../../../ai/services/memory-core/helpers/healEventLedgerStore.mjs';
@@ -590,8 +593,8 @@ test.describe('Neo.ai.daemons.services.RecoveryActuatorService', () => {
                       }
                   }
               },
-              firstService = createService({deploymentRuntimeAccessService: runtime}).service,
-              first        = await firstService.apply('mc-server', 'restart', {
+              {service: firstService, actuatorConfig} = createService({deploymentRuntimeAccessService: runtime}),
+              first = await firstService.apply('mc-server', 'restart', {
                   now            : 15_000,
                   isAuthorityHeld: () => held
               });
@@ -609,6 +612,17 @@ test.describe('Neo.ai.daemons.services.RecoveryActuatorService', () => {
               settled   = await successor.apply('mc-server', 'restart', {
                   now            : first.reobserveRequest.earliestObservationAt,
                   isAuthorityHeld: () => held
+              }),
+              reader = ({limit}) => readRecentRecoveryRunStatesWithCompleteness({
+                  dir: actuatorConfig.recoveryRunStateDir,
+                  limit
+              }),
+              planned = await DeploymentStateBridgeService.prototype.collectPlannedRestarts.call({
+                  recoveryRunStateReader: reader
+              }, {
+                  serviceKey: 'mc-server',
+                  baseline  : {observedAt: first.restartDispatch.requestedAt - 1},
+                  observedAt: Date.now() + 1000
               });
 
         expect(settled).toMatchObject({
@@ -617,6 +631,8 @@ test.describe('Neo.ai.daemons.services.RecoveryActuatorService', () => {
             effectDisposition: 'applied',
             recoveryRunId    : first.recoveryRunId
         });
+        expect(settled.restartDispatch).toEqual(first.restartDispatch);
+        expect(planned).toEqual({count: 1, reason: null, status: 'available'});
         expect(lifecycleCalls, 'the successor inspected the inherited uncertainty instead of POSTing').toHaveLength(1);
         expect(readCalls).toEqual([{serviceKey: 'mc-server', operation: 'inspect'}]);
     });
@@ -1568,6 +1584,159 @@ test.describe('Neo.ai.daemons.services.RecoveryActuatorService', () => {
             expect(runtimeCalls).toHaveLength(1);
             expect(runtimeCalls[0]).toMatchObject({serviceKey: 'mc-server', operation: 'restart'});
             expect(typeof runtimeCalls[0].isAuthorityHeld).toBe('function');
+        });
+
+        test('#16984: actual restart and reconfigure survive actuator → store → planned-restart reader', async () => {
+            const gibibyte      = 1024 ** 3,
+                  dockerCalls   = [],
+                  runtimeAccess = Neo.create(DeploymentRuntimeAccessService, {
+                      runtimeAccessConfig: {
+                          ...DEFAULT_RUNTIME_ACCESS_CONFIG,
+                          enabled                     : true,
+                          mechanism                   : 'docker-socket',
+                          socketPath                  : '/var/run/docker.sock',
+                          composeProject              : 'neo',
+                          readOperations              : ['inspect'],
+                          lifecycleOperations         : ['restart', 'update-memory-limit'],
+                          timeoutMs                   : 5000,
+                          responseMaxBytes            : 1024,
+                          defaultRestartTimeoutSeconds: 0,
+                          auditMode                   : 'metadata'
+                      },
+                      dockerRequestFn: async ({method, path: requestPath}) => {
+                          dockerCalls.push({method, path: requestPath});
+
+                          if (method === 'GET' && requestPath.startsWith('/containers/json?')) {
+                              const query        = new URL(requestPath, 'http://docker.local'),
+                                    filters      = JSON.parse(query.searchParams.get('filters')),
+                                    serviceLabel = filters.label.find(label =>
+                                        label.startsWith('com.docker.compose.service=')
+                                    ),
+                                    serviceKey   = serviceLabel.slice('com.docker.compose.service='.length);
+
+                              if (serviceKey === 'local-model') {
+                                  throw new Error('Pre-dispatch target lookup refusal');
+                              }
+
+                              return {
+                                  statusCode: 200,
+                                  headers   : {},
+                                  body      : JSON.stringify([{
+                                      Id    : `container-${serviceKey}`,
+                                      Names : [`/neo-${serviceKey}-1`],
+                                      Image : 'neo:test',
+                                      State : 'running',
+                                      Status: 'Up',
+                                      Labels: {
+                                          'com.docker.compose.project': 'neo',
+                                          'com.docker.compose.service': serviceKey
+                                      }
+                                  }])
+                              };
+                          }
+
+                          if (method === 'GET' && requestPath.endsWith('/json')) {
+                              const containerId = decodeURIComponent(requestPath.split('/')[2]);
+
+                              return {
+                                  statusCode: 200,
+                                  headers   : {},
+                                  body      : JSON.stringify({
+                                      Id        : containerId,
+                                      HostConfig: {Memory: 2 * gibibyte},
+                                      State     : {StartedAt: '2026-08-24T00:00:00.000Z'}
+                                  })
+                              };
+                          }
+
+                          if (method === 'POST') {
+                              return {statusCode: 204, headers: {}, body: ''};
+                          }
+
+                          throw new Error(`Unexpected Docker request ${method} ${requestPath}`);
+                      },
+                      nowFn   : () => Date.now(),
+                      writeLog: () => {}
+                  }),
+                  {service, actuatorConfig} = createService({
+                      serviceConfig: {deploymentRuntimeAccessService: runtimeAccess}
+                  }),
+                  restart = await service.apply('mc-server', 'restart', {
+                      isAuthorityHeld: () => true,
+                      now            : 100_000
+                  }),
+                  reconfigure = await service.apply('mc-server', 'reconfigure', {
+                      isAuthorityHeld: () => true,
+                      knob           : KNOB,
+                      knobValues     : VALUES,
+                      now            : 100_001
+                  }),
+                  otherService = await service.apply('kb-server', 'restart', {
+                      isAuthorityHeld: () => true,
+                      now            : 100_002
+                  }),
+                  ceiling = await service.apply('chroma', 'raise-ceiling', {
+                      isAuthorityHeld: () => true,
+                      knob           : 'container-memory-ceiling',
+                      knobValues     : {'deploy.chroma.memoryCeilingBytes': 8 * gibibyte},
+                      now            : 100_003,
+                      targetIdentity : {kind: 'compose-service', id: 'chroma'}
+                  }),
+                  notApplied = await service.apply('local-model', 'restart', {
+                      isAuthorityHeld: () => true,
+                      now            : 100_004
+                  }),
+                  declined = await service.apply('mc-server', 'restart', {
+                      isAuthorityHeld: () => false,
+                      now            : 100_005
+                  }),
+                  rejected = await service.apply('mc-server', 'exec', {now: 100_006}),
+                  reader = ({limit}) => readRecentRecoveryRunStatesWithCompleteness({
+                      dir: actuatorConfig.recoveryRunStateDir,
+                      limit
+                  }),
+                  stored = await reader({limit: actuatorConfig.recoveryRunRetentionLimit}),
+                  planned = await DeploymentStateBridgeService.prototype.collectPlannedRestarts.call({
+                      recoveryRunStateReader: reader
+                  }, {
+                      serviceKey: 'mc-server',
+                      baseline  : {observedAt: 1},
+                      observedAt: Date.now() + 1000
+                  });
+
+            expect(restart.status).toBe('actioned');
+            expect(reconfigure.status).toBe('actioned');
+            expect(otherService.status).toBe('actioned');
+            expect(ceiling, JSON.stringify({ceiling, dockerCalls})).toMatchObject({
+                status: 'actioned',
+                action: 'raise-ceiling'
+            });
+            expect(notApplied).toMatchObject({status: 'failed', effectDisposition: 'not-applied'});
+            expect(declined).toMatchObject({status: 'declined', reasonCode: 'authority-lost'});
+            expect(rejected).toMatchObject({status: 'rejected', reasonCode: 'unsupported-action'});
+            expect(stored.entries).toEqual(expect.arrayContaining([
+                expect.objectContaining({
+                    targetIdentity: {kind: 'compose-service', id: 'chroma'},
+                    details       : expect.objectContaining({
+                        runtimeAccess: expect.objectContaining({
+                            operation       : 'update-memory-limit',
+                            recordType      : 'deployment-runtime-access',
+                            runtimeMechanism: 'docker-socket'
+                        })
+                    })
+                }),
+                expect.objectContaining({
+                    targetIdentity: {kind: 'compose-service', id: 'local-model'},
+                    details       : expect.objectContaining({effectDisposition: 'not-applied'})
+                })
+            ]));
+            expect(dockerCalls.filter(call =>
+                call.method === 'POST' && call.path.includes('/restart?')
+            )).toHaveLength(3);
+            expect(dockerCalls.filter(call =>
+                call.method === 'POST' && call.path.endsWith('/update')
+            )).toHaveLength(1);
+            expect(planned).toEqual({count: 2, reason: null, status: 'available'});
         });
 
         test('the full reconfigure action refuses takeover after its scratch write and before overlay publication', async () => {

--- a/test/playwright/unit/ai/services/memory-core/helpers/recoveryRunStateStore.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/helpers/recoveryRunStateStore.spec.mjs
@@ -29,6 +29,7 @@ import {
     pruneRecoveryRunStates,
     readActiveRecoveryRunStates,
     readRecentRecoveryRunStates,
+    readRecentRecoveryRunStatesWithCompleteness,
     RECOVERY_RUN_GRAPH_NODE_TYPES,
     selectRecoveryRunGraphRecords
 } from '../../../../../../../ai/services/memory-core/helpers/recoveryRunStateStore.mjs';
@@ -518,5 +519,63 @@ test.describe('RecoveryRunStateStore', () => {
         const recent = await readRecentRecoveryRunStates({dir: tmpDir, limit: 2});
 
         expect(recent.map(entry => entry.recoveryRunId)).toEqual(['recovery-good']);
+    });
+
+    test('#16984: completeness-aware reads distinguish a genuinely empty store from retained damage', async () => {
+        const empty = await readRecentRecoveryRunStatesWithCompleteness({dir: tmpDir, limit: 5});
+
+        expect(empty).toEqual({
+            entries      : [],
+            activeEntries: [],
+            completeness : {
+                artifactCount          : 0,
+                incompleteArtifactCount: 0,
+                reasonCodes            : [],
+                status                 : 'complete'
+            }
+        });
+
+        const valid = runEntry('recovery-torn-for-completeness', 3000);
+
+        await writeFile(path.join(tmpDir, 'empty.jsonl'), '', 'utf8');
+        await writeFile(path.join(tmpDir, 'corrupt.jsonl'), '{"broken"\n', 'utf8');
+        await writeFile(
+            path.join(tmpDir, getRecoveryRunStateFileName(valid.recoveryRunId)),
+            `${JSON.stringify(valid)}\n{"torn"`,
+            'utf8'
+        );
+
+        const damaged = await readRecentRecoveryRunStatesWithCompleteness({dir: tmpDir, limit: 5});
+
+        expect(damaged.entries).toMatchObject([{recoveryRunId: valid.recoveryRunId}]);
+        expect(damaged.activeEntries).toEqual([]);
+        expect(damaged.completeness).toEqual({
+            artifactCount          : 3,
+            incompleteArtifactCount: 3,
+            reasonCodes            : ['artifact-empty', 'artifact-partial', 'artifact-undecodable'],
+            status                 : 'incomplete'
+        });
+    });
+
+    test('#16984: completeness reads retain active interlocks outside the ordinary recency cap', async () => {
+        const active = runEntry('recovery-active-oldest', 1000, {
+            details: {
+                effectDisposition: 'uncertain',
+                retentionClass   : ACTIVE_RECOVERY_RUN_RETENTION_CLASS
+            }
+        });
+        const newer = [runEntry('recovery-newer-1', 2000), runEntry('recovery-newer-2', 3000)];
+
+        await Promise.all([active, ...newer].map(entry => writeFile(
+            path.join(tmpDir, getRecoveryRunStateFileName(entry.recoveryRunId)),
+            `${JSON.stringify(entry)}\n`,
+            'utf8'
+        )));
+
+        const result = await readRecentRecoveryRunStatesWithCompleteness({dir: tmpDir, limit: 1});
+
+        expect(result.entries.map(entry => entry.recoveryRunId)).toEqual(['recovery-newer-2']);
+        expect(result.activeEntries.map(entry => entry.recoveryRunId)).toEqual(['recovery-active-oldest']);
+        expect(result.completeness.status).toBe('complete');
     });
 });

--- a/test/playwright/unit/ai/services/memory-core/helpers/recoveryRunStateStore.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/helpers/recoveryRunStateStore.spec.mjs
@@ -557,6 +557,22 @@ test.describe('RecoveryRunStateStore', () => {
         });
     });
 
+    test('#16984: an absent state directory is a complete zero before the first persisted run', async () => {
+        const absentDir = path.join(tmpDir, 'never-persisted'),
+            absent      = await readRecentRecoveryRunStatesWithCompleteness({dir: absentDir, limit: 5});
+
+        expect(absent).toEqual({
+            entries      : [],
+            activeEntries: [],
+            completeness : {
+                artifactCount          : 0,
+                incompleteArtifactCount: 0,
+                reasonCodes            : [],
+                status                 : 'complete'
+            }
+        });
+    });
+
     test('#16984: completeness reads retain active interlocks outside the ordinary recency cap', async () => {
         const active = runEntry('recovery-active-oldest', 1000, {
             details: {


### PR DESCRIPTION
Resolves #16984

Planned-restart subtraction now fails closed over retained recovery-run damage, retention-exempt active interlocks, unclassified effect states, and unbound dispatch windows. Positive restart and restart-bearing reconfigure receipts—including later applied settlements—retain their pre-dispatch coordinate through the production actuator → JSONL store → completeness reader → bridge path, while definite no-effect and non-restart lifecycle writes remain excluded.

Evidence: L2 (production `RecoveryActuatorService` → JSONL store → completeness reader → bridge composition plus targeted mutation controls) → L2 required (all nine close-target ACs are CI-verifiable). No residuals.

## AC Evidence

| AC-1 | `recoveryRunStateStore.spec.mjs` distinguishes retained empty/corrupt/partial artifacts; `DeploymentStateBridgeService.spec.mjs` proves damage degrades planned-restart health. |
| AC-2 | `DeploymentStateBridgeService.spec.mjs` proves a complete empty directory remains an available zero. |
| AC-3 | `RecoveryActuatorService.spec.mjs` executes actual restart and reconfigure writers through the real `DeploymentRuntimeAccessService` (Docker transport seam only), temporary JSONL store, production completeness reader, and `collectPlannedRestarts()`. |
| AC-4 | The production-chain assertion plus the mutation receipts below turn red when restart dispatch/settlement propagation is removed. |
| AC-5 | The same actual-writer composition proves wrong-service restart, `update-memory-limit`, definite `not-applied`, authority decline, and rejected/no-action rows do not enter the count. |
| AC-6 | `DeploymentStateBridgeService.spec.mjs` proves retention-exempt uncertainty outside the recency cap degrades, and schema-valid unclassified active interlocks cannot certify zero. |
| AC-7 | The post-inspect interleaving control degrades the current sample and counts the dispatch in the next bounded window. |
| AC-8 | The exact-subtraction boundary control pins restart churn as `authoritative: false`, `actionClass: record`, and the last evidence fact. |
| AC-9 | Production JSDoc distinguishes pre-dispatch `restartDispatch.requestedAt` from response-bound `runtimeAccess.observedAt`. |

## Deltas from ticket

None substantive. The implementation additionally preserves positively settled uncertain effects and scans active interlocks independently of the ordinary recency cap; both are required consequences of the ticket's completeness boundary.

## Test Evidence

Focused source mutations were applied one at a time and restored before the final green run:

- Collapsing completeness to readable entries turned the corrupt-store controls red (2 failures).
- Slicing active interlocks to the recency cap turned the retention-exempt control red (1 failure).
- Filtering active rows by `effectDisposition: uncertain` reproduced the false green (`available` instead of degraded; 1 failure).
- Disabling applied-settlement counting reproduced an available zero instead of count 1 (1 failure).
- Bypassing same-container `StartedAt` evidence admitted label-only settlement rows as available count 1 (1 failure).
- Disabling terminal-row invariants admitted a nonterminal reobserve row as available count 1 (1 failure).
- Removing the successful dispatch coordinate turned the production writer→reader composition red (1 failure).

## Post-Merge Validation

- [x] None — no deployment-only behavior remains outside the close target's CI-observable contract.

Authored by Emmy (GPT-5.6 Sol Ultra, Codex). Session 0dc1379e-5329-4fba-80ca-f6466822f7c9.
