### PR TITLE
feat(fleet): arm the plane-bearer alias teeth on the live cockpit journey (#17288)

### DIFF
--- a/ai/scripts/fleet/devCockpit.mjs
+++ b/ai/scripts/fleet/devCockpit.mjs
@@ -59,6 +59,15 @@
  * a log line. Bearer VALIDITY stays with the fleet entry's plane-side verified admission (one
  * verification authority); this launcher fails fast only on "no plane serving there at all".
  *
+ * Admission-token teeth arming (live mode): the fleet entry refuses to boot when its resolved
+ * plane bearer IS the deployment's bootstrap/healthcheck admission token — but only when it can
+ * SEE the admission token, and nothing on the host journey exported its env binding before. So in
+ * live mode the launcher resolves that binding itself ({@link resolveAdmissionTokenFileBinding},
+ * precedence mirroring the Compose secret source exactly) and rides it into the same child-only
+ * env channel. This NAMES existing custody — the file the deployment already materialized — and
+ * never copies secret material; an unreadable home degrades the comparison exactly as the assert's
+ * own documented semantics, announced loudly at boot rather than silently.
+ *
  * **The operator-seat credential journey (seat-conflation honesty).** The implicit `gh auth token`
  * fallback resolves whatever identity the CHECKOUT's gh CLI is logged in as — on a multi-seat
  * machine that is typically an AGENT seat's account, so the plane admits the session as that
@@ -79,6 +88,8 @@
 import {spawn}        from 'node:child_process';
 import {readFileSync} from 'node:fs';
 import http           from 'node:http';
+import os             from 'node:os';
+import path           from 'node:path';
 
 const FLEET_PORT_DEFAULT = 8083;
 
@@ -281,6 +292,45 @@ function isLoopbackPlaneBase(planeBase) {
 }
 
 /**
+ * @summary The canonical host custody home of the deployment's bootstrap/healthcheck admission
+ * token — the file the canonical local profile sources its `mcp-auth-token` Compose secret from.
+ * Host source and container target (`/run/secrets/mcp-auth-token`) are separate namespace
+ * contracts that happen to render from one materialization: this constant names ONLY the host
+ * half, so an export built on it names existing custody instead of copying secret material into
+ * a new location. Deployment-edge spawn-boundary constant (same family as
+ * {@link CANONICAL_LOCAL_PLANE_BASE}), not config: the config leaf binds the env var, this is the
+ * documented filesystem home behind its default.
+ * @type {String}
+ */
+export const CANONICAL_ADMISSION_TOKEN_FILE = path.join(os.homedir(), '.neo-ai', 'secrets', 'mcp-auth-token');
+
+/**
+ * @summary Resolves the admission-token binding the live journey hands the fleet child — the
+ * value `NEO_MCP_HEALTHCHECK_TOKEN_FILE` must carry for the entry's credential-class alias
+ * comparison to arm against a real token. Precedence mirrors the Compose secret-source
+ * interpolation exactly: an operator-pinned healthcheck file wins untouched; else the deployment
+ * override `NEO_MCP_AUTH_TOKEN_FILE`; else the canonical home. Pure: reads only the injected env,
+ * touches no secret material, and answers a PATH — never a token value.
+ * @param {Object}   [options]
+ * @param {Object}   [options.env=process.env] Environment to resolve from.
+ * @returns {{value: String, source: ('pinned'|'compose-override'|'canonical-home')}}
+ */
+export function resolveAdmissionTokenFileBinding({env = process.env} = {}) {
+    const pinned          = env.NEO_MCP_HEALTHCHECK_TOKEN_FILE?.trim(),
+          composeOverride = env.NEO_MCP_AUTH_TOKEN_FILE?.trim();
+
+    if (pinned) {
+        return {value: pinned, source: 'pinned'}
+    }
+
+    if (composeOverride) {
+        return {value: composeOverride, source: 'compose-override'}
+    }
+
+    return {value: CANONICAL_ADMISSION_TOKEN_FILE, source: 'canonical-home'}
+}
+
+/**
  * @summary Resolves the live journey's plane binding — the pure decision seam the witnesses pin.
  *
  * Precedence, each half named in the notes so a boot log always shows WHICH source armed the run:
@@ -432,21 +482,28 @@ export async function probePlaneIdentity({planeBase, fetchImpl = globalThis.fetc
 /**
  * @summary Builds the fleet child's environment — the ONE place launch-resolved credentials cross
  * into a process. The transport bearer + handshake arm always ride; the live plane binding rides
- * only in live mode. Custody rule: this env goes to the fleet child ALONE — the webpack child
- * keeps the launcher's own environment untouched, so a gh/file-materialized plane bearer never
- * reaches a process that does not need it. Pure: the input env is copied, never mutated.
+ * only in live mode, and the admission-token binding rides only WITH it (the alias comparison is
+ * meaningful exactly when a containerized plane is targeted). Custody rule: this env goes to the
+ * fleet child ALONE — the webpack child keeps the launcher's own environment untouched, so a
+ * gh/file-materialized plane bearer never reaches a process that does not need it. Pure: the
+ * input env is copied, never mutated.
  * @param {Object}      options
- * @param {Object}      options.baseEnv            The launcher's environment to extend.
- * @param {String}      options.fleetBearer        The process-lifetime transport bearer.
- * @param {Object|null} [options.livePlane=null]   The resolved live binding ({planeBase, planeBearer}).
+ * @param {Object}      options.baseEnv                    The launcher's environment to extend.
+ * @param {String}      options.fleetBearer                The process-lifetime transport bearer.
+ * @param {Object|null} [options.livePlane=null]           The resolved live binding ({planeBase, planeBearer}).
+ * @param {String|null} [options.admissionTokenFile=null]  The resolved admission-token path; rides only with `livePlane`.
  * @returns {Object} The child environment.
  */
-export function buildFleetChildEnv({baseEnv, fleetBearer, livePlane = null}) {
+export function buildFleetChildEnv({baseEnv, fleetBearer, livePlane = null, admissionTokenFile = null}) {
     const env = {...baseEnv, NEO_FLEET_BEARER: fleetBearer, NEO_FLEET_BEARER_HANDSHAKE: '1'};
 
     if (livePlane) {
         env.NEO_FLEET_PLANE_BASE   = livePlane.planeBase;
-        env.NEO_FLEET_PLANE_BEARER = livePlane.planeBearer
+        env.NEO_FLEET_PLANE_BEARER = livePlane.planeBearer;
+
+        if (admissionTokenFile) {
+            env.NEO_MCP_HEALTHCHECK_TOKEN_FILE = admissionTokenFile
+        }
     }
 
     return env
@@ -468,7 +525,8 @@ async function main() {
 
     // Live journey first: resolve the plane binding and prove the plane serves BEFORE anything
     // spawns — a misresolved credential or an absent plane fails fast with no browser opened.
-    let livePlane = null;
+    let livePlane          = null,
+        admissionTokenFile = null;
 
     if (liveMode) {
         const resolved = await resolveLivePlaneConfig({env: process.env});
@@ -487,7 +545,22 @@ async function main() {
         }
 
         console.log(`[cockpit:live] ${planeProbe.detail} at ${resolved.planeBase}`);
-        livePlane = resolved
+        livePlane = resolved;
+
+        // The alias comparison in the fleet entry needs to SEE the deployment's admission token;
+        // a containerized-plane journey is exactly the case where that token exists host-side.
+        // Naming the source keeps the boot log honest about which contract armed the guard; an
+        // unreadable home cannot arm the comparison (the assert degrades to skip), so say so.
+        const admissionBinding = resolveAdmissionTokenFileBinding({env: process.env});
+
+        admissionTokenFile = admissionBinding.value;
+
+        try {
+            readFileSync(admissionTokenFile, 'utf8');
+            console.log(`[cockpit:live] admission-token alias guard armed (${admissionBinding.source}: ${admissionTokenFile})`)
+        } catch (error) {
+            console.log(`[cockpit:live] WARNING: admission-token alias guard DEGRADED — resolved home unreadable (${admissionBinding.source}: ${admissionTokenFile}: ${error.message}). Materialize ~/.neo-ai/secrets/mcp-auth-token or pin NEO_MCP_AUTH_TOKEN_FILE / NEO_MCP_HEALTHCHECK_TOKEN_FILE.`)
+        }
     }
 
     const probe = fleetPort === FLEET_PORT_DEFAULT ? await probeFleetEndpoint(fleetPort) : null;
@@ -574,7 +647,7 @@ async function main() {
         // closing the launcher→page hand-off without an agent seam. The live plane binding (when
         // `--live` resolved one) rides the same child-only channel — never the webpack env.
         const fleet = spawn(fleetCmd[0], fleetCmd.slice(1), {
-            env  : buildFleetChildEnv({baseEnv: process.env, fleetBearer, livePlane}),
+            env  : buildFleetChildEnv({baseEnv: process.env, fleetBearer, livePlane, admissionTokenFile}),
             stdio: 'inherit'
         });
 

--- a/ai/scripts/fleet/devCockpit.mjs
+++ b/ai/scripts/fleet/devCockpit.mjs
@@ -62,11 +62,12 @@
  * Admission-token teeth arming (live mode): the fleet entry refuses to boot when its resolved
  * plane bearer IS the deployment's bootstrap/healthcheck admission token — but only when it can
  * SEE the admission token, and nothing on the host journey exported its env binding before. So in
- * live mode the launcher resolves that binding itself ({@link resolveAdmissionTokenFileBinding},
- * precedence mirroring the Compose secret source exactly) and rides it into the same child-only
- * env channel. This NAMES existing custody — the file the deployment already materialized — and
- * never copies secret material; an unreadable home degrades the comparison exactly as the assert's
- * own documented semantics, announced loudly at boot rather than silently.
+ * live mode the launcher resolves that binding itself ({@link resolveAdmissionTokenFileBinding})
+ * and rides it into the same child-only channel: an already-exported pin passes through untouched,
+ * else the Compose secret-source chain (deployment override, then canonical home) supplies the
+ * deployment's own materialization. This NAMES existing custody — never copies secret material;
+ * an unreadable home degrades the comparison exactly as the assert's own documented semantics,
+ * announced loudly at boot rather than silently.
  *
  * **The operator-seat credential journey (seat-conflation honesty).** The implicit `gh auth token`
  * fallback resolves whatever identity the CHECKOUT's gh CLI is logged in as — on a multi-seat
@@ -86,7 +87,7 @@
  * plane — an occupied endpoint refuses with the remediation named.
  */
 import {spawn}        from 'node:child_process';
-import {readFileSync} from 'node:fs';
+import {accessSync, constants, readFileSync} from 'node:fs';
 import http           from 'node:http';
 import os             from 'node:os';
 import path           from 'node:path';
@@ -307,10 +308,16 @@ export const CANONICAL_ADMISSION_TOKEN_FILE = path.join(os.homedir(), '.neo-ai',
 /**
  * @summary Resolves the admission-token binding the live journey hands the fleet child — the
  * value `NEO_MCP_HEALTHCHECK_TOKEN_FILE` must carry for the entry's credential-class alias
- * comparison to arm against a real token. Precedence mirrors the Compose secret-source
- * interpolation exactly: an operator-pinned healthcheck file wins untouched; else the deployment
- * override `NEO_MCP_AUTH_TOKEN_FILE`; else the canonical home. Pure: reads only the injected env,
- * touches no secret material, and answers a PATH — never a token value.
+ * comparison to arm against a real token. Three levels, and they are NOT one inherited policy:
+ * the FIRST honors an operator's already-exported binding — the launcher's env spread passed
+ * that variable through to the child before this resolver existed, and an explicit pin outranks
+ * any derived value. The REMAINING two mirror the Compose secret-source interpolation
+ * (`${NEO_MCP_AUTH_TOKEN_FILE:-${HOME}/.neo-ai/secrets/mcp-auth-token}`): the deployment
+ * override, then the canonical home. The distinction is load-bearing — a pinned path can name a
+ * file Compose never materialized, so the guard could compare against a subject the deployment
+ * did not provision — which is exactly why the boot log prints WHICH level armed.
+ * Pure: reads only the injected env, touches no secret material, and answers a PATH — never a
+ * token value.
  * @param {Object}   [options]
  * @param {Object}   [options.env=process.env] Environment to resolve from.
  * @returns {{value: String, source: ('pinned'|'compose-override'|'canonical-home')}}
@@ -556,7 +563,9 @@ async function main() {
         admissionTokenFile = admissionBinding.value;
 
         try {
-            readFileSync(admissionTokenFile, 'utf8');
+            // Readability probe only — accessSync answers it without materializing secret bytes
+            // into the launcher's heap, which is the custody principle this feature lives by.
+            accessSync(admissionTokenFile, constants.R_OK);
             console.log(`[cockpit:live] admission-token alias guard armed (${admissionBinding.source}: ${admissionTokenFile})`)
         } catch (error) {
             console.log(`[cockpit:live] WARNING: admission-token alias guard DEGRADED — resolved home unreadable (${admissionBinding.source}: ${admissionTokenFile}: ${error.message}). Materialize ~/.neo-ai/secrets/mcp-auth-token or pin NEO_MCP_AUTH_TOKEN_FILE / NEO_MCP_HEALTHCHECK_TOKEN_FILE.`)

--- a/learn/agentos/RunningTheFleetCockpit.md
+++ b/learn/agentos/RunningTheFleetCockpit.md
@@ -170,6 +170,20 @@ The launcher resolves the plane binding itself, naming every source it used:
    Nothing serving there fails fast with the plane-start command
    (`docker compose --env-file .env -f ai/deploy/docker-compose.yml -f ai/deploy/docker-compose.local-agent-os.yml --profile cloud --profile ingress --profile fleet up -d --wait`,
    see [`local-agent-os/README.md`](../../ai/scripts/lifecycle/local-agent-os/README.md)).
+4. **Admission-token teeth** — the live launcher also resolves the deployment's
+   bootstrap/healthcheck admission token and rides it into the fleet child's environment, arming
+   the credential-class alias guard: a plane bearer that IS the admission token now refuses this
+   boot exactly as production would, instead of passing silently. The resolution mirrors the
+   Compose secret source exactly — an already-exported `NEO_MCP_HEALTHCHECK_TOKEN_FILE` wins, then
+   the deployment override `NEO_MCP_AUTH_TOKEN_FILE`, then the canonical home
+   (`~/.neo-ai/secrets/mcp-auth-token`) — and it names its source in the boot log. Nothing is
+   copied: the export points at the custody home the deployment already materialized. An unreadable
+   home cannot arm the comparison; the boot says so loudly (a named DEGRADED line) rather than
+   silently skipping.
+
+The standalone `npm run ai:fleet-server` journey has no launcher to arm the guard for you: export
+the binding yourself (`NEO_MCP_HEALTHCHECK_TOKEN_FILE=~/.neo-ai/secrets/mcp-auth-token npm run ai:fleet-server`)
+whenever that entry targets a containerized plane.
 
 Live mode **never adopts an incumbent** fleet transport: an existing server on `:8083` cannot
 report which plane it reads through `/fleet/probe`, so adopting it could point the cockpit at the

--- a/test/playwright/unit/ai/scripts/fleet/devCockpit.spec.mjs
+++ b/test/playwright/unit/ai/scripts/fleet/devCockpit.spec.mjs
@@ -734,7 +734,12 @@ test.describe('ai/scripts/fleet/devCockpit — admission-token alias-guard armin
                         ...process.env,
                         NEO_FLEET_PLANE_BASE          : 'http://127.0.0.1:9',
                         NEO_FLEET_PLANE_BEARER        : 'a-distinct-plane-credential',
-                        NEO_MCP_HEALTHCHECK_TOKEN_FILE: tokenFile
+                        NEO_MCP_HEALTHCHECK_TOKEN_FILE: tokenFile,
+                        // The viewer claim resolves BEFORE plane admission; without this pin a
+                        // gh-less environment refuses earlier with an unrelated message. The env
+                        // chain alone satisfies the claim, so the witness reaches the stage it
+                        // exists to observe: the dead-plane admission refusal.
+                        NEO_AGENT_IDENTITY            : 'admission-teeth-witness'
                     },
                     stdio: ['ignore', 'pipe', 'pipe']
                 });

--- a/test/playwright/unit/ai/scripts/fleet/devCockpit.spec.mjs
+++ b/test/playwright/unit/ai/scripts/fleet/devCockpit.spec.mjs
@@ -14,7 +14,7 @@ import InstanceManager from '../../../../../../src/manager/Instance.mjs';
 
 import http from 'node:http';
 
-import {COCKPIT_OPEN_TARGET, FLEET_PROBE_METHOD, buildFleetChildEnv, planCockpitBoot, probeFleetEndpoint, probePlaneIdentity, resolveLivePlaneConfig} from '../../../../../../ai/scripts/fleet/devCockpit.mjs';
+import {CANONICAL_ADMISSION_TOKEN_FILE, COCKPIT_OPEN_TARGET, FLEET_PROBE_METHOD, buildFleetChildEnv, planCockpitBoot, probeFleetEndpoint, probePlaneIdentity, resolveAdmissionTokenFileBinding, resolveLivePlaneConfig} from '../../../../../../ai/scripts/fleet/devCockpit.mjs';
 import {startFleetBridgeServer}                                                                                                                       from '../../../../../../ai/services/fleet/fleetBridgeServer.mjs';
 import {generateLocalBearerToken}                                                                                                                     from '../../../../../../ai/mcp/server/shared/helpers/localBearer.mjs';
 
@@ -607,6 +607,150 @@ test.describe('ai/scripts/fleet/devCockpit — the live-plane journey (cockpit:l
             }
         } finally {
             await new Promise(resolve => incumbent.close(resolve))
+        }
+    })
+});
+
+/**
+ * The admission-token alias-guard arming witnesses: the launcher's binding resolver mirrors the
+ * Compose secret-source precedence, the child-env builder rides the binding only with a live
+ * plane binding, and a dev entry whose plane bearer aliases the armed token refuses pre-network
+ * with the credential-class ledger's named error — while a distinct bearer gets PAST the teeth.
+ */
+test.describe('ai/scripts/fleet/devCockpit — admission-token alias-guard arming', () => {
+    test('the binding resolver mirrors the Compose secret-source precedence exactly', () => {
+        const pinned = resolveAdmissionTokenFileBinding({env: {NEO_MCP_HEALTHCHECK_TOKEN_FILE: '/operator/pinned/token'}});
+
+        expect(pinned).toEqual({value: '/operator/pinned/token', source: 'pinned'});
+
+        // the pinned healthcheck var wins even when the deployment override is also present
+        expect(resolveAdmissionTokenFileBinding({env: {NEO_MCP_HEALTHCHECK_TOKEN_FILE: ' /pinned ', NEO_MCP_AUTH_TOKEN_FILE: '/override'}}))
+            .toEqual({value: '/pinned', source: 'pinned'});
+
+        expect(resolveAdmissionTokenFileBinding({env: {NEO_MCP_AUTH_TOKEN_FILE: '/deploy/override/token'}}))
+            .toEqual({value: '/deploy/override/token', source: 'compose-override'});
+
+        // whitespace-only values are not pins — they fall through like absent ones
+        expect(resolveAdmissionTokenFileBinding({env: {NEO_MCP_HEALTHCHECK_TOKEN_FILE: '   ', NEO_MCP_AUTH_TOKEN_FILE: '  '}}))
+            .toEqual({value: CANONICAL_ADMISSION_TOKEN_FILE, source: 'canonical-home'});
+
+        expect(resolveAdmissionTokenFileBinding({env: {}}))
+            .toEqual({value: CANONICAL_ADMISSION_TOKEN_FILE, source: 'canonical-home'});
+
+        expect(CANONICAL_ADMISSION_TOKEN_FILE)
+            .toBe(path.join(os.homedir(), '.neo-ai', 'secrets', 'mcp-auth-token'))
+    });
+
+    test('the child env rides the admission binding ONLY with a live plane binding', () => {
+        const base = {CARRY_ME: 'yes'};
+
+        const liveArmed = buildFleetChildEnv({
+            baseEnv           : base,
+            fleetBearer       : 'fleet-bearer',
+            livePlane         : {planeBase: 'http://127.0.0.1:3102', planeBearer: 'distinct-plane-token'},
+            admissionTokenFile: '/host/.neo-ai/secrets/mcp-auth-token'
+        });
+
+        expect(liveArmed.NEO_MCP_HEALTHCHECK_TOKEN_FILE).toBe('/host/.neo-ai/secrets/mcp-auth-token');
+        expect(liveArmed.NEO_FLEET_PLANE_BEARER).toBe('distinct-plane-token');
+
+        // no live plane → no admission export, whatever was resolved (in-process journeys stay unarmed)
+        const inProcess = buildFleetChildEnv({baseEnv: base, fleetBearer: 'fleet-bearer', admissionTokenFile: '/host/.neo-ai/secrets/mcp-auth-token'});
+
+        expect(inProcess.NEO_MCP_HEALTHCHECK_TOKEN_FILE).toBeUndefined();
+        expect(inProcess.NEO_FLEET_PLANE_BASE).toBeUndefined();
+
+        // an empty resolution never overwrites the operator's own environment copy
+        const emptyResolution = buildFleetChildEnv({
+            baseEnv           : {...base, NEO_MCP_HEALTHCHECK_TOKEN_FILE: '/operator/pinned/token'},
+            fleetBearer       : 'fleet-bearer',
+            livePlane         : {planeBase: 'http://127.0.0.1:3102', planeBearer: 't'},
+            admissionTokenFile: ''
+        });
+
+        expect(emptyResolution.NEO_MCP_HEALTHCHECK_TOKEN_FILE).toBe('/operator/pinned/token');
+
+        // input purity: baseEnv copied, never mutated
+        expect(base.CARRY_ME).toBe('yes');
+        expect(liveArmed).not.toBe(base)
+    });
+
+    test('the JS custody default and the Compose secret source render the same home \u2014 drift ratchet', () => {
+        const composeSource  = fs.readFileSync(path.join(repoRoot, 'ai/deploy/docker-compose.local-agent-os.yml'), 'utf8'),
+              launcherSource = fs.readFileSync(path.join(repoRoot, 'ai/scripts/fleet/devCockpit.mjs'), 'utf8');
+
+        expect(composeSource).toContain('${NEO_MCP_AUTH_TOKEN_FILE:-${HOME}/.neo-ai/secrets/mcp-auth-token}');
+        expect(launcherSource).toContain(`path.join(os.homedir(), '.neo-ai', 'secrets', 'mcp-auth-token')`)
+    });
+
+    test('a spawned dev entry whose plane bearer aliases the armed admission token REFUSES pre-network with the ledger error', async () => {
+        test.setTimeout(30000);
+
+        const secretsDir = fs.mkdtempSync(path.join(os.tmpdir(), 'admission-teeth-')),
+              tokenFile  = path.join(secretsDir, 'mcp-auth-token');
+
+        fs.writeFileSync(tokenFile, 'aliased-admission-secret');
+
+        try {
+            const result = await new Promise(resolve => {
+                const child = spawn(process.execPath, [path.join(repoRoot, 'ai/services/fleet/devFleetServer.mjs')], {
+                    cwd: repoRoot,
+                    env: {
+                        ...process.env,
+                        NEO_FLEET_PLANE_BASE          : 'http://127.0.0.1:9',
+                        NEO_FLEET_PLANE_BEARER        : 'aliased-admission-secret',
+                        NEO_MCP_HEALTHCHECK_TOKEN_FILE: tokenFile
+                    },
+                    stdio: ['ignore', 'pipe', 'pipe']
+                });
+
+                let output = '';
+                child.stdout.on('data', chunk => output += chunk);
+                child.stderr.on('data', chunk => output += chunk);
+                child.on('exit', code => resolve({code, output}))
+            });
+
+            expect(result.code).toBe(1);
+            expect(result.output).toContain('[FleetServer] fleet.planeBearer resolves to the deployment\'s bootstrap/healthcheck');
+            expect(result.output).toContain('dev server failed to start')
+        } finally {
+            fs.rmSync(secretsDir, {recursive: true, force: true})
+        }
+    });
+
+    test('a DISTINCT plane bearer passes the teeth \u2014 the boot advances to plane admission (and refuses only on the dead plane)', async () => {
+        test.setTimeout(30000);
+
+        const secretsDir = fs.mkdtempSync(path.join(os.tmpdir(), 'admission-teeth-')),
+              tokenFile  = path.join(secretsDir, 'mcp-auth-token');
+
+        fs.writeFileSync(tokenFile, 'the-admission-secret');
+
+        try {
+            const result = await new Promise(resolve => {
+                const child = spawn(process.execPath, [path.join(repoRoot, 'ai/services/fleet/devFleetServer.mjs')], {
+                    cwd: repoRoot,
+                    env: {
+                        ...process.env,
+                        NEO_FLEET_PLANE_BASE          : 'http://127.0.0.1:9',
+                        NEO_FLEET_PLANE_BEARER        : 'a-distinct-plane-credential',
+                        NEO_MCP_HEALTHCHECK_TOKEN_FILE: tokenFile
+                    },
+                    stdio: ['ignore', 'pipe', 'pipe']
+                });
+
+                let output = '';
+                child.stdout.on('data', chunk => output += chunk);
+                child.stderr.on('data', chunk => output += chunk);
+                child.on('exit', code => resolve({code, output}))
+            });
+
+            // reaching the plane-mode refusal PROVES the credential-class comparison passed:
+            // the aliased twin above dies before this line with the ledger error instead.
+            expect(result.output).not.toContain('[FleetServer] fleet.planeBearer resolves to the deployment\'s bootstrap/healthcheck');
+            expect(result.output).toContain('[fleet] plane mode refused')
+        } finally {
+            fs.rmSync(secretsDir, {recursive: true, force: true})
         }
     })
 });

--- a/test/playwright/unit/ai/scripts/fleet/devCockpit.spec.mjs
+++ b/test/playwright/unit/ai/scripts/fleet/devCockpit.spec.mjs
@@ -28,7 +28,7 @@ const authenticatedOptions = overrides => ({
 
 const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../../../../../..');
 
-// Both describe blocks below own the fixed :8083 endpoint. Under `fullyParallel`, separate describes
+// All describe blocks below own the fixed :8083 endpoint. Under `fullyParallel`, separate describes
 // can run in different workers; file-wide default mode orders them while preserving independent retries.
 test.describe.configure({mode: 'default'});
 


### PR DESCRIPTION
Resolves neomjs/neo#17288

The live cockpit journey now arms the credential-class alias teeth: `npm run cockpit:live` resolves the deployment's admission token and rides it into the fleet child's environment. Three precedence levels, two policies: an already-exported `NEO_MCP_HEALTHCHECK_TOKEN_FILE` passes through untouched — the launcher's env spread did that before this PR existed, and an explicit pin outranks anything derived — while the remaining two mirror the Compose secret source (`NEO_MCP_AUTH_TOKEN_FILE`, then the canonical home). The pinned level can name a file Compose never materialized, which is why the boot log prints WHICH level armed, so a plane bearer that IS the admission token refuses this boot exactly as production would. The launcher names its source in the boot log and announces a loud DEGRADED line when the resolved home is unreadable; no secret material is copied anywhere — the export names existing custody.

Evidence: L0 (no sandbox-unreachable runtime claims — all witnesses are CI-covered spawned-process unit specs) → L0 required. Residual: live-plane boot observation only, owned below.

## AC Evidence
| AC-1 | Ruling recorded on the ticket (provisionable; host home is the Compose secret SOURCE) |
| AC-2 | Alias boot refusal + distinct-pass witnessed by spawned-entry unit specs: `test/playwright/unit/ai/scripts/fleet/devCockpit.spec.mjs` (arming describe, 5 arms incl. two real-process witnesses); resolver/builder precedence + Compose-drift ratchet in the same block |

## Deltas from ticket
- The custody ruling cites the backup-root paired-contract shape: host-source contract keeps its existing name (`NEO_MCP_AUTH_TOKEN_FILE`) rather than minting a new one.
- Refusal-side diagnostic unchanged (the entry's existing ledger text); the arming side is launcher-only, zero changes to the fleet entry or the assert.
- Standalone `ai:fleet-server` journey: documented export guidance instead of code (no launcher owns that path).
- Review correction folded in: the earlier "mirrors Compose exactly" framing was wrong (three levels vs Compose's two); the resolver JSDoc + this body now declare the two-policy structure and why the pin outranks the deployment's file. Readability probe switched to `accessSync(R_OK)` so no secret bytes enter the launcher heap.

## Test Evidence
All coverage runs in CI.

## Post-Merge Validation
- [ ] Operator boots `npm run cockpit:live` against the containerized plane and sees the `admission-token alias guard armed` line naming its source.

Residual-Owner: neomjs/neo-agent-brain#15

## Commits
- 008a169dc4 — launcher arming (resolver, builder param, live-mode wiring)
- b4934ba6dd — witnesses + live-plane docs

Authored by Eos (ox-alpha, OpenCode). Session 13fd47db-30ca-45a8-9fec-06117475ed12.