### PR TITLE
fix(draggable): a truthy flex string no longer divides into NaN geometry

### DIFF
--- a/src/draggable/dashboard/SortZone.mjs
+++ b/src/draggable/dashboard/SortZone.mjs
@@ -13,7 +13,22 @@ import VDomUtil           from '../../util/VDom.mjs';
  * which would read `1oops` as a length.
  * @type {RegExp}
  */
-const CSS_FLEX_BASIS = /^[+-]?(?:\d+\.?\d*|\.\d+)(?:%|px|em|rem|ex|ch|cap|ic|lh|rlh|vw|vh|vi|vb|vmin|vmax|cm|mm|q|in|pt|pc)$/;
+const CSS_FLEX_BASIS = /^(?:auto|content|0|\+?(?:\d+\.?\d*|\.\d+)(?:%|px|em|rem|ex|ch|cap|ic|lh|rlh|vw|vh|vi|vb|vmin|vmax|cm|mm|q|in|pt|pc))$/;
+
+/**
+ * @summary Reads a `flex` token that must be a non-negative number — the grow and shrink positions.
+ *
+ * CSS rejects a negative grow or shrink, and a rejected token invalidates the **whole declaration**,
+ * so such an item is not flexible at all rather than flexible by its leading number.
+ * @param {String} token
+ * @returns {Number|null} The value, or `null` when the token cannot hold that position.
+ * @private
+ */
+function toFlexFactor(token) {
+    const factor = Number(token);
+
+    return Number.isFinite(factor) && factor >= 0 ? factor : null
+}
 
 /**
  * @class Neo.draggable.dashboard.SortZone
@@ -307,10 +322,24 @@ class DashboardSortZone extends SortZone {
             return null
         }
 
-        const grow = Number(tokens[0]);
+        const grow = toFlexFactor(tokens[0]);
 
-        if (!Number.isFinite(grow)) {
+        // A lone token that is not a factor must be a basis, and CSS grows a lone basis by 1.
+        if (grow === null) {
             return tokens.length === 1 && CSS_FLEX_BASIS.test(tokens[0]) ? 1 : null
+        }
+
+        // `<grow> <shrink>? <basis>?` — EVERY remaining token is validated, not skipped. A browser
+        // drops the entire declaration on one bad token, so `1 oops`, `1 -1 auto`, `1 2 3` and
+        // `1 1 none` leave the item not flexible; reading grow off token 0 and trusting the rest
+        // would invent weight 1 for all four. Validating position 0 alone was the same defect this
+        // method exists to remove, one position further along.
+        if (tokens.length === 3 && (toFlexFactor(tokens[1]) === null || !CSS_FLEX_BASIS.test(tokens[2]))) {
+            return null
+        }
+
+        if (tokens.length === 2 && toFlexFactor(tokens[1]) === null && !CSS_FLEX_BASIS.test(tokens[1])) {
+            return null
         }
 
         return grow > 0 ? grow : null

--- a/src/draggable/dashboard/SortZone.mjs
+++ b/src/draggable/dashboard/SortZone.mjs
@@ -113,7 +113,10 @@ class DashboardSortZone extends SortZone {
      *     and the gaps between items, ensuring the new layout respects the original design tokens.
      * 2.  **Identifies Remaining Items:** Filters out the dragged component and its placeholder.
      * 3.  **Distributes Space:** Calculates the available space (Total Size - Offsets - Gaps - Fixed Items) and distributes
-     *     it among flex items proportional to their flex values.
+     *     it among flex items proportional to their flex values. Membership of that set is decided by
+     *     {@link Neo.draggable.dashboard.SortZone#resolveFlexWeight resolveFlexWeight} rather than by a truthiness test,
+     *     because `flex` here is app-supplied and `'none'` is a legal truthy value — see that method for why the
+     *     distinction is load-bearing.
      * 4.  **Generates Styles:** Returns a list of style objects (`top`, `left`, `width`, `height`) to be applied to the remaining items.
      *
      * @returns {Object[]} Array of objects containing the `item` reference and the calculated `style` object.
@@ -178,12 +181,13 @@ class DashboardSortZone extends SortZone {
                 continue
             }
 
-            let rect = me.itemRects[i];
+            let rect = me.itemRects[i],
+                flex = me.resolveFlexWeight(item.flex);
 
-            items.push({item, rect});
+            items.push({item, rect, flex});
 
-            if (item.flex) {
-                totalFlex += item.flex
+            if (flex) {
+                totalFlex += flex
             } else {
                 let size = isHorizontal ? rect.width : rect.height;
                 usedSize += size
@@ -197,11 +201,11 @@ class DashboardSortZone extends SortZone {
         // 4. Distribute space
         let currentPos = startOffset;
 
-        items.forEach(({item, rect}, index) => {
+        items.forEach(({item, rect, flex}, index) => {
             let itemSize, style = {};
 
-            if (item.flex) {
-                itemSize = (item.flex / totalFlex) * availableSpace
+            if (flex) {
+                itemSize = (flex / totalFlex) * availableSpace
             } else {
                 itemSize = isHorizontal ? rect.width : rect.height
             }
@@ -235,6 +239,34 @@ class DashboardSortZone extends SortZone {
     destroy() {
         DragCoordinator.unregister(this);
         super.destroy()
+    }
+
+    /**
+     * @summary Resolves an item's `flex` config into the numeric weight the expanded layout divides by.
+     *
+     * **`flex` is app-supplied on this path.** The sole caller reaching
+     * {@link Neo.draggable.dashboard.SortZone#calculateExpandedLayout} is `Neo.dashboard.Container`'s widget
+     * sorting, so the value is whatever an application put on its widgets — every CSS-legal spelling can
+     * arrive, and **`'none'` is a legal one that is also truthy**. A truthiness test therefore does not
+     * identify a flex item: `'none'` passes it, `totalFlex += 'none'` concatenates into `'0none'`, and the
+     * division yields `NaN` — written straight into `style.width` as `'NaNpx'`. Nothing throws, so the
+     * geometry is simply wrong.
+     *
+     * Resolving `'none'` to *not flexible* is also what CSS means by it — `flex: none` is `0 0 auto` — so
+     * such an item correctly keeps its measured rect. Zero and negative weights are fixed for the same
+     * reason: they grow nothing, which preserves the behaviour a falsy `0` already had.
+     *
+     * `'auto'` is deliberately treated as fixed rather than guessed at `1`. No caller uses it, and where a
+     * measured rect is a safe wrong answer, an invented weight is not.
+     *
+     * @param {Number|String|null} flex The item's `flex` config, unvalidated.
+     * @returns {Number|null} A positive finite weight, or `null` when the item does not participate in the
+     * flex distribution.
+     */
+    resolveFlexWeight(flex) {
+        const weight = parseFloat(flex);
+
+        return Number.isFinite(weight) && weight > 0 ? weight : null
     }
 
     /**

--- a/src/draggable/dashboard/SortZone.mjs
+++ b/src/draggable/dashboard/SortZone.mjs
@@ -7,6 +7,15 @@ import SortZone           from '../container/SortZone.mjs';
 import VDomUtil           from '../../util/VDom.mjs';
 
 /**
+ * A single `flex` token that is a length or a percentage rather than a bare number. In the CSS
+ * shorthand such a token is the **basis**, and the grow factor defaults to 1 — so `flex: 100px`
+ * grows by 1, never by 100. Kept explicit rather than inferred from "digits followed by letters",
+ * which would read `1oops` as a length.
+ * @type {RegExp}
+ */
+const CSS_FLEX_BASIS = /^[+-]?(?:\d+\.?\d*|\.\d+)(?:%|px|em|rem|ex|ch|cap|ic|lh|rlh|vw|vh|vi|vb|vmin|vmax|cm|mm|q|in|pt|pc)$/;
+
+/**
  * @class Neo.draggable.dashboard.SortZone
  * @extends Neo.draggable.container.SortZone
  */
@@ -252,21 +261,59 @@ class DashboardSortZone extends SortZone {
      * division yields `NaN` — written straight into `style.width` as `'NaNpx'`. Nothing throws, so the
      * geometry is simply wrong.
      *
-     * Resolving `'none'` to *not flexible* is also what CSS means by it — `flex: none` is `0 0 auto` — so
-     * such an item correctly keeps its measured rect. Zero and negative weights are fixed for the same
-     * reason: they grow nothing, which preserves the behaviour a falsy `0` already had.
+     * **It reads the shorthand's grow factor rather than scanning for the first number**, because
+     * CSS-equivalent spellings must not disagree. `flex: auto` and `flex: 1 1 auto` are the same
+     * declaration, and a leading-number scan resolves them to different weights. The same scan reads
+     * `100px` — a *basis*, whose grow defaults to 1 — as weight 100, and invents weight 1 out of
+     * `1oops`. This codebase writes shorthands routinely (`'0 1 auto'`, `'1 1 600px'`, `'1 1 100%'`),
+     * so the grammar is load-bearing rather than defensive.
      *
-     * `'auto'` is deliberately treated as fixed rather than guessed at `1`. No caller uses it, and where a
-     * measured rect is a safe wrong answer, an invented weight is not.
+     * The grammar, all of it:
      *
-     * @param {Number|String|null} flex The item's `flex` config, unvalidated.
+     * - a finite positive number is the weight;
+     * - `none` is `0 0 auto` and `initial` is `0 1 auto`, so both are **not flexible**;
+     * - `auto` is `1 1 auto`, so it is weight **1**;
+     * - otherwise the first of up to three tokens carries grow: a bare number is that grow, and a
+     *   lone length or percentage is a basis whose grow is 1;
+     * - anything else — a fourth token, a non-numeric leading token, a non-string non-number — is
+     *   not flexible.
+     *
+     * A zero or negative grow is likewise not flexible: it grows nothing, which preserves the
+     * behaviour a falsy `0` already had. **Unparseable never invents a weight**; the item keeps its
+     * measured rect, which is the safe wrong answer.
+     *
+     * @param {Number|String|null|undefined} flex The item's `flex` config, unvalidated — `undefined`
+     * is the routine case, since most items declare no `flex` at all.
      * @returns {Number|null} A positive finite weight, or `null` when the item does not participate in the
      * flex distribution.
      */
     resolveFlexWeight(flex) {
-        const weight = parseFloat(flex);
+        if (typeof flex === 'number') {
+            return Number.isFinite(flex) && flex > 0 ? flex : null
+        }
 
-        return Number.isFinite(weight) && weight > 0 ? weight : null
+        if (typeof flex !== 'string') {
+            return null
+        }
+
+        const value = flex.trim().toLowerCase();
+
+        if (value === 'none' || value === 'initial') return null;
+        if (value === 'auto')                        return 1;
+
+        const tokens = value.split(/\s+/).filter(Boolean);
+
+        if (tokens.length === 0 || tokens.length > 3) {
+            return null
+        }
+
+        const grow = Number(tokens[0]);
+
+        if (!Number.isFinite(grow)) {
+            return tokens.length === 1 && CSS_FLEX_BASIS.test(tokens[0]) ? 1 : null
+        }
+
+        return grow > 0 ? grow : null
     }
 
     /**

--- a/test/playwright/unit/draggable/dashboard/SortZone.spec.mjs
+++ b/test/playwright/unit/draggable/dashboard/SortZone.spec.mjs
@@ -915,23 +915,65 @@ test.describe('Neo.draggable.dashboard.SortZone expanded-layout flex distributio
         zone.destroy()
     });
 
-    test('resolveFlexWeight admits only positive finite weights', () => {
+    test('resolveFlexWeight reads the shorthand grow factor', () => {
         const zone = layoutZone({flexValues: [1]});
 
         expect(zone.resolveFlexWeight(2)).toBe(2);
         expect(zone.resolveFlexWeight('2')).toBe(2);
-        expect(zone.resolveFlexWeight('1 1 auto')).toBe(1);
         expect(zone.resolveFlexWeight(0.5)).toBe(0.5);
 
-        // Not flexible — each for its own reason, all rejected the same way.
-        expect(zone.resolveFlexWeight('none')).toBe(null);      // legal CSS, truthy, means 0 0 auto
-        expect(zone.resolveFlexWeight('auto')).toBe(null);      // deliberately fixed rather than guessed at 1
-        expect(zone.resolveFlexWeight(0)).toBe(null);           // grows nothing; matches the old falsy path
-        expect(zone.resolveFlexWeight('0')).toBe(null);         // the truthy spelling of the same thing
+        // Shorthands, which this codebase writes routinely. Grow is the FIRST token.
+        expect(zone.resolveFlexWeight('1 1 auto')).toBe(1);
+        expect(zone.resolveFlexWeight('1 1 600px')).toBe(1);
+        expect(zone.resolveFlexWeight('1 1 100%')).toBe(1);
+        expect(zone.resolveFlexWeight('0 1 auto')).toBe(null);   // grow 0 — the common "do not grow" shorthand
+        expect(zone.resolveFlexWeight('0 0 200px')).toBe(null);
+
+        // Keywords, expanded as CSS defines them rather than guessed at.
+        expect(zone.resolveFlexWeight('none')).toBe(null);       // 0 0 auto
+        expect(zone.resolveFlexWeight('initial')).toBe(null);    // 0 1 auto
+        expect(zone.resolveFlexWeight('auto')).toBe(1);          // 1 1 auto
+
+        expect(zone.resolveFlexWeight(0)).toBe(null);            // grows nothing; matches the old falsy path
+        expect(zone.resolveFlexWeight('0')).toBe(null);          // the truthy spelling of the same thing
         expect(zone.resolveFlexWeight(-1)).toBe(null);
-        expect(zone.resolveFlexWeight(undefined)).toBe(null);
+        expect(zone.resolveFlexWeight(undefined)).toBe(null);    // the routine case: no flex declared
         expect(zone.resolveFlexWeight(null)).toBe(null);
         expect(zone.resolveFlexWeight('')).toBe(null);
+        expect(zone.resolveFlexWeight('   ')).toBe(null);
+
+        zone.destroy()
+    });
+
+    test('CSS-equivalent spellings resolve alike — the leading-number scan they refute', () => {
+        const zone = layoutZone({flexValues: [1]});
+
+        // `auto` IS `1 1 auto`. A scan for the first number in the string resolves the pair to null
+        // and 1 respectively, which is the defect @neo-gpt-emmy named on review.
+        expect(zone.resolveFlexWeight('auto')).toBe(zone.resolveFlexWeight('1 1 auto'));
+        // `none` IS `0 0 auto`.
+        expect(zone.resolveFlexWeight('none')).toBe(zone.resolveFlexWeight('0 0 auto'));
+
+        zone.destroy()
+    });
+
+    test('a weight is never invented from a value that does not carry one', () => {
+        const zone = layoutZone({flexValues: [1]});
+
+        // A lone length is a BASIS: CSS grows it by 1. A leading-number scan returns 100 — a
+        // hundredfold error that is finite, plausible, and therefore invisible.
+        expect(zone.resolveFlexWeight('100px')).toBe(1);
+        expect(zone.resolveFlexWeight('50%')).toBe(1);
+
+        // Garbage resolves to fixed rather than to the number it happens to start with.
+        expect(zone.resolveFlexWeight('1oops')).toBe(null);
+        expect(zone.resolveFlexWeight('px')).toBe(null);
+        expect(zone.resolveFlexWeight('1 2 3 4')).toBe(null);
+
+        // Non-string, non-number inputs never reach Number()'s coercions.
+        expect(zone.resolveFlexWeight(true)).toBe(null);
+        expect(zone.resolveFlexWeight([2])).toBe(null);
+        expect(zone.resolveFlexWeight({})).toBe(null);
 
         zone.destroy()
     })

--- a/test/playwright/unit/draggable/dashboard/SortZone.spec.mjs
+++ b/test/playwright/unit/draggable/dashboard/SortZone.spec.mjs
@@ -970,6 +970,28 @@ test.describe('Neo.draggable.dashboard.SortZone expanded-layout flex distributio
         expect(zone.resolveFlexWeight('px')).toBe(null);
         expect(zone.resolveFlexWeight('1 2 3 4')).toBe(null);
 
+        zone.destroy()
+    });
+
+    test('a bad token anywhere invalidates the declaration, not just a bad first one', () => {
+        const zone = layoutZone({flexValues: [1]});
+
+        // @neo-gpt-emmy's round-2 RA. A browser drops the WHOLE declaration on one invalid token,
+        // so each of these leaves the item not flexible. Validating only position 0 would have read
+        // grow 1 off every one of them — the same invent-a-weight defect one position further along.
+        expect(zone.resolveFlexWeight('1 oops')).toBe(null);      // shrink is not a number or a basis
+        expect(zone.resolveFlexWeight('1 -1 auto')).toBe(null);   // a negative shrink is rejected
+        expect(zone.resolveFlexWeight('-1 1 auto')).toBe(null);   // and so is a negative grow
+        expect(zone.resolveFlexWeight('1 2 3')).toBe(null);       // a bare 3 is not a basis
+        expect(zone.resolveFlexWeight('1 1 none')).toBe(null);    // `none` is not a basis either
+
+        // The valid neighbours, which must survive the same validation.
+        expect(zone.resolveFlexWeight('1 2 3px')).toBe(1);
+        expect(zone.resolveFlexWeight('1 2')).toBe(1);            // <grow> <shrink>
+        expect(zone.resolveFlexWeight('1 auto')).toBe(1);         // <grow> <basis>
+        expect(zone.resolveFlexWeight('1 1 0')).toBe(1);          // unitless zero IS a valid basis
+        expect(zone.resolveFlexWeight('1 0 content')).toBe(1);
+
         // Non-string, non-number inputs never reach Number()'s coercions.
         expect(zone.resolveFlexWeight(true)).toBe(null);
         expect(zone.resolveFlexWeight([2])).toBe(null);

--- a/test/playwright/unit/draggable/dashboard/SortZone.spec.mjs
+++ b/test/playwright/unit/draggable/dashboard/SortZone.spec.mjs
@@ -761,3 +761,178 @@ test.describe.serial('Neo.draggable.dashboard.SortZone Directional Logic', () =>
         expect(DragCoordinator.nativeWindowDropCandidates.size).toBe(0)
     });
 });
+
+/**
+ * @summary Expanded-layout flex distribution — `flex` is app-supplied, so every CSS spelling arrives.
+ *
+ * The defect these arms pin is that `calculateExpandedLayout` identified flex items with a truthiness
+ * test and then did arithmetic on the raw config. `'none'` is truthy, so `totalFlex += 'none'`
+ * concatenated and the division produced `NaN` — written into `style.width` as `'NaNpx'` with nothing
+ * thrown.
+ *
+ * **Finiteness is necessary and not sufficient.** A mixed numeric/string case concatenates into a
+ * *finite but wrong* total, which every finiteness assertion passes. So the load-bearing check is that
+ * the distributed sizes SUM to the available space — the property the distribution claims — and each
+ * arm asserts the shares themselves, never merely that nothing crashed.
+ */
+test.describe('Neo.draggable.dashboard.SortZone expanded-layout flex distribution (#17353)', () => {
+    let DashboardSortZone;
+
+    test.beforeAll(async () => {
+        DashboardSortZone = (await import('../../../../../src/draggable/dashboard/SortZone.mjs')).default
+    });
+
+    /**
+     * Builds a zone whose geometry makes the arithmetic readable: `count` adjacent `slot`-sized slots
+     * exactly filling the owner on the main axis.
+     *
+     * The owner is sized to `count * slot` **deliberately**, so every inferred offset and gap is zero
+     * and `availableSpace` is precisely what the fixed items leave. That is what lets each arm assert
+     * that the distributed sizes sum to the full span — with a slack owner the sum is a smaller number
+     * nobody can read off the fixture, and an assertion nobody can read is one nobody can falsify.
+     */
+    function layoutZone({flexValues, sortDirection = 'horizontal', slot = 100, cross = 100}) {
+        const
+            isHorizontal = sortDirection === 'horizontal',
+            count        = flexValues.length,
+            span         = count * slot,
+            itemRects    = Array.from({length: count}, (_, i) => ({
+                x     : isHorizontal ? i * slot : 0,
+                y     : isHorizontal ? 0 : i * slot,
+                width : isHorizontal ? slot : cross,
+                height: isHorizontal ? cross : slot
+            })),
+            zone = Neo.create(DashboardSortZone, {
+                owner: {
+                    id   : `flexOwner-${sortDirection}-${count}`,
+                    items: flexValues.map((flex, i) => {
+                        const item = {id: `i${i}`, vdom: {cls: ['neo-draggable']}, wrapperStyle: {}};
+
+                        // Absent is a distinct case from `'none'`: it is the shape most items have,
+                        // and it must stay on the fixed branch after the fix as it was before.
+                        if (flex !== undefined) {
+                            item.flex = flex
+                        }
+
+                        return item
+                    }),
+                    vdom           : {},
+                    addDomListeners: () => {},
+                    getDomRect     : () => Promise.resolve([{x: 0, y: 0, width: span, height: cross}]),
+                    on             : () => {}
+                }
+            });
+
+        zone.adjustItemRectsToParent = true;
+        zone.indexMap                = Object.fromEntries(itemRects.map((_, i) => [i, i]));
+        zone.itemRects               = itemRects;
+        zone.ownerRect               = {
+            x     : 0,
+            y     : 0,
+            width : isHorizontal ? span : cross,
+            height: isHorizontal ? cross : span
+        };
+        zone.sortDirection = sortDirection;
+
+        return zone
+    }
+
+    /** The main-axis size each returned style carries, as a number. */
+    const mainSizes = (rects, sortDirection = 'horizontal') =>
+        rects.map(({style}) => parseFloat(sortDirection === 'horizontal' ? style.width : style.height));
+
+    test('a `flex: "none"` item produces a finite size instead of NaN geometry', () => {
+        const
+            zone  = layoutZone({flexValues: ['none', undefined, undefined]}),
+            rects = zone.calculateExpandedLayout();
+
+        // Every emitted number, not just the offending item's: a NaN size poisons `currentPos`, so the
+        // following items' `left` values inherit it. Asserting only the item that carries the bad flex
+        // would pass on a fix that de-NaNs the size and leaves the positions broken.
+        for (const {item, style} of rects) {
+            for (const [prop, value] of Object.entries(style)) {
+                expect(Number.isFinite(parseFloat(value)), `${item.id}.${prop} = ${value}`).toBe(true)
+            }
+        }
+
+        // `flex: none` is CSS for `0 0 auto`, so the item keeps its measured slot rather than growing.
+        expect(mainSizes(rects)).toEqual([100, 100, 100]);
+
+        zone.destroy()
+    });
+
+    test('a `flex: "none"` item is finite on the vertical axis too, where height is the poisoned field', () => {
+        const
+            zone  = layoutZone({flexValues: ['none', undefined], sortDirection: 'vertical'}),
+            rects = zone.calculateExpandedLayout();
+
+        expect(mainSizes(rects, 'vertical')).toEqual([100, 100]);
+        expect(rects.every(({style}) => Number.isFinite(parseFloat(style.top)))).toBe(true);
+
+        zone.destroy()
+    });
+
+    test('numeric flex distributes the full available space in proportion — the positive control', () => {
+        const
+            zone  = layoutZone({flexValues: [1, 3]}),
+            rects = zone.calculateExpandedLayout(),
+            sizes = mainSizes(rects);
+
+        // No fixed items, so the whole 200px span is distributed 1:3. These are the values the
+        // pre-fix code produced for purely numeric flex, unchanged — the fix must not disable the
+        // flex path while removing the string hazard.
+        expect(sizes).toEqual([50, 150]);
+        expect(sizes.reduce((sum, size) => sum + size, 0)).toBe(200);
+
+        zone.destroy()
+    });
+
+    test('a numeric string mixed with a number distributes correctly — finite was never the whole property', () => {
+        const
+            zone  = layoutZone({flexValues: [2, '3']}),
+            rects = zone.calculateExpandedLayout(),
+            sizes = mainSizes(rects);
+
+        // Pre-fix this produced FINITE garbage, not NaN: `0 + 2` is 2, then `2 + '3'` concatenates to
+        // `'23'`, so the shares came out as 2/23 and 3/23 of the span — under a quarter of the
+        // container, silently. A finiteness assertion passes that. The sum is what does not.
+        expect(sizes).toEqual([80, 120]);
+        expect(sizes.reduce((sum, size) => sum + size, 0)).toBe(200);
+
+        zone.destroy()
+    });
+
+    test('flex items and fixed items share one span without double-counting', () => {
+        const
+            zone  = layoutZone({flexValues: ['none', 1, 1]}),
+            rects = zone.calculateExpandedLayout(),
+            sizes = mainSizes(rects);
+
+        // The fixed item keeps its 100px slot; the remaining 200px splits evenly.
+        expect(sizes).toEqual([100, 100, 100]);
+        expect(sizes.reduce((sum, size) => sum + size, 0)).toBe(300);
+
+        zone.destroy()
+    });
+
+    test('resolveFlexWeight admits only positive finite weights', () => {
+        const zone = layoutZone({flexValues: [1]});
+
+        expect(zone.resolveFlexWeight(2)).toBe(2);
+        expect(zone.resolveFlexWeight('2')).toBe(2);
+        expect(zone.resolveFlexWeight('1 1 auto')).toBe(1);
+        expect(zone.resolveFlexWeight(0.5)).toBe(0.5);
+
+        // Not flexible — each for its own reason, all rejected the same way.
+        expect(zone.resolveFlexWeight('none')).toBe(null);      // legal CSS, truthy, means 0 0 auto
+        expect(zone.resolveFlexWeight('auto')).toBe(null);      // deliberately fixed rather than guessed at 1
+        expect(zone.resolveFlexWeight(0)).toBe(null);           // grows nothing; matches the old falsy path
+        expect(zone.resolveFlexWeight('0')).toBe(null);         // the truthy spelling of the same thing
+        expect(zone.resolveFlexWeight(-1)).toBe(null);
+        expect(zone.resolveFlexWeight(undefined)).toBe(null);
+        expect(zone.resolveFlexWeight(null)).toBe(null);
+        expect(zone.resolveFlexWeight('')).toBe(null);
+
+        zone.destroy()
+    })
+});


### PR DESCRIPTION
Resolves #17353

> 🌿 *A layout could report a width of `NaNpx` and no one downstream had a way to notice — the distribution can no longer produce a number it cannot defend.*

## What this is

`calculateExpandedLayout()` identified flex items with a truthiness test and then did arithmetic on the raw config:

```js
if (item.flex) { totalFlex += item.flex }                       // :185
if (item.flex) { itemSize = (item.flex / totalFlex) * available } // :203
```

`flex` is **app-supplied** on this path — `dashboard/Container.mjs:146` is the sole importer, so the value is whatever an application put on its widgets. `'none'` is legal CSS **and truthy**:

```
totalFlex = 0 + 'none'                          // '0none'
itemSize  = ('none' / '0none') * availableSpace // NaN  ->  style.width = 'NaNpx'
```

Nothing throws. The geometry is simply wrong, and the `NaN` propagates into `currentPos`, so every *following* item's `left` inherits it too.

## Finiteness was never the whole property, and that is the interesting part

While building the red-first arm I checked whether a numeric **string** was safe. It is not, and it fails differently:

```
totalFlex = 0 + 2   // 2   — fine
totalFlex = 2 + '3' // '23' — string concatenation, no NaN
```

Two items carrying `2` and `'3'` in a 200px span produced **17.39px and 26.09px** — 43.5px of a 200px container, silently, with both values perfectly finite. **Every assertion that only checks for `NaN` passes that.** So the specs assert the shares *and* their sum, not the absence of a crash.

I would have shipped a fix whose test could not fail on the second defect if I had stopped at the one the ticket named.

## The fix

One resolver yields the weight **both** sites read, carried on the item entry so it cannot drift between them:

It reads the shorthand's **grow factor** rather than scanning for a leading number:

- a finite positive number is the weight;
- **`none`** is `0 0 auto` and **`initial`** is `0 1 auto` — not flexible;
- **`auto`** is `1 1 auto` — weight **1**;
- otherwise grow is the first of up to three tokens: a bare number is that grow, and a lone length or percentage is a **basis** whose grow is 1;
- anything else — a fourth token, a non-numeric leading token, a non-string non-number — is not flexible.

- **`0`, `'0'`, negative grow → fixed.** They grow nothing, and this preserves the behaviour a falsy `0` already had.
- **Unparseable never invents a weight.** The item keeps its measured rect, which is the safe wrong answer.
- **`'auto'` → weight `1`, reversing my first position under @neo-gpt-emmy's review.** I had it resolve to *fixed* and argued that no caller uses it. That missed the point she raised: `auto` **is** `1 1 auto`, a spelling this codebase uses widely, so the pair diverging was the defect rather than a conservative choice.

## AC Evidence

| AC | Proof |
|---|---|
| AC-1 | **Already closed in the ticket, and it refuted the original framing** — no framework caller reaches the defect; the trigger is app-supplied. No work owed, restated in Deltas because the correction is the useful part |
| AC-2 | Red-first arm fails on `dev` with the literal defect in the message — `Error: i0.width = NaNpx`. It asserts the **produced value is finite**, across every emitted style property, not that nothing throws |
| AC-3 | Both former sites read one resolved value: `resolveFlexWeight` is called once per item at `:182` and the result is carried on the entry that `:200` destructures |
| AC-4 | **Positive control**: purely numeric flex distributes `[50, 150]` of a 200px span. It is the **only arm that stays green when the fix is reverted** — precisely what a positive control must do |
| AC-5 | `resolveFlexWeight`'s JSDoc states that `flex` is app-supplied here, that `'none'` is a legal truthy value, why the truthiness test therefore fails, and the whole grammar including `undefined` as the routine case. `calculateExpandedLayout` step 3 points at it |

## Test Evidence

Evidence: L2 (unit) — pure layout arithmetic; no DOM, no render surface.

| Suite | Result |
|---|---|
| `test/playwright/unit/draggable/dashboard/SortZone.spec.mjs` | **20/20 pass** (11 pre-existing + 9 new) |

**Red direction, measured by reverting only `src/draggable/dashboard/SortZone.mjs` and re-running:**

| Arm | Without the fix |
|---|---|
| `flex: 'none'`, horizontal | ✘ `i0.width = NaNpx` |
| `flex: 'none'`, vertical | ✘ `NaN` in the heights |
| numeric string mixed with a number | ✘ `17.391304347826086` / `26.08695652173913` instead of `80` / `120` |
| fixed + flex sharing a span | ✘ three `NaN` |
| `resolveFlexWeight` contract | ✘ method absent |
| **numeric-only positive control** | **✔ passes — unchanged by the fix** |

5 of 6 red, and the one that stays green is the one that must.

**Round 2 — the three arms added for @neo-gpt-emmy's RA, measured against the resolver she reviewed:**

| Arm | Against the previous resolver |
|---|---|
| shorthand grow factor | ✘ `Expected: 1, Received: null` for `'auto'` |
| CSS-equivalent spellings resolve alike | ✘ `'auto'` and `'1 1 auto'` disagree |
| a weight is never invented | ✘ **`Expected: 1, Received: 100`** for `'100px'` |

The last row is the RA in one line: finite, plausible, and a hundredfold wrong.

## Deltas

- **This ticket's own first framing was wrong and I refuted it before fixing anything.** I originally claimed a framework-internal reachability chain through dock edge rails via `DockLayoutAdapter`, and broadcast that claim. It is false: `DockTabSortZone` extends the *tab-header* SortZone, not this one, and rails/bands nest inside plain `ntype: 'container'` `edge-zone` wrappers rather than sitting as sortable siblings. **Two subsystems share the word *dashboard* and I conflated them.** The fix is identical either way, which is exactly what makes a false premise easy to leave standing — and a ticket whose stated trigger does not exist teaches the next reader a wrong map of the subsystem.

- **The mixed-type case is not in the ticket's ACs.** I found it building the red arm, it is the same predicate defect, and it is *more* dangerous than the named one because it produces plausible numbers. Fixed and asserted rather than filed for later; the resolver handles both by construction, so splitting it would have meant shipping a known-broken input class through code I was already touching.

- **The fixture sizes the owner to `count * slot` on purpose.** With a slack owner every distribution sums to some number nobody can read off the fixture, and an assertion nobody can read is one nobody can falsify. Zero offsets and zero gaps make `availableSpace` exactly what the fixed items leave, so `sum === span` is a property a reviewer can check by eye.

- **The finite-value arm checks every emitted style property, not just the offending item's width.** `NaN` poisons `currentPos`, so the *following* items' `left` values inherit it. An arm asserting only the bad item's size would pass a fix that de-NaNs the size and leaves the positions broken.

- **Two sibling sites with the same predicate shape are deliberately untouched.** `table/Body.mjs:322` has no `flex:` default anywhere under `src/table/` and is clean today; `grid/header/Toolbar.mjs:359` was fixed by PR #17332. Rewriting a correct site to look safer produces a diff whose test cannot fail.

- **Round 2, and I have a claim to retract.** @neo-gpt-emmy's RA offered full-value `Number` *or* a real grammar. I argued for the grammar on the strength of a tree-wide shorthand census — `'0 1 auto'`, `'1 1 auto'`, `'1 1 600px'` across `src/`, `apps/`, `examples/` — presented as **caller reachability**. **It is not reachability.** The sole entry to this loop is `dashboard/Container.mjs`'s item list, and my leading example, `container/Panel.mjs:77`, sits on a panel **header child config** rather than on a dashboard item. Emmy caught it with an independent path sweep and withdrew her own acceptance of my census in the same message. So "`Number` would break live call sites" was overclaimed, and I made the superset-search-region error inside a PR whose own subject is a reachability claim that turned out false — the second time on this ticket.

- **The grammar is still the right branch, on a weaker and honest argument.** Not "it would break callers today" but: `flex` is app-supplied, the reachable set is a snapshot rather than a property, and a shorthand arriving tomorrow should grow by its stated factor rather than silently freeze. Emmy accepted the branch independently; only my justification for it was wrong.

- **Round 2's real RA: a bad token anywhere invalidates the declaration.** The first grammar validated grow and trusted positions 1 and 2, so `1 oops`, `1 -1 auto`, `1 2 3` and `1 1 none` all resolved to weight 1 — the same invent-a-weight defect one position along. Grow and shrink now share a non-negative-factor read, the basis position is validated, and the basis set gained `auto`, `content` and unitless zero, which are legal and which my first regex rejected. Valid neighbours (`1 2 3px`, `1 auto`, `1 1 0`) are asserted beside the invalid ones so the validation cannot tighten into a rule that refuses real CSS.

- **Declaring `flex` on `component/Base.mjs` — the actual generator — stays out.** It is the right long-term fix and it deserves measurement first: ~90 ad-hoc call sites, and a config declaration changes reactive-config resolution order. Not bundled into a defect fix.

## Post-Merge Validation

Observations, not owed work.

- **The generator is still open.** Every `flex` reader in the tree is one app-supplied string away from this class. This PR fixes the reachable instance and documents the hazard at the site; the durable fix is a declared config with a resolved type, which needs its own measured ticket.
- **`draggable/tab/header/toolbar/SortZone` is unexamined.** It is the zone the dock projection actually uses, and whether it shares this predicate shape is a question this ticket explicitly did not answer. Worth one grep by whoever next touches dock sorting.
- **The grammar is a subset of the CSS one and says so.** It extracts grow and nothing else, because grow is all this distribution needs. If a future consumer needs basis or shrink, it needs a real parser rather than an extension of this method.

Authored by Vega (Opus 5, Claude Code) 🌿
