### PR TITLE
test(fleet): serialize cockpit port owners (#17276)

### DIFF
--- a/test/playwright/unit/ai/scripts/fleet/devCockpit.spec.mjs
+++ b/test/playwright/unit/ai/scripts/fleet/devCockpit.spec.mjs
@@ -28,6 +28,10 @@ const authenticatedOptions = overrides => ({
 
 const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../../../../../..');
 
+// Both describe blocks below own the fixed :8083 endpoint. Under `fullyParallel`, separate describes
+// can run in different workers; file-wide default mode orders them while preserving independent retries.
+test.describe.configure({mode: 'default'});
+
 /**
  * The boot-plan witnesses for the one-command cockpit launcher: the pure decision seam
  * (refuse-on-authority-violation, refuse-on-incompatible-occupant, reuse-on-fleet-identity,
@@ -35,11 +39,6 @@ const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../
  * listener, and a closed port — a listener is never presumed to be a fleet server.
  */
 test.describe('ai/scripts/fleet/devCockpit — the live-by-default boot plan', () => {
-    // Two witnesses below OWN the real :8083 endpoint (the composed boot and the reuse
-    // falsifier). Parallel workers would race them onto the same port — and under the
-    // authenticated-reuse contract the loser correctly REFUSES, failing the wrong test.
-    test.describe.configure({mode: 'serial'});
-
     test('a non-default fleet port REFUSES with the named endpoint-authority reason', () => {
         const plan = planCockpitBoot({fleetPort: 9999});
 
@@ -309,9 +308,6 @@ test.describe('ai/scripts/fleet/devCockpit — the live-by-default boot plan', (
  * fail-fast, and the never-adopt-an-incumbent refusal.
  */
 test.describe('ai/scripts/fleet/devCockpit — the live-plane journey (cockpit:live)', () => {
-    // The composed witnesses below own :8083 in turn (serial, same discipline as the boot-plan suite).
-    test.describe.configure({mode: 'serial'});
-
     test('resolveLivePlaneConfig: env pin wins and the gh seam is never consulted', async () => {
         const resolved = await resolveLivePlaneConfig({
             env        : {NEO_FLEET_PLANE_BASE: 'http://127.0.0.1:4000', NEO_FLEET_PLANE_BEARER: 'env-token'},


### PR DESCRIPTION
Resolves #17276

Repairs the one-command cockpit witness after the new flaky-outcome gate exposed a real cross-describe port race. Both describe blocks own fixed `:8083`; under project `fullyParallel`, their separate inner `mode: serial` declarations still allowed them to run in different workers. File-scope `mode: default` makes the whole file one ordered worker group while preserving independent retries.

Evidence: L3 (hosted four-worker schedule receipt plus post-fix four-worker runner proof) → L3 required. No residuals.

## AC Evidence

| Acceptance criterion | Evidence |
|---|---|
| AC-1 | The unchanged composed-live witness launches the real supervisor path with a fixture plane and both child-command seams; it remains green in the 22/22 focused run. |
| AC-2 | The unchanged resolution witnesses cover env, secret-file, and gh precedence, pinned-dead refusal, all-empty refusal, and secret-free notes. |
| AC-3 | The unchanged plane-identity and no-adoption witnesses retain fail-fast unreachable-plane and incumbent-refusal behavior. |
| AC-4 | The unchanged composed-live witness proves the materialized plane bearer reaches the fleet child and stays absent from the webpack child. |
| AC-5 | Presence rendering/read-source behavior is unchanged from merged PR #17277; this one-file test-isolation diff touches no runtime or cockpit surface. |
| AC-6 | Activity-stream live-mode wiring is unchanged from merged PR #17277; no producer, adapter, or seeded-row path changed. |
| AC-7 | Mailbox/compose/catch-up and honest wake-lane behavior are unchanged from merged PR #17277; no Fleet wire or plane client code changed. |
| AC-8 | `learn/agentos/RunningTheFleetCockpit.md` remains unchanged and continues to document `cockpit:live`. |
| AC-9 | Hosted JSON at PR #17750 head `9cf4de4c65` shows boot-plan worker 8 and live-plane worker 6 overlapping; post-fix all 20 devCockpit results use one worker/parallel index with zero retries. |

## Deltas from ticket

- #17276 was reopened because its second separately-serial describe introduced the regression into the earlier #15283 fixed-port witness.
- The repair is one existing test file and uses Playwright's file-level override for `fullyParallel`; no timeout increase, new fixture, or follow-up ticket.
- The original delivery remains intact. This PR only restores mutual exclusion across its two port-owning witness groups.

## Test Evidence

- Pre-fix hosted receipt, PR #17750 run 32809325836: boot-plan group worker 8 and live-plane group worker 6 overlapped at `04:36:45Z`; the original composed boot saw `free` for 30s, then retry worker 9 passed in 1.0s.
- `CI=true npm run test-unit -- test/playwright/unit/ai/scripts/fleet/devCockpit.spec.mjs` — 22/22 passed, zero retries.
- Post-fix JSON: all 20 devCockpit results used `workerIndex: 1`, `parallelIndex: 0`, `retry: 0`.
- Diff check, block-alignment check, independent review, and all pre-commit hooks passed.

## Post-Merge Validation

- Rebase or rerun PR #17750 after this PR merges; its new flaky gate must report the full unit suite green with this fixed-port race removed.
- Merge order: **#17751 before #17750**.

## Evolution

The first repair used file-scope `serial`, which closed the port race but unnecessarily coupled skip/retry fate across the whole file. Inspecting Playwright's existing execution primitive produced the tighter `default` mode: same mutual exclusion, independent failures.

## Commits

- `e235555e32` — serialize every fixed-port cockpit witness at file scope.

Authored by Euclid (OpenAI GPT-5.6 Sol, Codex Desktop). Session ff882e8c-f21e-4195-987e-e0b7eb6dd441.
