### PR TITLE
feat(neural-link): add atomic drag transactions (#17821)

### DIFF
--- a/learn/guides/testing/WhiteboxE2E.md
+++ b/learn/guides/testing/WhiteboxE2E.md
@@ -144,10 +144,34 @@ await nlApp.simulateEvent([
 ]);
 ```
 
-**`simulateEvent` drives discrete events (click / key / input) — it does NOT drive a pointer drag-and-drop.** Neo's drag pipeline (grid column reordering, including locked-column / multi-region grids) is armed by a mouse-based drag sensor that requires a *real, time-spread* pointer gesture: it only fires `drag:start` once the pointer crosses its distance + delay thresholds, so a synthetic single event never arms it. To drive a column drag in an e2e, use Playwright's native mouse with a **stepped** move — the `{steps}` cadence generates the intermediate `mousemove` events the sensor needs:
+`simulateEvent` is the raw escape hatch for caller-authored event sequences. For a complete
+drag gesture, use `driveDrag`: Engine resolves live node/window geometry, reads the source
+window's live Mouse-sensor thresholds, dispatches one atomic source-document gesture, and returns
+a receipt distinguishing raw event dispatch from correlated `drag:start` / `drag:move` /
+`drag:end` observations:
 
 ```javascript
-// Real pointer-drag that arms the Mouse sensor (a synthetic single event does NOT):
+const receipt = await nlApp.driveDrag({
+    source     : {targetId: splitterId, windowId},
+    destination: {deltaX: 60, deltaY: 0},
+    steps      : 8,
+    durationMs : 160
+});
+
+expect(receipt).toMatchObject({success: true, phase: 'complete', released: true});
+expect(receipt.observed.moveCount).toBeGreaterThan(0);
+```
+
+The physical receipt deliberately says nothing about the component's semantic outcome. Assert the
+grid order, splitter size, or dock document separately through Neural Link.
+
+Use Playwright's native mouse when the test must **hold** the pointer down, inspect mid-gesture
+state, press Escape, or interleave application-specific readiness waits. `driveDrag` owns a whole
+transaction; it is not a pause/resume API. A native stepped move remains the right pattern for those
+interactive assertions:
+
+```javascript
+// Held pointer-drag for mid-interaction assertions:
 await page.mouse.move(startX, startY);
 await page.mouse.down();
 await page.mouse.move(targetX, targetY, { steps: 60 });

--- a/src/ai/Client.mjs
+++ b/src/ai/Client.mjs
@@ -1,10 +1,11 @@
-import Base                 from '../core/Base.mjs';
-import ClassSystemUtil      from '../util/ClassSystem.mjs';
-import ComponentService     from './client/ComponentService.mjs';
-import DataService          from './client/DataService.mjs';
-import DockService          from './client/DockService.mjs';
-import InstanceService      from './client/InstanceService.mjs';
-import InteractionService   from './client/InteractionService.mjs';
+import Base             from '../core/Base.mjs';
+import ClassSystemUtil  from '../util/ClassSystem.mjs';
+import ComponentService from './client/ComponentService.mjs';
+import DataService      from './client/DataService.mjs';
+import DockService      from './client/DockService.mjs';
+import InstanceService  from './client/InstanceService.mjs';
+import InteractionService, {registerInteractionServiceMethods}
+                            from './client/InteractionService.mjs';
 import RuntimeService       from './client/RuntimeService.mjs';
 import Socket               from '../data/connection/WebSocket.mjs';
 import WindowManager        from '../manager/Window.mjs';
@@ -167,9 +168,10 @@ class Client extends Base {
             patch_code           : runtime,
             position_window      : runtime,
             reload_page          : runtime,
-            set_route            : runtime,
-            simulate_event       : interaction
+            set_route            : runtime
         };
+
+        registerInteractionServiceMethods(me.serviceMap, interaction);
 
         Neo.currentWorker.on({
             connect   : me.onAppWorkerWindowConnect,

--- a/src/ai/client/InteractionService.mjs
+++ b/src/ai/client/InteractionService.mjs
@@ -1,4 +1,51 @@
-import Service from './Service.mjs';
+import Service       from './Service.mjs';
+import WindowManager from '../../manager/Window.mjs';
+
+const
+    defaultAnchor     = Object.freeze({x: 0.5, y: 0.5}),
+    defaultSteps      = 8,
+    maxDurationMs     = 30000,
+    maxSteps          = 120,
+    minStepDurationMs = 16;
+
+/**
+ * @param {String} phase
+ * @param {String} code
+ * @param {String} message
+ * @param {Object|null} source
+ * @param {Object|null} destination
+ * @returns {Object}
+ */
+function driveFailure(phase, code, message, source=null, destination=null) {
+    return {
+        cleanup : {attempted: false, succeeded: true},
+        destination,
+        dispatch: {down: false, moveCount: 0, up: false},
+        error   : {code, message},
+        observed: {ended: false, moveCount: 0, started: false},
+        phase,
+        released: false,
+        sensor  : null,
+        source,
+        success : false
+    }
+}
+
+/**
+ * @summary Registers the JSON-RPC method prefixes owned by one InteractionService instance.
+ * Keeping the mapping executable here gives the Client one registration path and unit tests one
+ * side-effect-free route witness; importing the Client singleton solely to inspect its map would
+ * open a real transport in every test worker.
+ * @param {Object} serviceMap Mutable Client prefix map.
+ * @param {InteractionService} service Owning service instance.
+ * @returns {Object} The same map after registration.
+ */
+export function registerInteractionServiceMethods(serviceMap, service) {
+    return Object.assign(serviceMap, {
+        drive_drag    : service,
+        simulate_event: service
+    })
+}
 
 /**
  * Service for handling interaction simulation commands.
@@ -23,7 +70,8 @@ class InteractionService extends Service {
      * @returns {Promise<Boolean>}
      */
     async simulateEvent({events}) {
-        let me = this;
+        let me      = this,
+            success = true;
 
         if (!Array.isArray(events)) {
             throw new Error('InteractionService: events must be an array')
@@ -34,15 +82,266 @@ class InteractionService extends Service {
                 await me.timeout(event.delay)
             }
 
-            await me.dispatch({
+            const dispatched = await me.dispatch({
                 id      : event.targetId,
                 options : event.options,
                 type    : event.type,
                 windowId: event.windowId
-            })
+            });
+
+            success = dispatched && success
         }
 
-        return true
+        return success
+    }
+
+    /**
+     * @summary Reads one window's current Main-realm geometry with a finite inner-viewport origin.
+     *
+     * The Window manager is the cross-window projection, but an ordinary dedicated-worker window
+     * can connect before publishing a geometry record. Atomic automation needs live geometry at
+     * execution time anyway, so the owning Main realm is the authority and the manager's shared
+     * calculator keeps browser-chrome normalization identical to the projection path.
+     * @param {String} windowId
+     * @returns {Promise<Object>}
+     * @protected
+     */
+    async resolveWindow(windowId) {
+        if (typeof windowId !== 'string' || !windowId) {
+            throw new Error('windowId must be a non-empty string')
+        }
+
+        const
+            windowData = await Neo.Main.getWindowData({windowId}),
+            geometry   = windowData ? WindowManager.calculateGeometry(windowData) : null;
+
+        if (!geometry?.innerRect || !Number.isFinite(geometry.innerRect.x) || !Number.isFinite(geometry.innerRect.y)) {
+            throw new Error(`window '${windowId}' has no live inner-viewport geometry`)
+        }
+
+        return {id: windowId, ...geometry}
+    }
+
+    /**
+     * @summary Reads one target's visual viewport rect from its owning Main realm.
+     * @param {String} targetId
+     * @param {String} windowId
+     * @returns {Promise<Object>}
+     * @protected
+     */
+    async resolveDomRect(targetId, windowId) {
+        const rect = await Neo.main.DomAccess.getBoundingClientRect({id: targetId, windowId});
+
+        if (
+            !rect || !Number.isFinite(rect.x) || !Number.isFinite(rect.y) ||
+            !Number.isFinite(rect.width) || !Number.isFinite(rect.height) ||
+            rect.width <= 0 || rect.height <= 0
+        ) {
+            throw new Error(`target '${targetId}' in window '${windowId}' has no finite rendered rectangle`)
+        }
+
+        return rect
+    }
+
+    /**
+     * @summary Validates one normalized node anchor.
+     * @param {Object|null} anchor
+     * @returns {{x:Number,y:Number}}
+     * @protected
+     */
+    normalizeAnchor(anchor) {
+        anchor ??= defaultAnchor;
+
+        if (
+            !Neo.isObject(anchor) || !Number.isFinite(anchor.x) || !Number.isFinite(anchor.y) ||
+            anchor.x < 0 || anchor.x > 1 || anchor.y < 0 || anchor.y > 1
+        ) {
+            throw new Error('anchor must contain finite x/y values in [0,1]')
+        }
+
+        return {x: anchor.x, y: anchor.y}
+    }
+
+    /**
+     * @summary Converts a target-window local point into both global screen and source-event client
+     * coordinates. Destination windows provide geometry only; every event still routes to source Main.
+     * @param {Object} options
+     * @param {Number} options.clientX
+     * @param {Number} options.clientY
+     * @param {Object} options.sourceWindow
+     * @param {String} options.windowId
+     * @returns {Promise<Object>}
+     * @protected
+     */
+    async resolvePoint({clientX, clientY, sourceWindow, targetId, windowId}) {
+        if (!Number.isFinite(clientX) || !Number.isFinite(clientY)) {
+            throw new Error('target-local clientX/clientY must be finite')
+        }
+
+        const
+            targetWindow = windowId === sourceWindow.id ? sourceWindow : await this.resolveWindow(windowId),
+            screen       = {
+                x: targetWindow.innerRect.x + clientX,
+                y: targetWindow.innerRect.y + clientY
+            };
+
+        return {
+            screen,
+            sourceEventClient: {
+                x: screen.x - sourceWindow.innerRect.x,
+                y: screen.y - sourceWindow.innerRect.y
+            },
+            targetClient: {x: clientX, y: clientY},
+            ...(targetId ? {targetId} : {}),
+            windowId
+        }
+    }
+
+    /**
+     * @summary Resolves one DOM node descriptor at its normalized visual anchor.
+     * @param {Object} descriptor
+     * @param {Object} sourceWindow
+     * @returns {Promise<Object>}
+     * @protected
+     */
+    async resolveNodePoint({anchor, targetId, windowId}, sourceWindow) {
+        if (typeof targetId !== 'string' || !targetId || typeof windowId !== 'string' || !windowId) {
+            throw new Error('node mode requires non-empty targetId and windowId')
+        }
+
+        const
+            normalized = this.normalizeAnchor(anchor),
+            rect       = await this.resolveDomRect(targetId, windowId);
+
+        return this.resolvePoint({
+            clientX: rect.x + rect.width  * normalized.x,
+            clientY: rect.y + rect.height * normalized.y,
+            sourceWindow,
+            targetId,
+            windowId
+        })
+    }
+
+    /**
+     * @summary Resolves one destination/waypoint descriptor through exactly one declared mode.
+     * @param {Object} descriptor
+     * @param {Object} source
+     * @param {Object} sourceWindow
+     * @param {Boolean} allowDelta
+     * @returns {Promise<Object>}
+     * @protected
+     */
+    async resolveDescriptor(descriptor, source, sourceWindow, allowDelta=true) {
+        if (!Neo.isObject(descriptor)) {
+            throw new Error('destination and waypoints must be objects')
+        }
+
+        if (Object.hasOwn(descriptor, 'screenX') || Object.hasOwn(descriptor, 'screenY')) {
+            throw new Error('caller-supplied screen coordinates are not accepted; Engine derives them from window geometry')
+        }
+
+        const
+            nodeMode  = Object.hasOwn(descriptor, 'targetId'),
+            pointMode = Object.hasOwn(descriptor, 'clientX') || Object.hasOwn(descriptor, 'clientY'),
+            deltaMode = Object.hasOwn(descriptor, 'deltaX') || Object.hasOwn(descriptor, 'deltaY'),
+            modeCount = Number(nodeMode) + Number(pointMode) + Number(deltaMode);
+
+        if (modeCount !== 1 || (deltaMode && !allowDelta)) {
+            throw new Error(`descriptor requires exactly one ${allowDelta ? 'node, point, or delta' : 'node or point'} mode`)
+        }
+
+        if (nodeMode) {
+            return this.resolveNodePoint(descriptor, sourceWindow)
+        }
+
+        if (pointMode) {
+            if (typeof descriptor.windowId !== 'string' || !descriptor.windowId) {
+                throw new Error('point mode requires windowId')
+            }
+
+            return this.resolvePoint({...descriptor, sourceWindow})
+        }
+
+        if (!Number.isFinite(descriptor.deltaX) || !Number.isFinite(descriptor.deltaY)) {
+            throw new Error('delta mode requires finite deltaX/deltaY')
+        }
+
+        return this.resolvePoint({
+            clientX : source.targetClient.x + descriptor.deltaX,
+            clientY : source.targetClient.y + descriptor.deltaY,
+            sourceWindow,
+            windowId: source.windowId
+        })
+    }
+
+    /**
+     * @summary Resolves and executes one whole physical drag while preserving Engine/Brain ownership:
+     * App validates and resolves geometry, source Main drives and observes the atomic Mouse lifecycle.
+     * Every expected refusal returns a typed failure receipt rather than throwing metadata the current
+     * JSON-RPC path cannot preserve.
+     * @param {Object} request
+     * @returns {Promise<Object>}
+     */
+    async driveDrag({destination, durationMs, source, steps=defaultSteps, waypoints=[]}={}) {
+        let resolvedSource      = null,
+            resolvedDestination = null,
+            executionStarted    = false;
+
+        try {
+            if (!Neo.isObject(source)) {
+                throw new Error('source is required')
+            }
+
+            if (!Number.isInteger(steps) || steps < 1 || steps > maxSteps) {
+                throw new Error(`steps must be an integer in [1,${maxSteps}]`)
+            }
+
+            durationMs ??= Math.max(160, steps * 20);
+
+            if (!Number.isFinite(durationMs) || durationMs < steps * minStepDurationMs || durationMs > maxDurationMs) {
+                throw new Error(`durationMs must be between steps * ${minStepDurationMs} and ${maxDurationMs}`)
+            }
+
+            if (!Array.isArray(waypoints)) {
+                throw new Error('waypoints must be an array')
+            }
+
+            const sourceWindow = await this.resolveWindow(source.windowId);
+
+            resolvedSource      = await this.resolveNodePoint(source, sourceWindow);
+            resolvedDestination = await this.resolveDescriptor(destination, resolvedSource, sourceWindow, true);
+
+            const resolvedWaypoints = [];
+
+            for (const waypoint of waypoints) {
+                resolvedWaypoints.push(await this.resolveDescriptor(waypoint, resolvedSource, sourceWindow, false))
+            }
+
+            await Neo.Main.importAddon({name: 'DragDrop', windowId: source.windowId});
+            await Neo.Main.importAddon({name: 'EventSimulator', windowId: source.windowId});
+
+            executionStarted = true;
+
+            const outcome = await Neo.main.addon.EventSimulator.driveDrag({
+                destination: resolvedDestination,
+                durationMs,
+                path       : [...resolvedWaypoints, resolvedDestination],
+                source     : resolvedSource,
+                steps,
+                windowId   : source.windowId
+            });
+
+            return Neo.isObject(outcome) ? outcome :
+                driveFailure('dispatch', 'INVALID_DRIVE_RESPONSE', 'source Main returned no structured drive receipt', resolvedSource, resolvedDestination)
+        } catch (error) {
+            return driveFailure(
+                executionStarted ? 'dispatch' : 'resolution',
+                executionStarted ? 'DRIVE_RPC_FAILED' : 'DRIVE_RESOLUTION_FAILED',
+                error?.message || String(error),
+                resolvedSource,
+                resolvedDestination
+            )
+        }
     }
 
     /**

--- a/src/main/addon/DragDrop.mjs
+++ b/src/main/addon/DragDrop.mjs
@@ -222,6 +222,21 @@ class DragDrop extends Base {
     dragResize = new Resize()
 
     /**
+     * The exact Mouse sensor instance this Main realm created. Gesture automation reads its live
+     * reactive threshold values; the class defaults are not runtime authority.
+     * @member {Neo.main.draggable.sensor.Mouse|null} mouseSensor=null
+     * @protected
+     */
+    mouseSensor = null
+
+    /**
+     * Resolves when the optional Mouse sensor import and construction complete.
+     * @member {Promise<Neo.main.draggable.sensor.Mouse>|null} mouseSensorPromise=null
+     * @protected
+     */
+    mouseSensorPromise = null
+
+    /**
      * Monotonic physical-drag lifetime. Reset/start invalidates every older async native move.
      * @member {Number} windowDragGeneration=0
      * @protected
@@ -255,19 +270,30 @@ class DragDrop extends Base {
         me.addGlobalEventListeners();
 
         if (Neo.config.hasMouseEvents) {
-            imports.push(import('../draggable/sensor/Mouse.mjs'))
+            me.mouseSensorPromise = import('../draggable/sensor/Mouse.mjs').then(module => {
+                me.mouseSensor = Neo.create({module: module.default});
+
+                return me.mouseSensor
+            });
+
+            imports.push(me.mouseSensorPromise)
         }
 
         if (Neo.config.hasTouchEvents) {
-            imports.push(import('../draggable/sensor/Touch.mjs'))
+            imports.push(import('../draggable/sensor/Touch.mjs').then(module => Neo.create({module: module.default})))
         }
 
-        Promise.all(imports).then(modules => {
-            // create the Mouse- and / or TouchSensor
-            modules.forEach(module => {
-                Neo.create({module: module.default})
-            })
-        })
+        Promise.all(imports)
+    }
+
+    /**
+     * @summary Returns this Main realm's exact live Mouse sensor, waiting for its lazy construction
+     * when necessary. A caller must fail closed on `null`; copying class defaults would stop
+     * observing per-instance overrides.
+     * @returns {Promise<Neo.main.draggable.sensor.Mouse|null>}
+     */
+    async getMouseSensor() {
+        return this.mouseSensor || await this.mouseSensorPromise || null
     }
 
     /**

--- a/src/main/addon/EventSimulator.mjs
+++ b/src/main/addon/EventSimulator.mjs
@@ -2,6 +2,89 @@ import Base      from './Base.mjs';
 import DomAccess from '../DomAccess.mjs';
 
 /**
+ * Internal typed abort. It never crosses a worker boundary; {@link EventSimulator#driveDrag}
+ * catches it and returns the public structured failure receipt.
+ */
+class DriveAbort extends Error {
+    constructor(phase, code, message) {
+        super(message);
+        Object.assign(this, {code, phase})
+    }
+}
+
+/**
+ * @param {{x:Number,y:Number}} a
+ * @param {{x:Number,y:Number}} b
+ * @returns {Number}
+ */
+function pointDistance(a, b) {
+    return Math.hypot(b.x - a.x, b.y - a.y)
+}
+
+/**
+ * @param {{screen:Object,sourceEventClient:Object}} from
+ * @param {{screen:Object,sourceEventClient:Object}} to
+ * @param {Number} ratio
+ * @returns {{screen:Object,sourceEventClient:Object}}
+ */
+function interpolatePoint(from, to, ratio) {
+    const interpolate = (a, b) => a + (b - a) * ratio;
+
+    return {
+        screen: {
+            x: interpolate(from.screen.x, to.screen.x),
+            y: interpolate(from.screen.y, to.screen.y)
+        },
+        sourceEventClient: {
+            x: interpolate(from.sourceEventClient.x, to.sourceEventClient.x),
+            y: interpolate(from.sourceEventClient.y, to.sourceEventClient.y)
+        }
+    }
+}
+
+/**
+ * @summary Samples one resolved polyline at a physical distance from its source.
+ * @param {Object} source
+ * @param {Object[]} path
+ * @param {Number} distance
+ * @returns {Object}
+ */
+function pointAtDistance(source, path, distance) {
+    let prior     = source,
+        traversed = 0;
+
+    for (const point of path) {
+        const segment = pointDistance(prior.sourceEventClient, point.sourceEventClient);
+
+        if (traversed + segment >= distance) {
+            return interpolatePoint(prior, point, segment === 0 ? 1 : (distance - traversed) / segment)
+        }
+
+        traversed += segment;
+        prior      = point
+    }
+
+    return path.at(-1)
+}
+
+/**
+ * @param {Object} source
+ * @param {Object[]} path
+ * @returns {Number}
+ */
+function pathLength(source, path) {
+    let prior = source,
+        total = 0;
+
+    path.forEach(point => {
+        total += pointDistance(prior.sourceEventClient, point.sourceEventClient);
+        prior  = point
+    });
+
+    return total
+}
+
+/**
  * Main Thread Addon to simulate native DOM events.
  * Used by Neural Link for advanced E2E testing and automation.
  *
@@ -22,7 +105,7 @@ class EventSimulator extends Base {
          * @protected
          */
         remote: {
-            app: ['dispatch']
+            app: ['dispatch', 'driveDrag']
         },
         /**
          * @member {Boolean} singleton=true
@@ -30,6 +113,14 @@ class EventSimulator extends Base {
          */
         singleton: true
     }
+
+    /**
+     * One Mouse sensor owns the source document. Overlapping automation transactions would both
+     * observe the same physical lifecycle, so a second caller is refused rather than queued.
+     * @member {Boolean} driveActive=false
+     * @protected
+     */
+    driveActive = false
 
     /**
      * Dispatches a native DOM event on a target element.
@@ -41,13 +132,29 @@ class EventSimulator extends Base {
      * @returns {Boolean} true if the event was dispatched successfully
      */
     dispatch(data) {
+        return this.dispatchNative(data).success
+    }
+
+    /**
+     * Constructs and dispatches one native event. The optional creation callback runs before
+     * `dispatchEvent()`, allowing an atomic gesture transaction to correlate synchronous
+     * `drag:*` lifecycle frames to this exact native Event object.
+     * @param {Object} data
+     * @param {String|HTMLElement|Document} data.id
+     * @param {String} data.type
+     * @param {Object} [data.options]
+     * @param {Function} [onCreate]
+     * @returns {{event: Event|null, success: Boolean}}
+     * @protected
+     */
+    dispatchNative(data, onCreate) {
         const
             {id, type, options = {}} = data,
             node = DomAccess.getElement(id);
 
         if (!node) {
             console.warn(`EventSimulator: Target node with id '${id}' not found.`);
-            return false
+            return {event: null, success: false}
         }
 
         let event, ctor;
@@ -115,12 +222,248 @@ class EventSimulator extends Base {
             // We might need a helper to construct it if advanced drag simulation is required.
 
             event = new ctor(type, options);
+            onCreate?.(event);
             node.dispatchEvent(event);
-            return true
+            return {event, success: true}
         } catch (e) {
             console.error(`EventSimulator: Failed to dispatch event '${type}' on '${id}'`, e);
-            return false
+            return {event: event || null, success: false}
         }
+    }
+
+    /**
+     * @summary Resolves the exact Mouse sensor retained by the source Main realm's DragDrop addon.
+     * @returns {Promise<Neo.main.draggable.sensor.Mouse|null>}
+     * @protected
+     */
+    async resolveMouseSensor() {
+        return await Neo.main.addon.DragDrop?.getMouseSensor?.() || null
+    }
+
+    /**
+     * @summary Returns this Main realm's document. Kept as a seam so single-thread unit specs can
+     * pin one listener surface even when another spec installs a different global document.
+     * @returns {Document}
+     * @protected
+     */
+    getDriveDocument() {
+        return document
+    }
+
+    /**
+     * @summary Executes and observes one complete Mouse-sensor drag in this source Main realm.
+     *
+     * The App worker has already resolved every node/window descriptor into global screen and
+     * source-realm client coordinates. This method owns the one atomic physical transaction:
+     * it reads the live sensor thresholds, dispatches mousedown on the source node, then uses the
+     * stable document body for every move/release (the source node may disappear mid-gesture),
+     * and correlates `drag:start/move/end` by native Event object identity. It never calls sensor
+     * lifecycle methods directly and never claims a consumer-specific semantic outcome.
+     *
+     * @param {Object} request Fully resolved drive request.
+     * @returns {Promise<Object>} Typed success/failure receipt; never throws for gesture outcomes.
+     */
+    async driveDrag({destination, durationMs, path, source, steps}) {
+        const receipt = {
+            cleanup : {attempted: false, succeeded: true},
+            destination,
+            dispatch: {down: false, moveCount: 0, up: false},
+            observed: {ended: false, moveCount: 0, started: false},
+            phase   : 'busy',
+            released: false,
+            sensor  : null,
+            source,
+            success : false
+        };
+
+        if (this.driveActive) {
+            return {...receipt, error: {code: 'DRAG_BUSY', message: 'another atomic drag is already active in this window'}}
+        }
+
+        this.driveActive = true;
+
+        let abort,
+            downEvent = null,
+            upEvent   = null,
+            listenersInstalled = false,
+            sensor,
+            ownedMoveEvents = new WeakSet();
+
+        const documentRef = this.getDriveDocument();
+
+        const
+            onStart = event => {
+                if (event.detail?.originalEvent === downEvent) {
+                    receipt.observed.started = true
+                }
+            },
+            onMove = event => {
+                if (ownedMoveEvents.has(event.detail?.originalEvent)) {
+                    receipt.observed.moveCount++
+                }
+            },
+            onEnd = event => {
+                if (event.detail?.originalEvent === upEvent) {
+                    receipt.observed.ended = true;
+                    receipt.released       = true
+                }
+            },
+            eventOptions = (point, buttons) => ({
+                bubbles   : true,
+                button    : 0,
+                buttons,
+                cancelable: true,
+                clientX   : point.sourceEventClient.x,
+                clientY   : point.sourceEventClient.y,
+                screenX   : point.screen.x,
+                screenY   : point.screen.y
+            }),
+            dispatchMove = point => {
+                const result = this.dispatchNative({
+                    id     : 'document.body',
+                    options: eventOptions(point, 1),
+                    type   : 'mousemove'
+                }, event => ownedMoveEvents.add(event));
+
+                result.success && receipt.dispatch.moveCount++;
+
+                return result.success
+            },
+            fail = (phase, code, message) => {
+                throw new DriveAbort(phase, code, message)
+            };
+
+        try {
+            sensor = await this.resolveMouseSensor();
+
+            if (!sensor) {
+                fail('busy', 'MOUSE_SENSOR_UNAVAILABLE', 'the source window has no live Mouse sensor')
+            }
+
+            if (sensor.currentElement || sensor.dragging) {
+                fail('busy', 'MOUSE_SENSOR_BUSY', 'the source window Mouse sensor is already engaged')
+            }
+
+            const
+                delayMs     = Number(sensor.delay),
+                minDistance = Number(sensor.minDistance);
+
+            receipt.sensor = {delayMs, minDistance};
+
+            if (!Number.isFinite(delayMs) || delayMs < 0 || !Number.isFinite(minDistance) || minDistance < 0) {
+                fail('arming', 'INVALID_SENSOR_THRESHOLDS', 'the live Mouse sensor thresholds are invalid')
+            }
+
+            if (!Array.isArray(path) || path.length === 0) {
+                fail('arming', 'EMPTY_DRAG_PATH', 'the resolved drag path is empty')
+            }
+
+            const
+                total       = pathLength(source, path),
+                armDistance = minDistance + 1;
+
+            if (total < armDistance) {
+                fail('arming', 'PATH_TOO_SHORT', 'the resolved path does not cross the live Mouse minimum distance')
+            }
+
+            documentRef.addEventListener('drag:start', onStart, true);
+            documentRef.addEventListener('drag:move',  onMove,  true);
+            documentRef.addEventListener('drag:end',   onEnd,   true);
+            listenersInstalled = true;
+
+            const down = this.dispatchNative({
+                id     : source.targetId,
+                options: eventOptions(source, 1),
+                type   : 'mousedown'
+            }, event => {downEvent = event});
+
+            receipt.dispatch.down = down.success;
+
+            if (!down.success) {
+                fail('dispatch', 'MOUSEDOWN_DISPATCH_FAILED', 'the source mousedown could not be dispatched')
+            }
+
+            await this.timeout(delayMs);
+
+            if (!dispatchMove(pointAtDistance(source, path, armDistance))) {
+                fail('dispatch', 'ARMING_MOVE_DISPATCH_FAILED', 'the threshold-crossing move could not be dispatched')
+            }
+
+            if (!receipt.observed.started) {
+                fail('arming', 'DRAG_NOT_ARMED', 'the live Mouse sensor emitted no correlated drag:start')
+            }
+
+            const interval = durationMs / steps;
+
+            for (let index = 1; index <= steps; index++) {
+                await this.timeout(interval);
+
+                const distance = armDistance + (total - armDistance) * index / steps;
+
+                if (!dispatchMove(pointAtDistance(source, path, distance))) {
+                    fail('dispatch', 'MOVE_DISPATCH_FAILED', `post-arm move ${index} could not be dispatched`)
+                }
+            }
+
+            if (receipt.observed.moveCount < 1) {
+                fail('movement', 'DRAG_MOVE_NOT_OBSERVED', 'no correlated drag:move was observed')
+            }
+
+            const up = this.dispatchNative({
+                id     : 'document.body',
+                options: eventOptions(path.at(-1), 0),
+                type   : 'mouseup'
+            }, event => {upEvent = event});
+
+            receipt.dispatch.up = up.success;
+
+            if (!up.success) {
+                fail('release', 'MOUSEUP_DISPATCH_FAILED', 'the terminal mouseup could not be dispatched')
+            }
+
+            if (!receipt.observed.ended) {
+                fail('release', 'DRAG_END_NOT_OBSERVED', 'no correlated drag:end was observed')
+            }
+
+            receipt.phase   = 'complete';
+            receipt.success = true
+        } catch (error) {
+            abort = error instanceof DriveAbort ? error :
+                new DriveAbort('dispatch', 'DRIVE_DRAG_FAILED', error?.message || String(error))
+        } finally {
+            if (receipt.dispatch.down && !receipt.released) {
+                receipt.cleanup.attempted = true;
+
+                const point   = path?.at?.(-1) || source,
+                      cleanup = this.dispatchNative({
+                          id     : 'document.body',
+                          options: eventOptions(point, 0),
+                          type   : 'mouseup'
+                      }, event => {upEvent = event});
+
+                receipt.cleanup.succeeded = cleanup.success;
+
+                if (!cleanup.success) {
+                    abort = new DriveAbort('cleanup', 'CLEANUP_RELEASE_FAILED', 'best-effort mouseup cleanup failed')
+                }
+            }
+
+            if (listenersInstalled) {
+                documentRef.removeEventListener('drag:start', onStart, true);
+                documentRef.removeEventListener('drag:move',  onMove,  true);
+                documentRef.removeEventListener('drag:end',   onEnd,   true)
+            }
+
+            this.driveActive = false
+        }
+
+        if (abort) {
+            receipt.phase   = abort.phase;
+            receipt.success = false;
+            receipt.error   = {code: abort.code, message: abort.message}
+        }
+
+        return receipt
     }
 }
 

--- a/test/playwright/e2e/core/SplitterLiveResizeNL.spec.mjs
+++ b/test/playwright/e2e/core/SplitterLiveResizeNL.spec.mjs
@@ -41,10 +41,13 @@ test.describe('Neo.component.Splitter live resizing', () => {
               previousId     = itemIds[splitterIndex - 1],
               nextId         = itemIds[splitterIndex + 1];
 
+        const {windowId} = await app.manageNeoConfig('get');
+
         expect(splitterIndex, 'the Splitter sits between two sibling components').toBeGreaterThan(0);
         expect(nextId).toBeTruthy();
+        expect(windowId, 'the page-owned App registry exposes its logical source window').toBeTruthy();
 
-        return {app, nextId, pageErrors, parentId, previousId, splitterId}
+        return {app, nextId, pageErrors, parentId, previousId, splitterId, windowId}
     };
 
     const rects = async (app, ids) => {
@@ -136,18 +139,46 @@ test.describe('Neo.component.Splitter live resizing', () => {
         expect(pageErrors).toEqual([])
     });
 
-    test('successful live release persists, while deferred mode keeps geometry on the proxy until release', async ({page, neuralLink}) => {
-        const {app, nextId, pageErrors, parentId, splitterId} = await openExample(page, neuralLink),
-              liveBefore                                      = await rects(app, [splitterId, nextId]);
+    test('atomic live release persists, while deferred held mode keeps geometry on the proxy', async ({page, neuralLink}) => {
+        const {app, nextId, pageErrors, parentId, splitterId, windowId} = await openExample(page, neuralLink),
+              liveBefore                                                = await rects(app, [splitterId, nextId]);
 
-        await moveWhileHeld(page, splitterId, {x: 60});
+        await expect.poll(() => page.evaluate(() => Boolean(Neo.main.addon.DragDrop.mouseSensor)), {
+            message: 'the source Main realm retains its live Mouse sensor',
+            timeout: 5000
+        }).toBe(true);
 
-        await expect.poll(async () => {
-            const held = await rects(app, [splitterId]);
-            return held[splitterId].x - liveBefore[splitterId].x
-        }, {message: 'live geometry changes before mouseup', timeout: 5000}).toBeGreaterThan(40);
+        const priorThresholds = await page.evaluate(() => {
+            const sensor = Neo.main.addon.DragDrop.mouseSensor;
 
-        await page.mouse.up();
+            const prior = {delay: sensor.delay, minDistance: sensor.minDistance};
+
+            sensor.set({delay: 180, minDistance: 11});
+
+            return prior
+        });
+
+        let receipt;
+
+        try {
+            receipt = await app.driveDrag({
+                source     : {targetId: splitterId, windowId},
+                destination: {deltaX: 60, deltaY: 0},
+                durationMs : 160,
+                steps      : 8
+            })
+        } finally {
+            await page.evaluate(prior => Neo.main.addon.DragDrop.mouseSensor?.set(prior), priorThresholds)
+        }
+
+        expect(receipt, JSON.stringify(receipt, null, 2)).toMatchObject({
+            success : true,
+            phase   : 'complete',
+            released: true,
+            sensor  : {delayMs: 180, minDistance: 11},
+            observed: {started: true, ended: true}
+        });
+        expect(receipt.observed.moveCount).toBeGreaterThan(0);
 
         const liveAfter    = await rects(app, [splitterId, nextId]);
         const durableAfter = await app.getComponent(nextId, ['wrapperStyle']);

--- a/test/playwright/e2e/neural-link/WindowOps.spec.mjs
+++ b/test/playwright/e2e/neural-link/WindowOps.spec.mjs
@@ -100,6 +100,78 @@ test.describe('Neural Link window operations (e2e)', () => {
             expect(popupWindow.ownerWindowId).toBeUndefined();
             expect(popupWindow.targetWindowId).toBeUndefined();
 
+            const
+                sourceWindow = windows.find(win => win.appName === 'Colors'),
+                sourceNodeId = 'nl-atomic-drag-source',
+                targetNodeId = 'nl-atomic-drag-target';
+
+            await page.evaluate(id => {
+                const node = document.createElement('div');
+
+                Object.assign(node, {
+                    className: 'neo-draggable',
+                    id
+                });
+                Object.assign(node.style, {
+                    height  : '40px',
+                    left    : '40px',
+                    position: 'fixed',
+                    top     : '120px',
+                    width   : '40px',
+                    zIndex  : '99999'
+                });
+                document.body.append(node)
+            }, sourceNodeId);
+
+            await popup.evaluate(id => {
+                const node = document.createElement('div');
+
+                Object.assign(node, {id});
+                Object.assign(node.style, {
+                    height  : '30px',
+                    left    : '80px',
+                    position: 'fixed',
+                    top     : '70px',
+                    width   : '50px',
+                    zIndex  : '99999'
+                });
+                document.body.append(node)
+            }, targetNodeId);
+
+            const dragReceipt = await app.driveDrag({
+                source: {
+                    targetId: sourceNodeId,
+                    windowId: sourceWindow.windowId
+                },
+                destination: {
+                    targetId: targetNodeId,
+                    windowId: popupWindow.windowId
+                },
+                durationMs: 160,
+                steps     : 8
+            });
+
+            expect(dragReceipt).toMatchObject({
+                success    : true,
+                phase      : 'complete',
+                released   : true,
+                source     : {windowId: sourceWindow.windowId},
+                destination: {windowId: popupWindow.windowId},
+                observed   : {started: true, ended: true}
+            });
+            expect(dragReceipt.observed.moveCount).toBeGreaterThan(0);
+            expect(dragReceipt.destination.screen.x - dragReceipt.destination.targetClient.x)
+                .toBeCloseTo(popupWindow.innerRect.x, 0);
+            expect(dragReceipt.destination.screen.y - dragReceipt.destination.targetClient.y)
+                .toBeCloseTo(popupWindow.innerRect.y, 0);
+            expect(dragReceipt.destination.screen.x - dragReceipt.destination.sourceEventClient.x)
+                .toBeCloseTo(sourceWindow.innerRect.x, 0);
+            expect(dragReceipt.destination.screen.y - dragReceipt.destination.sourceEventClient.y)
+                .toBeCloseTo(sourceWindow.innerRect.y, 0);
+
+            await page.evaluate(id => document.getElementById(id)?.remove(), sourceNodeId);
+            await popup.evaluate(id => document.getElementById(id)?.remove(), targetNodeId);
+
             const focusResult = await app.focusWindow(popupWindow.windowId);
             expect(focusResult).toMatchObject({
                 success : true,

--- a/test/playwright/fixtures.mjs
+++ b/test/playwright/fixtures.mjs
@@ -498,6 +498,17 @@ export const test = base.extend({
                     // --- Interaction Methods ---
 
                     /**
+                     * Drives one complete Engine-owned Mouse gesture and returns its physical
+                     * lifecycle receipt. This fixture calls the raw Engine RPC directly so Engine
+                     * whitebox coverage does not depend on the blocked Brain MCP tool (#204).
+                     * @param {Object} request The `drive_drag` request object.
+                     * @returns {Promise<Object>}
+                     */
+                    async driveDrag(request) {
+                        return NeuralLink_ConnectionService.call(sessionId, 'drive_drag', request)
+                    },
+
+                    /**
                      * Simulates a native DOM event directly onto the VNode exactly as a user would.
                      * @param {Object|Object[]} events Sequence of events (e.g., {action: 'click', targetId: 'my-comp'})
                      * @returns {Promise<Object>}

--- a/test/playwright/unit/ai/client/InteractionService.spec.mjs
+++ b/test/playwright/unit/ai/client/InteractionService.spec.mjs
@@ -1,0 +1,222 @@
+import {setup} from '../../../setup.mjs';
+
+setup({
+    appConfig: {name: 'InteractionServiceAtomicDragUnit'},
+    neoConfig: {unitTestMode: true}
+});
+
+import {test, expect} from '@playwright/test';
+import Neo            from '../../../../../src/Neo.mjs';
+import * as core      from '../../../../../src/core/_export.mjs';
+
+const {default: InteractionService, registerInteractionServiceMethods} =
+    await import('../../../../../src/ai/client/InteractionService.mjs');
+
+test.describe('Neo.ai.client.InteractionService', () => {
+    const
+        originalImportAddon    = Neo.Main.importAddon,
+        originalGetWindowData  = Neo.Main.getWindowData,
+        originalEventSimulator = Neo.main.addon.EventSimulator;
+
+    test.afterEach(() => {
+        Neo.Main.importAddon   = originalImportAddon;
+        Neo.Main.getWindowData = originalGetWindowData;
+
+        originalEventSimulator === undefined ?
+            delete Neo.main.addon.EventSimulator :
+            Neo.main.addon.EventSimulator = originalEventSimulator
+    });
+
+    test('simulateEvent executes the full raw sequence and aggregates a failed dispatch', async () => {
+        const
+            trace   = [],
+            results = [true, false, true],
+            host    = {
+                async dispatch(event) {
+                    trace.push(['dispatch', event.type]);
+
+                    return results.shift()
+                },
+                async timeout(delay) {
+                    trace.push(['delay', delay])
+                }
+            },
+            outcome = await InteractionService.prototype.simulateEvent.call(host, {
+                events: [
+                    {targetId: 'source', type: 'mousedown', windowId: 'main'},
+                    {delay: 20, targetId: 'missing', type: 'mousemove', windowId: 'main'},
+                    {targetId: 'document.body', type: 'mouseup', windowId: 'main'}
+                ]
+            });
+
+        expect(outcome).toBe(false);
+        expect(trace).toEqual([
+            ['dispatch', 'mousedown'],
+            ['delay', 20],
+            ['dispatch', 'mousemove'],
+            ['dispatch', 'mouseup']
+        ])
+    });
+
+    test('simulateEvent stays true only when every delegated dispatch succeeds', async () => {
+        const host = {
+            dispatch: async () => true,
+            timeout : async () => {}
+        };
+
+        await expect(InteractionService.prototype.simulateEvent.call(host, {
+            events: [{targetId: 'a', type: 'click', windowId: 'main'}]
+        })).resolves.toBe(true)
+    });
+
+    test('Client registration routes drive_drag through the InteractionService', () => {
+        const
+            map     = {get_window: {}},
+            service = {};
+
+        expect(registerInteractionServiceMethods(map, service)).toBe(map);
+        expect(map).toMatchObject({
+            drive_drag    : service,
+            simulate_event: service
+        })
+    });
+
+    test('resolveWindow reads the current owning Main realm when no projected geometry exists', async () => {
+        Neo.Main.getWindowData = async ({windowId}) => {
+            expect(windowId).toBe('source-window');
+
+            return {
+                innerHeight: 500,
+                innerWidth : 800,
+                outerHeight: 540,
+                outerWidth : 820,
+                screenLeft : 300,
+                screenTop  : 400
+            }
+        };
+
+        const resolved = await InteractionService.prototype.resolveWindow('source-window');
+
+        expect(resolved.id).toBe('source-window');
+        expect(resolved.innerRect).toMatchObject({height: 500, width: 800, x: 300, y: 400})
+    });
+
+    test('driveDrag resolves target-local geometry into one source-window atomic plan', async () => {
+        let captured,
+            sourceReads = 0;
+
+        const host = Object.create(InteractionService.prototype);
+
+        Object.assign(host, {
+            async resolveDomRect(targetId) {
+                return targetId === 'source' ?
+                    {height: 20, width: 40, x: 10, y: 20} :
+                    {height: 30, width: 50, x: 100, y: 200}
+            },
+            resolveWindow(windowId) {
+                windowId === 'source-window' && sourceReads++;
+
+                return {
+                    id       : windowId,
+                    innerRect: windowId === 'source-window' ? {x: 300, y: 400} : {x: 1200, y: 700}
+                }
+            }
+        });
+
+        Neo.Main.importAddon = async () => true;
+        Neo.main.addon.EventSimulator = {
+            async driveDrag(request) {
+                captured = request;
+                return {success: true, phase: 'complete'}
+            }
+        };
+
+        const outcome = await InteractionService.prototype.driveDrag.call(host, {
+            destination: {
+                anchor  : {x: 1, y: 0.5},
+                targetId: 'target',
+                windowId: 'target-window'
+            },
+            durationMs: 160,
+            source    : {
+                anchor  : {x: 0.5, y: 0.5},
+                targetId: 'source',
+                windowId: 'source-window'
+            },
+            steps: 8
+        });
+
+        expect(outcome).toEqual({success: true, phase: 'complete'});
+        expect(captured.windowId).toBe('source-window');
+        expect(captured.source).toMatchObject({
+            targetClient     : {x: 30, y: 30},
+            screen           : {x: 330, y: 430},
+            sourceEventClient: {x: 30, y: 30}
+        });
+        expect(captured.destination).toMatchObject({
+            targetClient     : {x: 150, y: 215},
+            screen           : {x: 1350, y: 915},
+            sourceEventClient: {x: 1050, y: 515},
+            windowId         : 'target-window'
+        });
+        expect(captured.path).toEqual([captured.destination])
+        expect(sourceReads, 'one source-window snapshot owns the whole coordinate conversion').toBe(1)
+    });
+
+    test('resolveDescriptor supports target-local point and source-relative delta as exclusive modes', async () => {
+        const
+            host = Object.assign(Object.create(InteractionService.prototype), {
+                resolveWindow: async windowId => ({id: windowId, innerRect: {x: 1000, y: 600}})
+            }),
+            sourceWindow = {id: 'source-window', innerRect: {x: 300, y: 400}},
+            source       = {
+                targetClient: {x: 30, y: 40},
+                windowId    : 'source-window'
+            },
+            point = await host.resolveDescriptor({clientX: 50, clientY: 70, windowId: 'target-window'}, source, sourceWindow),
+            delta = await host.resolveDescriptor({deltaX: 20, deltaY: -10}, source, sourceWindow);
+
+        expect(point).toMatchObject({
+            targetClient     : {x: 50, y: 70},
+            screen           : {x: 1050, y: 670},
+            sourceEventClient: {x: 750, y: 270}
+        });
+        expect(delta).toMatchObject({
+            targetClient     : {x: 50, y: 30},
+            screen           : {x: 350, y: 430},
+            sourceEventClient: {x: 50, y: 30}
+        });
+        await expect(host.resolveDescriptor({clientX: 1, clientY: 2, deltaX: 3, windowId: 'target-window'}, source, sourceWindow))
+            .rejects.toThrow(/exactly one/);
+        expect(() => host.normalizeAnchor({x: -0.1, y: 0.5})).toThrow(/\[0,1\]/)
+    });
+
+    test('driveDrag rejects competing screen authority before any Main call', async () => {
+        let called = false;
+
+        const host = Object.create(InteractionService.prototype);
+
+        Object.assign(host, {
+            async resolveDomRect() {
+                return {height: 20, width: 20, x: 10, y: 10}
+            },
+            resolveWindow(windowId) {
+                return {id: windowId, innerRect: {x: 0, y: 0}}
+            }
+        });
+
+        Neo.Main.importAddon = async () => {called = true};
+
+        const outcome = await InteractionService.prototype.driveDrag.call(host, {
+            destination: {clientX: 40, clientY: 20, screenX: 40, windowId: 'main'},
+            source     : {targetId: 'source', windowId: 'main'}
+        });
+
+        expect(outcome).toMatchObject({
+            success: false,
+            phase  : 'resolution',
+            error  : {code: 'DRIVE_RESOLUTION_FAILED'}
+        });
+        expect(called).toBe(false)
+    })
+});

--- a/test/playwright/unit/main/addon/EventSimulator.spec.mjs
+++ b/test/playwright/unit/main/addon/EventSimulator.spec.mjs
@@ -1,0 +1,412 @@
+import {setup} from '../../../setup.mjs';
+
+setup({
+    appConfig       : {name: 'MainEventSimulatorAtomicDragUnit'},
+    mockLocalStorage: false,
+    mockMain        : false,
+    neoConfig       : {unitTestMode: true}
+});
+
+import {test, expect} from '@playwright/test';
+import Neo            from '../../../../../src/Neo.mjs';
+import * as core      from '../../../../../src/core/_export.mjs';
+
+const
+    originalDocument  = globalThis.document,
+    originalDomAccess = Neo.main.DomAccess,
+    documentRef       = new EventTarget();
+
+documentRef.body = {};
+documentRef.getElementById = () => null;
+documentRef.querySelector  = () => null;
+globalThis.document = documentRef;
+
+delete Neo.main.DomAccess;
+
+const {default: EventSimulator} = await import('../../../../../src/main/addon/EventSimulator.mjs');
+
+function lifecycle(type, originalEvent) {
+    const event = new Event(type);
+
+    event.detail = {originalEvent};
+    documentRef.dispatchEvent(event)
+}
+
+test.describe('Neo.main.addon.EventSimulator.driveDrag', () => {
+    test.afterAll(() => {
+        originalDomAccess === undefined ? delete Neo.main.DomAccess : Neo.main.DomAccess = originalDomAccess;
+        originalDocument === undefined ? delete globalThis.document : globalThis.document = originalDocument
+    });
+
+    test('the raw dispatch contract still returns false for a missing target', () => {
+        expect(EventSimulator.dispatch({id: 'missing-node', type: 'click'})).toBe(false)
+    });
+
+    test('a second executor is refused before touching the live sensor', async () => {
+        const outcome = await EventSimulator.constructor.prototype.driveDrag.call({driveActive: true}, {});
+
+        expect(outcome).toMatchObject({
+            success: false,
+            phase  : 'busy',
+            error  : {code: 'DRAG_BUSY'}
+        })
+    });
+
+    test('owns one correlated start, post-arm move series and terminal end after source removal', async () => {
+        let downEvent,
+            moveIndex = 0,
+            sourceAvailable = true,
+            thresholdReads = 0;
+
+        const
+            calls  = [],
+            sensor = {currentElement: null, dragging: false},
+            host   = Object.create(EventSimulator.constructor.prototype);
+
+        Object.defineProperties(sensor, {
+            delay      : {get() {thresholdReads++; return 37}},
+            minDistance: {get() {thresholdReads++; return 6}}
+        });
+
+        Object.assign(host, {
+            driveActive     : false,
+            getDriveDocument: () => documentRef,
+            async resolveMouseSensor() {
+                return sensor
+            },
+            async timeout() {},
+            dispatchNative(data, onCreate) {
+                if (data.id === 'source' && !sourceAvailable) {
+                    return {event: null, success: false}
+                }
+
+                const event = {type: data.type};
+
+                onCreate?.(event);
+                calls.push({id: data.id, type: data.type});
+
+                if (data.type === 'mousedown') {
+                    downEvent       = event;
+                    sourceAvailable = false
+                } else if (data.type === 'mousemove') {
+                    moveIndex++;
+                    lifecycle(moveIndex === 1 ? 'drag:start' : 'drag:move', moveIndex === 1 ? downEvent : event)
+                } else if (data.type === 'mouseup') {
+                    lifecycle('drag:end', event)
+                }
+
+                return {event, success: true}
+            }
+        });
+
+        const outcome = await EventSimulator.constructor.prototype.driveDrag.call(host, {
+            destination: {
+                screen           : {x: 120, y: 20},
+                sourceEventClient: {x: 120, y: 20},
+                targetClient     : {x: 120, y: 20},
+                windowId         : 'main'
+            },
+            durationMs: 40,
+            path      : [{screen: {x: 120, y: 20}, sourceEventClient: {x: 120, y: 20}}],
+            source    : {
+                screen           : {x: 20, y: 20},
+                sourceEventClient: {x: 20, y: 20},
+                targetClient     : {x: 20, y: 20},
+                targetId         : 'source',
+                windowId         : 'main'
+            },
+            steps: 2
+        });
+
+        expect(outcome.success).toBe(true);
+        expect(outcome.phase).toBe('complete');
+        expect(outcome.sensor).toEqual({delayMs: 37, minDistance: 6});
+        expect(outcome.dispatch).toEqual({down: true, moveCount: 3, up: true});
+        expect(outcome.observed).toEqual({ended: true, moveCount: 2, started: true});
+        expect(outcome.released).toBe(true);
+        expect(sourceAvailable, 'the source is gone after mousedown; body owns every later event').toBe(false);
+        expect(thresholdReads).toBe(2);
+        expect(calls).toEqual([
+            {id: 'source',        type: 'mousedown'},
+            {id: 'document.body', type: 'mousemove'},
+            {id: 'document.body', type: 'mousemove'},
+            {id: 'document.body', type: 'mousemove'},
+            {id: 'document.body', type: 'mouseup'}
+        ])
+    });
+
+    test('an unrelated document lifecycle cannot arm the transaction, and cleanup releases once', async () => {
+        let downEvent,
+            upCount = 0;
+
+        const
+            calls = [],
+            host  = Object.create(EventSimulator.constructor.prototype);
+
+        Object.assign(host, {
+            driveActive     : false,
+            getDriveDocument: () => documentRef,
+            async resolveMouseSensor() {
+                return {currentElement: null, delay: 0, dragging: false, minDistance: 5}
+            },
+            async timeout() {},
+            dispatchNative(data, onCreate) {
+                const event = {type: data.type};
+
+                onCreate?.(event);
+                calls.push(data.type);
+
+                if (data.type === 'mousedown') {
+                    downEvent = event
+                } else if (data.type === 'mousemove') {
+                    lifecycle('drag:start', {foreign: true})
+                } else if (data.type === 'mouseup') {
+                    upCount++;
+                    lifecycle('drag:end', event)
+                }
+
+                return {event, success: true}
+            }
+        });
+
+        const outcome = await EventSimulator.constructor.prototype.driveDrag.call(host, {
+            destination: {screen: {x: 100, y: 0}, sourceEventClient: {x: 100, y: 0}},
+            durationMs : 32,
+            path       : [{screen: {x: 100, y: 0}, sourceEventClient: {x: 100, y: 0}}],
+            source     : {screen: {x: 0, y: 0}, sourceEventClient: {x: 0, y: 0}, targetId: 'source'},
+            steps      : 2
+        });
+
+        expect(downEvent).toBeTruthy();
+        expect(outcome).toMatchObject({
+            success : false,
+            phase   : 'arming',
+            error   : {code: 'DRAG_NOT_ARMED'},
+            cleanup : {attempted: true, succeeded: true},
+            observed: {started: false}
+        });
+        expect(upCount).toBe(1);
+        expect(calls).toEqual(['mousedown', 'mousemove', 'mouseup'])
+    });
+
+    test('a missing source fails dispatch before arming and needs no cleanup release', async () => {
+        const host = Object.assign(Object.create(EventSimulator.constructor.prototype), {
+            driveActive     : false,
+            getDriveDocument: () => documentRef,
+            async resolveMouseSensor() {
+                return {currentElement: null, delay: 0, dragging: false, minDistance: 5}
+            },
+            dispatchNative() {
+                return {event: null, success: false}
+            }
+        });
+
+        const outcome = await EventSimulator.constructor.prototype.driveDrag.call(host, {
+            destination: {screen: {x: 100, y: 0}, sourceEventClient: {x: 100, y: 0}},
+            durationMs : 16,
+            path       : [{screen: {x: 100, y: 0}, sourceEventClient: {x: 100, y: 0}}],
+            source     : {screen: {x: 0, y: 0}, sourceEventClient: {x: 0, y: 0}, targetId: 'missing'},
+            steps      : 1
+        });
+
+        expect(outcome).toMatchObject({
+            success: false,
+            phase  : 'dispatch',
+            error  : {code: 'MOUSEDOWN_DISPATCH_FAILED'},
+            cleanup: {attempted: false}
+        })
+    });
+
+    test('a failed best-effort mouseup reports cleanup failure without greening the gesture', async () => {
+        const host = Object.assign(Object.create(EventSimulator.constructor.prototype), {
+            driveActive     : false,
+            getDriveDocument: () => documentRef,
+            async resolveMouseSensor() {
+                return {currentElement: null, delay: 0, dragging: false, minDistance: 5}
+            },
+            async timeout() {},
+            dispatchNative(data, onCreate) {
+                const event = {type: data.type};
+
+                onCreate?.(event);
+
+                return {event, success: data.type !== 'mouseup'}
+            }
+        });
+
+        const outcome = await EventSimulator.constructor.prototype.driveDrag.call(host, {
+            destination: {screen: {x: 100, y: 0}, sourceEventClient: {x: 100, y: 0}},
+            durationMs : 16,
+            path       : [{screen: {x: 100, y: 0}, sourceEventClient: {x: 100, y: 0}}],
+            source     : {screen: {x: 0, y: 0}, sourceEventClient: {x: 0, y: 0}, targetId: 'source'},
+            steps      : 1
+        });
+
+        expect(outcome).toMatchObject({
+            success: false,
+            phase  : 'cleanup',
+            error  : {code: 'CLEANUP_RELEASE_FAILED'},
+            cleanup: {attempted: true, succeeded: false}
+        })
+    });
+
+    test('an already-engaged source sensor is refused before dispatch', async () => {
+        let dispatches = 0;
+
+        const host = Object.create(EventSimulator.constructor.prototype);
+
+        Object.assign(host, {
+            driveActive     : false,
+            getDriveDocument: () => documentRef,
+            async resolveMouseSensor() {
+                return {currentElement: {}, delay: 0, dragging: false, minDistance: 5}
+            },
+            dispatchNative() {
+                dispatches++;
+                return {event: {}, success: true}
+            }
+        });
+
+        const outcome = await EventSimulator.constructor.prototype.driveDrag.call(host, {
+            destination: {screen: {x: 100, y: 0}, sourceEventClient: {x: 100, y: 0}},
+            durationMs : 20,
+            path       : [{screen: {x: 100, y: 0}, sourceEventClient: {x: 100, y: 0}}],
+            source     : {screen: {x: 0, y: 0}, sourceEventClient: {x: 0, y: 0}, targetId: 'source'},
+            steps      : 1
+        });
+
+        expect(outcome).toMatchObject({success: false, phase: 'busy', error: {code: 'MOUSE_SENSOR_BUSY'}});
+        expect(dispatches).toBe(0)
+    });
+
+    test('a path shorter than the live threshold fails without inventing an overshoot', async () => {
+        let dispatches = 0;
+
+        const host = Object.create(EventSimulator.constructor.prototype);
+
+        Object.assign(host, {
+            driveActive     : false,
+            getDriveDocument: () => documentRef,
+            async resolveMouseSensor() {
+                return {currentElement: null, delay: 0, dragging: false, minDistance: 20}
+            },
+            dispatchNative() {
+                dispatches++;
+                return {event: {}, success: true}
+            }
+        });
+
+        const outcome = await EventSimulator.constructor.prototype.driveDrag.call(host, {
+            destination: {screen: {x: 10, y: 0}, sourceEventClient: {x: 10, y: 0}},
+            durationMs : 20,
+            path       : [{screen: {x: 10, y: 0}, sourceEventClient: {x: 10, y: 0}}],
+            source     : {screen: {x: 0, y: 0}, sourceEventClient: {x: 0, y: 0}, targetId: 'source'},
+            steps      : 1
+        });
+
+        expect(outcome).toMatchObject({success: false, phase: 'arming', error: {code: 'PATH_TOO_SHORT'}});
+        expect(dispatches).toBe(0)
+    });
+
+    test('arming without a correlated post-arm move fails movement and releases once', async () => {
+        let downEvent,
+            moveIndex = 0,
+            upCount   = 0;
+
+        const host = Object.create(EventSimulator.constructor.prototype);
+
+        Object.assign(host, {
+            driveActive     : false,
+            getDriveDocument: () => documentRef,
+            async resolveMouseSensor() {
+                return {currentElement: null, delay: 0, dragging: false, minDistance: 5}
+            },
+            async timeout() {},
+            dispatchNative(data, onCreate) {
+                const event = {type: data.type};
+
+                onCreate?.(event);
+
+                if (data.type === 'mousedown') {
+                    downEvent = event
+                } else if (data.type === 'mousemove') {
+                    moveIndex++;
+                    moveIndex === 1 && lifecycle('drag:start', downEvent)
+                } else if (data.type === 'mouseup') {
+                    upCount++;
+                    lifecycle('drag:end', event)
+                }
+
+                return {event, success: true}
+            }
+        });
+
+        const outcome = await EventSimulator.constructor.prototype.driveDrag.call(host, {
+            destination: {screen: {x: 100, y: 0}, sourceEventClient: {x: 100, y: 0}},
+            durationMs : 32,
+            path       : [{screen: {x: 100, y: 0}, sourceEventClient: {x: 100, y: 0}}],
+            source     : {screen: {x: 0, y: 0}, sourceEventClient: {x: 0, y: 0}, targetId: 'source'},
+            steps      : 2
+        });
+
+        expect(outcome).toMatchObject({
+            success : false,
+            phase   : 'movement',
+            error   : {code: 'DRAG_MOVE_NOT_OBSERVED'},
+            cleanup : {attempted: true, succeeded: true},
+            observed: {started: true, moveCount: 0}
+        });
+        expect(upCount).toBe(1)
+    });
+
+    test('a missing correlated drag:end stays a release failure after mouseup dispatch', async () => {
+        let downEvent,
+            moveIndex = 0,
+            upCount   = 0;
+
+        const host = Object.create(EventSimulator.constructor.prototype);
+
+        Object.assign(host, {
+            driveActive     : false,
+            getDriveDocument: () => documentRef,
+            async resolveMouseSensor() {
+                return {currentElement: null, delay: 0, dragging: false, minDistance: 5}
+            },
+            async timeout() {},
+            dispatchNative(data, onCreate) {
+                const event = {type: data.type};
+
+                onCreate?.(event);
+
+                if (data.type === 'mousedown') {
+                    downEvent = event
+                } else if (data.type === 'mousemove') {
+                    moveIndex++;
+                    lifecycle(moveIndex === 1 ? 'drag:start' : 'drag:move', moveIndex === 1 ? downEvent : event)
+                } else if (data.type === 'mouseup') {
+                    upCount++
+                }
+
+                return {event, success: true}
+            }
+        });
+
+        const outcome = await EventSimulator.constructor.prototype.driveDrag.call(host, {
+            destination: {screen: {x: 100, y: 0}, sourceEventClient: {x: 100, y: 0}},
+            durationMs : 16,
+            path       : [{screen: {x: 100, y: 0}, sourceEventClient: {x: 100, y: 0}}],
+            source     : {screen: {x: 0, y: 0}, sourceEventClient: {x: 0, y: 0}, targetId: 'source'},
+            steps      : 1
+        });
+
+        expect(outcome).toMatchObject({
+            success : false,
+            phase   : 'release',
+            error   : {code: 'DRAG_END_NOT_OBSERVED'},
+            dispatch: {up: true},
+            cleanup : {attempted: true, succeeded: true},
+            released: false
+        });
+        expect(upCount, 'terminal up plus one best-effort cleanup release').toBe(2)
+    })
+});


### PR DESCRIPTION
Resolves #17821

Adds one Engine-owned atomic drag transaction: the App worker validates and resolves live
same-/cross-window geometry, the source Main realm drives the exact live Mouse sensor, and the
receipt distinguishes raw dispatch from correlated `drag:start` / `drag:move` / `drag:end`.
`simulate_event` remains the full-sequence raw escape hatch and now reports aggregate dispatch
failure without skipping cleanup events.

Related: neomjs/neo-agent-brain#204

Evidence: L3 (live same-window Splitter actuation plus two-window Neural Link coordinate proof) → L3 required (runtime gesture, release, and cross-window coordinate ACs). No residuals.

## AC Evidence

| AC | Evidence |
|---|---|
| AC-1 | CI-covered: `src/ai/Client.mjs` uses `registerInteractionServiceMethods()`; `InteractionService.spec.mjs` pins `drive_drag → InteractionService`, exclusive modes, bounds, and competing-screen refusal. |
| AC-2 | CI-covered geometry units plus outside-CI `WindowOps.spec.mjs`: live Main-realm window data + BCR anchors derive target-local → screen → source-event points; source window is sampled once. |
| AC-3 | CI-covered `EventSimulator.spec.mjs` reads getter-backed live thresholds; outside-CI Splitter witness overrides the sensor to `delay=180`, `minDistance=11` and receives those exact values. |
| AC-4 | CI-covered `EventSimulator.spec.mjs` pins source-node down, a separate arming move, post-arm body moves, body release, path bounds, and post-arm duration. |
| AC-5 | CI-covered success and foreign-lifecycle negative controls require correlated start, move, and end from this transaction's exact native events. |
| AC-6 | CI-covered typed receipts separate dispatch/observed counts and resolved coordinate spaces; outside-CI Splitter assertions separately prove durable component geometry. |
| AC-7 | CI-covered failures: competing executor, busy sensor, short path, missing source, absent movement, missing terminal, and failed cleanup all retain exact phases and partial receipts. |
| AC-8 | CI-covered success control removes the source after mousedown; every later move and release must use `document.body`. |
| AC-9 | CI-covered mixed-success `simulateEvent()` sequence proves later mouseup still runs and the aggregate returns false. |
| AC-10 | CI-covered focused units exercise request modes/geometry, Client registration, live sensor authority, correlation, concurrency, scheduling, and cleanup. |
| AC-11 | CI-covered source shape: `test/playwright/fixtures.mjs#driveDrag()` calls the raw Engine RPC without importing Brain gesture semantics. |
| AC-12 | Outside-CI live proofs: atomic Splitter actuation/commit and two-window target-local → screen → source-event routing. |
| AC-13 | CI-covered guide source: `WhiteboxE2E.md` separates raw `simulateEvent`, whole-gesture `driveDrag`, and held/intervenable `page.mouse`. |
| AC-14 | Brain consumer remains separately owned by neomjs/neo-agent-brain#204; this diff changes no Brain API and returns the typed envelope that ticket consumes after merge. |

## Deltas from ticket

- A dedicated-worker source window has no projected `WindowManager.innerRect`; live proof caught
  that gap. Resolution now asks the owning Main realm for current window data and reuses the
  manager's canonical geometry calculator.
- Client registration uses one exported, side-effect-free helper so its focused unit does not
  instantiate the connecting Client singleton.
- No semantic dock/grid/splitter operation, consumer migration, diagnostic ledger, or Brain API was
  added.

## Test Evidence

- `NEO_AGENTOS_RUNTIME_ROOT=<brain-root> NEO_TEST_SKIP_CI=true npx playwright test core/SplitterLiveResizeNL.spec.mjs -c test/playwright/playwright.config.e2e.mjs --workers=1 --headed --grep 'atomic live release'` — 1/1 passed; real sensor values `180/11`, correlated lifecycle, release, and durable splitter width all observed.
- `NEO_AGENTOS_RUNTIME_ROOT=<brain-root> NEO_TEST_SKIP_CI=true npx playwright test neural-link/WindowOps.spec.mjs -c test/playwright/playwright.config.e2e.mjs --workers=1 --headed` — full journey passed once; repeated runs reached and passed the new atomic cross-window assertions, then the pre-existing native `positionWindow` step returned `blocked:true`.
- Untouched `origin/dev` control of the same `WindowOps` journey returned the identical later native-position refusal, proving that red branch-independent.

## Post-Merge Validation

- [x] None. Brain integration remains independently owned by neomjs/neo-agent-brain#204.

## Evolution

The first live same-window run falsified the manager-only geometry assumption: non-SharedWorker
apps publish their logical window identity without an `innerRect`. The final design reads live
geometry from the owning Main realm immediately before execution, while retaining the existing
Window manager calculator as the browser-normalization authority.

Authored by Euclid (GPT-5.6 Sol, Codex Desktop). Session ef7facf1-430b-42bc-9ed4-48332615e259.
