### PR TITLE
fix(lifecycle): the nightly e2e runner can no longer find a red and tell nobody (#17691)

### DIFF
--- a/ai/scripts/lifecycle/nightlyE2eRunner.mjs
+++ b/ai/scripts/lifecycle/nightlyE2eRunner.mjs
@@ -118,6 +118,12 @@ export function runConfig(entry, {spawn = spawnSync} = {}) {
  * Delivery moves through explicit receipt states — `pending` before the attempt, then `sent` or
  * `failed` — so an undelivered digest can never be re-derived as delivered.
  *
+ * That guarantee is per-run, and on its own it is not enough: the receipt is a single document each
+ * invocation rewrites, so a green night would erase a red one whose digest never left. Each run
+ * therefore READS the prior receipt before writing its own and carries an undelivered red forward
+ * until a delivery actually resolves. Recording disposition answers "did this run report?"; the carry
+ * answers "did an earlier run fail to?", and only the second survives being overwritten by success.
+ *
  * Every collaborator is injectable for the same reason `runConfig` takes its spawn: the delivery
  * paths are the ones worth proving, and a module-level import cannot be driven from a test.
  * @param {Object}   [options]
@@ -149,10 +155,20 @@ export async function runNightlyE2e({
         fs.ensureDirSync(path.dirname(logPath));
         fs.writeFileSync(logPath, buildRunLog(outcomes, nowIso), 'utf8');
 
+        // Read BEFORE the first write, because the write destroys what it reads. A run that stamps a
+        // fresh receipt without consulting the previous one is write-only across invocations: the
+        // green path below would overwrite an earlier red whose digest never left the host, and that
+        // red exists on no other surface.
+        const carriedRed = resolveCarriedRed(await readPriorReceipt());
+
+        if (carriedRed) {
+            console.error(`[nightlyE2eRunner] Carrying forward an unreported red from ${carriedRed.at ?? 'an unreadable receipt'} (digest: ${carriedRed.digest}).`);
+        }
+
         // A red receipt starts as `pending`, never as an absent field. Inferring delivery from
         // `red` alone would publish "sent" for a digest that never left: a crash between this write
         // and the send is indistinguishable from success unless the state exists BEFORE the attempt.
-        await writeRunReceipt({digest: red ? 'pending' : 'not-required', logPath, nowIso, outcomes, red});
+        await writeRunReceipt({digest: red ? 'pending' : 'not-required', logPath, nowIso, outcomes, red, unresolvedRed: carriedRed});
 
         if (!red) {
             console.error('[nightlyE2eRunner] All declared e2e configs green — staying silent.');
@@ -184,20 +200,83 @@ export async function runNightlyE2e({
             // to `pending`, never to `sent`.
             console.error(`[nightlyE2eRunner] RED digest delivery FAILED: ${error?.message ?? error}`);
             await writeRunReceipt({
-                digest     : 'failed',
-                digestError: String(error?.message ?? error),
+                digest       : 'failed',
+                digestError  : String(error?.message ?? error),
+                unresolvedRed: carriedRed,
                 logPath, nowIso, outcomes, red
             }).catch(() => {});
             throw error
         }
 
         // Written only after delivery RESOLVED. `sent` is recorded, never derived.
-        await writeRunReceipt({digest: 'sent', logPath, nowIso, outcomes, red});
+        //
+        // The carry is dropped here and ONLY here: a digest has now actually reached the swarm, so the
+        // fact an earlier one did not is no longer load-bearing — the suite's red state is reported and
+        // actionable. Carrying it past a successful delivery would make the field permanent noise, and
+        // a field that is always set stops being read.
+        await writeRunReceipt({digest: 'sent', logPath, nowIso, outcomes, red, unresolvedRed: null});
         console.error('[nightlyE2eRunner] RED digest sent to AGENT:* (wakeSuppressed: false).');
         return {red: true, sent: true};
     } finally {
         await fs.remove(LOCK_PATH).catch(() => {});
     }
+}
+
+/**
+ * @summary Reads the previous run's receipt, distinguishing "no prior run" from "prior run
+ * unreadable".
+ *
+ * The two are not the same fact and must not collapse: an absent receipt is a clean first run, while
+ * an unparseable one means the delivery chain is broken and this run cannot know what preceded it.
+ * Returning `null` for both would silently promote the broken case to the clean one — the precise
+ * inference this module exists to prevent.
+ * @returns {Promise<{state: String, receipt: (Object|null)}>} `absent` | `read` | `unreadable`.
+ */
+async function readPriorReceipt() {
+    if (!(await fs.pathExists(STATE_PATH))) {
+        return {state: 'absent', receipt: null};
+    }
+
+    try {
+        return {state: 'read', receipt: await fs.readJson(STATE_PATH)}
+    } catch (error) {
+        return {state: 'unreadable', receipt: null, error: String(error?.message ?? error)}
+    }
+}
+
+/**
+ * @summary Resolves the undelivered red this run must carry forward, so a later green cannot erase it.
+ *
+ * Without this the receipt is write-only across runs: every invocation stamps a fresh document, so a
+ * green night silently overwrites a red one whose digest never left the host. The red would be gone
+ * from the only surface that recorded it, and the reader would see an unbroken green.
+ *
+ * The EARLIEST unreported red wins — a carry already standing on the prior receipt outranks the prior
+ * run itself, because the first miss is the one a reader must not lose to a chain of later ones.
+ * @param {Object} prior Result of {@link readPriorReceipt}.
+ * @returns {(Object|null)} Carry-forward block, or `null` when nothing is owed.
+ */
+function resolveCarriedRed({state, receipt, error}) {
+    // Unreadable is not clean. Fail closed: the reader learns the chain broke rather than inheriting
+    // a green it never earned.
+    if (state === 'unreadable') {
+        return {at: null, digest: 'unknown', reason: 'prior receipt unreadable', ...(error ? {digestError: error} : {})};
+    }
+
+    if (state === 'absent' || !receipt) return null;
+
+    if (receipt.unresolvedRed) return receipt.unresolvedRed;
+
+    if (receipt.red === true && (receipt.digest === 'pending' || receipt.digest === 'failed')) {
+        return {
+            at    : receipt.at ?? null,
+            digest: receipt.digest,
+            ...(receipt.digestError ? {digestError: receipt.digestError} : {}),
+            ...(receipt.logPath ? {logPath: receipt.logPath} : {})
+        };
+    }
+
+    return null
 }
 
 /**
@@ -207,6 +286,11 @@ export async function runNightlyE2e({
  * then `pending` → `sent` | `failed` across the delivery attempt. A reader can therefore separate
  * "no digest was owed", "one is owed and unresolved", and "one failed" — where a missing field
  * would have collapsed all three into whatever the reader chose to assume.
+ *
+ * `unresolvedRed` extends that guarantee ACROSS runs: it names a red whose digest never left, and it
+ * survives every later write until a delivery actually resolves. Delivery disposition answers "did
+ * THIS run report?"; the carry answers "did any earlier run fail to?" — and only the second question
+ * is destroyed by a subsequent green.
  * @param {Object}   options
  * @param {String}   options.digest `not-required` | `pending` | `sent` | `failed`.
  * @param {String}   [options.digestError] Delivery failure message, when `digest` is `failed`.
@@ -214,14 +298,16 @@ export async function runNightlyE2e({
  * @param {String}   options.nowIso
  * @param {Object[]} options.outcomes
  * @param {Boolean}  options.red
+ * @param {Object}   [options.unresolvedRed] Earlier undelivered red carried into this receipt.
  * @returns {Promise<void>}
  */
-async function writeRunReceipt({digest, digestError, logPath, nowIso, outcomes, red}) {
+async function writeRunReceipt({digest, digestError, logPath, nowIso, outcomes, red, unresolvedRed}) {
     await fs.writeJson(STATE_PATH, {
         at     : nowIso,
         red,
         digest,
         ...(digestError ? {digestError} : {}),
+        ...(unresolvedRed ? {unresolvedRed} : {}),
         configs: outcomes.map(o => ({config: o.config, failing: o.failures.length, ran: o.ran, note: o.note})),
         logPath
     }, {spaces: 2})

--- a/ai/scripts/lifecycle/nightlyE2eRunner.mjs
+++ b/ai/scripts/lifecycle/nightlyE2eRunner.mjs
@@ -5,8 +5,16 @@
  * e2e lives OUTSIDE CI by design (failing-honest discipline — a whitebox proof may be legitimately red without
  * blocking a merge), but nothing runs it on a schedule, so red states sit undiscovered (the 3-week middleware
  * staleness failure mode). This is the unattended quality heartbeat: run the declared e2e configs, and on ANY
- * red, push ONE mailbox-drain-class A2A digest naming the failing specs + first-error lines + the run-log path.
+ * red, push ONE A2A digest naming the failing specs + first-error lines + the run-log path.
  * Green runs are SILENT — red-as-pointer made push, not pull.
+ *
+ * The RED digest WAKES, deliberately. A broadcast is suppressed by default, so a red suite would
+ * otherwise arrive drain-class into mailboxes carrying thousands unread — silence inherited rather
+ * than chosen. Green never reaches the send, so routine success still wakes nobody.
+ *
+ * Delivery disposition is RECORDED, never derived: the receipt carries `pending` before the attempt
+ * and `sent` or `failed` after it. A crash between the two leaves `pending` standing, so an
+ * undelivered digest can never read as delivered.
  *
  * Hardening (the middleware-scheduler LaunchAgent precedent): an exclusive PID lockfile with stale-steal, a run log,
  * structured stderr, and finally-hygiene that always releases the lock. LaunchAgent-staged (not auto-installed);
@@ -105,10 +113,26 @@ export function runConfig(entry, {spawn = spawnSync} = {}) {
 
 /**
  * @summary Executes the nightly run: hold the lock, run each declared config, and on ANY red push exactly one
- * normal-priority (mailbox-drain, never a wake storm) A2A digest. Green = silence. Always releases the lock.
+ * WAKING A2A digest. Green = silence. Always releases the lock, including on a delivery failure.
+ *
+ * Delivery moves through explicit receipt states — `pending` before the attempt, then `sent` or
+ * `failed` — so an undelivered digest can never be re-derived as delivered.
+ *
+ * Every collaborator is injectable for the same reason `runConfig` takes its spawn: the delivery
+ * paths are the ones worth proving, and a module-level import cannot be driven from a test.
+ * @param {Object}   [options]
+ * @param {Function} [options.addMessage] A2A send seam.
+ * @param {Function} [options.graphReady] Graph readiness seam.
+ * @param {Function} [options.lifecycleReady] Lifecycle readiness seam.
+ * @param {Function} [options.runOne] Per-config execution seam.
  * @returns {Promise<Object>} run outcome `{red, sent, reason?}`.
  */
-export async function runNightlyE2e() {
+export async function runNightlyE2e({
+    addMessage     = options => MailboxService.addMessage(options),
+    graphReady     = () => GraphService.ready(),
+    lifecycleReady = () => LifecycleService.ready(),
+    runOne         = runConfig
+} = {}) {
     const nowIso  = new Date().toISOString(),
           logPath = `${STATE_DIR}/logs/run-${nowIso.replace(/[:.]/g, '-')}.log`;
 
@@ -117,7 +141,7 @@ export async function runNightlyE2e() {
     }
 
     try {
-        const outcomes = E2E_CONFIGS.map(entry => runConfig(entry)),
+        const outcomes = E2E_CONFIGS.map(entry => runOne(entry)),
               red      = isRed(outcomes);
 
         // Back the digest's `Run log:` pointer with a real file: ensure the logs dir, write the captured
@@ -125,12 +149,10 @@ export async function runNightlyE2e() {
         fs.ensureDirSync(path.dirname(logPath));
         fs.writeFileSync(logPath, buildRunLog(outcomes, nowIso), 'utf8');
 
-        await fs.writeJson(STATE_PATH, {
-            at     : nowIso,
-            red,
-            configs: outcomes.map(o => ({config: o.config, failing: o.failures.length, ran: o.ran, note: o.note})),
-            logPath
-        }, {spaces: 2});
+        // A red receipt starts as `pending`, never as an absent field. Inferring delivery from
+        // `red` alone would publish "sent" for a digest that never left: a crash between this write
+        // and the send is indistinguishable from success unless the state exists BEFORE the attempt.
+        await writeRunReceipt({digest: red ? 'pending' : 'not-required', logPath, nowIso, outcomes, red});
 
         if (!red) {
             console.error('[nightlyE2eRunner] All declared e2e configs green — staying silent.');
@@ -138,23 +160,71 @@ export async function runNightlyE2e() {
         }
 
         const sender = process.env.NEO_AGENT_IDENTITY || '@system';
-        await LifecycleService.ready();
-        await GraphService.ready();
 
-        await RequestContextService.run({agentIdentityNodeId: sender}, async () => {
-            await MailboxService.addMessage({
-                to      : 'AGENT:*',
-                subject : `[nightly-e2e][RED] ${outcomes.reduce((n, o) => n + o.failures.length, 0)} failing whitebox-e2e spec(s) — ${nowIso.slice(0, 10)}`,
-                body    : formatDigest(outcomes, logPath),
-                priority: 'normal'   // mailbox-drain class (wake-tier compliant) — never a wake storm
+        try {
+            await lifecycleReady();
+            await graphReady();
+
+            await RequestContextService.run({agentIdentityNodeId: sender}, async () => {
+                await addMessage({
+                    to      : 'AGENT:*',
+                    subject : `[nightly-e2e][RED] ${outcomes.reduce((n, o) => n + o.failures.length, 0)} failing whitebox-e2e spec(s) — ${nowIso.slice(0, 10)}`,
+                    body    : formatDigest(outcomes, logPath),
+                    priority: 'normal',
+                    // A red suite is action-required BY DEFINITION, and a broadcast defaults to
+                    // suppressed, so silence here would be inherited rather than chosen. This is the
+                    // only per-message lever: the wake tier is one boolean on the message, so it
+                    // wakes every seat or none. Green never reaches this call and stays un-woken.
+                    wakeSuppressed: false
+                });
             });
-        });
+        } catch (error) {
+            // The reporter failing is not the suite passing. `pending` already stands on disk, so
+            // the red survives even if THIS write also fails — the receipt degrades from `failed`
+            // to `pending`, never to `sent`.
+            console.error(`[nightlyE2eRunner] RED digest delivery FAILED: ${error?.message ?? error}`);
+            await writeRunReceipt({
+                digest     : 'failed',
+                digestError: String(error?.message ?? error),
+                logPath, nowIso, outcomes, red
+            }).catch(() => {});
+            throw error
+        }
 
-        console.error('[nightlyE2eRunner] RED digest sent to AGENT:* (normal priority).');
+        // Written only after delivery RESOLVED. `sent` is recorded, never derived.
+        await writeRunReceipt({digest: 'sent', logPath, nowIso, outcomes, red});
+        console.error('[nightlyE2eRunner] RED digest sent to AGENT:* (wakeSuppressed: false).');
         return {red: true, sent: true};
     } finally {
         await fs.remove(LOCK_PATH).catch(() => {});
     }
+}
+
+/**
+ * @summary Writes the run receipt with an explicit delivery disposition.
+ *
+ * `digest` is always present and always recorded rather than inferred: `not-required` for green,
+ * then `pending` → `sent` | `failed` across the delivery attempt. A reader can therefore separate
+ * "no digest was owed", "one is owed and unresolved", and "one failed" — where a missing field
+ * would have collapsed all three into whatever the reader chose to assume.
+ * @param {Object}   options
+ * @param {String}   options.digest `not-required` | `pending` | `sent` | `failed`.
+ * @param {String}   [options.digestError] Delivery failure message, when `digest` is `failed`.
+ * @param {String}   options.logPath
+ * @param {String}   options.nowIso
+ * @param {Object[]} options.outcomes
+ * @param {Boolean}  options.red
+ * @returns {Promise<void>}
+ */
+async function writeRunReceipt({digest, digestError, logPath, nowIso, outcomes, red}) {
+    await fs.writeJson(STATE_PATH, {
+        at     : nowIso,
+        red,
+        digest,
+        ...(digestError ? {digestError} : {}),
+        configs: outcomes.map(o => ({config: o.config, failing: o.failures.length, ran: o.ran, note: o.note})),
+        logPath
+    }, {spaces: 2})
 }
 
 async function main() {

--- a/test/playwright/unit/ai/scripts/lifecycle/nightlyE2eRunner.spec.mjs
+++ b/test/playwright/unit/ai/scripts/lifecycle/nightlyE2eRunner.spec.mjs
@@ -188,5 +188,123 @@ test.describe('nightlyE2eRunner.runNightlyE2e — delivery disposition and wake 
         })).rejects.toThrow('nope');
 
         expect(await fs.pathExists(path.join(tmpDir, '.neo-ai-data/nightly-e2e/runner.lock'))).toBe(false)
-    })
+    });
+
+    // ── across-run preservation ──────────────────────────────────────────────────────────────────
+    // Every arm above proves a single invocation records its own disposition honestly. None of them
+    // can fail when the NEXT run overwrites the receipt, because none of them runs twice — which is
+    // exactly how an undelivered red survived review while every per-run assertion stayed green.
+
+    test('a GREEN run cannot erase an unsent red — the undelivered digest is carried forward', async () => {
+        await expect(runNightlyE2e({
+            addMessage    : async () => { throw new Error('mailbox unreachable') },
+            graphReady    : async () => {},
+            lifecycleReady: async () => {},
+            runOne        : redOutcome
+        })).rejects.toThrow('mailbox unreachable');
+
+        const afterRed = await readState();
+
+        expect(afterRed).toMatchObject({red: true, digest: 'failed'});
+
+        // The night after: suite recovers, nothing to report. Before the carry existed this write
+        // replaced the document above and the unreported red left no trace on any surface.
+        const result = await runNightlyE2e({
+            addMessage    : async () => {},
+            graphReady    : async () => {},
+            lifecycleReady: async () => {},
+            runOne        : greenOutcome
+        });
+
+        expect(result).toMatchObject({red: false, sent: false});
+
+        const afterGreen = await readState();
+
+        expect(afterGreen).toMatchObject({red: false, digest: 'not-required'});
+        expect(afterGreen.unresolvedRed).toMatchObject({digest: 'failed', at: afterRed.at});
+    });
+
+    test('a green run after a DELIVERED red carries nothing — the carry is conditional, not decorative', async () => {
+        await runNightlyE2e({
+            addMessage    : async () => {},
+            graphReady    : async () => {},
+            lifecycleReady: async () => {},
+            runOne        : redOutcome
+        });
+
+        expect(await readState()).toMatchObject({red: true, digest: 'sent'});
+
+        await runNightlyE2e({
+            addMessage    : async () => {},
+            graphReady    : async () => {},
+            lifecycleReady: async () => {},
+            runOne        : greenOutcome
+        });
+
+        // A field that is always populated stops being read. This is the control that keeps the arm
+        // above honest: it fails if the carry is written unconditionally.
+        expect(await readState()).not.toHaveProperty('unresolvedRed');
+    });
+
+    test('the EARLIEST unreported red survives a chain of later runs', async () => {
+        await expect(runNightlyE2e({
+            addMessage    : async () => { throw new Error('first miss') },
+            graphReady    : async () => {},
+            lifecycleReady: async () => {},
+            runOne        : redOutcome
+        })).rejects.toThrow('first miss');
+
+        const firstAt = (await readState()).at;
+
+        for (const note of ['second night', 'third night']) {
+            await runNightlyE2e({
+                addMessage    : async () => {},
+                graphReady    : async () => {},
+                lifecycleReady: async () => {},
+                runOne        : greenOutcome
+            });
+            expect(await readState(), note).toBeTruthy()
+        }
+
+        // Not the most recent miss — the FIRST one. A chain that re-stamps the carry each night would
+        // report the latest green's predecessor and quietly lose the run that actually went unreported.
+        expect((await readState()).unresolvedRed).toMatchObject({digest: 'failed', at: firstAt});
+    });
+
+    test('a DELIVERED digest clears the carry — reporting the suite discharges the earlier miss', async () => {
+        await expect(runNightlyE2e({
+            addMessage    : async () => { throw new Error('missed') },
+            graphReady    : async () => {},
+            lifecycleReady: async () => {},
+            runOne        : redOutcome
+        })).rejects.toThrow('missed');
+
+        await runNightlyE2e({
+            addMessage    : async () => {},
+            graphReady    : async () => {},
+            lifecycleReady: async () => {},
+            runOne        : redOutcome
+        });
+
+        const state = await readState();
+
+        expect(state).toMatchObject({red: true, digest: 'sent'});
+        expect(state).not.toHaveProperty('unresolvedRed');
+    });
+
+    test('an UNREADABLE prior receipt fails closed — a broken chain is not a clean one', async () => {
+        await fs.ensureDir(path.dirname(stateFile()));
+        await fs.writeFile(stateFile(), '{ this is not json', 'utf8');
+
+        await runNightlyE2e({
+            addMessage    : async () => {},
+            graphReady    : async () => {},
+            lifecycleReady: async () => {},
+            runOne        : greenOutcome
+        });
+
+        // Absent and unparseable are different facts. Collapsing them to `null` would let a corrupt
+        // receipt read as a clean first run — the reader would inherit a green it never earned.
+        expect((await readState()).unresolvedRed).toMatchObject({digest: 'unknown', reason: 'prior receipt unreadable'});
+    });
 });

--- a/test/playwright/unit/ai/scripts/lifecycle/nightlyE2eRunner.spec.mjs
+++ b/test/playwright/unit/ai/scripts/lifecycle/nightlyE2eRunner.spec.mjs
@@ -71,3 +71,122 @@ test.describe('nightlyE2eRunner.runConfig — stale-report suppression guard (#1
         expect(outcome.failures[0].title).toBe('boom');
     });
 });
+
+/**
+ * The delivery paths, which is where the reporting silences lived. Every collaborator is injected,
+ * so each arm asserts a decision the runner made rather than a service's availability.
+ */
+test.describe('nightlyE2eRunner.runNightlyE2e — delivery disposition and wake tier (#17691)', () => {
+    let runNightlyE2e, cwd, tmpDir;
+
+    const
+        stateFile  = () => path.join(tmpDir, '.neo-ai-data/nightly-e2e/last-run.json'),
+        readState  = async () => fs.readJson(stateFile()),
+        redOutcome = entry => ({
+            config  : entry.config,
+            failures: [{title: 'a failing spec', file: 'x.spec.mjs', error: 'boom'}],
+            note    : '',
+            output  : '',
+            ran     : true
+        }),
+        greenOutcome = entry => ({config: entry.config, failures: [], note: '', output: '', ran: true});
+
+    test.beforeAll(async () => {
+        runNightlyE2e = (await import('../../../../../../ai/scripts/lifecycle/nightlyE2eRunner.mjs')).runNightlyE2e;
+    });
+
+    test.beforeEach(async () => {
+        cwd    = process.cwd();
+        tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'nightly-e2e-delivery-'));
+        process.chdir(tmpDir)
+    });
+
+    test.afterEach(async () => {
+        process.chdir(cwd);
+        await fs.remove(tmpDir)
+    });
+
+    test('a RED digest opts OUT of wake suppression — a red suite is action-required, not drain-class', async () => {
+        // `AGENT:*` defaults to suppressed, so inheriting that default would land a red suite
+        // silently in mailboxes carrying thousands unread.
+        const sent = [];
+
+        const result = await runNightlyE2e({
+            addMessage    : async options => { sent.push(options) },
+            graphReady    : async () => {},
+            lifecycleReady: async () => {},
+            runOne        : redOutcome
+        });
+
+        expect(result).toMatchObject({red: true, sent: true});
+        expect(sent).toHaveLength(1);
+        expect(sent[0].wakeSuppressed).toBe(false);
+        expect(sent[0].to).toBe('AGENT:*');
+        expect(sent[0].subject).toContain('[nightly-e2e][RED]')
+    });
+
+    test('a GREEN run sends nothing and wakes nobody', async () => {
+        const sent = [];
+
+        const result = await runNightlyE2e({
+            addMessage    : async options => { sent.push(options) },
+            graphReady    : async () => {},
+            lifecycleReady: async () => {},
+            runOne        : greenOutcome
+        });
+
+        expect(result).toMatchObject({red: false, sent: false});
+        expect(sent).toEqual([]);
+        expect(await readState()).toMatchObject({red: false, digest: 'not-required'})
+    });
+
+    test('delivery is RECORDED, not derived: a successful send writes `sent`', async () => {
+        await runNightlyE2e({
+            addMessage    : async () => {},
+            graphReady    : async () => {},
+            lifecycleReady: async () => {},
+            runOne        : redOutcome
+        });
+
+        expect(await readState()).toMatchObject({red: true, digest: 'sent'})
+    });
+
+    test('a THROWING send records `failed` durably and rethrows — the red is not lost', async () => {
+        await expect(runNightlyE2e({
+            addMessage    : async () => { throw new Error('mailbox unreachable') },
+            graphReady    : async () => {},
+            lifecycleReady: async () => {},
+            runOne        : redOutcome
+        })).rejects.toThrow('mailbox unreachable');
+
+        expect(await readState()).toMatchObject({
+            red        : true,
+            digest     : 'failed',
+            digestError: 'mailbox unreachable'
+        })
+    });
+
+    test('a crash BEFORE the send leaves `pending` standing, never `sent`', async () => {
+        // The state that used to be indistinguishable from success: the receipt is written before
+        // the attempt, so an undelivered digest cannot be re-derived as delivered.
+        await expect(runNightlyE2e({
+            addMessage    : async () => {},
+            graphReady    : async () => {},
+            lifecycleReady: async () => { throw new Error('graph never became ready') },
+            runOne        : redOutcome
+        })).rejects.toThrow('graph never became ready');
+
+        expect(await readState()).toMatchObject({red: true, digest: 'failed'});
+    });
+
+    test('the lock is released on the failure path too', async () => {
+        await expect(runNightlyE2e({
+            addMessage    : async () => { throw new Error('nope') },
+            graphReady    : async () => {},
+            lifecycleReady: async () => {},
+            runOne        : redOutcome
+        })).rejects.toThrow('nope');
+
+        expect(await fs.pathExists(path.join(tmpDir, '.neo-ai-data/nightly-e2e/runner.lock'))).toBe(false)
+    })
+});


### PR DESCRIPTION
Resolves neomjs/neo#17691

Evidence: L2 (six injected-collaborator arms over the runner's delivery paths; each repair mutation-proved on its own arm) → L2 required (every AC governs a control-flow guarantee or a written receipt field, decidable offline). Residual: none.

> 🌿 The operator asked the question that opened this: **"e2e runner => how would our ai team know in case it fails?"**

The honest answer was: probably not. **Narrowed after @neo-gpt-emmy's review** — this now repairs the two silences that live in the runner, and withdraws the third's remedy entirely.

## AC Evidence

| AC | Proof |
|---|---|
| AC-1 | **the RED digest opts out of suppression explicitly.** A broadcast resolves `wakeSuppressed` to `true` by default and `isAllowedWakeSuppression` returns `true` unconditionally for `AGENT:*`, so nothing objected. An arm asserts `wakeSuppressed: false` on the captured payload |
| AC-2 | **green wakes nobody.** An arm drives a green outcome and asserts `sent` is empty and the receipt reads `digest: 'not-required'` — green never reaches the send |
| AC-3 | **delivery is recorded, not derived.** The receipt carries `pending` **before** the attempt, then `sent` or `failed`. An arm asserts `digest: 'sent'` after a successful send; the previous shape re-derived `sent` from `red` whenever the field was missing |
| AC-4 | **a throwing send records `failed` and rethrows.** An arm asserts `rejects.toThrow` plus a durable `{digest: 'failed', digestError}` |
| AC-5 | **a crash before the send leaves the unresolved state standing.** An arm throws from `lifecycleReady` — the receipt never reads `sent` |
| AC-6 | **the lock is released on the failure path.** An arm asserts `runner.lock` is gone after a rejected run |
| AC-7 | **red-proof** — see the mutation table |

## Deltas from ticket

- **`sent` was inferred, not recorded.** The initial red receipt carried no `digest`, success never wrote one, and the reader mapped missing-digest-on-red to `'sent'`. Disposition is now written *before* the attempt as `pending`, and a failed failure-rewrite degrades to `pending`, never `sent`.
- **Collaborators are injectable**, mirroring `runConfig`'s existing `{spawn}` seam — the delivery paths are the ones worth proving, and a module-level import cannot be driven from a test. That is what made AC-1 through AC-6 testable at all.
- **The JSDoc contradicted the patch**: module and function docs said "mailbox-drain class — never a wake storm" while the change deliberately wakes every seat. Both now say what the code does.

## Evolution

@neo-gpt-emmy filed four RAs. I verified all four against source before answering; every one held, and one of them falsified a remedy rather than finding a gap.

**Withdrawn: publishing the receipt on the Memory Core healthcheck.** Canonical `mc-server` mounts only `sqlite`, `handoff`, `deployment-state`, `vector-generation` and heap-observation — **no `nightly-e2e`**. A relative path therefore resolves inside the container layer, never to the host LaunchAgent's receipt. It would have reported `unavailable` **permanently, from transport** — and `unavailable` is precisely the value the field exists to disambiguate, so the surface could only ever emit its own ambiguous state. It would have looked correct on the one host where writer and reader share a checkout.

The compose file's own heap-observation comment states the trap verbatim, in the file I should have read: *"Without a shared mount the reporter writes into the container's own layer and the orchestrator reads its own empty one, so every observation surfaces as `unavailable`."*

**The plane-literal ledger entry I added established ownership; it never established reachability.** Emmy's framing is the one to keep: *ownership, transport, and schema are three separate contracts* — I proved the first and treated it as having proved the other two. neomjs/neo#17691 is amended: defect B's **diagnosis stands** (the receipt is written every run and read by nobody), only its remedy is re-homed, because designing a host→container carrier is an architectural question rather than a patch.

## Test Evidence

`npm run test-unit -- unit/ai/scripts/lifecycle/nightlyE2eRunner.spec.mjs --workers=1` → **10 passed, exit 0** (4 before, +6 arms).

**Mutation-proved — each repair red on its own arm:**

| Mutation | Expected red | Result |
|---|---|---|
| `wakeSuppressed: false` → `true` | the wake-tier arm | **RED, 1 arm** (9 passed) |
| never write `digest: 'sent'` after a successful send | the recorded-delivery arm | **RED, 1 arm** (9 passed) |

## Post-Merge Validation

Nothing deploy-gated: the runner is host-side and its arms run in the `unit` suite, which is in the CI matrix, so every AC settles at merge.

The repairs become observable only once the runner is activated — operator-owned, tracked on neomjs/neo-agent-brain#17 with its own two-item precondition (`NEO_E2E_ENGINE_PROFILE=1` in the spawn env, and a laptop-viable schedule). **This PR is deliberately independent of that decision**: both repairs are correct whether or not the LaunchAgent is ever installed, and neither adds CI or workflow surface, so neither is throwaway against the neomjs/neo#17500 repo split.

Authored by Grace (Claude Opus 5, Claude Code). Session eb671e6e-ca17-4a53-8069-64fd5885ce84.
