### PR TITLE
Restore the dependency-free half of the PR-body gate (#17916)

### DIFF
--- a/.github/workflows/agent-pr-body-lint.yml
+++ b/.github/workflows/agent-pr-body-lint.yml
@@ -1,0 +1,205 @@
+# Restored in #17916 after #17791 removed this file as collateral of the Brain split.
+#
+# THIS GATE IS DELIBERATELY PARTIAL. The original workflow (recoverable in full at
+# `91ae3604b4^:.github/workflows/agent-pr-body-lint.yml`) ran three steps; two of them invoked
+# `ai/scripts/*`, which moved to `neomjs/neo-agent-brain`. The whole file went out with them, and
+# with it the one step that never had a cross-repository dependency at all. That is the step below.
+#
+# Present here:
+#   - anchor PRESENCE for the six `pull-request-workflow.md` §9 anchors, plus the `Resolves #N`
+#     close-target rule (#12367). Inline `github-script`; no checkout, no npm, no Brain.
+#
+# NOT present here, and NOT silently dropped — each needs a cross-repository caller, which is
+# `neo-agent-skills#14`'s authority and `neo-agent-skills#24`'s mechanism:
+#   - the AC-Evidence CONTENT check (`ai/scripts/agent-preflight.mjs`) — it resolved the close
+#     target and failed a certificate that missed the ticket's AC count or left a proof slot empty.
+#   - the stacked-PR guard (`ai/scripts/lint/lint-pr-stacking.mjs`, origin #16589).
+#
+# So: a body that names every anchor over empty prose passes THIS gate. Read the anchor list as a
+# floor, never as a certification. `pull-request-workflow.md` §9 is being corrected under #17916 to
+# stop describing the content check as live while only presence is enforced.
+
+name: Agent PR Body Lint
+on:
+  pull_request:
+    types: [opened, edited, synchronize, ready_for_review]
+
+
+jobs:
+  lint-pr-body:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Validate PR Body
+        uses: actions/github-script@v9
+        with:
+          script: |
+            // Read the pull request LIVE rather than from `context.payload.pull_request`, which
+            // holds the body as it was when the event fired. A payload-sourced body cannot be
+            // corrected into a green verdict (a re-run replays the stale text) and cannot lose a
+            // green one it no longer deserves (an edit after a pass is never re-judged). #17431
+            // bought this property; it survives here because this step does its own fetch.
+            const {data: pr} = await github.rest.pulls.get({
+              owner      : context.repo.owner,
+              repo       : context.repo.repo,
+              pull_number: context.payload.pull_request.number
+            });
+
+            const author  = pr.user.login;
+            const body    = pr.body || "";
+            const isDraft = Boolean(pr.draft);
+
+            // Only enforce for known AI agent accounts or PRs labeled with 'ai'
+            const agentAuthors  = ['neo-opus-ada', 'neo-opus-grace', 'neo-opus-vega', 'neo-gemini-pro', 'neo-gpt'];
+            const isAgentAuthor = agentAuthors.includes(author) || author.startsWith('neo-');
+            const hasAiLabel    = pr.labels && pr.labels.some(l => l.name === 'ai');
+
+            if (!isAgentAuthor && !hasAiLabel) {
+              console.log(`✅ Author ${author} is not an AI agent and no 'ai' label present. Skipping lint.`);
+              return;
+            }
+
+            console.log(`🔍 Linting PR body for agent-authored PR by: ${author}`);
+
+            // ──────────────────────────────────────────────────────────────────────
+            // Two-layer mechanical body-shape validation (#11501, mirrors reviewer-side
+            // PR #11502/#11495 pattern derived from PR #11494's MCP `manage_pr_review`
+            // canonical primary surface).
+            //
+            // VISIBLE layer: explicit anchors from `pull-request-workflow.md §9`
+            // minimum-viable PR body structure. Misses surface as a precise list in
+            // the collapsed details block + ONE diagnostic anchor named in the
+            // human-facing message.
+            //
+            // INVISIBLE layer: structural template substrings checked SILENTLY.
+            // Misses NOT named in the follow-up comment — neither in prose nor as
+            // enumeration. Defeats Goodhart anchor-stuffing where an agent hallucinates
+            // a body that contains exactly the named visible anchors but omits the
+            // actual template structure or self-identification.
+            //
+            // ⚠️  SYNCHRONIZATION PROTOCOL: this list MUST stay in sync with
+            // `pull-request-workflow.md §9` minimum-viable PR body + §5 Self-
+            // Identification mandate. Per #11501 cycle-2 scope-correction, the
+            // shared-module extraction (`prReviewAnchors.mjs`) was reverted in
+            // PR #11502; sync-by-convention with comment-pointers is the accepted
+            // cross-surface coordination shape going forward.
+            // ──────────────────────────────────────────────────────────────────────
+
+            const VISIBLE_PR_BODY_ANCHORS = [
+              "Evidence:",
+              "## AC Evidence",
+              "## Test Evidence",
+              "## Post-Merge Validation"
+            ];
+
+            const INVISIBLE_PR_BODY_ANCHORS = [
+              "Authored by ",
+              "## Deltas"
+            ];
+
+            const missingVisible   = VISIBLE_PR_BODY_ANCHORS  .filter(a => !body.includes(a));
+            const missingInvisible = INVISIBLE_PR_BODY_ANCHORS.filter(a => !body.includes(a));
+
+            // Ticket-reference is a separate visible check (regex pattern, not substring).
+            //
+            // Operator rule (#12367): every agent PR body MUST contain at least one `Resolves #N`
+            // — the ONLY sanctioned closing keyword (it means *delivered work*). This mechanically
+            // enforces the 1-PR-per-ticket model: a ticket that needs N PRs cannot have N valid
+            // `Resolves` (only one PR can resolve it), so it must become an epic + subs or be split.
+            //   - `Closes #N` is FORBIDDEN: "Closes" = closed-without-delivery (not-planned /
+            //     superseded / dropped) — that outcome needs NO PR, so a PR must never carry it.
+            //   - `Fixes #N`  is FORBIDDEN: ambiguous; use `Resolves` (bug fixes included).
+            //   - `Refs #N` / `Related: #N` are allowed as ADDITIONAL references (e.g. a parent
+            //     epic). Draft PRs may temporarily use `Refs #N` / `Related: #N`
+            //     without `Resolves #N`, but `ready_for_review` reruns this workflow and
+            //     restores the mandatory close-target gate before handoff.
+            const hasResolves            = /\bResolves:?\s+#\d+/i.test(body);
+            const hasNonClosingReference = /\b(Refs|Related):?\s+#\d+/i.test(body);
+            const forbiddenClose         = body.match(/\b(Closes|Fixes):?\s+#\d+/i);
+
+            if (forbiddenClose) {
+              missingVisible.push(
+                "`" + forbiddenClose[1] + " #N` is forbidden — use `Resolves #N` " +
+                "(`Closes` = closed-without-delivery → no PR needed; `Fixes` is ambiguous)"
+              );
+            }
+
+            if (!hasResolves && !(isDraft && hasNonClosingReference)) {
+              missingVisible.push(isDraft
+                ? "`Refs #N` or `Related: #N` (draft-only non-closing reference required when `Resolves #N` is absent)"
+                : "`Resolves #N` (mandatory closing keyword — `Refs`/`Related` alone is NOT sufficient)");
+            }
+
+
+            if (missingVisible.length === 0 && missingInvisible.length === 0) {
+              console.log("✅ PR body contains all required anchors.");
+              return;
+            }
+
+            // Compose comment that guides toward the skill without enumerating invisible
+            // anchors. Even visible-list naming is bounded — at most ONE diagnostic
+            // anchor in the prose (the full visible-miss list goes in the collapsed
+            // details block for programmatic access; invisible misses are NEVER named).
+            const diagnosticAnchor = missingVisible[0] || null;
+
+            const skillPath    = '.agents/skills/pull-request/SKILL.md';
+            const workflowPath = '.agents/skills/pull-request/references/pull-request-workflow.md';
+
+            const prUrl = `https://github.com/${context.repo.owner}/${context.repo.repo}/pull/${pr.number}`;
+
+            const commentBody = [
+              `## 🚨 Agent PR Body Lint Violation`,
+              ``,
+              `@${author} — your [PR body on PR #${pr.number}](${prUrl}) does not match the pull-request template structure.`,
+              ``,
+              `**Required action**: read \`${skillPath}\` BEFORE editing the PR body. The skill points at:`,
+              `  - Minimum-viable PR body structure: \`${workflowPath} §9\``,
+              `  - Self-Identification mandate: \`${workflowPath} §5\``,
+              ``,
+              `Do NOT compose a substitute template or hallucinate section headings. The validator`,
+              `checks more structural anchors than this comment names. The only reliable path to`,
+              `passing is reading the actual workflow file and following its structure.`,
+              ``,
+              diagnosticAnchor
+                ? `**Diagnostic hint**: at least one recognized anchor like \`${diagnosticAnchor}\` is missing.`
+                : `**Diagnostic hint**: visible anchors appear present but the structural template anchors do not.`,
+              ``,
+              `<details>`,
+              `<summary>Visible anchors missing (full list)</summary>`,
+              ``,
+              missingVisible.length > 0
+                ? missingVisible.map(a => `- \`${a}\``).join('\n')
+                : `(none — visible layer passed; invisible structural layer caught the miss)`,
+              ``,
+              `</details>`,
+              ``,
+              `<sub>This is the CI tool-boundary lint companion to PR #11494's MCP \`manage_pr_review\` validator and PR #11502's \`agent-pr-review-body-lint.yml\` reviewer-side lint.`,
+              `Resolves #11501.</sub>`
+            ].join('\n');
+
+            // Only comment if this is a newly opened PR, to avoid spam on edits
+            if (context.payload.action === 'opened') {
+              await github.rest.issues.createComment({
+                owner       : context.repo.owner,
+                repo        : context.repo.repo,
+                issue_number: pr.number,
+                body        : commentBody
+              });
+            }
+
+            // The annotation must carry the ANSWER, not a pointer to one. The follow-up comment is
+            // posted only on `opened` (above), but an anchor almost always breaks on `edited` —
+            // that IS the event where someone rewrote a heading. Citing a comment that was never
+            // written made the failure undiagnosable exactly when it mattered: three authors across
+            // two model families each had to open this file to learn which anchor was missing.
+            // `missingVisible`/`missingInvisible` are already computed; they just never reached here.
+            const missingAll = [...missingVisible, ...missingInvisible];
+
+            core.setFailed([
+              `Agent PR body missing required template anchors: ${missingAll.map(a => `\`${a}\``).join(', ')}.`,
+              ``,
+              `These are matched as LITERAL substrings — casing, prefixes and suffixes all break them.`,
+              `Put improvements in the body text under a heading, never in the heading itself.`,
+              context.payload.action === 'opened'
+                ? `A follow-up comment on PR #${pr.number} carries the full guidance.`
+                : `(No follow-up comment is posted on \`${context.payload.action}\` events — this annotation is the diagnostic.)`
+            ].join('\n'));


### PR DESCRIPTION
Resolves #17916

Restores the PR-body anchor gate that has been absent from every repository since 2026-08-26. **One file, +205 lines, no source or test surface touched.**

Evidence: L3 (the gate is exercised live by this PR — its own run is the positive control, and the negative control below drives it red and back to green) → L3 required. No residuals.

## What was actually wrong

`pull-request-workflow.md` §9 line 337 tells every seat that `agent-pr-body-lint.yml` enforces six anchors as **unconditional**. That file was deleted in `91ae3604b4` (`fix(engine): remove received Brain substrate`, #17791) and exists in no repository — not here, not the Brain, not Skills.

It went out as collateral, not as a decision. The workflow ran **three** steps; two invoked `ai/scripts/*` that moved with the split, so the file could not run and was swept out with the mover set:

| step | implementation | Brain-dependent? |
|---|---|---|
| `Validate PR body with the owning implementation` | `node ai/scripts/agent-preflight.mjs` — the AC-Evidence **content** check | yes |
| `Validate PR Body` | inline `actions/github-script@v9` — anchor **presence** | **no — none at all** |
| `Stacked-PR guard` | `node ./ai/scripts/lint/lint-pr-stacking.mjs` | yes |

The third step needs no checkout, no `npm ci`, no Brain, and no cross-repository caller decision. It is the entire content of this PR.

## Why this was worth doing tonight rather than filing and moving on

It has a live victim, and the victim is not hypothetical. PR #17902 — APPROVED cross-family at Round 2, CLEAN, checks exit 0 — carried a body missing `## AC Evidence` and `## Test Evidence`, and **merged into `dev` at 06:31:27Z** carrying them. CI could not catch it (deleted), the local preflight could not (`neo-agent-skills#24` — unrunnable outside the Brain), and two review rounds did not. That PR is mine, so this is a self-report.

> **Correction to my own first account, which I got wrong in the ticket and in the review handoff.** I measured those missing anchors at ~06:33Z and edited the body at 06:34Z, and described that as a repair at the merge gate. It was not: #17902 had already merged three minutes earlier. My edit corrected the record of a merged PR and **prevented nothing**. That makes the case stronger rather than weaker — the gate's absence is not a near-miss, it is a body that missed two unconditional anchors and reached `dev` — but the original phrasing implied a save that did not happen, so it is corrected here and on #17916.

## Lifted, not re-authored

`git diff` of the extracted script against `91ae3604b4^` is **two comment lines**, and nothing else. That is deliberate: the deleted blob is the only surviving implementation of two properties an honest re-author would drop —

- **The body is fetched LIVE** via `github.rest.pulls.get`, never `context.payload.pull_request.body`. An event-snapshot body is wrong in both directions: a corrected body can never go green (a re-run replays the stale text), and a body edited after a green run keeps that green. This is #17431, closed COMPLETED, whose fix lived only in the deleted file.
- **No `run:` block exists in the file at all**, so a PR body — attacker-controlled text — is never interpolated into a shell.

## AC Evidence

Seven ACs on #17916. AC-7 is explicitly non-closing and cross-repository.

| # | Acceptance Criterion | Proof |
|---|---|---|
| AC-1 | The workflow exists and runs on `pull_request` for agent-authored PRs, with no step depending on anything outside this repository | `js-yaml` parse: one job `lint-pr-body`, **one** step `Validate PR Body`, triggers `{opened, edited, synchronize, ready_for_review}`. No `uses: actions/checkout`, no `npm`, no `node`, no `run:` anywhere in the file — the `Setup Node`/`npm ci`/checkout scaffolding existed only for the two removed steps and is gone with them |
| AC-2 | All six anchors and the `Resolves #N` rule are enforced, matching the arrays at `91ae3604b4^` | `diff` of the extracted `with.script` against the original: **2 lines, both comment prose** (the `#17431` attribution). `VISIBLE_PR_BODY_ANCHORS` = `Evidence:`, `## AC Evidence`, `## Test Evidence`, `## Post-Merge Validation`; `INVISIBLE` = `Authored by `, `## Deltas`; the `Resolves`/`Refs`/forbidden-`Closes`/`Fixes` regexes are carried verbatim |
| AC-3 | The live-body-fetch property (#17431) is preserved — a body corrected after a red run goes green on the `edited` event, **without** a push. Demonstrated, not asserted | See **Test Evidence**, negative control step 3: the anchor was restored by a body edit alone, `HEAD` unchanged, and the check went green |
| AC-4 | The PR body is never interpolated into a shell `run:` block | Structural, not behavioural: the file contains **zero** `run:` steps. The body reaches the script as a JS value from the API response |
| AC-5 | A negative control proves the gate can fail: removing one anchor reds the check, restoring it greens it | See **Test Evidence**. Removing `Authored by ` — an *invisible*-layer anchor, chosen precisely because a Goodhart-style body could name every visible one — drove the check red at unchanged `HEAD`, annotation: `missing required template anchors: `Authored by ``. Corrected after review: an earlier revision of this row credited `## Deltas`, which the run log does not support |
| AC-6 | The workflow carries a header comment naming the enforcement halves that are **not** present and where they are tracked | File header, lines 1–20: names the AC-Evidence content check and the stacked-PR guard, routes both to `neo-agent-skills#14`/`#24`, and states plainly that a body naming every anchor over empty prose passes this gate — a floor, not a certification |
| AC-7 | Cross-repo, non-closing: a `neo-agent-skills` change corrects line 337 | **Not in this PR, by design.** The corpus is a symlink into `node_modules/neo-agent-skills`; no Engine-side edit can reach it. #17916 stays open for it and does not gate on the release |

## Deltas from ticket

One, and it narrows rather than expands: #17916's Fix step 1 said to reduce the lifted step "plus its agent-author `if:` condition". There is no `if:` to carry — the `Validate PR Body` step never had one. The author gate lives *inside* the script (`isAgentAuthor` / `hasAiLabel`, early `return`), which is why the removed steps each carried a `condition mirroring it`. Restoring the step alone restores the gate exactly; adding a step-level `if:` would have duplicated the check in two places that could drift.

Noted and deliberately **not** changed: `agentAuthors` still lists `neo-gemini-pro` and omits seats added since. It is dead weight, not a defect — every entry starts with `neo-`, so `author.startsWith('neo-')` already subsumes the list, and the original file's own comment says so. Editing it here would be scope creep on a verbatim restore.

## Test Evidence

No unit or e2e surface exists for a workflow file; the gate is verified by running it, which this PR does.

**Static**

| check | result |
|---|---|
| `js-yaml` parse of the workflow | valid — 1 job, 1 step, expected triggers |
| lifted script under the real `github-script` wrapper (`AsyncFunction(...)`) | parses ✅ |
| `node --check` as a standalone ESM file | **fails** — `Illegal return statement`. Recorded rather than hidden: it is the *wrong instrument*, since `actions/github-script` evaluates the body inside an async function where top-level `return` is legal. The wrapper check above is the matching one |
| `diff` vs `91ae3604b4^` | 2 comment lines |

**Live, on this PR** — the gate lints its own PR, so the runs below are this workflow judging this workflow's body:

1. **Positive control** — this body, complete: `Agent PR Body Lint` **pass**.
2. **Negative control** — `Authored by ` removed from the body, no push: **fail** ([run 33366874780](https://github.com/neomjs/neo/actions/runs/33366874780)), annotation `Agent PR body missing required template anchors: `Authored by ``. Head `9d2d23d12f` unchanged across it.
3. **Live-fetch control (#17431)** — anchor restored by body edit alone, `HEAD` unchanged: **pass**. A payload-snapshot implementation would have stayed red here; that it recovers without a push is the property #17431 bought.

Run URLs for 1–3 are recorded in a follow-up comment on this PR, since they do not exist until after the body is first submitted.

## Out of Scope

- Re-homing the `agent-preflight` AC-Evidence **content** check, and the stacked-PR guard. Both need a cross-repository caller — `neo-agent-skills#14` (authority) and `#24` (mechanism). Named in the file header so they are not lost a second time.
- Making this a required status context on `dev`. #17171 owns that for all nineteen lint workflows.
- Renegotiating the anchor set. This restores the rules as they were.
- The `neo-agent-skills` correction to line 337 (AC-7) — a different repository and a release cycle.

## Post-Merge Validation

- On the first agent-authored PR opened after merge, confirm `Agent PR Body Lint` appears in the checks list and reports. It cannot be observed on `dev` itself — the workflow only runs on `pull_request`.

Authored by Grace (Anthropic Claude Opus 5, Claude Code). Session 3dcfa2ec-f13d-4e16-b217-eff5d9c256a9.

