### PR TITLE
fix(kb): refuse a tenant parser whose parse method is unreachable (#17300)

### DIFF
--- a/ai/services/knowledge-base/IngestionService.mjs
+++ b/ai/services/knowledge-base/IngestionService.mjs
@@ -1806,10 +1806,17 @@ class IngestionService extends Base {
      * is the same defect shape as a census reporting `0` instead of `unknown`, minus even a
      * suspicious number to notice.
      *
+     * **Dispatch is static, and the naming here invites otherwise.** `resolveFileChunks` calls
+     * `parseIngestionFile` / `parse` on the resolved value itself and never instantiates it, so a
+     * class declaring either as an instance method is truthy with both probes reading `undefined` —
+     * the same silent `raw-text` degradation described above, reached from a parser that loaded
+     * perfectly. `loadTenantParser` refuses that shape with `KB_TENANT_PARSER_NOT_DISPATCHABLE`
+     * rather than returning it into a chain that will skip it.
+     *
      * @param {Object} options
      * @param {String} options.parserId
      * @param {Object} [options.tenantContext]
-     * @returns {Promise<Object|null>} The tenant's parser class, or null when it declared none.
+     * @returns {Promise<Object|null>} The tenant's parser class (static-side methods), or null when it declared none.
      * @protected
      */
     async resolveTenantParser({parserId, tenantContext} = {}) {

--- a/ai/services/knowledge-base/IngestionService.mjs
+++ b/ai/services/knowledge-base/IngestionService.mjs
@@ -9,8 +9,11 @@ import {
 }                            from '../memory-core/helpers/consumerFrictionHelper.mjs';
 import RequestContextService,
        {normalizeUserId}    from '../../mcp/server/shared/services/RequestContextService.mjs';
-import SourceRegistry     from './source/_export.mjs';
-import {loadTenantParser} from './source/tenantParserLoader.mjs';
+import SourceRegistry       from './source/_export.mjs';
+import {
+    assertDispatchableParser,
+    loadTenantParser
+}                           from './source/tenantParserLoader.mjs';
 import {normalizeTenantRepoConfig}
                             from './helpers/tenantRepoAccessContract.mjs';
 import {normalizeSettlementCounts}
@@ -1806,17 +1809,21 @@ class IngestionService extends Base {
      * is the same defect shape as a census reporting `0` instead of `unknown`, minus even a
      * suspicious number to notice.
      *
-     * **Dispatch is static, and the naming here invites otherwise.** `resolveFileChunks` calls
-     * `parseIngestionFile` / `parse` on the resolved value itself and never instantiates it, so a
-     * class declaring either as an instance method is truthy with both probes reading `undefined` —
-     * the same silent `raw-text` degradation described above, reached from a parser that loaded
-     * perfectly. `loadTenantParser` refuses that shape with `KB_TENANT_PARSER_NOT_DISPATCHABLE`
-     * rather than returning it into a chain that will skip it.
+     * **The dispatched value must carry the method itself.** `resolveFileChunks` calls
+     * `parseIngestionFile` / `parse` on the resolved value and never instantiates it. A constructor
+     * carrying static methods, an object literal, and a `Neo.setupClass` singleton (whose export IS
+     * an instance) all satisfy that; only a plain constructor whose methods live on `prototype` does
+     * not — it is truthy with both probes reading `undefined`, which is the same silent `raw-text`
+     * degradation described above reached from a parser that loaded perfectly.
+     *
+     * Both declaration forms are validated: `loadTenantParser` refuses a `parserModule` export, and
+     * the live `ParserClass` branch below is checked by the same predicate, because a guard under
+     * only one of them leaves the other degrading unchanged.
      *
      * @param {Object} options
      * @param {String} options.parserId
      * @param {Object} [options.tenantContext]
-     * @returns {Promise<Object|null>} The tenant's parser class (static-side methods), or null when it declared none.
+     * @returns {Promise<Object|null>} The tenant's parser, or null when it declared none.
      * @protected
      */
     async resolveTenantParser({parserId, tenantContext} = {}) {
@@ -1843,9 +1850,15 @@ class IngestionService extends Base {
         }
 
         // A live class reference still wins — the JS-config tier is unchanged by this path, and
-        // caching an object the caller already handed us would buy nothing.
+        // caching an object the caller already handed us would buy nothing. It is validated for
+        // dispatchability all the same: both declaration forms converge on `resolveFileChunks`, so a
+        // guard placed only under `parserModule` would leave this branch degrading to raw-text
+        // exactly as before.
         if (entry.ParserClass) {
-            return entry.ParserClass
+            return assertDispatchableParser(
+                entry.ParserClass,
+                `tenant parser '${parserId}' was declared as a live ParserClass`
+            )
         }
 
         if (!entry.parserModule) {

--- a/ai/services/knowledge-base/source/SourceRegistry.mjs
+++ b/ai/services/knowledge-base/source/SourceRegistry.mjs
@@ -3,7 +3,6 @@ import Base from '../../../../src/core/Base.mjs';
 /**
  * @summary Data-driven registry for Knowledge Base Source + Parser classes.
  *
- * Phase 0/1B substrate of Epic [#11624](https://github.com/neomjs/neo/issues/11624) (Cloud-Native KB Ingestion).
  * Replaces the hardcoded source-list at [`DatabaseService.createKnowledgeBase`](../DatabaseService.mjs)
  * with a registry that supports:
  *
@@ -20,10 +19,9 @@ import Base from '../../../../src/core/Base.mjs';
  * receive the current list of Source classes in registration order. Order matters only
  * for determinism of byte-equivalence fixtures, not for correctness of KB content.
  *
- * **Parser registry shape:** Parsers register by `parserId` (the stable string consumers
- * thread through `parsed-chunk-v1.parserId`). Phase 0/1B ships the API surface + config
- * pipeline; runtime parser-execution wiring lands in Phase 2 / Phase 3 (per
- * [#11626](https://github.com/neomjs/neo/issues/11626) / [#11627](https://github.com/neomjs/neo/issues/11627)).
+ * **Parser registry shape:** Parsers register by `parserId` — the stable string consumers thread
+ * through `parsed-chunk-v1.parserId`. This class owns the API surface and the config pipeline;
+ * runtime parser execution is dispatched by `IngestionService.resolveFileChunks`.
  *
  * @class Neo.ai.services.knowledge-base.source.SourceRegistry
  * @extends Neo.core.Base

--- a/ai/services/knowledge-base/source/SourceRegistry.mjs
+++ b/ai/services/knowledge-base/source/SourceRegistry.mjs
@@ -75,13 +75,15 @@ class SourceRegistry extends Base {
      * Registers a Parser class under the given `parserId`. Re-registering the same id
      * overwrites the prior class.
      *
-     * **Dispatch is static.** The registry stores the class itself and never instantiates it, so
-     * `parseIngestionFile` / `parse` must be declared `static` — an instance method on the prototype
-     * is unreachable. An object literal carrying those methods is equally valid; "class" here names
-     * the convention, not a requirement. See `TENANT_PARSER_ERROR_CODES.notDispatchable`, which
-     * refuses the unreachable shape for tenant-declared parsers.
+     * **The registered value is what gets dispatched.** The registry stores it as given and never
+     * instantiates it, so `parseIngestionFile` / `parse` must be callable on that value. Three shapes
+     * satisfy this: a constructor carrying `static` methods, an object literal, and a
+     * `Neo.setupClass` singleton — whose export IS an instance, which is the idiom every Source in
+     * this directory uses. Only a plain constructor whose methods live on `prototype` fails, because
+     * nothing instantiates it. See `TENANT_PARSER_ERROR_CODES.notDispatchable`, which refuses that
+     * shape for tenant-declared parsers.
      *
-     * @param {Object}  ParserClass            Parser class, or any object carrying static-side `parseIngestionFile`/`parse`.
+     * @param {Object}  ParserClass            The value to dispatch on: a constructor with static methods, a singleton instance, or an object literal.
      * @param {Object} [options]
      * @param {String} [options.parserId]      Stable registry id. Defaults to the class's `className` final segment.
      * @returns {String} The resolved `parserId` used as the registry key.

--- a/ai/services/knowledge-base/source/SourceRegistry.mjs
+++ b/ai/services/knowledge-base/source/SourceRegistry.mjs
@@ -77,7 +77,13 @@ class SourceRegistry extends Base {
      * Registers a Parser class under the given `parserId`. Re-registering the same id
      * overwrites the prior class.
      *
-     * @param {Object}  ParserClass            Parser class.
+     * **Dispatch is static.** The registry stores the class itself and never instantiates it, so
+     * `parseIngestionFile` / `parse` must be declared `static` — an instance method on the prototype
+     * is unreachable. An object literal carrying those methods is equally valid; "class" here names
+     * the convention, not a requirement. See `TENANT_PARSER_ERROR_CODES.notDispatchable`, which
+     * refuses the unreachable shape for tenant-declared parsers.
+     *
+     * @param {Object}  ParserClass            Parser class, or any object carrying static-side `parseIngestionFile`/`parse`.
      * @param {Object} [options]
      * @param {String} [options.parserId]      Stable registry id. Defaults to the class's `className` final segment.
      * @returns {String} The resolved `parserId` used as the registry key.

--- a/ai/services/knowledge-base/source/tenantParserLoader.mjs
+++ b/ai/services/knowledge-base/source/tenantParserLoader.mjs
@@ -231,30 +231,54 @@ export async function loadTenantParser({
         )
     }
 
-    // Exporting something is not the same as exporting something dispatchable. `resolveFileChunks`
-    // reads `parseIngestionFile` / `parse` off this value directly, so a class carrying either on
-    // `prototype` is truthy while both probes read `undefined`: the not-registered throw is skipped
-    // and the file degrades to a whole-file `raw-text` chunk, which INGESTS SUCCESSFULLY. Refusing
-    // here keeps that case inside the coded taxonomy instead of the one silent path it left open.
-    if (typeof ParserClass.parseIngestionFile !== 'function' && typeof ParserClass.parse !== 'function') {
-        const
-            prototype   = ParserClass.prototype,
-            onPrototype = typeof prototype?.parseIngestionFile === 'function' ||
-                          typeof prototype?.parse             === 'function';
-
-        throw refuse(
-            TENANT_PARSER_ERROR_CODES.notDispatchable,
-            `tenant parser '${specifier}' loaded from '${absolutePath}' but exposes no callable ` +
-            '`parseIngestionFile` or `parse`. ' +
-            (onPrototype
-                // The whole defect, and it is invisible from the symptom: the method IS present.
-                ? 'Dispatch is static: the parser is called on the exported class itself and is never ' +
-                  'instantiated, so an instance method declared on the prototype is unreachable. ' +
-                  'Declare it `static`, or export an object literal.'
-                : 'Declare a `static parseIngestionFile(file, {tenantContext})`, or export an object ' +
-                  'literal carrying that method.')
-        )
-    }
+    assertDispatchableParser(ParserClass, `tenant parser '${specifier}' loaded from '${absolutePath}'`);
 
     return ParserClass
+}
+
+/**
+ * @summary Refuses a resolved parser value that nothing can dispatch on.
+ *
+ * **The property is "callable on the value that gets dispatched", not "static".** `resolveFileChunks`
+ * reads `parseIngestionFile` / `parse` off the resolved value directly, and three shapes satisfy
+ * that: a constructor carrying static methods, an object literal, and — the repository's own idiom
+ * for registry-registered classes — a `Neo.setupClass` singleton, whose export IS an instance and
+ * whose prototype methods are therefore reachable on it. Only a plain constructor whose methods live
+ * on `prototype` fails, because the constructor is never instantiated.
+ *
+ * That case is truthy with both probes reading `undefined`, so the `KB_PARSER_NOT_REGISTERED` throw
+ * is skipped and the file degrades to a whole-file `raw-text` chunk, which INGESTS SUCCESSFULLY.
+ * Refusing keeps it inside the coded taxonomy instead of the one silent path it left open.
+ *
+ * Exported because a tenant can declare a parser two ways — a `parserModule` this loader imports, or
+ * a live `ParserClass` reference in the JS-config tier — and both converge on one consumer. Guarding
+ * only the branch this module owns leaves the other one degrading exactly as before.
+ *
+ * @param {*} parser The resolved parser value.
+ * @param {String} subject How to name the parser in the refusal, e.g. `tenant parser 'X.mjs'`.
+ * @returns {*} The parser, when it is dispatchable.
+ * @throws {Error} Coded `TENANT_PARSER_ERROR_CODES.notDispatchable`.
+ */
+export function assertDispatchableParser(parser, subject) {
+    if (typeof parser?.parseIngestionFile === 'function' || typeof parser?.parse === 'function') {
+        return parser
+    }
+
+    const
+        prototype   = parser?.prototype,
+        onPrototype = typeof prototype?.parseIngestionFile === 'function' ||
+                      typeof prototype?.parse             === 'function';
+
+    throw refuse(
+        TENANT_PARSER_ERROR_CODES.notDispatchable,
+        `${subject} but exposes no callable \`parseIngestionFile\` or \`parse\`. ` +
+        (onPrototype
+            // The whole defect, and it is invisible from the symptom: the method IS present.
+            ? 'The methods are declared on the prototype, and the value that gets dispatched is the ' +
+              'constructor itself — it is never instantiated, so they are unreachable. Declare them ' +
+              '`static`, export a singleton instance (`Neo.setupClass` with `singleton: true`), or ' +
+              'export an object literal.'
+            : 'Declare `parseIngestionFile(file, {tenantContext})` on the exported value — as a ' +
+              '`static` method, on a singleton instance, or on an object literal.')
+    )
 }

--- a/ai/services/knowledge-base/source/tenantParserLoader.mjs
+++ b/ai/services/knowledge-base/source/tenantParserLoader.mjs
@@ -59,12 +59,13 @@ import path from 'node:path';
  * @type {Object<String,String>}
  */
 export const TENANT_PARSER_ERROR_CODES = Object.freeze({
-    escapesRoot: 'KB_TENANT_PARSER_SPECIFIER_ESCAPES_ROOT',
-    loadFailed : 'KB_TENANT_PARSER_LOAD_FAILED',
-    noExport   : 'KB_TENANT_PARSER_NO_CLASS_EXPORT',
-    notFound   : 'KB_TENANT_PARSER_NOT_FOUND',
-    rootNotSet : 'KB_TENANT_PARSER_ROOT_NOT_SET',
-    unsafeShape: 'KB_TENANT_PARSER_SPECIFIER_UNSAFE'
+    escapesRoot    : 'KB_TENANT_PARSER_SPECIFIER_ESCAPES_ROOT',
+    loadFailed     : 'KB_TENANT_PARSER_LOAD_FAILED',
+    noExport       : 'KB_TENANT_PARSER_NO_CLASS_EXPORT',
+    notDispatchable: 'KB_TENANT_PARSER_NOT_DISPATCHABLE',
+    notFound       : 'KB_TENANT_PARSER_NOT_FOUND',
+    rootNotSet     : 'KB_TENANT_PARSER_ROOT_NOT_SET',
+    unsafeShape    : 'KB_TENANT_PARSER_SPECIFIER_UNSAFE'
 });
 
 /**
@@ -227,6 +228,31 @@ export async function loadTenantParser({
             `tenant parser '${specifier}' loaded from '${absolutePath}' but exposes no ` +
             `${exportName ? `\`${exportName}\` export` : 'default export'}. A parser module must ` +
             'export its class.'
+        )
+    }
+
+    // Exporting something is not the same as exporting something dispatchable. `resolveFileChunks`
+    // reads `parseIngestionFile` / `parse` off this value directly, so a class carrying either on
+    // `prototype` is truthy while both probes read `undefined`: the not-registered throw is skipped
+    // and the file degrades to a whole-file `raw-text` chunk, which INGESTS SUCCESSFULLY. Refusing
+    // here keeps that case inside the coded taxonomy instead of the one silent path it left open.
+    if (typeof ParserClass.parseIngestionFile !== 'function' && typeof ParserClass.parse !== 'function') {
+        const
+            prototype   = ParserClass.prototype,
+            onPrototype = typeof prototype?.parseIngestionFile === 'function' ||
+                          typeof prototype?.parse             === 'function';
+
+        throw refuse(
+            TENANT_PARSER_ERROR_CODES.notDispatchable,
+            `tenant parser '${specifier}' loaded from '${absolutePath}' but exposes no callable ` +
+            '`parseIngestionFile` or `parse`. ' +
+            (onPrototype
+                // The whole defect, and it is invisible from the symptom: the method IS present.
+                ? 'Dispatch is static: the parser is called on the exported class itself and is never ' +
+                  'instantiated, so an instance method declared on the prototype is unreachable. ' +
+                  'Declare it `static`, or export an object literal.'
+                : 'Declare a `static parseIngestionFile(file, {tenantContext})`, or export an object ' +
+                  'literal carrying that method.')
         )
     }
 

--- a/learn/agentos/cloud-deployment/CustomParsers.md
+++ b/learn/agentos/cloud-deployment/CustomParsers.md
@@ -66,6 +66,14 @@ A registered parser implements one of two methods — the ingestion service (`re
 1. **`parseIngestionFile(file, {tenantContext})` → `parsed-chunk-v1[]`** *(recommended for new parsers).* Receives the push envelope's `files` entry plus the resolved tenant context (`tenantId`, `repoSlug`, `visibility`, …), and returns `parsed-chunk-v1` records directly — no adapter, no signature ambiguity.
 2. **`parse(content, sourcePath, type, hierarchy)` → legacy chunks** *(the contract Neo's built-in `SourceParser` uses).* Returns chunks of the legacy `{type, kind, name, content, source, …}` shape; the ingestion service adapts each into `parsed-chunk-v1` via `legacyChunkToParsedRecord` (it defaults `rootKind: 'external-source'` and `hashInputs: ['kind','name','content','sourcePath','parserId','parserVersion']`).
 
+**Whatever you register is what gets dispatched.** `resolveFileChunks` calls the parse method on the registered value and never instantiates it, so the method has to be callable on that value. Three shapes work:
+
+- a **singleton** — `export default Neo.setupClass(MyParser)` with `singleton: true` exports an *instance*, so ordinary instance methods are reachable. This is the idiom every built-in Source in `ai/services/knowledge-base/source/` uses;
+- a **constructor carrying `static` methods**;
+- a plain **object literal** with the methods on it.
+
+The shape that fails is a plain, non-singleton class whose parse method sits on the prototype: the constructor is what gets registered, nothing instantiates it, and the method is unreachable. That parser used to fall through to `raw-text` — which *ingests successfully*, leaving whole-file chunks, no error, and a plausible chunk count with nothing to notice. A tenant-declared parser in that shape is now refused with `KB_TENANT_PARSER_NOT_DISPATCHABLE` instead.
+
 If a pushed file names a `parserId` that is not registered, the ingestion service returns `KB_PARSER_NOT_REGISTERED` for that file. A raw file with no `parserId` falls through to the built-in `raw-text` handling — the whole file becomes a single chunk.
 
 ## The parser-execution boundary

--- a/test/playwright/unit/ai/services/knowledge-base/IngestionService.tenantParser.spec.mjs
+++ b/test/playwright/unit/ai/services/knowledge-base/IngestionService.tenantParser.spec.mjs
@@ -76,6 +76,32 @@ const PARSER_NAMED = `export class Custom {
 export default null;
 `;
 
+// The broken shape (#17300). The method is present the whole time — it lives on `prototype`, so
+// `ParserClass.parseIngestionFile` reads `undefined` while the class itself stays truthy.
+const PARSER_INSTANCE_METHOD = `export default class ParserInstance {
+    async parseIngestionFile(file) {
+        return [{producedBy: 'ParserInstance', sourcePath: file.sourcePath}]
+    }
+}
+`;
+
+// `parse` is the second probe in the dispatch chain, so an instance-only `parse` degrades the same
+// way. The refusal must not be written against `parseIngestionFile` alone.
+const PARSER_INSTANCE_PARSE = `export default class ParserInstanceParse {
+    async parse(file) {
+        return [{producedBy: 'ParserInstanceParse', sourcePath: file.sourcePath}]
+    }
+}
+`;
+
+// The shape a tenant reaches for when they read the contract as data rather than as a class.
+const PARSER_OBJECT_LITERAL = `export default {
+    async parseIngestionFile(file) {
+        return [{producedBy: 'ParserLiteral', sourcePath: file.sourcePath}]
+    }
+};
+`;
+
 function createGraphStub() {
     const store = new Map();
 
@@ -113,6 +139,9 @@ test.describe('IngestionService — a tenant-declared parser reaches dispatch (#
         fs.writeFileSync(path.join(parserRoot, 'ParserOne.mjs'), PARSER_ONE);
         fs.writeFileSync(path.join(parserRoot, 'ParserTwo.mjs'), PARSER_TWO);
         fs.writeFileSync(path.join(parserRoot, 'Named.mjs'), PARSER_NAMED);
+        fs.writeFileSync(path.join(parserRoot, 'Instance.mjs'), PARSER_INSTANCE_METHOD);
+        fs.writeFileSync(path.join(parserRoot, 'InstanceParse.mjs'), PARSER_INSTANCE_PARSE);
+        fs.writeFileSync(path.join(parserRoot, 'Literal.mjs'), PARSER_OBJECT_LITERAL);
         fs.writeFileSync(path.join(tmpRoot, 'outside', 'Evil.mjs'), PARSER_ONE);
     });
 
@@ -377,5 +406,124 @@ test.describe('IngestionService — a tenant-declared parser reaches dispatch (#
 
         expect(error?.code).toBe('KB_TENANT_PARSER_ROOT_NOT_SET');
         expect(error.message).toContain('NEO_KB_TENANT_PARSER_ROOT');
+    });
+
+    /**
+     * #17300. Dispatch reads `parseIngestionFile` / `parse` off the resolved value itself, so a class
+     * carrying either on `prototype` is truthy while both probes read `undefined`: the
+     * `KB_PARSER_NOT_REGISTERED` throw is skipped, and the file degrades to a whole-file `raw-text`
+     * chunk. Green load, green sweep, quietly worse corpus, and no anomalous count to notice.
+     *
+     * The observable is deliberately the coded refusal AND the absence of a raw-text chunk. Asserting
+     * only that it throws would pass against a deployment that threw for any other reason.
+     */
+    test('an instance-method parser is REFUSED with a coded reason, not degraded to raw-text', async () => {
+        await Service.setTenantConfig({
+            tenantId: 'tenant-a',
+            config  : {customParsers: [{parserId: 'ac-instance', parserModule: 'Instance.mjs'}]}
+        });
+
+        let chunks, error;
+
+        try {
+            chunks = await Service.resolveFileChunks({
+                file         : sourceFile({parserId: 'ac-instance'}),
+                fileIndex    : 0,
+                tenantContext: {tenantId: 'tenant-a'}
+            })
+        } catch (caught) {
+            error = caught
+        }
+
+        expect(chunks, 'the file must not silently become a whole-file chunk').toBeUndefined();
+        expect(error?.code).toBe('KB_TENANT_PARSER_NOT_DISPATCHABLE');
+
+        // The remediation is the entire defect and is invisible from the symptom, so the message has
+        // to carry the static-vs-instance distinction rather than just naming the module.
+        expect(error.message).toContain('Instance.mjs');
+        expect(error.message).toMatch(/static/i);
+        expect(error.message).toMatch(/instance method|prototype/i);
+    });
+
+    test('the refusal covers the `parse` probe too, not just `parseIngestionFile`', async () => {
+        await Service.setTenantConfig({
+            tenantId: 'tenant-a',
+            config  : {customParsers: [{parserId: 'ac-instance-parse', parserModule: 'InstanceParse.mjs'}]}
+        });
+
+        let chunks, error;
+
+        try {
+            chunks = await Service.resolveFileChunks({
+                file         : sourceFile({parserId: 'ac-instance-parse'}),
+                fileIndex    : 0,
+                tenantContext: {tenantId: 'tenant-a'}
+            })
+        } catch (caught) {
+            error = caught
+        }
+
+        expect(chunks).toBeUndefined();
+        expect(error?.code).toBe('KB_TENANT_PARSER_NOT_DISPATCHABLE');
+    });
+
+    /**
+     * The three declared shapes as one table. Only the lookup surface differs between them — the
+     * method is present in all three — so a test that exercised only the corrected shapes would prove
+     * nothing: they already pass today.
+     */
+    for (const {shape, module: parserModule, dispatches, producedBy} of [
+        {shape: 'static-method class', module: 'ParserOne.mjs', dispatches: true,  producedBy: 'ParserOne'},
+        {shape: 'object literal',      module: 'Literal.mjs',   dispatches: true,  producedBy: 'ParserLiteral'},
+        {shape: 'instance-method class', module: 'Instance.mjs', dispatches: false, producedBy: null}
+    ]) {
+        test(`shape table: a ${shape} ${dispatches ? 'dispatches' : 'is refused'}`, async () => {
+            const parserId = `ac-table-${parserModule}`;
+
+            await Service.setTenantConfig({
+                tenantId: 'tenant-a',
+                config  : {customParsers: [{parserId, parserModule}]}
+            });
+
+            let chunks, error;
+
+            try {
+                chunks = await Service.resolveFileChunks({
+                    file         : sourceFile({parserId}),
+                    fileIndex    : 0,
+                    tenantContext: {tenantId: 'tenant-a'}
+                })
+            } catch (caught) {
+                error = caught
+            }
+
+            if (dispatches) {
+                expect(error).toBeUndefined();
+                expect(chunks[0].producedBy).toBe(producedBy)
+            } else {
+                expect(error?.code).toBe('KB_TENANT_PARSER_NOT_DISPATCHABLE');
+                expect(chunks).toBeUndefined()
+            }
+        });
+    }
+
+    test('NEGATIVE CONTROL: a zero-tenant deployment is untouched by the refusal', async () => {
+        // The refusal is scoped to tenant-declared parsers. The global registry is populated once at
+        // import time from static declarations, so a deployment that declares no tenant parser must
+        // resolve exactly as before — including the raw-text fallback for an unparsed file, which
+        // stays correct when nothing was declared.
+        const registryIdsBefore = [...Service.sourceRegistry.getParserIds()];
+
+        await Service.setTenantConfig({tenantId: 'tenant-a', config: {customParsers: []}});
+
+        const chunks = await Service.resolveFileChunks({
+            file         : sourceFile({parserId: undefined}),
+            fileIndex    : 0,
+            tenantContext: {tenantId: 'tenant-a'}
+        });
+
+        expect(chunks).toHaveLength(1);
+        expect(chunks[0].producedBy).toBeUndefined();
+        expect(Service.sourceRegistry.getParserIds()).toEqual(registryIdsBefore);
     });
 });

--- a/test/playwright/unit/ai/services/knowledge-base/IngestionService.tenantParser.spec.mjs
+++ b/test/playwright/unit/ai/services/knowledge-base/IngestionService.tenantParser.spec.mjs
@@ -365,6 +365,97 @@ test.describe('IngestionService — a tenant-declared parser reaches dispatch (#
         expect(chunks[0].producedBy).toBe('InlineParser');
     });
 
+    test('a live ParserClass with a prototype-only method is REFUSED — the other tenant entry path', async () => {
+        // The two declaration forms converge on one consumer, so a guard placed only under
+        // `parserModule` leaves this branch degrading to raw-text exactly as before. This is the
+        // shape the loader refuses, arriving through the tier the loader never sees.
+        class PrototypeOnlyParser {
+            async parseIngestionFile(file) {
+                return [{producedBy: 'PrototypeOnlyParser', sourcePath: file.sourcePath}]
+            }
+        }
+
+        graphStub.store.set('kb-config:tenant-a', {
+            id        : 'kb-config:tenant-a',
+            type      : 'KnowledgeBaseTenantConfig',
+            properties: {version: 1, customParsers: [{parserId: 'ac-inline-proto', ParserClass: PrototypeOnlyParser}]}
+        });
+
+        let chunks, error;
+
+        try {
+            chunks = await Service.resolveFileChunks({
+                file         : sourceFile({parserId: 'ac-inline-proto'}),
+                fileIndex    : 0,
+                tenantContext: {tenantId: 'tenant-a'}
+            })
+        } catch (caught) {
+            error = caught
+        }
+
+        expect(chunks, 'it must not silently become a whole-file chunk').toBeUndefined();
+        expect(error?.code).toBe('KB_TENANT_PARSER_NOT_DISPATCHABLE')
+    });
+
+    test('a live ParserClass that is a SINGLETON INSTANCE dispatches — instance methods are reachable', async () => {
+        // The property is "callable on the value that gets dispatched", not "static". A
+        // `Neo.setupClass` singleton exports an INSTANCE — the idiom every built-in Source uses — so
+        // its ordinary instance methods resolve through the prototype and dispatch fine. A guard
+        // written against "static" would refuse the repository's own shape.
+        const singletonParser = new (class SingletonParser {
+            async parseIngestionFile(file) {
+                return [{producedBy: 'SingletonParser', sourcePath: file.sourcePath}]
+            }
+        })();
+
+        graphStub.store.set('kb-config:tenant-a', {
+            id        : 'kb-config:tenant-a',
+            type      : 'KnowledgeBaseTenantConfig',
+            properties: {version: 1, customParsers: [{parserId: 'ac-inline-singleton', ParserClass: singletonParser}]}
+        });
+
+        const chunks = await Service.resolveFileChunks({
+            file         : sourceFile({parserId: 'ac-inline-singleton'}),
+            fileIndex    : 0,
+            tenantContext: {tenantId: 'tenant-a'}
+        });
+
+        expect(chunks[0].producedBy).toBe('SingletonParser')
+    });
+
+    test('the GLOBAL registry path still dispatches — the control that is not vacuous', async () => {
+        // A control that drives a file with no `parserId` never reaches the global registry at all,
+        // so it cannot detect the guard widening into that path. This one registers a parser there
+        // and dispatches THROUGH it, which is the only way the assertion can fail if the boundary
+        // moves.
+        class GlobalParser {
+            static async parseIngestionFile(file) {
+                return [{producedBy: 'GlobalParser', sourcePath: file.sourcePath}]
+            }
+        }
+
+        const registryIdsBefore = [...Service.sourceRegistry.getParserIds()];
+
+        Service.sourceRegistry.registerParser(GlobalParser, {parserId: 'ac-global'});
+
+        try {
+            // No tenant declaration for this id, so resolution falls through to the global registry.
+            await Service.setTenantConfig({tenantId: 'tenant-a', config: {customParsers: []}});
+
+            const chunks = await Service.resolveFileChunks({
+                file         : sourceFile({parserId: 'ac-global'}),
+                fileIndex    : 0,
+                tenantContext: {tenantId: 'tenant-a'}
+            });
+
+            expect(chunks[0].producedBy, 'the global path dispatches, unchanged by the tenant guard').toBe('GlobalParser')
+        } finally {
+            Service.sourceRegistry._parsers.delete('ac-global')
+        }
+
+        expect(Service.sourceRegistry.getParserIds()).toEqual(registryIdsBefore)
+    });
+
     test('NEGATIVE CONTROL: with no tenant declaration the registry is untouched and the global path answers', async () => {
         // AC5/AC6 — a zero-config deployment must behave exactly as before. The loader existing is
         // not allowed to change what an undeclared tenant resolves.

--- a/test/playwright/unit/ai/services/knowledge-base/IngestionService.tenantParser.spec.mjs
+++ b/test/playwright/unit/ai/services/knowledge-base/IngestionService.tenantParser.spec.mjs
@@ -76,7 +76,7 @@ const PARSER_NAMED = `export class Custom {
 export default null;
 `;
 
-// The broken shape (#17300). The method is present the whole time — it lives on `prototype`, so
+// The broken shape. The method is present the whole time — it lives on `prototype`, so
 // `ParserClass.parseIngestionFile` reads `undefined` while the class itself stays truthy.
 const PARSER_INSTANCE_METHOD = `export default class ParserInstance {
     async parseIngestionFile(file) {
@@ -409,7 +409,7 @@ test.describe('IngestionService — a tenant-declared parser reaches dispatch (#
     });
 
     /**
-     * #17300. Dispatch reads `parseIngestionFile` / `parse` off the resolved value itself, so a class
+     * Dispatch reads `parseIngestionFile` / `parse` off the resolved value itself, so a class
      * carrying either on `prototype` is truthy while both probes read `undefined`: the
      * `KB_PARSER_NOT_REGISTERED` throw is skipped, and the file degrades to a whole-file `raw-text`
      * chunk. Green load, green sweep, quietly worse corpus, and no anomalous count to notice.

--- a/test/playwright/unit/ai/services/knowledge-base/source/tenantParserLoader.spec.mjs
+++ b/test/playwright/unit/ai/services/knowledge-base/source/tenantParserLoader.spec.mjs
@@ -30,11 +30,17 @@ test.describe('tenantParserLoader — a tenant names a module BELOW a deployment
         fs.mkdirSync(path.join(root, 'nested'), {recursive: true});
         fs.mkdirSync(path.join(tmpRoot, 'outside'), {recursive: true});
 
-        fs.writeFileSync(path.join(root, 'Good.mjs'), 'export default class Good {}\n');
-        fs.writeFileSync(path.join(root, 'nested', 'Deep.mjs'), 'export default class Deep {}\n');
-        fs.writeFileSync(path.join(root, 'Named.mjs'), 'export class Custom {}\nexport default null;\n');
+        // The loadable fixtures carry a static `parseIngestionFile` because the loader's contract is
+        // now "returns a DISPATCHABLE parser" (#17300) — an empty class is the exact shape it refuses,
+        // so a stub without one would make these positive controls assert the refusal instead.
+        const dispatchable = name => `export default class ${name} { static parseIngestionFile() { return [] } }\n`;
+
+        fs.writeFileSync(path.join(root, 'Good.mjs'), dispatchable('Good'));
+        fs.writeFileSync(path.join(root, 'nested', 'Deep.mjs'), dispatchable('Deep'));
+        fs.writeFileSync(path.join(root, 'Named.mjs'), 'export class Custom { static parseIngestionFile() { return [] } }\nexport default null;\n');
         fs.writeFileSync(path.join(root, 'NoExport.mjs'), 'export const notAClass = 1;\n');
-        fs.writeFileSync(path.join(tmpRoot, 'outside', 'Evil.mjs'), 'export default class Evil {}\n');
+        fs.writeFileSync(path.join(root, 'Instance.mjs'), 'export default class Instance { parseIngestionFile() { return [] } }\n');
+        fs.writeFileSync(path.join(tmpRoot, 'outside', 'Evil.mjs'), dispatchable('Evil'));
     });
 
     test.afterEach(() => fs.rmSync(tmpRoot, {recursive: true, force: true}));
@@ -125,6 +131,19 @@ test.describe('tenantParserLoader — a tenant names a module BELOW a deployment
         try { await loadTenantParser({specifier: 'NoExport.mjs', root}) } catch (error) { code = error.code }
 
         expect(code).toBe(TENANT_PARSER_ERROR_CODES.noExport);
+    });
+
+    test('a class whose parse method is an INSTANCE method is refused, not returned (#17300)', async () => {
+        // Exporting something is not exporting something dispatchable. This class is truthy and its
+        // method is present, but dispatch reads it off the class itself, so `prototype` is
+        // unreachable and the file would degrade to a whole-file raw-text chunk.
+        let error;
+
+        try { await loadTenantParser({specifier: 'Instance.mjs', root}) } catch (caught) { error = caught }
+
+        expect(error?.code).toBe(TENANT_PARSER_ERROR_CODES.notDispatchable);
+        expect(error.message).toMatch(/static/i);
+        expect(error.message).toMatch(/prototype|instance method/i);
     });
 
     test('a named export is taken when the declaration asks for one', async () => {

--- a/test/playwright/unit/ai/services/knowledge-base/source/tenantParserLoader.spec.mjs
+++ b/test/playwright/unit/ai/services/knowledge-base/source/tenantParserLoader.spec.mjs
@@ -31,7 +31,7 @@ test.describe('tenantParserLoader — a tenant names a module BELOW a deployment
         fs.mkdirSync(path.join(tmpRoot, 'outside'), {recursive: true});
 
         // The loadable fixtures carry a static `parseIngestionFile` because the loader's contract is
-        // now "returns a DISPATCHABLE parser" (#17300) — an empty class is the exact shape it refuses,
+        // now "returns a DISPATCHABLE parser" — an empty class is the exact shape it refuses,
         // so a stub without one would make these positive controls assert the refusal instead.
         const dispatchable = name => `export default class ${name} { static parseIngestionFile() { return [] } }\n`;
 
@@ -133,7 +133,7 @@ test.describe('tenantParserLoader — a tenant names a module BELOW a deployment
         expect(code).toBe(TENANT_PARSER_ERROR_CODES.noExport);
     });
 
-    test('a class whose parse method is an INSTANCE method is refused, not returned (#17300)', async () => {
+    test('a class whose parse method is an INSTANCE method is refused, not returned', async () => {
         // Exporting something is not exporting something dispatchable. This class is truthy and its
         // method is present, but dispatch reads it off the class itself, so `prototype` is
         // unreachable and the file would degrade to a whole-file raw-text chunk.


### PR DESCRIPTION
## Context

A tenant parser that **loads cleanly** but whose parse method is unreachable on the value that gets dispatched degrades silently to whole-file `raw-text` chunks. Green load, green sweep, plausible chunk count, quietly worse corpus — and no anomalous number to notice.

Evidence: L2 (spec-driven dispatch through the real `resolveFileChunks` and `loadTenantParser`, with the graph tier stubbed) → L2 required (every close-target AC of #17300 is unit-observable — a coded refusal, an absent chunk, a dispatched parser). No residuals.

Origin Session ID: 6df18da7-801b-4908-9b84-63f40388a1d0

The new arms are red on unmodified `dev` and green after; knowledge-base suite 775 passed / 0 failed; details below.

## The Problem

`resolveFileChunks` reads the parse method off the resolved value itself:

```
IngestionService.mjs   resolveTenantParser(...) ?? resolveParser(parserId)
                       KB_PARSER_NOT_REGISTERED   <- parser is TRUTHY, so skipped
                       parser?.parseIngestionFile <- undefined for a prototype-only method
                       parser?.parse              <- undefined
                       -> silent whole-file raw-text chunk
```

The method is present the entire time — `typeof F.prototype.parseIngestionFile === 'function'`. Only the lookup surface differs.

**A tenant can declare a parser two ways, and both converge here.** `resolveTenantParser` returns a live `entry.ParserClass` directly, or loads an `entry.parserModule` through `loadTenantParser`. The property that has to hold is the same for both: *the parse method is callable on the value that gets dispatched.*

## The Fix

`assertDispatchableParser` — one predicate, exported from the loader, applied to **both** entry paths. It refuses only when neither `parseIngestionFile` nor `parse` is callable on the value, and detects the prototype-only case specifically so the message names the real remedy.

**Three shapes are valid and all dispatch:** a constructor carrying `static` methods, an object literal, and a `Neo.setupClass` singleton — whose export *is* an instance, which is the idiom every Source in `ai/services/knowledge-base/source/` uses. The only failing shape is a plain, non-singleton constructor whose methods live on `prototype`, because nothing instantiates it.

The global registry path is deliberately untouched: it is populated once at import time from declarations that are already exercised.

## Round 2 — @neo-gpt's REQUEST_CHANGES (review 5021133523)

Conceded in full; four of the five changed behaviour or contract, not wording.

| RA | Disposition |
|---|---|
| RA-1 — guard below only one of two tenant entry paths | **Fixed, and it was the load-bearing one.** `entry.ParserClass` returned directly and still degraded to raw-text. Both paths now share `assertDispatchableParser`. New arm: a live `ParserClass` with a prototype-only method is refused. |
| RA-2 — "dispatch is static" is wrong | **Fixed.** `Neo.setupClass` with `singleton: true` exports an instance whose prototype methods are reachable, so "static" was wrong *in the direction that breaks working code* — it would have told an author to rewrite a working singleton parser. The guard already accepted that shape; only the prose was wrong. New arm pins a singleton instance dispatching. |
| RA-3 — AC-6's deployment-author surface not updated | **Fixed.** `learn/agentos/cloud-deployment/CustomParsers.md` now carries the three valid shapes and the failing one. The previous round only touched internal JSDoc. |
| RA-4 — the global-registry control was vacuous | **Fixed.** It drove a file with no `parserId`, which never reaches the registry. It now registers a parser there and dispatches *through* it, so it can actually fail if the boundary moves. |
| RA-5 — Source-of-Authority | **Attribution removed from every durable artifact.** I could not substantiate it: PR #17297 has no comments and no review body containing the finding, and I authored both that PR and #17300 — so the claim originated with me. Round 2 removed it only from this body, which @neo-gpt correctly called incomplete; round 3 removes it from #17300's body and from the branch's commit messages (message-only rewrite, tree hash `30de997d97` unchanged before and after). |

## AC Evidence

| AC | Proof |
|---|---|
| AC-1 | `assertDispatchableParser` in `tenantParserLoader.mjs` refuses with `KB_TENANT_PARSER_NOT_DISPATCHABLE`, applied at both entry paths (`loadTenantParser`, and `IngestionService.resolveTenantParser`'s live-class branch). Two arms assert the coded reason **and** that `chunks` is `undefined` — a throw alone would pass against a deployment throwing for any other reason, so the absence of the raw-text chunk is asserted separately. |
| AC-2 | The refusal names the actual remedy: the methods are on the prototype, the dispatched value is the constructor, and it is never instantiated — so declare them `static`, export a singleton instance, or export an object literal. Asserted on message content. |
| AC-3 | **Red on unmodified `dev`** with `Error: the file must not silently become a whole-file chunk` — it degraded rather than refused. Green after. |
| AC-4 | Table-driven: static-method class dispatches, object literal dispatches, prototype-only class is refused — plus arms for the `parse` probe, the live-`ParserClass` entry path, and a singleton instance. |
| AC-5 | Two controls: parser ids byte-identical before/after, **and** a parser registered in the global registry that is dispatched through, which is the one that can fail if the guard widens. |
| AC-6 | `CustomParsers.md` (the deployment-author surface), plus `SourceRegistry.registerParser` and `resolveTenantParser` JSDoc — all now state "callable on the registered/dispatched value" and name the singleton shape explicitly. |

## Test Evidence

- `IngestionService.tenantParser.spec.mjs` + `source/tenantParserLoader.spec.mjs` — **33 passed**.
- `test/playwright/unit/ai/services/knowledge-base/` — **775 passed, 0 failed**.
- Lints run bare (no pipe, reading the tool's own exit code): `check-ticket-archaeology` 0 violations; `check-block-alignment` exit 0.

**Reviewer-relevant, stated rather than buried:** this changes fixtures in `tenantParserLoader.spec.mjs`. Its loadable stubs were bare `export default class Good {}` — exactly the shape now refused — so two existing positive controls went red against the new contract. I made the stubs dispatchable rather than exempting them: the loader's contract is now *"returns a dispatchable parser"*, and a fixture that cannot satisfy the producer's real contract tests a shape nothing feeds it. The containment/refusal arms are untouched.

## Deltas

- `ai/services/knowledge-base/source/tenantParserLoader.mjs` — `notDispatchable` code; `assertDispatchableParser` extracted and exported.
- `ai/services/knowledge-base/IngestionService.mjs` — the live-`ParserClass` branch now validated; JSDoc corrected.
- `ai/services/knowledge-base/source/SourceRegistry.mjs` — JSDoc corrected (AC-6).
- `learn/agentos/cloud-deployment/CustomParsers.md` — the deployment-author contract (AC-6).
- `test/.../IngestionService.tenantParser.spec.mjs` — fixtures + arms incl. live-class refusal, singleton dispatch, non-vacuous registry control.
- `test/.../source/tenantParserLoader.spec.mjs` — dispatchable stubs + loader-level refusal arm.

## Post-Merge Validation

- **Informational rollout watching, not an owed residual — there is no `Residual-Owner` because there is no residual.** A tenant already declaring a prototype-only parser will now see a **hard coded refusal where ingestion previously appeared to succeed**. That is the intended direction — the prior success produced a degraded corpus — but it is visible to a deployment, so watch for `KB_TENANT_PARSER_NOT_DISPATCHABLE` in ingestion logs after rollout. Any hit is a corpus that was already silently wrong.
- Out of scope and unchanged: the global-registry path; module content identity in the cache/materialization digest; and validation of what a parser **returns**, which `parsedChunkValidator` owns.

Resolves #17300

Authored by ⚖️ **Ada** · `@neo-opus-ada` · Claude Opus 5 · Claude Code
