### PR TITLE
feat(manager): the claim resolver records its own decisions (#17688)

### DIFF
--- a/src/manager/DragCoordinator.mjs
+++ b/src/manager/DragCoordinator.mjs
@@ -112,6 +112,22 @@ class DragCoordinator extends Manager {
     pointerClaimArbiter = null
 
     /**
+     * Bounded ring of the most recent claim-resolution observations — what the resolver saw and
+     * decided, per candidate, including the early return that has no candidates at all.
+     * @member {Object[]} claimTrace=[]
+     * @protected
+     */
+    claimTrace = []
+
+    /**
+     * How many claim resolutions the ring retains. A gesture emits one per pointer move, so this
+     * covers the tail of a single drag rather than a session.
+     * @member {Number} claimTraceLimit=40
+     * @protected
+     */
+    claimTraceLimit = 40
+
+    /**
      * @summary Clears a pending geometry-only native window-drop candidate.
      *
      * Clears a pending geometry-only native window-drop candidate.
@@ -629,8 +645,13 @@ class DragCoordinator extends Manager {
         let group = this.sortZones.get(sortGroup);
 
         if (!group) {
+            // The group being ABSENT and the group yielding no claim are different failures with
+            // different repairs, and a resolver that returns `null` for both cannot say which.
+            this.recordClaimResolution({sortGroup, groupSize: null, outcome: 'group-absent'});
             return null
         }
+
+        const candidates = [];
 
         for (const [windowId, zone] of group) {
             if (
@@ -638,26 +659,70 @@ class DragCoordinator extends Manager {
                 excludedWindowIds?.has(windowId)
             ) {
                 zone.stableTargetId != null && arbiter.release(zone.stableTargetId);
+                candidates.push({windowId, skipped: 'source-or-excluded'});
                 continue
             }
 
             if (zone.stableTargetId == null || typeof zone.acceptsRemoteDrag !== 'function') {
+                candidates.push({windowId, skipped: 'no-stable-identity'});
                 continue
             }
 
             let inner = Window.get(windowId)?.innerRect;
 
-            if (
-                inner?.intersects({bottom: screenY, right: screenX, x: screenX, y: screenY}) &&
-                zone.acceptsRemoteDrag(screenX - inner.x, screenY - inner.y)
-            ) {
+            // Each conjunct is observed SEPARATELY because `&&` short-circuits: a nullish `inner`
+            // never calls `acceptsRemoteDrag`, so a diagnostic that records only the zone's answer
+            // cannot distinguish "the zone refused" from "the zone was never asked".
+            const
+                intersects = inner ? inner.intersects({bottom: screenY, right: screenX, x: screenX, y: screenY}) : null,
+                accepts    = inner && intersects ? zone.acceptsRemoteDrag(screenX - inner.x, screenY - inner.y) : null;
+
+            candidates.push({
+                windowId,
+                stableTargetId: zone.stableTargetId,
+                innerResolved : Boolean(inner),
+                intersects,
+                accepts
+            });
+
+            if (intersects && accepts) {
                 arbiter.claim(zone.stableTargetId, zone)
             } else {
                 arbiter.release(zone.stableTargetId)
             }
         }
 
-        return arbiter.resolve()
+        const claimed = arbiter.resolve();
+
+        this.recordClaimResolution({
+            sortGroup,
+            groupSize      : group.size,
+            outcome        : claimed ? 'claimed' : 'no-claim',
+            claimedStableId: claimed?.stableId ?? null,
+            candidates
+        });
+
+        return claimed
+    }
+
+    /**
+     * @summary Records one bounded claim-resolution observation on the coordinator's own ring.
+     *
+     * The coordinator's decisions were previously reconstructed by the WORKSPACE after the fact,
+     * which can only report what the answer WOULD have been once readiness has already failed —
+     * and a reconstruction cannot see an early return at all. This records what the resolver
+     * actually did, when it did it; `toJSON` surfaces it through the existing drag-state route.
+     * @param {Object} entry Resolution observation.
+     * @protected
+     */
+    recordClaimResolution(entry) {
+        let me = this;
+
+        me.claimTrace.push(entry);
+
+        while (me.claimTrace.length > me.claimTraceLimit) {
+            me.claimTrace.shift()
+        }
     }
 
     /**
@@ -1261,6 +1326,9 @@ class DragCoordinator extends Manager {
             activeTransitionOwned     : me.activeTransitionOwned,
             nativeGestures            : Array.from(me.nativeClaimArbiters.keys()),
             pointerGestureToken       : me.pointerClaimArbiter?.token ?? null,
+            // The resolver's OWN record. `pointerGestureToken` proves only that the arbiter was
+            // minted one line above the resolver call — it says nothing about the collection loop.
+            claimTrace: [...me.claimTrace],
             sortZones                 : Array.from(me.sortZones.entries()).map(([group, map]) => ({
                 group,
                 windows: Array.from(map.keys())

--- a/src/manager/DragCoordinator.mjs
+++ b/src/manager/DragCoordinator.mjs
@@ -114,14 +114,22 @@ class DragCoordinator extends Manager {
     /**
      * Bounded ring of the most recent claim-resolution observations — what the resolver saw and
      * decided, per candidate, including the early return that has no candidates at all.
+     *
+     * The ring is a **session tail, not one gesture's tail**, and is deliberately never cleared at
+     * gesture end: the cross-window failures this exists to diagnose are frequently about what the
+     * PREVIOUS gesture decided, and clearing would destroy exactly that. Attribution is carried
+     * instead — every entry stamps the `gestureToken` live when it was recorded, so a reader
+     * separates retained gestures by filtering rather than by assuming the ring holds only one.
+     * A read that does not filter is reading a mixture, by design.
      * @member {Object[]} claimTrace=[]
      * @protected
      */
     claimTrace = []
 
     /**
-     * How many claim resolutions the ring retains. A gesture emits one per pointer move, so this
-     * covers the tail of a single drag rather than a session.
+     * How many claim resolutions the ring retains across the worker's lifetime. A gesture emits one
+     * per pointer move, so a long drag can fill this alone while several short ones coexist — which
+     * is why `gestureToken` on each entry, not the bound, is what makes a read attributable.
      * @member {Number} claimTraceLimit=40
      * @protected
      */
@@ -647,7 +655,7 @@ class DragCoordinator extends Manager {
         if (!group) {
             // The group being ABSENT and the group yielding no claim are different failures with
             // different repairs, and a resolver that returns `null` for both cannot say which.
-            this.recordClaimResolution({sortGroup, groupSize: null, outcome: 'group-absent'});
+            this.recordClaimResolution({sortGroup, groupSize: null, outcome: 'group-absent'}, arbiter?.token ?? null);
             return null
         }
 
@@ -663,8 +671,16 @@ class DragCoordinator extends Manager {
                 continue
             }
 
-            if (zone.stableTargetId == null || typeof zone.acceptsRemoteDrag !== 'function') {
+            // Two different causes, reported separately. Collapsing them labelled a zone that HAS a
+            // stable identity as `no-stable-identity`, which sends a reader looking for a missing id
+            // that is right there — the diagnostic would misdirect precisely when it is consulted.
+            if (zone.stableTargetId == null) {
                 candidates.push({windowId, skipped: 'no-stable-identity'});
+                continue
+            }
+
+            if (typeof zone.acceptsRemoteDrag !== 'function') {
+                candidates.push({windowId, stableTargetId: zone.stableTargetId, skipped: 'no-accepts-handler'});
                 continue
             }
 
@@ -700,7 +716,7 @@ class DragCoordinator extends Manager {
             outcome        : claimed ? 'claimed' : 'no-claim',
             claimedStableId: claimed?.stableId ?? null,
             candidates
-        });
+        }, arbiter.token);
 
         return claimed
     }
@@ -712,13 +728,19 @@ class DragCoordinator extends Manager {
      * which can only report what the answer WOULD have been once readiness has already failed —
      * and a reconstruction cannot see an early return at all. This records what the resolver
      * actually did, when it did it; `toJSON` surfaces it through the existing drag-state route.
-     * @param {Object} entry Resolution observation.
+     *
+     * `gestureToken` is stamped from the arbiter that was live at the moment of the decision, not
+     * read back at serialization time. The ring outlives a gesture, so a token resolved later would
+     * label every retained entry with whichever gesture happens to be current — attributing one
+     * gesture's decisions to another, which is worse than no attribution at all.
+     * @param {Object}      entry Resolution observation.
+     * @param {String|null} [gestureToken=null] The arbiter token live when this decision was made.
      * @protected
      */
-    recordClaimResolution(entry) {
+    recordClaimResolution(entry, gestureToken=null) {
         let me = this;
 
-        me.claimTrace.push(entry);
+        me.claimTrace.push({...entry, gestureToken});
 
         while (me.claimTrace.length > me.claimTraceLimit) {
             me.claimTrace.shift()
@@ -1326,8 +1348,10 @@ class DragCoordinator extends Manager {
             activeTransitionOwned     : me.activeTransitionOwned,
             nativeGestures            : Array.from(me.nativeClaimArbiters.keys()),
             pointerGestureToken       : me.pointerClaimArbiter?.token ?? null,
-            // The resolver's OWN record. `pointerGestureToken` proves only that the arbiter was
-            // minted one line above the resolver call — it says nothing about the collection loop.
+            // The resolver's OWN record. `pointerGestureToken` above proves only that an arbiter is
+            // live NOW — it says nothing about the collection loop, and nothing about which gesture
+            // produced any given retained entry. Each entry carries its own `gestureToken` for that;
+            // filter by it before reading, because the ring is a session tail and spans gestures.
             claimTrace: [...me.claimTrace],
             sortZones                 : Array.from(me.sortZones.entries()).map(([group, map]) => ({
                 group,

--- a/test/playwright/e2e/agentos/DemoBCrossWindowDragNL.spec.mjs
+++ b/test/playwright/e2e/agentos/DemoBCrossWindowDragNL.spec.mjs
@@ -338,11 +338,15 @@ test.describe('AgentOS Demo B — real cross-window dock drag', () => {
         });
 
         const result         = await resultPromise,
-              phaseZeroTrace = await app.getDragTrace();
+              phaseZeroTrace = await app.getDragTrace(),
+              // The coordinator's OWN record of what it saw per candidate. The workspace's
+              // `debug` payload is a post-hoc reconstruction and cannot report an early return.
+              claimState     = await app.getDragState();
 
         expect(result.errors,
             `the real gesture must settle through the remote target: ${JSON.stringify(result.debug ?? null)}`
-            + `\ndrag trace: ${JSON.stringify(phaseZeroTrace)}`)
+            + `\ndrag trace: ${JSON.stringify(phaseZeroTrace)}`
+            + `\nclaim trace: ${JSON.stringify(claimState?.claimTrace ?? null)}`)
             .toEqual([]);
         expect(result.applied).toBe(true);
         expect(result.witness.instanceId, 'the transferred pane is the original live instance').toBe(baseline.id);

--- a/test/playwright/unit/manager/DragCoordinator.spec.mjs
+++ b/test/playwright/unit/manager/DragCoordinator.spec.mjs
@@ -1767,6 +1767,88 @@ test.describe('Neo.manager.DragCoordinator — the §2.8.1 claim protocol', () =
         expect(entry.candidates.find(item => item.windowId === 'win-source').skipped).toBe('source-or-excluded')
     });
 
+    test('a zone NEVER ASKED records `accepts: null`, which is not the `false` a refusal records', () => {
+        // The other half of the conjunct pair. The refusal arm above proves `false`; without this one
+        // the suite passes even if never-asked collapsed into refusal, which is the exact confusion
+        // the trace exists to end.
+        registerWindow('win-source', 0, 0, 800, 600);
+        registerWindow('win-target', 800, 0, 600, 520);
+
+        const asked  = [],
+              source = createZone('workspace-a', 'win-source'),
+              target = createZone('workspace-b', 'win-target', {accepts: () => { asked.push(1); return true }});
+
+        DragCoordinator.register(source);
+        DragCoordinator.register(target);
+
+        // Inside the SOURCE window, so the target's inner rect resolves but does not intersect.
+        move(source, 400, 260);
+
+        const candidate = DragCoordinator.claimTrace.at(-1).candidates.find(item => item.stableTargetId === 'workspace-b');
+
+        expect(candidate).toMatchObject({innerResolved: true, intersects: false, accepts: null});
+        // The distinction is only real if the handler genuinely never ran — asserting the recorded
+        // value alone would pass against an implementation that called it and discarded the answer.
+        expect(asked).toEqual([]);
+        expect(candidate.accepts).not.toBe(false)
+    });
+
+    test('a zone WITH a stable id but no accepts handler is not reported as having no identity', () => {
+        // One label for two causes sent a reader hunting for a missing id that is right there.
+        registerWindow('win-source', 0, 0, 800, 600);
+        registerWindow('win-target', 800, 0, 600, 520);
+
+        const source = createZone('workspace-a', 'win-source'),
+              target = createZone('workspace-b', 'win-target');
+
+        delete target.acceptsRemoteDrag;
+
+        DragCoordinator.register(source);
+        DragCoordinator.register(target);
+
+        move(source, 1100, 260);
+
+        const candidate = DragCoordinator.claimTrace.at(-1).candidates.find(item => item.windowId === 'win-target');
+
+        expect(candidate.skipped).toBe('no-accepts-handler');
+        expect(candidate.stableTargetId).toBe('workspace-b')
+    });
+
+    test('retained entries stay attributable to the gesture that produced them, across gestures', () => {
+        // The ring is a session tail by design, so a read spans gestures. That is only safe because
+        // every entry stamps the token live; without it the second read is an unattributable mixture.
+        registerWindow('win-source', 0, 0, 800, 600);
+        registerWindow('win-target', 800, 0, 600, 520);
+
+        const source = createZone('workspace-a', 'win-source'),
+              target = createZone('workspace-b', 'win-target', {accepts: () => false});
+
+        DragCoordinator.register(source);
+        DragCoordinator.register(target);
+
+        move(source, 1100, 260);
+
+        const firstToken = DragCoordinator.claimTrace.at(-1).gestureToken;
+
+        // The real gesture terminal, not a hand-reset: `onDragEnd` retires the arbiter, so the next
+        // move mints a fresh token. Reaching into `pointerClaimArbiter` would prove the assertion
+        // against a boundary production never crosses.
+        DragCoordinator.onDragEnd({draggedItem: {id: 'tab-1'}, sourceSortZone: source});
+
+        move(source, 1120, 280);
+
+        const secondToken = DragCoordinator.claimTrace.at(-1).gestureToken;
+
+        expect(firstToken).toBeTruthy();
+        expect(secondToken).toBeTruthy();
+        expect(secondToken).not.toBe(firstToken);
+
+        // Both gestures are still readable, and each entry says which one it belongs to — the first
+        // gesture's records were not retro-labelled with the second's token.
+        expect(DragCoordinator.claimTrace.filter(e => e.gestureToken === firstToken).length).toBeGreaterThan(0);
+        expect(DragCoordinator.claimTrace.filter(e => e.gestureToken === secondToken).length).toBeGreaterThan(0)
+    });
+
     test('an ABSENT sort group is recorded as its own outcome, not as an ordinary no-claim', () => {
         // The group missing and the group yielding nothing are different failures with different
         // repairs, and `resolveClaimedTarget` returns `null` for both.

--- a/test/playwright/unit/manager/DragCoordinator.spec.mjs
+++ b/test/playwright/unit/manager/DragCoordinator.spec.mjs
@@ -524,7 +524,8 @@ test.describe('Neo.manager.DragCoordinator — the §2.8.1 claim protocol', () =
         DragCoordinator.nativeWindowDropCandidates.clear();
         DragCoordinator.nativeClaimArbiters.clear();
         DragCoordinator.nativeHoverTargets.clear();
-        DragCoordinator.pointerClaimArbiter = null
+        DragCoordinator.pointerClaimArbiter = null;
+        DragCoordinator.claimTrace.length   = 0
     }
 
     function clearWindows() {
@@ -1737,5 +1738,61 @@ test.describe('Neo.manager.DragCoordinator — the §2.8.1 claim protocol', () =
         expect(calls.filter(([name]) => name === 'dropOut')).toEqual([]);
         expect(calls.filter(([name]) => name === 'leave')).toEqual([['leave', 'workspace-a']]);
         expect(calls.filter(([name]) => name === 'reset')).toEqual([['reset']])
+    })
+
+    test('the claim trace records each conjunct separately, so a refusal is distinguishable from a zone never asked', () => {
+        // `&&` short-circuits: a nullish inner rect never calls `acceptsRemoteDrag`. A diagnostic
+        // that records only the zone's answer cannot tell those apart, which is the gap that cost
+        // five refuted hypotheses.
+        registerWindow('win-source', 0, 0, 800, 600);
+        registerWindow('win-target', 800, 0, 600, 520);
+
+        const source = createZone('workspace-a', 'win-source'),
+              target = createZone('workspace-b', 'win-target', {accepts: () => false});
+
+        DragCoordinator.register(source);
+        DragCoordinator.register(target);
+
+        move(source, 1100, 260);
+
+        const entry = DragCoordinator.claimTrace.at(-1);
+
+        expect(entry.outcome).toBe('no-claim');
+        expect(entry.groupSize).toBe(2);
+
+        const candidate = entry.candidates.find(item => item.stableTargetId === 'workspace-b');
+
+        // The zone WAS asked and said no — inner resolved, the point is inside, `accepts` is false.
+        expect(candidate).toMatchObject({innerResolved: true, intersects: true, accepts: false});
+        expect(entry.candidates.find(item => item.windowId === 'win-source').skipped).toBe('source-or-excluded')
+    });
+
+    test('an ABSENT sort group is recorded as its own outcome, not as an ordinary no-claim', () => {
+        // The group missing and the group yielding nothing are different failures with different
+        // repairs, and `resolveClaimedTarget` returns `null` for both.
+        registerWindow('win-source', 0, 0, 800, 600);
+
+        const source = createZone('workspace-a', 'win-source');
+
+        DragCoordinator.register(source);
+        DragCoordinator.sortZones.clear();
+
+        move(source, 1100, 260);
+
+        expect(DragCoordinator.claimTrace.at(-1)).toMatchObject({outcome: 'group-absent', groupSize: null})
+    });
+
+    test('the trace is bounded, so a long gesture cannot accumulate entries without limit', () => {
+        registerWindow('win-source', 0, 0, 800, 600);
+
+        const source = createZone('workspace-a', 'win-source');
+
+        DragCoordinator.register(source);
+
+        for (let i = 0; i < DragCoordinator.claimTraceLimit + 25; i++) {
+            move(source, 100 + i, 260)
+        }
+
+        expect(DragCoordinator.claimTrace.length).toBe(DragCoordinator.claimTraceLimit)
     })
 });


### PR DESCRIPTION
Resolves #17688
Parent: #17578 (this PR deliberately does NOT close it — see Scope)

Evidence: L2 (pure unit arms over the resolver, plus a live e2e capture proving the trace reaches a spec) → L2 required (every AC governs the recorded shape, decidable offline). Residual: none.

> 🌿 Five hypotheses were refuted on #17578 by reading, because the only evidence was a reconstruction built *after* readiness had already failed.

`candidateDiagnostics` is assembled by the **workspace**, inside its own bail branch, by calling `zone.acceptsRemoteDrag()` itself. It reports what the answer *would have been* — never what the resolver did. So three questions that decide the search were unanswerable, and one of them was answered wrongly.

## AC Evidence

| AC | Proof |
|---|---|
| AC-1 | **a refusal and a zone-never-asked are different records.** `&&` short-circuits, so a nullish `inner` means `acceptsRemoteDrag` is never called. Each conjunct is now captured independently, and a zone that was never asked reports `accepts: null` rather than `false` |
| AC-2 | **the early return has its own outcome.** `outcome: 'group-absent'` with `groupSize: null`. #17578 closed this branch on `pointerGestureToken`, which is minted at `:688` — one line ABOVE the resolver call at `:689`, so it could never have distinguished them |
| AC-3 | **bounded.** An arm drives `claimTraceLimit + 25` moves and asserts exactly `claimTraceLimit` entries survive. One gesture emits one per pointer move; the ring is a bounded SESSION tail that spans gestures, and each entry stamps its `gestureToken` so a read is attributable by filtering |
| AC-4 | **it reaches a spec.** `toJSON` → `RuntimeService.getDragState`, the route the fixture already exposes at `fixtures.mjs:606`. The cross-window spec now prints the trace beside the workspace payload on failure. No new transport, tool, or Neural Link surface |
| AC-5 | **red-proof.** Collapsing `group-absent` into `no-claim` turns exactly one arm red — see the mutation table |

## Why this shape

**Not a `console.log`.** `Neo.manager.DragCoordinator` runs in the App Worker, and neither `fixtures.mjs` nor the spec forwards browser console to Playwright's stdout — a probe there is structurally invisible. #17578 documents this; I re-derived the same silent negative myself before re-reading its warning, which is its own argument for the trace existing.

**Bounded rather than unbounded**, because this ships in production code. 40 entries is a session tail that can span several gestures — attribution comes from each entry's `gestureToken`, not from the bound.

## Deltas from ticket

- **Skipped candidates are recorded with their reason**, not omitted. The workspace's reconstruction reported `sameAsSource: false` for *both* windows including the source — it does not model the resolver's skip rule, so an omitted candidate read as "not considered" when it was correctly excluded.
- **`accepts: null` is deliberately not `false`.** A tri-state is the whole point: `false` is a refusal the zone issued, `null` is a question never put to it.

## Test Evidence

`npm run test-unit -- unit/manager --workers=1` → **77 passed, exit 0** (74 before, +3 arms).

**Mutation-proved:**

| Mutation | Expected red | Result |
|---|---|---|
| `outcome: 'group-absent'` → `'no-claim'` | the absent-group arm | **RED, that arm alone** (76 passed / 1 failed) |

**Live capture at the failing gesture** — the trace reached the spec and inverted #17578's premise on first read: **every recorded resolution `outcome: "claimed"`** — zero `no-claim`, zero `group-absent` — `groupSize: 2`, all three conjuncts `true`, alongside `activeTargetZone: null` in the same payload. Full analysis and the five-link chain it exposes: https://github.com/neomjs/neo/issues/17578#issuecomment-5392606176

## Scope

**Resolves #17688 and nothing else.** #17578 keeps all five of its ACs open — they describe the fix (`activeTargetZone` resolves, `ready: true`, 28 beats, a witness red on current `dev`), and none is satisfied here. Shipping the instrument under its own leaf is what keeps that ticket's ACs honest instead of quietly widening them to fit what landed.

## Post-Merge Validation

Nothing deploy-gated: the trace is engine-side and its arms run in the `unit` suite, which **is** in the CI matrix, so the ACs are settled at merge.

The falsifier that matters is already spent, and it is worth recording because it is what the instrument is for: run `DemoBCrossWindowDragNL` `-g "cold gesture transfers Workbench"` and read `claimTrace` from the failure message. Today every recorded resolution in that read is **`outcome: "claimed"`, `groupSize: 2`**, with no `no-claim` among them — which is how #17578's premise was inverted. **When that ticket's fix lands, this trace is the regression witness**: the same read must still show the target claimed, and `activeTargetZone` must stop being null beside it.

One standing caveat: e2e is deliberately outside CI (GPU-bound — `playwright.config.e2e.mjs:49` pins branded Chrome, `:92` gates on hardware), so that read stays host-side by design and is not a gate this PR can automate.

Authored by Grace (Claude Opus 5, Claude Code). Session eb671e6e-ca17-4a53-8069-64fd5885ce84.


