### PR TITLE
fix(kb): consult the parser-identity signal during reconciliation (#17392)

### DIFF
--- a/ai/daemons/kb-reconciliation/KbReconciliationService.mjs
+++ b/ai/daemons/kb-reconciliation/KbReconciliationService.mjs
@@ -11,6 +11,7 @@ import logger            from '../../mcp/server/knowledge-base/logger.mjs';
 import {
     diffTenantChunks,
     diffTenantManifest,
+    diffTenantParserIdentity,
     formatReconciliationDetail,
     resolveOrphanVersionGap
 } from '../../services/knowledge-base/helpers/kbReconciliationEngine.mjs';
@@ -217,9 +218,21 @@ class KbReconciliationService extends Base {
             const currentVersion  = await this.fetchTenantConfigVersion(tenantId),
                   rows            = await this.fetchTenantRows(collection, tenantId),
                   manifestsByRepo = await this.fetchTenantManifests(tenantId),
-                  configDiff      = diffTenantChunks({rows, currentVersion, orphanVersionGap}),
-                  manifestDiff    = diffTenantManifest({rows, manifestsByRepo}),
-                  diff            = this.combineDiffs({configDiff, manifestDiff});
+                  declaredByRepo  = await this.fetchTenantDeclaredParsers(tenantId),
+                  // The manifest already records the paths the current push yields per repo, which is
+                  // exactly tier 1's question. A repo with no manifest is therefore *unknown* rather
+                  // than *empty*: `diffTenantParserIdentity` skips tier 1 for it and every row falls
+                  // to the replacement-gated tier, so a missing manifest can never mark a whole repo
+                  // actionable.
+                  yieldedPathsByRepo = Object.fromEntries(
+                      Object.entries(manifestsByRepo || {})
+                          .filter(([, manifest]) => Array.isArray(manifest?.pathsAfterPush))
+                          .map(([repo, manifest]) => [repo, manifest.pathsAfterPush])
+                  ),
+                  configDiff        = diffTenantChunks({rows, currentVersion, orphanVersionGap}),
+                  manifestDiff      = diffTenantManifest({rows, manifestsByRepo}),
+                  parserDiff        = diffTenantParserIdentity({rows, tenantId, declaredByRepo, yieldedPathsByRepo}),
+                  diff              = this.combineDiffs({configDiff, manifestDiff, parserDiff});
 
             if (diff.totalOrphanCount === 0) {
                 return // clean tenant — emit nothing
@@ -233,7 +246,7 @@ class KbReconciliationService extends Base {
 
             this.recordReconcileMetric({tenantId, repoSlug, diff, currentVersion, autoTombstone, tombstonedCount});
 
-            logger.info(`[KbReconciliationService] tenant ${tenantId}: ${diff.staleCount} config-stale chunk(s), ${diff.manifestOrphanCount} manifest-orphan chunk(s), ${diff.actionableCount} actionable, ${tombstonedCount} tombstoned (autoTombstone=${autoTombstone})`)
+            logger.info(`[KbReconciliationService] tenant ${tenantId}: ${diff.staleCount} config-stale chunk(s), ${diff.manifestOrphanCount} manifest-orphan chunk(s), ${diff.parserOrphanCount} parser-identity orphan chunk(s), ${diff.actionableCount} actionable, ${tombstonedCount} tombstoned (autoTombstone=${autoTombstone})`)
         } catch (err) {
             logger.error(`[KbReconciliationService] Reconciliation failed for tenant ${tenantId}: ${err.message}`)
         }
@@ -308,6 +321,40 @@ class KbReconciliationService extends Base {
     }
 
     /**
+     * @summary Test-stubbable seam — the `{parserId, parserVersion}` each of a tenant's repos
+     * currently declares, keyed by `repoSlug`.
+     *
+     * **The `parserVersion` default is load-bearing, not tidiness.** Chunk construction stamps
+     * `file.parserVersion || '1.0.0'` (`IngestionService.mjs:2402`, `:2430`), so a repo that declares
+     * no version produces rows stamped `'1.0.0'`. Resolving the declared pair without that same
+     * default would compare `undefined` against `'1.0.0'` and classify every row of such a repo as a
+     * parser orphan — a reclaim of the entire repo, caused by a comparison the producer never made.
+     *
+     * **A repo declaring no `parserId` is omitted rather than defaulted.** Omission makes it
+     * *unknown* to the classifier, which skips it; inventing an id would make its rows comparable to
+     * a pair nothing declared. Same reasoning as `yieldedPathsByRepo`'s unknown-vs-empty rule.
+     *
+     * @param {String} tenantId
+     * @returns {Promise<Object<String, {parserId: String, parserVersion: String}>>}
+     * @protected
+     */
+    async fetchTenantDeclaredParsers(tenantId) {
+        const config         = await IngestionService.getTenantConfig({tenantId}),
+              declaredByRepo = {};
+
+        for (const repo of config?.tenantRepos || []) {
+            if (typeof repo?.repoSlug === 'string' && repo.repoSlug && typeof repo?.parserId === 'string' && repo.parserId) {
+                declaredByRepo[repo.repoSlug] = {
+                    parserId     : repo.parserId,
+                    parserVersion: repo.parserVersion || '1.0.0'
+                }
+            }
+        }
+
+        return declaredByRepo
+    }
+
+    /**
      * @summary Combines config-stale and manifest-orphan diff axes into one delete/telemetry contract.
      * @param {Object} params
      * @param {Object} params.configDiff Result from `diffTenantChunks`.
@@ -315,21 +362,27 @@ class KbReconciliationService extends Base {
      * @returns {{staleOrphans: Array, manifestOrphans: Array, staleCount: Number, manifestOrphanCount: Number, totalOrphanCount: Number, actionableIds: Array<String>, actionableCount: Number}}
      * @protected
      */
-    combineDiffs({configDiff, manifestDiff} = {}) {
+    combineDiffs({configDiff, manifestDiff, parserDiff} = {}) {
         const actionableIds = [...new Set([
             ...(configDiff?.actionableIds || []),
-            ...(manifestDiff?.actionableIds || [])
+            ...(manifestDiff?.actionableIds || []),
+            ...(parserDiff?.actionableIds || [])
         ])];
+        // De-duplicated by id on purpose: one row can be an orphan under more than one signal, and
+        // `totalOrphanCount` answers "how many rows", never "how many classifications".
         const orphanIds = new Set([
             ...(configDiff?.staleOrphans || []).map(orphan => orphan.id),
-            ...(manifestDiff?.manifestOrphans || []).map(orphan => orphan.id)
+            ...(manifestDiff?.manifestOrphans || []).map(orphan => orphan.id),
+            ...(parserDiff?.parserOrphans || []).map(orphan => orphan.id)
         ].filter(id => typeof id === 'string' && id.length > 0));
 
         return {
             staleOrphans       : configDiff?.staleOrphans || [],
             manifestOrphans    : manifestDiff?.manifestOrphans || [],
+            parserOrphans      : parserDiff?.parserOrphans || [],
             staleCount         : configDiff?.staleCount || 0,
             manifestOrphanCount: manifestDiff?.orphanCount || 0,
+            parserOrphanCount  : parserDiff?.parserOrphanCount || 0,
             totalOrphanCount   : orphanIds.size,
             actionableIds,
             actionableCount    : actionableIds.length

--- a/test/playwright/unit/ai/daemons/kb-reconciliation/KbReconciliationService.spec.mjs
+++ b/test/playwright/unit/ai/daemons/kb-reconciliation/KbReconciliationService.spec.mjs
@@ -51,7 +51,7 @@ test.describe('Neo.ai.daemons.KbReconciliationService (#11640)', () => {
         id,
         metadata: {
             tenantConfigVersion: v,
-            ingestedAt          : 1000,
+            ingestedAt         : 1000,
             repoSlug           : 'repo-x',
             sourcePath         : 'src/' + id + '.js',
             tenantId           : 'tenant-x',
@@ -73,12 +73,12 @@ test.describe('Neo.ai.daemons.KbReconciliationService (#11640)', () => {
         logger            = (await import('../../../../../../ai/mcp/server/knowledge-base/logger.mjs')).default;
 
         originals = {
-            recorderReady       : KBRecorderService.ready,
-            getTenantIngestion  : KBRecorderService.getTenantIngestionRollup,
+            recorderReady        : KBRecorderService.ready,
+            getTenantIngestion   : KBRecorderService.getTenantIngestionRollup,
             recordIngestionMetric: KBRecorderService.recordIngestionMetric,
-            warn                : logger.warn,
-            error               : logger.error,
-            info                : logger.info
+            warn                 : logger.warn,
+            error                : logger.error,
+            info                 : logger.info
         };
 
         // `start()` awaits KBRecorderService.ready() — stub it to resolve immediately.
@@ -99,7 +99,8 @@ test.describe('Neo.ai.daemons.KbReconciliationService (#11640)', () => {
         // Drop instance-method seam overrides so the real prototype methods resurface for
         // the next test — an instance override otherwise leaks across tests in the worker.
         for (const seam of ['getKbConfig', 'fetchTenants', 'getCollection', 'fetchTenantConfigVersion',
-                             'fetchTenantRows', 'fetchTenantManifests', 'tombstoneOrphans', 'recordReconcileMetric',
+                             'fetchTenantRows', 'fetchTenantManifests', 'fetchTenantDeclaredParsers',
+                             'tombstoneOrphans', 'recordReconcileMetric',
                              'reconcileTenant', 'scheduleNext']) {
             delete KbReconciliationService[seam];
         }
@@ -228,10 +229,13 @@ test.describe('Neo.ai.daemons.KbReconciliationService (#11640)', () => {
 
     test.describe('reconcileTenant', () => {
         /** Wires the per-tenant seams; `rows` drives the real KbReconciliationEngine diff. */
-        function wireTenant({version, rows, manifestsByRepo = {}}) {
-            KbReconciliationService.fetchTenantConfigVersion = async () => version;
-            KbReconciliationService.fetchTenantRows          = async () => rows;
-            KbReconciliationService.fetchTenantManifests     = async () => manifestsByRepo;
+        function wireTenant({version, rows, manifestsByRepo = {}, declaredByRepo = {}}) {
+            KbReconciliationService.fetchTenantConfigVersion   = async () => version;
+            KbReconciliationService.fetchTenantRows            = async () => rows;
+            KbReconciliationService.fetchTenantManifests       = async () => manifestsByRepo;
+            // Stubbed even when empty: left unstubbed this seam reaches the real
+            // `IngestionService.getTenantConfig` from a unit test.
+            KbReconciliationService.fetchTenantDeclaredParsers = async () => declaredByRepo;
         }
 
         test('a clean tenant emits no telemetry and tombstones nothing', async () => {
@@ -272,7 +276,7 @@ test.describe('Neo.ai.daemons.KbReconciliationService (#11640)', () => {
             applyStubs();
             wireTenant({
                 version: 0,
-                rows: [
+                rows   : [
                     row('live', 0),
                     row('manifest-orphan', 0, {sourcePath: 'src/orphan.js'})
                 ],
@@ -320,7 +324,7 @@ test.describe('Neo.ai.daemons.KbReconciliationService (#11640)', () => {
             applyStubs();
             wireTenant({
                 version: 5,
-                rows: [
+                rows   : [
                     row('overlap', 1, {sourcePath: 'src/old.js'}),
                     row('manifest-only', 5, {sourcePath: 'src/removed.js'}),
                     row('live', 5)
@@ -352,7 +356,7 @@ test.describe('Neo.ai.daemons.KbReconciliationService (#11640)', () => {
             applyStubs();
             wireTenant({
                 version: 0,
-                rows: [
+                rows   : [
                     row('old-orphan', 0, {sourcePath: 'src/old.js', ingestedAt: 1000}),
                     row('newer-row', 0, {sourcePath: 'src/new.js', ingestedAt: 3000}),
                     row('live', 0)
@@ -447,8 +451,8 @@ test.describe('Neo.ai.daemons.KbReconciliationService (#11640)', () => {
         });
 
         test('is a no-op for an empty / non-array id set', async () => {
-            let deleteCalled = 0;
-            const collection = {delete: async () => { deleteCalled++ }};
+            let   deleteCalled = 0;
+            const collection   = {delete: async () => { deleteCalled++ }};
 
             expect(await KbReconciliationService.tombstoneOrphans(collection, [])).toBe(0);
             expect(await KbReconciliationService.tombstoneOrphans(collection, null)).toBe(0);
@@ -481,6 +485,172 @@ test.describe('Neo.ai.daemons.KbReconciliationService (#11640)', () => {
             expect(events[0].detail).toMatchObject({
                 staleCount: 4, actionableCount: 3, tombstonedCount: 3, currentVersion: 9, autoTombstone: true
             });
+        });
+    });
+
+    /**
+     * The third reconciliation signal, consulted by the daemon rather than only by its own spec.
+     *
+     * `diffTenantParserIdentity` shipped classified-but-unwired: green in isolation while no
+     * reconciliation tick called it, so a superseded parser generation stayed queryable forever. The
+     * arms below therefore assert the DAEMON's behaviour — what reaches `tombstoneOrphans` and the
+     * telemetry — never the classifier's return value, which was already covered.
+     */
+    test.describe('reconcileTenant — parser-identity signal', () => {
+        const REPO     = 'org/repo',
+              DECLARED = {parserId: 'docker-mcp-source', parserVersion: '1.1.0'},
+              OLD      = {parserId: 'docker-mcp-source', parserVersion: '1.0.0'};
+
+        /**
+         * @param {Object} options
+         * @returns {Object} One Chroma row carrying a parser pair.
+         */
+        function parserRow({id, path, parser = OLD, repoSlug = REPO, configVersion = 5}) {
+            return {
+                id,
+                metadata: {
+                    tenantId           : 'tenant-x',
+                    repoSlug,
+                    sourcePath         : path,
+                    parserId           : parser.parserId,
+                    parserVersion      : parser.parserVersion,
+                    tenantConfigVersion: configVersion
+                }
+            }
+        }
+
+        /**
+         * @param {Object} options
+         * @returns {Promise<{tombstonedIds: String[], metrics: Object[]}>}
+         */
+        async function run({rows, declaredByRepo, manifestsByRepo = {}, autoTombstone = true}) {
+            applyStubs();
+
+            KbReconciliationService.fetchTenantConfigVersion   = async () => 5;
+            KbReconciliationService.fetchTenantRows            = async () => rows;
+            KbReconciliationService.fetchTenantManifests       = async () => manifestsByRepo;
+            KbReconciliationService.fetchTenantDeclaredParsers = async () => declaredByRepo;
+
+            const tombstonedIds = [], metrics = [];
+
+            KbReconciliationService.tombstoneOrphans      = async (collection, ids) => {
+                tombstonedIds.push(...ids);
+                return ids.length
+            };
+            KbReconciliationService.recordReconcileMetric = metric => { metrics.push(metric) };
+
+            await KbReconciliationService.reconcileTenant({
+                tenantId: 'tenant-x', repoSlug: REPO, collection: {}, orphanVersionGap: 2, autoTombstone
+            });
+
+            return {tombstonedIds, metrics}
+        }
+
+        test('RED-PROOF: a superseded generation is reclaimed by the DAEMON, not merely classifiable', async () => {
+            // Fails before the wiring: the classifier would return the orphan and nothing would ask.
+            const {tombstonedIds, metrics} = await run({
+                rows           : [parserRow({id: 'old', path: 'a.md'}), parserRow({id: 'new', path: 'a.md', parser: DECLARED})],
+                declaredByRepo : {[REPO]: DECLARED},
+                manifestsByRepo: {[REPO]: {pathsAfterPush: ['a.md'], updatedAt: 1}}
+            });
+
+            expect(tombstonedIds, 'the superseded row reaches the delete path').toEqual(['old']);
+            expect(metrics[0].diff.parserOrphanCount).toBe(1);
+        });
+
+        test('CONTROL: an unchanged declared pair reclaims nothing — firing indiscriminately is equally green', async () => {
+            const {tombstonedIds, metrics} = await run({
+                rows           : [parserRow({id: 'current', path: 'a.md', parser: DECLARED})],
+                declaredByRepo : {[REPO]: DECLARED},
+                manifestsByRepo: {[REPO]: {pathsAfterPush: ['a.md'], updatedAt: 1}}
+            });
+
+            expect(tombstonedIds).toEqual([]);
+            expect(metrics).toHaveLength(0)
+        });
+
+        test('a repo declaring NO parserVersion does not orphan its own `1.0.0`-stamped rows', async () => {
+            // Chunk construction stamps `file.parserVersion || '1.0.0'`. Resolving the declared pair
+            // without that same default would compare `undefined` against `'1.0.0'` and reclaim the
+            // entire repo — a delete caused by a comparison the producer never made.
+            // The seam's own defaulting is asserted in the `fetchTenantDeclaredParsers` describe
+            // below; here the resolved pair is fed through the daemon to prove the round trip
+            // classifies nothing.
+            const {tombstonedIds, metrics} = await run({
+                rows           : [parserRow({id: 'v1', path: 'a.md', parser: {parserId: 'p', parserVersion: '1.0.0'}})],
+                declaredByRepo : {[REPO]: {parserId: 'p', parserVersion: '1.0.0'}},
+                manifestsByRepo: {[REPO]: {pathsAfterPush: ['a.md'], updatedAt: 1}}
+            });
+
+            expect(tombstonedIds).toEqual([]);
+            expect(metrics).toHaveLength(0)
+        });
+
+        test('a repo with NO declared pair is unknown, so its rows are never reclaimed', async () => {
+            // Omission must mean "cannot judge", never "judge against nothing".
+            const {tombstonedIds, metrics} = await run({
+                rows           : [parserRow({id: 'orphanish', path: 'a.md'})],
+                declaredByRepo : {},
+                manifestsByRepo: {[REPO]: {pathsAfterPush: ['a.md'], updatedAt: 1}}
+            });
+
+            expect(tombstonedIds).toEqual([]);
+            expect(metrics).toHaveLength(0)
+        });
+
+        test('a repo with NO manifest skips tier 1 — unknown is not empty', async () => {
+            // Without a manifest the daemon cannot know which paths the declared parser yields. The
+            // row must fall to the replacement-gated tier rather than being treated as unyielded,
+            // which would reclaim a whole repo on a missing envelope.
+            const {tombstonedIds} = await run({
+                rows           : [parserRow({id: 'old', path: 'gone.md'})],
+                declaredByRepo : {[REPO]: DECLARED},
+                manifestsByRepo: {}
+            });
+
+            expect(tombstonedIds, 'no replacement exists, and tier 1 is unavailable').toEqual([])
+        });
+
+        test('autoTombstone OFF reports the parser orphan but issues no delete', async () => {
+            const {tombstonedIds, metrics} = await run({
+                rows           : [parserRow({id: 'old', path: 'a.md'}), parserRow({id: 'new', path: 'a.md', parser: DECLARED})],
+                declaredByRepo : {[REPO]: DECLARED},
+                manifestsByRepo: {[REPO]: {pathsAfterPush: ['a.md'], updatedAt: 1}},
+                autoTombstone  : false
+            });
+
+            expect(tombstonedIds).toEqual([]);
+            expect(metrics[0].diff.parserOrphanCount).toBe(1)
+        });
+    });
+
+    test.describe('fetchTenantDeclaredParsers', () => {
+        test('mirrors the producer default and omits a repo declaring no parserId', async () => {
+            const IngestionService = (await import('../../../../../../ai/services/knowledge-base/IngestionService.mjs')).default,
+                  original         = IngestionService.getTenantConfig;
+
+            IngestionService.getTenantConfig = async () => ({
+                version    : 5,
+                tenantRepos: [
+                    {repoSlug: 'org/versioned', parserId: 'p', parserVersion: '2.0.0'},
+                    {repoSlug: 'org/unversioned', parserId: 'p'},
+                    {repoSlug: 'org/no-parser'},
+                    {parserId: 'p', parserVersion: '1.0.0'}
+                ]
+            });
+
+            try {
+                const declared = await KbReconciliationService.fetchTenantDeclaredParsers('tenant-x');
+
+                expect(declared['org/versioned']).toEqual({parserId: 'p', parserVersion: '2.0.0'});
+                // The producer stamps `file.parserVersion || '1.0.0'`, so the declared pair must too.
+                expect(declared['org/unversioned']).toEqual({parserId: 'p', parserVersion: '1.0.0'});
+                // No parserId and no repoSlug are both "cannot judge", so neither appears.
+                expect(declared['org/no-parser']).toBeUndefined();
+                expect(Object.keys(declared)).toHaveLength(2)
+            } finally {
+                IngestionService.getTenantConfig = original
+            }
         });
     });
 });


### PR DESCRIPTION
## Context

`diffTenantParserIdentity` shipped **classified-but-unwired**. #17393 / PR #17395 landed the classifier for a superseded parser generation; its two siblings are called by the reconciliation daemon and it was called only by its own spec. The signal was green in isolation while no tick consulted it, so the symptom #17392 was filed for — superseded rows staying queryable and ranking against first-party content — was unchanged on a deployment.

Evidence: L2 (spec-driven dispatch through the real `reconcileTenant` and the real `KbReconciliationEngine`, with the fetch seams stubbed) → L2 required (every close-target AC is unit-observable — what reaches `tombstoneOrphans`, and what the telemetry reports). No residuals.

Origin Session ID: 6df18da7-801b-4908-9b84-63f40388a1d0

The three behavioural arms are red on unmodified `dev` and green after; reconciliation specs 64 passed; wider suites below.

## The Problem

```
KbReconciliationService.mjs:220   configDiff   = diffTenantChunks({...})        <- wired
KbReconciliationService.mjs:221   manifestDiff = diffTenantManifest({...})      <- wired
                                  diffTenantParserIdentity                       <- spec-only
```

`formatReconciliationDetail` already read `diff.parserOrphanCount`, so the telemetry surface was reporting a constant zero rather than an absent field — the shape most likely to read as "measured and clean".

**I checked whether the absence was deliberate before treating it as a gap.** That distinction cost me a wrongly-premised PR earlier today (#17589, closed unmerged — there the dead call *was* the architecture). Here it is not: the commit subject calls it *"a third reconciliation signal"*, both siblings are wired, and #17392 stayed open after #17393 closed.

## The Fix

`reconcileTenant` resolves each repo's declared `{parserId, parserVersion}` behind a `fetchTenantDeclaredParsers` seam matching the existing `fetchTenantConfigVersion` / `fetchTenantManifests` shape, calls the third classifier, and folds its diff into `combineDiffs` so `autoTombstone` reclaims parser orphans on the same gated path as the other two signals.

**`yieldedPathsByRepo` comes from data the daemon already fetches.** The manifests' `pathsAfterPush` is exactly the set tier 1 asks about. A repo with no manifest stays **absent** rather than being passed as an empty array — so the classifier treats it as *unknown*, skips tier 1, and every one of its rows falls to the replacement-gated tier. Passing `[]` would have inverted that: a missing envelope would mark a whole repo immediately actionable.

**Two defaults in the seam are load-bearing, not tidiness:**

- Chunk construction stamps `file.parserVersion || '1.0.0'` (`IngestionService.mjs:2402`, `:2430`). The declared pair applies the same default, or a repo that declares no version would compare `undefined` against `'1.0.0'` and classify **every row of that repo** as an orphan — a whole-repo reclaim caused by a comparison the producer never made.
- A repo declaring no `parserId` is **omitted**, not defaulted. Omission means "cannot judge"; an invented id would mean "judge against nothing".

## AC Evidence

#17392 carries nine ACs. #17393 closed the **classifier** half of most of them; this PR closes the **wiring** half, and the two that can only be answered by a reconciliation pass. Stated per-AC rather than merged, so a reader can see which artifact certifies which.

| AC | Proof |
|---|---|
| AC-1 | **red-proof.** **Daemon-level here.** Reverting only `KbReconciliationService.mjs` leaves 3 arms red — the reclaim, the telemetry count, and the seam. The classifier-level red-proof shipped in #17393 (`RED-PROOF: a superseded generation surviving beside its replacement is classified`). Both are needed: the classifier one proves the state is detectable, this one proves a pass acts on it. |
| AC-2 | **actionable on the next pass, no bump.** **This PR.** `reconcileTenant` consults the signal every tick, so an existing orphan set is reclaimed without a `parserVersion` advance. Arm: `RED-PROOF: a superseded generation is reclaimed by the DAEMON`. The unyielded tier is classifier-side (#17393, `UNYIELDED: a path the declared parser no longer yields is immediately actionable`). |
| AC-3 | **control, unchanged pair.** Classifier: #17393 `CONTROL: an unchanged declared pair classifies nothing`. Daemon: `CONTROL: an unchanged declared pair reclaims nothing — firing indiscriminately is equally green` (no delete, no telemetry). |
| AC-4 | **`tenantConfigVersion` independence.** #17393 `tenantConfigVersion INDEPENDENCE: fires with the config version identical across both generations`. Unchanged by this PR — the daemon passes rows through untouched. |
| AC-5 | **tenant containment.** #17393 `TENANT CONTAINMENT: with both tenants resident in the shared collection, classifying A yields no row carrying B`. The daemon supplies `tenantId` to the classifier, which filters itself — the one signal of the three that does. |
| AC-6 | **no-hole.** #17393 `NO-HOLE: a still-yielded path with no replacement yet is seen but NOT actionable`. Preserved end to end here by deriving `yieldedPathsByRepo` from real manifests; daemon arm `a repo with NO manifest skips tier 1 — unknown is not empty` proves the absent case degrades rather than widens. |
| AC-7 | **missing stamp skipped.** #17393 `a row missing its parser stamp is SKIPPED, not classified`. Unchanged. |
| AC-8 | **telemetry distinguishes the three.** **This PR.** `combineDiffs` carries `parserOrphanCount` separately and the log line names it; `formatReconciliationDetail` already read the key and was reporting a constant zero. Arms assert the count with `autoTombstone` ON and OFF. |
| AC-9 | **no new destructive selector, no default change.** **This PR, by omission and asserted.** Reclaim reuses the existing `tombstoneOrphans` path — no new delete route, no MCP surface. `reconciliationEnabled` is untouched and still defaults to `false`; the `autoTombstone OFF` arm pins that the gate still suppresses the delete. |

## Test Evidence

- **Red-before-green, by reverting only the daemon** (`git stash` on `KbReconciliationService.mjs`, specs kept): **3 failed / 27 passed**. The reds are the reclaim arm, the telemetry-count arm, and the seam arm — the three that assert new behaviour.
- With the wiring: **64 passed** across `kb-reconciliation/` + `kbReconciliationEngine.spec.mjs`.
- The four **controls** (unchanged declared pair, no declared `parserVersion`, no declared pair, no manifest) pass in **both** states. That is the point — they assert the *absence* of a reclaim, so they are controls rather than defect witnesses, and a wiring that fired indiscriminately would break them.
- `test/playwright/unit/ai/daemons/` + `ai/services/knowledge-base/` — **3039 passed, 3 failed**. The 3 are the pre-existing `[unit-brain]` orchestrator reds (`authorityLeaseBoot:25`, `HostEdgePosture:303`, `:311`), reproduced earlier today on a pristine detached worktree at a base commit with zero modifications: those arms `spawnSync` a real boot with `cwd: process.cwd()`, and the gitignored operator overlays exist only in the main clone, so the child dies on `ERR_MODULE_NOT_FOUND`. One of the three is a POSITIVE CONTROL, which is the tell. CI runs from a full checkout.
- Lints run bare, reading each tool's own exit code: `check-ticket-archaeology` 0 violations (re-run **after** committing — it scopes to changed *tracked* files, and reading its "0 files in scope" on untracked work is how I shipped a lint red earlier today); `check-block-alignment` exit 0.

**Reviewer-relevant:** the spec's `afterEach` seam-cleanup list is an enumeration a new seam must join. `fetchTenantDeclaredParsers` was missing from it at first and my stub leaked into a later test, shadowing the real method. Added.

## Deltas

- `ai/daemons/kb-reconciliation/KbReconciliationService.mjs` — import the third classifier; call it; derive `yieldedPathsByRepo` from manifests; `fetchTenantDeclaredParsers` seam; `combineDiffs` folds the third diff; telemetry line names the count.
- `test/.../kb-reconciliation/KbReconciliationService.spec.mjs` — 7 arms (1 red-proof, 4 controls, telemetry ON/OFF) + the seam's own describe; `fetchTenantDeclaredParsers` added to the seam-cleanup list.

## Post-Merge Validation

- **This changes nothing on a deployment that has not opted in.** `aiConfig.knowledgeBase.reconciliationEnabled` defaults to `false` and `start()` is a documented no-op when unset. That gate is deliberate and explicitly out of scope here — wiring without the flag reclaims nothing, and the flag without the wiring reclaims no parser orphans. Different owners.
- On a deployment that *has* opted in with `autoTombstone`, the first tick after this lands may reclaim a backlog of accumulated parser orphans. That is the intended direction — those rows are unreachable-by-replacement and rank against first-party content — but it is a visible one-off delete volume, so watch the `parser-identity orphan chunk(s)` count on the first sweep. Informational, not an owed residual.

Resolves #17392

Authored by ⚖️ **Ada** · `@neo-opus-ada` · Claude Opus 5 · Claude Code
