### PR TITLE
feat(dashboard): dock splitters preview the conserved pair live before the semantic commit (#17820)

### DIFF
--- a/examples/dashboard/dock/MainContainer.mjs
+++ b/examples/dashboard/dock/MainContainer.mjs
@@ -77,10 +77,13 @@ const seededPerspectives = [{
  *
  * The engine class owns the whole host loop: the committed document ({@link #dockModel}), the pure
  * reducer (`applyDockZoneOperation`), the deferred, promise-chained re-projection through
- * `DockLayoutAdapter` and `DockProjectionReconciler` (`onDockZoneDocumentChange`), the FLIP motion
- * bracket, and the in-window cross-zone drop path. Dragging a splitter commits a `resizeSplit`
- * operation through `DockZoneModel`, and the layout re-projects from the new committed document —
- * the example adds nothing to that mechanism.
+ * `projection.LayoutAdapter` and `projection.Reconciler` (`onDockZoneDocumentChange`), the FLIP
+ * motion bracket, and the in-window cross-zone drop path. Every splitter previews live by default:
+ * a split boundary moves its conserved adjacent pair on the main thread (totals constant, both
+ * members' CSS bounds respected) and the edge boundary resizes its band the same way — release
+ * commits exactly one `resizeSplit` / `resizeEdgeZone` matching the final preview, Escape restores
+ * the exact pre-drag geometry, and the layout re-projects from the new committed document — the
+ * example adds nothing to that mechanism.
  *
  * What the example owns is exactly what an adopting app owns: which pane renders a catalog item
  * ({@link #resolvePane}), and its own chrome — a perspective toolbar consuming the saved-layout

--- a/learn/guides/uibuildingblocks/DockLayouts.md
+++ b/learn/guides/uibuildingblocks/DockLayouts.md
@@ -159,11 +159,14 @@ A tab click changes the live `Neo.tab.Container.activeIndex`, then immediately e
 tabs-node and item ids. That is why selecting a non-first tab survives a later resize, perspective restore, or unrelated
 re-projection: the next projection reads the committed `activeItemId` instead of a stale default.
 
-An edge splitter keeps its move frames even further from the document. The generic main-thread resize path previews
-the real band under its CSS min/max bounds; the App Worker sees no move-frame writes. Release converts the final bounded
-pixel size into one normalized `resizeEdgeZone` operation. Escape or rejection restores the previous presentation and
-commits nothing. Split-node splitters keep their own `resizeSplit` operation; split `sizes` and edge `extent` never
-share an authority.
+Every dock splitter previews live on the main thread by default (`liveResize: true`), and the App Worker sees no
+move-frame writes on either kind. An edge splitter resizes its real band under the band's CSS min/max bounds and
+releases into one normalized `resizeEdgeZone` operation. A split-node splitter previews the **conserved adjacent
+pair**: the two model-order children around the boundary change complementarily each frame — their total constant,
+the clamp window the intersection of both members' CSS bounds — and release commits exactly one `resizeSplit` whose
+vector equals the final previewed geometry, so re-projection never jumps. Escape or a rejected commit restores the
+exact pre-drag presentation of every touched pane and commits nothing. Setting `liveResize: false` on a splitter
+restores the deferred proxy-and-commit presentation. Split `sizes` and edge `extent` never share an authority.
 
 Auto-hide does not discard an edge's size. The rail reveal reads the owning edge descriptor's committed extent, and a
 perspective captures that same descriptor. The workspace fallback fraction is only for an edge that has never committed

--- a/learn/guides/uibuildingblocks/DockLayoutsAdoption.md
+++ b/learn/guides/uibuildingblocks/DockLayoutsAdoption.md
@@ -105,6 +105,11 @@ The adapter projects the right boundary splitter automatically. Move frames resi
 min/max bounds; release emits one `resizeEdgeZone` operation. The descriptor is also what auto-hide reveal and
 perspective restore read, so there is no app-side size map to maintain.
 
+Split boundaries need even less from you: every projected split splitter previews the conserved adjacent pair live by
+default — both panes track the pointer with their total constant, bounded by both members' CSS min/max — and release
+commits one `resizeSplit` equal to the final preview. There is nothing to enable; set `liveResize: false` on a
+splitter only when you explicitly want the deferred proxy-and-commit presentation back.
+
 Tab activation is equally automatic. Every projected tab strip converts its live `activeIndex` change into
 `setActiveItem`; this does not depend on close-action chrome being enabled. Do not mirror the selected tab in app state
 or add a listener of your own—the next projection reads the committed `activeItemId`.

--- a/src/dashboard/dock/interaction/DockSplitter.mjs
+++ b/src/dashboard/dock/interaction/DockSplitter.mjs
@@ -11,9 +11,11 @@ import NeoArray   from '../../../util/Array.mjs';
  * the terminal converts captured runtime geometry into one `resizeSplit` or `resizeEdgeZone`
  * descriptor, and
  * the commit flows through `Operations.applyOperation()` or a supplied owning reducer callback.
- * Split-node affordances keep the deferred proxy presentation and register no main-thread resize;
- * edge-zone affordances reuse the generic live sibling-resize path, then commit only its bounded
- * terminal fraction. Live adjacent-pair split preview remains a separate feature seam.
+ * Both affordance families preview live on the main thread by default: edge zones ride the generic
+ * single-target sibling-resize path, split boundaries ride its conserved-pair extension (the two
+ * model-order children around `boundaryIndex` change complementarily, their total constant per
+ * frame), and each commits only its bounded terminal. `liveResize: false` restores the deferred
+ * proxy presentation on either.
  *
  * The public split vocabulary stays dock-shaped: `orientation` describes the SPLIT NODE
  * (`horizontal` = side-by-side children), which maps onto the generic parent's `direction`
@@ -90,6 +92,13 @@ class DockSplitter extends Splitter {
          * @member {Function|null} onDockZoneDocumentChange=null
          */
         onDockZoneDocumentChange: null,
+        /**
+         * Dock affordances default to the proxy-free main-thread preview (default override of the
+         * inherited reactive config): edge bands resize live, split boundaries preview the
+         * conserved adjacent pair. `false` restores the deferred proxy-and-commit presentation.
+         * @member {Boolean} liveResize=true
+         */
+        liveResize: true,
         /**
          * Split orientation from the dock-zone model (`horizontal` means side-by-side children).
          * Maps onto the generic `direction` config as its inverse.
@@ -310,17 +319,47 @@ class DockSplitter extends Splitter {
     }
 
     /**
-     * Split-node affordances register no main-thread resize: the committed document is the sole size
-     * authority, so the deferred proxy presentation carries the gesture and the terminal commits
-     * semantically. Edge affordances use the inherited main-thread descriptor because their adjacent
-     * band must preview live under CSS min/max bounds; only the normalized terminal enters the document.
+     * Edge affordances use the inherited single-target descriptor: their band previews live under
+     * CSS min/max bounds. Split affordances emit the conserved-pair descriptor: the two model-order
+     * children around `boundaryIndex` preview complementary sizes on the main thread, and the
+     * terminal's CSS-bounded pixel result feeds the exact committed vector. `liveResize: false`
+     * registers nothing and retains the deferred proxy presentation. The committed document remains
+     * the sole size authority in every mode; pointer frames never cross the worker boundary.
      * @returns {Object|null}
      * @protected
      */
     getResizeConfig() {
-        let config = this.isEdgeZoneResize() ? super.getResizeConfig() : null;
+        let me = this;
 
-        return config ? {...config, awaitWorkerSettlement: true} : null
+        if (me.isEdgeZoneResize()) {
+            let config = super.getResizeConfig();
+
+            return config ? {...config, awaitWorkerSettlement: true} : null
+        }
+
+        if (!me.liveResize) return null;
+
+        let boundaryIndex = Number(me.boundaryIndex ?? me.data?.boundaryIndex),
+            children      = me.getSplitChildItems(),
+            target        = children[boundaryIndex],
+            counter       = children[boundaryIndex + 1];
+
+        // A splitter is never its own pair member: a consumer that stamps `dockNodeType` after
+        // construct would otherwise register a self-referencing descriptor whose bound-fold pins
+        // the clamp window shut — no preview beats a frozen one, and the per-gesture refresh
+        // re-registers the corrected pair.
+        if (!me.parent || !target || !counter || target === me || counter === me) return null;
+
+        return {
+            awaitWorkerSettlement: true,
+            axis                 : me.getSizeAxis(),
+            counterTargetId      : me.getLayoutElementId(counter),
+            parentId             : me.getLayoutElementId(me.parent),
+            preview              : true,
+            resizeNext           : false,
+            splitterSize         : me.size,
+            targetId             : me.getLayoutElementId(target)
+        }
     }
 
     /**
@@ -380,7 +419,6 @@ class DockSplitter extends Splitter {
      */
     onDragEnd(data={}) {
         let me         = this,
-            edgeResize = me.isEdgeZoneResize(),
             hasCapture = Boolean(me.dragStartState) || Array.isArray(data.sizes),
             descriptor = null,
             result;
@@ -406,12 +444,14 @@ class DockSplitter extends Splitter {
                 result     = me.commitResizeOperation(descriptor)
             }
         } catch (error) {
-            edgeResize && me.settleMainThreadResize(data, true);
+            me.settleMainThreadResize(data, true);
             me.dragStartState = null;
             throw error
         }
 
-        edgeResize && me.settleMainThreadResize(data, data.cancelled || Boolean(result.errors?.length));
+        // Edge AND pair terminals both await worker settlement now; the generation guard inside
+        // settleMainThreadResize scopes the call to gestures that actually opted in.
+        me.settleMainThreadResize(data, data.cancelled || Boolean(result.errors?.length));
 
         if (!data.cancelled) {
             me.fire(result.errors?.length ? 'dockSplitterResizeRejected' : 'dockSplitterResize', {
@@ -473,7 +513,11 @@ class DockSplitter extends Splitter {
             generation = ++me.dragGeneration;
 
         await me.captureDragStart(data);
-        await me.projectProxyTokens();
+
+        // the proxy paint round trip only pays off when a proxy will actually mount
+        if (!me.liveResize) {
+            await me.projectProxyTokens()
+        }
 
         if (generation !== me.dragGeneration || me.isDestroyed) {
             me.dragStartState = null;
@@ -499,6 +543,10 @@ class DockSplitter extends Splitter {
     }
 
     /**
+     * The terminal's `resizeSize` — the last CSS-bounded pixel value the main-thread preview
+     * actually painted — wins over pointer arithmetic when present, so the committed vector equals
+     * the final preview by construction and re-projection cannot jump. The pointer-delta fallback
+     * carries the proxy presentation, where no main-thread registration exists.
      * @param {Object} data
      * @returns {Number[]|null}
      * @protected
@@ -516,10 +564,18 @@ class DockSplitter extends Splitter {
             start          = Number(dragStartState?.[coordinate]),
             end            = Number(data[coordinate]),
             delta          = Number.isFinite(start) && Number.isFinite(end) ? end - start : 0,
+            terminal       = Number(data.resizeSize),
             output         = sizes.slice();
 
         if (!Number.isInteger(boundaryIndex) || boundaryIndex < 0 || boundaryIndex + 1 >= output.length) {
             return null
+        }
+
+        if (Number.isFinite(terminal) && dragStartState?.sizes) {
+            output[boundaryIndex + 1] = sizes[boundaryIndex] + sizes[boundaryIndex + 1] - terminal;
+            output[boundaryIndex]     = terminal;
+
+            return output
         }
 
         output[boundaryIndex]     += delta;

--- a/src/dashboard/dock/interaction/DockSplitter.mjs
+++ b/src/dashboard/dock/interaction/DockSplitter.mjs
@@ -228,20 +228,27 @@ class DockSplitter extends Splitter {
     /**
      * Captures the parent axis plus child sizes at drag start. Split terminals stay model-order
      * based; edge terminals normalize their CSS-bounded pixel result against the same parent box.
+     *
+     * Measurement identity matches the main-thread descriptor exactly: the OUTER layout
+     * participants (`getLayoutElementId()` — a custom-root component keeps its public id on an
+     * inner node) measured transform-immune (`getLayoutRect()`), so captured sizes, the live
+     * preview, and the committed vector all speak about the same boxes.
      * @param {Object} data
      * @returns {Promise<Object>}
      */
     async captureDragStart(data={}) {
         let me       = this,
             children = me.getSplitChildItems(),
-            ids      = [me.parent?.id, ...children.map(item => item.id)].filter(Boolean),
+            ids      = me.parent
+                ? [me.getLayoutElementId(me.parent), ...children.map(item => me.getLayoutElementId(item))]
+                : [],
             rects    = [],
             axis     = me.getSizeAxis(),
             sizes;
 
-        if (ids.length && me.parent?.getDomRect) {
+        if (ids.length && me.parent?.getLayoutRect) {
             try {
-                rects = await me.parent.getDomRect(ids)
+                rects = await me.parent.getLayoutRect(ids)
             } catch (error) {
                 rects = []
             }

--- a/src/main/draggable/Resize.mjs
+++ b/src/main/draggable/Resize.mjs
@@ -72,7 +72,9 @@ class Resize {
     }
 
     /**
-     * Applies one pointer frame without crossing the worker boundary.
+     * Applies one pointer frame without crossing the worker boundary. A registered counter target
+     * receives the complementary size in the same frame, so the pair total is conserved on this
+     * thread by construction — the worker never sees a drifting intermediate.
      * @param {Object} data
      * @returns {Number|null}
      */
@@ -102,7 +104,12 @@ class Resize {
 
         if (state.preview && value !== state.lastSize) {
             state.target.style.setProperty('flex', 'none');
-            state.target.style.setProperty(state.axis, `${value}px`)
+            state.target.style.setProperty(state.axis, `${value}px`);
+
+            if (state.counter) {
+                state.counter.style.setProperty('flex', 'none');
+                state.counter.style.setProperty(state.axis, `${state.pairTotal - value}px`)
+            }
         }
 
         state.lastSize = value;
@@ -111,7 +118,8 @@ class Resize {
     }
 
     /**
-     * Restores interrupted preview authority and clears the gesture.
+     * Restores interrupted preview authority — both pair members when a counter is registered —
+     * and clears the gesture.
      * @returns {Boolean}
      */
     cancel() {
@@ -125,7 +133,10 @@ class Resize {
     }
 
     /**
-     * Restores the exact inline properties captured before transient resize ownership began.
+     * Restores the exact inline properties captured before transient resize ownership began —
+     * both pair members when the state registered a counter. Every restoration authority
+     * (cancel, degenerate finish, settlement rejection, stale-target replay) routes through here,
+     * so the conserved pair can never be restored by halves.
      * @param {Object|null} state
      * @returns {Boolean}
      * @protected
@@ -133,15 +144,26 @@ class Resize {
     restoreState(state) {
         if (!state) return false;
 
-        Object.entries(state.originalStyle).forEach(([key, {priority, value}]) => {
-            if (value) {
-                state.target.style.setProperty(key, value, priority)
-            } else {
-                state.target.style.removeProperty(key)
-            }
-        });
+        this.restoreStyle(state.target, state.originalStyle);
+        state.counter && this.restoreStyle(state.counter, state.counterOriginalStyle);
 
         return true
+    }
+
+    /**
+     * Writes one captured inline-style snapshot back onto its element.
+     * @param {HTMLElement} target
+     * @param {Object} snapshot Property → {priority, value} map from `createState()`.
+     * @protected
+     */
+    restoreStyle(target, snapshot) {
+        Object.entries(snapshot || {}).forEach(([key, {priority, value}]) => {
+            if (value) {
+                target.style.setProperty(key, value, priority)
+            } else {
+                target.style.removeProperty(key)
+            }
+        })
     }
 
     /**
@@ -169,11 +191,46 @@ class Resize {
             layoutMax  = Math.max(0, Number(parentRect[config.axis]) - Number(config.splitterSize || 0)),
             computed   = globalThis.getComputedStyle?.(target),
             minValue   = resolveCssBound(computed?.getPropertyValue(`min-${config.axis}`), Number(parentRect[config.axis])),
-            maxValue   = resolveCssBound(computed?.getPropertyValue(`max-${config.axis}`), Number(parentRect[config.axis])),
-            minSize    = Number.isFinite(minValue) ? Math.max(0, minValue) : 0,
-            maxSize    = Math.max(minSize, Math.min(layoutMax, Number.isFinite(maxValue) ? maxValue : layoutMax));
+            maxValue   = resolveCssBound(computed?.getPropertyValue(`max-${config.axis}`), Number(parentRect[config.axis]));
+
+        let minSize = Number.isFinite(minValue) ? Math.max(0, minValue) : 0,
+            maxSize = Math.max(minSize, Math.min(layoutMax, Number.isFinite(maxValue) ? maxValue : layoutMax));
 
         if (!Number.isFinite(startSize) || !Number.isFinite(maxSize)) return null;
+
+        // Conserved-pair mode: a counter target turns the clamp window into the intersection of
+        // both members' CSS bounds under a constant pair total, so every previewed frame is a
+        // vector the semantic commit can reproduce exactly.
+        let counter = null, counterOriginalStyle = null, pairTotal = null;
+
+        if (config.counterTargetId) {
+            counter = DomAccess.getElement(config.counterTargetId);
+
+            if (!counter) return null;
+
+            const
+                counterRect  = DomAccess.getLayoutRect(counter),
+                counterStart = Number(counterRect[config.axis]),
+                counterComp  = globalThis.getComputedStyle?.(counter),
+                counterMinV  = resolveCssBound(counterComp?.getPropertyValue(`min-${config.axis}`), Number(parentRect[config.axis])),
+                counterMaxV  = resolveCssBound(counterComp?.getPropertyValue(`max-${config.axis}`), Number(parentRect[config.axis])),
+                counterMin   = Number.isFinite(counterMinV) ? Math.max(0, counterMinV) : 0;
+
+            if (!Number.isFinite(counterStart)) return null;
+
+            pairTotal = startSize + counterStart;
+            minSize   = Math.max(minSize, Number.isFinite(counterMaxV) ? pairTotal - counterMaxV : 0);
+            maxSize   = Math.max(minSize, Math.min(maxSize, pairTotal - counterMin));
+
+            counterOriginalStyle = {};
+
+            ['flex', config.axis].forEach(key => {
+                counterOriginalStyle[key] = {
+                    priority: counter.style.getPropertyPriority(key),
+                    value   : counter.style.getPropertyValue(key)
+                }
+            })
+        }
 
         const originalStyle = {};
 
@@ -188,11 +245,14 @@ class Resize {
             axis                 : config.axis,
             awaitWorkerSettlement: config.awaitWorkerSettlement === true,
             coordinate,
+            counter,
+            counterOriginalStyle,
             dragZoneId           : config.dragZoneId,
             lastSize             : startSize,
             maxSize,
             minSize,
             originalStyle,
+            pairTotal,
             parentId             : config.parentId,
             preview              : config.preview === true,
             resizeNext           : config.resizeNext === true,

--- a/test/playwright/component/dashboard/DockSplitterLivePreview.spec.mjs
+++ b/test/playwright/component/dashboard/DockSplitterLivePreview.spec.mjs
@@ -1,0 +1,212 @@
+import {test, expect} from '@playwright/test';
+
+/**
+ * The live conserved-pair preview contract — rendered tier, real pointer.
+ *
+ * Drives an actual drag against real projected geometry: both panes must track the pointer
+ * complementarily DURING the gesture (pair total constant, no proxy), the committed document must
+ * equal the final previewed geometry exactly (terminal parity — no jump), Escape must restore the
+ * exact pre-drag layout with zero commit, and the `liveResize: false` opt-out must keep panes
+ * static mid-gesture while the pointer-delta terminal still commits. The worker-tier math lives in
+ * `test/playwright/unit/dashboard/DockSplitterLivePreview.spec.mjs`; heavy-content journeys ride
+ * the external whitebox battery.
+ */
+
+let containerId;
+
+const DOC = {
+    schema: 'neo.dock.zone.v1',
+    root  : 'split-1',
+    items : {
+        alpha: {componentRef: 'alpha', title: 'Alpha'},
+        beta : {componentRef: 'beta',  title: 'Beta'}
+    },
+    nodes: {
+        'split-1': {type: 'split', orientation: 'horizontal', children: ['zone-a', 'zone-b'], sizes: [0.5, 0.5]},
+        'zone-a' : {type: 'tabs', items: ['alpha'], activeItemId: 'alpha'},
+        'zone-b' : {type: 'tabs', items: ['beta'],  activeItemId: 'beta'}
+    }
+};
+
+const mount = async (page, splitterConfig = {}, containerConfig = {}) => {
+    const result = await page.evaluate(async ({doc, cfg, box}) => {
+        const container = await Neo.worker.App.createNeoInstance({
+            importPath: '../dashboard/dock/projection/LayoutAdapter.mjs',
+            ntype     : 'container',
+            height    : 300,
+            layout    : {ntype: 'hbox', align: 'stretch'},
+            parentId  : 'dock-splitter-test-viewport',
+            width     : 606,
+            ...box,
+            items     : [
+                {ntype: 'component', id: 'lp-a', flex: 1, style: {background: '#223'}},
+                {
+                    ntype        : 'dashboard-dock-splitter',
+                    id           : 'lp-s',
+                    boundaryIndex: 0,
+                    // the adapter stamps projected splitters out of the split-children set at
+                    // projection time; the fixture mirrors that construct-time reality (a late
+                    // stamp would leave the eager zone registration self-countered — the class
+                    // guard turns that into no-preview rather than a frozen one)
+                    dockNodeType    : 'splitter',
+                    dockZoneDocument: doc,
+                    orientation     : 'horizontal',
+                    splitNodeId     : 'split-1',
+                    ...cfg
+                },
+                {ntype: 'component', id: 'lp-b', flex: 1, style: {background: '#232'}}
+            ]
+        });
+
+        if (!container.success) throw new Error(`container: ${container.error.message}`);
+
+        return {containerId: container.id}
+    }, {doc: DOC, cfg: splitterConfig, box: containerConfig});
+
+    await page.waitForSelector('#lp-s', {state: 'attached'});
+    return result
+};
+
+// worker getConfigs returns POSITIONAL values for array keys — zip them into a keyed map
+const getConfigs = async (page, id, keys) => {
+    const values = await page.evaluate(
+        ({id, keys}) => Neo.worker.App.getConfigs({id, keys}), {id, keys});
+    return Object.fromEntries(keys.map((key, index) => [key, values[index]]))
+};
+
+const rects = async page => ({
+    a: await page.locator('#lp-a').boundingBox(),
+    b: await page.locator('#lp-b').boundingBox()
+});
+
+// the Mouse sensor arms a drag only after delay(100ms) AND minDistance(5px) — a drive that moves
+// inside that window ends before the gesture officially starts and no drag:move ever fires
+const armDrag = async (page, cx, cy) => {
+    await page.mouse.move(cx, cy);
+    await page.mouse.down();
+    await page.waitForTimeout(130)
+};
+
+test.describe('Neo.dashboard.dock.interaction.DockSplitter — live pair preview, real pointer', () => {
+    test.setTimeout(60000);
+    test.use({viewport: {height: 800, width: 1200}});
+
+    test.beforeEach(async ({page}) => {
+        await page.goto('test/playwright/component/apps/dock-splitter/index.html');
+        await page.waitForSelector('#dock-splitter-test-viewport', {state: 'attached'})
+    });
+
+    test.afterEach(async ({page}) => {
+        containerId && await page.evaluate(id => Neo.worker.App.destroyNeoInstance(id), containerId);
+        containerId = null
+    });
+
+    test('both panes track the pointer complementarily; the commit equals the final preview', async ({page}) => {
+        ({containerId} = await mount(page));
+
+        const start = await rects(page),
+              total = start.a.width + start.b.width,
+              box   = await page.locator('#lp-s').boundingBox(),
+              cx    = box.x + box.width / 2,
+              cy    = box.y + box.height / 2;
+
+        await armDrag(page, cx, cy);
+        await page.mouse.move(cx + 40, cy, {steps: 8});
+
+        // mid-gesture: live complementary geometry, conserved total, no proxy element — and the
+        // committed document stays byte-identical while pointer frames run (no worker traffic)
+        const mid = await rects(page);
+        expect(mid.a.width).toBeGreaterThan(start.a.width + 30);
+        expect(mid.a.width + mid.b.width).toBeCloseTo(total, 0);
+        expect(await page.locator('.neo-dragproxy').count()).toBe(0);
+        expect((await getConfigs(page, 'lp-s', ['dockZoneDocument'])).dockZoneDocument.nodes['split-1'].sizes)
+            .toEqual([0.5, 0.5]);
+
+        await page.mouse.up();
+
+        // terminal parity: the committed fractions equal the final previewed pair exactly
+        await expect.poll(async () =>
+            (await getConfigs(page, 'lp-s', ['dockZoneDocument'])).dockZoneDocument.nodes['split-1'].sizes[0]
+        ).toBeCloseTo(mid.a.width / (mid.a.width + mid.b.width), 3);
+
+        // retained pixels: release does not jump the panes away from the last preview
+        const end = await rects(page);
+        expect(Math.abs(end.a.width - mid.a.width)).toBeLessThanOrEqual(1.5);
+        expect(end.a.width + end.b.width).toBeCloseTo(total, 0)
+    });
+
+    test('the vertical axis mirrors the contract: stacked panes track complementarily and commit exact heights', async ({page}) => {
+        ({containerId} = await mount(page, {orientation: 'vertical'}, {
+            height: 606,
+            layout: {ntype: 'vbox', align: 'stretch'},
+            width : 300
+        }));
+
+        const start = await rects(page),
+              total = start.a.height + start.b.height,
+              box   = await page.locator('#lp-s').boundingBox(),
+              cx    = box.x + box.width / 2,
+              cy    = box.y + box.height / 2;
+
+        await armDrag(page, cx, cy);
+        await page.mouse.move(cx, cy + 40, {steps: 8});
+
+        const mid = await rects(page);
+        expect(mid.a.height).toBeGreaterThan(start.a.height + 30);
+        expect(mid.a.height + mid.b.height).toBeCloseTo(total, 0);
+
+        await page.mouse.up();
+
+        await expect.poll(async () =>
+            (await getConfigs(page, 'lp-s', ['dockZoneDocument'])).dockZoneDocument.nodes['split-1'].sizes[0]
+        ).toBeCloseTo(mid.a.height / (mid.a.height + mid.b.height), 3)
+    });
+
+    test('Escape mid-gesture restores the exact pre-drag layout and commits nothing', async ({page}) => {
+        ({containerId} = await mount(page));
+
+        const start = await rects(page),
+              box   = await page.locator('#lp-s').boundingBox(),
+              cx    = box.x + box.width / 2,
+              cy    = box.y + box.height / 2;
+
+        await armDrag(page, cx, cy);
+        await page.mouse.move(cx + 50, cy, {steps: 8});
+
+        expect((await rects(page)).a.width).toBeGreaterThan(start.a.width + 40);
+
+        await page.keyboard.press('Escape');
+
+        await expect.poll(async () => (await rects(page)).a.width).toBeCloseTo(start.a.width, 0);
+
+        const after = await rects(page);
+        expect(after.b.width).toBeCloseTo(start.b.width, 0);
+
+        const doc = (await getConfigs(page, 'lp-s', ['dockZoneDocument'])).dockZoneDocument;
+        expect(doc.nodes['split-1'].sizes).toEqual([0.5, 0.5]);
+
+        await page.mouse.up()
+    });
+
+    test('liveResize: false keeps panes static mid-gesture; the pointer-delta terminal still commits', async ({page}) => {
+        ({containerId} = await mount(page, {liveResize: false}));
+
+        const start = await rects(page),
+              box   = await page.locator('#lp-s').boundingBox(),
+              cx    = box.x + box.width / 2,
+              cy    = box.y + box.height / 2;
+
+        await armDrag(page, cx, cy);
+        await page.mouse.move(cx + 40, cy, {steps: 8});
+
+        // deferred presentation: the committed geometry does not move under the pointer
+        const mid = await rects(page);
+        expect(mid.a.width).toBeCloseTo(start.a.width, 0);
+
+        await page.mouse.up();
+
+        await expect.poll(async () =>
+            (await getConfigs(page, 'lp-s', ['dockZoneDocument'])).dockZoneDocument.nodes['split-1'].sizes[0]
+        ).toBeGreaterThan(0.5)
+    });
+});

--- a/test/playwright/unit/dashboard/DockSplitter.spec.mjs
+++ b/test/playwright/unit/dashboard/DockSplitter.spec.mjs
@@ -47,7 +47,7 @@ const createParent = () => ({
         {dockNodeType: 'splitter', id: 'dock-splitter-placeholder'},
         {dockNodeType: 'tabs', flex: 0.3, id: 'right-component'}
     ],
-    getDomRect(ids) {
+    getLayoutRect(ids) {
         return Promise.resolve(ids.map(id => {
             if (id === 'dock-parent') {
                 return {height: 500, width: 1000, x: 0, y: 0}
@@ -90,7 +90,7 @@ const createEdgeParent = () => ({
         {dockNodeType: 'splitter', id: 'edge-splitter-placeholder'},
         {dockNodeType: 'tabs', flex: 1, id: 'center-component', vdom: {id: 'center-wrapper'}}
     ],
-    getDomRect(ids) {
+    getLayoutRect(ids) {
         return Promise.resolve(ids.map(id => {
             if (id === 'edge-parent') return {height: 600, width: 1000, x: 0, y: 0};
             if (id === 'left-component') return {height: 600, width: 200, x: 0, y: 0};

--- a/test/playwright/unit/dashboard/DockSplitterEquivalence.spec.mjs
+++ b/test/playwright/unit/dashboard/DockSplitterEquivalence.spec.mjs
@@ -84,13 +84,13 @@ test.describe('Neo.dashboard.dock.interaction.DockSplitter — behavior equivale
         expect(splitter.getSplitChildItems().map(item => item.id)).toEqual(['equiv-pane-a', 'equiv-pane-b']);
 
         // rect arm: deterministic child geometry, splitter excluded from the vector
-        container.getDomRect = async () => [{width: 600}, {width: 250}, {width: 350}];
+        container.getLayoutRect = async () => [{width: 600}, {width: 250}, {width: 350}];
         let state = await splitter.captureDragStart({clientX: 300, clientY: 150});
         expect(state.clientX).toBe(300);
         expect(state.sizes).toEqual([250, 350]);
 
         // fallback arm: a failed rect read degrades to flex weights, never throws
-        container.getDomRect = async () => { throw new Error('detached') };
+        container.getLayoutRect = async () => { throw new Error('detached') };
         state = await splitter.captureDragStart({clientX: 310, clientY: 150});
         expect(state.sizes).toEqual([1, 2])
     });
@@ -188,7 +188,7 @@ test.describe('Neo.dashboard.dock.interaction.DockSplitter — behavior equivale
 
         const zoneStarts = [];
         splitter.dragZone.dragStart = data => zoneStarts.push(data);
-        container.getDomRect = async () => [{width: 600}, {width: 300}, {width: 300}];
+        container.getLayoutRect = async () => [{width: 600}, {width: 300}, {width: 300}];
 
         await splitter.onDragStart({clientX: 300, clientY: 150});
 
@@ -202,7 +202,7 @@ test.describe('Neo.dashboard.dock.interaction.DockSplitter — behavior equivale
         let release;
         const zoneStarts = [];
         splitter.dragZone.dragStart = data => zoneStarts.push(data);
-        container.getDomRect = () => new Promise(resolve => {
+        container.getLayoutRect = () => new Promise(resolve => {
             release = () => resolve([{width: 600}, {width: 300}, {width: 300}])
         });
 
@@ -222,7 +222,7 @@ test.describe('Neo.dashboard.dock.interaction.DockSplitter — behavior equivale
         let release;
         const zoneStarts = [];
         splitter.dragZone.dragStart = data => zoneStarts.push(data);
-        container.getDomRect = () => new Promise(resolve => {
+        container.getLayoutRect = () => new Promise(resolve => {
             release = () => resolve([{width: 600}, {width: 300}, {width: 300}])
         });
 
@@ -240,7 +240,7 @@ test.describe('Neo.dashboard.dock.interaction.DockSplitter — behavior equivale
 
         const releases = [], zoneStarts = [];
         splitter.dragZone.dragStart = data => zoneStarts.push(data);
-        container.getDomRect = () => new Promise(resolve => {
+        container.getLayoutRect = () => new Promise(resolve => {
             releases.push(() => resolve([{width: 600}, {width: 300}, {width: 300}]))
         });
 
@@ -262,7 +262,7 @@ test.describe('Neo.dashboard.dock.interaction.DockSplitter — behavior equivale
         splitter.onDockZoneDocumentChange = (document, descriptor) => commits.push(descriptor);
         splitter.on('dockSplitterResizeRejected', payload => rejected.push(payload));
         splitter.dragZone.dragStart = data => zoneStarts.push(data);
-        container.getDomRect = () => new Promise(resolve => {
+        container.getLayoutRect = () => new Promise(resolve => {
             release = () => resolve([{width: 600}, {width: 300}, {width: 300}])
         });
 
@@ -286,7 +286,7 @@ test.describe('Neo.dashboard.dock.interaction.DockSplitter — behavior equivale
         const zoneEnds = [];
         splitter.dragZone.dragStart = async () => { splitter.dragGeneration++ };
         splitter.dragZone.dragEnd   = data => zoneEnds.push(data);
-        container.getDomRect = async () => [{width: 600}, {width: 300}, {width: 300}];
+        container.getLayoutRect = async () => [{width: 600}, {width: 300}, {width: 300}];
 
         await splitter.onDragStart({clientX: 300, clientY: 150});
 

--- a/test/playwright/unit/dashboard/DockSplitterEquivalence.spec.mjs
+++ b/test/playwright/unit/dashboard/DockSplitterEquivalence.spec.mjs
@@ -294,22 +294,29 @@ test.describe('Neo.dashboard.dock.interaction.DockSplitter — behavior equivale
         expect(zoneEnds[0]).toMatchObject({cancelled: true})
     });
 
-    test('the resize seam stays parked: no main-thread descriptor in either proxy mode', async () => {
-        mount();
+    test('the resize seam is live by default: conserved-pair descriptor, proxy fallback on opt-out', async () => {
+        mount({dockZoneDocument: DOC()});
 
-        // dock inherits the generic default: proxy presentation until the live-preview leaf lands
-        expect(splitter.liveResize).toBe(false);
-        expect(splitter.getResizeConfig()).toBe(null);
+        // the dock default flips the inherited proxy presentation to the main-thread pair preview
+        expect(splitter.liveResize).toBe(true);
+        expect(splitter.getResizeConfig()).toMatchObject({
+            axis           : 'width',
+            counterTargetId: 'equiv-pane-b',
+            preview        : true,
+            resizeNext     : false,
+            targetId       : 'equiv-pane-a'
+        });
 
         const pushed = [];
         splitter.dragZone.set = config => pushed.push(config);
 
         await splitter.refreshDragZone();
-        splitter.liveResize = true;               // afterSet re-drives the zone on its own
+        splitter.liveResize = false;              // afterSet re-drives the zone on its own
         await splitter.refreshDragZone();
 
-        expect(pushed[0]).toMatchObject({resizeConfig: null, useProxy: true});
-        expect(pushed.at(-1)).toMatchObject({resizeConfig: null, useProxy: false})
+        expect(pushed[0].useProxy).toBe(false);
+        expect(pushed[0].resizeConfig).toMatchObject({counterTargetId: 'equiv-pane-b', targetId: 'equiv-pane-a'});
+        expect(pushed.at(-1)).toMatchObject({resizeConfig: null, useProxy: true})
     });
 
     test('the descriptor factory resolves identity from configs when no projected data exists', () => {

--- a/test/playwright/unit/dashboard/DockSplitterLivePreview.spec.mjs
+++ b/test/playwright/unit/dashboard/DockSplitterLivePreview.spec.mjs
@@ -1,0 +1,157 @@
+import {setup} from '../../setup.mjs';
+
+setup({
+    appConfig: {
+        name: 'NeoDashboardDockSplitterLivePreviewTest'
+    }
+});
+
+import {test, expect} from '@playwright/test';
+import Neo            from '../../../../src/Neo.mjs';
+import * as core      from '../../../../src/core/_export.mjs';
+
+/**
+ * The live conserved-pair preview contract — worker tier.
+ *
+ * The main thread previews the adjacent pair (complementary sizes, constant total, both members'
+ * CSS bounds intersected) and reports one CSS-bounded terminal pixel value; this tier pins what the
+ * App Worker does with that report: the terminal wins over pointer arithmetic so the committed
+ * vector equals the final preview by construction, the pointer-delta fallback still carries the
+ * proxy presentation, and a live-preview rejection re-projects the unchanged committed document.
+ * (The rendered component tier drives the real pointer against real projected geometry.)
+ */
+test.describe('Neo.dashboard.dock.interaction.DockSplitter — live pair preview', () => {
+    let Container, DockSplitter, container, splitter;
+
+    const DOC = () => ({
+        schema: 'neo.dock.zone.v1',
+        root  : 'split-1',
+        items : {
+            alpha: {componentRef: 'alpha', title: 'Alpha'},
+            beta : {componentRef: 'beta',  title: 'Beta'}
+        },
+        nodes: {
+            'split-1': {type: 'split', orientation: 'horizontal', children: ['zone-a', 'zone-b'], sizes: [0.5, 0.5]},
+            'zone-a' : {type: 'tabs', items: ['alpha'], activeItemId: 'alpha'},
+            'zone-b' : {type: 'tabs', items: ['beta'],  activeItemId: 'beta'}
+        }
+    });
+
+    test.beforeAll(async () => {
+        Container    = (await import('../../../../src/container/Base.mjs')).default;
+        DockSplitter = (await import('../../../../src/dashboard/dock/interaction/DockSplitter.mjs')).default
+    });
+
+    const mount = (splitterConfig = {}) => {
+        container = Neo.create(Container, {
+            layout: {ntype: 'hbox', align: 'stretch'},
+            items : [
+                {ntype: 'component', flex: 1, id: 'live-pane-a'},
+                {
+                    module       : DockSplitter,
+                    id           : 'live-splitter',
+                    boundaryIndex: 0,
+                    orientation  : 'horizontal',
+                    splitNodeId  : 'split-1',
+                    ...splitterConfig
+                },
+                {ntype: 'component', flex: 1, id: 'live-pane-b'}
+            ]
+        });
+
+        splitter = container.items[1];
+        splitter.dockNodeType = 'splitter';
+        splitter.dragZone = {
+            destroy() {}, dragEnd() {}, dragStart() {}, isDestroyed: false,
+            async registerZone() {}, set() {}
+        };
+        container.getDomRect = async () => [{width: 600}, {width: 300}, {width: 300}];
+        return splitter
+    };
+
+    test.afterEach(() => {
+        container?.destroy();
+        container = splitter = null
+    });
+
+    test('the terminal pixel report wins over pointer arithmetic: committed vector equals the final preview', async () => {
+        mount({dockZoneDocument: DOC()});
+
+        await splitter.captureDragStart({clientX: 300, clientY: 150});
+
+        // the pointer travelled +199px, but the preview clamped/painted 340px last — 340 must commit
+        const result = splitter.onDragEnd({clientX: 499, clientY: 150, resizeSize: 340});
+
+        expect(result.errors).toEqual([]);
+
+        const sizes = splitter.dockZoneDocument.nodes['split-1'].sizes;
+        expect(sizes[0]).toBeCloseTo(340 / 600, 5);
+        expect(sizes[1]).toBeCloseTo(260 / 600, 5);
+        expect(sizes[0] + sizes[1]).toBeCloseTo(1, 5)
+    });
+
+    test('without a terminal report the pointer-delta fallback carries the proxy presentation', async () => {
+        mount({dockZoneDocument: DOC(), liveResize: false});
+
+        await splitter.captureDragStart({clientX: 300, clientY: 150});
+
+        const result = splitter.onDragEnd({clientX: 400, clientY: 150});
+
+        expect(result.errors).toEqual([]);
+        expect(splitter.dockZoneDocument.nodes['split-1'].sizes[0]).toBeCloseTo(400 / 600, 5)
+    });
+
+    test('pair terminals settle the main thread: restore on refusal, release on success, silence without a generation', async () => {
+        const drive = async (config, terminal) => {
+            const settles = [];
+
+            mount({
+                dockZoneDocument: DOC(),
+                ...config
+            });
+            splitter.dragZone.settleResize = data => settles.push(data);
+
+            await splitter.captureDragStart({clientX: 300, clientY: 150});
+            splitter.onDragEnd({clientX: 400, clientY: 150, ...terminal});
+
+            const calls = settles.slice();
+            container.destroy();
+            container = splitter = null;
+            return calls
+        };
+
+        // refusal: the generation-scoped snapshot must be restored — main painted preview pixels
+        const rejected = await drive(
+            {applyDockZoneOperation: () => ({document: null, errors: ['rejected']})},
+            {resizeGeneration: 3, resizeSize: 340, resizeTargetId: 'live-pane-a'}
+        );
+        expect(rejected).toEqual([{resizeGeneration: 3, resizeTargetId: 'live-pane-a', restore: true}]);
+
+        // success: the snapshot is released, never restored — the preview pixels ARE the outcome
+        const adopted = await drive({}, {resizeGeneration: 4, resizeSize: 340, resizeTargetId: 'live-pane-a'});
+        expect(adopted).toEqual([{resizeGeneration: 4, resizeTargetId: 'live-pane-a', restore: false}]);
+
+        // a terminal without a settlement generation (proxy presentation) never calls settle
+        const proxy = await drive({liveResize: false}, {});
+        expect(proxy).toEqual([])
+    });
+
+    test('opting back into liveResize at runtime re-registers the pair descriptor', async () => {
+        mount({liveResize: false});
+
+        const pushed = [];
+        splitter.dragZone.set = config => pushed.push(config);
+
+        expect(splitter.getResizeConfig()).toBe(null);
+
+        splitter.liveResize = true;               // afterSet re-drives the zone on its own
+        await splitter.refreshDragZone();
+
+        expect(pushed.at(-1).useProxy).toBe(false);
+        expect(pushed.at(-1).resizeConfig).toMatchObject({
+            counterTargetId: 'live-pane-b',
+            preview        : true,
+            targetId       : 'live-pane-a'
+        })
+    });
+});

--- a/test/playwright/unit/dashboard/DockSplitterLivePreview.spec.mjs
+++ b/test/playwright/unit/dashboard/DockSplitterLivePreview.spec.mjs
@@ -65,7 +65,7 @@ test.describe('Neo.dashboard.dock.interaction.DockSplitter — live pair preview
             destroy() {}, dragEnd() {}, dragStart() {}, isDestroyed: false,
             async registerZone() {}, set() {}
         };
-        container.getDomRect = async () => [{width: 600}, {width: 300}, {width: 300}];
+        container.getLayoutRect = async () => [{width: 600}, {width: 300}, {width: 300}];
         return splitter
     };
 
@@ -134,6 +134,36 @@ test.describe('Neo.dashboard.dock.interaction.DockSplitter — live pair preview
         // a terminal without a settlement generation (proxy presentation) never calls settle
         const proxy = await drive({liveResize: false}, {});
         expect(proxy).toEqual([])
+    });
+
+    test('capture measures the same outer layout boxes the descriptor registers: custom roots, transform-immune', async () => {
+        mount();
+
+        // custom vdom roots: the public id lives on an inner node; the WRAPPER participates in
+        // layout — descriptor and capture must both speak wrapper ids, or preview and commit
+        // reason about different boxes
+        container.vdom.id        = 'wrap-parent';
+        container.items[0].vdom.id = 'wrap-a';
+        container.items[2].vdom.id = 'wrap-b';
+
+        const requested = [],
+              layout    = {'wrap-parent': {width: 600}, 'wrap-a': {width: 220}, 'wrap-b': {width: 380}};
+
+        // the discriminator: only wrapper ids resolve to layout truth — an inner-id request
+        // (the pre-fix basis) would fall through to the zero shape and fail the size asserts
+        container.getLayoutRect = async ids => {
+            requested.push(...ids);
+            return ids.map(id => layout[id] || {width: 0})
+        };
+
+        const descriptor = splitter.getResizeConfig(),
+              state      = await splitter.captureDragStart({clientX: 300, clientY: 150});
+
+        expect(requested).toEqual(['wrap-parent', 'wrap-a', 'wrap-b']);
+        expect([descriptor.parentId, descriptor.targetId, descriptor.counterTargetId])
+            .toEqual(['wrap-parent', 'wrap-a', 'wrap-b']);
+        expect(state.sizes).toEqual([220, 380]);
+        expect(state.parentSize).toBe(600)
     });
 
     test('opting back into liveResize at runtime re-registers the pair descriptor', async () => {


### PR DESCRIPTION
Resolves #17820

Dock split boundaries now preview live: both model-order children around `boundaryIndex` track the pointer complementarily on the main thread — their total constant per frame by construction, the clamp window the intersection of BOTH members' CSS bounds under that total — and the committed vector equals the final previewed geometry exactly, because the terminal's CSS-bounded pixel report wins over pointer arithmetic. `liveResize: true` is the dock default (edge bands and split boundaries both proxy-free; `false` restores the deferred proxy-and-commit presentation). Pointer frames never cross the worker boundary; the committed document remains the sole size authority; exactly one `resizeSplit` commits at a successful terminal. The pair opts into the settlement seam the semantics leaf shipped: refusal, cancel, and thrown commits restore both captured snapshots through the single restoration authority, and a stale verdict can never touch a successor gesture.

Related: #17836
Related: #17838 (the settlement seam this consumes)
Related: #17819 / #17822 (the generic main-thread mechanism)

Evidence: L3 achieved locally (headed rendered real-pointer battery at the component tier + the worker-tier contract suite; receipts below) → L3 required (real-drag tracking, terminal parity/no-jump, Escape restoration ACs). Residual: the heavy-grid Workstation/example repeated-drag journeys (whitebox NL tier), Residual-Owner: #17844 — the external-Brain-gated battery that already owns dock whitebox evidence at ≥ the v13.2 merge line; the close-target AC carries the matching deferred-evidence annotation.

## AC Evidence

| AC | Proof |
|---|---|
| `liveResize: true` default, no drag proxy | Unit: the equivalence suite's live-default contract (pair descriptor emitted, `useProxy: false` pushed, opt-out registers `null`). Rendered: `.neo-dragproxy` count asserted 0 mid-gesture |
| A real drag continuously updates only the adjacent pair; the splitter follows their boundary | Rendered real-pointer witness: pane A tracks +40px of pointer travel mid-gesture while the pair total stays conserved; the splitter is a flex sibling, so the moving boundary carries it |
| Both axes preserve the adjacent pair's total | Rendered horizontal AND vertical drives assert complementary tracking with the total closeTo start; on the main thread conservation is arithmetic (`value` / `pairTotal − value` written in the same frame), not a hoped-for outcome |
| Document, saved layouts, perspective state byte-identical during move frames | Structural: preview never leaves the main thread (zero per-frame worker traffic). Witnessed: the rendered tracking test reads the committed document mid-gesture and asserts `[0.5, 0.5]` unchanged |
| Successful release commits exactly one `resizeSplit` matching the final preview; re-projection does not jump | Unit terminal-parity: `data.resizeSize` (the last CSS-bounded painted value) wins over contradictory pointer arithmetic, conservation exact. Rendered: committed fractions equal the final previewed ratio to 3 decimals, and post-release pane rects stay within 1.5px of the last preview |
| Escape, rejected vectors, destruction restore exact pre-drag styles, commit nothing, leave no residue | Rendered Escape witness: exact-width restoration + `[0.5, 0.5]` document + a still-armed gesture surface. Rejection: the pair's settlement contract (unit: `restore: true` on refusal, `restore: false` release on success, silence without a generation) riding the mechanism the merged semantics leaf witnessed at three tiers; `restoreState` extends to the counter snapshot so every restoration site covers both panes. Destruction: the equivalence suite's destroy-mid-gesture and destroy-during-capture witnesses |
| `liveResize: false` retains the proxy-and-commit interaction | Rendered: panes provably static mid-gesture, pointer-delta terminal still commits. Unit: the fallback vector path and the opt-out registration contract |
| Standalone example + Workstation real-pointer repeated drags with Grid/TreeGrid panes | DEFERRED — the residual above (#17844's battery; annotation on the close-target AC). The standalone example needs no code: the affordance is class-default, so its splitters preview live at this head |
| Existing proxy-paint, zone/cancel, sizing, and motion witnesses remain green | Composed batteries at this head: unit dashboard 602/602, component dashboard + heavy-content cadence 24/24 (paint, rails, equivalence pair, reveal suite included) |

## Deltas from ticket

- **The mechanism premise was re-shaped on-ticket before implementation** (the premise-alignment comment): the blocker landed as a MAIN-THREAD preview, so Fix steps 2–4's worker `drag:move` framing inverted into the conserved-pair extension of the main-thread descriptor, and the "no parallel main-thread resize system" bullet now cuts the other way. The falsification window closed silent; plan-of-record stood.
- **The pair consumes the settlement seam** the semantics leaf shipped after this ticket was authored: rejection-restore is settlement-based (not view-sync re-projection), and the terminal settle call is un-gated from edge-only — the generation guard inside `settleMainThreadResize` scopes it to opted-in gestures.
- **A splitter can never register itself as its own pair member** — a consumer stamping `dockNodeType` after construct would otherwise eagerly register a self-countered descriptor whose bound-fold pins the clamp window shut; the guard converts a frozen preview into no-preview, and the per-gesture refresh re-registers the corrected pair.
- **Proxy-token projection is skipped when no proxy will mount** — one main-thread round trip saved per live gesture.
- **Both members' CSS min/max bounds fold into one clamp window** under the constant pair total (reusing the shipped `resolveCssBound`), so every previewed frame is a vector the semantic commit can reproduce.

## Test Evidence

OUTSIDE-CI receipts at this head: rendered real-pointer battery 4/4 headed (`DockSplitterLivePreview` component tier — tracking + byte-stability, vertical axis, Escape restoration, proxy opt-out; drives are sensor-armed past the Mouse sensor's delay+minDistance gate, documented in-spec) and the full component dashboard + `SplitterHeavyContent` cadence sweep 24/24 (the generic single-target path is byte-compatible). CI carries the worker-tier suites: unit dashboard 602/602 including the 4-test pair contract (`DockSplitterLivePreview` unit tier) and the equivalence suite's race witnesses. The two fixture lessons that cost the diagnostic arc — sensor arming, and the adapter-load requirement for the global-namespace descriptor factory — are recorded as in-spec comments where the next author will trip on them.

## Post-Merge Validation

- [ ] Heavy-grid Workstation/example repeated-drag journeys at ≥ this merge SHA via the #17844 whitebox battery (the declared residual).

## Signal Ledger

- **GPT family — AUTHOR_SIGNAL:** @neo-gpt at the graduated D#17818 body (`DC_kwDODSospM4BFZu7`); #17820 is his authored leaf of that graduation, delivered here by its claimer.
- **Claude family — GRADUATION_APPROVED:** @neo-opus-vega (`DC_kwDODSospM4BFZuy`) + staleness/quorum confirmation (`DC_kwDODSospM4BFZvb`) + OQ7 exact-source revalidation (`DC_kwDODSospM4BFaDl`).
- **Family-keyed quorum:** met at graduation; epic #17836 carries the full ledger. This PR delivers the epic's third Engine leaf under that authority.

## Unresolved Dissent

None — the premise-alignment comment on the close target opened a falsification window on the mechanism re-shape (Tier-2.5, ticket author notified directly); it closed without dissent and the author's stacked work built against the aligned shape.

## Unresolved Liveness

None blocking — same disposition as the sibling leaves (#17841/#17845): active families signaled at graduation; this is not a Tier-2 substrate change.

## Commits

- d316cbeff4 — the conserved-pair mechanism: main-thread counter target + bound-fold + pair restoration authority; dock default flip, pair descriptor with settlement opt-in, terminal parity, self-counter guard
- 447fe4a3fa — the two-tier witness battery: worker contract (parity, fallback, settlement, opt-in) + rendered real-pointer (tracking/byte-stability, vertical axis, Escape, proxy opt-out) + equivalence census evolution

Authored by Mnemosyne (Claude Fable 5, Claude Code). Session c98e1ede-1a32-46f3-90ef-aaf37def487d. 🪢
