### PR TITLE
Root edge chips return for descriptor-shaped center zones (#17864)

### DIFF
--- a/src/dashboard/dock/interaction/DragAffordances.mjs
+++ b/src/dashboard/dock/interaction/DragAffordances.mjs
@@ -123,8 +123,9 @@ class DragAffordances extends Base {
                 .filter(nodeId => nodes[nodeId].type === 'tabs')
                 .map(nodeId => ({nodeId, container: host.down({dockNodeId: nodeId})}))
                 .filter(zone => zone.container),
-            // a zone entry is a DESCRIPTOR (string | {nodeId}) — the canonical unwrap keeps the
-            // producer's fail-closed id guard from silently dropping every root edge chip
+            // a zone entry is an OBJECT DESCRIPTOR ({nodeId, …} — the v13.2 contract rejects the
+            // retired string shorthand) — the canonical unwrap keeps the producer's fail-closed
+            // id guard from silently dropping every root edge chip
             rootId      = nodes[me.owner.dockModel.root]?.type === 'edge-zone'
                 ? (Document.getZoneNodeId(nodes[me.owner.dockModel.root].zones?.center) ?? me.owner.dockModel.root)
                 : me.owner.dockModel.root;

--- a/src/dashboard/dock/interaction/DragAffordances.mjs
+++ b/src/dashboard/dock/interaction/DragAffordances.mjs
@@ -1,4 +1,5 @@
 import Base                 from '../../../core/Base.mjs';
+import Document             from '../model/Document.mjs';
 import PreviewProducer      from './PreviewProducer.mjs';
 import {previewToOperation} from '../model/PreviewContract.mjs';
 
@@ -122,8 +123,10 @@ class DragAffordances extends Base {
                 .filter(nodeId => nodes[nodeId].type === 'tabs')
                 .map(nodeId => ({nodeId, container: host.down({dockNodeId: nodeId})}))
                 .filter(zone => zone.container),
+            // a zone entry is a DESCRIPTOR (string | {nodeId}) — the canonical unwrap keeps the
+            // producer's fail-closed id guard from silently dropping every root edge chip
             rootId      = nodes[me.owner.dockModel.root]?.type === 'edge-zone'
-                ? (nodes[me.owner.dockModel.root].zones?.center ?? me.owner.dockModel.root)
+                ? (Document.getZoneNodeId(nodes[me.owner.dockModel.root].zones?.center) ?? me.owner.dockModel.root)
                 : me.owner.dockModel.root;
 
         me.dragGeometry = host.getDomRect([host.id, ...zoneEntries.map(zone => zone.container.id)]).then(([hostRect, ...zoneRects]) => {

--- a/test/playwright/unit/dashboard/DockDragAffordances.spec.mjs
+++ b/test/playwright/unit/dashboard/DockDragAffordances.spec.mjs
@@ -186,6 +186,53 @@ test.describe('Neo.dashboard.dock.interaction.DragAffordances', () => {
         destroyAll(rig)
     });
 
+    test('an edge-zone root with a descriptor-shaped center still offers the root edge chips', async () => {
+        // The regression fingerprint: `zones.center` is a DESCRIPTOR ({nodeId}) in the current
+        // schema, and passing it raw where the producer requires a node-id string trips the
+        // fail-closed guard — the candidate set arrives with root: null and every container
+        // edge chip stays off, silently, for every edge-zone-rooted workspace.
+        const rig   = compose(),
+              rects = {
+                  host : {x: 0, y: 0, width: 800, height: 600},
+                  left : {x: 0, y: 0, width: 400, height: 600},
+                  right: {x: 400, y: 0, width: 400, height: 600}
+              };
+
+        rig.owner.dockModel = {
+            schema: 'neo.dock.zone.v1',
+            root  : 'root',
+            items : rig.owner.dockModel.items,
+            nodes : {
+                root        : {type: 'edge-zone', zones: {center: {nodeId: 'split-main'}, bottom: {nodeId: 'left-tabs', extent: 0.25, resizable: true}}},
+                'split-main': {type: 'split', orientation: 'horizontal', children: ['left-tabs', 'right-tabs'], sizes: [0.5, 0.5]},
+                'left-tabs' : {type: 'tabs', items: ['alpha', 'beta'], activeItemId: 'alpha'},
+                'right-tabs': {type: 'tabs', items: ['gamma'], activeItemId: 'gamma'}
+            }
+        };
+
+        rig.controller.host = {
+            id: 'host-1',
+            down(selector) {
+                return {'left-tabs': {id: 'zone-left'}, 'right-tabs': {id: 'zone-right'}}[selector.dockNodeId] ?? null
+            },
+            getDomRect: async () => [rects.host, rects.left, rects.right]
+        };
+
+        const geometry = await rig.controller.ensureGeometry();
+
+        // the unwrapped STRING is what the producer's id guard accepts
+        expect(geometry.root.nodeId).toBe('split-main');
+
+        await rig.controller.onDragMove({clientX: 200, clientY: 300, itemId: 'gamma', sourceNodeId: 'right-tabs'});
+
+        expect(rig.indicators.candidateSet?.zone?.nodeId).toBe('left-tabs');
+        expect(rig.indicators.candidateSet?.root, 'the root chip family must be offered').toBeTruthy();
+        expect(rig.indicators.candidateSet.root.nodeId).toBe('split-main');
+        expect(rig.indicators.candidateSet.root.chips.map(chip => chip.edge)).toEqual(['top', 'right', 'bottom', 'left']);
+
+        destroyAll(rig)
+    });
+
     test('the production measurement path: measure, map, and the degenerate self-heal', async () => {
         const rig   = compose(),
               rects = {


### PR DESCRIPTION
Resolves #17864

**Micro-review eligible: behavior-restoring one-liner — one unwrap call + a mutation-checked witness; no contract change.**

## The defect

`DragAffordances#ensureGeometry` passed the raw `zones.center` **descriptor object** (`{nodeId: 'split-main'}` in the current schema) where `PreviewProducer#produceCandidates` requires a node-id string. The producer's fail-closed guard (`typeof root.nodeId === 'string'`) then silently returned `root: null` — so **all four container edge chips were never offered** for every edge-zone-rooted workspace (workstation, cockpit). Split-rooted documents take the other branch with a bare string and kept working, which is how it hid: the affordance demos stayed green while the flagship lost its dock-to-container-edge family. Surfaced by #17863's park-journey diagnosis (`candidateSet.root: undefined` with the cross indicators lighting normally).

## The fix

`Document.getZoneNodeId` — the canonical **object-descriptor** reader (the v13.2 contract deliberately rejects the retired bare-string shorthand; fail-closed `null`, no hidden compatibility reader) — at the resolution site, plus the import. The producer's guard stays exactly as it is (correct fail-closed posture). *(Wording corrected per review — the original claimed dual-shape support.)*

## Evidence

- **New unit witness** drives the real `ensureGeometry` + move path with an edge-zone-rooted, descriptor-shaped document to the offered chip family (`root.nodeId === 'split-main'`, chips `['top','right','bottom','left']`) — **mutation-checked: red with the fix stashed, green with it.**
- Unit dashboard **605/605**; component dashboard **22/22**.
- The `WorkstationDragAffordancesNL` park journey — red on dev with the `topChip` TypeError — **greens at this head with zero spec changes** (1/1, whitebox run receipt in #17864), discharging its #17863 deferred-evidence annotation at merge.

Related: #17863 (the lane that escalated this), #13158 (parent), #17836.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
