### PR TITLE
fix(main): dist css and resource roots survive absolute mounts (#17918)

### DIFF
--- a/src/main/addon/Stylesheet.mjs
+++ b/src/main/addon/Stylesheet.mjs
@@ -43,20 +43,12 @@ class Stylesheet extends Base {
     construct(config) {
         super.construct(config);
 
-        let neoConfig = Neo.config,
-            env       = neoConfig.environment,
-            faPath;
+        let neoConfig = Neo.config;
 
         if (!neoConfig.useSSR) {
             if (neoConfig.useFontAwesome) {
-                if (env === 'development' || env === 'dist/esm') {
-                    faPath = neoConfig.basePath + 'node_modules/@fortawesome/fontawesome-free/css/all.min.css'
-                } else {
-                    faPath = (this.getAbsoluteDistRoot() ?? neoConfig.basePath.substring(6)) + 'resources/fontawesome-free/css/all.min.css'
-                }
-
                 this.createStyleSheet({
-                    href: faPath
+                    href: this.getFontAwesomePath()
                 })
             }
 
@@ -109,6 +101,26 @@ class Stylesheet extends Base {
         }
 
         return null
+    }
+
+    /**
+     * @summary The Font Awesome stylesheet URL for the active environment.
+     *
+     * Source and `dist/esm` fetch from the package inside `node_modules` (already basePath-rooted,
+     * so absolute mounts need no help). The bundled environments carry a copied
+     * `resources/fontawesome-free` tree inside `dist/<env>/`, addressed through the same dist-root
+     * derivation as every stylesheet.
+     * @returns {String}
+     * @protected
+     */
+    getFontAwesomePath() {
+        let {basePath, environment: env} = Neo.config;
+
+        if (env === 'development' || env === 'dist/esm') {
+            return basePath + 'node_modules/@fortawesome/fontawesome-free/css/all.min.css'
+        }
+
+        return (this.getAbsoluteDistRoot() ?? basePath.substring(6)) + 'resources/fontawesome-free/css/all.min.css'
     }
 
     /**

--- a/src/main/addon/Stylesheet.mjs
+++ b/src/main/addon/Stylesheet.mjs
@@ -52,7 +52,7 @@ class Stylesheet extends Base {
                 if (env === 'development' || env === 'dist/esm') {
                     faPath = neoConfig.basePath + 'node_modules/@fortawesome/fontawesome-free/css/all.min.css'
                 } else {
-                    faPath = neoConfig.basePath.substring(6) + 'resources/fontawesome-free/css/all.min.css'
+                    faPath = (this.getAbsoluteDistRoot() ?? neoConfig.basePath.substring(6)) + 'resources/fontawesome-free/css/all.min.css'
                 }
 
                 this.createStyleSheet({
@@ -73,9 +73,7 @@ class Stylesheet extends Base {
         let {config} = Neo,
             {themes} = config,
             folders  = ['src', ...themes],
-            env      = config.environment,
-            path     = env.startsWith('dist/') ? '' : config.appPath.includes('docs') ? `../dist/${env}/` : `../../dist/${env}/`,
-            rootPath = config.basePath.substring(6);
+            cssRoot  = this.getCssRoot();
 
         document.body.classList.add(themes[0]);
 
@@ -85,9 +83,56 @@ class Stylesheet extends Base {
             }
 
             this.createStyleSheet({
-                href: `${rootPath}${path}css/${folder}/Global.css`
+                href: `${cssRoot}css/${folder}/Global.css`
             })
         })
+    }
+
+    /**
+     * @summary Resolves the dist-tree root for stylesheet/resource URLs when `basePath` is absolute.
+     *
+     * The relative arithmetic in {@link #getCssRoot} (`basePath.substring(6)` = strip one `../../`
+     * hop) is exact for the engine's own serving, where a dist page lives INSIDE
+     * `dist/<env>/apps/<app>/` and `basePath` climbs to the repository root. An absolute mount
+     * (one index per app OUTSIDE dist, e.g. `basePath: '/mount/'`) has no hops to strip — the dist
+     * tree hangs directly under the mount, so the root is `basePath + 'dist/<env>/'` (dist
+     * environments already carry the `dist/` prefix in their name). Returns `null` for relative
+     * basePaths, so callers keep the proven relative arithmetic byte-identical.
+     * @returns {String|null}
+     * @protected
+     */
+    getAbsoluteDistRoot() {
+        let {basePath, environment: env} = Neo.config;
+
+        if (basePath.startsWith('/') || /^https?:\/\//.test(basePath)) {
+            return `${basePath}${env.startsWith('dist/') ? env : `dist/${env}`}/`
+        }
+
+        return null
+    }
+
+    /**
+     * @summary The URL prefix every theme/global stylesheet hangs from, ending at the dist tree.
+     *
+     * Absolute mounts resolve through {@link #getAbsoluteDistRoot}; relative basePaths keep the
+     * original page-relative arithmetic (`rootPath` compensates app depth beyond two levels,
+     * `path` adds the fixed hop into `dist/<env>/` for non-dist environments, and a dist-mode
+     * page already lives inside the dist tree).
+     * @returns {String}
+     * @protected
+     */
+    getCssRoot() {
+        let absoluteRoot = this.getAbsoluteDistRoot();
+
+        if (absoluteRoot) {
+            return absoluteRoot
+        }
+
+        let {config} = Neo,
+            env      = config.environment,
+            path     = env.startsWith('dist/') ? '' : config.appPath.includes('docs') ? `../dist/${env}/` : `../../dist/${env}/`;
+
+        return config.basePath.substring(6) + path
     }
 
     /**
@@ -99,10 +144,8 @@ class Stylesheet extends Base {
     async addThemeFiles(data) {
         let {className} = data,
             {config}    = Neo,
-            env         = config.environment,
-            path        = env.startsWith('dist/') ? '' : config.appPath.includes('docs') ? `../dist/${env}/` : `../../dist/${env}/`,
-            promises    = [],
-            rootPath    = config.basePath.substring(6);
+            cssRoot     = this.getCssRoot(),
+            promises    = [];
 
         if (className.startsWith('Neo.')) {
             className = className.substring(4)
@@ -113,7 +156,7 @@ class Stylesheet extends Base {
         data.folders.forEach(folder => {
             if (folder === 'src' || folder.includes('theme-') && config.themes.includes(`neo-${folder}`)) {
                 promises.push(this.createStyleSheet({
-                    href: `${rootPath}${path}css/${folder}/${className}.css`
+                    href: `${cssRoot}css/${folder}/${className}.css`
                 }))
             }
         });

--- a/test/playwright/unit/main/addon/Stylesheet.spec.mjs
+++ b/test/playwright/unit/main/addon/Stylesheet.spec.mjs
@@ -37,7 +37,38 @@ documentRef.createElement = () => {
     return link
 };
 documentRef.head    = {appendChild: () => {}};
+documentRef.body    = {classList: {add: () => {}}};
 globalThis.document = documentRef;
+
+/**
+ * Runs one root-derivation scenario: pins the named Neo.config fields, invokes the real method
+ * via prototype (the addon's construct runs the full theme bootstrap, which the derivation
+ * contract does not need), and returns the emitted hrefs. Config is restored in ALL cases —
+ * worker processes share Neo.config across spec files.
+ * @param {Object} configPatch Fields to pin on Neo.config for the scenario.
+ * @param {Function} invoke Receives the prototype-bound surface; drives the method under test.
+ * @returns {String[]} The hrefs handed to createStyleSheet, in emission order.
+ */
+function deriveHrefs(configPatch, invoke) {
+    const
+        saved = {},
+        start = createdLinks.length;
+
+    Object.keys(configPatch).forEach(key => {
+        saved[key] = Neo.config[key];
+        Neo.config[key] = configPatch[key]
+    });
+
+    try {
+        invoke(Stylesheet.prototype)
+    } finally {
+        Object.keys(saved).forEach(key => {
+            saved[key] === undefined ? delete Neo.config[key] : Neo.config[key] = saved[key]
+        })
+    }
+
+    return createdLinks.slice(start).map(link => link.href)
+}
 
 /**
  * @summary The settlement contract of `createStyleSheet`: a load failure must NAME its href.
@@ -90,5 +121,108 @@ test.describe('Neo.main.addon.Stylesheet#createStyleSheet', () => {
         createdLinks.at(-1).dispatchEvent(new Event('load'));
 
         await expect(promise).resolves.toBeUndefined()
+    });
+});
+
+/**
+ * @summary The dist-root derivation contract: absolute mounts resolve, relative arithmetic is pinned.
+ *
+ * `basePath.substring(6)` means "strip one `../../` hop" — exact for the engine's own serving,
+ * where a dist page lives inside `dist/<env>/apps/<app>/`. An absolute mount (one index per app
+ * OUTSIDE dist, the klarserver arrangement) has no hops to strip: `/mount/` became `udio/…` and
+ * every stylesheet 404'd, black-paging the app. The absolute branch derives `basePath +
+ * 'dist/<env>/'`; every relative shape below is pinned byte-identical to the pre-fix arithmetic.
+ */
+test.describe('Neo.main.addon.Stylesheet — dist-root derivation', () => {
+    test.beforeEach(() => {
+        globalThis.document = documentRef
+    });
+
+    test.afterEach(() => {
+        createdLinks.length = 0
+    });
+
+    test('an absolute mount in a dist environment derives basePath + env for every global sheet', () => {
+        const hrefs = deriveHrefs(
+            {appPath: 'apps/probe/app.mjs', basePath: '/mount/', environment: 'dist/production', themes: ['neo-theme-dark']},
+            proto => proto.addGlobalCss()
+        );
+
+        expect(hrefs).toEqual([
+            '/mount/dist/production/css/src/Global.css',
+            '/mount/dist/production/css/theme-dark/Global.css'
+        ])
+    });
+
+    test('an absolute mount in a source environment derives basePath + dist/<env>', () => {
+        const hrefs = deriveHrefs(
+            {appPath: 'apps/probe/app.mjs', basePath: '/mount/', environment: 'development', themes: ['neo-theme-light']},
+            proto => proto.addGlobalCss()
+        );
+
+        expect(hrefs).toEqual([
+            '/mount/dist/development/css/src/Global.css',
+            '/mount/dist/development/css/theme-light/Global.css'
+        ])
+    });
+
+    test('addThemeFiles emits mount-rooted theme sheets on an absolute basePath', async () => {
+        const hrefs = deriveHrefs(
+            {appPath: 'apps/probe/app.mjs', basePath: '/webstudio/', environment: 'dist/development', themes: ['neo-theme-dark']},
+            proto => proto.addThemeFiles({className: 'Neo.grid.Container', folders: ['src', 'theme-dark']})
+        );
+
+        expect(hrefs).toEqual([
+            '/webstudio/dist/development/css/src/grid/Container.css',
+            '/webstudio/dist/development/css/theme-dark/grid/Container.css'
+        ])
+    });
+
+    test('the relative shapes stay byte-identical: source app, docs app, and a page inside the dist tree', () => {
+        // source app two levels deep: rootPath '' + path '../../dist/development/'
+        expect(deriveHrefs(
+            {appPath: 'apps/probe/app.mjs', basePath: '../../', environment: 'development', themes: ['neo-theme-dark']},
+            proto => proto.addGlobalCss()
+        )).toEqual([
+            '../../dist/development/css/src/Global.css',
+            '../../dist/development/css/theme-dark/Global.css'
+        ]);
+
+        // the docs config uses the single-hop compensation
+        expect(deriveHrefs(
+            {appPath: 'docs/app.mjs', basePath: '../', environment: 'development', themes: ['neo-theme-dark']},
+            proto => proto.addGlobalCss()
+        )).toEqual([
+            '../dist/development/css/src/Global.css',
+            '../dist/development/css/theme-dark/Global.css'
+        ]);
+
+        // a dist-mode page lives inside dist/<env>: rootPath '../../' + path ''
+        expect(deriveHrefs(
+            {appPath: 'apps/probe/app.mjs', basePath: '../../../../', environment: 'dist/production', themes: ['neo-theme-dark']},
+            proto => proto.addGlobalCss()
+        )).toEqual([
+            '../../css/src/Global.css',
+            '../../css/theme-dark/Global.css'
+        ])
+    });
+
+    test('getAbsoluteDistRoot answers absolute and fully-qualified mounts, and yields to relative arithmetic', () => {
+        const probe = (basePath, environment) => {
+            const saved = {basePath: Neo.config.basePath, environment: Neo.config.environment};
+
+            Object.assign(Neo.config, {basePath, environment});
+
+            try {
+                return Stylesheet.prototype.getAbsoluteDistRoot()
+            } finally {
+                Object.assign(Neo.config, saved)
+            }
+        };
+
+        expect(probe('/mount/', 'dist/esm')).toBe('/mount/dist/esm/');
+        expect(probe('https://cdn.example/app/', 'dist/production')).toBe('https://cdn.example/app/dist/production/');
+        expect(probe('../../', 'dist/production')).toBeNull();
+        expect(probe('../../../../', 'development')).toBeNull()
     });
 });

--- a/test/playwright/unit/main/addon/Stylesheet.spec.mjs
+++ b/test/playwright/unit/main/addon/Stylesheet.spec.mjs
@@ -129,7 +129,7 @@ test.describe('Neo.main.addon.Stylesheet#createStyleSheet', () => {
  *
  * `basePath.substring(6)` means "strip one `../../` hop" — exact for the engine's own serving,
  * where a dist page lives inside `dist/<env>/apps/<app>/`. An absolute mount (one index per app
- * OUTSIDE dist, the klarserver arrangement) has no hops to strip: `/mount/` became `udio/…` and
+ * OUTSIDE dist, a fixed-mount server arrangement) has no hops to strip: `/mount/` became `udio/…` and
  * every stylesheet 404'd, black-paging the app. The absolute branch derives `basePath +
  * 'dist/<env>/'`; every relative shape below is pinned byte-identical to the pre-fix arithmetic.
  */
@@ -168,13 +168,13 @@ test.describe('Neo.main.addon.Stylesheet — dist-root derivation', () => {
 
     test('addThemeFiles emits mount-rooted theme sheets on an absolute basePath', async () => {
         const hrefs = deriveHrefs(
-            {appPath: 'apps/probe/app.mjs', basePath: '/webstudio/', environment: 'dist/development', themes: ['neo-theme-dark']},
+            {appPath: 'apps/probe/app.mjs', basePath: '/mount-b/', environment: 'dist/development', themes: ['neo-theme-dark']},
             proto => proto.addThemeFiles({className: 'Neo.grid.Container', folders: ['src', 'theme-dark']})
         );
 
         expect(hrefs).toEqual([
-            '/webstudio/dist/development/css/src/grid/Container.css',
-            '/webstudio/dist/development/css/theme-dark/grid/Container.css'
+            '/mount-b/dist/development/css/src/grid/Container.css',
+            '/mount-b/dist/development/css/theme-dark/grid/Container.css'
         ])
     });
 
@@ -205,6 +205,34 @@ test.describe('Neo.main.addon.Stylesheet — dist-root derivation', () => {
             '../../css/src/Global.css',
             '../../css/theme-dark/Global.css'
         ])
+    });
+
+    test('the Font Awesome path survives absolute mounts in bundled envs and stays package-rooted otherwise', () => {
+        const probe = (basePath, environment) => {
+            const saved = {basePath: Neo.config.basePath, environment: Neo.config.environment};
+
+            Object.assign(Neo.config, {basePath, environment});
+
+            try {
+                return Stylesheet.prototype.getFontAwesomePath()
+            } finally {
+                Object.assign(Neo.config, saved)
+            }
+        };
+
+        // bundled env, absolute mount: the black-page path — must root at the mount's dist tree
+        expect(probe('/mount/', 'dist/production'))
+            .toBe('/mount/dist/production/resources/fontawesome-free/css/all.min.css');
+
+        // bundled env, relative serving: the original strip-one-hop arithmetic, byte-identical
+        expect(probe('../../../../', 'dist/production'))
+            .toBe('../../resources/fontawesome-free/css/all.min.css');
+
+        // source + dist/esm fetch from node_modules, basePath-rooted in both mount shapes
+        expect(probe('/mount/', 'development'))
+            .toBe('/mount/node_modules/@fortawesome/fontawesome-free/css/all.min.css');
+        expect(probe('../../', 'dist/esm'))
+            .toBe('../../node_modules/@fortawesome/fontawesome-free/css/all.min.css')
     });
 
     test('getAbsoluteDistRoot answers absolute and fully-qualified mounts, and yields to relative arithmetic', () => {


### PR DESCRIPTION
Resolves #17918

🌿 A mount that names itself absolutely no longer loses four letters to arithmetic meant for climbing — the black page on `/mount/` is unsayable.

## Summary

`Stylesheet` derived every dist CSS/resource root as `basePath.substring(6)` — "strip one `../../` hop" — exact for the engine's own serving (a dist page lives inside `dist/<env>/apps/<app>/`), fatal for an absolute mount (`/<mount>/` loses its first six characters, nine sheets 404, black page — the measured blocker on the private consumer workspace and D#17886's fixture alike). The repair is deliberately bounded under the #17884 umbrella: `getAbsoluteDistRoot()` answers `basePath + dist/<env>/` for absolute/fully-qualified basePaths and `null` otherwise, `getCssRoot()` folds the two derivations behind one seam, and the three call sites (Font Awesome branch, `addGlobalCss`, `addThemeFiles`) consume it — the relative arithmetic is byte-identical, pinned by spec.

Evidence: L2 (real prototype methods over a stubbed document, exact-URL assertions) → L2 required (derivation ACs); the consumer-workspace dist boot is the L3 witness and lands as this PR's post-merge validation with receipts to #17918.

## AC Evidence

| AC | Evidence |
|---|---|
| AC-1 | three absolute-mount arms assert exact emitted URLs per site: `/mount/dist/production/css/...` (dist env), `/mount/dist/development/css/...` (source env), `/mount-b/dist/development/css/.../grid/Container.css` (`addThemeFiles`); the FA branch owns a dedicated four-shape arm via `getFontAwesomePath` (its call-site mutation reds — measured), and `getAbsoluteDistRoot` is asserted directly incl. the fully-qualified form |
| AC-2 | the exact-URL assertions ARE the red control: the reverted derivation emits `unt/…`-shaped hrefs and every absolute arm reds |
| AC-3 | one arm pins all three relative shapes byte-identical: source app (`../../dist/development/…`), docs app (`../dist/…`), page-inside-dist (`../../css/…`) |
| AC-4 | full unit suite: 2190 passed, 0 failed, fully-parallel |

## Deltas from ticket

None.

## Test Evidence

`main/addon/Stylesheet.spec.mjs` 8/8 (2 settlement arms from #17894 + 6 derivation arms incl. the dedicated Font Awesome four-shape arm; prototype invocation keeps the theme bootstrap out of scope, config pins restored in finally — worker processes share `Neo.config`). Full suite **2190/0** at `b5d1ed4b4c` (round-2 head: FA seam extracted for testability, fixture mounts anonymized).

## Post-Merge Validation

Delivered pre-merge via cherry-pick: BOTH bundled environments pass the full interaction battery on the private consumer workspace (exact coordinates + anonymized receipts on #17918). Post-merge residue = re-verify at the merged head once the workspace pin advances, dropping the local cherry-pick. (The `dist/esm` generator defects from D#17886's fixture are a separate filing; this PR does not touch the generator.)

Authored by Vega (Fable 5, Claude Code). Session b51135ac-ec45-4689-ac45-0e99fb073069.

