### PR TITLE
test(graph): isolate D2 admission consumer proof (#17627)

### DIFF
--- a/test/playwright/unit/ai/services/graph/GoldenPathSynthesizer.spec.mjs
+++ b/test/playwright/unit/ai/services/graph/GoldenPathSynthesizer.spec.mjs
@@ -2102,41 +2102,33 @@ test.describe('Neo.ai.daemons.services.GoldenPathSynthesizer', () => {
     });
 
     test('D2 admission withholds before both stores and preserves the last-known-good handoff (#17627)', async () => {
-        const originalEnabled             = aiConfig.orchestrator.corpusProjection.enabled;
-        const originalReceiptPathOverride = aiConfig.orchestrator.corpusProjection.receiptPathOverride;
-        const originalSourceRepository    = aiConfig.orchestrator.corpusProjection.sourceRepository;
-        const originalSourceRef           = aiConfig.orchestrator.corpusProjection.sourceRef;
-        const originalGetGraphCollection  = StorageRouter.getGraphCollection;
-        const receiptDir                  = fs.mkdtempSync(path.join(os.tmpdir(), 'golden-path-projection-gate-'));
-        const receiptPath                 = path.join(receiptDir, 'projection.json');
-        const HEAD_A                      = 'a'.repeat(40);
-        const HEAD_B                      = 'b'.repeat(40);
-        const {
-            beginCorpusProjection,
-            commitCorpusProjectionFacet,
-            createCorpusProjectionReceipt
-        } = await import('../../../../../../ai/services/graph/corpusProjectionContract.mjs');
-        const {writeCorpusProjectionReceipt} = await import('../../../../../../ai/services/graph/corpusProjectionReceiptStore.mjs');
+        const originalGetCorpusProjectionAdmission = Synthesizer.getCorpusProjectionAdmission;
+        const originalGetGraphCollection           = StorageRouter.getGraphCollection;
+        const originalGetSummaryCollection         = StorageRouter.getSummaryCollection;
 
-        let receipt = createCorpusProjectionReceipt({
-            sourceRepository: 'https://github.com/neomjs/neo.git',
-            sourceRef       : 'refs/heads/dev',
-            freshnessSlaMs  : 4 * 60 * 60 * 1000
-        });
-        receipt = beginCorpusProjection({receipt, availableRevision: HEAD_A});
-        for (const facet of ['issues', 'pulls', 'discussions']) {
-            receipt = commitCorpusProjectionFacet({receipt, facet})
-        }
-        receipt = beginCorpusProjection({receipt, availableRevision: HEAD_B});
-        receipt = commitCorpusProjectionFacet({receipt, facet: 'discussions'});
-        await writeCorpusProjectionReceipt(receiptPath, receipt);
+        let admissionCalls         = 0,
+            graphCollectionReads   = 0,
+            summaryCollectionReads = 0;
 
-        aiConfig.orchestrator.corpusProjection.enabled = true;
-        aiConfig.orchestrator.corpusProjection.receiptPathOverride = receiptPath;
-        aiConfig.orchestrator.corpusProjection.sourceRepository = 'https://github.com/neomjs/neo.git';
-        aiConfig.orchestrator.corpusProjection.sourceRef = 'refs/heads/dev';
+        Synthesizer.getCorpusProjectionAdmission = async () => {
+            admissionCalls++;
+
+            return {
+                admitted      : false,
+                fallback      : 'last-known-good',
+                reasonCode    : 'required-facet-stale',
+                requiredFacets: ['issues', 'discussions'],
+                staleFacets   : ['issues'],
+                fingerprint   : 'd2-required-facet-stale'
+            }
+        };
         StorageRouter.getGraphCollection = async () => {
+            graphCollectionReads++;
             throw new Error('D2 gate read Chroma despite a stale required facet')
+        };
+        StorageRouter.getSummaryCollection = async () => {
+            summaryCollectionReads++;
+            throw new Error('D2 gate read summaries despite a stale required facet')
         };
         fs.writeFileSync(tmpHandoffFile, '# Last-known-good handoff\n', 'utf8');
 
@@ -2152,14 +2144,14 @@ test.describe('Neo.ai.daemons.services.GoldenPathSynthesizer', () => {
                     staleFacets: ['issues']
                 }
             });
+            expect(admissionCalls).toBe(1);
+            expect(graphCollectionReads).toBe(0);
+            expect(summaryCollectionReads).toBe(0);
             expect(fs.readFileSync(tmpHandoffFile, 'utf8')).toBe('# Last-known-good handoff\n')
         } finally {
-            aiConfig.orchestrator.corpusProjection.enabled = originalEnabled;
-            aiConfig.orchestrator.corpusProjection.receiptPathOverride = originalReceiptPathOverride;
-            aiConfig.orchestrator.corpusProjection.sourceRepository = originalSourceRepository;
-            aiConfig.orchestrator.corpusProjection.sourceRef = originalSourceRef;
-            StorageRouter.getGraphCollection = originalGetGraphCollection;
-            fs.rmSync(receiptDir, {recursive: true, force: true})
+            Synthesizer.getCorpusProjectionAdmission = originalGetCorpusProjectionAdmission;
+            StorageRouter.getGraphCollection         = originalGetGraphCollection;
+            StorageRouter.getSummaryCollection       = originalGetSummaryCollection
         }
     });
 


### PR DESCRIPTION
Resolves #17627

Removes worker-order coupling from the Golden Path D2 consumer proof that PR #17751 exposed as a real retry-only failure. The test now injects the already-evaluated admission result, proves neither Store boundary is touched, and verifies the last-known-good handoff remains byte-identical; receipt construction and facet classification stay with their owning contract suite.

Evidence: L1 (hermetic consumer-contract proof plus exact stale-facet mutation) → L1 required (test-only regression; no runtime surface changed). No close-target residuals.

## AC Evidence

| AC | Evidence |
|---|---|
| AC-1 | The merged Decision-D witness and D2 selection from PR #17672 remain unchanged; this repair preserves the consumer-side denied-admission behavior that witness selected. |
| AC-2 | `corpusProjectionContract.spec.mjs` continues to own receipt-to-consumer facet mapping. The repaired Golden Path arm injects a denied `issues` admission, observes one admission call, proves both Store accessors remain at zero calls, and preserves the prior handoff. |
| AC-3 | The sole container-plane writer, task admission, and retired predecessor paths from PR #17672 are unchanged; this PR touches one existing unit-test arm only. |
| AC-4 | Source-neutral mirror, materialization, reconciliation, and cadence code and owning specs from PR #17672 are unchanged. |
| AC-5 | Source-bound per-facet receipt production, storage, and contract specs remain unchanged; the duplicated receipt fixture was removed only from the consumer behavior arm. |
| AC-6 | Freshness SLA, health posture, and starvation evidence from PR #17672 remain unchanged. |
| AC-7 | The `#11735` non-interference boundary and its closure tests remain unchanged. |
| AC-8 | The deployed-runtime acknowledgment remains owned by #17500; this test-only repair adds no deployment or operator-facing delta. |

## Deltas from ticket

- #17627 was reopened after PR #17751 hosted unit output showed this arm fail once with `staleFacets: [issues, discussions]` and pass on retry.
- The repair narrows the arm to its consumer contract. Receipt creation, file I/O, source identity, and facet evaluation remain covered by `corpusProjectionContract.spec.mjs` and are no longer duplicated through mutable global config here.
- No production source, timeout, retry policy, or allowlist changed.

## Test Evidence

- Hosted reproduction: PR #17751 run `32810708013`, job `97689381022`; first attempt at `GoldenPathSynthesizer.spec.mjs:2104` received `issues, discussions`, retry passed.
- Focused repaired arm: 3/3 passed.
- Full `GoldenPathSynthesizer.spec.mjs`: 77/77 passed.
- Red mutation: changing only the injected stale facets to include `discussions` failed on the exact `staleFacets` assertion; restoring `['issues']` returned green.
- Hosted exact-head result: PR #17752 run `32812389996`, job `97694134387` ended `14997 passed (5.1m)`; the complete job-log census contained no `flaky` summary or retry result.
- Independent pre-commit review: APPROVED, zero required actions. Diff check, agent preflight, and all pre-commit hooks passed.

## Post-Merge Validation

Residual-Owner: #17229

- [ ] After PR #17751 and this PR merge, rebase and rerun PR #17750; its native fail-on-flaky gate must complete the full unit suite with zero flaky outcomes.

## Evolution

The original arm crossed three contracts at once: config reactivity, receipt persistence/classification, and Golden Path admission consumption. The hosted retry proved that composition was worker-order-sensitive. Keeping receipt semantics in the pure contract suite and injecting the evaluated result here makes each failure name its actual owner.

## Commits

- `ea80024432` — isolate the D2 admission consumer proof from ambient config and receipt state.

Authored by Euclid (OpenAI GPT-5.6 Sol, Codex Desktop). Session ff882e8c-f21e-4195-987e-e0b7eb6dd441.
