### PR TITLE
learn/agentos custody splits by subject, not directory

### DIFF
--- a/learn/agentos/decisions/0040-agentos-extraction-topology.md
+++ b/learn/agentos/decisions/0040-agentos-extraction-topology.md
@@ -214,13 +214,22 @@ cannot survive its own coordinates: the Agent OS decision records live *inside*
 classify no `learn/agentos/**` row at all. The disposition is now explicit, and it is the same
 subject rule the next paragraph applies to tests and hooks rather than a new principle:
 
-| `learn/agentos` population | custody | why |
+| `learn/agentos` population | custody | specimen |
 |---|---|---|
-| Brain-owned learning guides; the Agent OS decision records under `learn/agentos/decisions/` | **extracted repository**, by exact-identity census | their subject is the Agent OS; a reader of a Brain ADR is working in the Brain |
-| rendered Portal / SEO / tree inputs; `resources/content` mirrors | **`neomjs/neo`** | their consumer is the published site, not the Agent OS |
+| guides and decision records whose **subject is the Agent OS** | **extracted repository**, by exact-identity census | `A2A.md`; `decisions/0027-autonomous-data-recovery-actuator.md` |
+| guides and decision records whose **subject is the Body or the Engine**, despite sharing this directory | **`neomjs/neo`** | `DockZoneModel.md`; `decisions/0029-docking-design.md` — a multi-window layout model does not become Brain-owned by filing location |
+| rendered Portal / SEO / tree inputs; `resources/content` mirrors | **`neomjs/neo`** | consumer is the published site, not the Agent OS |
 
-Neither half is a blanket directory move, and no `learn/agentos` path is left unclassified by
-omission.
+**Neither the directory nor a filename prefix decides any of it, and `decisions/` is no exception.**
+The 40-record corpus is mixed at both levels — `0027` is a Memory Core record and `0029` is a
+docking record, filed side by side; `A2A.md` and `DockZoneModel.md` are the same collision one
+directory up. A blanket "`decisions/` moves" rule would relocate the Body's design records into the
+Brain and reproduce, one level lower, exactly the location heuristic this section exists to reject.
+
+**This section names the categories and the invariant; it does not enumerate.** The exact per-file
+identities are the cut manifest's census (`#17787`), which is where a mixed corpus of this size can
+be resolved file by file and evidenced. What §2.7 guarantees is that every `learn/agentos` path has
+a category to be classified *into*, and that the classifier is subject rather than location.
 
 **Test and hook custody follows the SUBJECT, not the directory.** Lane-state, wake, presence, and
 Memory-Core context hooks under `.claude/hooks`, `.codex/hooks`, and `.kimi-code/hooks` are Agent OS

--- a/learn/agentos/decisions/0040-agentos-extraction-topology.md
+++ b/learn/agentos/decisions/0040-agentos-extraction-topology.md
@@ -201,11 +201,26 @@ lands.
 
 ### §2.7 Wave-one custody — what stays Engine, explicitly
 
-Staying in `neomjs/neo` in wave one: `apps/**` (the FM's later home is its own decision), published
-`learn/agentos` content and every Portal/SEO/tree input derived from it, `resources/content`
-mirrors, `src/ai/**`, and the minimal Engine contributor surface. The extracted repository takes the
+Staying in `neomjs/neo` in wave one: `apps/**` (the FM's later home is its own decision), every
+Portal/SEO/tree input derived from `learn/agentos` and the `resources/content` mirrors that publish
+it, `src/ai/**`, and the minimal Engine contributor surface. The extracted repository takes the
 Brain's executables and services per the inventory's disposition — custody follows the dispositioned
 population, not directory intuition.
+
+**`learn/agentos` splits by subject too, and this paragraph once said otherwise.** An earlier
+revision listed "published `learn/agentos` content" as one undivided Engine-staying category, which
+cannot survive its own coordinates: the Agent OS decision records live *inside*
+`learn/agentos/decisions/`, so a single clause answered both ways at once and the cut manifest could
+classify no `learn/agentos/**` row at all. The disposition is now explicit, and it is the same
+subject rule the next paragraph applies to tests and hooks rather than a new principle:
+
+| `learn/agentos` population | custody | why |
+|---|---|---|
+| Brain-owned learning guides; the Agent OS decision records under `learn/agentos/decisions/` | **extracted repository**, by exact-identity census | their subject is the Agent OS; a reader of a Brain ADR is working in the Brain |
+| rendered Portal / SEO / tree inputs; `resources/content` mirrors | **`neomjs/neo`** | their consumer is the published site, not the Agent OS |
+
+Neither half is a blanket directory move, and no `learn/agentos` path is left unclassified by
+omission.
 
 **Test and hook custody follows the SUBJECT, not the directory.** Lane-state, wake, presence, and
 Memory-Core context hooks under `.claude/hooks`, `.codex/hooks`, and `.kimi-code/hooks` are Agent OS
@@ -293,6 +308,15 @@ entrypoint class; a computed-import mechanism that bypasses the §2.4 dispositio
 change that reintroduces hoisting; a new out-of-`ai/` Brain-consumer class beyond the §2.3/§2.7
 dispositions (test infrastructure, app specs, tracked seat hooks); **any Engine `dependencies` or
 `devDependencies` edge on the extracted repository**; renaming the repository after creation.
+
+**Fired and discharged — `learn/agentos` custody, 2026-08-26.** The trigger above fired on operator
+direction that Brain-owned learning guides and the Agent OS decision records move to the extracted
+repository, with the CI-workflow consequences following. §2.7's `learn/agentos` table records the
+discharge. Two consequences worth stating rather than leaving to inference: the move itself is a
+separate receive leaf under the Wave-3 epic — **this amendment decides custody and relocates
+nothing** — and Epic #17500's earlier wave-one boundary, which kept all of `learn/agentos` Engine
+and listed moving it as out of scope, is **superseded** by this discharge on that same operator
+authority. Every other trigger in the list remains armed.
 
 **Retirement:** this ADR retires only by explicit successor in this series; the wave completing
 does not retire it — the topology it records is what "completed" means.


### PR DESCRIPTION
Resolves neomjs/neo#17800

🌿 *A `learn/agentos` path can no longer be Engine-staying and Brain-moving at the same time.*

Unblocks the split's critical path: neomjs/neo#17787's AC-4 pins **the merged** ADR 0040 correction, and neomjs/neo-agent-brain#13 / neomjs/neo-agent-brain#12 / neomjs/neo#17791 all wait on the manifest that AC gates.

Evidence: L2 (the amendment is a decision record; its correctness is read off the ADR's own subject rule and its own §5 trigger, both cited inline, plus the operator authority anchored publicly) → L2 is the ceiling for a custody decision: there is no runtime arm, and the classifiability claim is demonstrated below rather than asserted. No residuals.

## The defect

§2.7 listed **"published `learn/agentos` content"** as one undivided Engine-staying category. But the Agent OS decision records live *inside* `learn/agentos/decisions/`. One clause therefore answered both ways at once, and the Wave-3 cut manifest could classify **no** `learn/agentos/**` row — not the ADRs, not the guides, not the Portal inputs.

## What changed

**§2.7 — an explicit two-row disposition**, applying the subject rule the *very next paragraph* already uses for tests and hooks ("custody follows the SUBJECT, not the directory") rather than inventing a principle:

| `learn/agentos` population | custody | why |
|---|---|---|
| Brain-owned learning guides; decision records under `learn/agentos/decisions/` | extracted repository, by exact-identity census | their subject is the Agent OS |
| rendered Portal / SEO / tree inputs; `resources/content` mirrors | `neomjs/neo` | their consumer is the published site |

**§5 — the trigger recorded as fired and discharged.** §5's own *Revalidation triggers* list names "custody changes to `apps/**`, `learn/agentos`, or `src/ai/**`", so this is the trigger the ADR declares firing on the ADR. The discharge note states two things rather than leaving them to inference: this amendment **decides custody and relocates nothing**, and Epic neomjs/neo#17500's earlier all-`learn`-stays boundary is **superseded** on the same operator authority. Every other trigger stays armed.

## AC Evidence

| AC | proof |
|---|---|
| AC-1 | **MET** — §2.7's undivided clause is replaced by a two-row disposition table. The opening sentence now names Portal/SEO/tree inputs and `resources/content` mirrors as Engine-staying; the table names Brain-owned guides and `learn/agentos/decisions/` as extracted-repository custody by exact-identity census. No `learn/agentos` path is left unclassified by omission. |
| AC-2 | **MET** — §5 gains a *Fired and discharged — `learn/agentos` custody, 2026-08-26* note citing the operator direction that fired it, stating that this amendment decides custody and relocates nothing, and confirming every other trigger stays armed. |
| AC-3 | **MET, restated after review** — §2.7 gives every `learn/agentos` path a **category** to be classified into and names **subject** as the classifier; it does not enumerate. The exact per-file identities are neomjs/neo#17787's census. Four real paths — positive *and* negative on both levels — are classified under **Test Evidence** below; the earlier placeholder specimen is gone. |
| AC-4 | **MET** — the §5 discharge note explicitly marks Epic neomjs/neo#17500's all-`learn`-stays boundary superseded on the same operator authority. neomjs/neo#17800's AC-4 accepts either truth-syncing neomjs/neo#17500 **or** naming it here; naming it is the half that does not mutate another author's ticket. |
| AC-5 | **OPEN BY CONSTRUCTION** — neomjs/neo#17787's AC-4 pins the *merged* correction, so this AC closes on merge, not on approval. Listed rather than omitted so nobody reads an approval as the unblock. |

## Test Evidence

**AC-3 with real identities and both arms** — four tracked paths, positive and negative at each level, classified by §2.7's categories:

```
POSITIVE (subject = Agent OS → extracted repository)
  learn/agentos/A2A.md                                        agent-to-agent protocol
  learn/agentos/decisions/0027-autonomous-data-recovery…md     Memory Core recovery actuator

NEGATIVE (subject = Body/Engine, SAME directories → neomjs/neo)
  learn/agentos/DockZoneModel.md                               dock-zone model
  learn/agentos/decisions/0029-docking-design.md               multi-window layout, cross-window drag
```

The negative arm is the one that matters: `0029` and `0027` are filed side by side, and `DockZoneModel.md` sits beside `A2A.md`. A location rule classifies all four the same way and is wrong on half of them.

**The ambiguous phrase no longer disposes anything** — `grep "published \`learn/agentos\` content"` matches exactly one line, inside the amendment's own account of what it corrected. Deliberate: a decision record whose corrections are invisible teaches the next author nothing.

No runtime surface touched — `git diff --stat`: one file, +27 / −3. `agent-preflight` reports `0 .mjs files in scope`.

## Deltas

- **Cycle 2 — @neo-gpt-emmy caught the amendment reproducing the error it was written to fix.** The first table said custody follows subject, then used the directory `learn/agentos/decisions/` as custody authority for all 40 records. Her negative control holds on inspection: ADR 0029 is *Docking Design — multi-window layout, SharedWorker seam, cross-window drag*, filed beside Memory Core records like ADR 0027, and a blanket `decisions/` row moves the Body's design records into the Brain. **The same collision repeats one directory up, which the review did not need to reach:** `A2A.md` and `DockZoneModel.md` sit side by side, so "Brain-owned guides" was loose in exactly the same way. The table is now uniformly subject-keyed with a positive *and* a negative specimen at both levels, and says outright that `decisions/` is no exception.
- **Cycle 2 — the classifiability claim is truth-folded.** §2.7 now states that it names categories and the invariant and does **not** enumerate; exact per-file identities are neomjs/neo#17787's census. That is the honest division: a mixed 40-record corpus gets resolved file by file with evidence in the manifest, not by prose in an ADR.

- The amendment **names its own prior error in the ADR body** ("this paragraph once said otherwise") instead of silently rewriting the sentence. A decision record whose corrections are invisible teaches the next author nothing, and the ambiguity here was subtle enough to survive graduation, a Step-Back, and cross-family review.
- Chose a **table** over prose for the disposition: the manifest consumer needs a lookup, and prose is what produced a clause that answered twice.
- **Did not** touch neomjs/neo#17500's body. It is another author's ticket, so the supersession is recorded in the ADR (the authority surface) rather than by mutating their artifact — neomjs/neo#17800's AC-4 accepts either, and this is the half that does not collapse attribution.

## Post-Merge Validation

1. neomjs/neo#17787 can bind `wave3-cut-manifest.v1` — its AC-4 prerequisite is satisfied only by **merge**, not by approval.
2. The manifest classifies the two artifacts I surfaced at [#17787 comment 5425000805](https://github.com/neomjs/neo/issues/17787#issuecomment-5425000805) — `ai/mcp/deploy/proxy/Caddyfile` and `ai/scripts/lifecycle/nightly-e2e/com.neomjs.nightly-e2e.plist` — using this subject rule.
3. The separate Brain docs/ADR receive leaf (unclaimed successor) executes the move; neomjs/neo#17791 owns the Neo-side removal, last.

⚠️ **Merge-order note for whoever reviews second:** neomjs/neo#17783's AC-7 also amends §2.7, scoped to enforcement custody. Both tickets are mine; the second to merge rebases rather than clobbers.

Authored by Vega (Claude Opus 5, Claude Code). Session 8cfe8ea9-113f-4e32-a3f4-822ee92ff721.
