### PR TITLE
fix(ai): split redeploy backup verdicts (#16567)

### DIFF
--- a/ai/scripts/maintenance/backup.mjs
+++ b/ai/scripts/maintenance/backup.mjs
@@ -23,7 +23,8 @@ import {
     Memory_LifecycleService
 } from '../../services.mjs';
 
-import {buildSourceReceipt}             from '../../services/shared/captureReceipt.mjs';
+import {RECOVERY_SUBSTRATES} from '../../services/memory-core/helpers/bundleIntegrity.mjs';
+import {buildSourceReceipt}  from '../../services/shared/captureReceipt.mjs';
 import {
     resolveHeavyMaintenanceLeasePath,
     withHeavyMaintenanceLease
@@ -801,7 +802,7 @@ export function classifyIntegrityStatus(status) {
  * Declared above both consumers rather than between them, so neither reads as the authority.
  * @member {String[]} RECOVERY_SUBSTRATES
  */
-export const RECOVERY_SUBSTRATES = Object.freeze(['kb', 'mc', 'graph']);
+export {RECOVERY_SUBSTRATES};
 
 /**
  * Verifies row-count parity between source collections and the JSONL files written into the

--- a/ai/scripts/maintenance/redeployPreflight.mjs
+++ b/ai/scripts/maintenance/redeployPreflight.mjs
@@ -88,12 +88,13 @@ export const INITIALIZATION_MARKER_FILENAME = '.deployment-initialized';
  * @type {Object}
  */
 export const REDEPLOY_PREFLIGHT_DECISION = Object.freeze({
-    PROCEED_INITIALIZING      : 'PROCEED_INITIALIZING',
-    PROCEED_MARKER_RECOVERED  : 'PROCEED_MARKER_RECOVERED',
-    PROCEED_VERIFIED          : 'PROCEED_VERIFIED',
-    REFUSE_ALREADY_INITIALIZED: 'REFUSE_ALREADY_INITIALIZED',
-    REFUSE_NO_VERIFIED_BUNDLE : 'REFUSE_NO_VERIFIED_BUNDLE',
-    REFUSE_PLANE_STATE_UNKNOWN: 'REFUSE_PLANE_STATE_UNKNOWN'
+    PROCEED_INITIALIZING             : 'PROCEED_INITIALIZING',
+    PROCEED_MARKER_RECOVERED         : 'PROCEED_MARKER_RECOVERED',
+    PROCEED_VERIFIED                 : 'PROCEED_VERIFIED',
+    REFUSE_ALREADY_INITIALIZED       : 'REFUSE_ALREADY_INITIALIZED',
+    REFUSE_INCOMPLETE_RECOVERY_SOURCE: 'REFUSE_INCOMPLETE_RECOVERY_SOURCE',
+    REFUSE_NO_VERIFIED_BUNDLE        : 'REFUSE_NO_VERIFIED_BUNDLE',
+    REFUSE_PLANE_STATE_UNKNOWN       : 'REFUSE_PLANE_STATE_UNKNOWN'
 });
 
 /**
@@ -107,6 +108,9 @@ export const REDEPLOY_PREFLIGHT_DECISION = Object.freeze({
  * @param {Boolean} options.markerPresent Whether this host has recorded a prior deployment.
  * @param {Boolean} options.initializeRequested Whether the operator passed the explicit flag.
  * @param {String|null} [options.primaryVolumeState=null] Docker primary-volume observation.
+ * @param {Boolean} options.priorStateEvidence Whether the bundle proves a plane existed.
+ * @param {Boolean} options.recoverySourceAuthorized Whether the bundle is complete enough to restore.
+ * @param {String[]|null} [options.emptySubsystems=null] Named empty recovery substrates, when measured.
  * @param {String} options.verdictCode A `verifyLatestBackupRestorable` code.
  * @returns {{decision: String, proceed: Boolean, writeMarker: Boolean, reason: String}}
  */
@@ -114,9 +118,16 @@ export function evaluateRedeployPreconditions({
     markerPresent,
     initializeRequested,
     primaryVolumeState = null,
+    priorStateEvidence,
+    recoverySourceAuthorized,
+    emptySubsystems = null,
     verdictCode
 }) {
-    const restorable = verdictCode === 'RESTORABLE';
+    // Authorization cannot coherently exist without prior state. A malformed caller presenting
+    // that cross-product cell is refused on both paths: the claim blocks initialization, while the
+    // missing corroborating fact prevents an ordinary deploy.
+    const bundleProvesPriorState   = priorStateEvidence === true || recoverySourceAuthorized === true,
+          bundleAuthorizesRecovery = priorStateEvidence === true && recoverySourceAuthorized === true;
 
     if (initializeRequested) {
         const priorEvidence = [];
@@ -124,8 +135,8 @@ export function evaluateRedeployPreconditions({
         if (markerPresent) {
             priorEvidence.push('the initialization marker')
         }
-        if (restorable) {
-            priorEvidence.push('a verified restorable bundle')
+        if (bundleProvesPriorState) {
+            priorEvidence.push('a bundle containing prior-state rows')
         }
         if (primaryVolumeState === PRIMARY_VOLUME_STATE.PRESENT) {
             priorEvidence.push('the Compose-labeled primary-store volume')
@@ -165,7 +176,7 @@ export function evaluateRedeployPreconditions({
     }
 
     // Row 4 — the ordinary verified redeploy.
-    if (markerPresent && restorable) {
+    if (markerPresent && bundleAuthorizesRecovery) {
         return {
             decision   : REDEPLOY_PREFLIGHT_DECISION.PROCEED_VERIFIED,
             proceed    : true,
@@ -177,12 +188,28 @@ export function evaluateRedeployPreconditions({
     // Row 2 — no marker but a verified bundle. The bundle PROVES prior state, so the missing marker
     // is the anomaly rather than the deployment. Recorded rather than refused, otherwise a host that
     // lost its marker independently of its bundles could never deploy again.
-    if (restorable) {
+    if (bundleAuthorizesRecovery) {
         return {
             decision   : REDEPLOY_PREFLIGHT_DECISION.PROCEED_MARKER_RECOVERED,
             proceed    : true,
             writeMarker: true,
             reason     : 'No initialization marker, but a verified restorable bundle proves a prior deployment; recording the marker.'
+        }
+    }
+
+    // A partially populated bundle proves the plane existed but does not authorize a deploy. This
+    // refusal deliberately never recommends `--initialize`: the same prior-state fact blocks that
+    // destructive declaration above, and suggesting it here would reopen the exact interlock.
+    if (bundleProvesPriorState) {
+        const detail = Array.isArray(emptySubsystems) && emptySubsystems.length > 0
+            ? `empty recovery subsystem(s): ${emptySubsystems.join(', ')}`
+            : 'recovery-source completeness could not be established';
+
+        return {
+            decision   : REDEPLOY_PREFLIGHT_DECISION.REFUSE_INCOMPLETE_RECOVERY_SOURCE,
+            proceed    : false,
+            writeMarker: false,
+            reason     : `A bundle proves prior deployment but cannot authorize recovery (${detail}). No plane mutation is authorized.`
         }
     }
 
@@ -376,10 +403,13 @@ export async function runRedeployPreflight({
               ? await primaryVolumeProbeFn({composeProject})
               : {reason: 'not-required-for-ordinary-redeploy', state: null},
           outcome       = evaluateRedeployPreconditions({
+              emptySubsystems         : verdict.emptySubsystems ?? null,
               initializeRequested,
               markerPresent,
-              primaryVolumeState: primaryVolume.state,
-              verdictCode       : verdict.code
+              primaryVolumeState      : primaryVolume.state,
+              priorStateEvidence      : verdict.priorStateEvidence === true,
+              recoverySourceAuthorized: verdict.recoverySourceAuthorized === true,
+              verdictCode             : verdict.code
           });
 
     if (outcome.proceed && outcome.writeMarker) {
@@ -397,11 +427,15 @@ export async function runRedeployPreflight({
         primaryVolumeName      : primaryVolume.volumeName ?? null,
         primaryVolumeReason    : primaryVolume.reason,
         primaryVolumeState     : primaryVolume.state,
-        // The probe's own verdict travels with the decision so a deploy log records WHY, not just
-        // whether. `rowTotal` is what `RESTORABLE` was decided on.
-        verdictCode  : verdict.code,
-        verdictReason: verdict.reason ?? null,
-        rowTotal     : verdict.rowTotal ?? null
+        // The probe's own split facts travel with the decision so a deploy log records WHY, not just
+        // whether. Vector rows plus the integrity census prove prior state; the integrity-derived
+        // authorization is separate.
+        emptySubsystems         : verdict.emptySubsystems ?? null,
+        priorStateEvidence      : verdict.priorStateEvidence === true,
+        recoverySourceAuthorized: verdict.recoverySourceAuthorized === true,
+        verdictCode             : verdict.code,
+        verdictReason           : verdict.reason ?? null,
+        rowTotal                : verdict.rowTotal ?? null
     }
 }
 

--- a/ai/scripts/maintenance/restore.mjs
+++ b/ai/scripts/maintenance/restore.mjs
@@ -878,9 +878,10 @@ export function assessEmbeddingCompatibility({expectedDimension, logger = consol
  * `code` is the machine-readable verdict — `RESTORABLE`, `BUNDLE_ROOT_MISSING`, `NO_BUNDLES`,
  * `BUNDLE_EMPTY`, `BUNDLE_INCOMPLETE`, `BUNDLE_INVALID`, or `BUNDLE_UNVERIFIABLE`. `RESTORABLE`
  * asserts the bundle is structurally valid, non-empty, and complete across the canonical recovery
- * substrates. `priorStateEvidence` remains independently true for an incomplete non-empty bundle,
- * preserving the initialization interlock without authorizing recovery. `rowTotal` reports the
- * observed vector rows, and
+ * substrates. `priorStateEvidence` is the root-level disjunction over every examined bundle: one
+ * incomplete non-empty candidate keeps it true even when a newer empty or invalid candidate remains
+ * the reported failure. This preserves the initialization interlock without authorizing recovery.
+ * `rowTotal` reports the newest candidate's observed vector rows, and
  * `bundleRoot` names WHICH bundle earned the verdict — no longer necessarily the newest one present.
  * That strength lives here rather than in a caller so a shell gate consumes one authoritative verdict
  * instead of re-reading metadata and growing a second predicate able to disagree with this one.
@@ -890,7 +891,9 @@ export function assessEmbeddingCompatibility({expectedDimension, logger = consol
  * On failure the reported `code`/`bundleRoot`/`reason` describe the NEWEST bundle rather than an
  * invented aggregate, so a single-bundle root answers exactly as it did before this function learned
  * to look further back, and `redeployPreflight`'s refusal still prints the most recent cause.
- * `skipped` lists every rejected candidate newest-first; `examined` counts full validations spent.
+ * `priorStateEvidence` is the deliberate exception because the initialization interlock asks whether
+ * ANY examined bundle proves a prior plane. `skipped` lists every rejected candidate newest-first;
+ * `examined` counts full validations spent.
  *
  * It exists so a caller gating on this probe branches on a value rather than
  * pattern-matching English out of `reason`, which would silently stop working the moment the prose
@@ -961,7 +964,8 @@ export async function verifyLatestBackupRestorable({
 
     const skipped  = [];
     let   examined = 0,
-          newest   = null;
+          newest        = null,
+          sawPriorState = false;
 
     for (const bundleName of bundleNames) {
         if (examined >= maxBundlesExamined) {
@@ -979,6 +983,11 @@ export async function verifyLatestBackupRestorable({
 
         const verdict = await probeBundle({backupRoot, bundleName, logger, validateFn, checkedAt});
 
+        // Authorization belongs to one candidate; prior-state belongs to the root. A populated but
+        // incomplete older bundle must keep the initialization interlock closed even when the newest
+        // candidate is empty, invalid, or the scan stops before finding an authorized recovery source.
+        sawPriorState ||= verdict.priorStateEvidence === true;
+
         if (verdict.recoverySourceAuthorized) {
             // Reporting rather than hiding. The operator's repair for the incident was `rm -rf` on the
             // unusable newest directory; a fallback that silently succeeded would have removed the
@@ -990,7 +999,7 @@ export async function verifyLatestBackupRestorable({
                 );
             }
 
-            return {...verdict, skipped, examined}
+            return {...verdict, priorStateEvidence: sawPriorState, skipped, examined}
         }
 
         // FAIL CLOSED on an unobservable candidate. Walking backwards is only justified when the
@@ -1008,7 +1017,7 @@ export async function verifyLatestBackupRestorable({
                 `Reason: ${verdict.reason}`
             );
 
-            return {...verdict, skipped, examined}
+            return {...verdict, priorStateEvidence: sawPriorState, skipped, examined}
         }
 
         // The WHOLE verdict, not a projection of it. Rebuilding a reduced `{code, reason, bundleRoot}`
@@ -1019,12 +1028,10 @@ export async function verifyLatestBackupRestorable({
         skipped.push({bundleName, code: verdict.code, reason: verdict.reason});
     }
 
-    // No candidate survived. The verdict keeps the NEWEST bundle's own result rather than inventing an
-    // aggregate one: consumers (`redeployPreflight.evaluateRedeployPreconditions`) branch on
-    // `RESTORABLE` vs everything-else and log the code as the refusal cause, so the most recent
-    // failure remains the most useful thing to print — and a single-bundle root reports exactly what
-    // it reported before this function learned to look further back.
-    return {...newest, skipped, examined}
+    // No candidate survived. Failure provenance remains the NEWEST bundle's result; only the
+    // root-level prior-state fact aggregates across the walk so initialization cannot erase an older
+    // populated bundle from consideration.
+    return {...newest, priorStateEvidence: sawPriorState, skipped, examined}
 }
 
 /**

--- a/ai/scripts/maintenance/restore.mjs
+++ b/ai/scripts/maintenance/restore.mjs
@@ -14,6 +14,7 @@ import mcConfig from '../../mcp/server/memory-core/config.mjs';
 import AiConfig from '../../config.mjs';
 
 import {classifyRowVector}                          from '../../services/memory-core/helpers/vectorWriteInvariant.mjs';
+import {summarizeBundleIntegrity}                   from '../../services/memory-core/helpers/bundleIntegrity.mjs';
 import {HEAL_LEDGER_DIR_NAME, HEAL_LEDGER_FILENAME} from '../../services/memory-core/helpers/healEventLedgerStore.mjs';
 import {INCIDENT_LEDGER_BUNDLE_MEMBERS}             from '../../services/memory-core/helpers/incidentLedgerBundle.mjs';
 import {
@@ -451,8 +452,9 @@ export async function runRestore({
  * @summary The only per-candidate verdicts that authorize {@link verifyLatestBackupRestorable} to
  * keep walking backwards.
  *
- * Both members are POSITIVE findings about a bundle the validator actually read: it parsed and held
- * no recoverable rows (`BUNDLE_EMPTY`), or it parsed far enough to be judged malformed
+ * All three members are POSITIVE findings about a bundle the validator actually read: it held no
+ * recoverable rows (`BUNDLE_EMPTY`), carried prior-state rows but failed the all-substrate recovery
+ * contract (`BUNDLE_INCOMPLETE`), or was parsed far enough to be judged malformed
  * (`BUNDLE_INVALID`). Everything else — notably `BUNDLE_UNVERIFIABLE` — means the probe failed to
  * observe the candidate, which is not evidence about the candidate and must stop the walk.
  *
@@ -460,7 +462,7 @@ export async function runRestore({
  * continue-eligible; a new code fails closed until someone decides otherwise.
  * @type {Set<String>}
  */
-export const CONTINUE_ELIGIBLE_BUNDLE_VERDICTS = new Set(['BUNDLE_EMPTY', 'BUNDLE_INVALID']);
+export const CONTINUE_ELIGIBLE_BUNDLE_VERDICTS = new Set(['BUNDLE_EMPTY', 'BUNDLE_INCOMPLETE', 'BUNDLE_INVALID']);
 
 export class BundleContentError extends Error {
     /**
@@ -853,7 +855,7 @@ export function assessEmbeddingCompatibility({expectedDimension, logger = consol
  * ## Why it stops for an unreadable candidate
  *
  * Walking backwards is only justified by a POSITIVE finding: the validator reached this bundle and
- * judged its content unusable (`BUNDLE_EMPTY` / `BUNDLE_INVALID` — see
+ * judged its content unusable (`BUNDLE_EMPTY` / `BUNDLE_INCOMPLETE` / `BUNDLE_INVALID` — see
  * {@link CONTINUE_ELIGIBLE_BUNDLE_VERDICTS}). A permissions failure, a vanished mount, fd
  * exhaustion, or a defect inside the validator all mean *"I could not tell"*, and an earlier
  * revision of this walk collapsed those into `BUNDLE_INVALID` and continued — so a newer, perfectly
@@ -872,13 +874,18 @@ export function assessEmbeddingCompatibility({expectedDimension, logger = consol
  *     Cap on bundles validated. Read as a default parameter (evaluated per call, so an overlay change
  *     is honoured without a reload). Exhausting it warns which candidates went unexamined rather than
  *     reporting a clean "nothing restorable".
- * @returns {Promise<{restorable: Boolean, code: String, bundleRoot: String|null, reason: String|null, checkedAt: String, rowTotal: Number|undefined, embeddingAdvisories: Object[], skipped: Object[], examined: Number}>}
+ * @returns {Promise<{restorable: Boolean, priorStateEvidence: Boolean, recoverySourceAuthorized: Boolean, code: String, bundleRoot: String|null, reason: String|null, checkedAt: String, rowTotal: Number|undefined, embeddingAdvisories: Object[], skipped: Object[], examined: Number}>}
  * `code` is the machine-readable verdict — `RESTORABLE`, `BUNDLE_ROOT_MISSING`, `NO_BUNDLES`,
- * `BUNDLE_EMPTY`, `BUNDLE_INVALID`, or `BUNDLE_UNVERIFIABLE`. `RESTORABLE` asserts the bundle is BOTH
- * structurally valid and non-empty; `rowTotal` reports the row count it was decided on, and
+ * `BUNDLE_EMPTY`, `BUNDLE_INCOMPLETE`, `BUNDLE_INVALID`, or `BUNDLE_UNVERIFIABLE`. `RESTORABLE`
+ * asserts the bundle is structurally valid, non-empty, and complete across the canonical recovery
+ * substrates. `priorStateEvidence` remains independently true for an incomplete non-empty bundle,
+ * preserving the initialization interlock without authorizing recovery. `rowTotal` reports the
+ * observed vector rows, and
  * `bundleRoot` names WHICH bundle earned the verdict — no longer necessarily the newest one present.
  * That strength lives here rather than in a caller so a shell gate consumes one authoritative verdict
  * instead of re-reading metadata and growing a second predicate able to disagree with this one.
+ * `restorable` remains a compatibility alias of `recoverySourceAuthorized`; it must never be used
+ * as prior-state evidence now that the two questions have separate fields.
  *
  * On failure the reported `code`/`bundleRoot`/`reason` describe the NEWEST bundle rather than an
  * invented aggregate, so a single-bundle root answers exactly as it did before this function learned
@@ -918,7 +925,17 @@ export async function verifyLatestBackupRestorable({
         // path RELATIVE to the compose project directory, so a deployment run from a different host
         // checkout addresses a directory that never existed rather than an empty one. Reporting "no
         // bundle" for bundles sitting safely in a prior checkout would answer about the wrong subject.
-        return {restorable: false, code: 'BUNDLE_ROOT_MISSING', bundleRoot: null, reason: `backup root not found: ${backupRoot}`, checkedAt, skipped: [], examined: 0};
+        return {
+            restorable              : false,
+            priorStateEvidence      : false,
+            recoverySourceAuthorized: false,
+            code                    : 'BUNDLE_ROOT_MISSING',
+            bundleRoot              : null,
+            reason                  : `backup root not found: ${backupRoot}`,
+            checkedAt,
+            skipped                 : [],
+            examined                : 0
+        };
     }
 
     // backup-<ISO-ts> names sort lexically by their ISO timestamp, so reverse-sort yields newest-first.
@@ -929,7 +946,17 @@ export async function verifyLatestBackupRestorable({
         .reverse();
 
     if (bundleNames.length === 0) {
-        return {restorable: false, code: 'NO_BUNDLES', bundleRoot: null, reason: `no backup-* bundles under ${backupRoot}`, checkedAt, skipped: [], examined: 0};
+        return {
+            restorable              : false,
+            priorStateEvidence      : false,
+            recoverySourceAuthorized: false,
+            code                    : 'NO_BUNDLES',
+            bundleRoot              : null,
+            reason                  : `no backup-* bundles under ${backupRoot}`,
+            checkedAt,
+            skipped                 : [],
+            examined                : 0
+        };
     }
 
     const skipped  = [];
@@ -952,7 +979,7 @@ export async function verifyLatestBackupRestorable({
 
         const verdict = await probeBundle({backupRoot, bundleName, logger, validateFn, checkedAt});
 
-        if (verdict.restorable) {
+        if (verdict.recoverySourceAuthorized) {
             // Reporting rather than hiding. The operator's repair for the incident was `rm -rf` on the
             // unusable newest directory; a fallback that silently succeeded would have removed the
             // pressure to notice it at all, so every bundle passed over travels with the verdict.
@@ -1013,7 +1040,8 @@ export async function verifyLatestBackupRestorable({
  * @param {Object}    options.logger Log sink.
  * @param {Function}  options.validateFn Bundle validator seam.
  * @param {String}    options.checkedAt Shared ISO timestamp for the whole walk.
- * @returns {Promise<Object>} `RESTORABLE`, `BUNDLE_EMPTY`, or `BUNDLE_INVALID` for this bundle alone.
+ * @returns {Promise<Object>} `RESTORABLE`, `BUNDLE_EMPTY`, `BUNDLE_INCOMPLETE`, or `BUNDLE_INVALID`
+ *     for this bundle alone.
  *     `collectionCounts` and `emptyCollections` are present on EVERY return, and are `null` on the
  *     paths where nothing could be measured (`BUNDLE_INVALID` / `BUNDLE_UNVERIFIABLE`). `null` and
  *     `[]` are different answers: `[]` means the collections were counted and none were empty,
@@ -1036,70 +1064,82 @@ async function probeBundle({backupRoot, bundleName, logger, validateFn, checkedA
     };
 
     try {
-        const meta = await validateFn(bundleRoot, layout, logger),
-              // Non-emptiness is decided HERE, from the validator's own streaming pass, because a
-              // structurally-parseable bundle is not the same thing as a usable recovery source.
-              // A bundle carrying only the six required directories and a minimal meta parsed clean
-              // and returned `RESTORABLE` — the ticket's explicitly forbidden precondition, and the
-              // exact shape of the incident: the one bundle in the ledger completed after the plane
-              // was already empty. `code` has to be stronger than the prose it replaced.
-              //
-              // Vector-collection rows are the measure because they ARE the recovery payload. A
-              // bundle whose corpus is empty cannot restore a corpus, whatever else it contains.
-              collectionCounts = meta?.streamedCounts ?? {},
-              rowTotal         = Object.values(collectionCounts).reduce((sum, count) => sum + count, 0),
-              // A SUM cannot distinguish complete from partial. `rowTotal` clears the zero test on
-              // ANY single populated collection, so a KB-only export vouches for five collections it
-              // says nothing about — measured live: a 112MB KB-export-only artifact reported
-              // RESTORABLE. The per-collection facts are reported alongside the aggregate so
-              // a consumer can ask the question the total cannot answer.
-              //
-              // `restorable` deliberately still keys on the aggregate, and NOT because the question is
-              // merely unsettled: making a partially-empty bundle non-`RESTORABLE` would break a
-              // safety interlock. `evaluateRedeployPreconditions` reads this verdict in TWO
-              // incompatible roles — as PROOF OF PRIOR STATE (any populated collection shows the plane
-              // existed; it is one of the `priorEvidence` items that REFUSE `--initialize`), and as
-              // AUTHORIZATION TO PROCEED with a container-affecting redeploy (which does want
-              // completeness). Tightening the shared boolean breaks the first to serve the second: a
-              // host with a KB-only bundle and no marker would fall through to
-              // REFUSE_NO_VERIFIED_BUNDLE, whose message instructs the operator to pass
-              // `--initialize` — and `--initialize` would then PROCEED, because the bundle no longer
-              // counts as prior evidence, discarding a plane that had a real backup.
-              //
-              // So completeness is published as its OWN fact rather than folded into the boolean.
-              // Consumers that need a recovery source read `emptyCollections`; the interlock keeps
-              // reading `restorable`. Splitting the verdict's two roles is the real repair — it
-              // changes a consumed surface and does not belong under an incident-time additive
-              // change. Until that split lands, `emptyCollections` is a REPORTING fact only: a
-              // consumer that treats it as an authorization signal recreates the same interlock
-              // break from the outside.
-              emptyCollections = Object.entries(collectionCounts)
-                  .filter(([, count]) => !(count > 0))
-                  .map(([collection]) => collection)
-                  .sort();
+        const meta                     = await validateFn(bundleRoot, layout, logger),
+              observedCollectionCounts = meta?.streamedCounts ?? {},
+              declaredCollectionCounts = meta?.embedding?.counts,
+              // Schema-v1 declared counts are validated against the streamed rows in BOTH
+              // directions, and unlike the sparse observed map they retain zero-valued members.
+              // They remain reporting evidence; substrate authorization comes from the existing
+              // bundle-integrity SSOT below.
+              collectionCounts         = declaredCollectionCounts
+                  ? {...declaredCollectionCounts}
+                  : observedCollectionCounts,
+              rowTotal                  = Object.values(observedCollectionCounts)
+                  .reduce((sum, count) => sum + count, 0),
+              emptyCollections          = declaredCollectionCounts
+                  ? Object.entries(collectionCounts)
+                      .filter(([, count]) => !(count > 0))
+                      .map(([collection]) => collection)
+                      .sort()
+                  : null,
+              integrity                 = summarizeBundleIntegrity(meta?.integrity),
+              emptySubsystems           = integrity.emptySubsystems,
+              integrityRowsPresent      = Array.isArray(meta?.integrity)
+                  && meta.integrity.some(entry => entry?.sourceCount > 0 || entry?.bundleCount > 0),
+              priorStateEvidence        = rowTotal > 0 || integrityRowsPresent,
+              // Legacy bundles predate `bundle-meta.integrity`; preserve their established
+              // non-empty compatibility contract. Every current bundle must earn authorization
+              // through the shared all-substrate survivability rule.
+              recoverySourceAuthorized  = priorStateEvidence
+                  && (meta?.legacy === true || integrity.restorable === true);
 
-        if (rowTotal === 0) {
+        if (!priorStateEvidence) {
             return {
-                restorable         : false,
-                code               : 'BUNDLE_EMPTY',
+                restorable              : false,
+                priorStateEvidence,
+                recoverySourceAuthorized: false,
+                code                    : 'BUNDLE_EMPTY',
                 bundleRoot,
-                reason             : `bundle parses but carries zero recoverable rows: ${bundleRoot}`,
+                reason                  : `bundle parses but carries zero recoverable rows: ${bundleRoot}`,
                 checkedAt,
                 collectionCounts,
                 emptyCollections,
+                emptySubsystems,
                 rowTotal,
-                embeddingAdvisories: meta?.embeddingAdvisories ?? []
+                embeddingAdvisories     : meta?.embeddingAdvisories ?? []
+            }
+        }
+
+        if (!recoverySourceAuthorized) {
+            return {
+                restorable: false,
+                priorStateEvidence,
+                recoverySourceAuthorized,
+                code      : 'BUNDLE_INCOMPLETE',
+                bundleRoot,
+                reason    : emptySubsystems.length > 0
+                    ? `bundle has empty recovery subsystem(s): ${emptySubsystems.join(', ')} (${bundleRoot})`
+                    : `bundle carries prior-state rows but recovery-source completeness could not be established: ${bundleRoot}`,
+                checkedAt,
+                collectionCounts,
+                emptyCollections,
+                emptySubsystems,
+                rowTotal,
+                embeddingAdvisories    : meta?.embeddingAdvisories ?? []
             }
         }
 
         return {
             restorable         : true,
+            priorStateEvidence,
+            recoverySourceAuthorized,
             code               : 'RESTORABLE',
             bundleRoot,
             reason             : null,
             checkedAt,
             collectionCounts,
             emptyCollections,
+            emptySubsystems,
             rowTotal,
             embeddingAdvisories: meta?.embeddingAdvisories ?? []
         };
@@ -1121,8 +1161,10 @@ async function probeBundle({backupRoot, bundleName, logger, validateFn, checkedA
                   : `bundle verdict could not be established: ${error?.message ?? String(error)}`;
 
         return {
-            restorable: false,
-            code      : contentJudged ? 'BUNDLE_INVALID' : 'BUNDLE_UNVERIFIABLE',
+            restorable              : false,
+            priorStateEvidence      : false,
+            recoverySourceAuthorized: false,
+            code                    : contentJudged ? 'BUNDLE_INVALID' : 'BUNDLE_UNVERIFIABLE',
             bundleRoot,
             reason,
             checkedAt,
@@ -1136,6 +1178,7 @@ async function probeBundle({backupRoot, bundleName, logger, validateFn, checkedA
             // making the same mistake this whole verdict exists to remove.
             collectionCounts   : null,
             emptyCollections   : null,
+            emptySubsystems    : null,
             embeddingAdvisories: error.embeddingAdvisories ?? [],
             // Structured, so a consumer distinguishes the two states without matching English.
             // `errorCode` carries the syscall errno when the platform supplied one (EACCES, EMFILE…).

--- a/ai/services/memory-core/helpers/bundleIntegrity.mjs
+++ b/ai/services/memory-core/helpers/bundleIntegrity.mjs
@@ -36,6 +36,16 @@
  */
 
 /**
+ * @summary The complete recovery-substrate census carried by `bundle-meta.integrity`.
+ *
+ * Shared with the backup producer so the writer and every survivability reader cannot drift onto
+ * different populations. Optional copied artifacts are deliberately absent; only the three
+ * row-count-verified recovery substrates belong to this contract.
+ * @type {String[]}
+ */
+export const RECOVERY_SUBSTRATES = Object.freeze(['kb', 'mc', 'graph']);
+
+/**
  * @summary Names the subsystems whose export brought back no rows.
  * @param {Array<Object>|undefined|null} integrity `bundle-meta.integrity` checks.
  * @returns {String[]} Subsystem names, empty when none or when the block is absent.
@@ -53,6 +63,10 @@ export function emptySubsystems(integrity) {
  * verdict recorded. A boolean would force absent evidence into one of the decided answers, and
  * either choice is a lie — `false` condemns historical bundles, `true` re-creates the false-green
  * this module exists to end.
+ *
+ * Completeness includes the census itself. Missing, duplicate, unknown, or non-`pass` rows return
+ * `null`; a list whose known members all pass but which omits a recovery substrate is not proof that
+ * the omitted substrate passed. A known `empty` remains the stronger negative and returns `false`.
  *
  * ANY empty subsystem disqualifies the whole bundle. A partial restore is not a restore: recovering
  * memories while the knowledge base comes back with nothing is a silently incomplete system, which is
@@ -72,7 +86,24 @@ export function isBundleRestorable(integrity) {
         return null;
     }
 
-    return emptySubsystems(integrity).length === 0;
+    // One established empty is already a complete negative verdict, even when another row is
+    // unreadable. Nothing can make a bundle containing no KB (for example) a complete recovery
+    // source, so the known negative outranks the unknown sibling.
+    if (emptySubsystems(integrity).length > 0) {
+        return false
+    }
+
+    const seen = new Set();
+
+    for (const entry of integrity) {
+        if (!RECOVERY_SUBSTRATES.includes(entry?.subsystem) || seen.has(entry.subsystem) || entry.status !== 'pass') {
+            return null
+        }
+
+        seen.add(entry.subsystem)
+    }
+
+    return seen.size === RECOVERY_SUBSTRATES.length ? true : null
 }
 
 /**

--- a/test/playwright/unit/ai/scripts/maintenance/backup.spec.mjs
+++ b/test/playwright/unit/ai/scripts/maintenance/backup.spec.mjs
@@ -1110,11 +1110,17 @@ test.describe('bundle-meta — provenance and survivability never contradict (#1
     async function buildMeta({rows, currentId = 'kb-id', previousId = null}) {
         const bundleTree   = path.join(root, 'tree'),
               kbDir        = path.join(bundleTree, 'kb'),
+              mcDir        = path.join(bundleTree, 'mc'),
+              graphDir     = path.join(bundleTree, 'graph'),
               predecessors = path.join(root, 'published');
 
         fs.mkdirSync(kbDir,        {recursive: true});
+        fs.mkdirSync(mcDir,        {recursive: true});
+        fs.mkdirSync(graphDir,     {recursive: true});
         fs.mkdirSync(predecessors, {recursive: true});
         fs.writeFileSync(path.join(kbDir, 'kb-data.jsonl'), '{"id":"r"}\n'.repeat(rows));
+        fs.writeFileSync(path.join(mcDir, 'mc-data.jsonl'), '{"id":"r"}\n'.repeat(rows));
+        fs.writeFileSync(path.join(graphDir, 'graph-data.jsonl'), '{"id":"r"}\n'.repeat(rows));
 
         if (previousId) {
             const dir = path.join(predecessors, 'backup-2026-08-02T10-00-00.000Z');
@@ -1126,8 +1132,8 @@ test.describe('bundle-meta — provenance and survivability never contradict (#1
 
         return {
             integrity: await verifyBundleIntegrity(
-                {kb: kbDir, mc: path.join(bundleTree, 'no-mc'), graph: path.join(bundleTree, 'no-graph')},
-                {kb: rows}
+                {kb: kbDir, mc: mcDir, graph: graphDir},
+                {kb: rows, mc: rows, graph: rows}
             ),
             capture  : await buildCaptureBlock({
                 subsystems: {kb: {count: rows, collectionId: currentId}},
@@ -1191,6 +1197,17 @@ test.describe('bundle-meta — provenance and survivability never contradict (#1
     test('an ABSENT integrity block stays UNKNOWN — absence is a third answer, not a quiet false', async () => {
         expect(isBundleRestorable(undefined)).toBeNull();
         expect(summarizeBundleIntegrity(undefined)).toEqual({emptySubsystems: [], restorable: null});
+    });
+
+    test('#16567 an unestablished subsystem stays UNKNOWN instead of authorizing recovery', () => {
+        const integrity = [
+            {status: 'pass', subsystem: 'kb'},
+            {status: 'skipped', subsystem: 'mc'},
+            {status: 'pass', subsystem: 'graph'}
+        ];
+
+        expect(isBundleRestorable(integrity)).toBeNull();
+        expect(summarizeBundleIntegrity(integrity)).toEqual({emptySubsystems: [], restorable: null});
     });
 
     test('MIXED Memory Core: one re-embedded collection does not carry its sibling\'s verdict', async () => {

--- a/test/playwright/unit/ai/scripts/maintenance/offHostSync.spec.mjs
+++ b/test/playwright/unit/ai/scripts/maintenance/offHostSync.spec.mjs
@@ -920,9 +920,14 @@ test.describe('adversarial IO + encoding edges', () => {
 test.describe('backup receipt — the integrity verdict travels with the status', () => {
     const EMPTY = [
         {subsystem: 'kb', status: 'empty', sourceCount: 0, bundleCount: 0},
-        {subsystem: 'mc', status: 'empty', sourceCount: 0, bundleCount: 0}
+        {subsystem: 'mc', status: 'empty', sourceCount: 0, bundleCount: 0},
+        {subsystem: 'graph', status: 'empty', sourceCount: 0, bundleCount: 0}
     ];
-    const CLEAN = [{subsystem: 'kb', status: 'pass', sourceCount: 61206, bundleCount: 61206}];
+    const CLEAN = [
+        {subsystem: 'kb', status: 'pass', sourceCount: 61206, bundleCount: 61206},
+        {subsystem: 'mc', status: 'pass', sourceCount: 32462, bundleCount: 32462},
+        {subsystem: 'graph', status: 'pass', sourceCount: 34239, bundleCount: 34239}
+    ];
 
     test('a zero-row bundle is marked NOT restorable, and names which subsystems brought back nothing', () => {
         const receipt = buildBackupReceipt({
@@ -935,7 +940,7 @@ test.describe('backup receipt — the integrity verdict travels with the status'
         expect(receipt.backup.status).toBe('success');
         // …and the receipt now also says it is not a recovery source, with the reason named.
         expect(receipt.integrity.restorable).toBe(false);
-        expect(receipt.integrity.emptySubsystems).toEqual(['kb', 'mc']);
+        expect(receipt.integrity.emptySubsystems).toEqual(['kb', 'mc', 'graph']);
     });
 
     test('the projection KEY is wire-stable at schemaVersion 1 — a receipt reader must not lose the field', () => {

--- a/test/playwright/unit/ai/scripts/maintenance/redeployPreflight.spec.mjs
+++ b/test/playwright/unit/ai/scripts/maintenance/redeployPreflight.spec.mjs
@@ -5,7 +5,7 @@ import os             from 'os';
 import path           from 'path';
 
 import {
-    evaluateRedeployPreconditions,
+    evaluateRedeployPreconditions as evaluateRawRedeployPreconditions,
     INITIALIZATION_MARKER_FILENAME,
     observePrimaryStoreVolume,
     PRIMARY_STORE_VOLUME_NAME,
@@ -18,6 +18,22 @@ import {
 const DEPLOY_SCRIPT = new URL('../../../../../../ai/examples/cloud-deployment/deploy-pipeline.sh', import.meta.url);
 
 const silent = {error: () => {}, log: () => {}, warn: () => {}};
+
+/**
+ * @summary Supplies the split probe facts older truth-table fixtures collapsed into one code.
+ * @param {Object} options Truth-table inputs.
+ * @returns {Object}
+ */
+const evaluateRedeployPreconditions = options => {
+    const authorized = options.verdictCode === 'RESTORABLE';
+
+    return evaluateRawRedeployPreconditions({
+        emptySubsystems         : authorized ? [] : null,
+        priorStateEvidence      : authorized,
+        recoverySourceAuthorized: authorized,
+        ...options
+    })
+};
 
 /**
  * Every refusal code the probe can return. Rows 3 and 5 must hold for ALL of them — a gate that
@@ -127,7 +143,7 @@ test.describe('redeploy preflight — the truth table (#16055 AC2/AC3/AC4)', () 
 
         expect(outcome.proceed).toBe(false);
         expect(outcome.decision).toBe(REDEPLOY_PREFLIGHT_DECISION.REFUSE_ALREADY_INITIALIZED);
-        expect(outcome.reason).toContain('verified restorable bundle')
+        expect(outcome.reason).toContain('bundle containing prior-state rows')
     });
 
     test('--initialize refuses when the independently durable primary-store volume exists', () => {
@@ -173,6 +189,60 @@ test.describe('redeploy preflight — the truth table (#16055 AC2/AC3/AC4)', () 
         expect(outcome.writeMarker).toBe(true);
     });
 
+    test('#16567 an incomplete bundle blocks redeploy without reopening --initialize', () => {
+        const bundleFacts = {
+            emptySubsystems         : ['kb'],
+            priorStateEvidence      : true,
+            recoverySourceAuthorized: false,
+            verdictCode             : 'BUNDLE_INCOMPLETE'
+        };
+
+        const ordinary = evaluateRedeployPreconditions({
+            ...bundleFacts,
+            initializeRequested: false,
+            markerPresent      : false
+        });
+
+        expect(ordinary.proceed).toBe(false);
+        expect(ordinary.decision).toBe(REDEPLOY_PREFLIGHT_DECISION.REFUSE_INCOMPLETE_RECOVERY_SOURCE);
+        expect(ordinary.reason).toContain('kb');
+        expect(ordinary.reason).not.toMatch(/--initialize/);
+
+        // Prior rows still prove that a plane existed. Tightening authorization must not turn an
+        // incomplete bundle into permission to initialize over that plane.
+        const initialize = evaluateRedeployPreconditions({
+            ...bundleFacts,
+            initializeRequested: true,
+            markerPresent      : false,
+            primaryVolumeState : PRIMARY_VOLUME_STATE.ABSENT
+        });
+
+        expect(initialize.proceed).toBe(false);
+        expect(initialize.decision).toBe(REDEPLOY_PREFLIGHT_DECISION.REFUSE_ALREADY_INITIALIZED);
+    });
+
+    test('#16567 incoherent authorization never becomes a deploy or initialization permission', () => {
+        const incoherent = {
+            emptySubsystems         : null,
+            priorStateEvidence      : false,
+            recoverySourceAuthorized: true,
+            verdictCode             : 'RESTORABLE'
+        };
+
+        expect(evaluateRedeployPreconditions({
+            ...incoherent,
+            initializeRequested: false,
+            markerPresent      : false
+        }).decision).toBe(REDEPLOY_PREFLIGHT_DECISION.REFUSE_INCOMPLETE_RECOVERY_SOURCE);
+
+        expect(evaluateRedeployPreconditions({
+            ...incoherent,
+            initializeRequested: true,
+            markerPresent      : false,
+            primaryVolumeState : PRIMARY_VOLUME_STATE.ABSENT
+        }).decision).toBe(REDEPLOY_PREFLIGHT_DECISION.REFUSE_ALREADY_INITIALIZED);
+    });
+
     test('every (marker × flag × code) combination resolves to a declared decision', () => {
         // Completeness rather than spot-checks: an unhandled combination would fall through to
         // whatever the last branch happens to be, and the failure would be silent.
@@ -199,6 +269,15 @@ test.describe('redeploy preflight — the truth table (#16055 AC2/AC3/AC4)', () 
                 }
             }
         }
+
+        decisions.add(evaluateRedeployPreconditions({
+            emptySubsystems         : ['kb'],
+            initializeRequested     : false,
+            markerPresent           : false,
+            priorStateEvidence      : true,
+            recoverySourceAuthorized: false,
+            verdictCode             : 'BUNDLE_INCOMPLETE'
+        }).decision);
 
         // All decisions reachable — otherwise the table has dead rows and the coverage above is
         // measuring less than it appears to.
@@ -347,12 +426,45 @@ test.describe('redeploy preflight — wiring and marker durability (#16055 AC2)'
 
                       return {reason: 'unexpected', state: PRIMARY_VOLUME_STATE.PRESENT}
                   },
-                  probeFn: async () => ({code: 'NO_BUNDLES', reason: 'none', restorable: false})
+                  probeFn: async () => ({
+                      code                    : 'NO_BUNDLES',
+                      reason                  : 'none',
+                      priorStateEvidence      : false,
+                      recoverySourceAuthorized: false,
+                      restorable              : false
+                  })
               });
 
         expect(result.proceed).toBe(false);
         expect(primaryProbeCalls).toBe(0);
         expect(result.primaryVolumeState).toBeNull();
+        expect(await readInitializationMarker({backupRoot})).toBe(false);
+    });
+
+    test('#16567 the runner threads both bundle facts into the refusal receipt', async () => {
+        const backupRoot = path.join(workRoot, 'backups'),
+              result     = await runRedeployPreflight({
+                  backupRoot,
+                  initializeRequested: false,
+                  logger             : silent,
+                  probeFn            : async () => ({
+                      bundleRoot              : path.join(backupRoot, 'backup-incomplete'),
+                      code                    : 'BUNDLE_INCOMPLETE',
+                      emptySubsystems         : ['kb'],
+                      priorStateEvidence      : true,
+                      recoverySourceAuthorized: false,
+                      restorable              : false,
+                      rowTotal                : 42
+                  })
+              });
+
+        expect(result.decision).toBe(REDEPLOY_PREFLIGHT_DECISION.REFUSE_INCOMPLETE_RECOVERY_SOURCE);
+        expect(result.proceed).toBe(false);
+        expect(result.priorStateEvidence).toBe(true);
+        expect(result.recoverySourceAuthorized).toBe(false);
+        expect(result.emptySubsystems).toEqual(['kb']);
+        expect(result.reason).toContain('kb');
+        expect(result.reason).not.toMatch(/--initialize/);
         expect(await readInitializationMarker({backupRoot})).toBe(false);
     });
 
@@ -364,7 +476,13 @@ test.describe('redeploy preflight — wiring and marker durability (#16055 AC2)'
                   reason    : 'volume-not-found',
                   state     : PRIMARY_VOLUME_STATE.ABSENT
               }),
-              probeFn              = async () => ({code: 'NO_BUNDLES', reason: 'none', restorable: false});
+              probeFn              = async () => ({
+                  code                    : 'NO_BUNDLES',
+                  reason                  : 'none',
+                  priorStateEvidence      : false,
+                  recoverySourceAuthorized: false,
+                  restorable              : false
+              });
 
         const first = await runRedeployPreflight({
             backupRoot,

--- a/test/playwright/unit/ai/scripts/maintenance/restore.spec.mjs
+++ b/test/playwright/unit/ai/scripts/maintenance/restore.spec.mjs
@@ -969,6 +969,69 @@ test.describe('verifyLatestBackupRestorable — read-only restorability probe (#
         expect(populated.rowTotal).toBeGreaterThan(0);
     });
 
+    test('#16567 a declared zero collection proves prior state but cannot authorize recovery', async () => {
+        const bundleRoot = path.join(probeRoot, 'backup-2026-08-05T00-00-00');
+
+        for (const sub of ['kb', 'mc', 'graph', 'concepts', 'trajectories']) {
+            fs.mkdirSync(path.join(bundleRoot, sub), {recursive: true});
+        }
+
+        const row = collection => JSON.stringify({
+            id       : `${collection}-1`,
+            embedding: new Array(4096).fill(0.1),
+            metadata : {collection}
+        }) + '\n';
+
+        fs.writeFileSync(path.join(bundleRoot, 'mc', 'memory-backup.jsonl'), row('memories'));
+        fs.writeFileSync(path.join(bundleRoot, 'mc', 'summary-backup.jsonl'), row('summaries'));
+        fsExtra.writeJsonSync(path.join(bundleRoot, 'bundle-meta.json'), {
+            bundleVersion: 1,
+            embedding    : {
+                counts       : {kb: 0, memories: 1, summaries: 1},
+                dimension    : 4096,
+                schemaVersion: 1
+            },
+            integrity : [
+                {bundleCount: 0, sourceCount: 0, status: 'empty', subsystem: 'kb'},
+                {bundleCount: 2, sourceCount: 2, status: 'pass', subsystem: 'mc'},
+                {bundleCount: 1, sourceCount: 1, status: 'pass', subsystem: 'graph'}
+            ],
+            subsystems: {},
+            topology  : {chromaUnified: true, shared_topology: true}
+        });
+
+        const verdict = await verifyLatestBackupRestorable({backupRoot: probeRoot, logger: silent});
+
+        expect(verdict.code).toBe('BUNDLE_INCOMPLETE');
+        expect(verdict.priorStateEvidence).toBe(true);
+        expect(verdict.recoverySourceAuthorized).toBe(false);
+        expect(verdict.emptySubsystems).toEqual(['kb']);
+    });
+
+    test('#16567 a populated graph alone still proves prior state', async () => {
+        const bundleRoot = path.join(probeRoot, 'backup-2026-08-05T01-00-00');
+
+        fs.mkdirSync(bundleRoot, {recursive: true});
+
+        const verdict = await verifyLatestBackupRestorable({
+            backupRoot: probeRoot,
+            logger    : silent,
+            validateFn: async () => ({
+                embeddingAdvisories: [],
+                integrity          : [
+                    {status: 'skipped', subsystem: 'kb'},
+                    {status: 'skipped', subsystem: 'mc'},
+                    {bundleCount: 1, sourceCount: 1, status: 'pass', subsystem: 'graph'}
+                ],
+                streamedCounts: {}
+            })
+        });
+
+        expect(verdict.code).toBe('BUNDLE_INCOMPLETE');
+        expect(verdict.priorStateEvidence).toBe(true);
+        expect(verdict.recoverySourceAuthorized).toBe(false);
+    });
+
     test('the per-collection fields are present on EVERY verdict, and `null` means unmeasured — not "none empty"', async () => {
         // Found in review by @neo-opus-vega. The fields shipped on RESTORABLE and BUNDLE_EMPTY but were
         // ABSENT from the catch path, which made absence indistinguishable from "measured, none empty":
@@ -994,27 +1057,32 @@ test.describe('verifyLatestBackupRestorable — read-only restorability probe (#
                   return dir
               },
               withCounts = counts => JSON.stringify({
-                  streamedCounts: counts,
-                  topology      : {chromaUnified: true, shared_topology: true}
+                  embedding: {
+                      counts,
+                      dimension    : 4096,
+                      schemaVersion: 1
+                  },
+                  topology: {chromaUnified: true, shared_topology: true}
               });
 
         // MEASURED, some empty -> both fields populated, emptyCollections names WHICH.
         const measuredRoot = caseRoot('per-collection-measured');
 
         writeMeta(measuredRoot, 'backup-2026-07-10T00-00-00',
-            withCounts({'neo-knowledge-base': 5, 'neo-agent-memory': 0}));
+            withCounts({kb: 0, memories: 1, summaries: 0}));
 
         const populated = await verifyLatestBackupRestorable({backupRoot: measuredRoot, logger: silent});
 
         // The counts come from the validator's own streaming pass, not from the fixture's meta — so
         // this pins the SHAPE contract rather than a collection roster the validator owns.
-        expect(populated.code).toBe('RESTORABLE');
+        expect(populated.code).toBe('BUNDLE_INCOMPLETE');
         expect(populated.collectionCounts, 'measured must be an object, never null').not.toBe(null);
         expect(Object.keys(populated.collectionCounts).length).toBeGreaterThan(0);
 
-        // MEASURED, none empty -> emptyCollections is [], which is NOT the same answer as null.
+        // MEASURED zero members remain present in the declared census rather than disappearing from
+        // the sparse streamed map — zero members are part of the reporting contract.
         expect(Array.isArray(populated.emptyCollections), 'measured must be an array, never null').toBe(true);
-        expect(populated.emptyCollections).toEqual([]);
+        expect(populated.emptyCollections).toEqual(['kb', 'summaries']);
         expect(populated.emptyCollections).not.toBe(null);
 
         // UNMEASURED -> both `null`. This is the assertion the omission would have failed, and the one
@@ -1195,6 +1263,29 @@ test.describe('verifyLatestBackupRestorable — falls back past an unusable newe
             'backup-2026-07-03T00-00-00',
             'backup-2026-07-02T00-00-00'
         ]);
+    });
+
+    test('#16567 an incomplete newest bundle falls through to older complete history', async () => {
+        writeValidBundle('backup-2026-07-01T00-00-00');
+        const incomplete = writeValidBundle('backup-2026-07-02T00-00-00');
+
+        fsExtra.writeJsonSync(path.join(incomplete, 'bundle-meta.json'), {
+            bundleVersion: 1,
+            integrity    : [
+                {bundleCount: 0, sourceCount: 0, status: 'empty', subsystem: 'kb'},
+                {bundleCount: 1, sourceCount: 1, status: 'pass', subsystem: 'mc'},
+                {bundleCount: 1, sourceCount: 1, status: 'pass', subsystem: 'graph'}
+            ],
+            topology: {chromaUnified: true, shared_topology: true}
+        });
+
+        const verdict = await verifyLatestBackupRestorable({backupRoot: probeRoot, logger: silent});
+
+        expect(verdict.code).toBe('RESTORABLE');
+        expect(verdict.recoverySourceAuthorized).toBe(true);
+        expect(verdict.bundleRoot).toContain('backup-2026-07-01T00-00-00');
+        expect(verdict.skipped).toHaveLength(1);
+        expect(verdict.skipped[0].code).toBe('BUNDLE_INCOMPLETE');
     });
 
     test('REGRESSION GUARD: a legacy bundle carrying no bundle-meta.json but real rows stays restorable', async () => {

--- a/test/playwright/unit/ai/scripts/maintenance/restore.spec.mjs
+++ b/test/playwright/unit/ai/scripts/maintenance/restore.spec.mjs
@@ -1288,6 +1288,73 @@ test.describe('verifyLatestBackupRestorable — falls back past an unusable newe
         expect(verdict.skipped[0].code).toBe('BUNDLE_INCOMPLETE');
     });
 
+    test('#16567 a newer empty bundle cannot erase prior-state evidence from populated older history', async () => {
+        const incompleteName = 'backup-2026-08-05T01-00-00',
+              emptyName      = 'backup-2026-08-06T02-00-00',
+              incompleteMeta = {
+                  embeddingAdvisories: [],
+                  embedding          : {counts: {kb: 0, memories: 32462, summaries: 1777}},
+                  integrity          : [
+                      {bundleCount: 0,     sourceCount: 0,     status: 'empty', subsystem: 'kb'},
+                      {bundleCount: 34239, sourceCount: 34239, status: 'pass',  subsystem: 'mc'},
+                      {bundleCount: 12,    sourceCount: 12,    status: 'pass',  subsystem: 'graph'}
+                  ],
+                  streamedCounts: {memories: 32462, summaries: 1777}
+              },
+              emptyMeta = {
+                  embeddingAdvisories: [],
+                  embedding          : {counts: {kb: 0, memories: 0, summaries: 0}},
+                  integrity          : ['kb', 'mc', 'graph'].map(subsystem => ({
+                      bundleCount: 0,
+                      sourceCount: 0,
+                      status     : 'empty',
+                      subsystem
+                  })),
+                  streamedCounts: {}
+              },
+              bundles = {
+                  [emptyName]     : emptyMeta,
+                  [incompleteName]: incompleteMeta
+              },
+              validateFn = async bundleRoot => bundles[path.basename(bundleRoot)];
+
+        fs.mkdirSync(path.join(probeRoot, incompleteName), {recursive: true});
+
+        // Positive control: the populated incomplete bundle proves prior state by itself.
+        const alone = await verifyLatestBackupRestorable({backupRoot: probeRoot, logger: silent, validateFn});
+
+        expect(alone.code).toBe('BUNDLE_INCOMPLETE');
+        expect(alone.priorStateEvidence).toBe(true);
+        expect(alone.recoverySourceAuthorized).toBe(false);
+
+        // Probe: failure provenance stays on the empty newest bundle, while root-level prior-state
+        // evidence remains true because the older populated bundle was also examined.
+        fs.mkdirSync(path.join(probeRoot, emptyName), {recursive: true});
+
+        const stacked = await verifyLatestBackupRestorable({backupRoot: probeRoot, logger: silent, validateFn});
+
+        expect(stacked.code).toBe('BUNDLE_EMPTY');
+        expect(stacked.bundleRoot).toContain(emptyName);
+        expect(stacked.priorStateEvidence).toBe(true);
+        expect(stacked.recoverySourceAuthorized).toBe(false);
+        expect(stacked.skipped.map(item => item.code)).toEqual(['BUNDLE_EMPTY', 'BUNDLE_INCOMPLETE']);
+
+        const {evaluateRedeployPreconditions, PRIMARY_VOLUME_STATE} =
+                  await import('../../../../../../ai/scripts/maintenance/redeployPreflight.mjs'),
+              outcome = evaluateRedeployPreconditions({
+                  emptySubsystems         : stacked.emptySubsystems,
+                  initializeRequested     : true,
+                  markerPresent           : false,
+                  primaryVolumeState      : PRIMARY_VOLUME_STATE.ABSENT,
+                  priorStateEvidence      : stacked.priorStateEvidence,
+                  recoverySourceAuthorized: stacked.recoverySourceAuthorized,
+                  verdictCode             : stacked.code
+              });
+
+        expect(outcome.proceed).toBe(false);
+        expect(outcome.decision).toBe('REFUSE_ALREADY_INITIALIZED');
+    });
+
     test('REGRESSION GUARD: a legacy bundle carrying no bundle-meta.json but real rows stays restorable', async () => {
         // `validateBundle` documents meta-absence as the LEGACY bundle contract, returning
         // `{legacy: true}` rather than failing. An earlier draft of this change rejected meta-less

--- a/test/playwright/unit/ai/services/memory-core/HealthService.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/HealthService.spec.mjs
@@ -397,8 +397,8 @@ test.describe('HealthService #12382 — cached healthcheck freshness', () => {
         summaryGetCalls    = 0;
         summaryUnavailableOnCall = null;
 
-        const memoryCollection  = makeCollection(() => memoryCount);
-        const summaryCollection = makeCollection(() => summaryCount);
+        const memoryCollection          = makeCollection(() => memoryCount);
+        const summaryCollection         = makeCollection(() => summaryCount);
         const temporalSummaryCollection = makeCollection(() => 0);
 
         originals = {
@@ -415,8 +415,8 @@ test.describe('HealthService #12382 — cached healthcheck freshness', () => {
             // that count's latency tracked whatever the rest of the suite had written, and a retry got
             // a fresh worker talking to the same slow collection.
             getTemporalSummaryCollection: StorageRouter.getTemporalSummaryCollection,
-            getDatabaseStatus        : ChromaLifecycleService.getDatabaseStatus,
-            loopbackConnectProbe     : HealthService.loopbackConnectProbe
+            getDatabaseStatus           : ChromaLifecycleService.getDatabaseStatus,
+            loopbackConnectProbe        : HealthService.loopbackConnectProbe
         };
 
         ChromaManager.connected = true;
@@ -2189,11 +2189,13 @@ test.describe('HealthService #16240 — an empty-verdict bundle is not a recover
 
     const EMPTY_VERDICT = [
         {subsystem: 'kb', status: 'empty', sourceCount: 0, bundleCount: 0},
-        {subsystem: 'mc', status: 'empty', sourceCount: 0, bundleCount: 0}
+        {subsystem: 'mc', status: 'empty', sourceCount: 0, bundleCount: 0},
+        {subsystem: 'graph', status: 'empty', sourceCount: 0, bundleCount: 0}
     ];
     const CLEAN_VERDICT = [
         {subsystem: 'kb', status: 'pass', sourceCount: 61206, bundleCount: 61206},
-        {subsystem: 'mc', status: 'pass', sourceCount: 31173, bundleCount: 31173}
+        {subsystem: 'mc', status: 'pass', sourceCount: 31173, bundleCount: 31173},
+        {subsystem: 'graph', status: 'pass', sourceCount: 34239, bundleCount: 34239}
     ];
 
     test.beforeAll(async () => {
@@ -2533,10 +2535,10 @@ test.describe('HealthService #10783 — buildWakeFeaturesBlock', () => {
         const result = await buildWakeFeaturesBlock();
 
         expect(result).toEqual({
-            gateState            : 'unknown',
-            gateTrippedAt        : null,
-            gateTrippedBy        : null,
-            daemonRunning        : false,
+            gateState    : 'unknown',
+            gateTrippedAt: null,
+            gateTrippedBy: null,
+            daemonRunning: false,
             // Names what the read actually did. `no-pulse-file` is exactly ENOENT — never a claim
             // about configuration, which this block does not consult. It separates a read that
             // answered from one that could not happen, the same conflation the subscription note


### PR DESCRIPTION
Resolves neomjs/neo#16567

Redeploy backup verification now reports prior-state evidence separately from recovery-source authorization. Current bundles earn authorization through the existing all-substrate `bundleIntegrity` rule; a partially populated bundle returns `BUNDLE_INCOMPLETE`, names its empty subsystem, and may fall back to older complete history, while its prior rows still block `--initialize`. Legacy non-empty bundles retain their established compatibility path.

Evidence: L2 (real temporary bundle trees plus the pure redeploy truth table and every direct receipt/health consumer) → L2 required (all six close-target ACs are unit-observable). No residuals.

## AC Evidence

| Acceptance criterion | Evidence |
|---|---|
| AC-1 | CI-covered: `verifyLatestBackupRestorable()` emits independent `priorStateEvidence` / `recoverySourceAuthorized` facts; `#16567 a newer empty bundle cannot erase prior-state evidence from populated older history` proves the root walk still resolves `REFUSE_ALREADY_INITIALIZED`. |
| AC-2 | CI-covered: `#16567 a declared zero collection proves prior state but cannot authorize recovery` reproduces `kb: 0` with populated memory/summaries and asserts `BUNDLE_INCOMPLETE` plus `emptySubsystems: ['kb']`. |
| AC-3 | CI-covered: the incomplete-source refusal contains `kb`, writes no marker, and contains no `--initialize` instruction through both the pure and runner-level witnesses. |
| AC-4 | Source audit: `verifyLatestBackupRestorable` has one production caller, `redeployPreflight.mjs`; the latent activation receipt remains correct because `RESTORABLE` now means strict recovery authorization. Direct receipt, health, retention, and activation consumer suites are included in the focused set. |
| AC-5 | CI-covered: `emptyCollections` remains reporting evidence from schema-v1 declared counts; authorization consumes the existing `bundle-meta.integrity` SSOT instead. Missing, duplicate, skipped, or unknown integrity census rows resolve `null`, never permission. |
| AC-6 | CI-covered: the exact incomplete live shape is paired with graph-only prior evidence, older-complete fallback, ordinary-deploy refusal, initialize refusal, and incoherent-facts fail-closed controls. |

## Deltas from ticket

The ticket allowed split fields or a role parameter. This uses explicit fields and introduces `BUNDLE_INCOMPLETE` so known-incomplete newest history can fall through to an older complete bundle. `priorStateEvidence` is the disjunction across every examined bundle, while failure code/root/reason remain newest-candidate provenance. The recovery-substrate census moved to `bundleIntegrity.mjs` and remains re-exported from `backup.mjs`, keeping producer and consumers on one authority. `restorable` remains a compatibility alias of recovery authorization only.

## Test Evidence

- Pre-fix red: the exact `kb: 0` bundle returned `RESTORABLE`, and the split truth-table arm returned `REFUSE_NO_VERIFIED_BUNDLE` with an `--initialize` instruction.
- Diagonal controls: vector rows, graph-only rows, empty-newest over populated-incomplete history, incomplete newest history, legacy history, unestablished integrity, and an incoherent boolean pair each prove a different branch.
- All coverage runs in CI.

## Post-Merge Validation

None; no post-merge-only observable remains.

## Evolution

The first implementation sketch derived authorization from embedding collection counts. The engine-first scan found Neo's existing `bundleIntegrity` survivability authority, so the final shape consumes it instead; that scan also exposed the missing `skipped`/partial-census third state, now fail-closed as `null` rather than hand-waved as restorable.

Authored by Euclid (GPT-5.6 Sol, Codex). Session e3e2d32f-430b-4861-af1f-b6a214fa0513.