### PR TITLE
test(engine): restore the 21 buildScripts specs the ai/ path sweep deleted (#17924)

### DIFF
--- a/test/playwright/unit/buildScripts/DataSyncWatchdog.spec.mjs
+++ b/test/playwright/unit/buildScripts/DataSyncWatchdog.spec.mjs
@@ -1,0 +1,457 @@
+import {test, expect} from '@playwright/test';
+
+import {
+    ALARM_MARKER,
+    ALARM_TITLE_PREFIX,
+    buildAlarmBody,
+    buildAlarmTitle,
+    buildBreachComment,
+    buildRecoveryComment,
+    computeStreak,
+    evaluateBreach,
+    isRecovered,
+    buildRunsQuery,
+    latestCommitDate,
+    parseBranchName,
+    parseFacetNames,
+    parseThreshold,
+    selectAlarmIssue
+} from '../../../../buildScripts/dataSyncWatchdog.mjs';
+
+const
+    NOW = new Date('2026-07-26T12:00:00Z'),
+    run = (conclusion, created_at, id=1) => ({conclusion, created_at, html_url: `https://example.test/runs/${id}`, id});
+
+/**
+ * Threshold-logic witnesses for the Data Sync staleness watchdog: streak reduction,
+ * breach boundaries (consecutive-failures `>=`, success-age strictly-past), recovery shape,
+ * standing-issue selection by body marker, and the alarm body's self-describing contract.
+ * API-touching glue is deliberately thin and exercised via the workflow's dispatch dry run.
+ */
+test.describe('dataSyncWatchdog (#15948)', () => {
+    test('computeStreak: all-success history reports zero failures and the latest success', () => {
+        const {consecutiveFailures, lastSuccess, latest} = computeStreak({
+            runs: [run('success', '2026-07-26T11:00:00Z', 3), run('success', '2026-07-26T10:00:00Z', 2)]
+        });
+
+        expect(consecutiveFailures).toBe(0);
+        expect(latest.conclusion).toBe('success');
+        expect(lastSuccess.created_at).toBe('2026-07-26T11:00:00Z')
+    });
+
+    test('computeStreak: counts only the newest failure run, stopping at the first success', () => {
+        const {consecutiveFailures, lastSuccess} = computeStreak({
+            runs: [
+                run('failure', '2026-07-26T11:00:00Z', 5),
+                run('failure', '2026-07-26T10:00:00Z', 4),
+                run('failure', '2026-07-26T09:00:00Z', 3),
+                run('success', '2026-07-26T08:00:00Z', 2),
+                run('failure', '2026-07-26T07:00:00Z', 1)
+            ]
+        });
+
+        expect(consecutiveFailures).toBe(3);
+        expect(lastSuccess.id).toBe(2)
+    });
+
+    test('computeStreak: no visible success yields null (the outage-episode shape)', () => {
+        const {consecutiveFailures, lastSuccess} = computeStreak({
+            runs: [run('failure', '2026-07-26T11:00:00Z'), run('failure', '2026-07-26T10:00:00Z')]
+        });
+
+        expect(consecutiveFailures).toBe(2);
+        expect(lastSuccess).toBe(null)
+    });
+
+    test('evaluateBreach: below both thresholds is healthy', () => {
+        const {breached, reasons} = evaluateBreach({
+            consecutiveFailures   : 2,
+            lastSuccessAt         : '2026-07-26T11:30:00Z',
+            now                   : NOW,
+            maxConsecutiveFailures: 3,
+            maxSuccessAgeHours    : 24
+        });
+
+        expect(breached).toBe(false);
+        expect(reasons).toEqual([])
+    });
+
+    test('evaluateBreach: exactly-at-threshold consecutive failures breaches (`>=` boundary)', () => {
+        const {breached, reasons} = evaluateBreach({
+            consecutiveFailures   : 3,
+            lastSuccessAt         : '2026-07-26T11:30:00Z',
+            now                   : NOW,
+            maxConsecutiveFailures: 3,
+            maxSuccessAgeHours    : 24
+        });
+
+        expect(breached).toBe(true);
+        expect(reasons[0]).toContain('3 consecutive failures')
+    });
+
+    test('evaluateBreach: success age breaches strictly PAST the limit (24h00m is not a breach)', () => {
+        const healthy = evaluateBreach({
+            consecutiveFailures   : 1,
+            lastSuccessAt         : '2026-07-25T12:00:00Z', // exactly 24h
+            now                   : NOW,
+            maxConsecutiveFailures: 3,
+            maxSuccessAgeHours    : 24
+        });
+        const stale = evaluateBreach({
+            consecutiveFailures   : 1,
+            lastSuccessAt         : '2026-07-25T11:00:00Z', // 25h
+            now                   : NOW,
+            maxConsecutiveFailures: 3,
+            maxSuccessAgeHours    : 24
+        });
+
+        expect(healthy.breached).toBe(false);
+        expect(stale.breached).toBe(true);
+        expect(stale.reasons[0]).toContain('25.0h old')
+    });
+
+    test('evaluateBreach: no visible success is itself a breach reason (the 8-day episode class)', () => {
+        const {breached, reasons} = evaluateBreach({
+            consecutiveFailures   : 2,
+            lastSuccessAt         : null,
+            now                   : NOW,
+            maxConsecutiveFailures: 3,
+            maxSuccessAgeHours    : 24
+        });
+
+        expect(breached).toBe(true);
+        expect(reasons[0]).toContain('no successful run visible')
+    });
+
+    test('isRecovered: success with no active breach; a breach on ANY axis blocks recovery', () => {
+        expect(isRecovered({latestConclusion: 'success', breached: false})).toBe(true);
+        expect(isRecovered({latestConclusion: 'success', breached: true})).toBe(false); // certified-silence guard, in-contract
+        expect(isRecovered({latestConclusion: 'failure', breached: false})).toBe(false);
+        expect(isRecovered({latestConclusion: null, breached: false})).toBe(false)
+    });
+
+    test('parseThreshold: absent falls back; valid strings parse; unparseable or non-positive fails LOUD', () => {
+        expect(parseThreshold({name: 'X', raw: undefined, fallback: 48})).toBe(48);
+        expect(parseThreshold({name: 'X', raw: '', fallback: 48})).toBe(48);
+        expect(parseThreshold({name: 'X', raw: '12', fallback: 48})).toBe(12);
+        // a silence-detector must never silently substitute a threshold nobody chose
+        expect(() => parseThreshold({name: 'X', raw: 'fourty', fallback: 48})).toThrow(/positive number/);
+        expect(() => parseThreshold({name: 'X', raw: '0', fallback: 48})).toThrow(/positive number/);
+        expect(() => parseThreshold({name: 'X', raw: '-5', fallback: 48})).toThrow(/positive number/)
+    });
+
+    test('parseFacetNames: absent falls back; a comma/whitespace-only value fails LOUD (never a silent off-switch for the axis)', () => {
+        expect(parseFacetNames({name: 'X', raw: undefined, fallback: ['issues']})).toEqual(['issues']);
+        expect(parseFacetNames({name: 'X', raw: '', fallback: ['issues']})).toEqual(['issues']);
+        expect(parseFacetNames({name: 'X', raw: 'issues,pulls', fallback: []})).toEqual(['issues', 'pulls']);
+        expect(parseFacetNames({name: 'X', raw: ' issues , pulls ', fallback: []})).toEqual(['issues', 'pulls']);
+
+        // The reachable defect: an unset-vars composition (`${{ vars.A }},${{ vars.B }}`)
+        // renders a comma-only value, which must never silently empty the corpus axis.
+        expect(() => parseFacetNames({name: 'X', raw: ' ', fallback: ['issues']})).toThrow(/zero facets/);
+        expect(() => parseFacetNames({name: 'X', raw: ',', fallback: ['issues']})).toThrow(/zero facets/);
+        expect(() => parseFacetNames({name: 'X', raw: ',,', fallback: ['issues']})).toThrow(/zero facets/)
+    });
+
+    test('buildRunsQuery is branch-SCOPED, and refuses to build an unscoped query (#15994)', () => {
+        const q = buildRunsQuery({repository: 'neomjs/neo', workflow: 'data-sync-pipeline.yml', branch: 'dev'});
+
+        expect(q).toContain('branch=dev');
+        expect(q).toContain('/repos/neomjs/neo/actions/workflows/data-sync-pipeline.yml/runs?');
+
+        // The defect this closes: an unscoped query. There is deliberately no branch default,
+        // so omission cannot silently reintroduce the all-branches form.
+        expect(() => buildRunsQuery({repository: 'neomjs/neo', workflow: 'w.yml'})).toThrow(/branch is required/);
+        expect(() => buildRunsQuery({repository: 'neomjs/neo', workflow: 'w.yml', branch: '   '})).toThrow(/branch is required/);
+
+        // A branch needing encoding stays a single query parameter.
+        expect(buildRunsQuery({repository: 'r/n', workflow: 'w.yml', branch: 'feature/a b'}))
+            .toContain('branch=feature%2Fa%20b');
+    });
+
+    test('parseBranchName falls back when absent, fails LOUD on whitespace-only (#15994)', () => {
+        expect(parseBranchName({name: 'X', raw: undefined, fallback: 'dev'})).toBe('dev');
+        expect(parseBranchName({name: 'X', raw: '', fallback: 'dev'})).toBe('dev');
+        expect(parseBranchName({name: 'X', raw: ' main ', fallback: 'dev'})).toBe('main');
+
+        // A silently-empty override would drop the filter and widen the axis back to EVERY branch.
+        expect(() => parseBranchName({name: 'X', raw: '   ', fallback: 'dev'})).toThrow(/empty branch/);
+    });
+
+    test('computeStreak truncates on ANY success — which is why the query must be branch-scoped (#15994)', () => {
+        // The exact live shape on 2026-07-26: four dev failures, then a FEATURE-BRANCH success
+        // sitting among them. Unscoped, computeStreak stops there and reports 4 while dev was
+        // ~98 deep, and hands lastSuccess a run from a branch nobody deploys.
+        const mixed = [
+            {conclusion: 'failure', head_branch: 'dev',                             created_at: '2026-07-26T12:08:22Z'},
+            {conclusion: 'failure', head_branch: 'dev',                             created_at: '2026-07-26T10:06:00Z'},
+            {conclusion: 'failure', head_branch: 'dev',                             created_at: '2026-07-26T07:39:00Z'},
+            {conclusion: 'failure', head_branch: 'dev',                             created_at: '2026-07-26T04:31:00Z'},
+            {conclusion: 'success', head_branch: 'agent/15744-data-sync-app-identity', created_at: '2026-07-26T00:17:01Z'},
+            {conclusion: 'failure', head_branch: 'dev',                             created_at: '2026-07-26T00:04:00Z'}
+        ];
+
+        const polluted = computeStreak({runs: mixed});
+
+        expect(polluted.consecutiveFailures).toBe(4);
+        expect(polluted.lastSuccess.head_branch).not.toBe('dev');
+
+        // Branch-scoped, the same reducer sees the truth: the feature-branch row is never in the list.
+        const scoped = computeStreak({runs: mixed.filter(run => run.head_branch === 'dev')});
+
+        expect(scoped.consecutiveFailures).toBe(5);
+        expect(scoped.lastSuccess).toBe(null)
+    });
+
+    test('every branch label in the alarm body follows WATCHDOG_BRANCH, never a literal (#15994)', () => {
+        const body = buildAlarmBody({
+            consecutiveFailures: 4,
+            lastSuccess        : run('success', '2026-07-26T00:17:01Z'),
+            latestFailure      : null,
+            reasons            : ['corpus facet `pulls` is 214.8h old (threshold 48h)'],
+            corpusFacets       : [{facet: 'pulls', lastCommitAt: '2026-07-17T05:13:29Z', ageHours: 214.8, stale: true}],
+            branch             : 'release/13.2'
+        });
+
+        // Streak line, corpus header AND the table column all name the measured branch. A literal
+        // `dev` in any of them is a false statement the moment the branch is overridden.
+        expect(body).toContain('consecutive failures on `release/13.2`');
+        expect(body).toContain('**Corpus facets** (committed `release/13.2`');
+        expect(body).toContain('| facet | last commit on `release/13.2` | age | status |');
+        expect(body).not.toContain('`dev`');
+
+        // Omitted branch still renders the default truthfully rather than "undefined".
+        const defaulted = buildAlarmBody({
+            consecutiveFailures: 1,
+            lastSuccess        : run('success', '2026-07-26T00:17:01Z'),
+            latestFailure      : null,
+            reasons            : ['x'],
+            corpusFacets       : [{facet: 'pulls', lastCommitAt: '2026-07-17T05:13:29Z', ageHours: 214.8, stale: true}]
+        });
+
+        expect(defaulted).toContain('committed `dev`');
+        expect(defaulted).not.toContain('undefined')
+    });
+
+    test('selectAlarmIssue: body marker wins over title, PRs are excluded, marker beats prefix', () => {
+        const marked   = {number: 10, title: 'renamed alarm', body: `x ${ALARM_MARKER} y`},
+              prefixed = {number: 11, title: `${ALARM_TITLE_PREFIX} legacy`, body: 'no marker'},
+              pr       = {number: 12, title: `${ALARM_TITLE_PREFIX} a PR`, body: ALARM_MARKER, pull_request: {}};
+
+        expect(selectAlarmIssue([marked])).toEqual(marked);
+        expect(selectAlarmIssue([prefixed])).toEqual(prefixed); // legacy fallback
+        expect(selectAlarmIssue([pr])).toBe(null);
+        expect(selectAlarmIssue([prefixed, marked])).toEqual(marked);
+        expect(selectAlarmIssue([])).toBe(null)
+    });
+
+    test('buildAlarmBody: carries the idempotency marker, the streak facts, and no magic close keywords', () => {
+        const body = buildAlarmBody({
+            consecutiveFailures: 7,
+            lastSuccess        : run('success', '2026-07-17T03:20:56Z', 99),
+            latestFailure      : run('failure', '2026-07-25T22:03:27Z', 100),
+            reasons            : ['7 consecutive failures (threshold 3)']
+        });
+
+        expect(body).toContain(ALARM_MARKER);
+        expect(body).toContain('7 consecutive failures');
+        expect(body).toContain('2026-07-17T03:20:56Z');
+        expect(body).toContain('run 100');
+        // an alarm issue must never auto-close anything by keyword
+        expect(body).not.toMatch(/\b(Resolves|Closes|Fixes) #\d+/)
+    });
+
+    test('buildAlarmTitle: names the streak and the last-success date; the forced zero-streak case reads honestly', () => {
+        expect(buildAlarmTitle({consecutiveFailures: 5, lastSuccess: run('success', '2026-07-17T03:20:56Z')}))
+            .toBe(`${ALARM_TITLE_PREFIX} Data Sync Pipeline: 5 consecutive failures since 2026-07-17T03:20:56Z`);
+        expect(buildAlarmTitle({consecutiveFailures: 30, lastSuccess: null}))
+            .toContain('no recent success');
+        expect(buildAlarmTitle({consecutiveFailures: 0, lastSuccess: run('success', '2026-07-26T00:17:01Z'), forced: true}))
+            .toContain('forced breach evaluation')
+    });
+
+    test('buildBreachComment / buildRecoveryComment: carry the run links and the closing contract', () => {
+        expect(buildBreachComment({consecutiveFailures: 4, latestFailure: run('failure', 'x', 42)}))
+            .toContain('run 42');
+        const recovery = buildRecoveryComment({recoveringRun: run('success', 'y', 43), consecutiveFailures: 4});
+
+        expect(recovery).toContain('run 43');
+        expect(recovery).toContain('after 4 consecutive failures');
+        expect(recovery).toContain('re-opens on the next breach episode')
+    });
+
+    test('evaluateBreach: corpus axis — fresh, strict 48h boundary, stale, and missing-commit cases', () => {
+        const base = {
+            consecutiveFailures   : 0,
+            lastSuccessAt         : '2026-07-26T11:30:00Z',
+            now                   : NOW,
+            maxConsecutiveFailures: 3,
+            maxSuccessAgeHours    : 24,
+            maxCorpusAgeHours     : 48
+        };
+
+        expect(evaluateBreach({...base, corpusLastCommitAt: '2026-07-25T12:30:00Z'}).breached).toBe(false); // 47.5h
+        expect(evaluateBreach({...base, corpusLastCommitAt: '2026-07-24T12:00:00Z'}).breached).toBe(false); // exactly 48h
+        const stale = evaluateBreach({...base, corpusLastCommitAt: '2026-07-17T07:13:29Z'});
+
+        expect(stale.breached).toBe(true);
+        expect(stale.reasons[0]).toContain('resources/content');
+        expect(stale.reasons[0]).toContain('48h');
+
+        const missing = evaluateBreach({...base, corpusLastCommitAt: null});
+
+        expect(missing.breached).toBe(true);
+        expect(missing.reasons[0]).toContain('no `resources/content/**` commit visible')
+    });
+
+    test('evaluateBreach: a green run axis does NOT mask a stale corpus (the certified-silence case)', () => {
+        const {breached, reasons} = evaluateBreach({
+            consecutiveFailures   : 0,
+            lastSuccessAt         : '2026-07-26T00:17:01Z',
+            now                   : NOW,
+            corpusLastCommitAt    : '2026-07-17T07:13:29Z',
+            maxConsecutiveFailures: 3,
+            maxSuccessAgeHours    : 24,
+            maxCorpusAgeHours     : 48
+        });
+
+        expect(breached).toBe(true);
+        expect(reasons.length).toBe(1);
+        expect(reasons[0]).toContain('resources/content')
+    });
+
+    test('buildAlarmTitle: corpus-only breach names the corpus, not a zero streak', () => {
+        expect(buildAlarmTitle({
+            consecutiveFailures: 0,
+            lastSuccess        : run('success', '2026-07-26T00:17:01Z'),
+            corpusLastCommitAt : '2026-07-17T07:13:29Z',
+            corpusAgeHours     : 220.5
+        })).toBe(`${ALARM_TITLE_PREFIX} Data Sync corpus stale: last \`resources/content/**\` commit 2026-07-17T07:13:29Z (220.5h)`)
+    });
+
+    test('buildAlarmBody: carries the corpus axis line with the committed-dev rationale', () => {
+        const body = buildAlarmBody({
+            consecutiveFailures: 0,
+            lastSuccess        : run('success', '2026-07-26T00:17:01Z'),
+            latestFailure      : null,
+            reasons            : ['last `resources/content/**` commit is 220.5h old (threshold 48h)'],
+            corpusLastCommitAt : '2026-07-17T07:13:29Z',
+            corpusAgeHours     : 220.5
+        });
+
+        expect(body).toContain('**Corpus axis:**');
+        expect(body).toContain('2026-07-17T07:13:29Z (220.5h old)');
+        expect(body).toContain('committed `dev`')
+    });
+
+    test('latestCommitDate: newest-wins across a multi-path semantic corpus (archive-only repair is maintenance)', () => {
+        const entry = date => ({commit: {committer: {date}}});
+
+        // active landed yesterday, archive landed today — the archive repair counts
+        expect(latestCommitDate([[entry('2026-07-25T05:13:29Z')], [entry('2026-07-26T04:00:00Z')]]))
+            .toBe('2026-07-26T04:00:00Z');
+        // the reverse order resolves identically — freshness is the max, not the first path
+        expect(latestCommitDate([[entry('2026-07-26T04:00:00Z')], [entry('2026-07-17T05:13:29Z')]]))
+            .toBe('2026-07-26T04:00:00Z');
+        // no visible commit on ANY subpath is null — the missing-facet breach reason
+        expect(latestCommitDate([[], []])).toBe(null);
+        expect(latestCommitDate([[null], [undefined]])).toBe(null)
+    });
+
+    test('evaluateBreach: per-facet — a single stale facet breaches while the others are fresh', () => {
+        const {breached, reasons} = evaluateBreach({
+            consecutiveFailures: 0,
+            lastSuccessAt      : '2026-07-26T11:30:00Z',
+            now                : NOW,
+            corpusFacets       : [
+                {facet: 'issues', lastCommitAt: '2026-07-26T10:00:00Z', ageHours: 2.0},
+                {facet: 'pulls', lastCommitAt: '2026-07-17T05:13:29Z', ageHours: 214.8},
+                {facet: 'discussions', lastCommitAt: '2026-07-25T08:00:00Z', ageHours: 28.0}
+            ],
+            maxConsecutiveFailures: 3,
+            maxSuccessAgeHours    : 24,
+            maxCorpusAgeHours     : 48
+        });
+
+        expect(breached).toBe(true);
+        expect(reasons.length).toBe(1);
+        expect(reasons[0]).toContain('facet `pulls`');
+        expect(reasons[0]).toContain('214.8h')
+    });
+
+    test('evaluateBreach: per-facet — a facet with no visible commit breaches as its own reason', () => {
+        const {breached, reasons} = evaluateBreach({
+            consecutiveFailures: 0,
+            lastSuccessAt      : '2026-07-26T11:30:00Z',
+            now                : NOW,
+            corpusFacets       : [
+                {facet: 'issues', lastCommitAt: '2026-07-26T10:00:00Z', ageHours: 2.0},
+                {facet: 'discussions', lastCommitAt: null, ageHours: null}
+            ],
+            maxConsecutiveFailures: 3,
+            maxSuccessAgeHours    : 24,
+            maxCorpusAgeHours     : 48
+        });
+
+        expect(breached).toBe(true);
+        expect(reasons[0]).toBe('no commit visible for corpus facet `discussions` on the default branch')
+    });
+
+    test('evaluateBreach: per-facet — all facets fresh is healthy (the post-landing recovery shape)', () => {
+        const {breached, reasons} = evaluateBreach({
+            consecutiveFailures: 0,
+            lastSuccessAt      : '2026-07-26T11:30:00Z',
+            now                : NOW,
+            corpusFacets       : [
+                {facet: 'issues', lastCommitAt: '2026-07-26T10:00:00Z', ageHours: 2.0},
+                {facet: 'pulls', lastCommitAt: '2026-07-26T09:00:00Z', ageHours: 3.0},
+                {facet: 'discussions', lastCommitAt: '2026-07-26T08:00:00Z', ageHours: 4.0}
+            ],
+            maxConsecutiveFailures: 3,
+            maxSuccessAgeHours    : 24,
+            maxCorpusAgeHours     : 48
+        });
+
+        expect(breached).toBe(false);
+        expect(reasons).toEqual([])
+    });
+
+    test('buildAlarmTitle: a per-facet corpus breach names the stale facets, not the tree', () => {
+        expect(buildAlarmTitle({
+            consecutiveFailures: 0,
+            lastSuccess        : run('success', '2026-07-26T00:17:01Z'),
+            staleFacets        : [{facet: 'pulls', ageHours: 214.8}, {facet: 'discussions', ageHours: 214.8}]
+        })).toBe(`${ALARM_TITLE_PREFIX} Data Sync corpus stale: facets \`pulls\`, \`discussions\` (oldest 214.8h)`)
+    });
+
+    test('buildAlarmBody: the per-facet table carries each facet with its own age and status', () => {
+        const body = buildAlarmBody({
+            consecutiveFailures: 0,
+            lastSuccess        : run('success', '2026-07-26T00:17:01Z'),
+            latestFailure      : null,
+            reasons            : ['corpus facet `pulls` is 214.8h old (threshold 48h)'],
+            corpusFacets       : [
+                {facet: 'issues', lastCommitAt: '2026-07-26T10:00:00Z', ageHours: 2.0, stale: false},
+                {facet: 'pulls', lastCommitAt: '2026-07-17T05:13:29Z', ageHours: 214.8, stale: true},
+                {facet: 'discussions', lastCommitAt: null, ageHours: null, stale: true}
+            ]
+        });
+
+        expect(body).toContain('**Corpus facets**');
+        expect(body).toContain('| `issues` | 2026-07-26T10:00:00Z | 2.0h | ok |');
+        expect(body).toContain('| `pulls` | 2026-07-17T05:13:29Z | 214.8h | **STALE** |');
+        expect(body).toContain('| `discussions` | none visible | — | **STALE** |')
+    });
+
+    test('forced dispatch dry-run alarm body discloses its own provenance', () => {
+        const body = buildAlarmBody({
+            consecutiveFailures: 0,
+            lastSuccess        : run('success', '2026-07-26T11:00:00Z'),
+            latestFailure      : null,
+            reasons            : ['forced via workflow_dispatch (dry-run acceptance path)'],
+            forced             : true
+        });
+
+        expect(body).toContain('forced `workflow_dispatch` dry run')
+    });
+});

--- a/test/playwright/unit/buildScripts/build/themes.spec.mjs
+++ b/test/playwright/unit/buildScripts/build/themes.spec.mjs
@@ -1,0 +1,96 @@
+import {test, expect}  from '@playwright/test';
+import {execFileSync}  from 'node:child_process';
+import fs              from 'node:fs';
+import os              from 'node:os';
+import path            from 'node:path';
+import {fileURLToPath} from 'node:url';
+
+const
+    __filename = fileURLToPath(import.meta.url),
+    __dirname  = path.dirname(__filename),
+    scriptPath = path.resolve(__dirname, '../../../../../buildScripts/build/themes.mjs');
+
+/**
+ * build-themes theme-map regeneration: a full build reseeds the map from the effective SCSS
+ * tree — deletions and renames land on the next build — instead of merging the previous artifact
+ * (create-only insertion made deleted skins permanent fossils, re-inherited on every rebuild). The
+ * one preserved merge is the workspace overlay: the ENGINE's map still seeds a workspace build, so
+ * engine components stay resolvable. Fixtures run the real CLI against a minimal tmp tree, so the
+ * pin covers the shipped path rather than a re-implementation of it.
+ */
+test.describe('build-themes theme-map regeneration (#17222)', () => {
+    let root;
+
+    test.afterEach(() => {
+        fs.rmSync(root, {recursive: true, force: true});
+    });
+
+    const writeScss = (base, rel) => {
+        const filePath = path.join(base, 'resources/scss/src', rel);
+        fs.mkdirSync(path.dirname(filePath), {recursive: true});
+        fs.writeFileSync(filePath, '.x { color: red; }\n', 'utf8');
+    };
+
+    // execFileSync (not execSync): node is spawned directly with an argv array — no shell, so the
+    // absolute scriptPath can never be interpolated into a shell command (CodeQL-clean).
+    const runBuild = (cwd) => execFileSync('node', [scriptPath, '-n', '-e', 'dev', '-t', 'all'], {cwd, encoding: 'utf8', stdio: 'pipe'});
+
+    const readMap = (cwd) => JSON.parse(fs.readFileSync(path.join(cwd, 'resources/theme-map.json'), 'utf8'));
+
+    const mapKeys = (map) => {
+        const keys = [];
+        const walk = (node, prefix) => {
+            for (const [key, value] of Object.entries(node)) {
+                if (Array.isArray(value)) {
+                    keys.push(prefix + key);
+                } else {
+                    walk(value, prefix + key + '.');
+                }
+            }
+        };
+        walk(map, '');
+        return keys;
+    };
+
+    test('a full build reseeds from the effective SCSS tree — a fossil key from the previous map is gone (AC1)', () => {
+        root = fs.mkdtempSync(path.join(os.tmpdir(), 'neo-themes-seed-'));
+        fs.writeFileSync(path.join(root, 'package.json'), JSON.stringify({
+            bugs   : {url: 'https://example.invalid'},
+            name   : 'neo.mjs-fixture',
+            version: '1.0.0'
+        }));
+        writeScss(root, 'apps/demo/Widget.scss');
+
+        // The previous artifact carries a fossil: a key whose SCSS file no longer exists.
+        fs.writeFileSync(path.join(root, 'resources/theme-map.json'), JSON.stringify({apps: {demo: {Fossil: ['src']}}}));
+
+        runBuild(root);
+
+        const keys = mapKeys(readMap(root));
+        expect(keys).toContain('apps.demo.Widget');      // the real tree lands
+        expect(keys).not.toContain('apps.demo.Fossil');  // the fossil does not survive a fresh build
+    });
+
+    test('a workspace build still seeds from the ENGINE map, but never from its own previous output (AC2)', () => {
+        root = fs.mkdtempSync(path.join(os.tmpdir(), 'neo-themes-workspace-'));
+        fs.writeFileSync(path.join(root, 'package.json'), JSON.stringify({
+            bugs   : {url: 'https://example.invalid'},
+            name   : 'demo-workspace',
+            version: '1.0.0'
+        }));
+        writeScss(root, 'apps/demo/Widget.scss');
+
+        // The engine ships a built map; the workspace's own previous output carries a fossil.
+        const engineResources = path.join(root, 'node_modules/neo.mjs/resources');
+        fs.mkdirSync(engineResources, {recursive: true});
+        fs.writeFileSync(path.join(engineResources, 'theme-map.json'), JSON.stringify({Neo: {button: {Base: ['src']}}}));
+        fs.writeFileSync(path.join(root, 'resources/theme-map.json'), JSON.stringify({apps: {demo: {Fossil: ['src']}}}));
+
+        runBuild(root);
+
+        const keys = mapKeys(readMap(root));
+        expect(keys).toContain('Neo.button.Base');       // the engine overlay is preserved
+        expect(keys).toContain('apps.demo.Widget');      // the workspace's own tree lands
+        expect(keys).not.toContain('apps.demo.Fossil');  // the workspace's own fossil is not inherited
+    });
+});

--- a/test/playwright/unit/buildScripts/docs/index/PortalContentIndexes.spec.mjs
+++ b/test/playwright/unit/buildScripts/docs/index/PortalContentIndexes.spec.mjs
@@ -1,0 +1,256 @@
+import {test, expect}         from '@playwright/test';
+import fs                     from 'fs-extra';
+import os                     from 'os';
+import path                   from 'path';
+import createDiscussionIndex  from '../../../../../../buildScripts/docs/index/discussions.mjs';
+import createPullRequestIndex from '../../../../../../buildScripts/docs/index/pulls.mjs';
+
+/**
+ * @summary Verifies the Portal index generators: the PR generator emits the chunked
+ * root-plus-leaves contract (release-grouped); the Discussion generator emits the
+ * category-grouped chunked contract.
+ */
+
+function frontmatter(data) {
+    return [
+        '---',
+        ...Object.entries(data).map(([key, value]) => `${key}: ${JSON.stringify(value)}`),
+        '---',
+        '',
+        '# Body'
+    ].join('\n')
+}
+
+/**
+ * @param {Object} record
+ * @returns {Number|null}
+ */
+function getChunkNumber(record) {
+    const match = record.title?.match(/chunk-(\d+)$/);
+
+    return match ? Number(match[1]) : null
+}
+
+/**
+ * @param {Object[]} records
+ * @param {String} parentId
+ */
+function expectChunkFoldersDescending(records, parentId, {requireMultiple = true} = {}) {
+    const chunkNumbers = records
+        .filter(record => record.parentId === parentId && getChunkNumber(record) !== null)
+        .map(getChunkNumber);
+
+    if (requireMultiple) {
+        expect(chunkNumbers.length).toBeGreaterThan(1);
+    }
+
+    expect(chunkNumbers).toEqual([...chunkNumbers].sort((a, b) => b - a))
+}
+
+test.describe('Portal content index generators (#12210)', () => {
+    let tempDir;
+
+    test.beforeEach(async () => {
+        tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'portal-content-index-'))
+    });
+
+    test.afterEach(async () => {
+        await fs.remove(tempDir)
+    });
+
+    test('createPullRequestIndex emits a release-grouped chunked lazy surface (mirrors tickets)', async () => {
+        const
+            inputDir          = path.join(tempDir, 'resources/content/pulls'),
+            archiveDir        = path.join(tempDir, 'resources/content/archive/pulls'),
+            dataDir           = path.join(tempDir, 'apps/portal/resources/data'),
+            outputDir         = path.join(dataDir, 'pulls'),
+            chunkedOutputFile = path.join(dataDir, 'pulls/index.json'),
+            manifestFile      = path.join(dataDir, 'pulls/manifest.json');
+
+        // Active (unreleased) PRs → the `Latest` group. State (MERGED/OPEN/CLOSED) does NOT drive grouping.
+        await fs.outputFile(path.join(inputDir, 'chunk-1/pr-4.md'), frontmatter({
+            number   : 4,
+            title    : 'Unreleased merged PR',
+            state    : 'MERGED',
+            mergedAt : '2026-05-04T00:00:00Z',
+            updatedAt: '2026-05-04T00:00:00Z'
+        }));
+        await fs.outputFile(path.join(inputDir, 'chunk-1/pr-2.md'), frontmatter({
+            number   : 2,
+            title    : 'Unreleased open PR',
+            state    : 'OPEN',
+            updatedAt: '2026-05-02T00:00:00Z'
+        }));
+        await fs.outputFile(path.join(inputDir, 'chunk-1/pr-3.md'), frontmatter({
+            number   : 3,
+            title    : 'Unreleased closed PR',
+            state    : 'CLOSED',
+            closedAt : '2026-05-03T00:00:00Z',
+            updatedAt: '2026-05-03T00:00:00Z'
+        }));
+        // Archived (released) PR → the `v12.1.0` release group.
+        await fs.outputFile(path.join(archiveDir, 'v12.1.0/chunk-1/pr-1.md'), frontmatter({
+            number   : 1,
+            title    : 'Released PR',
+            state    : 'MERGED',
+            mergedAt : '2026-05-01T00:00:00Z',
+            updatedAt: '2026-05-01T00:00:00Z'
+        }));
+
+        await createPullRequestIndex({archiveDir, dataDir, inputDir, outputDir, chunkedOutputFile, manifestFile});
+
+        // 1. Chunked lazy surface: group roots (`Latest` first, then versions desc — grouping is by
+        //    RELEASE, not PR state) + chunk nodes carrying reconstruction metadata
+        //    (`contentDir` + `filePrefix`); chunk leaves omit the repeated `path`.
+        const index = await fs.readJson(chunkedOutputFile);
+
+        expect(index.find(record => record.id === 'Latest')).toEqual({
+            collapsed: true, id: 'Latest', isLeaf: false, parentId: null
+        });
+        expect(index.find(record => record.id === 'v12.1.0')).toEqual({
+            collapsed: false, id: 'v12.1.0', isLeaf: false, parentId: null
+        });
+        expect(index.find(record => record.id === 'Latest/active-chunk-1')).toMatchObject({
+            childCount : 3,
+            childrenUrl: 'pulls/latest/active-chunk-1.json',
+            contentDir : path.relative(process.cwd(), path.join(inputDir, 'chunk-1')),
+            filePrefix : 'pr-',
+            isLeaf     : false,
+            parentId   : 'Latest'
+        });
+
+        await expect(fs.readJson(path.join(outputDir, 'latest/active-chunk-1.json'))).resolves.toEqual([
+            {id: '4', parentId: 'Latest/active-chunk-1', title: 'Unreleased merged PR'},
+            {id: '3', parentId: 'Latest/active-chunk-1', title: 'Unreleased closed PR'},
+            {id: '2', parentId: 'Latest/active-chunk-1', title: 'Unreleased open PR'}
+        ]);
+
+        // 2. Crawler manifest enumerates the chunk leaf files.
+        const manifest = await fs.readJson(manifestFile);
+
+        expect(manifest.indexUrl).toBe('pulls/index.json');
+        expect(manifest.chunks.some(chunk => chunk.childrenUrl === 'pulls/latest/active-chunk-1.json')).toBe(true);
+
+        // 3. The deep-link id map names each leaf's chunk folder — active and archived alike.
+        await expect(fs.readJson(path.join(outputDir, 'idMap.json'))).resolves.toEqual({
+            '1': 'v12.1.0/archive-v12-1-0-chunk-1',
+            '2': 'Latest/active-chunk-1',
+            '3': 'Latest/active-chunk-1',
+            '4': 'Latest/active-chunk-1'
+        })
+    });
+
+    test('createPullRequestIndex orders chunk folders by chunk-number (desc), not by sortDate, matching the positional labels (#12309)', async () => {
+        const
+            inputDir          = path.join(tempDir, 'resources/content/pulls'),
+            archiveDir        = path.join(tempDir, 'resources/content/archive/pulls'),
+            dataDir           = path.join(tempDir, 'apps/portal/resources/data'),
+            outputDir         = path.join(dataDir, 'pulls'),
+            chunkedOutputFile = path.join(dataDir, 'pulls/index.json'),
+            manifestFile      = path.join(dataDir, 'pulls/manifest.json');
+
+        // Same Latest group, three chunk folders, NON-MONOTONIC dates: a sortDate ordering would emit
+        // [chunk-1, chunk-3, chunk-2] — scrambled relative to the positional `treeNodeName` labels.
+        await fs.outputFile(path.join(inputDir, 'chunk-1/pr-110.md'), frontmatter({
+            number   : 110,
+            title    : 'Newest date, lowest chunk',
+            state    : 'OPEN',
+            updatedAt: '2026-05-30T00:00:00Z'
+        }));
+        await fs.outputFile(path.join(inputDir, 'chunk-2/pr-210.md'), frontmatter({
+            number   : 210,
+            title    : 'Oldest date, middle chunk',
+            state    : 'OPEN',
+            updatedAt: '2026-05-01T00:00:00Z'
+        }));
+        await fs.outputFile(path.join(inputDir, 'chunk-3/pr-310.md'), frontmatter({
+            number   : 310,
+            title    : 'Middle date, highest chunk',
+            state    : 'OPEN',
+            updatedAt: '2026-05-15T00:00:00Z'
+        }));
+
+        await createPullRequestIndex({archiveDir, dataDir, inputDir, outputDir, chunkedOutputFile, manifestFile});
+
+        // Chunk folders descend by chunk-number (newest/highest chunk first), regardless of sortDate.
+        const index = await fs.readJson(chunkedOutputFile);
+
+        expect(index.map(record => record.id)).toEqual([
+            'Latest',
+            'Latest/active-chunk-3',
+            'Latest/active-chunk-2',
+            'Latest/active-chunk-1'
+        ])
+    });
+
+    test('committed pull-request index keeps active chunk folders in chunk-number order', async () => {
+        const index = await fs.readJson(path.join(process.cwd(), 'apps/portal/resources/data/pulls/index.json'));
+
+        expectChunkFoldersDescending(index, 'Latest', {requireMultiple: false})
+    });
+
+    test('createDiscussionIndex groups by frontmatter category for active and archive files', async () => {
+        const
+            inputDir   = path.join(tempDir, 'resources/content/discussions'),
+            archiveDir = path.join(tempDir, 'resources/content/archive/discussions'),
+            outputFile = path.join(tempDir, 'apps/portal/resources/data/discussions.json'),
+            outputDir  = path.join(tempDir, 'apps/portal/resources/data/discussions');
+
+        await fs.outputFile(path.join(inputDir, 'chunk-1/discussion-10.md'), frontmatter({
+            number   : 10,
+            title    : 'Active idea',
+            category : 'Ideas',
+            closed   : false,
+            updatedAt: '2026-05-10T00:00:00Z'
+        }));
+        await fs.outputFile(path.join(inputDir, 'chunk-1/discussion-12.md'), frontmatter({
+            number   : 12,
+            title    : 'Active fallback category',
+            closed   : false,
+            updatedAt: '2026-05-12T00:00:00Z'
+        }));
+        await fs.outputFile(path.join(archiveDir, 'v8.30.0/chunk-1/discussion-11.md'), frontmatter({
+            number   : 11,
+            title    : 'Archived answer',
+            category : 'Q&A',
+            closed   : true,
+            updatedAt: '2026-05-11T00:00:00Z'
+        }));
+
+        await createDiscussionIndex({archiveDir, inputDir, outputDir, outputFile});
+
+        const root = await fs.readJson(outputFile);
+
+        expect(root.map(record => record.id)).toEqual([
+            'Ideas',
+            'Ideas/active-chunk-1',
+            'General',
+            'General/active-chunk-1',
+            'Q&A',
+            'Q&A/archive-v8-30-0-chunk-1'
+        ]);
+
+        expect(root.find(record => record.id === 'Q&A/archive-v8-30-0-chunk-1')).toMatchObject({
+            childrenUrl: 'discussions/q-a/archive-v8-30-0-chunk-1.json',
+            childCount : 1,
+            contentDir : path.relative(process.cwd(), path.join(archiveDir, 'v8.30.0/chunk-1')),
+            filePrefix : 'discussion-',
+            isLeaf     : false,
+            parentId   : 'Q&A'
+        });
+
+        await expect(fs.readJson(path.join(outputDir, 'q-a/archive-v8-30-0-chunk-1.json'))).resolves.toEqual([{
+            id      : '11',
+            parentId: 'Q&A/archive-v8-30-0-chunk-1',
+            state   : 'closed',
+            title   : 'Archived answer'
+        }]);
+
+        // The deep-link id map spans categories and archive buckets alike.
+        await expect(fs.readJson(path.join(outputDir, 'idMap.json'))).resolves.toEqual({
+            '10': 'Ideas/active-chunk-1',
+            '11': 'Q&A/archive-v8-30-0-chunk-1',
+            '12': 'General/active-chunk-1'
+        })
+    })
+});

--- a/test/playwright/unit/buildScripts/docs/index/TicketIndex.spec.mjs
+++ b/test/playwright/unit/buildScripts/docs/index/TicketIndex.spec.mjs
@@ -1,0 +1,197 @@
+import {test, expect}    from '@playwright/test';
+import fs                from 'fs-extra';
+import os                from 'os';
+import path              from 'path';
+import createTicketIndex from '../../../../../../buildScripts/docs/index/tickets.mjs';
+
+/**
+ * @summary Verifies the Portal ticket index generator emits the chunked
+ * root-plus-leaves contract (root index, path-free leaf files, crawler manifest).
+ */
+
+function frontmatter(data) {
+    return [
+        '---',
+        ...Object.entries(data).map(([key, value]) => `${key}: ${JSON.stringify(value)}`),
+        '---',
+        '',
+        '# Body'
+    ].join('\n')
+}
+
+/**
+ * @param {Object} record
+ * @returns {Number|null}
+ */
+function getChunkNumber(record) {
+    const match = record.title?.match(/chunk-(\d+)$/);
+
+    return match ? Number(match[1]) : null
+}
+
+/**
+ * @param {Object[]} records
+ * @param {String} parentId
+ */
+function expectChunkFoldersDescending(records, parentId) {
+    const chunkNumbers = records
+        .filter(record => record.parentId === parentId && getChunkNumber(record) !== null)
+        .map(getChunkNumber);
+
+    expect(chunkNumbers.length).toBeGreaterThan(1);
+    expect(chunkNumbers).toEqual([...chunkNumbers].sort((a, b) => b - a))
+}
+
+test.describe('Portal ticket index generator (#12217)', () => {
+    let tempDir;
+
+    test.beforeEach(async () => {
+        tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'portal-ticket-index-'))
+    });
+
+    test.afterEach(async () => {
+        await fs.remove(tempDir)
+    });
+
+    test('emits the chunked path-free leaves, root index and manifest', async () => {
+        const
+            issuesDir         = path.join(tempDir, 'resources/content/issues'),
+            archiveDir        = path.join(tempDir, 'resources/content/archive/issues'),
+            dataDir           = path.join(tempDir, 'apps/portal/resources/data'),
+            outputDir         = path.join(dataDir, 'tickets'),
+            chunkedOutputFile = path.join(outputDir, 'index.json'),
+            manifestFile      = path.join(outputDir, 'manifest.json');
+
+        await fs.outputFile(path.join(issuesDir, 'chunk-2/issue-30.md'), frontmatter({
+            id       : 30,
+            title    : 'Active enhancement',
+            labels   : ['enhancement'],
+            updatedAt: '2026-05-30T00:00:00Z'
+        }));
+
+        await fs.outputFile(path.join(issuesDir, 'chunk-1/issue-10.md'), frontmatter({
+            id       : 10,
+            title    : 'Excluded chore',
+            labels   : ['chore'],
+            updatedAt: '2026-05-10T00:00:00Z'
+        }));
+
+        await fs.outputFile(path.join(archiveDir, 'v12.1.0/chunk-1/issue-20.md'), frontmatter({
+            id      : 20,
+            title   : 'Archived bug',
+            labels  : ['bug'],
+            closedAt: '2026-05-20T00:00:00Z'
+        }));
+
+        await fs.outputFile(path.join(archiveDir, 'v11.0.0/chunk-1/issue-5.md'), frontmatter({
+            id      : 5,
+            title   : 'Older docs ticket',
+            labels  : ['documentation'],
+            closedAt: '2025-11-05T00:00:00Z'
+        }));
+
+        await createTicketIndex({archiveDir, chunkedOutputFile, dataDir, issuesDir, manifestFile, outputDir});
+
+        const root = await fs.readJson(chunkedOutputFile);
+
+        expect(root.map(record => record.id)).toEqual([
+            'Backlog',
+            'Backlog/active-chunk-2',
+            'v12.1.0',
+            'v12.1.0/archive-v12-1-0-chunk-1',
+            'v11.0.0',
+            'v11.0.0/archive-v11-0-0-chunk-1'
+        ]);
+        expect(root.find(record => record.id === 'Backlog/active-chunk-2')).toMatchObject({
+            childrenUrl: 'tickets/backlog/active-chunk-2.json',
+            childCount : 1,
+            contentDir : path.relative(process.cwd(), path.join(issuesDir, 'chunk-2')),
+            filePrefix : 'issue-',
+            isLeaf     : false,
+            parentId   : 'Backlog',
+            title      : 'chunk-2'
+        });
+
+        await expect(fs.readJson(path.join(outputDir, 'backlog/active-chunk-2.json'))).resolves.toEqual([{
+            id      : '30',
+            parentId: 'Backlog/active-chunk-2',
+            title   : 'Active enhancement'
+        }]);
+
+        const archiveChunk = await fs.readJson(path.join(outputDir, 'v12-1-0/archive-v12-1-0-chunk-1.json'));
+
+        expect(archiveChunk).toEqual([{
+            id      : '20',
+            parentId: 'v12.1.0/archive-v12-1-0-chunk-1',
+            title   : 'Archived bug'
+        }]);
+        expect(archiveChunk[0]).not.toHaveProperty('path');
+
+        await expect(fs.readJson(manifestFile)).resolves.toMatchObject({
+            indexUrl: 'tickets/index.json',
+            chunks  : expect.arrayContaining([expect.objectContaining({
+                id         : 'Backlog/active-chunk-2',
+                childrenUrl: 'tickets/backlog/active-chunk-2.json',
+                childCount : 1
+            })])
+        });
+
+        // The deep-link id map names each leaf's chunk folder — and only included leaves:
+        // the excluded chore (id 10) must not appear.
+        await expect(fs.readJson(path.join(outputDir, 'idMap.json'))).resolves.toEqual({
+            '5' : 'v11.0.0/archive-v11-0-0-chunk-1',
+            '20': 'v12.1.0/archive-v12-1-0-chunk-1',
+            '30': 'Backlog/active-chunk-2'
+        })
+    });
+
+    test('orders chunk folders by chunk-number (desc), not by sortDate, matching the positional labels (#12309)', async () => {
+        const
+            issuesDir         = path.join(tempDir, 'resources/content/issues'),
+            archiveDir        = path.join(tempDir, 'resources/content/archive/issues'),
+            dataDir           = path.join(tempDir, 'apps/portal/resources/data'),
+            outputDir         = path.join(dataDir, 'tickets'),
+            chunkedOutputFile = path.join(outputDir, 'index.json'),
+            manifestFile      = path.join(outputDir, 'manifest.json');
+
+        // Three chunk folders in the SAME (Backlog) group with NON-MONOTONIC dates: the lowest-numbered
+        // chunk carries the newest date, the highest-numbered the middle date. A sortDate ordering would
+        // emit [chunk-1, chunk-3, chunk-2] — scrambled relative to the positional `treeNodeName` labels.
+        await fs.outputFile(path.join(issuesDir, 'chunk-1/issue-110.md'), frontmatter({
+            id       : 110,
+            title    : 'Newest date, lowest chunk',
+            labels   : ['enhancement'],
+            updatedAt: '2026-05-30T00:00:00Z'
+        }));
+        await fs.outputFile(path.join(issuesDir, 'chunk-2/issue-210.md'), frontmatter({
+            id       : 210,
+            title    : 'Oldest date, middle chunk',
+            labels   : ['enhancement'],
+            updatedAt: '2026-05-01T00:00:00Z'
+        }));
+        await fs.outputFile(path.join(issuesDir, 'chunk-3/issue-310.md'), frontmatter({
+            id       : 310,
+            title    : 'Middle date, highest chunk',
+            labels   : ['enhancement'],
+            updatedAt: '2026-05-15T00:00:00Z'
+        }));
+
+        await createTicketIndex({archiveDir, chunkedOutputFile, dataDir, issuesDir, manifestFile, outputDir});
+
+        // Chunk folders descend by chunk-number (newest/highest chunk first), regardless of sortDate.
+        const root = await fs.readJson(chunkedOutputFile);
+
+        expect(root.map(record => record.id)).toEqual([
+            'Backlog',
+            'Backlog/active-chunk-3',
+            'Backlog/active-chunk-2',
+            'Backlog/active-chunk-1'
+        ])
+    });
+
+    test('committed ticket index keeps active chunk folders in chunk-number order', async () => {
+        const root = await fs.readJson(path.join(process.cwd(), 'apps/portal/resources/data/tickets/index.json'));
+
+        expectChunkFoldersDescending(root, 'Backlog')
+    })
+});

--- a/test/playwright/unit/buildScripts/docs/seo/Generate.spec.mjs
+++ b/test/playwright/unit/buildScripts/docs/seo/Generate.spec.mjs
@@ -1,0 +1,85 @@
+import {test, expect} from '@playwright/test';
+import fs             from 'fs-extra';
+import path           from 'path';
+import fg             from 'fast-glob';
+
+import {
+    assertStableReleaseNoteGithubLinks,
+    getDisallowedReleaseNoteGithubLinks,
+    getReleaseNotePriority
+} from '../../../../../../buildScripts/docs/seo/generate.mjs';
+
+test.describe('docs SEO generator release-note link guard', () => {
+    test('getDisallowedReleaseNoteGithubLinks returns only mutable or release-ref Neo source links', () => {
+        const links = getDisallowedReleaseNoteGithubLinks([
+            'https://github.com/neomjs/neo/blob/dev/learn/agentos/DreamPipeline.md',
+            'https://github.com/neomjs/neo/tree/dev/.agents/skills',
+            'https://github.com/neomjs/neo/blob/07b6933fd0f1afa022146c5dee3d3becac582ff7/src/component/MagicMoveText.mjs',
+            'https://github.com/neomjs/neo/blob/main/learn/agentos/DreamPipeline.md',
+            'https://github.com/neomjs/neo/tree/v13.0.0/.agents/skills',
+            'https://github.com/neomjs/pages/blob/v13.0.0/buildScripts/enhanceSeo.mjs',
+            'https://github.com/neomjs/neo/blob/v13.0.0/src/Neo.mjs)'
+        ].join('\n'));
+
+        expect(links).toEqual([
+            'https://github.com/neomjs/neo/blob/main/learn/agentos/DreamPipeline.md',
+            'https://github.com/neomjs/neo/tree/v13.0.0/.agents/skills',
+            'https://github.com/neomjs/neo/blob/v13.0.0/src/Neo.mjs'
+        ]);
+    });
+
+    test('assertStableReleaseNoteGithubLinks fails with the release-note path and disallowed Neo source link', () => {
+        expect(() => assertStableReleaseNoteGithubLinks({
+            filePath: path.join(process.cwd(), 'resources/content/release-notes/v0.0.0.md'),
+            content : 'See https://github.com/neomjs/neo/blob/main/buildScripts/enhanceSeo.mjs'
+        })).toThrow(/resources\/content\/release-notes\/v0\.0\.0\.md[\s\S]*blob\/main\/buildScripts\/enhanceSeo\.mjs/);
+    });
+
+    test('active release notes use dev or immutable commit refs for Neo source links', async () => {
+        const files = await fg('resources/content/release-notes/**/*.md', {
+            cwd   : process.cwd(),
+            ignore: ['resources/content/archive/**']
+        });
+
+        const violations = [];
+
+        for (const file of files) {
+            const content = await fs.readFile(path.resolve(process.cwd(), file), 'utf-8');
+            const links   = getDisallowedReleaseNoteGithubLinks(content);
+
+            if (links.length > 0) {
+                violations.push({file, links});
+            }
+        }
+
+        expect(violations).toEqual([]);
+    });
+});
+
+test.describe('docs SEO generator release-note recency priority (#12753)', () => {
+    // Anchored on the newest release-note major = 13 (matches @tobiu's confirmed mapping).
+    test('current + most-recent major stay at 0.9', () => {
+        expect(getReleaseNotePriority('13.0.0', 13)).toBe(0.9);
+        expect(getReleaseNotePriority('12.1.0', 13)).toBe(0.9);
+    });
+
+    test('older majors decay below the evergreen 0.7+ tier', () => {
+        expect(getReleaseNotePriority('11.0.0', 13)).toBe(0.7);
+        expect(getReleaseNotePriority('10.5.0', 13)).toBe(0.6);
+        expect(getReleaseNotePriority('9.0.0',  13)).toBe(0.5);
+        expect(getReleaseNotePriority('8.1.2',  13)).toBe(0.4);
+        expect(getReleaseNotePriority('7.0.0',  13)).toBe(0.4); // delta 6 -> ancient floor
+    });
+
+    test('unparseable version or unknown anchor falls back to DEFAULT_PRIORITY (0.5)', () => {
+        expect(getReleaseNotePriority('not-a-version', 13)).toBe(0.5);
+        expect(getReleaseNotePriority('12.1.0', null)).toBe(0.5);
+    });
+
+    test('self-maintaining: re-anchoring on a newer major shifts the tiers down', () => {
+        // Once v14 ships, v14/v13 stay 0.9 and v12 decays to 0.7 — no code change needed.
+        expect(getReleaseNotePriority('14.0.0', 14)).toBe(0.9);
+        expect(getReleaseNotePriority('13.0.0', 14)).toBe(0.9);
+        expect(getReleaseNotePriority('12.0.0', 14)).toBe(0.7);
+    });
+});

--- a/test/playwright/unit/buildScripts/helpers/watchThemes.spec.mjs
+++ b/test/playwright/unit/buildScripts/helpers/watchThemes.spec.mjs
@@ -1,0 +1,288 @@
+import {test, expect} from '@playwright/test';
+import fs             from 'node:fs';
+import os             from 'node:os';
+import path           from 'node:path';
+
+import {
+    handleThemeWatchEvent,
+    inspectThemeWatcherAssets,
+    reconcileThemeStructure,
+    regenerateDevelopmentThemeMap,
+    startThemeWatcher
+} from '../../../../../buildScripts/helpers/watchThemes.mjs';
+
+/**
+ * @summary Pins watch-themes lifecycle reconciliation: low-latency content changes, exact
+ * add/rename/delete output + map state, partial failure visibility, and startup readiness.
+ */
+test.describe('buildScripts/helpers/watchThemes (#15585)', () => {
+    const roots = [];
+
+    function createRoot(name='neo.mjs-watch-fixture') {
+        const root = fs.mkdtempSync(path.join(os.tmpdir(), 'neo-watch-themes-'));
+
+        roots.push(root);
+        fs.writeFileSync(path.join(root, 'package.json'), JSON.stringify({
+            bugs   : {url: 'https://github.com/neomjs/neo/issues'},
+            name,
+            version: '1.0.0'
+        }));
+        fs.mkdirSync(path.join(root, 'resources/scss/src'), {recursive: true});
+
+        return root
+    }
+
+    function createLogger() {
+        const errors = [],
+              logs   = [];
+
+        return {
+            errors,
+            logger: {
+                error(message) {
+                    errors.push(message)
+                },
+                log(...items) {
+                    logs.push(items.join(' '))
+                }
+            },
+            logs
+        }
+    }
+
+    function mapLeaf(root, className) {
+        const themeMap = JSON.parse(fs.readFileSync(
+            path.join(root, 'resources/theme-map.json'),
+            'utf8'
+        ));
+
+        return className.split('.').reduce((scope, segment) => scope?.[segment], themeMap)
+    }
+
+    async function buildFixtureEntry(entry, {logger}) {
+        const source = fs.readFileSync(entry.sourcePath, 'utf8');
+
+        if (
+            source.includes("@use 'tokens'") &&
+            !fs.existsSync(path.join(path.dirname(entry.sourcePath), '_tokens.scss'))
+        ) {
+            const message = `[watch-themes] SCSS build failed for ${entry.filename}: missing tokens partial`;
+
+            logger.error(message);
+            throw new Error(message)
+        }
+
+        fs.mkdirSync(path.dirname(entry.outputPath), {recursive: true});
+        fs.writeFileSync(entry.outputPath, `/* ${entry.filename} */\n${source}`);
+        fs.writeFileSync(entry.outputPath + '.map', JSON.stringify({
+            sources: [path.relative(path.dirname(entry.outputPath), entry.sourcePath)]
+        }));
+
+        return entry.outputPath
+    }
+
+    function reconcileFixture(options) {
+        return reconcileThemeStructure({...options, build: buildFixtureEntry})
+    }
+
+    function writeScss(root, filename, content='.fixture { color: red; }') {
+        const target = path.join(root, 'resources/scss', filename);
+
+        fs.mkdirSync(path.dirname(target), {recursive: true});
+        fs.writeFileSync(target, content);
+
+        return target
+    }
+
+    test.afterAll(() => {
+        roots.forEach(root => fs.rmSync(root, {force: true, recursive: true}))
+    });
+
+    test('ordinary content changes keep the one-file path', async () => {
+        const
+            root       = createRoot(),
+            calls      = [],
+            {logger}   = createLogger(),
+            sourceFile = writeScss(root, 'src/Panel.scss');
+
+        await handleThemeWatchEvent('change', 'src/Panel.scss', {
+            build    : async filename => calls.push(['build', filename]),
+            logger,
+            reconcile: async () => {
+                calls.push(['reconcile']);
+                return {built: [], removed: [], themeMap: {}}
+            },
+            repoRoot: root
+        });
+
+        expect(fs.existsSync(sourceFile)).toBe(true);
+        expect(calls).toEqual([['build', 'src/Panel.scss']])
+    });
+
+    test('one structural event reconciles add, rename, delete, source maps, and the exact map', async () => {
+        const
+            root     = createRoot(),
+            {logger} = createLogger();
+
+        writeScss(root, 'src/Initial.scss');
+        await reconcileFixture({logger, repoRoot: root});
+
+        writeScss(root, 'src/Added.scss', '.added { display: flex; }');
+        await handleThemeWatchEvent('rename', 'src/Added.scss', {
+            logger,
+            reconcile: reconcileFixture,
+            repoRoot : root
+        });
+
+        expect(fs.existsSync(path.join(root, 'dist/development/css/src/Added.css'))).toBe(true);
+        expect(mapLeaf(root, 'Neo.Added')).toEqual(['src']);
+
+        fs.renameSync(
+            path.join(root, 'resources/scss/src/Added.scss'),
+            path.join(root, 'resources/scss/src/Renamed.scss')
+        );
+
+        // macOS is allowed to report only the retired filename. The census still discovers and
+        // builds the new path before replacing the map.
+        await handleThemeWatchEvent('rename', 'src/Added.scss', {
+            logger,
+            reconcile: reconcileFixture,
+            repoRoot : root
+        });
+
+        expect(fs.existsSync(path.join(root, 'dist/development/css/src/Added.css'))).toBe(false);
+        expect(fs.existsSync(path.join(root, 'dist/development/css/src/Added.css.map'))).toBe(false);
+        expect(fs.existsSync(path.join(root, 'dist/development/css/src/Renamed.css'))).toBe(true);
+        expect(mapLeaf(root, 'Neo.Added')).toBeUndefined();
+        expect(mapLeaf(root, 'Neo.Renamed')).toEqual(['src']);
+
+        fs.rmSync(path.join(root, 'resources/scss/src/Renamed.scss'));
+        await handleThemeWatchEvent('rename', 'src/Renamed.scss', {
+            logger,
+            reconcile: reconcileFixture,
+            repoRoot : root
+        });
+
+        expect(fs.existsSync(path.join(root, 'dist/development/css/src/Renamed.css'))).toBe(false);
+        expect(fs.existsSync(path.join(root, 'dist/development/css/src/Renamed.css.map'))).toBe(false);
+        expect(mapLeaf(root, 'Neo.Renamed')).toBeUndefined()
+    });
+
+    test('a deleted partial rebuilds its owning root and fails loudly when an importer breaks', async () => {
+        const
+            root             = createRoot(),
+            {errors, logger} = createLogger(),
+            partial          = writeScss(root, 'src/_tokens.scss', '$color: red;');
+
+        writeScss(root, 'src/Panel.scss', "@use 'tokens';\n.panel { color: tokens.$color; }");
+        await reconcileFixture({logger, repoRoot: root});
+        fs.rmSync(partial);
+
+        await expect(
+            handleThemeWatchEvent('rename', 'src/_tokens.scss', {
+                logger,
+                reconcile: reconcileFixture,
+                repoRoot : root
+            })
+        ).rejects.toThrow('[watch-themes] rename reconcile failed for src/_tokens.scss');
+
+        expect(errors.some(message => message.includes(
+            '[watch-themes] SCSS build failed for src/Panel.scss'
+        ))).toBe(true)
+    });
+
+    test('workspace regeneration preserves framework classes and removes retired local entries', () => {
+        const root = createRoot('theme-workspace');
+
+        writeScss(root, 'src/Local.scss');
+        writeScss(
+            path.join(root, 'node_modules/neo.mjs'),
+            'src/Base.scss'
+        );
+        fs.writeFileSync(path.join(root, 'resources/theme-map.json'), JSON.stringify({
+            Neo: {Retired: ['src']}
+        }));
+
+        regenerateDevelopmentThemeMap({repoRoot: root});
+
+        expect(mapLeaf(root, 'Neo.Base')).toEqual(['src']);
+        expect(mapLeaf(root, 'Neo.Local')).toEqual(['src']);
+        expect(mapLeaf(root, 'Neo.Retired')).toBeUndefined()
+    });
+
+    test('startup freshness preserves a prior valid one-file rebuild', async () => {
+        const
+            root     = createRoot(),
+            {logger} = createLogger(),
+            panel    = writeScss(root, 'src/Panel.scss'),
+            other    = writeScss(root, 'src/Other.scss');
+
+        fs.utimesSync(panel, 1, 1);
+        fs.utimesSync(other, 1, 1);
+        await reconcileFixture({logger, repoRoot: root});
+
+        const
+            panelCss = path.join(root, 'dist/development/css/src/Panel.css'),
+            otherCss = path.join(root, 'dist/development/css/src/Other.css');
+
+        // Panel changed and was rebuilt later. Other remains older than Panel's new source, but
+        // newer than its own source: that is a valid watcher state, not a reason for a full build.
+        fs.utimesSync(otherCss, 1.5, 1.5);
+        fs.utimesSync(panel, 2, 2);
+        fs.utimesSync(panelCss, 3, 3);
+
+        const state = inspectThemeWatcherAssets({repoRoot: root});
+
+        expect(state.ready).toBe(true);
+        expect(state.stale).toEqual([])
+    });
+
+    test('successful startup preloads Sass before opening the watcher', async () => {
+        const
+            root     = createRoot(),
+            calls    = [],
+            {logger} = createLogger(),
+            watcher  = {close() {}};
+
+        const result = await startThemeWatcher({
+            inspect     : () => ({ready: true}),
+            loadCompiler: async () => calls.push('compiler'),
+            logger,
+            reconcile   : async () => calls.push('reconcile'),
+            repoRoot    : root,
+            watch       : () => {
+                calls.push('watch');
+                return watcher
+            }
+        });
+
+        expect(result).toBe(watcher);
+        expect(calls).toEqual(['reconcile', 'compiler', 'watch'])
+    });
+
+    test('startup refuses loudly before the canonical initial build', async () => {
+        const
+            root     = createRoot(),
+            calls    = [],
+            {logger} = createLogger();
+
+        await expect(startThemeWatcher({
+            inspect: () => ({
+                invalidMap: null,
+                mapMissing: [],
+                missing   : ['resources/theme-map.json'],
+                ready     : false,
+                stale     : [],
+                symlinked : []
+            }),
+            loadCompiler: async () => calls.push('compiler'),
+            logger,
+            repoRoot    : root,
+            watch       : () => { throw new Error('watch must not start') }
+        })).rejects.toThrow(
+            'Recovery: npm run build-themes -- -n -e dev -t all'
+        );
+
+        expect(calls).toEqual([])
+    })
+});

--- a/test/playwright/unit/buildScripts/util/agent-push.spec.mjs
+++ b/test/playwright/unit/buildScripts/util/agent-push.spec.mjs
@@ -1,0 +1,157 @@
+import {test, expect} from '@playwright/test';
+import {
+    assertSafeRefspec,
+    buildGitPushArgs,
+    getCurrentBranch,
+    normalizeDestination,
+    parseArgs,
+    resolveDestination,
+    runAgentPush
+} from '../../../../../buildScripts/util/agent-push.mjs';
+
+test.describe('agent-push utility (#14419)', () => {
+    test('parses the narrow accepted argv surface', () => {
+        expect(parseArgs([])).toEqual({remote: 'origin', refspec: null, setUpstream: false});
+        expect(parseArgs(['-u'])).toEqual({remote: 'origin', refspec: null, setUpstream: true});
+        expect(parseArgs(['origin'])).toEqual({remote: 'origin', refspec: null, setUpstream: false});
+        expect(parseArgs(['-u', 'origin', 'agent/14419-agent-push'])).toEqual({
+            remote     : 'origin',
+            refspec    : 'agent/14419-agent-push',
+            setUpstream: true
+        })
+    });
+
+    test('refuses unsafe or widening push grammar before destination resolution', () => {
+        const rejected = [
+            ['upstream', 'agent/demo'],
+            ['origin', 'agent/demo:dev'],
+            ['origin', 'HEAD:refs/heads/dev'],
+            ['origin', 'agent/demo', 'agent/extra'],
+            ['origin', '+agent/demo'],
+            ['origin', 'agent/*'],
+            ['--tags'],
+            ['--all'],
+            ['--mirror'],
+            ['--delete'],
+            ['--force'],
+            ['--force-with-lease'],
+            ['--force-if-includes'],
+            ['-f'],
+            ['--porcelain']
+        ];
+
+        for (const argv of rejected) {
+            expect(() => parseArgs(argv), argv.join(' ')).toThrow()
+        }
+    });
+
+    test('refspec validation rejects source-destination and wildcard forms', () => {
+        expect(() => assertSafeRefspec('agent/demo:dev')).toThrow(/colon refspec/u);
+        expect(() => assertSafeRefspec('HEAD:refs/heads/dev')).toThrow(/colon refspec/u);
+        expect(() => assertSafeRefspec('+agent/demo')).toThrow(/force refspec/u);
+        expect(() => assertSafeRefspec('agent/*')).toThrow(/wildcard/u);
+        expect(() => assertSafeRefspec('agent/demo')).not.toThrow()
+    });
+
+    test('normalizes refs/heads prefixes without accepting unsafe destinations', () => {
+        expect(normalizeDestination('refs/heads/agent/demo')).toBe('agent/demo');
+        expect(normalizeDestination('agent/demo')).toBe('agent/demo')
+    });
+
+    test('resolves the effective destination from explicit, HEAD, and implicit forms', () => {
+        expect(resolveDestination({
+            currentBranch: 'agent/current',
+            refspec      : 'agent/explicit'
+        })).toBe('agent/explicit');
+
+        expect(resolveDestination({
+            currentBranch: 'agent/current',
+            refspec      : 'refs/heads/agent/full-ref'
+        })).toBe('agent/full-ref');
+
+        expect(resolveDestination({
+            currentBranch: 'agent/current',
+            refspec      : 'HEAD'
+        })).toBe('agent/current');
+
+        expect(resolveDestination({
+            currentBranch: 'agent/current',
+            refspec      : null
+        })).toBe('agent/current')
+    });
+
+    test('refuses destinations outside agent branches', () => {
+        expect(() => resolveDestination({
+            currentBranch: 'dev',
+            refspec      : null
+        })).toThrow(/agent\/\*/u);
+
+        expect(() => resolveDestination({
+            currentBranch: 'agent/current',
+            refspec      : 'main'
+        })).toThrow(/agent\/\*/u)
+    });
+
+    test('reads the current branch through git and rejects detached HEAD', () => {
+        const execFileSyncImpl = () => 'agent/current\n';
+
+        expect(getCurrentBranch({execFileSyncImpl})).toBe('agent/current');
+        expect(() => getCurrentBranch({execFileSyncImpl: () => 'HEAD\n'})).toThrow(/detached HEAD/u)
+    });
+
+    test('builds deterministic git push argv with the resolved destination', () => {
+        expect(buildGitPushArgs({
+            destination: 'agent/current',
+            remote     : 'origin'
+        })).toEqual(['push', 'origin', 'agent/current']);
+
+        expect(buildGitPushArgs({
+            destination: 'agent/current',
+            remote     : 'origin',
+            setUpstream: true
+        })).toEqual(['push', '-u', 'origin', 'agent/current']);
+
+        expect(buildGitPushArgs({
+            destination: 'agent/current',
+            refspec    : 'agent/explicit',
+            remote     : 'origin'
+        })).toEqual(['push', 'origin', 'agent/explicit'])
+    });
+
+    test('executes git push only after validation and propagates the git status', () => {
+        const calls  = [];
+        const status = runAgentPush({
+            argv            : ['-u'],
+            cwd             : '/repo',
+            execFileSyncImpl: () => 'agent/current\n',
+            spawnSyncImpl   : (cmd, args, options) => {
+                calls.push({cmd, args, options});
+                return {status: 7}
+            },
+            stderr: {write: () => {}}
+        });
+
+        expect(status).toBe(7);
+        expect(calls).toEqual([{
+            cmd    : 'git',
+            args   : ['push', '-u', 'origin', 'agent/current'],
+            options: {cwd: '/repo', stdio: 'inherit'}
+        }])
+    });
+
+    test('does not invoke git when validation fails', () => {
+        let   stderr = '';
+        const calls  = [];
+
+        const status = runAgentPush({
+            argv            : ['origin', 'agent/current:dev'],
+            execFileSyncImpl: () => 'agent/current\n',
+            spawnSyncImpl   : (...args) => calls.push(args),
+            stderr          : {write: value => { stderr += value }}
+        });
+
+        expect(status).toBe(1);
+        expect(calls).toEqual([]);
+        expect(stderr).toContain('agent-push:')
+    })
+});

--- a/test/playwright/unit/buildScripts/util/branchFreshness.spec.mjs
+++ b/test/playwright/unit/buildScripts/util/branchFreshness.spec.mjs
@@ -1,0 +1,87 @@
+import { test, expect }                                 from '@playwright/test';
+import {assessDevReferenceAuthority, detectStaleBranch} from '../../../../../buildScripts/util/branchFreshness.mjs';
+
+test.describe('buildScripts/util/branchFreshness.detectStaleBranch (#13710)', () => {
+    test('flags a behind branch whose two-dot diff carries many extra files (the #13708 revert-trap anchor)', () => {
+        expect(detectStaleBranch({ twoDotFiles: 32, threeDotFiles: 2 })).toEqual({ stale: true, extraFiles: 30 });
+    });
+
+    test('does NOT flag a current branch (two-dot equals three-dot)', () => {
+        expect(detectStaleBranch({ twoDotFiles: 3, threeDotFiles: 3 })).toEqual({ stale: false, extraFiles: 0 });
+    });
+
+    test('does NOT flag a slightly-behind branch under the threshold (low false-positive)', () => {
+        expect(detectStaleBranch({ twoDotFiles: 5, threeDotFiles: 2 })).toEqual({ stale: false, extraFiles: 3 });
+    });
+
+    test('threshold is tunable (the design knob #13710 leaves for review)', () => {
+        expect(detectStaleBranch({ twoDotFiles: 5, threeDotFiles: 2, threshold: 2 })).toEqual({ stale: true, extraFiles: 3 });
+    });
+
+    test('clamps extraFiles to zero when three-dot exceeds two-dot', () => {
+        expect(detectStaleBranch({ twoDotFiles: 2, threeDotFiles: 5 })).toEqual({ stale: false, extraFiles: 0 });
+    });
+});
+
+test.describe('buildScripts/util/branchFreshness.assessDevReferenceAuthority (#16163)', () => {
+    const
+        localSha  = 'a'.repeat(40),
+        remoteSha = 'b'.repeat(40);
+
+    test('successful fetch owns the authority without a fallback coordinate', () => {
+        expect(assessDevReferenceAuthority({fetchSucceeded: true})).toEqual({
+            usable: true,
+            status: 'fetched'
+        })
+    });
+
+    test('equal full local and remote coordinates preserve a proven-current local object', () => {
+        expect(assessDevReferenceAuthority({
+            fetchSucceeded: false,
+            localSha,
+            remoteSha     : localSha.toUpperCase()
+        })).toEqual({
+            usable: true,
+            status: 'verified-local'
+        })
+    });
+
+    test('different local and remote coordinates fail closed as stale', () => {
+        expect(assessDevReferenceAuthority({
+            fetchSucceeded: false,
+            localSha,
+            remoteSha
+        })).toEqual({
+            usable: false,
+            status: 'stale-local'
+        })
+    });
+
+    test('missing local or remote coordinates remain distinguishable', () => {
+        expect(assessDevReferenceAuthority({
+            fetchSucceeded: false,
+            remoteSha
+        })).toEqual({
+            usable: false,
+            status: 'local-unavailable'
+        });
+        expect(assessDevReferenceAuthority({
+            fetchSucceeded: false,
+            localSha
+        })).toEqual({
+            usable: false,
+            status: 'remote-unavailable'
+        })
+    });
+
+    test('malformed remote output never reads as an unchanged branch', () => {
+        expect(assessDevReferenceAuthority({
+            fetchSucceeded: false,
+            localSha,
+            remoteSha     : 'c'.repeat(41)
+        })).toEqual({
+            usable: false,
+            status: 'remote-malformed'
+        })
+    })
+});

--- a/test/playwright/unit/buildScripts/util/check-block-alignment.spec.mjs
+++ b/test/playwright/unit/buildScripts/util/check-block-alignment.spec.mjs
@@ -1,0 +1,1011 @@
+import {test, expect}            from '@playwright/test';
+import {execFileSync, spawnSync} from 'node:child_process';
+import fs                        from 'node:fs';
+import os                        from 'node:os';
+import path                      from 'node:path';
+import {fileURLToPath}           from 'node:url';
+
+const
+    __filename = fileURLToPath(import.meta.url),
+    __dirname  = path.dirname(__filename),
+    scriptPath = path.resolve(__dirname, '../../../../../buildScripts/util/check-block-alignment.mjs');
+
+/**
+ * check-block-alignment.mjs — the lint that mechanizes Neo's block alignment (import-`from`,
+ * object-literal colons, declaration `=` blocks) so it is never hand-counted. Coverage is constructed
+ * mostly without hand-aligned fixtures (the exact error class this gate removes): the misaligned input
+ * is trivial to write, the aligned form is DERIVED via `--fix`, and the false-positive guards use
+ * ungrouped inputs that pass regardless of spacing. The destructuring regression pins one concrete
+ * output fixture because the bug erased an existing human-reviewed block shape.
+ */
+test.describe('check-block-alignment.mjs (#13556)', () => {
+    let tempDir;
+
+    test.beforeEach(() => {
+        tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'neo-block-align-'));
+    });
+
+    test.afterEach(() => {
+        fs.rmSync(tempDir, {recursive: true, force: true});
+    });
+
+    const write = (name, content) => {
+        const filePath = path.join(tempDir, name);
+        fs.writeFileSync(filePath, content, 'utf8');
+        return filePath;
+    };
+
+    // spawnSync (not execSync): node is spawned directly with an argv array — no shell, so the
+    // absolute scriptPath + file args can never be interpolated into a shell command (CodeQL-clean).
+    //
+    // BOTH streams, on BOTH paths. The failure path always merged them; the success path returned
+    // stdout alone, so anything a PASSING run wrote to stderr was invisible to every arm in this
+    // file. A checker that emits an advisory about a file it does not fail is exactly that shape,
+    // and an arm asserting such an advisory would have failed for a reason having nothing to do with
+    // the advisory. `output` now means what its name claims.
+    const run = (...args) => {
+        const result = spawnSync('node', [scriptPath, ...args], {encoding: 'utf8'});
+
+        return {status: result.status, output: (result.stdout || '') + (result.stderr || '')}
+    };
+
+    const MISALIGNED = [
+        "import {a}        from './a.mjs';",
+        "import {bb, ccc} from './b.mjs';",
+        "import x          from './x.mjs';"
+    ].join('\n');
+
+    test('flags a misaligned import-from group with a file:line + expected-column diagnostic (exit 1)', () => {
+        const file             = write('m.mjs', MISALIGNED);
+        const {status, output} = run(file);
+
+        expect(status).toBe(1);
+        expect(output).toContain('Misaligned import');
+        expect(output).toMatch(/m\.mjs:1/);
+        expect(output).toMatch(/expected 'from' at column \d+/);
+    });
+
+    test('--fix aligns the group to one shared from-column and is idempotent', () => {
+        const file = write('m.mjs', MISALIGNED);
+
+        expect(run('--fix', file).status).toBe(0);
+
+        const
+            fixedLines = fs.readFileSync(file, 'utf8').split('\n').filter(line => line.startsWith('import')),
+            fromCols   = fixedLines.map(line => line.indexOf('from'));
+
+        expect(new Set(fromCols).size).toBe(1);        // every 'from' shares one column
+        expect(run(file).status).toBe(0);              // re-check passes — aligned file is clean
+        expect(run('--fix', file).status).toBe(0);   // idempotent — a second --fix changes nothing harmful
+    });
+
+    test('a lone single import is not a group — passes regardless of its spacing', () => {
+        const file = write('m.mjs', "import {something}        from './x.mjs';\n\nconst y = 1;\n");
+        expect(run(file).status).toBe(0);
+    });
+
+    test('multi-line imports break the run and are never aligned (no false positive)', () => {
+        const file = write('m.mjs', [
+            "import {",
+            "    alpha,",
+            "    beta",
+            "} from './ab.mjs';",
+            "import x from './x.mjs';"
+        ].join('\n'));
+        expect(run(file).status).toBe(0);
+    });
+
+    test('a file that cannot be processed fails (exit 1) even under --fix — no silent exit 0', () => {
+        // Guards the cycle-1 review bug: --fix swallowed a file-processing error and exited 0, masking a
+        // repair that never happened. An unprocessable (missing) file must fail in BOTH modes.
+        const missing = path.join(tempDir, 'does-not-exist.mjs');
+
+        const fixResult = run('--fix', missing);
+        expect(fixResult.status).toBe(1);
+        expect(fixResult.output).toContain('Error processing');
+
+        expect(run(missing).status).toBe(1); // check mode also fails
+    });
+
+    test.describe('the green line states the unit it judged', () => {
+        // This checker judges GROUPS. Both defects below are invisible to every other arm in this
+        // file, because both produce output the checker itself considers correct.
+
+        const SPLIT = [
+            'const x = {',
+            '    staleCount         : 0,',
+            '    manifestOrphanCount: 0,',
+            '    // prose about the next key',
+            '    parserOrphanCount: 0,',
+            '    totalOrphanCount : 0',
+            '};'
+        ].join('\n');
+
+        test('a comment splits one literal into two groups, and the file PASSES while the halves sit at different columns', () => {
+            const {status, output} = run(write('split.mjs', SPLIT));
+
+            // The defect, stated as the checker sees it: this is a pass. The two halves align to
+            // columns 23 and 21 and neither group is internally wrong, so there is nothing to report
+            // under the group rule — which is exactly why the notice has to exist.
+            expect(status).toBe(0);
+            expect(output).toContain('an alignment group starts here');
+            expect(output).toMatch(/split\.mjs:5/)
+        });
+
+        test('CONTROL: the same literal WITHOUT the comment is reported as misaligned', () => {
+            // Without this, "the checker notices the split" is equally consistent with a checker that
+            // cannot see the literal at all. The only difference between the two fixtures is the
+            // comment line.
+            const {status, output} = run(write('joined.mjs', SPLIT.split('\n').filter(line => !line.includes('prose about')).join('\n')));
+
+            expect(status).toBe(1);
+            expect(output).toContain('Misaligned object-literal colon')
+        });
+
+        test('CONTROL: a blank-line separation is deliberate and draws no notice', () => {
+            // A blank line is how an author separates groups on purpose. Reporting it would make the
+            // notice noise, and a notice that fires on intent gets tuned out before it ever fires on
+            // an accident.
+            const {status, output} = run(write('blank.mjs', SPLIT.replace('    // prose about the next key', '')));
+
+            expect(status).toBe(0);
+            expect(output).not.toContain('an alignment group starts here')
+        });
+
+        test('a violation names WHICH group of how many, because the column alone cannot say', () => {
+            const {status, output} = run(write('two.mjs', [
+                'const a = {',
+                '    one  : 1,',
+                '    two  : 2',
+                '};',
+                '',
+                'const b = {',
+                '    alpha        : 1,',
+                '    beta: 2',
+                '};'
+            ].join('\n')));
+
+            expect(status).toBe(1);
+            expect(output).toContain('(group 1 of 2)');
+            expect(output).toContain('(group 2 of 2)')
+        });
+
+        test('IMPORT groups name themselves too — the unit contract is not object-colon only', () => {
+        // The ticket says "each checker's failure output names the unit it judged". Implementing that
+        // for one of three evaluators would leave the generalized claim and the output disagreeing.
+        const {output} = run(write('imp.mjs', [
+            "import {a}        from './a.mjs';",
+            "import {bb, ccc} from './b.mjs';",
+            '',
+            'function f() {}',
+            '',
+            "import x   from './x.mjs';",
+            "import yy from './y.mjs';"
+        ].join('\n')));
+
+        expect(output).toContain('(group 1 of 2)');
+        expect(output).toContain('(group 2 of 2)')
+    });
+
+    test('ASSIGNMENT groups name themselves too', () => {
+        const {output} = run(write('asg.mjs', [
+            'const aa = 1;',
+            'const b  = 2;',
+            '',
+            'function f() {',
+            '    const ccccc = 3;',
+            '    const d = 4;',
+            '}'
+        ].join('\n')));
+
+        expect(output).toMatch(/Misaligned '='.*\(group \d of 2\)/)
+    });
+
+    test('a single group is not labelled — "group 1 of 1" would be noise', () => {
+            const {output} = run(write('one.mjs', ['const a = {', '    one  : 1,', '    two: 2', '};'].join('\n')));
+
+            expect(output).toContain('Misaligned object-literal colon');
+            expect(output).not.toContain('group 1 of 1')
+        })
+    });
+
+    test.describe('v1b: object-colon + `=` alignment (#13563)', () => {
+        test('--fix aligns an object-literal colon block to one column and is idempotent', () => {
+            const file = write('o.mjs', [
+                'const config = {',
+                '    db: 1,',
+                '    state: 2,',
+                '    intervals: 3',
+                '};'
+            ].join('\n'));
+
+            expect(run('--fix', file).status).toBe(0);
+
+            const colonCols = fs.readFileSync(file, 'utf8').split('\n')
+                .filter(line => /^\s+\w+\s*:/.test(line))
+                .map(line => line.indexOf(':'));
+
+            expect(colonCols.length).toBe(3);
+            expect(new Set(colonCols).size).toBe(1);     // db/state/intervals colons share one column
+            expect(run(file).status).toBe(0);            // aligned → clean
+            expect(run('--fix', file).status).toBe(0);   // idempotent
+        });
+
+        test('a shorthand property stays in the run without breaking colon alignment', () => {
+            const file = write('o.mjs', [
+                'const config = {',
+                '    db: 1,',
+                '    now,',
+                '    intervals: 3',
+                '};'
+            ].join('\n'));
+
+            expect(run('--fix', file).status).toBe(0);
+
+            const lines          = fs.readFileSync(file, 'utf8').split('\n');
+            const dbColon        = lines.find(line => /^\s+db\b/.test(line)).indexOf(':');
+            const intervalsColon = lines.find(line => /^\s+intervals\b/.test(line)).indexOf(':');
+
+            expect(dbColon).toBe(intervalsColon); // aligned across the `now,` shorthand
+        });
+
+        test('a nested object re-groups at its own indent (no cross-indent alignment)', () => {
+            const file = write('o.mjs', [
+                'const config = {',
+                '    a: 1,',
+                '    nested: {',
+                '        x: 1,',
+                '        yy: 2',
+                '    }',
+                '};'
+            ].join('\n'));
+
+            expect(run('--fix', file).status).toBe(0);
+
+            const lines = fs.readFileSync(file, 'utf8').split('\n');
+            const xCol  = lines.find(line => /^\s{8}x\b/.test(line)).indexOf(':');
+            const yyCol = lines.find(line => /^\s{8}yy\b/.test(line)).indexOf(':');
+
+            expect(xCol).toBe(yyCol);          // inner keys align to each other at the deeper indent
+            expect(run(file).status).toBe(0);  // aligned → clean
+        });
+
+        test('a lone colon property is not an alignment group — passes regardless of spacing', () => {
+            const file = write('o.mjs', 'const config = {\n    onlyKey:      1\n};\n');
+            expect(run(file).status).toBe(0);
+        });
+
+        test('template-string JSON examples are neither flagged nor fixed (#13670)', () => {
+            const file = write('prompt.mjs', [
+                'const prompt = `',
+                'Output STRICT JSON:',
+                '{',
+                '    "id": "x",',
+                '    "longName": "y"',
+                '}',
+                '`;'
+            ].join('\n'));
+            const before = fs.readFileSync(file, 'utf8');
+
+            expect(run(file).status).toBe(0);
+            expect(run('--fix', file).status).toBe(0);
+            expect(fs.readFileSync(file, 'utf8')).toBe(before);
+        });
+
+        test('a single-line template-valued property stays in its run — all keys align, not split (#14212)', () => {
+            // Regression: a property whose VALUE is a single-line template begins in code, so it must stay
+            // in its colon-alignment run. A prior mask flagged any line containing template content, which
+            // split the run here — leaving the keys before it tight and the rest far.
+            const file = write('tmpl-value.mjs', [
+                'const node = {',
+                '    id: memoryId,',
+                '    type: nodeType,',
+                '    name: `Memory: ${timestamp}`,',
+                '    semanticVectorId: memoryId',
+                '};'
+            ].join('\n'));
+
+            expect(run('--fix', file).status).toBe(0);
+
+            const colonCols = fs.readFileSync(file, 'utf8').split('\n')
+                .filter(line => /^\s+\w+\s*:/.test(line))
+                .map(line => line.indexOf(':'));
+
+            expect(colonCols.length).toBe(4);
+            expect(new Set(colonCols).size).toBe(1);     // id/type/name/semanticVectorId share one column — the template value did not split the run
+            expect(run(file).status).toBe(0);            // aligned → clean
+            expect(run('--fix', file).status).toBe(0);   // idempotent
+        });
+
+        test('template masking ignores quoted/comment backticks and preserves real object fixes (#13670)', () => {
+            const file = write('prompt-edge.mjs', [
+                'const quoted = "`";',
+                '// comment with ` must not open a template',
+                '/* block comment with ` must not open a template */',
+                'const rendered = `${(() => {',
+                '    const inner = `value ${`nested`}`;',
+                '    return inner;',
+                '})()}`;',
+                'const prompt = `',
+                'escaped \\` backtick stays content',
+                '{',
+                '    "id": "x",',
+                '    "longName": "y"',
+                '}',
+                '`;',
+                '',
+                'const config = {',
+                '    a: 1,',
+                '    longer: 2',
+                '};'
+            ].join('\n'));
+
+            expect(run('--fix', file).status).toBe(0);
+
+            const lines = fs.readFileSync(file, 'utf8').split('\n');
+            expect(lines).toContain('    "id": "x",');
+            expect(lines).toContain('    "longName": "y"');
+            expect(lines.find(line => /^\s+a\b/.test(line))).toBe('    a     : 1,');
+            expect(lines.find(line => /^\s+longer\b/.test(line))).toBe('    longer: 2');
+            expect(run(file).status).toBe(0);
+        });
+
+        test('--fix aligns a `=` declaration block (lone-keyword form) and is idempotent', () => {
+            const file = write('d.mjs', [
+                'const',
+                '    a = 1,',
+                '    bbb = 2;'
+            ].join('\n'));
+
+            expect(run('--fix', file).status).toBe(0);
+
+            const eqCols = fs.readFileSync(file, 'utf8').split('\n')
+                .filter(line => line.includes('='))
+                .map(line => line.indexOf('='));
+
+            expect(eqCols.length).toBe(2);
+            expect(new Set(eqCols).size).toBe(1);        // a/bbb `=` share one column
+            expect(run(file).status).toBe(0);
+            expect(run('--fix', file).status).toBe(0);   // idempotent
+        });
+
+        test('--fix aligns a keyword-head comma-block with bare continuations', () => {
+            const file = write('d.mjs', [
+                'const short = 1,',
+                '      muchLongerName = 2,',
+                '      blockValue = {',
+                '          a: 1',
+                '      };'
+            ].join('\n'));
+
+            expect(run('--fix', file).status).toBe(0);
+
+            const
+                lines    = fs.readFileSync(file, 'utf8').split('\n'),
+                shortEq  = lines.find(line => /short/.test(line)).indexOf('='),
+                longerEq = lines.find(line => /muchLongerName/.test(line)).indexOf('='),
+                blockEq  = lines.find(line => /blockValue/.test(line)).indexOf('=');
+
+            expect(shortEq).toBe(longerEq);
+            expect(blockEq).toBe(longerEq);
+            expect(run(file).status).toBe(0);
+        });
+
+        test('#13908: --fix aligns keyword-head comma-blocks with destructuring continuations', () => {
+            const file = write('d.mjs', [
+                '        let me = this,',
+                '            {record} = data,',
+                '            oldValue = me.value,',
+                '            {value} = record;'
+            ].join('\n'));
+
+            expect(run('--fix', file).status).toBe(0);
+
+            expect(fs.readFileSync(file, 'utf8').split('\n')).toEqual([
+                '        let me       = this,',
+                '            {record} = data,',
+                '            oldValue = me.value,',
+                '            {value}  = record;'
+            ]);
+            expect(run(file).status).toBe(0);
+        });
+
+        test('#15072: a destructuring-with-defaults declarator is left untouched, never mis-split into invalid JS', () => {
+            // The default `=` inside `{blockedNodes = []}` is NOT the assignment operator. Before the guard,
+            // --fix sliced the line at that first `=` and erased `[], ...} = focusContradiction` into a
+            // SyntaxError. Such a line now fails to match as a declaration, breaks the run, and is preserved
+            // byte-for-byte. Default-FREE destructuring (`{record}`, above) still aligns — this is the only
+            // shape excluded. Pins the exact multi-declarator input the aligner corrupted.
+            const original = [
+                'function buildRouteAttributionRecords(focusContradiction) {',
+                '    const {blockedNodes = [], focusCandidates = []} = focusContradiction,',
+                '          focusReasons = [...new Set(focusCandidates.flatMap(c => Array.isArray(c.reasons) ? c.reasons : []))];',
+                '    return {blockedNodes, focusReasons};',
+                '}'
+            ].join('\n');
+            const file = write('d.mjs', original);
+
+            expect(run('--fix', file).status).toBe(0);
+            expect(fs.readFileSync(file, 'utf8')).toBe(original);    // byte-identical: the default `=` is never an alignment column
+            expect(run(file).status).toBe(0);                        // check mode: no drift, so the author is never told to --fix
+            execFileSync('node', ['--check', file], {stdio: 'pipe'}); // throws if --fix left the file un-parseable
+        });
+
+        test('#15703: a multiline callback arrow breaks the declaration run and stays byte-identical', () => {
+            // The `=` inside `=>` is not an assignment operator. A callback body line can share the
+            // comma-block continuation indent, so the parser must reject it before reconstruction.
+            const original = [
+                'function selectObservations(observations) {',
+                '    const',
+                '        selected = observations.filter(',
+                '        observation => observation.keep',
+                '    ),',
+                '        count = selected.length;',
+                '',
+                '    return {selected, count}',
+                '}'
+            ].join('\n');
+            const file = write('callback-arrow.mjs', original);
+
+            expect(run('--fix', file).status).toBe(0);
+            expect(fs.readFileSync(file, 'utf8')).toBe(original);
+            expect(run(file).status).toBe(0);
+            expect(run('--fix', file).status).toBe(0);
+            expect(fs.readFileSync(file, 'utf8')).toBe(original);
+            execFileSync(process.execPath, ['--check', file], {stdio: 'pipe'});
+        });
+
+        test('#13896: --fix aligns repeated-keyword declaration blocks', () => {
+            const file = write('d.mjs', [
+                "const extra     = extraModels.length ? extraModels.join(', ') : 'none';",
+                'const requiredObserved = Neo.isNumber(observedRequiredCount) ? observedRequiredCount : observedCount;'
+            ].join('\n'));
+
+            expect(run(file).status).toBe(1);
+            expect(run('--fix', file).status).toBe(0);
+
+            const
+                lines      = fs.readFileSync(file, 'utf8').split('\n'),
+                extraEq    = lines[0].indexOf('='),
+                observedEq = lines[1].indexOf('=');
+
+            expect(extraEq).toBe(observedEq);
+            expect(lines[0]).toBe("const extra            = extraModels.length ? extraModels.join(', ') : 'none';");
+            expect(run(file).status).toBe(0);
+        });
+
+        test('#13896: --fix aligns repeated declarations when a new longer binding resets the block', () => {
+            const file = write('d.mjs', [
+                'const observedCount = availableModels.length;',
+                'const observedRequiredCount = getRequiredAvailable(availableModels).length;',
+                'const capacityReady      = observedRequiredCount >= requiredResidentModels;'
+            ].join('\n'));
+
+            expect(run('--fix', file).status).toBe(0);
+
+            const eqCols = fs.readFileSync(file, 'utf8').split('\n').map(line => line.indexOf('='));
+
+            expect(new Set(eqCols).size).toBe(1);
+            expect(run(file).status).toBe(0);
+        });
+
+        test('#13896: a lone keyword declaration normalizes stale padding', () => {
+            const file = write('d.mjs', 'const trigger   = buildSummaryTrigger({\n    now\n});\n');
+
+            expect(run(file).status).toBe(1);
+            expect(run('--fix', file).status).toBe(0);
+            expect(fs.readFileSync(file, 'utf8').split('\n')[0]).toBe('const trigger = buildSummaryTrigger({');
+            expect(run(file).status).toBe(0);
+        });
+
+        test('bare non-declaration assignments are NOT aligned (declaration-anchored only)', () => {
+            // No const/let/var anchor → arbitrary assignments must never be re-aligned (false-positive guard).
+            const file = write('d.mjs', 'obj.a = 1;\nobj.bbb = 2;\n');
+            expect(run(file).status).toBe(0);
+        });
+
+        test('mixed repeated-keyword declarations align keyword, name, and equals columns', () => {
+            const file = write('d.mjs', 'let aaa = 1;\nconst b = 2;\nlet cc = 3;\n');
+            expect(run('--fix', file).status).toBe(0);
+
+            const aligned = fs.readFileSync(file, 'utf8');
+            expect(aligned).toContain('let   aaa = 1;');
+            expect(aligned).toContain('const b   = 2;');
+            expect(aligned).toContain('let   cc  = 3;');
+        });
+
+        test('a computed key participates in colon alignment (the [isDescriptor] config pattern)', () => {
+            // Regression guard: a `[bracket]` key must be counted in the key width, not excluded — else
+            // the colons re-align to a narrower column and break the descriptor block.
+            const file = write('o.mjs', [
+                'const d = {',
+                '    [isDescriptor]: true,',
+                '    merge: 1,',
+                '    value: 2',
+                '};'
+            ].join('\n'));
+
+            expect(run('--fix', file).status).toBe(0);
+
+            const colonCols = fs.readFileSync(file, 'utf8').split('\n')
+                .filter(line => /^\s+(\[[^\]]+\]|\w+)\s*:/.test(line))
+                .map(line => line.indexOf(':'));
+
+            expect(colonCols.length).toBe(3);
+            expect(new Set(colonCols).size).toBe(1); // [isDescriptor]/merge/value colons share one column
+        });
+
+        test('a block-opening `=` value participates in lone-keyword block alignment', () => {
+            // Regression guard: an earlier fix collapsed `me    = this` to `me = this` before a block-opening
+            // sibling. That is still one declaration block and must align as a whole.
+            const file = write('d.mjs', [
+                'const',
+                '    me = this,',
+                '    camelRegex = 1,',
+                '    configSymbol = 2,',
+                '    cloneMap = {',
+                '        a: 1',
+                '    };'
+            ].join('\n'));
+
+            expect(run('--fix', file).status).toBe(0);
+
+            const
+                lines    = fs.readFileSync(file, 'utf8').split('\n'),
+                meEq     = lines.find(line => /\bme\b/.test(line)).indexOf('='),
+                camelEq  = lines.find(line => /camelRegex/.test(line)).indexOf('='),
+                configEq = lines.find(line => /configSymbol/.test(line)).indexOf('='),
+                cloneEq  = lines.find(line => /cloneMap/.test(line)).indexOf('=');
+
+            expect(new Set([meEq, camelEq, configEq, cloneEq]).size).toBe(1);
+            expect(lines.find(line => /\bme\b/.test(line))).toBe('    me           = this,');
+            expect(lines.find(line => /cloneMap/.test(line))).toBe('    cloneMap     = {');
+        });
+    });
+});
+
+/**
+ * Real-git integration for the --staged diff-scope. In lint-staged (pre-commit) mode the check
+ * reports drift in the RUNS the author touched — including untouched sibling lines inside such a
+ * run, since alignment is a property of the run — while a run they never touched must not block an
+ * unrelated commit, reusing the shared stagedDiff helper.
+ */
+test.describe('check-block-alignment.mjs --staged diff-scope (#13720)', () => {
+    let stagedDir;
+
+    const git = (...a) => execFileSync('git', a, {cwd: stagedDir, stdio: 'ignore'});
+
+    const runStaged = (file) => {
+        try {
+            return {status: 0, output: execFileSync('node', [scriptPath, '--staged', file], {cwd: stagedDir, encoding: 'utf8', stdio: 'pipe'})};
+        } catch (error) {
+            return {status: error.status, output: (error.stderr || '') + (error.stdout || '')};
+        }
+    };
+
+    test.beforeEach(() => {
+        stagedDir = fs.mkdtempSync(path.join(os.tmpdir(), 'neo-blockalign-staged-'));
+        git('init');
+        git('config', 'user.email', 'test@example.com');
+        git('config', 'user.name', 'Test User');
+    });
+
+    test.afterEach(() => {
+        fs.rmSync(stagedDir, {recursive: true, force: true});
+    });
+
+    test('does NOT flag a grandfathered misalignment on an untouched line', () => {
+        const file = path.join(stagedDir, 'src.mjs');
+        // Two misaligned imports (line 1 drifts), committed = grandfathered.
+        fs.writeFileSync(file, "import a from 'a';\nimport bb from 'b';\n", 'utf8');
+        git('add', 'src.mjs');
+        git('commit', '-m', 'init');
+        // Stage an unrelated added line (line 3); the grandfathered drift on line 1 stays untouched.
+        fs.writeFileSync(file, "import a from 'a';\nimport bb from 'b';\nexport const x = 1;\n", 'utf8');
+        git('add', 'src.mjs');
+
+        expect(runStaged('src.mjs').status).toBe(0);
+    });
+
+    test('flags a misalignment on a staged-ADDED line', () => {
+        const file = path.join(stagedDir, 'src.mjs');
+        // New file: both misaligned imports are staged-added, so line 1's drift is in scope.
+        fs.writeFileSync(file, "import a from 'a';\nimport bb from 'b';\n", 'utf8');
+        git('add', 'src.mjs');
+
+        const r = runStaged('src.mjs');
+        expect(r.status).toBe(1);
+        expect(r.output).toContain('Misaligned');
+    });
+});
+
+/**
+ * Real-git integration for the scoped pre-commit REPAIR (`--fix --staged`): the hook converts from
+ * reject to repair, rewriting drift in the RUNS the author touched. A run they never touched stays
+ * byte-identical — which is what these arms pin, and it still holds now that ownership is the run
+ * rather than the line; a git detection failure reports and never writes (fail-closed); pure `--fix`
+ * stays the deliberate whole-file pass. The detector is untouched —
+ * the entire pre-existing suite above runs unmodified against the new disposition surface.
+ */
+test.describe('check-block-alignment.mjs --fix --staged scoped repair (#17201)', () => {
+    let stagedDir;
+
+    const git = (...a) => execFileSync('git', a, {cwd: stagedDir, stdio: 'ignore'});
+
+    // execFileSync with an argv array (no shell), cwd-pinned to the fixture repo: the script resolves
+    // its gitRoot from the process cwd, exactly as lint-staged's invocation resolves the real one.
+    const run = (args, cwd = stagedDir) => {
+        try {
+            return {status: 0, output: execFileSync('node', [scriptPath, ...args], {cwd, encoding: 'utf8', stdio: 'pipe'})};
+        } catch (error) {
+            return {status: error.status, output: (error.stderr || '') + (error.stdout || '')};
+        }
+    };
+
+    test.beforeEach(() => {
+        stagedDir = fs.mkdtempSync(path.join(os.tmpdir(), 'neo-blockalign-scopedfix-'));
+        git('init');
+        git('config', 'user.email', 'test@example.com');
+        git('config', 'user.name', 'Test User');
+    });
+
+    test.afterEach(() => {
+        fs.rmSync(stagedDir, {recursive: true, force: true});
+    });
+
+    test('rewrites drift in the touched run only; a grandfathered run stays byte-identical (AC1)', () => {
+        const file = path.join(stagedDir, 'src.mjs');
+        // Committed: a misaligned import pair (line 1 drifts) — grandfathered, never owned again.
+        fs.writeFileSync(file, "import a from 'a';\nimport bb from 'b';\n", 'utf8');
+        git('add', 'src.mjs');
+        git('commit', '-m', 'init');
+
+        // Staged: an unrelated object block whose colon drift sits entirely on the ADDED lines.
+        fs.writeFileSync(file, [
+            "import a from 'a';",
+            "import bb from 'b';",
+            'const config = {',
+            '    db: 1,',
+            '    intervals: 3',
+            '};',
+            ''
+        ].join('\n'), 'utf8');
+        git('add', 'src.mjs');
+
+        expect(run(['--fix', '--staged', 'src.mjs']).status).toBe(0);
+
+        const lines = fs.readFileSync(file, 'utf8').split('\n');
+        expect(lines[0]).toBe("import a from 'a';");   // grandfathered import drift: byte-identical
+        expect(lines[1]).toBe("import bb from 'b';");
+        expect(lines[3]).toBe('    db       : 1,');    // owned colon drift: repaired
+        expect(lines[4]).toBe('    intervals: 3');
+    });
+
+    test('fails closed without a reliable staged-line set: reports, never writes (AC2)', () => {
+        // No git repository at or above this cwd: rev-parse fails, so the scoped repair must refuse
+        // to write rather than degrade into a whole-file reformat on a transient git error.
+        const bareDir = fs.mkdtempSync(path.join(os.tmpdir(), 'neo-blockalign-norepo-'));
+        try {
+            const file     = path.join(bareDir, 'src.mjs');
+            const original = "import a from 'a';\nimport bb from 'b';\n";
+            fs.writeFileSync(file, original, 'utf8');
+
+            const r = run(['--fix', '--staged', file], bareDir);
+            expect(r.status).toBe(1);
+            expect(r.output).toContain('Misaligned');
+            expect(r.output).toContain('repair skipped');
+            expect(fs.readFileSync(file, 'utf8')).toBe(original);   // byte-identical: nothing rewritten
+        } finally {
+            fs.rmSync(bareDir, {recursive: true, force: true});
+        }
+    });
+
+    test('the hook disposition: stage misaligned → --fix --staged repairs → commit proceeds, aligned (AC3)', () => {
+        const file = path.join(stagedDir, 'src.mjs');
+        // A brand-new file whose entire content is staged-added: every violation is owned.
+        fs.writeFileSync(file, "import a from 'a';\nimport bb from 'b';\n", 'utf8');
+        git('add', 'src.mjs');
+
+        // What the pre-commit hook now runs (the package.json lint-staged entry pinned below).
+        expect(run(['--fix', '--staged', 'src.mjs']).status).toBe(0);
+
+        git('add', 'src.mjs');                      // lint-staged re-stages the repair
+        git('commit', '-m', 'fixture commit');      // the commit proceeds without author action
+
+        const committed = execFileSync('git', ['show', 'HEAD:src.mjs'], {cwd: stagedDir, encoding: 'utf8'});
+        expect(committed).toBe("import a  from 'a';\nimport bb from 'b';\n");
+    });
+
+    test('the lint-staged entry invokes the scoped repair (AC3 wiring pin)', () => {
+        const pkg = JSON.parse(fs.readFileSync(path.resolve(__dirname, '../../../../../package.json'), 'utf8'));
+        expect(pkg['lint-staged']['*.mjs']).toContain('node ./buildScripts/util/check-block-alignment.mjs --fix --staged');
+    });
+
+    test('pure --fix remains the deliberate whole-file pass, grandfathered drift included (AC4)', () => {
+        const file = path.join(stagedDir, 'src.mjs');
+        fs.writeFileSync(file, "import a from 'a';\nimport bb from 'b';\n", 'utf8');
+        git('add', 'src.mjs');
+        git('commit', '-m', 'init');
+
+        // Nothing staged at all: the scoped repair would own no line, but a deliberate --fix
+        // rewrites the whole file regardless of staging.
+        expect(run(['--fix', 'src.mjs']).status).toBe(0);
+        expect(fs.readFileSync(file, 'utf8')).toBe("import a  from 'a';\nimport bb from 'b';\n");
+    });
+});
+
+/**
+ * The scoped repair's unchecked precondition: `getStagedAddedLines` speaks INDEX coordinates and the
+ * repair writes the WORKING TREE. On a partially staged file they drift by the unstaged edit's line
+ * delta, so index line N addresses a different line on disk — the repair then edits lines the author
+ * never staged and leaves the staged drift in place, reporting success for both halves.
+ */
+test.describe('check-block-alignment.mjs --fix --staged index-vs-worktree precondition (#17226)', () => {
+    let stagedDir;
+
+    const git = (...a) => execFileSync('git', a, {cwd: stagedDir, stdio: 'ignore'});
+
+    const run = (args, cwd = stagedDir) => {
+        try {
+            return {status: 0, output: execFileSync('node', [scriptPath, ...args], {cwd, encoding: 'utf8', stdio: 'pipe'})};
+        } catch (error) {
+            return {status: error.status, output: (error.stderr || '') + (error.stdout || '')};
+        }
+    };
+
+    // A file whose staged content carries alignable drift, then an unstaged edit ABOVE it that shifts
+    // every subsequent line by three — the shape that makes index and worktree coordinates disagree.
+    const seedShiftedFile = () => {
+        const file = path.join(stagedDir, 'src.mjs');
+
+        fs.writeFileSync(file, 'const zz = 1;\n', 'utf8');
+        git('add', 'src.mjs');
+        git('commit', '-m', 'init');
+
+        fs.writeFileSync(file, 'const zz = 1;\nconst obj = {\n    id: 1,\n    namelong: 2\n};\n', 'utf8');
+        git('add', 'src.mjs');
+
+        fs.writeFileSync(file, '// unstaged A\n// unstaged B\n// unstaged C\nconst zz = 1;\nconst obj = {\n    id: 1,\n    namelong: 2\n};\n', 'utf8');
+
+        return file
+    };
+
+    test.beforeEach(() => {
+        stagedDir = fs.mkdtempSync(path.join(os.tmpdir(), 'neo-blockalign-coords-'));
+        git('init');
+        git('config', 'user.email', 'test@example.com');
+        git('config', 'user.name', 'Test User');
+    });
+
+    test.afterEach(() => {
+        fs.rmSync(stagedDir, {recursive: true, force: true});
+    });
+
+    test('refuses to rewrite a file whose working tree has drifted from the index (#17226)', () => {
+        const file   = seedShiftedFile(),
+              before = fs.readFileSync(file, 'utf8'),
+              result = run(['--fix', '--staged', 'src.mjs']);
+
+        // Byte-identical is the assertion that matters: before this precondition the run rewrote
+        // `const zz` — a line the author never staged — and left the staged object block unrepaired.
+        expect(fs.readFileSync(file, 'utf8')).toBe(before);
+        expect(result.status).toBe(1);
+        expect(result.output).toContain('unstaged changes');
+    });
+
+    test('names the unstaged-changes cause apart from a failed staged-line read (#17226)', () => {
+        seedShiftedFile();
+
+        // Two causes, two author actions — stash your other edits, versus fix your git state. One
+        // message for both told the author neither, which is why the reason is carried per file.
+        expect(run(['--fix', '--staged', 'src.mjs']).output).toContain('stage or stash the rest');
+    });
+
+    test('a fully staged file is unaffected — the repair still runs (#17226)', () => {
+        const file = path.join(stagedDir, 'src.mjs');
+
+        fs.writeFileSync(file, "import a from 'a';\nimport bb from 'b';\n", 'utf8');
+        git('add', 'src.mjs');
+        git('commit', '-m', 'init');
+
+        fs.writeFileSync(file, "import a from 'a';\nimport bb from 'b';\nconst obj = {\n    id: 1,\n    namelong: 2\n};\n", 'utf8');
+        git('add', 'src.mjs');
+
+        // The control that keeps the new precondition from becoming a blanket refusal: with no
+        // unstaged changes the coordinates agree, so the scoped repair must behave exactly as before.
+        expect(run(['--fix', '--staged', 'src.mjs']).status).toBe(0);
+        expect(fs.readFileSync(file, 'utf8')).toContain('    id      : 1,');
+    });
+
+    test('pure --fix is unaffected by the precondition — still whole-file (#17226)', () => {
+        const file = seedShiftedFile();
+
+        // The deliberate pass has no staged-line set to misapply, so an unstaged edit is irrelevant
+        // to it; refusing here would break the documented remedy for grandfathered drift.
+        expect(run(['--fix', 'src.mjs']).status).toBe(0);
+        expect(fs.readFileSync(file, 'utf8')).toContain('const zz  = 1;');
+    });
+
+    // The usage header accepts `<file.mjs> [...]`, and a per-file refusal does NOT make the batch
+    // mutation-free: a safe file earlier in argv is already written when a later one refuses. Saying
+    // "no files were rewritten" there is the opposite of what just happened, and it sends the author
+    // away from a real repair sitting UNSTAGED in their tree. Found by @neo-gpt at the exact head.
+    test('a mixed batch reports the earlier repair instead of claiming nothing was written (#17226)', () => {
+        const safe = path.join(stagedDir, 'safe.mjs'),
+              file = path.join(stagedDir, 'src.mjs');
+
+        // Both baselines are committed in ONE commit before anything is staged. `git commit` with no
+        // pathspec commits the whole index, so seeding these files in sequence would sweep the first
+        // file's staged drift into the second file's commit and leave it with nothing staged.
+        fs.writeFileSync(safe, "import a from 'a';\nimport bb from 'b';\n", 'utf8');
+        fs.writeFileSync(file, 'const zz = 1;\n', 'utf8');
+        git('add', 'safe.mjs', 'src.mjs');
+        git('commit', '-m', 'init');
+
+        // safe.mjs: drift entirely on staged-added lines, no unstaged edit → repairable.
+        fs.writeFileSync(safe, "import a from 'a';\nimport bb from 'b';\nconst obj = {\n    id: 1,\n    namelong: 2\n};\n", 'utf8');
+        // src.mjs: staged drift, then an unstaged edit above it that shifts the coordinates → refused.
+        fs.writeFileSync(file, 'const zz = 1;\nconst obj = {\n    id: 1,\n    namelong: 2\n};\n', 'utf8');
+        git('add', 'safe.mjs', 'src.mjs');
+        fs.writeFileSync(file, '// unstaged A\n// unstaged B\n// unstaged C\nconst zz = 1;\nconst obj = {\n    id: 1,\n    namelong: 2\n};\n', 'utf8');
+
+        const result = run(['--fix', '--staged', 'safe.mjs', 'src.mjs']);
+
+        // The earlier file really was rewritten...
+        expect(fs.readFileSync(safe, 'utf8')).toContain('    id      : 1,');
+        // ...so the summary must say so, and must NOT claim the batch was a no-op.
+        expect(result.output).toContain('safe.mjs was already repaired before the refusal');
+        expect(result.output).not.toContain('No files were rewritten');
+        expect(result.status).toBe(1);
+    });
+
+    // The control that keeps the truthful-summary fix from inverting: when nothing was written, the
+    // no-op claim is correct and must survive.
+    test('an all-refused batch still reports that nothing was written (#17226)', () => {
+        seedShiftedFile();
+
+        const result = run(['--fix', '--staged', 'src.mjs']);
+
+        expect(result.output).toContain('No files were rewritten');
+        expect(result.output).not.toContain('already repaired before the refusal');
+    });
+});
+
+/**
+ * A one-line edit inside an EXISTING aligned run.
+ *
+ * The scoped repair masked whole-file violations by staged-added LINE, and alignment is a property
+ * of a RUN of >= 2 lines — so the most common edit shape there is escaped entirely. Two ways, and
+ * the second is the one that makes a violation-seeded mask insufficient:
+ *
+ *   1. a one-line addition presents as a 1-member run, so the rule has nothing to group;
+ *   2. WIDENING a line makes that line the widest, hence CORRECT — the violations land on its
+ *      untouched siblings, so a mask seeded from violated-AND-staged lines matches nothing at all.
+ *
+ * Membership therefore decides ownership: touch any line of a run and every violation in that run
+ * is yours. Untouched runs elsewhere stay untouched, which the grandfathering arm above still pins.
+ */
+test.describe('check-block-alignment.mjs --fix --staged run-scoped ownership', () => {
+    let stagedDir;
+
+    const git = (...a) => execFileSync('git', a, {cwd: stagedDir, stdio: 'ignore'});
+
+    const run = (args, cwd = stagedDir) => {
+        try {
+            return {status: 0, output: execFileSync('node', [scriptPath, ...args], {cwd, encoding: 'utf8', stdio: 'pipe'})};
+        } catch (error) {
+            return {status: error.status, output: (error.stderr || '') + (error.stdout || '')};
+        }
+    };
+
+    // Commit `before`, stage `after`, run the pre-commit repair, return the resulting lines.
+    const editAndRepair = (before, after) => {
+        const file = path.join(stagedDir, 'src.mjs');
+
+        fs.writeFileSync(file, before.join('\n') + '\n', 'utf8');
+        git('add', 'src.mjs');
+        git('commit', '-m', 'baseline');
+
+        fs.writeFileSync(file, after.join('\n') + '\n', 'utf8');
+        git('add', 'src.mjs');
+
+        const result = run(['--fix', '--staged', 'src.mjs']);
+
+        return {result, lines: fs.readFileSync(file, 'utf8').split('\n')};
+    };
+
+    test.beforeEach(() => {
+        stagedDir = fs.mkdtempSync(path.join(os.tmpdir(), 'neo-blockalign-runscope-'));
+        git('init');
+        git('config', 'user.email', 'test@example.com');
+        git('config', 'user.name', 'Test User');
+    });
+
+    test.afterEach(() => {
+        fs.rmSync(stagedDir, {recursive: true, force: true});
+    });
+
+    test('widening ONE import inside an existing run repairs its untouched siblings', () => {
+        const {result, lines} = editAndRepair([
+            "import Base       from './core/Base.mjs';",
+            "import NeoArray   from './util/Array.mjs';",
+            "import Store      from './data/Store.mjs';",
+            "import Collection from './collection/Base.mjs';"
+        ], [
+            "import Base       from './core/Base.mjs';",
+            "import NeoArray   from './util/Array.mjs';",
+            "import StoreWithAMuchLongerName from './data/Store.mjs';",
+            "import Collection from './collection/Base.mjs';"
+        ]);
+
+        expect(result.status).toBe(0);
+        // Three siblings widen to the column the staged line established. Before this, the repair
+        // exited 0 having written nothing — the block shipped misaligned.
+        expect(result.output).toContain('Aligned 3 line(s)');
+        expect(lines[0]).toBe("import Base                     from './core/Base.mjs';");
+        expect(lines[1]).toBe("import NeoArray                 from './util/Array.mjs';");
+        expect(lines[2]).toBe("import StoreWithAMuchLongerName from './data/Store.mjs';");
+        expect(lines[3]).toBe("import Collection               from './collection/Base.mjs';");
+    });
+
+    test('the same holds for an object-literal colon run', () => {
+        const {result, lines} = editAndRepair([
+            'const config = {',
+            '    db  : 1,',
+            '    port: 2',
+            '};'
+        ], [
+            'const config = {',
+            '    db  : 1,',
+            '    connectionPoolSize: 2',
+            '};'
+        ]);
+
+        expect(result.status).toBe(0);
+        expect(lines[1]).toBe('    db                : 1,');
+        expect(lines[2]).toBe('    connectionPoolSize: 2');
+    });
+
+    test('the same holds for an `=` declaration run', () => {
+        const {result, lines} = editAndRepair([
+            'const',
+            '    a  = 1,',
+            '    bb = 2;'
+        ], [
+            'const',
+            '    a  = 1,',
+            '    bbLongerName = 2;'
+        ]);
+
+        expect(result.status).toBe(0);
+        expect(lines[1]).toBe('    a            = 1,');
+        expect(lines[2]).toBe('    bbLongerName = 2;');
+    });
+
+    test('a run the author never touched stays byte-identical — ownership widened to the run, not to the file', () => {
+        const {result, lines} = editAndRepair([
+            "import a from 'a';",
+            "import bb from 'b';",
+            '',
+            'const config = {',
+            '    db  : 1,',
+            '    port: 2',
+            '};'
+        ], [
+            "import a from 'a';",
+            "import bb from 'b';",
+            '',
+            'const config = {',
+            '    db  : 1,',
+            '    connectionPoolSize: 2',
+            '};'
+        ]);
+
+        expect(result.status).toBe(0);
+        // The mutation control for the three arms above: if widening had leaked to the whole file,
+        // this grandfathered import pair would have been rewritten too.
+        expect(lines[0]).toBe("import a from 'a';");
+        expect(lines[1]).toBe("import bb from 'b';");
+        expect(lines[5]).toBe('    connectionPoolSize: 2');
+    });
+});

--- a/test/playwright/unit/buildScripts/util/check-branch-discipline.spec.mjs
+++ b/test/playwright/unit/buildScripts/util/check-branch-discipline.spec.mjs
@@ -1,0 +1,361 @@
+import { test, expect }                    from '@playwright/test';
+import {execFileSync, execSync, spawnSync} from 'node:child_process';
+import path                                from 'node:path';
+import fs                                  from 'node:fs';
+import os                                  from 'node:os';
+import { fileURLToPath }                   from 'node:url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname  = path.dirname(__filename);
+const scriptPath = path.resolve(__dirname, '../../../../../buildScripts/util/check-branch-discipline.mjs');
+
+test.describe('check-branch-discipline.mjs (#11133)', () => {
+    let tempDir;
+    let remoteDir;
+    let testScriptPath;
+
+    test.beforeEach(() => {
+        tempDir   = fs.mkdtempSync(path.join(os.tmpdir(), 'neo-branch-discipline-test-'));
+        remoteDir = fs.mkdtempSync(path.join(os.tmpdir(), 'neo-branch-discipline-remote-'));
+
+        execFileSync('git', ['init', '--bare', remoteDir], {stdio: 'ignore'});
+        execSync('git init', { cwd: tempDir, stdio: 'ignore' });
+        execSync('git config user.email "test@example.com"', { cwd: tempDir, stdio: 'ignore' });
+        execSync('git config user.name "Test User"', { cwd: tempDir, stdio: 'ignore' });
+        execSync('git checkout -b dev', { cwd: tempDir, stdio: 'ignore' });
+        execSync('git commit --allow-empty -m "Init"', { cwd: tempDir, stdio: 'ignore' });
+        execFileSync('git', ['remote', 'add', 'origin', remoteDir], {cwd: tempDir, stdio: 'ignore'});
+        execFileSync('git', ['push', '-u', 'origin', 'dev'], {cwd: tempDir, stdio: 'ignore'});
+
+        // Mirror the script into the tempDir so the path-root-equality check (`scriptRoot
+        // === gitRoot`) passes inside the temp repo.
+        testScriptPath = path.join(tempDir, 'buildScripts/util/check-branch-discipline.mjs');
+        fs.mkdirSync(path.dirname(testScriptPath), { recursive: true });
+        fs.copyFileSync(scriptPath, testScriptPath);
+        // check-branch-discipline.mjs imports ./branchFreshness.mjs — mirror the sibling too.
+        fs.copyFileSync(
+            path.resolve(__dirname, '../../../../../buildScripts/util/branchFreshness.mjs'),
+            path.join(tempDir, 'buildScripts/util/branchFreshness.mjs')
+        );
+        // …and ./mergedPullRequestPush.mjs, the merged-pull-request sibling predicate.
+        fs.copyFileSync(
+            path.resolve(__dirname, '../../../../../buildScripts/util/mergedPullRequestPush.mjs'),
+            path.join(tempDir, 'buildScripts/util/mergedPullRequestPush.mjs')
+        );
+    });
+
+    test.afterEach(() => {
+        fs.rmSync(tempDir, { recursive: true, force: true });
+        fs.rmSync(remoteDir, { recursive: true, force: true });
+    });
+
+    const runScript = (cwd = tempDir, env = null) => {
+        const result = spawnSync(process.execPath, [testScriptPath], {
+            cwd,
+            encoding: 'utf-8',
+            stdio   : 'pipe',
+            ...(env ? {env: {...process.env, ...env}} : {})
+        });
+
+        return {
+            status: result.status,
+            output: `${result.stdout || ''}${result.stderr || ''}`
+        }
+    };
+
+    /**
+     * Puts a fake `gh` first on PATH so the merged-pull-request check is driven by a fixed
+     * payload instead of the live GitHub API. Returns the env overlay for `runScript`.
+     * @param {String|null} stdout JSON the stub prints; `null` makes the stub exit non-zero,
+     *     standing in for offline / unauthenticated / rate-limited.
+     */
+    const stubGh = (stdout) => {
+        const binDir = path.join(tempDir, 'stub-bin');
+        fs.mkdirSync(binDir, {recursive: true});
+
+        const ghPath = path.join(binDir, 'gh');
+        fs.writeFileSync(
+            ghPath,
+            stdout === null
+                ? '#!/bin/sh\nexit 1\n'
+                : `#!/bin/sh\ncat <<'NEO_STUB_EOF'\n${stdout}\nNEO_STUB_EOF\n`,
+            {mode: 0o755}
+        );
+
+        return {PATH: `${binDir}${path.delimiter}${process.env.PATH}`}
+    };
+
+    const blockFetchHeadWrites = () => {
+        const fetchHead = path.join(tempDir, '.git', 'FETCH_HEAD');
+
+        fs.rmSync(fetchHead, {recursive: true, force: true});
+        fs.mkdirSync(fetchHead)
+    };
+
+    // Use execFileSync (no shell) — bypasses string-interpolation escape hazards
+    // (CodeQL js/incomplete-sanitization on backslash). Argv array goes directly
+    // to git without shell-quoting.
+    const featureCommit = (subject = 'feat: ship a real feature') => {
+        execFileSync('git', ['commit', '--allow-empty', '-m', subject], { cwd: tempDir, stdio: 'ignore' });
+    };
+
+    const choreSyncCommit = (subject = 'chore(data): Hourly data sync pipeline update [skip ci]') => {
+        execFileSync('git', ['commit', '--allow-empty', '-m', subject], { cwd: tempDir, stdio: 'ignore' });
+    };
+
+    test('clean feature branch passes (no chore-sync commits)', () => {
+        execSync('git checkout -b agent/0000-feature', { cwd: tempDir, stdio: 'ignore' });
+        featureCommit('feat(test): clean feature implementation');
+        const result = runScript();
+        expect(result.status).toBe(0);
+    });
+
+    test('chore-sync commit on feature branch blocks push (#11133 core failure mode)', () => {
+        execSync('git checkout -b agent/0000-feature', { cwd: tempDir, stdio: 'ignore' });
+        featureCommit('feat(test): a real feature');
+        choreSyncCommit('chore(data): Hourly data sync pipeline update [skip ci]');
+        const result = runScript();
+        expect(result.status).toBe(1);
+        expect(result.output).toContain('chore-sync commit');
+        expect(result.output).toContain('agent/0000-feature');
+        expect(result.output).toContain('clean-path');
+    });
+
+    test('chore-sync commit alone (no feature) still blocks', () => {
+        execSync('git checkout -b agent/0000-feature', { cwd: tempDir, stdio: 'ignore' });
+        choreSyncCommit('chore(data): Hourly data sync pipeline update');
+        const result = runScript();
+        expect(result.status).toBe(1);
+        expect(result.output).toContain('chore-sync commit');
+    });
+
+    test('designated sync branch (chore/sync-*) is exempt', () => {
+        execSync('git checkout -b chore/sync-123', { cwd: tempDir, stdio: 'ignore' });
+        choreSyncCommit();
+        const result = runScript();
+        expect(result.status).toBe(0);
+    });
+
+    test('designated sync branch (agent/sync-*) is exempt', () => {
+        execSync('git checkout -b agent/sync-456', { cwd: tempDir, stdio: 'ignore' });
+        choreSyncCommit();
+        const result = runScript();
+        expect(result.status).toBe(0);
+    });
+
+    test('protected branch dev bypasses (caught by §2.3 universal safety net)', () => {
+        // Already on `dev` from beforeEach; even with a chore-sync commit, pre-push from
+        // `dev` itself is out of scope for this gate (caught by separate §2.3 safety net).
+        choreSyncCommit();
+        const result = runScript();
+        expect(result.status).toBe(0);
+    });
+
+    test('regex anchored: lookalike subject like `chore(data) without colon` does NOT match', () => {
+        execSync('git checkout -b agent/0000-feature', { cwd: tempDir, stdio: 'ignore' });
+        execFileSync('git', ['commit', '--allow-empty', '-m', 'chore(data) lookalike but no colon'], { cwd: tempDir, stdio: 'ignore' });
+        const result = runScript();
+        expect(result.status).toBe(0);
+    });
+
+    test('regex case-insensitive: `chore(DATA): Sync` triggers', () => {
+        execSync('git checkout -b agent/0000-feature', { cwd: tempDir, stdio: 'ignore' });
+        execFileSync('git', ['commit', '--allow-empty', '-m', 'chore(DATA): Sync run'], { cwd: tempDir, stdio: 'ignore' });
+        const result = runScript();
+        expect(result.status).toBe(1);
+        expect(result.output).toContain('chore-sync commit');
+    });
+
+    test('fetch failure continues only when local origin/dev equals the remote coordinate (#16163)', () => {
+        execSync('git checkout -b agent/0000-equal-fallback', {cwd: tempDir, stdio: 'ignore'});
+        featureCommit();
+        blockFetchHeadWrites();
+
+        const
+            localDevSha = execFileSync(
+                'git',
+                ['rev-parse', '--verify', 'refs/remotes/origin/dev'],
+                {cwd: tempDir, encoding: 'utf-8'}
+            ).trim(),
+            result      = runScript();
+
+        expect(result.status).toBe(0);
+        expect(result.output).toContain(`matches remote dev at ${localDevSha}`)
+    });
+
+    test('fetch failure blocks when local origin/dev is behind the remote coordinate (#16163)', () => {
+        const localDevSha = execFileSync(
+            'git',
+            ['rev-parse', '--verify', 'refs/remotes/origin/dev'],
+            {cwd: tempDir, encoding: 'utf-8'}
+        ).trim();
+
+        featureCommit('feat(test): advance remote dev');
+
+        const remoteDevSha = execFileSync(
+            'git',
+            ['rev-parse', 'HEAD'],
+            {cwd: tempDir, encoding: 'utf-8'}
+        ).trim();
+
+        execFileSync('git', ['push', 'origin', 'dev'], {cwd: tempDir, stdio: 'ignore'});
+        execFileSync('git', ['update-ref', 'refs/remotes/origin/dev', localDevSha], {
+            cwd  : tempDir,
+            stdio: 'ignore'
+        });
+        execFileSync('git', ['checkout', '-b', 'agent/0000-stale-fallback', localDevSha], {
+            cwd  : tempDir,
+            stdio: 'ignore'
+        });
+        featureCommit();
+        blockFetchHeadWrites();
+
+        const result = runScript();
+
+        expect(result.status).toBe(1);
+        expect(result.output).toContain('local ref is stale');
+        expect(result.output).toContain(localDevSha);
+        expect(result.output).toContain(remoteDevSha)
+    });
+
+    test('successful fetch updates origin/dev despite a nonstandard configured refspec (#16163)', () => {
+        const localDevSha = execFileSync(
+            'git',
+            ['rev-parse', '--verify', 'refs/remotes/origin/dev'],
+            {cwd: tempDir, encoding: 'utf-8'}
+        ).trim();
+
+        featureCommit('feat(test): advance remote dev outside the feature branch');
+
+        const remoteDevSha = execFileSync(
+            'git',
+            ['rev-parse', 'HEAD'],
+            {cwd: tempDir, encoding: 'utf-8'}
+        ).trim();
+
+        execFileSync('git', ['push', 'origin', 'dev'], {cwd: tempDir, stdio: 'ignore'});
+        execFileSync('git', ['update-ref', 'refs/remotes/origin/dev', localDevSha], {
+            cwd  : tempDir,
+            stdio: 'ignore'
+        });
+        execFileSync('git', ['config', '--unset-all', 'remote.origin.fetch'], {
+            cwd  : tempDir,
+            stdio: 'ignore'
+        });
+        execFileSync('git', [
+            'config',
+            '--add',
+            'remote.origin.fetch',
+            '+refs/heads/main:refs/remotes/origin/main'
+        ], {
+            cwd  : tempDir,
+            stdio: 'ignore'
+        });
+        execFileSync('git', ['checkout', '-b', 'agent/0000-explicit-refspec', localDevSha], {
+            cwd  : tempDir,
+            stdio: 'ignore'
+        });
+        featureCommit();
+
+        const result          = runScript();
+        const refreshedDevSha = execFileSync(
+            'git',
+            ['rev-parse', '--verify', 'refs/remotes/origin/dev'],
+            {cwd: tempDir, encoding: 'utf-8'}
+        ).trim();
+
+        expect(result.status).toBe(0);
+        expect(refreshedDevSha).toBe(remoteDevSha)
+    });
+
+    test('fetch failure blocks when the remote dev coordinate is unavailable (#16163)', () => {
+        execFileSync('git', ['checkout', '-b', 'agent/0000-unavailable-remote'], {
+            cwd  : tempDir,
+            stdio: 'ignore'
+        });
+        featureCommit();
+        execFileSync('git', ['remote', 'set-url', 'origin', path.join(remoteDir, 'missing')], {
+            cwd  : tempDir,
+            stdio: 'ignore'
+        });
+
+        const result = runScript();
+
+        expect(result.status).toBe(1);
+        expect(result.output).toContain('remote refs/heads/dev coordinate is unavailable');
+        expect(result.output).not.toContain('local ref is stale')
+    });
+
+    test.describe('pushes that reach no pull request (#16256)', () => {
+        const MERGED_HEAD = 'ddf522a6feb4abf9faf4ad49af110d2a3a5c96b7';
+
+        const mergedPrPayload = JSON.stringify([{
+            number    : 16255,
+            state     : 'MERGED',
+            mergedAt  : '2026-08-01T11:27:27Z',
+            headRefOid: MERGED_HEAD
+        }]);
+
+        test('warns — and still exits 0 — when the branch PR merged and the head carries unreached commits', () => {
+            execFileSync('git', ['checkout', '-b', 'agent/0000-merged-pr'], {cwd: tempDir, stdio: 'ignore'});
+            featureCommit('feat(test): a commit that will reach no PR');
+
+            const result = runScript(tempDir, stubGh(mergedPrPayload));
+
+            // Advisory: the whole point is that the push proceeds.
+            expect(result.status).toBe(0);
+            expect(result.output).toContain('PR #16255');
+            expect(result.output).toContain('2026-08-01T11:27:27Z');
+            expect(result.output).toContain('reaches no PR and no CI');
+            // The author's next question — answered in the same breath.
+            expect(result.output).toContain('Your work is not lost');
+            expect(result.output).toContain('origin/dev');
+            expect(result.output).toContain('advisory')
+        });
+
+        test('stays silent on an open pull request — no new noise on the common path', () => {
+            execFileSync('git', ['checkout', '-b', 'agent/0000-open-pr'], {cwd: tempDir, stdio: 'ignore'});
+            featureCommit();
+
+            const result = runScript(tempDir, stubGh(JSON.stringify([{
+                number    : 16264,
+                state     : 'OPEN',
+                mergedAt  : null,
+                headRefOid: MERGED_HEAD
+            }])));
+
+            expect(result.status).toBe(0);
+            expect(result.output).not.toContain('reaches no PR')
+        });
+
+        test('stays silent when the branch never had a pull request', () => {
+            execFileSync('git', ['checkout', '-b', 'agent/0000-no-pr'], {cwd: tempDir, stdio: 'ignore'});
+            featureCommit();
+
+            const result = runScript(tempDir, stubGh('[]'));
+
+            expect(result.status).toBe(0);
+            expect(result.output).not.toContain('reaches no PR')
+        });
+
+        test('fails toward pushing when gh cannot answer (offline / unauthenticated / rate-limited)', () => {
+            execFileSync('git', ['checkout', '-b', 'agent/0000-gh-down'], {cwd: tempDir, stdio: 'ignore'});
+            featureCommit();
+
+            const result = runScript(tempDir, stubGh(null));
+
+            expect(result.status).toBe(0);
+            expect(result.output).not.toContain('reaches no PR')
+        });
+
+        test('fails toward pushing when gh returns unparseable output', () => {
+            execFileSync('git', ['checkout', '-b', 'agent/0000-gh-garbage'], {cwd: tempDir, stdio: 'ignore'});
+            featureCommit();
+
+            const result = runScript(tempDir, stubGh('not json at all'));
+
+            expect(result.status).toBe(0);
+            expect(result.output).not.toContain('reaches no PR')
+        })
+    })
+});

--- a/test/playwright/unit/buildScripts/util/check-chore-sync.spec.mjs
+++ b/test/playwright/unit/buildScripts/util/check-chore-sync.spec.mjs
@@ -1,0 +1,224 @@
+import { test, expect }  from '@playwright/test';
+import { execSync }      from 'node:child_process';
+import path              from 'node:path';
+import fs                from 'node:fs';
+import os                from 'node:os';
+import { fileURLToPath } from 'node:url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname  = path.dirname(__filename);
+const scriptPath = path.resolve(__dirname, '../../../../../buildScripts/util/check-chore-sync.mjs');
+
+test.describe('check-chore-sync.mjs', () => {
+    let tempDir;
+    let testScriptPath;
+
+    test.beforeEach(() => {
+        tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'neo-sync-test-'));
+        execSync('git init', { cwd: tempDir, stdio: 'ignore' });
+        execSync('git config user.email "test@example.com"', { cwd: tempDir, stdio: 'ignore' });
+        execSync('git config user.name "Test User"', { cwd: tempDir, stdio: 'ignore' });
+        execSync('git commit --allow-empty -m "Init"', { cwd: tempDir, stdio: 'ignore' });
+
+        testScriptPath = path.join(tempDir, 'buildScripts/util/check-chore-sync.mjs');
+        fs.mkdirSync(path.dirname(testScriptPath), {recursive: true});
+        fs.copyFileSync(scriptPath, testScriptPath);
+
+        // The guard imports its merge-inheritance rule from a shared helper (also consumed by
+        // check-whitespace), so the fixture must carry it too — the script anchors to the repo that
+        // owns it, and a bare copy would fail to resolve the import rather than test the guard.
+        fs.copyFileSync(
+            path.resolve(path.dirname(scriptPath), 'mergeInheritance.mjs'),
+            path.join(tempDir, 'buildScripts/util/mergeInheritance.mjs')
+        );
+
+        // Ensure we're on a non-data branch like 'dev'
+        execSync('git checkout -b dev', { cwd: tempDir, stdio: 'ignore' });
+    });
+
+    test.afterEach(() => {
+        fs.rmSync(tempDir, { recursive: true, force: true });
+    });
+
+    const runScript = (cwd, env = {}) => {
+        try {
+            const output = execSync(`node ${testScriptPath}`, {
+                cwd,
+                env     : { ...process.env, ...env },
+                encoding: 'utf-8',
+                stdio   : 'pipe'
+            });
+            return { status: 0, output };
+        } catch (error) {
+            return { status: error.status, output: error.stderr || error.stdout };
+        }
+    };
+
+    const stageFile = (filePath) => {
+        const fullPath = path.join(tempDir, filePath);
+        fs.mkdirSync(path.dirname(fullPath), { recursive: true });
+        fs.writeFileSync(fullPath, 'test content');
+        execSync(`git add ${filePath}`, { cwd: tempDir, stdio: 'ignore' });
+    };
+
+    test('normal reject: staging a data file on dev branch fails', () => {
+        stageFile('resources/content/issues/1.md');
+        const result = runScript(tempDir);
+        expect(result.status).toBe(1);
+        expect(result.output).toContain('Error: Sync-data leakage detected');
+        expect(result.output).toContain("Branch 'dev' (in root");
+        expect(result.output).toContain('resources/content/issues/1.md');
+    });
+
+    test('sanctioned bypass: staging a data file on chore/sync- branch passes', () => {
+        execSync('git checkout -b chore/sync-123', { cwd: tempDir, stdio: 'ignore' });
+        stageFile('resources/content/issues/1.md');
+        const result = runScript(tempDir);
+        expect(result.status).toBe(0);
+    });
+
+    test('sanctioned bypass: staging a data file on agent/sync- branch passes', () => {
+        execSync('git checkout -b agent/sync-123', { cwd: tempDir, stdio: 'ignore' });
+        stageFile('resources/content/issues/1.md');
+        const result = runScript(tempDir);
+        expect(result.status).toBe(0);
+    });
+
+    test('valid sync-only staging with NEO_SYNC_AUTOCOMMIT=1 passes for generated workflow content', () => {
+        [
+            'resources/content/issues/chunk-1/issue-1.md',
+            'resources/content/discussions/chunk-1/discussion-1.md',
+            'resources/content/pulls/chunk-1/pr-1.md',
+            'resources/content/release-notes/chunk-1/v1.0.0.md',
+            'resources/content/archive/issues/v1.0.0/chunk-1/issue-2.md',
+            'resources/content/_index.json',
+            'resources/content/.sync-metadata.json'
+        ].forEach(stageFile);
+
+        const result = runScript(tempDir, { NEO_SYNC_AUTOCOMMIT: '1' });
+        expect(result.status).toBe(0);
+    });
+
+    test('non-sync staged file rejection with env var: mixed files fails', () => {
+        stageFile('resources/content/issues/1.md');
+        stageFile('src/foo.js');
+        const result = runScript(tempDir, { NEO_SYNC_AUTOCOMMIT: '1' });
+        expect(result.status).toBe(1);
+        expect(result.output).toContain('Error: NEO_SYNC_AUTOCOMMIT bypass rejected.');
+        expect(result.output).toContain('Automated sync commits must ONLY contain data files.');
+        expect(result.output).toContain('src/foo.js');
+        // It shouldn't complain about the data file
+        expect(result.output).not.toContain('resources/content/issues/1.md');
+    });
+
+    test('non-sync staged file rejection with env var: unowned resources content fails', () => {
+        stageFile('resources/content/concepts/example.md');
+        const result = runScript(tempDir, { NEO_SYNC_AUTOCOMMIT: '1' });
+        expect(result.status).toBe(1);
+        expect(result.output).toContain('Error: NEO_SYNC_AUTOCOMMIT bypass rejected.');
+        expect(result.output).toContain('resources/content/concepts/example.md');
+    });
+
+    // Stages a real merge that carries a sync-pipeline commit — the exact shape of `git merge
+    // origin/dev` on a feature branch. `--no-commit` leaves MERGE_HEAD set with the merge staged,
+    // which is precisely the state the pre-commit hook runs in.
+    const startMergeCarryingSyncData = () => {
+        execSync('git checkout -b sync-pipeline-source', { cwd: tempDir, stdio: 'ignore' });
+        stageFile('resources/content/issues/1.md');
+        execSync('git commit -m "chore(data): Hourly data sync pipeline update"', { cwd: tempDir, stdio: 'ignore' });
+        execSync('git checkout dev', { cwd: tempDir, stdio: 'ignore' });
+        execSync('git merge --no-commit --no-ff sync-pipeline-source', { cwd: tempDir, stdio: 'ignore' });
+    };
+
+    test('merge: a dev-merge carrying the pipeline\'s sync files passes — a merge does not AUTHOR sync data', () => {
+        startMergeCarryingSyncData();
+
+        // The merge stages resources/content/issues/1.md, but the feature branch did not write it.
+        expect(execSync('git diff --cached --name-only', { cwd: tempDir, encoding: 'utf-8' }))
+            .toContain('resources/content/issues/1.md');
+
+        expect(runScript(tempDir).status).toBe(0);
+    });
+
+    test('merge: a sync file HAND-EDITED during the merge is still rejected — authoring in a merge is still authoring', () => {
+        // The allowance is "inherited from MERGE_HEAD", not "a merge is in progress". Editing a sync
+        // file on top of the merge diverges the index from MERGE_HEAD, which is authoring wearing a
+        // merge's clothes — the exact hole a blanket merge-exit would leave open.
+        startMergeCarryingSyncData();
+
+        // Must write DIFFERENT content than the merge brought in: re-staging identical bytes is not
+        // an edit, and the discriminator would rightly still call it inherited.
+        fs.writeFileSync(path.join(tempDir, 'resources/content/issues/1.md'), 'hand-edited on top of the merge');
+        execSync('git add resources/content/issues/1.md', { cwd: tempDir, stdio: 'ignore' });
+
+        const result = runScript(tempDir);
+
+        expect(result.status).toBe(1);
+        expect(result.output).toContain('Error: Sync-data leakage detected');
+        expect(result.output).toContain('resources/content/issues/1.md');
+    });
+
+    test('merge: an inherited sync file passes while a hand-edited sibling in the SAME merge is rejected', () => {
+        // Proves the discriminator is per-file, not a whole-commit verdict: one merge, two sync
+        // files, only the edited one is a violation.
+        execSync('git checkout -b sync-two-files', { cwd: tempDir, stdio: 'ignore' });
+        stageFile('resources/content/issues/inherited.md');
+        stageFile('resources/content/issues/edited.md');
+        execSync('git commit -m "chore(data): Hourly data sync pipeline update"', { cwd: tempDir, stdio: 'ignore' });
+        execSync('git checkout dev', { cwd: tempDir, stdio: 'ignore' });
+        execSync('git merge --no-commit --no-ff sync-two-files', { cwd: tempDir, stdio: 'ignore' });
+
+        fs.writeFileSync(path.join(tempDir, 'resources/content/issues/edited.md'), 'hand-edited during the merge');
+        execSync('git add resources/content/issues/edited.md', { cwd: tempDir, stdio: 'ignore' });
+
+        const result = runScript(tempDir);
+
+        expect(result.status).toBe(1);
+        expect(result.output).toContain('resources/content/issues/edited.md');
+        expect(result.output).not.toContain('resources/content/issues/inherited.md');
+    });
+
+    test('merge + NEO_SYNC_AUTOCOMMIT=1: mixed content is still rejected — the env arm runs first and a merge does not soften it', () => {
+        // Ordering guard: the autocommit arm protects the pipeline's own commits, which are never
+        // merges. A merge in flight must not become a way to smuggle source into a sync commit.
+        startMergeCarryingSyncData();
+        stageFile('src/foo.js');
+
+        const result = runScript(tempDir, { NEO_SYNC_AUTOCOMMIT: '1' });
+
+        expect(result.status).toBe(1);
+        expect(result.output).toContain('Error: NEO_SYNC_AUTOCOMMIT bypass rejected.');
+        expect(result.output).toContain('src/foo.js');
+    });
+
+    test('merge escape is scoped to the merge: the SAME branch and files still fail on an ordinary commit', () => {
+        // Guards the protection itself. If the escape ever widens from "a merge is in progress" to
+        // "this branch touched sync files", this arm goes red — the leakage check must survive.
+        startMergeCarryingSyncData();
+        execSync('git commit --no-edit', { cwd: tempDir, stdio: 'ignore' });
+
+        // Merge finished → no MERGE_HEAD → authoring sync data here is leakage again.
+        stageFile('resources/content/issues/2.md');
+        const result = runScript(tempDir);
+
+        expect(result.status).toBe(1);
+        expect(result.output).toContain('Error: Sync-data leakage detected');
+        expect(result.output).toContain('resources/content/issues/2.md');
+    });
+
+    test('script root anchoring: running from a non-repo cwd checks the owning repo', () => {
+        const otherDir = fs.mkdtempSync(path.join(os.tmpdir(), 'neo-sync-foreign-'));
+
+        try {
+            stageFile('resources/content/issues/1.md');
+            const result = runScript(otherDir);
+            expect(result.status).toBe(1);
+            expect(result.output).toContain('Error: Sync-data leakage detected');
+            expect(result.output).toContain("Branch 'dev' (in root");
+            expect(result.output).toContain(tempDir);
+            expect(result.output).toContain('resources/content/issues/1.md');
+        } finally {
+            fs.rmSync(otherDir, {recursive: true, force: true});
+        }
+    });
+});

--- a/test/playwright/unit/buildScripts/util/check-codeql-extraction.spec.mjs
+++ b/test/playwright/unit/buildScripts/util/check-codeql-extraction.spec.mjs
@@ -1,0 +1,257 @@
+import {test, expect}                                                                       from '@playwright/test';
+import {
+    fetchAnalyzeJobLogs,
+    findCodeqlExtractionErrors,
+    summarizeExtractionAcrossLegs,
+    EXTRACTION_GROUP_MARKER
+} from '../../../../../buildScripts/util/check-codeql-extraction.mjs';
+
+/**
+ * @summary The discriminating heart of the CodeQL extraction gate: given the raw Analyze-job
+ * log, does the pure parser detect a DROPPED file (the extractor's own verdict) and name it? These
+ * pin that the group header alone fails the gate even when per-file names don't parse (a dropped file
+ * must never pass silently), that a per-file line without the header still fails (format drift), and
+ * that a benign "parse error" mention does NOT false-positive on a clean tree.
+ *
+ * The I/O half uses injected fetch and sleep seams, so retry classification and fail-closed exhaustion
+ * are proven without mutating globals or reaching the live Actions API.
+ */
+test.describe('buildScripts/util/check-codeql-extraction — findCodeqlExtractionErrors (#15370)', () => {
+    // Actions prepends an ISO timestamp + a stream tag to every log line; the fixtures carry it so the
+    // parser is proven to tolerate the real prefix, not a stripped ideal.
+    const ts = '2026-07-18T09:11:17.1234567Z [build-stdout] ';
+
+    test('a clean Analyze log → no errors, no files (the common case must not false-positive)', () => {
+        const log = `${ts}Running CodeQL analysis.\n${ts}Finalizing database.\n${ts}Analysis produced 15 results.\n`;
+
+        expect(findCodeqlExtractionErrors(log)).toEqual({hasErrors: false, files: [], groupMarkerSeen: false})
+    });
+
+    test('the group header + per-file bullets → fails, naming every dropped file', () => {
+        // the REAL CodeQL format, verified against run 29568877624 (the pre-fix drop): a `##[group]`
+        // header line, then one `  * <repo-relative-path>#L<line>C<col>:<col>: A parse error occurred` bullet
+        // per dropped file — repo-relative paths, location suffix, NOT a `Could not process <path>:` line.
+        const log =
+            `${ts}Running CodeQL analysis.\n` +
+            `${ts}##[group]${EXTRACTION_GROUP_MARKER} (2 results)\n` +
+            `${ts}  * ai/scripts/benchmark/serving-cost-meter.mjs#L309C7:7: A parse error occurred: \`Unexpected token\`. Check the syntax of the file.\n` +
+            `${ts}  * apps/foo/Bar.mjs#L12C1:1: A parse error occurred: \`Unexpected token\`.\n`;
+
+        const result = findCodeqlExtractionErrors(log);
+
+        expect(result.hasErrors).toBe(true);
+        expect(result.groupMarkerSeen).toBe(true);
+        expect(result.files).toEqual([
+            'ai/scripts/benchmark/serving-cost-meter.mjs',
+            'apps/foo/Bar.mjs'
+        ])
+    });
+
+    test('detects + names the drop in a VERBATIM real CodeQL log (run 29568877624 — the pre-#15353 scan)', () => {
+        // copied byte-for-byte from the real Analyze-job log of the run that dropped serving-cost-meter.mjs
+        // yet "succeeded" with analyses[].warning empty — the exact false-clean this gate closes.
+        const log =
+            `${ts}##[group]Could not process some files due to syntax errors (1 result)\n` +
+            `${ts}  * ai/scripts/benchmark/serving-cost-meter.mjs#L309C7:7: A parse error occurred: \`Unexpected token\`. Check the syntax of the file. If the file is invalid, correct the error or [exclude](https://docs.github.com/en/code-security) the file from analysis.\n` +
+            `${ts}##[endgroup]\n`;
+
+        expect(findCodeqlExtractionErrors(log)).toEqual({
+            hasErrors: true, groupMarkerSeen: true, files: ['ai/scripts/benchmark/serving-cost-meter.mjs']
+        })
+    });
+
+    test('the group header ALONE (per-file format drifted) still fails — a dropped file never passes for want of a parsed name', () => {
+        const log = `${ts}${EXTRACTION_GROUP_MARKER}:\n${ts}[some future format we did not anticipate]\n`;
+
+        const result = findCodeqlExtractionErrors(log);
+
+        // the authoritative signal is the header; correctness must not depend on the per-file regex
+        expect(result.hasErrors).toBe(true);
+        expect(result.groupMarkerSeen).toBe(true);
+        expect(result.files).toEqual([])
+    });
+
+    test('a per-file bullet WITHOUT the group header still fails (header-format drift, other direction)', () => {
+        const log = `${ts}  * src/Weird.mjs#L5C1:1: A parse error occurred: \`Unexpected token\`\n`;
+
+        const result = findCodeqlExtractionErrors(log);
+
+        expect(result.hasErrors).toBe(true);
+        expect(result.groupMarkerSeen).toBe(false);
+        expect(result.files).toEqual(['src/Weird.mjs'])
+    });
+
+    test('a benign "parse error" mention does NOT false-positive (discriminating: not every parse-error string is a drop)', () => {
+        const log =
+            `${ts}Fixed a parse error in the query compiler.\n` +
+            `${ts}note: the extractor recovered from a parse error and continued.\n` +
+            `${ts}Analysis produced 15 results.\n`;
+
+        expect(findCodeqlExtractionErrors(log)).toMatchObject({hasErrors: false, files: []})
+    });
+
+    test('total on empty / null / undefined input (no throw)', () => {
+        for (const input of ['', null, undefined]) {
+            expect(findCodeqlExtractionErrors(input), `input=${String(input)}`).toEqual({hasErrors: false, files: [], groupMarkerSeen: false})
+        }
+    });
+
+    test('duplicate per-file bullets collapse (a file reported twice is named once)', () => {
+        const line = `${ts}  * src/Dup.mjs#L1C1:1: A parse error occurred: \`Unexpected token\`\n`;
+
+        expect(findCodeqlExtractionErrors(line + line).files).toEqual(['src/Dup.mjs'])
+    });
+
+    // --- summarizeExtractionAcrossLegs: matrix-robust aggregation (Euclid's matrix-false-clean finding) ---
+
+    const cleanLog = `${ts}Running CodeQL analysis.\n`;
+    const dropLog  = file => `${ts}##[group]${EXTRACTION_GROUP_MARKER} (1 result)\n${ts}  * ${file}#L1C1:1: A parse error occurred: \`Unexpected token\`\n`;
+
+    test('all matrix legs clean → no errors, legCount counted', () => {
+        const legs = [{name: 'Analyze (javascript)', log: cleanLog}, {name: 'Analyze (python)', log: cleanLog}];
+
+        expect(summarizeExtractionAcrossLegs(legs)).toEqual({hasErrors: false, dropped: [], legCount: 2})
+    });
+
+    test('a drop in a NON-first leg is caught — the matrix-shaped false-clean the `find`-first form missed', () => {
+        // js clean, python drops, go clean: certifying only the first (js) leg would pass this falsely
+        const legs = [
+            {name: 'Analyze (javascript)', log: cleanLog},
+            {name: 'Analyze (python)',     log: dropLog('ai/x.py')},
+            {name: 'Analyze (go)',         log: cleanLog}
+        ];
+        const result = summarizeExtractionAcrossLegs(legs);
+
+        expect(result.hasErrors).toBe(true);
+        expect(result.dropped).toEqual([{leg: 'Analyze (python)', file: 'ai/x.py'}]);
+        expect(result.legCount).toBe(3)
+    });
+
+    test('drops in MULTIPLE legs aggregate, each tagged with its leg', () => {
+        const legs = [
+            {name: 'Analyze (javascript)', log: dropLog('src/a.mjs')},
+            {name: 'Analyze (python)',     log: dropLog('ai/b.py')}
+        ];
+
+        expect(summarizeExtractionAcrossLegs(legs).dropped).toEqual([
+            {leg: 'Analyze (javascript)', file: 'src/a.mjs'},
+            {leg: 'Analyze (python)',     file: 'ai/b.py'}
+        ])
+    });
+
+    test('a leg with the group header but unparsed per-file bullets still fails, file:null tagged to the leg', () => {
+        const legs   = [{name: 'Analyze (javascript)', log: `${ts}##[group]${EXTRACTION_GROUP_MARKER} (1 result)\n${ts}[drifted format]\n`}];
+        const result = summarizeExtractionAcrossLegs(legs);
+
+        expect(result.hasErrors).toBe(true);
+        expect(result.dropped).toEqual([{leg: 'Analyze (javascript)', file: null}])
+    });
+
+    test('empty / non-array legs → no errors, total (never throws certifying an unread matrix)', () => {
+        expect(summarizeExtractionAcrossLegs([])).toEqual({hasErrors: false, dropped: [], legCount: 0});
+        expect(summarizeExtractionAcrossLegs(undefined)).toEqual({hasErrors: false, dropped: [], legCount: 0})
+    })
+});
+
+test.describe('buildScripts/util/check-codeql-extraction — fetchAnalyzeJobLogs (#16075)', () => {
+    const jobsResponse = status => ({
+        ok  : true,
+        json: async () => ({jobs: [{id: 42, name: 'Analyze (javascript)', status}]})
+    });
+    const logResponse = (status, statusText, log = '') => ({
+        ok  : status >= 200 && status < 300,
+        status,
+        statusText,
+        text: async () => log
+    });
+
+    test('a transient 404 is retried once, then the readable log certifies', async () => {
+        const responses = [
+                  jobsResponse('completed'),
+                  logResponse(404, 'Not Found'),
+                  logResponse(200, 'OK', 'clean log')
+              ],
+              delays    = [],
+              result    = await fetchAnalyzeJobLogs({
+                  repo       : 'neomjs/neo',
+                  runId      : 123,
+                  token      : 'test-token',
+                  fetchImpl  : async () => responses.shift(),
+                  sleep      : async delay => delays.push(delay),
+                  retryDelays: [5]
+              });
+
+        expect(result).toEqual([{name: 'Analyze (javascript)', log: 'clean log'}]);
+        expect(delays).toEqual([5]);
+        expect(responses).toEqual([])
+    });
+
+    test('a terminal 403 fails immediately without sleeping', async () => {
+        const responses = [jobsResponse('completed'), logResponse(403, 'Forbidden')],
+              delays    = [];
+
+        await expect(fetchAnalyzeJobLogs({
+            repo       : 'neomjs/neo',
+            runId      : 123,
+            token      : 'test-token',
+            fetchImpl  : async () => responses.shift(),
+            sleep      : async delay => delays.push(delay),
+            retryDelays: [5, 10]
+        })).rejects.toThrow('fetch Analyze leg "Analyze (javascript)" log failed: 403 Forbidden');
+
+        expect(delays).toEqual([]);
+        expect(responses).toEqual([])
+    });
+
+    test('retry exhaustion stays fail-closed and reports attempts plus elapsed window', async () => {
+        const responses = [
+                  jobsResponse('completed'),
+                  logResponse(503, 'Service Unavailable'),
+                  logResponse(503, 'Service Unavailable'),
+                  logResponse(503, 'Service Unavailable')
+              ],
+              delays    = [];
+
+        await expect(fetchAnalyzeJobLogs({
+            repo       : 'neomjs/neo',
+            runId      : 123,
+            token      : 'test-token',
+            fetchImpl  : async () => responses.shift(),
+            sleep      : async delay => delays.push(delay),
+            retryDelays: [5, 10]
+        })).rejects.toThrow('after 3 attempts over 15ms: 503 Service Unavailable');
+
+        expect(delays).toEqual([5, 10]);
+        expect(responses).toEqual([])
+    });
+
+    test('an incomplete Analyze leg is terminal and never fetches its log', async () => {
+        const responses = [jobsResponse('in_progress')];
+
+        await expect(fetchAnalyzeJobLogs({
+            repo     : 'neomjs/neo',
+            runId    : 123,
+            token    : 'test-token',
+            fetchImpl: async () => responses.shift()
+        })).rejects.toThrow('Analyze leg "Analyze (javascript)" is in_progress, not completed');
+
+        expect(responses).toEqual([])
+    })
+
+    test('a malformed jobs payload is terminal and never enters log-fetch retry', async () => {
+        let fetchCount = 0;
+
+        await expect(fetchAnalyzeJobLogs({
+            repo     : 'neomjs/neo',
+            runId    : 123,
+            token    : 'test-token',
+            fetchImpl: async () => {
+                fetchCount++;
+
+                return {ok: true, json: async () => { throw new SyntaxError('invalid JSON') }}
+            }
+        })).rejects.toThrow('invalid JSON');
+
+        expect(fetchCount).toBe(1)
+    })
+});

--- a/test/playwright/unit/buildScripts/util/check-examples-body-only.spec.mjs
+++ b/test/playwright/unit/buildScripts/util/check-examples-body-only.spec.mjs
@@ -1,0 +1,111 @@
+import {test, expect} from '@playwright/test';
+import {execFileSync} from 'node:child_process';
+import fs             from 'node:fs';
+import path           from 'node:path';
+
+// The Playwright unit runner executes with cwd = repo root, so resolve against it rather than
+// __dirname arithmetic — the latter is brittle across nesting depth and git-worktree layouts.
+const
+    repoRoot   = process.cwd(),
+    scriptPath = path.join(repoRoot, 'buildScripts/util/check-examples-body-only.mjs'),
+    fixtureDir = path.join(repoRoot, 'examples', '__check_examples_body_only_fixture__');
+
+/**
+ * Writes throwaway files under a dedicated `examples/` fixture dir, runs the guard as a subprocess,
+ * then removes the fixture dir (one recursive remove, even if the assertion throws).
+ *
+ * @param {Object<String,String>} files Map of path-relative-to-fixtureDir -> file contents.
+ * @returns {{exitCode:number, output:string}}
+ */
+function runWithFixture(files) {
+    let exitCode = 0,
+        output   = '';
+
+    try {
+        for (const [rel, content] of Object.entries(files)) {
+            const abs = path.join(fixtureDir, rel);
+            fs.mkdirSync(path.dirname(abs), {recursive: true});
+            fs.writeFileSync(abs, content);
+        }
+
+        output = execFileSync('node', [scriptPath], {cwd: repoRoot, encoding: 'utf8'});
+    } catch (err) {
+        exitCode = err.status;
+        output   = (err.stdout || '') + (err.stderr || '');
+    } finally {
+        fs.rmSync(fixtureDir, {recursive: true, force: true});
+    }
+
+    return {exitCode, output};
+}
+
+/**
+ * @summary CI guard test for `buildScripts/util/check-examples-body-only.mjs`.
+ *
+ * Verifies the guard distinguishes the clean Body-only tree from each misplacement class `build-all`
+ * chokes on: an `app.mjs` build target missing `neo-config.json`, and an example importing from `ai/`.
+ * A conforming Body fixture (`app.mjs` + `neo-config.json`, no `ai/` import) confirms no false positive.
+ * Each case plants throwaway fixtures under `examples/`, runs the guard as a subprocess, asserts, cleans up.
+ *
+ * @see buildScripts/util/check-examples-body-only.mjs
+ */
+// `describe.serial` is REQUIRED: fixtures planted on-disk under `examples/` would otherwise leak across
+// Playwright's parallel workers (fullyParallel default), racing the clean-tree PASS test against
+// another worker's planted fixture.
+test.describe.serial('check-examples-body-only CI guard', () => {
+    test.afterEach(() => fs.rmSync(fixtureDir, {recursive: true, force: true}));
+
+    test('exits 0 (PASS) on the current clean Body-only tree', () => {
+        // The committed examples/ tree must be Body-only after the harness-benchmark relocation.
+        const result = execFileSync('node', [scriptPath], {cwd: repoRoot, encoding: 'utf8'});
+        expect(result).toContain('PASS');
+    });
+
+    test('exits 1 (FAIL) on an app.mjs build target missing neo-config.json', () => {
+        const {exitCode, output} = runWithFixture({
+            'vanillaComparator/app.mjs'   : 'document.body.innerHTML = "vanilla";\n',
+            'vanillaComparator/index.html': '<!doctype html>\n'
+        });
+
+        expect(exitCode).toBe(1);
+        expect(output).toContain('FAIL');
+        expect(output).toContain('missing neo-config.json');
+        expect(output).toContain('ai/examples/');
+    });
+
+    test('exits 1 (FAIL) on an app.mjs build target missing index.html', () => {
+        // createStartingPoint reads index.html unconditionally too, so a build target with
+        // neo-config.json but no index.html is still a build-all breakage class.
+        const {exitCode, output} = runWithFixture({
+            'noIndexApp/app.mjs'        : "import Viewport from '../../../src/container/Viewport.mjs';\nexport default Viewport;\n",
+            'noIndexApp/neo-config.json': '{}\n'
+        });
+
+        expect(exitCode).toBe(1);
+        expect(output).toContain('FAIL');
+        expect(output).toContain('missing index.html');
+    });
+
+    test('exits 1 (FAIL) on an example importing from ai/', () => {
+        const {exitCode, output} = runWithFixture({
+            'harnessProbe/app.mjs'        : "import x from '../../../ai/services/Probe.mjs';\nexport default x;\n",
+            'harnessProbe/neo-config.json': '{}\n',
+            'harnessProbe/index.html'     : '<!doctype html>\n'
+        });
+
+        expect(exitCode).toBe(1);
+        expect(output).toContain('FAIL');
+        expect(output).toContain('importing from ai/');
+    });
+
+    test('exits 0 (PASS) for a conforming Body example fixture — no false positive', () => {
+        const {exitCode, output} = runWithFixture({
+            'goodBodyExample/app.mjs'        : "import Viewport from '../../../src/container/Viewport.mjs';\nexport default Viewport;\n",
+            'goodBodyExample/neo-config.json': '{}\n',
+            'goodBodyExample/index.html'     : '<!doctype html>\n'
+        });
+
+        expect(exitCode).toBe(0);
+        expect(output).toContain('PASS');
+    });
+});

--- a/test/playwright/unit/buildScripts/util/check-fixed-sleeps.spec.mjs
+++ b/test/playwright/unit/buildScripts/util/check-fixed-sleeps.spec.mjs
@@ -1,0 +1,477 @@
+import {test, expect}  from '@playwright/test';
+import {spawnSync}     from 'node:child_process';
+import fs              from 'node:fs';
+import os              from 'node:os';
+import path            from 'node:path';
+import {fileURLToPath} from 'node:url';
+
+const
+    __filename = fileURLToPath(import.meta.url),
+    __dirname  = path.dirname(__filename),
+    modulePath = path.resolve(__dirname, '../../../../../buildScripts/util/check-fixed-sleeps.mjs');
+
+/**
+ * check-fixed-sleeps.mjs — baseline reconciliation.
+ *
+ * The load-bearing case is the third one. These sites are overwhelmingly ONE byte-identical line,
+ * `setTimeout(resolve, 1000)`, repeated dozens of times in a single spec file — so any reconciliation
+ * keyed on file+text alone collapses them into ONE entry. Removing all but one then leaves the key
+ * still matching, nothing stale, and the guard green: a baseline that permits the original population
+ * forever while a single site remains. That is weaker than the per-file count this baseline was
+ * deliberately chosen OVER, wearing per-site clothes, and it is why reconciliation counts occurrences
+ * rather than testing membership.
+ *
+ * The fixtures below say 64 because a fixture is a stated premise, not a measurement — `site(64)` is
+ * true by construction. The prose above deliberately does NOT, because that would be a claim about a
+ * tree that moves: it read 64 while the tree held 63 until a reviewer caught it.
+ *
+ * Line numbers are deliberately NOT part of the key: they shift under any edit above them, so keying
+ * on them turns every unrelated change into a wall of false staleness — a guard nobody can keep green
+ * gets routed around, which is the failure this whole ticket is about.
+ */
+test.describe('check-fixed-sleeps.mjs — baseline reconciliation (#17124)', () => {
+    let reconcile;
+
+    test.beforeAll(async () => {
+        ({reconcile} = await import(modulePath))
+    });
+
+    const site = (count = 1) => ({count, file: 'a.spec.mjs', text: 'setTimeout(resolve, 1000);'}),
+          many = n => Array.from({length: n}, () => site());
+
+    test('a matching occurrence count is clean in both directions', () => {
+        const {fresh, stale} = reconcile({baseline: [site(64)], found: many(64)});
+
+        expect(fresh, 'nothing new').toEqual([]);
+        expect(stale, 'nothing stale').toEqual([]);
+    });
+
+    test('an ADDED occurrence is fresh even though its text already has a baseline entry', () => {
+        const {fresh, stale} = reconcile({baseline: [site(64)], found: many(65)});
+
+        expect(fresh.length).toBe(1);
+        expect(fresh[0].count, 'one occurrence beyond the allowance').toBe(1);
+        expect(stale).toEqual([]);
+    });
+
+    test('removing ONE of 64 identical sites goes stale — the key-collapse blind spot', () => {
+        const {fresh, stale} = reconcile({baseline: [site(64)], found: many(63)});
+
+        expect(stale.length, 'the shrink must be visible').toBe(1);
+        expect(stale[0].count, 'exactly one occurrence went away').toBe(1);
+        expect(fresh).toEqual([]);
+    });
+
+    test('a fully removed text goes stale for its whole count', () => {
+        const {fresh, stale} = reconcile({baseline: [site(64)], found: []});
+
+        expect(stale[0].count).toBe(64);
+        expect(fresh).toEqual([]);
+    });
+
+    test('a stale row reports its SURVIVORS, because the surplus alone picks the wrong remedy', () => {
+        const partial = reconcile({baseline: [site(64)], found: many(21)}),
+              total   = reconcile({baseline: [site(64)], found: []});
+
+        // Both lost sites, so both are stale by `count` alone — and the two take OPPOSITE remedies.
+        expect(partial.stale[0].count, 'the surplus is what the allowance overstates by').toBe(43);
+        expect(total.stale[0].count).toBe(64);
+
+        expect(partial.stale[0].remaining, 'reduce the row to these').toBe(21);
+        expect(total.stale[0].remaining, 'nothing survives, so the row goes').toBe(0);
+    });
+
+    test('deleting a PARTIALLY converted row fails the guard from the other side', () => {
+        // The remedy the old message prescribed, executed literally: 43 of 64 converted, row removed.
+        // The 21 survivors were legitimately grandfathered and now are not, so they re-enter as NEW —
+        // a conversion reported back to its author as a regression, which is why the row must be
+        // REDUCED. This is the failure the `remaining` field exists to stop, not a hypothetical.
+        const {fresh, stale} = reconcile({baseline: [], found: many(21)});
+
+        expect(fresh.length, 'the survivors come back as unaccounted').toBe(1);
+        expect(fresh[0].count, 'all 21 of them').toBe(21);
+        expect(stale, 'and the row that would have explained them is gone').toEqual([]);
+    });
+
+    test('the pattern in a COMMENT or a STRING is not a sleep — this file is the fixture', async () => {
+        // This spec's own docstring and its `site()` fixture both contain the literal text the guard
+        // matches, and neither sleeps. A guard that fires on prose about itself is a noise generator,
+        // and a noisy gate gets routed around within a week — the trap this whole ticket is against.
+        // Scanning this very file is the control: it would report two findings under the naive match.
+        const {findUnjustifiedSleeps} = await import(modulePath);
+
+        const {sites} = findUnjustifiedSleeps({
+            files  : [__filename],
+            rootDir: path.resolve(__dirname, '../../../../..')
+        });
+
+        expect(sites).toEqual([]);
+    });
+
+    test('a bypass is a spelling the guard cannot read — every candidate, and the delay by VALUE', async () => {
+        // Three executable bypasses, found by @neo-gpt reading the matcher rather than trusting its
+        // green run against the tree. Each is a legal way to write a one-second wait that the guard
+        // reported as no wait at all — the most expensive kind of gate, because it prints OK.
+        //
+        //   1. `exec` without /g returns the LEFTMOST match, so a sub-threshold call earlier on the
+        //      line consumed the line's only inspection and the real site behind it went unexamined.
+        //   2. `1_000` and 3. `1e3` are ordinary JavaScript spellings of 1000 that a `(\d+)` capture
+        //      cannot match at all — not mis-measured, invisible.
+        //
+        // The fixture lives on disk rather than in this file because the guard's own noise-control
+        // asserts THIS file yields nothing; embedding real call sites here would make two correct
+        // tests contradict each other. Each line is written from inside a quoted string for the same
+        // reason the `site()` fixture is.
+        const {findUnjustifiedSleeps} = await import(modulePath);
+
+        const
+            dir     = fs.mkdtempSync(path.join(os.tmpdir(), 'check-fixed-sleeps-')),
+            fixture = path.join(dir, 'bypass.spec.mjs');
+
+        try {
+            fs.writeFileSync(fixture, [
+                "await new Promise(resolve => setTimeout(resolve, 50)); await new Promise(resolve => setTimeout(resolve, 5000));",
+                "await new Promise(resolve => setTimeout(resolve, 1_000));",
+                "await new Promise(resolve => setTimeout(resolve, 1e3));",
+                "await new Promise(resolve => setTimeout(resolve, 1e+3));",
+                "await new Promise(resolve => setTimeout(resolve, 0x3e8));",
+                "await new Promise(resolve => setTimeout(resolve, 0o1750));",
+                "await new Promise(resolve => setTimeout(resolve, 0b1111101000));",
+                "await new Promise(resolve => setTimeout(resolve, 1000.));",
+                "await new Promise(resolve => setTimeout(resolve, .1e4));",
+                // Not a fixed literal: a named constant is already injectable, so it is not this
+                // guard's subject. It is the control proving the loose token match did not turn into
+                // a match-everything — `Number('DELAY_MS')` is NaN and the site is skipped.
+                "await new Promise(resolve => setTimeout(resolve, DELAY_MS));"
+            ].join('\n'), 'utf8');
+
+            const {sites} = findUnjustifiedSleeps({files: [fixture], rootDir: dir});
+
+            expect(sites.map(entry => entry.ms), 'every legal spelling of the threshold is read as milliseconds')
+                .toEqual([5000, 1000, 1000, 1000, 1000, 1000, 1000, 1000, 1000]);
+            expect(sites.length, 'the second call on line 1 is not shadowed by the first').toBe(9);
+        } finally {
+            fs.rmSync(dir, {force: true, recursive: true})
+        }
+    });
+
+    test('FORMATTING is not a bypass either — multiline, parenthesised, and comment-interposed calls', async () => {
+        // Found by @neo-gpt on re-review, after the spelling bypasses above were already closed: the
+        // matcher was applied one source LINE at a time, so a call the parser reads as a single
+        // 1000ms wait produced zero candidates whenever a newline or a comment fell inside it. Three
+        // more legal ways to write the same wait, each reported as no wait at all.
+        //
+        // This is why discovery moved to the parse tree. Spellings are enumerable and the previous
+        // fix enumerated them; FORMATTING is not, because whitespace and comments may sit between any
+        // two tokens. A text pattern cannot be made complete here — it can only be made longer.
+        const {findUnjustifiedSleeps} = await import(modulePath);
+
+        const
+            dir     = fs.mkdtempSync(path.join(os.tmpdir(), 'check-fixed-sleeps-fmt-')),
+            fixture = path.join(dir, 'formatting.spec.mjs');
+
+        try {
+            fs.writeFileSync(fixture, [
+                // The control: the single-line form the line-based matcher already caught. It anchors
+                // the other three — without it a zero-detection bug would read as a passing test.
+                "await new Promise(resolve => setTimeout(resolve, 1000));",
+                // 1. The call spans lines, so no single line holds the whole pattern.
+                "await new Promise(resolve => setTimeout(",
+                "    resolve,",
+                "    1000",
+                "));",
+                // 2. The delay is parenthesised — the parser reads the same Literal 1000.
+                "await new Promise(resolve => setTimeout(resolve, (1000)));",
+                // 3. A comment sits between the arguments.
+                "await new Promise(resolve => setTimeout(resolve, /* settle */ 1000));",
+                // The negative control travels with them: widening what the guard SEES must not widen
+                // what it REFUSES, and a named constant stays out regardless of how it is formatted.
+                "await new Promise(resolve => setTimeout(",
+                "    resolve,",
+                "    DELAY_MS",
+                "));"
+            ].join('\n'), 'utf8');
+
+            const {sites} = findUnjustifiedSleeps({files: [fixture], rootDir: dir});
+
+            expect(sites.map(entry => entry.ms), 'all four forms are one 1000ms wait each')
+                .toEqual([1000, 1000, 1000, 1000]);
+            // Line numbers, because "four sites" would also pass if the guard found the control four
+            // times. Each must be the site it claims: the multiline call reports its FIRST line, which
+            // is what keys the baseline.
+            expect(sites.map(entry => entry.line), 'each form is found at its own call site')
+                .toEqual([1, 2, 6, 7]);
+        } finally {
+            fs.rmSync(dir, {force: true, recursive: true})
+        }
+    });
+
+    test('#17184: the token pre-filter narrows PARSING, never the verdict', async () => {
+        // The guard parses 1,036 unit specs to inspect the 109 that contain the token at all, which
+        // cost 7x the pre-AST wall clock and got the process SIGKILLed under lint-staged. Skipping a
+        // file with no `setTimeout` token is sound because the matcher requires an Identifier callee
+        // of that exact name — but a substring test inside a guard that moved to an AST *because*
+        // substring tests are unsound needs its boundary pinned, not assumed.
+        //
+        // The third fixture is the one that matters: it CONTAINS the token, so the filter admits it,
+        // and the AST then correctly finds nothing. That is the proof the filter is not deciding —
+        // if it ever were, this file would report a false positive.
+        const {findUnjustifiedSleeps} = await import(modulePath);
+
+        const
+            dir    = fs.mkdtempSync(path.join(os.tmpdir(), 'check-fixed-sleeps-filter-')),
+            real   = path.join(dir, 'real.spec.mjs'),
+            absent = path.join(dir, 'absent.spec.mjs'),
+            quoted = path.join(dir, 'quoted.spec.mjs');
+
+        try {
+            fs.writeFileSync(real,   'await new Promise(resolve => setTimeout(resolve, 1000));\n', 'utf8');
+            fs.writeFileSync(absent, 'const value = 1000;\nexport default value;\n', 'utf8');
+            fs.writeFileSync(quoted, '// setTimeout(resolve, 1000) named in prose, never called\n'
+                + 'const doc = "setTimeout(resolve, 1000)";\nexport default doc;\n', 'utf8');
+
+            const {sites} = findUnjustifiedSleeps({files: [real, absent, quoted], rootDir: dir});
+
+            expect(sites.length, 'only the real call site counts').toBe(1);
+            expect(sites[0].file, 'and it is the file that actually calls it').toBe('real.spec.mjs');
+        } finally {
+            fs.rmSync(dir, {force: true, recursive: true})
+        }
+    });
+
+    test('#17184: the reported line is derived correctly deep inside a file', async () => {
+        // `locations` is no longer requested — it attaches a `loc` object to every node to spare one
+        // lookup — so the line comes from counting newlines before `node.start`. That derivation is a
+        // CORRECTNESS surface, not a performance detail: `line` and `text` are what a grandfathered
+        // baseline row is matched on, so an off-by-one would silently rekey every site at once and
+        // read as a wall of false staleness.
+        const {findUnjustifiedSleeps} = await import(modulePath);
+
+        const
+            dir     = fs.mkdtempSync(path.join(os.tmpdir(), 'check-fixed-sleeps-line-')),
+            fixture = path.join(dir, 'deep.spec.mjs'),
+            padding = 400;
+
+        try {
+            fs.writeFileSync(fixture, [
+                ...Array.from({length: padding}, (_, i) => `// filler line ${i + 1}`),
+                'await new Promise(resolve => setTimeout(resolve, 1000));'
+            ].join('\n'), 'utf8');
+
+            const {sites} = findUnjustifiedSleeps({files: [fixture], rootDir: dir});
+
+            expect(sites.length).toBe(1);
+            expect(sites[0].line, 'one-based, and 400 filler lines precede it').toBe(padding + 1);
+        } finally {
+            fs.rmSync(dir, {force: true, recursive: true})
+        }
+    });
+
+    test('an unparseable spec is reported, never skipped', async () => {
+        // A guard that swallows a parse failure reports the same OK for "nothing to find" and "could
+        // not look", and those differ by exactly the thing it exists to catch.
+        const {findUnjustifiedSleeps} = await import(modulePath);
+
+        const
+            dir     = fs.mkdtempSync(path.join(os.tmpdir(), 'check-fixed-sleeps-bad-')),
+            fixture = path.join(dir, 'broken.spec.mjs');
+
+        try {
+            // The fixture must carry the token, and that is the whole point: the
+            // pre-filter skips token-free files BEFORE parsing, so a broken file with no `setTimeout`
+            // is no longer reported by this guard. That narrowing is deliberate and sound — no token
+            // means no `setTimeout` call to find, parseable or not, so the VERDICT is unaffected —
+            // but it is a real narrowing of what this guard surfaces, and `check-parse.mjs` is the
+            // pre-commit task that owns "does every file parse". This spec pins the case that still
+            // matters: a file the guard would actually have inspected must never fail open.
+            fs.writeFileSync(fixture, 'const = ;\nsetTimeout(resolve, 1000);', 'utf8');
+
+            expect(() => findUnjustifiedSleeps({files: [fixture], rootDir: dir}))
+                .toThrow(/cannot parse/)
+        } finally {
+            fs.rmSync(dir, {force: true, recursive: true})
+        }
+    });
+
+    test('#17184: a Unicode-escaped identifier is still a setTimeout call', async () => {
+        // @neo-gpt's witness. `setTimeout` is `setTimeout` to the parser — acorn reports
+        // `callee.name === 'setTimeout'` — while the source contains no such substring, so the first
+        // pre-filter skipped the file and the guard reported nothing. My soundness argument said the
+        // literal token "must appear in source"; that is true of the token and false of the
+        // IdentifierName language acorn accepts, which is the gap between a lexer and a substring.
+        const {findUnjustifiedSleeps} = await import(modulePath);
+
+        const
+            dir     = fs.mkdtempSync(path.join(os.tmpdir(), 'check-fixed-sleeps-escape-')),
+            fixture = path.join(dir, 'escaped.spec.mjs');
+
+        try {
+            // Written through an escape so this spec file itself carries no bare call site — the same
+            // reason the other fixtures live on disk rather than inline.
+            fs.writeFileSync(fixture, 'await new Promise(resolve => set\\u0054imeout(resolve, 1000));\n', 'utf8');
+
+            const {sites} = findUnjustifiedSleeps({files: [fixture], rootDir: dir});
+
+            expect(sites.length, 'the escape is a spelling, not a bypass').toBe(1);
+            expect(sites[0].ms).toBe(1000);
+            expect(sites[0].line).toBe(1);
+        } finally {
+            fs.rmSync(dir, {force: true, recursive: true})
+        }
+    });
+
+    test('#17184: U+2028 is a line terminator — a remote marker must not discharge a site', async () => {
+        // The second witness, and the one that fails OPEN rather than merely misreporting. ECMAScript
+        // ends a line on U+2028 too, so the parser puts this call on line 6 while an LF-only split
+        // puts it on line 1 — dragging a `wall-clock-under-test:` marker from the top of the file into
+        // the LOOKBEHIND window and discharging a wait nobody accounted for.
+        const {findUnjustifiedSleeps} = await import(modulePath);
+
+        const
+            dir     = fs.mkdtempSync(path.join(os.tmpdir(), 'check-fixed-sleeps-lineterm-')),
+            fixture = path.join(dir, 'terminators.spec.mjs');
+
+        try {
+            // One physical LF; the rest of the breaks are U+2028. The marker is five logical lines
+            // above the call, so it is outside LOOKBEHIND and must NOT justify it.
+            fs.writeFileSync(fixture,
+                '// wall-clock-under-test: the elapsed time is the assertion\n'
+                + ['const a = 1;', 'const b = 2;', 'const c = 3;', 'const d = 4;',
+                   'await new Promise(resolve => setTimeout(resolve, 1000));'].join(' '),
+                'utf8');
+
+            const {sites} = findUnjustifiedSleeps({files: [fixture], rootDir: dir});
+
+            expect(sites.length, 'a marker five logical lines away does not reach this site').toBe(1);
+            expect(sites[0].line, 'ECMAScript line semantics, matching the parser').toBe(6);
+        } finally {
+            fs.rmSync(dir, {force: true, recursive: true})
+        }
+    });
+
+    test('#17184: a token-free file is skipped unparsed — the narrowing, stated', async () => {
+        // The mirror of the case above, present so the narrowing is a documented decision rather than
+        // a behaviour someone rediscovers. If this ever needs to throw again, the pre-filter is what
+        // has to go, and its whole value is the parsing it avoids.
+        const {findUnjustifiedSleeps} = await import(modulePath);
+
+        const
+            dir     = fs.mkdtempSync(path.join(os.tmpdir(), 'check-fixed-sleeps-skip-')),
+            fixture = path.join(dir, 'broken-but-irrelevant.spec.mjs');
+
+        try {
+            fs.writeFileSync(fixture, 'const = ;', 'utf8');
+
+            const {sites} = findUnjustifiedSleeps({files: [fixture], rootDir: dir});
+
+            expect(sites, 'unparseable, but it cannot contain the call this guard looks for').toEqual([])
+        } finally {
+            fs.rmSync(dir, {force: true, recursive: true})
+        }
+    });
+
+    test('a justified bypass spelling is still discharged — the widened matcher did not widen the verdict', async () => {
+        // The mirror of the case above, and the reason it matters: widening what the guard can SEE must
+        // not widen what it REFUSES. A `1e3` wait carrying the marker is an accounted wait exactly as a
+        // `1000` one is, or the repair would have converted a bypass into a false positive.
+        const {findUnjustifiedSleeps} = await import(modulePath);
+
+        const
+            dir     = fs.mkdtempSync(path.join(os.tmpdir(), 'check-fixed-sleeps-')),
+            fixture = path.join(dir, 'justified.spec.mjs');
+
+        try {
+            fs.writeFileSync(fixture, [
+                "// wall-clock-under-test: the scheduler's own elapsed time is the assertion",
+                "await new Promise(resolve => setTimeout(resolve, 1e3));"
+            ].join('\n'), 'utf8');
+
+            const {backlog, sites} = findUnjustifiedSleeps({files: [fixture], rootDir: dir});
+
+            expect(sites, 'the marker discharges it').toEqual([]);
+            expect(backlog, 'wall-clock-under-test is not leaf backlog').toEqual([]);
+        } finally {
+            fs.rmSync(dir, {force: true, recursive: true})
+        }
+    });
+
+    test('importing the module runs no lint and exits no process', () => {
+        // The module exports SCAN_SURFACE so the workflow-parity spec can import it as authority. Its
+        // CLI body must therefore stay behind a direct-invocation guard: an unguarded top-level body
+        // calls process.exit() inside whatever imports it, which kills a Playwright worker with NO
+        // failure message — the suite reports nothing rather than red. Reaching this assertion at all
+        // is the proof, since the import happens in beforeAll.
+        expect(typeof reconcile, 'the module imported without exiting the worker').toBe('function');
+    });
+
+    test('#17177: the callback arm is a wait too — inline-callback positives, named-constant-delay negative', async () => {
+        // The guard's own docstring states its subject: "a fixed second-scale wait that does not name
+        // what it waits for." An inline callback names nothing, and it blocks the wall clock exactly as
+        // long as the Identifier form — the first-argument restriction was a regex-capture artifact,
+        // never a decision. Widening what the guard SEES, though, must not widen what it REFUSES: the
+        // delay-literal contract is untouched, so a named-constant delay stays out on either arm.
+        const {findUnjustifiedSleeps} = await import(modulePath);
+
+        const
+            dir     = fs.mkdtempSync(path.join(os.tmpdir(), 'check-fixed-sleeps-callback-')),
+            fixture = path.join(dir, 'callback.spec.mjs');
+
+        try {
+            fs.writeFileSync(fixture, [
+                // The positives: both inline-callback spellings, invisible while the first argument
+                // must be an Identifier.
+                "setTimeout(() => { poll(); }, 8000);",
+                "setTimeout(function () { poll(); }, 1500);",
+                // The negative: a named-constant DELAY stays out regardless of the callback arm —
+                // the constant already names what this guard asks named.
+                "setTimeout(() => { poll(); }, DELAY_MS);",
+                // The Identifier control anchors the set: without it a zero-detection bug reads green.
+                "await new Promise(resolve => setTimeout(resolve, 1000));",
+                // The self-naming failure deadline: a failure detector, not a wait — its error text
+                // is the naming, so it is exempt like the named-constant delay.
+                "setTimeout(() => reject(new Error('the wake never landed')), 5000);",
+                // The exemption's boundary, pinned from both sides: a message-free reject names
+                // nothing, and a message behind a variable is not statically visible — both stay
+                // counted, because a form the guard cannot prove self-naming must never be waved through.
+                "setTimeout(() => reject(), 5000);",
+                "setTimeout(() => reject(new Error(msg)), 5000);"
+            ].join('\n'), 'utf8');
+
+            const {sites} = findUnjustifiedSleeps({files: [fixture], rootDir: dir});
+
+            expect(sites.map(entry => entry.ms), 'both callback spellings, the control, and the two unnamed deadline forms are seen')
+                .toEqual([8000, 1500, 1000, 5000, 5000]);
+            expect(sites.map(entry => entry.line), 'each at its own call site, the negatives absent')
+                .toEqual([1, 2, 4, 6, 7]);
+        } finally {
+            fs.rmSync(dir, {force: true, recursive: true})
+        }
+    });
+
+    test('#17177: the CLI exits 1 on a fresh callback-form wait and 0 on a clean tree', () => {
+        // The library-level pins above prove the site is SEEN; this proves the verdict crosses the
+        // process boundary. A sandbox cwd is the whole tree to the CLI (ROOT_DIR is process.cwd()),
+        // so the clean-tree leg runs without touching the repo — and on the pre-widening matcher the
+        // fixture leg inverts: the callback form is invisible, the exit stays 0, and this test is red.
+        const
+            dir      = fs.mkdtempSync(path.join(os.tmpdir(), 'check-fixed-sleeps-cli-')),
+            unitRoot = path.join(dir, 'test', 'playwright', 'unit');
+
+        fs.mkdirSync(unitRoot, {recursive: true});
+
+        try {
+            let res = spawnSync(process.execPath, [modulePath], {cwd: dir, encoding: 'utf8'});
+
+            expect(res.status, `clean tree exits 0: ${res.stderr}`).toBe(0);
+
+            fs.writeFileSync(path.join(unitRoot, 'fresh.spec.mjs'), 'setTimeout(() => { poll(); }, 8000);\n', 'utf8');
+
+            res = spawnSync(process.execPath, [modulePath], {cwd: dir, encoding: 'utf8'});
+
+            expect(res.status, `a fresh callback-form wait fails the guard: ${res.stdout}`).toBe(1);
+            expect(res.stderr).toContain('8000ms');
+        } finally {
+            fs.rmSync(dir, {force: true, recursive: true})
+        }
+    });
+});

--- a/test/playwright/unit/buildScripts/util/check-jsdoc-types.spec.mjs
+++ b/test/playwright/unit/buildScripts/util/check-jsdoc-types.spec.mjs
@@ -1,0 +1,151 @@
+import {test, expect}                                             from '@playwright/test';
+import {spawnSync}                                                from 'node:child_process';
+import path                                                       from 'node:path';
+import {fileURLToPath}                                            from 'node:url';
+import {describeScan, findUnparseableTypes, extractType, inScope} from '../../../../../buildScripts/util/check-jsdoc-types.mjs';
+
+const scriptPath = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../../../../../buildScripts/util/check-jsdoc-types.mjs');
+
+/**
+ * Self-test for the JSDoc-type lint: the mechanical gate that stops TS-like type expressions the
+ * docs build (the jsdoc engine → catharsis) cannot parse from breaking `npm run generate-docs-json` (the last
+ * `build all` step) + the docs app. Verifies it flags the build-breaking no-space record-union (+ malformed
+ * types), passes the catharsis-valid spaced / parenthesized / plain / top-level-union forms, scans only
+ * `/**` doc blocks (not `/*` or `//`), and scopes to the authored-source surface (src/ai/examples/apps/docs-app) —
+ * intentionally broader than the docs build (unparseable JSDoc is a defect anywhere, not only where it parses today).
+ */
+const block = (...lines) => ['/**', ...lines.map(l => ' * ' + l), ' */'].join('\n');
+
+test.describe('check-jsdoc-types guard', () => {
+    test('flags a bare union in a record value with no space after the colon (the build-breaker)', () => {
+        const hits = findUnparseableTypes(block('@returns {{layout:Object|null, errors:String[]}}'));
+
+        expect(hits.map(h => h.line)).toEqual([2]);
+        expect(hits[0].tag).toBe('returns');
+        expect(hits[0].expr).toBe('{layout:Object|null, errors:String[]}')
+    });
+
+    test('passes the same union when spaced or parenthesized (the catharsis-valid forms)', () => {
+        expect(findUnparseableTypes(block('@returns {{layout: Object|null, errors: String[]}}'))).toEqual([]);
+        expect(findUnparseableTypes(block('@returns {{layout:(Object|null), errors:String[]}}'))).toEqual([])
+    });
+
+    test('passes plain / array / generic / top-level-union types', () => {
+        // a top-level `{Object|null}` union is valid — only a bare union INSIDE a record value breaks
+        expect(findUnparseableTypes(block(
+            '@param {String} a',
+            '@param {String[]} b',
+            '@param {Array<String>} c',
+            '@returns {Object|null}'
+        ))).toEqual([])
+    });
+
+    test('scans only /** doc blocks — ignores /* block comments and // lines', () => {
+        // sitemap-style: a malformed type inside a single-star /* block is not a build input → not flagged
+        expect(findUnparseableTypes(['/*', ' * @member {String[}', ' */'].join('\n'))).toEqual([]);
+        expect(findUnparseableTypes('// @returns {Object|null|}')).toEqual([])
+    });
+
+    test('flags a malformed type INSIDE a /** doc block', () => {
+        expect(findUnparseableTypes(block('@member {String[}')).map(h => h.line)).toEqual([2])
+    });
+
+    test('extractType returns the inner type expression (tag braces stripped)', () => {
+        const record = ' * @returns {{a:String}}';
+        expect(extractType([record], 0, record.indexOf('{'))).toBe('{a:String}');
+
+        const scalar = ' * @param {String} name';
+        expect(extractType([scalar], 0, scalar.indexOf('{'))).toBe('String')
+    });
+
+    test('inScope covers the authored-source surface (src/ai/examples/apps/docs-app), broader than the docs build', () => {
+        expect(inScope('src/dashboard/DockZoneModel.mjs')).toBe(true);
+        expect(inScope('ai/WriteGuard.mjs')).toBe(true);
+        expect(inScope('examples/dashboard/dock/MainContainer.mjs')).toBe(true);
+        expect(inScope('docs/app/view/Main.mjs')).toBe(true);
+        expect(inScope('apps/portal/view/Main.mjs')).toBe(true);
+        expect(inScope('apps/ai/view/Main.mjs')).toBe(true); // ALL apps, not only docs-build-configured ones
+
+        // out of scope: build scripts, tests, underscore aggregators, the config overlays, non-.mjs
+        expect(inScope('buildScripts/util/check-jsdoc-types.mjs')).toBe(false);
+        expect(inScope('test/playwright/unit/foo.spec.mjs')).toBe(false);
+        expect(inScope('src/core/_export.mjs')).toBe(false);
+        expect(inScope('ai/config.mjs')).toBe(false);
+        expect(inScope('ai/mcp/server/memory-core/config.mjs')).toBe(false);
+        expect(inScope('README.md')).toBe(false)
+    })
+});
+
+test.describe('the success receipt states the scope it read', () => {
+    // This line gets QUOTED — into pull-request evidence sections, by readers who did not run it and
+    // have none of the surrounding context. A bare count then reads as coverage of THEIR diff.
+
+    test('a default run names the scope, not only a count', () => {
+        const {scope, scanned} = describeScan({supplied: 0, offered: 2048, admitted: 2048, read: 2048});
+
+        expect(scanned).toBe('2048 file(s) read');
+        expect(scope).toContain('docs-build parse scope');
+        expect(scope).toContain('src')
+    });
+
+    test('CONTROL: a run that read NONE of the supplied files is distinguishable from one that read all', () => {
+        // The arm that stops "mentions a scope" being satisfiable by prose. Both runs exit 0 and both
+        // report zero unparseable types; only the counts separate "I checked your files" from "I
+        // checked none of them".
+        const none = describeScan({supplied: 2, offered: 2, admitted: 0, read: 0}),
+              all  = describeScan({supplied: 2, offered: 2, admitted: 2, read: 2});
+
+        expect(none.scanned).toBe('0 of 2 supplied file(s) read');
+        expect(all.scanned).toBe('2 of 2 supplied file(s) read');
+        expect(none.scanned).not.toBe(all.scanned)
+    });
+
+    test('a partially-dropped set says so — the scope filter is otherwise silent', () => {
+        expect(describeScan({supplied: 7, offered: 7, admitted: 3, read: 3}).scanned).toBe('3 of 7 supplied file(s) read');
+    });
+
+    test('an ADMITTED file that could not be opened is never counted as read', () => {
+        // Selection and IO diverge, so two counts cannot describe the run. A file admitted by scope and
+        // then failing to open warns on one line and is skipped on the next; reporting the ADMITTED
+        // count as the scanned one is a green claim about a file nobody opened — this checker's own
+        // defect, committed inside the fix for it.
+        expect(describeScan({supplied: 1, offered: 1, admitted: 1, read: 0}).scanned)
+            .toBe('0 of 1 supplied file(s) read, 1 unreadable');
+
+        expect(describeScan({supplied: 0, offered: 9, admitted: 9, read: 7}).scanned)
+            .toBe('7 file(s) read, 2 unreadable')
+    });
+
+    test('CONTROL: a fully-read run says nothing about unreadable files', () => {
+        // Without this, "names the unreadable count" is equally consistent with a suffix that is always
+        // present and therefore carries no information.
+        expect(describeScan({supplied: 2, offered: 2, admitted: 2, read: 2}).scanned).not.toContain('unreadable')
+    });
+
+    test('the CLI actually emits it — a correct formatter proves nothing on its own', () => {
+        // Without this, the arms above pin a function `main()` might never call.
+        const result = spawnSync('node', [scriptPath, 'package.json'], {encoding: 'utf8'}),
+              output = (result.stdout || '') + (result.stderr || '');
+
+        expect(output).toContain('0 of 1 supplied file(s) read');
+        expect(output).toContain('docs-build parse scope')
+    });
+
+    test('the CLI does not claim to have read a missing in-scope file', () => {
+        // The reviewer falsifier, committed. `src/…` is in scope, so the path is admitted and then
+        // fails to open — previously reported as `1 of 1 supplied file(s) scanned`, exit 0.
+        const result = spawnSync('node', [scriptPath, 'src/doesNotExist17435.mjs'], {encoding: 'utf8'}),
+              output = (result.stdout || '') + (result.stderr || '');
+
+        expect(output).toContain('could not read');
+        expect(output).toContain('0 of 1 supplied file(s) read, 1 unreadable');
+        expect(output).not.toContain('1 of 1 supplied file(s) read,  0 unparseable')
+    });
+
+    test('a failure summary names the scope too — a violation list is quoted as often as a green line', () => {
+        const result = spawnSync('node', [scriptPath, '--quiet', 'src/Neo.mjs'], {encoding: 'utf8'}),
+              output = (result.stdout || '') + (result.stderr || '');
+
+        expect(output).toContain('docs-build parse scope')
+    })
+});

--- a/test/playwright/unit/buildScripts/util/check-parse.spec.mjs
+++ b/test/playwright/unit/buildScripts/util/check-parse.spec.mjs
@@ -1,0 +1,84 @@
+import {test, expect}  from '@playwright/test';
+import {execFileSync}  from 'node:child_process';
+import fs              from 'node:fs';
+import os              from 'node:os';
+import path            from 'node:path';
+import {fileURLToPath} from 'node:url';
+
+const
+    __filename = fileURLToPath(import.meta.url),
+    __dirname  = path.dirname(__filename),
+    scriptPath = path.resolve(__dirname, '../../../../../buildScripts/util/check-parse.mjs');
+
+/**
+ * check-parse.mjs — the commit-time syntax gate (`node --check` each staged `.mjs`). It is the durable
+ * backstop for mechanical rewrites whose output ships un-run: `check-block-alignment --fix` runs after the
+ * author's local test pass, so a destructuring-with-defaults edge case erased valid JS into a
+ * SyntaxError that was green locally and only red in CI (every importing spec threw). A parse gate catches
+ * every such break regardless of the source that produced it.
+ */
+test.describe('check-parse.mjs (#15072)', () => {
+    let tempDir;
+
+    test.beforeEach(() => {
+        tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'neo-check-parse-'));
+    });
+
+    test.afterEach(() => {
+        fs.rmSync(tempDir, {recursive: true, force: true});
+    });
+
+    const write = (name, content) => {
+        const filePath = path.join(tempDir, name);
+        fs.writeFileSync(filePath, content, 'utf8');
+        return filePath;
+    };
+
+    // execFileSync (not execSync): node is spawned directly with an argv array — no shell, so the absolute
+    // scriptPath + file args can never be interpolated into a shell command (CodeQL-clean).
+    const run = (...args) => {
+        try {
+            return {status: 0, output: execFileSync('node', [scriptPath, ...args], {encoding: 'utf8', stdio: 'pipe'})};
+        } catch (error) {
+            return {status: error.status, output: (error.stderr || '') + (error.stdout || '')};
+        }
+    };
+
+    test('passes (exit 0) when every staged .mjs parses', () => {
+        const file = write('ok.mjs', 'export const answer = 42;\n');
+        expect(run(file).status).toBe(0);
+    });
+
+    test('fails (exit 1) and names the file + SyntaxError when a staged .mjs no longer parses', () => {
+        // The exact aligner-corruption shape: a multi-declarator const mis-split at the default `=` inside
+        // the destructuring pattern, leaving an unterminated `{` — a plain SyntaxError.
+        const file             = write('broken.mjs', 'const {blockedNodes = focusContradiction,\n      focusReasons  = [1];\n');
+        const {status, output} = run(file);
+
+        expect(status).toBe(1);
+        expect(output).toContain('no longer parse');
+        expect(output).toContain('broken.mjs');
+        expect(output).toContain('SyntaxError');
+    });
+
+    test('a mixed batch fails on the one broken file and reports only it', () => {
+        const
+            good             = write('good.mjs', 'const a = 1, bb = 2;\n'),
+            broken           = write('broken.mjs', 'const {x = ;\n'),
+            {status, output} = run(good, broken);
+
+        expect(status).toBe(1);
+        expect(output).toContain('broken.mjs');
+        expect(output).not.toContain('good.mjs');   // clean files are never listed
+    });
+
+    test('non-.mjs paths are ignored — a broken .js never fails the gate', () => {
+        // lint-staged globs this gate to *.mjs; a stray non-.mjs arg must be a no-op, never a false block.
+        const file = write('broken.js', 'const {x = ;\n');
+        expect(run(file).status).toBe(0);
+    });
+
+    test('no .mjs files in scope is a clean no-op (exit 0)', () => {
+        expect(run().status).toBe(0);
+    });
+});

--- a/test/playwright/unit/buildScripts/util/check-ticket-archaeology.spec.mjs
+++ b/test/playwright/unit/buildScripts/util/check-ticket-archaeology.spec.mjs
@@ -1,0 +1,234 @@
+import {test, expect}                                                                                     from '@playwright/test';
+import {execFileSync, spawnSync}                                                                          from 'node:child_process';
+import {mkdtempSync, rmSync, writeFileSync}                                                               from 'node:fs';
+import {tmpdir}                                                                                           from 'node:os';
+import path                                                                                               from 'node:path';
+import {fileURLToPath}                                                                                    from 'node:url';
+import {describeRead, extractComment, findTicketRefs, isInScopePath, DEFAULT_SCAN_PATHS, DEFAULT_IGNORES} from '../../../../../buildScripts/util/check-ticket-archaeology.mjs';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = path.resolve(__dirname, '../../../../..');
+const GUARD     = path.join(REPO_ROOT, 'buildScripts/util/check-ticket-archaeology.mjs');
+
+// CLI-invoked from REPO_ROOT (where node_modules resolves Commander), capturing exit code + combined output.
+// Both streams, on both paths. The failure branch already merged them; the success branch returned
+// stdout alone, so anything a PASSING run wrote to stderr was invisible to every arm here — and an
+// unreadable input warns on stderr while still exiting 0.
+const runGuard = (args, env = {}) => {
+    const result = spawnSync('node', [GUARD, ...args], {cwd: REPO_ROOT, encoding: 'utf8', env: {...process.env, ...env}});
+
+    return {code: result.status, stdout: `${result.stdout || ''}${result.stderr || ''}`};
+};
+
+/**
+ * Self-test for the ticket-archaeology guard: the mechanical replacement for the discipline-only
+ * "no decay-prone ticket refs in durable comments" rule. Verifies it flags comment/JSDoc refs,
+ * exempts load-bearing string-literal anchors, and honors the inline escape marker.
+ */
+test.describe('check-ticket-archaeology guard', () => {
+    test('flags a numeric ticket ref inside a JSDoc block comment', () => {
+        const hits = findTicketRefs([
+            '/**',
+            ' * Resolves #12345 by reshaping the owner clause.',
+            ' */',
+            'const x = 1;'
+        ].join('\n'));
+
+        expect(hits).toEqual([{line: 2, text: '* Resolves #12345 by reshaping the owner clause.'}])
+    });
+
+    test('flags a ref in a full-line // comment and a trailing // comment', () => {
+        const full = findTicketRefs('// see #12345 for context\nconst a = 1;');
+        expect(full.map(h => h.line)).toEqual([1]);
+
+        const trailing = findTicketRefs('const b = 2; // added in #12345');
+        expect(trailing.map(h => h.line)).toEqual([1])
+    });
+
+    test('does NOT flag a ticket ref inside a string literal (load-bearing test.describe anchor)', () => {
+        const hits = findTicketRefs([
+            '/** behavior-only summary */',
+            "test.describe('Dockerized KB retrieval (#11645)', () => {});",
+            "const url = 'https://github.com/neomjs/neo/issues/12345';"
+        ].join('\n'));
+
+        expect(hits).toEqual([])
+    });
+
+    test('honors the inline escape marker on a genuinely load-bearing line', () => {
+        const hits = findTicketRefs('// keep this ref — see #12345 ticket-ref-ok: pins a retired-primitive successor');
+
+        expect(hits).toEqual([])
+    });
+
+    test('flags the named Epic / Discussion / ADR prose forms in comments', () => {
+        const hits = findTicketRefs([
+            '// part of Epic #11624',
+            '// graduated from Discussion #10137',
+            '// aligned-with ADR-0003'
+        ].join('\n'));
+
+        expect(hits.map(h => h.line)).toEqual([1, 2, 3])
+    });
+
+    test('does NOT flag a 6-hex-with-letters color or a markdown-style "# 12345" heading in a comment', () => {
+        const hits = findTicketRefs([
+            '// fallback color #1234ff for the badge',
+            '// # 12345 (spaced — markdown-style, not a ticket ref)'
+        ].join('\n'));
+
+        expect(hits).toEqual([])
+    });
+
+    test('closes block-comment state so post-block code lines are not treated as comments', () => {
+        const state = {inBlock: false};
+        extractComment('/** opens */', state);
+        expect(state.inBlock).toBe(false)
+    });
+});
+
+/**
+ * Boy-scout whole-touched-file behavior: the guard scans each passed file in FULL — touching a
+ * file obligates cleaning ALL its ticket-archaeology, not just the author's added lines (operator-directed,
+ * exactly like check-block-alignment). This reduces the grandfathered backlog as files are naturally touched
+ * (the prior added-lines-only scope froze it). Plus the generated-data skip-flag (data-sync / GitHub Workflow sync).
+ *
+ * CLI-invoked from REPO_ROOT against an isolated temp file, so the real argv-mode path — including the
+ * whole-file scan + the skip gate — is exercised end-to-end.
+ */
+test.describe('check-ticket-archaeology whole-touched-file + skip (#14279)', () => {
+    let tempDir, probe;
+
+    test.beforeEach(() => {
+        tempDir = mkdtempSync(path.join(tmpdir(), 'neo-archaeology-boyscout-'));
+        probe   = path.join(tempDir, 'probe.mjs');
+        // The ref sits on a line the author did NOT add this change — boy-scout must still flag it.
+        writeFileSync(probe, '// grandfathered ref #11111\nexport const a = 1;\nexport const b = 2;\n');
+    });
+
+    test.afterEach(() => rmSync(tempDir, {recursive: true, force: true}));
+
+    test('flags a ref on ANY line of a touched file (whole-file, not added-lines)', () => {
+        const {code, stdout} = runGuard([probe]);
+        expect(code).toBe(1);
+        expect(stdout).toContain('#11111');
+    });
+
+    test('--skip bypasses the gate (generated-data class)', () => {
+        const {code, stdout} = runGuard(['--skip', probe]);
+        expect(code).toBe(0);
+        expect(stdout).toContain('skipped');
+    });
+
+    test('NEO_SKIP_TICKET_ARCHAEOLOGY=1 bypasses the gate', () => {
+        const {code} = runGuard([probe], {NEO_SKIP_TICKET_ARCHAEOLOGY: '1'});
+        expect(code).toBe(0);
+    });
+});
+
+/**
+ * Base-mode scope selection: isInScopePath is the in-scope contract the `--base` CI selection applies to
+ * each changed path. The guard script lives outside the ai/src/test-playwright roots, so it must be listed
+ * explicitly in DEFAULT_SCAN_PATHS — otherwise a PR touching the guard triggers the lint workflow but the
+ * scan selects 0 files and greens vacuously (the gap this covers). Pure predicate → no live git diff needed.
+ */
+test.describe('check-ticket-archaeology --base scope selection (#14279)', () => {
+    test('selects the guard script itself — it triggers the lint workflow, so it must self-scan', () => {
+        expect(isInScopePath('buildScripts/util/check-ticket-archaeology.mjs', DEFAULT_SCAN_PATHS, DEFAULT_IGNORES)).toBe(true)
+    });
+
+    test('selects in-scope ai / src / test-playwright .mjs files', () => {
+        expect(isInScopePath('ai/services/foo.mjs', DEFAULT_SCAN_PATHS, DEFAULT_IGNORES)).toBe(true);
+        expect(isInScopePath('src/core/Base.mjs', DEFAULT_SCAN_PATHS, DEFAULT_IGNORES)).toBe(true);
+        expect(isInScopePath('test/playwright/unit/x.spec.mjs', DEFAULT_SCAN_PATHS, DEFAULT_IGNORES)).toBe(true)
+    });
+
+    test('rejects non-.mjs, out-of-scope dirs, a buildScripts sibling, and ignored fragments', () => {
+        expect(isInScopePath('buildScripts/util/check-ticket-archaeology.yml', DEFAULT_SCAN_PATHS, DEFAULT_IGNORES)).toBe(false);
+        expect(isInScopePath('buildScripts/util/other-guard.mjs', DEFAULT_SCAN_PATHS, DEFAULT_IGNORES)).toBe(false);
+        expect(isInScopePath('apps/portal/foo.mjs', DEFAULT_SCAN_PATHS, DEFAULT_IGNORES)).toBe(false);
+        expect(isInScopePath('test/unit/legacy.mjs', DEFAULT_SCAN_PATHS, DEFAULT_IGNORES)).toBe(false);
+        expect(isInScopePath('ai/node_modules/dep.mjs', DEFAULT_SCAN_PATHS, DEFAULT_IGNORES)).toBe(false)
+    });
+});
+
+/**
+ * CLI parser contract: the guard parses argv with Commander (a declared dependency), so an invalid
+ * invocation must fail loudly rather than silently changing the scanned set or base ref. These cover the
+ * fail-loud paths (unknown option, missing option value) plus the accepted forms (=value, space value,
+ * boolean flag, positional file).
+ */
+test.describe('check-ticket-archaeology CLI parser contract (#14279)', () => {
+    let tempDir, probe;
+
+    test.beforeEach(() => {
+        tempDir = mkdtempSync(path.join(tmpdir(), 'neo-archaeology-parser-'));
+        probe   = path.join(tempDir, 'probe.mjs');
+        writeFileSync(probe, '// ref #11111\nexport const a = 1;\n');
+    });
+
+    test.afterEach(() => rmSync(tempDir, {recursive: true, force: true}));
+
+    test('fails loudly on an unknown option (not swallowed as a positional file path)', () => {
+        const {code, stdout} = runGuard(['--bogus']);
+        expect(code).not.toBe(0);
+        expect(stdout.toLowerCase()).toContain('unknown option');
+    });
+
+    test('fails loudly on a missing value for --base / --dirs / --ignore', () => {
+        for (const flag of ['--base', '--dirs', '--ignore']) {
+            const {code, stdout} = runGuard([flag]);
+            expect(code, `${flag} with no value must error`).not.toBe(0);
+            expect(stdout.toLowerCase()).toContain('argument missing');
+        }
+    });
+
+    test('accepts --dirs=<value> (equals form) and honors it', () => {
+        const {code, stdout} = runGuard([`--dirs=${tempDir}`]);
+        expect(code).toBe(1);
+        expect(stdout).toContain('#11111');
+    });
+
+    test('accepts --dirs <value> (space-separated form)', () => {
+        const {code, stdout} = runGuard(['--dirs', tempDir]);
+        expect(code).toBe(1);
+        expect(stdout).toContain('#11111');
+    });
+
+    test('accepts the -q boolean flag (suppresses the per-violation listing)', () => {
+        const {code, stdout} = runGuard(['-q', '--dirs', tempDir]);
+        expect(code).toBe(1);
+        expect(stdout).toContain('decay-prone');
+        expect(stdout).not.toContain('probe.mjs:');
+    });
+
+    test('accepts a positional file path', () => {
+        const {code, stdout} = runGuard([probe]);
+        expect(code).toBe(1);
+        expect(stdout).toContain('#11111');
+    });
+});
+
+test.describe('the receipt reports what was READ, not what was selected', () => {
+    test('an unreadable selected file is never counted as read', () => {
+        // Selection and IO diverge. A selected path that fails to open warns and is skipped; reporting
+        // the SELECTED count as the scanned one is a green claim about a file nobody opened.
+        expect(describeRead(0, 1)).toBe('0 file(s) read, 1 unreadable');
+        expect(describeRead(7, 9)).toBe('7 file(s) read, 2 unreadable')
+    });
+
+    test('CONTROL: a fully-read run says nothing about unreadable files', () => {
+        // Otherwise "names the unreadable count" is equally consistent with an always-present suffix,
+        // which carries no information.
+        expect(describeRead(3, 3)).toBe('3 file(s) read')
+    });
+
+    test('the CLI does not claim to have read a missing file', () => {
+        // The reviewer falsifier, committed: previously `1 file(s) scanned, 0 violations`, exit 0.
+        const {code, stdout} = runGuard(['src/doesNotExist17435.mjs']);
+
+        expect(code).toBe(0);
+        expect(stdout).toContain('could not read');
+        expect(stdout).toContain('0 file(s) read, 1 unreadable')
+    })
+});

--- a/test/playwright/unit/buildScripts/util/check-whitespace.spec.mjs
+++ b/test/playwright/unit/buildScripts/util/check-whitespace.spec.mjs
@@ -1,0 +1,149 @@
+import { test, expect }  from '@playwright/test';
+import { execSync }      from 'node:child_process';
+import path              from 'node:path';
+import fs                from 'node:fs';
+import os                from 'node:os';
+import { fileURLToPath } from 'node:url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname  = path.dirname(__filename);
+const utilDir    = path.resolve(__dirname, '../../../../../buildScripts/util');
+
+/**
+ * Self-test for the trailing-whitespace guard, focused on the merge-inheritance boundary.
+ *
+ * The guard reads the staged set, and a merge stages every file it brings in — including the sync
+ * pipeline's content, whose trailing whitespace is CORRECT (markdown hard line breaks) and which the
+ * pipeline itself commits with `--no-verify` for exactly that reason. That escape belongs to a
+ * trusted CI job; a maintainer inheriting those commits through `git merge origin/dev` has no such
+ * hatch, so an inherited file must not be blamed on the merging branch. A file hand-edited during
+ * the merge is still authoring and still fails.
+ */
+test.describe('check-whitespace.mjs — merge inheritance', () => {
+    let tempDir, scriptPath;
+
+    test.beforeEach(() => {
+        tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'neo-ws-test-'));
+        execSync('git init', { cwd: tempDir, stdio: 'ignore' });
+        execSync('git config user.email "test@example.com"', { cwd: tempDir, stdio: 'ignore' });
+        execSync('git config user.name "Test User"', { cwd: tempDir, stdio: 'ignore' });
+        execSync('git commit --allow-empty -m "Init"', { cwd: tempDir, stdio: 'ignore' });
+
+        // The script anchors to the repo that owns it, so it must live inside the temp repo — and it
+        // needs its shared helper alongside, exactly as it sits on disk.
+        scriptPath = path.join(tempDir, 'buildScripts/util/check-whitespace.mjs');
+        fs.mkdirSync(path.dirname(scriptPath), { recursive: true });
+        fs.copyFileSync(path.join(utilDir, 'check-whitespace.mjs'), scriptPath);
+        fs.copyFileSync(path.join(utilDir, 'mergeInheritance.mjs'), path.join(tempDir, 'buildScripts/util/mergeInheritance.mjs'));
+
+        execSync('git checkout -b dev', { cwd: tempDir, stdio: 'ignore' });
+    });
+
+    test.afterEach(() => {
+        fs.rmSync(tempDir, { recursive: true, force: true });
+    });
+
+    const runOn = files => {
+        try {
+            execSync(`node ${scriptPath} ${files.join(' ')}`, { cwd: tempDir, encoding: 'utf-8', stdio: 'pipe' });
+            return { status: 0, output: '' };
+        } catch (error) {
+            return { status: error.status, output: error.stderr || error.stdout || '' };
+        }
+    };
+
+    const writeFile = (relPath, content) => {
+        const full = path.join(tempDir, relPath);
+        fs.mkdirSync(path.dirname(full), { recursive: true });
+        fs.writeFileSync(full, content);
+        return relPath;
+    };
+
+    // Trailing whitespace as the sync pipeline legitimately produces it: markdown hard line breaks.
+    const PIPELINE_CONTENT = 'a line ending in a hard break   \nanother   \n';
+
+    const startMergeCarryingWhitespace = () => {
+        execSync('git checkout -b sync-pipeline-source', { cwd: tempDir, stdio: 'ignore' });
+        writeFile('resources/content/discussions/d-1.md', PIPELINE_CONTENT);
+        execSync('git add -A', { cwd: tempDir, stdio: 'ignore' });
+        execSync('git commit -m "chore(data): Hourly data sync pipeline update"', { cwd: tempDir, stdio: 'ignore' });
+        execSync('git checkout dev', { cwd: tempDir, stdio: 'ignore' });
+        execSync('git merge --no-commit --no-ff sync-pipeline-source', { cwd: tempDir, stdio: 'ignore' });
+    };
+
+    test('an ORDINARY commit still fails on trailing whitespace — the guard is intact', () => {
+        writeFile('src/foo.mjs', 'const a = 1;   \n');
+        execSync('git add -A', { cwd: tempDir, stdio: 'ignore' });
+
+        const result = runOn(['src/foo.mjs']);
+
+        expect(result.status).toBe(1);
+        expect(result.output).toContain('Trailing whitespace found in src/foo.mjs:1');
+    });
+
+    test('a merge-INHERITED file passes — the pipeline authored it, this branch did not', () => {
+        startMergeCarryingWhitespace();
+
+        expect(runOn(['resources/content/discussions/d-1.md']).status).toBe(0);
+    });
+
+    test('a file HAND-EDITED during the merge still fails — authoring in a merge is still authoring', () => {
+        startMergeCarryingWhitespace();
+
+        // Different bytes than the merge brought in: this is an edit, so it diverges from MERGE_HEAD.
+        writeFile('resources/content/discussions/d-1.md', PIPELINE_CONTENT + 'hand-edited   \n');
+        execSync('git add resources/content/discussions/d-1.md', { cwd: tempDir, stdio: 'ignore' });
+
+        const result = runOn(['resources/content/discussions/d-1.md']);
+
+        expect(result.status).toBe(1);
+        expect(result.output).toContain('Trailing whitespace found in');
+    });
+
+    test('inherited and authored files are judged per-file inside ONE merge', () => {
+        startMergeCarryingWhitespace();
+
+        writeFile('src/mine.mjs', 'const b = 2;   \n');
+        execSync('git add src/mine.mjs', { cwd: tempDir, stdio: 'ignore' });
+
+        const result = runOn(['resources/content/discussions/d-1.md', 'src/mine.mjs']);
+
+        expect(result.status).toBe(1);
+        expect(result.output).toContain('src/mine.mjs');
+        expect(result.output).not.toContain('d-1.md');
+    });
+
+    test('absolute paths resolve the same as repo-relative ones — lint-staged passes absolute', () => {
+        startMergeCarryingWhitespace();
+
+        expect(runOn([path.join(tempDir, 'resources/content/discussions/d-1.md')]).status).toBe(0);
+    });
+
+    // NOTE ON WHAT IS *NOT* PINNED HERE. Two obvious-looking witnesses were written and deleted for
+    // being vacuous — they passed against the un-fixed helper, so they proved nothing:
+    //   · an INHERITED tab-bearing path: absent from the diverged set either way (quoted or not), so
+    //     both versions skip it. Same verdict, different reason — it cannot discriminate.
+    //   · a Windows-separator candidate: on POSIX `path.sep` IS `/`, so the normalization is an
+    //     identity no-op and the assertion cannot fail on this CI. The Win32 arm of
+    //     `.split(path.sep).join('/')` is reasoned, not proven — stated in the PR rather than
+    //     dressed in a green test.
+    // The authored-tab witness below is the real one: it reproduces the fail-open.
+    test('a TAB-bearing path AUTHORED during the merge still fails — without -z, git quotes it and the guard SKIPS it', () => {
+        execSync('git checkout -b sync-odd-names-2', { cwd: tempDir, stdio: 'ignore' });
+        writeFile('resources/content/discussions/tab\there.md', PIPELINE_CONTENT);
+        execSync('git add -A', { cwd: tempDir, stdio: 'ignore' });
+        execSync('git commit -m "chore(data): Hourly data sync pipeline update"', { cwd: tempDir, stdio: 'ignore' });
+        execSync('git checkout dev', { cwd: tempDir, stdio: 'ignore' });
+        execSync('git merge --no-commit --no-ff sync-odd-names-2', { cwd: tempDir, stdio: 'ignore' });
+
+        // Diverge it: now it is authored here, quoting or not.
+        writeFile('resources/content/discussions/tab\there.md', PIPELINE_CONTENT + 'edited   \n');
+        execSync('git add -A', { cwd: tempDir, stdio: 'ignore' });
+
+        const result = runOn(['"resources/content/discussions/tab\there.md"']);
+
+        expect(result.status).toBe(1);
+        expect(result.output).toContain('Trailing whitespace found in');
+    });
+
+});

--- a/test/playwright/unit/buildScripts/util/developmentThemeAssets.spec.mjs
+++ b/test/playwright/unit/buildScripts/util/developmentThemeAssets.spec.mjs
@@ -1,0 +1,359 @@
+import {test, expect} from '@playwright/test';
+import fs             from 'node:fs';
+import os             from 'node:os';
+import path           from 'node:path';
+
+import {
+    DEVELOPMENT_THEME_BUILD_COMMAND,
+    ensureDevelopmentThemeAssets,
+    inspectDevelopmentThemeAssets
+} from '../../../../../buildScripts/util/developmentThemeAssets.mjs';
+import webpackServerConfig, {
+    createDevelopmentThemeFreshnessHooks,
+    DEVELOPMENT_THEME_RECHECK_INTERVAL_MS
+} from '../../../../../buildScripts/webpack/webpack.server.config.mjs';
+
+/**
+ * @summary Pins the ordinary E2E theme preflight across fresh, missing, stale, failed-build,
+ * incomplete-output, and foreign-symlink states.
+ */
+test.describe('buildScripts/util/developmentThemeAssets (#15449)', () => {
+    const roots = [];
+
+    function createRoot() {
+        const root = fs.mkdtempSync(path.join(os.tmpdir(), 'neo-e2e-themes-'));
+
+        roots.push(root);
+        return root
+    }
+
+    function writeFile(root, relativePath, mtimeMs, content='fixture') {
+        const file = path.join(root, relativePath);
+
+        fs.mkdirSync(path.dirname(file), {recursive: true});
+        fs.writeFileSync(file, content);
+        fs.utimesSync(file, mtimeMs / 1000, mtimeMs / 1000)
+    }
+
+    function materialize(root, mtimeMs=Date.now()) {
+        writeFile(root, 'resources/theme-map.json', mtimeMs, JSON.stringify({
+            Neo: {Global: ['src', 'theme-neo-dark']}
+        }));
+        writeFile(root, 'dist/development/css/src/Global.css', mtimeMs);
+        writeFile(root, 'dist/development/css/theme-neo-dark/Global.css', mtimeMs)
+    }
+
+    function seedScss(root, mtimeMs=1000) {
+        writeFile(root, 'resources/scss/src/Global.scss', mtimeMs);
+        writeFile(root, 'resources/scss/theme-neo-dark/Global.scss', mtimeMs)
+    }
+
+    test.afterAll(() => {
+        roots.forEach(root => fs.rmSync(root, {force: true, recursive: true}))
+    });
+
+    test('fresh outputs do not rebuild', async () => {
+        const root   = createRoot();
+        let   builds = 0;
+
+        seedScss(root, 1000);
+        materialize(root, 2000);
+
+        const result = await ensureDevelopmentThemeAssets({
+            repoRoot: root,
+            build   : async () => builds++,
+            logger  : {log() {}}
+        });
+
+        expect(result.built).toBe(false);
+        expect(result.state.ready).toBe(true);
+        expect(builds).toBe(0)
+    });
+
+    test('a fresh map missing one census root entry is incomplete and triggers exactly one build', async () => {
+        const root   = createRoot();
+        let   builds = 0;
+
+        seedScss(root, 1000);
+        materialize(root, 2000);
+        writeFile(root, 'resources/theme-map.json', 3000, JSON.stringify({
+            Neo: {Global: ['src']} // fresh, parseable, non-empty — but theme-neo-dark is not reachable
+        }));
+
+        const state = inspectDevelopmentThemeAssets({repoRoot: root});
+
+        expect(state.ready).toBe(false);
+        expect(state.invalidMap).toBe(null);
+        expect(state.mapMissing).toEqual(['Neo.Global (theme-neo-dark)']);
+
+        const result = await ensureDevelopmentThemeAssets({
+            repoRoot: root,
+            build   : async () => {
+                builds++;
+                materialize(root, 4000)
+            },
+            logger: {log() {}}
+        });
+
+        expect(result.built).toBe(true);
+        expect(result.state.ready).toBe(true);
+        expect(builds).toBe(1)
+    });
+
+    test('a fresh map missing a census class entirely is incomplete and triggers exactly one build', async () => {
+        const root   = createRoot();
+        let   builds = 0;
+
+        seedScss(root, 1000);
+        writeFile(root, 'resources/scss/src/button/Base.scss', 1000);
+        materialize(root, 2000);
+        writeFile(root, 'dist/development/css/src/button/Base.css', 2000);
+
+        const state = inspectDevelopmentThemeAssets({repoRoot: root});
+
+        expect(state.ready).toBe(false);
+        expect(state.mapMissing).toEqual(['Neo.button.Base (src)']);
+
+        const result = await ensureDevelopmentThemeAssets({
+            repoRoot: root,
+            build   : async () => {
+                builds++;
+                materialize(root, 4000);
+                writeFile(root, 'resources/theme-map.json', 4000, JSON.stringify({
+                    Neo: {Global: ['src', 'theme-neo-dark'], button: {Base: ['src']}}
+                }))
+            },
+            logger: {log() {}}
+        });
+
+        expect(result.built).toBe(true);
+        expect(result.state.ready).toBe(true);
+        expect(builds).toBe(1)
+    });
+
+    test('the SCSS source tree, not additive retired theme-map entries, owns the CSS census', () => {
+        const root = createRoot();
+
+        seedScss(root, 1000);
+        materialize(root, 2000);
+        writeFile(root, 'resources/theme-map.json', 2000, JSON.stringify({
+            'Neo.apps.agentos.RetiredPanel': ['src', 'theme-neo-dark'],
+            Neo                            : {Global: ['src', 'theme-neo-dark']}
+        }));
+
+        const state = inspectDevelopmentThemeAssets({repoRoot: root});
+
+        expect(state.ready).toBe(true);
+        expect(state.expectedCss).toEqual([
+            path.join('dist/development/css/src/Global.css'),
+            path.join('dist/development/css/theme-neo-dark/Global.css')
+        ]);
+        expect(state.missing).toEqual([])
+    });
+
+    for (const missingPath of [
+        'resources/theme-map.json',
+        'dist/development/css/theme-neo-dark/Global.css'
+    ]) {
+        test(`a missing ${missingPath} triggers exactly one canonical build`, async () => {
+            const root   = createRoot();
+            let   builds = 0;
+
+            seedScss(root, 1000);
+            materialize(root, 2000);
+            fs.rmSync(path.join(root, missingPath));
+
+            const result = await ensureDevelopmentThemeAssets({
+                repoRoot: root,
+                build   : async () => {
+                    builds++;
+                    materialize(root, 3000)
+                },
+                logger: {log() {}}
+            });
+
+            expect(result.built).toBe(true);
+            expect(result.state.ready).toBe(true);
+            expect(builds).toBe(1)
+        })
+    }
+
+    for (const stalePath of [
+        'resources/theme-map.json',
+        'dist/development/css/src/Global.css'
+    ]) {
+        test(`a stale ${stalePath} triggers exactly one canonical build`, async () => {
+            const root   = createRoot();
+            let   builds = 0;
+
+            seedScss(root, 2000);
+            materialize(root, 3000);
+            fs.utimesSync(path.join(root, stalePath), 1, 1);
+
+            const result = await ensureDevelopmentThemeAssets({
+                repoRoot: root,
+                build   : async () => {
+                    builds++;
+                    materialize(root, 4000)
+                },
+                logger: {log() {}}
+            });
+
+            expect(result.built).toBe(true);
+            expect(result.state.ready).toBe(true);
+            expect(builds).toBe(1)
+        })
+    }
+
+    test('a failed builder aborts before browser startup and names the canonical recovery command', async () => {
+        const root = createRoot();
+
+        seedScss(root);
+
+        await expect(ensureDevelopmentThemeAssets({
+            repoRoot: root,
+            build   : async () => { throw new Error('exit code 7') },
+            logger  : {log() {}}
+        })).rejects.toThrow(`exit code 7\nRecovery: ${DEVELOPMENT_THEME_BUILD_COMMAND}`)
+    });
+
+    test('a successful but incomplete builder aborts after exactly one attempt', async () => {
+        const root   = createRoot();
+        let   builds = 0;
+
+        seedScss(root);
+
+        await expect(ensureDevelopmentThemeAssets({
+            repoRoot: root,
+            build   : async () => builds++,
+            logger  : {log() {}}
+        })).rejects.toThrow(`Recovery: ${DEVELOPMENT_THEME_BUILD_COMMAND}`);
+
+        expect(builds).toBe(1)
+    });
+
+    test('a symlink-borrowed output is never accepted as checkout-local readiness', () => {
+        const root       = createRoot(),
+              foreign    = createRoot(),
+              linkedPath = path.join(root, 'dist/development/css/src/Global.css');
+
+        seedScss(root, 1000);
+        materialize(root, 2000);
+        writeFile(foreign, 'Global.css', 3000);
+        fs.rmSync(linkedPath);
+        fs.symlinkSync(path.join(foreign, 'Global.css'), linkedPath);
+
+        const state = inspectDevelopmentThemeAssets({repoRoot: root});
+
+        expect(state.ready).toBe(false);
+        expect(state.symlinked).toContain('dist/development/css/src/Global.css')
+    })
+});
+
+/**
+ * @summary Pins the development-server consumer: startup inspection, bounded request-time
+ * revalidation, transition-based warning de-duplication, and fail-soft request handling.
+ */
+test.describe('webpack development-theme freshness hooks (#15666)', () => {
+    test('the live config wires a 5s guard before static serving', () => {
+        const staticMiddleware = {name: 'express-static', middleware() {}};
+        const middlewares      = webpackServerConfig.devServer.setupMiddlewares([staticMiddleware]);
+
+        expect(DEVELOPMENT_THEME_RECHECK_INTERVAL_MS).toBe(5000);
+        expect(webpackServerConfig.devServer.static.watch).toBe(false);
+        expect(typeof webpackServerConfig.devServer.onListening).toBe('function');
+        expect(middlewares[0].name).toBe('development-theme-freshness');
+        expect(middlewares[1]).toBe(staticMiddleware)
+    });
+
+    test('startup + bounded CSS requests warn once per fresh-to-stale transition', () => {
+        const
+            readyStates = [false, false, true, false],
+            warnings    = [];
+
+        let inspections = 0,
+            nextCalls   = 0,
+            now         = 0;
+
+        const hooks = createDevelopmentThemeFreshnessHooks({
+            inspect: () => ({ready: readyStates[inspections++]}),
+            logger : {warn: message => warnings.push(message)},
+            now    : () => now
+        });
+        const middleware = hooks.setupMiddlewares([])[0].middleware;
+
+        hooks.onListening();
+
+        const requestAt = time => {
+            now = time;
+            middleware(
+                {url: '/dist/development/css/src/Global.css?theme=dark'},
+                {},
+                () => nextCalls++
+            )
+        };
+
+        requestAt(4999);  // startup result is reused
+        requestAt(5000);  // stale revalidation, warning stays de-duped
+        requestAt(9999);  // second result is reused
+        requestAt(10000); // rebuild observed: fresh
+        requestAt(15000); // next fresh -> stale transition warns again
+
+        expect(inspections).toBe(4);
+        expect(nextCalls).toBe(5);
+        expect(warnings).toHaveLength(2);
+        warnings.forEach(message => {
+            expect(message).toContain(DEVELOPMENT_THEME_BUILD_COMMAND)
+        })
+    });
+
+    test('inspection errors never block responses and stay de-duped until a successful check', () => {
+        const warnings = [];
+
+        let inspections = 0,
+            mode        = 'error',
+            nextCalls   = 0,
+            now         = 0;
+
+        const hooks = createDevelopmentThemeFreshnessHooks({
+            inspect: () => {
+                inspections++;
+                if (mode === 'error') throw new Error('fixture inspection failed');
+                return {ready: true}
+            },
+            logger: {warn: message => warnings.push(message)},
+            now   : () => now
+        });
+        const middleware = hooks.setupMiddlewares([])[0].middleware;
+
+        expect(() => hooks.onListening()).not.toThrow();
+
+        now = 5000;
+        expect(() => middleware(
+            {url: '/dist/development/css/src/Global.css'},
+            {},
+            () => nextCalls++
+        )).not.toThrow();
+
+        expect(inspections).toBe(2);
+        expect(nextCalls).toBe(1);
+        expect(warnings).toHaveLength(1);
+
+        mode = 'fresh';
+        now  = 10000;
+        middleware({url: '/dist/development/css/src/Global.css'}, {}, () => nextCalls++);
+
+        mode = 'error';
+        now  = 15000;
+        middleware({url: '/dist/development/css/src/Global.css'}, {}, () => nextCalls++);
+
+        now = 20000;
+        middleware({url: '/src/Neo.mjs'}, {}, () => nextCalls++);
+
+        expect(inspections).toBe(4); // the non-theme request never inspects
+        expect(nextCalls).toBe(4);
+        expect(warnings).toHaveLength(2); // a successful check reset the error transition
+        expect(warnings[0]).toContain('fixture inspection failed');
+        expect(warnings[0]).toContain(DEVELOPMENT_THEME_BUILD_COMMAND)
+    })
+});

--- a/test/playwright/unit/buildScripts/util/mergedPullRequestPush.spec.mjs
+++ b/test/playwright/unit/buildScripts/util/mergedPullRequestPush.spec.mjs
@@ -1,0 +1,109 @@
+import { test, expect }              from '@playwright/test';
+import {assessMergedPullRequestPush} from '../../../../../buildScripts/util/mergedPullRequestPush.mjs';
+
+/**
+ * Coordinates lifted from a real occurrence: a pull request merged at one head while its
+ * branch ref had already advanced past it, leaving the commits in between attached to no
+ * pull request and covered by no CI run.
+ */
+const
+    MERGED_HEAD   = 'ddf522a6feb4abf9faf4ad49af110d2a3a5c96b7',
+    ADVANCED_HEAD = 'a993b72075411b321d50908687e6445b44599156',
+    MERGE_COMMIT  = 'ad76ede9bfc8607314e98934e4ed2840629c23aa',
+    mergedPr      = {number: 16255, state: 'MERGED', mergedAt: '2026-08-01T11:27:27Z', headRefOid: MERGED_HEAD};
+
+test.describe('buildScripts/util/mergedPullRequestPush.assessMergedPullRequestPush (#16256)', () => {
+    test('warns on the incident signature — merged PR, head beyond it, not yet in the base line', () => {
+        expect(assessMergedPullRequestPush({
+            pullRequest        : mergedPr,
+            headSha            : ADVANCED_HEAD,
+            headContainedInBase: false
+        })).toEqual({warn: true, status: 'unreached-commits'});
+    });
+
+    test('stays silent when the branch never had a pull request', () => {
+        expect(assessMergedPullRequestPush({
+            pullRequest        : null,
+            headSha            : ADVANCED_HEAD,
+            headContainedInBase: false
+        })).toEqual({warn: false, status: 'no-pull-request'});
+    });
+
+    test('stays silent on an open pull request — the common path adds no noise', () => {
+        expect(assessMergedPullRequestPush({
+            pullRequest        : {...mergedPr, state: 'OPEN', mergedAt: null},
+            headSha            : ADVANCED_HEAD,
+            headContainedInBase: false
+        })).toEqual({warn: false, status: 'pull-request-open'});
+    });
+
+    test('stays silent on a closed-unmerged pull request — its branch can still be reopened', () => {
+        expect(assessMergedPullRequestPush({
+            pullRequest        : {...mergedPr, state: 'CLOSED', mergedAt: null},
+            headSha            : ADVANCED_HEAD,
+            headContainedInBase: false
+        })).toEqual({warn: false, status: 'pull-request-not-merged'});
+    });
+
+    test('stays silent when head is exactly what the pull request merged (a re-push of merged work)', () => {
+        expect(assessMergedPullRequestPush({
+            pullRequest        : mergedPr,
+            headSha            : MERGED_HEAD,
+            headContainedInBase: false
+        })).toEqual({warn: false, status: 'head-matches-merged-head'});
+    });
+
+    test('compares the merged head case-insensitively rather than treating case as a divergence', () => {
+        expect(assessMergedPullRequestPush({
+            pullRequest        : {...mergedPr, headRefOid: MERGED_HEAD.toUpperCase()},
+            headSha            : MERGED_HEAD,
+            headContainedInBase: false
+        })).toEqual({warn: false, status: 'head-matches-merged-head'});
+    });
+
+    test('stays silent when everything on the branch is already contained in the base line', () => {
+        expect(assessMergedPullRequestPush({
+            pullRequest        : mergedPr,
+            headSha            : ADVANCED_HEAD,
+            headContainedInBase: true
+        })).toEqual({warn: false, status: 'head-contained-in-base'});
+    });
+
+    test('does NOT key off the merge commit — under squash-merge it shares no ancestry with the head branch', () => {
+        // Passing the base-line merge commit as the pull request's head coordinate must not
+        // silence the guard: the incident head is still unreached work.
+        expect(assessMergedPullRequestPush({
+            pullRequest        : {...mergedPr, headRefOid: MERGE_COMMIT},
+            headSha            : ADVANCED_HEAD,
+            headContainedInBase: false
+        })).toEqual({warn: true, status: 'unreached-commits'});
+    });
+
+    test.describe('fail toward pushing — every unresolvable input stays silent', () => {
+        const unresolvable = [
+            ['pull-request state missing',      {pullRequest: {...mergedPr, state: undefined},    headSha: ADVANCED_HEAD, headContainedInBase: false}, 'pull-request-unresolved'],
+            ['pull-request state non-string',   {pullRequest: {...mergedPr, state: 7},            headSha: ADVANCED_HEAD, headContainedInBase: false}, 'pull-request-unresolved'],
+            ['local head unreadable',           {pullRequest: mergedPr,                          headSha: null,          headContainedInBase: false}, 'coordinates-unresolved'],
+            ['local head abbreviated',          {pullRequest: mergedPr,                          headSha: 'a993b72',     headContainedInBase: false}, 'coordinates-unresolved'],
+            ['merged head missing from the PR', {pullRequest: {...mergedPr, headRefOid: null},    headSha: ADVANCED_HEAD, headContainedInBase: false}, 'coordinates-unresolved'],
+            ['containment unknown (git errored)', {pullRequest: mergedPr,                        headSha: ADVANCED_HEAD, headContainedInBase: null},  'base-containment-unknown'],
+            ['pull request is not an object',   {pullRequest: 'MERGED',                          headSha: ADVANCED_HEAD, headContainedInBase: false}, 'no-pull-request']
+        ];
+
+        for (const [label, args, status] of unresolvable) {
+            test(`silent when ${label}`, () => {
+                expect(assessMergedPullRequestPush(args)).toEqual({warn: false, status});
+            });
+        }
+
+        test('the fallback cannot be flipped to blocking — the return shape has no block channel', () => {
+            // AC: a test that fails if the fallback is ever flipped to blocking. `warn` is the
+            // only actionable field the predicate can emit, so no input can request an exit.
+            for (const [, args] of unresolvable) {
+                const result = assessMergedPullRequestPush(args);
+                expect(Object.keys(result).sort()).toEqual(['status', 'warn']);
+                expect(result.warn).toBe(false);
+            }
+        });
+    });
+});

--- a/test/playwright/unit/buildScripts/util/stagedDiff.spec.mjs
+++ b/test/playwright/unit/buildScripts/util/stagedDiff.spec.mjs
@@ -1,0 +1,33 @@
+import {test, expect}                         from '@playwright/test';
+import {getStagedAddedLines, parseAddedLines} from '../../../../../buildScripts/util/stagedDiff.mjs';
+
+test.describe('buildScripts/util/stagedDiff.parseAddedLines (#13717)', () => {
+    test('returns an empty set for empty diff text', () => {
+        expect([...parseAddedLines('')]).toEqual([]);
+    });
+
+    test('single-line add (count omitted → defaults to 1)', () => {
+        expect([...parseAddedLines('@@ -0,0 +5 @@\n+new line')].sort((a, b) => a - b)).toEqual([5]);
+    });
+
+    test('multi-line add range', () => {
+        expect([...parseAddedLines('@@ -10,0 +11,3 @@\n+a\n+b\n+c')].sort((a, b) => a - b)).toEqual([11, 12, 13]);
+    });
+
+    test('multiple hunks union their added lines', () => {
+        const diff = '@@ -1,0 +2,1 @@\n+x\n@@ -20,0 +30,2 @@\n+y\n+z';
+        expect([...parseAddedLines(diff)].sort((a, b) => a - b)).toEqual([2, 30, 31]);
+    });
+
+    test('pure-deletion hunk (+c,0) adds nothing', () => {
+        expect([...parseAddedLines('@@ -5,2 +4,0 @@\n-gone\n-gone2')]).toEqual([]);
+    });
+});
+
+test.describe('buildScripts/util/stagedDiff.getStagedAddedLines (#13717)', () => {
+    test('returns null (not an empty set) on git failure so the caller falls back to whole-file', () => {
+        // A non-repo cwd makes `git diff` fail; null is the fail-closed signal (detection unavailable),
+        // which the archaeology filter treats as "flag all findings" rather than suppressing them.
+        expect(getStagedAddedLines('any.mjs', '/nonexistent-neo-archaeology-dir')).toBeNull();
+    });
+});


### PR DESCRIPTION
Resolves #17924

Related: #17922 · Refs #17791 · Refs #17920

21 `buildScripts` guards regain unit coverage they lost on 2026-08-27. `c623b2f63c` deleted 804 unit specs when the Agent OS left for `neomjs/neo-agent-brain`, selecting them by their `test/playwright/unit/ai/` **path prefix** rather than by their subject — so 30 specs whose implementation stayed at `buildScripts/**` went with them. This restores the 21 that pass verbatim into `test/playwright/unit/buildScripts/**`, the sibling directory that survived the same sweep precisely because it carries no `ai/` prefix. No implementation file is touched.

Evidence: L2 (full local `unit` suite, exit-code verified, plus a per-spec stub-mutation harness over all 21 subjects) → L2 required (every AC on #17924 is observable in the `unit` CI project). Residual: none.

## AC Evidence

| AC | Proof |
|---|---|
| AC-1 | **the 21 exist under `test/playwright/unit/buildScripts/**` and `npm run test-unit` exits 0** — CI-covered and **verified selected, not merely collected**: this PR's `unit` job ran **2430 passed**; the dev-equivalent baseline (PR #17917, a workflow-only branch off the same base) ran **2155 passed**. The restored specs contribute **+275 executing tests in CI**. Local: `npm run test-unit` → **exit 0, 2459 passed, 0 failed**. |
| AC-2 | **each of the 21 reds against a seeded mutation of its own subject** — Outside-CI: per-spec stub-mutation harness, **21/21 KILLED**. Receipts in `## Test Evidence`. |
| AC-3 | **collected spec-file count rises by exactly 21, measured by count** — `git ls-tree -r --name-only 32eebf7733 test/playwright/unit \| grep -c '\.spec\.mjs$'` → **256**; same command at this branch's HEAD → **277**. Delta **+21**, measured by file count, never by run colour. |
| AC-4 | **no implementation file under `buildScripts/**` is modified** — CI-covered by the diff itself: all 21 changed paths are under `test/playwright/unit/buildScripts/`. `git show --stat` → `21 files changed, 5183 insertions(+)`, zero deletions, zero `buildScripts/**` entries. |
| AC-5 | **no restored spec is trimmed to pass; every unrestorable spec names its drift and is filed** — Six specs are deferred, not trimmed — each with a named cause in `## Deltas from ticket` and retained by #17922. The one spec I did trim (`check-theme-surfaces.spec.mjs`) is **not in this PR** for exactly that reason. |

## Deltas from ticket

**Six of the 27 specs with a surviving subject are deferred rather than restored.** Five share one shape — the spec encodes an expectation *about* an `ai/**` artifact that correctly departed, so restoring it is a rewrite against current topology, not a restoration:

| deferred spec | cause |
|---|---|
| `DataSyncPipeline.spec.mjs` | reds on the missing `syncGithubWorkflow.mjs --emit-only` emission stage — the #17920 defect, witnessed. It belongs to that PR, where the fix makes it green. |
| `util/check-theme-surfaces.spec.mjs` | fixtures drive `--fm-*` tokens; `collectShellSeamFailures` and the Fleet Manager surface left in `07704934c3` (#17805). |
| `docs/RebuildContentIndexesAndSeo.spec.mjs` | reads `ai/services/github-workflow/SyncService.mjs`. |
| `release/PublishReleaseNoteOrphan.spec.mjs` | reads `ai/scripts/lifecycle/postReleaseSync.mjs`. |
| `util/WorkflowConcurrency.spec.mjs` | asserts `ai/services/memory-core/MemoryService.mjs` trips the parity lane. |
| `util/WorkflowScopeClassifier.spec.mjs` | expects `run_integration` / `run_components` admissions the classifier no longer makes post-split. |

**Structure is preserved rather than flattened.** The destination's 17 surviving specs are flat and camelCase; the restored set keeps `util/`, `docs/`, `build/`, `helpers/`, `release/`. Rationale: it mirrors `buildScripts/`'s own layout and keeps the diff a faithful move. No guard demands the flat form, and renaming 21 files would have meant inventing names for subjects like `docs/seo/generate.mjs`. Push back if you read the destination convention as binding.

**Two forms encode path depth, not one.** The relocation is one level shallower, so **28** specifiers were re-expressed across both `from '…'` imports and `path.resolve(__dirname, '…')` chains. *(Corrected from 34 — @neo-gpt-emmy's P2. An exact old-blob/new-blob comparison over the 21 added files finds 28 changed depth specifiers, 26 whitespace-only lines, 0 content changes and 0 line-count drift; reproduced independently.)* An import-shaped rewrite alone leaves every `__dirname` chain silently wrong.

**Fixture strings that contain an import statement are deliberately untouched.** In `util/check-examples-body-only.spec.mjs` the fixture bodies embed `import … from '../../…'` as *file content* written into a temp directory. Those paths are relative to that directory, not to the spec. My first pass rewrote three of them; the rewrite is depth-correct and assertion-wrong, and the spec still passes either way.

**One severed import.** `DataSyncPipeline.spec.mjs` pulls `CREDENTIAL_FAMILIES` from `ai/services/fleet/redactCredentials.mjs`, which left. It is replaced by a local shape list documented as *not* a mirror of that catalogue — the boundary assertion is by value, so drift cannot weaken it. That spec is deferred regardless; the sever is on the branch history only.

## Test Evidence

**Per-spec mutation (AC-2), an author-side receipt — this harness is not a shipped CI artifact.** For each restored spec its subject module is replaced by a stub preserving the export *shape* and removing the *behavior*, the spec alone is run, and the subject is restored from the in-memory original (never `git checkout`, which stages the file and would carry the mutation into the next commit).

A spec that stays green against a gutted subject never exercised it. **21/21 KILLED, 0 SURVIVED:**

```
KILLED  DataSyncWatchdog · build/themes · docs/index/PortalContentIndexes · docs/index/TicketIndex
KILLED  docs/seo/Generate · helpers/watchThemes · util/agent-push · util/branchFreshness
KILLED  util/check-block-alignment · util/check-branch-discipline · util/check-chore-sync
KILLED  util/check-codeql-extraction · util/check-fixed-sleeps · util/check-jsdoc-types
KILLED  util/check-parse · util/check-ticket-archaeology · util/developmentThemeAssets
KILLED  util/mergedPullRequestPush · util/stagedDiff · util/check-whitespace
KILLED  util/check-examples-body-only
```

The last two resolve their subject by CLI path rather than by import, so their stub swap was driven explicitly; both still red. The working tree was verified clean (`git status --short` empty) after every mutation round — no stub survived into the commit.

**Restoration fidelity.** Content comes from `git show c623b2f63c^:<path>`, never a hand-retyped copy. The 36 failures the first full run produced were triaged to cause before anything was excluded, which is how the six deferrals got named rather than dropped.

## Post-Merge Validation

- [x] **Discharged pre-merge.** Both items below were verifiable on the PR run itself, so I ran them rather than deferring: this PR's `unit` job reports **2430 passed** against the dev-equivalent baseline's **2155** (PR #17917's `unit` job, a workflow-only branch off the same base) — the 21 specs are selected and executing in CI, not merely present in the tree. A job that passes is not evidence that the new files ran; the count delta is.
- [ ] On `dev` after merge, the `unit` count holds at ~2430 rather than falling back toward 2155 — a regression to the baseline would mean the specs stopped being collected, which no run colour would show.

Residual-Owner: #17922

Note on the local/CI spread: local reports 2459 and CI 2430. That 29-test gap is present on the baseline too (local vs CI on unchanged code) and is pre-existing environment gating, not an artifact of this change.

## Commits

- `9a5566c` — restore the 21 verbatim-passing specs, re-express 28 depth-encoding specifiers

---

Authored by Grace (Opus 5, Claude Code). Session 916d5adf-0cb3-4668-bdb8-ade1d1cd5b42.

