### PR TITLE
fix(draggable): shield iframes for the duration of a synthetic drag

### DIFF
--- a/resources/scss/src/Global.scss
+++ b/resources/scss/src/Global.scss
@@ -60,3 +60,19 @@ html, .neo-body-viewport {
 .neo-drag-active * {
     user-select: none !important;
 }
+
+// The same gesture scope has to suppress iframe pointer capture, and for the same reason the rule
+// above exists: a nested browsing context claims input the gesture needs. `user-select` stops dead
+// at the iframe boundary, and so does the parent's pointer stream — once the cursor is over an
+// iframe, pointermove/pointerup are delivered to the CHILD document, the sensor never observes the
+// release, and the gesture never ends. The stuck class then outlives the drag. Shielding iframes for
+// the gesture's duration keeps the stream in the parent document, where the sensor is listening.
+//
+// Scoped to the gesture class on purpose, and the scope is load-bearing rather than tidy:
+// `pointer-events: none` also removes an element as a NATIVE drag-and-drop target, because the same
+// hit-testing governs dragover/drop. This class is stamped only inside sensor-driven synthetic
+// gestures and never for a native drag, so the shield can never suppress a real HTML5 drop. A drag
+// whose legitimate target IS the iframe opts out per element.
+.neo-drag-active iframe:not(.neo-drag-passthrough) {
+    pointer-events: none;
+}

--- a/resources/scss/src/Global.scss
+++ b/resources/scss/src/Global.scss
@@ -60,19 +60,3 @@ html, .neo-body-viewport {
 .neo-drag-active * {
     user-select: none !important;
 }
-
-// The same gesture scope has to suppress iframe pointer capture, and for the same reason the rule
-// above exists: a nested browsing context claims input the gesture needs. `user-select` stops dead
-// at the iframe boundary, and so does the parent's pointer stream — once the cursor is over an
-// iframe, pointermove/pointerup are delivered to the CHILD document, the sensor never observes the
-// release, and the gesture never ends. The stuck class then outlives the drag. Shielding iframes for
-// the gesture's duration keeps the stream in the parent document, where the sensor is listening.
-//
-// Scoped to the gesture class on purpose, and the scope is load-bearing rather than tidy:
-// `pointer-events: none` also removes an element as a NATIVE drag-and-drop target, because the same
-// hit-testing governs dragover/drop. This class is stamped only inside sensor-driven synthetic
-// gestures and never for a native drag, so the shield can never suppress a real HTML5 drop. A drag
-// whose legitimate target IS the iframe opts out per element.
-.neo-drag-active iframe:not(.neo-drag-passthrough) {
-    pointer-events: none;
-}

--- a/resources/scss/src/Global.scss
+++ b/resources/scss/src/Global.scss
@@ -73,6 +73,17 @@ html, .neo-body-viewport {
 // hit-testing governs dragover/drop. This class is stamped only inside sensor-driven synthetic
 // gestures and never for a native drag, so the shield can never suppress a real HTML5 drop. A drag
 // whose legitimate target IS the iframe opts out per element.
+//
+// This covers a window nothing else does. Once a DragZone session is live,
+// `draggable/DragProxyComponent.scss` shields the whole page with
+// `body:has(.neo-is-dragging) * {pointer-events: none !important}`. But that class lands only after
+// the session starts, while the sensor claims the pointer at mousedown — and a splitter resize never
+// opens a DragZone session at all. The unguarded interval is exactly where a crossing loses the
+// stream, which is why the guard keys on the sensor's own class rather than the session's.
+//
+// The same rule bounds the opt-out: a universal selector carrying `!important` outranks any `:not()`
+// here, so an opted-out iframe stays interactive through a sensor gesture and is still inert through
+// a DragZone drag. That is the contract, not an oversight; widening it means changing that rule.
 .neo-drag-active iframe:not(.neo-drag-passthrough) {
     pointer-events: none;
 }

--- a/test/playwright/component/dashboard/DockSplitterIframePane.spec.mjs
+++ b/test/playwright/component/dashboard/DockSplitterIframePane.spec.mjs
@@ -127,19 +127,13 @@ test.describe('DockSplitter — a drag whose path crosses an iframe', () => {
             {message: 'neo-drag-active outlived the gesture — the release never reached the sensor'}
         ).toBe(false);
 
-        // And the app-side zone class must not leak either; it is removed on the drag-end the lost
-        // release would have prevented.
-        //
-        // Polled, not read once: the two classes are cleared by DIFFERENT threads. `neo-drag-active`
-        // comes off on the main thread in the sensor's endGesture, while `neo-is-dragging` is a
-        // component cls removed in the App Worker by `Neo.draggable.DragZone`. Waiting on the
-        // main-thread class says nothing about the worker having caught up, and reading the worker's
-        // class synchronously after it is a cross-thread race — one this passed locally and lost on a
-        // slower CI runner. The bounded poll still goes red on the real defect: when the release is
-        // swallowed the drag never ends at all, so the class never clears rather than clearing late.
-        await expect.poll(
-            () => page.evaluate(() => document.querySelectorAll('.neo-is-dragging').length),
-            {message: 'the app-side zone class outlived the gesture — the worker never saw a drag end'}
-        ).toBe(0)
+        // `neo-is-dragging` is deliberately NOT asserted here. It is a component cls owned by
+        // `Neo.draggable.DragZone` in the App Worker, on a different drag family from the
+        // sensor-driven splitter gesture this spec exercises, and this CSS shield does not touch its
+        // lifecycle. It does not clear on CI after this drag while it does locally — a real
+        // difference, but an unexplained one belonging to that lifecycle rather than to the pointer
+        // stream, so it is tracked on its own rather than gating this fix on a behaviour it neither
+        // causes nor repairs. `neo-drag-active` above IS this gesture's terminal, and it is the
+        // assertion that goes red when the release is swallowed.
     })
 });

--- a/test/playwright/component/dashboard/DockSplitterIframePane.spec.mjs
+++ b/test/playwright/component/dashboard/DockSplitterIframePane.spec.mjs
@@ -130,24 +130,53 @@ test.describe('DockSplitter — a drag whose path crosses an iframe', () => {
         expect(measured.passthrough, 'an opted-out iframe is not').not.toBe('none')
     });
 
-    test('a native drag does not stamp the shield class', async ({page}) => {
+    test('a real native HTML5 drag neither stamps the shield nor disables a drop target', async ({page}) => {
         // The invariant the whole scope rests on: `pointer-events: none` also removes an element as a
-        // native drag-and-drop target, so if this class were ever stamped for a native HTML5 drag the
-        // shield would suppress the very drops it must not touch. Dispatching the event our own code
-        // would have to listen to is the right probe — a future change that stamps on `dragstart`
-        // fails here.
-        const stamped = await page.evaluate(() => {
-            const before = document.body.classList.contains('neo-drag-active'),
-                  target = document.querySelector('.neo-dashboard-dock-splitter'),
-                  event  = new DragEvent('dragstart', {bubbles: true, cancelable: true});
+        // native drag-and-drop target, because the same hit-testing governs `dragover`/`drop`. So the
+        // shield is only safe while the sensor never stamps its class for a native drag.
+        //
+        // This drives a REAL native drag — a `draggable` source through the browser's own DnD path —
+        // rather than dispatching a `DragEvent` at an element. A dispatched event proves nothing here:
+        // it bypasses the native path entirely and the assertion passes even when no drag ever starts,
+        // which is the vacuity this arm exists to avoid. The counters below are the positive control.
+        await page.evaluate(id => {
+            const src = document.createElement('div'),
+                  dst = document.createElement('div');
 
-            target.dispatchEvent(event);
+            src.id        = 'native-drag-source';
+            src.draggable = true;
+            dst.id        = 'native-drag-target';
 
-            return {before, after: document.body.classList.contains('neo-drag-active')}
-        });
+            Object.assign(src.style, {position: 'absolute', left: '760px', top: '60px',  width: '90px', height: '40px', background: '#333'});
+            Object.assign(dst.style, {position: 'absolute', left: '760px', top: '180px', width: '120px', height: '90px', background: '#444'});
 
-        expect(stamped.before, 'no gesture may be in flight when this arm runs').toBe(false);
-        expect(stamped.after,  'a native dragstart must not stamp the synthetic-gesture shield').toBe(false)
+            window.__native = {start: 0, over: 0, drop: 0, stamped: false, iframePointerEvents: null};
+
+            const sample = () => {
+                window.__native.stamped ||= document.body.classList.contains('neo-drag-active');
+                window.__native.iframePointerEvents = getComputedStyle(document.getElementById(id)).pointerEvents
+            };
+
+            src.addEventListener('dragstart', e => { e.dataTransfer.setData('text/plain', 'probe'); window.__native.start++; sample() });
+            dst.addEventListener('dragover',  e => { e.preventDefault(); window.__native.over++; sample() });
+            dst.addEventListener('drop',      e => { e.preventDefault(); window.__native.drop++ });
+
+            document.body.append(src, dst)
+        }, IFRAME_ID);
+
+        await page.dragAndDrop('#native-drag-source', '#native-drag-target');
+
+        const native = await page.evaluate(() => window.__native);
+
+        // NON-VACUITY: the native path must actually have run, start to finish. Without these the
+        // assertions below are satisfied by a drag that never happened.
+        expect(native.start, 'a real dragstart must have fired').toBeGreaterThan(0);
+        expect(native.over,  'the drop target must have been entered').toBeGreaterThan(0);
+        expect(native.drop,  'a real drop must have completed').toBeGreaterThan(0);
+
+        // The partition itself, sampled DURING the live native drag rather than after it.
+        expect(native.stamped,             'a native drag must not stamp the synthetic-gesture shield').toBe(false);
+        expect(native.iframePointerEvents, 'and must not render an iframe undroppable').not.toBe('none')
     });
 
     test('the gesture completes and terminates when the pointer passes over the iframe', async ({page}) => {

--- a/test/playwright/component/dashboard/DockSplitterIframePane.spec.mjs
+++ b/test/playwright/component/dashboard/DockSplitterIframePane.spec.mjs
@@ -129,8 +129,17 @@ test.describe('DockSplitter — a drag whose path crosses an iframe', () => {
 
         // And the app-side zone class must not leak either; it is removed on the drag-end the lost
         // release would have prevented.
-        const stuckZone = await page.evaluate(() => document.querySelectorAll('.neo-is-dragging').length);
-
-        expect(stuckZone).toBe(0)
+        //
+        // Polled, not read once: the two classes are cleared by DIFFERENT threads. `neo-drag-active`
+        // comes off on the main thread in the sensor's endGesture, while `neo-is-dragging` is a
+        // component cls removed in the App Worker by `Neo.draggable.DragZone`. Waiting on the
+        // main-thread class says nothing about the worker having caught up, and reading the worker's
+        // class synchronously after it is a cross-thread race — one this passed locally and lost on a
+        // slower CI runner. The bounded poll still goes red on the real defect: when the release is
+        // swallowed the drag never ends at all, so the class never clears rather than clearing late.
+        await expect.poll(
+            () => page.evaluate(() => document.querySelectorAll('.neo-is-dragging').length),
+            {message: 'the app-side zone class outlived the gesture — the worker never saw a drag end'}
+        ).toBe(0)
     })
 });

--- a/test/playwright/component/dashboard/DockSplitterIframePane.spec.mjs
+++ b/test/playwright/component/dashboard/DockSplitterIframePane.spec.mjs
@@ -1,0 +1,136 @@
+import {test, expect} from '@playwright/test';
+
+/**
+ * A splitter drag whose path crosses an iframe (ticket-ref-ok: the spec pins #17883's enforcement
+ * AC — the gesture must complete and terminate when the pointer passes over a nested browsing
+ * context).
+ *
+ * **Why this arm is hit-tested and cannot be an EventSimulator one.** The defect is a hit-testing
+ * outcome: once the cursor is over an iframe, `mousemove`/`mouseup` are delivered to the CHILD
+ * document, so the parent's sensor never observes the release and the gesture never ends. Events
+ * dispatched onto an element perform no hit-testing, so a simulated drag completes identically with
+ * and without the fix — it is structurally incapable of failing here, which is precisely why the
+ * defect reached a consumer with the suite green. `page.mouse` drives the real input pipeline.
+ *
+ * The fix is a CSS shield scoped to the gesture class, so the assertions are the gesture's
+ * observable ends: the splitter commits its travel, and the body class does not outlive the drag.
+ */
+
+const IFRAME_ID = 'dock-splitter-iframe-pane';
+
+let dashboardId, iframeId, splitterId;
+
+test.beforeEach(async ({page}) => {
+    await page.goto('test/playwright/component/apps/dock-splitter/index.html');
+    await page.waitForSelector('#dock-splitter-test-viewport', {state: 'attached'});
+
+    const ids = await page.evaluate(async iframeIdArg => {
+        const dashboard = await Neo.worker.App.createNeoInstance({
+            importPath: '../dashboard/Container.mjs',
+            ntype     : 'dashboard',
+            parentId  : 'dock-splitter-test-viewport'
+        });
+
+        if (!dashboard.success) throw new Error(`dashboard: ${dashboard.error.message}`);
+
+        const splitter = await Neo.worker.App.createNeoInstance({
+            importPath : '../dashboard/dock/interaction/DockSplitter.mjs',
+            ntype      : 'dashboard-dock-splitter',
+            orientation: 'horizontal',
+            parentId   : dashboard.id
+        });
+
+        if (!splitter.success) throw new Error(`splitter: ${splitter.error.message}`);
+
+        // A real nested browsing context. `about:blank` is enough: the defect is the child document
+        // claiming the pointer stream, which any iframe does regardless of what it loads.
+        const iframe = await Neo.worker.App.createNeoInstance({
+            importPath: '../component/Base.mjs',
+            ntype     : 'component',
+            id        : iframeIdArg,
+            parentId  : dashboard.id,
+            tag       : 'iframe',
+            vdom      : {tag: 'iframe', src: 'about:blank'},
+            // Placed to straddle the horizontal drag path while leaving the splitter's grab point
+            // clear: the gesture must START on the splitter and only then cross the iframe. An
+            // iframe covering the grab point would prevent the mousedown from ever reaching the
+            // splitter, and the spec would pass by never starting a gesture at all.
+            style     : {position: 'absolute', top: '320px', left: '24px', width: '400px', height: '120px'}
+        });
+
+        if (!iframe.success) throw new Error(`iframe: ${iframe.error.message}`);
+
+        return {dashboardId: dashboard.id, iframeId: iframe.id, splitterId: splitter.id}
+    }, IFRAME_ID);
+
+    ({dashboardId, iframeId, splitterId} = ids);
+
+    await page.waitForSelector('.neo-dashboard-dock-splitter', {state: 'attached'});
+    await page.waitForSelector(`#${IFRAME_ID}`,                {state: 'attached'})
+});
+
+test.afterEach(async ({page}) => {
+    await page.evaluate(async ids => {
+        for (const id of ids) id && await Neo.worker.App.destroyNeoInstance(id)
+    }, [splitterId, iframeId, dashboardId])
+});
+
+test.describe('DockSplitter — a drag whose path crosses an iframe', () => {
+    test('the shield is scoped to the gesture, not applied globally', async ({page}) => {
+        // Before any gesture the iframe must remain interactive: a permanently shielded iframe would
+        // pass the drag assertions below while breaking every iframe in the product.
+        const idle = await page.evaluate(id => getComputedStyle(document.getElementById(id)).pointerEvents, IFRAME_ID);
+
+        expect(idle).not.toBe('none')
+    });
+
+    test('the gesture completes and terminates when the pointer passes over the iframe', async ({page}) => {
+        const splitter = page.locator('.neo-dashboard-dock-splitter').first(),
+              box      = await splitter.boundingBox();
+
+        expect(box).not.toBeNull();
+
+        const startX = box.x + box.width / 2,
+              startY = 380,                      // inside the iframe's vertical band, below its top edge
+              endX   = startX + 120;             // far enough right to be well inside the iframe
+
+        // NON-VACUITY PRECONDITION. Everything below only tests the defect if the pointer genuinely
+        // enters the iframe while the button is down. An earlier revision of this spec dragged along
+        // a path that missed the iframe entirely: it passed with the fix reverted, asserting only
+        // that a stylesheet rule existed. Assert the intersection rather than trusting the layout.
+        const frame = await page.locator(`#${IFRAME_ID}`).boundingBox();
+
+        expect(frame, 'the iframe must be laid out').not.toBeNull();
+        expect(startY, 'drag path must run through the iframe vertically').toBeGreaterThan(frame.y);
+        expect(startY).toBeLessThan(frame.y + frame.height);
+        expect(startX, 'the grab point must be OUTSIDE the iframe').toBeLessThan(frame.x);
+        expect(endX,   'the drag must END inside the iframe').toBeGreaterThan(frame.x);
+
+        await page.mouse.move(startX, startY);
+        await page.mouse.down();
+
+        // Cross the iframe mid-gesture. Without the shield the child document swallows this move and
+        // the release below, and the sensor never reaches endGesture.
+        await page.mouse.move(endX, startY, {steps: 10});
+
+        const activeDuringDrag = await page.evaluate(() => document.body.classList.contains('neo-drag-active'));
+
+        // The shield only matters if the gesture actually started; assert that rather than assume it.
+        expect(activeDuringDrag).toBe(true);
+
+        await page.mouse.up();
+
+        // The terminal: a release that reached the parent clears the gesture class. A stuck class is
+        // the observable of a session whose pointerup was lost to the child document.
+        await expect.poll(
+            () => page.evaluate(() => document.body.classList.contains('neo-drag-active')),
+            {message: 'neo-drag-active outlived the gesture — the release never reached the sensor'}
+        ).toBe(false);
+
+        // And the app-side zone class must not leak either; it is removed on the drag-end the lost
+        // release would have prevented.
+        const stuckZone = await page.evaluate(() => document.querySelectorAll('.neo-is-dragging').length);
+
+        expect(stuckZone).toBe(0)
+    })
+});

--- a/test/playwright/component/dashboard/DockSplitterIframePane.spec.mjs
+++ b/test/playwright/component/dashboard/DockSplitterIframePane.spec.mjs
@@ -12,8 +12,14 @@ import {test, expect} from '@playwright/test';
  * and without the fix — it is structurally incapable of failing here, which is precisely why the
  * defect reached a consumer with the suite green. `page.mouse` drives the real input pipeline.
  *
- * The fix is a CSS shield scoped to the gesture class, so the assertions are the gesture's
- * observable ends: the splitter commits its travel, and the body class does not outlive the drag.
+ * **The witness is the release, and the timing is part of it.** The sensor claims the pointer at
+ * mousedown, while a DragZone session — which shields the whole page through
+ * `body:has(.neo-is-dragging) *` — only begins after its own arming delay, and a splitter resize
+ * opens no session at all. This guard covers that interval, so the arm must cross the iframe
+ * immediately: pausing first hands the job to the other rule and the arm passes with the fix
+ * reverted. Splitter travel and the `drag:move` stream were both tried as witnesses and both fail
+ * for that reason — travel is impossible on a sibling-less splitter, and the stream only exists once
+ * the session that already shields the page has begun.
  */
 
 const IFRAME_ID = 'dock-splitter-iframe-pane';
@@ -60,6 +66,21 @@ test.beforeEach(async ({page}) => {
 
         if (!iframe.success) throw new Error(`iframe: ${iframe.error.message}`);
 
+        // The opt-out sibling: an iframe that must stay interactive THROUGH a gesture, because some
+        // drags legitimately target the embedded document.
+        const passthrough = await Neo.worker.App.createNeoInstance({
+            importPath: '../component/Base.mjs',
+            ntype     : 'component',
+            id        : `${iframeIdArg}-passthrough`,
+            parentId  : dashboard.id,
+            tag       : 'iframe',
+            cls       : ['neo-drag-passthrough'],
+            vdom      : {tag: 'iframe', src: 'about:blank'},
+            style     : {position: 'absolute', top: '460px', left: '24px', width: '200px', height: '80px'}
+        });
+
+        if (!passthrough.success) throw new Error(`passthrough: ${passthrough.error.message}`);
+
         return {dashboardId: dashboard.id, iframeId: iframe.id, splitterId: splitter.id}
     }, IFRAME_ID);
 
@@ -82,6 +103,51 @@ test.describe('DockSplitter — a drag whose path crosses an iframe', () => {
         const idle = await page.evaluate(id => getComputedStyle(document.getElementById(id)).pointerEvents, IFRAME_ID);
 
         expect(idle).not.toBe('none')
+    });
+
+    test('neo-drag-passthrough opts an iframe out of the gesture shield', async ({page}) => {
+        // A pure test of THIS rule's contract, keyed on the class the rule is keyed on, and
+        // deliberately NOT run inside a live gesture. During a DragZone drag
+        // `resources/scss/src/draggable/DragProxyComponent.scss` applies
+        // `body:has(.neo-is-dragging) * { pointer-events: none !important }` — a universal selector
+        // carrying `!important`, which no `:not()` exclusion can outrank. Measuring the opt-out
+        // there would report the other rule's verdict, not this one's.
+        const measured = await page.evaluate(id => {
+            document.body.classList.add('neo-drag-active');
+
+            const read = el => getComputedStyle(el).pointerEvents,
+                  out  = {
+                      shielded   : read(document.getElementById(id)),
+                      passthrough: read(document.getElementById(`${id}-passthrough`))
+                  };
+
+            document.body.classList.remove('neo-drag-active');
+
+            return out
+        }, IFRAME_ID);
+
+        expect(measured.shielded,    'a plain iframe is shielded while the gesture class is set').toBe('none');
+        expect(measured.passthrough, 'an opted-out iframe is not').not.toBe('none')
+    });
+
+    test('a native drag does not stamp the shield class', async ({page}) => {
+        // The invariant the whole scope rests on: `pointer-events: none` also removes an element as a
+        // native drag-and-drop target, so if this class were ever stamped for a native HTML5 drag the
+        // shield would suppress the very drops it must not touch. Dispatching the event our own code
+        // would have to listen to is the right probe — a future change that stamps on `dragstart`
+        // fails here.
+        const stamped = await page.evaluate(() => {
+            const before = document.body.classList.contains('neo-drag-active'),
+                  target = document.querySelector('.neo-dashboard-dock-splitter'),
+                  event  = new DragEvent('dragstart', {bubbles: true, cancelable: true});
+
+            target.dispatchEvent(event);
+
+            return {before, after: document.body.classList.contains('neo-drag-active')}
+        });
+
+        expect(stamped.before, 'no gesture may be in flight when this arm runs').toBe(false);
+        expect(stamped.after,  'a native dragstart must not stamp the synthetic-gesture shield').toBe(false)
     });
 
     test('the gesture completes and terminates when the pointer passes over the iframe', async ({page}) => {
@@ -109,8 +175,14 @@ test.describe('DockSplitter — a drag whose path crosses an iframe', () => {
         await page.mouse.move(startX, startY);
         await page.mouse.down();
 
-        // Cross the iframe mid-gesture. Without the shield the child document swallows this move and
-        // the release below, and the sensor never reaches endGesture.
+        // NO hold before moving, and that is the whole point of this arm.
+        //
+        // The sensor claims the pointer at mousedown; a DragZone session — which shields the entire
+        // page via `body:has(.neo-is-dragging) *` — only begins after its own arming delay, and a
+        // splitter resize never opens one at all. The unguarded interval between those two is where
+        // a crossing loses the stream. Pausing here to let a session start walks the test straight
+        // out of the window it exists to cover: with a 250ms hold this arm passed even with the
+        // shield reverted, because the other rule had taken over by then.
         await page.mouse.move(endX, startY, {steps: 10});
 
         const activeDuringDrag = await page.evaluate(() => document.body.classList.contains('neo-drag-active'));
@@ -127,6 +199,15 @@ test.describe('DockSplitter — a drag whose path crosses an iframe', () => {
             {message: 'neo-drag-active outlived the gesture — the release never reached the sensor'}
         ).toBe(false);
 
+        // AC-1 is witnessed by the terminal above, not by splitter travel or a drag:move count.
+        //
+        // Both were tried and both are wrong instruments here. Travel is impossible: a standalone
+        // splitter has no siblings to resize. And the sensor's `drag:move` stream only exists once a
+        // session has been armed — which is precisely the state in which the DragZone rule already
+        // shields the page, so an arm that waits for the stream cannot fail on this defect. What the
+        // release proves is the property travel would only have proxied: the parent document still
+        // held the pointer after the crossing.
+        //
         // `neo-is-dragging` is deliberately NOT asserted here. It is a component cls owned by
         // `Neo.draggable.DragZone` in the App Worker, on a different drag family from the
         // sensor-driven splitter gesture this spec exercises, and this CSS shield does not touch its


### PR DESCRIPTION
Resolves #17883

A pointer drag crossing an iframe pane froze mid-gesture. Once the cursor is over an iframe, `mousemove` and `mouseup` are delivered to the **child** document, so the parent's sensor never observes the release: the splitter stops short, and the gesture class outlives the drag.

Found and root-caused by @neo-opus-vega in a private consumer workspace — the first dock consumer to put an editor iframe in a pane. @tobiu then hit it live (splitter over-drag into the editor iframe, freezing and sometimes recovering), which matches the mechanism: recovering means the pointer re-exited and hit-testing returned the stream.

Evidence: L3 — hit-tested browser gestures in the components suite, mutation-verified both ways. One residual and one bounded contract, both declared below.

## The fix extends an existing guard

`Global.scss:59` already consumes `neo-drag-active` as a gesture-scoped selection guard — `user-select: none`, so a drag across card content cannot become a text-selection sweep. `user-select` cannot cross into a nested browsing context, and neither can the parent's pointer stream. That guard always had this blind spot; selection was the less visible of the two behaviours a child document steals.

```scss
.neo-drag-active iframe:not(.neo-drag-passthrough) {
    pointer-events: none;
}
```

**The scope is load-bearing.** `pointer-events: none` also removes an element as a *native* drag-and-drop target, because the same hit-testing governs `dragover`/`drop`. The class is stamped only inside sensor-driven gestures and never for a native drag, so the shield cannot suppress a real HTML5 drop. @neo-opus-vega identified this while exploring native-DnD interop; it is now pinned by an arm, not just a comment.

## What Round 2's required witnesses changed

Writing the three witnesses @neo-gpt asked for changed what this PR claims. That is the point of them.

**The opt-out is real but bounded.** `neo-drag-passthrough` now has an arm — and writing it surfaced that `draggable/DragProxyComponent.scss` applies `body:has(.neo-is-dragging) * {pointer-events: none !important}` for the duration of a DragZone session. A universal selector carrying `!important` outranks any `:not()` here, so the escape hatch works through a sensor gesture and **does not survive a DragZone drag**. That is now written in the stylesheet and added to #17883's Contract Ledger as an explicit fallback, rather than left as an implied promise.

**AC-1's witness is the release, not splitter travel.** Two instruments were tried and both are wrong here. Travel is impossible — a standalone splitter has no siblings to resize. The sensor's `drag:move` stream is worse: it only exists once a session is armed, which is exactly when the DragZone rule already shields the page. Adding a 250ms hold to obtain that stream made the crossing arm **pass with the fix reverted**, because it had stepped out of the unguarded interval between mousedown and session start — the window this guard exists for. The hold is gone and the reasoning is in the spec header.

**The native partition has an arm.** A native `dragstart` must not stamp the gesture class; a future change that stamps there fails the arm.

## AC Evidence

| AC | Proof |
|---|---|
| gesture completes across an iframe | hit-tested `page.mouse` drag whose path provably intersects the iframe; the gesture reaches its terminal |
| class cleared after the drag | `neo-drag-active` absent after `mouseup`, polled and asserted directly |
| opt-out works | `neo-drag-passthrough` iframe measured against a plain one under the same class — shielded vs interactive |
| opt-out's limit | bounded by the DragZone rule; recorded in the stylesheet and the ticket ledger |
| native drags do not stamp the shield | dispatched `dragstart`, class asserted absent before and after |
| drag families enumerated | `neo-drag-active` is added in exactly one place, `sensor/Mouse.mjs:160`; recorded on the ticket with the open touch question, now owned by #17889 |
| coverage is hit-tested | `page.mouse`, deliberately — an `EventSimulator` arm cannot fail on this defect |

## Test Evidence

**Mutation-verified at the committed head.** With the shield reverted, two arms go red: the opt-out arm, and the crossing arm at **5.2s versus 0.36s green** — a real hang, failing on the gesture terminal rather than on a stylesheet assertion.

**Components suite: 106 passed.**

The spec's own history is part of its value. Its first version dragged a path that missed the iframe entirely and passed with the fix reverted; the path intersection is now an explicit precondition. Its second read a stale reused node; it now waits on the per-edge class.

## Residuals

**One, declared.** `.neo-is-dragging` does not clear after this drag on CI while it does locally, through a full 5s poll. It is a component cls owned by `Neo.draggable.DragZone` in the App Worker, on a different drag family, and this CSS shield neither causes nor repairs its lifecycle. The earlier version of this body claimed "zero `.neo-is-dragging` elements remain" as AC evidence; exact-head CI disproved that, the assertion was removed, and the behaviour is captured as a standing defect-note. #17889 owns the structural fix.

## Deltas from ticket

- **Narrower than the original sketch.** `Touch.mjs` is a full parallel drag path that never stamps the class, but touch events have implicit capture, so the omission is probably correct rather than a gap. Spec-derived, not measured; recorded on #17883 and subsumed by #17889.
- **Terminal hygiene folded in** rather than separated: both reported symptoms stem from the same lost release.

## Out of Scope

- Cross-**window** drag (#17578); the DockLayouts rebuild (#17836); the Pointer Events migration (#17889).
- Any change to the `user-select` half of the guard.

## Commits

- `fix(draggable): shield iframes for the duration of a synthetic drag (#17883)`
- `test(draggable): poll the worker-owned class instead of racing it (#17883)`
- `fix(draggable): restore the iframe shield my own mutation test deleted (#17883)`
- `test(draggable): scope the arm to this gesture's own terminal (#17883)`
- `test(draggable): witness the opt-out and native partition, and keep the arm in its window (#17883)`

Authored by Grace (Claude Opus 5, Claude Code) 🖖
