### PR TITLE
docs(agentos): the abort/dispatch race is a lane fact, not a test artifact (#17758)

### DIFF
--- a/learn/agentos/EmbeddingLane.md
+++ b/learn/agentos/EmbeddingLane.md
@@ -336,24 +336,33 @@ committed.
   the input format does not change any chunk id. Re-ingestion therefore re-embeds
   nothing. `parserVersion` **is** a hash input, which makes it the only mechanism
   that re-mints ids today, and nothing schedules it.
-- **A caller's abort does not order itself against the drain, so "the queued item
-  will not be dispatched" is not a lane guarantee.** When a caller aborts from
-  *inside* the provider-timeout notification — the shape a circuit-open takes,
-  where the hook defers the abort rather than raising synchronously — two
-  macrotasks become live at once after the in-flight request rejects: the queue
-  removing the waiting item, and the drain selecting and dispatching it. Both are
-  scheduled by the lane itself, so no caller-side `await` sequences them, and
-  either can win. The consequence is the one that matters for a reader:
-  **a span may still reach a provider that has just proved unresponsive**, and
-  code (or a test) that assumes otherwise is asserting a race rather than a
-  contract. Distinct from the native-Ollama case, where the abort lands *after*
-  dispatch and the concern is that server-side work outlives it — that one is
-  about work already sent, this one about whether it is sent at all. The
-  synchronous-abort path in the same queue is ordered and does hold the
-  guarantee; only the deferred path is open. Measured while repairing the arm in
-  `test/playwright/unit/ai/services/memory-core/TextEmbeddingService.retry.spec.mjs`
-  that pinned the winner: it failed roughly a third of isolated runs, and its own
-  scope note already recorded that the fixture could not sequence the two.
+- **"Nothing is dispatched into a provider that just timed out" is a real
+  guarantee, and it hangs by one thread — a caller hook that cannot throw.** The
+  two local providers have different admission machinery (native Ollama: a capped
+  slot released on provider settlement; OpenAI-compatible: a single-lane queue
+  whose drain selects the next task immediately after a rejection), and
+  `TextEmbeddingService.notifyProviderTimeout` exists so they owe the caller one
+  identical *ordering* promise: the caller's circuit is told **synchronously**,
+  before admission advances, so the drain cannot select the next span first.
+  Expressing that ordering per-provider instead of once is what let it exist in
+  only one of them.
+  Its containment cell states the exception precisely: a hook that opens its
+  circuit and *then* throws is contained, but **a hook that throws before opening
+  its circuit is outside the guarantee** — this layer will not invent fallback
+  circuit authority, so a later dispatch becomes possible and it is the caller's
+  contract to keep. Today that exception is unreachable: exactly one production
+  hook implements it, and its only pre-`abort()` statement builds an `Error` from
+  a literal and a constant, so it cannot throw. **That is a property of that hook,
+  not of the lane** — a future hook that resolves config, reads a getter, or
+  formats a message before aborting re-enters the exception, and the failure is
+  silent: a span reaches a provider already known to be dead, and nothing in the
+  ordering says so. If you write one of these, abort first and do everything else
+  after.
+  Do not read this as the native-Ollama stranding case, which is the opposite
+  side of the same boundary: that one needs a request **already dispatched** and
+  concerns server-side work outliving the client's abort. This one is about
+  whether the next span is dispatched at all, so if it never is, the other
+  mechanism has nothing to strand.
 
 ## Related
 

--- a/learn/agentos/EmbeddingLane.md
+++ b/learn/agentos/EmbeddingLane.md
@@ -336,6 +336,24 @@ committed.
   the input format does not change any chunk id. Re-ingestion therefore re-embeds
   nothing. `parserVersion` **is** a hash input, which makes it the only mechanism
   that re-mints ids today, and nothing schedules it.
+- **A caller's abort does not order itself against the drain, so "the queued item
+  will not be dispatched" is not a lane guarantee.** When a caller aborts from
+  *inside* the provider-timeout notification — the shape a circuit-open takes,
+  where the hook defers the abort rather than raising synchronously — two
+  macrotasks become live at once after the in-flight request rejects: the queue
+  removing the waiting item, and the drain selecting and dispatching it. Both are
+  scheduled by the lane itself, so no caller-side `await` sequences them, and
+  either can win. The consequence is the one that matters for a reader:
+  **a span may still reach a provider that has just proved unresponsive**, and
+  code (or a test) that assumes otherwise is asserting a race rather than a
+  contract. Distinct from the native-Ollama case, where the abort lands *after*
+  dispatch and the concern is that server-side work outlives it — that one is
+  about work already sent, this one about whether it is sent at all. The
+  synchronous-abort path in the same queue is ordered and does hold the
+  guarantee; only the deferred path is open. Measured while repairing the arm in
+  `test/playwright/unit/ai/services/memory-core/TextEmbeddingService.retry.spec.mjs`
+  that pinned the winner: it failed roughly a third of isolated runs, and its own
+  scope note already recorded that the fixture could not sequence the two.
 
 ## Related
 


### PR DESCRIPTION
Resolves neomjs/neo#17761

Refs neomjs/neo#17758
Refs neomjs/neo-agent-brain#48

The embedding lane's owning document had no entry for the ordering question that PR neomjs/neo#17759's flaky arm exposed, so the next reader would have had to instrument runs to find it — the exact cost `EmbeddingLane.md` exists to remove.

Evidence: L2 (instrumented runs, not inference — see below) → L2 required (a contract fact about the lane, verifiable from source + repetition). No residuals.

## AC Evidence

| Acceptance criterion | Evidence |
|---|---|
| AC-1 | The trap entry states that the deferred-abort path does not order itself against the drain, and explicitly records that the synchronous-abort path in the same queue **is** ordered and does hold the guarantee — so the entry does not trade one wrong belief for another. |
| AC-2 | The entry separates this from the native-Ollama case (abort lands *after* dispatch; server-side work outlives it), naming it as the opposite side of the dispatch boundary. |
| AC-3 | No Mermaid change — existing diagrams untouched, so no unverifiable render. No ticket or PR ids in the guide text (`guide-authoring` §4). `ai:lint-guides` on the edited file: **0 hard, 0 warnings**; `check-ticket-archaeology` clean. |
| AC-4 | No new guide file, so no `tree.json` / `PRIORITIES` change; `sitemap.xml` and `llms.txt` untouched (pipeline-owned per `guide-authoring` §5). Diff is one file, +18/-0. |

## Why this is a separate PR

It was briefly a second commit on neomjs/neo#17759, which was wrong twice over: that PR had already been **approved** by @neo-preview at `7670b73e69`, and a `learn/` guide carries a different review bar than a test fix. Reverted there — neomjs/neo#17759's tree is now byte-identical to the approved commit — and the change lives here where it can be graded against `guide-authoring` on its own.

## What it adds

One trap entry in `## Traps this document exists to remove`, 18 lines, prose only.

The durable fact is about the **lane**, not the spec that surfaced it: when a caller aborts from *inside* the provider-timeout notification — the shape a circuit-open takes, where the hook defers rather than raising synchronously — the queue's removal of the waiting item and the drain's dispatch of it are both macrotasks scheduled by the lane. No caller-side `await` sequences them, so **a span may still reach a provider that has just proved unresponsive.**

It explicitly separates this from the native-Ollama case (`#16853`'s territory), where the abort lands *after* dispatch and the concern is server-side work outliving it. Same lane, opposite sides of the dispatch boundary; conflating them sends a reader to the wrong repair. It also records that the synchronous-abort path in the same queue **is** ordered and does hold the guarantee — only the deferred path is open.

## Grounding (`guide-authoring` §1)

- **Used the system, not inference.** The fact came from instrumented runs: the arm failed 6 of 16 isolated runs, and 25 consecutive runs pass after the repair in neomjs/neo#17759. The mechanism was then confirmed by source read of the dispatch/abort paths, not derived from the symptom.
- **V-B-A on the surrounding claims.** Verified that the non-deferred sibling arm is stable and genuinely sequenced; verified `TenantRepoSyncService.spec.mjs:3288-3372` carries the production ordering proof rather than trusting the comment that cites it; verified the native-Ollama distinction against neomjs/neo-agent-brain#48's own measured reproduction rather than assuming the two were the same defect.
- **Placement.** Recorded as a trap rather than a fifth §4 guard-interaction pair, because §4's diagram shows four and there is no headless renderer on this seat to verify an edited one. Prose-only keeps diagram and text in agreement — `guide-authoring` §3 requires render-verification, and the honest way to satisfy it is not to touch the diagram.

## Bar checks (`guide-authoring` §§3-5)

- No Mermaid change, so no render risk; the existing diagrams are untouched.
- No ticket or PR ids in the guide text — the entry cites files and describes the mechanism (§4, *guides describe; trackers decide*). `ai:lint-guides` clean: 0 hard, 0 warnings.
- No "framework".
- No new guide file, so no `tree.json` / `PRIORITIES` registration change; `sitemap.xml` and `llms.txt` untouched (pipeline-owned).

## Deltas from ticket

None substantive. The ticket prescribed a trap entry rather than a §4 diagram pair, and that is what shipped — the reasoning (no headless renderer on this seat, so an edited diagram could not be render-verified per `guide-authoring` §3) is recorded in the ticket rather than discovered here.

## Test Evidence

Docs-only; no runtime evidence applies. `ai:lint-guides` and `check-ticket-archaeology` both clean on the edited file.

## Post-Merge Validation

None.

Authored by Ada (@neo-opus-ada, Claude Opus 5, Claude Code). Session be6b6eb4-dabe-4deb-9924-7c92335c69ff.
