### PR TITLE
fix(dock): FLIP dispatches route to the host realm, not the first port (#17895)

### DIFF
--- a/src/dashboard/dock/Workspace.mjs
+++ b/src/dashboard/dock/Workspace.mjs
@@ -1603,7 +1603,10 @@ class Workspace extends Container {
         }
 
         try {
-            await flip?.captureFirst({hostId: host.id, markerPrefix: flipMarkerPrefix})
+            // windowId routes the call to the host's OWN main thread: without it, SharedWorker
+            // port resolution falls back to the first connected window — the wrong realm the
+            // moment a second window exists.
+            await flip?.captureFirst({hostId: host.id, markerPrefix: flipMarkerPrefix, windowId: host.windowId})
         } catch (error) {/* instant landing */}
 
         if (me.isDestroyed) {
@@ -1670,7 +1673,7 @@ class Workspace extends Container {
             MotionSignal.enter(me);
 
             try {
-                rawPlayed = flip.play({hostId: host.id, markerPrefix: flipMarkerPrefix, geometryOnly: result?.landedInPlace === true})
+                rawPlayed = flip.play({geometryOnly: result?.landedInPlace === true, hostId: host.id, markerPrefix: flipMarkerPrefix, windowId: host.windowId})
             } catch (error) {
                 rawPlayed = Promise.reject(error)
             }

--- a/test/playwright/unit/dashboard/DockWorkspace.spec.mjs
+++ b/test/playwright/unit/dashboard/DockWorkspace.spec.mjs
@@ -1176,7 +1176,7 @@ test.describe('Neo.dashboard.dock.Workspace', () => {
         expect(order).toEqual(['captureFirst', 'chromeHook', 'play'])
     });
 
-    test('both FLIP dispatches carry the host windowId — the payload routes to the host realm, never the first port', async () => {
+    test('both FLIP dispatches carry the host windowId — the key generateRemote swaps the destination on', async () => {
         workspace = Neo.create(PlainWorkspace, {dockModel: createDocument(), windowId: 'flip-realm-7'});
 
         const

--- a/test/playwright/unit/dashboard/DockWorkspace.spec.mjs
+++ b/test/playwright/unit/dashboard/DockWorkspace.spec.mjs
@@ -1176,6 +1176,51 @@ test.describe('Neo.dashboard.dock.Workspace', () => {
         expect(order).toEqual(['captureFirst', 'chromeHook', 'play'])
     });
 
+    test('both FLIP dispatches carry the host windowId — the payload routes to the host realm, never the first port', async () => {
+        workspace = Neo.create(PlainWorkspace, {dockModel: createDocument(), windowId: 'flip-realm-7'});
+
+        const
+            payloads = [],
+            hadMain  = Object.prototype.hasOwnProperty.call(Neo, 'main'),
+            mainNs   = Neo.main = Neo.main || {},
+            hadAddon = Object.prototype.hasOwnProperty.call(mainNs, 'addon'),
+            addonNs  = mainNs.addon = mainNs.addon || {},
+            previous = addonNs.DockFlip;
+
+        addonNs.DockFlip = {
+            captureFirst: data => {payloads.push(['captureFirst', data])},
+            play        : data => {payloads.push(['play', data])}
+        };
+
+        try {
+            const result = workspace.applyDockZoneOperation({operation: 'moveItem', itemId: 'terminal', targetNodeId: 'editor-tabs', index: 1});
+
+            workspace.onDockZoneDocumentChange(result.document);
+            await workspace.refreshPromise;
+
+            const hostWindowId = workspace.getDockHost().windowId;
+
+            // a both-undefined match would be vacuous: the routing key must actually exist
+            expect(hostWindowId).not.toBeNull();
+            expect(hostWindowId).toBeDefined();
+
+            expect(payloads).toHaveLength(2);
+
+            for (const [method, data] of payloads) {
+                expect(data.windowId, `${method} routes to the host realm`).toBe(hostWindowId);
+                expect(data.hostId).toBe(workspace.getDockHost().id)
+            }
+        } finally {
+            if (previous === undefined) {
+                delete addonNs.DockFlip
+            } else {
+                addonNs.DockFlip = previous
+            }
+            !hadAddon && delete mainNs.addon;
+            !hadMain  && delete Neo.main
+        }
+    });
+
     test('a persisted title renders as escaped text, never as markup', async () => {
         const
             evil     = '<img src=x onerror="window.__pwned = 1">',


### PR DESCRIPTION
Resolves #17895

🌿 The animation now knocks on the door of the window that owns the furniture — first-come-first-served routing is unsayable.

## Summary

`refreshDockWorkspace` called `Neo.main.addon.DockFlip.captureFirst` / `.play` without a `windowId`. `RemoteMethodAccess#generateRemote` swaps the deprecated `'main'` destination for `data.windowId` only when the caller provides one — absent, SharedWorker port resolution falls through to the last-resort FIRST port. Single window: correct by coincidence, plus two deprecation warnings on every boot (the field observation, captured via a race-free CDP auto-attach; receipts in #17895). Multi window: the FLIP capture and play address the first connected window's DOM, not the host's — a silent wrong-realm no-op the moment a tear-out exists.

Both payloads now carry `windowId: host.windowId` — the realm that owns the captured markers. A null `windowId` (unmounted edge) keeps the previous fallback path by construction, since the swap only fires on a truthy value.

## AC Evidence

| AC | Evidence |
|---|---|
| AC-1 | both dispatches carry `windowId: host.windowId`; new `DockWorkspace.spec.mjs` arm drives a real commit through a capturing DockFlip stub and asserts both payloads carry the explicit host realm (`flip-realm-7`), with a non-null guard so a both-undefined match cannot pass vacuously |
| AC-2 | **live boot receipt at runtime sources `74b6d26df9`** — the engine's own SharedWorkers dock app (`apps/workstation`, DockFlip + SharedWorkers enabled) booted under race-free CDP auto-attach with a `promiseMessage` recorder in the App worker, then a real splitter drag committed a dock operation: `captureFirst` and `play` both dispatched to `dest: "e7f76846-1cf4-461f-9ead-86c803741de0"` (the host window's id), with **zero** DockFlip `destination "main"` deprecation warnings; the recorded dispatches make the zero-warning claim non-vacuous. Positive control: the same instrument pre-fix captured exactly the two DockFlip warnings (receipts in #17895) |
| AC-3 | full unit suite: 2151 passed, 0 failed, fully-parallel mode |

## Deltas from ticket

None. (The AC-2 receipt venue is the engine's own workstation app rather than the private consumer workspace — same SharedWorkers + DockFlip topology, publicly reproducible.)

## Test Evidence

Targeted: `DockWorkspace.spec.mjs` + `DockFlip.spec.mjs` 56/56 (55 prior + the new payload arm; the FLIP-ordering arm is untouched). Full suite: **2151 passed, 0 failed, fully-parallel mode** at `74b6d26df9`; `ea502e474c` renames only the new spec's title to its actual seam (the payload carries the key `generateRemote` swaps the destination on).

## Post-Merge Validation

Non-gating observation, no residual ownership: the same boot instrument on the consumer workspace shows zero DockFlip deprecation warnings after its engine pin advances past this merge. (The instrument also surfaced ~50 deprecated-main dispatches from non-dock callers — `importAddon`, grid addon registrations, `startWorker` — explicitly outside this ticket's scope; filed separately.)

Authored by Vega (Fable 5, Claude Code). Session b51135ac-ec45-4689-ac45-0e99fb073069.
