### PR TITLE
fix(agentos): a negation git can never reach no longer reads like one that works

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -108,7 +108,11 @@ resources/data/reports/
 
 # Agent OS Local Data
 .env
-.neo-ai-data
+# Contents, NOT the directory — the same rule the /docs/output/* block below records. A bare
+# `.neo-ai-data` makes the negation unreachable, and the two tracked concept files would go on
+# looking fine because git grandfathers already-tracked paths: only the NEXT one added would
+# vanish, reported by nothing. #17697
+.neo-ai-data/*
 !.neo-ai-data/concepts/
 .neo-ai-secrets
 # Parity-plane runtime root (docker-compose.dev.yml relocated plane) — runtime data, never tracked

--- a/test/playwright/unit/buildScripts/gitignoreNegationReachability.spec.mjs
+++ b/test/playwright/unit/buildScripts/gitignoreNegationReachability.spec.mjs
@@ -1,0 +1,207 @@
+import {test, expect} from '@playwright/test';
+import {execFileSync} from 'node:child_process';
+import fs             from 'node:fs';
+import os             from 'node:os';
+import path           from 'node:path';
+
+/**
+ * @summary Every `!` line in the repository `.gitignore` must actually be able to un-ignore something.
+ *
+ * **The failure this guards.** Git does not descend into an ignored directory, so a negation placed
+ * beneath a bare directory rule never participates. `.neo-ai-data` + `!.neo-ai-data/concepts/` read
+ * exactly like the working `.gemini/*` + `!.gemini/concepts/` two blocks away, and only one of them
+ * does anything. Nothing is red when it breaks: existing tracked files keep working because git
+ * grandfathers already-tracked paths, so the cost lands on the *next* file added under that
+ * directory — silently absent from `git status`, silently absent from `git add`.
+ *
+ * **Why this materialises a real tree instead of probing paths.** `git check-ignore` answers a
+ * different question than it appears to, in three ways, each of which produced a wrong answer while
+ * this guard was being written:
+ *
+ * 1. It exits `0` when **any** rule matches — including a negation. Reading the exit code as
+ *    "ignored" reported 20 dead negations where there was one.
+ * 2. Given a path that does **not exist**, beneath a directory that **is** ignored, it reports no
+ *    match at all. "No rule matched" is not "not ignored", and a synthetic probe hits this every
+ *    time the parent is exactly the directory under test.
+ * 3. Consequently a hypothetical path cannot answer the question at all. So each probe is written to
+ *    disk in a scratch repository carrying the real `.gitignore`, and the verdict comes from
+ *    `git status --porcelain`, which is the behaviour anyone actually depends on.
+ *
+ * **Each negation is tested against its own control.** A rule is reachable when the probe is visible
+ * WITH the negation present and ignored WITHOUT it. The second half is what stops the guard passing
+ * vacuously on a probe that no rule would have ignored in the first place.
+ */
+
+const
+    ROOT_DIR       = path.resolve(process.cwd()),
+    GITIGNORE_PATH = path.join(ROOT_DIR, '.gitignore'),
+    PROBE_DIR      = 'probe-dir',
+    PROBE_LEAF     = 'probe-leaf';
+
+/**
+ * @typedef {Object} Negation
+ * @property {Number} line  1-based line number in `.gitignore`.
+ * @property {String} rule  The raw `!…` line.
+ * @property {String} probe Repo-relative path the rule intends to keep visible.
+ */
+
+/**
+ * @summary Turns a negation pattern into one concrete path it is meant to un-ignore.
+ *
+ * A wrong derivation is the quiet way this guard could pass on everything, so the mapping is
+ * asserted directly by its own arm rather than only exercised through the sweep.
+ *
+ * @param {String} rule A `.gitignore` line beginning with `!`.
+ * @returns {String} A repo-relative probe path.
+ */
+export function deriveProbePath(rule) {
+    let pattern = rule.slice(1).trim();
+
+    const isDirectory = pattern.endsWith('/');
+
+    pattern = pattern.replace(/^\/+/, '').replace(/\/+$/, '');
+
+    const segments = pattern.split('/').map(segment => {
+        if (segment === '**')  return PROBE_DIR;
+        if (segment === '*')   return PROBE_LEAF;
+        return segment.includes('*') ? segment.replace(/\*/g, PROBE_LEAF) : segment
+    });
+
+    if (isDirectory) {
+        segments.push(`${PROBE_LEAF}.jsonl`)
+    }
+
+    return segments.join('/')
+}
+
+/**
+ * @summary Lists the negations in a `.gitignore`, skipping comments and blanks.
+ * @param {String} content
+ * @returns {Negation[]}
+ */
+export function readNegations(content) {
+    return content.split('\n').flatMap((raw, index) => {
+        const rule = raw.trim();
+
+        return rule.startsWith('!') ? [{line: index + 1, rule, probe: deriveProbePath(rule)}] : []
+    })
+}
+
+/**
+ * @summary Materialises every probe in a scratch repository and reports which paths git can see.
+ *
+ * @param {String} content   The `.gitignore` body to install.
+ * @param {String[]} probes  Repo-relative probe paths to create.
+ * @returns {Set<String>} The probes git reports as untracked, i.e. NOT ignored.
+ */
+export function visibleProbes(content, probes) {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'neo-gitignore-'));
+
+    try {
+        execFileSync('git', ['init', '-q', '.'], {cwd: dir});
+        fs.writeFileSync(path.join(dir, '.gitignore'), content, 'utf8');
+
+        for (const probe of probes) {
+            const target = path.join(dir, probe);
+
+            fs.mkdirSync(path.dirname(target), {recursive: true});
+            fs.writeFileSync(target, 'probe\n', 'utf8')
+        }
+
+        const seen = execFileSync('git', ['status', '--porcelain', '--untracked-files=all'], {cwd: dir, encoding: 'utf8'});
+
+        return new Set(
+            seen.split('\n')
+                .map(row => row.slice(3).trim())
+                .filter(Boolean)
+                .map(row => row.replace(/^"|"$/g, ''))
+        )
+    } finally {
+        fs.rmSync(dir, {recursive: true, force: true})
+    }
+}
+
+/**
+ * @summary Reports every negation git cannot reach, each judged against its own without-the-rule control.
+ * @param {String} content
+ * @returns {{checked: Number, dead: Negation[], inert: Negation[]}}
+ */
+export function unreachableNegations(content) {
+    const
+        negations = readNegations(content),
+        probes    = negations.map(negation => negation.probe),
+        withRules = visibleProbes(content, probes),
+        dead      = [],
+        inert     = [];
+
+    for (const negation of negations) {
+        const
+            withoutRule = content.split('\n').filter((_, index) => index + 1 !== negation.line).join('\n'),
+            controlSeen = visibleProbes(withoutRule, [negation.probe]);
+
+        if (!withRules.has(negation.probe)) {
+            dead.push(negation)
+        } else if (controlSeen.has(negation.probe)) {
+            // Visible either way: the rule un-ignores nothing. Not a failure — a redundant line is
+            // harmless where an unreachable one is a trap — but reported so it can be retired.
+            inert.push(negation)
+        }
+    }
+
+    return {checked: negations.length, dead, inert}
+}
+
+test.describe('.gitignore negation reachability (#17697)', () => {
+
+    test('probe derivation maps a pattern onto a path the rule is actually about', () => {
+        expect(deriveProbePath('!/apps/agentos/index.html')).toBe('apps/agentos/index.html');
+        expect(deriveProbePath('!/apps/agentos/**/*.mjs')).toBe(`apps/agentos/${PROBE_DIR}/${PROBE_LEAF}.mjs`);
+        expect(deriveProbePath('!/apps/agentos/design/*.html')).toBe(`apps/agentos/design/${PROBE_LEAF}.html`);
+        expect(deriveProbePath('!.neo-ai-data/concepts/')).toBe(`.neo-ai-data/concepts/${PROBE_LEAF}.jsonl`);
+        expect(deriveProbePath('!/docs/output/class-hierarchy.json')).toBe('docs/output/class-hierarchy.json')
+    });
+
+    test('POSITIVE CONTROL: a bare directory above a negation is reported dead', () => {
+        // The exact shape the repository shipped. Without this arm a guard that always returns an
+        // empty list would pass every other test in this file.
+        const result = unreachableNegations('buildout\n!buildout/keep/\n');
+
+        expect(result.checked).toBe(1);
+        expect(result.dead.map(negation => negation.rule)).toEqual(['!buildout/keep/'])
+    });
+
+    test('POSITIVE CONTROL: the same pair written as contents-not-directory is reachable', () => {
+        // The fix, proven to be a fix rather than merely different: one character apart from the arm
+        // above, opposite verdict.
+        const result = unreachableNegations('buildout/*\n!buildout/keep/\n');
+
+        expect(result.dead).toEqual([]);
+        expect(result.inert).toEqual([])
+    });
+
+    test('a negation that un-ignores nothing is reported inert, not dead', () => {
+        const result = unreachableNegations('unrelated-path\n!buildout/keep/\n');
+
+        expect(result.dead).toEqual([]);
+        expect(result.inert.map(negation => negation.rule)).toEqual(['!buildout/keep/'])
+    });
+
+    test('every negation in the repository .gitignore is reachable', () => {
+        const
+            content = fs.readFileSync(GITIGNORE_PATH, 'utf8'),
+            result  = unreachableNegations(content);
+
+        // Reach, stated in the output rather than assumed by the reader: this guard covers the
+        // repository-root `.gitignore` and nothing else. Nested `.gitignore` files, `.git/info/exclude`
+        // and any global ignore are unexamined, so a green here says nothing about them.
+        console.log(`gitignore negation reachability: ${result.checked} negations checked in .gitignore (repo root only — nested .gitignore, .git/info/exclude and global ignores are NOT covered)`);
+
+        if (result.inert.length) {
+            console.log(`  inert (harmless, retirable): ${result.inert.map(negation => `L${negation.line} ${negation.rule}`).join(', ')}`)
+        }
+
+        expect(
+            result.dead.map(negation => `L${negation.line} ${negation.rule} (probe: ${negation.probe})`)
+        ).toEqual([])
+    })
+});


### PR DESCRIPTION
Resolves #17697

> 🌿 *One character separated a rule that protects a directory from one that quietly discards its next file — and the difference is no longer something a reader has to know by heart.*

## What this is

`.gitignore` carried:

```
.neo-ai-data
!.neo-ai-data/concepts/
```

**Git does not descend into an ignored directory, so that negation never participated.** Measured before the fix:

```
$ git check-ignore -v .neo-ai-data/concepts/probe.jsonl
.gitignore:111:.neo-ai-data     .neo-ai-data/concepts/probe.jsonl
```

The ignore rule wins; line 112 is decoration.

**Nothing was ever red, and that is the whole problem.** `nodes.jsonl` and `edges.jsonl` are tracked and fine — git does not apply ignore rules to already-tracked paths. They survive because they **predate the rule**, not because it permits them. The cost was reserved for the *next* file added under `concepts/`: absent from `git status`, absent from `git add`, discovered by whoever read an incomplete corpus.

**The repository already knew this.** `.gitignore:82-84` carries an inline comment on `/docs/output/*` saying exactly it — *"Contents, NOT the directory: git does not descend into an ignored directory, so the negation below would be unreachable"* (#16600). The lesson was learned, written into the file, and the identical defect sat **two blocks above it**. Discipline held once and then did not, which is the entire argument for shipping a guard with the one-character fix.

## The instrument is part of the finding

`git check-ignore` answered a different question than it appeared to, **three separate times**, each producing a confident wrong answer:

**1. Exit `0` means "a rule matched" — including a negation.** My first census reported **20 dead negations**. Every working `!/apps/**/*.mjs` line "matched" and was scored as ignored. The discriminator is the *polarity of the matched pattern*, never the exit code. Corrected count: **1 of 68**.

**2. A path that does not exist, beneath a directory that is ignored, reports no match at all.** After applying the fix I probed `.neo-ai-data/sqlite/x.db` and got `NOT IGNORED` — which read like the fix had *opened* the runtime plane. It had not. `x.db` does not exist, git short-circuits at the ignored parent, and **"no rule matched" is not "not ignored"**. I nearly reverted a correct fix on that reading.

**3. Therefore a hypothetical path cannot answer the question.** Which is a design constraint, not a footnote: the guard materialises every probe on disk in a scratch repository and reads `git status`, because that is the behaviour anyone actually depends on.

## AC Evidence

| AC | Proof |
|---|---|
| AC-1 | Negation reachable. On a **real file** in the live tree: with the fix, `git status --porcelain` reports `?? .neo-ai-data/concepts/probe-negation-reach.tmp`; with the previous rule stashed back in, status reports **nothing** and `check-ignore` names `.gitignore:111:.neo-ai-data`. Same file, both directions, one minute apart |
| AC-2 | Runtime data still ignored. `git add -A -n -- .neo-ai-data` adds nothing; `.neo-ai-data/sqlite`, `.neo-ai-data/wake-daemon` and `.neo-ai-data/graph.sqlite` all match `.gitignore:115:.neo-ai-data/*`. Cross-checked on a materialised tree where the nested files exist — see Deltas for why the live tree alone could not answer this |
| AC-3 | The guard decides by **polarity of the matched pattern**, and in fact by something stronger — see AC-4 |
| AC-4 | **POSITIVE CONTROL:** `unreachableNegations('buildout\n!buildout/keep/\n')` reports it dead, and the one-character sibling `'buildout/*\n!buildout/keep/\n'` reports it reachable. Two arms, one character apart, opposite verdicts — a guard that always returned an empty list fails the first |
| AC-5 | **NON-VACUITY:** run against the pre-fix `.gitignore` the guard names `L112 !.neo-ai-data/concepts/`. The positive-control arm pins that permanently, since it carries the exact shape the repository shipped |
| AC-6 | Reach printed on every run: *"68 negations checked in .gitignore (repo root only — nested .gitignore, .git/info/exclude and global ignores are NOT covered)"* |
| AC-7 | `git ls-files .neo-ai-data/` still returns both concept files; the diff touches no path under `.neo-ai-data/` |

## Test Evidence

Evidence: L2 (unit) — a config file and a guard over it; no runtime surface.

| Suite | Result |
|---|---|
| `test/playwright/unit/buildScripts/gitignoreNegationReachability.spec.mjs` | **5/5 pass** |
| Guard output | `68 negations checked`, 0 dead, 0 inert |
| Live-tree probe, both directions | recorded in AC-1 |
| Full `lint-staged` battery | pass |

**The guard judges each negation against its own control**: reachable means the probe is visible *with* the rule present and ignored *without* it. The second half is what stops the sweep passing on a probe that nothing would have ignored anyway — the vacuity mode a reachability check falls into most naturally.

## Deltas

- **My first census was wrong by a factor of twenty, and the wrong number is in the ticket on purpose.** Reading `check-ignore`'s exit code as a verdict reported 20 dead negations. The corrected figure is 1. It is recorded because the guard had to be built to avoid the same mistake, and a ticket that hides its author's wrong turn teaches nobody which turn to avoid.

- **I nearly reverted the fix on a bad reading.** Post-fix, `.neo-ai-data/sqlite/x.db` probed as `NOT IGNORED` — apparently the fix opening the runtime plane. The path simply does not exist; git short-circuits at the ignored parent and reports no match. Settled by building a **real** tree with those files present, where `git add -A -n` adds only the two concept files. **A synthetic path and a real one are different experiments**, and only one of them is the question.

- **Two verdicts, not one.** A negation visible *both* with and without its rule is reported **inert** rather than dead. A redundant line is harmless where an unreachable one is a trap, and collapsing them would either fail on harmless lines or hide the dangerous ones behind a soft word. Currently zero inert.

- **The 20 `!/apps/**/*.mjs` lines are all reachable.** Their parent rules are file globs (`/apps/**/*.mjs`), not bare directories, so git still descends. That is the control group: the sweep would be far less trustworthy if it found nothing wrong anywhere, and equally so if it condemned everything.

- **Spec, not lint script plus workflow.** The precedent is `lintWorkflowScanRootParity.spec.mjs` — a spec guarding a configuration invariant nothing else can see, riding the always-on unit lane. A new `*-lint.yml` would also have to register itself in that very spec, so the cheaper shape is the one that already exists.

- **The Brain repository got the correct form directly, never this one.** `neomjs/neo-agent-brain` PR #2 writes `.neo-ai-data/*` with the reason inline. This ticket exists because comparing the two files is what exposed the Engine's copy.

## Post-Merge Validation

Observations, not owed work.

- **`.git/info/exclude` and nested `.gitignore` files are unexamined**, and the guard says so in its own output rather than letting a green imply coverage. Whether either carries the same shape is unmeasured — one command each, for whoever wants it.
- **The next negation added is the real test.** The guard's value is entirely in the 69th rule, not the 68 it just checked.
- **`check-ignore`'s exit code will mislead someone else.** It misled me three ways in one sitting. If another guard in this repository keys on it, it is answering a different question than its author believes.

Authored by Vega (Opus 5, Claude Code) 🌿
