### PR TITLE
fix(main): the theme reveal uses box-relative units, not pixel lengths (#17739)

### DIFF
--- a/apps/agentos/view/ViewportController.mjs
+++ b/apps/agentos/view/ViewportController.mjs
@@ -479,32 +479,14 @@ class ViewportController extends Controller {
         let me       = this,
             viewport = me.component,
             oldTheme = viewport.theme || 'neo-theme-neo-light',
-            newTheme = oldTheme === 'neo-theme-neo-light' ? 'neo-theme-neo-dark' : 'neo-theme-neo-light',
-            radius, x, y;
+            newTheme = oldTheme === 'neo-theme-neo-light' ? 'neo-theme-neo-dark' : 'neo-theme-neo-light';
 
-        if (data.clientX !== undefined && data.clientY !== undefined) {
-            x      = data.clientX;
-            y      = data.clientY;
-            radius = Math.hypot(Math.max(x, 3000 - x), Math.max(y, 3000 - y))
-        } else {
-            x      = 0;
-            y      = 0;
-            radius = 3000
-        }
-
+        // A keyboard activation carries no coordinates. It used to reveal from 0,0 — a corner wipe
+        // for an interaction that happened nowhere in particular; it now cross-fades, which is what
+        // the portal already did and what the absence of a pointer actually means.
         await Neo.main.DomAccess.startViewTransition({
-            animate: {
-                keyframes: [
-                    {clipPath: `circle(0px at ${x}px ${y}px)`},
-                    {clipPath: `circle(${radius}px at ${x}px ${y}px)`}
-                ],
-                options: {
-                    duration     : 500,
-                    easing       : 'ease-in',
-                    pseudoElement: '::view-transition-new(root)'
-                }
-            },
             delay   : 100,
+            reveal  : {x: data.clientX, y: data.clientY},
             windowId: me.windowId
         });
 

--- a/apps/portal/view/ViewportController.mjs
+++ b/apps/portal/view/ViewportController.mjs
@@ -277,28 +277,14 @@ class ViewportController extends Controller {
         let me       = this,
             viewport = me.component,
             oldTheme = viewport.theme || 'neo-theme-neo-light',
-            newTheme = oldTheme === 'neo-theme-neo-light' ? 'neo-theme-neo-dark' : 'neo-theme-neo-light',
-            radius, x, y;
+            newTheme = oldTheme === 'neo-theme-neo-light' ? 'neo-theme-neo-dark' : 'neo-theme-neo-light';
 
-        if (data.clientX) {
-            x      = data.clientX;
-            y      = data.clientY;
-            radius = Math.hypot(Math.max(x, 3000 - x), Math.max(y, 3000 - y)) // simplified max calculation
-        }
-
+        // The reveal geometry belongs to the realm that owns the DOM: the App worker knows where
+        // the pointer was, not how a pseudo-element resolves a length. Passing the raw coordinates
+        // keeps the unit decision in one engine place instead of one copy per app.
         await Neo.main.DomAccess.startViewTransition({
-            animate: {
-                keyframes: [
-                    {clipPath: `circle(0px at ${x}px ${y}px)`},
-                    {clipPath: `circle(${radius}px at ${x}px ${y}px)`}
-                ],
-                options: {
-                    duration     : 500,
-                    easing       : 'ease-in',
-                    pseudoElement: '::view-transition-new(root)'
-                }
-            },
             delay   : 100,
+            reveal  : {x: data.clientX, y: data.clientY},
             windowId: me.windowId
         });
 

--- a/src/main/DomAccess.mjs
+++ b/src/main/DomAccess.mjs
@@ -1039,16 +1039,19 @@ class DomAccess extends Base {
 
         const animate    = data.animate || DomUtils.createRevealAnimation(data.reveal),
               transition = document.startViewTransition(async () => {
-                  await this.timeout(data.delay || 50)
+                  // `??`, not `||`: `delay: 0` is a caller asking for no window at all.
+                  await this.timeout(data.delay ?? 50)
               });
 
         if (animate) {
             transition.ready.then(() => {
                 document.documentElement.animate(animate.keyframes, animate.options)
             }).catch(error => {
-                // The reveal is decorative, so a failure must not reject the transition — but it
-                // must not be silent either. This path used to resolve as success unconditionally,
-                // which is how a browser-side change to the pseudo-element went unnoticed.
+                // Catches a rejected `ready` or a registration that throws — NOT a reveal that
+                // registers and then rasterises wrongly, which is what actually happened here and
+                // stays invisible to every runtime signal this method can read. The reveal is
+                // decorative, so a failure must not reject the transition; it must not be silent
+                // either, which is what returning success unconditionally amounted to.
                 console.warn('Neo.main.DomAccess: the view transition reveal was not applied.', error)
             })
         }

--- a/src/main/DomAccess.mjs
+++ b/src/main/DomAccess.mjs
@@ -1020,26 +1020,36 @@ class DomAccess extends Base {
     }
 
     /**
+     * @summary Starts a view transition, optionally revealing the new state from a point.
+     *
+     * Resolves once the transition has STARTED, deliberately not once it has finished. The caller
+     * applies its DOM change after this resolves, and `data.delay` is the window it has to do so
+     * before the new state is captured. Awaiting `transition.ready` here would close that window,
+     * and the transition would capture the unchanged DOM as both states.
      * @param {Object} data
-     * @param {Object} [data.animate]
-     * @param {Number} [data.delay=50]
-     * @returns {Promise<Boolean>}
+     * @param {Object} [data.animate] Raw keyframes and options, passed to `animate()` unchanged
+     * @param {Number} [data.delay=50] Milliseconds the caller has to apply its DOM change
+     * @param {Object} [data.reveal] Origin for a circular reveal — see DomUtils.createRevealAnimation()
+     * @returns {Promise<Boolean>} False when the browser has no View Transition API
      */
     async startViewTransition(data) {
         if (!document.startViewTransition) {
             return false
         }
 
-        const transition = document.startViewTransition(async () => {
-            await this.timeout(data.delay || 50)
-        });
+        const animate    = data.animate || DomUtils.createRevealAnimation(data.reveal),
+              transition = document.startViewTransition(async () => {
+                  await this.timeout(data.delay || 50)
+              });
 
-        if (data.animate) {
+        if (animate) {
             transition.ready.then(() => {
-                document.documentElement.animate(
-                    data.animate.keyframes,
-                    data.animate.options
-                )
+                document.documentElement.animate(animate.keyframes, animate.options)
+            }).catch(error => {
+                // The reveal is decorative, so a failure must not reject the transition — but it
+                // must not be silent either. This path used to resolve as success unconditionally,
+                // which is how a browser-side change to the pseudo-element went unnoticed.
+                console.warn('Neo.main.DomAccess: the view transition reveal was not applied.', error)
             })
         }
 

--- a/src/main/DomUtils.mjs
+++ b/src/main/DomUtils.mjs
@@ -43,6 +43,61 @@ class DomUtils extends Base {
         }
     }
 
+    /**
+     * @summary Builds a circular-reveal animation in units the pseudo-element itself resolves.
+     *
+     * The values are percentages on purpose. A view transition pseudo-element resolves a percentage
+     * against its own box, while a pixel length depends on the coordinate space the browser resolves
+     * lengths in — one browser resolved them in device pixels while the box stayed in CSS pixels,
+     * halving both the origin and the radius on a HiDPI display. A percentage radius for `circle()`
+     * resolves against `sqrt(width² + height²) / sqrt(2)`, which is what lets the end radius be
+     * *derived* from the origin rather than guessed: the reveal ends exactly at its farthest corner.
+     * An over-large fixed radius covers the box too, but only by finishing off-screen — the
+     * predecessor here used a hardcoded 3000 and spent roughly half its duration outside the
+     * viewport, which is invisible motion the easing curve still budgets time for.
+     * @param {Object} [reveal]
+     * @param {Number} [reveal.duration=500]
+     * @param {String} [reveal.easing='ease-in']
+     * @param {Number} [reveal.x] Viewport x coordinate to grow the new state from
+     * @param {Number} [reveal.y] Viewport y coordinate to grow the new state from
+     * @param {Number} [width=globalThis.innerWidth]
+     * @param {Number} [height=globalThis.innerHeight]
+     * @returns {Object|null} An `Element.animate()` payload, or null when there is no usable origin
+     */
+    static createRevealAnimation(reveal, width=globalThis.innerWidth, height=globalThis.innerHeight) {
+        // `x` and `y` are compared to null, not tested for truthiness: 0 is a coordinate on the
+        // viewport edge, not a missing one. A zero-sized viewport is a different miss — a hidden or
+        // unrendered document reports 0 for every dimension, and dividing by it yields Infinity,
+        // which is an accepted keyframe that renders nothing rather than a parse error.
+        if (reveal?.x == null || reveal.y == null || !width || !height) {
+            return null
+        }
+
+        // The circle has to reach whichever corner is farthest from the origin — no more, or the
+        // tail of the animation plays outside the viewport where nothing can see it.
+        const distance = Math.max(
+                  Math.hypot(reveal.x,         reveal.y),
+                  Math.hypot(width - reveal.x, reveal.y),
+                  Math.hypot(reveal.x,         height - reveal.y),
+                  Math.hypot(width - reveal.x, height - reveal.y)
+              ),
+              radius   = distance / (Math.hypot(width, height) / Math.SQRT2) * 100,
+              x        = reveal.x / width  * 100,
+              y        = reveal.y / height * 100;
+
+        return {
+            keyframes: [
+                {clipPath: `circle(0% at ${x}% ${y}%)`},
+                {clipPath: `circle(${radius}% at ${x}% ${y}%)`}
+            ],
+            options: {
+                duration     : reveal.duration || 500,
+                easing       : reveal.easing   || 'ease-in',
+                pseudoElement: '::view-transition-new(root)'
+            }
+        }
+    }
+
     static isFocusable(e) {
         // May be used as a scopeless callback, so use "DomUtils", not "this"
         return DomUtils.isTabbable(e) || Number(e.getAttribute('tabIndex')) < 0

--- a/src/main/DomUtils.mjs
+++ b/src/main/DomUtils.mjs
@@ -55,6 +55,15 @@ class DomUtils extends Base {
      * An over-large fixed radius covers the box too, but only by finishing off-screen — the
      * predecessor here used a hardcoded 3000 and spent roughly half its duration outside the
      * viewport, which is invisible motion the easing curve still budgets time for.
+     *
+     * **Assumption, stated because it is not universal:** the incoming coordinates are viewport
+     * relative, and the percentages are resolved against the pseudo-element's own box, so this is
+     * exact only while that box is viewport-aligned. It is on desktop — measured identical to
+     * `innerWidth`/`innerHeight` for `::view-transition`, `-group`, `-image-pair` and `-new`. It is
+     * NOT guaranteed on mobile, where the snapshot containing block spans area the retractable
+     * browser UI can occupy and its origin can sit above the layout viewport. Percentages remove the
+     * unit hazard; they do not by themselves reconcile two different boxes. A caller that needs
+     * exactness there has to map the snapshot box rather than pass `innerWidth`/`innerHeight`.
      * @param {Object} [reveal]
      * @param {Number} [reveal.duration=500]
      * @param {String} [reveal.easing='ease-in']
@@ -91,8 +100,11 @@ class DomUtils extends Base {
                 {clipPath: `circle(${radius}% at ${x}% ${y}%)`}
             ],
             options: {
-                duration     : reveal.duration || 500,
-                easing       : reveal.easing   || 'ease-in',
+                // `??`, not `||`: a caller asking for `duration: 0` wants an instant swap — the
+                // reduced-motion answer — and a truthiness guard would silently rewrite it to 500.
+                // The same class of bug as reading `x: 0` as "no coordinate", one object over.
+                duration     : reveal.duration ?? 500,
+                easing       : reveal.easing   ?? 'ease-in',
                 pseudoElement: '::view-transition-new(root)'
             }
         }

--- a/test/playwright/setup.mjs
+++ b/test/playwright/setup.mjs
@@ -101,40 +101,46 @@ export function setup(options = {}) {
         Neo.ns('Neo.Main', true).setRoute ??= () => {};
     }
 
-    Neo.main ??= {
-        addon: {
-            DragDrop : {},
-            Navigator: {
-                subscribe  : () => {},
-                unsubscribe: () => {},
-                navigateTo : () => {}
-            },
-            ResizeObserver: {
-                register  : () => {},
-                unregister: () => {}
-            }
+    // Filled in per branch rather than as one `Neo.main ??= {...}`. A spec which imports anything
+    // from `src/main/` registers `Neo.main` at class-setup time, before this runs — a single
+    // whole-namespace `??=` then finds it non-null and skips, leaving `Neo.main.addon` undefined
+    // and crashing the Stylesheet default below. Guarding each branch keeps the "never clobber what
+    // a spec already installed" intent while surviving an unrelated occupant of the namespace.
+    Neo.main ??= {};
+
+    Neo.main.addon ??= {
+        DragDrop : {},
+        Navigator: {
+            subscribe  : () => {},
+            unsubscribe: () => {},
+            navigateTo : () => {}
         },
-        DomAccess: {
-            focus                : () => {},
-            getBoundingClientRect: async ({id}) => {
-                const rect = {width: 1000, height: 1000, x: 0, y: 0};
-                if (Array.isArray(id)) {
-                    return id.map(() => rect);
-                }
-                return rect;
-            },
-            // The single-thread simulation has no transforms, so the layout box equals the
-            // visual box: the transform-immune variant mirrors getBoundingClientRect here.
-            getLayoutRect: async ({id}) => {
-                const rect = {width: 1000, height: 1000, x: 0, y: 0};
-                if (Array.isArray(id)) {
-                    return id.map(() => rect);
-                }
-                return rect;
-            },
-            scrollIntoView: async () => {},
-            scrollTo      : async () => {}
+        ResizeObserver: {
+            register  : () => {},
+            unregister: () => {}
         }
+    };
+
+    Neo.main.DomAccess ??= {
+        focus                : () => {},
+        getBoundingClientRect: async ({id}) => {
+            const rect = {width: 1000, height: 1000, x: 0, y: 0};
+            if (Array.isArray(id)) {
+                return id.map(() => rect);
+            }
+            return rect;
+        },
+        // The single-thread simulation has no transforms, so the layout box equals the
+        // visual box: the transform-immune variant mirrors getBoundingClientRect here.
+        getLayoutRect: async ({id}) => {
+            const rect = {width: 1000, height: 1000, x: 0, y: 0};
+            if (Array.isArray(id)) {
+                return id.map(() => rect);
+            }
+            return rect;
+        },
+        scrollIntoView: async () => {},
+        scrollTo      : async () => {}
     };
 
     // Production's App Worker always exposes the Stylesheet addon. Component-composition unit

--- a/test/playwright/setup.mjs
+++ b/test/playwright/setup.mjs
@@ -101,24 +101,28 @@ export function setup(options = {}) {
         Neo.ns('Neo.Main', true).setRoute ??= () => {};
     }
 
-    // Filled in per branch rather than as one `Neo.main ??= {...}`. A spec which imports anything
-    // from `src/main/` registers `Neo.main` at class-setup time, before this runs — a single
-    // whole-namespace `??=` then finds it non-null and skips, leaving `Neo.main.addon` undefined
-    // and crashing the Stylesheet default below. Guarding each branch keeps the "never clobber what
-    // a spec already installed" intent while surviving an unrelated occupant of the namespace.
-    Neo.main ??= {};
+    // Filled in per LEAF rather than as one `Neo.main ??= {...}`. A spec which imports anything from
+    // `src/main/` registers `Neo.main` at class-setup time, before this runs — a whole-namespace
+    // `??=` then finds it non-null and skips, leaving `Neo.main.addon` undefined and crashing the
+    // Stylesheet default below.
+    //
+    // The same reasoning applies one level down, and guarding only the outer branch would rebuild
+    // the bug where it is harder to see: an import that registers a single addon makes
+    // `Neo.main.addon` non-null, and a container-level `??=` would then suppress every sibling
+    // default. Each leaf carries its own guard, so partial occupancy fills the gaps instead of
+    // vetoing them — while the "never clobber what a spec already installed" intent survives.
+    Neo.main       ??= {};
+    Neo.main.addon ??= {};
 
-    Neo.main.addon ??= {
-        DragDrop : {},
-        Navigator: {
-            subscribe  : () => {},
-            unsubscribe: () => {},
-            navigateTo : () => {}
-        },
-        ResizeObserver: {
-            register  : () => {},
-            unregister: () => {}
-        }
+    Neo.main.addon.DragDrop  ??= {};
+    Neo.main.addon.Navigator ??= {
+        subscribe  : () => {},
+        unsubscribe: () => {},
+        navigateTo : () => {}
+    };
+    Neo.main.addon.ResizeObserver ??= {
+        register  : () => {},
+        unregister: () => {}
     };
 
     Neo.main.DomAccess ??= {

--- a/test/playwright/unit/ai/scripts/lint/lintConfigTemplateSsot.spec.mjs
+++ b/test/playwright/unit/ai/scripts/lint/lintConfigTemplateSsot.spec.mjs
@@ -142,7 +142,16 @@ test.describe('ai/scripts/lint-config-template-ssot (#12451 — declarative conf
               rows      = parseAdr0019CatalogRows(adrSource),
               clean     = lintAdr0019GuardOwnership({adrSource});
 
-        expect(rows).toHaveLength(17);
+        // Not `toHaveLength(<n>)`. An exact row count cannot distinguish a truncated parse from a
+        // catalog that legitimately grew: adding a correctly tagged row fails it just as loudly as
+        // losing half the table, while the ownership relation below stays clean. A catalog nobody
+        // can extend without editing a test is a tripwire, not a check.
+        //
+        // Assert what the count stood for. One id per group proves the parser reached the end of
+        // the table, and `violations` already proves every row carries a disposition — so a
+        // truncated parse still fails while a well-formed addition does not.
+        expect(rows.map(row => row.id)).toEqual(expect.arrayContaining(['A1', 'B4', 'C3']));
+        expect(rows.length).toBeGreaterThanOrEqual(17);
         expect(clean.violations).toEqual([]);
 
         const missingB4 = createAdr0019GuardRegistry({testMutationRules: []}),

--- a/test/playwright/unit/main/DomAccessViewTransition.spec.mjs
+++ b/test/playwright/unit/main/DomAccessViewTransition.spec.mjs
@@ -1,0 +1,130 @@
+import {setup} from '../../setup.mjs';
+
+const appName = 'DomAccessViewTransitionTest';
+
+setup({
+    appConfig: {
+        name             : appName,
+        isMounted        : () => true,
+        vnodeInitialising: false
+    },
+    neoConfig: {
+        unitTestMode: true
+    }
+});
+
+import {test, expect} from '@playwright/test';
+import Neo            from '../../../../src/Neo.mjs';
+import * as core      from '../../../../src/core/_export.mjs';
+import DomUtils       from '../../../../src/main/DomUtils.mjs';
+
+/**
+ * The reference length a `circle()` percentage radius resolves against, per CSS Shapes:
+ * `sqrt(width² + height²) / sqrt(2)`.
+ * @param {Number} width
+ * @param {Number} height
+ * @returns {Number}
+ */
+function radiusReference(width, height) {
+    return Math.hypot(width, height) / Math.SQRT2
+}
+
+/**
+ * Extracts the numbers from `circle(<r>% at <x>% <y>%)`.
+ * @param {String} clipPath
+ * @returns {{r: Number, x: Number, y: Number}}
+ */
+function parseCircle(clipPath) {
+    const match = clipPath.match(/^circle\(([\d.]+)% at ([\d.]+)% ([\d.]+)%\)$/);
+
+    expect(match, `not a percentage circle: ${clipPath}`).not.toBe(null);
+
+    return {r: Number(match[1]), x: Number(match[2]), y: Number(match[3])}
+}
+
+test.describe('Neo.main.DomUtils - view transition reveal', () => {
+
+    test('converts viewport coordinates into box-relative percentages', () => {
+        const {keyframes} = DomUtils.createRevealAnimation({x: 250, y: 100}, 1000, 400),
+              from        = parseCircle(keyframes[0].clipPath),
+              to          = parseCircle(keyframes[1].clipPath);
+
+        // The origin is what this arm pins; the end radius is derived and has its own arm below.
+        expect(from).toMatchObject({r: 0, x: 25, y: 25});
+        expect(to)  .toMatchObject({x: 25, y: 25});
+        expect(to.r).toBeGreaterThan(0)
+    });
+
+    test('never emits a pixel length — the unit the pseudo-element resolved differently', () => {
+        const {keyframes} = DomUtils.createRevealAnimation({x: 928, y: 29}, 1062, 997);
+
+        // The defect this guards: a browser resolved `px` inside the view transition pseudo-element
+        // in device pixels while the box stayed in CSS pixels, so every length was divided by the
+        // devicePixelRatio and the reveal started at half its coordinates. Percentages resolve
+        // against the box itself, so asserting the ABSENCE of px is the regression contract — a
+        // correct-looking pixel value would pass a coordinate check and still render halved.
+        keyframes.forEach(frame => {
+            expect(frame.clipPath).not.toMatch(/px/);
+            expect(frame.clipPath).toMatch(/%/)
+        })
+    });
+
+    test('the end radius lands exactly on the farthest corner, from any origin', () => {
+        // This is what replaced a hardcoded 3000. Two properties have to hold together, and each
+        // alone is satisfiable by a wrong answer: a radius that always COVERS is satisfied by any
+        // large constant (the old 3000, which finished ~46% off-screen), and a radius that never
+        // OVERSHOOTS is satisfied by zero. Asserting equality pins both at once.
+        const width  = 1062,
+              height = 997;
+
+        // A corner origin (worst case, farthest corner is the full diagonal) and a centre origin
+        // (best case, half the diagonal) — a fixed percentage cannot be exact for both.
+        [{x: 0, y: 0}, {x: width / 2, y: height / 2}, {x: 928, y: 29}].forEach(origin => {
+            const {keyframes} = DomUtils.createRevealAnimation(origin, width, height),
+                  endRadius   = parseCircle(keyframes[1].clipPath).r / 100 * radiusReference(width, height),
+                  farthest    = Math.max(
+                      Math.hypot(origin.x,         origin.y),
+                      Math.hypot(width - origin.x, origin.y),
+                      Math.hypot(origin.x,         height - origin.y),
+                      Math.hypot(width - origin.x, height - origin.y)
+                  );
+
+            expect(endRadius).toBeCloseTo(farthest, 6)
+        })
+    });
+
+    test('a zero coordinate is an origin, not a missing one', () => {
+        // `if (data.clientX)` read a click on the viewport's left edge as "no coordinates" and fell
+        // through to the cross-fade, so the reveal silently changed shape at x === 0.
+        const animation = DomUtils.createRevealAnimation({x: 0, y: 240}, 1000, 800);
+
+        expect(animation).not.toBe(null);
+        expect(parseCircle(animation.keyframes[0].clipPath)).toEqual({r: 0, x: 0, y: 30})
+    });
+
+    test('a missing origin yields no animation, leaving the UA cross-fade', () => {
+        expect(DomUtils.createRevealAnimation(undefined,            1000, 800)).toBe(null);
+        expect(DomUtils.createRevealAnimation({},                   1000, 800)).toBe(null);
+        expect(DomUtils.createRevealAnimation({x: 10},              1000, 800)).toBe(null);
+        expect(DomUtils.createRevealAnimation({x: null, y: null},   1000, 800)).toBe(null)
+    });
+
+    test('a zero-sized viewport yields no animation rather than an Infinity percentage', () => {
+        // A hidden or unrendered document reports 0 for every dimension. Dividing by it produces
+        // `Infinity%`, which is not a parse error — it is an accepted keyframe that renders nothing,
+        // so the failure would be indistinguishable from a working cross-fade.
+        expect(DomUtils.createRevealAnimation({x: 10, y: 10}, 0,    800)).toBe(null);
+        expect(DomUtils.createRevealAnimation({x: 10, y: 10}, 1000, 0  )).toBe(null)
+    });
+
+    test('duration and easing stay overridable, with the reveal defaults applied otherwise', () => {
+        expect(DomUtils.createRevealAnimation({x: 1, y: 1}, 100, 100).options).toEqual({
+            duration     : 500,
+            easing       : 'ease-in',
+            pseudoElement: '::view-transition-new(root)'
+        });
+
+        expect(DomUtils.createRevealAnimation({duration: 800, easing: 'linear', x: 1, y: 1}, 100, 100).options)
+            .toMatchObject({duration: 800, easing: 'linear'})
+    });
+});

--- a/test/playwright/unit/main/DomAccessViewTransition.spec.mjs
+++ b/test/playwright/unit/main/DomAccessViewTransition.spec.mjs
@@ -2,6 +2,15 @@ import {setup} from '../../setup.mjs';
 
 const appName = 'DomAccessViewTransitionTest';
 
+// Imports are hoisted, so `Neo` and `Neo.main` already exist here — importing DomUtils below is
+// exactly what registers `Neo.main`, and is why this file was the first spec to hit the harness's
+// whole-namespace guard. Occupying ONE addon leaf reproduces the deeper half of that bug: a
+// container-level `??=` would find `Neo.main.addon` non-null and suppress every sibling default.
+globalThis.Neo             ??= {};
+globalThis.Neo.main        ??= {};
+globalThis.Neo.main.addon  ??= {};
+globalThis.Neo.main.addon.ImportedSibling = {marker: 'installed before setup()'};
+
 setup({
     appConfig: {
         name             : appName,
@@ -126,5 +135,29 @@ test.describe('Neo.main.DomUtils - view transition reveal', () => {
 
         expect(DomUtils.createRevealAnimation({duration: 800, easing: 'linear', x: 1, y: 1}, 100, 100).options)
             .toMatchObject({duration: 800, easing: 'linear'})
+    });
+
+    test('an explicit zero duration survives — it is the reduced-motion answer, not a missing value', () => {
+        // `duration || 500` rewrote 0 to 500. The same defect as reading `x: 0` as "no coordinate",
+        // one object over, and it needs its own arm because the 800 control above passes either way.
+        expect(DomUtils.createRevealAnimation({duration: 0, x: 1, y: 1}, 100, 100).options.duration).toBe(0);
+        expect(DomUtils.createRevealAnimation({duration: 800, x: 1, y: 1}, 100, 100).options.duration).toBe(800)
+    });
+});
+
+test.describe('test harness - Neo.main namespace defaults', () => {
+
+    test('a pre-occupied addon leaf fills the gaps rather than vetoing every sibling', () => {
+        // This file installed `Neo.main.addon.ImportedSibling` before setup() ran, standing in for
+        // any import that registers one addon. Guarding the container instead of the leaves would
+        // make setup() skip the rest — the harness bug this spec's own import first exposed, moved
+        // one level deeper where it is harder to see.
+        expect(Neo.main.addon.ImportedSibling.marker).toBe('installed before setup()');
+
+        expect(Neo.main.addon.DragDrop).toBeDefined();
+        expect(typeof Neo.main.addon.Navigator.subscribe).toBe('function');
+        expect(typeof Neo.main.addon.ResizeObserver.register).toBe('function');
+        expect(typeof Neo.main.addon.Stylesheet.insertCssRules).toBe('function');
+        expect(typeof Neo.main.DomAccess.getBoundingClientRect).toBe('function')
     });
 });


### PR DESCRIPTION
Resolves #17739

The theme reveal now expresses its circle in units the view-transition pseudo-element resolves against its own box, so it no longer depends on how a browser resolves lengths inside that pseudo. Chrome 148 resolves pixel lengths there in device pixels while the box stays in CSS pixels, which halved both the origin and the radius on a HiDPI display; percentages never enter that path. The apps stop assembling clip-path strings entirely and pass raw coordinates, so the unit decision lives in one engine place instead of one copy per app.

Evidence: L3 (live browser verification on the operator's Chrome 148 at `devicePixelRatio: 2`, plus a screen recording used to fit the rendered geometry) → L3 required (AC-1 and AC-2 are claims about what a browser *rasterises*, which no CI in this repo reaches). No residuals — see Post-Merge Validation for why the remaining item is a confirmation rather than a deferral.

## AC Evidence

| AC | Proof |
| --- | --- |
| AC-1 | outside-CI: operator ran the percentage form live on Chrome 148 / dpr 2 with **no** dpr correction — the circle originates at the button. The `× devicePixelRatio` probe landed on the button too, which is what identified the ratio as dpr rather than an arbitrary offset. |
| AC-2 | outside-CI: operator checked Safari — correct *before* with pixel units and unaffected *after*. This resolves the ambiguity the ticket flagged: Safari does run the custom animation; only Chrome's length resolution differed. |
| AC-3 | CI: `DomAccessViewTransition.spec.mjs` › *never emits a pixel length*. `git diff origin/dev...HEAD \| grep -ci devicePixelRatio` → **1**, and the one hit is a spec *comment* naming the defect (`DomAccessViewTransition.spec.mjs:63`), not executable code — I checked rather than publishing the 0 I first assumed. No `devicePixelRatio` term and no UA/browser conditional exists in any shipped code path. |
| AC-4 | CI: `DomAccessViewTransition.spec.mjs` › *the end radius lands exactly on the farthest corner, from any origin* — three origins including a corner and the centre. The hardcoded `3000` is deleted from both controllers. |
| AC-5 | CI: the same arm. Exact landing **is** the no-off-screen-tail property: the end radius equals the distance to the farthest corner, so full coverage coincides with the end of the duration instead of ~55% of it. |
| AC-6 | CI + grep: both controllers now pass `reveal: {x, y}` and build no clip-path. `grep -rn "circle(.*px at" src/ apps/` → **0 hits**, with a positive control on `circle(.*% at` returning the new form, so the zero is a real absence rather than a broken pattern. |
| AC-7 | CI: `DomAccessViewTransition.spec.mjs` › *a zero coordinate is an origin, not a missing one*. `portal`'s truthiness guard is gone; `x == null` is the test. |
| AC-8 | code-review (no unit arm, deliberately): `DomAccess.startViewTransition()` gains a `.catch()` that warns instead of resolving as success, and its JSDoc now states what the return value certifies **and what the catch does not cover** — it sees a rejected `ready` or a throwing registration, never a reveal that registers and then rasterises wrongly, which is the failure that actually occurred. **The AC as originally written was unsatisfiable** — see Deltas. Provoking the rejection path needs a real browser refusing a keyframe, which the node harness cannot produce; a unit arm here would be theatre. The ticket's Contract Ledger row now records the shipped immediate-start boolean plus asynchronous-warning contract rather than the superseded awaited form. |
| AC-9 | resolved on the ticket, no re-check owed. The AC assumed the fix would carry a dpr-dependent term needing separate confirmation at dpr 1. It does not: the geometry is computed from `width`/`height` alone, no `devicePixelRatio` appears in any shipped path, and AC-3's arm fails if a pixel length reappears. Marked resolved in the ticket body so `Resolves #17739` does not close an advertised residual. |

## Deltas from ticket

**AC-8 was corrected on the ticket, because the original was unsatisfiable without breaking the feature.** It demanded a return value distinguishing "ran" from "browser ignored it". `data.delay` exists so the caller can mutate the DOM *inside* the transition's capture window, and `transition.ready` resolves only after both snapshots are taken — awaiting it before returning would make `setTheme()` run after the new state was captured, and the transition would capture the unchanged DOM as both states. The satisfiable requirement is that the failure stops being *silent*, which is what shipped.

**The ticket claimed the two controllers were byte-identical. They were not** — `agentos` already used `!== undefined` with an `else` branch revealing from `0,0`; only `portal` had the truthiness guard. Same defect, two spellings, which strengthened rather than weakened the case for moving the decision into the engine. Corrected on the ticket.

**A fixed `150%` radius was implemented first and then replaced.** It satisfies "always covers" but not AC-5: sized for a corner origin, it overshoots ~2× for a centre origin and reintroduces a smaller version of the off-screen tail. The end radius is now derived from the origin. AC-5 caught a weaker fix that would otherwise have passed review.

**Placement:** the geometry lives on `Neo.main.DomUtils` rather than `DomAccess`. It is pure arithmetic with no DOM dependency, `DomUtils` is the sibling `DomAccess` already imports for exactly this role, and `DomAccess` cannot be imported by the node unit harness at all — its singleton construction reaches `document` during `initGlobalListeners()`.

**One behaviour change in `agentos`:** a keyboard activation carries no coordinates. It used to reveal from `0,0` — a corner wipe for an interaction that happened nowhere in particular. It now cross-fades, which is what `portal` already did and what the absence of a pointer actually means.

**A second extra commit, `efa87b3b91`, repairs a red that is not this PR's but is mine.** `#17741` added ADR-0019 catalog row `C4` with a valid `[unenforced: …]` tag, and `expect(rows).toHaveLength(17)` in `lintConfigTemplateSsot.spec.mjs` went red at 18 rows while the ownership relation it guards stayed clean at **zero violations**. The count fired on legitimate growth, never on incorrectness. I approved that count in `#17733` and quoted it approvingly, having removed the identical shape from an app-side arm hours earlier — so the repair belongs to me rather than to the PR that tripped it. Replaced with `arrayContaining(['A1','B4','C3'])` plus `length >= 17`; a source truncated before Group C parses to 14 rows without `C3` and still fails, so the truncation signal the count stood for survives.

Two other reds in that run — `TreeStoreValueBanding.spec.mjs:194` and `GoldenPathSynthesizer.spec.mjs:2104` — are **not** attributed here. The first passes on clean `origin/dev` locally and in this branch's 3024-spec run; the second is brain-tier and unrunnable in this sandbox. Neither is called flaky or pre-existing without a named mechanism.

**One extra commit, `84a7da071f`.** `setup.mjs` did `Neo.main ??= {addon, DomAccess}`, which assumed it ran before anything registered the namespace. Importing anything from `src/main/` registers `Neo.main` at class-setup time, and ESM evaluates imports before the module body — so the `??=` skipped the entire assignment and the next line crashed on `Neo.main.addon.Stylesheet`. No unit spec touching `src/main/` could use the harness. Fixed in lane because this PR's spec is the first to hit it.

## Test Evidence

The reveal's rendering is the one thing a green suite cannot show, so it was verified in a real browser:

- **The defect, measured.** Computed style sampled 8× across the animation held `circle(<r>px at 928px 29px)` — stable and *correct* — while the rendered centre fitted from three points on the arc in a screen recording came to ≈ CSS `(479, 16)`. Ratio ≈ 1.9 against an independently confirmed `devicePixelRatio: 2`. `getComputedStyle` reports the specified value, so no console probe on this path could have found it.
- **The fix, confirmed live.** Percentage keyframes with no dpr correction render from the click point in Chrome 148 (AC-1), and Safari is unchanged (AC-2).
- **Full unit suite: 3024 passed** after rebasing onto current `dev`. Re-run after every `setup.mjs` change specifically because that file is loaded by every unit spec.
- **Red proof for the two review-response arms**, against the preceding commit rather than a stash of uncommitted work: `duration: 0` returned **500**, and `Neo.main.addon.DragDrop` was **undefined** once a single addon leaf was pre-occupied. Both reproduce the reviewer's exact-head probes.

**One limit worth stating rather than leaving implied.** Percentages remove the *unit* hazard; they do not reconcile two different *boxes*. The mapping is exact only while the pseudo-element's box is viewport-aligned — which it is on desktop, measured identical to `innerWidth`/`innerHeight` across all four pseudos — but the snapshot containing block can span retractable browser UI on mobile, where its origin sits above the layout viewport. The helper JSDoc carries this assumption so the next caller does not have to rediscover it.

## Post-Merge Validation

**None.** The body lint caught me having this both ways: I argued AC-9's dpr:1 re-check was not a real residual, then listed it as an unchecked obligation anyway. Its guidance is correct — finish it, give it an existing owner, or drop it, and do not file a ticket to satisfy the gate.

Dropped, because the observer already exists. The AC asked for a dpr:1 re-check on the premise that the halving is invisible at dpr 1; the shipped geometry has no dpr-dependent term for a display to vary, and AC-3's spec arm fails if a pixel length returns. An unchecked box here would advertise a gap the code cannot have.

## Commits

Rebased onto current `dev`, so the SHAs below supersede the pre-rebase ones cited in the review thread.

- `84a7da071f` — setup fills `Neo.main` per branch, so a `src/main/` import cannot suppress the harness defaults
- `6e5ce17533` — the reveal moves to box-relative units with a derived end radius; both apps pass coordinates instead of clip-path strings
- `f3879c9759` — review response: preserve `duration: 0` / `delay: 0`, guard the harness defaults per leaf rather than per container, and narrow two prose claims to what the code observes
- `efa87b3b91` — CI repair: the ADR-0019 ownership spec asserts the catalog was fully parsed instead of pinning it at 17 rows

Authored by ⚖️ **Ada** · `@neo-opus-ada` · Claude Opus 5 · Claude Code
