### PR TITLE
fix(build): a dist/esm build that cannot boot must not exit 0 (#17921)

### DIFF
--- a/buildScripts/build/esmodules.mjs
+++ b/buildScripts/build/esmodules.mjs
@@ -5,6 +5,7 @@ import {minifyHtml}         from '../util/minifyHtml.mjs';
 import {processFileContent} from '../util/astTemplateProcessor.mjs';
 
 import {
+    esmOutputRoot,
     findUnresolvableImports,
     relativeSpecifiers,
     resolveSourceRoots,
@@ -13,7 +14,7 @@ import {
 } from '../util/esmDistTransforms.mjs';
 
 const
-    outputBasePath = 'dist/esm/',
+    outputBasePath = `${esmOutputRoot}/`,
     root           = path.resolve(),
     requireJson    = path => JSON.parse(fs.readFileSync(path, 'utf-8')),
     packageJson    = requireJson(path.join(root, 'package.json')),
@@ -21,11 +22,21 @@ const
     startDate      = new Date();
 
 const
-    inputDirectories = resolveSourceRoots({insideNeo, packageJson}),
     /** `{outputPath, specifiers}` per emitted module, checked once the whole tree exists. */
-    emittedModules   = [],
+    emittedModules = [],
     /** Files that threw. Collected rather than logged, so the build can refuse to exit 0. */
-    failures         = [];
+    failures       = [];
+
+let inputDirectories;
+
+// A rejected source root is a manifest mistake, not an engine crash: the developer who typed the
+// path is the one who has to read this, and a stack trace through buildScripts tells them nothing.
+try {
+    inputDirectories = resolveSourceRoots({insideNeo, packageJson})
+} catch (error) {
+    console.error(`\ndist/esm: ${error.message}`);
+    process.exit(1)
+}
 
 async function minifyDirectory(inputDir, outputDir) {
     if (fs.existsSync(inputDir)) {
@@ -134,18 +145,33 @@ Promise.all(promises).then(() => {
     // Runs only once the whole tree exists, because a forward reference to a file another root has
     // not emitted yet is not a defect. `dist/esm` ships without a resolver, so this is the only
     // stage that can tell a working output from one that merely finished.
-    const unresolvable = findUnresolvableImports(
-        emittedModules,
-        fs.existsSync,
-        (outputPath, specifier) => path.resolve(path.dirname(outputPath), specifier)
-    );
+    const
+        unresolvable = findUnresolvableImports(
+            emittedModules,
+            fs.existsSync,
+            (outputPath, specifier) => path.resolve(path.dirname(outputPath), specifier)
+        ),
+        report       = reason => unresolvable.filter(entry => entry.reason === reason)
+            .map(({outputPath, specifier}) => `  ${path.relative(root, outputPath)} → ${specifier}`),
+        missing      = report('missing'),
+        wrongEngine  = report('engine-identity');
+
+    if (missing.length > 0) {
+        console.error(`\ndist/esm: ${missing.length} import(s) do not resolve inside the output tree:`);
+        missing.forEach(line => console.error(line));
+        console.error('\nA source root the app imports may be missing from package.json "neo.esmSourceRoots".')
+    }
+
+    // Separate from the missing set on purpose: these DO resolve. They reach the workspace's own
+    // engine source instead of the copy in dist/esm, so the app boots two disjoint module graphs —
+    // a failure that looks like nothing at build time and like everything at runtime.
+    if (wrongEngine.length > 0) {
+        console.error(`\ndist/esm: ${wrongEngine.length} import(s) still address the workspace engine at node_modules/neo.mjs:`);
+        wrongEngine.forEach(line => console.error(line));
+        console.error('\nThese must be rewritten to the flattened dist/esm/src copy; two engine graphs cannot share a class registry.')
+    }
 
     if (unresolvable.length > 0) {
-        console.error(`\ndist/esm: ${unresolvable.length} import(s) do not resolve inside the output tree:`);
-        unresolvable.forEach(({outputPath, specifier}) => {
-            console.error(`  ${path.relative(root, outputPath)} → ${specifier}`)
-        });
-        console.error('\nA source root the app imports may be missing from package.json "neo.esmSourceRoots".');
         process.exit(1)
     }
 

--- a/buildScripts/build/esmodules.mjs
+++ b/buildScripts/build/esmodules.mjs
@@ -4,32 +4,28 @@ import * as Terser          from 'terser';
 import {minifyHtml}         from '../util/minifyHtml.mjs';
 import {processFileContent} from '../util/astTemplateProcessor.mjs';
 
+import {
+    findUnresolvableImports,
+    relativeSpecifiers,
+    resolveSourceRoots,
+    rewriteImportPaths,
+    rewriteNeoConfig
+} from '../util/esmDistTransforms.mjs';
+
 const
     outputBasePath = 'dist/esm/',
-    regexImport    = /(import(?:\s*(?:[\w*{}\n\r\t, ]+from\s*)?|\s*\(\s*)?)(["`])((?:(?!\2).)*node_modules(?:(?!\2).)*)\2/g,
     root           = path.resolve(),
     requireJson    = path => JSON.parse(fs.readFileSync(path, 'utf-8')),
     packageJson    = requireJson(path.join(root, 'package.json')),
     insideNeo      = packageJson.name.includes('neo.mjs'),
     startDate      = new Date();
 
-let inputDirectories;
-
-if (insideNeo) {
-    inputDirectories = ['apps', 'docs', 'examples', 'src']
-} else {
-    inputDirectories = ['apps', 'docs', 'node_modules/neo.mjs/src', 'src']
-}
-
-function adjustImportPathHandler(match, p1, p2, p3) {
-    let newPath;
-    if (p3.includes('/node_modules/neo.mjs/')) {
-        newPath = p3.replace('/node_modules/neo.mjs/', '/')
-    } else {
-        newPath = '../../' + p3;
-    }
-    return p1 + p2 + newPath + p2
-}
+const
+    inputDirectories = resolveSourceRoots({insideNeo, packageJson}),
+    /** `{outputPath, specifiers}` per emitted module, checked once the whole tree exists. */
+    emittedModules   = [],
+    /** Files that threw. Collected rather than logged, so the build can refuse to exit 0. */
+    failures         = [];
 
 async function minifyDirectory(inputDir, outputDir) {
     if (fs.existsSync(inputDir)) {
@@ -40,8 +36,8 @@ async function minifyDirectory(inputDir, outputDir) {
                 continue;
             }
 
-            const currentPath = dirent.parentPath || dirent.path;
-            const inputPath = path.join(currentPath, dirent.name);
+            const currentPath     = dirent.parentPath || dirent.path;
+            const inputPath       = path.join(currentPath, dirent.name);
             const normalizedInput = inputPath.replace(/\\/g, '/');
 
             if (normalizedInput.includes('/docs/output/')) {
@@ -69,15 +65,7 @@ async function minifyFile(content, outputPath) {
         if (outputPath.endsWith('.json')) {
             const jsonContent = JSON.parse(content);
             if (outputPath.endsWith('neo-config.json')) {
-                Object.assign(jsonContent, {
-                    basePath: '../../' + jsonContent.basePath,
-                    environment: 'dist/esm',
-                    mainPath: './Main.mjs',
-                    workerBasePath: jsonContent.basePath + 'src/worker/'
-                });
-                if (!insideNeo) {
-                    jsonContent.appPath = jsonContent.appPath.substring(6)
-                }
+                rewriteNeoConfig(jsonContent, {insideNeo})
             }
             fs.writeFileSync(outputPath, JSON.stringify(jsonContent));
             console.log(`Minified JSON: ${outputPath}`)
@@ -86,27 +74,36 @@ async function minifyFile(content, outputPath) {
             fs.writeFileSync(outputPath, minifiedContent);
             console.log(`Minified HTML: ${outputPath}`)
         } else if (outputPath.endsWith('.mjs')) {
-            let adjustedContent = content.replace(regexImport, adjustImportPathHandler);
+            let adjustedContent = rewriteImportPaths(content);
 
             // AST-based processing for html templates
             const result = processFileContent(adjustedContent, outputPath);
 
             const minifiedResult = await Terser.minify(result.content, {
-                module: true,
+                module  : true,
                 compress: {dead_code: true},
-                mangle: {toplevel: true}
+                mangle  : {toplevel: true}
             });
 
             fs.writeFileSync(outputPath, minifiedResult.code);
+
+            // Recorded from the emitted code, not the source: Terser normalizes quoting, so this is
+            // the only text that reflects what the browser will actually request.
+            emittedModules.push({outputPath, specifiers: relativeSpecifiers(minifiedResult.code)});
+
             console.log(`Minified JS: ${outputPath}`)
         }
     } catch (e) {
+        // Recorded, not merely logged. This catch used to swallow: a file that threw was simply
+        // ABSENT from dist/esm and the build still exited 0 — the same silent-success failure mode
+        // as an unrewritten import, on the error path instead of the transform path.
+        failures.push({outputPath, error: e});
         console.error(`Error minifying ${outputPath}:`, e)
     }
 }
 
 const promises = [];
-const swPath = path.resolve(root, 'ServiceWorker.mjs');
+const swPath   = path.resolve(root, 'ServiceWorker.mjs');
 
 if (fs.existsSync(swPath)) {
     promises.push(minifyFile(fs.readFileSync(swPath, 'utf8'), path.resolve(root, outputBasePath, 'ServiceWorker.mjs')));
@@ -127,6 +124,31 @@ Promise.all(promises).then(() => {
     if (fs.existsSync(docsOutputPath)) {
         fs.copySync(docsOutputPath, path.resolve(root, outputBasePath, 'docs/output'))
     }
+
+    if (failures.length > 0) {
+        console.error(`\ndist/esm: ${failures.length} file(s) failed to build:`);
+        failures.forEach(({outputPath}) => console.error(`  ${path.relative(root, outputPath)}`));
+        process.exit(1)
+    }
+
+    // Runs only once the whole tree exists, because a forward reference to a file another root has
+    // not emitted yet is not a defect. `dist/esm` ships without a resolver, so this is the only
+    // stage that can tell a working output from one that merely finished.
+    const unresolvable = findUnresolvableImports(
+        emittedModules,
+        fs.existsSync,
+        (outputPath, specifier) => path.resolve(path.dirname(outputPath), specifier)
+    );
+
+    if (unresolvable.length > 0) {
+        console.error(`\ndist/esm: ${unresolvable.length} import(s) do not resolve inside the output tree:`);
+        unresolvable.forEach(({outputPath, specifier}) => {
+            console.error(`  ${path.relative(root, outputPath)} → ${specifier}`)
+        });
+        console.error('\nA source root the app imports may be missing from package.json "neo.esmSourceRoots".');
+        process.exit(1)
+    }
+
     const processTime = (Math.round((new Date - startDate) * 100) / 100000).toFixed(2);
     console.log(`\nTotal time for dist/esm: ${processTime}s`);
     process.exit()

--- a/buildScripts/util/esmDistTransforms.mjs
+++ b/buildScripts/util/esmDistTransforms.mjs
@@ -14,7 +14,28 @@
  */
 
 /**
- * Matches a static or dynamic import specifier that mentions `node_modules`.
+ * The output tree this build writes, relative to the workspace root.
+ *
+ * Exported rather than duplicated in the build script because it is now a *boundary*: a declared
+ * source root is only safe if it cannot address this tree, and that check has to compare against the
+ * same string the caller writes into.
+ *
+ * @type {String}
+ */
+export const esmOutputRoot = 'dist/esm';
+
+/**
+ * The engine's own package path inside a consuming workspace.
+ *
+ * Every specifier that still names it after the rewrite addresses a SECOND engine module graph, which
+ * is why it is a failure independent of whether the file it names exists.
+ *
+ * @type {String}
+ */
+export const enginePackagePath = 'node_modules/neo.mjs';
+
+/**
+ * Matches a static import, a dynamic import, or a re-export whose specifier mentions `node_modules`.
  *
  * Returned as a factory, not a shared constant: the pattern carries the `g` flag, so a single shared
  * instance would carry `lastIndex` between unrelated callers and skip matches non-deterministically.
@@ -25,10 +46,15 @@
  * normalized the untouched specifiers to double quotes afterwards, which made the output *look*
  * like the rewrite had run.
  *
+ * `export ... from` is matched for the same reason the quote class is wide: a re-export is a request
+ * the browser makes, so a rewrite that skips it emits a specifier addressing the workspace's engine
+ * from inside `dist/esm`. It used to be skipped, and the emitted path happened to resolve, so nothing
+ * failed — it simply booted two disjoint engine graphs.
+ *
  * @returns {RegExp}
  */
 export const createImportSpecifierRegex = () =>
-    /(import(?:\s*(?:[\w*{}\n\r\t, ]+from\s*)?|\s*\(\s*)?)(["'`])((?:(?!\2).)*node_modules(?:(?!\2).)*)\2/g;
+    /((?:import|export)(?:\s*(?:[\w*{}\n\r\t, ]+from\s*)?|\s*\(\s*)?)(["'`])((?:(?!\2).)*node_modules(?:(?!\2).)*)\2/g;
 
 /**
  * Matches any relative import specifier, whatever the quote style.
@@ -118,10 +144,16 @@ export function rewriteNeoConfig(config, {insideNeo}) {
  *
  * Declared roots are additive and de-duplicated; the defaults cannot be dropped.
  *
+ * A declared root is not just an input path. The caller resolves it twice — once against the
+ * workspace to read from, once against `dist/esm` to write to — so the manifest field is an OUTPUT
+ * authority, and validating its type without validating its containment turns a convenience into an
+ * overwrite primitive. See {@link unsafeSourceRootReason}.
+ *
  * @param {Object}  options
  * @param {Boolean} options.insideNeo
  * @param {Object}  options.packageJson the consuming workspace's manifest
  * @returns {String[]}
+ * @throws {Error} on a malformed or unsafe declaration; never on a default
  */
 export function resolveSourceRoots({insideNeo, packageJson}) {
     const
@@ -138,7 +170,79 @@ export function resolveSourceRoots({insideNeo, packageJson}) {
         throw new Error('package.json "neo.esmSourceRoots" must be an array of non-empty strings')
     }
 
-    return [...new Set([...defaults, ...declared])]
+    const safe = declared.map(entry => {
+        const
+            root   = normalizeSourceRoot(entry),
+            reason = unsafeSourceRootReason(root);
+
+        if (reason) {
+            throw new Error(`package.json "neo.esmSourceRoots" entry ${JSON.stringify(entry)} ${reason}`)
+        }
+
+        return root
+    });
+
+    return [...new Set([...defaults, ...safe])]
+}
+
+/**
+ * The workspace-relative form of a declared source root: POSIX separators, no `./` prefix, no
+ * duplicate or trailing slashes.
+ *
+ * Normalizing before validating is the point — `.\\..//outside/` and `../outside` are the same
+ * request, and a check that only recognised one of them would be a check the other walks past.
+ *
+ * @param {String} root
+ * @returns {String}
+ */
+export const normalizeSourceRoot = root =>
+    root.replace(/\\/g, '/').replace(/\/{2,}/g, '/').replace(/^\.\//, '').replace(/\/$/, '');
+
+/**
+ * Why a normalized source root may not be built, or `null` when it is safe.
+ *
+ * The caller derives the output directory from the declared string, so an unconstrained entry does
+ * not merely read the wrong tree — it writes one. Two shapes are decisive:
+ *
+ * - an absolute root makes input and output the SAME external directory, because `path.resolve`
+ *   discards every earlier segment once it meets one: the build then minifies a foreign tree in
+ *   place, which is data loss, not a bad build;
+ * - a traversing root escapes `dist/esm` on the output side, so `../../outside` emits into the
+ *   workspace beside the output tree rather than inside it.
+ *
+ * The absolute forms are matched textually rather than through `path.isAbsolute`, because a Windows
+ * manifest is a perfectly ordinary thing to read on a POSIX CI box and the platform of the *checker*
+ * must not decide whether the declaration is safe.
+ *
+ * Overlap with `dist/esm` is rejected in both directions: a root beneath the output tree feeds the
+ * build its own output, and a root above it (`.`, `dist`) does the same one level up.
+ *
+ * @param {String} root a value already through {@link normalizeSourceRoot}
+ * @returns {String|null} the reason, phrased to complete `entry "x" …`
+ */
+export function unsafeSourceRootReason(root) {
+    if (root.startsWith('/')) {
+        return 'must be workspace-relative; an absolute root makes the build read and write the same external directory'
+    }
+
+    if (/^[a-z]:/i.test(root)) {
+        return 'must be workspace-relative; a drive-qualified root is absolute on Windows'
+    }
+
+    const segments = root.split('/').filter(segment => segment && segment !== '.');
+
+    if (segments.includes('..')) {
+        return 'must not traverse upwards; the output path is derived from it and would escape dist/esm'
+    }
+
+    const outputSegments = esmOutputRoot.split('/');
+
+    if (segments.every((segment, index) => segment === outputSegments[index]) ||
+        outputSegments.every((segment, index) => segment === segments[index])) {
+        return `must not overlap "${esmOutputRoot}"; the build would read its own output tree`
+    }
+
+    return null
 }
 
 /**
@@ -152,31 +256,59 @@ export function relativeSpecifiers(code) {
 }
 
 /**
- * Reports every emitted module whose relative imports do not resolve to a file that was emitted.
+ * Reports every emitted import that cannot boot: one naming a file that is not there, and one naming
+ * the wrong engine.
  *
  * This is the guard the build never had. Both shipped defect classes end the same way — a specifier
  * pointing at a file that is not in the output tree — and both were invisible because a copy-and-
  * minify build has no resolver to complain: an unrewritten `node_modules` path lands inside
  * `dist/esm` at a path that was never populated, and an uncopied source root leaves a sibling import
- * dangling. Containment in the output tree is therefore NOT the property to check; existence is.
+ * dangling. Containment in the output tree is NOT the property that separates those, because the
+ * rewrite deliberately points third-party packages back out at `../../node_modules/`. Existence is.
+ *
+ * Existence alone, however, is only sufficient for a package the output does not own. The engine the
+ * output DOES own is copied to `dist/esm/src`, so an emitted specifier that still names
+ * `node_modules/neo.mjs` addresses the workspace's own source engine — a second, disjoint module
+ * graph with its own class registry and its own singletons. It resolves, it exists, and the app that
+ * loads it fails at runtime in a way no path check would ever have reported. Identity, not
+ * existence, is the property there, so that shape fails whether or not the target is on disk.
  *
  * @param {Object[]} modules `{outputPath, specifiers}` records, as emitted
  * @param {Function} exists  predicate over an absolute path, injected so specs need no fixture tree
  * @param {Function} resolve `(from, specifier) => absolutePath`
- * @returns {Object[]} `{outputPath, specifier, resolved}` for each unresolvable import
+ * @returns {Object[]} `{outputPath, specifier, resolved, reason}`; reason is `missing` or `engine-identity`
  */
 export function findUnresolvableImports(modules, exists, resolve) {
     const failures = [];
 
     modules.forEach(({outputPath, specifiers}) => {
         specifiers.forEach(specifier => {
-            const resolved = resolve(outputPath, specifier);
+            const
+                resolved = resolve(outputPath, specifier),
+                reason   = addressesSourceEngine(resolved) || addressesSourceEngine(specifier)
+                    ? 'engine-identity'
+                    : exists(resolved) ? null : 'missing';
 
-            if (!exists(resolved)) {
-                failures.push({outputPath, specifier, resolved})
+            if (reason) {
+                failures.push({outputPath, specifier, resolved, reason})
             }
         })
     });
 
     return failures
+}
+
+/**
+ * True for a path that traverses the workspace's own engine package.
+ *
+ * Checked on whole segments: a directory named `node_modules/neo.mjs-examples` is somebody else's
+ * package and must not be caught by a substring match.
+ *
+ * @param {String} candidate
+ * @returns {Boolean}
+ */
+export function addressesSourceEngine(candidate) {
+    const normalized = candidate.replace(/\\/g, '/');
+
+    return normalized.includes(`/${enginePackagePath}/`) || normalized.startsWith(`${enginePackagePath}/`)
 }

--- a/buildScripts/util/esmDistTransforms.mjs
+++ b/buildScripts/util/esmDistTransforms.mjs
@@ -37,8 +37,18 @@ export const enginePackagePath = 'node_modules/neo.mjs';
 /**
  * Matches a static import, a dynamic import, or a re-export whose specifier mentions `node_modules`.
  *
- * Returned as a factory, not a shared constant: the pattern carries the `g` flag, so a single shared
- * instance would carry `lastIndex` between unrelated callers and skip matches non-deterministically.
+ * A module-scope constant, compiled once. It was a factory, justified on the `g` flag carrying
+ * `lastIndex` between callers — which is a real hazard and **does not reach either consumer here**:
+ * `String.replace` and `String.matchAll` both leave `lastIndex` at 0 (`matchAll` iterates a clone).
+ * Measured both ways before this was changed. A function around a literal is not a defence; it is
+ * this cache discarded once per call, on a path that runs over every emitted module in the tree.
+ *
+ * **The invariant that keeps it safe, stated because it is now shared:** no consumer may leave
+ * `lastIndex` dirty. `.exec()` or `.test()` against this constant would do exactly that, and the
+ * next `matchAll` would silently start mid-string. Neither is used; a future one must reset it.
+ *
+ * Module-private for the same reason — an exported factory hands a fresh object to every caller and
+ * so hides that invariant instead of stating it. Nothing outside this file consumed either pattern.
  *
  * The quote class is `["'`]` and the single quote is the point. It was `["`]` — double quote or
  * backtick only — while the engine's house style, and every generated workspace's, is the single
@@ -51,20 +61,22 @@ export const enginePackagePath = 'node_modules/neo.mjs';
  * from inside `dist/esm`. It used to be skipped, and the emitted path happened to resolve, so nothing
  * failed — it simply booted two disjoint engine graphs.
  *
- * @returns {RegExp}
+ * @type {RegExp}
  */
-export const createImportSpecifierRegex = () =>
+const IMPORT_SPECIFIER_REGEX =
     /((?:import|export)(?:\s*(?:[\w*{}\n\r\t, ]+from\s*)?|\s*\(\s*)?)(["'`])((?:(?!\2).)*node_modules(?:(?!\2).)*)\2/g;
 
 /**
  * Matches any relative import specifier, whatever the quote style.
  *
+ * Module-scope constant, same reasoning and same `lastIndex` invariant as the pattern above.
+ *
  * Deliberately separate from the rewrite pattern: this one runs over *emitted* code, which Terser has
  * already normalized, so it cannot assume the source's quoting.
  *
- * @returns {RegExp}
+ * @type {RegExp}
  */
-export const createRelativeSpecifierRegex = () =>
+const RELATIVE_SPECIFIER_REGEX =
     /(?:import|export)(?:\s*(?:[\w*{}\n\r\t, ]+from\s*)?|\s*\(\s*)(["'`])(\.{1,2}\/(?:(?!\1).)*)\1/g;
 
 /**
@@ -78,7 +90,7 @@ export const createRelativeSpecifierRegex = () =>
  * @returns {String}
  */
 export function rewriteImportPaths(content) {
-    return content.replace(createImportSpecifierRegex(), (match, prefix, quote, specifier) => {
+    return content.replace(IMPORT_SPECIFIER_REGEX, (match, prefix, quote, specifier) => {
         const rewritten = specifier.includes('/node_modules/neo.mjs/')
             ? specifier.replace('/node_modules/neo.mjs/', '/')
             : '../../' + specifier;
@@ -252,7 +264,7 @@ export function unsafeSourceRootReason(root) {
  * @returns {String[]}
  */
 export function relativeSpecifiers(code) {
-    return [...code.matchAll(createRelativeSpecifierRegex())].map(match => match[2])
+    return [...code.matchAll(RELATIVE_SPECIFIER_REGEX)].map(match => match[2])
 }
 
 /**

--- a/buildScripts/util/esmDistTransforms.mjs
+++ b/buildScripts/util/esmDistTransforms.mjs
@@ -1,0 +1,182 @@
+/**
+ * The pure transforms behind `buildScripts/build/esmodules.mjs`.
+ *
+ * They live here rather than inside the build script because that script executes its work at module
+ * scope: importing it *runs a build*. A transform that cannot be imported cannot be pinned by a spec,
+ * and every defect this module exists to fix was a silent one that only a spec would have caught.
+ *
+ * `dist/development` and `dist/production` are webpack bundles, so webpack resolves imports wherever
+ * they point and these assumptions never had to hold. `dist/esm` is a copy-and-minify transform with
+ * no resolver, so each assumption below is load-bearing.
+ *
+ * @see https://github.com/neomjs/neo/issues/17921
+ * @see https://github.com/neomjs/neo/issues/6752 introduced the workspace import rewrite
+ */
+
+/**
+ * Matches a static or dynamic import specifier that mentions `node_modules`.
+ *
+ * Returned as a factory, not a shared constant: the pattern carries the `g` flag, so a single shared
+ * instance would carry `lastIndex` between unrelated callers and skip matches non-deterministically.
+ *
+ * The quote class is `["'`]` and the single quote is the point. It was `["`]` — double quote or
+ * backtick only — while the engine's house style, and every generated workspace's, is the single
+ * quote. So the rewrite added by #6752 never fired on the code it was written for, and Terser
+ * normalized the untouched specifiers to double quotes afterwards, which made the output *look*
+ * like the rewrite had run.
+ *
+ * @returns {RegExp}
+ */
+export const createImportSpecifierRegex = () =>
+    /(import(?:\s*(?:[\w*{}\n\r\t, ]+from\s*)?|\s*\(\s*)?)(["'`])((?:(?!\2).)*node_modules(?:(?!\2).)*)\2/g;
+
+/**
+ * Matches any relative import specifier, whatever the quote style.
+ *
+ * Deliberately separate from the rewrite pattern: this one runs over *emitted* code, which Terser has
+ * already normalized, so it cannot assume the source's quoting.
+ *
+ * @returns {RegExp}
+ */
+export const createRelativeSpecifierRegex = () =>
+    /(?:import|export)(?:\s*(?:[\w*{}\n\r\t, ]+from\s*)?|\s*\(\s*)(["'`])(\.{1,2}\/(?:(?!\1).)*)\1/g;
+
+/**
+ * Rewrites `node_modules`-bearing specifiers for the flattened `dist/esm` layout.
+ *
+ * The engine is copied from `node_modules/neo.mjs/src` to `dist/esm/src`, which preserves the
+ * relative depth — so dropping the `node_modules/neo.mjs/` segment is the whole rewrite. Any other
+ * package keeps its `node_modules` path but sits two levels further away, hence the `../../`.
+ *
+ * @param {String} content
+ * @returns {String}
+ */
+export function rewriteImportPaths(content) {
+    return content.replace(createImportSpecifierRegex(), (match, prefix, quote, specifier) => {
+        const rewritten = specifier.includes('/node_modules/neo.mjs/')
+            ? specifier.replace('/node_modules/neo.mjs/', '/')
+            : '../../' + specifier;
+
+        return prefix + quote + rewritten + quote
+    })
+}
+
+/**
+ * True for a base path that already addresses a fixed location: an absolute mount (`/mount/`), a
+ * protocol-relative host (`//cdn/`), or a fully-qualified URL.
+ *
+ * @param {String} basePath
+ * @returns {Boolean}
+ */
+export const isFixedBasePath = basePath =>
+    typeof basePath === 'string' && (basePath.startsWith('/') || /^[a-z][a-z\d+\-.]*:\/\//i.test(basePath));
+
+/**
+ * Applies the `dist/esm` overrides to a parsed `neo-config.json`.
+ *
+ * `basePath` gains `../../` because the config moves two directories deeper in the output tree, and
+ * the value is *position-relative* arithmetic — it compensates for where the config now sits. A fixed
+ * base path is not position-relative and has nothing to compensate for, so prefixing it produced
+ * `../..//mount/`, which no environment can resolve. It passes through untouched.
+ *
+ * `workerBasePath` composes from the ORIGINAL `basePath` rather than the prefixed one, and that
+ * asymmetry is intentional and pre-existing — the worker path is resolved from a different origin.
+ * Preserved exactly.
+ *
+ * @param {Object} config parsed neo-config.json; mutated in place, matching the caller's contract
+ * @param {Object}  options
+ * @param {Boolean} options.insideNeo
+ * @returns {Object} the same object
+ */
+export function rewriteNeoConfig(config, {insideNeo}) {
+    const {basePath} = config;
+
+    Object.assign(config, {
+        basePath      : isFixedBasePath(basePath) ? basePath : '../../' + basePath,
+        environment   : 'dist/esm',
+        mainPath      : './Main.mjs',
+        workerBasePath: basePath + 'src/worker/'
+    });
+
+    if (!insideNeo) {
+        config.appPath = config.appPath.substring(6)
+    }
+
+    return config
+}
+
+/**
+ * The directory trees copied into `dist/esm`.
+ *
+ * The list used to be a hardcoded four entries, so a workspace keeping shared view code in any other
+ * root-level tree — a component library beside `apps/` — produced a `dist/esm` whose app files import
+ * siblings that were never copied. Nothing warned; the app worker simply died fetching a module.
+ *
+ * Extra roots are declared in the workspace's own `package.json`, not passed as a CLI flag, because
+ * `buildScripts/build/all.mjs` spawns this build with no argv — a flag would be unreachable through
+ * the primary entry point and only work when the script was invoked directly.
+ *
+ * Declared roots are additive and de-duplicated; the defaults cannot be dropped.
+ *
+ * @param {Object}  options
+ * @param {Boolean} options.insideNeo
+ * @param {Object}  options.packageJson the consuming workspace's manifest
+ * @returns {String[]}
+ */
+export function resolveSourceRoots({insideNeo, packageJson}) {
+    const
+        defaults = insideNeo
+            ? ['apps', 'docs', 'examples', 'src']
+            : ['apps', 'docs', 'node_modules/neo.mjs/src', 'src'],
+        declared = packageJson?.neo?.esmSourceRoots;
+
+    if (!declared) {
+        return defaults
+    }
+
+    if (!Array.isArray(declared) || declared.some(entry => typeof entry !== 'string' || !entry)) {
+        throw new Error('package.json "neo.esmSourceRoots" must be an array of non-empty strings')
+    }
+
+    return [...new Set([...defaults, ...declared])]
+}
+
+/**
+ * Every relative specifier imported by a piece of emitted code.
+ *
+ * @param {String} code
+ * @returns {String[]}
+ */
+export function relativeSpecifiers(code) {
+    return [...code.matchAll(createRelativeSpecifierRegex())].map(match => match[2])
+}
+
+/**
+ * Reports every emitted module whose relative imports do not resolve to a file that was emitted.
+ *
+ * This is the guard the build never had. Both shipped defect classes end the same way — a specifier
+ * pointing at a file that is not in the output tree — and both were invisible because a copy-and-
+ * minify build has no resolver to complain: an unrewritten `node_modules` path lands inside
+ * `dist/esm` at a path that was never populated, and an uncopied source root leaves a sibling import
+ * dangling. Containment in the output tree is therefore NOT the property to check; existence is.
+ *
+ * @param {Object[]} modules `{outputPath, specifiers}` records, as emitted
+ * @param {Function} exists  predicate over an absolute path, injected so specs need no fixture tree
+ * @param {Function} resolve `(from, specifier) => absolutePath`
+ * @returns {Object[]} `{outputPath, specifier, resolved}` for each unresolvable import
+ */
+export function findUnresolvableImports(modules, exists, resolve) {
+    const failures = [];
+
+    modules.forEach(({outputPath, specifiers}) => {
+        specifiers.forEach(specifier => {
+            const resolved = resolve(outputPath, specifier);
+
+            if (!exists(resolved)) {
+                failures.push({outputPath, specifier, resolved})
+            }
+        })
+    });
+
+    return failures
+}

--- a/test/playwright/unit/buildScripts/esmDistTransforms.spec.mjs
+++ b/test/playwright/unit/buildScripts/esmDistTransforms.spec.mjs
@@ -1,0 +1,251 @@
+import {test, expect} from '@playwright/test';
+
+/**
+ * `dist/esm` is a copy-and-minify transform with no module resolver, so every path assumption it
+ * makes is load-bearing at runtime rather than at build time. That is why all three defects behind
+ * this file shipped: each produced a *successful* build whose output could not boot.
+ *
+ * Each arm below is written to fail against the code as it shipped, not merely to describe the fix:
+ *
+ * - the quote class was `["`]`, so the single-quote arm reds on the pattern as it shipped;
+ * - `basePath` was prefixed unconditionally, so the fixed-base-path arms red on the old rewrite;
+ * - the source-root list and the unresolvable-import guard had no implementation at all.
+ *
+ * The relative-`basePath` arm is the opposite kind: it passes both before and after by design. It is
+ * the non-regression control for the fix, and it is the only arm here that is allowed to be green
+ * against the old code.
+ *
+ * @see https://github.com/neomjs/neo/issues/17921
+ */
+test.describe('esmDistTransforms — a dist/esm build that finishes must also be able to boot', () => {
+    let transforms;
+
+    test.beforeAll(async () => {
+        transforms = await import('../../../../buildScripts/util/esmDistTransforms.mjs')
+    });
+
+    test.describe('rewriteImportPaths — the workspace rewrite must see house-style code', () => {
+        /**
+         * The engine's convention, and every generated workspace's, is the single quote. The shipped
+         * pattern matched double quotes and backticks only, so the rewrite that exists for exactly
+         * this case never fired — and Terser then normalized the untouched specifiers to double
+         * quotes, which made the output look rewritten.
+         */
+        ['\'', '"', '`'].forEach(quote => {
+            test(`static import, quoted with ${quote}`, () => {
+                const source = `import Base from ${quote}../../../node_modules/neo.mjs/src/core/Base.mjs${quote};`;
+
+                expect(transforms.rewriteImportPaths(source))
+                    .toBe(`import Base from ${quote}../../../src/core/Base.mjs${quote};`)
+            });
+
+            test(`dynamic import, quoted with ${quote}`, () => {
+                const source = `const m = await import(${quote}../../node_modules/neo.mjs/src/Neo.mjs${quote});`;
+
+                expect(transforms.rewriteImportPaths(source))
+                    .toBe(`const m = await import(${quote}../../src/Neo.mjs${quote});`)
+            })
+        });
+
+        /**
+         * The depth must survive the rewrite. `node_modules/neo.mjs/src` becomes `dist/esm/src` while
+         * `apps` becomes `dist/esm/apps`, so both sides move by the same amount and the number of
+         * `../` segments is unchanged. A rewrite that "worked" but shifted depth would resolve to
+         * nothing, which is the failure this whole file is about.
+         */
+        test('the relative depth is preserved exactly', () => {
+            const rewritten = transforms.rewriteImportPaths(
+                "import x from '../../../../node_modules/neo.mjs/src/util/Function.mjs';");
+
+            expect(rewritten).toBe("import x from '../../../../src/util/Function.mjs';")
+        });
+
+        /** A third-party package is not flattened; it moves two levels deeper with the output tree. */
+        test('a non-neo package keeps node_modules and gains the output-tree offset', () => {
+            expect(transforms.rewriteImportPaths("import x from '../../node_modules/some-lib/index.mjs';"))
+                .toBe("import x from '../../../../node_modules/some-lib/index.mjs';")
+        });
+
+        /** Nothing without `node_modules` is touched; the rewrite must not be a general path mangler. */
+        test('a plain relative import is left alone', () => {
+            const source = "import x from '../view/Viewport.mjs';";
+
+            expect(transforms.rewriteImportPaths(source)).toBe(source)
+        });
+
+        /**
+         * The pattern carries the `g` flag. Handing callers one shared instance would leak
+         * `lastIndex` between them and drop matches depending on call order, so it is a factory —
+         * asserted here because the failure would be intermittent and blamed on anything else.
+         */
+        test('repeated calls are independent', () => {
+            const source = "import a from '../node_modules/neo.mjs/src/A.mjs';";
+
+            expect(transforms.rewriteImportPaths(source)).toBe(transforms.rewriteImportPaths(source))
+        })
+    });
+
+    test.describe('rewriteNeoConfig — only a position-relative basePath may be compensated', () => {
+        /**
+         * The control arm: the relative shape must stay byte-identical. `../../` compensates for the
+         * config sitting two directories deeper in the output tree.
+         */
+        test('a relative basePath still gains the output-tree offset', () => {
+            const config = transforms.rewriteNeoConfig(
+                {appPath: 'apps/x/app.mjs', basePath: '../../'}, {insideNeo: true});
+
+            expect(config.basePath).toBe('../../../../');
+            expect(config.environment).toBe('dist/esm');
+            expect(config.mainPath).toBe('./Main.mjs')
+        });
+
+        /**
+         * The shipped defect: an absolute mount is not position-relative, so prefixing it emitted
+         * `../..//mount/` — a value no environment resolves.
+         */
+        ['/mount/', '//cdn.example.com/neo/', 'https://cdn.example.com/neo/'].forEach(basePath => {
+            test(`a fixed basePath passes through unchanged: ${basePath}`, () => {
+                const config = transforms.rewriteNeoConfig(
+                    {appPath: 'apps/x/app.mjs', basePath}, {insideNeo: true});
+
+                expect(config.basePath).toBe(basePath)
+            })
+        });
+
+        /**
+         * `workerBasePath` composes from the ORIGINAL basePath, never the compensated one. The
+         * asymmetry is pre-existing and deliberate, and a fix to `basePath` must not quietly change
+         * it — so it is pinned on both shapes.
+         */
+        test('workerBasePath composes from the original basePath in both shapes', () => {
+            expect(transforms.rewriteNeoConfig(
+                {appPath: 'apps/x/app.mjs', basePath: '../../'}, {insideNeo: true}).workerBasePath)
+                .toBe('../../src/worker/');
+
+            expect(transforms.rewriteNeoConfig(
+                {appPath: 'apps/x/app.mjs', basePath: '/mount/'}, {insideNeo: true}).workerBasePath)
+                .toBe('/mount/src/worker/')
+        });
+
+        test('a workspace build trims the appPath prefix, an in-engine build does not', () => {
+            expect(transforms.rewriteNeoConfig(
+                {appPath: '../../apps/x/app.mjs', basePath: '../../'}, {insideNeo: false}).appPath)
+                .toBe('apps/x/app.mjs');
+
+            expect(transforms.rewriteNeoConfig(
+                {appPath: 'apps/x/app.mjs', basePath: '../../'}, {insideNeo: true}).appPath)
+                .toBe('apps/x/app.mjs')
+        })
+    });
+
+    test.describe('resolveSourceRoots — a workspace may keep source outside the four known trees', () => {
+        const workspace = {name: 'my-workspace'};
+
+        test('the defaults are unchanged when nothing is declared', () => {
+            expect(transforms.resolveSourceRoots({insideNeo: false, packageJson: workspace}))
+                .toEqual(['apps', 'docs', 'node_modules/neo.mjs/src', 'src']);
+
+            expect(transforms.resolveSourceRoots({insideNeo: true, packageJson: workspace}))
+                .toEqual(['apps', 'docs', 'examples', 'src'])
+        });
+
+        /** The shipped defect: a component library beside `apps/` was never copied, and nothing said so. */
+        test('declared roots are added to the defaults', () => {
+            expect(transforms.resolveSourceRoots({
+                insideNeo  : false,
+                packageJson: {...workspace, neo: {esmSourceRoots: ['components', 'shared']}}
+            })).toEqual(['apps', 'docs', 'node_modules/neo.mjs/src', 'src', 'components', 'shared'])
+        });
+
+        /** Additive, never subtractive: a workspace cannot drop a default by re-declaring the list. */
+        test('a declared root that duplicates a default does not appear twice', () => {
+            expect(transforms.resolveSourceRoots({
+                insideNeo  : false,
+                packageJson: {...workspace, neo: {esmSourceRoots: ['src', 'components']}}
+            })).toEqual(['apps', 'docs', 'node_modules/neo.mjs/src', 'src', 'components'])
+        });
+
+        /**
+         * A malformed declaration must be loud. Silently ignoring it would reproduce the exact defect
+         * this option exists to fix, while looking configured.
+         */
+        [{esmSourceRoots: 'components'}, {esmSourceRoots: ['ok', '']}, {esmSourceRoots: [1]}].forEach((neo, index) => {
+            test(`a malformed esmSourceRoots declaration throws (case ${index})`, () => {
+                expect(() => transforms.resolveSourceRoots({insideNeo: false, packageJson: {...workspace, neo}}))
+                    .toThrow(/esmSourceRoots/)
+            })
+        })
+    });
+
+    test.describe('relativeSpecifiers — read from emitted code, which Terser has already normalized', () => {
+        test('all quote styles and both import forms are seen', () => {
+            const emitted = [
+                'import a from"./a.mjs";',
+                "import b from '../b.mjs';",
+                'import(`./c.mjs`);',
+                'export*from"../d.mjs";',
+                'import"./side-effect.mjs";'
+            ].join('');
+
+            expect(transforms.relativeSpecifiers(emitted).sort())
+                .toEqual(['../b.mjs', '../d.mjs', './a.mjs', './c.mjs', './side-effect.mjs'])
+        });
+
+        /** Bare specifiers are the resolver's business, not the output tree's. */
+        test('bare package specifiers are ignored', () => {
+            expect(transforms.relativeSpecifiers('import x from"neo.mjs";')).toEqual([])
+        })
+    });
+
+    test.describe('findUnresolvableImports — existence, not containment, is the property', () => {
+        const resolve = (outputPath, specifier) =>
+            specifier.startsWith('./')
+                ? outputPath.replace(/[^/]+$/, '') + specifier.slice(2)
+                : outputPath.replace(/[^/]+\/[^/]+$/, '') + specifier.slice(3);
+
+        test('a resolvable tree reports nothing', () => {
+            const failures = transforms.findUnresolvableImports(
+                [{outputPath: 'dist/esm/apps/x/app.mjs', specifiers: ['./view.mjs']}],
+                candidate => candidate === 'dist/esm/apps/x/view.mjs',
+                resolve);
+
+            expect(failures).toEqual([])
+        });
+
+        /**
+         * The decisive arm. An unrewritten `node_modules` specifier lands at a path that is INSIDE
+         * `dist/esm` and was simply never populated — so a containment check calls it fine and the
+         * build greens on output that cannot boot. Only existence separates the two.
+         */
+        test('an import inside the output tree but never emitted is a failure', () => {
+            const failures = transforms.findUnresolvableImports(
+                [{outputPath: 'dist/esm/apps/x/app.mjs', specifiers: ['./node_modules/neo.mjs/src/Neo.mjs']}],
+                () => false,
+                resolve);
+
+            expect(failures).toHaveLength(1);
+            expect(failures[0].outputPath).toBe('dist/esm/apps/x/app.mjs');
+            expect(failures[0].specifier).toBe('./node_modules/neo.mjs/src/Neo.mjs')
+        });
+
+        /** The uncopied-source-root shape: a sibling import that no root ever emitted. */
+        test('an import into an uncopied source root is a failure and names the specifier', () => {
+            const failures = transforms.findUnresolvableImports(
+                [{outputPath: 'dist/esm/apps/x/app.mjs', specifiers: ['../../components/Button.mjs']}],
+                () => false,
+                resolve);
+
+            expect(failures).toHaveLength(1);
+            expect(failures[0].specifier).toBe('../../components/Button.mjs')
+        });
+
+        test('every offending specifier is reported, not just the first', () => {
+            const failures = transforms.findUnresolvableImports(
+                [{outputPath: 'dist/esm/a.mjs', specifiers: ['./x.mjs', './y.mjs']}],
+                () => false,
+                resolve);
+
+            expect(failures.map(entry => entry.specifier)).toEqual(['./x.mjs', './y.mjs'])
+        })
+    })
+});

--- a/test/playwright/unit/buildScripts/esmDistTransforms.spec.mjs
+++ b/test/playwright/unit/buildScripts/esmDistTransforms.spec.mjs
@@ -1,3 +1,4 @@
+import path           from 'path';
 import {test, expect} from '@playwright/test';
 
 /**
@@ -58,6 +59,32 @@ test.describe('esmDistTransforms — a dist/esm build that finishes must also be
                 "import x from '../../../../node_modules/neo.mjs/src/util/Function.mjs';");
 
             expect(rewritten).toBe("import x from '../../../../src/util/Function.mjs';")
+        });
+
+        /**
+         * A re-export is a request the browser makes, so it needs the same rewrite. The pattern
+         * matched `import` only, which left `export … from` addressing the workspace's own engine
+         * from inside `dist/esm` — a path that resolves, so nothing failed; it simply booted a second
+         * engine graph. Reds against the shipped pattern.
+         */
+        [
+            ["export {default} from '../../node_modules/neo.mjs/src/core/Base.mjs';",
+             "export {default} from '../../src/core/Base.mjs';"],
+            ['export*from"../node_modules/neo.mjs/src/Neo.mjs";',
+             'export*from"../src/Neo.mjs";'],
+            ["export * as Neo from '../node_modules/neo.mjs/src/Neo.mjs';",
+             "export * as Neo from '../src/Neo.mjs';"]
+        ].forEach(([source, expected], index) => {
+            test(`a re-export of the engine is rewritten too (form ${index})`, () => {
+                expect(transforms.rewriteImportPaths(source)).toBe(expected)
+            })
+        });
+
+        /** The rewrite must stay a specifier rewrite: an ordinary export naming the string is not one. */
+        test('an exported string that merely contains node_modules is untouched', () => {
+            const source = "export const dir = 'x/node_modules/neo.mjs/y';";
+
+            expect(transforms.rewriteImportPaths(source)).toBe(source)
         });
 
         /** A third-party package is not flattened; it moves two levels deeper with the output tree. */
@@ -174,6 +201,52 @@ test.describe('esmDistTransforms — a dist/esm build that finishes must also be
                 expect(() => transforms.resolveSourceRoots({insideNeo: false, packageJson: {...workspace, neo}}))
                     .toThrow(/esmSourceRoots/)
             })
+        });
+
+        /**
+         * The declared root is not only an input path: the build resolves it a second time against
+         * `dist/esm` to decide where to WRITE. An unconstrained entry is therefore an output
+         * authority, and type-checking it while leaving containment open is what turns a convenience
+         * into an overwrite primitive.
+         *
+         * Each entry below is a shape the shipped `resolveSourceRoots` returned verbatim:
+         *
+         * - `/tmp/external` — `path.resolve` discards everything before an absolute segment, so the
+         *   build's input and output become the SAME external directory and it minifies a foreign
+         *   tree in place;
+         * - `C:\external` / `..\..\outside` — the Windows spellings of the same two requests, which
+         *   a POSIX-only check reads as harmless relative directory names;
+         * - `../../outside` — writes into the workspace beside `dist/esm` rather than inside it;
+         * - `dist/esm`, `dist`, `.` — feed the build its own output tree.
+         *
+         * All red against the shipped implementation, which validated only "non-empty string".
+         */
+        ['/tmp/external', 'C:\\external', '../../outside', '..\\..\\outside', 'dist/esm', 'dist/esm/nested', 'dist', '.', './']
+            .forEach(entry => {
+                test(`an unsafe declared root is refused: ${JSON.stringify(entry)}`, () => {
+                    expect(() => transforms.resolveSourceRoots({
+                        insideNeo  : false,
+                        packageJson: {...workspace, neo: {esmSourceRoots: [entry]}}
+                    })).toThrow(/esmSourceRoots/)
+                })
+            });
+
+        /** The guard must not be a blanket refusal: ordinary roots, in either spelling, still pass. */
+        test('safe roots are normalized to the workspace-relative form and kept', () => {
+            expect(transforms.resolveSourceRoots({
+                insideNeo  : false,
+                packageJson: {...workspace, neo: {esmSourceRoots: ['./components/', 'shared\\ui', 'distribution']}}
+            })).toEqual(['apps', 'docs', 'node_modules/neo.mjs/src', 'src', 'components', 'shared/ui', 'distribution'])
+        });
+
+        /** Normalization happens before the check, so the same request cannot be spelled past it. */
+        test('a traversing root is refused however it is spelled', () => {
+            ['.././../outside', './../outside', 'a/../../outside'].forEach(entry => {
+                expect(() => transforms.resolveSourceRoots({
+                    insideNeo  : false,
+                    packageJson: {...workspace, neo: {esmSourceRoots: [entry]}}
+                }), entry).toThrow(/esmSourceRoots/)
+            })
         })
     });
 
@@ -197,7 +270,7 @@ test.describe('esmDistTransforms — a dist/esm build that finishes must also be
         })
     });
 
-    test.describe('findUnresolvableImports — existence, not containment, is the property', () => {
+    test.describe('findUnresolvableImports — existence for a foreign package, identity for the engine', () => {
         const resolve = (outputPath, specifier) =>
             specifier.startsWith('./')
                 ? outputPath.replace(/[^/]+$/, '') + specifier.slice(2)
@@ -246,6 +319,72 @@ test.describe('esmDistTransforms — a dist/esm build that finishes must also be
                 resolve);
 
             expect(failures.map(entry => entry.specifier)).toEqual(['./x.mjs', './y.mjs'])
+        });
+
+        /**
+         * These arms use the production resolver rather than the toy one above, because the shape they
+         * describe only exists at real depth: an unrewritten engine specifier climbs out of `dist/esm`
+         * and lands back in the workspace it was copied FROM.
+         */
+        const resolveReal = (outputPath, specifier) => path.resolve(path.dirname(outputPath), specifier);
+
+        /**
+         * The arm that reds against the existence-only guard. The target is the workspace's real
+         * `node_modules/neo.mjs` source, so `exists` says yes and the build greened — while the app
+         * loaded a second engine graph beside the copy in `dist/esm/src`, each with its own class
+         * registry and its own singletons. Nothing about that is observable as a missing file, which
+         * is exactly why existence is the wrong property for the one package the output owns.
+         */
+        test('an engine import that resolves to the real workspace source is still a failure', () => {
+            const failures = transforms.findUnresolvableImports(
+                [{
+                    outputPath: '/workspace/dist/esm/apps/x/app.mjs',
+                    specifiers: ['../../../../node_modules/neo.mjs/src/Neo.mjs']
+                }],
+                () => true,
+                resolveReal);
+
+            expect(failures).toHaveLength(1);
+            expect(failures[0].reason).toBe('engine-identity');
+            expect(failures[0].resolved).toBe('/workspace/node_modules/neo.mjs/src/Neo.mjs')
+        });
+
+        /**
+         * The non-vacuity control for the arm above: the rewrite deliberately points third-party
+         * packages back OUT of the output tree, so an existing target outside `dist/esm` must still
+         * pass. A guard that failed this one would be a containment check wearing an identity label,
+         * and it would break every workspace that imports a package.
+         */
+        test('a third-party package outside the output tree passes when it exists', () => {
+            expect(transforms.findUnresolvableImports(
+                [{
+                    outputPath: '/workspace/dist/esm/apps/x/app.mjs',
+                    specifiers: ['../../../../node_modules/some-lib/index.mjs']
+                }],
+                () => true,
+                resolveReal)).toEqual([])
+        });
+
+        /** A package whose name merely starts with the engine's is somebody else's package. */
+        test('a look-alike package name is not mistaken for the engine', () => {
+            expect(transforms.findUnresolvableImports(
+                [{
+                    outputPath: '/workspace/dist/esm/apps/x/app.mjs',
+                    specifiers: ['../../../../node_modules/neo.mjs-examples/index.mjs']
+                }],
+                () => true,
+                resolveReal)).toEqual([])
+        });
+
+        /** The two classes are distinguishable downstream, because the build reports them apart. */
+        test('a missing import is reported as missing, not as an identity failure', () => {
+            const failures = transforms.findUnresolvableImports(
+                [{outputPath: '/workspace/dist/esm/apps/x/app.mjs', specifiers: ['../../components/Button.mjs']}],
+                () => false,
+                resolveReal);
+
+            expect(failures).toHaveLength(1);
+            expect(failures[0].reason).toBe('missing')
         })
     })
 });

--- a/test/playwright/unit/buildScripts/esmWorkspaceBuild.spec.mjs
+++ b/test/playwright/unit/buildScripts/esmWorkspaceBuild.spec.mjs
@@ -27,21 +27,29 @@ test.describe('esmodules.mjs — a greenfield workspace build', () => {
         engineRoot = path.resolve(import.meta.dirname, '../../../..'),
         buildPath  = path.join(engineRoot, 'buildScripts/build/esmodules.mjs');
 
-    let workspace;
+    let workspace, external;
 
     /**
      * Writes the minimum workspace that reproduces the shipped failure. The engine copy is a stub
      * rather than the real `src/`: the defect is about path arithmetic and copy sets, so a real
      * engine would add minutes of Terser work without adding a single observation.
      */
-    const createWorkspace = ({declareExtraRoot}) => {
+    const createWorkspace = ({declareExtraRoot, engineReExport, sourceRoots}) => {
         const root = fs.mkdtempSync(path.join(os.tmpdir(), 'neo-esm-ws-'));
 
         fs.outputJsonSync(path.join(root, 'package.json'), {
             name   : 'my-workspace',
             version: '1.0.0',
+            ...(sourceRoots ? {neo: {esmSourceRoots: sourceRoots}} : {}),
             ...(declareExtraRoot ? {neo: {esmSourceRoots: ['components']}} : {})
         });
+
+        // A re-export of the engine. The rewrite matched `import` only, so this specifier used to
+        // survive into the output and address the workspace's own engine from inside dist/esm.
+        if (engineReExport) {
+            fs.outputFileSync(path.join(root, 'components/engine.mjs'),
+                "export {default as Base} from '../node_modules/neo.mjs/src/core/Base.mjs';\n")
+        }
 
         // The engine, as a workspace consumes it.
         fs.outputFileSync(path.join(root, 'node_modules/neo.mjs/src/core/Base.mjs'),
@@ -76,7 +84,8 @@ test.describe('esmodules.mjs — a greenfield workspace build', () => {
 
     test.afterEach(() => {
         workspace && fs.removeSync(workspace);
-        workspace = null
+        external && fs.removeSync(external);
+        workspace = external = null
     });
 
     test('a configured workspace builds a tree whose every import resolves', () => {
@@ -116,6 +125,64 @@ test.describe('esmodules.mjs — a greenfield workspace build', () => {
         expect(output).toContain('apps/myapp/view/Viewport.mjs');
         expect(output).toContain('components/Button.mjs');
         expect(output).toContain('neo.esmSourceRoots')
+    });
+
+    /**
+     * The declared root decides where the build WRITES, so an unvalidated one is an overwrite
+     * primitive rather than a copy list. `path.resolve` discards every earlier segment once it meets
+     * an absolute one, which collapses the build's input and output onto the same external directory:
+     * the tree is read, minified, and written back over itself, outside the workspace entirely.
+     *
+     * The sentinel is the point of the arm. Asserting only the exit code would pass against a build
+     * that refused for some unrelated reason while still having touched the directory.
+     */
+    test('an absolute declared root is refused and the external tree is left byte-identical', () => {
+        external = fs.mkdtempSync(path.join(os.tmpdir(), 'neo-esm-external-'));
+
+        const
+            sentinelPath = path.join(external, 'keep.mjs'),
+            sentinel     = '// not the build\'s to touch\nexport default class Keep {}\n';
+
+        fs.outputFileSync(sentinelPath, sentinel);
+
+        workspace = createWorkspace({sourceRoots: [external]});
+
+        const {status, output} = runBuild(workspace);
+
+        expect(status, `build should have refused, output:\n${output}`).toBe(1);
+        expect(output).toContain('esmSourceRoots');
+        expect(fs.readFileSync(sentinelPath, 'utf8')).toBe(sentinel);
+        expect(fs.existsSync(path.join(external, 'dist'))).toBe(false)
+    });
+
+    /** The traversing spelling of the same request: it must not emit beside the output tree. */
+    test('a traversing declared root is refused before anything is written', () => {
+        workspace = createWorkspace({sourceRoots: ['../../outside']});
+
+        const {status, output} = runBuild(workspace);
+
+        expect(status, `build should have refused, output:\n${output}`).toBe(1);
+        expect(output).toContain('esmSourceRoots');
+        expect(fs.existsSync(path.join(workspace, 'dist'))).toBe(false)
+    });
+
+    /**
+     * The re-export arm. `export … from` was not part of the rewrite pattern, so this specifier
+     * reached the output unchanged — and there it either dangles or, worse, resolves back to the
+     * workspace's own engine source and boots a second module graph. Either way the build used to
+     * exit 0.
+     */
+    test('a re-export of the engine is rewritten to the flattened copy', () => {
+        workspace = createWorkspace({declareExtraRoot: true, engineReExport: true});
+
+        const {status, output} = runBuild(workspace);
+
+        expect(status, `build failed:\n${output}`).toBe(0);
+
+        const emitted = fs.readFileSync(path.join(workspace, 'dist/esm/components/engine.mjs'), 'utf8');
+
+        expect(emitted).not.toContain('node_modules');
+        expect(emitted).toContain('../src/core/Base.mjs')
     });
 
     /** An absolute mount must survive the config rewrite; `../..//mount/` resolves nowhere. */

--- a/test/playwright/unit/buildScripts/esmWorkspaceBuild.spec.mjs
+++ b/test/playwright/unit/buildScripts/esmWorkspaceBuild.spec.mjs
@@ -1,0 +1,138 @@
+import {execFileSync} from 'child_process';
+import fs             from 'fs-extra';
+import os             from 'os';
+import path           from 'path';
+import {test, expect} from '@playwright/test';
+
+/**
+ * Drives the real `buildScripts/build/esmodules.mjs` over a synthetic greenfield workspace.
+ *
+ * The sibling spec pins the transforms in isolation; this one exists because every defect it covers
+ * was a *composition* failure. Each transform looked reasonable on its own — the build finished, it
+ * printed success, and it exited 0. What was broken was the relationship between what the build
+ * copied and what the emitted code asked for, and only running the script end to end over a workspace
+ * layout can observe that.
+ *
+ * The workspace shape is the one that broke: an app importing the engine from `node_modules/neo.mjs`
+ * with house-style single quotes, plus a component library in a root-level tree outside the four
+ * hardcoded roots.
+ *
+ * BOUNDS: this asserts the build produces a tree whose every import resolves. It does NOT boot the
+ * output in a browser — see the ticket's AC-4, which remains open for the headless boot arm.
+ *
+ * @see https://github.com/neomjs/neo/issues/17921
+ */
+test.describe('esmodules.mjs — a greenfield workspace build', () => {
+    const
+        engineRoot = path.resolve(import.meta.dirname, '../../../..'),
+        buildPath  = path.join(engineRoot, 'buildScripts/build/esmodules.mjs');
+
+    let workspace;
+
+    /**
+     * Writes the minimum workspace that reproduces the shipped failure. The engine copy is a stub
+     * rather than the real `src/`: the defect is about path arithmetic and copy sets, so a real
+     * engine would add minutes of Terser work without adding a single observation.
+     */
+    const createWorkspace = ({declareExtraRoot}) => {
+        const root = fs.mkdtempSync(path.join(os.tmpdir(), 'neo-esm-ws-'));
+
+        fs.outputJsonSync(path.join(root, 'package.json'), {
+            name   : 'my-workspace',
+            version: '1.0.0',
+            ...(declareExtraRoot ? {neo: {esmSourceRoots: ['components']}} : {})
+        });
+
+        // The engine, as a workspace consumes it.
+        fs.outputFileSync(path.join(root, 'node_modules/neo.mjs/src/core/Base.mjs'),
+            'export default class Base {}\n');
+
+        // The component library that lives outside the four hardcoded roots.
+        fs.outputFileSync(path.join(root, 'components/Button.mjs'),
+            "import Base from '../node_modules/neo.mjs/src/core/Base.mjs';\nexport default class Button extends Base {}\n");
+
+        // The app. Single-quoted, which is the house style the rewrite used not to match.
+        fs.outputFileSync(path.join(root, 'apps/myapp/view/Viewport.mjs'),
+            "import Base   from '../../../node_modules/neo.mjs/src/core/Base.mjs';\n" +
+            "import Button from '../../../components/Button.mjs';\n" +
+            'export default class Viewport extends Base {static button = Button}\n');
+
+        fs.outputJsonSync(path.join(root, 'apps/myapp/neo-config.json'), {
+            appPath : '../../apps/myapp/app.mjs',
+            basePath: '../../'
+        });
+
+        return root
+    };
+
+    /** Runs the build in the workspace, returning `{status, output}` rather than throwing. */
+    const runBuild = cwd => {
+        try {
+            return {status: 0, output: execFileSync('node', [buildPath], {cwd, encoding: 'utf8', stdio: 'pipe'})}
+        } catch (error) {
+            return {status: error.status, output: `${error.stdout || ''}${error.stderr || ''}`}
+        }
+    };
+
+    test.afterEach(() => {
+        workspace && fs.removeSync(workspace);
+        workspace = null
+    });
+
+    test('a configured workspace builds a tree whose every import resolves', () => {
+        workspace = createWorkspace({declareExtraRoot: true});
+
+        const {status, output} = runBuild(workspace);
+
+        expect(status, `build failed:\n${output}`).toBe(0);
+
+        // The extra root was copied at all — the silent-drop defect.
+        expect(fs.existsSync(path.join(workspace, 'dist/esm/components/Button.mjs'))).toBe(true);
+
+        // The engine was flattened out of node_modules, and the app's single-quoted specifier was
+        // rewritten to reach it. Asserted through the emitted code, which is what the browser reads.
+        const emitted = fs.readFileSync(path.join(workspace, 'dist/esm/apps/myapp/view/Viewport.mjs'), 'utf8');
+
+        expect(emitted).not.toContain('node_modules');
+        expect(fs.existsSync(path.join(workspace, 'dist/esm/src/core/Base.mjs'))).toBe(true);
+
+        // The config's relative basePath still gains the output-tree offset.
+        expect(fs.readJsonSync(path.join(workspace, 'dist/esm/apps/myapp/neo-config.json')).basePath)
+            .toBe('../../../../')
+    });
+
+    /**
+     * The decisive arm. Before this change the same workspace built "successfully" and exited 0 while
+     * emitting an app that imports a component tree nobody copied — the app worker then died on
+     * `Failed to fetch dynamically imported module`, with nothing in the build output to explain it.
+     */
+    test('an undeclared source root fails the build and names the file and specifier', () => {
+        workspace = createWorkspace({declareExtraRoot: false});
+
+        const {status, output} = runBuild(workspace);
+
+        expect(status, `build should have failed, output:\n${output}`).toBe(1);
+        expect(output).toContain('do not resolve inside the output tree');
+        expect(output).toContain('apps/myapp/view/Viewport.mjs');
+        expect(output).toContain('components/Button.mjs');
+        expect(output).toContain('neo.esmSourceRoots')
+    });
+
+    /** An absolute mount must survive the config rewrite; `../..//mount/` resolves nowhere. */
+    test('an absolute basePath passes through the emitted neo-config', () => {
+        workspace = createWorkspace({declareExtraRoot: true});
+        fs.outputJsonSync(path.join(workspace, 'apps/myapp/neo-config.json'), {
+            appPath : '../../apps/myapp/app.mjs',
+            basePath: '/mount/'
+        });
+
+        const {status, output} = runBuild(workspace);
+
+        expect(status, `build failed:\n${output}`).toBe(0);
+
+        const config = fs.readJsonSync(path.join(workspace, 'dist/esm/apps/myapp/neo-config.json'));
+
+        expect(config.basePath).toBe('/mount/');
+        expect(config.workerBasePath).toBe('/mount/src/worker/')
+    })
+});


### PR DESCRIPTION
Resolves #17921

Three defects made a workspace `dist/esm` build finish, print success, exit 0, and emit a tree the app worker could not load. All three are fixed, and the failure class now fails the build instead of shipping. `dist/development` and `dist/production` are webpack bundles, so webpack follows imports wherever they point and none of these assumptions ever had to hold; `dist/esm` is a copy-and-minify transform with no resolver, which is why all three accumulated unnoticed.

Evidence: L2 (source-bound mutation proof — every arm reverted against the code as it shipped, plus the real build script driven over a greenfield workspace) → L2 required (all close-target ACs are build-time and CI-reachable). Residual: none for this close target; the headless-boot arm was carved out of AC-4 to #17931. Residual-Owner: #17931.

| # | Defect | Fix |
|---|---|---|
| 1 | The rewrite's quote class was `["`]` and the house style is the single quote, so the workspace rewrite never fired on the code it was written for. Terser then normalized the untouched specifiers to double quotes, which made the output *look* rewritten. | Quote class is `["'`]`; all three classes pinned for static and dynamic imports. |
| 2 | `inputDirectories` was a hardcoded four-entry list, so a source root outside it was silently not copied. | Extra roots are declared as `neo.esmSourceRoots` in the workspace manifest, additive to the defaults. |
| 3 | `basePath` was prefixed unconditionally, so an absolute mount became `../..//mount/`. | A fixed base path — absolute, protocol-relative or fully-qualified — passes through unchanged; the relative shape stays byte-identical. |

**Existence for a foreign package, identity for the engine.** Both defect classes end the same way — a specifier pointing at a file not in the output tree — but an unrewritten `node_modules` path lands *inside* `dist/esm` at a location nothing ever populated, so a containment check calls it fine, and the rewrite deliberately points third-party packages back *out* at `../../node_modules/`, so containment is not checkable for them either. Existence separates those.

Existence is not sufficient for the one package the output owns. @neo-gpt-emmy's RA-2 was right: an emitted specifier still naming `node_modules/neo.mjs` resolves to the workspace's own engine *source*, so it exists, the guard passed, and the app booted two disjoint module graphs — defect 1 of the ticket, surviving in a form no path check would report. That shape now fails on **identity**, whatever is on disk, and is reported apart from the missing set because the two need different fixes. `export … from` joined the rewrite for the same reason: a re-export is a request the browser makes.

**One defect the ticket did not name:** `minifyFile`'s catch swallowed. A file that threw was simply absent from `dist/esm` and the build still exited 0 — the same silent-success mode as an unrewritten import, on the error path. Failures are collected and the build refuses to exit 0.

The pure transforms moved to `buildScripts/util/esmDistTransforms.mjs` because the build script does its work at module scope: importing it runs a build, and a transform that cannot be imported cannot be pinned by a spec.

## AC Evidence

| AC-1 | CI-covered: `test/playwright/unit/buildScripts/esmDistTransforms.spec.mjs` — six quote/form arms (single, double, backtick × static, dynamic) plus depth-preservation, third-party passthrough and no-op arms |
| AC-2 | CI-covered: `esmDistTransforms.spec.mjs` (`resolveSourceRoots` incl. nine unsafe-root arms and two safe controls, `findUnresolvableImports` incl. the identity arms) and `esmWorkspaceBuild.spec.mjs` — "an undeclared source root fails the build and names the file and specifier", plus the absolute/traversing refusals and the re-export arm. The field's contract is now in #17921's Contract Ledger |
| AC-3 | CI-covered: `esmDistTransforms.spec.mjs` — three fixed-base arms, the relative control, and `workerBasePath` pinned on both shapes; `esmWorkspaceBuild.spec.mjs` asserts it through the emitted config |
| AC-4 | CI-covered: `esmWorkspaceBuild.spec.mjs` drives the real `buildScripts/build/esmodules.mjs` over a synthetic greenfield workspace and asserts every emitted import resolves. The struck-through boot half is owned by #17931 |

## Deltas from ticket

- **AC-4 was split, not reported as met.** The build half shipped; the headless boot arm went to #17931 because it needs the real engine instead of a stub and its own mutation control. #17921's AC-4 is updated to show the carve-out, and @neo-opus-vega is invited there to object if she would rather it had stayed whole.
- **A fourth defect was fixed** beyond the ticket's three: the swallowed catch in `minifyFile`. Same silent-success class, error path instead of transform path — in scope for AC-2's fail-loud intent.
- **Mechanism choice for AC-2.** The ticket allowed a package.json field *or* a CLI flag. `buildScripts/build/all.mjs:155` spawns this build with no argv, so a flag would be unreachable through the primary entry point. A malformed declaration throws rather than being ignored — silently dropping it would reproduce the exact defect the option exists to fix, while looking configured.

## Test Evidence

Every arm is mutation-proven against the code as it shipped; an arm that cannot fail on the defect is not covering it.

| Mutation | Result |
|---|---|
| quote class reverted to `["`]` | **4 failed** — exactly the four single-quote arms |
| `basePath` prefixed unconditionally | **3 failed** — exactly the three fixed-base arms; the relative control stayed green, as designed |
| `findUnresolvableImports` uses containment instead of existence | **3 failed** — exactly the arms asserting that distinction |
| declared roots returned verbatim (the shipped `resolveSourceRoots`) | `/tmp/external`, `../../outside`, `C:\external` and `dist/esm` are all **accepted**; with the caller's own arithmetic `/tmp/external` gives `in=/tmp/external out=/tmp/external` — the same directory. **9 unsafe-root arms + 2 workspace arms fail** against it; the ordinary-root control is identical in both versions |
| rewrite pattern restored to `import`-only | **3 re-export arms fail**, and the workspace re-export arm fails through the real build script |
| `findUnresolvableImports` restored to existence-only | returns `[]` for an engine import whose target exists — **the identity arm fails**; the third-party control is identical in both versions |
| quote class reverted, run through the **real build script** | build **exits 1** naming both offenders: `dist/esm/components/Button.mjs → ../node_modules/neo.mjs/src/core/Base.mjs` and `dist/esm/apps/myapp/view/Viewport.mjs → ../../../node_modules/neo.mjs/src/core/Base.mjs` |

The last row is the one worth reading: with the shipped defect restored, the new guard catches it at build time and names the exact files — the failure that previously exited 0.

## Post-Merge Validation

- [ ] #17931 closes the headless-boot arm carved out of AC-4.

Residual-Owner: #17931

The one thing this PR cannot observe is whether the new guard stays silent against a **full** engine copy — the fixture stubs the engine deliberately, because path arithmetic needs no real engine and Terser over the whole `src/` tree adds minutes. #17931's fixture uses the real engine and is where a false positive would surface. Flagging it for the reviewer rather than parking it as an unowned obligation.

## Commits

- `0f7c1bf31a` — the three transform fixes, the resolution guard, the non-swallowing error path, and both specs.
  *(was listed as `2ba2d2fa7d`, which is not on this branch — the SHA changed and the body kept the old one.)*
- `fcd539ffec` — RA-1 and RA-2: declared source roots are normalized and refused when they can address the output tree; the engine-identity failure class; `export … from` joins the rewrite.
- `74fd9417b2` — @tobiu’s catch: both specifier regexes become module-scope constants and go module-private. A factory returning a literal discards the cache a `const` gives, and exporting it hid the `lastIndex` invariant instead of stating it.

## Found in passing — not fixed here

`buildScripts/util/check-shorthand.mjs:26` still declares `DEFAULT_DIRS = ['ai', 'src', 'test/playwright']`, and the `ai/` tree left this repository in the Engine/Brain split. lint-staged passes explicit paths so the commit path is unaffected, but a bare `node buildScripts/util/check-shorthand.mjs` — what a human runs — dies with `find: ai: No such file or directory`. Out of scope here; happy to file it.

Authored by @neo-opus-grace (Anthropic Claude Opus 5, Claude Code).

