### PR TITLE
fix(agentos): keep family resolution import-safe (#17702)

### DIFF
--- a/ai/services/github-workflow/PullRequestService.mjs
+++ b/ai/services/github-workflow/PullRequestService.mjs
@@ -971,7 +971,7 @@ async function buildMergeReadinessProjection({
                 authorFamily      : resolveAuthorFamilyFromLogins({
                     selfIdLogin: snapshot.authorSelfIdLogin,
                     openerLogin: snapshot.authorLogin
-                }) ?? null,
+                }, undefined, {warn: logger.warn}) ?? null,
                 approvalsTruncated: snapshot.approvals.hasPreviousPage,
                 reviews           : snapshot.approvals.nodes.map(node => ({state: 'APPROVED', author: {login: node.login}}))
             }),

--- a/ai/services/graph/GoldenPathSynthesizer.mjs
+++ b/ai/services/graph/GoldenPathSynthesizer.mjs
@@ -855,7 +855,7 @@ class GoldenPathSynthesizer extends Base {
      * @returns {(String|undefined)}
      */
     static resolveAuthorFamily(pr, agentFamilies) {
-        return resolvePrAuthorFamily(pr, agentFamilies)
+        return resolvePrAuthorFamily(pr, agentFamilies, {warn: logger.warn})
     }
 
     /**
@@ -865,7 +865,7 @@ class GoldenPathSynthesizer extends Base {
      * @returns {Boolean}
      */
     static hasCrossFamilyReview(pr, agentFamilies) {
-        return resolvePrCrossFamilyReview(pr, agentFamilies)
+        return resolvePrCrossFamilyReview(pr, agentFamilies, {warn: logger.warn})
     }
 
     /**

--- a/ai/services/graph/activePrCycleSection.mjs
+++ b/ai/services/graph/activePrCycleSection.mjs
@@ -1,4 +1,5 @@
 import aiConfig               from '../../mcp/server/memory-core/config.mjs';
+import logger                 from '../../mcp/server/memory-core/logger.mjs';
 import {hasCrossFamilyReview} from './agentFamilyResolution.mjs';
 
 /**
@@ -32,7 +33,7 @@ export function renderRecentOpenPrSummary(prs, {limit = aiConfig.goldenPathRecen
 
     for (const pr of recent) {
         const author = pr.author?.login || 'unknown';
-        section += `- **PR #${pr.number}**: ${pr.title} — author @${author} — opened ${pr.createdAt} — cross-family reviewed: ${hasCrossFamilyReview(pr) ? 'yes' : 'no'}\n`;
+        section += `- **PR #${pr.number}**: ${pr.title} — author @${author} — opened ${pr.createdAt} — cross-family reviewed: ${hasCrossFamilyReview(pr, undefined, {warn: logger.warn}) ? 'yes' : 'no'}\n`;
     }
 
     section += `\n`;

--- a/ai/services/graph/agentFamilyResolution.mjs
+++ b/ai/services/graph/agentFamilyResolution.mjs
@@ -1,7 +1,6 @@
 import {buildHydrationIndex} from '../../graph/identityHydration.mjs';
 import {migrateResident}     from '../../graph/identityRootsMigration.mjs';
 import {IDENTITIES}          from '../../graph/identityRoots.mjs';
-import logger                from '../../mcp/server/memory-core/logger.mjs';
 
 /**
  * @module ai/services/graph/agentFamilyResolution
@@ -10,9 +9,31 @@ import logger                from '../../mcp/server/memory-core/logger.mjs';
  *
  * Owner contract: resolve a maintainer's bare GitHub login + model family from the canonical
  * `identityRoots.mjs` roster (and a PR body's `Authored by …` self-id), and decide whether a PR
- * carries cross-family review coverage. These are stateless utilities over the identity roster;
+ * carries cross-family review coverage. These are import-safe utilities over the identity roster;
+ * runtime owners inject their warning sink rather than pulling a server logger/config closure into
+ * every source-only consumer.
  * `GoldenPathSynthesizer` keeps thin static delegating shims so its public API stays stable.
  */
+
+/**
+ * @summary Emits a non-fatal family-resolution warning through an injected source-neutral sink.
+ * Warning delivery must never change the family verdict, so a broken sink falls back to
+ * `console.warn` and a broken fallback is swallowed.
+ * @param {String} message
+ * @param {Function} [warn=console.warn]
+ * @private
+ */
+function emitWarning(message, warn=console.warn) {
+    try {
+        (typeof warn === 'function' ? warn : console.warn)(message)
+    } catch {
+        try {
+            console.warn(message)
+        } catch {
+            // Warning transport is optional; family resolution is not.
+        }
+    }
+}
 
 /**
  * The roster's family value for a seat whose underlying model is not publicly known — an unreleased
@@ -195,16 +216,26 @@ export function parseSelfIdLogin(body) {
  * @param {String|null} [logins.selfIdLogin] `@`-stripped login parsed from the body self-id.
  * @param {String|null} [logins.openerLogin] `@`-stripped GitHub opener login (advisory).
  * @param {Object} [agentFamilies=getCoreSwarmAgentFamilies()] Login-to-family map.
+ * @param {Object} [options]
+ * @param {Function} [options.warn=console.warn] Runtime-owner warning sink.
  * @returns {(String|undefined)} The model family, or undefined when neither login resolves.
  */
-export function resolveAuthorFamilyFromLogins({selfIdLogin = null, openerLogin = null} = {}, agentFamilies = getCoreSwarmAgentFamilies()) {
+export function resolveAuthorFamilyFromLogins(
+    {selfIdLogin = null, openerLogin = null} = {},
+    agentFamilies = getCoreSwarmAgentFamilies(),
+    {warn = console.warn} = {}
+) {
     const
         selfIdFamily = selfIdLogin ? agentFamilies[selfIdLogin] : undefined,
         openerFamily = openerLogin ? agentFamilies[openerLogin] : undefined;
 
     if (selfIdFamily) {
         if (openerFamily && openerFamily !== selfIdFamily) {
-            logger.warn(`[agentFamilyResolution] author identity drift — body self-id @${selfIdLogin} (${selfIdFamily}) != opener @${openerLogin} (${openerFamily}); using the canonical self-id.`);
+            emitWarning(
+                `[agentFamilyResolution] author identity drift — body self-id @${selfIdLogin} ` +
+                `(${selfIdFamily}) != opener @${openerLogin} (${openerFamily}); using the canonical self-id.`,
+                warn
+            )
         }
 
         return selfIdFamily
@@ -222,17 +253,28 @@ export function resolveAuthorFamilyFromLogins({selfIdLogin = null, openerLogin =
  * silently trusted. Model-name substring inference is deliberately NOT used — the self-id is the
  * canonical source, the login is the legacy bridge until every agent PR body carries `@identity`.
  * @param {Object} pr GitHub PR payload (`author`, `body`, `number`).
- * @param {Object} agentFamilies Login-to-family map (`@`-stripped logins).
+ * @param {Object} [agentFamilies=getCoreSwarmAgentFamilies()] Login-to-family map.
+ * @param {Object} [options]
+ * @param {Function} [options.warn=console.warn] Runtime-owner warning sink.
  * @returns {(String|undefined)} The model family, or undefined when neither source resolves.
  */
-export function resolveAuthorFamily(pr, agentFamilies) {
+export function resolveAuthorFamily(
+    pr,
+    agentFamilies = getCoreSwarmAgentFamilies(),
+    {warn = console.warn} = {}
+) {
     const selfIdLogin  = parseSelfIdLogin(pr?.body),
           selfIdFamily = selfIdLogin ? agentFamilies[selfIdLogin] : undefined,
           loginFamily  = agentFamilies[pr?.author?.login];
 
     if (selfIdFamily) {
         if (loginFamily && loginFamily !== selfIdFamily) {
-            logger.warn(`[GoldenPathSynthesizer] PR #${pr.number}: author identity drift — body self-id @${selfIdLogin} (${selfIdFamily}) != GitHub login @${pr.author?.login} (${loginFamily}); using the canonical self-id.`);
+            emitWarning(
+                `[GoldenPathSynthesizer] PR #${pr.number}: author identity drift — body self-id ` +
+                `@${selfIdLogin} (${selfIdFamily}) != GitHub login @${pr.author?.login} ` +
+                `(${loginFamily}); using the canonical self-id.`,
+                warn
+            )
         }
 
         return selfIdFamily
@@ -307,10 +349,12 @@ export function groupReviewsByFamily(reviews = [], agentFamilies = getCoreSwarmA
  *
  * @param {Object} pr GitHub PR payload from `gh pr list`.
  * @param {Object} [agentFamilies=getCoreSwarmAgentFamilies()] Login-to-family map.
+ * @param {Object} [options]
+ * @param {Function} [options.warn=console.warn] Runtime-owner warning sink.
  * @returns {Boolean}
  */
-export function hasCrossFamilyReview(pr, agentFamilies = getCoreSwarmAgentFamilies()) {
-    const verdict = resolveCrossFamilyVerdict(pr, agentFamilies);
+export function hasCrossFamilyReview(pr, agentFamilies = getCoreSwarmAgentFamilies(), options = {}) {
+    const verdict = resolveCrossFamilyVerdict(pr, agentFamilies, options);
 
     // `null` (author family unresolvable) maps to TRUE here, preserving this function's original
     // reading: an unrostered author is an EXTERNAL contributor, and the mandate exists to stop one
@@ -347,13 +391,15 @@ export function hasCrossFamilyReview(pr, agentFamilies = getCoreSwarmAgentFamili
  *
  * @param {Object} pr GitHub PR payload (`author`, `body`, `reviews`).
  * @param {Object} [agentFamilies=getCoreSwarmAgentFamilies()] Login-to-family map.
+ * @param {Object} [options]
+ * @param {Function} [options.warn=console.warn] Runtime-owner warning sink.
  * @returns {{crossFamily: (Boolean|null), authorFamily: (String|null), approvingFamilies: String[], unclassifiedApprovers: String[]}}
  */
-export function resolveCrossFamilyVerdict(pr, agentFamilies = getCoreSwarmAgentFamilies()) {
+export function resolveCrossFamilyVerdict(pr, agentFamilies = getCoreSwarmAgentFamilies(), options = {}) {
     const
         // A caller that already resolved the canonical author passes it directly; everyone else
         // keeps the body-parsing path. Same precedence either way — the self-id wins over the opener.
-        authorFamily = (pr?.authorFamily ?? resolveAuthorFamily(pr, agentFamilies)) ?? null,
+        authorFamily = (pr?.authorFamily ?? resolveAuthorFamily(pr, agentFamilies, options)) ?? null,
         reviews      = Array.isArray(pr?.reviews) ? pr.reviews : [],
         approvals    = reviews.filter(review => review?.state === 'APPROVED'),
         resolved     = approvals.map(review => resolveReviewerFamily(review, agentFamilies)),

--- a/test/playwright/unit/ai/services/graph/GoldenPathSynthesizer.spec.mjs
+++ b/test/playwright/unit/ai/services/graph/GoldenPathSynthesizer.spec.mjs
@@ -781,6 +781,34 @@ test.describe('Neo.ai.daemons.services.GoldenPathSynthesizer', () => {
         expect(section).toContain('### Recent Open PRs (`0` of `0` items)');
     });
 
+    test('#17702 Active PR rendering keeps author-drift warnings on the Memory Core logger', () => {
+        const consoleWarnings = [], memoryCoreWarnings = [], originalConsoleWarn = console.warn;
+
+        console.warn = message => consoleWarnings.push(message);
+        logger.warn   = message => memoryCoreWarnings.push(message);
+
+        try {
+            GoldenPathSynthesizer.constructor.renderActivePrCycleState({
+                capturedAt: new Date('2026-08-24T14:00:00.000Z'),
+                now       : new Date('2026-08-24T14:00:00.000Z'),
+                prs       : [{
+                    number   : 17702,
+                    title    : 'import-safe family resolution',
+                    createdAt: '2026-08-24T12:00:00.000Z',
+                    author   : {login: 'neo-opus-grace'},
+                    body     : 'Authored by Euclid (GPT-5, Codex Desktop). Session test.',
+                    reviews  : []
+                }]
+            })
+        } finally {
+            console.warn = originalConsoleWarn
+        }
+
+        expect(memoryCoreWarnings).toHaveLength(1);
+        expect(memoryCoreWarnings[0]).toContain('author identity drift');
+        expect(consoleWarnings).toEqual([])
+    });
+
     test('synthesizeGoldenPath skips Neo repo enrichment sections when deployment config disables them', async () => {
         const originalGetGraphCollection   = StorageRouter.getGraphCollection;
         const originalGetSummaryCollection = StorageRouter.getSummaryCollection;

--- a/test/playwright/unit/ai/services/graph/agentFamilyResolution.spec.mjs
+++ b/test/playwright/unit/ai/services/graph/agentFamilyResolution.spec.mjs
@@ -1,15 +1,18 @@
 import {test, expect} from '@playwright/test';
+import {spawnSync}    from 'node:child_process';
 import Neo            from '../../../../../../src/Neo.mjs';
 import '../../../../../../src/core/_export.mjs';
 
 import {
     getCoreSwarmAgentFamilies,
     groupReviewsByFamily,
+    resolveAuthorFamily,
+    resolveAuthorFamilyFromLogins,
     resolveResidentFamily,
     resolveReviewerFamily
 } from '../../../../../../ai/services/graph/agentFamilyResolution.mjs';
-import {IDENTITIES}                                       from '../../../../../../ai/graph/identityRoots.mjs';
-import {migrateResident}                                  from '../../../../../../ai/graph/identityRootsMigration.mjs';
+import {IDENTITIES}      from '../../../../../../ai/graph/identityRoots.mjs';
+import {migrateResident} from '../../../../../../ai/graph/identityRootsMigration.mjs';
 
 /**
  * Consumer-migration coverage for the identityRoots flat-fact retirement: the family read-path
@@ -18,6 +21,56 @@ import {migrateResident}                                  from '../../../../../.
  * map must be exactly what the flat read produced before the move.
  */
 test.describe('ai/services/graph/agentFamilyResolution — hydration-index family reads', () => {
+    test('#17702 pure consumers import without bootstrapping Neo or AiConfig', () => {
+        const child = spawnSync(process.execPath, ['--input-type=module', '--eval', [
+            'await import("./ai/services/graph/agentFamilyResolution.mjs");',
+            'await import("./ai/scripts/lifecycle/revalidationSweep.mjs");',
+            'process.stdout.write("IMPORT_SAFE");'
+        ].join(' ')], {
+            cwd     : process.cwd(),
+            encoding: 'utf8'
+        });
+
+        expect(child.status, child.stderr).toBe(0);
+        expect(child.stdout).toBe('IMPORT_SAFE')
+    });
+
+    test('#17702 runtime owners inject drift warnings without changing family verdicts', () => {
+        const
+            families = {'neo-gpt-emmy': 'gpt', 'neo-opus-grace': 'claude'},
+            warnings = [],
+            options  = {warn: message => warnings.push(message)};
+
+        expect(resolveAuthorFamilyFromLogins({
+            selfIdLogin: 'neo-gpt-emmy',
+            openerLogin: 'neo-opus-grace'
+        }, families, options)).toBe('gpt');
+        expect(resolveAuthorFamily({
+            number: 17702,
+            author: {login: 'neo-opus-grace'},
+            body  : 'Authored by Neo GPT Emmy (GPT-5.6 Sol Ultra, Codex). Session test.'
+        }, families, options)).toBe('gpt');
+
+        expect(warnings).toHaveLength(2);
+        expect(warnings[0]).toContain('author identity drift');
+        expect(warnings[1]).toContain('PR #17702');
+
+        const originalWarn = console.warn, fallbackWarnings = [];
+
+        console.warn = message => fallbackWarnings.push(message);
+
+        try {
+            expect(resolveAuthorFamilyFromLogins({
+                selfIdLogin: 'neo-gpt-emmy',
+                openerLogin: 'neo-opus-grace'
+            }, families, {warn: () => { throw new Error('broken sink') }})).toBe('gpt')
+        } finally {
+            console.warn = originalWarn
+        }
+
+        expect(fallbackWarnings).toHaveLength(1)
+    });
+
     test('REGRESSION AC: the login-to-family map is IDENTICAL to the flat-property derivation', () => {
         const flatDerived = Object.fromEntries(
             IDENTITIES


### PR DESCRIPTION
Resolves #17702

Family/reviewer resolution is import-safe again: the pure helper no longer imports the Memory Core logger/config closure. Every runtime owner—including the live Active PR Cycle renderer—injects its existing warning function; standalone consumers fall back to `console.warn`; warning failure never changes a family verdict. A fresh child now imports both the resolver and `revalidationSweep` without a Neo/AiConfig prelude.

Related: #17500

Decision Record impact: `aligned-with ADR 0019` C1/B5 and ADR 0039/0040 import-boundary semantics; no amendment.

Evidence: L3 (fresh child imports plus exact clean-SHA full plane proof at `27f91c2641`: instrument errors 1→0; topology unchanged at 44 findings / 35 blockers / 9 non-blockers) → L3 required (all #17702 ACs are import/runtime-observable). No residuals.

## AC Evidence

| AC-1 | Child-process witness imports `agentFamilyResolution.mjs` and `revalidationSweep.mjs` before Neo exists; direct commands print `AGENT_FAMILY_IMPORT_OK` / `REVALIDATION_SWEEP_IMPORT_OK`. |
| AC-2 | Resolver imports are now limited to identity hydration/migration/roster modules; no logger/AiConfig/ConfigProvider/Env/Neo edge remains. |
| AC-3 | Existing family/reviewer/cross-family matrices remain green in the 337-test changed-owner battery. |
| AC-4 | Injected warning tests cover both author-drift branches and a throwing sink; the fallback warns without changing the `gpt` verdict. |
| AC-5 | `GoldenPathSynthesizer` static shims and live Active PR Cycle renderer pass the Memory Core logger; `PullRequestService` passes the GitHub Workflow logger at its existing owner site. |
| AC-6 | The fresh child test fails if the runtime logger import returns even though the ordinary unit process imports the Neo prelude first. |
| AC-7 | Clean-SHA `agentOsPlaneBoundaryProof` at `27f91c2641` reports `instrumentErrors: []` and unchanged topology counts: 44 findings / 35 blockers / 9 non-blockers. |
| AC-8 | Resolver, Golden Path, GitHub Workflow reviewer, revalidation-sweep, and plane-boundary focused suites pass: 169/169. |

## Deltas from ticket

Review expanded the runtime-owner census from two to three: `activePrCycleSection.mjs` already owned the Memory Core config closure and now keeps author-drift warnings on that server's durable logger. The `agentFamilies` default widening is deliberate rather than incidental: it harmonizes the resolver with its siblings and resolves the canonical roster on omission instead of throwing.

## Test Evidence

- RED mutation: removing the Active PR Cycle sink argument flips exactly its channel arm red (Memory Core warning hits 1→0; setup/teardown remain green).
- GREEN: the changed-owner battery passes 169/169 at `27f91c2641`.
- Outside CI: `node ai/scripts/diagnostics/agentOsPlaneBoundaryProof.mjs --json` at clean head `27f91c2641` — source-bound, `dirtyPaths: []`, 0 instrument errors; topology unchanged at 44 / 35 / 9.
- Direct no-prelude imports remain covered for both resolver and sweep.

## Post-Merge Validation

None. The child-process regression and full proof are the standing import/instrument contract.

## Commits

- `fce347d13e` — remove the pure resolver's runtime logger dependency and inject owner sinks.
- `27f91c2641` — preserve the Memory Core channel at the live Active PR Cycle consumer.

## Evolution

Grace's two-way consumer probe found that the original Contract Ledger counted the Golden Path static shim but omitted its live extracted renderer. The ticket ledger now names all three runtime consumers, and the new arm pins the renderer's durable warning channel.

## Signal Ledger

- `gpt` author signal: Emmy's source-Discussion signal, carried by Epic #17500 at the corrected final body anchor.
- `claude` non-author signal: Vega's `[GRADUATION_APPROVED]`, revalidated in the independent Epic Review at https://github.com/neomjs/neo/issues/17500#issuecomment-5376063521.
- Family-keyed quorum remains current for this blocker-repair leaf.

## Unresolved Dissent

None at the corrected Discussion/Epic authority anchor.

## Unresolved Liveness

Kimi is benched/unhosted and Gemini is operator-benched; neither absence is counted as consent or a hold gate.

Authored by Emmy (GPT-5.6 Sol Ultra, Codex). Session 0dc1379e-5329-4fba-80ca-f6466822f7c9.

