### PR TITLE
fix(fleet): separate AgentOS runtime and target roots (#17718)

### DIFF
--- a/ai/services/fleet/generateKimiSeatConfig.mjs
+++ b/ai/services/fleet/generateKimiSeatConfig.mjs
@@ -24,10 +24,10 @@ export const KIMI_SEAT_SERVERS = Object.freeze([
  * this module only decides their content. Sibling of `generateOpenCodeSeatConfig.mjs` — same
  * three load-bearing constraints, with the harness-specific surfaces mapped:
  *
- * 1. **Organs canonical.** MCP server CODE runs from the canonical checkout (the Memory Core
+ * 1. **AgentOS runtime authority.** MCP server CODE runs from the AgentOS runtime root (the Memory Core
  *    resolves its data root from the server code's own file location — a per-seat copy forks an
  *    empty graph island). The island guard REJECTS any server script resolving outside
- *    `canonicalRoot`, sibling parity.
+ *    `agentosRuntimeRoot`, sibling parity.
  * 2. **Seat personal.** Identity + credentials load via `--env-file` from the seat's OWN `.env`
  *    (`NEO_AGENT_IDENTITY`, `GH_TOKEN`, provider keys), wired per-server in `mcp.json`.
  * 3. **The memory layer loads via the identity-anchor hook.** Kimi Code auto-loads the PROJECT
@@ -45,10 +45,11 @@ export const KIMI_SEAT_SERVERS = Object.freeze([
  * envelope beside its own `server/instances/{server_id}.json` coordinates — exactly what the
  * wake daemon's kimi-server route discovers. No seat-side writers beyond the tracked hook.
  *
- * **Two roots, by harness design:** `config.toml` lives in the harness home (`kimiHome` —
- * `$KIMI_CODE_HOME`), while the MCP wiring lives in the seat checkout (`.kimi-code/mcp.json` is
- * a project-level file, untracked per seat). The generator takes both roots explicitly; the
- * coupling is loud, not latent.
+ * **Two roots, by harness design:** AgentOS executables and Neural Link's package/Bridge cwd derive
+ * from `agentosRuntimeRoot`; the project-level `.kimi-code/mcp.json` and seat `.env` live under
+ * `targetRepoRoot`. `config.toml` remains in the harness home (`kimiHome` — `$KIMI_CODE_HOME`).
+ * The generator takes every root explicitly; executable and target authority cannot be inferred
+ * from each other after the repository split.
  *
  * **Emission shape:** `mcp.json` is strict JSON (comment-stripped `JSON.parse` must succeed —
  * the unit spec enforces it). `config.toml` carries only what the harness needs beyond its
@@ -57,10 +58,11 @@ export const KIMI_SEAT_SERVERS = Object.freeze([
  * env per the launch contract's `env-key` mode).
  *
  * @param {Object} options
- * @param {String} options.canonicalRoot  Absolute path of the CANONICAL neo checkout (organs).
- * @param {String} options.seatEnvFile    Absolute path of the seat's own `.env` (identity + keys).
- * @param {String} options.workspaceRoot  Absolute path of the seat's working checkout — the
- *                                        `.kimi-code/mcp.json` target and the Neural Link `--cwd`.
+ * @param {String} options.agentosRuntimeRoot Absolute AgentOS runtime root — every local MCP
+ *                                            entrypoint and Neural Link `--cwd` resolve here.
+ * @param {String} options.targetRepoRoot     Absolute target checkout — the `.kimi-code/mcp.json`
+ *                                            destination and project authority.
+ * @param {String} options.seatEnvFile        Absolute path of the seat's own `.env` (identity + keys).
  * @param {String} options.kimiHome       Absolute path of the seat's harness home
  *                                        (`$KIMI_CODE_HOME`) — the `config.toml` target.
  * @param {String} options.memoryDir      Absolute path of the seat's persistent memory dir —
@@ -80,15 +82,15 @@ export const KIMI_SEAT_SERVERS = Object.freeze([
  * @returns {{files: Array<{path: String, content: String}>}} the emission list — callers own
  * writing (mode, atomicity, divergence policy).
  * @throws {Error} naming the offending argument on missing/invalid input, and
- * `generateKimiSeatConfig: island guard` when a server script resolves outside `canonicalRoot`.
+ * `generateKimiSeatConfig: island guard` when a server script resolves outside `agentosRuntimeRoot`.
  */
-export function generateKimiSeatConfig({canonicalRoot, seatEnvFile, workspaceRoot, kimiHome, memoryDir, nodeBinary, environment = {}, defaultModel = 'kimi-code/k3', servers = KIMI_SEAT_SERVERS, remoteServers = {}} = {}) {
-    assertNonEmptyString(canonicalRoot, 'canonicalRoot');
-    assertNonEmptyString(seatEnvFile,   'seatEnvFile');
-    assertNonEmptyString(workspaceRoot, 'workspaceRoot');
-    assertNonEmptyString(kimiHome,      'kimiHome');
-    assertNonEmptyString(memoryDir,     'memoryDir');
-    assertNonEmptyString(nodeBinary,    'nodeBinary');
+export function generateKimiSeatConfig({agentosRuntimeRoot, targetRepoRoot, seatEnvFile, kimiHome, memoryDir, nodeBinary, environment = {}, defaultModel = 'kimi-code/k3', servers = KIMI_SEAT_SERVERS, remoteServers = {}} = {}) {
+    assertNonEmptyString(agentosRuntimeRoot, 'agentosRuntimeRoot');
+    assertNonEmptyString(targetRepoRoot,     'targetRepoRoot');
+    assertNonEmptyString(seatEnvFile,        'seatEnvFile');
+    assertNonEmptyString(kimiHome,           'kimiHome');
+    assertNonEmptyString(memoryDir,          'memoryDir');
+    assertNonEmptyString(nodeBinary,         'nodeBinary');
 
     if (!Array.isArray(servers) || servers.length === 0) {
         throw new Error("generateKimiSeatConfig: 'servers' must be a non-empty array.");
@@ -96,22 +98,22 @@ export function generateKimiSeatConfig({canonicalRoot, seatEnvFile, workspaceRoo
 
     // Trailing slashes are legal input: `normalize` keeps them, and `root + '/'` would become a
     // double-slash that every valid script then fails (the guard mis-rejecting valid input).
-    const root = path.posix.normalize(canonicalRoot).replace(/(.)\/+$/, '$1');
+    const runtimeRoot = path.posix.normalize(agentosRuntimeRoot).replace(/(.)\/+$/, '$1');
 
-    // Island guard: every server script MUST resolve inside the canonical checkout — a script
+    // Island guard: every server script MUST resolve inside the AgentOS runtime root — a script
     // outside it forks the shared graph's data root into an empty island (see the module JSDoc).
     servers.forEach(server => {
-        const resolved = path.posix.normalize(path.posix.join(root, server.script));
+        const resolved = path.posix.normalize(path.posix.join(runtimeRoot, server.script));
 
-        if (!resolved.startsWith(root + '/') || !server.name || typeof server.needsCwd !== 'boolean') {
-            throw new Error(`generateKimiSeatConfig: island guard — server script '${server.script}' escapes canonicalRoot '${root}' or the entry is malformed.`);
+        if (!resolved.startsWith(runtimeRoot + '/') || !server.name || typeof server.needsCwd !== 'boolean') {
+            throw new Error(`generateKimiSeatConfig: island guard — server script '${server.script}' escapes agentosRuntimeRoot '${runtimeRoot}' or the entry is malformed.`);
         }
     });
     assertRemoteServerMap(remoteServers, servers);
 
     return {files: [
         {path: path.posix.join(kimiHome, 'config.toml'),                 content: renderConfigToml({defaultModel, nodeBinary, seatEnvFile, kimiHome, servers})},
-        {path: path.posix.join(workspaceRoot, '.kimi-code', 'mcp.json'), content: renderMcpJson({root, seatEnvFile, workspaceRoot, nodeBinary, environment, servers, remoteServers})},
+        {path: path.posix.join(targetRepoRoot, '.kimi-code', 'mcp.json'), content: renderMcpJson({runtimeRoot, seatEnvFile, nodeBinary, environment, servers, remoteServers})},
         {path: path.posix.join(memoryDir, 'MEMORY.md'),                  content: renderMemoryIndexMd({harness: 'kimi-code'})},
         {path: path.posix.join(memoryDir, 'seat-pointers.md'),           content: renderSeatPointersMd()},
         {path: path.posix.join(memoryDir, 'identity.md'),                content: renderIdentityMd()},
@@ -155,9 +157,9 @@ function renderConfigToml({defaultModel, nodeBinary, seatEnvFile, kimiHome, serv
     return [
         '# GENERATED by ai/services/fleet/generateKimiSeatConfig.mjs — regenerate, do not hand-edit.',
         '#',
-        '# 1. ORGANS CANONICAL: MCP server code runs from the canonical checkout (.kimi-code/mcp.json);',
-        '#    the Memory Core resolves its data root from the server code location, so per-seat server',
-        '#    copies fork an empty graph island.',
+        '# 1. AGENTOS RUNTIME: MCP server code and Neural Link package cwd resolve from the AgentOS',
+        '#    runtime root recorded in .kimi-code/mcp.json; the Memory Core resolves its data root',
+        '#    from server-code location, so target-repo server copies fork an empty graph island.',
         '# 2. SEAT PERSONAL: identity + credentials load via --env-file from the seat\'s own .env.',
         '# 3. PERMISSION: wake-fired turns must not freeze on approval dialogs for the seat\'s own MCP',
         '#    calls (2026-07-18 incident, opencode-seat parity); default mode is auto.',
@@ -250,7 +252,7 @@ function renderTurnPresenceHooks({nodeBinary, seatEnvFile}) {
  * @returns {String}
  * @private
  */
-function renderMcpJson({root, seatEnvFile, workspaceRoot, nodeBinary, environment, servers, remoteServers}) {
+function renderMcpJson({runtimeRoot, seatEnvFile, nodeBinary, environment, servers, remoteServers}) {
     const mcpServers = {};
 
     servers.forEach(server => {
@@ -265,10 +267,10 @@ function renderMcpJson({root, seatEnvFile, workspaceRoot, nodeBinary, environmen
             return
         }
 
-        const args = ['--env-file=' + seatEnvFile, path.posix.join(root, server.script)];
+        const args = ['--env-file=' + seatEnvFile, path.posix.join(runtimeRoot, server.script)];
 
         if (server.needsCwd) {
-            args.push('--cwd', workspaceRoot);
+            args.push('--cwd', runtimeRoot);
         }
 
         mcpServers[server.name] = {

--- a/ai/services/fleet/generateOpenCodeSeatConfig.mjs
+++ b/ai/services/fleet/generateOpenCodeSeatConfig.mjs
@@ -4,8 +4,8 @@ import {MEMORY_LAYER_BOOT_FILES, renderAboutThisLayerMd, renderIdentityMd, rende
 
 /**
  * The canonical MCP server set every OpenCode seat wires, keyed by the seat-config server name.
- * `script` is the POSIX path relative to the canonical (organs) checkout. `needsCwd: true` marks
- * the Neural Link: its `--cwd` binds the possession target to the seat's OWN working tree.
+ * `script` is the POSIX path relative to the AgentOS runtime root. `needsCwd: true` marks
+ * Neural Link: its `--cwd` starts the AgentOS package/Bridge from that same runtime authority.
  * Fixed module data, not a configurable default — an unlisted server is a deliberate caller
  * override via `options.servers`, never an accident of omission.
  * @type {ReadonlyArray<{name: String, script: String, needsCwd: Boolean}>}
@@ -26,12 +26,12 @@ export const OPENCODE_SEAT_SERVERS = Object.freeze([
  * The three load-bearing seat constraints this productizes (verified live on the first OpenCode
  * seat, `@neo-kimi-phoebe`, 2026-07-18):
  *
- * 1. **Organs canonical.** MCP server CODE must run from the canonical checkout: the Memory
+ * 1. **AgentOS runtime authority.** MCP server CODE must run from the AgentOS runtime root: the Memory
  *    Core resolves its DATA ROOT from the server code's own file location
  *    (`ai/mcp/server/memory-core/configBase.mjs:21-28` — `import.meta.url` → `neoRootDir` →
  *    `.neo-ai-data/*`). Server code under a per-seat checkout silently forks an empty graph
  *    island whose writes never merge back. The island guard below therefore REJECTS any server
- *    script path that resolves outside `canonicalRoot`.
+ *    script path that resolves outside `agentosRuntimeRoot`.
  * 2. **Seat personal.** Identity + credentials load via `--env-file` from the seat's OWN `.env`
  *    (`NEO_AGENT_IDENTITY`, `GH_TOKEN`, provider keys). Node's `--env-file` never overwrites
  *    already-set vars, so explicit `environment` entries win where a caller needs them to.
@@ -57,7 +57,7 @@ export const OPENCODE_SEAT_SERVERS = Object.freeze([
  *
  * - **`permission.external_directory`** — a wake-fired turn must never freeze on an approval
  *   dialog for the seat's own files (2026-07-18 incident). The allow-list covers the seat home
- *   (workspace + memory), the canonical checkout (read access to server code), and any
+ *   (target checkout + memory), the AgentOS runtime root (read access to server code), and any
  *   caller-supplied `extraAllowedPaths`; the catch-all stays `"ask"` (insertion order matters:
  *   the LAST matching rule wins).
  * - **The wake-envelope boot hook** (emitted only when `wakeHookPath` is given) — binding the
@@ -75,10 +75,11 @@ export const OPENCODE_SEAT_SERVERS = Object.freeze([
  * unit spec enforces it).
  *
  * @param {Object} options
- * @param {String} options.canonicalRoot  Absolute path of the CANONICAL neo checkout (organs).
- * @param {String} options.seatEnvFile    Absolute path of the seat's own `.env` (identity + keys).
- * @param {String} options.workspaceRoot  Absolute path of the seat's working checkout — the
- *                                        `opencode.jsonc` target and the Neural Link `--cwd`.
+ * @param {String} options.agentosRuntimeRoot Absolute AgentOS runtime root — every local MCP
+ *                                            entrypoint and Neural Link `--cwd` resolve here.
+ * @param {String} options.targetRepoRoot     Absolute target checkout — the `opencode.jsonc`
+ *                                            destination and project authority.
+ * @param {String} options.seatEnvFile        Absolute path of the seat's own `.env` (identity + keys).
  * @param {String} options.memoryDir      Absolute path of the seat's always-loaded memory dir —
  *                                        the `MEMORY.md` / `seat-pointers.md` / `identity.md` /
  *                                        `about-this-layer.md` scaffold target and the
@@ -104,14 +105,14 @@ export const OPENCODE_SEAT_SERVERS = Object.freeze([
  * writing (mode, atomicity, divergence policy).
  * @throws {Error} naming the offending argument on missing/invalid input, and
  * `generateOpenCodeSeatConfig: island guard` when a server script resolves outside
- * `canonicalRoot`.
+ * `agentosRuntimeRoot`.
  */
-export function generateOpenCodeSeatConfig({canonicalRoot, seatEnvFile, workspaceRoot, memoryDir, nodeBinary, environment = {}, extraAllowedPaths = [], wakeHookPath, servers = OPENCODE_SEAT_SERVERS, seatHome, remoteServers = {}} = {}) {
-    assertNonEmptyString(canonicalRoot, 'canonicalRoot');
-    assertNonEmptyString(seatEnvFile,   'seatEnvFile');
-    assertNonEmptyString(workspaceRoot, 'workspaceRoot');
-    assertNonEmptyString(memoryDir,     'memoryDir');
-    assertNonEmptyString(nodeBinary,    'nodeBinary');
+export function generateOpenCodeSeatConfig({agentosRuntimeRoot, targetRepoRoot, seatEnvFile, memoryDir, nodeBinary, environment = {}, extraAllowedPaths = [], wakeHookPath, servers = OPENCODE_SEAT_SERVERS, seatHome, remoteServers = {}} = {}) {
+    assertNonEmptyString(agentosRuntimeRoot, 'agentosRuntimeRoot');
+    assertNonEmptyString(targetRepoRoot,     'targetRepoRoot');
+    assertNonEmptyString(seatEnvFile,        'seatEnvFile');
+    assertNonEmptyString(memoryDir,          'memoryDir');
+    assertNonEmptyString(nodeBinary,         'nodeBinary');
 
     if (!Array.isArray(servers) || servers.length === 0) {
         throw new Error("generateOpenCodeSeatConfig: 'servers' must be a non-empty array.");
@@ -119,21 +120,21 @@ export function generateOpenCodeSeatConfig({canonicalRoot, seatEnvFile, workspac
 
     // Trailing slashes are legal input: `normalize` keeps them, and `root + '/'` would become
     // a double-slash that every valid script then fails (the guard mis-rejecting valid input).
-    const root = path.posix.normalize(canonicalRoot).replace(/(.)\/+$/, '$1');
+    const runtimeRoot = path.posix.normalize(agentosRuntimeRoot).replace(/(.)\/+$/, '$1');
 
-    // Island guard: every server script MUST resolve inside the canonical checkout — a script
+    // Island guard: every server script MUST resolve inside the AgentOS runtime root — a script
     // outside it forks the shared graph's data root into an empty island (see the module JSDoc).
     servers.forEach(server => {
-        const resolved = path.posix.normalize(path.posix.join(root, server.script));
+        const resolved = path.posix.normalize(path.posix.join(runtimeRoot, server.script));
 
-        if (!resolved.startsWith(root + '/') || !server.name || typeof server.needsCwd !== 'boolean') {
-            throw new Error(`generateOpenCodeSeatConfig: island guard — server script '${server.script}' escapes canonicalRoot '${root}' or the entry is malformed.`);
+        if (!resolved.startsWith(runtimeRoot + '/') || !server.name || typeof server.needsCwd !== 'boolean') {
+            throw new Error(`generateOpenCodeSeatConfig: island guard — server script '${server.script}' escapes agentosRuntimeRoot '${runtimeRoot}' or the entry is malformed.`);
         }
     });
     assertRemoteServerMap(remoteServers, servers);
 
     const files = [
-        {path: path.posix.join(workspaceRoot, 'opencode.jsonc'),    content: renderOpencodeJsonc({root, seatEnvFile, workspaceRoot, memoryDir, nodeBinary, environment, extraAllowedPaths, servers, seatHome, remoteServers})},
+        {path: path.posix.join(targetRepoRoot, 'opencode.jsonc'), content: renderOpencodeJsonc({runtimeRoot, targetRepoRoot, seatEnvFile, memoryDir, nodeBinary, environment, extraAllowedPaths, servers, seatHome, remoteServers})},
         {path: path.posix.join(memoryDir, 'MEMORY.md'),             content: renderMemoryIndexMd({harness: 'opencode'})},
         {path: path.posix.join(memoryDir, 'seat-pointers.md'),      content: renderSeatPointersMd()},
         {path: path.posix.join(memoryDir, 'identity.md'),           content: renderIdentityMd()},
@@ -155,13 +156,13 @@ export function generateOpenCodeSeatConfig({canonicalRoot, seatEnvFile, workspac
  * @returns {String}
  * @private
  */
-function renderOpencodeJsonc({root, seatEnvFile, workspaceRoot, memoryDir, nodeBinary, environment, extraAllowedPaths, servers, seatHome, remoteServers}) {
+function renderOpencodeJsonc({runtimeRoot, targetRepoRoot, seatEnvFile, memoryDir, nodeBinary, environment, extraAllowedPaths, servers, seatHome, remoteServers}) {
     const
         header = [
             '  // GENERATED by ai/services/fleet/generateOpenCodeSeatConfig.mjs — regenerate, do not hand-edit.',
             '  //',
-            '  // 1. ORGANS CANONICAL: server code runs from the canonical checkout; the Memory Core resolves',
-            '  //    its data root from the server code location, so per-seat server copies fork an empty island.',
+            '  // 1. AGENTOS RUNTIME: server code and Neural Link package cwd resolve from the AgentOS',
+            '  //    runtime root; target-repo server copies would fork Memory Core into an empty island.',
             '  // 2. SEAT PERSONAL: identity + credentials load via --env-file from the seat\'s own .env.',
             '  // 3. MEMORY: the instructions files are the always-loaded identity layer; the Memory Core is',
             '  //    the on-demand deep archive. add_memory at end of every turn feeds it.',
@@ -187,10 +188,10 @@ function renderOpencodeJsonc({root, seatEnvFile, workspaceRoot, memoryDir, nodeB
         }
 
         const
-            command = [nodeBinary, '--env-file=' + seatEnvFile, path.posix.join(root, server.script)],
+            command = [nodeBinary, '--env-file=' + seatEnvFile, path.posix.join(runtimeRoot, server.script)],
             entry   = {
                 type       : 'local',
-                command    : server.needsCwd ? [...command, '--cwd', workspaceRoot] : command,
+                command    : server.needsCwd ? [...command, '--cwd', runtimeRoot] : command,
                 enabled    : true,
                 environment: {...environment}
             };
@@ -202,7 +203,7 @@ function renderOpencodeJsonc({root, seatEnvFile, workspaceRoot, memoryDir, nodeB
         // The seat home: explicit `seatHome` when given, else `memoryDir`'s parent — the
         // documented default derivation (the coupling is loud here, not latent).
         seatHomePath = seatHome ?? path.posix.dirname(path.posix.normalize(memoryDir)),
-        allowedPaths = [seatHomePath + '/**', workspaceRoot + '/**', root + '/**', ...extraAllowedPaths],
+        allowedPaths = [seatHomePath + '/**', targetRepoRoot + '/**', runtimeRoot + '/**', ...extraAllowedPaths],
         externalDirectory = {'*': 'ask'};
 
     allowedPaths.forEach(allowedPath => {

--- a/ai/services/fleet/managedAgentWorkspacePlan.mjs
+++ b/ai/services/fleet/managedAgentWorkspacePlan.mjs
@@ -138,12 +138,14 @@ const
         'cwd',
         'grant',
         'grants',
+        'agentosRuntimeRoot',
         'instanceRoot',
         'mainCheckout',
         'nodePath',
         'owner',
         'ownerPrincipal',
         'repoPath',
+        'targetRepoRoot',
         'secret',
         'token'
     ].map(key => key.toLowerCase()));

--- a/ai/services/fleet/prepareManagedAgentWorkspace.mjs
+++ b/ai/services/fleet/prepareManagedAgentWorkspace.mjs
@@ -3,7 +3,6 @@ import fs                                          from 'node:fs/promises';
 import {writeFileAtomic}                           from '../shared/atomicFileWrite.mjs';
 import path                                        from 'node:path';
 import crypto                                      from 'node:crypto';
-import {fileURLToPath}                             from 'node:url';
 import {isDeepStrictEqual}                         from 'node:util';
 import {hydrateCurrentWorktree}                    from '../../scripts/migrations/bootstrapWorktree.mjs';
 import {MCP_SERVERS, resolveMcpMatrix}             from './mcpServers.mjs';
@@ -18,9 +17,6 @@ import {OPENCODE_SEAT_SERVERS, generateOpenCodeSeatConfig} from './generateOpenC
 export {createManagedAgentWorkspacePlan} from './managedAgentWorkspacePlan.mjs';
 
 const
-    __filename               = fileURLToPath(import.meta.url),
-    __dirname                = path.dirname(__filename),
-    DEFAULT_MAIN_CHECKOUT    = path.resolve(__dirname, '../../..'),
     NEO_MCP_NAME_PREFIX      = 'neo-mjs-',
     CODEX_REMOTE_TRUST_BEGIN = '# Fleet-managed remote MCP project trust begin',
     CODEX_REMOTE_TRUST_END   = '# Fleet-managed remote MCP project trust end';
@@ -106,12 +102,14 @@ const
         'cwd',
         'grant',
         'grants',
+        'agentosRuntimeRoot',
         'instanceRoot',
         'mainCheckout',
         'nodePath',
         'owner',
         'ownerPrincipal',
         'repoPath',
+        'targetRepoRoot',
         'secret',
         'token'
     ].map(key => key.toLowerCase()));
@@ -194,15 +192,25 @@ function validateManagedAgentWorkspacePlan(plan) {
     return expected
 }
 
-/** @private */
-function bindManagedAgentWorkspacePlan({logicalPlan, repoPath, mainCheckout, nodePath}) {
+/**
+ * @summary Binds a logical seat plan to the two explicit host roots. Local server entrypoints and
+ * Neural Link's package/Bridge cwd are AgentOS-owned; target-repository ownership starts at generated
+ * artifacts and harness execution, never at the MCP executable edge.
+ * @param {Object} options
+ * @param {ManagedAgentWorkspacePlan} options.logicalPlan
+ * @param {String} options.agentosRuntimeRoot
+ * @param {String} options.nodePath
+ * @returns {Object[]}
+ * @private
+ */
+function bindManagedAgentWorkspacePlan({logicalPlan, agentosRuntimeRoot, nodePath}) {
     return logicalPlan.mcpServers.map(server => ({
         ...server,
         command   : nodePath,
-        sourceRoot: mainCheckout,
+        sourceRoot: agentosRuntimeRoot,
         args      : [
-            path.join(mainCheckout, server.entrypoint),
-            ...(server.key === 'neural-link' ? ['--cwd', repoPath] : [])
+            path.join(agentosRuntimeRoot, server.entrypoint),
+            ...(server.key === 'neural-link' ? ['--cwd', agentosRuntimeRoot] : [])
         ],
         runtimeEnv        : [...server.runtimeEnv],
         requiredRuntimeEnv: [...server.requiredRuntimeEnv],
@@ -213,13 +221,13 @@ function bindManagedAgentWorkspacePlan({logicalPlan, repoPath, mainCheckout, nod
 
 /**
  * @summary Bind and apply one validated logical workspace plan at the host-only effect edge. This
- * function alone introduces absolute repo/home/main-checkout/Node paths, then preserves the existing
- * bounded effect census: `stat`/`lstat`/`access`, checkout hydration, bounded reads, `mkdir`,
+ * function alone introduces absolute target-repo/home/AgentOS-runtime/Node paths, then preserves
+ * the existing bounded effect census: `stat`/`lstat`/`access`, checkout hydration, bounded reads, `mkdir`,
  * create-only and temporary writes, atomic `rename`, `chmod(0600)`, and receipt `unlink`. It never
  * spawns a process. Completed hydration or atomic/create-only artifacts may remain after a later
  * failure; retry converges that honest partial state without exposing partial file bytes.
  *
- * The sole production caller remains `startAgentProvisioned()` through the compatibility composer
+ * The sole production caller remains `startAgentProvisioned()` through the plan/apply composer
  * below. Renderers and convergence helpers consume the same host-bound plan shape as before.
  * Canonical re-derivation proves internal coherence with the plan's own logical inputs; it does not
  * prove registry authorization or cross-process provenance. That belongs to the later authenticated
@@ -227,16 +235,16 @@ function bindManagedAgentWorkspacePlan({logicalPlan, repoPath, mainCheckout, nod
  * @param {Object} options
  * @param {ManagedAgentWorkspacePlan} options.plan Closed logical plan; structural clones accepted
  *     after schema and canonical-projection coherence validation.
- * @param {String} options.repoPath Absolute provisioned checkout path.
+ * @param {String} options.targetRepoRoot Absolute provisioned target checkout path.
  * @param {String} options.instanceRoot Absolute Fleet harness-home root.
- * @param {String} [options.mainCheckout] Installed canonical checkout.
+ * @param {String} options.agentosRuntimeRoot Installed AgentOS runtime root.
  * @param {String} [options.nodePath] Node executable used for installed MCP entrypoints.
  * @param {Object} [options.remoteMcpCapability] Existing non-secret installed-adapter proof.
  * @param {Function} [options.hydrateWorkspace] Import-safe checkout hydration seam.
  * @param {Function} [options.deriveInstanceHome] Per-agent home derivation seam.
  * @param {Object} [options.fileSystem] Promise filesystem seam.
  * @param {Function} [options.log] Hydration logger.
- * @returns {Promise<{repoPath: String, instanceHome: String, mcpMatrix: Object, mcpPlan: Object[], hydration: Object, artifacts: Object[]}>}
+ * @returns {Promise<{agentosRuntimeRoot: String, targetRepoRoot: String, instanceHome: String, mcpMatrix: Object, mcpPlan: Object[], hydration: Object, artifacts: Object[]}>}
  * @throws {ManagedWorkspacePreparationError} For invalid plans/bindings, unsafe paths, unsupported
  *     capabilities, divergent content, or effect failures.
  */
@@ -261,9 +269,9 @@ export async function applyManagedAgentWorkspacePlan(options={}) {
 /** @private */
 async function applyManagedAgentWorkspacePlanUnchecked({
     plan: inputPlan,
-    repoPath,
+    targetRepoRoot,
     instanceRoot,
-    mainCheckout = DEFAULT_MAIN_CHECKOUT,
+    agentosRuntimeRoot,
     nodePath = process.execPath,
     remoteMcpCapability = null,
     hydrateWorkspace = hydrateCurrentWorktree,
@@ -273,25 +281,24 @@ async function applyManagedAgentWorkspacePlanUnchecked({
 } = {}) {
     const logicalPlan = validateManagedAgentWorkspacePlan(inputPlan);
 
-    assertAbsolutePath(repoPath, 'repoPath');
+    assertAbsolutePath(targetRepoRoot, 'targetRepoRoot');
     assertAbsolutePath(instanceRoot, 'instanceRoot');
-    assertAbsolutePath(mainCheckout, 'mainCheckout');
+    assertAbsolutePath(agentosRuntimeRoot, 'agentosRuntimeRoot');
     assertAbsolutePath(nodePath, 'nodePath');
 
     const
-        canonicalRepoPath     = path.resolve(repoPath),
-        canonicalInstanceRoot = path.resolve(instanceRoot),
-        installedRoot         = path.resolve(mainCheckout),
-        agent                 = logicalPlan.agent,
-        instanceHome          = deriveInstanceHome({
+        canonicalTargetRepoRoot     = path.resolve(targetRepoRoot),
+        canonicalInstanceRoot       = path.resolve(instanceRoot),
+        canonicalAgentosRuntimeRoot = path.resolve(agentosRuntimeRoot),
+        agent                       = logicalPlan.agent,
+        instanceHome                = deriveInstanceHome({
             instanceRoot: canonicalInstanceRoot,
             agentId     : agent.id,
             harnessType : agent.harnessType
         }),
-        plan = bindManagedAgentWorkspacePlan({
+        plan                        = bindManagedAgentWorkspacePlan({
             logicalPlan,
-            repoPath    : canonicalRepoPath,
-            mainCheckout: installedRoot,
+            agentosRuntimeRoot: canonicalAgentosRuntimeRoot,
             nodePath
         });
 
@@ -299,8 +306,8 @@ async function applyManagedAgentWorkspacePlanUnchecked({
     await assertRemoteBridgeCapability({
         agent,
         plan,
-        capability  : remoteMcpCapability,
-        mainCheckout: installedRoot,
+        capability        : remoteMcpCapability,
+        agentosRuntimeRoot: canonicalAgentosRuntimeRoot,
         nodePath,
         fileSystem
     });
@@ -312,12 +319,12 @@ async function applyManagedAgentWorkspacePlanUnchecked({
     });
 
     const hydration = await hydrateWorkspace({
-        mainCheckout: installedRoot,
-        projectRoot : canonicalRepoPath,
+        mainCheckout: canonicalAgentosRuntimeRoot,
+        projectRoot : canonicalTargetRepoRoot,
         log
     });
 
-    await assertRealDirectory(canonicalRepoPath, 'repoPath', fileSystem);
+    await assertRealDirectory(canonicalTargetRepoRoot, 'targetRepoRoot', fileSystem);
     await assertExecutablePlan({plan, nodePath, fileSystem});
     await assertNoSymlinkSegments({
         rootPath  : canonicalInstanceRoot,
@@ -328,19 +335,20 @@ async function applyManagedAgentWorkspacePlanUnchecked({
 
     const artifacts = await prepareHarnessArtifacts({
         agent,
-        repoPath    : canonicalRepoPath,
+        targetRepoRoot    : canonicalTargetRepoRoot,
         instanceHome,
-        mainCheckout: installedRoot,
+        agentosRuntimeRoot: canonicalAgentosRuntimeRoot,
         plan,
         remoteMcpCapability,
         fileSystem
     });
 
     return {
-        repoPath : canonicalRepoPath,
+        agentosRuntimeRoot: canonicalAgentosRuntimeRoot,
+        targetRepoRoot    : canonicalTargetRepoRoot,
         instanceHome,
-        mcpMatrix: {...logicalPlan.mcpMatrix},
-        mcpPlan  : plan.map(server => ({
+        mcpMatrix         : {...logicalPlan.mcpMatrix},
+        mcpPlan           : plan.map(server => ({
             ...server,
             args              : [...server.args],
             runtimeEnv        : [...server.runtimeEnv],
@@ -353,17 +361,18 @@ async function applyManagedAgentWorkspacePlanUnchecked({
 }
 
 /**
- * @summary Compatibility composer for the existing Fleet workspace preparation surface: resolve
- * the sparse-at-rest MCP matrix once, project the closed logical input, plan once, then apply once.
- * It preserves the established option names, six-field return, artifact bytes, safety gates, and
- * local/remote transition behavior while exposing the plan/apply seam for later container ownership.
+ * @summary Fleet workspace preparation composer: resolve the sparse-at-rest MCP matrix once,
+ * project the closed logical input, plan once, then apply once. Runtime and target roots are required
+ * under their semantic names; the former `mainCheckout` / `repoPath` aliases are deliberately not
+ * accepted because a stale caller must fail during seat re-materialization instead of silently
+ * executing AgentOS from the target repository.
  *
- * Executable MCP entrypoints deliberately resolve from the installed `mainCheckout`: fresh managed
+ * Executable MCP entrypoints deliberately resolve from `agentosRuntimeRoot`: fresh managed
  * clones have no dependencies, dependency installation/build is outside this composer, and sharing
  * another checkout's writable `node_modules` would collapse the checkout boundary. The prepared
- * `repoPath` remains the single harness cwd/project truth (and Neural Link's explicit `--cwd`), while
- * its ignored overlays are hydrated for resident workspace tooling. No resident dependency artifact
- * is created or adopted.
+ * `targetRepoRoot` remains the single harness cwd/project truth, while Neural Link's explicit `--cwd`
+ * resolves from AgentOS because it starts the AgentOS package/Bridge. Target ignored overlays are
+ * hydrated for resident workspace tooling; no resident dependency artifact is created or adopted.
  *
  * Product adapters are evidence-gated. Codex uses project TOML plus an isolated home; Claude Code
  * uses an explicit strict MCP JSON with environment-variable references; Claude Desktop uses its
@@ -374,9 +383,9 @@ async function applyManagedAgentWorkspacePlanUnchecked({
  *
  * @param {Object}   options
  * @param {Object}   options.agent               Fleet registry agent definition.
- * @param {String}   options.repoPath            Absolute provisioned checkout path.
+ * @param {String}   options.targetRepoRoot      Absolute provisioned target checkout path.
  * @param {String}   options.instanceRoot        Absolute Fleet harness-home root.
- * @param {String}  [options.mainCheckout]       Installed canonical checkout; defaults to this module's repo root.
+ * @param {String}   options.agentosRuntimeRoot  Installed AgentOS runtime root.
  * @param {String}  [options.nodePath]           Node executable used for installed MCP entrypoints.
  * @param {Object}  [options.mcpTarget]          Resolved non-secret tenant target:
  *     `{kind:'tenant', credentialEnvVar, resources:{memory-core:{url},knowledge-base:{url}}}`.
@@ -387,16 +396,16 @@ async function applyManagedAgentWorkspacePlanUnchecked({
  * @param {Function}[options.resolveMatrix]       Sparse-at-rest MCP resolver seam.
  * @param {Object}  [options.fileSystem]          Promise filesystem seam.
  * @param {Function}[options.log]                 Hydration logger.
- * @returns {Promise<{repoPath: String, instanceHome: String, mcpMatrix: Object, mcpPlan: Object[], hydration: Object, artifacts: Object[]}>}
+ * @returns {Promise<{agentosRuntimeRoot: String, targetRepoRoot: String, instanceHome: String, mcpMatrix: Object, mcpPlan: Object[], hydration: Object, artifacts: Object[]}>}
  * @throws {ManagedWorkspacePreparationError} for unsupported adapters or divergent owned content.
  * @see createManagedAgentWorkspacePlan
  * @see applyManagedAgentWorkspacePlan
  */
 export async function prepareManagedAgentWorkspace({
     agent,
-    repoPath,
+    targetRepoRoot,
     instanceRoot,
-    mainCheckout = DEFAULT_MAIN_CHECKOUT,
+    agentosRuntimeRoot,
     nodePath = process.execPath,
     hydrateWorkspace = hydrateCurrentWorktree,
     deriveInstanceHome = deriveAgentInstanceHome,
@@ -430,9 +439,9 @@ export async function prepareManagedAgentWorkspace({
 
     return applyManagedAgentWorkspacePlan({
         plan,
-        repoPath,
+        targetRepoRoot,
         instanceRoot,
-        mainCheckout,
+        agentosRuntimeRoot,
         nodePath,
         remoteMcpCapability,
         hydrateWorkspace,
@@ -531,13 +540,13 @@ function isPortableAbsolutePath(value) {
  * @param {Object} options.agent
  * @param {Object[]} options.plan
  * @param {Object|null} options.capability
- * @param {String} options.mainCheckout
+ * @param {String} options.agentosRuntimeRoot
  * @param {String} options.nodePath
  * @param {Object} options.fileSystem
  * @returns {Promise<void>}
  * @private
  */
-async function assertRemoteBridgeCapability({agent, plan, capability, mainCheckout, nodePath, fileSystem}) {
+async function assertRemoteBridgeCapability({agent, plan, capability, agentosRuntimeRoot, nodePath, fileSystem}) {
     if (agent.harnessType !== 'claude-desktop' ||
         !plan.some(server => server.enabled && server.target === 'tenant')) {
         return
@@ -545,7 +554,7 @@ async function assertRemoteBridgeCapability({agent, plan, capability, mainChecko
 
     const
         bridge             = capability?.bridge,
-        expectedEntrypoint = path.join(mainCheckout, 'ai/mcp/client/stdioToStreamableHttp.mjs');
+        expectedEntrypoint = path.join(agentosRuntimeRoot, 'ai/mcp/client/stdioToStreamableHttp.mjs');
 
     if (capability?.harnessType !== 'claude-desktop' ||
         !bridge ||
@@ -650,9 +659,9 @@ async function assertNoSymlinkSegments({rootPath, targetPath, fileSystem, label}
 /** @private */
 async function prepareHarnessArtifacts({
     agent,
-    repoPath,
+    targetRepoRoot,
     instanceHome,
-    mainCheckout,
+    agentosRuntimeRoot,
     plan,
     remoteMcpCapability,
     fileSystem
@@ -660,11 +669,11 @@ async function prepareHarnessArtifacts({
     switch (agent.harnessType) {
         case 'codex':
         case 'codex-desktop':
-            return prepareCodexArtifacts({agent, repoPath, instanceHome, mainCheckout, plan, fileSystem});
+            return prepareCodexArtifacts({agent, targetRepoRoot, instanceHome, agentosRuntimeRoot, plan, fileSystem});
         case 'kimi-code':
-            return prepareKimiArtifacts({repoPath, instanceHome, mainCheckout, plan, fileSystem});
+            return prepareKimiArtifacts({targetRepoRoot, instanceHome, agentosRuntimeRoot, plan, fileSystem});
         case 'opencode':
-            return prepareOpenCodeArtifacts({repoPath, instanceHome, mainCheckout, plan, fileSystem});
+            return prepareOpenCodeArtifacts({targetRepoRoot, instanceHome, agentosRuntimeRoot, plan, fileSystem});
         case 'claude-code':
             return prepareClaudeJsonArtifact({
                 agent,
@@ -691,10 +700,10 @@ async function prepareHarnessArtifacts({
 }
 
 /** @private */
-async function prepareCodexArtifacts({agent, repoPath, instanceHome, mainCheckout, plan, fileSystem}) {
+async function prepareCodexArtifacts({agent, targetRepoRoot, instanceHome, agentosRuntimeRoot, plan, fileSystem}) {
     const
-        templatePath   = path.join(mainCheckout, '.codex', 'config.template.toml'),
-        projectPath    = path.join(repoPath, '.codex', 'config.toml'),
+        templatePath   = path.join(agentosRuntimeRoot, '.codex', 'config.template.toml'),
+        projectPath    = path.join(targetRepoRoot, '.codex', 'config.toml'),
         template       = await fileSystem.readFile(templatePath, 'utf8'),
         projectContent = renderCodexProjectConfig(template, plan),
         legacyContent  = renderCodexProjectConfig(template, localizePlan(plan)),
@@ -715,7 +724,7 @@ async function prepareCodexArtifacts({agent, repoPath, instanceHome, mainCheckou
         instanceHome,
         remote,
         ownedLabel     : 'mcp_servers.\"neo-mjs-*\"',
-        trustedRoot    : repoPath,
+        trustedRoot    : targetRepoRoot,
         fileSystem
     }));
     const homeArtifact = await convergeTextArtifact({
@@ -729,7 +738,7 @@ async function prepareCodexArtifacts({agent, repoPath, instanceHome, mainCheckou
 
     if (await convergeCodexRemoteTrust({
         filePath   : homePath,
-        repoPath,
+        repoPath   : targetRepoRoot,
         remote,
         trustedRoot: instanceHome,
         fileSystem
@@ -849,7 +858,7 @@ function renderClaudeJsonContent({agent, plan, remoteMcpCapability, interpolateE
  * clobber or even flag them); the config/hook surfaces converge on their Fleet-owned projections.
  * @private
  */
-async function prepareKimiArtifacts({repoPath, instanceHome, mainCheckout, plan, fileSystem}) {
+async function prepareKimiArtifacts({targetRepoRoot, instanceHome, agentosRuntimeRoot, plan, fileSystem}) {
     const
         enabledKeys = new Set(plan.filter(server => server.enabled).map(server => server.key)),
         servers     = KIMI_SEAT_SERVERS.filter(server => enabledKeys.has(server.name.slice(NEO_MCP_NAME_PREFIX.length)));
@@ -861,26 +870,26 @@ async function prepareKimiArtifacts({repoPath, instanceHome, mainCheckout, plan,
     const
         remoteServers = createRemoteServerMap(plan),
         {files}       = generateKimiSeatConfig({
-        canonicalRoot: mainCheckout,
-        seatEnvFile  : path.join(repoPath, '.env'),
-        workspaceRoot: repoPath,
-        kimiHome     : instanceHome,
-        memoryDir    : path.join(instanceHome, 'memory'),
-        nodeBinary   : plan[0].command,
-        servers,
-        remoteServers
-    }),
+            agentosRuntimeRoot,
+            targetRepoRoot,
+            seatEnvFile: path.join(targetRepoRoot, '.env'),
+            kimiHome   : instanceHome,
+            memoryDir  : path.join(instanceHome, 'memory'),
+            nodeBinary : plan[0].command,
+            servers,
+            remoteServers
+        }),
         {files: legacyFiles} = generateKimiSeatConfig({
-            canonicalRoot: mainCheckout,
-            seatEnvFile  : path.join(repoPath, '.env'),
-            workspaceRoot: repoPath,
-            kimiHome     : instanceHome,
-            memoryDir    : path.join(instanceHome, 'memory'),
-            nodeBinary   : plan[0].command,
+            agentosRuntimeRoot,
+            targetRepoRoot,
+            seatEnvFile: path.join(targetRepoRoot, '.env'),
+            kimiHome   : instanceHome,
+            memoryDir  : path.join(instanceHome, 'memory'),
+            nodeBinary : plan[0].command,
             servers
         });
 
-    return convergeSeatConfigFiles({files, legacyFiles, repoPath, instanceHome, fileSystem, policies: [
+    return convergeSeatConfigFiles({files, legacyFiles, repoPath: targetRepoRoot, instanceHome, fileSystem, policies: [
         {match: /config\.toml$/,                   ownedProjection: kimiConfigTomlOwnedProjection, ownedLabel: 'default_permission_mode,default_model,[[permission.rules]],[[hooks]]'},
         {
             match          : /\.kimi-code\/mcp\.json$/,
@@ -900,7 +909,7 @@ async function prepareKimiArtifacts({repoPath, instanceHome, mainCheckout, plan,
  * Fleet-owned; divergence fails closed per the generated-artifact posture).
  * @private
  */
-async function prepareOpenCodeArtifacts({repoPath, instanceHome, mainCheckout, plan, fileSystem}) {
+async function prepareOpenCodeArtifacts({targetRepoRoot, instanceHome, agentosRuntimeRoot, plan, fileSystem}) {
     const
         enabledKeys = new Set(plan.filter(server => server.enabled).map(server => server.key)),
         servers     = OPENCODE_SEAT_SERVERS.filter(server => enabledKeys.has(server.name.slice(NEO_MCP_NAME_PREFIX.length)));
@@ -912,19 +921,19 @@ async function prepareOpenCodeArtifacts({repoPath, instanceHome, mainCheckout, p
     const
         remoteServers = createRemoteServerMap(plan),
         options       = {
-        canonicalRoot: mainCheckout,
-        seatEnvFile  : path.join(repoPath, '.env'),
-        workspaceRoot: repoPath,
-        memoryDir    : path.join(instanceHome, 'memory'),
-        nodeBinary   : plan[0].command,
-        seatHome     : instanceHome,
-        wakeHookPath : path.join(instanceHome, 'write-wake-envelope.mjs'),
-        servers
-    },
+            agentosRuntimeRoot,
+            targetRepoRoot,
+            seatEnvFile : path.join(targetRepoRoot, '.env'),
+            memoryDir   : path.join(instanceHome, 'memory'),
+            nodeBinary  : plan[0].command,
+            seatHome    : instanceHome,
+            wakeHookPath: path.join(instanceHome, 'write-wake-envelope.mjs'),
+            servers
+        },
         {files}       = generateOpenCodeSeatConfig({...options, remoteServers}),
         {files: legacyFiles} = generateOpenCodeSeatConfig(options);
 
-    return convergeSeatConfigFiles({files, legacyFiles, repoPath, instanceHome, fileSystem, policies: [
+    return convergeSeatConfigFiles({files, legacyFiles, repoPath: targetRepoRoot, instanceHome, fileSystem, policies: [
         {
             match          : /opencode\.jsonc$/,
             ownedProjection: opencodeJsoncOwnedProjection,

--- a/ai/services/fleet/startAgentProvisioned.mjs
+++ b/ai/services/fleet/startAgentProvisioned.mjs
@@ -1,6 +1,10 @@
 import {REMOTE_MCP_CREDENTIAL_ENV_VAR} from './mcpServers.mjs';
 import {ensureAgentRepo}               from './ensureAgentRepo.mjs';
 import {prepareManagedAgentWorkspace}  from './prepareManagedAgentWorkspace.mjs';
+import path                            from 'node:path';
+import {fileURLToPath}                 from 'node:url';
+
+const DEFAULT_AGENTOS_RUNTIME_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../../..');
 
 /**
  * @summary Resolve the provider login that names the canonical AgentIdentity. Fleet `id` names one
@@ -29,7 +33,7 @@ function expectedAgentIdentity(agent) {
  * `FleetLifecycleService.start` supervises a process but knows nothing about repos: it spawns the
  * harness in the Fleet Manager's own working directory. This composer closes that gap. Given an agent
  * whose definition carries its working-repo coordinates (`metadata.repo = {cloneUrl, repoSlug}`), it
- * first ensures the canonical checkout exists — clone-or-reuse, never clobber, via
+ * first ensures the target checkout exists — clone-or-reuse, never clobber, via
  * {@link Neo.ai.services.fleet.ensureAgentRepo} — then hydrates the checkout + isolated harness home
  * through {@link Neo.ai.services.fleet.prepareManagedAgentWorkspace}, and only then starts the harness
  * with its `cwd` pinned to the prepared checkout. Fleet Manager auto-memory is checkout-path-keyed, so
@@ -67,7 +71,8 @@ function expectedAgentIdentity(agent) {
  *                                              singleton only for an opted-in remote seat.
  * @param {String}   [options.instanceRoot]     Explicit harness-home root; omitted ⇒ the lifecycle
  *                                              service's config-resolved `getInstanceRoot()` value.
- * @param {String}   [options.mainCheckout]     Installed canonical checkout override for preparation.
+ * @param {String}   [options.agentosRuntimeRoot] Installed AgentOS runtime root; defaults to the
+ *                                                package root containing this composer.
  * @param {String}   [options.nodePath]         Node executable override for generated MCP definitions.
  * @returns {Promise<Object>} the agent's lifecycle status (see `FleetLifecycleService.status`).
  * @throws {Error} when `lifecycleService` / `agentId` is missing, the agent is unknown, `managedRoot`
@@ -83,7 +88,7 @@ export async function startAgentProvisioned({
     prepareWorkspace = prepareManagedAgentWorkspace,
     tenantService = null,
     instanceRoot,
-    mainCheckout,
+    agentosRuntimeRoot = DEFAULT_AGENTOS_RUNTIME_ROOT,
     nodePath
 } = {}) {
     if (!lifecycleService) throw new Error("startAgentProvisioned: 'lifecycleService' is required.");
@@ -121,6 +126,9 @@ export async function startAgentProvisioned({
     if (!managedRoot) {
         throw new Error(`startAgentProvisioned: 'managedRoot' is required to provision the repo for agent '${agentId}'.`);
     }
+    if (typeof agentosRuntimeRoot !== 'string' || !path.isAbsolute(agentosRuntimeRoot)) {
+        throw new Error(`startAgentProvisioned: 'agentosRuntimeRoot' must be an absolute path for agent '${agentId}'.`)
+    }
 
     let
         remotePlan                   = null,
@@ -146,7 +154,7 @@ export async function startAgentProvisioned({
         }
 
         remoteCapability = await lifecycleService.assertRemoteMcpCapability(agent, {
-            mainCheckout,
+            mainCheckout: agentosRuntimeRoot,
             nodePath
         });
 
@@ -169,7 +177,7 @@ export async function startAgentProvisioned({
     // is never spawned into an unprovisioned / conflicting directory (fail-closed). Input validation
     // (managedRoot / agentId / repoSlug / a missing cloneUrl when a clone is needed) is inherited from
     // the provisioning chain's own contracts — not re-implemented here.
-    const {repoPath} = await ensureRepo({
+    const {repoPath: targetRepoRoot} = await ensureRepo({
         managedRoot,
         agentId,
         repoSlug: repo.repoSlug,
@@ -182,9 +190,9 @@ export async function startAgentProvisioned({
     // propagates, so `start` is never called over divergent or unsupported resident state.
     const prepared = await prepareWorkspace({
         agent,
-        repoPath,
+        targetRepoRoot,
         instanceRoot       : instanceRoot ?? lifecycleService.getInstanceRoot?.(),
-        mainCheckout,
+        agentosRuntimeRoot,
         nodePath,
         remoteMcpCapability: remoteCapability,
         mcpTarget          : remotePlan && {
@@ -194,15 +202,17 @@ export async function startAgentProvisioned({
         }
     });
 
-    if (!prepared || prepared.repoPath !== repoPath) {
-        throw new Error(`startAgentProvisioned: preparation did not return the canonical provisioned repoPath for agent '${agentId}'.`);
+    if (!prepared ||
+        prepared.targetRepoRoot !== targetRepoRoot ||
+        prepared.agentosRuntimeRoot !== path.resolve(agentosRuntimeRoot)) {
+        throw new Error(`startAgentProvisioned: preparation did not return the exact AgentOS runtime and target repo roots for agent '${agentId}'.`);
     }
 
     if (target?.kind === 'tenant') {
         await lifecycleService.inspectPreparedRemoteMcpAdapter({
             agent,
             binaryPath  : remoteCapability.binaryPath,
-            repoPath    : prepared.repoPath,
+            repoPath    : prepared.targetRepoRoot,
             instanceHome: prepared.instanceHome,
             mcpMatrix   : prepared.mcpMatrix,
             mcpPlan     : prepared.mcpPlan,
@@ -214,7 +224,7 @@ export async function startAgentProvisioned({
     }
 
     return lifecycleService.start(agentId, {
-        cwd: prepared.repoPath,
+        cwd: prepared.targetRepoRoot,
         ...(target?.kind === 'tenant'
             ? {resolvedCredential, resolvedMcpCredential, remoteMcpCapability: remoteCapability}
             : {})

--- a/test/playwright/unit/ai/services/fleet/generateKimiSeatConfig.spec.mjs
+++ b/test/playwright/unit/ai/services/fleet/generateKimiSeatConfig.spec.mjs
@@ -10,23 +10,23 @@ import {KIMI_SEAT_SERVERS, generateKimiSeatConfig} from '../../../../../../ai/se
 // host-runtime side effects and each case is fully isolated. Mirrors generateOpenCodeSeatConfig.spec.
 
 const PARAMS = {
-    canonicalRoot: '/canonical',
-    seatEnvFile  : '/seat/checkout/.env',
-    workspaceRoot: '/seat/checkout',
-    kimiHome     : '/fleet/instances/p/kimi',
-    memoryDir    : '/seat/memory',
-    nodeBinary   : '/usr/local/bin/node',
-    environment  : {NEO_OPENAI_COMPATIBLE_HOST: 'http://127.0.0.1:1234', PATH: '/usr/bin:/bin', HOME: '/Users/fleet'}
+    agentosRuntimeRoot: '/agentos/runtime',
+    targetRepoRoot    : '/seat/checkout',
+    seatEnvFile       : '/seat/checkout/.env',
+    kimiHome          : '/fleet/instances/p/kimi',
+    memoryDir         : '/seat/memory',
+    nodeBinary        : '/usr/local/bin/node',
+    environment       : {NEO_OPENAI_COMPATIBLE_HOST: 'http://127.0.0.1:1234', PATH: '/usr/bin:/bin', HOME: '/Users/fleet'}
 };
 
 const findFile = (files, suffix) => files.find(file => file.path.endsWith(suffix));
 
 test.describe('generateKimiSeatConfig (Kimi Code seat scaffold emission, #15612)', () => {
-    test('golden shape: mcp.json parses as strict JSON and wires the canonical four servers, organs-rooted', () => {
+    test('golden shape: mcp.json parses as strict JSON and wires the canonical four servers, AgentOS-rooted', () => {
         const
             {files} = generateKimiSeatConfig(PARAMS),
             mcp     = JSON.parse(findFile(files, '.kimi-code/mcp.json').content).mcpServers,
-            script  = name => `/canonical/ai/mcp/server/${name}/mcp-server.mjs`;
+            script  = name => `/agentos/runtime/ai/mcp/server/${name}/mcp-server.mjs`;
 
         for (const server of KIMI_SEAT_SERVERS) {
             const entry = mcp[server.name];
@@ -41,8 +41,9 @@ test.describe('generateKimiSeatConfig (Kimi Code seat scaffold emission, #15612)
         expect(mcp['neo-mjs-memory-core'].args[1]).toBe(script('memory-core'));
         expect(mcp['neo-mjs-github-workflow'].args[1]).toBe(script('github-workflow'));
         expect(mcp['neo-mjs-knowledge-base'].args[1]).toBe(script('knowledge-base'));
-        // The Neural Link additionally binds --cwd to the seat's own working tree.
-        expect(mcp['neo-mjs-neural-link'].args).toEqual(['--env-file=/seat/checkout/.env', script('neural-link'), '--cwd', '/seat/checkout']);
+        // Neural Link starts its package/Bridge from Agent OS; the target checkout owns artifacts,
+        // not executable authority.
+        expect(mcp['neo-mjs-neural-link'].args).toEqual(['--env-file=/seat/checkout/.env', script('neural-link'), '--cwd', '/agentos/runtime']);
     });
 
     test('golden shape: config.toml carries the auto permission posture, default model, per-server allow rules, and the tracked wake hook', () => {
@@ -176,7 +177,9 @@ test.describe('generateKimiSeatConfig (Kimi Code seat scaffold emission, #15612)
         // Live-frozen from the pre-change origin/dev artifact. This is deliberately not current-vs-current:
         // an unconditional remote credential echo in any generated file changes the digest.
         // Bumped 2026-08-15: the seat-layer rules gained the defect-note anti-pattern line.
-        expect(digest).toBe('2652a60b456146fd4906c7151347b4c7bc1f329ec9a606d777d57b507704f5d6')
+        // Bumped 2026-08-24: AgentOS runtime and target-repository roots became explicit, and Neural
+        // Link's package cwd moved to the runtime authority.
+        expect(digest).toBe('85906be5c2de8ede420c9cfec5e34b236bf410c31f9b01dc724784795c3563c3')
     });
 
     test('remote map replaces only selected servers with the exact Kimi HTTP adapter grammar', () => {
@@ -242,7 +245,7 @@ test.describe('generateKimiSeatConfig (Kimi Code seat scaffold emission, #15612)
         })
     });
 
-    test('island guard: a server script escaping canonicalRoot throws; a malformed entry throws', () => {
+    test('island guard: a server script escaping agentosRuntimeRoot throws; a malformed entry throws', () => {
         const evil = [{name: 'evil', script: '../evil/mcp-server.mjs', needsCwd: false}];
 
         expect(() => generateKimiSeatConfig({...PARAMS, servers: evil})).toThrow(/island guard/);
@@ -250,20 +253,30 @@ test.describe('generateKimiSeatConfig (Kimi Code seat scaffold emission, #15612)
         expect(() => generateKimiSeatConfig({...PARAMS, servers: []})).toThrow(/'servers' must be a non-empty array/);
     });
 
-    test('island guard: a trailing-slash canonicalRoot is accepted (valid input must not mis-reject)', () => {
+    test('island guard: a trailing-slash agentosRuntimeRoot is accepted (valid input must not mis-reject)', () => {
         const
-            {files} = generateKimiSeatConfig({...PARAMS, canonicalRoot: '/canonical/'}),
+            {files} = generateKimiSeatConfig({...PARAMS, agentosRuntimeRoot: '/agentos/runtime/'}),
             mcp     = JSON.parse(findFile(files, '.kimi-code/mcp.json').content).mcpServers;
 
-        expect(mcp['neo-mjs-memory-core'].args[1]).toBe('/canonical/ai/mcp/server/memory-core/mcp-server.mjs');
+        expect(mcp['neo-mjs-memory-core'].args[1]).toBe('/agentos/runtime/ai/mcp/server/memory-core/mcp-server.mjs');
     });
 
     test('named throws: every required param is validated by name', () => {
-        for (const key of ['canonicalRoot', 'seatEnvFile', 'workspaceRoot', 'kimiHome', 'memoryDir', 'nodeBinary']) {
+        for (const key of ['agentosRuntimeRoot', 'targetRepoRoot', 'seatEnvFile', 'kimiHome', 'memoryDir', 'nodeBinary']) {
             const params = {...PARAMS};
             delete params[key];
             expect(() => generateKimiSeatConfig(params), `missing '${key}' must throw`).toThrow(new RegExp(`'${key}'`));
         }
+
+        const legacyOnly = {
+            ...PARAMS,
+            canonicalRoot: PARAMS.agentosRuntimeRoot,
+            workspaceRoot: PARAMS.targetRepoRoot
+        };
+        delete legacyOnly.agentosRuntimeRoot;
+        delete legacyOnly.targetRepoRoot;
+
+        expect(() => generateKimiSeatConfig(legacyOnly)).toThrow(/'agentosRuntimeRoot'/)
     });
 
     test('defaultModel override lands in config.toml', () => {

--- a/test/playwright/unit/ai/services/fleet/generateOpenCodeSeatConfig.spec.mjs
+++ b/test/playwright/unit/ai/services/fleet/generateOpenCodeSeatConfig.spec.mjs
@@ -6,14 +6,14 @@ import {OPENCODE_SEAT_SERVERS, generateOpenCodeSeatConfig} from '../../../../../
 // host-runtime side effects and each case is fully isolated. Mirrors deriveHarnessLaunchSpec.spec.
 
 const PARAMS = {
-    canonicalRoot    : '/canonical',
-    seatEnvFile      : '/seat/checkout/.env',
-    workspaceRoot    : '/seat/checkout',
-    memoryDir        : '/seat/memory',
-    nodeBinary       : '/usr/local/bin/node',
-    environment      : {NEO_OPENAI_COMPATIBLE_HOST: 'http://127.0.0.1:1234', PATH: '/usr/bin:/bin'},
-    extraAllowedPaths: ['/opt/fleet/**'],
-    wakeHookPath     : '/seat/write-wake-envelope.mjs'
+    agentosRuntimeRoot: '/agentos/runtime',
+    targetRepoRoot    : '/seat/checkout',
+    seatEnvFile       : '/seat/checkout/.env',
+    memoryDir         : '/seat/memory',
+    nodeBinary        : '/usr/local/bin/node',
+    environment       : {NEO_OPENAI_COMPATIBLE_HOST: 'http://127.0.0.1:1234', PATH: '/usr/bin:/bin'},
+    extraAllowedPaths : ['/opt/fleet/**'],
+    wakeHookPath      : '/seat/write-wake-envelope.mjs'
 };
 
 const parseJsonc = content => JSON.parse(content.split('\n').filter(line => !line.trimStart().startsWith('//')).join('\n'));
@@ -23,7 +23,7 @@ test.describe('generateOpenCodeSeatConfig (OpenCode seat scaffold emission)', ()
         const
             {files}  = generateOpenCodeSeatConfig(PARAMS),
             config   = parseJsonc(files.find(file => file.path === '/seat/checkout/opencode.jsonc').content),
-            expected = name => ['/usr/local/bin/node', '--env-file=/seat/checkout/.env', `/canonical/ai/mcp/server/${name}/mcp-server.mjs`];
+            expected = name => ['/usr/local/bin/node', '--env-file=/seat/checkout/.env', `/agentos/runtime/ai/mcp/server/${name}/mcp-server.mjs`];
 
         expect(config.$schema).toBe('https://opencode.ai/config.json');
         // The always-loaded slot carries the boot files ONLY — detail files (seat-pointers,
@@ -31,17 +31,18 @@ test.describe('generateOpenCodeSeatConfig (OpenCode seat scaffold emission)', ()
         // every turn (the 27.2KB → ~10KB hot-index reshape).
         expect(config.instructions).toEqual(['/seat/memory/MEMORY.md', '/seat/memory/identity.md']);
 
-        // The four canonical servers, organs-rooted; the Neural Link additionally binds --cwd.
+        // Local server code and Neural Link's package/Bridge cwd are Agent OS-owned. Project
+        // artifacts and the seat env remain target-repository-owned.
         expect(config.mcp['neo-mjs-memory-core']).toEqual({type: 'local', command: expected('memory-core'), enabled: true, environment: PARAMS.environment});
         expect(config.mcp['neo-mjs-github-workflow'].command).toEqual(expected('github-workflow'));
         expect(config.mcp['neo-mjs-knowledge-base'].command).toEqual(expected('knowledge-base'));
-        expect(config.mcp['neo-mjs-neural-link'].command).toEqual([...expected('neural-link'), '--cwd', '/seat/checkout']);
+        expect(config.mcp['neo-mjs-neural-link'].command).toEqual([...expected('neural-link'), '--cwd', '/agentos/runtime']);
 
         // Permission block: catch-all stays "ask" FIRST (last matching rule wins), seat paths allowed.
         const externalDirectory = config.permission.external_directory;
 
         expect(Object.keys(externalDirectory)[0]).toBe('*');
-        expect(externalDirectory).toMatchObject({'*': 'ask', '/seat/**': 'allow', '/seat/checkout/**': 'allow', '/canonical/**': 'allow', '/opt/fleet/**': 'allow'});
+        expect(externalDirectory).toMatchObject({'*': 'ask', '/seat/**': 'allow', '/seat/checkout/**': 'allow', '/agentos/runtime/**': 'allow', '/opt/fleet/**': 'allow'});
     });
 
     test('emission list: five scaffold files by default, the wake hook only when wakeHookPath is given', () => {
@@ -99,7 +100,9 @@ test.describe('generateOpenCodeSeatConfig (OpenCode seat scaffold emission)', ()
         // Bumped 2026-08-23: the wake hook now stamps `agentIdentity` from NEO_AGENT_IDENTITY so the
         // reader can refuse an envelope a DIFFERENT seat wrote to the same shared path. A change to
         // hook content is precisely what this digest exists to surface, so it is bumped, not relaxed.
-        expect(digest).toBe('34d20d3a8e3a5a01dee7cf7c12ba272d912ef5ffe906a5977fe1c78a5956f9d7')
+        // Bumped 2026-08-24: AgentOS runtime and target-repository roots became explicit, and Neural
+        // Link's package cwd moved to the runtime authority.
+        expect(digest).toBe('bea77518dd1af0f6603c1ab794a7f71a8e8a34914dde9275664e47504bde4f6c')
     });
 
     test('remote map replaces only selected servers with the exact OpenCode HTTP adapter grammar', () => {
@@ -166,7 +169,7 @@ test.describe('generateOpenCodeSeatConfig (OpenCode seat scaffold emission)', ()
         })
     });
 
-    test('island guard: a server script escaping canonicalRoot throws; a malformed entry throws', () => {
+    test('island guard: a server script escaping agentosRuntimeRoot throws; a malformed entry throws', () => {
         const evil = [{name: 'evil', script: '../evil/mcp-server.mjs', needsCwd: false}];
 
         expect(() => generateOpenCodeSeatConfig({...PARAMS, servers: evil})).toThrow(/island guard/);
@@ -174,12 +177,12 @@ test.describe('generateOpenCodeSeatConfig (OpenCode seat scaffold emission)', ()
         expect(() => generateOpenCodeSeatConfig({...PARAMS, servers: []})).toThrow(/'servers' must be a non-empty array/);
     });
 
-    test('island guard: a trailing-slash canonicalRoot is accepted (valid input must not mis-reject)', () => {
+    test('island guard: a trailing-slash agentosRuntimeRoot is accepted (valid input must not mis-reject)', () => {
         const
-            {files} = generateOpenCodeSeatConfig({...PARAMS, canonicalRoot: '/canonical/'}),
+            {files} = generateOpenCodeSeatConfig({...PARAMS, agentosRuntimeRoot: '/agentos/runtime/'}),
             config  = parseJsonc(files[0].content);
 
-        expect(config.mcp['neo-mjs-memory-core'].command[2]).toBe('/canonical/ai/mcp/server/memory-core/mcp-server.mjs');
+        expect(config.mcp['neo-mjs-memory-core'].command[2]).toBe('/agentos/runtime/ai/mcp/server/memory-core/mcp-server.mjs');
     });
 
     test('seatHome: explicit param wins; default derives from memoryDir parent', () => {
@@ -193,12 +196,22 @@ test.describe('generateOpenCodeSeatConfig (OpenCode seat scaffold emission)', ()
     });
 
     test('named throws: every required param is validated by name', () => {
-        for (const key of ['canonicalRoot', 'seatEnvFile', 'workspaceRoot', 'memoryDir', 'nodeBinary']) {
+        for (const key of ['agentosRuntimeRoot', 'targetRepoRoot', 'seatEnvFile', 'memoryDir', 'nodeBinary']) {
             const params = {...PARAMS};
 
             delete params[key];
             expect(() => generateOpenCodeSeatConfig(params)).toThrow(new RegExp(`'${key}' must be a non-empty string`));
         }
+
+        const legacyOnly = {
+            ...PARAMS,
+            canonicalRoot: PARAMS.agentosRuntimeRoot,
+            workspaceRoot: PARAMS.targetRepoRoot
+        };
+        delete legacyOnly.agentosRuntimeRoot;
+        delete legacyOnly.targetRepoRoot;
+
+        expect(() => generateOpenCodeSeatConfig(legacyOnly)).toThrow(/'agentosRuntimeRoot'/)
     });
 
     test('sovereignty guard: the emitted identity.md is a template — sovereignty header, zero story content', () => {
@@ -228,7 +241,7 @@ test.describe('generateOpenCodeSeatConfig (OpenCode seat scaffold emission)', ()
         expect(hook).not.toMatch(/import .* from '(?!node:)/); // no non-node imports (C1-clean)
     });
 
-    test('OPENCODE_SEAT_SERVERS: the canonical four are organs-relative scripts', () => {
+    test('OPENCODE_SEAT_SERVERS: the canonical four are AgentOS-relative scripts', () => {
         expect(OPENCODE_SEAT_SERVERS.map(server => server.name)).toEqual([
             'neo-mjs-memory-core', 'neo-mjs-github-workflow', 'neo-mjs-knowledge-base', 'neo-mjs-neural-link'
         ]);

--- a/test/playwright/unit/ai/services/fleet/prepareManagedAgentWorkspace.spec.mjs
+++ b/test/playwright/unit/ai/services/fleet/prepareManagedAgentWorkspace.spec.mjs
@@ -59,25 +59,25 @@ const BOUNDED_APPLY_EFFECTS = new Set([
     'writeFile'
 ]);
 
-let root, mainCheckout, repoRoot, instanceRoot, hydrationCalls;
+let root, agentosRuntimeRoot, repoRoot, instanceRoot, hydrationCalls;
 
 test.beforeEach(async () => {
     root          = await fs.mkdtemp(path.join(os.tmpdir(), 'neo-fleet-workspace-'));
-    mainCheckout  = path.join(root, 'installed-neo');
+    agentosRuntimeRoot  = path.join(root, 'installed-neo');
     repoRoot      = path.join(root, 'managed-repos');
     instanceRoot  = path.join(root, 'instances');
     hydrationCalls = [];
 
-    await fs.mkdir(path.join(mainCheckout, '.codex'), {recursive: true});
-    await fs.writeFile(path.join(mainCheckout, '.codex', 'config.template.toml'), TEMPLATE, 'utf8');
-    await fs.mkdir(path.join(mainCheckout, 'ai/mcp/client'), {recursive: true});
+    await fs.mkdir(path.join(agentosRuntimeRoot, '.codex'), {recursive: true});
+    await fs.writeFile(path.join(agentosRuntimeRoot, '.codex', 'config.template.toml'), TEMPLATE, 'utf8');
+    await fs.mkdir(path.join(agentosRuntimeRoot, 'ai/mcp/client'), {recursive: true});
     await fs.writeFile(
-        path.join(mainCheckout, 'ai/mcp/client/stdioToStreamableHttp.mjs'),
+        path.join(agentosRuntimeRoot, 'ai/mcp/client/stdioToStreamableHttp.mjs'),
         '// installed Neo bridge entrypoint\n',
         'utf8'
     );
     for (const relativePath of MCP_ENTRYPOINTS) {
-        const filePath = path.join(mainCheckout, relativePath);
+        const filePath = path.join(agentosRuntimeRoot, relativePath);
         await fs.mkdir(path.dirname(filePath), {recursive: true});
         await fs.writeFile(filePath, '// installed canonical entrypoint\n', 'utf8');
     }
@@ -102,15 +102,15 @@ function makeHydrate() {
 function options(agent, repoName = agent.id) {
     const result = {
         agent,
-        repoPath        : path.join(repoRoot, repoName),
+        targetRepoRoot  : path.join(repoRoot, repoName),
         instanceRoot,
-        mainCheckout,
+        agentosRuntimeRoot,
         nodePath        : NODE_PATH,
         hydrateWorkspace: makeHydrate()
     };
 
     if (agent.harnessType === 'claude-desktop') {
-        result.remoteMcpCapability = claudeDesktopRemoteCapability(mainCheckout)
+        result.remoteMcpCapability = claudeDesktopRemoteCapability(agentosRuntimeRoot)
     }
 
     return result
@@ -283,7 +283,7 @@ function tomlMcpTable(content, name) {
 }
 
 test.describe('managed workspace logical plan → host apply boundary', () => {
-    test('the compatibility composer has one production caller', async () => {
+    test('the plan/apply composer has one production caller', async () => {
         const callers = [];
 
         for (const rootName of ['ai', 'apps', 'buildScripts', 'src']) {
@@ -397,7 +397,7 @@ test.describe('managed workspace logical plan → host apply boundary', () => {
         });
         expect(first.mcpServers.every(server => server.entrypoint && !path.isAbsolute(server.entrypoint))).toBe(true);
         expect(collectStrings(first).filter(value => !/^https?:/.test(value)).every(value => !path.isAbsolute(value))).toBe(true);
-        expect(JSON.stringify(first)).not.toMatch(/"(?:args|command|cwd|mainCheckout|nodePath|owner|grant|authorization)"/);
+        expect(JSON.stringify(first)).not.toMatch(/"(?:args|command|cwd|agentosRuntimeRoot|targetRepoRoot|mainCheckout|repoPath|nodePath|owner|grant|authorization)"/);
     });
 
     test('planner rejects forbidden/unknown/absolute fields without evaluating effectful accessors', () => {
@@ -405,8 +405,11 @@ test.describe('managed workspace logical plan → host apply boundary', () => {
             name  : 'owner',
             mutate: input => { input.owner = '@someone' }
         }, {
-            name  : 'nested repoPath',
-            mutate: input => { input.agent.repoPath = '/tmp/repo' }
+            name  : 'nested targetRepoRoot',
+            mutate: input => { input.agent.targetRepoRoot = '/tmp/repo' }
+        }, {
+            name  : 'legacy root alias',
+            mutate: input => { input.agent.repoPath = '/tmp/legacy-repo' }
         }, {
             name  : 'bearer value',
             mutate: input => { input.mcpTarget = {...tenantTarget(), bearer: 'secret-value'} }
@@ -486,9 +489,9 @@ test.describe('managed workspace logical plan → host apply boundary', () => {
 
         const result = await applyManagedAgentWorkspacePlan({
             plan            : structuredClone(plan),
-            repoPath        : path.join(repoRoot, 'direct-apply'),
+            targetRepoRoot  : path.join(repoRoot, 'direct-apply'),
             instanceRoot,
-            mainCheckout,
+            agentosRuntimeRoot,
             nodePath        : NODE_PATH,
             hydrateWorkspace: async args => {
                 operations.push('hydrateWorkspace');
@@ -502,15 +505,46 @@ test.describe('managed workspace logical plan → host apply boundary', () => {
         expect(operations).toContain('hydrateWorkspace');
         expect(operations).toContain('writeFile');
         expect(Object.keys(result)).toEqual([
-            'repoPath',
+            'agentosRuntimeRoot',
+            'targetRepoRoot',
             'instanceHome',
             'mcpMatrix',
             'mcpPlan',
             'hydration',
             'artifacts'
         ]);
-        expect(result.mcpPlan[0].args[0]).toBe(path.join(mainCheckout, MCP_ENTRYPOINTS[0]));
-        expect(path.isAbsolute(result.mcpPlan[0].args[0])).toBe(true)
+        expect(result.mcpPlan[0].args[0]).toBe(path.join(agentosRuntimeRoot, MCP_ENTRYPOINTS[0]));
+        expect(path.isAbsolute(result.mcpPlan[0].args[0])).toBe(true);
+        expect(result.agentosRuntimeRoot).toBe(agentosRuntimeRoot);
+        expect(result.targetRepoRoot).toBe(path.join(repoRoot, 'direct-apply'));
+        expect(result.mcpPlan.every(server => server.sourceRoot === agentosRuntimeRoot)).toBe(true);
+        expect(result.mcpPlan.find(server => server.key === 'neural-link').args.slice(-2))
+            .toEqual(['--cwd', agentosRuntimeRoot])
+    });
+
+    test('host apply requires both semantic roots and never falls back to legacy aliases', async () => {
+        const
+            plan    = createManagedAgentWorkspacePlan(logicalInput()),
+            hydrate = makeHydrate(),
+            base    = {plan, instanceRoot, nodePath: NODE_PATH, hydrateWorkspace: hydrate};
+
+        await expect(applyManagedAgentWorkspacePlan({
+            ...base,
+            targetRepoRoot: path.join(repoRoot, 'missing-runtime')
+        })).rejects.toThrow(/agentosRuntimeRoot/);
+
+        await expect(applyManagedAgentWorkspacePlan({
+            ...base,
+            agentosRuntimeRoot
+        })).rejects.toThrow(/targetRepoRoot/);
+
+        await expect(applyManagedAgentWorkspacePlan({
+            ...base,
+            mainCheckout: agentosRuntimeRoot,
+            repoPath    : path.join(repoRoot, 'legacy-only')
+        })).rejects.toThrow(/targetRepoRoot/);
+
+        expect(hydrationCalls).toEqual([])
     });
 
     test('host apply rejects projection drift while accepting a coherent clone without proving provenance', async () => {
@@ -524,9 +558,9 @@ test.describe('managed workspace logical plan → host apply boundary', () => {
 
         await expect(applyManagedAgentWorkspacePlan({
             plan            : divergentPlan,
-            repoPath        : path.join(repoRoot, 'divergent-plan'),
+            targetRepoRoot  : path.join(repoRoot, 'divergent-plan'),
             instanceRoot,
-            mainCheckout,
+            agentosRuntimeRoot,
             nodePath        : NODE_PATH,
             hydrateWorkspace: async args => {
                 hydrationCalls.push(args);
@@ -544,9 +578,9 @@ test.describe('managed workspace logical plan → host apply boundary', () => {
 
         const result = await applyManagedAgentWorkspacePlan({
             plan            : coherentPlan,
-            repoPath        : path.join(repoRoot, 'coherent-plan'),
+            targetRepoRoot  : path.join(repoRoot, 'coherent-plan'),
             instanceRoot,
-            mainCheckout,
+            agentosRuntimeRoot,
             nodePath        : NODE_PATH,
             hydrateWorkspace: makeHydrate()
         });
@@ -557,17 +591,17 @@ test.describe('managed workspace logical plan → host apply boundary', () => {
 
     test('invalid host input is normalized and a completed artifact converges after a mid-apply failure', async () => {
         const
-            plan     = createManagedAgentWorkspacePlan(logicalInput()),
-            badPlan  = structuredClone(plan),
-            repoPath = path.join(repoRoot, 'partial-apply');
+            plan           = createManagedAgentWorkspacePlan(logicalInput()),
+            badPlan        = structuredClone(plan),
+            targetRepoRoot = path.join(repoRoot, 'partial-apply');
 
         badPlan.agent.id = '/tmp/escaped-agent';
 
         await expect(applyManagedAgentWorkspacePlan({
             plan            : badPlan,
-            repoPath,
+            targetRepoRoot,
             instanceRoot,
-            mainCheckout,
+            agentosRuntimeRoot,
             nodePath        : NODE_PATH,
             hydrateWorkspace: makeHydrate()
         })).rejects.toBeInstanceOf(ManagedWorkspacePreparationError);
@@ -589,16 +623,16 @@ test.describe('managed workspace logical plan → host apply boundary', () => {
         });
         const applyOptions = {
             plan,
-            repoPath,
+            targetRepoRoot,
             instanceRoot,
-            mainCheckout,
+            agentosRuntimeRoot,
             nodePath        : NODE_PATH,
             hydrateWorkspace: makeHydrate()
         };
 
         await expect(applyManagedAgentWorkspacePlan({...applyOptions, fileSystem: failingFileSystem}))
             .rejects.toBeInstanceOf(ManagedWorkspacePreparationError);
-        expect(await read(path.join(repoPath, '.codex', 'config.toml'))).toContain('neo-mjs-memory-core');
+        expect(await read(path.join(targetRepoRoot, '.codex', 'config.toml'))).toContain('neo-mjs-memory-core');
 
         const retry = await applyManagedAgentWorkspacePlan(applyOptions);
 
@@ -609,7 +643,7 @@ test.describe('managed workspace logical plan → host apply boundary', () => {
         ])
     });
 
-    test('compatibility composer resolves once before entering one host apply sequence', async () => {
+    test('plan/apply composer resolves once before entering one host apply sequence', async () => {
         const
             events = [],
             agent  = makeAgent('codex'),
@@ -633,7 +667,8 @@ test.describe('managed workspace logical plan → host apply boundary', () => {
 
         expect(events).toEqual(['resolve', 'apply:derive', 'apply:hydrate']);
         expect(Object.keys(result)).toEqual([
-            'repoPath',
+            'agentosRuntimeRoot',
+            'targetRepoRoot',
             'instanceHome',
             'mcpMatrix',
             'mcpPlan',
@@ -648,15 +683,16 @@ test.describe('prepareManagedAgentWorkspace', () => {
         const
             opts              = options(makeAgent('codex')),
             result            = await prepareManagedAgentWorkspace(opts),
-            projectConfigPath = path.join(opts.repoPath, '.codex', 'config.toml'),
+            projectConfigPath = path.join(opts.targetRepoRoot, '.codex', 'config.toml'),
             homeConfigPath    = path.join(result.instanceHome, 'config.toml'),
             memoriesPath      = path.join(result.instanceHome, 'memories'),
             projectConfig     = await read(projectConfigPath),
             homeConfig        = await read(homeConfigPath);
 
         expect(hydrationCalls).toHaveLength(1);
-        expect(hydrationCalls[0]).toMatchObject({mainCheckout, projectRoot: opts.repoPath});
-        expect(result.repoPath).toBe(opts.repoPath);
+        expect(hydrationCalls[0]).toMatchObject({mainCheckout: agentosRuntimeRoot, projectRoot: opts.targetRepoRoot});
+        expect(result.agentosRuntimeRoot).toBe(agentosRuntimeRoot);
+        expect(result.targetRepoRoot).toBe(opts.targetRepoRoot);
         expect(result.hydration).toEqual({hydrated: true});
         expect(result.mcpPlan).toHaveLength(5);
         expect(result.mcpPlan.map(server => server.key)).toEqual([
@@ -680,13 +716,13 @@ test.describe('prepareManagedAgentWorkspace', () => {
             WORKSPACE_ARTIFACT_STATES.CREATED
         ]);
 
-        // Fresh managed clones have no dependencies: every executable comes from the installed
-        // checkout, while Neural Link receives the managed repo as its explicit project cwd.
+        // Fresh target clones have no dependencies: every executable and Neural Link's package cwd
+        // come from AgentOS, while project artifacts remain under the target repository.
         expect(projectConfig).toContain(`command = ${JSON.stringify(NODE_PATH)}`);
-        expect(projectConfig).toContain(path.join(mainCheckout, 'ai/mcp/server/memory-core/mcp-server.mjs'));
-        expect(projectConfig).toContain(JSON.stringify(['--cwd', opts.repoPath]).slice(1, -1));
+        expect(projectConfig).toContain(path.join(agentosRuntimeRoot, 'ai/mcp/server/memory-core/mcp-server.mjs'));
+        expect(projectConfig).toContain(JSON.stringify(['--cwd', agentosRuntimeRoot]).slice(1, -1));
         expect(projectConfig).not.toContain('command = "npm"');
-        await expect(fs.stat(path.join(opts.repoPath, 'node_modules'))).rejects.toMatchObject({code: 'ENOENT'});
+        await expect(fs.stat(path.join(opts.targetRepoRoot, 'node_modules'))).rejects.toMatchObject({code: 'ENOENT'});
 
         // All catalog keys are projected from current defaults; optional workflows remain disabled.
         expect(projectConfig.match(/^\[mcp_servers\./gm)).toHaveLength(5);
@@ -694,7 +730,7 @@ test.describe('prepareManagedAgentWorkspace', () => {
         expect(projectConfig).toMatch(/\[mcp_servers\."neo-mjs-gitlab-workflow"\][\s\S]*?enabled = false/);
         expect(homeConfig).toContain('cli_auth_credentials_store = "file"');
         expect(homeConfig).toContain('mcp_oauth_credentials_store = "file"');
-        expect(homeConfig).not.toContain(`[projects.${JSON.stringify(opts.repoPath)}]`);
+        expect(homeConfig).not.toContain(`[projects.${JSON.stringify(opts.targetRepoRoot)}]`);
         expect(homeConfig).not.toContain('trust_level = "trusted"');
         expect(homeConfig).toBe([
             '# Fleet-owned Codex home policy. Authentication material itself is created by Codex login, never by Fleet.',
@@ -713,7 +749,7 @@ test.describe('prepareManagedAgentWorkspace', () => {
     test('re-entry reports MATCH and ignores unrelated operator-owned TOML tables/keys', async () => {
         const opts        = options(makeAgent('codex'));
         const first       = await prepareManagedAgentWorkspace(opts);
-        const projectPath = path.join(opts.repoPath, '.codex', 'config.toml');
+        const projectPath = path.join(opts.targetRepoRoot, '.codex', 'config.toml');
         const homePath    = path.join(first.instanceHome, 'config.toml');
 
         await fs.appendFile(projectPath, '\n[mcp_servers."operator-local"]\ncommand = "custom"\n', 'utf8');
@@ -841,13 +877,13 @@ test.describe('prepareManagedAgentWorkspace', () => {
             foreignDeps = path.join(root, 'foreign-resident', 'node_modules');
 
         await fs.mkdir(foreignDeps, {recursive: true});
-        await fs.mkdir(opts.repoPath, {recursive: true});
-        await fs.symlink(foreignDeps, path.join(opts.repoPath, 'node_modules'), 'dir');
+        await fs.mkdir(opts.targetRepoRoot, {recursive: true});
+        await fs.symlink(foreignDeps, path.join(opts.targetRepoRoot, 'node_modules'), 'dir');
 
         const result = await prepareManagedAgentWorkspace(opts);
 
         expect(result.artifacts.every(item => item.ownedKeys !== 'dependency-root')).toBe(true);
-        expect(path.resolve(path.dirname(path.join(opts.repoPath, 'node_modules')), await fs.readlink(path.join(opts.repoPath, 'node_modules'))))
+        expect(path.resolve(path.dirname(path.join(opts.targetRepoRoot, 'node_modules')), await fs.readlink(path.join(opts.targetRepoRoot, 'node_modules'))))
             .toBe(foreignDeps);
     });
 
@@ -865,14 +901,25 @@ test.describe('prepareManagedAgentWorkspace', () => {
         await expect(prepareManagedAgentWorkspace(missingNode)).rejects.toMatchObject({
             code: 'FLEET_WORKSPACE_UNSUPPORTED'
         });
-        await expect(fs.stat(path.join(missingNode.repoPath, '.codex', 'config.toml'))).rejects.toMatchObject({code: 'ENOENT'});
+        await expect(fs.stat(path.join(missingNode.targetRepoRoot, '.codex', 'config.toml'))).rejects.toMatchObject({code: 'ENOENT'});
 
         const missingEntrypoint = options(makeAgent('codex'), 'missing-entrypoint');
-        await fs.rm(path.join(mainCheckout, MCP_ENTRYPOINTS[0]));
+        await fs.rm(path.join(agentosRuntimeRoot, MCP_ENTRYPOINTS[0]));
         await expect(prepareManagedAgentWorkspace(missingEntrypoint)).rejects.toMatchObject({
             code: 'FLEET_WORKSPACE_UNSUPPORTED'
         });
-        await expect(fs.stat(path.join(missingEntrypoint.repoPath, '.codex', 'config.toml'))).rejects.toMatchObject({code: 'ENOENT'});
+        await expect(fs.stat(path.join(missingEntrypoint.targetRepoRoot, '.codex', 'config.toml'))).rejects.toMatchObject({code: 'ENOENT'});
+    });
+
+    test('swapping AgentOS runtime and target roots fails at the AgentOS executable guard', async () => {
+        const opts = options(makeAgent('codex'), 'swapped-roots');
+
+        [opts.agentosRuntimeRoot, opts.targetRepoRoot] = [opts.targetRepoRoot, opts.agentosRuntimeRoot];
+
+        await expect(prepareManagedAgentWorkspace(opts)).rejects.toMatchObject({
+            code   : 'FLEET_WORKSPACE_UNSUPPORTED',
+            message: expect.stringMatching(/installed file entrypoint/)
+        })
     });
 
     test('directory-valued Node and MCP entrypoint paths fail executable preflight', async () => {
@@ -884,7 +931,7 @@ test.describe('prepareManagedAgentWorkspace', () => {
         });
 
         const directoryEntrypoint = options(makeAgent('codex'), 'directory-entrypoint');
-        const directoryPath       = path.join(mainCheckout, MCP_ENTRYPOINTS[0]);
+        const directoryPath       = path.join(agentosRuntimeRoot, MCP_ENTRYPOINTS[0]);
         await fs.rm(directoryPath);
         await fs.mkdir(directoryPath);
 
@@ -919,9 +966,9 @@ test.describe('prepareManagedAgentWorkspace', () => {
         ]);
         expect(nl.command).toBe(NODE_PATH);
         expect(nl.args).toEqual([
-            path.join(mainCheckout, 'ai/mcp/server/neural-link/mcp-server.mjs'),
+            path.join(agentosRuntimeRoot, 'ai/mcp/server/neural-link/mcp-server.mjs'),
             '--cwd',
-            opts.repoPath
+            agentosRuntimeRoot
         ]);
         expect(nl.env).toEqual({
             NEO_AGENT_IDENTITY         : '${NEO_AGENT_IDENTITY}',
@@ -929,7 +976,7 @@ test.describe('prepareManagedAgentWorkspace', () => {
             NEO_NL_TOOL_PROJECTION_MODE: '${NEO_NL_TOOL_PROJECTION_MODE}'
         });
         expect(raw).not.toContain('secret-token-value');
-        await expect(fs.stat(path.join(opts.repoPath, '.mcp.json'))).rejects.toMatchObject({code: 'ENOENT'});
+        await expect(fs.stat(path.join(opts.targetRepoRoot, '.mcp.json'))).rejects.toMatchObject({code: 'ENOENT'});
     });
 
     test('Claude Desktop: default profile includes Neural Link without persisting its optional Bridge token', async () => {
@@ -1005,8 +1052,8 @@ test.describe('prepareManagedAgentWorkspace', () => {
         await expect(prepareManagedAgentWorkspace()).rejects.toThrow(/agent/);
         await expect(prepareManagedAgentWorkspace({
             ...options(makeAgent('codex')),
-            repoPath: 'relative/repo'
-        })).rejects.toThrow(/repoPath.*absolute/);
+            targetRepoRoot: 'relative/repo'
+        })).rejects.toThrow(/targetRepoRoot.*absolute/);
         expect(hydrationCalls).toHaveLength(0);
     });
 
@@ -1015,7 +1062,7 @@ test.describe('prepareManagedAgentWorkspace', () => {
             opts   = options(makeAgent('kimi-code')),
             result = await prepareManagedAgentWorkspace(opts),
             config = await read(path.join(result.instanceHome, 'config.toml')),
-            mcp    = JSON.parse(await read(path.join(opts.repoPath, '.kimi-code', 'mcp.json'))),
+            mcp    = JSON.parse(await read(path.join(opts.targetRepoRoot, '.kimi-code', 'mcp.json'))),
             hook   = await read(path.join(result.instanceHome, 'hooks', 'identityAnchorHook.mjs')),
             memory = await read(path.join(result.instanceHome, 'memory', 'MEMORY.md'));
 
@@ -1078,7 +1125,7 @@ test.describe('prepareManagedAgentWorkspace', () => {
         const
             opts        = options(makeAgent('opencode')),
             result      = await prepareManagedAgentWorkspace(opts),
-            jsoncSource = await read(path.join(opts.repoPath, 'opencode.jsonc')),
+            jsoncSource = await read(path.join(opts.targetRepoRoot, 'opencode.jsonc')),
             config      = JSON.parse(jsoncSource.split('\n').filter(line => !line.trimStart().startsWith('//')).join('\n'));
 
         // 6 artifacts: opencode.jsonc + 4 memory-layer files + the wake-envelope boot hook.
@@ -1092,7 +1139,7 @@ test.describe('prepareManagedAgentWorkspace', () => {
         expect(Object.keys(config.mcp).sort()).toEqual(['neo-mjs-knowledge-base', 'neo-mjs-memory-core', 'neo-mjs-neural-link']);
         // Permission allow-list covers the seat home, the managed repo, and the canonical checkout.
         expect(config.permission.external_directory[result.instanceHome + '/**']).toBe('allow');
-        expect(config.permission.external_directory[opts.repoPath + '/**']).toBe('allow');
+        expect(config.permission.external_directory[opts.targetRepoRoot + '/**']).toBe('allow');
         expect(config.permission.external_directory['*']).toBe('ask');
 
         const hook = await read(path.join(result.instanceHome, 'write-wake-envelope.mjs'));
@@ -1118,7 +1165,7 @@ test.describe('prepareManagedAgentWorkspace', () => {
         const cases = [{
             harnessType: 'codex',
             inspect    : async (opts, result) => {
-                const source = await read(path.join(opts.repoPath, '.codex', 'config.toml'));
+                const source = await read(path.join(opts.targetRepoRoot, '.codex', 'config.toml'));
 
                 expect(source).toMatch(/\[mcp_servers\."neo-mjs-memory-core"\][\s\S]*?url = "https:\/\/tenant\.example\.com\/agentos\/mc\/mcp"[\s\S]*?bearer_token_env_var = "NEO_MCP_REMOTE_TOKEN"/);
                 expect(source).toMatch(/\[mcp_servers\."neo-mjs-knowledge-base"\][\s\S]*?url = "https:\/\/tenant\.example\.com\/agentos\/kb\/mcp"[\s\S]*?bearer_token_env_var = "NEO_MCP_REMOTE_TOKEN"/);
@@ -1127,7 +1174,7 @@ test.describe('prepareManagedAgentWorkspace', () => {
         }, {
             harnessType: 'codex-desktop',
             inspect    : async (opts, result) => {
-                const source = await read(path.join(opts.repoPath, '.codex', 'config.toml'));
+                const source = await read(path.join(opts.targetRepoRoot, '.codex', 'config.toml'));
 
                 expect(source).toContain('bearer_token_env_var = "NEO_MCP_REMOTE_TOKEN"');
                 expect(result.instanceHome).toContain('codex-desktop')
@@ -1154,7 +1201,7 @@ test.describe('prepareManagedAgentWorkspace', () => {
             inspect    : async (opts, result) => {
                 const
                     config = JSON.parse(await read(path.join(result.instanceHome, 'claude_desktop_config.json'))),
-                    bridge = path.join(mainCheckout, 'ai/mcp/client/stdioToStreamableHttp.mjs');
+                    bridge = path.join(agentosRuntimeRoot, 'ai/mcp/client/stdioToStreamableHttp.mjs');
 
                 expect(config.mcpServers['neo-mjs-memory-core']).toEqual({
                     command: NODE_PATH,
@@ -1181,7 +1228,7 @@ test.describe('prepareManagedAgentWorkspace', () => {
         }, {
             harnessType: 'kimi-code',
             inspect    : async opts => {
-                const config = JSON.parse(await read(path.join(opts.repoPath, '.kimi-code', 'mcp.json')));
+                const config = JSON.parse(await read(path.join(opts.targetRepoRoot, '.kimi-code', 'mcp.json')));
 
                 expect(config.mcpServers['neo-mjs-memory-core']).toEqual({
                     url              : 'https://tenant.example.com/agentos/mc/mcp',
@@ -1198,7 +1245,7 @@ test.describe('prepareManagedAgentWorkspace', () => {
         }, {
             harnessType: 'opencode',
             inspect    : async opts => {
-                const config = parseJsonc(await read(path.join(opts.repoPath, 'opencode.jsonc')));
+                const config = parseJsonc(await read(path.join(opts.targetRepoRoot, 'opencode.jsonc')));
 
                 expect(config.mcp['neo-mjs-memory-core']).toEqual({
                     type   : 'remote',
@@ -1247,7 +1294,7 @@ test.describe('prepareManagedAgentWorkspace', () => {
     test('transport transition is local → remote → different remote → local, preserving unrelated TOML bytes', async () => {
         const
             opts        = options(makeAgent('codex'), 'transition-codex'),
-            projectPath = path.join(opts.repoPath, '.codex', 'config.toml');
+            projectPath = path.join(opts.targetRepoRoot, '.codex', 'config.toml');
 
         const local              = await prepareManagedAgentWorkspace(opts);
         const localBaseline      = await read(projectPath);
@@ -1314,11 +1361,11 @@ test.describe('prepareManagedAgentWorkspace', () => {
                 operatorBlock: strictOperatorBlock
             }, {
                 harnessType  : 'kimi-code',
-                artifactPath : opts => path.join(opts.repoPath, '.kimi-code', 'mcp.json'),
+                artifactPath : opts => path.join(opts.targetRepoRoot, '.kimi-code', 'mcp.json'),
                 operatorBlock: strictOperatorBlock
             }, {
                 harnessType  : 'opencode',
-                artifactPath : opts => path.join(opts.repoPath, 'opencode.jsonc'),
+                artifactPath : opts => path.join(opts.targetRepoRoot, 'opencode.jsonc'),
                 operatorBlock: jsoncOperatorBlock
             }];
 
@@ -1375,7 +1422,7 @@ test.describe('prepareManagedAgentWorkspace', () => {
     test('a receipt cannot authorize an operator-edited transport projection', async () => {
         const
             opts        = options(makeAgent('codex'), 'edited-remote'),
-            projectPath = path.join(opts.repoPath, '.codex', 'config.toml');
+            projectPath = path.join(opts.targetRepoRoot, '.codex', 'config.toml');
 
         opts.mcpTarget = tenantTarget();
         await prepareManagedAgentWorkspace(opts);
@@ -1445,7 +1492,7 @@ test.describe('prepareManagedAgentWorkspace', () => {
             fixture = await startBridgeFixture(token),
             opts    = options(makeAgent('claude-desktop'), 'remote-desktop-live-bridge');
 
-        opts.mainCheckout       = PROJECT_ROOT;
+        opts.agentosRuntimeRoot       = PROJECT_ROOT;
         opts.remoteMcpCapability = claudeDesktopRemoteCapability(PROJECT_ROOT);
         opts.mcpTarget           = tenantTarget(fixture.baseUrl);
 
@@ -1531,7 +1578,7 @@ test.describe('prepareManagedAgentWorkspace', () => {
         const missingBridge = options(makeAgent('claude-desktop'), 'remote-desktop-missing-bridge');
 
         missingBridge.mcpTarget = tenantTarget();
-        await fs.rm(path.join(mainCheckout, 'ai/mcp/client/stdioToStreamableHttp.mjs'));
+        await fs.rm(path.join(agentosRuntimeRoot, 'ai/mcp/client/stdioToStreamableHttp.mjs'));
 
         await expect(prepareManagedAgentWorkspace(missingBridge)).rejects.toMatchObject({
             code: 'FLEET_WORKSPACE_UNSUPPORTED'

--- a/test/playwright/unit/ai/startAgentProvisioned.spec.mjs
+++ b/test/playwright/unit/ai/startAgentProvisioned.spec.mjs
@@ -71,15 +71,18 @@ function buildPreparedMcpPlan(args, mcpMatrix) {
 
         return {
             key,
-            name              : `neo-mjs-${key}`,
+            name            : `neo-mjs-${key}`,
             enabled,
-            target            : resource ? 'tenant' : 'resident',
-            transport         : resource ? 'streamable-http' : 'stdio',
-            url               : resource?.url || null,
-            credentialEnvVar  : resource ? 'NEO_MCP_REMOTE_TOKEN' : null,
-            command           : '/usr/bin/node',
-            sourceRoot        : '/installed/neo',
-            args              : [`/installed/neo/ai/mcp/server/${key}/mcp-server.mjs`],
+            target          : resource ? 'tenant' : 'resident',
+            transport       : resource ? 'streamable-http' : 'stdio',
+            url             : resource?.url || null,
+            credentialEnvVar: resource ? 'NEO_MCP_REMOTE_TOKEN' : null,
+            command         : '/usr/bin/node',
+            sourceRoot      : args.agentosRuntimeRoot,
+            args            : [
+                `${args.agentosRuntimeRoot}/ai/mcp/server/${key}/mcp-server.mjs`,
+                ...(key === 'neural-link' ? ['--cwd', args.agentosRuntimeRoot] : [])
+            ],
             runtimeEnv        : ['NEO_AGENT_IDENTITY'],
             requiredRuntimeEnv: ['NEO_AGENT_IDENTITY'],
             secretEnv         : [],
@@ -104,10 +107,11 @@ function makePrepareWorkspace(events) {
         };
 
         return {
-            repoPath    : args.repoPath,
-            instanceHome: `/instances/${args.agent.id}`,
+            agentosRuntimeRoot: args.agentosRuntimeRoot,
+            targetRepoRoot    : args.targetRepoRoot,
+            instanceHome      : `/instances/${args.agent.id}`,
             mcpMatrix,
-            mcpPlan     : buildPreparedMcpPlan(args, mcpMatrix)
+            mcpPlan           : buildPreparedMcpPlan(args, mcpMatrix)
         }
     };
     fn.calls    = calls;
@@ -176,21 +180,21 @@ function makeTenantService({
 }
 
 test.describe('startAgentProvisioned (Fleet Manager spawn-time repo provisioning)', () => {
-    test('provisions, prepares, then starts with one canonical checkout path', async () => {
+    test('provisions the target, binds AgentOS runtime, then launches from the target root', async () => {
         const events           = [],
               lifecycle        = makeLifecycle({agents: repoAgent('a'), events}),
               ensureRepo       = makeEnsureRepo('/managed/a/neomjs-neo', events),
               prepareWorkspace = makePrepareWorkspace(events),
               cloneRepo        = () => {},
               status           = await startAgentProvisioned({
-                  lifecycleService: lifecycle,
-                  agentId         : 'a',
-                  managedRoot     : '/managed',
+                  lifecycleService  : lifecycle,
+                  agentId           : 'a',
+                  managedRoot       : '/managed',
                   cloneRepo,
                   ensureRepo,
                   prepareWorkspace,
-                  mainCheckout    : '/installed/neo',
-                  nodePath        : '/usr/bin/node'
+                  agentosRuntimeRoot: '/installed/neo',
+                  nodePath          : '/usr/bin/node'
               });
 
         // provisioning fed the agent's metadata.repo coordinates + the managed root + the clone seam
@@ -198,14 +202,14 @@ test.describe('startAgentProvisioned (Fleet Manager spawn-time repo provisioning
         expect(ensureRepo.calls[0]).toMatchObject({managedRoot: '/managed', agentId: 'a', repoSlug: 'neomjs/neo', cloneUrl: REPO.cloneUrl, cloneRepo});
         expect(prepareWorkspace.calls).toHaveLength(1);
         expect(prepareWorkspace.calls[0]).toMatchObject({
-            agent       : repoAgent('a').a,
-            repoPath    : '/managed/a/neomjs-neo',
-            instanceRoot: '/instances',
-            mainCheckout: '/installed/neo',
-            nodePath    : '/usr/bin/node'
+            agent             : repoAgent('a').a,
+            targetRepoRoot    : '/managed/a/neomjs-neo',
+            instanceRoot      : '/instances',
+            agentosRuntimeRoot: '/installed/neo',
+            nodePath          : '/usr/bin/node'
         });
         expect(events).toEqual(['ensure', 'prepare', 'start']);
-        // The harness starts with cwd === provisioned repoPath === prepared repoPath.
+        // Runtime authority stays AgentOS-owned; the harness cwd stays the provisioned target root.
         expect(lifecycle.calls.start).toHaveLength(1);
         expect(lifecycle.calls.start[0]).toEqual({id: 'a', opts: {cwd: '/managed/a/neomjs-neo'}});
         expect(status.state).toBe('running');
@@ -239,10 +243,11 @@ test.describe('startAgentProvisioned (Fleet Manager spawn-time repo provisioning
             prepareWorkspace = makePrepareWorkspace(events);
 
         await startAgentProvisioned({
-            lifecycleService: lifecycle,
+            lifecycleService  : lifecycle,
             tenantService,
-            agentId         : 'a',
-            managedRoot     : '/managed',
+            agentId           : 'a',
+            managedRoot       : '/managed',
+            agentosRuntimeRoot: '/installed/neo',
             ensureRepo,
             prepareWorkspace
         });
@@ -261,7 +266,7 @@ test.describe('startAgentProvisioned (Fleet Manager spawn-time repo provisioning
         expect(lifecycle.calls.credential).toEqual(['a']);
         expect(lifecycle.calls.capability).toEqual([{
             agent  : agents.a,
-            options: {mainCheckout: undefined, nodePath: undefined}
+            options: {mainCheckout: '/installed/neo', nodePath: undefined}
         }]);
         expect(tenantService.calls.resolve).toEqual(['tenant-a']);
         expect(tenantService.calls.credential).toEqual(['tenant-a']);
@@ -592,6 +597,26 @@ test.describe('startAgentProvisioned (Fleet Manager spawn-time repo provisioning
         expect(lifecycle.calls.start).toHaveLength(0);
     });
 
+    test('a relative AgentOS runtime root rejects before repo or harness effects', async () => {
+        const
+            lifecycle        = makeLifecycle({agents: repoAgent('a')}),
+            ensureRepo       = makeEnsureRepo(),
+            prepareWorkspace = makePrepareWorkspace();
+
+        await expect(startAgentProvisioned({
+            lifecycleService  : lifecycle,
+            agentId           : 'a',
+            managedRoot       : '/managed',
+            agentosRuntimeRoot: 'relative/agentos',
+            ensureRepo,
+            prepareWorkspace
+        })).rejects.toThrow(/agentosRuntimeRoot.*absolute/);
+
+        expect(ensureRepo.calls).toEqual([]);
+        expect(prepareWorkspace.calls).toEqual([]);
+        expect(lifecycle.calls.start).toEqual([])
+    });
+
     test('an unknown agent throws', async () => {
         const lifecycle = makeLifecycle({agents: {}});
 
@@ -607,8 +632,11 @@ test.describe('startAgentProvisioned (Fleet Manager spawn-time repo provisioning
             agentId         : 'a',
             managedRoot     : '/managed',
             ensureRepo      : makeEnsureRepo('/managed/a/neomjs-neo'),
-            prepareWorkspace: async () => ({repoPath: '/other/repo'})
-        })).rejects.toThrow(/canonical provisioned repoPath/);
+            prepareWorkspace: async args => ({
+                agentosRuntimeRoot: args.agentosRuntimeRoot,
+                targetRepoRoot    : '/other/repo'
+            })
+        })).rejects.toThrow(/exact AgentOS runtime and target repo roots/);
 
         expect(lifecycle.calls.start).toHaveLength(0);
     });


### PR DESCRIPTION
Resolves #17718

Fleet seat preparation now carries two explicit roots end to end: `agentosRuntimeRoot` owns every local MCP entrypoint and Neural Link's package/Bridge cwd; `targetRepoRoot` owns hydration, seat/project artifacts, permissions, and harness launch cwd. The former `mainCheckout` / `repoPath` and generator `canonicalRoot` / `workspaceRoot` option aliases are not accepted, so a stale seat fails during re-materialization instead of silently executing AgentOS from an Engine target.

Related: #17500

Evidence: L2 (hermetic plan/apply, generator, artifact, and launch-contract tests with distinct/omitted/swapped roots; 91/91 focused) → L2 required (all close-target ACs are unit-observable root/path contracts). No residuals.

## AC Evidence

| AC-1 | `prepareManagedAgentWorkspace.spec.mjs` — host apply requires both semantic absolute roots, rejects legacy-only aliases before hydration, and the public preparation/apply JSDoc exposes no compatibility options. |
| AC-2 | Managed-plan + Kimi/OpenCode golden arms assert every local entrypoint and `sourceRoot` below `agentosRuntimeRoot`; swapped roots fail at the named installed-entrypoint guard, and island errors name `agentosRuntimeRoot`. |
| AC-3 | Central Codex/Claude plan, Kimi strict JSON, and OpenCode JSONC arms assert Neural Link `--cwd === agentosRuntimeRoot`. |
| AC-4 | Owning specs keep seat `.env`, project configs, OpenCode permission targets, hydration `projectRoot`, and `startAgentProvisioned` harness cwd at `targetRepoRoot`. |
| AC-5 | Host-apply and composer receipts assert exact `agentosRuntimeRoot` + `targetRepoRoot`; `startAgentProvisioned` refuses a receipt that substitutes either root. |
| AC-6 | Missing-runtime, missing-target, relative-root, and legacy-only arms reject before hydration/repo/harness effects. |
| AC-7 | Distinct-root positive controls pass; the swapped-root arm fails on absent AgentOS executable authority; the three Neural Link golden arms are the named removal falsifiers. |
| AC-8 | Existing Kimi/OpenCode remote-map and cross-harness remote-adapter arms remain exact remote grammar and acquire no local command/path/cwd. |
| AC-9 | Focused managed-workspace + Kimi + OpenCode + provisioned-launch suites pass 91/91; no `.mjs` file was added. |

## Deltas from ticket

The sole production consumer, `startAgentProvisioned`, now maps provisioning's generic `repoPath` into `targetRepoRoot`, validates the two-root receipt, and launches from the target. The pure logical planner's host-field deny set also names both new roots. `FleetLifecycleService` retains its independent installed-capability `mainCheckout` vocabulary; it is not a workspace compatibility alias, and the composer maps the resolved AgentOS root into that existing probe boundary.

## Test Evidence

- RED-first: with specs switched to the explicit contract before production code, the two generator suites failed 32/35 on the retired `canonicalRoot` requirement; after the implementation, the complete focused surface passes 91/91.
- Full-unit attempt: 15,022 passed; 25 unrelated infrastructure/census cases are locally unexecutable because the preserved user-owned `ai/deploy/.neo-ai-data/` backup tree enters repository scans, live graph/log paths are readonly in this sandbox, and spawned deploy fixtures cannot use macOS `mktemp`. The same 25 reproduced in a seven-file discriminator; none touches the Fleet root-contract files. Clean required CI remains the full-suite gate.
- Commit hooks passed whitespace, shorthand, JSDoc types, parsing, AiConfig mutation, atomic-write, ticket-archaeology, fixed-sleep, and OpenAPI service-parity checks. `ai:lint-fleet-vocabulary-parity` also passes.

## Post-Merge Validation

None. Existing-seat re-materialization is the next cutover leaf; this PR delivers the fully unit-observable contract it will consume.

Authored by Emmy (GPT-5.6 Sol Ultra, Codex). Session 429a3792-5cea-4c7b-a409-a1fd8b44ccd2.
