### PR TITLE
fix(testing): retain browser launch receipts per run (#17679)

### DIFF
--- a/test/playwright/e2e/custom-reporter.js
+++ b/test/playwright/e2e/custom-reporter.js
@@ -1,15 +1,20 @@
-import fs from 'fs-extra';
-import os from 'os';
-import { execSync } from 'child_process';
-import path from 'path';
-import {isEngineProfile} from './utils/gpuIntent.mjs';
+import fs                       from 'fs-extra';
+import os                       from 'os';
+import {createHash, randomUUID} from 'node:crypto';
+import { execSync }             from 'child_process';
+import path                     from 'path';
+import {isEngineProfile}        from './utils/gpuIntent.mjs';
+
+export const BROWSER_LIFECYCLE_RECEIPT_RECORD_TYPE = 'neo-e2e-browser-lifecycle-receipt';
+export const DEFAULT_BROWSER_LIFECYCLE_RECEIPT_LIMIT = 100;
 
 const
-  ANSI_ESCAPE_PATTERN = /\u001B\[[0-?]*[ -/]*[@-~]/g,
-  HEADLESS_TOKEN_PATTERN = /(?:^|\s)-{1,2}headless(?:=[^\s]+)?(?=\s|$)/,
-  LAUNCH_COMMAND_PATTERN = /^<launching>\s+(.+)$/m,
-  MACH_SERVICE_PERMISSION_TOKEN = 'Permission denied (1100)',
-  PROCESS_EXIT_PATTERN = /\[pid=(\d+)]\s+<process did exit: exitCode=([^,>]+), signal=([^>]+)>/;
+  ANSI_ESCAPE_PATTERN                    = /\u001B\[[0-?]*[ -/]*[@-~]/g,
+  BROWSER_LIFECYCLE_RECEIPT_FILE_PATTERN = /^receipt-[a-f0-9]{64}\.json$/,
+  HEADLESS_TOKEN_PATTERN                 = /(?:^|\s)-{1,2}headless(?:=[^\s]+)?(?=\s|$)/,
+  LAUNCH_COMMAND_PATTERN                 = /^<launching>\s+(.+)$/m,
+  MACH_SERVICE_PERMISSION_TOKEN          = 'Permission denied (1100)',
+  PROCESS_EXIT_PATTERN                   = /\[pid=(\d+)]\s+<process did exit: exitCode=([^,>]+), signal=([^>]+)>/;
 
 /**
  * @summary Resolves a bounded browser-kind enum without persisting arbitrary executable paths.
@@ -68,6 +73,93 @@ export function readOptionalSystemFact(read, fallback=null) {
   } catch {
     return fallback
   }
+}
+
+/**
+ * @summary Derives a bounded cross-platform filename without projecting a caller-owned run id.
+ * @param {String} runId
+ * @returns {String}
+ */
+function browserLifecycleReceiptFileName(runId) {
+  const digest = createHash('sha256').update(runId).digest('hex');
+
+  return `receipt-${digest}.json`
+}
+
+/**
+ * @summary Resolves one run-owned lifecycle-receipt file outside Playwright's cleaned outputDir.
+ * @param {Object} [options]
+ * @param {Function} [options.createRunId=randomUUID]
+ * @param {String} [options.receiptRoot='test-results/e2e/browser-lifecycle']
+ * @param {String|null} [options.runId=null]
+ * @returns {{outputFile: String, runId: String}}
+ */
+export function resolveBrowserLifecycleReceipt({
+  createRunId = randomUUID,
+  receiptRoot = 'test-results/e2e/browser-lifecycle',
+  runId = null
+} = {}) {
+  const resolvedRunId = typeof runId === 'string' && runId.length > 0 ? runId : createRunId();
+
+  if (typeof receiptRoot !== 'string' || receiptRoot.length === 0) {
+    throw new TypeError('Browser lifecycle receipt root must be a non-empty string')
+  }
+  if (typeof resolvedRunId !== 'string' || resolvedRunId.length === 0) {
+    throw new TypeError('Browser lifecycle run id must be a non-empty string')
+  }
+
+  return {
+    outputFile: path.join(receiptRoot, browserLifecycleReceiptFileName(resolvedRunId)),
+    runId     : resolvedRunId
+  }
+}
+
+/**
+ * @summary Prunes only recognized reporter-owned regular files beyond the bounded newest window.
+ * @param {String} receiptRoot Browser lifecycle receipt directory.
+ * @param {Object} [options]
+ * @param {Number} [options.limit=DEFAULT_BROWSER_LIFECYCLE_RECEIPT_LIMIT]
+ * @returns {{retained: Number, removed: String[]}}
+ */
+export function pruneBrowserLifecycleReceipts(receiptRoot, {
+  limit = DEFAULT_BROWSER_LIFECYCLE_RECEIPT_LIMIT
+} = {}) {
+  if (!Number.isInteger(limit) || limit <= 0) {
+    throw new TypeError('Browser lifecycle receipt limit must be a positive integer')
+  }
+  if (!fs.pathExistsSync(receiptRoot)) return {retained: 0, removed: []};
+
+  const owned = [];
+
+  for (const entry of fs.readdirSync(receiptRoot, {withFileTypes: true})) {
+    if (!entry.isFile() || !BROWSER_LIFECYCLE_RECEIPT_FILE_PATTERN.test(entry.name)) continue;
+
+    const filePath = path.join(receiptRoot, entry.name);
+
+    try {
+      const value = fs.readJsonSync(filePath),
+            stat  = fs.lstatSync(filePath);
+
+      if (
+        value?.recordType === BROWSER_LIFECYCLE_RECEIPT_RECORD_TYPE &&
+        typeof value?.runId === 'string' &&
+        value.runId.length > 0 &&
+        entry.name === browserLifecycleReceiptFileName(value.runId)
+      ) {
+        owned.push({filePath, mtimeMs: stat.mtimeMs, name: entry.name})
+      }
+    } catch {
+      // Malformed, disappearing, and unreadable files are not proven reporter-owned; leave them.
+    }
+  }
+
+  owned.sort((left, right) => right.mtimeMs - left.mtimeMs || right.name.localeCompare(left.name));
+
+  const removed = owned.slice(limit).map(entry => entry.name).sort();
+
+  for (const name of removed) fs.removeSync(path.join(receiptRoot, name));
+
+  return {retained: Math.min(owned.length, limit), removed}
 }
 
 /**
@@ -142,9 +234,13 @@ export default class BenchmarkSystemReporter {
    * @summary Initializes one reporter-owned receipt without taking ownership of Playwright browsers.
    * @param {Object} [options]
    * @param {String} [options.outputFile='benchmark-system-info.json']
+   * @param {String|null} [options.runId=null]
+   * @param {Number} [options.retentionLimit=DEFAULT_BROWSER_LIFECYCLE_RECEIPT_LIMIT]
    */
   constructor(options={}) {
       this.outputFile = options?.outputFile || 'benchmark-system-info.json';
+      this.runId = options?.runId || randomUUID();
+      this.retentionLimit = options?.retentionLimit ?? DEFAULT_BROWSER_LIFECYCLE_RECEIPT_LIMIT;
       this.receipt = null;
       this.launchExits = new Map();
   }
@@ -159,14 +255,16 @@ export default class BenchmarkSystemReporter {
     const systemInfo = this.getSystemInfo();
 
     this.receipt = {
+      recordType: BROWSER_LIFECYCLE_RECEIPT_RECORD_TYPE,
+      runId     : this.runId,
       ...systemInfo,
       benchmarkRun: {
-        timestamp: new Date().toISOString(),
+        timestamp         : new Date().toISOString(),
         playwrightProjects: config.projects?.map(p => p.name) || [],
-        totalTests: suite.allTests().length
+        totalTests        : suite.allTests().length
       },
       browserLifecycle: {
-        profile: resolveE2eProfileName(),
+        profile    : resolveE2eProfileName(),
         launchExits: [...this.launchExits.values()]
       }
     };
@@ -195,7 +293,8 @@ export default class BenchmarkSystemReporter {
     if (!this.receipt) return;
 
     fs.ensureDirSync(path.dirname(this.outputFile));
-    fs.writeJsonSync(this.outputFile, this.receipt, { spaces: 2 })
+    fs.writeJsonSync(this.outputFile, this.receipt, { spaces: 2 });
+    pruneBrowserLifecycleReceipts(path.dirname(this.outputFile), {limit: this.retentionLimit})
   }
 
   /**
@@ -245,6 +344,7 @@ export default class BenchmarkSystemReporter {
 
     const receipt = {
       ...incident,
+      capturedAt : new Date().toISOString(),
       observedVia: [observedVia]
     };
 
@@ -342,19 +442,19 @@ export default class BenchmarkSystemReporter {
     }
 
     return {
-      os: this.getOSName(),
+      os         : this.getOSName(),
       osVersion,
-      arch: process.arch,
-      platform: process.platform,
+      arch       : process.arch,
+      platform   : process.platform,
       totalMemory: Math.round(os.totalmem() / (1024 ** 3)),
-      freeMemory: Math.round(os.freemem() / (1024 ** 3)),
-      cpuCores: os.cpus().length,
+      freeMemory : Math.round(os.freemem() / (1024 ** 3)),
+      cpuCores   : os.cpus().length,
       cpuModel,
       cpuSpeed,
       nodeVersion: process.version,
-      timestamp: new Date().toISOString(),
+      timestamp  : new Date().toISOString(),
       loadAverage: readOptionalSystemFact(() => os.loadavg(), null),
-      uptime: readOptionalSystemFact(() => Math.round(os.uptime() / 3600), null),
+      uptime     : readOptionalSystemFact(() => Math.round(os.uptime() / 3600), null),
     };
   }
 

--- a/test/playwright/playwright.config.e2e.mjs
+++ b/test/playwright/playwright.config.e2e.mjs
@@ -3,6 +3,10 @@ import './configTemplateResolver.mjs';
 import {defineConfig, devices}             from '@playwright/test';
 import {resolveFreePortSync}               from './resolveFreePort.mjs';
 import {activeLaunchArgs, requiresGlProbe} from './e2e/utils/gpuIntent.mjs';
+import {
+    DEFAULT_BROWSER_LIFECYCLE_RECEIPT_LIMIT,
+    resolveBrowserLifecycleReceipt
+} from './e2e/custom-reporter.js';
 
 // Per-process by default: this suite renders ITS OWN checkout (reuseExistingServer:false below), so a
 // fixed default would silently adopt a foreign dev-server squatting on 8080 — that server serves the
@@ -23,7 +27,18 @@ process.env.NEO_E2E_PORT = String(PORT);
 //   cd test/playwright && dir="test-results/e2e/battery/run-1" && mkdir -p "$dir" && \
 //   NEO_E2E_RUN_ID=run-1 npx playwright test -c playwright.config.e2e.mjs e2e/<spec> 2>&1 | tee "$dir/run.log"
 const RUN_ID        = process.env.NEO_E2E_RUN_ID || null,
-      ARTIFACT_ROOT = RUN_ID ? `./test-results/e2e/battery/${RUN_ID}/artifacts` : './test-results/e2e/artifacts';
+      ARTIFACT_ROOT = RUN_ID ? `./test-results/e2e/battery/${RUN_ID}/artifacts` : './test-results/e2e/artifacts',
+      // Lifecycle receipts must outlive Playwright's outputDir cleanup and later runs. Retaining the
+      // newest 100 gives a useful recent-run window while bounding reporter-owned accumulation. Total
+      // run volume is unmeasured, so this policy deliberately makes no duration claim.
+      LIFECYCLE_RECEIPT = resolveBrowserLifecycleReceipt({
+          receiptRoot: './test-results/e2e/browser-lifecycle',
+          // The internal pin is inherited by Playwright's config re-imports and workers. Only the
+          // caller-owned NEO_E2E_RUN_ID scopes the normal battery artifact tree above.
+          runId       : RUN_ID || process.env.NEO_E2E_LIFECYCLE_RUN_ID || null
+      });
+
+process.env.NEO_E2E_LIFECYCLE_RUN_ID = LIFECYCLE_RECEIPT.runId;
 
 const
     launchArgs     = activeLaunchArgs(),
@@ -52,7 +67,10 @@ export default defineConfig({
         ['list'],
         ['html', { outputFolder: 'test-results/e2e/html-report', open: 'never' }],
         ['json', { outputFile: 'test-results/e2e/results.json' }],
-        ['./e2e/custom-reporter.js', { outputFile: 'test-results/e2e/benchmark-system-info.json' }]
+        ['./e2e/custom-reporter.js', {
+            ...LIFECYCLE_RECEIPT,
+            retentionLimit: DEFAULT_BROWSER_LIFECYCLE_RECEIPT_LIMIT
+        }]
     ],
 
     use: {

--- a/test/playwright/unit/e2e/browserLifecycleReporter.spec.mjs
+++ b/test/playwright/unit/e2e/browserLifecycleReporter.spec.mjs
@@ -3,9 +3,12 @@ import os             from 'os';
 import path           from 'path';
 import {expect, test} from '@playwright/test';
 import BenchmarkSystemReporter, {
+    BROWSER_LIFECYCLE_RECEIPT_RECORD_TYPE,
     classifyBrowserLaunchExit,
+    pruneBrowserLifecycleReceipts,
     readOptionalSystemFact,
     resolveBrowserKind,
+    resolveBrowserLifecycleReceipt,
     resolveE2eProfileName
 } from '../../e2e/custom-reporter.js';
 
@@ -193,6 +196,159 @@ test.describe('e2e/custom-reporter browser lifecycle', () => {
         }, 'Unknown')).toBe('Unknown')
     });
 
+    test('#17679 resolves one safe per-run receipt path without rewriting a supplied run id', () => {
+        const supplied = resolveBrowserLifecycleReceipt({
+            receiptRoot: '/tmp/browser-lifecycle',
+            runId      : 'battery/run 1'
+        });
+        const minted = resolveBrowserLifecycleReceipt({
+            createRunId: () => 'opaque-minted-id',
+            receiptRoot: '/tmp/browser-lifecycle',
+            runId      : null
+        });
+
+        expect(supplied.runId).toBe('battery/run 1');
+        expect(minted.runId).toBe('opaque-minted-id');
+        expect(path.dirname(supplied.outputFile)).toBe('/tmp/browser-lifecycle');
+        expect(path.dirname(minted.outputFile)).toBe('/tmp/browser-lifecycle');
+        expect(path.basename(supplied.outputFile)).toMatch(/^receipt-[a-f0-9]{64}\.json$/);
+        expect(path.basename(minted.outputFile)).toMatch(/^receipt-[a-f0-9]{64}\.json$/);
+        expect(supplied.outputFile).not.toBe(minted.outputFile);
+        expect(() => resolveBrowserLifecycleReceipt({receiptRoot: '', runId: 'run'})).toThrow(
+            'Browser lifecycle receipt root must be a non-empty string'
+        );
+        expect(() => resolveBrowserLifecycleReceipt({createRunId: () => '', runId: null})).toThrow(
+            'Browser lifecycle run id must be a non-empty string'
+        )
+    });
+
+    test('#17679 control: a fixed output file retains only the second launch exit', async () => {
+        const root       = await fs.mkdtemp(path.join(os.tmpdir(), 'neo-browser-lifecycle-fixed-')),
+              outputFile = path.join(root, 'benchmark-system-info.json'),
+              project    = {name: 'chromium', use: {browserName: 'chromium', channel: 'chrome', headless: true}};
+
+        try {
+            for (const [runId, pid] of [['run-one', 4101], ['run-two', 4102]]) {
+                const reporter = new BenchmarkSystemReporter({outputFile, runId});
+
+                reporter.onBegin({projects: [project]}, {allTests: () => []});
+                reporter.onError({message: launchExit({pid})}, {project})
+            }
+
+            const retained = await fs.readJson(outputFile);
+
+            expect(retained.runId).toBe('run-two');
+            expect(retained.browserLifecycle.launchExits).toEqual([
+                expect.objectContaining({processId: 4102})
+            ]);
+            expect(JSON.stringify(retained)).not.toContain('4101')
+        } finally {
+            await fs.remove(root)
+        }
+    });
+
+    test('#17679 two reporter runs retain distinct launch-exit receipts across artifact cleanup', async () => {
+        const root         = await fs.mkdtemp(path.join(os.tmpdir(), 'neo-browser-lifecycle-history-')),
+              receiptRoot  = path.join(root, 'receipts'),
+              artifactDir  = path.join(root, 'artifacts'),
+              project      = {name: 'chromium', use: {browserName: 'chromium', channel: 'chrome', headless: true}},
+              receiptFiles = new Map();
+
+        try {
+            await fs.ensureDir(artifactDir);
+            await fs.writeFile(path.join(artifactDir, 'trace.zip'), 'ephemeral');
+
+            for (const runId of ['run-one', 'run-two']) {
+                const receipt  = resolveBrowserLifecycleReceipt({receiptRoot, runId}),
+                      reporter = new BenchmarkSystemReporter({...receipt, retentionLimit: 100});
+
+                receiptFiles.set(runId, receipt.outputFile);
+                reporter.onBegin({projects: [project]}, {allTests: () => []});
+                reporter.onError({message: launchExit({pid: runId === 'run-one' ? 4101 : 4102})}, {project})
+            }
+
+            await fs.emptyDir(artifactDir);
+
+            const first  = await fs.readJson(receiptFiles.get('run-one')),
+                  second = await fs.readJson(receiptFiles.get('run-two'));
+
+            expect(first).toMatchObject({
+                recordType      : BROWSER_LIFECYCLE_RECEIPT_RECORD_TYPE,
+                runId           : 'run-one',
+                browserLifecycle: {launchExits: [expect.objectContaining({processId: 4101})]}
+            });
+            expect(second).toMatchObject({
+                recordType      : BROWSER_LIFECYCLE_RECEIPT_RECORD_TYPE,
+                runId           : 'run-two',
+                browserLifecycle: {launchExits: [expect.objectContaining({processId: 4102})]}
+            });
+            const receiptRows = [first, second].flatMap(receipt => (
+                      receipt.browserLifecycle.launchExits.map(exit => ({...exit, runId: receipt.runId}))
+                  )),
+                  nativeReports = receiptRows.map((row, index) => ({
+                      capturedAt: new Date(Date.parse(row.capturedAt) + 21 + index * 18).toISOString(),
+                      processId : row.processId
+                  })),
+                  joinedRunIds = nativeReports.map(nativeReport => receiptRows.find(row => (
+                      row.processId === nativeReport.processId &&
+                      Math.abs(Date.parse(nativeReport.capturedAt) - Date.parse(row.capturedAt)) <= 57
+                  ))?.runId);
+
+            expect(joinedRunIds).toEqual(['run-one', 'run-two']);
+            expect(await fs.readdir(artifactDir)).toEqual([]);
+        } finally {
+            await fs.remove(root)
+        }
+    });
+
+    test('#17679 retention prunes only old reporter-owned regular files', async () => {
+        const root = await fs.mkdtemp(path.join(os.tmpdir(), 'neo-browser-lifecycle-prune-'));
+
+        try {
+            const ownedFiles = new Map();
+
+            for (const [runId, mtime] of [['run-one', 1000], ['run-two', 2000], ['run-three', 3000]]) {
+                const file = resolveBrowserLifecycleReceipt({receiptRoot: root, runId}).outputFile;
+
+                ownedFiles.set(runId, file);
+                await fs.writeJson(file, {recordType: BROWSER_LIFECYCLE_RECEIPT_RECORD_TYPE, runId});
+                await fs.utimes(file, mtime / 1000, mtime / 1000)
+            }
+
+            const foreignFile    = path.join(root, `receipt-${'e'.repeat(64)}.json`),
+                  mismatchedFile = path.join(root, `receipt-${'d'.repeat(64)}.json`),
+                  malformedFile  = path.join(root, `receipt-${'c'.repeat(64)}.json`),
+                  linkedFile     = path.join(root, `receipt-${'b'.repeat(64)}.json`);
+
+            await fs.writeJson(foreignFile, {recordType: 'another-owner'});
+            await fs.writeJson(mismatchedFile, {
+                recordType: BROWSER_LIFECYCLE_RECEIPT_RECORD_TYPE,
+                runId     : 'not-owned-at-this-path'
+            });
+            await fs.writeFile(malformedFile, '{broken');
+            await fs.symlink(ownedFiles.get('run-three'), linkedFile);
+
+            expect(await pruneBrowserLifecycleReceipts(root, {limit: 2})).toEqual({
+                retained: 2,
+                removed : [path.basename(ownedFiles.get('run-one'))]
+            });
+            expect(await fs.pathExists(ownedFiles.get('run-one'))).toBe(false);
+
+            for (const file of [
+                ownedFiles.get('run-two'),
+                ownedFiles.get('run-three'),
+                foreignFile,
+                mismatchedFile,
+                malformedFile,
+                linkedFile
+            ]) {
+                expect(await fs.pathExists(file), `${path.basename(file)} survives`).toBe(true)
+            }
+        } finally {
+            await fs.remove(root)
+        }
+    });
+
     test('#16161 deduplicates reporter paths and persists no raw launch command', async () => {
         const
             directory            = await fs.mkdtemp(path.join(os.tmpdir(), 'neo-browser-lifecycle-')),
@@ -245,9 +401,14 @@ test.describe('e2e/custom-reporter browser lifecycle', () => {
             expect(terminal[0]).toContain('failure=before-browser-object cause=unclassified-process-exit');
             expect(terminal[0]).toContain('remedy=inspect-retained-launch-exit');
             expect(raw).not.toContain('<launching>');
+            expect(raw).not.toContain('/Applications/Google Chrome.app');
+            expect(raw).not.toContain('--headless');
             expect(raw).not.toContain('user-data-dir');
+            expect(raw).not.toContain('/private/profile');
             expect(raw).not.toContain('private.example.test');
-            expect(raw).not.toContain('secret-window-title')
+            expect(raw).not.toContain('secret-window-title');
+            expect(raw).not.toContain('browserType.launch');
+            expect(raw).not.toContain('Failed to launch the browser process')
         } finally {
             console.error = originalConsoleError;
             await fs.remove(directory)

--- a/test/playwright/unit/e2e/glState.spec.mjs
+++ b/test/playwright/unit/e2e/glState.spec.mjs
@@ -181,9 +181,10 @@ test.describe('e2e/utils/glState', () => {
 
     test('#16151 presenting config has one Chrome owner; engine config retains the GL probe', async () => {
         const
-            previousEngine = process.env.NEO_E2E_ENGINE_PROFILE,
-            previousFilm   = process.env.NEO_FILM_TAKE,
-            previousPort   = process.env.NEO_E2E_PORT;
+            previousEngine      = process.env.NEO_E2E_ENGINE_PROFILE,
+            previousFilm        = process.env.NEO_FILM_TAKE,
+            previousPort        = process.env.NEO_E2E_PORT,
+            previousLifecycleId = process.env.NEO_E2E_LIFECYCLE_RUN_ID;
 
         try {
             delete process.env.NEO_E2E_ENGINE_PROFILE;
@@ -225,6 +226,76 @@ test.describe('e2e/utils/glState', () => {
                 delete process.env.NEO_E2E_PORT
             } else {
                 process.env.NEO_E2E_PORT = previousPort
+            }
+
+            if (previousLifecycleId === undefined) {
+                delete process.env.NEO_E2E_LIFECYCLE_RUN_ID
+            } else {
+                process.env.NEO_E2E_LIFECYCLE_RUN_ID = previousLifecycleId
+            }
+        }
+    });
+
+    test('#17679 E2E config retains one receipt identity outside outputDir across re-imports', async () => {
+        const
+            previousEngine      = process.env.NEO_E2E_ENGINE_PROFILE,
+            previousFilm        = process.env.NEO_FILM_TAKE,
+            previousPort        = process.env.NEO_E2E_PORT,
+            previousRunId       = process.env.NEO_E2E_RUN_ID,
+            previousLifecycleId = process.env.NEO_E2E_LIFECYCLE_RUN_ID,
+            reporterOptions     = config => config.reporter.find(([name]) => (
+                name === './e2e/custom-reporter.js'
+            ))[1];
+
+        try {
+            delete process.env.NEO_E2E_ENGINE_PROFILE;
+            delete process.env.NEO_FILM_TAKE;
+            delete process.env.NEO_E2E_RUN_ID;
+            delete process.env.NEO_E2E_LIFECYCLE_RUN_ID;
+
+            const first = (
+                      await import(`../../playwright.config.e2e.mjs?receipt=first-${Date.now()}`)
+                  ).default,
+                  second = (
+                      await import(`../../playwright.config.e2e.mjs?receipt=second-${Date.now()}`)
+                  ).default,
+                  firstReceipt = reporterOptions(first),
+                  secondReceipt = reporterOptions(second);
+
+            expect(first.outputDir).toBe('./test-results/e2e/artifacts');
+            expect(firstReceipt.runId).toMatch(/^[a-f0-9-]{36}$/);
+            expect(firstReceipt.retentionLimit).toBe(100);
+            expect(secondReceipt.runId).toBe(firstReceipt.runId);
+            expect(secondReceipt.outputFile).toBe(firstReceipt.outputFile);
+            expect(firstReceipt.outputFile).toMatch(
+                /^test-results\/e2e\/browser-lifecycle\/receipt-[a-f0-9]{64}\.json$/
+            );
+            expect(firstReceipt.outputFile.startsWith(first.outputDir.replace(/^\.\//, ''))).toBe(false);
+
+            process.env.NEO_E2E_RUN_ID = 'caller/battery run';
+            const supplied = (
+                      await import(`../../playwright.config.e2e.mjs?receipt=supplied-${Date.now()}`)
+                  ).default,
+                  suppliedReceipt = reporterOptions(supplied);
+
+            expect(supplied.outputDir).toBe('./test-results/e2e/battery/caller/battery run/artifacts');
+            expect(suppliedReceipt.runId).toBe('caller/battery run');
+            expect(suppliedReceipt.outputFile).toMatch(
+                /^test-results\/e2e\/browser-lifecycle\/receipt-[a-f0-9]{64}\.json$/
+            )
+        } finally {
+            for (const [name, value] of [
+                ['NEO_E2E_ENGINE_PROFILE', previousEngine],
+                ['NEO_FILM_TAKE', previousFilm],
+                ['NEO_E2E_PORT', previousPort],
+                ['NEO_E2E_RUN_ID', previousRunId],
+                ['NEO_E2E_LIFECYCLE_RUN_ID', previousLifecycleId]
+            ]) {
+                if (value === undefined) {
+                    delete process.env[name]
+                } else {
+                    process.env[name] = value
+                }
             }
         }
     });


### PR DESCRIPTION
Resolves #17679

Related: #16151

Each E2E run now writes a marker-owned receipt under `test-results/e2e/browser-lifecycle/`, with the exact caller run ID echoed inside and a bounded SHA-256-derived filename. The config pins one opaque identity across re-imports, launch exits carry capture times, and retention keeps only the newest 100 proven-owned regular files while leaving foreign, malformed, mismatched, and symlink artifacts untouched.

Evidence: L2 (production config import plus real-filesystem reporter, cleanup, retention, and synthetic-correlation controls) → L2 required (all ten close-target ACs are CI-verifiable). No residuals.

## AC Evidence

| AC-1 | `browserLifecycleReporter.spec.mjs` drives two reporter instances at one fixed output path and proves only the second launch exit survives. |
| AC-2 | The two-run filesystem witness resolves separate output files and byte-reads the first PID after the second run completes. |
| AC-3 | Resolver controls preserve a supplied run ID exactly and mint an opaque UUID otherwise; `glState.spec.mjs` proves production config re-imports share that minted identity. |
| AC-4 | The production-config control pins the lifecycle root outside `outputDir`; the two-run witness empties the artifact directory and then reads both retained receipts. |
| AC-5 | Config documents the 100-receipt count policy; pruning requires the exact record marker plus the run-ID-derived filename, and foreign, malformed, mismatched, and symlink negatives survive. |
| AC-6 | Each synthetic rejected launch calls the real reporter before any assertion and its immediate `onError()` flush is byte-read from disk. |
| AC-7 | The serialized-row control is explicitly negative for executable path, launch args, user-data directory, profile path, URL, title, profile content, and raw launch-error grammar. |
| AC-8 | Existing channel, browser-kind, launch-mode, cause, remedy, and `transportState: not-observable` assertions remain in the owning suite. |
| AC-9 | Each incident carries `capturedAt`; the two-run control joins synthetic native receipts to retained run IDs by exact PID and a bounded 21–57 ms interval. |
| AC-10 | Both owning E2E-unit specs pass together, including production config, reporter, privacy, retention, and prior lifecycle contracts. |

## Deltas from ticket

The per-run filename is a fixed-size SHA-256 derivation rather than a caller-ID projection, making it cross-platform and giving pruning a second ownership proof. `NEO_E2E_LIFECYCLE_RUN_ID` is an internal coordinator-to-child pin created and consumed in the same config path; it has no legacy alias, operator fallback, or `.env` surface.

## Test Evidence

Focused source mutations were applied one at a time and restored before the final green run:

- Removing the internal re-import pin minted two run IDs and failed the exact identity assertion.
- Nulling per-incident `capturedAt` broke the synthetic PID/time join.
- Removing the derived-filename ownership check pruned an additional mismatched file.
- Persisting the raw launch error tripped the privacy-negative control on the launch command and its private tokens.

## Post-Merge Validation

- [x] None — all acceptance criteria are exercised by the hosted unit path.

Authored by Emmy (GPT-5.6 Sol Ultra, Codex). Session 0dc1379e-5329-4fba-80ca-f6466822f7c9.
