### PR TITLE
test(grid): pinning survives a paused thumb drag (#17430)

### DIFF
--- a/test/playwright/e2e/grid/ThumbDragPause.spec.mjs
+++ b/test/playwright/e2e/grid/ThumbDragPause.spec.mjs
@@ -11,9 +11,16 @@ import { test, expect } from '@playwright/test';
  * stays engaged until the worker catches up. This spec exists to keep that a property rather
  * than an implementation detail.
  *
- * The assertion reads `--grid-row-pin-offset` — the CSS custom property `applyPinning` writes
- * onto the body nodes — instead of judging paint from a screenshot. A reintroduced inactivity
- * timeout clears the offset to `0px`, so the observable and the defect are the same quantity.
+ * **The pause must land on an ENGAGED pin, and that ordering is the whole test.** An earlier
+ * revision paused immediately after `mousedown`, before any scroll had given the pin work to
+ * do — so it demonstrated only that a fresh scroll engages pinning after an idle hold, which
+ * is not the property in the title. `mousedown` alone calls `applyPinning` with `deltaY` of
+ * zero and writes nothing observable. The sequence below therefore engages the pin with a real
+ * jump, proves it engaged, and only then stops the world.
+ *
+ * The observable is `--grid-row-pin-offset` — the CSS custom property `applyPinning` writes
+ * onto the body nodes — rather than a screenshot, so the assertion and the defect are the same
+ * quantity and no rendering judgement enters the loop.
  */
 test.describe('Desktop (1920x1080): BigData Grid Paused Thumb Drag Pinning', () => {
     test.use({ viewport: { width: 1920, height: 1080 } });
@@ -45,9 +52,8 @@ test.describe('Desktop (1920x1080): BigData Grid Paused Thumb Drag Pinning', () 
             return {scrollHeight: wrapper.scrollHeight, clientHeight: wrapper.clientHeight}
         });
 
-        // The pin only has work to do when a thumb jump outruns the worker, which needs a store far
-        // taller than the viewport. If the 100k-row setup silently failed, every assertion below
-        // would be measuring a grid that cannot lag.
+        // If the 100k-row setup silently failed, every assertion below would be measuring a grid
+        // that cannot lag, and a grid that cannot lag never pins.
         expect(geometry.scrollHeight, `grid is deeply scrollable (${JSON.stringify(geometry)})`)
             .toBeGreaterThan(geometry.clientHeight * 10);
 
@@ -91,9 +97,14 @@ test.describe('Desktop (1920x1080): BigData Grid Paused Thumb Drag Pinning', () 
 
         // Engage the drag the way the engine sees it. Chrome paints the scrollbar thumb in the
         // compositor, so a synthetic CDP mouse press over it never hit-tests to a scroll — measured
-        // here as `scrollTop` stuck at 0 through a full press-and-drag. `GridRowScrollPinning` binds
+        // as `scrollTop` stuck at 0 through a full press-and-drag. `GridRowScrollPinning` binds
         // `mousedown` to the scrollbar NODE, so dispatching there sets `isThumbDragging` exactly as a
         // real press does, and it makes the pause provably event-free rather than merely still.
+        const jump = () => page.evaluate(() => {
+            const wrapper = document.querySelector('.neo-grid-view');
+            wrapper.scrollTop = wrapper.scrollTop + 120000
+        });
+
         await page.evaluate(() => {
             const scrollbar = document.querySelector('.neo-grid-vertical-scrollbar'),
                   box       = scrollbar.getBoundingClientRect();
@@ -103,7 +114,25 @@ test.describe('Desktop (1920x1080): BigData Grid Paused Thumb Drag Pinning', () 
             }))
         });
 
-        // Mark the pause window so the samples inside it can be isolated from the drag around it.
+        // --- Engage the pin BEFORE the pause, and prove it engaged. This is the ordering the
+        // --- earlier revision got wrong; without it the pause lands on a pin that never existed.
+        await jump();
+        await page.waitForTimeout(120);
+
+        const engagement = await page.evaluate(() => {
+            const parse = value => parseFloat(value) || 0,
+                  peak  = window.__PIN_SAMPLES.reduce(
+                      (max, sample) => Math.max(max, Math.abs(parse(sample.offset))), 0
+                  );
+
+            return {peakOffset: peak, sampleCount: window.__PIN_SAMPLES.length}
+        });
+
+        // The positive control for the whole scenario: the pin did real work — a large reverse
+        // translate holding stale rows in view — before anything was asked to survive a pause.
+        expect(engagement.peakOffset, `pin engaged with real work before the pause (${JSON.stringify(engagement)})`)
+            .toBeGreaterThan(100);
+
         const pauseStart = await page.evaluate(() => performance.now());
 
         // Longer than any plausible inactivity timeout. The press is held and nothing moves: no
@@ -112,15 +141,41 @@ test.describe('Desktop (1920x1080): BigData Grid Paused Thumb Drag Pinning', () 
 
         const pauseEnd = await page.evaluate(() => performance.now());
 
-        // The resumed drag. Each jump is far larger than the pooled rows can cover, so the worker is
-        // demonstrably behind and the pin has something to hold.
-        for (const _ of [0, 1]) {
-            await page.evaluate(() => {
-                const wrapper = document.querySelector('.neo-grid-view');
-                wrapper.scrollTop = wrapper.scrollTop + 60000
-            });
-            await page.waitForTimeout(200)
-        }
+        // The first resumed event, then a deliberate wait for the worker to CATCH UP.
+        //
+        // The catch-up is the discriminator, and it is easy to leave out. `isPinningActive` latches:
+        // once engaged it survives on its own until `applyPinning` sees BOTH a released thumb and a
+        // settled delta (`!isThumbDragging && Math.abs(deltaY) < 5`). So a jump taken while the latch
+        // is still set re-pins regardless of whether the held-thumb state survived the pause — an
+        // earlier revision of this spec asserted exactly there and was green against a mutation that
+        // cleared `isThumbDragging` outright. Letting the worker settle first is what un-latches it,
+        // and only then does the next jump actually ask whether the thumb is still held.
+        await jump();
+
+        const settled = await page.evaluate(async () => {
+            const body  = document.querySelector('.neo-grid-body'),
+                  read  = () => Math.abs(parseFloat(body.style.getPropertyValue('--grid-row-pin-offset')) || 0),
+                  start = performance.now();
+
+            while (performance.now() - start < 4000) {
+                if (read() < 5) return {caughtUp: true, offset: read(), waitedMs: performance.now() - start};
+                await new Promise(resolve => setTimeout(resolve, 50))
+            }
+
+            return {caughtUp: false, offset: read(), waitedMs: performance.now() - start}
+        });
+
+        // Positive control for the discriminator itself: without a real catch-up the latch never
+        // clears, and the final jump below would re-pin under either hypothesis.
+        expect(settled.caughtUp, `the worker caught up before the final jump (${JSON.stringify(settled)})`).toBe(true);
+
+        const catchUpEnd = await page.evaluate(() => performance.now());
+
+        // The question the whole spec exists to ask: with the latch cleared, is the thumb STILL held?
+        // If the pause dropped that state this jump cannot engage the pin and the pooled rows leave
+        // the viewport while the worker chases a 120k-pixel move nothing is holding.
+        await jump();
+        await page.waitForTimeout(400);
 
         const afterDrag = await page.evaluate(() => {
             cancelAnimationFrame(window.__PIN_RAF);
@@ -135,7 +190,8 @@ test.describe('Desktop (1920x1080): BigData Grid Paused Thumb Drag Pinning', () 
         const {samples}    = afterDrag,
               parseOffset  = value => parseFloat(value) || 0,
               pauseSamples = samples.filter(sample => sample.t >= pauseStart && sample.t <= pauseEnd),
-              postSamples  = samples.filter(sample => sample.t > pauseEnd);
+              postSamples  = samples.filter(sample => sample.t > pauseEnd),
+              finalSamples = samples.filter(sample => sample.t > catchUpEnd);
 
         // --- Positive controls. Without these the assertions below pass on a drag that never ran,
         // --- which is how the pre-removal version of this spec could go green having observed nothing.
@@ -144,18 +200,23 @@ test.describe('Desktop (1920x1080): BigData Grid Paused Thumb Drag Pinning', () 
         expect(postSamples.length,  'frames were observed AFTER the pause').toBeGreaterThan(1);
         expect(afterDrag.scrollTop, 'the post-pause drag actually scrolled the grid').toBeGreaterThan(0);
 
-        // The pause must really have been still — otherwise this is a moving-drag test wearing a
-        // pause's name, and it cannot speak to the property it claims to cover.
+        // The pause must really have been event-free — otherwise this is a moving-drag test wearing
+        // a pause's name, and it cannot speak to the property it claims to cover.
         const pauseScrollTops = new Set(pauseSamples.map(sample => sample.scrollTop));
         expect(pauseScrollTops.size, 'the grid did not scroll during the pause').toBe(1);
 
-        // --- The property. Pinning engages while the worker is behind, and the pause does not drop it.
-        const engagedAfterPause = postSamples.some(sample => Math.abs(parseOffset(sample.offset)) > 0);
+        expect(finalSamples.length, 'frames were observed AFTER the catch-up').toBeGreaterThan(1);
 
-        expect(engagedAfterPause, 'pinning engaged on the drag that followed the pause').toBe(true);
+        // --- The property, asserted where it is actually separable. The offset legitimately relaxes
+        // --- toward zero as the worker catches up — that is the pin working, not dropping — so a
+        // --- reading taken while the latch is still set proves nothing. This one is taken after the
+        // --- latch cleared, where engagement can only come from a thumb that is still held.
+        const engagedAfterCatchUp = finalSamples.some(sample => Math.abs(parseOffset(sample.offset)) > 100);
 
-        // Rows stay painted across the pause and the drag that follows it. A dropped pin shows up
-        // here as pooled rows pushed clean out of the viewport while the worker catches up.
+        expect(engagedAfterCatchUp, 'the still-held thumb re-engages the pin after the latch cleared').toBe(true);
+
+        // Rows stay painted throughout. A dropped held-thumb state shows up here as pooled rows
+        // pushed clean out of the viewport while the worker chases a jump nothing is holding.
         const blankFrames = [...pauseSamples, ...postSamples].filter(sample => !sample.painted);
 
         expect(blankFrames.length, 'no frame blanked during or after the pause').toBe(0)

--- a/test/playwright/e2e/grid/ThumbDragPause.spec.mjs
+++ b/test/playwright/e2e/grid/ThumbDragPause.spec.mjs
@@ -1,0 +1,163 @@
+import { test, expect } from '@playwright/test';
+
+/**
+ * Row pinning must survive a thumb drag that STOPS MOVING while the button is still held.
+ *
+ * A pause is the state where a drag is live but no events arrive, which is exactly when a
+ * disengagement bug is invisible to a moving-drag test: a continuous drag re-enters
+ * `applyPinning` on every scroll event, so it repairs its own state and can never observe a
+ * pin that was dropped in between. `GridRowScrollPinning` holds `isThumbDragging` from
+ * scrollbar `mousedown` until `mouseup` with no inactivity timer, and once pinning engages it
+ * stays engaged until the worker catches up. This spec exists to keep that a property rather
+ * than an implementation detail.
+ *
+ * The assertion reads `--grid-row-pin-offset` — the CSS custom property `applyPinning` writes
+ * onto the body nodes — instead of judging paint from a screenshot. A reintroduced inactivity
+ * timeout clears the offset to `0px`, so the observable and the defect are the same quantity.
+ */
+test.describe('Desktop (1920x1080): BigData Grid Paused Thumb Drag Pinning', () => {
+    test.use({ viewport: { width: 1920, height: 1080 } });
+
+    test.beforeEach(async ({ page }) => {
+        await page.goto('/examples/grid/bigData/index.html');
+
+        await page.waitForSelector('.neo-grid-container', { state: 'visible', timeout: 30000 });
+        await page.waitForTimeout(1000);
+
+        // 100k rows: the pin only has work to do when the thumb jump outruns the App Worker, and a
+        // small store lets the worker keep up, which would make every assertion below vacuously true.
+        await page.locator('.controls-container-button').click();
+        await page.waitForTimeout(500);
+
+        const rowsInput = page.locator('label:has-text("Amount Rows")').locator('..').locator('.neo-textfield-input').last();
+
+        await rowsInput.click({ force: true });
+        await page.locator('.neo-list-item:has-text("100000")').click({ force: true });
+        await page.waitForTimeout(5000);
+
+        await page.locator('.controls-container-button').click();
+        await page.waitForTimeout(500);
+    });
+
+    test('pinning survives a paused thumb drag', async ({ page }) => {
+        const geometry = await page.evaluate(() => {
+            const wrapper = document.querySelector('.neo-grid-view');
+            return {scrollHeight: wrapper.scrollHeight, clientHeight: wrapper.clientHeight}
+        });
+
+        // The pin only has work to do when a thumb jump outruns the worker, which needs a store far
+        // taller than the viewport. If the 100k-row setup silently failed, every assertion below
+        // would be measuring a grid that cannot lag.
+        expect(geometry.scrollHeight, `grid is deeply scrollable (${JSON.stringify(geometry)})`)
+            .toBeGreaterThan(geometry.clientHeight * 10);
+
+        // Record the pin offset on every animation frame. Sampling continuously rather than at the
+        // end is what makes a mid-pause drop observable: a single post-drag read cannot distinguish
+        // "pinning held throughout" from "pinning dropped and re-engaged on the next scroll event".
+        await page.evaluate(() => {
+            window.__PIN_SAMPLES = [];
+
+            const read = () => {
+                const body = document.querySelector('.neo-grid-body');
+
+                if (body) {
+                    const rows        = Array.from(document.querySelectorAll('.neo-grid-row')),
+                          wrapper     = document.querySelector('.neo-grid-view'),
+                          wrapperRect = wrapper.getBoundingClientRect();
+
+                    let painted = false;
+
+                    if (rows.length > 0) {
+                        const rowsTop    = Math.min(...rows.map(row => row.getBoundingClientRect().top)),
+                              rowsBottom = Math.max(...rows.map(row => row.getBoundingClientRect().bottom));
+
+                        painted = rowsBottom > wrapperRect.top && rowsTop < wrapperRect.bottom;
+                    }
+
+                    window.__PIN_SAMPLES.push({
+                        t        : performance.now(),
+                        offset   : body.style.getPropertyValue('--grid-row-pin-offset') || '',
+                        rowCount : rows.length,
+                        painted,
+                        scrollTop: wrapper.scrollTop
+                    })
+                }
+
+                window.__PIN_RAF = requestAnimationFrame(read)
+            };
+
+            read()
+        });
+
+        // Engage the drag the way the engine sees it. Chrome paints the scrollbar thumb in the
+        // compositor, so a synthetic CDP mouse press over it never hit-tests to a scroll — measured
+        // here as `scrollTop` stuck at 0 through a full press-and-drag. `GridRowScrollPinning` binds
+        // `mousedown` to the scrollbar NODE, so dispatching there sets `isThumbDragging` exactly as a
+        // real press does, and it makes the pause provably event-free rather than merely still.
+        await page.evaluate(() => {
+            const scrollbar = document.querySelector('.neo-grid-vertical-scrollbar'),
+                  box       = scrollbar.getBoundingClientRect();
+
+            scrollbar.dispatchEvent(new MouseEvent('mousedown', {
+                clientX: box.right - 5, clientY: box.top + 40, bubbles: true, cancelable: true
+            }))
+        });
+
+        // Mark the pause window so the samples inside it can be isolated from the drag around it.
+        const pauseStart = await page.evaluate(() => performance.now());
+
+        // Longer than any plausible inactivity timeout. The press is held and nothing moves: no
+        // scroll events, so no `applyPinning` re-entry can quietly repair dropped state.
+        await page.waitForTimeout(2500);
+
+        const pauseEnd = await page.evaluate(() => performance.now());
+
+        // The resumed drag. Each jump is far larger than the pooled rows can cover, so the worker is
+        // demonstrably behind and the pin has something to hold.
+        for (const _ of [0, 1]) {
+            await page.evaluate(() => {
+                const wrapper = document.querySelector('.neo-grid-view');
+                wrapper.scrollTop = wrapper.scrollTop + 60000
+            });
+            await page.waitForTimeout(200)
+        }
+
+        const afterDrag = await page.evaluate(() => {
+            cancelAnimationFrame(window.__PIN_RAF);
+            return {
+                samples  : window.__PIN_SAMPLES,
+                scrollTop: document.querySelector('.neo-grid-view').scrollTop
+            }
+        });
+
+        await page.evaluate(() => window.dispatchEvent(new MouseEvent('mouseup', {bubbles: true})));
+
+        const {samples}    = afterDrag,
+              parseOffset  = value => parseFloat(value) || 0,
+              pauseSamples = samples.filter(sample => sample.t >= pauseStart && sample.t <= pauseEnd),
+              postSamples  = samples.filter(sample => sample.t > pauseEnd);
+
+        // --- Positive controls. Without these the assertions below pass on a drag that never ran,
+        // --- which is how the pre-removal version of this spec could go green having observed nothing.
+        expect(samples.length,      'the frame sampler produced samples').toBeGreaterThan(10);
+        expect(pauseSamples.length, 'frames were observed DURING the pause').toBeGreaterThan(10);
+        expect(postSamples.length,  'frames were observed AFTER the pause').toBeGreaterThan(1);
+        expect(afterDrag.scrollTop, 'the post-pause drag actually scrolled the grid').toBeGreaterThan(0);
+
+        // The pause must really have been still — otherwise this is a moving-drag test wearing a
+        // pause's name, and it cannot speak to the property it claims to cover.
+        const pauseScrollTops = new Set(pauseSamples.map(sample => sample.scrollTop));
+        expect(pauseScrollTops.size, 'the grid did not scroll during the pause').toBe(1);
+
+        // --- The property. Pinning engages while the worker is behind, and the pause does not drop it.
+        const engagedAfterPause = postSamples.some(sample => Math.abs(parseOffset(sample.offset)) > 0);
+
+        expect(engagedAfterPause, 'pinning engaged on the drag that followed the pause').toBe(true);
+
+        // Rows stay painted across the pause and the drag that follows it. A dropped pin shows up
+        // here as pooled rows pushed clean out of the viewport while the worker catches up.
+        const blankFrames = [...pauseSamples, ...postSamples].filter(sample => !sample.painted);
+
+        expect(blankFrames.length, 'no frame blanked during or after the pause').toBe(0)
+    })
+});


### PR DESCRIPTION
Resolves #17430

#17421 took `apps/devindex` and its five e2e specs with it. Most of what those specs covered survives elsewhere — the ticket measured that rather than assuming it — but two properties genuinely left. This restores the first against a neo-owned fixture and records a decision on the second.

Evidence: L2 (the repo's own e2e harness against a real Chrome and a live dev server, plus a mutation control run on engine source) → L2 required (the surviving AC is a browser-observable engine property). No residuals.

## AC Evidence

| AC | Evidence |
|---|---|
| AC-1 | *A neo-fixture spec asserts pinning survives a paused thumb drag.* `test/playwright/e2e/grid/ThumbDragPause.spec.mjs` against `/examples/grid/bigData/index.html` at 100k rows: press held on the scrollbar, 2500ms with no events, then a resumed jump. Green in 11.1s. |
| AC-2 | *That spec fails when the pause handling is removed or short-circuited.* Ran the control: a `setTimeout` clearing `isThumbDragging`/`isPinningActive` 1500ms after `mousedown` — an inactivity timeout is exactly the absent thing that constitutes the pause handling. Spec went **red on the pinning assertion itself**, `Expected: true, Received: false` at `pinning engaged on the drag that followed the pause`. Mutation reverted; `src/main/addon/GridRowScrollPinning.mjs` is untouched in this diff. |
| AC-3 | *Either a grid scroll benchmark exists, or record the decision not to have one and say what covers scroll-cost regressions instead.* **Decision: no benchmark.** Reasoning and the covering surface below. |
| AC-4 | *If a benchmark lands, label its first run as a new series with its fixture named.* **N/A — no benchmark lands.** Conditional on AC-3's other branch. |

## The AC-3 decision, and why it is a decision rather than a deferral

A wall-clock grid benchmark here would be a number nobody can read. #17421 already recorded the reason: `GridProfile` and `GridScrollBenchmark` measured 50k rows × 37 columns, and the nearest neo-owned fixture is 20k × 50. A new series under that fixture cannot be compared against the pre-removal numbers, and the failure mode is not that the comparison is unavailable — it is that the comparison is *available and wrong*, because two series of milliseconds look comparable whether or not they are.

What covers scroll-cost regressions instead, today:

- **`grid/RowPinning.spec.mjs`** — per-frame telemetry over five scroll profiles including a native thumb drag and a compositor-saturation flood, asserting blank frames and jitter bounces are zero. That is the property a scroll benchmark exists to protect, asserted directly rather than inferred from a duration.
- **`grid/LockedCellHorizontalStability.spec.mjs`** and **`grid/ColumnOverdragScroll.spec.mjs`** — recycling and locked-region correctness under scroll.
- **this spec** — the pinned state across an event-free interval.

The gap that remains is genuinely a *cost* gap: nothing here would catch a change that keeps every frame correct while making each one twice as expensive. That is worth having eventually, and it wants a fixture decision plus a baseline series, which is a different piece of work from restoring a lost assertion. Recording it as an accepted absence rather than carrying it as a silent one.

## Deltas from ticket

- **The departed spec was itself vacuous, which the ticket did not know.** `ThumbDragPause.spec.mjs` asserted `expect(isBlank).toBe(false)` on a flag initialised to `false` and only ever set from inside a `scroll` listener. A run where the drag produced no scroll passed having observed nothing. AC-2's wording — "a moving-drag-only assertion must not be able to satisfy it" — turned out to understate the problem: the *old* assertion could be satisfied by no drag at all. Hence the four explicit positive controls before any property assertion.
- **A synthetic mouse press cannot drive this scrollbar, and that is measured, not assumed.** The first two runs failed on the new positive control with `scrollTop: 0` after a full press-and-drag. Diagnostics showed `.neo-grid-vertical-scrollbar` is a 16px native-overflow element (`scrollHeight` 640032 / `clientHeight` 1046), so Chrome paints the thumb in the compositor and a CDP press over it never hit-tests to a scroll. The spec therefore dispatches `mousedown` on the scrollbar node — the same route `RowPinning.spec.mjs`'s Profile 5 already uses, and the node `GridRowScrollPinning` actually binds. This is stricter than a real drag, not weaker: the pause becomes provably event-free rather than merely still.
- **The observable is a CSS custom property, not a screenshot.** `applyPinning` writes `--grid-row-pin-offset` onto the body nodes, so the assertion and the defect are the same quantity. A reintroduced timeout clears it to `0px`; there is no rendering judgement in the loop.
- **Sampling is per-animation-frame, continuous.** A single post-drag read cannot distinguish "pinning held throughout" from "pinning dropped mid-pause and re-engaged on the next scroll event" — and the second is the actual bug shape, since any scroll event re-enters `applyPinning` and repairs the state it should have kept.

## Test Evidence

- `npm run test-e2e -- e2e/grid/ThumbDragPause.spec.mjs` — **1 passed (13.9s)**, spec itself 11.1s.
- Mutation control, same command with the inactivity timeout patched into `GridRowScrollPinning.onMouseDown` — **1 failed**, on `pinning engaged on the drag that followed the pause`. Red for the intended reason rather than an incidental one.
- `npm run test-e2e -- e2e/grid/RowPinning.spec.mjs` — **1 passed (53.4s)**, run as a harness control before authoring so a red on the new spec could not be blamed on the environment.

## Post-Merge Validation

None — the spec runs in the same e2e harness CI runs.

## Evolution

Two corrections, both caught by the spec's own positive controls rather than by review. The first press-and-drag targeted `box.x + box.width - 5` on the grid view, copied from `RowPinning`'s Profile 4; it scrolled nothing. The second targeted the scrollbar's own bounding box and also scrolled nothing — at which point the controls had falsified my mechanism twice, and the honest move was a throwaway diagnostic spec that dumped the geometry instead of a third guess. That is what showed the native-overflow shape. Worth stating plainly: had I written the assertions without the `scrollTop > 0` control, both of those runs would have reported green, and I would have shipped a spec that presses a scrollbar and measures nothing — the precise defect this PR exists to remove.

Authored by Grace (Claude Opus 5, Claude Code). Session 8daa7672-824e-4d4a-9283-8a0b908180c8.
