### PR TITLE
feat(agentos): gate unless-you-want on indefinite objects (#17370)

### DIFF
--- a/ai/scripts/lifecycle/deferencePhraseMatch.mjs
+++ b/ai/scripts/lifecycle/deferencePhraseMatch.mjs
@@ -19,6 +19,7 @@
 export const DEFERENCE_PHRASES = [
     'would you like me to',
     'unless you want me',
+    'unless you want',
     'want me to',
     'do you want me',
     'Your steer on',
@@ -43,6 +44,23 @@ export const DEFERENCE_PHRASES = [
     // after a reviewer EXECUTED those sentences against this matcher rather than arguing about them.
     'if you want it'
 ];
+
+/**
+ * The closed object vocabulary that makes `unless you want` a lane handback rather than ordinary
+ * technical prose. Each token is an indefinite pro-form: it offers an unspecified alternative to
+ * an action the agent already chose. Concrete noun phrases stay available to authors, because an
+ * enforcing Stop hook that reserved them would become a leash rather than a mirror.
+ *
+ * Kept as exported data rather than hidden in a regex so every semantic expansion is a reviewable
+ * list change with a bidirectional falsifier corpus.
+ * @type {String[]}
+ */
+export const INDEFINITE_DEFERENCE_OBJECTS = Object.freeze([
+    'something',
+    'anything',
+    'otherwise',
+    'another'
+]);
 
 /**
  * Phrases whose gate-forming reading depends on clause POSITION, not presence.
@@ -97,6 +115,31 @@ function isClauseTerminal(text, endIndex) {
 
     // Soft wrap folds to whitespace; judge what actually follows the wrap.
     return /^[.,:;!?)\]}"'’”]/.test(rest.replace(/^\r?\n[ \t]*/, ''))
+}
+
+/**
+ * @summary Reports whether a matched phrase takes one closed indefinite object token.
+ *
+ * Spaces/tabs and one soft wrap are layout, not grammar, so they are transparent. A paragraph
+ * break ends the clause and cannot manufacture an object continuation. Only the first lexical
+ * token is inspected; the closed data set above owns the semantic decision.
+ * @param {String} text Searchable assistant-turn text.
+ * @param {Number} endIndex Index one past the matched phrase.
+ * @returns {Boolean}
+ * @private
+ */
+function hasIndefiniteDeferenceObject(text, endIndex) {
+    let rest = text.slice(endIndex).replace(/^[ \t]+/, '');
+
+    if (/^\r?\n[ \t]*\r?\n/.test(rest)) {
+        return false
+    }
+
+    rest = rest.replace(/^\r?\n[ \t]*/, '');
+
+    const token = /^([a-z]+)/i.exec(rest)?.[1]?.toLowerCase();
+
+    return token != null && INDEFINITE_DEFERENCE_OBJECTS.includes(token)
 }
 
 /**
@@ -228,7 +271,7 @@ function isAttributiveCitationContext(phrase, text, startIndex) {
         return false;
     }
 
-    const prefix  = text.slice(Math.max(0, startIndex - 80), startIndex).toLowerCase(),
+    const prefix   = text.slice(Math.max(0, startIndex - 80), startIndex).toLowerCase(),
           anchored = CITATION_ANCHOR.exec(prefix);
 
     return anchored !== null && isCitationBridge(anchored[1]);
@@ -261,6 +304,11 @@ export function matchDeferencePhrase(text = '', phrases = DEFERENCE_PHRASES) {
                 endIndex   = startIndex + match[0].length - match[1].length;
 
             if (CLAUSE_TERMINAL_PHRASES.has(phrase) && !isClauseTerminal(searchableText, endIndex)) {
+                continue;
+            }
+
+            if (phrase === 'unless you want' &&
+                !hasIndefiniteDeferenceObject(searchableText, endIndex)) {
                 continue;
             }
 

--- a/ai/scripts/lifecycle/deferencePhraseMatch.mjs
+++ b/ai/scripts/lifecycle/deferencePhraseMatch.mjs
@@ -58,8 +58,7 @@ export const DEFERENCE_PHRASES = [
 export const INDEFINITE_DEFERENCE_OBJECTS = Object.freeze([
     'something',
     'anything',
-    'otherwise',
-    'another'
+    'otherwise'
 ]);
 
 /**

--- a/test/playwright/unit/hooks/deferencePhraseMatch.spec.mjs
+++ b/test/playwright/unit/hooks/deferencePhraseMatch.spec.mjs
@@ -2,6 +2,7 @@ import {test, expect} from '@playwright/test';
 
 import {DEFERENCE_PHRASES,
         DEFERENCE_REMINDER,
+        INDEFINITE_DEFERENCE_OBJECTS,
         buildDeferenceReminder,
         detectDeferencePhrase,
         matchDeferencePhrase} from '../../../../ai/scripts/lifecycle/deferencePhraseMatch.mjs';
@@ -31,6 +32,49 @@ test.describe('ai/scripts/lifecycle/deferencePhraseMatch', () => {
         // Reporting the phrase is not using it - this ticket's own body does exactly that.
         expect(matchDeferencePhrase("The phrase unless you'd rather is part of the deference register."))
             .toBeNull();
+    });
+
+    test('unless you want matches only the closed indefinite-object vocabulary', () => {
+        expect(INDEFINITE_DEFERENCE_OBJECTS).toEqual([
+            'something',
+            'anything',
+            'otherwise',
+            'another'
+        ]);
+
+        expect(matchDeferencePhrase('Taking the parser lane next unless you want something else first.'))
+            .toBe('unless you want');
+        expect(matchDeferencePhrase('Taking the parser lane next unless you want anything else.'))
+            .toBe('unless you want');
+        expect(matchDeferencePhrase('Taking the parser lane next unless you want otherwise.'))
+            .toBe('unless you want');
+        expect(matchDeferencePhrase('Taking the parser lane next unless you want another option.'))
+            .toBe('unless you want');
+        expect(matchDeferencePhrase('Taking the parser lane next UNLESS YOU WANT ANYTHING else.'))
+            .toBe('unless you want');
+
+        expect(matchDeferencePhrase('The default is fine unless you want deterministic isolation.')).toBeNull();
+        expect(matchDeferencePhrase('Keep the current plan unless you want a smaller batch size.')).toBeNull();
+        expect(matchDeferencePhrase('Use the first parser unless you want the other parser.')).toBeNull();
+        expect(matchDeferencePhrase('Taking the parser lane next unless you want.')).toBeNull();
+
+        // The longer existing entry stays independently reachable rather than being shadowed by
+        // the new prefix phrase.
+        expect(matchDeferencePhrase('I can take it unless you want me elsewhere.')).toBe('unless you want me')
+    });
+
+    test('indefinite-object matching reads grammar rather than Markdown layout', () => {
+        expect(matchDeferencePhrase('Taking the parser lane next **unless you want** something else first.'))
+            .toBe('unless you want');
+        expect(matchDeferencePhrase('Taking the parser lane next unless you want\n    anything else first.'))
+            .toBe('unless you want');
+
+        // A concrete object remains ordinary prose across the same soft-wrap path.
+        expect(matchDeferencePhrase('Keep the default unless you want\n    deterministic isolation.')).toBeNull();
+
+        // A paragraph break ends the clause. The next paragraph cannot be recruited as the object.
+        expect(matchDeferencePhrase('Taking the parser lane next unless you want\n\nsomething else is available.'))
+            .toBeNull()
     });
 
     test('matches each tight phrase case-insensitively', () => {

--- a/test/playwright/unit/hooks/deferencePhraseMatch.spec.mjs
+++ b/test/playwright/unit/hooks/deferencePhraseMatch.spec.mjs
@@ -38,8 +38,7 @@ test.describe('ai/scripts/lifecycle/deferencePhraseMatch', () => {
         expect(INDEFINITE_DEFERENCE_OBJECTS).toEqual([
             'something',
             'anything',
-            'otherwise',
-            'another'
+            'otherwise'
         ]);
 
         expect(matchDeferencePhrase('Taking the parser lane next unless you want something else first.'))
@@ -48,14 +47,14 @@ test.describe('ai/scripts/lifecycle/deferencePhraseMatch', () => {
             .toBe('unless you want');
         expect(matchDeferencePhrase('Taking the parser lane next unless you want otherwise.'))
             .toBe('unless you want');
-        expect(matchDeferencePhrase('Taking the parser lane next unless you want another option.'))
-            .toBe('unless you want');
         expect(matchDeferencePhrase('Taking the parser lane next UNLESS YOU WANT ANYTHING else.'))
             .toBe('unless you want');
 
         expect(matchDeferencePhrase('The default is fine unless you want deterministic isolation.')).toBeNull();
         expect(matchDeferencePhrase('Keep the current plan unless you want a smaller batch size.')).toBeNull();
         expect(matchDeferencePhrase('Use the first parser unless you want the other parser.')).toBeNull();
+        expect(matchDeferencePhrase('Use the first parser unless you want another parser.')).toBeNull();
+        expect(matchDeferencePhrase('Idempotent unless you want another run to overwrite state.')).toBeNull();
         expect(matchDeferencePhrase('Taking the parser lane next unless you want.')).toBeNull();
 
         // The longer existing entry stays independently reachable rather than being shadowed by


### PR DESCRIPTION
Resolves #17370

The deference matcher now recognizes `unless you want` only when its next object is one of three always-pro-form tokens: `something`, `anything`, or `otherwise`. Concrete technical noun phrases—including `another parser` / `another run`—terminal use, and paragraph-separated text stay silent; the longer `unless you want me` entry and the existing `if you want it` clause-terminal grammar remain independent.

Evidence: L1 (pure matcher contract + bidirectional Playwright unit corpus) → L1 required (all close-target ACs are deterministic repository behavior). No residuals.

## AC Evidence

| AC-1 | `INDEFINITE_DEFERENCE_OBJECTS` is exported frozen data; the owning spec asserts the exact three-token set and a positive arm for each token. |
| AC-2 | `deferencePhraseMatch.spec.mjs` drives both directions: indefinite alternatives fire; `deterministic isolation`, `a smaller batch size`, `the other parser`, `another parser`, and `another run` return `null`. |
| AC-3 | The truly terminal `unless you want.` returns `null`; the new phrase is not added to `CLAUSE_TERMINAL_PHRASES`. |
| AC-4 | The longer existing form remains independently reachable: `unless you want me elsewhere` returns `unless you want me`, never the new prefix phrase. |
| AC-5 | Emphasis and one soft wrap preserve the indefinite object; the same wrapped concrete object stays silent, and a paragraph break does not bridge. |
| AC-6 | The existing `if you want it` clause-position/layout corpus remains unchanged and green in the owning 23-arm matcher suite. |

## Deltas from ticket

The original ticket prescribed clause-terminality but could not match its own positive example. Intake executed that prescription, proved the contradiction, and the ticket author accepted an indefinite-object discriminator instead. Round-1 review then executed the four-token set and proved `another` can head the same concrete noun phrases the discriminator exists to exclude, so the contract, code, and tests now converge on the three grammar-uniform tokens. `operatorInLoop`, citation handling, and `isClauseTerminal()` remain unchanged.

## Test Evidence

All coverage runs in CI.

## Post-Merge Validation

None — the matcher and every close-target branch are deterministic and CI-observable.

Authored by Emmy (GPT-5.6 Sol Ultra, Codex) consuming Ada's narrowed contract — session A 85b245b1-fa02-49fa-96f6-54e36eda9e4e, session B 429a3792-5cea-4c7b-a409-a1fd8b44ccd2.
