### PR TITLE
test(ci): fail unit runs on flaky outcomes (#17229)

### DIFF
--- a/test/playwright/playwright.config.unit.mjs
+++ b/test/playwright/playwright.config.unit.mjs
@@ -1,9 +1,9 @@
 import './configTemplateResolver.mjs';
 
-import {defineConfig}      from '@playwright/test';
-import {existsSync}        from 'node:fs';
-import path                from 'path';
-import {fileURLToPath}     from 'url';
+import {defineConfig}                             from '@playwright/test';
+import {existsSync}                               from 'node:fs';
+import path                                       from 'path';
+import {fileURLToPath}                            from 'url';
 import {CHROMA_CLI_ENTRYPOINT, resolvePackageDir} from './chromaProcess.mjs';
 
 const __filename = fileURLToPath(import.meta.url);
@@ -182,9 +182,37 @@ export function buildProjects({brainPresent}) {
     }];
 }
 
-const brainPresent = hasBrainTier(repoRoot);
+/**
+ * @summary Builds the environment-specific unit-run policy without hiding CI semantics in module state.
+ *
+ * CI's measured four-worker run remains the isolation instrument; local workers stay unconstrained because
+ * local ordering cannot prove that surface. Retries remain held at two, while `failOnFlakyTests` makes a
+ * green-after-retry outcome disqualifying instead of silently moving either measurement variable.
+ * @param {Object} options
+ * @param {Boolean} options.isCI
+ * @returns {Object}
+ */
+export function buildUnitRunPolicy({isCI}) {
+    const reporter = [['json', {outputFile: path.join(__dirname, 'test-results/unit/test-results.json')}]];
 
-assertBrainTierForEnvironment({brainPresent, isCI: !!process.env.CI});
+    isCI && reporter.unshift(['github']);
+
+    return {
+        failOnFlakyTests: isCI,
+        forbidOnly      : isCI,
+        reporter,
+        // Keep the measured `workers: 4` flip and its held retry variable together. A retry-pass is
+        // now disqualifying in CI; changing either count would move the experiment instead.
+        retries: isCI ? 2 : 0,
+        workers: isCI ? 4 : undefined
+    }
+}
+
+const
+    isCI         = !!process.env.CI,
+    brainPresent = hasBrainTier(repoRoot);
+
+assertBrainTierForEnvironment({brainPresent, isCI});
 
 if (!brainPresent) {
     console.info('[playwright.config.unit] Brain-tier set not installed (see package.brain.json) — skipping chroma-setup + unit-brain* projects. Run `npm run install-brain` to arm them.');
@@ -194,21 +222,7 @@ export default defineConfig({
     testDir      : path.join(__dirname, 'unit'),
     outputDir    : path.join(__dirname, 'test-results/unit'),
     fullyParallel: true,
-    forbidOnly   : !!process.env.CI,
-    retries      : process.env.CI ? 2 : 0,
-    // Re-land of the measured ~2.7× win. `1` was not a preference — it was the mask: single-worker
-    // ordering hides cross-file isolation defects, three of which were found and fixed by the
-    // enabler leaves before this flip became re-attemptable.
-    //
-    // Local is NOT the instrument. The local runner cannot hold a wide unit run (the Chroma/web-server
-    // lifecycle contends), and single-worker local green says nothing about ordering that only exists
-    // at four. The falsifier lives in CI, which is why this ships as a probe rather than a claim.
-    //
-    // Read `retries: 2` above together with this line: a retry can convert an isolation flake into a
-    // reported pass, so a green sample is only evidence when its retry count is ZERO. Green-after-retry
-    // is the failure this flip exists to surface, wearing a pass.
-    workers : process.env.CI ? 4 : undefined,
-    reporter: [['json', {outputFile: path.join(__dirname, 'test-results/unit/test-results.json')}]],
+    ...buildUnitRunPolicy({isCI}),
     use     : {trace: 'on-first-retry'},
     projects: buildProjects({brainPresent})
 });

--- a/test/playwright/unit/test/chromaProcess.spec.mjs
+++ b/test/playwright/unit/test/chromaProcess.spec.mjs
@@ -16,6 +16,7 @@ import unitConfig, {
     brainHookTestMatch,
     brainTestMatch,
     buildProjects,
+    buildUnitRunPolicy,
     hasBrainTier,
     knowledgeBaseConfigTemplateTestMatch,
     memoryCoreConfigTemplateTestMatch,
@@ -100,6 +101,33 @@ test.describe('playwright.config.unit — Chroma capability admission', () => {
         expect(() => assertBrainTierForEnvironment({brainPresent: false, isCI: true})).toThrow(/silent coverage loss/);
         expect(() => assertBrainTierForEnvironment({brainPresent: true,  isCI: true})).not.toThrow();
         expect(() => assertBrainTierForEnvironment({brainPresent: false, isCI: false})).not.toThrow();
+    });
+
+    test('CI treats retry-pass outcomes as attributed failures without moving retries or workers (#17229)', () => {
+        const
+            ci    = buildUnitRunPolicy({isCI: true}),
+            local = buildUnitRunPolicy({isCI: false});
+
+        expect(ci.failOnFlakyTests).toBe(true);
+        expect(ci.forbidOnly).toBe(true);
+        expect(ci.retries).toBe(2);
+        expect(ci.workers).toBe(4);
+        expect(ci.reporter.map(([name]) => name)).toEqual(['github', 'json']);
+        expect(ci.reporter[1]).toEqual(local.reporter[0]);
+
+        expect(local.failOnFlakyTests).toBe(false);
+        expect(local.forbidOnly).toBe(false);
+        expect(local.retries).toBe(0);
+        expect(local.workers).toBeUndefined();
+        expect(local.reporter.map(([name]) => name)).toEqual(['json']);
+
+        expect({
+            failOnFlakyTests: unitConfig.failOnFlakyTests,
+            forbidOnly      : unitConfig.forbidOnly,
+            reporter        : unitConfig.reporter,
+            retries         : unitConfig.retries,
+            workers         : unitConfig.workers
+        }).toEqual(buildUnitRunPolicy({isCI: !!process.env.CI}))
     });
 
     test('hasBrainTier requires all three roots AND their consumable entrypoints — an empty husk is not armed', () => {


### PR DESCRIPTION
Resolves #17229

Makes Playwright's own flaky classification a consumed CI signal instead of a green line nobody reads. The unit config now enables `failOnFlakyTests` in CI and adds the built-in `github` reporter alongside the existing JSON reporter; `retries: 2` and `workers: 4` remain unchanged.

Evidence: L2 (real Playwright fail-once runner control plus owning config-contract tests) → L2 required. No residuals.

## AC Evidence

| Acceptance criterion | Evidence |
|---|---|
| AC-1 | `buildUnitRunPolicy({isCI: true})` enables `failOnFlakyTests`; the same deliberate fail-once probe exited 0 without the gate and 1 with it. |
| AC-2 | CI prepends Playwright's built-in `github` reporter, whose installed implementation annotates `flaky` outcomes; the JSON reporter and exact output file remain present. |
| AC-3 | Known defects remain exact ticket-owned `NEO_TEST_SKIP_CI` skips. The gate has no allowlist: every executed retry-pass is newly flaky and disqualifying. |
| AC-4 | Red control used one unchanged probe: retry 0 failed, retry 1 passed, and JSON reported `ok: true`, `status: flaky`; toggling only `failOnFlakyTests` changed process exit 0 → 1. |
| AC-5 | The config contract pins CI `retries: 2` and `workers: 4`, plus local `retries: 0` and unconstrained workers. |

## Deltas from ticket

- The original parser-versus-defect-ledger fork was retired after the engine-first scan found both required primitives in installed Playwright 1.61.1.
- The environment delta is exposed as pure `buildUnitRunPolicy({isCI})`, and the existing config-contract spec proves both the helper and its consumption by the default config.
- No workflow, log scraper, defect-ledger transport, persistent known-flake registry, or follow-up ticket was added.

## Test Evidence

- `npm run test-unit -- test/playwright/unit/test/chromaProcess.spec.mjs` — 19/19 passed.
- Real fail-once probe, gate absent — exit 0; Playwright reported `1 flaky`; JSON kept `spec.ok: true`, `tests[0].status: flaky`, failed retry 0, passed retry 1.
- Same probe, gate enabled — exit 1 with the same exact test attribution and retry outcomes.
- `CI=true` default-config import — `failOnFlakyTests:true`, `forbidOnly:true`, `retries:2`, `workers:4`, reporters `github,json`.
- JSDoc type check, block-alignment check, diff check, and all pre-commit hooks passed.

## Post-Merge Validation

None — the red control exercises the same Playwright status branch before merge; a future organic flaky outcome is a consumer event, not required validation.

## Evolution

The ticket began by choosing between two custom observers. Scanning the engine first removed both: Playwright already owns flaky-run failure and GitHub annotation. The resulting lane changes two existing files and adds no new operational surface.

## Commits

- `494c2c0e01` — make CI retry-pass outcomes fail with exact attribution.

Authored by Euclid (OpenAI GPT-5.6 Sol, Codex Desktop). Session ff882e8c-f21e-4195-987e-e0b7eb6dd441.