### PR TITLE
feat(dashboard): commit active tabs and resizable edge zones (#17838)

### DIFF
--- a/apps/workstation/tour/denseWorkstation.mjs
+++ b/apps/workstation/tour/denseWorkstation.mjs
@@ -39,7 +39,15 @@ export const initialDocument = Object.freeze({
         inspector: {componentRef: 'Inspector', title: 'Selection Inspector',          kind: 'panel', autoHidden: true}
     },
     nodes: {
-        root               : {type: 'edge-zone', zones: {center: 'split-main', left: 'left-tabs', right: 'split-right', bottom: 'bottom-tabs'}},
+        root               : {
+            type : 'edge-zone',
+            zones: {
+                center: {nodeId: 'split-main'},
+                left  : {nodeId: 'left-tabs',   extent: 0.20, resizable: true},
+                right : {nodeId: 'split-right', extent: 0.25, resizable: true},
+                bottom: {nodeId: 'bottom-tabs', extent: 0.25, resizable: true}
+            }
+        },
         'split-main'       : {type: 'split', orientation: 'horizontal', children: ['scale-tabs', 'heavy-tabs'], sizes: [0.6, 0.4]},
         'scale-tabs'       : {type: 'tabs', items: ['scale'], activeItemId: 'scale'},
         'heavy-tabs'       : {type: 'tabs', items: ['alerts', 'activity', 'topology', 'runtime', 'traces', 'logs', 'console', 'builds', 'deploys', 'security', 'memory', 'files'], activeItemId: 'alerts'},

--- a/apps/workstation/view/Workspace.mjs
+++ b/apps/workstation/view/Workspace.mjs
@@ -1315,7 +1315,7 @@ class Workspace extends DockWorkspace {
             root  : `workstation-vessel-root:${itemId}`,
             items : {},
             nodes : {
-                [`workstation-vessel-root:${itemId}`]: {type: 'edge-zone', zones: {center: tabsNodeId}},
+                [`workstation-vessel-root:${itemId}`]: {type: 'edge-zone', zones: {center: {nodeId: tabsNodeId}}},
                 [tabsNodeId]                         : {type: 'tabs', items: [], activeItemId: null}
             }
         }

--- a/apps/workstation/view/Workspace.mjs
+++ b/apps/workstation/view/Workspace.mjs
@@ -2126,7 +2126,7 @@ class Workspace extends DockWorkspace {
         let {geometryOnly = false, operation = null, preserveItemIds} = descriptor || {};
 
         return {
-            geometryOnly  : geometryOnly === true || operation === 'resizeSplit',
+            geometryOnly  : geometryOnly === true || ['resizeEdgeZone', 'resizeSplit'].includes(operation),
             retainTopology: operation === 'detachItem' || operation === 'transferNode',
             ...(Array.isArray(preserveItemIds) && preserveItemIds.length > 0 ? {preserveItemIds} : {})
         }

--- a/examples/dashboard/choreography/demoADockChoreography.mjs
+++ b/examples/dashboard/choreography/demoADockChoreography.mjs
@@ -63,7 +63,13 @@ export const initialDocument = Object.freeze({
         terminal: {componentRef: 'Terminal', title: 'Terminal', kind: 'terminal'}
     },
     nodes: {
-        root         : {type: 'edge-zone', zones: {center: 'editor-tabs', right: 'side-tabs'}},
+        root         : {
+            type : 'edge-zone',
+            zones: {
+                center: {nodeId: 'editor-tabs'},
+                right : {nodeId: 'side-tabs', extent: 0.25, resizable: true}
+            }
+        },
         'editor-tabs': {type: 'tabs', items: ['editor'],  activeItemId: 'editor'},
         'side-tabs'  : {type: 'tabs', items: ['preview'], activeItemId: 'preview'}
     }
@@ -108,8 +114,8 @@ export const demoATourScript = Object.freeze({
                 type   : 'topology-assert',
                 caption: 'the studio, committed: editor column at center, preview docked right',
                 expect : [
-                    {path: 'nodes.root.zones.center', equals: 'split-editor-tabs-0'},
-                    {path: 'nodes.root.zones.right',  equals: 'side-tabs'},
+                    {path: 'nodes.root.zones.center.nodeId', equals: 'split-editor-tabs-0'},
+                    {path: 'nodes.root.zones.right.nodeId',  equals: 'side-tabs'},
                     {path: 'nodes.side-tabs.items',   equals: ['preview']}
                 ]
             },
@@ -126,7 +132,7 @@ export const demoATourScript = Object.freeze({
                 descriptor: {operation: 'addTab', itemId: 'terminal', tabsNodeId: 'side-tabs'},
                 expect    : [
                     {path: 'nodes.side-tabs.items',   equals: ['preview', 'terminal']},
-                    {path: 'nodes.root.zones.center', equals: 'editor-tabs'}
+                    {path: 'nodes.root.zones.center.nodeId', equals: 'editor-tabs'}
                 ]
             },
             {type: 'pause', ms: 900, caption: 'the folding pane shrinks toward its tab slot — the tab IS the pane, relocated'},
@@ -142,7 +148,7 @@ export const demoATourScript = Object.freeze({
                 descriptor: {operation: 'addTab', itemId: 'logs', tabsNodeId: 'side-tabs'},
                 expect    : [
                     {path: 'nodes.side-tabs.items',   equals: ['preview', 'terminal', 'logs']},
-                    {path: 'nodes.root.zones.center', equals: 'editor-tabs'}
+                    {path: 'nodes.root.zones.center.nodeId', equals: 'editor-tabs'}
                 ]
             },
             {type: 'pause', ms: 1200, caption: 'scene break — density without loss, committed'}
@@ -203,7 +209,7 @@ export const demoATourScript = Object.freeze({
                 caption: 'finale: the dense studio, exactly as the dance left it',
                 expect : [
                     {path: 'nodes.side-tabs.items',    equals: ['preview', 'terminal', 'logs']},
-                    {path: 'nodes.root.zones.center',  equals: 'editor-tabs'},
+                    {path: 'nodes.root.zones.center.nodeId', equals: 'editor-tabs'},
                     {path: 'items.preview.autoHidden', equals: false}
                 ]
             }

--- a/examples/dashboard/crossWindow/DemoBWorkspace.mjs
+++ b/examples/dashboard/crossWindow/DemoBWorkspace.mjs
@@ -4439,7 +4439,7 @@ class DemoBWorkspace extends Container {
             root  : 'popup-root',
             items : {},
             nodes : {
-                'popup-root': {type: 'edge-zone', zones: {center: 'popup-tabs'}},
+                'popup-root': {type: 'edge-zone', zones: {center: {nodeId: 'popup-tabs'}}},
                 'popup-tabs': {type: 'tabs', items: [], activeItemId: null}
             }
         }

--- a/examples/dashboard/crossWindow/demoBPerspectives.mjs
+++ b/examples/dashboard/crossWindow/demoBPerspectives.mjs
@@ -34,7 +34,7 @@ export const initialDocument = Object.freeze({
         console  : {componentRef: 'Console',   title: 'Console',   kind: 'terminal'}
     },
     nodes: {
-        root            : {type: 'edge-zone', zones: {center: 'workbench-tabs', right: 'side-tabs'}},
+        root            : {type: 'edge-zone', zones: {center: {nodeId: 'workbench-tabs'}, right: {nodeId: 'side-tabs'}}},
         'workbench-tabs': {type: 'tabs', items: ['workbench'], activeItemId: 'workbench'},
         'side-tabs'     : {type: 'tabs', items: ['inspector', 'timeline', 'console'], activeItemId: 'inspector'}
     }

--- a/examples/dashboard/crossWindowWitness/Harness.mjs
+++ b/examples/dashboard/crossWindowWitness/Harness.mjs
@@ -82,12 +82,12 @@ class Harness extends Viewport {
         const sourceDoc = () => ({
             schema: 'neo.dock.zone.v1', root: 'root',
             items : {strategy: {componentRef: 'strategy', title: 'Strategy', kind: 'panel'}, terminal: {componentRef: 'terminal', title: 'Terminal', kind: 'terminal'}},
-            nodes : {root: {type: 'edge-zone', zones: {center: 'main-tabs', right: 'side-tabs'}}, 'main-tabs': {type: 'tabs', items: ['strategy'], activeItemId: 'strategy'}, 'side-tabs': {type: 'tabs', items: ['terminal'], activeItemId: 'terminal'}}
+            nodes : {root: {type: 'edge-zone', zones: {center: {nodeId: 'main-tabs'}, right: {nodeId: 'side-tabs'}}}, 'main-tabs': {type: 'tabs', items: ['strategy'], activeItemId: 'strategy'}, 'side-tabs': {type: 'tabs', items: ['terminal'], activeItemId: 'terminal'}}
         });
         const targetDoc = () => ({
             schema: 'neo.dock.zone.v1', root: 'root',
             items : {alpha: {componentRef: 'alpha', title: 'Alpha', kind: 'panel'}},
-            nodes : {root: {type: 'edge-zone', zones: {center: 'main-tabs'}}, 'main-tabs': {type: 'tabs', items: ['alpha'], activeItemId: 'alpha'}}
+            nodes : {root: {type: 'edge-zone', zones: {center: {nodeId: 'main-tabs'}}}, 'main-tabs': {type: 'tabs', items: ['alpha'], activeItemId: 'alpha'}}
         });
 
         const transfers = [], fires = [];

--- a/examples/dashboard/dock/MainContainer.mjs
+++ b/examples/dashboard/dock/MainContainer.mjs
@@ -34,7 +34,13 @@ const initialDockModel = {
         history  : {componentRef: 'History',   title: 'History',   kind: 'panel'}
     },
     nodes: {
-        root            : {type: 'edge-zone', zones: {center: 'root-split', right: 'inspector-tabs'}},
+        root            : {
+            type : 'edge-zone',
+            zones: {
+                center: {nodeId: 'root-split'},
+                right : {nodeId: 'inspector-tabs', extent: 0.25, resizable: true}
+            }
+        },
         'root-split'    : {type: 'split', orientation: 'horizontal', children: ['main-tabs', 'side-split'], sizes: [0.65, 0.35]},
         'main-tabs'     : {type: 'tabs',  items: ['strategy', 'swarm', 'metrics', 'timeline', 'agents', 'alerts', 'history'], activeItemId: 'strategy'},
         'side-split'    : {type: 'split', orientation: 'vertical', children: ['terminal-tabs', 'logs-tabs'], sizes: [0.6, 0.4]},

--- a/learn/agentos/DockZoneModel.md
+++ b/learn/agentos/DockZoneModel.md
@@ -11,11 +11,9 @@ Method references below name their owning module.
 
 ## Scope
 
-This contract is the first concrete slice of the QT-grade docking line; the Agent Harness cockpit is one consumer among several (workstation, `examples/dashboard/*`). It defines the data model that rendering, preview, and persistence slices consume.
-
-This document does not implement drag previews, split/tab rendering, layout persistence, or cross-window choreography. Those are follow-up leaves. This slice exists so those leaves do not invent incompatible object models.
-
-The preview-state section below records the follow-up drag-to-dock contract. It still defines data shape only: no renderer, event listener, persistence writer, or drag manager lives here.
+This is the executable v13.2 contract shared by the Workstation, the dashboard examples, and external consumers. It
+defines the committed document, semantic operations, projection boundary, persistence wrappers, and the strict line
+between serializable truth and per-window interaction state.
 
 ## Existing Substrates
 
@@ -25,25 +23,20 @@ The contract composes with these current Neo substrates:
 |---|---|---|
 | Declarative layouts | `learn/guides/uibuildingblocks/Layouts.md`, `src/layout/HBox.mjs`, `src/layout/VBox.mjs`, `src/layout/Card.mjs` | Dock splits map to `hbox` / `vbox`; tabbed slots map to a tab header plus `card`-style active content. |
 | JSON-first UI state | `learn/benefits/body/JSONFirstUIs.md`, `learn/gettingstarted/DescribingTheUI.md` | Persist only pure JSON. Runtime component instances, DOMRects, and window objects stay out of the serialized model. |
-| Dashboard drag substrate | `src/dashboard/Container.mjs`, `src/draggable/dashboard/SortZone.mjs` | Dock rendering adapts this model into dashboard/sort-zone mechanics instead of forking drag handling. |
+| Dashboard drag substrate | `src/dashboard/Container.mjs`, `src/draggable/dashboard/SortZone.mjs`, `src/dashboard/dock/interaction/TabSortZone.mjs` | Dock rendering adapts this model into existing dashboard/sort-zone mechanics instead of forking drag handling. |
 | Cross-window geometry | `src/manager/Window.mjs`, `src/manager/DragCoordinator.mjs`, `src/main/addon/WindowPosition.mjs` | Dock drop targeting uses existing screen-coordinate and remote-drag authority. The model stores the accepted result, not transient geometry. |
-| Flagship self-use | `apps/workstation/view/Workspace.mjs`, ADR 0020 | The flagship in-repo consumer is the Workstation operator workspace: terminal, transcript, preview, and inspector panes arranged as a persistent, perspective-switchable workspace. |
+| Engine consumers | `apps/workstation/`, `examples/dashboard/`, ADR 0020 | Minimal and high-density applications consume the same document and operation vocabulary without app-specific docking branches. |
 
 The subsystem realizing this contract lives at `src/dashboard/dock/**` (`Neo.dashboard.dock.*`); ADR 0029's §2.9 amendment records the final package and wire family.
 
 ## Ownership Boundary
 
-The model is a generic dashboard-layer contract (`src/dashboard/`), not a new core layout primitive yet.
+The model is a generic dashboard-layer contract, not a core layout primitive.
 
-Initial durable surface: this document.
-
-**Resolved (operator, 2026-06-13):** the dock-zone subsystem lives in `src/dashboard/` — `Neo.dashboard.dock.model.Document` (the executor) co-located with `Neo.dashboard.dock.projection.LayoutAdapter` (the renderer) — reusable across apps. Dock zones are a Neo layout topic available to other apps, not a harness-app-private concern; only app-specific pane wiring / persistence glue stays in the harness app. The decision tree below is the rationale that led here — its conditional "harness app layer" model placement (option 1) and the "second independent in-repo consumer required before lifting" gate (option 2) are superseded by this decision.
-
-The rationale that resolved to the dashboard layer:
-
-1. If the first implementation only proves Agent Harness workspace persistence with app-specific pane wiring or persistence glue, place that app-specific code in the harness app layer and keep the model documented here.
-2. If the first implementation is a reusable projection adapter that consumes dashboard/container/tab primitives and emits ordinary Neo configs, place the adapter in the dashboard layer while keeping the model contract here. A second independent in-repo use is still required before lifting the model/parser or public API beyond dashboard adaptation. Candidate second use: the Portal learning workspace, where docs, Monaco/live preview, output panes, and inspectors benefit from saveable split/tab workspaces.
-3. Only after reusable behavior exceeds dashboard adaptation should a generic core layout primitive be considered.
+The dock-zone subsystem lives in `src/dashboard/dock/`: `model.Document` owns document invariants,
+`model.Operations` executes semantic changes, `projection.LayoutAdapter` derives component configs, and
+`projection.Reconciler` preserves live component identity across projections. Dock zones are an engine capability;
+applications contribute pane resolution, product chrome, and product-specific policy only.
 
 Rejected alternatives:
 
@@ -86,8 +79,8 @@ The persisted document is a versioned JSON object:
     "root": {
       "type": "edge-zone",
       "zones": {
-        "center": "main-tabs",
-        "right": "side-split"
+        "center": {"nodeId": "main-tabs"},
+        "right": {"nodeId": "side-split", "extent": 0.25, "resizable": true}
       }
     },
     "main-tabs": {
@@ -119,7 +112,7 @@ The persisted document is a versioned JSON object:
 
 | Type | Required fields | Meaning | Layout mapping |
 |---|---|---|---|
-| `edge-zone` | `zones` | Root or nested edge container with `top`, `right`, `bottom`, `left`, and/or `center` entries. Missing zones are empty. | A future adapter composes edge bands around the center with `vbox`/`hbox`. |
+| `edge-zone` | `zones` | Root or nested edge container. Each `top`, `right`, `bottom`, `left`, or `center` entry is `{nodeId, extent?, resizable?}`; missing zones are empty. `extent` is a normalized fraction and belongs to the edge descriptor, never to a side map. | The adapter composes edge bands around the center with `vbox`/`hbox` and projects a splitter only when `resizable: true`. |
 | `split` | `orientation`, `children` | Ordered splitter container. `orientation: horizontal` means children are side-by-side; `vertical` means stacked. | `horizontal` -> `hbox`; `vertical` -> `vbox`. |
 | `tabs` | `items`, `activeItemId` | Ordered tab slot containing stable item ids. | Tab header plus `card` active content. |
 
@@ -155,7 +148,7 @@ Persist:
 
 - `schema`
 - root node id
-- node ids, types, zone mapping, split orientation, split child order, normalized split sizes
+- node ids, types, nested edge descriptors (including committed `extent` / `resizable`), split orientation, split child order, normalized split sizes
 - tab item order and `activeItemId`
 - stable item ids, item pin state, and JSON-only item metadata
 - committed item auto-hide/collapsed state
@@ -171,6 +164,21 @@ Do not persist:
 - transient popup/window-drag flags such as `isWindowDragging`
 
 If a future slice needs to restore detached windows, it should persist semantic placement plus an optional window placement hint separately. The dock-zone model remains the component-layout authority, not an OS-window session dump.
+
+### Active tabs and edge extents
+
+Two values that look like presentation are committed document truth:
+
+- `tabs.activeItemId` changes through `setActiveItem`. A projected `Neo.tab.Container` may render an integer
+  `activeIndex`, but every user activation is converted back to the stable item id before an unrelated projection can
+  reset it.
+- `edge-zone.zones[edge].extent` changes through `resizeEdgeZone`. Pointer-move pixels and inline preview styles stay
+  in the main thread. CSS min/max bounds constrain that preview and its one normalized terminal value; only successful
+  release advances the document. Escape, stale generations, rejection, and destruction commit nothing.
+
+Auto-hide preserves the owning edge descriptor. A reveal overlay reads that committed extent; only an edge with no
+committed extent uses the workspace's presentation fallback. Saved layouts and perspectives capture the descriptor,
+so restoring a perspective restores the edge size and active tab together.
 
 ## Named Layout Collections / Perspectives
 
@@ -210,13 +218,15 @@ Storage remains out of scope for this layer. Browser preferences, Memory Core pe
 
 ## Operations
 
-The model mutates only through semantic operations — `model.Operations.applyOperation()` is the single dispatch — never through direct tree surgery in UI handlers:
+Every mutation goes through `Neo.dashboard.dock.model.Operations`; `applyOperation()` is the single dispatch, and UI handlers never perform tree surgery directly:
 
 | Operation | Inputs | Result |
 |---|---|---|
+| `setActiveItem` | `tabsNodeId`, `itemId` | Commits a member item as the tabs node's `activeItemId`; unknown nodes and non-members fail closed. |
 | `moveItem` | `itemId`, `targetNodeId`, `index` | Reorders an item within a tab slot or split-derived target. |
 | `splitNode` | `targetNodeId`, `orientation`, `beforeNodeId`, `afterNodeId`, `sizes` | Replaces a node with a split containing the old and new nodes. |
 | `resizeSplit` | `splitNodeId`, `sizes` | Updates an existing split node's normalized child sizes after a splitter affordance. |
+| `resizeEdgeZone` | `edgeZoneId`, `edge`, `extent` | Commits one normalized extent when that nested edge descriptor explicitly has `resizable: true`. |
 | `addTab` | `itemId`, `tabsNodeId`, `index` | Inserts an item into a tab slot and may set `activeItemId`. |
 | `detachItem` | `itemId` | Removes an item from the dock tree while preserving its item record for popup/window ownership. |
 | `closeItem` | `itemId` | Removes an item from both tree and catalog when policy permits. |
@@ -243,7 +253,7 @@ Every operation must maintain:
 
 The dock model does not own pointer events.
 
-Future drag-to-dock preview slices should listen to existing drag surfaces and produce a transient `dockPreview` object:
+Drag-to-dock interaction listens to the existing drag surfaces and produces a transient `dockPreview` object:
 
 ```json
 {
@@ -335,7 +345,7 @@ The contract is deliberately JSON-first. `projection.LayoutAdapter` projects the
 - `split.orientation: vertical` -> container `layout: {ntype: 'vbox', align: 'stretch'}`
 - `split.sizes` -> child `flex` values
 - `tabs.items` -> tab header order plus card children
-- `activeItemId` -> active card index derived from `items.indexOf(activeItemId)`
+- `activeItemId` -> active card index derived from `items.indexOf(activeItemId)`; user activation emits `setActiveItem` before a later projection can overwrite it
 
 The adapter must treat `componentRef` as the stable bridge between persisted layout and live component ownership. When no live component exists, the adapter may instantiate from `item.blueprint`; when a live component exists, it should move/re-parent the instance without destroying it, matching the existing dashboard and multi-window precedent.
 
@@ -373,7 +383,7 @@ Required wrapper fields:
 - `title`: display label for layout pickers or recovery UIs.
 - `dockZone`: a normalized `neo.dock.zone.v1` model after semantic operations have run.
 - `captureScope`: `window` for one document or `topology` for a multi-window capture.
-- `windowFingerprint`: JSON-only topology-shape evidence, or `null` when a legacy v1 record had no captured fingerprint.
+- `windowFingerprint`: JSON-only topology-shape evidence, or `null` when no fingerprint was captured.
 
 Optional wrapper fields:
 
@@ -397,19 +407,21 @@ Restore must validate the wrapper schema, the inner dock-zone schema, and the no
 
 Component recovery remains the adapter's responsibility. A restored item with an unresolved `componentRef` follows the stale component reference policy above: preserve the item record and semantic placement long enough for validation, explicit recovery, placeholder rendering, or intentional removal. Persistence must not silently drop the item or rewrite the dock tree to hide the missing component.
 
-Persistence ownership follows the landed placement: reusable import/export, validation, and storage projection logic lives in the dashboard layer (`src/dashboard/`, e.g. `PerspectiveLibrary`), per the 2026-06-13 operator resolution recorded in §Ownership Boundary. Only app-specific storage backends, pane registries, or preference wiring stay app-local — for any consumer, the harness cockpit included.
+Reusable envelope validation and restore live in `model.Persistence`; named collections and perspectives live in
+`persistence.PerspectiveLibrary`. Only storage backends, pane registries, and product preference wiring stay app-local.
 
 ## Split/Tab Adapter Boundary
 
 The rendering boundary is an adapter/reconciler pair, not a new layout engine. `Neo.dashboard.dock.projection.LayoutAdapter` consumes the dock-zone model and emits ordinary Neo child configs; `Neo.dashboard.dock.projection.Reconciler` hands surviving live components into that projection without changing their identity. Existing containers still own layout, tabs, and cards.
 
-Adapter, projection reconciler, and model live in the dashboard layer (`src/dashboard/`) — per the operator's 2026-06-13 placement decision (see §Ownership Boundary), the dock-zone subsystem is a reusable Neo layout topic, not harness-app-private. A *further* lift into a generic core layout primitive (beyond dashboard adaptation) still requires a second independent in-repo consumer and source evidence that the logic is reusable outside dashboard adaptation.
+Adapter, reconciler, and model live under `src/dashboard/dock/`. A further lift into a generic core layout primitive is
+governed by ADR 0029 §2.5; consumers do not change the package boundary locally.
 
-Rejected placements for the first adapter:
+Rejected boundaries:
 
-- **Generic core layout primitive:** rejected for this slice. Core layout classes own child arrangement; they do not yet need to own dock item identity, stale component recovery, drag-drop producer handoff, or future blueprint persistence.
-- **Tab-container fork:** rejected. `Neo.tab.Container` already owns tab button order, card-backed active content, `activeIndex`, and `tabBarPosition`; the adapter/reconciler pair should feed it compatible child/header configs and retained live children rather than create a harness-only tab system.
-- **Splitter-owned model:** rejected. `Neo.component.Splitter` is a resize affordance for existing siblings, not the authority for persistent split topology. The model keeps split orientation, child order, and normalized sizes; splitters may render between children later.
+- **Generic core layout primitive:** core layout classes own child arrangement; they do not own dock item identity, stale component recovery, or drag/drop semantics.
+- **Tab-container fork:** `Neo.tab.Container` already owns tab button order, card-backed active content, `activeIndex`, and `tabBarPosition`; the adapter feeds it compatible configs and retained live children.
+- **Splitter-owned model:** `Neo.component.Splitter` owns sibling-resize mechanics, not persistent topology. The dock document keeps split sizes and edge extents; projected splitters emit semantic terminal operations.
 - **Preview producer as adapter owner:** rejected. Drag preview state is runtime-only and converts to semantic operations on drop. The adapter receives committed model changes; it must not depend on hover rectangles or pointer lifecycle state.
 
 ### Adapter Input
@@ -436,7 +448,9 @@ The adapter must not read `DOMRect`, `windowId`, pointer coordinates, preview pl
 | `children` | projected child configs in listed order | Ordering is model-owned and serializable. |
 | `sizes` | child `flex` values when present | Normalize or ignore invalid ratios before projection. |
 
-Resizable splitters (`interaction.DockSplitter`) sit between projected children and write back semantic size changes through exactly one `resizeSplit` commit at drag end — pointer handlers never mutate persisted `sizes`.
+Projected `interaction.DockSplitter` instances sit between split children and between resizable edge bands and the center. Pointer-move pixels remain
+main-thread runtime state; the terminal emits exactly one `resizeSplit` or `resizeEdgeZone` operation. Escape and
+rejection restore presentation and commit nothing.
 
 ### Tab Projection
 
@@ -449,7 +463,9 @@ Resizable splitters (`interaction.DockSplitter`) sit between projected children 
 | item `title` | child `header.text` or equivalent header config | The title is display text, not identity. |
 | item `componentRef` | existing component move or blueprint instantiation | Runtime refs stay outside serialized state. |
 
-The adapter must preserve the current `Neo.tab.Container` contract: tab headers and card children stay index-aligned, and active state is index-based at render time even though the persisted dock model is id-based.
+The adapter preserves the `Neo.tab.Container` contract: tab headers and card children stay index-aligned, and active
+state is index-based at render time even though the persisted dock model is id-based. Every projected tab strip reports
+user activation through `setActiveItem`, independently of whether close-action chrome is enabled.
 
 ### Component Identity Handoff
 
@@ -471,35 +487,13 @@ The resolver may return either an existing live component or a materializable co
 The contract is justified by two independent shapes:
 
 1. Enterprise desktop migration signal: users expect QT/WPF-class dock/split/tab workspaces in web-delivered software.
-2. Agent Harness self-use: operators need persistent workspaces for fleet, transcript, terminal, strategy, preview, and inspector panes, with panes detachable into OS windows and reintegratable without losing state.
+2. Agent Institution self-use: operators need persistent workspaces for activity, tasks, memories, chat, strategy, and inspector panes, with panes detachable into OS windows and reintegratable without losing state.
 
-The Portal learning workspace is the next in-repo validation candidate before lifting any implementation into a generic core primitive.
+## Executable Evidence
 
-## Acceptance Boundaries
-
-This contract satisfies the model-contract leaf when:
-
-- the tree covers edge zones, nested splits, tabbed slots, stable item identity, and serializable ordering
-- ownership is documented as a generic dashboard-layer contract (2026-06-13 operator resolution), core-layout-last behind the design record's §2.5 trigger
-- serializable fields are separated from drag/preview/window runtime state
-- a second independent use shape is named
-- the split/tab adapter boundary is documented as model-in / existing-Neo-primitive-out
-- no preview UI, persistence implementation, or concrete split/tab rendering component is bundled into this slice
-
-The preview-state follow-up satisfies its leaf when:
-
-- `dockPreview` covers edge targets, split orientation/ratio, tab placement, rejected targets, stable item identity, and target container identity
-- allowed producers are existing drag, sort-zone, drag-coordinator, and window-geometry signals
-- forbidden producers prevent a parallel docking drag system
-- preview-only fields are explicitly runtime-only and are not serialized
-- downstream consumers for rendering, drop handling, and persistence are named
-
-The layout-persistence follow-up satisfies its leaf when:
-
-- a saved layout wrapper is defined separately from the inner dock-zone model
-- wrapper schema, layout identity, display title, and normalized `dockZone` payload are named
-- restore fails closed on unsupported schema or invalid saved state
-- stale `componentRef` recovery delegates to the adapter policy instead of duplicating restore semantics
-- runtime preview/window/component/credential state remains outside persisted layout data
-
-If a future PR introduces new `.mjs` files for this contract, it must run `structural-pre-flight` before choosing the destination.
+- `test/playwright/unit/dashboard/DockZoneModel.spec.mjs` pins document validation, normalization, every semantic
+  operation, persistence refusal, and the final wire family.
+- `DockLayoutAdapter.spec.mjs`, `DockWorkspace.spec.mjs`, and `DockSplitter.spec.mjs` pin projection, active-item
+  commits, edge affordances, terminal-only resize commits, and cancellation.
+- The Workstation and dashboard whitebox journeys exercise live component identity, real pointer gestures, auto-hide
+  reveal, and perspective restoration against the same contract.

--- a/learn/agentos/decisions/0029-docking-design.md
+++ b/learn/agentos/decisions/0029-docking-design.md
@@ -1,6 +1,6 @@
 # ADR 0029: Docking Design — Multi-Window Layout Model, Perspectives, Cross-Window Drag
 
-> Architectural Decision Record for the design tier **above** the landed `dockZone.v1` model contract: the multi-window layout model and its SharedWorker seam, named perspectives across a window topology (carried by the `dockLayout.v2` envelope per the §2.2 amendment), cross-window drag as semantic operations (`transferItem`), grouped drag (`moveNode` / `transferNode`) and tab overflow, the core-lift disposition, the container contract embedded product surfaces consume, the auto-hide UI contract, and — per the §2.8 amendment (2026-07-16) — the multi-window choreography contracts: the gesture claim protocol, the gesture outcome machine, and vessel lifecycle/admission. It settles the questions the remaining docking capability leaves share and cannot answer coherently one leaf at a time. Everything is **additive on the landed `dockZone.v1` model — not a redesign**: where this record names a new schema or operation, it extends the existing family; it never alters a landed shape.
+> Architectural Decision Record for the design tier **above** the landed `neo.dock.zone.v1` model contract: the multi-window layout model and its SharedWorker seam, named perspectives across a window topology (carried by `neo.dock.layout.v1`), cross-window drag as semantic operations (`transferItem`), grouped drag (`moveNode` / `transferNode`) and tab overflow, the core-lift disposition, the container contract embedded product surfaces consume, the auto-hide UI contract, and — per the §2.8 amendment (2026-07-16) — the multi-window choreography contracts: the gesture claim protocol, the gesture outcome machine, and vessel lifecycle/admission.
 
 | Attribute | Value |
 |---|---|
@@ -8,7 +8,7 @@
 | **Author** | @neo-fable-clio (Clio, Claude Fable 5, Claude Code). The cross-window seam contract descends from Discussion #13370's graduated Option-4 convergence (cross-family); the §7 auto-hide contract was written implementation-sufficient for its claimed leaf owner (@neo-opus-grace, #13280). |
 | **Resolves** | #14423 — the #13158 design-gate sub: settle the seven shared design questions (layout model, perspectives, cross-window drag, grouped drag/overflow, core-lift disposition, container contract, auto-hide UI) before further implementation lands on the current base (operator direction, 2026-07-02). |
 | **Parent epic** | #13158 (*QT-parity docking polish*) under #13012 (Agent Harness). Operator re-ranked 2026-07-02 as an agent-harness cornerstone: the docking shell is the substrate the #13015 FM-UX and #13444 HOME surfaces stand on. |
-| **Depends on** | **ADR 0020** (the embodiment vessel — extended, never superseded); the landed **`dockZone.v1` model contract** ([`learn/agentos/DockZoneModel.md`](../DockZoneModel.md)) — that document remains the contract of record for landed substrate (`src/dashboard/DockZoneModel.mjs`, `src/dashboard/DockLayoutAdapter.mjs`, `src/dashboard/DockSplitter.mjs`, `src/dashboard/DockPreview.mjs` — lifted from `apps/agentos/view/` per #15207's shared-owner re-scope); this ADR is the prescriptive design tier above it. |
+| **Depends on** | **ADR 0020** (the embodiment vessel — extended, never superseded); the landed model contract ([`learn/agentos/DockZoneModel.md`](../DockZoneModel.md)) realized under `src/dashboard/dock/{model,projection,interaction,persistence,window}`; this ADR is the prescriptive design tier above it. |
 | **Connects to** | #13280 (§7's implementation leaf, Grace) · #13444 Institution-Cockpit panes + #13015 FM-UX cards (the §6 container-contract consumers) · #13025 / #13028 (landed window-manager leaves consumed as boundaries by §3 — formalized, not reopened) · Discussion #13370 (graduated 2026-06-15: the seam contract, placement-hint layer, contract-over-lift constraint absorbed here) · `examples/dashboard/dock/` (verification surface, #13247). |
 | **Implemented by** | the §5 Decomposition leaves — one Contract-Ledgered leaf per capability, each citing its section here as its upstream contract. |
 | **Anti-anchor for** | a **parallel drag system** (every interaction rides the existing preview → operation path); a **dock-aware `DragCoordinator`** (the coordinator arbitrates targets and MUST stay dock-blind); **serialize-and-recreate popout state** (the component exists once in the SharedWorker heap; windows are render targets); **geometry-persisting placement hints** (`windowId`s, rects, monitor coordinates never serialize); a **third collection shape** beside `dockLayoutCollection.v1`; a **core lift before the §2.5 trigger fires**. |
@@ -43,11 +43,17 @@
 
 #### The reducer-container pattern (landed, normative — amended 2026-08-22, `#17541`)
 
-The normative host is the engine class **`Neo.dashboard.dock.Workspace`** (`src/dashboard/DockWorkspace.mjs`); `examples/dashboard/dock/MainContainer.mjs` is its minimal consumer. New docking workspaces extend it; the three flagship hosts (workstation, dockdemo Demo B, fleet cockpit) still carry the hand-rolled loop and migrate as leaves of epic `#17539` (`#17546` first) — until each lands, its copy is consumer-owned, not normative. The class contract:
+The normative host is the engine class **`Neo.dashboard.dock.Workspace`**
+(`src/dashboard/dock/Workspace.mjs`); `examples/dashboard/dock/MainContainer.mjs` is its minimal consumer and
+`apps/workstation/` its high-density consumer. New docking workspaces extend it. The class contract:
 
 - **The workspace container** owns the committed dock-zone document (`dockModel`) and its saved-layout collection. It lives in the App Worker heap.
 - **`applyDockZoneOperation(descriptor)`** is a pure reducer: `Operations.applyOperation` over the current document. No pointer handler, splitter, or drag surface mutates the document directly.
-- **`onDockZoneDocumentChange(document)`** is the view-sync: it stores the committed document and re-projects it through `DockLayoutAdapter.project()` — one atomic ownership transaction per commit, scheduled off the settled tail of the refresh chain and reconciled by `DockProjectionReconciler` so surviving panes keep their identity. A failed transaction stays observable on its own commit's promise and never suppresses a later one; a configured dock-host reference that resolves to no live host fails loudly.
+- **`onDockZoneDocumentChange(document)`** is the view-sync: it stores the committed document and re-projects it
+  through `projection.LayoutAdapter.project()` — one atomic ownership transaction per commit, scheduled off the
+  settled tail of the refresh chain and reconciled by `projection.Reconciler` so surviving panes keep their identity.
+  A failed transaction stays observable on its own commit's promise and never suppresses a later one; a configured
+  dock-host reference that resolves to no live host fails loudly.
 
 Interaction surfaces (splitters, drag previews, rail tabs, pin controls) emit **operation descriptors**; the reducer commits them; the view-sync re-projects. This is the only sanctioned mutation path.
 
@@ -62,9 +68,10 @@ A **workspace** is one `dockZone.v1` document owned by one workspace container. 
 
 A browser window — including the primary one — is a **render target**, never a state owner. The SharedWorker heap persists while at least one window remains connected; any single window (including the opener) can close or reload without destroying workspace truth.
 
-#### The placement-hint layer — `neo.dock.windowPlacementHints.v1`
+#### The placement-hint fields — additive on `neo.dock.layout.v1`
 
-Resolved by Discussion #13370 (OQ1) and bound here: window placement intent is a **separate hint layer keyed by item id**, never fields inside the dock-zone tree.
+Window placement intent is a **separate hint layer keyed by item id**, never fields inside the dock-zone tree. Its
+durable half is additive data inside the layout envelope; it does not mint a standalone schema identity.
 
 | Hint field class | Fields | Persistence |
 |---|---|---|
@@ -77,8 +84,8 @@ Resolved by Discussion #13370 (OQ1) and bound here: window placement intent is a
 
 | State class | Examples | Owner | Persistence |
 |---|---|---|---|
-| **Worker-owned shared truth** | committed `dockZone.v1` documents; the workspace-set registry; `dockLayout.v2` wrappers (perspectives incl., §2.2 amendment); `dockLayoutCollection.v1`; durable placement hints; item catalogs incl. `pinned` / `autoHidden` | workspace container(s) in the App Worker | Serializable per contract rules |
-| **Per-window render projection** | projected config trees; edge rails; splitter affordances; tab headers; placeholder panes | `DockLayoutAdapter.project()` output per window | Never persisted; derived |
+| **Worker-owned shared truth** | committed `neo.dock.zone.v1` documents incl. tab `activeItemId`, split `sizes`, and edge `extent`/`resizable`; the workspace-set registry; `neo.dock.layout.v1` perspectives; `neo.dock.layoutCollection.v1`; durable placement hints; item catalogs incl. `pinned` / `autoHidden` | workspace container(s) in the App Worker | Serializable per contract rules |
+| **Per-window render projection** | projected config trees; edge rails; splitter affordances; tab headers; placeholder panes | `projection.LayoutAdapter.project()` output per window | Never persisted; derived |
 | **Per-window runtime interaction state** | `dockPreview` payloads; reveal/open state of auto-hidden panes (§2.7); hover state; splitter pixel math mid-drag | the window's drag/interaction surfaces | Never persisted; never crosses the seam except as operation descriptors |
 | **Main-thread-only state** | DOM nodes; `DOMRect`s; screen coordinates; native window geometry; `getWindowAt` lookups | main-thread addons (`Neo.manager.Window`, `WindowPosition`) | Never persisted; consumed by arbitration (§2.3), results delivered as semantic events |
 
@@ -86,7 +93,25 @@ Every future docking leaf classifies each new piece of state into exactly one ro
 
 #### Splitter reconciliation (Discussion #13370 OQ3, dispositioned)
 
-`Neo.dashboard.dock.interaction.DockSplitter` is the dock-workspace resize affordance: it renders between projected split children and commits through the `resizeSplit` semantic operation (`DockLayoutAdapter.createResizeSplitOperation`). `Neo.component.Splitter` remains the general-purpose sibling-resize component for non-dock layouts. They stay separate: the dock splitter's contract obligation (semantic commit through the reducer, never direct mutation of persisted `sizes`) is dock-specific, and folding it into the general component would leak dock semantics into core. A future unification is possible only behind the §2.5 lift trigger, never before it.
+`Neo.dashboard.dock.interaction.DockSplitter` extends `Neo.component.Splitter`: the generic parent owns registration,
+pointer mechanics, proxy/live presentation, CSS bounds, cancellation, generation fencing, and teardown. The dock
+subclass adds only semantic terminals. Split-node affordances commit `resizeSplit`; edge-zone affordances commit
+`resizeEdgeZone`. No dock document concept enters the generic component.
+
+#### Committed tab and edge state (amendment, 2026-08-29 — #17838)
+
+The document owns two values that previously looked like projection state:
+
+- A `tabs` node owns `activeItemId`. Every projected tab strip reports user activation through
+  `{operation: 'setActiveItem', tabsNodeId, itemId}`, whether close-action chrome is enabled or not. Membership is
+  validated against the committed node; invalid descriptors fail closed and restore document truth.
+- An edge-zone entry is a nested descriptor `{nodeId, extent?, resizable?}`. `extent` is a normalized fraction and
+  `resizable: true` is the explicit permission to project an edge splitter. No parallel edge-size or policy map exists.
+
+Edge pointer frames resize only main-thread presentation under the target band's CSS min/max bounds. Successful release
+converts the final pixel size into one normalized `resizeEdgeZone` commit. Escape, stale generation, rejection, and
+destruction restore the prior projection and commit zero operations. Split-node `sizes` remain authoritative only for
+split nodes; an edge never borrows an ancestor split ratio.
 
 ### §2.2 Named Perspectives
 
@@ -96,7 +121,10 @@ Single-workspace persistence is shipped and closed (fail-closed restore and no-s
 
 #### Capture scope (amendment, 2026-07-11 — #14773: the shipped envelope IS the perspective carrier)
 
-**Why this amendment exists.** This section originally projected a NEW persisted schema (`neo.dock.perspective.v1`) for topology-scope perspectives. The perspective substrate that actually landed ships `neo.dock.layout.v1` — the EXISTING envelope family extended with the perspective fields (`captureScope`, `windowFingerprint`, `perspectiveName`, `windowDocuments`) — and it covers BOTH scopes. Minting a second wrapper name for the same capability territory would itself be the shape-proliferation this record's own anti-anchor forbids; the reconciliation therefore RETIRES the `dockPerspective.v1` name entirely: **`dockLayout.v2` is v2 of the ENVELOPE carrying v1 of the perspective CAPABILITY.** Vocabulary mapping, stated once: the capability scope this section calls `workspace` is the envelope value `captureScope: 'window'`. `workspace` is this record's PROSE label only — runtime and tool surfaces (the NL perspective tools included) speak the executable vocabulary `window | topology` (`Persistence.CAPTURE_SCOPES`, the SSOT); minting `workspace` as a third runtime enum value is the drift this mapping exists to prevent.
+The one persisted perspective carrier is `neo.dock.layout.v1`, extended with `captureScope`, `windowFingerprint`,
+`perspectiveName`, and `windowDocuments`; it covers both scopes. No second perspective schema or migration reader exists.
+The capability scope this section calls `workspace` is the executable envelope value `captureScope: 'window'`.
+Runtime and Neural Link surfaces speak `window | topology` (`Persistence.CAPTURE_SCOPES`, the SSOT).
 
 Two scopes exist. A perspective declares which one it is; there is no implicit scope.
 
@@ -125,7 +153,7 @@ Rules, inheriting every `dockLayoutCollection.v1` discipline:
 - `dockZone` carries the PRIMARY window's document (slot 0); `windowDocuments` is an array of the ADDITIONAL windows' documents (slots 1..N), valid only on `captureScope: 'topology'` records — each tree validated by the landed path.
 - **The durable placement-hint layer is the REMAINING §2.2 obligation** (detached-item intent, `owningWorkspaceId`, semantic `fallbackTarget` — the §2.1 durable set). It lands as ADDITIVE fields on this same envelope when the multi-window restore leaf files — never as a new schema name. A perspective containing `windowId`, screen coordinates, monitor geometry, or rects remains invalid and must be rejected at validation.
 - `metadata` is JSON-only, no secrets — enforced by the same `findSecretMetadataKey` class of checks that guards saved layouts.
-- Perspective collections (named sets of perspectives) reuse `dockLayoutCollection.v1` verbatim with `dockLayout.v2` entries; they must not fork a third collection shape — and after this amendment not even a second WRAPPER shape exists.
+- Perspective collections reuse `neo.dock.layoutCollection.v1` with `neo.dock.layout.v1` entries; they must not fork another collection or wrapper shape.
 
 #### Restore semantics into a changed window topology
 
@@ -138,7 +166,9 @@ Windows are render targets (§2.1); restoring a perspective restores **worker-ow
 
 #### Revision migration
 
-`revision` is monotonic per perspective. An unknown *wrapper* schema version fails closed (keep last-good, surface the error) — same rule as the landed wrappers. A future envelope revision (`dockLayout.v3`) must ship a documented migration in the same change that introduces it — the shipped `v1 → v2` migration (`migrateSavedLayout`, honest defaults) is the precedent; silent best-effort upgrades are forbidden.
+`revision` is monotonic per perspective. An unknown wrapper schema version fails closed (keep last-good, surface the
+error). A future envelope revision must define its compatibility or migration contract in the same change that
+introduces it; silent best-effort upgrades are forbidden. The current greenfield v1 has no compatibility reader.
 
 ### §2.3 Cross-Window Drag
 
@@ -192,7 +222,9 @@ logical proxy rect is never a substitute for the live vessel rect used by dual-w
 | `getNativeWindowDrag(windowId)` | Expose the drag payload a detached OS window carries (`{draggedItem, …}`), enabling drop-candidate commit on native window movement. |
 | `onTerminalWindowDrop(draggedItem)` | Finalize when a native-window drag terminates as a standalone window (the drag ends detached rather than re-docking). |
 
-**Binding invariant — the coordinator stays dock-blind:** `DragCoordinator` arbitrates *which target* receives the drag; it MUST NOT import `DockZoneModel`, `DockLayoutAdapter`, or any preview module, and it never interprets dock semantics. This holds in landed code and is now contract. (Changing it triggers the amend-this-ADR escalation named in §1 Context.)
+**Binding invariant — the coordinator stays dock-blind:** `DragCoordinator` arbitrates *which target* receives the
+drag; it MUST NOT import any `Neo.dashboard.dock.*` model, projection, or interaction module, and it never interprets
+dock semantics. Changing that boundary amends this ADR before implementation.
 
 **Binding constraint (Discussion #13370 OQ2):** the reusable shape is this **contract**, not a lift of `Neo.draggable.dashboard.SortZone` out of the dashboard layer. Dock workspaces implement the contract; they do not inherit the dashboard sort zone.
 
@@ -238,7 +270,10 @@ The preview layer carries grouped intent with one additive, optional, runtime-on
 
 #### Tab overflow
 
-Overflow is a **generic tab-subsystem affordance — not a dock concern, not a model change** (mechanism realized by #15098; the first implementation #15062 mis-homed it in `dashboard/plugin/` and was replaced). When a `tabs` node's headers exceed the available extent, the overflowing tabs collapse behind a floating overflow control whose menu reaches them (selecting one sets `activeItemId` via the ordinary semantic path); nothing new persists — `items` order and `activeItemId` already capture the state. It is owned by **`Neo.tab.plugin.Overflow`**, a plugin on the generic `Neo.tab.header.Toolbar` (sibling to the other `src/*/plugin/` affordances), whose pure static `computeOverflow({items, extent, activeItemId, controlWidth})` returns the visible/hidden partition (active-never-hidden). The dock is a **consumer**: `DockLayoutAdapter.projectTabsNode` injects the plugin into each projected header toolbar's `plugins` — a one-directional adapter→plugin consume; the plugin owns its decision, nothing reaches back to the adapter. The control is an **out-of-collection** floating button (rooted at `document.body`, never in `owner.items`) so the header SortZone that `dragResortable` wires never sees it and committed tab order stays uncorrupted. **Invalidation contract:** the plugin re-measures + re-partitions on every tab-set mutation (insert / remove / reorder), not only on resize + `activeIndexChange`. It must **not** fork a dock-specific tab container (inherited from the contract's §Split/Tab Adapter Boundary) — the affordance is tab-native; the dock merely consumes it.
+Overflow is a **generic tab-subsystem affordance — not a dock concern, not a model change**. When a `tabs` node's
+headers exceed the available extent, the overflowing tabs collapse behind a floating control whose menu reaches them;
+selection commits through the ordinary `setActiveItem` path. `Neo.tab.plugin.Overflow` owns the partition, while
+`Neo.dashboard.dock.projection.LayoutAdapter.projectTabsNode()` only installs the plugin. Nothing new persists.
 
 ### §2.5 Core-Lift Clause Disposition
 
@@ -289,7 +324,7 @@ What remains — and what #13280 builds — is the **runtime interaction layer**
 
 | Interaction | Behavior |
 |---|---|
-| Click a rail tab | Transient **reveal**: the pane renders as an **overlay** anchored to its edge — left/right rails reveal full-height, top/bottom rails full-width. The overlay's free dimension uses the extent the item's owning split last committed (`sizes`, still in the document) when one exists, else an adapter-default fraction of the workspace extent (default `0.25`, workspace-configurable). Overlay, never push: revealing MUST NOT re-layout the committed projection. Focus moves into the pane. |
+| Click a rail tab | Transient **reveal**: the pane renders as an **overlay** anchored to its edge — left/right rails reveal full-height, top/bottom rails full-width. The overlay's free dimension uses its owning edge descriptor's committed `extent`; only a never-sized edge uses the workspace fallback (default `0.25`, configurable). Overlay, never push: revealing MUST NOT re-layout the committed projection. Focus moves into the pane. |
 | Hover a rail tab | No reveal by default. A workspace MAY opt in via `autoHideRevealOnHover: true` (workspace-level config, not persisted per item); hover-reveal then opens after a short dwell and never steals focus. Default off — hover reveals are an accessibility hazard. |
 | Dismiss | Focus leaving the overlay, `Escape`, clicking outside the overlay, or re-clicking the rail tab. Dismiss discards runtime reveal state only; no operation is emitted. |
 | Pin control on the revealed overlay | Emits `setItemPinned(itemId, true)` through the reducer — the model clears `autoHidden` (landed guard); the item re-enters the tab flow at its recorded placement; the overlay closes. |
@@ -351,7 +386,7 @@ Four invariants, all mandatory:
 
 #### §2.8.4 Constraints and merge order
 
-- **Placement hints stay additive on `dockLayout.v2`.** Any schema revision ships migration + fail-closed tests atomically (Discussion #15204's `revalidationTrigger` fires on a non-additive requirement).
+- **Placement hints stay additive on `neo.dock.layout.v1`.** Any future schema revision defines compatibility and fail-closed tests atomically.
 - **ADR 0034 boundary:** the Electron shell may improve vessel *materialization*; it never forks placement or arbitration semantics.
 - **Merge order:** this amendment precedes all consuming implementation — #15244 (G1 tear-out), #15246 (G3 composition/arbitration), #15247 (G4 reintegration/vessel), #15248 (teardown hygiene) cite their §2.8 subsection as upstream contract; the #15243 spike's row 6 binds to §2.8.1's identity requirements without implementing arbitration.
 
@@ -510,8 +545,8 @@ name exists only as §2.2 history. A future identity enters this table by amendi
 reserving a row.
 
 The former layout v1/v2 wrapper split collapses into one `neo.dock.layout.v1` carrying the perspective
-fields; the migration reader (`migrateSavedLayout`) and every v1-acceptance site are **deleted**, not
-renamed. Negative controls moved into the new family (`neo.dock.layout.v2`/`.v999`,
+fields; the migration reader and every dual-version branch are **deleted**, not renamed. Negative controls use the
+new family (`neo.dock.layout.v2`/`.v999`,
 `neo.dock.zone.v2`, `neo.dock.preview.v2`, `neo.dock.layoutCollection.v0`/`.v2`) so they prove
 unsupported-**version** rejection, and dedicated controls prove the retired `neo.harness.*` **family** is
 rejected fail-closed at both the envelope and collection tiers. No alias, dual parser, or compatibility
@@ -576,7 +611,7 @@ Per the parent epic's discipline (one Contract-Ledgered leaf per capability), im
 |---|---|---|
 | Auto-hide UI: reveal overlay + pin control + rail drag source | §2.7 | landed — #13280 closed; the §4 auto-hide capability row carries the e2e evidence |
 | `CrossWindowDragTarget` formalization + dock workspace target + `transferItem` | §2.3 | document-pair participation landed in #14769 / PR #15017; placement-hint integration remains part of §2.2's future workspace-set transaction |
-| Topology perspectives: the hint layer on `dockLayout.v2` + switcher + restore reconciliation | §2.2 | envelope + model-level capture/collection substrate landed; NL capture/list/restore tools merged (#15019); the placement-hint layer + atomic multi-window restore remain |
+| Topology perspectives: additive hints on `neo.dock.layout.v1` + switcher + restore reconciliation | §2.2 | envelope + model-level capture/collection substrate landed; NL capture/list/restore tools merged (#15019); the placement-hint layer + atomic multi-window restore remain |
 | Grouped drag (`moveNode`/`transferNode`) + tab overflow affordance | §2.4 | landed — #14770 (`moveNode`/`transferNode`) + #14850 (tab drag) + #15098 (`Neo.tab.plugin.Overflow`) |
 | Core lift to a non-dashboard namespace | §2.5 | **gated** — fires only on the named trigger |
 | The engine-owned workspace host (`Neo.dashboard.dock.Workspace`) + per-host migration | §2.1 | class + example landed — `#17541`; the flagship host migrations are leaves of epic `#17539` |

--- a/learn/guides/uibuildingblocks/DockLayouts.md
+++ b/learn/guides/uibuildingblocks/DockLayouts.md
@@ -47,11 +47,11 @@ flowchart TD
     classDef cross fill:#1a3c34,stroke:#2ecc71,stroke-width:1px,color:#eee
 
     Document["The committed document<br/>neo.dock.zone.v1 — persisted JSON tree<br/>owned by ONE workspace container"]:::doc
-    Model["Neo.dashboard.dock.model.Document<br/>the pure reducer: applyOperation"]:::doc
+    Model["Neo.dashboard.dock.model.Operations<br/>the pure semantic reducer"]:::doc
     Adapter["projection.LayoutAdapter.project()<br/>document → ordinary Neo configs"]:::proj
     Reconciler["projection.Reconciler<br/>hands LIVE components across projections"]:::proj
     Surfaces["Interaction surfaces<br/>TabSortZone · DockSplitter · Rail<br/>PreviewProducer → Preview"]:::inter
-    Descriptors["operation descriptors<br/>moveItem · splitNode · addTab · resizeSplit<br/>detachItem · transferItem · moveNode"]:::inter
+    Descriptors["operation descriptors<br/>setActiveItem · resizeSplit · resizeEdgeZone<br/>moveItem · splitNode · addTab · detachItem"]:::inter
     Coordinator["Neo.manager.DragCoordinator<br/>cross-window arbitration — dock-BLIND"]:::cross
     Arbiter["GestureClaimArbiter<br/>one token per gesture, deterministic winner"]:::cross
     Vessels["Vessel lifecycle<br/>window.TearOut choreography · VesselEmbodiment<br/>VesselConversion · VesselPark"]:::cross
@@ -142,7 +142,7 @@ before it lands ([ADR 0029 §2.1](../../agentos/decisions/0029-docking-design.md
 
 | If you are looking at… | It lives in… | Persisted? |
 |---|---|---|
-| the dock tree, item catalog, `sizes`, `pinned`/`autoHidden`, saved layouts and perspectives | **worker-owned shared truth** — the workspace container's committed documents | yes — serializable by contract |
+| the dock tree, item catalog, tab `activeItemId`, split `sizes`, edge `extent`/`resizable`, `pinned`/`autoHidden`, saved layouts and perspectives | **worker-owned shared truth** — the workspace container's committed documents | yes — serializable by contract |
 | projected configs, edge rails, splitter affordances, tab headers | **per-window render projection** — `projection.LayoutAdapter.project()` output | never — derived |
 | drag previews, hover state, reveal state of an auto-hidden pane, mid-drag splitter math | **per-window runtime interaction state** | never — dies with the gesture |
 | DOM nodes, `DOMRect`s, screen coordinates, native window geometry | **main-thread-only state** — addons and window managers | never — delivered upward as semantic events only |
@@ -153,12 +153,26 @@ perspective into a changed window topology is therefore *semantic recovery*: con
 placement in the tree, never at stored pixels, and a window that cannot be re-created costs you nothing but the
 window. State that wants to live in two rows is two pieces of state — the review bar enforces it.
 
+### Tabs and edge splitters use the same commit boundary
+
+A tab click changes the live `Neo.tab.Container.activeIndex`, then immediately emits `setActiveItem` with the stable
+tabs-node and item ids. That is why selecting a non-first tab survives a later resize, perspective restore, or unrelated
+re-projection: the next projection reads the committed `activeItemId` instead of a stale default.
+
+An edge splitter keeps its move frames even further from the document. The generic main-thread resize path previews
+the real band under its CSS min/max bounds; the App Worker sees no move-frame writes. Release converts the final bounded
+pixel size into one normalized `resizeEdgeZone` operation. Escape or rejection restores the previous presentation and
+commits nothing. Split-node splitters keep their own `resizeSplit` operation; split `sizes` and edge `extent` never
+share an authority.
+
+Auto-hide does not discard an edge's size. The rail reveal reads the owning edge descriptor's committed extent, and a
+perspective captures that same descriptor. The workspace fallback fraction is only for an edge that has never committed
+an extent.
+
 ## Adopting docking in your application
 
-The engine owns the host loop every consumer used to copy. The workstation app (`apps/workstation/`) — the dense
-twenty-pane cockpit — has migrated onto the engine class, so two live consumers now prove the shape: measure your
-own adoption against `examples/dashboard/dock/` (minimal) or the workstation (richest). The fleet cockpit and the
-dock demos still carry hand-rolled copies that are migrating next. The checklist below is the compressed form;
+The engine owns the host loop every consumer used to copy. Two live consumers prove the shape: measure your adoption
+against `examples/dashboard/dock/` (minimal) or `apps/workstation/` (high-density). The checklist below is the compressed form;
 [Dock Layouts: Adopting in Your App](DockLayoutsAdoption.md) walks the same surface at full depth — the first part
 of the guide series this page fronts. Once you extend the class, the adoption surface is:
 
@@ -187,12 +201,13 @@ of the guide series this page fronts. Once you extend the class, the adoption su
    that joins the SharedWorker session; detached panes arrive at runtime. The canonical example is the cross-window
    demo's `?popout` boot branch (`examples/dashboard/crossWindow/Viewport.mjs`), whose own JSDoc says it all: "This
    window carries no workspace of its own; the opener's workspace reparents the live pane into it on connect."
-5. **Persist through the wrappers, not by hand.** `createSavedLayout` / `restoreSavedLayout` and the
-   perspective-carrying `neo.dock.layout.v1` envelope give you named, switchable, fail-closed-validated arrangements.
+5. **Persist through the wrappers, not by hand.** `model.Persistence` and
+   `persistence.PerspectiveLibrary` use the perspective-carrying `neo.dock.layout.v1` envelope for named,
+   switchable, fail-closed-validated arrangements.
    Restore refuses invalid documents wholesale — your users' layouts never half-restore.
 
-Styling arrives through the engine's token layer. The dock's visual language is being promoted from app stylesheets
-into `resources/scss/src/dashboard/` as neutral `--dock-*` tokens, so a consumer skins the affordances by
+Styling arrives through the engine's token layer. The dock's visual language lives in
+`resources/scss/src/dashboard/Container.scss` as neutral `--dock-*` tokens, so a consumer skins the affordances by
 overriding tokens rather than re-painting internals — the same discipline as every other engine surface.
 
 ## The wire vocabulary — one greenfield family

--- a/learn/guides/uibuildingblocks/DockLayoutsAdoption.md
+++ b/learn/guides/uibuildingblocks/DockLayoutsAdoption.md
@@ -24,7 +24,7 @@ flowchart TD
     Extend["extends Neo.dashboard.dock.Workspace"]:::yours
     Seed["Decision 1 — seed + mount<br/>your initial document, your shell placement"]:::yours
     Panes["Decision 2 — resolvePane<br/>your components become panes"]:::yours
-    Policy["Decision 3 — policies<br/>pinnable · movable today<br/>closable is a forward contract"]:::yours
+    Policy["Decision 3 — policies<br/>pinnable · movable · closable<br/>the reducer is the authority"]:::yours
     Skin["Decision 4 — skin by tokens<br/>override anchor, never repaint internals"]:::yours
     Persist["Decision 5 — persistence<br/>saved layouts + perspectives"]:::yours
 
@@ -55,6 +55,7 @@ loudly — to guess either one:
 ```javascript readonly
 import DockWorkspace from '../../../src/dashboard/dock/Workspace.mjs';
 import Document from '../../../src/dashboard/dock/model/Document.mjs';
+import Persistence from '../../../src/dashboard/dock/model/Persistence.mjs';
 
 const initialDockModel = {
     schema: 'neo.dock.zone.v1',
@@ -64,7 +65,7 @@ const initialDockModel = {
         preview: {componentRef: 'Preview', title: 'Preview', kind: 'panel'}
     },
     nodes: {
-        root         : {type: 'edge-zone', zones: {center: 'main-split'}},
+        root         : {type: 'edge-zone', zones: {center: {nodeId: 'main-split'}}},
         'main-split' : {type: 'split', orientation: 'horizontal', children: ['editor-tabs', 'side-tabs'], sizes: [0.6, 0.4]},
         'editor-tabs': {type: 'tabs', items: ['editor'],  activeItemId: 'editor'},
         'side-tabs'  : {type: 'tabs', items: ['preview'], activeItemId: 'preview'}
@@ -89,6 +90,24 @@ class Workspace extends DockWorkspace {
 That is a complete, working docking workspace: two tabbed zones in a resizable split, drag a tab across zones, done.
 The document is plain serializable JSON — an item **catalog** (what exists) and a **node tree** (where it lives) —
 and `Document.clone` gives your seed a private copy so later commits never mutate your constant.
+
+Initial edge bands use the same nested descriptor shape. Give the band a committed normalized extent and opt it into
+the splitter explicitly:
+
+```javascript readonly
+zones: {
+    center: {nodeId: 'main-split'},
+    right : {nodeId: 'inspector-tabs', extent: 0.25, resizable: true}
+}
+```
+
+The adapter projects the right boundary splitter automatically. Move frames resize only the real band under its CSS
+min/max bounds; release emits one `resizeEdgeZone` operation. The descriptor is also what auto-hide reveal and
+perspective restore read, so there is no app-side size map to maintain.
+
+Tab activation is equally automatic. Every projected tab strip converts its live `activeIndex` change into
+`setActiveItem`; this does not depend on close-action chrome being enabled. Do not mirror the selected tab in app state
+or add a listener of your own—the next projection reads the committed `activeItemId`.
 
 Two placement configs cover the layouts real apps actually have. The example app
 (`examples/dashboard/dock/MainContainer.mjs`) puts a perspective toolbar above its shell, so it declares
@@ -159,12 +178,12 @@ titles — the workstation uses it to give cached panes stable header names.
 
 ## Decision 3 — policies live in the model, not in your UI
 
-Per item, the catalog carries policy hints. Two of them are enforced by the reducer **today** — `pinnable` and
-`movable` — and the honest way to teach them is by what the model actually refuses:
+Per item, the catalog carries policy hints. `pinnable`, `movable`, and `closable` are enforced by the reducer, and the
+honest way to teach them is by what the model actually refuses:
 
 ```javascript readonly
 items: {
-    console: {componentRef: 'Console', title: 'Console', pinnable: false, movable: false}
+    console: {componentRef: 'Console', title: 'Console', closable: false, pinnable: false, movable: false}
 }
 ```
 
@@ -172,12 +191,8 @@ A `setItemAutoHidden` against that item returns `{document, errors: ['item "cons
 committed document does not advance; a cross-document transfer containing an unmovable member fails the same way,
 atomically. This is the fail-closed discipline the intro promised, experienced from the adopter's side: your UI never
 grows `if (item.movable)` branches, your policies cannot drift between surfaces, and an agent driving your workspace
-through the Neural Link hits exactly the same wall a pointer does — one rulebook, every caller.
-
-The third hint, `closable`, is currently a declared catalog field the operations do not yet consult — `closeItem`
-removes any existing item. Routing close actions through model policy is an open engine leaf; declare the field now
-as a forward contract, and the enforcement arrives beneath your persisted documents unchanged when that leaf lands.
-Until then, do not present a close affordance as model-refused — it is not, yet.
+through the Neural Link hits exactly the same wall a pointer does — one rulebook, every caller. `closeItem` likewise
+refuses the console above, whether the request comes from projected close chrome or a programmatic operation.
 
 ## Decision 4 — skin it with tokens, on the right scope
 
@@ -235,8 +250,8 @@ const restored = Persistence.restoreSavedLayout(layout);
 restored.document && this.onDockZoneDocumentChange(restored.document)
 ```
 
-`createSavedLayoutCollection` and `restoreActiveSavedLayout` lift the same discipline to named perspective sets — the
-example's perspective toolbar is the working reference: a handful of named layouts, switchable live, surviving
+`PerspectiveLibrary.createSavedLayoutCollection` and `PerspectiveLibrary.restoreActiveSavedLayout` lift the same
+discipline to named perspective sets — the example's perspective toolbar is the working reference: a handful of named layouts, switchable live, surviving
 reload. The rule underneath is the one the intro stated and the reducer enforces: your users' layouts never
 half-restore. A saved layout either validates completely or it is rejected completely, and runtime-only preview state
 can never leak into a persisted document — `createSavedLayout` refuses to serialize it.
@@ -278,7 +293,8 @@ richest live reference for each):
 - `getDockProjectionOptions()` — its entire multi-window surface: cross-window drag participation, tear-out and
   vessel-conversion opt-ins, the drag-affordance layer's seams. Extra options for the projection, so opting into a
   capability is one returned key, never a rewritten loop.
-- `getRefreshOptions(descriptor)` — maps committed operations onto the reconciler's fast paths (`resizeSplit` →
+- `getRefreshOptions(descriptor)` — maps committed operations onto the reconciler's fast paths (`resizeSplit` and
+  `resizeEdgeZone` →
   geometry-only; `detachItem`/`transferNode` → retained topology; per-commit `preserveItemIds` for panes an owner
   holds mid-flight).
 - `beforeRefreshDockWorkspace()` — retires the active gesture session's geometry before the projection changes under
@@ -304,8 +320,8 @@ product policy in your app.
   substitute for a Viewport instance.
 - **Mutating the document anywhere but the reducer.** Everything you see is a projection of committed state; edit
   state directly and the shell will fight you and win. Commit descriptors; let the view-sync re-project.
-- **Enforcing `pinnable` or `movable` in the UI.** The model refuses those operations; UI-side guards drift and
-  disagree with every other committer. `closable` remains the forward contract described above.
+- **Enforcing `pinnable`, `movable`, or `closable` in the UI.** The model refuses those operations; UI-side guards
+  drift and disagree with every other committer.
 - **Awaiting motion you do not need to await.** Fire-and-forget is the default for a reason; take
   `afterRefreshDockWorkspace`'s `played` promise only when chrome genuinely must trail the animation.
 - **Pinning your tests to one fixture.** Derive expected remainders from a pre-operation topology read instead of

--- a/resources/scss/src/apps/workstation/Workspace.scss
+++ b/resources/scss/src/apps/workstation/Workspace.scss
@@ -220,9 +220,15 @@
     // Workstation owns density policy; the shared dashboard owns projection hooks and defaults.
     // Root-font-relative bounds remain readable while both fluid terms follow this definite-size
     // host, including when the standalone app becomes a child workspace.
-    --dock-edge-band-left-inline-size : clamp(11.25rem, 20.3125cqi, 16.25rem);
-    --dock-edge-band-right-inline-size: clamp(13.75rem, 25cqi, 20rem);
-    --dock-edge-band-bottom-block-size: clamp(8.75rem, 28cqb, 12.5rem);
+    --dock-edge-band-left-inline-size     : 20.3125cqi;
+    --dock-edge-band-left-max-inline-size : 16.25rem;
+    --dock-edge-band-left-min-inline-size : 11.25rem;
+    --dock-edge-band-right-inline-size    : 25cqi;
+    --dock-edge-band-right-max-inline-size: 20rem;
+    --dock-edge-band-right-min-inline-size: 13.75rem;
+    --dock-edge-band-bottom-block-size    : 28cqb;
+    --dock-edge-band-bottom-max-block-size: 12.5rem;
+    --dock-edge-band-bottom-min-block-size: 8.75rem;
 
     padding : 12px;
     position: relative;

--- a/resources/scss/src/dashboard/Container.scss
+++ b/resources/scss/src/dashboard/Container.scss
@@ -424,19 +424,27 @@
     // `.neo-dashboard` zones, so declaring these tokens on every dashboard would shadow
     // application values inherited from the actual query host.
     &-left {
-        inline-size: var(--dock-edge-band-left-inline-size, var(--dock-edge-band-inline-size, 17.5rem));
+        inline-size    : var(--dock-edge-band-left-inline-size, var(--dock-edge-band-inline-size, 17.5rem));
+        max-inline-size: var(--dock-edge-band-left-max-inline-size, var(--dock-edge-band-max-inline-size, 50%));
+        min-inline-size: var(--dock-edge-band-left-min-inline-size, var(--dock-edge-band-min-inline-size, 8rem));
     }
 
     &-right {
-        inline-size: var(--dock-edge-band-right-inline-size, var(--dock-edge-band-inline-size, 17.5rem));
+        inline-size    : var(--dock-edge-band-right-inline-size, var(--dock-edge-band-inline-size, 17.5rem));
+        max-inline-size: var(--dock-edge-band-right-max-inline-size, var(--dock-edge-band-max-inline-size, 50%));
+        min-inline-size: var(--dock-edge-band-right-min-inline-size, var(--dock-edge-band-min-inline-size, 8rem));
     }
 
     &-top {
-        block-size: var(--dock-edge-band-top-block-size, var(--dock-edge-band-block-size, 12.5rem));
+        block-size    : var(--dock-edge-band-top-block-size, var(--dock-edge-band-block-size, 12.5rem));
+        max-block-size: var(--dock-edge-band-top-max-block-size, var(--dock-edge-band-max-block-size, 50%));
+        min-block-size: var(--dock-edge-band-top-min-block-size, var(--dock-edge-band-min-block-size, 6rem));
     }
 
     &-bottom {
-        block-size: var(--dock-edge-band-bottom-block-size, var(--dock-edge-band-block-size, 12.5rem));
+        block-size    : var(--dock-edge-band-bottom-block-size, var(--dock-edge-band-block-size, 12.5rem));
+        max-block-size: var(--dock-edge-band-bottom-max-block-size, var(--dock-edge-band-max-block-size, 50%));
+        min-block-size: var(--dock-edge-band-bottom-min-block-size, var(--dock-edge-band-min-block-size, 6rem));
     }
 }
 

--- a/src/ai/client/DockService.mjs
+++ b/src/ai/client/DockService.mjs
@@ -14,7 +14,7 @@ import {deriveSubtreePath}    from '../deriveSubtreePath.mjs';
  * The service never mutates layout state outside the landed commit path: operations dispatch
  * through `Operations.applyOperation()` (or the holder's own `applyDockZoneOperation`
  * override when present), and successful documents commit back exactly the way
- * `DockSplitter.commitResizeSplit()` does — including the `onDockZoneDocumentChange`
+ * `DockSplitter.commitResizeOperation()` does — including the `onDockZoneDocumentChange`
  * notification hook. Policy rejections (e.g. `pinnable: false`) therefore surface as the
  * executor's structured `errors`, never get bypassed.
  *

--- a/src/dashboard/dock/Workspace.mjs
+++ b/src/dashboard/dock/Workspace.mjs
@@ -1180,14 +1180,45 @@ class Workspace extends Container {
     }
 
     /**
-     * Updates close availability when the user changes the live active tab without committing a
-     * Dock document operation.
+     * Commits user tab activation through the document reducer, independently of close-action UI.
+     *
+     * Reconciliation can re-emit the already-committed index; that path is a byte-identical no-op.
+     * A stale/invalid projection is restored to document truth so a rejected activation changes
+     * neither durable state nor the rendered selection.
      * @param {Object} data
+     * @param {String} data.dockNodeId
      * @param {Neo.component.Base|null} [data.item]
      * @param {Neo.tab.Container|null} [data.tabContainer]
+     * @returns {{document:Object,errors:String[]}|null}
      */
-    onDockActiveIndexChange({item, tabContainer}={}) {
-        this.syncDockCloseAction(tabContainer || item?.parent?.parent || null)
+    onDockActiveIndexChange({dockNodeId, item, tabContainer}={}) {
+        let me        = this,
+            container = tabContainer || item?.parent?.parent || null,
+            itemId    = me.getActiveDockItemId(container),
+            committed = me.dockModel?.nodes?.[dockNodeId]?.activeItemId,
+            descriptor, result;
+
+        me.syncDockCloseAction(container);
+
+        if (!me.dockModel || !itemId || committed === itemId) {
+            return null
+        }
+
+        descriptor = {operation: 'setActiveItem', tabsNodeId: dockNodeId, itemId};
+        result     = me.applyDockZoneOperation(descriptor);
+
+        if (result && !result.errors?.length && result.document) {
+            me.onDockZoneDocumentChange(result.document, descriptor, container)
+        } else if (container) {
+            let itemIds = container.getTabBar()?.sortZoneConfig?.dockItemIds || [],
+                index   = itemIds.indexOf(committed);
+
+            if (index > -1 && container.activeIndex !== index) {
+                container.activeIndex = index
+            }
+        }
+
+        return result
     }
 
     /**
@@ -1470,10 +1501,10 @@ class Workspace extends Container {
             config = LayoutAdapter.project(document, {
                 onDockCrossZoneDrop: me.onDockCrossZoneDrop.bind(me),
                 ...me.getDockProjectionOptions(),
+                onDockActiveIndexChange: me.onDockActiveIndexChange.bind(me),
                 ...(me.enableDockCloseAction && {
-                    enableDockCloseAction  : true,
-                    onDockActiveIndexChange: me.onDockActiveIndexChange.bind(me),
-                    onDockHeaderAction     : me.onDockHeaderAction.bind(me)
+                    enableDockCloseAction: true,
+                    onDockHeaderAction   : me.onDockHeaderAction.bind(me)
                 }),
                 applyDockZoneOperation   : me.applyDockZoneOperation.bind(me),
                 onDockZoneDocumentChange : me.onDockZoneDocumentChange.bind(me),

--- a/src/dashboard/dock/interaction/DockSplitter.mjs
+++ b/src/dashboard/dock/interaction/DockSplitter.mjs
@@ -8,10 +8,12 @@ import NeoArray   from '../../../util/Array.mjs';
  * The generic parent owns every gesture mechanic — eager DragZone creation and registration,
  * per-gesture refresh, proxy handling, generation fencing, Escape/cancel restoration, and
  * teardown. This class adds ONLY the dock semantics on top: pointer geometry stays runtime-only,
- * the terminal converts the captured adjacent-pair sizes into one `resizeSplit` descriptor, and
+ * the terminal converts captured runtime geometry into one `resizeSplit` or `resizeEdgeZone`
+ * descriptor, and
  * the commit flows through `Operations.applyOperation()` or a supplied owning reducer callback.
- * No main-thread resize registration exists here: the deferred proxy presentation is the dock
- * default, and a live adjacent-pair preview is a separate feature seam consuming this class.
+ * Split-node affordances keep the deferred proxy presentation and register no main-thread resize;
+ * edge-zone affordances reuse the generic live sibling-resize path, then commit only its bounded
+ * terminal fraction. Live adjacent-pair split preview remains a separate feature seam.
  *
  * The public split vocabulary stays dock-shaped: `orientation` describes the SPLIT NODE
  * (`horizontal` = side-by-side children), which maps onto the generic parent's `direction`
@@ -84,7 +86,8 @@ class DockSplitter extends Splitter {
          */
         dockZoneDocument_: null,
         /**
-         * Notified after a successful local document commit.
+         * View-sync callback. Notified after a successful local document commit; an edge-terminal
+         * rejection receives the unchanged committed document so its main-thread preview is restored.
          * @member {Function|null} onDockZoneDocumentChange=null
          */
         onDockZoneDocumentChange: null,
@@ -215,7 +218,8 @@ class DockSplitter extends Splitter {
     }
 
     /**
-     * Captures child sizes at drag start so drag completion can stay model-order based.
+     * Captures the parent axis plus child sizes at drag start. Split terminals stay model-order
+     * based; edge terminals normalize their CSS-bounded pixel result against the same parent box.
      * @param {Object} data
      * @returns {Promise<Object>}
      */
@@ -243,8 +247,9 @@ class DockSplitter extends Splitter {
         });
 
         me.dragStartState = {
-            clientX: data.clientX,
-            clientY: data.clientY,
+            clientX   : data.clientX,
+            clientY   : data.clientY,
+            parentSize: Number(rects[0]?.[axis]),
             sizes
         };
 
@@ -256,7 +261,7 @@ class DockSplitter extends Splitter {
      * @returns {{document:(Object|null), errors:String[]}}
      * @protected
      */
-    commitResizeSplit(descriptor) {
+    commitResizeOperation(descriptor) {
         let me     = this,
             result = null;
 
@@ -269,7 +274,7 @@ class DockSplitter extends Splitter {
         if (!result) {
             result = {
                 document: me.dockZoneDocument,
-                errors  : ['DockSplitter requires `dockZoneDocument` or `applyDockZoneOperation` to commit resizeSplit.']
+                errors  : ['DockSplitter requires `dockZoneDocument` or `applyDockZoneOperation` to commit a resize operation.']
             }
         }
 
@@ -285,6 +290,18 @@ class DockSplitter extends Splitter {
     }
 
     /**
+     * @summary Creates the one semantic resize descriptor matching this projected affordance.
+     * @param {Object} data Main-thread terminal payload.
+     * @returns {Object}
+     * @protected
+     */
+    createResizeDescriptor(data={}) {
+        return this.isEdgeZoneResize()
+            ? Neo.dashboard.dock.projection.LayoutAdapter.createResizeEdgeZoneOperation(this, this.resolveEdgeExtent(data))
+            : this.createResizeSplitDescriptor(data)
+    }
+
+    /**
      * @param {Object} data
      * @returns {Object}
      * @protected
@@ -294,14 +311,25 @@ class DockSplitter extends Splitter {
     }
 
     /**
-     * The dock splitter registers no main-thread resize: the committed document is the sole size
+     * Split-node affordances register no main-thread resize: the committed document is the sole size
      * authority, so the deferred proxy presentation carries the gesture and the terminal commits
-     * semantically. A live adjacent-pair preview is a separate feature seam.
+     * semantically. Edge affordances use the inherited main-thread descriptor because their adjacent
+     * band must preview live under CSS min/max bounds; only the normalized terminal enters the document.
      * @returns {Object|null}
      * @protected
      */
     getResizeConfig() {
-        return null
+        return this.isEdgeZoneResize() ? super.getResizeConfig() : null
+    }
+
+    /**
+     * @summary Whether this projection commits the extent of an edge-zone descriptor.
+     * @returns {Boolean}
+     * @protected
+     */
+    isEdgeZoneResize() {
+        return this.data?.operation === 'resizeEdgeZone'
+            || (typeof this.edgeZoneId === 'string' && typeof this.edge === 'string')
     }
 
     /**
@@ -345,20 +373,25 @@ class DockSplitter extends Splitter {
 
     /**
      * The dock terminal: generic teardown first (generation fence, presentation restore, zone
-     * end), then EXACTLY one semantic commit derived from the captured pair — never a sibling
-     * `wrapperStyle` write, which is the generic parent's terminal and stays overridden here.
+     * end), then EXACTLY one semantic commit derived from captured runtime geometry — never a
+     * sibling `wrapperStyle` write, which is the generic parent's terminal and stays overridden here.
      * @param {Object} data
      * @returns {Object}
      */
     onDragEnd(data={}) {
         let me         = this,
             hasCapture = Boolean(me.dragStartState) || Array.isArray(data.sizes),
-            descriptor = hasCapture ? me.createResizeSplitDescriptor(data) : null,
+            descriptor = null,
             result;
 
         me.dragGeneration++;
         me.cleanupResize();
         me.dragZone?.dragEnd(data);
+
+        if (data.cancelled) {
+            me.dragStartState = null;
+            return {document: me.dockZoneDocument, errors: []}
+        }
 
         // The end-overtakes-start race: a real-pointer release can land while the async start
         // path is still capturing. A terminal without capture state (and no explicit vector) is
@@ -366,10 +399,18 @@ class DockSplitter extends Splitter {
         if (!hasCapture) {
             result = {
                 document: me.dockZoneDocument ?? null,
-                errors  : ['DockSplitter received a terminal without capture state; no resizeSplit was committed.']
+                errors  : ['DockSplitter received a terminal without capture state; no semantic resize was committed.']
             }
         } else {
-            result = me.commitResizeSplit(descriptor)
+            descriptor = me.createResizeDescriptor(data);
+            result     = me.commitResizeOperation(descriptor);
+
+            // Main-thread live resize intentionally retains its terminal pixels on success. A rejected
+            // semantic edge descriptor owns no such pixels, so re-project the unchanged committed document
+            // through the existing view-sync seam to restore the prior band geometry.
+            if (me.isEdgeZoneResize() && result.errors?.length && typeof me.onDockZoneDocumentChange === 'function') {
+                me.onDockZoneDocumentChange(me.dockZoneDocument, descriptor, me)
+            }
         }
 
         me.fire(result.errors?.length ? 'dockSplitterResizeRejected' : 'dockSplitterResize', {
@@ -381,6 +422,18 @@ class DockSplitter extends Splitter {
         me.dragStartState = null;
 
         return result
+    }
+
+    /**
+     * Clears the dock-only geometry snapshot when Escape closes the logical gesture. The generic
+     * parent restores presentation; the native sensor suppresses its later drag:end after cancel,
+     * so this state cannot rely on the cancelled onDragEnd() branch for retirement.
+     * @param {Object} data
+     * @protected
+     */
+    onDragCancel(data={}) {
+        super.onDragCancel(data);
+        this.dragStartState = null
     }
 
     /**
@@ -406,6 +459,21 @@ class DockSplitter extends Splitter {
         }
 
         await super.onDragStart(data)
+    }
+
+    /**
+     * @summary Normalizes the CSS-bounded terminal pixel size against the captured parent axis.
+     * @param {Object} data Main-thread terminal payload.
+     * @returns {Number} Fractional extent; invalid geometry deliberately reaches the reducer as `NaN`.
+     * @protected
+     */
+    resolveEdgeExtent(data={}) {
+        const parentSize = Number(this.dragStartState?.parentSize),
+              size       = Number(data.resizeSize);
+
+        return Number.isFinite(parentSize) && parentSize > 0 && Number.isFinite(size)
+            ? size / parentSize
+            : Number.NaN
     }
 
     /**

--- a/src/dashboard/dock/interaction/DockSplitter.mjs
+++ b/src/dashboard/dock/interaction/DockSplitter.mjs
@@ -86,8 +86,7 @@ class DockSplitter extends Splitter {
          */
         dockZoneDocument_: null,
         /**
-         * View-sync callback. Notified after a successful local document commit; an edge-terminal
-         * rejection receives the unchanged committed document so its main-thread preview is restored.
+         * View-sync callback. Notified after a successful local document commit.
          * @member {Function|null} onDockZoneDocumentChange=null
          */
         onDockZoneDocumentChange: null,
@@ -319,7 +318,9 @@ class DockSplitter extends Splitter {
      * @protected
      */
     getResizeConfig() {
-        return this.isEdgeZoneResize() ? super.getResizeConfig() : null
+        let config = this.isEdgeZoneResize() ? super.getResizeConfig() : null;
+
+        return config ? {...config, awaitWorkerSettlement: true} : null
     }
 
     /**
@@ -328,8 +329,7 @@ class DockSplitter extends Splitter {
      * @protected
      */
     isEdgeZoneResize() {
-        return this.data?.operation === 'resizeEdgeZone'
-            || (typeof this.edgeZoneId === 'string' && typeof this.edge === 'string')
+        return typeof this.edgeZoneId === 'string' && typeof this.edge === 'string'
     }
 
     /**
@@ -380,6 +380,7 @@ class DockSplitter extends Splitter {
      */
     onDragEnd(data={}) {
         let me         = this,
+            edgeResize = me.isEdgeZoneResize(),
             hasCapture = Boolean(me.dragStartState) || Array.isArray(data.sizes),
             descriptor = null,
             result;
@@ -388,40 +389,61 @@ class DockSplitter extends Splitter {
         me.cleanupResize();
         me.dragZone?.dragEnd(data);
 
-        if (data.cancelled) {
+        try {
+            if (data.cancelled) {
+                result = {document: me.dockZoneDocument, errors: []}
+            }
+            // The end-overtakes-start race: a real-pointer release can land while the async start
+            // path is still capturing. A terminal without capture state (and no explicit vector) is
+            // not a gesture — committing would write a zero-delta operation; reject loudly instead.
+            else if (!hasCapture) {
+                result = {
+                    document: me.dockZoneDocument ?? null,
+                    errors  : ['DockSplitter received a terminal without capture state; no semantic resize was committed.']
+                }
+            } else {
+                descriptor = me.createResizeDescriptor(data);
+                result     = me.commitResizeOperation(descriptor)
+            }
+        } catch (error) {
+            edgeResize && me.settleMainThreadResize(data, true);
             me.dragStartState = null;
-            return {document: me.dockZoneDocument, errors: []}
+            throw error
         }
 
-        // The end-overtakes-start race: a real-pointer release can land while the async start
-        // path is still capturing. A terminal without capture state (and no explicit vector) is
-        // not a gesture — committing would write a zero-delta operation; reject loudly instead.
-        if (!hasCapture) {
-            result = {
-                document: me.dockZoneDocument ?? null,
-                errors  : ['DockSplitter received a terminal without capture state; no semantic resize was committed.']
-            }
-        } else {
-            descriptor = me.createResizeDescriptor(data);
-            result     = me.commitResizeOperation(descriptor);
+        edgeResize && me.settleMainThreadResize(data, data.cancelled || Boolean(result.errors?.length));
 
-            // Main-thread live resize intentionally retains its terminal pixels on success. A rejected
-            // semantic edge descriptor owns no such pixels, so re-project the unchanged committed document
-            // through the existing view-sync seam to restore the prior band geometry.
-            if (me.isEdgeZoneResize() && result.errors?.length && typeof me.onDockZoneDocumentChange === 'function') {
-                me.onDockZoneDocumentChange(me.dockZoneDocument, descriptor, me)
-            }
+        if (!data.cancelled) {
+            me.fire(result.errors?.length ? 'dockSplitterResizeRejected' : 'dockSplitterResize', {
+                descriptor,
+                result,
+                splitter: me
+            })
         }
-
-        me.fire(result.errors?.length ? 'dockSplitterResizeRejected' : 'dockSplitterResize', {
-            descriptor,
-            result,
-            splitter: me
-        });
 
         me.dragStartState = null;
 
         return result
+    }
+
+    /**
+     * Routes the semantic terminal verdict to the generation-scoped main-thread preview owner.
+     * @param {Object} data
+     * @param {Number} data.resizeGeneration
+     * @param {String} data.resizeTargetId
+     * @param {Boolean} restore
+     * @protected
+     */
+    settleMainThreadResize(data, restore) {
+        if (!Number.isInteger(data.resizeGeneration)) return;
+
+        this.dragZone?.settleResize?.({
+            resizeGeneration: data.resizeGeneration,
+            resizeTargetId  : data.resizeTargetId,
+            restore
+        })?.catch?.(error => {
+            error !== Neo.isDestroyed && console.error('DockSplitter: main-thread resize settlement failed', error)
+        })
     }
 
     /**

--- a/src/dashboard/dock/interaction/Rail.mjs
+++ b/src/dashboard/dock/interaction/Rail.mjs
@@ -286,7 +286,7 @@ class Rail extends Container {
     /**
      * Commits a dock-zone operation descriptor through the owning reducer callback, falling back to
      * a local `Operations.applyOperation()` — identical commit contract to
-     * `DockSplitter.commitResizeSplit()` so dashboard reducers handle every affordance with one
+     * `DockSplitter.commitResizeOperation()` so dashboard reducers handle every affordance with one
      * code path. The rail commits `setItemPinned` (the overlay pin escape); reveal/dismiss never
      * commit anything.
      * @param {Object} descriptor

--- a/src/dashboard/dock/interaction/Rail.mjs
+++ b/src/dashboard/dock/interaction/Rail.mjs
@@ -622,9 +622,8 @@ class Rail extends Container {
     }
 
     /**
-     * Resolves the overlay's free-dimension extent for an item: the share its owning split last
-     * committed (still in the document), else `null` — the overlay then falls back to its
-     * workspace-configurable default fraction.
+     * Resolves the overlay's free-dimension extent from the owning edge descriptor, else `null` —
+     * the overlay then falls back to its workspace-configurable pre-commit fraction.
      * @param {String} itemId
      * @returns {Number|null}
      * @protected
@@ -634,7 +633,9 @@ class Rail extends Container {
 
         // Runtime namespace lookup avoids an import cycle (the adapter imports this class);
         // fail-soft to null — the overlay then uses its default fraction.
-        return document ? (Neo.dashboard?.dock?.projection?.LayoutAdapter?.resolveRevealExtent(document, itemId) ?? null) : null
+        return document
+            ? (Neo.dashboard?.dock?.projection?.LayoutAdapter?.resolveRevealExtent(document, itemId) ?? null)
+            : null
     }
 
     /**

--- a/src/dashboard/dock/model/Document.mjs
+++ b/src/dashboard/dock/model/Document.mjs
@@ -137,6 +137,45 @@ class Document extends Base {
     static dockZoneEdgeKeys = new Set(['top', 'right', 'bottom', 'left', 'center'])
 
     /**
+     * Fields allowed on one nested edge-zone descriptor.
+     * @member {Set<String>} dockZoneDescriptorKeys
+     * @protected
+     * @static
+     */
+    static dockZoneDescriptorKeys = new Set(['nodeId', 'extent', 'resizable'])
+
+    /**
+     * @summary Resolves the child node id owned by one final nested edge-zone descriptor.
+     *
+     * The v13.2 greenfield contract deliberately rejects the retired string shorthand. Returning
+     * null for every non-record shape keeps tree walkers fail-closed without creating a hidden
+     * compatibility reader.
+     * @param {*} descriptor
+     * @returns {String|null}
+     * @static
+     */
+    static getZoneNodeId(descriptor) {
+        return Document.isJsonRecord(descriptor) && typeof descriptor.nodeId === 'string' && descriptor.nodeId
+            ? descriptor.nodeId
+            : null
+    }
+
+    /**
+     * @summary Repoints one nested edge-zone descriptor while preserving its extent and policy.
+     * @param {Object} edgeZoneNode
+     * @param {String} edge
+     * @param {String} nodeId
+     * @protected
+     * @static
+     */
+    static setZoneNodeId(edgeZoneNode, edge, nodeId) {
+        edgeZoneNode.zones[edge] = {
+            ...(Document.isJsonRecord(edgeZoneNode.zones[edge]) ? edgeZoneNode.zones[edge] : {}),
+            nodeId
+        }
+    }
+
+    /**
      * @summary Type-aware deep clone of a dock-zone document.
      *
      * Uses `Neo.clone` (deep, ignoring Neo instances) rather than a `JSON.parse(JSON.stringify())`
@@ -354,11 +393,35 @@ class Document extends Base {
                     return unexpected
                 }
 
-                if (node.type === 'edge-zone' && Document.isJsonRecord(node.zones)) {
+                if (node.type === 'edge-zone') {
+                    if (!Document.isJsonRecord(node.zones)) {
+                        return {key: 'zones', path: `${path}.nodes.${nodeId}.zones`, reason: 'edge-zone zones must be a JSON object'}
+                    }
+
                     unexpected = Document.findUnexpectedKey(node.zones, Document.dockZoneEdgeKeys, `${path}.nodes.${nodeId}.zones`);
 
                     if (unexpected) {
                         return unexpected
+                    }
+
+                    for (const [edge, descriptor] of Object.entries(node.zones)) {
+                        if (!Document.isJsonRecord(descriptor)) {
+                            return {
+                                key   : edge,
+                                path  : `${path}.nodes.${nodeId}.zones.${edge}`,
+                                reason: 'edge-zone descriptor must be a JSON object'
+                            }
+                        }
+
+                        unexpected = Document.findUnexpectedKey(
+                            descriptor,
+                            Document.dockZoneDescriptorKeys,
+                            `${path}.nodes.${nodeId}.zones.${edge}`
+                        );
+
+                        if (unexpected) {
+                            return unexpected
+                        }
                     }
                 }
             }
@@ -440,8 +503,8 @@ class Document extends Base {
                 const index = node.children.indexOf(nodeId);
                 if (index > -1) return {parentId, slot: index}
             } else if (node.type === 'edge-zone' && node.zones) {
-                for (const [zone, target] of Object.entries(node.zones)) {
-                    if (target === nodeId) return {parentId, slot: zone}
+                for (const [zone, descriptor] of Object.entries(node.zones)) {
+                    if (Document.getZoneNodeId(descriptor) === nodeId) return {parentId, slot: zone}
                 }
             }
         }
@@ -490,7 +553,7 @@ class Document extends Base {
                 if (node.type === 'split') {
                     (node.children || []).forEach(walk)
                 } else if (node.type === 'edge-zone') {
-                    Object.values(node.zones || {}).forEach(walk)
+                    Object.values(node.zones || {}).map(Document.getZoneNodeId).forEach(walk)
                 }
             };
 
@@ -602,7 +665,7 @@ class Document extends Base {
         } else if (typeof parentSlot.slot === 'number') {
             document.nodes[parentSlot.parentId].children[parentSlot.slot] = newSplitId
         } else {
-            document.nodes[parentSlot.parentId].zones[parentSlot.slot] = newSplitId
+            Document.setZoneNodeId(document.nodes[parentSlot.parentId], parentSlot.slot, newSplitId)
         }
 
         return []
@@ -666,9 +729,52 @@ class Document extends Base {
                     errors.push(`split "${nodeId}" sizes do not sum to 1`)
                 }
             } else if (node.type === 'edge-zone') {
-                Object.values(node.zones || {}).forEach(targetId => {
-                    if (!nodes[targetId]) errors.push(`edge-zone "${nodeId}" references missing node "${targetId}"`)
-                })
+                if (!Document.isJsonRecord(node.zones)) {
+                    errors.push(`edge-zone "${nodeId}" zones must be a JSON object`)
+                    continue
+                }
+
+                for (const [edge, descriptor] of Object.entries(node.zones)) {
+                    if (!Document.dockZoneEdgeKeys.has(edge)) {
+                        errors.push(`edge-zone "${nodeId}" has unsupported edge "${edge}"`);
+                        continue
+                    }
+
+                    if (!Document.isJsonRecord(descriptor)) {
+                        errors.push(`edge-zone "${nodeId}" zone "${edge}" descriptor must be a JSON object`);
+                        continue
+                    }
+
+                    let unexpected = Document.findUnexpectedKey(
+                            descriptor,
+                            Document.dockZoneDescriptorKeys,
+                            `document.nodes.${nodeId}.zones.${edge}`
+                        ),
+                        targetId = Document.getZoneNodeId(descriptor);
+
+                    if (unexpected) {
+                        errors.push(`${unexpected.path} ${unexpected.reason}`)
+                    }
+
+                    if (!targetId) {
+                        errors.push(`edge-zone "${nodeId}" zone "${edge}" descriptor requires a non-empty nodeId`)
+                    } else if (!nodes[targetId]) {
+                        errors.push(`edge-zone "${nodeId}" references missing node "${targetId}"`)
+                    }
+
+                    if (Object.hasOwn(descriptor, 'extent') && (
+                        typeof descriptor.extent !== 'number' ||
+                        !Number.isFinite(descriptor.extent) ||
+                        descriptor.extent <= 0 ||
+                        descriptor.extent >= 1
+                    )) {
+                        errors.push(`edge-zone "${nodeId}" zone "${edge}" extent must be a finite number between 0 and 1`)
+                    }
+
+                    if (Object.hasOwn(descriptor, 'resizable') && typeof descriptor.resizable !== 'boolean') {
+                        errors.push(`edge-zone "${nodeId}" zone "${edge}" resizable must be a boolean`)
+                    }
+                }
             } else if (node.type === 'tabs') {
                 (node.items || []).forEach(itemId => {
                     if (!items[itemId]) errors.push(`tabs "${nodeId}" references missing item "${itemId}"`);
@@ -722,9 +828,14 @@ class Document extends Base {
                     node.sizes = node.children.map(() => 1 / count)
                 }
             } else if (node.type === 'edge-zone') {
-                for (const [zone, target] of Object.entries(node.zones || {})) {
-                    let resolved = collapse(target);
-                    if (resolved && doc.nodes[resolved]) { node.zones[zone] = resolved } else { delete node.zones[zone] }
+                for (const [zone, descriptor] of Object.entries(node.zones || {})) {
+                    let resolved = collapse(Document.getZoneNodeId(descriptor));
+
+                    if (resolved && doc.nodes[resolved]) {
+                        Document.setZoneNodeId(node, zone, resolved)
+                    } else {
+                        delete node.zones[zone]
+                    }
                 }
             } else if (node.type === 'tabs') {
                 if (!node.items || node.items.length === 0) { delete doc.nodes[nodeId]; return null }
@@ -861,7 +972,11 @@ class Document extends Base {
                     return `t${node.items?.length || 0}`;
                 case 'edge-zone':
                     return `e{${[...Document.dockZoneEdgeKeys]
-                        .map(zone => node.zones?.[zone] ? `${zone}:${walk(node.zones[zone])}` : '')
+                        .map(zone => {
+                            let nodeId = Document.getZoneNodeId(node.zones?.[zone]);
+
+                            return nodeId ? `${zone}:${walk(nodeId)}` : ''
+                        })
                         .filter(Boolean).join(',')}}`;
                 default:
                     errors.push(`fingerprint walk found unsupported node type "${node.type}"`);
@@ -956,7 +1071,7 @@ class Document extends Base {
             return null
         }
 
-        centerId = root.zones?.center;
+        centerId = Document.getZoneNodeId(root.zones?.center);
 
         return centerId && document.nodes[centerId] ? centerId : null
     }

--- a/src/dashboard/dock/model/Operations.mjs
+++ b/src/dashboard/dock/model/Operations.mjs
@@ -42,10 +42,12 @@ class Operations extends Base {
                 ? Operations.moveItem(document, {itemId: descriptor.itemId, targetNodeId: descriptor.tabsNodeId, index: descriptor.index})
                 : Operations.addTab(document, descriptor),
         applyDocument    : (document, descriptor) => Operations.applyDocument(document, descriptor),
+        setActiveItem    : (document, descriptor) => Operations.setActiveItem(document, descriptor),
         moveItem         : (document, descriptor) => Operations.moveItem(document, descriptor),
         splitNode        : (document, descriptor) => Operations.splitNode(document, descriptor),
         moveNode         : (document, descriptor) => Operations.moveNode(document, descriptor),
         resizeSplit      : (document, descriptor) => Operations.resizeSplit(document, descriptor),
+        resizeEdgeZone   : (document, descriptor) => Operations.resizeEdgeZone(document, descriptor),
         detachItem       : (document, descriptor) => Operations.detachItem(document, descriptor),
         closeItem        : (document, descriptor) => Operations.closeItem(document, descriptor),
         setItemPinned    : (document, descriptor) => Operations.setItemPinned(document, descriptor),
@@ -127,6 +129,43 @@ class Operations extends Base {
     }
 
     /**
+     * @summary Commits one tabs node's active item through the semantic reducer.
+     *
+     * Projection events carry both the semantic tabs-node id and the selected item id. Membership
+     * is validated against the committed document so a stale projected tab cannot redirect
+     * activation into another stack. An already-active item is a successful byte-identical no-op.
+     * @param {Object} document
+     * @param {Object} args {tabsNodeId, itemId}
+     * @returns {{document:Object, errors:String[]}}
+     * @static
+     */
+    static setActiveItem(document, {tabsNodeId, itemId} = {}) {
+        let tabs = document.nodes?.[tabsNodeId];
+
+        if (!tabs) {
+            return {document, errors: [`unknown tabs node "${tabsNodeId}"`]}
+        }
+
+        if (tabs.type !== 'tabs') {
+            return {document, errors: [`"${tabsNodeId}" is not a tabs node`]}
+        }
+
+        if (!(tabs.items || []).includes(itemId)) {
+            return {document, errors: [`item "${itemId}" is not a member of tabs node "${tabsNodeId}"`]}
+        }
+
+        if (tabs.activeItemId === itemId) {
+            return {document, errors: []}
+        }
+
+        let doc = Document.clone(document);
+
+        doc.nodes[tabsNodeId].activeItemId = itemId;
+
+        return Document.commit(document, doc)
+    }
+
+    /**
      * @summary Splits `targetNodeId` against a new pane holding `itemId`.
      *
      * Wraps `itemId` in a fresh single-tab node and replaces `targetNodeId` in its parent with a new
@@ -178,7 +217,7 @@ class Operations extends Base {
         } else if (typeof parentSlot.slot === 'number') {
             doc.nodes[parentSlot.parentId].children[parentSlot.slot] = newSplitId
         } else {
-            doc.nodes[parentSlot.parentId].zones[parentSlot.slot] = newSplitId
+            Document.setZoneNodeId(doc.nodes[parentSlot.parentId], parentSlot.slot, newSplitId)
         }
 
         return Document.commit(document, doc)
@@ -215,6 +254,56 @@ class Operations extends Base {
         let doc = Document.clone(document);
 
         doc.nodes[splitNodeId].sizes = normalized.sizes;
+
+        return Document.commit(document, doc)
+    }
+
+    /**
+     * @summary Commits one normalized extent onto a resizable nested edge-zone descriptor.
+     *
+     * Runtime pixels and CSS constraints stay outside the document. The interaction layer converts
+     * its final CSS-bounded geometry into this normalized fraction; the reducer validates only the
+     * durable semantic domain and the descriptor's explicit resize permission.
+     * @param {Object} document
+     * @param {Object} args {edgeZoneId, edge, extent}
+     * @returns {{document:Object, errors:String[]}}
+     * @static
+     */
+    static resizeEdgeZone(document, {edgeZoneId, edge, extent} = {}) {
+        let edgeZone   = document.nodes?.[edgeZoneId],
+            descriptor = edgeZone?.zones?.[edge];
+
+        if (!edgeZone) {
+            return {document, errors: [`unknown edge-zone node "${edgeZoneId}"`]}
+        }
+
+        if (edgeZone.type !== 'edge-zone') {
+            return {document, errors: [`"${edgeZoneId}" is not an edge-zone node`]}
+        }
+
+        if (!['top', 'right', 'bottom', 'left'].includes(edge)) {
+            return {document, errors: [`edge "${edge}" is not resizable`]}
+        }
+
+        if (!Document.isJsonRecord(descriptor) || !Document.getZoneNodeId(descriptor)) {
+            return {document, errors: [`edge-zone "${edgeZoneId}" has no valid "${edge}" descriptor`]}
+        }
+
+        if (descriptor.resizable !== true) {
+            return {document, errors: [`edge-zone "${edgeZoneId}" edge "${edge}" is not resizable`]}
+        }
+
+        if (typeof extent !== 'number' || !Number.isFinite(extent) || extent <= 0 || extent >= 1) {
+            return {document, errors: ['extent must be a finite number between 0 and 1']}
+        }
+
+        if (descriptor.extent === extent) {
+            return {document, errors: []}
+        }
+
+        let doc = Document.clone(document);
+
+        doc.nodes[edgeZoneId].zones[edge].extent = extent;
 
         return Document.commit(document, doc)
     }

--- a/src/dashboard/dock/model/TopologyDiff.mjs
+++ b/src/dashboard/dock/model/TopologyDiff.mjs
@@ -77,7 +77,7 @@ class TopologyDiff extends Base {
             } else if (node.type === 'split') {
                 (node.children || []).forEach(walk)
             } else if (node.type === 'edge-zone') {
-                Object.keys(node.zones || {}).sort().forEach(zone => walk(node.zones[zone]))
+                Object.keys(node.zones || {}).sort().forEach(zone => walk(Document.getZoneNodeId(node.zones[zone])))
             }
         };
 

--- a/src/dashboard/dock/projection/LayoutAdapter.mjs
+++ b/src/dashboard/dock/projection/LayoutAdapter.mjs
@@ -279,6 +279,24 @@ class LayoutAdapter extends Base {
     }
 
     /**
+     * @summary Creates the semantic descriptor emitted after an edge splitter resolves.
+     * @param {Object} splitter Projected splitter config, or its data payload.
+     * @param {Number} extent Final CSS-bounded normalized edge extent.
+     * @returns {Object}
+     * @static
+     */
+    static createResizeEdgeZoneOperation(splitter, extent) {
+        let metadata = splitter?.data || splitter || {};
+
+        return {
+            operation : 'resizeEdgeZone',
+            edgeZoneId: metadata.edgeZoneId || metadata.dockNodeId || splitter?.edgeZoneId,
+            edge      : metadata.edge || splitter?.edge,
+            extent
+        }
+    }
+
+    /**
      * @summary Projects the stable resize affordance between two adjacent split children.
      * @param {String} splitNodeId
      * @param {String} orientation
@@ -314,6 +332,50 @@ class LayoutAdapter extends Base {
             size                             : this.splitterSize,
             splitNodeId,
             [isVertical ? 'height' : 'width']: this.splitterSize
+        }
+    }
+
+    /**
+     * @summary Projects the resize affordance between one resizable edge band and the center.
+     *
+     * The generic splitter owns pointer/live-preview mechanics. This metadata selects the adjacent
+     * band and gives DockSplitter only the semantic terminal descriptor it adds on release.
+     * @param {String} edgeZoneId
+     * @param {String} edge One of top/right/bottom/left.
+     * @param {Object} descriptor Nested edge descriptor.
+     * @param {Object} context
+     * @returns {Object}
+     * @protected
+     * @static
+     */
+    static createEdgeSplitterAffordance(edgeZoneId, edge, descriptor, context={}) {
+        let orientation  = edge === 'left' || edge === 'right' ? 'horizontal' : 'vertical',
+            resizeTarget = edge === 'left' || edge === 'top' ? 'previous' : 'next',
+            vertical     = orientation === 'vertical';
+
+        return {
+            applyDockZoneOperation: context.applyDockZoneOperation,
+            cls                   : ['neo-dashboard-dock-splitter', `neo-dashboard-dock-splitter-${orientation}`],
+            data                  : {
+                dockNodeId  : edgeZoneId,
+                dockSplitter: true,
+                edge,
+                edgeZoneId,
+                operation   : 'resizeEdgeZone',
+                orientation
+            },
+            dockNodeId                     : edgeZoneId,
+            dockNodeType                   : 'splitter',
+            dockZoneDocument               : context.dockZoneDocument,
+            edge,
+            edgeZoneId,
+            module                         : DockSplitter,
+            ntype                          : 'dashboard-dock-splitter',
+            onDockZoneDocumentChange       : context.onDockZoneDocumentChange,
+            orientation,
+            resizeTarget,
+            size                           : this.splitterSize,
+            [vertical ? 'height' : 'width']: this.splitterSize
         }
     }
 
@@ -456,7 +518,7 @@ class LayoutAdapter extends Base {
         }
 
         if (node.type === 'edge-zone') {
-            Object.values(node.zones || {}).forEach(childId => {
+            Object.values(node.zones || {}).map(Document.getZoneNodeId).forEach(childId => {
                 result.push(...this.collectAutoHiddenItems(childId, context))
             })
         } else if (node.type === 'split') {
@@ -535,11 +597,10 @@ class LayoutAdapter extends Base {
     }
 
     /**
-     * Resolves the reveal overlay's free-dimension extent for an item: the share its owning
-     * subtree holds at the nearest ancestor split, per that split's committed `sizes` — the
-     * "last committed extent, still in the document" rule. Returns `null` when no ancestor split
-     * carries usable sizes (e.g. a tabs node sitting directly in an edge-zone slot); the overlay
-     * then falls back to its workspace-configurable default fraction. Never reads DOM geometry.
+     * Resolves the reveal overlay's free-dimension extent from the item's owning edge descriptor.
+     * Split sizes govern split children only; they must never be borrowed as edge-band authority.
+     * Returns `null` when the owning edge has never committed an extent, so the overlay uses its
+     * workspace-configurable pre-commit fallback. Never reads DOM geometry.
      * @param {Object} model Committed dock-zone document.
      * @param {String} itemId
      * @returns {Number|null} Fraction in `(0, 1]`, or `null`.
@@ -556,8 +617,13 @@ class LayoutAdapter extends Base {
                 if (node.type === 'split' && (node.children || []).includes(id)) {
                     return {index: node.children.indexOf(id), nodeId, split: true}
                 }
-                if (node.type === 'edge-zone' && Object.values(node.zones || {}).includes(id)) {
-                    return {nodeId, split: false}
+
+                if (node.type === 'edge-zone') {
+                    for (const descriptor of Object.values(node.zones || {})) {
+                        if (Document.getZoneNodeId(descriptor) === id) {
+                            return {descriptor, nodeId, split: false}
+                        }
+                    }
                 }
             }
             return null
@@ -570,17 +636,10 @@ class LayoutAdapter extends Base {
                 return null
             }
 
-            if (parent.split) {
-                let sizes = nodes[parent.nodeId].sizes;
+            if (!parent.split) {
+                let extent = Number(parent.descriptor?.extent);
 
-                if (Array.isArray(sizes) && sizes.length) {
-                    let total = sizes.reduce((sum, value) => sum + (Number(value) || 0), 0),
-                        share = Number(sizes[parent.index]);
-
-                    return total > 0 && Number.isFinite(share) && share > 0 ? share / total : null
-                }
-
-                return null
+                return Number.isFinite(extent) && extent > 0 && extent < 1 ? extent : null
             }
 
             childId = parent.nodeId
@@ -610,8 +669,10 @@ class LayoutAdapter extends Base {
             railedItemIds = new Set();
 
         ['top', 'right', 'bottom', 'left'].forEach(edge => {
-            if (zones[edge]) {
-                let itemIds = this.collectAutoHiddenItems(zones[edge], context);
+            let zoneId = Document.getZoneNodeId(zones[edge]);
+
+            if (zoneId) {
+                let itemIds = this.collectAutoHiddenItems(zoneId, context);
 
                 if (itemIds.length) {
                     railsByEdge[edge] = itemIds;
@@ -630,24 +691,33 @@ class LayoutAdapter extends Base {
         // returns null for an empty tab flow — see its constraint comment).
         let band;
 
-        if (railsByEdge.left)  middleItems.push(this.createEdgeRail(railsByEdge.left, 'left', context));
-        if (zones.left)        (band = this.projectEdgeBand(zones.left, 'left', childContext)) && middleItems.push(band);
+        if (railsByEdge.left) middleItems.push(this.createEdgeRail(railsByEdge.left, 'left', context));
 
-        if (zones.center) {
-            centerConfig      = this.projectNode(zones.center, childContext);
+        if (zones.left && (band = this.projectEdgeBand(zones.left, 'left', childContext))) {
+            middleItems.push(band);
+            zones.left.resizable === true && middleItems.push(this.createEdgeSplitterAffordance(nodeId, 'left', zones.left, context))
+        }
+
+        if (Document.getZoneNodeId(zones.center)) {
+            centerConfig      = this.projectNode(Document.getZoneNodeId(zones.center), childContext);
             centerConfig.flex = 1;
             middleItems.push(centerConfig)
         }
 
-        if (zones.right)       (band = this.projectEdgeBand(zones.right, 'right', childContext)) && middleItems.push(band);
+        if (zones.right && (band = this.projectEdgeBand(zones.right, 'right', childContext))) {
+            zones.right.resizable === true && middleItems.push(this.createEdgeSplitterAffordance(nodeId, 'right', zones.right, context));
+            middleItems.push(band)
+        }
+
         if (railsByEdge.right) middleItems.push(this.createEdgeRail(railsByEdge.right, 'right', context));
 
         if (railsByEdge.top) {
             rows.push(this.createEdgeRail(railsByEdge.top, 'top', context))
         }
 
-        if (zones.top) {
-            (band = this.projectEdgeBand(zones.top, 'top', childContext)) && rows.push(band)
+        if (zones.top && (band = this.projectEdgeBand(zones.top, 'top', childContext))) {
+            rows.push(band);
+            zones.top.resizable === true && rows.push(this.createEdgeSplitterAffordance(nodeId, 'top', zones.top, context))
         }
 
         if (middleItems.length === 1) {
@@ -662,8 +732,9 @@ class LayoutAdapter extends Base {
             })
         }
 
-        if (zones.bottom) {
-            (band = this.projectEdgeBand(zones.bottom, 'bottom', childContext)) && rows.push(band)
+        if (zones.bottom && (band = this.projectEdgeBand(zones.bottom, 'bottom', childContext))) {
+            zones.bottom.resizable === true && rows.push(this.createEdgeSplitterAffordance(nodeId, 'bottom', zones.bottom, context));
+            rows.push(band)
         }
 
         if (railsByEdge.bottom) {
@@ -684,15 +755,20 @@ class LayoutAdapter extends Base {
      * Marks an edge-band zone projection: bands keep a fixed cross-extent (the
      * `neo-dashboard-dock-edge-band(-edge)` CSS hooks) instead of flexing against the center —
      * an unsized band silently eats workspace geometry the center owns.
-     * @param {String} zoneId
+     * @param {Object} descriptor Nested edge descriptor.
      * @param {String} edge One of `top`, `right`, `bottom`, `left`.
      * @param {Object} context
      * @returns {Object}
      * @protected
      * @static
      */
-    static projectEdgeBand(zoneId, edge, context) {
-        let config = this.projectNode(zoneId, context);
+    static projectEdgeBand(descriptor, edge, context) {
+        let zoneId = Document.getZoneNodeId(descriptor),
+            config = zoneId ? this.projectNode(zoneId, context) : null;
+
+        if (!config) {
+            return null
+        }
 
         // An edge band whose tab flow is EMPTY (every item railed away as autoHidden) must not
         // hold layout. The fixed cross-extent below exists to protect the CENTER from an unsized
@@ -708,6 +784,10 @@ class LayoutAdapter extends Base {
 
         config.cls  = [...(config.cls || []), 'neo-dashboard-dock-edge-band', `neo-dashboard-dock-edge-band-${edge}`];
         config.flex = 'none';
+
+        if (Number.isFinite(descriptor.extent)) {
+            config[edge === 'left' || edge === 'right' ? 'width' : 'height'] = `${descriptor.extent * 100}%`
+        }
 
         return config
     }

--- a/src/dashboard/dock/projection/LayoutAdapter.mjs
+++ b/src/dashboard/dock/projection/LayoutAdapter.mjs
@@ -286,12 +286,14 @@ class LayoutAdapter extends Base {
      * @static
      */
     static createResizeEdgeZoneOperation(splitter, extent) {
-        let metadata = splitter?.data || splitter || {};
+        let edgeZoneId = splitter?.edgeZoneId || splitter?.dockNodeId,
+            edge       = splitter?.edge,
+            metadata   = !edgeZoneId || !edge ? splitter?.data || {} : {};
 
         return {
             operation : 'resizeEdgeZone',
-            edgeZoneId: metadata.edgeZoneId || metadata.dockNodeId || splitter?.edgeZoneId,
-            edge      : metadata.edge || splitter?.edge,
+            edgeZoneId: edgeZoneId || metadata.edgeZoneId || metadata.dockNodeId,
+            edge      : edge || metadata.edge,
             extent
         }
     }

--- a/src/dashboard/dock/projection/LayoutAdapter.mjs
+++ b/src/dashboard/dock/projection/LayoutAdapter.mjs
@@ -369,6 +369,7 @@ class LayoutAdapter extends Base {
             dockZoneDocument               : context.dockZoneDocument,
             edge,
             edgeZoneId,
+            liveResize                     : true,
             module                         : DockSplitter,
             ntype                          : 'dashboard-dock-splitter',
             onDockZoneDocumentChange       : context.onDockZoneDocumentChange,

--- a/src/dashboard/dock/projection/Reconciler.mjs
+++ b/src/dashboard/dock/projection/Reconciler.mjs
@@ -112,9 +112,10 @@ class Reconciler extends Base {
      * @summary Reconciles a geometry-only projection without moving live dock chrome.
      *
      * The fast path is deliberately strict: dock-node ancestry/order, split orientation, tab item
-     * order, and active selection must all be unchanged. Only then may projected child `flex`
-     * values be applied to the retained shell in place. Any structural or ownership delta defers
-     * to the staged descendant → ancestor transaction in {@link #reconcileProjection}.
+     * order, and active selection must all be unchanged. Only then may projected child geometry
+     * (`flex`, `width`, and `height`) be applied to the retained shell in place. Any structural or
+     * ownership delta defers to the staged descendant → ancestor transaction in
+     * {@link #reconcileProjection}.
      * @param {Neo.component.Base} oldShell
      * @param {Object} nextConfig
      * @param {Map<String,Neo.component.Base>} placeholders
@@ -169,7 +170,9 @@ class Reconciler extends Base {
             plans       = new Map();
 
         nextNodes.forEach((next, nodeId) => {
-            const current = currentNodes.get(nodeId).node;
+            const
+                current    = currentNodes.get(nodeId).node,
+                dimensions = {};
 
             if (Object.hasOwn(next.node, 'flex')) {
                 current.setSilent({
@@ -177,6 +180,14 @@ class Reconciler extends Base {
                     wrapperStyle: {...current.wrapperStyle, flex: next.node.flex ?? null}
                 })
             }
+
+            for (const key of ['height', 'width']) {
+                if (Object.hasOwn(next.node, key) && current[key] !== next.node[key]) {
+                    dimensions[key] = next.node[key]
+                }
+            }
+
+            Object.keys(dimensions).length && current.set(dimensions);
 
             if (next.type === 'tabs') {
                 plans.set(nodeId, {

--- a/src/draggable/DragZone.mjs
+++ b/src/draggable/DragZone.mjs
@@ -263,6 +263,25 @@ class DragZone extends Base {
     }
 
     /**
+     * Routes one semantic resize verdict back to the exact main-thread gesture owner.
+     * @param {Object} data
+     * @param {Number} data.resizeGeneration
+     * @param {String} data.resizeTargetId
+     * @param {Boolean} [data.restore=false]
+     * @returns {Promise<Boolean>|undefined}
+     */
+    settleResize(data={}) {
+        let me = this;
+
+        return Neo.main.addon.DragDrop.settleResize?.({
+            appName   : me.appName,
+            dragZoneId: me.id,
+            windowId  : me.windowId,
+            ...data
+        })
+    }
+
+    /**
      * Triggered after the windowId config got changed
      * @param {Number|null} value
      * @param {Number|null} oldValue

--- a/src/main/addon/DragDrop.mjs
+++ b/src/main/addon/DragDrop.mjs
@@ -191,6 +191,7 @@ class DragDrop extends Base {
                 'resumeWindowDrag',
                 'setConfigs',
                 'setDragProxyElement',
+                'settleResize',
                 'startWindowDrag',
                 'unregisterZone'
             ]
@@ -329,9 +330,10 @@ class DragDrop extends Base {
             DomEvents.sendMessageToApp({
                 ...parsedEvent,
                 ...(resize ? {
-                    resizeAxis    : resize.axis,
-                    resizeSize    : resize.size,
-                    resizeTargetId: resize.targetId
+                    resizeAxis      : resize.axis,
+                    resizeGeneration: resize.generation,
+                    resizeSize      : resize.size,
+                    resizeTargetId  : resize.targetId
                 } : {}),
                 dragZoneId: me.dragZoneId,
                 isDrop,
@@ -788,6 +790,25 @@ class DragDrop extends Base {
             me.zoneRegistrations[data.dragElementRootId] = data.dragZoneId;
             me.dragResize?.register(data)
         }
+    }
+
+    /**
+     * Settles one generation-scoped main-thread resize terminal after the App Worker accepts or
+     * rejects its semantic commit.
+     * @param {Object} data
+     * @param {String} data.dragZoneId
+     * @param {Number} data.resizeGeneration
+     * @param {Boolean} [data.restore=false]
+     * @param {String} data.resizeTargetId
+     * @returns {Boolean}
+     */
+    settleResize({dragZoneId, resizeGeneration, resizeTargetId, restore=false}={}) {
+        return this.dragResize?.settle({
+            dragZoneId,
+            generation: resizeGeneration,
+            restore,
+            targetId  : resizeTargetId
+        }) === true
     }
 
     /**

--- a/src/main/draggable/Resize.mjs
+++ b/src/main/draggable/Resize.mjs
@@ -1,6 +1,25 @@
 import DomAccess from '../DomAccess.mjs';
 
 /**
+ * @summary Resolves one computed CSS bound into pixels against its owning layout axis.
+ *
+ * Computed styles resolve absolute units such as `rem` to pixels, but percentage min/max values
+ * remain percentages. Treating `50%` as the number 50 silently turns a half-workspace ceiling into
+ * a 50px ceiling, so percentages are resolved explicitly against the measured parent layout box.
+ * @param {String} value Computed CSS property value.
+ * @param {Number} parentSize Parent layout extent on the resize axis.
+ * @returns {Number} Pixel bound, or `NaN` when no finite bound exists.
+ */
+function resolveCssBound(value, parentSize) {
+    const source = String(value ?? '').trim(),
+          number = Number.parseFloat(source);
+
+    if (!Number.isFinite(number)) return Number.NaN;
+
+    return source.endsWith('%') ? parentSize * number / 100 : number
+}
+
+/**
  * @summary Gesture-local DOM resizing owned by the main-thread DragDrop addon.
  *
  * Pointer frames mutate only the registered target's outer layout node. The App Worker receives
@@ -113,8 +132,8 @@ class Resize {
             startSize  = Number(targetRect[config.axis]),
             layoutMax  = Math.max(0, Number(parentRect[config.axis]) - Number(config.splitterSize || 0)),
             computed   = globalThis.getComputedStyle?.(target),
-            minValue   = Number.parseFloat(computed?.getPropertyValue(`min-${config.axis}`)),
-            maxValue   = Number.parseFloat(computed?.getPropertyValue(`max-${config.axis}`)),
+            minValue   = resolveCssBound(computed?.getPropertyValue(`min-${config.axis}`), Number(parentRect[config.axis])),
+            maxValue   = resolveCssBound(computed?.getPropertyValue(`max-${config.axis}`), Number(parentRect[config.axis])),
             minSize    = Number.isFinite(minValue) ? Math.max(0, minValue) : 0,
             maxSize    = Math.max(minSize, Math.min(layoutMax, Number.isFinite(maxValue) ? maxValue : layoutMax));
 

--- a/src/main/draggable/Resize.mjs
+++ b/src/main/draggable/Resize.mjs
@@ -53,7 +53,7 @@ class Resize {
 
         const delta = coordinate - state.startCoordinate,
               value = Math.min(
-                  Math.max(state.startSize + (state.resizeNext ? -delta : delta), 0),
+                  Math.max(state.startSize + (state.resizeNext ? -delta : delta), state.minSize || 0),
                   state.maxSize
               );
 
@@ -111,7 +111,12 @@ class Resize {
             parentRect = DomAccess.getLayoutRect(parent),
             targetRect = DomAccess.getLayoutRect(target),
             startSize  = Number(targetRect[config.axis]),
-            maxSize    = Math.max(0, Number(parentRect[config.axis]) - Number(config.splitterSize || 0));
+            layoutMax  = Math.max(0, Number(parentRect[config.axis]) - Number(config.splitterSize || 0)),
+            computed   = globalThis.getComputedStyle?.(target),
+            minValue   = Number.parseFloat(computed?.getPropertyValue(`min-${config.axis}`)),
+            maxValue   = Number.parseFloat(computed?.getPropertyValue(`max-${config.axis}`)),
+            minSize    = Number.isFinite(minValue) ? Math.max(0, minValue) : 0,
+            maxSize    = Math.max(minSize, Math.min(layoutMax, Number.isFinite(maxValue) ? maxValue : layoutMax));
 
         if (!Number.isFinite(startSize) || !Number.isFinite(maxSize)) return null;
 
@@ -130,6 +135,7 @@ class Resize {
             dragZoneId: config.dragZoneId,
             lastSize  : startSize,
             maxSize,
+            minSize,
             originalStyle,
             preview   : config.preview === true,
             resizeNext: config.resizeNext === true,

--- a/src/main/draggable/Resize.mjs
+++ b/src/main/draggable/Resize.mjs
@@ -43,6 +43,21 @@ class Resize {
     registrations = {}
 
     /**
+     * One opt-in terminal whose pixels await the App Worker's semantic commit verdict.
+     * @member {Object|null} pendingTerminal=null
+     * @protected
+     */
+    pendingTerminal = null
+
+    /**
+     * Monotonic identity for worker-settled terminals. A stale response can never settle a
+     * successor gesture which happens to address the same zone and target.
+     * @member {Number} settlementGeneration=0
+     * @protected
+     */
+    settlementGeneration = 0
+
+    /**
      * Active transient preview state.
      * @member {Object|null} state=null
      * @protected
@@ -62,7 +77,16 @@ class Resize {
      * @returns {Number|null}
      */
     apply(data) {
-        let {state} = this;
+        let me               = this,
+            {gesture, state} = me;
+
+        if (gesture) {
+            const clientX = Number(data.clientX),
+                  clientY = Number(data.clientY);
+
+            Number.isFinite(clientX) && (gesture.latestClientX = clientX);
+            Number.isFinite(clientY) && (gesture.latestClientY = clientY)
+        }
 
         if (!state) return null;
 
@@ -93,19 +117,31 @@ class Resize {
     cancel() {
         let {state} = this;
 
-        if (state) {
-            Object.entries(state.originalStyle).forEach(([key, {priority, value}]) => {
-                if (value) {
-                    state.target.style.setProperty(key, value, priority)
-                } else {
-                    state.target.style.removeProperty(key)
-                }
-            })
-        }
+        this.restoreState(state);
 
         this.gesture = this.state = null;
 
         return Boolean(state)
+    }
+
+    /**
+     * Restores the exact inline properties captured before transient resize ownership began.
+     * @param {Object|null} state
+     * @returns {Boolean}
+     * @protected
+     */
+    restoreState(state) {
+        if (!state) return false;
+
+        Object.entries(state.originalStyle).forEach(([key, {priority, value}]) => {
+            if (value) {
+                state.target.style.setProperty(key, value, priority)
+            } else {
+                state.target.style.removeProperty(key)
+            }
+        });
+
+        return true
     }
 
     /**
@@ -149,44 +185,88 @@ class Resize {
         });
 
         return {
-            axis      : config.axis,
+            axis                 : config.axis,
+            awaitWorkerSettlement: config.awaitWorkerSettlement === true,
             coordinate,
-            dragZoneId: config.dragZoneId,
-            lastSize  : startSize,
+            dragZoneId           : config.dragZoneId,
+            lastSize             : startSize,
             maxSize,
             minSize,
             originalStyle,
-            preview   : config.preview === true,
-            resizeNext: config.resizeNext === true,
+            parentId             : config.parentId,
+            preview              : config.preview === true,
+            resizeNext           : config.resizeNext === true,
             startCoordinate,
             startSize,
             target,
-            targetId  : config.targetId
+            targetId             : config.targetId
         }
     }
 
     /**
-     * Resolves the terminal size and relinquishes transient DOM authority without undoing success.
+     * Resolves the terminal size and relinquishes active gesture authority without undoing success.
+     * Semantic consumers may opt into one generation-scoped pending terminal: success discards its
+     * rollback snapshot, while rejection restores the exact pre-gesture inline properties.
      * @param {Object} data
-     * @returns {{axis: String, size: Number, targetId: String}|null}
+     * @returns {{axis: String, generation: (Number|undefined), size: Number, targetId: String}|null}
      */
     finish(data) {
-        let state = this.state,
-            size  = this.apply(data),
+        let me    = this,
+            state = me.state,
+            size  = me.apply(data),
             result;
 
         if (state && Number.isFinite(size)) {
-            result = {axis: state.axis, size, targetId: state.targetId}
+            result = {axis: state.axis, size, targetId: state.targetId};
+
+            if (state.preview && state.awaitWorkerSettlement) {
+                me.pendingTerminal && me.restoreState(me.pendingTerminal);
+
+                const generation = ++me.settlementGeneration;
+
+                me.pendingTerminal = {...state, generation};
+                result.generation  = generation
+            }
+        } else if (state?.preview) {
+            me.restoreState(state)
         }
 
-        this.gesture = this.state = null;
+        me.gesture = me.state = null;
 
         return result || null
     }
 
     /**
+     * Settles one exact worker-owned semantic terminal. Success merely relinquishes the rollback
+     * snapshot; rejection restores the transient target. All three identities must match so a late
+     * response cannot mutate a newer gesture which reused the same DOM node.
+     * @param {Object} data
+     * @param {String} data.dragZoneId
+     * @param {Number} data.generation
+     * @param {Boolean} [data.restore=false]
+     * @param {String} data.targetId
+     * @returns {Boolean}
+     */
+    settle({dragZoneId, generation, restore=false, targetId}={}) {
+        let me      = this,
+            pending = me.pendingTerminal;
+
+        if (
+            !pending || pending.dragZoneId !== dragZoneId || pending.generation !== generation ||
+            pending.targetId !== targetId
+        ) return false;
+
+        restore && me.restoreState(pending);
+        me.pendingTerminal = null;
+
+        return true
+    }
+
+    /**
      * Registers or clears one DragZone descriptor. A late same-gesture registration reuses the
-     * immutable native start coordinate rather than the latest pointer frame.
+     * immutable native start coordinate. When reconciliation replaced the target after eager
+     * registration, it restores the stale target, captures the current one, and replays the latest
+     * pointer frame so live preview cannot remain bound to retired DOM.
      * @param {Object} data
      */
     register(data) {
@@ -200,8 +280,22 @@ class Resize {
                 dragZoneId: data.dragZoneId
             };
 
-            if (!me.state && me.gesture?.dragZoneId === data.dragZoneId) {
-                me.state = me.createState(me.registrations[data.dragElementRootId], me.gesture)
+            if (me.gesture?.dragZoneId === data.dragZoneId) {
+                const
+                    config  = me.registrations[data.dragElementRootId],
+                    current = me.state,
+                    changed = !current || current.axis !== config.axis || current.parentId !== config.parentId ||
+                        current.targetId !== config.targetId;
+
+                if (changed) {
+                    me.restoreState(current);
+                    me.state = me.createState(config, me.gesture);
+
+                    me.state && me.apply({
+                        clientX: me.gesture.latestClientX,
+                        clientY: me.gesture.latestClientY
+                    })
+                }
             }
         } else {
             if (me.state?.dragZoneId === data.dragZoneId) {
@@ -234,17 +328,26 @@ class Resize {
      * @param {String|null} dragZoneId
      */
     start(path, data, dragZoneId) {
-        this.cancel();
+        let me = this;
 
-        this.gesture = {
-            clientX: data.clientX,
-            clientY: data.clientY,
-            dragZoneId
+        if (me.pendingTerminal) {
+            me.restoreState(me.pendingTerminal);
+            me.pendingTerminal = null
+        }
+
+        me.cancel();
+
+        me.gesture = {
+            clientX      : data.clientX,
+            clientY      : data.clientY,
+            dragZoneId,
+            latestClientX: data.clientX,
+            latestClientY: data.clientY
         };
 
-        const config = this.resolve(path);
+        const config = me.resolve(path);
 
-        this.state = config?.dragZoneId === dragZoneId ? this.createState(config, this.gesture) : null
+        me.state = config?.dragZoneId === dragZoneId ? me.createState(config, me.gesture) : null
     }
 
     /**
@@ -256,6 +359,11 @@ class Resize {
 
         if (data?.dragZoneId && me.state?.dragZoneId === data.dragZoneId) {
             me.cancel()
+        }
+
+        if (data?.dragZoneId && me.pendingTerminal?.dragZoneId === data.dragZoneId) {
+            me.restoreState(me.pendingTerminal);
+            me.pendingTerminal = null
         }
 
         if (data?.dragElementRootId) {

--- a/test/playwright/component/dashboard/DockSplitterPaint.spec.mjs
+++ b/test/playwright/component/dashboard/DockSplitterPaint.spec.mjs
@@ -498,10 +498,11 @@ test.describe('Neo.dashboard.dock.interaction.DockSplitter — the rendered affo
  * reported against. A witness that assembles its own consumer cannot answer whether THAT page got
  * fixed — it can only show the parts work when someone wires them correctly.
  *
- * The example needs no interaction: its initial dock document commits two splits, so both splitter
- * orientations render on load. And it sets no `themes` in its config, so it boots under the LEGACY
- * `neo-theme-light` — which makes this the strongest available statement of the floor. A consumer
- * that opted into nothing, not even a neo theme, still gets a findable drag target.
+ * The example needs no interaction: its initial dock document commits two splits plus one resizable
+ * Inspector edge, so three splitters across both orientations render on load. And it sets no `themes`
+ * in its config, so it boots under the LEGACY `neo-theme-light` — which makes this the strongest
+ * available statement of the floor. A consumer that opted into nothing, not even a neo theme, still
+ * gets a findable drag target.
  */
 test.describe('examples/dashboard/dock — the consumer the defect was reported against', () => {
     test('gets a visible splitter with no app tokens at all', async ({page}) => {
@@ -538,8 +539,10 @@ test.describe('examples/dashboard/dock — the consumer the defect was reported 
             return result
         });
 
-        expect(measured.splitters.length, 'the example commits two splits, so both orientations render')
-            .toBe(2);
+        expect(measured.splitters.length, 'two split boundaries plus the Inspector edge render')
+            .toBe(3);
+        expect(new Set(measured.splitters.map(splitter => splitter.horizontal)), 'both orientations remain covered')
+            .toEqual(new Set([false, true]));
         expect(measured.theme, 'and it boots under the legacy theme it never opted out of')
             .toContain('neo-theme-light');
         expect(measured.appSetsTokens, 'precondition: no app override is in play').toBe(false);

--- a/test/playwright/e2e/dashboard/DemoATourNL.spec.mjs
+++ b/test/playwright/e2e/dashboard/DemoATourNL.spec.mjs
@@ -40,7 +40,7 @@ test.describe('Demo-A dock-choreography tour journey (Neural Link)', () => {
         // opening truth: the edge-zone stage, preview docked right by construction
         const opening = await readModel();
 
-        expect(opening.nodes.root.zones.center).toBe('editor-tabs');
+        expect(opening.nodes.root.zones.center.nodeId).toBe('editor-tabs');
         expect(opening.nodes['side-tabs'].items).toEqual(['preview']);
 
         // instrument FLIP observation BEFORE starting: sample marker transforms per frame
@@ -154,7 +154,7 @@ test.describe('Demo-A dock-choreography tour journey (Neural Link)', () => {
         const finale = await readModel();
 
         expect(finale.nodes['side-tabs'].items).toEqual(['preview', 'terminal', 'logs']);
-        expect(finale.nodes.root.zones.center).toBe('editor-tabs');
+        expect(finale.nodes.root.zones.center.nodeId).toBe('editor-tabs');
         expect(finale.items.preview.autoHidden).toBe(false);
         expect(finale.items.terminal.autoHidden).toBe(false);
         expect(finale.items.logs.autoHidden).toBe(false);

--- a/test/playwright/e2e/dashboard/DemoBCrossWindowDragNL.spec.mjs
+++ b/test/playwright/e2e/dashboard/DemoBCrossWindowDragNL.spec.mjs
@@ -395,7 +395,7 @@ test.describe('Dashboard Demo B — real cross-window dock drag', () => {
                       console  : {componentRef: 'Console',   title: 'Console',   kind: 'terminal'}
                   },
                   nodes: {
-                      root       : {type: 'edge-zone', zones: {right: 'side-tabs'}},
+                      root       : {type: 'edge-zone', zones: {right: {nodeId: 'side-tabs'}}},
                       'side-tabs': {
                           type: 'tabs', items: ['inspector', 'timeline', 'console'], activeItemId: 'inspector'
                       }
@@ -408,7 +408,7 @@ test.describe('Dashboard Demo B — real cross-window dock drag', () => {
                       workbench: {componentRef: 'Workbench', title: 'Workbench', kind: 'panel'}
                   },
                   nodes: {
-                      'popup-root': {type: 'edge-zone', zones: {center: 'popup-tabs'}},
+                      'popup-root': {type: 'edge-zone', zones: {center: {nodeId: 'popup-tabs'}}},
                       'popup-tabs': {type: 'tabs', items: ['workbench'], activeItemId: 'workbench'}
                   }
               };

--- a/test/playwright/e2e/dashboard/DockAutoHideRevealNL.spec.mjs
+++ b/test/playwright/e2e/dashboard/DockAutoHideRevealNL.spec.mjs
@@ -77,7 +77,7 @@ const createFourEdgeRailDocument = () => {
         });
 
         nodes[`${edge}-tabs`] = {type: 'tabs', items: itemIds, activeItemId: itemIds[0]};
-        nodes.root.zones[edge] = `${edge}-tabs`
+        nodes.root.zones[edge] = {nodeId: `${edge}-tabs`, extent: 0.2, resizable: true}
     }
 
     return {schema: 'neo.dock.zone.v1', root: 'root', items, nodes}

--- a/test/playwright/e2e/dashboard/DockAutoHideRevealNL.spec.mjs
+++ b/test/playwright/e2e/dashboard/DockAutoHideRevealNL.spec.mjs
@@ -96,6 +96,16 @@ test.describe('Dock auto-hide reveal/pin journey (Neural Link)', () => {
         expect(before?.items?.inspector?.autoHidden, 'the inspector must start visible').not.toBe(true);
         await expect(page.locator('.neo-dashboard-dock-edge-rail .neo-dashboard-dock-rail-tab')).toHaveCount(0);
 
+        const splitters = await app.findInstances(
+                  {className: 'Neo.dashboard.dock.interaction.DockSplitter'},
+                  ['id', 'edge']
+              ),
+              rightSplitterId = (Array.isArray(splitters) ? splitters : [splitters])
+                  .find(record => (record?.properties || record)?.edge === 'right')?.id;
+
+        expect(rightSplitterId, 'the example projects the Inspector boundary as a semantic edge splitter').toBeTruthy();
+        await expect(page.locator(`#${rightSplitterId}`), 'the Inspector boundary splitter is visibly rendered').toBeVisible();
+
         await tuckInspector({ app, holderId, page });
 
         // Product truth #1: the committed auto-hidden item projects as a REAL rail button.
@@ -126,6 +136,22 @@ test.describe('Dock auto-hide reveal/pin journey (Neural Link)', () => {
         const overlay = page.locator('.neo-dashboard-dock-reveal-overlay').first();
         await expect(overlay, 'the reveal overlay must open on rail-tab click').toBeVisible({ timeout: 10000 });
         await expect(overlay.locator('.neo-dashboard-dock-reveal-title'), 'the overlay must title the revealed item').toHaveText('Inspector');
+        const revealGeometry = await overlay.evaluate(element => {
+            const workspace     = element.closest('.neo-dashboard'),
+                  overlayRect   = element.getBoundingClientRect(),
+                  workspaceRect = workspace?.getBoundingClientRect();
+
+            return {
+                inlineWidth: element.style.width,
+                widthRatio : workspaceRect?.width ? overlayRect.width / workspaceRect.width : null
+            }
+        });
+
+        expect(revealGeometry.inlineWidth, 'the overlay receives the committed right-edge extent').toBe('25%');
+        expect(revealGeometry.widthRatio, 'rendered reveal width matches the committed edge fraction').toBeCloseTo(
+            hidden.nodes.root.zones.right.extent,
+            2
+        );
         await expect.poll(() => page.evaluate(() => window.__neoDockRevealAnimationStarts), {
             message: 'the token-scoped reveal animation must start on the first reveal'
         }).toBeGreaterThan(0);

--- a/test/playwright/e2e/dashboard/DockAutoHideRevealNL.spec.mjs
+++ b/test/playwright/e2e/dashboard/DockAutoHideRevealNL.spec.mjs
@@ -58,7 +58,7 @@ const createFourEdgeRailDocument = () => {
             center: {componentRef: 'Center', title: 'Center', kind: 'panel'}
         },
         nodes = {
-            root         : {type: 'edge-zone', zones: {center: 'center-tabs'}},
+            root         : {type: 'edge-zone', zones: {center: {nodeId: 'center-tabs'}}},
             'center-tabs': {type: 'tabs', items: ['center'], activeItemId: 'center'}
         };
 

--- a/test/playwright/e2e/workstation/WorkstationEdgeSplitterNL.spec.mjs
+++ b/test/playwright/e2e/workstation/WorkstationEdgeSplitterNL.spec.mjs
@@ -152,7 +152,7 @@ test.describe('Workstation edge splitters — runtime pixels commit once as docu
             expect(splitterId, `${edge}: the initial workspace projects one complete visible edge affordance`).toBeTruthy()
         }
 
-        const dragEdge = async ({edge, dx=0, dy=0, cancel=false}) => {
+        const dragEdge = async ({edge, dx=0, dy=0, cancel=false, reject=false}) => {
             await expect(workspaceRoot, `${edge}: prior projection motion has released`)
                 .not.toHaveClass(/neo-dashboard-dock-animating/, {timeout: 10000});
             await expect(page.locator('.neo-dock-flip-fixed-stage'), `${edge}: no fixed-stage residue remains`)
@@ -168,6 +168,13 @@ test.describe('Workstation edge splitters — runtime pixels commit once as docu
             expect(resizeConfig, `${edge}: the generic main-thread resize descriptor is registered`).toMatchObject({
                 preview: true
             });
+
+            const registeredResize = await page.evaluate(id => (
+                Neo.main.addon.DragDrop.dragResize.registrations[id] ?? null
+            ), splitterId);
+
+            expect(registeredResize, `${edge}: an eager main-thread registration exists before pointer start`)
+                .toMatchObject({axis: resizeConfig.axis, dragZoneId: expect.any(String), preview: true});
 
             expect(rect, `${edge}: the settled splitter has pointer geometry`).toBeTruthy();
 
@@ -200,6 +207,15 @@ test.describe('Workstation edge splitters — runtime pixels commit once as docu
             await page.mouse.move(startX + Math.sign(dx || 1) * 12, startY + Math.sign(dy || 1) * 12, {steps: 4});
             await page.mouse.move(startX + dx, startY + dy, {steps: 16});
 
+            await expect.poll(() => page.evaluate(() => Neo.main.addon.DragDrop.dragResize.active), {
+                message  : `${edge}: the real pointer gesture activates main-thread resize ownership`,
+                timeout  : 10000,
+                intervals: [25, 50]
+            }).toBe(true);
+
+            expect(await page.evaluate(() => Neo.main.addon.DragDrop.dragResize.state?.targetId ?? null),
+                `${edge}: the same-gesture refresh replaces any retired eager target`).toBe(resizeConfig.targetId);
+
             await expect.poll(async () => Math.abs((await readResizeRatio(resizeConfig)) - beforeRatio), {
                 message  : `${edge}: main-thread preview changes the real band before release`,
                 timeout  : 10000,
@@ -228,7 +244,30 @@ test.describe('Workstation edge splitters — runtime pixels commit once as docu
                 return before
             }
 
+            if (reject) {
+                const state = (await app.getComponent(splitterId, ['dragStartState'])).dragStartState;
+
+                expect(state, `${edge}: the semantic splitter still owns its geometry capture`).toBeTruthy();
+                await app.setProperties(splitterId, {dragStartState: {...state, parentSize: null}})
+            }
+
             await page.mouse.up();
+
+            if (reject) {
+                await expect.poll(() => readResizeRatio(resizeConfig), {
+                    message  : `${edge}: reducer rejection restores the exact pre-gesture rendered band`,
+                    timeout  : 10000,
+                    intervals: [25, 50]
+                }).toBeCloseTo(beforeRatio, 2);
+                expect(JSON.stringify(await readDocument()), `${edge}: reducer rejection commits zero document bytes`)
+                    .toBe(beforeRaw);
+                expect(
+                    (await app.getComponent(splitterId, ['dragStartState'])).dragStartState,
+                    `${edge}: reducer rejection retires the worker-side geometry snapshot`
+                ).toBeNull();
+
+                return before
+            }
 
             await expect.poll(async () => {
                 const document = await readDocument();
@@ -252,6 +291,13 @@ test.describe('Workstation edge splitters — runtime pixels commit once as docu
                 intervals: [50, 100]
             }).toBeLessThan(0.015);
 
+            const settledBand = await app.getComponent(settledConfig.targetId, ['height', 'width']);
+
+            expect(
+                settledBand[settledConfig.axis],
+                `${edge}: the retained component adopts committed percentage authority`
+            ).toBe(`${after.nodes.root.zones[edge].extent * 100}%`);
+
             return after
         };
 
@@ -268,6 +314,10 @@ test.describe('Workstation edge splitters — runtime pixels commit once as docu
         expect((await readActiveTabs()).activeIndex).toBe(1);
         await expect(page.locator('.workstation-pane-audit'), 'cancel leaves the same selected pane rendered').toBeVisible();
 
-        expect(pageErrors, 'the two-axis resize and cancellation surface no page errors').toEqual([])
+        await dragEdge({edge: 'left', dx: 70, reject: true});
+        expect((await readDocument()).nodes['right-top-tabs'].activeItemId).toBe('audit');
+        expect((await readActiveTabs()).activeIndex).toBe(1);
+
+        expect(pageErrors, 'the two-axis resize, cancellation, and rejection surface no page errors').toEqual([])
     })
 });

--- a/test/playwright/e2e/workstation/WorkstationEdgeSplitterNL.spec.mjs
+++ b/test/playwright/e2e/workstation/WorkstationEdgeSplitterNL.spec.mjs
@@ -1,0 +1,229 @@
+import {test, expect} from '../../fixtures.mjs';
+
+/**
+ * @summary Whitebox E2E for committed edge-zone resizing and active-tab persistence.
+ *
+ * Playwright owns the real pointer gesture and rendered-band geometry. Neural Link owns the
+ * committed-document and live TabContainer assertions. The pair proves the boundary that unit tests
+ * cannot: move frames resize only main-thread pixels, release commits one normalized edge extent,
+ * projection lands on the same final geometry, and Escape restores the prior presentation without a
+ * document write. A non-first tab remains selected through both axes and the cancelled gesture.
+ *
+ * Run: NEO_AGENTOS_RUNTIME_ROOT=/path/to/neo-agent-brain npx playwright test
+ * test/playwright/e2e/workstation/WorkstationEdgeSplitterNL.spec.mjs
+ * -c test/playwright/playwright.config.e2e.mjs --workers=1
+ */
+test.describe('Workstation edge splitters — runtime pixels commit once as document extent', () => {
+    test.setTimeout(120000);
+    test.use({viewport: {height: 900, width: 1440}});
+
+    const asArray = value => Array.isArray(value) ? value : value ? [value] : [];
+    const values  = record => record?.properties || record || {};
+
+    test('both axes preserve the active tab; Escape restores without committing', async ({page, neuralLink}) => {
+        const pageErrors = [];
+
+        page.on('pageerror', error => {
+            const value = String(error?.stack || error?.message || error || '');
+
+            value && value !== 'undefined' && pageErrors.push(value)
+        });
+
+        await page.goto('/apps/workstation/index.html');
+        await page.waitForSelector('.workstation-dock-host', {timeout: 30000});
+
+        const app           = await neuralLink.connectToApp('Workstation'),
+              workspaces    = asArray(await app.findInstances({className: 'Workstation.view.Workspace'}, ['id'])),
+              workspaceId   = workspaces[0]?.id,
+              workspaceRoot = page.locator('.workstation-workspace');
+
+        expect(workspaceId, 'the Workstation workspace exists in the App Worker').toBeTruthy();
+
+        const readDocument = async () => {
+            const result = await app.getDockTopology(workspaceId);
+
+            return result?.document ?? result
+        };
+
+        const readActiveTabs = async () => {
+            const result = await app.queryComponent({dockNodeId: 'right-top-tabs'}, ['id', 'activeIndex']);
+
+            return values(Array.isArray(result) ? result[0] : result)
+        };
+
+        const findEdgeSplitterId = async edge => {
+            const records = asArray(await app.findInstances(
+                {className: 'Neo.dashboard.dock.interaction.DockSplitter'},
+                ['id', 'edge', 'edgeZoneId', 'data.operation']
+            )),
+                candidates = records
+                    .filter(record => values(record).edge === edge)
+                    .map(record => record.id);
+
+            return page.evaluate(ids => ids.find(id => {
+                const element = document.getElementById(id),
+                      rect    = element?.getBoundingClientRect();
+
+                return Boolean(rect?.width && rect.height)
+            }) || null, candidates)
+        };
+
+        const readResizeRatio = config => page.evaluate(({axis, parentId, targetId}) => {
+            const parent = document.getElementById(parentId),
+                  target = document.getElementById(targetId);
+
+            if (!parent || !target) return null;
+
+            const parentRect = parent.getBoundingClientRect(),
+                  targetRect = target.getBoundingClientRect();
+
+            return axis === 'height' ? targetRect.height / parentRect.height : targetRect.width / parentRect.width
+        }, config);
+
+        const auditChrome   = await app.callMethod(workspaceId, 'getTabChromeIdentity', ['right-top-tabs']),
+              auditHeaderId = auditChrome?.buttons?.audit;
+
+        expect(auditHeaderId, 'the non-first Audit tab has a live header button').toBeTruthy();
+        await page.locator(`#${auditHeaderId}`).click({timeout: 10000});
+
+        await expect.poll(async () => (await readDocument()).nodes['right-top-tabs'].activeItemId, {
+            message  : 'the real tab click commits audit into document truth',
+            timeout  : 10000,
+            intervals: [50, 100]
+        }).toBe('audit');
+        await expect.poll(async () => (await readActiveTabs()).activeIndex, {
+            message  : 'the live TabContainer converges on the committed second item',
+            timeout  : 10000,
+            intervals: [50, 100]
+        }).toBe(1);
+        await expect(page.locator('.workstation-pane-audit'), 'the selected pane is rendered').toBeVisible();
+
+        for (const edge of ['left', 'right', 'bottom']) {
+            const splitterId = await findEdgeSplitterId(edge);
+
+            expect(splitterId, `${edge}: the initial workspace projects an edge splitter`).toBeTruthy();
+            await expect(page.locator(`#${splitterId}`), `${edge}: the initial edge splitter is visible`).toBeVisible()
+        }
+
+        const dragEdge = async ({edge, dx=0, dy=0, cancel=false}) => {
+            await expect(workspaceRoot, `${edge}: prior projection motion has released`)
+                .not.toHaveClass(/neo-dashboard-dock-animating/, {timeout: 10000});
+            await expect(page.locator('.neo-dock-flip-fixed-stage'), `${edge}: no fixed-stage residue remains`)
+                .toHaveCount(0, {timeout: 10000});
+
+            const splitterId = await findEdgeSplitterId(edge);
+
+            expect(splitterId, `${edge}: a semantic edge splitter is projected`).toBeTruthy();
+
+            const resizeConfig = await app.callMethod(splitterId, 'getResizeConfig', []);
+
+            expect(resizeConfig, `${edge}: the generic main-thread resize descriptor is registered`).toMatchObject({
+                preview: true
+            });
+
+            const splitterLocator = page.locator(`#${splitterId}`);
+
+            await expect(splitterLocator, `${edge}: the projected splitter is visible and pointer-reachable`).toBeVisible();
+
+            const rect        = await splitterLocator.boundingBox(),
+                  startX      = rect.x + rect.width / 2,
+                  startY      = rect.y + rect.height / 2,
+                  before      = await readDocument(),
+                  beforeRaw   = JSON.stringify(before),
+                  beforeRatio = await readResizeRatio(resizeConfig);
+
+            expect(beforeRatio, `${edge}: the target band has measurable geometry`).toBeGreaterThan(0);
+
+            const hitPath = await page.evaluate(({x, y}) => {
+                const ids = [];
+
+                for (let current = document.elementFromPoint(x, y); current; current = current.parentElement) {
+                    current.id && ids.push(current.id)
+                }
+
+                return ids
+            }, {x: startX, y: startY});
+
+            expect(hitPath, `${edge}: the physical hit path contains the semantic splitter`)
+                .toContain(splitterId);
+
+            await page.mouse.move(startX, startY);
+            await page.mouse.down();
+            // fixed-sleep-justification: the real mouse sensor has a deliberate press-duration
+            // threshold; this arms the gesture and is never used as a settlement wait.
+            await page.waitForTimeout(150);
+            await page.mouse.move(startX + Math.sign(dx || 1) * 12, startY + Math.sign(dy || 1) * 12, {steps: 4});
+            await page.mouse.move(startX + dx, startY + dy, {steps: 16});
+
+            await expect.poll(async () => Math.abs((await readResizeRatio(resizeConfig)) - beforeRatio), {
+                message  : `${edge}: main-thread preview changes the real band before release`,
+                timeout  : 10000,
+                intervals: [25, 50]
+            }).toBeGreaterThan(0.02);
+
+            expect(JSON.stringify(await readDocument()), `${edge}: move frames do not mutate document bytes`)
+                .toBe(beforeRaw);
+
+            if (cancel) {
+                await page.keyboard.press('Escape');
+                await page.mouse.up();
+
+                await expect.poll(() => readResizeRatio(resizeConfig), {
+                    message  : `${edge}: Escape restores the pre-gesture band`,
+                    timeout  : 10000,
+                    intervals: [25, 50]
+                }).toBeCloseTo(beforeRatio, 2);
+                expect(JSON.stringify(await readDocument()), `${edge}: Escape commits zero operations`)
+                    .toBe(beforeRaw);
+                expect(
+                    (await app.getComponent(splitterId, ['dragStartState'])).dragStartState,
+                    `${edge}: Escape retires the worker-side geometry snapshot without a later drag:end`
+                ).toBeNull();
+
+                return before
+            }
+
+            await page.mouse.up();
+
+            await expect.poll(async () => {
+                const document = await readDocument();
+
+                return Math.abs(document.nodes.root.zones[edge].extent - before.nodes.root.zones[edge].extent)
+            }, {
+                message  : `${edge}: release commits a changed normalized edge extent`,
+                timeout  : 10000,
+                intervals: [50, 100]
+            }).toBeGreaterThan(0.02);
+
+            const after = await readDocument();
+
+            const settledSplitterId = await findEdgeSplitterId(edge),
+                  settledConfig     = await app.callMethod(settledSplitterId, 'getResizeConfig', []);
+
+            await expect.poll(async () => Math.abs(
+                (await readResizeRatio(settledConfig)) - after.nodes.root.zones[edge].extent
+            ), {
+                message  : `${edge}: re-projection lands on the exact bounded terminal extent`,
+                timeout  : 10000,
+                intervals: [50, 100]
+            }).toBeLessThan(0.015);
+
+            return after
+        };
+
+        await dragEdge({edge: 'left', dx: 90});
+        expect((await readDocument()).nodes['right-top-tabs'].activeItemId).toBe('audit');
+        expect((await readActiveTabs()).activeIndex).toBe(1);
+
+        await dragEdge({edge: 'bottom', dy: -70});
+        expect((await readDocument()).nodes['right-top-tabs'].activeItemId).toBe('audit');
+        expect((await readActiveTabs()).activeIndex).toBe(1);
+
+        await dragEdge({edge: 'left', dx: 70, cancel: true});
+        expect((await readDocument()).nodes['right-top-tabs'].activeItemId).toBe('audit');
+        expect((await readActiveTabs()).activeIndex).toBe(1);
+        await expect(page.locator('.workstation-pane-audit'), 'cancel leaves the same selected pane rendered').toBeVisible();
+
+        expect(pageErrors, 'the two-axis resize and cancellation surface no page errors').toEqual([])
+    })
+});

--- a/test/playwright/e2e/workstation/WorkstationEdgeSplitterNL.spec.mjs
+++ b/test/playwright/e2e/workstation/WorkstationEdgeSplitterNL.spec.mjs
@@ -51,7 +51,7 @@ test.describe('Workstation edge splitters — runtime pixels commit once as docu
             return values(Array.isArray(result) ? result[0] : result)
         };
 
-        const findEdgeSplitterId = async edge => {
+        const findEdgeSplitter = async edge => {
             const records = asArray(await app.findInstances(
                 {className: 'Neo.dashboard.dock.interaction.DockSplitter'},
                 ['id', 'edge', 'edgeZoneId', 'data.operation']
@@ -60,12 +60,56 @@ test.describe('Workstation edge splitters — runtime pixels commit once as docu
                     .filter(record => values(record).edge === edge)
                     .map(record => record.id);
 
-            return page.evaluate(ids => ids.find(id => {
-                const element = document.getElementById(id),
-                      rect    = element?.getBoundingClientRect();
+            for (const id of candidates) {
+                let resizeConfig;
 
-                return Boolean(rect?.width && rect.height)
-            }) || null, candidates)
+                try {
+                    resizeConfig = await app.callMethod(id, 'getResizeConfig', [])
+                } catch {
+                    continue
+                }
+
+                const live = resizeConfig && (await Promise.all([
+                    id,
+                    resizeConfig.parentId,
+                    resizeConfig.targetId
+                ].map(nodeId => page.locator(`#${nodeId}`).isVisible()))).every(Boolean);
+
+                if (live) return {id, resizeConfig}
+            }
+
+            return null
+        };
+
+        const findStableEdgeSplitter = async edge => {
+            let resolved = null;
+
+            await expect.poll(async () => {
+                const before = await findEdgeSplitter(edge);
+
+                if (!before) {
+                    resolved = null;
+                    return null
+                }
+
+                // A committed tab activation schedules one projection tick after document truth
+                // advances. Two paint frames distinguish its outgoing splitter from the settled
+                // generation without sleeping or forcing a second projection.
+                await page.evaluate(() => new Promise(resolve => requestAnimationFrame(() => requestAnimationFrame(resolve))));
+
+                const after = await findEdgeSplitter(edge),
+                      rect  = after?.id === before.id ? await page.locator(`#${after.id}`).boundingBox() : null;
+
+                resolved = rect ? {...after, rect} : null;
+
+                return resolved?.id ?? null
+            }, {
+                message  : `${edge}: one projected splitter generation stays pointer-reachable`,
+                timeout  : 10000,
+                intervals: [25, 50]
+            }).not.toBeNull();
+
+            return resolved
         };
 
         const readResizeRatio = config => page.evaluate(({axis, parentId, targetId}) => {
@@ -97,12 +141,15 @@ test.describe('Workstation edge splitters — runtime pixels commit once as docu
             intervals: [50, 100]
         }).toBe(1);
         await expect(page.locator('.workstation-pane-audit'), 'the selected pane is rendered').toBeVisible();
+        await expect(workspaceRoot, 'the activation projection has settled before the edge inventory')
+            .not.toHaveClass(/neo-dashboard-dock-animating/, {timeout: 10000});
+        await expect(page.locator('.neo-dock-flip-fixed-stage'), 'the activation leaves no fixed-stage residue')
+            .toHaveCount(0, {timeout: 10000});
 
         for (const edge of ['left', 'right', 'bottom']) {
-            const splitterId = await findEdgeSplitterId(edge);
+            const splitterId = (await findStableEdgeSplitter(edge))?.id;
 
-            expect(splitterId, `${edge}: the initial workspace projects an edge splitter`).toBeTruthy();
-            await expect(page.locator(`#${splitterId}`), `${edge}: the initial edge splitter is visible`).toBeVisible()
+            expect(splitterId, `${edge}: the initial workspace projects one complete visible edge affordance`).toBeTruthy()
         }
 
         const dragEdge = async ({edge, dx=0, dy=0, cancel=false}) => {
@@ -111,22 +158,20 @@ test.describe('Workstation edge splitters — runtime pixels commit once as docu
             await expect(page.locator('.neo-dock-flip-fixed-stage'), `${edge}: no fixed-stage residue remains`)
                 .toHaveCount(0, {timeout: 10000});
 
-            const splitterId = await findEdgeSplitterId(edge);
+            const splitter     = await findStableEdgeSplitter(edge),
+                  splitterId   = splitter?.id,
+                  resizeConfig = splitter?.resizeConfig,
+                  rect         = splitter?.rect;
 
             expect(splitterId, `${edge}: a semantic edge splitter is projected`).toBeTruthy();
-
-            const resizeConfig = await app.callMethod(splitterId, 'getResizeConfig', []);
 
             expect(resizeConfig, `${edge}: the generic main-thread resize descriptor is registered`).toMatchObject({
                 preview: true
             });
 
-            const splitterLocator = page.locator(`#${splitterId}`);
+            expect(rect, `${edge}: the settled splitter has pointer geometry`).toBeTruthy();
 
-            await expect(splitterLocator, `${edge}: the projected splitter is visible and pointer-reachable`).toBeVisible();
-
-            const rect        = await splitterLocator.boundingBox(),
-                  startX      = rect.x + rect.width / 2,
+            const startX      = rect.x + rect.width / 2,
                   startY      = rect.y + rect.height / 2,
                   before      = await readDocument(),
                   beforeRaw   = JSON.stringify(before),
@@ -197,8 +242,7 @@ test.describe('Workstation edge splitters — runtime pixels commit once as docu
 
             const after = await readDocument();
 
-            const settledSplitterId = await findEdgeSplitterId(edge),
-                  settledConfig     = await app.callMethod(settledSplitterId, 'getResizeConfig', []);
+            const settledConfig = (await findEdgeSplitter(edge))?.resizeConfig;
 
             await expect.poll(async () => Math.abs(
                 (await readResizeRatio(settledConfig)) - after.nodes.root.zones[edge].extent
@@ -211,11 +255,11 @@ test.describe('Workstation edge splitters — runtime pixels commit once as docu
             return after
         };
 
-        await dragEdge({edge: 'left', dx: 90});
+        await dragEdge({edge: 'left', dx: -70});
         expect((await readDocument()).nodes['right-top-tabs'].activeItemId).toBe('audit');
         expect((await readActiveTabs()).activeIndex).toBe(1);
 
-        await dragEdge({edge: 'bottom', dy: -70});
+        await dragEdge({edge: 'bottom', dy: 70});
         expect((await readDocument()).nodes['right-top-tabs'].activeItemId).toBe('audit');
         expect((await readActiveTabs()).activeIndex).toBe(1);
 

--- a/test/playwright/e2e/workstation/WorkstationPerspectivesNL.spec.mjs
+++ b/test/playwright/e2e/workstation/WorkstationPerspectivesNL.spec.mjs
@@ -5,12 +5,13 @@ const {NeuralLink_DockService} = await loadNeuralLinkModules();
 /**
  * @summary Whitebox E2E witness for the Neural Link perspective path on the workstation Workspace.
  *
- * The workstation Workspace carries a `PerspectiveLibrary` (holder-resolved by the client
+ * The workstation Workspace carries a `Neo.dashboard.dock.persistence.PerspectiveLibrary`
+ * (holder-resolved by the client
  * DockService), so the agent-driven perspective trio activates on the film's primary surface:
  *
  *   capture_perspective (stored through the holder's library) → list_perspectives
  *   → execute_dock_operation (disruption) → restore_perspective
- *   (exact baseline neo.dock.zone.v1 document through the library's fail-closed load
+ *   (exact baseline `neo.dock.zone.v1` document through the library's fail-closed load
  *    plus the workspace's document-commit seam)
  *
  * All assertions read worker truth, never the DOM. The baseline is read live, so the spec
@@ -62,12 +63,27 @@ test.describe('Workstation — NL perspectives: capture → list → disrupt →
 
         expect(wsId, 'the workstation Workspace must exist in the App Worker').toBeTruthy();
 
+        const selected = await app.executeDockOperation(wsId, {
+            itemId    : 'audit',
+            operation : 'setActiveItem',
+            tabsNodeId: 'right-top-tabs'
+        });
+
+        expect(selected.errors).toEqual([]);
+        expect(selected.applied).toBe(true);
+
         const baseline = (await app.getDockTopology(wsId)).document;
 
+        const baselineLeftExtent = baseline.nodes.root?.zones?.left?.extent;
+
         expect(
-            baseline.nodes['bottom-tabs']?.items,
-            'precondition: the workspace boots with feed in the bottom tabs (the disruption source)'
-        ).toContain('feed');
+            baselineLeftExtent,
+            'precondition: the workspace boots with a committed left-edge extent'
+        ).toBe(0.2);
+        expect(
+            baseline.nodes['right-top-tabs'].activeItemId,
+            'precondition: capture starts from the non-first Audit tab'
+        ).toBe('audit');
 
         // 1. capture_perspective — must land in the holder's store, not degrade to agent-held
         const captured = await NeuralLink_DockService.capturePerspective({
@@ -98,19 +114,21 @@ test.describe('Workstation — NL perspectives: capture → list → disrupt →
             'list_perspectives must surface the just-captured layout'
         ).toBe(true);
 
-        // 3. Disruption through the semantic dockZone.v1 path
+        // 3. Disruption through the semantic dockZone.v1 path. Edge extent is document truth, so
+        // perspective fidelity must cover it explicitly instead of relying on an unrelated item move.
         const disrupted = await app.executeDockOperation(wsId, {
-            itemId      : 'feed',
-            operation   : 'moveItem',
-            targetNodeId: 'heavy-tabs'
+            edge      : 'left',
+            edgeZoneId: 'root',
+            extent    : 0.32,
+            operation : 'resizeEdgeZone'
         });
 
         expect(disrupted.errors).toEqual([]);
         expect(disrupted.applied).toBe(true);
         expect(
-            disrupted.document.nodes['bottom-tabs'].items,
-            'the disruption must be observable before restore (restore-fidelity is vacuous otherwise)'
-        ).not.toContain('feed');
+            disrupted.document.nodes.root.zones.left.extent,
+            'the edge-size disruption must be observable before restore (restore-fidelity is vacuous otherwise)'
+        ).toBe(0.32);
 
         // 4. restore_perspective — store load + the workspace commit seam returns the exact baseline
         const restored = await NeuralLink_DockService.restorePerspective({
@@ -125,6 +143,14 @@ test.describe('Workstation — NL perspectives: capture → list → disrupt →
             restored.document,
             'restore must return the exact pre-disruption dockZone.v1 document'
         ).toEqual(baseline);
+        expect(
+            restored.document.nodes.root.zones.left.extent,
+            'restore must recover the captured edge extent, not retain the disrupted live size'
+        ).toBe(baselineLeftExtent);
+        expect(
+            restored.document.nodes['right-top-tabs'].activeItemId,
+            'restore must retain the captured non-first tab selection'
+        ).toBe('audit');
 
         // 5. Fail-closed: an unknown name errors structurally and touches nothing
         const failed = await NeuralLink_DockService.restorePerspective({

--- a/test/playwright/unit/dashboard/DockCrossWindowParticipation.spec.mjs
+++ b/test/playwright/unit/dashboard/DockCrossWindowParticipation.spec.mjs
@@ -28,7 +28,7 @@ function sourceDoc() {
             terminal: {componentRef: 'terminal', title: 'Terminal', kind: 'terminal'}
         },
         nodes: {
-            root       : {type: 'edge-zone', zones: {center: 'main-tabs', right: 'side-tabs'}},
+            root       : {type: 'edge-zone', zones: {center: {nodeId: 'main-tabs'}, right: {nodeId: 'side-tabs'}}},
             'main-tabs': {type: 'tabs', items: ['strategy'], activeItemId: 'strategy'},
             'side-tabs': {type: 'tabs', items: ['terminal'], activeItemId: 'terminal'}
         }
@@ -42,7 +42,7 @@ function targetDoc() {
         root  : 'root',
         items : {alpha: {componentRef: 'alpha', title: 'Alpha', kind: 'panel'}},
         nodes : {
-            root       : {type: 'edge-zone', zones: {center: 'main-tabs'}},
+            root       : {type: 'edge-zone', zones: {center: {nodeId: 'main-tabs'}}},
             'main-tabs': {type: 'tabs', items: ['alpha'], activeItemId: 'alpha'}
         }
     }
@@ -240,7 +240,7 @@ test.describe('Neo.dashboard.dock.window.Participation (ADR 0029 §2.3 — works
         const transfers = [];
 
         target.nodes['target-tabs'] = target.nodes['main-tabs'];
-        target.nodes.root.zones.center = 'target-tabs';
+        target.nodes.root.zones.center.nodeId = 'target-tabs';
         delete target.nodes['main-tabs'];
 
         const create = commitTransfer => Neo.create(DockCrossWindowParticipation, {

--- a/test/playwright/unit/dashboard/DockFlip.spec.mjs
+++ b/test/playwright/unit/dashboard/DockFlip.spec.mjs
@@ -110,6 +110,7 @@ test.describe('Neo.main.addon.DockFlip', () => {
                 flipMarkerPrefix        : 'dock-flip-item-',
                 getDockProjectionOptions: () => ({}),
                 getPaneHeaderText       : DockWorkspace.prototype.getPaneHeaderText,
+                onDockActiveIndexChange() {},
                 onDockCrossZoneDrop() {},
                 onDockZoneDocumentChange() {},
                 resolvePane         : DockWorkspace.prototype.resolvePane,

--- a/test/playwright/unit/dashboard/DockLayoutAdapter.spec.mjs
+++ b/test/playwright/unit/dashboard/DockLayoutAdapter.spec.mjs
@@ -105,8 +105,8 @@ const createEdgeZoneModel = () => ({
         root: {
             type : 'edge-zone',
             zones: {
-                center: 'main-tabs',
-                right : 'side-split'
+                center: {nodeId: 'main-tabs'},
+                right : {nodeId: 'side-split', extent: 0.3, resizable: true}
             }
         },
         'main-tabs': {
@@ -150,7 +150,13 @@ const createTabsBandModel = () => ({
         operator: {componentRef: 'operator', title: 'Operator', kind: 'tool',      autoHidden: true}
     },
     nodes: {
-        root       : {type: 'edge-zone', zones: {center: 'main-tabs', right: 'tool-tabs'}},
+        root       : {
+            type : 'edge-zone',
+            zones: {
+                center: {nodeId: 'main-tabs'},
+                right : {nodeId: 'tool-tabs', extent: 0.25, resizable: true}
+            }
+        },
         'main-tabs': {type: 'tabs', items: ['strategy'], activeItemId: 'strategy'},
         'tool-tabs': {type: 'tabs', items: ['detail', 'operator'], activeItemId: 'detail'}
     }
@@ -437,8 +443,9 @@ test.describe('Neo.dashboard.dock.projection.LayoutAdapter', () => {
                 })
             }),
             row    = result.items[0],
-            center = row.items[0],
-            right  = row.items[1],
+            center = row.items.find(item => item.dockNodeId === 'main-tabs'),
+            right  = row.items.find(item => item.dockNodeId === 'side-split'),
+            edgeSplitter = row.items.find(item => item.data?.operation === 'resizeEdgeZone'),
             rightChildren = getProjectedChildren(right);
 
         expect(result.dockNodeType).toBe('edge-zone');
@@ -451,8 +458,64 @@ test.describe('Neo.dashboard.dock.projection.LayoutAdapter', () => {
         expect(center.items.map(item => item.header.text)).toEqual(['Strategy', 'Swarm']);
 
         expect(right.layout).toEqual({ntype: 'vbox', align: 'stretch'});
+        expect(right.width).toBe('30%');
         expect(rightChildren.map(item => item.flex)).toEqual([0.55, 0.45]);
         expect(rightChildren.map(item => item.items[0].data.dockItemId)).toEqual(['terminal', 'inspector']);
+
+        expect(edgeSplitter.module).toBe(DockSplitter);
+        expect(edgeSplitter.edge).toBe('right');
+        expect(edgeSplitter.edgeZoneId).toBe('root');
+        expect(edgeSplitter.data).toMatchObject({
+            dockNodeId : 'root',
+            edge       : 'right',
+            edgeZoneId : 'root',
+            operation  : 'resizeEdgeZone',
+            orientation: 'horizontal'
+        })
+    });
+
+    test('omits edge splitters when the descriptor does not opt into resizing', () => {
+        let model = createEdgeZoneModel();
+
+        model.nodes.root.zones.right.resizable = false;
+
+        let result = DockLayoutAdapter.project(model, {
+                resolveComponentRef: componentRef => ({ntype: 'dashboard-panel', reference: componentRef})
+            }),
+            row = result.items[0];
+
+        expect(row.items.some(item => item.data?.operation === 'resizeEdgeZone')).toBe(false)
+    });
+
+    test('projects left, right, and bottom splitters on their center-facing boundaries', () => {
+        let model = createEdgeZoneModel();
+
+        Object.assign(model.items, {
+            navigator: {componentRef: 'navigator', title: 'Navigator', kind: 'panel'},
+            feed     : {componentRef: 'feed',      title: 'Feed',      kind: 'panel'}
+        });
+        Object.assign(model.nodes, {
+            'left-tabs'  : {type: 'tabs', items: ['navigator'], activeItemId: 'navigator'},
+            'bottom-tabs': {type: 'tabs', items: ['feed'],      activeItemId: 'feed'}
+        });
+        Object.assign(model.nodes.root.zones, {
+            left  : {nodeId: 'left-tabs',   extent: 0.2,  resizable: true},
+            bottom: {nodeId: 'bottom-tabs', extent: 0.25, resizable: true}
+        });
+
+        let result = DockLayoutAdapter.project(model, {
+                resolveComponentRef: componentRef => ({ntype: 'dashboard-panel', reference: componentRef})
+            }),
+            row       = result.items.find(item => item.dockNodeType === 'edge-zone-row'),
+            splitters = [...row.items, ...result.items].filter(item => item.data?.operation === 'resizeEdgeZone');
+
+        expect(splitters.map(item => item.edge)).toEqual(['left', 'right', 'bottom']);
+        expect(row.items.indexOf(row.items.find(item => item.dockNodeId === 'left-tabs')))
+            .toBeLessThan(row.items.indexOf(row.items.find(item => item.edge === 'left')));
+        expect(row.items.indexOf(row.items.find(item => item.edge === 'right')))
+            .toBeLessThan(row.items.indexOf(row.items.find(item => item.dockNodeId === 'side-split')));
+        expect(result.items.indexOf(result.items.find(item => item.edge === 'bottom')))
+            .toBeLessThan(result.items.indexOf(result.items.find(item => item.dockNodeId === 'bottom-tabs')))
     });
 
     test('falls back to recoverable placeholders without mutating the source model', () => {
@@ -706,12 +769,13 @@ test.describe('Neo.dashboard.dock.projection.LayoutAdapter', () => {
         expect(rail.resolveComponentRef).toBe(resolveComponentRef)
     });
 
-    test('resolveRevealExtent returns the committed split share, else null', () => {
+    test('resolveRevealExtent returns the committed edge extent, never a nested split share', () => {
         let model = createEdgeZoneModel();
 
-        // terminal-tabs is side-split child 0: sizes [0.55, 0.45] → 0.55 share.
-        expect(DockLayoutAdapter.resolveRevealExtent(model, 'terminal')).toBeCloseTo(0.55);
-        expect(DockLayoutAdapter.resolveRevealExtent(model, 'inspector')).toBeCloseTo(0.45);
+        // Both items belong to the right edge. The nested split sizes are internal to that band;
+        // reveal uses the edge descriptor's committed extent for either item.
+        expect(DockLayoutAdapter.resolveRevealExtent(model, 'terminal')).toBeCloseTo(0.3);
+        expect(DockLayoutAdapter.resolveRevealExtent(model, 'inspector')).toBeCloseTo(0.3);
 
         // strategy's tabs node sits directly in an edge-zone slot — no ancestor split, no extent.
         expect(DockLayoutAdapter.resolveRevealExtent(model, 'strategy')).toBeNull();
@@ -726,7 +790,7 @@ test.describe('Neo.dashboard.dock.projection.LayoutAdapter', () => {
 
         model.items.navigator    = {componentRef: 'navigator', title: 'Navigator', kind: 'panel'};
         model.nodes['left-tabs'] = {type: 'tabs', items: ['navigator'], activeItemId: 'navigator'};
-        model.nodes.root.zones.left = 'left-tabs';
+        model.nodes.root.zones.left = {nodeId: 'left-tabs', extent: 0.2, resizable: true};
 
         model.items.navigator.autoHidden = true;
         model.items.terminal.autoHidden  = true;
@@ -970,7 +1034,8 @@ test.describe('Neo.dashboard.dock.projection.LayoutAdapter', () => {
                 onDockStackDragTerminal: data => terminals.push(data),
                 resolveComponentRef    : componentRef => ({ntype: 'dashboard-panel', reference: componentRef})
             });
-            const mainTabs = result.items[0].items[0];
+            const mainTabs = result.items[0].items.find(item => item.dockNodeId === 'main-tabs');
+            const side     = result.items[0].items.find(item => item.dockNodeId === 'side-split');
             const header   = mainTabs.items[1].header;
 
             expect(mainTabs.items[0].header.text).toBe('Strategy');
@@ -983,7 +1048,7 @@ test.describe('Neo.dashboard.dock.projection.LayoutAdapter', () => {
                 title        : 'Drag whole stack'
             });
             expect(mainTabs.headerToolbar.sortZoneConfig.dockGroupNodeId).toBe('main-tabs');
-            expect(result.items[0].items[1].items[0].headerToolbar.sortZoneConfig.dockGroupNodeId).toBeNull();
+            expect(side.items[0].headerToolbar.sortZoneConfig.dockGroupNodeId).toBeNull();
 
             mainTabs.listeners.dockStackDragTerminal({groupNodeId: 'main-tabs'});
             expect(terminals).toEqual([{groupNodeId: 'main-tabs'}]);

--- a/test/playwright/unit/dashboard/DockProjectionReconciler.spec.mjs
+++ b/test/playwright/unit/dashboard/DockProjectionReconciler.spec.mjs
@@ -48,6 +48,26 @@ const createSplitModel = () => ({
     }
 });
 
+const createEdgeModel = () => ({
+    schema: 'neo.dock.zone.v1',
+    root  : 'root-edge',
+    items : {
+        center: {componentRef: 'center', kind: 'panel', title: 'Center'},
+        left  : {componentRef: 'left',   kind: 'panel', title: 'Left'}
+    },
+    nodes: {
+        'center-tabs': {activeItemId: 'center', items: ['center'], type: 'tabs'},
+        'left-tabs'  : {activeItemId: 'left',   items: ['left'],   type: 'tabs'},
+        'root-edge'  : {
+            type : 'edge-zone',
+            zones: {
+                center: {nodeId: 'center-tabs'},
+                left  : {nodeId: 'left-tabs', extent: 0.2, resizable: true}
+            }
+        }
+    }
+});
+
 const createThreeChildSplitModel = () => {
     const model = createSplitModel();
 
@@ -411,6 +431,25 @@ test.describe('Neo.dashboard.dock.projection.Reconciler', () => {
             expect(placeholders.size).toBe(0)
         } finally {
             host.destroy()
+        }
+    });
+
+    test('updates a retained edge band to the newly committed percentage extent', async () => {
+        const receipt = await reconcileModel(createEdgeModel(), nextModel => {
+            nextModel.nodes['root-edge'].zones.left.extent = 0.26
+        }, {geometryOnly: true});
+
+        try {
+            const
+                currentTabs = DockProjectionReconciler.collectProjectedTabs(receipt.oldShell),
+                leftTab     = currentTabs.get('left-tabs');
+
+            expect(receipt.result.nextShell).toBe(receipt.oldShell);
+            expect(receipt.stagedCount).toBe(0);
+            expect(leftTab.width).toBe('26%');
+            expect(leftTab.getVdomRoot().width).toBe('26%')
+        } finally {
+            receipt.host.destroy()
         }
     });
 

--- a/test/playwright/unit/dashboard/DockRail.spec.mjs
+++ b/test/playwright/unit/dashboard/DockRail.spec.mjs
@@ -24,7 +24,10 @@ const createDocument = () => ({
     nodes: {
         root: {
             type : 'edge-zone',
-            zones: {center: 'main-tabs', right: 'side-tabs'}
+            zones: {
+                center: {nodeId: 'main-tabs'},
+                right : {nodeId: 'side-tabs', extent: 0.25, resizable: true}
+            }
         },
         'main-tabs': {type: 'tabs', items: ['editor'],   activeItemId: 'editor'},
         'side-tabs': {type: 'tabs', items: ['terminal'], activeItemId: 'terminal'}

--- a/test/playwright/unit/dashboard/DockSplitter.spec.mjs
+++ b/test/playwright/unit/dashboard/DockSplitter.spec.mjs
@@ -62,6 +62,73 @@ const createParent = () => ({
     }
 });
 
+const createEdgeDocument = () => ({
+    schema: 'neo.dock.zone.v1',
+    root  : 'root',
+    items : {
+        center: {componentRef: 'center', title: 'Center'},
+        left  : {componentRef: 'left', title: 'Left'}
+    },
+    nodes: {
+        root: {
+            type : 'edge-zone',
+            zones: {
+                center: {nodeId: 'center-tabs'},
+                left  : {nodeId: 'left-tabs', extent: 0.2, resizable: true}
+            }
+        },
+        'center-tabs': {type: 'tabs', items: ['center'], activeItemId: 'center'},
+        'left-tabs'  : {type: 'tabs', items: ['left'], activeItemId: 'left'}
+    }
+});
+
+const createEdgeParent = () => ({
+    disabled: false,
+    id      : 'edge-parent',
+    items   : [
+        {dockNodeType: 'tabs', id: 'left-component', vdom: {id: 'left-wrapper'}},
+        {dockNodeType: 'splitter', id: 'edge-splitter-placeholder'},
+        {dockNodeType: 'tabs', flex: 1, id: 'center-component', vdom: {id: 'center-wrapper'}}
+    ],
+    getDomRect(ids) {
+        return Promise.resolve(ids.map(id => {
+            if (id === 'edge-parent') return {height: 600, width: 1000, x: 0, y: 0};
+            if (id === 'left-component') return {height: 600, width: 200, x: 0, y: 0};
+            return {height: 600, width: 794, x: 206, y: 0}
+        }))
+    },
+    indexOf(item) {
+        return this.items.indexOf(item)
+    }
+});
+
+const createEdgeSplitter = config => {
+    const instance = Neo.create(DockSplitter, {
+        data: {
+            dockNodeId: 'root',
+            edge      : 'left',
+            edgeZoneId: 'root',
+            operation : 'resizeEdgeZone'
+        },
+        dockZoneDocument: createEdgeDocument(),
+        edge            : 'left',
+        edgeZoneId      : 'root',
+        liveResize      : true,
+        orientation     : 'horizontal',
+        parentComponent : createEdgeParent(),
+        resizeTarget    : 'previous',
+        ...config
+    });
+
+    instance.dragZone = {
+        destroy: () => {}, dragEnd: () => {}, isDestroyed: false, registerZone: async () => {}, set: () => {}
+    };
+    instance.dockNodeType    = 'splitter';
+    instance.parent.items[1] = instance;
+
+    return instance
+};
+
 test.describe('Neo.dashboard.dock.interaction.DockSplitter', () => {
     let splitter;
 
@@ -231,6 +298,116 @@ test.describe('Neo.dashboard.dock.interaction.DockSplitter', () => {
         expect(notified).toBe(false);                                            // notify is gated on success — NOT fired
         expect(splitter.dockZoneDocument.nodes.root.sizes).toEqual([0.7, 0.3]);  // the local doc is left untouched
         expect(rejected).toHaveLength(1)                                         // the rejection event fired instead
+    });
+
+    test('edge terminal normalizes the bounded pixel preview into one resizeEdgeZone commit', async () => {
+        let document   = createEdgeDocument(),
+            operations = [];
+
+        splitter = createEdgeSplitter({
+            applyDockZoneOperation(descriptor) {
+                operations.push(descriptor);
+                return Neo.dashboard.dock.model.Operations.applyOperation(document, descriptor)
+            },
+            dockZoneDocument: document,
+            id              : 'dock-edge-splitter-commit'
+        });
+
+        await splitter.captureDragStart({clientX: 200, clientY: 0});
+
+        const result = splitter.onDragEnd({
+            clientX       : 240,
+            clientY       : 0,
+            resizeAxis    : 'width',
+            resizeSize    : 240,
+            resizeTargetId: 'left-wrapper'
+        });
+
+        expect(operations).toEqual([{
+            operation : 'resizeEdgeZone',
+            edgeZoneId: 'root',
+            edge      : 'left',
+            extent    : 0.24
+        }]);
+        expect(result.errors).toEqual([]);
+        expect(result.document.nodes.root.zones.left.extent).toBe(0.24);
+        expect(splitter.getResizeConfig()).toEqual({
+            axis        : 'width',
+            parentId    : 'edge-parent',
+            preview     : true,
+            resizeNext  : false,
+            splitterSize: 6,
+            targetId    : 'left-wrapper'
+        })
+    });
+
+    test('a cancelled edge terminal restores presentation and commits zero operations', async () => {
+        const operations = [];
+
+        splitter = createEdgeSplitter({
+            applyDockZoneOperation(descriptor) {
+                operations.push(descriptor);
+                return {document: createEdgeDocument(), errors: []}
+            },
+            id: 'dock-edge-splitter-cancel'
+        });
+
+        await splitter.captureDragStart({clientX: 200, clientY: 0});
+        splitter.onDragEnd({cancelled: true, clientX: 240, clientY: 0, resizeSize: 240});
+
+        expect(operations).toEqual([]);
+        expect(splitter.dragStartState).toBeNull()
+    });
+
+    test('Escape cancel retires the dock geometry snapshot without waiting for drag:end', async () => {
+        const operations = [];
+
+        splitter = createEdgeSplitter({
+            applyDockZoneOperation(descriptor) {
+                operations.push(descriptor);
+                return {document: createEdgeDocument(), errors: []}
+            },
+            id: 'dock-edge-splitter-escape'
+        });
+
+        await splitter.captureDragStart({clientX: 200, clientY: 0});
+        expect(splitter.dragStartState).not.toBeNull();
+
+        splitter.onDragCancel({key: 'Escape'});
+
+        expect(operations).toEqual([]);
+        expect(splitter.dragStartState).toBeNull()
+    });
+
+    test('a rejected edge terminal re-projects the unchanged committed document', async () => {
+        const document = createEdgeDocument(),
+              restores = [];
+
+        splitter = createEdgeSplitter({
+            applyDockZoneOperation() {
+                return {document, errors: ['rejected edge extent']}
+            },
+            dockZoneDocument: document,
+            id              : 'dock-edge-splitter-reject',
+            onDockZoneDocumentChange(current, descriptor, instance) {
+                restores.push({current, descriptor, instance})
+            }
+        });
+
+        await splitter.captureDragStart({clientX: 200, clientY: 0});
+        const result = splitter.onDragEnd({clientX: 240, clientY: 0, resizeSize: 240});
+
+        expect(result.errors).toEqual(['rejected edge extent']);
+        expect(restores).toHaveLength(1);
+        expect(restores[0].current).toEqual(document);
+        expect(restores[0].descriptor).toEqual({
+            operation : 'resizeEdgeZone',
+            edgeZoneId: 'root',
+            edge      : 'left',
+            extent    : 0.24
+        });
+        expect(restores[0].instance).toBe(splitter);
+        expect(document.nodes.root.zones.left.extent).toBe(0.2)
     });
 });
 

--- a/test/playwright/unit/dashboard/DockSplitter.spec.mjs
+++ b/test/playwright/unit/dashboard/DockSplitter.spec.mjs
@@ -121,7 +121,8 @@ const createEdgeSplitter = config => {
     });
 
     instance.dragZone = {
-        destroy: () => {}, dragEnd: () => {}, isDestroyed: false, registerZone: async () => {}, set: () => {}
+        destroy     : () => {}, dragEnd: () => {}, isDestroyed: false, registerZone: async () => {}, set: () => {},
+        settleResize: () => {}
     };
     instance.dockNodeType    = 'splitter';
     instance.parent.items[1] = instance;
@@ -316,11 +317,12 @@ test.describe('Neo.dashboard.dock.interaction.DockSplitter', () => {
         await splitter.captureDragStart({clientX: 200, clientY: 0});
 
         const result = splitter.onDragEnd({
-            clientX       : 240,
-            clientY       : 0,
-            resizeAxis    : 'width',
-            resizeSize    : 240,
-            resizeTargetId: 'left-wrapper'
+            clientX         : 240,
+            clientY         : 0,
+            resizeAxis      : 'width',
+            resizeGeneration: 7,
+            resizeSize      : 240,
+            resizeTargetId  : 'left-wrapper'
         });
 
         expect(operations).toEqual([{
@@ -332,13 +334,40 @@ test.describe('Neo.dashboard.dock.interaction.DockSplitter', () => {
         expect(result.errors).toEqual([]);
         expect(result.document.nodes.root.zones.left.extent).toBe(0.24);
         expect(splitter.getResizeConfig()).toEqual({
-            axis        : 'width',
-            parentId    : 'edge-parent',
-            preview     : true,
-            resizeNext  : false,
-            splitterSize: 6,
-            targetId    : 'left-wrapper'
+            axis                 : 'width',
+            awaitWorkerSettlement: true,
+            parentId             : 'edge-parent',
+            preview              : true,
+            resizeNext           : false,
+            splitterSize         : 6,
+            targetId             : 'left-wrapper'
         })
+    });
+
+    test('instance edge identity cannot be hijacked by colliding StateProvider data', () => {
+        splitter = createEdgeSplitter({id: 'dock-edge-splitter-provider-collision'});
+
+        splitter.getStateProvider = () => ({
+            getHierarchyData: () => ({
+                dockNodeId: 'provider-root',
+                edge      : 'right',
+                edgeZoneId: 'provider-root',
+                operation : 'resizeEdgeZone'
+            })
+        });
+
+        expect(DockLayoutAdapter.createResizeEdgeZoneOperation(splitter, 0.25)).toEqual({
+            operation : 'resizeEdgeZone',
+            edgeZoneId: 'root',
+            edge      : 'left',
+            extent    : 0.25
+        });
+
+        splitter.edge       = null;
+        splitter.edgeZoneId = null;
+
+        expect(splitter.isEdgeZoneResize(), 'provider data cannot reclassify a split affordance as an edge affordance')
+            .toBe(false)
     });
 
     test('a cancelled edge terminal restores presentation and commits zero operations', async () => {
@@ -379,9 +408,10 @@ test.describe('Neo.dashboard.dock.interaction.DockSplitter', () => {
         expect(splitter.dragStartState).toBeNull()
     });
 
-    test('a rejected edge terminal re-projects the unchanged committed document', async () => {
-        const document = createEdgeDocument(),
-              restores = [];
+    test('a rejected edge terminal restores the exact pending main-thread preview', async () => {
+        const document    = createEdgeDocument(),
+              notifies    = [],
+              settlements = [];
 
         splitter = createEdgeSplitter({
             applyDockZoneOperation() {
@@ -390,23 +420,28 @@ test.describe('Neo.dashboard.dock.interaction.DockSplitter', () => {
             dockZoneDocument: document,
             id              : 'dock-edge-splitter-reject',
             onDockZoneDocumentChange(current, descriptor, instance) {
-                restores.push({current, descriptor, instance})
+                notifies.push({current, descriptor, instance})
             }
         });
 
+        splitter.dragZone.settleResize = data => settlements.push(data);
+
         await splitter.captureDragStart({clientX: 200, clientY: 0});
-        const result = splitter.onDragEnd({clientX: 240, clientY: 0, resizeSize: 240});
+        const result = splitter.onDragEnd({
+            clientX         : 240,
+            clientY         : 0,
+            resizeGeneration: 9,
+            resizeSize      : 240,
+            resizeTargetId  : 'left-wrapper'
+        });
 
         expect(result.errors).toEqual(['rejected edge extent']);
-        expect(restores).toHaveLength(1);
-        expect(restores[0].current).toEqual(document);
-        expect(restores[0].descriptor).toEqual({
-            operation : 'resizeEdgeZone',
-            edgeZoneId: 'root',
-            edge      : 'left',
-            extent    : 0.24
-        });
-        expect(restores[0].instance).toBe(splitter);
+        expect(notifies, 'unchanged projection is not a presentation rollback mechanism').toEqual([]);
+        expect(settlements).toEqual([{
+            resizeGeneration: 9,
+            resizeTargetId  : 'left-wrapper',
+            restore         : true
+        }]);
         expect(document.nodes.root.zones.left.extent).toBe(0.2)
     });
 });

--- a/test/playwright/unit/dashboard/DockSplitterEquivalence.spec.mjs
+++ b/test/playwright/unit/dashboard/DockSplitterEquivalence.spec.mjs
@@ -331,12 +331,16 @@ test.describe('Neo.dashboard.dock.interaction.DockSplitter — behavior equivale
 
         const ownMembers = Object.getOwnPropertyNames(Object.getPrototypeOf(splitter));
 
-        for (const inherited of ['createDragZone', 'refreshDragZone', 'onDragCancel', 'applyResize', 'construct', 'destroy']) {
+        for (const inherited of ['createDragZone', 'refreshDragZone', 'applyResize', 'construct', 'destroy']) {
             expect(ownMembers, `${inherited} stays inherited from the generic Splitter`).not.toContain(inherited)
         }
 
-        // the dock terminal is the one deliberate override, and the generation fence exists
+        // the deliberate dock overrides compose on top of the generic machinery: the semantic
+        // terminal, the state-clearing cancel (semantics leaf), and the fenced start — and the
+        // generation fence exists
         expect(ownMembers).toContain('onDragEnd');
+        expect(ownMembers).toContain('onDragCancel');
+        expect(ownMembers).toContain('onDragStart');
         expect(Number.isInteger(splitter.dragGeneration)).toBe(true)
     });
 });

--- a/test/playwright/unit/dashboard/DockTabEnterButton.spec.mjs
+++ b/test/playwright/unit/dashboard/DockTabEnterButton.spec.mjs
@@ -179,6 +179,7 @@ test.describe('Neo.dashboard.dock.interaction.TabEnterButton', () => {
                 getRefreshOptions               : () => ({}),
                 getTabInsertProjectionDescriptor: DockWorkspace.prototype.getTabInsertProjectionDescriptor,
                 isDestroyed                     : false,
+                onDockActiveIndexChange() {},
                 onDockCrossZoneDrop() {},
                 onDockZoneDocumentChange: DockWorkspace.prototype.onDockZoneDocumentChange,
                 refreshDockWorkspace    : transient => refreshes.push(transient),

--- a/test/playwright/unit/dashboard/DockTopologyDiff.spec.mjs
+++ b/test/playwright/unit/dashboard/DockTopologyDiff.spec.mjs
@@ -27,7 +27,7 @@ function doc() {
             inspector: {componentRef: 'inspector', title: 'Inspector', kind: 'inspector'}
         },
         nodes: {
-            root        : {type: 'edge-zone', zones: {center: 'main-split'}},
+            root        : {type: 'edge-zone', zones: {center: {nodeId: 'main-split'}}},
             'main-split': {type: 'split', orientation: 'horizontal', children: ['main-tabs', 'side-tabs'], sizes: [0.5, 0.5]},
             'main-tabs' : {type: 'tabs', items: ['strategy', 'swarm'], activeItemId: 'swarm'},
             'side-tabs' : {type: 'tabs', items: ['terminal'], activeItemId: 'terminal'}

--- a/test/playwright/unit/dashboard/DockWorkspace.spec.mjs
+++ b/test/playwright/unit/dashboard/DockWorkspace.spec.mjs
@@ -26,7 +26,7 @@ const createDocument = () => ({
         terminal: {componentRef: 'Terminal', title: 'Terminal', kind: 'terminal'}
     },
     nodes: {
-        root         : {type: 'edge-zone', zones: {center: 'root-split'}},
+        root         : {type: 'edge-zone', zones: {center: {nodeId: 'root-split'}}},
         'root-split' : {type: 'split', orientation: 'horizontal', children: ['editor-tabs', 'side-tabs'], sizes: [0.6, 0.4]},
         'editor-tabs': {type: 'tabs', items: ['editor'],              activeItemId: 'editor'},
         'side-tabs'  : {type: 'tabs', items: ['preview', 'terminal'], activeItemId: 'preview'}
@@ -636,22 +636,26 @@ test.describe('Neo.dashboard.dock.Workspace', () => {
 
         await side.set({activeIndex: 1});
         expect(closeAction.hidden, 'explicit false is projected into live availability').toBe(true);
+        await workspace.refreshPromise;
+
+        expect(workspace.getDockZoneDocument().nodes['side-tabs'].activeItemId).toBe('terminal');
 
         const refused = workspace.onDockHeaderAction({action: 'close', dockNodeId: 'side-tabs', tabContainer: side});
 
         expect(refused.errors).toEqual(['item "terminal" is not closable']);
-        expect(workspace.getDockZoneDocument()).toBe(document);
-        expect(workspace.refreshPromise).toBeNull();
+        expect(workspace.getDockZoneDocument().nodes['side-tabs'].activeItemId).toBe('terminal');
         expect(side.activeIndex).toBe(1);
         expect(side.getActionItem('close')).toBe(closeAction);
         expect(focusTargets).toEqual([]);
+
+        const activationRefresh = workspace.refreshPromise;
 
         workspace.dockModel = null;
 
         const noDocument = workspace.onDockHeaderAction({action: 'close', dockNodeId: 'side-tabs', tabContainer: side});
 
         expect(noDocument.errors).toEqual(['Dock close action requires a committed document']);
-        expect(workspace.refreshPromise).toBeNull();
+        expect(workspace.refreshPromise).toBe(activationRefresh);
         expect(focusTargets).toEqual([]);
 
         workspace.dockModel = document;
@@ -664,12 +668,59 @@ test.describe('Neo.dashboard.dock.Workspace', () => {
 
         const retainedSide = tabsOf(workspace.items[0]).get('side-tabs');
 
-        expect(commits.map(item => item.itemId)).toEqual(['terminal', 'preview']);
+        expect(commits.map(item => [item.operation, item.itemId])).toEqual([
+            ['setActiveItem', 'terminal'],
+            ['closeItem',     'terminal'],
+            ['closeItem',     'preview']
+        ]);
         expect(workspace.getDockZoneDocument().nodes['side-tabs'].items).toEqual(['terminal']);
         expect(retainedSide).toBe(side);
         expect(retainedSide.getActionItem('close')).toBe(closeAction);
         expect(closeAction.hidden).toBe(true);
         expect(focusTargets).toEqual(['terminal'])
+    });
+
+    test('tab activation commits with close actions disabled and survives unrelated re-projection', async () => {
+        const document = createDocument();
+
+        workspace = Neo.create(PlainWorkspace, {dockModel: document});
+
+        const tabs  = tabsOf(workspace.items[0]),
+            side    = tabs.get('side-tabs'),
+            commits = [],
+            apply   = workspace.applyDockZoneOperation.bind(workspace);
+
+        workspace.applyDockZoneOperation = descriptor => {
+            commits.push(descriptor);
+            return apply(descriptor)
+        };
+
+        expect(side.getActionItem?.('close')).toBeFalsy();
+
+        await side.set({activeIndex: 1});
+        await workspace.refreshPromise;
+
+        expect(commits).toEqual([{
+            operation : 'setActiveItem',
+            tabsNodeId: 'side-tabs',
+            itemId    : 'terminal'
+        }]);
+        expect(workspace.dockModel.nodes['side-tabs'].activeItemId).toBe('terminal');
+        expect(tabsOf(workspace.items[0]).get('side-tabs')).toBe(side);
+        expect(side.activeIndex).toBe(1);
+
+        const resized = workspace.applyDockZoneOperation({
+            operation  : 'resizeSplit',
+            splitNodeId: 'root-split',
+            sizes      : [0.7, 0.3]
+        });
+
+        workspace.onDockZoneDocumentChange(resized.document, {operation: 'resizeSplit'}, workspace);
+        await workspace.refreshPromise;
+
+        expect(workspace.dockModel.nodes['side-tabs'].activeItemId).toBe('terminal');
+        expect(side.activeIndex).toBe(1);
+        expect(commits).toHaveLength(2)
     });
 
     test('a model-ahead close targets live chrome but focuses the model-selected successor', async () => {

--- a/test/playwright/unit/dashboard/DockZoneModel.spec.mjs
+++ b/test/playwright/unit/dashboard/DockZoneModel.spec.mjs
@@ -41,7 +41,7 @@ function doc() {
             inspector: {componentRef: 'inspector', title: 'Inspector', kind: 'inspector'}
         },
         nodes: {
-            root       : {type: 'edge-zone', zones: {center: 'main-tabs', right: 'side-tabs'}},
+            root       : {type: 'edge-zone', zones: {center: {nodeId: 'main-tabs'}, right: {nodeId: 'side-tabs'}}},
             'main-tabs': {type: 'tabs', items: ['strategy', 'swarm'], activeItemId: 'swarm'},
             'side-tabs': {type: 'tabs', items: ['terminal'], activeItemId: 'terminal'}
         }
@@ -63,8 +63,25 @@ function splitDoc(sizes=[0.5, 0.5]) {
         children   : ['main-tabs', 'side-tabs'],
         sizes
     };
-    d.nodes.root.zones.center = 'main-split';
+    d.nodes.root.zones.center.nodeId = 'main-split';
     delete d.nodes.root.zones.right;
+
+    return d
+}
+
+/**
+ * The final greenfield edge-zone shape: every zone owns its node id together with optional
+ * committed extent and resize policy. Kept separate from {@link #doc} until the hard-cut tests
+ * prove the nested contract, so the red phase isolates the missing behavior.
+ * @returns {Object}
+ */
+function nestedEdgeDoc() {
+    const d = doc();
+
+    d.nodes.root.zones = {
+        center: {nodeId: 'main-tabs'},
+        right : {nodeId: 'side-tabs', extent: 0.25, resizable: true}
+    };
 
     return d
 }
@@ -106,7 +123,7 @@ test.describe('Neo.dashboard.dock.model.Document', () => {
 
         test('rejects a dangling node reference', () => {
             const d = doc();
-            d.nodes.root.zones.center = 'does-not-exist';
+            d.nodes.root.zones.center.nodeId = 'does-not-exist';
             expect(Document.validate(d).length).toBeGreaterThan(0)
         });
 
@@ -120,7 +137,7 @@ test.describe('Neo.dashboard.dock.model.Document', () => {
         test('rejects split sizes that mismatch or do not sum to 1', () => {
             const d = doc();
             d.nodes.split = {type: 'split', orientation: 'horizontal', children: ['main-tabs', 'side-tabs'], sizes: [0.5]};
-            d.nodes.root.zones.center = 'split';
+            d.nodes.root.zones.center.nodeId = 'split';
             delete d.nodes.root.zones.right;
             expect(Document.validate(d).length).toBeGreaterThan(0);
 
@@ -132,6 +149,30 @@ test.describe('Neo.dashboard.dock.model.Document', () => {
             const d = doc();
             d.nodes['main-tabs'].activeItemId = 'terminal';
             expect(Document.validate(d).length).toBeGreaterThan(0)
+        });
+
+        test('accepts nested edge descriptors and rejects the retired string form', () => {
+            expect(Document.validate(nestedEdgeDoc())).toEqual([]);
+
+            const legacy = doc();
+
+            legacy.nodes.root.zones = {center: 'main-tabs', right: 'side-tabs'};
+
+            expect(Document.validate(legacy).join('\n')).toContain('descriptor')
+        });
+
+        test('rejects malformed nested edge descriptor state', () => {
+            const missingNodeId = nestedEdgeDoc(),
+                invalidExtent   = nestedEdgeDoc(),
+                invalidPolicy   = nestedEdgeDoc();
+
+            delete missingNodeId.nodes.root.zones.right.nodeId;
+            invalidExtent.nodes.root.zones.right.extent    = 1;
+            invalidPolicy.nodes.root.zones.right.resizable = 'yes';
+
+            expect(Document.validate(missingNodeId).join('\n')).toContain('nodeId');
+            expect(Document.validate(invalidExtent).join('\n')).toContain('extent');
+            expect(Document.validate(invalidPolicy).join('\n')).toContain('resizable')
         })
     });
 
@@ -258,7 +299,7 @@ test.describe('Neo.dashboard.dock.model.Document', () => {
         test('cyclic node graphs fail closed through the public return shapes, never a throw', () => {
             const cyclic = doc();
             cyclic.nodes['loop-split'] = {type: 'split', orientation: 'horizontal', children: ['main-tabs', 'loop-split'], sizes: [0.5, 0.5]};
-            cyclic.nodes.root.zones.center = 'loop-split';
+            cyclic.nodes.root.zones.center.nodeId = 'loop-split';
 
             const direct = Document.computeShapeFingerprint(cyclic);
             expect(direct.fingerprint).toBe(null);
@@ -464,7 +505,7 @@ test.describe('Neo.dashboard.dock.model.Document', () => {
                 title   : 'Operator Default'
             });
 
-            layout.dockZone.nodes.root.zones.center = 'missing-tabs';
+            layout.dockZone.nodes.root.zones.center.nodeId = 'missing-tabs';
 
             const {document, errors} = Persistence.restoreSavedLayout(layout);
 
@@ -692,7 +733,7 @@ test.describe('Neo.dashboard.dock.model.Document', () => {
                 children   : ['main-tabs', 'side-tabs'],
                 sizes      : [0.2, 0.8]
             };
-            input.nodes.root.zones.center = 'split';
+            input.nodes.root.zones.center.nodeId = 'split';
             delete input.nodes.root.zones.right;
 
             const snapshot         = JSON.stringify(input),
@@ -789,7 +830,7 @@ test.describe('Neo.dashboard.dock.model.Document', () => {
 
             const invalid = Document.clone(review);
 
-            invalid.dockZone.nodes.root.zones.center = 'missing-tabs';
+            invalid.dockZone.nodes.root.zones.center.nodeId = 'missing-tabs';
 
             const rejected = PerspectiveLibrary.upsertSavedLayout(collection, invalid, {activate: true});
 
@@ -1155,6 +1196,79 @@ test.describe('Neo.dashboard.dock.model.Document', () => {
         })
     });
 
+    test.describe('setActiveItem', () => {
+        test('commits a member item through the exported operation vocabulary', () => {
+            const input            = nestedEdgeDoc(),
+                {document, errors} = Operations.applyOperation(input, {
+                    operation : 'setActiveItem',
+                    tabsNodeId: 'main-tabs',
+                    itemId    : 'strategy'
+                });
+
+            expect(errors).toEqual([]);
+            expect(document.nodes['main-tabs'].activeItemId).toBe('strategy');
+            expect(input.nodes['main-tabs'].activeItemId).toBe('swarm')
+        });
+
+        test('fails closed for an unknown tabs node or non-member item', () => {
+            const input     = nestedEdgeDoc(),
+                missingNode = Operations.applyOperation(input, {
+                    operation : 'setActiveItem',
+                    tabsNodeId: 'ghost',
+                    itemId    : 'strategy'
+                }),
+                nonMember = Operations.applyOperation(input, {
+                    operation : 'setActiveItem',
+                    tabsNodeId: 'main-tabs',
+                    itemId    : 'terminal'
+                });
+
+            expect(missingNode.errors.length).toBeGreaterThan(0);
+            expect(nonMember.errors.length).toBeGreaterThan(0);
+            expect(missingNode.document).toBe(input);
+            expect(nonMember.document).toBe(input)
+        })
+    });
+
+    test.describe('resizeEdgeZone', () => {
+        test('commits one normalized extent on a resizable edge descriptor', () => {
+            const input            = nestedEdgeDoc(),
+                {document, errors} = Operations.applyOperation(input, {
+                    operation : 'resizeEdgeZone',
+                    edgeZoneId: 'root',
+                    edge      : 'right',
+                    extent    : 0.4
+                });
+
+            expect(errors).toEqual([]);
+            expect(document.nodes.root.zones.right.extent).toBe(0.4);
+            expect(input.nodes.root.zones.right.extent).toBe(0.25)
+        });
+
+        test('fails closed for center, non-resizable, unknown, and invalid extents', () => {
+            const input = nestedEdgeDoc(),
+                cases   = [
+                    {edgeZoneId: 'root', edge: 'center', extent: 0.4},
+                    {edgeZoneId: 'root', edge: 'right', extent: 0},
+                    {edgeZoneId: 'root', edge: 'right', extent: 1},
+                    {edgeZoneId: 'ghost', edge: 'right', extent: 0.4}
+                ];
+
+            input.nodes.root.zones.right.resizable = false;
+            cases.push({edgeZoneId: 'root', edge: 'right', extent: 0.4});
+
+            for (const descriptor of cases) {
+                const {document, errors} = Operations.applyOperation(input, {
+                    operation: 'resizeEdgeZone',
+                    ...descriptor
+                });
+
+                expect(errors.length).toBeGreaterThan(0);
+                expect(document).toBe(input)
+            }
+        })
+    });
+
     test.describe('moveItem', () => {
         test('relocates an in-tree item to another tabs node', () => {
             const {document, errors} = Operations.moveItem(doc(), {itemId: 'strategy', targetNodeId: 'side-tabs', index: 0});
@@ -1176,7 +1290,7 @@ test.describe('Neo.dashboard.dock.model.Document', () => {
             });
             expect(errors).toEqual([]);
             // root.zones.center now points at a split holding [main-tabs, <new tabs with inspector>]
-            const splitId = document.nodes.root.zones.center,
+            const splitId = document.nodes.root.zones.center.nodeId,
                   split   = document.nodes[splitId];
             expect(split.type).toBe('split');
             expect(split.orientation).toBe('horizontal');
@@ -1186,14 +1300,21 @@ test.describe('Neo.dashboard.dock.model.Document', () => {
         });
 
         test('splits before the target (new pane first)', () => {
-            const {document, errors} = Operations.splitNode(doc(), {
+            const input = doc();
+
+            Object.assign(input.nodes.root.zones.right, {extent: 0.25, resizable: true});
+
+            const {document, errors} = Operations.splitNode(input, {
                 itemId: 'inspector', targetNodeId: 'side-tabs', orientation: 'vertical', position: 'before', sizes: [0.3, 0.7]
             });
             expect(errors).toEqual([]);
-            const splitId = document.nodes.root.zones.right,
+            const splitId = document.nodes.root.zones.right.nodeId,
                   split   = document.nodes[splitId];
             expect(document.nodes[split.children[0]].items).toEqual(['inspector']);
-            expect(split.children[1]).toBe('side-tabs')
+            expect(split.children[1]).toBe('side-tabs');
+            expect(document.nodes.root.zones.right).toEqual({
+                nodeId: splitId, extent: 0.25, resizable: true
+            })
         });
 
         test('splitting the root makes the new split the root', () => {
@@ -1449,10 +1570,10 @@ test.describe('Neo.dashboard.dock.model.Document', () => {
         test('collapses a single-child split into its child', () => {
             const d = doc();
             d.nodes.split = {type: 'split', orientation: 'horizontal', children: ['main-tabs'], sizes: [1]};
-            d.nodes.root.zones.center = 'split';
+            d.nodes.root.zones.center.nodeId = 'split';
             const out = Document.normalizeTree(d);
             expect(out.nodes.split).toBeUndefined();
-            expect(out.nodes.root.zones.center).toBe('main-tabs')
+            expect(out.nodes.root.zones.center.nodeId).toBe('main-tabs')
         });
 
         test('prunes nodes unreachable from the root', () => {
@@ -1475,7 +1596,7 @@ test.describe('Neo.dashboard.dock.model.Document', () => {
             const descriptor         = {operation: 'splitNode', itemId: 'inspector', targetNodeId: 'main-tabs', orientation: 'horizontal', position: 'after', sizes: [0.5, 0.5]};
             const {document, errors} = Operations.applyOperation(doc(), descriptor);
             expect(errors).toEqual([]);
-            expect(document.nodes[document.nodes.root.zones.center].type).toBe('split')
+            expect(document.nodes[document.nodes.root.zones.center.nodeId].type).toBe('split')
         });
 
         test('dispatches resizeSplit descriptors', () => {
@@ -1524,7 +1645,7 @@ test.describe('Neo.dashboard.dock.model.Document', () => {
                 const {document, errors} = Operations.applyOperation(doc(), descriptor);
                 expect(errors).toEqual([]);
 
-                const split   = document.nodes[document.nodes.root.zones[c.zone]],
+                const split   = document.nodes[document.nodes.root.zones[c.zone].nodeId],
                       newPane = c.lead ? split.children[0] : split.children[1],
                       keep    = c.lead ? split.children[1] : split.children[0];
 
@@ -1597,7 +1718,7 @@ test.describe('Neo.dashboard.dock.model.Document', () => {
                 stream: {componentRef: 'stream', title: 'Stream', kind: 'panel'}
             },
             nodes : {
-                'popup-root': {type: 'edge-zone', zones: {center: 'popup-tabs'}},
+                'popup-root': {type: 'edge-zone', zones: {center: {nodeId: 'popup-tabs'}}},
                 'popup-tabs': {type: 'tabs', items: ['drill', 'stream'], activeItemId: 'drill'}
             }
         });
@@ -1631,7 +1752,7 @@ test.describe('Neo.dashboard.dock.model.Document', () => {
             expect(Document.resolveStackRoot(noCenter)).toBeNull();
 
             const ghostCenter = vessel();
-            ghostCenter.nodes['popup-root'].zones.center = 'ghost';
+            ghostCenter.nodes['popup-root'].zones.center.nodeId = 'ghost';
             expect(Document.resolveStackRoot(ghostCenter)).toBeNull()
         });
 
@@ -1683,7 +1804,7 @@ test.describe('Neo.dashboard.dock.model.Document', () => {
             root  : 'root',
             items : {alpha: {componentRef: 'alpha', title: 'Alpha', kind: 'panel'}},
             nodes : {
-                root       : {type: 'edge-zone', zones: {center: 'main-tabs'}},
+                root       : {type: 'edge-zone', zones: {center: {nodeId: 'main-tabs'}}},
                 'main-tabs': {type: 'tabs', items: ['alpha'], activeItemId: 'alpha'}
             }
         });
@@ -1820,7 +1941,7 @@ test.describe('Neo.dashboard.dock.model.Document', () => {
 
             expect(errors).toEqual([]);
 
-            const centerId = document.nodes.root.zones.center;
+            const centerId = document.nodes.root.zones.center.nodeId;
 
             expect(document.nodes[centerId].type).toBe('split');
             expect(document.nodes[centerId].children).toContain('main-tabs');
@@ -1870,7 +1991,7 @@ test.describe('Neo.dashboard.dock.model.Document', () => {
             const d = doc();
 
             d.nodes = {
-                root: {type: 'edge-zone', zones: {center: 'tri'}},
+                root: {type: 'edge-zone', zones: {center: {nodeId: 'tri'}}},
                 tri : {type: 'split', orientation: 'horizontal', children: ['a', 'b', 'c'], sizes: [0.2, 0.3, 0.5]},
                 a   : {type: 'tabs', items: ['strategy'], activeItemId: 'strategy'},
                 b   : {type: 'tabs', items: ['swarm'],    activeItemId: 'swarm'},
@@ -1905,7 +2026,7 @@ test.describe('Neo.dashboard.dock.model.Document', () => {
             root  : 'root',
             items : {alpha: {componentRef: 'alpha', title: 'Alpha', kind: 'panel'}},
             nodes : {
-                root       : {type: 'edge-zone', zones: {center: 'main-tabs'}},
+                root       : {type: 'edge-zone', zones: {center: {nodeId: 'main-tabs'}}},
                 'main-tabs': {type: 'tabs', items: ['alpha'], activeItemId: 'alpha'}
             }
         });
@@ -1936,7 +2057,7 @@ test.describe('Neo.dashboard.dock.model.Document', () => {
             source.nodes['grp-a'] = {type: 'tabs', items: ['log'],   activeItemId: 'log'};
             source.nodes['grp-b'] = {type: 'tabs', items: ['watch'], activeItemId: 'watch'};
             source.nodes.grp      = {type: 'split', orientation: 'horizontal', children: ['grp-a', 'grp-b'], sizes: [0.5, 0.5]};
-            source.nodes.root.zones.right = 'grp';
+            source.nodes.root.zones.right = {nodeId: 'grp'};
             delete source.nodes['side-tabs'];
             delete source.items.terminal;
 

--- a/test/playwright/unit/examples/dashboard/choreography/DemoAWorkspace.spec.mjs
+++ b/test/playwright/unit/examples/dashboard/choreography/DemoAWorkspace.spec.mjs
@@ -39,8 +39,8 @@ test.describe.serial('Neo.examples.dashboard.choreography.DemoAWorkspace', () =>
         const doc = workspace.getDockZoneDocument();
 
         expect(doc).not.toBe(initialDocument);            // a clone, never the shared module constant
-        expect(doc.nodes.root.zones.center).toBe('editor-tabs');
-        expect(doc.nodes.root.zones.right).toBe('side-tabs')
+        expect(doc.nodes.root.zones.center.nodeId).toBe('editor-tabs');
+        expect(doc.nodes.root.zones.right.nodeId).toBe('side-tabs')
     });
 
     test('applyDockZoneOperation is the pure reducer: fail-closed result, no self-mutation', () => {

--- a/test/playwright/unit/examples/dashboard/choreography/demoADockChoreography.spec.mjs
+++ b/test/playwright/unit/examples/dashboard/choreography/demoADockChoreography.spec.mjs
@@ -110,7 +110,7 @@ test.describe.serial('examples/dashboard/choreography/demoADockChoreography', ()
         const finale = holder.dockZoneDocument;
 
         expect(finale.nodes['side-tabs'].items).toEqual(['preview', 'terminal', 'logs']);
-        expect(finale.nodes.root.zones.center).toBe('editor-tabs');
+        expect(finale.nodes.root.zones.center.nodeId).toBe('editor-tabs');
         expect(finale.items.preview.autoHidden).toBe(false);
         expect(finale.items.terminal.autoHidden).toBe(false);
         expect(finale.items.logs.autoHidden).toBe(false)

--- a/test/playwright/unit/examples/dashboard/crossWindow/DemoBWorkspace.spec.mjs
+++ b/test/playwright/unit/examples/dashboard/crossWindow/DemoBWorkspace.spec.mjs
@@ -230,7 +230,7 @@ test.describe.serial('Neo.examples.dashboard.crossWindow.DemoBWorkspace', () => 
         const doc = workspace.getDockZoneDocument();
 
         expect(doc).not.toBe(initialDocument);
-        expect(doc.nodes.root.zones.center).toBe('workbench-tabs');
+        expect(doc.nodes.root.zones.center.nodeId).toBe('workbench-tabs');
         expect(doc.nodes['side-tabs'].items).toEqual(['inspector', 'timeline', 'console'])
     });
 
@@ -272,7 +272,7 @@ test.describe.serial('Neo.examples.dashboard.crossWindow.DemoBWorkspace', () => 
 
         expect(loaded.loaded).toBe(true);
         expect(workspace.getDockZoneDocument().nodes['split-workbench-tabs-0']).toBeUndefined();
-        expect(workspace.getDockZoneDocument().nodes.root.zones.center).toBe('workbench-tabs')
+        expect(workspace.getDockZoneDocument().nodes.root.zones.center.nodeId).toBe('workbench-tabs')
     });
 
     test('loading an unknown perspective fails closed and mutates nothing', () => {

--- a/test/playwright/unit/main/addon/DragDrop.spec.mjs
+++ b/test/playwright/unit/main/addon/DragDrop.spec.mjs
@@ -1318,7 +1318,7 @@ test.describe('Neo.main.addon.DragDrop — main-thread resize preview', () => {
         }
     };
 
-    const createState = ({axis='width', preview=true, resizeNext=true}={}) => {
+    const createState = ({axis='width', awaitWorkerSettlement=false, preview=true, resizeNext=true}={}) => {
         const style  = createStyle({flex: '1 1 0%'}),
               target = {style};
 
@@ -1326,7 +1326,9 @@ test.describe('Neo.main.addon.DragDrop — main-thread resize preview', () => {
 
         resize.state = {
             axis,
+            awaitWorkerSettlement,
             coordinate   : axis === 'width' ? 'clientX' : 'clientY',
+            dragZoneId   : 'splitter-zone',
             lastSize     : 300,
             maxSize      : 590,
             minSize      : 0,
@@ -1335,6 +1337,7 @@ test.describe('Neo.main.addon.DragDrop — main-thread resize preview', () => {
                 flex  : {priority: '', value: '1 1 0%'}
             },
             preview,
+            parentId       : 'parent-wrapper',
             resizeNext,
             startCoordinate: 100,
             startSize      : 300,
@@ -1389,6 +1392,98 @@ test.describe('Neo.main.addon.DragDrop — main-thread resize preview', () => {
             axis: 'width', size: 420, targetId: 'target-wrapper'
         });
         expect(style.getPropertyValue('width')).toBe('420px')
+    });
+
+    test('worker settlement keeps accepted pixels, restores rejected pixels, and rejects stale generations', () => {
+        let state = createState({awaitWorkerSettlement: true}),
+            terminal;
+
+        terminal = state.resize.finish({clientX: 190, clientY: 0});
+
+        expect(terminal).toEqual({
+            axis      : 'width',
+            generation: 1,
+            size      : 210,
+            targetId  : 'target-wrapper'
+        });
+        expect(state.style.getPropertyValue('width')).toBe('210px');
+        expect(state.resize.settle({
+            dragZoneId: 'splitter-zone',
+            generation: 2,
+            restore   : true,
+            targetId  : 'target-wrapper'
+        }), 'a stale verdict cannot touch the current terminal').toBe(false);
+        expect(state.style.getPropertyValue('width')).toBe('210px');
+        expect(state.resize.settle({
+            dragZoneId: 'splitter-zone',
+            generation: 1,
+            restore   : true,
+            targetId  : 'target-wrapper'
+        })).toBe(true);
+        expect(state.style.getPropertyValue('width')).toBe('');
+        expect(state.style.getPropertyValue('flex')).toBe('1 1 0%');
+        expect(state.resize.pendingTerminal).toBeNull();
+
+        state    = createState({awaitWorkerSettlement: true});
+        terminal = state.resize.finish({clientX: 180, clientY: 0});
+
+        expect(state.resize.settle({
+            dragZoneId: 'splitter-zone',
+            generation: terminal.generation,
+            targetId  : 'target-wrapper'
+        })).toBe(true);
+        expect(state.style.getPropertyValue('width'), 'acceptance retains terminal pixels until projection owns them')
+            .toBe('220px');
+        expect(state.resize.pendingTerminal).toBeNull()
+    });
+
+    test('a same-gesture registration replaces a retired target and replays the latest pointer frame', () => {
+        const
+            first             = createState(),
+            replacementStyle  = createStyle({flex: '1 1 0%'}),
+            replacementTarget = {style: replacementStyle};
+
+        first.resize.apply({clientX: 150, clientY: 0});
+        first.resize.gesture = {
+            clientX      : 100,
+            clientY      : 0,
+            dragZoneId   : 'splitter-zone',
+            latestClientX: 180,
+            latestClientY: 0
+        };
+        first.resize.createState = config => ({
+            ...first.resize.state,
+            axis         : config.axis,
+            dragZoneId   : config.dragZoneId,
+            lastSize     : 300,
+            originalStyle: {
+                flex : {priority: '', value: '1 1 0%'},
+                width: {priority: '', value: ''}
+            },
+            parentId       : config.parentId,
+            startCoordinate: 100,
+            startSize      : 300,
+            target         : replacementTarget,
+            targetId       : config.targetId
+        });
+
+        first.resize.register({
+            dragElementRootId: 'splitter-root',
+            dragZoneId       : 'splitter-zone',
+            resizeConfig     : {
+                axis      : 'width',
+                parentId  : 'current-parent',
+                preview   : true,
+                resizeNext: true,
+                targetId  : 'current-target'
+            }
+        });
+
+        expect(first.style.getPropertyValue('width'), 'the retired target regains its original authority').toBe('');
+        expect(first.style.getPropertyValue('flex')).toBe('1 1 0%');
+        expect(first.resize.state.targetId).toBe('current-target');
+        expect(replacementStyle.getPropertyValue('width'), 'the latest frame is replayed on the current target')
+            .toBe('220px')
     });
 
     test('createState derives pixel bounds from the target computed style', () => {

--- a/test/playwright/unit/main/addon/DragDrop.spec.mjs
+++ b/test/playwright/unit/main/addon/DragDrop.spec.mjs
@@ -1329,6 +1329,7 @@ test.describe('Neo.main.addon.DragDrop — main-thread resize preview', () => {
             coordinate   : axis === 'width' ? 'clientX' : 'clientY',
             lastSize     : 300,
             maxSize      : 590,
+            minSize      : 0,
             originalStyle: {
                 [axis]: {priority: '', value: ''},
                 flex  : {priority: '', value: '1 1 0%'}
@@ -1374,6 +1375,56 @@ test.describe('Neo.main.addon.DragDrop — main-thread resize preview', () => {
         });
         expect(state.style.getPropertyValue('width')).toBe('');
         expect(state.style.getPropertyValue('flex')).toBe('1 1 0%')
+    });
+
+    test('CSS min/max bounds clamp both live preview and terminal output', () => {
+        const {resize, style} = createState();
+
+        Object.assign(resize.state, {minSize: 180, maxSize: 420});
+
+        expect(resize.apply({clientX: 500, clientY: 0})).toBe(180);
+        expect(style.getPropertyValue('width')).toBe('180px');
+
+        expect(resize.finish({clientX: -500, clientY: 0})).toEqual({
+            axis: 'width', size: 420, targetId: 'target-wrapper'
+        });
+        expect(style.getPropertyValue('width')).toBe('420px')
+    });
+
+    test('createState derives pixel bounds from the target computed style', () => {
+        const originalGetElement       = Neo.main.DomAccess.getElement,
+              originalGetLayoutRect    = Neo.main.DomAccess.getLayoutRect,
+              originalGetComputedStyle = globalThis.getComputedStyle,
+              parent                   = {},
+              target                   = {style: createStyle({flex: '1 1 0%'})};
+
+        Neo.main.DomAccess.getElement = id => id === 'parent' ? parent : target;
+        Neo.main.DomAccess.getLayoutRect = element => element === parent
+            ? {width: 600, height: 400}
+            : {width: 300, height: 200};
+        globalThis.getComputedStyle = () => ({
+            getPropertyValue: key => ({'min-width': '120px', 'max-width': '440px'})[key] || 'none'
+        });
+
+        try {
+            const state = new Resize().createState({
+                axis        : 'width',
+                parentId    : 'parent',
+                preview     : true,
+                resizeNext  : true,
+                splitterSize: 6,
+                targetId    : 'target'
+            }, {clientX: 100});
+
+            expect(state.minSize).toBe(120);
+            expect(state.maxSize).toBe(440)
+        } finally {
+            Neo.main.DomAccess.getElement    = originalGetElement;
+            Neo.main.DomAccess.getLayoutRect = originalGetLayoutRect;
+            originalGetComputedStyle === undefined
+                ? delete globalThis.getComputedStyle
+                : globalThis.getComputedStyle = originalGetComputedStyle
+        }
     });
 
     test('cancel restores exact inline authority and a live move emits no App-Worker frame', () => {

--- a/test/playwright/unit/main/addon/DragDrop.spec.mjs
+++ b/test/playwright/unit/main/addon/DragDrop.spec.mjs
@@ -1427,6 +1427,42 @@ test.describe('Neo.main.addon.DragDrop — main-thread resize preview', () => {
         }
     });
 
+    test('createState resolves percentage bounds against the parent layout axis', () => {
+        const originalGetElement       = Neo.main.DomAccess.getElement,
+              originalGetLayoutRect    = Neo.main.DomAccess.getLayoutRect,
+              originalGetComputedStyle = globalThis.getComputedStyle,
+              parent                   = {},
+              target                   = {style: createStyle({flex: '1 1 0%'})};
+
+        Neo.main.DomAccess.getElement = id => id === 'parent' ? parent : target;
+        Neo.main.DomAccess.getLayoutRect = element => element === parent
+            ? {width: 800, height: 600}
+            : {width: 240, height: 180};
+        globalThis.getComputedStyle = () => ({
+            getPropertyValue: key => ({'min-width': '120px', 'max-width': '50%'})[key] || 'none'
+        });
+
+        try {
+            const state = new Resize().createState({
+                axis        : 'width',
+                parentId    : 'parent',
+                preview     : true,
+                resizeNext  : true,
+                splitterSize: 6,
+                targetId    : 'target'
+            }, {clientX: 100});
+
+            expect(state.minSize).toBe(120);
+            expect(state.maxSize, '50% is half the 800px parent, not the literal number 50').toBe(400)
+        } finally {
+            Neo.main.DomAccess.getElement    = originalGetElement;
+            Neo.main.DomAccess.getLayoutRect = originalGetLayoutRect;
+            originalGetComputedStyle === undefined
+                ? delete globalThis.getComputedStyle
+                : globalThis.getComputedStyle = originalGetComputedStyle
+        }
+    });
+
     test('cancel restores exact inline authority and a live move emits no App-Worker frame', () => {
         const {resize, style} = createState(),
               addon           = {dragResize: resize},


### PR DESCRIPTION
Resolves #17838

DockLayouts now commits tab activation and initial edge-band sizing through the same document reducer as every other layout change. Edge-zone entries own `{nodeId, extent?, resizable?}`; projected edge splitters preview real CSS-bounded geometry in the main thread and commit one normalized `resizeEdgeZone` terminal. Workstation and the dashboard example seed their intended boundaries, auto-hide reveal and perspectives preserve committed extents, and the public guides describe the executable final contract.

Related: #17836
Related: #17837
Related: neomjs/neo-agent-institution#39

Evidence: L3 (real-pointer Workstation edge-resize/cancel journey, rendered reveal geometry, and live perspective round trip) → L3 required (AC-3, AC-6–11). Residual: none.

## AC Evidence

| AC | Proof |
|---|---|
| AC-1 | CI-covered: `DockZoneModel.spec.mjs` proves valid/no-op/refused `setActiveItem` descriptors and byte-identical refusal. |
| AC-2 | CI-covered: `DockLayoutAdapter.spec.mjs` + `DockWorkspace.spec.mjs` prove activation reporting with close actions enabled and disabled. |
| AC-3 | CI-covered split/unrelated re-projection proof in `DockWorkspace.spec.mjs`; outside-CI edge and perspective proofs in `WorkstationEdgeSplitterNL.spec.mjs` and `WorkstationPerspectivesNL.spec.mjs`. |
| AC-4 | CI-covered: `DockZoneModel.spec.mjs` validates the nested descriptor shape and rejects string/parallel/unknown fields. |
| AC-5 | CI-covered: `DockZoneModel.spec.mjs`, `DragDrop.spec.mjs`, and `DockSplitter.spec.mjs` cover permission, normalized extent, CSS min/max, and terminal conversion. |
| AC-6 | Outside-CI: `WorkstationEdgeSplitterNL.spec.mjs` asserts byte-identical document truth while real pointer frames resize the band. |
| AC-7 | Outside-CI: the same journey requires one changed terminal extent and final rendered ratio within 0.015. |
| AC-8 | CI-covered generation/stale-target/rejection/Escape tests plus outside-CI Escape and forced-reducer-rejection restores, zero document writes, and `dragStartState: null`; prerequisite destruction equivalence is owned by `#17837`. |
| AC-9 | Outside-CI: `DockAutoHideRevealNL.spec.mjs` proves the rendered overlay consumes the committed 25% edge extent and reveal remains byte-stable. |
| AC-10 | CI-covered adapter matrix plus headed Workstation left/right/bottom inventory and example Inspector-boundary proof. |
| AC-11 | Outside-CI: Workstation both-axis resize/cancel, perspective active-item+extent restore, and full dashboard reveal/pin/rail suite. |
| AC-12 | CI-covered focused regression families; final current-head CI is the complete existing-suite gate. |
| AC-13 | ADR 0029, `DockZoneModel.md`, `DockLayouts.md`, and `DockLayoutsAdoption.md` carry the final semantics; all three Mermaid diagrams render in Chromium. |
| AC-14 | Exact diff/source sweep finds no compatibility reader, parallel edge map, retired class path, or old wire-family reintroduction. Institution migration remains owned by its linked ticket. |

## Deltas from ticket

- Added percentage-aware CSS-bound resolution in the existing main-thread resize controller. Computed `max-width: 50%` remains a percentage; parsing it as the literal number 50 would clamp a half-workspace bound to 50px.
- Real Escape never forwards the suppressed native `drag:end`, so DockSplitter explicitly retires its dock-only geometry snapshot in `onDragCancel()`.
- The headed witness binds a complete live affordance (splitter + registered parent + target) and requires the same splitter id to survive two paint frames. A committed tab activation advances document truth before its deferred projection starts, so a merely visible outgoing id is not yet a pointer-stable generation.
- Review falsification found that `component.Abstract#data` is a StateProvider shortcut, not local splitter metadata. Edge identity now reads the instance configs first and never lets colliding provider keys reclassify a split affordance.
- Semantic edge terminals now opt into a generation-scoped main-thread settlement: reducer success releases the rollback snapshot; refusal restores the exact pre-gesture inline authority. A same-gesture registration which replaces a retired projection target replays the latest pointer frame onto the current target.
- Geometry-only reconciliation now adopts projected edge `width`/`height`, so a successful resize becomes durable percentage authority instead of remaining correct only through retained main-thread pixels.

## Test Evidence

- `WorkstationEdgeSplitterNL.spec.mjs`: 1/1 passed at current head `aa820b62e8` — real click, three initial edge affordances, left + bottom pointer resize, current-target replay, committed percentage ownership, non-first tab persistence, Escape restore, and forced reducer rejection restoring rendered geometry with zero document write.
- `WorkstationPerspectivesNL.spec.mjs`: 1/1 passed at current head `aa820b62e8` — captured non-first Audit tab + 0.20 left extent, disrupted to 0.32, restored both exactly.
- `DockAutoHideRevealNL.spec.mjs`: 4/4 passed at current head `aa820b62e8` — Inspector splitter, committed 25% reveal geometry, byte-stable reveal/dismiss, pin, DOM retirement, focus-contained prose selection, and four-edge rails.
- Mermaid render: 3/3 diagrams produced non-empty SVGs from the rebased tree in Chromium (`DockLayouts.md` ×2, `DockLayoutsAdoption.md` ×1).

## Signal Ledger

| Family | Signal |
|---|---|
| GPT (author) | [AUTHOR_SIGNAL at the selected body revision](https://github.com/neomjs/neo/discussions/17818#discussioncomment-18193339) |
| Claude (non-author) | [GRADUATION_APPROVED](https://github.com/neomjs/neo/discussions/17818#discussioncomment-18193330), [quorum/staleness confirmation](https://github.com/neomjs/neo/discussions/17818#discussioncomment-18193371), and [OQ7 exact-source revalidation](https://github.com/neomjs/neo/discussions/17818#discussioncomment-18194661) |

## Unresolved Dissent

None. The divergence matrix was folded, the non-author STEP_BACK was discharged, and OQ1–OQ8 were resolved before graduation.

## Unresolved Liveness

None. Tier-2 liveness artifacts are not applicable to this engine architecture change; the graduated Discussion records both active families and a non-author approval.

## Slot Rationale

Decision Record impact: amends ADR 0029 at its state-ownership and auto-hide decisions with committed `activeItemId`, nested edge descriptors, and terminal-only edge resizing; all worker/runtime/main-thread boundaries remain binding. `DockZoneModel.md` is rewritten in place from ticket-era planning language into the current executable contract, reducing future decay rather than adding another loaded rule slot.

## Post-Merge Validation

No Engine-only post-merge validation remains. The external consumer is owned separately by
[neo-agent-institution#39](https://github.com/neomjs/neo-agent-institution/issues/39).

## Commits

- `8be502ef64` — document/reducer/projection/consumer semantic contracts.
- `1452cd3cbf` — live edge terminal, CSS bounds, cancellation, and consumer witnesses.
- `fed30a7d14` — ADR and guide current-state rewrite.
- `ca69fbd801` — evidence-driven real-pointer witness hardening.
- `fcf345b702` — align inherited-mechanism and rendered-example witnesses with the delivered edge semantics.
- `aa820b62e8` — settle semantic resize terminals, harden instance identity, and preserve durable edge geometry.

## Evolution

The headed witness exposed three non-product assumptions and turned them into stronger evidence: discovery now binds the full registered affordance; a splitter id must survive two paint frames before pointer capture because committed tab activation schedules projection after document truth advances; and Workstation seeds its edge bands at CSS maxima, so success gestures shrink inward while the cancel leg grows and restores. Post-open CI then caught two stale test expectations: the deliberate dock `onDragCancel` override had to leave the inherited-only census, and the example now renders its two split boundaries plus one Inspector edge boundary. Round-1 review subsequently falsified two runtime assumptions: provider-backed `data` is not local identity, and unchanged re-projection cannot restore main-thread pixels. The corrective head keeps the selected architecture and closes both boundaries with instance-first identity, exact terminal settlement, stale-target replay, and a rendered rejection witness.

Authored by Euclid (GPT-5.6 Sol, Codex Desktop). Session 01a03dec-efe5-71b3-8c19-e6b29187b970.
