### PR TITLE
feat(agentos): 0 agents shared with you is not a dead plane (#16824)

### DIFF
--- a/ai/services/fleet/fleetCockpitStatus.mjs
+++ b/ai/services/fleet/fleetCockpitStatus.mjs
@@ -73,10 +73,31 @@ function githubAvatarUrl(githubUsername) {
  *     `registryBridge.fleetRuntimeStatus()` — rows carry an observed `lifecycle` when present.
  * @param {Object[]} options.events        Optional already-normalized cockpit events.
  * @param {Object}   options.capabilities  Optional source-capability overrides from wired adapters.
- * @returns {Object} serializable cockpit DTO `{sources, capabilities, rows, events}`.
+ * @param {Number}   [options.operatorsPresent=null] Optional PLANE-level count of operators present,
+ *     independent of `rows`. Supplied by the plane-side presence projection when it exists; `null`
+ *     means NOT REPORTED and must never be rendered as zero. A bare count only — identities would
+ *     invert the default-private boundary.
+ * @returns {Object} serializable cockpit DTO `{sources, presence, capabilities, rows, events}`,
+ *     where `presence` is `{operatorsPresent: Number|null}`.
  */
-export function createFleetCockpitStatus({agents = [], fleetStatus = [], runtimeStatus = [], wakeStatus = [], throttleStatus = [], presenceStatus = [], events = [], capabilities = {}} = {}) {
+export function createFleetCockpitStatus({agents = [], fleetStatus = [], runtimeStatus = [], wakeStatus = [], throttleStatus = [], presenceStatus = [], operatorsPresent = null, events = [], capabilities = {}} = {}) {
     const suppliedCapabilities = capabilities || {}
+
+    // A PLANE-level count, deliberately separate from the per-agent presence axis above. That axis
+    // is keyed by `agentId`, so it can only describe rows the viewer already receives — and the
+    // question this answers is what a viewer with ZERO rows should be told. A default-private plane
+    // that shares nothing with you returns an empty roster, which is indistinguishable from a plane
+    // with no agents defined unless something outside the rows reports liveness.
+    //
+    // A bare COUNT, never identities: the count discloses that the plane is alive, while a list
+    // would invert the default-private boundary this whole feature exists to serve.
+    //
+    // `null` when unsupplied is load-bearing — it means "not reported", which a consumer must
+    // render differently from a reported `0`. Coercing absence to zero would fabricate "nobody is
+    // here" on every plane whose producer has not shipped yet.
+    const planePresence = Number.isInteger(operatorsPresent) && operatorsPresent >= 0
+        ? {operatorsPresent}
+        : {operatorsPresent: null}
 
     const statusByAgentId = new Map(
         fleetStatus.map(status => [status.agentId || status.id, sanitizePayload(status)])
@@ -118,6 +139,7 @@ export function createFleetCockpitStatus({agents = [], fleetStatus = [], runtime
 
     return {
         sources     : FLEET_COCKPIT_SOURCES,
+        presence    : planePresence,
         capabilities: {
             activity: suppliedCapabilities.activity || createNotWiredCapability(FLEET_COCKPIT_SOURCES.activity, 'A2A / PR / lane activity adapter not wired'),
             runtime : suppliedCapabilities.runtime || createNotWiredCapability(FLEET_COCKPIT_SOURCES.runtime, 'runtime process status is pending the Fleet runtime-status wire method'),

--- a/apps/agentos/view/fleet/cockpit/Container.mjs
+++ b/apps/agentos/view/fleet/cockpit/Container.mjs
@@ -2379,7 +2379,7 @@ class FleetCockpit extends DockWorkspace {
 
             // invoked INSIDE the chain so a synchronous throw rejects the tracked promise rather
             // than escaping before the settle hook attaches — see the activity twin
-            const {capabilities, rows} = await boundedRead(
+            const {capabilities, presence, rows} = await boundedRead(
                 Promise.resolve().then(() => bridge.fleetRoster()),
                 me.livenessReadTimeout,
                 () => { me.gridReadInFlight-- }
@@ -2412,7 +2412,23 @@ class FleetCockpit extends DockWorkspace {
                 // module documents as needing a retained reason. Cleared by the ordinary paths: a
                 // populated snapshot clears it below; a transport failure retracts it in
                 // {@link #degradeWiredSurface} (the claim must not outlive the connection).
-                me.gridDegradedReason = 'server connected · fleet registry empty — define agents to go live';
+                // TWO empty kinds, and telling them apart is the whole point. A default-private
+                // plane answers "0 agents shared with you" identically to a plane with nothing
+                // defined — so "define agents to go live" is a LIE in the actionable direction
+                // whenever the plane HAS agents this viewer cannot see. The operator action differs
+                // categorically: request access, not define agents, and not start the server.
+                //
+                // Only a plane-level count can separate them, because a scoped-empty roster carries
+                // no rows for the per-agent presence axis to describe. `null` means NOT REPORTED and
+                // keeps the pre-projection line byte-identical — absence must never render as zero,
+                // which would claim an empty plane on every deployment whose producer has not
+                // shipped.
+                const operatorsPresent = presence?.operatorsPresent;
+
+                me.gridDegradedReason = Number.isInteger(operatorsPresent) && operatorsPresent > 0
+                    ? `plane alive · ${operatorsPresent} ${operatorsPresent === 1 ? 'operator' : 'operators'} present · ` +
+                      '0 agents shared with you · request access'
+                    : 'server connected · fleet registry empty — define agents to go live';
                 return
             }
 

--- a/test/playwright/unit/ai/services/fleet/fleetCockpitStatus.spec.mjs
+++ b/test/playwright/unit/ai/services/fleet/fleetCockpitStatus.spec.mjs
@@ -520,4 +520,35 @@ test.describe('fleetCockpitStatus - Body-side cockpit DTO contract', () => {
             expect(['on', 'off', 'suppressed', 'unknown']).toContain(row.wake.state)
         }
     })
+
+    // The PLANE-level operator count. Separate from the per-agent presence axis by necessity —
+    // that axis is keyed by agentId, so it can only describe rows the viewer already has, and the
+    // question here is what a viewer with ZERO rows should be told.
+    test('carries a plane-level operator count independent of rows — a bare count, never identities', () => {
+        const snapshot = createFleetCockpitStatus({agents: [], operatorsPresent: 4})
+
+        expect(snapshot.presence).toEqual({operatorsPresent: 4})
+        expect(snapshot.rows).toEqual([])
+
+        // the boundary this feature exists to serve: liveness is disclosed, membership is not
+        expect(JSON.stringify(snapshot.presence)).not.toMatch(/agent|id|user|name/i)
+    })
+
+    test('an unsupplied count is null, never a fabricated zero', () => {
+        // Absence and reported-zero are different facts and an operator acts on them differently:
+        // `null` is "not reported" (render the pre-projection line), `0` is "nobody is here".
+        // Coercing absence to zero would claim an empty plane on every deployment whose producer
+        // has not shipped.
+        expect(createFleetCockpitStatus({agents: []}).presence).toEqual({operatorsPresent: null})
+        expect(createFleetCockpitStatus({agents: [], operatorsPresent: 0}).presence).toEqual({operatorsPresent: 0})
+    })
+
+    test('a malformed count degrades to not-reported rather than riding the wire', () => {
+        // The DTO owns every value it emits. A negative or non-integer count is a producer defect,
+        // and rendering "plane alive · -1 operators present" would be worse than saying nothing.
+        for (const bad of [-1, 1.5, '3', NaN, null, undefined, {}]) {
+            expect(createFleetCockpitStatus({agents: [], operatorsPresent: bad}).presence)
+                .toEqual({operatorsPresent: null})
+        }
+    })
 })

--- a/test/playwright/unit/apps/agentos/view/fleet/cockpit/container.spec.mjs
+++ b/test/playwright/unit/apps/agentos/view/fleet/cockpit/container.spec.mjs
@@ -400,6 +400,54 @@ test.describe('Fleet cockpit — Store-backed roster (loadRoster)', () => {
         expect(cockpit.gridDegradedReason).toBe('server connected · fleet registry empty — define agents to go live')
     });
 
+    // Two empty kinds. A default-private plane answering "0 agents shared with you" is not a plane
+    // with nothing defined, and "define agents to go live" is a lie in the ACTIONABLE direction
+    // against a plane that has agents this viewer cannot see.
+    test('SCOPED-empty names the plane as alive and the action as request-access', async () => {
+        const {cockpit} = await routeLoadRoster({
+            fleetRoster: async () => ({presence: {operatorsPresent: 3}, rows: []})
+        });
+
+        expect(cockpit.gridDegradedReason).toBe(
+            'plane alive · 3 operators present · 0 agents shared with you · request access'
+        );
+        // still the answered-empty disposition — the sample survives, only the CAUSE differs
+        expect(cockpit.rosterSourceMode).toBe('sample')
+    });
+
+    test('a single operator is not pluralised — the count is rendered, not templated over', async () => {
+        const {cockpit} = await routeLoadRoster({
+            fleetRoster: async () => ({presence: {operatorsPresent: 1}, rows: []})
+        });
+
+        expect(cockpit.gridDegradedReason).toContain('1 operator present');
+        expect(cockpit.gridDegradedReason).not.toContain('1 operators')
+    });
+
+    test('a REPORTED zero is the truly-empty plane, not a scoped one', async () => {
+        // 0 shared AND 0 operators present is the genuine define-agents case. Reporting zero is a
+        // fact; the scoped line would claim liveness the producer just denied.
+        const {cockpit} = await routeLoadRoster({
+            fleetRoster: async () => ({presence: {operatorsPresent: 0}, rows: []})
+        });
+
+        expect(cockpit.gridDegradedReason).toBe('server connected · fleet registry empty — define agents to go live')
+    });
+
+    test('an ABSENT count leaves the pre-projection line byte-identical', async () => {
+        // The no-regression arm: every plane whose presence projection has not shipped must render
+        // exactly what it rendered before. Absence is NOT REPORTED, never a zero to reason from.
+        const {cockpit} = await routeLoadRoster({fleetRoster: async () => ({rows: []})});
+
+        expect(cockpit.gridDegradedReason).toBe('server connected · fleet registry empty — define agents to go live');
+
+        const {cockpit: nulled} = await routeLoadRoster({
+            fleetRoster: async () => ({presence: {operatorsPresent: null}, rows: []})
+        });
+
+        expect(nulled.gridDegradedReason).toBe('server connected · fleet registry empty — define agents to go live')
+    });
+
     test('the answered-empty reason is RETRACTED on silence — the claim must not outlive the connection', async () => {
         // empty answer retains the cause…
         const {cockpit} = await routeLoadRoster({fleetRoster: async () => ({rows: []})});


### PR DESCRIPTION
Resolves neomjs/neo#16824

The cockpit had exactly one answered-empty line — `server connected · fleet registry empty — define agents to go live`. On a default-private plane that shares nothing with the viewer, that is a lie in the **actionable** direction: it tells someone to define agents on a plane that *has* agents they cannot see. The operator action differs categorically — request access, not define agents, and not start the server.

Evidence: L2 (the DTO and the cockpit read path are both executed under spec, with the empty branch driven through the real `loadRoster`). Residual: none.

## AC Evidence
| AC | Evidence |
|---|---|
| AC-1 | `createFleetCockpitStatus` accepts `operatorsPresent` and emits top-level `presence: {operatorsPresent}` — a bare count, asserted to carry no identity-shaped keys (`fleetCockpitStatus.spec.mjs`, *"a bare count, never identities"*). See the twin note below: the parity-linted twins bind method **names**, and `fleetRoster` is already in both |
| AC-2 | `container.spec.mjs` — *"SCOPED-empty names the plane as alive and the action as request-access"* asserts the exact line `plane alive · 3 operators present · 0 agents shared with you · request access`, distinguishable from the registry-empty line and from the dead-plane retraction path the adjacent arms already cover |
| AC-3 | *"an ABSENT count leaves the pre-projection line byte-identical"* — asserts the full string for both a missing `presence` and an explicit `{operatorsPresent: null}` |
| AC-4 | four cockpit arms (`container.spec.mjs`) + three DTO arms (`fleetCockpitStatus.spec.mjs`); **142 passed** across the two files |

## Deltas from ticket

**AC-1 says "twin-bound, parity-linted" and that turned out not to describe these files.** `ai/services/fleet/fleetWireMethods.mjs` and its browser twin bind method **names** — `fleetRoster` is already listed in both and needs no change — not result shapes. The result contract lives in the producer's JSDoc and in `createFleetCockpitStatus`'s signature, which is where I put it. `lint-fleet-vocabulary-parity` passes unchanged. Flagging it rather than quietly satisfying a different thing than the AC asked for.

**A malformed count degrades to not-reported.** Not in the ticket. `-1`, `1.5`, `'3'`, `NaN` and `{}` all yield `{operatorsPresent: null}` — the DTO owns every value it emits, and `plane alive · -1 operators present` is worse than saying nothing.

**A reported `0` renders the registry-empty line, deliberately.** Zero shared *and* zero operators present is the genuine define-agents case; using the scoped line there would claim liveness the producer just denied. Only a positive count takes the new branch.

**Pluralisation is rendered, not templated over** — `1 operator present`, with an arm asserting the string `1 operators` never appears.

## Test Evidence

**Red-proof.** Collapsing the branch back to the single unconditional line turns the scoped-empty arms red **on their own assertions**, not on an adjacent error — the pluralisation arm fails with `Expected substring: "1 operator present"`. The absent-count arm stays green under that mutation, which is the check that it is testing no-regression rather than the new branch.

Both specs green after restore: **142 passed**.

## Post-Merge Validation

Nothing is owed here. This is the consumer half by the ticket's own scoping — the plane-side projection that supplies the count is S3's, and this PR is the contract it must meet: an integer ≥ 0 as `operatorsPresent`, or nothing at all. A producer that cannot determine the count must omit it rather than send `0`.

Authored by Grace (Claude Opus 5, Claude Code). Session 728a756d-71df-48e6-8dad-0bac498ca23e.
