### PR TITLE
docs(skills): the cycle-1 short path is a rule with a shape that exists (#17261)

### DIFF
--- a/.agents/skills/pr-review/references/pr-review-guide.md
+++ b/.agents/skills/pr-review/references/pr-review-guide.md
@@ -180,13 +180,19 @@ At RC2 or >24KB, load the payload. **A demand round is a `CHANGES_REQUESTED`** �
 `**Glance:**` (the premise + correctness check), the canonical
 `- **Origin Session ID:**` line. No premise snapshot, no Depth Floor, no audits.
 
-**When:** a MECHANICAL PR — no architectural concept to teach (test-only /
-config-leaf / behavior-preserving / docs / receipt refresh) — at ANY size, or a
-micro/contained diff. **Never** for ADR / new abstraction / consumed contract /
-security / migration / fleet-critical zones (`ai/` config, release path,
-workflows, substrate, MCP contracts) — full form regardless of size. Authors
-signal with `Micro-review eligible: <class> — <why>`; the reviewer decides;
-escalating to full is always free, the reverse never happens.
+**When — a rule, not a permission.** A MECHANICAL PR *gets* this shape: no
+architectural concept to teach (test-only / config-leaf / behavior-preserving /
+docs / receipt refresh), at ANY size. **Paying the full floor on a mechanical
+diff is itself the violation** — an optional short path does not get used.
+**Never** for ADR / new abstraction / consumed
+contract / security / migration / fleet-critical zones (`ai/` config, release
+path, workflows, substrate, MCP contracts) — full form regardless of size.
+Authors signal with `Micro-review eligible: <class> — <why>`; the reviewer
+decides; escalating to full is always free, the reverse never happens.
+
+**Trigger is mechanical-vs-concept-bearing, never line count.** Worked pair: a
+400-line receipt refresh teaches nothing → MICRO; a 3-line ADR row defines a
+predicate reviewers run against `dev` → FULL. Size pointed the wrong way twice.
 
 **Bounded-repair guard (Grace, #17527):** a repair stays micro-eligible only
 while it touches NO site the prescription did not name — a widened repair is a
@@ -199,7 +205,7 @@ RESIDUE under the circuit breaker after semantics cleared.
 
 ## 7. Depth Floor — Preventing Rubber-Stamp Approvals
 
-Structural compliance ≠ rigor — these mandates (+ the concept-graph feed) are for **concept-bearing** changes: touch an ADR/new-abstraction/consumed-contract/security/migration. A **mechanical** PR (test/config/behavior-preserving, any size) gets a premise+correctness glance → Approve.
+Structural compliance ≠ rigor. This floor is for **concept-bearing** changes. A **mechanical** PR takes §6.4's Micro-Review instead — cycle-1-eligible, no prior round; §6.4 owns the rule and its never-zones.
 
 ### 7.1 Minimum-One-Challenge for Peer Reviews
 

--- a/.agents/skills/pr-review/references/pr-review-guide.md
+++ b/.agents/skills/pr-review/references/pr-review-guide.md
@@ -175,37 +175,35 @@ At RC2 or >24KB, load the payload. **A demand round is a `CHANGES_REQUESTED`** �
 
 ### 6.4 Micro-Review — the blast-scaled Cycle-1 light path
 
-`# PR Micro-Review` (`assets/pr-review-micro-review-template.md`) — anchors:
-`**Class:**` asserting `micro` | `contained` | `mechanical`, `**Verdict:**`,
-`**Glance:**` (the premise + correctness check), the canonical
-`- **Origin Session ID:**` line. No premise snapshot, no Depth Floor, no audits.
+`# PR Micro-Review` — the asset
+(`assets/pr-review-micro-review-template.md`) carries the anchors; `Class` is
+`micro` | `contained` | `mechanical`. No premise snapshot, no Depth Floor, no
+audits.
 
-**When — a rule, not a permission.** A MECHANICAL PR *gets* this shape: no
+**When — a rule, not a permission.** A MECHANICAL PR *gets* this shape — no
 architectural concept to teach (test-only / config-leaf / behavior-preserving /
-docs / receipt refresh), at ANY size. **Paying the full floor on a mechanical
-diff is itself the violation** — an optional short path does not get used.
-**Never** for ADR / new abstraction / consumed
-contract / security / migration / fleet-critical zones (`ai/` config, release
-path, workflows, substrate, MCP contracts) — full form regardless of size.
-Authors signal with `Micro-review eligible: <class> — <why>`; the reviewer
-decides; escalating to full is always free, the reverse never happens.
-
-**Trigger is mechanical-vs-concept-bearing, never line count.** Worked pair: a
-400-line receipt refresh teaches nothing → MICRO; a 3-line ADR row defines a
-predicate reviewers run against `dev` → FULL. Size pointed the wrong way twice.
+docs / receipt refresh) — at ANY size, or a micro/contained diff. Paying the full
+floor on a mechanical diff is itself the violation; an optional path goes unused.
+**Never** for ADR / new abstraction / consumed contract / security / migration /
+fleet-critical zones (`ai/` config, release path, workflows, substrate, MCP
+contracts) — full form regardless of size. Authors signal with
+`Micro-review eligible: <class> — <why>`; the reviewer decides; escalating to
+full is always free, the reverse never happens. **Keys on
+mechanical-vs-concept-bearing, never size:** a 400-line receipt refresh → MICRO;
+a 3-line ADR row → FULL.
 
 **Bounded-repair guard (Grace, #17527):** a repair stays micro-eligible only
 while it touches NO site the prescription did not name — a widened repair is a
 new change wearing a repair's eligibility: full form.
 
-Three light paths, three axes: **Micro-Review** scales the Cycle-1 review FORM
-(this section); §6.1's **micro-change exception** scales the cross-family MERGE
-gate (`chore` < 20 lines / pure docs); **Micro-Delta** closes mechanical-hygiene
-RESIDUE under the circuit breaker after semantics cleared.
+Three light paths, three axes: Micro-Review = this section's cycle-1 FORM;
+§6.1's **micro-change exception** = the cross-family MERGE gate (`chore` < 20
+lines / pure docs); **Micro-Delta** = mechanical-hygiene RESIDUE after semantics
+cleared.
 
 ## 7. Depth Floor — Preventing Rubber-Stamp Approvals
 
-Structural compliance ≠ rigor. This floor is for **concept-bearing** changes. A **mechanical** PR takes §6.4's Micro-Review instead — cycle-1-eligible, no prior round; §6.4 owns the rule and its never-zones.
+Structural compliance ≠ rigor. This floor is for **concept-bearing** changes; a **mechanical** PR takes §6.4's Micro-Review instead — cycle-1-eligible, no prior round.
 
 ### 7.1 Minimum-One-Challenge for Peer Reviews
 

--- a/.agents/skills/pr-review/references/pr-review-guide.md
+++ b/.agents/skills/pr-review/references/pr-review-guide.md
@@ -176,21 +176,20 @@ At RC2 or >24KB, load the payload. **A demand round is a `CHANGES_REQUESTED`** �
 ### 6.4 Micro-Review — the blast-scaled Cycle-1 light path
 
 `# PR Micro-Review` — the asset
-(`assets/pr-review-micro-review-template.md`) carries the anchors; `Class` is
-`micro` | `contained` | `mechanical`. No premise snapshot, no Depth Floor, no
-audits.
+(`assets/pr-review-micro-review-template.md`) carries the anchors and classes.
+No premise snapshot, no Depth Floor, no audits.
 
 **When — a rule, not a permission.** A MECHANICAL PR *gets* this shape — no
 architectural concept to teach (test-only / config-leaf / behavior-preserving /
 docs / receipt refresh) — at ANY size, or a micro/contained diff. Paying the full
-floor on a mechanical diff is itself the violation; an optional path goes unused.
-**Never** for ADR / new abstraction / consumed contract / security / migration /
-fleet-critical zones (`ai/` config, release path, workflows, substrate, MCP
-contracts) — full form regardless of size. Authors signal with
-`Micro-review eligible: <class> — <why>`; the reviewer decides; escalating to
-full is always free, the reverse never happens. **Keys on
-mechanical-vs-concept-bearing, never size:** a 400-line receipt refresh → MICRO;
-a 3-line ADR row → FULL.
+floor on a mechanical diff is itself the violation. **Never** for ADR / new
+abstraction / consumed contract / security / migration / fleet-critical zones
+(`ai/` config, release path, workflows, substrate, MCP contracts) — full form
+regardless of size. Authors signal with `Micro-review eligible: <class> — <why>`;
+**the reviewer owns the classification**, but a full-form escalation must NAME
+the concept-bearing surface or never-zone earning it. The reverse never happens.
+**Keys on mechanical-vs-concept-bearing, never size:** a 400-line receipt refresh
+→ MICRO; a 3-line ADR row → FULL.
 
 **Bounded-repair guard (Grace, #17527):** a repair stays micro-eligible only
 while it touches NO site the prescription did not name — a widened repair is a

--- a/.agents/skills/pull-request/references/pull-request-workflow.md
+++ b/.agents/skills/pull-request/references/pull-request-workflow.md
@@ -252,8 +252,11 @@ After an author posts a review-response comment with fixup commits and the autho
 
 When a review lands on your PR, verify the reviewer used the correct
 template before treating the review as substantively complete:
-- **Cycle 1**: review must follow `pr-review-template.md` structure
-  (Strategic-Fit Decision, Depth Floor, Graph Ingestion Notes, [...])
+- **Cycle 1**: `pr-review-template.md` structure (Strategic-Fit Decision,
+  Depth Floor, Graph Ingestion Notes, [...]) — **or**
+  `pr-review-micro-review-template.md` when the PR is mechanical per
+  `pr-review-guide.md` §6.4. A correctly-short micro-review is compliant;
+  demanding the full form on a mechanical diff is the violation
 - **Cycle 2 (ordinary)**: `pr-review-round-2-template.md` — dispositions
   Cycle-1 actions verbatim; mints no new checklist
 - **Cycle ≥2 exceptional** (D+S, repair re-entry):

--- a/.agents/skills/pull-request/references/pull-request-workflow.md
+++ b/.agents/skills/pull-request/references/pull-request-workflow.md
@@ -252,11 +252,11 @@ After an author posts a review-response comment with fixup commits and the autho
 
 When a review lands on your PR, verify the reviewer used the correct
 template before treating the review as substantively complete:
-- **Cycle 1**: `pr-review-template.md` structure (Strategic-Fit Decision,
-  Depth Floor, Graph Ingestion Notes, [...]) — **or**
+- **Cycle 1**: `pr-review-template.md` — **or**
   `pr-review-micro-review-template.md` when the PR is mechanical per
-  `pr-review-guide.md` §6.4. A correctly-short micro-review is compliant;
-  demanding the full form on a mechanical diff is the violation
+  `pr-review-guide.md` §6.4. The reviewer owns the classification, but a full
+  form on a mechanical diff must NAME the concept-bearing surface or never-zone
+  earning it; unnamed, the escalation is the violation
 - **Cycle 2 (ordinary)**: `pr-review-round-2-template.md` — dispositions
   Cycle-1 actions verbatim; mints no new checklist
 - **Cycle ≥2 exceptional** (D+S, repair re-entry):


### PR DESCRIPTION
Resolves #17261

The guide promised a short path for mechanical PRs and gave no route to one; the author-side mandate would have rejected the route once it existed. Both repaired.

**Byte accounting, stated in full because a scoped pass is not an overall reduction.** Against `origin/dev`: `pr-review-guide.md` **−4** (this is AC-6's scope, and it is met), `pull-request-workflow.md` **+195**, so the whole changed skill-Markdown surface is **+191**. `lint-skill-manifest --base origin/dev` is green on all three of its budgets. The `+195` buys the author-side mandate that stops a compliant micro-review being rejected — the half of this ticket that has no cheaper form.

Evidence: L2 (the accepting shape is executed against the live validator, not read from the asset list). Residual: none.

## AC Evidence
| AC | Evidence |
|---|---|
| AC-1 | **Already met before this PR, verified not assumed.** `pr-review-micro-review-template.md` landed 2026-08-22 (#17532) — *three days after* this ticket's own correction enumerated four accepted shapes and found no cycle-1 form. `validate_pr_review_body` on a filled micro body returns `{"valid": true, "template": ".agents/skills/pr-review/assets/pr-review-micro-review-template.md"}` |
| AC-2 | §6.4 now reads **"When — a rule, not a permission"**: a mechanical PR *gets* the shape, and *"paying the full floor on a mechanical diff is itself the violation"*. The rule is **enforceable** because the escape is qualified — the reviewer owns the classification, but a full-form escalation must NAME the concept-bearing surface or never-zone earning it (RA-1) |
| AC-3 | §6.4 states the trigger keys on mechanical-vs-concept-bearing, with a worked pair where size points the wrong way **both** ways: 400-line receipt refresh → MICRO; 3-line ADR row → FULL |
| AC-4 | `pull-request-workflow.md` §6.4 Cycle-1 now names `pr-review-micro-review-template.md` alongside the full template, and carries the **same** named-basis requirement in the same words — a mandate that differs between the reviewer's copy and the author's copy is how a compliant review gets rejected, which is this ticket's own grievance |
| AC-5 | §7 points at §6.4 instead of describing a path it cannot produce, and no longer restates rules §6.4 owns |
| AC-6 | `pr-review-guide.md` vs `origin/dev`: **−4 bytes** (scope is `pr-review/**`). `lint-skill-manifest --base origin/dev` green on all three of its budgets. Additions paid for out of duplication — see the correction below |

## Slot rationale (§1.1 — substrate mutation)

Both files are skill substrate loaded on demand by `/pr-review` and `/pull-request`, not per-turn.

- **Disposition:** `rewrite` for §7 (it described an unproducible path; now it routes) and `compress-to-trigger` for §6.4's added rule. No new section, no new file.
- **Trigger frequency × failure severity × enforceability:** high frequency (every review), moderate severity (the failure mode is paid ceremony, not a wrong merge), and **partly enforceable** — `validate_pr_review_body` already accepts the shape, so this closes the human half that was still pointing the wrong way.
- **Load:** `pr-review-guide.md` **−4** against `origin/dev` (AC-6's scope, met); `pull-request-workflow.md` **+195**; whole surface **+191**, lint green. The ticket's requirement is the right one for its scope: a guide that spends prose describing a path it cannot produce should pay for the path out of that prose, and it did — the growth is entirely the author-side mandate, which is new obligation rather than restated prose.
- **Retirement trigger:** retire the §7 pointer if §6.4 is ever merged into §7; the rule itself retires only if the micro shape is withdrawn.

## Deltas from ticket

**AC-1 was already satisfied, and the ticket could not have known.** Its correction is dated 2026-08-19; the micro-review asset landed 2026-08-22. I verified against the live validator rather than the asset listing, because this ticket's own history is an author asserting *"the validator accepts exactly two structures"* and later recording **"That is false, and it was false when filed. I asserted a refusal I had not enumerated."* Repeating that here would have been the one unforgivable move.

**I also checked the submit gate, which the validator explicitly does not predict** (*"does not predict the submit gate"*). `PullRequestService.mjs:44` holds `PR_REVIEW_MICRO_TEMPLATE_PATH`; `:1977` records that *a wrongly-rejected valid micro-review is the theater this tier removes*; the prior-round refusal at `:1378-1384` is scoped to bodies declaring themselves Round 2. So micro is genuinely reachable on first contact — the grievance's second half ("every short shape requires a preceding review") no longer holds for this shape.

**AC-4 was the live contradiction and the one that would still bite.** `pull-request-workflow.md` §6.4 read *"Cycle 1: review must follow `pr-review-template.md`"*. An author obeying that mandate would reject a correctly-short micro-review as structurally non-compliant — the ticket's exact grievance, still armed after the shape existed.

## Correction — my first AC-6 number was measured wrong

This body originally claimed **"106482 → 106463, −19"**. That baseline was captured **after** I had already edited §7, so I measured the change from a state that already contained part of it. `lint-skill-manifest` measures against `origin/dev` — the real baseline — and went **RED**: guide `+293` (over the 250 per-file delta), `33752` bytes (over the 33700 payload budget), `+493` net across `.agents/skills`.

All three are green at `ae10587d27`, and AC-6 now holds against `origin/dev` rather than my own snapshot.

**The additions are paid for out of duplication, which is what the ticket asked for:**

- §6.4's anchors paragraph enumerated `Class` / `Verdict` / `Glance` / `Origin Session ID` — fields the template asset already carries. It now points at the asset, which is the Map-vs-World-Atlas discipline the lint names in its own failure text.
- the "three light paths" line restated that Micro-Review is the cycle-1 form, which the new rule paragraph directly above it now establishes.
- §7 no longer restates the never-zones §6.4 owns one link away.

No AC was lost to the cuts — the rule framing, the worked pair, the author-side mandate and the §7 pointer were each re-verified after the final edit.

**The transferable half:** a "did my change grow this?" measurement has to be taken against the merge base, not against the working tree, and the working tree is exactly what is closest to hand once editing starts. A self-reported byte budget that never touches `origin/<branch>` is measuring the wrong difference — and it will always be flattering, because the part already written is inside the baseline.

## Test Evidence

All coverage runs in CI. The one check that is not a test: `validate_pr_review_body` executed against a filled micro body, returning `valid: true` and naming the micro template — run before writing any prose, because the whole ticket turns on which shapes the gate actually accepts.

## Post-Merge Validation

Nothing is owed after merge.

Authored by Grace (Claude Opus 5, Claude Code). Session 728a756d-71df-48e6-8dad-0bac498ca23e.
