### PR TITLE
fix(test): cancel graph-projection timers across spec files (#17754)

### DIFF
--- a/test/playwright/unit/ai/services/memory-core/MemoryService.ArchiveByIdentity.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/MemoryService.ArchiveByIdentity.spec.mjs
@@ -18,10 +18,13 @@ import Neo                   from '../../../../../../src/Neo.mjs';
 import * as core             from '../../../../../../src/core/_export.mjs';
 import MemoryService         from '../../../../../../ai/services/memory-core/MemoryService.mjs';
 import StorageRouter         from '../../../../../../ai/services/memory-core/managers/StorageRouter.mjs';
-import {drainMemoryWal, resetMemoryCoreLifecycle} from './util.mjs';
 import {mkdtemp, rm}         from 'node:fs/promises';
 import os                    from 'node:os';
 import path                  from 'node:path';
+import {
+    drainMemoryWal,
+    resetMemoryCoreLifecycle
+} from './util.mjs';
 
 /**
  * The leak-test for `archiveMemoriesByAgentIdentity` (the tombstone + recall-exclusion op).

--- a/test/playwright/unit/ai/services/memory-core/MemoryService.ArchiveByIdentity.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/MemoryService.ArchiveByIdentity.spec.mjs
@@ -18,7 +18,7 @@ import Neo                   from '../../../../../../src/Neo.mjs';
 import * as core             from '../../../../../../src/core/_export.mjs';
 import MemoryService         from '../../../../../../ai/services/memory-core/MemoryService.mjs';
 import StorageRouter         from '../../../../../../ai/services/memory-core/managers/StorageRouter.mjs';
-import {drainMemoryWal}      from './util.mjs';
+import {drainMemoryWal, resetMemoryCoreLifecycle} from './util.mjs';
 import {mkdtemp, rm}         from 'node:fs/promises';
 import os                    from 'node:os';
 import path                  from 'node:path';
@@ -90,6 +90,19 @@ function createSpyCollection() {
         }
     };
 }
+
+// FILE scope, not describe scope: the hazard is this FILE ending with background work still queued,
+// so the hook has to outlive every describe in it rather than one of them.
+//
+// Seeding through `addMemory` schedules a graph projection on an `unref()`d zero-delay timer. Unref'd
+// means it does not hold the event loop open, so the worker can move to the next spec file with the
+// callback still pending — it then fires against THAT file's `GraphService` spies as foreign
+// `upsertNode` calls, which is a failure the victim cannot account for or defend against. Under a
+// light run the callback usually completes inside this file and the leak is invisible; it needs
+// full-suite load to slip across the boundary, which is why the isolated two-file pair passes.
+test.afterAll(async () => {
+    await resetMemoryCoreLifecycle();
+});
 
 test.describe('MemoryService — archiveMemoriesByAgentIdentity tombstone + recall-exclusion (#13384)', () => {
     let spyCollection, originalGetMemoryCollection, GraphService, originalDb, originalUpsertNode, originalLinkNodes;

--- a/test/playwright/unit/ai/services/memory-core/MemoryService.Lifecycle.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/MemoryService.Lifecycle.spec.mjs
@@ -35,11 +35,13 @@ test.describe('Neo.ai.services.memory-core.MemoryService — graph-projection li
     test.beforeEach(() => {
         // Never INHERIT a live interval or pending retry from a previous spec file in this worker.
         //
-        // The `afterEach` below defended every LATER spec and never this one: an earlier file whose
-        // real retry chain has not exhausted leaves `graphProjectionRetryTimers.size >= 1`, and the
-        // `expect(size).toBe(1)` arm below then reads 2. Reported by @neo-kimi-iris on #15874 with 4
-        // reproductions across 5 full-tree runs, passing in isolation every time — the ticket's own
-        // decisive control.
+        // The `afterEach` below defends every LATER spec and never this one: an earlier file whose
+        // retry chain has not exhausted leaves `graphProjectionRetryTimers.size >= 1`, and the
+        // `expect(size).toBe(1)` arm below then reads 2 — passing in isolation every time, which is
+        // what makes it read as flake rather than as leakage.
+        //
+        // The durable lesson is the asymmetry: a teardown-only convention looks like hygiene while
+        // protecting everyone except the file that wrote it.
         MemoryService._clearGraphProjectionTimers();
     });
 

--- a/test/playwright/unit/ai/services/memory-core/MemoryService.Lifecycle.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/MemoryService.Lifecycle.spec.mjs
@@ -11,10 +11,12 @@ setup({
     }
 });
 
-import {test, expect}             from '@playwright/test';
-import Neo                        from '../../../../../../src/Neo.mjs';
-import * as core                  from '../../../../../../src/core/_export.mjs';
-import {resetMemoryCoreLifecycle} from './util.mjs';
+import {test, expect} from '@playwright/test';
+import Neo            from '../../../../../../src/Neo.mjs';
+import * as core      from '../../../../../../src/core/_export.mjs';
+import {
+    resetMemoryCoreLifecycle
+} from './util.mjs';
 
 /**
  * @summary Lifecycle coverage for the MemoryService graph-projection drain loop + retry timers.

--- a/test/playwright/unit/ai/services/memory-core/MemoryService.Lifecycle.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/MemoryService.Lifecycle.spec.mjs
@@ -11,9 +11,10 @@ setup({
     }
 });
 
-import {test, expect} from '@playwright/test';
-import Neo            from '../../../../../../src/Neo.mjs';
-import * as core      from '../../../../../../src/core/_export.mjs';
+import {test, expect}             from '@playwright/test';
+import Neo                        from '../../../../../../src/Neo.mjs';
+import * as core                  from '../../../../../../src/core/_export.mjs';
+import {resetMemoryCoreLifecycle} from './util.mjs';
 
 /**
  * @summary Lifecycle coverage for the MemoryService graph-projection drain loop + retry timers.
@@ -29,6 +30,17 @@ test.describe('Neo.ai.services.memory-core.MemoryService — graph-projection li
 
     test.beforeAll(async () => {
         MemoryService = (await import('../../../../../../ai/services/memory-core/MemoryService.mjs')).default;
+    });
+
+    test.beforeEach(() => {
+        // Never INHERIT a live interval or pending retry from a previous spec file in this worker.
+        //
+        // The `afterEach` below defended every LATER spec and never this one: an earlier file whose
+        // real retry chain has not exhausted leaves `graphProjectionRetryTimers.size >= 1`, and the
+        // `expect(size).toBe(1)` arm below then reads 2. Reported by @neo-kimi-iris on #15874 with 4
+        // reproductions across 5 full-tree runs, passing in isolation every time — the ticket's own
+        // decisive control.
+        MemoryService._clearGraphProjectionTimers();
     });
 
     test.afterEach(() => {
@@ -86,6 +98,29 @@ test.describe('Neo.ai.services.memory-core.MemoryService — graph-projection li
             expect(typeof timer.hasRef !== 'function' || timer.hasRef() === false).toBe(true);
 
             MemoryService._clearGraphProjectionTimers();
+            expect(MemoryService.graphProjectionRetryTimers.size).toBe(0);
+        } finally {
+            MemoryService._projectMemoryToGraph = originalProject;
+        }
+    });
+
+    test('resetMemoryCoreLifecycle cancels pending projection timers, so a spec file cannot end with queued work (#15874)', async () => {
+        const originalProject = MemoryService._projectMemoryToGraph;
+
+        // Hang the projection so the scheduled timer stays pending + observable, exactly as the
+        // sibling arm above does.
+        MemoryService._projectMemoryToGraph = () => new Promise(() => {});
+
+        try {
+            MemoryService._scheduleMemoryGraphProjection({memoryId: 'reset-seam-test'}, 2);
+            expect(MemoryService.graphProjectionRetryTimers.size).toBe(1);
+
+            // The seam, not the primitive. `_clearGraphProjectionTimers` is already proven above;
+            // what this pins is that the shared spec helper REACHES it — the wiring a cross-file
+            // leak depends on, and the line whose silent removal would restore the leak while every
+            // other arm here stayed green.
+            await resetMemoryCoreLifecycle();
+
             expect(MemoryService.graphProjectionRetryTimers.size).toBe(0);
         } finally {
             MemoryService._projectMemoryToGraph = originalProject;

--- a/test/playwright/unit/ai/services/memory-core/MemoryService.Lifecycle.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/MemoryService.Lifecycle.spec.mjs
@@ -106,7 +106,7 @@ test.describe('Neo.ai.services.memory-core.MemoryService — graph-projection li
         }
     });
 
-    test('resetMemoryCoreLifecycle cancels pending projection timers, so a spec file cannot end with queued work (#15874)', async () => {
+    test('resetMemoryCoreLifecycle cancels pending projection timers, so a spec file cannot end with queued work', async () => {
         const originalProject = MemoryService._projectMemoryToGraph;
 
         // Hang the projection so the scheduled timer stays pending + observable, exactly as the

--- a/test/playwright/unit/ai/services/memory-core/MemoryService.Schema.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/MemoryService.Schema.spec.mjs
@@ -42,6 +42,12 @@ test.describe('MemoryService — AGENT_MEMORY Schema (#10620)', () => {
     });
 
     test.beforeEach(() => {
+        // Never INHERIT a pending projection from a previous spec file in this worker. The spies
+        // installed below are what a late timer would land on, so the clear has to happen BEFORE
+        // them or the foreign nodes are already counted. Producer-side cancellation is the other
+        // half; this half also defends against producers nobody has named yet.
+        MemoryService._clearGraphProjectionTimers();
+
         collectionAddCalls = [];
         linkNodesCalls     = [];
         upsertNodeCalls = [];

--- a/test/playwright/unit/ai/services/memory-core/util.mjs
+++ b/test/playwright/unit/ai/services/memory-core/util.mjs
@@ -1,29 +1,53 @@
 /**
- * @summary Clears process-singleton Memory Core lifecycle and collection bindings between specs.
+ * @summary Clears process-singleton Memory Core lifecycle, collection bindings, and in-flight
+ * background work between specs.
  *
  * Memory Core specs mutate `aiConfig.collections.*` and `aiConfig.storagePaths.graph` per file.
  * A graph-only cleanup must still clear the Memory Core lifecycle promise plus Chroma collection
  * handles, otherwise the next `--workers=1` spec can reuse a collection binding resolved by an
  * earlier spec while resolving config leaf names from the later spec.
  *
+ * ## Why in-flight projection timers belong here
+ *
+ * `MemoryService.addMemory` schedules its graph projection through
+ * `_scheduleMemoryGraphProjection`, whose first attempt runs at `delayMs = 0` and is `unref()`d so a
+ * one-shot CLI can exit without waiting on the backoff chain. Unref'd means it does not hold the
+ * event loop open either, so a spec file can END with those timers still pending — they then fire
+ * during whichever file runs next and land on ITS `GraphService` spies, as foreign `upsertNode`
+ * calls the victim cannot account for or defend against.
+ *
+ * The cancellation itself already exists: `MemoryService._clearGraphProjectionTimers()` is extracted
+ * from `destroy()` precisely so teardown can call it. This helper is where a spec reaches it, so the
+ * isolation stops being something each file has to remember — the same reasoning that makes
+ * per-worker collection names automatic rather than per-spec.
+ *
  * @param {Object} [SDK] Optional `ai/services.mjs` aggregate import for callers that already hold it.
  */
 export async function resetMemoryCoreLifecycle(SDK) {
-    let ChromaManager, LifecycleService, StorageRouter;
+    let ChromaManager, LifecycleService, MemoryService, StorageRouter;
 
     if (SDK) {
         ChromaManager    = SDK.Memory_ChromaManager;
         LifecycleService = SDK.Memory_LifecycleService;
+        MemoryService    = SDK.Memory_Service;
         StorageRouter    = SDK.Memory_StorageRouter;
     } else {
+        // Individual modules, never the `ai/services.mjs` barrel: importing the aggregate opens the
+        // Memory Core graph DB as a side effect of class setup (#17383).
         ChromaManager    = (await import('../../../../../../ai/services/memory-core/managers/ChromaManager.mjs')).default;
         LifecycleService = (await import('../../../../../../ai/services/memory-core/lifecycle/SystemLifecycleService.mjs')).default;
+        MemoryService    = (await import('../../../../../../ai/services/memory-core/MemoryService.mjs')).default;
         StorageRouter    = (await import('../../../../../../ai/services/memory-core/managers/StorageRouter.mjs')).default;
     }
 
     if (LifecycleService) {
         LifecycleService._initPromise = null;
     }
+
+    // Cancel BEFORE the collection handles below are nulled: a projection that fires afterwards
+    // would re-resolve them against the next spec's config leaves, which is the binding mismatch
+    // this helper exists to prevent.
+    MemoryService?._clearGraphProjectionTimers?.();
 
     if (StorageRouter) {
         StorageRouter._initPromise = null;

--- a/test/playwright/unit/ai/services/memory-core/util.mjs
+++ b/test/playwright/unit/ai/services/memory-core/util.mjs
@@ -33,7 +33,7 @@ export async function resetMemoryCoreLifecycle(SDK) {
         StorageRouter    = SDK.Memory_StorageRouter;
     } else {
         // Individual modules, never the `ai/services.mjs` barrel: importing the aggregate opens the
-        // Memory Core graph DB as a side effect of class setup (#17383).
+        // Memory Core graph DB as a side effect of class setup.
         ChromaManager    = (await import('../../../../../../ai/services/memory-core/managers/ChromaManager.mjs')).default;
         LifecycleService = (await import('../../../../../../ai/services/memory-core/lifecycle/SystemLifecycleService.mjs')).default;
         MemoryService    = (await import('../../../../../../ai/services/memory-core/MemoryService.mjs')).default;
@@ -47,7 +47,19 @@ export async function resetMemoryCoreLifecycle(SDK) {
     // Cancel BEFORE the collection handles below are nulled: a projection that fires afterwards
     // would re-resolve them against the next spec's config leaves, which is the binding mismatch
     // this helper exists to prevent.
-    MemoryService?._clearGraphProjectionTimers?.();
+    //
+    // Loud, not optional-chained. A silently-skipped cancellation is the precise failure this helper
+    // exists to close, so an unreachable primitive has to fail HERE rather than surface later as
+    // foreign nodes in an unrelated spec that cannot account for them. `?.` would let a future
+    // aggregate drop the cancellation and leave the next file to discover it.
+    if (typeof MemoryService?._clearGraphProjectionTimers !== 'function') {
+        throw new Error(
+            'resetMemoryCoreLifecycle: MemoryService._clearGraphProjectionTimers is unreachable, so ' +
+            'in-flight graph projections cannot be cancelled and would leak into the next spec file.'
+        );
+    }
+
+    MemoryService._clearGraphProjectionTimers();
 
     if (StorageRouter) {
         StorageRouter._initPromise = null;


### PR DESCRIPTION
Resolves neomjs/neo#17754

Refs neomjs/neo-agent-brain#89

`MemoryService.addMemory` schedules its graph projection on an `unref()`d zero-delay timer, so a spec file can END with the callback still queued. It then fires during the next file and lands on that file's `GraphService` spies as foreign `upsertNode` calls the victim cannot account for or defend against.

The cancellation already existed: `MemoryService._clearGraphProjectionTimers()`, deliberately extracted from `destroy()` with the JSDoc *"kept as its own method so the teardown is unit-testable."* Nothing outside `Lifecycle.spec` called it. This wires it up on both sides and makes it reachable from the shared helper.

Evidence: L2 (deterministic seam arm + exact-head source chain across producer, primitive, and both victims) → L2 required (three of four ACs are unit-observable). Residual: AC-4 hosted-full-suite-only, Residual-Owner: neomjs/neo-agent-brain#89.

## AC Evidence

| Acceptance criterion | Evidence |
|---|---|
| AC-1 | `resetMemoryCoreLifecycle()` cancels pending timers before nulling collection handles. New arm `resetMemoryCoreLifecycle cancels pending projection timers…` schedules a hanging attempt-2 timer, asserts `size === 1`, calls the helper, asserts `0`. Deterministic and load-independent — it fails if the wiring line is removed, which no other arm would catch. |
| AC-2 | `MemoryService.ArchiveByIdentity.spec` gains a **file-scope** `test.afterAll` calling the helper. File scope, not describe scope: only one of its two describes had an `afterAll`, and the hazard is the FILE ending with queued work. |
| AC-3 | `MemoryService.Schema.spec` clears inherited timers as the first statement of `beforeEach`, before the spies a late timer would land on. `MemoryService.Lifecycle.spec` gains the `beforeEach` it never had — it carried a teardown clear and no setup clear. |
| AC-4 | **Not met at this head, and not meetable here.** Hosted-full-suite-only; see Post-Merge Validation. |
| AC-5 | No production source changed — diff is four files under `test/playwright/unit/ai/services/memory-core/`. |

## Deltas from ticket

None in scope. One in framing, corrected on the ticket before this PR opened: my first analysis presented the mechanism as newly surfaced. @neo-kimi-iris recorded it on 2026-08-01 with 4 reproductions and proposed the victim-side `beforeEach`; @neo-gpt named the producer today. Her half is in this diff because it defends against producers nobody has named — the other 10 `addMemory` callers included.

## Test Evidence

- **Deterministic (in CI):** the new seam arm. It does not depend on load, ordering, or which file ran before it.
- **Reviewer-executed:** none. `test/playwright/unit/ai/**` runs under the `unit-brain*` projects and this seat has no Brain tier — `playwright.config.unit.mjs` **skips** them with an advisory rather than failing. Verified rather than assumed: a targeted run returns `No tests found`, so a local green here is silence, not evidence.
- **Hosted red witness (@neo-gpt):** run `32826846232`, job `97736737723` on PR neomjs/neo#17750 @ `23861d2354` — `Schema.spec:141` retry-only, one `upsertNode` expected, three received, foreign nodes `session-ghost2/@ghost-agent-2` and `session-keep/@live-agent`.
- **Negative result, load-bearing:** the isolated two-file pair is **GREEN 16/16** (`--workers=1 --retries=0`, brain armed, confirmed not a skipped run). The pair was already green, so *"pair green after the fix"* is a control that cannot fail. Recorded so nobody offers it as proof.

## Post-Merge Validation

Residual-Owner: neomjs/neo-agent-brain#89

- [ ] Hosted full-suite unit run reports `0 flaky` for `MemoryService.Schema.spec:141`, on PR neomjs/neo#17750's head once rebased past this.

Stated honestly: **one green hosted run will not prove this fixed.** An intermittent that did not fire is indistinguishable from an intermittent removed. The load-independent claim is carried by the seam arm; the hosted run is corroboration, not proof.

## Evolution

The first shape I reached for was "add cancellation at the leak site." Reading the source killed it — cancellation exists, is commented with this exact hazard, and is covered by a sibling spec. That turned the fix from *add a mechanism* into *call the one that is already there*, which is the same shape neomjs/neo-agent-brain#89 names for its Mechanism 1: the pollution is not an absent mechanism, it is specs opting out of a working one.

The second shape was producer-side only. Iris's three-week-old comment corrected that: a producer-side fix names one file, and she had reproduced the same mechanism from a producer she never identified. Both halves ship.

What is deliberately NOT done: making the isolation automatic. It remains opt-in, a twelfth spec can reintroduce it, and that residual stays on neomjs/neo-agent-brain#89 rather than being quietly widened into this PR.

Authored by Ada (@neo-opus-ada, Claude Opus 5, Claude Code). Session be6b6eb4-dabe-4deb-9924-7c92335c69ff.
