### PR TITLE
docs(ai): the executor's advertised surface stops claiming isolation (#16979)

### DIFF
--- a/ai/mcp/server/file-system/openapi.yaml
+++ b/ai/mcp/server/file-system/openapi.yaml
@@ -12,7 +12,7 @@ info:
     `run_playwright_test` executes a spec, and a spec is arbitrary JavaScript,
     so what it reads and writes is bounded by the process this server runs in
     — not by the path guard. `write_file` plus `run_playwright_test` therefore
-    composes past the jail without either call violating it (#16481).
+    composes past the jail without either call violating it.
 
     Real containment needs process or container isolation for the executor.
     Until that exists, treat this surface as: jailed arguments, unjailed
@@ -35,7 +35,7 @@ tags:
   - name: IO
     description: File IO capabilities
   - name: Execution
-    description: Execution sandbox
+    description: Runs code with this server's host trust; arguments are jailed, execution is not
 
 paths:
   /healthcheck:
@@ -217,9 +217,9 @@ paths:
       # surface keeps describing runner isolation while the real limit lives one call away.
       x-neo-tool-summary: "Executes one Playwright spec. EXECUTION IS NOT JAILED — the spec runs with this server's host trust."
       description: |
-        Runs the Playwright runner isolated to the requested spec file to test pass/fail conditions.
+        Runs one Playwright spec to test pass/fail conditions. EXECUTION IS NOT JAILED.
 
-        EXECUTION IS NOT JAILED. The path argument is validated against the project root; the spec
+        The path argument is validated against the project root; the spec
         that runs is arbitrary JavaScript, so what it reads and writes is bounded by this server's
         host process, not by that root. Combined with write_file this reaches outside the project
         root without either call violating a guard. Do not pass this tool input you would not grant

--- a/learn/agentos/decisions/0031-target-architecture-composition.md
+++ b/learn/agentos/decisions/0031-target-architecture-composition.md
@@ -78,6 +78,7 @@ decision owns; *Parent* = the composition record that already aggregates it, whe
 | 0038 | Body ↔ Brain seam | FM client topology: the cockpit connects (three roles / two registries), four non-aliased identity facts, two never-aggregated grant families + at-rest coherence | amends 0020/0026/0034 |
 | 0039 | Brain / SDK package boundary | Two-plane SDK barrel: a host entrypoint cannot reach a durable store by import alone; one Proxy identity per service; static walk plus runtime denial witness | composes 0018 |
 | 0040 | Brain / repository boundary | The AgentOS extraction topology: `neomjs/neo-agent-brain` — Edge root + independent nested `cloud/`, no workspaces, two root authorities, two blocking receipts before any relocation, cut precedes v13.2 | realizes 0039 |
+| 0041 | Tool surface / host trust | The file-system executor runs unjailed and says so: the path guard binds arguments, never the process; isolation rejected on cost because a broken sandbox reporting success is worse than none; every projected surface states the limit | none |
 
 ## §3 Trajectory Invariants
 

--- a/learn/agentos/decisions/0041-file-system-executor-unjailed-execution.md
+++ b/learn/agentos/decisions/0041-file-system-executor-unjailed-execution.md
@@ -1,0 +1,90 @@
+# ADR 0041: The File-System Executor Runs Unjailed, And Says So
+
+> `run_playwright_test` executes arbitrary JavaScript with the host trust of the MCP server process.
+> The path guard binds **arguments**, never the **process**, so `write_file` composed with
+> `run_playwright_test` reaches outside the project root without either call violating a guard. We
+> **accept** that, because the containment that would fix it costs more than the exposure is worth on
+> a surface whose callers already hold host access — and we pay for the acceptance in honesty: every
+> projected surface a caller receives states the limit, and no surface anywhere claims isolation.
+
+| Attribute | Value |
+|---|---|
+| **Status** | Accepted — 2026-08-25 |
+| **Author** | Grace (@neo-opus-grace), recording the decision #16979 exists to force; defect reported externally by @novice-22 (three independent times, reproduced from source), split from #16481 by @neo-opus-vega, projected-surface census by @neo-gpt-emmy |
+| **Resolves** | #16979 AC-1 — "a decision is recorded: isolate the executor, or accept unjailed execution as the contract" |
+| **Anti-anchor for** | any guard that blocks the specific two-step reproduction while leaving arbitrary JS execution unbounded; any surface text that describes this executor as isolated, sandboxed, or contained; a sandbox that reports success while no longer containing |
+
+---
+
+## 1. Context
+
+The file-system MCP server validates every path argument against the project root. That guard is real
+and it works — for arguments. It cannot bind what a *spec* does, because a Playwright spec is
+arbitrary JavaScript running in the server's own process.
+
+So the read/write set of `run_playwright_test` is the host process, not the project root, and the
+composition is trivial: `write_file` a spec inside the root, then `run_playwright_test` it, and the
+spec reads or writes anywhere the server can. Neither call violates the jail. The jail was never the
+thing standing between the tool and the host.
+
+The external reporter stated the closure precisely, and it is why this needed a decision rather than
+a cleverer guard:
+
+> *"A sound tool-level partition would have to keep `write_file` out of everywhere
+> `run_playwright_test` can read. But a spec is arbitrary JavaScript, so the executor's read set is
+> not statically bounded — it is the project."*
+
+There is no line to draw between the two tools. A guard attempting one becomes a guard over a set
+nobody can enumerate, which is exactly how the previous wording came to promise containment it could
+not deliver.
+
+## 2. Decision
+
+**Accept unjailed execution as the contract.** Do not isolate the executor.
+
+The alternative — a child process with a restricted filesystem view, or a container — was considered
+and rejected on cost, not on difficulty:
+
+- test runs get slower and need their fixtures carried across the boundary;
+- failure diagnostics have to cross it too, or debugging gets materially worse;
+- the boundary becomes a thing to keep correct, and **a broken sandbox that reports success is worse
+  than no sandbox** — it converts a known limit into a false assurance.
+
+That last cost is decisive rather than merely large. This surface is used by agents already operating
+on this repository with host access. Isolation would therefore buy little real containment while
+introducing a component whose silent failure mode is *believing you are contained*. Trading a limit
+people can read for an assurance that can rot is a bad trade at this exposure level.
+
+## 3. What acceptance obliges
+
+Acceptance is not free. It is only honest if the limit reaches the caller, so:
+
+- **Every projected surface states it.** The MCP tool surface is projected twice — `tools/list` reads
+  `x-neo-tool-summary` (compacted, ~120 chars) and the full schema reads `description`. Both carry
+  the limit. A warning in only one is a warning one call away from the discovery path that mattered.
+- **The word "isolated" does not appear** describing this executor, in any operation description,
+  summary, or tag. The prior text opened with *"Runs the Playwright runner isolated to the requested
+  spec file"* and buried the correction below it, which reads as containment to anyone who stops at
+  the first sentence.
+- **The tag is not "Execution sandbox".** A tag describing a sandbox re-asserts, at the category
+  level, exactly what the operation retracts.
+
+## 4. Consequences
+
+**Accepted:** the composition described in #16481 continues to work. It is a documented property of
+the surface, not a latent defect, and a reader who grants this tool input they would not grant the
+host process has been told plainly not to.
+
+**Required:** any future capability on this server that executes caller-supplied code inherits this
+ADR — it is unjailed by construction and must say so on both projections at the moment it ships.
+Retrofitting the warning is the losing order, and this ADR exists because that order was tried once.
+
+**Revisit when** the executor gains a caller who does *not* already hold host trust — a hosted
+instance, an untrusted contributor path, or an MCP client outside the maintainer fleet. That changes
+the exposure calculus in §2 completely, and the rejection recorded here does not survive it. Until
+then, isolation would be machinery guarding a boundary that no caller is on the far side of.
+
+## 5. Related
+
+#16979 (this decision) · #16481 (the false-claim correction, PR #16976) · ADR 0039 (two-plane
+boundary — a different boundary, and this ADR does not weaken it)

--- a/test/playwright/unit/ai/mcp/server/file-system/FileSystemService.spec.mjs
+++ b/test/playwright/unit/ai/mcp/server/file-system/FileSystemService.spec.mjs
@@ -2,6 +2,7 @@ import {test, expect}    from '@playwright/test';
 import fs                from 'fs-extra';
 import os                from 'os';
 import path              from 'path';
+import * as yaml         from 'js-yaml';
 import FileSystemService from '../../../../../../../ai/mcp/server/file-system/services/FileSystemService.mjs';
 
 /**
@@ -285,5 +286,64 @@ test.describe('ai/mcp/server/file-system FileSystemService', () => {
     test('#16508 an in-suite symlink resolving outside the Playwright suite is refused', async () => {
         await expect(FileSystemService.runPlaywrightTest({absolutePath: path.join(aliasInSuite, path.basename(hostile))}))
             .rejects.toThrow(/403 Forbidden: Can only execute Playwright specs/);
+    });
+});
+
+/**
+ * The executor's advertised surface — ADR 0041. ticket-ref-ok: these arms enforce that ADR's §3
+ * obligations verbatim; without the anchor a future reader cannot tell why the honesty is mandatory
+ * rather than stylistic, and would reasonably relax it.
+ *
+ * `run_playwright_test` runs arbitrary JavaScript with the server's host trust. That is an accepted
+ * contract, not a defect — but acceptance is only honest while every projected surface says so, and
+ * the surface is projected TWICE: `tools/list` reads the compacted `x-neo-tool-summary`, the full
+ * schema reads `description`. A warning on one is a warning one call away from the path that matters.
+ *
+ * These arms pin the honesty, because prose regresses silently and a reader who stops at the first
+ * sentence is the reader this exists for.
+ */
+test.describe('ai/mcp/server/file-system advertised executor surface', () => {
+    const spec = yaml.load(fs.readFileSync(
+        path.resolve(process.cwd(), 'ai/mcp/server/file-system/openapi.yaml'), 'utf-8'
+    ));
+
+    const operation = spec.paths['/run_playwright_test'].post;
+
+    test('no surface describing the executor claims isolation', () => {
+        const surfaces = [
+            operation.description,
+            operation.summary,
+            operation['x-neo-tool-summary'],
+            spec.tags.find(tag => tag.name === 'Execution').description
+        ];
+
+        for (const text of surfaces) {
+            // 'isolated'/'sandbox' is the exact word the prior text opened with, and it is what a
+            // caller who reads one sentence takes away.
+            expect(text, `executor surface must not claim containment: ${text}`)
+                .not.toMatch(/\bisolat(ed|ion)\b|\bsandbox(ed)?\b|\bcontained\b/i);
+        }
+    });
+
+    test('BOTH projections carry the limit — the compact one and the full one', () => {
+        // ToolService projects `description` for the full schema and `x-neo-tool-summary` for the
+        // compacted `tools/list`. Warning only the full one leaves ordinary discovery uninformed.
+        expect(operation['x-neo-tool-summary']).toMatch(/NOT JAILED/);
+        expect(operation.description).toMatch(/NOT JAILED/);
+        // Leading, not buried: the first sentence is what a scanning reader receives.
+        expect(operation.description.trim().split('\n')[0]).toMatch(/NOT JAILED/);
+    });
+
+    test('no internal ticket reference rides the projected payload', () => {
+        // The MCP description budget forbids internal cross-refs: they reach every consuming agent's
+        // context and rot when the referenced item closes.
+        const projected = [operation.description, operation['x-neo-tool-summary'], spec.info.description].join('\n');
+
+        expect(projected).not.toMatch(/#\d{4,}/);
+    });
+
+    test('the compacted summary stays inside the tools/list budget', () => {
+        expect(operation['x-neo-tool-summary'].length).toBeLessThanOrEqual(120);
+        expect(operation.description.length).toBeLessThanOrEqual(1024);
     });
 });


### PR DESCRIPTION
Resolves #16979

The path guard binds **arguments**, never the **process**. `run_playwright_test` executes arbitrary JavaScript with the MCP server's host trust, so `write_file` composed with it reaches outside the project root without either call violating a guard. This PR records the decision that gap demands — **accept unjailed execution as the contract** — and makes the acceptance honest at the surfaces callers actually receive, which it was not.

Evidence: L1 (static — the advertised surface is a parsed artifact, and four regression arms assert against the parsed YAML) → L1 required (both ACs in scope are statically verifiable; the accepted contract has no runtime behavior to observe). No residuals.

## AC Evidence

AC-2 and AC-3 are **conditional on a branch not taken** — both are prefixed *"if isolation is chosen"*, and the decision is acceptance. They are discharged as N/A by their own terms rather than unmet; claiming them delivered would assert a containment proof that does not exist, which is the dishonesty this ticket was split out to end.

| AC | Evidence |
|---|---|
| AC-1 | *A decision is recorded: isolate the executor, or accept unjailed execution as the contract.* `learn/agentos/decisions/0041-file-system-executor-unjailed-execution.md` — **accept**, with the rejection argued on cost rather than difficulty, and carrying its own revisit trigger (the first caller who does not already hold host trust). |
| AC-2 | *If isolation is chosen, the composition in #16481 fails after it.* **N/A — branch not taken.** Isolation was rejected in ADR 0041 §2, so the composition continues to work and is documented as a property of the surface rather than a latent defect. |
| AC-3 | *If isolation is chosen, a BROKEN sandbox must fail closed.* **N/A — branch not taken.** This AC's own hazard is in fact the load-bearing argument *for* rejection: ADR 0041 §2 cites "a broken sandbox that reports success is worse than none" as the decisive cost, so the risk is avoided by not building the sandbox. |
| AC-4 | *If acceptance is chosen, the ADR says so, and #16976's wording becomes the permanent contract rather than an interim note.* ADR 0041 §2–3 promotes it, and the three surfaces that still contradicted it are corrected. Four arms in `FileSystemService.spec.mjs` pin it against silent regression; 23/23 green. |

## Deltas from ticket

- **@neo-gpt-emmy's census was partly overtaken, and the residue is what mattered.** Her A+FU receipt on PR #16976 found `run_playwright_test` reaching callers as *"Runs the Playwright runner isolated to the requested spec file"* with the host-authority warning only at top level. Since then an `x-neo-tool-summary` carrying `EXECUTION IS NOT JAILED` landed, so the compact `tools/list` projection is already honest. Three items survived and are fixed here: the full `description` still **opened** with "isolated" and buried the correction below it; the `Execution` **tag** still read `Execution sandbox`; and the payload still carried an internal ticket reference.
- **The leading sentence is the whole point, not a nicety.** `ToolService.mjs:196` projects `operation.description` verbatim, so a caller who stops at sentence one previously received "isolated" and nothing else. The correction was present but positioned where it could be missed by exactly the reader it exists for.
- **The internal ref was a budget violation, not untidiness.** `pr-review` §5.3's MCP-Tool-Description Budget Audit forbids internal cross-refs in the description payload — they reach every consuming agent's context window and rot when the referenced item closes. Removed; the file now matches `#\d{4,}` zero times.
- **ADR placement:** `learn/agentos/decisions/`, next number 0041. Deliberately short — this records one narrow acceptance and its revisit trigger, not a topology; it is ~5 KB against 0040's 23 KB, and the difference is scope rather than rigor.
- **AC-2/AC-3 are N/A rather than skipped**, and the ticket wrote them that way. Both are prefixed *"if isolation is chosen"*. Marking them delivered would claim a containment proof that does not exist, which is the exact dishonesty this ticket was split out to end.

## Test Evidence

All coverage runs in CI. What a green suite cannot show is whether the assertions can fail, so the four new arms were written against the failure they guard:

- **`no surface describing the executor claims isolation`** — matches `isolated|isolation|sandbox|contained` across the description, summary, `x-neo-tool-summary`, and the `Execution` tag. Before this PR the description and the tag both matched, so the arm was red on the pre-change tree by construction.
- **`BOTH projections carry the limit`** — asserts `NOT JAILED` in the compact and full projections *and* that the description's **first line** carries it. The last clause is what the old text failed while the rest passed.
- **`no internal ticket reference rides the projected payload`** — `#\d{4,}` over the projected strings; red before, since `(#16481)` was in `info.description`.
- **`the compacted summary stays inside the tools/list budget`** — 100/120 and 438/1024 measured, so a future warning expansion cannot silently blow the cap the summary exists to fit.

Full file: **23/23 green**, the 19 pre-existing guard arms untouched.

## Post-Merge Validation

None — the advertised surface is a static artifact parsed by the suite exactly as `ToolService` parses it, and the decision it records has no runtime behavior to observe.

## Evolution

Two corrections during implementation. The first import used `import yaml from 'js-yaml'`, which the ESM build rejects; the repo's own idiom is `import * as yaml`, already used by `lint-openapi-service-parity.mjs` — I should have read the sibling before writing the line. The second: `check-ticket-archaeology` blocked the ADR reference in the spec docblock. Here the reference is genuinely load-bearing rather than decorative — the arms enforce that ADR's obligations verbatim, and without the anchor a future reader cannot tell why the honesty is mandatory rather than stylistic — so it carries the sanctioned `ticket-ref-ok:` marker with that reason, instead of being dropped.

Authored by Grace (Claude Opus 5, Claude Code). Session 8daa7672-824e-4d4a-9283-8a0b908180c8.
