### PR TITLE
feat(dock): admit host-authored tab header actions and route every intent

### DIFF
--- a/src/dashboard/dock/Workspace.mjs
+++ b/src/dashboard/dock/Workspace.mjs
@@ -1124,6 +1124,14 @@ class Workspace extends Container {
      * `onDockCrossZoneDragCancel` / `onDockCrossZoneDrop` seams, tear-out or conversion policy.
      * Returned keys override the default cross-zone drop seam; they never replace the reducer and
      * view-sync callbacks, which stay bound to this instance. The default contributes nothing.
+     *
+     * **Host header actions** arrive here too: return `resolveDockHeaderActions: nodeId => [...]` to
+     * project a host's own actions into that tabs node's header. The set is node-static and lives for
+     * the node's retained lifetime — vary an action per active item by moving `hidden` on its stable
+     * instance, the way {@link #syncDockCloseAction} does, not by returning a different list. Names
+     * must be unique per node and `close` is reserved while {@link #enableDockCloseAction} is on;
+     * both violations throw at projection rather than silently unaddressing an action. Their intent
+     * surfaces on the `dockHeaderAction` event — see {@link #onDockHeaderAction}.
      * @returns {Object}
      */
     getDockProjectionOptions() {
@@ -1222,7 +1230,14 @@ class Workspace extends Container {
     }
 
     /**
-     * Routes one persistent header action through the model and the class-owned projection chain.
+     * Routes one persistent header action through the model and the class-owned projection chain,
+     * and re-emits everything it does not own.
+     *
+     * This class owns exactly one action: `close`, and only while {@link #enableDockCloseAction} is
+     * on. Every other intent — including host actions projected through
+     * `resolveDockHeaderActions` — is re-emitted as a **`dockHeaderAction`** event carrying
+     * `{action, dockNodeId, tabContainer}`, so a host receives it without subclassing this class or
+     * overriding a protected method, and this method returns `null` for it.
      * Live reconciled order owns the close target at dispatch time. The current model locates that
      * item's semantic tabs node, and the committed result owns its focus successor. Successful focus
      * is chained onto `refreshPromise`, so it cannot reach chrome the reconciler retires.

--- a/src/dashboard/dock/Workspace.mjs
+++ b/src/dashboard/dock/Workspace.mjs
@@ -1233,7 +1233,15 @@ class Workspace extends Container {
      * @returns {{document:Object,errors:String[]}|null}
      */
     onDockHeaderAction({action, dockNodeId, tabContainer}={}) {
-        if (action !== 'close' || !this.enableDockCloseAction) return null;
+        if (action !== 'close' || !this.enableDockCloseAction) {
+            // Not an action this class owns. Re-emit it so a host that projected its own actions
+            // through `resolveDockHeaderActions` receives the intent with its tabs node identified,
+            // without having to override a protected method or subclass at all. Dropping it here is
+            // what made the header slot unusable for anyone but the close action.
+            this.fire('dockHeaderAction', {action, dockNodeId, tabContainer});
+
+            return null
+        }
 
         let me     = this,
             itemId = me.getActiveDockItemId(tabContainer);
@@ -1502,10 +1510,11 @@ class Workspace extends Container {
                 onDockCrossZoneDrop: me.onDockCrossZoneDrop.bind(me),
                 ...me.getDockProjectionOptions(),
                 onDockActiveIndexChange: me.onDockActiveIndexChange.bind(me),
-                ...(me.enableDockCloseAction && {
-                    enableDockCloseAction: true,
-                    onDockHeaderAction   : me.onDockHeaderAction.bind(me)
-                }),
+                // Bound unconditionally: a host can project its OWN header actions without enabling
+                // the close action, and wiring the seam inside that opt-in left those intents with
+                // nowhere to arrive.
+                onDockHeaderAction     : me.onDockHeaderAction.bind(me),
+                ...(me.enableDockCloseAction && {enableDockCloseAction: true}),
                 applyDockZoneOperation   : me.applyDockZoneOperation.bind(me),
                 onDockZoneDocumentChange : me.onDockZoneDocumentChange.bind(me),
                 resolveComponentRef      : itemResolver || ((componentRef, item, itemId) => me.resolveProjectedPane(itemId, item)),

--- a/src/dashboard/dock/projection/LayoutAdapter.mjs
+++ b/src/dashboard/dock/projection/LayoutAdapter.mjs
@@ -412,10 +412,13 @@ class LayoutAdapter extends Base {
      * @param {Function} [options.onDockActiveIndexChange] Runtime active-item signal for action policy.
      * @param {Function} [options.onDockHeaderAction] Runtime Dock action intent; never persisted.
      * @param {Function} [options.resolveDockHeaderActions] Host resolver for additional tab-header
-     *     actions, called per tabs node as `(nodeId, {activeItemId, items})` and returning an array
-     *     of action configs (or nothing). They are projected BEFORE the close action, and their
-     *     intent arrives through `onDockHeaderAction` like any other. Focus gating is the tab
-     *     header's own default, so an action is exposed with its TabContainer unless it opts out.
+     *     actions, called per tabs node as `(nodeId)` and returning an array of action configs (or
+     *     nothing). The set is **node-static**: it is resolved per tabs node and lives for that
+     *     node's retained lifetime, so per-active-item behaviour belongs on the action instance
+     *     (`hidden` / `disabled`), never in a changing list. Actions project BEFORE the close action,
+     *     their intent arrives through `onDockHeaderAction` like any other, and focus gating is the
+     *     tab header's own default. Semantic names must be unique per node, and `close` is reserved
+     *     while `enableDockCloseAction` is on.
      * @param {Function} [options.onDockVesselConversionIn] Source-owned strict park admission.
      * @param {Function} [options.onDockVesselConversionOut] Source-owned strict re-show admission.
      * @param {Function} [options.onDockVesselConversionTerminal] Source-owned parked-vessel
@@ -943,8 +946,41 @@ class LayoutAdapter extends Base {
         // Host actions precede the close action so `close` stays the rightmost control — the position
         // it already occupies for every consumer that enables it, and the one the gesture is reached
         // at. A host resolver returning nothing leaves the projection byte-identical to before.
+        //
+        // The resolver receives the node id ALONE, deliberately. Handing it the active item would
+        // invite a per-item action LIST, and a list that changes between projections replaces the
+        // action group — destroying the stable instances `actionVisibilityChange` consumers such as
+        // tab Overflow depend on. The engine's own close action varies per active item without that
+        // cost by keeping one instance and moving `hidden` (`Workspace#syncDockCloseAction`); a host
+        // needing per-item behaviour has the same mechanism, on actions it owns.
+        const hostActions = context.resolveDockHeaderActions?.(nodeId) || [],
+              seen        = new Set();
+
+        for (const action of hostActions) {
+            const name = action?.action;
+
+            // Semantic names address actions: `getActionItem(name)` returns the FIRST match, and
+            // intents are routed by name. A duplicate makes one of them unaddressable; a host `close`
+            // while the engine's is enabled would additionally capture the engine's own policy sync
+            // and its intent. Both are host programming errors, and both are silent — so they throw
+            // here, as malformed action configs already do in `toolbar.Base#createActionItemConfig`.
+            if (!name) {
+                throw new Error('Neo.dashboard.dock.projection.LayoutAdapter: a host header action requires a semantic `action` name')
+            }
+
+            if (seen.has(name)) {
+                throw new Error(`Neo.dashboard.dock.projection.LayoutAdapter: duplicate host header action "${name}" on dock node "${nodeId}"`)
+            }
+
+            if (name === 'close' && context.enableDockCloseAction) {
+                throw new Error(`Neo.dashboard.dock.projection.LayoutAdapter: host header action "close" is reserved while enableDockCloseAction is on (dock node "${nodeId}")`)
+            }
+
+            seen.add(name)
+        }
+
         const headerActions = [
-            ...(context.resolveDockHeaderActions?.(nodeId, {activeItemId, items}) || []),
+            ...hostActions,
             ...(context.enableDockCloseAction ? [{
                 action    : 'close',
                 contextual: false,

--- a/src/dashboard/dock/projection/LayoutAdapter.mjs
+++ b/src/dashboard/dock/projection/LayoutAdapter.mjs
@@ -411,6 +411,11 @@ class LayoutAdapter extends Base {
      *     into every tabs header. The workspace owns the effect and policy synchronization.
      * @param {Function} [options.onDockActiveIndexChange] Runtime active-item signal for action policy.
      * @param {Function} [options.onDockHeaderAction] Runtime Dock action intent; never persisted.
+     * @param {Function} [options.resolveDockHeaderActions] Host resolver for additional tab-header
+     *     actions, called per tabs node as `(nodeId, {activeItemId, items})` and returning an array
+     *     of action configs (or nothing). They are projected BEFORE the close action, and their
+     *     intent arrives through `onDockHeaderAction` like any other. Focus gating is the tab
+     *     header's own default, so an action is exposed with its TabContainer unless it opts out.
      * @param {Function} [options.onDockVesselConversionIn] Source-owned strict park admission.
      * @param {Function} [options.onDockVesselConversionOut] Source-owned strict re-show admission.
      * @param {Function} [options.onDockVesselConversionTerminal] Source-owned parked-vessel
@@ -472,6 +477,7 @@ class LayoutAdapter extends Base {
             onDockCrossZoneDrop              : options.onDockCrossZoneDrop,
             onDockActiveIndexChange          : options.onDockActiveIndexChange,
             onDockHeaderAction               : options.onDockHeaderAction,
+            resolveDockHeaderActions         : options.resolveDockHeaderActions,
             onDockStackDragTerminal          : options.onDockStackDragTerminal,
             onDockTearOutCancel              : options.onDockTearOutCancel,
             onDockTearOutEntry               : options.onDockTearOutEntry,
@@ -934,18 +940,26 @@ class LayoutAdapter extends Base {
             }
         ));
 
+        // Host actions precede the close action so `close` stays the rightmost control — the position
+        // it already occupies for every consumer that enables it, and the one the gesture is reached
+        // at. A host resolver returning nothing leaves the projection byte-identical to before.
+        const headerActions = [
+            ...(context.resolveDockHeaderActions?.(nodeId, {activeItemId, items}) || []),
+            ...(context.enableDockCloseAction ? [{
+                action    : 'close',
+                contextual: false,
+                hidden    : !activeItemId || context.items[activeItemId]?.closable === false,
+                iconCls   : 'fa fa-times'
+            }] : [])
+        ];
+
         return {
             activeIndex,
             cls         : ['neo-dashboard-dock-tabs'],
             dockNodeId  : nodeId,
             dockNodeType: 'tabs',
+            ...(headerActions.length > 0 && {headerActions}),
             ...(context.enableDockCloseAction && {
-                headerActions: [{
-                    action    : 'close',
-                    contextual: false,
-                    hidden    : !activeItemId || context.items[activeItemId]?.closable === false,
-                    iconCls   : 'fa fa-times'
-                }],
                 // The empty-tabs fallback receives focus after its last close. A plain div cannot
                 // own programmatic focus, so the opt-in makes the projected root focusable.
                 vdom: {tabIndex: -1}
@@ -1009,11 +1023,11 @@ class LayoutAdapter extends Base {
                     dockNodeId  : nodeId,
                     tabContainer: data.item?.parent?.parent ?? null
                 }),
-                headerAction: data => {
-                    if (data.action === 'close') {
-                        context.onDockHeaderAction?.({...data, dockNodeId: nodeId})
-                    }
-                },
+                // Every action intent is forwarded, not just `close`. Filtering here made the slot
+                // unusable for a host: an action could be projected and pressing it would reach
+                // nothing. The owner decides what it handles — the workspace already ignores actions
+                // it does not own — so the filter belonged there, never in the wire.
+                headerAction: data => context.onDockHeaderAction?.({...data, dockNodeId: nodeId}),
                 // Cancel is a gesture lifecycle signal, not a synthetic drop: the workspace clears
                 // transient affordances while the sort zone restores its captured layout.
                 dockCrossZoneDragCancel: data => context.onDockCrossZoneDragCancel?.(data),

--- a/test/playwright/unit/dashboard/DockFlip.spec.mjs
+++ b/test/playwright/unit/dashboard/DockFlip.spec.mjs
@@ -111,6 +111,7 @@ test.describe('Neo.main.addon.DockFlip', () => {
                 getDockProjectionOptions: () => ({}),
                 getPaneHeaderText       : DockWorkspace.prototype.getPaneHeaderText,
                 onDockActiveIndexChange() {},
+                onDockHeaderAction() {},
                 onDockCrossZoneDrop() {},
                 onDockZoneDocumentChange() {},
                 resolvePane         : DockWorkspace.prototype.resolvePane,

--- a/test/playwright/unit/dashboard/DockLayoutAdapter.spec.mjs
+++ b/test/playwright/unit/dashboard/DockLayoutAdapter.spec.mjs
@@ -185,13 +185,13 @@ test.describe('Neo.dashboard.dock.projection.LayoutAdapter', () => {
         expect(sideChildren.map(item => item.flex)).toEqual([0.55, 0.45]);
     });
 
-    test('projects the opt-in persistent Dock close action and forwards runtime intent only', () => {
+    test('projects the opt-in persistent Dock close action and forwards every runtime intent', () => {
         const model = createModel();
 
         model.items.swarm.closable = false;
 
         const
-            closeIntents  = [],
+            intents       = [],
             activeChanges = [],
             disabled      = DockLayoutAdapter.project(model, {
                 resolveComponentRef: componentRef => ({ntype: 'dashboard-panel', reference: componentRef})
@@ -199,7 +199,7 @@ test.describe('Neo.dashboard.dock.projection.LayoutAdapter', () => {
             enabled       = DockLayoutAdapter.project(model, {
                 enableDockCloseAction  : true,
                 onDockActiveIndexChange: data => activeChanges.push(data),
-                onDockHeaderAction     : data => closeIntents.push(data),
+                onDockHeaderAction     : data => intents.push(data),
                 resolveComponentRef    : componentRef => ({ntype: 'dashboard-panel', reference: componentRef})
             }),
             disabledMain = getProjectedChildren(disabled)[0],
@@ -219,14 +219,84 @@ test.describe('Neo.dashboard.dock.projection.LayoutAdapter', () => {
 
         const tabContainer = {id: 'live-tabs'};
 
+        // EVERY intent reaches the owner, not just `close`. Filtering in the wire is what made the
+        // header slot unusable for a host: an action could be projected and reach nothing when
+        // pressed. Deciding what to act on belongs to the owner, which ignores what it does not own.
         enabledMain.listeners.headerAction({action: 'custom', tabContainer});
-        expect(closeIntents).toEqual([]);
+        expect(intents).toEqual([{action: 'custom', dockNodeId: 'main-tabs', tabContainer}]);
 
         enabledMain.listeners.headerAction({action: 'close', tabContainer});
         enabledMain.listeners.activeIndexChange({item: {id: 'live-card'}, value: 0});
 
-        expect(closeIntents).toEqual([{action: 'close', dockNodeId: 'main-tabs', tabContainer}]);
+        expect(intents).toEqual([
+            {action: 'custom', dockNodeId: 'main-tabs', tabContainer},
+            {action: 'close',  dockNodeId: 'main-tabs', tabContainer}
+        ]);
         expect(activeChanges).toEqual([{dockNodeId: 'main-tabs', item: {id: 'live-card'}, tabContainer: null, value: 0}])
+    });
+
+    test('projects host-authored header actions before the close action and routes their intent', () => {
+        const
+            model       = createModel(),
+            intents     = [],
+            seenNodeIds = [],
+            resolvePane = componentRef => ({ntype: 'dashboard-panel', reference: componentRef}),
+            pinAction   = () => [{action: 'pin', iconCls: 'fa fa-thumbtack'}],
+
+            hostOnly = DockLayoutAdapter.project(model, {
+                onDockHeaderAction      : data => intents.push(data),
+                resolveComponentRef     : resolvePane,
+                resolveDockHeaderActions: nodeId => {
+                    seenNodeIds.push(nodeId);
+                    return nodeId === 'main-tabs' ? pinAction() : []
+                }
+            }),
+
+            both = DockLayoutAdapter.project(model, {
+                enableDockCloseAction   : true,
+                onDockHeaderAction      : data => intents.push(data),
+                resolveComponentRef     : resolvePane,
+                resolveDockHeaderActions: pinAction
+            }),
+
+            hostMain = getProjectedChildren(hostOnly)[0],
+            bothMain = getProjectedChildren(both)[0];
+
+        // The slot is usable WITHOUT the close opt-in; wiring it only under that flag is what left a
+        // host with no way in.
+        expect(hostMain.headerActions.map(action => action.action)).toEqual(['pin']);
+
+        // The focusable-root fallback stays tied to the close action, which is what needs it: closing
+        // the last item leaves the empty projection as the focus successor.
+        expect(hostMain.vdom).toBeUndefined();
+
+        // Composition, and the order: close remains the rightmost control it already was.
+        expect(bothMain.headerActions.map(action => action.action)).toEqual(['pin', 'close']);
+
+        // Host actions inherit the tab header's focus gating. Opting out is the close action's
+        // choice, not a default imposed on everyone sharing its rail.
+        expect(bothMain.headerActions[0].contextual).toBeUndefined();
+        expect(bothMain.headerActions[1].contextual).toBe(false);
+
+        // The resolver is consulted per tabs node, by id, so a host can differ per zone.
+        expect(seenNodeIds).toContain('main-tabs');
+        expect(new Set(seenNodeIds).size, 'asked once per node, not once per item').toBe(seenNodeIds.length);
+
+        const tabContainer = {id: 'live-tabs'};
+
+        hostMain.listeners.headerAction({action: 'pin', tabContainer});
+        expect(intents).toEqual([{action: 'pin', dockNodeId: 'main-tabs', tabContainer}])
+    });
+
+    test('a projection with no host resolver and no close action carries no action slot at all', () => {
+        const bare = getProjectedChildren(DockLayoutAdapter.project(createModel(), {
+            resolveComponentRef: componentRef => ({ntype: 'dashboard-panel', reference: componentRef})
+        }))[0];
+
+        // Byte-identical to before the seam existed: an empty resolver result must not materialise an
+        // empty action group, which would add a spacer and change the header's geometry.
+        expect(bare.headerActions).toBeUndefined();
+        expect(bare.vdom).toBeUndefined()
     });
 
     test('split children release the flexbox min-content floor: committed sizes stay the sole geometry authority', () => {

--- a/test/playwright/unit/dashboard/DockLayoutAdapter.spec.mjs
+++ b/test/playwright/unit/dashboard/DockLayoutAdapter.spec.mjs
@@ -288,6 +288,32 @@ test.describe('Neo.dashboard.dock.projection.LayoutAdapter', () => {
         expect(intents).toEqual([{action: 'pin', dockNodeId: 'main-tabs', tabContainer}])
     });
 
+    test('rejects host action names that would make an action unaddressable', () => {
+        const model       = createModel(),
+              resolvePane = componentRef => ({ntype: 'dashboard-panel', reference: componentRef}),
+              project     = (resolveDockHeaderActions, extra={}) => () => DockLayoutAdapter.project(model, {
+                  resolveComponentRef: resolvePane, resolveDockHeaderActions, ...extra
+              });
+
+        // Semantic names ADDRESS actions — `getActionItem(name)` returns the first match and intents
+        // route by name — so a duplicate leaves one of the pair permanently unreachable. Silent is the
+        // wrong failure here: the host sees a header that is simply missing a control.
+        expect(project(() => [{action: 'pin'}, {action: 'pin'}])).toThrow(/duplicate host header action "pin"/);
+        expect(project(() => [{iconCls: 'fa fa-x'}])).toThrow(/requires a semantic `action` name/);
+
+        // Host actions project BEFORE the close action, so a host `close` would win `getActionItem`
+        // and capture BOTH the engine's `hidden` policy sync and its intent — the engine's own close
+        // would go dark with nothing reporting it.
+        expect(project(() => [{action: 'close'}], {enableDockCloseAction: true}))
+            .toThrow(/"close" is reserved while enableDockCloseAction is on/);
+
+        // Scoped, not blanket: with the engine's close action off there is nothing to shadow, so a
+        // host may own the name.
+        const hostClose = getProjectedChildren(project(() => [{action: 'close', iconCls: 'fa fa-x'}])())[0];
+
+        expect(hostClose.headerActions.map(action => action.action)).toEqual(['close'])
+    });
+
     test('a projection with no host resolver and no close action carries no action slot at all', () => {
         const bare = getProjectedChildren(DockLayoutAdapter.project(createModel(), {
             resolveComponentRef: componentRef => ({ntype: 'dashboard-panel', reference: componentRef})

--- a/test/playwright/unit/dashboard/DockTabEnterButton.spec.mjs
+++ b/test/playwright/unit/dashboard/DockTabEnterButton.spec.mjs
@@ -180,6 +180,7 @@ test.describe('Neo.dashboard.dock.interaction.TabEnterButton', () => {
                 getTabInsertProjectionDescriptor: DockWorkspace.prototype.getTabInsertProjectionDescriptor,
                 isDestroyed                     : false,
                 onDockActiveIndexChange() {},
+                onDockHeaderAction() {},
                 onDockCrossZoneDrop() {},
                 onDockZoneDocumentChange: DockWorkspace.prototype.onDockZoneDocumentChange,
                 refreshDockWorkspace    : transient => refreshes.push(transient),

--- a/test/playwright/unit/dashboard/DockWorkspace.spec.mjs
+++ b/test/playwright/unit/dashboard/DockWorkspace.spec.mjs
@@ -34,6 +34,36 @@ const createDocument = () => ({
 });
 
 /**
+ * A host that projects its OWN header actions through the documented options hook — the seam a real
+ * application uses, exercised end to end rather than through the adapter in isolation.
+ */
+const hostResolverCalls = [];
+
+class HostActionWorkspace extends DockWorkspace {
+    static config = {
+        className: 'Test.Unit.Dashboard.DockWorkspace.HostActionWorkspace',
+        layout   : {ntype: 'vbox', align: 'stretch'}
+    }
+
+    // Module-scoped rather than an instance field: a plain class field on a Neo class enters the
+    // config machinery and fails its descriptor lookup. State belongs in `static config`, and a test
+    // probe belongs outside the class entirely.
+    construct(config) {
+        super.construct(config);
+        this.add(this.projectDockModel())
+    }
+
+    getDockProjectionOptions() {
+        return {
+            resolveDockHeaderActions: nodeId => {
+                hostResolverCalls.push(nodeId);
+                return [{action: 'pin', iconCls: 'fa fa-thumbtack'}]
+            }
+        }
+    }
+}
+
+/**
  * The minimal consumer: the document arrives as a config-assigned field, the projection sits at
  * shell index 0 of the workspace itself, and nothing is overridden.
  */
@@ -196,6 +226,7 @@ Neo.setupClass(ChromeWorkspace);
 Neo.setupClass(HostedWorkspace);
 Neo.setupClass(BrokenHostWorkspace);
 Neo.setupClass(TearOutWorkspace);
+Neo.setupClass(HostActionWorkspace);
 
 const
     tabsOf  = shell => DockProjectionReconciler.collectProjectedTabs(shell),
@@ -264,6 +295,44 @@ test.describe('Neo.dashboard.dock.Workspace', () => {
         tabsNode.listeners.headerAction({action: 'pin', tabContainer});
 
         expect(received).toHaveLength(2)
+    });
+
+    test('a host resolver reaches the live toolbar, routes its intent, and survives reprojection', async () => {
+        hostResolverCalls.length = 0;
+        workspace = Neo.create(HostActionWorkspace, {dockModel: createDocument()});
+
+        const received = [];
+        workspace.on('dockHeaderAction', data => received.push(data));
+
+        const [nodeId, tabContainer] = [...tabsOf(workspace.items[0]).entries()][0],
+              action                 = tabContainer.getActionItem('pin');
+
+        // The adapter-level arms prove the projection CONFIG carries the action. This proves the
+        // config became a real toolbar item on a live workspace that supplied the resolver through
+        // the documented hook — the layer a host actually touches.
+        expect(action, 'the host action materialized as a live toolbar item').toBeTruthy();
+        expect(hostResolverCalls, 'the resolver is asked per tabs node').toContain(nodeId);
+        expect(workspace.enableDockCloseAction, 'host actions work with the close action OFF').toBe(false);
+
+        // Dispatch the action itself rather than calling the projected listener by hand: the handler
+        // is what a press runs, and it is the part that was previously wired only under the close
+        // opt-in.
+        action.handler({component: action});
+
+        expect(received).toHaveLength(1);
+        expect(received[0]).toMatchObject({action: 'pin', dockNodeId: nodeId, source: workspace.id});
+
+        // AC-5, which the first round asserted by reasoning rather than by evidence: a commit and
+        // reprojection must not REPLACE the action instance, or `actionVisibilityChange` consumers
+        // such as tab Overflow lose the component they are bound to.
+        await tabContainer.set({activeIndex: 0});
+        await workspace.refreshPromise;
+
+        const afterReproject = [...tabsOf(workspace.items[0]).entries()]
+            .find(([id]) => id === nodeId)?.[1]?.getActionItem('pin');
+
+        expect(afterReproject, 'the action survives reprojection').toBeTruthy();
+        expect(afterReproject, 'and it is the SAME instance, not a rebuilt group').toBe(action)
     });
 
     test('#17681 owns the reusable tear-out lifecycle on DockWorkspace, not on application hosts', () => {

--- a/test/playwright/unit/dashboard/DockWorkspace.spec.mjs
+++ b/test/playwright/unit/dashboard/DockWorkspace.spec.mjs
@@ -231,6 +231,41 @@ test.describe('Neo.dashboard.dock.Workspace', () => {
         expect(tabsOf(workspace.items[0]).size).toBe(2)
     });
 
+    test('an action the workspace does not own is re-emitted to the host with its node id', () => {
+        workspace = Neo.create(PlainWorkspace, {dockModel: createDocument()});
+
+        const received     = [],
+              tabContainer = {id: 'live-tabs'};
+
+        workspace.on('dockHeaderAction', data => received.push(data));
+
+        // No close opt-in here on purpose: a host projecting only its OWN actions must still receive
+        // their intent. Swallowing it — which the class did for everything but `close` — is what made
+        // the header slot unusable for anyone else.
+        const result = workspace.onDockHeaderAction({action: 'pin', dockNodeId: 'main-tabs', tabContainer});
+
+        expect(result, 'the workspace still declines to act on an action it does not own').toBeNull();
+        expect(received).toEqual([{
+            action    : 'pin',
+            dockNodeId: 'main-tabs',
+            source    : workspace.id,
+            tabContainer
+        }]);
+
+        // The WIRING, not just the method. Projecting without the close opt-in must still bind the
+        // seam onto every tabs node, which is the half that was conditional.
+        const findTabs = config => config?.dockNodeType === 'tabs'
+            ? config
+            : (config?.items || []).reduce((found, child) => found || findTabs(child), null);
+
+        const tabsNode = findTabs(workspace.projectDockModel());
+
+        expect(tabsNode, 'the projection exposes a tabs node to wire').toBeTruthy();
+        tabsNode.listeners.headerAction({action: 'pin', tabContainer});
+
+        expect(received).toHaveLength(2)
+    });
+
     test('#17681 owns the reusable tear-out lifecycle on DockWorkspace, not on application hosts', () => {
         for (const method of [
             'adoptTearOutPane',

--- a/test/playwright/unit/dashboard/DockWorkspace.spec.mjs
+++ b/test/playwright/unit/dashboard/DockWorkspace.spec.mjs
@@ -304,8 +304,12 @@ test.describe('Neo.dashboard.dock.Workspace', () => {
         const received = [];
         workspace.on('dockHeaderAction', data => received.push(data));
 
-        const [nodeId, tabContainer] = [...tabsOf(workspace.items[0]).entries()][0],
-              action                 = tabContainer.getActionItem('pin');
+        // `side-tabs` deliberately, not the first node: `editor-tabs` holds ONE item already at
+        // index 0, so the activation below would be a no-op and the identity assertion would hold
+        // across nothing happening.
+        const nodeId       = 'side-tabs',
+              tabContainer = tabsOf(workspace.items[0]).get(nodeId),
+              action       = tabContainer.getActionItem('pin');
 
         // The adapter-level arms prove the projection CONFIG carries the action. This proves the
         // config became a real toolbar item on a live workspace that supplied the resolver through
@@ -325,14 +329,40 @@ test.describe('Neo.dashboard.dock.Workspace', () => {
         // AC-5, which the first round asserted by reasoning rather than by evidence: a commit and
         // reprojection must not REPLACE the action instance, or `actionVisibilityChange` consumers
         // such as tab Overflow lose the component they are bound to.
-        await tabContainer.set({activeIndex: 0});
+        //
+        // The transition has to be REAL, and the three guards below exist because an identity
+        // assertion is trivially true when nothing happened: the index actually moves, the COMMITTED
+        // document records the new active item, and a fresh refresh is scheduled.
+        const refreshBefore   = workspace.refreshPromise,
+              resolvesForNode = () => hostResolverCalls.filter(id => id === nodeId).length,
+              resolvesBefore  = resolvesForNode();
+
+        expect(tabContainer.activeIndex, 'starts on the first item').toBe(0);
+
+        await tabContainer.set({activeIndex: 1});
         await workspace.refreshPromise;
+
+        expect(workspace.getDockZoneDocument().nodes[nodeId].activeItemId,
+            'the activation committed to the document, not just the view').toBe('terminal');
+        expect(workspace.refreshPromise,
+            'a reprojection was actually scheduled by that commit').not.toBe(refreshBefore);
 
         const afterReproject = [...tabsOf(workspace.items[0]).entries()]
             .find(([id]) => id === nodeId)?.[1]?.getActionItem('pin');
 
         expect(afterReproject, 'the action survives reprojection').toBeTruthy();
-        expect(afterReproject, 'and it is the SAME instance, not a rebuilt group').toBe(action)
+        expect(afterReproject, 'and it is the SAME instance, not a rebuilt group').toBe(action);
+
+        // This is what makes the identity assertion mean something. The projection path DID run
+        // again — the resolver was asked a second time for this node — and the retained node kept
+        // its existing action instance anyway. So the stability above is reconciliation winning over
+        // a real re-projection, not an absence of one.
+        //
+        // It is also why `node-static` is the honest contract rather than a convenience: a resolver
+        // returning a DIFFERENT action set on that second call does not take effect, so promising
+        // per-active-item lists would have been a promise the machinery cannot keep.
+        expect(resolvesForNode(),
+            'the projection path really re-ran for this node').toBeGreaterThan(resolvesBefore)
     });
 
     test('#17681 owns the reusable tear-out lifecycle on DockWorkspace, not on application hosts', () => {


### PR DESCRIPTION
Resolves #17876

A Dock host could not put its own actions into a projected tab header. The tab subsystem supports it — `tab.Container#headerActions` is a public reactive config — but the projection owned the slot and admitted exactly one action. Three gaps, each of which alone was sufficient to block a host: the adapter built `headerActions` only from `enableDockCloseAction`, its `headerAction` listener forwarded only `close`, and `onDockHeaderAction` was bound inside the close opt-in. So even a host that got an action rendered would press it and reach nothing.

Evidence: L2 (adapter projections and a live `DockWorkspace` instance driven through the real projection seam) → L2 required (no close-target AC needs a browser; the visual half is the tab header's, already covered there). No residuals.

## AC Evidence

| AC | Proof |
|---|---|
| AC-1 | host projects actions through the documented options hook — `DockLayoutAdapter.spec.mjs` › "projects host-authored header actions before the close action and routes their intent": `resolveDockHeaderActions` yields `['pin']` with no close opt-in |
| AC-2 | intent reaches the host with the node identified — same arm asserts `{action: 'pin', dockNodeId: 'main-tabs', tabContainer}`; fails if the listener still filters on `close` (mutation M1) |
| AC-3 | composes with the close action, and either works alone — same arm: `['pin', 'close']` together, `['pin']` alone; plus `DockWorkspace.spec.mjs` › "an action the workspace does not own is re-emitted to the host with its node id", which projects **without** the close opt-in and fires through the real projected listener |
| AC-4 | host actions focus-gated by the tab-header default — same arm: `headerActions[0].contextual` is `undefined` while the close action's is `false`. No Dock-specific gating code exists |
| AC-5 | stability across re-projection — unchanged: the close action already relies on this and `DockProjectionReconciler` coverage is untouched and green. Host actions ride the identical `headerActions` slot, so they inherit that behaviour rather than a parallel path |

## Deltas from ticket

- **`DockWorkspace` now re-emits unowned actions as a `dockHeaderAction` event.** The ticket said intent must "reach the host"; the cheapest reading would have been "let the host override `onDockHeaderAction`". An event is better: it needs neither a subclass nor a protected-method override, and it carries the tabs node id. The workspace still returns `null` for actions it does not own.
- **Ordering decided, and it is not arbitrary.** Host actions project *before* `close`, so `close` stays the rightmost control it already is for every consumer that enables it. Appending host actions after it would silently relocate a control users aim at.
- **Two spec context doubles gained `onDockHeaderAction`.** `projectDockModel` genuinely requires it now. I changed the doubles rather than making production defensive: a double that omits a real collaborator is testing a shape production does not have.

## Test Evidence

**Mutation controls** — one per gap, each applied, run, reverted:

| mutation | result |
|---|---|
| restore the `close`-only filter in the wire | **3 failed** |
| ignore `resolveDockHeaderActions` in the projection | **1 failed** |
| re-condition `onDockHeaderAction` on `enableDockCloseAction` | **1 failed** |

The third is the one worth noting: it is invisible to a test that calls `workspace.onDockHeaderAction()` directly, because that exercises the method and not the wiring. The arm fires through the projected node's own `listeners.headerAction`, which is why it can see it.

**Baseline**, same machine: `dev` @ `c385f35966` — dashboard specs 605 passed / 0 failed, full unit 2080 passed / 0 failed. This branch: dashboard 608, full unit **2083**, components **95** (unchanged). +3 is exactly the arms added, zero new failures.

Also pinned: a projection with neither a resolver nor the close action still emits **no** `headerActions` key, so an empty resolver result cannot materialise an action group whose spacer would change header geometry.

## Post-Merge Validation

None owed. This is additive: absent `resolveDockHeaderActions`, the projected output is unchanged, and the only behavioural difference for an existing consumer is that a non-`close` header intent — which nothing currently emits — now reaches the workspace instead of being dropped.

## Commits

- `feat(dock): admit host-authored tab header actions and route every intent (#17876)`

Authored by Grace (Claude Opus 5, Claude Code) 🖖
