### PR TITLE
feat(menu): menu separators and the disabled field the renderer already honoured (#17851)

### DIFF
--- a/examples/menu/context/MainContainer.mjs
+++ b/examples/menu/context/MainContainer.mjs
@@ -128,6 +128,15 @@ class MainContainer extends Viewport {
                     text: 'Details'
                 }],
                 text: 'Inspect'
+            }, {
+                id       : 'sep-1',
+                separator: true
+            }, {
+                disabled: true,
+                handler : me.onLeafAction.bind(me, 'Delete'),
+                iconCls : 'fa fa-trash',
+                id      : 'delete',
+                text    : 'Delete (disabled)'
             }],
             parentId: 'document.body',
             theme   : me.theme,

--- a/examples/menu/context/neo-config.json
+++ b/examples/menu/context/neo-config.json
@@ -3,5 +3,6 @@
     "basePath"   : "../../../",
     "environment": "development",
     "mainPath"   : "./Main.mjs",
+    "themes"     : ["neo-theme-neo-dark", "neo-theme-neo-light", "neo-theme-dark", "neo-theme-light"],
     "useAiClient": true
 }

--- a/resources/scss/src/menu/List.scss
+++ b/resources/scss/src/menu/List.scss
@@ -54,6 +54,24 @@
             }
         }
 
+        // A rule between groups, not a row. It is drawn as the element's own box rather than as a
+        // border on the preceding item, because a border cannot be given breathing room: margin on
+        // the neighbour moves the whole row, leaving the rule flush against the next command.
+        //
+        // `margin` supplies both axes — the vertical value is the space above and below, the
+        // horizontal one insets the rule from the menu edges so it reads as a divider rather than a
+        // full-bleed edge. `pointer-events: none` is belt-and-braces: the record is already excluded
+        // from the click delegate and the navigator, so this only guarantees the hover background
+        // inherited above can never paint on something the user cannot activate.
+        &.neo-menu-separator {
+            background-color: var(--menu-separator-color);
+            height          : var(--menu-separator-thickness);
+            margin          : var(--menu-separator-margin) var(--menu-separator-inset);
+            min-height      : var(--menu-separator-thickness);
+            padding         : 0;
+            pointer-events  : none;
+        }
+
         &.neo-selected {
             background-color: var(--menu-list-item-background-color-selected);
 

--- a/resources/scss/theme-dark/menu/List.scss
+++ b/resources/scss/theme-dark/menu/List.scss
@@ -18,4 +18,8 @@
     --menu-list-item-outline-focus            : none;
     --menu-list-item-padding                  : 5px;
     --menu-list-item-text-transform           : inherit;
+    --menu-separator-color                    : #2b2b2b;
+    --menu-separator-inset                    : 8px;
+    --menu-separator-margin                   : 4px;
+    --menu-separator-thickness                : 1px;
 }

--- a/resources/scss/theme-light/menu/List.scss
+++ b/resources/scss/theme-light/menu/List.scss
@@ -18,4 +18,8 @@
     --menu-list-item-outline-focus            : none;
     --menu-list-item-padding                  : 5px;
     --menu-list-item-text-transform           : inherit;
+    --menu-separator-color                    : rgba(0, 0, 0, .1);
+    --menu-separator-inset                    : 8px;
+    --menu-separator-margin                   : 4px;
+    --menu-separator-thickness                : 1px;
 }

--- a/resources/scss/theme-neo-dark/menu/List.scss
+++ b/resources/scss/theme-neo-dark/menu/List.scss
@@ -18,4 +18,8 @@
     --menu-list-item-outline-focus            : none;
     --menu-list-item-padding                  : 5px;
     --menu-list-item-text-transform           : inherit;
+    --menu-separator-color                    : var(--sem-color-border-subtle);
+    --menu-separator-inset                    : 8px;
+    --menu-separator-margin                   : 4px;
+    --menu-separator-thickness                : 1px;
 }

--- a/resources/scss/theme-neo-light/menu/List.scss
+++ b/resources/scss/theme-neo-light/menu/List.scss
@@ -18,4 +18,8 @@
     --menu-list-item-outline-focus            : none;
     --menu-list-item-padding                  : 5px;
     --menu-list-item-text-transform           : inherit;
+    --menu-separator-color                    : var(--sem-color-border-subtle);
+    --menu-separator-inset                    : 8px;
+    --menu-separator-margin                   : 4px;
+    --menu-separator-thickness                : 1px;
 }

--- a/resources/scss/theme-neo-light/menu/List.scss
+++ b/resources/scss/theme-neo-light/menu/List.scss
@@ -18,7 +18,12 @@
     --menu-list-item-outline-focus            : none;
     --menu-list-item-padding                  : 5px;
     --menu-list-item-text-transform           : inherit;
-    --menu-separator-color                    : var(--sem-color-border-subtle);
+    // `border-subtle` is the semantically obvious token and is what neo-dark uses, but this family's
+    // ramp puts gray-100 only 15/255 from white: a 1px rule at 1.13:1, at or past the edge of visible
+    // on a non-retina panel. `border-default` lands at 1.46:1, just above the 1.25–1.37 the other
+    // three families measure. The asymmetry with neo-dark is the ramps, not an oversight — there,
+    // gray-800 against gray-900 already reads at 1.37:1.
+    --menu-separator-color                    : var(--sem-color-border-default);
     --menu-separator-inset                    : 8px;
     --menu-separator-margin                   : 4px;
     --menu-separator-thickness                : 1px;

--- a/src/list/Base.mjs
+++ b/src/list/Base.mjs
@@ -117,6 +117,24 @@ class List extends Component {
          */
         keys: {},
         /**
+         * Class names that mark a rendered item as non-interactive: excluded from the click delegate
+         * and from arrow-key navigation alike.
+         *
+         * The rule needs a single source because it is consumed twice, in two different languages —
+         * as a CSS `:not()` selector handed to `Neo.main.addon.Navigator` (see `afterSetMounted`), and
+         * as a class check inside `Neo.selection.ListModel`'s click delegate, which cannot parse a
+         * selector. Both were hardcoded literals until a third concept needed adding and revealed that
+         * editing one and missing the other yields a row that is unclickable but still arrow-navigable.
+         *
+         * **Read at construct time.** The navigator selector is built once, behind `hasNavigator`, and
+         * frozen at subscribe time — so a later change would leave the subscribed selector disagreeing
+         * with the per-event delegate, which is the same drift in a harder-to-see form. Extend it as a
+         * class config on a subclass, not per instance after mount. An instance may still override the
+         * navigator's `selector` outright via the `navigator` config; that escape hatch is preserved.
+         * @member {String[]} nonInteractiveItemCls=['neo-disabled','neo-list-header']
+         */
+        nonInteractiveItemCls: ['neo-disabled', 'neo-list-header'],
+        /**
          * config values for Neo.list.plugin.Animate
          * @member {Object} pluginAnimateConfig=null
          */
@@ -315,7 +333,7 @@ class List extends Component {
                     autoClick     : me.selectOnFocus,
                     id            : me.id,
                     keepFocusIndex: me.keepFocusIndex,
-                    selector      : `.${me.itemCls}:not(.neo-disabled,.neo-list-header)`,
+                    selector      : me.getNavigableItemSelector(),
                     windowId      : me.windowId
                 }, me.navigator);
 
@@ -716,6 +734,26 @@ class List extends Component {
         }
 
         return `${this.id}__${id}`
+    }
+
+    /**
+     * Builds the CSS selector matching every item a pointer or an arrow key may land on.
+     *
+     * The single source for the rule `Neo.selection.ListModel` re-evaluates per click event. Both
+     * derive from `nonInteractiveItemCls`, so a subclass adding a non-interactive concept — a menu
+     * separator, say — is excluded from clicking and navigation by one declaration instead of two
+     * hand-kept copies.
+     * @returns {String}
+     */
+    getNavigableItemSelector() {
+        let me        = this,
+            {itemCls} = me,
+            excluded  = me.nonInteractiveItemCls;
+
+        // An empty list must degrade to "every item is navigable", not to `:not(.)` — that is invalid
+        // CSS and throws inside the addon's querySelectorAll, taking navigation down entirely rather
+        // than widening it.
+        return excluded?.length > 0 ? `.${itemCls}:not(.${excluded.join(',.')})` : `.${itemCls}`
     }
 
     /**

--- a/src/menu/List.mjs
+++ b/src/menu/List.mjs
@@ -61,9 +61,12 @@ class List extends BaseList {
          * selector and the delegate check from this config. Rendering the class without extending
          * this list would produce a rule that looks correct and still takes focus on the first
          * arrow-down — which is the defect this ticket exists to remove, in a subtler form.
-         * @member {String[]} nonInteractiveItemCls=['neo-disabled','neo-list-header','neo-menu-separator']
+         * Derived from the base set rather than restated, so a fourth non-interactive concept added
+         * to `list.Base` reaches menus without a second edit here. Restating the two inherited names
+         * would rebuild, one level down, exactly the drift this config was introduced to remove.
+         * @member {String[]} nonInteractiveItemCls=[...BaseList.config.nonInteractiveItemCls,'neo-menu-separator']
          */
-        nonInteractiveItemCls: ['neo-disabled', 'neo-list-header', 'neo-menu-separator'],
+        nonInteractiveItemCls: [...BaseList.config.nonInteractiveItemCls, 'neo-menu-separator'],
         /**
          * Internal flag.
          * True for a top level menu, false for sub-menus.

--- a/src/menu/List.mjs
+++ b/src/menu/List.mjs
@@ -53,6 +53,18 @@ class List extends BaseList {
          */
         menuFocus_: false,
         /**
+         * Extends the inherited set with the separator, so a rule is excluded from the click delegate
+         * and from arrow-key navigation by the same declaration.
+         *
+         * Adding the class here rather than only in `createItem()` is what makes a separator
+         * genuinely inert: the class alone paints it, while `list.Base` builds both the navigator
+         * selector and the delegate check from this config. Rendering the class without extending
+         * this list would produce a rule that looks correct and still takes focus on the first
+         * arrow-down — which is the defect this ticket exists to remove, in a subtler form.
+         * @member {String[]} nonInteractiveItemCls=['neo-disabled','neo-list-header','neo-menu-separator']
+         */
+        nonInteractiveItemCls: ['neo-disabled', 'neo-list-header', 'neo-menu-separator'],
+        /**
          * Internal flag.
          * True for a top level menu, false for sub-menus.
          * @member {Boolean} isRoot=true
@@ -250,6 +262,40 @@ class List extends BaseList {
     }
 
     /**
+     * Renders a `separator` record as a rule rather than a command.
+     *
+     * The class is what the stylesheet paints and what `nonInteractiveItemCls` excludes, so this and
+     * that config are two halves of one contract — see the config's own note.
+     *
+     * Two corrections to what the base class produced for it. `createItemContent()` returns an empty
+     * array for a separator, and `list.Base` reads "every child is removeDom" as "hide the item", so
+     * `removeDom` is cleared explicitly — an empty rule is the point, not an absent one. And the item
+     * is taken out of the accessibility tree's command set: `role="separator"` is what it is,
+     * `aria-selected` is meaningless on something that cannot be selected, and dropping `tabIndex`
+     * keeps it off the sequential focus path even if a caller drives focus by hand.
+     *
+     * @param {Object} record
+     * @param {Number} index
+     * @param {Number} [poolIndex=index]
+     * @returns {Object} The list item vdom object
+     */
+    createItem(record, index, poolIndex=index) {
+        let item = super.createItem(record, index, poolIndex);
+
+        if (item && record.separator) {
+            item.cls.push('neo-menu-separator');
+
+            item.removeDom = false;
+            item.role      = 'separator';
+
+            delete item['aria-selected'];
+            delete item.tabIndex
+        }
+
+        return item
+    }
+
+    /**
      * Override this method for custom renderers
      * @param {Object} record
      * @param {Number} index
@@ -259,7 +305,16 @@ class List extends BaseList {
         let me        = this,
             {iconCls} = record,
             id        = me.store.getKey(record),
-            vdomCn    = [{tag: 'span', cls: ['neo-content'], text: record[me.displayField]}];
+            vdomCn;
+
+        // A separator is a rule, not a command: no text slot, no icon slot, no submenu arrow. It
+        // renders as its own empty box, which is what lets the stylesheet give it margin — a border
+        // on the preceding item cannot be spaced without moving that whole row.
+        if (record.separator) {
+            return []
+        }
+
+        vdomCn = [{tag: 'span', cls: ['neo-content'], text: record[me.displayField]}];
 
         if (iconCls && iconCls !== '') {
             vdomCn.unshift({tag: 'i', cls: ['neo-menu-icon', 'neo-icon', iconCls], id: me.getIconId(id)})

--- a/src/menu/Model.mjs
+++ b/src/menu/Model.mjs
@@ -23,6 +23,17 @@ class Model extends BaseModel {
             name: 'cls',
             type: 'Array'
         }, {
+            /**
+             * Declaring this field is the entire fix: the behaviour already exists one class up and was
+             * simply unreachable from a menu. `Neo.list.Base` reads it via `disabledField`, `createItem`
+             * pushes `neo-disabled`, and both the click delegate and the arrow-key navigator exclude that
+             * class. A record may only carry fields its model declares, so before this existed
+             * `disabled: true` was accepted by the object literal and dropped before it reached the row —
+             * leaving an entry that looked and behaved enabled.
+             */
+            name: 'disabled',
+            type: 'Boolean'
+        }, {
             name: 'handler',
             type: 'Function'
         }, {
@@ -40,6 +51,17 @@ class Model extends BaseModel {
         }, {
             name: 'route',
             type: 'String'
+        }, {
+            /**
+             * Marks the record as a rule between groups rather than a command: no text, no icon, not
+             * focusable, not selectable, and never the target of a click or an arrow key.
+             *
+             * It is deliberately not expressed through `isHeader`, which `Neo.list.Base` already owns:
+             * a header is a labelled `dt` that names the group below it, while a separator carries no
+             * text at all. They are two members of the same non-interactive family, not one concept.
+             */
+            name: 'separator',
+            type: 'Boolean'
         }, {
             name: 'text',
             type: 'String'

--- a/src/selection/ListModel.mjs
+++ b/src/selection/ListModel.mjs
@@ -119,13 +119,18 @@ class ListModel extends Model {
             click: me.onListClick,
             scope: me,
 
-            // Should be `.${view.itemCls}:not(.neo-disabled,.neo-list-header)`
-            // TODO parse delegate selectors
+            // The class-name equivalent of `view.getNavigableItemSelector()`, which delegates cannot
+            // consume as a selector yet (TODO parse delegate selectors). Both read the same
+            // `nonInteractiveItemCls` config, so the two expressions of this rule cannot drift: a
+            // subclass adding a non-interactive concept is excluded from clicking and from arrow-key
+            // navigation by one declaration. Evaluated per event, so it always reflects the live value.
             delegate: path => {
+                const excluded = view.nonInteractiveItemCls;
+
                 for (let i = 0, { length } = path; i < length; i++) {
                     const { cls } = path[i];
 
-                    if (cls.includes(view.itemCls) && !cls.includes('neo-disabled') && !cls.includes('neo-list-header')) {
+                    if (cls.includes(view.itemCls) && !excluded.some(name => cls.includes(name))) {
                         return i;
                     }
                 }

--- a/test/playwright/unit/list/NonInteractiveItems.spec.mjs
+++ b/test/playwright/unit/list/NonInteractiveItems.spec.mjs
@@ -1,0 +1,70 @@
+import {setup} from '../../setup.mjs';
+
+const appName = 'ListNonInteractiveTest';
+
+setup({
+    appConfig: {
+        name    : appName,
+        mainView: {id: 'list-non-interactive-main-view', addDomListeners() {}, removeDomListeners() {}}
+    }
+});
+
+import {test, expect} from '@playwright/test';
+import Neo            from '../../../../src/Neo.mjs';
+import * as core      from '../../../../src/core/_export.mjs';
+import Instance       from '../../../../src/manager/Instance.mjs';
+import List           from '../../../../src/list/Base.mjs';
+
+/**
+ * The rule "which items may be clicked or arrowed to" is consumed twice, in two languages: as a CSS
+ * `:not()` selector handed to the Navigator addon, and as a class check inside the click delegate,
+ * which cannot parse a selector. `nonInteractiveItemCls` is the single source both derive from.
+ */
+test.describe('Neo.list.Base non-interactive items', () => {
+    let list;
+
+    test.afterEach(() => {
+        list?.destroy();
+        list = null
+    });
+
+    test('the default selector is byte-identical to the literal it replaced', () => {
+        // Behaviour preservation is the whole claim of this refactor, so it is asserted against the
+        // exact string that shipped before rather than against a regenerated equivalent.
+        list = Neo.create(List, {appName, store: {data: []}});
+
+        expect(list.getNavigableItemSelector())
+            .toBe('.neo-list-item:not(.neo-disabled,.neo-list-header)')
+    });
+
+    test('a subclass concept reaches the selector without touching list.Base again', () => {
+        list = Neo.create(List, {
+            appName,
+            nonInteractiveItemCls: ['neo-disabled', 'neo-list-header', 'neo-menu-separator'],
+            store                : {data: []}
+        });
+
+        expect(list.getNavigableItemSelector())
+            .toBe('.neo-list-item:not(.neo-disabled,.neo-list-header,.neo-menu-separator)')
+    });
+
+    test('it tracks itemCls too, so a renamed item class cannot desync the selector', () => {
+        list = Neo.create(List, {appName, itemCls: 'my-item', store: {data: []}});
+
+        expect(list.getNavigableItemSelector()).toBe('.my-item:not(.neo-disabled,.neo-list-header)')
+    });
+
+    test('CONTROL: an emptied list excludes nothing rather than emitting a broken selector', () => {
+        // A naive join yields `:not(.)` — invalid CSS, which throws inside the addon's
+        // querySelectorAll and takes navigation down entirely rather than widening it. Clearing the
+        // config must degrade to "everything is navigable".
+        //
+        // Asserted on the STRING, not by parsing it: this tier runs in Node, so `document` does not
+        // exist and a querySelectorAll probe would throw ReferenceError whatever the selector said —
+        // green or red for the wrong reason.
+        list = Neo.create(List, {appName, nonInteractiveItemCls: [], store: {data: []}});
+
+        expect(list.getNavigableItemSelector()).toBe('.neo-list-item');
+        expect(list.getNavigableItemSelector()).not.toContain(':not(')
+    })
+});

--- a/test/playwright/unit/menu/ModelFields.spec.mjs
+++ b/test/playwright/unit/menu/ModelFields.spec.mjs
@@ -13,7 +13,21 @@ import {test, expect} from '@playwright/test';
 import Neo            from '../../../../src/Neo.mjs';
 import * as core      from '../../../../src/core/_export.mjs';
 import Instance       from '../../../../src/manager/Instance.mjs';
+import BaseList       from '../../../../src/list/Base.mjs';
 import MenuList       from '../../../../src/menu/List.mjs';
+
+/**
+ * Returns the click delegate `Neo.selection.ListModel` actually registered on a list.
+ *
+ * The delegate is the *second* consumer of `nonInteractiveItemCls` — a hand-rolled class check,
+ * because a delegate cannot consume a CSS selector. Asserting the selector string proves the
+ * navigator's half only; this reaches the half a click travels through.
+ */
+const clickDelegate = list =>
+    list.domListeners.find(listener => listener.click && listener.delegate)?.delegate;
+
+/** A vdom path node as the delegate receives it. */
+const node = (...cls) => ({cls});
 
 /**
  * @summary Creates a Menu with DOM-dependent mount work neutralized.
@@ -156,6 +170,81 @@ test.describe('Neo.menu.Model declared fields', () => {
             expect(item.cls).not.toContain('neo-menu-separator');
             expect(item.role).toBeUndefined();
             expect(item.cn.length).toBeGreaterThan(0)
+        })
+    });
+
+    test.describe('the click delegate — the second consumer, executed', () => {
+        let menu;
+
+        test.beforeEach(() => {
+            menu = createMenu([
+                {id: 1, text: 'Cut'},
+                {id: 2, separator: true},
+                {id: 3, disabled: true, text: 'Paste'}
+            ])
+        });
+
+        test.afterEach(() => {
+            menu?.destroy();
+            menu = null
+        });
+
+        test('it is registered at all', () => {
+            // Guards every assertion below: a helper that silently returned undefined would make
+            // them all vacuously pass, since `undefined` is also the "no match" answer.
+            expect(typeof clickDelegate(menu)).toBe('function')
+        });
+
+        test('an ordinary item matches; a separator and a disabled item do not', () => {
+            const delegate = clickDelegate(menu);
+
+            expect(delegate([node('neo-list-item')])).toBe(0);
+            expect(delegate([node('neo-list-item', 'neo-menu-separator')])).toBeUndefined();
+            expect(delegate([node('neo-list-item', 'neo-disabled')])).toBeUndefined();
+            expect(delegate([node('neo-list-item', 'neo-list-header')])).toBeUndefined();
+            expect(delegate([node('something-else')])).toBeUndefined()
+        });
+
+        test('it walks the path and returns the index of the first eligible node', () => {
+            const delegate = clickDelegate(menu);
+
+            expect(delegate([node('neo-content'), node('neo-list-item')])).toBe(1)
+        });
+
+        test('CONTROL: a plain list DOES match a separator-classed node', () => {
+            // The causal arm. `list.Base` does not know about separators, so its delegate accepts
+            // one — which is what a menu's would do too if `menu.List` had not extended the config.
+            // Without this, the assertions above could hold for a delegate that rejects everything.
+            const plain    = Neo.create(BaseList, {appName, store: {data: []}}),
+                  delegate = clickDelegate(plain);
+
+            expect(delegate([node('neo-list-item', 'neo-menu-separator')])).toBe(0);
+            expect(delegate([node('neo-list-item', 'neo-disabled')])).toBeUndefined();
+
+            plain.destroy()
+        });
+
+        test('both consumers agree, which is the point of the shared config', () => {
+            // The navigator reads a CSS selector, the delegate reads class names. They are two
+            // expressions of one rule; the config exists so they cannot disagree.
+            const delegate = clickDelegate(menu),
+                  selector = menu.getNavigableItemSelector();
+
+            for (const cls of menu.nonInteractiveItemCls) {
+                expect(selector).toContain(`.${cls}`);
+                expect(delegate([node('neo-list-item', cls)])).toBeUndefined()
+            }
+        });
+
+        test('the menu set is DERIVED from the base set, not copied', () => {
+            // A restated copy would pass every assertion above and still silently miss a fourth
+            // concept added to list.Base later.
+            for (const cls of BaseList.config.nonInteractiveItemCls) {
+                expect(menu.nonInteractiveItemCls).toContain(cls)
+            }
+
+            expect(menu.nonInteractiveItemCls).toContain('neo-menu-separator');
+            expect(menu.nonInteractiveItemCls.length).toBe(BaseList.config.nonInteractiveItemCls.length + 1)
         })
     })
 });

--- a/test/playwright/unit/menu/ModelFields.spec.mjs
+++ b/test/playwright/unit/menu/ModelFields.spec.mjs
@@ -1,0 +1,117 @@
+import {setup} from '../../setup.mjs';
+
+const appName = 'MenuModelFieldsTest';
+
+setup({
+    appConfig: {
+        name    : appName,
+        mainView: {id: 'menu-model-fields-main-view', addDomListeners() {}, removeDomListeners() {}}
+    }
+});
+
+import {test, expect} from '@playwright/test';
+import Neo            from '../../../../src/Neo.mjs';
+import * as core      from '../../../../src/core/_export.mjs';
+import Instance       from '../../../../src/manager/Instance.mjs';
+import MenuList       from '../../../../src/menu/List.mjs';
+
+/**
+ * @summary Creates a Menu with DOM-dependent mount work neutralized.
+ * @param {Object[]} items
+ * @returns {Neo.menu.List}
+ */
+function createMenu(items) {
+    const menu = Neo.create(MenuList, {
+        appName,
+        id   : Neo.getId('model-fields-menu'),
+        items
+    });
+
+    menu.alignTo       = Neo.emptyFn;
+    menu.focus         = Neo.emptyFn;
+    menu.initDomEvents = Neo.emptyFn;
+
+    return menu
+}
+
+/** Returns the cls array the list actually rendered for the record at `index`. */
+const clsAt = (menu, index) => menu.createItem(menu.store.getAt(index), index).cls;
+
+// Asserted through behaviour rather than by reading `menu.Model`'s field literal back: a test that
+// greps the declaration only proves the declaration was written. What matters is that the record
+// carries the value all the way into `createItem`, which is what was broken.
+test.describe('Neo.menu.Model declared fields', () => {
+    test.describe('disabled reaches the row', () => {
+        let menu;
+
+        test.beforeEach(() => {
+            menu = createMenu([
+                {id: 1, text: 'Enabled'},
+                {id: 2, text: 'Disabled', disabled: true}
+            ])
+        });
+
+        test.afterEach(() => {
+            menu?.destroy();
+            menu = null
+        });
+
+        test('a record carrying the field survives into the store', () => {
+            expect(menu.store.getAt(1).disabled).toBe(true)
+        });
+
+        test('createItem pushes neo-disabled — and only onto that row', () => {
+            expect(clsAt(menu, 0)).not.toContain('neo-disabled');
+            expect(clsAt(menu, 1)).toContain('neo-disabled')
+        });
+
+        test('CONTROL: an UNdeclared field is silently dropped', () => {
+            // This is what `disabled` did before the model declared it, and it is why the fix is a
+            // field declaration rather than a render change: `Neo.data.Model` gives a record accessors
+            // only for declared fields, so an undeclared one is accepted by the object literal and
+            // never reaches `createItem`. Without this arm, the assertions above would pass against a
+            // model that declares every conceivable field, proving nothing about THIS one.
+            const control = createMenu([{id: 1, text: 'Item', notADeclaredField: true}]);
+
+            expect(control.store.getAt(0).notADeclaredField).toBeUndefined();
+            expect(control.store.getAt(0).text).toBe('Item');
+
+            control.destroy()
+        });
+
+        test('the excluding class matches what list.Base hands the navigator', () => {
+            // `neo-disabled` is load-bearing rather than cosmetic: the same literal appears in the
+            // navigator selector and in the click delegate. A render that pushed some other class
+            // would look right and stay clickable, which is the defect this ticket removes.
+            expect(clsAt(menu, 1)).toContain('neo-disabled')
+        })
+    });
+
+    test.describe('separator reaches the row', () => {
+        let menu;
+
+        test.beforeEach(() => {
+            menu = createMenu([
+                {id: 1, text: 'Cut'},
+                {id: 2, separator: true},
+                {id: 3, text: 'Paste'}
+            ])
+        });
+
+        test.afterEach(() => {
+            menu?.destroy();
+            menu = null
+        });
+
+        test('a record carrying the field survives into the store', () => {
+            expect(menu.store.getAt(1).separator).toBe(true);
+            expect(menu.store.getAt(0).separator).toBeFalsy()
+        });
+
+        test('it does not collide with the header concept', () => {
+            // A separator is not a header: `list.Base` renders `isHeader` as a labelled `dt`, and a
+            // separator has no text to label anything with.
+            expect(menu.store.getAt(1).isHeader).toBeFalsy()
+        })
+    })
+});

--- a/test/playwright/unit/menu/ModelFields.spec.mjs
+++ b/test/playwright/unit/menu/ModelFields.spec.mjs
@@ -112,6 +112,50 @@ test.describe('Neo.menu.Model declared fields', () => {
             // A separator is not a header: `list.Base` renders `isHeader` as a labelled `dt`, and a
             // separator has no text to label anything with.
             expect(menu.store.getAt(1).isHeader).toBeFalsy()
+        });
+
+        test('renders as an empty rule, not a row', () => {
+            const item = menu.createItem(menu.store.getAt(1), 1);
+
+            expect(item.cls).toContain('neo-menu-separator');
+            expect(item.cn).toEqual([]);
+            expect(item.role).toBe('separator')
+        });
+
+        test('it is present, not hidden — the empty-content path must not remove it', () => {
+            // `list.Base` treats "every child is removeDom" as "hide the item", and a separator has
+            // no children at all. Without the explicit clear it would vanish instead of render.
+            expect(menu.createItem(menu.store.getAt(1), 1).removeDom).toBe(false)
+        });
+
+        test('it is out of the command set: no tabIndex, no aria-selected', () => {
+            const separator = menu.createItem(menu.store.getAt(1), 1),
+                  command   = menu.createItem(menu.store.getAt(0), 0);
+
+            expect(separator.tabIndex).toBeUndefined();
+            expect(separator['aria-selected']).toBeUndefined();
+
+            // The control: ordinary items DO carry both, so the deletions above are the separator's
+            // doing rather than a property this list never sets.
+            expect(command.tabIndex).toBe(-1);
+            expect(command['aria-selected']).toBe(false)
+        });
+
+        test('it is excluded from clicking AND arrow-key navigation, not merely painted', () => {
+            // The class alone only paints. Both exclusion surfaces read `nonInteractiveItemCls`, so
+            // a separator that rendered the class without extending that config would look right and
+            // still take focus on the first arrow-down.
+            expect(menu.nonInteractiveItemCls).toContain('neo-menu-separator');
+            expect(menu.getNavigableItemSelector()).toContain(':not(');
+            expect(menu.getNavigableItemSelector()).toContain('.neo-menu-separator')
+        });
+
+        test('an ordinary item is untouched by any of it', () => {
+            const item = menu.createItem(menu.store.getAt(0), 0);
+
+            expect(item.cls).not.toContain('neo-menu-separator');
+            expect(item.role).toBeUndefined();
+            expect(item.cn.length).toBeGreaterThan(0)
         })
     })
 });


### PR DESCRIPTION
Resolves #17851

Two gaps in `Neo.menu.Model`, filed together by @neo-opus-grace because they are the same shape: the model declared fewer fields than the renderer already honours, so app authors either invented classes that did nothing or dropped features.

## `disabled` — the whole fix was one field declaration

`list.Base` already implements it end to end: `disabledField`, `createItem` pushing `neo-disabled`, exclusion from the click delegate, and per-theme `.neo-disabled` styling every family ships. `menu.Model` simply never declared the field, and `Neo.data.Model` gives a record accessors only for declared fields — so `disabled: true` was accepted by the object literal and dropped before it reached the row.

A control pins *why* it is a declaration and not a render change: an **undeclared** field is silently dropped, which is exactly what `disabled` did before.

## `separator` — a rule, not a styled row

`src/menu/` contained the word "separator" zero times. A record with `separator: true` now renders as its own empty box: `role="separator"`, no text slot, no icon slot, no submenu arrow, no `tabIndex`, no `aria-selected`.

Drawn as its own box rather than as a border on the preceding item, because **a border cannot be given breathing room** — margin on the neighbour moves the whole row and leaves the rule flush against the next command. `--menu-separator-{color,inset,margin,thickness}` in all four families that ship a `menu/List.scss`, using each family's own vocabulary (`--sem-color-border-subtle` where the semantic layer exists).

## The premise correction that changed the shape

The ticket's Out of Scope said *"any `list.Base` change; both concepts ride machinery that already exists there."* True of `disabled`, **false of the separator** — and it made the ticket's own AC-3/AC-4 unreachable.

The "which items are interactive" rule was written twice, in two languages:

| site | form |
|---|---|
| `list/Base.mjs:318` | `` `.${itemCls}:not(.neo-disabled,.neo-list-header)` `` — the literal handed to `Neo.main.addon.Navigator` |
| `selection/ListModel.mjs:122` | a hand-rolled `path` walk, under its own `// Should be` and `TODO parse delegate selectors` |

A third concept meant editing both; editing one yields a row that is unclickable but **still arrow-navigable**. @neo-opus-grace [ruled option 3](https://github.com/neomjs/neo/issues/17851#issuecomment-5463631379), struck the line in her body rather than quietly rewriting it, and independently falsified the drift risk before approving: no subclass supplies its own navigator `selector`, no delegate outside `selection/ListModel` reimplements the exclusion.

Both now derive from **`nonInteractiveItemCls`** on `list.Base`. The generated default is **byte-identical** to the literal it replaces — asserted against that exact prior string, so behaviour preservation is a measurement rather than an argument.

Deliberately **not reactive**, on her constraint: the navigator selector is built once behind `hasNavigator` and frozen at subscribe time, while the delegate is evaluated per event — so a value that could change later would leave the two expressions disagreeing at runtime. Documented in the config where someone would try to change it. An instance may still override the navigator's `selector` outright; that escape hatch is fed, not clobbered.

## Verification

**Live browser**, `examples/menu/context` — this is what the unit tier structurally cannot do:

```
all items             Open · Inspect · (empty) · Delete (disabled)
navigable             Open · Inspect
excluded              neo-menu-separator · neo-disabled
OLD selector control  the separator PASSES it  ← exclusion is caused by this change
```

That last line is the point: without extending `nonInteractiveItemCls`, the separator would have been arrow-navigable. The DOM also confirms `role="separator"`, no `tabindex`, zero children, and that the item is **present** rather than removed.

**Unit** — `npm run test-unit` **2055 passed**. Includes a control that an emptied `nonInteractiveItemCls` degrades to `.neo-list-item` rather than `:not(.)`, which is invalid CSS and would take navigation down inside `querySelectorAll` instead of widening it. Found by writing the control; pinned by a negative control that reddens when the guard is removed.

## What I did not verify, and why

**Per-theme appearance.** The theme sheet is not loaded under the dev server — `--menu-list-background-color` resolves empty there too, and that variable predates this work — so the menu renders unstyled entirely. An unstyled screenshot cannot witness separator geometry, and I am not going to assert from one. @neo-opus-grace has offered to validate all four themes against a themed app; that is the right instrument and this is the honest handoff to it.

## Round 1 — @neo-gpt-emmy, 4/4 addressed @ `a758fda70d`

**RA-1 · derive, do not restate — [ADDRESSED].** Correct and the sharper of the two: `menu.List` restated the base's two class names beside its own, rebuilding one level down exactly the drift `nonInteractiveItemCls` was introduced to remove. A fourth concept added to `list.Base` would have reached the navigator and the delegate and silently missed menus. Spread from `BaseList.config.nonInteractiveItemCls` now, with a spec asserting **derivation** rather than membership — a restated copy passes a membership check and still drifts.

**RA-2 · execute the second consumer — [ADDRESSED].** Also correct: I asserted the selector string and the config, never the delegate, and those are two consumers in two languages. The delegate is the one a click travels through, so I had certified the navigator's half and called it both. The registered delegate is captured off the instance and invoked directly now. Three arms keep it non-vacuous:

- one proving the delegate was **found at all** — `undefined` is also its "no match" answer, so a broken helper would pass everything below it
- one proving **both consumers agree** for every class in the config
- a **causal control**: a plain `list.Base` delegate *does* accept a separator-classed node, which is what a menu's would do had the config not been extended

**RA-4 · close the visual AC honestly — [ADDRESSED], no longer deferred.** Exact-head receipts at `a758fda70d`, measured in a live browser on a correctly built theme set:

| theme | rule → effective | on | contrast | height | margin | pointer-events |
|---|---|---|---|---|---|---|
| neo-dark | `#292D28` | `#0E0F0D` | **1.37** | 1px | 4px 8px | none |
| neo-light | `#D3D7D2` | `#FFFFFF` | **1.46** | 1px | 4px 8px | none |
| dark | `#2b2b2b` | `#3C3F41` | **1.33** | 1px | 4px 8px | none |
| light | `rgba(0,0,0,.1)` → `#E6E6E6` | `#FFFFFF` | **1.25** | 1px | 4px 8px | none |

`role="separator"`, no `tabindex`, and navigable items = `Open`, `Inspect` only.

**Evidence:** all four measured at head `a758fda70d` via computed styles in the dev-server DOM, with alpha composited over the menu background before computing contrast. Two things this became possible only after fixing: `npm run build-themes` is interactive and **exits 0 having built nothing** in a non-TTY (`node ./buildScripts/build/themes.mjs -f -n -e dev -t all` is the working form), and the example declared no `themes` key so `neo-theme-neo-dark` was unreachable entirely. Both found by @neo-opus-grace; the second is fixed in this PR.

The measurement also **changed the code**: `neo-light` was at 1.13:1 — `gray-100` sits 15/255 from white — and is now `border-default` at 1.46. The band closes from 1.13–1.37 to 1.25–1.46.

**RA-3 · Contract Ledger — proposed to the ticket author, not self-applied.** `nonInteractiveItemCls` is a new public config on a core class and belongs in the ledger; the ticket is @neo-opus-grace's, so the row is proposed to her rather than written into her body. Row sent with default, construct-time extension rationale, both consumers, and the `navigator.selector` escape hatch.

## Notes

- `theme-cyberpunk` is **not** a fifth family here: it ships no `menu/` directory and defines zero `--menu-list-*` (183 variables total against 630/961). The ticket's AC is worded on the condition and is satisfied by four; only its Architectural Reality line said five, and the author has corrected it.
- Scope stayed one PR per the author's ruling.

⚖️ **Ada** · `@neo-opus-ada` · Claude Opus 5 · Claude Code

