### PR TITLE
fix(main): honor point alignment targets and offsets (#17824)

### DIFF
--- a/src/component/Base.mjs
+++ b/src/component/Base.mjs
@@ -68,8 +68,10 @@ class Component extends Abstract {
          */
         ntype: 'component',
         /**
-         * The default alignment specification to position this Component relative to some other
-         * Component, or Element or Rectangle. Only applies in case floating = true.
+         * The default alignment specification to position this Component relative to another
+         * Component/Element id, or to a JSON-safe viewport Rectangle `{x,y,width,height}`. A zero-size
+         * Rectangle is a point target (for example a context-menu pointer coordinate). Live DOM objects
+         * never cross the worker boundary. Only applies in case floating = true.
          * @member {Object|String} align_={[isDescriptor]: true, merge: 'deep', value: {edgeAlign: 't-b',constrainTo: 'document.body'}}
          * @reactive
          */

--- a/src/main/DomAccess.mjs
+++ b/src/main/DomAccess.mjs
@@ -33,7 +33,14 @@ const
         Alt    : 1,
         Meta   : 1,
         Control: 1
-    };
+    },
+    /**
+     * @summary Identifies the JSON-safe viewport Rectangle accepted by floating alignment.
+     * @param {*} value
+     * @returns {Boolean}
+     */
+    isSerializedRectangle = value => Boolean(value) && !value.nodeType &&
+        ['x', 'y', 'width', 'height'].every(key => Number.isFinite(value[key]));
 
 /**
  * @class Neo.main.DomAccess
@@ -134,22 +141,25 @@ class DomAccess extends Base {
      */
     addAligned(alignSpec) {
         const
-            me                   = this,
-            {id}                 = alignSpec,
-            aligns               = me._aligns || (me._aligns = new Map()),
-            resizeObserver       = me._alignResizeObserver || (me._alignResizeObserver = new ResizeObserver(me.syncAligns)),
-            {constrainToElement} = alignSpec;
+            me                                           = this,
+            {id}                                         = alignSpec,
+            aligns                                       = me._aligns || (me._aligns = new Map()),
+            resizeObserver                               = me._alignResizeObserver || (me._alignResizeObserver = new ResizeObserver(me.syncAligns)),
+            {constrainToElement, subject, targetElement} = alignSpec;
 
         // Set up listeners which monitor for changes
         if (!aligns.has(id)) {
+            // The subject size participates in every alignment, including coordinate targets.
+            resizeObserver.observe(subject);
+
             // Realign when the target's layout-controlling element changes size. `align()` stores
             // `alignSpec.offsetParent = targetElement.offsetParent` — the TARGET's layout parent, which is
             // null when the target is position:fixed (or the body/root). Guard against observing null —
             // `ResizeObserver.observe(null)` throws "parameter 1 is not of type 'Element'".
             alignSpec.offsetParent && resizeObserver.observe(alignSpec.offsetParent);
 
-            // Realign when align to target changes size
-            resizeObserver.observe(alignSpec.targetElement);
+            // Element targets can resize. Serialized viewport Rectangles have no physical node to observe.
+            targetElement && resizeObserver.observe(targetElement);
 
             // Realign when constraining element changes size
             if (constrainToElement) {
@@ -211,17 +221,23 @@ class DomAccess extends Base {
     }
 
     /**
+     * @summary Aligns a physical subject to either an element or serialized viewport Rectangle.
      * @param {Object} data
+     * @param {String} data.id
+     * @param {String|HTMLElement|{x:Number,y:Number,width:Number,height:Number}} [data.target]
+     * @param {String|HTMLElement} [data.constrainTo]
      * @returns {Promise<void>}
      */
     async align(data) {
         const
-            me            = this,
-            {constrainTo} = data,
-            subject       = data.subject = me.getElement(data.id),
-            {style}       = subject,
-            align         = {...data},
-            lastAlign     = me._aligns?.get(data.id);
+            me             = this,
+            {constrainTo}  = data,
+            subject        = data.subject = me.getElement(data.id),
+            {style}        = subject,
+            align          = {...data},
+            lastAlign      = me._aligns?.get(data.id),
+            targetIsObject = typeof data.target === 'object' && !data.target?.nodeType,
+            targetIsRect   = isSerializedRectangle(data.target);
 
         if (lastAlign) {
             subject.classList.remove(`neo-aligned-${lastAlign.result.position}`)
@@ -231,15 +247,23 @@ class DomAccess extends Base {
         // by a previous align call.
         me.resetDimensions(align);
 
-        // The Rectangle's align spec target and constrainTo must be Rectangles
-        align.target = me.getClippedRect({id : data.targetElement = me.getElementOrBody(data.target)});
+        data.targetElement = targetIsObject ? null : me.getElementOrBody(data.target);
+        data.targetRect    = targetIsRect ? new Rectangle(
+            data.target.x,
+            data.target.y,
+            data.target.width,
+            data.target.height
+        ) : null;
+
+        // Rectangle targets are already viewport geometry; element targets retain clipping semantics.
+        align.target = data.targetRect || (data.targetElement && me.getClippedRect({id: data.targetElement}));
 
         if (!align.target) {
             // Set the Component with id data.id to hidden : true
             return Neo.worker.App.setConfigs({id: data.id, hidden: true})
         }
 
-        data.offsetParent = data.targetElement.offsetParent;
+        data.offsetParent = data.targetElement?.offsetParent || null;
 
         if (constrainTo) {
             align.constrainTo = me.getBoundingClientRect({id : data.constrainToElement = me.getElementOrBody(constrainTo)})
@@ -1217,7 +1241,9 @@ class DomAccess extends Base {
 
         // Keep all registered aligns aligned on any detected change
         _aligns?.forEach(align => {
-            const targetPresent = document.contains(align.targetElement);
+            const
+                {targetElement} = align,
+                targetPresent   = targetElement ? document.contains(targetElement) : Boolean(align.targetRect);
 
             // Align subject and target still in the DOM - correct its alignment
             if (document.contains(align.subject) && targetPresent) {
@@ -1225,7 +1251,8 @@ class DomAccess extends Base {
                 if (isScroll && !isDocScroll) {
                     // If the scrolling element does NOT contain the reference target,
                     // then the reference target did not move relative to viewport.
-                    const targetMoved = evtTarget.contains(align.targetElement) || (align.constrainToElement && evtTarget.contains(align.constrainToElement));
+                    const targetMoved = (targetElement && evtTarget.contains(targetElement)) ||
+                        (align.constrainToElement && evtTarget.contains(align.constrainToElement));
 
                     if (!targetMoved) {
                         return // Skip this alignment
@@ -1237,7 +1264,7 @@ class DomAccess extends Base {
             // Align subject or target no longer in the DOM - remove it.
             else {
                 // If target is no longer in the DOM, hide the subject component
-                if (!targetPresent) {
+                if (targetElement && !targetPresent) {
                     Neo.worker.App.setConfigs({ id: align.id, hidden: true })
                 }
 
@@ -1250,7 +1277,7 @@ class DomAccess extends Base {
                 // and unobserve(null) throws just like observe(null).
                 _alignResizeObserver.unobserve(align.subject);
                 align.offsetParent && _alignResizeObserver.unobserve(align.offsetParent);
-                _alignResizeObserver.unobserve(align.targetElement);
+                targetElement && _alignResizeObserver.unobserve(targetElement);
                 if (constrainToElement) {
                     _alignResizeObserver.unobserve(constrainToElement)
                 }

--- a/src/util/Rectangle.mjs
+++ b/src/util/Rectangle.mjs
@@ -29,13 +29,13 @@ const
             theirEdgeZone = edgeZone[edgeParts[4]];
 
         return {
-            ourEdge         : edgeParts[1],
-            ourEdgeOffset   : parseInt(edgeParts[2] || 50),
-            ourEdgeUnit     : edgeParts[3] || '%',
+            ourEdge        : edgeParts[1],
+            ourEdgeOffset  : parseInt(edgeParts[2] || 50),
+            ourEdgeUnit    : edgeParts[3] || '%',
             ourEdgeZone,
-            theirEdge       : edgeParts[4],
-            theirEdgeOffset : parseInt(edgeParts[5] || 50),
-            theirEdgeUnit   : edgeParts[6] || '%',
+            theirEdge      : edgeParts[4],
+            theirEdgeOffset: parseInt(edgeParts[5] || 50),
+            theirEdgeUnit  : edgeParts[6] || '%',
             theirEdgeZone,
 
             // Aligned to an edge, *outside* of the target.
@@ -59,17 +59,42 @@ const
         // Convert DOMRect into Rectangle
         return r && new Rectangle(r.x, r.y, r.width, r.height);
     },
+    /**
+     * @summary Applies the documented final offset while preserving alignment metadata.
+     *
+     * `moveBy()` is intentionally immutable and its clone carries geometric minima only. Alignment
+     * consumers also need the resolved zone/position, so the finishing step transfers those two
+     * semantic fields onto the moved clone. Every successful `alignTo()` return passes through this
+     * helper; otherwise constrained and overlap returns silently skip the same public option.
+     * @param {Rectangle} result
+     * @param {Number[]|undefined} offset
+     * @returns {Rectangle}
+     */
+    finishAlignResult = (result, offset) => {
+        if (!offset) {
+            return result
+        }
+
+        const
+            {position, zone} = result,
+            moved            = result.moveBy(offset);
+
+        moved.position = position;
+        moved.zone     = zone;
+
+        return moved
+    },
     oppositeEdge = {
-        t : 'b',
-        r : 'l',
-        b : 't',
-        l : 'r'
+        t: 'b',
+        r: 'l',
+        b: 't',
+        l: 'r'
     },
     edgeZone = {
-        t : 0,
-        r : 1,
-        b : 2,
-        l : 3
+        t: 0,
+        r: 1,
+        b: 2,
+        l: 3
     },
     zoneNames = ['top', 'right', 'bottom', 'left'],
     zoneEdges = ['t', 'r', 'b', 'l'],
@@ -351,6 +376,18 @@ export default class Rectangle extends DOMRect {
         return result;
     }
 
+    /**
+     * @summary Returns an immutable Rectangle aligned to a target, optionally constrained and offset.
+     * @param {Object} align
+     * @param {Boolean|String} [align.axisLock]
+     * @param {DOMRect|HTMLElement|Rectangle|String} [align.constrainTo]
+     * @param {String} align.edgeAlign
+     * @param {Boolean} [align.matchSize]
+     * @param {Number[]} [align.offset] Final `[x, y]` vector applied after alignment/constraint.
+     * @param {DOMRect|HTMLElement|Rectangle|String} align.target
+     * @param {Number|Number[]} [align.targetMargin]
+     * @returns {Rectangle}
+     */
     alignTo(align) {
         const
             me             = this,
@@ -418,7 +455,7 @@ export default class Rectangle extends DOMRect {
             // They asked to overlap the target, for example t0-t0
             // In these cases, we just return the result
             if (targetRect.intersects(result)) {
-                return result;
+                return finishAlignResult(result, offset);
             }
 
             // This is the zone we try to fit into first, the one that was asked for
@@ -437,26 +474,26 @@ export default class Rectangle extends DOMRect {
                 // so r20-l30 has to become l20-r30.
                 // The other two zones revert to centered so are easier
                 zonesToTry[1] = {
-                    zone      : zone = (zone + 2) % 4,
-                    edgeAlign : createReversedEdgeAlign(edges)
+                    zone     : zone = (zone + 2) % 4,
+                    edgeAlign: createReversedEdgeAlign(edges)
                 }
 
                 // Fall back to the other two zones.
                 zonesToTry.push({
-                    zone      : zone = (edges.theirEdgeZone + 1) % 4,
-                    edgeAlign : `${oppositeEdge[zoneEdges[zone]]}-${zoneEdges[zone]}`
+                    zone     : zone = (edges.theirEdgeZone + 1) % 4,
+                    edgeAlign: `${oppositeEdge[zoneEdges[zone]]}-${zoneEdges[zone]}`
                 });
                 zonesToTry.push({
-                    zone      : zone = (edges.theirEdgeZone + 3) % 4,
-                    edgeAlign : `${oppositeEdge[zoneEdges[zone]]}-${zoneEdges[zone]}`
+                    zone     : zone = (edges.theirEdgeZone + 3) % 4,
+                    edgeAlign: `${oppositeEdge[zoneEdges[zone]]}-${zoneEdges[zone]}`
                 });
             }
             else {
                 // go through the other zones in order
                 for (let i = 1; i < 4; i++) {
                     zonesToTry.push({
-                        zone      : zone = (zone + 1) % 4,
-                        edgeAlign : `${oppositeEdge[zoneEdges[zone]]}-${zoneEdges[zone]}`
+                        zone     : zone = (zone + 1) % 4,
+                        edgeAlign: `${oppositeEdge[zoneEdges[zone]]}-${zoneEdges[zone]}`
                     });
                 }
             }
@@ -517,17 +554,12 @@ export default class Rectangle extends DOMRect {
                 if (solution) {
                     solution.zone = zone;
                     solution.position = zoneNames[zone];
-                    return solution;
+                    return finishAlignResult(solution, offset);
                 }
             }
         }
 
-        // Add the configurable finishing touch.
-        if (offset) {
-            result.moveBy(offset);
-        }
-
-        return result;
+        return finishAlignResult(result, offset);
     }
 
     getAnchorPoint(edgeZone, edgeOffset, edgeUnit, margin = emptyArray) {

--- a/test/playwright/unit/main/DomAccessAlign.spec.mjs
+++ b/test/playwright/unit/main/DomAccessAlign.spec.mjs
@@ -1,0 +1,247 @@
+import {setup} from '../../setup.mjs';
+
+const appName = 'DomAccessAlignTest';
+
+import {test, expect} from '@playwright/test';
+import Neo            from '../../../../src/Neo.mjs';
+import * as core      from '../../../../src/core/_export.mjs';
+
+const
+    classSet    = new Set(),
+    observed    = [],
+    unobserved  = [],
+    hiddenCalls = [],
+    elements    = new Map();
+
+const defaultView = {
+    getComputedStyle() {
+        return {
+            getPropertyValue() {
+                return '0px'
+            }
+        }
+    }
+};
+
+function createElement(id, {height, width, x, y}, offsetParent=null) {
+    return {
+        id,
+        connected    : true,
+        nodeType     : 1,
+        offsetParent,
+        parentElement: null,
+        style        : {},
+        classList    : {
+            add(value) {
+                classSet.add(value)
+            },
+            remove(value) {
+                classSet.delete(value)
+            }
+        },
+        getBoundingClientRect() {
+            return new DOMRect(x, y, width, height)
+        }
+    }
+}
+
+const
+    body    = createElement('body',    {height: 400, width: 500, x: 0,   y: 0}),
+    subject = createElement('subject', {height: 80,  width: 100, x: 0,   y: 0}),
+    target  = createElement('target',  {height: 50,  width: 50,  x: 200, y: 100});
+
+globalThis.document = {
+    body,
+    documentElement: {id: 'document-element'},
+    addEventListener() {},
+    contains(node) {
+        return Boolean(node?.connected)
+    },
+    getElementById(id) {
+        return elements.get(id) || null
+    },
+    querySelector(selector) {
+        return elements.get(selector.match(/'([^']+)'/)?.[1]) || null
+    }
+};
+
+body.ownerDocument = subject.ownerDocument = target.ownerDocument = {
+    defaultView
+};
+
+elements.set('body', body);
+elements.set('subject', subject);
+elements.set('target', target);
+
+globalThis.ResizeObserver = class ResizeObserver {
+    constructor(callback) {
+        this.callback = callback
+    }
+
+    observe(node) {
+        if (!node) {
+            throw new TypeError('ResizeObserver.observe target is required')
+        }
+
+        observed.push(node.id)
+    }
+
+    unobserve(node) {
+        if (!node) {
+            throw new TypeError('ResizeObserver.unobserve target is required')
+        }
+
+        unobserved.push(node.id)
+    }
+};
+
+globalThis.MutationObserver = class MutationObserver {
+    constructor(callback) {
+        this.callback = callback
+    }
+
+    observe() {}
+};
+
+// A previously-run spec may leave setup()'s plain DomAccess mock in this reused worker. Remove only
+// that mock before loading the production singleton; an already-registered real singleton is retained.
+if (Neo.main?.DomAccess && Neo.main.DomAccess.className !== 'Neo.main.DomAccess') {
+    delete Neo.main.DomAccess
+}
+
+const {default: DomAccess} = await import('../../../../src/main/DomAccess.mjs');
+
+setup({
+    appConfig: {
+        name: appName
+    },
+    neoConfig: {
+        unitTestMode: true,
+        useDomIds   : true
+    }
+});
+
+Neo.worker.App.setConfigs = data => {
+    hiddenCalls.push(data)
+};
+
+/**
+ * @summary Aligns the shared subject with the complete component-originated dimension envelope.
+ * @param {Object} [config]
+ * @returns {Promise<void>}
+ */
+function alignSubject(config={}) {
+    return DomAccess.align({
+        id                 : 'subject',
+        edgeAlign          : 't0-b0',
+        configuredFlex     : null,
+        configuredHeight   : null,
+        configuredMaxHeight: null,
+        configuredMaxWidth : null,
+        configuredMinHeight: null,
+        configuredMinWidth : null,
+        configuredWidth    : null,
+        ...config
+    })
+}
+
+test.beforeEach(() => {
+    classSet.clear();
+    observed.length = 0;
+    unobserved.length = 0;
+    hiddenCalls.length = 0;
+    body.connected = subject.connected = target.connected = true;
+    DomAccess._aligns?.clear()
+});
+
+test.describe('Neo.main.DomAccess alignment targets', () => {
+    test('aligns to serialized viewport geometry and observes only real elements', async () => {
+        await alignSubject({
+            axisLock   : true,
+            constrainTo: 'body',
+            target     : {x: 450, y: 380, width: 0, height: 0}
+        });
+
+        expect(subject.style.transform).toBe('translate(400px,300px)');
+        expect(classSet.has('neo-aligned-top')).toBe(true);
+        expect(new Set(observed)).toEqual(new Set(['subject', 'body']));
+        expect(DomAccess._aligns.get('subject').targetElement).toBe(null)
+    });
+
+    test('preserves element-backed target alignment and observation', async () => {
+        await alignSubject({
+            constrainTo: 'body',
+            target     : 'target'
+        });
+
+        expect(subject.style.transform).toBe('translate(200px,150px)');
+        expect(new Set(observed)).toEqual(new Set(['subject', 'target', 'body']));
+        expect(DomAccess._aligns.get('subject').targetElement).toBe(target)
+    });
+
+    test('keeps point-target subjects inside every viewport edge', async () => {
+        const cases = [{
+            point   : {x: 250, y: 200, width: 0, height: 0},
+            expected: 'translate(250px,200px)',
+            position: 'bottom'
+        }, {
+            point   : {x: 450, y: 380, width: 0, height: 0},
+            expected: 'translate(400px,300px)',
+            position: 'top'
+        }, {
+            point   : {x: 10, y: 380, width: 0, height: 0},
+            expected: 'translate(10px,300px)',
+            position: 'top'
+        }, {
+            point   : {x: 490, y: 10, width: 0, height: 0},
+            expected: 'translate(400px,10px)',
+            position: 'bottom'
+        }, {
+            point   : {x: 10, y: 10, width: 0, height: 0},
+            expected: 'translate(10px,10px)',
+            position: 'bottom'
+        }];
+
+        for (const {expected, point, position} of cases) {
+            await alignSubject({
+                axisLock   : true,
+                constrainTo: 'body',
+                target     : point
+            });
+
+            expect(subject.style.transform).toBe(expected);
+            expect(classSet.has(`neo-aligned-${position}`)).toBe(true)
+        }
+    });
+
+    test('cleans a coordinate-target alignment without hiding or unobserving null', async () => {
+        await alignSubject({
+            constrainTo: 'body',
+            target     : {x: 250, y: 200, width: 0, height: 0}
+        });
+
+        subject.connected = false;
+        DomAccess.syncAligns();
+
+        expect(hiddenCalls).toEqual([]);
+        expect(new Set(unobserved)).toEqual(new Set(['subject', 'body']));
+        expect(DomAccess._aligns.has('subject')).toBe(false)
+    });
+
+    test('keeps the existing missing-element target failure posture', async () => {
+        await alignSubject({target: 'target'});
+
+        target.connected = false;
+        DomAccess.syncAligns();
+
+        expect(hiddenCalls).toEqual([{id: 'subject', hidden: true}]);
+        expect(DomAccess._aligns.has('subject')).toBe(false)
+    });
+
+    test('rejects malformed serialized geometry through the hidden-target posture', async () => {
+        await alignSubject({target: {x: 10, y: 20}});
+
+        expect(hiddenCalls).toEqual([{id: 'subject', hidden: true}]);
+        expect(DomAccess._aligns?.has('subject') || false).toBe(false)
+    })
+});

--- a/test/playwright/unit/util/Rectangle.spec.mjs
+++ b/test/playwright/unit/util/Rectangle.spec.mjs
@@ -62,7 +62,7 @@ test.describe('Rectangle', () => {
 
         test('Should constrain non-fitting subject rectangle when minima allow', () => {
             const constrainTo = new Rectangle(0, 0, 200, 200);
-            const subject = new Rectangle(1000, 1000, 210, 210);
+            const subject     = new Rectangle(1000, 1000, 210, 210);
 
             // Subject Rectangle is willing to shrink to 200x200
             subject.minWidth = subject.minHeight = 200;
@@ -123,6 +123,49 @@ test.describe('Rectangle', () => {
     });
 
     test.describe('alignTo', () => {
+        test('applies the final offset without mutating the source Rectangle', () => {
+            const
+                subject = new Rectangle(0, 0, 50, 50),
+                result  = subject.alignTo({
+                    target   : new Rectangle(100, 100, 100, 100),
+                    edgeAlign: 't0-b0',
+                    offset   : [12, 34]
+                });
+
+            expect(result.equals(new Rectangle(112, 234, 50, 50))).toBe(true);
+            expect(result.position).toBe('bottom');
+            expect(subject.equals(new Rectangle(0, 0, 50, 50))).toBe(true)
+        });
+
+        test('applies the final offset to an overlapping early-return result', () => {
+            const result = new Rectangle(0, 0, 100, 100).alignTo({
+                target     : new Rectangle(100, 100, 50, 50),
+                constrainTo: new Rectangle(0, 0, 150, 150),
+                edgeAlign  : 't0-t0',
+                offset     : [5, 7]
+            });
+
+            expect(result.equals(new Rectangle(105, 107, 100, 100))).toBe(true);
+            expect(result.position).toBe('top')
+        });
+
+        test('applies the final offset to a constrained solution', () => {
+            const subject = new Rectangle(0, 0, 50, 200);
+
+            subject.minHeight = 100;
+
+            const result = subject.alignTo({
+                target     : new Rectangle(200, 350, 100, 100),
+                constrainTo: new Rectangle(0, 0, 500, 500),
+                edgeAlign  : 't-b',
+                matchSize  : true,
+                offset     : [7, 9]
+            });
+
+            expect(result.equals(new Rectangle(157, 309, 50, 200))).toBe(true);
+            expect(result.position).toBe('left')
+        });
+
         test.describe('unconstrained', () => {
             const target = new Rectangle(100, 100, 100, 100);
 
@@ -237,92 +280,92 @@ test.describe('Rectangle', () => {
             let result = new Rectangle(0, 0, 50, 50).alignTo({
                 target,
                 targetMargin: 10,
-                edgeAlign: 't-b'
+                edgeAlign   : 't-b'
             });
             expect(result.equals(new Rectangle(125, 200, 50, 50))).toBe(true);
 
             result = new Rectangle(0, 0, 50, 50).alignTo({
                 target,
                 targetMargin: 10,
-                edgeAlign: 't0-b0'
+                edgeAlign   : 't0-b0'
             });
             expect(result.equals(new Rectangle(110, 200, 50, 50))).toBe(true);
 
             result = new Rectangle(0, 0, 50, 50).alignTo({
                 target,
                 targetMargin: 10,
-                edgeAlign: 't100-b100'
+                edgeAlign   : 't100-b100'
             });
             expect(result.equals(new Rectangle(140, 200, 50, 50))).toBe(true);
 
             result = new Rectangle(0, 0, 50, 50).alignTo({
                 target,
                 targetMargin: 10,
-                edgeAlign: 'b-t'
+                edgeAlign   : 'b-t'
             });
             expect(result.equals(new Rectangle(125, 50, 50, 50))).toBe(true);
 
             result = new Rectangle(0, 0, 50, 50).alignTo({
                 target,
                 targetMargin: 10,
-                edgeAlign: 'b0-t0'
+                edgeAlign   : 'b0-t0'
             });
             expect(result.equals(new Rectangle(110, 50, 50, 50))).toBe(true);
 
             result = new Rectangle(0, 0, 50, 50).alignTo({
                 target,
                 targetMargin: 10,
-                edgeAlign: 'b100-t100'
+                edgeAlign   : 'b100-t100'
             });
             expect(result.equals(new Rectangle(140, 50, 50, 50))).toBe(true);
 
             result = new Rectangle(0, 0, 50, 50).alignTo({
                 target,
                 targetMargin: 10,
-                edgeAlign: 'l-r'
+                edgeAlign   : 'l-r'
             });
             expect(result.equals(new Rectangle(200, 125, 50, 50))).toBe(true);
 
             result = new Rectangle(0, 0, 50, 50).alignTo({
                 target,
                 targetMargin: 10,
-                edgeAlign: 'l0-r0'
+                edgeAlign   : 'l0-r0'
             });
             expect(result.equals(new Rectangle(200, 110, 50, 50))).toBe(true);
 
             result = new Rectangle(0, 0, 50, 50).alignTo({
                 target,
                 targetMargin: 10,
-                edgeAlign: 'l100-r100'
+                edgeAlign   : 'l100-r100'
             });
             expect(result.equals(new Rectangle(200, 140, 50, 50))).toBe(true);
 
             result = new Rectangle(0, 0, 50, 50).alignTo({
                 target,
                 targetMargin: 10,
-                edgeAlign: 'r-l'
+                edgeAlign   : 'r-l'
             });
             expect(result.equals(new Rectangle(50, 125, 50, 50))).toBe(true);
 
             result = new Rectangle(0, 0, 50, 50).alignTo({
                 target,
                 targetMargin: 10,
-                edgeAlign: 'r0-l0'
+                edgeAlign   : 'r0-l0'
             });
             expect(result.equals(new Rectangle(50, 110, 50, 50))).toBe(true);
 
             result = new Rectangle(0, 0, 50, 50).alignTo({
                 target,
                 targetMargin: 10,
-                edgeAlign: 'r100-l100'
+                edgeAlign   : 'r100-l100'
             });
             expect(result.equals(new Rectangle(50, 140, 50, 50))).toBe(true);
         });
 
         test.describe('constrained, edgeAlign : "t-b"', () => {
             const constrainTo = new Rectangle(0, 0, 500, 500);
-            let target = new Rectangle(200, 200, 100, 100);
-            let subject = new Rectangle(0, 0, 10, 1000);
+            let   target      = new Rectangle(200, 200, 100, 100);
+            let   subject     = new Rectangle(0, 0, 10, 1000);
 
             test('Subject shrinks to fit', () => {
                 subject.minHeight = 100;


### PR DESCRIPTION
Resolves #17824

`Rectangle#alignTo()` now retains its documented final offset on every successful return path, while Main-thread alignment accepts JSON-safe viewport rectangles and zero-size point targets without inventing DOM anchors. Existing element targets keep their measurement, observation, cleanup, and hidden-target behavior.

Related: #17825
Related: #17826

Evidence: L2 (production alignment paths exercised through the custom Engine unit harness) → L2 required (all close-target ACs are deterministic Engine contracts). No residuals.

## AC Evidence

| AC-1 | `test/playwright/unit/util/Rectangle.spec.mjs` covers direct, overlap, constrained, and axis-flipped results; it also asserts source immutability and alignment metadata. |
| AC-2 | `test/playwright/unit/main/DomAccessAlign.spec.mjs` exercises serialized geometry and the existing element/id path through the production `DomAccess` singleton. |
| AC-3 | The point-target matrix covers centre plus all four viewport edges with `axisLock` and `constrainTo`, asserting both placement and resolved edge. |
| AC-4 | Coordinate registration and teardown assert that only physical subject/constraint elements reach `ResizeObserver`; no missing target is observed or unobserved. |
| AC-5 | The element-target control asserts unchanged placement, target identity, observation, and missing-target cleanup. |
| AC-6 | The focused specs run through `npm run test-unit -- test/playwright/unit/main/DomAccessAlign.spec.mjs test/playwright/unit/util/Rectangle.spec.mjs`, never the default Playwright command. |

## Deltas from ticket

The new Main-thread fixture removes only the known plain `setup()` DomAccess mock before loading the production singleton, making the proof independent of Playwright worker reuse order. `addAligned()` also begins observing the subject itself, so element targets now realign after subject resizes; the existing guarded width/height writes make that observer path converge without a feedback loop.

## Test Evidence

All coverage runs in CI.

## Post-Merge Validation

None — all close-target behavior is covered before merge.

Authored by Euclid (OpenAI GPT-5.6 Sol Ultra, Codex Desktop). Session d893ccaa-a773-4796-a67c-748667ab2563.
