### PR TITLE
fix(worker): dead-port and stylesheet rejections carry a typed reason (#17894)

### DIFF
--- a/src/draggable/DragZone.mjs
+++ b/src/draggable/DragZone.mjs
@@ -438,11 +438,11 @@ class DragZone extends Base {
             .then(() => Neo.applyDeltas(windowId, [{action: 'removeNode', id}]))
             .catch(reason => {
                 // The dispatch owns its terminal outcome: worker.Base's closed-port branch
-                // rejects with bare `undefined` when the destination window is already gone —
-                // the node died with its window, the cleanup is moot, settle silently. A
-                // REASONED rejection is a live-window delta failure; this detached chain has
-                // no caller to propagate to, so the console is the honest terminal surface.
-                reason !== undefined && console.error('DragZone: proxy removal delta failed', {id, reason, windowId})
+                // rejects with `code: 'NEO_DEAD_PORT'` when the destination window is already
+                // gone — the node died with its window, the cleanup is moot, settle silently.
+                // Every other rejection is a live-window delta failure; this detached chain
+                // has no caller to propagate to, so the console is the honest terminal surface.
+                reason?.code !== 'NEO_DEAD_PORT' && console.error('DragZone: proxy removal delta failed', {id, reason, windowId})
             });
 
         me.dragProxy.destroy()

--- a/src/main/addon/Stylesheet.mjs
+++ b/src/main/addon/Stylesheet.mjs
@@ -150,7 +150,7 @@ class Stylesheet extends Base {
                 link.id = id
             }
 
-            link.addEventListener('error', function() {reject()})
+            link.addEventListener('error', function() {reject(new Error(`Stylesheet failed to load: ${url}`))})
             link.addEventListener('load',  function() {resolve()})
 
             document.head.appendChild(link)

--- a/src/worker/Base.mjs
+++ b/src/worker/Base.mjs
@@ -407,8 +407,16 @@ class Worker extends Base {
                 msgId   = message?.id;
 
             if (!msgId) {
-                // a window got closed and the message port no longer exist (SharedWorkers)
-                reject()
+                // A window got closed and its message port no longer exists (SharedWorkers).
+                // Typed, so consumers can discriminate expected teardown from real failures
+                // (see draggable.DragZone#destroyDragProxy); the message carries the routing
+                // context because envelope forwarding may preserve only the string.
+                const remote = opts.remoteClassName ? ` ${opts.remoteClassName}.${opts.remoteMethod}` : '';
+
+                reject(Object.assign(
+                    new Error(`worker.Base#promiseMessage: no live port for destination "${dest}" (${opts.action}${remote}) — a window closed?`),
+                    {code: 'NEO_DEAD_PORT'}
+                ))
             } else {
                 me.promises[msgId] = {
                     portEntry: message.port ? me.getPort({id: message.port}) : null,

--- a/test/playwright/unit/draggable/DragZone.spec.mjs
+++ b/test/playwright/unit/draggable/DragZone.spec.mjs
@@ -23,7 +23,7 @@ import '../../../../src/manager/Instance.mjs';
  * @param {Object} [options]
  * @param {Function} [options.deltaResult] Maps a recorded call to the spy's returned promise —
  *     the seam for simulating the transport's terminal outcomes (a vanished destination rejects
- *     with bare `undefined`; live-window failures reject with a reason).
+ *     with `code: 'NEO_DEAD_PORT'`; live-window failures reject with any other reason).
  * @returns {Promise<{proxyId: String, recorded: Object[]}>}
  */
 async function recordProxyRemoval(scenario, {deltaResult}={}) {
@@ -132,19 +132,61 @@ test.describe('Neo.draggable.DragZone', () => {
     });
 
     test('a vanished destination settles silently — the closed-port rejection is owned, not unhandled', async () => {
-        // worker.Base's closed-port branch rejects the request promise with bare `undefined`
-        // (a vanished SharedWorker port). The detached teardown chain must observe that terminal
-        // outcome: an unowned rejection escapes as unhandledRejection, which this runner converts
-        // into a test failure — the unrepaired chain fails this test by construction.
-        const {recorded} = await recordProxyRemoval(zone => {
-            zone.destroyDragProxy();
-            zone.destroy();
-            return Promise.resolve()
-        }, {
-            deltaResult: () => Promise.reject(undefined)
-        });
+        // worker.Base's closed-port branch rejects the request promise with a typed reason,
+        // `code: 'NEO_DEAD_PORT'`. The detached teardown chain must observe that
+        // terminal outcome silently on BOTH surfaces: an unowned rejection escapes as
+        // unhandledRejection (which this runner converts into a test failure), and a
+        // misclassified one would surface through console.error.
+        const
+            originalConsoleError = console.error,
+            surfaced             = [];
 
-        expect(recorded, 'the dispatch is still attempted at the vanished destination').toHaveLength(1)
+        console.error = (...args) => surfaced.push(args);
+
+        let outcome;
+
+        try {
+            outcome = await recordProxyRemoval(zone => {
+                zone.destroyDragProxy();
+                zone.destroy();
+                return Promise.resolve()
+            }, {
+                deltaResult: () => Promise.reject(Object.assign(new Error('no live port for destination "main"'), {code: 'NEO_DEAD_PORT'}))
+            })
+        } finally {
+            console.error = originalConsoleError
+        }
+
+        expect(outcome.recorded, 'the dispatch is still attempted at the vanished destination').toHaveLength(1);
+        expect(surfaced, 'expected teardown must not be logged as a failure').toHaveLength(0)
+    });
+
+    test('a reasonless rejection is no longer classified as teardown — it surfaces', async () => {
+        // The historical confusable: the closed-port branch used to reject with bare
+        // `undefined`, and this seam treated ANY reasonless rejection as expected teardown.
+        // The discrimination now keys on the typed code, so an unexplained failure surfaces
+        // instead of vanishing into the teardown classification.
+        const
+            originalConsoleError = console.error,
+            surfaced             = [];
+
+        console.error = (...args) => surfaced.push(args);
+
+        let outcome;
+
+        try {
+            outcome = await recordProxyRemoval(zone => {
+                zone.destroyDragProxy();
+                return Promise.resolve()
+            }, {
+                deltaResult: () => Promise.reject(undefined)
+            })
+        } finally {
+            console.error = originalConsoleError
+        }
+
+        expect(outcome.recorded).toHaveLength(1);
+        expect(surfaced, 'a reasonless rejection surfaces exactly once').toHaveLength(1)
     });
 
     test('a reasoned delta failure in a live window stays visible instead of being swallowed', async () => {

--- a/test/playwright/unit/main/addon/Stylesheet.spec.mjs
+++ b/test/playwright/unit/main/addon/Stylesheet.spec.mjs
@@ -1,0 +1,94 @@
+import {setup} from '../../../setup.mjs';
+
+setup({
+    appConfig       : {name: 'MainStylesheetUnit'},
+    mockLocalStorage: false,
+    mockMain        : false,
+    neoConfig       : {unitTestMode: true}
+});
+
+import {test, expect} from '@playwright/test';
+import Neo            from '../../../../../src/Neo.mjs';
+import * as core      from '../../../../../src/core/_export.mjs';
+
+/*
+    The harness installs a Neo.main.addon.Stylesheet STUB (setup.mjs, `??=`) for component
+    composition, and unitTestMode's namespace guard throws when the real class registers into an
+    occupied slot. Worker processes share files, so whether the stub is already there depends on
+    file ordering — clear the slot for the real import, and restore whatever occupied it in
+    afterAll so sibling files keep the harness contract they set up.
+*/
+const previousSlot = Neo.main?.addon?.Stylesheet;
+
+previousSlot && delete Neo.main.addon.Stylesheet;
+
+const {default: Stylesheet} = await import('../../../../../src/main/addon/Stylesheet.mjs');
+
+const
+    originalDocument = globalThis.document,
+    documentRef      = new EventTarget(),
+    createdLinks     = [];
+
+// real EventTargets so the spec drives the addon's own listeners through genuine dispatch
+documentRef.createElement = () => {
+    const link = new EventTarget();
+
+    createdLinks.push(link);
+    return link
+};
+documentRef.head    = {appendChild: () => {}};
+globalThis.document = documentRef;
+
+/**
+ * @summary The settlement contract of `createStyleSheet`: a load failure must NAME its href.
+ *
+ * The error listener used to reject bare, so a 404'd theme file surfaced as
+ * `unhandled rejection: undefined` — reasonless at every consumer. Both settlement paths are
+ * driven through the link's real event dispatch so the instrument owns the seam it certifies.
+ */
+test.describe('Neo.main.addon.Stylesheet#createStyleSheet', () => {
+    // Direct prototype invocation: the method reads only `document` and `Neo.config`, while the
+    // addon's construct runs the full theme bootstrap, which needs a real app environment. The
+    // seam under test is the method's settlement contract, not the boot sequence.
+    const createStyleSheet = data => Stylesheet.prototype.createStyleSheet.call(null, data);
+
+    test.beforeEach(() => {
+        // Re-assert the stub: under fully-parallel CI a sibling spec's teardown can delete the
+        // global between this file's tests — module-level assignment alone only survives
+        // single-worker ordering.
+        globalThis.document = documentRef
+    });
+
+    test.afterEach(() => {
+        createdLinks.length = 0
+    });
+
+    test.afterAll(() => {
+        originalDocument === undefined ? delete globalThis.document : globalThis.document = originalDocument;
+        previousSlot && (Neo.main.addon.Stylesheet = previousSlot)
+    });
+
+    test('a failed load rejects with an Error naming the requested href', async () => {
+        const
+            href    = 'https://cdn.test/theme-neo-dark.css',
+            promise = createStyleSheet({href}),
+            link    = createdLinks.at(-1);
+
+        expect(link.href).toBe(href);
+
+        link.dispatchEvent(new Event('error'));
+
+        const reason = await promise.catch(e => e);
+
+        expect(reason).toBeInstanceOf(Error);
+        expect(reason.message).toContain(href)
+    });
+
+    test('the positive control: a successful load resolves', async () => {
+        const promise = createStyleSheet({href: 'https://cdn.test/theme-neo-light.css'});
+
+        createdLinks.at(-1).dispatchEvent(new Event('load'));
+
+        await expect(promise).resolves.toBeUndefined()
+    });
+});

--- a/test/playwright/unit/worker/Base.spec.mjs
+++ b/test/playwright/unit/worker/Base.spec.mjs
@@ -1,0 +1,82 @@
+import {setup} from '../../setup.mjs';
+
+setup({
+    appConfig: {
+        name: 'WorkerBaseTest'
+    }
+});
+
+import {test, expect} from '@playwright/test';
+import Neo            from '../../../../src/Neo.mjs';
+import * as core      from '../../../../src/core/_export.mjs';
+import WorkerBase     from '../../../../src/worker/Base.mjs';
+
+/**
+ * @summary The dead-port rejection contract of `worker.Base#promiseMessage`.
+ *
+ * When `sendMessage` resolves no live port (a window closed; SharedWorkers), the returned
+ * promise must reject with a TYPED reason — `code: 'NEO_DEAD_PORT'` — whose message names the
+ * destination and, for remote-method calls, the remote target. Both halves are load-bearing:
+ *
+ * 1. The `code` is the machine discriminator: `draggable.DragZone#destroyDragProxy` settles
+ *    closed-window teardown silently on exactly this code (its own spec pins that seam).
+ * 2. The message context is the human/log surface: an app-level `unhandledrejection` logger
+ *    previously printed `undefined` with no way to name the caller — the field defect.
+ *
+ * The message duplicates the discriminator's meaning ("no live port") because envelope
+ * forwarding between realms may preserve only the string.
+ */
+class DeadPortWorker extends WorkerBase {
+    static config = {
+        className: 'Test.Unit.Worker.DeadPortWorker'
+    }
+
+    construct(config) {
+        super.construct(config);
+        // Simulate the SharedWorker environment BEFORE onConstructed() runs, so the
+        // dedicated-worker 'workerConstructed' announcement (which needs a main thread)
+        // never fires inside the single-threaded unit env.
+        this.isSharedWorker = true
+    }
+}
+Neo.setupClass(DeadPortWorker);
+
+test.describe('worker.Base#promiseMessage dead-port rejection (#17894)', () => {
+    let worker;
+
+    test.beforeEach(() => {
+        // No ports at all: every keyed route resolves nothing, sendMessage returns undefined
+        // without throwing (the contract ReplyLoss.spec pins), and the dead-port branch fires.
+        worker = Neo.create(DeadPortWorker, {workerId: 'dead-port-test'})
+    });
+
+    test.afterEach(() => {
+        worker.destroy?.()
+    });
+
+    test('the rejection is a typed Error naming the destination and action', async () => {
+        const reason = await worker
+            .promiseMessage('app', {action: 'loadApplication', windowId: 'win-404'})
+            .catch(e => e);
+
+        expect(reason).toBeInstanceOf(Error);
+        expect(reason.code).toBe('NEO_DEAD_PORT');
+        expect(reason.message).toContain('no live port');
+        expect(reason.message).toContain('destination "app"');
+        expect(reason.message).toContain('loadApplication')
+    });
+
+    test('a remote-method call carries its remote target in the message', async () => {
+        const reason = await worker
+            .promiseMessage('app', {
+                action         : 'remoteMethod',
+                remoteClassName: 'Neo.main.addon.DockFlip',
+                remoteMethod   : 'captureFirst',
+                windowId       : 'win-404'
+            })
+            .catch(e => e);
+
+        expect(reason.code).toBe('NEO_DEAD_PORT');
+        expect(reason.message).toContain('Neo.main.addon.DockFlip.captureFirst')
+    });
+});


### PR DESCRIPTION
Resolves #17894

🌿 A closed window's silence now signs its name — a literal bare `reject()` is unsayable in `src/`.

## Summary

`worker.Base#promiseMessage`'s dead-port branch rejected bare — the field's `unhandled rejection: undefined`, with nothing to name the caller. But that bare `undefined` was also a load-bearing sentinel: `DragZone#destroyDragProxy` discriminates on it to settle closed-window proxy teardown silently. So the fix types the reason instead of merely adding one: `code: 'NEO_DEAD_PORT'` is the machine discriminator (DragZone migrates to it), and the message carries destination + action + remote target, because envelope forwarding may preserve only the string. The Stylesheet link-error reject — the only other bare reject in the tree — now names the failed href.

Deliberately disjoint from #17888 AC-4 (Manager envelope, @neo-gpt): no `Manager.mjs`, no `ReplyLoss.spec.mjs` — the dead-port contract gets its own `worker/Base.spec.mjs`.

Root-cause receipt: a CDP attach to the app SharedWorker of a client workspace (Playwright page consoles cannot see shared workers) pinned the field signature at `worker/Base.mjs:411` — `Uncaught (in promise)`, reason `undefined`; details in #17894.

Evidence: L2 (exact-head unit specs + full fully-parallel suite) → L2 required (every AC is unit-provable pre-merge); no residuals.

## AC Evidence

| AC | Evidence |
|---|---|
| AC-1 | `src/worker/Base.mjs` rejects `Error` + `code: 'NEO_DEAD_PORT'`; `worker/Base.spec.mjs` asserts code, `destination "app"`, action, and the `Neo.main.addon.DockFlip.captureFirst`-style remote target in the message |
| AC-2 | `DragZone.spec.mjs`: typed teardown settles with zero `console.error`; every other reason — including the historical bare `undefined` — surfaces exactly once (each arm reds the reverted discriminator by construction) |
| AC-3 | `main/addon/Stylesheet.spec.mjs` (new): dispatches the created link's real `error` event and asserts the rejection is an `Error` naming the requested href, with a positive `load` control so the instrument owns both settlement paths |
| AC-4 | grep receipt at `4a97a5e40f`: literal bare `reject()` count in `src/` = 0 |
| AC-5 | full unit suite: 2155 passed, 0 failed, fully-parallel mode — two consecutive runs (worker-ordering shake) |

## Deltas from ticket

None.

## Test Evidence

Targeted: `worker/Base.spec.mjs` 2/2 (new), `worker/ReplyLoss.spec.mjs` 15/15 (adjacent contracts untouched), `draggable/DragZone.spec.mjs` including the migrated silent arm (now asserting console silence, which the old test never did) and the new reasonless-surfaces arm, `main/addon/Stylesheet.spec.mjs` 2/2 (new). Full suite: **2155 passed, 0 failed, fully-parallel mode, two consecutive runs** at `4a97a5e40f`. The Stylesheet spec clears the harness's `Neo.main.addon.Stylesheet` stub for the real import and restores it in `afterAll` — worker processes share files, so the slot's occupancy is ordering-dependent.

## Post-Merge Validation

Non-gating observation, no residual ownership: on the next field occurrence, the client workspace's app-worker log line names the dead port and caller instead of `undefined`, and its theme-CSS 404s (a distinct, pre-existing URL-contract issue) surface as `Stylesheet failed to load: <url>`.

Authored by Vega (Fable 5, Claude Code). Session b51135ac-ec45-4689-ac45-0e99fb073069.
