### PR TITLE
fix(build): the staged repair owns the run it touched, not just the line (#17757)

### DIFF
--- a/buildScripts/util/check-block-alignment.mjs
+++ b/buildScripts/util/check-block-alignment.mjs
@@ -91,12 +91,15 @@ function alignedImportLine({clause, source}, fromColumn) {
 function evaluateImportAlignment(lines, maskedLines = []) {
     const
         violations = [],
+        runs       = [],
         fixedLines = lines.slice();
 
     // Only runs that ARE groups are numbered, so "group 2 of 3" counts what a reader can see.
     const groups = collectImportRuns(lines, maskedLines).filter(run => run.length >= 2);
 
     groups.forEach((run, groupIndex) => {
+        runs.push({kind: 'import', group: groupIndex + 1, lineIndices: run.map(entry => entry.lineIndex)});
+
         // The `from` column = widest `import <clause>` in the run + one space.
         const fromColumn = Math.max(...run.map(entry => IMPORT_PREFIX.length + entry.clause.length)) + 1;
 
@@ -115,7 +118,7 @@ function evaluateImportAlignment(lines, maskedLines = []) {
         }
     });
 
-    return {violations, fixedLines};
+    return {violations, fixedLines, runs};
 }
 
 // ─────────────────────────── object-literal colons (v1b) ───────────────────────────
@@ -185,8 +188,9 @@ function collectPropertyRuns(lines, maskedLines = []) {
  */
 function evaluateColonAlignment(lines, maskedLines = []) {
     const
-        violations = [],
-        fixedLines = lines.slice();
+        violations    = [],
+        alignmentRuns = [],
+        fixedLines    = lines.slice();
 
     const runs = collectPropertyRuns(lines, maskedLines),
           // Only runs that ARE alignment groups are counted, so "group 2 of 3" matches what a reader
@@ -197,6 +201,8 @@ function evaluateColonAlignment(lines, maskedLines = []) {
         const colonMembers = run.filter(entry => entry.kind === 'colon'),
               indent       = run[0].indent,
               keyWidth     = Math.max(...colonMembers.map(entry => entry.key.length));
+
+        alignmentRuns.push({kind: 'object-colon', group: groupIndex + 1, lineIndices: colonMembers.map(entry => entry.lineIndex)});
 
         for (const entry of colonMembers) {
             const expected = `${indent}${entry.key.padEnd(keyWidth)}: ${entry.value}`;
@@ -213,7 +219,7 @@ function evaluateColonAlignment(lines, maskedLines = []) {
         }
     });
 
-    return {violations, fixedLines, notices: detectCommentOnlyFragmentation(lines, groups)};
+    return {violations, fixedLines, runs: alignmentRuns, notices: detectCommentOnlyFragmentation(lines, groups)};
 }
 
 // ─────────────────────────── `=` declaration blocks (v1b) ───────────────────────────
@@ -392,6 +398,7 @@ function collectAssignmentRuns(lines, maskedLines = []) {
 function evaluateAssignmentAlignment(lines, maskedLines = []) {
     const
         violations = [],
+        runs       = [],
         fixedLines = lines.slice();
 
     // Only runs that ARE groups are numbered, so "group 2 of 3" counts what a reader can see.
@@ -402,6 +409,8 @@ function evaluateAssignmentAlignment(lines, maskedLines = []) {
 
     groups.forEach(({entries, mode}, groupIndex) => {
         const simpleParts = entries;
+
+        runs.push({kind: 'assignment', group: groupIndex + 1, lineIndices: simpleParts.map(part => part.lineIndex)});
 
         const
             keywordWidth = mode === 'keyword' ? Math.max(...simpleParts.map(part => part.keyword.length)) : 0,
@@ -428,7 +437,7 @@ function evaluateAssignmentAlignment(lines, maskedLines = []) {
         }
     });
 
-    return {violations, fixedLines};
+    return {violations, fixedLines, runs};
 }
 
 // ───────────────────────────────── driver ─────────────────────────────────
@@ -646,8 +655,50 @@ function detectCommentOnlyFragmentation(lines, runs) {
  */
 const unfixableReasons = new Map();
 
+/**
+ * @summary Widens a line-scoped staged mask to the enclosing alignment RUN.
+ *
+ * Alignment is a property of a run of >= 2 consecutive lines, and the staged view is a set of
+ * individual added lines. Intersecting the two directly asks a block-scoped rule to answer from a
+ * line-scoped input, and it degrades to silence in the most common edit shape there is: adding or
+ * widening ONE line inside a run that already exists.
+ *
+ * Two distinct ways that fails, and the second is why seeding from violations alone is not enough:
+ *
+ * 1. A one-line addition presents as a 1-member run, so the rule has nothing to group.
+ * 2. **Widening a line makes that line CORRECT.** The widest member defines the column, so the edited
+ *    line carries no violation at all — its untouched siblings do. A mask seeded from
+ *    violated-AND-staged lines therefore matches nothing, and the repair writes nothing while
+ *    reporting success.
+ *
+ * So membership decides ownership, not violation: if any line of a run was staged, the author has
+ * taken responsibility for that run and every violation in it is theirs to repair. Untouched runs
+ * elsewhere in the file stay untouched, which is the scoping intent `--staged` was added for.
+ *
+ * Both the scoped repair and the scoped report call this, so the two can never disagree about which
+ * drift belongs to a commit — a check quieter than its own fixer is how a gate reports green on a
+ * file it would rewrite.
+ *
+ * @param {Array<{lineIndex: Number, kind: String, group: Number}>} violations Whole-file violations.
+ * @param {Array<{kind: String, group: Number, lineIndices: Number[]}>} runs Whole-file alignment runs.
+ * @param {Set<Number>} added 1-based staged-added line numbers.
+ * @returns {Array<Object>} The subset of `violations` whose run contains at least one staged line.
+ */
+function violationsInTouchedRuns(violations, runs, added) {
+    // `kind` scopes the group number: import group 1 and object-colon group 1 are different runs.
+    const identity = ({kind, group}) => `${kind}#${group}`;
+
+    const touched = new Set(
+        runs.filter(run => run.lineIndices.some(lineIndex => added.has(lineIndex + 1)))
+            .map(identity)
+    );
+
+    return violations.filter(violation => touched.has(identity(violation)));
+}
+
 function processFile(file, fix, gitRoot = null, scopedFix = false) {
     const allViolations = [];
+    const allRuns       = [];
     const originalLines = fs.readFileSync(file, 'utf8').split('\n');
     const maskedLines   = computeTemplateLiteralLineMask(originalLines);
     let   lines         = originalLines;
@@ -655,8 +706,9 @@ function processFile(file, fix, gitRoot = null, scopedFix = false) {
     const allNotices = [];
 
     for (const evaluate of EVALUATORS) {
-        const {violations, fixedLines, notices} = evaluate(lines, maskedLines);
+        const {violations, fixedLines, notices, runs} = evaluate(lines, maskedLines);
         allViolations.push(...violations);
+        runs    && allRuns.push(...runs);
         notices && allNotices.push(...notices);
         lines = fixedLines;
     }
@@ -701,7 +753,7 @@ function processFile(file, fix, gitRoot = null, scopedFix = false) {
                 return 'unfixable';
             }
 
-            const owned = allViolations.filter(v => added.has(v.lineIndex + 1));
+            const owned = violationsInTouchedRuns(allViolations, allRuns, added);
 
             if (owned.length === 0) return 'clean';
 
@@ -726,7 +778,7 @@ function processFile(file, fix, gitRoot = null, scopedFix = false) {
     // so a grandfathered misalignment on an untouched line never blocks an unrelated commit. Fail
     // CLOSED: a null detection (git read failure) reports the whole file rather than suppressing drift.
     const added    = gitRoot ? getStagedAddedLines(file, gitRoot) : null;
-    const reported = added ? allViolations.filter(v => added.has(v.lineIndex + 1)) : allViolations;
+    const reported = added ? violationsInTouchedRuns(allViolations, allRuns, added) : allViolations;
 
     if (reported.length === 0) return 'clean';
 

--- a/buildScripts/util/check-block-alignment.mjs
+++ b/buildScripts/util/check-block-alignment.mjs
@@ -25,9 +25,9 @@ import {getStagedAddedLines, isWorkingTreeCleanFor} from './stagedDiff.mjs';
  *
  * Usage:
  *   node buildScripts/util/check-block-alignment.mjs <file.mjs> [...]                # check; exit 1 on drift
- *   node buildScripts/util/check-block-alignment.mjs --staged <file.mjs> [...]       # check, scoped to staged-added lines
+ *   node buildScripts/util/check-block-alignment.mjs --staged <file.mjs> [...]       # check, scoped to runs the author touched
  *   node buildScripts/util/check-block-alignment.mjs --fix <file.mjs> [...]          # rewrite whole-file (deliberate pass)
- *   node buildScripts/util/check-block-alignment.mjs --fix --staged <file.mjs> [...] # pre-commit repair: rewrite only staged-added lines
+ *   node buildScripts/util/check-block-alignment.mjs --fix --staged <file.mjs> [...] # pre-commit repair: rewrite runs the author touched
  */
 
 // ───────────────────────────── import-`from` (v1) ─────────────────────────────
@@ -635,11 +635,14 @@ function detectCommentOnlyFragmentation(lines, runs) {
  * evaluators are chained — each sees the prior's fixed lines — which is safe because none changes the
  * line COUNT and the three line-shapes (import / property / declaration) are disjoint.
  *
- * Dispositions: check mode reports drift (scoped to staged-added lines under `--staged`); pure
- * `--fix` rewrites whole-file as a deliberate pass; `--fix --staged` (the pre-commit repair)
- * rewrites ONLY violations on the author's staged-added lines, so a grandfathered misalignment on an
- * untouched line is never sprayed into an unrelated commit. The scoped repair fails CLOSED: without
- * a reliable staged-line set it reports and writes nothing (`'unfixable'`).
+ * Dispositions: check mode reports drift (scoped to touched RUNS under `--staged`); pure `--fix`
+ * rewrites whole-file as a deliberate pass; `--fix --staged` (the pre-commit repair) rewrites every
+ * violation in a run the author touched — including its untouched sibling lines, because alignment
+ * is a property of the run and a staged line is often the widest, hence the only correct one. A run
+ * the author never touched stays byte-identical, so grandfathered drift is still never sprayed into
+ * an unrelated commit. Ownership is computed once by {@link violationsInTouchedRuns} and shared by
+ * both scoped paths. The scoped repair fails CLOSED: without a reliable staged-line set it reports
+ * and writes nothing (`'unfixable'`).
  * @param {String}  file
  * @param {Boolean} fix
  * @param {String}  [gitRoot]   Repository root for staged-line scoping (check `--staged` and `--fix --staged`).
@@ -774,9 +777,10 @@ function processFile(file, fix, gitRoot = null, scopedFix = false) {
         return 'fixed';
     }
 
-    // Staged (pre-commit) check mode: report only drift the author introduced on staged-added lines,
-    // so a grandfathered misalignment on an untouched line never blocks an unrelated commit. Fail
-    // CLOSED: a null detection (git read failure) reports the whole file rather than suppressing drift.
+    // Staged (pre-commit) check mode: report drift in the runs the author touched, so a run they
+    // never touched never blocks an unrelated commit. Same ownership function as the scoped repair —
+    // a check quieter than its own fixer reports green on a file it would rewrite. Fail CLOSED: a
+    // null detection (git read failure) reports the whole file rather than suppressing drift.
     const added    = gitRoot ? getStagedAddedLines(file, gitRoot) : null;
     const reported = added ? violationsInTouchedRuns(allViolations, allRuns, added) : allViolations;
 
@@ -795,9 +799,9 @@ const
     staged = args.includes('--staged'),
     files  = args.filter(arg => arg !== '--fix' && arg !== '--staged');
 
-// --staged (pre-commit) mode: resolve the repo root once so processFile can scope drift to the
-// author's staged-added lines — in check mode for the REPORT set, in `--fix --staged` mode for the
-// REWRITE set. Fail-closed: a rev-parse failure → null gitRoot → check mode reports whole-file and
+// --staged (pre-commit) mode: resolve the repo root once so processFile can scope drift to the runs
+// the author touched — in check mode for the REPORT set, in `--fix --staged` mode for the REWRITE
+// set. Fail-closed: a rev-parse failure → null gitRoot → check mode reports whole-file and
 // the scoped repair refuses to write (drift is neither suppressed nor half-repaired by a git failure).
 let gitRoot = null;
 if (staged) {

--- a/test/playwright/unit/ai/buildScripts/util/check-block-alignment.spec.mjs
+++ b/test/playwright/unit/ai/buildScripts/util/check-block-alignment.spec.mjs
@@ -868,3 +868,142 @@ test.describe('check-block-alignment.mjs --fix --staged index-vs-worktree precon
         expect(result.output).not.toContain('already repaired before the refusal');
     });
 });
+
+/**
+ * A one-line edit inside an EXISTING aligned run.
+ *
+ * The scoped repair masked whole-file violations by staged-added LINE, and alignment is a property
+ * of a RUN of >= 2 lines — so the most common edit shape there is escaped entirely. Two ways, and
+ * the second is the one that makes a violation-seeded mask insufficient:
+ *
+ *   1. a one-line addition presents as a 1-member run, so the rule has nothing to group;
+ *   2. WIDENING a line makes that line the widest, hence CORRECT — the violations land on its
+ *      untouched siblings, so a mask seeded from violated-AND-staged lines matches nothing at all.
+ *
+ * Membership therefore decides ownership: touch any line of a run and every violation in that run
+ * is yours. Untouched runs elsewhere stay untouched, which the grandfathering arm above still pins.
+ */
+test.describe('check-block-alignment.mjs --fix --staged run-scoped ownership', () => {
+    let stagedDir;
+
+    const git = (...a) => execFileSync('git', a, {cwd: stagedDir, stdio: 'ignore'});
+
+    const run = (args, cwd = stagedDir) => {
+        try {
+            return {status: 0, output: execFileSync('node', [scriptPath, ...args], {cwd, encoding: 'utf8', stdio: 'pipe'})};
+        } catch (error) {
+            return {status: error.status, output: (error.stderr || '') + (error.stdout || '')};
+        }
+    };
+
+    // Commit `before`, stage `after`, run the pre-commit repair, return the resulting lines.
+    const editAndRepair = (before, after) => {
+        const file = path.join(stagedDir, 'src.mjs');
+
+        fs.writeFileSync(file, before.join('\n') + '\n', 'utf8');
+        git('add', 'src.mjs');
+        git('commit', '-m', 'baseline');
+
+        fs.writeFileSync(file, after.join('\n') + '\n', 'utf8');
+        git('add', 'src.mjs');
+
+        const result = run(['--fix', '--staged', 'src.mjs']);
+
+        return {result, lines: fs.readFileSync(file, 'utf8').split('\n')};
+    };
+
+    test.beforeEach(() => {
+        stagedDir = fs.mkdtempSync(path.join(os.tmpdir(), 'neo-blockalign-runscope-'));
+        git('init');
+        git('config', 'user.email', 'test@example.com');
+        git('config', 'user.name', 'Test User');
+    });
+
+    test.afterEach(() => {
+        fs.rmSync(stagedDir, {recursive: true, force: true});
+    });
+
+    test('widening ONE import inside an existing run repairs its untouched siblings', () => {
+        const {result, lines} = editAndRepair([
+            "import Base       from './core/Base.mjs';",
+            "import NeoArray   from './util/Array.mjs';",
+            "import Store      from './data/Store.mjs';",
+            "import Collection from './collection/Base.mjs';"
+        ], [
+            "import Base       from './core/Base.mjs';",
+            "import NeoArray   from './util/Array.mjs';",
+            "import StoreWithAMuchLongerName from './data/Store.mjs';",
+            "import Collection from './collection/Base.mjs';"
+        ]);
+
+        expect(result.status).toBe(0);
+        // Three siblings widen to the column the staged line established. Before this, the repair
+        // exited 0 having written nothing — the block shipped misaligned.
+        expect(result.output).toContain('Aligned 3 line(s)');
+        expect(lines[0]).toBe("import Base                     from './core/Base.mjs';");
+        expect(lines[1]).toBe("import NeoArray                 from './util/Array.mjs';");
+        expect(lines[2]).toBe("import StoreWithAMuchLongerName from './data/Store.mjs';");
+        expect(lines[3]).toBe("import Collection               from './collection/Base.mjs';");
+    });
+
+    test('the same holds for an object-literal colon run', () => {
+        const {result, lines} = editAndRepair([
+            'const config = {',
+            '    db  : 1,',
+            '    port: 2',
+            '};'
+        ], [
+            'const config = {',
+            '    db  : 1,',
+            '    connectionPoolSize: 2',
+            '};'
+        ]);
+
+        expect(result.status).toBe(0);
+        expect(lines[1]).toBe('    db                : 1,');
+        expect(lines[2]).toBe('    connectionPoolSize: 2');
+    });
+
+    test('the same holds for an `=` declaration run', () => {
+        const {result, lines} = editAndRepair([
+            'const',
+            '    a  = 1,',
+            '    bb = 2;'
+        ], [
+            'const',
+            '    a  = 1,',
+            '    bbLongerName = 2;'
+        ]);
+
+        expect(result.status).toBe(0);
+        expect(lines[1]).toBe('    a            = 1,');
+        expect(lines[2]).toBe('    bbLongerName = 2;');
+    });
+
+    test('a run the author never touched stays byte-identical — ownership widened to the run, not to the file', () => {
+        const {result, lines} = editAndRepair([
+            "import a from 'a';",
+            "import bb from 'b';",
+            '',
+            'const config = {',
+            '    db  : 1,',
+            '    port: 2',
+            '};'
+        ], [
+            "import a from 'a';",
+            "import bb from 'b';",
+            '',
+            'const config = {',
+            '    db  : 1,',
+            '    connectionPoolSize: 2',
+            '};'
+        ]);
+
+        expect(result.status).toBe(0);
+        // The mutation control for the three arms above: if widening had leaked to the whole file,
+        // this grandfathered import pair would have been rewritten too.
+        expect(lines[0]).toBe("import a from 'a';");
+        expect(lines[1]).toBe("import bb from 'b';");
+        expect(lines[5]).toBe('    connectionPoolSize: 2');
+    });
+});

--- a/test/playwright/unit/ai/buildScripts/util/check-block-alignment.spec.mjs
+++ b/test/playwright/unit/ai/buildScripts/util/check-block-alignment.spec.mjs
@@ -566,8 +566,9 @@ test.describe('check-block-alignment.mjs (#13556)', () => {
 
 /**
  * Real-git integration for the --staged diff-scope. In lint-staged (pre-commit) mode the check
- * reports only drift on the author's staged-ADDED lines — a grandfathered misalignment on an
- * untouched line must not block an unrelated commit — reusing the shared stagedDiff helper.
+ * reports drift in the RUNS the author touched — including untouched sibling lines inside such a
+ * run, since alignment is a property of the run — while a run they never touched must not block an
+ * unrelated commit, reusing the shared stagedDiff helper.
  */
 test.describe('check-block-alignment.mjs --staged diff-scope (#13720)', () => {
     let stagedDir;

--- a/test/playwright/unit/ai/buildScripts/util/check-block-alignment.spec.mjs
+++ b/test/playwright/unit/ai/buildScripts/util/check-block-alignment.spec.mjs
@@ -620,9 +620,10 @@ test.describe('check-block-alignment.mjs --staged diff-scope (#13720)', () => {
 
 /**
  * Real-git integration for the scoped pre-commit REPAIR (`--fix --staged`): the hook converts from
- * reject to repair, rewriting ONLY drift on the author's staged-added lines. A grandfathered
- * misalignment on an untouched line stays byte-identical; a git detection failure reports and never
- * writes (fail-closed); pure `--fix` stays the deliberate whole-file pass. The detector is untouched —
+ * reject to repair, rewriting drift in the RUNS the author touched. A run they never touched stays
+ * byte-identical — which is what these arms pin, and it still holds now that ownership is the run
+ * rather than the line; a git detection failure reports and never writes (fail-closed); pure `--fix`
+ * stays the deliberate whole-file pass. The detector is untouched —
  * the entire pre-existing suite above runs unmodified against the new disposition surface.
  */
 test.describe('check-block-alignment.mjs --fix --staged scoped repair (#17201)', () => {
@@ -651,7 +652,7 @@ test.describe('check-block-alignment.mjs --fix --staged scoped repair (#17201)',
         fs.rmSync(stagedDir, {recursive: true, force: true});
     });
 
-    test('rewrites only staged-added-line drift; a grandfathered misalignment stays byte-identical (AC1)', () => {
+    test('rewrites drift in the touched run only; a grandfathered run stays byte-identical (AC1)', () => {
         const file = path.join(stagedDir, 'src.mjs');
         // Committed: a misaligned import pair (line 1 drifts) — grandfathered, never owned again.
         fs.writeFileSync(file, "import a from 'a';\nimport bb from 'b';\n", 'utf8');


### PR DESCRIPTION
Resolves #17757

The scoped pre-commit repair masked whole-file violations by staged-added **line**, while alignment is a property of a **run** of ≥ 2 consecutive lines. Ownership now keys on run *membership*: touch any line of a run and every violation in that run is yours to repair. Untouched runs elsewhere in the file stay untouched, which is the scoping intent `--staged` was added for.

Evidence: L2 (red-then-green against `dev`'s checker on a real git fixture, plus a mutation control) → L2 required (every AC is run-observable; the checker is a Node script the suite drives as a subprocess). No residuals.

## AC Evidence

Counted over the three LIVE criteria; the ticket's dropped one is struck and does not count.

| AC | Evidence |
|---|---|
| AC-1 | *A one-line import added to or widened inside an existing aligned run is fixed by the pre-commit path, red-then-green.* `check-block-alignment.spec.mjs` › *"widening ONE import inside an existing run repairs its untouched siblings"*. Verified against `dev`'s checker on a real git fixture: **old** exits 0 leaving the block misaligned, **new** reports `Aligned 3 line(s)`. |
| AC-2 | *The same coverage holds for object-literal colon and `=` groups, not just imports.* Same describe › *"the same holds for an object-literal colon run"* and › *"the same holds for an `=` declaration run"*. All three evaluators return the runs they grouped, and one shared helper masks both the scoped repair and the scoped report. |
| AC-3 | *A decision is recorded on the wide-run case: widen, or instruct the multi-line form.* Decision: **widen** ships; the multi-line-form instruction is explicitly NOT adopted, with the reason recorded under **Deltas from ticket** below and on the ticket. |

The ticket's second criterion (*"`check` reports every drift `--fix` would rewrite"*) was falsified at intake and struck by its author ([`IC_5411493069`](https://github.com/neomjs/neo/issues/17757#issuecomment-5411493069)) — the two modes already agree, and its row 1 came from a truncated pipe. No proof slot is owed for it.

## Deltas from ticket

- **Seeding from violations would not have worked, and that is the substantive discovery.** The obvious reading of "admit the whole run" is to expand from staged lines that *have* violations. That still finds nothing in the ticket's own scenario: widening a clause makes that line the **widest**, hence correct — the violations land on its untouched siblings, so a violated-AND-staged mask matches zero rows. Membership, not violation, has to be the seed. The fixture pins exactly this: the staged line carries no violation and the repair still fires.
- **The scoped *check* path was widened too, not just the fix.** They now call one helper. A check quieter than its own fixer is how a gate reports green on a file it would rewrite, and the ticket's original framing (before AC-2 was dropped) was about precisely that class of divergence — worth closing structurally even though the specific divergence it alleged did not exist.
- **AC-4 decision — widen, and deliberately not a threshold.** Both the ticket author and I independently preferred *"past some width, tell the author to use the multi-line form"*. It is not in this PR, and the reason is a rule rather than a scope call: `ticket-intake` §10's written-claim gate gives *"hardcoded numerical threshold"* its own row — measure the current value and verify where `N` came from, and prefer a semantic assertion over a brittle cap when the derivation is undocumented. No such number has been measured, and inventing one here would codify exactly what that gate exists to stop. What survives is the observation that motivated it: whole-file `--fix` widening 8 siblings to a 49-character column to accommodate one outlier is the outcome that sends authors to the multi-line form by hand. Recorded rather than acted on.

## Test Evidence

All coverage runs in CI. What a green suite cannot show is whether the new arms can fail, so:

- **Red-then-green on a real git fixture.** Baseline written with hand-authored padding, committed, then one clause widened and staged — the ticket's exact shape. `dev`'s checker: `exit=0`, file byte-identical, block ships misaligned. This branch: `Aligned 3 line(s)`, all three siblings widened to the new column.
- **50/50** on `check-block-alignment.spec.mjs` — 4 new arms plus all 46 pre-existing.
- **Mutation control.** › *"a run the author never touched stays byte-identical"* — a committed misaligned import pair survives untouched while a colon run in the same file is repaired. Without it, a fix that leaked to the whole file would be indistinguishable from one scoped to the run, and both would be green.
- The pre-existing grandfathering arm (`#17201` AC1) is unchanged and still passes, which is the same boundary asserted from the other direction.

## Post-Merge Validation

None — the checker is exercised by the suite at the same fidelity `lint-staged` invokes it, and this PR's own pre-commit run exercised the changed path against its own diff.

## Evolution

Two of my own errors are worth recording because each produced a real check. My first fixture used `sed` against a padded baseline, the pattern did not match, and nothing was staged — so `dev`'s checker "passed" vacuously and briefly looked like the defect did not reproduce. The rewritten fixture writes its padding by hand rather than depending on the tool under test. And the first attempt at exposing runs collided with an existing `runs` binding inside the colon evaluator, which Node caught as a syntax error before any test could report on it.

Authored by Grace (Claude Opus 5, Claude Code). Session 8daa7672-824e-4d4a-9283-8a0b908180c8.
