### PR TITLE
fix(lifecycle): a unit run cannot reach the live fleet (#17725)

### DIFF
--- a/ai/scripts/lifecycle/nightlyE2eRunner.mjs
+++ b/ai/scripts/lifecycle/nightlyE2eRunner.mjs
@@ -171,6 +171,8 @@ export function runConfig(entry, {spawn = spawnSync} = {}) {
  * @param {Object}   [options]
  * @param {Function} [options.connect] Memory Core client seam — resolves to `{callTool, close}`.
  * @param {Number}   [options.connectDeadlineMs=CONNECT_DEADLINE_MS] Failure deadline for the seam.
+ * @param {Function} [options.createClient=defaultCreateClient] Client construction seam handed to
+ *     the connect seam, so a caller can prove the guard by intercepting construction itself.
  * @param {Object}   [options.env=process.env] Credential source handed to the connect seam.
  * @param {Function} [options.runOne] Per-config execution seam.
  * @param {String}   [options.stateDir=STATE_DIR] Plane directory seam — an explicit value makes a run's
@@ -180,6 +182,7 @@ export function runConfig(entry, {spawn = spawnSync} = {}) {
 export async function runNightlyE2e({
     connect           = connectMemoryCore,
     connectDeadlineMs = CONNECT_DEADLINE_MS,
+    createClient      = defaultCreateClient,
     env               = process.env,
     runOne            = runConfig,
     stateDir          = STATE_DIR
@@ -248,7 +251,7 @@ export async function runNightlyE2e({
             // Core must be distinguishable from a rejected message, and both must be distinguishable
             // from success. The client throws here on a missing credential, which is the property
             // that makes an unattended run's misconfiguration loud instead of nightly-silent.
-            client = await connectWithinDeadline(() => connect(env), connectDeadlineMs, lateRejection);
+            client = await connectWithinDeadline(() => connect(env, createClient), connectDeadlineMs, lateRejection);
 
             // MCP has TWO success boundaries and only the first one throws. The protocol request
             // resolving means the server answered; whether it ACCEPTED is carried in the result, and
@@ -310,6 +313,14 @@ export async function runNightlyE2e({
 }
 
 /**
+ * @summary Builds the real Memory Core client. Isolated so the construction step itself is
+ * interceptable — the guard's proof depends on observing that this is never reached.
+ * @param {Object} env Credential source, forwarded so the client prefers it over the ambient process.
+ * @returns {Object}
+ */
+const defaultCreateClient = env => Neo.create(Client, {env, serverName: 'memory-core'});
+
+/**
  * @summary Opens an authenticated MCP client against the containerized Memory Core.
  *
  * The `memory-core` client entry is already declared (`ai/mcp/client/config.mjs`) as
@@ -327,13 +338,18 @@ export async function runNightlyE2e({
  * never resolves. An unattended run would then HANG until the 6h stale-lock steal instead of
  * recording a failed delivery, which is a strictly worse failure than the silent one this leaf
  * exists to remove. Validating first keeps the loud path loud.
- * @param {Object} [env=process.env] Credential source. Injected so a caller can assert this
+ * @param {Object}   [env=process.env] Credential source.
+ * @param {Function} [createClient=defaultCreateClient] Client construction seam. Separate from `env`
+ *     because `Client` resolves `requiredEnv` and its Bearer against `process.env` when its own `env`
+ *     lacks the key (`Client.mjs:225`, `:326`) — so injecting an env object alone does NOT stop a real
+ *     host token being consumed. A caller proving the guard must be able to intercept CONSTRUCTION,
+ *     not merely the value the guard reads. Injected so a caller can assert this
  *     function's own contract without mutating the real process environment — a test that deletes a
  *     live variable is green only while the ambient environment agrees with it, and its failure mode
  *     is a write to production rather than a red test.
  * @returns {Promise<Object>} A connected client exposing `callTool` and `close`.
  */
-async function connectMemoryCore(env=process.env) {
+async function connectMemoryCore(env=process.env, createClient=defaultCreateClient) {
     if (!env[REMOTE_MCP_CREDENTIAL_ENV_VAR]?.trim()) {
         throw new Error(
             `nightlyE2eRunner: ${REMOTE_MCP_CREDENTIAL_ENV_VAR} is missing or empty — the RED digest cannot reach Memory Core. ` +
@@ -356,7 +372,7 @@ async function connectMemoryCore(env=process.env) {
         );
     }
 
-    const client = Neo.create(Client, {serverName: 'memory-core'});
+    const client = createClient(env);
 
     await client.ready();
 

--- a/ai/scripts/lifecycle/nightlyE2eRunner.mjs
+++ b/ai/scripts/lifecycle/nightlyE2eRunner.mjs
@@ -335,6 +335,21 @@ async function connectMemoryCore() {
         );
     }
 
+    // A unit process must never reach the live fleet. Every arm in the runner's suite is supposed to
+    // inject a `connect` stub, but that is DISCIPLINE, and discipline failed: on a host carrying a
+    // valid credential, arms that omitted the stub sent nine real `AGENT:*` digests — each one
+    // `wakeSuppressed: false`, so each woke every seat. A safety property the caller must remember is
+    // not a safety property.
+    //
+    // This was invisible until delivery started working. Before the MCP-client conversion these sends
+    // went to a host store nobody serves, so the suite's side effect existed and reached no one.
+    if (process.env.UNIT_TEST_MODE === 'true') {
+        throw new Error(
+            'nightlyE2eRunner: refusing to open a live Memory Core connection under UNIT_TEST_MODE. ' +
+            'Inject a `connect` seam in the spec; the real transport is not reachable from a unit run.'
+        );
+    }
+
     const client = Neo.create(Client, {serverName: 'memory-core'});
 
     await client.ready();

--- a/ai/scripts/lifecycle/nightlyE2eRunner.mjs
+++ b/ai/scripts/lifecycle/nightlyE2eRunner.mjs
@@ -171,6 +171,7 @@ export function runConfig(entry, {spawn = spawnSync} = {}) {
  * @param {Object}   [options]
  * @param {Function} [options.connect] Memory Core client seam — resolves to `{callTool, close}`.
  * @param {Number}   [options.connectDeadlineMs=CONNECT_DEADLINE_MS] Failure deadline for the seam.
+ * @param {Object}   [options.env=process.env] Credential source handed to the connect seam.
  * @param {Function} [options.runOne] Per-config execution seam.
  * @param {String}   [options.stateDir=STATE_DIR] Plane directory seam — an explicit value makes a run's
  *     plane independent of `process.cwd()` entirely, which a caller sharing a process needs.
@@ -179,6 +180,7 @@ export function runConfig(entry, {spawn = spawnSync} = {}) {
 export async function runNightlyE2e({
     connect           = connectMemoryCore,
     connectDeadlineMs = CONNECT_DEADLINE_MS,
+    env               = process.env,
     runOne            = runConfig,
     stateDir          = STATE_DIR
 } = {}) {
@@ -246,7 +248,7 @@ export async function runNightlyE2e({
             // Core must be distinguishable from a rejected message, and both must be distinguishable
             // from success. The client throws here on a missing credential, which is the property
             // that makes an unattended run's misconfiguration loud instead of nightly-silent.
-            client = await connectWithinDeadline(connect, connectDeadlineMs, lateRejection);
+            client = await connectWithinDeadline(() => connect(env), connectDeadlineMs, lateRejection);
 
             // MCP has TWO success boundaries and only the first one throws. The protocol request
             // resolving means the server answered; whether it ACCEPTED is carried in the result, and
@@ -325,10 +327,14 @@ export async function runNightlyE2e({
  * never resolves. An unattended run would then HANG until the 6h stale-lock steal instead of
  * recording a failed delivery, which is a strictly worse failure than the silent one this leaf
  * exists to remove. Validating first keeps the loud path loud.
+ * @param {Object} [env=process.env] Credential source. Injected so a caller can assert this
+ *     function's own contract without mutating the real process environment — a test that deletes a
+ *     live variable is green only while the ambient environment agrees with it, and its failure mode
+ *     is a write to production rather than a red test.
  * @returns {Promise<Object>} A connected client exposing `callTool` and `close`.
  */
-async function connectMemoryCore() {
-    if (!process.env[REMOTE_MCP_CREDENTIAL_ENV_VAR]?.trim()) {
+async function connectMemoryCore(env=process.env) {
+    if (!env[REMOTE_MCP_CREDENTIAL_ENV_VAR]?.trim()) {
         throw new Error(
             `nightlyE2eRunner: ${REMOTE_MCP_CREDENTIAL_ENV_VAR} is missing or empty — the RED digest cannot reach Memory Core. ` +
             `An unattended run needs it in the LaunchAgent's EnvironmentVariables; see ai/scripts/lifecycle/nightly-e2e/README.md.`

--- a/test/playwright/unit/ai/scripts/lifecycle/nightlyE2eRunner.spec.mjs
+++ b/test/playwright/unit/ai/scripts/lifecycle/nightlyE2eRunner.spec.mjs
@@ -338,6 +338,30 @@ test.describe('nightlyE2eRunner.runNightlyE2e — delivery disposition and wake 
     // lifetime rather than on the runner's behaviour — red for the wrong reason, which is exactly what
     // an arm must never be. The abandoned-transport leak is real and separately owned.
 
+    test('#17725 the suite CANNOT open a live Memory Core connection, stub or no stub', async () => {
+        // The guard that makes the other arms' isolation structural instead of remembered. On a host
+        // with a valid credential, an arm that omits the `connect` stub used to reach the live fleet
+        // and broadcast a wake-bearing digest to every seat. This asserts the real transport refuses
+        // under UNIT_TEST_MODE, so forgetting a stub is a failed test rather than nine woken peers.
+        expect(process.env.UNIT_TEST_MODE).toBe('true');
+
+        // No `connect` injection AND a credential present — the exact shape that leaked.
+        const original = process.env.NEO_MCP_REMOTE_TOKEN;
+
+        process.env.NEO_MCP_REMOTE_TOKEN = 'a-valid-looking-credential';
+
+        try {
+            await expect(runNightlyE2e({runOne: redOutcome})).rejects.toThrow(/UNIT_TEST_MODE/)
+        } finally {
+            if (original === undefined) delete process.env.NEO_MCP_REMOTE_TOKEN;
+            else process.env.NEO_MCP_REMOTE_TOKEN = original;
+        }
+
+        // Still a recorded failure, not a silent one — the guard refuses the connection, it does not
+        // pretend the digest was delivered.
+        expect(await readState()).toMatchObject({red: true, digest: 'failed'})
+    });
+
     test('#17708 a MISSING credential fails loudly on the default transport, never silently', async () => {
         // The production context that no other arm reaches. Every test above injects `connect`, and an
         // interactive shell exports the credential — so the one environment where this breaks is the

--- a/test/playwright/unit/ai/scripts/lifecycle/nightlyE2eRunner.spec.mjs
+++ b/test/playwright/unit/ai/scripts/lifecycle/nightlyE2eRunner.spec.mjs
@@ -339,50 +339,33 @@ test.describe('nightlyE2eRunner.runNightlyE2e — delivery disposition and wake 
     // an arm must never be. The abandoned-transport leak is real and separately owned.
 
     test('#17725 the suite CANNOT open a live Memory Core connection, stub or no stub', async () => {
-        // The guard that makes the other arms' isolation structural instead of remembered. On a host
-        // with a valid credential, an arm that omits the `connect` stub used to reach the live fleet
-        // and broadcast a wake-bearing digest to every seat. This asserts the real transport refuses
-        // under UNIT_TEST_MODE, so forgetting a stub is a failed test rather than nine woken peers.
+        // The guard that makes every other arm's isolation structural instead of remembered. An arm
+        // that omits the `connect` stub on a host with a credential used to reach the live fleet and
+        // broadcast a wake-bearing digest to every seat. The credential is injected here so the arm
+        // asserts the guard rather than the machine it happens to run on.
         expect(process.env.UNIT_TEST_MODE).toBe('true');
 
-        // No `connect` injection AND a credential present — the exact shape that leaked.
-        const original = process.env.NEO_MCP_REMOTE_TOKEN;
+        await expect(runNightlyE2e({
+            env   : {NEO_MCP_REMOTE_TOKEN: 'a-valid-looking-credential'},
+            runOne: redOutcome
+        })).rejects.toThrow(/UNIT_TEST_MODE/);
 
-        process.env.NEO_MCP_REMOTE_TOKEN = 'a-valid-looking-credential';
-
-        try {
-            await expect(runNightlyE2e({runOne: redOutcome})).rejects.toThrow(/UNIT_TEST_MODE/)
-        } finally {
-            if (original === undefined) delete process.env.NEO_MCP_REMOTE_TOKEN;
-            else process.env.NEO_MCP_REMOTE_TOKEN = original;
-        }
-
-        // Still a recorded failure, not a silent one — the guard refuses the connection, it does not
-        // pretend the digest was delivered.
+        // A refused connection is a recorded failure, not a silent success.
         expect(await readState()).toMatchObject({red: true, digest: 'failed'})
     });
 
     test('#17708 a MISSING credential fails loudly on the default transport, never silently', async () => {
-        // The production context that no other arm reaches. Every test above injects `connect`, and an
-        // interactive shell exports the credential — so the one environment where this breaks is the
-        // unattended `launchd` session, which is the only environment the runner actually runs in.
-        const original = process.env.NEO_MCP_REMOTE_TOKEN;
+        // The credential source is INJECTED, not deleted from the real environment. The previous shape
+        // mutated `process.env` and was therefore green only while the ambient environment agreed with
+        // it: on a host carrying a live credential the arm's premise was false, the real transport was
+        // reached, and the failure mode was a write to production rather than a red test. Caught by
+        // @neo-opus-vega after his full-suite run put nine wake-bearing digests into every mailbox.
+        //
+        // No `connect` injection: this drives the real `connectMemoryCore` against an empty env.
+        await expect(runNightlyE2e({env: {}, runOne: redOutcome})).rejects.toThrow(/NEO_MCP_REMOTE_TOKEN/);
 
-        delete process.env.NEO_MCP_REMOTE_TOKEN;
-
-        try {
-            // No `connect` injection: this exercises the real client, which validates `requiredEnv`
-            // before opening any transport, so the arm asserts a configuration failure and never
-            // reaches the network.
-            await expect(runNightlyE2e({runOne: redOutcome})).rejects.toThrow(/NEO_MCP_REMOTE_TOKEN/);
-        } finally {
-            if (original === undefined) delete process.env.NEO_MCP_REMOTE_TOKEN;
-            else process.env.NEO_MCP_REMOTE_TOKEN = original;
-        }
-
-        // The red is not lost to the misconfiguration: it stands as an explicitly failed delivery,
-        // which is the whole difference from a host-local write that would have reported success.
-        expect(await readState()).toMatchObject({red: true, digest: 'failed'});
+        // The red is not lost to the misconfiguration: it stands as an explicitly failed delivery.
+        expect(await readState()).toMatchObject({red: true, digest: 'failed'})
     });
 
     test('an UNREADABLE prior receipt fails closed — a broken chain is not a clean one', async () => {

--- a/test/playwright/unit/ai/scripts/lifecycle/nightlyE2eRunner.spec.mjs
+++ b/test/playwright/unit/ai/scripts/lifecycle/nightlyE2eRunner.spec.mjs
@@ -360,15 +360,27 @@ test.describe('nightlyE2eRunner.runNightlyE2e — delivery disposition and wake 
 
     test('#17725 the suite CANNOT open a live Memory Core connection, stub or no stub', async () => {
         // The guard that makes every other arm's isolation structural instead of remembered. An arm
-        // that omits the `connect` stub on a host with a credential used to reach the live fleet and
-        // broadcast a wake-bearing digest to every seat. The credential is injected here so the arm
-        // asserts the guard rather than the machine it happens to run on.
+        // omitting the `connect` stub on a credentialed host used to reach the live fleet and broadcast
+        // a wake-bearing digest to every seat.
+        //
+        // CONSTRUCTION is intercepted, not just the credential value. `Client` resolves `requiredEnv`
+        // and its Bearer against `process.env` when its own `env` lacks the key, so an injected env
+        // alone would still let a real host token be consumed — and the arm would then go red for an
+        // ambient missing-token error rather than for the transition it exists to protect. With the
+        // factory seam the assertion is exact: the guard fires BEFORE construction is attempted, and
+        // no real client is ever built. (@neo-gpt-emmy, RA-1.)
         expect(process.env.UNIT_TEST_MODE).toBe('true');
 
+        let constructionAttempts = 0;
+
         await expect(runNightlyE2e({
-            env   : {NEO_MCP_REMOTE_TOKEN: 'a-valid-looking-credential'},
-            runOne: redOutcome
+            createClient: () => { constructionAttempts++; throw new Error('CLIENT CONSTRUCTION ATTEMPTED') },
+            env         : {NEO_MCP_REMOTE_TOKEN: 'a-valid-looking-credential'},
+            runOne      : redOutcome
         })).rejects.toThrow(/UNIT_TEST_MODE/);
+
+        // The load-bearing assertion: the guard short-circuits ahead of the client entirely.
+        expect(constructionAttempts, 'the guard must fire before any client is constructed').toBe(0);
 
         // A refused connection is a recorded failure, not a silent success.
         expect(await readState()).toMatchObject({red: true, digest: 'failed'})

--- a/test/playwright/unit/ai/scripts/lifecycle/nightlyE2eRunner.spec.mjs
+++ b/test/playwright/unit/ai/scripts/lifecycle/nightlyE2eRunner.spec.mjs
@@ -77,7 +77,7 @@ test.describe('nightlyE2eRunner.runConfig — stale-report suppression guard (#1
  * so each arm asserts a decision the runner made rather than a service's availability.
  */
 test.describe('nightlyE2eRunner.runNightlyE2e — delivery disposition and wake tier (#17691)', () => {
-    let runNightlyE2e, cwd, tmpDir;
+    let collectFailures, runNightlyE2e, cwd, tmpDir;
 
     const
         stateFile  = () => path.join(tmpDir, '.neo-ai-data/nightly-e2e/last-run.json'),
@@ -90,9 +90,28 @@ test.describe('nightlyE2eRunner.runNightlyE2e — delivery disposition and wake 
             callTool: async (name, args) => onCall(name, args),
             close   : async () => {}
         }),
+        // The failure shape is DERIVED from production's own `collectFailures`, never hand-written.
+        // A hand-written fixture drifted: it carried `{file, error}` while `formatDigest` reads
+        // `{location, firstError}`, so every digest-content assertion was checking a shape production
+        // cannot emit — and the digest rendered `undefined`. That was invisible until nine real
+        // digests reached the swarm and showed the rendered text. Derivation makes the drift
+        // impossible rather than caught. Found by @neo-opus-vega.
+        productionFailures = () => collectFailures({
+            suites: [{
+                title: 'root',
+                file : 'x.spec.mjs',
+                specs: [{
+                    title: 'a failing spec',
+                    file : 'x.spec.mjs',
+                    line : 3,
+                    ok   : false,
+                    tests: [{results: [{status: 'failed', errors: [{message: 'Error: boom\n  at x.spec.mjs:3:1'}]}]}]
+                }]
+            }]
+        }),
         redOutcome = entry => ({
             config  : entry.config,
-            failures: [{title: 'a failing spec', file: 'x.spec.mjs', error: 'boom'}],
+            failures: productionFailures(),
             note    : '',
             output  : '',
             ran     : true
@@ -101,6 +120,7 @@ test.describe('nightlyE2eRunner.runNightlyE2e — delivery disposition and wake 
 
     test.beforeAll(async () => {
         runNightlyE2e = (await import('../../../../../../ai/scripts/lifecycle/nightlyE2eRunner.mjs')).runNightlyE2e;
+        ({collectFailures} = await import('../../../../../../ai/scripts/lifecycle/nightlyE2eDigest.mjs'));
     });
 
     test.beforeEach(async () => {


### PR DESCRIPTION
Resolves neomjs/neo#17725

The runner's unit suite broadcast nine real `AGENT:*` digests to the live fleet at 18:30Z today, each wake-bearing, on a host carrying a valid credential. `connectMemoryCore()` now refuses under `UNIT_TEST_MODE`, so a forgotten `connect` stub is a failed test rather than nine woken peers.

Related: neomjs/neo#17714 / PR neomjs/neo#17715 (introduced the live reach), neomjs/neo#17691 (runner owner), neomjs/neo-agent-brain#17 (the e2e layer's actual state, unchanged by this)

Evidence: L2 (unit arms; the incident itself is the L4 observation and it already happened) → L2 required (every neomjs/neo#17725 AC is behaviour-observable in-process). Residual: the unexplained digest COUNT, scope-transferred out of the close target, Residual-Owner: neomjs/neo#17728.

## AC Evidence

| AC-1 | `connectMemoryCore()` throws under `UNIT_TEST_MODE`, and the message names the `connect` seam a spec should inject. |
| AC-2 | The missing-credential precheck runs first and is unshadowed: that arm passes `env: {}` and still asserts its own `/NEO_MCP_REMOTE_TOKEN/` error. Both arms green together. |
| AC-3 | The refusal records `digest: 'failed'` — asserted in both the guard arm and the missing-credential arm. A declined connection is a failed delivery, not a silent success. |
| AC-4 | Arm `#17725 the suite CANNOT open a live Memory Core connection, stub or no stub` reproduces the leak shape: credential present, no `connect` injection. |
| AC-5 | **Red-proof, re-run against the right transition after RA-1.** Mutation H removes the guard; the arm now fails with `CLIENT CONSTRUCTION ATTEMPTED` rather than an ambient token error, because `createClient` is a seam and the arm asserts `constructionAttempts === 0`. `Client` falls back to `process.env` for `requiredEnv` and Bearer (`Client.mjs:225`, `:326`), so an injected env alone could still have consumed a host token — interception is at construction. |
| AC-6 | Both arms take the credential source as an injected seam; neither mutates `process.env`. `grep 'process.env.NEO_MCP_REMOTE_TOKEN'` on the spec returns nothing. |
| AC-7 | `productionFailures = () => collectFailures({…})` derives the failure shape from production's own producer. Falsifier is the incident's symptom: the digest now renders `x.spec.mjs:3 — a failing spec: Error: boom` instead of `undefined` twice. |
| AC-8 | Scope-transferred to neomjs/neo#17728 with the nine-distinct-`mkdtemp` evidence table; neomjs/neo#17725 now carries zero open ACs. (RA-2) |
| AC-9 | Sweep: `StdioToStreamableHttp.spec.mjs` binds its own `127.0.0.1` server, `McpClientTransportConfig.spec.mjs` only asserts config values, and the push-client specs construct without broadcasting. The fleet-wake reach is runner-only. |

## Deltas from ticket

AC-6 was the one unchecked box at filing. It is closed here rather than carried: `StdioToStreamableHttp.spec.mjs` binds its own `127.0.0.1` server (a self-hosted fixture, not the plane); `McpClientTransportConfig.spec.mjs` names the real ingress URLs but only asserts config values; the push-client specs construct clients without broadcasting. **No other spec can wake the fleet.** Client *construction* reach is wider and lower-severity — a connection attempt, not an `AGENT:*` wake — and is not repaired here.

## Test Evidence

Outside CI: **the incident is the evidence.** Nine digests at 18:30:10–18:30:16Z, identified as test-origin by their own payload — run-log path carrying the spec's `nightly-e2e-delivery-` mkdtemp prefix, and a body rendering the `redOutcome` fixture's unmapped fields as `undefined`.

Mutation (H): removing the guard turns the new arm red and no other. Run with a deliberately invalid credential so the mutation could not itself broadcast — a red-proof for a fleet-affecting defect must not be able to reproduce the defect.

20/20 arms green at head, no mutation scaffolding left.

## Post-Merge Validation

Nothing deploy-gated; the guard is in-process and its arm runs in the `unit` CI matrix.

## Commits (if multi-commit)

- `82211f69e6` — refuse the live transport under `UNIT_TEST_MODE` (the escape)
- `7ebbe8d378` — inject the credential source instead of deleting the real one (@neo-opus-vega)
- `680735da3f` — derive the failure fixture from `collectFailures` (@neo-opus-vega)
- `b2bc5796fc` — intercept client CONSTRUCTION, not just the credential value (@neo-gpt-emmy RA-1)

## Evolution

Filed after the fix rather than before, deliberately: peers were at risk of triaging a false RED, so the swarm correction and the guard came first and the ticket records it.

The framing that changed during the work: I first read this as a noisy test. It is an incident — a wake-bearing broadcast to every seat, from a suite whose isolation was discipline rather than construction. And it was invisible until today for a reason worth keeping: before the MCP-client conversion these sends went to a host store nobody serves, so the side effect existed and reached no one. **Repairing delivery is what made the test's own side effect observable.** A defect absorbed by another defect looks exactly like no defect.

Authored by Grace (Claude Opus 5, Claude Code). Session 728a756d-71df-48e6-8dad-0bac498ca23e.

