### PR TITLE
fix(agentos): ignore generated hook projections (#17892)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -158,3 +158,11 @@ resources/content/computed-route.json
 # bytes (neomjs/neo#17798).
 .agents/skills
 .claude/skills/
+
+# Agent OS seat hooks are generated-not-tracked projections under ADR 0040 §2.7.
+# Keep the Engine-owned contributor guard and Kimi hook-root README visible.
+.claude/hooks/*
+!.claude/hooks/rgReplaceGuardHook.mjs
+.codex/hooks/
+.kimi-code/hooks/*
+!.kimi-code/hooks/README.md


### PR DESCRIPTION
Resolves #17892

Restores ADR 0040 §2.7's generated-not-tracked hook projection contract in the Engine checkout. Generated Claude, Codex, and Kimi hook paths are ignored, while explicit negations keep the Engine-owned Claude guard and Kimi hook-root README visible.

Evidence: L3 (real Git ignore-rule probes, mutation controls, and physical projected-file status checks) → L3 required (all seven close-target ACs are observable through the real Git index and ignore engine). No residuals.

Micro-review eligible: mechanical — one declarative `.gitignore` block, no executable code.

## AC Evidence

| AC | Evidence |
|---|---|
| AC-1 | `git check-ignore --no-index -v` names positive rules for representative projected paths under `.claude/hooks/`, `.codex/hooks/`, and `.kimi-code/hooks/`. |
| AC-2 | The same command names `!.claude/hooks/rgReplaceGuardHook.mjs` and `!.kimi-code/hooks/README.md` for the two tracked survivors; the assertion is on pattern text, not exit code. |
| AC-3 | The committed shapes are contents-glob + negation for Claude/Kimi. Mutation to a bare `.claude/hooks/` rule makes the guard match the positive rule, proving the negation becomes inert. |
| AC-4 | Removing the Claude negation makes the tracked guard match `.claude/hooks/*`, while a sibling projected path matches that same positive rule in the accepted candidate. |
| AC-5 | `git ls-files` still returns exactly `.claude/hooks/rgReplaceGuardHook.mjs` and `.kimi-code/hooks/README.md`. |
| AC-6 | Physical placeholder projections under Claude and Kimi report `!!` with `--ignored`; scoped ordinary status reports only the intended `.gitignore` edit. Codex's representative path matches its positive rule. Placeholders were removed after the probe. |
| AC-7 | The inline comment names ADR 0040 §2.7, generated-not-tracked custody, and both retained Engine-owned artifacts. |

## Deltas from ticket

None substantive from the corrected live ticket. The implementation uses the exact contents-glob/negation shapes established by its non-vacuity controls.

## Test Evidence

- Candidate: all three projected paths matched positive rules; both survivors matched explicit negative rules.
- Mutation 1: removing the Claude negation made the guard match `.claude/hooks/*`.
- Mutation 2: changing the contents glob to bare `.claude/hooks/` left the negation inert and made the guard match the positive directory rule.
- Physical projection: real placeholder files under Claude/Kimi were ignored and absent from scoped ordinary status; both were removed after observation.
- `git diff --check` and the pre-commit whitespace gate passed.

## Post-Merge Validation

None. Every close-target AC is decidable pre-merge through Git's real ignore/index behavior.

Related: neomjs/neo-agent-brain#250 · neomjs/neo-agent-brain#184

Authored by Emmy (GPT-5.6 Sol Ultra, Codex). Session 4426fb43-4968-4084-832e-1830de2e8747.
