### PR TITLE
feat(menu): render a TreeStore-driven cascade (#17839)

### DIFF
--- a/examples/menu/tree/MainContainer.mjs
+++ b/examples/menu/tree/MainContainer.mjs
@@ -1,0 +1,61 @@
+import ConfigurationViewport from '../../ConfigurationViewport.mjs';
+import MainStore             from './MainStore.mjs';
+import MenuList              from '../../../src/menu/List.mjs';
+import NumberField           from '../../../src/form/field/Number.mjs';
+
+/**
+ * @summary menu.List rendering a cascade out of a Neo.data.TreeStore.
+ *
+ * Identical wiring to `examples/menu/list`, with one difference: the store is a TreeStore instead of a
+ * menu.Store. The list does not render the tree store itself — each level derives its own flat store of
+ * the records at that level, so selection and key navigation stay correct while the tree stays the one
+ * shared source of truth.
+ *
+ * @class Neo.examples.menu.tree.MainContainer
+ * @extends Neo.examples.ConfigurationViewport
+ */
+class MainContainer extends ConfigurationViewport {
+    static config = {
+        className           : 'Neo.examples.menu.tree.MainContainer',
+        autoMount           : true,
+        configItemLabelWidth: 130,
+        configItemWidth     : 230,
+        layout              : {ntype: 'hbox', align: 'stretch'}
+    }
+
+    createConfigurationComponents() {
+        let me = this;
+
+        return [{
+            module   : NumberField,
+            clearable: true,
+            labelText: 'height',
+            listeners: {change: me.onConfigChange.bind(me, 'height')},
+            maxValue : 800,
+            minValue : 30,
+            stepSize : 5,
+            style    : {marginTop: '10px'},
+            value    : me.exampleComponent.height
+        }, {
+            module   : NumberField,
+            clearable: true,
+            labelText: 'width',
+            listeners: {change: me.onConfigChange.bind(me, 'width')},
+            maxValue : 800,
+            minValue : 100,
+            stepSize : 5,
+            style    : {marginTop: '10px'},
+            value    : me.exampleComponent.width
+        }]
+    }
+
+    createExampleComponent() {
+        return Neo.create({
+            module      : MenuList,
+            displayField: 'text',
+            store       : MainStore
+        })
+    }
+}
+
+export default Neo.setupClass(MainContainer);

--- a/examples/menu/tree/MainModel.mjs
+++ b/examples/menu/tree/MainModel.mjs
@@ -1,0 +1,32 @@
+import TreeModel from '../../../src/data/TreeModel.mjs';
+
+/**
+ * @class Neo.examples.menu.tree.MainModel
+ * @extends Neo.data.TreeModel
+ */
+class MainModel extends TreeModel {
+    static config = {
+        /**
+         * @member {String} className='Neo.examples.menu.tree.MainModel'
+         * @protected
+         */
+        className: 'Neo.examples.menu.tree.MainModel',
+        /**
+         * The hierarchy fields (parentId, isLeaf, depth, …) come from Neo.data.TreeModel.
+         * Only the menu-facing fields are declared here.
+         * @member {Object[]} fields
+         */
+        fields: [{
+            name: 'iconCls',
+            type: 'String'
+        }, {
+            name: 'id',
+            type: 'String'
+        }, {
+            name: 'text',
+            type: 'String'
+        }]
+    }
+}
+
+export default Neo.setupClass(MainModel);

--- a/examples/menu/tree/MainStore.mjs
+++ b/examples/menu/tree/MainStore.mjs
@@ -1,0 +1,59 @@
+import MainModel from './MainModel.mjs';
+import TreeStore from '../../../src/data/TreeStore.mjs';
+
+/**
+ * @summary A flat, parent-keyed menu definition — the shape a contribution registry produces.
+ *
+ * Compare `examples/menu/list/MainStore.mjs`, which nests an `items` array inside each group. Here
+ * every entry is a sibling record pointing at its parent by key, so an independent module can append
+ * one row targeting `edit` without reading, rewriting, or even knowing about the rest of the menu.
+ * That is the property nested arrays cannot offer: contributing into a group means mutating the
+ * group's own record.
+ *
+ * `collapsed` is irrelevant to a cascading menu — each level is read through the Structural Layer via
+ * `TreeStore#getChildren()`, so nothing has to be expanded for a submenu to render.
+ *
+ * @class Neo.examples.menu.tree.MainStore
+ * @extends Neo.data.TreeStore
+ */
+class MainStore extends TreeStore {
+    static config = {
+        /**
+         * @member {String} className='Neo.examples.menu.tree.MainStore'
+         * @protected
+         */
+        className: 'Neo.examples.menu.tree.MainStore',
+        /**
+         * @member {Neo.examples.menu.tree.MainModel} model=MainModel
+         */
+        model: MainModel,
+        /**
+         * @member {Object[]} data
+         */
+        data: [
+            {id: 'file',            iconCls: 'fa fa-folder',        text: 'File',        isLeaf: false},
+            {id: 'file-new',        iconCls: 'fa fa-plus',          text: 'New',         isLeaf: false, parentId: 'file'},
+            {id: 'file-new-file',   iconCls: 'far fa-file',         text: 'File',        isLeaf: true,  parentId: 'file-new'},
+            {id: 'file-new-folder', iconCls: 'far fa-folder',       text: 'Folder',      isLeaf: true,  parentId: 'file-new'},
+            {id: 'file-open',       iconCls: 'far fa-folder-open',  text: 'Open',        isLeaf: true,  parentId: 'file'},
+            {id: 'file-save',       iconCls: 'far fa-save',         text: 'Save',        isLeaf: true,  parentId: 'file'},
+
+            {id: 'edit',            iconCls: 'fa fa-pen',           text: 'Edit',        isLeaf: false},
+            {id: 'edit-copy',       iconCls: 'far fa-copy',         text: 'Copy',        isLeaf: true,  parentId: 'edit'},
+            {id: 'edit-paste',      iconCls: 'fa fa-paste',         text: 'Paste',       isLeaf: true,  parentId: 'edit'},
+
+            // Contributed by an unrelated module: one appended record, targeting a group it does not own.
+            {id: 'edit-format',     iconCls: 'fa fa-wand-magic',    text: 'Format',      isLeaf: true,  parentId: 'edit'},
+
+            {id: 'view',            iconCls: 'far fa-eye',          text: 'View',        isLeaf: false},
+            {id: 'view-theme',      iconCls: 'fa fa-palette',       text: 'Theme',       isLeaf: false, parentId: 'view'},
+            {id: 'view-theme-dark', iconCls: 'fa fa-moon',          text: 'Dark',        isLeaf: true,  parentId: 'view-theme'},
+            {id: 'view-theme-light',iconCls: 'fa fa-sun',           text: 'Light',       isLeaf: true,  parentId: 'view-theme'},
+            {id: 'view-zoom',       iconCls: 'fa fa-magnifying-glass', text: 'Zoom',     isLeaf: true,  parentId: 'view'},
+
+            {id: 'about',           iconCls: 'fa fa-circle-info',   text: 'About',       isLeaf: true}
+        ]
+    }
+}
+
+export default Neo.setupClass(MainStore);

--- a/examples/menu/tree/app.mjs
+++ b/examples/menu/tree/app.mjs
@@ -1,0 +1,6 @@
+import MainContainer from './MainContainer.mjs';
+
+export const onStart = () => Neo.app({
+    mainView: MainContainer,
+    name    : 'Neo.examples.menu.tree'
+});

--- a/examples/menu/tree/index.html
+++ b/examples/menu/tree/index.html
@@ -1,0 +1,11 @@
+<!DOCTYPE HTML>
+<html>
+<head>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta charset="UTF-8">
+    <title>Neo MenuList TreeStore</title>
+</head>
+<body>
+    <script src="../../../src/MicroLoader.mjs" type="module"></script>
+</body>
+</html>

--- a/examples/menu/tree/neo-config.json
+++ b/examples/menu/tree/neo-config.json
@@ -1,0 +1,6 @@
+{
+    "appPath"    : "examples/menu/tree/app.mjs",
+    "basePath"   : "../../../",
+    "environment": "development",
+    "mainPath"   : "./Main.mjs"
+}

--- a/learn/guides/datahandling/TreeStore.md
+++ b/learn/guides/datahandling/TreeStore.md
@@ -124,7 +124,7 @@ searching it for a parent key returns nothing for an unexpanded branch:
 // Wrong for a collapsed branch: the projection cannot see its children.
 treeStore.find('parentId', 'node-a'); // => []
 
-// Right: reads the Structural Layer, O(1), unaffected by expansion, filtering or sorting.
+// Right: reads the Structural Layer. O(1) to find the child array, O(k) to hydrate its k entries.
 treeStore.getChildren('node-a');      // => [record, record, …]
 
 // Root level. 'root' is the default, so the argument is optional.
@@ -134,6 +134,12 @@ treeStore.getChildren();
 `getChildren()` returns a **new array of hydrated records**, so Turbo Mode (`autoInitRecords: false`)
 callers get real records rather than the raw objects held internally, and mutating the returned array
 cannot corrupt the store. It returns `[]` for a leaf or an unknown key.
+
+**Expansion and filtering do not affect it; sorting does.** Visibility is a property of the Projection
+Layer, so a collapsed or filtered-out branch still returns its children. Order is not: `doSort()`
+reorders the child arrays in the Structural Layer itself, so returned siblings follow the store's
+current sort. That is deliberate — it lets a level-at-a-time consumer inherit ordering from the tree
+instead of implementing its own.
 
 Reach for `collectAllDescendants()` instead when you want an entire subtree; `getChildren()` is
 deliberately one level deep. And note that reading children this way **does not expand anything** —

--- a/learn/guides/datahandling/TreeStore.md
+++ b/learn/guides/datahandling/TreeStore.md
@@ -22,6 +22,8 @@ The `Neo.data.TreeStore` solves this by acting as a highly optimized architectur
 
 The complexity is managed entirely by the data layer, allowing UI components like `Neo.grid.Container` to render TreeGrids without knowing they are rendering a tree.
 
+> **`TreeStore` is not grid-only.** The Projection Layer is what a virtual scroller needs, so the grid is the most demanding consumer — but it is not the only shape. Components that render **one level at a time** — a cascading menu, a breadcrumb, a column browser — never touch the projection at all. They read the Structural Layer through `getChildren()` and let the hierarchy stay collapsed while they render it. `Neo.menu.List` works this way. If your consumer renders a level rather than a scrollable flat list, read the [Reading one level](#reading-one-level) section below rather than the projection semantics above.
+
 ### The RecordFactory: Bypassing the ORM Memory Trap
 
 Before discussing how the TreeStore manages state, we must address the fundamental problem of data instantiation at scale.
@@ -112,6 +114,30 @@ In Neo.mjs, `siblingCount` and `siblingIndex` are maintained directly on the rec
 Since virtual scrolling occurs at 60-120fps and mutations are comparatively rare, this explicit architectural trade-off ensures the UI never stutters while calculating accessibility attributes. Every row in the Neo.mjs TreeGrid is fully accessible without sacrificing a single frame of performance.
 
 ## Working with the TreeStore
+
+### Reading one level
+
+`items` is the **Projection Layer** — the currently *visible* nodes. Since `collapsed` defaults to `true`,
+searching it for a parent key returns nothing for an unexpanded branch:
+
+```javascript readonly
+// Wrong for a collapsed branch: the projection cannot see its children.
+treeStore.find('parentId', 'node-a'); // => []
+
+// Right: reads the Structural Layer, O(1), unaffected by expansion, filtering or sorting.
+treeStore.getChildren('node-a');      // => [record, record, …]
+
+// Root level. 'root' is the default, so the argument is optional.
+treeStore.getChildren();
+```
+
+`getChildren()` returns a **new array of hydrated records**, so Turbo Mode (`autoInitRecords: false`)
+callers get real records rather than the raw objects held internally, and mutating the returned array
+cannot corrupt the store. It returns `[]` for a leaf or an unknown key.
+
+Reach for `collectAllDescendants()` instead when you want an entire subtree; `getChildren()` is
+deliberately one level deep. And note that reading children this way **does not expand anything** —
+expansion is a view-state concern, and a level-at-a-time consumer should never mutate it just to render.
 
 ### Expanding and Collapsing
 

--- a/src/data/TreeStore.mjs
+++ b/src/data/TreeStore.mjs
@@ -636,7 +636,17 @@ class TreeStore extends Store {
      * **Why this is not a scan of `items`:** `items` is the Projection Layer — it holds only the
      * currently visible nodes, so `find('parentId', key)` silently returns nothing for a collapsed
      * branch, and `collapsed` defaults to `true`. This reads the Structural Layer (`#childrenMap`)
-     * directly, which answers in O(1) and is unaffected by expansion, filtering, or sorting state.
+     * directly instead.
+     *
+     * **Cost:** an O(1) lookup of the child array, then O(k) to hydrate and copy its k entries — not
+     * O(1) overall.
+     *
+     * **Visibility vs order — they behave differently, and only one is independent:**
+     * - *Independent:* expansion and filtering. A collapsed or filtered-out branch still returns its
+     *   children, because visibility is a property of the projection, not of the hierarchy.
+     * - *NOT independent:* order. `doSort()` reorders the child arrays in the Structural Layer itself,
+     *   so the returned sibling order follows the store's current sort. That is the intended contract —
+     *   it is how a level-at-a-time consumer inherits ordering it never has to implement.
      *
      * Consumers rendering one level at a time — a cascading menu, a breadcrumb, a column browser —
      * need exactly this: a branch's children without expanding the branch as a side effect.

--- a/src/data/TreeStore.mjs
+++ b/src/data/TreeStore.mjs
@@ -631,6 +631,31 @@ class TreeStore extends Store {
     }
 
     /**
+     * @summary Returns the direct children of a node, regardless of expansion state.
+     *
+     * **Why this is not a scan of `items`:** `items` is the Projection Layer — it holds only the
+     * currently visible nodes, so `find('parentId', key)` silently returns nothing for a collapsed
+     * branch, and `collapsed` defaults to `true`. This reads the Structural Layer (`#childrenMap`)
+     * directly, which answers in O(1) and is unaffected by expansion, filtering, or sorting state.
+     *
+     * Consumers rendering one level at a time — a cascading menu, a breadcrumb, a column browser —
+     * need exactly this: a branch's children without expanding the branch as a side effect.
+     * `collectAllDescendants()` is the wrong tool for them, since it returns the entire subtree.
+     *
+     * Records are hydrated on the way out, so Turbo Mode (`autoInitRecords: false`) callers receive
+     * real records rather than the raw objects held in the map.
+     *
+     * @param {String|Number} [parentId='root'] The parent node key. Root-level nodes live under 'root'.
+     * @returns {Object[]} A new array of the direct child records; empty when the node has none.
+     */
+    getChildren(parentId='root') {
+        let me       = this,
+            children = me.#childrenMap.get(parentId) || [];
+
+        return children.map(item => me.hydrateRecord(item))
+    }
+
+    /**
      * @summary Calculates the target flat array index for a newly added node.
      *
      * **Architectural Mechanics:**
@@ -744,12 +769,12 @@ class TreeStore extends Store {
      *
      * Consequently, it must also manually synchronize the internal `map`
      * to reflect the newly calculated flat projection, guaranteeing O(1) lookup integrity for the VDOM rendering loop.
-     * 
+     *
      * **Turbo Mode Consistency:**
-     * In **Turbo Mode** (`autoInitRecords: false`), bulk projections deal with raw data objects. 
+     * In **Turbo Mode** (`autoInitRecords: false`), bulk projections deal with raw data objects.
      * However, UI interactions (like Grid selections) rely on `SelectionModel` resolving DOM
      * `data-record-id` values (which fallback to `internalId`) back to records via `store.get()`.
-     * To prevent `store.get()` from failing, this method explicitly invokes `getInternalId` to 
+     * To prevent `store.get()` from failing, this method explicitly invokes `getInternalId` to
      * force generation of internal IDs on raw objects and perfectly synchronizes the `internalIdMap`.
      *
      * @private

--- a/src/menu/List.mjs
+++ b/src/menu/List.mjs
@@ -1,6 +1,7 @@
 import BaseList  from '../list/Base.mjs';
 import ListModel from '../selection/menu/ListModel.mjs';
 import Store     from './Store.mjs';
+import TreeStore from '../data/TreeStore.mjs';
 
 /**
  * A floating root menu forms one interaction island with its exact align target and every mounted
@@ -75,10 +76,26 @@ class List extends BaseList {
          * @member {Neo.selection.menu.ListModel} selectionModel=ListModel
          * @reactive
          */
+        /**
+         * The key of the record whose children this level renders.
+         *
+         * Only relevant when the menu is driven by a `Neo.data.TreeStore`. The root menu keeps the
+         * default and renders the tree roots; every submenu is created with the key of the item that
+         * opened it. Distinct from the inherited `parentId`, which is the VDOM parent node.
+         * @member {String|Number} parentRecordId='root'
+         */
+        parentRecordId: 'root',
+        /**
+         * @member {Neo.selection.menu.ListModel} selectionModel=ListModel
+         */
         selectionModel: ListModel,
         /**
-         * Value for the list.Base store_ config
-         * @member {Neo.menu.Store} store=Store
+         * Value for the list.Base store_ config.
+         *
+         * Accepts either a flat `Neo.menu.Store` (nested `items` arrays on each record) or a
+         * `Neo.data.TreeStore` (hierarchy expressed via `parentId`). See `beforeSetStore()` for why a
+         * tree store is not rendered directly.
+         * @member {Neo.menu.Store|Neo.data.TreeStore} store=Store
          * @reactive
          */
         store: Store,
@@ -119,6 +136,16 @@ class List extends BaseList {
      * @protected
      */
     outsidePointerListenerOwner = null
+    /**
+     * The hierarchy source, when this menu is driven by a `Neo.data.TreeStore`.
+     *
+     * The tree store is the single source of truth and is shared by every level of the cascade; it is
+     * never owned by a level and never destroyed by one. Each level renders the flat `store` derived
+     * from it. Null for the classic nested-`items` API.
+     * @member {Neo.data.TreeStore|null} sourceStore=null
+     * @protected
+     */
+    sourceStore = null
 
     /**
      * Triggered after the items config got changed
@@ -190,6 +217,36 @@ class List extends BaseList {
      */
     afterSetZIndex(value, oldValue) {
         this.style = {...this.style, zIndex: value}
+    }
+
+    /**
+     * Triggered before the store config gets changed.
+     *
+     * A `Neo.data.TreeStore` is deliberately NOT handed to `list.Base` for rendering. The inherited
+     * index math walks the full store: `getSelectedIndex()` and `getHeaderlessIndex()` both index into
+     * `store.items`. A level rendering only a subset of a shared tree store would therefore resolve
+     * selection and key navigation against every record in the tree while its DOM held one level —
+     * it would render correctly and mis-target silently.
+     *
+     * Instead the tree store is kept as `sourceStore` and this level receives its own flat store
+     * holding exactly the records it renders. `syncLevelRecords()` fills it once the configs are applied.
+     * @param {Object|Neo.data.Store|Neo.data.TreeStore} value
+     * @param {Object|Neo.data.Store} oldValue
+     * @returns {Neo.data.Store}
+     * @protected
+     */
+    beforeSetStore(value, oldValue) {
+        if (value instanceof TreeStore) {
+            this.sourceStore = value;
+
+            // The level store reuses the tree store's model CLASS, so its records keep every field the
+            // hierarchy declares (isLeaf, parentId, depth) next to the menu fields. Re-adding records
+            // under menu.Model instead would silently drop them, and hasChildren() reads isLeaf.
+            // A fresh instance, not the shared one: a level owns and destroys its own store, never the source.
+            value = {model: value.model.constructor, module: Store}
+        }
+
+        return super.beforeSetStore(value, oldValue)
     }
 
     /**
@@ -302,11 +359,41 @@ class List extends BaseList {
     }
 
     /**
+     * Returns the data-related configs for a child level, for whichever store shape drives this menu.
+     *
+     * Tree-driven levels share the one `sourceStore` and identify their slice by `parentRecordId`;
+     * classic levels keep handing down the nested `items` array. Kept as its own method so both shapes
+     * stay side by side and visible, instead of hiding a branch inside `showSubMenu()`'s config literal.
+     * @param {Object} record The item that opened the submenu
+     * @returns {Object}
+     * @protected
+     */
+    getSubMenuData(record) {
+        let me = this;
+
+        if (me.sourceStore) {
+            return {
+                parentRecordId: me.store.getKey(record),
+                store         : me.sourceStore
+            }
+        }
+
+        return {items: record.items}
+    }
+
+    /**
      * Checks if a record has items
      * @param {Object} record
      * @returns {Boolean}
      */
     hasChildren(record) {
+        // TreeModel declares isLeaf: true by default, so a branch node opts in explicitly. Testing the
+        // declared flag rather than childCount keeps async subtree loading intact: a branch whose
+        // children have not arrived yet must still render its arrow and open.
+        if (this.sourceStore) {
+            return record.isLeaf === false
+        }
+
         return Array.isArray(record.items) && record.items.length > 0
     }
 
@@ -379,13 +466,22 @@ class List extends BaseList {
     }
 
     /**
+     *
+     */
+    onConstructed() {
+        super.onConstructed();
+        this.syncLevelRecords()
+    }
+
+    /**
      * @param {String} nodeId
      */
     onKeyDownEnter(nodeId) {
         if (nodeId) {
-            let me       = this,
-                recordId = me.getItemRecordId(nodeId),
-                record   = me.store.get(recordId),
+            let me          = this,
+                recordId    = me.getItemRecordId(nodeId),
+                record      = me.store.get(recordId),
+                hasChildren = me.hasChildren(record),
                 submenu;
 
             me.callback(record.handler, me, [record]);
@@ -395,9 +491,11 @@ class List extends BaseList {
                 value  : record.route
             });
 
-            me.hideOnLeafItemClick && !record.items && me.unmount();
+            // hasChildren() is the single branch predicate: it is store-shape aware, and it does not
+            // treat an empty `items: []` array as a parent the way a raw truthiness test would.
+            me.hideOnLeafItemClick && !hasChildren && me.unmount();
 
-            if (record.items) {
+            if (hasChildren) {
                 submenu = me.subMenuMap?.[me.getMenuMapId(recordId)];
 
                 if (submenu) {
@@ -451,7 +549,7 @@ class List extends BaseList {
                 appName        : me.appName,
                 displayField   : me.displayField,
                 floating       : true,
-                items          : record.items,
+                ...me.getSubMenuData(record),
                 isRoot         : false,
                 parentComponent: me.parentComponent,
                 parentId       : me.app.mainView.id,
@@ -464,6 +562,24 @@ class List extends BaseList {
         if (me.activeSubMenu !== subMenu) {
             me.activeSubMenu = subMenu;
             subMenu.initVnode(true)
+        }
+    }
+
+    /**
+     * Fills this level's flat store with exactly the records it renders.
+     *
+     * A no-op for the classic nested-`items` API, where `afterSetItems()` already owns the contents.
+     * Driven from `onConstructed()` rather than a config setter because the derivation needs both
+     * `sourceStore` and `parentRecordId`, and config application order is not a contract worth
+     * depending on.
+     * @protected
+     */
+    syncLevelRecords() {
+        let me = this;
+
+        if (me.sourceStore) {
+            me.store.clear();
+            me.store.add(me.sourceStore.getChildren(me.parentRecordId))
         }
     }
 

--- a/src/menu/List.mjs
+++ b/src/menu/List.mjs
@@ -288,6 +288,7 @@ class List extends BaseList {
         me.sourceStore?.un({
             mutate      : me.onSourceStoreMutate,
             recordChange: me.onSourceStoreRecordChange,
+            sort        : me.onSourceStoreSort,
             scope       : me
         });
 
@@ -609,9 +610,16 @@ class List extends BaseList {
      * @protected
      */
     onSourceStoreMutate(data) {
-        let me      = this,
-            added   = (data.addedItems   || []).filter(record => me.belongsToLevel(record)),
-            removed = (data.removedItems || []).filter(record => me.belongsToLevel(record));
+        let me            = this,
+            {sourceStore} = me,
+            removed       = (data.removedItems || []).filter(record => me.belongsToLevel(record)),
+            added         = (data.addedItems   || [])
+                .filter(record => me.belongsToLevel(record))
+                // Resolve every addition through the source before inserting it. The mutate payload can
+                // carry raw data, and letting the level store hydrate that would mint a SECOND record
+                // instance for the same key. Levels resolve a later recordChange by identity, so a clone
+                // is not merely wasteful — the row silently stops updating for the rest of its life.
+                .map(record => sourceStore.get(sourceStore.getKey(record)) || record);
 
         // Splicing the level store is enough to repaint it: the collection turns a mutation into a
         // `load` (via onCollectionMutate), which list.Base already re-renders on. Calling createItems()

--- a/src/menu/List.mjs
+++ b/src/menu/List.mjs
@@ -283,6 +283,14 @@ class List extends BaseList {
         me.syncOutsidePointerListener(false);
         activeSubMenu?.unmount();
 
+        // The tree store outlives every level, so a level that stops rendering must stop listening.
+        // Its own object literal — on() and un() both consume keys from what they are handed.
+        me.sourceStore?.un({
+            mutate      : me.onSourceStoreMutate,
+            recordChange: me.onSourceStoreRecordChange,
+            scope       : me
+        });
+
         Object.entries(subMenuMap).forEach(([key, value]) => {
             value.destroy();
             subMenuMap[key] = null
@@ -470,7 +478,21 @@ class List extends BaseList {
      */
     onConstructed() {
         super.onConstructed();
-        this.syncLevelRecords()
+
+        let me = this;
+
+        if (me.sourceStore) {
+            me.syncLevelRecords();
+
+            // Its own object: Observable#on() and #un() CONSUME keys from what they are handed
+            // (`scope` among them), so the two calls can never share one literal.
+            me.sourceStore.on({
+                mutate      : me.onSourceStoreMutate,
+                recordChange: me.onSourceStoreRecordChange,
+                sort        : me.onSourceStoreSort,
+                scope       : me
+            })
+        }
     }
 
     /**
@@ -563,6 +585,70 @@ class List extends BaseList {
             me.activeSubMenu = subMenu;
             subMenu.initVnode(true)
         }
+    }
+
+    /**
+     * A mutation anywhere in the shared tree is broadcast to every level. Only the records parented by
+     * this level's `parentRecordId` belong here.
+     * @param {Object} record
+     * @returns {Boolean}
+     * @protected
+     */
+    belongsToLevel(record) {
+        return (record.parentId || 'root') === this.parentRecordId
+    }
+
+    /**
+     * Splices this level for a tree mutation, rather than re-deriving it.
+     *
+     * Records contributed to a group after mount therefore appear without rebuilding the cascade, and
+     * order follows the Structural Layer — so a sort applied to the tree store reaches every level.
+     * @param {Object} data
+     * @param {Object[]} data.addedItems
+     * @param {Object[]} data.removedItems
+     * @protected
+     */
+    onSourceStoreMutate(data) {
+        let me      = this,
+            added   = (data.addedItems   || []).filter(record => me.belongsToLevel(record)),
+            removed = (data.removedItems || []).filter(record => me.belongsToLevel(record));
+
+        // Splicing the level store is enough to repaint it: the collection turns a mutation into a
+        // `load` (via onCollectionMutate), which list.Base already re-renders on. Calling createItems()
+        // here as well rendered the level twice per contribution.
+        removed.length && me.store.remove(removed);
+        added.length   && me.store.add(added)
+    }
+
+    /**
+     * Re-derives this level after the tree store sorts.
+     *
+     * A sort reorders the Structural Layer wholesale, so sibling order is controlled at the tree and
+     * every level follows it. Re-deriving is correct here precisely because nothing is spliceable —
+     * unlike a mutation, a sort has no added or removed set.
+     * @protected
+     */
+    onSourceStoreSort() {
+        // syncLevelRecords() clears and refills the level store, and that mutation repaints it through
+        // the same load path a contribution uses. No explicit re-render here either.
+        this.syncLevelRecords()
+    }
+
+    /**
+     * Repaints the single row a changed record occupies, if this level renders it.
+     *
+     * A level shares record INSTANCES with the tree store, so the data is already current — only the
+     * rendering needs to catch up. `data.index` from the source is the tree's projection index and is
+     * meaningless here, so the row is resolved against this level's own store.
+     * @param {Object} data
+     * @param {Object} data.record
+     * @protected
+     */
+    onSourceStoreRecordChange(data) {
+        let me    = this,
+            index = me.store.indexOf(data.record);
+
+        index > -1 && me.onStoreRecordChange({...data, index})
     }
 
     /**

--- a/test/playwright/unit/data/TreeStore.spec.mjs
+++ b/test/playwright/unit/data/TreeStore.spec.mjs
@@ -977,7 +977,7 @@ test.describe('Neo.data.TreeStore (updateKey override)', () => {
         expect(store.get('1-1-1').parentId).toBe('1-1');
 
         let itemToUpdate = store.get('1-1');
-        
+
         // Perform the key update
         store.updateKey(itemToUpdate, 'new-id');
 
@@ -988,7 +988,7 @@ test.describe('Neo.data.TreeStore (updateKey override)', () => {
         // Validate base maps fallback resolving correctly
         expect(store.get('1-1')).toBeNull();
         expect(store.get('new-id')).toBe(itemToUpdate);
-        
+
         // Validate children have correct new parentId
         let child1 = store.get('1-1-1');
         let child2 = store.get('1-1-2');
@@ -1013,11 +1013,93 @@ test.describe('Neo.data.TreeStore (updateKey override)', () => {
         store.updateKey(itemToUpdate, 'new-root-x');
 
         expect(store.getKey(itemToUpdate)).toBe('new-root-x');
-        
+
         // Child X1 is hidden because root is collapsed.
         // Getting it will hydrate it via allRecordsMap.
         let hydratedChild = store.get('1-1');
-        
+
         expect(hydratedChild.parentId).toBe('new-root-x');
     });
+});
+
+test.describe('Neo.data.TreeStore (getChildren)', () => {
+    let store;
+
+    class GetChildrenTreeModel extends TreeModel {
+        static config = {
+            className: 'Test.Unit.Data.TreeStore.GetChildrenTreeModel',
+            fields   : [
+                {name: 'id',   type: 'String'},
+                {name: 'name', type: 'String'}
+            ]
+        }
+    }
+
+    const GetChildrenModel = Neo.setupClass(GetChildrenTreeModel);
+
+    test.beforeEach(() => {
+        store = Neo.create(TreeStore, {
+            model: GetChildrenModel,
+            data : [
+                {id: 'root-1', name: 'src',          isLeaf: false, collapsed: false},
+                {id: 'folder', name: 'component',    isLeaf: false, collapsed: true, parentId: 'root-1'},
+                {id: 'leaf-a', name: 'Base.mjs',     isLeaf: true,                   parentId: 'folder'},
+                {id: 'leaf-b', name: 'Button.mjs',   isLeaf: true,                   parentId: 'folder'},
+                {id: 'root-2', name: 'package.json', isLeaf: true}
+            ]
+        })
+    });
+
+    test.afterEach(() => {
+        store?.destroy()
+    });
+
+    test('returns the children of a COLLAPSED node — the case find() cannot serve', () => {
+        expect(store.get('folder').collapsed).toBe(true);
+
+        // Premise control. The Projection Layer holds visible nodes only, so this is the exact gap
+        // getChildren() exists to close. If this assertion ever flips, the accessor has stopped
+        // earning its existence and this block should be revisited rather than quietly kept green.
+        expect(store.find('parentId', 'folder')).toHaveLength(0);
+
+        const children = store.getChildren('folder');
+
+        expect(children).toHaveLength(2);
+        expect(children.map(item => item.name)).toEqual(['Base.mjs', 'Button.mjs'])
+    });
+
+    test('returns the root level by default', () => {
+        expect(store.getChildren().map(item => item.id)).toEqual(['root-1', 'root-2'])
+    });
+
+    test('returns an empty array for a leaf and for an unknown key', () => {
+        expect(store.getChildren('leaf-a')).toEqual([]);
+        expect(store.getChildren('does-not-exist')).toEqual([])
+    });
+
+    test('hands back a copy — mutating the result cannot corrupt the Structural Layer', () => {
+        store.getChildren('folder').push({id: 'injected'});
+
+        expect(store.getChildren('folder')).toHaveLength(2)
+    });
+
+    test('hydrates records in Turbo Mode', () => {
+        const turboStore = Neo.create(TreeStore, {
+            autoInitRecords: false,
+            model          : GetChildrenModel,
+            data           : [
+                {id: 'r',  name: 'Root',  isLeaf: false, collapsed: true},
+                {id: 'c1', name: 'Child', isLeaf: true, parentId: 'r'}
+            ]
+        });
+
+        // Raw objects in the map, records on the way out: a Turbo Mode caller must not have to know.
+        const children = turboStore.getChildren('r');
+
+        expect(children).toHaveLength(1);
+        expect(children[0].isRecord).toBe(true);
+        expect(children[0].name).toBe('Child');
+
+        turboStore.destroy()
+    })
 });

--- a/test/playwright/unit/menu/ListTreeStore.spec.mjs
+++ b/test/playwright/unit/menu/ListTreeStore.spec.mjs
@@ -224,6 +224,86 @@ test.describe('Neo.menu.List driven by a TreeStore', () => {
         expect(root.store.getCount()).toBe(3)
     });
 
+    test('changing one record repaints that row only — no level rebuild', () => {
+        const menu = createMenu({store: treeStore});
+
+        menus.push(menu);
+
+        let rebuilds = 0, rowRepaints = 0;
+
+        menu.createItems         = () => {rebuilds++};
+        menu.onStoreRecordChange = () => {rowRepaints++};
+
+        treeStore.get('edit').text = 'Edit (modified)';
+
+        expect(rowRepaints).toBe(1);
+        expect(rebuilds).toBe(0);
+
+        // Levels share record instances with the tree, so the data was already current.
+        expect(menu.store.get('edit').text).toBe('Edit (modified)')
+    });
+
+    test('a record contributed after mount appears, and only its own level re-renders', () => {
+        const root   = createMenu({store: treeStore}),
+              level1 = createMenu({...root.getSubMenuData(root.store.get('edit'))});
+
+        menus.push(root, level1);
+
+        let rootRenders = 0, levelRenders = 0;
+
+        root.createItems   = () => {rootRenders++};
+        level1.createItems = () => {levelRenders++};
+
+        expect(level1.store.getCount()).toBe(1);
+
+        // An unrelated module contributes into a group it does not own.
+        treeStore.add({id: 'edit-find', text: 'Find', isLeaf: true, parentId: 'edit'});
+
+        expect(level1.store.get('edit-find').text).toBe('Find');
+        expect(level1.store.getCount()).toBe(2);
+        expect(levelRenders).toBe(1);
+
+        // The root level holds no record parented by 'edit', so it must not have moved at all.
+        expect(rootRenders).toBe(0);
+        expect(root.store.getCount()).toBe(3)
+    });
+
+    test('contribution order does not change the result', () => {
+        const storeA = createTreeStore(),
+              storeB = createTreeStore(),
+              menuA  = createMenu({store: storeA}),
+              menuB  = createMenu({store: storeB});
+
+        menus.push(menuA, menuB);
+
+        storeA.add({id: 'x', text: 'X', isLeaf: true});
+        storeA.add({id: 'y', text: 'Y', isLeaf: true});
+
+        storeB.add({id: 'y', text: 'Y', isLeaf: true});
+        storeB.add({id: 'x', text: 'X', isLeaf: true});
+
+        // Same set either way. Order is the tree's to decide (see the sort test), not the caller's.
+        expect(new Set(menuA.store.items.map(i => i.id)))
+            .toEqual(new Set(menuB.store.items.map(i => i.id)));
+
+        storeA.destroy();
+        storeB.destroy()
+    });
+
+    test('sibling order follows the tree, and a tree sort reaches every level', () => {
+        const root   = createMenu({store: treeStore}),
+              level1 = createMenu({...root.getSubMenuData(root.store.get('file'))});
+
+        menus.push(root, level1);
+
+        expect(level1.store.items.map(i => i.text)).toEqual(['New', 'Open']);
+
+        treeStore.sorters = [{property: 'text', direction: 'DESC'}];
+
+        // Order is controlled once, at the tree; a level never sorts independently of it.
+        expect(level1.store.items.map(i => i.text)).toEqual(['Open', 'New'])
+    });
+
     test('the classic nested-items API is untouched', () => {
         const menu = createMenu({
             items: [

--- a/test/playwright/unit/menu/ListTreeStore.spec.mjs
+++ b/test/playwright/unit/menu/ListTreeStore.spec.mjs
@@ -200,6 +200,30 @@ test.describe('Neo.menu.List driven by a TreeStore', () => {
         expect(treeStore.getChildren('edit')).toHaveLength(1)
     });
 
+    test('showSubMenu opens a real child level and leaves the parent alive', () => {
+        const root = createMenu({store: treeStore});
+
+        menus.push(root);
+
+        const record = root.store.get('file'),
+              nodeId = root.getItemId(root.store.getKey(record));
+
+        root.showSubMenu(nodeId, record);
+
+        const submenu = root.activeSubMenu;
+
+        menus.push(submenu);
+
+        expect(submenu).toBeTruthy();
+        expect(submenu.sourceStore).toBe(treeStore);
+        expect(submenu.store.items.map(item => item.id)).toEqual(['file-new', 'file-open']);
+
+        // Opening a child must not tear the parent down. Guards the whole interaction path, which a
+        // themeless browser cannot report on reliably.
+        expect(root.isDestroyed).toBeFalsy();
+        expect(root.store.getCount()).toBe(3)
+    });
+
     test('the classic nested-items API is untouched', () => {
         const menu = createMenu({
             items: [

--- a/test/playwright/unit/menu/ListTreeStore.spec.mjs
+++ b/test/playwright/unit/menu/ListTreeStore.spec.mjs
@@ -1,0 +1,229 @@
+import {setup} from '../../setup.mjs';
+
+const
+    appName  = 'MenuListTreeStoreTest',
+    mainView = {
+        id          : 'menu-treestore-main-view',
+        domListeners: [],
+        addDomListeners() {},
+        removeDomListeners() {}
+    };
+
+setup({
+    neoConfig: {
+        unitTestMode: true
+    },
+    appConfig: {
+        name: appName,
+        mainView
+    }
+});
+
+import {test, expect} from '@playwright/test';
+import Neo            from '../../../../src/Neo.mjs';
+import * as core      from '../../../../src/core/_export.mjs';
+import Instance       from '../../../../src/manager/Instance.mjs';
+import MenuList       from '../../../../src/menu/List.mjs';
+import TreeModel      from '../../../../src/data/TreeModel.mjs';
+import TreeStore      from '../../../../src/data/TreeStore.mjs';
+
+/**
+ * @summary menu.List driven by a Neo.data.TreeStore.
+ *
+ * The cascade renders one floating menu.List per level. A level never renders a subset of the shared
+ * tree store — list.Base index math (getSelectedIndex, getHeaderlessIndex) walks the full store.items,
+ * so a subset would resolve selection against the whole tree. Each level therefore derives its own flat
+ * store, and the tree store stays the single shared source of truth that no level owns.
+ */
+
+class MenuTreeModel extends TreeModel {
+    static config = {
+        className: 'Test.Unit.Menu.ListTreeStore.MenuTreeModel',
+        fields   : [
+            {name: 'id',      type: 'String'},
+            {name: 'iconCls', type: 'String'},
+            {name: 'text',    type: 'String'}
+        ]
+    }
+}
+
+const MenuModel = Neo.setupClass(MenuTreeModel);
+
+/**
+ * @param {Object} [config]
+ * @returns {Neo.data.TreeStore}
+ */
+function createTreeStore(config={}) {
+    return Neo.create(TreeStore, {
+        model: MenuModel,
+        data : [
+            {id: 'file',      text: 'File',       isLeaf: false, collapsed: true},
+            {id: 'file-new',  text: 'New',        isLeaf: false, collapsed: true, parentId: 'file'},
+            {id: 'file-new-f',text: 'File…',      isLeaf: true,                   parentId: 'file-new'},
+            {id: 'file-open', text: 'Open',       isLeaf: true,                   parentId: 'file'},
+            {id: 'edit',      text: 'Edit',       isLeaf: false, collapsed: true},
+            {id: 'edit-copy', text: 'Copy',       isLeaf: true,                   parentId: 'edit'},
+            {id: 'about',     text: 'About',      isLeaf: true}
+        ],
+        ...config
+    })
+}
+
+/**
+ * @param {Object} [config]
+ * @returns {Neo.menu.List}
+ */
+function createMenu(config={}) {
+    const menu = Neo.create(MenuList, {
+        appName,
+        id: Neo.getId('treestore-menu'),
+        ...config
+    });
+
+    menu.alignTo       = Neo.emptyFn;
+    menu.focus         = Neo.emptyFn;
+    menu.initDomEvents = Neo.emptyFn;
+
+    return menu
+}
+
+test.describe('Neo.menu.List driven by a TreeStore', () => {
+    let menus, treeStore;
+
+    test.beforeEach(() => {
+        menus     = [];
+        treeStore = createTreeStore()
+    });
+
+    test.afterEach(() => {
+        menus.forEach(menu => {!menu.isDestroyed && menu.destroy()});
+        !treeStore.isDestroyed && treeStore.destroy()
+    });
+
+    test('the root level renders the tree roots only, not the flattened tree', () => {
+        const menu = createMenu({store: treeStore});
+
+        menus.push(menu);
+
+        // The tree holds 7 records across 3 depths. The root menu shows 3.
+        expect(menu.store.getCount()).toBe(3);
+        expect(menu.store.items.map(item => item.id)).toEqual(['file', 'edit', 'about'])
+    });
+
+    test('keeps the tree store as sourceStore and does NOT render it directly', () => {
+        const menu = createMenu({store: treeStore});
+
+        menus.push(menu);
+
+        expect(menu.sourceStore).toBe(treeStore);
+        expect(menu.store).not.toBe(treeStore);
+        expect(menu.store instanceof TreeStore).toBe(false)
+    });
+
+    test('the level store reuses the tree model class, so hierarchy fields survive', () => {
+        const menu = createMenu({store: treeStore});
+
+        menus.push(menu);
+
+        // Re-adding under menu.Model would silently drop isLeaf/parentId, and hasChildren() reads isLeaf.
+        const record = menu.store.get('file');
+
+        expect(record.isLeaf).toBe(false);
+        expect(record.text).toBe('File');
+
+        // A distinct model INSTANCE, so no level can destroy a schema another level is using.
+        expect(menu.store.model).not.toBe(treeStore.model);
+        expect(menu.store.model.className).toBe(treeStore.model.className)
+    });
+
+    test('hasChildren answers from isLeaf, never from a nested items array', () => {
+        const menu = createMenu({store: treeStore});
+
+        menus.push(menu);
+
+        const branch = menu.store.get('file'),
+              leaf   = menu.store.get('about');
+
+        expect(branch.items).toBeUndefined();
+        expect(menu.hasChildren(branch)).toBe(true);
+        expect(menu.hasChildren(leaf)).toBe(false)
+    });
+
+    test('a child level renders the children of its parent record, at any depth', () => {
+        const root = createMenu({store: treeStore});
+
+        menus.push(root);
+
+        const level1 = createMenu({...root.getSubMenuData(root.store.get('file'))});
+
+        menus.push(level1);
+
+        expect(level1.store.items.map(item => item.id)).toEqual(['file-new', 'file-open']);
+
+        // Depth 3: the cascade is not limited to one level of nesting.
+        const level2 = createMenu({...level1.getSubMenuData(level1.store.get('file-new'))});
+
+        menus.push(level2);
+
+        expect(level2.store.items.map(item => item.id)).toEqual(['file-new-f'])
+    });
+
+    test('a child level reads through the COLLAPSED tree — expansion is not a rendering prerequisite', () => {
+        const root = createMenu({store: treeStore});
+
+        menus.push(root);
+
+        // Every branch in the fixture is collapsed. A menu must never mutate expansion state to render.
+        expect(treeStore.get('file').collapsed).toBe(true);
+
+        const level1 = createMenu({...root.getSubMenuData(root.store.get('file'))});
+
+        menus.push(level1);
+
+        expect(level1.store.getCount()).toBe(2);
+        expect(treeStore.get('file').collapsed).toBe(true)
+    });
+
+    test('destroying a level does NOT destroy the shared tree store', () => {
+        const root   = createMenu({store: treeStore}),
+              level1 = createMenu({...root.getSubMenuData(root.store.get('edit'))});
+
+        expect(level1.store.getCount()).toBe(1);
+
+        // list.Base sets autoDestroyStore: true and destroys me.store on teardown. Because a level's
+        // store is its own derived one, the shared source can never be reached by that path.
+        level1.destroy();
+        root.destroy();
+
+        expect(treeStore.isDestroyed).toBeFalsy();
+        expect(treeStore.getCount()).toBe(3);
+        expect(treeStore.getChildren('edit')).toHaveLength(1)
+    });
+
+    test('the classic nested-items API is untouched', () => {
+        const menu = createMenu({
+            items: [
+                {id: 'a', text: 'A', items: [{id: 'a-1', text: 'A1'}]},
+                {id: 'b', text: 'B'}
+            ]
+        });
+
+        menus.push(menu);
+
+        expect(menu.sourceStore).toBeNull();
+        expect(menu.store.getCount()).toBe(2);
+        expect(menu.hasChildren(menu.store.get('a'))).toBe(true);
+        expect(menu.hasChildren(menu.store.get('b'))).toBe(false);
+        expect(menu.getSubMenuData(menu.store.get('a'))).toEqual({items: [{id: 'a-1', text: 'A1'}]})
+    });
+
+    test('an empty items array is a leaf to every path, not just to the arrow', () => {
+        const menu = createMenu({items: [{id: 'empty', text: 'Empty', items: []}]});
+
+        menus.push(menu);
+
+        // Guards the raw-truthiness regression: `!record.items` is false for [], so the keyboard path
+        // used to treat an empty array as a parent while the arrow treated it as a leaf.
+        expect(menu.hasChildren(menu.store.get('empty'))).toBe(false)
+    })
+});

--- a/test/playwright/unit/menu/ListTreeStore.spec.mjs
+++ b/test/playwright/unit/menu/ListTreeStore.spec.mjs
@@ -304,6 +304,54 @@ test.describe('Neo.menu.List driven by a TreeStore', () => {
         expect(level1.store.items.map(i => i.text)).toEqual(['Open', 'New'])
     });
 
+    test('a late addition stays live: add, then change it at the source, repaints exactly one row', () => {
+        const menu = createMenu({store: treeStore});
+
+        menus.push(menu);
+
+        treeStore.add({id: 'late', text: 'Late', isLeaf: true});
+
+        // The level must hold the SOURCE's own instance. Letting the level store hydrate the mutate
+        // payload mints a clone, and a later recordChange — resolved by identity — can never find it,
+        // so the row silently freezes for the rest of the menu's life.
+        expect(menu.store.get('late')).toBe(treeStore.get('late'));
+
+        let rowRepaints = 0;
+
+        menu.onStoreRecordChange = () => {rowRepaints++};
+
+        treeStore.get('late').text = 'Late (modified)';
+
+        expect(rowRepaints).toBe(1);
+        expect(menu.store.get('late').text).toBe('Late (modified)')
+    });
+
+    test('a destroyed level leaves no listener behind on the still-live source', () => {
+        const root   = createMenu({store: treeStore}),
+              level1 = createMenu({...root.getSubMenuData(root.store.get('file'))});
+
+        menus.push(root);
+
+        const before = treeStore.toJSON().listeners;
+
+        expect(before.sort.length).toBeGreaterThan(0);
+
+        level1.destroy();
+
+        const after = treeStore.toJSON().listeners;
+
+        // Teardown must be symmetric with what onConstructed subscribed. An asymmetric un() leaves a
+        // destroyed level still driving syncLevelRecords on the next source sort.
+        expect((after.mutate       || []).length).toBe(before.mutate.length       - 1);
+        expect((after.recordChange || []).length).toBe(before.recordChange.length - 1);
+        expect((after.sort         || []).length).toBe(before.sort.length         - 1);
+
+        // And the surviving level keeps working when the source sorts afterwards.
+        treeStore.sorters = [{property: 'text', direction: 'DESC'}];
+
+        expect(root.store.getCount()).toBe(3)
+    });
+
     test('the classic nested-items API is untouched', () => {
         const menu = createMenu({
             items: [


### PR DESCRIPTION
Resolves #17839

`menu.List` now accepts a `Neo.data.TreeStore` and renders a cascading menu out of `parentId`-keyed records, so an architecture where independent modules contribute into shared menu groups can hand the engine records instead of hand-rolling a recursive assembler. The nested-`items` API is untouched. A level never renders a subset of the shared tree store — `list.Base` index math walks the full `store.items`, so each level derives its own flat store and the tree stays the one shared source nobody owns.

Evidence: L3 (example booted in Chromium — the root level renders the tree roots, not the flattened tree; full unit suite 1954 passed) → L3 required (no AC needs an operator-gated or destructive step). Residual: none.

## AC Evidence
| AC | Proof |
|---|---|
| AC-1 accepts a TreeStore, renders roots | CI-covered: `unit/menu/ListTreeStore.spec.mjs` — "the root level renders the tree roots only, not the flattened tree" (3 of 7 records) |
| AC-2 `hasChildren()` without reading `items` | CI-covered: same spec — "hasChildren answers from isLeaf, never from a nested items array" (asserts `record.items` is undefined) |
| AC-3 sub-menu children from `parentId`, cascade intact | CI-covered: same spec — "showSubMenu opens a real child level and leaves the parent alive" + "a child level renders the children of its parent record" |
| AC-4 arbitrary depth | CI-covered: same spec — depth-3 assertion in "…at any depth" (`file` → `file-new` → `file-new-f`) |
| AC-5 nested-`items` API unchanged | CI-covered: "the classic nested-items API is untouched" + pre-existing `unit/menu/List.spec.mjs` + full suite 1954 passed |
| AC-6 shared store survives sub-menu destruction | CI-covered: "destroying a level does NOT destroy the shared tree store" (destroys two levels, asserts store alive with its records) |
| AC-7 one record change does not rebuild | CI-covered: "changing one record repaints that row only — no level rebuild" (exact counts: 1 row repaint, 0 rebuilds) |
| AC-8 post-mount records appear, order-independent | CI-covered: "a record contributed after mount appears, and only its own level re-renders" + "contribution order does not change the result" |
| AC-9 sibling order deterministic and controllable | CI-covered: "sibling order follows the tree, and a tree sort reaches every level" — narrowed, see Deltas |
| AC-10 `getChildren()` on a collapsed node | CI-covered: `unit/data/TreeStore.spec.mjs` — "returns the children of a COLLAPSED node", plus leaf/unknown-key, copy-safety and Turbo Mode hydration cases |
| AC-11 unit coverage both shapes, explicit config | CI-covered: run via `playwright.config.unit.mjs` (never bare `npx playwright test`) — 1954 passed |
| AC-12 example under `examples/menu/` | outside-CI: `examples/menu/tree/` booted at `http://localhost:<port>/examples/menu/tree/index.html`; root menu rendered File / Edit / View / About with icons |
| AC-13 guide no longer implies grid-only | CI-covered by inspection: `learn/guides/datahandling/TreeStore.md` gains a "not grid-only" callout and a "Reading one level" section documenting `getChildren()` |

## Deltas from ticket
- **`TreeStore#getChildren()` was added** — the ticket first recorded `TreeStore` as "consumed, not modified". Implementation proved it could not answer "direct children of X": `items` is the Projection Layer and `collapsed` defaults to `true`, `#childrenMap` is hard-private, and `collectAllDescendants()` returns the whole subtree. The ticket body and Contract Ledger were corrected before this PR opened.
- **AC-9 was narrowed.** It originally also required that positional separators survive a sort. Neither `menu.Model` nor the nested-`items` API models separators, so there was nothing to preserve — the criterion could not be satisfied by any implementation. Narrowed to the half that exists (order determinism) and recorded under the ticket's Out of Scope, rather than left as an unmeetable AC.
- **`onKeyDownEnter` now routes through `hasChildren()`** instead of reading `record.items` raw. Not in the original ticket: the two paths had diverged, and `!record.items` is `false` for an empty array, so `items: []` was a parent to the keyboard and a leaf to the arrow. In scope because it is the same predicate.
- 7 whitespace-only lines in two touched files: pre-existing trailing whitespace that `check-whitespace` rejects file-wide rather than diff-wide. No added line carried any.

## Test Evidence
All unit coverage runs in CI. Outside-CI receipts:

- **Live boot (L3).** `examples/menu/tree/` served from the dev server rendered exactly the 4 root records out of a 16-record tree — the level-derivation property, observed rather than inferred.
- **Negative control on `getChildren()`.** Replacing the implementation with the obvious-but-wrong `this.find('parentId', parentId)` reddens 4 of its 5 specs, including the collapsed case. The 5th (leaf / unknown key) correctly stays green — both implementations return `[]` there, so it is a boundary test, not a mechanism test. The specs witness the property rather than merely passing.
- **Exact-count assertions caught a real defect.** "only its own level re-renders" asserted 1 render and observed 2: splicing the level store already produces a `load` through `onCollectionMutate`, which `list.Base` re-renders on, so an explicit `createItems()` rendered every contribution twice. Removed.
- **Not observed:** the styled cascade opening in a browser. Themes cannot be built in a git worktree (`dist/` and `node_modules` are gitignored and absent), so the page renders unstyled. The interaction is covered deterministically instead by "showSubMenu opens a real child level and leaves the parent alive". Calling this out rather than implying visual confirmation.

## Gates actually run
Stated explicitly because two mandated gates are unreachable from an Engine seat after the repo split (`c623b2f63c`, "remove received Brain implementation", #17806) — diagnosed by @neo-opus-vega.

- **Ran:** husky pre-commit — `check-whitespace`, `check-shorthand`, `check-derived-domain`, `check-jsdoc-types`, `check-fixed-sleeps`, `check-ticket-archaeology`, `check-engine-brain-boundary`, `check-block-alignment --fix`, `check-parse`.
- **Ran:** CI 17/17 at `58c3546e33` — `unit` (1m2s, a real suite run), `components`, `substrate`, 5× `lint`, `check`, `check-freshness`, CodeQL + extraction guard, `review-admission/mergeability`.
- **NOT run — `npm run agent-preflight`.** Mandated by `pull-request-workflow.md §1`; the script left for the Brain in `c623b2f63c` and no longer exists in this repo. An Engine seat cannot run it. Not claiming it passed.
- **NOT run — `agent-pr-body-lint`.** The workflow was removed by the same commit, so the `Resolves` / `Evidence:` / `## AC Evidence` structure in this body is unenforced here. I followed it anyway because it is what a reviewer reads, but do not read its presence as a machine-verified certificate.

## Post-Merge Validation
- [ ] Open `examples/menu/tree/` in a themed environment and confirm the cascade opens, closes and aligns like `examples/menu/list/`.
- [ ] Confirm no consumer relies on `menu.List#store` being an instance of `menu.Store` specifically — a `TreeStore` input now yields a derived level store of the tree's model class.

## Commits
- `a5f4850b96` — `feat(menu)`: level derivation, `hasChildren`/`showSubMenu`/keyboard-path union, `TreeStore#getChildren()`, guide
- `a10fe7199c` — `docs(menu)`: `examples/menu/tree` + the `showSubMenu` interaction spec
- `58c3546e33` — `feat(menu)`: level reactivity (recordChange / mutate / sort), unsubscribe on destroy

## Evolution
The first design rendered each level as a filtered subset of one shared `TreeStore`. That was abandoned on evidence: `getSelectedIndex()` (`list/Base.mjs:671`) and `getHeaderlessIndex()` (`:696`) index positionally into the full `store.items`, so a subset would resolve selection and key navigation against the entire tree while its DOM held one level — rendering correctly and mis-targeting silently. Per-level derived stores remove the hazard instead of working around it, and dissolve the `autoDestroyStore` trap as a side effect: the tree store never sits in `me.store`, so `list.Base` cannot reach it on teardown.

The premise also changed. The item arrived framed as "finish an incomplete retrofit" — menus left behind while `tree/` and `grid/` moved to the 2026 primitives. That framing is false and was dropped from the ticket: **zero files under `src/` import `data/TreeStore.mjs` or `data/TreeModel.mjs`**. `tree/List.mjs` imports `selection/TreeModel` — a different class sharing a basename — and builds hierarchy from a flat store keyed on `parentId`/`level`. No migration ever swept the primitive into the component layer, which is why it had no children accessor: this PR adopts a primitive rather than finishing a migration.

Authored by Ada (Claude Opus 5, Claude Code). Session 16636a26-a8e1-4f27-9c7b-9365f5000c0f.
