### PR TITLE
feat(menu): complete Menu and Picker outside dismissal (#17825)

### DIFF
--- a/src/form/field/Picker.mjs
+++ b/src/form/field/Picker.mjs
@@ -5,7 +5,10 @@ import Text          from './Text.mjs';
 
 /**
  * The abstract picker field provides an arrow down trigger which opens a floating container to provide
- * more data selection options
+ * more data selection options. The field and picker form one focus/pointer interaction island: while
+ * visible, one listener on the owning app main view dismisses the picker on outside pointer input even
+ * when the target is non-focusable and browser focus remains on the field.
+ *
  * @class Neo.form.field.Picker
  * @extends Neo.form.field.Text
  * @abstract
@@ -88,6 +91,19 @@ class Picker extends Text {
     }
 
     /**
+     * The exact listener config attached to the owning app's main view while the picker is visible.
+     * @member {Object|null} outsidePointerListener=null
+     * @protected
+     */
+    outsidePointerListener = null
+    /**
+     * The main view currently carrying `outsidePointerListener`.
+     * @member {Neo.component.Base|null} outsidePointerListenerOwner=null
+     * @protected
+     */
+    outsidePointerListenerOwner = null
+
+    /**
      * @param {Object} config
      */
     construct(config) {
@@ -110,6 +126,10 @@ class Picker extends Text {
     afterSetMounted(value, oldValue) {
         if (value === false && oldValue && this.pickerIsMounted) {
             this.picker.hide()
+        }
+
+        if (value === false && oldValue !== undefined) {
+            this.syncOutsidePointerListener(false)
         }
 
         super.afterSetMounted(value, oldValue)
@@ -139,14 +159,14 @@ class Picker extends Text {
             pickerComponent = me.createPickerComponent();
 
         me.picker =  Neo.create({
-            module   : Container,
-            parentId : 'document.body',
-            floating : true,
-            align    : {
-                edgeAlign : pickerWidth ? 't0-b0' : 't-b',
-                matchSize : !pickerWidth,
-                axisLock  : true,
-                target    : me.getInputWrapperId()
+            module  : Container,
+            parentId: 'document.body',
+            floating: true,
+            align   : {
+                edgeAlign: pickerWidth ? 't0-b0' : 't-b',
+                matchSize: !pickerWidth,
+                axisLock : true,
+                target   : me.getInputWrapperId()
             },
             appName  : me.appName,
             cls      : ['neo-picker-container', 'neo-container'],
@@ -198,6 +218,8 @@ class Picker extends Text {
     destroy(...args) {
         let {picker} = this;
 
+        this.syncOutsidePointerListener(false);
+
         if (picker?.hidden === false) {
             picker.unmount()
         }
@@ -222,11 +244,35 @@ class Picker extends Text {
     }
 
     /**
+     * @summary Tests whether a serialized DOM path belongs to the field or its floating picker.
+     * @param {Object[]} [path]
+     * @returns {Boolean}
+     * @protected
+     */
+    isInteractionPath(path=[]) {
+        const ids = new Set(path.map(item => item.id).filter(Boolean));
+
+        return ids.has(this.id) || ids.has(this.picker?.id)
+    }
+
+    /**
      *
      */
     async hidePicker() {
         if (this.picker) {
             this.picker.hidden = true
+        }
+    }
+
+    /**
+     * Hides the picker when pointer input lands outside its field/picker interaction island.
+     * @param {Object} data
+     * @param {Object[]} [data.path]
+     * @protected
+     */
+    onAppMouseDown(data) {
+        if (this.picker?.hidden === false && !this.isInteractionPath(data.path)) {
+            this.hidePicker()
         }
     }
 
@@ -305,7 +351,10 @@ class Picker extends Text {
      * @protected
      */
     onPickerHiddenChange(data) {
-        this.pickerIsMounted = !data.value
+        const visible = !data.value;
+
+        this.pickerIsMounted = visible;
+        this.syncOutsidePointerListener(visible)
     }
 
     /**
@@ -321,6 +370,29 @@ class Picker extends Text {
      */
     showPicker() {
         this.getPicker().hidden = false
+    }
+
+    /**
+     * Adds or removes one retained `mousedown` config on the owning app main view.
+     * @param {Boolean} attach
+     * @protected
+     */
+    syncOutsidePointerListener(attach) {
+        let me    = this,
+            owner = me.outsidePointerListenerOwner;
+
+        if (attach && !owner) {
+            owner = me.app?.mainView;
+
+            if (owner) {
+                me.outsidePointerListener ||= {mousedown: me.onAppMouseDown, scope: me};
+                owner.addDomListeners(me.outsidePointerListener);
+                me.outsidePointerListenerOwner = owner
+            }
+        } else if (!attach && owner) {
+            owner.removeDomListeners(me.outsidePointerListener);
+            me.outsidePointerListenerOwner = null
+        }
     }
 
     /**

--- a/src/menu/List.mjs
+++ b/src/menu/List.mjs
@@ -3,6 +3,11 @@ import ListModel from '../selection/menu/ListModel.mjs';
 import Store     from './Store.mjs';
 
 /**
+ * A floating root menu forms one interaction island with its exact align target and every mounted
+ * descendant submenu. While mounted, it listens on its own app main view so outside pointer input
+ * can dismiss it even when a non-focusable target produces no focus transition. Focus movement uses
+ * the same structural island; timing is never the ownership signal.
+ *
  * @class Neo.menu.List
  * @extends Neo.list.Base
  */
@@ -27,12 +32,6 @@ class List extends BaseList {
          * @member {String[]} baseCls=['neo-menu-list','neo-list']
          */
         baseCls: ['neo-menu-list', 'neo-list'],
-        /**
-         * setTimeout() id after a focus-leave event.
-         * @member {Number|null} focusTimeoutId=null
-         * @protected
-         */
-        focusTimeoutId: null,
         /**
          * Hides a floating list on leaf item click, in case it has a parentComponent
          * @member {Boolean} hideOnLeafItemClick=true
@@ -109,6 +108,19 @@ class List extends BaseList {
     }
 
     /**
+     * The exact listener config attached to the owning app's main view while this floating root is mounted.
+     * @member {Object|null} outsidePointerListener=null
+     * @protected
+     */
+    outsidePointerListener = null
+    /**
+     * The main view currently carrying `outsidePointerListener`.
+     * @member {Neo.component.Base|null} outsidePointerListenerOwner=null
+     * @protected
+     */
+    outsidePointerListenerOwner = null
+
+    /**
      * Triggered after the items config got changed
      * @param {Object[]} value
      * @param {Object[]} oldValue
@@ -133,17 +145,26 @@ class List extends BaseList {
 
             if (me.isRoot) {
                 if (!value) {
-                    me.focusTimeoutId = setTimeout(() => {
-                        me[me.floating ? 'unmount' : 'hideSubMenu']()
-                    }, 20)
-                } else {
-                    clearTimeout(me.focusTimeoutId);
-                    me.focusTimeoutId = null
+                    me[me.floating ? 'unmount' : 'hideSubMenu']()
                 }
             } else {
                 // bubble the focus change upwards
                 me.parentMenu.menuFocus = value
             }
+        }
+    }
+
+    /**
+     * Keeps the app-root outside-pointer listener symmetric with the floating root's mounted lifecycle.
+     * @param {Boolean} value
+     * @param {Boolean} oldValue
+     * @protected
+     */
+    afterSetMounted(value, oldValue) {
+        super.afterSetMounted(value, oldValue);
+
+        if (oldValue !== undefined && this.isRoot && this.floating) {
+            this.syncOutsidePointerListener(value)
         }
     }
 
@@ -202,6 +223,7 @@ class List extends BaseList {
             {activeSubMenu} = me,
             subMenuMap      = me.subMenuMap || {};
 
+        me.syncOutsidePointerListener(false);
         activeSubMenu?.unmount();
 
         Object.entries(subMenuMap).forEach(([key, value]) => {
@@ -210,6 +232,48 @@ class List extends BaseList {
         });
 
         super.destroy(...args)
+    }
+
+    /**
+     * @summary Tests whether a serialized DOM path belongs to this menu tree or its exact trigger.
+     * @param {Object[]} [path]
+     * @returns {Boolean}
+     * @protected
+     */
+    isInteractionPath(path=[]) {
+        const ids  = new Set(path.map(item => item.id).filter(Boolean));
+        let   root = this;
+
+        while (root.parentMenu) {
+            root = root.parentMenu
+        }
+
+        const menus = [root];
+        let   menu;
+
+        while ((menu = menus.pop())) {
+            if (ids.has(menu.id)) {
+                return true
+            }
+
+            Object.values(menu.subMenuMap || {}).forEach(submenu => {
+                submenu?.mounted && menus.push(submenu)
+            })
+        }
+
+        return Neo.isString(root.align?.target) && ids.has(root.align.target)
+    }
+
+    /**
+     * Dismisses a floating root from pointer input outside the complete menu interaction island.
+     * @param {Object} data
+     * @param {Object[]} [data.path]
+     * @protected
+     */
+    onAppMouseDown(data) {
+        if (this.isRoot && this.floating && !this.isInteractionPath(data.path)) {
+            this.unmount()
+        }
     }
 
     /**
@@ -274,21 +338,33 @@ class List extends BaseList {
     onFocusLeave(data) {
         super.onFocusLeave(data);
 
-        let insideParent = false,
-            parentId     = this.parentComponent?.id,
-            item;
+        const leftPathIsOwnTree = data.oldPath?.some(item => item.id === this.id);
 
-        if (parentId) {
-            for (item of data.oldPath) {
-                if (item.id === parentId) {
-                    insideParent = true;
-                    break
-                }
-            }
-        }
-
-        if (!insideParent) {
+        if (!data.relatedTarget || leftPathIsOwnTree || !this.isInteractionPath(data.oldPath)) {
             this.menuFocus = false
+        }
+    }
+
+    /**
+     * Adds or removes one retained `mousedown` config on the owning app main view.
+     * @param {Boolean} attach
+     * @protected
+     */
+    syncOutsidePointerListener(attach) {
+        let me    = this,
+            owner = me.outsidePointerListenerOwner;
+
+        if (attach && !owner) {
+            owner = me.app?.mainView;
+
+            if (owner) {
+                me.outsidePointerListener ||= {mousedown: me.onAppMouseDown, scope: me};
+                owner.addDomListeners(me.outsidePointerListener);
+                me.outsidePointerListenerOwner = owner
+            }
+        } else if (!attach && owner) {
+            owner.removeDomListeners(me.outsidePointerListener);
+            me.outsidePointerListenerOwner = null
         }
     }
 
@@ -365,12 +441,12 @@ class List extends BaseList {
             subMenuMap   = me.subMenuMap || (me.subMenuMap = {}),
             subMenuMapId = me.getMenuMapId(recordId),
             subMenu      = subMenuMap[subMenuMapId] || (subMenuMap[subMenuMapId] = Neo.create({
-                module         : List,
-                align          : {
-                    target       : nodeId,
-                    edgeAlign    : 'l0-r0',
-                    axisLock     : true,
-                    targetMargin : me.subMenuGap
+                module: List,
+                align : {
+                    target      : nodeId,
+                    edgeAlign   : 'l0-r0',
+                    axisLock    : true,
+                    targetMargin: me.subMenuGap
                 },
                 appName        : me.appName,
                 displayField   : me.displayField,
@@ -411,6 +487,7 @@ class List extends BaseList {
      *
      */
     unmount() {
+        this._menuFocus = false;
         this.selectionModel?.deselectAll(true); // silent update
         this.hideSubMenu();
 

--- a/test/playwright/unit/form/field/Picker.spec.mjs
+++ b/test/playwright/unit/form/field/Picker.spec.mjs
@@ -1,0 +1,148 @@
+import {setup} from '../../../setup.mjs';
+
+const
+    appName  = 'PickerDismissalTest',
+    added    = [],
+    removed  = [],
+    mainView = {
+        id          : 'picker-test-main-view',
+        domListeners: [],
+
+        addDomListeners(value) {
+            const listeners = Array.isArray(value) ? value : [value];
+
+            this.domListeners.push(...listeners);
+            added.push(...listeners)
+        },
+
+        removeDomListeners(value) {
+            const listeners = Array.isArray(value) ? value : [value];
+
+            listeners.forEach(listener => {
+                const index = this.domListeners.indexOf(listener);
+
+                if (index > -1) {
+                    this.domListeners.splice(index, 1)
+                }
+
+                removed.push(listener)
+            })
+        }
+    };
+
+setup({
+    appConfig: {
+        name: appName,
+        mainView
+    }
+});
+
+import {test, expect} from '@playwright/test';
+import Neo            from '../../../../../src/Neo.mjs';
+import * as core      from '../../../../../src/core/_export.mjs';
+import Picker         from '../../../../../src/form/field/Picker.mjs';
+
+class TestPicker extends Picker {
+    static config = {
+        className: 'Test.Unit.Form.Field.DismissalPicker'
+    }
+}
+
+TestPicker = Neo.setupClass(TestPicker);
+
+/**
+ * @summary Creates the abstract Picker contract with physical DOM work neutralized.
+ * @returns {TestPicker}
+ */
+function createField() {
+    const
+        field  = Neo.create(TestPicker, {appName, id: Neo.getId('dismissal-picker')}),
+        picker = field.getPicker();
+
+    picker.initVnode = async () => {
+        picker._mounted = true;
+        return picker
+    };
+    picker.unmount = () => {
+        picker._mounted = false
+    };
+
+    return field
+}
+
+test.describe('Neo.form.field.Picker outside-pointer dismissal', () => {
+    let field;
+
+    test.beforeEach(() => {
+        added.length = 0;
+        removed.length = 0;
+        mainView.domListeners.length = 0;
+        field = createField()
+    });
+
+    test.afterEach(() => {
+        !field?.isDestroyed && field.destroy()
+    });
+
+    test('attaches once while shown and removes the exact listener while hidden', async () => {
+        field.showPicker();
+        field.showPicker();
+
+        expect(added).toHaveLength(1);
+        expect(mainView.domListeners).toEqual(added);
+
+        await field.hidePicker();
+
+        expect(removed).toHaveLength(1);
+        expect(removed[0]).toBe(added[0]);
+        expect(mainView.domListeners).toEqual([])
+    });
+
+    test('keeps field and picker pointers inside but dismisses non-focusable app chrome', () => {
+        const picker     = field.picker;
+        let   dismissals = 0;
+
+        field.showPicker();
+        field.hidePicker = () => dismissals++;
+
+        field.onAppMouseDown({path: [{id: field.id}]});
+        field.onAppMouseDown({path: [{id: picker.id}]});
+
+        expect(dismissals).toBe(0);
+
+        field.onAppMouseDown({path: [{id: 'non-focusable-workspace'}]});
+
+        expect(dismissals).toBe(1)
+    });
+
+    test('preserves both focus-island directions and Escape semantics', () => {
+        const picker = field.picker,
+              escape = {};
+        let   dismissals = 0;
+
+        field.hidePicker = () => dismissals++;
+
+        field.onFocusLeave({oldPath: [{id: picker.id}]});
+        picker.onFocusLeave({oldPath: [{id: field.id}]});
+
+        expect(dismissals).toBe(0);
+
+        field.onFocusLeave({oldPath: [{id: 'focusable-outside'}]});
+        picker.onFocusLeave({oldPath: [{id: 'focusable-outside'}]});
+
+        field.pickerIsMounted = true;
+        expect(field.onKeyDownEscape(escape)).toBe(false);
+        expect(escape.cancelBubble).toBe(true);
+        expect(dismissals).toBe(3)
+    });
+
+    test('removes the exact app-root listener during destroy', () => {
+        field.showPicker();
+        field.destroy();
+
+        expect(added).toHaveLength(1);
+        expect(removed).toHaveLength(1);
+        expect(removed[0]).toBe(added[0]);
+        expect(mainView.domListeners).toEqual([])
+    })
+});

--- a/test/playwright/unit/menu/List.spec.mjs
+++ b/test/playwright/unit/menu/List.spec.mjs
@@ -1,0 +1,204 @@
+import {setup} from '../../setup.mjs';
+
+const
+    appName  = 'MenuListDismissalTest',
+    added    = [],
+    removed  = [],
+    mainView = {
+        id          : 'menu-test-main-view',
+        domListeners: [],
+
+        addDomListeners(value) {
+            const listeners = Array.isArray(value) ? value : [value];
+
+            this.domListeners.push(...listeners);
+            added.push(...listeners)
+        },
+
+        removeDomListeners(value) {
+            const listeners = Array.isArray(value) ? value : [value];
+
+            listeners.forEach(listener => {
+                const index = this.domListeners.indexOf(listener);
+
+                if (index > -1) {
+                    this.domListeners.splice(index, 1)
+                }
+
+                removed.push(listener)
+            })
+        }
+    };
+
+setup({
+    appConfig: {
+        name: appName,
+        mainView
+    }
+});
+
+import {test, expect} from '@playwright/test';
+import Neo            from '../../../../src/Neo.mjs';
+import * as core      from '../../../../src/core/_export.mjs';
+import MenuList       from '../../../../src/menu/List.mjs';
+
+/**
+ * @summary Creates a root or descendant Menu with DOM-dependent mount work neutralized.
+ * @param {Object} [config]
+ * @returns {Neo.menu.List}
+ */
+function createMenu(config={}) {
+    const menu = Neo.create(MenuList, {
+        appName,
+        id      : Neo.getId('dismissal-menu'),
+        ...config
+    });
+
+    menu.alignTo       = Neo.emptyFn;
+    menu.focus         = Neo.emptyFn;
+    menu.initDomEvents = Neo.emptyFn;
+
+    return menu
+}
+
+test.describe('Neo.menu.List floating dismissal', () => {
+    let menus;
+
+    test.beforeEach(() => {
+        added.length = 0;
+        removed.length = 0;
+        mainView.domListeners.length = 0;
+        menus = []
+    });
+
+    test.afterEach(() => {
+        menus.forEach(menu => {
+            !menu.isDestroyed && menu.destroy()
+        })
+    });
+
+    test('attaches one exact app-root listener only while a floating root is mounted', () => {
+        const
+            menu    = createMenu({floating: true,  isRoot: true}),
+            inline  = createMenu({floating: false, isRoot: true}),
+            submenu = createMenu({floating: true,  isRoot: false});
+
+        menus.push(menu, inline, submenu);
+        menu.mounted = true;
+        menu.mounted = true;
+        inline.mounted = true;
+        submenu.mounted = true;
+
+        expect(added).toHaveLength(1);
+        expect(mainView.domListeners).toEqual(added);
+
+        menu.mounted = false;
+
+        expect(removed).toHaveLength(1);
+        expect(removed[0]).toBe(added[0]);
+        expect(mainView.domListeners).toEqual([])
+    });
+
+    test('treats the trigger and every mounted submenu level as inside, but dismisses outside', () => {
+        const
+            root = createMenu({
+                align   : {edgeAlign: 't0-b0', target: 'menu-trigger'},
+                floating: true,
+                isRoot  : true
+            }),
+            level1 = createMenu({floating: true, isRoot: false, parentMenu: root}),
+            level2 = createMenu({floating: true, isRoot: false, parentMenu: level1});
+
+        menus.push(root, level1, level2);
+        level1._mounted = level2._mounted = true;
+        root.subMenuMap = {first: level1};
+        level1.subMenuMap = {second: level2};
+
+        let dismissals = 0;
+
+        root.unmount = () => dismissals++;
+
+        [root.id, 'menu-trigger', level1.id, level2.id].forEach(id => {
+            root.onAppMouseDown({path: [{id}]})
+        });
+
+        expect(dismissals).toBe(0);
+
+        // This models the deterministically broken case: pointer input on non-focusable app chrome,
+        // with no focus event available to help dismissal.
+        root.onAppMouseDown({path: [{id: 'non-focusable-workspace'}]});
+
+        expect(dismissals).toBe(1)
+    });
+
+    test('uses structural focus partners instead of a frame-sized correctness timer', () => {
+        const
+            root   = createMenu({floating: true, isRoot: true}),
+            level1 = createMenu({floating: true, isRoot: false, parentMenu: root}),
+            level2 = createMenu({floating: true, isRoot: false, parentMenu: level1});
+
+        menus.push(root, level1, level2);
+        level1._mounted = level2._mounted = true;
+        root.subMenuMap = {first: level1};
+        level1.subMenuMap = {second: level2};
+
+        let dismissals = 0;
+
+        root.unmount = () => dismissals++;
+        root.menuFocus = true;
+
+        root.onFocusLeave({
+            oldPath      : [{id: level1.id}],
+            relatedTarget: {id: level1.id}
+        });
+        root.onFocusLeave({
+            oldPath      : [{id: level2.id}],
+            relatedTarget: {id: level2.id}
+        });
+
+        expect(root.menuFocus).toBe(true);
+        expect(dismissals).toBe(0);
+        expect(root.focusTimeoutId).toBeUndefined();
+
+        root.onFocusLeave({
+            oldPath      : [{id: 'focusable-outside'}],
+            relatedTarget: {id: 'focusable-outside'}
+        });
+
+        expect(dismissals).toBe(1);
+        expect(root.focusTimeoutId).toBeUndefined()
+    });
+
+    test('keeps document blur and Escape as immediate dismissal paths', () => {
+        const root = createMenu({floating: true, isRoot: true});
+
+        menus.push(root);
+
+        let dismissals = 0;
+
+        root.unmount = () => dismissals++;
+        root.menuFocus = true;
+        root.onFocusLeave({oldPath: [{id: root.id}], relatedTarget: null});
+        root.menuFocus = true;
+        root.onFocusLeave({
+            oldPath      : [{id: root.id}],
+            relatedTarget: {id: 'focusable-outside'}
+        });
+        root.onKeyDownEscape({});
+
+        expect(dismissals).toBe(3)
+    });
+
+    test('removes the exact app-root listener during destroy', () => {
+        const menu = createMenu({floating: true, isRoot: true});
+
+        menus.push(menu);
+        menu.mounted = true;
+        menu.destroy();
+
+        expect(added).toHaveLength(1);
+        expect(removed).toHaveLength(1);
+        expect(removed[0]).toBe(added[0]);
+        expect(mainView.domListeners).toEqual([])
+    })
+});


### PR DESCRIPTION
Resolves #17825

Floating root menus and picker fields now register one scoped `mousedown` listener on their own app main view only while visible. Serialized event paths define the interaction island, so non-focusable outside chrome dismisses reliably, while menu roots, two submenu levels, exact triggers, fields, and picker bodies remain inside. Menu focus ownership is structural and the 20ms correctness timer is gone.

Related: #17826

Evidence: L2 (production Menu/Picker lifecycle and serialized-event paths exercised through the custom Engine unit harness) → L2 required (all close-target ACs are deterministic Engine contracts). No residuals.

## AC Evidence

| AC-1 | `test/playwright/unit/menu/List.spec.mjs` and `test/playwright/unit/form/field/Picker.spec.mjs` send outside `mousedown` paths with no focus transition and assert immediate dismissal. |
| AC-2 | The focused matrices keep root menu, first/second submenu, exact trigger, field, and picker paths inside; inline menus and non-root menus never register the app listener. |
| AC-3 | The Menu focus proof traverses both mounted submenu levels and asserts no timeout state exists; true focus exit dismisses immediately. |
| AC-4 | Focus tab-out/standalone focusout, document blur, Escape, and trigger toggling paths are pinned; leaf handling remains on the unchanged `onKeyDownEnter()` path. |
| AC-5 | Menu and Picker lifecycle proofs assert one registration plus removal by the identical retained config across hide/unmount/destroy. |
| AC-6 | Picker changes stop at shared focus/pointer dismissal; the complete Engine unit suite keeps selection, typeahead, and existing field behavior green. |

## Deltas from ticket

The standalone-focusout control distinguishes an old menu path from a focus-move destination, preventing a non-null `relatedTarget` from preserving a menu that focus actually left. Trigger identity is deliberately the exact string `align.target`, not `parentComponent`: shipped Button-menu factories bind that target to the Button id, while a coordinate-anchored context menu has no trigger element and may still use `parentComponent` only for logical ancestry. The ticket was corrected to match this contract.

## Test Evidence

All coverage runs in CI.

## Post-Merge Validation

None — all close-target behavior is covered before merge.

Authored by Euclid (OpenAI GPT-5.6 Sol Ultra, Codex Desktop). Session d893ccaa-a773-4796-a67c-748667ab2563.
