### PR TITLE
fix(menu): a leaf click closes the whole menu tree again (#17850)

### DIFF
--- a/src/menu/List.mjs
+++ b/src/menu/List.mjs
@@ -516,7 +516,24 @@ class List extends BaseList {
 
             // hasChildren() is the single branch predicate: it is store-shape aware, and it does not
             // treat an empty `items: []` array as a parent the way a raw truthiness test would.
-            me.hideOnLeafItemClick && !hasChildren && me.unmount();
+            if (me.hideOnLeafItemClick && !hasChildren) {
+                /*
+                    Through the SETTER, and that is the whole point. `afterSetMenuFocus` is the only
+                    path that closes ANCESTORS: a non-root menu bubbles to `parentMenu`, recursing
+                    until the floating root unmounts itself and cascades back down via `hideSubMenu()`.
+
+                    `unmount()` writes `_menuFocus` silently on purpose — reaching it *from*
+                    `afterSetMenuFocus` must not re-enter that hook. But a leaf click reaches
+                    `unmount()` directly, so calling it first swallowed the only signal the ancestors
+                    ever get, and left the submenu closed under a still-open parent. It also disarmed
+                    the fallback: a later `menuFocus = false` from `onFocusLeave` found the value
+                    already false, so the setter fired nothing.
+                */
+                me.menuFocus = false;
+
+                // The root's cascade may already have taken this menu down.
+                me.mounted && me.unmount()
+            }
 
             if (hasChildren) {
                 submenu = me.subMenuMap?.[me.getMenuMapId(recordId)];

--- a/test/playwright/component/menu/List.spec.mjs
+++ b/test/playwright/component/menu/List.spec.mjs
@@ -1,0 +1,143 @@
+import {test, expect} from '@playwright/test';
+
+let menuId;
+
+/**
+ * @summary The three-level tree the cascade is measured on.
+ *
+ * Depth two on purpose: at depth one the clicked menu IS the root, so closing only itself passes by
+ * accident. `Copy name` sits two levels below the root, and a correct dismissal has to travel up
+ * through `Details` and `Inspect` before it can come back down.
+ * @type {Object[]}
+ */
+const items = [{
+    id  : 'open',
+    text: 'Open'
+}, {
+    id   : 'inspect',
+    items: [{
+        id   : 'details',
+        items: [{
+            id  : 'copy-name',
+            text: 'Copy name'
+        }],
+        text: 'Details'
+    }],
+    text: 'Inspect'
+}];
+
+/**
+ * @summary Creates the floating root menu inside the component harness app.
+ * @param {Object} page
+ * @param {Object} [config] Merged over the defaults, e.g. `{hideOnLeafItemClick: false}`
+ * @returns {Promise<String>} The root menu id
+ */
+async function createMenu(page, config={}) {
+    const result = await page.evaluate(instanceConfig => {
+        return Neo.worker.App.createNeoInstance(instanceConfig)
+    }, {
+        align       : {axisLock: true, edgeAlign: 't0-b0', target: {x: 40, y: 40, width: 0, height: 0}},
+        displayField: 'text',
+        floating    : true,
+        importPath  : '../menu/List.mjs',
+        items,
+        ntype       : 'menu-list',
+        parentId    : 'component-test-viewport',
+        ...config
+    });
+
+    if (!result.success) {
+        throw new Error(`Component creation failed: ${result.error.message}`)
+    }
+
+    return result.id
+}
+
+/**
+ * @summary Walks the real tree open with pointer input, leaving focus on the leaf.
+ * @param {Object} page
+ * @returns {Promise<void>}
+ */
+async function openToLeaf(page) {
+    const menus = page.locator('.neo-menu-list');
+
+    await expect(menus).toHaveCount(1);
+    await page.getByText('Inspect', {exact: true}).click();
+    await expect(menus).toHaveCount(2);
+    await page.getByText('Details', {exact: true}).click();
+    await expect(menus).toHaveCount(3)
+}
+
+/**
+ * @summary Starts recording how many menu levels stand, on every DOM mutation batch.
+ *
+ * A settled assertion cannot witness this defect. `expect(locator).toHaveCount(0)` is web-first: it
+ * re-polls until the timeout, so it reports the tree that eventually stands, not the tree the click
+ * produced. The regression closed the clicked submenu on its own and left two ancestors mounted until
+ * a later focus round-trip swept them up — under a retrying assertion that is a pass, and it is how
+ * the defect reached `dev` with the suites green. Recording every intermediate state instead makes
+ * the lingering ancestors the observation rather than a state polled past.
+ * @param {Object} page
+ * @returns {Promise<void>}
+ */
+function recordLevelCounts(page) {
+    return page.evaluate(() => {
+        const count = () => document.querySelectorAll('.neo-menu-list').length;
+
+        window.__menuLevelCounts = [count()];
+
+        new MutationObserver(() => {
+            const current = count();
+
+            current !== window.__menuLevelCounts.at(-1) && window.__menuLevelCounts.push(current)
+        }).observe(document.body, {childList: true, subtree: true})
+    })
+}
+
+/**
+ * @summary Returns the recorded level-count transitions, newest last.
+ * @param {Object} page
+ * @returns {Promise<Number[]>}
+ */
+function levelCounts(page) {
+    return page.evaluate(() => window.__menuLevelCounts)
+}
+
+test.describe('Neo.menu.List leaf-click cascade', () => {
+    test.beforeEach(async ({page}) => {
+        await page.goto('test/playwright/component/apps/empty-viewport/index.html');
+        await page.waitForSelector('#component-test-viewport', {state: 'attached'})
+    });
+
+    test.afterEach(async ({page}) => {
+        if (menuId) {
+            await page.evaluate(id => Neo.worker.App.destroyNeoInstance(id), menuId);
+            menuId = null
+        }
+    });
+
+    test('a leaf click takes every level down together, with no ancestor left standing', async ({page}) => {
+        menuId = await createMenu(page);
+
+        await openToLeaf(page);
+        await recordLevelCounts(page);
+        await page.getByText('Copy name', {exact: true}).click();
+        await expect(page.locator('.neo-menu-list')).toHaveCount(0);
+
+        // Three levels stand, then none. Any value in between is an ancestor that outlived the
+        // submenu the click was in — exactly what the regression produced ([3, 2, 0]).
+        expect(await levelCounts(page)).toEqual([3, 0])
+    });
+
+    test('hideOnLeafItemClick: false keeps every level open', async ({page}) => {
+        menuId = await createMenu(page, {hideOnLeafItemClick: false});
+
+        await openToLeaf(page);
+        await recordLevelCounts(page);
+        await page.getByText('Copy name', {exact: true}).click();
+
+        // The policy gate governs the dismissal as a whole, so the tree never moves off three.
+        await expect(page.locator('.neo-menu-list')).toHaveCount(3);
+        expect(await levelCounts(page)).toEqual([3])
+    })
+});

--- a/test/playwright/e2e/rendering/ContextMenuNL.spec.mjs
+++ b/test/playwright/e2e/rendering/ContextMenuNL.spec.mjs
@@ -33,6 +33,33 @@ async function expectDismissed(page, app, menuId) {
 }
 
 /**
+ * @summary Starts recording how many menu levels stand, on every DOM mutation batch.
+ *
+ * Every settled assertion in this file is web-first and re-polls until the timeout, which is correct
+ * for the states they describe and blind to a transient one. The leaf-click cascade is transient: a
+ * dismissal that reaches only the clicked submenu still ends at zero menus, because a later focus
+ * round-trip sweeps the ancestors up — so `toHaveCount(0)` below reports the settled tree and passes
+ * either way. Measured, not inferred: that is how one such regression reached `dev` past this very
+ * assertion. Recording the transitions makes the lingering ancestors an observation instead of a
+ * state polled past.
+ * @param {Object} page
+ * @returns {Promise<void>}
+ */
+function recordLevelCounts(page) {
+    return page.evaluate(() => {
+        const count = () => document.querySelectorAll('.neo-menu-list').length;
+
+        window.__menuLevelCounts = [count()];
+
+        new MutationObserver(() => {
+            const current = count();
+
+            current !== window.__menuLevelCounts.at(-1) && window.__menuLevelCounts.push(current)
+        }).observe(document.body, {childList: true, subtree: true})
+    })
+}
+
+/**
  * @summary Opens or repositions the context menu with a real browser right click.
  * @param {Object} page
  * @param {Object} app
@@ -156,10 +183,15 @@ test.describe('Context Menu — real pointer + Neural Link', () => {
         expect(menuState).toMatchObject({hidden: false, mounted: true});
 
         // The real leaf click updates worker-owned state and follows Menu's leaf-dismissal policy.
+        await recordLevelCounts(page);
         await page.getByText('Copy name', {exact: true}).click();
         await expect(page.getByText('Last action: Copy name')).toBeVisible();
         await expect.poll(async () => (await getMainState(app)).lastAction).toBe('Copy name');
         await expect(page.locator('.neo-menu-list')).toHaveCount(0);
+
+        // Three levels stand, then none. Any value in between is an ancestor that outlived the submenu
+        // the click was in — a partial cascade records [3, 2, 0] here while the assertion above passes.
+        expect(await page.evaluate(() => window.__menuLevelCounts)).toEqual([3, 0]);
 
         // Reopen at a fresh point after the nested tree settled; identity stays stable and Escape closes it.
         await openAt(page, app, {x: 300, y: 240}, 8, menuId);

--- a/test/playwright/unit/menu/List.spec.mjs
+++ b/test/playwright/unit/menu/List.spec.mjs
@@ -40,6 +40,7 @@ setup({
 import {test, expect} from '@playwright/test';
 import Neo            from '../../../../src/Neo.mjs';
 import * as core      from '../../../../src/core/_export.mjs';
+import Instance       from '../../../../src/manager/Instance.mjs';
 import MenuList       from '../../../../src/menu/List.mjs';
 
 /**
@@ -187,6 +188,40 @@ test.describe('Neo.menu.List floating dismissal', () => {
         root.onKeyDownEscape({});
 
         expect(dismissals).toBe(3)
+    });
+
+    test('a leaf click inside a submenu dismisses the whole tree, not only its own level', () => {
+        const
+            root   = createMenu({floating: true, isRoot: true}),
+            level1 = createMenu({floating: true, isRoot: false, parentMenu: root}),
+            level2 = createMenu({floating: true, isRoot: false, parentMenu: level1});
+
+        menus.push(root, level1, level2);
+
+        // Added after construct, not as an `items` config: resolving items during initConfig reaches
+        // getController(), which needs a manager the unit harness does not stand up.
+        level2.store.add({text: 'Copy name'});
+        root._mounted = level1._mounted = level2._mounted = true;
+        root.subMenuMap   = {first: level1};
+        level1.subMenuMap = {second: level2};
+
+        let rootDismissals = 0,
+            leafDismissals = 0;
+
+        root.unmount   = () => rootDismissals++;
+        level2.unmount = () => leafDismissals++;
+
+        // Focus reaching the deepest level primes the whole chain — afterSetMenuFocus bubbles upwards.
+        level2.menuFocus = true;
+
+        expect(root.menuFocus).toBe(true);
+
+        level2.onKeyDownEnter(level2.getItemId(level2.store.getAt(0)));
+
+        // Depth 2 on purpose: at depth 1 the root IS the parent, so closing only the clicked menu
+        // passes by accident and the regression stays invisible.
+        expect(leafDismissals).toBe(1);
+        expect(rootDismissals).toBe(1)
     });
 
     test('removes the exact app-root listener during destroy', () => {

--- a/test/playwright/unit/menu/List.spec.mjs
+++ b/test/playwright/unit/menu/List.spec.mjs
@@ -190,38 +190,64 @@ test.describe('Neo.menu.List floating dismissal', () => {
         expect(dismissals).toBe(3)
     });
 
-    test('a leaf click inside a submenu dismisses the whole tree, not only its own level', () => {
+    /**
+     * @summary A root plus two descendant levels, wired so the real dismissal cascade can run.
+     *
+     * `activeSubMenu` is what `hideSubMenu()` follows, so it — not `subMenuMap` — is what makes an
+     * ancestor's `unmount()` reach its descendants. `Neo.applyDeltas` is stubbed by the unit setup,
+     * so no `unmount()` here needs replacing with a counter: the levels really do unmount, and
+     * `mounted` is the witness.
+     * @param {Object} [level2Config]
+     * @returns {Object}
+     */
+    function createTree(level2Config={}) {
         const
             root   = createMenu({floating: true, isRoot: true}),
             level1 = createMenu({floating: true, isRoot: false, parentMenu: root}),
-            level2 = createMenu({floating: true, isRoot: false, parentMenu: level1});
+            level2 = createMenu({floating: true, isRoot: false, parentMenu: level1, ...level2Config});
 
         menus.push(root, level1, level2);
 
         // Added after construct, not as an `items` config: resolving items during initConfig reaches
         // getController(), which needs a manager the unit harness does not stand up.
         level2.store.add({text: 'Copy name'});
+
         root._mounted = level1._mounted = level2._mounted = true;
-        root.subMenuMap   = {first: level1};
-        level1.subMenuMap = {second: level2};
-
-        let rootDismissals = 0,
-            leafDismissals = 0;
-
-        root.unmount   = () => rootDismissals++;
-        level2.unmount = () => leafDismissals++;
+        root.activeSubMenu   = level1;
+        level1.activeSubMenu = level2;
 
         // Focus reaching the deepest level primes the whole chain — afterSetMenuFocus bubbles upwards.
         level2.menuFocus = true;
 
+        return {root, level1, level2, leafNodeId: level2.getItemId(level2.store.getAt(0))}
+    }
+
+    test('a leaf click inside a submenu unmounts every level, not only its own', () => {
+        const {root, level1, level2, leafNodeId} = createTree();
+
         expect(root.menuFocus).toBe(true);
 
-        level2.onKeyDownEnter(level2.getItemId(level2.store.getAt(0)));
+        level2.onKeyDownEnter(leafNodeId);
 
-        // Depth 2 on purpose: at depth 1 the root IS the parent, so closing only the clicked menu
-        // passes by accident and the regression stays invisible.
-        expect(leafDismissals).toBe(1);
-        expect(rootDismissals).toBe(1)
+        // The regression left level1 and the root mounted while level2 closed under them, so the
+        // witness has to be every level's mounted state — counting that the root was TOLD to unmount
+        // would pass against exactly that bug. Depth 2 on purpose: at depth 1 the root IS the parent,
+        // so closing only the clicked menu passes by accident.
+        expect(level2.mounted).toBe(false);
+        expect(level1.mounted).toBe(false);
+        expect(root.mounted).toBe(false)
+    });
+
+    test('hideOnLeafItemClick: false leaves the whole tree mounted on a leaf click', () => {
+        const {root, level1, level2, leafNodeId} = createTree({hideOnLeafItemClick: false});
+
+        level2.onKeyDownEnter(leafNodeId);
+
+        // The policy gate still governs the new setter write, not just the unmount that follows it.
+        expect(level2.mounted).toBe(true);
+        expect(level1.mounted).toBe(true);
+        expect(root.mounted).toBe(true);
+        expect(root.menuFocus).toBe(true)
     });
 
     test('removes the exact app-root listener during destroy', () => {


### PR DESCRIPTION
Resolves #17850
Related: #17825, #17851

A leaf click inside a submenu ran its handler, unmounted that submenu, and left every menu above it open — an orphaned menu hanging over the app after the chosen action had already run. Regression from #17825, one line old.

Evidence: L3 (live three-level reproduction in `examples/menu/context/`, plus mutation-checked coverage in the unit, component and e2e tiers) → L3 required (the AC is observable menu state). Residual: none.

## The mechanism

`afterSetMenuFocus` is the only path that closes **ancestors**: a non-root menu bubbles to `parentMenu`, recursing until the floating root unmounts itself and cascades back down through `hideSubMenu()`.

`onKeyDownEnter` reached `unmount()` directly, and #17825 had added `this._menuFocus = false;` to `unmount()`. The underscore is the whole defect — it bypasses the config setter, so `afterSetMenuFocus` never runs and no ancestor is told. It also disarmed the fallback: `onFocusLeave` later writes `menuFocus = false` over an already-false value, the setter sees no change, and that hook stays silent too.

The silent write is correct where it sits — reaching `unmount()` *from* `afterSetMenuFocus` must not re-enter that hook — so it stays. The leaf-click path propagates through the setter first instead, and guards the follow-up on `mounted`, because the root's cascade may already have taken this level down.

## Why the suites were green when this landed

This regression reached `dev` past a full green run, so "the tests pass" was never going to be the case for merging it. Both reasons are measured, against `origin/dev` with the fix reverted.

**1. The unit tier cannot see the DOM.** The unit witness runs with `Neo.applyDeltas` stubbed. It asserts worker-side `mounted` on all three levels and it does fail on the unfixed source — but a user does not look at `mounted`.

**2. A browser witness written the obvious way ALSO passes on the regression.** `expect(page.locator('.neo-menu-list')).toHaveCount(0)` is a web-first assertion: it re-polls until the timeout. On the unfixed source the tree *does* reach zero, because a later focus round-trip sweeps the ancestors up. The settled state is identical with and without the fix.

`e2e/rendering/ContextMenuNL.spec.mjs` already carried exactly that assertion at exactly that step. Run against the reverted fix, **it passes** — so the one spec claiming to prove leaf-click dismissal was blind to this defect class before CI topology entered the picture at all.

The defect is the *transient*. Recording the level-count transitions across the click makes the lingering ancestors an observation instead of a state polled past:

```
unfixed: [3, 2, 0]     the clicked submenu closes alone; two ancestors stand
fixed  : [3, 0]        the whole tree goes together
```

## AC Evidence

| AC | Proof |
|---|---|
| AC-1 | Leaf click unmounts the submenu **and** every ancestor: the transition record is `[3, 0]`, with no intermediate. |
| AC-2 | Verified at depth 3, not 1 — `Copy name` sits inside `Details` inside `Inspect`. At depth 1 the root IS the parent, so closing only the clicked menu passes by accident. |
| AC-3 | Outside-pointer dismissal from #17825 intact: pointer-down outside → 0 menus. `isInteractionPath` and `onAppMouseDown` are untouched. |
| AC-4 | Root-menu leaf click still closes it — covered by the unchanged `hideOnLeafItemClick` path and the 5 pre-existing dismissal specs. |
| AC-5 | Three arms, each **red on the reverted fix and green with it**: unit `mounted` on all levels, new component spec, and `ContextMenuNL`. |
| AC-6 | `hideOnLeafItemClick: false` still suppresses the close — asserted in the unit and component tiers; the flag guards the whole block. |

## Test Evidence

**Component tier — new, and the one that closes the gap.** `test/playwright/component/menu/List.spec.mjs`: real main thread, real App worker, real pointer input, no Brain runtime. It lives here because this is a tier CI runs, on a path (`src/`) that triggers it.

```
fixed    2 passed
reverted 1 failed  ->  expect(levelCounts).toEqual([3, 0])
                       Received: [3, 2, 0]
         1 passed  (the hideOnLeafItemClick: false control, correctly green both ways)
```

**e2e tier —** `ContextMenuNL.spec.mjs` gains the same witness, so its cascade claim is now true. Run with `NEO_AGENTOS_RUNTIME_ROOT` wired to a Brain checkout:

```
fixed    1 passed
reverted 1 failed  ->  same assertion, Received: [3, 2, 0]
```

**Unit tier —** `test/playwright/unit/menu/List.spec.mjs` asserts `mounted` on all three levels plus an AC-6 control.

```
reverted 1 failed  ->  expect(level1.mounted).toBe(false)   Received: true
```

Every "reverted" run above used `git checkout origin/dev -- src/menu/List.mjs`, with the mutation asserted before the run (regressed one-liner present, setter write absent). An earlier revision of this PR claimed a `git stash`-based control; that control was hollow — the fix was already committed, so `stash push` moved nothing and the "unfixed" run exercised fixed code. The numbers above replace it.

Suites at this head: **components 82/82**, `unit/menu` **23/23**, `check-fixed-sleeps` / `check-jsdoc-types` / `check-spec-retirement` clean.

## Deltas from ticket

The ticket offered two candidate shapes and left the choice to whoever owns #17825. This implements **A — propagate before unmounting**, because B needs a re-entrancy guard flag to distinguish the bubble's own call from every other caller, and A needs none.

Two additions the ticket did not name:

- `test/playwright/unit/menu/List.spec.mjs` gains the `manager/Instance` import its sibling `ListTreeStore.spec.mjs` already carries. Without it, touching a store in that harness reaches `getController()` → `Neo.get`, which the unit setup does not stand up.
- The browser tiers above, added on operator direction after the fix was approved: unit coverage without a main thread is not sufficient evidence for this class.

## Out of scope, named

The e2e suite runs in **no CI workflow** — `test.yml`'s matrix is `unit` and `components` only, while `npm run test-e2e` exists and 83 specs sit behind it. That is why `ContextMenuNL`'s (blind) assertion was never even executed on a PR. Its own ticket; this PR does not change CI topology. Distinct from #17844, which owns *battery execution* of the NL-gated set against a Brain checkout and the receipts that come back — `ContextMenuNL` is in that set, and this PR changes what it asserts.

## Post-Merge Validation

None. Everything the ACs assert is reachable from this head.

Origin Session ID: 35fdecfd-9cae-44be-a727-de1bac27397f
