### PR TITLE
feat(build): the substrate guard measures the Claude load path (#17763)

### DIFF
--- a/.github/workflows/substrate-size-guard.yml
+++ b/.github/workflows/substrate-size-guard.yml
@@ -6,6 +6,11 @@ on:
     paths:
       - 'AGENTS.md'
       - '.agents/ANTIGRAVITY_RULES.md'
+      # The Claude entry point (#17175). It is a symlink to AGENTS.md today, so editing the CONTENT
+      # already triggers via the line above — but repointing the symlink, or replacing it with an
+      # @-import file, changes what the seat loads while touching neither watched path. That is the
+      # exact shape PR #17156 had, and it rode green because nothing watched this path.
+      - '.claude/CLAUDE.md'
       # Combined-budget members (#15257's pr-review loaded surface). A guard that does not RUN on the
       # edit it exists to catch is not a guard — the +135 B drift that put dev over its own gate was
       # a guide edit, and nothing was watching.
@@ -19,6 +24,11 @@ on:
     paths:
       - 'AGENTS.md'
       - '.agents/ANTIGRAVITY_RULES.md'
+      # The Claude entry point (#17175). It is a symlink to AGENTS.md today, so editing the CONTENT
+      # already triggers via the line above — but repointing the symlink, or replacing it with an
+      # @-import file, changes what the seat loads while touching neither watched path. That is the
+      # exact shape PR #17156 had, and it rode green because nothing watched this path.
+      - '.claude/CLAUDE.md'
       # Combined-budget members (#15257's pr-review loaded surface). A guard that does not RUN on the
       # edit it exists to catch is not a guard — the +135 B drift that put dev over its own gate was
       # a guide edit, and nothing was watching.

--- a/ai/scripts/diagnostics/check-substrate-size.mjs
+++ b/ai/scripts/diagnostics/check-substrate-size.mjs
@@ -13,11 +13,86 @@ const ROOT_DIR = path.resolve(process.cwd());
 // Per-file budget limit for Antigravity memory files (24 KiB hard limit).
 const PER_FILE_LIMIT_BYTES = 24576;
 
-// The surfaces that Antigravity injects globally on every turn.
+/**
+ * The per-turn entry points, each naming the harness that loads it and whose constant governs it.
+ *
+ * **The number's substrate is per-harness, and inheriting one harness's constant into another's
+ * contract is how correct-looking arithmetic governs the wrong seat.** `24576` is documented in-repo
+ * as ANTIGRAVITY's per-file hard limit. The Claude seat's own cap is an operator-stated constraint
+ * whose *semantics* — what it is measured over — remain unconfirmed, because the experiment that
+ * would settle them needs an authenticated seat and has not run. Until it does, the Claude row is
+ * checked against the inherited number and `limitConfirmed: false` says so out loud, so the next
+ * reader inherits a flagged assumption rather than a silent one.
+ *
+ * @member {Object[]} TARGET_FILES
+ */
 const TARGET_FILES = [
-    'AGENTS.md',
-    '.agents/ANTIGRAVITY_RULES.md'
+    {path: 'AGENTS.md',                    harness: 'Antigravity + Claude', limitConfirmed: true},
+    {path: '.agents/ANTIGRAVITY_RULES.md', harness: 'Antigravity',          limitConfirmed: true},
+    {path: '.claude/CLAUDE.md',            harness: 'Claude Code',          limitConfirmed: false}
 ];
+
+// A whole-line `@path` import in a CLAUDE.md. Claude Code resolves these relative to the importing
+// file and loads the target's CONTENT, so the importer's own byte count is not what the seat pays.
+const AT_IMPORT_PATTERN = /^@(\S+)\s*$/;
+
+/**
+ * @summary Returns the bytes a harness actually loads for an entry point, following BOTH indirections.
+ *
+ * A substrate entry point can reach its content two ways, and a near-miss once changed the file from
+ * one to the other: `.claude/CLAUDE.md` is a SYMLINK to `AGENTS.md` today, and a proposed change
+ * would have replaced it with a real file carrying `@`-imports. A check that reads only one form
+ * computes the wrong total — `lstat` on the symlink reports 12 bytes (the target path string), and
+ * `stat` on an import stub reports ~25 bytes, while the seat loads tens of kilobytes in both cases.
+ *
+ * Symlinks resolve through `realpathSync`, which also keys the cycle guard on file identity rather
+ * than on the path used to reach it. Imports recurse, because an imported file may import further.
+ *
+ * @param {String} file Repo-relative or absolute path to the entry point.
+ * @param {Set<String>} [seen] Realpaths already counted — cycle guard and double-count guard.
+ * @returns {{bytes: Number, members: String[]}} Loaded bytes, and the imported members contributing.
+ * @throws {Error} If an import names a file that does not exist — a budget that silently drops a
+ *   renamed member measures a fiction and passes, so this fails closed like the combined budgets do.
+ */
+function resolveLoadedSize(file, seen = new Set()) {
+    const
+        full = path.isAbsolute(file) ? file : path.join(ROOT_DIR, file),
+        real = fs.realpathSync(full);
+
+    // An entry point reachable twice (symlink plus direct import) is paid for once by the loader.
+    if (seen.has(real)) {
+        return {bytes: 0, members: []};
+    }
+
+    seen.add(real);
+
+    const
+        text    = fs.readFileSync(real, 'utf8'),
+        members = [];
+
+    let bytes = Buffer.byteLength(text, 'utf8');
+
+    text.split('\n').forEach(line => {
+        const match = line.match(AT_IMPORT_PATTERN);
+
+        if (!match) {
+            return;
+        }
+
+        const target = path.resolve(path.dirname(real), match[1]);
+
+        if (!fs.existsSync(target)) {
+            throw new Error(`${file} imports '${match[1]}', which does not exist`);
+        }
+
+        const child = resolveLoadedSize(target, seen);
+
+        bytes += child.bytes;
+        members.push(path.relative(ROOT_DIR, target), ...child.members);
+    });
+
+    return {bytes, members};
+}
 
 /**
  * Budgets over a GROUP of files rather than each file alone.
@@ -56,21 +131,44 @@ let hasError = false;
 console.log(`\n🔍 Checking Antigravity Substrate sizes against ${PER_FILE_LIMIT_BYTES} byte per-file limit...`);
 console.log('--------------------------------------------------------------------------------');
 
-TARGET_FILES.forEach(file => {
+TARGET_FILES.forEach(({path: file, harness, limitConfirmed}) => {
     const fullPath = path.join(ROOT_DIR, file);
+
     if (!fs.existsSync(fullPath)) {
         console.error(`❌ Error: Required substrate file ${file} not found.`);
         hasError = true;
         return;
     }
 
-    const stats  = fs.statSync(fullPath);
-    const size   = stats.size;
-    const status = size > PER_FILE_LIMIT_BYTES ? '❌ EXCEEDS' : '✅ PASS';
+    let loaded;
 
-    console.log(`📄 ${file.padEnd(30)} : ${size} bytes [${status}]`);
+    try {
+        loaded = resolveLoadedSize(file);
+    } catch (error) {
+        // Fail closed for the same reason the combined budgets do: an unresolvable member means the
+        // total is unknown, and an unknown total must never render as a pass.
+        console.error(`❌ Error: ${error.message}`);
+        hasError = true;
+        return;
+    }
 
-    if (size > PER_FILE_LIMIT_BYTES) {
+    const
+        size   = loaded.bytes,
+        over   = size > PER_FILE_LIMIT_BYTES,
+        status = over ? '❌ EXCEEDS' : '✅ PASS';
+
+    console.log(`📄 ${file.padEnd(30)} : ${size} bytes [${status}] · ${harness}${limitConfirmed ? '' : ' · limit INHERITED from another harness, semantics unconfirmed'}`);
+
+    // Headroom, not just pass/fail: this drift is gradual, so a shrinking margin is the signal — by
+    // the time it flips to EXCEEDS the substrate is already truncating. Counts bytes an author may
+    // still ADD, which is the question they are actually asking.
+    console.log(`   limit ${PER_FILE_LIMIT_BYTES} · ${over ? `OVER by ${size - PER_FILE_LIMIT_BYTES}` : `headroom ${PER_FILE_LIMIT_BYTES - size}`} bytes`);
+
+    // Name what the total is made of whenever it is not just the file itself, so a reader can see
+    // WHY an entry point costs more than its own bytes rather than re-deriving the import chain.
+    loaded.members.length && console.log(`   composed via @-import: ${loaded.members.join(', ')}`);
+
+    if (over) {
         hasError = true;
     }
 });

--- a/test/playwright/unit/ai/scripts/diagnostics/CheckSubstrateSize.spec.mjs
+++ b/test/playwright/unit/ai/scripts/diagnostics/CheckSubstrateSize.spec.mjs
@@ -40,11 +40,22 @@ test.describe('check-substrate-size.mjs — combined budgets', () => {
         fs.writeFileSync(full, 'x'.repeat(bytes));
     };
 
+    // Mirrors production: `.claude/CLAUDE.md` is a symlink, not a regular file.
+    const symlinkClaudeEntry = (target = '../AGENTS.md') => {
+        const full = path.join(tempDir, '.claude/CLAUDE.md');
+
+        fs.mkdirSync(path.dirname(full), { recursive: true });
+        fs.symlinkSync(target, full);
+    };
+
     // The per-file targets must exist and stay under 24 KiB, or that arm fails for its own reasons
-    // and tells us nothing about the combined arm under test.
+    // and tells us nothing about the combined arm under test. `.claude/CLAUDE.md` joined that set
+    // later — without it these cases go red on a missing target, and the FAILING cases stay green
+    // for the wrong reason, which is worse.
     const seedPerFileTargets = () => {
         writeFile('AGENTS.md', 1000);
         writeFile('.agents/ANTIGRAVITY_RULES.md', 1000);
+        symlinkClaudeEntry();
     };
 
     const seedCombined = (circuitBreakerBytes, guideBytes) => {
@@ -139,11 +150,109 @@ test.describe('check-substrate-size.mjs — combined budgets', () => {
     test('the per-file arm still fails independently — the combined arm did not replace it', () => {
         writeFile('AGENTS.md', 24577);
         writeFile('.agents/ANTIGRAVITY_RULES.md', 1000);
+        symlinkClaudeEntry();
         seedCombined(2207, 36544);
 
         const result = run();
 
         expect(result.status).toBe(1);
         expect(result.output).toContain('EXCEEDS');
+    });
+
+    /**
+     * The Claude entry point.
+     *
+     * `.claude/CLAUDE.md` reaches its content two ways, and a near-miss once changed the file from
+     * one to the other: it is a symlink today, and a proposed change would have replaced it with a
+     * real file carrying `@`-imports. The guard measured NEITHER — the path was not a target at all,
+     * which is why that change rode green while altering what every Claude seat loads.
+     *
+     * Each case keeps `AGENTS.md` under its own per-file limit, so a failure here can only come from
+     * the Claude entry rather than leaking in from the arm above.
+     */
+    test.describe('the Claude load path', () => {
+        // The importer's own bytes count too — the seat loads this file AND its targets.
+        const writeClaudeImporter = (...targets) => {
+            const full = path.join(tempDir, '.claude/CLAUDE.md');
+
+            fs.mkdirSync(path.dirname(full), { recursive: true });
+            fs.writeFileSync(full, targets.map(target => `@${target}`).join('\n') + '\n');
+
+            return fs.statSync(full).size;
+        };
+
+        const seedUnrelatedArms = () => {
+            writeFile('AGENTS.md', 24000);
+            writeFile('.agents/ANTIGRAVITY_RULES.md', 1000);
+            seedCombined(2207, 36544);
+        };
+
+        test('the SYMLINK form is measured through the link, not as its 12-byte path string', () => {
+            seedUnrelatedArms();
+            symlinkClaudeEntry();
+
+            const result = run();
+
+            expect(result.status).toBe(0);
+            // The discriminator. `lstat` on this path reports 12 — the length of '../AGENTS.md' —
+            // and a guard reading that would report a 24 KiB surface as comfortably tiny forever.
+            // Seeing the TARGET's size is what proves the link was followed rather than counted.
+            expect(result.output).toMatch(/\.claude\/CLAUDE\.md\s+: 24000 bytes/);
+        });
+
+        test('the @-IMPORT form is measured as the SUM it loads — the near-miss reproduced', () => {
+            seedUnrelatedArms();
+            writeFile('extra.md', 1586);
+
+            const stub = writeClaudeImporter('../AGENTS.md', '../extra.md');
+
+            // 27 + 24,000 + 1,586 = 25,613 against a 24,576 limit. Under the old guard this path was
+            // unmeasured; under a stat-only guard it reads as the 27-byte stub and passes.
+            expect(stub).toBe(27);
+
+            const result = run();
+
+            expect(result.status).toBe(1);
+            expect(result.output).toMatch(/\.claude\/CLAUDE\.md\s+: 25613 bytes \[❌ EXCEEDS\]/);
+            expect(result.output).toContain('OVER by 1037 bytes');
+            // Naming the members is what turns "too big" into an actionable finding.
+            expect(result.output).toContain('composed via @-import: AGENTS.md, extra.md');
+        });
+
+        test('the same import shape PASSES when the sum fits — the arm measures bytes, not the mere presence of an import', () => {
+            seedUnrelatedArms();
+            writeFile('extra.md', 100);
+            writeClaudeImporter('../AGENTS.md', '../extra.md');
+
+            const result = run();
+
+            // Mutation control for the case above. Without it, an arm that failed on ANY @-import
+            // would be indistinguishable from one that failed on the total — and would still be green.
+            expect(result.status).toBe(0);
+            expect(result.output).toMatch(/\.claude\/CLAUDE\.md\s+: 24127 bytes/);
+        });
+
+        test('EXACTLY at the per-file limit passes, and one byte more fails — the boundary is `>`, not `>=`', () => {
+            // Worth pinning precisely: production `AGENTS.md` currently sits 2 bytes under this
+            // number, so which side of the boundary is legal is not a hypothetical distinction.
+            seedUnrelatedArms();
+            writeFile('extra.md', 549); // 27 + 24,000 + 549 = 24,576 exactly
+
+            writeClaudeImporter('../AGENTS.md', '../extra.md');
+            expect(run().status).toBe(0);
+
+            writeFile('extra.md', 550); // = 24,577
+            expect(run().status).toBe(1);
+        });
+
+        test('an import naming a missing file fails CLOSED — an unknown total must never render as a pass', () => {
+            seedUnrelatedArms();
+            writeClaudeImporter('../AGENTS.md', '../vanished.md');
+
+            const result = run();
+
+            expect(result.status).toBe(1);
+            expect(result.output).toContain("imports '../vanished.md', which does not exist");
+        });
     });
 });


### PR DESCRIPTION
Resolves #17763

Refs #17175

`.claude/CLAUDE.md` — what a Claude seat loads every turn — was in neither the substrate guard's target list nor the workflow's watch paths, so a change to it altered every seat's loaded context while triggering nothing. The entry point reaches its content two ways and the near-miss changed the file from one to the other, so following only one form still computes the wrong total: `lstat` on today's symlink reports **12** bytes (the length of `../AGENTS.md`) and `stat` on an import stub reports **27**, while the seat loads tens of kilobytes in both cases. The guard now resolves both forms, names which harness each target belongs to, and reports headroom instead of a bare verdict.

Evidence: L2 (unit-level red/green against a synthetic root, plus a mutation control) → L2 required (every AC is run-observable; the guard is a pure Node script the suite drives as a subprocess). No residuals.

## AC Evidence

| AC | Evidence |
|---|---|
| AC-1 | *Symlink resolved to its target's bytes.* `CheckSubstrateSize.spec.mjs` › *"the SYMLINK form is measured through the link, not as its 12-byte path string"* pins the reported size at the target's 24,000, not the link's 12. |
| AC-2 | *`@`-import measured as the recursive sum, cycle-guarded, fail-closed on a missing target.* Same spec › *"the @-IMPORT form is measured as the SUM it loads"* (27 + 24,000 + 1,586 = 25,613, `OVER by 1037`) and › *"an import naming a missing file fails CLOSED"*. `resolveLoadedSize` keys its guard on `realpathSync` identity, so a file reachable twice is counted once. |
| AC-3 | *Workflow watch paths carry the Claude entry in both lists.* `.github/workflows/substrate-size-guard.yml` — `.claude/CLAUDE.md` added under `pull_request.paths` and `push.paths`. Static config; no runtime arm. |
| AC-4 | *Per-file arm reports headroom.* Same spec › *"EXACTLY at the per-file limit passes, and one byte more fails"* pins the boundary; live output on this branch reads `AGENTS.md : 24574 bytes [PASS] · limit 24576 · headroom 2 bytes`. |
| AC-5 | *Red-then-green control with a mutation control.* The two arms above are the near-miss; › *"the same import shape PASSES when the sum fits"* is the mutation control, so an arm failing on *any* import is distinguishable from one measuring the sum. All five new arms verified red against the pre-change guard (see Test Evidence). |

## Deltas from ticket

- **`TARGET_FILES` entries became objects** rather than bare paths, carrying `harness` and `limitConfirmed`. The ticket asked only that the Claude path be evaluated; the shape change is what lets the output say *which* harness's constant is governing a row. The Claude row ships `limitConfirmed: false`, so the inherited-number assumption is visible in every run rather than resolved silently while its confirming experiment stays blocked.
- **The near-miss fixture keeps `AGENTS.md` at 24,000, not its live 24,574.** A spec asserting against real file sizes flips red the day someone edits the file — drift-coupling, not a test. The synthetic value also keeps `AGENTS.md` under its own per-file limit, so a failure in these arms can only come from the Claude entry.
- **No `COMBINED_BUDGETS` entry**, against the umbrella's suggestion. Rationale is on #17763 and was A2A'd to its author: the second member of the Claude composition (`MEMORY.md`) is harness auto-memory living outside the repo, so a group budget would hold one repo-resident member — a per-file limit wearing a group's clothes. The `@`-import recursion expresses composition without a hardcoded member list.
- **`seedPerFileTargets()` now seeds the Claude entry.** Without it the existing suite's *passing* cases go red on a missing target — and, worse, its *failing* cases stay green for the wrong reason. Two of the seven pre-existing arms failed until this landed.

## Test Evidence

All coverage runs in CI. The one thing a green suite cannot show is whether the new arms *can* fail, so:

- **Red-proof.** With `check-substrate-size.mjs` stashed to its `dev` state and the spec unchanged, all **5** new arms fail; the 2 pre-existing arms in the same grep still pass. They fail for the right reason — the old guard does not measure that path at all.
- **Green.** `npm run test-unit -- …/CheckSubstrateSize.spec.mjs` → **14/14**.
- **No sibling regression.** `npm run test-unit -- test/playwright/unit/ai/scripts/diagnostics/` → **456/456**.
- **Live guard on this branch** still passes and now prints the Claude row plus `headroom 2 bytes` for `AGENTS.md`.

## Post-Merge Validation

None — the guard is a pure Node script exercised by the suite at the same fidelity it runs in CI, and the workflow path change is verified by the next PR that touches `.claude/CLAUDE.md`.

## Evolution

The first draft cited ticket and PR numbers in the durable JSDoc and spec comments. `check-ticket-archaeology` rejected it at pre-commit — six refs across two files — and it is right: durable comments describe behavior, and tracking refs rot when the referenced item closes. The rationale moved here and to the commit message, which is where it does not decay. The guard's own runtime string dropped its ticket number too, matching the refless precedent already in that file (*"see the ticket that set it"*).

Authored by Grace (Claude Opus 5, Claude Code). Session 8daa7672-824e-4d4a-9283-8a0b908180c8.
