### PR TITLE
fix(knowledge-base): a refusal we already classify as futile is no longer retried (#16972)

### DIFF
--- a/ai/services/knowledge-base/VectorService.mjs
+++ b/ai/services/knowledge-base/VectorService.mjs
@@ -1882,9 +1882,13 @@ class VectorService extends Base {
                     // is deliberately preserved — it is the one re-offer that graduates the durable
                     // fence, and it is a single call rather than a budget.
                     //
-                    // Deferrable classes (timeout, transport closure, circuit open) keep their full
-                    // budget: only OUR OWN deliberate refusals are non-retryable, and inference about
-                    // another process is never a basis for discarding a corpus.
+                    // The contrast case is a RETRY-ELIGIBLE failure — an unclassified provider error is
+                    // the clean example — which keeps every attempt, because only our own deliberate
+                    // refusals are futile and inference about another process is never a basis for
+                    // discarding a corpus. Timeout and circuit-open are deliberately NOT that contrast:
+                    // both leave this loop through earlier mechanisms of their own and never spend the
+                    // full budget either, so citing them here would describe a behaviour the code does
+                    // not have.
                     if (classifyEmbedDisposition(classifyEmbedFailureError(err)) === EMBED_DISPOSITION.rejected) {
                         console.error(`Embedding batch ${batchNumber} was refused as ${classifyEmbedFailureError(err)}; ending the retry budget after one dispatch — a later attempt cannot change this verdict.`, err.message);
                         retries = maxRetries;

--- a/ai/services/knowledge-base/VectorService.mjs
+++ b/ai/services/knowledge-base/VectorService.mjs
@@ -44,8 +44,10 @@ import {
     upsertEmbeddingPoisonEntries
 }                                                                     from './helpers/kbEmbeddingPoisonStore.mjs';
 import {
+    EMBED_DISPOSITION,
     KB_VECTOR_EMBED_PROVIDER_CIRCUIT_OPEN,
     KB_VECTOR_EMBED_UNDELIVERABLE_AT_GEOMETRY,
+    classifyEmbedDisposition,
     classifyEmbedFailureError,
     classifyEmbedResidencyDisposition,
     isAcceptedThenDiedError,
@@ -1863,6 +1865,32 @@ class VectorService extends Base {
                     }
 
                     lastError = err;
+
+                    // A rejected-class refusal is futile to re-issue BY DEFINITION, and the authority
+                    // for that is not local: `REJECTED_EMBED_ERROR_CODES` already documents membership
+                    // as "a later attempt is either futile or unsafe, never merely unlucky: an input
+                    // over the embedding budget is over it on every retry". The classifier, the KB
+                    // translation and the set all existed — this dispatch site simply never asked, so a
+                    // deterministic provider refusal spent the whole retry budget proving a verdict the
+                    // first response already carried. Measured in production: an 18,832-token input
+                    // against a 16,384-token ceiling, re-dispatched five times per batch, 47 such
+                    // batches in one repository.
+                    //
+                    // The budget is ENDED, not the aftermath: retry exhaustion below is reached exactly
+                    // as it would be after the last attempt, so first-batch abort, poison isolation and
+                    // the carried-prefix contract are untouched. The isolation dispatch in particular
+                    // is deliberately preserved — it is the one re-offer that graduates the durable
+                    // fence, and it is a single call rather than a budget.
+                    //
+                    // Deferrable classes (timeout, transport closure, circuit open) keep their full
+                    // budget: only OUR OWN deliberate refusals are non-retryable, and inference about
+                    // another process is never a basis for discarding a corpus.
+                    if (classifyEmbedDisposition(classifyEmbedFailureError(err)) === EMBED_DISPOSITION.rejected) {
+                        console.error(`Embedding batch ${batchNumber} was refused as ${classifyEmbedFailureError(err)}; ending the retry budget after one dispatch — a later attempt cannot change this verdict.`, err.message);
+                        retries = maxRetries;
+                        continue
+                    }
+
                     retries++;
                     console.error(`An error occurred during embedding batch ${batchNumber}. Retrying (${retries}/${maxRetries})...`, err.message);
                     if (retries < maxRetries) {

--- a/test/playwright/unit/ai/services/knowledge-base/VectorService.batchFailureIsolation.spec.mjs
+++ b/test/playwright/unit/ai/services/knowledge-base/VectorService.batchFailureIsolation.spec.mjs
@@ -141,58 +141,70 @@ test.describe('VectorService.embedChunks — one failing batch must not strand t
         expect(result).toEqual({embedded: 0, settled: 0, remaining: 0, skipped: 0, yielded: false});
     });
 
-    test('#16972 a rejected-class refusal costs ONE batch dispatch, not the whole retry budget', async () => {
+    test('#16972 a rejected-class refusal costs ONE batch dispatch, and isolation still runs', async () => {
         // The defect: `REJECTED_EMBED_ERROR_CODES` already documented `KB_VECTOR_EMBED_INPUT_TRUNCATED`
-        // as "a later attempt is either futile or unsafe" — and this dispatch site never asked. So a
-        // deterministic provider refusal spent every retry re-proving a verdict the first response
-        // already carried. Measured in production: an 18,832-token input against a 16,384 ceiling,
-        // five identical dispatches per batch, 47 such batches in one repository.
+        // as "a later attempt is either futile or unsafe" — and this dispatch site never asked, so a
+        // deterministic refusal spent every retry re-proving a verdict the first response carried.
+        // Measured in production: an 18,832-token input against a 16,384 ceiling, five identical
+        // dispatches per batch, 47 such batches in one repository.
         //
-        // Counted by input WIDTH deliberately. Retry exhaustion still enters poison isolation, which
-        // re-offers a suspect ALONE on purpose — that single dispatch is what graduates the durable
-        // fence and is NOT what this ticket removes. Only full-width attempts are the retry budget.
-        Object.assign(KB_Config.data, {batchSize: 50, batchDelay: 0, maxRetries: 4});
+        // The fixture carries an independent embeddable TAIL on purpose. Retry exhaustion is followed
+        // by paired isolation, and isolation can only PROVE a poison when a control outside the failed
+        // batch exists — without one it returns `unproved` and the first-batch abort raises, which
+        // would let this arm pass while the isolation path was never exercised at all.
+        Object.assign(KB_Config.data, {batchSize: 2, batchDelay: 0, maxRetries: 4});
 
-        const spy    = createSpyCollection(),
-              chunks = makeChunks(3);
+        const spy       = createSpyCollection(),
+              chunks    = makeChunks(4),
+              persisted = [];
 
-        let fullWidthAttempts = 0;
+        let fullWidthAttempts = 0,
+            isolationCalls    = 0;
 
         TextEmbeddingService.embedTexts = async texts => {
-            if (texts.length === chunks.length) fullWidthAttempts++;
+            if (texts.some(text => text.includes('for chunk 0'))) {
+                if (texts.length === 2) fullWidthAttempts++;
+                if (texts.length === 1) isolationCalls++;
 
-            const error = new Error('request (18832 tokens) exceeds the available context size (16384 tokens)');
-            error.code  = EMBEDDING_INPUT_TRUNCATED_CODE;
-            throw error
+                const error = new Error('request (18832 tokens) exceeds the available context size (16384 tokens)');
+                error.code  = EMBEDDING_INPUT_TRUNCATED_CODE;
+                throw error
+            }
+
+            if (texts.length === 1) isolationCalls++;
+
+            return texts.map(() => new Array(384).fill(0))
         };
 
-        // The aftermath is deliberately unchanged and asserted as such: a first batch whose refusal
-        // forbids poison isolation still raises the first-batch abort. This ticket removes futile
-        // DISPATCHES, not the abort. That strand has its own owner, and naming it is the point: a
-        // reader must be able to tell "out of scope here" from "unowned". ticket-ref-ok: #16843.
-        await expect(
-            KB_VectorService.embedChunks({collection: spy, chunksToProcess: chunks}),
-            'the first-batch abort still raises — only the wasted dispatches are gone'
-        ).rejects.toThrow(/Failed to process batch 1/);
+        const result = await KB_VectorService.embedChunks({
+            collection     : spy,
+            chunksToProcess: chunks,
+            onPoisonEntries: async entries => persisted.push(...entries)
+        });
 
         expect(
             fullWidthAttempts,
             'a refusal the provider states deterministically must be dispatched once, never re-issued'
         ).toBe(1);
-        expect(spy.upsertedIds, 'and a truncated embedding must never be stored').toEqual([]);
+
+        // The other half of the same guarantee: the retry BUDGET is what ended, not the convergence
+        // path. Isolation re-offers candidates alone, and that single dispatch is what graduates the
+        // durable geometry fence — so this arm reds if the guard ever short-circuits past it.
+        expect(isolationCalls, 'post-budget isolation must still run and be reached').toBeGreaterThan(0);
+        expect(persisted.map(entry => entry.chunkId), 'the refused input is fenced by exact identity')
+            .toContain('chunk-0');
+        expect(spy.upsertedIds, 'and the recoverable tail still lands').toContain('chunk-2');
     });
 
-    test('#16972 NON-VACUITY: a deferrable class still spends its full retry budget', async () => {
+    test('#16972 NON-VACUITY: a retry-eligible failure still spends its full retry budget', async () => {
         // The guard above must convict ONLY our own deliberate refusals. A guard that stopped
         // retrying everything would pass the arm above while destroying the recovery path.
         //
-        // The control is an UNCLASSIFIED error, chosen after a provider timeout proved to be the
-        // wrong control, and the id is the evidence rather than decoration — the claim is about one
-        // specific merged change a reader must be able to verify. ticket-ref-ok: #16978 ends the
-        // sweep on a provider timeout, so a timeout skips the retry budget by an earlier mechanism.
-        // budget by a different and earlier mechanism. An error carrying no code is the honest
-        // "unlucky, not futile" case — it maps to `KB_VECTOR_EMBED_FAILED`, is outside the rejected
-        // set, and its retries are the recovery path this guard must not touch.
+        // The control is an UNCLASSIFIED error, and choosing it took one failed attempt: a provider
+        // timeout is NOT retry-eligible in this loop — it exits through an earlier mechanism, as does
+        // circuit-open — so it proves nothing about this guard. An error carrying no code is the
+        // honest "unlucky, not futile" case: it maps to `KB_VECTOR_EMBED_FAILED`, sits outside the
+        // rejected set, and its retries are the recovery path this guard must leave alone.
         Object.assign(KB_Config.data, {batchSize: 50, batchDelay: 0, maxRetries: 3});
 
         const spy    = createSpyCollection(),
@@ -210,7 +222,7 @@ test.describe('VectorService.embedChunks — one failing batch must not strand t
 
         expect(
             fullWidthAttempts,
-            'a timeout is unlucky rather than futile — the retry budget is the recovery path'
+            'a retry-eligible failure is unlucky rather than futile — the budget IS the recovery path'
         ).toBe(3);
     });
 

--- a/test/playwright/unit/ai/services/knowledge-base/VectorService.batchFailureIsolation.spec.mjs
+++ b/test/playwright/unit/ai/services/knowledge-base/VectorService.batchFailureIsolation.spec.mjs
@@ -24,6 +24,8 @@ import {
 } from '../../../../../../ai/provider/createTimeoutError.mjs';
 import {KB_VECTOR_EMBED_PROVIDER_CIRCUIT_OPEN}
     from '../../../../../../ai/services/knowledge-base/helpers/embedFailureClassification.mjs';
+import {EMBEDDING_INPUT_TRUNCATED_CODE}
+    from '../../../../../../ai/services/memory-core/TextEmbeddingService.mjs';
 
 /**
  * Batch-failure isolation for `VectorService.embedChunks`.
@@ -137,6 +139,79 @@ test.describe('VectorService.embedChunks — one failing batch must not strand t
         expect(providerCalls, 'nothing to embed must reach the provider zero times').toBe(0);
         expect(spy.upsertedIds, 'and nothing may be written').toEqual([]);
         expect(result).toEqual({embedded: 0, settled: 0, remaining: 0, skipped: 0, yielded: false});
+    });
+
+    test('#16972 a rejected-class refusal costs ONE batch dispatch, not the whole retry budget', async () => {
+        // The defect: `REJECTED_EMBED_ERROR_CODES` already documented `KB_VECTOR_EMBED_INPUT_TRUNCATED`
+        // as "a later attempt is either futile or unsafe" — and this dispatch site never asked. So a
+        // deterministic provider refusal spent every retry re-proving a verdict the first response
+        // already carried. Measured in production: an 18,832-token input against a 16,384 ceiling,
+        // five identical dispatches per batch, 47 such batches in one repository.
+        //
+        // Counted by input WIDTH deliberately. Retry exhaustion still enters poison isolation, which
+        // re-offers a suspect ALONE on purpose — that single dispatch is what graduates the durable
+        // fence and is NOT what this ticket removes. Only full-width attempts are the retry budget.
+        Object.assign(KB_Config.data, {batchSize: 50, batchDelay: 0, maxRetries: 4});
+
+        const spy    = createSpyCollection(),
+              chunks = makeChunks(3);
+
+        let fullWidthAttempts = 0;
+
+        TextEmbeddingService.embedTexts = async texts => {
+            if (texts.length === chunks.length) fullWidthAttempts++;
+
+            const error = new Error('request (18832 tokens) exceeds the available context size (16384 tokens)');
+            error.code  = EMBEDDING_INPUT_TRUNCATED_CODE;
+            throw error
+        };
+
+        // The aftermath is deliberately unchanged and asserted as such: a first batch whose refusal
+        // forbids poison isolation still raises the first-batch abort. This ticket removes futile
+        // DISPATCHES, not the abort. That strand has its own owner, and naming it is the point: a
+        // reader must be able to tell "out of scope here" from "unowned". ticket-ref-ok: #16843.
+        await expect(
+            KB_VectorService.embedChunks({collection: spy, chunksToProcess: chunks}),
+            'the first-batch abort still raises — only the wasted dispatches are gone'
+        ).rejects.toThrow(/Failed to process batch 1/);
+
+        expect(
+            fullWidthAttempts,
+            'a refusal the provider states deterministically must be dispatched once, never re-issued'
+        ).toBe(1);
+        expect(spy.upsertedIds, 'and a truncated embedding must never be stored').toEqual([]);
+    });
+
+    test('#16972 NON-VACUITY: a deferrable class still spends its full retry budget', async () => {
+        // The guard above must convict ONLY our own deliberate refusals. A guard that stopped
+        // retrying everything would pass the arm above while destroying the recovery path.
+        //
+        // The control is an UNCLASSIFIED error, chosen after a provider timeout proved to be the
+        // wrong control, and the id is the evidence rather than decoration — the claim is about one
+        // specific merged change a reader must be able to verify. ticket-ref-ok: #16978 ends the
+        // sweep on a provider timeout, so a timeout skips the retry budget by an earlier mechanism.
+        // budget by a different and earlier mechanism. An error carrying no code is the honest
+        // "unlucky, not futile" case — it maps to `KB_VECTOR_EMBED_FAILED`, is outside the rejected
+        // set, and its retries are the recovery path this guard must not touch.
+        Object.assign(KB_Config.data, {batchSize: 50, batchDelay: 0, maxRetries: 3});
+
+        const spy    = createSpyCollection(),
+              chunks = makeChunks(3);
+
+        let fullWidthAttempts = 0;
+
+        TextEmbeddingService.embedTexts = async texts => {
+            if (texts.length === chunks.length) fullWidthAttempts++;
+
+            throw new Error('provider answered with an unclassified failure')
+        };
+
+        await KB_VectorService.embedChunks({collection: spy, chunksToProcess: chunks}).catch(() => {});
+
+        expect(
+            fullWidthAttempts,
+            'a timeout is unlucky rather than futile — the retry budget is the recovery path'
+        ).toBe(3);
     });
 
     test('a poisoned batch is skipped and every LATER batch still embeds', async () => {


### PR DESCRIPTION
Resolves neomjs/neo#16972

> 🌿 A refusal the provider states in full on its first answer can no longer be re-asked four more times.

`REJECTED_EMBED_ERROR_CODES` has documented `KB_VECTOR_EMBED_INPUT_TRUNCATED` as non-retryable all along — *"a later attempt is either futile or unsafe, never merely unlucky: an input over the embedding budget is over it on every retry"* — and the embed dispatch site never asked. The classifier, the KB translation and the closed set all existed; only the consumer was missing.

Measured in production: an **18,832-token** input against a **16,384-token** ceiling, re-dispatched **five times per batch**, **47** such batches in one repository. Every one of the five was known-doomed at dispatch, because the first `400` already carried both numbers.

Evidence: L2 (hermetic unit arms plus three reverted source mutations — no live or integration receipt for the production path) → L2 required (the ACs govern dispatch counts and the preserved isolation path, both decidable in the owning spec). Corrected from L3 at @neo-gpt-emmy's RA-2: a production behaviour change proven only by hermetic arms is L2, and the mutation depth does not promote the class. No residuals.

## AC Evidence

| AC-1 | A rejected-class failure is not retried — the guard classifies before `retries++` and ends the budget on `EMBED_DISPOSITION.rejected`; arm `#16972 a rejected-class refusal costs ONE batch dispatch` asserts **1** full-width dispatch |
| AC-2 | Non-vacuity — arm `#16972 NON-VACUITY: a deferrable class still spends its full retry budget` asserts **3** full-width dispatches for an unclassified error, so the guard convicts only our own refusals |
| AC-3 | Red-proved by mutation — guard disabled: **`Expected: 1, Received: 4`**. Asserted on the dispatch **count**, not the log text |
| AC-4 | Aftermath reached and convicted — the fixture carries an independent embeddable tail so isolation runs and proves the poison; the arm asserts **one** full-width dispatch, **at least one** post-budget isolation dispatch, `chunk-0` fenced by exact identity, and the recoverable tail landing. Two mutations each red a different assertion: forbidding isolation reds the isolation term, disabling the guard gives `Expected: 1, Received: 4` |
| AC-5 | The guard consults `classifyEmbedDisposition` against the shared `REJECTED_EMBED_ERROR_CODES` rather than re-listing codes locally, so a future addition to that set is honoured here without a second edit |

## Deltas from ticket

**The ticket's ACs were written in this same session, against a located mechanism rather than a hypothesis.** neomjs/neo#16972 had a settled disposition since 2026-08-17 but deliberately no ACs — *"writing them first is how a ticket acquires a fix shape nobody re-justified."* Locating the mechanism changed the size of the work dramatically: four of the five pieces already existed and only the consultation was missing, so this is one guard rather than the adaptive-stride subsystem the original body prescribed (struck twice, and correctly).

**The non-vacuity control caught my first choice of control.** I reached for a provider timeout as the "deferrable" case. The arm failed, and the reason is recorded in the spec: a merged change already ends the sweep on a timeout, so a timeout skips the retry budget by an *earlier* mechanism and proves nothing about this guard. An unclassified error is the honest "unlucky, not futile" case. A non-vacuity arm that never fails is decoration; this one earned its place on first run.

**What this does NOT fix, verified rather than assumed.** A first batch whose refusal forbids poison isolation still raises the first-batch abort. I asserted that in the spec rather than leaving it implied, because it bounds the claim: this change removes futile *dispatches*, not the strand. The abort belongs to the batch-isolation lane that owns this spec file.

**Deliberately out of scope, with a named home:** the durable `KB_VECTOR_EMBED_UNDELIVERABLE_AT_GEOMETRY` fence accrues strikes from single-input *call-ceiling expiry*, so a structured **refusal** never graduates by that path even though the `400` names both numbers. That is a new trigger rather than a missing consultation — the refusal-side sibling of the death-side trigger — and bundling it would make a one-line-consultation fix wait on a fence redesign. Recorded in neomjs/neo#16972's Out of Scope.

**Round-1 repairs — both RAs were claims I asserted without running the mechanism.**

- **RA-1.** The original arm proved the budget ended and proved nothing about what follows, and its comment explained the abort as `isPoisonIsolationForbidden()` convicting the truncated class. **That was false** — the predicate convicts abort, provider-death, `ABORT_ERR`, circuit-open and timeout, never this code. The real cause was `isolation.unproved`: my fixture put every chunk in the failed batch, so no control existed outside it. Emmy diagnosed that from the source before I did. Fixed by giving the fixture a tail, and the arm now reds when isolation is bypassed.
- **RA-2.** The production comment named "timeout, transport closure, circuit open" as the contrast case that keeps its full budget. Timeout and circuit-open leave this loop through earlier mechanisms and never spend the budget either — and **my own non-vacuity arm had already failed on exactly that**, which should have told me the sentence was wrong when I wrote it. Now named as a retry-eligible failure, with both early-exiting classes called out. Evidence class corrected L3 → L2.

This is the third defect of one shape I have been involved in today — a claim about a mechanism nobody ran — and the first where I am the author rather than the reviewer.

## Test Evidence

- **GREEN** `npm run test-unit -- test/playwright/unit/ai/services/knowledge-base/` — **765/765** at `234ed4a0a1`.
- **GREEN** focused: `VectorService.batchFailureIsolation.spec.mjs` — **20/20**, including both new arms.
- **RED, mutation** (AC-3) — guard disabled via `if (false && …)`:
  ```
  expect(received).toBe(expected)
  Expected: 1
  Received: 4
  ```
  Reverted; `git diff origin/dev` touches two files.
- **Control that fired and was fixed** (AC-2) — the first non-vacuity attempt used `PROVIDER_TIMEOUT_CODE` and failed, revealing that a timeout is not retried by this loop at all. Switched to an unclassified error, and the reason is in the spec comment so nobody re-derives it.
- Pre-commit gates green after two `ticket-ref-ok` markers: the archaeology lint blocks bare `#N` in durable comments, and both of mine are load-bearing (the id *is* the evidence for a claim about one specific merged change), so the marker is the correct escape rather than deleting the reference.

## Post-Merge Validation

None owed. The guard is a unit-suite contract running in the standing `unit` job.

Worth watching on the plane that motivated the ticket, as an observation rather than owed work: the ingestion log should now show one `An error occurred during embedding batch N` line per refused batch instead of five, with the same terminal outcome. That is a log-shape change, not a behaviour change — the corpus is unblocked only when the refusal-class graduation lands.

## Deltas

See **Deltas from ticket** above — ACs authored against a located mechanism, the non-vacuity control corrected on first run, the unchanged aftermath asserted rather than assumed, and the graduation trigger scoped out with a named home.

Authored by Vega (Opus 5, Claude Code). Memory Core session `cad88c79-073f-4816-aaa7-e779224f2af3`.

