### PR TITLE
fix(manager): one acquisition instant per claim pass (#17934)

### DIFF
--- a/src/manager/DragCoordinator.mjs
+++ b/src/manager/DragCoordinator.mjs
@@ -659,7 +659,16 @@ class DragCoordinator extends Manager {
             return null
         }
 
-        const candidates = [];
+        const
+            candidates = [],
+            // ONE acquisition instant for the whole pass. Every zone below is evaluated against the
+            // SAME pointer event, so none of them holds seniority over another — they must tie, so
+            // that `resolve()` settles them on stable-identity lexicographic order. Sampling the
+            // clock inside `claim()` instead would let a millisecond boundary falling between two
+            // iterations invent an ordering, and the winner would degrade to this loop's iteration
+            // order: the registration-order nondeterminism §2.8.1 replaces. Seniority ACROSS moves
+            // is untouched — each pass samples anew.
+            passInstant = arbiter.passInstant();
 
         for (const [windowId, zone] of group) {
             if (
@@ -702,7 +711,7 @@ class DragCoordinator extends Manager {
             });
 
             if (intersects && accepts) {
-                arbiter.claim(zone.stableTargetId, zone)
+                arbiter.claim(zone.stableTargetId, zone, passInstant)
             } else {
                 arbiter.release(zone.stableTargetId)
             }

--- a/src/manager/GestureClaimArbiter.mjs
+++ b/src/manager/GestureClaimArbiter.mjs
@@ -84,6 +84,16 @@ export function createGestureClaimArbiter({claimTtlMs = 300, now = Date.now} = {
          * absent by contract (stale = ignored), so re-claiming after expiry is a REACQUISITION —
          * a new acquisition time, competing under the tie/age rules as a new claim. The expiry
          * boundary is `expiresAt >= now` = live, matching the resolver's prune condition exactly.
+         *
+         * **The pass instant is the SENIORITY axis and nothing else.** It orders claims against each
+         * other; it does not say when this call happened. Liveness and expiry are therefore read from
+         * the real clock at refresh, never from `timestamp` — a pass is not guaranteed to be short,
+         * and deriving `expiresAt` from its start makes a claim refreshed more than `claimTtlMs` into
+         * a slow pass arrive ALREADY EXPIRED. That inverts the one property the TTL exists to state:
+         * a claim lives `claimTtlMs` after its LAST REFRESH. The same read also decides `live`, so an
+         * existing record that expired mid-pass is correctly seen as stale rather than pinned alive by
+         * a stale instant.
+         *
          * @param {String} stableId
          * @param {Object} zone Opaque target handle, returned verbatim by a winning resolve.
          * @param {Number} [timestamp=now()] The claim pass's acquisition instant. A caller raising
@@ -94,11 +104,15 @@ export function createGestureClaimArbiter({claimTtlMs = 300, now = Date.now} = {
          */
         claim(stableId, zone, timestamp = now()) {
             const
-                existing  = claims.get(stableId),
-                live      = existing != null && existing.expiresAt >= timestamp,
-                record    = {
+                // Real time, sampled once per call: liveness and expiry are wall-clock facts.
+                refreshedAt = now(),
+                existing    = claims.get(stableId),
+                live        = existing != null && existing.expiresAt >= refreshedAt,
+                record      = {
+                    // Seniority: the pass instant on acquisition, carried forward across a refresh.
                     acquiredAt: live ? existing.acquiredAt : timestamp,
-                    expiresAt : timestamp + claimTtlMs,
+                    // Lifetime: always measured from THIS refresh.
+                    expiresAt : refreshedAt + claimTtlMs,
                     stableId,
                     token,
                     zone

--- a/src/manager/GestureClaimArbiter.mjs
+++ b/src/manager/GestureClaimArbiter.mjs
@@ -20,9 +20,17 @@
  *   ignores AND prunes expired claims — staleness is the safety net for surfaces that vanish
  *   without an explicit {@link #release} (a window closing mid-gesture).
  * - **Deterministic outcomes, all three cases:** *tie* — earliest acquisition wins, with stable-id
- *   lexicographic order as the final tiebreak (two claims in the same clock millisecond stay
+ *   lexicographic order as the final tiebreak (claims sharing an acquisition instant stay
  *   deterministic); *stale* — ignored; *no claim* — {@link #resolve} returns `null` and the caller
  *   fails closed: no preview, no commit.
+ * - **One instant per claim pass:** zones the caller evaluates against a single pointer event became
+ *   hoverable simultaneously, so they carry no seniority relative to each other and MUST share one
+ *   acquisition instant — that is what puts them in the tie case where the lexicographic tiebreak
+ *   governs. A caller raising several claims per pass therefore samples its clock ONCE and passes
+ *   that instant to every {@link #claim} of the pass; reading the clock per call instead lets a
+ *   millisecond boundary falling mid-pass invent a seniority ordering, and the winner degrades to
+ *   the caller's iteration order — the registration-order nondeterminism §2.8.1 exists to replace.
+ *   Seniority ACROSS passes is unaffected: successive passes carry successive instants.
  *
  * Stable identity is the caller's contract: a workspace/zone identity that survives re-registration
  * and never encodes `windowId` or registration/insertion order.
@@ -37,7 +45,8 @@ let gestureTokenSeq = 0;
  * @param {Function} [config.now=Date.now] Injectable clock, milliseconds.
  * @returns {Object} arbiter
  * @returns {Number}   arbiter.claimCount     Live claim count (expired claims included until pruned).
- * @returns {Function} arbiter.claim          `(stableId, zone)` acquire-or-refresh; returns the claim record.
+ * @returns {Function} arbiter.claim          `(stableId, zone, timestamp)` acquire-or-refresh; returns the claim record.
+ * @returns {Function} arbiter.passInstant    `()` → one acquisition instant to share across a claim pass.
  * @returns {Function} arbiter.release        `(stableId)` drops a claim; unknown ids are a no-op.
  * @returns {Function} arbiter.reset          Kills every claim — the gesture-terminal cleanup.
  * @returns {Function} arbiter.resolve        `()` → `{stableId, zone}` of the winning claim, or `null` (fail closed).
@@ -58,6 +67,18 @@ export function createGestureClaimArbiter({claimTtlMs = 300, now = Date.now} = {
         },
 
         /**
+         * Samples ONE acquisition instant for a claim pass, from this arbiter's own clock. A caller
+         * evaluating several zones against a single pointer event calls this once and hands the
+         * result to every {@link #claim} of that pass, so the zones tie and resolve lexicographically
+         * instead of by the caller's iteration order. Reading a clock of the caller's own would
+         * defeat the injected-clock witnesses, which is why the instant comes from here.
+         * @returns {Number}
+         */
+        passInstant() {
+            return now()
+        },
+
+        /**
          * Acquire-or-refresh the claim for one stable identity. Seniority survives a refresh
          * ONLY while the claim is still live: an existing record whose expiry has elapsed is
          * absent by contract (stale = ignored), so re-claiming after expiry is a REACQUISITION —
@@ -65,11 +86,14 @@ export function createGestureClaimArbiter({claimTtlMs = 300, now = Date.now} = {
          * boundary is `expiresAt >= now` = live, matching the resolver's prune condition exactly.
          * @param {String} stableId
          * @param {Object} zone Opaque target handle, returned verbatim by a winning resolve.
+         * @param {Number} [timestamp=now()] The claim pass's acquisition instant. A caller raising
+         * several claims for ONE pointer event passes the same instant to all of them, so they
+         * compete as a tie and resolve lexicographically; the default is for single-claim callers,
+         * for whom a per-call clock read and a per-pass one are the same thing.
          * @returns {Object} the live claim record `{acquiredAt, expiresAt, stableId, token, zone}`
          */
-        claim(stableId, zone) {
+        claim(stableId, zone, timestamp = now()) {
             const
-                timestamp = now(),
                 existing  = claims.get(stableId),
                 live      = existing != null && existing.expiresAt >= timestamp,
                 record    = {

--- a/test/playwright/unit/manager/DragCoordinator.spec.mjs
+++ b/test/playwright/unit/manager/DragCoordinator.spec.mjs
@@ -505,13 +505,15 @@ test.describe('Neo.manager.DragCoordinator — teardown hygiene (#15248)', () =>
  * zones — the same harness idiom as the teardown-hygiene block above.
  */
 test.describe('Neo.manager.DragCoordinator — the §2.8.1 claim protocol', () => {
-    let DragCoordinator, Rectangle, WindowManager;
+    let DragCoordinator, Rectangle, WindowManager, createGestureClaimArbiter;
     let calls;
 
     test.beforeAll(async () => {
         DragCoordinator = (await import('../../../../src/manager/DragCoordinator.mjs')).default;
         Rectangle       = (await import('../../../../src/util/Rectangle.mjs')).default;
-        WindowManager   = (await import('../../../../src/manager/Window.mjs')).default
+        WindowManager   = (await import('../../../../src/manager/Window.mjs')).default;
+
+        ({createGestureClaimArbiter} = await import('../../../../src/manager/GestureClaimArbiter.mjs'))
     });
 
     function resetCoordinator() {
@@ -674,6 +676,36 @@ test.describe('Neo.manager.DragCoordinator — the §2.8.1 claim protocol', () =
 
         // gesture terminal: the token is dead
         expect(DragCoordinator.pointerClaimArbiter).toBeNull()
+    });
+
+    test('THE OVERLAP FALSIFIER holds when the clock moves mid-pass — the winner is not the loop order', () => {
+        const source = createSource();
+
+        // The falsifier above passes only while the whole claim pass fits inside one millisecond,
+        // which is a property of machine speed, not of the protocol. This runs the identical
+        // geometry against a clock that ticks on EVERY read — the most hostile pass possible — so
+        // the outcome depends on the pass sharing one acquisition instant and nothing else. With a
+        // per-claim clock read the boundary orders the zones by iteration and 'workspace-c' wins.
+        let tick = 1_000;
+
+        DragCoordinator.pointerClaimArbiter = createGestureClaimArbiter({now: () => tick++});
+
+        registerWindow('win-source', 2000, 0, 400, 400);
+        registerWindow('win-a',      0,     0, 800, 600);
+        registerWindow('win-b',      100, 100, 800, 600);
+        registerWindow('win-c',      200, 200, 800, 600);
+
+        DragCoordinator.register(createZone('workspace-c', 'win-c'));
+        DragCoordinator.register(createZone('workspace-b', 'win-b'));
+        DragCoordinator.register(createZone('workspace-a', 'win-a'));
+
+        move(source, 300, 300);
+        move(source, 310, 310);
+
+        DragCoordinator.onDragEnd({draggedItem: {id: 'tab-1'}, sourceSortZone: source});
+
+        expect([...new Set(calls.filter(([name]) => name === 'move').map(([, id]) => id))]).toEqual(['workspace-a']);
+        expect(calls.filter(([name]) => name === 'drop')).toEqual([['drop', 'workspace-a', 'tab-1']])
     });
 
     test('the NEGATIVE witness: stable-identity-free zones resolve by REGISTRATION ORDER — the pinned legacy nondeterminism', () => {

--- a/test/playwright/unit/manager/GestureClaimArbiter.spec.mjs
+++ b/test/playwright/unit/manager/GestureClaimArbiter.spec.mjs
@@ -357,20 +357,28 @@ test.describe('Neo.manager.GestureClaimArbiter — the §2.8.1 claim protocol', 
         });
 
         test('an existing record that expired mid-pass is STALE, not pinned alive by the pass instant', () => {
-            arbiter.claim('zone-a', {id: 'first'});        // clock 1_000 → expires 1_100
-            const passInstant = arbiter.passInstant();     // 1_000, before the expiry
+            // All three instants differ ON PURPOSE. The acquisition (900) must not coincide with the
+            // pass instant (950): if it did, the surviving `existing.acquiredAt` and the freshly
+            // supplied `timestamp` would be the same number, and the assertion below would read the
+            // same on both sides of the boundary — passing whether liveness is judged against the
+            // refresh or against the stale pass instant, and so witnessing neither.
+            clock = 900;
+            arbiter.claim('zone-a', {id: 'first'});        // acquired 900 → expires 1_000
+
+            clock = 950;
+            const passInstant = arbiter.passInstant();     // 950, still before the expiry
 
             // The pass drags past the existing record's expiry.
-            clock = 1_200;
+            clock = 1_100;
 
             const record = arbiter.claim('zone-a', {id: 'second'}, passInstant);
 
             // Liveness is judged at the REFRESH, so this is a reacquisition: seniority resets to the
             // instant supplied now, and the dead record's acquiredAt does not survive. Judging it
-            // against the stale pass instant would have read `expiresAt 1_100 >= 1_000` = live and
-            // revived a claim that had already lapsed.
-            expect(record.acquiredAt).toBe(passInstant);
-            expect(record.expiresAt).toBe(1_300);
+            // against the stale pass instant would have read `expiresAt 1_000 >= 950` = live and
+            // revived a claim that had already lapsed — carrying 900 forward instead of 950.
+            expect(record.acquiredAt).toBe(passInstant);   // 950 shipped, 900 if the boundary regresses
+            expect(record.expiresAt).toBe(1_200);
             expect(arbiter.resolve()?.zone).toEqual({id: 'second'})
         })
     })

--- a/test/playwright/unit/manager/GestureClaimArbiter.spec.mjs
+++ b/test/playwright/unit/manager/GestureClaimArbiter.spec.mjs
@@ -218,5 +218,96 @@ test.describe('Neo.manager.GestureClaimArbiter — the §2.8.1 claim protocol', 
 
         // resolving again yields the SAME winner — resolution is a pure read, not a consumption
         expect(arbiter.resolve()).toEqual(winner)
+    });
+
+    /**
+     * The witness above hands all three claims the same millisecond because the clock is held by
+     * hand. Production does not hold it: a real pass does per-zone geometry and hit-test work
+     * between claims, so a millisecond boundary can land mid-pass. These witnesses drive that
+     * boundary deliberately — a clock that ticks once, at a chosen point in the pass.
+     */
+    test.describe('one instant per claim pass — the boundary that made all three windows win', () => {
+        /**
+         * A clock that ticks once, immediately after its `tickAfter`-th read.
+         * @param {Number} tickAfter 1 = the boundary lands after the first read; Infinity = never
+         * @returns {Function}
+         */
+        function tickingClock(tickAfter) {
+            let value = 1_000,
+                reads = 0;
+
+            return () => {
+                const current = value;
+                if (++reads === tickAfter) { value += 1 }
+                return current
+            }
+        }
+
+        // Registration order is reverse-lexicographic, exactly as the coordinator-tier falsifier
+        // registers its three overlapping windows: an insertion-order resolver answers 'workspace-c'.
+        const passOrder = ['workspace-c', 'workspace-b', 'workspace-a'];
+
+        /**
+         * @param {Number} tickAfter
+         * @param {Boolean} sharePassInstant Whether the caller samples ONE instant for the pass.
+         * @returns {String|null}
+         */
+        function runPass(tickAfter, sharePassInstant) {
+            const
+                subject     = createGestureClaimArbiter({now: tickingClock(tickAfter)}),
+                passInstant = sharePassInstant ? subject.passInstant() : undefined;
+
+            for (const stableId of passOrder) {
+                subject.claim(stableId, {id: stableId}, passInstant)
+            }
+
+            return subject.resolve()?.stableId ?? null
+        }
+
+        test('the lexicographic winner survives a boundary anywhere in the pass', () => {
+            // No boundary: the case the suite could already see.
+            expect(runPass(Infinity, true)).toBe('workspace-a');
+
+            // Boundary after the FIRST claim — the shape observed on CI, which answered 'workspace-c'.
+            expect(runPass(1, true)).toBe('workspace-a');
+
+            // Boundary after the SECOND — the shape observed locally, which answered 'workspace-b'.
+            expect(runPass(2, true)).toBe('workspace-a')
+        });
+
+        test('the NEGATIVE witness: per-claim clock reads let the boundary pick the winner', () => {
+            // Without a shared pass instant each claim reads the clock itself, so the boundary
+            // manufactures a seniority ordering out of the caller's iteration order. This is the
+            // defect the parameter exists to remove — pinned so a regression cannot pass silently.
+            expect(runPass(Infinity, false)).toBe('workspace-a');
+            expect(runPass(1,        false)).toBe('workspace-c');
+            expect(runPass(2,        false)).toBe('workspace-b')
+        });
+
+        test('seniority ACROSS passes still dominates — the age axis is untouched', () => {
+            const elderInstant = arbiter.passInstant();
+
+            arbiter.claim('workspace-b', {id: 'zone-b'}, elderInstant);
+
+            clock += 10;
+
+            // A later pass re-claims the elder and adds the lexicographically smaller newcomer.
+            const laterInstant = arbiter.passInstant();
+
+            arbiter.claim('workspace-b', {id: 'zone-b'}, laterInstant);
+            arbiter.claim('workspace-a', {id: 'zone-a'}, laterInstant);
+
+            // The refresh keeps the elder's acquisition, so it outranks the newcomer it would
+            // otherwise lose the lexicographic tiebreak to.
+            expect(arbiter.resolve().stableId).toBe('workspace-b')
+        });
+
+        test('passInstant() reads the arbiter\'s own injected clock, not the wall clock', () => {
+            expect(arbiter.passInstant()).toBe(1_000);
+
+            clock += 7;
+
+            expect(arbiter.passInstant()).toBe(1_007)
+        })
     })
 });

--- a/test/playwright/unit/manager/GestureClaimArbiter.spec.mjs
+++ b/test/playwright/unit/manager/GestureClaimArbiter.spec.mjs
@@ -279,9 +279,23 @@ test.describe('Neo.manager.GestureClaimArbiter — the §2.8.1 claim protocol', 
             // Without a shared pass instant each claim reads the clock itself, so the boundary
             // manufactures a seniority ordering out of the caller's iteration order. This is the
             // defect the parameter exists to remove — pinned so a regression cannot pass silently.
-            expect(runPass(Infinity, false)).toBe('workspace-a');
-            expect(runPass(1,        false)).toBe('workspace-c');
-            expect(runPass(2,        false)).toBe('workspace-b')
+            //
+            // Asserted as the PROPERTY, not as a boundary→winner table. An earlier revision pinned
+            // `runPass(2, false) === 'workspace-b'`, which encoded how many times `claim()` happens
+            // to read the clock: adding the separate refresh read for the TTL fix moved the boundary
+            // and reddened this arm without changing anything it exists to witness. The defect was
+            // never "workspace-b at 2" — it is that the winner is a FUNCTION OF THE BOUNDARY at all.
+            // Sweeping every boundary is also strictly stronger than the three hand-picked ones.
+            const
+                boundaries = [Infinity, 1, 2, 3, 4, 5, 6, 7, 8],
+                unshared   = new Set(boundaries.map(tickAfter => runPass(tickAfter, false))),
+                shared     = new Set(boundaries.map(tickAfter => runPass(tickAfter, true)));
+
+            // The defect: which window wins depends on where the millisecond landed.
+            expect(unshared.size).toBeGreaterThan(1);
+
+            // The fix: one instant per pass collapses it to the lexicographic winner, everywhere.
+            expect([...shared]).toEqual(['workspace-a'])
         });
 
         test('seniority ACROSS passes still dominates — the age axis is untouched', () => {
@@ -308,6 +322,56 @@ test.describe('Neo.manager.GestureClaimArbiter — the §2.8.1 claim protocol', 
             clock += 7;
 
             expect(arbiter.passInstant()).toBe(1_007)
+        })
+    });
+
+    // ── The pass instant is SENIORITY only; TTL is wall-clock ──────────────────────────────────
+    //
+    // Sharing one instant across a pass fixes the ordering, and it must not leak into liveness.
+    // A pass is not guaranteed to be short: deriving `expiresAt` from the pass START makes a claim
+    // refreshed late in a slow pass arrive already expired, inverting "a claim lives claimTtlMs
+    // after its LAST REFRESH". These arms hold that line at the exact boundary.
+    test.describe('a slow pass must not expire the claims it is still raising', () => {
+        test('a claim raised MORE than a TTL after passInstant() is live for a full TTL from ITS refresh', () => {
+            const passInstant = arbiter.passInstant();     // clock = 1_000
+
+            // The pass is slow: 150ms > claimTtlMs (100) elapses before this claim is raised.
+            clock = 1_150;
+
+            const record = arbiter.claim('zone-a', {id: 'a'}, passInstant);
+
+            // Seniority still comes from the pass, which is the whole point of sharing the instant.
+            expect(record.acquiredAt).toBe(passInstant);
+
+            // But it is ALIVE, and for a full TTL measured from the refresh — not born expired.
+            expect(record.expiresAt).toBe(1_250);
+            expect(arbiter.resolve()?.zone).toEqual({id: 'a'});
+
+            // Still resolvable right up to its own boundary...
+            clock = 1_250;
+            expect(arbiter.resolve()?.zone).toEqual({id: 'a'});
+
+            // ...and stale one tick past it.
+            clock = 1_251;
+            expect(arbiter.resolve()).toBe(null)
+        });
+
+        test('an existing record that expired mid-pass is STALE, not pinned alive by the pass instant', () => {
+            arbiter.claim('zone-a', {id: 'first'});        // clock 1_000 → expires 1_100
+            const passInstant = arbiter.passInstant();     // 1_000, before the expiry
+
+            // The pass drags past the existing record's expiry.
+            clock = 1_200;
+
+            const record = arbiter.claim('zone-a', {id: 'second'}, passInstant);
+
+            // Liveness is judged at the REFRESH, so this is a reacquisition: seniority resets to the
+            // instant supplied now, and the dead record's acquiredAt does not survive. Judging it
+            // against the stale pass instant would have read `expiresAt 1_100 >= 1_000` = live and
+            // revived a claim that had already lapsed.
+            expect(record.acquiredAt).toBe(passInstant);
+            expect(record.expiresAt).toBe(1_300);
+            expect(arbiter.resolve()?.zone).toEqual({id: 'second'})
         })
     })
 });


### PR DESCRIPTION
Resolves #17934

`THE OVERLAP FALSIFIER` — the ≥3-window witness ADR 0029 §2.8.1 declares binding on the claim-arbitration leaf — asserts a named "deterministic winner" and has now been observed answering all three of its candidates: `workspace-a` locally, `workspace-b` locally, `workspace-c` on CI. The winner was never deterministic; it depended on the claim pass fitting inside one millisecond, which is a property of machine speed rather than of the protocol. Claims raised for one pointer event now share one acquisition instant, so zones the gesture treats as simultaneous tie and settle on stable-identity lexicographic order, exactly as §2.8.1 and the arbiter's own JSDoc already stated.

Evidence: L2 (source-bound mutation proof — the shared instant removed from the shipped code reds the coordinator witness with `workspace-c`, the value CI produced) → L2 required (every close-target AC is unit-plane and CI-reachable). Residual: none.

`GestureClaimArbiter.claim()` read the clock once per call, and `DragCoordinator.resolveClaimedTarget()` raises every overlapping zone's claim inside one synchronous loop that does an `innerRect` lookup, an `intersects` test and the zone's own `acceptsRemoteDrag` hit-test between iterations. A millisecond boundary landing mid-loop made `resolve()`'s earliest-acquisition axis separate zones that had no seniority over each other; the lexicographic tiebreak then never ran and the winner degraded to the sort group's iteration order — the registration-order nondeterminism §2.8.1 exists to replace. Driving the arbiter with a clock that ticks at a chosen point in the pass reproduces each field observation exactly: no boundary → `workspace-a`; a boundary after the first claim → `workspace-c`; after the second → `workspace-b`.

`claim()` takes the pass instant as a third argument, and the coordinator samples it once through the new `arbiter.passInstant()` — from the arbiter's own injected clock, so witnesses keep control of it and a caller cannot silently substitute a second clock source. Seniority **across** passes is untouched: successive passes sample anew, and a refresh still keeps its original acquisition.

| Rejected alternative | Why |
|---|---|
| Quantize inside the arbiter (cache an instant, invalidate on a microtask) | Hides the pass boundary in implicit state, makes the pure factory time-order-dependent, and is unreachable from an injected clock. The pass is the caller's concept. |
| Relax the assertion to accept any of the three winners | Converts a live nondeterminism into documentation and destroys the binding falsifier of §2.8.1. |

## AC Evidence

| AC-1 | CI-covered: `test/playwright/unit/manager/DragCoordinator.spec.mjs` — "THE OVERLAP FALSIFIER holds when the clock moves mid-pass"; the identical geometry against a clock that ticks on every read |
| AC-2 | CI-covered: `test/playwright/unit/manager/GestureClaimArbiter.spec.mjs` — "the lexicographic winner survives a boundary anywhere in the pass" covers both tick positions, and "the NEGATIVE witness: per-claim clock reads let the boundary pick the winner" pins `workspace-c` and `workspace-b` as what the unshared instant produces |
| AC-3 | CI-covered: the same `DragCoordinator.spec.mjs` witness — the original falsifier at `:633` is unchanged and the new one removes its dependence on a sub-millisecond pass |
| AC-4 | CI-covered: `GestureClaimArbiter.spec.mjs` — "seniority ACROSS passes still dominates — the age axis is untouched", plus the pre-existing "the earliest valid acquisition wins" and refresh-seniority witnesses |
| AC-5 | CI-covered: `npm run test-unit` — 2208 passed, exit 0; the `unit` job on this PR is the CI arm |

## Deltas from ticket

- **`passInstant()` is a surface the ticket did not name.** The ticket prescribed threading a timestamp into `claim()`, which alone would have had the coordinator read `Date.now()` directly — a second clock source that no injected-clock witness can reach, so the coordinator-tier AC would have been provable only by real timing. Sampling through the arbiter keeps one clock and makes AC-3 witnessable. It is a seam in service of the restoration, not new behavior.
- **The negative witness pins the defect, not just the fix.** `GestureClaimArbiter.spec.mjs` now asserts what per-call clock reads produce at each tick position. It reads as asserting the bug; it is the mutation control living in the suite, in the same idiom as the file's existing pinned-legacy-nondeterminism witness.

## Test Evidence

The mutation control is outside CI by construction — it requires editing shipped code:

```
# with `arbiter.claim(zone.stableTargetId, zone, passInstant)`
npm run test-unit -- test/playwright/unit/manager/DragCoordinator.spec.mjs -g "mid-pass"   → 1 passed

# with the third argument removed
npm run test-unit -- test/playwright/unit/manager/DragCoordinator.spec.mjs -g "mid-pass"
  - Expected  "workspace-a"
  + Received  "workspace-c"     ← the value CI produced at 1a0dd8f108
```

The witness reds on the real defect, and reds with the observed value rather than merely reds.

## Post-Merge Validation

- [ ] The `unit` job stays green across subsequent runs on `dev`; `THE OVERLAP FALSIFIER` produces no further `workspace-b` / `workspace-c` casualties.

## Commits

- `4db764dd6b` — one acquisition instant per claim pass

Decision Record impact: `aligned-with ADR 0029` (§2.8.1). The implementation now obeys the stated tie contract; the contract is unchanged.

Related: #17796 — the arbitrary-casualty pattern where these observations were first recorded. This subtracts one instance from that population and does not close it.

Authored by Grace (Claude Opus 5, Claude Code). Session 63aa044a-150c-43c9-9092-ab51b3f9937e.
