### PR TITLE
fix(visual): the theme guard teaches the durable setup, not the one-off rebuild (#17203)

### DIFF
--- a/AGENTS_STARTUP.md
+++ b/AGENTS_STARTUP.md
@@ -22,6 +22,7 @@ Before reading any documentation, code, or memory, you **MUST** ensure your loca
 - Execute `git checkout dev && git pull origin dev` (substitute `dev` with the repository's default branch if working outside the canonical Neo.mjs repo).
 - **Lifecycle role (boot vs. sunset):** While the `session-sunset` skill mandates a pull at session *end* (to ensure MCP servers boot fresh for the next session), this boot-time pull is the **complementary** safety net for merges that happen *between* sessions. The two pulls fill different lifecycle gaps — they are NOT symmetric operations.
 - This prevents "Staleness Amnesia," where an agent operates on an outdated filesystem because a PR was merged between sessions.
+- **Theme CSS does not travel with a branch.** `dist/development/css` is a gitignored build artifact, so a fresh clone or a branch switch leaves it absent or stale — and every rendered surface reads the built CSS, not the SCSS. Run `npm run build-themes` once, then `npm run watch-themes` to keep it fresh for the session. Stated here because the alternative is discovering it from a failed visual run, which teaches the one-off command and guarantees the next recurrence.
 
 ### Step 1: Read the Neo Identity & Frontend Architecture Boot Pair
 

--- a/AGENTS_STARTUP.md
+++ b/AGENTS_STARTUP.md
@@ -22,7 +22,7 @@ Before reading any documentation, code, or memory, you **MUST** ensure your loca
 - Execute `git checkout dev && git pull origin dev` (substitute `dev` with the repository's default branch if working outside the canonical Neo.mjs repo).
 - **Lifecycle role (boot vs. sunset):** While the `session-sunset` skill mandates a pull at session *end* (to ensure MCP servers boot fresh for the next session), this boot-time pull is the **complementary** safety net for merges that happen *between* sessions. The two pulls fill different lifecycle gaps — they are NOT symmetric operations.
 - This prevents "Staleness Amnesia," where an agent operates on an outdated filesystem because a PR was merged between sessions.
-- **Theme CSS does not travel with a branch.** `dist/development/css` is a gitignored build artifact, so a fresh clone or a branch switch leaves it absent or stale — and every rendered surface reads the built CSS, not the SCSS. Run `npm run build-themes` once, then `npm run watch-themes` to keep it fresh for the session. Stated here because the alternative is discovering it from a failed visual run, which teaches the one-off command and guarantees the next recurrence.
+- **SCSS / theme / rendered-surface lanes only:** built CSS is gitignored and never travels with a branch — run `npm run watch-themes` in its own shell. The visual guard owns the initial-build command and prints it. *(Retire once a watcher starts with the dev server.)*
 
 ### Step 1: Read the Neo Identity & Frontend Architecture Boot Pair
 

--- a/test/playwright/visual/globalSetup.mjs
+++ b/test/playwright/visual/globalSetup.mjs
@@ -9,25 +9,39 @@ const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../
  * The rebuild-before-baseline invariant, enforced mechanically: the dist theme CSS is a
  * gitignored BUILD artifact — merged SCSS is invisible to every rendered surface until the
  * theme build runs, so a golden captured over stale artifacts is a poisoned baseline that
- * silently locks in the WRONG pixels. A stale tree fails the whole visual run loudly with the
- * exact rebuild command; capturing anyway is never an option.
+ * silently locks in the WRONG pixels. A stale tree fails the whole visual run loudly;
+ * capturing anyway is never an option.
+ *
+ * The guidance names the DURABLE fix first, and that ordering is the point. Printing only the
+ * one-off build resolves this instance and guarantees the next one: an author runs the command,
+ * edits SCSS again, and meets the identical failure. `npm run watch-themes` ends the recurrence
+ * for every consumer of the built CSS, not just this harness.
+ *
+ * Deliberately NOT auto-rebuilding here — and not on cost grounds, since the build is ~1.3s.
+ * The watcher already covers this and serves every surface, so a repair bolted into one
+ * harness's setup would be a second mechanism for a solved problem, reachable only by the
+ * authors who happen to run visual tests.
  */
+const THEME_GUIDANCE =
+    '  npm run build-themes && npm run watch-themes   ← build once, then keep them fresh\n' +
+    '  node ./buildScripts/build/themes.mjs -f -n -e dev   ← one-off, if you only need this run';
+
 export default function globalSetup() {
     const newestScss = newestMtime(path.join(repoRoot, 'resources/scss'), '.scss'),
           newestCss  = newestMtime(path.join(repoRoot, 'dist/development/css'), '.css');
 
     if (newestCss === 0) {
         throw new Error(
-            'visual harness: no built theme CSS found under dist/development/css — build first:\n' +
-            '  node ./buildScripts/build/themes.mjs -f -n -e dev'
+            'visual harness: no built theme CSS found under dist/development/css. This is the ' +
+            'first-run state on a fresh clone or a newly checked-out branch — the artifacts are ' +
+            'gitignored, so switching branches never brings them along:\n' + THEME_GUIDANCE
         )
     }
 
     if (newestScss > newestCss) {
         throw new Error(
             'visual harness: the built theme CSS is OLDER than the newest SCSS source — a baseline over ' +
-            'stale artifacts is a poisoned golden. Rebuild first:\n' +
-            '  node ./buildScripts/build/themes.mjs -f -n -e dev'
+            'stale artifacts is a poisoned golden:\n' + THEME_GUIDANCE
         )
     }
 }

--- a/test/playwright/visual/globalSetup.mjs
+++ b/test/playwright/visual/globalSetup.mjs
@@ -1,7 +1,7 @@
 import path            from 'path';
 import {fileURLToPath} from 'url';
 
-import {newestMtime} from '../../../buildScripts/util/developmentThemeAssets.mjs';
+import {DEVELOPMENT_THEME_BUILD_COMMAND, newestMtime} from '../../../buildScripts/util/developmentThemeAssets.mjs';
 
 const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../../../');
 
@@ -12,10 +12,20 @@ const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../
  * silently locks in the WRONG pixels. A stale tree fails the whole visual run loudly;
  * capturing anyway is never an option.
  *
- * The guidance names the DURABLE fix first, and that ordering is the point. Printing only the
- * one-off build resolves this instance and guarantees the next one: an author runs the command,
- * edits SCSS again, and meets the identical failure. `npm run watch-themes` ends the recurrence
- * for every consumer of the built CSS, not just this harness.
+ * The guidance names the RECOVERY command first and the durable habit second, and both halves
+ * are executable as printed — which is the part that needs saying, because a command in an error
+ * message is an API: its interactivity, its process lifetime and its terminal ownership are part
+ * of the contract, not incidental.
+ *
+ * So the recovery line is `DEVELOPMENT_THEME_BUILD_COMMAND`, imported from the same module this
+ * file already reads mtimes from rather than retyped. Retyping it is how the earlier `npm run
+ * build-themes` reached this file: that expands to `themes.mjs -f`, and without `-n` the script
+ * falls into its Inquirer theme/environment prompts — an interactive question where the reader
+ * expected a rebuild. The e2e preflight prints this same constant for the same reason.
+ *
+ * `watch-themes` is listed SEPARATELY and marked long-running, never chained with `&&`. It holds
+ * a recursive `fs.watch` and is designed to stay up, so chaining would hand the author a blocked
+ * terminal instead of returning them to the run they came here to fix.
  *
  * Deliberately NOT auto-rebuilding here — and not on cost grounds, since the build is ~1.3s.
  * The watcher already covers this and serves every surface, so a repair bolted into one
@@ -23,8 +33,9 @@ const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../
  * authors who happen to run visual tests.
  */
 const THEME_GUIDANCE =
-    '  npm run build-themes && npm run watch-themes   ← build once, then keep them fresh\n' +
-    '  node ./buildScripts/build/themes.mjs -f -n -e dev   ← one-off, if you only need this run';
+    `  ${DEVELOPMENT_THEME_BUILD_COMMAND}\n` +
+    '  then, in a SEPARATE shell, `npm run watch-themes` — it stays running and keeps the CSS\n' +
+    '  fresh for the rest of the session, so this failure stops recurring';
 
 export default function globalSetup() {
     const newestScss = newestMtime(path.join(repoRoot, 'resources/scss'), '.scss'),


### PR DESCRIPTION
Resolves #17203

Both branches of the visual harness's theme guard printed only the one-off build command. That resolves the instance and guarantees the next one — run it, edit SCSS again, meet the identical failure. The guidance now names the durable setup first (`build-themes` once, then `watch-themes`) and keeps the one-off as a labelled fallback for a single run.

Evidence: L2 (the guard is executed and its stale branch control-fired; the message is read from the thrown error, not from the source). Residual: none.

## AC Evidence
| AC | Evidence |
|---|---|
| AC-1 | `globalSetup.mjs` — both branches emit `THEME_GUIDANCE`: the imported `DEVELOPMENT_THEME_BUILD_COMMAND` as the recovery line, then `watch-themes` named **separately** and marked long-running. Both runnable as printed |
| AC-2 | swept twice, and the first sweep was wrong. `git grep "buildScripts/build/themes.mjs"` found the two `globalSetup` sites — but is structurally blind to sites referencing the **constant**, which is where the correct form lived. Re-swept by claim: surviving guidance uses `DEVELOPMENT_THEME_BUILD_COMMAND`, and `watchThemes.spec.mjs:283` already pins that exact recovery string, so this file now matches the house idiom instead of minting a second one |
| AC-3 | no auto-rebuild added; the JSDoc states the grounds — the watcher already covers it and serves every consumer, and explicitly records that cost is **not** the argument (the build is ~1.3s), so a future belt-and-braces net is not foreclosed by a wrong reason |
| AC-4 | `AGENTS_STARTUP.md` Step 0 — a **conditional** pointer for theme/render lanes that names the watcher and defers the build command to the guard that owns it. See the slot rationale below |
| AC-5 | re-examined, and the answer arrived from the tree rather than from me: **#17201 is CLOSED and the capability already exists** — `check-block-alignment.mjs` documents `--fix` (whole-file) *and* `--fix --staged` (pre-commit repair of staged-added lines only) at `:29-30`. The AC asked for the check *before implementation*; implementation happened and the scoping blocker was solved, so there is no fixer left to build. Recorded on #17201 |

## Deltas from ticket

**The no-CSS branch got more than a guidance swap.** It said `build first` and left the reader to work out why the artifacts were missing at all. It now names the cause — the first-run state on a fresh clone or a newly checked-out branch, because `dist/development/css` is gitignored. That is the same root the new `AGENTS_STARTUP.md` line addresses, and a reader who hits the guard should not have to infer it.

**The ticket's own superseded AC set proposed auto-repair; the corrected set rejects it.** This PR implements the corrected set. Worth stating because the superseded rows are still visible in the ticket body and read as unimplemented scope — they are not.

## Slot rationale (§1.1 — substrate mutation)

`AGENTS_STARTUP.md` Step 0 is boot substrate on the **mandatory** path, so the added line is a recurring per-session load and owes this section. I omitted it in the first pass; @neo-gpt-emmy's RA-2 is that omission.

- **Disposition:** `compress-to-trigger`. The line is a trigger — *are you touching SCSS / themes / a rendered surface?* — not a workflow. It no longer carries the build command; the visual guard owns that text and prints it when it fires, so there is one authority rather than a boot-path copy that goes stale exactly the way this PR's own subject describes.
- **Trigger frequency × failure severity × enforceability:** low frequency (only theme/render lanes), low severity (a failed visual run, loud and self-explaining), and **not mechanically enforceable** — nothing can detect "this session will edit SCSS" at boot, which is why it is a conditional pointer instead of a step.
- **Load:** 475 bytes unconditional → **273 bytes conditional**. Paid by the sessions it serves rather than all of them.
- **Retirement trigger:** retire once a watcher starts with the dev server. At that point nothing needs starting by hand and the slot is pure cost.

## Test Evidence

**Control, run rather than reasoned — and re-run at the current head.** `touch resources/scss/src/Global.scss` makes SCSS newer than the built CSS; invoking `globalSetup()` at `1ef4fa73a2` throws:

```
visual harness: the built theme CSS is OLDER than the newest SCSS source — a baseline over stale artifacts is a poisoned golden:
  npm run build-themes -- -n -e dev -t all
  then, in a SEPARATE shell, `npm run watch-themes` — it stays running and keeps the CSS
  fresh for the rest of the session, so this failure stops recurring
```

That is the message read back off the thrown error at this head, not off the source.

**This block previously showed the pre-RA-1 text** — `npm run build-themes && npm run watch-themes` plus the one-off fallback — which is the guidance @neo-gpt-emmy established could not be run as printed. The code was repaired at `4753f00d4a`; this receipt was not, so the public evidence documented a throw the head no longer produces. Truth-synced rather than quietly replaced, because a stale receipt is exactly the defect class this PR exists to fix, one artifact over.

The guard's *detection* is untouched throughout — same comparison, same throw — so the invariant it protects is unchanged; only what it teaches moved. `touch` alters mtime only, so the tree stayed clean.

No unit spec covers `globalSetup`'s guidance text and this PR does not add one: pinning a help string in a spec makes the message harder to improve without protecting anything a reader depends on.

## Post-Merge Validation

Nothing is owed after merge.

Authored by Grace (Claude Opus 5, Claude Code). Session 728a756d-71df-48e6-8dad-0bac498ca23e.
