### PR TITLE
fix(agentos): remove the misleading token-limit header from wake prompts (#17685)

### DIFF
--- a/ai/daemons/wake/localWakeAdapters.mjs
+++ b/ai/daemons/wake/localWakeAdapters.mjs
@@ -46,15 +46,6 @@ export function formatLocalWakeDigest(envelope = {}) {
     );
     const lines = [`[WAKE][priority:${priority}] ${total} events for ${identity}:`];
 
-    // The session-cost line (AC-2): present only when the receiver's context gate
-    // probed the session successfully and attached the result to this envelope. Absent probe
-    // data means no field — and no line, so an unprobed wake stays noise-free.
-    const sessionContext = payload.sessionContext;
-
-    if (Number.isFinite(sessionContext?.contextTokens) && Number.isFinite(sessionContext?.maxContextTokens)) {
-        lines.push(`[session-context: ${formatContextTokens(sessionContext.contextTokens)} tokens, gate at ${formatContextTokens(sessionContext.maxContextTokens)}]`);
-    }
-
     if (breakdown.sent_to_me?.count > 0) {
         const latestPriority = normalizeWakePriority(latestMessage.priority);
         const prioritySuffix = latestPriority === priority ? '' : `, latest priority: ${latestPriority}`;
@@ -104,16 +95,6 @@ export function formatLocalWakeDigest(envelope = {}) {
     }
 
     return lines.join('\n');
-}
-
-/**
- * @summary Formats a token count the way the gate thresholds are written (250K, 45K).
- * @param {Number} value
- * @returns {String}
- * @private
- */
-function formatContextTokens(value) {
-    return value >= 1000 ? `${Math.round(value / 1000)}K` : String(value);
 }
 
 /**

--- a/test/playwright/unit/ai/daemons/wake/localWakeAdapters.spec.mjs
+++ b/test/playwright/unit/ai/daemons/wake/localWakeAdapters.spec.mjs
@@ -39,6 +39,22 @@ test.describe.serial('ai/daemons/wake/localWakeAdapters', () => {
         );
     });
 
+    test('the digest renders no session-context line regardless of probe state (AC-1)', () => {
+        // The envelope field survives for any future instrument — only its render died.
+        const probed = record('test');
+
+        probed.envelope.payload.sessionContext = {contextTokens: 45_000, maxContextTokens: 250_000};
+
+        expect(formatLocalWakeDigest(probed.envelope)).not.toContain('session-context');
+        // Absent probe data → no field → nothing to render either
+        expect(formatLocalWakeDigest(record('test').envelope)).not.toContain('session-context');
+        // A malformed field is treated as absent, never rendered half-formed
+        const malformed = record('test');
+
+        malformed.envelope.payload.sessionContext = {contextTokens: 'big'};
+
+        expect(formatLocalWakeDigest(malformed.envelope)).not.toContain('session-context');
+    });
 
     test('preserves strongest message priority and the pure-heartbeat lifecycle directive', () => {
         const mixed = record('test').envelope;

--- a/test/playwright/unit/ai/daemons/wake/localWakeAdapters.spec.mjs
+++ b/test/playwright/unit/ai/daemons/wake/localWakeAdapters.spec.mjs
@@ -39,26 +39,6 @@ test.describe.serial('ai/daemons/wake/localWakeAdapters', () => {
         );
     });
 
-    test('the session-context line rides the digest only when the gate attached probe data (AC-2)', () => {
-        const probed = record('test');
-
-        probed.envelope.payload.sessionContext = {contextTokens: 45_000, maxContextTokens: 250_000};
-
-        const probedDigest = formatLocalWakeDigest(probed.envelope);
-
-        expect(probedDigest).toContain('[session-context: 45K tokens, gate at 250K]');
-        // The line sits directly under the [WAKE] header, ahead of the breakdown bullets
-        expect(probedDigest.indexOf('[session-context:')).toBeLessThan(probedDigest.indexOf('1 message events'));
-
-        // Absent probe data → no field → no line (an unprobed wake stays noise-free)
-        expect(formatLocalWakeDigest(record('test').envelope)).not.toContain('session-context');
-        // A malformed field is treated as absent, never rendered half-formed
-        const malformed = record('test');
-
-        malformed.envelope.payload.sessionContext = {contextTokens: 'big'};
-
-        expect(formatLocalWakeDigest(malformed.envelope)).not.toContain('session-context');
-    });
 
     test('preserves strongest message priority and the pure-heartbeat lifecycle directive', () => {
         const mixed = record('test').envelope;


### PR DESCRIPTION
Resolves #17685

## The problem

The `[session-context: N tokens, gate at M]` header rendered into wake prompts reads as a context-occupancy gauge while actually measuring last-turn `input + cache.read` against the wake-deferral threshold — thresholds sized from Kimi-K3 economics that do not transfer across model families. Live specimen: a `231K/250K` header was read as "88% of context used" (operator-corrected; real window 1M, ~23%), which then drove a wrong operational decision.

## The fix

Remove the display block from `formatLocalWakeDigest` and its now-dead `formatContextTokens` helper. The context gate POLICY is untouched — oversized wakes still defer silently; the envelope still carries probed `sessionContext` for any future instrument. Only the misleading rendering dies.

## AC Evidence

| AC | Proof |
|---|---|
| AC-1 | Restored spec arm: a probed envelope (`payload.sessionContext` attached) renders no `session-context` line; unprobed + malformed-field absence arms retained alongside |
| AC-2 | Receiver spec arms asserting the *envelope payload* field remain green — the instrument survives the rendering removal |
| AC-3 | Full wake suite green at this head |

## Deltas from ticket

The original push deleted the stale spec arm instead of inverting it. Per review: that arm asserted the *rendered digest string* (AC-1), while the receiver-side envelope-payload arms assert the *field* (AC-2) and pass regardless of rendering — deletion therefore left AC-1 unasserted. The arm is now restored inverted: probed envelope in, `session-context` absence out.

## Test Evidence

Full wake suite locally at this head: 317 tests, green (one daemon-spec timing flake failed once in a combined run, passed on isolated rerun; module untouched by this diff). Exact-head CI receipt lands on push.

Evidence: L2 (unit arms over digest rendering + envelope payload) → L2 required (ACs govern prompt rendering only). Residual: none.

Authored by Eos (ox-alpha, OpenCode). Session 65095daf-eaf1-46e9-a02e-cc43fde4ec2d.

## Post-Merge Validation

None — rendering-only removal; the deferral policy and envelope instrumentation are covered by retained unit arms at this head.
