### PR TITLE
fix(ai): enforce Playwright suite path containment (#16508)

### DIFF
--- a/ai/mcp/server/file-system/services/FileSystemService.mjs
+++ b/ai/mcp/server/file-system/services/FileSystemService.mjs
@@ -1,7 +1,7 @@
-import fs from 'fs/promises';
-import path from 'path';
+import fs           from 'fs/promises';
+import path         from 'path';
 import { execFile } from 'child_process';
-import util from 'util';
+import util         from 'util';
 
 /**
  * `execFile`, not `exec`. `exec` spawns a shell, which would make every argument a fragment of a
@@ -127,7 +127,7 @@ class FileSystemService {
 
     static async readFile({absolutePath}) {
         const safePath = await ensureSandboxed(absolutePath);
-        const buffer = await fs.readFile(safePath);
+        const buffer   = await fs.readFile(safePath);
         return { content: buffer.toString('utf-8') };
     }
 
@@ -139,12 +139,12 @@ class FileSystemService {
 
     static async listDirectory({absolutePath}) {
         const safePath = await ensureSandboxed(absolutePath);
-        const entries = await fs.readdir(safePath, { withFileTypes: true });
+        const entries  = await fs.readdir(safePath, { withFileTypes: true });
 
         return entries.map(entry => ({
-            name: entry.name,
+            name       : entry.name,
             isDirectory: entry.isDirectory(),
-            isFile: entry.isFile()
+            isFile     : entry.isFile()
         }));
     }
 
@@ -161,11 +161,23 @@ class FileSystemService {
         }
     }
 
+    /**
+     * @summary Runs one Playwright spec only when its canonical path is inside the project suite.
+     * @param {Object} options
+     * @param {String} options.absolutePath The caller-selected spec path.
+     * @returns {Promise<String>} The Playwright runner output.
+     * @throws {Error} If the canonical path is outside the project or Playwright suite.
+     */
     static async runPlaywrightTest({absolutePath}) {
-        const safePath = await ensureSandboxed(absolutePath);
+        const
+            safePath  = await ensureSandboxed(absolutePath),
+            suiteRoot = await fs.realpath(path.resolve(process.cwd(), 'test/playwright')),
+            relative  = path.relative(suiteRoot, safePath);
 
-        // Strict guard: ensure it's actually a test file in the playwright directory
-        if (!safePath.includes('test/playwright/')) {
+        // `safePath` and `suiteRoot` are both canonical. Compare on a segment boundary so a sibling
+        // such as `/atest/playwright/` cannot impersonate the suite, and keep the suite root itself
+        // excluded because it is a directory rather than a spec.
+        if (relative === '' || path.isAbsolute(relative) || relative.split(path.sep)[0] === '..') {
             throw new Error('403 Forbidden: Can only execute Playwright specs within the test/playwright/ directory.');
         }
 

--- a/ai/mcp/server/file-system/services/FileSystemService.mjs
+++ b/ai/mcp/server/file-system/services/FileSystemService.mjs
@@ -166,13 +166,26 @@ class FileSystemService {
      * @param {Object} options
      * @param {String} options.absolutePath The caller-selected spec path.
      * @returns {Promise<String>} The Playwright runner output.
-     * @throws {Error} If the canonical path is outside the project or Playwright suite.
+     * @throws {Error} If the canonical path is outside the project or Playwright suite, or if
+     *   canonical Playwright suite containment cannot be established.
      */
     static async runPlaywrightTest({absolutePath}) {
-        const
-            safePath  = await ensureSandboxed(absolutePath),
-            suiteRoot = await fs.realpath(path.resolve(process.cwd(), 'test/playwright')),
-            relative  = path.relative(suiteRoot, safePath);
+        const safePath = await ensureSandboxed(absolutePath);
+        let   suiteRoot;
+
+        // `safePath` proves project containment, not suite containment. If the suite boundary
+        // itself cannot be canonicalized, that second verdict is unknown and must fail closed with
+        // the guard's vocabulary rather than escape as a retry-looking filesystem error.
+        try {
+            suiteRoot = await fs.realpath(path.resolve(process.cwd(), 'test/playwright'))
+        } catch (error) {
+            throw new Error(
+                `403 Forbidden: Playwright suite containment could not be established (${error?.code ?? 'unknown'}). ` +
+                `Refusing the operation — this is NOT a verdict that the path is inside the suite.`
+            );
+        }
+
+        const relative = path.relative(suiteRoot, safePath);
 
         // `safePath` and `suiteRoot` are both canonical. Compare on a segment boundary so a sibling
         // such as `/atest/playwright/` cannot impersonate the suite, and keep the suite root itself

--- a/test/playwright/unit/ai/mcp/server/file-system/FileSystemService.spec.mjs
+++ b/test/playwright/unit/ai/mcp/server/file-system/FileSystemService.spec.mjs
@@ -19,18 +19,37 @@ import FileSystemService from '../../../../../../../ai/mcp/server/file-system/se
  */
 test.describe('ai/mcp/server/file-system FileSystemService', () => {
     const
-        root   = path.resolve(process.cwd()),
-        tmpDir = path.join(root, 'tmp', `fs-service-spec-${process.pid}`),
+        root        = path.resolve(process.cwd()),
+        suiteRoot   = path.join(root, 'test', 'playwright'),
+        suiteTmpDir = path.join(suiteRoot, `.fs-service-spec-${process.pid}`),
+        tmpDir      = path.join(root, 'tmp', `fs-service-spec-${process.pid}`),
+        falseSuite  = path.join(tmpDir, 'atest', 'playwright'),
+        falseSpec   = path.join(falseSuite, 'probe.spec.mjs'),
+        inSuiteSpec = path.join(
+            suiteRoot,
+            'unit',
+            'ai',
+            'mcp',
+            'server',
+            'file-system',
+            'toolServiceDispatch.spec.mjs'
+        ),
+        aliasInSuite = path.join(suiteTmpDir, 'outside-alias'),
         // A space AND a semicolon: the space alone splits argv-vs-shell, the semicolon is what turns
         // a split into command execution. Both are legal in a POSIX filename and both pass the jail.
-        hostile = path.join(tmpDir, 'probe ;.mjs');
+        hostile      = path.join(tmpDir, 'probe ;.mjs');
 
     test.beforeAll(async () => {
         await fs.ensureDir(tmpDir);
+        await fs.ensureDir(falseSuite);
+        await fs.ensureDir(suiteTmpDir);
         await fs.writeFile(hostile, 'export const ok = 1;\n', 'utf-8');
+        await fs.writeFile(falseSpec, 'export const outsideSuite = true;\n', 'utf-8');
+        await fs.symlink(tmpDir, aliasInSuite, 'dir');
     });
 
     test.afterAll(async () => {
+        await fs.remove(suiteTmpDir).catch(() => {});
         await fs.remove(tmpDir).catch(() => {});
     });
 
@@ -221,6 +240,34 @@ test.describe('ai/mcp/server/file-system FileSystemService', () => {
     test('#15818 runPlaywrightTest still refuses a sandboxed path outside test/playwright/', async () => {
         // The directory guard is independent of the argv change and must survive it.
         await expect(FileSystemService.runPlaywrightTest({absolutePath: hostile}))
+            .rejects.toThrow(/403 Forbidden: Can only execute Playwright specs/);
+    });
+
+    test('#16508 a substring-shaped path outside the Playwright suite is refused', async () => {
+        // The old guard admitted this exact shape: `/atest/playwright/` contains the literal
+        // `test/playwright/`, even though the canonical file is nowhere inside the suite root.
+        await expect(FileSystemService.runPlaywrightTest({absolutePath: falseSpec}))
+            .rejects.toThrow(/403 Forbidden: Can only execute Playwright specs/);
+    });
+
+    test('#16508 a legitimate spec inside the Playwright suite still crosses the guard', async () => {
+        const result = await FileSystemService.runPlaywrightTest({absolutePath: inSuiteSpec});
+
+        // The runner outcome is deliberately not asserted here: this method currently invokes the
+        // generic Playwright CLI, whose config contract belongs to a different ticket. Either result
+        // proves the suite guard admitted the canonical in-suite path instead of refusing everything.
+        expect(result).toMatch(/^Test (?:Passed|Failed):/);
+    });
+
+    test('#16508 traversal that normalizes outside the Playwright suite is refused', async () => {
+        const traversal = [suiteRoot, '..', '..', path.relative(root, hostile)].join(path.sep);
+
+        await expect(FileSystemService.runPlaywrightTest({absolutePath: traversal}))
+            .rejects.toThrow(/403 Forbidden: Can only execute Playwright specs/);
+    });
+
+    test('#16508 an in-suite symlink resolving outside the Playwright suite is refused', async () => {
+        await expect(FileSystemService.runPlaywrightTest({absolutePath: path.join(aliasInSuite, path.basename(hostile))}))
             .rejects.toThrow(/403 Forbidden: Can only execute Playwright specs/);
     });
 });

--- a/test/playwright/unit/ai/mcp/server/file-system/FileSystemService.spec.mjs
+++ b/test/playwright/unit/ai/mcp/server/file-system/FileSystemService.spec.mjs
@@ -259,6 +259,22 @@ test.describe('ai/mcp/server/file-system FileSystemService', () => {
         expect(result).toMatch(/^Test (?:Passed|Failed):/);
     });
 
+    test('#16508 an unresolvable Playwright suite root fails closed as a containment refusal', async () => {
+        const originalCwd = process.cwd;
+
+        // The outer project jail can still prove this file is inside the temporary cwd. The second
+        // boundary cannot prove where the Playwright suite is because that cwd has no such tree.
+        // A raw ENOENT is therefore an escaped guard ambiguity, not an ordinary I/O failure.
+        process.cwd = () => tmpDir;
+
+        try {
+            await expect(FileSystemService.runPlaywrightTest({absolutePath: hostile}))
+                .rejects.toThrow(/403 Forbidden: Playwright suite containment could not be established \(ENOENT\)/);
+        } finally {
+            process.cwd = originalCwd
+        }
+    });
+
     test('#16508 traversal that normalizes outside the Playwright suite is refused', async () => {
         const traversal = [suiteRoot, '..', '..', path.relative(root, hostile)].join(path.sep);
 


### PR DESCRIPTION
Resolves neomjs/neo#16508

`runPlaywrightTest()` now compares the canonical requested path against the canonical `test/playwright` root with `path.relative()`, so substring-shaped siblings cannot impersonate the suite. If that suite root cannot be canonicalized, the guard now fails closed with a classified containment refusal instead of leaking a retry-looking filesystem error. The outer `ensureSandboxed()` jail remains unchanged, and the existing MCP unit spec covers the bypass, an unresolvable suite root, the in-suite positive control, traversal, and symlink resolution.

Evidence: L2 (behavioral unit coverage exercises canonical filesystem paths and the real runner boundary) → L2 required (all five close-target ACs are unit-observable). No residuals.

## AC Evidence

| Acceptance criterion | Evidence |
|---|---|
| AC-1 | CI-covered: `FileSystemService.runPlaywrightTest()` uses `path.relative()` over canonical candidate and suite-root paths; unresolvable suite-root canonicalization is classified and refused. |
| AC-2 | CI-covered: `#16508 a substring-shaped path outside the Playwright suite is refused`; pre-fix red resolved to `Test Failed: No tests found` instead of rejecting. |
| AC-3 | CI-covered: `#16508 a legitimate spec inside the Playwright suite still crosses the guard`. |
| AC-4 | CI-covered: dedicated traversal and in-suite-symlink-to-outside-suite refusal arms. |
| AC-5 | CI-covered: `ensureSandboxed()` is unchanged; all pre-existing canonical jail regression arms remain, and the suite-root `ENOENT` arm proves the secondary boundary also fails closed. |

## Deltas from ticket

None substantive. Executor process isolation remains the separate concern tracked by `#16979`; this PR changes only the narrower suite-directory guarantee.

## Test Evidence

- Original pre-fix red proof: the focused file failed exactly 1 of 18 tests because `/atest/playwright/` passed the substring guard and reached the runner.
- Review red proof against `2b6e63bfd0`: the added suite-root arm failed exactly 1 of 19 tests because raw `ENOENT` escaped before classification.
- Rebased exact head `eb61347edb`: focused file 19/19 passed.
- Exact-head full unit: 15,114 passed and 13 skipped; two unrelated transient failures (DragCoordinator overlap ordering and MemoryService retry-timer count) both passed in the targeted same-head rerun, 48/48.
- All coverage runs in CI.

## Post-Merge Validation

None; no post-merge-only observable remains.

Authored by Euclid (GPT-5.6 Sol, Codex). Session e3e2d32f-430b-4861-af1f-b6a214fa0513.
