### PR TITLE
feat(menu): an opt-in entrance that follows the side the aligner chose (#17860)

### DIFF
--- a/resources/scss/src/menu/List.scss
+++ b/resources/scss/src/menu/List.scss
@@ -1,3 +1,72 @@
+/* The opt-in directional entrance, gated by `menu.List#animateSpawn`.
+
+   Direction is never configured. `Neo.main.addon.DomAccess` publishes the side the alignment search
+   settled on as `neo-aligned-{top|right|bottom|left}`, so the rule below reads the outcome rather
+   than a guess — and when the search FLIPS a submenu for want of space, the entrance mirrors with it
+   for free. That is the case worth having: a hand-configured direction is wrong exactly when the
+   menu is near a screen edge.
+
+   `translate` is the individual transform property, deliberately not `transform`. The aligner owns
+   `transform` — `DomAccess.align()` writes `translate(x,y)` there to position the menu — and the two
+   compose rather than clobber (measured: `transform: translate(300px,200px)` plus
+   `translate: -40px 0` lands at x=260 with the matrix intact). This is also why the entrance moves
+   nothing that affects the layout box: `addAligned()` observes the subject with a `ResizeObserver`
+   and re-aligns on size change, so an entrance that grew or shrank the menu would re-enter alignment
+   mid-flight and measure its own animation.
+
+   Durations and easings come from `_motion.scss`, the sanctioned vocabulary — a literal here would be
+   a contract violation, and the token is what carries the reduced-motion collapse to 0ms. */
+.neo-menu-list.neo-animate-spawn {
+    /* Distance is small on purpose: this reads as "arriving", not "flying in". */
+    --menu-spawn-distance: 8px;
+
+    /* Between mount and the first alignment the menu is already in the DOM at an unresolved
+       position — `component.Base` fires `alignTo()` without awaiting it. Hold it invisible until a
+       zone lands, or the entrance would be preceded by a fully opaque menu jumping into place.
+       The selector matches only while NO `neo-aligned-*` class is present, so it stops applying the
+       moment alignment resolves and never hides a menu that is merely re-aligning. (`neo-align-initial`
+       is spelled without the `d` precisely so it cannot satisfy this substring match.) */
+    &:not([class*='neo-aligned-']) {
+        opacity: 0;
+    }
+
+    /* `neo-align-initial` marks the subject's FIRST alignment only. A scroll-driven re-align can
+       legitimately change the resolved zone, and keying on `neo-aligned-*` alone would replay the
+       entrance every time that happened. */
+    &.neo-align-initial {
+        animation-duration       : var(--motion-base);
+        animation-fill-mode      : both;
+        animation-timing-function: var(--ease-out-soft);
+
+        /* The menu sits on the named side of its target, so it enters FROM the target: each keyframe
+           starts displaced toward the item that opened it and settles at rest. */
+        &.neo-aligned-bottom { animation-name: neo-menu-spawn-from-top;    }
+        &.neo-aligned-left   { animation-name: neo-menu-spawn-from-right;  }
+        &.neo-aligned-right  { animation-name: neo-menu-spawn-from-left;   }
+        &.neo-aligned-top    { animation-name: neo-menu-spawn-from-bottom; }
+    }
+}
+
+@keyframes neo-menu-spawn-from-bottom {
+    from { opacity: 0; translate: 0 var(--menu-spawn-distance); }
+    to   { opacity: 1; translate: 0 0; }
+}
+
+@keyframes neo-menu-spawn-from-left {
+    from { opacity: 0; translate: calc(var(--menu-spawn-distance) * -1) 0; }
+    to   { opacity: 1; translate: 0 0; }
+}
+
+@keyframes neo-menu-spawn-from-right {
+    from { opacity: 0; translate: var(--menu-spawn-distance) 0; }
+    to   { opacity: 1; translate: 0 0; }
+}
+
+@keyframes neo-menu-spawn-from-top {
+    from { opacity: 0; translate: 0 calc(var(--menu-spawn-distance) * -1); }
+    to   { opacity: 1; translate: 0 0; }
+}
+
 .neo-menu-list {
     background-color: var(--menu-list-background-color);
     border          : 1px solid var(--menu-list-border-color);

--- a/resources/scss/src/menu/List.scss
+++ b/resources/scss/src/menu/List.scss
@@ -24,27 +24,27 @@
        position — `component.Base` fires `alignTo()` without awaiting it. Hold it invisible until a
        zone lands, or the entrance would be preceded by a fully opaque menu jumping into place.
        The selector matches only while NO `neo-aligned-*` class is present, so it stops applying the
-       moment alignment resolves and never hides a menu that is merely re-aligning. (`neo-align-initial`
-       is spelled without the `d` precisely so it cannot satisfy this substring match.) */
+       moment alignment resolves and never hides a menu that is merely re-aligning. */
     &:not([class*='neo-aligned-']) {
         opacity: 0;
     }
 
-    /* `neo-align-initial` marks the subject's FIRST alignment only. A scroll-driven re-align can
-       legitimately change the resolved zone, and keying on `neo-aligned-*` alone would replay the
-       entrance every time that happened. */
-    &.neo-align-initial {
-        animation-duration       : var(--motion-base);
-        animation-fill-mode      : both;
-        animation-timing-function: var(--ease-out-soft);
+    /* The entrance is keyed on the resolved zone alone. `DomAccess.align()` swaps this class only on
+       a REAL zone change, so an ordinary resync -- scroll, resize, the document-mutation resync that
+       opening a submenu triggers -- leaves it untouched and the running animation is never destroyed.
+       A genuine flip does change it, which restarts the entrance mirrored: the menu really did arrive
+       on the other side.
 
-        /* The menu sits on the named side of its target, so it enters FROM the target: each keyframe
-           starts displaced toward the item that opened it and settles at rest. */
-        &.neo-aligned-bottom { animation-name: neo-menu-spawn-from-top;    }
-        &.neo-aligned-left   { animation-name: neo-menu-spawn-from-right;  }
-        &.neo-aligned-right  { animation-name: neo-menu-spawn-from-left;   }
-        &.neo-aligned-top    { animation-name: neo-menu-spawn-from-bottom; }
-    }
+       Keying on a separate transient marker was tried and is wrong: any class the aligner removes and
+       re-adds around a layout read DESTROYS the animation rather than resuming it. */
+    &.neo-aligned-bottom { animation-name: neo-menu-spawn-from-top;    }
+    &.neo-aligned-left   { animation-name: neo-menu-spawn-from-right;  }
+    &.neo-aligned-right  { animation-name: neo-menu-spawn-from-left;   }
+    &.neo-aligned-top    { animation-name: neo-menu-spawn-from-bottom; }
+
+    animation-duration       : var(--motion-base);
+    animation-fill-mode      : both;
+    animation-timing-function: var(--ease-out-soft);
 }
 
 @keyframes neo-menu-spawn-from-bottom {

--- a/src/main/DomAccess.mjs
+++ b/src/main/DomAccess.mjs
@@ -149,6 +149,23 @@ class DomAccess extends Base {
 
         // Set up listeners which monitor for changes
         if (!aligns.has(id)) {
+            // No entry yet, so this alignment is the subject's arrival rather than a resync. The
+            // marker publishes that distinction to CSS, which cannot otherwise tell a spawn from a
+            // re-align: both produce a `neo-aligned-*` class change. Consumers pair it with the
+            // resolved zone (`.neo-align-initial.neo-aligned-right`) to play an entrance in the
+            // direction the zone search actually chose.
+            //
+            // It is cleared by `unalign()` and NOT on the next align, which looks like the tighter
+            // contract and is the wrong one: `onDocumentMutation` resyncs every aligned subject on
+            // ordinary body churn — opening a submenu is enough — so removing it per-align strips it
+            // milliseconds into the entrance and cancels the animation. Leaving it until the subject
+            // is unaligned is safe because a resync that keeps the same zone leaves `animation-name`
+            // untouched, and an unchanged name does not restart a running animation (measured: a
+            // running animation kept advancing across unrelated class churn, and reset to 0 only when
+            // the name itself changed). A genuine zone FLIP therefore replays the entrance, which is
+            // the intended reading — the menu really did arrive on the other side.
+            subject.classList.add('neo-align-initial');
+
             // The subject size participates in every alignment, including coordinate targets.
             resizeObserver.observe(subject);
 
@@ -1284,6 +1301,7 @@ class DomAccess extends Base {
 
                 // Clear the last aligned class.
                 align.subject.classList.remove(`neo-aligned-${align.result?.position}`);
+                align.subject.classList.remove('neo-align-initial');
 
                 _aligns.delete(align.id)
             }

--- a/src/main/DomAccess.mjs
+++ b/src/main/DomAccess.mjs
@@ -137,6 +137,12 @@ class DomAccess extends Base {
     }
 
     /**
+     * @summary Registers one alignment so it is re-resolved whenever its geometry inputs change.
+     *
+     * Observes the subject, the target, the target's offset parent and any constraining element with a
+     * shared `ResizeObserver`, and installs the document-level scroll and mutation listeners on first
+     * use. Every one of those paths re-enters `align()`, which is why that method must be idempotent
+     * for an unchanged result — a resync happens far more often than a real move.
      * @param {Object} alignSpec
      */
     addAligned(alignSpec) {
@@ -149,23 +155,6 @@ class DomAccess extends Base {
 
         // Set up listeners which monitor for changes
         if (!aligns.has(id)) {
-            // No entry yet, so this alignment is the subject's arrival rather than a resync. The
-            // marker publishes that distinction to CSS, which cannot otherwise tell a spawn from a
-            // re-align: both produce a `neo-aligned-*` class change. Consumers pair it with the
-            // resolved zone (`.neo-align-initial.neo-aligned-right`) to play an entrance in the
-            // direction the zone search actually chose.
-            //
-            // It is cleared by `unalign()` and NOT on the next align, which looks like the tighter
-            // contract and is the wrong one: `onDocumentMutation` resyncs every aligned subject on
-            // ordinary body churn — opening a submenu is enough — so removing it per-align strips it
-            // milliseconds into the entrance and cancels the animation. Leaving it until the subject
-            // is unaligned is safe because a resync that keeps the same zone leaves `animation-name`
-            // untouched, and an unchanged name does not restart a running animation (measured: a
-            // running animation kept advancing across unrelated class churn, and reset to 0 only when
-            // the name itself changed). A genuine zone FLIP therefore replays the entrance, which is
-            // the intended reading — the menu really did arrive on the other side.
-            subject.classList.add('neo-align-initial');
-
             // The subject size participates in every alignment, including coordinate targets.
             resizeObserver.observe(subject);
 
@@ -256,9 +245,12 @@ class DomAccess extends Base {
             targetIsObject = typeof data.target === 'object' && !data.target?.nodeType,
             targetIsRect   = isSerializedRectangle(data.target);
 
-        if (lastAlign) {
-            subject.classList.remove(`neo-aligned-${lastAlign.result.position}`)
-        }
+        // The previous zone class is NOT dropped here. Removing it before the zone search knows the
+        // new result means every resync passes through a classless frame, even when the zone is
+        // unchanged — and a class removed and re-added around a layout read does not resume a CSS
+        // animation, it destroys one and starts another (measured: `currentTime` 949ms -> `none` with
+        // zero animations -> a different Animation object at 0). The swap is therefore deferred to
+        // the point where the new position is known, and skipped entirely when it matches.
 
         // Release any constrainTo or matchSize sizing which may have been imposed
         // by a previous align call.
@@ -305,8 +297,22 @@ class DomAccess extends Base {
             style.height = `${result.height}px`
         }
 
-        // Place box shadow at correct edge
-        subject.classList.add(`neo-aligned-${result.position}`);
+        // Place box shadow at correct edge. Swapped only on a real zone change, so an ordinary
+        // resync leaves the class — and anything keyed on it, including a CSS entrance animation and
+        // the shadow repaint — completely untouched.
+        const
+            previousPosition = lastAlign?.result?.position,
+            positionCls      = `neo-aligned-${result.position}`;
+
+        // Guarded on the SUBJECT, not on the cached align record. Keying off `lastAlign` looks
+        // equivalent and is not: a subject can lose the class without the record changing — a hidden
+        // menu is removed from the DOM and remounts as a fresh element, so it comes back classless
+        // while `_aligns` still reports the same zone. That guard silently never re-added the class,
+        // and a reused menu stayed unaligned for the rest of its life.
+        if (!subject.classList.contains(positionCls)) {
+            previousPosition && subject.classList.remove(`neo-aligned-${previousPosition}`);
+            subject.classList.add(positionCls)
+        }
 
         // Register an alignment to be kept in sync
         me.addAligned(data)
@@ -1301,7 +1307,6 @@ class DomAccess extends Base {
 
                 // Clear the last aligned class.
                 align.subject.classList.remove(`neo-aligned-${align.result?.position}`);
-                align.subject.classList.remove('neo-align-initial');
 
                 _aligns.delete(align.id)
             }

--- a/src/menu/List.mjs
+++ b/src/menu/List.mjs
@@ -30,6 +30,21 @@ class List extends BaseList {
          */
         activeSubMenu: null,
         /**
+         * Opts this menu into a directional entrance: it fades up while sliding in from the side it
+         * spawned on, so a submenu reads as emerging from the item that opened it.
+         *
+         * Deliberately NOT the inherited `list.Base#animate_`, which is a different concept — that one
+         * loads `list/plugin/Animate.mjs` to transition items between positions inside a list that is
+         * already on screen. This animates the arrival of the floating surface itself.
+         *
+         * The direction is not configured: `Neo.main.addon.DomAccess` publishes the resolved side as
+         * `neo-aligned-{top|right|bottom|left}`, so the entrance follows the zone the alignment search
+         * actually chose — including when it flips for want of space.
+         * @member {Boolean} animateSpawn_=false
+         * @reactive
+         */
+        animateSpawn_: false,
+        /**
          * @member {String[]} baseCls=['neo-menu-list','neo-list']
          */
         baseCls: ['neo-menu-list', 'neo-list'],
@@ -161,6 +176,16 @@ class List extends BaseList {
      * @protected
      */
     sourceStore = null
+
+    /**
+     * Triggered after the animateSpawn config got changed
+     * @param {Boolean} value
+     * @param {Boolean} oldValue
+     * @protected
+     */
+    afterSetAnimateSpawn(value, oldValue) {
+        this[value ? 'addCls' : 'removeCls']('neo-animate-spawn')
+    }
 
     /**
      * Triggered after the items config got changed
@@ -644,9 +669,12 @@ class List extends BaseList {
                     axisLock    : true,
                     targetMargin: me.subMenuGap
                 },
-                appName        : me.appName,
-                displayField   : me.displayField,
-                floating       : true,
+                // Inherited deliberately: the entrance exists to make a CASCADE legible, so a submenu
+                // that did not animate while its root did would invert the effect it is there for.
+                animateSpawn: me.animateSpawn,
+                appName     : me.appName,
+                displayField: me.displayField,
+                floating    : true,
                 ...me.getSubMenuData(record),
                 isRoot         : false,
                 parentComponent: me.parentComponent,

--- a/src/menu/List.mjs
+++ b/src/menu/List.mjs
@@ -178,13 +178,23 @@ class List extends BaseList {
     sourceStore = null
 
     /**
-     * Triggered after the animateSpawn config got changed
+     * @summary Toggles the entrance-animation opt-in across this menu and every cached descendant.
+     *
+     * Triggered after the animateSpawn config got changed.
      * @param {Boolean} value
      * @param {Boolean} oldValue
      * @protected
      */
     afterSetAnimateSpawn(value, oldValue) {
-        this[value ? 'addCls' : 'removeCls']('neo-animate-spawn')
+        this[value ? 'addCls' : 'removeCls']('neo-animate-spawn');
+
+        // Submenus are cached in `subMenuMap` and reused across open/close cycles, so the value copied
+        // into `showSubMenu()`'s create config only ever reaches the ones created after the change. A
+        // cascade whose levels disagreed would be worse than one that does not animate at all, so the
+        // change follows `afterSetTheme()`'s shape and reaches every level that already exists.
+        Object.values(this.subMenuMap || {}).forEach(menu => {
+            menu.animateSpawn = value
+        })
     }
 
     /**

--- a/test/playwright/component/menu/SpawnAnimation.spec.mjs
+++ b/test/playwright/component/menu/SpawnAnimation.spec.mjs
@@ -14,11 +14,8 @@ const items = [{
 
 /**
  * @summary Creates the floating root menu.
- *
- * `align.target` is a zero-sized point on the left of the viewport, so the submenu has room to the
- * right and the zone search resolves `right` — the direction the tests below assert against.
  * @param {Object} page
- * @param {Object} [config]
+ * @param {Object} [config] Merged over the defaults, e.g. `{animateSpawn: true}`
  * @returns {Promise<String>}
  */
 async function createMenu(page, config={}) {
@@ -44,10 +41,6 @@ async function createMenu(page, config={}) {
 
 /**
  * @summary Reports the animation contract for every mounted menu level, outermost first.
- *
- * Deliberately reads the resolved CSS contract — classes plus computed `animation-name` and duration —
- * rather than sampling a visual state mid-flight. A frame grabbed during a 200ms entrance is a race;
- * the contract is not.
  * @param {Object} page
  * @returns {Promise<Object[]>}
  */
@@ -59,8 +52,7 @@ function animationContract(page) {
             aligned      : [...node.classList].find(cls => cls.startsWith('neo-aligned-')) || null,
             animateCls   : node.classList.contains('neo-animate-spawn'),
             animationName: style.animationName,
-            duration     : style.animationDuration,
-            initial      : node.classList.contains('neo-align-initial')
+            duration     : style.animationDuration
         }
     }))
 }
@@ -89,22 +81,15 @@ test.describe('Neo.menu.List spawn animation', () => {
         }
     });
 
-    test('is off by default: the aligner marks the spawn, but nothing animates', async ({page}) => {
+    test('is off by default: the aligner resolves a zone, but nothing animates', async ({page}) => {
         menuId = await createMenu(page);
 
         await openSubMenu(page);
 
         const levels = await animationContract(page);
 
-        // The marker and the resolved zone are unconditional — they are the aligner's, and other
-        // consumers (the box-shadow edge) already depend on them.
         levels.forEach(level => {
-            expect(level.initial).toBe(true);
-            expect(level.aligned).not.toBeNull()
-        });
-
-        // The opt-in is what gates motion. Default off must leave the rendered result untouched.
-        levels.forEach(level => {
+            expect(level.aligned).not.toBeNull();
             expect(level.animateCls).toBe(false);
             expect(level.animationName).toBe('none')
         })
@@ -118,29 +103,128 @@ test.describe('Neo.menu.List spawn animation', () => {
         const byZone = Object.fromEntries((await animationContract(page)).map(level => [level.aligned, level]));
 
         // A menu sits on the named side of its target and enters FROM the target, so the keyframes are
-        // the mirror of the zone. The submenu is the case worth asserting: it resolves `right`, so it
-        // slides in from the left and reads as emerging from the item that opened it.
+        // the mirror of the zone. The submenu is the case worth asserting.
         expect(byZone['neo-aligned-right']?.animationName).toBe('neo-menu-spawn-from-left');
         expect(byZone['neo-aligned-bottom']?.animationName).toBe('neo-menu-spawn-from-top');
-
-        // The submenu is created by showSubMenu(), not by the caller — without explicit propagation it
-        // would stay unanimated while its root moved, inverting the effect the feature exists for.
         expect(byZone['neo-aligned-right']?.animateCls).toBe(true)
     });
 
-    test('the entrance survives the DOM churn that opening a submenu causes', async ({page}) => {
+    test('a same-zone resync does not restart the entrance', async ({page}) => {
         menuId = await createMenu(page, {animateSpawn: true});
+        await expect(page.locator('.neo-menu-list')).toHaveCount(1);
+
+        // The name alone cannot witness this. A class removed and re-added around a layout read leaves
+        // `animation-name` identical while DESTROYING the running animation and starting a fresh one —
+        // measured directly: currentTime 949ms -> `none` with zero animations -> a different Animation
+        // object at 0. So the witness is WAAPI identity plus monotonic progress, not the resolved name.
+        const result = await page.evaluate(async () => {
+            const
+                node = document.querySelector('.neo-menu-list'),
+                anim = node.getAnimations()[0];
+
+            if (!anim) { return {error: 'no running animation to observe'} }
+
+            // Tag the live object; a restart produces a different one and the tag will be gone.
+            anim.__spawnProbe = 'original';
+            anim.pause();
+            anim.currentTime = 40;
+
+            const before = {name: getComputedStyle(node).animationName, time: anim.currentTime};
+
+            // Force the ordinary resync path: a body mutation drives `onDocumentMutation` ->
+            // `syncAligns()` -> `align()`, which is where the class churn used to happen.
+            const churn = document.createElement('div');
+
+            document.body.appendChild(churn);
+            await new Promise(resolve => setTimeout(resolve, 150));
+            churn.remove();
+            await new Promise(resolve => setTimeout(resolve, 100));
+
+            const after = node.getAnimations()[0];
+
+            return {
+                before,
+                afterName    : getComputedStyle(node).animationName,
+                sameObject   : after?.__spawnProbe === 'original',
+                progressKept : after ? after.currentTime >= before.time : false,
+                animationLost: !after
+            }
+        });
+
+        expect(result.error).toBeUndefined();
+        expect(result.afterName).toBe(result.before.name);
+        expect(result.animationLost).toBe(false);
+        // The two that a name-only assertion cannot see:
+        expect(result.sameObject).toBe(true);
+        expect(result.progressKept).toBe(true)
+    });
+
+    test('a right-edge spawn flips the zone and mirrors the entrance', async ({page}) => {
+        // Target hard against the right edge: the zone search cannot fit the submenu on the right, so
+        // it selects the mirrored zone — and the entrance must follow the flip rather than a config.
+        const width = page.viewportSize().width;
+
+        menuId = await createMenu(page, {
+            align       : {axisLock: true, edgeAlign: 't0-b0', target: {x: width - 4, y: 40, width: 0, height: 0}},
+            animateSpawn: true
+        });
 
         await openSubMenu(page);
 
-        // `onDocumentMutation` resyncs every aligned subject on ordinary body churn, and opening a
-        // submenu is enough to trigger it. A marker cleared per-align would be stripped milliseconds
-        // into the root's entrance and cancel it, so the root must still carry both the marker and a
-        // live animation name after its child has mounted.
-        const root = (await animationContract(page)).find(level => level.aligned === 'neo-aligned-bottom');
+        const zones = (await animationContract(page)).map(level => level.aligned);
 
-        expect(root.initial).toBe(true);
-        expect(root.animationName).toBe('neo-menu-spawn-from-top')
+        expect(zones).toContain('neo-aligned-left');
+
+        const flipped = (await animationContract(page)).find(level => level.aligned === 'neo-aligned-left');
+
+        expect(flipped.animationName).toBe('neo-menu-spawn-from-right')
+    });
+
+    test('a dismissed and reopened instance is cleaned up and re-arms', async ({page}) => {
+        menuId = await createMenu(page, {animateSpawn: true});
+        await expect(page.locator('.neo-menu-list')).toHaveCount(1);
+
+        // Dismissal must clear the resolved zone, or a reopen would find the class already present and
+        // never re-fire the entrance.
+        //
+        // Observed on the subject id rather than the `.neo-menu-list` locator: the reopened menu takes
+        // focus, and a locator count that momentarily matches can be followed by a focus-driven
+        // dismissal before the read lands. The id is the stable handle across the whole cycle.
+        await page.evaluate(id => Neo.worker.App.setConfigs({id, hidden: true}), menuId);
+        await expect.poll(async () => page.evaluate(id => !!document.getElementById(id), menuId)).toBe(false);
+
+        await page.evaluate(id => Neo.worker.App.setConfigs({id, hidden: false}), menuId);
+        await expect.poll(async () => page.evaluate(id => {
+            const node = document.getElementById(id);
+
+            return node ? [...node.classList].find(cls => cls.startsWith('neo-aligned-')) ?? '' : '';
+        }, menuId)).toMatch(/^neo-aligned-/);
+
+        // Positive match on purpose, above: `.not.toBeNull()` is satisfied by `undefined`, so against
+        // an absent node it passes instantly and waits for nothing — a poll that cannot poll.
+        const animationName = await page.evaluate(
+            id => getComputedStyle(document.getElementById(id)).animationName, menuId
+        );
+
+        expect(animationName).not.toBe('none')
+    });
+
+    test('arrow-key navigation reaches items during the entrance window', async ({page}) => {
+        menuId = await createMenu(page, {animateSpawn: true});
+        await expect(page.locator('.neo-menu-list')).toHaveCount(1);
+
+        // The entrance animates opacity and `translate`; neither removes an element from the
+        // navigator's `node.offsetParent && node.matches(selector)` filter. An implementation reaching
+        // for `display` or `visibility` would drop every item out of keyboard reach for its duration,
+        // which is exactly the regression this pins.
+        const reachable = await page.evaluate(() => {
+            const node = document.querySelector('.neo-menu-list');
+
+            return [...node.querySelectorAll('.neo-list-item')]
+                .every(item => item.offsetParent !== null)
+        });
+
+        expect(reachable).toBe(true)
     });
 
     test('collapses to instant under prefers-reduced-motion', async ({page}) => {
@@ -150,9 +234,6 @@ test.describe('Neo.menu.List spawn animation', () => {
 
         await openSubMenu(page);
 
-        // The durations come from the `_motion.scss` vocabulary, which collapses every tier to 0ms
-        // under reduced motion. Asserting the resolved duration exercises that contract instead of
-        // trusting that a token was used.
         (await animationContract(page)).forEach(level => {
             expect(level.animationName).not.toBe('none');
             expect(level.duration).toBe('0s')

--- a/test/playwright/component/menu/SpawnAnimation.spec.mjs
+++ b/test/playwright/component/menu/SpawnAnimation.spec.mjs
@@ -1,0 +1,161 @@
+import {test, expect} from '@playwright/test';
+
+let menuId;
+
+/**
+ * @summary A two-level tree, so the cascade direction can be measured rather than the root's alone.
+ * @type {Object[]}
+ */
+const items = [{
+    id   : 'inspect',
+    items: [{id: 'copy-name', text: 'Copy name'}],
+    text : 'Inspect'
+}];
+
+/**
+ * @summary Creates the floating root menu.
+ *
+ * `align.target` is a zero-sized point on the left of the viewport, so the submenu has room to the
+ * right and the zone search resolves `right` — the direction the tests below assert against.
+ * @param {Object} page
+ * @param {Object} [config]
+ * @returns {Promise<String>}
+ */
+async function createMenu(page, config={}) {
+    const result = await page.evaluate(instanceConfig => {
+        return Neo.worker.App.createNeoInstance(instanceConfig)
+    }, {
+        align       : {axisLock: true, edgeAlign: 't0-b0', target: {x: 40, y: 40, width: 0, height: 0}},
+        displayField: 'text',
+        floating    : true,
+        importPath  : '../menu/List.mjs',
+        items,
+        ntype       : 'menu-list',
+        parentId    : 'component-test-viewport',
+        ...config
+    });
+
+    if (!result.success) {
+        throw new Error(`Component creation failed: ${result.error.message}`)
+    }
+
+    return result.id
+}
+
+/**
+ * @summary Reports the animation contract for every mounted menu level, outermost first.
+ *
+ * Deliberately reads the resolved CSS contract — classes plus computed `animation-name` and duration —
+ * rather than sampling a visual state mid-flight. A frame grabbed during a 200ms entrance is a race;
+ * the contract is not.
+ * @param {Object} page
+ * @returns {Promise<Object[]>}
+ */
+function animationContract(page) {
+    return page.evaluate(() => [...document.querySelectorAll('.neo-menu-list')].map(node => {
+        const style = getComputedStyle(node);
+
+        return {
+            aligned      : [...node.classList].find(cls => cls.startsWith('neo-aligned-')) || null,
+            animateCls   : node.classList.contains('neo-animate-spawn'),
+            animationName: style.animationName,
+            duration     : style.animationDuration,
+            initial      : node.classList.contains('neo-align-initial')
+        }
+    }))
+}
+
+/**
+ * @summary Opens the submenu through the real click delegate.
+ * @param {Object} page
+ * @returns {Promise<void>}
+ */
+async function openSubMenu(page) {
+    await expect(page.locator('.neo-menu-list')).toHaveCount(1);
+    await page.getByText('Inspect', {exact: true}).click();
+    await expect(page.locator('.neo-menu-list')).toHaveCount(2)
+}
+
+test.describe('Neo.menu.List spawn animation', () => {
+    test.beforeEach(async ({page}) => {
+        await page.goto('test/playwright/component/apps/empty-viewport/index.html');
+        await page.waitForSelector('#component-test-viewport', {state: 'attached'})
+    });
+
+    test.afterEach(async ({page}) => {
+        if (menuId) {
+            await page.evaluate(id => Neo.worker.App.destroyNeoInstance(id), menuId);
+            menuId = null
+        }
+    });
+
+    test('is off by default: the aligner marks the spawn, but nothing animates', async ({page}) => {
+        menuId = await createMenu(page);
+
+        await openSubMenu(page);
+
+        const levels = await animationContract(page);
+
+        // The marker and the resolved zone are unconditional — they are the aligner's, and other
+        // consumers (the box-shadow edge) already depend on them.
+        levels.forEach(level => {
+            expect(level.initial).toBe(true);
+            expect(level.aligned).not.toBeNull()
+        });
+
+        // The opt-in is what gates motion. Default off must leave the rendered result untouched.
+        levels.forEach(level => {
+            expect(level.animateCls).toBe(false);
+            expect(level.animationName).toBe('none')
+        })
+    });
+
+    test('animates every level, in the direction the zone search resolved', async ({page}) => {
+        menuId = await createMenu(page, {animateSpawn: true});
+
+        await openSubMenu(page);
+
+        const byZone = Object.fromEntries((await animationContract(page)).map(level => [level.aligned, level]));
+
+        // A menu sits on the named side of its target and enters FROM the target, so the keyframes are
+        // the mirror of the zone. The submenu is the case worth asserting: it resolves `right`, so it
+        // slides in from the left and reads as emerging from the item that opened it.
+        expect(byZone['neo-aligned-right']?.animationName).toBe('neo-menu-spawn-from-left');
+        expect(byZone['neo-aligned-bottom']?.animationName).toBe('neo-menu-spawn-from-top');
+
+        // The submenu is created by showSubMenu(), not by the caller — without explicit propagation it
+        // would stay unanimated while its root moved, inverting the effect the feature exists for.
+        expect(byZone['neo-aligned-right']?.animateCls).toBe(true)
+    });
+
+    test('the entrance survives the DOM churn that opening a submenu causes', async ({page}) => {
+        menuId = await createMenu(page, {animateSpawn: true});
+
+        await openSubMenu(page);
+
+        // `onDocumentMutation` resyncs every aligned subject on ordinary body churn, and opening a
+        // submenu is enough to trigger it. A marker cleared per-align would be stripped milliseconds
+        // into the root's entrance and cancel it, so the root must still carry both the marker and a
+        // live animation name after its child has mounted.
+        const root = (await animationContract(page)).find(level => level.aligned === 'neo-aligned-bottom');
+
+        expect(root.initial).toBe(true);
+        expect(root.animationName).toBe('neo-menu-spawn-from-top')
+    });
+
+    test('collapses to instant under prefers-reduced-motion', async ({page}) => {
+        await page.emulateMedia({reducedMotion: 'reduce'});
+
+        menuId = await createMenu(page, {animateSpawn: true});
+
+        await openSubMenu(page);
+
+        // The durations come from the `_motion.scss` vocabulary, which collapses every tier to 0ms
+        // under reduced motion. Asserting the resolved duration exercises that contract instead of
+        // trusting that a token was used.
+        (await animationContract(page)).forEach(level => {
+            expect(level.animationName).not.toBe('none');
+            expect(level.duration).toBe('0s')
+        })
+    })
+});

--- a/test/playwright/component/menu/SpawnAnimation.spec.mjs
+++ b/test/playwright/component/menu/SpawnAnimation.spec.mjs
@@ -209,22 +209,84 @@ test.describe('Neo.menu.List spawn animation', () => {
         expect(animationName).not.toBe('none')
     });
 
-    test('arrow-key navigation reaches items during the entrance window', async ({page}) => {
-        menuId = await createMenu(page, {animateSpawn: true});
-        await expect(page.locator('.neo-menu-list')).toHaveCount(1);
+    test('propagates a later animateSpawn change to an already-cached submenu, both ways', async ({page}) => {
+        // Created with the flag OFF, so the submenu is cached without it — the exact case a
+        // creation-time copy cannot reach.
+        menuId = await createMenu(page);
 
-        // The entrance animates opacity and `translate`; neither removes an element from the
-        // navigator's `node.offsetParent && node.matches(selector)` filter. An implementation reaching
-        // for `display` or `visibility` would drop every item out of keyboard reach for its duration,
-        // which is exactly the regression this pins.
-        const reachable = await page.evaluate(() => {
-            const node = document.querySelector('.neo-menu-list');
+        await openSubMenu(page);
 
-            return [...node.querySelectorAll('.neo-list-item')]
-                .every(item => item.offsetParent !== null)
+        const subMenuHasCls = () => page.evaluate(() => {
+            const menus = [...document.querySelectorAll('.neo-menu-list')];
+
+            // The submenu is the level the root does not own; identify it by its resolved zone.
+            return menus.find(node => node.classList.contains('neo-aligned-right'))
+                ?.classList.contains('neo-animate-spawn') ?? null
         });
 
-        expect(reachable).toBe(true)
+        expect(await subMenuHasCls()).toBe(false);
+
+        await page.evaluate(id => Neo.worker.App.setConfigs({id, animateSpawn: true}), menuId);
+        await expect.poll(subMenuHasCls).toBe(true);
+
+        // …and back off again: a one-way propagation would leave the cascade animating forever.
+        await page.evaluate(id => Neo.worker.App.setConfigs({id, animateSpawn: false}), menuId);
+        await expect.poll(subMenuHasCls).toBe(false)
+    });
+
+    test('arrow-key navigation works during the entrance window', async ({page}) => {
+        // Three rows on purpose: with the single-item default, ArrowDown has nowhere to move and an
+        // "an item is active" assertion passes without the key ever arriving.
+        menuId = await createMenu(page, {
+            animateSpawn: true,
+            items       : [{id: 'one', text: 'One'}, {id: 'two', text: 'Two'}, {id: 'three', text: 'Three'}]
+        });
+        await expect(page.locator('.neo-menu-list')).toHaveCount(1);
+
+        // Hold the entrance open deterministically instead of racing a 200ms animation: pause the
+        // running animation early, so every key below is pressed while the menu is mid-entrance.
+        const paused = await page.evaluate(() => {
+            const anim = document.querySelector('.neo-menu-list')?.getAnimations()[0];
+
+            if (!anim) { return false }
+
+            anim.pause();
+            anim.currentTime = 10;
+
+            return true
+        });
+
+        expect(paused).toBe(true);
+
+        // Drive the real key and observe the navigator, rather than asserting a property that merely
+        // WOULD break — `offsetParent` being non-null does not prove a key reaches anything.
+        const activeText = () => page.evaluate(
+            () => document.querySelector('.neo-navigator-active-item')?.textContent.trim() ?? null
+        );
+
+        await page.locator('.neo-menu-list .neo-list-item').first().focus();
+
+        const before = await activeText();
+
+        await page.keyboard.press('ArrowDown');
+        await expect.poll(activeText).not.toBe(before);
+
+        const after = await activeText();
+
+        // Non-vacuity: an item is already active on focus, so `exists` alone would pass without the
+        // key ever arriving. The witness is that the key MOVED the navigator.
+        expect(after).not.toBeNull();
+        expect(after).not.toBe(before);
+
+        // The animation must still have been mid-flight while that happened, or the window was not
+        // the thing under test.
+        const stillMidEntrance = await page.evaluate(() => {
+            const anim = document.querySelector('.neo-menu-list')?.getAnimations()[0];
+
+            return anim ? anim.playState === 'paused' && Number(anim.currentTime) < 200 : false
+        });
+
+        expect(stillMidEntrance).toBe(true)
     });
 
     test('collapses to instant under prefers-reduced-motion', async ({page}) => {

--- a/test/playwright/unit/main/DomAccessAlign.spec.mjs
+++ b/test/playwright/unit/main/DomAccessAlign.spec.mjs
@@ -31,9 +31,15 @@ function createElement(id, {height, width, x, y}, offsetParent=null) {
         offsetParent,
         parentElement: null,
         style        : {},
+        // Backed by one Set, so the three methods agree with each other. `contains` is not decoration:
+        // `align()` reads it to decide whether the resolved zone class is already on the subject, and a
+        // double that answered only `add`/`remove` made a real production read look like a missing API.
         classList    : {
             add(value) {
                 classSet.add(value)
+            },
+            contains(value) {
+                return classSet.has(value)
             },
             remove(value) {
                 classSet.delete(value)


### PR DESCRIPTION
Resolves #17860
Related: #17850, #17851, #5008

`menu.List#animateSpawn` (default `false`) fades a menu up while sliding it in from the side it spawned on, so a submenu reads as emerging from the item that opened it. Instant stays the default and the default path is byte-unchanged.

Evidence: L3 (real pointer input in a real browser, component tier, plus live measurement on `examples/menu/context/`) → L3 required (the ACs are observable CSS contract). Residual: none.

## The direction is never configured

`DomAccess.align()` has always published the side the zone search settled on:

```js
subject.classList.add(`neo-aligned-${result.position}`);   // top | right | bottom | left
```

It exists for the box-shadow edge, is removed before re-align and on teardown, and `component/Base.scss` already consumes all four. The entrance reads that outcome rather than guessing — so when the search **flips** a submenu for want of space, the animation mirrors with it. A configured direction is wrong in exactly that case.

No new main-thread signal ships. `align()` already published the resolved zone as `neo-aligned-*` for the box shadow; the only change is that it now swaps that class **only when the subject does not already carry it**, so an unchanged alignment touches nothing. An earlier revision added a transient marker for this and it was withdrawn — see below.

## Three constraints, each measured rather than assumed

**1. The entrance animates `translate`, not `transform`.** The aligner owns `transform` — it writes `translate(x,y)` there. The individual property composes: `transform: translate(300px,200px)` + `translate: -40px 0` → `x = 260`, matrix intact. No wrapper node needed; the ticket originally specified one and is corrected.

**2. Nothing that changes the layout box may animate.** `addAligned()` observes the subject with a `ResizeObserver`, so a scale entrance would re-enter alignment mid-flight and measure its own motion.

**3. An unchanged alignment must not touch the class.** This is the correction from review — see below.

## The claim this rested on was false, and the fix moved to the root

My first version added a transient `neo-align-initial` marker and argued a same-zone resync was safe because *"an unchanged `animation-name` does not restart a running animation."* I had measured that against **unrelated** class churn. That is not what `align()` does: it **removes** the zone class, reads layout, and re-adds it.

Reproduced after @neo-gpt's RA-1:

```
before:  currentTime 949.96ms
mid:     animation-name "none", 0 animations      ← destroyed
after:   currentTime 0, a DIFFERENT Animation object
finalNameLooksUnchanged: true                     ← the old assertion passed anyway
```

**`align()` now swaps the zone class only when the subject does not already carry it.** An ordinary resync — scroll, resize, the document-mutation resync that opening a submenu triggers — leaves the class, the running animation, and the shadow repaint untouched. A real flip still changes it and restarts the entrance mirrored, which is the intended reading.

That deletes the marker entirely, and with it the objection that the default path was not byte-unchanged: nothing is added to every aligned subject any more.

**The guard is on the SUBJECT, not the cached align record.** Keying off `lastAlign` looks equivalent and is not — a hidden menu leaves the DOM and remounts classless while `_aligns` still reports the same zone, so that version never re-added the class and a reused menu stayed unaligned permanently. **The reuse witness RA-4 asked for caught it one run after it was written.**

**`unalign()` does not exist** and never did; cleanup is in `syncAligns()`. Corrected in code comments, this body, and the ticket.

## AC Evidence

| AC | Proof |
|---|---|
| Idempotent on an unchanged zone | `align()` swaps `neo-aligned-*` only when the subject lacks it; witnessed by **WAAPI identity + monotonic progress**, since the resolved name is identical across a restart |
| Default off is unchanged | no class is added to any aligned subject; spec asserts `animation-name: none` on every level while the aligner's own classes are present |
| Direction follows the resolved zone | submenu `neo-aligned-right` → `neo-menu-spawn-from-left`; root `neo-aligned-bottom` → `neo-menu-spawn-from-top` |
| Flip | right-edge target resolves `neo-aligned-left` → mirrored `from-right` keyframes |
| Reuse | dismiss/reopen the same instance: zone cleared then re-resolved, entrance re-arms |
| Cascade inherits, and keeps inheriting | creation-time propagation **plus** `afterSetAnimateSpawn` walking `subMenuMap`, pinned in **both** directions on an already-cached submenu |
| Keyboard during the entrance | animation paused mid-flight, `ArrowDown` pressed, navigator's active item **moves** — a three-row menu, because with one row "an item is active" passes without the key arriving |
| Reduced motion | `emulateMedia({reducedMotion: 'reduce'})` → resolved duration `0s` |
| No literals | durations/easings resolve through `--motion-*` |

## Test Evidence

`test/playwright/component/menu/SpawnAnimation.spec.mjs` — real pointer and keyboard input in a real browser, 8 arms. Assertions are on resolved contract and **animation identity**, never a sampled visual state.

**Mutation-checked, each failing on the assertion that encodes its defect:**

```
revert the idempotent-class guard   → 1 failed  same-zone resync: Expected true, Received false
                                                (sameObject / progressKept)
                                                ...all 6 name-based assertions still PASS
remove the subMenuMap propagation   → 1 failed  cached-submenu both-ways witness
```

Two vacuity defects were found in my own arms and fixed: `expect.poll(...).not.toBeNull()` passes on `undefined` (replaced with a positive `toMatch`), and the keyboard arm asserted "an item is active" on a single-row menu, which is true before any key is pressed.

Suites at this head: **unit 2061/2061** (the five `DomAccessAlign` failures from the new `classList.contains` read are fixed — the spec's `classList` double now implements it, backed by the same Set), **components 94/94**, four lint guards clean.

## Deltas from ticket

- **No inner wrapper node.** The ticket specified one to keep the animation off the aligner's `transform`; the individual `translate` property composes with it, so the wrapper is unnecessary. Ticket corrected.
- **No transient marker at all.** The ticket proposed one, cleared on the next align. The browser showed that removing and re-adding any class around a layout read destroys the running animation, so the mechanism moved into `align()`'s existing class swap instead. Ticket corrected; the withdrawn row is struck there with the measurement.

## Out of Scope

Exit / dismissal animation, deliberately. Dismissal cascades `unmount()` through the tree from three entry points, that cascade regressed as recently as #17850, and deferring DOM removal would open a window where a menu is visibly present but logically dismissed — and would invalidate the `[3, 0]` level-count witness from #17852. Its own ticket, after this has mileage.

Also out: generalising to other floating surfaces (dialog, picker, tooltip) — one consumer does not justify a generic config; per-item entrance stagger; and any change to `neo-aligned-*` semantics or the zone search, which are read-only inputs here.

## Post-Merge Validation

None. Everything the ACs assert is reachable from this head.

Origin Session ID: 57d042dc-6295-4fea-8347-a79adb8135fc



