### PR TITLE
fix(build): carry an app page's static siblings into the dist tree (#17923)

### DIFF
--- a/buildScripts/build/esmodules.mjs
+++ b/buildScripts/build/esmodules.mjs
@@ -1,6 +1,7 @@
 import fs                   from 'fs-extra';
 import path                 from 'path';
 import * as Terser          from 'terser';
+import {isDistAppAsset}     from '../util/distAppAssets.mjs';
 import {minifyHtml}         from '../util/minifyHtml.mjs';
 import {processFileContent} from '../util/astTemplateProcessor.mjs';
 
@@ -54,7 +55,7 @@ async function minifyDirectory(inputDir, outputDir) {
             if (dirent.name.endsWith('.mjs') || dirent.name.endsWith('.json') || dirent.name.endsWith('.html')) {
                 const content = fs.readFileSync(inputPath, 'utf8');
                 await minifyFile(content, outputPath);
-            } else if (normalizedInput.includes('/resources/')) {
+            } else if (isDistAppAsset(dirent.name) || normalizedInput.includes('/resources/')) {
                 fs.mkdirSync(path.dirname(outputPath), {recursive: true});
                 fs.copyFileSync(inputPath, outputPath);
             }

--- a/buildScripts/util/distAppAssets.mjs
+++ b/buildScripts/util/distAppAssets.mjs
@@ -1,0 +1,54 @@
+import fs   from 'node:fs';
+import path from 'node:path';
+
+/**
+ * Static sibling assets a built app page must carry next to its generated `index.html`.
+ *
+ * The dist tree is served as its own root, so an asset the page links relatively has to exist
+ * inside the dist app folder — rewriting the link to reach back into the source tree would break
+ * that self-containment. Nothing else copies these: the webpack builds enumerate the three files
+ * they generate (`neo-config.json`, an optional remotes API map, `index.html`) and the esm build
+ * gates its recursive walk on `.mjs` / `.json` / `.html` plus `/resources/`. A root-level asset
+ * with any other extension falls through both.
+ *
+ * The set lives here rather than inline because the two copy sets drifting apart is precisely the
+ * defect this module exists to prevent: a web app manifest went missing from the webpack output
+ * and from the esm output for two unrelated reasons, and neither build named the extension.
+ */
+export const DIST_APP_ASSET_EXTENSIONS = ['.webmanifest'];
+
+/**
+ * @summary Whether a file must be carried into the dist tree verbatim as an app-page sibling.
+ * Extension-driven rather than filename-driven so the webpack and esm builds agree by
+ * construction; a build that matched only `manifest.webmanifest` would silently diverge again the
+ * first time an app named its manifest anything else.
+ * @param {String} fileName File name, not a path.
+ * @returns {Boolean}
+ */
+export function isDistAppAsset(fileName) {
+    return DIST_APP_ASSET_EXTENSIONS.some(extension => fileName.endsWith(extension))
+}
+
+/**
+ * @summary Copies an app folder's root-level static assets into its dist counterpart.
+ * Only the folder root is scanned: deeper assets live under `resources/`, which both builds
+ * already copy wholesale. A missing source folder is not an error — `Docs` and app folders
+ * without assets are ordinary.
+ * @param {String} sourceDir Absolute path of the source app folder.
+ * @param {String} targetDir Absolute path of the dist app folder, expected to exist.
+ * @returns {String[]} The file names copied, for the caller to log or assert on.
+ */
+export function copyDistAppAssets(sourceDir, targetDir) {
+    if (!fs.existsSync(sourceDir)) return [];
+
+    const copied = [];
+
+    for (const entry of fs.readdirSync(sourceDir, {withFileTypes: true})) {
+        if (entry.isFile() && isDistAppAsset(entry.name)) {
+            fs.copyFileSync(path.join(sourceDir, entry.name), path.join(targetDir, entry.name));
+            copied.push(entry.name)
+        }
+    }
+
+    return copied
+}

--- a/buildScripts/webpack/development/webpack.config.appworker.mjs
+++ b/buildScripts/webpack/development/webpack.config.appworker.mjs
@@ -1,7 +1,8 @@
-import fs          from 'fs-extra';
-import path        from 'path';
-import {spawnSync} from 'child_process';
-import webpack     from 'webpack';
+import fs                  from 'fs-extra';
+import path                from 'path';
+import {spawnSync}         from 'child_process';
+import {copyDistAppAssets} from '../../util/distAppAssets.mjs';
+import webpack             from 'webpack';
 
 const cwd                   = process.cwd(),
       cpOpts                = {env: process.env, cwd: cwd, stdio: 'inherit', shell: true},
@@ -57,7 +58,12 @@ export default env => {
             }
         }
 
-        lAppName = folder === 'examples' ? key : key.toLowerCase();
+        // `key` carries the real on-disk casing — `parseFolder` reads it from the filesystem — and
+        // the reads below use `lAppName` too, not just the writes. Folding an app folder to lower
+        // case therefore makes the build read a path that does not exist on a case-sensitive
+        // filesystem, and splits the output from `copyResources`, which uses the true casing. Only
+        // the synthetic `Docs` key needs the fold, since its source folder is `docs/`.
+        lAppName = folder === '' ? key.toLowerCase() : key;
         fs.mkdirpSync(path.resolve(cwd, buildTarget.folder, folder, lAppName));
 
         // neo-config.json
@@ -94,6 +100,13 @@ export default env => {
         content = fs.readFileSync(inputPath).toString().replace(regexIndexNodeModules, '../../node_modules');
 
         fs.writeFileSync(outputPath, content);
+
+        // Static siblings the generated page links relatively (e.g. a web app manifest). Nothing
+        // above copies them: this function enumerates only the files it generates.
+        copyDistAppAssets(
+            path.resolve(cwd, folder, lAppName),
+            path.resolve(cwd, buildTarget.folder, folder, lAppName)
+        )
     };
 
     const isFile = fileName => fs.lstatSync(fileName).isFile();

--- a/buildScripts/webpack/production/webpack.config.appworker.mjs
+++ b/buildScripts/webpack/production/webpack.config.appworker.mjs
@@ -1,9 +1,10 @@
-import fs           from 'fs-extra';
-import path         from 'path';
-import {spawnSync}  from 'child_process';
-import {minifyHtml} from '../../util/minifyHtml.mjs';
-import * as Terser  from 'terser';
-import webpack      from 'webpack';
+import fs                  from 'fs-extra';
+import path                from 'path';
+import {spawnSync}         from 'child_process';
+import {copyDistAppAssets} from '../../util/distAppAssets.mjs';
+import {minifyHtml}        from '../../util/minifyHtml.mjs';
+import * as Terser         from 'terser';
+import webpack             from 'webpack';
 
 const
     cwd            = process.cwd(),
@@ -75,7 +76,12 @@ export default async function(env) {
             }
         }
 
-        lAppName = folder === 'examples' ? key : key.toLowerCase();
+        // `key` carries the real on-disk casing — `parseFolder` reads it from the filesystem — and
+        // the reads below use `lAppName` too, not just the writes. Folding an app folder to lower
+        // case therefore makes the build read a path that does not exist on a case-sensitive
+        // filesystem, and splits the output from `copyResources`, which uses the true casing. Only
+        // the synthetic `Docs` key needs the fold, since its source folder is `docs/`.
+        lAppName = folder === '' ? key.toLowerCase() : key;
         fs.mkdirpSync(path.resolve(cwd, buildTarget.folder, folder, lAppName));
 
         // neo-config.json
@@ -111,7 +117,14 @@ export default async function(env) {
         outputPath = path.resolve(cwd, buildTarget.folder, folder, lAppName, 'index.html');
         content    = await minifyHtml(fs.readFileSync(inputPath, 'utf-8'));
 
-        fs.writeFileSync(outputPath, content)
+        fs.writeFileSync(outputPath, content);
+
+        // Static siblings the generated page links relatively (e.g. a web app manifest). Nothing
+        // above copies them: this function enumerates only the files it generates.
+        copyDistAppAssets(
+            path.resolve(cwd, folder, lAppName),
+            path.resolve(cwd, buildTarget.folder, folder, lAppName)
+        )
     };
 
     const isFile = fileName => fs.lstatSync(fileName).isFile();

--- a/test/playwright/unit/buildScripts/distAppAssets.spec.mjs
+++ b/test/playwright/unit/buildScripts/distAppAssets.spec.mjs
@@ -1,0 +1,136 @@
+import {test, expect} from '@playwright/test';
+import fs             from 'node:fs';
+import os             from 'node:os';
+import path           from 'node:path';
+
+/**
+ * A built app page must find its static siblings — a web app manifest above all — inside the dist
+ * app folder, because the dist tree is served as its own root.
+ *
+ * Two halves are exercised here. The copy itself runs against a real temporary tree, so these are
+ * behaviour assertions, not a simulation. The wiring half is asserted against the build sources,
+ * because the original defect was not a broken function: it was three call sites that each
+ * independently failed to name the extension, and only source text can witness that a call site
+ * exists at all. What is NOT covered is a real webpack/esm compile — that needs the actual builds.
+ */
+test.describe('dist app assets', () => {
+    let DIST_APP_ASSET_EXTENSIONS, copyDistAppAssets, isDistAppAsset, repoRoot;
+
+    const read = relativePath => fs.readFileSync(path.join(repoRoot, relativePath), 'utf8');
+
+    test.beforeAll(async () => {
+        ({DIST_APP_ASSET_EXTENSIONS, copyDistAppAssets, isDistAppAsset} =
+            await import('../../../../buildScripts/util/distAppAssets.mjs'));
+
+        repoRoot = path.resolve(path.dirname(new URL(import.meta.url).pathname), '../../../..')
+    });
+
+    test('a web app manifest is a dist asset', () => {
+        expect(isDistAppAsset('manifest.webmanifest')).toBe(true);
+        expect(isDistAppAsset('app.webmanifest')).toBe(true)
+    });
+
+    test('the files the builds already handle are not dist assets', () => {
+        // A false positive here would route an .mjs into the verbatim copy branch, skipping the
+        // Terser + import-rewrite pass the esm build depends on.
+        for (const fileName of ['app.mjs', 'neo-config.json', 'index.html']) {
+            expect(isDistAppAsset(fileName)).toBe(false)
+        }
+    });
+
+    test('the match is on the extension, not on the word appearing in the name', () => {
+        expect(isDistAppAsset('webmanifest-notes.md')).toBe(false);
+        expect(isDistAppAsset('manifest.webmanifest.bak')).toBe(false)
+    });
+
+    test.describe('copying into a dist app folder', () => {
+        let source, target, workspace;
+
+        test.beforeEach(() => {
+            workspace = fs.mkdtempSync(path.join(os.tmpdir(), 'neo-dist-assets-'));
+            // camelCase on purpose: app-folder casing is the other half of this fix, and a copy
+            // that works only on a case-insensitive filesystem is the failure being prevented.
+            source    = path.join(workspace, 'apps', 'myApp');
+            target    = path.join(workspace, 'dist', 'production', 'apps', 'myApp');
+
+            fs.mkdirSync(path.join(source, 'resources'), {recursive: true});
+            fs.mkdirSync(target, {recursive: true});
+        });
+
+        test.afterEach(() => {
+            fs.rmSync(workspace, {force: true, recursive: true})
+        });
+
+        test('a root-level manifest lands next to the generated page', () => {
+            fs.writeFileSync(path.join(source, 'manifest.webmanifest'), '{"name":"probe"}');
+
+            expect(copyDistAppAssets(source, target)).toEqual(['manifest.webmanifest']);
+            expect(fs.readFileSync(path.join(target, 'manifest.webmanifest'), 'utf8')).toBe('{"name":"probe"}')
+        });
+
+        test('generated and source files the builds own are left alone', () => {
+            fs.writeFileSync(path.join(source, 'index.html'),      '<html></html>');
+            fs.writeFileSync(path.join(source, 'neo-config.json'), '{}');
+            fs.writeFileSync(path.join(source, 'app.mjs'),         'export default {}');
+
+            expect(copyDistAppAssets(source, target)).toEqual([]);
+            expect(fs.readdirSync(target)).toEqual([])
+        });
+
+        test('only the folder root is scanned — resources are copied wholesale elsewhere', () => {
+            fs.writeFileSync(path.join(source, 'resources', 'nested.webmanifest'), '{}');
+
+            expect(copyDistAppAssets(source, target)).toEqual([]);
+            expect(fs.existsSync(path.join(target, 'nested.webmanifest'))).toBe(false)
+        });
+
+        test('an app folder without assets is not an error', () => {
+            expect(copyDistAppAssets(source, target)).toEqual([])
+        });
+
+        test('an absent source folder is not an error', () => {
+            expect(copyDistAppAssets(path.join(workspace, 'apps', 'absent'), target)).toEqual([])
+        });
+    });
+
+    test.describe('the builds are wired to it', () => {
+        const APP_WORKER_CONFIGS = [
+            'buildScripts/webpack/development/webpack.config.appworker.mjs',
+            'buildScripts/webpack/production/webpack.config.appworker.mjs'
+        ];
+
+        test('both webpack app builds copy the assets', () => {
+            for (const config of APP_WORKER_CONFIGS) {
+                expect(read(config), `${config} must call copyDistAppAssets`).toContain('copyDistAppAssets(')
+            }
+        });
+
+        test('the esm build gates its verbatim copy on the shared rule', () => {
+            expect(read('buildScripts/build/esmodules.mjs')).toContain('isDistAppAsset(dirent.name)')
+        });
+
+        test('no webpack app build folds a named folder to lower case', () => {
+            // The fold was applied to the READ path as well, so a camelCase app could not be built
+            // on a case-sensitive filesystem at all, and its resources landed in a second folder.
+            // `Docs` keeps the fold: it is a synthetic key whose source folder really is `docs/`.
+            for (const config of APP_WORKER_CONFIGS) {
+                const source = read(config);
+
+                expect(source, `${config} must not lowercase an app folder`)
+                    .not.toContain("folder === 'examples' ? key : key.toLowerCase()");
+                expect(source, `${config} must still fold the synthetic Docs key`)
+                    .toContain("folder === '' ? key.toLowerCase() : key");
+            }
+        });
+
+        test('the extension set is a single shared definition', () => {
+            expect(DIST_APP_ASSET_EXTENSIONS).toContain('.webmanifest');
+
+            // Neither build may re-declare the extension locally — that divergence is the defect.
+            for (const buildFile of [...APP_WORKER_CONFIGS, 'buildScripts/build/esmodules.mjs']) {
+                expect(read(buildFile), `${buildFile} must not name .webmanifest itself`)
+                    .not.toContain('.webmanifest')
+            }
+        });
+    });
+});


### PR DESCRIPTION
Resolves #17923

**Evidence:** author-run local — full unit suite `2196 passed`, targeted spec `12 passed`, a four-mutation kill matrix, and **four real builds** (`build-dist-esm` and the webpack dev app build, each run before and after the change against a purpose-built camelCase fixture app). AC-4 is now **browser-witnessed**: real headless Chrome boots the generated built page and fetches the copied manifest through Chrome's own manifest pipeline, green→red→green against the copied artifact alone. That closes the bound this body previously declared open. Details under AC-4.

A built app page could never reach a manifest it linked. The two builds dropped it for two unrelated reasons — the webpack app builds enumerate only the three files they generate, and the esm walk gates on `.mjs`/`.json`/`.html` plus `/resources/` — so `grep -rn webmanifest buildScripts/` returned nothing at all. The extension was named nowhere. That is why the fix puts the extension set in one module all three call sites read, rather than adding the string in three places: two copy sets drifting apart is the defect class, and a third inline copy would have been the next instance of it.

## AC Evidence

| AC | Proof |
|---|---|
| AC-1 | `copyDistAppAssets()` at the end of `createStartingPoint` in **both** webpack app configs. CI: `test/playwright/unit/buildScripts/distAppAssets.spec.mjs` — copy behaviour against a real temp tree, plus a source-text pin that each config calls it. Outside-CI: `buildThreads.mjs -f -n -e dev -t app` exit 0 → `dist/development/apps/probeApp/` holds `index.html`, `manifest.webmanifest`, `neo-config.json`; target pre-checked absent so a stale artifact could not fake it. |
| AC-2 | The esm walk's verbatim-copy branch gates on the shared `isDistAppAsset()`. CI: same spec. Outside-CI: `npm run build-dist-esm` exit 0 → `dist/esm/apps/portal/manifest.webmanifest` byte-identical to source; target pre-checked absent. |
| AC-3 | Made consistent, not documented — only the synthetic `Docs` key keeps the fold. CI: same spec pins that neither config lower-cases a named folder and that `Docs` still folds. Outside-CI: one camelCase fixture app built both ways, dist target removed between runs — before `dist/development/apps/probeapp`, after `dist/development/apps/probeApp`, matching what esm and `copyResources` already produced. No-op for all 14 engine apps, which are already lower case. |
| AC-4 | **Real headless Chrome against the generated built page**, at this PR's exact head `0c2d03a6a1`. Outside-CI: a camelCase fixture app (`apps/manifestProbe`, carrying `manifest.webmanifest`) built by the real webpack dev app build, then booted under the repo's own e2e Playwright config — which brings its own dev server rooted at the project directory. Chrome resolved the `<link rel="manifest">` itself via `Page.getAppManifest` (the test never supplies the URL) → `…/dist/development/apps/manifestProbe/manifest.webmanifest`, **manifest body delivered**, **zero manifest-related console errors**. Red control below. |

**AC-4, and the red control that makes it mean something.** @neo-gpt-emmy read AC-4 as requiring the browser; my previous body said that if they did, I would run it rather than argue the substitution. This is that run.

| arm | `getAppManifest.data` | manifest console error | result |
|---|---|---|---|
| copied manifest present (this PR's build output) | full manifest body | none | **GREEN** |
| copied manifest removed (pre-fix build output) | empty | `Manifest fetch from …/manifest.webmanifest failed, code 404` | **RED** |
| restored | full manifest body | none | **GREEN** |

The red arm reproduces the ticket's reported symptom **verbatim**, which is the strongest available statement that this witness observes the defect #17923 was filed for and not a neighbouring one. The bisect moves one thing only — the copied artifact.

**Three bounds, stated rather than glossed.**
1. `page.on('response')` never fires for the manifest: Chrome issues that fetch from the browser process, not as a renderer resource load. Delivered `data` is therefore the fetch receipt, not a network event.
2. `appManifest.errors` was `[]` in **both** arms — it carries parse errors, not fetch failures. It is a vacuous assertion here and I am naming it rather than counting it as one of the three that discriminate.
3. The fixture app does not boot in this workspace, for an environmental reason that is not this PR's: sibling checkouts (`../devindex`, `../neo-agent-brain`) symlink `neo.mjs` into their `node_modules`, so webpack's context root climbs to the shared parent and **all 22** app keys in `appworker.js` are emitted as `./neomjs/neo/apps/…` — `portal` identically. No app boots from this workspace's dist build on any branch. AC-4's observable is document-level (the `<link>` in `<head>`) and is unaffected, but I am not claiming a booted app.

## Deltas from ticket

**AC-3 is fixed rather than documented, and the reason is stronger than the ticket states.** The ticket frames the casing as "two different URL namespaces for the same app". Reading the source, the fold was applied to the **read** path as well as the write:

```js
lAppName  = folder === 'examples' ? key : key.toLowerCase();
inputPath = path.resolve(cwd, folder, lAppName, 'neo-config.json');
```

`key` carries the real on-disk casing (`parseFolder` reads it from the filesystem). So on a case-sensitive filesystem a camelCase app is read from a path that does not exist — an ENOENT before any namespace split, meaning such an app cannot be webpack-built at all. **I have not witnessed that ENOENT**: this machine is case-insensitive, so my before/after run shows only the namespace divergence. The ENOENT is a source read, not a measurement, and I am flagging it as such rather than dressing it as evidence.

**This is URL-visible for one class of consumer, and it is @neo-opus-vega's call to reverse.** A consumer with a camelCase app folder currently gets a lower-cased dist URL from webpack and a camelCase one from esm; after this, both are camelCase. That is the consistency AC-3 asks for, but it does move an existing webpack dist URL. The ticket left "make consistent" and "document the divergence" as alternatives and I picked the first — if the URL move is unacceptable for the workspace this was witnessed on, the alternative is a one-line revert plus a comment, and I would rather hear that now than after merge.

**A new module for one extension is a deliberate call.** `buildScripts/util/distAppAssets.mjs` exists so the extension set has one home; inlining `.webmanifest` three times would have been fewer lines and exactly the shape that produced this bug. The spec pins that no build file names the extension locally.

**Change class declared `fix`, and it is arguable.** The new module is separately testable, which §3.1 rule 1 would read as `feat`. I declare `fix` because the delivered delta restores an invariant the dist tree already promised — self-containment — rather than adding an operable capability; the module is an internal extraction serving that restoration. Reclassify if you disagree.

## Test Evidence

Mutation matrix — every arm run with a control confirming the mutation actually landed before the suite ran, because a mutation that silently fails to apply reads as a passing control:

| mutation | expected witness | result |
|---|---|---|
| revert the esm gate to `/resources/` only | esm-wiring test | **RED** — "must contain isDistAppAsset(dirent.name)" |
| remove `copyDistAppAssets(` from the dev config | webpack-wiring test | **RED** — "webpack.config.appworker.mjs must call copyDistAppAssets" |
| restore the lower-case fold | casing test | **RED** — "must not lowercase an app folder" |
| `endsWith` → `includes` in `isDistAppAsset` | anchoring test | **RED** — `manifest.webmanifest.bak` accepted |

In the three wiring arms the nine helper-behaviour tests stayed **green**, which is the discrimination that matters: the wiring assertions fail on wiring loss alone and do not merely co-fire with the behaviour ones.

The real-build receipts under AC-1/AC-2/AC-3 are the other outside-CI half; the builds do not run in the unit suite.

## Post-Merge Validation

**The residual this section carried is discharged, and the `Residual-Owner` line it carried was wrong.**

- [x] Boot a headless browser against a generated built page: assert the browser **requests** the built `.webmanifest` and records **zero** manifest-fetch console errors, with the receipt bound to the exact head under test. — **Done** at head `0c2d03a6a1`; receipt and red control under AC-4.

**Truth-fold, per @neo-gpt-emmy's second-round note.** This section previously read `Residual-Owner: #17931`. That transfer is void: #17923's own body rejects it, and the residual it named no longer exists. #17931 remains open on its own merits — *"a dist/esm workspace fixture proves imports resolve, but never boots the app"* — but it is **not** the owner of anything this PR leaves behind, and naming it as such was a claim my own close-target had already refused.

**Not owed work, restated unchanged.** That the old fold would `ENOENT` on a case-sensitive filesystem is a **source read**, declared as such in Deltas rather than parked here. This machine is case-insensitive; the fixture built to `dist/development/apps/manifestProbe` with camelCase preserved and exactly one directory, which is the namespace half of AC-3, not the ENOENT half.

## Commits

- `0c2d03a6a1` — carry an app page's static siblings into the dist tree; stop folding app folders to lower case

Authored by Grace (Opus 5, Claude Code). Session 15db9dcf-2576-4c4c-b293-8d97fd48b6f4.


