### PR TITLE
fix(test): assert the pack path streams, instead of sampling process RSS (#17773)

### DIFF
--- a/test/playwright/unit/ai/scripts/maintenance/knowledgeBaseArtifact.spec.mjs
+++ b/test/playwright/unit/ai/scripts/maintenance/knowledgeBaseArtifact.spec.mjs
@@ -796,7 +796,18 @@ test.describe('Knowledge Base release artifact — collection-scoped contract (#
 
         // Patched on `fs-extra`, which is what the implementation imports as its `fs`. Patching
         // node:fs here would observe nothing and the arm would be vacuous.
-        const originals     = {createReadStream: fsExtra.createReadStream, readFileSync: fsExtra.readFileSync},
+        //
+        // ALL THREE whole-file seams are observed, not just the sync one. A partially refactored path
+        // could open a stream — satisfying the positive control below — and still slurp the JSONL
+        // through `readFile` or `promises.readFile`, leaving "never reads it whole" green while the
+        // ERR_STRING_TOO_LONG defect is back. The contract names the family, so the arm watches the
+        // family.
+        const originals = {
+                  createReadStream: fsExtra.createReadStream,
+                  readFileSync    : fsExtra.readFileSync,
+                  readFile        : fsExtra.readFile,
+                  promisesReadFile: fsExtra.promises.readFile
+              },
               streamedFrom  = [],
               readWholeFrom = [];
 
@@ -810,12 +821,26 @@ test.describe('Knowledge Base release artifact — collection-scoped contract (#
             return originals.readFileSync(target, ...rest)
         };
 
+        fsExtra.readFile = (target, ...rest) => {
+            readWholeFrom.push(String(target));
+            return originals.readFile(target, ...rest)
+        };
+
+        fsExtra.promises.readFile = (target, ...rest) => {
+            readWholeFrom.push(String(target));
+            return originals.promisesReadFile(target, ...rest)
+        };
+
         let packed;
 
         try {
             packed = await packArtifactToV2({artifactDir: dir, jsonlPath: jsonl, dimension: FIXTURE_DIMENSION});
         } finally {
-            Object.assign(fsExtra, originals)
+            // Every patched function restored, including the nested promises seam.
+            fsExtra.createReadStream  = originals.createReadStream;
+            fsExtra.readFileSync      = originals.readFileSync;
+            fsExtra.readFile          = originals.readFile;
+            fsExtra.promises.readFile = originals.promisesReadFile
         }
 
         expect(packed.recordCount).toBe(4000);
@@ -824,8 +849,9 @@ test.describe('Knowledge Base release artifact — collection-scoped contract (#
 
         // The JSONL is opened as a stream …
         expect(streamedFrom, 'the JSONL is read through a stream').toContain(jsonl);
-        // … and never slurped whole. This is the assertion that fails if the implementation reverts.
-        expect(readWholeFrom, 'the JSONL is never read as one string').not.toContain(jsonl);
+        // … and never slurped whole through ANY of the three seams. This is the assertion that fails
+        // if the implementation reverts, on the sync path or either promise path.
+        expect(readWholeFrom, 'the JSONL reaches no whole-file read seam').not.toContain(jsonl);
     });
 
     test('a REORDERED v2 JSONL aborts the real download BEFORE any import runs', async () => {

--- a/test/playwright/unit/ai/scripts/maintenance/knowledgeBaseArtifact.spec.mjs
+++ b/test/playwright/unit/ai/scripts/maintenance/knowledgeBaseArtifact.spec.mjs
@@ -772,12 +772,21 @@ test.describe('Knowledge Base release artifact — collection-scoped contract (#
             .rejects.toThrow(/'dimension' must be a positive integer, got "4" \(string\)/);
     });
 
-    test('pack streams: peak RSS stays bounded well below the JSONL it rewrites', async () => {
+    test('pack STREAMS the JSONL and never reads it whole', async () => {
         // The defect this closes could not be seen by any small fixture: the old implementation read the
         // whole JSONL into ONE utf-8 string, and the real 2.81 GiB export is 5.62x Node's
         // MAX_STRING_LENGTH (536,870,888) — so the shipped path threw ERR_STRING_TOO_LONG on the corpus
-        // it was written for while passing every 3-row test. This asserts the SHAPE (bounded retention)
-        // rather than re-running the corpus; the full-corpus receipt lives on the PR.
+        // it was written for while passing every 3-row test.
+        //
+        // This asserts the MECHANISM, not a memory reading. The previous version bounded
+        // `process.memoryUsage().rss` growth at `jsonlBytes * 4`, and that instrument could never
+        // decide this question: measured on the real packer, the STREAMING path costs 4-17x the file
+        // in RSS (transient fp16/batch buffers plus V8 heap growth, none of which is returned), while
+        // a whole-file read costs only ~1.4-2.7x. So the "bad" implementation sat comfortably under a
+        // bound the good one exceeded, and what the arm actually sampled was process history — the
+        // same call reads ~7.4 MB cold and ~1.8 MB warm, which is why it reddened unrelated PRs.
+        //
+        // A stream read and a whole-file read are distinguishable exactly, so the arm asks that.
         const dir   = path.join(workRoot, 'stream-bound'),
               jsonl = path.join(dir, `${KB_BACKUP_FILE_PREFIX}stream.jsonl`),
               ids   = Array.from({length: 4000}, (_, i) => `kb-${i}`);
@@ -785,16 +794,38 @@ test.describe('Knowledge Base release artifact — collection-scoped contract (#
         await fsExtra.ensureDir(dir);
         fs.writeFileSync(jsonl, jsonlFixture(ids));
 
-        const jsonlBytes = fs.statSync(jsonl).size,
-              before     = process.memoryUsage().rss;
+        // Patched on `fs-extra`, which is what the implementation imports as its `fs`. Patching
+        // node:fs here would observe nothing and the arm would be vacuous.
+        const originals     = {createReadStream: fsExtra.createReadStream, readFileSync: fsExtra.readFileSync},
+              streamedFrom  = [],
+              readWholeFrom = [];
 
-        const packed = await packArtifactToV2({artifactDir: dir, jsonlPath: jsonl, dimension: FIXTURE_DIMENSION});
+        fsExtra.createReadStream = (target, ...rest) => {
+            streamedFrom.push(String(target));
+            return originals.createReadStream(target, ...rest)
+        };
+
+        fsExtra.readFileSync = (target, ...rest) => {
+            readWholeFrom.push(String(target));
+            return originals.readFileSync(target, ...rest)
+        };
+
+        let packed;
+
+        try {
+            packed = await packArtifactToV2({artifactDir: dir, jsonlPath: jsonl, dimension: FIXTURE_DIMENSION});
+        } finally {
+            Object.assign(fsExtra, originals)
+        }
 
         expect(packed.recordCount).toBe(4000);
         // Sidecar size is exact arithmetic, so a streaming bug that dropped or duplicated a row shows here.
         expect(fs.statSync(path.join(dir, ARTIFACT_VECTORS_FILENAME)).size).toBe(4000 * FIXTURE_DIMENSION * 2);
-        // Growth must not scale with the file: a whole-file read would retain at least its own bytes.
-        expect(process.memoryUsage().rss - before).toBeLessThan(jsonlBytes * 4);
+
+        // The JSONL is opened as a stream …
+        expect(streamedFrom, 'the JSONL is read through a stream').toContain(jsonl);
+        // … and never slurped whole. This is the assertion that fails if the implementation reverts.
+        expect(readWholeFrom, 'the JSONL is never read as one string').not.toContain(jsonl);
     });
 
     test('a REORDERED v2 JSONL aborts the real download BEFORE any import runs', async () => {


### PR DESCRIPTION
## Context

`knowledgeBaseArtifact.spec.mjs:775` reds unrelated PRs. `failOnFlakyTests: isCI` (#17229) turns its green-after-retry into a red run, so it has now blocked two PRs that never touched the knowledge-base artifact path: @neo-gpt's #17769 (observed `1,863,680` against a `< 1,753,836` bound) and my #17770 (`2,453,504`).

Evidence: L2 (spy on the real `fs-extra` read seams through the real `packArtifactToV2`) → L2 required (the close-target ACs are all unit-observable — which read API the pack path uses). No residuals.

Origin Session ID: 6df18da7-801b-4908-9b84-63f40388a1d0

## The Problem

The arm is not mis-tuned. **At any threshold, on this instrument, it cannot fail for the right reason.**

Measured on this deployment with `--expose-gc` and GC settled between readings, comparing the real streaming packer against a deliberate whole-file read of the same fixture:

| rows | JSONL | streaming RSS | whole-file RSS | stream / file | whole / file |
|---|---|---|---|---|---|
| 4,000 | 428 KB | 7,376 KB | 1,152 KB | **17.2x** | 2.7x |
| 20,000 | 2,211 KB | 10,800 KB | 3,792 KB | **4.9x** | 1.7x |
| 60,000 | 6,743 KB | 42,704 KB | 9,360 KB | **6.3x** | 1.4x |
| 120,000 | 13,637 KB | 56,112 KB | 24,672 KB | **4.1x** | 1.8x |

The **streaming** path costs more process RSS than the whole-file read, at every size — RSS is high-water process memory that never returns, and it captures the packer's transient fp16/batch buffers and V8 heap growth, none of which is "retention proportional to file size". So the `< jsonlBytes * 4` ceiling sits **above** what the broken implementation retains and **below** what the correct one does. The pre-fix code that threw `ERR_STRING_TOO_LONG` on the 2.81 GiB export would have passed this arm.

And what it did measure was process history: the same call reads ~7.4 MB cold and ~1.8 MB warm, which is exactly why its verdict depended on what ran before it in the worker rather than on the code under test.

## The Fix

A stream read and a whole-file read are **exactly** distinguishable, so the arm asks that instead of sampling a global counter: the JSONL is opened through `createReadStream` and never passed to `readFileSync`. That holds at any fixture size and does not depend on GC timing or worker warmth.

Patched on **`fs-extra`**, which is what `knowledgeBaseArtifact.mjs` imports as its `fs`. My first draft patched `node:fs` and observed nothing — it failed loudly rather than passing vacuously, which is the direction that mistake should fail in, and is worth knowing for the next spy in this file.

## AC Evidence

| AC | Proof |
|---|---|
| AC-1 | The arm no longer calls `process.memoryUsage()`; the verdict is two `toContain` / `not.toContain` assertions over recorded read-seam calls. |
| AC-2 | **Red-proof against the real defect.** With `streamJsonlRecords` temporarily switched to `fs.readFileSync(jsonlPath, 'utf8').split('\n')`, the arm FAILS on `the JSONL is never read as one string`. This is the mutation the old bound passed, which is why it is the AC that matters. Implementation restored via `git checkout` immediately after. |
| AC-3 | **25 consecutive runs clean** (`--repeat-each=25 --workers=1 --retries=0`), plus the full file green from a cold process. |
| AC-4 | The `recordCount` and sidecar-size assertions are byte-identical — those are exact arithmetic and were never the flaky part. |
| AC-5 | The comment states what the arm proves, the measured reason RSS was abandoned, and the `fs-extra`-not-node:fs seam note, so the next reader does not reintroduce a threshold. |

## Test Evidence

- `knowledgeBaseArtifact.spec.mjs` — **40 passed**.
- Red-proof: **1 failed** under the mutated implementation, at the intended assertion.
- Repetition: **25/25 clean**.

## Deltas

- `test/playwright/unit/ai/scripts/maintenance/knowledgeBaseArtifact.spec.mjs` — one arm rewritten. No production file changes.

## Post-Merge Validation

- The two PRs this reddened (#17769, #17770) should go green on their next CI run without any change of their own. That is the observable.
- If this arm ever flakes again it is a real regression, not noise — the new assertions have no timing or memory dependence.

Resolves #17773

Authored by ⚖️ **Ada** · `@neo-opus-ada` · Claude Opus 5 · Claude Code
