### PR TITLE
fix(data): a pipeline push keyed by its wire type no longer forks a record (#17716)

### DIFF
--- a/learn/guides/datahandling/DataPipelines.md
+++ b/learn/guides/datahandling/DataPipelines.md
@@ -231,9 +231,7 @@ that asymmetry turns a type mismatch into a *miss* rather than a near-miss — a
 strategy answers a miss by adding, leaving two records under one identity that nothing later removes.
 
 The Store therefore resolves each pushed key through `Store#getCanonicalKey()` before looking it up, and
-stores that canonical key rather than the received one. The method delegates to the same
-`RecordFactory.parseRecordValue()` that record insertion uses, so lookup and insertion cannot disagree
-about identity:
+stores that canonical key rather than the received one:
 
 ```javascript readonly
 // Model declares {name: 'id', type: 'Integer'} and the Store already holds record 1.
@@ -241,12 +239,27 @@ store.pipeline.simulatePush({id: '1', status: 'offline'});
 // -> updates record 1. Without canonicalization this appends a second record with id 1.
 ```
 
-A key that cannot be canonicalized is **refused** rather than inserted. An `Integer` key of `'abc'` would
-store as `NaN` while the Collection stays keyed by `'abc'`, making the record unreachable by any later
-lookup — so the push is dropped instead of persisting an entry nothing can address.
+This is not `Integer`-only. A `String`-keyed Model receiving a numeric push is the same defect mirrored,
+and takes the same path.
 
-This applies to every declared key type, not just `Integer`: a `String`-keyed Model receiving a numeric
-push is the same defect mirrored, and is handled by the same path.
+**Supported domain.** A key field which declares no `convert` and no `calculate`, and whose declared type
+converts to a primitive. Inside it, the conversion is delegated to the same
+`RecordFactory.parseRecordValue()` insertion uses, so the declared-type rules are not restated in a second
+place where they could drift.
+
+**Everything else is refused, and a refused push is dropped** rather than inserted — a wrong key is worse
+than no key, because it adds a second row under an identity that already exists. A push is refused when:
+
+| case | why a lookup cannot reproduce the stored key |
+| --- | --- |
+| `calculate` on the key field | the stored key is derived from a record which does not exist at lookup time |
+| `convert` on the key field | insertion passes the Record to the converter; a lookup can only pass the raw value, so a converter which reads the record yields a different key on each path |
+| a `Date` (or any object) key | conversion produces an equal-but-distinct object each time, and a `Map` compares keys by identity, so the lookup could never match what was stored |
+| a value converting to `NaN`, e.g. an `Integer` key of `'abc'` | it would store as `NaN` behind a `'abc'` map key, leaving the record unreachable |
+| `null`, `undefined`, or an absent key | not an identity at all; passing it on lets an upsert invent a row for a record the payload never named |
+
+If your server owns keys in one of the refused shapes, push a `'reload'` strategy instead of an insert —
+the Store can re-read a projection it cannot address record-by-record.
 
 ## Migration Path for Legacy Configs
 

--- a/learn/guides/datahandling/DataPipelines.md
+++ b/learn/guides/datahandling/DataPipelines.md
@@ -222,6 +222,32 @@ does not become visible and a locally sorted insert lands in sorted order. For s
 (`remoteFilter`, `remoteSort`, or pagination), prefer `'reloadWhenUncertain'` or `'reload'` unless your
 server payload explicitly proves visible membership and order.
 
+#### The pushed key is canonicalized before lookup
+
+A push carries whatever type the wire happened to use, and JSON has no way to say "this `1` is the same
+record as the `1` you already hold". A Store keys its Collection by strict `Map` identity, so `"1"` and `1`
+are different keys, while `Store#add()` converts every field to the type its Model declares. Left alone,
+that asymmetry turns a type mismatch into a *miss* rather than a near-miss — and an `'insert'` / `'upsert'`
+strategy answers a miss by adding, leaving two records under one identity that nothing later removes.
+
+The Store therefore resolves each pushed key through `Store#getCanonicalKey()` before looking it up, and
+stores that canonical key rather than the received one. The method delegates to the same
+`RecordFactory.parseRecordValue()` that record insertion uses, so lookup and insertion cannot disagree
+about identity:
+
+```javascript readonly
+// Model declares {name: 'id', type: 'Integer'} and the Store already holds record 1.
+store.pipeline.simulatePush({id: '1', status: 'offline'});
+// -> updates record 1. Without canonicalization this appends a second record with id 1.
+```
+
+A key that cannot be canonicalized is **refused** rather than inserted. An `Integer` key of `'abc'` would
+store as `NaN` while the Collection stays keyed by `'abc'`, making the record unreachable by any later
+lookup — so the push is dropped instead of persisting an entry nothing can address.
+
+This applies to every declared key type, not just `Integer`: a `String`-keyed Model receiving a numeric
+push is the same defect mirrored, and is handled by the same path.
+
 ## Migration Path for Legacy Configs
 
 If you are upgrading from an older version of Neo.mjs, your existing `url` and `api` configs on Stores are still fully supported.

--- a/src/component/Gallery.mjs
+++ b/src/component/Gallery.mjs
@@ -513,8 +513,8 @@ class Gallery extends Component {
     getItemId(vnodeId) {
         let itemId = vnodeId.split('__')[1];
 
-        if (!this.useInternalId && this.store.getKeyType()?.includes('int')) {
-            itemId = parseInt(itemId)
+        if (!this.useInternalId) {
+            itemId = this.store.getCanonicalKey(itemId)
         }
 
         return itemId

--- a/src/component/Helix.mjs
+++ b/src/component/Helix.mjs
@@ -813,8 +813,8 @@ class Helix extends Component {
     getItemId(vnodeId) {
         let itemId = vnodeId.split('__')[1];
 
-        if (!this.useInternalId && this.store.getKeyType()?.includes('int')) {
-            itemId = parseInt(itemId)
+        if (!this.useInternalId) {
+            itemId = this.store.getCanonicalKey(itemId)
         }
 
         return itemId

--- a/src/data/Store.mjs
+++ b/src/data/Store.mjs
@@ -1238,16 +1238,17 @@ class Store extends Collection {
     getCanonicalKey(value) {
         let field = this.model?.getField(this.getKeyProperty());
 
-        // Without a declared key field there is nothing to canonicalize against, so the value stands
-        // as its own identity.
-        if (!field) {
-            return value
-        }
-
-        // An absent value is not an identity. Passing it on lets a caller insert a row for a record
-        // the push never named.
+        // An absent value is not an identity, whatever the Model says. This is checked before the
+        // no-field case on purpose: a Store without a declared key field would otherwise pass null
+        // straight through, and a caller which inserts on a miss then adds a row nothing can address.
         if (value === null || value === undefined) {
             return undefined
+        }
+
+        // With no declared key field there is nothing to canonicalize against, so a present value
+        // stands as its own identity.
+        if (!field) {
+            return value
         }
 
         // Context-dependent keys cannot be resolved from a value alone — see Supported domain.

--- a/src/data/Store.mjs
+++ b/src/data/Store.mjs
@@ -1201,16 +1201,59 @@ class Store extends Collection {
     }
 
     /**
+     * Resolves the canonical key a record insertion would store for a given value.
+     *
+     * @summary Puts a key lookup and a key insertion on one type, so neither can hold a different
+     * identity for the same record.
+     *
+     * `Collection.get()` is a strict `Map` lookup, while `add()` routes each field through
+     * `RecordFactory.parseRecordValue()` and converts it to its declared type. A value whose type
+     * differs from the stored one is therefore not a near-miss but a miss, and callers which answer
+     * a miss by inserting will append a second record under the same identity.
+     *
+     * Delegates to the same parser insertion uses, rather than reimplementing its rules, so the two
+     * cannot drift apart: `Integer`, `String`, `Float`, `Date` and custom `convert` semantics all
+     * stay owned by `RecordFactory`.
+     *
+     * @param {*} value The key as it was received, e.g. from a server push or a DOM id.
+     * @returns {*|undefined} The canonical key, or `undefined` when the value cannot be
+     * canonicalized — a key that would store as `NaN` is unreachable by any later lookup, so it is
+     * refused rather than persisted.
+     */
+    getCanonicalKey(value) {
+        let field = this.model?.getField(this.getKeyProperty());
+
+        // A calculated key is derived from a record that does not exist yet, and an absent value has
+        // no identity to canonicalize.
+        if (value === null || value === undefined || !field || field.calculate) {
+            return value
+        }
+
+        let canonical = RecordFactory.parseRecordValue({record: {}, field, value});
+
+        return Number.isNaN(canonical) ? undefined : canonical
+    }
+
+    /**
      * @param {Object} data
      * @protected
      */
     onPipelinePush(data) {
-        let me = this,
-            id = data[me.getKeyProperty()],
+        let me          = this,
+            keyProperty = me.getKeyProperty(),
+            id          = me.getCanonicalKey(me.getKey(data)),
             record;
 
         if (id !== undefined) {
             record = me.get(id);
+
+            // The Collection keys itself by the value it is handed, so a received key would be
+            // stored verbatim and then miss every later canonical lookup — the same identity split,
+            // one insert further along. Only a key the payload carries directly is rewritten; a
+            // mapped one stays the Model's to resolve.
+            if (Object.hasOwn(data, keyProperty) && data[keyProperty] !== id) {
+                data = {...data, [keyProperty]: id}
+            }
 
             if (record) {
                 record.set(data)

--- a/src/data/Store.mjs
+++ b/src/data/Store.mjs
@@ -1201,37 +1201,68 @@ class Store extends Collection {
     }
 
     /**
-     * Resolves the canonical key a record insertion would store for a given value.
+     * Resolves the canonical key a record insertion would store for a given value, or refuses.
      *
-     * @summary Puts a key lookup and a key insertion on one type, so neither can hold a different
-     * identity for the same record.
+     * @summary Puts a key lookup and a key insertion on one Map identity, so neither can hold a
+     * different record under the same key.
      *
      * `Collection.get()` is a strict `Map` lookup, while `add()` routes each field through
      * `RecordFactory.parseRecordValue()` and converts it to its declared type. A value whose type
      * differs from the stored one is therefore not a near-miss but a miss, and callers which answer
      * a miss by inserting will append a second record under the same identity.
      *
-     * Delegates to the same parser insertion uses, rather than reimplementing its rules, so the two
-     * cannot drift apart: `Integer`, `String`, `Float`, `Date` and custom `convert` semantics all
-     * stay owned by `RecordFactory`.
+     * ## Supported domain
+     *
+     * A key whose field declares no `convert` and no `calculate`, and which converts to a primitive.
+     * Within it, the conversion is delegated to the parser insertion uses, so the declared-type rules
+     * stay owned by `RecordFactory` rather than being restated here.
+     *
+     * Everything else is **refused** with `undefined`, because a wrong key is worse than no key —
+     * it inserts a second row under an identity that already exists:
+     *
+     * - `calculate` derives the stored key from a record that does not exist at lookup time;
+     * - `convert` receives the Record at insertion, while a lookup can only offer the raw value, so
+     *   a converter which reads the record produces a different key on each path;
+     * - an object result — a `Date` key being the realistic case — is equal-but-distinct on every
+     *   call, and a `Map` compares keys by identity, so it could never match what was stored;
+     * - a value that converts to `NaN`, or which the field's length/nullable rules reject, has no
+     *   addressable identity at all.
+     *
+     * Refusal is not silent at the call site: `onPipelinePush()` drops the push rather than
+     * synthesizing a row for a record the payload never successfully named.
      *
      * @param {*} value The key as it was received, e.g. from a server push or a DOM id.
-     * @returns {*|undefined} The canonical key, or `undefined` when the value cannot be
-     * canonicalized — a key that would store as `NaN` is unreachable by any later lookup, so it is
-     * refused rather than persisted.
+     * @returns {*|undefined} The canonical key, or `undefined` when the value falls outside the
+     * supported domain above.
      */
     getCanonicalKey(value) {
         let field = this.model?.getField(this.getKeyProperty());
 
-        // A calculated key is derived from a record that does not exist yet, and an absent value has
-        // no identity to canonicalize.
-        if (value === null || value === undefined || !field || field.calculate) {
+        // Without a declared key field there is nothing to canonicalize against, so the value stands
+        // as its own identity.
+        if (!field) {
             return value
+        }
+
+        // An absent value is not an identity. Passing it on lets a caller insert a row for a record
+        // the push never named.
+        if (value === null || value === undefined) {
+            return undefined
+        }
+
+        // Context-dependent keys cannot be resolved from a value alone — see Supported domain.
+        if (field.calculate || field.convert) {
+            return undefined
         }
 
         let canonical = RecordFactory.parseRecordValue({record: {}, field, value});
 
-        return Number.isNaN(canonical) ? undefined : canonical
+        // `typeof null` is 'object'; a null here means the field's own rules rejected the value.
+        if (canonical === null || canonical === undefined || Number.isNaN(canonical)) {
+            return undefined
+        }
+
+        return typeof canonical === 'object' ? undefined : canonical
     }
 
     /**

--- a/src/list/Base.mjs
+++ b/src/list/Base.mjs
@@ -725,8 +725,8 @@ class List extends Component {
     getItemRecordId(vnodeId) {
         let itemId = vnodeId.split('__')[1];
 
-        if (!this.useInternalId && this.store.getKeyType()?.includes('int')) {
-            itemId = parseInt(itemId)
+        if (!this.useInternalId) {
+            itemId = this.store.getCanonicalKey(itemId)
         }
 
         return itemId

--- a/src/list/Buffered.mjs
+++ b/src/list/Buffered.mjs
@@ -529,8 +529,10 @@ class Buffered extends ComponentList {
             return super.getItemRecordId(nodeOrId)
         }
 
-        if (value !== null && value !== undefined && this.store.getKeyType()?.includes('int')) {
-            value = Number(value)
+        // A refused key canonicalizes to undefined and falls through to the null contract below,
+        // which is the same answer this returned for an id it could not resolve.
+        if (value !== null && value !== undefined) {
+            value = this.store.getCanonicalKey(value)
         }
 
         return value ?? null

--- a/test/playwright/unit/data/StorePush.spec.mjs
+++ b/test/playwright/unit/data/StorePush.spec.mjs
@@ -55,6 +55,35 @@ let StorePushPipeline = class StorePushPipeline extends Pipeline {
 }
 StorePushPipeline = Neo.setupClass(StorePushPipeline);
 
+let StringKeyPushModel = class StringKeyPushModel extends Model {
+    static config = {
+        className  : 'Test.Unit.Data.StorePush.StringKeyModel',
+        keyProperty: 'id',
+        fields     : [
+            {name: 'id',     type: 'String'},
+            {name: 'status', type: 'String'}
+        ]
+    }
+}
+StringKeyPushModel = Neo.setupClass(StringKeyPushModel);
+
+let StringKeyPushPipeline = class StringKeyPushPipeline extends Pipeline {
+    static config = {
+        className: 'Test.Unit.Data.StorePush.StringKeyPipeline'
+    }
+
+    async read() {
+        return [
+            {id: '1', status: 'pending'}
+        ]
+    }
+
+    simulatePush(data) {
+        this.fire('push', data)
+    }
+}
+StringKeyPushPipeline = Neo.setupClass(StringKeyPushPipeline);
+
 function createStore(config={}) {
     return Neo.create(Store, {
         model   : StorePushModel,
@@ -117,6 +146,69 @@ test.describe('Neo.data.Store - Push Integration', () => {
 
         expect(store.count).toBe(3);
         expect(store.get(3).status).toBe('created');
+
+        store.destroy()
+    });
+
+    test('Store should update, not fork, when a push key arrives as a different type', async () => {
+        const store = createStore({pushInsertStrategy: 'upsert'});
+
+        await store.load();
+        expect(store.count).toBe(2);
+
+        // The stored key is the Integer 1; the push carries "1". A strict Map lookup on the received
+        // value misses, and an upsert answers a miss by appending — so this asserts one identity,
+        // not merely a successful update.
+        store.pipeline.simulatePush({id: '1', status: 'done'});
+
+        expect(store.count).toBe(2);
+        expect(store.get(1).status).toBe('done');
+        expect(store.items.filter(record => Number(record.id) === 1)).toHaveLength(1);
+
+        // Canonicalization must not turn every push into an update: an unseen key still inserts, and
+        // it lands under the key a later canonical lookup will use.
+        store.pipeline.simulatePush({id: '3', rank: 3, status: 'created', type: 'visible'});
+
+        expect(store.count).toBe(3);
+        expect(store.get(3).status).toBe('created');
+        expect(store.items.filter(record => Number(record.id) === 3)).toHaveLength(1);
+
+        store.destroy()
+    });
+
+    test('Store should refuse a push key which cannot be canonicalized', async () => {
+        const store = createStore({pushInsertStrategy: 'upsert'});
+
+        await store.load();
+
+        // `parseInt('bad')` is NaN. Persisting it would leave the record field and the map key
+        // disagreeing, so the record would be unreachable by any later lookup — refuse instead.
+        store.pipeline.simulatePush({id: 'bad', rank: 9, status: 'created', type: 'visible'});
+
+        expect(store.count).toBe(2);
+        expect(store.get('bad')).toBe(null);
+
+        store.destroy()
+    });
+
+    test('Store should canonicalize a push key for a String-keyed Model too', async () => {
+        const store = Neo.create(Store, {
+            model   : StringKeyPushModel,
+            pipeline: {module: StringKeyPushPipeline},
+
+            pushInsertStrategy: 'upsert'
+        });
+
+        await store.load();
+        expect(store.count).toBe(1);
+
+        // The symmetric case: the stored key is the String '1' and the push carries the number 1.
+        // An int-only rule would leave this one forking.
+        store.pipeline.simulatePush({id: 1, status: 'done'});
+
+        expect(store.count).toBe(1);
+        expect(store.get('1').status).toBe('done');
+        expect(store.items.filter(record => String(record.id) === '1')).toHaveLength(1);
 
         store.destroy()
     });

--- a/test/playwright/unit/data/StorePush.spec.mjs
+++ b/test/playwright/unit/data/StorePush.spec.mjs
@@ -298,6 +298,25 @@ test.describe('Neo.data.Store - Push Integration', () => {
         store.destroy()
     });
 
+    test('Store should refuse an absent key even without a Model to canonicalize against', async () => {
+        // No declared key field, so there is nothing to convert — but "nothing to convert" must not
+        // become "anything is a key". Ordering this check after the no-field case let `null` through
+        // and inserted a row that `get(null)` could never retrieve.
+        const store = Neo.create(Store, {pushInsertStrategy: 'upsert'});
+
+        expect(store.getCanonicalKey(null)).toBeUndefined();
+        expect(store.getCanonicalKey(undefined)).toBeUndefined();
+
+        // A present value still stands as its own identity when no field declares otherwise.
+        expect(store.getCanonicalKey('abc')).toBe('abc');
+
+        store.onPipelinePush({id: null, status: 'created'});
+
+        expect(store.count).toBe(0);
+
+        store.destroy()
+    });
+
     test('Store should respect local sorters for inserted pipeline pushes', async () => {
         const store = createStore({
             pushInsertStrategy: 'insert',

--- a/test/playwright/unit/data/StorePush.spec.mjs
+++ b/test/playwright/unit/data/StorePush.spec.mjs
@@ -84,6 +84,43 @@ let StringKeyPushPipeline = class StringKeyPushPipeline extends Pipeline {
 }
 StringKeyPushPipeline = Neo.setupClass(StringKeyPushPipeline);
 
+let ConvertKeyPushModel = class ConvertKeyPushModel extends Model {
+    static config = {
+        className  : 'Test.Unit.Data.StorePush.ConvertKeyModel',
+        keyProperty: 'id',
+        fields     : [
+            // Reads the record it is converting for, so insertion and a bare lookup cannot agree.
+            {name: 'id', type: 'String', convert: (value, record) => `${record ? 'record' : 'plain'}:${value}`},
+            {name: 'status', type: 'String'}
+        ]
+    }
+}
+ConvertKeyPushModel = Neo.setupClass(ConvertKeyPushModel);
+
+let DateKeyPushModel = class DateKeyPushModel extends Model {
+    static config = {
+        className  : 'Test.Unit.Data.StorePush.DateKeyModel',
+        keyProperty: 'id',
+        fields     : [
+            {name: 'id',     type: 'Date'},
+            {name: 'status', type: 'String'}
+        ]
+    }
+}
+DateKeyPushModel = Neo.setupClass(DateKeyPushModel);
+
+let CalculatedKeyPushModel = class CalculatedKeyPushModel extends Model {
+    static config = {
+        className  : 'Test.Unit.Data.StorePush.CalculatedKeyModel',
+        keyProperty: 'id',
+        fields     : [
+            {name: 'id', type: 'String', calculate: data => `calc:${data?.status ?? ''}`},
+            {name: 'status', type: 'String'}
+        ]
+    }
+}
+CalculatedKeyPushModel = Neo.setupClass(CalculatedKeyPushModel);
+
 function createStore(config={}) {
     return Neo.create(Store, {
         model   : StorePushModel,
@@ -209,6 +246,54 @@ test.describe('Neo.data.Store - Push Integration', () => {
         expect(store.count).toBe(1);
         expect(store.get('1').status).toBe('done');
         expect(store.items.filter(record => String(record.id) === '1')).toHaveLength(1);
+
+        store.destroy()
+    });
+
+    test('Store should refuse a key whose stored identity a lookup cannot reproduce', async () => {
+        // A record-dependent `convert` sees the Record at insertion and only the raw value at
+        // lookup, so the two produce different keys. Asserted as a comparison, not an assumption.
+        const convertStore = Neo.create(Store, {model: ConvertKeyPushModel, pushInsertStrategy: 'upsert'});
+
+        convertStore.add({id: '1', status: 'pending'});
+
+        const storedKey = convertStore.getKey(convertStore.items[0]);
+
+        expect(storedKey).toBe('record:1');
+        expect(convertStore.getCanonicalKey('1')).toBeUndefined();
+
+        // A Date key is equal-but-distinct on every conversion, and a Map compares by identity.
+        const dateStore = Neo.create(Store, {model: DateKeyPushModel, pushInsertStrategy: 'upsert'}),
+              stamp     = '2026-08-24T00:00:00.000Z';
+
+        expect(new Date(stamp)).not.toBe(new Date(stamp));
+        expect(dateStore.getCanonicalKey(stamp)).toBeUndefined();
+
+        // A calculated key is derived from a record which does not exist at lookup time.
+        const calcStore = Neo.create(Store, {model: CalculatedKeyPushModel, pushInsertStrategy: 'upsert'});
+
+        expect(calcStore.getCanonicalKey('wire')).toBeUndefined();
+
+        convertStore.destroy();
+        dateStore.destroy();
+        calcStore.destroy()
+    });
+
+    test('Store should not synthesize a row for a push which names no key', async () => {
+        const store = createStore({pushInsertStrategy: 'upsert'});
+
+        await store.load();
+        expect(store.count).toBe(2);
+
+        // `null` is not an identity. Passed on, it misses every lookup and the upsert invents a row
+        // with a generated id for a record the payload never named.
+        expect(store.getCanonicalKey(null)).toBeUndefined();
+
+        store.pipeline.simulatePush({id: null, status: 'created'});
+        expect(store.count).toBe(2);
+
+        store.pipeline.simulatePush({status: 'created'});
+        expect(store.count).toBe(2);
 
         store.destroy()
     });

--- a/test/playwright/unit/list/Buffered.spec.mjs
+++ b/test/playwright/unit/list/Buffered.spec.mjs
@@ -124,6 +124,18 @@ test.describe('Neo.list.Buffered — fixed-height component row windowing (#1755
         list = null
     });
 
+    test('getItemRecordId canonicalizes a logical id and keeps its null contract', async () => {
+        await createList();
+
+        // The id round-trips through the DOM as a string; the Store keys by Integer. Resolving it
+        // through the Store's canonical-key boundary is what makes the returned id a usable key.
+        expect(list.getItemRecordId(list.getItemId(3))).toBe(3);
+        expect(list.store.get(list.getItemRecordId(list.getItemId(3)))).toBe(list.store.get(3));
+
+        // An id the list cannot resolve still answers null rather than a half-converted value.
+        expect(list.getItemRecordId(`${list.getLogicalIdPrefix()}not-a-key`)).toBe(null)
+    });
+
     test('5,000 records mount only viewport + buffer rows with honest semantic positions', async () => {
         await createList();
 


### PR DESCRIPTION
Resolves #17716

`Store#onPipelinePush()` looked its key up as received while insertion converts it, so a key whose type differed from the stored one was a miss rather than a near-miss — and an upsert answers a miss by appending, leaving two records under one identity that nothing later removes. `getCanonicalKey()` resolves the key insertion would store **within a supported domain** and refuses everything outside it, the push path applies it to both the lookup and the stored payload, and the four engine sites that each hand-rolled a local type-report-then-convert idiom consume it instead.

Evidence: L2 (exact-head unit + component CI; local full unit 3012 with a per-falsifier mutation proof against `origin/dev`) → L2 required (every close-target AC is a repository-local store contract with no runtime surface beyond CI reach). No residuals.

## AC Evidence
| AC-1 | `test/playwright/unit/data/StorePush.spec.mjs` — push `id: '1'` against stored Integer `1`: `count` stays `2`, one record holds identity `1`. |
| AC-2 | Same spec, `StringKeyPushModel` fixture — push `id: 1` against stored `'1'`: `count` stays `1`. |
| AC-3 | Same spec — push `id: '3'` under `upsert`, then `store.get(3)` resolves the inserted record by its canonical key. |
| AC-4 | Same spec — `id: 'bad'` against an Integer Store: refused, `count` unchanged, `store.get('bad')` null. `getCanonicalKey()` returns `undefined` rather than persisting a `NaN` field behind a `'bad'` map key. |
| AC-5 | Supported domain: `getCanonicalKey()` delegates to `RecordFactory.parseRecordValue()`, so declared-type rules are not restated. Outside it, one executable arm per refusal — "refuse a key whose stored identity a lookup cannot reproduce" compares a record-dependent `convert` against **real insertion** (`getKey()` returns `record:1` while the primitive refuses), asserts `new Date(x) !== new Date(x)` before refusing Date keys, and refuses a calculated key; "not synthesize a row for a push which names no key" covers `null` and an absent key at push level. |
| AC-6 | `src/list/Base.mjs`, `src/component/Gallery.mjs`, `src/component/Helix.mjs`, `src/list/Buffered.mjs` consume the primitive. `test/playwright/unit/list/Buffered.spec.mjs` binds both halves of its contract: a canonicalized logical id resolves the record, and an unresolvable id still answers `null`. |
| AC-7 | `src/collection/Base.mjs` is untouched — `get()` remains a strict `Map` lookup, so a genuine type mismatch elsewhere still surfaces instead of being forgiven. |
| AC-8 | Outside-CI mutation proof — see Test Evidence. |
| AC-9 | `learn/guides/datahandling/DataPipelines.md` — "The pushed key is canonicalized before lookup" states the supported domain and carries a per-refusal table with the reason each shape cannot be reproduced by a lookup. `ai:lint-guides`: 0 hard. |

## Deltas from ticket
The ticket's insertion-equivalence claim was too broad and is now narrowed in its Contract Ledger, the JSDoc, and the guide together. Delegating to `parseRecordValue()` shares the **function**, not the **call context**: insertion passes a real Record and a lookup cannot, so a record-reading `convert` produces a different key on each path. Separately, `Map` keys compare by identity, so a `Date` key is equal-but-distinct on every conversion and could never match. Both are refused rather than approximated.

The site census moved from three to four. `src/list/Buffered.mjs:532` spells the idiom `Number()` with its own null guard rather than `parseInt`, and my original count was taken against an installed package snapshot instead of this source tree — where the file does not carry that line at all.

## Test Evidence
Mutation proof, which a green suite cannot show. With `src/data/Store.mjs` reverted to `origin/dev` and the tests retained, each motivating arm convicts:

| falsifier | result without the fix |
| --- | --- |
| Integer Store, push `'1'` | `Expected: 1, Received: 2` |
| Integer Store, push `'3'` then `get(3)` | `Expected: 2, Received: 3` |
| `'bad'` refused | `Expected: 2, Received: 3` |

3 failed / 6 passed against the baseline. The baseline was asserted before the red was trusted — `getCanonicalKey` occurrences in the reverted file: `0`. The revert targets the **baseline ref**, not a stash: after the first commit `git stash` reverts only to `HEAD`, which already carries the fix, and a control whose baseline holds the treatment proves nothing.

## Post-Merge Validation
None. Every close-target AC is verified at this head.

## Commits
- `b03d23b2` — `getCanonicalKey()` plus the repaired push path.
- `2eb8297e` — three components consume the primitive.
- `d36da0b6` — the guide states the contract.
- `fefd4eee` — narrow the domain to what a lookup can reproduce; add the fourth site and the refusal arms.

## Evolution
The first version claimed insertion equivalence for every declared key type on the grounds that it called the same parser. Cross-family review falsified that at four states — record-dependent `convert`, `Date`/object identity, `null` synthesizing a row through a `!== undefined` guard, and calculated keys — establishing that sharing a function is not sharing its call context, and that for identity the discriminator is Map-key reachability rather than value-shaped equality. The method now advertises a domain it can actually hold and refuses the rest, since a wrong key is worse than no key.

Authored by Ada (`@neo-opus-ada`, Claude Opus 5, Claude Code). Memory Core session f13e43f1-5332-434a-bbae-600b69af2faa.
