### PR TITLE
Edge-band resize agency: drop the boot-pinned caps, restore the floors, floor the preview (#17857)

### DIFF
--- a/learn/guides/uibuildingblocks/DockLayouts.md
+++ b/learn/guides/uibuildingblocks/DockLayouts.md
@@ -160,8 +160,9 @@ tabs-node and item ids. That is why selecting a non-first tab survives a later r
 re-projection: the next projection reads the committed `activeItemId` instead of a stale default.
 
 Every dock splitter previews live on the main thread by default (`liveResize: true`), and the App Worker sees no
-move-frame writes on either kind. An edge splitter resizes its real band under the band's CSS min/max bounds and
-releases into one normalized `resizeEdgeZone` operation. A split-node splitter previews the **conserved adjacent
+move-frame writes on either kind. An edge splitter resizes its real band under the band's CSS min/max bounds — floored
+at one committable pixel, because a valid edge `extent` is strictly between 0 and 1 and the preview never paints a
+frame the document model would refuse — and releases into one normalized `resizeEdgeZone` operation. A split-node splitter previews the **conserved adjacent
 pair**: the two model-order children around the boundary change complementarily each frame — their total constant,
 the clamp window the intersection of both members' CSS bounds — and release commits exactly one `resizeSplit` whose
 vector equals the final previewed geometry, so re-projection never jumps. Escape or a rejected commit restores the

--- a/resources/scss/src/apps/workstation/Viewport.scss
+++ b/resources/scss/src/apps/workstation/Viewport.scss
@@ -138,8 +138,11 @@
 // grid cells. Those are the classes a torn-out pane carries, so those are the rules that travel.
 .workstation-viewport {
     // Grouped with `.neo-dashboard-dock-edge-band` in the workspace block. The band is chrome and
-    // stayed; this half is pane skin, so the pair split rather than moved together.
-    .neo-tab-container {
+    // stayed; this half is pane skin, so the pair split rather than moved together. A tab
+    // container that IS an edge band stays out: its drag axis carries the engine's
+    // `min-inline/block-size` floor vars (the splitter's inward resize bound), and a physical
+    // zero here out-cascades them; its cross axis is zeroed by the workspace's band rule.
+    .neo-tab-container:not(.neo-dashboard-dock-edge-band) {
         min-height: 0;
         min-width : 0;
     }

--- a/resources/scss/src/apps/workstation/Workspace.scss
+++ b/resources/scss/src/apps/workstation/Workspace.scss
@@ -50,10 +50,19 @@
     }
 
     // The band is dock chrome and stays; `.neo-tab-container` was grouped with it and is pane
-    // skin, so the pair had to split rather than move together.
-    .neo-dashboard-dock-edge-band {
+    // skin, so the pair had to split rather than move together. Zero only the CROSS axis:
+    // the drag axis carries the engine's `min-inline/block-size` floor vars, which the
+    // splitter's live-resize clamp reads as its inward bound — a physical `min-width: 0`
+    // here out-cascades those logical floors and lets a drag collapse the band to 0px,
+    // an extent the document model refuses to commit.
+    .neo-dashboard-dock-edge-band-left,
+    .neo-dashboard-dock-edge-band-right {
         min-height: 0;
-        min-width : 0;
+    }
+
+    .neo-dashboard-dock-edge-band-bottom,
+    .neo-dashboard-dock-edge-band-top {
+        min-width: 0;
     }
 
     /* Values only. The rail's structural paint moved to `src/dashboard/Container.scss`, where the
@@ -218,16 +227,17 @@
 
 .workstation-dock-host {
     // Workstation owns density policy; the shared dashboard owns projection hooks and defaults.
-    // Root-font-relative bounds remain readable while both fluid terms follow this definite-size
-    // host, including when the standalone app becomes a child workspace.
+    // Root-font-relative floors remain readable while the fluid preferred terms follow this
+    // definite-size host, including when the standalone app becomes a child workspace.
+    // No max overrides: boot width is governed by each edge's committed document extent (the
+    // projection's inline percentage), so a rem cap here only limits how far the USER may drag —
+    // and a cap at or below the boot width pins the band with zero outward headroom. The engine's
+    // 50% default protects the center at every container size.
     --dock-edge-band-left-inline-size     : 20.3125cqi;
-    --dock-edge-band-left-max-inline-size : 16.25rem;
     --dock-edge-band-left-min-inline-size : 11.25rem;
     --dock-edge-band-right-inline-size    : 25cqi;
-    --dock-edge-band-right-max-inline-size: 20rem;
     --dock-edge-band-right-min-inline-size: 13.75rem;
     --dock-edge-band-bottom-block-size    : 28cqb;
-    --dock-edge-band-bottom-max-block-size: 12.5rem;
     --dock-edge-band-bottom-min-block-size: 8.75rem;
 
     padding : 12px;

--- a/resources/scss/src/apps/workstation/Workspace.scss
+++ b/resources/scss/src/apps/workstation/Workspace.scss
@@ -232,7 +232,8 @@
     // No max overrides: boot width is governed by each edge's committed document extent (the
     // projection's inline percentage), so a rem cap here only limits how far the USER may drag —
     // and a cap at or below the boot width pins the band with zero outward headroom. The engine's
-    // 50% default protects the center at every container size.
+    // 50% default then bounds each edge INDIVIDUALLY — a container-relative per-band cap, not an
+    // aggregate center reservation (opposing edges dragged to their caps can meet in the middle).
     --dock-edge-band-left-inline-size     : 20.3125cqi;
     --dock-edge-band-left-min-inline-size : 11.25rem;
     --dock-edge-band-right-inline-size    : 25cqi;

--- a/src/dashboard/dock/interaction/DockSplitter.mjs
+++ b/src/dashboard/dock/interaction/DockSplitter.mjs
@@ -327,7 +327,9 @@ class DockSplitter extends Splitter {
 
     /**
      * Edge affordances use the inherited single-target descriptor: their band previews live under
-     * CSS min/max bounds. Split affordances emit the conserved-pair descriptor: the two model-order
+     * CSS min/max bounds plus a 1px commit-domain floor (the extent the semantic commit accepts is
+     * the open interval (0,1), so the preview must never paint the 0px frame the model refuses).
+     * Split affordances emit the conserved-pair descriptor: the two model-order
      * children around `boundaryIndex` preview complementary sizes on the main thread, and the
      * terminal's CSS-bounded pixel result feeds the exact committed vector. `liveResize: false`
      * registers nothing and retains the deferred proxy presentation. The committed document remains
@@ -341,7 +343,12 @@ class DockSplitter extends Splitter {
         if (me.isEdgeZoneResize()) {
             let config = super.getResizeConfig();
 
-            return config ? {...config, awaitWorkerSettlement: true} : null
+            // The commit-domain floor: `resizeEdgeZone` validates extent on the OPEN interval
+            // (0,1), so a preview frame at 0px is a state the model categorically refuses — a
+            // consumer whose CSS zeroes the band's min would otherwise collapse the band live,
+            // then watch the refused terminal restore it. One pixel keeps every previewable
+            // frame committable without imposing any design opinion of its own.
+            return config ? {...config, awaitWorkerSettlement: true, minSize: 1} : null
         }
 
         if (!me.liveResize) return null;

--- a/src/main/draggable/Resize.mjs
+++ b/src/main/draggable/Resize.mjs
@@ -193,7 +193,13 @@ class Resize {
             minValue   = resolveCssBound(computed?.getPropertyValue(`min-${config.axis}`), Number(parentRect[config.axis])),
             maxValue   = resolveCssBound(computed?.getPropertyValue(`max-${config.axis}`), Number(parentRect[config.axis]));
 
-        let minSize = Number.isFinite(minValue) ? Math.max(0, minValue) : 0,
+        // A descriptor-supplied floor folds in beneath the CSS bounds: the registering owner
+        // knows its commit domain (e.g. an edge extent must stay above zero), and the preview
+        // must never paint a frame that domain refuses — CSS alone cannot guarantee that.
+        let minSize = Math.max(
+                Number.isFinite(minValue) ? Math.max(0, minValue) : 0,
+                Number.isFinite(config.minSize) ? config.minSize : 0
+            ),
             maxSize = Math.max(minSize, Math.min(layoutMax, Number.isFinite(maxValue) ? maxValue : layoutMax));
 
         if (!Number.isFinite(startSize) || !Number.isFinite(maxSize)) return null;

--- a/test/playwright/component/dashboard/DockSplitterLivePreview.spec.mjs
+++ b/test/playwright/component/dashboard/DockSplitterLivePreview.spec.mjs
@@ -37,7 +37,6 @@ const mount = async (page, splitterConfig = {}, containerConfig = {}) => {
             layout    : {ntype: 'hbox', align: 'stretch'},
             parentId  : 'dock-splitter-test-viewport',
             width     : 606,
-            ...box,
             items     : [
                 {ntype: 'component', id: 'lp-a', flex: 1, style: {background: '#223'}},
                 {
@@ -55,7 +54,10 @@ const mount = async (page, splitterConfig = {}, containerConfig = {}) => {
                     ...cfg
                 },
                 {ntype: 'component', id: 'lp-b', flex: 1, style: {background: '#232'}}
-            ]
+            ],
+            // last so a scenario can override the item set (the edge witness needs a flex-free,
+            // CSS-floor-zeroed band instead of the symmetric pair)
+            ...box
         });
 
         if (!container.success) throw new Error(`container: ${container.error.message}`);
@@ -186,6 +188,76 @@ test.describe('Neo.dashboard.dock.interaction.DockSplitter — live pair preview
         expect(doc.nodes['split-1'].sizes).toEqual([0.5, 0.5]);
 
         await page.mouse.up()
+    });
+
+    test('an edge drag past zero clamps at the commit-domain floor and commits — never refuse-and-restore', async ({page}) => {
+        // The reported-defect fingerprint: a theme zeroes the band's CSS minimum, a decisive
+        // inward drag previews the band to 0px, and 0 / parentSize is an extent the model refuses
+        // on the OPEN interval (0,1) — the refusal restores the pre-drag width and the gesture
+        // reads as "snaps back on drop". The edge descriptor's minSize floor keeps the preview
+        // out of the refusal domain: the band clamps at 1px and that frame COMMITS.
+        const edgeDoc = {
+            schema: 'neo.dock.zone.v1',
+            root  : 'root',
+            items : {
+                center: {componentRef: 'center', title: 'Center'},
+                left  : {componentRef: 'left',   title: 'Left'}
+            },
+            nodes: {
+                root: {
+                    type : 'edge-zone',
+                    zones: {
+                        center: {nodeId: 'center-tabs'},
+                        left  : {nodeId: 'left-tabs', extent: 0.2, resizable: true}
+                    }
+                },
+                'center-tabs': {type: 'tabs', items: ['center'], activeItemId: 'center'},
+                'left-tabs'  : {type: 'tabs', items: ['left'],   activeItemId: 'left'}
+            }
+        };
+
+        ({containerId} = await mount(page, {}, {
+            items: [
+                // mirror the defect surface: a fixed-width band whose CSS floor is zeroed
+                {ntype: 'component', id: 'lp-a', style: {background: '#223', minWidth: '0px'}, width: 200},
+                {
+                    ntype           : 'dashboard-dock-splitter',
+                    id              : 'lp-s',
+                    dockNodeType    : 'splitter',
+                    dockZoneDocument: edgeDoc,
+                    edge            : 'left',
+                    edgeZoneId      : 'root',
+                    orientation     : 'horizontal',
+                    resizeTarget    : 'previous'
+                },
+                {ntype: 'component', id: 'lp-b', flex: 1, style: {background: '#232'}}
+            ]
+        }));
+
+        await expect.poll(async () => (await rects(page)).a.width).toBeCloseTo(200, 0);
+
+        const box = await page.locator('#lp-s').boundingBox(),
+              cx  = box.x + box.width / 2,
+              cy  = box.y + box.height / 2;
+
+        await armDrag(page, cx, cy);
+        await page.mouse.move(cx - 300, cy, {steps: 10});
+
+        // mid-gesture: the preview clamps at the descriptor floor, not at the refused 0px frame
+        const mid = await rects(page);
+        expect(mid.a.width).toBeGreaterThanOrEqual(0.5);
+        expect(mid.a.width).toBeLessThanOrEqual(2);
+
+        await page.mouse.up();
+
+        // the floor frame commits: the extent leaves 0.2 for the 1px fraction instead of being
+        // refused back to it — and the painted band keeps the previewed floor (no snap-back)
+        await expect.poll(async () => {
+            const doc = (await getConfigs(page, 'lp-s', ['dockZoneDocument'])).dockZoneDocument;
+            return doc.nodes.root.zones.left.extent
+        }).toBeCloseTo(1 / 606, 4);
+
+        expect((await rects(page)).a.width).toBeLessThanOrEqual(2)
     });
 
     test('liveResize: false keeps panes static mid-gesture; the pointer-delta terminal still commits', async ({page}) => {

--- a/test/playwright/unit/dashboard/DockSplitter.spec.mjs
+++ b/test/playwright/unit/dashboard/DockSplitter.spec.mjs
@@ -333,9 +333,13 @@ test.describe('Neo.dashboard.dock.interaction.DockSplitter', () => {
         }]);
         expect(result.errors).toEqual([]);
         expect(result.document.nodes.root.zones.left.extent).toBe(0.24);
+        // minSize: 1 is the commit-domain floor — resizeEdgeZone validates extent on the OPEN
+        // interval (0,1), so the registered preview window must exclude the 0px frame even when
+        // a consumer's CSS zeroes the band's own minimum.
         expect(splitter.getResizeConfig()).toEqual({
             axis                 : 'width',
             awaitWorkerSettlement: true,
+            minSize              : 1,
             parentId             : 'edge-parent',
             preview              : true,
             resizeNext           : false,
@@ -443,6 +447,39 @@ test.describe('Neo.dashboard.dock.interaction.DockSplitter', () => {
             restore         : true
         }]);
         expect(document.nodes.root.zones.left.extent).toBe(0.2)
+    });
+
+    test('a zero-pixel terminal lands outside the open extent interval: refused, restored, uncommitted', async () => {
+        // The exact fingerprint the descriptor's minSize floor exists to prevent: a consumer
+        // whose CSS zeroes the band minimum lets the preview collapse to 0px, and 0 / parentSize
+        // is an extent the model refuses on the OPEN interval (0,1). The worker half must refuse
+        // loudly and settle a restore — never commit a vanished band.
+        const document    = createEdgeDocument(),
+              settlements = [];
+
+        splitter = createEdgeSplitter({
+            dockZoneDocument: document,
+            id              : 'dock-edge-splitter-zero-extent'
+        });
+
+        splitter.dragZone.settleResize = data => settlements.push(data);
+
+        await splitter.captureDragStart({clientX: 200, clientY: 0});
+        const result = splitter.onDragEnd({
+            clientX         : 0,
+            clientY         : 0,
+            resizeGeneration: 11,
+            resizeSize      : 0,
+            resizeTargetId  : 'left-wrapper'
+        });
+
+        expect(result.errors).toEqual(['extent must be a finite number between 0 and 1']);
+        expect(settlements).toEqual([{
+            resizeGeneration: 11,
+            resizeTargetId  : 'left-wrapper',
+            restore         : true
+        }]);
+        expect(splitter.dockZoneDocument.nodes.root.zones.left.extent).toBe(0.2)
     });
 });
 


### PR DESCRIPTION
Resolves #17857

## What broke, precisely

Operator report on `apps/workstation`: the left edge splitter drags left but **snaps back on drop**, and **cannot drag right at all**. Reproduced with a real pointer; both symptoms carry receipts on the ticket.

- **Right frozen:** the workstation theme caps the left band at `16.25rem` (260px) while the committed extent (`0.20`) paints 315px in a 1576px row — the band boots pinned AT its own max, so `Resize.createState` computes `maxSize === startSize` and every rightward frame clamps to the start. The constants are 1280px-era (`20.3125cqi × 1280 = 16.25rem` exactly): PR #17845 unfolded a *preferred-width* `clamp()` into real `max-inline-size` caps — numerically faithful, semantically different. All three resizable edges boot pinned at desktop sizes.
- **Snap-back:** two pane-skin min resets (`.neo-dashboard-dock-edge-band {min-width: 0}` and the `.neo-tab-container` half of the same split pair) out-cascade the engine's logical floor vars, so a decisive inward drag previews the band to **0px**; `resizeEdgeZone` validates extent on the **open** interval (0,1), refuses, and the settlement restores the pre-drag width. The refusal machinery works exactly as #17845 designed it — it was just reachable from a healthy gesture.

## The fix

**Workstation theme** (commit 2): caps dropped — boot width is governed by the document extent's inline percentage, so a rem cap only limits how far the *user* may drag, and the engine's 50% default then bounds **each individual edge** (a container-relative per-band cap, not an aggregate center reservation — opposing edges dragged to their caps can meet in the middle; wording corrected per review RA-2). The two min resets now zero only the **cross** axis (bands) and **exclude bands** (tab containers), so the rem floors govern the drag axis again.

**Engine parity floor** (commit 1): the edge descriptor carries `minSize: 1` and `Resize.createState` folds a descriptor floor beneath the CSS bounds. The preview can never paint the 0px frame the model categorically refuses — preview-commit parity now covers the refusal domain, even for a consumer whose CSS zeroes the band minimum.

## Evidence

| Gesture (1600×1000, real pointer) | Before | After |
|---|---|---|
| Rightward drag from boot | frozen at 260px | 315 → 515px, committed `32.69%` (= 515/1576) |
| Decisive far-left drag | previews to 0px, refused, restored | clamps at 180px (11.25rem floor), committed `11.4213%` (= 180/1576) |
| Right/bottom edges | pinned at 320px / 200px | full extents, 50% caps, floors 220px / 140px |

- Unit: **2041/2041** — includes the updated edge-descriptor contract (`minSize: 1`) and a new zero-pixel refusal fingerprint driven through real `Operations`.
- Component (real main thread): **22/22** — new witness drives a real drag past zero over a CSS-zeroed band: clamps at the floor, commits `1/606`, no restore. **Mutation-checked:** red with the engine floor stashed.
- The refusal path itself stays pinned by the pre-existing rejected-terminal spec (restore semantics unchanged).

## Out of scope

Whitebox edge-drag journey extension rides the #17844 lane (e2e runs in no CI per the #17853 resolution — the teeth here are unit/component tier). Preferred-size density vars untouched (shadowed by document extents at runtime).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
