### PR TITLE
feat(toolbar): gate actions on showOnFocus via the reactive containsFocus

### DIFF
--- a/src/tab/Container.mjs
+++ b/src/tab/Container.mjs
@@ -80,8 +80,9 @@ class Container extends BaseContainer {
          */
         headerToolbar: null,
         /**
-         * Optional flat action configs for the tab header toolbar. Tab actions are contextual by
-         * default; an action can set contextual=false to stay persistent.
+         * Optional flat action configs for the tab header toolbar. Tab actions are gated on this
+         * TabContainer holding focus by default; an action can set `showOnFocus: false` to stay
+         * persistent.
          * @member {Object[]|String[]|null} headerActions=null
          * @reactive
          */
@@ -606,35 +607,14 @@ class Container extends BaseContainer {
         this.layout = {ntype: 'flexbox', ...this.getLayoutConfig()};
         super.onConstructed();
 
-        this.getTabBar().on('action', this.onHeaderAction, this)
-    }
+        let tabBar = this.getTabBar();
 
-    /**
-     * Arms contextual actions only when focus enters the tab body. Header/action focus retains the
-     * current state through manager.Focus's closest-common-component path.
-     * @param {Object} data
-     */
-    onFocusEnter(data) {
-        super.onFocusEnter(data);
+        tabBar.on('action', this.onHeaderAction, this);
 
-        this.isBodyFocusPath(data.path) && (this.getTabBar().contextualActionsVisible = true)
-    }
-
-    /**
-     * Arms contextual actions when an internal focus move enters the body.
-     * @param {Object} data
-     */
-    onFocusMove(data) {
-        this.isBodyFocusPath(data.path) && (this.getTabBar().contextualActionsVisible = true)
-    }
-
-    /**
-     * Disarms contextual actions only after focus leaves the complete TabContainer realm.
-     * @param {Object} data
-     */
-    onFocusLeave(data) {
-        super.onFocusLeave(data);
-        this.getTabBar().contextualActionsVisible = false
+        // The bar is constructed before its parent finished wiring, so its own attempt may have
+        // resolved nothing. The subject is this TabContainer: focus anywhere inside it — a tab
+        // button, the body, an action — exposes the gated actions; only leaving hides them.
+        tabBar.wireFocusSubject()
     }
 
     /**
@@ -774,27 +754,6 @@ class Container extends BaseContainer {
         })
     }
 
-    /**
-     * True when a focused DOM path resolves through the tab body component.
-     * @param {Object[]} [path=[]]
-     * @returns {Boolean}
-     * @protected
-     */
-    isBodyFocusPath(path=[]) {
-        let component = path
-            .map(node => Neo.getComponent(node.id))
-            .find(Boolean);
-
-        while (component && component !== this) {
-            if (component.id === this.bodyContainerId) {
-                return true
-            }
-
-            component = component.parent
-        }
-
-        return false
-    }
 }
 
 export default Neo.setupClass(Container);

--- a/src/tab/header/Toolbar.mjs
+++ b/src/tab/header/Toolbar.mjs
@@ -7,11 +7,12 @@ import BaseToolbar from '../../toolbar/Base.mjs';
 class Toolbar extends BaseToolbar {
     static config = {
         /**
-         * Tab-header actions are contextual by default. Persistent actions opt out explicitly.
-         * @member {Object} actionDefaults={contextual:true}
+         * Tab-header actions are focus-gated by default. Persistent actions opt out explicitly with
+         * `showOnFocus: false` (or the deprecated `contextual: false`).
+         * @member {Object} actionDefaults={showOnFocus:true}
          */
         actionDefaults: {
-            contextual: true
+            showOnFocus: true
         },
         /**
          * @member {String} className='Neo.tab.header.Toolbar'

--- a/src/toolbar/Base.mjs
+++ b/src/toolbar/Base.mjs
@@ -252,16 +252,15 @@ class Toolbar extends Container {
     /**
      * Whether one action item is gated on the focus subject.
      *
-     * `contextual` is the deprecated spelling of `showOnFocus`, kept because it is shipped. The
-     * current name wins when both are present, and it is the one an action ends up carrying —
-     * {@link #createActionItemConfig} resolves a consumer's explicit `contextual` into it, so a
-     * subclass default expressed in either spelling cannot outrank an explicit opt-out.
+     * One key decides it. `contextual` is the deprecated spelling and is an INPUT alias only:
+     * {@link #createActionItemConfig} resolves it into `showOnFocus` and deletes it, so no instance
+     * ever carries both and no reader has to know which spelling won.
      * @param {Neo.component.Base} item
      * @returns {Boolean}
      * @protected
      */
     isFocusGatedAction(item) {
-        return item.showOnFocus === true || item.contextual === true
+        return item.showOnFocus === true
     }
 
     /**
@@ -368,18 +367,11 @@ class Toolbar extends Container {
             vdom['aria-label'] = String(resolved.action).replace(/[-_]+/g, ' ')
         }
 
-        // An explicit gate on the action always outranks `actionDefaults`, in EITHER spelling. Order
-        // alone cannot deliver that: a subclass default of `showOnFocus: true` and a consumer's
-        // `contextual: false` are different keys, so both survive the spread and the opt-out is lost.
-        // Resolving the consumer's intent into the current name — and dropping the alias — keeps the
-        // two shipped `contextual: false` callers gated exactly as before.
-        let showOnFocus = Object.hasOwn(resolved, 'showOnFocus') ? resolved.showOnFocus === true :
-                          Object.hasOwn(resolved, 'contextual')  ? resolved.contextual  === true :
-                          undefined;
+        let defaults = me.actionDefaults || {};
 
         let config = {
             role: 'button',
-            ...(me.actionDefaults || {}),
+            ...defaults,
             handler: me.fireAction.bind(me),
             ...resolved,
             cls,
@@ -387,10 +379,24 @@ class Toolbar extends Container {
             ...(Object.keys(vdom).length > 0 && {vdom})
         };
 
-        if (showOnFocus !== undefined) {
-            config.showOnFocus = showOnFocus;
-            delete config.contextual
-        }
+        // The gate is normalized to exactly ONE key, so nothing downstream has to reconcile two
+        // spellings. Precedence is explicit rather than positional, because the spread cannot express
+        // it: `showOnFocus` and `contextual` are different keys, so BOTH survive it and the
+        // deprecated one would decide whenever it happened to be truthy — including when both arrive
+        // from `actionDefaults`, where there is no "own" value to prefer.
+        //
+        // Nearest wins, current name before the alias: the action's own `showOnFocus`, then its
+        // `contextual`, then the defaults' `showOnFocus`, then the defaults' `contextual`.
+        let gate = Object.hasOwn(resolved,  'showOnFocus') ? resolved.showOnFocus  === true :
+                   Object.hasOwn(resolved,  'contextual')  ? resolved.contextual   === true :
+                   Object.hasOwn(defaults,  'showOnFocus') ? defaults.showOnFocus  === true :
+                   Object.hasOwn(defaults,  'contextual')  ? defaults.contextual   === true :
+                   undefined;
+
+        // `contextual` is an INPUT alias only; it never survives onto the instance.
+        delete config.contextual;
+
+        gate === undefined ? delete config.showOnFocus : (config.showOnFocus = gate);
 
         return config
     }

--- a/src/toolbar/Base.mjs
+++ b/src/toolbar/Base.mjs
@@ -57,8 +57,11 @@ class Toolbar extends Container {
          */
         baseCls: ['neo-toolbar'],
         /**
-         * Whether focus-contextual actions are currently exposed. Inactive contextual actions keep
-         * their layout extent but leave pointer, keyboard, and accessibility navigation.
+         * Whether focus-gated actions are currently exposed. Inactive actions keep their layout
+         * extent but leave pointer, keyboard, and accessibility navigation.
+         *
+         * Driven by {@link #focusSubjectId}; a composition may still set it directly when its
+         * exposing signal is not a focus event.
          * @member {Boolean} contextualActionsVisible=false
          * @reactive
          */
@@ -68,6 +71,18 @@ class Toolbar extends Container {
          * @reactive
          */
         dock_: null,
+        /**
+         * Component whose focus exposes this toolbar's `showOnFocus` actions. `null` resolves to the
+         * toolbar's parent container — for a tab header toolbar that is the TabContainer itself.
+         *
+         * One subject covers both edges, and that is a property of `manager.Focus` rather than a
+         * simplification: it fires `focusEnter` / `focusLeave` only up to the closest component
+         * common to the old and new paths. Focus moving anywhere INSIDE the subject — including onto
+         * one of these actions — never fires `focusLeave` on it, so an action cannot vanish from
+         * under the pointer reaching for it. Only leaving the subject entirely re-hides them.
+         * @member {String|null} focusSubjectId=null
+         */
+        focusSubjectId: null,
         /**
          * @member {Object} itemDefaults={ntype:'button'}
          * @reactive
@@ -139,6 +154,17 @@ class Toolbar extends Container {
     }
 
     /**
+     * @param {Boolean} value
+     * @param {Boolean} oldValue
+     * @protected
+     */
+    afterSetMounted(value, oldValue) {
+        super.afterSetMounted(value, oldValue);
+
+        value && this.wireFocusSubject()
+    }
+
+    /**
      * Checks if the new dock position matches a value of the static dockPositions config
      * @param {String} value
      * @param {String} oldValue
@@ -170,6 +196,15 @@ class Toolbar extends Container {
     }
 
     /**
+     * @protected
+     */
+    onConstructed() {
+        super.onConstructed();
+
+        this.wireFocusSubject()
+    }
+
+    /**
      * Reserves or releases contextual action interactivity while preserving layout geometry.
      * @param {Boolean} [silent=false]
      */
@@ -178,7 +213,7 @@ class Toolbar extends Container {
             visible = me.contextualActionsVisible;
 
         me.getActionItems().forEach(item => {
-            if (item.contextual !== true) {
+            if (!me.isFocusGatedAction(item)) {
                 return
             }
 
@@ -212,6 +247,59 @@ class Toolbar extends Container {
 
             !silent && item.update()
         })
+    }
+
+    /**
+     * Whether one action item is gated on the focus subject.
+     *
+     * `contextual` is the deprecated spelling of `showOnFocus`, kept because it is shipped. The
+     * current name wins when both are present, and it is the one an action ends up carrying —
+     * {@link #createActionItemConfig} resolves a consumer's explicit `contextual` into it, so a
+     * subclass default expressed in either spelling cannot outrank an explicit opt-out.
+     * @param {Neo.component.Base} item
+     * @returns {Boolean}
+     * @protected
+     */
+    isFocusGatedAction(item) {
+        return item.showOnFocus === true || item.contextual === true
+    }
+
+    /**
+     * Subscribes the focus gate to its subject.
+     *
+     * Idempotent and safe to call early: the subject may not exist yet when a toolbar is built as
+     * an early child, so the first attempt can resolve nothing. It then leaves the toolbar unwired
+     * rather than marking it done, and the owner's `onConstructed` or this toolbar's mount retries.
+     * Binding once at a single moment would be either too early for the subject or too late for a
+     * toolbar that never mounts.
+     * @protected
+     */
+    wireFocusSubject() {
+        let me = this;
+
+        if (me.focusSubjectWired) {
+            return
+        }
+
+        let subject = me.focusSubjectId ? Neo.getComponent(me.focusSubjectId) : me.parent;
+
+        if (!subject) {
+            return
+        }
+
+        me.focusSubjectWired = true;
+
+        // `containsFocus` is a reactive config that `manager.Focus` already maintains on every
+        // component in the focus path, so the gate is a subscription to existing state rather than
+        // a second interpretation of focus events. `observeConfig()` also ties the subscription to
+        // this toolbar's lifecycle, which hand-rolled listeners do not.
+        me.observeConfig(subject, 'containsFocus', value => {
+            me.contextualActionsVisible = value === true
+        });
+
+        // Wiring can land after the subject already holds focus; the subscription only reports
+        // CHANGES, so the current value has to be adopted once.
+        me.contextualActionsVisible = subject.containsFocus === true
     }
 
     /**
@@ -280,7 +368,16 @@ class Toolbar extends Container {
             vdom['aria-label'] = String(resolved.action).replace(/[-_]+/g, ' ')
         }
 
-        return {
+        // An explicit gate on the action always outranks `actionDefaults`, in EITHER spelling. Order
+        // alone cannot deliver that: a subclass default of `showOnFocus: true` and a consumer's
+        // `contextual: false` are different keys, so both survive the spread and the opt-out is lost.
+        // Resolving the consumer's intent into the current name — and dropping the alias — keeps the
+        // two shipped `contextual: false` callers gated exactly as before.
+        let showOnFocus = Object.hasOwn(resolved, 'showOnFocus') ? resolved.showOnFocus === true :
+                          Object.hasOwn(resolved, 'contextual')  ? resolved.contextual  === true :
+                          undefined;
+
+        let config = {
             role: 'button',
             ...(me.actionDefaults || {}),
             handler: me.fireAction.bind(me),
@@ -288,7 +385,14 @@ class Toolbar extends Container {
             cls,
             isToolbarAction: true,
             ...(Object.keys(vdom).length > 0 && {vdom})
+        };
+
+        if (showOnFocus !== undefined) {
+            config.showOnFocus = showOnFocus;
+            delete config.contextual
         }
+
+        return config
     }
 
     /**

--- a/test/playwright/e2e/tab/TabHeaderActionsNL.spec.mjs
+++ b/test/playwright/e2e/tab/TabHeaderActionsNL.spec.mjs
@@ -40,7 +40,7 @@ test.describe('TabContainer flat header actions (Neural Link)', () => {
 
         const actionRecords = asArray(await app.queryComponent(
                   {isToolbarAction: true},
-                  ['id', 'action', 'contextual', 'role', 'vdom', 'wrapperCls']
+                  ['id', 'action', 'showOnFocus', 'role', 'vdom', 'wrapperCls']
               )),
               actionsByName = Object.fromEntries(actionRecords.map(record => [valueOf(record, 'action'), record])),
               nextRecord    = actionsByName['next-tab'],
@@ -100,11 +100,14 @@ test.describe('TabContainer flat header actions (Neural Link)', () => {
         await expect(previousAction).toHaveCSS('visibility', 'hidden');
         await expect(page.getByRole('button', {name: 'previous tab', exact: true})).toHaveCount(0);
 
-        // Entering through a persistent header action does not arm the contextual sibling.
+        // The gate subject is the TabContainer, not its body: entering through ANY descendant --
+        // here a persistent header action -- is focus inside the container, so the gated sibling is
+        // exposed too. Gating on body focus instead would leave a tab whose body holds nothing
+        // focusable unable to ever reach its own actions.
         await nextAction.click();
         await expect.poll(async () => (await app.getComponent(tabId, ['activeIndex'])).activeIndex)
             .toBe(0);
-        await expect(previousAction).toHaveCSS('visibility', 'hidden');
+        await expect(previousAction).toHaveCSS('visibility', 'visible');
 
         const tabIds = await bar.locator('.neo-tab-header-button').evaluateAll(nodes => nodes.map(node => node.id));
 
@@ -203,7 +206,17 @@ test.describe('TabContainer flat header actions (Neural Link)', () => {
         await expect(previousAction,
             'focus moving into the logically-owned Overflow/menu realm retains contextual actions').toHaveCSS('visibility', 'visible');
 
+        // Dismiss the menu BEFORE leaving. An outside click while it is open is absorbed by its own
+        // dismissal and focus REVERTS to the floating Overflow control — which this toolbar logically
+        // owns, so the container still contains focus and the actions correctly stay visible (the
+        // assertion just above says exactly that). Without the Escape this step asserts a transition
+        // that never happens; it passed under the old body-armed gate only because focus leaving the
+        // body once meant it never re-armed.
+        await page.keyboard.press('Escape');
         await outsideField.click();
+        await expect.poll(() => page.evaluate(() => document.activeElement?.id),
+            {message: 'the outside field really took focus, so the next assertion covers a genuine exit'}
+        ).toBe('activeIndexField__input');
         await expect(previousAction).toHaveCSS('visibility', 'hidden');
 
         // Start from an all-fit header. Mid-gesture action growth would overflow, but the SortZone's

--- a/test/playwright/unit/tab/HeaderActions.spec.mjs
+++ b/test/playwright/unit/tab/HeaderActions.spec.mjs
@@ -18,7 +18,18 @@ import LivePreview    from '../../../../src/code/LivePreview.mjs';
 import TabContainer   from '../../../../src/tab/Container.mjs';
 import EffectButton   from '../../../../src/tab/header/EffectButton.mjs';
 import Toolbar        from '../../../../src/toolbar/Base.mjs';
+import '../../../../src/manager/Focus.mjs';
 import '../../../../src/manager/Instance.mjs';
+
+/**
+ * Drives the real focus manager rather than a component's focus hooks. The gate is wired through
+ * `manager.Focus` firing `focusEnter` / `focusLeave` on each component in the path, so calling a
+ * container's hook directly would assert against a mechanism the product no longer uses.
+ */
+const focusOpts  = ids => ({componentPath: ids, data: {path: ids.map(id => ({id})), relatedTarget: null}}),
+      focusEnter = ids => Neo.manager.Focus.focusEnter(focusOpts(ids)),
+      focusLeave = ids => Neo.manager.Focus.focusLeave(focusOpts(ids)),
+      focusMove  = ids => Neo.manager.Focus.focusMove(focusOpts(ids));
 
 /**
  * @summary Pins flat toolbar action materialisation and mixed TabContainer semantics.
@@ -263,9 +274,9 @@ test.describe.serial('Neo tab header actions', () => {
         expect(bar.getActionItems().every(item => !item.wrapperCls.includes('neo-draggable'))).toBe(true)
     });
 
-    test('body focus arms contextual actions and the TabContainer realm retains them', () => {
+    test('TabContainer focus exposes showOnFocus actions and holds them across internal moves', () => {
         const tabs = own(Neo.create(TabContainer, {
-                  headerActions: [{action: 'contextual', iconCls: 'fa fa-eye'}],
+                  headerActions: [{action: 'gated', iconCls: 'fa fa-eye'}],
                   items        : [{module: Component, header: {text: 'One'}}]
               })),
               action = tabs.getActionItems()[0],
@@ -275,17 +286,110 @@ test.describe.serial('Neo tab header actions', () => {
 
         expect(action.cls).toContain('neo-toolbar-action-context-inactive');
 
-        tabs.onFocusEnter({path: [{id: card.id}, {id: body.id}, {id: tabs.id}]});
+        focusEnter([card.id, body.id, tabs.id]);
         expect(action.cls).not.toContain('neo-toolbar-action-context-inactive');
 
-        tabs.onFocusMove({
-            oldPath: [{id: card.id}, {id: body.id}, {id: tabs.id}],
-            path   : [{id: action.id}, {id: bar.id}, {id: tabs.id}]
-        });
+        // Reaching for the action must not hide it. `focusMove` fires `focusLeave` only up to the
+        // closest common component, which is the TabContainer itself, so the subject never sees a
+        // leave. An implementation observing the BODY would disarm here and hide the action being
+        // clicked.
+        focusMove([action.id, bar.id, tabs.id]);
         expect(action.cls).not.toContain('neo-toolbar-action-context-inactive');
 
-        tabs.onFocusLeave({oldPath: [{id: action.id}, {id: bar.id}, {id: tabs.id}]});
+        focusLeave([action.id, bar.id, tabs.id]);
         expect(action.cls).toContain('neo-toolbar-action-context-inactive')
+    });
+
+    test('focusing a tab button exposes the actions — the subject is the container, not the body', () => {
+        const tabs = own(Neo.create(TabContainer, {
+                  headerActions: [{action: 'gated', iconCls: 'fa fa-eye'}],
+                  items        : [{module: Component, header: {text: 'One'}}]
+              })),
+              action = tabs.getActionItems()[0],
+              bar    = tabs.getTabBar(),
+              button = tabs.getTabButtons()[0];
+
+        // The whole point of the container being the subject: a tab whose body holds nothing
+        // focusable would never expose its actions if arming required body focus.
+        focusEnter([button.id, bar.id, tabs.id]);
+        expect(action.cls).not.toContain('neo-toolbar-action-context-inactive');
+
+        focusLeave([button.id, bar.id, tabs.id]);
+        expect(action.cls).toContain('neo-toolbar-action-context-inactive')
+    });
+
+    test('a plain toolbar arms on its own parent, with no TabContainer involved', () => {
+        const container = own(Neo.create(BaseContainer, {
+                  items: [{
+                      module : Toolbar,
+                      actions: [{action: 'gated', iconCls: 'fa fa-eye', showOnFocus: true}]
+                  }, {
+                      module: Component
+                  }]
+              })),
+              toolbar = container.items[0],
+              sibling = container.items[1],
+              action  = toolbar.getActionItems()[0];
+
+        expect(action.cls).toContain('neo-toolbar-action-context-inactive');
+
+        focusEnter([sibling.id, container.id]);
+        expect(action.cls).not.toContain('neo-toolbar-action-context-inactive');
+
+        // Default subjects are both the parent, so moving focus INTO the toolbar cannot disarm it:
+        // the parent is the closest common component and never receives `focusLeave`.
+        focusMove([action.id, toolbar.id, container.id]);
+        expect(action.cls).not.toContain('neo-toolbar-action-context-inactive');
+
+        focusLeave([action.id, toolbar.id, container.id]);
+        expect(action.cls).toContain('neo-toolbar-action-context-inactive')
+    });
+
+    test('an explicit gate outranks actionDefaults in either spelling', () => {
+        const tabs = own(Neo.create(TabContainer, {
+                  headerActions: [
+                      {action: 'legacy-persistent', contextual : false, iconCls: 'fa fa-one'},
+                      {action: 'persistent',        showOnFocus: false, iconCls: 'fa fa-two'},
+                      {action: 'legacy-gated',      contextual : true,  iconCls: 'fa fa-three'},
+                      {action: 'defaulted',                             iconCls: 'fa fa-four'}
+                  ],
+                  items: [{module: Component, header: {text: 'One'}}]
+              })),
+              [legacyPersistent, persistent, legacyGated, defaulted] = tabs.getActionItems();
+
+        // The tab header defaults to `showOnFocus: true`. A consumer opting out with the deprecated
+        // `contextual: false` must still be persistent — the two shipped callers do exactly this,
+        // and a spread alone would leave both keys present and keep them gated.
+        expect(legacyPersistent.cls).not.toContain('neo-toolbar-action-context-inactive');
+        expect(persistent.cls).not.toContain('neo-toolbar-action-context-inactive');
+        expect(legacyGated.cls).toContain('neo-toolbar-action-context-inactive');
+        expect(defaulted.cls).toContain('neo-toolbar-action-context-inactive');
+
+        // The alias is resolved into the current name and dropped, so nothing downstream has to
+        // consult two keys.
+        expect(legacyPersistent.showOnFocus).toBe(false);
+        expect(legacyGated.showOnFocus).toBe(true)
+    });
+
+    test('an opt-out survives a subclass whose actionDefaults still use the deprecated spelling', () => {
+        const container = own(Neo.create(BaseContainer, {
+                  items: [{
+                      module        : Toolbar,
+                      actionDefaults: {contextual: true},
+                      actions       : [
+                          {action: 'persistent', showOnFocus: false, iconCls: 'fa fa-one'},
+                          {action: 'gated',                          iconCls: 'fa fa-two'}
+                      ]
+                  }]
+              })),
+              [persistent, gated] = container.items[0].getActionItems();
+
+        // `actionDefaults.contextual` and the action's `showOnFocus` are different keys, so both
+        // survive the spread. Unless the resolved intent drops the alias, this action stays gated
+        // despite opting out — and it would be invisible until its container took focus.
+        expect(persistent.cls).not.toContain('neo-toolbar-action-context-inactive');
+        expect(persistent.contextual).toBeUndefined();
+        expect(gated.cls).toContain('neo-toolbar-action-context-inactive')
     });
 
     test('LivePreview keeps semantic actions stable across active-tab and popup lifecycles', async () => {

--- a/test/playwright/unit/tab/HeaderActions.spec.mjs
+++ b/test/playwright/unit/tab/HeaderActions.spec.mjs
@@ -371,6 +371,35 @@ test.describe.serial('Neo tab header actions', () => {
         expect(legacyGated.showOnFocus).toBe(true)
     });
 
+    test('a mixed actionDefaults lets the CURRENT key decide, not the deprecated one', () => {
+        const container = own(Neo.create(BaseContainer, {
+                  items: [{
+                      module        : Toolbar,
+                      actionDefaults: {contextual: true, showOnFocus: false},
+                      actions       : [{action: 'persistent', iconCls: 'fa fa-one'}]
+                  }, {
+                      module        : Toolbar,
+                      actionDefaults: {contextual: false, showOnFocus: true},
+                      actions       : [{action: 'gated', iconCls: 'fa fa-two'}]
+                  }]
+              })),
+              [persistent] = container.items[0].getActionItems(),
+              [gated]      = container.items[1].getActionItems();
+
+        // Both keys arrive from actionDefaults, so there is no "own" value to prefer and positional
+        // spread order cannot express precedence — whichever deprecated value happened to be truthy
+        // would decide. The current key must win in BOTH directions, which is why the second toolbar
+        // inverts the pair.
+        expect(persistent.cls).not.toContain('neo-toolbar-action-context-inactive');
+        expect(persistent.showOnFocus).toBe(false);
+        expect(gated.cls).toContain('neo-toolbar-action-context-inactive');
+        expect(gated.showOnFocus).toBe(true);
+
+        // The alias is an INPUT only; no instance carries both keys for a later reader to reconcile.
+        expect(persistent.contextual).toBeUndefined();
+        expect(gated.contextual).toBeUndefined()
+    });
+
     test('an opt-out survives a subclass whose actionDefaults still use the deprecated spelling', () => {
         const container = own(Neo.create(BaseContainer, {
                   items: [{


### PR DESCRIPTION
Resolves #17874

Toolbar actions gated on `contextual` — a boolean naming no context — driven by three hand-rolled handlers in `tab.Container` that re-derived from focus *events* what `manager.Focus` already maintains as reactive *state*. The gate now observes the subject's `containsFocus` config through `observeConfig()`, which also ties the subscription to the toolbar's lifecycle. The subject defaults to the toolbar's parent, so a plain toolbar gets the capability with no wiring at all, and for a tab header toolbar the parent *is* the TabContainer. `tab.Container` is a net deletion: `onFocusEnter`, `onFocusMove`, `onFocusLeave` and `isBodyFocusPath` all go.

Evidence: L3 (the NL whitebox e2e runs the real browser journey and asserts computed `visibility`) → L3 required. No residuals.

## AC Evidence

| AC | Proof |
|---|---|
| AC-1 | `showOnFocus: true` is exposed while the subject holds focus — `HeaderActions.spec.mjs` › "TabContainer focus exposes showOnFocus actions and holds them across internal moves" |
| AC-2 | the gate observes the reactive config, not focus handlers — `toolbar/Base.mjs` `wireFocusSubject()` calls `observeConfig(subject, 'containsFocus', …)`; `tab/Container.mjs` has no focus handler left (AC-7 asserts the absence) |
| AC-3 | alias + opt-out precedence — `HeaderActions.spec.mjs` › "an explicit gate outranks actionDefaults in either spelling" and › "an opt-out survives a subclass whose actionDefaults still use the deprecated spelling" |
| AC-4 | works with no TabContainer — `HeaderActions.spec.mjs` › "a plain toolbar arms on its own parent, with no TabContainer involved" |
| AC-5 | reaching for the action keeps it exposed — same arm as AC-1, whose `focusMove` step fails when the subject is the body (mutation control below) |
| AC-6 | focusing a tab button exposes the actions — `HeaderActions.spec.mjs` › "focusing a tab button exposes the actions — the subject is the container, not the body" |
| AC-7 | `grep -n "onFocusEnter\|onFocusMove\|onFocusLeave\|isBodyFocusPath" src/tab/Container.mjs` returns nothing; the file is a net deletion in the diffstat |

## Deltas from ticket

- **The e2e needed a correction, and finding out why is the substantive part.** `TabHeaderActionsNL.spec.mjs` clicked an outside field *while the Overflow menu was open* and asserted the actions hid. That click is absorbed by the menu's own dismissal and focus **reverts to the floating Overflow control** — which this toolbar logically owns — so focus never left the container. The step asserted a transition that does not happen. It passed before only because the old body-armed gate never re-armed once focus had left the body. Pressing Escape first makes the exit real, and the step now also asserts the field actually took focus so it cannot pass again on a non-transition.
- One consequential behaviour change, deliberate: entering through a *persistent* header action now also exposes the gated ones, because that is focus inside the container. The old spec asserted the opposite; it is updated with the reason.

## Test Evidence

**The e2e caught a real regression that the whole unit suite missed** — 2084 unit tests green while the browser journey failed. That is the case for this kind of coverage, not a hypothetical.

**Mutation controls**, each applied, run, reverted:

| mutation | result |
|---|---|
| point the subject at the body (the sibling) instead of the parent | **1 failed** — the `focusMove` step of the AC-1/AC-5 arm: the action vanishes as the pointer reaches it |
| keep the deprecated alias instead of dropping it after resolution | **1 failed** — the AC-3 legacy-`actionDefaults` arm |

An earlier version of the alias mutation reddened **nothing**, which exposed that I had written the rule twice — a guard in `isFocusGatedAction` plus the alias drop, either one sufficient. The guard is gone; one mechanism now carries it and is covered.

**Baseline**, same machine: `dev` @ `c385f35966` 2080 passed / 0 failed → this branch 2084 passed / 0 failed. +4 is exactly the arms added, zero new failures. Components suite 95 passed. A single failure seen in one `dev` run did not reproduce on a re-run of the same commit — flake, falsified by repetition.

**Outside CI:** the NL e2e is Brain-gated behind `NEO_AGENTOS_RUNTIME_ROOT` and runs in no workflow, so its green here is local:

```bash
NEO_AGENTOS_RUNTIME_ROOT=/path/to/neo-agent-brain npm run test-e2e -- TabHeaderActionsNL
```

## Post-Merge Validation

None owed. Worth knowing rather than tracking: an action that set `contextual: true` on a toolbar OUTSIDE a TabContainer was previously hidden forever, because nothing drove its gate. It now correctly follows its parent's focus. No such caller exists in this repo — `contextual` appears only in `code/LivePreview.mjs` and `dashboard/dock/projection/LayoutAdapter.mjs`, both passing `false`.

## Commits

- `feat(toolbar): gate actions on showOnFocus via the reactive containsFocus (#17874)`

Authored by Grace (Claude Opus 5, Claude Code) 🖖
