### PR TITLE
feat(ai): make ADR-0019 enforcement self-checking (#17481)

### DIFF
--- a/.github/workflows/config-template-ssot-lint.yml
+++ b/.github/workflows/config-template-ssot-lint.yml
@@ -14,6 +14,11 @@ on:
       # removal can be blessed by updating the record of what exists, with nothing re-reading reality.
       - 'ai/scripts/lint/config-leaf-parity.json'
       - 'ai/scripts/lint/lint-config-template-ssot.mjs'
+      # ADR-0019's catalog and its sibling executable rule objects are inputs to the two-way
+      # ownership verdict. A change to any one must run the checker on that same PR.
+      - 'learn/agentos/decisions/0019-aiconfig-reactive-provider-ssot.md'
+      - 'buildScripts/util/check-aiconfig-antipatterns.mjs'
+      - 'buildScripts/util/check-aiconfig-test-mutation.mjs'
       - '.github/workflows/config-template-ssot-lint.yml'
       # Compose templates are SCANNED by two rules — the Compose/default parity check and the
       # behavior-binding clock projection check (#17115) — so by the scanned ⊆ watched invariant
@@ -43,6 +48,11 @@ on:
       # removal can be blessed by updating the record of what exists, with nothing re-reading reality.
       - 'ai/scripts/lint/config-leaf-parity.json'
       - 'ai/scripts/lint/lint-config-template-ssot.mjs'
+      # ADR-0019's catalog and its sibling executable rule objects are inputs to the two-way
+      # ownership verdict. A change to any one must run the checker on that same push.
+      - 'learn/agentos/decisions/0019-aiconfig-reactive-provider-ssot.md'
+      - 'buildScripts/util/check-aiconfig-antipatterns.mjs'
+      - 'buildScripts/util/check-aiconfig-test-mutation.mjs'
       - '.github/workflows/config-template-ssot-lint.yml'
       # Compose templates are SCANNED by two rules — the Compose/default parity check and the
       # behavior-binding clock projection check (#17115) — so by the scanned ⊆ watched invariant

--- a/ai/scripts/lint/lint-config-template-ssot.mjs
+++ b/ai/scripts/lint/lint-config-template-ssot.mjs
@@ -47,6 +47,9 @@ import {fileURLToPath, pathToFileURL} from 'node:url';
 import {parse}            from 'acorn';
 import {load as loadYaml} from 'js-yaml';
 
+import {ADR_0019_RULES as ANTIPATTERN_ADR_RULES}   from '../../../buildScripts/util/check-aiconfig-antipatterns.mjs';
+import {ADR_0019_RULES as TEST_MUTATION_ADR_RULES} from '../../../buildScripts/util/check-aiconfig-test-mutation.mjs';
+
 const __filename = fileURLToPath(import.meta.url);
 const __dirname  = path.dirname(__filename);
 const ROOT_DIR   = path.resolve(__dirname, '../../..');
@@ -63,6 +66,9 @@ const SCAN_ROOT_REL                   = 'ai';
 const TEST_SCAN_ROOT_REL              = 'test';
 const DEPLOY_SCAN_ROOT_REL            = 'ai/deploy';
 const SELF_REL_FILE                   = 'ai/scripts/lint/lint-config-template-ssot.mjs';
+const ADR_0019_REL_FILE               = 'learn/agentos/decisions/0019-aiconfig-reactive-provider-ssot.md';
+const ANTIPATTERN_GUARD_REL_FILE      = 'buildScripts/util/check-aiconfig-antipatterns.mjs';
+const TEST_MUTATION_GUARD_REL_FILE    = 'buildScripts/util/check-aiconfig-test-mutation.mjs';
 
 // The workflow-parity SSOT: every glob a path-filtered workflow must watch for this lint's
 // verdict to stay reproducible at PR time (scanned ⊆ watched as a mechanical fact, not YAML
@@ -76,7 +82,13 @@ export const SCAN_SURFACE = Object.freeze([
     // sibling parity spec DEMAND the workflow watch it; leaving it undeclared would let the spec
     // report a satisfied invariant over an incomplete picture of what this lint actually reads —
     // the same shape as the unprojected clock these rules exist to catch, one layer up.
-    `${DEPLOY_SCAN_ROOT_REL}/**`
+    `${DEPLOY_SCAN_ROOT_REL}/**`,
+    // The AiConfig catalog and both sibling guard declarations are verdict inputs for the
+    // tag-to-executable-rule ownership check. If any changes without this lint running, the
+    // two-way contract can drift on the exact commit that introduced the disagreement.
+    ADR_0019_REL_FILE,
+    ANTIPATTERN_GUARD_REL_FILE,
+    TEST_MUTATION_GUARD_REL_FILE
 ]);
 const CONFIG_TEMPLATE_KIND_CACHE         = new Map();
 const SERVICE_EXPORT_CONFIG_TEMPLATE_REL = Object.freeze({
@@ -241,6 +253,53 @@ function shouldScanAiConfigImplementation(file) {
 }
 
 /**
+ * @summary The A4 catalog rule object consumed by the config-template scanner.
+ * @type {{id: String, detect: Function}}
+ */
+const INLINE_ENV_LEAF_RULE = Object.freeze({id: 'A4', detect: detectInlineEnvLeaves});
+
+/**
+ * @summary Executable implementation rules for direct AiConfig misuse.
+ *
+ * Catalog ids live on the same objects as their predicates. Descriptive ids cover additional
+ * SSOT failure shapes that the ADR decision sentence governs but its A/B/C catalog does not name;
+ * the ADR ownership validator deliberately projects only A/B/C ids.
+ * @type {ReadonlyArray<{id: String, kind: String, pattern: RegExp}>}
+ */
+export const AI_CONFIG_IMPLEMENTATION_RULES = Object.freeze([
+    Object.freeze({
+        id     : 'B1',
+        kind   : 'export',
+        pattern: /\bexport\s+(?:const|let|var)\s+[A-Za-z_$][\w$]*\s*=\s*AiConfig(?:\?\.|\.)/
+    }),
+    Object.freeze({
+        id     : 'B5',
+        kind   : 'config-pass-through',
+        pattern: /\b[A-Za-z_$][\w$]*Config[\w$]*\s*:\s*AiConfig(?:\?\.|\.)/
+    }),
+    Object.freeze({
+        id     : 'B5',
+        kind   : 'config-parameter-default',
+        pattern: /[({,]\s*[A-Za-z_$][\w$]*Config[\w$]*\s*=\s*AiConfig(?:\?\.|\.)/
+    }),
+    Object.freeze({
+        id     : 'B3',
+        kind   : 'defensive-optional-chain',
+        pattern: /\bAiConfig\?\.|\bAiConfig(?:\.[A-Za-z_$][\w$]*)+\?\./
+    }),
+    Object.freeze({
+        id     : 'TYPE-COERCION',
+        kind   : 'type-coercion',
+        pattern: /\b(?:Number|Boolean)\s*\(\s*AiConfig(?:\?\.|\.)/
+    }),
+    Object.freeze({
+        id     : 'HIDDEN-DEFAULT',
+        kind   : 'hidden-default',
+        pattern: /\bAiConfig(?:\?\.|\.[A-Za-z_$][\w$]*)[^;\n]*(?:\?\?|\|\|)/
+    })
+]);
+
+/**
  * @summary Detects single-line `leaf(...)` defaults that read `process.env` inline.
  *
  * Pure: operates on source text, so it is unit-testable without touching disk. Env access
@@ -288,30 +347,10 @@ export function detectAiConfigImplementationViolations(source) {
         if (trimmed.startsWith('//') || trimmed.startsWith('*') || trimmed.startsWith('/*') || trimmed.startsWith('*/')) return;
         if (!/\bAiConfig(?:\?\.|\.)/.test(trimmed)) return;
 
-        const push = kind => violations.push({line: index + 1, kind, text: trimmed});
-
-        if (/\bexport\s+(?:const|let|var)\s+[A-Za-z_$][\w$]*\s*=\s*AiConfig(?:\?\.|\.)/.test(trimmed)) {
-            push('export');
-        }
-
-        if (/\b[A-Za-z_$][\w$]*Config[\w$]*\s*:\s*AiConfig(?:\?\.|\.)/.test(trimmed)) {
-            push('config-pass-through');
-        }
-
-        if (/[({,]\s*[A-Za-z_$][\w$]*Config[\w$]*\s*=\s*AiConfig(?:\?\.|\.)/.test(trimmed)) {
-            push('config-parameter-default');
-        }
-
-        if (/\bAiConfig\?\.|\bAiConfig(?:\.[A-Za-z_$][\w$]*)+\?\./.test(trimmed)) {
-            push('defensive-optional-chain');
-        }
-
-        if (/\b(?:Number|Boolean)\s*\(\s*AiConfig(?:\?\.|\.)/.test(trimmed)) {
-            push('type-coercion');
-        }
-
-        if (/\bAiConfig(?:\?\.|\.[A-Za-z_$][\w$]*)[^;\n]*(?:\?\?|\|\|)/.test(trimmed)) {
-            push('hidden-default');
+        for (const rule of AI_CONFIG_IMPLEMENTATION_RULES) {
+            if (rule.pattern.test(trimmed)) {
+                violations.push({line: index + 1, kind: rule.kind, rule: rule.id, text: trimmed})
+            }
         }
     });
 
@@ -2093,6 +2132,348 @@ function stripStringsAndLineComment(line) {
 }
 
 /**
+ * @summary Collects environment names owned by `leaf(default, env, type)` declarations.
+ * @param {String} source Config source.
+ * @returns {Set<String>} Declared environment names.
+ */
+export function collectConfigEnvNamesFromSource(source) {
+    const names = new Set(),
+          ast   = parseModule(source);
+
+    walkAstScoped(ast, node => {
+        if (node.type !== 'CallExpression') return;
+
+        const isLeaf = node.callee?.type === 'Identifier' && node.callee.name === 'leaf' ||
+            node.callee?.type === 'MemberExpression' &&
+            !node.callee.computed && node.callee.property?.name === 'leaf';
+
+        if (!isLeaf) return;
+
+        const envArg = node.arguments?.[1];
+        if (envArg?.type === 'Literal' && typeof envArg.value === 'string' && envArg.value) {
+            names.add(envArg.value)
+        }
+    });
+
+    return names;
+}
+
+/**
+ * @summary Builds the repository-wide set of env names already bound by AiConfig leaves.
+ * @param {String} [rootDir] Repo root.
+ * @returns {Set<String>} Declared environment names.
+ */
+export function collectDeclaredAiConfigEnvNames(rootDir = ROOT_DIR) {
+    const names = new Set();
+
+    walkMjsFiles(path.join(rootDir, SCAN_ROOT_REL))
+        .filter(file => [CONFIG_BASE_BASENAME, CONFIG_TEMPLATE_BASENAME].includes(path.basename(file)))
+        .forEach(file => {
+            collectConfigEnvNamesFromSource(fs.readFileSync(file, 'utf8')).forEach(name => names.add(name))
+        });
+
+    return names;
+}
+
+/**
+ * @summary Classifies a source module as a thread entrypoint from executable ownership shape.
+ *
+ * A direct `process.argv[1]`/`import.meta.url` guard or an unguarded top-level `main()` call is a
+ * checkable execution boundary. File names are deliberately not authority: `Agent.mjs` and
+ * `runAgent.mjs` differ by behaviour, not by a reader deciding that one name sounds entry-like.
+ * @param {Object} options
+ * @param {String} options.source Module source.
+ * @param {Object} [options.ast] Parsed module.
+ * @returns {Boolean}
+ */
+export function isThreadEntrypoint({source, ast = parseModule(source)}) {
+    const callsMain = expression => {
+        if (!expression) return false;
+        if (expression.type === 'AwaitExpression' || expression.type === 'ChainExpression') {
+            return callsMain(expression.argument ?? expression.expression)
+        }
+        if (expression.type !== 'CallExpression') return false;
+        if (expression.callee?.type === 'Identifier' && expression.callee.name === 'main') return true;
+        return expression.callee?.type === 'MemberExpression' && callsMain(expression.callee.object)
+    };
+
+    for (const statement of ast.body) {
+        if (statement.type === 'ExpressionStatement' && callsMain(statement.expression)) return true;
+
+        if (statement.type === 'IfStatement') {
+            const condition = source.slice(statement.test.start, statement.test.end),
+                  hasArgv   = /process\s*\.\s*argv\s*\[\s*1\s*]/.test(condition),
+                  hasModule = /import\s*\.\s*meta\s*\.\s*url|fileURLToPath\s*\(\s*import\s*\.\s*meta\s*\.\s*url/.test(condition);
+
+            if (hasArgv && hasModule) return true;
+        }
+    }
+
+    return false;
+}
+
+/**
+ * @summary Collects `process.env.NAME` / `process.env['NAME']` references from an AST subtree.
+ * @param {Object} node AST subtree.
+ * @param {Set<String>} [out] Accumulator.
+ * @returns {Set<String>} Environment names.
+ */
+function collectProcessEnvNames(node, out = new Set()) {
+    if (!node || typeof node !== 'object') return out;
+
+    if (node.type === 'MemberExpression' && node.object?.type === 'MemberExpression' &&
+        node.object.object?.type === 'Identifier' && node.object.object.name === 'process' &&
+        !node.object.computed && node.object.property?.name === 'env'
+    ) {
+        const name = node.computed ? node.property?.value : node.property?.name;
+        if (typeof name === 'string' && name) out.add(name)
+    }
+
+    for (const [key, value] of Object.entries(node)) {
+        if (['loc', 'start', 'end', 'type'].includes(key)) continue;
+        if (Array.isArray(value)) {
+            value.forEach(child => collectProcessEnvNames(child, out));
+        } else {
+            collectProcessEnvNames(value, out)
+        }
+    }
+
+    return out;
+}
+
+/**
+ * @summary Detects C1's module-evaluated competing-resolver shape in non-entrypoint modules.
+ *
+ * Import location is intentionally irrelevant. The violation requires an exported module-scope
+ * value that re-reads an env name already owned by an AiConfig leaf; a bare `AiConfig` import
+ * therefore stays green while `DEFAULT_DB_PATH = process.env.NEO_DB_PATH || ...; export
+ * {DEFAULT_DB_PATH}` is red. An exported function that reads env only when invoked is not A1's
+ * module-evaluation shape and remains outside C1.
+ * @param {String} source Module source.
+ * @param {Object} options
+ * @param {Set<String>} options.configEnvNames Env names bound by AiConfig leaves.
+ * @param {Object} [options.ast] Parsed module.
+ * @returns {Array<{line: Number, kind: String, rule: String, binding: String, env: String, text: String}>}
+ */
+export function detectNonEntrypointConfigResolvers(
+    source,
+    {configEnvNames, ast = parseModule(source)} = {}
+) {
+    if (isThreadEntrypoint({source, ast})) return [];
+
+    const declarations = new Map(),
+          exported     = new Set(),
+          lines        = source.split('\n');
+
+    const recordDeclaration = declaration => {
+        if (declaration?.type === 'VariableDeclaration') {
+            declaration.declarations.forEach(item => {
+                if (item.id?.type === 'Identifier') declarations.set(item.id.name, item)
+            })
+        }
+    };
+
+    for (const statement of ast.body) {
+        if (statement.type === 'VariableDeclaration') {
+            recordDeclaration(statement)
+        }
+
+        if (statement.type !== 'ExportNamedDeclaration') continue;
+
+        recordDeclaration(statement.declaration);
+
+        if (statement.declaration?.type === 'VariableDeclaration') {
+            statement.declaration.declarations.forEach(item => {
+                if (item.id?.type === 'Identifier') exported.add(item.id.name)
+            })
+        }
+
+        statement.specifiers?.forEach(specifier => {
+            if (specifier.local?.name) exported.add(specifier.local.name)
+        })
+    }
+
+    const declaredNames = configEnvNames instanceof Set ? configEnvNames : new Set(),
+          violations    = [];
+
+    for (const binding of exported) {
+        const declaration = declarations.get(binding);
+        if (!declaration) continue;
+
+        const envNames = [...collectProcessEnvNames(declaration.init)]
+            .filter(name => declaredNames.has(name));
+
+        for (const env of envNames) {
+            const line = declaration.loc?.start?.line || 1;
+            violations.push({
+                line,
+                kind: 'competing-config-resolver',
+                rule: 'C1',
+                binding,
+                env,
+                text: lines[line - 1]?.trim() || ''
+            })
+        }
+    }
+
+    return violations;
+}
+
+const MODULE_SCOPE_CAPTURE_RULE = Object.freeze({id: 'B2', detect: detectModuleScopeAiConfigCaptures});
+const C1_RESOLVER_RULE          = Object.freeze({id: 'C1', detect: detectNonEntrypointConfigResolvers});
+const TEST_CONFIG_RULES         = Object.freeze([
+    Object.freeze({id: 'C3', detect: detectTestConfigOverlayImports}),
+    Object.freeze({id: 'B1', detect: detectTestConfigProviderExports})
+]);
+
+/**
+ * @summary AiConfig catalog rule objects executed by this guard.
+ * @type {ReadonlyArray<Object>}
+ */
+export const ADR_0019_RULES = Object.freeze([
+    INLINE_ENV_LEAF_RULE,
+    ...AI_CONFIG_IMPLEMENTATION_RULES.filter(rule => /^[A-C]\d+$/.test(rule.id)),
+    MODULE_SCOPE_CAPTURE_RULE,
+    C1_RESOLVER_RULE,
+    ...TEST_CONFIG_RULES
+]);
+
+/**
+ * @summary Builds the named guard registry consumed by the catalog's two-way ownership check.
+ * @param {Object} [options] Injectable rule arrays for mutation tests.
+ * @returns {Map<String,Set<String>>} Guard name to enforced catalog ids.
+ */
+export function createAdr0019GuardRegistry({
+    antipatternRules = ANTIPATTERN_ADR_RULES,
+    testMutationRules = TEST_MUTATION_ADR_RULES,
+    configSsotRules = ADR_0019_RULES
+} = {}) {
+    return new Map([
+        ['check-aiconfig-antipatterns', new Set(antipatternRules.map(rule => rule.id))],
+        ['check-aiconfig-test-mutation', new Set(testMutationRules.map(rule => rule.id))],
+        ['lint-config-template-ssot', new Set(configSsotRules.map(rule => rule.id))]
+    ])
+}
+
+/**
+ * @summary Parses the AiConfig catalog ids and machine-owned enforcement tags.
+ * @param {String} source ADR source.
+ * @returns {Array<{id: String, tag: String, guards: String[], unenforced: Boolean, line: Number}>}
+ */
+export function parseAdr0019CatalogRows(source) {
+    const rows  = [],
+          lines = source.split('\n');
+    let   inCatalog = false;
+
+    lines.forEach((line, index) => {
+        if (/^## 3\.\s/.test(line)) {
+            inCatalog = true;
+            return
+        }
+        if (inCatalog && /^### Group D\/E\b/.test(line)) {
+            inCatalog = false;
+            return
+        }
+        if (!inCatalog || !/^\|/.test(line)) return;
+
+        const cells = line.split(/(?<!\\)\|/);
+        if (cells.length < 5) return;
+
+        const id = cells[1].match(/\b([A-C]\d+)\b/)?.[1];
+        if (!id) return;
+
+        const tag          = cells[3].trim(),
+              guardedMatch = tag.match(/\[guarded:\s*([^\]]+)\]/),
+              unenforced   = /\[unenforced(?::[^\]]+)?\]/.test(tag),
+              guards       = guardedMatch
+                  ? guardedMatch[1].split(',').map(value => value.trim()).filter(Boolean)
+                  : [];
+
+        rows.push({id, tag, guards, unenforced, line: index + 1})
+    });
+
+    return rows;
+}
+
+/**
+ * @summary Validates the catalog's tag-to-executable-rule relation in both directions.
+ *
+ * A tagged guard must execute the named id (no overstatement), and every executable catalog id
+ * must name that guard in the ADR (no understatement). `[unenforced: reason]` is the explicit
+ * negative state; a live/proposed/file tag with neither state is rejected as unverifiable prose.
+ * @param {Object} options
+ * @param {String} options.adrSource ADR source.
+ * @param {Map<String,Set<String>>} [options.guardRegistry] Injectable guard registry.
+ * @returns {{rows: Object[], violations: Object[]}}
+ */
+export function validateAdr0019GuardOwnership({
+    adrSource,
+    guardRegistry = createAdr0019GuardRegistry()
+}) {
+    const rows       = parseAdr0019CatalogRows(adrSource),
+          rowsById   = new Map(),
+          violations = [];
+
+    for (const row of rows) {
+        if (rowsById.has(row.id)) {
+            violations.push({id: row.id, kind: 'duplicate-row', line: row.line});
+            continue;
+        }
+        rowsById.set(row.id, row);
+
+        if (row.guards.length === 0 && !row.unenforced) {
+            violations.push({id: row.id, kind: 'unverifiable-tag', line: row.line, tag: row.tag})
+        }
+
+        for (const guard of row.guards) {
+            const ids = guardRegistry.get(guard);
+            if (!ids) {
+                violations.push({id: row.id, guard, kind: 'unknown-guard', line: row.line});
+            } else if (!ids.has(row.id)) {
+                violations.push({id: row.id, guard, kind: 'overstates-enforcement', line: row.line})
+            }
+        }
+
+        if (row.unenforced) {
+            for (const [guard, ids] of guardRegistry) {
+                if (ids.has(row.id)) {
+                    violations.push({id: row.id, guard, kind: 'understates-enforcement', line: row.line})
+                }
+            }
+        }
+    }
+
+    for (const [guard, ids] of guardRegistry) {
+        for (const id of ids) {
+            const row = rowsById.get(id);
+            if (!row) {
+                violations.push({id, guard, kind: 'guard-id-missing-from-adr'});
+            } else if (!row.guards.includes(guard)) {
+                violations.push({id, guard, kind: 'understates-enforcement', line: row.line})
+            }
+        }
+    }
+
+    return {rows, violations};
+}
+
+/**
+ * @summary Reads the AiConfig decision catalog and applies two-way guard-ownership validation.
+ * @param {Object} [options]
+ * @param {String} [options.rootDir] Repo root.
+ * @param {String} [options.adrSource] Injected ADR source.
+ * @param {Map<String,Set<String>>} [options.guardRegistry] Injectable registry.
+ * @returns {{rows: Object[], violations: Object[]}}
+ */
+export function lintAdr0019GuardOwnership({
+    rootDir      = ROOT_DIR,
+    adrSource   = fs.readFileSync(path.join(rootDir, ADR_0019_REL_FILE), 'utf8'),
+    guardRegistry
+} = {}) {
+    return validateAdr0019GuardOwnership({adrSource, guardRegistry})
+}
+
+/**
  * @summary Core lint: scans config templates and partitions inline-env leaf defaults into
  * baselined, new (unbaselined), and stale-baseline sets.
  * @param {Object} [options]
@@ -2110,7 +2491,7 @@ export function lintConfigTemplateSsot({rootDir = ROOT_DIR, files, baseline = BA
     const violations = [];
 
     for (const {file, source} of records) {
-        for (const hit of detectInlineEnvLeaves(source)) {
+        for (const hit of INLINE_ENV_LEAF_RULE.detect(source)) {
             violations.push({file, ...hit});
         }
     }
@@ -2194,7 +2575,7 @@ export async function lintAiConfigModuleScopeCaptures({
 
         const configPathKindsByIdentifier = await buildConfigPathKindsByIdentifier({rootDir, file, source});
 
-        for (const hit of detectModuleScopeAiConfigCaptures(source, {configPathKindsByIdentifier})) {
+        for (const hit of MODULE_SCOPE_CAPTURE_RULE.detect(source, {configPathKindsByIdentifier})) {
             violations.push({file, ...hit});
         }
     }
@@ -2208,6 +2589,39 @@ export async function lintAiConfigModuleScopeCaptures({
         newViolations: violations.filter(v => !baselineKeys.has(keyOf(v))),
         staleBaseline: baseline.filter(b => !violationKeys.has(keyOf(b)))
     };
+}
+
+/**
+ * @summary Scans non-entrypoint modules for exported resolvers that compete with AiConfig leaves.
+ * @param {Object} [options]
+ * @param {String} [options.rootDir] Repo root.
+ * @param {Array<{file: String, source: String}>} [options.files] Injected implementation records.
+ * @param {Set<String>} [options.configEnvNames] Injected leaf-owned env set.
+ * @returns {{violations: Object[]}}
+ */
+export function lintNonEntrypointConfigResolvers({
+    rootDir       = ROOT_DIR,
+    files,
+    configEnvNames = collectDeclaredAiConfigEnvNames(rootDir)
+} = {}) {
+    const records = files || walkMjsFiles(path.join(rootDir, SCAN_ROOT_REL))
+        .map(abs => ({
+            file  : normalizeFile(path.relative(rootDir, abs)),
+            source: fs.readFileSync(abs, 'utf8')
+        }))
+        .filter(({file}) => shouldScanAiConfigImplementation(file));
+
+    const violations = [];
+
+    for (const {file, source} of records) {
+        if (!shouldScanAiConfigImplementation(file)) continue;
+
+        for (const hit of C1_RESOLVER_RULE.detect(source, {configEnvNames})) {
+            violations.push({file, ...hit})
+        }
+    }
+
+    return {violations};
 }
 
 /**
@@ -2229,10 +2643,12 @@ export function lintTestConfigAuthority({rootDir = ROOT_DIR, files} = {}) {
     for (const {file, source} of records) {
         const ast = parseModule(source);
 
-        violations.push(
-            ...detectTestConfigOverlayImports(source, {file, rootDir, ast}),
-            ...detectTestConfigProviderExports(source, {file, rootDir, ast})
-        );
+        TEST_CONFIG_RULES.forEach(rule => {
+            violations.push(...rule.detect(source, {file, rootDir, ast}).map(hit => ({
+                ...hit,
+                rule: rule.id
+            })))
+        })
     }
 
     return {violations};
@@ -2257,7 +2673,7 @@ const TEST_CONFIG_OVERLAY_FIX_HINT = 'Tests resolve committed config templates, 
 /**
  * @summary CLI wrapper. Returns an exit code (0 clean, 1 on new violations or stale baseline rows).
  * @param {Object} [options] Forwarded to {@link lintConfigTemplateSsot}.
- * @returns {{exitCode: Number, violations: Object[], newViolations: Object[], staleBaseline: Object[], testConfig: Object}}
+ * @returns {{exitCode: Number, violations: Object[], newViolations: Object[], staleBaseline: Object[], testConfig: Object, c1Resolvers: Object, adrOwnership: Object}}
  */
 export async function runLint(options = {}) {
     const {
@@ -2268,7 +2684,11 @@ export async function runLint(options = {}) {
               implementationBaseline = AI_CONFIG_IMPLEMENTATION_BASELINE,
               moduleScopeFiles,
               moduleScopeBaseline    = AI_CONFIG_MODULE_SCOPE_BASELINE,
-              testConfigFiles
+              testConfigFiles,
+              c1Files,
+              configEnvNames,
+              adrSource,
+              guardRegistry
           } = options,
           result               = lintConfigTemplateSsot({rootDir, files, baseline}),
           implementationResult = lintAiConfigImplementationSsot({
@@ -2281,7 +2701,13 @@ export async function runLint(options = {}) {
               files   : moduleScopeFiles,
               baseline: moduleScopeBaseline
           }),
+          c1Result = lintNonEntrypointConfigResolvers({
+              rootDir,
+              files: c1Files,
+              configEnvNames
+          }),
           testConfigResult = lintTestConfigAuthority({rootDir, files: testConfigFiles}),
+          adrOwnershipResult = lintAdr0019GuardOwnership({rootDir, adrSource, guardRegistry}),
           parityResult     = await detectConfigLeafParityViolations({rootDir}),
           composeDefaultViolations = await detectComposeDefaultRestatements({rootDir}),
           projectionViolations     = await detectUnprojectedBehaviorBindingClocks({rootDir}),
@@ -2290,7 +2716,9 @@ export async function runLint(options = {}) {
               implementationResult.staleBaseline.length > 0,
           hasModuleScopeFailures = moduleScopeResult.newViolations.length > 0 ||
               moduleScopeResult.staleBaseline.length > 0,
+          hasC1Failures = c1Result.violations.length > 0,
           hasTestConfigFailures = testConfigResult.violations.length > 0,
+          hasAdrOwnershipFailures = adrOwnershipResult.violations.length > 0,
           hasComposeDefaultFailures = composeDefaultViolations.length > 0,
           hasProjectionFailures     = projectionViolations.length > 0,
           hasParityFailures = Object.keys(parityResult.missing).length > 0 ||
@@ -2311,16 +2739,18 @@ export async function runLint(options = {}) {
     }
 
     if (newViolations.length === 0 && staleBaseline.length === 0 && !hasImplementationFailures &&
-        !hasModuleScopeFailures && !hasTestConfigFailures && !hasParityFailures &&
+        !hasModuleScopeFailures && !hasC1Failures && !hasTestConfigFailures && !hasAdrOwnershipFailures && !hasParityFailures &&
         !hasComposeDefaultFailures && !hasProjectionFailures
     ) {
-        console.log(`[lint-config-template-ssot] OK - ${violations.length} inline-env leaf default(s), ${implementationResult.violations.length} AiConfig implementation SSOT hit(s), ${moduleScopeResult.violations.length} module-scope AiConfig capture(s), ${testConfigResult.violations.length} test config-authority violation(s), all baselined or target-zero.`);
+        console.log(`[lint-config-template-ssot] OK - ${violations.length} inline-env leaf default(s), ${implementationResult.violations.length} AiConfig implementation SSOT hit(s), ${moduleScopeResult.violations.length} module-scope AiConfig capture(s), ${c1Result.violations.length} C1 competing resolver(s), ${testConfigResult.violations.length} test config-authority violation(s), ${adrOwnershipResult.violations.length} ADR ownership mismatch(es), all baselined or target-zero.`);
         return {
             exitCode: 0,
             ...result,
             implementation : implementationResult,
             moduleScope    : moduleScopeResult,
+            c1Resolvers    : c1Result,
             testConfig     : testConfigResult,
+            adrOwnership   : adrOwnershipResult,
             composeDefaults: {violations: composeDefaultViolations},
             projection     : {violations: projectionViolations}
         };
@@ -2389,6 +2819,17 @@ export async function runLint(options = {}) {
         console.error('');
     }
 
+    if (c1Result.violations.length > 0) {
+        console.error(`[lint-config-template-ssot] FAILED - ${c1Result.violations.length} non-entrypoint competing config resolver(s):\n`);
+
+        for (const v of c1Result.violations) {
+            console.error(`- ${v.file}:${v.line}  (${v.rule}/${v.env})`);
+            console.error(`    ${v.text}`);
+        }
+
+        console.error('\nRead the AiConfig leaf at the use site. A non-entrypoint must not export a second resolver for an env the leaf already owns (ADR 0019 C1).\n');
+    }
+
     if (testConfigResult.violations.length > 0) {
         console.error(`[lint-config-template-ssot] FAILED - ${testConfigResult.violations.length} test config-authority violation(s):\n`);
 
@@ -2400,12 +2841,24 @@ export async function runLint(options = {}) {
         console.error(`\n${TEST_CONFIG_OVERLAY_FIX_HINT}\n`);
     }
 
+    if (adrOwnershipResult.violations.length > 0) {
+        console.error(`[lint-config-template-ssot] FAILED - ${adrOwnershipResult.violations.length} ADR-0019 catalog ownership mismatch(es):\n`);
+
+        for (const v of adrOwnershipResult.violations) {
+            console.error(`- ${v.id}${v.guard ? ` / ${v.guard}` : ''}: ${v.kind}${v.line ? ` (ADR line ${v.line})` : ''}`)
+        }
+
+        console.error('\nEach §3 row must use `[guarded: <guard>]` for executable rule objects or `[unenforced: <reason>]`; declarations and tags must agree both ways.\n');
+    }
+
     return {
         exitCode: 1,
         ...result,
         implementation : implementationResult,
         moduleScope    : moduleScopeResult,
+        c1Resolvers    : c1Result,
         testConfig     : testConfigResult,
+        adrOwnership   : adrOwnershipResult,
         composeDefaults: {violations: composeDefaultViolations}
     };
 }
@@ -2420,6 +2873,8 @@ async function main() {
         console.log('(outside the BASELINE), when a BASELINE row no longer matches a violation,');
         console.log('when ai/ implementation code adds mechanical ADR-19 AiConfig SSOT violations,');
         console.log('when ai/ implementation code adds module-scope AiConfig leaf captures,');
+        console.log('when a non-entrypoint exports a competing resolver for an AiConfig-owned env,');
+        console.log('when ADR-0019 catalog tags disagree with executable guard rule objects,');
         console.log('when test code imports an ignored overlay / exports a config-template-derived authority,');
         console.log('when Compose restates a config default / derived-retired env,');
         console.log('or when a declared config path leaves a template surface without updating the snapshot.');

--- a/ai/scripts/lint/lint-config-template-ssot.mjs
+++ b/ai/scripts/lint/lint-config-template-ssot.mjs
@@ -47,9 +47,6 @@ import {fileURLToPath, pathToFileURL} from 'node:url';
 import {parse}            from 'acorn';
 import {load as loadYaml} from 'js-yaml';
 
-import {ADR_0019_RULES as ANTIPATTERN_ADR_RULES}   from '../../../buildScripts/util/check-aiconfig-antipatterns.mjs';
-import {ADR_0019_RULES as TEST_MUTATION_ADR_RULES} from '../../../buildScripts/util/check-aiconfig-test-mutation.mjs';
-
 const __filename = fileURLToPath(import.meta.url);
 const __dirname  = path.dirname(__filename);
 const ROOT_DIR   = path.resolve(__dirname, '../../..');
@@ -2339,18 +2336,86 @@ export const ADR_0019_RULES = Object.freeze([
 ]);
 
 /**
+ * @summary Reads catalog ids from an exported array of executable rule objects.
+ *
+ * A detached string array is deliberately rejected. Every element must be an object carrying both
+ * an `id` literal and the `pattern` or `detect` property the owning scanner invokes.
+ * @param {String} source Guard module source.
+ * @returns {String[]} Catalog ids in declaration order.
+ */
+export function collectCatalogRuleIdsFromSource(source) {
+    const ast = parseModule(source);
+
+    for (const statement of ast.body) {
+        const declaration = statement.type === 'ExportNamedDeclaration'
+                  ? statement.declaration
+                  : statement,
+              declarator = declaration?.type === 'VariableDeclaration'
+                  ? declaration.declarations.find(item => item.id?.name === 'ADR_0019_RULES')
+                  : null;
+
+        if (!declarator) continue;
+
+        const expression = declarator.init?.type === 'CallExpression' &&
+              declarator.init.callee?.type === 'MemberExpression' &&
+              declarator.init.callee.object?.name === 'Object' &&
+              declarator.init.callee.property?.name === 'freeze'
+            ? declarator.init.arguments[0]
+            : declarator.init;
+
+        if (expression?.type !== 'ArrayExpression') {
+            throw new Error('ADR_0019_RULES must be an exported array of executable rule objects')
+        }
+
+        return expression.elements.map(element => {
+            if (element?.type !== 'CallExpression' ||
+                element.callee?.type !== 'MemberExpression' ||
+                element.callee.object?.name !== 'Object' ||
+                element.callee.property?.name !== 'freeze' ||
+                element.arguments[0]?.type !== 'ObjectExpression'
+            ) {
+                throw new Error('ADR_0019_RULES entries must be Object.freeze({...}) rule objects')
+            }
+
+            const properties = element.arguments[0].properties,
+                  idProperty = properties.find(property => property.key?.name === 'id'),
+                  executable = properties.some(property => ['pattern', 'detect'].includes(property.key?.name));
+
+            if (idProperty?.value?.type !== 'Literal' || typeof idProperty.value.value !== 'string' || !executable) {
+                throw new Error('Each ADR_0019_RULES object requires a string id plus pattern/detect')
+            }
+
+            return idProperty.value.value
+        })
+    }
+
+    throw new Error('Guard source does not export ADR_0019_RULES')
+}
+
+/**
  * @summary Builds the named guard registry consumed by the catalog's two-way ownership check.
- * @param {Object} [options] Injectable rule arrays for mutation tests.
+ * @param {Object} [options] Injectable rule arrays/sources for mutation tests.
+ * @param {String} [options.rootDir] Repo root.
  * @returns {Map<String,Set<String>>} Guard name to enforced catalog ids.
  */
 export function createAdr0019GuardRegistry({
-    antipatternRules = ANTIPATTERN_ADR_RULES,
-    testMutationRules = TEST_MUTATION_ADR_RULES,
+    rootDir = ROOT_DIR,
+    antipatternRules,
+    antipatternSource = fs.readFileSync(path.join(rootDir, ANTIPATTERN_GUARD_REL_FILE), 'utf8'),
+    testMutationRules,
+    testMutationSource = fs.readFileSync(path.join(rootDir, TEST_MUTATION_GUARD_REL_FILE), 'utf8'),
     configSsotRules = ADR_0019_RULES
 } = {}) {
+    const antipatternIds = antipatternRules
+              ? antipatternRules.map(rule => rule.id)
+              : collectCatalogRuleIdsFromSource(antipatternSource),
+          testMutationIds = testMutationRules
+              ? testMutationRules.map(rule => rule.id)
+              : collectCatalogRuleIdsFromSource(testMutationSource);
+
     return new Map([
-        ['check-aiconfig-antipatterns', new Set(antipatternRules.map(rule => rule.id))],
-        ['check-aiconfig-test-mutation', new Set(testMutationRules.map(rule => rule.id))],
+        ['check-aiconfig-antipatterns', new Set(antipatternIds)],
+        ['check-aiconfig-test-mutation', new Set(testMutationIds)],
         ['lint-config-template-ssot', new Set(configSsotRules.map(rule => rule.id))]
     ])
 }

--- a/buildScripts/util/check-aiconfig-antipatterns.mjs
+++ b/buildScripts/util/check-aiconfig-antipatterns.mjs
@@ -121,6 +121,25 @@ export const PLANE_ROOT_REDERIVATION = /\bpath\.(?:join|resolve)\s*\(\s*__dirnam
  */
 export const PLANE_LITERAL_ASSIGNMENT = /(?:\b(?:const|let|var)\s+[\w$]+|[\w$]+\s*)=\s*['"`]\.neo-ai-data\//;
 
+/**
+ * @summary AiConfig catalog rules enforced by this guard, with each id attached to the
+ * executable predicate it names.
+ *
+ * This is deliberately not a detached `RULE_IDS` inventory. The scanner below consumes these
+ * exact objects, so changing a predicate or its catalog ownership is one edit rather than two
+ * independently-drifting claims.
+ * @type {ReadonlyArray<{id: String, pattern: RegExp, filePattern?: RegExp}>}
+ */
+export const ADR_0019_RULES = Object.freeze([
+    Object.freeze({id: 'B3', pattern: new RegExp(B3_DEFENSIVE_CHAIN.source, 'g')}),
+    Object.freeze({id: 'A5', pattern: new RegExp(A5_ENV_HELPER.source, 'g')}),
+    Object.freeze({
+        id         : 'A1',
+        filePattern: A1_IMPORT_GATE,
+        pattern    : new RegExp(A1_ENV_REDERIVATION.source, 'g')
+    })
+]);
+
 /*
  * Rule-scoped grandfathering: each rule carries its OWN set of repo-relative POSIX paths, so one
  * rule's existing-surface exemption can never widen another's — A5 keeps its zero-baseline ratchet
@@ -167,12 +186,12 @@ export const ALLOWLIST = Object.freeze({
     ])
 });
 
-const RULES = [
-    {id: 'B3', pattern: new RegExp(B3_DEFENSIVE_CHAIN.source, 'g')},
-    {id: 'A5', pattern: new RegExp(A5_ENV_HELPER.source, 'g')},
-    {id: 'PLANE-ROOT', pattern: new RegExp(PLANE_ROOT_REDERIVATION.source, 'g')},
-    {id: 'PLANE-LITERAL', pattern: new RegExp(PLANE_LITERAL_ASSIGNMENT.source, 'g')}
-];
+const A1_RULE = ADR_0019_RULES.find(rule => rule.id === 'A1');
+const RULES   = Object.freeze([
+    ...ADR_0019_RULES.filter(rule => rule !== A1_RULE),
+    Object.freeze({id: 'PLANE-ROOT',    pattern: new RegExp(PLANE_ROOT_REDERIVATION.source, 'g')}),
+    Object.freeze({id: 'PLANE-LITERAL', pattern: new RegExp(PLANE_LITERAL_ASSIGNMENT.source, 'g')})
+]);
 
 /**
  * @summary Scans file content for the A1 / A5 / B3 / PLANE-ROOT / PLANE-LITERAL antipatterns whose root token sits in code.
@@ -191,7 +210,7 @@ export function findAntipatterns(content) {
           hits          = [],
           a1Candidates  = [],
           codeOnlyLines = [],
-          a1Global      = new RegExp(A1_ENV_REDERIVATION.source, 'g');
+          a1Global      = new RegExp(A1_RULE.pattern.source, 'g');
 
     lines.forEach((line, index) => {
         // Mask + projection compute UNCONDITIONALLY — before the escape check. The mask no longer
@@ -243,13 +262,13 @@ export function findAntipatterns(content) {
         // whose env token lives inside a string or comment. On the projection, masked env tokens
         // are spaces — the regex simply cannot match them.
         for (const match of codeOnly.matchAll(a1Global)) {
-            a1Candidates.push({line: index + 1, rule: 'A1', text: line.trim()});
+            a1Candidates.push({line: index + 1, rule: A1_RULE.id, text: line.trim()});
             break
         }
     });
 
     // A1 is two-signal: candidates emit only when the file's CODE opens the import gate.
-    if (a1Candidates.length && A1_IMPORT_GATE.test(codeOnlyLines.join('\n'))) {
+    if (a1Candidates.length && A1_RULE.filePattern.test(codeOnlyLines.join('\n'))) {
         hits.push(...a1Candidates)
     }
 

--- a/buildScripts/util/check-aiconfig-test-mutation.mjs
+++ b/buildScripts/util/check-aiconfig-test-mutation.mjs
@@ -384,6 +384,21 @@ export function findCloneCaptures(content) {
 }
 
 /**
+ * @summary AiConfig catalog rules enforced by this guard, with each id attached to the
+ * executable detector the scanner invokes.
+ *
+ * The restore-capture detector is intentionally absent: it is a separate correctness class and
+ * does not claim an AiConfig catalog id. Keeping B4 on the detector object prevents a detached
+ * file-level id list from agreeing with comments while the executable rule changes underneath it.
+ * @type {ReadonlyArray<{id: String, detect: Function}>}
+ */
+export const ADR_0019_RULES = Object.freeze([
+    Object.freeze({id: 'B4', detect: findDbPathMutations})
+]);
+
+const B4_RULE = ADR_0019_RULES[0];
+
+/**
  * @summary Scans one file's content for both rules, applying the allowlist to Class-A only.
  *
  * The allowlist is scoped to Class-A and stays that way. Every entry justifies a DB-PATH mutation
@@ -404,7 +419,7 @@ export function findCloneCaptures(content) {
  */
 export function scanFileContent(file, content, {allowlist = ALLOWLIST} = {}) {
     return {
-        dbPathHits: allowlist.has(file) ? [] : findDbPathMutations(content),
+        dbPathHits: allowlist.has(file) ? [] : B4_RULE.detect(content),
         cloneHits : findCloneCaptures(content)
     }
 }

--- a/learn/agentos/decisions/0019-aiconfig-reactive-provider-ssot.md
+++ b/learn/agentos/decisions/0019-aiconfig-reactive-provider-ssot.md
@@ -45,33 +45,35 @@ A reviewer checks a config-touching diff against this list; the lint (sub #2) me
 ### Group A — re-implementing the Provider's resolution
 | ID | Antipattern | Tag | Sanctioned form |
 |---|---|---|---|
-| A1 | module-level re-derivation (`const DB_PATH = process.env.X \|\| path.join(...)`) | `[live: daemons :53-54/:36, deploy]` | read `AiConfig.X.Y` at the use site |
-| A2 | imperative cascade hooks (`afterApplyEnvLeaf`) | `[#12420-proposed]` | a `formula` (only if genuinely computed) or a plain leaf derivation |
-| A3 | over-engineered resolution helpers (`resolveAiDataRoot`) | `[#12420-proposed]` | the leaf's env-binding already resolves |
-| A4 | inline `process.env.UNIT_TEST_MODE ? test : prod` inside a leaf | `[live: #12451]` | declarative leaf; test-mode resolved by construction |
-| A5 | a `hasEnvValue(name)` helper | `[#12420-proposed]` | delete it — `leaf(default, env, type)` owns the env-check |
-| A6 | leaf+formula duplication (one path defined in both) | `[#12420-proposed]` | one definition — the leaf |
-| A7 | a formula re-implementing the leaf's env-resolution | `[#12420-proposed]` | drop the env knob (likely YAGNI) → `path.join(data.root, …)` |
-| A8 | `storagePaths.graph` 4-branch tangle (`:memory:` + two env vars, one read direct from `process.env`, + derive) | `[#12420-proposed]` | one leaf + one derivation; test-mode by construction |
-| A9 | `formulas` for plain path-joins | both | a leaf/derivation; formulas = reactive computed values only |
+| A1 | module-level re-derivation (`const DB_PATH = process.env.X \|\| path.join(...)`) | `[guarded: check-aiconfig-antipatterns]` — live debt is allowlisted there | read `AiConfig.X.Y` at the use site |
+| A2 | imperative cascade hooks (`afterApplyEnvLeaf`) | `[unenforced: #12420-proposed]` | a `formula` (only if genuinely computed) or a plain leaf derivation |
+| A3 | over-engineered resolution helpers (`resolveAiDataRoot`) | `[unenforced: #12420-proposed]` | the leaf's env-binding already resolves |
+| A4 | inline `process.env.UNIT_TEST_MODE ? test : prod` inside a leaf | `[guarded: lint-config-template-ssot]` | declarative leaf; test-mode resolved by construction |
+| A5 | a `hasEnvValue(name)` helper | `[guarded: check-aiconfig-antipatterns]` — zero-baseline reintroduction ratchet | delete it — `leaf(default, env, type)` owns the env-check |
+| A6 | leaf+formula duplication (one path defined in both) | `[unenforced: #12420-proposed]` | one definition — the leaf |
+| A7 | a formula re-implementing the leaf's env-resolution | `[unenforced: #12420-proposed]` | drop the env knob (likely YAGNI) → `path.join(data.root, …)` |
+| A8 | `storagePaths.graph` 4-branch tangle (`:memory:` + two env vars, one read direct from `process.env`, + derive) | `[unenforced: #12420-proposed]` | one leaf + one derivation; test-mode by construction |
+| A9 | `formulas` for plain path-joins | `[unenforced: mixed live/proposed debt]` | a leaf/derivation; formulas = reactive computed values only |
 
 ### Group B — indirection AROUND the SSOT (even when reading it)
 | ID | Antipattern | Tag | Sanctioned form |
 |---|---|---|---|
-| B1 | exporting config values/subtrees (`export const X = AiConfig.Y`) | `[live: TaskDefinitions.mjs]` | consumers import `AiConfig` and read at use site |
-| B2 | `const X = AiConfig.Y` pointers | review-only | read inline — alias only if used 3+ times in one scope |
-| B3 | defensive `?.` on `AiConfig` reads | `[live-on-dev]` | the SSOT guarantees the tree; let it fail loud |
-| **B4 ⭐** | **SAFETY-CRITICAL — runtime writes to `AiConfig`** (see §4) | `[live-on-dev: check-aiconfig-test-mutation]` — the gate is the enforcement anchor; it scans `test/**` only, so `ai/**` is unenforced (§4) | tests isolate by construction (`UNIT_TEST_MODE`); NEVER mutate the shared singleton |
-| B5 | passing `AiConfig` values into other consumers' configs (`Orchestrator → buildTaskDefinitions({chromaPort, …})`, 14 threaded args) | `[live: daemons]` | the consumer imports `AiConfig` and reads it (see §5 for the C1×B5 resolution) |
+| B1 | exporting config values/subtrees (`export const X = AiConfig.Y`) | `[guarded: lint-config-template-ssot]` | consumers import `AiConfig` and read at use site |
+| B2 | `const X = AiConfig.Y` pointers | `[guarded: lint-config-template-ssot]` — primitive/formula captures; live proxy subtrees remain valid | read inline — alias only if used 3+ times in one scope |
+| B3 | defensive `?.` on `AiConfig` reads | `[guarded: check-aiconfig-antipatterns, lint-config-template-ssot]` | the SSOT guarantees the tree; let it fail loud |
+| **B4 ⭐** | **SAFETY-CRITICAL — runtime writes to `AiConfig`** (see §4) | `[guarded: check-aiconfig-test-mutation]` — scans `test/**` only, so `ai/**` remains unenforced (§4) | tests isolate by construction (`UNIT_TEST_MODE`); NEVER mutate the shared singleton |
+| B5 | passing `AiConfig` values into other consumers' configs (`Orchestrator → buildTaskDefinitions({chromaPort, …})`, 14 threaded args) | `[guarded: lint-config-template-ssot]` — statically recognisable pass-throughs | the consumer imports `AiConfig` and reads it (see §5 for the C1×B5 resolution) |
 
 ### Group C — boundary / duplication
 | ID | Antipattern | Tag | Sanctioned form |
 |---|---|---|---|
-| C1 ⛔ | **NEO imports ONLY in thread-entrypoints** (ZERO tolerance — `import Neo`/`_export`/`AiConfig` in a *non-entrypoint* script can BREAK things) | `[live: TaskDefinitions.mjs]` | keep the non-entrypoint Neo-free; it takes pure FUNCTIONS from a shared module, and any LITERAL it needs must earn §5.5's anchor reason — being a non-entrypoint is never itself the reason, and it must not carry a resolver for anything a leaf already binds |
-| C2 | duplicated primitives (`chromaClientPrimitives` re-implements the embedding dummy-fn; `chromaTestIsolation` hidden default DB names) | `[live-on-dev]` | fold into the SSOT leaves |
-| C3 | tests import `config.mjs` (overlay) not `config.template.mjs` (canonical) | `[guarded: the lint's test config-authority rule (AST-resolved, scans `test/`), 0 on dev — #11976 repaired the backlog; #16628 wired the CI trigger to the scanned surface]` | tests import the canonical template |
+| C1 ⛔ | a non-entrypoint exports a competing resolver/value for an env already bound by an AiConfig leaf (`const X = process.env.Y \|\| …; export {X}`) | `[guarded: lint-config-template-ssot]` — zero-baseline | import `AiConfig` and read the resolved leaf at the use site; a bare import is legal, but a second exported resolver is not |
+| C2 | duplicated primitives (`chromaClientPrimitives` re-implements the embedding dummy-fn; `chromaTestIsolation` hidden default DB names) | `[unenforced: live debt]` | fold into the SSOT leaves |
+| C3 | tests import `config.mjs` (overlay) not `config.template.mjs` (canonical) | `[guarded: lint-config-template-ssot]` — AST-resolved, scans `test/**`, zero-baseline | tests import the canonical template |
 
-> **V-B-A classification correction (@neo-opus-4-7, `dev` line-evidence — Discussion #12453 `DC_kwDODSospM4BBgm5`):** the `ai/` daemon *entrypoints* (`bridge/daemon.mjs:3-6`, `orchestrator/daemon.mjs:25-27`) **legitimately `import Neo`/`_export`/`AiConfig`** — they ARE entrypoints, so their path re-derivation is **A1** (re-derivation with AiConfig already in scope), NOT a C1 violation; the "can BREAK things" framing applies to *non-entrypoints* only. The **single genuine C1×B5 site is `TaskDefinitions.mjs`** (no Neo import; `export const DEFAULT_DB_PATH`). The fan-out census MUST tag `A1-with-AiConfig-imported` vs `genuine-C1` so daemons are not over-counted as C1.
+> **C1 correction and ownership (2026-08-24, #17481):** import location was the wrong predicate. The `ai/` daemon entrypoints legitimately import `Neo`/`_export`/`AiConfig`, and ordinary non-entrypoint use sites may import `AiConfig` after their process entrypoint bootstraps Neo. The recorded genuine C1 site had **no Neo import**: it re-derived `DEFAULT_DB_PATH` from an env already bound by a leaf and exported that competing truth. C1 is therefore the intersection of A1's re-derivation and an export, scoped to non-entrypoints; B1 remains distinct because it exports a frozen copy *from* AiConfig. The boundary was exposed by `#17466`'s corrected Agent claim and `#17481`'s import-only probe. The guard pins both edges: import-only in `ai/Agent.mjs` is GREEN, while adding the competing exported resolver is RED. Entrypoints that re-derive still fail A1.
+
+> **Tag contract (2026-08-24, #17481):** every §3 row declares either `[guarded: <guard>]` or `[unenforced: <reason>]`. The named guards export ids on the executable rule objects they run, and `lint-config-template-ssot` validates the relation both ways. These tags are enforcement ownership, not point-in-time instance counts; live debt and baselines stay with the owning guard.
 
 ### Group D/E — why this keeps happening (root, compressed)
 **D1** premise-gate failure (review checks template-compliance/tests-green, not solution-shape) · **D2** reviewing the diff, not the model · **D3** correlated same-family blind-spot · **E1** broken-window · **E2** codify-don't-promise · **E3** operating without understanding the primitive. The structural answer to all of D/E is **this ADR + the lint** — not reviewer diligence (empirically insufficient).

--- a/test/playwright/unit/ai/buildScripts/util/check-aiconfig-antipatterns.spec.mjs
+++ b/test/playwright/unit/ai/buildScripts/util/check-aiconfig-antipatterns.spec.mjs
@@ -1,11 +1,11 @@
-import {test, expect}                                                      from '@playwright/test';
-import {findAntipatterns, filterAllowlistedHits, ALLOWLIST, ESCAPE_MARKER} from '../../../../../../buildScripts/util/check-aiconfig-antipatterns.mjs';
-import {A1_IMPORT_GATE}                                                    from '../../../../../../buildScripts/util/check-aiconfig-antipatterns.mjs';
-import {spawnSync}                                                         from 'node:child_process';
-import fs                                                                  from 'node:fs';
-import path                                                                from 'node:path';
-import process                                                             from 'node:process';
-import {fileURLToPath}                                                     from 'node:url';
+import {test, expect}                                                                      from '@playwright/test';
+import {findAntipatterns, filterAllowlistedHits, ADR_0019_RULES, ALLOWLIST, ESCAPE_MARKER} from '../../../../../../buildScripts/util/check-aiconfig-antipatterns.mjs';
+import {A1_IMPORT_GATE}                                                                    from '../../../../../../buildScripts/util/check-aiconfig-antipatterns.mjs';
+import {spawnSync}                                                                         from 'node:child_process';
+import fs                                                                                  from 'node:fs';
+import path                                                                                from 'node:path';
+import process                                                                             from 'node:process';
+import {fileURLToPath}                                                                     from 'node:url';
 
 const
     __dirname   = path.dirname(fileURLToPath(import.meta.url)),
@@ -21,6 +21,12 @@ const
  * honors the inline escape marker plus the census-seeded grandfather allowlist.
  */
 test.describe('check-aiconfig-antipatterns guard', () => {
+    test('ADR-0019 ids live on the executable rule objects', () => {
+        expect(ADR_0019_RULES.map(rule => rule.id).sort()).toEqual(['A1', 'A5', 'B3']);
+        expect(ADR_0019_RULES.every(rule => rule.pattern instanceof RegExp)).toBe(true);
+        expect(ADR_0019_RULES.find(rule => rule.id === 'A1').filePattern).toBe(A1_IMPORT_GATE)
+    });
+
     test('B3: flags a defensive hop directly on a config root', () => {
         expect(findAntipatterns('if (!this.configFile || !this.aiConfig?.load) return;').map(h => h.rule)).toEqual(['B3']);
         expect(findAntipatterns('const mode = AiConfig?.auth;').map(h => h.rule)).toEqual(['B3']);

--- a/test/playwright/unit/ai/buildScripts/util/check-aiconfig-test-mutation.spec.mjs
+++ b/test/playwright/unit/ai/buildScripts/util/check-aiconfig-test-mutation.spec.mjs
@@ -1,10 +1,10 @@
-import {test, expect}                                                                      from '@playwright/test';
-import {spawnSync}                                                                         from 'node:child_process';
-import {existsSync, mkdirSync, rmSync, writeFileSync}                                      from 'node:fs';
-import path                                                                                from 'node:path';
-import process                                                                             from 'node:process';
-import {fileURLToPath}                                                                     from 'node:url';
-import {findDbPathMutations, findCloneCaptures, scanFileContent, ALLOWLIST, ESCAPE_MARKER} from '../../../../../../buildScripts/util/check-aiconfig-test-mutation.mjs';
+import {test, expect}                                                                                      from '@playwright/test';
+import {spawnSync}                                                                                         from 'node:child_process';
+import {existsSync, mkdirSync, rmSync, writeFileSync}                                                      from 'node:fs';
+import path                                                                                                from 'node:path';
+import process                                                                                             from 'node:process';
+import {fileURLToPath}                                                                                     from 'node:url';
+import {findDbPathMutations, findCloneCaptures, scanFileContent, ADR_0019_RULES, ALLOWLIST, ESCAPE_MARKER} from '../../../../../../buildScripts/util/check-aiconfig-test-mutation.mjs';
 
 const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../../../../../..');
 
@@ -16,6 +16,11 @@ const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../
  * inline escape marker.
  */
 test.describe('check-aiconfig-test-mutation guard', () => {
+    test('B4 lives on the executable mutation rule object', () => {
+        expect(ADR_0019_RULES.map(rule => rule.id)).toEqual(['B4']);
+        expect(ADR_0019_RULES[0].detect).toBe(findDbPathMutations)
+    });
+
     test('flags storagePaths / database / collections / logPath assignments', () => {
         expect(findDbPathMutations('aiConfig.storagePaths.graph = testPath;').map(h => h.line)).toEqual([1]);
         expect(findDbPathMutations("aiConfig.engines.chroma.database = `graph-${process.pid}`;").map(h => h.line)).toEqual([1]);

--- a/test/playwright/unit/ai/scripts/lint/lintConfigTemplateSsot.spec.mjs
+++ b/test/playwright/unit/ai/scripts/lint/lintConfigTemplateSsot.spec.mjs
@@ -1,29 +1,37 @@
-import {test, expect}  from '@playwright/test';
-import {spawnSync}     from 'node:child_process';
-import path            from 'node:path';
-import {pathToFileURL} from 'node:url';
+import {test, expect}                          from '@playwright/test';
+import {spawnSync}                             from 'node:child_process';
+import {existsSync, readdirSync, readFileSync} from 'node:fs';
+import path                                    from 'node:path';
+import {pathToFileURL}                         from 'node:url';
 
 import {
+    ADR_0019_RULES,
     AI_CONFIG_IMPLEMENTATION_BASELINE,
     AI_CONFIG_MODULE_SCOPE_BASELINE,
     BASELINE,
     buildConfigLeafParitySnapshot,
     buildConfigPathKindsByIdentifier,
     collectConfigPathKindsFromSource,
+    collectConfigEnvNamesFromSource,
     collectDeclaredConfigPaths,
+    createAdr0019GuardRegistry,
     detectAiConfigImplementationViolations,
     detectComposeDefaultRestatements,
     detectComposeDefaultRestatementsFromDocuments,
     detectConfigLeafParityViolations,
     detectInlineEnvLeaves,
     detectModuleScopeAiConfigCaptures,
+    detectNonEntrypointConfigResolvers,
     detectTestConfigOverlayImports,
     detectTestConfigProviderExports,
     detectUnprojectedBehaviorBindingClocksFromSources,
     lintAiConfigImplementationSsot,
     lintAiConfigModuleScopeCaptures,
+    lintAdr0019GuardOwnership,
     lintConfigTemplateSsot,
     lintTestConfigAuthority,
+    isThreadEntrypoint,
+    parseAdr0019CatalogRows,
     runLint
 } from '../../../../../../ai/scripts/lint/lint-config-template-ssot.mjs';
 
@@ -61,6 +69,94 @@ test.describe('ai/scripts/lint-config-template-ssot (#12451 — declarative conf
 
         expect(result.status, result.stderr).toBe(0);
         expect(result.stdout).toContain('[lint-config-template-ssot] OK');
+    });
+
+    test('ADR-0019 ids live on executable rule objects, not a detached file list', () => {
+        expect([...new Set(ADR_0019_RULES.map(rule => rule.id))].sort())
+            .toEqual(['A4', 'B1', 'B2', 'B3', 'B5', 'C1', 'C3']);
+        expect(ADR_0019_RULES.every(rule => typeof rule.detect === 'function' || rule.pattern instanceof RegExp))
+            .toBe(true)
+    });
+
+    test('C1 boundary: import-only is GREEN; exported module-time re-derivation is RED', () => {
+        const envNames = new Set(['NEO_DB_PATH']),
+              clean    = [
+                  "import AiConfig from './config.mjs';",
+                  'export default class Agent {}'
+              ].join('\n'),
+              red      = [
+                  clean,
+                  "const DEFAULT_DB_PATH = process.env.NEO_DB_PATH || './data/db';",
+                  'export {DEFAULT_DB_PATH};'
+              ].join('\n');
+
+        expect(detectNonEntrypointConfigResolvers(clean, {configEnvNames: envNames})).toEqual([]);
+        expect(detectNonEntrypointConfigResolvers(red, {configEnvNames: envNames}).map(hit => hit.rule))
+            .toEqual(['C1']);
+
+        // A runtime function is not A1's module-evaluation shape.
+        expect(detectNonEntrypointConfigResolvers(
+            'export function readPath() { return process.env.NEO_DB_PATH; }',
+            {configEnvNames: envNames}
+        )).toEqual([])
+    });
+
+    test('C1 only binds env names that a leaf already owns', () => {
+        const names = collectConfigEnvNamesFromSource([
+            "const data = {dbPath: leaf('/tmp/db', 'NEO_DB_PATH', 'string')};",
+            "const ignored = process.env.NOT_A_LEAF;"
+        ].join('\n'));
+
+        expect([...names]).toEqual(['NEO_DB_PATH']);
+        expect(detectNonEntrypointConfigResolvers(
+            "export const EXTERNAL = process.env.NOT_A_LEAF || 'x';",
+            {configEnvNames: names}
+        )).toEqual([])
+    });
+
+    test('entrypoint classification is executable: runAgent + every daemon pass; Agent does not', () => {
+        const rootDir  = process.cwd(),
+              read     = rel => readFileSync(path.join(rootDir, rel), 'utf8'),
+              runAgent = read('ai/scripts/runners/runAgent.mjs'),
+              agent    = read('ai/Agent.mjs'),
+              daemons  = readdirSync(path.join(rootDir, 'ai/daemons'), {withFileTypes: true})
+                  .filter(entry => entry.isDirectory())
+                  .map(entry => `ai/daemons/${entry.name}/daemon.mjs`)
+                  .filter(rel => existsSync(path.join(rootDir, rel)));
+
+        expect(isThreadEntrypoint({source: runAgent})).toBe(true);
+        expect(isThreadEntrypoint({source: agent})).toBe(false);
+        expect(daemons.length).toBeGreaterThan(0);
+        daemons.forEach(rel => expect(isThreadEntrypoint({source: read(rel)}), rel).toBe(true))
+    });
+
+    test('ADR-0019 guard ownership is exact in both directions', () => {
+        const adrSource = readFileSync(
+                  path.join(process.cwd(), 'learn/agentos/decisions/0019-aiconfig-reactive-provider-ssot.md'),
+                  'utf8'
+              ),
+              rows      = parseAdr0019CatalogRows(adrSource),
+              clean     = lintAdr0019GuardOwnership({adrSource});
+
+        expect(rows).toHaveLength(17);
+        expect(clean.violations).toEqual([]);
+
+        const missingB4 = createAdr0019GuardRegistry({testMutationRules: []}),
+              overstate = lintAdr0019GuardOwnership({adrSource, guardRegistry: missingB4});
+
+        expect(overstate.violations).toContainEqual(expect.objectContaining({
+            id: 'B4', guard: 'check-aiconfig-test-mutation', kind: 'overstates-enforcement'
+        }));
+
+        const understatedSource = adrSource.replace(
+                  '[guarded: check-aiconfig-antipatterns]` — live debt',
+                  '[unenforced: mutation]` — live debt'
+              ),
+              understate = lintAdr0019GuardOwnership({adrSource: understatedSource});
+
+        expect(understate.violations).toContainEqual(expect.objectContaining({
+            id: 'A1', guard: 'check-aiconfig-antipatterns', kind: 'understates-enforcement'
+        }))
     });
 
     // ---- pure detection ----
@@ -494,6 +590,40 @@ test.describe('ai/scripts/lint-config-template-ssot (#12451 — declarative conf
 
         expect(result.exitCode).toBe(0);
         expect(result.moduleScope.newViolations).toHaveLength(0);
+    });
+
+    test('the combined lint keeps C1 import-only GREEN and competing export RED', async () => {
+        const common = {
+                  files                 : [],
+                  implementationFiles   : [],
+                  implementationBaseline: [],
+                  moduleScopeFiles      : [],
+                  moduleScopeBaseline   : [],
+                  testConfigFiles       : [],
+                  configEnvNames        : new Set(['NEO_DB_PATH'])
+              },
+              importOnly = fileOf(
+                  'ai/Agent.mjs',
+                  "import AiConfig from './config.mjs';\nexport default class Agent {}"
+              ),
+              competing = fileOf(
+                  'ai/Agent.mjs',
+                  [
+                      importOnly.source,
+                      "const DEFAULT_DB_PATH = process.env.NEO_DB_PATH || './data/db';",
+                      'export {DEFAULT_DB_PATH};'
+                  ].join('\n')
+              );
+
+        const green = await runLint({...common, c1Files: [importOnly]}),
+              red   = await runLint({...common, c1Files: [competing]});
+
+        expect(green.exitCode).toBe(0);
+        expect(green.c1Resolvers.violations).toEqual([]);
+        expect(red.exitCode).toBe(1);
+        expect(red.c1Resolvers.violations).toEqual([
+            expect.objectContaining({file: 'ai/Agent.mjs', rule: 'C1', env: 'NEO_DB_PATH'})
+        ])
     });
 
     test('a test overlay import fails the combined lint without a baseline escape hatch', async () => {

--- a/test/playwright/unit/ai/scripts/lint/lintConfigTemplateSsot.spec.mjs
+++ b/test/playwright/unit/ai/scripts/lint/lintConfigTemplateSsot.spec.mjs
@@ -11,6 +11,7 @@ import {
     BASELINE,
     buildConfigLeafParitySnapshot,
     buildConfigPathKindsByIdentifier,
+    collectCatalogRuleIdsFromSource,
     collectConfigPathKindsFromSource,
     collectConfigEnvNamesFromSource,
     collectDeclaredConfigPaths,
@@ -75,7 +76,10 @@ test.describe('ai/scripts/lint-config-template-ssot (#12451 — declarative conf
         expect([...new Set(ADR_0019_RULES.map(rule => rule.id))].sort())
             .toEqual(['A4', 'B1', 'B2', 'B3', 'B5', 'C1', 'C3']);
         expect(ADR_0019_RULES.every(rule => typeof rule.detect === 'function' || rule.pattern instanceof RegExp))
-            .toBe(true)
+            .toBe(true);
+        expect(() => collectCatalogRuleIdsFromSource(
+            "export const ADR_0019_RULES = Object.freeze(['B4']);"
+        )).toThrow(/rule objects/)
     });
 
     test('C1 boundary: import-only is GREEN; exported module-time re-derivation is RED', () => {


### PR DESCRIPTION
Resolves #17481

Related: #17466

ADR-0019's catalog is now self-checking instead of self-describing: each existing AiConfig guard attaches catalog IDs to the executable rule objects it actually runs, the config SSOT lint validates every ADR tag in both directions, and C1 now rejects only a non-entrypoint's exported competing resolver—not a bare `AiConfig` import. The workflow watches the ADR and both sibling guards, so the ownership contract cannot drift on an unobserved commit.

Evidence: L1 (static guard contracts + mutation-bound unit arms) → L1 required (all close-target ACs are repository-static and CI-observable). No residuals.

## AC Evidence

| AC-1 | ADR-0019's own recorded no-import/exported-resolver case establishes C1's boundary; the amended row and controls encode it. |
| AC-2 | `ADR_0019_RULES` in all three guards binds each catalog ID to the predicate/detector object the scanner invokes; owning specs assert the mappings. |
| AC-3 | `validateAdr0019GuardOwnership()` parses §3, resolves named guards, and red-proves both overstatement and understatement. |
| AC-4 | All 17 ADR rows now declare `[guarded: ...]` or `[unenforced: ...]`; the shipped ADR returns zero ownership mismatches. |
| AC-5 | The retained superseded prose is non-authoritative: the executable guarded/unenforced grammar replaces its proposed prose-only contract. |
| AC-6 | ADR-0019 records C1 as A1 re-derivation plus export, distinct from B1's frozen AiConfig export; the AST detector implements that ownership. |
| AC-7 | The C1 row, correction note, sanctioned boundary, and machine-owned tag contract are amended together in ADR-0019. |
| AC-8 | `detectNonEntrypointConfigResolvers()` ignores import location and matches only exported module-time values whose env is already leaf-bound. |
| AC-9 | `isThreadEntrypoint()` classifies executable ownership from a CLI guard or top-level `main()` call; tests distinguish `runAgent.mjs` from `Agent.mjs`. |
| AC-10 | The same `ai/Agent.mjs` fixture passes with import-only and fails after a distinct competing-resolver mutation, both through the combined lint. |
| AC-11 | The live full-tree config SSOT lint reports zero C1 resolvers and zero ADR ownership mismatches; no baseline was added. |
| AC-12 | The entrypoint spec dynamically enumerates every current `ai/daemons/*/daemon.mjs` and requires each to stay legal. |
| AC-13 | ADR-0019 cites `#17466`'s corrected Agent claim and `#17481`'s probe as the boundary's empirical origin. |

## Deltas from ticket

The config SSOT workflow's scan surface now includes ADR-0019 and both sibling guard modules; without that expansion, the two-way check could be correct yet absent on the commit that changes its inputs. A local whole-suite diagnostic was not used as positive evidence because user-owned ignored backup files enter several repository-wide scans; those files were preserved untouched. Clean PR CI remains the full-tree merge gate.

## Test Evidence

All coverage runs in CI.

## Post-Merge Validation

None — every acceptance criterion is observable before merge.

## Commits

- `e1ab361f20` — bind catalog IDs to executable rules, add C1 + two-way ownership enforcement, amend ADR-0019, and wire CI coverage.
- `e4a34af603` — keep the executable lint plane-neutral by parsing sibling rule objects from source instead of importing build guards.

## Substrate slot rationale

Disposition: **keep** in the conditionally loaded ADR-0019 read-gate. The amendment adds 1,009 bytes only to AiConfig author/review turns, where the failure severity is safety-critical and enforcement is now mechanical through the two-way lint. Decay mitigation: catalog tags are validated against executable rule objects and every verdict input is CI-watched. Retirement trigger: when §3 becomes a generated view of the guard registry, retire the hand-authored tag column and this explanatory contract together.

## Evolution

Intake first rejected a three-way prose contradiction: import location was simultaneously required to pass and fail. Vega folded that into a GREEN/RED pair. The first implementation then over-fired on exported functions that read env only at invocation; the live-tree falsifier narrowed C1 to its settled A1 intersection—module-evaluation re-derivation plus export—without baselining those unrelated functions.

Authored by Emmy (GPT-5.6 Sol Ultra, Codex) consuming Vega's handoff — session A cad88c79-073f-4816-aaa7-e779224f2af3, session B 429a3792-5cea-4c7b-a409-a1fd8b44ccd2.
