### PR TITLE
The enforcement read-back names what was observed, not a head SHA

### DIFF
--- a/ai/scripts/diagnostics/agentOsExtractionInventory.mjs
+++ b/ai/scripts/diagnostics/agentOsExtractionInventory.mjs
@@ -1951,8 +1951,10 @@ export function runPlaneBoundaryProof({projectRoot = PROJECT_ROOT, execFile = ex
  * @param {String} config.skillsPackage.referenceClosure.ref Immutable owner-produced receipt coordinate.
  * @param {'red'|'green'} config.skillsPackage.referenceClosure.state Observed closure state at the cut.
  * @param {Object} config.enforcement One-time required-context read-back.
- * @param {String} config.enforcement.headSha Enforcement implementation/head SHA.
+ * @param {String} config.enforcement.ref Public coordinate of the read-back observation.
+ * @param {String} config.enforcement.rulesetDigest `sha256:<hex>` over the observed branch ruleset.
  * @param {String} config.enforcement.requiredContext Surviving required context.
+ * @param {Number} config.enforcement.integrationId Check-integration id owning that context.
  * @param {Object} config.learningCensus Immutable Brain-guide / ADR disposition census.
  * @param {String} config.learningCensus.ref Public census comment coordinate.
  * @param {String} config.learningCensus.commitSha Brain commit containing the census artifact.
@@ -2057,7 +2059,8 @@ export function buildWave3CutManifest({
         !VALID_REFERENCE_CLOSURE_STATE.has(skillsPackage.referenceClosure?.state)) {
         errors.push('skills-package-coordinate-missing')
     }
-    if (!GIT_SHA_RE.test(enforcement.headSha ?? '') || !enforcement.requiredContext) {
+    if (!enforcement.ref || !DIGEST_RE.test(enforcement.rulesetDigest ?? '') ||
+        !enforcement.requiredContext || !Number.isInteger(enforcement.integrationId)) {
         errors.push('enforcement-coordinate-missing')
     }
     if (!learningCensus.ref || !GIT_SHA_RE.test(learningCensus.commitSha ?? '') ||
@@ -2135,8 +2138,10 @@ export function buildWave3CutManifest({
                 }
             },
             enforcement: {
-                headSha        : enforcement.headSha ?? null,
-                requiredContext: enforcement.requiredContext ?? null
+                ref            : enforcement.ref ?? null,
+                rulesetDigest  : enforcement.rulesetDigest ?? null,
+                requiredContext: enforcement.requiredContext ?? null,
+                integrationId  : enforcement.integrationId ?? null
             },
             learningCensus: {
                 schemaVersion    : learningArtifact.schemaVersion ?? null,

--- a/test/playwright/unit/ai/scripts/diagnostics/agentOsExtractionInventory.spec.mjs
+++ b/test/playwright/unit/ai/scripts/diagnostics/agentOsExtractionInventory.spec.mjs
@@ -272,8 +272,10 @@ test.describe('agentOsExtractionInventory — exact population × explicit autho
                     }
                 },
                 enforcement: {
-                    headSha        : 'e'.repeat(40),
-                    requiredContext: 'integration-parity'
+                    ref            : 'issuecomment-fixture#enforcement-read-back',
+                    rulesetDigest  : `sha256:${'e'.repeat(64)}`,
+                    requiredContext: 'integration-parity',
+                    integrationId  : 15368
                 },
                 learningCensus: {
                     ref         : 'discussioncomment-fixture#learning-census',
@@ -417,6 +419,41 @@ test.describe('agentOsExtractionInventory — exact population × explicit autho
             'custody-correction-coordinate-missing',
             'rollback-pair-missing'
         ])
+    });
+
+    test('each enforcement read-back field is individually load-bearing', () => {
+        // The coarse fail-closed test above passes an ABSENT enforcement object, so it would stay
+        // green even if three of the four fields were never validated. These arms vary exactly one
+        // field at a time and assert the typed error appears — the non-vacuity half. Without them a
+        // future edit could drop `rulesetDigest` from validation and no test would notice.
+        const valid = {
+                ref            : 'issuecomment-fixture#enforcement-read-back',
+                rulesetDigest  : `sha256:${'e'.repeat(64)}`,
+                requiredContext: 'integration-parity',
+                integrationId  : 15368
+            },
+            // A ruleset observation is not a commit. The enforcement read-back has no implementing
+            // head to cite, so a SHA field there would carry a fiction; `ref` plus digest name where
+            // the observation lives and what it observed, which is what a read-back actually is.
+            invalidVariants = [
+                ['ref missing',            {...valid, ref            : ''}],
+                ['digest not sha256',      {...valid, rulesetDigest  : 'e'.repeat(64)}],
+                ['digest wrong length',    {...valid, rulesetDigest  : `sha256:${'e'.repeat(63)}`}],
+                ['requiredContext missing',{...valid, requiredContext: ''}],
+                ['integrationId absent',   {...valid, integrationId  : undefined}],
+                ['integrationId not int',  {...valid, integrationId  : '15368'}]
+            ];
+
+        invalidVariants.forEach(([label, enforcement]) => {
+            const receipt = buildWave3CutManifest({enforcement});
+
+            expect(receipt.errors, label).toContain('enforcement-coordinate-missing')
+        });
+
+        // Positive control: the same harness must NOT raise the enforcement error for a valid
+        // read-back, or every arm above would pass for the wrong reason.
+        expect(buildWave3CutManifest({enforcement: valid}).errors)
+            .not.toContain('enforcement-coordinate-missing')
     });
 
     test('Wave-3 tracker arithmetic rejects a stale source denominator', () => {


### PR DESCRIPTION
Refs #17783

🌿 *The enforcement receipt can no longer claim a commit that never existed.*

Evidence: L3 (mutation-verified — the new arm goes red when the validation it constrains is removed; 52/52 targeted spec green at this head) → L3 sufficient (no operator-gated or destructive step in scope). No residuals.

## The defect

The Wave-3 cut input required `enforcement.{headSha, requiredContext}`. But the enforcement deliverable is a **one-time observation of a branch ruleset** — it has no implementing head. Any SHA in that field carries a fiction, and the manifest bind commit cannot stand in for a ruleset read, which is exactly why @neo-gpt-emmy held the final green emission.

## The fix, following an idiom rather than inventing one

`enforcement` now carries `{ref, rulesetDigest, requiredContext, integrationId}` — a public coordinate for **where** the observation lives plus a digest for **what** it observed. That shape is not new to this file: `skillsPackage.referenceClosure` is already `{ref, state}` and `learningCensus` already carries `{ref, commitSha, …}`. Validation is fail-closed on all four and reuses the file's existing `DIGEST_RE` rather than adding a pattern.

```
ai/scripts/diagnostics/agentOsExtractionInventory.mjs
  1953-1957   JSDoc: headSha → ref + rulesetDigest + integrationId
  2062-2064   fail-closed: ref non-empty · DIGEST_RE on rulesetDigest · context non-empty · integrationId an integer
  2140-2145   emitted prerequisites.enforcement carries all four
```

## AC Evidence

| AC | proof |
|---|---|
| AC-4 | **PARTIAL — the pre-cut half.** The read-back exists and now has a home: `ref` + `rulesetDigest` + `requiredContext` + `integrationId` are exactly the fields the observation produces. The values themselves (digest `sha256:54d48a48…`, `integration-parity`, `integrationId 15368`, source `GET /repos/neomjs/neo/rules/branches/dev`) are recorded at [#17783 comment 5426844579](https://github.com/neomjs/neo/issues/17783#issuecomment-5426844579). The **post-cut** half — a second read-back proving the context survived the split — is unchanged and still post-severance. |
| AC-1 · AC-2 · AC-3 · AC-5 · AC-6 · AC-7 | Untouched. All six are post-cut by construction; this PR is deliberately the pre-cut slice only, which is why it carries `Refs` and not `Resolves`. |

## Test Evidence

**The pre-existing fail-closed test could not have caught this.** It passes an *absent* `enforcement` object, so it stays green even if three of the four fields are never validated. Added a per-field arm — six negative variants plus a positive control:

```
ref missing · digest not sha256-prefixed · digest wrong length
requiredContext missing · integrationId absent · integrationId not an integer
   → each must raise `enforcement-coordinate-missing`
a fully valid read-back
   → must NOT raise it   (positive control: without this, all six could pass for the wrong reason)
```

**Mutation-verified, not asserted.** Removing the `rulesetDigest` and `integrationId` checks from validation turns the new arm **red**:

```
MUTANT (validation reduced to !ref || !requiredContext)
  1 failed  › each enforcement read-back field is individually load-bearing
FIXED
  52 passed (16.9s)   env -u NEO_MCP_REMOTE_TOKEN npx playwright test -c test/playwright/playwright.config.unit.mjs --workers=1 <spec>
```

## Deltas

- **`headSha` is removed, not retained alongside.** Keeping it would preserve a field whose only honest value is `null` for this deliverable, and a nullable SHA invites a future caller to fill it with the nearest commit — which is the fiction this PR exists to remove.
- **No new regex, no new helper.** `DIGEST_RE` already existed at line 194; adding a parallel pattern would have been the added machinery the standing bar forbids.
- **`Refs #17783`, not `Resolves`.** Six of the ticket's seven ACs are post-cut, and AC-4 itself is only half-delivered here. Closing it on this PR would overclaim.
- One durable comment initially cited the ticket number and `check-ticket-archaeology` correctly rejected it — rewritten to describe the behaviour instead.

## Post-Merge Validation

1. @neo-gpt-emmy re-runs the final manifest emission with the four-field `enforcement` object; the held green emission should no longer be blocked by `enforcement-coordinate-missing`.
2. The remaining hold reasons are unaffected and stay outstanding: the plane-proof topology findings (red-capable by `#17533`) and the two structurally-unrunnable probes.
3. AC-4's post-cut read-back runs after severance and is not claimed here.

Authored by Vega (Claude Opus 5, Claude Code). Session 8cfe8ea9-113f-4e32-a3f4-822ee92ff721.
