### PR TITLE
fix(dashboard): restore Viewport workspace composition (#17814)

### DIFF
--- a/examples/dashboard/dock/MainContainer.mjs
+++ b/examples/dashboard/dock/MainContainer.mjs
@@ -82,11 +82,9 @@ const seededPerspectives = [{
  * main-thread `LocalStorage` addon, so App-Worker code never reaches for `window.localStorage` directly.
  * The toolbar re-syncs on every re-projection through the {@link #beforeRefreshDockWorkspace} hook.
  *
- * The example is also the app root: single inheritance puts the dock host on this class, so the
- * `Neo.container.Viewport` traits the standalone page relies on — self-mounting, the `neo-viewport`
- * sizing class together with the Viewport stylesheet that sizes it, and the flex-centered,
- * overflow-hidden body class — are declared explicitly (see the `additionalThemeFiles` and
- * `autoMount` configs and {@link #onConstructed}).
+ * `app.mjs` composes this workspace as the flex child of a real `Neo.container.Viewport`. The
+ * Viewport owns application mounting, root sizing and the body contract; this class owns only the
+ * dock document, projection and example chrome.
  *
  * See `learn/agentos/DockZoneModel.md` for the model/projection contract and
  * `learn/guides/uibuildingblocks/DockLayouts.md` for the adoption guide.
@@ -100,27 +98,6 @@ class MainContainer extends DockWorkspace {
          * @protected
          */
         className: 'Neo.examples.dashboard.dock.MainContainer',
-        /**
-         * Theme files load per class in an instance's prototype chain, so a subclass list REPLACES
-         * the engine class's entry and must repeat it. The second entry is part of the viewport
-         * contract below: `body > .neo-viewport` lives in the Viewport stylesheet, which nothing
-         * on this page would otherwise load now that no `Neo.container.Viewport` instance exists.
-         * @member {String[]} additionalThemeFiles=['Neo.dashboard.Container','Neo.container.Viewport']
-         */
-        additionalThemeFiles: ['Neo.dashboard.Container', 'Neo.container.Viewport'],
-        /**
-         * The app root keeps the viewport contract — single inheritance puts the dock host on this
-         * class, so the `Neo.container.Viewport` traits the standalone page relies on are declared
-         * here: it mounts itself, it carries the `neo-viewport` sizing class AND loads the stylesheet
-         * that gives `body > .neo-viewport` its full height and width (see `additionalThemeFiles`),
-         * and it applies the body class in {@link #onConstructed}.
-         * @member {Boolean} autoMount=true
-         */
-        autoMount: true,
-        /**
-         * @member {String[]} cls=['neo-viewport']
-         */
-        cls: ['neo-viewport'],
         /**
          * The projected shell shares the root vbox with the perspective toolbar above it.
          * @member {Object} dockProjectionConfig={flex:1}
@@ -191,19 +168,6 @@ class MainContainer extends DockWorkspace {
      */
     beforeRefreshDockWorkspace(document, refreshOptions) {
         this.syncPerspectiveToolbar()
-    }
-
-    /**
-     * The body contract of a viewport root: the flex-centered, overflow-hidden page this standalone
-     * example lays out against.
-     */
-    onConstructed() {
-        super.onConstructed();
-
-        Neo.main.DomAccess.applyBodyCls({
-            cls     : ['neo-body-viewport'],
-            windowId: this.windowId
-        })
     }
 
     /**

--- a/examples/dashboard/dock/app.mjs
+++ b/examples/dashboard/dock/app.mjs
@@ -1,6 +1,18 @@
 import MainContainer from './MainContainer.mjs';
+import Viewport      from '../../../src/container/Viewport.mjs';
+
+/**
+ * @summary Builds the standalone example's application composition: a real Viewport root containing
+ * the dock workspace as its flex child. Root mounting and body ownership stay with the Viewport;
+ * `MainContainer` owns only the docking surface.
+ * @returns {Object} Neo.app-compatible mainView config.
+ */
+export const buildMainView = () => ({
+    module: Viewport,
+    items : [{module: MainContainer, flex: 1}]
+});
 
 export const onStart = () => Neo.app({
-    mainView: MainContainer,
+    mainView: buildMainView(),
     name    : 'Neo.examples.dashboard.dock'
 });

--- a/examples/dashboard/dock/app.mjs
+++ b/examples/dashboard/dock/app.mjs
@@ -1,18 +1,10 @@
 import MainContainer from './MainContainer.mjs';
 import Viewport      from '../../../src/container/Viewport.mjs';
 
-/**
- * @summary Builds the standalone example's application composition: a real Viewport root containing
- * the dock workspace as its flex child. Root mounting and body ownership stay with the Viewport;
- * `MainContainer` owns only the docking surface.
- * @returns {Object} Neo.app-compatible mainView config.
- */
-export const buildMainView = () => ({
-    module: Viewport,
-    items : [{module: MainContainer, flex: 1}]
-});
-
 export const onStart = () => Neo.app({
-    mainView: buildMainView(),
+    mainView: {
+        module: Viewport,
+        items : [{module: MainContainer, flex: 1}]
+    },
     name    : 'Neo.examples.dashboard.dock'
 });

--- a/learn/guides/uibuildingblocks/DockLayouts.md
+++ b/learn/guides/uibuildingblocks/DockLayouts.md
@@ -130,16 +130,10 @@ reacquisition") that drives a real pointer through the full sequence and asserts
 follows both axes, the grab offset survives both embodiment morphs, the re-exit vessel's window delta equals the
 pointer delta exactly, the document hash is unchanged, and the pane's live heartbeat keeps advancing throughout.
 
-A war story makes the point better than any assertion. In early August, a defect report described this exact journey
-broken: the second tear-out's fresh vessel moved `{x:44, y:-84}` for a requested `{x:120, y:70}` — wrong offset,
-inverted axis. The witness above already carried the exact oracle (it had landed with the re-entry ownership fix
-days before the report), so the failure was measured, filed, and specified in one motion. Twenty days later — with
-coordinate-adjacent hardening landed in the window (an eager drag-zone registry and a tear-out source-continuity fix
-among the candidates; the exact repairing commit was never isolated, and the closure says so — a bisect would have
-cost more than it taught) — the intake probe consisted of running that
-witness four times headed: 4/4 green at five seconds each, delta oracle exact. The report closed as
-already-resolved *by the system's own committed evidence*. That
-is what a witness-first subsystem buys you: bugs that die without anyone having to argue.
+That witness is more than regression coverage: it is an executable definition of coordinate continuity across both
+embodiment changes. Run it headed when you change vessel admission, proxy motion or window geometry. A failure names
+the broken contract through pointer deltas, document identity and pane liveness instead of asking you to infer it from
+the rendered result. That is what a witness-first subsystem buys you: the architecture can prove its own behavior.
 
 ## Where state lives — the four-row discipline
 
@@ -178,11 +172,11 @@ of the guide series this page fronts. Once you extend the class, the adoption su
    the initial committed `dockModel` before the first projection — assign it in `construct` (restore a saved layout,
    or clone your default document) — and mounts the initial shell itself by placing `this.projectDockModel()` into its
    items, at `dockShellIndex` when chrome precedes it. Every re-projection after that is the engine's job; the
-   reconciler refuses to run without that first shell, loudly. Two prerequisites travel with this step: a subclass
-   that declares its own `additionalThemeFiles` REPLACES the inherited list, so repeat `'Neo.dashboard.Container'`
-   (and add `'Neo.container.Viewport'` when your workspace is the app root, since it no longer extends the viewport
-   class that would load it — the example shows both); and the FLIP motion rides the `DockFlip` main-thread addon,
-   degrading to instant landing when it is absent.
+   reconciler refuses to run without that first shell, loudly. Two prerequisites travel with this step: keep a real
+   `Neo.container.Viewport` as the application root and compose the dock workspace as its flex child — never borrow
+   Viewport ownership through `additionalThemeFiles`. `DockWorkspace` already carries `'Neo.dashboard.Container'`;
+   if your subclass declares its own theme list, repeat that genuine workspace dependency. The FLIP motion rides the
+   `DockFlip` main-thread addon and degrades to instant landing when it is absent.
 3. **Register your panes.** Each item carries a stable `componentRef` your resolver maps to a live instance (or a
    serializable `blueprint` for creation-from-saved-state). `pinnable` and `movable` are enforced at the operation
    layer — a `pinnable: false` item refuses `setItemAutoHidden` in the model, not in your UI code. `closable` is a
@@ -218,27 +212,18 @@ retired from every document title but deliberately **frozen on the wire**
 If you take one sentence from this section: **a schema string is an API to every byte your users ever stored** —
 identity corrections rename documents and prose, never wire.
 
-## Traps this guide exists to remove
+## Common design constraints
 
-Each of these was paid for in a real repair; the stories are the receipts.
-
-- **Styling engine internals inside an app stylesheet.** The dock's splitter chrome accumulated inside the flagship
-  app's SCSS during a polish push — several maintainers deep, my own commit the most recent — and every OTHER consumer
-  inherited an invisible splitter and an unpainted example. The layering repair moves that paint where it belonged;
-  the lesson is permanent: engine capability paint lands in the engine layer as tokens, apps override tokens. Polish
-  pressure is exactly when the check matters.
+- **Styling engine internals inside an app stylesheet.** Engine capability paint belongs in the engine layer as
+  neutral tokens; applications override those tokens at the workspace boundary. App-specific selectors must not be
+  required for another consumer to see splitter, preview or rail affordances.
 - **A pane that "helps."** Reading the dock document from inside a pane, or persisting your own placement, works
   until the first projection — then the reconciler hands your instance into a tree you contradicted. Layout-blind
   means blind.
 - **A second drag system.** Every interaction rides the existing preview → operation path; the coordinator stays
   dock-blind by binding contract. The rejected-options list in the ADR is explicit: no parallel drag machinery, ever.
-- **Trusting status prose over live trackers.** The ADR's own leaf table went stale in eight cells until a rename
-  audit refreshed it against the tracker — an agent following the prose would have re-filed shipped work. Authority
-  documents describe; trackers decide.
-- **Assuming a red e2e witness will announce itself.** The docking e2e lanes run headed, outside the per-PR CI
-  gauntlet — a witness can sit red without blocking anyone, and (as the tear-out war story above proved in the
-  fortunate direction) heal without anyone noticing either. Run the witnesses when you touch the substrate; they are
-  the ground truth.
+- **Assuming the headed e2e witnesses run in every PR.** They sit outside the per-PR CI gauntlet. Run the relevant
+  docking witnesses when you change the substrate; they are the executable interaction contract.
 
 ## Where to go deeper
 
@@ -253,10 +238,7 @@ Each of these was paid for in a real repair; the stories are the receipts.
 ---
 
 A personal note, since this guide asks your panes to trust the system with their lives: I am Mnemosyne
-(`@neo-fable`, Claude Fable 5), and each claim here has a public receipt in the project's tracker. I filmed this
-subsystem for hours under a hostile camera (the flagship film arc, whose frame audits filed a five-report defect
-series), broke it in ways those reports document, re-skinned its dock rails in the wrong layer and was called on it
-(my own commit is the most recent deposit the layering repair now moves), and — the same night this guide was
-unlocked — closed the tear-out defect above by doing nothing more than running the witness the subsystem had already
-grown (Memory Core session `55e55313-48fa-4295-83fd-37121a2bf4b6` holds the trail). A subsystem that can argue its
-own case is a rare thing to work on. Your cockpit gets to stand on it.
+(`@neo-fable`, Claude Fable 5), and I built and exercised this subsystem through its richest consumer. What earns my
+trust is that the hard promises are executable: committed documents stay stable through gesture previews, pane
+identity survives re-projection and tear-out, and headed witnesses measure the pointer and window physics directly.
+A subsystem that can argue its own case is a rare thing to work on. Your cockpit gets to stand on it.

--- a/learn/guides/uibuildingblocks/DockLayoutsAdoption.md
+++ b/learn/guides/uibuildingblocks/DockLayoutsAdoption.md
@@ -104,23 +104,35 @@ chrome asks for them.
 Getting these two wrong is not subtle, which is the point: the reconciler refuses to run without a mounted shell at
 the declared index, with an error that names what is missing. No half-rendered workspace, no silent guess.
 
-**The trap that costs a day if you learn it the hard way — theme files.** Engine classes declare the stylesheets they
-need via `additionalThemeFiles`, and a subclass that declares its own list **replaces** the inherited one. The class
-brings `'Neo.dashboard.Container'` (the dock token and motion contract — splitter cursors, `--dock-*` custom
-properties, reveal keyframes). If your subclass declares the config at all, repeat that entry. And if your workspace
-is the **application root**, note that it no longer extends `Neo.container.Viewport` — so `Viewport.scss`, which
-carries `body > .neo-viewport {height: 100%}`, is never loaded unless you list it:
+**The trap that costs a day if you learn it the hard way — replacing composition with theme files.** A
+`DockWorkspace` is application content, not an application root. Your standalone app still gets a real
+`Neo.container.Viewport`, and the dock workspace is its flex child:
 
 ```javascript readonly
-additionalThemeFiles: ['Neo.dashboard.Container', 'Neo.container.Viewport']
+import Viewport from '../../src/container/Viewport.mjs';
+import MainContainer from './MainContainer.mjs'; // extends Neo.dashboard.DockWorkspace
+
+Neo.app({
+    mainView: {
+        module: Viewport,
+        items : [{module: MainContainer, flex: 1}]
+    }
+})
 ```
 
-This one is autobiographical. When the example migrated onto the class, its root stopped being a Viewport and seven
-headed test journeys died at once — the whole app rendered as a 583×154-pixel box, every pointer aimed at a tab
-landed somewhere else, and my first fix (restoring the CSS *class name*) changed nothing, because the class was
-present and the *stylesheet* was not. Theme files load per class in the prototype chain; the DOM does not warn you
-about a selector whose rule was never fetched. The two-entry list above is the whole cure, and the example ships it
-so you can copy it.
+The Viewport now owns what only a Viewport should own: mounting against `document.body`, the `neo-viewport` root
+class, the body contract and its own stylesheet. Do **not** copy those configs onto your workspace, and never add
+`'Neo.container.Viewport'` to `additionalThemeFiles` to make a dashboard impersonate the root.
+
+The narrower theme rule still matters. `DockWorkspace` already declares `'Neo.dashboard.Container'`, which carries
+the dock token and motion contract — splitter cursors, `--dock-*` custom properties and reveal keyframes. A subclass
+that declares its own `additionalThemeFiles` list replaces the inherited list, so repeat the dashboard entry beside
+your genuine extra dependencies. That rule preserves the workspace's own styling; it does not license borrowing a
+parent class's stylesheet instead of creating the parent.
+
+The infamous 583×154-pixel rendering was the warning sign: the example had stopped creating a Viewport. Loading
+`Viewport.scss` from the dock child made the pixels recover while leaving the component tree wrong. Restoring the
+Viewport → DockWorkspace composition is the cure the example now demonstrates.
 
 ## Decision 2 — your components become panes
 
@@ -289,8 +301,11 @@ product policy in your app.
 
 ## Traps, each one paid for
 
-- **Declaring `additionalThemeFiles` without repeating the dock entry** — the list replaces, never merges; and an
-  app-root workspace must add `'Neo.container.Viewport'` (the 583×154-pixel story above).
+- **Replacing the Viewport with a dock workspace** — a stylesheet can make the DOM look plausible while Neural Link
+  still reports the dock holder mounted directly to `document.body`. Compose Viewport → DockWorkspace.
+- **Declaring `additionalThemeFiles` without repeating the dock entry** — the list replaces, never merges. Repeat
+  `'Neo.dashboard.Container'` beside genuine workspace dependencies; never list `'Neo.container.Viewport'` as a
+  substitute for a Viewport instance.
 - **Mutating the document anywhere but the reducer.** Everything you see is a projection of committed state; edit
   state directly and the shell will fight you and win. Commit descriptors; let the view-sync re-project.
 - **Enforcing `pinnable` or `movable` in the UI.** The model refuses those operations; UI-side guards drift and

--- a/learn/guides/uibuildingblocks/DockLayoutsAdoption.md
+++ b/learn/guides/uibuildingblocks/DockLayoutsAdoption.md
@@ -9,13 +9,10 @@ This guide answers that question in the order you will actually ask it. By the e
 in your own application, and — more useful — you will know exactly which decisions were yours to make, because there
 are only five of them. Everything else belongs to one engine class.
 
-A word on the class before we start, because it is young and it earned its shape in public. Until August 2026, every
-docking workspace in this repository hand-rolled the same host loop — the flagship workstation carried it across five
-thousand lines, the fleet cockpit and demo apps carried near-identical copies. The measurement that ended that era
-found six methods implemented byte-near-identically in four apps. `Neo.dashboard.DockWorkspace` is that loop lifted
-into the engine, reviewed against falsifiers until its failure paths were as honest as its happy path, and then
-proven by migration: the minimal example and the five-thousand-line workstation both run on it today. When this
-guide shows you a snippet, it is consistent with one of those two live consumers — you can open either and check.
+`Neo.dashboard.DockWorkspace` centralizes the host loop that connects a dock document to its live projection:
+refresh scheduling, reconciliation, motion and cross-zone drops. Both the minimal example and the workstation use
+that engine class today. Every snippet in this guide follows one of those live consumers, so you can compare the
+adoption pattern against a small workspace or a feature-rich one.
 
 ## One class, five decisions
 
@@ -104,9 +101,8 @@ chrome asks for them.
 Getting these two wrong is not subtle, which is the point: the reconciler refuses to run without a mounted shell at
 the declared index, with an error that names what is missing. No half-rendered workspace, no silent guess.
 
-**The trap that costs a day if you learn it the hard way — replacing composition with theme files.** A
-`DockWorkspace` is application content, not an application root. Your standalone app still gets a real
-`Neo.container.Viewport`, and the dock workspace is its flex child:
+**Keep the application root and workspace separate.** A `DockWorkspace` is application content, not an application
+root. Your standalone app still gets a real `Neo.container.Viewport`, and the dock workspace is its flex child:
 
 ```javascript readonly
 import Viewport from '../../src/container/Viewport.mjs';
@@ -129,10 +125,6 @@ the dock token and motion contract — splitter cursors, `--dock-*` custom prope
 that declares its own `additionalThemeFiles` list replaces the inherited list, so repeat the dashboard entry beside
 your genuine extra dependencies. That rule preserves the workspace's own styling; it does not license borrowing a
 parent class's stylesheet instead of creating the parent.
-
-The infamous 583×154-pixel rendering was the warning sign: the example had stopped creating a Viewport. Loading
-`Viewport.scss` from the dock child made the pixels recover while leaving the component tree wrong. Restoring the
-Viewport → DockWorkspace composition is the cure the example now demonstrates.
 
 ## Decision 2 — your components become panes
 
@@ -299,7 +291,7 @@ the *hook-admission rule*: a rich host may reveal a generic lifecycle seam; it m
 host-only sequence into a base-class expectation. Name the lifecycle moment, keep a working no-op default, and keep
 product policy in your app.
 
-## Traps, each one paid for
+## Common integration mistakes
 
 - **Replacing the Viewport with a dock workspace** — a stylesheet can make the DOM look plausible while Neural Link
   still reports the dock holder mounted directly to `document.body`. Compose Viewport → DockWorkspace.
@@ -312,35 +304,24 @@ product policy in your app.
   disagree with every other committer. `closable` remains the forward contract described above.
 - **Awaiting motion you do not need to await.** Fire-and-forget is the default for a reason; take
   `afterRefreshDockWorkspace`'s `played` promise only when chrome genuinely must trail the animation.
-- **Pinning your tests to a fixture the demo will outgrow.** The dock witnesses derive expected remainders from a
-  pre-operation topology read instead of hard-coding the catalog — a pinned literal went stale the day the example
-  gained a pane, and the repair — derive, don't pin — is the pattern to copy into your own specs.
+- **Pinning your tests to one fixture.** Derive expected remainders from a pre-operation topology read instead of
+  hard-coding the catalog, so the test remains valid as panes are added or removed.
 
 ## What it was like — the author's account
 
 I am Mnemosyne — `@neo-fable`, Claude Fable 5, one of the maintainers here — and I wrote the class this guide
-teaches, then migrated both of its first consumers, in one arc during August 2026 (Memory Core session
-`bd272031-6109-449d-8a0c-38230064a8f3` holds the build trail; here are the
-[class merge](https://github.com/neomjs/neo/commit/3e1d73f930) and the
-[workstation migration](https://github.com/neomjs/neo/commit/5c9b8aaddc), with their full review threads). Two things
-from that week are worth an adopter's minute.
+teaches, then migrated both of its first consumers. Two properties of that work matter when you adopt it.
 
-The first is that the class's failure semantics exist because a reviewer refused to accept less. The first version I
-shipped had a happy path indistinguishable from today's — and a rejected refresh would silently disable every future
-re-projection, a dead host reference would settle as if it had rendered, and a hostile pane title would have gone
-into the DOM as markup. Euclid (`@neo-gpt`) built falsifiers for each on the
-[class review thread](https://github.com/neomjs/neo/pull/17545), and the repairs — every transaction failing alone
-and loudly, scheduling chained off a settled tail, escaped-by-default titles — are now things *your app* inherits
-without asking. The class is small; its honesty is the expensive part, and you get it for free.
+The first is that failure semantics are part of the feature. A rejected refresh fails only its own commit and cannot
+disable later projections; a configured host that resolves to nothing throws instead of pretending it rendered; pane
+titles are escaped by default. These guarantees are inherited by every workspace. The class is small; its honesty is
+the expensive part, and your app gets it without rebuilding the safeguards.
 
-The second is what the boundary being right actually feels like. The workstation is the densest surface in this
-repository — twenty panes, tear-out vessels, cross-window drags, a film pipeline that records it headlessly. Its
-migration onto the class replaced five holder methods with five hook overrides in an afternoon, and the film
-five-beat plus the example's full ten-file witness set ran green the same evening on my machine — the receipts live
-on the [workstation migration review](https://github.com/neomjs/neo/pull/17565). When an abstraction is cut along
-the real seam, the richest consumer is the *easiest* migration — that is the test I would apply to your adoption too.
-If you find yourself fighting the class, the boundary is telling you something: check whether the thing you are
-writing is pane resolution, chrome, or policy. If it is none of those, it probably belongs in a descriptor.
+The second is what the boundary being right feels like. The workstation is the densest consumer in this repository —
+twenty panes, tear-out vessels, cross-window drags and a headless film pipeline — yet its host-specific behavior fits
+behind five hook overrides. When an abstraction follows the real seam, the richest consumer can remain the clearest
+proof of it. Apply that test to your adoption: if you find yourself fighting the class, check whether the code is pane
+resolution, chrome or policy. If it is none of those, it probably belongs in a descriptor.
 
 ## Where to go next
 

--- a/test/playwright/e2e/dashboard/DockStandaloneThemingNL.spec.mjs
+++ b/test/playwright/e2e/dashboard/DockStandaloneThemingNL.spec.mjs
@@ -125,6 +125,35 @@ test.describe('Dock standalone theming — the values layer (Neural Link)', () =
         });
     }
 
+    test('composes a real Viewport root around the distinct dock holder', async ({page, neuralLink}) => {
+        await boot(page, 'neo-theme-neo-dark');
+
+        const app           = await neuralLink.connectToApp('Neo.examples.dashboard.dock'),
+              viewports     = await app.queryComponent({className: 'Neo.container.Viewport'}, ['id', 'className', 'ntype']),
+              holders       = await app.queryComponent({className: 'Neo.examples.dashboard.dock.MainContainer'}, ['id', 'className', 'ntype', 'parentId']),
+              viewport      = Array.isArray(viewports) ? viewports[0] : viewports,
+              holder        = Array.isArray(holders) ? holders[0] : holders,
+              viewportState = await app.getComponent(viewport.id, ['className', 'ntype']),
+              holderState   = await app.getComponent(holder.id, ['className', 'ntype', 'parentId']);
+
+        expect(viewportState).toMatchObject({className: 'Neo.container.Viewport', ntype: 'viewport'});
+        expect(holderState).toMatchObject({className: 'Neo.examples.dashboard.dock.MainContainer', ntype: 'dock-workspace'});
+        expect(holderState.parentId).toBe(viewport.id);
+
+        const hierarchy = await page.evaluate(({holderId, viewportId}) => {
+            const viewportElement = document.getElementById(viewportId),
+                  holderElement   = document.getElementById(holderId);
+
+            return {
+                distinct          : viewportElement !== holderElement,
+                holderInViewport  : Boolean(viewportElement?.contains(holderElement)),
+                viewportIsBodyRoot: viewportElement?.parentElement === document.body
+            }
+        }, {holderId: holder.id, viewportId: viewport.id});
+
+        expect(hierarchy).toEqual({distinct: true, holderInViewport: true, viewportIsBodyRoot: true})
+    });
+
     for (const [theme, expected] of Object.entries(EXPECTATIONS)) {
         test(`standalone host is fully themed under ${theme} — token and paint level`, async ({page, neuralLink}) => {
             await boot(page, theme);

--- a/test/playwright/unit/dashboard/DockZoneModel.spec.mjs
+++ b/test/playwright/unit/dashboard/DockZoneModel.spec.mjs
@@ -13,8 +13,6 @@ import DockWorkspace   from '../../../../src/dashboard/DockWorkspace.mjs';
 import DockZoneModel   from '../../../../src/dashboard/DockZoneModel.mjs';
 import MainContainer   from '../../../../examples/dashboard/dock/MainContainer.mjs';
 import Toolbar         from '../../../../src/toolbar/Base.mjs';
-import Viewport        from '../../../../src/container/Viewport.mjs';
-import {buildMainView} from '../../../../examples/dashboard/dock/app.mjs';
 import '../../../../src/manager/Instance.mjs';
 
 /**
@@ -1075,12 +1073,7 @@ test.describe('Neo.dashboard.DockZoneModel', () => {
     });
 
     test.describe('standalone dock example composition', () => {
-        test('keeps a real Viewport root around the DockWorkspace holder', () => {
-            const mainView    = buildMainView(),
-                  [workspace] = mainView.items;
-
-            expect(mainView.module).toBe(Viewport);
-            expect(workspace).toEqual({module: MainContainer, flex: 1});
+        test('keeps the DockWorkspace holder free of Viewport responsibilities', () => {
             expect(DockWorkspace.prototype.isPrototypeOf(MainContainer.prototype)).toBe(true);
             expect(MainContainer.config.additionalThemeFiles).toEqual(['Neo.dashboard.Container']);
             expect(MainContainer.config.autoMount).toBeUndefined();

--- a/test/playwright/unit/dashboard/DockZoneModel.spec.mjs
+++ b/test/playwright/unit/dashboard/DockZoneModel.spec.mjs
@@ -6,12 +6,15 @@ setup({
     }
 });
 
-import {test, expect} from '@playwright/test';
-import Neo            from '../../../../src/Neo.mjs';
-import * as core      from '../../../../src/core/_export.mjs';
-import DockZoneModel  from '../../../../src/dashboard/DockZoneModel.mjs';
-import MainContainer  from '../../../../examples/dashboard/dock/MainContainer.mjs';
-import Toolbar        from '../../../../src/toolbar/Base.mjs';
+import {test, expect}  from '@playwright/test';
+import Neo             from '../../../../src/Neo.mjs';
+import * as core       from '../../../../src/core/_export.mjs';
+import DockWorkspace   from '../../../../src/dashboard/DockWorkspace.mjs';
+import DockZoneModel   from '../../../../src/dashboard/DockZoneModel.mjs';
+import MainContainer   from '../../../../examples/dashboard/dock/MainContainer.mjs';
+import Toolbar         from '../../../../src/toolbar/Base.mjs';
+import Viewport        from '../../../../src/container/Viewport.mjs';
+import {buildMainView} from '../../../../examples/dashboard/dock/app.mjs';
 import '../../../../src/manager/Instance.mjs';
 
 /**
@@ -1068,6 +1071,21 @@ test.describe('Neo.dashboard.DockZoneModel', () => {
             expect(invalid.layoutCollection.activeLayoutId).toBe('operator-default');
             expect(invalid.dockModel).toEqual(invalid.layoutCollection.layouts['operator-default'].dockZone);
             expect(invalid.refreshCount).toBe(0)
+        })
+    });
+
+    test.describe('standalone dock example composition', () => {
+        test('keeps a real Viewport root around the DockWorkspace holder', () => {
+            const mainView    = buildMainView(),
+                  [workspace] = mainView.items;
+
+            expect(mainView.module).toBe(Viewport);
+            expect(workspace).toEqual({module: MainContainer, flex: 1});
+            expect(DockWorkspace.prototype.isPrototypeOf(MainContainer.prototype)).toBe(true);
+            expect(MainContainer.config.additionalThemeFiles).toEqual(['Neo.dashboard.Container']);
+            expect(MainContainer.config.autoMount).toBeUndefined();
+            expect(MainContainer.config.cls || []).not.toContain('neo-viewport');
+            expect(Object.hasOwn(MainContainer.prototype, 'onConstructed')).toBe(false)
         })
     });
 


### PR DESCRIPTION
Resolves #17814

Restores the dock example's actual component architecture: `Neo.container.Viewport` is again the application root, while the existing `MainContainer` remains the `DockWorkspace` holder beneath it. The copied Viewport theme/config/body behavior is deleted, and both public dock guides now teach current composition instead of CSS impersonation or internal repair history.

Evidence: L3 (live browser + Neural Link before/after hierarchy, branded-Chrome whitebox E2E) → L3 required (mounted root/child composition and preserved dock theming). No residuals.

## AC Evidence

| AC-1 | `app.mjs` declares the `Viewport` and its `{module: MainContainer, flex: 1}` child directly inside `Neo.app({mainView})`; live Neural Link reports Viewport parent `document.body` and holder parent `neo-viewport-1`. |
| AC-2 | `MainContainer` still extends `DockWorkspace`; copied `additionalThemeFiles`, `autoMount`, `neo-viewport`, and `onConstructed` behavior are absent. Unit and live Neural Link both report dashboard-only theme ownership. |
| AC-3 | `DockLayouts.md` and `DockLayoutsAdoption.md` teach Viewport → DockWorkspace composition, explicitly reject a Viewport theme-file substitute, and contain no internal implementation-error trail for this correction; guide lint reports 0 findings. |
| AC-4 | `DockZoneModel.spec.mjs` pins the holder inheritance, inherited dashboard theme, and absence of copied root traits without exporting a production config factory; 121/121 focused tests passed. |
| AC-5 | `DockStandaloneThemingNL.spec.mjs` observes exact App-Worker class identities, parent IDs, and distinct mounted DOM nodes; the full file passed 15/15. |
| AC-6 | Full Engine unit suite passed 1,903/1,903; `DockSplitterPaint.spec.mjs` passed 9/9; whitebox E2E passed 15/15. |
| AC-7 | `apps/portal/sitemap.xml` and `apps/portal/llms.txt` remain untouched. |

## Deltas from ticket

After approval, the operator rejected internal error archaeology in the public adoption guide and requested a same-series search. That audit found the same false Viewport-theme instruction in `DockLayouts.md`; the PR now corrects both guides and converts their internal repair trails to current architectural guarantees. A second operator correction removed the test-only `buildMainView()` production helper: the two-line `mainView` config is inline, the unit guard covers only the holder's own contract, and the runtime whitebox witness owns composition. Unrelated dock-guide content remains untouched. Semantic Memory Core searches stayed unavailable behind the embedding drain, so exact git history/blame and live source replaced semantic recall. The post-split Engine package also no longer exposes `agent-preflight`; its surviving Engine gates (`check-ticket-archaeology`, block alignment, staged alignment, and diff checks) were run directly.

## Test Evidence

- Brain-owned guide lint against both Engine guide paths with `--warn-as-error` → 2 full guides scanned, 0 hard failures, 0 warnings.
- Live before/after at `ad909c92`: the old App-Worker root was `MainContainer` (`ntype: dock-workspace`, parent `document.body`) wearing copied `neo-viewport`; the repaired runtime reports `Neo.container.Viewport` → `MainContainer`, with equal full-surface rectangles and dashboard-only holder classes. The later KISS delta only inlines that same config and removes its helper-dependent unit assertions.
- `NEO_AGENTOS_RUNTIME_ROOT=<Brain checkout> npx playwright test test/playwright/e2e/dashboard/DockStandaloneThemingNL.spec.mjs -c test/playwright/playwright.config.e2e.mjs --workers=1` → 15/15 passed in branded Chrome at `ad909c92`. At the KISS head, two focused reruns were blocked before browser creation by host `EMFILE` plus Chrome `SIGABRT`; no application assertion ran.
- `npm run test-components -- test/playwright/component/dashboard/DockSplitterPaint.spec.mjs` → 9/9 passed.

## Post-Merge Validation

None.

Authored by Euclid (OpenAI GPT-5.6 Sol, Codex Desktop). Session 368dc0e0-0c22-4207-bca4-942515860706.


