### PR TITLE
feat(build): enforce the agent substrate byte budget in the engine (#17911)

### DIFF
--- a/.github/workflows/substrate-size-guard.yml
+++ b/.github/workflows/substrate-size-guard.yml
@@ -1,0 +1,47 @@
+# Asserts every per-turn agent substrate entry point still fits its byte budget.
+#
+# `AGENTS.md` is injected on every turn of every seat. Past its harness limit the file is not
+# rejected — its tail is silently truncated, and agents lose the bottom of their own rules without
+# any surface saying so. The margin is currently 2 bytes, so this is a live edge rather than a
+# theoretical one.
+#
+# The guard measures what a seat LOADS, not what the entry point weighs: `.claude/CLAUDE.md` is a
+# symlink whose own `lstat` is 12 bytes, and PR #17156 nearly replaced it with a stub carrying two
+# `@`-imports. Both forms are followed, so neither shape can under-report.
+#
+# No path filter, deliberately, matching `substrate-sync`: a path-skipped workflow reports *pending*
+# rather than success and can therefore never be bound as a required status check. A guard that a
+# path filter can switch off is the failure this workflow exists to end — the previous incarnation
+# lived in another repository, was wired to nothing, and passed by never being looked at.
+#
+# No `npm ci`: the guard uses only Node built-ins, so an install would be latency with no bearing on
+# the result.
+
+name: substrate-size-guard
+
+permissions:
+  contents: read
+
+on:
+  pull_request:
+  push:
+    branches: [dev, main]
+
+concurrency:
+  group: substrate-size-guard-${{ github.run_attempt == '1' && github.ref || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  substrate-size:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '24'
+
+      - name: Check agent substrate sizes
+        run: npm run check-substrate-size

--- a/buildScripts/util/check-substrate-size.mjs
+++ b/buildScripts/util/check-substrate-size.mjs
@@ -223,10 +223,21 @@ export function main({root = REPO_ROOT, targets = TARGET_FILES, limit = PER_FILE
     return 0
 }
 
-// Entrypoint guard, realpath-hardened on BOTH sides. The common spellings compare `process.argv[1]`
-// to `import.meta.url` directly, which disagree whenever the script is reached through a symlink:
-// argv[1] is the link path, import.meta.url is the resolved target, so the module loads, `main()`
-// never runs, and the process exits 0 — a guard that silently stops guarding.
-if (process.argv[1] && fs.realpathSync(process.argv[1]) === fileURLToPath(import.meta.url)) {
+// Entrypoint guard, canonicalized on BOTH sides — and it has to be both.
+//
+// The common spellings compare `process.argv[1]` to `import.meta.url` directly, which disagree
+// whenever the script is reached through a symlink: argv[1] is the link path, import.meta.url is the
+// resolved target, so the module loads, `main()` never runs, and the process exits 0 — a guard that
+// silently stops guarding, in a script whose entire job is to fail loudly.
+//
+// Realpathing only argv[1] fixes the ordinary symlink case and leaves one open, because
+// import.meta.url is *usually* already resolved but not always: under `--preserve-symlinks-main`
+// node keeps the link path there, so the resolved argv[1] and the unresolved import.meta.url differ
+// and the guard goes false again. That is the same silent exit 0, reachable by a flag rather than by
+// a link. Found by @neo-gpt in review — the comment claimed BOTH sides while the code canonicalized
+// one, so it read as covered.
+//
+// Both operands through realpathSync, compared as canonical paths.
+if (process.argv[1] && fs.realpathSync(process.argv[1]) === fs.realpathSync(fileURLToPath(import.meta.url))) {
     process.exit(main())
 }

--- a/buildScripts/util/check-substrate-size.mjs
+++ b/buildScripts/util/check-substrate-size.mjs
@@ -1,0 +1,232 @@
+import fs              from 'node:fs';
+import path            from 'node:path';
+import process         from 'node:process';
+import {fileURLToPath} from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url)),
+      REPO_ROOT = path.resolve(__dirname, '../..');
+
+/**
+ * @module buildScripts/util/check-substrate-size
+ * @summary Enforces the per-turn agent substrate byte budget across every harness entry point.
+ *
+ * ## Why this lives here
+ *
+ * The engine owns the substrate files. `AGENTS.md`, `.agents/ANTIGRAVITY_RULES.md` and
+ * `.claude/CLAUDE.md` are committed in this repository, so the check that measures them belongs
+ * beside its targets. It previously lived at `ai/scripts/diagnostics/check-substrate-size.mjs`,
+ * which moved to `neomjs/neo-agent-brain` with the rest of `ai/` during the split — while the files
+ * it guards stayed here. The result was a guard that was declared and built but routed nowhere:
+ * unreferenced by any `package.json` script or workflow in *either* repository, and exiting 1 on
+ * "Required substrate file not found" for all three targets when run in the repo that held it.
+ *
+ * Placement follows the sibling `buildScripts/util/check-*.mjs` family
+ * (`check-engine-brain-boundary`, `check-package-contents`, `check-relative-links`,
+ * `check-theme-surfaces`) — structural fast-path, no novel directory choice. Re-creating `ai/` in
+ * the engine to host it would reintroduce exactly the tree the split removed, and
+ * `check-engine-brain-boundary` exists to keep that direction one-way.
+ *
+ * ## What "size" means
+ *
+ * The cost a seat pays is the bytes its entry point *loads*, which is not the bytes the entry point
+ * *is*. `lstat` on `.claude/CLAUDE.md` reports 12 — the length of the string `../AGENTS.md` — while
+ * the seat reads ~24 KB through it. So both indirections are followed: symlinks via `realpathSync`,
+ * and whole-line `@path` imports recursively, because an imported file may import further.
+ *
+ * @see https://github.com/neomjs/neo/issues/17175
+ */
+
+/**
+ * Per-file budget, in bytes. Documented in-repo as ANTIGRAVITY's hard limit.
+ *
+ * Do NOT raise this to make a run pass: a graduated budget is an architectural decision, not a lint
+ * setting. The remedy for a breach is Progressive Disclosure — move granular instruction into
+ * `.agents/skills/` Atlas files.
+ *
+ * @member {Number} PER_FILE_LIMIT_BYTES
+ */
+export const PER_FILE_LIMIT_BYTES = 24576;
+
+/**
+ * The per-turn entry points, each naming the harness that loads it and whose constant governs it.
+ *
+ * **The number's substrate is per-harness, and inheriting one harness's constant into another's
+ * contract is how correct-looking arithmetic governs the wrong seat.** `24576` is ANTIGRAVITY's
+ * documented per-file hard limit. The Claude seat's own cap is an operator-stated constraint whose
+ * *semantics* — what it is measured over — remain unconfirmed, because the experiment that would
+ * settle them needs a fresh authenticated seat and has not run. Until it does, the
+ * Claude row is checked against the inherited number and `limitConfirmed: false` says so out loud,
+ * so the next reader inherits a flagged assumption rather than a silent one.
+ *
+ * @member {Object[]} TARGET_FILES
+ */
+export const TARGET_FILES = [
+    {path: 'AGENTS.md',                    harness: 'Antigravity + Claude', limitConfirmed: true},
+    {path: '.agents/ANTIGRAVITY_RULES.md', harness: 'Antigravity',          limitConfirmed: true},
+    {path: '.claude/CLAUDE.md',            harness: 'Claude Code',          limitConfirmed: false}
+];
+
+/**
+ * A whole-line `@path` import in a CLAUDE.md. Claude Code resolves these relative to the importing
+ * file and loads the target's CONTENT, so the importer's own byte count is not what the seat pays.
+ *
+ * @member {RegExp} AT_IMPORT_PATTERN
+ */
+export const AT_IMPORT_PATTERN = /^@(\S+)\s*$/;
+
+/**
+ * @summary Returns the bytes a harness actually loads for an entry point, following BOTH indirections.
+ *
+ * A substrate entry point can reach its content two ways, and a near-miss once changed the file from
+ * one to the other: `.claude/CLAUDE.md` is a SYMLINK to `AGENTS.md` today, and a proposed change
+ * would have replaced it with a real file carrying `@`-imports. A check that reads only one form computes the
+ * wrong total — `lstat` on the symlink reports 12 bytes (the target path string), and `stat` on an
+ * import stub reports ~25 bytes, while the seat loads tens of kilobytes in both cases.
+ *
+ * Symlinks resolve through `realpathSync`, which also keys the cycle guard on file identity rather
+ * than on the path used to reach it. Imports recurse, because an imported file may import further.
+ *
+ * @param {String} file Repo-relative or absolute path to the entry point.
+ * @param {Object}   [options={}]
+ * @param {String}   [options.root=REPO_ROOT] Base for relative paths and for reported member names.
+ * @param {Set<String>} [options.seen] Realpaths already counted — cycle guard and double-count guard.
+ * @returns {{bytes: Number, members: String[]}} Loaded bytes, and the imported members contributing.
+ * @throws {Error} If an import names a file that does not exist — a budget that silently drops a
+ *   renamed member measures a fiction and passes, so this fails closed rather than skipping.
+ */
+export function resolveLoadedSize(file, {root = REPO_ROOT, seen = new Set()} = {}) {
+    const
+        full = path.isAbsolute(file) ? file : path.join(root, file),
+        real = fs.realpathSync(full);
+
+    // An entry point reachable twice (symlink plus direct import) is paid for once by the loader.
+    if (seen.has(real)) {
+        return {bytes: 0, members: []}
+    }
+
+    seen.add(real);
+
+    const
+        text    = fs.readFileSync(real, 'utf8'),
+        members = [];
+
+    let bytes = Buffer.byteLength(text, 'utf8');
+
+    text.split('\n').forEach(line => {
+        const match = line.match(AT_IMPORT_PATTERN);
+
+        if (!match) {
+            return
+        }
+
+        const target = path.resolve(path.dirname(real), match[1]);
+
+        if (!fs.existsSync(target)) {
+            throw new Error(`${file} imports '${match[1]}', which does not exist`)
+        }
+
+        const child = resolveLoadedSize(target, {root, seen});
+
+        bytes += child.bytes;
+        members.push(path.relative(root, target), ...child.members)
+    });
+
+    return {bytes, members}
+}
+
+/**
+ * @summary Measures every target and returns one row per entry point — the pure half of the guard.
+ *
+ * Returned rather than printed so the arms that matter can be asserted without spawning a process:
+ * a guard whose only observable is stdout gets tested by reading its own log line back, which
+ * confirms the formatter rather than the measurement.
+ *
+ * @param {Object}     [options={}]
+ * @param {String}     [options.root=REPO_ROOT] Tree to measure — a temp fixture in tests.
+ * @param {Object[]}   [options.targets=TARGET_FILES]
+ * @param {Number}     [options.limit=PER_FILE_LIMIT_BYTES]
+ * @returns {Object[]} Rows: `{file, harness, limitConfirmed, bytes, members, over, headroom, error}`.
+ *   A row carrying `error` is a failure, never a skip.
+ */
+export function collectReport({root = REPO_ROOT, targets = TARGET_FILES, limit = PER_FILE_LIMIT_BYTES} = {}) {
+    return targets.map(({path: file, harness, limitConfirmed}) => {
+        const row = {file, harness, limitConfirmed, bytes: null, members: [], over: false, headroom: null, error: null};
+
+        if (!fs.existsSync(path.join(root, file))) {
+            row.error = `Required substrate file ${file} not found.`;
+            return row
+        }
+
+        let loaded;
+
+        try {
+            loaded = resolveLoadedSize(file, {root})
+        } catch (error) {
+            // Fail closed: an unresolvable member means the total is unknown, and an unknown total
+            // must never render as a pass.
+            row.error = error.message;
+            return row
+        }
+
+        row.bytes    = loaded.bytes;
+        row.members  = loaded.members;
+        row.over     = loaded.bytes > limit;
+        row.headroom = limit - loaded.bytes;
+
+        return row
+    })
+}
+
+/**
+ * @summary Prints the report and exits non-zero if any target breached or could not be measured.
+ * @returns {Number} The process exit code, so a caller can assert it without a spawn.
+ */
+export function main({root = REPO_ROOT, targets = TARGET_FILES, limit = PER_FILE_LIMIT_BYTES} = {}) {
+    const rows = collectReport({root, targets, limit});
+
+    console.log(`\n🔍 Checking agent substrate sizes against the ${limit} byte per-file limit...`);
+    console.log('--------------------------------------------------------------------------------');
+
+    rows.forEach(({file, harness, limitConfirmed, bytes, members, over, headroom, error}) => {
+        if (error) {
+            console.error(`❌ Error: ${error}`);
+            return
+        }
+
+        const status = over ? '❌ EXCEEDS' : '✅ PASS';
+
+        console.log(`📄 ${file.padEnd(30)} : ${bytes} bytes [${status}] · ${harness}${limitConfirmed ? '' : ' · limit INHERITED from another harness, semantics unconfirmed'}`);
+
+        // Headroom, not just pass/fail: this drift is gradual, so a shrinking margin is the signal —
+        // by the time it flips to EXCEEDS the substrate is already truncating. Counts bytes an
+        // author may still ADD, which is the question they are actually asking.
+        console.log(`   limit ${limit} · ${over ? `OVER by ${-headroom}` : `headroom ${headroom}`} bytes`);
+
+        // Name what the total is made of whenever it is not just the file itself, so a reader can
+        // see WHY an entry point costs more than its own bytes rather than re-deriving the chain.
+        members.length && console.log(`   composed via @-import: ${members.join(', ')}`)
+    });
+
+    console.log('--------------------------------------------------------------------------------');
+
+    if (rows.some(row => row.error || row.over)) {
+        console.error(`\n❌ Substrate Size Check FAILED!`);
+        console.error(`A file exceeds the hard limit of ${limit} bytes: the bottom of the offending file is silently truncated and agents lose critical memory.`);
+        console.error(`Fix by migrating granular instructions to .agents/skills/ Atlas files (Progressive Disclosure).`);
+        console.error(`Do NOT raise a limit to make this pass: a graduated budget is a decision, not a lint setting.`);
+
+        return 1
+    }
+
+    console.log(`\n✅ Substrate Size Check PASSED. Every measured file is under ${limit} bytes.\n`);
+
+    return 0
+}
+
+// Entrypoint guard, realpath-hardened on BOTH sides. The common spellings compare `process.argv[1]`
+// to `import.meta.url` directly, which disagree whenever the script is reached through a symlink:
+// argv[1] is the link path, import.meta.url is the resolved target, so the module loads, `main()`
+// never runs, and the process exits 0 — a guard that silently stops guarding.
+if (process.argv[1] && fs.realpathSync(process.argv[1]) === fileURLToPath(import.meta.url)) {
+    process.exit(main())
+}

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
         "check-package-contents"               : "node ./buildScripts/util/check-package-contents.mjs",
         "check-reactive-tags"                  : "node ./buildScripts/helpers/checkReactiveTags.mjs",
         "check-relative-links"                 : "node ./buildScripts/util/check-relative-links.mjs",
+        "check-substrate-size"                 : "node ./buildScripts/util/check-substrate-size.mjs",
         "convert-design-tokens"                : "node ./buildScripts/helpers/convertDesignTokens.mjs",
         "create-app"                           : "node ./buildScripts/create/app.mjs",
         "create-app-minimal"                   : "node ./buildScripts/create/appMinimal.mjs",

--- a/test/playwright/unit/buildScripts/checkSubstrateSize.spec.mjs
+++ b/test/playwright/unit/buildScripts/checkSubstrateSize.spec.mjs
@@ -1,4 +1,5 @@
 import {test, expect} from '@playwright/test';
+import {spawnSync}    from 'node:child_process';
 import fs             from 'fs';
 import os             from 'os';
 import path           from 'path';
@@ -154,5 +155,170 @@ test.describe('check-substrate-size — resolution mechanics', () => {
         expect('hand off to @tobiu (human operator)').toMatch(/@tobiu/);
         expect('hand off to @tobiu (human operator)'.match(AT_IMPORT_PATTERN)).toBeNull();
         expect('**No `<noreply@*>` footers.**'.match(AT_IMPORT_PATTERN)).toBeNull()
+    })
+});
+
+/**
+ * The executable boundary — the one the workflow actually trusts.
+ *
+ * Everything above imports `collectReport` and `resolveLoadedSize` and drives them with fixture
+ * roots. That covers the measurement and nothing else: `main()`, its exit code, the headroom line,
+ * `REPO_ROOT`'s derivation, and the entrypoint guard were all unreached, so the CI step could stop
+ * enforcing anything while every assertion stayed green. Raised by @neo-gpt in review.
+ *
+ * **How the fixture reaches `REPO_ROOT` without a CLI flag.** The script derives
+ * `REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '../..')`, so a COPY placed at
+ * `<fixture>/buildScripts/util/check-substrate-size.mjs` measures `<fixture>`. That is why the copy
+ * exists rather than a `--root` option: adding one would create a public CLI contract purely to make
+ * the code testable, and it would test the flag instead of the derivation. Every run below also uses
+ * a foreign `cwd`, so a regression of `REPO_ROOT` to `process.cwd()` reds these arms.
+ *
+ * The script imports only node builtins, so a copy is a faithful executable.
+ */
+test.describe('check-substrate-size — the process boundary', () => {
+    const SCRIPT_REL = 'buildScripts/util/check-substrate-size.mjs';
+
+    let scratch = [];
+
+    test.afterAll(() => {
+        scratch.forEach(dir => fs.rmSync(dir, {force: true, recursive: true}));
+        scratch = []
+    });
+
+    /**
+     * @summary Builds a runnable fixture repo: a copy of the real script over a substrate tree.
+     * @param {Object} [options]
+     * @param {Boolean} [options.over=false] Push AGENTS.md past the limit.
+     * @param {Boolean} [options.danglingImport=false] Point CLAUDE.md at a file that is not there.
+     * @param {Boolean} [options.missingTarget=false] Omit a required substrate file entirely.
+     * @returns {String} Absolute fixture root.
+     */
+    function buildRunnableRepo({over = false, danglingImport = false, missingTarget = false} = {}) {
+        const root = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), 'substrate-exec-')));
+
+        scratch.push(root);
+
+        fs.mkdirSync(path.join(root, '.agents'));
+        fs.mkdirSync(path.join(root, '.claude'));
+        fs.mkdirSync(path.join(root, 'buildScripts/util'), {recursive: true});
+        fs.copyFileSync(path.resolve(process.cwd(), SCRIPT_REL), path.join(root, SCRIPT_REL));
+
+        fs.writeFileSync(path.join(root, 'AGENTS.md'), 'A'.repeat(over ? PER_FILE_LIMIT_BYTES + 1 : 100));
+        fs.writeFileSync(path.join(root, '.agents/ANTIGRAVITY_RULES.md'), 'R'.repeat(100));
+
+        if (!missingTarget) {
+            fs.writeFileSync(
+                path.join(root, '.claude/CLAUDE.md'),
+                danglingImport ? '@../NOT_THERE.md\n' : '@../AGENTS.md\n'
+            )
+        }
+
+        return root
+    }
+
+    /**
+     * @summary Runs the fixture's script as a real process from a foreign cwd.
+     * @param {String} root Fixture root.
+     * @param {Object} [options]
+     * @param {String[]} [options.nodeArgs=[]] Extra node flags, e.g. `--preserve-symlinks-main`.
+     * @param {String} [options.entry] Path to invoke instead of the script itself (a symlink).
+     * @returns {{code: Number, output: String}}
+     */
+    function run(root, {nodeArgs = [], entry} = {}) {
+        const result = spawnSync(
+            process.execPath,
+            [...nodeArgs, entry ?? path.join(root, SCRIPT_REL)],
+            // A foreign cwd on purpose: os.tmpdir() holds no substrate, so anything resolving its
+            // root from process.cwd() reports three missing targets instead of measuring the fixture.
+            {cwd: os.tmpdir(), encoding: 'utf8'}
+        );
+
+        return {code: result.status, output: `${result.stdout ?? ''}${result.stderr ?? ''}`}
+    }
+
+    test('CONTROL: an under-limit tree exits 0 and reports headroom', () => {
+        const {code, output} = run(buildRunnableRepo());
+
+        expect(code, `expected a clean exit, got:\n${output}`).toBe(0);
+        expect(output).toContain('PASSED');
+
+        // The headroom line is the guard's actual product — the drift is gradual, so the margin is
+        // the signal. Losing it while still exiting 0 would be a silent downgrade to pass/fail.
+        expect(output, 'the headroom line disappeared from the report').toMatch(/headroom \d+ bytes/);
+
+        // Proof the foreign cwd did not decide the measurement: a process.cwd() root finds nothing.
+        expect(output).not.toContain('not found')
+    });
+
+    test('an over-limit file exits 1', () => {
+        const {code, output} = run(buildRunnableRepo({over: true}));
+
+        expect(code).toBe(1);
+        expect(output).toContain('EXCEEDS');
+        expect(output).toMatch(/OVER by \d+ bytes/)
+    });
+
+    test('an import naming a file that is not there exits 1', () => {
+        // `row.error`, not `row.over`. A main() that only checked `over` would exit 0 here while the
+        // substrate was unmeasurable — the failure mode is not "too big", it is "we do not know".
+        const {code, output} = run(buildRunnableRepo({danglingImport: true}));
+
+        expect(code).toBe(1);
+        expect(output).toContain('Error')
+    });
+
+    test('a missing required target exits 1', () => {
+        const {code, output} = run(buildRunnableRepo({missingTarget: true}));
+
+        expect(code).toBe(1);
+        expect(output).toContain('not found')
+    });
+
+    /**
+     * @summary Symlinks the fixture's script beside itself and returns the link path.
+     *
+     * Beside, not elsewhere, and that placement is the experiment rather than convenience. Under
+     * `--preserve-symlinks-main` node keeps the LINK path in `import.meta.url`, and `REPO_ROOT` is
+     * derived from that path — so a link parked in a different directory would move the measured
+     * root as well as exercise the guard, and a failure could not be attributed to either. Keeping
+     * the link at the same depth holds `REPO_ROOT` fixed so the node flag is the only variable.
+     * @param {String} root
+     * @param {String} name
+     * @returns {String} Absolute link path.
+     */
+    function linkBesideScript(root, name) {
+        const link = path.join(root, 'buildScripts/util', name);
+
+        fs.symlinkSync(path.join(root, SCRIPT_REL), link);
+
+        return link
+    }
+
+    test('reached through a SYMLINK the guard still fires', () => {
+        const
+            root = buildRunnableRepo({over: true}),
+            link = linkBesideScript(root, 'via-link.mjs');
+
+        const {code, output} = run(root, {entry: link});
+
+        // Exit 0 here would NOT mean "passed" — it would mean main() never ran. That is the whole
+        // hazard: a guard that stops guarding reports success.
+        expect(code, `the guard did not fire through the symlink:\n${output}`).toBe(1);
+        expect(output).toContain('EXCEEDS')
+    });
+
+    test('under --preserve-symlinks-main the guard STILL fires', () => {
+        // The arm the one-sided realpath let through. With this flag node keeps the LINK path in
+        // import.meta.url while argv[1] still resolves, so realpathing only argv[1] made the two
+        // operands disagree and the process exited 0 with the substrate unchecked. Canonicalizing
+        // both is what closes it. Found by @neo-gpt in review.
+        const
+            root = buildRunnableRepo({over: true}),
+            link = linkBesideScript(root, 'via-preserve.mjs');
+
+        const {code, output} = run(root, {entry: link, nodeArgs: ['--preserve-symlinks-main']});
+
+        expect(code, `silent exit 0 — the entrypoint guard did not invoke main():\n${output}`).toBe(1);
+        expect(output).toContain('EXCEEDS')
     })
 });

--- a/test/playwright/unit/buildScripts/checkSubstrateSize.spec.mjs
+++ b/test/playwright/unit/buildScripts/checkSubstrateSize.spec.mjs
@@ -1,0 +1,158 @@
+import {test, expect} from '@playwright/test';
+import fs             from 'fs';
+import os             from 'os';
+import path           from 'path';
+
+import {
+    AT_IMPORT_PATTERN, collectReport, PER_FILE_LIMIT_BYTES, resolveLoadedSize
+} from '../../../../buildScripts/util/check-substrate-size.mjs';
+
+/**
+ * The guard exists because a substrate breach is SILENT: past the limit the tail of `AGENTS.md` is
+ * truncated and every seat loses the bottom of its own rules with nothing reporting it. So the arms
+ * that matter are the ones where a wrong implementation still looks green — a symlink measured as
+ * its own 12-byte path string, an import stub measured as its own ~25 bytes, a renamed import
+ * quietly dropped from the total.
+ *
+ * Sizes are the real ones from the near-miss this guard exists to catch (`AGENTS.md` 24,380 B,
+ * `NOW.md` 1,586 B) so the fixture reproduces the incident's arithmetic rather than a convenient toy.
+ */
+
+const
+    AGENTS_BYTES = 24380,
+    NOW_BYTES    = 1586,
+    // '@../AGENTS.md\n@../NOW.md\n' — the stub's own bytes, which the seat also reads.
+    STUB_BYTES   = 25;
+
+/**
+ * Builds a throwaway substrate tree and returns its realpath.
+ *
+ * The root is realpath-resolved because `os.tmpdir()` is itself a symlink on macOS
+ * (`/var` → `/private/var`); leaving it unresolved would make reported member paths relative to a
+ * directory the resolved files are not actually under.
+ *
+ * @param {String} claudeShape Either `'symlink'` (today's tree) or `'imports'` (the near-miss shape).
+ * @returns {String} Absolute realpath of the fixture root.
+ */
+function buildTree(claudeShape) {
+    const root = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), 'substrate-size-')));
+
+    fs.mkdirSync(path.join(root, '.agents'));
+    fs.mkdirSync(path.join(root, '.claude'));
+
+    fs.writeFileSync(path.join(root, 'AGENTS.md'), 'A'.repeat(AGENTS_BYTES));
+    fs.writeFileSync(path.join(root, 'NOW.md'),    'N'.repeat(NOW_BYTES));
+    fs.writeFileSync(path.join(root, '.agents/ANTIGRAVITY_RULES.md'), 'R'.repeat(100));
+
+    claudeShape === 'symlink' ?
+        fs.symlinkSync('../AGENTS.md', path.join(root, '.claude/CLAUDE.md')) :
+        fs.writeFileSync(path.join(root, '.claude/CLAUDE.md'), '@../AGENTS.md\n@../NOW.md\n');
+
+    return root
+}
+
+const claudeRow = rows => rows.find(row => row.file === '.claude/CLAUDE.md');
+
+test.describe('check-substrate-size — the two entry-point shapes', () => {
+    test('CONTROL: the symlink tree passes, measured as the TARGET and not as the link', () => {
+        const row = claudeRow(collectReport({root: buildTree('symlink')}));
+
+        // The whole point: `lstat` on this symlink reports 12 — the length of '../AGENTS.md'. A
+        // guard reporting 12 passes every conceivable substrate and is worse than no guard.
+        expect(row.bytes).toBe(AGENTS_BYTES);
+        expect(row.bytes).not.toBe('../AGENTS.md'.length);
+        expect(row.over).toBe(false);
+        expect(row.error).toBeNull();
+        expect(row.headroom).toBe(PER_FILE_LIMIT_BYTES - AGENTS_BYTES)
+    });
+
+    test('the PR #17156 near-miss FAILS: two @-imports are summed as one loaded unit', () => {
+        const row = claudeRow(collectReport({root: buildTree('imports')}));
+
+        // 24,380 + 1,586 + the stub's own 25. Pinned as a literal: a summing regression that drops
+        // a member or forgets the importer's own bytes must not be able to still land on it.
+        expect(row.bytes).toBe(AGENTS_BYTES + NOW_BYTES + STUB_BYTES);
+        expect(row.bytes).toBe(25991);
+        expect(row.over).toBe(true);
+        expect(row.headroom).toBe(PER_FILE_LIMIT_BYTES - 25991);
+        expect(row.members).toEqual(['AGENTS.md', 'NOW.md'])
+    });
+
+    test('the same tree differs ONLY in that shape — so the shape is what the guard caught', () => {
+        // Non-vacuity: both arms above must not be passing for some unrelated fixture difference.
+        const symlink = claudeRow(collectReport({root: buildTree('symlink')})),
+              imports = claudeRow(collectReport({root: buildTree('imports')}));
+
+        expect(symlink.over).toBe(false);
+        expect(imports.over).toBe(true);
+        expect(imports.bytes - symlink.bytes).toBe(NOW_BYTES + STUB_BYTES)
+    })
+});
+
+test.describe('check-substrate-size — fails closed', () => {
+    test('an import naming a file that does not exist is an ERROR, never a skipped member', () => {
+        const root = buildTree('imports');
+
+        // The rename case: a budget that silently drops a missing member measures a fiction, and
+        // the fiction is always SMALLER — so it passes.
+        fs.rmSync(path.join(root, 'NOW.md'));
+
+        const row = claudeRow(collectReport({root}));
+
+        expect(row.error).toContain("imports '../NOW.md', which does not exist");
+        expect(row.bytes).toBeNull();
+        expect(row.over).toBe(false)
+    });
+
+    test('a missing target file is an ERROR row, not an absent row that reads as a pass', () => {
+        const root = buildTree('symlink');
+
+        fs.rmSync(path.join(root, '.agents/ANTIGRAVITY_RULES.md'));
+
+        const rows = collectReport({root}),
+              row  = rows.find(entry => entry.file === '.agents/ANTIGRAVITY_RULES.md');
+
+        expect(rows).toHaveLength(3);
+        expect(row.error).toBe('Required substrate file .agents/ANTIGRAVITY_RULES.md not found.')
+    })
+});
+
+test.describe('check-substrate-size — resolution mechanics', () => {
+    test('imports recurse, because an imported file may import further', () => {
+        const root = buildTree('imports');
+
+        fs.writeFileSync(path.join(root, 'NOW.md'), '@./DEEP.md\n');
+        fs.writeFileSync(path.join(root, 'DEEP.md'), 'D'.repeat(500));
+
+        const {bytes, members} = resolveLoadedSize('.claude/CLAUDE.md', {root});
+
+        expect(members).toEqual(['AGENTS.md', 'NOW.md', 'DEEP.md']);
+        expect(bytes).toBe(AGENTS_BYTES + 11 + 500 + STUB_BYTES)
+    });
+
+    test('a file reachable twice is paid for once, and a cycle terminates', () => {
+        const root = buildTree('imports');
+
+        // Both the stub (as '../AGENTS.md' from .claude/) and NOW.md (as './AGENTS.md' from the
+        // root) import the same file by different paths; the loader reads it once.
+        fs.writeFileSync(path.join(root, 'NOW.md'), '@./AGENTS.md\n');
+
+        const {bytes} = resolveLoadedSize('.claude/CLAUDE.md', {root});
+
+        // '@./AGENTS.md\n' is 13 bytes, and AGENTS.md itself is counted ONCE despite two referents —
+        // the cycle guard keys on realpath, so the two spellings collapse to one identity.
+        expect(bytes).toBe(AGENTS_BYTES + 13 + STUB_BYTES);
+        expect(bytes).toBeLessThan(2 * AGENTS_BYTES);
+
+        // A self-import must not recurse forever.
+        fs.writeFileSync(path.join(root, 'NOW.md'), '@./NOW.md\n');
+        expect(() => resolveLoadedSize('.claude/CLAUDE.md', {root})).not.toThrow()
+    });
+
+    test('only a whole-line @path is an import — a mid-prose @handle is prose', () => {
+        expect('@../AGENTS.md'.match(AT_IMPORT_PATTERN)[1]).toBe('../AGENTS.md');
+        expect('hand off to @tobiu (human operator)').toMatch(/@tobiu/);
+        expect('hand off to @tobiu (human operator)'.match(AT_IMPORT_PATTERN)).toBeNull();
+        expect('**No `<noreply@*>` footers.**'.match(AT_IMPORT_PATTERN)).toBeNull()
+    })
+});


### PR DESCRIPTION
Resolves #17911

The substrate-size guard measures three files that live in this repo and had no caller in any repo. Its source moved to `neo-agent-brain` with the rest of `ai/` during the #17500 cut; the files stayed here. This restores it beside its targets at `buildScripts/util/check-substrate-size.mjs`, wires an npm script and a workflow, and pins the two entry-point shapes with an executable control. `AGENTS.md` is currently **2 bytes** under its limit, so the instrument was unrunnable for the entire drift from ~196 B.

Evidence: fully achieved in-sandbox — the guard is executed, not inspected, and the workflow runs on this PR itself, so AC-1's "green run rather than inspection" is discharged by this PR's own check. No residual ACs, no unavailable-environment effects. *(The `Evidence:` line normally cites `learn/agentos/process/evidence-ladder.md` L-levels; that file is absent from this repo — see Deltas — and I am not citing levels I cannot read.)*

## AC Evidence

| AC | Proof |
|---|---|
| AC-1 — exists beside its targets + a production caller, verified by a green run | `buildScripts/util/check-substrate-size.mjs` + `package.json#scripts.check-substrate-size` + `.github/workflows/substrate-size-guard.yml`; this PR's own `substrate-size-guard` check is the green run. Local: `npm run check-substrate-size` → exit 0, 3 targets measured. |
| AC-2 — resolves its own repo root, not `process.cwd()` | `check-substrate-size.mjs` `REPO_ROOT` from `import.meta.url`. Receipt: run with `cd /tmp && node <abs-path>` → exit 0. The pre-fix cwd form returned "Required substrate file not found" for all three targets from a foreign cwd. |
| AC-3 — headroom reported every run, not just pass/fail | `main()` prints `limit … · headroom N bytes` per row; live output in the Test Evidence receipt below. Asserted in `checkSubstrateSize.spec.mjs` — the symlink control pins `headroom` explicitly. |
| AC-4 — control reproduces the near-miss; two arms differ only in shape | `checkSubstrateSize.spec.mjs` — "the near-miss FAILS: two `@`-imports are summed as one loaded unit" (25,991 B, over) vs "the symlink tree passes, measured as the TARGET not the link" (24,380 B), plus a third arm asserting the two fixtures differ only by that shape. |
| AC-5 — fails closed on a missing member or missing target | `checkSubstrateSize.spec.mjs` — a removed import target yields an error row with `bytes: null`, never a smaller passing total; a removed target file yields an error row rather than an absent one. |

## Deltas from ticket

Three changes beyond relocation, none of which alter what the guard measures:

- **Repo-root resolution** (AC-2) was added to the ticket after triage bit on it: my own first run of the Brain copy silently measured the wrong tree because a `cd` in a compound command did not persist, and reported a clean "not found" that looked like a finding.
- **The measuring half is exported** (`collectReport`, `resolveLoadedSize`) so the arms can be asserted without spawning. A guard whose only observable is stdout gets tested by reading its own log line back, which confirms the formatter rather than the measurement.
- **The entrypoint guard is realpath-hardened on both sides.** Both in-tree spellings compare `process.argv[1]` to `import.meta.url` directly; those disagree whenever the script is reached through a symlink, so the module loads, `main()` never runs, and the process exits 0 — a guard that silently stops guarding. Verified by executing through a symlink.

**Workflow trigger — a deliberate departure from #17911's sibling family, flagged for the reviewer.** The `check-*` workflows use path filters. This one takes none, following `substrate-sync.yml`, whose comment states the reason: a path-skipped workflow reports *pending* rather than success and can therefore never be bound as a required status check. Given #17783 R1 measured **zero** required contexts on `dev`, binding-eligibility seemed the more valuable property for a guard on a 2-byte margin. Cost is one always-on job; it installs nothing and uses only Node built-ins. Push back if you read that trade differently.

**Not in scope, and not silently absorbed:** #17175 keeps AC-1 (the `@`-import budgeting experiment, which needs a fresh authenticated seat), AC-2, AC-7 and AC-8. The Claude row stays `limitConfirmed: false` so that assumption is flagged rather than silent. The orphaned Brain copy is not deleted — different repo, and its checkout is under concurrent write.

**Pattern, reported not filed:** `agent-preflight.mjs`, `agent-pr-body-lint.yml` and `learn/agentos/process/evidence-ladder.md` are all referenced by the live `pull-request` skill and all absent from this repo — the same shape as #17783 R2/R3 on guards this PR does not touch. Sent to @neo-gpt as candidate residuals for #17783 rather than annexed here; #17911 stays one leaf.

## Test Evidence

`npm run test-unit -- test/playwright/unit/buildScripts/checkSubstrateSize.spec.mjs` → **8/8 passed**.

**Mutation (outside CI — what green cannot show).** Two mutations applied to the guard, both ways:

| mutation | result |
|---|---|
| `AT_IMPORT_PATTERN` made non-matching | **6 red**, including the near-miss arm and the recursion/cycle arms |
| missing-import `throw` → `return` (fail-open) | the fails-closed arm goes **red** |
| both reverted | **8/8 green**, `grep MUTANT` → clean |

The two arms that stayed green under both mutations are the symlink control and the missing-target row — correctly insensitive to import-resolution logic, which is the discrimination that makes the other six meaningful.

**Live guard receipt**, `npm run check-substrate-size` at this head:

```
AGENTS.md                    : 24574 bytes [PASS] · Antigravity + Claude · headroom 2 bytes
.agents/ANTIGRAVITY_RULES.md :  3734 bytes [PASS] · Antigravity          · headroom 20842 bytes
.claude/CLAUDE.md            : 24574 bytes [PASS] · Claude Code          · headroom 2 bytes
                                                     limit INHERITED from another harness, semantics unconfirmed
```

## Post-Merge Validation

- [ ] `substrate-size-guard` appears as a check on the next PR touching any path, confirming the no-path-filter trigger behaves as intended on a diff unrelated to substrate.
- [ ] Consider binding `substrate-size-guard` as a required status context on `dev` — it is now eligible, but the binding itself is a repository setting and belongs to #17783 AC-1, not here.
- [ ] `AGENTS.md` at 2 bytes of headroom is now enforced rather than merely true. The first substrate PR to hit the wall gets a red check instead of a silent truncation; what to do with the headroom is a separate call.

## Commits

- `e27ffe2` — restore the guard beside its targets, wire npm script + workflow, add the two-shape control. Single commit; the SHA moved once pre-review when the subject was reclassified `fix` → `feat` (a new operable path, not a restoration of defined behavior) and the leaf close target changed to #17911.

Refs #17175 · Refs #17783 · Refs #17763 · Refs #17500

🖖 Authored by Grace (Claude Opus 5, Claude Code). Session 6450d654-e742-4791-ba87-b440f2301aa0.
