### PR TITLE
fix(build): the sync pipeline refuses to publish confidential content (#17730)

### DIFF
--- a/.github/workflows/data-sync-pipeline.yml
+++ b/.github/workflows/data-sync-pipeline.yml
@@ -112,10 +112,16 @@ jobs:
       # `DATA_SYNC_READER_TOKEN` is passed under its own name rather than as `GITHUB_TOKEN`: the
       # scoping function strips `GITHUB_TOKEN`/`GH_TOKEN` from every child by design, so a token
       # arriving under either of those names would be discarded before any stage could read it.
+      # `NEO_CONFIDENTIAL_TERMS` is the #17730 publication guard's denylist. It is supplied as a secret
+      # rather than committed, because this repository is public and a guard carrying the names it
+      # protects publishes exactly what it withholds. An UNSET secret renders as an empty string, which
+      # the guard reads as the explicit policy "there are no terms to guard" — so populating it is an
+      # operator action, and until it is populated the guard admits everything.
       - name: Run bounded Data Sync emission and publish
         env:
           DATA_SYNC_PUBLISHER_TOKEN: ${{ steps.publisher-token.outputs.token }}
           DATA_SYNC_READER_TOKEN: ${{ github.token }}
+          NEO_CONFIDENTIAL_TERMS: ${{ secrets.NEO_CONFIDENTIAL_TERMS }}
         run: node ./buildScripts/dataSyncPipeline.mjs
       - name: Push Data to neomjs/pages
         env:

--- a/buildScripts/dataSyncPipeline.mjs
+++ b/buildScripts/dataSyncPipeline.mjs
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 
 import {spawn}                from 'node:child_process';
+import {readFile}      from 'node:fs/promises';
 import path                   from 'node:path';
 import process                from 'node:process';
 import {fileURLToPath}        from 'node:url';
@@ -269,6 +270,117 @@ export function isGeneratedDataPath(filePath) {
         || filePath === 'apps/portal/llms.txt'
         || filePath.startsWith('apps/portal/resources/data/')
         || filePath.startsWith('resources/content/')
+}
+
+/**
+ * Environment variable carrying the confidential-term denylist, comma-separated.
+ *
+ * The list lives OUT of the tree on purpose: this repository is public, and a guard that commits the
+ * names it protects publishes exactly what it exists to withhold. An ABSENT variable is a
+ * configuration failure, never an empty list — see {@link readConfidentialTerms}.
+ * @type {String}
+ */
+export const CONFIDENTIAL_TERMS_ENV_VAR = 'NEO_CONFIDENTIAL_TERMS';
+
+/**
+ * @summary Reads the confidential-term denylist, distinguishing "explicitly none" from "unconfigured".
+ *
+ * An empty string is a VALID policy — a deployment with no client names to protect states so. An
+ * absent variable is not that statement; it is nobody having made one, and treating the two alike is
+ * how a guard silently protects nothing. Absence therefore throws.
+ * @param {Object} [env=process.env] Environment source.
+ * @returns {String[]} Lower-cased terms, possibly empty.
+ * @throws {Error} When the variable is absent entirely.
+ */
+export function readConfidentialTerms(env = process.env) {
+    const raw = env[CONFIDENTIAL_TERMS_ENV_VAR];
+
+    if (raw === undefined) {
+        throw new Error(
+            `Data Sync: ${CONFIDENTIAL_TERMS_ENV_VAR} is not set. A publication run must state its ` +
+            `confidentiality policy — set it to an empty string to declare that there are no terms to guard.`
+        )
+    }
+
+    return raw.split(',').map(term => term.trim().toLowerCase()).filter(Boolean)
+}
+
+/**
+ * @summary Finds confidential terms used as PROSE, exempting identity forms by construction.
+ *
+ * The exemption is the whole difficulty. A client name also appears legitimately inside git identity
+ * — `someone@example.com` co-author trailers, `@handle` mentions of contributors — and those forms
+ * outnumbered the real leaks 2:1 in the census that motivated this guard. A denylist that fails on
+ * them fails the HOURLY sync forever, so it would be switched off within a day.
+ *
+ * One character of lookbehind separates the two populations exactly: an identity form is always
+ * introduced by `@`, and a prose reference never is. `mcp.example.net` (a private host, a real leak)
+ * is preceded by `.` and matches; `uhlig@example.com` and `@example` do not.
+ * @param {String}   content File contents.
+ * @param {String[]} terms Lower-cased denylist.
+ * @returns {Array<{line: Number, termIndex: Number}>} One entry per prose occurrence.
+ */
+export function findConfidentialProse(content, terms) {
+    const hits = [], lower = content.toLowerCase();
+
+    terms.forEach((term, termIndex) => {
+        let from = 0, at;
+
+        while ((at = lower.indexOf(term, from)) !== -1) {
+            from = at + term.length;
+
+            // `@` immediately before the match is an email local-part boundary or a handle sigil.
+            // Both are identity, not prose.
+            if (content[at - 1] === '@') continue;
+
+            hits.push({line: content.slice(0, at).split('\n').length, termIndex})
+        }
+    });
+
+    return hits
+}
+
+/**
+ * @summary Refuses to publish staged content carrying a confidential term.
+ *
+ * This GATES: it throws, the staging step fails, and the publication commit is never made. It
+ * deliberately does not sanitize — a pipeline that quietly rewrites content teaches nobody, and the
+ * author never learns their comment leaked into a tree that mirrors it within the hour.
+ *
+ * The message names the file, the line and WHICH rule fired, never the matched value: CI logs for a
+ * public repository are themselves a public artifact, so echoing the term would leak it into the
+ * record of the guard that caught it.
+ * @param {Object}   options
+ * @param {String}   options.cwd Repository root.
+ * @param {String[]} options.paths Repository-relative staged paths.
+ * @param {Function} options.readFile Reader accepting an absolute path, returning file text.
+ * @param {String[]} options.terms Lower-cased denylist.
+ * @returns {Promise<void>}
+ * @throws {Error} When any staged file carries a term in prose.
+ */
+async function assertNoConfidentialContent({cwd, paths, readFile, terms}) {
+    if (terms.length === 0) return;
+
+    const findings = [];
+
+    for (const filePath of paths) {
+        // A staged DELETION has no readable blob, and a removed leak is the outcome we want anyway.
+        const content = await readFile(path.join(cwd, filePath), 'utf8').catch(() => null);
+
+        if (content === null) continue;
+
+        for (const {line, termIndex} of findConfidentialProse(content, terms)) {
+            findings.push(`${filePath}:${line} (term #${termIndex + 1})`)
+        }
+    }
+
+    if (findings.length > 0) {
+        throw new Error(
+            `Data Sync refused to publish confidential content in ${findings.length} location(s): ` +
+            `${findings.join(', ')}. Sanitize the source artifact on GitHub, then let the next run ` +
+            `re-mirror it. The matched values are withheld deliberately — CI logs are public too.`
+        )
+    }
 }
 
 /**
@@ -685,14 +797,25 @@ export async function emitGeneratedData({
  * @returns {Promise<{attempts: Number, baseSha: String, changed: Boolean, pushed: Boolean}>}
  */
 export async function runDataSyncPipeline({
+    denylist,
     cwd         = process.cwd(),
     emit        = emitGeneratedData,
     execute     = executeCommand,
     log         = console.log,
-    maxAttempts = 2
+    maxAttempts = 2,
+    read        = readFile
 } = {}) {
     if (!Number.isInteger(maxAttempts) || maxAttempts < 1) {
         throw new TypeError('maxAttempts must be a positive integer')
+    }
+
+    // No default. A publication run states its confidentiality policy or does not run: a defaulted
+    // empty list is indistinguishable from a deliberate one, and the difference is the whole guard.
+    if (!Array.isArray(denylist)) {
+        throw new TypeError(
+            'denylist must be an array — a publication run states its confidentiality policy, it never ' +
+            'inherits one'
+        )
     }
 
     await git(execute, cwd, ['config', 'user.name', 'github-actions[bot]']);
@@ -757,6 +880,7 @@ export async function runDataSyncPipeline({
         const stagedPaths = await readStagedPaths(execute, cwd);
 
         assertGeneratedOnly(stagedPaths);
+        await assertNoConfidentialContent({cwd, paths: stagedPaths, readFile: read, terms: denylist});
         log(`[DataSync] staged attempt=${attempt}/${maxAttempts} files=${stagedPaths.length}`);
 
         currentSha = await fetchRemoteDev(execute, cwd);
@@ -865,7 +989,7 @@ const modulePath   = fileURLToPath(import.meta.url);
 const cliEntryPath = process.argv[1] ? path.resolve(process.argv[1]) : null;
 
 if (cliEntryPath === modulePath) {
-    runDataSyncPipeline().catch(error => {
+    runDataSyncPipeline({denylist: readConfidentialTerms()}).catch(error => {
         console.error(`[DataSync] ${error.message}`);
         process.exitCode = 1
     })

--- a/learn/agentos/process/correction-culture.md
+++ b/learn/agentos/process/correction-culture.md
@@ -78,6 +78,33 @@ claim, or add a second one to defend? A bound, falsifier, or provenance supports
 it costs fewer words than the retraction it prevents. Motivating instance, not causal proof: nine
 withdrawals in one afternoon (2026-08-07), the one artifact needing none already cut.
 
+## Correcting a public artifact: the window is one hour
+
+Correction culture assumes a correction can catch up with the mistake. On public GitHub artifacts it
+sometimes cannot, and the reason is mechanical rather than social.
+
+The Data Sync Pipeline mirrors issues, PRs and discussions into `resources/content/**` and commits
+that mirror to the public tree on an hourly schedule. So an artifact you publish is copied into git
+history within the hour, and **editing the artifact afterwards does not un-commit the copy.** The
+gap between publishing and the next run is the entire remediation budget — and nothing in the
+authoring moment tells you the clock is running.
+
+Two consequences worth holding:
+
+- **Speed matters more than it feels like it does.** For an ordinary wrong claim this is harmless:
+  the mirror carries a superseded statement, which is what history is for. For anything that must
+  not be public at all, the correction is a race, and after an hour it is no longer winnable by
+  editing.
+- **Therefore the fix is not "remediate faster", which is this document's rejected remedy in its
+  usual costume.** The mechanism is a publication guard that refuses to admit the content, and it
+  is why one exists on the staging path. Guarding beats hurrying, for the same reason mechanisms
+  beat promises everywhere else here.
+
+The mirror has one redeeming property, learned by damaging an artifact while sanitizing it: it is
+the only copy of pre-edit artifact text we hold. GitHub exposes no edit history through its API, so
+when an edit goes wrong the mirror is the recovery source — up to an hour stale, and better than
+nothing.
+
 ## The record
 
 Live instances from the day this was written (2026-07-25): Memory Core session

--- a/test/playwright/unit/ai/buildScripts/DataSyncPipeline.spec.mjs
+++ b/test/playwright/unit/ai/buildScripts/DataSyncPipeline.spec.mjs
@@ -10,8 +10,11 @@ import {CREDENTIAL_FAMILIES} from '../../../../../ai/services/fleet/redactCreden
 import {
     aggregateDeferredFailures,
     classifyStageFailure,
+    CONFIDENTIAL_TERMS_ENV_VAR,
     describeStageFailure,
     emitGeneratedData,
+    findConfidentialProse,
+    readConfidentialTerms,
     executeCommand,
     GENERATED_DATA_PATHS,
     isGeneratedDataPath,
@@ -140,8 +143,9 @@ test.describe('Data Sync pipeline publisher (#15746)', () => {
             let emissions = 0;
 
             const result = await runDataSyncPipeline({
-                cwd : fixture.runner,
-                emit: async ({attempt, cwd}) => {
+                denylist: [],
+                cwd     : fixture.runner,
+                emit    : async ({attempt, cwd}) => {
                     emissions++;
                     await write(cwd, generatedFile, `generated:v1:attempt-${attempt}\n`);
                     await write(cwd, 'resources/content/issues/chunk-10/issue-15977.md', '# Issue 15977\n');
@@ -192,8 +196,9 @@ test.describe('Data Sync pipeline publisher (#15746)', () => {
             let emissions = 0;
 
             const result = await runDataSyncPipeline({
-                cwd    : fixture.runner,
-                execute: async (command, args, options) => {
+                denylist: [],
+                cwd     : fixture.runner,
+                execute : async (command, args, options) => {
                     commands.push([command, ...args]);
                     return executeCommand(command, args, options)
                 },
@@ -232,8 +237,9 @@ test.describe('Data Sync pipeline publisher (#15746)', () => {
 
         try {
             await expect(runDataSyncPipeline({
-                cwd : fixture.runner,
-                emit: async ({attempt, cwd}) => {
+                denylist: [],
+                cwd     : fixture.runner,
+                emit    : async ({attempt, cwd}) => {
                     const source = (await fs.readFile(path.join(cwd, 'source.txt'), 'utf8')).trim();
 
                     await write(cwd, generatedFile, `generated:${source}:attempt-${attempt}\n`);
@@ -260,8 +266,9 @@ test.describe('Data Sync pipeline publisher (#15746)', () => {
             await write(fixture.runner, 'source.txt', 'manual-local-change\n');
 
             await runDataSyncPipeline({
-                cwd : fixture.runner,
-                emit: async ({cwd}) => {
+                denylist: [],
+                cwd     : fixture.runner,
+                emit    : async ({cwd}) => {
                     await write(cwd, generatedFile, 'generated:v1:allowlisted\n');
                     await write(cwd, 'source.txt', 'manual-emission-change\n')
                 },
@@ -541,8 +548,9 @@ test.describe('tokenScope validation fails closed', () => {
             const corpusFailure = new Error('discussion resource limit');
 
             await expect(runDataSyncPipeline({
-                cwd : fixture.runner,
-                emit: async ({cwd}) => {
+                denylist: [],
+                cwd     : fixture.runner,
+                emit    : async ({cwd}) => {
                     await write(cwd, generatedFile, 'generated:partial-progress\n');
                     return {deferredError: corpusFailure}
                 },
@@ -697,8 +705,9 @@ test.describe('a deferred stage failure cannot freeze corpus publication (#17148
 
         try {
             await expect(runDataSyncPipeline({
-                cwd : fixture.runner,
-                emit: async ({attempt, cwd, log}) => {
+                denylist: [],
+                cwd     : fixture.runner,
+                emit    : async ({attempt, cwd, log}) => {
                     await write(cwd, generatedFile, 'generated:corpus-despite-denial\n');
 
                     return emitGeneratedData({
@@ -912,4 +921,116 @@ test.describe('gitAuthenticated keeps the credential out of argv', () => {
         expect(seenEnv.PATH).toBe('/usr/bin');
         expect(seenEnv.GIT_CONFIG_VALUE_0).toContain(Buffer.from(`x-access-token:${secret}`).toString('base64'))
     });
+
+});
+
+// The mirror commits every issue/PR/discussion comment into this PUBLIC tree on the next hourly
+// run, so a leaked comment becomes a committed file within the hour and sanitizing the comment
+// afterwards does not un-commit it. The window between publishing a leak and the next run is the
+// entire remediation budget. These arms use a synthetic token exclusively — the guard's own tests
+// must never carry the values it exists to withhold.
+test.describe('confidential-content publication guard (#17730)', () => {
+    const TERM = 'zzsynthetictenantzz';
+
+    test('a staged file carrying a denylisted term fails the run, and nothing is published', async () => {
+        const fixture = await createRepositoryFixture();
+
+        try {
+            await expect(runDataSyncPipeline({
+                denylist: [TERM],
+                cwd     : fixture.runner,
+                emit    : async ({cwd}) => {
+                    await write(cwd, generatedFile, `# Issue\n\nThe ${TERM} plane is red.\n`)
+                },
+                log: () => {}
+            })).rejects.toThrow(/refused to publish confidential content/u);
+
+            // It GATES. A check whose result does not stop the publication is a log line.
+            expect(remoteSubjects(fixture)).toEqual(['initial'])
+        } finally {
+            await fs.rm(fixture.root, {recursive: true, force: true})
+        }
+    });
+
+    test('the failure names the file and WHICH rule fired, never the matched value', async () => {
+        const fixture = await createRepositoryFixture();
+
+        try {
+            let message = '';
+
+            await runDataSyncPipeline({
+                denylist: [TERM],
+                cwd     : fixture.runner,
+                emit    : async ({cwd}) => {
+                    await write(cwd, generatedFile, `# Issue\n\nline two\nThe ${TERM} plane is red.\n`)
+                },
+                log: () => {}
+            }).catch(error => { message = error.message });
+
+            expect(message).toContain(generatedFile);
+            expect(message).toContain(':4');
+            expect(message).toContain('term #1');
+
+            // CI logs for a public repository are themselves a public artifact. A guard that
+            // echoes the term leaks it into the record of catching it.
+            expect(message).not.toContain(TERM)
+        } finally {
+            await fs.rm(fixture.root, {recursive: true, force: true})
+        }
+    });
+
+    test('identity forms publish normally, so the hourly sync is not broken by trailers and handles', async () => {
+        const fixture = await createRepositoryFixture();
+
+        try {
+            const result = await runDataSyncPipeline({
+                denylist: [TERM],
+                cwd     : fixture.runner,
+                emit    : async ({cwd}) => {
+                    await write(cwd, generatedFile,
+                        `# Issue\n\nCo-Authored-By: A Person <person@${TERM}.com>\nThanks @${TERM}!\n`)
+                },
+                log: () => {}
+            });
+
+            // The census behind this ticket found identity forms outnumbering real leaks 2:1. A
+            // denylist that fails on them fails EVERY hourly run, and would be switched off in a day.
+            expect(result).toMatchObject({changed: true, pushed: true});
+            expect(remoteSubjects(fixture)).toEqual([
+                'chore(data): Hourly data sync pipeline update [skip ci]',
+                'initial'
+            ])
+        } finally {
+            await fs.rm(fixture.root, {recursive: true, force: true})
+        }
+    });
+
+    test('a publication run must state its policy — an inherited one is refused', async () => {
+        await expect(runDataSyncPipeline({cwd: '/repo'})).rejects.toThrow(/denylist must be an array/u)
+    });
+
+    test('an ABSENT denylist variable is a configuration failure, an empty one is a policy', () => {
+        expect(() => readConfidentialTerms({})).toThrow(new RegExp(CONFIDENTIAL_TERMS_ENV_VAR, 'u'));
+
+        // Explicitly none — a deployment with nothing to guard says so, and that is not the same
+        // statement as nobody having configured the guard at all.
+        expect(readConfidentialTerms({[CONFIDENTIAL_TERMS_ENV_VAR]: ''})).toEqual([]);
+        expect(readConfidentialTerms({[CONFIDENTIAL_TERMS_ENV_VAR]: ' Alpha , beta ,'})).toEqual(['alpha', 'beta'])
+    });
+
+    test('prose matches, identity forms do not — one character of lookbehind separates them', () => {
+        const terms = ['acme'];
+
+        expect(findConfidentialProse('the acme plane', terms)).toEqual([{line: 1, termIndex: 0}]);
+        expect(findConfidentialProse('acme-memory-core', terms)).toEqual([{line: 1, termIndex: 0}]);
+
+        // A private HOST is a real leak and is preceded by `.`, not `@`.
+        expect(findConfidentialProse('https://mcp.acme.net/x', terms)).toEqual([{line: 1, termIndex: 0}]);
+
+        expect(findConfidentialProse('uhlig@acme.com', terms)).toEqual([]);
+        expect(findConfidentialProse('thanks @acme for the fix', terms)).toEqual([]);
+
+        expect(findConfidentialProse('one\ntwo\nthe acme plane', terms)).toEqual([{line: 3, termIndex: 0}]);
+        expect(findConfidentialProse('ACME shipped', terms)).toEqual([{line: 1, termIndex: 0}])
+    })
 });


### PR DESCRIPTION
Resolves #17730

The Data Sync Pipeline's staging path now refuses to publish content carrying a denylisted term: it throws, the stage fails, and the publication commit is never made. It sits beside the existing path allowlist (`assertGeneratedOnly`) and shares its semantics deliberately — one is a gate on *which paths* may be published, this is a gate on *what they may contain*. It does not sanitize: a pipeline that quietly rewrites content teaches nobody, and the author never learns their comment leaked into a tree that mirrors it within the hour.

**The guard is inert until an operator populates `NEO_CONFIDENTIAL_TERMS`.** An unset repository secret renders as an empty string, which the guard reads as the explicit policy "there are no terms to guard" — so this PR ships the mechanism, and the list is an operator action. That is stated here rather than buried because a guard nobody populates looks exactly like a guard that works.

Evidence: L3 (a real git-repository fixture — the guard refuses a seeded publication and the local origin's history is verified unchanged) → L1 only for the workflow `env:` wiring, which no sandbox run can exercise. Residual: none — all eight ACs are delivered on this branch.

## AC Evidence
| AC-1 | `DataSyncPipeline.spec.mjs` — *a staged file carrying a denylisted term fails the run, and nothing is published*; asserts both the rejection and `remoteSubjects === ['initial']` |
| AC-2 | same spec — *the failure names the file and WHICH rule fired, never the matched value*; asserts the message contains the path, `:4` and `term #1`, and `.not.toContain(TERM)` |
| AC-3 | AC-1's arm is the gate proof: the assertion that survives is the *absence* of a publication commit, not the presence of a log line |
| AC-4 | denylist is sourced from `NEO_CONFIDENTIAL_TERMS`, never the tree; every arm uses the synthetic token `zzsynthetictenantzz`, and the pure arms use `acme` |
| AC-5 | same spec — *identity forms publish normally*, exercising `<person@TERM.com>` and `@TERM` in one file and asserting `{changed: true, pushed: true}`; plus the unit arm covering both shapes against a private host |
| AC-6 | the guard throws rather than skipping, so a false positive is a failed hourly run; `findConfidentialProse`'s JSDoc records why that cost forces the list to stay narrow |
| AC-7 | red-proof below |
| AC-8 | `learn/agentos/process/correction-culture.md` — new section *Correcting a public artifact: the window is one hour* |

## Deltas from ticket

**`denylist` is a required parameter with no default.** The ticket did not ask for this; #17728 did, an hour before this branch. There, a test seam injected by parameter *name* failed OPEN when the callee renamed the parameter — the injection was silently ignored, the production default took over, and a unit run wrote a waking broadcast to every peer's mailbox. A defaulted `[]` here would reproduce that class exactly: rename the option later and every caller silently reverts to "guard nothing". A required parameter fails closed under that rename. Cost is six existing call sites now stating `denylist: []`.

**Absent and empty are different states.** `readConfidentialTerms` throws when the variable is missing and returns `[]` when it is empty. "Nobody configured this" and "there is nothing to guard" are different statements, and conflating them is how a guard silently protects nothing.

**The identity-form exemption is one character of lookbehind, not a pattern list.** An identity form is always introduced by `@`; prose never is. So `<user@name.com>` and `@name` pass, while `name-memory-core` and `https://mcp.name.net/` — a private host, the leak shape that motivated this — still fail. The census behind the ticket found identity forms outnumbering real leaks 2:1, so a guard that trips on them fails every hourly run and is switched off within a day.

**Scanning covers all staged paths, not only `resources/content/**`.** Same cost, strictly larger coverage; the portal's derived JSON is mirrored from the same artifacts.

Substrate note: `correction-culture.md` is an ordinary process doc under `learn/agentos/`, not directly loaded per turn, so it carries in-doc lifecycle rationale rather than a slot-disposition block. It extends an existing document rather than adding a sixth.

## Test Evidence

**Red-proof (mutation).** Commenting out the single `assertNoConfidentialContent` call and running the suite: **2 failed, 42 passed**. The two reds are exactly the gate-firing arms, and both fail for the *right* reason rather than an adjacent one — `expect(received).rejects.toThrow()` because the run no longer rejects, and `expect(message).toContain(generatedFile)` because no error is produced. Notably the identity-form arm stays **green** under the mutation, which is correct and is the check that the arm is not accidentally passing because of the guard.

Guard restored, suite back to **44 passed**.

## Post-Merge Validation

Nothing is owed after merge, so there is no checklist here — deliberately, because both candidates fail the residual rule for the same reason and inventing owners for them would create exactly the dangling pointers that rule exists to prevent.

Populating the `NEO_CONFIDENTIAL_TERMS` secret is an operator action on a credential surface that no existing ticket owns; it is stated in the second paragraph, where a reader meets it before the diff rather than after. The first hourly run after merge exercising the added `env:` key is observation, not work: it happens whether or not anyone watches, and the workflow already fails loudly on a stage error.

## Commits
- `ed65cad303` — the guard, its wiring, and its arms
- `bbb4170e82` — the author-facing one-hour window note (AC-8)

Authored by Grace (Claude Opus 5, Claude Code). Session 728a756d-71df-48e6-8dad-0bac498ca23e.
