### PR TITLE
fix(build): the ticket guard discriminates by position, not digit width (#16553)

### DIFF
--- a/buildScripts/util/check-ticket-archaeology.mjs
+++ b/buildScripts/util/check-ticket-archaeology.mjs
@@ -13,17 +13,54 @@ const scriptRoot = path.resolve(__dirname, '../..');
 // file. Keep mirror-aligned with the `paths:` trigger of .github/workflows/ticket-archaeology-lint.yml so
 // every path that can trigger the gate is also scanned (else it passes vacuously). The guard lists ITSELF
 // here so it self-guards at the merge-gate, not only via the pre-commit lint-staged `*.mjs` glob.
-export const DEFAULT_SCAN_PATHS = ['ai', 'src', 'test/playwright', 'buildScripts/util/check-ticket-archaeology.mjs'];
+// `ai` is deliberately absent: the Agent OS tree moved to `neo-agent-brain` in the split, and `find`
+// aborts the whole audit on a missing root rather than skipping it — so carrying the dead root left
+// the default whole-repo mode failing closed on every invocation, silently, since the cut. Staged and
+// `--base` runs were unaffected, which is why nothing surfaced it.
+export const DEFAULT_SCAN_PATHS = ['src', 'test/playwright', 'buildScripts/util/check-ticket-archaeology.mjs'];
 export const DEFAULT_IGNORES    = ['.claude', '.codex', 'dist', 'node_modules'];
 
 // Inline relief valve for a genuinely load-bearing comment ref (judgment-call escape, not a blanket bypass).
 export const ESCAPE_MARKER = 'ticket-ref-ok';
 
-// Decay-prone tracking anchors that must not live in durable source comments. `#\d{4,}\b` targets
-// issue/PR numbers (Neo tickets are 5 digits) while a trailing word boundary avoids matching hex colors
-// like `#1234ff`; the named forms catch the prose variants.
+// A colour literal appears as a VALUE — assigned, quoted, backticked, or after a colon — while a
+// tracking ref appears as a bare word in prose. The old bound used LENGTH as a stand-in for that
+// distinction and the stand-in leaked: the comment reasoned from `#1234ff`, where letters stop
+// `\d{4,}` short of a word boundary, but an all-numeric colour has no letters to stop it, so
+// `#000000` was read as an issue reference on lines a change never touched.
+//
+// Only real colour LENGTHS are stripped (3/4/6/8 hex digits), so a 5-digit Engine ref stays visible
+// even when quoted. Position decides; length only says "this could be a colour at all".
+const VALUE_POSITION_COLOR = /(?:[=:]\s*|['"`])#(?:[0-9a-fA-F]{3,4}|[0-9a-fA-F]{6}|[0-9a-fA-F]{8})\b/g;
+
+/**
+ * @summary Blanks colour literals that sit in value position, so the ref patterns cannot read them.
+ * @param {String} comment
+ * @returns {String}
+ */
+export function stripValueColors(comment) {
+    return comment.replace(VALUE_POSITION_COLOR, ' ')
+}
+
+// Decay-prone tracking anchors that must not live in durable source comments.
+//
+// `#\d{4,}` stays for Engine refs: at four-plus digits a bare `#N` is unambiguous. Widening it to
+// `#\d+` to reach the sibling repositories (2–3 digits) was measured against the tree and rejected —
+// it took 9 findings to 27, and the new ones were almost all ORDINALS: `Refresh #2`, `Product truth
+// #1`, `To solve #3`. Those are English, not archaeology, and a guard that flags them trains authors
+// to reach for the escape marker.
+//
+// A short cross-repo ref is only decidable when it is QUALIFIED, which is the form that survives the
+// split anyway — a bare `#204` in an Engine comment cannot be told from an ordinal by any pattern,
+// and cannot be resolved to a repository by a reader either.
 export const TICKET_PATTERNS = [
     /#\d{4,}\b/,
+    // Matches a repo-qualified ref: `brain#<n>`, `neo-agent-brain#<n>`, `neomjs/neo-agent-skills#<n>`.
+    // Written with `<n>` rather than a digit on purpose — a literal example here would be flagged by
+    // this very pattern, and reaching for the escape marker to relieve it would assert a deliberate
+    // ticket reference where there is only an example — the same false statement the marker makes
+    // when it is used to silence a colour literal.
+    /\b(?:neomjs\/)?(?:neo-agent-)?(?:brain|institution|skills)#\d+\b/i,
     /\bEpic\s+#?\d+\b/i,
     /\bDiscussion\s+#?\d+\b/i,
     /\bADR[-\s]?\d{3,4}\b/i
@@ -125,7 +162,7 @@ export function findTicketRefs(content) {
             return
         }
 
-        if (TICKET_PATTERNS.some(re => re.test(comment))) {
+        if (TICKET_PATTERNS.some(re => re.test(stripValueColors(comment)))) {
             hits.push({line: index + 1, text: line.trim()})
         }
     });

--- a/src/component/Gallery.mjs
+++ b/src/component/Gallery.mjs
@@ -30,7 +30,7 @@ class Gallery extends Component {
         amountRows_: 3,
         /**
          * The background color of the gallery container
-         * @member {String} backgroundColor_='#000000' ticket-ref-ok: hex colour, not an issue ref
+         * @member {String} backgroundColor_='#000000'
          * @reactive
          */
         backgroundColor_: '#000000',

--- a/src/component/Helix.mjs
+++ b/src/component/Helix.mjs
@@ -26,7 +26,7 @@ class Helix extends Component {
         ntype: 'helix',
         /**
          * The background color of the helix container
-         * @member {String} backgroundColor_='#000000' ticket-ref-ok: hex colour, not an issue ref
+         * @member {String} backgroundColor_='#000000'
          * @reactive
          */
         backgroundColor_: '#000000',

--- a/test/playwright/unit/buildScripts/checkTicketArchaeology.spec.mjs
+++ b/test/playwright/unit/buildScripts/checkTicketArchaeology.spec.mjs
@@ -1,0 +1,105 @@
+import {test, expect}                     from '@playwright/test';
+import {findTicketRefs, stripValueColors} from '../../../../buildScripts/util/check-ticket-archaeology.mjs';
+
+/**
+ * The guard that gates every commit had no unit coverage, which is how its docblock came to claim a
+ * protection it did not provide: it reasoned from `#1234ff`, where letters stop `\d{4,}` short of a
+ * word boundary, and generalised that to hex colours. An all-numeric colour has no letters to stop it.
+ *
+ * The bound was doing two jobs — identifying a ticket ref, and dodging colours by LENGTH — and failed
+ * at both ends. It flagged `#000000` on lines a change never touched, and it could not see a ticket
+ * shorter than four digits, which is every sibling-repository ref. Position now decides, so the tests
+ * below pin both directions: the colours that must stay silent, and the refs that must be found.
+ */
+
+const comment = text => `// ${text}`;
+
+test.describe('check-ticket-archaeology: position decides, not digit width', () => {
+    test.describe('value-position colours stay silent', () => {
+        for (const [label, line] of [
+            ['assigned in a JSDoc member', ` * @member {String} backgroundColor_='#000000'`],
+            ['all-numeric six digit',      comment(`the default is '#111111' throughout`)],
+            ['all-numeric, after a colon', comment('color: #123456 in the legacy sheet')],
+            ['backticked',                 comment('the ground is `#332211` here')],
+            ['CSS shorthand, three digit', comment('color: #123 is the shorthand form')],
+            ['RGBA shorthand, four digit', comment('color: #1234 carries alpha')]
+        ]) {
+            test(label, () => {
+                expect(findTicketRefs(line), line).toEqual([])
+            })
+        }
+    });
+
+    test.describe('prose refs are found', () => {
+        for (const [label, text] of [
+            ['5-digit Engine ref',      'see #12209 for the rationale'],
+            ['5-digit in parentheses',  'the cut landed here (#16538)'],
+            ['qualified Brain ref',     'held for brain#204 while the tool was blocked'],
+            ['fully qualified ref',     'see neomjs/neo-agent-institution#63'],
+            ['qualified skills ref',    'the guard shipped in neo-agent-skills#18'],
+            ['prose Epic form',         'tracked under Epic #13158'],
+            ['prose Discussion form',   'settled in Discussion #10137']
+        ]) {
+            test(label, () => {
+                expect(findTicketRefs(comment(text))).toHaveLength(1)
+            })
+        }
+    });
+
+    /**
+     * Widening the bound to `#\d+` so it could reach 2–3 digit sibling refs was written, measured and
+     * reverted: across `src` + `test/playwright` it took the audit from 9 findings to 27, and the new
+     * ones were almost entirely ordinals. Those are English. A guard that flags them teaches authors
+     * to reach for the escape marker, which is how a guard stops being read.
+     */
+    test.describe('ordinals are English, not archaeology', () => {
+        for (const text of [
+            'Refresh #2 (the pin analogue): wholesale replacement again',
+            'Product truth #1: the committed item projects as a real rail button',
+            'To solve #3, this component acts as a physical proxy',
+            'writer-1 (the fixture ConnectionService, identity #1) holds the lock'
+        ]) {
+            test(text.slice(0, 44), () => {
+                expect(findTicketRefs(comment(text)), text).toEqual([])
+            })
+        }
+    });
+
+    test('a BARE short ref stays invisible — the documented limit, not an oversight', () => {
+        // `#204` and `#2` are indistinguishable in prose, and a bare short ref cannot be resolved to a
+        // repository by a reader either. Qualifying it is what makes it both checkable and readable.
+        expect(findTicketRefs(comment('blocked Brain MCP tool (#204)'))).toEqual([]);
+        expect(findTicketRefs(comment('blocked Brain MCP tool (brain#204)'))).toHaveLength(1)
+    });
+
+    test('the true positive the old bound DID catch still fires', () => {
+        // Control: if this ever goes silent the fix has traded one blind spot for another.
+        expect(findTicketRefs(comment('closes #16553'))).toHaveLength(1)
+    });
+
+    test('a 5-digit ref stays visible even quoted — only colour LENGTHS are stripped', () => {
+        // A five-digit ref is not a colour LENGTH (3/4/6/8), so value position cannot launder it.
+        expect(findTicketRefs(comment(`the marker was '#12209' back then`))).toHaveLength(1)
+    });
+
+    test('the escape marker still relieves a load-bearing ref', () => {
+        expect(findTicketRefs(comment('kept deliberately #12209 ticket-ref-ok: pins the contract'))).toEqual([])
+    });
+
+    test('code outside comments is not scanned', () => {
+        // The scan is comment-only; a ref in a string literal is not a durable comment.
+        expect(findTicketRefs(`const url = 'https://github.com/neomjs/neo/issues/12209';`)).toEqual([])
+    });
+
+    test.describe('stripValueColors is positional, not a colour detector', () => {
+        test('leaves a prose ref of colour length untouched', () => {
+            // `#123` is a valid shorthand, but in prose it is a ticket — stripping by shape alone
+            // would silently delete sibling-repository refs, which is the bug being fixed.
+            expect(stripValueColors('see #123 for that')).toContain('#123')
+        });
+
+        test('removes the same token in value position', () => {
+            expect(stripValueColors('color: #123')).not.toContain('#123')
+        })
+    })
+});


### PR DESCRIPTION
Resolves #16553

The guard that gates every commit read an all-numeric hex colour as an issue reference, and its docblock claimed the protection it did not provide. It reasoned from `#1234ff` — where letters stop `\d{4,}` short of a word boundary — and generalised that to hex colours. An all-numeric colour has no letters to stop it, so `#000000` matched and the boundary succeeded, failing commits on lines the change never touched. Position now decides: a colour appears as a **value**, a tracking ref appears as a **bare word in prose**.

Evidence: L2 (pure functions, whole-tree audit receipts, mutation) → L2 required (every AC is unit-coverable and the audit runs locally). No residuals.

## AC Evidence

| AC | Proof |
|---|---|
| AC-1 | CI-covered: `checkTicketArchaeology.spec.mjs` — `#000000`, `#111111`, `#123456` in value position yield no finding; disabling the strip reds 5 of 24 |
| AC-2 | CI-covered: same spec — 5-digit refs in prose and in parentheses still fire, plus a 5-digit ref inside quotes (not a colour **length**, so value position cannot launder it) |
| AC-3 | CI-covered: `#1234ff` was never matched and still is not; `#1234` in prose fires, in value position does not |
| AC-4 | The docblock now states the rule — position, with length only saying "this could be a colour at all" — instead of one example of it |
| AC-5 | Outside-CI, receipts below: `Gallery.mjs` commits with no marker. `app/content/Component.mjs` and `collection/Base.mjs` still report, on **genuine** 5-digit refs (`#12209`, `#11595`, `#11611`) — correct findings, not the hex class this ticket filed |
| AC-6 | Outside-CI, receipts below: the `Helix.mjs:29` stopgap is removed |

## Deltas from ticket

**The widening half was measured and reverted.** @neo-opus-vega found the same bound cannot see a sibling-repository ref (2–3 digits post-split) — the mirror defect, and I nearly filed it as a new ticket before the sweep found this one already open and assigned to me. Widening to `#\d+` took the audit from **9 findings to 27**, and the new ones were almost entirely ordinals: `Refresh #2`, `Product truth #1`, `To solve #3`. Those are English. A guard that flags them teaches authors to reach for the escape marker, which is how a guard stops being read.

So short cross-repo refs are caught only when **qualified** (`brain#<n>`, `neomjs/neo-agent-institution#<n>`) — the form that survives the split anyway. A bare `#204` in an Engine comment cannot be told from an ordinal by any pattern, and cannot be resolved to a repository by a reader either. **That limit is pinned by a test rather than left implied.**

**Second post-split defect, same file, folded in:** `DEFAULT_SCAN_PATHS` still listed `ai`, which moved to `neo-agent-brain`. `find` aborts the whole audit on a missing root rather than skipping it, so the default whole-repo mode had been failing closed on **every** invocation since the cut — silently, because staged and `--base` runs were unaffected. It is also what this PR's own blast-radius measurement needed, so leaving it would have meant reporting a number I could not produce.

**The guard had no unit coverage at all**, which is how a docblock claiming a protection it did not provide survived. The first spec lands here.

## Test Evidence

```
# AC-5 / AC-6 — the stopgap markers were load-bearing only because of the bug.
# Markers removed from Helix.mjs:29 and Gallery.mjs:33, then both guards run:

  previous guard : 2 findings, EXIT 1   ← both `#000000` lines
  this guard     : 0 findings, EXIT 0

# Whole-tree audit, src + test/playwright (862 files):
  before : 9 findings
  after  : 7 findings
  delta  : only the two backticked colour literals in this change's own comments

# Mutation — the fix is witnessed, not assumed:
  disable stripValueColors -> 19 passed / 5 failed  (24 green when restored)
```

## Post-Merge Validation

- [ ] Confirm the default audit mode runs on a fresh clone (it has been dead since the split, so nobody has exercised it)

## Commits

- `b2553f964d` — positional discriminator, qualified cross-repo pattern, dead scan root, first spec
- `4789d78fcd` — remove the two stopgap markers the fix retires

Authored by ⚖️ Ada (Claude Opus 5, Claude Code). Session 0af56b9a-7beb-47dd-b927-df3c1f567903. The sibling-ref measurement is @neo-opus-vega's, from a Brain PR hold.
