### PR TITLE
fix(vdom): apply merged children's update depth at the dispatch site (#17589)

### DIFF
--- a/src/mixin/VdomLifecycle.mjs
+++ b/src/mixin/VdomLifecycle.mjs
@@ -1027,12 +1027,17 @@ class VdomLifecycle extends Base {
                     && !me.isChildUpdating(resolve)
                     && vnode
                 ) {
-                    // Check for merged child updates and adjust the update depth accordingly
-                    // let adjustedDepth = VDomUpdate.getAdjustedUpdateDepth(me.id);
-                    //
-                    // if (adjustedDepth !== null) {
-                    //     me.updateDepth = adjustedDepth;
-                    // }
+                    // Absorb the depth that merged children asked for before dispatching.
+                    // executeVdomUpdate() records this owner's updateDepth into `depths`, and the
+                    // collision filter deletes a merged child's own payload whenever this owner
+                    // claims to cover it. That claim only holds once the children's requirements
+                    // are folded in here, so a child which merged with updateDepth: -1 keeps its
+                    // subtree instead of being pruned by an owner that stopped short of it.
+                    let adjustedDepth = VDomUpdate.getAdjustedUpdateDepth(me.id);
+
+                    if (adjustedDepth !== null) {
+                        me.updateDepth = adjustedDepth
+                    }
 
                     // Verify that the critical rendering path => CSS files for the new tree is in place.
                     // Call-time `Neo.currentWorker` resolution, one read per invocation — the

--- a/test/playwright/unit/vdom/AsymmetricUpdates.spec.mjs
+++ b/test/playwright/unit/vdom/AsymmetricUpdates.spec.mjs
@@ -40,6 +40,13 @@ const createMockComponent = (id, parentId, vdom) => {
     return component;
 };
 
+/**
+ * These arms certify the arithmetic of `VDomUpdate.getAdjustedUpdateDepth()` and its composition with
+ * `TreeBuilder`, by calling both directly against mock components. They deliberately do NOT cover the
+ * wiring: nothing here asserts that anything in production ever applies the adjusted depth, so they
+ * stay green whether or not the dispatch site calls it. `MergedUpdateDepth.spec.mjs` owns that half,
+ * driving `update()` -> `updateVdom()` -> `executeVdomUpdate()` and reading the resulting deltas.
+ */
 test.describe('Neo.vdom.VdomAsymmetricUpdates', () => {
     test.beforeEach(() => {
         VDomUpdate.mergedCallbackMap.clear();

--- a/test/playwright/unit/vdom/MergedUpdateDepth.spec.mjs
+++ b/test/playwright/unit/vdom/MergedUpdateDepth.spec.mjs
@@ -1,0 +1,246 @@
+import {setup} from '../../setup.mjs';
+
+const appName = 'MergedUpdateDepthTest';
+
+setup({
+    neoConfig: {
+        allowVdomUpdatesInTests: true,
+        useDomApiRenderer      : true,
+        useVdomWorker          : false
+    },
+    appConfig: {
+        name: appName
+    }
+});
+
+import {test, expect}     from '@playwright/test';
+import Neo                from '../../../../src/Neo.mjs';
+import * as core          from '../../../../src/core/_export.mjs';
+import Component          from '../../../../src/component/Base.mjs';
+import Container          from '../../../../src/container/Base.mjs';
+import VdomHelper         from '../../../../src/vdom/Helper.mjs';
+import DomApiVnodeCreator from '../../../../src/vdom/util/DomApiVnodeCreator.mjs';
+
+// Mock applyDeltas to prevent errors during mount
+const realApplyDeltas = Neo.applyDeltas; // patched at import; restored in afterAll below
+
+Neo.applyDeltas = async () => {};
+
+test.afterAll(() => {
+    Neo.applyDeltas = realApplyDeltas;
+});
+
+class MockComponent extends Component {
+    static config = {
+        className: 'Test.MergedDepthComponent',
+        ntype    : 'test-merged-depth-component',
+        _vdom    : {tag: 'div', cls: ['leaf-component']}
+    }
+}
+MockComponent = Neo.setupClass(MockComponent);
+
+class MockContainer extends Container {
+    static config = {
+        className: 'Test.MergedDepthContainer',
+        ntype    : 'test-merged-depth-container',
+        _vdom    : {tag: 'div', cls: ['branch-container']}
+    }
+}
+MockContainer = Neo.setupClass(MockContainer);
+
+/**
+ * A merged child registers the depth its own subtree needs, but the owner dispatches the batch.
+ * `collectPayloads()` reads `owner.updateDepth` into `depths`, and the collision filter then trusts
+ * that value as a *coverage claim* when it deletes the child's own payload as "covered by the parent".
+ * `VDomUpdate.getAdjustedUpdateDepth()` is what makes the claim true; while its call site is disabled
+ * the filter deletes a payload nothing replaced, and the child's subtree is silently dropped.
+ *
+ * Every arm drives the real dispatch path (`update()` -> `updateVdom()` -> `executeVdomUpdate()`) and
+ * reads the resulting deltas, because a direct call to `getAdjustedUpdateDepth()` cannot witness a
+ * dead call site.
+ */
+test.describe('Merged child update depth', () => {
+    let container, testRun = 0;
+
+    test.beforeEach(() => {
+        testRun++
+    });
+
+    test.afterEach(() => {
+        if (container) {
+            container.destroy();
+            container = null
+        }
+    });
+
+    /**
+     * Builds owner -> branch -> twig -> leaf, so the leaf sits at distance 3 from the owner: beyond a
+     * finite owner depth of 2, but inside `branch`'s full-subtree (-1) scope.
+     *
+     * The warm-up flush is load-bearing. Mounting leaves every component at `updateDepth: -1`, and
+     * `beforeSetUpdateDepth()` only ever widens (`oldValue === -1 || value === -1 ? -1 : ...`), so a
+     * later assignment of 2 would be silently clamped back to -1 and the arm would test an owner that
+     * already requested the whole tree. `getVdomUpdatePayload()` resets `_updateDepth` to the class
+     * default after each payload build, so one flush per component is what makes a finite depth
+     * reachable at all.
+     */
+    async function createTree() {
+        container = Neo.create(MockContainer, {
+            appName,
+            id   : `owner-${testRun}`,
+            items: [{
+                module: MockContainer,
+                id    : `branch-${testRun}`,
+                items : [{
+                    module: MockContainer,
+                    id    : `twig-${testRun}`,
+                    items : [{
+                        module: MockComponent,
+                        id    : `leaf-${testRun}`,
+                        text  : 'Leaf'
+                    }]
+                }]
+            }]
+        });
+
+        await container.initVnode(true);
+        container.mounted = true;
+
+        const branch = container.items[0],
+              twig   = branch.items[0],
+              leaf   = twig.items[0];
+
+        await container.promiseUpdate();
+        await branch.promiseUpdate();
+
+        expect(container.updateDepth, 'the warm-up returned the owner to a finite depth').toBe(1);
+        expect(branch.updateDepth,    'the warm-up returned the branch to a finite depth').toBe(1);
+
+        return {branch, twig, leaf}
+    }
+
+    /**
+     * Captures the batch handed to the VDOM worker, so an arm can assert on reach (which nodes were
+     * expanded) rather than only on the resulting deltas.
+     */
+    function captureBatch() {
+        const captured = {},
+              original = VdomHelper.updateBatch.bind(VdomHelper);
+
+        VdomHelper.updateBatch = async function(data) {
+            captured.updates = data.updates;
+            return original(data)
+        };
+
+        captured.restore = () => {
+            VdomHelper.updateBatch = original
+        };
+
+        return captured
+    }
+
+    /**
+     * Positive control for the oracle the two arms below rely on.
+     *
+     * Without it, "no delta for the leaf" would be indistinguishable from "this fixture never produces
+     * a leaf delta at all" -- an absence that reads exactly like a finding. An owner that declares the
+     * full subtree itself must carry the leaf, fixed or not.
+     */
+    test('control: an owner declaring -1 carries a distance-3 leaf', async () => {
+        const {leaf} = await createTree();
+
+        container.setSilent({style: {color: 'purple'}});
+        container.updateDepth = -1;
+
+        leaf.vdom.text = 'Leaf Updated';
+
+        const {deltas}  = await container.promiseUpdate();
+        const leafDelta = deltas.find(d => d.id === leaf.id);
+
+        expect(leafDelta, 'the oracle can observe a distance-3 leaf delta').toBeTruthy();
+        expect(leafDelta.textContent).toBe('Leaf Updated')
+    });
+
+    /**
+     * The regression. `branch` merges into the owner's cycle carrying `updateDepth: -1` -- the shape
+     * `grid.Body` dispatches, where cells are mutated in place and the whole subtree is re-serialised
+     * with no per-cell dirty registration to fall back on.
+     *
+     * The owner stays at its finite depth 2, so its tree prunes at the twig, while the collision filter
+     * deletes `branch`'s own -1 payload as covered. Nothing carries the leaf.
+     */
+    test('a merged child registering -1 widens the owner past its finite depth', async () => {
+        const {branch, twig, leaf} = await createTree();
+
+        // The owner has a pending update, so `branch` merges into it rather than dispatching alone.
+        container.setSilent({style: {color: 'purple'}});
+        container.updateDepth = 2;
+
+        // Mutated in place, deliberately without registering the leaf itself: the -1 below is the only
+        // thing promising to carry it.
+        leaf.vdom.text = 'Leaf Updated';
+
+        branch.updateDepth = -1;
+        branch.update();
+
+        const batch = captureBatch();
+
+        let deltas;
+
+        try {
+            ({deltas} = await container.promiseUpdate())
+        } finally {
+            batch.restore()
+        }
+
+        const twigNode = batch.updates[container.id]?.vdom.cn[0].cn[0];
+
+        expect(twigNode?.tag, 'the merged -1 expands the twig instead of pruning it').toBeDefined();
+
+        const leafDelta = deltas.find(d => d.id === leaf.id);
+
+        expect(leafDelta, 'the merged -1 subtree reaches the leaf the owner\'s depth 2 cannot').toBeTruthy();
+        expect(leafDelta.textContent).toBe('Leaf Updated');
+
+        // The branch payload is deleted as "covered by the parent"; that is only sound once the
+        // owner's depth actually covers it.
+        expect(batch.updates[branch.id], 'the branch payload is covered by the owner').toBeUndefined()
+    });
+
+    /**
+     * The no-op companion, and the discriminating control the oracle has to pass: a bound that
+     * genuinely cannot reach the leaf must leave it absent. `branch` asks for depth 1, so the adjusted
+     * depth is `max(2, 1 + 1)` -- unchanged. Restoring the compensation must not widen finite depths,
+     * and must not turn every merge into a full-tree update.
+     */
+    test('a merged child registering a finite depth leaves the owner depth unchanged', async () => {
+        const {branch, twig, leaf} = await createTree();
+
+        container.setSilent({style: {color: 'green'}});
+        container.updateDepth = 2;
+
+        leaf.vdom.text = 'Leaf Updated';
+
+        branch.updateDepth = 1;
+        branch.update();
+
+        const batch = captureBatch();
+
+        let deltas;
+
+        try {
+            ({deltas} = await container.promiseUpdate())
+        } finally {
+            batch.restore()
+        }
+
+        const twigNode = batch.updates[container.id]?.vdom.cn[0].cn[0];
+
+        expect(twigNode?.componentId, 'the owner still prunes at the twig').toBe(twig.id);
+        expect(twigNode?.tag,         'the owner was not widened to a full-tree update').toBeUndefined();
+
+        const leafDelta = deltas.find(d => d.id === leaf.id);
+
+        expect(leafDelta, 'nothing in this batch declared a scope reaching the leaf').toBeFalsy()
+    })
+});


### PR DESCRIPTION
## Context

`VDomUpdate.getAdjustedUpdateDepth()` widens an owner's update depth to cover every child that merged into its cycle, poisoning to `-1` when any child needs a full subtree. Its dispatch-site call was commented out on 2026-01-20 in `9e2a82ee57` (a WIP batching commit that shipped the allowlist half and disabled the depth half). Seven months, no design record, and the function's only live callers were four assertions that invoke it directly — so it stayed green while nothing in production applied its answer.

This restores the call and adds the dispatch-path coverage that would have caught its removal.

Evidence: `MergedUpdateDepth.spec.mjs:172` is red on unmodified `dev` at `fd742cdd71` and green after the fix; full unit suite 15192 passed, with 12 pre-existing `[unit-brain]` reds carrying a named cause and a base-commit control (both below).

## The mechanism, corrected

The ticket attributed the loss to `TreeBuilder` pruning alone. Measured, it needs **both** halves, and neither is sufficient on its own:

1. The owner's tree prunes at its own finite depth, so the merged child's subtree is not expanded.
2. `executeVdomUpdate()`'s collision filter then **deletes the merged child's own payload** as "covered by the parent" — `parentDepth > distance` — and that payload was the thing that would have carried the subtree.

The compensation is what makes the coverage claim in step 2 true. Without it the filter deletes a payload nothing replaced. Probe on `dev`, owner at depth 2 with a child that merged at `-1`:

```
after merge   {"ownerDepth":2,"adjusted":-1,"mergedChildren":["p-branch"]}
batch keys    ["p-owner"]                        <- branch payload deleted
owner payload ... "cn":[{"componentId":"p-twig","neoIgnore":true}]   <- pruned at distance 2
deltas        [{"style":{"color":"green"},"id":"p-owner"}]            <- p-leaf's text change is GONE
```

`canMergeUpdate()` returns `true` unconditionally, so the merge is never refused on depth grounds — sound only if the compensation runs.

`grid/Body.mjs:832` (`me.updateDepth = -1; me.update()`) is the production registrant this protects.

## A finding that changes the fixture contract

`beforeSetUpdateDepth()` (`src/component/Base.mjs:1104`) only ever **widens**:

```js
return oldValue === -1 || value === -1 ? -1 : Math.max(value, oldValue)
```

Mounting leaves components at `-1`, so a spec that assigns `updateDepth = 2` after mount is silently clamped back to `-1` and ends up testing an owner that already requested the whole tree. My first fixture did exactly that and was green in all three arms for a reason unrelated to merged depth. `getVdomUpdatePayload()` resets `_updateDepth` to the class default after each payload build, so a warm-up flush is the only way to reach a finite depth. This is documented on `createTree()` because the next author will hit it.

## AC Evidence

| AC | Proof |
|---|---|
| AC-1 | `src/mixin/VdomLifecycle.mjs:1030-1040` — `getAdjustedUpdateDepth(me.id)` is applied before the payload is built, and the commented-out block is replaced rather than left beside the live call. |
| AC-2 | `MergedUpdateDepth.spec.mjs:172` drives `update()` -> `updateVdom()` -> `executeVdomUpdate()` and reads deltas. **Red on unmodified `dev` at `fd742cdd71`** (`git diff --stat src/` empty) at `expect(twigNode?.tag).toBeDefined()`; green after the fix. Both runs under Test Evidence. |
| AC-3 | `MergedUpdateDepth.spec.mjs:216` — a child merging at depth 1 leaves `max(2, 1+1) = 2` unchanged; asserts the twig is still a pruned placeholder (`componentId` set, `tag` undefined) and the leaf stays absent. Green **before and after**, so the fix cannot silently widen every merged update into a full-tree update. |
| AC-4 | Satisfied by the AC's own "*or an added sibling does*": `MergedUpdateDepth.spec.mjs` is that sibling. The four direct-call arms keep their value as unit coverage of the manager's arithmetic; `AsymmetricUpdates.spec.mjs:43` now carries a describe-level docblock stating they deliberately do not cover the wiring and naming where that half lives, so the false-coverage reading is not re-derived. |
| AC-5 | Payload table below, measured on a 122-component `grid.Body`-shaped tree — not asserted. |

## Payload size

Measured on a `grid.Body`-shaped tree (owner -> body -> 20 rows x 5 cells = 122 components), one cell's text changed, bytes of the batch handed to the VDOM worker:

| owner reach | bytes | carries the change |
|---|---|---|
| depth 2 (pre-fix) | 2,893 | **no** |
| `-1` (post-fix) | 32,206 | yes |
| finite depth 4 (tightest bound that reaches the cell) | 32,206 | yes |

The 11.1x is against a payload that was cheap **because it was wrong**. Against the tightest *correct* alternative the fix costs **1.00x** — depth is a uniform radius, not a path, so any bound reaching distance-3 cells expands all 20 rows. So `-1` poisoning carries no payload penalty over a correct finite bound here, and the sparse saving that remains comes from the `mergedChildIds` allowlist, not the depth term.

Scope of that claim: measured for this shape, and it is the shape #17427 is about. Per the ticket's Probe A the compensation is inert for finite registrants, so no other case changes.

## Test Evidence

- `test/playwright/unit/vdom/MergedUpdateDepth.spec.mjs` — 3 arms.
  - On unmodified `dev` (`fd742cdd71`): **1 failed, 2 passed**. The failure is arm 2, at `expect(twigNode?.tag).toBeDefined()` — the twig pruned.
  - With the fix: **3 passed**.
- Both controls are load-bearing and both pass on `dev`: the positive control (an owner declaring `-1` itself) proves the oracle can observe a distance-3 leaf delta at all, and arm 3 proves it goes to "absent" when the bound genuinely cannot reach. Without the first, "no leaf delta" would be indistinguishable from a fixture that never produces one.
- `test/playwright/unit/vdom/` — **159 passed**, 0 failed.
- Full unit suite (`--workers=1 --retries=0`) — **15192 passed, 12 failed, 11 skipped (12.7m)**. All 12 reds are `[unit-brain]`, all under `ai/`, none in `vdom/` or anywhere this diff reaches — and they are **not mine, with a named cause and a control**:

  ```
  authorityLeaseBoot.spec.mjs:25                  (1 arm)
  HostEdgePosture.spec.mjs:303,311                (2, one of them a POSITIVE CONTROL)
  genesisProbe.spec.mjs:567                       (1)
  scriptPlaneClosure.spec.mjs:887,899,917,978     (4)
  hostBarrelRuntimeReach.spec.mjs:105,121,170     (3, one of them a CONTROL)
  HealthService.providerReady.spec.mjs:741        (1)
  ```

  That three of them are *control* arms is the tell: controls fail when the harness cannot reach the code under test. Cause, from the subprocess stderr rather than inferred:

  ```
  Error [ERR_MODULE_NOT_FOUND]: Cannot find module '<worktree>/ai/config.mjs'
    imported from '<worktree>/ai/daemons/orchestrator/daemon.mjs'
  ```

  These arms `spawnSync` a real boot with `cwd: REPO_ROOT`, and `REPO_ROOT = process.cwd()` (`HostEdgePosture.spec.mjs:35`) is the **linked worktree**, which by design does not carry the gitignored operator overlay `ai/config.mjs` (ADR-0019 §2.1). The spawned process cannot resolve it, so the controls cannot reach the code under test — exactly what they exist to report.

  **Control:** a detached worktree at the same base commit `fd742cdd71`, zero modifications (`git status` clean), nothing else running, reproduces **all 12 — same specs, same line numbers**. So they are independent of this diff, and the one that worried me (`genesisProbe:567` binds a port, and I had run concurrent suites) fails there in isolation too, ruling out my own interference.

  CI runs from a full checkout and observes the real behaviour, so there is no unobserved residual here and nothing to file. I am not fabricating the overlay to make them green — its absence is the design.

## Deltas

- `src/mixin/VdomLifecycle.mjs` — restore the widening at the dispatch site; the comment states the invariant (the collision filter's coverage claim) rather than the incident.
- `test/playwright/unit/vdom/MergedUpdateDepth.spec.mjs` — new, 3 arms plus the warm-up contract.
- `test/playwright/unit/vdom/AsymmetricUpdates.spec.mjs` — describe-level docblock only; no assertion changed.

## Post-Merge Validation

- Watch `grid/` and `list/` suites on `dev`: `grid.Body` is the only production `-1` registrant today, so it is the only surface whose payloads change shape.
- The payload table above is the baseline for #17427's finite-bound work: if `Body.mjs:832` later computes a real bound, the correct comparison is against 32,206 bytes, not against the 2,893-byte broken payload.

Resolves #17589

Authored by ⚖️ **Ada** · `@neo-opus-ada` · Claude Opus 5 · Claude Code
