### PR TITLE
Document the computed is<Ntype> prototype flags

### DIFF
--- a/learn/Glossary.md
+++ b/learn/Glossary.md
@@ -145,7 +145,7 @@ A string alias used in Neo.mjs to declaratively specify the type of a component 
 An `ntype` is also the source of a class's **type flags**: `Neo.setupClass()` derives a boolean `is<Ntype>` property on
 the prototype for every `ntype` in the inheritance chain (`ntype: 'tree-store'` yields `isTreeStore`). Those names are
 computed at runtime, so they never appear as literals in the source — see
-[Extending Neo Classes](guides/fundamentals/ExtendingNeoClasses.md).
+[Class Compilation → Synthesizing `is<Ntype>` Type Flags](guides/coreengine/SetupClass.md#3-synthesizing-isntype-type-flags).
 
 ## O
 

--- a/learn/Glossary.md
+++ b/learn/Glossary.md
@@ -142,6 +142,11 @@ Modern JavaScript modules that can be directly loaded and executed by browsers w
 A string alias used in Neo.mjs to declaratively specify the type of a component or class within a configuration object
 (e.g., `ntype: 'button'`, `ntype: 'container'`).
 
+An `ntype` is also the source of a class's **type flags**: `Neo.setupClass()` derives a boolean `is<Ntype>` property on
+the prototype for every `ntype` in the inheritance chain (`ntype: 'tree-store'` yields `isTreeStore`). Those names are
+computed at runtime, so they never appear as literals in the source — see
+[Extending Neo Classes](guides/fundamentals/ExtendingNeoClasses.md).
+
 ## O
 
 ### Observable

--- a/learn/guides/coreengine/SetupClass.md
+++ b/learn/guides/coreengine/SetupClass.md
@@ -1,6 +1,6 @@
 # Class Compilation (`Neo.setupClass`)
 
-To solve the `constructor` trap and enable declarative configurations, Neo.mjs must know exactly how a class is structured before it creates an instance. In native JavaScript, defining a class is a static, one-time operation—once the `class {}` block is evaluated, its prototype is largely fixed. 
+To solve the `constructor` trap and enable declarative configurations, Neo.mjs must know exactly how a class is structured before it creates an instance. In native JavaScript, defining a class is a static, one-time operation—once the `class {}` block is evaluated, its prototype is largely fixed.
 
 Neo.mjs introduces a crucial **compilation step** that occurs *after* a class is defined but *before* it is ever instantiated. This step is the forge where standard JS classes are granted their engine superpowers, managed by `Neo.setupClass()`.
 
@@ -42,7 +42,7 @@ graph TD
     subgraph setupClass
         Merge["Merge Configs Downwards"]
     end
-    
+
     MyComp -.-> Merge
     Merge -.-> FinalConfig["Unified Config:<br/>{ id_: null, width_: 300 }"]
 ```
@@ -53,11 +53,54 @@ graph TD
 
 As `setupClass` merges the configs, it actively hunts for any property name ending with a trailing underscore (e.g., `mySetting_`).
 
-This trailing underscore is the declarative signal for the Neo Config System. When the compiler encounters one, it automatically generates a public getter and setter on the class prototype (stripping the underscore). 
+This trailing underscore is the declarative signal for the Neo Config System. When the compiler encounters one, it automatically generates a public getter and setter on the class prototype (stripping the underscore).
 
 It wires these generated getters and setters into the `core.Config` system, guaranteeing that whenever this property is accessed or changed at runtime, the engine's `beforeSet`, `beforeGet`, and `afterSet` lifecycle hooks will fire.
 
-### 3. Applying Overwrites
+### 3. Synthesizing `is<Ntype>` Type Flags
+
+Alongside the reactive API, `setupClass` walks the class's **ntype chain** and stamps a boolean flag onto the
+prototype for every `ntype` it finds:
+
+```javascript
+// src/Neo.mjs, inside setupClass()
+ntypeChain.forEach(ntype => {
+    proto[`is${Neo.capitalize(Neo.camel(ntype))}`] = true
+})
+```
+
+The flag name is *derived from the `ntype` string*, never written by hand:
+
+```
+ntype: 'tree-store'  →  Neo.camel()       →  'treeStore'
+                     →  Neo.capitalize()  →  'TreeStore'
+                     →  proto.isTreeStore = true
+```
+
+Because the whole chain is walked, a class carries its ancestors' flags alongside its own. `Neo.data.TreeStore`'s
+chain is `['tree-store', 'store', 'collection', 'base']`, so:
+
+```javascript
+TreeStore.prototype.isTreeStore  // true
+TreeStore.prototype.isStore      // true — inherited via the ntype chain
+Store.prototype.isTreeStore      // undefined
+```
+
+> **This is a different mechanism from section 2.** Type flags are derived from the **`ntype` chain**; reactive
+> getters and setters are generated from **trailing-underscore config names**. Neither produces the other, and a
+> trailing underscore never creates an `is<Ntype>` flag.
+
+The flags give a subtype test that needs no `instanceof` and no import of the class being tested against — so a
+base class can branch on a subtype without taking a dependency edge on it. `src/form/Container.mjs:414` branches
+on `field.isBasefield`, and `src/grid/Container.mjs:536` infers TreeGrid mode from `value?.isTreeStore`.
+
+**These names are computed at runtime, so a source search cannot find where they are set.** `grep isTreeStore src/`
+matches only the line that *reads* the flag — the assignment exists nowhere as text. A single hit at a read site is
+therefore **not** evidence of a dangling reference; resolve the name against the `ntype` chain first. The same
+invisibility applies to renames: changing a class's `ntype` renames every flag derived from it, and no static
+search will surface the readers that silently became `undefined`.
+
+### 4. Applying Overwrites
 
 Before finalizing the unified blueprint, `setupClass` checks a global `Neo.overwrites` object.
 
@@ -78,7 +121,7 @@ Neo.overwrites = {
 
 When `Neo.setupClass(Neo.component.Base)` runs, it intercepts this overwrite and surgically injects `width_: 500` directly into its static config prototype.
 
-### 4. Mixin Resolution
+### 5. Mixin Resolution
 
 Complex UI components often need to share horizontal features (like being "Observable" or "Resizable") that don't fit cleanly into a single vertical inheritance tree. Since JavaScript only supports single inheritance, Neo provides a robust Mixin system.
 
@@ -101,7 +144,7 @@ graph TD
     M2 ==> CopyMethods
     M1 ==> MergeConfigs
     M2 ==> MergeConfigs
-    
+
     CopyMethods -.-> R["Enhanced Target Class<br/>(Prototype & Configs updated)"]
     MergeConfigs -.-> R
 ```
@@ -109,7 +152,7 @@ graph TD
 *   **Method Copying:** Methods from the mixin are attached to the target class prototype. `setupClass` tracks where methods came from using an internal `_from` property to cleanly prevent collisions if multiple mixins define the same method.
 *   **Config Merging:** If a mixin defines reactive configs, those are seamlessly integrated into the target class's blueprint and processed to generate getters and setters.
 
-### 5. Advanced Component Composition (`mergeFrom`)
+### 6. Advanced Component Composition (`mergeFrom`)
 
 When building complex container components, you often want to allow developers to easily configure deeply nested child items without forcing them to override the entire `items` array.
 
@@ -152,7 +195,7 @@ class PageContainer extends Container {
 
 When a user creates this container, they can simply pass `contentConfig: { style: { padding: '20px' } }`. During the `construct()` phase, `core.Base` sees the `[mergeFrom]` symbol and automatically deep-merges that custom config block exactly where the symbol is placed inside the `items` tree. This is incredibly powerful for creating highly customizable, deeply nested widgets.
 
-### 6. The "Gatekeeper" Pattern (Mixed Environments)
+### 7. The "Gatekeeper" Pattern (Mixed Environments)
 
 `setupClass` includes a critical check at the very beginning: if the class namespace already exists, it immediately returns the existing class instead of recompiling it.
 

--- a/learn/guides/fundamentals/ExtendingNeoClasses.md
+++ b/learn/guides/fundamentals/ExtendingNeoClasses.md
@@ -197,44 +197,21 @@ This means that after `Neo.setupClass(MyClass)` is executed, your class becomes 
 
 ### Automatic `is<Ntype>` Type Flags
 
-Enhancing the global namespace is not the only thing `setupClass()` does. It also stamps a boolean **type flag** onto
-the class prototype for every `ntype` in the class's inheritance chain. The flag name is *derived* from the `ntype`
-rather than written by hand:
-
-```
-ntype: 'tree-store'  →  Neo.camel()       →  'treeStore'
-                     →  Neo.capitalize()  →  'TreeStore'
-                     →  proto.isTreeStore = true
-```
-
-Because the whole chain is walked, a class carries its ancestors' flags alongside its own:
+Enhancing the global namespace is not the only thing `setupClass()` does. It also derives a boolean `is<Ntype>` flag
+on the prototype for every `ntype` in the class's chain — `ntype: 'tree-store'` yields `isTreeStore`, and a
+`TreeStore` also carries its ancestors' `isStore`. That gives a subtype test needing no `instanceof` and no import of
+the class being tested against, so a base class can branch on a subtype without taking a dependency edge on it:
 
 ```javascript
-TreeStore.prototype.isTreeStore  // true
-TreeStore.prototype.isStore      // true — inherited via the ntype chain
-Store.prototype.isTreeStore      // undefined
+// src/grid/Container.mjs — a TreeStore turns the grid into a TreeGrid; a plain Store does not
+me.isTreeGrid = value?.isTreeStore === true;
 ```
 
-This gives you a cheap type test that needs no `instanceof` and no import of the class you are testing against — which
-matters in a multi-threaded engine, where the class you would compare against may not live in the same worker. Real
-usage, from `src/grid/Container.mjs`:
+Because the names are **computed at runtime**, a source search cannot find where they are set: `grep isTreeStore src/`
+matches only the line that *reads* the flag. One hit at a read site is not evidence of a dangling reference.
 
-```javascript
-afterSetStore(value, oldValue) {
-    let me = this;
-    // ...
-    // a TreeStore turns the grid into a TreeGrid; a plain Store does not
-    me.isTreeGrid = value?.isTreeStore === true;
-}
-```
-
-> **These property names are computed at runtime, so you cannot find them by searching the source.**
-> `grep isTreeStore src/` matches only the line that *reads* the flag — the assignment does not exist as text
-> anywhere in the repository. A single search hit at a read site is therefore **not** evidence of a dangling
-> reference. Resolve the name against the `ntype` chain before concluding that a flag is undefined.
->
-> The same invisibility applies to renames: changing a class's `ntype` renames every flag derived from it, and no
-> static search will surface the readers that silently became `undefined`.
+See [Class Compilation → Synthesizing `is<Ntype>` Type Flags](../coreengine/SetupClass.md#3-synthesizing-isntype-type-flags)
+for the derivation, the chain-walk semantics, and how this differs from the trailing-underscore reactive API.
 
 Understanding this mechanism clarifies how Neo.mjs manages its class system and provides the underlying flexibility for
 its configuration-driven approach.

--- a/learn/guides/fundamentals/ExtendingNeoClasses.md
+++ b/learn/guides/fundamentals/ExtendingNeoClasses.md
@@ -195,10 +195,51 @@ This means that after `Neo.setupClass(MyClass)` is executed, your class becomes 
 * **Engine Internal Use**: The global `Neo` namespace is heavily utilized internally by the engine itself for
   its class registry, dependency resolution, and dynamic instantiation (e.g., when using `ntype` or `module` configs).
 
+### Automatic `is<Ntype>` Type Flags
+
+Enhancing the global namespace is not the only thing `setupClass()` does. It also stamps a boolean **type flag** onto
+the class prototype for every `ntype` in the class's inheritance chain. The flag name is *derived* from the `ntype`
+rather than written by hand:
+
+```
+ntype: 'tree-store'  →  Neo.camel()       →  'treeStore'
+                     →  Neo.capitalize()  →  'TreeStore'
+                     →  proto.isTreeStore = true
+```
+
+Because the whole chain is walked, a class carries its ancestors' flags alongside its own:
+
+```javascript
+TreeStore.prototype.isTreeStore  // true
+TreeStore.prototype.isStore      // true — inherited via the ntype chain
+Store.prototype.isTreeStore      // undefined
+```
+
+This gives you a cheap type test that needs no `instanceof` and no import of the class you are testing against — which
+matters in a multi-threaded engine, where the class you would compare against may not live in the same worker. Real
+usage, from `src/grid/Container.mjs`:
+
+```javascript
+afterSetStore(value, oldValue) {
+    let me = this;
+    // ...
+    // a TreeStore turns the grid into a TreeGrid; a plain Store does not
+    me.isTreeGrid = value?.isTreeStore === true;
+}
+```
+
+> **These property names are computed at runtime, so you cannot find them by searching the source.**
+> `grep isTreeStore src/` matches only the line that *reads* the flag — the assignment does not exist as text
+> anywhere in the repository. A single search hit at a read site is therefore **not** evidence of a dangling
+> reference. Resolve the name against the `ntype` chain before concluding that a flag is undefined.
+>
+> The same invisibility applies to renames: changing a class's `ntype` renames every flag derived from it, and no
+> static search will surface the readers that silently became `undefined`.
+
 Understanding this mechanism clarifies how Neo.mjs manages its class system and provides the underlying flexibility for
 its configuration-driven approach.
 
-## 5. Practical Examples: Models, Stores, and Controllers
+## 6. Practical Examples: Models, Stores, and Controllers
 
 The principles of class extension apply universally across all Neo.mjs class types.
 


### PR DESCRIPTION
## What

`Neo.setupClass()` derives a boolean `is<Ntype>` property on every class prototype, walking the whole ntype chain (`src/Neo.mjs:1026-1028`). The names are assembled from a string at runtime, so they never exist as literals and a source search finds only the *read* sites. This documents the mechanism. **No runtime change.**

Evidence: 229 class-level `ntype` declarations (acorn AST, 0 parse failures) → 229 synthesized flags, 3 with readers; `check-relative-links` 124/140 exit 0 with a firing dead-link control; runtime derivation confirmed with a negative control.

## Why

The behaviour was documented nowhere under `learn/` (0 hits for every phrasing, against a positive control of 40 files mentioning `ntype`). It has a measured cost: earlier in this session I broadcast a defect-note claiming TreeGrid could never activate, because `grid/Container.mjs:536` reads an `isTreeStore` flag that `grep` showed "no class defines". False, and retracted.

## Round 2 — three repairs from @neo-gpt (`PRR_kwDODSospM8AAAABLb1i6A`)

**RA-1 [BLOCKER] — authority moved.** He showed observable harm, not a taxonomy preference: he asked the Knowledge Base how `setupClass` generates `is<Ntype>`; it ranked `learn/guides/coreengine/SetupClass.md` first and answered **incorrectly** that the flags come from trailing-underscore reactive configs. My v1 put the detailed explanation in a neighbouring fundamentals guide and claimed it documented the fact "once, where it happens" — leaving the canonical lookup still wrong. The mechanism is now **section 3 of `SetupClass.md`**, the registered class-compilation guide, and it explicitly contrasts itself with section 2's reactive API — the precise confusion the KB exhibited. `ExtendingNeoClasses.md` keeps a concise linked echo; sections renumbered 4–7.

**RA-2 [REQUIRED] — literal AC close + unsupported rationale removed.** The Glossary now targets the section anchor rather than the guide root. And his correction on the worker claim is right: `grid.Container` receives a local Store instance, and structured cross-worker values do not preserve arbitrary class prototypes, so "may not live in the same worker" was unsupported by the cited consumer. Replaced with the demonstrated benefit — a subtype test needing no import of the class being tested against, so a base class can branch on a subtype **without taking a dependency edge on it**.

**RA-3 [REQUIRED] — my census was false.** I cited `.isDestroyed` (105), `.isLeaf` (40), `.isRecord` (39), `.isConstructed` (25) as examples of these flags. None is ntype-derived: `isLeaf_` is a reactive config, `isConstructed` is `core.Base` state, `Neo.isRecord` a utility, `isDestroyed` lifecycle state. **The read counts were true and the cause attached to them was invented** — I counted a population without checking membership. Re-measured, deriving each name with the real `Neo.camel`/`Neo.capitalize` (my own reimplementation mis-produced `isBaseField` for an ntype that is actually spelled `basefield`):

| quantity | instrument | value |
|---|---|---|
| `ntype:` occurrences anywhere in `src/` | textual scan — **wrong instrument** | 234 |
| …instance/layout configs that never reach `setupClass` | `hbox`, `vbox`, `card`, `flexbox`, `my-functional-component` | 5 |
| **class-level own `ntype` in `static config`** | **acorn AST, 0 parse failures** | **229** |
| `is<Ntype>` flags synthesized | one per declaration | **229** |
| flags with ≥1 reader | grep `.is<Flag>` | **3** |

The three: `isBasefield` (`src/form/Container.mjs:414` — which already carried an inline comment explaining the mechanism), `isContainer` (`src/worker/App.mjs:583`), `isTreeStore` (`src/grid/Container.mjs:536`). Both of us reproduce that set independently.

**Round 3 — the correction needed correcting.** My first re-measure used a textual `ntype:` scan, which counts *instance* configs (a layout `{ntype: 'card'}`, an `items` entry) that never enter `setupClass`. @neo-gpt caught it: only a class's own `ntype` in its `static config` synthesizes a flag. **Third instrument/population mismatch in this ticket's own history** — the failure it exists to document. Re-measured with an acorn AST walk over `PropertyDefinition` `static config` nodes, 0 parse failures.

*Cross-checked and settled:* @neo-gpt initially measured 228, then retracted it in place — his fresh Babel **and** independent Acorn passes both yield **229**, zero parse failures, matching my Acorn walk. Three parses across two authors and two parser libraries agree, and the five exclusions match exactly.

## AC Evidence

| # | Acceptance criterion | Evidence |
|---|---|---|
| 1 | `SetupClass.md` documents the synthesis as a numbered operation, with the reactive-API contrast | new `### 3. Synthesizing is<Ntype> Type Flags`; headings now run 1–7 |
| 2 | `ExtendingNeoClasses.md` §5 carries a concise linked echo | subsection reduced to 6 lines + link to the authority section |
| 3 | States the names are computed and one grep hit ≠ dangling reference | present in `SetupClass.md` §3 and echoed in the fundamentals guide |
| 4 | Notes that renaming an `ntype` renames its derived flags | `SetupClass.md` §3, closing paragraph |
| 5 | Glossary links the authority **section anchor** | `Glossary.md` → `guides/coreengine/SetupClass.md#3-synthesizing-isntype-type-flags` |
| 6 | Duplicate `## 5.` heading renumbered | `ExtendingNeoClasses.md` headings 1,2,3,4,5,6 |
| 7 | Census names only measured ntype-derived flags, derived via `Neo.camel`/`Neo.capitalize` | table above; false four removed from ticket, PR and docs |
| 8 | Each claim reproducible from `src/Neo.mjs`; doc cites `setupClass` | §3 quotes `Neo.mjs:1026-1028` verbatim and cites the file |

## Deltas from ticket

- **The authority surface changed during review.** #17904 originally named `ExtendingNeoClasses.md` §5 as the home; it is now `SetupClass.md`, with the fundamentals guide demoted to an echo. Ticket body updated to match, with the reason recorded rather than silently swapped.
- **One AC added** (census honesty), because the defect RA-3 found had no AC that would have caught it.
- No other scope change. Still docs-only.

## Test Evidence

- `npm run check-relative-links` → **OK, 124 links across 140 files, exit 0** (122 before this work; +1 Glossary→authority, +1 fundamentals→authority).
- **Dead-link control fires:** pointing the Glossary link at `NoSuchGuide.md#…` reds with exit 1 naming the file. Verified *staged*, because the guard resolves referrers from `git ls-files` — an unstaged edit produces a clean pass that means nothing. That control is why v1's portal-id link form was caught.
- Runtime derivation with a negative control: `TreeStore.prototype.isTreeStore === true`, `.isStore === true` (inherited), `Store.prototype.isTreeStore === undefined`.
- Census reproducible: walk `src/**/*.mjs` with acorn, visit `PropertyDefinition` where `static && key.name === 'config'`, collect `Literal` values of **own** `ntype` properties on the `ObjectExpression`, derive names via `Neo.capitalize(Neo.camel(n))`, then grep readers. **A textual `ntype:` enumeration is the wrong instrument** — it counts instance/layout configs that never reach `setupClass`.
- `check-engine-brain-boundary`, `check-theme-surfaces`, `check-examples-body-only`: exit 0. Pre-commit hooks (`check-whitespace`, `check-relative-links`) pass; the whitespace hook caught four pre-existing trailing-space lines in `SetupClass.md`, now stripped.
- `check-reactive-tags` exits 1 on `dev` — **pre-existing, not mine**: its 90 findings are all under `ai/`, `apps/`, `src/`; this diff is `learn/` only. Captured separately as a defect-note (wired into neither CI nor lint-staged).

## Post-Merge Validation

Re-ask the Knowledge Base how `setupClass` generates `is<Ntype>` once `learn/` is re-ingested. RA-1's negative control was that it answered "trailing-underscore reactive configs"; after ingestion it should cite the ntype chain. **That check cannot run at merge time** — it depends on corpus re-ingestion, and the live plane currently runs a pre-split image (neomjs/neo-agent-brain#253), so it is genuinely post-merge and belongs to whoever next validates the corpus.

## Out of scope

- The synthesis itself and `grid/Container.mjs:536` — both correct as written.
- Per-class `@member {Boolean} isX=true` JSDoc: scales with class count and drifts.
- A lint resolving `is<Ntype>` reads against the ntype chain — possibly worthwhile, not what this buys.

Resolves #17904

Authored by Claude Opus 5 (Claude Code), @neo-opus-ada.
Session 698ab063-0650-4531-a2b4-53ca4268509c
