### PR TITLE
feat(menu): add real-pointer context-menu example (#17826)

### DIFF
--- a/examples/menu/context/MainContainer.mjs
+++ b/examples/menu/context/MainContainer.mjs
@@ -1,0 +1,207 @@
+import Button   from '../../../src/button/Base.mjs';
+import Label    from '../../../src/component/Label.mjs';
+import MenuList from '../../../src/menu/List.mjs';
+import Viewport from '../../../src/container/Viewport.mjs';
+
+/**
+ * Minimal context-menu composition: real browser `contextmenu` input becomes serialized point
+ * alignment for one reusable floating Menu. Menu owns outside-pointer/focus dismissal; the app owns
+ * only its surface, menu contents, and the selected-action state shown below.
+ *
+ * @class Neo.examples.menu.context.MainContainer
+ * @extends Neo.container.Viewport
+ */
+class MainContainer extends Viewport {
+    static config = {
+        /**
+         * @member {String} className='Neo.examples.menu.context.MainContainer'
+         * @protected
+         */
+        className: 'Neo.examples.menu.context.MainContainer',
+        /**
+         * @member {String[]} cls=['neo-context-menu-workspace']
+         */
+        cls: ['neo-context-menu-workspace'],
+        /**
+         * @member {Object} layout={ntype:'vbox',align:'center',pack:'center'}
+         */
+        layout: {ntype: 'vbox', align: 'center', pack: 'center'},
+        /**
+         * @member {Object} style
+         */
+        style: {gap: '1.5em', padding: '3em'},
+        /**
+         * @member {Object[]} items
+         */
+        items: [{
+            module: Label,
+            text  : 'Right-click anywhere in this workspace to open the context menu.'
+        }, {
+            module   : Button,
+            handler  : 'up.onFocusableClick',
+            reference: 'focusable-target',
+            text     : 'Focusable outside target'
+        }, {
+            module   : Label,
+            reference: 'context-status',
+            text     : 'Last action: none'
+        }]
+    }
+
+    /**
+     * The one Menu instance reused across every context-menu invocation.
+     * @member {Neo.menu.List|null} contextMenu=null
+     * @protected
+     */
+    contextMenu = null
+    /**
+     * Last pointer point handed to the alignment engine, exposed for whitebox evidence.
+     * @member {Object|null} contextPoint=null
+     */
+    contextPoint = null
+    /**
+     * Stable Menu identity exposed without serializing the Menu instance itself.
+     * @member {String|null} contextMenuId=null
+     */
+    contextMenuId = null
+    /**
+     * Number of real context-menu invocations handled by this instance.
+     * @member {Number} openCount=0
+     */
+    openCount = 0
+    /**
+     * Last selected leaf action.
+     * @member {String} lastAction='none'
+     */
+    lastAction = 'none'
+
+    /**
+     * @param {Object} config
+     */
+    construct(config) {
+        super.construct(config);
+
+        let me = this;
+
+        // Native suppression is scoped to this example class; no application/document workaround.
+        Neo.main.DomEvents.registerPreventDefaultTargets({
+            name    : 'contextmenu',
+            cls     : 'neo-context-menu-workspace',
+            windowId: me.windowId
+        });
+
+        me.addDomListeners({contextmenu: me.onContextMenu, scope: me})
+    }
+
+    /**
+     * Creates the one floating Menu. A context point is geometry, not a persistent trigger element,
+     * so `parentComponent` is deliberately absent.
+     * @returns {Neo.menu.List}
+     * @protected
+     */
+    createContextMenu() {
+        let me = this;
+
+        return Neo.create(MenuList, {
+            align       : me.createMenuAlign({x: 0, y: 0}),
+            appName     : me.appName,
+            displayField: 'text',
+            floating    : true,
+            hidden      : true,
+            items       : [{
+                handler: me.onLeafAction.bind(me, 'Open'),
+                iconCls: 'fa fa-folder-open',
+                id     : 'open',
+                text   : 'Open'
+            }, {
+                iconCls: 'fa fa-magnifying-glass',
+                id     : 'inspect',
+                items  : [{
+                    iconCls: 'fa fa-circle-info',
+                    id     : 'details',
+                    items  : [{
+                        handler: me.onLeafAction.bind(me, 'Copy name'),
+                        iconCls: 'fa fa-copy',
+                        id     : 'copy-name',
+                        text   : 'Copy name'
+                    }],
+                    text: 'Details'
+                }],
+                text: 'Inspect'
+            }],
+            parentId: 'document.body',
+            theme   : me.theme,
+            windowId: me.windowId
+        })
+    }
+
+    /**
+     * @summary Creates the complete point-alignment contract for one pointer coordinate.
+     * @param {{x:Number,y:Number}} point
+     * @returns {Object}
+     * @protected
+     */
+    createMenuAlign(point) {
+        return {
+            axisLock   : true,
+            constrainTo: 'document.body',
+            edgeAlign  : 't0-b0',
+            target     : {x: point.x, y: point.y, width: 0, height: 0}
+        }
+    }
+
+    /**
+     * Destroys the detached floating Menu with its owning example.
+     * @param {...*} args
+     */
+    destroy(...args) {
+        this.contextMenu?.destroy(true, false);
+        super.destroy(...args)
+    }
+
+    /**
+     * Records an ordinary focusable outside click without taking over Menu dismissal.
+     */
+    onFocusableClick() {
+        this.getReference('context-status').text = 'Focusable outside target clicked'
+    }
+
+    /**
+     * Records the selected Menu leaf in worker state and in the visible status label.
+     * @param {String} action
+     * @protected
+     */
+    onLeafAction(action) {
+        this.lastAction = action;
+        this.getReference('context-status').text = `Last action: ${action}`
+    }
+
+    /**
+     * Opens or repositions the reusable Menu from a real serialized browser context-menu event.
+     * @param {Object} data
+     * @param {Number} data.clientX
+     * @param {Number} data.clientY
+     * @returns {Promise<void>}
+     * @protected
+     */
+    async onContextMenu(data) {
+        let me    = this,
+            point = me.contextPoint = {x: data.clientX, y: data.clientY},
+            menu  = me.contextMenu || (me.contextMenu = me.createContextMenu());
+
+        me.contextMenuId = menu.id;
+        me.openCount++;
+
+        menu.hideSubMenu();
+        menu.selectionModel?.deselectAll(true);
+        menu.align = me.createMenuAlign(point);
+
+        if (menu.hidden) {
+            menu.hidden = false
+        } else {
+            await menu.alignTo()
+        }
+    }
+}
+
+export default Neo.setupClass(MainContainer);

--- a/examples/menu/context/app.mjs
+++ b/examples/menu/context/app.mjs
@@ -1,0 +1,6 @@
+import MainContainer from './MainContainer.mjs';
+
+export const onStart = () => Neo.app({
+    mainView: MainContainer,
+    name    : 'Neo.examples.menu.context'
+});

--- a/examples/menu/context/index.html
+++ b/examples/menu/context/index.html
@@ -1,0 +1,11 @@
+<!DOCTYPE HTML>
+<html>
+<head>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta charset="UTF-8">
+    <title>Neo Context Menu</title>
+</head>
+<body>
+    <script src="../../../src/MicroLoader.mjs" type="module"></script>
+</body>
+</html>

--- a/examples/menu/context/neo-config.json
+++ b/examples/menu/context/neo-config.json
@@ -1,0 +1,7 @@
+{
+    "appPath"    : "examples/menu/context/app.mjs",
+    "basePath"   : "../../../",
+    "environment": "development",
+    "mainPath"   : "./Main.mjs",
+    "useAiClient": true
+}

--- a/test/playwright/e2e/rendering/ContextMenuNL.spec.mjs
+++ b/test/playwright/e2e/rendering/ContextMenuNL.spec.mjs
@@ -1,0 +1,174 @@
+import {test, expect} from '../../fixtures.mjs';
+
+test.use({viewport: {width: 1280, height: 720}});
+
+/**
+ * @summary Returns the one context-menu example MainContainer property projection.
+ * @param {Object} app
+ * @returns {Promise<Object>}
+ */
+async function getMainState(app) {
+    const result = await app.queryComponent(
+        {className: 'Neo.examples.menu.context.MainContainer'},
+        ['id', 'contextMenuId', 'contextPoint', 'lastAction', 'openCount']
+    );
+
+    return (Array.isArray(result) ? result[0] : result).properties
+}
+
+/**
+ * @summary Requires worker and DOM dismissal to settle together.
+ * @param {Object} page
+ * @param {Object} app
+ * @param {String} menuId
+ * @returns {Promise<void>}
+ */
+async function expectDismissed(page, app, menuId) {
+    await expect.poll(async () => {
+        const state = await app.getComponent(menuId, ['hidden', 'mounted']);
+
+        return `${state.hidden}:${state.mounted}`
+    }).toBe('true:false');
+    await expect(page.locator(`#${menuId}`)).toHaveCount(0)
+}
+
+/**
+ * @summary Opens or repositions the context menu with a real browser right click.
+ * @param {Object} page
+ * @param {Object} app
+ * @param {{x:Number,y:Number}} point
+ * @param {Number} openCount
+ * @param {String|null} [expectedMenuId]
+ * @returns {Promise<{box:Object,menuId:String}>}
+ */
+async function openAt(page, app, point, openCount, expectedMenuId=null) {
+    await page.mouse.click(point.x, point.y, {button: 'right'});
+
+    await expect.poll(async () => (await getMainState(app)).openCount).toBe(openCount);
+
+    const
+        state  = await getMainState(app),
+        menuId = state.contextMenuId,
+        menu   = page.locator(`#${menuId}`);
+
+    expectedMenuId && expect(menuId).toBe(expectedMenuId);
+    expect(state.contextPoint).toEqual(point);
+    await expect.poll(async () => {
+        const menuState = await app.getComponent(menuId, ['align', 'hidden', 'mounted']);
+
+        return menuState.mounted === true &&
+            menuState.hidden === false &&
+            menuState.align.target.x === point.x &&
+            menuState.align.target.y === point.y &&
+            Boolean(await menu.boundingBox())
+    }).toBe(true);
+
+    return {box: await menu.boundingBox(), menuId}
+}
+
+test.describe('Context Menu — real pointer + Neural Link', () => {
+    test('reuses one Menu across placement, hierarchy, action and dismissal paths', async ({page, neuralLink}) => {
+        const pageErrors = [];
+
+        page.on('pageerror', error => pageErrors.push(String(error?.stack || error?.message || error)));
+        await page.goto('/examples/menu/context/index.html');
+
+        const app = await neuralLink.connectToApp('Neo.examples.menu.context');
+
+        await expect(page.getByText('Right-click anywhere in this workspace')).toBeVisible();
+
+        // Observe native suppression after the event has completed its browser dispatch.
+        await page.evaluate(() => {
+            window.__contextMenuDefaultPrevented = null;
+            document.addEventListener('contextmenu', event => {
+                queueMicrotask(() => {
+                    window.__contextMenuDefaultPrevented = event.defaultPrevented
+                })
+            }, {once: true})
+        });
+
+        const
+            center = {x: 640, y: 360},
+            first  = await openAt(page, app, center, 1),
+            menuId = first.menuId;
+
+        expect(first.box.x).toBeCloseTo(center.x, 0);
+        expect(first.box.y).toBeCloseTo(center.y, 0);
+        await expect.poll(() => page.evaluate(() => window.__contextMenuDefaultPrevented)).toBe(true);
+
+        const firstMenuState = await app.getComponent(menuId, [
+            'align', 'hidden', 'menuFocus', 'mounted', 'parentComponent'
+        ]);
+
+        expect(firstMenuState).toMatchObject({
+            hidden         : false,
+            menuFocus      : true,
+            mounted        : true,
+            parentComponent: null
+        });
+        expect(firstMenuState.align.target).toEqual({...center, width: 0, height: 0});
+
+        // Reposition the SAME live Menu at all viewport edges. Each physical rectangle must remain
+        // wholly viewport-contained; the worker point records the unmodified browser coordinate.
+        const edgePoints = [
+            {x: 640,  y: 1},
+            {x: 1279, y: 360},
+            {x: 640,  y: 719},
+            {x: 1,    y: 360}
+        ];
+
+        for (let index = 0; index < edgePoints.length; index++) {
+            const {box} = await openAt(page, app, edgePoints[index], index + 2, menuId);
+
+            expect(box.x).toBeGreaterThanOrEqual(0);
+            expect(box.y).toBeGreaterThanOrEqual(0);
+            expect(box.x + box.width).toBeLessThanOrEqual(1280);
+            expect(box.y + box.height).toBeLessThanOrEqual(720)
+        }
+
+        // Non-focusable app chrome produces no helpful focus move; pointer containment must still dismiss.
+        await page.mouse.click(640, 100);
+        await expectDismissed(page, app, menuId);
+
+        let menuState = await app.getComponent(menuId, ['hidden', 'mounted']);
+        expect(menuState).toMatchObject({hidden: true, mounted: false});
+
+        // A focusable outside target dismisses on mousedown and then receives the ordinary click/focus.
+        await openAt(page, app, {x: 80, y: 80}, 6, menuId);
+
+        const focusable = page.getByRole('button', {name: 'Focusable outside target'});
+        await focusable.click();
+        await expectDismissed(page, app, menuId);
+        await expect(page.getByText('Focusable outside target clicked')).toBeVisible();
+        await expect.poll(() => page.evaluate(() => document.activeElement?.textContent?.trim())).toBe(
+            'Focusable outside target'
+        );
+
+        // Real nested clicks keep the root plus both descendant submenus mounted and focus the leaf.
+        await openAt(page, app, center, 7, menuId);
+        await page.getByText('Inspect', {exact: true}).click();
+        await expect(page.locator('.neo-menu-list')).toHaveCount(2);
+        await page.getByText('Details', {exact: true}).click();
+        await expect(page.locator('.neo-menu-list')).toHaveCount(3);
+        await expect.poll(() => page.evaluate(() => document.activeElement?.textContent?.trim())).toBe('Copy name');
+
+        menuState = await app.getComponent(menuId, ['hidden', 'mounted']);
+        expect(menuState).toMatchObject({hidden: false, mounted: true});
+
+        // The real leaf click updates worker-owned state and follows Menu's leaf-dismissal policy.
+        await page.getByText('Copy name', {exact: true}).click();
+        await expect(page.getByText('Last action: Copy name')).toBeVisible();
+        await expect.poll(async () => (await getMainState(app)).lastAction).toBe('Copy name');
+        await expect(page.locator('.neo-menu-list')).toHaveCount(0);
+
+        // Reopen at a fresh point after the nested tree settled; identity stays stable and Escape closes it.
+        await openAt(page, app, {x: 300, y: 240}, 8, menuId);
+        await page.keyboard.press('Escape');
+        await expectDismissed(page, app, menuId);
+
+        const finalState = await getMainState(app);
+        expect(finalState).toMatchObject({contextMenuId: menuId, lastAction: 'Copy name', openCount: 8});
+        expect(pageErrors).toEqual([]);
+        expect(await app.getConsoleLogs('error')).toEqual([])
+    })
+});


### PR DESCRIPTION
Resolves #17826

Adds a complete `examples/menu/context/` Body app that converts native right-click coordinates into one reusable floating `Neo.menu.List`, plus a Whitebox journey combining real Playwright mouse/keyboard input with Neural Link worker-state assertions. The example delegates alignment and dismissal to the merged Engine primitives; it contains no application-level outside listener or direct `left/top` fallback.

Evidence: L3 (three-run real Chrome pointer/keyboard journey plus Neural Link worker and DOM proof) → L3 required (AC-2 through AC-8 observable browser behavior). No residuals.

## AC Evidence

| AC-1 | `examples/menu/context/` contains the four complete Body-app markers; `check-examples-body-only` passed and the dev build compiled all 403 example modules. |
| AC-2 | `ContextMenuNL.spec.mjs` uses `page.mouse.click(..., {button:'right'})`, observes `defaultPrevented:true`, and asserts one worker Menu with the exact serialized point target. |
| AC-3 | The journey asserts exact center placement, then top/right/bottom/left probes keep the complete physical Menu rectangle inside the 1280×720 viewport. |
| AC-4 | Real clicks on `Inspect` and `Details` produce three mounted Menu levels and focus the second-level `Copy name` leaf while the root remains mounted. |
| AC-5 | A real `Copy name` leaf click updates `MainContainer.lastAction`, updates the visible status Label, and settles the full Menu tree. |
| AC-6 | Real non-focusable background, focusable Button, and Escape paths dismiss through matching worker+DOM terminals; menu/submenu clicks remain inside. |
| AC-7 | Eight invocations across center, edges, dismissal, nested action, and final reopen retain the same `contextMenuId` while updating `contextPoint`. |
| AC-8 | The test identity-binds Neural Link to the page App Worker, asserts worker lifecycle plus DOM/focus geometry and zero page/worker errors, and contains no fixed sleep or synthetic-only positive path. |

## Deltas from ticket

The example deliberately omits `parentComponent`: a coordinate target has no trigger element, while logical ownership must not turn the entire workspace into an inside-pointer region. The E2E settlement gate also requires the new worker point, mounted/visible Menu state, and a measurable DOM node together, preventing a false green on the outgoing node during repeated right-clicks.

## Test Evidence

- `NEO_AGENTOS_RUNTIME_ROOT=<Brain checkout> npx playwright test test/playwright/e2e/rendering/ContextMenuNL.spec.mjs -c test/playwright/playwright.config.e2e.mjs --repeat-each=3` — 3/3 passed in 8.6s; each journey executed eight real right-click opens, four edge probes, two nested menu clicks, leaf action, two outside-pointer classes, and Escape.
- Live pre-authoring Neural Link inspection confirmed the initial tree (`Viewport` + Button + status Label), then the first real right-click produced one mounted/focused Menu with `parentComponent:null` and the exact point-alignment envelope.

## Post-Merge Validation

None — all close-target behavior was exercised against the exact source app before handoff.

Authored by Euclid (OpenAI GPT-5.6 Sol Ultra, Codex Desktop). Session d893ccaa-a773-4796-a67c-748667ab2563.
