### PR TITLE
fix(worker): route main-thread calls to owning windows (#17899)

### DIFF
--- a/src/component/Sparkline.mjs
+++ b/src/component/Sparkline.mjs
@@ -235,6 +235,7 @@ class Sparkline extends Canvas {
     }
 
     /**
+     * @summary Ensures the Canvas Worker through the main-thread realm that owns this Sparkline.
      * @returns {Promise<void>}
      */
     async initAsync() {
@@ -242,7 +243,10 @@ class Sparkline extends Canvas {
 
         if (this.rendererImportPath) {
              // Ensure Canvas Worker is running
-            await Neo.worker.Manager.startWorker({name: 'canvas'});
+            await Neo.worker.Manager.startWorker({
+                name    : 'canvas',
+                windowId: this.windowId
+            });
 
             // Wait for the Canvas Worker remote to be available.
             let i = 0;

--- a/src/grid/Container.mjs
+++ b/src/grid/Container.mjs
@@ -602,6 +602,11 @@ class GridContainer extends BaseContainer {
     }
 
     /**
+     * @summary Keeps the ScrollManager realm aligned on initial attachment and later window transfers.
+     *
+     * Grids can be constructed while detached, so their first real `windowId` transition is
+     * `null` → id. Forwarding only when `oldValue` was truthy left the ScrollManager permanently
+     * windowless and routed its main-thread addon registrations through the first-port fallback.
      * Triggered after the windowId config got changed
      * @param {String|null} value
      * @param {String|null} oldValue
@@ -612,7 +617,7 @@ class GridContainer extends BaseContainer {
 
         let {scrollManager} = this;
 
-        if (oldValue && scrollManager) {
+        if (scrollManager) {
             scrollManager.windowId = value
         }
     }

--- a/src/grid/ScrollManager.mjs
+++ b/src/grid/ScrollManager.mjs
@@ -94,14 +94,21 @@ class ScrollManager extends Base {
     }
 
     /**
+     * @summary Registers mount-owned addons in the current realm and retires them before unmount transfers.
      * @param {Boolean} value
      * @param {Boolean} oldValue
      */
     afterSetMounted(value, oldValue) {
+        let me = this;
+
         if (value) {
-            this.dragScroll && this.updateDragScrollAddon(true);
-            this.rowScrollPinning && this.updateRowScrollPinningAddon(true);
-            this.updateGridHorizontalScrollSyncAddon(true);
+            me.dragScroll && me.updateDragScrollAddon(true);
+            me.rowScrollPinning && me.updateRowScrollPinningAddon(true);
+            me.updateGridHorizontalScrollSyncAddon(true)
+        } else if (oldValue && me.windowId) {
+            me.dragScroll && me.updateDragScrollAddon(false);
+            me.rowScrollPinning && me.updateRowScrollPinningAddon(false);
+            me.updateGridHorizontalScrollSyncAddon(false)
         }
     }
 

--- a/test/playwright/unit/component/Sparkline.spec.mjs
+++ b/test/playwright/unit/component/Sparkline.spec.mjs
@@ -1,0 +1,54 @@
+/**
+ * @file test/playwright/unit/component/Sparkline.spec.mjs
+ * @summary Pins the owning-window route used while Sparkline ensures its Canvas Worker.
+ */
+
+import {setup} from '../../setup.mjs';
+
+setup({appConfig: {name: 'ComponentSparklineRoutingTest'}});
+
+import {test, expect}  from '@playwright/test';
+import Neo             from '../../../../src/Neo.mjs';
+import * as core       from '../../../../src/core/_export.mjs';
+import InstanceManager from '../../../../src/manager/Instance.mjs';
+import Sparkline       from '../../../../src/component/Sparkline.mjs';
+
+test.describe('Neo.component.Sparkline worker routing', () => {
+    test('the idempotent startWorker ensure carries the component windowId exactly once', async () => {
+        const
+            originalCanvas      = Neo.worker.Canvas,
+            originalStartWorker = Neo.worker.Manager.startWorker,
+            startCalls          = [];
+        let sparkline;
+
+        Neo.worker.Canvas = {loadModule: async () => {}};
+        Neo.worker.Manager.startWorker = async data => {
+            startCalls.push(data);
+            return true
+        };
+
+        try {
+            sparkline = Neo.create(Sparkline, {
+                appName : 'ComponentSparklineRoutingTest',
+                id      : 'component-sparkline-routing',
+                windowId: 'sparkline-window'
+            });
+
+            await sparkline.ready();
+
+            expect(startCalls).toEqual([{
+                name    : 'canvas',
+                windowId: 'sparkline-window'
+            }])
+        } finally {
+            sparkline?.destroy();
+            Neo.worker.Manager.startWorker = originalStartWorker;
+
+            if (originalCanvas === undefined) {
+                delete Neo.worker.Canvas
+            } else {
+                Neo.worker.Canvas = originalCanvas
+            }
+        }
+    })
+});

--- a/test/playwright/unit/grid/LockedColumns.spec.mjs
+++ b/test/playwright/unit/grid/LockedColumns.spec.mjs
@@ -222,6 +222,102 @@ test.describe('Grid Locked Columns', () => {
         expect(hoverSyncActive).toBe(true);
     });
 
+    test('a late initial windowId owns every ScrollManager addon registration', async () => {
+        const
+            {scrollManager} = grid,
+            originalGetAddon = Neo.currentWorker.getAddon,
+            getAddonCalls     = [],
+            registrations    = [],
+            targetAddons     = new Set([
+                'GridDragScroll',
+                'GridRowScrollPinning',
+                'GridHorizontalScrollSync'
+            ]),
+            windowId         = 'grid-late-window';
+
+        grid.mounted = false;
+
+        Neo.currentWorker.getAddon = async (name, targetWindowId) => {
+            getAddonCalls.push({name, windowId: targetWindowId});
+
+            return {
+                register: data => registrations.push({data, name}),
+                unregister() {}
+            }
+        };
+
+        try {
+            expect(scrollManager.windowId).toBeNull();
+
+            grid.windowId = windowId;
+
+            expect(scrollManager.windowId).toBe(windowId);
+
+            grid.mounted = true;
+            await grid.timeout(0);
+
+            expect(getAddonCalls.filter(({name}) => targetAddons.has(name))).toEqual([
+                {name: 'GridDragScroll',           windowId},
+                {name: 'GridRowScrollPinning',     windowId},
+                {name: 'GridHorizontalScrollSync', windowId}
+            ]);
+            expect(registrations
+                .filter(({name}) => targetAddons.has(name))
+                .map(({data, name}) => ({name, windowId: data.windowId}))).toEqual([
+                {name: 'GridDragScroll',           windowId},
+                {name: 'GridRowScrollPinning',     windowId},
+                {name: 'GridHorizontalScrollSync', windowId}
+            ])
+        } finally {
+            Neo.currentWorker.getAddon = originalGetAddon
+        }
+    });
+
+    test('a cross-window remount retires old-realm addon registrations before adopting the new realm', async () => {
+        const
+            originalGetAddon = Neo.currentWorker.getAddon,
+            events           = [],
+            targetAddons     = new Set([
+                'GridDragScroll',
+                'GridRowScrollPinning',
+                'GridHorizontalScrollSync'
+            ]),
+            oldWindowId      = 'grid-window-old',
+            newWindowId      = 'grid-window-new';
+
+        grid.mounted = false;
+
+        Neo.currentWorker.getAddon = async name => ({
+            register: data => targetAddons.has(name) && events.push({action: 'register', name, windowId: data.windowId}),
+            unregister: data => targetAddons.has(name) && events.push({action: 'unregister', name, windowId: data.windowId})
+        });
+
+        try {
+            grid.windowId = oldWindowId;
+            grid.mounted  = true;
+            await grid.timeout(0);
+
+            events.length = 0;
+            grid.mounted  = false;
+            await grid.timeout(0);
+
+            grid.windowId = newWindowId;
+            grid.mounted  = true;
+            await grid.timeout(0);
+
+            expect(events).toEqual([
+                {action: 'unregister', name: 'GridDragScroll',           windowId: oldWindowId},
+                {action: 'unregister', name: 'GridRowScrollPinning',     windowId: oldWindowId},
+                {action: 'unregister', name: 'GridHorizontalScrollSync', windowId: oldWindowId},
+                {action: 'register',   name: 'GridDragScroll',           windowId: newWindowId},
+                {action: 'register',   name: 'GridRowScrollPinning',     windowId: newWindowId},
+                {action: 'register',   name: 'GridHorizontalScrollSync', windowId: newWindowId}
+            ])
+        } finally {
+            Neo.currentWorker.getAddon = originalGetAddon
+        }
+    });
+
     test('responsiveLockPolicy applies matching breakpoint lock states through column setters', async () => {
         grid.responsiveLockPolicy = {
             breakpoints: [{


### PR DESCRIPTION
Resolves #17899

Completes the explicit-window migration for Workstation's remaining SharedWorker boot traffic. Detached grids now pass their first real realm into `ScrollManager`, retire mount-owned addon registrations before a window transfer, and register only in the new realm; each Sparkline routes its idempotent Canvas-worker ensure through its owning window.

Evidence: L3 (fresh Chromium SharedWorker boot, race-free CDP auto-attach, exact remote-route recorder, and a real Neural Link `resizeSplit`) → L3 required (all runtime ACs). No residuals.

Related: #8149, #9478, #17895

## AC Evidence

| AC | Evidence |
|---|---|
| AC-1 | committed head `b73888bb`: fresh public Workstation boot plus `resizeSplit` emitted zero `destination "main" is deprecated` warnings; every recorded target call used the one live window UUID |
| AC-2 | `LockedColumns.spec.mjs` proves detached `null` → real realm propagation, all three addon payloads, and old-realm unregister → new-realm register ordering across an actual unmount/window/remount transfer |
| AC-3 | source + live receipt explain the volume: `Sparkline#initAsync` performs one ensure per pooled Sparkline instance; the headless viewport created five and recorded exactly five window-routed `startWorker` calls; `Manager#startWorker` returns immediately once Canvas already exists, so the field's ~35 is pool population, not retries or 35 worker creations |
| AC-4 | complete fully-parallel unit suite: 2179 passed, 0 failed |

## Deltas from ticket

The six `importAddon` warnings and six grid-register warnings were one lifecycle defect, not separate caller omissions: two detached Workstation grids each requested three addons while their `ScrollManager.windowId` remained null. The partial `#9478` migration also left old-realm registrations behind because cross-window insertion unmounts before changing `windowId`; the same transaction now retires those registrations before remount. The `startWorker` volume is intentional per-instance ensure traffic, so this PR fixes its route without adding a speculative global cache.

## Test Evidence

- Browser-plane receipt at `b73888bb`: zero deprecated-main warnings; `GridDragScroll`, `GridRowScrollPinning`, and `GridHorizontalScrollSync` each registered twice to the exact Workstation UUID; five `startWorker(canvas)` calls and both DockFlip calls used that UUID; the real `resizeSplit` applied without errors.
- Initial red controls failed independently: the Grid manager stayed null after its owner received a real window, and Sparkline sent `{name: 'canvas'}` without `windowId`.
- Transfer red control observed zero old-realm unregisters before the fix; after the unmount repair it observes all three unregisters before all three new-realm registrations.

## Post-Merge Validation

None — every close-target AC is observed pre-merge.

Authored by Euclid (OpenAI GPT-5.6 Sol, Codex Desktop). Session a63227a3-7e65-4384-ba2c-89a2fb98ec7b.
