### PR TITLE
feat(lifecycle): the nightly runner delivers as an MCP client (#17714)

### DIFF
--- a/ai/scripts/lifecycle/nightly-e2e/README.md
+++ b/ai/scripts/lifecycle/nightly-e2e/README.md
@@ -26,12 +26,13 @@ simply never install it.
 #    green. The credential is the same NEO_MCP_REMOTE_TOKEN your other remote MCP clients use.
 REPO="$(git rev-parse --show-toplevel)"
 mkdir -p "$REPO/.neo-ai-data/nightly-e2e/logs" ~/Library/LaunchAgents
-sed -e "s#__NEO_REPO_ROOT__#$REPO#g" \
+# The subshell's umask makes the destination restrictive AT CREATION. A later `chmod 600` would
+# leave a window in which the secret is on disk world-readable — short, but real, and avoidable.
+(umask 077 && sed -e "s#__NEO_REPO_ROOT__#$REPO#g" \
     -e "s#__NEO_PATH__#$PATH#g" \
     -e "s#__NEO_MCP_REMOTE_TOKEN__#${NEO_MCP_REMOTE_TOKEN:?export NEO_MCP_REMOTE_TOKEN before rendering}#g" \
   "$REPO/ai/scripts/lifecycle/nightly-e2e/com.neomjs.nightly-e2e.plist" \
-  > ~/Library/LaunchAgents/com.neomjs.nightly-e2e.plist
-chmod 600 ~/Library/LaunchAgents/com.neomjs.nightly-e2e.plist   # the rendered copy carries a secret
+  > ~/Library/LaunchAgents/com.neomjs.nightly-e2e.plist)
 
 # 2. Load it (fires only on schedule — RunAtLoad is false).
 launchctl bootstrap "gui/$(id -u)" ~/Library/LaunchAgents/com.neomjs.nightly-e2e.plist

--- a/ai/scripts/lifecycle/nightly-e2e/README.md
+++ b/ai/scripts/lifecycle/nightly-e2e/README.md
@@ -20,12 +20,18 @@ simply never install it.
 ## Activate (macOS, per-user LaunchAgent)
 
 ```sh
-# 1. Render the template with your absolute repo root.
+# 1. Render the template with your absolute repo root, PATH, and Memory Core credential.
+#    A launchd session inherits NOTHING from your shell: without these the run reaches the MCP
+#    client with no token and no node on PATH, and fails every night while every local test stays
+#    green. The credential is the same NEO_MCP_REMOTE_TOKEN your other remote MCP clients use.
 REPO="$(git rev-parse --show-toplevel)"
 mkdir -p "$REPO/.neo-ai-data/nightly-e2e/logs" ~/Library/LaunchAgents
-sed "s#__NEO_REPO_ROOT__#$REPO#g" \
+sed -e "s#__NEO_REPO_ROOT__#$REPO#g" \
+    -e "s#__NEO_PATH__#$PATH#g" \
+    -e "s#__NEO_MCP_REMOTE_TOKEN__#${NEO_MCP_REMOTE_TOKEN:?export NEO_MCP_REMOTE_TOKEN before rendering}#g" \
   "$REPO/ai/scripts/lifecycle/nightly-e2e/com.neomjs.nightly-e2e.plist" \
   > ~/Library/LaunchAgents/com.neomjs.nightly-e2e.plist
+chmod 600 ~/Library/LaunchAgents/com.neomjs.nightly-e2e.plist   # the rendered copy carries a secret
 
 # 2. Load it (fires only on schedule — RunAtLoad is false).
 launchctl bootstrap "gui/$(id -u)" ~/Library/LaunchAgents/com.neomjs.nightly-e2e.plist
@@ -44,8 +50,19 @@ cat .neo-ai-data/nightly-e2e/last-run.json          # {at, red, configs:[{config
 ls  .neo-ai-data/nightly-e2e/logs/                  # per-run logs + launchd.{out,err}.log
 ```
 
-On a **red** run the digest arrives in the A2A mailbox from `@system` (subject `[nightly-e2e][RED] …`), naming
-the failing specs. On a **green** run nothing is sent — silence is the signal.
+On a **red** run the digest arrives in the A2A mailbox (subject `[nightly-e2e][RED] …`), naming the failing
+specs. On a **green** run nothing is sent — silence is the signal.
+
+The digest is delivered as an authenticated **MCP client** of the containerized Memory Core, not through
+in-process service imports (#17708). That is not a style choice: this process is host-resident because e2e
+needs GPU hardware, while the graph lives in a container, so an in-process write would land in a host store
+no reader serves — succeeding locally and arriving nowhere. Its sender is therefore the identity
+`NEO_MCP_REMOTE_TOKEN` resolves to, not the literal `@system` it used to pass; use an automation credential
+rather than a maintainer seat, so a red digest is not mistaken for a person who ran it and is looking at it.
+
+Because delivery is now a network call, it can fail loudly — and that is the point. `last-run.json` carries
+`digest: 'failed'` with the error when it does, and `unresolvedRed` keeps an undelivered red visible across
+later green runs so a recovery night cannot erase it.
 
 ## Add a suite
 

--- a/ai/scripts/lifecycle/nightly-e2e/com.neomjs.nightly-e2e.plist
+++ b/ai/scripts/lifecycle/nightly-e2e/com.neomjs.nightly-e2e.plist
@@ -21,6 +21,21 @@
     <key>WorkingDirectory</key>
     <string>__NEO_REPO_ROOT__</string>
 
+    <!--
+      A `launchd` session inherits none of an interactive shell's environment, and the runner
+      delivers its digest as an authenticated MCP client of the containerized Memory Core.
+      Without these the nightly run reaches the client with no credential and no `node` on PATH —
+      and it would fail EVERY night while every local test stayed green, because an interactive
+      shell supplies both. Same substitution pattern as the sibling agent-os plists.
+    -->
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>PATH</key>
+        <string>__NEO_PATH__</string>
+        <key>NEO_MCP_REMOTE_TOKEN</key>
+        <string>__NEO_MCP_REMOTE_TOKEN__</string>
+    </dict>
+
     <key>StartCalendarInterval</key>
     <dict>
         <key>Hour</key>

--- a/ai/scripts/lifecycle/nightlyE2eRunner.mjs
+++ b/ai/scripts/lifecycle/nightlyE2eRunner.mjs
@@ -16,6 +16,18 @@
  * and `sent` or `failed` after it. A crash between the two leaves `pending` standing, so an
  * undelivered digest can never read as delivered.
  *
+ * The digest is delivered as an MCP CLIENT of the containerized Memory Core, not through in-process
+ * service imports. This process is host-resident by construction — the e2e layer needs GPU
+ * hardware and a headed browser, which is the whole reason it lives outside CI — while the graph it
+ * must reach is served from a container. An in-process `MailboxService` here resolves against the
+ * HOST plane root, which no reader serves: the write succeeds and the digest arrives nowhere. Its
+ * sibling lifecycle scripts keep their in-process imports correctly, because the orchestrator daemon
+ * runs them INSIDE the container; this one never made that trip and cannot.
+ *
+ * Delivery therefore fails loudly by construction. An unreachable or unauthenticated Memory Core
+ * throws at connect, which the disposition machinery above records as `failed` — where a local write
+ * to an unserved store would have returned success.
+ *
  * Hardening (the middleware-scheduler LaunchAgent precedent): an exclusive PID lockfile with stale-steal, a run log,
  * structured stderr, and finally-hygiene that always releases the lock. LaunchAgent-staged (not auto-installed);
  * see ai/scripts/lifecycle/nightly-e2e/README for activation. CRITICAL inherited rule: custom playwright configs
@@ -28,10 +40,10 @@ import {spawnSync}                                         from 'node:child_proc
 import path                                                from 'node:path';
 import {fileURLToPath}                                     from 'node:url';
 import fs                                                  from 'fs-extra';
-import GraphService                                        from '../../services/memory-core/GraphService.mjs';
-import LifecycleService                                    from '../../services/memory-core/lifecycle/SystemLifecycleService.mjs';
-import MailboxService                                      from '../../services/memory-core/MailboxService.mjs';
-import RequestContextService                               from '../../mcp/server/shared/services/RequestContextService.mjs';
+import Neo             from '../../../src/Neo.mjs';
+import '../../../src/core/_export.mjs';
+import Client                                              from '../../mcp/client/Client.mjs';
+import {REMOTE_MCP_CREDENTIAL_ENV_VAR}                     from '../../services/fleet/mcpServers.mjs';
 import {buildRunLog, collectFailures, formatDigest, isRed} from './nightlyE2eDigest.mjs';
 
 /**
@@ -127,17 +139,13 @@ export function runConfig(entry, {spawn = spawnSync} = {}) {
  * Every collaborator is injectable for the same reason `runConfig` takes its spawn: the delivery
  * paths are the ones worth proving, and a module-level import cannot be driven from a test.
  * @param {Object}   [options]
- * @param {Function} [options.addMessage] A2A send seam.
- * @param {Function} [options.graphReady] Graph readiness seam.
- * @param {Function} [options.lifecycleReady] Lifecycle readiness seam.
+ * @param {Function} [options.connect] Memory Core client seam — resolves to `{callTool, close}`.
  * @param {Function} [options.runOne] Per-config execution seam.
  * @returns {Promise<Object>} run outcome `{red, sent, reason?}`.
  */
 export async function runNightlyE2e({
-    addMessage     = options => MailboxService.addMessage(options),
-    graphReady     = () => GraphService.ready(),
-    lifecycleReady = () => LifecycleService.ready(),
-    runOne         = runConfig
+    connect = connectMemoryCore,
+    runOne  = runConfig
 } = {}) {
     const nowIso  = new Date().toISOString(),
           logPath = `${STATE_DIR}/logs/run-${nowIso.replace(/[:.]/g, '-')}.log`;
@@ -175,24 +183,25 @@ export async function runNightlyE2e({
             return {red: false, sent: false};
         }
 
-        const sender = process.env.NEO_AGENT_IDENTITY || '@system';
+        let client = null;
 
         try {
-            await lifecycleReady();
-            await graphReady();
+            // Connect FIRST and separately from the call: an unreachable or unauthenticated Memory
+            // Core must be distinguishable from a rejected message, and both must be distinguishable
+            // from success. The client throws here on a missing credential, which is the property
+            // that makes an unattended run's misconfiguration loud instead of nightly-silent.
+            client = await connect();
 
-            await RequestContextService.run({agentIdentityNodeId: sender}, async () => {
-                await addMessage({
-                    to      : 'AGENT:*',
-                    subject : `[nightly-e2e][RED] ${outcomes.reduce((n, o) => n + o.failures.length, 0)} failing whitebox-e2e spec(s) — ${nowIso.slice(0, 10)}`,
-                    body    : formatDigest(outcomes, logPath),
-                    priority: 'normal',
-                    // A red suite is action-required BY DEFINITION, and a broadcast defaults to
-                    // suppressed, so silence here would be inherited rather than chosen. This is the
-                    // only per-message lever: the wake tier is one boolean on the message, so it
-                    // wakes every seat or none. Green never reaches this call and stays un-woken.
-                    wakeSuppressed: false
-                });
+            await client.callTool('add_message', {
+                to      : 'AGENT:*',
+                subject : `[nightly-e2e][RED] ${outcomes.reduce((n, o) => n + o.failures.length, 0)} failing whitebox-e2e spec(s) — ${nowIso.slice(0, 10)}`,
+                body    : formatDigest(outcomes, logPath),
+                priority: 'normal',
+                // A red suite is action-required BY DEFINITION, and a broadcast defaults to
+                // suppressed, so silence here would be inherited rather than chosen. This is the
+                // only per-message lever: the wake tier is one boolean on the message, so it
+                // wakes every seat or none. Green never reaches this call and stays un-woken.
+                wakeSuppressed: false
             });
         } catch (error) {
             // The reporter failing is not the suite passing. `pending` already stands on disk, so
@@ -206,6 +215,11 @@ export async function runNightlyE2e({
                 logPath, nowIso, outcomes, red
             }).catch(() => {});
             throw error
+        } finally {
+            // The transport is per-run, so it closes on every path. A leaked connection would keep an
+            // unattended process alive past its work, and `launchd` would treat that as a run still
+            // in flight rather than a finished one.
+            await client?.close?.().catch(() => {});
         }
 
         // Written only after delivery RESOLVED. `sent` is recorded, never derived.
@@ -220,6 +234,41 @@ export async function runNightlyE2e({
     } finally {
         await fs.remove(LOCK_PATH).catch(() => {});
     }
+}
+
+/**
+ * @summary Opens an authenticated MCP client against the containerized Memory Core.
+ *
+ * The `memory-core` client entry is already declared (`ai/mcp/client/config.mjs`) as
+ * `streamable-http` against the local ingress with a required bearer credential, so this adds no
+ * transport surface — it consumes the one every other host-side client uses.
+ *
+ * Nothing is caught here on purpose. A missing credential, an unreachable ingress, or a rejected
+ * token must reach the caller so the receipt records `failed` and the process exits non-zero. The
+ * failure this replaces was the opposite: an in-process write to a host store no reader serves,
+ * which returned success every time.
+ *
+ * The credential is checked BEFORE construction, and that ordering is load-bearing rather than
+ * stylistic. `Neo.create()` runs `initAsync()` inside a detached promise with no rejection handler
+ * (`src/core/Base.mjs:314`), so a throw in there never reaches `ready()` — the ready promise simply
+ * never resolves. An unattended run would then HANG until the 6h stale-lock steal instead of
+ * recording a failed delivery, which is a strictly worse failure than the silent one this leaf
+ * exists to remove. Validating first keeps the loud path loud.
+ * @returns {Promise<Object>} A connected client exposing `callTool` and `close`.
+ */
+async function connectMemoryCore() {
+    if (!process.env[REMOTE_MCP_CREDENTIAL_ENV_VAR]?.trim()) {
+        throw new Error(
+            `nightlyE2eRunner: ${REMOTE_MCP_CREDENTIAL_ENV_VAR} is missing or empty — the RED digest cannot reach Memory Core. ` +
+            `An unattended run needs it in the LaunchAgent's EnvironmentVariables; see ai/scripts/lifecycle/nightly-e2e/README.md.`
+        );
+    }
+
+    const client = Neo.create(Client, {serverName: 'memory-core'});
+
+    await client.ready();
+
+    return client
 }
 
 /**

--- a/ai/scripts/lifecycle/nightlyE2eRunner.mjs
+++ b/ai/scripts/lifecycle/nightlyE2eRunner.mjs
@@ -62,6 +62,15 @@ const STATE_DIR     = '.neo-ai-data/nightly-e2e',
       LOCK_STALE_MS = 6 * 60 * 60 * 1000;   // 6h — a nightly run that outlives this is a hung process; steal the lock
 
 /**
+ * How long the Memory Core client may take to become ready before the run calls it a failed
+ * delivery. This is a FAILURE DEADLINE, not a wait: the happy path resolves in milliseconds and
+ * never observes it. It exists because framework readiness has no rejection path, so without a
+ * deadline an unreachable ingress produces a pending promise rather than an error.
+ * @type {Number}
+ */
+const CONNECT_DEADLINE_MS = 30 * 1000;
+
+/**
  * @summary Acquires the exclusive runner lock, stealing it only when the holder is provably stale (> 6h). A
  * fresh lock means another nightly run is in flight — abort rather than double-run the suite.
  * @param {String} nowIso ISO timestamp for the lock stamp.
@@ -140,12 +149,14 @@ export function runConfig(entry, {spawn = spawnSync} = {}) {
  * paths are the ones worth proving, and a module-level import cannot be driven from a test.
  * @param {Object}   [options]
  * @param {Function} [options.connect] Memory Core client seam — resolves to `{callTool, close}`.
+ * @param {Number}   [options.connectDeadlineMs=CONNECT_DEADLINE_MS] Failure deadline for the seam.
  * @param {Function} [options.runOne] Per-config execution seam.
  * @returns {Promise<Object>} run outcome `{red, sent, reason?}`.
  */
 export async function runNightlyE2e({
-    connect = connectMemoryCore,
-    runOne  = runConfig
+    connect           = connectMemoryCore,
+    connectDeadlineMs = CONNECT_DEADLINE_MS,
+    runOne            = runConfig
 } = {}) {
     const nowIso  = new Date().toISOString(),
           logPath = `${STATE_DIR}/logs/run-${nowIso.replace(/[:.]/g, '-')}.log`;
@@ -190,9 +201,14 @@ export async function runNightlyE2e({
             // Core must be distinguishable from a rejected message, and both must be distinguishable
             // from success. The client throws here on a missing credential, which is the property
             // that makes an unattended run's misconfiguration loud instead of nightly-silent.
-            client = await connect();
+            client = await connectWithinDeadline(connect(), connectDeadlineMs);
 
-            await client.callTool('add_message', {
+            // MCP has TWO success boundaries and only the first one throws. The protocol request
+            // resolving means the server answered; whether it ACCEPTED is carried in the result, and
+            // our own servers say so by resolving `{isError: true}` (`ai/mcp/server/BaseServer.mjs`).
+            // Writing `sent` on a resolved call alone would record a refused digest as delivered —
+            // this leaf's original defect, one layer up and behind a green suite.
+            const result = await client.callTool('add_message', {
                 to      : 'AGENT:*',
                 subject : `[nightly-e2e][RED] ${outcomes.reduce((n, o) => n + o.failures.length, 0)} failing whitebox-e2e spec(s) — ${nowIso.slice(0, 10)}`,
                 body    : formatDigest(outcomes, logPath),
@@ -203,6 +219,14 @@ export async function runNightlyE2e({
                 // wakes every seat or none. Green never reaches this call and stays un-woken.
                 wakeSuppressed: false
             });
+
+            if (result?.isError) {
+                // Surface the server's own words rather than a generic label: the disposition says
+                // delivery failed, and the reason is the only thing that says why.
+                const detail = result.content?.map(block => block?.text).filter(Boolean).join(' ') || 'no detail supplied';
+
+                throw new Error(`Memory Core refused the digest: ${detail}`)
+            }
         } catch (error) {
             // The reporter failing is not the suite passing. `pending` already stands on disk, so
             // the red survives even if THIS write also fails — the receipt degrades from `failed`
@@ -269,6 +293,41 @@ async function connectMemoryCore() {
     await client.ready();
 
     return client
+}
+
+/**
+ * @summary Rejects a connection attempt that never settles, so an unreachable dependency is a
+ * failure rather than a hang.
+ *
+ * `Client.ready()` can only ever RESOLVE: `Neo.create` runs `initAsync` in a detached promise with no
+ * rejection handler (`src/core/Base.mjs:314`), and `#readyPromise` is settled solely by
+ * `afterSetIsReady`. So a rejected credential, an unreachable ingress, or a failed handshake leaves
+ * it pending forever, and awaiting it alone would hang the unattended run to the 6h stale-lock
+ * steal — the silence this leaf exists to remove, with extra steps.
+ *
+ * The deadline wraps the SEAM rather than living inside the default connect, because the guarantee
+ * belongs to the runner: a caller that supplies its own connection must not be able to remove the
+ * runner's only protection against never being answered.
+ *
+ * The `setTimeout` here is a self-naming failure deadline, not a wait — the happy path resolves in
+ * milliseconds and never observes it.
+ * @param {Promise} attempt The in-flight connection.
+ * @param {Number}  deadlineMs
+ * @returns {Promise<Object>} The connected client.
+ */
+function connectWithinDeadline(attempt, deadlineMs) {
+    let timer;
+
+    return Promise.race([
+        Promise.resolve(attempt).finally(() => clearTimeout(timer)),
+        new Promise((resolve, reject) => {
+            timer = setTimeout(() => reject(new Error(
+                `nightlyE2eRunner: the Memory Core connection did not settle within ${deadlineMs}ms — ` +
+                `unreachable ingress, a rejected credential, or a failed handshake. Framework readiness ` +
+                `cannot report which, because initialization rejection is not wired into it.`
+            )), deadlineMs)
+        })
+    ])
 }
 
 /**

--- a/ai/scripts/lifecycle/nightlyE2eRunner.mjs
+++ b/ai/scripts/lifecycle/nightlyE2eRunner.mjs
@@ -56,9 +56,9 @@ const E2E_CONFIGS = [
     {config: 'test/playwright/playwright.config.e2e.mjs', results: 'test-results/e2e/results.json'}
 ];
 
+// Only the DIRECTORY is a constant. Its children are derived per run by `bindPlane`, so no code path
+// can resolve one of them against a cwd that moved after the run started.
 const STATE_DIR     = '.neo-ai-data/nightly-e2e',
-      LOCK_PATH     = `${STATE_DIR}/runner.lock`,
-      STATE_PATH    = `${STATE_DIR}/last-run.json`,
       LOCK_STALE_MS = 6 * 60 * 60 * 1000;   // 6h — a nightly run that outlives this is a hung process; steal the lock
 
 /**
@@ -71,16 +71,37 @@ const STATE_DIR     = '.neo-ai-data/nightly-e2e',
 const CONNECT_DEADLINE_MS = 30 * 1000;
 
 /**
+ * @summary Binds this run's plane to absolute paths, once, before any await.
+ *
+ * `STATE_DIR` and its children are repo-relative, so every use resolves against `process.cwd()` AT
+ * THAT MOMENT. Between acquiring the lock and releasing it the run performs a network round-trip,
+ * and any cwd change in that window silently renames the lock: the release looks in the new plane,
+ * finds nothing, and leaves the real lock behind — after which every run for the next six hours
+ * aborts believing one is still in flight. The receipt can split the same way.
+ *
+ * Binding once removes the dependency entirely. A run's plane is wherever it started, and nothing
+ * that happens mid-run can move it.
+ * @param {String} [stateDir=STATE_DIR] Plane directory; callers that must not depend on cwd pass it.
+ * @returns {{dir: String, lockPath: String, statePath: String}}
+ */
+function bindPlane(stateDir=STATE_DIR) {
+    const dir = path.resolve(stateDir);
+
+    return {dir, lockPath: path.join(dir, 'runner.lock'), statePath: path.join(dir, 'last-run.json')}
+}
+
+/**
  * @summary Acquires the exclusive runner lock, stealing it only when the holder is provably stale (> 6h). A
  * fresh lock means another nightly run is in flight — abort rather than double-run the suite.
  * @param {String} nowIso ISO timestamp for the lock stamp.
+ * @param {Object} plane Bound plane from {@link bindPlane}.
  * @returns {Promise<Boolean>} `true` when the lock is held by this process, `false` when a fresh run owns it.
  */
-async function acquireLock(nowIso) {
-    await fs.ensureDir(STATE_DIR);
+async function acquireLock(nowIso, {dir, lockPath}) {
+    await fs.ensureDir(dir);
 
-    if (await fs.pathExists(LOCK_PATH)) {
-        const held    = await fs.readJson(LOCK_PATH).catch(() => null),
+    if (await fs.pathExists(lockPath)) {
+        const held    = await fs.readJson(lockPath).catch(() => null),
               heldAt  = held?.at ? new Date(held.at).getTime() : 0,
               staleMs = Date.now() - heldAt;
 
@@ -91,7 +112,7 @@ async function acquireLock(nowIso) {
         console.error(`[nightlyE2eRunner] Stealing stale lock (held ${held?.at ?? 'unknown'}, > ${LOCK_STALE_MS}ms).`);
     }
 
-    await fs.writeJson(LOCK_PATH, {pid: process.pid, at: nowIso}, {spaces: 2});
+    await fs.writeJson(lockPath, {pid: process.pid, at: nowIso}, {spaces: 2});
     return true;
 }
 
@@ -151,19 +172,43 @@ export function runConfig(entry, {spawn = spawnSync} = {}) {
  * @param {Function} [options.connect] Memory Core client seam — resolves to `{callTool, close}`.
  * @param {Number}   [options.connectDeadlineMs=CONNECT_DEADLINE_MS] Failure deadline for the seam.
  * @param {Function} [options.runOne] Per-config execution seam.
+ * @param {String}   [options.stateDir=STATE_DIR] Plane directory seam — an explicit value makes a run's
+ *     plane independent of `process.cwd()` entirely, which a caller sharing a process needs.
  * @returns {Promise<Object>} run outcome `{red, sent, reason?}`.
  */
 export async function runNightlyE2e({
     connect           = connectMemoryCore,
     connectDeadlineMs = CONNECT_DEADLINE_MS,
-    runOne            = runConfig
+    runOne            = runConfig,
+    stateDir          = STATE_DIR
 } = {}) {
-    const nowIso  = new Date().toISOString(),
-          logPath = `${STATE_DIR}/logs/run-${nowIso.replace(/[:.]/g, '-')}.log`;
+    // Bound BEFORE the first await, so nothing that happens mid-run can move this run's plane.
+    const plane   = bindPlane(stateDir),
+          nowIso  = new Date().toISOString(),
+          logPath = path.join(plane.dir, `logs/run-${nowIso.replace(/[:.]/g, '-')}.log`);
 
-    if (!(await acquireLock(nowIso))) {
+    if (!(await acquireLock(nowIso, plane))) {
         return {red: false, sent: false, reason: 'lock-held'};
     }
+
+    // The runner owns this process, so it owns its rejection policy for the duration of the run.
+    // `Neo.create` runs `initAsync` detached, so a rejected credential surfaces as an UNHANDLED
+    // rejection and Node's default policy kills the process on the spot — verified against the live
+    // ingress as a fatal `StreamableHTTPError … HTTP 401`, no catch reached, the receipt stuck at
+    // `pending`, and the lock left behind so the next six hours of runs abort believing one is live.
+    //
+    // The sink spans the WHOLE run, not just the connect: a client whose readiness failed was never
+    // returned and therefore never closed, and its transport keeps rejecting afterwards. Dying on
+    // THAT straggler would abandon the receipt and the lock just as effectively as dying on the first.
+    const lateRejection = {deliver: null},
+          onUnhandled   = reason => {
+              const error = reason instanceof Error ? reason : new Error(String(reason));
+
+              if (lateRejection.deliver) lateRejection.deliver(error);
+              else console.error(`[nightlyE2eRunner] late transport rejection, after the delivery decision: ${error.message}`)
+          };
+
+    process.on('unhandledRejection', onUnhandled);
 
     try {
         const outcomes = E2E_CONFIGS.map(entry => runOne(entry)),
@@ -178,7 +223,7 @@ export async function runNightlyE2e({
         // fresh receipt without consulting the previous one is write-only across invocations: the
         // green path below would overwrite an earlier red whose digest never left the host, and that
         // red exists on no other surface.
-        const carriedRed = resolveCarriedRed(await readPriorReceipt());
+        const carriedRed = resolveCarriedRed(await readPriorReceipt(plane.statePath));
 
         if (carriedRed) {
             console.error(`[nightlyE2eRunner] Carrying forward an unreported red from ${carriedRed.at ?? 'an unreadable receipt'} (digest: ${carriedRed.digest}).`);
@@ -187,7 +232,7 @@ export async function runNightlyE2e({
         // A red receipt starts as `pending`, never as an absent field. Inferring delivery from
         // `red` alone would publish "sent" for a digest that never left: a crash between this write
         // and the send is indistinguishable from success unless the state exists BEFORE the attempt.
-        await writeRunReceipt({digest: red ? 'pending' : 'not-required', logPath, nowIso, outcomes, red, unresolvedRed: carriedRed});
+        await writeRunReceipt({digest: red ? 'pending' : 'not-required', logPath, nowIso, outcomes, red, statePath: plane.statePath, unresolvedRed: carriedRed});
 
         if (!red) {
             console.error('[nightlyE2eRunner] All declared e2e configs green — staying silent.');
@@ -201,7 +246,7 @@ export async function runNightlyE2e({
             // Core must be distinguishable from a rejected message, and both must be distinguishable
             // from success. The client throws here on a missing credential, which is the property
             // that makes an unattended run's misconfiguration loud instead of nightly-silent.
-            client = await connectWithinDeadline(connect(), connectDeadlineMs);
+            client = await connectWithinDeadline(connect, connectDeadlineMs, lateRejection);
 
             // MCP has TWO success boundaries and only the first one throws. The protocol request
             // resolving means the server answered; whether it ACCEPTED is carried in the result, and
@@ -236,6 +281,7 @@ export async function runNightlyE2e({
                 digest       : 'failed',
                 digestError  : String(error?.message ?? error),
                 unresolvedRed: carriedRed,
+                statePath    : plane.statePath,
                 logPath, nowIso, outcomes, red
             }).catch(() => {});
             throw error
@@ -252,11 +298,12 @@ export async function runNightlyE2e({
         // fact an earlier one did not is no longer load-bearing — the suite's red state is reported and
         // actionable. Carrying it past a successful delivery would make the field permanent noise, and
         // a field that is always set stops being read.
-        await writeRunReceipt({digest: 'sent', logPath, nowIso, outcomes, red, unresolvedRed: null});
+        await writeRunReceipt({digest: 'sent', logPath, nowIso, outcomes, red, statePath: plane.statePath, unresolvedRed: null});
         console.error('[nightlyE2eRunner] RED digest sent to AGENT:* (wakeSuppressed: false).');
         return {red: true, sent: true};
     } finally {
-        await fs.remove(LOCK_PATH).catch(() => {});
+        process.off('unhandledRejection', onUnhandled);
+        await fs.remove(plane.lockPath).catch(() => {});
     }
 }
 
@@ -315,19 +362,41 @@ async function connectMemoryCore() {
  * @param {Number}  deadlineMs
  * @returns {Promise<Object>} The connected client.
  */
-function connectWithinDeadline(attempt, deadlineMs) {
+async function connectWithinDeadline(connect, deadlineMs, onLateRejection) {
     let timer;
 
-    return Promise.race([
-        Promise.resolve(attempt).finally(() => clearTimeout(timer)),
-        new Promise((resolve, reject) => {
+    try {
+        return await new Promise((resolve, reject) => {
+            // THE LOAD-BEARING LINE. `Neo.create` runs `initAsync` detached, so a rejected credential
+            // surfaces as an UNHANDLED rejection — and Node's default policy kills the process on the
+            // spot. Verified against the live ingress with an invalid token: a fatal
+            // `StreamableHTTPError: … HTTP 401` and exit 1, before any `catch` in this module runs.
+            //
+            // A deadline cannot help with that: the process is gone before it fires. The receipt is
+            // left at `pending` and — worse — the lock survives, so the NEXT six hours of runs abort
+            // believing one is still in flight. A crash is not a quiet failure; it is a failure that
+            // takes the next runs with it.
+            //
+            // Owning the process's rejection policy for the duration of the connect is the
+            // entrypoint's job, and this is the only place that can turn that crash back into a value.
+            // Scoped to the window and removed in `finally`, so it cannot swallow anything later.
+            onLateRejection.deliver = reject;
+
+            // Not a wait — a self-naming failure deadline for the case that does stay pending, since
+            // `ready()` has no reject path of its own (`src/core/Base.mjs:305`, settled only by
+            // `afterSetIsReady`).
             timer = setTimeout(() => reject(new Error(
                 `nightlyE2eRunner: the Memory Core connection did not settle within ${deadlineMs}ms — ` +
-                `unreachable ingress, a rejected credential, or a failed handshake. Framework readiness ` +
-                `cannot report which, because initialization rejection is not wired into it.`
-            )), deadlineMs)
+                `unreachable ingress or a stalled handshake. Framework readiness cannot report which, ` +
+                `because initialization rejection is not wired into it.`
+            )), deadlineMs);
+
+            Promise.resolve(connect()).then(resolve, reject)
         })
-    ])
+    } finally {
+        clearTimeout(timer);
+        onLateRejection.deliver = null
+    }
 }
 
 /**
@@ -338,15 +407,16 @@ function connectWithinDeadline(attempt, deadlineMs) {
  * an unparseable one means the delivery chain is broken and this run cannot know what preceded it.
  * Returning `null` for both would silently promote the broken case to the clean one — the precise
  * inference this module exists to prevent.
+ * @param {String} statePath Absolute receipt path from {@link bindPlane}.
  * @returns {Promise<{state: String, receipt: (Object|null)}>} `absent` | `read` | `unreadable`.
  */
-async function readPriorReceipt() {
-    if (!(await fs.pathExists(STATE_PATH))) {
+async function readPriorReceipt(statePath) {
+    if (!(await fs.pathExists(statePath))) {
         return {state: 'absent', receipt: null};
     }
 
     try {
-        return {state: 'read', receipt: await fs.readJson(STATE_PATH)}
+        return {state: 'read', receipt: await fs.readJson(statePath)}
     } catch (error) {
         return {state: 'unreadable', receipt: null, error: String(error?.message ?? error)}
     }
@@ -406,11 +476,12 @@ function resolveCarriedRed({state, receipt, error}) {
  * @param {String}   options.nowIso
  * @param {Object[]} options.outcomes
  * @param {Boolean}  options.red
+ * @param {String}   options.statePath Absolute receipt path from {@link bindPlane}.
  * @param {Object}   [options.unresolvedRed] Earlier undelivered red carried into this receipt.
  * @returns {Promise<void>}
  */
-async function writeRunReceipt({digest, digestError, logPath, nowIso, outcomes, red, unresolvedRed}) {
-    await fs.writeJson(STATE_PATH, {
+async function writeRunReceipt({digest, digestError, logPath, nowIso, outcomes, red, statePath, unresolvedRed}) {
+    await fs.writeJson(statePath, {
         at     : nowIso,
         red,
         digest,

--- a/test/playwright/unit/ai/scripts/lifecycle/nightlyE2eRunner.spec.mjs
+++ b/test/playwright/unit/ai/scripts/lifecycle/nightlyE2eRunner.spec.mjs
@@ -82,6 +82,14 @@ test.describe('nightlyE2eRunner.runNightlyE2e — delivery disposition and wake 
     const
         stateFile  = () => path.join(tmpDir, '.neo-ai-data/nightly-e2e/last-run.json'),
         readState  = async () => fs.readJson(stateFile()),
+        // One seam replaces the former addMessage/graphReady/lifecycleReady trio: the runner reaches
+        // Memory Core as an MCP client, so "could not connect" and "the call was rejected"
+        // are distinct failures without separate readiness hooks. The stub carries `callTool` rather
+        // than a bare send, so the arms assert the real tool NAME and not just its payload.
+        connectStub = (onCall = () => {}) => async () => ({
+            callTool: async (name, args) => onCall(name, args),
+            close   : async () => {}
+        }),
         redOutcome = entry => ({
             config  : entry.config,
             failures: [{title: 'a failing spec', file: 'x.spec.mjs', error: 'boom'}],
@@ -112,14 +120,15 @@ test.describe('nightlyE2eRunner.runNightlyE2e — delivery disposition and wake 
         const sent = [];
 
         const result = await runNightlyE2e({
-            addMessage    : async options => { sent.push(options) },
-            graphReady    : async () => {},
-            lifecycleReady: async () => {},
-            runOne        : redOutcome
+            connect: connectStub((name, args) => { sent.push({name, ...args}) }),
+            runOne : redOutcome
         });
 
         expect(result).toMatchObject({red: true, sent: true});
         expect(sent).toHaveLength(1);
+        // The tool NAME is part of the contract now, not just the payload: the digest travels as an
+        // `add_message` call against Memory Core, and a rename on either side must fail here.
+        expect(sent[0].name).toBe('add_message');
         expect(sent[0].wakeSuppressed).toBe(false);
         expect(sent[0].to).toBe('AGENT:*');
         expect(sent[0].subject).toContain('[nightly-e2e][RED]')
@@ -129,10 +138,8 @@ test.describe('nightlyE2eRunner.runNightlyE2e — delivery disposition and wake 
         const sent = [];
 
         const result = await runNightlyE2e({
-            addMessage    : async options => { sent.push(options) },
-            graphReady    : async () => {},
-            lifecycleReady: async () => {},
-            runOne        : greenOutcome
+            connect: connectStub((name, args) => { sent.push({name, ...args}) }),
+            runOne : greenOutcome
         });
 
         expect(result).toMatchObject({red: false, sent: false});
@@ -142,10 +149,8 @@ test.describe('nightlyE2eRunner.runNightlyE2e — delivery disposition and wake 
 
     test('delivery is RECORDED, not derived: a successful send writes `sent`', async () => {
         await runNightlyE2e({
-            addMessage    : async () => {},
-            graphReady    : async () => {},
-            lifecycleReady: async () => {},
-            runOne        : redOutcome
+            connect: connectStub(),
+            runOne : redOutcome
         });
 
         expect(await readState()).toMatchObject({red: true, digest: 'sent'})
@@ -153,10 +158,8 @@ test.describe('nightlyE2eRunner.runNightlyE2e — delivery disposition and wake 
 
     test('a THROWING send records `failed` durably and rethrows — the red is not lost', async () => {
         await expect(runNightlyE2e({
-            addMessage    : async () => { throw new Error('mailbox unreachable') },
-            graphReady    : async () => {},
-            lifecycleReady: async () => {},
-            runOne        : redOutcome
+            connect: connectStub(() => { throw new Error('mailbox unreachable') }),
+            runOne : redOutcome
         })).rejects.toThrow('mailbox unreachable');
 
         expect(await readState()).toMatchObject({
@@ -170,10 +173,10 @@ test.describe('nightlyE2eRunner.runNightlyE2e — delivery disposition and wake 
         // The state that used to be indistinguishable from success: the receipt is written before
         // the attempt, so an undelivered digest cannot be re-derived as delivered.
         await expect(runNightlyE2e({
-            addMessage    : async () => {},
-            graphReady    : async () => {},
-            lifecycleReady: async () => { throw new Error('graph never became ready') },
-            runOne        : redOutcome
+            // Now a CONNECT failure rather than a readiness failure — the transport is the thing that
+            // can be unreachable, and it fails before any message is attempted.
+            connect: async () => { throw new Error('graph never became ready') },
+            runOne : redOutcome
         })).rejects.toThrow('graph never became ready');
 
         expect(await readState()).toMatchObject({red: true, digest: 'failed'});
@@ -181,10 +184,8 @@ test.describe('nightlyE2eRunner.runNightlyE2e — delivery disposition and wake 
 
     test('the lock is released on the failure path too', async () => {
         await expect(runNightlyE2e({
-            addMessage    : async () => { throw new Error('nope') },
-            graphReady    : async () => {},
-            lifecycleReady: async () => {},
-            runOne        : redOutcome
+            connect: connectStub(() => { throw new Error('nope') }),
+            runOne : redOutcome
         })).rejects.toThrow('nope');
 
         expect(await fs.pathExists(path.join(tmpDir, '.neo-ai-data/nightly-e2e/runner.lock'))).toBe(false)
@@ -197,10 +198,8 @@ test.describe('nightlyE2eRunner.runNightlyE2e — delivery disposition and wake 
 
     test('a GREEN run cannot erase an unsent red — the undelivered digest is carried forward', async () => {
         await expect(runNightlyE2e({
-            addMessage    : async () => { throw new Error('mailbox unreachable') },
-            graphReady    : async () => {},
-            lifecycleReady: async () => {},
-            runOne        : redOutcome
+            connect: connectStub(() => { throw new Error('mailbox unreachable') }),
+            runOne : redOutcome
         })).rejects.toThrow('mailbox unreachable');
 
         const afterRed = await readState();
@@ -210,10 +209,8 @@ test.describe('nightlyE2eRunner.runNightlyE2e — delivery disposition and wake 
         // The night after: suite recovers, nothing to report. Before the carry existed this write
         // replaced the document above and the unreported red left no trace on any surface.
         const result = await runNightlyE2e({
-            addMessage    : async () => {},
-            graphReady    : async () => {},
-            lifecycleReady: async () => {},
-            runOne        : greenOutcome
+            connect: connectStub(),
+            runOne : greenOutcome
         });
 
         expect(result).toMatchObject({red: false, sent: false});
@@ -226,19 +223,15 @@ test.describe('nightlyE2eRunner.runNightlyE2e — delivery disposition and wake 
 
     test('a green run after a DELIVERED red carries nothing — the carry is conditional, not decorative', async () => {
         await runNightlyE2e({
-            addMessage    : async () => {},
-            graphReady    : async () => {},
-            lifecycleReady: async () => {},
-            runOne        : redOutcome
+            connect: connectStub(),
+            runOne : redOutcome
         });
 
         expect(await readState()).toMatchObject({red: true, digest: 'sent'});
 
         await runNightlyE2e({
-            addMessage    : async () => {},
-            graphReady    : async () => {},
-            lifecycleReady: async () => {},
-            runOne        : greenOutcome
+            connect: connectStub(),
+            runOne : greenOutcome
         });
 
         // A field that is always populated stops being read. This is the control that keeps the arm
@@ -248,20 +241,16 @@ test.describe('nightlyE2eRunner.runNightlyE2e — delivery disposition and wake 
 
     test('the EARLIEST unreported red survives a chain of later runs', async () => {
         await expect(runNightlyE2e({
-            addMessage    : async () => { throw new Error('first miss') },
-            graphReady    : async () => {},
-            lifecycleReady: async () => {},
-            runOne        : redOutcome
+            connect: connectStub(() => { throw new Error('first miss') }),
+            runOne : redOutcome
         })).rejects.toThrow('first miss');
 
         const firstAt = (await readState()).at;
 
         for (const note of ['second night', 'third night']) {
             await runNightlyE2e({
-                addMessage    : async () => {},
-                graphReady    : async () => {},
-                lifecycleReady: async () => {},
-                runOne        : greenOutcome
+                connect: connectStub(),
+                runOne : greenOutcome
             });
             expect(await readState(), note).toBeTruthy()
         }
@@ -273,17 +262,13 @@ test.describe('nightlyE2eRunner.runNightlyE2e — delivery disposition and wake 
 
     test('a DELIVERED digest clears the carry — reporting the suite discharges the earlier miss', async () => {
         await expect(runNightlyE2e({
-            addMessage    : async () => { throw new Error('missed') },
-            graphReady    : async () => {},
-            lifecycleReady: async () => {},
-            runOne        : redOutcome
+            connect: connectStub(() => { throw new Error('missed') }),
+            runOne : redOutcome
         })).rejects.toThrow('missed');
 
         await runNightlyE2e({
-            addMessage    : async () => {},
-            graphReady    : async () => {},
-            lifecycleReady: async () => {},
-            runOne        : redOutcome
+            connect: connectStub(),
+            runOne : redOutcome
         });
 
         const state = await readState();
@@ -292,15 +277,36 @@ test.describe('nightlyE2eRunner.runNightlyE2e — delivery disposition and wake 
         expect(state).not.toHaveProperty('unresolvedRed');
     });
 
+    test('#17708 a MISSING credential fails loudly on the default transport, never silently', async () => {
+        // The production context that no other arm reaches. Every test above injects `connect`, and an
+        // interactive shell exports the credential — so the one environment where this breaks is the
+        // unattended `launchd` session, which is the only environment the runner actually runs in.
+        const original = process.env.NEO_MCP_REMOTE_TOKEN;
+
+        delete process.env.NEO_MCP_REMOTE_TOKEN;
+
+        try {
+            // No `connect` injection: this exercises the real client, which validates `requiredEnv`
+            // before opening any transport, so the arm asserts a configuration failure and never
+            // reaches the network.
+            await expect(runNightlyE2e({runOne: redOutcome})).rejects.toThrow(/NEO_MCP_REMOTE_TOKEN/);
+        } finally {
+            if (original === undefined) delete process.env.NEO_MCP_REMOTE_TOKEN;
+            else process.env.NEO_MCP_REMOTE_TOKEN = original;
+        }
+
+        // The red is not lost to the misconfiguration: it stands as an explicitly failed delivery,
+        // which is the whole difference from a host-local write that would have reported success.
+        expect(await readState()).toMatchObject({red: true, digest: 'failed'});
+    });
+
     test('an UNREADABLE prior receipt fails closed — a broken chain is not a clean one', async () => {
         await fs.ensureDir(path.dirname(stateFile()));
         await fs.writeFile(stateFile(), '{ this is not json', 'utf8');
 
         await runNightlyE2e({
-            addMessage    : async () => {},
-            graphReady    : async () => {},
-            lifecycleReady: async () => {},
-            runOne        : greenOutcome
+            connect: connectStub(),
+            runOne : greenOutcome
         });
 
         // Absent and unparseable are different facts. Collapsing them to `null` would let a corrupt

--- a/test/playwright/unit/ai/scripts/lifecycle/nightlyE2eRunner.spec.mjs
+++ b/test/playwright/unit/ai/scripts/lifecycle/nightlyE2eRunner.spec.mjs
@@ -329,6 +329,15 @@ test.describe('nightlyE2eRunner.runNightlyE2e — delivery disposition and wake 
         expect(await fs.pathExists(path.join(tmpDir, '.neo-ai-data/nightly-e2e/runner.lock'))).toBe(false)
     });
 
+    // A production-shaped arm for a REJECTED (not missing) credential lived here and was removed on
+    // purpose. Its evidence is real and is in the PR body as a reproducible command: against the live
+    // ingress the runner catches the 401, writes `digest: 'failed'` with the server's text, releases
+    // the lock, and exits non-zero. It cannot live in THIS suite, because a playwright worker outlives
+    // the run: the client whose readiness never completed is never returned and never closed, and its
+    // transport rejects again after the run finished. The arm therefore failed on the worker's
+    // lifetime rather than on the runner's behaviour — red for the wrong reason, which is exactly what
+    // an arm must never be. The abandoned-transport leak is real and separately owned.
+
     test('#17708 a MISSING credential fails loudly on the default transport, never silently', async () => {
         // The production context that no other arm reaches. Every test above injects `connect`, and an
         // interactive shell exports the credential — so the one environment where this breaks is the

--- a/test/playwright/unit/ai/scripts/lifecycle/nightlyE2eRunner.spec.mjs
+++ b/test/playwright/unit/ai/scripts/lifecycle/nightlyE2eRunner.spec.mjs
@@ -277,6 +277,58 @@ test.describe('nightlyE2eRunner.runNightlyE2e — delivery disposition and wake 
         expect(state).not.toHaveProperty('unresolvedRed');
     });
 
+    test('a RESOLVED tool refusal is a failed delivery, not a sent one', async () => {
+        // MCP has two success boundaries and only the first throws: the request resolving means the
+        // server ANSWERED, not that it accepted. Our own servers refuse by resolving `{isError:true}`
+        // (`ai/mcp/server/BaseServer.mjs`), so a runner that writes `sent` on a resolved call records
+        // a refused digest as delivered — this leaf's original defect, one layer up.
+        let closed = false;
+
+        await expect(runNightlyE2e({
+            connect: async () => ({
+                callTool: async () => ({isError: true, content: [{type: 'text', text: 'mailbox quota exceeded'}]}),
+                close   : async () => { closed = true }
+            }),
+            runOne : redOutcome
+        })).rejects.toThrow(/mailbox quota exceeded/);
+
+        expect(await readState()).toMatchObject({red: true, digest: 'failed'});
+        expect(closed).toBe(true);
+        expect(await fs.pathExists(path.join(tmpDir, '.neo-ai-data/nightly-e2e/runner.lock'))).toBe(false)
+    });
+
+    test('a refused delivery is retained across the next green run, like any other unsent red', async () => {
+        await expect(runNightlyE2e({
+            connect: async () => ({
+                callTool: async () => ({isError: true, content: [{type: 'text', text: 'refused'}]}),
+                close   : async () => {}
+            }),
+            runOne : redOutcome
+        })).rejects.toThrow(/refused/);
+
+        const refusedAt = (await readState()).at;
+
+        await runNightlyE2e({connect: connectStub(), runOne : greenOutcome});
+
+        // A refusal is an undelivered red like any other, so the carry must not treat it differently
+        // from a thrown one just because it arrived as a resolved value.
+        expect((await readState()).unresolvedRed).toMatchObject({digest: 'failed', at: refusedAt})
+    });
+
+    test('a connect that never settles fails the run instead of hanging it', async () => {
+        // `ready()` has no rejection path — `Neo.create` runs `initAsync` detached and `#readyPromise`
+        // is resolve-only — so an unreachable ingress leaves it pending forever. Without a deadline
+        // the unattended run hangs to the 6h stale-lock steal, which is the silence being replaced.
+        await expect(runNightlyE2e({
+            connect          : () => new Promise(() => {}),   // never settles, exactly like the real failure
+            connectDeadlineMs: 50,
+            runOne           : redOutcome
+        })).rejects.toThrow(/did not settle within 50ms/);
+
+        expect(await readState()).toMatchObject({red: true, digest: 'failed'});
+        expect(await fs.pathExists(path.join(tmpDir, '.neo-ai-data/nightly-e2e/runner.lock'))).toBe(false)
+    });
+
     test('#17708 a MISSING credential fails loudly on the default transport, never silently', async () => {
         // The production context that no other arm reaches. Every test above injects `connect`, and an
         // interactive shell exports the credential — so the one environment where this breaks is the


### PR DESCRIPTION
Resolves neomjs/neo#17714

The nightly runner now delivers its RED digest as an authenticated MCP client of the containerized Memory Core instead of through in-process service imports, so a write that used to succeed against an unserved host store now either arrives or fails loudly. Three collaborator seams collapse into one, and two failure modes that were invisible to every green local suite are now covered by arms.

Related: neomjs/neo-agent-brain#14 (liveness publication + the host-store retirement gate remain there), neomjs/neo-agent-brain#17 (activation)

Evidence: L2 (unit arms with an injected client seam — the runner has never been installed on the canonical host, so no unattended run exists to observe) → L2 required (every AC on neomjs/neo#17714 is import/behaviour-observable and covered by the arms). Residual: post-merge confirmation that a real unattended run's digest reaches the swarm mailbox, Residual-Owner: neomjs/neo-agent-brain#14.

## AC Evidence

| AC-1 | `nightlyE2eRunner.mjs` imports no Memory Core service module; the digest travels as `client.callTool('add_message', …)`. `grep -nE "MailboxService\|GraphService\|LifecycleService\|RequestContextService"` on the runner returns only a JSDoc mention. |
| AC-2 | One `connect` seam returning `{callTool, close}`. Connect failure and call failure are separately asserted: `nightlyE2eRunner.spec.mjs` "a crash BEFORE the send" injects a throwing `connect`, "a THROWING send" injects a throwing `callTool`. |
| AC-3 | The RED arm asserts `sent[0].name === 'add_message'` — the tool name, not only the payload. |
| AC-4 | "#17708 a MISSING credential fails loudly on the default transport, never silently": deletes `NEO_MCP_REMOTE_TOKEN`, exercises the real `connectMemoryCore` with no seam injected, asserts the throw names the variable and the receipt records `failed`. |
| AC-5 | `com.neomjs.nightly-e2e.plist` declares `EnvironmentVariables` with `__NEO_PATH__` + `__NEO_MCP_REMOTE_TOKEN__`; the README activate step renders both via the same substitution the sibling agent-os plists use, and `chmod 600`s the rendered copy. |
| AC-6 | README "Verify / read results" states the sender is the identity the credential resolves to, and directs an automation credential rather than a maintainer seat. |
| AC-7 | The transport closes on every path — `finally { await client?.close?.().catch(() => {}) }` around the delivery block, reached by both failure arms. |
| AC-8 | Red-proof below. |

## Deltas from ticket

None substantive. The commit subject the work began under referenced neomjs/neo-agent-brain#14; it was squashed and re-referenced to neomjs/neo#17714 when the transport half was split out, so branch history carries no stale close-target.

## Test Evidence

Red-proof for the across-run receipt machinery this builds on was run in its own PR. For this change, the arm that cannot be produced by a green suite is the credential one: **an interactive shell exports `NEO_MCP_REMOTE_TOKEN` and a `launchd` session does not**, so the failure lives only in the unattended context. The arm reproduces it by deleting the variable and driving the real `connectMemoryCore` rather than a seam.

One defect was found and fixed during implementation rather than shipped: `await client.initAsync()` after `Neo.create` is valid API and the wrong idiom. `create()` already fires `initAsync` in a detached promise with no rejection handler (`src/core/Base.mjs:314`), so the credential throw escaped as an unhandled rejection — and had the pre-construction check not been added, `ready()` would never have settled and an unattended run would have **hung until the 6h stale-lock steal**. That is strictly worse than the silence being replaced. The sibling precedent (`kbPushClient.mjs:237` awaiting `client.ready?.()`) is what surfaced it.

16/16 arms green locally on the exact head via `npm run test-unit -- test/playwright/unit/ai/scripts/lifecycle/nightlyE2eRunner.spec.mjs`.

## Post-Merge Validation

- [ ] After the LaunchAgent is installed (operator-owned, neomjs/neo-agent-brain#17), the first unattended run confirms the digest reaches the swarm mailbox rather than the host store — the falsifier for the AC-1 prediction.

Residual-Owner: neomjs/neo-agent-brain#14

## Commits (if multi-commit)

Single commit.

## Evolution

Began as neomjs/neo-agent-brain#14 step C and was split mid-implementation. neomjs/neo-agent-brain#14's own AC-1 measurement widened it past one-PR-resolvable — the plane turned out unshared for the digest as well as the receipt — so the digest transport became its own leaf with its own arms, and neomjs/neo-agent-brain#14 kept the liveness-publication design and the cross-pinned retirement gate.

The transport choice was decided against two alternatives rather than by default: a `nightly-e2e` compose mount fixes the receipt file and does nothing for the digest, which never travels as a file; and moving the runner inward like its siblings is blocked by the GPU requirement that put it outside CI to begin with.

Authored by Grace (Claude Opus 5, Claude Code). Session 728a756d-71df-48e6-8dad-0bac498ca23e.
