### PR TITLE
fix(github): classify believed-open lookup evidence (#16196)

### DIFF
--- a/ai/mcp/server/github-workflow/openapi.yaml
+++ b/ai/mcp/server/github-workflow/openapi.yaml
@@ -2220,7 +2220,13 @@ components:
                 type: integer
               reason:
                 type: string
-                enum: [not-found-or-inaccessible]
+                enum: [not-found, unrecognized-state, lookup-error, unresolved]
+                description: >
+                  Why the submitted coordinate could not be verified: not-found requires a null row
+                  plus one exact alias-scoped NOT_FOUND error; unrecognized-state requires an
+                  exact-number row with an unknown state and no alias error; lookup-error covers an
+                  exact non-NOT_FOUND, duplicate, or inconsistent row/error payload; unresolved means
+                  neither a usable exact-number row nor an exact alias-scoped error was observed.
 
     PullRequestConversation:
       type: object

--- a/ai/services/github-workflow/PullRequestService.mjs
+++ b/ai/services/github-workflow/PullRequestService.mjs
@@ -222,32 +222,71 @@ function getBelievedOpenValidationMessage(believedOpen) {
 }
 
 /**
+ * @summary Selects GraphQL errors owned by one direct believed-open alias.
+ *
+ * GitHub error messages are human prose and cannot own a classifier. The typed error is usable only
+ * when its path is exactly `['repository', alias]`; an extra-depth, reordered, malformed, or unrelated
+ * path describes a different observation and must not be borrowed.
+ *
+ * @param {Object[]|undefined} errors Partial GraphQL response errors.
+ * @param {String} alias Deterministic repository-level lookup alias.
+ * @returns {Object[]} Exact alias-scoped errors.
+ */
+function getBelievedOpenAliasErrors(errors, alias) {
+    if (!Array.isArray(errors)) return [];
+
+    return errors.filter(error =>
+        Array.isArray(error?.path) &&
+        error.path.length === 2 &&
+        error.path[0] === 'repository' &&
+        error.path[1] === alias
+    )
+}
+
+/**
  * @summary Classifies every submitted PR coordinate from its direct aliased GitHub row.
  * @param {Object} repository Repository result containing the direct alias fields.
  * @param {Array<{alias: String, number: Number}>} lookups Ordered alias-to-number lookup plan.
+ * @param {Object[]} [errors=[]] Typed partial-response errors returned beside repository data.
  * @returns {{stillOpen: Number[], falsified: Object[], unverifiable: Object[]}}
  */
-function projectBelievedOpen(repository, lookups) {
+function projectBelievedOpen(repository, lookups, errors=[]) {
     const stillOpen    = [];
     const falsified    = [];
     const unverifiable = [];
 
     lookups.forEach(({alias, number}) => {
-        const pullRequest = repository[alias];
+        const pullRequest    = repository[alias],
+              aliasErrors    = getBelievedOpenAliasErrors(errors, alias),
+              aliasPresent   = Object.hasOwn(repository, alias),
+              rowIsNull      = aliasPresent && pullRequest === null,
+              rowPresent     = aliasPresent && pullRequest !== null && pullRequest !== undefined,
+              exactNumberRow = rowPresent &&
+                  typeof pullRequest === 'object' &&
+                  !Array.isArray(pullRequest) &&
+                  pullRequest.number === number;
 
-        if (pullRequest?.state === 'OPEN') {
+        if (aliasErrors.length > 0) {
+            const reason = rowIsNull && aliasErrors.length === 1 && aliasErrors[0]?.type === 'NOT_FOUND'
+                ? 'not-found'
+                : 'lookup-error';
+
+            unverifiable.push({number, reason});
+            return
+        }
+
+        if (!exactNumberRow) {
+            unverifiable.push({number, reason: 'unresolved'});
+        } else if (pullRequest.state === 'OPEN') {
             stillOpen.push(number);
-        } else if (['CLOSED', 'MERGED'].includes(pullRequest?.state)) {
+        } else if (['CLOSED', 'MERGED'].includes(pullRequest.state)) {
             falsified.push({
                 number,
                 state   : pullRequest.state,
                 mergedAt: pullRequest.mergedAt ?? null
             })
         } else {
-            unverifiable.push({
-                number,
-                reason: 'not-found-or-inaccessible'
-            })
+            unverifiable.push({number, reason: 'unrecognized-state'})
         }
     });
 
@@ -3817,9 +3856,11 @@ class PullRequestService extends Base {
             const response = beliefPlan
                 ? await GraphqlService.query(beliefPlan.query, variables, {strict: false})
                 : await GraphqlService.query(FETCH_PULL_REQUESTS, variables);
-            const data = beliefPlan && response && Object.hasOwn(response, 'data')
+            const partialEnvelope = beliefPlan && response && Object.hasOwn(response, 'data'),
+                  data            = partialEnvelope
                 ? response.data
-                : response;
+                : response,
+                  errors = partialEnvelope ? response.errors : [];
             const pullRequests = data.repository.pullRequests.nodes.map(normalizePullRequestListItem);
 
             const result = {
@@ -3829,7 +3870,7 @@ class PullRequestService extends Base {
 
             if (beliefPlan) {
                 result.checkedAt = new Date().toISOString();
-                result.belief    = projectBelievedOpen(data.repository, beliefPlan.lookups);
+                result.belief    = projectBelievedOpen(data.repository, beliefPlan.lookups, errors);
             }
 
             return result;
@@ -4300,7 +4341,7 @@ class PullRequestService extends Base {
 
             if (markerChanges.length > 0 || currentTerminal !== incomingTerminal || auditFieldChanges.length > 0) {
                 return {
-                    error                        : 'PR Review Budget Audit Validation Failed',
+                    error  : 'PR Review Budget Audit Validation Failed',
                     message: buildReviewBudgetAuditRefusal({
                         currentAudit,
                         incomingAudit,

--- a/test/playwright/unit/ai/mcp/server/github-workflow/ToolRegistration.spec.mjs
+++ b/test/playwright/unit/ai/mcp/server/github-workflow/ToolRegistration.spec.mjs
@@ -148,6 +148,7 @@ test.describe('GitHub Workflow MCP Server Tool Registration', () => {
         const believedOpen = operation.parameters.find(parameter => parameter.name === 'believedOpen');
         const response     = doc.components.schemas.PullRequestListResponse.properties;
         const belief       = doc.components.schemas.PullRequestBelief;
+        const reasons      = belief.properties.unverifiable.items.properties.reason.enum;
 
         expect(operation['x-neo-tool-summary']).toContain('believedOpen');
         expect(operation['x-neo-tool-summary'].length).toBeLessThanOrEqual(120);
@@ -162,10 +163,11 @@ test.describe('GitHub Workflow MCP Server Tool Registration', () => {
             }
         });
 
-        const {listTools} = await import('../../../../../../../ai/mcp/server/github-workflow/toolService.mjs');
-        const toolSchema  = listTools().tools
-            .find(tool => tool.name === 'list_pull_requests')
-            .inputSchema.properties.believedOpen;
+        const {listTools}   = await import('../../../../../../../ai/mcp/server/github-workflow/toolService.mjs');
+        const listedTool    = listTools().tools.find(tool => tool.name === 'list_pull_requests');
+        const toolSchema    = listedTool.inputSchema.properties.believedOpen;
+        const listedReasons = listedTool.outputSchema.properties.belief.properties
+            .unverifiable.items.properties.reason.enum;
 
         expect(toolSchema).toMatchObject({
             type       : 'array',
@@ -179,6 +181,8 @@ test.describe('GitHub Workflow MCP Server Tool Registration', () => {
         expect(response.checkedAt.format).toBe('date-time');
         expect(response.belief.$ref).toBe('#/components/schemas/PullRequestBelief');
         expect(belief.required).toEqual(['stillOpen', 'falsified', 'unverifiable']);
+        expect(reasons).toEqual(['not-found', 'unrecognized-state', 'lookup-error', 'unresolved']);
+        expect(listedReasons).toEqual(reasons);
         expect(operations.filter(value => value.operationId === 'list_pull_requests')).toHaveLength(1);
         expect(operations.some(value => value.operationId === 'falsify_pull_request_belief')).toBe(false);
     });

--- a/test/playwright/unit/ai/services/github-workflow/PullRequestService.spec.mjs
+++ b/test/playwright/unit/ai/services/github-workflow/PullRequestService.spec.mjs
@@ -146,7 +146,7 @@ test.describe('Neo.ai.services.github-workflow.PullRequestService — list fresh
                         believedOpen3: null
                     }
                 },
-                errors: [{path: ['repository', 'believedOpen3']}]
+                errors: [{type: 'NOT_FOUND', path: ['repository', 'believedOpen3']}]
             }
         };
 
@@ -185,9 +185,78 @@ test.describe('Neo.ai.services.github-workflow.PullRequestService — list fresh
             }],
             unverifiable: [{
                 number: 999999,
-                reason: 'not-found-or-inaccessible'
+                reason: 'not-found'
             }]
         })
+    });
+
+    test('#16196 classifies only exact-number rows and exact alias-scoped typed errors', async () => {
+        GraphqlService.query = async () => ({
+            data: {
+                repository: {
+                    pullRequests  : {nodes: [row({number: 700})]},
+                    believedOpen0 : {number: 20, state: 'OPEN', mergedAt: null},
+                    believedOpen1 : {number: 21, state: 'CLOSED', mergedAt: null},
+                    believedOpen2 : {number: 999, state: 'MERGED', mergedAt: '2026-08-24T00:00:00Z'},
+                    believedOpen3 : {number: 23, state: 'ALIEN', mergedAt: null},
+                    believedOpen4 : null,
+                    believedOpen5 : null,
+                    believedOpen6 : {number: 26, state: 'OPEN', mergedAt: null},
+                    believedOpen7 : null,
+                    believedOpen8 : null,
+                    believedOpen9 : null,
+                    believedOpen10: {number: 30, state: 'MERGED', mergedAt: '2026-08-24T01:00:00Z'},
+                    believedOpen12: 'malformed-row'
+                }
+            },
+            errors: [
+                {type: 'NOT_FOUND', path: ['repository', 'believedOpen4'], message: 'permission denied'},
+                {type: 'FORBIDDEN', path: ['repository', 'believedOpen5'], message: 'Could not resolve PullRequest'},
+                {type: 'NOT_FOUND', path: ['repository', 'believedOpen6']},
+                {type: 'NOT_FOUND', path: ['repository', 'believedOpen7']},
+                {type: 'NOT_FOUND', path: ['repository', 'believedOpen7']},
+                {type: 'NOT_FOUND', path: ['repository', 'believedOpen8', 'extra']},
+                {type: 'NOT_FOUND', path: ['repository', 'believedOpen9'], message: 'not an absence message'},
+                {type: 'NOT_FOUND', path: ['repository', 'believedOpen13']},
+                {type: 'NOT_FOUND', path: ['believedOpen11', 'repository']},
+                {type: 'NOT_FOUND', path: 'repository.believedOpen11'},
+                {type: 'NOT_FOUND'},
+                {type: 'NOT_FOUND', path: ['repository', 'unrelatedAlias']}
+            ]
+        });
+
+        const result = await PullRequestService.listPullRequests({
+            believedOpen: [20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33]
+        });
+
+        expect(result.belief).toEqual({
+            stillOpen: [20],
+            falsified: [{
+                number  : 21,
+                state   : 'CLOSED',
+                mergedAt: null
+            }, {
+                number  : 30,
+                state   : 'MERGED',
+                mergedAt: '2026-08-24T01:00:00Z'
+            }],
+            unverifiable: [
+                {number: 22, reason: 'unresolved'},
+                {number: 23, reason: 'unrecognized-state'},
+                {number: 24, reason: 'not-found'},
+                {number: 25, reason: 'lookup-error'},
+                {number: 26, reason: 'lookup-error'},
+                {number: 27, reason: 'lookup-error'},
+                {number: 28, reason: 'unresolved'},
+                {number: 29, reason: 'not-found'},
+                {number: 31, reason: 'unresolved'},
+                {number: 32, reason: 'unresolved'},
+                {number: 33, reason: 'lookup-error'}
+            ]
+        });
+        expect(result.belief.stillOpen).toHaveLength(1);
+        expect(result.belief.falsified).toHaveLength(2);
+        expect(result.belief.unverifiable).toHaveLength(11);
     });
 
     test('accepts an explicit empty belief without changing the board query', async () => {


### PR DESCRIPTION
Resolves #16196

`list_pull_requests({believedOpen})` now classifies only what one partial GraphQL response proves: exact alias-scoped typed errors and exact-number rows. Missing or malformed evidence stays unresolved, contradictory/duplicate provider evidence becomes a lookup error, and no wrong-number terminal row can falsify the caller's belief.

Evidence: L2 (one-request partial-response classifier plus OpenAPI and emitted `tools/list.outputSchema` controls) → L2 required (all ten close-target ACs are CI-verifiable). No residuals.

## AC Evidence

| AC-1 | `PullRequestService.spec.mjs` proves only exact two-segment `['repository', alias]` paths match; extra-depth, reordered, unrelated, missing, and non-array paths remain unowned. |
| AC-2 | The classifier reads only exact `type: 'NOT_FOUND'`; paired fixtures use misleading human messages in both directions. |
| AC-3 | An explicit own-property null row plus one exact alias-scoped `NOT_FOUND` produces `not-found`; an omitted alias does not. |
| AC-4 | An exact-number row with an unknown state and no exact alias error produces `unrecognized-state`. |
| AC-5 | Exact non-`NOT_FOUND`, duplicate exact errors, row-plus-error contradictions, and exact errors over omitted aliases produce `lookup-error`. |
| AC-6 | Missing, malformed, and wrong-number rows without exact alias evidence produce `unresolved`. |
| AC-7 | Every state bucket requires `row.number === submittedNumber`; the wrong-number terminal mutation turns the exhaustive matrix red. |
| AC-8 | `openapi.yaml` and `ToolRegistration.spec.mjs` expose exactly the four reasons in both source OpenAPI and emitted `tools/list.outputSchema`. |
| AC-9 | Existing one-query, explicit-empty/default, and structured repository-level failure controls stay green in the 195-test owning matrix. |
| AC-10 | The exhaustive matrix asserts disjoint totals: 1 still-open + 2 falsified + 11 unverifiable for 14 submitted coordinates. |

## Deltas from ticket

None substantive. The implementation adds one pure exact-path selector and documents the four reason semantics at their OpenAPI source.

## Test Evidence

Focused source mutations were applied one at a time and restored before the final green run:

- Dropping `response.errors` produced 2 focused failures and reclassified exact provider evidence as unresolved/open.
- Removing submitted-number identity admitted the wrong PR's `MERGED` row into `falsified` (1 failure).
- Relaxing the error path from exactly two segments to a prefix misattributed an extra-depth error as `not-found` (1 failure).
- Conflating an omitted alias with an explicit null row misclassified the inconsistent payload as `not-found` (1 failure).

## Post-Merge Validation

- [x] None — the service, OpenAPI, and emitted tool schema contracts are fully exercised in CI.

Authored by Emmy (GPT-5.6 Sol Ultra, Codex). Session 0dc1379e-5329-4fba-80ca-f6466822f7c9.
