### PR TITLE
fix(workstation): restore the film-stage center density (#17865)

### DIFF
--- a/apps/workstation/tour/denseWorkstation.mjs
+++ b/apps/workstation/tour/denseWorkstation.mjs
@@ -11,6 +11,10 @@
 
 /**
  * The dense opening stage. Every catalog item is placed in the tree.
+ *
+ * Edge extents preserve both center panes at the 2560×1440 film stage. Ordinary desktop
+ * sizes intentionally resolve to the theme's usability floors, while the resizable descriptors
+ * retain the Engine's 50% per-edge agency after boot.
  * @type {Object}
  */
 export const initialDocument = Object.freeze({
@@ -43,9 +47,9 @@ export const initialDocument = Object.freeze({
             type : 'edge-zone',
             zones: {
                 center: {nodeId: 'split-main'},
-                left  : {nodeId: 'left-tabs',   extent: 0.20, resizable: true},
-                right : {nodeId: 'split-right', extent: 0.25, resizable: true},
-                bottom: {nodeId: 'bottom-tabs', extent: 0.25, resizable: true}
+                left  : {nodeId: 'left-tabs',   extent: 0.11, resizable: true},
+                right : {nodeId: 'split-right', extent: 0.14, resizable: true},
+                bottom: {nodeId: 'bottom-tabs', extent: 0.17, resizable: true}
             }
         },
         'split-main'       : {type: 'split', orientation: 'horizontal', children: ['scale-tabs', 'heavy-tabs'], sizes: [0.6, 0.4]},

--- a/test/playwright/e2e/workstation/WorkstationNL.spec.mjs
+++ b/test/playwright/e2e/workstation/WorkstationNL.spec.mjs
@@ -192,8 +192,12 @@ const expectSparklineCellFit = geometry => {
  */
 const readDockChrome = page => page.evaluate(() => {
     const
-        horizontal = document.querySelector('.neo-dashboard-dock-splitter-horizontal'),
-        vertical   = document.querySelector('.neo-dashboard-dock-splitter-vertical'),
+        horizontal = document.querySelector(
+            '.neo-dashboard-dock-split-horizontal > .neo-dashboard-dock-splitter-horizontal'
+        ),
+        vertical = document.querySelector(
+            '.neo-dashboard-dock-split-vertical > .neo-dashboard-dock-splitter-vertical'
+        ),
         scalePane  = document.querySelector('.workstation-scale-pane'),
         tabBody    = scalePane?.closest('.neo-tab-body-container'),
         readStyle  = element => {
@@ -320,7 +324,9 @@ const readOverflowMenuSkin = page => page.evaluate(() => {
  */
 const readHorizontalSplitGeometry = page => page.evaluate(() => {
     const
-        splitter = document.querySelector('.neo-dashboard-dock-splitter-horizontal'),
+        splitter = document.querySelector(
+            '.neo-dashboard-dock-split-horizontal > .neo-dashboard-dock-splitter-horizontal'
+        ),
         children = splitter && [...splitter.parentElement.children]
             .filter(element => !element.classList.contains('neo-dashboard-dock-splitter'));
 
@@ -680,17 +686,17 @@ test.describe('Workstation — dense living-data composition', () => {
             expect(geometry.bottomBand.nearestQueryContainerId).toBe(dockHost.id);
             expect(geometry.leftBand.computedExtent).toBeCloseTo(clamp(
                 rootFontSize * 11.25,
-                dockHost.contentInlineSize * 0.20,
+                dockHost.contentInlineSize * 0.11,
                 dockHost.contentInlineSize * 0.5
             ), 1);
             expect(geometry.rightBand.computedExtent).toBeCloseTo(clamp(
                 rootFontSize * 13.75,
-                dockHost.contentInlineSize * 0.25,
+                dockHost.contentInlineSize * 0.14,
                 dockHost.contentInlineSize * 0.5
             ), 1);
             expect(geometry.bottomBand.computedExtent).toBeCloseTo(clamp(
                 rootFontSize * 8.75,
-                dockHost.contentBlockSize * 0.25,
+                dockHost.contentBlockSize * 0.17,
                 dockHost.contentBlockSize * 0.5
             ), 1)
         };
@@ -700,8 +706,11 @@ test.describe('Workstation — dense living-data composition', () => {
         assertHostRelativeBandGeometry(wideGeometry);
         assertHostRelativeBandGeometry(narrowGeometry);
         assertHostRelativeBandGeometry(shortGeometry);
-        expect(narrowGeometry.leftBand.width).toBeLessThan(wideGeometry.leftBand.width);
-        expect(narrowGeometry.rightBand.width).toBeLessThan(wideGeometry.rightBand.width);
+        // The film-stage extents deliberately leave ordinary desktop sizes on the existing
+        // usability floors; shrinking the viewport must preserve those floors, not squeeze the
+        // side surfaces below them. The center absorbs the responsive delta.
+        expect(narrowGeometry.leftBand.width).toBeCloseTo(wideGeometry.leftBand.width, 1);
+        expect(narrowGeometry.rightBand.width).toBeCloseTo(wideGeometry.rightBand.width, 1);
         expect(narrowGeometry.center.width, 'the primary center keeps its desktop working floor')
             .toBeGreaterThanOrEqual(400);
         expect(narrowGeometry.scale.width, 'the 100k-row primary grid remains usable')
@@ -714,7 +723,7 @@ test.describe('Workstation — dense living-data composition', () => {
         expect(narrowGeometry.scale.right).toBeLessThanOrEqual(narrowGeometry.center.right + 1);
         expect(narrowGeometry.overflowControls, 'tab overflow remains owner-exact at the narrow desktop floor')
             .toBe(1);
-        expect(shortGeometry.bottomBand.height).toBeLessThan(wideGeometry.bottomBand.height);
+        expect(shortGeometry.bottomBand.height).toBeCloseTo(wideGeometry.bottomBand.height, 1);
         expect(shortGeometry.center.width).toBeCloseTo(narrowGeometry.center.width, 1);
         expect(shortGeometry.scale.width).toBeCloseTo(narrowGeometry.scale.width, 1);
         expect(shortGeometry.scale.height, 'the short desktop keeps a usable primary grid height')
@@ -726,23 +735,23 @@ test.describe('Workstation — dense living-data composition', () => {
 
         await readAtViewport({height: 900, width: 1400});
 
-        const largeHostGeometry = await readAtHost({height: 600, width: 1100});
+        const largeHostGeometry = await readAtHost({height: 900, width: 1600});
 
         assertHostRelativeBandGeometry(largeHostGeometry);
         // unclamped mid-range spot check: both bands render their COMMITTED document extents
-        // (right 0.25, bottom 0.25 of the host axis), not a preferred-size fraction
+        // (right 0.14, bottom 0.17 of the host axis), not a preferred-size fraction
         expect(largeHostGeometry.rightBand.computedExtent)
-            .toBeCloseTo(largeHostGeometry.dockHost.contentInlineSize * 0.25, 1);
+            .toBeCloseTo(largeHostGeometry.dockHost.contentInlineSize * 0.14, 1);
         expect(largeHostGeometry.bottomBand.computedExtent)
-            .toBeCloseTo(largeHostGeometry.dockHost.contentBlockSize * 0.25, 1);
+            .toBeCloseTo(largeHostGeometry.dockHost.contentBlockSize * 0.17, 1);
 
         await page.setViewportSize({height: 850, width: 1300});
 
         const fixedHostGeometry = await readResponsiveDockGeometry(page);
 
         expect(fixedHostGeometry.viewport).toEqual({height: 850, width: 1300});
-        expect(fixedHostGeometry.dockHost.contentInlineSize).toBeCloseTo(1100, 1);
-        expect(fixedHostGeometry.dockHost.contentBlockSize).toBeCloseTo(600, 1);
+        expect(fixedHostGeometry.dockHost.contentInlineSize).toBeCloseTo(1600, 1);
+        expect(fixedHostGeometry.dockHost.contentBlockSize).toBeCloseTo(900, 1);
         assertHostRelativeBandGeometry(fixedHostGeometry);
         expect(fixedHostGeometry.leftBand.computedExtent)
             .toBeCloseTo(largeHostGeometry.leftBand.computedExtent, 2);
@@ -790,9 +799,12 @@ test.describe('Workstation — dense living-data composition', () => {
 
         const restoredGeometry = await readAtViewport({height: 1440, width: 2560});
 
-        expect(restoredGeometry.leftBand.computedExtent).toBeCloseTo(260, 1);
-        expect(restoredGeometry.rightBand.computedExtent).toBeCloseTo(320, 1);
-        expect(restoredGeometry.bottomBand.computedExtent).toBeCloseTo(200, 1);
+        expect(restoredGeometry.leftBand.computedExtent)
+            .toBeCloseTo(restoredGeometry.dockHost.contentInlineSize * 0.11, 1);
+        expect(restoredGeometry.rightBand.computedExtent)
+            .toBeCloseTo(restoredGeometry.dockHost.contentInlineSize * 0.14, 1);
+        expect(restoredGeometry.bottomBand.computedExtent)
+            .toBeCloseTo(restoredGeometry.dockHost.contentBlockSize * 0.17, 1);
         expect(restoredGeometry.overflowControls).toBe(1);
 
         await expect(tourButton).toHaveText('Start dense tour');
@@ -854,13 +866,17 @@ test.describe('Workstation — dense living-data composition', () => {
         expect(hoverTourBackground, 'hover remains in the Workstation signal palette').not.toBe('rgb(67, 93, 177)');
 
         const
-            horizontalSplitter = page.locator('.neo-dashboard-dock-splitter-horizontal'),
-            verticalSplitter   = page.locator('.neo-dashboard-dock-splitter-vertical'),
+            horizontalSplitter = page.locator(
+                '.neo-dashboard-dock-split-horizontal > .neo-dashboard-dock-splitter-horizontal'
+            ),
+            verticalSplitter = page.locator(
+                '.neo-dashboard-dock-split-vertical > .neo-dashboard-dock-splitter-vertical'
+            ),
             darkDockRest       = await readDockChrome(page);
 
         await expect(horizontalSplitter, 'the horizontal document boundary projects one real splitter').toHaveCount(1);
         await expect(verticalSplitter, 'the vertical document boundary projects one real splitter').toHaveCount(1);
-        expect(darkDockRest.splitterCount).toBe(2);
+        expect(darkDockRest.splitterCount).toBe(5);
         expect(darkDockRest.horizontal.cursor).toBe('ew-resize');
         expect(darkDockRest.vertical.cursor).toBe('ns-resize');
         expect(darkDockRest.horizontal.background, 'the horizontal splitter is visible at rest')
@@ -933,7 +949,7 @@ test.describe('Workstation — dense living-data composition', () => {
 
         const lightDockRest = await readDockChrome(page);
 
-        expect(lightDockRest.splitterCount).toBe(2);
+        expect(lightDockRest.splitterCount).toBe(5);
         expect(lightDockRest.horizontal.background, 'light mode retains a visible resting splitter')
             .not.toBe('rgba(0, 0, 0, 0)');
         expect(lightDockRest.tabBody.background, 'light mode keeps the tab body out of pane chrome')
@@ -1039,9 +1055,9 @@ test.describe('Workstation — dense living-data composition', () => {
         expect(gridLayout.scaleTrailingSpace).toBeLessThanOrEqual(140);
         expect(gridLayout.heavyWidth, 'the dense heavy-tab panel is no longer cramped by the scale grid')
             .toBeGreaterThanOrEqual(700);
-        expect(gridLayout.leftBandWidth).toBeCloseTo(260, 0);
+        expect(gridLayout.leftBandWidth).toBeCloseTo(restoredGeometry.leftBand.computedExtent, 1);
         expect(gridLayout.rightBandWidth, 'the stacked evidence cards get more room than the queue card')
-            .toBeCloseTo(320, 0);
+            .toBeCloseTo(restoredGeometry.rightBand.computedExtent, 1);
         expect(feedWidths.Event / feedWidths.State,
             'Event remains the narrative column without consuming nearly the whole feed').toBeLessThanOrEqual(2.1);
         expect(feedWidths.Event / feedWidths.Value).toBeLessThanOrEqual(2.1);
@@ -1051,13 +1067,20 @@ test.describe('Workstation — dense living-data composition', () => {
             boundaryCount                = Object.values(dragModelBefore.nodes)
                 .filter(node => node.type === 'split')
                 .reduce((count, node) => count + node.children.length - 1, 0),
+            edgeSplitterCount              = Object.values(dragModelBefore.nodes)
+                .filter(node => node.type === 'edge-zone')
+                .reduce((count, node) => count + Object.values(node.zones || {})
+                    .filter(zone => zone?.resizable === true).length, 0),
             dragGeometryBefore = await readHorizontalSplitGeometry(page),
             dragIdentityBefore = await readIdentity(app, workspaceId),
             dragSplitterBox    = await horizontalSplitter.boundingBox();
 
         expect(boundaryCount, 'each opening-document split contributes one boundary').toBe(2);
+        expect(await page.locator('.neo-dashboard-dock-split > .neo-dashboard-dock-splitter').count(),
+            'the DOM owns exactly one split child per model boundary').toBe(boundaryCount);
         expect(await page.locator('.neo-dashboard-dock-splitter').count(),
-            'the DOM owns exactly one real splitter per model boundary').toBe(boundaryCount);
+            'the DOM additionally owns one splitter per resizable edge descriptor')
+            .toBe(boundaryCount + edgeSplitterCount);
         expect(dragGeometryBefore.boundaryWidth).toBe(6);
 
         await page.evaluate(() => {
@@ -1150,7 +1173,8 @@ test.describe('Workstation — dense living-data composition', () => {
         expect(dragChromeAfter, 'a resize preserves every opening tab surface and paired button identity')
             .toEqual(beforeChrome);
         expect(scalePanePreserved, 'the exact scale pane DOM node survives splitter re-projection').toBe(true);
-        expect(await page.locator('.neo-dashboard-dock-splitter').count()).toBe(boundaryCount);
+        expect(await page.locator('.neo-dashboard-dock-splitter').count())
+            .toBe(boundaryCount + edgeSplitterCount);
         expectSparklineCellFit(await readSparklineGeometry(page,'.workstation-scale-pane'));
         expectSparklineCellFit(await readSparklineGeometry(page,'.workstation-feed-pane'));
 

--- a/test/playwright/e2e/workstation/WorkstationResidentCardSizingNL.spec.mjs
+++ b/test/playwright/e2e/workstation/WorkstationResidentCardSizingNL.spec.mjs
@@ -119,6 +119,73 @@ test.describe('Workstation resident cards — pane-keyed sizing at a roomy viewp
     })
 });
 
+test.describe('Workstation resident cards — film-stage density from the committed document', () => {
+    test.setTimeout(90000);
+    test.use({
+        contextOptions: {screen: {height: 1440, width: 2560}},
+        viewport      : {height: 1440, width: 2560}
+    });
+
+    test('the opening extents keep both the scale grid and dense resident group usable', async ({page, neuralLink}) => {
+        await bootWorkstation(page);
+
+        const app         = await neuralLink.connectToApp('Workstation'),
+              workspaces  = await app.findInstances({className: 'Workstation.view.Workspace'}, ['id']),
+              workspaceId = (Array.isArray(workspaces) ? workspaces : [workspaces])[0]?.id;
+
+        expect(workspaceId, 'the film stage owns a Workstation workspace').toBeTruthy();
+
+        const {dockModel} = await app.getComponent(workspaceId, ['dockModel']),
+              geometry    = await page.evaluate(() => {
+                  const
+                      rect       = element => element?.getBoundingClientRect(),
+                      host       = document.querySelector('.workstation-dock-host'),
+                      hostRect   = rect(host),
+                      hostStyle  = getComputedStyle(host),
+                      number     = property => Number.parseFloat(hostStyle[property]) || 0,
+                      left       = rect(document.querySelector('.neo-dashboard-dock-edge-band-left')),
+                      right      = rect(document.querySelector('.neo-dashboard-dock-edge-band-right')),
+                      bottom     = rect(document.querySelector('.neo-dashboard-dock-edge-band-bottom')),
+                      heavy      = rect([...document.querySelectorAll('.neo-tab-header-toolbar')]
+                          .find(element => element.textContent?.includes('Priority Alert Observatory'))
+                          ?.closest('.neo-tab-container')),
+                      scale      = document.querySelector('.workstation-scale-pane .neo-grid-header-toolbar'),
+                      scaleRect  = rect(scale),
+                      lastHeader = rect([...scale?.querySelectorAll('.neo-grid-header-button') || []].at(-1));
+
+                  return {
+                      bottomHeight    : bottom?.height,
+                      contentBlockSize: hostRect.height
+                          - number('borderTopWidth') - number('borderBottomWidth')
+                          - number('paddingTop') - number('paddingBottom'),
+                      contentInlineSize: hostRect.width
+                          - number('borderLeftWidth') - number('borderRightWidth')
+                          - number('paddingLeft') - number('paddingRight'),
+                      heavyWidth        : heavy?.width,
+                      leftWidth         : left?.width,
+                      rightWidth        : right?.width,
+                      scaleTrailingSpace: scaleRect?.right - lastHeader?.right
+                  }
+              });
+
+        expect(dockModel.nodes.root.zones).toMatchObject({
+            left  : {extent: 0.11, resizable: true},
+            right : {extent: 0.14, resizable: true},
+            bottom: {extent: 0.17, resizable: true}
+        });
+        expect(geometry.leftWidth).toBeCloseTo(geometry.contentInlineSize * 0.11, 1);
+        expect(geometry.rightWidth).toBeCloseTo(geometry.contentInlineSize * 0.14, 1);
+        expect(geometry.bottomHeight).toBeCloseTo(geometry.contentBlockSize * 0.17, 1);
+        expect(geometry.rightWidth, 'the evidence band stays wider than the queue band')
+            .toBeGreaterThan(geometry.leftWidth);
+        expect(geometry.heavyWidth, 'the dense twelve-tab resident group keeps its working width')
+            .toBeGreaterThanOrEqual(700);
+        expect(geometry.scaleTrailingSpace, 'the 100k grid headers fit without wasting a second panel')
+            .toBeGreaterThanOrEqual(0);
+        expect(geometry.scaleTrailingSpace).toBeLessThanOrEqual(140)
+    })
+});
+
 test.describe('Workstation resident cards — progressive disclosure at a short viewport', () => {
     test.setTimeout(90000);
     test.use({


### PR DESCRIPTION
Resolves #17865

Retunes only Workstation's committed opening edge extents to `0.11 / 0.14 / 0.17`, restoring the 2560×1440 film composition without reintroducing Engine caps. The focused witness binds those worker-owned values to rendered geometry and independently requires both center consumers to remain usable: the dense resident group stays at least 700px wide and the 100k grid headers fit with bounded trailing space.

Evidence: L3 (exact-head live Chromium whitebox at the 2560×1440 film stage) → L3 required (AC-2 rendered density and worker/document agreement). Residual: post-density full-tour choreography; Residual-Owner: #17871 (midpoint-scroll blank grid) and #17872 (Security FLIP-stage recurrence).

## AC Evidence

| AC | Evidence |
|---|---|
| AC-1 | Film-stage density decided: `initialDocument` records `0.11 / 0.14 / 0.17`; the issue body records the live-derived decision and rejected alternatives. |
| AC-2 | `WorkstationResidentCardSizingNL` is 4/4 green, including the new worker→DOM film-stage witness. Mutation control: restoring the right extent to `0.25` while updating the duplicated extent expectations still fails independently at `heavyWidth = 622.421875 < 700`. `WorkstationNL` advances beyond every changed band/splitter/density assertion; its later grid-continuity and Security-stage regressions are explicitly owned by #17871 and #17872. |
| AC-3 | This PR resolves the surviving #17865 owner and links the completed delivery back to #17863. |

## Deltas from ticket

- The suggested `0.13 / 0.16 / 0.17` candidate was rejected by the live app: the scale header still overran its toolbar by `41.859375px`. The accepted horizontal pair is `0.11 / 0.14`, yielding roughly 279 / 355px bands at the film stage.
- The focused film-stage gate lives in the existing resident-card sizing suite instead of depending on the 2,000-line full-tour witness. The full tour remains updated so it no longer asserts retired band or splitter cardinalities.
- Moving the density gate exposed remaining same-genus first-match/count sites missed by #17863; this PR structurally targets split-node children and distinguishes two split boundaries from three resizable edge affordances.
- Independent post-density failures are not folded into this density PR: #17871 owns the midpoint-scroll blank-grid recurrence and #17872 owns the Security fixed-stage recurrence.

## Test Evidence

- Final focused witness: `1 passed` in 4.5s.
- Full `WorkstationResidentCardSizingNL.spec.mjs`: `4 passed` in 12.0s.
- Mutation control: right extent `0.25` + matching extent assertions → red at the independent heavy-pane guard (`622.421875 < 700`); reverted, focused witness green again.
- Full `WorkstationNL` before the retune: deterministic density red (`507.188` received versus legacy `260`). At the final branch it advances beyond every changed density/splitter assertion, then exposes #17872 (`securityStageBursts = 2`) and #17871 (three midpoint `blankFrames`).
- `agent-preflight --no-fix --change-class restoration` passed for the commit subject and all three changed files.

## Post-Merge Validation

No post-merge validation is required for #17865; the exact unmerged branch is executable through the whitebox fixture and satisfies the close-target's runtime evidence level. The independent runtime proofs remain with #17871 and #17872.

Related: #17863 · #13158 · #17857 · #15252 · #17871 · #17872

Authored by Euclid (OpenAI GPT-5.6 Sol, Codex Desktop) consuming Mnemosyne's handoff — session A c98e1ede-1a32-46f3-90ef-aaf37def487d, session B 6243a442-7ced-4c0f-81c6-99b0f8358e63.
