### PR TITLE
feat(agentos): disposition extraction workflows (#17699)

### DIFF
--- a/ai/scripts/diagnostics/agentOsExtractionInventory.json
+++ b/ai/scripts/diagnostics/agentOsExtractionInventory.json
@@ -19,15 +19,20 @@
         {
             "identity": ".github/workflows/adr-seam-table-lint.yml",
             "disposition": "pin-fetch",
-            "targetRepository": "neomjs/neo-agent-brain",
             "pinAuthority": "ADR 0040 §2.3 CI or Fleet provisioning pins one immutable AgentOS runtime revision",
             "source": "ADR 0040 §2.7 wave-one custody plus Epic #17500 leaf 7",
             "rationale": "the Engine retains learn/agentos decisions, so its ADR seam gate stays here and consumes the pinned AgentOS validator"
         },
         {
+            "identity": ".github/workflows/adr-status-lint.yml",
+            "disposition": "pin-fetch",
+            "pinAuthority": "ADR 0040 §2.3 CI or Fleet provisioning pins one immutable AgentOS runtime revision",
+            "source": "ADR 0040 §2.7 wave-one decision custody plus Epic #17500 leaf 7",
+            "rationale": "the Engine retains learn/agentos decisions, so its status gate stays here and consumes the pinned AgentOS validator"
+        },
+        {
             "identity": ".github/workflows/agent-pr-body-lint.yml",
             "disposition": "pin-fetch",
-            "targetRepository": "neomjs/neo-agent-brain",
             "pinAuthority": "ADR 0040 §2.3 CI or Fleet provisioning pins one immutable AgentOS runtime revision",
             "source": "ADR 0040 §2.7 minimal Engine contributor surface plus Epic #17500 leaf 7",
             "rationale": "Engine pull requests retain their admission gate while the AgentOS-owned preflight implementation is fetched at a pinned revision"
@@ -42,7 +47,6 @@
         {
             "identity": ".github/workflows/commit-authorship-lint.yml",
             "disposition": "pin-fetch",
-            "targetRepository": "neomjs/neo-agent-brain",
             "pinAuthority": "ADR 0040 §2.3 CI or Fleet provisioning pins one immutable AgentOS runtime revision",
             "source": "ADR 0040 §2.7 minimal Engine contributor surface plus Epic #17500 leaf 7",
             "rationale": "the Engine owns its commit-history policy while the implementation script moves with AgentOS and is consumed at a pin"
@@ -64,7 +68,6 @@
         {
             "identity": ".github/workflows/discussion-lifecycle-audit.yml",
             "disposition": "pin-fetch",
-            "targetRepository": "neomjs/neo-agent-brain",
             "pinAuthority": "ADR 0040 §2.3 CI or Fleet provisioning pins one immutable AgentOS runtime revision",
             "source": "ADR 0040 §2.7 retained skills and content custody plus Epic #17500 leaf 7",
             "rationale": "the Engine retains the ideation skill and mirrored Discussion corpus, so its lifecycle audit fetches the AgentOS diagnostic at a pin"
@@ -72,7 +75,6 @@
         {
             "identity": ".github/workflows/front-door-fingerprint.yml",
             "disposition": "pin-fetch",
-            "targetRepository": "neomjs/neo-agent-brain",
             "pinAuthority": "ADR 0040 §2.3 CI or Fleet provisioning pins one immutable AgentOS runtime revision",
             "source": "ADR 0040 §2.7 retained published learn content plus Epic #17500 leaf 7",
             "rationale": "the guarded Introduction stays Engine-owned, so the Engine workflow retains ownership and pins its AgentOS validator"
@@ -80,7 +82,6 @@
         {
             "identity": ".github/workflows/guard-ci-parity-lint.yml",
             "disposition": "pin-fetch",
-            "targetRepository": "neomjs/neo-agent-brain",
             "pinAuthority": "ADR 0040 §2.3 CI or Fleet provisioning pins one immutable AgentOS runtime revision",
             "source": "Epic #17500 leaf 7 per-file workflow ownership",
             "rationale": "the Engine owns its workflow and package-hook parity while consuming the moved guard registry and validator from one pinned AgentOS revision"
@@ -88,7 +89,6 @@
         {
             "identity": ".github/workflows/identity-engine-coherence-lint.yml",
             "disposition": "pin-fetch",
-            "targetRepository": "neomjs/neo-agent-brain",
             "pinAuthority": "ADR 0040 §2.3 CI or Fleet provisioning pins one immutable AgentOS runtime revision",
             "source": "ADR 0040 §2.7 retained learn content plus explicit cross-repository pinning",
             "rationale": "the public Engine-owned ModelStats document remains the guarded target and compares against identity authority from a pinned AgentOS revision"
@@ -110,7 +110,6 @@
         {
             "identity": ".github/workflows/npm-script-entrypoint-lint.yml",
             "disposition": "pin-fetch",
-            "targetRepository": "neomjs/neo-agent-brain",
             "pinAuthority": "ADR 0040 §2.3 CI or Fleet provisioning pins one immutable AgentOS runtime revision",
             "source": "ADR 0040 §2.1 independent manifests plus Epic #17500 leaf 7",
             "rationale": "the Engine retains its root script and entrypoint guard while fetching the shared AgentOS validator at the compatibility pin"
@@ -125,7 +124,6 @@
         {
             "identity": ".github/workflows/retry-bound-classification-lint.yml",
             "disposition": "pin-fetch",
-            "targetRepository": "neomjs/neo-agent-brain",
             "pinAuthority": "ADR 0040 §2.3 CI or Fleet provisioning pins one immutable AgentOS runtime revision",
             "source": "ADR 0040 §2.7 retained Engine source and app custody plus Epic #17500 leaf 7",
             "rationale": "the Engine keeps retry-bound enforcement over src and apps while consuming the moved registry and validator from a pinned AgentOS revision"
@@ -140,7 +138,6 @@
         {
             "identity": ".github/workflows/skill-manifest-lint.yml",
             "disposition": "pin-fetch",
-            "targetRepository": "neomjs/neo-agent-brain",
             "pinAuthority": "ADR 0040 §2.3 CI or Fleet provisioning pins one immutable AgentOS runtime revision",
             "source": "ADR 0040 §2.7 minimal contributor and published guide custody",
             "rationale": "the Engine retains the skill manifests and published guidance while fetching the moved AgentOS manifest validators at a pin"
@@ -148,7 +145,6 @@
         {
             "identity": ".github/workflows/substrate-size-guard.yml",
             "disposition": "pin-fetch",
-            "targetRepository": "neomjs/neo-agent-brain",
             "pinAuthority": "ADR 0040 §2.3 CI or Fleet provisioning pins one immutable AgentOS runtime revision",
             "source": "ADR 0040 §2.7 minimal Engine contributor surface plus Epic #17500 leaf 7",
             "rationale": "the Engine-retained instruction and skill payloads remain the measured subject while the AgentOS size diagnostic is consumed at a pin"
@@ -156,7 +152,6 @@
         {
             "identity": ".github/workflows/tree-json-lint.yml",
             "disposition": "pin-fetch",
-            "targetRepository": "neomjs/neo-agent-brain",
             "pinAuthority": "ADR 0040 §2.3 CI or Fleet provisioning pins one immutable AgentOS runtime revision",
             "source": "ADR 0040 §2.7 retained learn, Portal, SEO, and tree-input custody",
             "rationale": "the Engine owns every guarded content and Portal output, so its workflow stays and pins the moved AgentOS validator"

--- a/ai/scripts/diagnostics/agentOsExtractionInventory.json
+++ b/ai/scripts/diagnostics/agentOsExtractionInventory.json
@@ -1,12 +1,13 @@
 {
     "$schema": {
         "description": "Source-owned judgments for the C-prime AgentOS extraction inventory.",
-        "schemaVersion": "agentos-extraction-inventory.v4",
+        "schemaVersion": "agentos-extraction-inventory.v5",
         "runtimeProbeEligibility": "eligible means import and eager evaluation settle safely inside the disposable denial child; ineligible rows name the exact unguarded or external-work boundary",
         "manifestAuthority": "launch-root targets and package declarations are exact identity populations; every package row names explicit engine/edge/cloud/shared manifestTargets and never relies on workspace hoisting",
         "consumerEdgeAuthority": "consumerEdges reconcile both outside-to-AgentOS and Edge-reached AgentOS-to-outside imports; line numbers are evidence while source/kind/specifier/target/ordinal form stable identity",
         "consumerSourceClassAuthority": "source classes already owned by AgentOS through an independent project/custody contract are one exact registry row, never thousands of internal-import rows",
-        "engineDependencyCovenant": "the Engine carries no AgentOS package in dependencies or devDependencies; exact forbidden package names are source-owned below"
+        "engineDependencyCovenant": "the Engine carries no AgentOS package in dependencies or devDependencies; exact forbidden package names are source-owned below",
+        "workflowFileDispositionAuthority": "every workflow file with an AgentOS artifact occurrence has exactly one repository-cut action: move, pin-fetch, or retire; occurrence plane custody never chooses the file action"
     },
     "engineDependencyCovenant": {
         "forbiddenPackages": [
@@ -14,6 +15,153 @@
             "neo-agent-brain"
         ]
     },
+    "workflowFileDispositions": [
+        {
+            "identity": ".github/workflows/adr-seam-table-lint.yml",
+            "disposition": "pin-fetch",
+            "targetRepository": "neomjs/neo-agent-brain",
+            "pinAuthority": "ADR 0040 §2.3 CI or Fleet provisioning pins one immutable AgentOS runtime revision",
+            "source": "ADR 0040 §2.7 wave-one custody plus Epic #17500 leaf 7",
+            "rationale": "the Engine retains learn/agentos decisions, so its ADR seam gate stays here and consumes the pinned AgentOS validator"
+        },
+        {
+            "identity": ".github/workflows/agent-pr-body-lint.yml",
+            "disposition": "pin-fetch",
+            "targetRepository": "neomjs/neo-agent-brain",
+            "pinAuthority": "ADR 0040 §2.3 CI or Fleet provisioning pins one immutable AgentOS runtime revision",
+            "source": "ADR 0040 §2.7 minimal Engine contributor surface plus Epic #17500 leaf 7",
+            "rationale": "Engine pull requests retain their admission gate while the AgentOS-owned preflight implementation is fetched at a pinned revision"
+        },
+        {
+            "identity": ".github/workflows/check-retired-primitives.yml",
+            "disposition": "move",
+            "targetRepository": "neomjs/neo-agent-brain",
+            "source": "ADR 0040 §2.7 subject-owned test and guard custody",
+            "rationale": "the guarded retired-primitives population and its diagnostic are AgentOS implementation, so the workflow moves with its subject"
+        },
+        {
+            "identity": ".github/workflows/commit-authorship-lint.yml",
+            "disposition": "pin-fetch",
+            "targetRepository": "neomjs/neo-agent-brain",
+            "pinAuthority": "ADR 0040 §2.3 CI or Fleet provisioning pins one immutable AgentOS runtime revision",
+            "source": "ADR 0040 §2.7 minimal Engine contributor surface plus Epic #17500 leaf 7",
+            "rationale": "the Engine owns its commit-history policy while the implementation script moves with AgentOS and is consumed at a pin"
+        },
+        {
+            "identity": ".github/workflows/config-template-ssot-lint.yml",
+            "disposition": "move",
+            "targetRepository": "neomjs/neo-agent-brain",
+            "source": "ADR 0040 §3 preserves ADR 0019 config authority during realm relocation",
+            "rationale": "the AiConfig templates, bases, deployment inputs, parity registry, and validator all move with the AgentOS package planes"
+        },
+        {
+            "identity": ".github/workflows/detection-retention-sla.yml",
+            "disposition": "move",
+            "targetRepository": "neomjs/neo-agent-brain",
+            "source": "ADR 0040 §2.1 nested Cloud package custody",
+            "rationale": "the SLA workflow guards Cloud-owned AgentOS maintenance and configuration, so the workflow moves with the Cloud subject"
+        },
+        {
+            "identity": ".github/workflows/discussion-lifecycle-audit.yml",
+            "disposition": "pin-fetch",
+            "targetRepository": "neomjs/neo-agent-brain",
+            "pinAuthority": "ADR 0040 §2.3 CI or Fleet provisioning pins one immutable AgentOS runtime revision",
+            "source": "ADR 0040 §2.7 retained skills and content custody plus Epic #17500 leaf 7",
+            "rationale": "the Engine retains the ideation skill and mirrored Discussion corpus, so its lifecycle audit fetches the AgentOS diagnostic at a pin"
+        },
+        {
+            "identity": ".github/workflows/front-door-fingerprint.yml",
+            "disposition": "pin-fetch",
+            "targetRepository": "neomjs/neo-agent-brain",
+            "pinAuthority": "ADR 0040 §2.3 CI or Fleet provisioning pins one immutable AgentOS runtime revision",
+            "source": "ADR 0040 §2.7 retained published learn content plus Epic #17500 leaf 7",
+            "rationale": "the guarded Introduction stays Engine-owned, so the Engine workflow retains ownership and pins its AgentOS validator"
+        },
+        {
+            "identity": ".github/workflows/guard-ci-parity-lint.yml",
+            "disposition": "pin-fetch",
+            "targetRepository": "neomjs/neo-agent-brain",
+            "pinAuthority": "ADR 0040 §2.3 CI or Fleet provisioning pins one immutable AgentOS runtime revision",
+            "source": "Epic #17500 leaf 7 per-file workflow ownership",
+            "rationale": "the Engine owns its workflow and package-hook parity while consuming the moved guard registry and validator from one pinned AgentOS revision"
+        },
+        {
+            "identity": ".github/workflows/identity-engine-coherence-lint.yml",
+            "disposition": "pin-fetch",
+            "targetRepository": "neomjs/neo-agent-brain",
+            "pinAuthority": "ADR 0040 §2.3 CI or Fleet provisioning pins one immutable AgentOS runtime revision",
+            "source": "ADR 0040 §2.7 retained learn content plus explicit cross-repository pinning",
+            "rationale": "the public Engine-owned ModelStats document remains the guarded target and compares against identity authority from a pinned AgentOS revision"
+        },
+        {
+            "identity": ".github/workflows/identity-vocabulary-lint.yml",
+            "disposition": "move",
+            "targetRepository": "neomjs/neo-agent-brain",
+            "source": "ADR 0040 §2.7 AgentOS MCP and identity subject custody",
+            "rationale": "the guarded MCP OpenAPI vocabulary and the validator are AgentOS-owned, so their workflow moves with the source authority"
+        },
+        {
+            "identity": ".github/workflows/mcp-test-location-lint.yml",
+            "disposition": "move",
+            "targetRepository": "neomjs/neo-agent-brain",
+            "source": "ADR 0040 §2.7 test custody follows the AgentOS service subject",
+            "rationale": "the workflow governs AgentOS MCP server test placement and its own AgentOS unit witness, so it moves with that test population"
+        },
+        {
+            "identity": ".github/workflows/npm-script-entrypoint-lint.yml",
+            "disposition": "pin-fetch",
+            "targetRepository": "neomjs/neo-agent-brain",
+            "pinAuthority": "ADR 0040 §2.3 CI or Fleet provisioning pins one immutable AgentOS runtime revision",
+            "source": "ADR 0040 §2.1 independent manifests plus Epic #17500 leaf 7",
+            "rationale": "the Engine retains its root script and entrypoint guard while fetching the shared AgentOS validator at the compatibility pin"
+        },
+        {
+            "identity": ".github/workflows/openapi-service-parity-lint.yml",
+            "disposition": "move",
+            "targetRepository": "neomjs/neo-agent-brain",
+            "source": "ADR 0040 §2.7 AgentOS MCP and service custody",
+            "rationale": "the OpenAPI schemas, MCP handlers, service barrels, census, and parity validator all belong to AgentOS after the cut"
+        },
+        {
+            "identity": ".github/workflows/retry-bound-classification-lint.yml",
+            "disposition": "pin-fetch",
+            "targetRepository": "neomjs/neo-agent-brain",
+            "pinAuthority": "ADR 0040 §2.3 CI or Fleet provisioning pins one immutable AgentOS runtime revision",
+            "source": "ADR 0040 §2.7 retained Engine source and app custody plus Epic #17500 leaf 7",
+            "rationale": "the Engine keeps retry-bound enforcement over src and apps while consuming the moved registry and validator from a pinned AgentOS revision"
+        },
+        {
+            "identity": ".github/workflows/script-plane-lint.yml",
+            "disposition": "move",
+            "targetRepository": "neomjs/neo-agent-brain",
+            "source": "ADR 0040 §§2.1 and 2.4 executable-plane authority",
+            "rationale": "the workflow enforces AgentOS root and Cloud script-plane topology, so both its population and validator move to the new repository"
+        },
+        {
+            "identity": ".github/workflows/skill-manifest-lint.yml",
+            "disposition": "pin-fetch",
+            "targetRepository": "neomjs/neo-agent-brain",
+            "pinAuthority": "ADR 0040 §2.3 CI or Fleet provisioning pins one immutable AgentOS runtime revision",
+            "source": "ADR 0040 §2.7 minimal contributor and published guide custody",
+            "rationale": "the Engine retains the skill manifests and published guidance while fetching the moved AgentOS manifest validators at a pin"
+        },
+        {
+            "identity": ".github/workflows/substrate-size-guard.yml",
+            "disposition": "pin-fetch",
+            "targetRepository": "neomjs/neo-agent-brain",
+            "pinAuthority": "ADR 0040 §2.3 CI or Fleet provisioning pins one immutable AgentOS runtime revision",
+            "source": "ADR 0040 §2.7 minimal Engine contributor surface plus Epic #17500 leaf 7",
+            "rationale": "the Engine-retained instruction and skill payloads remain the measured subject while the AgentOS size diagnostic is consumed at a pin"
+        },
+        {
+            "identity": ".github/workflows/tree-json-lint.yml",
+            "disposition": "pin-fetch",
+            "targetRepository": "neomjs/neo-agent-brain",
+            "pinAuthority": "ADR 0040 §2.3 CI or Fleet provisioning pins one immutable AgentOS runtime revision",
+            "source": "ADR 0040 §2.7 retained learn, Portal, SEO, and tree-input custody",
+            "rationale": "the Engine owns every guarded content and Portal output, so its workflow stays and pins the moved AgentOS validator"
+        }
+    ],
     "consumerEdges": [
         {
             "identities": [

--- a/ai/scripts/diagnostics/agentOsExtractionInventory.mjs
+++ b/ai/scripts/diagnostics/agentOsExtractionInventory.mjs
@@ -56,10 +56,11 @@ const
     DEFAULT_REGISTRY_PATH   = path.join(PROJECT_ROOT, 'ai/scripts/diagnostics/agentOsExtractionInventory.json'),
     SCRIPT_PATH_RE          = /\bai\/scripts\/[A-Za-z0-9_./-]+\.mjs\b/g,
     WORKFLOW_ARTIFACT_RE    = /\b(?:test\/playwright\/unit\/)?ai\/scripts\/[A-Za-z0-9_./-]+\.(?:json|mjs)\b/g,
-    VALID_DISPOSITIONS      = new Set(['cloud', 'edge', 'retire', 'shared', 'stays-engine']),
-    VALID_MANIFEST_TARGETS  = new Set(['cloud', 'edge', 'engine', 'shared']),
-    VALID_PROBE_ELIGIBILITY = new Set(['eligible', 'ineligible']),
-    VALID_SUCCESSOR_PHASES  = new Set(['engine-continuity', 'move', 'seat-reprovisioning']),
+    AGENTOS_TARGET_REPOSITORY = 'neomjs/neo-agent-brain',
+    VALID_DISPOSITIONS        = new Set(['cloud', 'edge', 'retire', 'shared', 'stays-engine']),
+    VALID_MANIFEST_TARGETS    = new Set(['cloud', 'edge', 'engine', 'shared']),
+    VALID_PROBE_ELIGIBILITY   = new Set(['eligible', 'ineligible']),
+    VALID_SUCCESSOR_PHASES    = new Set(['engine-continuity', 'move', 'seat-reprovisioning']),
     LAUNCH_CALLEES          = new Set([
         'exec', 'execFile', 'execFileSync', 'execSync', 'fork', 'runCommand', 'spawn', 'spawnSync'
     ]),
@@ -87,8 +88,23 @@ export const SURFACE = Object.freeze({
     rootScript         : 'root-script',
     scriptModule       : 'script-module',
     subprocessLaunch   : 'subprocess-launch',
+    workflowFile       : 'workflow-file',
     workflowReference  : 'workflow-reference'
 });
+
+/**
+ * Repository-cut actions for workflows that currently reach AgentOS-owned artifacts.
+ * These are deliberately separate from Edge/Cloud execution custody: one answers where a
+ * referenced target runs, the other answers which repository owns the workflow after the cut.
+ * @type {Object<String, String>}
+ */
+export const WORKFLOW_FILE_DISPOSITION = Object.freeze({
+    move    : 'move',
+    pinFetch: 'pin-fetch',
+    retire  : 'retire'
+});
+
+const VALID_WORKFLOW_FILE_DISPOSITIONS = new Set(Object.values(WORKFLOW_FILE_DISPOSITION));
 
 /**
  * Stable direction vocabulary for package-boundary consumer edges.
@@ -742,11 +758,190 @@ export function collectWorkflowReferences({projectRoot = PROJECT_ROOT, scriptRow
             rationale  : null,
             evidence   : {
                 target              : row.target,
+                workflowFile        : row.identity.split('::', 1)[0],
                 suggestedDisposition: target?.disposition ?? null,
                 suggestedRationale  : target?.disposition ? `follows ${row.target}` : null
             }
         }
     }).sort(compareRows)
+}
+
+/**
+ * @summary Folds exact workflow occurrences into the file population that needs one repository-cut
+ * action. Occurrence custody remains evidence; it never chooses the file action.
+ * @param {Object[]} workflowRows Reconciled workflow-reference rows.
+ * @returns {{rows: Object[], errors: Object[]}}
+ */
+export function deriveWorkflowFilePopulation(workflowRows = []) {
+    const
+        errors = [],
+        files  = new Map();
+
+    if (!Array.isArray(workflowRows)) {
+        return {
+            rows  : [],
+            errors: [{kind: 'invalid-workflow-reference-population', key: 'workflowRows'}]
+        }
+    }
+
+    workflowRows.forEach(row => {
+        const workflowFile = row?.evidence?.workflowFile ?? row?.identity?.split('::', 1)[0];
+
+        if (typeof workflowFile !== 'string'
+            || !/^\.github\/workflows\/[^/]+\.ya?ml$/.test(workflowFile)) {
+            errors.push({
+                kind: 'invalid-workflow-file-identity',
+                key : String(workflowFile ?? row?.identity ?? 'missing')
+            });
+            return
+        }
+
+        const file = files.get(workflowFile) ?? {
+            dispositions   : new Set(),
+            occurrenceCount: 0,
+            targets        : new Set()
+        };
+
+        file.occurrenceCount++;
+        row.disposition && file.dispositions.add(row.disposition);
+        row.evidence?.target && file.targets.add(row.evidence.target);
+        files.set(workflowFile, file)
+    });
+
+    const rows = [...files.entries()].map(([identity, file]) => ({
+        surface    : SURFACE.workflowFile,
+        identity,
+        source     : identity,
+        disposition: null,
+        rationale  : null,
+        evidence   : {
+            occurrenceCount       : file.occurrenceCount,
+            occurrenceDispositions: [...file.dispositions].sort(),
+            targets               : [...file.targets].sort()
+        }
+    })).sort(compareRows);
+
+    return {
+        rows,
+        errors: errors.sort((a, b) => `${a.kind}:${a.key}`.localeCompare(`${b.kind}:${b.key}`))
+    }
+}
+
+/**
+ * @summary Reconciles the source-derived workflow-file population against one explicit cut action
+ * per file. The action registry is separate from Edge/Cloud custody by construction.
+ * @param {Object[]} workflowRows Reconciled workflow-reference rows.
+ * @param {Object} registry Source-owned extraction registry.
+ * @returns {Object}
+ */
+export function reconcileWorkflowFileDispositions(workflowRows, registry) {
+    const
+        population   = deriveWorkflowFilePopulation(workflowRows),
+        errors       = [...population.errors],
+        authorityMap = new Map(),
+        derivedKeys  = new Set(population.rows.map(row => row.identity)),
+        authority    = Array.isArray(registry?.workflowFileDispositions)
+            ? registry.workflowFileDispositions
+            : [];
+
+    if (!Array.isArray(registry?.workflowFileDispositions)) {
+        errors.push({kind: 'invalid-workflow-file-registry', key: 'workflowFileDispositions'})
+    }
+
+    authority.forEach(entry => {
+        const {identity} = entry ?? {};
+
+        if (typeof identity !== 'string' || !identity.trim()) {
+            errors.push({kind: 'missing-workflow-file-identity', key: 'workflowFileDispositions'});
+            return
+        }
+
+        if (authorityMap.has(identity)) {
+            errors.push({kind: 'duplicate-workflow-file-authority', key: identity});
+            return
+        }
+
+        authorityMap.set(identity, entry);
+
+        if (!VALID_WORKFLOW_FILE_DISPOSITIONS.has(entry.disposition)) {
+            errors.push({kind: 'invalid-workflow-file-disposition', key: identity})
+        }
+        if (typeof entry.rationale !== 'string' || entry.rationale.trim().length < 12) {
+            errors.push({kind: 'missing-workflow-file-rationale', key: identity})
+        }
+        if (typeof entry.source !== 'string' || !entry.source.trim()) {
+            errors.push({kind: 'missing-workflow-file-source', key: identity})
+        }
+
+        const unexpected = [];
+
+        if (entry.disposition === WORKFLOW_FILE_DISPOSITION.move) {
+            if (entry.targetRepository !== AGENTOS_TARGET_REPOSITORY) {
+                errors.push({kind: 'invalid-workflow-move-target', key: identity})
+            }
+            Object.hasOwn(entry, 'pinAuthority') && unexpected.push('pinAuthority');
+            Object.hasOwn(entry, 'retirementEvidence') && unexpected.push('retirementEvidence')
+        } else if (entry.disposition === WORKFLOW_FILE_DISPOSITION.pinFetch) {
+            if (entry.targetRepository !== AGENTOS_TARGET_REPOSITORY) {
+                errors.push({kind: 'invalid-workflow-pin-target', key: identity})
+            }
+            if (typeof entry.pinAuthority !== 'string' || entry.pinAuthority.trim().length < 12) {
+                errors.push({kind: 'missing-workflow-pin-authority', key: identity})
+            }
+            Object.hasOwn(entry, 'retirementEvidence') && unexpected.push('retirementEvidence')
+        } else if (entry.disposition === WORKFLOW_FILE_DISPOSITION.retire) {
+            if (typeof entry.retirementEvidence !== 'string'
+                || entry.retirementEvidence.trim().length < 12) {
+                errors.push({kind: 'missing-workflow-retirement-evidence', key: identity})
+            }
+            Object.hasOwn(entry, 'targetRepository') && unexpected.push('targetRepository');
+            Object.hasOwn(entry, 'pinAuthority') && unexpected.push('pinAuthority')
+        }
+
+        unexpected.forEach(field => errors.push({
+            kind: 'unexpected-workflow-file-metadata', key: `${identity}::${field}`
+        }))
+    });
+
+    const rows = population.rows.map(row => {
+        const entry = authorityMap.get(row.identity);
+
+        if (!entry) return row;
+
+        return {
+            ...row,
+            disposition    : entry.disposition,
+            rationale      : entry.rationale,
+            authoritySource: entry.source,
+            ...(entry.targetRepository ? {targetRepository: entry.targetRepository} : {}),
+            ...(entry.pinAuthority ? {pinAuthority: entry.pinAuthority} : {}),
+            ...(entry.retirementEvidence ? {retirementEvidence: entry.retirementEvidence} : {}),
+            evidence       : {...row.evidence, override: true}
+        }
+    });
+
+    const
+        diskMinusAuthority = rows.filter(row => !authorityMap.has(row.identity))
+            .map(row => row.identity).sort(),
+        authorityMinusDisk = [...authorityMap.keys()].filter(identity => !derivedKeys.has(identity)).sort();
+
+    diskMinusAuthority.forEach(key => errors.push({kind: 'missing-workflow-file-authority', key}));
+    authorityMinusDisk.forEach(key => errors.push({kind: 'stale-workflow-file-authority', key}));
+
+    const byDisposition = Object.fromEntries(Object.values(WORKFLOW_FILE_DISPOSITION)
+        .map(disposition => [disposition, rows.filter(row => row.disposition === disposition).length]));
+
+    return {
+        total          : rows.length,
+        occurrenceTotal: rows.reduce((total, row) => total + row.evidence.occurrenceCount, 0),
+        byDisposition,
+        rows           : rows.sort(compareRows),
+        residue        : {diskMinusAuthority, authorityMinusDisk},
+        errors         : errors.sort((a, b) => `${a.kind}:${a.key}`.localeCompare(`${b.kind}:${b.key}`)),
+        ok             : diskMinusAuthority.length === 0
+            && authorityMinusDisk.length === 0
+            && errors.length === 0
+    }
 }
 
 /**
@@ -1597,6 +1792,10 @@ export function buildInventory({
             ...configRows
         ],
         reconciled                           = reconcileInventory(allDerived, registry, subprocess.parseFailures),
+        workflowFiles                        = reconcileWorkflowFileDispositions(
+            reconciled.rows.filter(row => row.surface === SURFACE.workflowReference),
+            registry
+        ),
         sha                                  = execFileSync('git', ['-C', projectRoot, 'rev-parse', 'HEAD'], {encoding: 'utf8'}).trim(),
         status                               = execFileSync(
             'git', ['-C', projectRoot, 'status', '--porcelain=v1', '--untracked-files=all'], {encoding: 'utf8'}
@@ -1611,13 +1810,21 @@ export function buildInventory({
     reconciled.errors.push(...consumerEdges.errors);
     reconciled.errors.push(...consumerSourceClasses.errors);
     reconciled.errors.push(...engineDependencyCovenant.errors);
+    reconciled.errors.push(...workflowFiles.errors);
     reconciled.rows.push(...consumerEdges.rows);
     reconciled.rows.push(...consumerSourceClasses.rows);
+    reconciled.rows.push(...workflowFiles.rows);
     reconciled.residue.diskMinusAuthority.push(...consumerEdges.residue.diskMinusAuthority.map(
         identity => rowKey(SURFACE.consumerEdge, identity)
     ));
     reconciled.residue.authorityMinusDisk.push(...consumerEdges.residue.authorityMinusDisk.map(
         identity => rowKey(SURFACE.consumerEdge, identity)
+    ));
+    reconciled.residue.diskMinusAuthority.push(...workflowFiles.residue.diskMinusAuthority.map(
+        identity => rowKey(SURFACE.workflowFile, identity)
+    ));
+    reconciled.residue.authorityMinusDisk.push(...workflowFiles.residue.authorityMinusDisk.map(
+        identity => rowKey(SURFACE.workflowFile, identity)
     ));
     reconciled.rows.sort(compareRows);
     reconciled.residue.diskMinusAuthority.sort();
@@ -1627,7 +1834,8 @@ export function buildInventory({
         && dependencyPopulation.errors.length === 0
         && consumerEdges.ok
         && consumerSourceClasses.ok
-        && engineDependencyCovenant.ok;
+        && engineDependencyCovenant.ok
+        && workflowFiles.ok;
 
     const bindingError = sourceBindingError(status, allowDirty);
 
@@ -1654,7 +1862,7 @@ export function buildInventory({
     reconciled.ok &&= dependencyManifests.errors.length === 0;
 
     return {
-        schemaVersion: 'agentos-extraction-inventory.v4',
+        schemaVersion: 'agentos-extraction-inventory.v5',
         capturedAt,
         git          : {
             sha,
@@ -1686,6 +1894,7 @@ export function buildInventory({
             residue      : consumerEdges.residue,
             sourceClasses: consumerSourceClasses.rows
         },
+        workflowFiles,
         engineDependencyCovenant,
         runtimeProbeEligibility,
         counts,
@@ -1730,6 +1939,16 @@ export function formatInventory(report) {
     lines.push('  preclassified source classes:');
     report.consumerEdges.sourceClasses.forEach(row => lines.push(
         `    ${row.identity} — ${row.evidence.fileCount} tracked files → ${row.successorPhase}`
+    ));
+
+    const workflowFiles = report.workflowFiles;
+
+    lines.push('', `workflow-file identities: ${workflowFiles.total} · ` +
+        `occurrences ${workflowFiles.occurrenceTotal}`);
+    Object.entries(workflowFiles.byDisposition).sort(([a], [b]) => a.localeCompare(b))
+        .forEach(([disposition, count]) => lines.push(`  ${disposition}: ${count}`));
+    workflowFiles.rows.forEach(row => lines.push(
+        `  ${String(row.disposition).padEnd(10)} ${row.identity} — ${row.evidence.occurrenceCount} occurrences`
     ));
 
     lines.push('', `Engine→AgentOS forbidden packages: ${report.engineDependencyCovenant.forbiddenPackages.join(', ')}`);

--- a/ai/scripts/diagnostics/agentOsExtractionInventory.mjs
+++ b/ai/scripts/diagnostics/agentOsExtractionInventory.mjs
@@ -51,17 +51,17 @@ import {censusPlaneOpeners}           from './planePlacementCensus.mjs';
  */
 
 const
-    __filename              = fileURLToPath(import.meta.url),
-    PROJECT_ROOT            = path.resolve(path.dirname(__filename), '../../..'),
-    DEFAULT_REGISTRY_PATH   = path.join(PROJECT_ROOT, 'ai/scripts/diagnostics/agentOsExtractionInventory.json'),
-    SCRIPT_PATH_RE          = /\bai\/scripts\/[A-Za-z0-9_./-]+\.mjs\b/g,
-    WORKFLOW_ARTIFACT_RE    = /\b(?:test\/playwright\/unit\/)?ai\/scripts\/[A-Za-z0-9_./-]+\.(?:json|mjs)\b/g,
+    __filename                = fileURLToPath(import.meta.url),
+    PROJECT_ROOT              = path.resolve(path.dirname(__filename), '../../..'),
+    DEFAULT_REGISTRY_PATH     = path.join(PROJECT_ROOT, 'ai/scripts/diagnostics/agentOsExtractionInventory.json'),
+    SCRIPT_PATH_RE            = /\bai\/scripts\/[A-Za-z0-9_./-]+\.mjs\b/g,
+    WORKFLOW_ARTIFACT_RE      = /\b(?:test\/playwright\/unit\/)?ai\/scripts\/[A-Za-z0-9_./-]+\.(?:json|mjs)\b/g,
     AGENTOS_TARGET_REPOSITORY = 'neomjs/neo-agent-brain',
     VALID_DISPOSITIONS        = new Set(['cloud', 'edge', 'retire', 'shared', 'stays-engine']),
     VALID_MANIFEST_TARGETS    = new Set(['cloud', 'edge', 'engine', 'shared']),
     VALID_PROBE_ELIGIBILITY   = new Set(['eligible', 'ineligible']),
     VALID_SUCCESSOR_PHASES    = new Set(['engine-continuity', 'move', 'seat-reprovisioning']),
-    LAUNCH_CALLEES          = new Set([
+    LAUNCH_CALLEES            = new Set([
         'exec', 'execFile', 'execFileSync', 'execSync', 'fork', 'runCommand', 'spawn', 'spawnSync'
     ]),
     SUBPROCESS_SCAN_ROOTS   = ['.agents', '.claude', '.codex', 'ai', 'buildScripts', 'test'];
@@ -882,12 +882,10 @@ export function reconcileWorkflowFileDispositions(workflowRows, registry) {
             Object.hasOwn(entry, 'pinAuthority') && unexpected.push('pinAuthority');
             Object.hasOwn(entry, 'retirementEvidence') && unexpected.push('retirementEvidence')
         } else if (entry.disposition === WORKFLOW_FILE_DISPOSITION.pinFetch) {
-            if (entry.targetRepository !== AGENTOS_TARGET_REPOSITORY) {
-                errors.push({kind: 'invalid-workflow-pin-target', key: identity})
-            }
             if (typeof entry.pinAuthority !== 'string' || entry.pinAuthority.trim().length < 12) {
                 errors.push({kind: 'missing-workflow-pin-authority', key: identity})
             }
+            Object.hasOwn(entry, 'targetRepository') && unexpected.push('targetRepository');
             Object.hasOwn(entry, 'retirementEvidence') && unexpected.push('retirementEvidence')
         } else if (entry.disposition === WORKFLOW_FILE_DISPOSITION.retire) {
             if (typeof entry.retirementEvidence !== 'string'

--- a/test/playwright/unit/ai/scripts/diagnostics/agentOsExtractionInventory.spec.mjs
+++ b/test/playwright/unit/ai/scripts/diagnostics/agentOsExtractionInventory.spec.mjs
@@ -94,12 +94,11 @@ test.describe('agentOsExtractionInventory — exact population × explicit autho
             population = deriveWorkflowFilePopulation(rows),
             result     = reconcileWorkflowFileDispositions(rows, {
                 workflowFileDispositions: [{
-                    identity        : workflowA,
-                    disposition     : WORKFLOW_FILE_DISPOSITION.pinFetch,
-                    targetRepository: 'neomjs/neo-agent-brain',
-                    pinAuthority    : 'fixture immutable compatibility receipt',
-                    source          : 'fixture authority',
-                    rationale       : 'mixed target custody does not choose the file action'
+                    identity    : workflowA,
+                    disposition : WORKFLOW_FILE_DISPOSITION.pinFetch,
+                    pinAuthority: 'fixture immutable compatibility receipt',
+                    source      : 'fixture authority',
+                    rationale   : 'mixed target custody does not choose the file action'
                 }, {
                     identity        : workflowB,
                     disposition     : WORKFLOW_FILE_DISPOSITION.move,
@@ -209,7 +208,8 @@ test.describe('agentOsExtractionInventory — exact population × explicit autho
         expect(result.errors.map(error => error.kind)).toEqual(expect.arrayContaining([
             'invalid-workflow-move-target',
             'missing-workflow-pin-authority',
-            'missing-workflow-retirement-evidence'
+            'missing-workflow-retirement-evidence',
+            'unexpected-workflow-file-metadata'
         ]))
     });
 
@@ -1111,11 +1111,18 @@ test.describe('agentOsExtractionInventory — exact population × explicit autho
         expect(first.consumerEdges.byDirection[CONSUMER_EDGE_DIRECTION.agentOsToOutside]).toBeGreaterThan(0);
         expect(first.consumerEdges.byDirection[CONSUMER_EDGE_DIRECTION.outsideToAgentOs]).toBeGreaterThan(0);
         expect(first.consumerEdges.residue).toEqual({diskMinusAuthority: [], authorityMinusDisk: []});
-        expect(first.workflowFiles.total).toBe(19);
-        expect(first.workflowFiles.occurrenceTotal).toBe(69);
-        expect(first.workflowFiles.byDisposition).toEqual({move: 7, 'pin-fetch': 12, retire: 0});
+        expect(first.workflowFiles.total).toBe(20);
+        expect(first.workflowFiles.occurrenceTotal).toBe(72);
+        expect(first.workflowFiles.byDisposition).toEqual({move: 7, 'pin-fetch': 13, retire: 0});
         expect(first.workflowFiles.residue).toEqual({diskMinusAuthority: [], authorityMinusDisk: []});
         expect(first.workflowFiles.rows.map(row => row.identity)).toEqual(workflowFiles.sort());
+        expect(first.workflowFiles.rows
+            .filter(row => row.disposition === WORKFLOW_FILE_DISPOSITION.move)
+            .every(row => row.targetRepository === 'neomjs/neo-agent-brain')).toBe(true);
+        expect(first.workflowFiles.rows
+            .filter(row => row.disposition === WORKFLOW_FILE_DISPOSITION.pinFetch)
+            .every(row => !Object.hasOwn(row, 'targetRepository') && typeof row.pinAuthority === 'string'))
+            .toBe(true);
         expect(first.consumerEdges.sourceClasses).toContainEqual(expect.objectContaining({
             identity   : 'test/playwright/unit/ai/**',
             disposition: 'moves-agentos-test',
@@ -1209,8 +1216,8 @@ test.describe('agentOsExtractionInventory — exact population × explicit autho
         expect(human).toContain('package.brain.json::devDependencies::better-sqlite3 @');
         expect(human).toContain('consumer-edge identities:');
         expect(human).toContain('preclassified source classes:');
-        expect(human).toContain('workflow-file identities: 19 · occurrences 69');
-        expect(human).toContain('pin-fetch: 12');
+        expect(human).toContain('workflow-file identities: 20 · occurrences 72');
+        expect(human).toContain('pin-fetch: 13');
         expect(human).toContain('Engine→AgentOS forbidden packages:');
 
         const keys = first.rows.map(row => rowKey(row.surface, row.identity));

--- a/test/playwright/unit/ai/scripts/diagnostics/agentOsExtractionInventory.spec.mjs
+++ b/test/playwright/unit/ai/scripts/diagnostics/agentOsExtractionInventory.spec.mjs
@@ -11,6 +11,7 @@ import {
     collectPackageDependencies,
     composeDependencyManifests,
     deriveRuntimeProbeTargets,
+    deriveWorkflowFilePopulation,
     discoverSubprocessLaunches,
     discoverWorkflowReferences,
     formatInventory,
@@ -21,13 +22,15 @@ import {
     reconcileConsumerEdges,
     reconcileConsumerSourceClasses,
     reconcileRuntimeProbeEligibility,
+    reconcileWorkflowFileDispositions,
     resolveTrackedConfigSpecifier,
     rowKey,
     CONSUMER_EDGE_DIRECTION,
     CONSUMER_EDGE_DISPOSITIONS,
     RUNTIME_PROBE_ELIGIBILITY,
     sourceBindingError,
-    SURFACE
+    SURFACE,
+    WORKFLOW_FILE_DISPOSITION
 }                       from '../../../../../../ai/scripts/diagnostics/agentOsExtractionInventory.mjs';
 import {resolveRelative}    from '../../../../../../ai/scripts/lint/scriptPlaneClosure.mjs';
 import {censusPlaneOpeners} from '../../../../../../ai/scripts/diagnostics/planePlacementCensus.mjs';
@@ -66,6 +69,148 @@ test.describe('agentOsExtractionInventory — exact population × explicit autho
             '.github/workflows/fixture.yml:3',
             '.github/workflows/fixture.yml:4'
         ])
+    });
+
+    test('workflow-file authority is one action per file, independent of occurrence plane custody', () => {
+        const
+            workflowA = '.github/workflows/a.yml',
+            workflowB = '.github/workflows/b.yml',
+            rows      = [{
+                surface    : SURFACE.workflowReference,
+                identity   : `${workflowA}::ai/scripts/a.mjs::1`,
+                disposition: 'edge',
+                evidence   : {workflowFile: workflowA, target: 'ai/scripts/a.mjs'}
+            }, {
+                surface    : SURFACE.workflowReference,
+                identity   : `${workflowA}::ai/scripts/b.mjs::1`,
+                disposition: 'cloud',
+                evidence   : {workflowFile: workflowA, target: 'ai/scripts/b.mjs'}
+            }, {
+                surface    : SURFACE.workflowReference,
+                identity   : `${workflowB}::ai/scripts/c.mjs::1`,
+                disposition: 'edge',
+                evidence   : {workflowFile: workflowB, target: 'ai/scripts/c.mjs'}
+            }],
+            population = deriveWorkflowFilePopulation(rows),
+            result     = reconcileWorkflowFileDispositions(rows, {
+                workflowFileDispositions: [{
+                    identity        : workflowA,
+                    disposition     : WORKFLOW_FILE_DISPOSITION.pinFetch,
+                    targetRepository: 'neomjs/neo-agent-brain',
+                    pinAuthority    : 'fixture immutable compatibility receipt',
+                    source          : 'fixture authority',
+                    rationale       : 'mixed target custody does not choose the file action'
+                }, {
+                    identity        : workflowB,
+                    disposition     : WORKFLOW_FILE_DISPOSITION.move,
+                    targetRepository: 'neomjs/neo-agent-brain',
+                    source          : 'fixture authority',
+                    rationale       : 'the workflow follows its AgentOS-owned subject'
+                }]
+            });
+
+        expect(population.errors).toEqual([]);
+        expect(population.rows).toHaveLength(2);
+        expect(result.ok).toBe(true);
+        expect(result.total).toBe(2);
+        expect(result.occurrenceTotal).toBe(3);
+        expect(result.byDisposition).toEqual({move: 1, 'pin-fetch': 1, retire: 0});
+        expect(result.rows[0]).toEqual(expect.objectContaining({
+            identity   : workflowA,
+            disposition: WORKFLOW_FILE_DISPOSITION.pinFetch,
+            evidence   : expect.objectContaining({
+                occurrenceCount       : 2,
+                occurrenceDispositions: ['cloud', 'edge']
+            })
+        }))
+    });
+
+    test('RED: workflow-file authority never infers, copies, duplicates, or outlives source', () => {
+        const
+            workflow = '.github/workflows/a.yml',
+            rows     = [{
+                surface    : SURFACE.workflowReference,
+                identity   : `${workflow}::ai/scripts/a.mjs::1`,
+                disposition: 'edge',
+                evidence   : {workflowFile: workflow, target: 'ai/scripts/a.mjs'}
+            }, {
+                surface    : SURFACE.workflowReference,
+                identity   : `${workflow}::ai/scripts/b.mjs::1`,
+                disposition: 'cloud',
+                evidence   : {workflowFile: workflow, target: 'ai/scripts/b.mjs'}
+            }],
+            missing = reconcileWorkflowFileDispositions(rows, {workflowFileDispositions: []}),
+            hostile = reconcileWorkflowFileDispositions(rows, {
+                workflowFileDispositions: [{
+                    identity   : workflow,
+                    disposition: 'copy',
+                    source     : 'fixture authority',
+                    rationale  : 'copy must never become a fourth action'
+                }, {
+                    identity        : workflow,
+                    disposition     : WORKFLOW_FILE_DISPOSITION.move,
+                    targetRepository: 'neomjs/neo-agent-brain',
+                    source          : 'duplicate fixture',
+                    rationale       : 'duplicate authority must stay visible'
+                }, {
+                    identity        : '.github/workflows/stale.yml',
+                    disposition     : WORKFLOW_FILE_DISPOSITION.move,
+                    targetRepository: 'neomjs/neo-agent-brain',
+                    pinAuthority    : 'metadata from the wrong action',
+                    source          : 'stale fixture',
+                    rationale       : 'authority without source must stay red'
+                }]
+            });
+
+        expect(missing.ok).toBe(false);
+        expect(missing.errors).toContainEqual({
+            kind: 'missing-workflow-file-authority', key: workflow
+        });
+        expect(hostile.ok).toBe(false);
+        expect(hostile.errors.map(error => error.kind)).toEqual(expect.arrayContaining([
+            'duplicate-workflow-file-authority',
+            'invalid-workflow-file-disposition',
+            'stale-workflow-file-authority',
+            'unexpected-workflow-file-metadata'
+        ]))
+    });
+
+    test('RED: every workflow-file action requires its own terminal authority metadata', () => {
+        const
+            files = ['move.yml', 'pin.yml', 'retire.yml'].map(name => `.github/workflows/${name}`),
+            rows  = files.map((workflowFile, index) => ({
+                surface    : SURFACE.workflowReference,
+                identity   : `${workflowFile}::ai/scripts/${index}.mjs::1`,
+                disposition: 'edge',
+                evidence   : {workflowFile, target: `ai/scripts/${index}.mjs`}
+            })),
+            result = reconcileWorkflowFileDispositions(rows, {
+                workflowFileDispositions: [{
+                    identity        : files[0],
+                    disposition     : WORKFLOW_FILE_DISPOSITION.move,
+                    targetRepository: 'neomjs/wrong-target',
+                    source          : 'fixture authority',
+                    rationale       : 'a move must name the canonical target repository'
+                }, {
+                    identity        : files[1],
+                    disposition     : WORKFLOW_FILE_DISPOSITION.pinFetch,
+                    targetRepository: 'neomjs/neo-agent-brain',
+                    source          : 'fixture authority',
+                    rationale       : 'a pin fetch must name its immutable ref authority'
+                }, {
+                    identity   : files[2],
+                    disposition: WORKFLOW_FILE_DISPOSITION.retire,
+                    source     : 'fixture authority',
+                    rationale  : 'a retirement must name its terminal evidence'
+                }]
+            });
+
+        expect(result.ok).toBe(false);
+        expect(result.errors.map(error => error.kind)).toEqual(expect.arrayContaining([
+            'invalid-workflow-move-target',
+            'missing-workflow-pin-authority',
+            'missing-workflow-retirement-evidence'
+        ]))
     });
 
     test('subprocess discovery uses executable AST calls, folds static strings, and ignores prose', () => {
@@ -909,7 +1054,8 @@ test.describe('agentOsExtractionInventory — exact population × explicit autho
                   .filter(file => /\.ya?ml$/.test(file))
                   .flatMap(file => discoverWorkflowReferences(
                       fs.readFileSync(path.join(REPO_ROOT, file), 'utf8'), file
-                  ));
+                  )),
+              workflowFiles = [...new Set(workflowReferences.map(row => row.identity.split('::', 1)[0]))];
 
         const packageDependencies = collectPackageDependencies({projectRoot: REPO_ROOT}).rows;
 
@@ -925,8 +1071,9 @@ test.describe('agentOsExtractionInventory — exact population × explicit autho
         expect(first.counts[SURFACE.scriptModule].total).toBe(scriptFiles.length);
         expect(first.counts[SURFACE.rootScript].total).toBe(packageScripts.length);
         expect(first.counts[SURFACE.workflowReference].total).toBe(workflowReferences.length);
+        expect(first.counts[SURFACE.workflowFile].total).toBe(workflowFiles.length);
         expect(first.counts[SURFACE.planeOpener].total).toBe(censusPlaneOpeners({projectRoot: REPO_ROOT}).total);
-        expect(first.schemaVersion).toBe('agentos-extraction-inventory.v4');
+        expect(first.schemaVersion).toBe('agentos-extraction-inventory.v5');
         expect(first.counts[SURFACE.launchRoot].total).toBe(first.launchRoots.total);
         expect(first.launchRoots.rows.map(row => row.identity))
             .toEqual(first.rows.filter(row => row.surface === SURFACE.launchRoot).map(row => row.identity));
@@ -964,6 +1111,11 @@ test.describe('agentOsExtractionInventory — exact population × explicit autho
         expect(first.consumerEdges.byDirection[CONSUMER_EDGE_DIRECTION.agentOsToOutside]).toBeGreaterThan(0);
         expect(first.consumerEdges.byDirection[CONSUMER_EDGE_DIRECTION.outsideToAgentOs]).toBeGreaterThan(0);
         expect(first.consumerEdges.residue).toEqual({diskMinusAuthority: [], authorityMinusDisk: []});
+        expect(first.workflowFiles.total).toBe(19);
+        expect(first.workflowFiles.occurrenceTotal).toBe(69);
+        expect(first.workflowFiles.byDisposition).toEqual({move: 7, 'pin-fetch': 12, retire: 0});
+        expect(first.workflowFiles.residue).toEqual({diskMinusAuthority: [], authorityMinusDisk: []});
+        expect(first.workflowFiles.rows.map(row => row.identity)).toEqual(workflowFiles.sort());
         expect(first.consumerEdges.sourceClasses).toContainEqual(expect.objectContaining({
             identity   : 'test/playwright/unit/ai/**',
             disposition: 'moves-agentos-test',
@@ -1057,6 +1209,8 @@ test.describe('agentOsExtractionInventory — exact population × explicit autho
         expect(human).toContain('package.brain.json::devDependencies::better-sqlite3 @');
         expect(human).toContain('consumer-edge identities:');
         expect(human).toContain('preclassified source classes:');
+        expect(human).toContain('workflow-file identities: 19 · occurrences 69');
+        expect(human).toContain('pin-fetch: 12');
         expect(human).toContain('Engine→AgentOS forbidden packages:');
 
         const keys = first.rows.map(row => rowKey(row.surface, row.identity));
@@ -1069,6 +1223,8 @@ test.describe('agentOsExtractionInventory — exact population × explicit autho
         first.rows.forEach(row => {
             if ([SURFACE.consumerEdge, SURFACE.consumerSourceClass].includes(row.surface)) {
                 expect(validConsumerDispositions.has(row.disposition)).toBe(true)
+            } else if (row.surface === SURFACE.workflowFile) {
+                expect(Object.values(WORKFLOW_FILE_DISPOSITION)).toContain(row.disposition)
             } else {
                 expect(['cloud', 'edge', 'retire', 'shared', 'stays-engine']).toContain(row.disposition)
             }
@@ -1089,6 +1245,7 @@ test.describe('agentOsExtractionInventory — exact population × explicit autho
             SURFACE.rootScript,
             SURFACE.scriptModule,
             SURFACE.subprocessLaunch,
+            SURFACE.workflowFile,
             SURFACE.workflowReference,
             SURFACE.consumerEdge,
             SURFACE.consumerSourceClass


### PR DESCRIPTION
Resolves #17699

The extraction inventory now derives one repository-cut authority row per AgentOS-touching workflow file. Current source binds 20 files / 72 occurrences to 7 `move`, 13 `pin-fetch`, and 0 `retire` actions; `copy` is not in the vocabulary. Missing, duplicate, stale, malformed, or action-incomplete rows make the same SHA-bound inventory red. No workflow YAML changes in this classification leaf.

Related: #17500

Decision Record impact: `depends-on ADR 0040`; `aligned-with ADR 0039`.

Evidence: L3 (real clean-tree inventory at `f38992fa5c`: schema v5, `ok:true`, 20/72, 7/13/0, zero residue/errors; mutation-sensitive focused guard 35/35) → L3 required (all close-target ACs are repository-local and executable). No residuals.

## AC Evidence

| AC-1 | `deriveWorkflowFilePopulation()` folds the source-derived `workflow-reference` rows; the clean receipt proves 20 files from 72 occurrences without a second file list. |
| AC-2 | `reconcileWorkflowFileDispositions()` requires one exact authority per derived file; current receipt has zero disk-minus-authority and authority-minus-disk. |
| AC-3 | `WORKFLOW_FILE_DISPOSITION` contains only `move`, `pin-fetch`, and `retire`; the hostile `copy` fixture fails with `invalid-workflow-file-disposition`. |
| AC-4 | The reconciler requires the canonical target repository only for `move`, immutable `pinAuthority` only for `pin-fetch`, and terminal evidence only for `retire`; cross-action metadata is red. |
| AC-5 | Focused hostile controls cover missing, duplicate, stale-extra, malformed metadata, and mixed Edge/Cloud occurrences with no inferred file action. |
| AC-6 | Existing occurrence rows retain their Edge/Cloud dispositions and remain in the general zero-residue report; the file-action layer composes as a separate surface. |
| AC-7 | JSON and human receipts expose sorted workflow rows, total/occurrence counts, 7/13/0 action counts, and schema `agentos-extraction-inventory.v5`. |
| AC-8 | Changed-file receipt contains only the existing inventory JSON, diagnostic, and focused unit spec; `.github/workflows/**` is untouched. |

## Deltas from ticket

Review restored the ticket's 1:1 metadata contract: `targetRepository` answers destination only for `move`; `pinAuthority` answers immutable fetch source for `pin-fetch`. Current `dev` also added `adr-status-lint.yml`, which the source-derived census correctly forced into the registry as the thirteenth pin-fetch workflow.

## Test Evidence

All coverage runs in CI.

## Post-Merge Validation

None. The committed inventory and focused unit guard are the standing dev-branch proof.

## Commits

- `667337d6d1` — derive and enforce workflow-file cut dispositions.
- `f38992fa5c` — disambiguate pin-fetch metadata and reconcile the new ADR-status workflow.

## Evolution

Ada's review caught one field answering opposite questions by action. The repair removes `targetRepository` from all pin-fetch rows, makes its presence there an error, and keeps `pinAuthority` as the sole fetch-source contract.

## Signal Ledger

- `gpt` author signal: Emmy's source-Discussion signal, carried by Epic #17500 at the corrected final body anchor.
- `claude` non-author signal: Vega's `[GRADUATION_APPROVED]`, revalidated in the independent Epic Review at https://github.com/neomjs/neo/issues/17500#issuecomment-5376063521.
- Family-keyed quorum remains current for the folded workflow-disposition leaf.

## Unresolved Dissent

None at the corrected Discussion/Epic authority anchor.

## Unresolved Liveness

Kimi is benched/unhosted and Gemini is operator-benched; neither absence is counted as consent, and neither is a hold gate under the Epic's recorded liveness disposition.

Authored by Emmy (GPT-5.6 Sol Ultra, Codex). Session 0dc1379e-5329-4fba-80ca-f6466822f7c9.
