### PR TITLE
fix(worker): root the Data Worker's lazy imports at explicit bases

### DIFF
--- a/.github/workflows/consumer-worker-build.yml
+++ b/.github/workflows/consumer-worker-build.yml
@@ -1,0 +1,52 @@
+name: Consumer Worker Build
+
+# The only check that builds this package from OUTSIDE itself.
+#
+# Every other build check runs where the repository IS the workspace, which is precisely the case in
+# which the worker configs' consumer rebasing is never exercised. Four defects of that shape landed
+# within one day (#17881, #17868, and the two the #17882 review found), each invisible to a green
+# suite here. A guard that reasons about relative paths would have missed the one that mattered — the
+# optional-root failure was found by a physical build a minute after a simulated one reported every
+# root correct — so this packs, installs and compiles for real.
+#
+# PR-only, and path-filtered to the two layers that own the contract plus the guard's own sources:
+# `Data.mjs` decides which roots exist, the worker configs decide where those roots live once the
+# framework is a dependency, and changing either without the other is the defect.
+
+on:
+  pull_request:
+    branches: [dev]
+    paths:
+      - 'src/worker/Data.mjs'
+      - 'buildScripts/webpack/workerContextRebasePlugin.mjs'
+      - 'buildScripts/webpack/development/webpack.config.worker.mjs'
+      - 'buildScripts/webpack/production/webpack.config.worker.mjs'
+      - 'buildScripts/util/check-consumer-worker-build.mjs'
+      - '.github/workflows/consumer-worker-build.yml'
+      - '.npmignore'
+      - 'package.json'
+
+concurrency:
+  group: consumer-worker-build-${{ github.run_attempt == '1' && github.ref || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  guard:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '24'
+          cache: 'npm'
+
+      # The guard resolves webpack from the FIXTURE, not from here, so the framework's own install is
+      # needed only for `npm pack` to run against a complete tree.
+      - name: Install dependencies
+        run: npm ci --ignore-scripts
+
+      - name: Build a Data worker from an installed copy, under an `apps/` ancestor
+        run: node buildScripts/util/check-consumer-worker-build.mjs

--- a/buildScripts/util/check-consumer-worker-build.mjs
+++ b/buildScripts/util/check-consumer-worker-build.mjs
@@ -1,0 +1,212 @@
+#!/usr/bin/env node
+import {execFileSync}  from 'node:child_process';
+import fs              from 'node:fs';
+import os              from 'node:os';
+import path            from 'node:path';
+import process         from 'node:process';
+import {createRequire} from 'node:module';
+import {fileURLToPath} from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url)),
+      ROOT      = path.resolve(__dirname, '../..');
+
+/**
+ * @module buildScripts/util/check-consumer-worker-build
+ * @summary Builds a Data worker from an installed copy of this package, because this repository's
+ * own build structurally cannot observe what a consumer's build does.
+ *
+ * ## The defect class
+ *
+ * A worker authors its lazy-import roots relative to its own directory, and the worker webpack
+ * configs translate those roots outward once the framework is a dependency. Every check we run lives
+ * on the framework side of that translation, where the repository *is* the workspace — so the
+ * translation is never exercised and its failures are invisible. Four defects of exactly this shape
+ * landed within one day:
+ *
+ * - An unanchored `webpackInclude` matched on an *ancestor* directory named `apps`, so a nested
+ *   workspace registered its entire tree. In this repository the same pattern is correct, which is
+ *   why it survived: the include narrows properly exactly when the repository is the thing built.
+ * - Splitting that context into four static roots then broke the configs' consumer rebasing: three
+ *   roots resolved inside `node_modules/neo.mjs` and one resolved nowhere.
+ * - Those same four roots are *optional* for a consumer, and rebasing an absent one failed the build
+ *   outright — a case a path-arithmetic simulation cannot see, because it never asks whether a
+ *   directory exists.
+ * - Dependencies resolved by filesystem path rather than module resolution, which breaks the moment
+ *   npm hoists them to a consumer root this package cannot see.
+ *
+ * ## Why it packs and builds for real
+ *
+ * Reasoning about relative paths is explicitly not a substitute, and neither is a simulated layout:
+ * the simulation encodes the dimensions its author thought of, and the optional-root failure above
+ * was found by a physical build within a minute of a simulated one reporting all roots correct. Only
+ * an installed copy, built from a workspace that is not this repository, can falsify the claim.
+ *
+ * The fixture workspace is created **under a directory named `apps`** so the original ancestor-match
+ * trigger is covered by the same run, and it deliberately ships no `examples/` or `docs/app/` so the
+ * optional-root path is exercised rather than assumed.
+ *
+ * ## What it does NOT do
+ *
+ * It does not assert bundle size, chunk counts, or anything about *this* repository's build — those
+ * are observable here and belong to cheaper checks. It answers one question: does a consumer's Data
+ * worker resolve the consumer's modules, and only those?
+ */
+
+/**
+ * @summary Modules the fixture plants, and what a correct consumer build must do with each.
+ *
+ * Spelled as required-present / required-absent rather than an exact module list: the graph legitimately
+ * carries framework internals whose count is not this guard's business, while presence and absence of
+ * these three is precisely the contract.
+ */
+const FIXTURE_EXPECTATIONS = [{
+    file   : 'apps/probe/data/ConsumerOnly.mjs',
+    match  : /apps[/\\]probe[/\\]data[/\\]ConsumerOnly\.mjs$/,
+    present: true,
+    because: 'a consumer-owned app-space module must be reachable from the consumer\'s Data worker'
+}, {
+    file   : 'RootOnly.mjs',
+    match  : /(^|[/\\])RootOnly\.mjs$/,
+    present: false,
+    because: 'a root-level Node-only script must never be registered in a browser worker bundle'
+}, {
+    file   : 'client/src/Unrelated.mjs',
+    match  : /client[/\\]src[/\\]Unrelated\.mjs$/,
+    present: false,
+    because: 'an unrelated application tree must not be dragged in by an over-wide context'
+}];
+
+/**
+ * @summary Rule logic, split from the pack/install/build so it is unit-testable without spawning.
+ *
+ * @param {Object}   result
+ * @param {String}   result.mode `development` or `production`, for the failure message only.
+ * @param {String[]} result.moduleNames Module identifiers from the compilation.
+ * @param {String[]} result.errors Compilation error messages.
+ * @param {Object[]} [expectations=FIXTURE_EXPECTATIONS]
+ * @returns {String[]} Human-readable failures; empty means the build honours the contract.
+ */
+export function collectConsumerBuildFailures({mode, moduleNames, errors}, expectations = FIXTURE_EXPECTATIONS) {
+    const failures = [];
+
+    for (const error of errors) {
+        failures.push(`[${mode}] build error: ${error.split('\n')[0]}`)
+    }
+
+    for (const {file, match, present, because} of expectations) {
+        const found = moduleNames.some(name => match.test(name));
+
+        if (found !== present) {
+            failures.push(
+                `[${mode}] ${file} is ${found ? 'present' : 'absent'}, expected ${present ? 'present' : 'absent'} — ${because}`
+            )
+        }
+    }
+
+    return failures
+}
+
+/** @summary Writes the consumer fixture: one app-space module, two that must never be reached. */
+function createFixture(workspace) {
+    const files = {
+        'package.json'                    : JSON.stringify({name: 'neo-consumer-fixture', version: '1.0.0', type: 'module'}, null, 4),
+        'apps/probe/data/ConsumerOnly.mjs': 'export default class ConsumerOnly {}\n',
+        'RootOnly.mjs'                    : 'export default "root-level node script";\n',
+        'client/src/Unrelated.mjs'        : 'export default "unrelated application tree";\n'
+    };
+
+    for (const [relative, contents] of Object.entries(files)) {
+        const target = path.join(workspace, relative);
+
+        fs.mkdirSync(path.dirname(target), {recursive: true});
+        fs.writeFileSync(target, contents)
+    }
+}
+
+/**
+ * @summary Compiles the installed worker config for one mode and reports what the graph holds.
+ *
+ * The config resolves `neoPath` from `process.cwd()` at import time, so the process must already be
+ * standing in the consumer when the module loads — running it from the framework checkout silently
+ * builds the framework's own tree instead, and every consumer assertion then fails for the wrong
+ * reason. The caller owns the `chdir`; this only consumes it.
+ */
+async function buildWorker(workspace, mode) {
+    const webpack = createRequire(path.join(workspace, 'package.json'))('webpack');
+
+    const {default: configFactory} = await import(
+        path.join(workspace, `node_modules/neo.mjs/buildScripts/webpack/${mode}/webpack.config.worker.mjs`)
+    );
+
+    const config = configFactory({worker: 'data', insideNeo: 'false'});
+
+    config.output = {...config.output, path: path.join(workspace, 'dist', mode)};
+
+    const stats = await new Promise((resolve, reject) => {
+        webpack(config, (err, result) => err ? reject(err) : resolve(result))
+    });
+
+    const json = stats.toJson({modules: true, errors: true, all: false});
+
+    return {
+        mode,
+        moduleNames: (json.modules || []).map(m => m.name || ''),
+        errors     : (json.errors  || []).map(e => e.message || String(e))
+    }
+}
+
+async function main() {
+    const workspaceRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'neo-consumer-')),
+          // Nested under `apps` on purpose: the ancestor-name match is half of what this guard covers.
+          workspace     = path.join(workspaceRoot, 'apps', 'workspace');
+
+    fs.mkdirSync(workspace, {recursive: true});
+
+    try {
+        createFixture(workspace);
+
+        console.log('check-consumer-worker-build: packing…');
+        const packed = execFileSync('npm', ['pack', '--pack-destination', workspace], {cwd: ROOT, encoding: 'utf8'})
+            .trim().split('\n').pop().trim();
+
+        console.log(`check-consumer-worker-build: installing ${packed} into the fixture…`);
+        // The published package declares no runtime dependencies, so a consumer that builds neo's
+        // workers supplies the build toolchain itself; installing it here mirrors that reality.
+        execFileSync('npm', ['install', '--no-audit', '--no-fund', '--ignore-scripts', `./${packed}`, 'fs-extra', 'webpack'],
+            {cwd: workspace, encoding: 'utf8', stdio: 'pipe'});
+
+        const failures = [],
+              origCwd  = process.cwd();
+
+        // Stand in the consumer before the configs load: they read `process.cwd()` at import time.
+        process.chdir(workspace);
+
+        try {
+            for (const mode of ['development', 'production']) {
+                console.log(`check-consumer-worker-build: building ${mode}…`);
+                failures.push(...collectConsumerBuildFailures(await buildWorker(workspace, mode)))
+            }
+        } finally {
+            process.chdir(origCwd)
+        }
+
+        if (failures.length) {
+            console.error(`\ncheck-consumer-worker-build: FAILED (${failures.length})\n`);
+            failures.forEach(failure => console.error(`  ${failure}`));
+            console.error('\nA consumer build resolves differently from this repository\'s own. See #17881.');
+            process.exit(1)
+        }
+
+        console.log('\ncheck-consumer-worker-build: OK — both modes resolve the consumer\'s modules and only those.')
+    } finally {
+        fs.rmSync(workspaceRoot, {recursive: true, force: true})
+    }
+}
+
+// Only the CLI path packs and builds; importing the module for its rule logic must stay cheap.
+if (process.argv[1] && path.resolve(process.argv[1]) === path.resolve(fileURLToPath(import.meta.url))) {
+    main().catch(error => {
+        console.error(`check-consumer-worker-build: ${error.message}`);
+        process.exit(1)
+    })
+}

--- a/buildScripts/webpack/development/webpack.config.worker.mjs
+++ b/buildScripts/webpack/development/webpack.config.worker.mjs
@@ -1,6 +1,6 @@
-import fs      from 'fs-extra';
-import path    from 'path';
-import webpack from 'webpack';
+import fs                        from 'fs-extra';
+import path                      from 'path';
+import workerContextRebasePlugin from '../workerContextRebasePlugin.mjs';
 
 const cwd            = process.cwd(),
       requireJson    = path => JSON.parse(fs.readFileSync((path))),
@@ -34,15 +34,7 @@ export default env => {
         },
 
         plugins: [
-            new webpack.ContextReplacementPlugin(/.*/, context => {
-                let con = context.context;
-
-                if (!insideNeo && (con.includes('/src/worker') || con.includes('\\src\\worker'))) {
-                    if (!context.request.startsWith('../../') && !context.request.startsWith('..\\..\\') && !context.request.startsWith('../data/') && !context.request.startsWith('..\\data\\')) {
-                        context.request = path.join('../../', context.request);
-                    }
-                }
-            })
+            workerContextRebasePlugin(insideNeo)
         ],
 
         output: {

--- a/buildScripts/webpack/production/webpack.config.worker.mjs
+++ b/buildScripts/webpack/production/webpack.config.worker.mjs
@@ -1,6 +1,6 @@
-import fs      from 'fs-extra';
-import path    from 'path';
-import webpack from 'webpack';
+import fs                        from 'fs-extra';
+import path                      from 'path';
+import workerContextRebasePlugin from '../workerContextRebasePlugin.mjs';
 
 const cwd            = process.cwd(),
       requireJson    = path => JSON.parse(fs.readFileSync((path))),
@@ -33,15 +33,7 @@ export default env => {
         },
 
         plugins: [
-            new webpack.ContextReplacementPlugin(/.*/, context => {
-                let con = context.context;
-
-                if (!insideNeo && (con.includes('/src/worker') || con.includes('\\src\\worker'))) {
-                    if (!context.request.startsWith('../../') && !context.request.startsWith('..\\..\\') && !context.request.startsWith('../data/') && !context.request.startsWith('..\\data\\')) {
-                        context.request = path.join('../../', context.request);
-                    }
-                }
-            })
+            workerContextRebasePlugin(insideNeo)
         ],
 
         output: {

--- a/buildScripts/webpack/workerContextRebasePlugin.mjs
+++ b/buildScripts/webpack/workerContextRebasePlugin.mjs
@@ -1,0 +1,56 @@
+import path    from 'path';
+import webpack from 'webpack';
+
+/**
+ * @summary Does this context root resolve inside the installed `neo.mjs` package?
+ *
+ * Worker roots fall into two kinds. **Package-local** roots (`src/data`, and the connection,
+ * parser and normalizer trees beneath it) ship with the framework, so they resolve as authored no
+ * matter who installed it. Everything else is **app space** — the consumer's `apps`, `examples`
+ * and `docs/app` trees — which live outside the package and must be rebased.
+ *
+ * Both separators are accepted, and a bare root counts: a context request carries no trailing
+ * separator, so `../data` and `../data/connection` are equally package-local.
+ *
+ * @param {String} request A context request, relative to the worker's directory.
+ * @returns {Boolean}
+ * @private
+ */
+function isPackageLocal(request) {
+    return request === '../data'  || request.startsWith('../data/') ||
+           request === '..\\data' || request.startsWith('..\\data\\')
+}
+
+/**
+ * @summary Rebases a worker's lazy context roots from the installed package out to the consumer workspace.
+ *
+ * A worker authors its dynamic-import roots relative to its own directory, which is correct while
+ * the repository *is* the thing being built. Once `neo.mjs` is a dependency, the same relative root
+ * points inside `node_modules/neo.mjs`, where the consumer's application code does not live. This
+ * plugin supplies the missing half of that contract: app-space roots step out to the consumer
+ * workspace, package-local roots stay where they are.
+ *
+ * **Why the phase gate.** `ContextReplacementPlugin` taps both `beforeResolve` and `afterResolve`,
+ * so this callback runs twice for every context; only the first carries an unresolved request.
+ * Gating on that phase keeps the rebase idempotent, which frees the request test to mean exactly one
+ * thing — "is this root package-local?" — rather than doubling as an already-rebased marker. A
+ * marker built from the request string cannot tell an authored `../../apps` from a rebased one, and
+ * would silently leave the former pointing into the package.
+ *
+ * @param {Boolean} insideNeo Building the framework repository itself, where no rebasing applies.
+ * @returns {webpack.ContextReplacementPlugin}
+ */
+export default function workerContextRebasePlugin(insideNeo) {
+    return new webpack.ContextReplacementPlugin(/.*/, context => {
+        // afterResolve repeats the callback with the request already rebased.
+        if (context.resource !== undefined) return;
+
+        const con = context.context;
+
+        if (insideNeo || !con || !(con.includes('/src/worker') || con.includes('\\src\\worker'))) return;
+
+        if (!isPackageLocal(context.request)) {
+            context.request = path.join('../../', context.request)
+        }
+    })
+}

--- a/buildScripts/webpack/workerContextRebasePlugin.mjs
+++ b/buildScripts/webpack/workerContextRebasePlugin.mjs
@@ -1,5 +1,12 @@
+import fs      from 'fs';
 import path    from 'path';
 import webpack from 'webpack';
+
+/**
+ * @summary A pattern that matches nothing, used to empty an optional root's context.
+ * @private
+ */
+const MATCHES_NOTHING = /(?!)/;
 
 /**
  * @summary Does this context root resolve inside the installed `neo.mjs` package?
@@ -37,6 +44,13 @@ function isPackageLocal(request) {
  * marker built from the request string cannot tell an authored `../../apps` from a rebased one, and
  * would silently leave the former pointing into the package.
  *
+ * **Optional roots.** App-space roots are optional for a consumer: most workspaces have `apps` and
+ * no `examples` or `docs/app`. A rebased root that does not exist would fail the build, so an absent
+ * one keeps its package-relative request — which always resolves, since the published package ships
+ * all of them — and has its match emptied instead. Resolving it to the framework's own tree without
+ * emptying it would pull the engine's examples into a consumer bundle, which is the bloat this
+ * change exists to remove.
+ *
  * @param {Boolean} insideNeo Building the framework repository itself, where no rebasing applies.
  * @returns {webpack.ContextReplacementPlugin}
  */
@@ -49,8 +63,14 @@ export default function workerContextRebasePlugin(insideNeo) {
 
         if (insideNeo || !con || !(con.includes('/src/worker') || con.includes('\\src\\worker'))) return;
 
-        if (!isPackageLocal(context.request)) {
-            context.request = path.join('../../', context.request)
+        if (isPackageLocal(context.request)) return;
+
+        const rebased = path.join('../../', context.request);
+
+        if (fs.existsSync(path.resolve(con, rebased))) {
+            context.request = rebased
+        } else {
+            context.regExp = MATCHES_NOTHING
         }
     })
 }

--- a/src/worker/Data.mjs
+++ b/src/worker/Data.mjs
@@ -78,18 +78,75 @@ class Data extends Base {
      * @param {String} msg.path The path to the module to load.
      * @returns {Promise<Object>} {success: true, id} or {success: false, error}
      */
+    /**
+     * @summary Imports one app-space module through an EXPLICIT per-root context.
+     *
+     * Each branch below carries a STATIC prefix, so webpack roots its lazy context at that exact
+     * directory. The previous shape — one `../../${path}.mjs` context narrowed by a `webpackInclude`
+     * — could not do that: include/exclude are matched against the ABSOLUTE resource path, so a
+     * workspace nested under an ancestor directory named `apps`, `examples` or `docs/app` matched on
+     * the ancestor and the include stopped narrowing anything. Measured before this change: this
+     * repo's own build registered 797 modules with 762 legitimately matching, while a workspace one
+     * level under an `apps/` ancestor registered 1244 with 7 — the entire tree, including root-level
+     * Node scripts, reachable from a browser worker.
+     *
+     * An explicit base cannot be widened by a name further up the filesystem, which is why this is a
+     * different shape rather than a stricter regex: anchoring the include to a separator does not
+     * help when the ancestor supplies the separator too.
+     *
+     * The sibling `loadDataModule` switch already resolved its three roots this way; this is that
+     * pattern applied to the two call sites that predated it.
+     * @param {String} path App-space module path without the `.mjs` suffix.
+     * @returns {Promise<Object>} The imported module namespace.
+     * @throws {Error} When the path names no supported root.
+     * @protected
+     */
+    async importAppSpaceModule(path) {
+        if (path.startsWith('apps/')) {
+            return import(
+                /* webpackExclude: /(?:\/|\\)(buildScripts|dist|node_modules(?:\/|\\)(?!neo\.mjs)|ai(?:\/|\\)|\.claude(?:\/|\\)|server\.mjs|test(?:\/|\\))/ */
+                /* webpackMode: "lazy" */
+                `../../apps/${path.slice(5)}.mjs`
+            )
+        }
+
+        if (path.startsWith('examples/')) {
+            return import(
+                /* webpackExclude: /(?:\/|\\)(buildScripts|dist|node_modules(?:\/|\\)(?!neo\.mjs)|ai(?:\/|\\)|\.claude(?:\/|\\)|server\.mjs|test(?:\/|\\))/ */
+                /* webpackMode: "lazy" */
+                `../../examples/${path.slice(9)}.mjs`
+            )
+        }
+
+        if (path.startsWith('docs/app/')) {
+            return import(
+                /* webpackExclude: /(?:\/|\\)(buildScripts|dist|node_modules(?:\/|\\)(?!neo\.mjs)|ai(?:\/|\\)|\.claude(?:\/|\\)|server\.mjs|test(?:\/|\\))/ */
+                /* webpackMode: "lazy" */
+                `../../docs/app/${path.slice(9)}.mjs`
+            )
+        }
+
+        if (path.startsWith('src/data/')) {
+            return import(
+                /* webpackExclude: /(?:\/|\\)(buildScripts|dist|node_modules(?:\/|\\)(?!neo\.mjs)|ai(?:\/|\\)|\.claude(?:\/|\\)|server\.mjs|test(?:\/|\\))/ */
+                /* webpackMode: "lazy" */
+                `../data/${path.slice(9)}.mjs`
+            )
+        }
+
+        // A typed refusal, matching `loadDataModule`'s own default branch: an unsupported root is a
+        // caller error, and resolving it through a wider context is exactly what this method exists
+        // to stop.
+        throw new Error(`Unsupported module root: ${path}`)
+    }
+
     async createInstance({config, path}) {
         if (path.endsWith('.mjs')) {
             path = path.slice(0, -4)
         }
 
         try {
-            let module = await import(
-                /* webpackInclude: /(?:apps|docs\/app|examples|src\/data)\/.*\.mjs$/ */
-                /* webpackExclude: /(?:\/|\\)(buildScripts|dist|node_modules(?:\/|\\)(?!neo\.mjs)|ai(?:\/|\\)|\.claude(?:\/|\\)|server\.mjs|test(?:\/|\\))/ */
-                /* webpackMode: "lazy" */
-                `../../${path}.mjs`
-            );
+            let module = await this.importAppSpaceModule(path);
 
             // module.default is the Neo class
             let instance = Neo.create(module.default, config);
@@ -176,12 +233,7 @@ class Data extends Base {
         }
 
         try {
-            await import(
-                /* webpackInclude: /(?:apps|docs\/app|examples|src\/data)\/.*\.mjs$/ */
-                /* webpackExclude: /(?:\/|\\)(buildScripts|dist|node_modules(?:\/|\\)(?!neo\.mjs)|ai(?:\/|\\)|\.claude(?:\/|\\)|server\.mjs|test(?:\/|\\))/ */
-                /* webpackMode: "lazy" */
-                `../../${path}.mjs`
-            );
+            await this.importAppSpaceModule(path);
             return {success: true, path}
         } catch (e) {
             console.error(`Data Worker: Failed to load module ${path}`, e);

--- a/src/worker/Data.mjs
+++ b/src/worker/Data.mjs
@@ -69,33 +69,21 @@ class Data extends Base {
     }
 
     /**
-     * @summary Remotely loads an ES module and creates an instance of it inside the Data Worker.
-     * This is crucial for avoiding the loading of heavy data-shaping logic (like Parsers/Normalizers)
-     * inside the App Worker.
+     * @summary Imports one app-space module through an explicit per-root context.
      *
-     * @param {Object} msg
-     * @param {Object} msg.config The configuration object to pass to the new instance.
-     * @param {String} msg.path The path to the module to load.
-     * @returns {Promise<Object>} {success: true, id} or {success: false, error}
-     */
-    /**
-     * @summary Imports one app-space module through an EXPLICIT per-root context.
+     * Each branch carries a static prefix, so webpack roots its lazy context at that exact
+     * directory. A single context rooted above the app-space trees and narrowed by a
+     * `webpackInclude` cannot express the same guarantee: include patterns are matched against the
+     * absolute resource path, so a directory named `apps`, `examples` or `docs/app` anywhere *above*
+     * the workspace satisfies them and the include stops narrowing. An explicit base is not widenable
+     * by an ancestor's name, and holding that invariant is why this method exists.
      *
-     * Each branch below carries a STATIC prefix, so webpack roots its lazy context at that exact
-     * directory. The previous shape — one `../../${path}.mjs` context narrowed by a `webpackInclude`
-     * — could not do that: include/exclude are matched against the ABSOLUTE resource path, so a
-     * workspace nested under an ancestor directory named `apps`, `examples` or `docs/app` matched on
-     * the ancestor and the include stopped narrowing anything. Measured before this change: this
-     * repo's own build registered 797 modules with 762 legitimately matching, while a workspace one
-     * level under an `apps/` ancestor registered 1244 with 7 — the entire tree, including root-level
-     * Node scripts, reachable from a browser worker.
+     * This owns only the package-relative half of the contract. When the framework is an installed
+     * dependency these roots point inside `node_modules/neo.mjs`, and rebasing them out to the
+     * consuming workspace belongs to the worker webpack configs — see
+     * `buildScripts/webpack/workerContextRebasePlugin.mjs`. Changing the prefixes here without
+     * changing that mapping breaks module resolution for every consumer.
      *
-     * An explicit base cannot be widened by a name further up the filesystem, which is why this is a
-     * different shape rather than a stricter regex: anchoring the include to a separator does not
-     * help when the ancestor supplies the separator too.
-     *
-     * The sibling `loadDataModule` switch already resolved its three roots this way; this is that
-     * pattern applied to the two call sites that predated it.
      * @param {String} path App-space module path without the `.mjs` suffix.
      * @returns {Promise<Object>} The imported module namespace.
      * @throws {Error} When the path names no supported root.
@@ -140,6 +128,16 @@ class Data extends Base {
         throw new Error(`Unsupported module root: ${path}`)
     }
 
+    /**
+     * @summary Remotely loads an ES module and creates an instance of it inside the Data Worker.
+     * This is crucial for avoiding the loading of heavy data-shaping logic (like Parsers/Normalizers)
+     * inside the App Worker.
+     *
+     * @param {Object} msg
+     * @param {Object} msg.config The configuration object to pass to the new instance.
+     * @param {String} msg.path The path to the module to load.
+     * @returns {Promise<Object>} {success: true, id} or {success: false, error}
+     */
     async createInstance({config, path}) {
         if (path.endsWith('.mjs')) {
             path = path.slice(0, -4)

--- a/test/playwright/unit/buildScripts/checkConsumerWorkerBuild.spec.mjs
+++ b/test/playwright/unit/buildScripts/checkConsumerWorkerBuild.spec.mjs
@@ -1,0 +1,66 @@
+import {test, expect} from '@playwright/test';
+
+/**
+ * The consumer worker-build guard (ticket-ref-ok: the spec pins #17881's enforcement AC — a guard
+ * that fails when an installed Data worker resolves the framework's modules instead of the
+ * consumer's, or fails outright on an app-space root the consumer does not have).
+ *
+ * Only the rule logic is exercised here. The guard's expensive half — `npm pack`, install into a
+ * fixture nested under an `apps/` ancestor, and two real webpack compiles — is what the CI workflow
+ * runs, and it cannot be meaningfully faked: a simulated layout is exactly the instrument that
+ * reported every root correct while the physical build failed on two of them. So this spec asserts
+ * the failure DIRECTIONS, and the workflow asserts the behaviour.
+ */
+test.describe('check-consumer-worker-build — rule logic', () => {
+    let collectConsumerBuildFailures;
+
+    const CONSUMER  = './apps/probe/data/ConsumerOnly.mjs',
+          ROOT_ONLY = './RootOnly.mjs',
+          UNRELATED = './client/src/Unrelated.mjs',
+          healthy   = {mode: 'development', moduleNames: [CONSUMER, './src/worker/Data.mjs'], errors: []};
+
+    test.beforeAll(async () => {
+        ({collectConsumerBuildFailures} = await import('../../../../buildScripts/util/check-consumer-worker-build.mjs'))
+    });
+
+    test('a build resolving only the consumer\'s modules passes', () => {
+        expect(collectConsumerBuildFailures(healthy)).toEqual([])
+    });
+
+    test('a missing consumer module fails — the context resolved somewhere else', () => {
+        const failures = collectConsumerBuildFailures({...healthy, moduleNames: ['./src/worker/Data.mjs']});
+
+        expect(failures).toHaveLength(1);
+        expect(failures[0]).toContain('ConsumerOnly.mjs is absent, expected present')
+    });
+
+    test('a root-level Node script reaching a worker bundle fails', () => {
+        const failures = collectConsumerBuildFailures({...healthy, moduleNames: [CONSUMER, ROOT_ONLY]});
+
+        expect(failures).toHaveLength(1);
+        expect(failures[0]).toContain('RootOnly.mjs is present, expected absent')
+    });
+
+    test('an unrelated application tree reaching a worker bundle fails', () => {
+        const failures = collectConsumerBuildFailures({...healthy, moduleNames: [CONSUMER, UNRELATED]});
+
+        expect(failures).toHaveLength(1);
+        expect(failures[0]).toContain('Unrelated.mjs is present, expected absent')
+    });
+
+    test('a resolution error fails even when every module expectation holds', () => {
+        // The optional-root regression: the graph can be correct while an absent root fails the build.
+        const failures = collectConsumerBuildFailures({...healthy, errors: ["Module not found: Error: Can't resolve '../../../../examples'"]});
+
+        expect(failures).toHaveLength(1);
+        expect(failures[0]).toContain("Can't resolve '../../../../examples'")
+    });
+
+    test('every violation is reported, not just the first', () => {
+        const failures = collectConsumerBuildFailures({mode: 'production', moduleNames: [ROOT_ONLY, UNRELATED], errors: ['boom']});
+
+        // one error + missing consumer module + two forbidden modules
+        expect(failures).toHaveLength(4);
+        failures.forEach(failure => expect(failure).toContain('[production]'))
+    })
+});


### PR DESCRIPTION
Resolves #17881

`createInstance` and `loadModule` each opened one lazy context over the **repository root** and relied on a `webpackInclude` to narrow it. That include is unanchored, and webpack matches include/exclude against the **absolute** resource path — so a workspace nested under an ancestor directory named `apps`, `examples` or `docs/app` matches on the ancestor and the include stops narrowing anything.

Both now share `importAppSpaceModule`, which dispatches to four imports carrying **static prefixes**, so each context is rooted where it belongs and no ancestor name can widen it.

**Round 2 changes the shape.** @neo-gpt's review established that this is one contract across two layers, not a source-only fix, and he was right on both counts he raised. The worker webpack configs already translate a worker's context roots from the installed package out to the consuming workspace, and that translation did not understand the new prefixes. This PR now carries that half too.

Evidence: L3 — a physical npm-layout consumer build, plus clean-room in-repo before/after compiles and the exact-head unit suite. One residual, declared below.

## What Round 2 fixes

| symptom in a consumer | cause |
|---|---|
| `../../apps\|examples\|docs/app` resolved under `node_modules/neo.mjs` | a `startsWith('../../')` test exempted them from rebasing |
| `../data` rebased to `../../../data`, unresolvable | it missed the `'../data/'` exemption by its trailing separator |
| two roots failed the build outright | app-space roots are optional; a consumer has `apps` and usually no `examples` or `docs/app` |

**The measured reason the first two happened.** On a real data-worker compile the plugin's callback fires **twice per context** — `beforeResolve`, then `afterResolve` — so that prefix test was doing double duty as an idempotence marker. A marker read off the request string cannot distinguish an authored `../../apps` from an already-rebased one, so the new prefixes collided with it by looking finished. Idempotence now comes from the hook phase webpack already distinguishes, which frees the request test to mean one thing: is this root package-local?

Extracted to one factory, `buildScripts/webpack/workerContextRebasePlugin.mjs`. Both configs carried the rule byte-identically, and one copy drifting is exactly how the trailing-separator case stayed wrong in both.

## Contract Ledger Matrix

| Target Surface | Source of Authority | Behavior | Fallback | Docs | Evidence |
|---|---|---|---|---|---|
| `createInstance({config, path})` | `src/worker/Data.mjs` | accepted roots `apps/`, `examples/`, `docs/app/`, `src/data/`; a trailing `.mjs` is stripped before dispatch | unsupported root throws `Unsupported module root: <path>` | method JSDoc | unit suite; physical consumer build |
| `loadModule({path})` | `src/worker/Data.mjs` | same four roots, same refusal, via the shared helper | as above | method JSDoc | as above |
| `importAppSpaceModule(path)` | `src/worker/Data.mjs` | one static-prefixed context per root; package-relative only | typed refusal, no wider context | method JSDoc, which names the config-side half | in-repo 930-chunk identity |
| `workerContextRebasePlugin(insideNeo)` | `buildScripts/webpack/workerContextRebasePlugin.mjs` | app-space roots rebase to the consumer workspace; package-local roots do not; an absent root keeps its package-relative request with an emptied match | `insideNeo` is a total no-op | factory JSDoc | 0 request mutations at `insideNeo=true` |

## AC Evidence

| AC | Proof |
|---|---|
| AC-1 | context rooted at the intended directories — `importAppSpaceModule` dispatches to `../../apps/`, `../../examples/`, `../../docs/app/` and `../data/`, each a static prefix. The only remaining `webpackInclude` sites are the three pre-existing `loadDataModule` roots, whose bases were already explicit |
| AC-2 | **built from the nested consumer layout.** `npm pack` → installed into a workspace whose only app-space tree is `apps/probe/data/ConsumerOnly.mjs`. That consumer-owned module reaches the module graph, with **0 resolution errors** |
| AC-3 | this repo's build unchanged in reach — 931 emitted assets, 930 of them lazy chunks, and **0 context-request mutations** at `insideNeo=true`, measured by wrapping the real plugin on a real compile |
| AC-4 | root-level Node scripts not registered in a worker bundle — no context is rooted above `apps/`, `examples/`, `docs/app/` or `src/data/`, so a root-level `.mjs` has no context that could enumerate it |

## Test Evidence

**Unit**, exact head: **2144 passed / 0 failed** (the count rose from 2098 with the rebase onto `dev`, which brought in new specs).

**Physical consumer control.** neo.mjs packed and installed into a scratch workspace, compiled with `cwd` at the consumer so the config resolves `neoPath` to `./node_modules/neo.mjs/` exactly as a real consumer build does:

| | ConsumerOnly.mjs in graph | resolution errors |
|---|---|---|
| before the config fix | no | — |
| after the config fix, before optional-root handling | yes | 2 |
| at this head | **yes** | **0** |

**In-repo**, clean output each run: 930 lazy chunks before and after, 0 request mutations at `insideNeo=true`.

**A note on my Round 1 evidence, because it is the point of the ticket.** I first built a *simulated* consumer probe that computed path arithmetic against a fake layout. It went green on all seven roots — and it could not have caught the optional-root failure, because it never asked whether a directory exists. The physical build found that within a minute. My Round 1 body also claimed "same reach", "structurally unreachable" and "No residuals" for a case I had not built; @neo-gpt was right to fail the audit on all three. Those claims are gone.

## Residuals

**One, declared.** An absent app-space root yields an empty context rather than no context. A consumer requesting `examples/Foo` gets a runtime resolution failure from an empty context instead of a build-time error. That is the intended trade — a consumer without an `examples/` tree has no such module to load — but it is a behaviour difference, not an absence of one.

## Deltas from ticket

- **The ticket named one layer; the defect spans two.** Its "shape of the fix" section proposed separate narrow imports per supported root. That is necessary and not sufficient: the roots also have to mean the right thing once the framework is a dependency, which is config-side. #17881's Contract Ledger is being updated to carry both.
- **Both wide sites, not one.** The ticket named `createInstance`; `loadModule` carried an identical wide context and is fixed by the same shared helper. `src/worker/App.mjs:384` remains out of scope per the ticket.
- **Optional roots were not anticipated by the ticket at all** — they only exist as a question once one context becomes four.

## Commits

- `fix(worker): root the Data Worker's lazy imports at explicit bases (#17881)`
- `fix(build): rebase the worker's static contexts for installed consumers (#17881)`
- `fix(build): empty an absent app-space root instead of failing the build (#17881)`

Authored by Grace (Claude Opus 5, Claude Code) 🖖
