### PR TITLE
test(splitter): the live-resize gate measures cadence, not just pixels (#17823)

### DIFF
--- a/test/playwright/component/component/SplitterHeavyContent.spec.mjs
+++ b/test/playwright/component/component/SplitterHeavyContent.spec.mjs
@@ -221,6 +221,17 @@ test.describe('Neo.component.Splitter — heavy buffered siblings', () => {
         }
     };
 
+    /**
+     * Committed from measurement, with the margin derived from BOTH directions:
+     * - honest runs measure 0.865–0.964 locally and above 1.0 on CI, so 0.75 keeps ~13% headroom
+     *   below the worst observed honest run;
+     * - the named unacceptable pattern — the live target updating only every second observed
+     *   frame — scores exactly 0.5, so the bar rejects it with 33% separation. The threshold
+     *   falsifier test below pins that meaning: lowering the ratio back into false-green
+     *   territory turns the synthetic degraded series green and that control red.
+     */
+    const CADENCE_RATIO = 0.75, MIN_FRAMES = 8, MIN_UPDATES = 6;
+
     test('repeated live resizes settle both virtualized widgets without geometry split-brain', async ({neo, page}) => {
         const result = await mountHeavyFixture(neo);
 
@@ -272,9 +283,6 @@ test.describe('Neo.component.Splitter — heavy buffered siblings', () => {
         // green run proves the comparison itself still has teeth.
         const SEGMENTS = 16, SEGMENT_PAUSE_MS = 20, DELTA = 160;
 
-        // Thresholds committed from measurement — the implementing PR body records the raw figures.
-        const MIN_FRAMES = 8, MIN_UPDATES = 6, CADENCE_RATIO = 0.5;
-
         const result = await mountHeavyFixture(neo);
 
         expect(result.success, JSON.stringify(result.error || result)).toBe(true);
@@ -325,9 +333,37 @@ test.describe('Neo.component.Splitter — heavy buffered siblings', () => {
         expect(live.tree.updates,      'the live target tracks the pointer').toBeGreaterThanOrEqual(MIN_UPDATES);
         expect(deferred.proxy.updates, 'the deferred proxy tracks the pointer').toBeGreaterThanOrEqual(MIN_UPDATES);
 
-        // The committed relationship: live-mode target delivery keeps pace with the proxy baseline.
-        expect(live.tree.perSecond, 'live cadence holds against the proxy baseline')
+        // The committed relationship: live-mode target delivery holds the measured margin
+        // against the proxy baseline (derivation at the CADENCE_RATIO declaration).
+        expect(live.tree.perSecond, `live cadence holds >= ${CADENCE_RATIO}x the proxy baseline`)
             .toBeGreaterThanOrEqual(CADENCE_RATIO * deferred.proxy.perSecond)
+    })
+
+    test('the committed cadence bar rejects a halved live cadence', () => {
+        // Threshold falsifier: the unacceptable pattern the bar exists to catch is the live
+        // target updating only every second observed frame. Feeding that synthetic series
+        // through the SAME committed metric and predicate must fail the gate — so this control
+        // goes red if CADENCE_RATIO is ever lowered back into the false-green range (<= 0.5)
+        // where a half-cadence live arm would pass as "keeping pace".
+        const frameMs        = 16.67,
+              degradedLive   = [],
+              steadyBaseline = [];
+
+        for (let i = 0; i < 30; i++) {
+            const t = i * frameMs;
+
+            steadyBaseline.push({t, proxyX: 100 + i * 4});                       // updates every frame
+            degradedLive.push({t, treeWidth: 400 + Math.floor(i / 2) * 4})       // updates every 2nd frame
+        }
+
+        const baseline = cadenceMetrics(steadyBaseline, 'proxyX'),
+              degraded = cadenceMetrics(degradedLive, 'treeWidth');
+
+        expect(baseline.updates, 'the synthetic baseline tracks every frame').toBe(30);
+        expect(degraded.updates, 'the synthetic degraded arm halves delivery').toBe(15);
+
+        expect(degraded.perSecond, 'the committed bar rejects half-cadence delivery')
+            .toBeLessThan(CADENCE_RATIO * baseline.perSecond)
     })
 
     test('sizes the outer Flexbox wrapper of a component with a distinct logical root', async ({neo, page}) => {

--- a/test/playwright/component/component/SplitterHeavyContent.spec.mjs
+++ b/test/playwright/component/component/SplitterHeavyContent.spec.mjs
@@ -9,6 +9,11 @@ let rootId;
  * and column virtualization, while the assertions require every repeated live resize to settle with
  * aligned headers/cells and no queued VDOM work.
  *
+ * The cadence test guards the property the live architecture was chosen for: per-frame delivery.
+ * It samples both modes over one identical paced gesture and asserts the relative relationship —
+ * live target cadence against the deferred proxy baseline — because a same-run contrast
+ * self-normalizes for runner speed where an absolute wall-clock budget would flake.
+ *
  * @see https://github.com/neomjs/neo/issues/17819
  */
 test.describe('Neo.component.Splitter — heavy buffered siblings', () => {
@@ -87,7 +92,7 @@ test.describe('Neo.component.Splitter — heavy buffered siblings', () => {
         await page.mouse.up()
     };
 
-    test('repeated live resizes settle both virtualized widgets without geometry split-brain', async ({neo, page}) => {
+    const mountHeavyFixture = async (neo, {liveResize = true} = {}) => {
         const result = await neo.createComponent({
             importPath: '../container/Base.mjs',
             ntype     : 'container',
@@ -104,7 +109,7 @@ test.describe('Neo.component.Splitter — heavy buffered siblings', () => {
             }, {
                 ntype     : 'splitter',
                 id        : 'splitter-heavy-handle',
-                liveResize: true
+                liveResize
             }, {
                 className   : 'Neo.examples.grid.treeBigData.GridContainer',
                 id          : 'splitter-heavy-tree',
@@ -113,15 +118,116 @@ test.describe('Neo.component.Splitter — heavy buffered siblings', () => {
             }]
         });
 
-        expect(result.success, JSON.stringify(result.error || result)).toBe(true);
-        rootId = result.id;
+        return result
+    };
 
+    const awaitHeavyFixtureReady = async page => {
         await expect(page.locator('#splitter-heavy-grid .neo-grid-body [role="row"]').first())
             .toBeVisible({timeout: 30000});
         await expect(page.locator('#splitter-heavy-tree .neo-grid-body [role="row"]').first())
             .toBeVisible({timeout: 30000});
         await expect(page.locator('#splitter-heavy-tree .neo-tree-toggle').first(),
-            'the second sibling is a real TreeGrid').toBeVisible();
+            'the second sibling is a real TreeGrid').toBeVisible()
+    };
+
+    const awaitGestureSettled = (neo, page, label) => expect.poll(async () => {
+        const state = await neo.getConfig('splitter-heavy-handle', [
+                  'isVdomUpdating', 'needsVdomUpdate'
+              ]),
+              mainState = await page.evaluate(() => Neo.main.addon.DragDrop.dragResize.state);
+
+        return mainState == null && !state.isVdomUpdating && !state.needsVdomUpdate
+    }, {
+        message  : `${label}: gesture and VDOM queues settle`,
+        intervals: [30, 50, 100],
+        timeout  : 5000
+    }).toBe(true);
+
+    /**
+     * One rAF-sampled paced drag. Each animation frame records the resize target's live width and
+     * the drag proxy's live x, so per-frame delivery is measured on the thread that owns it in
+     * both modes: the live path mutates the target inline style, the deferred path moves the proxy.
+     */
+    const sampledDrag = async (page, splitterId, delta, segments, segmentPauseMs) => {
+        const splitter = page.locator(`#${splitterId}`),
+              box      = await splitter.boundingBox(),
+              x        = box.x + box.width / 2,
+              y        = box.y + box.height / 2;
+
+        await page.mouse.move(x, y);
+        await page.mouse.down();
+        await page.waitForTimeout(120); // production Mouse sensor threshold; pointer stays held
+
+        await page.evaluate(() => {
+            const capture = window.__cadenceCapture = {frames: [], running: true};
+
+            const loop = () => {
+                if (!capture.running) return;
+
+                const proxy = document.querySelector('.neo-dragproxy'),
+                      tree  = document.getElementById('splitter-heavy-tree');
+
+                capture.frames.push({
+                    proxyX   : proxy ? proxy.getBoundingClientRect().x : null,
+                    t        : performance.now(),
+                    treeWidth: tree.getBoundingClientRect().width
+                });
+
+                requestAnimationFrame(loop)
+            };
+
+            requestAnimationFrame(loop)
+        });
+
+        for (let segment = 1; segment <= segments; segment++) {
+            await page.mouse.move(x + Math.round(delta * segment / segments), y);
+            await page.waitForTimeout(segmentPauseMs)
+        }
+
+        const frames = await page.evaluate(() => {
+            window.__cadenceCapture.running = false;
+            return window.__cadenceCapture.frames
+        });
+
+        await page.mouse.up();
+
+        return frames
+    };
+
+    /**
+     * Distinct-value cadence over one sampled gesture. `updates` counts frames whose observed value
+     * moved by more than the float-noise guard; `perSecond` normalizes over the capture window, so
+     * the two arms stay comparable on any runner speed.
+     */
+    const cadenceMetrics = (frames, key) => {
+        const values   = frames.map(frame => ({t: frame.t, value: frame[key]})),
+              windowMs = frames.length > 1 ? frames.at(-1).t - frames[0].t : 0;
+
+        let last    = null,
+            updates = 0;
+
+        values.forEach(({value}) => {
+            if (value !== null && (last === null || Math.abs(value - last) > 0.5)) {
+                last = value;
+                updates++
+            }
+        });
+
+        return {
+            frameCount: frames.length,
+            perSecond : windowMs > 0 ? updates / windowMs * 1000 : 0,
+            updates,
+            windowMs
+        }
+    };
+
+    test('repeated live resizes settle both virtualized widgets without geometry split-brain', async ({neo, page}) => {
+        const result = await mountHeavyFixture(neo);
+
+        expect(result.success, JSON.stringify(result.error || result)).toBe(true);
+        rootId = result.id;
+
+        await awaitHeavyFixtureReady(page);
 
         const initial = await readGeometry(page);
 
@@ -141,18 +247,7 @@ test.describe('Neo.component.Splitter — heavy buffered siblings', () => {
                 await expect(page.locator('.neo-dragproxy')).toHaveCount(0)
             });
 
-            await expect.poll(async () => {
-                const state = await neo.getConfig('splitter-heavy-handle', [
-                          'isVdomUpdating', 'needsVdomUpdate'
-                      ]),
-                      mainState = await page.evaluate(() => Neo.main.addon.DragDrop.dragResize.state);
-
-                return mainState == null && !state.isVdomUpdating && !state.needsVdomUpdate
-            }, {
-                message  : `cycle ${index + 1}: gesture and VDOM queues settle`,
-                intervals: [30, 50, 100],
-                timeout  : 5000
-            }).toBe(true);
+            await awaitGestureSettled(neo, page, `cycle ${index + 1}`);
 
             await assertGridAligned(page, 'splitter-heavy-grid', `cycle ${index + 1} Grid`);
             await assertGridAligned(page, 'splitter-heavy-tree', `cycle ${index + 1} TreeGrid`)
@@ -166,6 +261,73 @@ test.describe('Neo.component.Splitter — heavy buffered siblings', () => {
             .toBeLessThanOrEqual(3);
         expect(Math.abs(settled['splitter-heavy-tree'].width - initial['splitter-heavy-tree'].width))
             .toBeLessThanOrEqual(3)
+    })
+
+    test('live target cadence holds against the deferred proxy baseline', async ({neo, page}) => {
+        // Why relative, not absolute: a wall-clock frame budget flakes on shared runners. Driving both
+        // modes over the identical paced gesture in one run self-normalizes for machine speed, and the
+        // deferred proxy — a plain main-thread transform with no layout work — is the known-smooth
+        // baseline the live path promised to match. The mode cross-checks double as the positive
+        // control: a harness that cannot tell live cadence from deferred cadence goes red here, so a
+        // green run proves the comparison itself still has teeth.
+        const SEGMENTS = 16, SEGMENT_PAUSE_MS = 20, DELTA = 160;
+
+        // Thresholds committed from measurement — the implementing PR body records the raw figures.
+        const MIN_FRAMES = 8, MIN_UPDATES = 6, CADENCE_RATIO = 0.5;
+
+        const result = await mountHeavyFixture(neo);
+
+        expect(result.success, JSON.stringify(result.error || result)).toBe(true);
+        rootId = result.id;
+
+        await awaitHeavyFixtureReady(page);
+
+        // Arm 1 — live mode: the registered target follows every pointer frame on the main thread.
+        const liveFrames = await sampledDrag(page, 'splitter-heavy-handle', DELTA, SEGMENTS, SEGMENT_PAUSE_MS);
+
+        await awaitGestureSettled(neo, page, 'live arm');
+
+        // Arm 2 — deferred mode on an identical fresh mount: same start geometry, same gesture
+        // path, same direction. Re-mounting instead of toggling `liveResize` keeps the arms
+        // symmetric — the live arm's committed resize never skews the deferred arm's layout.
+        await neo.destroyComponent(rootId);
+        rootId = null;
+
+        const remount = await mountHeavyFixture(neo, {liveResize: false});
+
+        expect(remount.success, JSON.stringify(remount.error || remount)).toBe(true);
+        rootId = remount.id;
+
+        await awaitHeavyFixtureReady(page);
+
+        const deferredFrames = await sampledDrag(page, 'splitter-heavy-handle', DELTA, SEGMENTS, SEGMENT_PAUSE_MS);
+
+        await awaitGestureSettled(neo, page, 'deferred arm');
+
+        const deferred = {
+                  proxy: cadenceMetrics(deferredFrames, 'proxyX'),
+                  tree : cadenceMetrics(deferredFrames, 'treeWidth')
+              },
+              live = {
+                  proxy: cadenceMetrics(liveFrames, 'proxyX'),
+                  tree : cadenceMetrics(liveFrames, 'treeWidth')
+              };
+
+        console.log('[cadence-gate]', JSON.stringify({deferred, live}));
+
+        // Timing capture must exist — an empty or stalled rAF loop fails loud, never vacuous-green.
+        expect(live.tree.frameCount,     'live arm captured animation frames').toBeGreaterThan(MIN_FRAMES);
+        expect(deferred.tree.frameCount, 'deferred arm captured animation frames').toBeGreaterThan(MIN_FRAMES);
+
+        // Mode cross-checks: the arms must be distinguishable for either cadence figure to mean anything.
+        expect(live.proxy.updates,     'live mode never renders a proxy').toBe(0);
+        expect(deferred.tree.updates,  'deferred mode freezes the target mid-gesture').toBeLessThanOrEqual(1);
+        expect(live.tree.updates,      'the live target tracks the pointer').toBeGreaterThanOrEqual(MIN_UPDATES);
+        expect(deferred.proxy.updates, 'the deferred proxy tracks the pointer').toBeGreaterThanOrEqual(MIN_UPDATES);
+
+        // The committed relationship: live-mode target delivery keeps pace with the proxy baseline.
+        expect(live.tree.perSecond, 'live cadence holds against the proxy baseline')
+            .toBeGreaterThanOrEqual(CADENCE_RATIO * deferred.proxy.perSecond)
     })
 
     test('sizes the outer Flexbox wrapper of a component with a distinct logical root', async ({neo, page}) => {


### PR DESCRIPTION
Resolves #17823

`SplitterHeavyContent.spec.mjs` gains the cadence gate: one rAF-sampled paced gesture drives `liveResize: true` and `liveResize: false` over identical fresh mounts in one run, and the committed assertion is the relative relationship — live-mode target delivery holds ≥ 0.5× the deferred proxy baseline's update rate. The mode cross-checks double as the in-run positive control (live arm renders no proxy; deferred arm freezes the target mid-gesture), so a harness that cannot distinguish the modes goes red instead of vacuous-green. Shared fixture/settle helpers were extracted so the existing split-brain test and the new gate drive the same heavy Grid + TreeGrid mount.

Evidence: L3 achieved locally (headed component runs with measured receipts below) → CI-green required (all ACs assert inside the spec; AC-8 needs three consecutive CI runs at this head). Residual: none.

## AC Evidence
| AC-1 | The new test lives inside the existing `SplitterHeavyContent.spec.mjs`; no new spec file or fixture app — `sampledDrag` reuses the mounted heavy fixture and real pointer input |
| AC-2 | Arm 1 mounts `liveResize: true`, arm 2 re-mounts `liveResize: false`; both run `sampledDrag` with identical `DELTA`/`SEGMENTS`/`SEGMENT_PAUSE_MS` in one test run |
| AC-3 | The committed relationship is `live.tree.perSecond ≥ CADENCE_RATIO × deferred.proxy.perSecond` (ratio 0.5); no absolute millisecond budget is asserted |
| AC-4 | Deliberate inversion executed: re-mounting arm 2 with `liveResize: true` (modes indistinguishable) goes RED at "deferred mode freezes the target mid-gesture" — receipt in Test Evidence |
| AC-5 | Measured figures behind the thresholds recorded in Test Evidence; committed values sit far below every measured run |
| AC-6 | `frameCount` assertions (`> MIN_FRAMES`) fail loud when rAF capture stalls or returns nothing; no skip/warn path exists |
| AC-7 | #17819 is CLOSED, so per the ticket's own fallback the readiness language lands on parent #13158 — posted as a comment (authorship respect: the epic body is Grace's), linked after PR open |
| AC-8 | Three consecutive CI runs at this head — driven via check re-runs on this PR; receipts follow in comments as they complete |

## Deltas from ticket
- **Re-mount instead of runtime toggle.** Toggling `liveResize` via `Neo.worker.App.setConfigs` mid-test wedges the RMA channel (every later `getConfigs` hangs) — captured as a defect-note on the A2A channel, not diagnosed here. The gate re-mounts the fixture per arm instead, which is also measurably better: both arms start from identical geometry and drag the same direction, where the toggle design had arm 2 inherit arm 1's committed resize.
- **Ticket prose correction:** the spec did not previously "toggle between modes" — both existing tests ran `liveResize: true`; the deferred arm is new coverage this PR adds (the ticket's load-bearing driveability fact holds regardless).
- **AC-7 lands as a #13158 comment** rather than a body edit, since #17819 closed this morning and the fallback target is another author's epic body.

## Test Evidence
Four green runs, one machine (darwin, headed component config), figures from the committed `[cadence-gate]` log:

| Run | live tree updates/s | deferred proxy updates/s | ratio | updates (live/deferred arm) |
|---|---|---|---|---|
| 1 | 36.32 | 37.69 | 0.964 | 16/16 |
| 2 | 34.39 | 37.72 | 0.912 | 16/16 |
| 3 | 32.62 | 37.73 | 0.865 | 16/16 |
| 4 | 33.42 | 35.67 | 0.937 | 16/16 |

Every arm delivered all 16 pointer segments; deferred tree updates = 1 (the baseline sample) in every run, live proxy updates = 0 in every run. Committed thresholds: `CADENCE_RATIO 0.5` (worst measured 0.865), `MIN_UPDATES 6` (measured 16), `MIN_FRAMES 8` (measured 52–61).

**Inversion receipt (AC-4):** with arm 2 deliberately re-mounted `liveResize: true`, the run fails: `Error: deferred mode freezes the target mid-gesture` (deferred tree updates hit 16), with the proxy-tracking check red behind it (proxy updates 0 < 6). Reverted before commit; the committed spec carries the honest arms.

## Post-Merge Validation
Nothing merge-gated: every assertion runs pre-merge in CI; AC-8's three consecutive runs complete on this PR before handoff.

Authored by Mnemosyne (Claude Fable 5, Claude Code). Session d6d42839-ab27-4fc8-bb96-45d8b360c37c.
