### PR TITLE
fix(build): make a lost Data Sync stage and a frozen corpus loud (#17920)

### DIFF
--- a/buildScripts/dataSyncPipeline.mjs
+++ b/buildScripts/dataSyncPipeline.mjs
@@ -7,8 +7,8 @@ import {fileURLToPath}        from 'node:url';
 
 import {
     DEFAULT_CORPUS_PATH,
-    DEFAULT_MAX_CORPUS_AGE_HOURS,
-    FACET_PATHS
+    FACET_PATHS,
+    resolveMaxCorpusAgeHours
 }                             from './dataSyncWatchdog.mjs';
 
 /**
@@ -673,8 +673,14 @@ export async function readCorpusFacetCommitDates({
  * corpus that stops advancing while the derivation stage keeps rebuilding the portal from it and
  * committing the result — a green run, fresh derived commits, and a frozen source.
  *
- * Threshold is `DEFAULT_MAX_CORPUS_AGE_HOURS`, imported from the watchdog rather than restated, so the
- * two mechanisms cannot disagree about what "stale" means. It is deliberately NOT the pipeline's hourly
+ * Threshold comes from `resolveMaxCorpusAgeHours()`, the watchdog's own resolver, so the two mechanisms
+ * resolve one effective policy — including the `WATCHDOG_MAX_CORPUS_AGE_HOURS` override.
+ *
+ * **An earlier revision imported `DEFAULT_MAX_CORPUS_AGE_HOURS` and claimed the two "cannot disagree".
+ * That was false**: the constant is only the fallback, so with the override set this guard judged at 48h
+ * while the alarm judged at the override. A 60h corpus under a 72h override had this function rejecting
+ * all three facets while `evaluateBreach` returned `{breached: false}` for the same corpus.
+ * Sharing a default is not sharing policy; sharing the resolver is. It is deliberately NOT the hourly
  * cadence: a facet only commits when GitHub content actually changed, so a cadence-tight threshold would
  * breach on every quiet hour and be muted within a day. 48h catches this defect on day two instead of
  * day five, which is the improvement actually on offer; a tighter bound needs a producer that emits a
@@ -682,12 +688,13 @@ export async function readCorpusFacetCommitDates({
  *
  * @param {Object} options
  * @param {Object<String, String|null>} options.facetCommitDates Facet name → newest ISO commit date.
- * @param {Number} [options.maxAgeHours=DEFAULT_MAX_CORPUS_AGE_HOURS] Staleness bound.
+ * @param {Number} [options.maxAgeHours=resolveMaxCorpusAgeHours()] Staleness bound. Resolved per call,
+ *     so an override set after module load is still honoured.
  * @param {Date}   [options.now=new Date()] Clock, injected so the spec can witness a boundary.
  * @throws {Error} Naming every stale facet with its measured age, never just the first.
  * @returns {void}
  */
-export function assertCorpusFreshness({facetCommitDates, maxAgeHours = DEFAULT_MAX_CORPUS_AGE_HOURS, now = new Date()}) {
+export function assertCorpusFreshness({facetCommitDates, maxAgeHours = resolveMaxCorpusAgeHours(), now = new Date()}) {
     const stale = Object.entries(facetCommitDates).map(([facet, lastCommitAt]) => ({
         ageHours: lastCommitAt ? (now.getTime() - Date.parse(lastCommitAt)) / 3_600_000 : null,
         facet,

--- a/buildScripts/dataSyncPipeline.mjs
+++ b/buildScripts/dataSyncPipeline.mjs
@@ -5,6 +5,12 @@ import path                   from 'node:path';
 import process                from 'node:process';
 import {fileURLToPath}        from 'node:url';
 
+import {
+    DEFAULT_CORPUS_PATH,
+    DEFAULT_MAX_CORPUS_AGE_HOURS,
+    FACET_PATHS
+}                             from './dataSyncWatchdog.mjs';
+
 /**
  * @module buildScripts.dataSyncPipeline
  * @summary Runs the scheduled Data Sync emission from a verified `dev` head and
@@ -73,12 +79,66 @@ const
             // labels over GraphQL. That is a credentialled read, so `none` was a mis-declaration —
             // not a deliberate denial — and it failed exactly as `scopedStageEnv` promises a
             // mis-declared stage will.
-            args      : ['./buildScripts/docs/rebuildContentIndexesAndSeo.mjs', '--include-labels'],
-            command   : process.execPath,
-            label     : 'content indexes and SEO',
-            tokenScope: 'reader'
+            args               : ['./buildScripts/docs/rebuildContentIndexesAndSeo.mjs', '--include-labels'],
+            command            : process.execPath,
+            label              : 'content indexes and SEO',
+            requiresFreshCorpus: true,
+            tokenScope         : 'reader'
         }
     ];
+
+/**
+ * The emission stages this pipeline must run, declared INDEPENDENTLY of `emissionCommands`.
+ *
+ * The independence is the whole mechanism and it is easy to destroy by tidying: derive this list
+ * from `emissionCommands` and deleting a stage deletes its own expectation, so the assertion below
+ * passes on a pipeline that lost a generator. That is not a hypothetical — `c623b2f63c` removed the
+ * `GitHub Workflow corpus` entry and the run went *shorter*, not red, and stayed green for five days
+ * over a frozen corpus.
+ *
+ * This is a second hand-maintained list on purpose, which the credential vocabulary above rightly
+ * refuses to be. The distinction: `stageTokenSources` centralizes so selection and scrubbing cannot
+ * drift, because there drift is the defect. Here drift IS the signal — the list is the independent
+ * witness, and a witness derived from the thing it witnesses attests to nothing. Adding a stage is
+ * meant to cost an edit here; that edit is the review surface.
+ *
+ * It names only the stages the ENGINE owns. GitHub corpus PRODUCTION is deliberately absent: the
+ * emitter lives in the Agent OS repository, which consumes this Engine as a published package and is
+ * never imported by it, so the producer publishes the corpus INTO this repository and can never
+ * appear in `emissionCommands` again. An absent producer is therefore not detectable on this axis at
+ * all; {@link #assertCorpusFreshness} is the instrument that catches it, and the two axes together
+ * are what make `no-generated-changes` unreachable by having no generator.
+ * @type {String[]}
+ */
+export const REQUIRED_EMISSION_STAGES = ['install dependencies', 'content indexes and SEO'];
+
+/**
+ * @summary Refuses to run an emission whose stage set has lost a required stage.
+ *
+ * Fails BEFORE any stage runs. A pipeline missing a generator must not first publish whatever the
+ * survivors derive and then report the gap — the derived commit is the artifact that made the
+ * five-day outage look healthy.
+ *
+ * @param {Object}   [options]
+ * @param {Object[]} [options.stages=emissionCommands] The stage table to check.
+ * @param {String[]} [options.required=REQUIRED_EMISSION_STAGES] Labels that must be present.
+ * @throws {Error} Naming every missing label, never just the first.
+ * @returns {void}
+ */
+export function assertEmissionStageSet({stages = emissionCommands, required = REQUIRED_EMISSION_STAGES} = {}) {
+    const
+        present = new Set(stages.map(stage => stage.label)),
+        missing = required.filter(label => !present.has(label));
+
+    if (missing.length > 0) {
+        throw new Error(
+            `dataSyncPipeline: emission stage set is missing ${missing.map(label => `"${label}"`).join(', ')}. ` +
+            `Expected ${JSON.stringify(required)}, found ${JSON.stringify([...present])}. A stage that ` +
+            'vanishes from `emissionCommands` must turn this run RED, not shorter — a run that emits ' +
+            'less and still exits 0 is indistinguishable from a run with nothing to do.'
+        )
+    }
+}
 
 /**
  * @summary Builds the child environment for one emission stage, carrying exactly the credential
@@ -555,6 +615,100 @@ export function aggregateDeferredFailures(errors) {
 }
 
 /**
+ * @summary Reads each corpus facet's newest COMMIT date, the only honest freshness instrument here.
+ *
+ * Not `mtime`: this runs in an ephemeral Actions checkout where every file's mtime is checkout time,
+ * so an mtime probe certifies a five-day-old corpus as seconds fresh. Not the working tree either —
+ * the question is what the branch carries, which is what every downstream consumer clones.
+ *
+ * A facet with NO commit visible resolves to `null` rather than to a large age, and the assertion
+ * below treats that as stale. `null` here means "the instrument saw nothing", which for a corpus
+ * that is supposed to be published on a cadence is the loudest state, not the most permissive one.
+ *
+ * @param {Object}   options
+ * @param {String}   options.cwd Repository root.
+ * @param {Function} options.execute Child-process executor.
+ * @param {String}   [options.corpusPath=DEFAULT_CORPUS_PATH] Corpus root the facet subpaths hang off.
+ * @param {Object}   [options.facetPaths=FACET_PATHS] Facet name → subpaths, shared with the watchdog.
+ * @param {String}   [options.ref=remoteDevRef] The ref whose committed corpus is measured.
+ * @returns {Promise<Object<String, String|null>>} Facet name → newest ISO commit date, or `null`.
+ */
+export async function readCorpusFacetCommitDates({
+    cwd,
+    execute,
+    corpusPath = DEFAULT_CORPUS_PATH,
+    facetPaths = FACET_PATHS,
+    ref        = remoteDevRef
+}) {
+    const dates = {};
+
+    for (const [facet, subpaths] of Object.entries(facetPaths)) {
+        const observed = [];
+
+        for (const subpath of subpaths) {
+            // Newest-wins across a multi-path facet, matching `dataSyncWatchdog.latestCommitDate`:
+            // `issues` spans active + archive and consumers dual-source them, so an archive-only
+            // repair is maintenance rather than freshness. Measuring min-wins here would breach on
+            // a healthy corpus and train everyone to ignore the guard.
+            const {stdout} = await git(execute, cwd, [
+                'log', '-1', '--format=%cI', ref, '--', path.posix.join(corpusPath, subpath)
+            ]);
+
+            stdout.trim() && observed.push(stdout.trim())
+        }
+
+        dates[facet] = observed.length > 0 ?
+            observed.reduce((newest, date) => Date.parse(date) > Date.parse(newest) ? date : newest) :
+            null
+    }
+
+    return dates
+}
+
+/**
+ * @summary Refuses to DERIVE the portal from a corpus the pipeline is no longer producing.
+ *
+ * This is the axis that catches an absent producer. The stage-set assertion cannot: the emitter runs
+ * in the Agent OS repository, so its absence never shows up in `emissionCommands`. What shows up is a
+ * corpus that stops advancing while the derivation stage keeps rebuilding the portal from it and
+ * committing the result — a green run, fresh derived commits, and a frozen source.
+ *
+ * Threshold is `DEFAULT_MAX_CORPUS_AGE_HOURS`, imported from the watchdog rather than restated, so the
+ * two mechanisms cannot disagree about what "stale" means. It is deliberately NOT the pipeline's hourly
+ * cadence: a facet only commits when GitHub content actually changed, so a cadence-tight threshold would
+ * breach on every quiet hour and be muted within a day. 48h catches this defect on day two instead of
+ * day five, which is the improvement actually on offer; a tighter bound needs a producer that emits a
+ * heartbeat even when nothing changed, and that is not in this ticket.
+ *
+ * @param {Object} options
+ * @param {Object<String, String|null>} options.facetCommitDates Facet name → newest ISO commit date.
+ * @param {Number} [options.maxAgeHours=DEFAULT_MAX_CORPUS_AGE_HOURS] Staleness bound.
+ * @param {Date}   [options.now=new Date()] Clock, injected so the spec can witness a boundary.
+ * @throws {Error} Naming every stale facet with its measured age, never just the first.
+ * @returns {void}
+ */
+export function assertCorpusFreshness({facetCommitDates, maxAgeHours = DEFAULT_MAX_CORPUS_AGE_HOURS, now = new Date()}) {
+    const stale = Object.entries(facetCommitDates).map(([facet, lastCommitAt]) => ({
+        ageHours: lastCommitAt ? (now.getTime() - Date.parse(lastCommitAt)) / 3_600_000 : null,
+        facet,
+        lastCommitAt
+    })).filter(({ageHours}) => ageHours === null || ageHours > maxAgeHours);
+
+    if (stale.length > 0) {
+        throw new Error(
+            'dataSyncPipeline: refusing to derive the portal from a stale corpus — ' +
+            stale.map(({ageHours, facet, lastCommitAt}) => lastCommitAt ?
+                `\`${facet}\` is ${ageHours.toFixed(1)}h old (threshold ${maxAgeHours}h)` :
+                `no commit visible for \`${facet}\``
+            ).join(', ') +
+            '. The derivation stage reads this corpus and commits what it produces, so deriving from a ' +
+            'frozen source publishes fresh-looking artifacts over stale facts. If the producer is down, ' +
+            'that is the finding; a shorter green run is not.'
+        )
+    }
+}
+
+/**
  * @summary Runs the complete generated-output emission sequence for one fresh-head attempt.
  * @param {Object}   options
  * @param {Number}   options.attempt Current attempt number.
@@ -571,6 +725,11 @@ export async function emitGeneratedData({
     execute = executeCommand,
     log     = console.log
 }) {
+
+    // BEFORE any stage runs, and before any artifact is produced. A pipeline that has lost a stage
+    // must not first publish what the survivors derive and then mention the gap — that derived
+    // commit is precisely what made five days of a frozen corpus read as healthy.
+    assertEmissionStageSet();
 
     // EVERY deferred failure, not the last one. A single slot silently dropped three of the four
     // DevIndex stages when one denial failed them all, so the run reported one cause and hid the
@@ -595,9 +754,25 @@ export async function emitGeneratedData({
         command,
         label,
         publishGeneratedProgressOnFailure = false,
+        requiresFreshCorpus = false,
         tokenScope
     } of emissionCommands) {
         log(`[DataSync] emit attempt=${attempt} stage=${label} credential=${tokenScope}`);
+
+        // A per-stage flag, like `publishGeneratedProgressOnFailure` beside it, and unlike the
+        // `requiresCredential` flag this file rightly refused: that one would have restated
+        // `tokenScope`, free to drift from it. This declares something nothing else declares —
+        // which stages CONSUME the corpus — and only the consumer can be refused an input.
+        if (requiresFreshCorpus) {
+            const facetCommitDates = await readCorpusFacetCommitDates({cwd, execute});
+
+            log(
+                `[DataSync] emit attempt=${attempt} stage=${label} corpus=` +
+                Object.entries(facetCommitDates).map(([facet, date]) => `${facet}@${date ?? 'none'}`).join(' ')
+            );
+
+            assertCorpusFreshness({facetCommitDates})
+        }
 
         try {
             await execute(command, args, {cwd, env: scopedStageEnv(tokenScope)})

--- a/buildScripts/dataSyncWatchdog.mjs
+++ b/buildScripts/dataSyncWatchdog.mjs
@@ -207,6 +207,31 @@ export function parseThreshold({name, raw, fallback}) {
 }
 
 /**
+ * @summary The ONE effective corpus-age policy, resolved the same way for every consumer.
+ *
+ * The pipeline's freshness guard and this watchdog's alarm judge the same corpus, so they must
+ * resolve the same number or they can contradict each other about it. Importing
+ * `DEFAULT_MAX_CORPUS_AGE_HOURS` is NOT that: the constant is the fallback, while the operative
+ * value is `WATCHDOG_MAX_CORPUS_AGE_HOURS` when it is set. A consumer holding the constant sees
+ * 48h while this tool sees the override, so a 60h corpus under a 72h override is stale to one and
+ * fresh to the other. Sharing a default is not sharing policy.
+ *
+ * Resolved per call rather than at module load, so the value cannot be frozen by import order and
+ * a test can drive it through `env` without mutating the process.
+ *
+ * @param {Object} [env=process.env] Environment to resolve from.
+ * @returns {Number} Effective maximum corpus age in hours.
+ * @throws {Error} Via {@link parseThreshold} when the override is present but not a positive number.
+ */
+export function resolveMaxCorpusAgeHours(env = process.env) {
+    return parseThreshold({
+        name    : 'WATCHDOG_MAX_CORPUS_AGE_HOURS',
+        raw     : env.WATCHDOG_MAX_CORPUS_AGE_HOURS,
+        fallback: DEFAULT_MAX_CORPUS_AGE_HOURS
+    })
+}
+
+/**
  * Parses the facet-list env var with the same loud discipline as `parseThreshold`:
  * absent or empty falls back to the default set, but a PRESENT value that resolves to
  * zero names (comma/whitespace-only — the realistic shape of an unset-vars composition
@@ -441,7 +466,9 @@ async function main() {
         corpusPath             = process.env.WATCHDOG_CORPUS_PATH || DEFAULT_CORPUS_PATH,
         maxConsecutiveFailures = parseThreshold({name: 'WATCHDOG_MAX_CONSECUTIVE_FAILURES', raw: process.env.WATCHDOG_MAX_CONSECUTIVE_FAILURES, fallback: DEFAULT_MAX_CONSECUTIVE_FAILURES}),
         maxSuccessAgeHours     = parseThreshold({name: 'WATCHDOG_MAX_SUCCESS_AGE_HOURS', raw: process.env.WATCHDOG_MAX_SUCCESS_AGE_HOURS, fallback: DEFAULT_MAX_SUCCESS_AGE_HOURS}),
-        maxCorpusAgeHours      = parseThreshold({name: 'WATCHDOG_MAX_CORPUS_AGE_HOURS', raw: process.env.WATCHDOG_MAX_CORPUS_AGE_HOURS, fallback: DEFAULT_MAX_CORPUS_AGE_HOURS}),
+        // Through the shared resolver, not a second inline `parseThreshold` — a duplicated
+        // resolution site is how the pipeline and this tool came to hold different numbers.
+        maxCorpusAgeHours      = resolveMaxCorpusAgeHours(process.env),
         dryRun                 = process.env.WATCHDOG_DRY_RUN === 'true' || args.has('--dry-run'),
         forceBreach            = process.env.WATCHDOG_FORCE_BREACH === 'true',
         forceRecovery          = process.env.WATCHDOG_FORCE_RECOVERY === 'true',

--- a/buildScripts/dataSyncWatchdog.mjs
+++ b/buildScripts/dataSyncWatchdog.mjs
@@ -65,6 +65,11 @@ const
      * freshness is the newest commit across both (an archive-only repair is maintenance).
      * `WATCHDOG_CORPUS_FACETS` overrides the NAME list only; unknown names get a single
      * subpath equal to their name.
+     *
+     * EXPORTED because the pipeline's own freshness guard measures the same corpus this
+     * axis measures. Two hand-maintained facet lists is how a facet gets added to the watchdog and
+     * missed by the guard — the guard then certifies a corpus one third of which it never looked
+     * at, and that failure is silent. One declaration, two consumers.
      * @type {Object<String, String[]>}
      */
     FACET_PATHS = {
@@ -73,6 +78,8 @@ const
         discussions: ['discussions']
     },
     DEFAULT_CORPUS_FACETS            = Object.keys(FACET_PATHS);
+
+export {DEFAULT_CORPUS_PATH, DEFAULT_MAX_CORPUS_AGE_HOURS, FACET_PATHS};
 
 /**
  * Reduces the newest-first completed run history to the streak facts.

--- a/test/playwright/unit/buildScripts/dataSyncPipeline.spec.mjs
+++ b/test/playwright/unit/buildScripts/dataSyncPipeline.spec.mjs
@@ -8,6 +8,10 @@ import {
     readCorpusFacetCommitDates,
     REQUIRED_EMISSION_STAGES
 }                     from '../../../../buildScripts/dataSyncPipeline.mjs';
+import {
+    evaluateBreach,
+    resolveMaxCorpusAgeHours
+}                     from '../../../../buildScripts/dataSyncWatchdog.mjs';
 
 const
     NOW   = new Date('2026-08-31T12:00:00Z'),
@@ -147,6 +151,80 @@ test.describe('dataSyncPipeline guards (#17920)', () => {
                 maxAgeHours     : 48,
                 now             : NOW
             })).toThrow()
+        });
+
+        // The guard and the alarm judge the SAME corpus, so they must resolve the same number.
+        // An earlier revision imported `DEFAULT_MAX_CORPUS_AGE_HOURS` — the fallback, not the
+        // policy — so with `WATCHDOG_MAX_CORPUS_AGE_HOURS` set the guard judged at 48h while the
+        // alarm judged at the override, and the two contradicted each other about one corpus.
+        // Kept as a standing control: 60h corpus, 72h policy.
+        test('a 60h corpus under a 72h override is fresh to BOTH the guard and the alarm', () => {
+            const
+                corpusAt  = hours(60),
+                effective = resolveMaxCorpusAgeHours({WATCHDOG_MAX_CORPUS_AGE_HOURS: '72'});
+
+            expect(effective).toBe(72);
+
+            // The guard, resolving through the shared policy rather than the imported default.
+            expect(() => assertCorpusFreshness({
+                facetCommitDates: {...fresh, issues: corpusAt},
+                maxAgeHours     : effective,
+                now             : NOW
+            })).not.toThrow();
+
+            // The alarm, on the same corpus and the same resolved policy.
+            expect(evaluateBreach({
+                consecutiveFailures: 0,
+                corpusFacets       : [{ageHours: 60, facet: 'issues', lastCommitAt: corpusAt}],
+                lastSuccessAt      : hours(1),
+                maxCorpusAgeHours  : effective,
+                now                : NOW
+            }).breached).toBe(false)
+        });
+
+        // The same corpus with NO override: both must now judge it stale at the 48h fallback.
+        // Without this arm the control above passes for a guard that ignores the corpus entirely.
+        test('the same 60h corpus is stale to BOTH once the override is absent', () => {
+            const
+                corpusAt  = hours(60),
+                effective = resolveMaxCorpusAgeHours({});
+
+            expect(effective).toBe(48);
+
+            expect(() => assertCorpusFreshness({
+                facetCommitDates: {...fresh, issues: corpusAt},
+                maxAgeHours     : effective,
+                now             : NOW
+            })).toThrow(/`issues` is 60\.0h old \(threshold 48h\)/);
+
+            expect(evaluateBreach({
+                consecutiveFailures: 0,
+                corpusFacets       : [{ageHours: 60, facet: 'issues', lastCommitAt: corpusAt}],
+                lastSuccessAt      : hours(1),
+                maxCorpusAgeHours  : effective,
+                now                : NOW
+            }).breached).toBe(true)
+        });
+
+        // The resolver is what the guard uses BY DEFAULT, not merely what a caller may pass.
+        // Asserting only the explicit-argument path would leave the production call site — which
+        // passes no `maxAgeHours` at all — completely uncovered.
+        test('the guard DEFAULTS to the resolved policy, not to the imported constant', () => {
+            const prior = process.env.WATCHDOG_MAX_CORPUS_AGE_HOURS;
+
+            try {
+                process.env.WATCHDOG_MAX_CORPUS_AGE_HOURS = '72';
+
+                // No `maxAgeHours` argument: the default expression must resolve the override.
+                expect(() => assertCorpusFreshness({
+                    facetCommitDates: {...fresh, issues: hours(60)},
+                    now             : NOW
+                })).not.toThrow()
+            } finally {
+                prior === undefined ?
+                    delete process.env.WATCHDOG_MAX_CORPUS_AGE_HOURS :
+                    process.env.WATCHDOG_MAX_CORPUS_AGE_HOURS = prior
+            }
         })
     });
 

--- a/test/playwright/unit/buildScripts/dataSyncPipeline.spec.mjs
+++ b/test/playwright/unit/buildScripts/dataSyncPipeline.spec.mjs
@@ -1,0 +1,265 @@
+import {test, expect} from '@playwright/test';
+import {readFile}     from 'node:fs/promises';
+
+import {
+    assertCorpusFreshness,
+    assertEmissionStageSet,
+    emitGeneratedData,
+    readCorpusFacetCommitDates,
+    REQUIRED_EMISSION_STAGES
+}                     from '../../../../buildScripts/dataSyncPipeline.mjs';
+
+const
+    NOW   = new Date('2026-08-31T12:00:00Z'),
+    hours = n => new Date(NOW.getTime() - n * 3_600_000).toISOString(),
+
+    /**
+     * The stage table as it stands, restated here rather than imported: `emissionCommands` is not
+     * exported, and importing it would make the mutation below a mutation of the module's own state.
+     * @type {Object[]}
+     */
+    fullStages = [
+        {label: 'install dependencies',   tokenScope: 'none'},
+        {label: 'content indexes and SEO', requiresFreshCorpus: true, tokenScope: 'reader'}
+    ];
+
+/**
+ * The two axes that make `no-generated-changes` unreachable by having no generator.
+ *
+ * `c623b2f63c` removed the `GitHub Workflow corpus` stage and the pipeline went SHORTER, not red:
+ * two stages, both green, `no-generated-changes`, exit 0 — for five days, over a corpus frozen on
+ * 2026-08-26, while the surviving derivation stage kept committing fresh-looking portal artifacts
+ * derived from it. Every spec here is a negative control against that exact shape: each one is
+ * written so that removing the guard it covers turns it red.
+ */
+test.describe('dataSyncPipeline guards (#17920)', () => {
+    test.describe('stage-set assertion (AC-3)', () => {
+        test('accepts the stage set that is actually declared', () => {
+            expect(() => assertEmissionStageSet({stages: fullStages})).not.toThrow()
+        });
+
+        test('a stage removed from the table turns the run RED, naming the stage', () => {
+            const mutated = fullStages.filter(stage => stage.label !== 'content indexes and SEO');
+
+            // Not merely `toThrow()`: a guard that threw for any other reason would pass that, and
+            // the finding is specifically that the ABSENCE must be named. An operator reading a
+            // shorter run needs the missing label, not a generic failure.
+            expect(() => assertEmissionStageSet({stages: mutated}))
+                .toThrow(/missing "content indexes and SEO"/)
+        });
+
+        test('names EVERY missing stage, not just the first', () => {
+            let message = '';
+
+            try {
+                assertEmissionStageSet({stages: []})
+            } catch (error) {
+                message = error.message
+            }
+
+            // The pipeline's own deferred-failure design learned this: a single slot let one cause
+            // hide three others and the operator sized the outage from whichever ran last.
+            for (const label of REQUIRED_EMISSION_STAGES) {
+                expect(message).toContain(label)
+            }
+        });
+
+        test('a table carrying only unrelated stages does not lower the bar', () => {
+            expect(() => assertEmissionStageSet({stages: [{label: 'something else'}]}))
+                .toThrow(/missing/)
+        });
+
+        test('the expectation is a LITERAL, not derived from the table it checks', async () => {
+            // This assertion is on SOURCE TEXT, and it has to be. The mutation that silently defeats
+            // this guard is not deleting it — it is tidying `REQUIRED_EMISSION_STAGES` into
+            // `emissionCommands.map(stage => stage.label)`. At runtime that is INVISIBLE while the
+            // table is intact: both forms yield the same two labels, so every behavioural assertion
+            // here stays green. It only turns dangerous when a stage is later deleted, and by then
+            // the expectation deletes itself alongside it — a witness derived from the thing it
+            // witnesses attests to nothing.
+            //
+            // Verified by mutation, not by reasoning: with the derived form in place the whole
+            // behavioural suite passed 15/15, and only this check goes red.
+            const source = await readFile(
+                new URL('../../../../buildScripts/dataSyncPipeline.mjs', import.meta.url), 'utf8'
+            );
+
+            const [, declaration] = source.match(/export const REQUIRED_EMISSION_STAGES\s*=\s*([^;]+);/) ?? [];
+
+            expect(declaration, 'REQUIRED_EMISSION_STAGES declaration not found — was it renamed?')
+                .toBeDefined();
+            expect(declaration, 'the expectation must not be computed from `emissionCommands`')
+                .not.toContain('emissionCommands');
+            expect(declaration.trim(), 'the expectation must be an inline array literal')
+                .toMatch(/^\[[^[\]]*\]$/);
+
+            // And the literal must still describe the running module, or the guard drifts the other
+            // way: a stale literal that expects stages nobody runs breaks every green pipeline.
+            expect(REQUIRED_EMISSION_STAGES).toEqual(['install dependencies', 'content indexes and SEO'])
+        })
+    });
+
+    test.describe('corpus freshness assertion (AC-4)', () => {
+        const fresh = {discussions: hours(2), issues: hours(1), pulls: hours(3)};
+
+        test('a corpus advancing on cadence derives normally', () => {
+            expect(() => assertCorpusFreshness({facetCommitDates: fresh, maxAgeHours: 48, now: NOW}))
+                .not.toThrow()
+        });
+
+        test('the five-day frozen corpus is refused, naming the facet and its age', () => {
+            // The witnessed shape: all three facets last committed 2026-08-26, measured 08-31.
+            expect(() => assertCorpusFreshness({
+                facetCommitDates: {discussions: hours(120), issues: hours(116), pulls: hours(118)},
+                maxAgeHours     : 48,
+                now             : NOW
+            })).toThrow(/`issues` is 116\.0h old \(threshold 48h\)/)
+        });
+
+        test('ONE stale facet is enough — facets drift apart and are certified separately', () => {
+            expect(() => assertCorpusFreshness({
+                facetCommitDates: {...fresh, pulls: hours(72)},
+                maxAgeHours     : 48,
+                now             : NOW
+            })).toThrow(/`pulls`/)
+        });
+
+        test('a facet with no commit visible is stale, not permissive', () => {
+            // `null` means the instrument saw nothing. For a corpus published on a cadence that is
+            // the loudest state; treating it as "no age to compare" fails OPEN, which is the whole
+            // family of defect this ticket sits in.
+            expect(() => assertCorpusFreshness({
+                facetCommitDates: {...fresh, discussions: null},
+                maxAgeHours     : 48,
+                now             : NOW
+            })).toThrow(/no commit visible for `discussions`/)
+        });
+
+        test('the boundary is strictly past the threshold, not at it', () => {
+            expect(() => assertCorpusFreshness({
+                facetCommitDates: {...fresh, issues: hours(48)},
+                maxAgeHours     : 48,
+                now             : NOW
+            })).not.toThrow();
+
+            expect(() => assertCorpusFreshness({
+                facetCommitDates: {...fresh, issues: hours(48.1)},
+                maxAgeHours     : 48,
+                now             : NOW
+            })).toThrow()
+        })
+    });
+
+    test.describe('facet commit dates are read from the COMMITTED corpus', () => {
+        const gitLog = dates => (command, args) => {
+            const subpath = args[args.indexOf('--') + 1];
+
+            return Promise.resolve({stderr: '', stdout: (dates[subpath] ?? '') + '\n'})
+        };
+
+        test('measures git log, never mtime — the Actions checkout makes every file look fresh', async () => {
+            const calls = [];
+
+            await readCorpusFacetCommitDates({
+                cwd    : '/repo',
+                execute: (command, args) => {
+                    calls.push({args, command});
+
+                    return Promise.resolve({stderr: '', stdout: `${hours(1)}\n`})
+                }
+            });
+
+            expect(calls.every(call => call.command === 'git')).toBe(true);
+            expect(calls.every(call => call.args[0] === 'log')).toBe(true);
+            expect(calls.every(call => call.args.includes('--format=%cI'))).toBe(true)
+        });
+
+        test('a multi-path facet resolves newest-wins, so an archive-only repair is not freshness', async () => {
+            // `issues` spans active + archive. Min-wins would breach on a healthy corpus and train
+            // everyone to mute the guard; the watchdog settled newest-wins and this must agree.
+            const dates = await readCorpusFacetCommitDates({
+                cwd    : '/repo',
+                execute: gitLog({
+                    'resources/content/archive/issues': hours(100),
+                    'resources/content/discussions'   : hours(3),
+                    'resources/content/issues'        : hours(2),
+                    'resources/content/pulls'         : hours(4)
+                })
+            });
+
+            expect(dates.issues).toBe(hours(2))
+        });
+
+        test('a facet git reports nothing for resolves to null, not to now', async () => {
+            const dates = await readCorpusFacetCommitDates({
+                cwd    : '/repo',
+                execute: gitLog({'resources/content/issues': hours(2)})
+            });
+
+            expect(dates.pulls).toBeNull();
+            expect(dates.discussions).toBeNull()
+        })
+    });
+
+    test.describe('the refusal reaches the RUN path, not only the pure function', () => {
+        // A guard that only exists as an exported function nothing calls is the same silence this
+        // ticket is about. These two witness the wiring inside `emitGeneratedData`.
+        const runWith = ({corpusAgeHours}) => {
+            const executed = [];
+
+            return {
+                executed,
+                promise: emitGeneratedData({
+                    attempt: 1,
+                    cwd    : '/repo',
+                    execute: (command, args) => {
+                        if (command === 'git') {
+                            return Promise.resolve({stderr: '', stdout: `${hours(corpusAgeHours)}\n`})
+                        }
+
+                        executed.push(args.join(' '));
+
+                        return Promise.resolve({stderr: '', stdout: ''})
+                    },
+                    log: () => {}
+                })
+            }
+        };
+
+        test('a stale corpus stops the derivation stage from running at all', async () => {
+            const {executed, promise} = runWith({corpusAgeHours: 120});
+
+            await expect(promise).rejects.toThrow(/refusing to derive the portal from a stale corpus/);
+
+            // The load-bearing assertion. Failing AFTER derivation would still have published the
+            // artifact that made the outage look healthy; the refusal has to precede the work.
+            expect(executed.some(args => args.includes('rebuildContentIndexesAndSeo'))).toBe(false)
+        });
+
+        test('a fresh corpus lets the derivation stage run', async () => {
+            const {executed, promise} = runWith({corpusAgeHours: 1});
+
+            await promise;
+
+            expect(executed.some(args => args.includes('rebuildContentIndexesAndSeo'))).toBe(true)
+        });
+
+        test('the stage-set assertion is wired in too, and fires before ANY stage runs', async () => {
+            // Witnesses the REAL guard rather than an injected stand-in: a sentinel is added to the
+            // expectation the running module holds, so the only way this passes is if
+            // `emitGeneratedData` actually calls `assertEmissionStageSet`. Playwright gives each
+            // worker its own module instance and tests within one run serially, so the mutation
+            // cannot reach a sibling test; it is restored regardless.
+            REQUIRED_EMISSION_STAGES.push('a stage nobody declared');
+
+            try {
+                const {executed, promise} = runWith({corpusAgeHours: 1});
+
+                await expect(promise).rejects.toThrow(/missing "a stage nobody declared"/);
+                expect(executed).toHaveLength(0)
+            } finally {
+                REQUIRED_EMISSION_STAGES.pop()
+            }
+        })
+    })
+});


### PR DESCRIPTION
Resolves #17938

Related: #17920

**Evidence:** author-run local — full unit suite `2200 passed`, targeted spec `16 passed`, `check-engine-brain-boundary` exit 0, plus a three-mutation kill matrix reproduced below. No runtime claim here rests on a scheduled run; the two ACs that need one are explicitly left open.

`c623b2f63c` removed the `GitHub Workflow corpus` emission stage and the pipeline went **shorter, not red**: two stages, both green, `no-generated-changes`, exit 0 — for five days, while the surviving derivation stage kept rebuilding the portal from a corpus frozen on 2026-08-26 and committing the result. A green run, fresh derived commits, and a dead source. This PR makes both halves of that silence loud.

## AC Evidence

| AC | Proof |
| --- | --- |
| AC-3 | **A stage vanishing from `emissionCommands` turns the run RED** — `assertEmissionStageSet()` fires before any stage executes; the expectation is an independent literal, not derived from the table it checks. Shown failing first: with the guard removed the wiring witness reds and the other 15 stay green. Detail below. |
| AC-4 | **Derivation refuses a stale corpus** — `assertCorpusFreshness()` resolves the policy through `resolveMaxCorpusAgeHours()`, the watchdog's own resolver, so guard and alarm share ONE effective threshold including the `WATCHDOG_MAX_CORPUS_AGE_HOURS` override. 19 arms green; the no-threshold arm reds against the old imported-constant default and nothing else. Detail below. |
| AC-1 · AC-5 · AC-6 | **Not delivered here, and not claimed.** They remain open on #17920, the parent. This PR closes the delivery leaf #17938, which owns exactly the two ACs above. |

### AC-3 — a stage vanishing from `emissionCommands` turns the run RED

`assertEmissionStageSet()` runs **before any stage executes**, so a pipeline that lost a generator cannot first publish what the survivors derive and then mention the gap — that derived commit is exactly what made the outage read as healthy.

Shown failing against the current implementation first, as the AC requires: with the guard commented out, the wiring witness goes red and the other 15 stay green.

The expectation is declared **independently** of the table it checks. This is deliberately a second hand-maintained list, which the credential vocabulary in the same file rightly refuses to be — and the distinction is load-bearing. `stageTokenSources` centralizes so that selection and scrubbing cannot drift, because there drift *is* the defect. Here drift *is the signal*: a witness derived from the thing it witnesses attests to nothing.

### AC-4 — derivation refuses a stale corpus rather than deriving from it

`assertCorpusFreshness()` runs immediately before the `content indexes and SEO` stage and throws naming every stale facet with its measured age.

Freshness is read from **committed** dates via `git log -1 --format=%cI`, never `mtime`: this runs in an ephemeral Actions checkout where every file's mtime is checkout time, so an mtime probe would certify the five-day-old corpus as seconds fresh. A facet with no commit visible resolves to `null` and is treated as **stale**, not as "no age to compare" — that direction fails closed.

This is also the only axis that can see an **absent producer** at all. The emitter is Agent-OS-side (the Agent OS consumes the published Engine and is never imported by it), so its absence never shows up in `emissionCommands`. The two axes together are what make `no-generated-changes` unreachable by having no generator.

## Deltas from ticket

**RA-1 (P1, @neo-gpt-emmy) — one effective corpus-age authority.** Her falsifier was exact and the defect was real: the guard imported `DEFAULT_MAX_CORPUS_AGE_HOURS` while the watchdog resolves `WATCHDOG_MAX_CORPUS_AGE_HOURS` at runtime, so a 60h corpus under a 72h override was rejected by the guard while the alarm returned `{breached: false}` for the same corpus. The JSDoc's "cannot disagree" claim was false. `resolveMaxCorpusAgeHours(env)` is now the single resolution site, consumed by both — the watchdog's own resolution goes through it instead of a second inline `parseThreshold`, and the guard defaults to it **per call**, so an override set after module load is honoured. The corrected JSDoc records the false claim rather than quietly replacing it.

**Why the third test arm exists, and why the first two were not enough.** The two arms passing an explicit `maxAgeHours` prove agreement *given* a policy — and they stay green against the old code, so they certify nothing about the defect. Only the arm that passes **no** threshold exercises the default expression, which is the production call site's actual shape. Reproducing the defect (default back to the literal `48`) reds exactly that arm and nothing else, at exit 1.

**RA-3 — I was wrong, and the corrected action is done.** I argued that carving a leaf would be opening a ticket to satisfy a linter. @neo-gpt-emmy's corrected framing is right: this is **delivery decomposition**, not linter appeasement. The distinction is whether the leaf owns a coherent slice somebody could pick up independently, and this one does — two Engine-side guards, mechanically verifiable, one PR. The tell that my reasoning was motivated rather than principled is that the same shape is live in this repo twice today, both mine: #17924 under #17922, and #17931 under #17921. I applied a rule against a leaf here that I had not applied to either of those.

#17938 now owns AC-3 and AC-4 with their own ACs, ledger, out-of-scope and avoided-traps; #17920 keeps AC-1, AC-5 and AC-6. This PR `Resolves #17938` and stays `Related: #17920`, so the closing keyword names something this PR genuinely closes — no gate deviation left to declare.

**RA-2 — applied to #17920's operative body.** Its Contract Ledger said "older than the pipeline cadence" while this ships a deliberate 48h band, and an implementation must not silently overrule its source ticket. The Fix step, the ledger row, and the AC prose now all read the effective corpus-age band — `resolveMaxCorpusAgeHours()`, default 48h, overridable via `WATCHDOG_MAX_CORPUS_AGE_HOURS` — and a new ledger row names the single resolution site as the policy authority, recording the divergence RA-1 found rather than quietly closing it. The band is 48h rather than the hourly cadence because a facet only commits when GitHub content actually changed: a cadence-tight threshold breaches every quiet night and a guard that cries wolf daily is muted within a day. That reasoning is now in the ticket, not only in a comment.

**One unrelated observation, reported rather than labelled flaky.** Across three full local `unit` runs at this head, `manager/DragCoordinator.spec.mjs` — "THE OVERLAP FALSIFIER" — failed **once** (`workspace-b` where `workspace-a` was expected) and passed twice. It passes in isolation, and one control run with these changes stashed was green at 2200. One failure in three is not enough to attribute to this diff, and not enough to call flaky either; recorded so whoever sees it next has a prior instead of a shrug.


**Three of the six ACs are not in this PR, and I would rather say so than imply coverage.** AC-1 (facets advance again) and AC-6 (two consecutive scheduled runs commit facet changes) require the Agent-OS-side emitter to exist and to have run twice; neither is assertable from this repository today. AC-5 (the watchdog alarm body still claims "runs fail on schedule" against a zero streak) is a text fix in a different file and belongs in its own change. #17920 stays open on those.

**The staleness threshold is 48h, not the pipeline's hourly cadence — this is the judgement call most worth challenging.** The ticket says "older than the pipeline's own cadence". A facet only commits when GitHub content actually changed, so a cadence-tight bound would breach on every quiet hour and be muted inside a day. 48h is imported from the watchdog's `DEFAULT_MAX_CORPUS_AGE_HOURS` rather than restated, so the guard and the alarm cannot disagree about what "stale" means. It catches this defect on **day two instead of day five**, which is the improvement actually on offer — not day one. Day one needs a producer that emits a heartbeat even when nothing changed, and that is not in this ticket. If you read the AC as binding to the literal cadence, say so and I will take it back to the ticket rather than argue it in review.

**`FACET_PATHS`, `DEFAULT_CORPUS_PATH` and `DEFAULT_MAX_CORPUS_AGE_HOURS` are newly exported from `dataSyncWatchdog.mjs`.** Two hand-maintained facet lists is how a facet gets added to one and missed by the other, after which the guard certifies a corpus one third of which it never looked at — silently. One declaration, two consumers.

**No new dependency direction.** Nothing here imports or spawns Agent OS substrate and `package.json` is untouched; `check-engine-brain-boundary` passes (`0 crossing(s), 559 file(s) scanned`).

**Spec filename.** `dataSyncPipeline.spec.mjs`, camelCase after its subject — matching all 17 specs on `dev`. Note for whoever picks up the deferred spec in #17925: that one is `DataSyncPipeline.spec.mjs` (PascalCase, same subject). On a case-insensitive filesystem those are the same path, so the restoration should **merge into this file** rather than recreate it. Flagging it because it will not surface as a git conflict on Linux CI.

## Test Evidence

16 specs, all in `test/playwright/unit/buildScripts/dataSyncPipeline.spec.mjs`. Green is not the evidence — the kill matrix is:

| mutation | result |
|---|---|
| `assertEmissionStageSet()` call removed from `emitGeneratedData` | **1 failed**, 14 passed |
| `assertCorpusFreshness()` call removed from the stage loop | **1 failed**, 14 passed |
| `REQUIRED_EMISSION_STAGES` derived as `emissionCommands.map(s => s.label)` | **1 failed**, 15 passed — *only after the fix described below* |

**The independence check earned its shape by failing.** My first version of it was behavioural: inject an empty `stages` array and assert the guard still expects the full set. Against the derived expectation that suite passed **15/15**. The mutation is invisible at runtime while the table is intact — both forms evaluate to the same two labels at module load, and the derivation only turns dangerous when a stage is *later* deleted, at which point the expectation deletes itself alongside it. So the check is now an assertion on **source text**: the declaration must be an inline array literal and must not mention `emissionCommands`. I would not have found this by reading the code, and I am reporting it because a reviewer should weigh a guard whose first form was a false green.

Two specs witness that each refusal reaches the **run path**, not merely the exported function — including that a stale corpus leaves `rebuildContentIndexesAndSeo` unexecuted, since failing *after* derivation would still publish the artifact that made the outage look healthy.

- full unit suite: `2200 passed (11.8s)`
- `npm run check-engine-brain-boundary`: exit 0

## Post-Merge Validation

The honest instrument is facet commit timestamps on `origin/dev`, never run status — the whole finding is that those two came apart.

- The next scheduled run should turn **red** on the freshness guard, because the corpus is still frozen at 2026-08-26 and no producer exists yet. **That is the intended outcome of this PR, not a regression.** A red pipeline naming a dead producer is strictly better than five days of green over a frozen corpus. If that noise is judged unacceptable before the Agent-OS-side emitter lands, the fix is to land the emitter, not to widen the threshold.
- Once the emitter is publishing, `git log -1 --format=%cI origin/dev -- resources/content/{issues,pulls,discussions}` should advance on cadence, which is AC-1/AC-6 and belongs to a later change.

## Commits

- `5b94da119d` — fix(build): make a lost Data Sync stage and a frozen corpus loud (#17920)

