### PR TITLE
fix(test): stop pinning an unsequenced race in the DEFERRED circuit arm (#17758)

### DIFF
--- a/learn/agentos/EmbeddingLane.md
+++ b/learn/agentos/EmbeddingLane.md
@@ -336,24 +336,6 @@ committed.
   the input format does not change any chunk id. Re-ingestion therefore re-embeds
   nothing. `parserVersion` **is** a hash input, which makes it the only mechanism
   that re-mints ids today, and nothing schedules it.
-- **A caller's abort does not order itself against the drain, so "the queued item
-  will not be dispatched" is not a lane guarantee.** When a caller aborts from
-  *inside* the provider-timeout notification — the shape a circuit-open takes,
-  where the hook defers the abort rather than raising synchronously — two
-  macrotasks become live at once after the in-flight request rejects: the queue
-  removing the waiting item, and the drain selecting and dispatching it. Both are
-  scheduled by the lane itself, so no caller-side `await` sequences them, and
-  either can win. The consequence is the one that matters for a reader:
-  **a span may still reach a provider that has just proved unresponsive**, and
-  code (or a test) that assumes otherwise is asserting a race rather than a
-  contract. Distinct from the native-Ollama case, where the abort lands *after*
-  dispatch and the concern is that server-side work outlives it — that one is
-  about work already sent, this one about whether it is sent at all. The
-  synchronous-abort path in the same queue is ordered and does hold the
-  guarantee; only the deferred path is open. Measured while repairing the arm in
-  `test/playwright/unit/ai/services/memory-core/TextEmbeddingService.retry.spec.mjs`
-  that pinned the winner: it failed roughly a third of isolated runs, and its own
-  scope note already recorded that the fixture could not sequence the two.
 
 ## Related
 

--- a/learn/agentos/EmbeddingLane.md
+++ b/learn/agentos/EmbeddingLane.md
@@ -336,6 +336,24 @@ committed.
   the input format does not change any chunk id. Re-ingestion therefore re-embeds
   nothing. `parserVersion` **is** a hash input, which makes it the only mechanism
   that re-mints ids today, and nothing schedules it.
+- **A caller's abort does not order itself against the drain, so "the queued item
+  will not be dispatched" is not a lane guarantee.** When a caller aborts from
+  *inside* the provider-timeout notification — the shape a circuit-open takes,
+  where the hook defers the abort rather than raising synchronously — two
+  macrotasks become live at once after the in-flight request rejects: the queue
+  removing the waiting item, and the drain selecting and dispatching it. Both are
+  scheduled by the lane itself, so no caller-side `await` sequences them, and
+  either can win. The consequence is the one that matters for a reader:
+  **a span may still reach a provider that has just proved unresponsive**, and
+  code (or a test) that assumes otherwise is asserting a race rather than a
+  contract. Distinct from the native-Ollama case, where the abort lands *after*
+  dispatch and the concern is that server-side work outlives it — that one is
+  about work already sent, this one about whether it is sent at all. The
+  synchronous-abort path in the same queue is ordered and does hold the
+  guarantee; only the deferred path is open. Measured while repairing the arm in
+  `test/playwright/unit/ai/services/memory-core/TextEmbeddingService.retry.spec.mjs`
+  that pinned the winner: it failed roughly a third of isolated runs, and its own
+  scope note already recorded that the fixture could not sequence the two.
 
 ## Related
 

--- a/test/playwright/unit/ai/services/memory-core/TextEmbeddingService.retry.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/TextEmbeddingService.retry.spec.mjs
@@ -1281,11 +1281,27 @@ test.describe.serial('TextEmbeddingService #11393/#11402/#12487/#12509 — openA
             signal: controller.signal
         }).then(() => null, error => error);
 
-        await new Promise(resolve => setTimeout(resolve, 50));
-        await Promise.all([repoA, repoB]);
+        const [, errorB] = await Promise.all([repoA, repoB]);
 
         expect(hookCalls.length, 'the deferred hook still received the timeout').toBeGreaterThanOrEqual(1);
-        expect(requestCount, 'queue-level abort removal alone keeps B at zero calls here').toBe(1);
+
+        // Deliberately NOT `expect(requestCount).toBe(1)`.
+        //
+        // Deferring the abort to a macrotask puts two macrotasks in an unordered race after A's
+        // timeout rejects: the drain selecting and dispatching B, and the queued abort removing it.
+        // Nothing this fixture can await sequences them — which is exactly what the scope note above
+        // says, so pinning the winner here asserted the property that paragraph disclaims. It sampled
+        // a coin flip: ~37% of ISOLATED runs saw B dispatch (6 of 16), and the fixed sleep this
+        // replaces only shifted the odds rather than ordering anything.
+        //
+        // Nothing is uncovered by dropping it. The non-deferred sibling directly above still pins
+        // `requestCount` to 1 — that path IS sequenced — and the deferred ordering guarantee is
+        // exercised in production composition by
+        // `daemons/orchestrator/services/TenantRepoSyncService.spec.mjs` (the run-scoped circuit
+        // sweep). What this arm still owns is the fixture-controlled half: the deferred hook fires,
+        // and the queued repository fails rather than silently succeeding — true whether or not B
+        // reached the provider.
+        expect(errorB, 'the queued repository fails, rather than silently succeeding').toBeTruthy();
     });
 
     test('a mid-batch provider failure carries the completed prefix on the ORIGINAL error (#17112)', async () => {


### PR DESCRIPTION
Resolves neomjs/neo#17758

Refs neomjs/neo-agent-brain#46

`TextEmbeddingService.retry.spec.mjs:1248` — *"the queued repository stays protected even when the circuit-open is DEFERRED"* — failed **~37% of the time in complete isolation** (6 of 16 isolated runs, same assertion every time: `requestCount` expected 1, received 2). Not pollution, not order-dependent — the spec alone, nothing else in the run.

Evidence: L2 (25 consecutive isolated runs plus a mutation control on the surviving assertion) → L2 required (the close-target ACs are all run-observable). No residuals.

## AC Evidence

| Acceptance criterion | Evidence |
|---|---|
| AC-1 | **25/25 consecutive isolated runs clean** with `--retries=0`, against 6/16 failing before. The rate is ~37%, so a single green would have been meaningless — the run count is the evidence. |
| AC-2 | The surviving assertions are fixture-controlled: the deferred hook fires, and the queued repository fails rather than silently succeeding. Neither depends on which macrotask wins. The unsequenced `requestCount` pin is gone, and the fixed 50 ms sleep with it. |
| AC-3 | The replacement comment records that `daemons/orchestrator/services/TenantRepoSyncService.spec.mjs` owns the deferred ordering proof, so the coverage is not read as lost. |
| AC-4 | `memory-core/` serial: **1883 passed**. Full serial unit run receipt added as a comment below when it completes (~15 min). |

## The mechanism

Deferring the abort to a macrotask (`setTimeout(() => controller.abort(circuitError), 0)`) puts two macrotasks in an **unordered race** after A's 400 ms timeout rejects: the drain selecting and dispatching B, and the queued abort removing it. Nothing the fixture can `await` sequences those two — the `await new Promise(resolve => setTimeout(resolve, 50))` it used runs *before* A's timeout even fires, so it only shifted the odds.

The arm's own scope note already said this:

> *"this fixture CANNOT exercise the ordering guarantee. That is a property of the fixture, not of the lane: the tenant-sync production composition in `TenantRepoSyncService.spec.mjs` DOES exercise it."*

`expect(requestCount).toBe(1)` therefore asserted precisely the property the paragraph directly above it disclaims.

## Why no coverage is lost

- The **non-deferred sibling** immediately above still pins `requestCount` to 1 — that path *is* sequenced, and it is stable across every run I made.
- The **deferred** ordering guarantee is exercised in production composition at `TenantRepoSyncService.spec.mjs:3288-3372` (run-scoped circuit sweep, `KB_VECTOR_EMBED_PROVIDER_CIRCUIT_OPEN`). Verified, not taken from the comment.

## Deltas from ticket

The ticket left the fix shape open between "sequence it deterministically" and "narrow to the fixture's documented scope". Option 1 is not available: both racing steps are macrotasks scheduled by the code under test, so no external await orders them. Option 2 taken.

## Test Evidence

- **Before:** 6 failures in 16 isolated runs (10-run batch → 5 failures; 6-run batch → 1), identical assertion and values each time.
- **After:** 25/25 isolated runs clean.
- **Mutation control:** inverting the surviving assertion to `toBeFalsy()` turns it red (`1 failed`), so it is not vacuous — it still catches a queued repository that silently *succeeds*, which is the defect the sibling arm names.
- `memory-core/` directory, serial, `--retries=0`: 1883 passed.

## Post-Merge Validation

None — the close-target effects are all observable in the unit suite.

## Why this was urgent

PR neomjs/neo#17750 merged at 09:49Z and set `failOnFlakyTests: isCI`. CI runs `workers: 4, retries: 2`, so a ~37% per-attempt flake fails once and passes on retry — exactly the outcome that gate converts into a red run. The flake was not new; its consequence was. This is the gate working correctly on its first real subject, not a defect in neomjs/neo#17750.

## Evolution

I first recorded this arm on neomjs/neo-agent-brain#46 as a fresh order-dependent pollution witness, on the strength of "passes alone, 54/54". That was two samples of a coin flip — at a 37% rate, two consecutive passes happen roughly 40% of the time by luck. [Retracted there](https://github.com/neomjs/neo-agent-brain/issues/46#issuecomment-5411107259); neomjs/neo-agent-brain#46 is back to no live witness. The lesson that produced this PR is that an isolation control needs a repetition count chosen against the suspected rate, not a single clean run.

Authored by Ada (@neo-opus-ada, Claude Opus 5, Claude Code). Session be6b6eb4-dabe-4deb-9924-7c92335c69ff.
