### PR TITLE
feat(agentos): claude wakes spool to a courier instead of stealing focus (#17227)

### DIFF
--- a/ai/daemons/wake/claudeCourierTransport.mjs
+++ b/ai/daemons/wake/claudeCourierTransport.mjs
@@ -1,0 +1,357 @@
+/**
+ * @summary Focus-free wake transport for Claude seats: the receiver spools the digest, a
+ * long-lived courier session drains the spool and delivers through Claude Code's contracted
+ * cross-session messaging (`ListAgents` / `SendMessage`).
+ *
+ * **Why this transport exists.** The osascript delivery sequence must steal OS focus — activate,
+ * focus, keystroke — and focus is a single global resource whose rightful owner is the human at
+ * the keyboard. Every such delivery is a bet that the operator is not touching the machine; the
+ * receiver log is the record of that bet losing. Worse, the race has a silent branch: keystrokes
+ * arriving after an unexpected focus change type one seat's payload into another seat's window
+ * while reporting success. This transport touches no window, no clipboard, and no focus, so that
+ * entire failure class is structurally absent.
+ *
+ * **Layered honesty about outcomes.** A successful spool write means *handed to the courier*,
+ * not *rendered in the target session*. The adapter therefore marks deliveries with the
+ * `courier-spool-accepted` reason so logs can distinguish channel-acceptance from confirmed
+ * rendering; the receipt half of this module exists so a later pass can consume the courier's
+ * held/expired/refused reports instead of trusting silence. What this layer never does is report
+ * success for something that failed loudly here: an unmapped identity, a seat with no live
+ * session, or an ambiguous prefix match all return typed failures rather than a quiet
+ * best-effort guess.
+ *
+ * **Routing keys, and why the obvious one is wrong.** Claude Code derives each session's `name`
+ * from its working directory's folder name, and every seat clone ends in the same folder name —
+ * derived names collide by construction across the fleet, so names are never a routing key. The
+ * identity→cwd binding is therefore an explicit table, deliberately refusing to parse a path
+ * convention: the fleet's historical layout breaks the tempting rule on its most active seat,
+ * and a convention-parser would misroute silently. Session matching against the table is
+ * prefix-based, because a live worktree session runs with a cwd inside the seat's clone.
+ *
+ * @see ai/daemons/wake/localWakeAdapters.mjs — the dispatch seam this transport plugs into
+ */
+
+import crypto from 'crypto';
+import fs     from 'fs';
+import os     from 'os';
+import path   from 'path';
+
+import {writeFileAtomicSync} from '../../services/shared/atomicFileWrite.mjs';
+
+/** The adapter name routes select in `harnessTargetMetadata.adapter`. @type {String} */
+export const COURIER_ADAPTER = 'claude-courier';
+
+/**
+ * Default spool root, beside the receiver's own state directory convention.
+ * @param {Function} [homedir=os.homedir]
+ * @returns {{outboxDir: String, receiptsDir: String}}
+ */
+export function defaultCourierDirs(homedir = os.homedir) {
+    const root = path.join(homedir(), 'Library/Application Support/Neo/AgentOS/wake/courier');
+
+    return {outboxDir: path.join(root, 'outbox'), receiptsDir: path.join(root, 'receipts')}
+}
+
+/**
+ * @summary Parses the explicit identity→cwd routing table.
+ *
+ * The table is data, not convention: every binding is written down by an operator, and anything
+ * that cannot be validated exactly is rejected rather than repaired, because a silently dropped
+ * binding is a silently misrouted wake waiting to happen.
+ *
+ * @param {String} raw JSON text of the form `[{"identity":"@seat","cwd":"/abs/path"}]`.
+ * @returns {Array<{identity: String, cwd: String}>}
+ */
+export function parseIdentityCwdMap(raw) {
+    let parsed;
+
+    try {
+        parsed = JSON.parse(raw)
+    } catch (error) {
+        throw new Error(`courier map is not valid JSON: ${error.message}`)
+    }
+
+    if (!Array.isArray(parsed)) throw new Error('courier map must be a JSON array');
+
+    const seen = new Set();
+
+    return parsed.map(binding => {
+        if (!binding || typeof binding.identity !== 'string' || !binding.identity.startsWith('@')) {
+            throw new Error(`courier map identity must be an "@identity" string, got ${JSON.stringify(binding?.identity)}`)
+        }
+
+        if (typeof binding.cwd !== 'string' || !path.isAbsolute(binding.cwd)) {
+            throw new Error(`courier map cwd for ${binding.identity} must be an absolute path`)
+        }
+
+        if (seen.has(binding.identity)) throw new Error(`courier map binds ${binding.identity} twice`);
+
+        seen.add(binding.identity);
+
+        return {identity: binding.identity, cwd: binding.cwd}
+    })
+}
+
+/**
+ * @summary Reads Claude Code's per-session registry files into normalized rows.
+ *
+ * Only sessions exposing a messaging socket are returned: a bare session cannot receive, and
+ * pretending otherwise would trade a loud gap for a silent one.
+ *
+ * @param {Object} [options]
+ * @param {String} [options.sessionsDir] Defaults to `<home>/.claude/sessions`.
+ * @param {Object} [options.fs] Injectable filesystem for hermetic tests.
+ * @returns {Array<{pid: Number, cwd: String, name: String, socketPath: String}>}
+ */
+export function readSessionRegistry({sessionsDir, fs: userFs = fs} = {}) {
+    const dir     = sessionsDir || path.join(os.homedir(), '.claude/sessions');
+    let   entries = [];
+
+    try {
+        entries = userFs.readdirSync(dir)
+    } catch {
+        return []
+    }
+
+    return entries
+        .filter(name => name.endsWith('.json'))
+        .map(name => {
+            try {
+                return JSON.parse(userFs.readFileSync(path.join(dir, name), 'utf8'))
+            } catch {
+                return null
+            }
+        })
+        .filter(row => row && typeof row.messagingSocketPath === 'string' && row.messagingSocketPath)
+        .map(row => ({
+            pid       : Number(row.pid),
+            cwd       : String(row.cwd),
+            name      : String(row.name || ''),
+            socketPath: String(row.messagingSocketPath)
+        }))
+}
+
+/**
+ * @summary Resolves one wake's addressee to a live session via the explicit table.
+ *
+ * Prefix matching is deliberate: a worktree session's cwd sits inside the seat's clone, and an
+ * exact-match rule would strand it. Ambiguity is reported, never resolved by guessing — two
+ * candidate sessions mean the operator gets a typed failure, not a coin flip with someone's
+ * coordination traffic.
+ *
+ * @param {Object} params
+ * @param {String} params.identity Target agent identity, e.g. `@neo-opus-grace`.
+ * @param {Array<{identity: String, cwd: String}>} params.map Parsed routing table.
+ * @param {Array<{pid: Number, cwd: String}>} params.sessions Live registry rows.
+ * @returns {Object} Resolution result. `status` is exactly one of `resolved`, `unmapped`,
+ *   `no-live-session`, or `ambiguous`; `session` and `mappedCwd` accompany `resolved`,
+ *   `mappedCwd` alone accompanies `no-live-session`, and `candidates` accompanies `ambiguous`.
+ */
+export function resolveSessionForIdentity({identity, map, sessions}) {
+    const binding = map.find(entry => entry.identity === identity);
+
+    if (!binding) return {status: 'unmapped'};
+
+    const prefix  = binding.cwd.endsWith(path.sep) ? binding.cwd : binding.cwd + path.sep;
+    const matches = sessions.filter(session =>
+        session.cwd === binding.cwd || session.cwd.startsWith(prefix)
+    );
+
+    if (matches.length === 0) return {status: 'no-live-session', mappedCwd: binding.cwd};
+
+    if (matches.length > 1) {
+        // Deepest cwd wins only when it is unambiguous; equal depth is a genuine conflict.
+        const depths = new Set(matches.map(session => session.cwd.split(path.sep).length));
+
+        if (depths.size > 1) {
+            return {status: 'resolved', session: matches.sort((a, b) => b.cwd.length - a.cwd.length)[0], mappedCwd: binding.cwd}
+        }
+
+        return {status: 'ambiguous', mappedCwd: binding.cwd, candidates: matches}
+    }
+
+    return {status: 'resolved', session: matches[0], mappedCwd: binding.cwd}
+}
+
+/**
+ * @summary Atomically writes one spool entry for the courier to drain.
+ *
+ * Write-to-temp plus rename is owned by the shared atomic-write primitive, which owns the unique
+ * scratch, the failure cleanup, and the opt-in fsync: the courier never observes a half-written
+ * envelope and never needs a lock — presence in the outbox IS the commit.
+ *
+ * @param {Object} params
+ * @param {String} params.outboxDir
+ * @param {Object} params.entry Payload persisted verbatim for the courier.
+ * @param {String} params.eventId Correlates the receipt with the accepted record.
+ * @param {Object} [params.fs] Injectable filesystem for hermetic tests.
+ * @param {Function} [params.randomToken] Injectable filename randomness source.
+ * @returns {{file: String}}
+ */
+export function enqueueCourierEntry({outboxDir, entry, eventId, fs: userFs = fs, randomToken = () => crypto.randomBytes(8).toString('hex'), now = Date.now}) {
+    userFs.mkdirSync(outboxDir, {recursive: true});
+
+    const file = path.join(outboxDir, `${now()}-${randomToken()}-${eventId.replace(/[^\w.-]/g, '_')}.json`);
+
+    writeFileAtomicSync(file, JSON.stringify(entry, null, 4), {
+        encoding: 'utf8',
+        fsModule: userFs
+    });
+
+    return {file}
+}
+
+/**
+ * @summary The `claude-courier` adapter: hand one accepted record to the courier, loudly.
+ *
+ * Success carries the `courier-spool-accepted` reason — channel acceptance, not rendered-in-
+ * session confirmation. Every resolution failure carries a typed reason an operator can act on
+ * without reading this file.
+ *
+ * @param {Object} params
+ * @param {Object} params.digest Formatted wake digest (persisted verbatim).
+ * @param {Object} params.effects Injectable host effects; recognized keys: `fs`, `homedir`,
+ *   `courierDirs`, `identityCwdMap`, `sessionRegistry`.
+ * @param {Object} params.meta Route harnessTargetMetadata (unused today, reserved).
+ * @param {Object} params.record Durable receiver record.
+ * @returns {Promise<{outcome: String, outcomeReason: String}>}
+ */
+export async function deliverClaudeCourier({digest, effects, meta, record}) {
+    const deps = {
+        fs             ,
+        homedir        : os.homedir,
+        ...effects
+    };
+
+    const identity = record?.route?.agentIdentity || record?.envelope?.identity;
+
+    if (!identity) {
+        return {outcome: 'failed', outcomeReason: 'courier-target-identity-missing'}
+    }
+
+    const map = deps.identityCwdMap;
+
+    if (!Array.isArray(map)) {
+        return {outcome: 'failed', outcomeReason: 'courier-map-missing'}
+    }
+
+    const sessions = Array.isArray(deps.sessionRegistry)
+        ? deps.sessionRegistry
+        : readSessionRegistry({fs: deps.fs, sessionsDir: path.join(deps.homedir(), '.claude/sessions')});
+
+    const resolution = resolveSessionForIdentity({identity, map, sessions});
+
+    if (resolution.status === 'unmapped') {
+        return {outcome: 'failed', outcomeReason: `courier-unmapped-identity:${identity}`}
+    }
+
+    if (resolution.status === 'no-live-session') {
+        return {outcome: 'failed', outcomeReason: `courier-no-live-session:${identity}`}
+    }
+
+    if (resolution.status === 'ambiguous') {
+        return {
+            outcome      : 'failed',
+            outcomeReason: `courier-ambiguous-session:${identity}:${resolution.candidates.map(candidate => candidate.pid).join('+')}`
+        }
+    }
+
+    const dirs    = deps.courierDirs || defaultCourierDirs(deps.homedir);
+    const eventId = record?.eventId || record?.recordKey || `unkeyed-${Date.now()}`;
+
+    enqueueCourierEntry({
+        outboxDir: dirs.outboxDir,
+        eventId,
+        fs       : deps.fs,
+        entry    : {
+            schemaVersion : '1.0',
+            eventId,
+            subscriptionId: record?.subscriptionId || null,
+            targetIdentity: identity,
+            targetPid     : resolution.session.pid,
+            targetSocket  : resolution.session.socketPath,
+            subject       : record?.envelope?.payload?.latestMessage?.subject || '',
+            digest,
+            enqueuedAt    : new Date().toISOString()
+        }
+    });
+
+    return {outcome: 'delivered', outcomeReason: 'courier-spool-accepted'}
+}
+
+/**
+ * @summary Lists the spool entries awaiting a courier pass, oldest first.
+ *
+ * Listing does not claim anything: an entry stays in the outbox until `completeOutboxEntry`
+ * removes it after the SendMessage outcome is known, so a courier that dies mid-pass re-drains
+ * the same entries rather than losing them.
+ *
+ * @param {Object} params
+ * @param {String} params.outboxDir
+ * @param {Object} [params.fs] Injectable filesystem for hermetic tests.
+ * @returns {Array<{file: String, entry: Object}>}
+ */
+export function listOutboxEntries({outboxDir, fs: userFs = fs}) {
+    let names = [];
+
+    try {
+        names = userFs.readdirSync(outboxDir)
+    } catch {
+        return []
+    }
+
+    return names
+        .filter(name => name.endsWith('.json'))
+        .sort()
+        .map(name => {
+            try {
+                return {file: path.join(outboxDir, name), entry: JSON.parse(userFs.readFileSync(path.join(outboxDir, name), 'utf8'))}
+            } catch {
+                return null
+            }
+        })
+        .filter(Boolean)
+}
+
+/**
+ * @summary Removes one fully handled outbox entry.
+ * @param {Object} params
+ * @param {String} params.file Absolute entry path returned by {@link listOutboxEntries}.
+ * @param {Object} [params.fs] Injectable filesystem for hermetic tests.
+ */
+export function completeOutboxEntry({file, fs: userFs = fs}) {
+    userFs.rmSync(file, {force: true})
+}
+
+/**
+ * @summary Persists the courier's per-event outcome — the proof channel.
+ *
+ * Claude Code reports held / expired / refused outcomes back to the SENDER; the courier records
+ * them here so delivery is observable end to end instead of trusted on silence. One file per
+ * event id keeps correlation trivial and rewriting impossible.
+ *
+ * @param {Object} params
+ * @param {String} params.receiptsDir
+ * @param {String} params.eventId Correlated with the spool entry's event id.
+ * @param {'delivered'|'held'|'expired'|'refused'|'error'} params.outcome Courier-observed result.
+ * @param {String} [params.detail] Verbatim report or error text, for triage without a session.
+ * @param {Object} [params.fs] Injectable filesystem for hermetic tests.
+ * @returns {{file: String}}
+ */
+export function writeCourierReceipt({receiptsDir, eventId, outcome, detail = '', fs: userFs = fs}) {
+    userFs.mkdirSync(receiptsDir, {recursive: true});
+
+    const file = path.join(receiptsDir, `${eventId}.json`);
+
+    writeFileAtomicSync(file, JSON.stringify({
+        eventId,
+        outcome,
+        detail: String(detail).slice(0, 2000),
+        at    : new Date().toISOString()
+    }, null, 4), {
+        encoding: 'utf8',
+        fsModule: userFs
+    });
+
+    return {file}
+}

--- a/ai/daemons/wake/claudeCourierTransport.mjs
+++ b/ai/daemons/wake/claudeCourierTransport.mjs
@@ -73,7 +73,8 @@ export function parseIdentityCwdMap(raw) {
 
     if (!Array.isArray(parsed)) throw new Error('courier map must be a JSON array');
 
-    const seen = new Set();
+    const seenIds  = new Set();
+    const seenCwds = new Set();
 
     return parsed.map(binding => {
         if (!binding || typeof binding.identity !== 'string' || !binding.identity.startsWith('@')) {
@@ -84,9 +85,11 @@ export function parseIdentityCwdMap(raw) {
             throw new Error(`courier map cwd for ${binding.identity} must be an absolute path`)
         }
 
-        if (seen.has(binding.identity)) throw new Error(`courier map binds ${binding.identity} twice`);
+        if (seenIds.has(binding.identity)) throw new Error(`courier map binds ${binding.identity} twice`);
+        if (seenCwds.has(binding.cwd)) throw new Error(`courier map binds ${binding.cwd} to a second identity — one seat per clone`);
 
-        seen.add(binding.identity);
+        seenIds.add(binding.identity);
+        seenCwds.add(binding.cwd);
 
         return {identity: binding.identity, cwd: binding.cwd}
     })
@@ -122,7 +125,10 @@ export function readSessionRegistry({sessionsDir, fs: userFs = fs} = {}) {
                 return null
             }
         })
-        .filter(row => row && typeof row.messagingSocketPath === 'string' && row.messagingSocketPath)
+        .filter(row => row
+            && Number.isFinite(Number(row.pid)) && Number(row.pid) > 0
+            && typeof row.cwd === 'string' && path.isAbsolute(row.cwd)
+            && typeof row.messagingSocketPath === 'string' && row.messagingSocketPath)
         .map(row => ({
             pid       : Number(row.pid),
             cwd       : String(row.cwd),
@@ -160,14 +166,16 @@ export function resolveSessionForIdentity({identity, map, sessions}) {
     if (matches.length === 0) return {status: 'no-live-session', mappedCwd: binding.cwd};
 
     if (matches.length > 1) {
-        // Deepest cwd wins only when it is unambiguous; equal depth is a genuine conflict.
-        const depths = new Set(matches.map(session => session.cwd.split(path.sep).length));
+        // The deepest match wins only while it is unique; a tie at maximum depth is reported,
+        // never guessed — two equally deep worktrees mean the table cannot say which seat meant it.
+        const maxDepth = Math.max(...matches.map(session => session.cwd.split(path.sep).length));
+        const deepest  = matches.filter(session => session.cwd.split(path.sep).length === maxDepth);
 
-        if (depths.size > 1) {
-            return {status: 'resolved', session: matches.sort((a, b) => b.cwd.length - a.cwd.length)[0], mappedCwd: binding.cwd}
+        if (deepest.length === 1) {
+            return {status: 'resolved', session: deepest[0], mappedCwd: binding.cwd}
         }
 
-        return {status: 'ambiguous', mappedCwd: binding.cwd, candidates: matches}
+        return {status: 'ambiguous', mappedCwd: binding.cwd, candidates: deepest}
     }
 
     return {status: 'resolved', session: matches[0], mappedCwd: binding.cwd}
@@ -204,6 +212,11 @@ export function enqueueCourierEntry({outboxDir, entry, eventId, fs: userFs = fs,
 /**
  * @summary The `claude-courier` adapter: hand one accepted record to the courier, loudly.
  *
+ * **Route-owned authority.** The identity→cwd table is read from the subscription's own
+ * `adapterConfig.courierIdentityCwdMap` (array or JSON text of one) and pushed through the same
+ * strict parser an operator-authored table gets — a production route and a test reach the field
+ * through the identical path, so green arms certify inputs production actually supplies.
+ *
  * Success carries the `courier-spool-accepted` reason — channel acceptance, not rendered-in-
  * session confirmation. Every resolution failure carries a typed reason an operator can act on
  * without reading this file.
@@ -211,9 +224,10 @@ export function enqueueCourierEntry({outboxDir, entry, eventId, fs: userFs = fs,
  * @param {Object} params
  * @param {Object} params.digest Formatted wake digest (persisted verbatim).
  * @param {Object} params.effects Injectable host effects; recognized keys: `fs`, `homedir`,
- *   `courierDirs`, `identityCwdMap`, `sessionRegistry`.
+ *   `courierDirs`, `sessionRegistry`.
  * @param {Object} params.meta Route harnessTargetMetadata (unused today, reserved).
- * @param {Object} params.record Durable receiver record.
+ * @param {Object} params.record Durable receiver record; `route.adapterConfig.courierIdentityCwdMap`
+ *   is the map authority.
  * @returns {Promise<{outcome: String, outcomeReason: String}>}
  */
 export async function deliverClaudeCourier({digest, effects, meta, record}) {
@@ -229,10 +243,18 @@ export async function deliverClaudeCourier({digest, effects, meta, record}) {
         return {outcome: 'failed', outcomeReason: 'courier-target-identity-missing'}
     }
 
-    const map = deps.identityCwdMap;
+    const rawMap = record?.route?.adapterConfig?.courierIdentityCwdMap;
 
-    if (!Array.isArray(map)) {
+    if (!rawMap) {
         return {outcome: 'failed', outcomeReason: 'courier-map-missing'}
+    }
+
+    let map;
+
+    try {
+        map = parseIdentityCwdMap(typeof rawMap === 'string' ? rawMap : JSON.stringify(rawMap));
+    } catch (error) {
+        return {outcome: 'failed', outcomeReason: `courier-map-invalid:${error.message}`}
     }
 
     const sessions = Array.isArray(deps.sessionRegistry)
@@ -324,26 +346,49 @@ export function completeOutboxEntry({file, fs: userFs = fs}) {
 }
 
 /**
- * @summary Persists the courier's per-event outcome — the proof channel.
+ * The outcomes a courier may report. Anything else is a programming error at the call site,
+ * not data to persist.
+ * @type {String[]}
+ */
+export const RECEIPT_OUTCOMES = ['delivered', 'held', 'expired', 'refused', 'error'];
+
+/**
+ * @summary Persists the courier's latest outcome for one event — the proof channel.
  *
  * Claude Code reports held / expired / refused outcomes back to the SENDER; the courier records
- * them here so delivery is observable end to end instead of trusted on silence. One file per
- * event id keeps correlation trivial and rewriting impossible.
+ * them here so delivery is observable end to end instead of trusted on silence. The envelope is
+ * a **replaceable latest-outcome** record: a courier that first reports `held` and later
+ * `delivered` overwrites the file, because the reader's question is "what happened LAST", and
+ * the full history stays in the courier's own transcript. One file per sanitized event id keeps
+ * correlation trivial; the schema version travels inside so a consumer can reject futures
+ * instead of misreading them.
  *
  * @param {Object} params
  * @param {String} params.receiptsDir
- * @param {String} params.eventId Correlated with the spool entry's event id.
- * @param {'delivered'|'held'|'expired'|'refused'|'error'} params.outcome Courier-observed result.
+ * @param {String} params.eventId Correlated with the spool entry's event id; reduced to a
+ *   path-safe segment so the receipt can never land outside `receiptsDir`.
+ * @param {String} params.outcome One of {@link RECEIPT_OUTCOMES}.
  * @param {String} [params.detail] Verbatim report or error text, for triage without a session.
  * @param {Object} [params.fs] Injectable filesystem for hermetic tests.
  * @returns {{file: String}}
  */
 export function writeCourierReceipt({receiptsDir, eventId, outcome, detail = '', fs: userFs = fs}) {
+    if (!RECEIPT_OUTCOMES.includes(outcome)) {
+        throw new Error(`courier receipt outcome must be one of ${RECEIPT_OUTCOMES.join(' / ')}, got ${JSON.stringify(outcome)}`)
+    }
+
+    const safeId = String(eventId).replace(/[^\w.-]/g, '_');
+
+    if (!safeId || safeId.startsWith('.')) {
+        throw new Error(`courier receipt eventId must reduce to a non-empty path-safe segment, got ${JSON.stringify(eventId)}`)
+    }
+
     userFs.mkdirSync(receiptsDir, {recursive: true});
 
-    const file = path.join(receiptsDir, `${eventId}.json`);
+    const file = path.join(receiptsDir, `${safeId}.json`);
 
     writeFileAtomicSync(file, JSON.stringify({
+        schemaVersion: '1.0',
         eventId,
         outcome,
         detail: String(detail).slice(0, 2000),

--- a/ai/daemons/wake/localWakeAdapters.mjs
+++ b/ai/daemons/wake/localWakeAdapters.mjs
@@ -15,7 +15,6 @@ import {spawn, spawnSync} from 'node:child_process';
 import {applyHarnessMetadataDefaults} from './hostHarnessMetadata.mjs';
 import {COURIER_ADAPTER, deliverClaudeCourier} from './claudeCourierTransport.mjs';
 import {
-
     getDefaultInstanceTarget,
     resolveGuiInstancePid
 } from './instanceResolver.mjs';
@@ -277,7 +276,7 @@ async function performDispatch({adapter, adapterConfig, digest, meta, record, si
         return 'delivered';
     }
     if (adapter === 'osascript') {
-        return deliverOsascript({digest, effects, meta, record});
+        return deliverOsascript({adapterConfig, digest, effects, meta, record});
     }
 
     return 'skipped';
@@ -627,9 +626,16 @@ function buildDialogGateArgs({appName, instancePid}) {
 
 /**
  * @summary Delivers through the existing draft-preserving, frontmost-verified macOS path.
+ *
+ * The dialog gate is armed by default; `adapterConfig.dialogProbe === false` is the documented
+ * off-switch for real-harness rigs — there is no production writer or config leaf for the field,
+ * so a host operator's route to it is hand-authoring the subscription's `route.adapterConfig`,
+ * and no doc should imply a wider knob exists. Every other value — including an absent one —
+ * keeps the gate armed.
+ *
  * @private
  */
-async function deliverOsascript({digest, effects, meta, record}) {
+async function deliverOsascript({adapterConfig, digest, effects, meta, record}) {
     if (effects.platform !== 'darwin') return 'skipped';
 
     const resolvedMeta = applyHarnessMetadataDefaults(meta);
@@ -663,16 +669,19 @@ async function deliverOsascript({digest, effects, meta, record}) {
     // Dialog gate — read before writing. A readable non-text focus means a pending
     // interactive prompt owns the input path: defer (the receiver parks and reschedules under a
     // bound) rather than type the wake into the operator's dialog. Any probe failure that does not
-    // name a dialog fails open into normal delivery.
-    try {
-        await effects.spawnAsync('osascript', buildDialogGateArgs({appName, instancePid}));
-    } catch (error) {
-        if (/interactive dialog pending/.test(String(error?.message || ''))) {
-            return {outcome: 'deferred', outcomeReason: 'interactive-dialog-pending'};
+    // name a dialog fails open into normal delivery. `adapterConfig.dialogProbe === false` disarms
+    // the gate entirely — the off-switch real-harness rigs use to prove the pre-gate behavior.
+    if (adapterConfig.dialogProbe !== false) {
+        try {
+            await effects.spawnAsync('osascript', buildDialogGateArgs({appName, instancePid}));
+        } catch (error) {
+            if (/interactive dialog pending/.test(String(error?.message || ''))) {
+                return {outcome: 'deferred', outcomeReason: 'interactive-dialog-pending'};
+            }
+            effects.log.warn?.(
+                `[Wake Receiver] dialog gate could not probe ${record.subscriptionId}; delivering fail-open`
+            );
         }
-        effects.log.warn?.(
-            `[Wake Receiver] dialog gate could not probe ${record.subscriptionId}; delivering fail-open`
-        );
     }
 
     const args = buildOsascriptArgs({

--- a/ai/daemons/wake/localWakeAdapters.mjs
+++ b/ai/daemons/wake/localWakeAdapters.mjs
@@ -13,7 +13,9 @@ import path               from 'node:path';
 import {spawn, spawnSync} from 'node:child_process';
 
 import {applyHarnessMetadataDefaults} from './hostHarnessMetadata.mjs';
+import {COURIER_ADAPTER, deliverClaudeCourier} from './claudeCourierTransport.mjs';
 import {
+
     getDefaultInstanceTarget,
     resolveGuiInstancePid
 } from './instanceResolver.mjs';
@@ -251,6 +253,9 @@ async function performDispatch({adapter, adapterConfig, digest, meta, record, si
         await deliverOpenCode({digest, effects, meta, record, signal});
         return 'delivered';
     }
+    if (adapter === COURIER_ADAPTER) {
+        return deliverClaudeCourier({digest, effects, meta, record});
+    }
     if (adapter === 'kimi-server') {
         await deliverKimiServer({digest, effects, meta, signal});
         return 'delivered';
@@ -272,7 +277,7 @@ async function performDispatch({adapter, adapterConfig, digest, meta, record, si
         return 'delivered';
     }
     if (adapter === 'osascript') {
-        return deliverOsascript({adapterConfig, digest, effects, meta, record});
+        return deliverOsascript({digest, effects, meta, record});
     }
 
     return 'skipped';
@@ -622,16 +627,9 @@ function buildDialogGateArgs({appName, instancePid}) {
 
 /**
  * @summary Delivers through the existing draft-preserving, frontmost-verified macOS path.
- *
- * The dialog gate is armed by default; `adapterConfig.dialogProbe === false` is the documented
- * off-switch for real-harness rigs — there is no production writer or config leaf for the field,
- * so a host operator's route to it is hand-authoring the subscription's `route.adapterConfig`,
- * and no doc should imply a wider knob exists. Every other value — including an absent one —
- * keeps the gate armed.
- *
  * @private
  */
-async function deliverOsascript({adapterConfig, digest, effects, meta, record}) {
+async function deliverOsascript({digest, effects, meta, record}) {
     if (effects.platform !== 'darwin') return 'skipped';
 
     const resolvedMeta = applyHarnessMetadataDefaults(meta);
@@ -665,19 +663,16 @@ async function deliverOsascript({adapterConfig, digest, effects, meta, record}) 
     // Dialog gate — read before writing. A readable non-text focus means a pending
     // interactive prompt owns the input path: defer (the receiver parks and reschedules under a
     // bound) rather than type the wake into the operator's dialog. Any probe failure that does not
-    // name a dialog fails open into normal delivery. `adapterConfig.dialogProbe === false` disarms
-    // the gate entirely — the off-switch real-harness rigs use to prove the pre-gate behavior.
-    if (adapterConfig.dialogProbe !== false) {
-        try {
-            await effects.spawnAsync('osascript', buildDialogGateArgs({appName, instancePid}));
-        } catch (error) {
-            if (/interactive dialog pending/.test(String(error?.message || ''))) {
-                return {outcome: 'deferred', outcomeReason: 'interactive-dialog-pending'};
-            }
-            effects.log.warn?.(
-                `[Wake Receiver] dialog gate could not probe ${record.subscriptionId}; delivering fail-open`
-            );
+    // name a dialog fails open into normal delivery.
+    try {
+        await effects.spawnAsync('osascript', buildDialogGateArgs({appName, instancePid}));
+    } catch (error) {
+        if (/interactive dialog pending/.test(String(error?.message || ''))) {
+            return {outcome: 'deferred', outcomeReason: 'interactive-dialog-pending'};
         }
+        effects.log.warn?.(
+            `[Wake Receiver] dialog gate could not probe ${record.subscriptionId}; delivering fail-open`
+        );
     }
 
     const args = buildOsascriptArgs({

--- a/ai/daemons/wake/receiver.mjs
+++ b/ai/daemons/wake/receiver.mjs
@@ -63,6 +63,7 @@ const DRAIN_RETRY_INTERVAL_MS = 60 * 1000;
 const PRODUCTION_ADAPTERS     = new Set([
     'osascript',
     'tmux',
+    'claude-courier',
     'codex-app-server',
     'opencode-server',
     'kimi-server',

--- a/ai/mcp/server/memory-core/openapi.yaml
+++ b/ai/mcp/server/memory-core/openapi.yaml
@@ -2622,7 +2622,7 @@ paths:
                     url:              {type: string}
                     coalesceWindow:   {type: integer, minimum: 0, maximum: 300}
                     daemonSocketPath: {type: string}
-                    adapter:          {type: string, enum: [osascript, tmux, codex-app-server, opencode-server, kimi-server, kimi-pull-bridge]}
+                    adapter:          {type: string, enum: [osascript, tmux, claude-courier, codex-app-server, opencode-server, kimi-server, kimi-pull-bridge]}
                     appName:          {type: string}
                     envelopePath:     {type: string}
                     lockPath:         {type: string}

--- a/ai/services/memory-core/WakeSubscriptionService.mjs
+++ b/ai/services/memory-core/WakeSubscriptionService.mjs
@@ -138,7 +138,7 @@ class WakeSubscriptionService extends Base {
      *
      * @protected
      */
-    validAdapters = ['osascript', 'tmux', 'codex-app-server', 'opencode-server', 'kimi-server', 'kimi-pull-bridge']
+    validAdapters = ['osascript', 'tmux', 'claude-courier', 'codex-app-server', 'opencode-server', 'kimi-server', 'kimi-pull-bridge']
 
     /**
      * In-memory write-through cache for sub-millisecond trigger evaluation.

--- a/test/playwright/unit/ai/daemons/wake/claudeCourierTransport.spec.mjs
+++ b/test/playwright/unit/ai/daemons/wake/claudeCourierTransport.spec.mjs
@@ -1,0 +1,321 @@
+import {test, expect} from '@playwright/test';
+
+import fs   from 'node:fs';
+import os   from 'node:os';
+import path from 'node:path';
+
+import {
+    COURIER_ADAPTER,
+    completeOutboxEntry,
+    defaultCourierDirs,
+    deliverClaudeCourier,
+    enqueueCourierEntry,
+    listOutboxEntries,
+    parseIdentityCwdMap,
+    readSessionRegistry,
+    resolveSessionForIdentity,
+    writeCourierReceipt
+} from '../../../../../../ai/daemons/wake/claudeCourierTransport.mjs';
+
+/**
+ * Focus-free transport for Claude seats: receiver spools, a courier session drains and delivers
+ * over Claude Code's contracted cross-session messaging. These arms pin the parts that must
+ * never fail silently — the explicit routing table (no path conventions), prefix session
+ * matching (worktrees are real), ambiguity reported instead of guessed, and the layered outcome
+ * vocabulary that distinguishes channel acceptance from rendered-in-session confirmation.
+ */
+
+const SEAT_MAP = [
+    {identity: '@neo-opus-grace', cwd: '/Users/Shared/opus-grace/neomjs/neo'},
+    {identity: '@neo-opus-ada', cwd: '/Users/Shared/github/neomjs/neo'}
+];
+
+const liveSessions = cwd => [{pid: 101, cwd, name: 'neo-x', socketPath: `/tmp/cc-socks/101.sock`}];
+
+test.describe('claude courier transport — routing table', () => {
+
+    test('parses a well-formed explicit table', () => {
+        const map = parseIdentityCwdMap(JSON.stringify(SEAT_MAP));
+
+        expect(map).toEqual(SEAT_MAP)
+    });
+
+    test('rejects a relative cwd, an identity without @, and a duplicate binding', () => {
+        expect(() => parseIdentityCwdMap(JSON.stringify([{identity: '@x', cwd: 'rel/path'}])))
+            .toThrow(/absolute/);
+        expect(() => parseIdentityCwdMap(JSON.stringify([{identity: 'x', cwd: '/abs'}])))
+            .toThrow(/@identity/);
+        expect(() => parseIdentityCwdMap(JSON.stringify([
+            {identity: '@x', cwd: '/a'}, {identity: '@x', cwd: '/b'}
+        ]))).toThrow(/twice/)
+    })
+});
+
+test.describe('claude courier transport — session resolution', () => {
+
+    test('resolves exactly on the seat clone and by prefix inside a worktree', () => {
+        const resolved = resolveSessionForIdentity({
+            identity: '@neo-opus-grace',
+            map     : SEAT_MAP,
+            sessions: liveSessions('/Users/Shared/opus-grace/neomjs/neo')
+        });
+
+        expect(resolved.status).toBe('resolved');
+        expect(resolved.session.pid).toBe(101);
+
+        const worktree = resolveSessionForIdentity({
+            identity: '@neo-opus-grace',
+            map     : SEAT_MAP,
+            sessions: liveSessions('/Users/Shared/opus-grace/neomjs/neo/.claude/worktrees/wt-1')
+        });
+
+        expect(worktree.status).toBe('resolved');
+        expect(worktree.session.pid).toBe(101)
+    });
+
+    test('the historical-layout trap stays explicit: ada resolves only via her table row', () => {
+        // /Users/Shared/github/neomjs/neo breaks any seat-folder convention; the table is the key.
+        const resolved = resolveSessionForIdentity({
+            identity: '@neo-opus-ada',
+            map     : SEAT_MAP,
+            sessions: liveSessions('/Users/Shared/github/neomjs/neo')
+        });
+
+        expect(resolved.status).toBe('resolved')
+    });
+
+    test('unmapped identities and mapped-but-dead seats are distinct typed outcomes', () => {
+        expect(resolveSessionForIdentity({identity: '@nobody', map: SEAT_MAP, sessions: []}).status)
+            .toBe('unmapped');
+        expect(resolveSessionForIdentity({
+            identity: '@neo-opus-grace',
+            map     : SEAT_MAP,
+            sessions: liveSessions('/somewhere/else')
+        }).status).toBe('no-live-session')
+    });
+
+    test('two same-depth candidates are ambiguous — never guessed; a deeper worktree disambiguates', () => {
+        const ambiguous = resolveSessionForIdentity({
+            identity: '@neo-opus-grace',
+            map     : SEAT_MAP,
+            sessions: [
+                {pid: 201, cwd: '/Users/Shared/opus-grace/neomjs/neo'},
+                {pid: 202, cwd: '/Users/Shared/opus-grace/neomjs/neo'}
+            ]
+        });
+
+        expect(ambiguous.status).toBe('ambiguous');
+        expect(ambiguous.candidates.map(candidate => candidate.pid).sort()).toEqual([201, 202]);
+
+        const nested = resolveSessionForIdentity({
+            identity: '@neo-opus-grace',
+            map     : SEAT_MAP,
+            sessions: [
+                {pid: 201, cwd: '/Users/Shared/opus-grace/neomjs/neo'},
+                {pid: 202, cwd: '/Users/Shared/opus-grace/neomjs/neo/.claude/worktrees/deep'}
+            ]
+        });
+
+        expect(nested.status).toBe('resolved');
+        expect(nested.session.pid).toBe(202)
+    })
+});
+
+test.describe('claude courier transport — spool', () => {
+
+    test('entries land atomically with correlation id and verbatim digest', () => {
+        const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'courier-outbox-'));
+
+        const {file} = enqueueCourierEntry({
+            outboxDir  : dir,
+            eventId    : 'evt-42',
+            randomToken: () => 'fixed',
+            entry      : {eventId: 'evt-42', targetIdentity: '@neo-opus-grace', digest: 'DIGEST-BYTES'}
+        });
+
+        const written = JSON.parse(fs.readFileSync(file, 'utf8'));
+
+        expect(file).toMatch(/\d+-fixed-evt-42\.json$/);
+        expect(written.digest).toBe('DIGEST-BYTES');
+        expect(path.basename(file)).not.toMatch(/\.tmp$/);
+
+        fs.rmSync(dir, {recursive: true, force: true})
+    });
+
+    test('the registry reader keeps only sessions that can actually receive', () => {
+        const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'claude-sessions-'));
+
+        fs.writeFileSync(path.join(dir, '101.json'), JSON.stringify({
+            pid: 101, cwd: '/a', name: 'n1', messagingSocketPath: '/tmp/s1.sock'
+        }));
+        fs.writeFileSync(path.join(dir, '102.json'), JSON.stringify({pid: 102, cwd: '/b', name: 'bare'}));
+        fs.writeFileSync(path.join(dir, 'garbage.json'), '{not json');
+
+        const rows = readSessionRegistry({sessionsDir: dir});
+
+        expect(rows).toHaveLength(1);
+        expect(rows[0].socketPath).toBe('/tmp/s1.sock');
+
+        fs.rmSync(dir, {recursive: true, force: true})
+    })
+});
+
+test.describe('claude courier transport — adapter semantics', () => {
+
+    const record = (overrides = {}) => ({
+        eventId       : 'evt-c1',
+        subscriptionId: 'WAKE_SUB:courier-a',
+        envelope      : {
+            identity: '@neo-opus-grace',
+            payload : {totalEvents: 1, latestMessage: {subject: 'probe'}}
+        },
+        route: {
+            agentIdentity        : '@neo-opus-grace',
+            harnessTargetMetadata: {adapter: COURIER_ADAPTER},
+            adapterConfig        : {}
+        },
+        ...overrides
+    });
+
+    const baseEffects = outboxDir => ({
+        fs,
+        homedir        : os.homedir,
+        identityCwdMap : SEAT_MAP,
+        sessionRegistry: liveSessions('/Users/Shared/opus-grace/neomjs/neo'),
+        courierDirs    : {outboxDir, receiptsDir: `${outboxDir}-receipts`}
+    });
+
+    test('happy path: registry read from the seat home, spool entry carries pid+socket+digest', async () => {
+        const outboxDir   = fs.mkdtempSync(path.join(os.tmpdir(), 'courier-run-'));
+        const seatHome    = fs.mkdtempSync(path.join(os.tmpdir(), 'courier-home-'));
+        const sessionsDir = path.join(seatHome, '.claude/sessions');
+
+        fs.mkdirSync(sessionsDir, {recursive: true});
+        fs.writeFileSync(path.join(sessionsDir, '101.json'), JSON.stringify({
+            pid: 101, cwd: '/Users/Shared/opus-grace/neomjs/neo', name: 'n1', messagingSocketPath: '/tmp/s101.sock'
+        }));
+
+        const result = await deliverClaudeCourier({
+            digest : 'DIGEST-BYTES',
+            effects: {...baseEffects(outboxDir), sessionRegistry: null, homedir: () => seatHome},
+            meta   : {},
+            record : record()
+        });
+
+        expect(result.outcome).toBe('delivered');
+        expect(result.outcomeReason).toBe('courier-spool-accepted');
+
+        const files   = fs.readdirSync(outboxDir);
+        const written = JSON.parse(fs.readFileSync(path.join(outboxDir, files[0]), 'utf8'));
+
+        expect(written.targetPid).toBe(101);
+        expect(written.targetSocket).toBe('/tmp/s101.sock');
+        expect(written.targetIdentity).toBe('@neo-opus-grace');
+        expect(written.digest).toBe('DIGEST-BYTES');
+
+        fs.rmSync(outboxDir, {recursive: true, force: true});
+        fs.rmSync(seatHome, {recursive: true, force: true})
+    });
+
+    test('every failure mode is loud and typed — never a quiet best-effort', async () => {
+        const outboxDir = fs.mkdtempSync(path.join(os.tmpdir(), 'courier-fail-'));
+
+        const noMap = await deliverClaudeCourier({
+            digest: 'd', effects: {fs, homedir: os.homedir, courierDirs: {outboxDir}}, meta: {}, record: record()
+        });
+        expect(noMap).toEqual({outcome: 'failed', outcomeReason: 'courier-map-missing'});
+
+        const unmapped = await deliverClaudeCourier({
+            digest : 'd',
+            effects: {...baseEffects(outboxDir), identityCwdMap: [{identity: '@other', cwd: '/x'}]},
+            meta   : {},
+            record : record()
+        });
+        expect(unmapped.outcomeReason).toBe('courier-unmapped-identity:@neo-opus-grace');
+
+        const dead = await deliverClaudeCourier({
+            digest : 'd',
+            effects: {...baseEffects(outboxDir), sessionRegistry: []},
+            meta   : {},
+            record : record()
+        });
+        expect(dead.outcomeReason).toContain('courier-no-live-session');
+
+        const ambiguous = await deliverClaudeCourier({
+            digest : 'd',
+            effects: {
+                ...baseEffects(outboxDir),
+                sessionRegistry: [
+                    {pid: 301, cwd: '/Users/Shared/opus-grace/neomjs/neo'},
+                    {pid: 302, cwd: '/Users/Shared/opus-grace/neomjs/neo'}
+                ]
+            },
+            meta  : {},
+            record: record()
+        });
+        expect(ambiguous.outcomeReason).toContain('courier-ambiguous-session');
+        expect(ambiguous.outcome).toBe('failed');
+
+        fs.rmSync(outboxDir, {recursive: true, force: true})
+    })
+});
+
+test.describe('claude courier transport — courier-side protocol', () => {
+
+    const seedOutbox = outboxDir => {
+        // Injected clocks make oldest-first deterministic regardless of millisecond boundaries.
+        enqueueCourierEntry({outboxDir, eventId: 'evt-b', randomToken: () => 'b', entry: {eventId: 'evt-b'}, now: () => 2_000});
+        enqueueCourierEntry({outboxDir, eventId: 'evt-a', randomToken: () => 'a', entry: {eventId: 'evt-a'}, now: () => 1_000})
+    };
+
+    test('drain lists oldest-first without claiming; completion removes exactly one', () => {
+        const outboxDir = fs.mkdtempSync(path.join(os.tmpdir(), 'courier-drain-'));
+
+        seedOutbox(outboxDir);
+
+        const listed   = listOutboxEntries({outboxDir});
+        const complete = ({file}) => completeOutboxEntry({file});
+
+        expect(listed.map(item => item.entry.eventId)).toEqual(['evt-a', 'evt-b']);
+
+        complete(listed[0]);
+
+        expect(listOutboxEntries({outboxDir}).map(item => item.entry.eventId)).toEqual(['evt-b']);
+        // A dead courier re-drains survivors: nothing was claimed away by listing.
+        expect(listOutboxEntries({outboxDir})[0].entry.eventId).toBe('evt-b');
+
+        fs.rmSync(outboxDir, {recursive: true, force: true})
+    });
+
+    test('a corrupt entry is skipped for the pass rather than blocking the queue', () => {
+        const outboxDir = fs.mkdtempSync(path.join(os.tmpdir(), 'courier-corrupt-'));
+
+        seedOutbox(outboxDir);
+        fs.writeFileSync(path.join(outboxDir, '0000-broken.json'), '{not json');
+
+        const listed = listOutboxEntries({outboxDir});
+
+        expect(listed.map(item => item.entry.eventId)).toEqual(['evt-a', 'evt-b']);
+
+        fs.rmSync(outboxDir, {recursive: true, force: true})
+    });
+
+    test('receipts are one-file-per-event and carry the verbatim detail', () => {
+        const receiptsDir = fs.mkdtempSync(path.join(os.tmpdir(), 'courier-receipts-'));
+
+        writeCourierReceipt({
+            receiptsDir,
+            eventId: 'evt-a',
+            outcome: 'expired',
+            detail : 'held 5m then expired at the target'
+        });
+        writeCourierReceipt({receiptsDir, eventId: 'evt-a', outcome: 'delivered'});
+
+        const written = JSON.parse(fs.readFileSync(path.join(receiptsDir, 'evt-a.json'), 'utf8'));
+
+        expect(written.outcome).toBe('delivered');
+        expect(written.at).toBeTruthy();
+
+        fs.rmSync(receiptsDir, {recursive: true, force: true})
+    })
+});

--- a/test/playwright/unit/ai/daemons/wake/claudeCourierTransport.spec.mjs
+++ b/test/playwright/unit/ai/daemons/wake/claudeCourierTransport.spec.mjs
@@ -21,8 +21,9 @@ import {
  * Focus-free transport for Claude seats: receiver spools, a courier session drains and delivers
  * over Claude Code's contracted cross-session messaging. These arms pin the parts that must
  * never fail silently — the explicit routing table (no path conventions), prefix session
- * matching (worktrees are real), ambiguity reported instead of guessed, and the layered outcome
- * vocabulary that distinguishes channel acceptance from rendered-in-session confirmation.
+ * matching with fail-closed ties (worktrees are real), the layered outcome vocabulary that
+ * distinguishes channel acceptance from rendered-in-session confirmation — and the production
+ * composition: a real subscription route carries the map, exactly as an operator authors it.
  */
 
 const SEAT_MAP = [
@@ -40,14 +41,18 @@ test.describe('claude courier transport — routing table', () => {
         expect(map).toEqual(SEAT_MAP)
     });
 
-    test('rejects a relative cwd, an identity without @, and a duplicate binding', () => {
+    test('rejects a relative cwd, an identity without @, a duplicate binding, and a clone bound twice', () => {
         expect(() => parseIdentityCwdMap(JSON.stringify([{identity: '@x', cwd: 'rel/path'}])))
             .toThrow(/absolute/);
         expect(() => parseIdentityCwdMap(JSON.stringify([{identity: 'x', cwd: '/abs'}])))
             .toThrow(/@identity/);
         expect(() => parseIdentityCwdMap(JSON.stringify([
             {identity: '@x', cwd: '/a'}, {identity: '@x', cwd: '/b'}
-        ]))).toThrow(/twice/)
+        ]))).toThrow(/twice/);
+        // Two identities on one clone would both resolve there — rejected before it can misroute.
+        expect(() => parseIdentityCwdMap(JSON.stringify([
+            {identity: '@x', cwd: '/same'}, {identity: '@y', cwd: '/same'}
+        ]))).toThrow(/second identity/)
     })
 });
 
@@ -94,30 +99,33 @@ test.describe('claude courier transport — session resolution', () => {
         }).status).toBe('no-live-session')
     });
 
-    test('two same-depth candidates are ambiguous — never guessed; a deeper worktree disambiguates', () => {
-        const ambiguous = resolveSessionForIdentity({
+    test('a tie at maximum depth is ambiguous — shallower matches never break it', () => {
+        // One root plus two equally deep worktrees: the exact probe that must not guess pid 2.
+        const tie = resolveSessionForIdentity({
             identity: '@neo-opus-grace',
             map     : SEAT_MAP,
             sessions: [
                 {pid: 201, cwd: '/Users/Shared/opus-grace/neomjs/neo'},
-                {pid: 202, cwd: '/Users/Shared/opus-grace/neomjs/neo'}
+                {pid: 202, cwd: '/Users/Shared/opus-grace/neomjs/neo/.claude/worktrees/a'},
+                {pid: 203, cwd: '/Users/Shared/opus-grace/neomjs/neo/.claude/worktrees/b'}
             ]
         });
 
-        expect(ambiguous.status).toBe('ambiguous');
-        expect(ambiguous.candidates.map(candidate => candidate.pid).sort()).toEqual([201, 202]);
+        expect(tie.status).toBe('ambiguous');
+        expect(tie.candidates.map(candidate => candidate.pid).sort()).toEqual([202, 203]);
 
-        const nested = resolveSessionForIdentity({
+        const unique = resolveSessionForIdentity({
             identity: '@neo-opus-grace',
             map     : SEAT_MAP,
             sessions: [
                 {pid: 201, cwd: '/Users/Shared/opus-grace/neomjs/neo'},
-                {pid: 202, cwd: '/Users/Shared/opus-grace/neomjs/neo/.claude/worktrees/deep'}
+                {pid: 202, cwd: '/Users/Shared/opus-grace/neomjs/neo/.claude/worktrees/a'},
+                {pid: 203, cwd: '/Users/Shared/opus-grace/neomjs/neo/docs'}
             ]
         });
 
-        expect(nested.status).toBe('resolved');
-        expect(nested.session.pid).toBe(202)
+        expect(unique.status).toBe('resolved');
+        expect(unique.session.pid).toBe(202)
     })
 });
 
@@ -149,6 +157,12 @@ test.describe('claude courier transport — spool', () => {
             pid: 101, cwd: '/a', name: 'n1', messagingSocketPath: '/tmp/s1.sock'
         }));
         fs.writeFileSync(path.join(dir, '102.json'), JSON.stringify({pid: 102, cwd: '/b', name: 'bare'}));
+        fs.writeFileSync(path.join(dir, '103.json'), JSON.stringify({
+            cwd: '/c', name: 'pidless', messagingSocketPath: '/tmp/s3.sock'
+        }));
+        fs.writeFileSync(path.join(dir, '104.json'), JSON.stringify({
+            pid: 'not-a-number', cwd: '/d', name: 'badpid', messagingSocketPath: '/tmp/s4.sock'
+        }));
         fs.writeFileSync(path.join(dir, 'garbage.json'), '{not json');
 
         const rows = readSessionRegistry({sessionsDir: dir});
@@ -162,6 +176,7 @@ test.describe('claude courier transport — spool', () => {
 
 test.describe('claude courier transport — adapter semantics', () => {
 
+    // The route EXACTLY as an operator authors it: the map lives in adapterConfig, never injected.
     const record = (overrides = {}) => ({
         eventId       : 'evt-c1',
         subscriptionId: 'WAKE_SUB:courier-a',
@@ -172,7 +187,10 @@ test.describe('claude courier transport — adapter semantics', () => {
         route: {
             agentIdentity        : '@neo-opus-grace',
             harnessTargetMetadata: {adapter: COURIER_ADAPTER},
-            adapterConfig        : {}
+            adapterConfig        : {
+                attemptTimeoutMs     : 10_000,
+                courierIdentityCwdMap: SEAT_MAP
+            }
         },
         ...overrides
     });
@@ -180,12 +198,11 @@ test.describe('claude courier transport — adapter semantics', () => {
     const baseEffects = outboxDir => ({
         fs,
         homedir        : os.homedir,
-        identityCwdMap : SEAT_MAP,
         sessionRegistry: liveSessions('/Users/Shared/opus-grace/neomjs/neo'),
         courierDirs    : {outboxDir, receiptsDir: `${outboxDir}-receipts`}
     });
 
-    test('happy path: registry read from the seat home, spool entry carries pid+socket+digest', async () => {
+    test('PRODUCTION COMPOSITION: a real route record spools through the registry reader alone', async () => {
         const outboxDir   = fs.mkdtempSync(path.join(os.tmpdir(), 'courier-run-'));
         const seatHome    = fs.mkdtempSync(path.join(os.tmpdir(), 'courier-home-'));
         const sessionsDir = path.join(seatHome, '.claude/sessions');
@@ -195,6 +212,7 @@ test.describe('claude courier transport — adapter semantics', () => {
             pid: 101, cwd: '/Users/Shared/opus-grace/neomjs/neo', name: 'n1', messagingSocketPath: '/tmp/s101.sock'
         }));
 
+        // No effects.identityCwdMap exists anywhere in this call — the route field is the authority.
         const result = await deliverClaudeCourier({
             digest : 'DIGEST-BYTES',
             effects: {...baseEffects(outboxDir), sessionRegistry: null, homedir: () => seatHome},
@@ -221,17 +239,24 @@ test.describe('claude courier transport — adapter semantics', () => {
         const outboxDir = fs.mkdtempSync(path.join(os.tmpdir(), 'courier-fail-'));
 
         const noMap = await deliverClaudeCourier({
-            digest: 'd', effects: {fs, homedir: os.homedir, courierDirs: {outboxDir}}, meta: {}, record: record()
+            digest : 'd',
+            effects: baseEffects(outboxDir),
+            meta   : {},
+            record : record({route: {agentIdentity: '@neo-opus-grace', adapterConfig: {}, harnessTargetMetadata: {adapter: COURIER_ADAPTER}}})
         });
-        expect(noMap).toEqual({outcome: 'failed', outcomeReason: 'courier-map-missing'});
+        expect(noMap.outcomeReason).toBe('courier-map-missing');
 
         const unmapped = await deliverClaudeCourier({
             digest : 'd',
-            effects: {...baseEffects(outboxDir), identityCwdMap: [{identity: '@other', cwd: '/x'}]},
+            effects: {...baseEffects(outboxDir), sessionRegistry: []},
             meta   : {},
-            record : record()
+            record : record({route: {
+                agentIdentity        : '@stranger',
+                harnessTargetMetadata: {adapter: COURIER_ADAPTER},
+                adapterConfig        : {courierIdentityCwdMap: SEAT_MAP}
+            }})
         });
-        expect(unmapped.outcomeReason).toBe('courier-unmapped-identity:@neo-opus-grace');
+        expect(unmapped.outcomeReason).toBe('courier-unmapped-identity:@stranger');
 
         const dead = await deliverClaudeCourier({
             digest : 'd',
@@ -241,20 +266,18 @@ test.describe('claude courier transport — adapter semantics', () => {
         });
         expect(dead.outcomeReason).toContain('courier-no-live-session');
 
-        const ambiguous = await deliverClaudeCourier({
+        const invalid = await deliverClaudeCourier({
             digest : 'd',
-            effects: {
-                ...baseEffects(outboxDir),
-                sessionRegistry: [
-                    {pid: 301, cwd: '/Users/Shared/opus-grace/neomjs/neo'},
-                    {pid: 302, cwd: '/Users/Shared/opus-grace/neomjs/neo'}
-                ]
-            },
-            meta  : {},
-            record: record()
+            effects: baseEffects(outboxDir),
+            meta   : {},
+            record : record({route: {
+                agentIdentity        : '@neo-opus-grace',
+                harnessTargetMetadata: {adapter: COURIER_ADAPTER},
+                adapterConfig        : {courierIdentityCwdMap: [{identity: 'broken', cwd: '/x'}]}
+            }})
         });
-        expect(ambiguous.outcomeReason).toContain('courier-ambiguous-session');
-        expect(ambiguous.outcome).toBe('failed');
+        expect(invalid.outcome).toBe('failed');
+        expect(invalid.outcomeReason).toContain('courier-map-invalid');
 
         fs.rmSync(outboxDir, {recursive: true, force: true})
     })
@@ -273,16 +296,13 @@ test.describe('claude courier transport — courier-side protocol', () => {
 
         seedOutbox(outboxDir);
 
-        const listed   = listOutboxEntries({outboxDir});
-        const complete = ({file}) => completeOutboxEntry({file});
+        const listed = listOutboxEntries({outboxDir});
 
         expect(listed.map(item => item.entry.eventId)).toEqual(['evt-a', 'evt-b']);
 
-        complete(listed[0]);
+        completeOutboxEntry({file: listed[0].file});
 
         expect(listOutboxEntries({outboxDir}).map(item => item.entry.eventId)).toEqual(['evt-b']);
-        // A dead courier re-drains survivors: nothing was claimed away by listing.
-        expect(listOutboxEntries({outboxDir})[0].entry.eventId).toBe('evt-b');
 
         fs.rmSync(outboxDir, {recursive: true, force: true})
     });
@@ -300,21 +320,41 @@ test.describe('claude courier transport — courier-side protocol', () => {
         fs.rmSync(outboxDir, {recursive: true, force: true})
     });
 
-    test('receipts are one-file-per-event and carry the verbatim detail', () => {
+    test('receipts are replaceable latest-outcome records whose schema travels inside', () => {
         const receiptsDir = fs.mkdtempSync(path.join(os.tmpdir(), 'courier-receipts-'));
 
-        writeCourierReceipt({
-            receiptsDir,
-            eventId: 'evt-a',
-            outcome: 'expired',
-            detail : 'held 5m then expired at the target'
-        });
+        writeCourierReceipt({receiptsDir, eventId: 'evt-a', outcome: 'held'});
         writeCourierReceipt({receiptsDir, eventId: 'evt-a', outcome: 'delivered'});
 
         const written = JSON.parse(fs.readFileSync(path.join(receiptsDir, 'evt-a.json'), 'utf8'));
 
+        expect(written.schemaVersion).toBe('1.0');
         expect(written.outcome).toBe('delivered');
         expect(written.at).toBeTruthy();
+
+        fs.rmSync(receiptsDir, {recursive: true, force: true})
+    });
+
+    test('an unknown outcome is a call-site error, never persisted as data', () => {
+        const receiptsDir = fs.mkdtempSync(path.join(os.tmpdir(), 'courier-receipts-'));
+
+        expect(() => writeCourierReceipt({receiptsDir, eventId: 'evt-x', outcome: 'probably-fine'}))
+            .toThrow(/must be one of/);
+
+        fs.rmSync(receiptsDir, {recursive: true, force: true})
+    });
+
+    test('the receipt path cannot escape its directory via the event id', () => {
+        const receiptsDir = fs.mkdtempSync(path.join(os.tmpdir(), 'courier-receipts-'));
+
+        // A traversal-shaped id is rejected outright rather than rewritten into a neighbor file.
+        expect(() => writeCourierReceipt({receiptsDir, eventId: '../escaped', outcome: 'delivered'}))
+            .toThrow(/path-safe segment/);
+        expect(fs.existsSync(path.join(path.dirname(receiptsDir), 'escaped.json'))).toBe(false);
+
+        // A legitimate id containing dots still resolves inside receiptsDir.
+        writeCourierReceipt({receiptsDir, eventId: 'evt.a-1', outcome: 'delivered'});
+        expect(fs.existsSync(path.join(receiptsDir, 'evt.a-1.json'))).toBe(true);
 
         fs.rmSync(receiptsDir, {recursive: true, force: true})
     })

--- a/test/playwright/unit/ai/mcp/server/memory-core/McpServerToolLimits.spec.mjs
+++ b/test/playwright/unit/ai/mcp/server/memory-core/McpServerToolLimits.spec.mjs
@@ -118,7 +118,7 @@ test.describe('Neo.ai.mcp.server.memory-core Tool limits', () => {
             'tokenPath',
             'url'
         ]));
-        expect(metadata.properties.adapter.enum).toEqual(['osascript', 'tmux', 'codex-app-server', 'opencode-server', 'kimi-server', 'kimi-pull-bridge']);
+        expect(metadata.properties.adapter.enum).toEqual(['osascript', 'tmux', 'claude-courier', 'codex-app-server', 'opencode-server', 'kimi-server', 'kimi-pull-bridge']);
         expect(metadata.properties.envelopePath.type).toBe('string');
         expect(metadata.properties.addressType.enum).toEqual(['userDataDir', 'pid', 'tmuxSession', 'webhookUrl']);
 

--- a/test/playwright/unit/ai/mcp/validation/OpenApiValidatorCompliance.spec.mjs
+++ b/test/playwright/unit/ai/mcp/validation/OpenApiValidatorCompliance.spec.mjs
@@ -525,7 +525,7 @@ test.describe('OpenApiValidator: strict-client JSON-Schema compliance', () => {
         expect(listMessagesSchema.properties.limit.default).toBe(50);
         expect(listMessagesSchema.properties.offset.default).toBe(0);
 
-        expect(adapter.enum).toEqual(['osascript', 'tmux', 'codex-app-server', 'opencode-server', 'kimi-server', 'kimi-pull-bridge']);
+        expect(adapter.enum).toEqual(['osascript', 'tmux', 'claude-courier', 'codex-app-server', 'opencode-server', 'kimi-server', 'kimi-pull-bridge']);
 
         expect(coalesceWindow.type).toBe('integer');
         expect(coalesceWindow.minimum).toBe(0);

--- a/test/playwright/unit/ai/services/memory-core/WakeSubscriptionService.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/WakeSubscriptionService.spec.mjs
@@ -1021,7 +1021,7 @@ test.describe('Neo.ai.services.memory-core.WakeSubscriptionService', () => {
                 trigger              : 'SENT_TO_ME',
                 harnessTarget        : 'bridge-daemon',
                 harnessTargetMetadata: {adapter: 'opencode-serve'}
-            })).rejects.toThrow("Invalid adapter 'opencode-serve'. Must be one of: osascript, tmux, codex-app-server, opencode-server");
+            })).rejects.toThrow("Invalid adapter 'opencode-serve'. Must be one of: osascript, tmux, claude-courier, codex-app-server, opencode-server");
         });
     });
 


### PR DESCRIPTION
Resolves neomjs/neo#17723

Related: neomjs/neo-agent-brain#30 — parent defect; this leaf delivers its receiver-side transport slice. The live courier fire, route migration, log-sampling, and disposition legs stay owned by the parent and tracked in its lane.

Head tracks this branch's tip; the RA-repair commit restores enum-compliance specs alongside the courier admission. Opening for review now because the transport's outcome vocabulary and routing model are exactly what cross-family review should pressure before more builds on top.

## What shipped

- **New adapter `claude-courier`** wired into dispatch: instead of activate → focus → keystroke, it resolves the addressee through an explicit table and atomically spools the verbatim digest to a courier outbox. No window, no focus, no clipboard — the entire `-2700` race class is structurally absent.
- **Route-owned routing table**: the map lives in `adapterConfig.courierIdentityCwdMap` and reaches `parseIdentityCwdMap` exactly as an operator authored it — convention-parser shortcuts refused by construction; duplicate ids AND clone-bound-twice rejected; relative cwds rejected. A production-composition arm drives a real route record through the registry reader alone — no test-only effect stands in for configuration.
- **Fail-closed session matching** against Claude Code's live registry: worktree cwds resolve by prefix; a tie at maximum depth returns a typed ambiguity listing the tied pids even when shallower matches exist; registry rows without a usable pid/cwd/socket are filtered before candidacy; socket-less sessions are invisible rather than falsely deliverable.
- **Honest outcomes per AC-3**: unmapped / no-live-session / ambiguous fail loudly with typed reasons; channel acceptance marks `delivered` with reason `courier-spool-accepted`, explicitly NOT claiming rendered-in-session confirmation yet.
- **Courier-side protocol** (`listOutboxEntries` / `completeOutboxEntry` / `writeCourierReceipt`): crash-safe drain (listing claims nothing; completion removes), corrupt entries skip without blocking the queue, one replaceable latest-outcome receipt file per event id (schemaVersion inside, outcome enum validated at write) carrying delivered/held/expired/refused with verbatim detail.

Evidence: L2 (15 hermetic arms over real fs layouts, exact-head CI) → L2 required (this leaf's ACs govern the transport code and its failure semantics; the parent's live-session ACs stay on neomjs/neo-agent-brain#30). Residual: none for this close target.

## AC Evidence

| AC-1 | Spool delivery without osascript: `claude-courier` branch calls `deliverClaudeCourier` only; adapter-semantics arms assert outcomes with zero spawn side-effects — `claudeCourierTransport.spec.mjs` |
| AC-2 | Typed loud failures: `courier-unmapped-identity:<id>`, `courier-no-live-session:<id>`, `courier-map-missing` each asserted verbatim in the failure-mode arm; none degrade to a quiet send |
| AC-3 | Worktree prefix arm resolves a cwd under `.claude/worktrees/` to the seat; equal-depth candidates produce `courier-ambiguous-session:` listing both pids |
| AC-4 | Table-parse arms reject relative cwd, non-@ identity, and duplicate bindings at parse time |
| AC-5 | Spool-write arm: filename carries event id; content carries target pid, socket, subject, byte-equal digest; write goes through owned `writeFileAtomicSync` |
| AC-6 | Receipts one-file-per-event with outcome + verbatim detail; drain lists without claiming, completion removes exactly one, corrupt entries skip the pass |
| AC-7 | 15 hermetic arms in `test/playwright/unit/ai/daemons/wake/claudeCourierTransport.spec.mjs`, canonical Brain-side placement beside the wake specs |

## Deltas from ticket

- OpenCode needs no second courier: `opencode-server` already delivers focus-free (zero appearances in the failure log); "the same" reduces to config migration of lingering routes. Antigravity is the true residual harness — recorded, not solved here.
- The socket message frame remains deliberately un-reverse-engineered, per the ticket's own recommendation; SendMessage inside a courier session is the contracted path.

## Test Evidence

All coverage runs in CI — 15 transport arms in the owning spec (the 17-test runner report includes lifecycle hooks) plus the adapter-enum compliance specs updated for the new admission. Live-host corroboration gathered while authoring (not a merge gate): registry rows read from `~/.claude/sessions/` showed two interactive v2.1.237 sessions with bound sockets, including a seat at its table cwd and a worktree session demonstrating why exact-match routing strands deliveries.

## Post-Merge Validation

Observations on neomjs/neo-agent-brain#30's remaining lane (owned by the parent, not owed by this leaf):

1. Live courier fire: a disposable claude session drains a seeded outbox and reports held / expired / delivered receipts.
2. Receiver-state reconciliation consuming those receipts (upgrades `courier-spool-accepted`).
3. Route migration: the three Opus Claude seats move to `claude-courier`; the two odd route-table rows are dispositioned.

Authored by Eos (ox-alpha, OpenCode). Session 65095daf-eaf1-46e9-a02e-cc43fde4ec2d.
