### PR TITLE
fix(mcp-client): close transport after failed initialization (#17719)

### DIFF
--- a/ai/mcp/client/Client.mjs
+++ b/ai/mcp/client/Client.mjs
@@ -285,13 +285,20 @@ class Client extends Base {
     }
 
     /**
-     * Closes the connection.
+     * @summary Closes the current transport and clears connection truth before awaiting teardown.
+     *
+     * Clearing `connected` first keeps a teardown rejection from leaving a client that still claims
+     * it is usable. Transport ownership remains with this instance even when initialization never
+     * reaches the caller-facing ready state.
      * @returns {Promise<void>}
      */
     async close() {
-        if (this.transport) {
-            await this.transport.close();
-            this.connected = false;
+        const transport = this.transport;
+
+        this.connected = false;
+
+        if (transport) {
+            await transport.close()
         }
     }
 
@@ -303,6 +310,15 @@ class Client extends Base {
         super.destroy();
     }
 
+    /**
+     * @summary Initializes one MCP connection and releases any transport opened by a failed attempt.
+     *
+     * `Neo.core.Base#ready()` remains the one-shot external wait contract and deliberately has no
+     * rejection channel. A connection failure therefore still rethrows into the owner process's
+     * error policy, but it must not strand the SDK transport merely because readiness never returns
+     * the instance to its caller. Cleanup failure is logged without masking the original init error.
+     * @returns {Promise<void>}
+     */
     async initAsync() {
         const me = this;
 
@@ -335,28 +351,38 @@ class Client extends Base {
         });
 
         // 3. Connect the client and create tool proxies
-        me.transport = me.createTransport();
+        try {
+            me.transport = me.createTransport();
 
-        me.client = new McpSdkClient({
-            name   : me.clientName,
-            version: me.clientVersion
-        }, {
-            capabilities: {}
-        });
+            me.client = new McpSdkClient({
+                name   : me.clientName,
+                version: me.clientVersion
+            }, {
+                capabilities: {}
+            });
 
-        await me.client.connect(me.transport);
-        me.connected = true;
+            await me.client.connect(me.transport);
+            me.connected = true;
 
-        // Fetch tools and create dynamic proxies
-        const tools = await me.listTools();
-        me.tools = {};
-        tools.forEach(tool => {
-            const camelCaseName = Neo.snakeToCamel(tool.name);
-            // console.log(`[MCP Client] Creating tool proxy: ${tool.name} -> ${camelCaseName}`); // Debug log (Commented out for production)
-            me.tools[camelCaseName] = async (args) => {
-                return me.callTool(tool.name, args);
-            };
-        });
+            // Fetch tools and create dynamic proxies
+            const tools = await me.listTools();
+            me.tools = {};
+            tools.forEach(tool => {
+                const camelCaseName = Neo.snakeToCamel(tool.name);
+                // console.log(`[MCP Client] Creating tool proxy: ${tool.name} -> ${camelCaseName}`); // Debug log (Commented out for production)
+                me.tools[camelCaseName] = async (args) => {
+                    return me.callTool(tool.name, args);
+                };
+            })
+        } catch (error) {
+            try {
+                await me.close()
+            } catch (closeError) {
+                console.error('MCP Client: Error closing transport after initialization failure:', closeError)
+            }
+
+            throw error
+        }
     }
 
     /**

--- a/test/playwright/unit/ai/mcp/client/McpClientTransportConfig.spec.mjs
+++ b/test/playwright/unit/ai/mcp/client/McpClientTransportConfig.spec.mjs
@@ -202,6 +202,24 @@ test.describe('Neo.ai.mcp.client.Client transport config', () => {
         client.destroy();
     });
 
+    test('#17719 close clears connection truth even when transport teardown rejects', async () => {
+        const client = Neo.create(TransportConfigClient);
+
+        client.connected = true;
+        client.transport = {
+            async close() {
+                throw new Error('transport close rejected')
+            }
+        };
+
+        await expect(client.close()).rejects.toThrow('transport close rejected');
+        expect(client.connected).toBe(false);
+
+        // Prevent destroy() from re-driving the deliberately rejecting fixture transport.
+        client.transport = null;
+        client.destroy()
+    });
+
     test('resolves remote Bearer auth without mutating shared client config', () => {
         const
             serverName = addServerConfig({

--- a/test/playwright/unit/ai/scripts/lifecycle/nightlyE2eRunner.spec.mjs
+++ b/test/playwright/unit/ai/scripts/lifecycle/nightlyE2eRunner.spec.mjs
@@ -17,6 +17,7 @@ import {test, expect} from '@playwright/test';
 import fs             from 'fs-extra';
 import os             from 'node:os';
 import path           from 'node:path';
+import {spawnSync}    from 'node:child_process';
 import Neo            from '../../../../../../src/Neo.mjs';
 import * as core      from '../../../../../../src/core/_export.mjs';
 
@@ -80,8 +81,8 @@ test.describe('nightlyE2eRunner.runNightlyE2e — delivery disposition and wake 
     let runNightlyE2e, cwd, tmpDir;
 
     const
-        stateFile  = () => path.join(tmpDir, '.neo-ai-data/nightly-e2e/last-run.json'),
-        readState  = async () => fs.readJson(stateFile()),
+        stateFile = () => path.join(tmpDir, '.neo-ai-data/nightly-e2e/last-run.json'),
+        readState = async () => fs.readJson(stateFile()),
         // One seam replaces the former addMessage/graphReady/lifecycleReady trio: the runner reaches
         // Memory Core as an MCP client, so "could not connect" and "the call was rejected"
         // are distinct failures without separate readiness hooks. The stub carries `callTool` rather
@@ -329,14 +330,120 @@ test.describe('nightlyE2eRunner.runNightlyE2e — delivery disposition and wake 
         expect(await fs.pathExists(path.join(tmpDir, '.neo-ai-data/nightly-e2e/runner.lock'))).toBe(false)
     });
 
-    // A production-shaped arm for a REJECTED (not missing) credential lived here and was removed on
-    // purpose. Its evidence is real and is in the PR body as a reproducible command: against the live
-    // ingress the runner catches the 401, writes `digest: 'failed'` with the server's text, releases
-    // the lock, and exits non-zero. It cannot live in THIS suite, because a playwright worker outlives
-    // the run: the client whose readiness never completed is never returned and never closed, and its
-    // transport rejects again after the run finished. The arm therefore failed on the worker's
-    // lifetime rather than on the runner's behaviour — red for the wrong reason, which is exactly what
-    // an arm must never be. The abandoned-transport leak is real and separately owned.
+    test('#17719 a PRESENT-BUT-REJECTED credential closes its Client transport in a long-lived process', () => {
+        // This arm used to live in-process and was removed because the Playwright worker outlived the
+        // run: Client readiness failed before the instance could be returned, nobody closed the opened
+        // transport, and its late rejection failed the worker AFTER every runner assertion passed.
+        // A child process gives that exact production path its own rejection policy while deliberately
+        // staying alive after the run, so transport ownership and the runner receipt are both observable.
+        const
+            neoUrl    = new URL('../../../../../../src/Neo.mjs', import.meta.url).href,
+            coreUrl   = new URL('../../../../../../src/core/_export.mjs', import.meta.url).href,
+            clientUrl = new URL('../../../../../../ai/mcp/client/Client.mjs', import.meta.url).href,
+            runnerUrl = new URL('../../../../../../ai/scripts/lifecycle/nightlyE2eRunner.mjs', import.meta.url).href,
+            stateDir  = path.join(tmpDir, 'rejected-credential-plane'),
+            probe     = `
+                import http from 'node:http';
+                import fs   from 'node:fs/promises';
+                import path from 'node:path';
+
+                await import(${JSON.stringify(neoUrl)});
+                await import(${JSON.stringify(coreUrl)});
+
+                const
+                    {default: Client}   = await import(${JSON.stringify(clientUrl)}),
+                    {runNightlyE2e}     = await import(${JSON.stringify(runnerUrl)}),
+                    stateDir            = ${JSON.stringify(stateDir)},
+                    unhandled           = [],
+                    rejectingServer     = http.createServer((request, response) => {
+                        request.resume();
+                        response.writeHead(401, {'content-type': 'application/json'});
+                        response.end(JSON.stringify({error: 'invalid_token', error_description: 'credential rejected by intake probe'}));
+                    });
+
+                process.on('unhandledRejection', error => unhandled.push(String(error?.message ?? error)));
+
+                await new Promise(resolve => rejectingServer.listen(0, '127.0.0.1', resolve));
+
+                const endpoint = 'http://127.0.0.1:' + rejectingServer.address().port + '/mcp';
+                let client, closeCalls = 0, caught = null;
+
+                const connect = () => {
+                    client = Neo.create(Client, {
+                        connectionConfig: {
+                            transportType   : 'streamable-http',
+                            url             : endpoint,
+                            transportOptions: {requestInit: {headers: {Authorization: 'Bearer rejected'}}}
+                        },
+                        serverName: 'rejected-credential-probe'
+                    });
+
+                    const originalClose = client.close.bind(client);
+                    client.close = async () => {
+                        closeCalls++;
+                        await originalClose();
+                        throw new Error('instrumented close failure after transport close')
+                    };
+
+                    return client.ready()
+                };
+
+                try {
+                    await runNightlyE2e({
+                        connect,
+                        connectDeadlineMs: 1000,
+                        stateDir,
+                        runOne: entry => ({
+                            config  : entry.config,
+                            failures: [{title: 'probe red', file: 'probe.spec.mjs', error: 'boom'}],
+                            note    : '',
+                            output  : '',
+                            ran     : true
+                        })
+                    })
+                } catch (error) {
+                    caught = String(error?.message ?? error)
+                }
+
+                // The process intentionally outlives the run. Any transport rejection after the
+                // runner removed its scoped sink is now observable instead of being hidden by exit.
+                await new Promise(resolve => setTimeout(resolve, 500));
+
+                const
+                    receipt = JSON.parse(await fs.readFile(path.join(stateDir, 'last-run.json'), 'utf8')),
+                    lock    = await fs.stat(path.join(stateDir, 'runner.lock')).then(() => true, () => false),
+                    result  = {
+                        caught,
+                        closeCalls,
+                        connected: client?.connected,
+                        digest   : receipt.digest,
+                        lock,
+                        unhandled
+                    };
+
+                rejectingServer.closeAllConnections?.();
+                await new Promise(resolve => rejectingServer.close(resolve));
+                process.stdout.write(JSON.stringify(result));
+            `,
+            result = spawnSync(process.execPath, ['--input-type=module', '--eval', probe], {
+                cwd     : tmpDir,
+                encoding: 'utf8',
+                timeout : 10000
+            });
+
+        expect(result.status, result.stderr).toBe(0);
+        expect(result.stderr).toContain('Error closing transport after initialization failure');
+        expect(result.stderr).toContain('instrumented close failure after transport close');
+
+        const observation = JSON.parse(result.stdout);
+
+        expect(observation.caught).toContain('invalid_token');
+        expect(observation.closeCalls, 'failed init must close the transport without a returned handle').toBe(1);
+        expect(observation.connected).toBe(false);
+        expect(observation.digest).toBe('failed');
+        expect(observation.lock).toBe(false);
+        expect(observation.unhandled).toHaveLength(1)
+    });
 
     test('#17708 a MISSING credential fails loudly on the default transport, never silently', async () => {
         // The production context that no other arm reaches. Every test above injects `connect`, and an


### PR DESCRIPTION
Resolves #17719

An MCP client now closes the SDK transport it opened whenever connection or tool discovery fails, even though `Neo.create()` never returns the half-initialized instance. Teardown cannot leave `connected` claiming success, and a cleanup failure is logged without replacing the original initialization error. The production-shaped present-but-rejected credential arm removed by PR #17715 is restored in a deliberately long-lived child process.

Related: #15031 · Found via: PR #17715 / #17714

Evidence: L2 (real SDK Streamable HTTP transport against a hermetic rejecting endpoint in a spawned long-lived process, plus owning unit controls) → L2 required (all six close-target ACs are unit-observable lifecycle contracts). No residuals.

## AC Evidence

| AC-1 | The restored `nightlyE2eRunner.spec.mjs` arm creates the real `Client` through `Neo.create()`, returns only `ready()`, and observes the client-owned close exactly once after the endpoint rejects the credential. |
| AC-2 | The child stays alive for 500 ms after the run-scoped rejection sink is removed; transport close remains exactly once and no second late transport rejection appears. |
| AC-3 | `Client#initAsync()` explicitly retains `Base#ready()` as a one-shot resolve-only contract. This is accepted under #15031, whose rejection-path AC sanctions an explicit owner-process error surface for `ai/scripts/lifecycle/*` consumers instead of a generic Base lifecycle replay. |
| AC-4 | No engine contract changes. `nightlyE2eRunner` keeps its sanctioned run-scoped error surface; `kbPushClient.mjs` is unchanged. The runner's late-rejection branch remains as a regression detector even though the repaired transport should no longer reach it. |
| AC-5 | RED-first: before the `Client` repair, the restored long-lived arm failed on `closeCalls` with expected 1 / received 0; after the repair, it observes one close, `connected: false`, and no late second rejection. |
| AC-6 | The present-but-rejected credential arm displaced by PR #17715 is restored. It also proves the runner writes `digest: "failed"`, releases its lock, and preserves the original `invalid_token` failure when post-close instrumentation throws. |

## Deltas from ticket

Live authority in #15031 is stronger than the ticket's initial "consumer-side workaround" framing: it names the `ready()` hang, directs maintainers to `ai/scripts/lifecycle/*`, and sanctions keeping an explicit error surface. This PR therefore leaves `Base.mjs` and the runner sink intact. `Client#close()` clears connection truth before awaiting teardown; a client that failed before transport creation remains a no-op teardown; and initialization cleanup logs its own failure while rethrowing the original cause.

## Test Evidence

- RED-first lifecycle mutation: reverting client-owned cleanup changes the restored arm from `closeCalls: 1` to `closeCalls: 0` without moving the failure into runner assertions.
- Live local invalid-token probe after the repair: `closeCalls: 1`, transport created, `connected: false`, `isReady: false`; the remaining single unhandled rejection is the deliberately retained Base/owner-process error surface, not a later transport straggler.
- The local full-unit attempt reached 14,964 passes but was not a clean gate: 27 unrelated environment/baseline cases failed and 63 did not run. None is in the three changed files; clean required CI remains the full-suite gate.
- Commit hooks passed whitespace, shorthand, JSDoc, parse, fixed-sleep, archaeology, and AgentOS preflight checks. All owning coverage runs in CI.

## Post-Merge Validation

None. The lifecycle contract and long-lived-process failure mode are fully observable before merge.

Authored by Emmy (GPT-5.6 Sol Ultra, Codex). Session 429a3792-5cea-4c7b-a409-a1fd8b44ccd2.
