### PR TITLE
test(backup): a bundle folder no longer stands in for the export that should fill it (#17711)

### DIFF
--- a/test/playwright/unit/ai/scripts/maintenance/backup.spec.mjs
+++ b/test/playwright/unit/ai/scripts/maintenance/backup.spec.mjs
@@ -27,6 +27,37 @@ import path            from 'path';
 // races. CI runs workers:1 (see playwright.config.unit.mjs) so this is local-DX only.
 test.describe.configure({mode: 'serial'});
 
+/**
+ * @summary Whether a copy subsystem's receipt accounts for itself — it copied rows, or it names the
+ * source that was absent.
+ *
+ * The distinction this exists to draw: a bundle folder is created before its subsystem runs, so
+ * folder existence proves nothing about whether anything landed in it. A receipt reading `copied: 0`
+ * with no explanation is the case that must fail — it is indistinguishable, from the outside, from a
+ * subsystem that silently did nothing. `ledgers` nests its own per-source receipts, so an accounted
+ * parent may carry the explanation entirely in its children.
+ *
+ * @param {Object} receipt A `subsystems.<name>` entry from `runBackup`.
+ * @returns {Boolean}
+ */
+function copyReceiptIsAccounted(receipt) {
+    if (!receipt || typeof receipt !== 'object') {
+        return false
+    }
+
+    if (Number.isFinite(receipt.copied) && receipt.copied > 0) {
+        return true
+    }
+
+    if (typeof receipt.note === 'string' && receipt.note.length > 0) {
+        return true
+    }
+
+    const nested = Object.values(receipt).filter(value => value && typeof value === 'object');
+
+    return nested.length > 0 && nested.every(copyReceiptIsAccounted)
+}
+
 test.describe('backup.mjs orchestrator — atomic bundle assembly (#10129 Phase 2)', () => {
     let SDK, fsExtra, runBackup;
     let KB_ChromaManager, Memory_StorageRouter;
@@ -101,7 +132,7 @@ test.describe('backup.mjs orchestrator — atomic bundle assembly (#10129 Phase 
         }
     });
 
-    test('produces a bundle with all 5 subfolders and routes populated subsystems into their JSONL slots', async () => {
+    test('every subsystem in the bundle either exported, or named the source it had none of (#16617)', async () => {
         const silentLogger = {log: () => {}, error: () => {}};
 
         const result = await runBackup({
@@ -113,9 +144,13 @@ test.describe('backup.mjs orchestrator — atomic bundle assembly (#10129 Phase 
 
         expect(result.bundleRoot).toBe(bundleRoot);
 
-        for (const sub of ['kb', 'mc', 'graph', 'concepts', 'trajectories']) {
-            expect(fs.existsSync(path.join(bundleRoot, sub))).toBe(true);
-        }
+        // The bundle's own layout, not a hand-counted subset of it. The list this replaced named
+        // five folders while `runBackup` creates seven — so `mailbox` and `ledgers` were outside
+        // every assertion in this file, which is exactly where a subsystem that exports nothing
+        // goes unnoticed.
+        expect(fs.readdirSync(bundleRoot).sort()).toEqual([
+            'bundle-meta.json', 'concepts', 'graph', 'kb', 'ledgers', 'mailbox', 'mc', 'trajectories'
+        ]);
 
         const kbFiles = fs.readdirSync(path.join(bundleRoot, 'kb')).filter(f => f.endsWith('.jsonl'));
         expect(kbFiles.length).toBe(1);
@@ -136,14 +171,38 @@ test.describe('backup.mjs orchestrator — atomic bundle assembly (#10129 Phase 
         expect(result.subsystems.trajectories).toEqual({copied: 1});
         expect(result.subsystems.mc.count).toBe(2);
 
-        const mcIntegrity = result.meta.integrity.find(check => check.subsystem === 'mc');
-        expect(mcIntegrity.status).toBe('pass');
-        expect(mcIntegrity.sourceCount).toBe(2);
-        expect(mcIntegrity.bundleCount).toBe(2);
+        // Every subsystem must prove it either EXPORTED or named its own zero. The folder-existence
+        // loop this replaced could not tell those apart — an empty directory satisfied it, so a
+        // subsystem that exported nothing looked identical to one that worked.
+        //
+        // No row counts are pinned for `graph`: its size comes from the run-scoped test graph store,
+        // so asserting a number would make this verdict track corpus fill, which is the defect this
+        // ticket exists to remove. `verifyBundleIntegrity` already compares source against bundle,
+        // and `pass` is reachable only above zero — zero-parity is reported as `empty` and a missing
+        // count as `skipped`. So `pass` carries "exported, and completely" without naming a size.
+        const integrityBy = Object.fromEntries(result.meta.integrity.map(check => [check.subsystem, check]));
 
-        // graph subfolder exists but GraphService.db is not wired in unit-test mode,
-        // so no graph-backup file is emitted. This is the documented "source has no data"
-        // branch per ticket AC ("non-empty content when the source subsystems have data").
+        expect(Object.keys(integrityBy).sort(), 'every recovery substrate is checked').toEqual(['graph', 'kb', 'mc']);
+
+        for (const subsystem of ['kb', 'mc', 'graph']) {
+            const check = integrityBy[subsystem];
+
+            expect(check.status, `${subsystem}: exported nothing, or its skip is unnamed`).toBe('pass');
+            expect(check.bundleCount, `${subsystem}: row-count parity`).toBe(check.sourceCount);
+            expect(check.sourceCount, `${subsystem}: a zero-row export is not a recovery source`)
+                .toBeGreaterThan(0);
+        }
+
+        // The copy subsystems. `mailbox` and `ledgers` genuinely have no source in this fixture, and
+        // that is the named-skip half: `copied: 0` is acceptable only when the receipt carries the
+        // note saying which source was absent. An unexplained zero fails.
+        for (const [subsystem, receipt] of Object.entries(result.subsystems)) {
+            if (['kb', 'mc', 'graph'].includes(subsystem)) {
+                continue
+            }
+
+            expect(copyReceiptIsAccounted(receipt), `${subsystem}: ${JSON.stringify(receipt)}`).toBe(true);
+        }
     });
 
     test('keeps the final root invisible until capture completes, then publishes it without staging residue (#16417)', async () => {

--- a/test/playwright/unit/ai/scripts/maintenance/backup.spec.mjs
+++ b/test/playwright/unit/ai/scripts/maintenance/backup.spec.mjs
@@ -27,8 +27,9 @@ import path            from 'path';
 // ordering has to be constrained; the other three blocks import pure functions and scope their
 // fixtures to a pid+timestamp temp dir. File-level serial made any failure in the first block skip
 // every test after it — 42 of them, measured — which reports "1 failed" while nothing else ran, and
-// a summary that hides its own blast radius is worse than a louder one. CI runs workers:1 (see
-// playwright.config.unit.mjs) so the constraint is local-DX either way.
+// a summary that hides its own blast radius is worse than a louder one. The constraint is NOT
+// local-DX-only: `playwright.config.unit.mjs` sets `workers: process.env.CI ? 4 : undefined`, so CI
+// runs four unit workers and the singleton race it guards is reachable there too.
 
 /**
  * @summary Whether a copy subsystem's receipt accounts for itself — it copied rows, or it names the
@@ -48,6 +49,17 @@ function copyReceiptIsAccounted(receipt) {
         return false
     }
 
+    const nested = Object.values(receipt).filter(value => value && typeof value === 'object');
+
+    // Nested receipts are checked FIRST and regardless of the aggregate. An earlier revision
+    // returned on a positive `copied` before looking down, so `{copied: 2, recoveryRuns: {copied: 0}}`
+    // — a real shape this suite already fixtures — passed with an unexplained nested zero, which is
+    // the exact case this predicate exists to catch. A positive parent does not account for a silent
+    // child.
+    if (!nested.every(copyReceiptIsAccounted)) {
+        return false
+    }
+
     if (Number.isFinite(receipt.copied) && receipt.copied > 0) {
         return true
     }
@@ -56,9 +68,34 @@ function copyReceiptIsAccounted(receipt) {
         return true
     }
 
-    const nested = Object.values(receipt).filter(value => value && typeof value === 'object');
+    // A zero aggregate over children that each named their own absence is accounted; a bare
+    // `{copied: 0}` leaf is not.
+    return nested.length > 0
+}
 
-    return nested.length > 0 && nested.every(copyReceiptIsAccounted)
+/**
+ * @summary Whether a recovery substrate's integrity check names a legitimate outcome.
+ *
+ * Every outcome `verifyBundleIntegrity` can emit is stated explicitly, because a property is
+ * corpus-independent only when it accepts each legitimate state by name rather than requiring the
+ * one that happens to occur. `pass` means rows were exported and the counts agree. `empty` is the
+ * declared zero-parity outcome and is legitimate here: `storagePaths.graphTest` is `':memory:'`, so
+ * the run-scoped graph carries whatever the process happened to write and may hold nothing. `fail`
+ * and `skipped` are never accounted.
+ *
+ * @param {Object} check One `meta.integrity` entry.
+ * @returns {Boolean}
+ */
+function integrityOutcomeIsAccounted(check) {
+    if (check?.status === 'pass') {
+        return check.sourceCount > 0 && check.bundleCount === check.sourceCount
+    }
+
+    if (check?.status === 'empty') {
+        return check.sourceCount === 0 && check.bundleCount === 0
+    }
+
+    return false
 }
 
 test.describe('backup.mjs orchestrator — atomic bundle assembly (#10129 Phase 2)', () => {
@@ -180,23 +217,30 @@ test.describe('backup.mjs orchestrator — atomic bundle assembly (#10129 Phase 
         // loop this replaced could not tell those apart — an empty directory satisfied it, so a
         // subsystem that exported nothing looked identical to one that worked.
         //
-        // No row counts are pinned for `graph`: its size comes from the run-scoped test graph store,
-        // so asserting a number would make this verdict track corpus fill, which is the defect this
-        // ticket exists to remove. `verifyBundleIntegrity` already compares source against bundle,
-        // and `pass` is reachable only above zero — zero-parity is reported as `empty` and a missing
-        // count as `skipped`. So `pass` carries "exported, and completely" without naming a size.
+        // The strictness is split by what the fixture actually controls, which is the only honest
+        // place to put it. `kb` and `mc` are seeded here, so they must reach `pass` above zero. The
+        // graph is NOT seeded: `storagePaths.graphTest` is `':memory:'`, so its rows are whatever the
+        // process happened to write, and demanding `pass` would make this verdict depend on ambient
+        // in-process fill — removing an exact count does not remove that dependency, which is the
+        // defect this ticket is named after. It is held to the property instead: every legitimate
+        // outcome named, `fail` and `skipped` never accepted.
         const integrityBy = Object.fromEntries(result.meta.integrity.map(check => [check.subsystem, check]));
 
         expect(Object.keys(integrityBy).sort(), 'every recovery substrate is checked').toEqual(['graph', 'kb', 'mc']);
 
-        for (const subsystem of ['kb', 'mc', 'graph']) {
+        for (const subsystem of ['kb', 'mc']) {
             const check = integrityBy[subsystem];
 
-            expect(check.status, `${subsystem}: exported nothing, or its skip is unnamed`).toBe('pass');
+            expect(check.status, `${subsystem}: seeded by this fixture, so it must export`).toBe('pass');
             expect(check.bundleCount, `${subsystem}: row-count parity`).toBe(check.sourceCount);
             expect(check.sourceCount, `${subsystem}: a zero-row export is not a recovery source`)
                 .toBeGreaterThan(0);
         }
+
+        expect(
+            integrityOutcomeIsAccounted(integrityBy.graph),
+            `graph: ${JSON.stringify(integrityBy.graph)} is neither a complete export nor a declared zero`
+        ).toBe(true);
 
         // The copy subsystems. `mailbox` and `ledgers` genuinely have no source in this fixture, and
         // that is the named-skip half: `copied: 0` is acceptable only when the receipt carries the
@@ -208,6 +252,53 @@ test.describe('backup.mjs orchestrator — atomic bundle assembly (#10129 Phase 
 
             expect(copyReceiptIsAccounted(receipt), `${subsystem}: ${JSON.stringify(receipt)}`).toBe(true);
         }
+    });
+
+    // Both predicates above decide the verdict of the arm before this one, so they are proved here
+    // against constructed inputs rather than against whatever the run-scoped graph happens to hold.
+    // That is the point: a property is corpus-independent only if its own proof is.
+    test('an integrity outcome is accounted only when it names a complete export or a declared zero (#17711)', () => {
+        // The two legitimate states, both accepted — this is the pair that makes the graph arm hold
+        // whether the `:memory:` store carries rows or nothing.
+        expect(integrityOutcomeIsAccounted({status: 'pass',  sourceCount: 17, bundleCount: 17})).toBe(true);
+        expect(integrityOutcomeIsAccounted({status: 'empty', sourceCount: 0,  bundleCount: 0})).toBe(true);
+
+        // `fail` and `skipped` are the outcomes a green must never absorb.
+        expect(integrityOutcomeIsAccounted({status: 'fail',    sourceCount: 17, bundleCount: 3})).toBe(false);
+        expect(integrityOutcomeIsAccounted({status: 'skipped', reason: 'no numeric source count'})).toBe(false);
+
+        // A torn write that still calls itself `pass`, and a `pass` at zero — both must be refused,
+        // because `pass` is the status the loop trusts.
+        expect(integrityOutcomeIsAccounted({status: 'pass', sourceCount: 17, bundleCount: 3})).toBe(false);
+        expect(integrityOutcomeIsAccounted({status: 'pass', sourceCount: 0,  bundleCount: 0})).toBe(false);
+
+        // An `empty` whose counts disagree is not the declared zero-parity state.
+        expect(integrityOutcomeIsAccounted({status: 'empty', sourceCount: 0, bundleCount: 4})).toBe(false);
+        expect(integrityOutcomeIsAccounted(undefined)).toBe(false);
+    });
+
+    test('a positive aggregate does not account for an unexplained nested zero (#17711)', () => {
+        // The regression this predicate was rewritten for: an earlier revision returned on a
+        // positive `copied` before inspecting children, so a silent nested zero rode a healthy
+        // parent. `ledgers` is exactly that shape and this suite already fixtures it.
+        expect(copyReceiptIsAccounted({copied: 2, recoveryRuns: {copied: 0}})).toBe(false);
+
+        // Same parent, child now naming its own absence — accounted.
+        expect(copyReceiptIsAccounted({
+            copied      : 2,
+            recoveryRuns: {copied: 0, note: 'source not present: recovery-runs'}
+        })).toBe(true);
+
+        // A zero aggregate over children that each named their absence is accounted; a bare leaf zero
+        // is not, whatever nesting sits above it.
+        expect(copyReceiptIsAccounted({
+            copied      : 0,
+            healAttempts: {copied: 0, note: 'source not present: heal-attempts.json'},
+            healEvents  : {copied: 0, note: 'source not present: data-heal-events'}
+        })).toBe(true);
+        expect(copyReceiptIsAccounted({copied: 0})).toBe(false);
+        expect(copyReceiptIsAccounted({copied: 3})).toBe(true);
+        expect(copyReceiptIsAccounted(null)).toBe(false);
     });
 
     test('keeps the final root invisible until capture completes, then publishes it without staging residue (#16417)', async () => {

--- a/test/playwright/unit/ai/scripts/maintenance/backup.spec.mjs
+++ b/test/playwright/unit/ai/scripts/maintenance/backup.spec.mjs
@@ -22,10 +22,13 @@ import InstanceManager from '../../../../../../src/manager/Instance.mjs';
 import fs              from 'fs';
 import path            from 'path';
 
-// Serial mode: this file mutates KB + MC singleton collection accessors across
-// beforeAll/afterAll. Serial ordering within this file prevents local multi-worker
-// races. CI runs workers:1 (see playwright.config.unit.mjs) so this is local-DX only.
-test.describe.configure({mode: 'serial'});
+// Serial mode is declared on the ONE describe that needs it, not on the file. Only the orchestrator
+// block mutates KB + MC singleton collection accessors across beforeAll/afterAll, so only its
+// ordering has to be constrained; the other three blocks import pure functions and scope their
+// fixtures to a pid+timestamp temp dir. File-level serial made any failure in the first block skip
+// every test after it — 42 of them, measured — which reports "1 failed" while nothing else ran, and
+// a summary that hides its own blast radius is worse than a louder one. CI runs workers:1 (see
+// playwright.config.unit.mjs) so the constraint is local-DX either way.
 
 /**
  * @summary Whether a copy subsystem's receipt accounts for itself — it copied rows, or it names the
@@ -59,6 +62,8 @@ function copyReceiptIsAccounted(receipt) {
 }
 
 test.describe('backup.mjs orchestrator — atomic bundle assembly (#10129 Phase 2)', () => {
+    test.describe.configure({mode: 'serial'});
+
     let SDK, fsExtra, runBackup;
     let KB_ChromaManager, Memory_StorageRouter;
     let originalKbCollection, originalMcGetMemory, originalMcGetSummary;


### PR DESCRIPTION
Resolves neomjs/neo#17711

> 🌿 A bundle folder can no longer stand in for the export that was supposed to fill it, a single fault can no longer report itself as the only one, and neither assertion needs the graph to be full.

Related: neomjs/neo-agent-brain#57

Two test-integrity defects in `backup.spec.mjs`, both measured before being fixed, plus three repairs from round-1 review.

**1. A folder stood in for its export.** The spec asserted five bundle subfolders exist. `runBackup` ensures every layout folder *before* any subsystem runs, so existence proves nothing about contents — and the list was stale: seven folders are created, five were named, leaving `mailbox` and `ledgers` outside every assertion in the file. Both export nothing here. Replaced with a property: each recovery substrate's integrity outcome must be a **named legitimate** one, and each copy subsystem must have copied rows or carry the `note` naming its absent source.

**2. One failure hid forty-two tests.** `test.describe.configure({mode: 'serial'})` sat at file scope, so any fault in the orchestrator block skipped everything after it. Moved onto the one block that earns it — the only one mutating the KB/MC singleton accessors across its hooks.

Evidence: L3 (in-process execution plus four reverted source mutations; a pure Node/Playwright unit surface the sandbox reaches fully) → L3 required (two ACs are worded "red-proved by mutation" and "measured before/after"). No residuals.

## AC Evidence

| AC-1 | Every subsystem asserted EXPORTED or named its absent source — MUTATION A: dropping the `note` from `copyJsonlSource`'s absent-source return fails with `mailbox: {"copied":0}`. Nested leaves are now checked too: `{copied: 2, recoveryRuns: {copied: 0}}` fails, pinned by a dedicated arm |
| AC-2 | Folder assertion is an equality against the bundle's own layout (all eight entries incl. `bundle-meta.json`), not a hand-counted subset — an unasserted eighth folder fails it |
| AC-3 | No count pinned for `graph`, **and the arm holds on an empty store** — MUTATION D: graph row counts forced to zero (an initialized store with no rows, AC-3's exact state) yields `{status: 'empty', 0/0}` and the arm passes. `fail`, `skipped`, torn `pass` and `pass`-at-zero are all rejected, pinned by a table-driven arm against constructed inputs |
| AC-4 | Orchestrator-block failure no longer aborts the other three — MUTATION C: injected `beforeAll` throw gives **before 1 failed / 42 did not run / 2 passed · after 1 failed / 22 did not run / 22 passed** |
| AC-5 | `serial` still declared on the singleton-mutating block; the other three blocks import pure functions into pid+timestamp temp dirs |
| AC-6 | Focused spec **47/47 green** at `b91add1d61` |

## Deltas from ticket

**Round-2 repairs, all three verified at source before being accepted.**

- **The graph arm was corpus-coupled and my reasoning for it was a non-sequitur.** `storagePaths.graphTest` is `':memory:'`, so the run-scoped graph holds whatever the process happened to write; the 17 rows previously observed were ambient fill, not seeded. Asserting `status === 'pass'` therefore *required* non-empty ambient fill. "`pass` is unreachable at zero" implies "asserting `pass` demands non-zero" — I had written the reverse. Replaced with `integrityOutcomeIsAccounted`, which names every legitimate outcome; `kb` and `mc` are seeded here and stay held to `pass` above zero, because strictness belongs where the fixture controls the data.
- **`copyReceiptIsAccounted` short-circuited on a positive aggregate**, so `{copied: 2, recoveryRuns: {copied: 0}}` — a shape this suite already fixtures — passed with an unexplained nested zero. Nested receipts are now checked first and regardless of the aggregate, which makes the round-1 claim about catching nested silent zeros true rather than aspirational.
- **The header claimed CI runs one unit worker.** `playwright.config.unit.mjs` sets `workers: process.env.CI ? 4 : undefined`, so the singleton race the serial constraint guards is reachable in CI, not local-DX only. Corrected, constraint unchanged.

**Retraction — my own round-1 red-proof for the graph arm no longer holds, and should not.** Round 1 claimed MUTATION B (forcing `#exportGraph`'s uninitialised-graph branch) "still goes red", offered as evidence the arm was premise-independent. Measured at this head: that branch yields `{status: 'empty', 0/0}` and is now **accepted**. It was red before only because the arm demanded `pass` — i.e. the red was the defect, not the proof. The graph arm's real red-proof is the table-driven rejection of `fail` / `skipped` / torn `pass` / `pass`-at-zero.

**The parent ticket's premise for AC-1 also did not survive execution.** neomjs/neo-agent-brain#57 claimed `#exportGraph` always takes its uninitialised branch in a host run, so `graph/` is created while nothing is exported. Graph in fact exports and reaches `pass` under ambient fill, because the `UNIT_TEST_MODE` `graphTest` formula wires it — which neomjs/neo-agent-brain#57's body had recorded as "safe-by-construction" two corrections earlier and then reasoned past. neomjs/neo-agent-brain#57 carries the retraction and the measurement.

**AC-4's shape was corrected on the parent, not weakened.** neomjs/neo-agent-brain#57's wording also demanded "a failure count without a `did not run` count for that file" — a different *set* from "42 sibling tests": 20 tests in unrelated blocks versus all 42. Playwright skips the remainder of a serial scope after any failure, so the residual 22 are the orchestrator block's own tests. neomjs/neo#17711's AC-4 states the reachable property; its Out of Scope records why zero is not it.

**Found while sizing, deliberately not fixed here:** `copyJsonlSource` returns `{copied: jsonlFiles.length}` with no `note` for a source directory that exists but holds zero `.jsonl` files (`backup.mjs:1452`, warn-only). A genuine production silent-zero that the new assertion fails on at the top level — repairing production behaviour does not belong in a test-integrity PR. Recorded on neomjs/neo-agent-brain#57.

## Test Evidence

- **GREEN** `npm run test-unit -- test/playwright/unit/ai/scripts/maintenance/backup.spec.mjs --workers=1` — **47/47** at `b91add1d61`.
- **MEASURED, mutation D** (AC-3) — graph row counts forced to zero, the initialized-but-empty state AC-3 names: `{"subsystem":"graph","status":"empty","sourceCount":0,"bundleCount":0}` and the arm **passes**. The pre-repair assertion rejected this exact state.
- **MEASURED, mutation B** — forcing the uninitialised-graph branch also yields `status: 'empty'`, likewise accepted. Recorded because it retires a round-1 claim of mine rather than supporting one.
- **RED, mutation A** (AC-1) — `note` dropped from `copyJsonlSource`'s absent-source return: `Error: mailbox: {"copied":0}`. **Positive control, same run:** the failure lands after the folder assertion passed, so every assertion the replaced five-folder loop made still held under it.
- **MEASURED, mutation C** (AC-4) — injected `beforeAll` throw: `before 1 failed · 42 did not run · 2 passed` → `after 1 failed · 22 did not run · 22 passed`.
- **Property-level red proofs, no ambient dependence:** two new arms assert both predicates against constructed inputs — every integrity outcome (`pass` positive-parity accepted; `empty` zero-parity accepted; `fail`, `skipped`, torn `pass`, `pass`-at-zero rejected) and every receipt shape (bare `{copied: 0}` rejected; positive parent over a silent child rejected; zero parent over children that each named their absence accepted).
- **Negative result, kept:** converting the orchestrator block's hooks to `beforeEach`/`afterEach` to force failures instead of skips left the count at **22** — the hook type is not what causes the skip — and would have cost nineteen fixture rebuilds. Reverted rather than kept as an unearned behaviour change.
- All four mutations reverted; `git diff origin/dev` on this branch touches one file.

## Post-Merge Validation

None. Both assertions are unit-suite contracts running in the standing `unit` job. The production silent-zero path the new assertion guards (`backup.mjs:1452`) is recorded on neomjs/neo-agent-brain#57; nothing here defers to a post-merge observation.

## Deltas

See **Deltas from ticket** above — three round-2 repairs, one retraction of my own round-1 evidence claim, neomjs/neo-agent-brain#57's graph-vacuity premise retracted in its body with the measurement that falsified it, and the AC-4 clause conflation recorded there rather than met in its weaker half.

Authored by Vega (Opus 5, Claude Code). Memory Core session `cad88c79-073f-4816-aaa7-e779224f2af3`.
