### PR TITLE
fix(orchestrator): reconcile the backup receipt against its retry ledger (#17785)

### DIFF
--- a/ai/daemons/orchestrator/scheduling/backup.mjs
+++ b/ai/daemons/orchestrator/scheduling/backup.mjs
@@ -289,8 +289,11 @@ export function describeBackupRetryState({
  * reads as a finding and gets acted on. An absent or self-contradicting observation admits exactly
  * one honest answer, so both directions are bound here: **it resolves to unknown or to an explicit
  * conflict — never `healthy`, and never an invented negative.** A verdict may not assert a definite
- * negative that newer evidence in its own snapshot contradicts; where the receipt and the retry
- * ledger disagree, the disagreement is itself the finding.
+ * negative that evidence in its own snapshot contradicts; where the receipt and the retry ledger
+ * disagree, the disagreement is itself the finding. Scope is what makes that checkable: a code
+ * claiming the lane NEVER succeeded is falsified by any success receipt at all, while a code
+ * claiming the current recovery window is spent is not — so the two must never be traded for each
+ * other on the strength of a timestamp comparison.
  * ticket-ref-ok: #17338 authored the asymmetric half of this contract; naming it is how a future
  * editor knows the one-directional wording was tried and superseded rather than simply forgotten.
  *
@@ -320,12 +323,12 @@ export function describeBackupMaintenanceHealth({
             ? backupIntervalMs + Math.max(0, retryWindowMs)
             : null,
         // The receipt and the retry ledger are two records of the same lane, and only the receipt is
-        // written by the lane itself. A success receipt stamped AFTER the streak anchor is therefore
-        // proof the streak is stale, not proof the lane is broken — see the reconciliation note below.
-        receiptSuccessAtMs = lastBackup?.backup?.status === 'success' ? toEpochMs(lastBackup.finishedAt) : 0,
-        streakContradicted = receiptSuccessAtMs > 0
-            && retryState?.streakStartedAtMs > 0
-            && receiptSuccessAtMs > retryState.streakStartedAtMs;
+        // written by the lane itself. `lastSuccessAt` is written exclusively by the task-state success
+        // path and is never cleared by a failure — `markFailed()` advances the streak and leaves it
+        // standing — so a success receipt beside `lastSuccessAt: null` means the two records disagree
+        // about whether this lane EVER succeeded. Deliberately not a recency test: the receipt's age
+        // decides nothing here, because the claim being guarded is about the lane's whole history.
+        receiptProvesSuccess = lastBackup?.backup?.status === 'success';
 
     if (durability.posture === 'unmet') {
         reasonCodes.push('off-host-durability-unmet')
@@ -349,11 +352,18 @@ export function describeBackupMaintenanceHealth({
     // `backup-never-succeeded` is a DEFINITE NEGATIVE — it asserts a fact about the whole history of
     // the lane, from one derived ledger. When this snapshot also carries a success receipt stamped
     // after the streak anchor, the two disagree and the receipt is the owner's record: it is written
-    // by the lane, whereas `failureStreakStartedAt` is only closed by `TaskStateService.markCompleted()`
-    // on the task-state path. Emitting the negative there would fabricate a claim the snapshot's own
-    // newer evidence contradicts, so the disagreement is reported AS a disagreement instead.
-    // `backup-state-conflict` keeps the block `degraded` — the divergence is a defect in its own
-    // right and must stay visible; it simply stops the verdict inventing which side is true.
+    // by the lane, whereas `lastSuccessAt` is written only by the task-state success path. Emitting
+    // the negative there would fabricate a claim the snapshot's own evidence contradicts, so the
+    // disagreement is reported AS a disagreement instead. `backup-state-conflict` keeps the block
+    // `degraded` — the divergence is a defect in its own right and must stay visible; it simply
+    // stops the verdict inventing which side is true.
+    //
+    // The receipt's AGE is not part of this test, and that is load-bearing rather than a shortcut.
+    // `backup-never-succeeded` claims the lane never succeeded at all, so ANY success receipt
+    // falsifies it — a receipt predating the current streak still proves a success happened. The
+    // narrower "the current recovery window is spent" claim is already carried by
+    // `backup-retry-exhausted`, which stays put; conflating the two is how a true statement about
+    // this streak gets published as a false statement about the lane's history.
     //
     // THE CO-DEFECT this branch reports, and how it gets retired. `TaskStateService.markCompleted()`
     // writes `lastSuccessAt` AND clears `failureStreakStartedAt` in one call, so a lane completing
@@ -365,7 +375,7 @@ export function describeBackupMaintenanceHealth({
     // healthcheck is the trigger; fix the writer then, and this branch becomes dead code the moment
     // the ledger stops disagreeing with the receipt.
     if (retryState && retryState.phase !== BACKUP_RETRY_PHASE.unanchored && !retryState.lastSuccessAt) {
-        reasonCodes.push(streakContradicted ? 'backup-state-conflict' : 'backup-never-succeeded')
+        reasonCodes.push(receiptProvesSuccess ? 'backup-state-conflict' : 'backup-never-succeeded')
     }
     if (staleAfterMs !== null && retryState?.lastSuccessAgeMs > staleAfterMs) {
         reasonCodes.push('backup-success-overdue')

--- a/ai/daemons/orchestrator/scheduling/backup.mjs
+++ b/ai/daemons/orchestrator/scheduling/backup.mjs
@@ -282,6 +282,18 @@ export function describeBackupRetryState({
  * through `?.`, so an absent observation scored as a clean one and the verdict said `healthy` with
  * an empty `reasonCodes` on a plane holding no backup at all.
  *
+ * **The contract is symmetric, and both halves are load-bearing.** Bounding only the positive
+ * direction — *never `healthy` from an absent observation* — closes the false positive and licenses
+ * its mirror: a scorer can comply by reporting `backup-never-succeeded` instead, which is equally
+ * unfounded from the same unread input and considerably more expensive, because a definite negative
+ * reads as a finding and gets acted on. An absent or self-contradicting observation admits exactly
+ * one honest answer, so both directions are bound here: **it resolves to unknown or to an explicit
+ * conflict — never `healthy`, and never an invented negative.** A verdict may not assert a definite
+ * negative that newer evidence in its own snapshot contradicts; where the receipt and the retry
+ * ledger disagree, the disagreement is itself the finding.
+ * ticket-ref-ok: #17338 authored the asymmetric half of this contract; naming it is how a future
+ * editor knows the one-directional wording was tried and superseded rather than simply forgotten.
+ *
  * `observationStatus` carries that difference. It is deliberately NOT the field of the same name one
  * level up in the healthcheck payload: `maintenance.observationStatus` reports whether the
  * deployment-state bridge could be READ, this one whether the verdict's own input was PRESENT. Their
@@ -306,7 +318,14 @@ export function describeBackupMaintenanceHealth({
         retryRead    = retryState !== null && retryState !== undefined,
         staleAfterMs = backupIntervalMs > 0
             ? backupIntervalMs + Math.max(0, retryWindowMs)
-            : null;
+            : null,
+        // The receipt and the retry ledger are two records of the same lane, and only the receipt is
+        // written by the lane itself. A success receipt stamped AFTER the streak anchor is therefore
+        // proof the streak is stale, not proof the lane is broken — see the reconciliation note below.
+        receiptSuccessAtMs = lastBackup?.backup?.status === 'success' ? toEpochMs(lastBackup.finishedAt) : 0,
+        streakContradicted = receiptSuccessAtMs > 0
+            && retryState?.streakStartedAtMs > 0
+            && receiptSuccessAtMs > retryState.streakStartedAtMs;
 
     if (durability.posture === 'unmet') {
         reasonCodes.push('off-host-durability-unmet')
@@ -326,8 +345,27 @@ export function describeBackupMaintenanceHealth({
     }
     // `unanchored` is the expected pre-first-run state: it stays pending rather than turning every
     // fresh deployment into a never-succeeded incident before the lane has had one opportunity.
+    //
+    // `backup-never-succeeded` is a DEFINITE NEGATIVE — it asserts a fact about the whole history of
+    // the lane, from one derived ledger. When this snapshot also carries a success receipt stamped
+    // after the streak anchor, the two disagree and the receipt is the owner's record: it is written
+    // by the lane, whereas `failureStreakStartedAt` is only closed by `TaskStateService.markCompleted()`
+    // on the task-state path. Emitting the negative there would fabricate a claim the snapshot's own
+    // newer evidence contradicts, so the disagreement is reported AS a disagreement instead.
+    // `backup-state-conflict` keeps the block `degraded` — the divergence is a defect in its own
+    // right and must stay visible; it simply stops the verdict inventing which side is true.
+    //
+    // THE CO-DEFECT this branch reports, and how it gets retired. `TaskStateService.markCompleted()`
+    // writes `lastSuccessAt` AND clears `failureStreakStartedAt` in one call, so a lane completing
+    // through the task-state path cannot reach the state reconciled here: an open streak with no
+    // recorded success, while receipts keep succeeding, means the lane writes its receipt without
+    // going through that path. Repairing the writer is not this function's job, and needs no
+    // calendar reminder to be picked up — **this code is the observer.** `backup-state-conflict` is
+    // emitted only when the two records have actually diverged, so its first live appearance in a
+    // healthcheck is the trigger; fix the writer then, and this branch becomes dead code the moment
+    // the ledger stops disagreeing with the receipt.
     if (retryState && retryState.phase !== BACKUP_RETRY_PHASE.unanchored && !retryState.lastSuccessAt) {
-        reasonCodes.push('backup-never-succeeded')
+        reasonCodes.push(streakContradicted ? 'backup-state-conflict' : 'backup-never-succeeded')
     }
     if (staleAfterMs !== null && retryState?.lastSuccessAgeMs > staleAfterMs) {
         reasonCodes.push('backup-success-overdue')

--- a/test/playwright/unit/ai/daemons/orchestrator/scheduling/backup.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/scheduling/backup.spec.mjs
@@ -456,13 +456,30 @@ test.describe('orchestrator/scheduling/backup — receipt/retry reconciliation (
         ]);
     });
 
-    // CONTROL, and the discriminator this fix turns on. A success receipt OLDER than the streak is
-    // exactly the evidence the streak already accounts for — the lane succeeded, then began failing.
-    // Reddens any implementation that tests for a receipt's existence instead of its RECENCY.
-    test('a success receipt older than the streak does not suppress the negative', () => {
+    // The receipt's AGE decides nothing, and this arm is where that is enforced. `markFailed()`
+    // advances the streak and leaves `lastSuccessAt` standing, so a lane that genuinely succeeded
+    // and then began failing never reaches this branch at all — it has a recorded success. Reaching
+    // it with a success receipt of ANY age therefore means the two records disagree about whole-lane
+    // history, and the whole-history negative is falsified either way. Reddens any implementation
+    // that reintroduces a recency comparison to decide between the two codes.
+    test('a success receipt older than the streak yields the same conflict, not the negative', () => {
         expect(conflicted({
             lastBackup: {backup: {status: 'success'}, finishedAt: iso(STREAK_AT - DAY_MS), status: 'ok'}
-        }).reasonCodes).toEqual(['backup-retry-exhausted', 'backup-never-succeeded']);
+        }).reasonCodes).toEqual(['backup-retry-exhausted', 'backup-state-conflict']);
+    });
+
+    // CONTROL, and the discriminator the reconciliation actually turns on: the receipt's STATUS. A
+    // failed receipt proves a run happened, never that one succeeded, so the negative must survive
+    // it. Reddens any implementation that reads a receipt's mere presence as proof of success —
+    // which is the shape a recency test collapses into once the timestamps stop being consulted.
+    test('a failed receipt does not suppress the negative', () => {
+        expect(conflicted({
+            lastBackup: {backup: {status: 'failed'}, finishedAt: iso(STREAK_AT + DAY_MS), status: 'ok'}
+        }).reasonCodes).toEqual([
+            'backup-retry-exhausted',
+            'backup-last-run-failed',
+            'backup-never-succeeded'
+        ]);
     });
 
     // AC-3 (iii). The conflict must not launder an unrelated true negative. Reddens if the

--- a/test/playwright/unit/ai/daemons/orchestrator/scheduling/backup.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/scheduling/backup.spec.mjs
@@ -410,3 +410,75 @@ test.describe('orchestrator/scheduling/backup — maintenance health (#17068)', 
         expect(cases).not.toContain('healthy');
     });
 });
+
+// Binding only the positive direction — never `healthy` from an unread input — leaves a scorer free
+// to emit the opposite unfounded verdict from that same input, and a definite negative is the more
+// expensive half: it reads as a finding and gets acted on. These arms bind the negative direction
+// without unbinding the positive one, and the reconciliation they cover is between two records of
+// one lane that ride the same snapshot — the receipt the lane writes, and the retry ledger derived
+// from task state.
+test.describe('orchestrator/scheduling/backup — receipt/retry reconciliation (#17785)', () => {
+    const
+        STREAK_AT = T,
+        // The shape measured on pin 467fd122f3: streak open, no ledger success, receipt 21 days newer.
+        conflicted = (overrides = {}) => describeBackupMaintenanceHealth({
+            backupIntervalMs: DAY_MS,
+            durability      : {posture: 'configured'},
+            lastBackup      : {backup: {status: 'success'}, finishedAt: iso(STREAK_AT + 21 * DAY_MS), status: 'ok'},
+            retryState      : {
+                phase            : BACKUP_RETRY_PHASE.exhausted,
+                lastSuccessAgeMs : null,
+                lastSuccessAt    : null,
+                streakStartedAtMs: STREAK_AT
+            },
+            retryWindowMs: WINDOW_MS,
+            ...overrides
+        });
+
+    // AC-3 (i). Reddens if the reconciliation is removed: the scorer falls back to the ledger alone
+    // and `backup-never-succeeded` returns — the exact string that cost four maintainers an evening.
+    test('a success receipt newer than the streak yields a conflict, never a fabricated negative', () => {
+        expect(conflicted()).toEqual({
+            observationStatus: 'observed',
+            reasonCodes      : ['backup-retry-exhausted', 'backup-state-conflict'],
+            staleAfterMs     : DAY_MS + WINDOW_MS,
+            status           : 'degraded'
+        });
+    });
+
+    // AC-3 (ii). The first direction stays bound. Reddens if the reconciliation is widened to
+    // suppress the negative whenever a receipt is merely PRESENT: here there is none, the lane
+    // genuinely has no recorded success, and the definite negative is the honest answer.
+    test('a genuinely receipt-less exhausted lane still reports backup-never-succeeded', () => {
+        expect(conflicted({lastBackup: null}).reasonCodes).toEqual([
+            'backup-retry-exhausted',
+            'backup-never-succeeded'
+        ]);
+    });
+
+    // CONTROL, and the discriminator this fix turns on. A success receipt OLDER than the streak is
+    // exactly the evidence the streak already accounts for — the lane succeeded, then began failing.
+    // Reddens any implementation that tests for a receipt's existence instead of its RECENCY.
+    test('a success receipt older than the streak does not suppress the negative', () => {
+        expect(conflicted({
+            lastBackup: {backup: {status: 'success'}, finishedAt: iso(STREAK_AT - DAY_MS), status: 'ok'}
+        }).reasonCodes).toEqual(['backup-retry-exhausted', 'backup-never-succeeded']);
+    });
+
+    // AC-3 (iii). The conflict must not launder an unrelated true negative. Reddens if the
+    // reconciliation is placed so that it returns early or clears previously pushed codes.
+    test('off-host-durability-unmet survives the conflict verdict', () => {
+        expect(conflicted({durability: {posture: 'unmet'}}).reasonCodes).toEqual([
+            'off-host-durability-unmet',
+            'backup-retry-exhausted',
+            'backup-state-conflict'
+        ]);
+    });
+
+    // The divergence is a defect in its own right and must stay visible: reporting the disagreement
+    // is not the same as resolving it in the receipt's favour and going quiet.
+    test('a conflicted lane never reads healthy', () => {
+        expect(conflicted().status).toBe('degraded');
+        expect(conflicted({durability: {posture: 'unmet'}}).status).toBe('degraded');
+    });
+});

--- a/test/playwright/unit/ai/mcp/server/memory-core/HealthcheckBackupDetails.spec.mjs
+++ b/test/playwright/unit/ai/mcp/server/memory-core/HealthcheckBackupDetails.spec.mjs
@@ -1,0 +1,92 @@
+import {setup} from '../../../../../setup.mjs';
+
+const appName = 'HealthcheckBackupDetailsTest';
+
+setup({
+    neoConfig: {
+        unitTestMode: true
+    },
+    appConfig: {
+        name             : appName,
+        isMounted        : () => true,
+        vnodeInitialising: false
+    }
+});
+
+import {test, expect} from '@playwright/test';
+import Neo            from '../../../../../../../src/Neo.mjs';
+import * as core      from '../../../../../../../src/core/_export.mjs';
+
+/**
+ * The human-readable backup line in a composed healthcheck must be a RENDERING of the maintenance
+ * verdict's reason codes, never a second producer of them.
+ *
+ * Operators and agents read this sentence rather than the structured block, so a wording assembled
+ * beside the codes instead of from them would let the prose outlive a corrected verdict: the surface
+ * would keep asserting a finding the scorer no longer makes, and correcting the scorer would leave
+ * the reader's experience untouched.
+ *
+ * The arms assert derivation in both directions — codes reach the prose verbatim, and a code absent
+ * from the verdict appears nowhere in any rendered line.
+ */
+
+const
+    // Minimal composer inputs. Only the backup arm is exercised; every other degradation source is
+    // held quiet so a detail line can originate from exactly one place.
+    baseArgs = reasonCodes => ({
+        health              : {status: 'healthy', details: []},
+        memoryWalDrain      : {state: 'caught-up', pendingDrainDepth: 0, oldestPendingAgeMs: null, stallThresholdMs: 1},
+        plane               : {id: 'test-plane', dataRoot: '/tmp/test-plane'},
+        deploymentInspection: {
+            ok      : true,
+            status  : 'available',
+            snapshot: {maintenance: {health: {status: 'degraded', reasonCodes, staleAfterMs: null}}}
+        }
+    }),
+
+    backupDetailOf = composed => (composed.details || []).find(line => line.startsWith('Backup maintenance is degraded:')),
+
+    compose = async reasonCodes => {
+        const {composeMemoryCoreHealthcheck} = await import(
+            '../../../../../../../ai/mcp/server/memory-core/toolService.mjs'
+        );
+
+        return composeMemoryCoreHealthcheck(baseArgs(reasonCodes))
+    };
+
+test.describe('memory-core healthcheck — the backup detail line derives from the verdict', () => {
+    test('the rendered sentence is the verdict\'s reason codes, verbatim and in order', async () => {
+        expect(backupDetailOf(await compose(['backup-retry-exhausted', 'backup-state-conflict']))).toBe(
+            'Backup maintenance is degraded: backup-retry-exhausted, backup-state-conflict.'
+        );
+    });
+
+    // The derivation arm proper: change the verdict, the prose must change with it. Reddens if any
+    // detail line is ever built from something other than the verdict's reason codes.
+    test('mutating the verdict mutates the prose', async () => {
+        const
+            conflict = backupDetailOf(await compose(['backup-state-conflict'])),
+            negative = backupDetailOf(await compose(['backup-never-succeeded']));
+
+        expect(conflict).toBe('Backup maintenance is degraded: backup-state-conflict.');
+        expect(negative).toBe('Backup maintenance is degraded: backup-never-succeeded.');
+        expect(conflict).not.toBe(negative);
+    });
+
+    // NO INDEPENDENT EMISSION PATH. This is the arm that catches a corrected scorer whose old
+    // finding survives in the prose: with the definite negative absent from the verdict, it must be
+    // absent from every rendered line — not merely from the backup line.
+    test('a code absent from the verdict appears nowhere in details', async () => {
+        const composed = await compose(['backup-retry-exhausted', 'backup-state-conflict']);
+
+        expect(composed.details.join('\n')).not.toContain('backup-never-succeeded');
+    });
+
+    // Guards the fallback branch rather than assuming it never fires: a degraded verdict naming no
+    // reason is still a real state, and the reader needs a pointer rather than a bare accusation.
+    test('an empty reason-code list falls back to a pointer, not to a bare sentence', async () => {
+        expect(backupDetailOf(await compose([]))).toBe(
+            'Backup maintenance is degraded: see maintenance.backup.'
+        );
+    });
+});


### PR DESCRIPTION
Resolves #17785

The backup maintenance scorer held two records of the same lane and read only one. `describeBackupMaintenanceHealth()` derived `backup-never-succeeded` from the retry ledger alone while a success receipt sat unread in the same snapshot — so a plane taking a good backup every day reported that it had never taken one. A success receipt now yields `backup-state-conflict` instead: the two records disagree, that disagreement is reported as itself, and the verdict stops inventing which side is true. The receipt's age is not consulted, deliberately — the code being guarded claims the lane *never* succeeded, so any success receipt falsifies it, while `backup-retry-exhausted` carries the narrower current-window claim and stays put.

Evidence: L2 (pure-function unit specs; both changed surfaces are fully reachable in-sandbox) → L2 required (AC-1 … AC-5). No residual.

## AC Evidence
| AC-1 | CI-covered: `backup.spec.mjs` — *"a success receipt newer than the streak yields a conflict, never a fabricated negative"* (reasonCodes) + `HealthcheckBackupDetails.spec.mjs` — *"a code absent from the verdict appears nowhere in details"* (`details[]`) |
| AC-2 | Documented with a named trigger, per the AC's second branch: `backup.mjs` records that `TaskStateService.markCompleted()` writes `lastSuccessAt` and clears `failureStreakStartedAt` in one call, so the observed state is only reachable by a lane writing its receipt outside that path. The trigger is not a calendar reminder — **the new code is the observer**: `backup-state-conflict` is emitted only on real divergence, so its first live appearance is the signal to repair the writer, and the branch becomes dead code once the ledger agrees with the receipt. |
| AC-3 | CI-covered, three arms + two controls: (i) *"a success receipt newer than the streak yields a conflict, never a fabricated negative"*; (ii) *"a genuinely receipt-less exhausted lane still reports backup-never-succeeded"*; (iii) *"off-host-durability-unmet survives the conflict verdict"*; controls: *"a success receipt older than the streak yields the same conflict, not the negative"* and *"a failed receipt does not suppress the negative"*. Mutation receipts below. |
| AC-4 | CI-covered: `HealthcheckBackupDetails.spec.mjs`, four arms — verbatim rendering, mutating-the-verdict-mutates-the-prose, no-independent-emission, and the empty-code-list fallback. |
| AC-5 | `describeBackupMaintenanceHealth()` JSDoc states the symmetric contract: an absent or self-contradicting observation resolves to unknown or an explicit conflict — never `healthy`, never an invented negative — and names why scope makes it checkable: a whole-history code is falsified by any success receipt, a current-window code is not, so the two are never traded on a timestamp comparison. |

## Deltas from ticket
**The reconciliation tests the receipt's STATUS, not its age** — corrected under review, and the correction is the substance of round 2. An earlier revision suppressed the negative only for a receipt *newer* than the streak anchor. That reintroduced the same fabricated-negative class one axis over: `backup-never-succeeded` is a claim about the lane's whole history, so **any** success receipt falsifies it, and `markFailed()` never clears `lastSuccessAt` — so a lane that genuinely succeeded and then began failing has a recorded success and never reaches this branch at all. Reaching it with a success receipt of any age therefore means the two records disagree about whole-lane history.

Added a **control the ACs did not ask for**: *a failed receipt does not suppress the negative*. It pins the real discriminator — a failed receipt proves a run happened, never that one succeeded — and catches the shape a dropped recency test collapses into.

`backup-retry-exhausted` is deliberately **kept** alongside `backup-state-conflict`: it claims the current recovery window is spent, which stays true, and is exactly the narrower claim that must never be traded for the whole-history one.

`## Contract Ledger` backfilled on #17785 (8 rows: reason-code contract, `details[]` projection, receipt fallbacks, census non-coupling, co-defect ownership).

Scope held: no census coupling (the ticket's point 4), no `offHostSync` change, no kb-server arm (specimen withdrawn as non-reproducible post-bump), no backup-mechanism change.

## Test Evidence
All coverage runs in CI. The mutation results below are what a green suite cannot show — each arm was verified to redden against a named mutation, and the exact failure count checked rather than "some tests failed":

| mutation applied to the implementation | red | which arms |
|---|---|---|
| A — reconciliation removed (`receiptProvesSuccess = false`) | **3** | newer-receipt · older-receipt · durability-survival |
| B — recency reintroduced (the rejected round-1 rule) | **1** | older-receipt only |
| C — receipt presence read as proof of success | **1** | failed-receipt control only |
| D — independent `details[]` emitter added | **1** | appears-nowhere arm only |

Three distinct conviction sets across A/B/C, so no two arms are one assertion wearing two labels. **B is the round-2 arm**: it applies the exact rule the review rejected and is caught by the exact arm the review asked for. Each mutation was reverted and **37/37 green restored** before commit; the receipt-less and never-healthy arms held green under A, which is the negative half of the proof — they must not depend on the reconciliation.

## Post-Merge Validation
None — deliberately, and this is the design rather than an omission. The two candidates were "confirm the conflict verdict on a deployed plane" and "repair the task-state writer", and both already have an **in-code observer** instead of a checklist owner: `backup-state-conflict` is emitted only on genuine divergence, so a deployed healthcheck surfaces it without anyone remembering to look, and that same first emission is the repair trigger. An unchecked box with no owner is a promise nobody holds; this PR leaves none behind.

## Commits
- `70c1687e45` — reconcile the receipt against the retry ledger; symmetric-contract JSDoc; AC-3/AC-4 arms.
- `cf6eabcfc5` — round-2 correction: reconcile on the receipt's status rather than its age; invert the older-receipt arm to assert the conflict; add the failed-receipt control.

## Evolution
Round 2, and the load-bearing one: @neo-gpt rejected the recency test. `backup-never-succeeded` is a whole-history claim, so any success receipt falsifies it — and since `markFailed()` leaves `lastSuccessAt` standing, a genuinely succeeded-then-failing lane never reaches this branch. The recency comparison was therefore deciding between two codes on a fact irrelevant to either, and my own control was enforcing that error while my own JSDoc contradicted it. The rule collapsed to the receipt's status, and the control inverted to assert the conflict for an older receipt. He also caught that the retargeted ticket carried no Contract Ledger for the consumed surface; backfilled.

Two pivots worth recording, both course-corrections away from wrong shapes. The first diagnosis called this a payload self-contradiction between two `observationStatus` fields; that was falsified by the source, which documents the two as deliberately disjoint subjects, and @neo-gpt's archaeology relocated the defect inside the orchestrator snapshot where it actually lives. The second: the `details[]` arm was briefly implemented by extracting a pure render helper, to avoid importing a module graph that expects an entrypoint to have established the Neo namespace. The operator corrected the premise — a spec file *can* be an entrypoint, and the sibling spec in the same directory already is one — so the extraction was reverted as scope creep and the spec adopted the established `setup()` idiom instead.

Authored by Ada (Claude Opus 5, Claude Code). Session 2aaae0bf-8ed1-4d02-9172-841bca0c2467.
