### PR TITLE
feat(ai): make merge-readiness self-falsifying (#17373)

### DIFF
--- a/.agents/skills/pr-review/references/pr-review-guide.md
+++ b/.agents/skills/pr-review/references/pr-review-guide.md
@@ -343,9 +343,11 @@ Before `manage_pr_review`, review relay, merge claim, or PR lane-state, re-run
 PR-scoped mailbox + live `state,mergedAt,reviewRequests`; wakes are not cache and
 acceptance can be A2A-only. Authority moved → hand off. Relay §9, not flattened
 `reviewDecision`; every requested seat must be disposed. Canonical
-`[merge-eligible]` requires the current positive B-prime observation marker;
-otherwise use `[merge-readiness-uncertified][no-positive-observation]`, or
-`[merge-readiness-uncertified][issuer-unavailable:cloud-mode]` in cloud.
+`[merge-eligible]` requires the current positive B-prime marker and zero joined
+predicate blockers; `NON_REQUIRED_CHECK_FAILING` means the required subset passed
+while another emitted check failed. Certification absence is instrument truth, not
+an artifact blocker: use `[merge-readiness-uncertified][no-positive-observation]`,
+or `[merge-readiness-uncertified][issuer-unavailable:cloud-mode]` in cloud.
 
 ## 11. Post-Review-Cycle Reviewer Pickup
 

--- a/ai/scripts/lifecycle/validateMergeReady.mjs
+++ b/ai/scripts/lifecycle/validateMergeReady.mjs
@@ -40,11 +40,14 @@ export const MERGEABLE_STATES = ['CLEAN', 'UNSTABLE'];
  *     withdraw at T1 by posting `[MERGE_HOLD]`; `reviewDecision` is a flattened snapshot with no
  *     notion of supersession and still reads APPROVED. This is rule 5's mirror — there a PENDING
  *     obligation was invisible, here a RETRACTED approval is.
+ *  8. `nonRequiredFailures` is fetched AND empty. Branch rules define the required subset, not the
+ *     complete safety set: a failing emitted check outside that subset is still a current-head failure
+ *     and must be named by the joined merge predicate rather than left for callers to rediscover.
  *
- * Fail-CLOSED contract: `state`, `mergedAt`, `checksGreen`, `mergeStateStatus`, and `reviewRequests`
- * that were NOT fetched (`undefined`) each block readiness — an un-queried field cannot certify a
- * green surface, and an omitted `reviewRequests` must never be read as "no outstanding reviewers".
- * Pass `mergedAt: null` and `reviewRequests: []` to assert fetched-and-empty values.
+ * Fail-CLOSED contract: `state`, `mergedAt`, `checksGreen`, `mergeStateStatus`, `reviewRequests`,
+ * and `nonRequiredFailures` that were NOT fetched (`undefined`) each block readiness — an un-queried
+ * field cannot certify a green surface. Pass `mergedAt: null`, `reviewRequests: []`, and
+ * `nonRequiredFailures: []` to assert fetched-and-empty values.
  *
  * @param {Object} [pr={}]
  * @param {String} [pr.state] GitHub PR state; only fetched `OPEN` passes.
@@ -58,6 +61,9 @@ export const MERGEABLE_STATES = ['CLEAN', 'UNSTABLE'];
  * @param {Object} [pr.crossFamilyVerdict] Verdict from `resolveCrossFamilyVerdict` — `{crossFamily, authorFamily, approvingFamilies, authorLogin}`. `undefined` (not resolved) fails closed; `crossFamily: null` (author family unresolved) blocks with its own reason rather than collapsing into pass or fail.
  * @param {String} [pr.approvedAtOid] Commit oid the approving review was submitted against. Optional: absent means the anchor is not reported, never that it is fresh.
  * @param {String} [pr.headRefOid] Current head oid, paired with `approvedAtOid` to surface a stale approval anchor.
+ * @param {String[]} [pr.nonRequiredFailures] Stable labels for failing emitted checks outside the
+ * required set. `undefined` means the population was not resolved and fails closed; `[]` asserts a
+ * fetched population with no failures.
  * @returns {{strictMergeReady: Boolean, blockers: String[], advisories: String[]}}
  */
 export function validateMergeReady(pr = {}) {
@@ -71,6 +77,7 @@ export function validateMergeReady(pr = {}) {
         disposedReviewers = [],
         approvedAtOid,
         headRefOid,
+        nonRequiredFailures,
         crossFamilyVerdict,
         holdVerdict
     } = pr;
@@ -160,6 +167,17 @@ export function validateMergeReady(pr = {}) {
         blockers.push(checksGreen === undefined
             ? 'checksGreen was not fetched — cannot certify CI; failing closed.'
             : 'not all required CI checks are green.');
+    }
+
+    if (nonRequiredFailures === undefined) {
+        blockers.push('nonRequiredFailures was not resolved — cannot certify the emitted non-required check population; failing closed.');
+    } else if (!Array.isArray(nonRequiredFailures)) {
+        blockers.push('nonRequiredFailures is malformed — expected a fetched array of failing emitted-check labels; failing closed.');
+    } else if (nonRequiredFailures.some(label => typeof label !== 'string' || !label.trim())) {
+        blockers.push('nonRequiredFailures contains an unreadable label — cannot name every failing emitted check; failing closed.');
+    } else {
+        [...new Set(nonRequiredFailures.map(label => label.trim()))]
+            .forEach(label => blockers.push(`non-required check '${label}' is failing.`));
     }
 
     if (mergeStateStatus === undefined) {

--- a/ai/services/github-workflow/PullRequestService.mjs
+++ b/ai/services/github-workflow/PullRequestService.mjs
@@ -746,6 +746,18 @@ function compareRequiredAndEmittedContexts(requiredContexts, emittedContexts) {
     return {requiredStates, emittedOnly};
 }
 
+/**
+ * @summary Names one emitted check strongly enough to distinguish generic job names across workflows.
+ * @param {Object} context Normalized emitted context.
+ * @returns {String}
+ */
+function getEmittedContextLabel(context) {
+    const name  = context?.name || 'unnamed-check',
+          owner = context?.workflow?.name || context?.integration;
+
+    return owner && owner !== name ? `${name} [${owner}]` : name;
+}
+
 function normalizeBoundPrincipals(identityAssertion) {
     const principals = identityAssertion?.principals || {};
 
@@ -916,6 +928,11 @@ async function buildMergeReadinessProjection({
     const checksVerdict = checkSourceReady
         ? selectedChecksGreen ? 'green' : 'not-green'
         : 'unknown';
+    const nonRequiredFailures = checkSourceReady
+        ? comparison.emittedOnly
+            .filter(item => item.state === 'failing')
+            .map(getEmittedContextLabel)
+        : undefined;
     const reviewRequests = reviewSourceReady
         ? snapshot.reviewRequests.nodes.map(item => item.login)
         : undefined;
@@ -1000,10 +1017,32 @@ async function buildMergeReadinessProjection({
         crossFamilyVerdict,
         holdVerdict,
         approvedAtOid,
-        headRefOid      : snapshot.headRefOid
+        headRefOid      : snapshot.headRefOid,
+        nonRequiredFailures
     });
     const sourceMergeReady    = predicate.strictMergeReady && sourceBlockers.length === 0;
     const certifiedMergeReady = sourceMergeReady && identityBindingComplete;
+    const certification       = identityBindingComplete
+        ? {
+            outcome          : sourceMergeReady ? 'issued' : 'withheld-artifact-not-ready',
+            code             : null,
+            missingPrincipals: [],
+            affects          : ['b-prime-certification']
+        }
+        : {
+            outcome          : 'unbound-certification-withheld',
+            code             : 'IDENTITY_BINDING_MISSING',
+            missingPrincipals: ['memoryCoreIdentity'],
+            affects          : ['b-prime-certification']
+        };
+    // GitHub gives a formal review's commit, but not the commit whose CHECKS the reviewer observed.
+    // Reporting the first beside an explicit "not observable" for the second prevents a re-anchored
+    // verdict from posing as re-verified evidence.
+    const approvalAnchors = {
+        verdictCommitOid       : approvedAtOid ?? null,
+        checksEvidenceCommitOid: null,
+        checksEvidenceStatus   : 'not-observable-from-review-source'
+    };
     const requiredSet         = {
         source  : `GET ${rulesPath}`,
         digest  : digestValue(requiredContexts),
@@ -1025,6 +1064,7 @@ async function buildMergeReadinessProjection({
         },
         requiredSet,
         contextStates: comparison.requiredStates,
+        approvalAnchors,
         predicate
     };
     const observationId = digestValue(observationCore);
@@ -1039,32 +1079,22 @@ async function buildMergeReadinessProjection({
         emittedOnly     : comparison.emittedOnly,
         checksGreen,
         checksVerdict,
-        verdict         : identityBindingComplete
-            ? sourceMergeReady ? 'merge-ready-observed' : 'not-merge-ready'
-            : 'unavailable',
-        statement       : !identityBindingComplete
-            ? `Observed GitHub checks verdict '${checksVerdict}' at ${observedAt} for ${owner}/${repo}#${prNumber} head ${snapshot.headRefOid}; B-prime certification is unavailable because Memory Core identity is unbound.`
-            : certifiedMergeReady
-                // An advisory rides INSIDE the merge-ready sentence rather than after it. It fires
-                // only when everything else is green — exactly when nothing draws the eye — and the
-                // merge-ready statement travels beside `[merge-eligible]` to the human gate. A
-                // sentence that says "strict merge-ready" and stops is, at a stale anchor, true and
-                // misleading in the same breath.
-                // The plural agrees rather than hedging with a slash: this sentence is the whole
-                // deliverable — it travels beside `[merge-eligible]` to the human gate — so it is
-                // the one string where wording carries weight, and `1 advisory/advisories require`
-                // reads as generated text a reader discounts.
-                ? `Observed strict merge-ready at ${observedAt} for ${owner}/${repo}#${prNumber} head ${snapshot.headRefOid}.${predicate.advisories.length > 0 ? ` ${predicate.advisories.length} ${predicate.advisories.length === 1 ? 'advisory requires' : 'advisories require'} a reader judgement before merge — see 'advisories'.` : ''}`
-                : `Did not observe strict merge-readiness at ${observedAt} for ${owner}/${repo}#${prNumber} head ${snapshot.headRefOid}.`,
+        verdict         : sourceMergeReady ? 'merge-ready-observed' : 'not-merge-ready',
+        certification,
+        // Artifact truth leads; instrument truth follows as an independent clause. An unbound
+        // certifier is equally unbound on a perfect and a broken PR, so it cannot rewrite the
+        // artifact verdict or enter the blocker set.
+        statement       : sourceMergeReady
+            ? `Observed strict merge-ready at ${observedAt} for ${owner}/${repo}#${prNumber} head ${snapshot.headRefOid}.${predicate.advisories.length > 0 ? ` ${predicate.advisories.length} ${predicate.advisories.length === 1 ? 'advisory requires' : 'advisories require'} a reader judgement before merge — see 'advisories'.` : ''}${!identityBindingComplete ? ' B-prime certification is unavailable because Memory Core identity is unbound; this does not change merge eligibility.' : ''}`
+            : `Did not observe strict merge-readiness at ${observedAt} for ${owner}/${repo}#${prNumber} head ${snapshot.headRefOid}.`,
         blockers: [
-            ...(!identityBindingComplete ? [{
-                code             : 'IDENTITY_BINDING_MISSING',
-                message          : 'Memory Core identity is unbound; GitHub checks remain readable but B-prime certification is unavailable.',
-                missingPrincipals: ['memoryCoreIdentity'],
-                affects          : ['b-prime-certification']
-            }] : []),
             ...sourceBlockers,
-            ...predicate.blockers.map(message => ({code: 'STRICT_MERGE_READINESS', message}))
+            ...predicate.blockers.map(message => ({
+                code: message.startsWith('non-required check ')
+                    ? 'NON_REQUIRED_CHECK_FAILING'
+                    : 'STRICT_MERGE_READINESS',
+                message
+            }))
         ],
         // Lifted to top level and coded, in the same shape as `blockers`, and the symmetry is the
         // point rather than tidiness. A blocker is discoverable three other ways — it flips

--- a/test/playwright/unit/ai/scripts/lifecycle/validateMergeReady.spec.mjs
+++ b/test/playwright/unit/ai/scripts/lifecycle/validateMergeReady.spec.mjs
@@ -15,10 +15,11 @@ test.describe('validateMergeReady — strict merge-readiness contract', () => {
     // The gate itself is fail-closed on an unresolved verdict, which its own arms assert explicitly
     // rather than relying on this builder's silence.
     const openSource = overrides => ({
-        state             : 'OPEN',
-        mergedAt          : null,
-        crossFamilyVerdict: {crossFamily: true, authorFamily: 'claude', approvingFamilies: ['gpt'], authorLogin: 'neo-opus-grace'},
-        holdVerdict       : {held: false, holders: []},
+        state              : 'OPEN',
+        mergedAt           : null,
+        crossFamilyVerdict : {crossFamily: true, authorFamily: 'claude', approvingFamilies: ['gpt'], authorLogin: 'neo-opus-grace'},
+        holdVerdict        : {held: false, holders: []},
+        nonRequiredFailures: [],
         ...overrides
     });
 
@@ -63,6 +64,58 @@ test.describe('validateMergeReady — strict merge-readiness contract', () => {
         }));
         expect(result.strictMergeReady).toBe(false);
         expect(result.blockers.join(' ')).toContain('CI checks');
+    });
+
+    test('a failing non-required check blocks and names every failing context', () => {
+        const result = validateMergeReady(openSource({
+            reviewDecision     : 'APPROVED',
+            checksGreen        : true,
+            mergeStateStatus   : 'CLEAN',
+            reviewRequests     : [],
+            nonRequiredFailures: ['lint-pr-body [Agent PR Body Lint]', 'CodeQL']
+        }));
+
+        expect(result.strictMergeReady).toBe(false);
+        expect(result.blockers).toContain("non-required check 'lint-pr-body [Agent PR Body Lint]' is failing.");
+        expect(result.blockers).toContain("non-required check 'CodeQL' is failing.");
+    });
+
+    test('a fetched empty non-required failure set leaves the all-green control unchanged', () => {
+        const result = validateMergeReady(openSource({
+            reviewDecision     : 'APPROVED',
+            checksGreen        : true,
+            mergeStateStatus   : 'CLEAN',
+            reviewRequests     : [],
+            nonRequiredFailures: []
+        }));
+
+        expect(result).toMatchObject({strictMergeReady: true, blockers: []});
+    });
+
+    test('an unresolved non-required failure population fails closed', () => {
+        const result = validateMergeReady(openSource({
+            reviewDecision     : 'APPROVED',
+            checksGreen        : true,
+            mergeStateStatus   : 'CLEAN',
+            reviewRequests     : [],
+            nonRequiredFailures: undefined
+        }));
+
+        expect(result.strictMergeReady).toBe(false);
+        expect(result.blockers.join(' ')).toContain('nonRequiredFailures was not resolved');
+    });
+
+    test('a malformed non-required failure label cannot disappear into a green result', () => {
+        const result = validateMergeReady(openSource({
+            reviewDecision     : 'APPROVED',
+            checksGreen        : true,
+            mergeStateStatus   : 'CLEAN',
+            reviewRequests     : [],
+            nonRequiredFailures: [null]
+        }));
+
+        expect(result.strictMergeReady).toBe(false);
+        expect(result.blockers.join(' ')).toContain('unreadable label');
     });
 
     test('a DIRTY merge state (conflict / stale base) blocks', () => {
@@ -149,10 +202,11 @@ test.describe('validateMergeReady — the approval anchor', () => {
     // The gate itself is fail-closed on an unresolved verdict, which its own arms assert explicitly
     // rather than relying on this builder's silence.
     const openSource = overrides => ({
-        state             : 'OPEN',
-        mergedAt          : null,
-        crossFamilyVerdict: {crossFamily: true, authorFamily: 'claude', approvingFamilies: ['gpt'], authorLogin: 'neo-opus-grace'},
-        holdVerdict       : {held: false, holders: []},
+        state              : 'OPEN',
+        mergedAt           : null,
+        crossFamilyVerdict : {crossFamily: true, authorFamily: 'claude', approvingFamilies: ['gpt'], authorLogin: 'neo-opus-grace'},
+        holdVerdict        : {held: false, holders: []},
+        nonRequiredFailures: [],
         ...overrides
     });
 
@@ -238,13 +292,14 @@ test.describe('validateMergeReady — the cross-family mandate', () => {
     // Deliberately NOT the shared `openSource` builder: these arms are about the verdict field, so
     // inheriting a healthy default would be the one thing that makes them vacuous.
     const green = overrides => ({
-        state           : 'OPEN',
-        mergedAt        : null,
-        reviewDecision  : 'APPROVED',
-        checksGreen     : true,
-        mergeStateStatus: 'CLEAN',
-        reviewRequests  : [],
-        holdVerdict     : {held: false, holders: []},
+        state              : 'OPEN',
+        mergedAt           : null,
+        reviewDecision     : 'APPROVED',
+        checksGreen        : true,
+        mergeStateStatus   : 'CLEAN',
+        reviewRequests     : [],
+        holdVerdict        : {held: false, holders: []},
+        nonRequiredFailures: [],
         ...overrides
     });
 
@@ -307,13 +362,14 @@ test.describe('validateMergeReady — the reviewer-hold gate', () => {
     // Not the shared builder: these arms are about the hold field, so inheriting a healthy default
     // is the one thing that would make them vacuous.
     const green = overrides => ({
-        state             : 'OPEN',
-        mergedAt          : null,
-        reviewDecision    : 'APPROVED',
-        checksGreen       : true,
-        mergeStateStatus  : 'CLEAN',
-        reviewRequests    : [],
-        crossFamilyVerdict: {crossFamily: true, authorFamily: 'claude', approvingFamilies: ['gpt']},
+        state              : 'OPEN',
+        mergedAt           : null,
+        reviewDecision     : 'APPROVED',
+        checksGreen        : true,
+        mergeStateStatus   : 'CLEAN',
+        reviewRequests     : [],
+        crossFamilyVerdict : {crossFamily: true, authorFamily: 'claude', approvingFamilies: ['gpt']},
+        nonRequiredFailures: [],
         ...overrides
     });
 

--- a/test/playwright/unit/ai/services/github-workflow/PullRequestService.spec.mjs
+++ b/test/playwright/unit/ai/services/github-workflow/PullRequestService.spec.mjs
@@ -576,6 +576,12 @@ test.describe('Neo.ai.services.github-workflow.PullRequestService — merge-read
         expect(result.principals).toEqual(PRINCIPALS);
         expect(result.checksVerdict).toBe('green');
         expect(result.predicate.strictMergeReady).toBe(true);
+        expect(result.certification).toEqual({
+            outcome          : 'issued',
+            code             : null,
+            missingPrincipals: [],
+            affects          : ['b-prime-certification']
+        });
         expect(Object.isFrozen(result)).toBe(true);
         expect(Object.isFrozen(result.requiredSet.contexts)).toBe(true);
         expect(deps.calls()).toEqual({queryCall: 2, restCall: 2});
@@ -590,6 +596,11 @@ test.describe('Neo.ai.services.github-workflow.PullRequestService — merge-read
 
         expect(result.verdict).toBe('merge-ready-observed');
         expect(result.predicate.advisories).toEqual([]);
+        expect(result.approvalAnchors).toEqual({
+            verdictCommitOid       : HEAD,
+            checksEvidenceCommitOid: null,
+            checksEvidenceStatus   : 'not-observable-from-review-source'
+        });
     });
 
     test('#17339: an approval earned on a superseded commit is reported without blocking readiness', async () => {
@@ -612,6 +623,11 @@ test.describe('Neo.ai.services.github-workflow.PullRequestService — merge-read
         expect(result.predicate.advisories).toHaveLength(1);
         expect(result.predicate.advisories[0]).toContain(HEAD);
         expect(result.predicate.advisories[0]).toContain(NEXT_HEAD);
+        expect(result.approvalAnchors).toEqual({
+            verdictCommitOid       : HEAD,
+            checksEvidenceCommitOid: null,
+            checksEvidenceStatus   : 'not-observable-from-review-source'
+        });
 
         // …and it REACHES the surface that travels to the merge gate. Nested inside `predicate` the
         // advisory fires only on an otherwise-green observation, so it competes with nothing and is
@@ -657,6 +673,7 @@ test.describe('Neo.ai.services.github-workflow.PullRequestService — merge-read
         // and a later COMMENTED/CHANGES_REQUESTED review does not become the anchor: only an
         // APPROVED review earns one.
         expect(result.predicate.advisories).toEqual([]);
+        expect(result.approvalAnchors.verdictCommitOid).toBe(HEAD);
     });
 
     test('#17339: an unfetched review connection yields silence, never a fresh-anchor claim', async () => {
@@ -667,6 +684,11 @@ test.describe('Neo.ai.services.github-workflow.PullRequestService — merge-read
         // for it is not making a weaker claim, and what must NOT happen is an advisory asserting
         // freshness it never observed.
         expect(result.predicate.advisories).toEqual([]);
+        expect(result.approvalAnchors).toEqual({
+            verdictCommitOid       : null,
+            checksEvidenceCommitOid: null,
+            checksEvidenceStatus   : 'not-observable-from-review-source'
+        });
 
         // The verdict, however, DID move with the §6.1 rule, and the two facts sit either side of
         // this module's fail-closed line. The same unfetched connection that leaves the anchor
@@ -806,37 +828,48 @@ test.describe('Neo.ai.services.github-workflow.PullRequestService — merge-read
         }
     });
 
-    test('#16902: returns a checks verdict but withholds B-prime when Memory Core identity is unbound', async () => {
+    test('#17373: certification availability stays named but cannot change artifact merge eligibility', async () => {
         const identityAssertion = {
             ok        : true,
             code      : 'OK',
             reason    : null,
             principals: {...PRINCIPALS, memoryCoreIdentity: null}
         };
-        const deps   = dependencies();
-        const result = await PullRequestService.getConversation({
+        const boundDeps   = dependencies();
+        const unboundDeps = dependencies();
+        const bound       = await project(boundDeps);
+        const unbound     = await PullRequestService.getConversation({
             pr_number : 16029,
             projection: 'merge-readiness',
             identityAssertion
-        }, deps);
+        }, unboundDeps);
 
-        expect(result.verdict).toBe('unavailable');
-        expect(result.checksVerdict).toBe('green');
-        expect(result.checksGreen).toBe(true);
-        expect(result.predicate.strictMergeReady).toBe(true);
-        expect(result.identityBinding).toEqual({complete: false, missing: ['memoryCoreIdentity']});
-        expect(result.principals.memoryCoreIdentity).toBeNull();
-        expect(result.blockers).toContainEqual(expect.objectContaining({
+        // Same PR, opposite instrument availability: artifact verdict and blockers are byte-identical.
+        expect(JSON.stringify(unbound.predicate)).toBe(JSON.stringify(bound.predicate));
+        expect(JSON.stringify(unbound.blockers)).toBe(JSON.stringify(bound.blockers));
+        expect(unbound.verdict).toBe('merge-ready-observed');
+        expect(unbound.verdict).toBe(bound.verdict);
+        expect(unbound.checksVerdict).toBe('green');
+        expect(unbound.checksGreen).toBe(true);
+        expect(unbound.identityBinding).toEqual({complete: false, missing: ['memoryCoreIdentity']});
+        expect(unbound.principals.memoryCoreIdentity).toBeNull();
+        expect(unbound.certification).toEqual({
+            outcome          : 'unbound-certification-withheld',
             code             : 'IDENTITY_BINDING_MISSING',
             missingPrincipals: ['memoryCoreIdentity'],
             affects          : ['b-prime-certification']
-        }));
-        expect(result.marker).toBeUndefined();
-        expect(result.audit).toContainEqual({
+        });
+        expect(unbound.statement).toContain('Observed strict merge-ready');
+        expect(unbound.statement).toContain('does not change merge eligibility');
+        expect(bound.certification.outcome).toBe('issued');
+        expect(unbound.marker).toBeUndefined();
+        expect(bound.marker).toMatch(/^\[merge-eligible]/);
+        expect(unbound.audit).toContainEqual({
             source : 'memory-core-identity',
             outcome: 'unbound-certification-withheld'
         });
-        expect(deps.calls()).toEqual({queryCall: 2, restCall: 2});
+        expect(boundDeps.calls()).toEqual({queryCall: 2, restCall: 2});
+        expect(unboundDeps.calls()).toEqual({queryCall: 2, restCall: 2});
     });
 
     test('#16902: latest workflow invocation supersedes an earlier failure on the same exact head', async () => {
@@ -878,7 +911,7 @@ test.describe('Neo.ai.services.github-workflow.PullRequestService — merge-read
         expect(result.emittedContexts[0].workflow.runNumber).toBe(10);
     });
 
-    test('#16902: an optional latest failure makes the checks verdict non-green without changing B-prime', async () => {
+    test('#17373: an optional latest failure blocks the joined predicate and names its workflow', async () => {
         const optionalWorkflow = workflowFixture({
             id          : 288951422,
             name        : 'Agent PR Body Lint',
@@ -895,12 +928,17 @@ test.describe('Neo.ai.services.github-workflow.PullRequestService — merge-read
         }));
 
         expect(result.checksGreen).toBe(true);
-        expect(result.predicate.strictMergeReady).toBe(true);
-        expect(result.verdict).toBe('merge-ready-observed');
+        expect(result.predicate.strictMergeReady).toBe(false);
+        expect(result.verdict).toBe('not-merge-ready');
         expect(result.emittedOnly).toEqual([
             expect.objectContaining({name: 'lint-pr-body', state: 'failing'})
         ]);
         expect(result.checksVerdict).toBe('not-green');
+        expect(result.certification.outcome).toBe('withheld-artifact-not-ready');
+        expect(result.blockers).toContainEqual({
+            code   : 'NON_REQUIRED_CHECK_FAILING',
+            message: "non-required check 'lint-pr-body [Agent PR Body Lint]' is failing."
+        });
     });
 
     test('#16902: a newer attempt of one workflow run supersedes its earlier attempt', async () => {


### PR DESCRIPTION
Resolves #17373

The merge-readiness projection now answers the artifact question once. A failing emitted check outside the branch-required subset enters the joined predicate as `NON_REQUIRED_CHECK_FAILING`; certification availability remains a separate, named statement about the instrument and never rewrites artifact eligibility. The approval verdict commit is exposed beside an explicit declaration that the review source cannot report which head's checks the reviewer observed.

Evidence: L2 (source-owned double-read projection + pure predicate + mutation-separated unit corpus) → L2 required (the close-target changes an MCP-consumed merge-readiness contract, but every branch is deterministic and source-observable). No residuals.

## AC Evidence

| AC-1 | `comparison.emittedOnly` is reduced to stable labels for failing non-required contexts; each becomes a named predicate blocker and top-level `NON_REQUIRED_CHECK_FAILING`. |
| AC-2 | Mutation A removes that producer arm: the specimen-1 projection fails while the otherwise-identical all-green control passes. |
| AC-3 | A fetched empty non-required-failure set leaves `strictMergeReady: true` and `blockers: []`; missing/malformed populations fail closed. |
| AC-4 | `approvalAnchors` reports `verdictCommitOid` and explicitly states `checksEvidenceStatus: not-observable-from-review-source` with a null evidence commit. |
| AC-5 | `pr-review-guide.md` §10.1 points reviewers at `NON_REQUIRED_CHECK_FAILING` and distinguishes artifact blockers from certification state. |
| AC-6 | Bound and unbound identity arms assert byte-identical `predicate`, `blockers`, and artifact `verdict`; only `certification`, statement, audit, and marker differ. |
| AC-7 | Unavailable certification remains explicit as `certification.outcome = unbound-certification-withheld`, `IDENTITY_BINDING_MISSING`, and `affects: ['b-prime-certification']`. |
| AC-8 | Mutation B erases the certification record and fails AC-7 without touching the predicate. Mirror Mutation C makes unbound certification block: the unchanged AC-7 `certification.toEqual` assertion passes first, then AC-6's predicate byte-identity assertion fails on `strictMergeReady: false` plus the injected blocker. |

## Deltas from ticket

GitHub exposes the commit attached to a submitted review, but not the commit whose checks that reviewer actually examined. The checks-evidence anchor therefore ships as an explicit non-observation rather than a fabricated head.

The top-level `verdict` now reports artifact eligibility under both bound and unbound Memory Core identity. The canonical `[merge-eligible][B-prime:…]` marker remains certification-gated, so an unbound instrument can describe a merge-ready artifact without minting a certificate it cannot issue.

## Test Evidence

- Mutation A: drop the non-required-failure producer → specimen fails, all-green control passes.
- Mutation B: erase unbound certification → certification arm fails, artifact-failure control passes.
- Mutation C: make unbound certification block → the unchanged certification-object assertion passes, then predicate byte identity fails on the injected blocker.
- Local full-unit sweep: 15,277 passed; 25 unrelated failures are confined to the user-owned untracked `ai/deploy/.neo-ai-data` backup corpus and live-host process/deployment fixtures. Hosted clean-checkout CI remains the merge gate.

## Turn-Memory Load-Effect Audit

- **Placement:** `pr-review-guide.md` is the existing conditional payload loaded only when `pr-review` fires. Codex's per-prompt hook loads `.codex/CODEX.md`, not this guide; Claude's per-skill symlink resolves to the same canonical payload.
- **Map vs Atlas:** no `SKILL.md` router, manifest, global-turn file, or new reference is added. One compact clause extends existing §10.1, the exact review-state freshness owner.
- **Disposition:** `rewrite` / `DISCIPLINE-ONLY`. Trigger frequency is PR-state relay/merge-readiness only; failure severity is high; enforcement remains executable in `PullRequestService` and `validateMergeReady`, while the guide tells reviewers which field to trust.
- **Budget:** `pr-review-guide.md` moves from 33,455 to 33,634 bytes (+179), below its 33,700-byte per-file budget; router and manifest bytes are unchanged.
- **Decay:** no duplicated mechanics or schema are added. If the projection field retires, the single §10.1 name is the only skill-side reference to remove.

## Post-Merge Validation

None — source snapshots, identity pairs, evidence-anchor absence, and both mutation diagonals are deterministic and CI-observable.

Authored by Emmy (GPT-5.6 Sol Ultra, Codex). Session 4ea23778-dd28-418b-be42-da7ea6ed2359.
