### PR TITLE
fix(lint): preserve multiline template state (#16484)

### DIFF
--- a/ai/scripts/lint/lint-retry-bounds.mjs
+++ b/ai/scripts/lint/lint-retry-bounds.mjs
@@ -170,11 +170,15 @@ export function classifyLine(line, inBlockComment) {
  * them); they are a discovery-layer defect. Real false positives that survive this — easing curves,
  * power-law random — are genuine code and do get classified.
  *
- * Template literals spanning multiple lines carry their open state across the scan, because prompts
- * and rendered-report templates are exactly where multi-line markdown lives — leaving continuation
- * lines unstripped put five pure-prose entries in front of the classifier on the first run.
- * Single-quote/double-quote state deliberately does NOT carry: an unterminated `'` is a syntax
- * error, so treating it as open would silently blank the rest of the file.
+ * Template literals spanning multiple lines carry an OPAQUE context stack across the scan, because
+ * a boolean "inside template" cannot represent the nested-template/substitution shape. Losing the
+ * substitution depth at a newline made a nested backtick close the OUTER template; later markdown
+ * then leaked out as code. The stack retains template text, `${...}` brace depth, nested templates,
+ * and strings inside substitutions until their actual delimiters close.
+ *
+ * Single-quote/double-quote state outside a substitution deliberately does NOT carry: an
+ * unterminated quote is a syntax error, so treating it as open would silently blank the rest of the
+ * file. Quotes inside a multi-line substitution do carry as part of that substitution's context.
  *
  * **`${…}` substitutions are PRESERVED.** They are executable code that merely lives inside a
  * template, and blanking them cost a real site: `src/form/field/FileUpload.mjs` computes
@@ -182,47 +186,106 @@ export function classifyLine(line, inBlockComment) {
  * it. Nesting is tracked by depth so a substitution containing its own template (or an object
  * literal's braces) closes at the right brace rather than the first one.
  * @param {String} line Raw source line.
- * @param {Boolean} [inTemplate=false] Whether the scanner is inside a multi-line template literal.
- * @returns {{code: String, inTemplate: Boolean}} Line with literal TEXT blanked, substitutions kept.
+ * @param {Boolean|Object} [state=false] Prior opaque state. Boolean input remains supported for the
+ *                                      focused single-line contract; production passes `state` back.
+ * @returns {{code: String, inTemplate: Boolean, state: Object}} Line with literal TEXT blanked,
+ *                                                               substitutions kept, and next state.
  */
-export function stripLiterals(line, inTemplate = false) {
-    let out        = '',
-        quote      = inTemplate ? '`' : null,
-        substDepth = 0;
+export function stripLiterals(line, state = false) {
+    const contexts = state && typeof state === 'object' && Array.isArray(state.contexts)
+        ? state.contexts.map(context => ({...context}))
+        : state === true ? [{type: 'template'}] : [];
+
+    let out       = '',
+        rootQuote = null;
+
+    const isEscaped = index => {
+        let slashCount = 0;
+
+        for (let i = index - 1; i >= 0 && line[i] === '\\'; i--) {
+            slashCount++
+        }
+
+        return slashCount % 2 === 1
+    };
 
     for (let i = 0; i < line.length; i++) {
-        const char = line[i],
-              prev = line[i - 1];
+        const char    = line[i],
+              context = contexts.at(-1);
 
-        // Inside a `${...}` substitution the content is code: emit it verbatim and track brace depth
-        // so a nested template or object literal does not close the substitution early.
-        if (substDepth > 0) {
-            if (char === '{') substDepth++;
-            if (char === '}') substDepth--;
-            out += substDepth === 0 ? ' ' : char;
+        if (context?.type === 'template') {
+            if (char === '$' && line[i + 1] === '{' && !isEscaped(i)) {
+                contexts.push({type: 'substitution', braceDepth: 1, quote: null});
+                out += '  ';
+                i++
+            } else if (char === '`' && !isEscaped(i)) {
+                contexts.pop();
+                out += char
+            } else {
+                out += ' '
+            }
+
             continue;
         }
 
-        if (quote) {
-            if (quote === '`' && char === '$' && line[i + 1] === '{') {
-                substDepth = 1;
-                out       += '  ';
-                i++;
-            } else if (char === quote && prev !== '\\') {
-                quote = null;
-                out  += char;
+        if (context?.type === 'substitution') {
+            if (context.quote) {
+                if (char === context.quote && !isEscaped(i)) {
+                    context.quote = null;
+                    out          += char
+                } else {
+                    out += ' '
+                }
+            } else if ((char === '\'' || char === '"') && !isEscaped(i)) {
+                context.quote = char;
+                out          += char
+            } else if (char === '`' && !isEscaped(i)) {
+                contexts.push({type: 'template'});
+                out += char
+            } else if (char === '{') {
+                context.braceDepth++;
+                out += char
+            } else if (char === '}') {
+                context.braceDepth--;
+
+                if (context.braceDepth === 0) {
+                    contexts.pop();
+                    out += ' '
+                } else {
+                    out += char
+                }
             } else {
-                out += ' ';
+                out += char
             }
-        } else if (char === '\'' || char === '"' || char === '`') {
-            quote = char;
-            out  += char;
+
+            continue;
+        }
+
+        if (rootQuote) {
+            if (char === rootQuote && !isEscaped(i)) {
+                rootQuote = null;
+                out      += char
+            } else {
+                out += ' '
+            }
+        } else if ((char === '\'' || char === '"') && !isEscaped(i)) {
+            rootQuote = char;
+            out      += char
+        } else if (char === '`' && !isEscaped(i)) {
+            contexts.push({type: 'template'});
+            out += char
         } else {
-            out += char;
+            out += char
         }
     }
 
-    return {code: out, inTemplate: quote === '`'};
+    const nextState = {contexts};
+
+    return {
+        code      : out,
+        inTemplate: contexts.some(context => context.type === 'template'),
+        state     : nextState
+    }
 }
 
 /**
@@ -394,7 +457,7 @@ export function discoverCandidates({rootDir = ROOT_DIR} = {}) {
                   lines = fs.readFileSync(file, 'utf8').split('\n');
 
             let inBlockComment = false,
-                inTemplate     = false;
+                literalState   = false;
 
             lines.forEach((line, index) => {
                 const state = classifyLine(line, inBlockComment);
@@ -404,31 +467,9 @@ export function discoverCandidates({rootDir = ROOT_DIR} = {}) {
                 // one that a preceding code line left open.
                 if (!state.isCode) return;
 
-                const stripped = stripLiterals(line, inTemplate),
-                      wasOpen  = inTemplate;
+                const stripped = stripLiterals(line, literalState);
 
-                inTemplate = stripped.inTemplate;
-
-                // KNOWN FALSE NEGATIVE, retained deliberately (@neo-gpt-emmy's scanner escape).
-                //
-                // A growth expression inside a `${…}` substitution on a CONTINUATION line of a
-                // multi-line template is preserved by `stripLiterals` and then discarded here —
-                // discovered and dropped in the same pass. That is a real escape and it is not fixed.
-                //
-                // Removing this return does NOT fix it, which is the measured part. Doing so
-                // immediately surfaces `ai/demo-agents/dev.mjs:258` as a candidate whose match is
-                // `**AI Generated PR**` — markdown bold inside literal text, exactly what
-                // `stripLiterals` exists to blank. The cause is upstream: the template opened at
-                // dev.mjs:118 is never seen to close, so by 258 the scanner still believes it is
-                // inside a template; `stripLiterals(line, true)` then reads 258's OPENING backtick
-                // as a CLOSE and emits the whole literal as code.
-                //
-                // So this return is masking a `stripLiterals` state-tracking defect as well as the
-                // escape, and lifting it trades a known false negative for a false positive — which
-                // is the worse of the two, because a gate that cries wolf gets routed around. The
-                // real repair is multi-line template state tracking, which is outside the closure
-                // boundary set for this PR. Recorded rather than silently retained.
-                if (wasOpen) return;
+                literalState = stripped.state;
 
                 // Every match, not the first. `PATTERNS.find` returned one hit per line, so
                 // `(px - a) ** 2 + (py - b) ** 2` — two growth expressions — produced ONE obligation
@@ -521,7 +562,8 @@ export function unresolvedWitnessPaths(key, witness, rootDir = ROOT_DIR) {
  * @summary A `retry-growth` entry must name lifetime AND carrier; a `not-a-retry` entry must not,
  * because a bound carrier for something that never retries is a claim nobody can witness. BOTH
  * require a witness — that requirement is what keeps this a classification registry rather than a
- * suppression allowlist.
+ * suppression allowlist. Witness semantics are owned by `retry-bound-registry.json#$schema.witness`;
+ * this validator enforces the shape and resolves every path/symbol the witness chooses to name.
  * @param {String} key Registry key.
  * @param {Object} entry Registry entry.
  * @returns {String[]} Problems; empty when valid.

--- a/ai/scripts/lint/lint-retry-bounds.mjs
+++ b/ai/scripts/lint/lint-retry-bounds.mjs
@@ -174,11 +174,13 @@ export function classifyLine(line, inBlockComment) {
  * a boolean "inside template" cannot represent the nested-template/substitution shape. Losing the
  * substitution depth at a newline made a nested backtick close the OUTER template; later markdown
  * then leaked out as code. The stack retains template text, `${...}` brace depth, nested templates,
- * and strings inside substitutions until their actual delimiters close.
+ * until their actual delimiters close.
  *
  * Single-quote/double-quote state outside a substitution deliberately does NOT carry: an
  * unterminated quote is a syntax error, so treating it as open would silently blank the rest of the
- * file. Quotes inside a multi-line substitution do carry as part of that substitution's context.
+ * file. The same rule applies inside substitutions: without modelling regex literals, a quote glyph
+ * in `/["']/` cannot safely become resumable string state. Substitution code therefore carries only
+ * brace/template structure across lines, matching the pre-existing scanner boundary.
  *
  * **`${…}` substitutions are PRESERVED.** They are executable code that merely lives inside a
  * template, and blanking them cost a real site: `src/form/field/FileUpload.mjs` computes
@@ -190,6 +192,7 @@ export function classifyLine(line, inBlockComment) {
  *                                      focused single-line contract; production passes `state` back.
  * @returns {{code: String, inTemplate: Boolean, state: Object}} Line with literal TEXT blanked,
  *                                                               substitutions kept, and next state.
+ * `inTemplate` is reporting-only; callers must pass `state` to resume without losing substitutions.
  */
 export function stripLiterals(line, state = false) {
     const contexts = state && typeof state === 'object' && Array.isArray(state.contexts)
@@ -215,7 +218,7 @@ export function stripLiterals(line, state = false) {
 
         if (context?.type === 'template') {
             if (char === '$' && line[i + 1] === '{' && !isEscaped(i)) {
-                contexts.push({type: 'substitution', braceDepth: 1, quote: null});
+                contexts.push({type: 'substitution', braceDepth: 1});
                 out += '  ';
                 i++
             } else if (char === '`' && !isEscaped(i)) {
@@ -229,17 +232,7 @@ export function stripLiterals(line, state = false) {
         }
 
         if (context?.type === 'substitution') {
-            if (context.quote) {
-                if (char === context.quote && !isEscaped(i)) {
-                    context.quote = null;
-                    out          += char
-                } else {
-                    out += ' '
-                }
-            } else if ((char === '\'' || char === '"') && !isEscaped(i)) {
-                context.quote = char;
-                out          += char
-            } else if (char === '`' && !isEscaped(i)) {
+            if (char === '`' && !isEscaped(i)) {
                 contexts.push({type: 'template'});
                 out += char
             } else if (char === '{') {

--- a/ai/scripts/lint/retry-bound-registry.json
+++ b/ai/scripts/lint/retry-bound-registry.json
@@ -16,7 +16,7 @@
             "max-window",
             "terminal-state"
         ],
-        "witness": "REQUIRED for every entry. Names the spec or the bounding construct that PROVES the classification. An entry without one is a suppression, not a classification.",
+        "witness": "REQUIRED for every entry. Source-keyed contract: the site key anchors the source; the witness may state a co-located construct/rationale inline or name a repo-relative path with an optional #symbol. Every named path/symbol must resolve. An entry without a witness is a suppression, not a classification.",
         "regenerate": "node ai/scripts/lint/lint-retry-bounds.mjs --list"
     },
     "sites": {

--- a/test/playwright/unit/ai/scripts/lint/lintRetryBounds.spec.mjs
+++ b/test/playwright/unit/ai/scripts/lint/lintRetryBounds.spec.mjs
@@ -339,6 +339,17 @@ test.describe('lint-retry-bounds — discovery + explicit bound classification (
         expect(candidates).toEqual([])
     });
 
+    test('regex quote glyphs inside a substitution do not corrupt later literal state', () => {
+        const candidates = discoverFixture([
+            'export function quoteForShell(value) {',
+            '    const escaped = `"${value.replace(/[()%!^"<>&|]/g, match => `^${match}`)}"`;',
+            '    return `see the base ** attempt note in the docs`',
+            '}'
+        ].join('\n'));
+
+        expect(candidates).toEqual([])
+    });
+
     test('comment lines are excluded by shape, including block continuations', () => {
         expect(classifyLine('  const a = 2 ** b;', false).isCode).toBe(true);
         expect(classifyLine('  // 2 ** b', false).isCode).toBe(false);

--- a/test/playwright/unit/ai/scripts/lint/lintRetryBounds.spec.mjs
+++ b/test/playwright/unit/ai/scripts/lint/lintRetryBounds.spec.mjs
@@ -1,5 +1,6 @@
 import {test, expect} from '@playwright/test';
 import fs             from 'fs-extra';
+import os             from 'os';
 import path           from 'path';
 import {
     classifyLine,
@@ -30,6 +31,25 @@ function siteStartingWith(prefix) {
     expect(hit, `no registry entry starts with ${prefix}`).toBeTruthy();
 
     return hit[1];
+}
+
+/**
+ * Runs the production discovery seam against one disposable source file.
+ *
+ * @param {String} source Fixture source.
+ * @returns {Object[]} Discovered candidates.
+ */
+function discoverFixture(source) {
+    const rootDir = fs.mkdtempSync(path.join(os.tmpdir(), 'neo-retry-bounds-template-'));
+
+    try {
+        ['ai', 'src', 'apps', 'buildScripts'].forEach(dir => fs.ensureDirSync(path.join(rootDir, dir)));
+        fs.writeFileSync(path.join(rootDir, 'ai/templateFixture.mjs'), source);
+
+        return discoverCandidates({rootDir})
+    } finally {
+        fs.removeSync(rootDir)
+    }
 }
 
 test.describe('lint-retry-bounds — discovery + explicit bound classification (#16443)', () => {
@@ -257,6 +277,20 @@ test.describe('lint-retry-bounds — discovery + explicit bound classification (
         }).join(' ')).toMatch(/does not exist/);
     });
 
+    test('the witness contract is source-keyed — inline rationale or a resolvable path', () => {
+        expect(REGISTRY.$schema.witness).toMatch(/Source-keyed contract/);
+
+        expect(validateEntry('ai/example.mjs#schedule:deadbeef', {
+            kind   : 'not-a-retry',
+            witness: 'The exponent is byte-unit conversion evaluated once; no retry loop exists.'
+        })).toEqual([]);
+
+        expect(validateEntry('ai/example.mjs#schedule:deadbeef', {
+            kind   : 'not-a-retry',
+            witness: 'Guarded by ai/agent/Loop.mjs#processEvent'
+        })).toEqual([])
+    });
+
     test('every live witness resolves', () => {
         Object.entries(SITES).forEach(([key, entry]) => {
             expect(unresolvedWitnessPaths(key, entry.witness)).toEqual([]);
@@ -270,6 +304,39 @@ test.describe('lint-retry-bounds — discovery + explicit bound classification (
         // Multi-line template state carries, so a prose continuation line is not scanned as code.
         expect(stripLiterals('const s = `line one', false).inTemplate).toBe(true);
         expect(stripLiterals('  2. **Feature Namespace:** prose', true).code.trim()).toBe('');
+    });
+
+    test('a growth expression in a continuation-line template substitution IS discovered', () => {
+        const candidates = discoverFixture([
+            'export function schedule(base, attempt) {',
+            '    return `status:',
+            '        ${base * 2 ** attempt}',
+            '    `',
+            '}'
+        ].join('\n'));
+
+        expect(candidates).toHaveLength(1);
+        expect(candidates[0]).toMatchObject({
+            file   : 'ai/templateFixture.mjs',
+            line   : 3,
+            pattern: 'exponent',
+            symbol : 'schedule'
+        })
+    });
+
+    test('nested templates do not leak later markdown bold into discovery', () => {
+        const candidates = discoverFixture([
+            'export function render(items, issueId, changes) {',
+            '    const prompt = `header',
+            '        ${items.map(item => `',
+            '            ${item}',
+            '        `).join("\\n")}',
+            '    `;',
+            '    return `Closes #${issueId}\\n\\n**AI Generated PR**\\n${changes.map(change => `- ${change}`).join("\\n")}`',
+            '}'
+        ].join('\n'));
+
+        expect(candidates).toEqual([])
     });
 
     test('comment lines are excluded by shape, including block continuations', () => {


### PR DESCRIPTION
Resolves #16484

The retry-bound scanner now carries an opaque template/substitution context stack across source lines, so executable growth inside a continuation-line `${...}` is classified without leaking nested-template markdown into the candidate set. The registry's existing witness behavior is made explicit as a source-keyed contract rather than converted into a path-only migration.

Evidence: L2 (end-to-end disposable-source discovery plus the exact live-tree lint) → L2 required (all six close-target ACs are repository-local and unit-observable). No residuals.

## AC Evidence

| AC | Evidence |
|---|---|
| AC-1 | `lintRetryBounds.spec.mjs` carries opposing fixtures: continuation-line growth is discovered; nested-template markdown produces zero candidates. |
| AC-2 | Both fixtures enter through `discoverFixture()` → production `discoverCandidates()`, not a direct `stripLiterals()` call. |
| AC-3 | The live-tree classification arm remains exact, and the production command reports every candidate classified; the nested fixture reproduces the `ai/demo-agents/dev.mjs:258` false-positive class. |
| AC-4 | The `wasOpen` suppression branch is removed; `discoverCandidates()` passes the returned opaque state to the next line. |
| AC-5 | Both deletion controls are red: restoring continuation suppression loses the growth candidate; collapsing the state stack to a boolean leaks markdown in both the fixture and the live tree. Reviewer census after the regex-quote repair is 10 runaway EOF contexts, equal to `dev` and down from 12 on Round 1. |
| AC-6 | `retry-bound-registry.json#$schema.witness` owns the source-keyed contract; `validateEntry()` cites that authority and the focused spec accepts inline rationale plus a resolvable path/symbol. |

## Deltas from ticket

The witness fork resolves to the existing source-keyed semantics: the registry key anchors the site; inline co-located rationale is valid; any repo path or `#symbol` a witness names must resolve. Requiring path-only witnesses would reclassify the established registry without strengthening inline bounds such as same-expression clamps.

## Test Evidence

- Pre-fix red: the new continuation-substitution arm failed exactly once while the markdown control and 20 neighboring tests passed.
- Suppression mutation: reintroducing the `wasOpen` return failed only the continuation arm (1 failed / 21 passed).
- State-collapse mutation: replacing the opaque state with its boolean projection failed the nested-template arm and exposed the real `ai/demo-agents/dev.mjs:258` false candidate (3 failed / 19 passed).
- Review repair: removing unsound substitution quote-state reduced the complete `ai/**/*.mjs` runaway-context census from 12 to 10 (parity with `dev`); the regex-quote fixture stays at zero candidates.

## Post-Merge Validation

None. The production lint and its focused unit family are the standing contract.

## Commits

- `132ed02e95` — preserve multi-line template state and pin both error polarities.
- `fd482fc02e` — remove regex-ambiguous quote state and restore census parity.

Authored by Euclid (OpenAI GPT-5.6 Sol, Codex Desktop). Session d16d6348-b17f-4119-8e0d-dd7c4dab104b.

## Evolution

Round-1 review measured 12 files left in runaway literal context versus 10 on `dev`. The carried `context.quote` state could not distinguish strings from regex character classes, so it was removed rather than expanded into a partial regex parser; the template/substitution stack remains, and the live census is back at 10.