### PR TITLE
docs(readme): add Engine repository map (#17808)

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,19 @@ The organism has two hemispheres, joined by the Neural Link:
 - **The Brain ([`neomjs/neo-agent-brain`](https://github.com/neomjs/neo-agent-brain))** — the Agent OS: Memory Core, Knowledge Base, Native Edge Graph, A2A coordination, GitHub workflow automation, DreamService, and the named human + AI maintainer institution. This is the differentiator: the self-evolving engineering institution that builds, reviews, and maintains the Body in public.
 - **The Body ([`neomjs/neo`](https://github.com/neomjs/neo), this repository)** — the production multi-threaded application engine under `/src/`: App Worker, VDom Worker, Data Worker, Canvas Worker, SharedWorker, JSON blueprints, object permanence, and zero-build native ES modules. The Body is the runtime the Brain inhabits, improves, and ships to production.
 
+## The repository map
+
+- **You are here:** [`neomjs/neo`](https://github.com/neomjs/neo) — **Body / Engine**: the
+  multi-threaded application runtime.
+- [`neomjs/neo-agent-brain`](https://github.com/neomjs/neo-agent-brain) — **Brain / Agent OS**:
+  institutional memory, repository knowledge, coordination, and self-evolution.
+- [`neomjs/neo-agent-institution`](https://github.com/neomjs/neo-agent-institution) —
+  **Institution**: the Fleet Manager and operator-facing application.
+- [`neomjs/devindex`](https://github.com/neomjs/devindex) — **DevIndex**: the GitHub meritocracy
+  index, its application, and its data factory.
+- [`neomjs/neo-agent-skills`](https://github.com/neomjs/neo-agent-skills) — **Skills**: the canonical
+  installable agent-skill substrate shared by the repositories.
+
 The same possession primitive points beyond web UI — *Software → Games → Robots → X* — toward any domain where AI needs an embodied runtime.
 
 Neo.mjs's evolution mechanism is the **MX loop** — Model Experience as production mechanism. Internal friction from real agent work becomes tickets, tickets become PRs, PRs become skills and memory, and the next agent starts with better reflexes. The trajectory is **autonomous narrow intelligence (ANI)** by accumulation, under gated-RSI by design: the swarm runs the engineering lifecycle, and the founder-architect holds final merge authority as a governance choice.
@@ -103,7 +116,7 @@ The AI maintainers carry persistent identities across sessions. They author tick
 
 The IDE is not an editor. It is the substrate where these maintainers coordinate, review, and govern the codebase as peers to human engineers — under gated-RSI by design: the swarm runs the engineering lifecycle, and the founder-architect holds final merge authority as a governance choice.
 
-**What's next — the Agent Harness**: the institution gets a face. A downloadable, Electron-shelled, multi-window Neo app whose main process hosts the Agent OS — fleet manager first, so operating a cross-family agent team stops requiring a terminal. **Read**: [ADR 0020 — the Agent Harness concept anchor](https://github.com/neomjs/neo-agent-brain/blob/dev/learn/agentos/decisions/0020-agent-harness-concept.md) · [Epic #13012](https://github.com/neomjs/neo/issues/13012) · graduated from [Discussion #10119](https://github.com/orgs/neomjs/discussions/10119)
+**What's next — the Agent Harness**: the institution gets a face. A downloadable, Electron-shelled, multi-window Neo app whose main process hosts the Agent OS — fleet manager first, so operating a cross-family agent team stops requiring a terminal. **Read**: [ADR 0020 — the Agent Harness concept anchor](./learn/agentos/decisions/0020-agent-harness-concept.md) · [Epic #13012](https://github.com/neomjs/neo/issues/13012) · graduated from [Discussion #10119](https://github.com/orgs/neomjs/discussions/10119)
 
 #### The Evolution Mechanism
 
@@ -125,7 +138,7 @@ The Neural Link is not an API garnish. It is the bridge that lets agents move fr
 
 This is the next evolution of conversational UIs: not a chat panel beside the app, but agents collaborating inside the live application itself. The primitive transcends web UI: the same architecture maps to game-engine scene graphs, robotics sensorimotor loops, and any future domain where AI needs to embody. *Software → Games → Robots → X*.
 
-**Read**: [Neural Link](https://github.com/neomjs/neo-agent-brain/blob/dev/learn/agentos/NeuralLink.md), [`learn/benefits/body/ObjectPermanence.md`](./learn/benefits/body/ObjectPermanence.md), and [`learn/benefits/body/OffTheMainThread.md`](./learn/benefits/body/OffTheMainThread.md)
+**Read**: [Neural Link](./learn/agentos/NeuralLink.md), [`learn/benefits/body/ObjectPermanence.md`](./learn/benefits/body/ObjectPermanence.md), and [`learn/benefits/body/OffTheMainThread.md`](./learn/benefits/body/OffTheMainThread.md)
 
 </br></br>
 ## Quickstart


### PR DESCRIPTION
Resolves #17808

Adds the missing five-repository map to the Engine front door while preserving its organization narrative and Engine-first paths. It also repairs two README links that pointed at Brain files Brain has not received and therefore returned 404.

Evidence: L1 static/readability and live-door proof achieved → L1 required; this documentation-only delta claims no runtime effect.

## Identity surface scope

- **FRAMING:** the existing organism apex remains intact; the new map locates this repository as the Body/Engine projection.
- **FACTS:** no version, metrics, roster, or capability-count facts change.
- **ACTIONS touched:** yes — five repository-navigation doors and two repaired read-more doors.
- **Out-of-tree changes:** none. GitHub repository metadata and generated Portal/SEO surfaces are unchanged.

## AC Evidence

| AC-1 | The `## The repository map` section contains exactly five bulleted repository links with one-line ownership: Engine, Brain, Institution, DevIndex, and Skills. |
| AC-2 | The map contains exactly one `You are here` marker. It is plain text before the `neomjs/neo` anchor; no sibling carries it. |
| AC-3 | The organism opening and canonical Introduction relationship are unchanged; non-map prose changes are limited to the two verified link-target repairs. |
| AC-4 | `## Quickstart`, `npx neo-app@latest`, Engine architecture/learning links, and the Engine contributing door remain present and primary. |
| AC-5 | All five repository URLs return HTTP 200. The stale Brain links for ADR 0020 and Neural Link returned 404 and now target their existing Engine-local files; no missing Brain path remains in README. |
| AC-6 | Link audit separately enumerates 44 Markdown and 15 HTML targets (56 unique); all 13 local paths exist. `git diff --check` passes. |
| AC-7 | Merge-gated: a formal cross-family identity review is required after current-head CI is green. |

## Deltas from ticket

The audit found two existing 404s within the ticket's sibling-link/readability scope: `learn/agentos/decisions/0020-agent-harness-concept.md` and `learn/agentos/NeuralLink.md` were linked under Brain but still live in Engine. Both now use their current local canonical paths. No other narrative, badge, quickstart, architecture, roster, metric, or community change is included.

## Test Evidence

- Map audit — exactly five repository rows; exactly one plain-text Engine marker before its link.
- Link audit — 44 Markdown + 15 HTML targets, 56 unique; 13/13 local paths present; five map URLs HTTP 200.
- Door audit — Quickstart, `npx neo-app@latest`, canonical Introduction, Engine learning, and contribution surfaces remain present.
- External transport note — the pre-existing npm and Slack URLs return access-denied responses to automated HEAD requests, not 404; neither target changed in this PR.

## Post-Merge Validation

- None. The README map and repaired links are directly inspectable from the PR head.

Authored by Euclid (OpenAI GPT-5.6 Sol, Codex Desktop). Session 61410a49-3b2b-4aa5-9769-1c5925515016.
