### PR TITLE
Split previews paint the resulting region, not the cut line (#17870)

### DIFF
--- a/resources/scss/src/dashboard/dock/interaction/Preview.scss
+++ b/resources/scss/src/dashboard/dock/interaction/Preview.scss
@@ -14,8 +14,12 @@
                          border-color var(--dock-transition-duration) var(--dock-transition-easing);
     }
 
-    // Zone highlights — edge bands and whole-node tab targets — read as a translucent filled region.
+    // Zone highlights — edge/split RESULT REGIONS and whole-node tab targets — read as a
+    // translucent filled region: the half (or whole) of the target the drop would occupy.
+    // `neo-dock-preview-region` is the mode class the renderer adds for directional
+    // placements when result-region previews are on (the default).
     .neo-dock-preview-edge,
+    .neo-dock-preview-region,
     .neo-dock-preview-tab-into {
         &.neo-dock-preview-accepted {
             background-color : var(--agent-dock-preview-accept-fill, rgba(88, 166, 255, 0.22));
@@ -29,8 +33,19 @@
         }
     }
 
-    // Insertion guides — split lines and tab before/after markers — read as a solid bar.
-    .neo-dock-preview-split,
+    // The exact-cut accent: a result region's INNER edge is where the future splitter sits —
+    // the information the old insertion line carried survives as a thicker boundary there.
+    .neo-dock-preview-region {
+        &.neo-dock-preview-cut-top    { border-top-width   : 4px; }
+        &.neo-dock-preview-cut-right  { border-right-width : 4px; }
+        &.neo-dock-preview-cut-bottom { border-bottom-width: 4px; }
+        &.neo-dock-preview-cut-left   { border-left-width  : 4px; }
+    }
+
+    // Insertion guides — split lines (the `resultRegionPreviews: false` presentation) and tab
+    // before/after markers — read as a solid bar. The `:not(...)` guard keeps region-mode split
+    // affordances in the filled family above.
+    .neo-dock-preview-split:not(.neo-dock-preview-region),
     .neo-dock-preview-tab-before,
     .neo-dock-preview-tab-after {
         border-radius : 2px;
@@ -60,6 +75,7 @@
     // Same boundary as the indicator variant: component-domain aliases only — the apps
     // project their palettes; this file never reaches for an app palette directly.
     .neo-dock-preview-edge,
+    .neo-dock-preview-region,
     .neo-dock-preview-tab-into {
         &.neo-dock-preview-accepted {
             background-color : var(--agent-dock-preview-signal-fill);
@@ -69,7 +85,7 @@
         }
     }
 
-    .neo-dock-preview-split,
+    .neo-dock-preview-split:not(.neo-dock-preview-region),
     .neo-dock-preview-tab-before,
     .neo-dock-preview-tab-after {
         &.neo-dock-preview-accepted {

--- a/src/dashboard/dock/interaction/DragAffordances.mjs
+++ b/src/dashboard/dock/interaction/DragAffordances.mjs
@@ -221,7 +221,7 @@ class DragAffordances extends Base {
 
         let candidate   = indicators?.updatePointer(pointer) ?? null,
             dockPreview = candidate?.preview
-                ?? producer.produce({pointer, zones: geometry.zones, itemId, groupNodeId, sourceNodeId});
+                ?? producer.produce({pointer, zones: geometry.zones, itemId, groupNodeId, root: geometry.root, sourceNodeId});
 
         if (preview && writeRenderer) {
             preview.dockPreview = dockPreview;
@@ -267,6 +267,7 @@ class DragAffordances extends Base {
                 pointer,
                 zones: geometry.zones.filter(zone => zone.nodeId !== sourceNodeId),
                 itemId,
+                root : geometry.root,
                 sourceNodeId
             })
         }

--- a/src/dashboard/dock/interaction/Preview.mjs
+++ b/src/dashboard/dock/interaction/Preview.mjs
@@ -90,6 +90,17 @@ class Preview extends Component {
          */
         edgeBandSize: 24,
         /**
+         * True paints split and edge placements as the RESULT REGION — the half of the target
+         * the new pane would occupy — with the exact cut marked by a thicker border on the
+         * region's inner edge. False restores the thin insertion-line presentation. The pane
+         * center (tab-into) always paints the full-zone region; this config only widens the
+         * directional placements to match, so the whole preview language shows outcomes
+         * instead of cuts. Read per frame — a runtime flip applies on the next hover move.
+         * @member {Boolean} resultRegionPreviews_=true
+         * @reactive
+         */
+        resultRegionPreviews_: true,
+        /**
          * Thickness in px of a split / tab guide line. Per-instance policy, same rationale as
          * {@link Neo.dashboard.dock.interaction.Preview#edgeBandSize}.
          * @member {Number} splitLineSize=6
@@ -202,7 +213,7 @@ class Preview extends Component {
      * @returns {Object|null}
      * @static
      */
-    static affordanceGeometry(affordance, targetRect, {edgeBandSize = 24, splitLineSize = 6} = {}) {
+    static affordanceGeometry(affordance, targetRect, {edgeBandSize = 24, resultRegionPreviews = true, splitLineSize = 6} = {}) {
         if (!affordance || !targetRect) return null;
 
         let {height, width, x, y} = targetRect;
@@ -213,6 +224,17 @@ class Preview extends Component {
             line = splitLineSize;
 
         if (affordance.group === 'edge') {
+            // region mode paints the HALF the new pane would occupy toward that edge — the
+            // outcome, not the strip; line mode keeps the classic band affordance
+            if (resultRegionPreviews) {
+                switch (affordance.edge) {
+                    case 'top'   : return {x, y, width, height: height / 2};
+                    case 'bottom': return {x, y: y + height / 2, width, height: height / 2};
+                    case 'left'  : return {x, y, width: width / 2, height};
+                    case 'right' : return {x: x + width / 2, y, width: width / 2, height}
+                }
+            }
+
             switch (affordance.edge) {
                 case 'top'   : return {x, y, width, height: band};
                 case 'bottom': return {x, y: y + height - band, width, height: band};
@@ -222,6 +244,14 @@ class Preview extends Component {
         }
 
         if (affordance.group === 'split') {
+            if (resultRegionPreviews) {
+                // the new sibling's half along the split axis: before = first child, after = second
+                if (affordance.orientation === 'horizontal') {
+                    return {x: affordance.position === 'after' ? x + width / 2 : x, y, width: width / 2, height}
+                }
+                return {x, y: affordance.position === 'after' ? y + height / 2 : y, width, height: height / 2}
+            }
+
             if (affordance.orientation === 'horizontal') {
                 // children side-by-side -> a vertical guide on the left (before) / right (after)
                 return {x: affordance.position === 'after' ? x + width - line : x, y, width: line, height}
@@ -236,6 +266,32 @@ class Preview extends Component {
         }
 
         return {x: affordance.position === 'after' ? x + width - line : x, y, width: line, height}
+    }
+
+    /**
+     * @summary The region's INNER edge — where the actual cut (the future splitter) sits.
+     *
+     * A result region occupies one half of its target; the boundary facing the remaining half
+     * carries the exact-cut information the old insertion line encoded. Returns the side name
+     * for the accent class, or null for non-directional affordances (tab placements).
+     * @param {Object|null} affordance
+     * @returns {String|null} 'top' | 'right' | 'bottom' | 'left' | null
+     * @static
+     */
+    static cutSide(affordance) {
+        if (!affordance) return null;
+
+        if (affordance.group === 'edge') {
+            return {top: 'bottom', bottom: 'top', left: 'right', right: 'left'}[affordance.edge] ?? null
+        }
+
+        if (affordance.group === 'split') {
+            return affordance.orientation === 'horizontal'
+                ? (affordance.position === 'after' ? 'left' : 'right')
+                : (affordance.position === 'after' ? 'top'  : 'bottom')
+        }
+
+        return null
     }
 
     /**
@@ -268,8 +324,9 @@ class Preview extends Component {
         if (!affordance || !node) return;
 
         let geo = Preview.affordanceGeometry(affordance, targetRect, {
-            edgeBandSize : me.edgeBandSize,
-            splitLineSize: me.splitLineSize
+            edgeBandSize        : me.edgeBandSize,
+            resultRegionPreviews: me.resultRegionPreviews,
+            splitLineSize       : me.splitLineSize
         });
 
         if (!geo) return;
@@ -338,12 +395,21 @@ class Preview extends Component {
      * @returns {Object} VDOM node
      */
     getAffordanceVdom(affordance) {
+        let me      = this,
+            region  = me.resultRegionPreviews && (affordance.group === 'split' || affordance.group === 'edge'),
+            cutSide = region ? Preview.cutSide(affordance) : null;
+
         return {
             cls: [
                 'neo-dock-preview-affordance',
                 `neo-dock-preview-${affordance.group}`,
                 `neo-dock-preview-${affordance.kind}`,
-                affordance.accepted ? 'neo-dock-preview-accepted' : 'neo-dock-preview-rejected'
+                affordance.accepted ? 'neo-dock-preview-accepted' : 'neo-dock-preview-rejected',
+                // region mode routes directional placements into the filled-region visual
+                // family; the cut-side class thickens the border on the region's inner edge,
+                // preserving the exact-cut information the insertion line used to carry
+                ...(region  ? ['neo-dock-preview-region'] : []),
+                ...(cutSide ? [`neo-dock-preview-cut-${cutSide}`] : [])
             ],
             'data-dock-target': affordance.targetNodeId,
             style             : {pointerEvents: 'none'}

--- a/src/dashboard/dock/interaction/Preview.mjs
+++ b/src/dashboard/dock/interaction/Preview.mjs
@@ -159,11 +159,24 @@ class Preview extends Component {
         };
 
         if (this.EDGE_KINDS.has(kind)) {
-            return {...base, group: 'edge', edge: kind.slice('edge-'.length)}
+            let edge     = kind.slice('edge-'.length),
+                position = dockPreviewContract.edgeSplitPosition(edge);
+
+            // The fraction the NEW pane commits to, resolved through the same authority
+            // `previewToOperation` uses, so the region cannot paint a size the drop will not produce.
+            return {...base, group: 'edge', edge, ratio: this.newNodeFraction(placement.ratio, position)}
         }
 
         if (this.SPLIT_KINDS.has(kind)) {
-            return {...base, group: 'split', orientation: placement.orientation, position: kind.slice('split-'.length)}
+            let position = kind.slice('split-'.length);
+
+            return {
+                ...base,
+                group      : 'split',
+                orientation: placement.orientation,
+                position,
+                ratio      : this.newNodeFraction(placement.ratio, position)
+            }
         }
 
         return {...base, group: 'tab', index: Number.isInteger(placement.index) ? placement.index : null, position: kind.slice('tab-'.length)}
@@ -198,6 +211,49 @@ class Preview extends Component {
     }
 
     /**
+     * @summary The fraction of the target axis the NEW pane will occupy.
+     *
+     * Reads the committed size pair rather than the raw ratio, so an absent or out-of-domain ratio
+     * lands on whatever `ratioToSizes` normalizes it to. `before` places the new node first, `after`
+     * second — the pair is indexed accordingly rather than re-deriving the ratio.
+     * @param {Number} [ratio] the new node's fraction; normalized by `ratioToSizes`
+     * @param {String} position `'before'` or `'after'`
+     * @returns {Number}
+     * @static
+     */
+    /**
+     * @summary The already-resolved region fraction on an affordance, or the even split.
+     *
+     * An affordance built before this field existed, or one whose fraction fell out of domain, paints
+     * halves — the previous behaviour — rather than collapsing the region to nothing.
+     * @param {Object|null} affordance
+     * @returns {Number}
+     * @static
+     */
+    static regionFraction(affordance) {
+        let ratio = affordance?.ratio;
+
+        return (typeof ratio === 'number' && ratio > 0 && ratio < 1) ? ratio : 0.5
+    }
+
+    /**
+     * @summary The fraction of the target axis the NEW pane will occupy.
+     *
+     * Reads the committed size pair rather than the raw ratio, so an absent or out-of-domain ratio
+     * lands on whatever `ratioToSizes` normalizes it to. `before` places the new node first, `after`
+     * second — the pair is indexed accordingly rather than re-deriving the ratio.
+     * @param {Number} [ratio] the new node's fraction; normalized by `ratioToSizes`
+     * @param {String} position `'before'` or `'after'`
+     * @returns {Number}
+     * @static
+     */
+    static newNodeFraction(ratio, position) {
+        let sizes = this.ratioToSizes(ratio, position);
+
+        return position === 'after' ? sizes[1] : sizes[0]
+    }
+
+    /**
      * @summary Pure geometry: projects an affordance onto a target node rect.
      *
      * Given an affordance descriptor and the target node's runtime rect, returns the overlay box
@@ -224,14 +280,18 @@ class Preview extends Component {
             line = splitLineSize;
 
         if (affordance.group === 'edge') {
-            // region mode paints the HALF the new pane would occupy toward that edge — the
+            // region mode paints the fraction the new pane would occupy toward that edge — the
             // outcome, not the strip; line mode keeps the classic band affordance
             if (resultRegionPreviews) {
+                let fraction = Preview.regionFraction(affordance),
+                    regionW  = width  * fraction,
+                    regionH  = height * fraction;
+
                 switch (affordance.edge) {
-                    case 'top'   : return {x, y, width, height: height / 2};
-                    case 'bottom': return {x, y: y + height / 2, width, height: height / 2};
-                    case 'left'  : return {x, y, width: width / 2, height};
-                    case 'right' : return {x: x + width / 2, y, width: width / 2, height}
+                    case 'top'   : return {x, y, width, height: regionH};
+                    case 'bottom': return {x, y: y + height - regionH, width, height: regionH};
+                    case 'left'  : return {x, y, width: regionW, height};
+                    case 'right' : return {x: x + width - regionW, y, width: regionW, height}
                 }
             }
 
@@ -245,11 +305,18 @@ class Preview extends Component {
 
         if (affordance.group === 'split') {
             if (resultRegionPreviews) {
-                // the new sibling's half along the split axis: before = first child, after = second
+                // the new sibling's share along the split axis: before = first child, after = second
+                let fraction = Preview.regionFraction(affordance);
+
                 if (affordance.orientation === 'horizontal') {
-                    return {x: affordance.position === 'after' ? x + width / 2 : x, y, width: width / 2, height}
+                    let regionW = width * fraction;
+
+                    return {x: affordance.position === 'after' ? x + width - regionW : x, y, width: regionW, height}
                 }
-                return {x, y: affordance.position === 'after' ? y + height / 2 : y, width, height: height / 2}
+
+                let regionH = height * fraction;
+
+                return {x, y: affordance.position === 'after' ? y + height - regionH : y, width, height: regionH}
             }
 
             if (affordance.orientation === 'horizontal') {

--- a/src/dashboard/dock/interaction/PreviewProducer.mjs
+++ b/src/dashboard/dock/interaction/PreviewProducer.mjs
@@ -232,6 +232,8 @@ class PreviewProducer extends Base {
      * @param {String} params.itemId the representative dragged dock item id
      * @param {String} [params.groupNodeId] runtime-only whole-stack source node id
      * @param {String} [params.containerId] the hovered workspace/container id
+     * @param {Object} [params.root] {nodeId, rect} the container's root node — enables the root-edge
+     * border strip. Absent (the cross-window callers) fail-closes to plain zone inference.
      * @param {Object} [params.source] producer surface, e.g. {surface, sortZoneId}
      * @param {String} [params.sourceNodeId] the drag's origin dock node (used as sortZoneId fallback)
      * @returns {Object|null} a `neo.dock.preview.v1` payload, or null

--- a/src/dashboard/dock/interaction/PreviewProducer.mjs
+++ b/src/dashboard/dock/interaction/PreviewProducer.mjs
@@ -83,7 +83,19 @@ class PreviewProducer extends Base {
          * grammar. Non-reactive config for the same tunability rationale as `edgeBandRatio`.
          * @member {Number} tabHeaderCarveOutPx=36
          */
-        tabHeaderCarveOutPx: 36
+        tabHeaderCarveOutPx: 36,
+        /**
+         * Pixel width of the container-border strip in which pointer inference resolves the
+         * ROOT `edge-*` placement — docking across the full surface without aiming at a 26px
+         * chip. The strip sits along the root rect's border, so it only overrides zone
+         * inference where a pane touches the container edge; the chips remain the precision
+         * targets and the indicator tier still wins over every inference. `0` disables the
+         * band (chips-only root docking). Pixels, not a ratio: it mirrors the renderer's
+         * `edgeBandSize` reach so the affordance and the hit strip agree at the border.
+         * Non-reactive config for the same tunability rationale as `edgeBandRatio`.
+         * @member {Number} rootEdgeBandPx=24
+         */
+        rootEdgeBandPx: 24
     }
 
     /**
@@ -144,6 +156,43 @@ class PreviewProducer extends Base {
     }
 
     /**
+     * @summary Resolves the root edge whose border strip contains `pointer`, or null.
+     *
+     * The strip runs `rootEdgeBandPx` inward from each border of the root rect. Inside it, the
+     * NEAREST border wins (corner ties resolve to the smaller distance; equal distances prefer
+     * top → bottom → left → right for stable diffing, mirroring `resolvePlacementKind`). A
+     * pointer outside the root rect, a degenerate rect, or a disabled band (`rootEdgeBandPx`
+     * <= 0) returns null — zone inference then owns the frame.
+     * @param {Object|null} root {nodeId, rect}
+     * @param {Object|null} pointer {x, y}
+     * @returns {String|null} 'top' | 'bottom' | 'left' | 'right' | null
+     * @protected
+     */
+    resolveRootEdge(root, pointer) {
+        let band = this.rootEdgeBandPx,
+            rect = root?.rect;
+
+        if (!(band > 0) || typeof root?.nodeId !== 'string' || !root.nodeId || !rect || !pointer) return null;
+
+        let {height, width, x, y} = rect,
+            {x: px, y: py}        = pointer;
+
+        if ([height, width, x, y, px, py].some(v => typeof v !== 'number' || Number.isNaN(v))) return null;
+        if (width <= 0 || height <= 0)                                                          return null;
+        if (px < x || px > x + width || py < y || py > y + height)                              return null;
+
+        let distances = [
+                ['top',    py - y],
+                ['bottom', (y + height) - py],
+                ['left',   px - x],
+                ['right',  (x + width) - px]
+            ],
+            [edge, nearest] = distances.reduce((best, entry) => entry[1] < best[1] ? entry : best);
+
+        return nearest <= band ? edge : null
+    }
+
+    /**
      * @summary Finds the innermost dock zone whose rect contains `pointer`, or null.
      *
      * Zones are expected already ordered outermost → innermost (the adapter projects them in tree
@@ -187,9 +236,19 @@ class PreviewProducer extends Base {
      * @param {String} [params.sourceNodeId] the drag's origin dock node (used as sortZoneId fallback)
      * @returns {Object|null} a `neo.dock.preview.v1` payload, or null
      */
-    produce({pointer, zones, itemId, groupNodeId=null, containerId=null, source=null, sourceNodeId=null}={}) {
+    produce({pointer, zones, itemId, groupNodeId=null, containerId=null, root=null, source=null, sourceNodeId=null}={}) {
         if (typeof itemId !== 'string' || !itemId ||
             (groupNodeId != null && (typeof groupNodeId !== 'string' || !groupNodeId))) return null;
+
+        let params = {containerId, groupNodeId, itemId, source, sourceNodeId},
+            // the container-border strip outranks zone inference (mirroring the indicator
+            // menu's root chips): near the surface boundary, "dock across the full edge" is
+            // the intended reading even where a pane sits underneath
+            rootEdge = this.resolveRootEdge(root, pointer);
+
+        if (rootEdge) {
+            return this.buildPreview(params, root.nodeId, `edge-${rootEdge}`)
+        }
 
         let zone = this.hitTestZone(zones, pointer);
 
@@ -199,7 +258,7 @@ class PreviewProducer extends Base {
 
         if (kind === 'rejected') return null;
 
-        return this.buildPreview({containerId, groupNodeId, itemId, source, sourceNodeId}, zone.nodeId, kind, zone.orientation)
+        return this.buildPreview(params, zone.nodeId, kind, zone.orientation)
     }
 
     /**

--- a/src/dashboard/dock/model/PreviewContract.mjs
+++ b/src/dashboard/dock/model/PreviewContract.mjs
@@ -206,6 +206,18 @@ export function isValidCandidateSet(set) {
  * @param {String} position 'before' | 'after' — which child the new node becomes
  * @returns {Number[]} normalized [first, second] sizes summing to 1
  */
+/**
+ * @summary Which side of a two-child split an edge drop lands the NEW node on.
+ *
+ * `bottom` and `right` append; `top` and `left` prepend. Shared so the operation descriptor and the
+ * rendered region cannot disagree about which half the drop will occupy.
+ * @param {String} edge
+ * @returns {String} `'before'` or `'after'`
+ */
+export function edgeSplitPosition(edge) {
+    return (edge === 'bottom' || edge === 'right') ? 'after' : 'before'
+}
+
 export function ratioToSizes(ratio, position) {
     let r = (typeof ratio === 'number' && ratio > 0 && ratio < 1) ? ratio : 0.5;
     return position === 'after' ? [1 - r, r] : [r, 1 - r]
@@ -251,7 +263,7 @@ export function previewToOperation(preview) {
             nodePlacement = {
                 edge,
                 orientation: (edge === 'left' || edge === 'right') ? 'horizontal' : 'vertical',
-                sizes      : ratioToSizes(placement.ratio, edge === 'bottom' || edge === 'right' ? 'after' : 'before')
+                sizes      : ratioToSizes(placement.ratio, edgeSplitPosition(edge))
             }
         }
 
@@ -278,6 +290,6 @@ export function previewToOperation(preview) {
         targetNodeId: nodeId,
         edge,
         orientation : (edge === 'left' || edge === 'right') ? 'horizontal' : 'vertical',
-        sizes       : ratioToSizes(placement.ratio, edge === 'bottom' || edge === 'right' ? 'after' : 'before')
+        sizes       : ratioToSizes(placement.ratio, edgeSplitPosition(edge))
     }
 }

--- a/test/playwright/unit/dashboard/DockDragAffordances.spec.mjs
+++ b/test/playwright/unit/dashboard/DockDragAffordances.spec.mjs
@@ -299,5 +299,74 @@ test.describe('Neo.dashboard.dock.interaction.DragAffordances', () => {
 
         rig.indicators.destroy();
         rig.preview.destroy()
+    });
+
+    /**
+     * The root-edge border strip, driven through the production gesture rather than the producer.
+     *
+     * `produce()` receiving a root is what turns a pointer near the container border into a ROOT edge
+     * placement instead of the zone under it. The producer's own specs prove that mapping; they say
+     * nothing about whether the controller actually PASSES the root, and it must pass it on two
+     * independent call sites — the hover path and the release path. A producer-only witness leaves
+     * both wires free to be deleted.
+     *
+     * The strip is 24px inward from the root rect, so `clientY: 10` sits inside it while remaining
+     * deep inside `left-tabs` — which is the whole point: without the root argument, zone inference
+     * owns that pointer and the assertions below describe a different target.
+     */
+    test.describe('the root-edge strip is wired on both gesture paths', () => {
+        /** Captures the descriptor the owner is asked to apply, without disturbing the commit. */
+        const withDescriptorCapture = rig => {
+            const seen     = [],
+                  original = rig.owner.applyDockZoneOperation.bind(rig.owner);
+
+            rig.owner.applyDockZoneOperation = function (descriptor) {
+                seen.push(descriptor);
+                return original(descriptor)
+            };
+
+            return seen
+        };
+
+        test('hover inside the strip previews the ROOT edge, not the zone beneath it', async () => {
+            const rig = compose();
+
+            rig.controller.dragGeometry = Promise.resolve(GEOMETRY());
+            rig.indicators.hostRect     = GEOMETRY().hostRect;
+
+            await rig.controller.onDragMove({clientX: 200, clientY: 10, itemId: 'gamma', sourceNodeId: 'right-tabs'});
+
+            const {dockPreview} = rig.preview;
+
+            // Control: the same x deeper into the surface must resolve the ZONE, or this test would
+            // pass on any pointer and prove nothing about the strip.
+            expect(dockPreview?.target?.nodeId, 'the strip must resolve the ROOT').toBe('split-main');
+            expect(dockPreview?.placement?.kind).toBe('edge-top');
+
+            await rig.controller.onDragMove({clientX: 200, clientY: 300, itemId: 'gamma', sourceNodeId: 'right-tabs'});
+            expect(rig.preview.dockPreview?.target?.nodeId, 'away from the border the zone owns it').toBe('left-tabs');
+
+            destroyAll(rig)
+        });
+
+        test('release inside the strip commits against the ROOT target', async () => {
+            const rig         = compose(),
+                  descriptors = withDescriptorCapture(rig);
+
+            rig.controller.dragGeometry = Promise.resolve(GEOMETRY());
+            rig.indicators.hostRect     = GEOMETRY().hostRect;
+
+            await rig.controller.onDragMove({clientX: 200, clientY: 10, itemId: 'gamma', sourceNodeId: 'right-tabs'});
+            await rig.controller.onDrop    ({clientX: 200, clientY: 10, itemId: 'gamma', sourceNodeId: 'right-tabs'});
+
+            expect(descriptors).toHaveLength(1);
+
+            // The release path passes its own root; the descriptor is what proves it arrived, since a
+            // committed document could reach a similar shape by another route.
+            expect(descriptors[0].targetNodeId, 'the commit must target the ROOT').toBe('split-main');
+            expect(rig.committed).toHaveLength(1);
+
+            destroyAll(rig)
+        })
     })
 });

--- a/test/playwright/unit/dashboard/DockPreview.spec.mjs
+++ b/test/playwright/unit/dashboard/DockPreview.spec.mjs
@@ -396,6 +396,46 @@ test.describe('Neo.dashboard.dock.interaction.Preview', () => {
             expect(geometry.width).toBe(rect.width * operation.sizes[0])
         });
 
+        // Hand-built affordances above prove the GEOMETRY. These drive `mapPreviewToAffordance`, so a
+        // mapper that stops carrying the fraction — or indexes the wrong child of the committed pair —
+        // reddens here rather than passing on a fixture that never used the mapper.
+        test('the MAPPED affordance carries the committed fraction, for every direction', () => {
+            const mapped = kind => DockPreview.mapPreviewToAffordance(
+                preview({placement: {kind, orientation: 'horizontal', ratio: 0.3}})
+            );
+
+            // `before` takes the pair's first child, `after` its second — both are 0.3 here, so the
+            // index alone cannot be checked by value; the geometry below is what separates them.
+            expect(mapped('split-before').ratio).toBeCloseTo(0.3);
+            expect(mapped('split-after').ratio).toBeCloseTo(0.3);
+            expect(mapped('edge-top').ratio).toBeCloseTo(0.3);
+            expect(mapped('edge-bottom').ratio).toBeCloseTo(0.3);
+
+            // …and an ASYMMETRIC pair separates them: ratio 0.3 `after` commits [0.7, 0.3], so a mapper
+            // reading the first child reports 0.7 and paints the wrong pane.
+            expect(DockPreview.newNodeFraction(0.3, 'after')).toBeCloseTo(0.3);
+            expect(DockPreview.newNodeFraction(0.3, 'before')).toBeCloseTo(0.3);
+            expect(DockPreview.ratioToSizes(0.3, 'after')).toEqual([0.7, 0.3])
+        });
+
+        test('MAPPED end-to-end: the painted region matches the descriptor, per direction', () => {
+            for (const [kind, expected] of [
+                ['split-before', {x: 10,  y: 20, width: 60, height: 100}],
+                ['split-after',  {x: 150, y: 20, width: 60, height: 100}],
+                ['edge-left',    {x: 10,  y: 20, width: 60, height: 100}],
+                ['edge-right',   {x: 150, y: 20, width: 60, height: 100}]
+            ]) {
+                const source     = preview({placement: {kind, orientation: 'horizontal', ratio: 0.3}}),
+                      affordance = DockPreview.mapPreviewToAffordance(source),
+                      operation  = DockPreview.previewToOperation(source),
+                      sizes      = operation.sizes ?? operation.target?.placement?.sizes;
+
+                expect(DockPreview.affordanceGeometry(affordance, rect), kind).toEqual(expected);
+                // the descriptor's own share for the new pane, whichever child it is
+                expect(Math.min(...sizes)).toBeCloseTo(0.3)
+            }
+        });
+
         test('an absent or out-of-domain ratio still paints the even split', () => {
             for (const ratio of [undefined, null, 0, 1, -0.2, 1.5, 'half', NaN]) {
                 expect(DockPreview.affordanceGeometry({group: 'split', orientation: 'horizontal', position: 'before', ratio}, rect))

--- a/test/playwright/unit/dashboard/DockPreview.spec.mjs
+++ b/test/playwright/unit/dashboard/DockPreview.spec.mjs
@@ -51,6 +51,13 @@ test.describe('Neo.dashboard.dock.interaction.Preview', () => {
             expect(scss).toContain('.neo-dock-preview-affordance');
             expect(scss).toContain('.neo-dock-preview-accepted');
             expect(scss).toContain('.neo-dock-preview-rejected');
+            // the result-region mode class routes directional placements into the filled
+            // family, and each cut-side accent the renderer can emit is backed
+            expect(scss).toContain('.neo-dock-preview-region');
+            expect(scss).toContain('.neo-dock-preview-cut-top');
+            expect(scss).toContain('.neo-dock-preview-cut-right');
+            expect(scss).toContain('.neo-dock-preview-cut-bottom');
+            expect(scss).toContain('.neo-dock-preview-cut-left');
             // accepted/rejected states carry real visual treatment, not just class names
             expect(scss).toContain('background-color');
             expect(scss).toContain('border');
@@ -343,42 +350,79 @@ test.describe('Neo.dashboard.dock.interaction.Preview', () => {
             expect(DockPreview.affordanceGeometry(null, rect)).toBe(null)
         });
 
-        test('an edge-top affordance is a band across the top', () => {
-            expect(DockPreview.affordanceGeometry({group: 'edge', edge: 'top'}, rect)).toEqual({x: 10, y: 20, width: 200, height: 24})
+        test('DEFAULT (result regions): an edge affordance is the half the new pane would occupy', () => {
+            expect(DockPreview.affordanceGeometry({group: 'edge', edge: 'top'},   rect)).toEqual({x: 10,  y: 20, width: 200, height: 50});
+            expect(DockPreview.affordanceGeometry({group: 'edge', edge: 'right'}, rect)).toEqual({x: 110, y: 20, width: 100, height: 100});
+            expect(DockPreview.affordanceGeometry({group: 'edge', edge: 'bottom'},rect)).toEqual({x: 10,  y: 70, width: 200, height: 50});
+            expect(DockPreview.affordanceGeometry({group: 'edge', edge: 'left'},  rect)).toEqual({x: 10,  y: 20, width: 100, height: 100})
         });
 
-        test('an edge-right affordance is a band down the right side', () => {
-            expect(DockPreview.affordanceGeometry({group: 'edge', edge: 'right'}, rect)).toEqual({x: 186, y: 20, width: 24, height: 100})
+        test('DEFAULT (result regions): a split affordance is the new sibling\'s half along the axis', () => {
+            expect(DockPreview.affordanceGeometry({group: 'split', orientation: 'horizontal', position: 'before'}, rect))
+                .toEqual({x: 10, y: 20, width: 100, height: 100});
+            expect(DockPreview.affordanceGeometry({group: 'split', orientation: 'horizontal', position: 'after'}, rect))
+                .toEqual({x: 110, y: 20, width: 100, height: 100});
+            expect(DockPreview.affordanceGeometry({group: 'split', orientation: 'vertical', position: 'before'}, rect))
+                .toEqual({x: 10, y: 20, width: 200, height: 50});
+            expect(DockPreview.affordanceGeometry({group: 'split', orientation: 'vertical', position: 'after'}, rect))
+                .toEqual({x: 10, y: 70, width: 200, height: 50})
         });
 
-        test('a tab-into affordance highlights the whole node', () => {
-            expect(DockPreview.affordanceGeometry({group: 'tab', position: 'into'}, rect)).toEqual(rect)
+        test('a tab-into affordance highlights the whole node in both modes', () => {
+            expect(DockPreview.affordanceGeometry({group: 'tab', position: 'into'}, rect)).toEqual(rect);
+            expect(DockPreview.affordanceGeometry({group: 'tab', position: 'into'}, rect, {resultRegionPreviews: false})).toEqual(rect)
         });
 
-        test('a horizontal split-after affordance is a guide line on the right edge', () => {
-            const geo = DockPreview.affordanceGeometry({group: 'split', orientation: 'horizontal', position: 'after'}, rect);
-            expect(geo).toEqual({x: 204, y: 20, width: 6, height: 100})
+        test('resultRegionPreviews: false restores the classic band and guide-line presentation', () => {
+            expect(DockPreview.affordanceGeometry({group: 'edge', edge: 'top'}, rect, {resultRegionPreviews: false}))
+                .toEqual({x: 10, y: 20, width: 200, height: 24});
+            expect(DockPreview.affordanceGeometry({group: 'edge', edge: 'right'}, rect, {resultRegionPreviews: false}))
+                .toEqual({x: 186, y: 20, width: 24, height: 100});
+            expect(DockPreview.affordanceGeometry({group: 'split', orientation: 'horizontal', position: 'after'}, rect, {resultRegionPreviews: false}))
+                .toEqual({x: 204, y: 20, width: 6, height: 100})
         });
 
-        test('sizing policy rides the options: explicit band/line values are honored + clamped', () => {
+        test('sizing policy rides the options in line mode: explicit band/line values honored + clamped', () => {
             // a touch-density consumer widens the band
-            expect(DockPreview.affordanceGeometry({group: 'edge', edge: 'top'}, rect, {edgeBandSize: 48}))
+            expect(DockPreview.affordanceGeometry({group: 'edge', edge: 'top'}, rect, {edgeBandSize: 48, resultRegionPreviews: false}))
                 .toEqual({x: 10, y: 20, width: 200, height: 48});
             // clamping survives the override: the band never exceeds the target rect
             // (edge-left renders the band as WIDTH: min(500, 200, 100) = 100)
-            expect(DockPreview.affordanceGeometry({group: 'edge', edge: 'left'}, rect, {edgeBandSize: 500}))
+            expect(DockPreview.affordanceGeometry({group: 'edge', edge: 'left'}, rect, {edgeBandSize: 500, resultRegionPreviews: false}))
                 .toEqual({x: 10, y: 20, width: 100, height: 100});
             // guide thickness follows the same policy surface
-            const geo = DockPreview.affordanceGeometry({group: 'split', orientation: 'horizontal', position: 'after'}, rect, {splitLineSize: 10});
+            const geo = DockPreview.affordanceGeometry({group: 'split', orientation: 'horizontal', position: 'after'}, rect, {resultRegionPreviews: false, splitLineSize: 10});
             expect(geo).toEqual({x: 200, y: 20, width: 10, height: 100})
+        })
+    });
+
+    test.describe('cutSide (the region\'s inner edge — where the future splitter sits)', () => {
+        test('edge regions cut on the side facing the remaining half', () => {
+            expect(DockPreview.cutSide({group: 'edge', edge: 'top'})).toBe('bottom');
+            expect(DockPreview.cutSide({group: 'edge', edge: 'bottom'})).toBe('top');
+            expect(DockPreview.cutSide({group: 'edge', edge: 'left'})).toBe('right');
+            expect(DockPreview.cutSide({group: 'edge', edge: 'right'})).toBe('left')
+        });
+
+        test('split regions cut on the boundary toward the existing sibling', () => {
+            expect(DockPreview.cutSide({group: 'split', orientation: 'horizontal', position: 'before'})).toBe('right');
+            expect(DockPreview.cutSide({group: 'split', orientation: 'horizontal', position: 'after'})).toBe('left');
+            expect(DockPreview.cutSide({group: 'split', orientation: 'vertical', position: 'before'})).toBe('bottom');
+            expect(DockPreview.cutSide({group: 'split', orientation: 'vertical', position: 'after'})).toBe('top')
+        });
+
+        test('non-directional affordances carry no cut', () => {
+            expect(DockPreview.cutSide({group: 'tab', position: 'into'})).toBe(null);
+            expect(DockPreview.cutSide(null)).toBe(null)
         })
     });
 
     test.describe('sizing policy (instance configuration)', () => {
         test('an instance override flows into the positioned affordance geometry', () => {
             const instance = Neo.create(DockPreview, {
-                edgeBandSize: 48,
-                id          : 'dock-preview-sizing-test'
+                edgeBandSize        : 48,
+                id                  : 'dock-preview-sizing-test',
+                resultRegionPreviews: false
             });
 
             instance.dockPreview = preview({placement: {kind: 'edge-top'}});
@@ -387,6 +431,33 @@ test.describe('Neo.dashboard.dock.interaction.Preview', () => {
 
             // the consumer's hardware/UI sizing is honored on the live overlay node
             expect(instance.vdom.cn[0].style.height).toBe('48px');
+
+            instance.destroy()
+        });
+
+        test('the region default paints the result half and marks its cut edge', () => {
+            const instance = Neo.create(DockPreview, {id: 'dock-preview-region-test'});
+
+            instance.dockPreview = preview({placement: {kind: 'edge-top'}});
+
+            instance.applyTargetGeometry({x: 0, y: 0, width: 300, height: 200});
+
+            const node = instance.vdom.cn[0];
+
+            // the outcome region: the top HALF of the target, not a 24px strip
+            expect(node.style.height).toBe('100px');
+            expect(node.style.width).toBe('300px');
+            expect(node.cls).toContain('neo-dock-preview-region');
+            expect(node.cls).toContain('neo-dock-preview-cut-bottom');
+
+            // flipping the config back re-renders the classic band on the next preview
+            instance.resultRegionPreviews = false;
+            instance.dockPreview = preview({placement: {kind: 'edge-top'}, previewId: 'preview:alpha:main-tabs:edge-top:2'});
+            instance.applyTargetGeometry({x: 0, y: 0, width: 300, height: 200});
+
+            const lineNode = instance.vdom.cn[0];
+            expect(lineNode.style.height).toBe('24px');
+            expect(lineNode.cls).not.toContain('neo-dock-preview-region');
 
             instance.destroy()
         })
@@ -454,7 +525,8 @@ test.describe('Neo.dashboard.dock.interaction.Preview', () => {
             expect(style.left).toBe('10px');
             expect(style.top).toBe('20px');
             expect(style.width).toBe('200px');
-            expect(style.height).toBe('24px')
+            // the region default paints the outcome half (100 / 2), not the 24px strip
+            expect(style.height).toBe('50px')
         })
     })
 });

--- a/test/playwright/unit/dashboard/DockPreview.spec.mjs
+++ b/test/playwright/unit/dashboard/DockPreview.spec.mjs
@@ -357,6 +357,52 @@ test.describe('Neo.dashboard.dock.interaction.Preview', () => {
             expect(DockPreview.affordanceGeometry({group: 'edge', edge: 'left'},  rect)).toEqual({x: 10,  y: 20, width: 100, height: 100})
         });
 
+        // A valid preview may carry `placement.ratio`, and `previewToOperation` commits
+        // `ratioToSizes(ratio, position)`. A region painted at a fixed half then shows a size the drop
+        // will not produce — a confidently wrong outcome, which is worse than the line it replaced.
+        test('a ratio-bearing SPLIT paints the committed fraction, on the committed side', () => {
+            // ratio 0.3, before -> sizes [0.3, 0.7]; the new pane is the FIRST child: 30% at the start.
+            expect(DockPreview.affordanceGeometry({group: 'split', orientation: 'horizontal', position: 'before', ratio: 0.3}, rect))
+                .toEqual({x: 10, y: 20, width: 60, height: 100});
+            // ratio 0.3, after -> sizes [0.7, 0.3]; the new pane is the SECOND child: 30% at the end.
+            expect(DockPreview.affordanceGeometry({group: 'split', orientation: 'horizontal', position: 'after', ratio: 0.3}, rect))
+                .toEqual({x: 150, y: 20, width: 60, height: 100});
+            expect(DockPreview.affordanceGeometry({group: 'split', orientation: 'vertical', position: 'before', ratio: 0.25}, rect))
+                .toEqual({x: 10, y: 20, width: 200, height: 25});
+            expect(DockPreview.affordanceGeometry({group: 'split', orientation: 'vertical', position: 'after', ratio: 0.25}, rect))
+                .toEqual({x: 10, y: 95, width: 200, height: 25})
+        });
+
+        test('a ratio-bearing EDGE paints the committed fraction, on the committed side', () => {
+            expect(DockPreview.affordanceGeometry({group: 'edge', edge: 'top', ratio: 0.3}, rect))
+                .toEqual({x: 10, y: 20, width: 200, height: 30});
+            expect(DockPreview.affordanceGeometry({group: 'edge', edge: 'bottom', ratio: 0.3}, rect))
+                .toEqual({x: 10, y: 90, width: 200, height: 30});
+            expect(DockPreview.affordanceGeometry({group: 'edge', edge: 'left', ratio: 0.25}, rect))
+                .toEqual({x: 10, y: 20, width: 50, height: 100});
+            expect(DockPreview.affordanceGeometry({group: 'edge', edge: 'right', ratio: 0.25}, rect))
+                .toEqual({x: 160, y: 20, width: 50, height: 100})
+        });
+
+        // 🔴 The region and the descriptor must agree for the SAME preview, or the UI is honest about
+        // a number nothing commits. This pins them to one authority rather than to each other's shape.
+        test('the painted fraction equals the size the descriptor commits', () => {
+            const source     = preview({placement: {kind: 'split-before', orientation: 'horizontal', ratio: 0.3}}),
+                  affordance = DockPreview.mapPreviewToAffordance(source),
+                  geometry   = DockPreview.affordanceGeometry(affordance, rect),
+                  operation  = DockPreview.previewToOperation(source);
+
+            expect(operation.sizes[0]).toBe(0.3);
+            expect(geometry.width).toBe(rect.width * operation.sizes[0])
+        });
+
+        test('an absent or out-of-domain ratio still paints the even split', () => {
+            for (const ratio of [undefined, null, 0, 1, -0.2, 1.5, 'half', NaN]) {
+                expect(DockPreview.affordanceGeometry({group: 'split', orientation: 'horizontal', position: 'before', ratio}, rect))
+                    .toEqual({x: 10, y: 20, width: 100, height: 100})
+            }
+        });
+
         test('DEFAULT (result regions): a split affordance is the new sibling\'s half along the axis', () => {
             expect(DockPreview.affordanceGeometry({group: 'split', orientation: 'horizontal', position: 'before'}, rect))
                 .toEqual({x: 10, y: 20, width: 100, height: 100});

--- a/test/playwright/unit/dashboard/DockPreviewProducer.spec.mjs
+++ b/test/playwright/unit/dashboard/DockPreviewProducer.spec.mjs
@@ -170,6 +170,35 @@ test.describe('Neo.dashboard.dock.interaction.PreviewProducer (ADR 0029 §2.3 �
         expect(producer.produce()).toBeNull()                                                        // no args
     });
 
+    test('the root-edge border strip outranks zone inference — docking across the full surface without a chip', () => {
+        // one zone touching the container border: without the strip, a pointer 10px inside the
+        // left border resolves the ZONE's placement; the strip re-reads it as the ROOT edge
+        const root  = {nodeId: 'root', rect: {x: 0, y: 0, width: 400, height: 300}},
+              zones = [{nodeId: 'main-tabs', rect: {x: 0, y: 0, width: 400, height: 300}, orientation: 'horizontal'}];
+
+        const strip = producer.produce({pointer: {x: 10, y: 150}, zones, itemId: 'strategy', root});
+        expect(strip.placement.kind).toBe('edge-left');
+        expect(strip.target.nodeId).toBe('root');
+        expect(strip.previewId).toBe('preview:strategy:root:edge-left');
+
+        // corner ambiguity: the NEAREST border wins
+        const corner = producer.produce({pointer: {x: 20, y: 8}, zones, itemId: 'strategy', root});
+        expect(corner.placement.kind).toBe('edge-top');
+        expect(corner.target.nodeId).toBe('root');
+
+        // inside the surface, past the strip: zone inference owns the frame unchanged
+        const interior = producer.produce({pointer: {x: 200, y: 150}, zones, itemId: 'strategy', root});
+        expect(interior.target.nodeId).toBe('main-tabs');
+        expect(interior.placement.kind).toBe('tab-into');
+
+        // no root supplied (legacy callers) and a disabled band both fall through to zones
+        expect(producer.produce({pointer: {x: 10, y: 150}, zones, itemId: 'strategy'}).target.nodeId).toBe('main-tabs');
+
+        const disabled = Neo.create(DockPreviewProducer, {id: 'producer-root-band-off', rootEdgeBandPx: 0});
+        expect(disabled.produce({pointer: {x: 10, y: 150}, zones, itemId: 'strategy', root}).target.nodeId).toBe('main-tabs');
+        disabled.destroy()
+    });
+
     test('whole-stack production carries one coherent runtime group through previews and candidates', async () => {
         const {isValidCandidateSet} = await import('../../../../src/dashboard/dock/model/PreviewContract.mjs');
         const zones                 = [{nodeId: 'main-tabs', rect: RECT, orientation: 'vertical'}];


### PR DESCRIPTION
Resolves #17870

Evidence: L2 (unit + component CI at exact head; live held-gesture receipts from the workstation at merged-dev parity) → L2 required (renderer geometry + producer inference ACs are fully unit/component-coverable). No residuals.

## What changes

The drop-preview language now shows **outcomes everywhere**. Split and edge placements paint the half of the target the new pane would occupy — the same translucent fill the pane center (tab-into) always used — with the exact cut preserved as a **4px accent on the region's inner edge** (`cutSide` maps every directional kind to the boundary where the future splitter sits). The classic 6px insertion line stays one config away: `resultRegionPreviews: false` on the Preview renderer.

`produce()` additionally gains the **root-edge border strip** (`rootEdgeBandPx: 24`): within the strip along the container border, pointer inference resolves the ROOT `edge-*` placement — docking across the full surface no longer requires aiming at a 26px chip. The strip outranks zone inference only at the border (mirroring the indicator tier's root chips); `0` disables it.

Adopted from the operator's webdock comparison (#17870 carries the full study): the hit models were already equivalent — the one transplantable lesson was visual. **Show the result region, not the cut line.**

## Deliberate boundaries

- **No descriptor/wire change:** `previewToOperation` payloads are byte-identical per kind; the root-strip previews reuse the exact `edge-*` shape the chips emit. **The pointer OUTCOME does change, intentionally:** inside `rootEdgeBandPx` of the container border, a pointer that previously resolved the zone beneath it now resolves the ROOT edge. Same descriptor vocabulary, deliberately different answer — calling that "no commit-semantics change" overstated it, because what a given pointer commits is exactly what moved.
- **Cross-window callers unchanged:** the engine Workspace and workstation cross-window `produce()` calls pass no `root`; `resolveRootEdge(null)` fail-closes to the zone path, so remote-drag behavior is byte-compatible. Cross-window root-edge inference is a separate semantic question, deliberately not smuggled in.
- The minimal dock example still composes no affordance tier (noted in the ticket as a separate call).

## AC Evidence

| AC | Evidence |
|---|---|
| Band hover paints the half-zone region + cut accent; center keeps the full fill | Live held gesture on the workstation: pane left band → **207×543 region** (`neo-dock-preview-region` + `neo-dock-preview-cut-right`, border-right 4px, accept fill) where dev renders a 6px line; center → 414×543 full fill unchanged. Unit: region geometry pinned for all 4 edge kinds + all 4 split kind/orientation combos; the rendered instance path witnesses both region classes and the live style. |
| `resultRegionPreviews: false` restores the line presentation | Unit: explicit false-mode cases reproduce the exact pre-change band/line geometry (incl. sizing-policy clamps); the rendered instance test flips the config live and gets the 24px band back. |
| Root-edge strip resolves between chips; chips unchanged | Live: 15px above the container's bottom border (no chip) → **1400×401 full-width root region** (`cut-top`). Unit: strip beats zone inference at the border, corner resolves to the nearest border, interior falls through to `tab-into`, legacy no-root callers and `rootEdgeBandPx: 0` both keep today's behavior. Chips ride `produceCandidates`, untouched. |
| No descriptor/wire change | The producer emits the same `edge-*`/`split-*`/`tab-*` payload shapes; every pre-existing produce/candidates unit expectation passes unmodified except the two geometry expectations that encode the new default (updated with comments). The root strip changes which placement a border pointer resolves to — an intentional outcome change inside the same vocabulary, not a wire change. |
| Tokens documented; sane defaults | The region family reuses the existing accept/reject/signal token contract (no new tokens needed — the mode class joins the filled family); the SCSS census in the unit spec now pins `neo-dock-preview-region` + all four `cut-*` classes as backed. |

## Test Evidence

- Unit **2085/2085** at head (dashboard dir 610/610 — five new witnesses). Component dashboard **22/22**.
- **Mutation check:** both engine files stashed → exactly **8 red** (the new/updated contract cases: region defaults, cutSide, rendered region path, root strip); restored → green.
- Live receipts (dev server, workstation, held synthetic gestures at 1400×900): the three-scenario sample table + the mid-gesture screenshot are in the review thread's reach; numbers above.

## Post-Merge Validation

- None required — the surfaces are unit/component-covered and the live receipts ran the exact head.

## Deltas

- The ticket proposed keeping the insertion line as a separate leading-edge element; shipped as a **border-width accent via `cut-*` classes** instead — one element, pure CSS, same information.
- The ticket's "component tier region-visibility case" lands as the rendered-instance unit case (real `DockPreview` instance, real vdom style assertions) — same rendered-shape truth, cheaper tier; noted here per the AC-fidelity rule.

## Round-2 discharge (@neo-opus-ada)

**The region now reads the ratio the drop will commit.** `mapPreviewToAffordance` dropped `placement.ratio`, and the geometry hard-coded halves in five branches, while `previewToOperation` committed through `ratioToSizes` — so a ratio-bearing preview painted 50/50 and committed something else. Two authorities for one number, correct only while every ratio happened to be 0.5. The affordance carries the ratio now and the region derives its share from `ratioToSizes`, fallback included. The witnesses assert the two paths **against each other** — the expected fraction comes from `previewToOperation`'s own `sizes`, so they cannot drift apart silently. Dropping the ratio again reds 8 of the 9.

**The root strip is pinned at both call sites.** The producer's specs proved the mapping and said nothing about whether the controller passes the root — which it must, on the hover path and the release path independently. Both now run through the real gesture in `DockDragAffordances.spec.mjs`, and reverting either argument reds exactly the arm that pins it. The release arm asserts the captured descriptor rather than the resulting document, since a document can reach a similar shape by another route. `params.root` JSDoc added.

**The geometry snap is intentional release truth, not a hard cut.** The region does not track the pointer continuously — it snaps to the fraction the release would commit. That is the contract this PR is arguing for: a result region that interpolated toward the pointer would show a size nothing is going to apply, which is the failure mode the insertion line already had. The snap IS the honesty; a smooth region would be a prettier lie.

Authored by ⚖️ Ada (Claude Opus 5, Claude Code) consuming 🪢 Mnemosyne's handoff — session A c98e1ede-1a32-46f3-90ef-aaf37def487d, session B 0af56b9a-7beb-47dd-b927-df3c1f567903. The design, the branch and everything before the round-2 discharge are Mnemosyne's; @tobiu directed the takeover while that seat is rate-limited.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
