### PR TITLE
test(workstation): align Security FLIP oracle (#17872)

### DIFF
--- a/test/playwright/e2e/workstation/WorkstationNL.spec.mjs
+++ b/test/playwright/e2e/workstation/WorkstationNL.spec.mjs
@@ -1355,7 +1355,6 @@ test.describe('Workstation — dense living-data composition', () => {
                 sampledFrames                  : 0,
                 securityCaptured               : false,
                 securityActiveHeaderMissFrames : 0,
-                securityEnterMotionFrames      : 0,
                 securityBodyMissingFrames      : 0,
                 securityFullyClippedFrames     : 0,
                 securityFullyClippedSamples    : [],
@@ -1363,11 +1362,21 @@ test.describe('Workstation — dense living-data composition', () => {
                 securityPresenceTransitions    : [],
                 securityOverflowMutationFrames : 0,
                 securityReplacementFrames      : 0,
+                securityStageTransitions       : [],
                 securityStageFramesByBurst     : []
             };
-            const activeTabEmptySpans = {};
-            let   securityNode        = null,
-                  securityWasStaged   = false;
+            const
+                activeTabEmptySpans = {},
+                roundRect           = rect => rect && ({
+                    bottom: Math.round(rect.bottom),
+                    height: Math.round(rect.height),
+                    left  : Math.round(rect.left),
+                    right : Math.round(rect.right),
+                    top   : Math.round(rect.top),
+                    width : Math.round(rect.width)
+                });
+            let   securityNode      = null,
+                  securityWasStaged = false;
 
             state.securityStageBursts = 0;
             state.securityStageFrames = 0;
@@ -1548,6 +1557,7 @@ test.describe('Workstation — dense living-data composition', () => {
                     if (staged) {
                         const
                             bodyStyle = securityBody && getComputedStyle(securityBody),
+                            nodeStyle = getComputedStyle(currentSecurityNode),
                             rect      = currentSecurityNode.getBoundingClientRect(),
                             insetX    = Math.min(8, rect.width / 4),
                             insetY    = Math.min(8, rect.height / 4),
@@ -1566,7 +1576,23 @@ test.describe('Workstation — dense living-data composition', () => {
 
                         if (!securityWasStaged) {
                             state.securityStageBursts++;
-                            state.securityStageFramesByBurst.push(0)
+                            state.securityStageFramesByBurst.push(0);
+                            state.securityStageTransitions.push({
+                                activeHeader       : activeHeader?.textContent?.trim() || null,
+                                activeHeaderVisible: Boolean(activeHeader && isVisible(activeHeader)),
+                                caption            : document.querySelector('.workstation-tour-caption')?.textContent?.trim() || '',
+                                computedTransform  : nodeStyle.transform,
+                                connected          : currentSecurityNode.isConnected,
+                                firstRect          : roundRect(rect),
+                                inlineTransform    : currentSecurityNode.style.transform,
+                                lastRect           : roundRect(securityBody?.getBoundingClientRect()),
+                                stagePins          : {
+                                    height: currentSecurityNode.style.height,
+                                    left  : currentSecurityNode.style.left,
+                                    top   : currentSecurityNode.style.top,
+                                    width : currentSecurityNode.style.width
+                                }
+                            })
                         }
 
                         state.securityStageFrames++;
@@ -1580,7 +1606,6 @@ test.describe('Workstation — dense living-data composition', () => {
 
                         if (!painted) {
                             const
-                                nodeStyle  = getComputedStyle(currentSecurityNode),
                                 parentRect = currentSecurityNode.parentElement?.getBoundingClientRect();
 
                             state.securityFullyClippedFrames++;
@@ -1614,10 +1639,6 @@ test.describe('Workstation — dense living-data composition', () => {
                                     width: Math.round(rect.width)
                                 })
                         }
-                    }
-
-                    if (!staged && getComputedStyle(currentSecurityNode).transform !== 'none') {
-                        state.securityEnterMotionFrames++
                     }
 
                     securityWasStaged = staged
@@ -1804,22 +1825,53 @@ test.describe('Workstation — dense living-data composition', () => {
             `the active Security pane never leaves the DOM after capture: ${JSON.stringify(monitor.securityPresenceTransitions)}`)
             .toBe(0);
         expect(monitor.securityReplacementFrames, 'Security keeps the same DOM node across split and return').toBe(0);
+
+        const expectedSecurityStageCaptions = workstationTourScript.scenes
+            .flatMap(scene => scene.steps)
+            .filter(step => step.type === 'op' && step.descriptor?.itemId === 'security')
+            .map(step => step.caption);
+
         expect(monitor.securityStageBursts,
-            'only the return crossing stages: the split promotes a never-presented card (entering, unstaged)').toBe(1);
-        expect(monitor.securityEnterMotionFrames,
-            'the promoted never-presented pane presents its entering grow-in without a fixed stage')
-            .toBeGreaterThan(0);
-        expect(monitor.securityStageFramesByBurst, 'the sequential sampler isolates the return stage')
-            .toHaveLength(1);
-        expect(monitor.securityStageFramesByBurst[0], 'the return stage spans multiple sequential samples')
-            .toBeGreaterThan(1);
+            `the reducer-owned active tab stages on split and return: ${JSON.stringify(monitor.securityStageTransitions)}`)
+            .toBe(2);
+        expect(monitor.securityStageTransitions.map(transition => transition.caption),
+            'the sampler names the split and return crossings in screenplay order')
+            .toEqual(expectedSecurityStageCaptions);
+        expect(monitor.securityStageFramesByBurst, 'the sequential sampler isolates both crossings')
+            .toHaveLength(2);
+        expect(monitor.securityStageFramesByBurst.every(count => count > 1),
+            'each staged crossing spans multiple sequential samples').toBe(true);
+        monitor.securityStageTransitions.forEach((transition, index) => {
+            expect(transition.connected, `crossing ${index + 1}: the exact pane remains connected`).toBe(true);
+            expect(transition.activeHeaderVisible,
+                `crossing ${index + 1}: the reducer-owned Security tab remains visibly active`).toBe(true);
+            expect(transition.activeHeader, `crossing ${index + 1}: active header identity`)
+                .toBe('Security Signal Center');
+            expect(transition.computedTransform, `crossing ${index + 1}: fixed-stage inverse is live`)
+                .not.toBe('none');
+            expect(transition.inlineTransform, `crossing ${index + 1}: inline inverse is installed`)
+                .toContain('translate(');
+            expect(Number.parseFloat(transition.stagePins.width),
+                `crossing ${index + 1}: fixed-stage Last width is pinned`).toBeGreaterThan(0);
+            expect(Number.parseFloat(transition.stagePins.height),
+                `crossing ${index + 1}: fixed-stage Last height is pinned`).toBeGreaterThan(0);
+
+            for (const [name, rect] of Object.entries({First: transition.firstRect, Last: transition.lastRect})) {
+                expect(rect?.width, `crossing ${index + 1}: ${name} width is presentable`).toBeGreaterThan(0);
+                expect(rect?.height, `crossing ${index + 1}: ${name} height is presentable`).toBeGreaterThan(0)
+            }
+        });
+        expect(monitor.securityStageTransitions[0].firstRect,
+            'the split First is the return Last').toEqual(monitor.securityStageTransitions[1].lastRect);
+        expect(monitor.securityStageTransitions[0].lastRect,
+            'the split Last is the return First').toEqual(monitor.securityStageTransitions[1].firstRect);
         expect(monitor.securityStageFrames).toBe(monitor.securityStageFramesByBurst.reduce((sum, count) => sum + count, 0));
         expect(monitor.securityBodyMissingFrames,
-            'fixed staging keeps the exact pane inside its real destination body').toBe(0);
+            'both fixed stages keep the exact pane inside its real destination body').toBe(0);
         expect(monitor.securityActiveHeaderMissFrames,
             'every staged frame retains a visible active tab header').toBe(0);
         expect(monitor.securityOverflowMutationFrames,
-            'the real tab-body overflow contract stays hidden throughout the staged return').toBe(0);
+            'the real tab-body overflow contract stays hidden throughout both staged crossings').toBe(0);
         expect(monitor.securityFullyClippedFrames,
             `every staged frame paints pane content: ${JSON.stringify(monitor.securityFullyClippedSamples)}`).toBe(0);
         expect(monitor.palettes.length, 'the actual tour materially renders both theme palettes').toBeGreaterThanOrEqual(2);


### PR DESCRIPTION
Resolves #17872

The Workstation Security oracle now follows the reducer-owned active-tab contract shipped by `#17838`: because the overflow selection survives the intervening cross-zone projection, Security has presentable geometry before both `splitNode` and `addTab`, so both crossings legitimately use the fixed FLIP stage. The runtime monitor records each crossing by screenplay caption, captures the transformed First and committed Last rectangles, and proves the two moves are reciprocal while preserving the existing identity, clipping, overflow, and cleanup guards. The zero-area First rule from `#16356` remains unchanged.

Related: #17838
Related: #16356

Evidence: L3 (real Chromium Workstation choreography plus a classification red control) → L3 required (AC-1 through AC-6 are browser-runtime claims). No residuals.

Micro-review eligible: mechanical — one existing E2E oracle changes; production behavior and public contracts are untouched.

## AC Evidence

| AC | Proof |
|---|---|
| AC-1 | Outside CI: the monitor records the exact `splitNode(security → below scale)` and `addTab(security → heavy)` captions in screenplay order, one record per stage burst. |
| AC-2 | CI-covered: the unchanged `DockFlip.spec.mjs` zero-area First witness remains green and proves entering panes never receive the fixed-stage class or a zero-scale inverse. |
| AC-3 | Outside CI: both recorded crossings carry positive First/Last rectangles, a live inverse transform, positive fixed-stage pins, and a visible reducer-owned Security header. The governing contract is `#17838` / commit `d10605c04e`, which made tab activation survive unrelated projection. |
| AC-4 | Outside CI: both crossings retain the same connected Security node, span multiple sampled frames, paint within the destination clip, preserve hidden body overflow, and leave no class/transform residue. |
| AC-5 | Outside CI: two consecutive candidate runs completed the full Security assertion family; a final hard-oracle run passed the complete Workstation row. The one intervening row failure was solely the existing `#17871` blank-grid assertion, which remains hard and unchanged. |
| AC-6 | Outside CI mutation: inverting the presentable-First predicate classified both positive First rectangles as entering; the new oracle failed specifically at `Expected: 2 / Received: 0` stage bursts. |

## Deltas from ticket

The second burst is intentional, so no production repair is made. The original one-burst oracle was correct before commit `d10605c04e`: active tab selection was live-only, and the intervening cross-zone projection restored `alerts`, leaving Security zero-area immediately before the split. `#17838` made that selection document-authoritative. This PR replaces the stale count premise with the positive-geometry branch the ticket explicitly prescribed and removes the now-inapplicable entering-motion counter.

The sibling midpoint-scroll recurrence remains owned by `#17871`; its assertion is neither softened nor reordered in the committed diff.

## Test Evidence

- Hard exact-candidate Workstation row: 1 passed in real Chromium.
- Consecutive Security-family probe: both runs passed every new Security assertion; one row was fully green and one retained the independent three-frame `#17871` failure.
- Classification mutation: positive Firsts forced into the entering branch produced zero fixed-stage bursts and failed the new two-crossing assertion.

## Post-Merge Validation

None — every close-target AC is observed pre-merge.

## Evolution

The initial symptom looked like a recurrence of the zero-area staging defect. Transition telemetry falsified that premise: both rectangles were positive, and history traced the behavior change to reducer-owned tab activation. The implementation therefore strengthens the witness instead of changing DockFlip or weakening the count.

Authored by Euclid (GPT-5.6 Sol, Codex Desktop). Session a63227a3-7e65-4384-ba2c-89a2fb98ec7b.
