### PR TITLE
test(util): cover Matrix calculations and CSS serialization (#15429)

### DIFF
--- a/test/playwright/unit/util/Matrix.spec.mjs
+++ b/test/playwright/unit/util/Matrix.spec.mjs
@@ -1,0 +1,135 @@
+import {setup} from '../../setup.mjs';
+
+setup({
+    appConfig: {
+        name: 'MatrixUtilTest'
+    }
+});
+
+import {test, expect} from '@playwright/test';
+import Neo            from '../../../../src/Neo.mjs';
+import * as core      from '../../../../src/core/_export.mjs';
+import Matrix         from '../../../../src/util/Matrix.mjs';
+
+const identity4 = [
+    [1, 0, 0, 0],
+    [0, 1, 0, 0],
+    [0, 0, 1, 0],
+    [0, 0, 0, 1]
+];
+
+/**
+ * @summary Asserts two numeric matrices element-by-element without treating IEEE `-0` as a mismatch.
+ * @param {Number[][]} actual
+ * @param {Number[][]} expected
+ * @returns {void}
+ */
+function expectMatrixClose(actual, expected) {
+    expect(actual).toHaveLength(expected.length);
+
+    expected.forEach((row, rowIndex) => {
+        expect(actual[rowIndex]).toHaveLength(row.length);
+        row.forEach((value, columnIndex) => {
+            expect(actual[rowIndex][columnIndex]).toBeCloseTo(value)
+        })
+    })
+}
+
+/**
+ * @summary Coverage for the public Neo.util.Matrix calculation and CSS-serialization contract.
+ */
+test.describe('Neo.util.Matrix', () => {
+    let instances = [];
+
+    /**
+     * @summary Creates a Matrix through the Neo lifecycle and tracks it for deterministic teardown.
+     * @param {Number[][]} items
+     * @returns {Neo.util.Matrix}
+     */
+    function createMatrix(items) {
+        const matrix = Neo.create(Matrix, {items});
+
+        instances.push(matrix);
+
+        return matrix
+    }
+
+    test.afterEach(() => {
+        instances.forEach(matrix => matrix.destroy());
+        instances = []
+    });
+
+    test('rotateX preserves identity at zero and places sine/cosine at pi/2', () => {
+        expectMatrixClose(Matrix.rotateX(0), identity4);
+        expectMatrixClose(Matrix.rotateX(Math.PI / 2), [
+            [1, 0,  0, 0],
+            [0, 0, -1, 0],
+            [0, 1,  0, 0],
+            [0, 0,  0, 1]
+        ])
+    });
+
+    test('rotateY preserves identity at zero and places sine/cosine at pi/2', () => {
+        expectMatrixClose(Matrix.rotateY(0), identity4);
+        expectMatrixClose(Matrix.rotateY(Math.PI / 2), [
+            [0, 0, -1, 0],
+            [0, 1,  0, 0],
+            [1, 0,  0, 0],
+            [0, 0,  0, 1]
+        ])
+    });
+
+    test('rotateZ preserves identity at zero and places sine/cosine at pi/2', () => {
+        expectMatrixClose(Matrix.rotateZ(0), identity4);
+        expectMatrixClose(Matrix.rotateZ(Math.PI / 2), [
+            [0, -1, 0, 0],
+            [1,  0, 0, 0],
+            [0,  0, 1, 0],
+            [0,  0, 0, 1]
+        ])
+    });
+
+    test('getElement and e use one-based coordinates and return null outside the matrix', () => {
+        const matrix = createMatrix([
+            [1, 2, 3],
+            [4, 5, 6]
+        ]);
+
+        expect(matrix.getElement(1, 2)).toBe(2);
+        expect(matrix.e(2, 3)).toBe(6);
+        expect(matrix.getElement(0, 1)).toBeNull();
+        expect(matrix.getElement(3, 1)).toBeNull();
+        expect(matrix.e(1, 0)).toBeNull();
+        expect(matrix.e(1, 4)).toBeNull()
+    });
+
+    test('multiply writes a hand-computed product into and returns the argument', () => {
+        const left   = createMatrix([[1, 2], [3, 4]]),
+              right  = createMatrix([[5, 6], [7, 8]]),
+              result = left.multiply(right);
+
+        expect(result).toBe(right);
+        expect(result.items).toEqual([[19, 22], [43, 50]]);
+        expect(left.items).toEqual([[1, 2], [3, 4]])
+    });
+
+    test('x delegates to multiply and preserves an identity product', () => {
+        const identity = createMatrix([[1, 0], [0, 1]]),
+              target   = createMatrix([[2, 3], [4, 5]]),
+              result   = identity.x(target);
+
+        expect(result).toBe(target);
+        expect(result.items).toEqual([[2, 3], [4, 5]])
+    });
+
+    test('getTransformStyle serializes a 4x4 matrix at ten-decimal precision', () => {
+        const matrix = createMatrix(identity4);
+
+        expect(matrix.getTransformStyle()).toBe(
+            'matrix3d(1.0000000000,0.0000000000,0.0000000000,0.0000000000,' +
+            '0.0000000000,1.0000000000,0.0000000000,0.0000000000,' +
+            '0.0000000000,0.0000000000,1.0000000000,0.0000000000,' +
+            '0.0000000000,0.0000000000,0.0000000000,1.0000000000)'
+        )
+    })
+});


### PR DESCRIPTION
Resolves #15429

Adds the missing focused contract coverage for `Neo.util.Matrix`: rotation geometry, one-based lookup boundaries, mutating multiplication semantics, the `x()` alias, and exact CSS `matrix3d()` serialization. Instances enter through `Neo.create()` and are destroyed after every test, so the coverage exercises the real reactive-config lifecycle without leaking global registrations.

Salvage provenance: @Ap-0007 authored the original coverage in PR #15441. This fresh implementation preserves that contribution's correct rotation and serialization witnesses, applies the verified lifecycle repair, and completes the ticket's remaining required edges on current `dev`.

Evidence: L2 (focused Matrix spec plus the complete Body-unit project) → L2 required (AC-1 through AC-6 are fully unit-observable). Residual: none.

Micro-review eligible: mechanical — test-only coverage in the established util-spec family; no production code, consumed contract, security boundary, or runtime behavior changes.

## AC Evidence

| AC | Evidence |
|---|---|
| AC-1 | `test/playwright/unit/util/Matrix.spec.mjs` exists in the canonical util-spec directory and covers every named public surface |
| AC-2 | Three rotation arms assert zero-angle identity and independently specified π/2 sine/cosine placement, with IEEE `-0` handled numerically |
| AC-3 | The lookup arm covers both `getElement()` and `e()`, valid one-based coordinates, and all four row/column boundary directions |
| AC-4 | The multiplication arm uses the hand-computed `[[19,22],[43,50]]` product, asserts argument mutation/return identity, and separately covers `x()` with identity multiplication |
| AC-5 | The serialization arm pins the complete 4×4 identity `matrix3d(...)` string at ten-decimal precision |
| AC-6 | Covered by the focused Matrix command and the complete `unit` project; clean-checkout CI owns the repository-wide Brain lanes |

## Deltas from ticket

The prior closed PR exposed the Neo-specific construction boundary: raw `new Matrix()` skips reactive config initialization. This version uses `Neo.create(Matrix, {items})`, destroys every instance in `afterEach`, and includes the ticket-required alias, out-of-bounds, hand-computed-product, and zero-angle witnesses that the first draft lacked. No Matrix runtime change is needed. A repository-wide local run cannot serve as clean-checkout evidence because repository scanners enter the preserved untracked backup; CI remains authoritative for the Brain lanes, while the complete Body `unit` project is green.

## Test Evidence

All coverage runs in CI.

## Post-Merge Validation

Nothing is owed after merge.

Authored by Emmy (GPT-5.6 Sol Ultra, Codex). Session 429a3792-5cea-4c7b-a409-a1fd8b44ccd2.
