### PR TITLE
feat(ai): reject ticket ids in narrative guides (#17574)

### DIFF
--- a/.agents/skills/guide-authoring/references/guide-authoring-bar.md
+++ b/.agents/skills/guide-authoring/references/guide-authoring-bar.md
@@ -38,6 +38,8 @@ Measured against `resources/content/release-notes/chunk-2/v13.0.0.md` ("Memory B
 
 A guide is *explanation*; it does NOT inline tool catalogs, payload specs, CLI flag tables, or config formats. That *reference* is extracted to `tooling/` — preferentially **generated** from source (`openapi.yaml`, config schema) so it cannot stale. Link to it; never dump it. Before deleting inlined reference, verify the target actually holds the specific content (no-info-loss). Describe the **current paradigm**; demote or omit superseded manual procedures (e.g. manual restore is a backstop, not the data-integrity story) even when the old tool still exists.
 
+- **Guides describe; trackers decide.** Never cite ticket or PR ids in `learn/guides/**`, including code. Describe the durable mechanism and cite stable files or decision authority; `ai:lint-guides` enforces a HARD failure.
+
 ## 5. Mechanics — register the guide; never commit the pipeline-owned SEO output — `MACHINE-ENFORCEABLE-CANDIDATE`
 
 - **File + registration (the inputs you edit).** A new guide is `learn/<section>/<slug>.md`, registered in **two source inputs**: (1) `learn/tree.json` — the nav SSOT (`npm run ai:lint-tree-json` green); and (2) `buildScripts/docs/seo/generate.mjs` — **add + rank the guide in the `PRIORITIES` map** (e.g. `['agentos/IdentityFirewall', 1.0]`). That map is where a guide's SEO weight is set.

--- a/ai/scripts/lint/lint-guides.mjs
+++ b/ai/scripts/lint/lint-guides.mjs
@@ -20,6 +20,8 @@
  *     (the hallucinated-command class).
  *   - Tool-table refs under a Tools heading that resolve to no `ai/mcp/server/*​/openapi.yaml`
  *     operationId — the MCP-tool analogue of the hallucinated-command class.
+ *   - Ticket references under nested `learn/guides/` Markdown — guide prose describes the durable
+ *     mechanism; trackers own mutable ids. CSS/Mermaid hex-color values remain valid.
  *
  * **WARN (report-only, exit 0) — heuristics a human confirms:**
  *   - No Mermaid block at all (the bar wants >=1 diagram that carries the story).
@@ -28,9 +30,11 @@
  *     belongs in `tooling/`, not inlined into an explanation guide (Diátaxis).
  *   - `framework` identity-guard hits (Neo is an Application Engine + organism, never a framework).
  *
- * **Scope:** the conceptual-guide surfaces only — top-level `learn/agentos/*.md` and
- * `learn/benefits/*.md`. ADRs (`decisions/`), generated/reference docs (`tooling/`), and
- * process docs (`process/`) are deliberately excluded: they are reference, not narrative guides.
+ * **Scope:** the complete guide-quality rules run only over top-level `learn/agentos/*.md` and
+ * `learn/benefits/*.md`. The ticket-reference rule additionally traverses
+ * nested `learn/guides/` Markdown; widening every rule there would turn unrelated legacy debt into a
+ * hard gate. ADRs (`decisions/`), generated/reference docs (`tooling/`), and process docs
+ * (`process/`) remain deliberately excluded from the complete rule set.
  *
  * @see .agents/skills/guide-authoring/references/guide-authoring-bar.md (the discipline half)
  * @see learn/agentos/decisions/0008-skill-anatomy-and-authoring-contract.md
@@ -49,6 +53,12 @@ const ROOT_DIR   = path.resolve(__dirname, '../../..');
  * (`decisions/`, `tooling/`, `process/`) are reference/ADR substrate, intentionally excluded.
  */
 const GUIDE_DIRS = ['learn/agentos', 'learn/benefits'];
+
+/** Recursive narrative-guide tree scanned by the ticket-reference rule only. */
+const GUIDE_SERIES_DIR = 'learn/guides';
+
+/** CSS hexadecimal lengths that can otherwise be indistinguishable from numeric ticket ids. */
+const CSS_HEX_LENGTHS = new Set([4, 6, 8]);
 
 /**
  * Mermaid keywords that break the parser when reused as a node ID or `classDef` name.
@@ -227,6 +237,78 @@ function checkDeadScriptRefs(content, scriptKeys) {
 }
 
 /**
+ * Returns whether a character offset sits inside a Markdown inline-code span. Fenced code is
+ * tracked separately by {@link checkTicketIds}; this helper deliberately counts only unescaped
+ * backticks before the token on its line.
+ * @param {string} line
+ * @param {number} index
+ * @returns {boolean}
+ */
+function isInsideInlineCode(line, index) {
+    let count = 0;
+
+    for (let i = 0; i < index; i++) {
+        if (line[i] === '`' && line[i - 1] !== '\\') count++;
+    }
+
+    return count % 2 === 1;
+}
+
+/**
+ * Distinguishes an all-numeric CSS/Mermaid color from a ticket id. The numeric token is exempt
+ * only inside fenced/inline code AND after a CSS property or Mermaid `fill:`/`stroke:`/`color:`
+ * value anchor. A bare numeric hash token in either code shape still fails.
+ * @param {string} line
+ * @param {number} index
+ * @param {string} token
+ * @param {boolean} inFence
+ * @returns {boolean}
+ */
+function isSyntacticHexColor(line, index, token, inFence) {
+    const digits = token.slice(1);
+
+    if (!CSS_HEX_LENGTHS.has(digits.length) || (!inFence && !isInsideInlineCode(line, index))) {
+        return false;
+    }
+
+    const before = line.slice(0, index);
+
+    return /(?:^|[;{,])\s*(?:--[\w-]+|[A-Za-z-]+)\s*:[^#]*$/.test(before)
+        || /\b(?:fill|stroke|color)\s*:[^#]*$/i.test(before);
+}
+
+/**
+ * HARD check for mutable tracker references in durable `learn/guides/**` prose. Ticket-like
+ * tokens remain forbidden inside inline/fenced examples; only syntactic CSS/Mermaid colors are
+ * exempt because an all-numeric six-digit color is lexically identical to a future ticket id.
+ * @param {string} content
+ * @returns {Array<{severity: string, rule: string, line: number, detail: string}>}
+ */
+function checkTicketIds(content) {
+    const findings = [];
+    let   inFence  = false;
+
+    content.split('\n').forEach((line, i) => {
+        if (line.trim().startsWith('```')) {
+            inFence = !inFence;
+            return;
+        }
+
+        const pattern = /#[0-9]{4,}(?![0-9A-Za-z])/g;
+        let   match;
+
+        while ((match = pattern.exec(line)) !== null) {
+            if (isSyntacticHexColor(line, match.index, match[0], inFence)) continue;
+
+            findings.push({severity: 'HARD', rule: 'ticket-id', line: i + 1,
+                detail: `ticket reference "${match[0]}" rots in guides — describe the repair and cite stable files or authority documents instead`});
+        }
+    });
+
+    return findings;
+}
+
+/**
  * HARD check: tool-table rows that reference an MCP tool no server exposes — the OpenAPI-operation
  * analogue of {@link checkDeadScriptRefs}. Scoped to rows under a {@link TOOLS_HEADING} so config /
  * property / schema tables (same `| `name` |` shape) never false-positive. Generalizes the
@@ -346,6 +428,48 @@ function discoverGuides() {
     return files.sort();
 }
 
+/**
+ * Recursively discovers the narrative guide-series tree for the ticket-reference rule. Symlinks
+ * are not followed; only real directories and Markdown files participate.
+ * @returns {string[]} repo-relative file paths
+ */
+function discoverGuideSeries() {
+    const files = [];
+
+    function visit(dir) {
+        const absDir = path.join(ROOT_DIR, dir);
+        if (!existsSync(absDir)) return;
+
+        for (const entry of readdirSync(absDir, {withFileTypes: true})) {
+            const relative = path.join(dir, entry.name);
+
+            if (entry.isDirectory()) visit(relative);
+            else if (entry.isFile() && entry.name.endsWith('.md')) files.push(relative);
+        }
+    }
+
+    visit(GUIDE_SERIES_DIR);
+
+    return files.sort();
+}
+
+/**
+ * Returns whether an explicit CLI path resolves to a Markdown file inside the narrative guide
+ * tree. Resolving first prevents `learn/guides/../agentos` from inheriting the recursive rule.
+ * @param {string} file
+ * @returns {boolean}
+ */
+function isGuideSeriesFile(file) {
+    const absolute   = path.isAbsolute(file) ? path.resolve(file) : path.resolve(ROOT_DIR, file);
+    const seriesRoot = path.join(ROOT_DIR, GUIDE_SERIES_DIR);
+    const relative   = path.relative(seriesRoot, absolute);
+
+    return Boolean(relative)
+        && !relative.startsWith(`..${path.sep}`)
+        && !path.isAbsolute(relative)
+        && relative.endsWith('.md');
+}
+
 /** @returns {Set<string>} the defined `package.json` script names. */
 function loadScriptKeys() {
     const pkg = JSON.parse(readFileSync(path.join(ROOT_DIR, 'package.json'), 'utf8'));
@@ -400,19 +524,32 @@ function parseArgs(argv = process.argv.slice(2)) {
 /**
  * CLI entry. Returns a numeric exit code (no `process.exit`) so tests can drive it directly.
  * @param {{files: string[], warnAsError: boolean}} [options] both keys optional (files defaults to discoverGuides())
- * @returns {{exitCode: number, hard: number, warn: number}}
+ * @returns {{exitCode: number, hard: number, warn: number, fullGuideCount: number, ticketIdGuideCount: number}}
  */
 function runLint(options = {}) {
     const scriptKeys   = loadScriptKeys();
     const operationIds = loadOperationIds();
-    const files        = options.files?.length ? options.files : discoverGuides();
+    const explicit     = Boolean(options.files?.length);
+    const fullFiles    = explicit ? options.files : discoverGuides();
+    const ticketFiles  = explicit ? options.files.filter(isGuideSeriesFile) : discoverGuideSeries();
+    const files        = new Map();
+
+    for (const file of fullFiles)   files.set(file, {...files.get(file), full: true});
+    for (const file of ticketFiles) files.set(file, {...files.get(file), ticketIds: true});
 
     let hard = 0, warn = 0;
 
-    for (const file of files) {
+    for (const [file, scope] of [...files.entries()].sort(([a], [b]) => a.localeCompare(b))) {
         const abs      = path.isAbsolute(file) ? file : path.join(ROOT_DIR, file);
         const content  = readFileSync(abs, 'utf8');
-        const findings = lintGuide(content, {filePath: file, fileDir: path.dirname(abs), scriptKeys, operationIds});
+        const findings = [];
+
+        if (scope.full) {
+            findings.push(...lintGuide(content, {filePath: file, fileDir: path.dirname(abs), scriptKeys, operationIds}));
+        }
+        if (scope.ticketIds) findings.push(...checkTicketIds(content));
+
+        findings.sort((a, b) => a.line - b.line);
 
         if (findings.length === 0) continue;
 
@@ -426,11 +563,11 @@ function runLint(options = {}) {
 
     const failed = hard > 0 || (options.warnAsError && warn > 0);
 
-    console.log(`\n[lint-guides] ${files.length} guide(s) scanned — ${hard} hard, ${warn} warning(s).`);
+    console.log(`\n[lint-guides] ${fullFiles.length} full guide(s) scanned; ${ticketFiles.length} guide-series ticket-id scan(s) — ${hard} hard, ${warn} warning(s).`);
     if (!failed) console.log('[lint-guides] OK');
     else         console.error(`[lint-guides] FAILED — ${hard} hard failure(s)${options.warnAsError ? ` + ${warn} warning(s) (--warn-as-error)` : ''}.`);
 
-    return {exitCode: failed ? 1 : 0, hard, warn};
+    return {exitCode: failed ? 1 : 0, hard, warn, fullGuideCount: fullFiles.length, ticketIdGuideCount: ticketFiles.length};
 }
 
 function main() {
@@ -438,8 +575,9 @@ function main() {
 
     if (options.help) {
         console.log('Usage: node ai/scripts/lint/lint-guides.mjs [files...] [--warn-as-error]');
-        console.log('  Mechanical guide-quality lint for learn/agentos/*.md + learn/benefits/*.md.');
-        console.log('  HARD (exit 1): mermaid reserved-word / self-loop, dead local links, dead ai:* script refs, openapi tool-parity.');
+        console.log('  Full guide-quality lint: learn/agentos/*.md + learn/benefits/*.md.');
+        console.log('  Recursive ticket-id lint: learn/guides/**/*.md (CSS/Mermaid colors exempt).');
+        console.log('  HARD (exit 1): mermaid reserved-word / self-loop, dead local links, dead ai:* script refs, openapi tool-parity, guide ticket ids.');
         console.log('  WARN:          no-mermaid, LR-squish, feature-list headings, "framework".');
         console.log('  --warn-as-error  treat warnings as failures too.');
         process.exit(0);
@@ -455,6 +593,7 @@ if (process.argv[1] && path.resolve(process.argv[1]) === __filename) {
 export {
     FEATURE_LIST_HEADING,
     GUIDE_DIRS,
+    GUIDE_SERIES_DIR,
     LR_NODE_WARN,
     MERMAID_RESERVED,
     TOOLS_HEADING,
@@ -464,6 +603,8 @@ export {
     checkMermaidOrientation,
     checkOpenApiToolParity,
     checkProse,
+    checkTicketIds,
+    discoverGuideSeries,
     discoverGuides,
     extractMermaidBlocks,
     loadOperationIds,

--- a/ai/scripts/lint/lint-guides.mjs
+++ b/ai/scripts/lint/lint-guides.mjs
@@ -60,6 +60,9 @@ const GUIDE_SERIES_DIR = 'learn/guides';
 /** CSS hexadecimal lengths that can otherwise be indistinguishable from numeric ticket ids. */
 const CSS_HEX_LENGTHS = new Set([4, 6, 8]);
 
+/** CSS properties whose value grammar commonly carries raw hexadecimal colors. */
+const CSS_COLOR_PROPERTY = /^(?:--[\w-]+|accent-color|background(?:-color)?|border(?:-(?:block|inline)(?:-(?:start|end))?|-(?:top|right|bottom|left))?(?:-color)?|box-shadow|caret-color|color|column-rule(?:-color)?|fill|flood-color|lighting-color|outline(?:-color)?|scrollbar-color|stop-color|stroke|text-decoration(?:-color)?|text-emphasis(?:-color)?|text-shadow)$/i;
+
 /**
  * Mermaid keywords that break the parser when reused as a node ID or `classDef` name.
  * `graph`/`flowchart` are also legal as the diagram-type declaration on the FIRST block line,
@@ -271,9 +274,10 @@ function isSyntacticHexColor(line, index, token, inFence) {
         return false;
     }
 
-    const before = line.slice(0, index);
+    const before      = line.slice(0, index);
+    const declaration = before.match(/(?:^|[;{])\s*([-\w]+)\s*:[^#]*$/);
 
-    return /(?:^|[;{,])\s*(?:--[\w-]+|[A-Za-z-]+)\s*:[^#]*$/.test(before)
+    return Boolean(declaration && CSS_COLOR_PROPERTY.test(declaration[1]))
         || /\b(?:fill|stroke|color)\s*:[^#]*$/i.test(before);
 }
 

--- a/learn/guides/fundamentals/CodebaseOverview.md
+++ b/learn/guides/fundamentals/CodebaseOverview.md
@@ -431,7 +431,7 @@ Local inference via MLX Server / ML Studio is a first-class deployment target �
 #### Daemon Lifecycle Scripts (`buildScripts/ai/`)
 
 Offline cognitive maintenance runs as **Node.js scripts**, not MCP protocol operations:
-- `node buildScripts/ai/runSandman.mjs` — Triggers the DreamService REM pipeline: extracts Semantic Graph nodes, detects topological conflicts (obsolete/superseded tickets), and runs Capability Gap Inference (TEST_GAP, GUIDE_GAP). *(Note: the orchestrator's `golden-path` cadence task synthesizes the strategic roadmap into `sandman_handoff.md` directly via `GoldenPathSynthesizer.synthesizeGoldenPath()`; no separate standalone runner ships per #12078.)*
+- `node buildScripts/ai/runSandman.mjs` — Triggers the DreamService REM pipeline: extracts Semantic Graph nodes, detects topological conflicts (obsolete/superseded tickets), and runs Capability Gap Inference (TEST_GAP, GUIDE_GAP). *(Note: the orchestrator's `golden-path` cadence task synthesizes the strategic roadmap into `sandman_handoff.md` directly via `GoldenPathSynthesizer.synthesizeGoldenPath()`; that path has no separate standalone runner.)*
 - Additional utilities: `syncKnowledgeBase.mjs`, `defragChromaDB.mjs`, `defragSQLiteDB.mjs`, `recreateGraphDb.mjs` — the maintenance toolkit for the vector and graph databases.
 
 ---
@@ -449,7 +449,7 @@ Formalized Anthropic Progressive Disclosure Skills natively used by the swarm. L
 - `epic-create`: Author Epic bodies as problem-scope + intended-solution — ACs live in the sub-tickets, subs are linked (not listed) so the body doesn't stale (creation-side dual of ticket-create).
 - `epic-review`: Pre-work six-stage gating chain for epics (roadmap fit, approach elegance, source discussion mapping, sub-structure coherence, prescription layer, avoided-traps completeness). You never review your own epic. A source-Discussion participant narrows rather than skips: cite Stages 1–2, run 2.5 from context, and run 3–5 in full — the Discussion is the epic's input, the decomposition is a transformation you have not seen.
 - `epic-resolution`: Closeout protocol for parent epics resolving the completion status (exit gate).
-- `update-roadmap`: Post-release celebrate + plan-next-roadmap — cornerstones + rationale + an explicit deferred set scoped into a GitHub milestone with a named steward per epic (release-altitude analog of `epic-create`; sibling to the parked release-cut skill #10321).
+- `update-roadmap`: Post-release celebrate + plan-next-roadmap — cornerstones + rationale + an explicit deferred set scoped into a GitHub milestone with a named steward per epic (the release-altitude analog of `epic-create`; release cutting remains deliberately separate).
 - `blog-post`: Public-facing hero-piece authoring — narrative arc, sourcing every external claim (verify-before-assert; an authority's verbal statement is not a citable source), killing the three over-claim flavors (unsourced superlative / universal quantifier / misleading fraction), and a mandatory cross-family review bar (the blog sibling of the release-notes methodology).
 - `release-notes`: Release notes as an EPIC with mining-driven iterations — multi-source scope derivation (the tracker lags shipped reality), heavy per-arc Memory-Core mining, per-claim V-B-A, the precedent-SET quality bar — majors AND minors (hero chapters, named case studies with real timelines, War Stories, honest bounds, never downplay a release), and the `publish.mjs` flat-root staging lifecycle (staging file → atomic-hash → GitHub Release → chunk-N mirror).
 - `guide-authoring`: Per-sub enforcement for `learn/` guide quality — grounding discipline, rich narrative + benefits + lived voice, render-verified TD Mermaid, conceptual-vs-reference separation, generated-file hygiene, and no-rubber-stamp review.
@@ -476,7 +476,7 @@ Formalized Anthropic Progressive Disclosure Skills natively used by the swarm. L
 **Coordination:**
 - `lane-intent`: Narrow, non-authoritative, 2h TTL-bound pre-V-B-A signal for collision-prone / long-V-B-A lanes (deep `/memory-mining`, `/tech-debt-radar`, multi-turn architectural V-B-A). Distinct from authoritative `[lane-claim]` (post-V-B-A).
 - `post-review-pickup`: Mandatory active lane selection at ANY PR-lifecycle event boundary (review post / author response / post-impl / post-PR-open-update / post-ticket-create / post-blocked-resolution). Requires explicit `lane-state: next-lane` declaration per AGENTS.md §15.6 self-select mandate.
-- `peer-naming`: The Social Name ritual (#11240 Layer 4) — peer-sketched → criterion-audited → bearer-assented → peer-unvetoed → operator-confirmed; codifies how a maintainer is *given* a name distinct from the `@handle` (name ≠ handle).
+- `peer-naming`: The Social Name ritual's identity Layer 4 — peer-sketched → criterion-audited → bearer-assented → peer-unvetoed → operator-confirmed; codifies how a maintainer is *given* a name distinct from the `@handle` (name ≠ handle).
 
 **Meta:**
 - `create-skill`: Architectural blueprinting for new operational abilities.

--- a/learn/guides/specificfeatures/TearOutPortabilityMatrix.md
+++ b/learn/guides/specificfeatures/TearOutPortabilityMatrix.md
@@ -8,11 +8,11 @@ selected by CITING this ledger's receipts, under the authority of ADR 0029 and t
 contract: WHATWG activation, `moveTo` throttling, and screen-topology permissions all vary by
 platform, and assumption is not evidence.
 
-Authority chain (this ledger sits at the BOTTOM): Discussion #15204 OQ2 `[RESOLVED_TO_AC]` (the
-ratified matrix contract) → issue #15243 (OPEN — owns the complete 7×3 result and the
-revalidation gate) → this ledger (the accumulating receipts its children produce). The ledger
-is registered hidden in the learn tree: an internal evidence surface, not a public-facing
-guide.
+Authority chain (this ledger sits at the BOTTOM): the source design discussion's OQ2
+`[RESOLVED_TO_AC]` decision (the ratified matrix contract) → the live matrix tracker (which owns
+the complete 7×3 result and revalidation gate) → this ledger (the accumulating receipts its
+children produce). The ledger is registered hidden in the learn tree: an internal evidence
+surface, not a public-facing guide.
 
 ## The grammar under test
 
@@ -111,10 +111,10 @@ carried honestly per footnote ²'s lesson: the rate is measured under CDP-synthe
 which this same suite proved distorts activation semantics — the real-input reap rate is
 unknown (the flagship demo's manual operation suggests real-mouse tear-outs succeed at a far
 higher rate). **RESOLVED (2026-07-18):** the race was attributed (a false re-entry — the exit's own layout
-choreography jumped the hysteresis read) and FIXED at mechanism in PR #15413 (Schmitt-trigger
-arming, merged); this ledger's own witness confirmed 6/6 survivals post-fix against the exact
+choreography jumped the hysteresis read) and FIXED at mechanism by the merged Schmitt-trigger
+arming repair; this ledger's own witness confirmed 6/6 survivals post-fix against the exact
 pre-fix baseline, and the post-rebase run holds 3/3. The `revalidationTrigger` question is
-resolved-as-fixed; rows 4–7 are measurable again as #15243 children.
+resolved-as-fixed; rows 4–7 are measurable again through their dedicated witness leaves.
 
 **Attribution hypothesis (source-anchored, falsifier-backed):** the boundary-EXIT reconfigures
 the exact geometry the hysteresis reads — the drag placeholder hides and the remaining items
@@ -164,10 +164,11 @@ target. The exact canonical full-journey control
 `DemoBPerspectivesNL.spec.mjs` failed because the intended popup never rendered the live
 CounterPane. The narrower `DemoBCrossWindowDragNL.spec.mjs` stayed green while logging three
 window connections, proving that its current receipt does not falsify competing-vessel identity.
-The composition repair belongs to #15396; this matrix does not absorb it. Row 4's former second
-gap (Demo B exposes no `Neo.data.Store`) is now CLOSED by the Fleet-surface receipt above.
+The composition repair belongs to the dedicated full-journey repair; this matrix does not absorb
+it. Row 4's former second gap (Demo B exposes no `Neo.data.Store`) is now CLOSED by the
+Fleet-surface receipt above.
 
-**#15396 green control (2026-07-19, verdicts still pending):** the matrix runner now includes the
+**Full-journey green control (2026-07-19, verdicts still pending):** the matrix runner now includes the
 full Demo B cross-window journey. Its macOS/Chrome headed round-trip externally observes exactly
 one `?popout=workbench` Playwright `Page`, instruments browser-realm `window.open` independently of
 the app counter, verifies that the same `Page` survives park → re-show → detached terminal, records

--- a/learn/guides/testing/ComponentTesting.md
+++ b/learn/guides/testing/ComponentTesting.md
@@ -223,4 +223,4 @@ We are actively exploring **"Deep E2E"** testing powered by the **Neural Link**.
 *   Verify state across multiple windows seamlessly.
 *   Hot-patch code during runtime for advanced assertions.
 
-This capability is tracked in **[Issue #8851](https://github.com/neomjs/neo/issues/8851)**. If this feature is important to your workflow, please leave a comment on the ticket to help us prioritize it.
+This remains the Neural Link-backed testing direction rather than a shipped fixture contract. Until it lands, treat the current component bridge's visibility limits as real and use a dedicated application harness for flows that need deeper worker-state access.

--- a/test/playwright/unit/ai/scripts/lint/lintGuides.spec.mjs
+++ b/test/playwright/unit/ai/scripts/lint/lintGuides.spec.mjs
@@ -175,6 +175,26 @@ test.describe('ai/scripts/lint-guides (#14354 — mechanical guide-quality lint)
         expect(found[0].detail).toContain('#56789');
     });
 
+    test('checkTicketIds: CSS-length ticket ids after prose labels remain HARD in code', () => {
+        const content = [
+            '```text',
+            'Related: #9473',
+            'Ticket: #123456',
+            'issue: #12345678',
+            '```',
+            'Refs: `#8856` in the body'
+        ].join('\n');
+        const found = checkTicketIds(content);
+
+        expect(found.map(f => [f.line, f.detail.match(/#[0-9]+/)[0]])).toEqual([
+            [2, '#9473'],
+            [3, '#123456'],
+            [4, '#12345678'],
+            [6, '#8856']
+        ]);
+        expect(found.every(f => f.severity === 'HARD' && f.rule === 'ticket-id')).toBe(true);
+    });
+
     test('discoverGuideSeries: recursively reaches nested guides without widening the full-guide surface', () => {
         const files = discoverGuideSeries();
 

--- a/test/playwright/unit/ai/scripts/lint/lintGuides.spec.mjs
+++ b/test/playwright/unit/ai/scripts/lint/lintGuides.spec.mjs
@@ -1,6 +1,7 @@
-import {test, expect} from '@playwright/test';
-import {spawnSync}    from 'node:child_process';
-import path           from 'node:path';
+import {test, expect}                                  from '@playwright/test';
+import {spawnSync}                                     from 'node:child_process';
+import {mkdirSync, mkdtempSync, rmSync, writeFileSync} from 'node:fs';
+import path                                            from 'node:path';
 
 import {
     checkDeadLinks,
@@ -9,6 +10,8 @@ import {
     checkMermaidOrientation,
     checkOpenApiToolParity,
     checkProse,
+    checkTicketIds,
+    discoverGuideSeries,
     extractMermaidBlocks,
     lintGuide,
     parseArgs
@@ -19,9 +22,9 @@ import {
  * Tests the pure check functions against hand-built inputs so reviewer
  * V-B-A is cheap, plus the two boundaries a guide lint MUST get right to be trustworthy:
  *   - true positives fire (reserved-word Mermaid, self-loops, dead links, hallucinated `ai:*` refs,
- *     hallucinated MCP tool-table refs);
+ *     hallucinated MCP tool-table refs, rotting guide ticket references);
  *   - false positives DON'T (the `graph LR` declaration line, real `package.json` scripts, fenced code,
- *     config/property tables outside a Tools heading).
+ *     config/property tables outside a Tools heading, CSS/Mermaid hex colors).
  */
 test.describe('ai/scripts/lint-guides (#14354 — mechanical guide-quality lint)', () => {
     const scriptPath = path.resolve(process.cwd(), 'ai/scripts/lint/lint-guides.mjs');
@@ -133,6 +136,76 @@ test.describe('ai/scripts/lint-guides (#14354 — mechanical guide-quality lint)
 
     test('checkDeadScriptRefs: bare prose mention (no backtick / no "npm run") is NOT flagged', () => {
         expect(checkDeadScriptRefs('The ai:foo namespace is conceptual.', new Set())).toHaveLength(0);
+    });
+
+    test('checkTicketIds: prose, inline code, fenced code and multiple references are HARD with exact lines', () => {
+        const content = [
+            '# Guide',
+            'The old path came from #12345 and PR #23456.',
+            'Inline `#34567` still rots.',
+            '```text',
+            'Replay #45678 rather than explaining the mechanism.',
+            '```'
+        ].join('\n');
+        const found = checkTicketIds(content);
+
+        expect(found).toHaveLength(4);
+        expect(found.map(f => f.line)).toEqual([2, 2, 3, 5]);
+        expect(found.every(f => f.severity === 'HARD' && f.rule === 'ticket-id')).toBe(true);
+        expect(found.map(f => f.detail).join(' ')).toContain('#45678');
+    });
+
+    test('checkTicketIds: CSS/Mermaid colors stay green without exempting a bare code ticket id', () => {
+        const content = [
+            '```mermaid',
+            'flowchart TD',
+            '  classDef pane fill:#3498db,stroke:#282829,color:#1234',
+            '```',
+            '```css',
+            '.pane { border: 1px solid #282829; color: #1234; }',
+            '```',
+            'The literal `color: #282829` is a color.',
+            'The literal `#56789` is still a tracker reference.',
+            'Short fragments #123 and alphanumeric hashes #123abc are not ticket ids.'
+        ].join('\n');
+        const found = checkTicketIds(content);
+
+        expect(found).toHaveLength(1);
+        expect(found[0]).toMatchObject({line: 9, severity: 'HARD', rule: 'ticket-id'});
+        expect(found[0].detail).toContain('#56789');
+    });
+
+    test('discoverGuideSeries: recursively reaches nested guides without widening the full-guide surface', () => {
+        const files = discoverGuideSeries();
+
+        expect(files).toContain('learn/guides/testing/ComponentTesting.md');
+        expect(files).toContain('learn/guides/userinteraction/events/CustomEvents.md');
+        expect(files.some(file => file.startsWith('learn/agentos/'))).toBe(false);
+    });
+
+    test('CLI: the default discovery path makes one nested scratch guide red, then green', () => {
+        const seriesRoot = path.resolve(process.cwd(), 'learn/guides');
+        mkdirSync(seriesRoot, {recursive: true});
+
+        const scratchDir  = mkdtempSync(path.join(seriesRoot, '.ticket-id-red-'));
+        const scratchFile = path.join(scratchDir, 'ScratchGuide.md');
+
+        try {
+            writeFileSync(scratchFile, '# Scratch\n\nThe shortcut lives in #98765.\n');
+
+            const red = spawnSync('node', [scriptPath], {cwd: process.cwd(), encoding: 'utf8'});
+            expect(red.status).toBe(1);
+            expect(red.stdout).toContain(path.relative(process.cwd(), scratchFile));
+            expect(red.stdout).toContain('[ticket-id] line 3');
+
+            writeFileSync(scratchFile, '# Scratch\n\nThe shortcut is described by its mechanism.\n');
+
+            const green = spawnSync('node', [scriptPath], {cwd: process.cwd(), encoding: 'utf8'});
+            expect(green.status).toBe(0);
+            expect(green.stdout).toContain('guide-series ticket-id scan(s)');
+        } finally {
+            rmSync(scratchDir, {recursive: true, force: true});
+        }
     });
 
     test('checkProse: feature-list heading + "framework" warn; fenced code is ignored', () => {


### PR DESCRIPTION
Resolves #17574

Related: #17540
Related PR: #17572

`ai:lint-guides` now preserves its existing 36-file full-quality surface while a second, recursive pass checks all 56 files under `learn/guides/` for mutable tracker references. Prose, inline code, and fenced examples fail with exact line diagnostics; CSS/Mermaid color values remain valid. The ten live references were rephrased across the three measured guides without changing their mechanisms or evidence. The guide-authoring discipline now states the same no-ticket-id rule before CI enforces it.

Evidence: L2 (focused unit contract plus the real default CLI discovery path, including RED→GREEN scratch transition and the live 36+56 corpus pass) → L2 required (all seven close-target ACs are CI-reachable). No residuals.

## AC Evidence

| AC-1 | `discoverGuideSeries()` recursively feeds only `checkTicketIds()` for nested `learn/guides/` Markdown; the default-CLI spec proves a nested scratch file can fail. |
| AC-2 | `discoverGuides()` remains the full-rule authority; the production receipt reports 36 full guides while the separate ticket-id pass reports 56. |
| AC-3 | `CodebaseOverview.md`, `TearOutPortabilityMatrix.md`, and `ComponentTesting.md` now describe the durable mechanism; the default lint reports zero HARDs across the live series. |
| AC-4 | `lintGuides.spec.mjs` covers prose, two references on one line, inline code, fenced code, and exact line diagnostics. |
| AC-5 | Negative controls keep short/alphanumeric hashes and CSS/Mermaid colors green, including `#282829`; labelled 4/6/8-digit references and a bare inline ticket id remain red. |
| AC-6 | The default-CLI arm creates a real nested scratch guide, observes `[ticket-id] line 3` with exit 1, removes the reference, and observes exit 0 through the same route. |
| AC-7 | `npm run ai:lint-guides` → 36 full guides + 56 ticket-id scans, 0 hard, 27 report-only pre-existing warnings, exit 0. |

## Deltas from ticket

- Fresh intake found ten tracker references across three files, replacing the original two-file census.
- The literal numeric-hash regex also matched real CSS/Mermaid colors. The implementation exempts only recognized color-bearing CSS properties, CSS custom properties, and Mermaid color anchors inside fenced/inline code; a bare or prose-labelled numeric hash in either shape still fails.
- The full legacy guide rule set remains on its existing surface; only the new rule recurses, avoiding the measured unrelated dead-link HARD and 50 warnings.
- Review repair adds the discipline echo to the existing guide-authoring payload; it does not widen the lint or skill trigger surface.

## Substrate Mutation Rationale

- `.agents/skills/guide-authoring/references/guide-authoring-bar.md` §4: `keep` in the conditional payload. Trigger frequency is guide authoring/review only; missing it defers a mechanically enforceable rule until CI; `ai:lint-guides` owns enforcement. The placement adds +225 payload bytes and zero `SKILL.md` router bytes.

## Test Evidence

All coverage runs in CI.

## Post-Merge Validation

None — every close-target effect is exercised by the unit suite's real CLI child process and clean-checkout corpus.

## Commits

- `812918e38a` — add the recursive guide-series ticket-id lint and corpus sweep.
- `86ab9e297f` — narrow the color exemption, add its adversarial arm, and state the discipline rule.

Authored by Emmy (GPT-5.6 Sol Ultra, Codex). Session 429a3792-5cea-4c7b-a409-a1fd8b44ccd2.
