### PR TITLE
fix(dashboard): serialize dock projection across first mount (#17888)

### DIFF
--- a/src/dashboard/dock/Workspace.mjs
+++ b/src/dashboard/dock/Workspace.mjs
@@ -1552,6 +1552,9 @@ class Workspace extends Container {
      * A `null` document reconciles toward the EMPTY projection: every pane retires, the shell
      * survives. A configured {@link #dockHostReference} that resolves to no live host throws —
      * the committed document is not rendered, and that must fail loudly, never settle silently.
+     * Before the first mount, the host's own {@link Neo.component.Base#promiseUpdate} is the
+     * ordering boundary: it settles when the initial tree mounts (or rejects on destruction), so
+     * the reconciler can never insert a staging shell into the tree that `initVnode()` is serializing.
      * The reconciler's outcome is captured and its `landedInPlace` — the path it ACTUALLY took,
      * never the requested one — rides the FLIP play as `geometryOnly`; after the play is
      * dispatched, {@link #afterRefreshDockWorkspace} is awaited with the outcome and the play's
@@ -1581,6 +1584,22 @@ class Workspace extends Container {
 
         if (!host) {
             throw new Error(`Workspace ${me.id}: dockHostReference "${me.dockHostReference}" resolved to no live dock host — the committed document is not rendered`)
+        }
+
+        if (!host.mounted) {
+            try {
+                await host.promiseUpdate()
+            } catch (error) {
+                if (error === Neo.isDestroyed || me.isDestroyed || host.isDestroyed) {
+                    return
+                }
+
+                throw error
+            }
+        }
+
+        if (me.isDestroyed || host.isDestroyed) {
+            return
         }
 
         try {

--- a/src/dashboard/dock/projection/Reconciler.mjs
+++ b/src/dashboard/dock/projection/Reconciler.mjs
@@ -482,6 +482,8 @@ class Reconciler extends Base {
      *
      * Cross-tab card/button moves must commit before this method runs. The distinct ancestor commit
      * prevents the main-thread delta from retiring a child after its retained ancestor has landed.
+     * The destination projection also owns fixed `width` / `height`: retained edge-band chrome must
+     * take those values (or clear obsolete ones) instead of carrying source geometry across the move.
      * @param {Map<String,Object>} plans
      * @returns {Map<String,Object>}
      * @static
@@ -513,6 +515,8 @@ class Reconciler extends Base {
                 flex     : plan.config.flex,
                 listeners: plan.config.listeners,
                 style    : plan.config.style,
+                height   : Object.hasOwn(plan.config, 'height') ? plan.config.height : null,
+                width    : Object.hasOwn(plan.config, 'width')  ? plan.config.width  : null,
                 // Flexbox stores parent-owned sizing on the child's wrapper. A retained tab
                 // otherwise carries its source split ratio into the destination projection.
                 wrapperStyle: {...tab.wrapperStyle, flex: plan.config.flex ?? null}

--- a/src/worker/Manager.mjs
+++ b/src/worker/Manager.mjs
@@ -463,7 +463,8 @@ class Manager extends Base {
      *     that contain DOM updates. It normalizes `autoMount` operations into `insertNode` deltas and delegates
      *     them to `handleDomUpdate`.
      * 2.  **Promise Resolution:** It resolves pending promises for `reply` messages (e.g., remote method calls).
-     * 3.  **Message Forwarding:** It routes messages between workers (e.g., App -> Data).
+     * 3.  **Message Forwarding:** It routes messages between workers (e.g., App -> Data), preserving
+     *     a rejected worker's named cause inside the reply `data` field the origin consumes.
      *
      * @param {Object} event
      */
@@ -534,11 +535,17 @@ class Manager extends Base {
             me.promiseMessage(dest, data, transfer).then(response => {
                 me.sendMessage(response.destination, response)
             }).catch(err => {
+                const
+                    reason  = err?.data ?? err,
+                    message = reason?.error?.message || reason?.error || reason?.message ||
+                        'Worker message forwarding failed',
+                    error   = reason instanceof Error ? reason : new Error(String(message));
+
                 me.sendMessage(data.origin, {
                     action : 'reply',
+                    data   : error,
                     reject : true,
-                    replyId: data.id,
-                    error  : err.message
+                    replyId: data.id
                 })
             })
         }

--- a/test/playwright/component/apps/dock-first-mount/app.mjs
+++ b/test/playwright/component/apps/dock-first-mount/app.mjs
@@ -1,0 +1,111 @@
+import DockWorkspace from '../../../../../src/dashboard/dock/Workspace.mjs';
+import Document      from '../../../../../src/dashboard/dock/model/Document.mjs';
+import Viewport      from '../../../../../src/container/Viewport.mjs';
+import '../../../../../src/tab/Container.mjs';
+
+const bootstrapDocument = {
+    schema: 'neo.dock.zone.v1',
+    root  : 'root',
+    items : {},
+    nodes : {
+        root        : {type: 'edge-zone', zones: {center: {nodeId: 'empty-tabs'}}},
+        'empty-tabs': {type: 'tabs', items: []}
+    }
+};
+
+const realDocument = {
+    schema: 'neo.dock.zone.v1',
+    root  : 'root',
+    items : {
+        strategy : {componentRef: 'Strategy',  title: 'Strategy',  kind: 'panel'},
+        terminal : {componentRef: 'Terminal',  title: 'Terminal',  kind: 'terminal'},
+        logs     : {componentRef: 'Logs',      title: 'Logs',      kind: 'panel'},
+        inspector: {componentRef: 'Inspector', title: 'Inspector', kind: 'panel'},
+        metrics  : {componentRef: 'Metrics',   title: 'Metrics',   kind: 'panel'}
+    },
+    nodes: {
+        root            : {
+            type : 'edge-zone',
+            zones: {
+                center: {nodeId: 'root-split'},
+                right : {nodeId: 'inspector-tabs', extent: 0.25, resizable: true}
+            }
+        },
+        'root-split'    : {type: 'split', orientation: 'horizontal', children: ['main-tabs', 'side-split'], sizes: [0.65, 0.35]},
+        'main-tabs'     : {type: 'tabs', items: ['strategy', 'metrics'], activeItemId: 'strategy'},
+        'side-split'    : {type: 'split', orientation: 'vertical', children: ['terminal-tabs', 'logs-tabs'], sizes: [0.6, 0.4]},
+        'terminal-tabs' : {type: 'tabs', items: ['terminal'], activeItemId: 'terminal'},
+        'logs-tabs'     : {type: 'tabs', items: ['logs'], activeItemId: 'logs'},
+        'inspector-tabs': {type: 'tabs', items: ['inspector'], activeItemId: 'inspector'}
+    }
+};
+
+/**
+ * @summary Browser fixture for an empty-zone bootstrap dock whose real document commits before the
+ * first mount. No FLIP addon is configured, so the `timeout(0)` refresh reaches the mount boundary
+ * without an incidental main-thread round-trip hiding the race.
+ */
+class DeferredDockWorkspace extends DockWorkspace {
+    static config = {
+        /**
+         * @member {String} className='Test.Playwright.Component.DockFirstMount.Workspace'
+         * @protected
+         */
+        className: 'Test.Playwright.Component.DockFirstMount.Workspace',
+        /**
+         * Whitebox receipt that this exact fixture, rather than the ordinary dashboard example, is live.
+         * @member {Boolean} deferredBootFixture=true
+         */
+        deferredBootFixture: true,
+        /**
+         * Browser receipt of whether the deferred refresh crossed the mount boundary too early.
+         * @member {Boolean|null} refreshBeforeMount=null
+         */
+        refreshBeforeMount: null,
+        /**
+         * @member {Object} layout={ntype:'vbox',align:'stretch'}
+         */
+        layout: {ntype: 'vbox', align: 'stretch'}
+    }
+
+    /**
+     * @param {Object} config
+     */
+    construct(config) {
+        super.construct(config);
+
+        this.dockModel = Document.clone(bootstrapDocument);
+        this.add(this.projectDockModel());
+        this.onDockZoneDocumentChange(Document.clone(realDocument))
+    }
+
+    /**
+     * Records the host state at the last possible point before projection staging.
+     */
+    beforeRefreshDockWorkspace() {
+        this.refreshBeforeMount = !this.mounted
+    }
+
+    /**
+     * @param {String} itemId
+     * @param {Object} item
+     * @returns {Object}
+     */
+    resolvePane(itemId, item) {
+        return {
+            ntype: 'component',
+            style: {alignItems: 'center', display: 'flex', justifyContent: 'center'},
+            text : item?.title || itemId
+        }
+    }
+}
+
+DeferredDockWorkspace = Neo.setupClass(DeferredDockWorkspace);
+
+export const onStart = () => Neo.app({
+    mainView: {
+        module: Viewport,
+        items : [{module: DeferredDockWorkspace, flex: 1}]
+    },
+    name: 'Test.Playwright.DockFirstMount'
+});

--- a/test/playwright/component/apps/dock-first-mount/index.html
+++ b/test/playwright/component/apps/dock-first-mount/index.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Neo.mjs Dock First Mount Test App</title>
+</head>
+<body>
+    <script src="../../../../../src/MicroLoader.mjs" type="module"></script>
+</body>
+</html>

--- a/test/playwright/component/apps/dock-first-mount/neo-config.json
+++ b/test/playwright/component/apps/dock-first-mount/neo-config.json
@@ -1,0 +1,10 @@
+{
+    "appPath"         : "test/playwright/component/apps/dock-first-mount/app.mjs",
+    "basePath"        : "../../../../../",
+    "environment"     : "development",
+    "mainPath"        : "./Main.mjs",
+    "mainThreadAddons": ["DragDrop", "Navigator", "Stylesheet"],
+    "themes"          : ["neo-theme-neo-dark", "neo-theme-neo-light"],
+    "useAiClient"     : true,
+    "useSharedWorkers": true
+}

--- a/test/playwright/e2e/dashboard/DockOperationsNL.spec.mjs
+++ b/test/playwright/e2e/dashboard/DockOperationsNL.spec.mjs
@@ -1,5 +1,8 @@
 import { test, expect } from '../../fixtures.mjs';
 
+const asArray = value => Array.isArray(value) ? value : value ? [value] : [];
+const values  = record => record?.properties || record || {};
+
 /**
  * Whitebox-e2e for the dockZone.v1 semantic-operation surface through the Neural Link service tier:
  * every structural op class executes via `execute_dock_operation` against the LIVE example workspace,
@@ -63,6 +66,135 @@ test.describe('Dock semantic operations (Neural Link, structural)', () => {
         expect(tabsNodeHolding(topo, 'inspector')).toBe('inspector-tabs');
         // the read half and the holder's own committed truth are the SAME document
         expect(JSON.stringify(topo)).toBe(JSON.stringify(committed));
+    });
+
+    test('a deferred first document cannot poison the SharedWorker mount or later edge resizes', async ({page, neuralLink}) => {
+        const pageErrors = [];
+
+        page.on('pageerror', error => pageErrors.push(String(error?.message || error)));
+
+        await page.goto('/test/playwright/component/apps/dock-first-mount/');
+        await page.waitForSelector('.neo-dock-workspace', {state: 'visible'});
+
+        const
+            app     = await neuralLink.connectToApp('Test.Playwright.DockFirstMount'),
+            holders = asArray(await app.findInstances(
+                {className: 'Test.Playwright.Component.DockFirstMount.Workspace'},
+                ['deferredBootFixture', 'id', 'mounted', 'refreshBeforeMount']
+            )),
+            holderId  = holders[0]?.id,
+            shellRoot = page.locator('.neo-dock-workspace .neo-dashboard-dock-edge-zone');
+
+        expect(holderId, 'the deferred dock holder exists in the Shared App Worker').toBeTruthy();
+        expect(values(holders[0]).deferredBootFixture, 'the bootstrap-to-real browser fixture loaded').toBe(true);
+        expect(values(holders[0]).refreshBeforeMount, 'refresh staging begins only after the host mount').toBe(false);
+        expect(await page.evaluate(() => Neo.config.useSharedWorkers)).toBe(true);
+
+        const readTopology = async () => {
+            const result = await app.getDockTopology(holderId);
+
+            return result?.document ?? result
+        };
+
+        await expect.poll(async () => Object.keys((await readTopology())?.items || {}).length, {
+            message: 'the deferred real document becomes committed worker truth',
+            timeout: 10000
+        }).toBe(5);
+        await expect(shellRoot, 'the DOM must contain exactly one projected root shell').toHaveCount(1);
+
+        const directChildren = asArray(await app.findInstances(
+                {parentId: holderId},
+                ['id', 'dockNodeId', 'dockNodeType', 'mounted']
+            )),
+            projectionRoots = directChildren.filter(record => values(record).dockNodeType === 'edge-zone'),
+            consistency     = await app.verifyComponentConsistency(holderId);
+
+        expect(projectionRoots, 'worker ownership contains one projected root shell').toHaveLength(1);
+        expect(consistency.consistent, `workspace items/vdom/DOM: ${JSON.stringify(consistency)}`).toBe(true);
+
+        const readEdgeResizeParticipants = async () => {
+            const
+                centerRecord    = asArray(await app.queryComponent({dockNodeId: 'root-split'}, ['id', 'mounted']))[0],
+                inspectorRecord = asArray(await app.queryComponent({dockNodeId: 'inspector-tabs'}, ['id', 'mounted']))[0],
+                splitters       = asArray(await app.findInstances(
+                    {className: 'Neo.dashboard.dock.interaction.DockSplitter'},
+                    ['id', 'edge', 'edgeZoneId', 'mounted']
+                )),
+                edgeSplitter    = splitters.find(record => {
+                    const data = values(record);
+
+                    return data.edge === 'right' && data.edgeZoneId === 'root'
+                }),
+                ids = {
+                    center   : centerRecord?.id ?? values(centerRecord).id,
+                    inspector: inspectorRecord?.id ?? values(inspectorRecord).id,
+                    splitter : edgeSplitter?.id ?? values(edgeSplitter).id
+                };
+
+            expect(ids, 'all three edge-resize participants exist').toMatchObject({
+                center   : expect.any(String),
+                inspector: expect.any(String),
+                splitter : expect.any(String)
+            });
+
+            const [center, splitter, inspector] = await app.getDomRect([
+                ids.center,
+                ids.splitter,
+                ids.inspector
+            ]);
+
+            return {center, ids, inspector, splitter}
+        };
+
+        const assertVisibleGeometryInsideViewport = async label => {
+            const receipt = await page.locator(
+                '.neo-dashboard-dock-edge-zone, .neo-dashboard-dock-splitter, [class*="dock-flip-item-"]'
+            ).evaluateAll(nodes => ({
+                height: innerHeight,
+                width : innerWidth,
+                rects : nodes.map(node => node.getBoundingClientRect()).filter(rect => rect.width > 0 && rect.height > 0)
+                    .map(({bottom, left, right, top}) => ({bottom, left, right, top}))
+            }));
+
+            expect(receipt.rects.length, `${label}: visible dock geometry exists`).toBeGreaterThan(5);
+            receipt.rects.forEach(rect => {
+                expect(rect.left,   `${label}: left edge`).toBeGreaterThanOrEqual(-1);
+                expect(rect.top,    `${label}: top edge`).toBeGreaterThanOrEqual(-1);
+                expect(rect.right,  `${label}: right edge`).toBeLessThanOrEqual(receipt.width + 1);
+                expect(rect.bottom, `${label}: bottom edge`).toBeLessThanOrEqual(receipt.height + 1)
+            })
+        };
+
+        await assertVisibleGeometryInsideViewport('first projection');
+
+        const before  = await readEdgeResizeParticipants();
+        const resized = await app.executeDockOperation(holderId, {
+            operation : 'resizeEdgeZone',
+            edgeZoneId: 'root',
+            edge      : 'right',
+            extent    : 0.33
+        });
+
+        expect(resized).toMatchObject({applied: true, errors: []});
+        await expect.poll(async () => (await readEdgeResizeParticipants()).inspector.width, {
+            message: 'the right band follows the committed edge extent',
+            timeout: 10000
+        }).toBeGreaterThan(before.inspector.width + 20);
+
+        const after = await readEdgeResizeParticipants();
+
+        expect(after.center.width, 'the center contracts with the larger right band').toBeLessThan(before.center.width);
+        expect(after.splitter.x, 'the edge splitter moves with the band').toBeLessThan(before.splitter.x);
+        expect(after.inspector.width, 'the right band itself resizes').toBeGreaterThan(before.inspector.width);
+        expect((await readTopology()).nodes.root.zones.right.extent).toBe(0.33);
+        await expect(shellRoot, 'post-resize DOM still owns one projection shell').toHaveCount(1);
+        await assertVisibleGeometryInsideViewport('post-resize projection');
+
+        const postResizeConsistency = await app.verifyComponentConsistency(holderId);
+
+        expect(postResizeConsistency.consistent,
+            `post-resize items/vdom/DOM: ${JSON.stringify(postResizeConsistency)}`).toBe(true);
+        expect(pageErrors, 'no anonymous promise rejection or page error survives').toEqual([])
     });
 
     test('close action resolves reordered live identity, retains chrome and restores successor or root focus', async ({ page, neuralLink }) => {

--- a/test/playwright/unit/dashboard/DockWorkspace.spec.mjs
+++ b/test/playwright/unit/dashboard/DockWorkspace.spec.mjs
@@ -16,6 +16,8 @@ import DockLayoutAdapter        from '../../../../src/dashboard/dock/projection/
 import DockProjectionReconciler from '../../../../src/dashboard/dock/projection/Reconciler.mjs';
 import DockService              from '../../../../src/ai/client/DockService.mjs';
 import DockWorkspace            from '../../../../src/dashboard/dock/Workspace.mjs';
+import DomApiVnodeCreator       from '../../../../src/vdom/util/DomApiVnodeCreator.mjs';
+import VdomHelper               from '../../../../src/vdom/Helper.mjs';
 
 const createDocument = () => ({
     schema: 'neo.dock.zone.v1',
@@ -30,6 +32,36 @@ const createDocument = () => ({
         'root-split' : {type: 'split', orientation: 'horizontal', children: ['editor-tabs', 'side-tabs'], sizes: [0.6, 0.4]},
         'editor-tabs': {type: 'tabs', items: ['editor'],              activeItemId: 'editor'},
         'side-tabs'  : {type: 'tabs', items: ['preview', 'terminal'], activeItemId: 'preview'}
+    }
+});
+
+const createEmptyDocument = () => ({
+    schema: 'neo.dock.zone.v1',
+    root  : 'root',
+    items : {},
+    nodes : {
+        root        : {type: 'edge-zone', zones: {center: {nodeId: 'empty-tabs'}}},
+        'empty-tabs': {type: 'tabs', items: []}
+    }
+});
+
+const createEdgeDocument = () => ({
+    schema: 'neo.dock.zone.v1',
+    root  : 'root',
+    items : {
+        center   : {componentRef: 'Center',    title: 'Center',    kind: 'panel'},
+        inspector: {componentRef: 'Inspector', title: 'Inspector', kind: 'panel'}
+    },
+    nodes: {
+        root            : {
+            type : 'edge-zone',
+            zones: {
+                center: {nodeId: 'center-tabs'},
+                right : {nodeId: 'inspector-tabs', extent: 0.25, resizable: true}
+            }
+        },
+        'center-tabs'   : {type: 'tabs', items: ['center'], activeItemId: 'center'},
+        'inspector-tabs': {type: 'tabs', items: ['inspector'], activeItemId: 'inspector'}
     }
 });
 
@@ -954,6 +986,82 @@ test.describe('Neo.dashboard.dock.Workspace', () => {
         expect(timeline).toEqual(['start:1', 'end:1', 'start:1', 'end:1']);
         expect(workspace.items.length).toBe(1);
         expect(tabsOf(workspace.items[0]).get('editor-tabs').getTabBar().sortZoneConfig.dockItemIds).toEqual(['preview', 'editor', 'terminal'])
+    });
+
+    test('a deferred first document does not stage a second shell before the workspace mounts', async () => {
+        const
+            allowVdomUpdatesInTests = Neo.config.allowVdomUpdatesInTests,
+            useDomApiRenderer       = Neo.config.useDomApiRenderer,
+            domAccessAlign          = Neo.main.DomAccess.align,
+            enteredRefresh          = Promise.withResolvers();
+
+        Neo.config.allowVdomUpdatesInTests = true;
+        Neo.config.useDomApiRenderer       = true;
+        Neo.main.DomAccess.align           = async () => {};
+        workspace = Neo.create(PlainWorkspace, {
+            appName  : 'DashboardDockWorkspaceTest',
+            dockModel: createEmptyDocument(),
+            windowId : 1
+        });
+
+        const refreshDockWorkspace = workspace.refreshDockWorkspace.bind(workspace);
+
+        workspace.refreshDockWorkspace = (...args) => {
+            enteredRefresh.resolve();
+            return refreshDockWorkspace(...args)
+        };
+
+        try {
+            // Build the first vnode without mounting it. This is the real boot window: the app's
+            // main-view mount is still pending while an async catalog can commit the real document.
+            await workspace.initVnode();
+            expect(workspace.mounted).toBe(false);
+
+            const initialShell = workspace.items[0];
+
+            workspace.onDockZoneDocumentChange(createDocument());
+
+            await enteredRefresh.promise;
+            await Promise.resolve();
+
+            // Reconciler may not insert its hidden staging shell until the initial tree exists in
+            // the DOM. Otherwise initVnode can serialize old + staged shells as the first mount.
+            expect(workspace.items).toHaveLength(1);
+            expect(workspace.items[0]).toBe(initialShell)
+        } finally {
+            workspace.mounted = true;
+            await workspace.refreshPromise?.catch(() => {});
+            Neo.config.allowVdomUpdatesInTests = allowVdomUpdatesInTests;
+            Neo.config.useDomApiRenderer       = useDomApiRenderer;
+            Neo.main.DomAccess.align           = domAccessAlign
+        }
+
+        expect(workspace.items).toHaveLength(1);
+        expect(tabsOf(workspace.items[0]).has('editor-tabs')).toBe(true)
+    });
+
+    test('a staged edge resize transfers fixed dimensions onto retained tab chrome', async () => {
+        workspace = Neo.create(PlainWorkspace, {dockModel: createEdgeDocument()});
+
+        const inspector = tabsOf(workspace.items[0]).get('inspector-tabs');
+
+        expect(inspector.width).toBe('25%');
+
+        const result = workspace.applyDockZoneOperation({
+            operation : 'resizeEdgeZone',
+            edgeZoneId: 'root',
+            edge      : 'right',
+            extent    : 0.33
+        });
+
+        workspace.onDockZoneDocumentChange(result.document, {operation: 'resizeEdgeZone'}, workspace);
+        await workspace.refreshPromise;
+
+        const retainedInspector = tabsOf(workspace.items[0]).get('inspector-tabs');
+
+        expect(retainedInspector).toBe(inspector);
+        expect(retainedInspector.width).toBe('33%');
+        expect(retainedInspector.vdom.width).toBe('33%')
     });
 
     test('a destroyed workspace drops its pending refresh without throwing', async () => {

--- a/test/playwright/unit/vdom/MainRenderQueue.spec.mjs
+++ b/test/playwright/unit/vdom/MainRenderQueue.spec.mjs
@@ -8,7 +8,7 @@ const __dirname     = path.dirname(fileURLToPath(import.meta.url));
 const REPO_ROOT     = path.resolve(__dirname, '../../../..');
 const execFileAsync = promisify(execFile);
 
-async function runRenderQueueProbe(hidden) {
+async function runRenderQueueProbe(hidden, probeForwarding=false) {
     const script = `
         import Neo from './src/Neo.mjs';
         import * as core from './src/core/_export.mjs';
@@ -84,13 +84,54 @@ async function runRenderQueueProbe(hidden) {
         next?.callback();
         globalThis.setTimeout = originalTimeout;
 
+        let forwarded;
+
+        if (${probeForwarding}) {
+            const
+                {default: WorkerBase} = await import('./src/worker/Base.mjs'),
+                sent                  = [],
+                consumer              = Object.create(WorkerBase.prototype);
+
+            WorkerManager.promiseMessage = () => Promise.reject({
+                data  : new Error('vdom projection failed'),
+                reject: true
+            });
+            WorkerManager.sendMessage = (destination, message) => sent.push({destination, message});
+            WorkerManager.onWorkerMessage({
+                data: {action: 'remoteMethod', destination: 'vdom', id: 'origin-q', origin: 'app'}
+            });
+
+            await Promise.resolve();
+            await Promise.resolve();
+
+            let consumerRejection;
+            const [{destination, message}] = sent;
+
+            consumer.promises = {
+                'origin-q': {
+                    reject : value => {consumerRejection = value},
+                    resolve: () => {}
+                }
+            };
+            consumer.onMessage({data: message});
+
+            forwarded = {
+                consumerMessage: consumerRejection?.message,
+                dataMessage    : message.data?.message,
+                destination,
+                reject         : message.reject,
+                replyId        : message.replyId
+            }
+        }
+
         console.log(JSON.stringify({
             applied       : applied.length,
             delay         : next?.delay,
             kind          : next?.kind,
             queueRemaining: Main.writeQueue.length,
             resolved,
-            running       : Main.running
+            running       : Main.running,
+            ...(${probeForwarding} ? {forwarded} : {})
         }))
     `;
     const {stdout} = await execFileAsync(process.execPath, ['--input-type=module', '-e', script], {
@@ -132,6 +173,18 @@ test.describe('Neo.Main render queue scheduling', () => {
             queueRemaining: 0,
             resolved      : {settled: true},
             running       : false
+        })
+    });
+
+    test('forwards a rejected worker cause through the reply data the origin consumes', async () => {
+        const {forwarded} = await runRenderQueueProbe(false, true);
+
+        expect(forwarded).toEqual({
+            consumerMessage: 'vdom projection failed',
+            dataMessage    : 'vdom projection failed',
+            destination    : 'app',
+            reject         : true,
+            replyId        : 'origin-q'
         })
     })
 });


### PR DESCRIPTION
Resolves #17888

Serializes dock reconciliation behind the actual host's first mount, so an async real document can never let the initial VDOM snapshot absorb Reconciler's hidden staging shell. The same transaction now carries destination-owned fixed dimensions with retained tab chrome, and forwarded worker failures retain a named cause in the reply envelope consumed by the origin.

Evidence: L3 (live SharedWorker browser fixture across five independent fresh Chromium launches plus mutation controls) → L3 required (all runtime ACs). No residuals.

Related: #17836

## AC Evidence
| AC-1 | `DockOperationsNL.spec.mjs` + `dock-first-mount` fixture: literal empty document → deferred real document under `useSharedWorkers:true`; five independent fresh Chromium launches passed consecutively. |
| AC-2 | `DockWorkspace.spec.mjs` deterministically holds the workspace unmounted and proves no second shell stages; removing the mount gate reds that assertion. The browser fixture independently records `refreshBeforeMount:false`; the same mutation makes it `true`. |
| AC-3 | The browser witness asserts one projection shell, worker/VDOM/DOM consistency, all visible dock geometry inside the viewport, then commits `resizeEdgeZone` and observes center, splitter, and band move together. `DockWorkspace.spec.mjs` pins the retained edge band's `25%` → `33%` dimension transfer. |
| AC-4 | `MainRenderQueue.spec.mjs` injects a forwarded VDOM failure through the real Manager and WorkerBase consumer; the origin rejects with `vdom projection failed`, never `undefined`. |
| AC-5 | The complete unit suite and all eight `DockOperationsNL` journeys pass; the seven ordinary dashboard journeys retain their dedicated-worker configuration. |

## Deltas from ticket
The ticket's timing direction was right, with one wording correction: TreeBuilder is synchronous; it does not interleave with Reconciler. The invalid staging shell was already present before TreeBuilder took the first snapshot. AC-3 also exposed a separate transaction defect in the same symptom chain: retained edge-band tabs kept their old `width` / `height`, so a committed resize could move the center while leaving the band fixed. The Reconciler now transfers or clears those destination-owned dimensions. AC-4 mapped to Manager's forwarded-rejection envelope (`error` written at the top level while WorkerBase reads `data`).

## Test Evidence
- SharedWorker fresh-launch battery: `5/5` independent Playwright processes passed with one projection shell, consistent worker/VDOM/DOM ownership, in-viewport geometry, and post-boot edge resize.
- Mount-gate mutation: removing the guard changes the live fixture receipt to `refreshBeforeMount:true` and reds the browser test.
- Retained-dimension mutation: omitting the Reconciler transfer leaves the edge band at `25%` and reds the unit + browser resize witnesses.
- Full dock Neural Link spec: `8/8` passed, including the seven dedicated-worker journeys.

## Post-Merge Validation
None — every close-target AC is observed pre-merge.

Authored by Euclid (OpenAI GPT-5.6 Sol, Codex Desktop). Session a63227a3-7e65-4384-ba2c-89a2fb98ec7b.
