### PR TITLE
test(dashboard): read the drop overlay's computed colour, not its stylesheet (#17890)

### DIFF
--- a/test/playwright/component/dashboard/DockPreviewRegionRender.spec.mjs
+++ b/test/playwright/component/dashboard/DockPreviewRegionRender.spec.mjs
@@ -11,18 +11,19 @@ import {test, expect} from '@playwright/test';
  * test that reads its own SCSS cannot observe what a browser composites, which is how an edge that
  * paints far darker than its siblings shipped with everything green.
  *
- * So this mounts the real renderer, drives one affordance per edge through the real config, and
- * reads COMPUTED style off the produced node. Colour is the property under test; geometry is
- * asserted only enough to prove each edge actually painted the band it claims.
+ * So this mounts the real renderer, drives one affordance per edge and both split positions through
+ * the real config, and reads COMPUTED style off the produced node.
+ *
+ * **Colour is the whole subject; geometry is deliberately NOT asserted.** Placement comes from
+ * `applyTargetGeometry`, which is a method rather than a remote config and so cannot be driven over
+ * RMA — an earlier revision carried a target rect, a viewport id and a returned `rect` that nothing
+ * ever read. Dead witnesses are worse than absent ones: they read as coverage. The pure geometry
+ * contract is a unit concern and is tested there.
  */
 
-const
-    EDGES  = ['top', 'right', 'bottom', 'left'],
-    // A deliberately non-square target: a square one would hide any axis-dependent defect, since
-    // width and height would be interchangeable.
-    TARGET = {x: 0, y: 0, width: 800, height: 400};
+const EDGES = ['top', 'right', 'bottom', 'left'];
 
-let previewId, viewportId;
+let previewId;
 
 const buildPreview = kind => ({
     schema   : 'neo.dock.preview.v1',
@@ -37,8 +38,6 @@ const buildPreview = kind => ({
 test.beforeEach(async ({page}) => {
     await page.goto('test/playwright/component/apps/dock-splitter/index.html');
     await page.waitForSelector('#dock-splitter-test-viewport', {state: 'attached'});
-
-    viewportId = 'dock-splitter-test-viewport';
 
     previewId = await page.evaluate(async () => {
         const preview = await Neo.worker.App.createNeoInstance({
@@ -81,8 +80,7 @@ const renderEdge = async (page, edge) => {
 
         if (!node) return {missing: true};
 
-        const s = getComputedStyle(node),
-              r = node.getBoundingClientRect();
+        const s = getComputedStyle(node);
 
         return {
             background  : s.backgroundColor,
@@ -91,8 +89,7 @@ const renderEdge = async (page, edge) => {
             borderBottom: {width: s.borderBottomWidth, color: s.borderBottomColor},
             borderLeft  : {width: s.borderLeftWidth,   color: s.borderLeftColor},
             opacity     : s.opacity,
-            cls         : node.className,
-            rect        : {width: Math.round(r.width), height: Math.round(r.height)}
+            cls         : node.className
         }
     })
 };
@@ -141,16 +138,33 @@ test.describe('Neo.dashboard.dock.interaction.Preview — what each edge region 
         expect(fill, 'the fill must not be transparent').not.toMatch(/rgba\(0, 0, 0, 0\)|transparent/);
         expect(fill, 'the fill must carry alpha — an opaque fill is the reported defect').toMatch(/rgba\([^)]+,\s*0?\.\d+\)/);
 
-        // Border colour is shared; only ONE side per edge may be thicker (the cut side).
-        for (const edge of EDGES) {
+        // Border, compared ACROSS edges — not merely within each one.
+        //
+        // An earlier revision asserted only that the four SIDES of a given edge shared a colour and
+        // that exactly one was thicker. Every edge could satisfy that independently while differing
+        // from its siblings: a right-only border colour, or a base/cut width that changes with the
+        // axis, stayed green. AC-1 asks for equality across edges, so the per-edge facts are reduced
+        // to one normalized signature and the SIGNATURES are compared.
+        const signatures = EDGES.map(edge => {
             const r      = rendered[edge],
-                  widths = [r.borderTop.width, r.borderRight.width, r.borderBottom.width, r.borderLeft.width],
-                  thick  = widths.filter(w => parseFloat(w) > 2);
+                  sides  = [r.borderTop, r.borderRight, r.borderBottom, r.borderLeft],
+                  widths = sides.map(side => parseFloat(side.width)),
+                  cut    = widths.filter(width => width > 2),
+                  base   = widths.filter(width => width <= 2),
+                  colors = new Set(sides.map(side => side.color));
 
-            expect(thick, `${edge}: exactly one border side may carry the cut accent`).toHaveLength(1);
-            expect(new Set([r.borderTop.color, r.borderRight.color, r.borderBottom.color, r.borderLeft.color]).size,
-                `${edge}: all four border colours must match`).toBe(1)
-        }
+            // Structure first: exactly one cut side, three base sides, one shared colour. Without
+            // this the reduction below could collapse a genuinely broken edge into a tidy signature.
+            expect(cut,      `${edge}: exactly one border side may carry the cut accent`).toHaveLength(1);
+            expect(base,     `${edge}: the other three sides must stay at the base width`).toHaveLength(3);
+            expect(colors.size, `${edge}: all four border colours must match`).toBe(1);
+            expect(new Set(base).size, `${edge}: the three base sides must share one width`).toBe(1);
+
+            return `${[...colors][0]}|base:${base[0]}|cut:${cut[0]}`
+        });
+
+        expect(new Set(signatures).size,
+            `border signature must be identical across edges, got ${JSON.stringify(signatures)}`).toBe(1);
 
         // Opacity is a multiplier on the whole overlay; an edge-dependent value would darken one axis.
         expect(new Set(EDGES.map(e => rendered[e].opacity)).size, 'opacity must not vary by edge').toBe(1)
@@ -161,17 +175,23 @@ test.describe('Neo.dashboard.dock.interaction.Preview — what each edge region 
         // as a SOLID background — correct for a thin insertion guide, and exactly what "the border
         // colour with no transparency" looks like if a region-mode split ever reaches it. Region
         // mode is the default, so a split must land in the translucent family with the edges.
-        const edge  = await renderEdge(page, 'top'),
-              split = await renderSplit(page, 'before');
+        const edge = await renderEdge(page, 'top');
 
-        expect(split.missing, 'a split affordance must render').toBeFalsy();
+        // BOTH positions, not one. `before` and `after` take different branches in
+        // `affordanceGeometry` and carry inverted cut sides, so proving one says nothing about the
+        // other — and `after` is the branch a right-hand drop actually produces.
+        for (const position of ['before', 'after']) {
+            const split = await renderSplit(page, position);
 
-        // The PAINT is asserted before the class that routes it. Ordered the other way, a mutant
-        // that drops the region class fails on the class line and the colour assertion never runs —
-        // red for the adjacent reason, leaving the property actually under test unproven.
-        expect(split.background, 'a region-mode split must not paint the solid accent bar').toBe(edge.background);
-        expect(split.background, 'the split fill must carry alpha').toMatch(/rgba\([^)]+,\s*0?\.\d+\)/);
-        expect(split.cls, 'a split in region mode must carry the region class').toContain('neo-dock-preview-region')
+            expect(split.missing, `split-${position}: an affordance must render`).toBeFalsy();
+
+            // The PAINT is asserted before the class that routes it. Ordered the other way, a mutant
+            // that drops the region class fails on the class line and the colour assertion never runs —
+            // red for the adjacent reason, leaving the property actually under test unproven.
+            expect(split.background, `split-${position}: must not paint the solid accent bar`).toBe(edge.background);
+            expect(split.background, `split-${position}: the fill must carry alpha`).toMatch(/rgba\([^)]+,\s*0?\.\d+\)/);
+            expect(split.cls, `split-${position}: a region-mode split must carry the region class`).toContain('neo-dock-preview-region')
+        }
     });
 
     test('each edge carries its own kind and cut classes', async ({page}) => {

--- a/test/playwright/component/dashboard/DockPreviewRegionRender.spec.mjs
+++ b/test/playwright/component/dashboard/DockPreviewRegionRender.spec.mjs
@@ -1,0 +1,187 @@
+import {test, expect} from '@playwright/test';
+
+/**
+ * What a drop-preview region actually RENDERS, per edge (ticket-ref-ok: this is the enforcement AC
+ * for the left/right region-preview defect — the four edges must be visually equal apart from which
+ * side carries the thicker cut border).
+ *
+ * **Why this arm exists at all.** Three layers of coverage already touch this surface and none of
+ * them can fail on it: the e2e symmetry spec compares band *thicknesses*, the unit spec asserts the
+ * *stylesheet as source text* (`readFileSync` + `toContain`), and neither renders an affordance. A
+ * test that reads its own SCSS cannot observe what a browser composites, which is how an edge that
+ * paints far darker than its siblings shipped with everything green.
+ *
+ * So this mounts the real renderer, drives one affordance per edge through the real config, and
+ * reads COMPUTED style off the produced node. Colour is the property under test; geometry is
+ * asserted only enough to prove each edge actually painted the band it claims.
+ */
+
+const
+    EDGES  = ['top', 'right', 'bottom', 'left'],
+    // A deliberately non-square target: a square one would hide any axis-dependent defect, since
+    // width and height would be interchangeable.
+    TARGET = {x: 0, y: 0, width: 800, height: 400};
+
+let previewId, viewportId;
+
+const buildPreview = kind => ({
+    schema   : 'neo.dock.preview.v1',
+    previewId: `preview:probe:main-tabs:${kind}`,
+    itemId   : 'probe-item',
+    source   : {surface: 'dashboard-sort-zone', sortZoneId: 'probe-zone'},
+    target   : {containerId: 'workspace', nodeId: 'main-tabs'},
+    placement: {kind, ratio: 0.5},
+    feedback : {state: 'accepted'}
+});
+
+test.beforeEach(async ({page}) => {
+    await page.goto('test/playwright/component/apps/dock-splitter/index.html');
+    await page.waitForSelector('#dock-splitter-test-viewport', {state: 'attached'});
+
+    viewportId = 'dock-splitter-test-viewport';
+
+    previewId = await page.evaluate(async () => {
+        const preview = await Neo.worker.App.createNeoInstance({
+            importPath: '../dashboard/dock/interaction/Preview.mjs',
+            ntype     : 'dock-preview',
+            parentId  : 'dock-splitter-test-viewport'
+        });
+
+        if (!preview.success) throw new Error(`preview: ${preview.error.message}`);
+
+        return preview.id
+    });
+
+    expect(previewId, 'the preview renderer must mount').toBeTruthy()
+});
+
+test.afterEach(async ({page}) => {
+    await page.evaluate(async id => { id && await Neo.worker.App.destroyNeoInstance(id) }, previewId)
+});
+
+/**
+ * Renders one edge affordance and reads back what the browser computed for it.
+ *
+ * The instance lives in the App Worker, so the config is set over RMA rather than by reaching for
+ * `Neo.get` on the main thread — which does not exist there. Geometry is deliberately NOT driven
+ * here: `applyTargetGeometry` is a method, not a remote config, and the fill/border/opacity under
+ * test are decided by the class set alone. The pure geometry contract is a unit concern.
+ */
+const renderEdge = async (page, edge) => {
+    await page.evaluate(([id, previewObj]) => Neo.worker.App.setConfigs({id, dockPreview: previewObj}),
+        [previewId, buildPreview(`edge-${edge}`)]);
+
+    // Wait for THIS edge's class, not merely for a node to exist. The node is reused across
+    // renders, so `waitForSelector` on the generic class returns the PREVIOUS edge's node
+    // immediately and every subsequent read is a stale one.
+    await page.waitForSelector(`.neo-dock-preview-edge-${edge}`, {state: 'attached', timeout: 4000});
+
+    return page.evaluate(() => {
+        const node = document.querySelector('.neo-dock-preview-affordance');
+
+        if (!node) return {missing: true};
+
+        const s = getComputedStyle(node),
+              r = node.getBoundingClientRect();
+
+        return {
+            background  : s.backgroundColor,
+            borderTop   : {width: s.borderTopWidth,    color: s.borderTopColor},
+            borderRight : {width: s.borderRightWidth,  color: s.borderRightColor},
+            borderBottom: {width: s.borderBottomWidth, color: s.borderBottomColor},
+            borderLeft  : {width: s.borderLeftWidth,   color: s.borderLeftColor},
+            opacity     : s.opacity,
+            cls         : node.className,
+            rect        : {width: Math.round(r.width), height: Math.round(r.height)}
+        }
+    })
+};
+
+/** The split-group sibling of {@link renderEdge}; `orientation` decides the split axis. */
+const renderSplit = async (page, position, orientation = 'horizontal') => {
+    const kind = `split-${position}`;
+
+    await page.evaluate(([id, previewObj]) => Neo.worker.App.setConfigs({id, dockPreview: previewObj}), [previewId, {
+        ...buildPreview(kind),
+        placement: {kind, orientation, ratio: 0.5}
+    }]);
+
+    await page.waitForSelector(`.neo-dock-preview-${kind}`, {state: 'attached', timeout: 4000});
+
+    return page.evaluate(() => {
+        const node = document.querySelector('.neo-dock-preview-affordance');
+
+        if (!node) return {missing: true};
+
+        const s = getComputedStyle(node);
+
+        return {background: s.backgroundColor, opacity: s.opacity, cls: node.className}
+    })
+};
+
+test.describe('Neo.dashboard.dock.interaction.Preview — what each edge region paints', () => {
+    test('every edge paints the same translucent fill — only the cut border differs', async ({page}) => {
+        const rendered = {};
+
+        for (const edge of EDGES) {
+            rendered[edge] = await renderEdge(page, edge);
+            expect(rendered[edge].missing, `${edge}: an affordance node must be rendered`).toBeFalsy()
+        }
+
+        // The property the defect reports: one edge reading far darker than its siblings. A fill
+        // that differs between edges IS the bug, whatever produced it.
+        const fills = EDGES.map(e => rendered[e].background);
+
+        expect(new Set(fills).size, `fills must be identical across edges, got ${JSON.stringify(fills)}`).toBe(1);
+
+        // Non-vacuity: a transparent fill everywhere would also collapse to one value while
+        // rendering nothing. Pin that the fill is a real translucent colour.
+        const fill = fills[0];
+
+        expect(fill, 'the fill must not be transparent').not.toMatch(/rgba\(0, 0, 0, 0\)|transparent/);
+        expect(fill, 'the fill must carry alpha — an opaque fill is the reported defect').toMatch(/rgba\([^)]+,\s*0?\.\d+\)/);
+
+        // Border colour is shared; only ONE side per edge may be thicker (the cut side).
+        for (const edge of EDGES) {
+            const r      = rendered[edge],
+                  widths = [r.borderTop.width, r.borderRight.width, r.borderBottom.width, r.borderLeft.width],
+                  thick  = widths.filter(w => parseFloat(w) > 2);
+
+            expect(thick, `${edge}: exactly one border side may carry the cut accent`).toHaveLength(1);
+            expect(new Set([r.borderTop.color, r.borderRight.color, r.borderBottom.color, r.borderLeft.color]).size,
+                `${edge}: all four border colours must match`).toBe(1)
+        }
+
+        // Opacity is a multiplier on the whole overlay; an edge-dependent value would darken one axis.
+        expect(new Set(EDGES.map(e => rendered[e].opacity)).size, 'opacity must not vary by edge').toBe(1)
+    });
+
+    test('a split placement paints the same translucent region, not the solid insertion bar', async ({page}) => {
+        // The `.neo-dock-preview-split:not(.neo-dock-preview-region)` rule paints the accent colour
+        // as a SOLID background — correct for a thin insertion guide, and exactly what "the border
+        // colour with no transparency" looks like if a region-mode split ever reaches it. Region
+        // mode is the default, so a split must land in the translucent family with the edges.
+        const edge  = await renderEdge(page, 'top'),
+              split = await renderSplit(page, 'before');
+
+        expect(split.missing, 'a split affordance must render').toBeFalsy();
+        expect(split.cls, 'a split in region mode must carry the region class').toContain('neo-dock-preview-region');
+        expect(split.background, 'a region-mode split must not paint the solid accent bar').toBe(edge.background);
+        expect(split.background, 'the split fill must carry alpha').toMatch(/rgba\([^)]+,\s*0?\.\d+\)/)
+    });
+
+    test('each edge carries its own kind and cut classes', async ({page}) => {
+        // Guards the fill assertions above: identical colours read off a node that never received
+        // the per-edge classes would be a green that means nothing. The cut side is the INVERSE of
+        // the edge — a left region's inner boundary is on its right.
+        const inverse = {top: 'bottom', bottom: 'top', left: 'right', right: 'left'};
+
+        for (const edge of EDGES) {
+            const {cls} = await renderEdge(page, edge);
+
+            expect(cls, `${edge}: the region mode class must be present`).toContain('neo-dock-preview-region');
+            expect(cls, `${edge}: the per-edge kind class must be present`).toContain(`neo-dock-preview-edge-${edge}`);
+            expect(cls, `${edge}: the cut side must be the inner edge`).toContain(`neo-dock-preview-cut-${inverse[edge]}`)
+        }
+    })
+});

--- a/test/playwright/component/dashboard/DockPreviewRegionRender.spec.mjs
+++ b/test/playwright/component/dashboard/DockPreviewRegionRender.spec.mjs
@@ -165,9 +165,13 @@ test.describe('Neo.dashboard.dock.interaction.Preview — what each edge region 
               split = await renderSplit(page, 'before');
 
         expect(split.missing, 'a split affordance must render').toBeFalsy();
-        expect(split.cls, 'a split in region mode must carry the region class').toContain('neo-dock-preview-region');
+
+        // The PAINT is asserted before the class that routes it. Ordered the other way, a mutant
+        // that drops the region class fails on the class line and the colour assertion never runs —
+        // red for the adjacent reason, leaving the property actually under test unproven.
         expect(split.background, 'a region-mode split must not paint the solid accent bar').toBe(edge.background);
-        expect(split.background, 'the split fill must carry alpha').toMatch(/rgba\([^)]+,\s*0?\.\d+\)/)
+        expect(split.background, 'the split fill must carry alpha').toMatch(/rgba\([^)]+,\s*0?\.\d+\)/);
+        expect(split.cls, 'a split in region mode must carry the region class').toContain('neo-dock-preview-region')
     });
 
     test('each edge carries its own kind and cut classes', async ({page}) => {


### PR DESCRIPTION
Resolves #17890

Adds the first arm anywhere in the suite that renders a drop affordance and reads a **computed colour**.

Evidence: L3 (component suite, real Chromium, real renderer mounted through the App worker, computed style read off the produced node) → L3 required (all close-target ACs). No residuals.

## Why this arm exists

Three layers already touch this surface and **none can fail on it**:

| layer | asserts | why it cannot fail |
|---|---|---|
| `test/playwright/e2e/**` | — | e2e runs in **no workflow** (#17853, closed `NOT_PLANNED`) |
| `WorkstationDockPreviewSymmetryNL.spec.mjs` | the four band *thicknesses* | geometry only — blind to fill and opacity |
| `unit/dashboard/DockPreview.spec.mjs` | `readFileSync(Preview.scss)` + `toContain` | the stylesheet as **source text** |

A test that greps its own SCSS never observes what a browser composites. This mounts the real `dock-preview` renderer, drives one affordance per edge **and both split positions** through the real config over RMA, and reads computed style off the produced node.

## Test Evidence

`npm run test-components -- dashboard/DockPreviewRegionRender` → **3 passed**, green at exact head against current `dev`.

**Mutation 1 — the four-edge equality arm (edge-specific).** `.neo-dock-preview-cut-right` widened `4px → 6px`, which changes exactly one edge (the left region's cut side is its right boundary):

```
Error: border signature must be identical across edges, got
["rgb(94, 234, 212)|base:2|cut:4", "…|cut:4", "…|cut:4", "…|cut:6"]
Expected: 1   Received: 2
```

Red on the cross-edge assertion, and the other two arms stayed green — so the mutant is specific to the arm it proves. **The previous revision of this spec would have passed it**, because it compared the four sides *within* each edge and never the edges to each other.

**Mutation 2 — the split arm.** Narrowing `getAffordanceVdom`'s region predicate to `group === 'edge'` drops a region-mode split into the solid-bar family:

```
Expected: "rgba(94, 234, 212, 0.2)"   Received: "rgb(94, 234, 212)"
```

Both mutations reverted with `git restore --staged --worktree`; `git diff --cached` empty and the suite green again before push.

The second commit exists because the first ordering asserted the **class** before the **paint**: the mutant went red on the routing mechanism and the colour assertion never executed — red for the adjacent reason.

## AC Evidence (against the restated #17890)

- **AC-1** ✅ computed fill, **border, and opacity compared across edges**. Each edge reduces to one normalized signature — shared colour, base width, cut width — and the signatures are compared. Per-edge structure (exactly one cut side, three base sides, one colour) is asserted first, so a broken edge cannot collapse into a tidy signature.
- **AC-2** ✅ non-vacuous, with an **edge-specific** mutant for the cross-edge arm and a separate mutant for the split arm. Also pins that the fill is neither transparent nor opaque, and that each node received its per-edge `kind` and inverted `cut-` classes.
- **AC-3** ✅ (restated) held-drag measurement taken and recorded on #17890 — one held drag, all nine zones sampled with `getComputedStyle` while the button was down.
- **AC-4** ✅ (restated) root-caused, no code fix required — see below.
- **AC-5** ✅ the e2e colour blind spot is explicitly recorded as owned by this component arm, in the spec header.

## What the reported defect actually was — and what this PR does *not* claim

The left/right overlays rendered as a solid accent block because the browser ran **new JS against a stale compiled theme CSS**. `60592e6a85` (08-30 08:43) added the `region` class plus the `:not(.neo-dock-preview-region)` guard *and* changed split geometry from a 6px line to a half-pane region; the report came against a `dist/` built before it. Under the pre-commit stylesheet `.neo-dock-preview-split` painted a solid accent with no guard, so `edge` and `tab-into` stayed translucent while `split` went solid — zone for zone, the report. A theme rebuild fixed it; **no code defect exists and none is fixed here.**

**This arm would not have caught that**, because the components suite builds its own CSS — `playwright.config.component.mjs` runs `e2e/globalSetup.mjs`, which calls `ensureDevelopmentThemeAssets()`. Stating it explicitly so the coverage is not read as protection it does not provide.

#17900 / PR #17902 (`npm run check-themes`) is **standalone stale-build detection** for that class — a command that answers whether built theme CSS trails its SCSS. It deliberately does **not** rebuild automatically and does not wire the check into any suite; both are listed as out of scope on that ticket.

## Deltas from ticket

#17890's AC-3 and AC-4 were **restated** before this PR claims them, because as written they presumed a code defect that does not exist. Both originals are struck through in the ticket with what actually satisfied them; nothing was quietly dropped. A `Related` downgrade would not have been honest — the ticket's premise needed correcting, not its link type.

## Out of Scope

- Wiring e2e into CI — #17853, closed `NOT_PLANNED`; an accepted state, not this PR's to change.
- The latent `:not(...)` selector-binding trap (`tab-before`/`tab-after` are unguarded because the `:not()` binds to the first selector only) — real, recorded on #17890, and needs its own leaf rather than riding this one to green.
- Geometry assertions. `applyTargetGeometry` is a method rather than a remote config and cannot be driven over RMA; an earlier revision carried a target rect, a viewport id and a returned rect that nothing read. Those dead witnesses are removed rather than left reading as coverage.
- #17889 (Pointer Events migration), #17883 (iframe drag freeze).

## Post-Merge Validation

None — every close-target AC is observed pre-merge in the component suite, which runs in CI.

Authored by Grace (Anthropic Claude Opus 5, Claude Code). Session 56bc214a-5b55-41a2-848a-cdfa372abbcd.
