### PR TITLE
Committed-drag journeys speak the v13.2 mechanics (#17863)

### DIFF
--- a/test/playwright/e2e/workstation/WorkstationDockFlipResizeNL.spec.mjs
+++ b/test/playwright/e2e/workstation/WorkstationDockFlipResizeNL.spec.mjs
@@ -40,12 +40,13 @@ test.describe('Workstation — DockFlip classifies a committed splitter resize a
         await page.goto('/apps/workstation/index.html');
         await page.waitForSelector('.workstation-dock-host', {timeout: 30000});
 
-        const app            = await neuralLink.connectToApp('Workstation'),
-              splitterResult = await app.queryVdom({cls: 'neo-dashboard-dock-splitter-horizontal'}),
-              splitterNode   = Array.isArray(splitterResult) ? splitterResult[0] : (splitterResult?.vdom ?? splitterResult),
-              splitterDomId  = splitterNode?.id;
+        // resizable edge zones share the orientation class — only the SPLIT container's own child
+        // commits resizeSplit and plays the landed-in-place FLIP this journey measures
+        const app           = await neuralLink.connectToApp('Workstation'),
+              splitterDomId = await page.evaluate(() =>
+                  document.querySelector('.neo-dashboard-dock-split-horizontal > .neo-dashboard-dock-splitter-horizontal')?.id);
 
-        expect(splitterDomId, 'the horizontal splitter must exist in the vdom').toBeTruthy();
+        expect(splitterDomId, 'the main split splitter must exist in the rendered projection').toBeTruthy();
 
         const [rect] = await app.getDomRect(splitterDomId),
               cx     = rect.x + rect.width / 2,
@@ -101,6 +102,11 @@ test.describe('Workstation — DockFlip classifies a committed splitter resize a
 
         await page.mouse.move(cx, cy);
         await page.mouse.down();
+        // the Mouse sensor arms once delay AND minDistance are both satisfied — evaluated at
+        // move events and once more when the delay timer re-enters with the latest coords. A
+        // drive that moves and releases inside the delay window clears that timer on mouseup,
+        // so no drag session ever opens, nothing commits, and nothing can flip
+        await page.waitForTimeout(130);
         await page.mouse.move(cx + 40, cy, {steps: 4});
         await page.mouse.move(cx + 160, cy, {steps: 8});
         await page.mouse.up();
@@ -112,22 +118,37 @@ test.describe('Workstation — DockFlip classifies a committed splitter resize a
 
         const landedIdx  = samples.findIndex(s => Math.abs(s.w - w1) <= 2),
               inverseIdx = landedIdx < 0 ? -1 : samples.findIndex((s, i) => i >= landedIdx && s.transformed),
-              exposed    = landedIdx < 0 ? 0 : (inverseIdx < 0 ? Infinity : inverseIdx - landedIdx),
-              exposedMs  = landedIdx < 0 ? 0 : (inverseIdx < 0 ? Infinity : samples[inverseIdx].t - samples[landedIdx].t);
+              // a reversal = an UNTRANSFORMED sample leaving the landed width again — the
+              // double-take's visible snap-back without the motion system owning the frame
+              reversalIdx = landedIdx < 0 ? -1 : samples.findIndex((s, i) => i > landedIdx && !s.transformed && Math.abs(s.w - w1) > 2),
+              exposed     = landedIdx < 0 || inverseIdx < 0 ? 0 : inverseIdx - landedIdx,
+              exposedMs   = landedIdx < 0 || inverseIdx < 0 ? 0 : samples[inverseIdx].t - samples[landedIdx].t;
 
-        console.log('[flip-diag] w0:', w0, 'w1:', w1, 'landedIdx:', landedIdx, 'inverseIdx:', inverseIdx, 'exposedFrames:', exposed, 'exposedMs:', exposedMs, 'samples:', samples.length);
+        console.log('[flip-diag] w0:', w0, 'w1:', w1, 'landedIdx:', landedIdx, 'inverseIdx:', inverseIdx, 'reversalIdx:', reversalIdx, 'exposedFrames:', exposed, 'exposedMs:', exposedMs, 'samples:', samples.length);
         console.log('[flip-diag] window:', JSON.stringify(samples.slice(Math.max(0, (landedIdx < 0 ? 0 : landedIdx) - 3), (landedIdx < 0 ? 0 : landedIdx) + 20)));
 
         expect(Math.abs(w1 - w0), 'the drag must have committed a real resize (~+160px on the left pane)').toBeGreaterThan(100);
 
-        // AC1/AC2: the committed layout may sit exposed WITHOUT its inverse for at most ~2 rAF
-        // frames at a 60Hz cadence — asserted as 34ms because rAF cadence is host-dependent
-        // (this host samples at 120Hz; the red state's stage-A burn measured ~150-300ms here).
-        // landedIdx === -1 means the layout never painted without its inverse — the ideal landing.
-        expect(
-            exposedMs,
-            `the committed layout sat exposed for ${exposed} frames / ${exposedMs}ms before the inverse installed (red state: ~15 frames / 150-300ms)`
-        ).toBeLessThanOrEqual(34);
+        // AC1/AC2, mode-aware. The double-take needs a DISCONTINUITY: the committed layout
+        // painting displaced frames the motion system does not own.
+        // - When a FLIP plays (a transform appears), the committed layout may sit exposed
+        //   without its inverse for at most ~2 rAF frames — asserted as 34ms because rAF
+        //   cadence is host-dependent (the red state's stage-A burn measured ~150-300ms here).
+        // - Under the live boundary preview there is nothing to invert: the pane reaches the
+        //   committed width UNDER THE POINTER and release changes no pixels (terminal parity),
+        //   so no transform ever appearing is the ideal — provided no untransformed frame
+        //   leaves the landed width again (that reversal IS the double-take's signature).
+        if (inverseIdx >= 0) {
+            expect(
+                exposedMs,
+                `the committed layout sat exposed for ${exposed} frames / ${exposedMs}ms before the inverse installed (red state: ~15 frames / 150-300ms)`
+            ).toBeLessThanOrEqual(34)
+        } else {
+            expect(
+                reversalIdx,
+                'without a playing flip, no untransformed frame may leave the landed width again (the visible double-take)'
+            ).toBe(-1)
+        }
 
         // Settlement truth: after the full gesture + play, the pane converges to the committed
         // geometry and no transform lingers.

--- a/test/playwright/e2e/workstation/WorkstationDockFlipResizeNL.spec.mjs
+++ b/test/playwright/e2e/workstation/WorkstationDockFlipResizeNL.spec.mjs
@@ -1,28 +1,33 @@
 import {test, expect} from '../../fixtures.mjs';
 
 /**
- * @summary Whitebox E2E witness: a committed same-node splitter resize must be
- * classified as landed-in-place, not as a replacement tree.
+ * @summary Whitebox E2E witness: a committed splitter resize paints no visible double-take —
+ * in EITHER presentation mode.
  *
- * Defect mechanics (red state): the marker nodes of a committed resize survive in place with
- * unchanged ancestor lineage, so `hasPreservedMarkerSet()` can never classify the set — the
- * replacement-tree branch burns its full bounded detach poll (`maxFrames = 15`) on nodes that
- * never detach. The committed layout sits EXPOSED for ~15 frames, then the inverse transform
- * snaps the panes back to their pre-drag geometry and plays forward — a double-take on every
- * committed splitter drag, and the wide window in which async gBCR readers ingest scaled
- * fiction.
+ * The guarded property is the user-visible discontinuity around the commit, and it has two
+ * legitimate green shapes:
  *
- * Fix under test: the geometry discriminator `hasLandedInPlace()` — an exact, lineage-
- * unchanged marker set whose current rect already differs from First beyond the motion
- * epsilons has landed in place; stage A and the replacement-tree settle frame are bypassed.
+ * - **A FLIP plays** (deferred presentation, or any future path that moves pixels at commit):
+ *   the committed layout may sit exposed without its inverse transform for at most ~2 rAF
+ *   frames. The historic red state burned ~15 frames — the marker nodes of a same-node commit
+ *   survive in place with unchanged lineage, `hasPreservedMarkerSet()` could never classify
+ *   the set, and the replacement-tree branch exhausted its bounded detach poll before the
+ *   inverse snapped the panes back and played forward: a double-take on every committed drag,
+ *   and the window in which async gBCR readers ingest scaled fiction. The landed-in-place
+ *   discriminator (`hasLandedInPlace()`) closes that window.
+ * - **No FLIP plays** (the live boundary preview): the pane reaches the committed width UNDER
+ *   the pointer and release changes no pixels (terminal parity), so there is nothing to
+ *   invert — no transform ever appearing is the ideal, PROVIDED no untransformed frame leaves
+ *   the landed width again. That reversal is the double-take's visible signature, and the
+ *   witness stays failing-capable through it.
  *
  * Witness method: a page-side rAF sampler records the visual (computed, transform-inclusive)
- * width of the pane left of the dragged splitter across the commit. The discriminating
- * measurement is the exposed-Last window: the TIME between the committed layout first painting
- * and the inverse transform appearing. The assertion is time-based, not frame-count-based:
- * the close-target AC's "within 2 rAF frames" phrasing assumes a 60Hz cadence (~34ms); this host samples at
- * 120Hz, where a frame count would misread by 2x. Red: ~150-300ms (the 15-frame stage-A burn).
- * Green: <= 34ms, or the layout never paints without its inverse at all.
+ * width of the pane left of the dragged splitter across the whole gesture. When an inverse
+ * appears, the exposed-window assertion is time-based, not frame-count-based: the close-target
+ * AC's "within 2 rAF frames" phrasing assumes a 60Hz cadence (~34ms); this host samples at
+ * 120Hz, where a frame count would misread by 2x. Without an inverse, the reversal scan owns
+ * the verdict. Out of scope by design: a hypothetical jump-cut-without-flip (motion absence)
+ * belongs to the DockMotion specs, not this discontinuity witness.
  *
  * CDP page.mouse is REQUIRED: the commit must ride the trusted-input path (the app-side
  * synthetic path does not exercise the real drag lifecycle — measured in the drag-selection lane).
@@ -36,7 +41,7 @@ test.describe('Workstation — DockFlip classifies a committed splitter resize a
         viewport      : {height: 900, width: 1440}
     });
 
-    test('the inverse transform installs within 2 frames of the committed layout landing (no stage-A double-take)', async ({page, neuralLink}) => {
+    test('a committed splitter resize paints no double-take: bounded inverse when a FLIP plays, no untransformed reversal when live parity needs none', async ({page, neuralLink}) => {
         await page.goto('/apps/workstation/index.html');
         await page.waitForSelector('.workstation-dock-host', {timeout: 30000});
 

--- a/test/playwright/e2e/workstation/WorkstationGridRepaintNL.spec.mjs
+++ b/test/playwright/e2e/workstation/WorkstationGridRepaintNL.spec.mjs
@@ -9,7 +9,9 @@ import {test, expect} from '../../fixtures.mjs';
  */
 const readHorizontalSplitGeometry = page => page.evaluate(() => {
     const
-        splitter = document.querySelector('.neo-dashboard-dock-splitter-horizontal'),
+        // resizable edge zones share the orientation class — this journey reads the SPLIT
+        // container's own boundary, the one a resizeSplit commit moves
+        splitter = document.querySelector('.neo-dashboard-dock-split-horizontal > .neo-dashboard-dock-splitter-horizontal'),
         children = splitter && [...splitter.parentElement.children]
             .filter(element => !element.classList.contains('neo-dashboard-dock-splitter'));
 
@@ -26,6 +28,17 @@ const readHorizontalSplitGeometry = page => page.evaluate(() => {
         secondWidth  : second.width
     }
 });
+
+/**
+ * Resolves the main split node's own splitter through its owning split container. Resizable
+ * edge zones project splitters with the same orientation class, so a bare first-match on
+ * `neo-dashboard-dock-splitter-horizontal` grabs the LEFT EDGE affordance — whose drag commits
+ * a `resizeEdgeZone` extent, never the `resizeSplit` sizes this journey settles on.
+ * @param {import('@playwright/test').Page} page
+ * @returns {Promise<String|undefined>} The splitter's DOM id.
+ */
+const resolveSplitSplitterId = page => page.evaluate(() =>
+    document.querySelector('.neo-dashboard-dock-split-horizontal > .neo-dashboard-dock-splitter-horizontal')?.id);
 
 /**
  * Arms a MutationObserver that flips a page-global flag the moment the workspace enters the
@@ -216,12 +229,10 @@ test.describe('Workstation — grid repaint truth across a real splitter drag', 
         const windowId = await page.evaluate(() => Neo.worker.Manager.windowId);
 
         const dragSplitter = async direction => {
-            const splitterResult = await app.queryVdom({cls: 'neo-dashboard-dock-splitter-horizontal'}, wsId),
-                  splitterNode   = Array.isArray(splitterResult) ? splitterResult[0] : (splitterResult?.vdom ?? splitterResult),
-                  splitterDomId  = splitterNode?.id,
-                  [rect]         = await app.getDomRect(splitterDomId),
-                  cx             = rect.x + rect.width / 2,
-                  cy             = rect.y + rect.height / 2;
+            const splitterDomId = await resolveSplitSplitterId(page),
+                  [rect]        = await app.getDomRect(splitterDomId),
+                  cx            = rect.x + rect.width / 2,
+                  cy            = rect.y + rect.height / 2;
 
             expect(splitterDomId, 'the horizontal splitter must exist in the vdom').toBeTruthy();
 
@@ -438,13 +449,11 @@ test.describe('Workstation — grid repaint truth across a real splitter drag', 
         ).toBe(String(pre));
 
         // --- the real drag on the split that resizes THIS pane ----------------------------
-        const windowId2       = await page.evaluate(() => Neo.worker.Manager.windowId),
-              splitterResult2 = await app.queryVdom({cls: 'neo-dashboard-dock-splitter-horizontal'}, wsId),
-              splitterNode2   = Array.isArray(splitterResult2) ? splitterResult2[0] : (splitterResult2?.vdom ?? splitterResult2),
-              splitterDomId2  = splitterNode2?.id,
-              [rect2]         = await app.getDomRect(splitterDomId2),
-              cx              = rect2.x + rect2.width / 2,
-              cy              = rect2.y + rect2.height / 2;
+        const windowId2      = await page.evaluate(() => Neo.worker.Manager.windowId),
+              splitterDomId2 = await resolveSplitSplitterId(page),
+              [rect2]        = await app.getDomRect(splitterDomId2),
+              cx             = rect2.x + rect2.width / 2,
+              cy             = rect2.y + rect2.height / 2;
 
         expect(splitterDomId2, 'the horizontal splitter must exist in the vdom').toBeTruthy();
 

--- a/test/playwright/e2e/workstation/WorkstationNL.spec.mjs
+++ b/test/playwright/e2e/workstation/WorkstationNL.spec.mjs
@@ -608,7 +608,9 @@ test.describe('Workstation — dense living-data composition', () => {
             }).toEqual({
                 height   : viewport.height,
                 railTabs : 2,
-                splitters: 2,
+                // 2 split-node boundaries + 3 resizable edge affordances (left/right/bottom
+                // bands each project their own splitter since edge zones became resizable)
+                splitters: 5,
                 viewport,
                 width    : viewport.width
             });
@@ -654,7 +656,12 @@ test.describe('Workstation — dense living-data composition', () => {
             shortGeometry  = await readAtViewport({height: 600, width: 900});
 
         /**
-         * @summary Asserts each band resolves its cq unit and rem clamp against the measured dock host.
+         * @summary Asserts each band renders its COMMITTED document extent against the measured
+         * dock host, inside the theme floors and the engine's per-edge 50% cap.
+         *
+         * The band's size authority is the dock document (`extent` → the projection's inline
+         * percentage), no longer a preferred-width clamp: the theme keeps rem floors on the drag
+         * axis and the engine default caps each edge individually at 50% of its container.
          * @param {Object} geometry
          * @returns {void}
          */
@@ -673,18 +680,18 @@ test.describe('Workstation — dense living-data composition', () => {
             expect(geometry.bottomBand.nearestQueryContainerId).toBe(dockHost.id);
             expect(geometry.leftBand.computedExtent).toBeCloseTo(clamp(
                 rootFontSize * 11.25,
-                dockHost.contentInlineSize * 0.203125,
-                rootFontSize * 16.25
+                dockHost.contentInlineSize * 0.20,
+                dockHost.contentInlineSize * 0.5
             ), 1);
             expect(geometry.rightBand.computedExtent).toBeCloseTo(clamp(
                 rootFontSize * 13.75,
                 dockHost.contentInlineSize * 0.25,
-                rootFontSize * 20
+                dockHost.contentInlineSize * 0.5
             ), 1);
             expect(geometry.bottomBand.computedExtent).toBeCloseTo(clamp(
                 rootFontSize * 8.75,
-                dockHost.contentBlockSize * 0.28,
-                rootFontSize * 12.5
+                dockHost.contentBlockSize * 0.25,
+                dockHost.contentBlockSize * 0.5
             ), 1)
         };
 
@@ -722,10 +729,12 @@ test.describe('Workstation — dense living-data composition', () => {
         const largeHostGeometry = await readAtHost({height: 600, width: 1100});
 
         assertHostRelativeBandGeometry(largeHostGeometry);
+        // unclamped mid-range spot check: both bands render their COMMITTED document extents
+        // (right 0.25, bottom 0.25 of the host axis), not a preferred-size fraction
         expect(largeHostGeometry.rightBand.computedExtent)
             .toBeCloseTo(largeHostGeometry.dockHost.contentInlineSize * 0.25, 1);
         expect(largeHostGeometry.bottomBand.computedExtent)
-            .toBeCloseTo(largeHostGeometry.dockHost.contentBlockSize * 0.28, 1);
+            .toBeCloseTo(largeHostGeometry.dockHost.contentBlockSize * 0.25, 1);
 
         await page.setViewportSize({height: 850, width: 1300});
 

--- a/test/playwright/e2e/workstation/WorkstationSplitterGridGeometryNL.spec.mjs
+++ b/test/playwright/e2e/workstation/WorkstationSplitterGridGeometryNL.spec.mjs
@@ -355,7 +355,9 @@ test.describe('Workstation splitter drags: grid geometry stays attributable (#16
 
         /** One committed drag + positive-entry settlement + the keyed attribution matrix. */
         async function dragAndVerify(deltaX, tag) {
-            const splitter                 = page.locator('.neo-dashboard-dock-splitter-horizontal'),
+            // resizable edge zones share the orientation class — only the SPLIT container's own
+            // child is the resizeSplit affordance this journey commits through
+            const splitter                 = page.locator('.neo-dashboard-dock-split-horizontal > .neo-dashboard-dock-splitter-horizontal'),
                   box                      = await splitter.boundingBox(),
                   sx                       = box.x + box.width / 2,
                   sy                       = box.y + box.height / 2,
@@ -377,6 +379,11 @@ test.describe('Workstation splitter drags: grid geometry stays attributable (#16
 
             await page.mouse.move(sx, sy);
             await page.mouse.down();
+            // the Mouse sensor arms once delay AND minDistance are both satisfied — at a move
+            // event, or when the delay timer re-enters with the latest coords. Arming here,
+            // BEFORE the travel, keeps every travel move inside the live drag session (moves
+            // fired pre-arm carry no drag:move and leave the preview at its start size)
+            await page.waitForTimeout(130);
             await page.mouse.move(sx + Math.sign(deltaX) * 12, sy, {steps: 4});
             await page.mouse.move(sx + deltaX, sy, {steps: 15});
             await page.waitForTimeout(400); // gesture hold before release (drag realism, not settlement)

--- a/test/playwright/e2e/workstation/WorkstationStarvedGeometryNL.spec.mjs
+++ b/test/playwright/e2e/workstation/WorkstationStarvedGeometryNL.spec.mjs
@@ -131,22 +131,35 @@ test.describe('Workstation rendering starvation: grid geometry still converges (
         // VERTICALLY under starvation. The rendered row pool is a direct function of the
         // worker's availableHeight — it can only grow past its boot count if the worker
         // learned the taller box through a delivery no frame ever carried.
-        const domHeightAfterFlex = await page.evaluate(feedGridId => {
+        const {domHeightAfterFlex, freedBandHeight} = await page.evaluate(feedGridId => {
             let zoneChild = document.getElementById(feedGridId);
 
             while (zoneChild && !zoneChild.parentElement?.classList.contains('neo-dashboard-dock-edge-zone')) {
                 zoneChild = zoneChild.parentElement
             }
 
-            zoneChild.style.flex = '0 0 60px';
+            const bandHeightBefore = zoneChild.getBoundingClientRect().height;
 
-            return document.getElementById('neo-grid-container-1').getBoundingClientRect().height
+            // rig mutation, not a product journey: the walk-up lands on the bottom edge band,
+            // whose theme floor (min-block-size) would clamp the shrink and starve the trigger
+            // of its growth — release it alongside the flex pin
+            Object.assign(zoneChild.style, {flex: '0 0 60px', minHeight: '0px'});
+
+            return {
+                domHeightAfterFlex: document.getElementById('neo-grid-container-1').getBoundingClientRect().height,
+                freedBandHeight   : bandHeightBefore - zoneChild.getBoundingClientRect().height
+            }
         }, FEED_GRID_ID);
 
         const bootRows = bootState.rows;
 
-        expect(domHeightAfterFlex, 'the zone mutation grew the grid layout box (trigger premise)')
-            .toBeGreaterThan(bootState.gridHeight + 100);
+        // trigger premise, derived from the mutation itself: most of the height the band gave
+        // up must arrive at the grid's layout box (a fixed literal here calibrates to one
+        // theme era's band chrome and rots when extents or floors change; the layout-chain
+        // integrity claim is proportional, and a pipeline that eats the freed space still fails)
+        expect(freedBandHeight, 'the rig mutation must actually free band height').toBeGreaterThan(60);
+        expect(domHeightAfterFlex - bootState.gridHeight, 'the zone mutation grew the grid layout box (trigger premise)')
+            .toBeGreaterThan(freedBandHeight * 0.6);
 
         await expect.poll(
             async () => (await readMatrixState(page, GRID_ID)).rows,


### PR DESCRIPTION
Resolves #17863

Evidence: L3 (live whitebox Chromium against the external Brain runtime — the only tier that executes these journeys; e2e runs in no CI per the #17853 resolution) → L3 required (real-pointer committed-drag journeys). Residual: AC-4, Residual-Owner: #17864. Residual: AC-5, Residual-Owner: #17865.

## The mechanism story

Seven deterministic reds, four mechanisms — and the dominant one is the **wrong-splitter genus**: since edge zones became resizable, the workstation boots **three** `.neo-dashboard-dock-splitter-horizontal` elements (left edge + main split + right edge share the orientation class), so every first-match consumer — `querySelector`, `queryVdom(...)[0]`, a strict-mode locator — silently bound the **left edge** splitter, whose drag commits `resizeEdgeZone`, never the `resizeSplit` the journeys settle on. Every site now targets `'.neo-dashboard-dock-split-horizontal > .neo-dashboard-dock-splitter-horizontal'` (the split container's own child).

Second: the **arming model, corrected at source** (`Mouse.mjs:166`) — the sensor evaluates delay+minDistance at move events AND once more via the delay-timer re-entry with the latest coords. Move-then-release drives die (mouseup clears the timer); travel fired pre-arm carries no `drag:move`. The affected drives now arm before their travel, with the model documented at each site.

Third: **FlipResize instrumented a retired mechanism** — under live-by-default terminal parity the pane reaches the committed width UNDER the pointer and release changes nothing, so no inverse transform ever installs (`exposed: Infinity` was the instrument failing to distinguish the ideal from the defect). The witness is now mode-aware — its title, summary, and green definition name the guarded property (no visible post-commit double-take): a playing flip keeps the ≤34ms exposure bound (the deferred world stays failable); no flip ⇒ assert no untransformed frame leaves the landed width. Diag receipt of the ideal live landing: `landedIdx: 32, inverseIdx: -1, reversalIdx: -1`, 361 byte-stable samples after a monotonic 427→587px pointer-tracked approach.

Fourth: **StarvedGeometry's rig premise** — its `flex: 0 0 60px` mutation fought the band's theme floor (freeing +54px against a +100 literal calibrated to pre-rewrite band chrome). The rig now releases the floor it mutates against and derives its bound from the height actually freed (proportional, era-proof, still failing-capable: a pipeline that eats the freed space fails).

## AC Evidence

| AC | Evidence |
|---|---|
| AC-1 (FlipResize + GridRepaint ×2 target the split splitter, arm, commit) | Solo receipts: FlipResize 1/1 (7.9s, renamed witness; diag line above); GridRepaint 2/2 in the 3-file batch after retargeting (the 10-cycle committed-drag marathon now executes). In the six-file family batch all three stay green. |
| AC-2 (SplitterGridGeometry locator + reproducer) | 2/2 solo (10.5s): cells-agree green both directions with the structural locator + pre-travel arm; the deterministic reproducer stays green solo/small-batch (see Test Evidence for the one composition-only observation). |
| AC-3 (StarvedGeometry derived premise, failing-capable) | 1/1 (4.6s) with the freed-height-derived bound (`> freedBandHeight × 0.6` + `freedBandHeight > 60`); a pipeline that eats the freed space still fails, and the rig asserts the mutation actually freed height. |
| AC-4 (DragAffordances park journey) | **[deferred-evidence — engine sibling #17864]**: the spec ships unchanged by design; PR #17867 (open, CI green, mutation-checked witness) makes it green — verified 1/1 at that PR's head with zero spec changes. |
| AC-5 (WorkstationNL dense tour) | Mechanical layers delivered here (splitter census 2→5; the band model rewritten from the retired preferred-width clamp to committed extents with floors + the per-edge 50% cap; one stale 0.28 fraction) — each verified by the tour progressing past its former failure line. Remaining film-stage density literals: **[deferred-evidence — design sibling #17865]**. |
| AC-6 (no assertion weakened) | Commit asserts stay exact (`resizeSplit` delta > 0.02, terminal-parity fractions); the deferred-world ≤34ms exposure bound stands whenever a flip plays; the StarvedGeometry derivation cannot tautologize (requires the freed height to reach the grid box); the FlipResize no-flip branch red-guards via the reversal scan. |

## Test Evidence

- Solo/small-batch receipts (exact head `3c14f53e75`, whitebox `NEO_AGENTOS_RUNTIME_ROOT` + `playwright.config.e2e.mjs`): FlipResize 1/1 · GridRepaint 2/2 · SplitterGridGeometry 2/2 · StarvedGeometry 1/1.
- Six-file family batch: **10 passed / 1 skipped (pre-existing in-spec conditional) / 3 failed** — the failures are exactly the two deferred siblings (AC-4 → #17864, AC-5 → #17865) plus ONE composition-only observation: the SplitterGridGeometry deterministic reproducer reds **only** when GridRepaint's now-functional drag marathon precedes it in the shared stream (solo re-run 2/2 green the same minute) — the e2e order-sensitivity genus already recorded on #17844; documented, not chased, not this PR's residual.
- Hosted CI green at head (unit/component matrices; e2e has no CI workflow per the #17853 resolution — the receipts above are this surface's evidence tier).

## Post-Merge Validation

- AC-4 flips green automatically when PR #17867 merges (no action in this PR); AC-5 resolves with #17865's design decision. Both owners are open and named on #17863's ACs.

## Deltas

- The ticket's original bucket map was corrected in-body during implementation (dated amendment on #17863): GridRepaint's mechanism moved from "unarmed drive" to the wrong-splitter genus, and the arming model gained the delay-timer re-entry the original statement missed.
- A `queryVdom` cn-walk was tried for the vdom-side retarget and rejected ("Component not found") — the page-side structural selector is the proven route and is used everywhere.
- FlipResize's witness prose/title initially kept the inverse-only narrative; corrected in-review to name the mode-aware property (review RA-2).

Authored by 🪢 Mnemosyne (Claude Fable 5, Claude Code). Session c98e1ede-1a32-46f3-90ef-aaf37def487d.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
