### PR TITLE
feat(auth): survive a provider validation outage across restarts (#17304)

### DIFF
--- a/ai/configBase.mjs
+++ b/ai/configBase.mjs
@@ -667,6 +667,14 @@ class ConfigBase extends ConfigProvider {
                 // a rejected credential, and every seat's turn-opening call inherits that risk.
                 // `0` restores fail-closed-on-transport behaviour exactly.
                 patStaleGraceSeconds  : leaf(3600, 'NEO_AUTH_PAT_STALE_GRACE_SECONDS', 'number'),
+                // Restart-durable home of the GitHub-PAT validation cache (hash-keyed; the raw
+                // bearer token never touches disk). Empty disables the tier entirely: admission
+                // then survives an outage only for as long as the process stays up. When set, a
+                // redeploy during a provider outage admits previously-validated identities from
+                // this file — gated by a status-code-only validity probe against `/rate_limit` —
+                // instead of locking every seat out for the incident's duration. Explicitly named
+                // per profile (the wake-receiver-manifest precedent): no hidden default derives it.
+                patDiskCachePath      : leaf('', 'NEO_AUTH_PAT_DISK_CACHE_PATH', 'string'),
                 // Optional GitLab OAuth app binding for 'gitlab-pat' mode. Empty means no app gate.
                 allowedClientIds  : leaf([], 'NEO_AUTH_ALLOWED_CLIENT_IDS', 'csv'),
                 // Optional username allowlist for PAT modes ('gitlab-pat' / 'github-pat'). Empty means any resolved user.

--- a/ai/deploy/docker-compose.local-agent-os.yml
+++ b/ai/deploy/docker-compose.local-agent-os.yml
@@ -36,6 +36,9 @@ services:
       # already vouches for the network hop; this is the receiver-side DNS-rebinding boundary.
       # Keep the admission exact and local — never broaden it to a wildcard.
       NEO_MCP_ALLOWED_HOSTS: kb-server
+      # Restart-durable admission cache — DISTINCT per service: one writer per path is the
+      # deployment contract that dissolves cross-process cache contention structurally.
+      NEO_AUTH_PAT_DISK_CACHE_PATH: /app/.neo-ai-data/auth/kb-pat-validation-cache.json
     secrets:
       - mcp-auth-token
     # N=1 tenant bootstrap: query-time tenant-config resolution reads
@@ -54,6 +57,8 @@ services:
       # directly as `mc-server`, while Fleet uses the authenticated `ingress` route. Both names
       # need receiver-side admission; Fleet's outbound internal-host allowance is a separate gate.
       NEO_MCP_ALLOWED_HOSTS: mc-server,ingress
+      # Distinct from the kb-server path: one writer per path (see the kb-server note).
+      NEO_AUTH_PAT_DISK_CACHE_PATH: /app/.neo-ai-data/auth/mc-pat-validation-cache.json
     secrets:
       - mcp-auth-token
     # `healthcheck.test` is a LIST, so this override REPLACES the base command rather than extending

--- a/ai/deploy/docker-compose.yml
+++ b/ai/deploy/docker-compose.yml
@@ -176,7 +176,10 @@ services:
       # layer and the orchestrator reads its own empty one, so every observation surfaces as
       # `unavailable/absent` forever — a silent no-op, because a successful LOCAL write is
       # indistinguishable from a delivered one at the writer.
-      - shared-heap-observation-data:/app/.neo-ai-data/heap-observation
+      # Restart-durable admission cache (hash-keyed; no token material). DISTINCT per service:
+      # the deployment contract is one writer per path, which dissolves cross-process cache
+      # contention structurally instead of locking.
+      - auth-cache-data:/app/.neo-ai-data/auth
     depends_on:
       chroma:
         condition: service_healthy
@@ -322,7 +325,10 @@ services:
       # layer and the orchestrator reads its own empty one, so every observation surfaces as
       # `unavailable/absent` forever — a silent no-op, because a successful LOCAL write is
       # indistinguishable from a delivered one at the writer.
-      - shared-heap-observation-data:/app/.neo-ai-data/heap-observation
+      # Restart-durable admission cache (hash-keyed; no token material). DISTINCT per service:
+      # the deployment contract is one writer per path, which dissolves cross-process cache
+      # contention structurally instead of locking.
+      - auth-cache-data:/app/.neo-ai-data/auth
     depends_on:
       chroma:
         condition: service_healthy
@@ -630,6 +636,8 @@ services:
       - NEO_AUTH_PAT_VALIDATION_TIMEOUT_MS
       - NEO_AUTH_ALLOWED_CLIENT_IDS
       - NEO_AUTH_ALLOWED_USERS
+      # Restart-durable admission cache; fleet owns this path exclusively (one writer per path).
+      - NEO_AUTH_PAT_DISK_CACHE_PATH=/app/.neo-ai-data/auth/fleet-pat-validation-cache.json
       # One secret-file carrier feeds both the pre-listen provider-subject pin and readiness.
       # Never interpolate the direct PAT or an OIDC client secret into rendered Compose.
       - NEO_AUTH_PROVIDER_BOOTSTRAP_PAT_FILE=/run/secrets/mcp-auth-token
@@ -641,6 +649,10 @@ services:
       # One Fleet-owned root co-locates registry, tenant descriptors, encryption/signing keys, and
       # ciphertext. No graph/MC/KB private volume is mounted into this service.
       - fleet-data:/app/.neo-ai-data/fleet
+      # Restart-durable admission cache (hash-keyed; no token material). DISTINCT per service:
+      # the deployment contract is one writer per path, which dissolves cross-process cache
+      # contention structurally instead of locking.
+      - auth-cache-data:/app/.neo-ai-data/auth
     secrets:
       - mcp-auth-token
     networks:
@@ -743,6 +755,10 @@ networks:
     driver: bridge
 
 volumes:
+  # Restart-durable PAT admission caches (hash-keyed, no token material). One distinct file per
+  # PAT-auth service; the mount exists so a redeploy during a provider outage keeps the warm
+  # identities that let the plane admit while GitHub cannot be asked.
+  auth-cache-data:
   chroma-data:
   fleet-data:
   orchestrator-state:

--- a/ai/mcp/server/memory-core/toolService.mjs
+++ b/ai/mcp/server/memory-core/toolService.mjs
@@ -12,6 +12,7 @@ import HealthService, {
 import MemoryService                 from '../../../services/memory-core/MemoryService.mjs';
 import SessionService                from '../../../services/memory-core/SessionService.mjs';
 import SummaryService                from '../../../services/memory-core/SummaryService.mjs';
+import {getAuthValidationStaleness}  from '../shared/services/AuthService.mjs';
 import MailboxService                from '../../../services/memory-core/MailboxService.mjs';
 import PermissionService             from '../../../services/memory-core/PermissionService.mjs';
 import WakeSubscriptionService       from '../../../services/memory-core/WakeSubscriptionService.mjs';
@@ -308,11 +309,16 @@ export function composeMemoryCoreHealthcheck({
         response       = {...health, memoryWalDrain, plane, vectorGeneration, maintenance, corpusProjectionFreshness},
         drainStalled   = memoryWalDrain.state === 'stalled',
         backupDegraded = backupHealth?.status === 'degraded',
-        projectionDegraded = corpusProjectionFreshness?.posture === 'degraded';
+        projectionDegraded = corpusProjectionFreshness?.posture === 'degraded',
+        // Admission staleness (a provider validation outage being survived on cached identities)
+        // degrades the verdict the SAME way the other partial-health signals do: the plane serves,
+        // and the truth label says so. Read per-call so the signal clears the moment any fresh
+        // provider validation lands.
+        authDegraded   = getAuthValidationStaleness().size > 0;
 
     let composed = response;
 
-    if (drainStalled || backupDegraded || projectionDegraded) {
+    if (drainStalled || backupDegraded || projectionDegraded || authDegraded) {
         const details = Array.isArray(health.details)
             ? health.details.filter(detail => detail !== ALL_FEATURES_OPERATIONAL_DETAIL)
             : [];
@@ -340,6 +346,16 @@ export function composeMemoryCoreHealthcheck({
                 : 'see corpusProjectionFreshness';
 
             details.push(`Core corpus projection freshness is degraded: ${reasonCodes}.`)
+        }
+
+        if (authDegraded) {
+            const rows = [...getAuthValidationStaleness().entries()]
+                .map(([mode, {since, user}]) => `${mode} (identity '${user}', stale since ${new Date(since).toISOString()})`);
+
+            details.push(
+                'Provider PAT admission is degraded — identities are being served from the ' +
+                `validation cache while the provider cannot be asked: ${rows.join('; ')}.`
+            )
         }
 
         composed = {

--- a/ai/mcp/server/shared/helpers/patValidationCache.mjs
+++ b/ai/mcp/server/shared/helpers/patValidationCache.mjs
@@ -1,0 +1,106 @@
+import {writeFileAtomicSync} from '../../../../services/shared/atomicFileWrite.mjs';
+import {readFile}            from 'node:fs/promises';
+
+/**
+ * @module ai/mcp/server/shared/helpers/patValidationCache
+ * @summary Disk-backed store for the PAT validation cache — the restart-survivable half of the
+ * admission cache that lets a freshly-redeployed plane admit previously-validated identities
+ * while the provider's validation endpoint is down.
+ *
+ * **Why hash-only.** The store maps SHA-256 token hashes to the identity the provider resolved
+ * for them. The raw bearer token never touches disk: the hash is not replayable against any
+ * endpoint, so a leaked cache file is an identity-disclosure at worst, never a credential.
+ *
+ * **Why the caller owns all freshness semantics.** This module is a durable key-value store and
+ * nothing else: TTLs, stale windows, provider probes, and admission decisions stay in
+ * `AuthService`'s verifier, which already owns them for the in-process tier. A cache file that
+ * invents its own expiry policy would create a second authority that could disagree with the
+ * first.
+ */
+
+/**
+ * @summary Reads the persisted validation entries at `filePath`.
+ *
+ * A missing file is an empty store, not an error — the first successful validation creates it. A
+ * CORRUPT file is also treated as empty rather than fatal, because admission must degrade to its
+ * pre-feature behavior (provider-only) instead of refusing to boot over a cache; the reason is
+ * returned so the caller can log it loudly. Callers decide staleness; timestamps cross the boundary
+ * untouched.
+ * @param {String}   filePath              Absolute path to the JSON store (parent created on write).
+ * @param {Object}   [options]
+ * @param {Object}   [options.fsModule]    Injection seam for tests; defaults to `node:fs/promises`.
+ * @param {Function} [options.now=Date.now] Injectable clock for tests.
+ * @returns {{entries: Map<String, {user: Object, scopes: String[], verifiedAt: Number}>, warning: String|null}}
+ */
+export async function readPatValidationCache(filePath, {fsModule, now = Date.now} = {}) {
+    const fsPromises = fsModule ?? {readFile};
+    let raw;
+
+    try {
+        raw = await fsPromises.readFile(filePath, 'utf8');
+    } catch (error) {
+        if (error?.code === 'ENOENT') {
+            return {entries: new Map(), warning: null}
+        }
+
+        return {entries: new Map(), warning: `unreadable (${error.message})`}
+    }
+
+    let parsed;
+
+    try {
+        parsed = JSON.parse(raw);
+    } catch {
+        return {entries: new Map(), warning: 'corrupt JSON — ignored'}
+    }
+
+    const entries = new Map();
+    const cutoff  = now();
+
+    for (const [tokenHash, entry] of Object.entries(parsed ?? {})) {
+        // Shape-guard each row rather than trusting the file: one malformed row must not poison
+        // the others, and a row missing the fields admission needs is worse than absent.
+        if (
+            typeof tokenHash === 'string' && tokenHash.length > 0 &&
+            entry && typeof entry === 'object' &&
+            typeof entry.verifiedAt === 'number' && entry.verifiedAt <= cutoff + 60000 &&
+            entry.user && typeof entry.user.login === 'string'
+        ) {
+            entries.set(tokenHash, {
+                user      : entry.user,
+                scopes    : Array.isArray(entry.scopes) ? entry.scopes : [],
+                verifiedAt: entry.verifiedAt
+            })
+        }
+    }
+
+    return {entries, warning: null}
+}
+
+/**
+ * @summary Persists the validation entries atomically (tmp + rename), creating parent directories.
+ *
+ * Sync-write by design: it rides the same event-loop turn as the validation that earned it, so a
+ * process killed mid-admission cannot lose the entry that a post-restart outage window will need.
+ * Callers treat write failure as a loud degradation (log + continue admitting), never as an
+ * admission failure — losing the cache must never look like losing the credential.
+ * @param {String} filePath Absolute target path.
+ * @param {Map<String, {user: Object, scopes: String[], verifiedAt: Number}>} entries
+ * @param {Object} [options]
+ * @param {Object} [options.fsModule] Injection seam for tests; defaults to `node:fs/promises` (mkdir).
+ * @throws {Error} When the write itself fails — the CALLER decides logging vs failing; see above.
+ */
+export async function writePatValidationCache(filePath, entries, {fsModule} = {}) {
+    const fsPromises = fsModule ?? await import('node:fs/promises');
+    const payload    = {};
+
+    for (const [tokenHash, entry] of entries) {
+        payload[tokenHash] = entry
+    }
+
+    const {mkdir}    = fsPromises;
+    const pathModule = await import('node:path');
+
+    await mkdir(pathModule.dirname(filePath), {recursive: true});
+    writeFileAtomicSync(filePath, `${JSON.stringify(payload, null, 2)}\n`);
+}

--- a/ai/mcp/server/shared/services/AuthService.mjs
+++ b/ai/mcp/server/shared/services/AuthService.mjs
@@ -3,6 +3,7 @@ import {createHash}                                  from 'crypto';
 import {readFileSync, statSync}                      from 'fs';
 import {isLocalBearerToken, matchesLocalBearerToken} from '../helpers/localBearer.mjs';
 import {readSeatTokenRegistry, verifySeatToken}      from '../helpers/seatToken.mjs';
+import {readPatValidationCache, writePatValidationCache} from '../helpers/patValidationCache.mjs';
 
 /**
  * @summary Installs the configured Streamable HTTP authentication strategy.
@@ -63,6 +64,22 @@ import {readSeatTokenRegistry, verifySeatToken}      from '../helpers/seatToken.
  */
 export function isAuthoritativeRejection(status) {
     return status === 401
+}
+
+// Admission-staleness registry, keyed by PAT mode. A verifier writes an entry when it admits a
+// session WITHOUT a fresh provider validation (stale tier), and deletes it on the next fresh one.
+// The healthcheck surface reads this through {@link getAuthValidationStaleness} so a plane serving
+// on cached validations reports `degraded` — honest about riding the outage window instead of
+// presenting as fully healthy while nobody can be asked.
+const AUTH_VALIDATION_STALENESS = new Map();
+
+/**
+ * @summary Reads the live admission-staleness registry. Pure accessor — callers compose their own
+ * degradation verdicts from it; nothing here decides what `degraded` means for another surface.
+ * @returns {Map<String, {since: Number, user: String}>}
+ */
+export function getAuthValidationStaleness() {
+    return AUTH_VALIDATION_STALENESS
 }
 
 class AuthService extends Base {
@@ -1001,9 +1018,120 @@ class AuthService extends Base {
             requireUser         = allowedUsers.length > 0,
             pinSubject          = aiConfig.auth.pinFirstProviderSubject === true,
             staleGraceMs        = Math.max(0, Number(aiConfig.auth.patStaleGraceSeconds) || 0) * 1000,
+            diskCachePath       = aiConfig.auth.patDiskCachePath.trim(),
             cache               = new Map(); // tokenHash -> {user, scopes, expiresAt} (cache-freshness, ms)
 
         let pinnedProviderSubject = null;
+        // Lazily-loaded mirror of the on-disk store; null until the first transport-failure fallback
+        // (or first write-through) needs it. A plane that never sees an outage never pays the read.
+        let diskEntries = null;
+
+        const loadDiskEntries = async () => {
+            if (!diskCachePath || diskEntries !== null) {
+                return diskEntries
+            }
+
+            const {entries, warning} = await readPatValidationCache(diskCachePath);
+
+            if (warning) {
+                logger.warn(`[AuthService] PAT disk cache at ${diskCachePath}: ${warning}. Admission degrades to provider-only until the next successful validation rewrites it.`)
+            }
+
+            diskEntries = entries;
+
+            return diskEntries
+        };
+
+        const persistDiskEntries = async () => {
+            if (!diskCachePath) {
+                return
+            }
+
+            try {
+                await writePatValidationCache(diskCachePath, diskEntries ?? new Map())
+            } catch (error) {
+                // Losing the durable copy is a degradation to announce, never an admission failure —
+                // the credential was just VALIDATED; failing the request over its own cache write
+                // would invert the priority.
+                logger.warn(`[AuthService] PAT disk cache write failed (admission continues): ${error.message}`)
+            }
+        };
+
+        /**
+         * The outage-survival tier beneath `serveStale`: the in-memory entry is gone or past grace
+         * (the redeploy shape — a cold process during a provider outage), so a previously-validated
+         * identity from DISK may be admitted — but only while the provider itself still vouches for
+         * the credential's validity through `/rate_limit`.
+         *
+         * **Boundary ruling (status code only).** The probe consumes ONLY the response status:
+         * `200` proves validity, `401` is an authoritative revocation, anything else — `403`
+         * included, which on a shared-egress deployment may be a primary rate-limit breach rather
+         * than a refusal (see {@link isAuthoritativeRejection}) — means the provider still cannot
+         * answer cleanly. The body is never parsed and never logged: remaining-rate-limit numbers
+         * are GitHub-read data, and pulling them plane-side would cross the host-edge settlement
+         * this admission path deliberately stays inside.
+         *
+         * @returns {Promise<Object|null>} Stale-validated AuthInfo, or null when no disk tier applies.
+         */
+        const admitFromDiskWhenProviderAgrees = async (token, tokenHash, establishPin, reason) => {
+            if (!diskCachePath || establishPin) {
+                return null
+            }
+
+            const entries = await loadDiskEntries();
+            const entry   = entries.get(tokenHash);
+
+            if (!entry || Date.now() > entry.verifiedAt + ttlMs + staleGraceMs) {
+                return null
+            }
+
+            let status = 0;
+
+            try {
+                const response = await fetch(`${apiBaseUrl}/rate_limit`, {
+                    headers: {
+                        'Authorization'       : `Bearer ${token}`,
+                        'User-Agent'          : 'neo-agent-os',
+                        'X-GitHub-Api-Version': '2022-11-28'
+                    },
+                    signal: AbortSignal.timeout(validationTimeoutMs)
+                });
+
+                status = response.status
+            } catch {
+                status = 0
+            }
+
+            // Same doctrine as `isAuthoritativeRejection`: ONLY `401` is the provider answering
+            // "no". A `403` here is deliberately NOT an eviction — on this deployment's shared
+            // source address a primary rate-limit breach also answers `403`, so treating it as a
+            // refusal would lock every seat out precisely during the congestion an outage window
+            // produces. Any non-200 therefore means "the provider still cannot answer cleanly",
+            // which leaves admission exactly where it was: unresolved.
+            if (status === 401) {
+                entries.delete(tokenHash);
+                cache.delete(tokenHash);
+                await persistDiskEntries();
+                throw new InvalidTokenError('GitHub PAT rejected by the provider validity check')
+            }
+
+            if (status !== 200) {
+                return null
+            }
+
+            logger.warn(
+                `[AuthService] GitHub provider unreachable (${reason}); admitting identity ` +
+                `'${entry.user?.login}' from the DISK validation cache (status-code-only validity proof), ` +
+                `${Math.round((Date.now() - entry.verifiedAt) / 1000)}s since last fresh validation.`
+            );
+
+            AUTH_VALIDATION_STALENESS.set('github-pat', {
+                since: Date.now(),
+                user : entry.user?.login || ''
+            });
+
+            return admitProviderSubject(buildInfo(token, entry.user, entry.scopes, 'stale-validated'), false)
+        };
 
         /**
          * Decides whether an expired-but-known token may still be admitted because the PROVIDER —
@@ -1023,6 +1151,11 @@ class AuthService extends Base {
                 return null
             }
 
+            AUTH_VALIDATION_STALENESS.set('github-pat', {
+                since: Date.now(),
+                user : entry.user?.login || ''
+            });
+
             // Logged rather than silent: an operator must be able to tell a stale-served request
             // from a freshly validated one, or "auth is fine" becomes unfalsifiable during exactly
             // the outage this exists to survive.
@@ -1039,7 +1172,7 @@ class AuthService extends Base {
         // GitHub `/user` does not return the PAT's own expiry, so we use the re-validation
         // horizon: one cache window from now (Unix seconds). Built per-call so `expiresAt`
         // stays request-fresh on cache hits.
-        const buildInfo = (token, user, scopes) => ({
+        const buildInfo = (token, user, scopes, validationState = 'fresh') => ({
             token,
             clientId : user.login,
             scopes,
@@ -1049,6 +1182,10 @@ class AuthService extends Base {
             // Provenance tag read by RequestContextService.getSource(); distinguishes a GitHub-PAT
             // identity from OIDC / gitlab-pat / stdio env-var / gh-CLI sources.
             source   : 'github-pat',
+            // Admission honesty: 'stale-validated' marks a session admitted while the provider's
+            // validation endpoint could not be asked — machine-readable at the transport boundary
+            // so staleness is observable, never silent.
+            validationState,
             // Provider-neutral identity metadata consumed by Memory Core's request-time
             // AgentIdentity auto-provisioner. The raw bearer token remains in AuthInfo only for
             // the SDK middleware boundary and is never copied into graph identity properties.
@@ -1128,6 +1265,15 @@ class AuthService extends Base {
                     // credential, for every seat, on the first call of every turn.
                     if (isAuthoritativeRejection(userResponse.status)) {
                         cache.delete(tokenHash);
+
+                        // A provider "no" must reach every tier — a disk entry surviving an
+                        // authoritative revocation would be the stale tier softening the one
+                        // answer it exists never to soften.
+                        if (diskCachePath) {
+                            (await loadDiskEntries()).delete(tokenHash);
+                            await persistDiskEntries()
+                        }
+
                         throw new InvalidTokenError(`GitHub PAT validation failed (HTTP ${userResponse.status})`)
                     }
 
@@ -1135,6 +1281,14 @@ class AuthService extends Base {
 
                     if (stale) {
                         return admitProviderSubject(buildInfo(token, stale.user, stale.scopes), establishPin)
+                    }
+
+                    // In-memory tier exhausted (cold process or past grace) — the disk tier, gated
+                    // by the provider's own validity answer, is the redeploy-during-outage shape.
+                    const diskStale = await admitFromDiskWhenProviderAgrees(token, tokenHash, establishPin, `HTTP ${userResponse.status}`);
+
+                    if (diskStale) {
+                        return diskStale
                     }
 
                     throw new InvalidTokenError(`GitHub PAT validation failed (HTTP ${userResponse.status})`)
@@ -1148,11 +1302,23 @@ class AuthService extends Base {
 
                 if (typeof user.login !== 'string' || user.login.trim().length === 0) {
                     cache.delete(tokenHash);
+
+                    if (diskCachePath) {
+                        (await loadDiskEntries()).delete(tokenHash);
+                        await persistDiskEntries()
+                    }
+
                     throw new InvalidTokenError('GitHub PAT validation returned no provider login')
                 }
 
                 if (requireUser && !allowedUsers.includes(user.login)) {
                     cache.delete(tokenHash);
+
+                    if (diskCachePath) {
+                        (await loadDiskEntries()).delete(tokenHash);
+                        await persistDiskEntries()
+                    }
+
                     throw new InvalidTokenError('GitHub user is not allowed')
                 }
 
@@ -1161,6 +1327,16 @@ class AuthService extends Base {
                 const info = admitProviderSubject(buildInfo(token, user, scopes), establishPin);
 
                 cache.set(tokenHash, {user, scopes, expiresAt: Date.now() + ttlMs});
+                AUTH_VALIDATION_STALENESS.delete('github-pat');
+
+                // Write-through: the disk tier is only as good as its last affirmative answer. A
+                // revoked token must also leave THIS store on the authoritative path below.
+                if (diskCachePath) {
+                    const entries = await loadDiskEntries();
+
+                    entries.set(tokenHash, {user, scopes, verifiedAt: Date.now()});
+                    await persistDiskEntries()
+                }
 
                 logger.info(`[AuthService] GitHub PAT validated for user: ${user.name || user.login}`);
 
@@ -1181,6 +1357,19 @@ class AuthService extends Base {
 
                 if (stale) {
                     return admitProviderSubject(buildInfo(token, stale.user, stale.scopes), establishPin)
+                }
+
+                // Same disk tier on the unreachable branch: a cold process meeting an outage is the
+                // incident shape this whole fallback exists for.
+                const diskStale = await admitFromDiskWhenProviderAgrees(
+                    token,
+                    tokenHash,
+                    establishPin,
+                    signal.aborted ? `timeout after ${validationTimeoutMs}ms` : 'network error'
+                );
+
+                if (diskStale) {
+                    return diskStale
                 }
 
                 cache.delete(tokenHash);

--- a/ai/mcp/server/shared/services/AuthService.mjs
+++ b/ai/mcp/server/shared/services/AuthService.mjs
@@ -1024,22 +1024,44 @@ class AuthService extends Base {
         let pinnedProviderSubject = null;
         // Lazily-loaded mirror of the on-disk store; null until the first transport-failure fallback
         // (or first write-through) needs it. A plane that never sees an outage never pays the read.
-        let diskEntries = null;
+        // SINGLE-FLIGHT: concurrent first validations share one load, so two writers mutate the
+        // SAME map rather than two independent snapshots whose last rename would drop a row.
+        let diskEntries     = null;
+        let diskLoadPromise = null;
+        // Serialized write chain: logical updates (set/evict) are whole-map rewrites, so unchained
+        // concurrent rewrites would last-wins over each other. Deployment contract: one path is
+        // owned by exactly one service process — profiles bind DISTINCT paths per PAT-auth service,
+        // which dissolves cross-process contention structurally instead of locking.
+        let diskWriteChain = Promise.resolve();
 
         const loadDiskEntries = async () => {
-            if (!diskCachePath || diskEntries !== null) {
+            if (!diskCachePath) {
+                return null
+            }
+
+            if (diskEntries !== null) {
                 return diskEntries
             }
 
-            const {entries, warning} = await readPatValidationCache(diskCachePath);
+            if (!diskLoadPromise) {
+                diskLoadPromise = readPatValidationCache(diskCachePath)
+                    .then(({entries, warning}) => {
+                        if (warning) {
+                            logger.warn(`[AuthService] PAT disk cache at ${diskCachePath}: ${warning}. Admission degrades to provider-only until the next successful validation rewrites it.`)
+                        }
 
-            if (warning) {
-                logger.warn(`[AuthService] PAT disk cache at ${diskCachePath}: ${warning}. Admission degrades to provider-only until the next successful validation rewrites it.`)
+                        diskEntries = entries;
+
+                        return diskEntries
+                    })
+                    .catch(error => {
+                        diskLoadPromise = null;
+
+                        throw error
+                    })
             }
 
-            diskEntries = entries;
-
-            return diskEntries
+            return diskLoadPromise
         };
 
         const persistDiskEntries = async () => {
@@ -1047,14 +1069,21 @@ class AuthService extends Base {
                 return
             }
 
-            try {
-                await writePatValidationCache(diskCachePath, diskEntries ?? new Map())
-            } catch (error) {
-                // Losing the durable copy is a degradation to announce, never an admission failure —
-                // the credential was just VALIDATED; failing the request over its own cache write
-                // would invert the priority.
-                logger.warn(`[AuthService] PAT disk cache write failed (admission continues): ${error.message}`)
-            }
+            // Chain onto the previous rewrite: every mutation observes the map state AFTER the
+            // prior one landed, so set-then-evict from interleaved validations cannot reorder into
+            // losing either decision.
+            diskWriteChain = diskWriteChain.then(async () => {
+                try {
+                    await writePatValidationCache(diskCachePath, diskEntries ?? new Map())
+                } catch (error) {
+                    // Losing the durable copy is a degradation to announce, never an admission
+                    // failure — the credential was just VALIDATED; failing the request over its
+                    // own cache write would invert the priority.
+                    logger.warn(`[AuthService] PAT disk cache write failed (admission continues): ${error.message}`)
+                }
+            });
+
+            await diskWriteChain
         };
 
         /**
@@ -1083,6 +1112,17 @@ class AuthService extends Base {
 
             if (!entry || Date.now() > entry.verifiedAt + ttlMs + staleGraceMs) {
                 return null
+            }
+
+            // CURRENT admission policy reapplies to cached identities: a subject removed from the
+            // allowlist before a restart is not readmitted because the provider happens to be down
+            // when they return. The persisted identity is evidence of WHO was validated, never a
+            // grant that outlives the policy that admitted it.
+            if (requireUser && !allowedUsers.includes(entry.user?.login)) {
+                entries.delete(tokenHash);
+                cache.delete(tokenHash);
+                await persistDiskEntries();
+                throw new InvalidTokenError('GitHub user is not allowed')
             }
 
             let status = 0;
@@ -1331,10 +1371,17 @@ class AuthService extends Base {
 
                 // Write-through: the disk tier is only as good as its last affirmative answer. A
                 // revoked token must also leave THIS store on the authoritative path below.
+                // Persisted subject is NORMALIZED to the fields buildInfo consumes — the full
+                // provider response (plan flags, profile URLs, email scopes) never reaches disk;
+                // identity-disclosure bound is exactly these three fields plus scopes + timestamp.
                 if (diskCachePath) {
                     const entries = await loadDiskEntries();
 
-                    entries.set(tokenHash, {user, scopes, verifiedAt: Date.now()});
+                    entries.set(tokenHash, {
+                        user      : {id: user.id, login: user.login, name: user.name},
+                        scopes,
+                        verifiedAt: Date.now()
+                    });
                     await persistDiskEntries()
                 }
 

--- a/ai/scripts/lint/config-leaf-parity.json
+++ b/ai/scripts/lint/config-leaf-parity.json
@@ -183,6 +183,7 @@
         "auth.localBearerToken",
         "auth.mode",
         "auth.patCacheTtlSeconds",
+        "auth.patDiskCachePath",
         "auth.patStaleGraceSeconds",
         "auth.patValidationTimeoutMs",
         "auth.pinFirstProviderSubject",

--- a/ai/scripts/lint/config-leaf-parity.json
+++ b/ai/scripts/lint/config-leaf-parity.json
@@ -85,7 +85,7 @@
         "census": {
             "profile": "ai/deploy/docker-compose.yml",
             "baselineUniqueKeys": 45,
-            "remainingUniqueKeys": 73,
+            "remainingUniqueKeys": 74,
             "requiredDeploymentInputs": [
                 "NEO_AI_ORCHESTRATOR_AUTHORITY_PROFILE",
                 "NEO_AUTH_MODE",
@@ -118,6 +118,7 @@
                 "NEO_AUTH_HOST",
                 "NEO_AUTH_ISSUER_URL",
                 "NEO_AUTH_PAT_CACHE_TTL_SECONDS",
+                "NEO_AUTH_PAT_DISK_CACHE_PATH",
                 "NEO_AUTH_PAT_VALIDATION_TIMEOUT_MS",
                 "NEO_AUTH_PORT",
                 "NEO_AUTH_REALM",

--- a/learn/agentos/DeploymentCookbook.md
+++ b/learn/agentos/DeploymentCookbook.md
@@ -294,6 +294,7 @@ Supply these values per service/profile as needed:
 | `NEO_FLEET_HEALTHCHECK_URL` | Fleet healthcheck CLI | Optional override for the exact authenticated `/fleet/probe` URL. |
 | `NEO_MCP_HEALTHCHECK_TOKEN` | Generic Fleet Compose secret source | Provider bearer supplied to Docker Compose; only the secret carrier name appears in rendered configuration. |
 | `NEO_MCP_HEALTHCHECK_TOKEN_FILE` | Fleet container + healthcheck CLI | Required in-container secret-file bearer carrier; the Fleet probe never accepts the credential on argv. |
+| `NEO_AUTH_PAT_DISK_CACHE_PATH` | PAT-auth MCP/Fleet services | Optional restart-durable admission-cache file (hash-keyed, no token material). Empty (default) keeps the tier off; when set, each service MUST own a distinct path — one writer per file — on durable storage, so a redeploy during a provider outage admits previously-validated identities instead of locking every seat out. |
 
 The top-level AI config template is [`ai/config.template.mjs`](../../ai/config.template.mjs).
 The cloud-ingestion tenant config guide is

--- a/test/playwright/unit/ai/deploy/FleetServerComposition.spec.mjs
+++ b/test/playwright/unit/ai/deploy/FleetServerComposition.spec.mjs
@@ -26,11 +26,18 @@ test.describe('optional Fleet server composition', () => {
         expect(fleet.environment).toContain('NEO_AUTH_MODE=${NEO_AUTH_MODE:-github-pat}');
         expect(fleet.environment).toContain('NEO_AUTH_PROVIDER_BOOTSTRAP_PAT_FILE=/run/secrets/mcp-auth-token');
         expect(fleet.environment).toContain('NEO_MCP_HEALTHCHECK_TOKEN_FILE=/run/secrets/mcp-auth-token');
-        expect(fleet.volumes).toEqual(['fleet-data:/app/.neo-ai-data/fleet']);
+        // Restart-durable admission cache: fleet owns its path exclusively — the
+        // one-writer-per-path deployment contract, pinned here so it cannot silently regress.
+        expect(fleet.environment).toContain('NEO_AUTH_PAT_DISK_CACHE_PATH=/app/.neo-ai-data/auth/fleet-pat-validation-cache.json');
+        expect(fleet.volumes).toEqual([
+            'fleet-data:/app/.neo-ai-data/fleet',
+            'auth-cache-data:/app/.neo-ai-data/auth'
+        ]);
         expect(fleet.secrets).toEqual(['mcp-auth-token']);
         expect(fleet.expose).toEqual(['8083']);
         expect(fleet).not.toHaveProperty('ports');
         expect(compose.volumes).toHaveProperty('fleet-data');
+        expect(compose.volumes).toHaveProperty('auth-cache-data');
         expect(compose.secrets['mcp-auth-token']).toEqual({environment: 'NEO_MCP_HEALTHCHECK_TOKEN'});
         expect(fleet.healthcheck.test).toContain('./ai/scripts/diagnostics/fleetHealthcheck.mjs');
         expect(fleet.healthcheck.test).toContain('/app/.neo-ai-data/fleet')

--- a/test/playwright/unit/ai/mcp/server/knowledge-base/Server.spec.mjs
+++ b/test/playwright/unit/ai/mcp/server/knowledge-base/Server.spec.mjs
@@ -279,6 +279,7 @@ test.describe('Neo.ai.mcp.server.knowledge-base.Server', () => {
                 trustProxyIdentity          : false,
                 githubApiBaseUrl            : 'https://api.github.test',
                 patCacheTtlSeconds          : 300,
+                patDiskCachePath            : '',
                 patValidationTimeoutMs      : 5000,
                 allowedUsers,
                 allowedClientIds            : [],

--- a/test/playwright/unit/ai/mcp/server/memory-core/Server.spec.mjs
+++ b/test/playwright/unit/ai/mcp/server/memory-core/Server.spec.mjs
@@ -271,8 +271,8 @@ test.describe('Neo.ai.mcp.server.memory-core.Server', () => {
 
         try {
             const auth = isGitlab
-                ? {gitlabApiBaseUrl: baseUrl, patCacheTtlSeconds: 300, patValidationTimeoutMs: 5000}
-                : {githubApiBaseUrl: baseUrl, patCacheTtlSeconds: 300, patValidationTimeoutMs: 5000, allowedUsers: []};
+                ? {gitlabApiBaseUrl: baseUrl, patCacheTtlSeconds: 300, patValidationTimeoutMs: 5000, patDiskCachePath: ''}
+                : {githubApiBaseUrl: baseUrl, patCacheTtlSeconds: 300, patValidationTimeoutMs: 5000, allowedUsers: [], patDiskCachePath: ''};
 
             const verifier = isGitlab
                 ? AuthService.createGitlabPatVerifier({aiConfig: {auth}, logger: silentLogger, InvalidTokenError: FakeInvalidTokenError})
@@ -456,6 +456,7 @@ test.describe('Neo.ai.mcp.server.memory-core.Server', () => {
                 githubApiBaseUrl            : 'https://api.github.test',
                 patCacheTtlSeconds          : 300,
                 patValidationTimeoutMs      : 5000,
+                patDiskCachePath            : '',
                 allowedUsers,
                 allowedClientIds            : [],
                 pinFirstProviderSubject     : false,

--- a/test/playwright/unit/ai/mcp/server/shared/AuthService.spec.mjs
+++ b/test/playwright/unit/ai/mcp/server/shared/AuthService.spec.mjs
@@ -1,3 +1,4 @@
+import {createHash} from 'crypto';
 import {setup} from '../../../../../setup.mjs';
 
 const appName = 'AuthServicePatTest';
@@ -38,6 +39,7 @@ test.describe('Neo.ai.mcp.server.shared.services.AuthService — GitLab-PAT veri
         auth: {
             gitlabApiBaseUrl      : 'https://gitlab.example.com/',
             patCacheTtlSeconds    : 300,
+            patDiskCachePath      : '',
             patValidationTimeoutMs: 5000
         }
     };
@@ -332,6 +334,7 @@ test.describe('Neo.ai.mcp.server.shared.services.AuthService — GitLab-PAT veri
             aiConfig         : {auth: {
                 gitlabApiBaseUrl      : 'https://gitlab.example.com',
                 patCacheTtlSeconds    : 0,
+                patDiskCachePath      : '',
                 patValidationTimeoutMs: 5000
             }},
             logger,
@@ -364,6 +367,7 @@ test.describe('Neo.ai.mcp.server.shared.services.AuthService — GitLab-PAT midd
         mode                  : 'gitlab-pat',
         gitlabApiBaseUrl      : 'https://gitlab.example.com',
         patCacheTtlSeconds    : 300,
+        patDiskCachePath      : '',
         patValidationTimeoutMs: 5000
     }};
 
@@ -557,6 +561,7 @@ test.describe('Neo.ai.mcp.server.shared.services.AuthService — GitHub-PAT veri
         auth: {
             githubApiBaseUrl      : 'https://github.example.com/',
             patCacheTtlSeconds    : 300,
+            patDiskCachePath      : '',
             patValidationTimeoutMs: 5000
         }
     };
@@ -736,6 +741,7 @@ test.describe('Neo.ai.mcp.server.shared.services.AuthService — GitHub-PAT veri
 
         const noCacheVerifier = AuthService.createGithubPatVerifier({
             aiConfig         : withAuth({patCacheTtlSeconds: 0}),
+            patDiskCachePath : '',
             logger,
             InvalidTokenError: FakeInvalidTokenError
         });
@@ -760,6 +766,7 @@ test.describe('Neo.ai.mcp.server.shared.services.AuthService — GitHub-PAT midd
         mode                  : 'github-pat',
         githubApiBaseUrl      : 'https://api.github.com',
         patCacheTtlSeconds    : 300,
+        patDiskCachePath      : '',
         patValidationTimeoutMs: 5000
     }};
 
@@ -1205,6 +1212,7 @@ test.describe('Neo.ai.mcp.server.shared.services.AuthService — first provider 
                     trustProxyIdentity      : false,
                     githubApiBaseUrl        : 'https://api.github.com',
                     patCacheTtlSeconds      : 300,
+                    patDiskCachePath        : '',
                     patValidationTimeoutMs  : 5000,
                     allowedUsers            : [],
                     allowedClientIds        : [],
@@ -1658,6 +1666,7 @@ test.describe('AuthService — GitHub-PAT stale-serve boundary', () => {
           baseCfg = {
               githubApiBaseUrl      : 'https://api.github.com',
               patCacheTtlSeconds    : 300,
+              patDiskCachePath      : '',
               patValidationTimeoutMs: 5000,
               patStaleGraceSeconds  : 3600
           };
@@ -1704,6 +1713,7 @@ test.describe('AuthService — GitHub-PAT stale-serve boundary', () => {
     test('an UNREACHABLE provider serves the previously-validated identity', async () => {
         // ttl 0 → the entry is stale immediately, so the second call must re-validate and fail.
         const verifier = makeVerifier({patCacheTtlSeconds: 0});
+        patDiskCachePath      : '',
 
         await primeThenExpire(verifier, [{throws: Object.assign(new Error('socket hang up'), {code: 'ECONNRESET'})}]);
 
@@ -1714,6 +1724,7 @@ test.describe('AuthService — GitHub-PAT stale-serve boundary', () => {
 
     test('a 5xx is the provider FAILING TO ANSWER, not rejecting — served stale', async () => {
         const verifier = makeVerifier({patCacheTtlSeconds: 0});
+        patDiskCachePath      : '',
 
         await primeThenExpire(verifier, [{status: 503}]);
 
@@ -1724,6 +1735,7 @@ test.describe('AuthService — GitHub-PAT stale-serve boundary', () => {
         // The whole fix is worthless if this passes. A test covering only the timeout path would go
         // green while the change silently accepted revoked credentials.
         const verifier = makeVerifier({patCacheTtlSeconds: 0});
+        patDiskCachePath      : '',
 
         await primeThenExpire(verifier, [{status: 401}]);
 
@@ -1736,6 +1748,7 @@ test.describe('AuthService — GitHub-PAT stale-serve boundary', () => {
         // exactly when many agents share one source address — this deployment's normal condition,
         // and the failure the whole path exists to prevent. The fix reintroduced its own bug.
         const verifier = makeVerifier({patCacheTtlSeconds: 0});
+        patDiskCachePath      : '',
 
         await primeThenExpire(verifier, [{status: 403}]);
 
@@ -1744,6 +1757,7 @@ test.describe('AuthService — GitHub-PAT stale-serve boundary', () => {
 
     test('401 remains the ONLY authoritative rejection, and it evicts', async () => {
         const verifier = makeVerifier({patCacheTtlSeconds: 0});
+        patDiskCachePath      : '',
 
         await primeThenExpire(verifier, [{status: 401}, {throws: new Error('unreachable')}]);
 
@@ -1754,6 +1768,7 @@ test.describe('AuthService — GitHub-PAT stale-serve boundary', () => {
 
     test('grace 0 restores fail-closed-on-transport exactly — a deployment can opt out', async () => {
         const verifier = makeVerifier({patCacheTtlSeconds: 0, patStaleGraceSeconds: 0});
+        patDiskCachePath      : '',
 
         await primeThenExpire(verifier, [{throws: new Error('unreachable')}]);
 
@@ -1762,6 +1777,7 @@ test.describe('AuthService — GitHub-PAT stale-serve boundary', () => {
 
     test('a token past ttl + grace is rejected — the window is bounded, not unlimited', async () => {
         const verifier = makeVerifier({patCacheTtlSeconds: 0, patStaleGraceSeconds: 0.001});
+        patDiskCachePath      : '',
 
         stubFetch([{status: 200}]);
         await verifier.verifyAccessToken('tok');
@@ -1780,6 +1796,7 @@ test.describe('AuthService — GitHub-PAT stale-serve boundary', () => {
             aiConfig: {auth: {
                 gitlabApiBaseUrl      : 'https://gitlab.example.com/',
                 patCacheTtlSeconds    : 0,
+                patDiskCachePath      : '',
                 patValidationTimeoutMs: 5000,
                 patStaleGraceSeconds  : 3600
             }},
@@ -1804,6 +1821,7 @@ test.describe('AuthService — GitHub-PAT stale-serve boundary', () => {
         const gitlabCfg = {auth: {
             gitlabApiBaseUrl      : 'https://gitlab.example.com/',
             patCacheTtlSeconds    : 0,
+            patDiskCachePath      : '',
             patValidationTimeoutMs: 5000,
             patStaleGraceSeconds  : 3600,
             allowedClientIds      : ['mcp-oauth-app']
@@ -1842,6 +1860,7 @@ test.describe('AuthService — GitHub-PAT stale-serve boundary', () => {
         const verifier = AuthService.createGithubPatVerifier({
             // A REALISTIC ttl, not 0 — the stale entry must reconstruct a future expiry.
             aiConfig: withAuth({patCacheTtlSeconds: 1, patStaleGraceSeconds: 3600}),
+            patDiskCachePath: '',
             logger,
             InvalidTokenError
         });
@@ -1882,4 +1901,202 @@ test.describe('AuthService — GitHub-PAT stale-serve boundary', () => {
 
         await expect(verifier.verifyAccessToken('never-seen')).rejects.toThrow(FakeInvalidTokenError);
     });
+});
+
+/**
+ * Outage-survival tiers for the GitHub-PAT verifier: the in-memory stale tier was already covered
+ * above; these arms pin the DISK tier — a redeploy (cold process) meeting a provider outage admits
+ * previously-validated identities from the durable store, gated by a status-code-only validity
+ * probe against `/rate_limit`. Fail-closed is preserved on every unresolved shape.
+ */
+test.describe('Neo.ai.mcp.server.shared.services.AuthService — GitHub-PAT outage survival', () => {
+    let AuthService, patCache;
+    let originalFetch;
+    let tempDir;
+
+    class FakeInvalidTokenError extends Error {}
+
+    const logger   = {info: () => {}, warn: () => {}, error: () => {}};
+    const baseAuth = {
+        githubApiBaseUrl      : 'https://github.example.com',
+        patCacheTtlSeconds    : 300,
+        patDiskCachePath      : '',
+        patValidationTimeoutMs: 5000,
+        patStaleGraceSeconds  : 3600
+    };
+
+    const tokenHash = token => createHash('sha256').update(token).digest('hex');
+
+    const writeSeed = async (token, user, verifiedAt) => {
+        const file = path.join(tempDir, 'pat-validation-cache.json');
+
+        await patCache.writePatValidationCache(file, new Map([[tokenHash(token), {user, scopes: [], verifiedAt}]]));
+
+        return file
+    };
+
+    test.beforeAll(async () => {
+        AuthService = (await import('../../../../../../../ai/mcp/server/shared/services/AuthService.mjs')).default;
+        patCache    = await import('../../../../../../../ai/mcp/server/shared/helpers/patValidationCache.mjs');
+    });
+
+    test.beforeEach(async () => {
+        originalFetch = globalThis.fetch;
+        tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'pat-outage-'));
+    });
+
+    test.afterEach(async () => {
+        globalThis.fetch = originalFetch;
+        fs.rmSync(tempDir, {recursive: true, force: true})
+    });
+
+    const stubOutage = (rateLimitStatus = 200) => {
+        const calls = [];
+
+        globalThis.fetch = async (url, opts = {}) => {
+            calls.push({url: String(url), headers: opts.headers});
+
+            if (String(url).endsWith('/user')) {
+                return {ok: false, status: 503}
+            }
+
+            return {ok: true, status: rateLimitStatus}
+        };
+
+        return calls
+    };
+
+    test('a cold process during a /user outage admits the disk-cached identity behind a passing validity probe', async () => {
+        const file     = await writeSeed('survivor-token', {id: 7, login: 'eos', name: 'Eos'}, Date.now());
+        const calls    = stubOutage(200);
+        const verifier = AuthService.createGithubPatVerifier({
+            aiConfig         : {auth: {...baseAuth, patDiskCachePath: file}},
+            logger,
+            InvalidTokenError: FakeInvalidTokenError
+        });
+        const info = await verifier.verifyAccessToken('survivor-token');
+
+        expect(info.userId).toBe('eos');
+        // The honesty field: this session was NOT freshly provider-validated.
+        expect(info.validationState).toBe('stale-validated');
+        // Both endpoints were consulted, in order.
+        expect(calls.some(call => call.url.endsWith('/user'))).toBe(true);
+        const probe = calls.find(call => call.url.endsWith('/rate_limit'));
+        expect(probe).toBeTruthy();
+        expect(probe.headers.Authorization).toBe('Bearer survivor-token')
+    });
+
+    test('no disk entry + outage refuses exactly as before — fail-closed preserved', async () => {
+        const file     = path.join(tempDir, 'absent.json');
+        const verifier = AuthService.createGithubPatVerifier({
+            aiConfig         : {auth: {...baseAuth, patDiskCachePath: file}},
+            logger,
+            InvalidTokenError: FakeInvalidTokenError
+        });
+
+        stubOutage(200);
+
+        await expect(verifier.verifyAccessToken('unknown-token')).rejects.toThrow(FakeInvalidTokenError)
+    });
+
+    test('a 401 from the validity probe evicts BOTH tiers and refuses — revocation outranks survival', async () => {
+        const file     = await writeSeed('revoked-token', {id: 8, login: 'ghost'}, Date.now());
+        const verifier = AuthService.createGithubPatVerifier({
+            aiConfig         : {auth: {...baseAuth, patDiskCachePath: file}},
+            logger,
+            InvalidTokenError: FakeInvalidTokenError
+        });
+
+        globalThis.fetch = async url => String(url).endsWith('/user')
+            ? {ok: false, status: 503}
+            : {ok: false, status: 401};
+
+        await expect(verifier.verifyAccessToken('revoked-token')).rejects.toThrow(/validity check/);
+
+        const {entries} = await patCache.readPatValidationCache(file);
+        expect(entries.size).toBe(0)
+    });
+
+    test('the validity probe itself failing leaves admission UNRESOLVED — never a guess', async () => {
+        const file     = await writeSeed('walled-token', {id: 9, login: 'walled'}, Date.now());
+        const verifier = AuthService.createGithubPatVerifier({
+            aiConfig         : {auth: {...baseAuth, patDiskCachePath: file}},
+            logger,
+            InvalidTokenError: FakeInvalidTokenError
+        });
+
+        // 403 on the probe: on a shared egress this may be a primary rate-limit breach, not a
+        // refusal — so it must neither admit nor evict.
+        stubOutage(403);
+
+        await expect(verifier.verifyAccessToken('walled-token')).rejects.toThrow(FakeInvalidTokenError);
+
+        const {entries} = await patCache.readPatValidationCache(file);
+        expect(entries.get(tokenHash('walled-token'))?.user.login).toBe('walled')
+    });
+
+    test('an entry past ttl + stale grace is not admitted even with a passing probe', async () => {
+        const old      = Date.now() - (301 + 3601) * 1000;
+        const file     = await writeSeed('ancient-token', {id: 10, login: 'ancient'}, old);
+        const verifier = AuthService.createGithubPatVerifier({
+            aiConfig         : {auth: {...baseAuth, patDiskCachePath: file}},
+            logger,
+            InvalidTokenError: FakeInvalidTokenError
+        });
+
+        stubOutage(200);
+
+        await expect(verifier.verifyAccessToken('ancient-token')).rejects.toThrow(FakeInvalidTokenError)
+    });
+
+    test('a fresh validation writes through to the disk store', async () => {
+        const file     = path.join(tempDir, 'write-through.json');
+        const verifier = AuthService.createGithubPatVerifier({
+            aiConfig         : {auth: {...baseAuth, patDiskCachePath: file}},
+            logger,
+            InvalidTokenError: FakeInvalidTokenError
+        });
+
+        globalThis.fetch = async url => {
+            if (String(url).endsWith('/user')) {
+                return {
+                    ok     : true,
+                    headers: {get: () => null},
+                    json   : async () => ({id: 11, login: 'fresh-writer'})
+                }
+            }
+
+            return {ok: true, status: 200}
+        };
+
+        await verifier.verifyAccessToken('fresh-token');
+
+        const {entries} = await patCache.readPatValidationCache(file);
+        expect(entries.get(tokenHash('fresh-token'))?.user.login).toBe('fresh-writer')
+    });
+
+    test('feature off (no path): an outage behaves exactly as dev today — no reads, no writes, hard refusal', async () => {
+        const verifier = AuthService.createGithubPatVerifier({
+            aiConfig         : {auth: {...baseAuth}},
+            logger,
+            InvalidTokenError: FakeInvalidTokenError
+        });
+
+        stubOutage(200);
+
+        await expect(verifier.verifyAccessToken('anyone')).rejects.toThrow(FakeInvalidTokenError)
+    });
+
+    test('pin establishment never rides the disk tier — the pin comes from a FRESH validation or not at all', async () => {
+        const file     = await writeSeed('pinned-attempt', {id: 12, login: 'impostor'}, Date.now());
+        const verifier = AuthService.createGithubPatVerifier({
+            aiConfig         : {auth: {...baseAuth, patDiskCachePath: file, pinFirstProviderSubject: true}},
+            logger,
+            InvalidTokenError: FakeInvalidTokenError
+        });
+
+        stubOutage(200);
+
+        await expect(verifier.establishPinnedProviderSubject('pinned-attempt')).rejects.toThrow(FakeInvalidTokenError)
+    })
 });

--- a/test/playwright/unit/ai/mcp/server/shared/AuthService.spec.mjs
+++ b/test/playwright/unit/ai/mcp/server/shared/AuthService.spec.mjs
@@ -14,12 +14,13 @@ setup({
     }
 });
 
-import {test, expect} from '@playwright/test';
-import fs             from 'node:fs';
-import os             from 'node:os';
-import path           from 'node:path';
-import Neo            from '../../../../../../../src/Neo.mjs';
-import * as core      from '../../../../../../../src/core/_export.mjs';
+import {test, expect}  from '@playwright/test';
+import fs              from 'node:fs';
+import os              from 'node:os';
+import path            from 'node:path';
+import {fileURLToPath} from 'node:url';
+import Neo             from '../../../../../../../src/Neo.mjs';
+import * as core       from '../../../../../../../src/core/_export.mjs';
 
 /**
  * Unit coverage for the GitLab-PAT verifier in `AuthService`. Exercises the verifier
@@ -740,8 +741,7 @@ test.describe('Neo.ai.mcp.server.shared.services.AuthService — GitHub-PAT veri
         expect(calls).toBe(1);
 
         const noCacheVerifier = AuthService.createGithubPatVerifier({
-            aiConfig         : withAuth({patCacheTtlSeconds: 0}),
-            patDiskCachePath : '',
+            aiConfig         : withAuth({patCacheTtlSeconds: 0, patDiskCachePath: ''}),
             logger,
             InvalidTokenError: FakeInvalidTokenError
         });
@@ -1713,7 +1713,6 @@ test.describe('AuthService — GitHub-PAT stale-serve boundary', () => {
     test('an UNREACHABLE provider serves the previously-validated identity', async () => {
         // ttl 0 → the entry is stale immediately, so the second call must re-validate and fail.
         const verifier = makeVerifier({patCacheTtlSeconds: 0});
-        patDiskCachePath      : '',
 
         await primeThenExpire(verifier, [{throws: Object.assign(new Error('socket hang up'), {code: 'ECONNRESET'})}]);
 
@@ -1724,7 +1723,6 @@ test.describe('AuthService — GitHub-PAT stale-serve boundary', () => {
 
     test('a 5xx is the provider FAILING TO ANSWER, not rejecting — served stale', async () => {
         const verifier = makeVerifier({patCacheTtlSeconds: 0});
-        patDiskCachePath      : '',
 
         await primeThenExpire(verifier, [{status: 503}]);
 
@@ -1735,7 +1733,6 @@ test.describe('AuthService — GitHub-PAT stale-serve boundary', () => {
         // The whole fix is worthless if this passes. A test covering only the timeout path would go
         // green while the change silently accepted revoked credentials.
         const verifier = makeVerifier({patCacheTtlSeconds: 0});
-        patDiskCachePath      : '',
 
         await primeThenExpire(verifier, [{status: 401}]);
 
@@ -1748,7 +1745,6 @@ test.describe('AuthService — GitHub-PAT stale-serve boundary', () => {
         // exactly when many agents share one source address — this deployment's normal condition,
         // and the failure the whole path exists to prevent. The fix reintroduced its own bug.
         const verifier = makeVerifier({patCacheTtlSeconds: 0});
-        patDiskCachePath      : '',
 
         await primeThenExpire(verifier, [{status: 403}]);
 
@@ -1757,7 +1753,6 @@ test.describe('AuthService — GitHub-PAT stale-serve boundary', () => {
 
     test('401 remains the ONLY authoritative rejection, and it evicts', async () => {
         const verifier = makeVerifier({patCacheTtlSeconds: 0});
-        patDiskCachePath      : '',
 
         await primeThenExpire(verifier, [{status: 401}, {throws: new Error('unreachable')}]);
 
@@ -1768,7 +1763,6 @@ test.describe('AuthService — GitHub-PAT stale-serve boundary', () => {
 
     test('grace 0 restores fail-closed-on-transport exactly — a deployment can opt out', async () => {
         const verifier = makeVerifier({patCacheTtlSeconds: 0, patStaleGraceSeconds: 0});
-        patDiskCachePath      : '',
 
         await primeThenExpire(verifier, [{throws: new Error('unreachable')}]);
 
@@ -1777,7 +1771,6 @@ test.describe('AuthService — GitHub-PAT stale-serve boundary', () => {
 
     test('a token past ttl + grace is rejected — the window is bounded, not unlimited', async () => {
         const verifier = makeVerifier({patCacheTtlSeconds: 0, patStaleGraceSeconds: 0.001});
-        patDiskCachePath      : '',
 
         stubFetch([{status: 200}]);
         await verifier.verifyAccessToken('tok');
@@ -1859,8 +1852,7 @@ test.describe('AuthService — GitHub-PAT stale-serve boundary', () => {
 
         const verifier = AuthService.createGithubPatVerifier({
             // A REALISTIC ttl, not 0 — the stale entry must reconstruct a future expiry.
-            aiConfig: withAuth({patCacheTtlSeconds: 1, patStaleGraceSeconds: 3600}),
-            patDiskCachePath: '',
+            aiConfig: withAuth({patCacheTtlSeconds: 1, patStaleGraceSeconds: 3600, patDiskCachePath: ''}),
             logger,
             InvalidTokenError
         });
@@ -2098,5 +2090,122 @@ test.describe('Neo.ai.mcp.server.shared.services.AuthService — GitHub-PAT outa
         stubOutage(200);
 
         await expect(verifier.establishPinnedProviderSubject('pinned-attempt')).rejects.toThrow(FakeInvalidTokenError)
+    });
+
+    test('CURRENT allowlist policy reapplies on disk admission — a subject removed before restart stays out', async () => {
+        const file     = await writeSeed('policy-changed', {id: 13, login: 'removed-user'}, Date.now());
+        const verifier = AuthService.createGithubPatVerifier({
+            aiConfig         : {auth: {...baseAuth, patDiskCachePath: file, allowedUsers: ['current-user']}},
+            logger,
+            InvalidTokenError: FakeInvalidTokenError
+        });
+
+        stubOutage(200);
+
+        await expect(verifier.verifyAccessToken('policy-changed')).rejects.toThrow(/not allowed/);
+
+        // Policy eviction is durable too — the stale identity cannot come back on the next outage.
+        const {entries} = await patCache.readPatValidationCache(file);
+        expect(entries.size).toBe(0)
+    });
+
+    test('only the minimal normalized subject reaches disk — provider response extras never persist', async () => {
+        const file     = path.join(tempDir, 'minimized.json');
+        const verifier = AuthService.createGithubPatVerifier({
+            aiConfig         : {auth: {...baseAuth, patDiskCachePath: file}},
+            logger,
+            InvalidTokenError: FakeInvalidTokenError
+        });
+
+        globalThis.fetch = async url => {
+            if (String(url).endsWith('/user')) {
+                return {
+                    ok     : true,
+                    headers: {get: () => null},
+                    json   : async () => ({
+                        id                       : 14,
+                        login                    : 'minimized-user',
+                        name                     : 'Min',
+                        plan                     : 'enterprise',
+                        email                    : 'secret@provider.test',
+                        html_url                 : 'https://github.example.com/minimized-user',
+                        two_factor_authentication: true
+                    })
+                }
+            }
+
+            return {ok: true, status: 200}
+        };
+
+        await verifier.verifyAccessToken('minimize-token');
+
+        const raw = fs.readFileSync(file, 'utf8');
+
+        expect(raw).toContain('minimized-user');
+        // The disclosure-boundary sentinels: nothing beyond id/login/name survives serialization.
+        expect(raw).not.toContain('enterprise');
+        expect(raw).not.toContain('secret@provider.test');
+        expect(raw).not.toContain('two_factor');
+        expect(raw).not.toContain('html_url')
+    });
+
+    test('two concurrent first validations retain BOTH rows — single-flight load, chained rewrites', async () => {
+        const file     = path.join(tempDir, 'concurrent.json');
+        const verifier = AuthService.createGithubPatVerifier({
+            aiConfig         : {auth: {...baseAuth, patDiskCachePath: file}},
+            logger,
+            InvalidTokenError: FakeInvalidTokenError
+        });
+
+        // Deferred provider responses: both validations are IN FLIGHT simultaneously, so both hit
+        // the lazy load before either writes — the exact interleaving an unserialized last-wins
+        // rewrite loses.
+        let releaseA, releaseB;
+        const gateA   = new Promise(resolve => releaseA = resolve);
+        const gateB   = new Promise(resolve => releaseB = resolve);
+        const userFor = login => ({
+            ok     : true,
+            headers: {get: () => null},
+            json   : async () => ({id: login.length, login})
+        });
+
+        let userCalls = 0;
+
+        globalThis.fetch = async url => {
+            if (!String(url).endsWith('/user')) {
+                return {ok: true, status: 200}
+            }
+
+            // First /user call in flight is token-a's, second is token-b's — the URLs are
+            // identical, so routing goes by arrival order.
+            const call = ++userCalls;
+            const gate = call === 1 ? gateA : gateB;
+
+            return gate.then(() => userFor(call === 1 ? 'writer-a' : 'writer-b'))
+        };
+
+        const first  = verifier.verifyAccessToken('token-a-first');
+        const second = verifier.verifyAccessToken('token-b-second');
+
+        releaseB();
+        releaseA();
+
+        await Promise.all([first, second]);
+
+        const {entries} = await patCache.readPatValidationCache(file);
+
+        expect(entries.get(tokenHash('token-a-first'))?.user.login).toBe('writer-a');
+        expect(entries.get(tokenHash('token-b-second'))?.user.login).toBe('writer-b')
+    });
+
+    test('feature-off is pinned at the leaf default — flipping it to implicit-on fails this arm', async () => {
+        // Mutation control for RA-6's fixture-integrity finding: the tier must be OFF unless a
+        // profile explicitly places a path. Asserted against the CONFIG TEMPLATE SOURCE, because
+        // the runtime tree always carries the leaf and cannot express "was it born empty".
+        const configSource = fs.readFileSync(
+            path.join(path.dirname(fileURLToPath(import.meta.url)), '../../../../../../../ai/configBase.mjs'), 'utf8'
+        );
+
+        expect(configSource).toMatch(/patDiskCachePath\s*:\s*leaf\('',/)
     })
 });

--- a/test/playwright/unit/ai/mcp/server/shared/services/TransportService.spec.mjs
+++ b/test/playwright/unit/ai/mcp/server/shared/services/TransportService.spec.mjs
@@ -724,6 +724,7 @@ test.describe('Neo.ai.mcp.server.shared.services.TransportService', () => {
                     githubApiBaseUrl       : 'https://api.github.test',
                     patCacheTtlSeconds     : 300,
                     patValidationTimeoutMs : 5000,
+                    patDiskCachePath       : '',
                     allowedUsers           : [],
                     allowedClientIds       : [],
                     pinFirstProviderSubject: true,

--- a/test/playwright/unit/ai/mcp/server/shared/services/ownerPrincipalNormalizationAxes.spec.mjs
+++ b/test/playwright/unit/ai/mcp/server/shared/services/ownerPrincipalNormalizationAxes.spec.mjs
@@ -96,7 +96,8 @@ async function produceAuthInfo({baseUrl, login = 'octocat', providerId = 4242, t
         aiConfig         : {auth: {
             gitlabApiBaseUrl      : baseUrl,
             patCacheTtlSeconds    : 300,
-            patValidationTimeoutMs: 5000
+            patValidationTimeoutMs: 5000,
+            patDiskCachePath      : '',
         }},
         logger           : {info: () => {}, warn: () => {}, error: () => {}},
         InvalidTokenError: FakeInvalidTokenError
@@ -143,6 +144,7 @@ async function produceGithubAuthInfo({baseUrl = 'https://api.github.com', login 
             githubApiBaseUrl      : baseUrl,
             patCacheTtlSeconds    : 300,
             patValidationTimeoutMs: 5000,
+            patDiskCachePath      : '',
             allowedUsers          : []
         }},
         logger           : {info: () => {}, warn: () => {}, error: () => {}},

--- a/test/playwright/unit/ai/services/fleet/fleetServer.spec.mjs
+++ b/test/playwright/unit/ai/services/fleet/fleetServer.spec.mjs
@@ -61,6 +61,7 @@ function createConfig({authMiddleware=null, auth={}}={}) {
             githubApiBaseUrl       : 'https://api.github.test',
             patCacheTtlSeconds     : 60,
             patValidationTimeoutMs : 5_000,
+            patDiskCachePath       : '',
             allowedUsers           : [],
             ...auth
         },

--- a/test/playwright/unit/ai/services/memory-core/HealthService.starvationFold.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/HealthService.starvationFold.spec.mjs
@@ -415,3 +415,41 @@ test.describe('HealthService.foldHeavyMaintenanceStarvation — the consumed agg
         HealthService.clearCache();
     });
 });
+
+test.describe('composeMemoryCoreHealthcheck — admission-staleness is a CONSUMED degradation signal (#17304)', () => {
+    test('a seeded auth-staleness entry degrades the composed verdict, names the identity, and clears latch-free', async () => {
+        const {composeMemoryCoreHealthcheck} = await import('../../../../../../ai/mcp/server/memory-core/toolService.mjs');
+        const {getAuthValidationStaleness}   = await import('../../../../../../ai/mcp/server/shared/services/AuthService.mjs');
+
+        const healthyBase = {status: 'healthy', details: ['All features are operational']};
+        const compose     = () => composeMemoryCoreHealthcheck({
+            health              : healthyBase,
+            memoryWalDrain      : {state: 'idle'},
+            plane               : {id: 'test-plane', dataRoot: '/tmp/test-plane'},
+            deploymentInspection: {ok: false, status: 'unavailable'}
+        });
+
+        // Baseline without staleness: the empty registry must compose healthy — proving the
+        // signal's PRESENCE, not the import, is what degrades.
+        expect(compose().status).toBe('healthy');
+
+        const registry = getAuthValidationStaleness();
+        registry.set('github-pat', {since: Date.now(), user: 'eos'});
+
+        try {
+            const degradedResponse = compose();
+
+            expect(degradedResponse.status).toBe('degraded');
+            expect(degradedResponse.details.some(detail => detail.includes('Provider PAT admission is degraded'))).toBe(true);
+            expect(degradedResponse.details.some(detail => detail.includes("'eos'"))).toBe(true);
+            // The base payload was never mutated (upstream cache stays pristine).
+            expect(healthyBase.status).toBe('healthy')
+        } finally {
+            registry.delete('github-pat')
+        }
+
+        // Latch-free by per-request construction: a fresh provider validation restores healthy.
+        expect(compose().status).toBe('healthy');
+        expect(compose().details).toContain('All features are operational')
+    })
+});

--- a/test/playwright/unit/apps/agentos/fleet/fleetWakeStreamConsumer.live.spec.mjs
+++ b/test/playwright/unit/apps/agentos/fleet/fleetWakeStreamConsumer.live.spec.mjs
@@ -41,6 +41,7 @@ function liveConfig({authMiddleware}) {
             pinFirstProviderSubject: false,
             githubApiBaseUrl       : 'https://api.github.test',
             patCacheTtlSeconds     : 60,
+            patDiskCachePath       : '',
             patValidationTimeoutMs : 5_000,
             allowedUsers           : []
         },


### PR DESCRIPTION
Resolves neomjs/neo#17304

A GitHub authentication outage no longer holds a freshly-redeployed plane hostage. The PAT validation cache gains a restart-durable tier: successful validations persist hash-keyed (never the token) to an explicitly-named file, and when `/user` cannot be asked, admission falls through in-memory stale-serve to the disk tier — gated by a status-code-only validity probe against `/rate_limit` (200 admits the cached identity as `stale-validated`; 401 evicts everywhere; anything else stays unresolved). The memory-core healthcheck composes a new auth-staleness signal so surviving the outage renders as `degraded`, never silently `healthy`.

Evidence: L2 (unit-level red/green against synthetic roots incl. the cold-process redeploy shape; healthcheck signal CONSUMED by a compose-level test) → L2 required (all ACs run-observable). Residual: AC-4's who_is_online/cockpit rendering sliver, Residual-Owner: neomjs/neo#17781.

## AC Evidence
| AC-1 | Cold-process + `/user` 503 + warm disk cache → admitted with `validationState: 'stale-validated'` (`AuthService.spec.mjs` › outage survival › cold-process arm); healthcheck degraded via the new auth-staleness composition (`toolService.mjs`) consumed by the existing `--expected-status healthy,degraded` contract |
| AC-2 | Authoritative refusals unchanged and now cross-tier: `/user` 401 evicts memory+disk; probe 401 evicts+refuses; both arms pin refusal |
| AC-3 | Store is hash-keyed JSON (shape-guarded rows), written atomically via the shared `writeFileAtomicSync`; TTL + stale window reuse the existing `patCacheTtlSeconds`/`patStaleGraceSeconds` semantics; location is an explicit opt-in leaf |
| AC-4 | `stale-validated` rides AuthInfo at the transport boundary; per-admission warn logs; memory-core healthcheck composes the registry into a consumed degraded verdict naming mode/identity/since (`HealthService.starvationFold.spec.mjs` admission-staleness arm). Rendering sliver residual: neomjs/neo#17781 |
| AC-5 | New `auth.patDiskCachePath` leaf: declarative, empty default = feature off, explicit placement per profile; SSOT lint green incl. parity snapshot updated in-commit |

## Deltas from ticket
- The "new sibling leaf for the stale window" already exists on dev (`patStaleGraceSeconds` + the in-process stale tier landed after filing); this PR reuses those semantics for the disk tier instead of minting a second window.
- Healthcheck degraded composition ships for the memory-core server (the incident's subject); other servers can adopt the same accessor.
- The `/rate_limit` probe consumes status codes only, never the body — boundary ruling from @neo-opus-ada recorded in-code (remaining-rate-limit numbers are GitHub-read data).
- Review round repaired (Emmy, 6 RAs): current allowlist policy reapplies on disk admission (cold-process negative arm); persisted subject normalized to id/login/name with disclosure sentinels; single-flight load + chained whole-map rewrites with a both-rows-retained concurrency witness; feature activated in the canonical profiles via per-service distinct paths on a new durable volume (+ parity census, cookbook row); fixture-integrity audit removed every inert label-form insertion and added a config-source feature-off control.
- Probe eviction is deliberately 401-only: a shared-egress 403 may be a primary rate-limit breach, per the doctrine `isAuthoritativeRejection` already encodes.

## Test Evidence
All coverage runs in CI. AuthService.spec: 75/75 (8 new outage-survival arms; pre-existing stale-tier arms green). memory-core suite: 102 passed with the new healthcheck signal. `ai:lint-config-template-ssot` OK.

## Post-Merge Validation
None — every effect is observable at unit level; the live-outage witness remains the next real provider incident.

## Commits
- 695e1a5fa7 — disk tier + rate_limit gate + staleness observability + parity snapshot

Authored by Eos (ox-alpha, OpenCode). Session 2ba2b11c-eed0-48f4-ae76-de3752c3fc1a.