### PR TITLE
Grid cell editing migrates to the View focus anchor (#17935)

### DIFF
--- a/src/grid/plugin/CellEditing.mjs
+++ b/src/grid/plugin/CellEditing.mjs
@@ -1,6 +1,14 @@
 import BaseCellEditing from '../../table/plugin/CellEditing.mjs';
 
 /**
+ * @summary The grid flavor of inline cell editing: the shared plugin over pooled row components.
+ *
+ * Grid bodies differ from table bodies in exactly two contracts the base plugin seams out:
+ * `getCellId` takes a row INDEX (pooled row ids are `…__row-<index % poolSize>`, so a record
+ * argument turns into `row-NaN` and the editor silently never mounts), and rows are pooled
+ * components rather than vdom children of the body root (so the table's `cn[rowIndex]` row
+ * rebuild indexes a wrong or missing node once the grid scrolls). Both overrides mirror what
+ * `grid.Body#onStoreRecordChange` does for record-driven redraws.
  * @class Neo.grid.plugin.CellEditing
  * @extends Neo.table.plugin.CellEditing
  */
@@ -23,11 +31,45 @@ class CellEditing extends BaseCellEditing {
         /**
          * @member {String[]} editorCls=['neo-grid-editor']
          */
-        editorCls: ['neo-grid-editor'],
-        /**
-         * @member {Boolean} focusCells=true
-         */
-        focusCells: true
+        editorCls: ['neo-grid-editor']
+    }
+
+    /**
+     * Grid cell node ids derive from the row index — the store's index, which is the same
+     * mapping `createViewData` assigns pooled rows by, and it follows a filtered store because
+     * `indexOf` walks the filtered items.
+     * @param {Object} record
+     * @param {String} dataField
+     * @returns {String}
+     */
+    getCellNodeId(record, dataField) {
+        let {body} = this.owner;
+
+        return body.getCellId(body.store.indexOf(record), dataField)
+    }
+
+    /**
+     * Pooled-row redraw, mirroring `grid.Body#onStoreRecordChange`: resolve the row COMPONENT
+     * through the window (`storeIndex % poolSize`) and rebuild its vdom without recycling, so
+     * the editor's vdom reference cannot survive the redraw. Off-window rows have no mounted
+     * node to clean.
+     * @param {Object} record
+     * @returns {Promise<void>}
+     */
+    async redrawRow(record) {
+        let {body}        = this.owner,
+            {mountedRows} = body,
+            rowIndex      = body.store.indexOf(record),
+            row;
+
+        if (rowIndex >= mountedRows[0] && rowIndex <= mountedRows[1]) {
+            row = body.items[rowIndex % body.items.length];
+
+            if (row) {
+                row.createVdom(false, false);
+                await body.promiseUpdate()
+            }
+        }
     }
 }
 

--- a/src/table/plugin/CellEditing.mjs
+++ b/src/table/plugin/CellEditing.mjs
@@ -3,6 +3,13 @@ import TextField from '../../form/field/Text.mjs';
 import VdomUtil  from '../../util/VDom.mjs';
 
 /**
+ * @summary Inline cell editing for table & grid containers, written against the View focus anchor.
+ *
+ * DOM focus never sits on a cell: the owning view (grid.View, or the table body where no view
+ * exists) is the single focus anchor, and cells are addressed through the selection model. Every
+ * seam here follows from that: keys register on the anchor's registry, the edit target resolves
+ * from the selection model rather than from a key event's target, and settling an editor returns
+ * focus to the anchor so keyboard navigation continues where the gesture left off.
  * @class Neo.table.plugin.CellEditing
  * @extends Neo.plugin.Base
  */
@@ -32,6 +39,8 @@ class CellEditing extends Plugin {
          */
         editorCls: ['neo-table-editor'],
         /**
+         * True returns DOM focus to the owner's focus anchor after an editor settles, so
+         * keyboard navigation continues from the edited cell's selection.
          * @member {Boolean} focusCells=true
          */
         focusCells: true
@@ -56,11 +65,18 @@ class CellEditing extends Plugin {
 
         let me               = this,
             {owner}          = me,
-            {selectionModel} = owner;
+            // Grids host the selection model on the VIEW (the focus anchor); tables keep it on
+            // the container. The model host is where selectionModelChange fires, too.
+            modelHost        = owner.view ?? owner,
+            {selectionModel} = modelHost;
 
         owner.on({
-            cellDoubleClick     : me.onCellDoubleClick,
-            focusLeave          : me.onFocusLeave,
+            cellDoubleClick: me.onCellDoubleClick,
+            focusLeave     : me.onFocusLeave,
+            scope          : me
+        });
+
+        modelHost.on({
             selectionModelChange: me.onSelectionModelChange,
             scope               : me
         });
@@ -70,11 +86,22 @@ class CellEditing extends Plugin {
             me.onSelectionModelChange({value: selectionModel})
         }
 
-        owner.body.keys.add({
-            Enter: 'onTableKeyDown',
-            Space: 'onTableKeyDown',
-            scope: me
-        })
+        // The focus anchor's registry, NOT the body's: keydown events target the focused
+        // element, and grid.View (where present) is the single focus anchor — key handlers
+        // registered on the body are unreachable there. Tables have no view and anchor on
+        // the body, so the fallback keeps their registry unchanged.
+        let anchor = me.getFocusAnchor(),
+            keys   = {
+                Enter: 'onTableKeyDown',
+                Space: 'onTableKeyDown',
+                scope: me
+            };
+
+        if (anchor.keys?.add) {
+            anchor.keys.add(keys)
+        } else {
+            anchor.keys = keys
+        }
     }
 
     /**
@@ -99,6 +126,43 @@ class CellEditing extends Plugin {
     }
 
     /**
+     * The physical cell node id {@link #mountEditor} patches the editor into. Table body ids
+     * derive from the record directly; grid bodies pool their rows and derive from the row
+     * INDEX, so the grid plugin overrides this seam.
+     * @param {Object} record
+     * @param {String} dataField
+     * @returns {String}
+     */
+    getCellNodeId(record, dataField) {
+        return this.owner.body.getCellId(record, dataField)
+    }
+
+    /**
+     * The component holding DOM focus for the owner: the view where one exists (grid), the body
+     * otherwise (table).
+     * @returns {Neo.component.Base}
+     */
+    getFocusAnchor() {
+        let {owner} = this;
+
+        return owner.view || owner.body
+    }
+
+    /**
+     * The id the active selection model uses for the given cell. Grid cell models speak logical
+     * ids (`<recordId>__<dataField>`), table cell models the physical node id — both bodies
+     * expose the matching builder.
+     * @param {Object} record
+     * @param {String} dataField
+     * @returns {String}
+     */
+    getSelectionCellId(record, dataField) {
+        let {body} = this.owner;
+
+        return body.getLogicalCellId?.(record, dataField) || body.getCellId(record, dataField)
+    }
+
+    /**
      * @param {Object} record
      * @param {String} dataField
      * @returns {Promise<void>}
@@ -111,8 +175,8 @@ class CellEditing extends Plugin {
         let me                  = this,
             {appName, windowId} = me,
             {body}              = me.owner,
-            cellId              = body.getCellId(record, dataField),
-            cellNode            = VdomUtil.find(body.vdom, cellId).vdom,
+            cellId              = me.getCellNodeId(record, dataField),
+            cellNode            = VdomUtil.find(body.vdom, cellId)?.vdom,
             column              = me.owner.headerToolbar.getColumn(dataField),
             editor              = me.editors[dataField],
             value               = record[dataField],
@@ -120,10 +184,13 @@ class CellEditing extends Plugin {
 
         if (me.mountedEditor) {
             await me.unmountEditor();
-            await me.timeout(10)
+            await me.timeout(10);
+
+            // The row redraw rebuilt its cell nodes — the earlier resolution is stale
+            cellNode = VdomUtil.find(body.vdom, cellId)?.vdom
         }
 
-        if (!column.editable) {
+        if (!column.editable || !cellNode) {
             return
         }
 
@@ -170,7 +237,9 @@ class CellEditing extends Plugin {
 
         await me.timeout(30);
 
-        editor.focus()
+        // children:true descends to the input element: the field's outer div is not focusable,
+        // so focusing the component id alone is a silent no-op at the DomAccess layer.
+        editor.focus(editor.id, true)
     }
 
     /**
@@ -238,11 +307,31 @@ class CellEditing extends Plugin {
     }
 
     /**
+     * A cell selection moving off the edited cell settles the editor: committing when the field
+     * is valid & dirty, unmounting otherwise — an abandoned editor must not linger in a cell the
+     * selection has left. Selecting the edited cell itself (every mount flow selects first) is a
+     * no-op.
      * @param {Object} data
+     * @param {String[]} data.selection
+     * @returns {Promise<void>}
      */
-    onSelectionChange(data) {
-        // todo: Once we separate cell selections & focus, we can use this event to mount editors
-        // console.log('onSelectionChange', data);
+    async onSelectionChange({selection}) {
+        let me     = this,
+            editor = me.mountedEditor,
+            editedCellIds;
+
+        if (editor) {
+            // The model speaks logical ids under `useInternalId: false` and physical node ids
+            // otherwise — the edited cell counts as still-selected in either dialect.
+            editedCellIds = [
+                me.getSelectionCellId(editor.record, editor.dataField),
+                me.getCellNodeId(editor.record, editor.dataField)
+            ];
+
+            if (!selection?.some(id => editedCellIds.includes(id))) {
+                await me.submitEditor()
+            }
+        }
     }
 
     /**
@@ -261,17 +350,59 @@ class CellEditing extends Plugin {
      * @returns {Promise<void>}
      */
     async onTableKeyDown(data) {
-        let me       = this,
-            {target} = data,
-            {body}   = me.owner,
-            dataField, record;
+        let me   = this,
+            cell = me.resolveSelectedCell();
 
-        if (!me.mountedEditor && target.cls?.includes('neo-selected')) {
-            dataField = body.getCellDataField(target.id);
-            record    = body.getRecord(target.id);
-
-            await me.mountEditor(record, dataField)
+        if (!me.mountedEditor && cell) {
+            await me.mountEditor(cell.record, cell.dataField)
         }
+    }
+
+    /**
+     * Resolves the edit target from the ACTIVE selection, never from an event target: under the
+     * View focus anchor, key events target the anchor element, so the selected cell exists only
+     * in the selection model. Grid cell models answer logical ids (`<recordId>__<dataField>`),
+     * table cell models physical node ids — both forms resolve here.
+     * @returns {{dataField: String, record: Object}|null}
+     */
+    resolveSelectedCell() {
+        let {owner} = this,
+            model   = (owner.view ?? owner).selectionModel || owner.selectionModel,
+            cellId, dataField, parts, record;
+
+        if (!model?.ntype?.includes('cell') || !model.hasSelection()) {
+            return null
+        }
+
+        cellId    = model.getSelection()[0];
+        record    = owner.body.getRecord(cellId);
+        dataField = owner.body.getCellDataField(cellId);
+
+        if (!record || !dataField) {
+            parts = cellId.split('__');
+
+            if (parts.length === 2) {
+                record    ??= owner.store.get(parts[0]);
+                dataField ||= parts[1]
+            }
+        }
+
+        return record && dataField ? {dataField, record} : null
+    }
+
+    /**
+     * Re-renders the row a settled editor occupied, removing the editor's vdom reference. The
+     * table body owns its row vdom directly; grid bodies pool row components, so the grid
+     * plugin overrides this seam with the pooled redraw.
+     * @param {Object} record
+     * @returns {Promise<void>}
+     */
+    async redrawRow(record) {
+        let {body}   = this.owner,
+            rowIndex = body.store.indexOf(record);
+
+        body.getVdomRoot().cn[rowIndex] = body.createRow({record, rowIndex});
+        await body.promiseUpdate()
     }
 
     /**
@@ -295,7 +426,10 @@ class CellEditing extends Plugin {
         if (cellId) {
             selectionModel?.deselect(cellId, true); // the cell might still count as selected => silent deselect first
             selectionModel?.select(cellId);
-            me.focusCells && me.owner.focus(cellId)
+
+            // Cells are not focusable — DOM focus returns to the anchor, whose keys drive the
+            // next Enter/Space edit on the selection this method just placed.
+            me.focusCells && me.getFocusAnchor().focus()
         }
     }
 
@@ -327,15 +461,12 @@ class CellEditing extends Plugin {
             return
         }
 
-        let me       = this,
-            record   = me.mountedEditor.record,
-            {body}   = me.owner,
-            rowIndex = body.store.indexOf(record);
+        let me     = this,
+            record = me.mountedEditor.record;
 
         me.mountedEditor = null;
 
-        body.getVdomRoot().cn[rowIndex] = body.createRow({record, rowIndex});
-        await body.promiseUpdate()
+        await me.redrawRow(record)
     }
 }
 

--- a/test/playwright/component/grid/CellEditingFocusAnchor.spec.mjs
+++ b/test/playwright/component/grid/CellEditingFocusAnchor.spec.mjs
@@ -1,0 +1,194 @@
+import {test, expect} from '@playwright/test';
+
+/**
+ * What grid inline cell editing actually DOES under the View focus anchor (ticket-ref-ok: this is
+ * the enforcement suite for the focus-anchor migration of table.plugin.CellEditing and its grid
+ * flavor).
+ *
+ * **Why a component arm.** Every defect this suite pins shipped green: the plugin's key handlers
+ * sat on a registry no keydown could reach, its guard read a key target that is never a cell, its
+ * cell focus call was a DomAccess no-op, and its unmount path threw against pooled grid rows —
+ * all invisible to source-text assertions, because each one is a runtime seam between the plugin,
+ * the focus anchor, the selection model and the row pool. So this mounts a real grid in a real
+ * browser, drives real clicks and real keydowns, and reads DOM focus and cell content back.
+ */
+
+const GRID_ID = 'cell-editing-probe-grid';
+
+let gridId;
+
+test.beforeEach(async ({page}) => {
+    await page.goto('test/playwright/component/apps/empty-viewport/index.html');
+    await page.waitForSelector('#component-test-viewport', {state: 'attached'});
+
+    gridId = await page.evaluate(async id => {
+        // ntype configs resolve only for classes the app worker has imported — preload the cell
+        // selection model the same way the grid itself arrives (throwaway standalone instance)
+        await Neo.worker.App.createNeoInstance({
+            importPath: '../selection/grid/CellModel.mjs',
+            ntype     : 'selection-grid-cellmodel',
+            id        : 'cell-model-preload'
+        });
+
+        const grid = await Neo.worker.App.createNeoInstance({
+            importPath: '../grid/Container.mjs',
+            ntype     : 'grid-container',
+            id,
+            parentId  : 'component-test-viewport',
+            height    : 300,
+            width     : 600,
+
+            cellEditing: true,
+
+            body: {
+                selectionModel: {ntype: 'selection-grid-cellmodel'}
+            },
+
+            columnDefaults: {
+                editable: true,
+                width   : 200
+            },
+
+            columns: [
+                {dataField: 'firstname', text: 'Firstname'},
+                {dataField: 'lastname',  text: 'Lastname'}
+            ],
+
+            store: {
+                keyProperty: 'id',
+
+                model: {
+                    fields: [
+                        {name: 'id',        type: 'Int'},
+                        {name: 'firstname', type: 'String'},
+                        {name: 'lastname',  type: 'String'}
+                    ]
+                },
+
+                data: [
+                    {id: 1, firstname: 'Ada',   lastname: 'Lovelace'},
+                    {id: 2, firstname: 'Grace', lastname: 'Hopper'},
+                    {id: 3, firstname: 'Anita', lastname: 'Borg'}
+                ]
+            }
+        });
+
+        if (!grid.success) throw new Error(`grid: ${grid.error.message}`);
+
+        return grid.id
+    }, GRID_ID);
+
+    expect(gridId, 'the grid must mount').toBeTruthy();
+
+    // Rows render once the resize observation lands — wait for a real cell, not just the frame
+    await page.waitForSelector('.neo-grid-cell[data-field=firstname]', {state: 'attached', timeout: 6000})
+});
+
+test.afterEach(async ({page}) => {
+    await page.evaluate(async id => { id && await Neo.worker.App.destroyNeoInstance(id) }, gridId)
+});
+
+/** DOM-level snapshot of everything the suite asserts on. */
+const snap = page => page.evaluate(() => ({
+    active     : document.activeElement?.id ?? document.activeElement?.tagName,
+    editorCells: [...document.querySelectorAll('.neo-grid-editor')].map(el => el.parentElement?.id),
+    firstCell  : document.querySelector('.neo-grid-cell[data-field=firstname]')?.textContent,
+    viewId     : document.querySelector('.neo-grid-view')?.id
+}));
+
+const firstnameCell = (page, nth = 0) => page.locator('.neo-grid-cell[data-field=firstname]').nth(nth);
+
+/**
+ * Click a firstname cell, then place DOM focus on the anchor. Whether a cell CLICK focuses the
+ * view is the selection model's affordance (richer models do it, the plain cell model does not) —
+ * the plugin's contract starts at "the anchor holds focus and a cell is selected", so the harness
+ * establishes exactly that state.
+ */
+const selectAndFocus = async (page, nth = 0) => {
+    await firstnameCell(page, nth).click();
+    await page.evaluate(() => document.querySelector('.neo-grid-view').focus())
+};
+
+test.describe('grid CellEditing — the View focus anchor drives every gesture', () => {
+    test('Enter on a selected cell mounts a focused editor; Escape settles and refocuses the anchor', async ({page}) => {
+        await selectAndFocus(page);
+
+        let state = await snap(page);
+
+        await page.keyboard.press('Enter');
+        await page.waitForSelector('.neo-grid-editor', {state: 'attached', timeout: 4000});
+
+        // The editor is mounted in a cell AND owns DOM focus — the plugin descends to the input
+        await page.waitForSelector('.neo-grid-editor input:focus', {state: 'attached', timeout: 4000});
+
+        state = await snap(page);
+
+        expect(state.editorCells).toHaveLength(1);
+
+        await page.keyboard.press('Escape');
+        await page.waitForSelector('.neo-grid-editor', {state: 'detached', timeout: 4000});
+
+        state = await snap(page);
+
+        // Settled: no editor remains, and focus returned to the anchor for the next key gesture
+        expect(state.editorCells).toHaveLength(0);
+        expect(state.active).toBe(state.viewId)
+    });
+
+    test('moving the cell selection settles a mounted editor — and commits a dirty edit', async ({page}) => {
+        await selectAndFocus(page);
+        await page.keyboard.press('Enter');
+        await page.waitForSelector('.neo-grid-editor', {state: 'attached', timeout: 4000});
+
+        await page.locator('.neo-grid-editor input').fill('Edited');
+
+        // Clicking another row's cell moves the selection off the edited cell
+        await firstnameCell(page, 1).click();
+        await page.waitForSelector('.neo-grid-editor', {state: 'detached', timeout: 4000});
+
+        const state = await snap(page);
+
+        // No zombie editor lingers, and the dirty value committed into the record's cell
+        expect(state.editorCells).toHaveLength(0);
+        expect(state.firstCell).toBe('Edited')
+    });
+
+    test('the abandon-then-reedit cycle produces a mounted AND focused editor', async ({page}) => {
+        await selectAndFocus(page);
+        await page.keyboard.press('Enter');
+        await page.waitForSelector('.neo-grid-editor', {state: 'attached', timeout: 4000});
+
+        // Abandon by selecting the second row, then immediately edit there
+        await selectAndFocus(page, 1);
+        await page.waitForSelector('.neo-grid-editor', {state: 'detached', timeout: 4000});
+        await page.keyboard.press('Enter');
+
+        // The second editor is not a zombie: it mounts AND its input receives real DOM focus
+        await page.waitForSelector('.neo-grid-editor input:focus', {state: 'attached', timeout: 4000});
+
+        expect((await snap(page)).editorCells).toHaveLength(1)
+    });
+
+    test('focus leaving the grid unmounts the editor — the focusLeave contract survives the migration', async ({page}) => {
+        // A focusable sibling OUTSIDE the grid: real DOM focus must actually move for focusLeave
+        await page.evaluate(async () => {
+            await Neo.worker.App.createNeoInstance({
+                importPath: '../button/Base.mjs',
+                ntype     : 'button',
+                id        : 'outside-button',
+                parentId  : 'component-test-viewport',
+                text      : 'outside'
+            })
+        });
+        await page.waitForSelector('#outside-button', {state: 'attached', timeout: 4000});
+
+        await selectAndFocus(page);
+        await page.keyboard.press('Enter');
+        await page.waitForSelector('.neo-grid-editor', {state: 'attached', timeout: 4000});
+
+        await page.click('#outside-button');
+        await page.waitForSelector('.neo-grid-editor', {state: 'detached', timeout: 4000});
+
+        expect((await snap(page)).editorCells).toHaveLength(0)
+    })
+});


### PR DESCRIPTION
Resolves #17935

> 🌿 *Seven ways one plugin still spoke to a focus model that no longer exists — after this change, none of them is speakable.*

## Summary

`table.plugin.CellEditing` (which the grid flavor inherits) predates the grid's single-focus-anchor refactor and broke against it seven witnessed ways: keys on a registry keydowns cannot reach, a guard reading the key target for `neo-selected` (the target is always the View), `focusCells` as a silent DomAccess no-op, abandoned editors lingering as unfocusable zombies, `getCellId(record, …)` against the grid's `(rowIndex, …)` signature (`__row-NaN` → silent rejection — stock grid cell editing never mounted at all), `unmountEditor` calling `createRow` which grid bodies do not have (every unmount path threw in the worker — including the focusLeave handler), and model wiring against `owner.selectionModel` when grids host the model on the VIEW.

The migration: keys register on the focus anchor (`owner.view ?? owner.body`); the edit target resolves from the selection model in both id dialects; two grid-specific seams (`getCellNodeId`, `redrawRow`) land in the previously config-only grid plugin, mirroring `grid.Body#onStoreRecordChange`'s pooled-row idiom; a selection moving off the edited cell settles it (commit when dirty & valid, unmount otherwise); the plugin owns focusing its editor input (`children: true` descent); settling refocuses the anchor.

## AC Evidence

| AC | Proof |
|---|---|
| AC-1 (Enter mounts via anchor + selection model) | `CellEditingFocusAnchor.spec.mjs` arm 1: real grid, real click, real keydown — editor mounts and its input holds DOM focus (`input:focus` waited, not snapshot-raced) |
| AC-2 (focusCells honest) | `selectCell` focuses the anchor; arm 1 asserts `document.activeElement` returns to the view el after Escape |
| AC-3 (cell-switch settles, polarity: commit) | arm 2: dirty edit + selection move → editor detaches, the committed value renders in the cell |
| AC-4 (re-edit focused, no zombie) | arm 3: mount → abandon → re-edit → exactly one editor, input focused |
| AC-5 (focusLeave unmount pinned) | arm 4: real focus departure to an outside button → editor unmounts (previously: worker crash) |
| AC-6/7 (grid seams + model host) | `getCellNodeId`/`redrawRow` overrides + `modelHost = owner.view ?? owner` in connect/resolve/settle; arms 1-4 all run through them |

## Test Evidence

Component suite (real renderer, its own theme preflight): **4/4 green**; full component config: **115 passed** (zero collateral).

Mutation matrix — each fix reverted against the shipped suite:

| Mutation | Result |
|---|---|
| keys registered on the body again | **red** (mount arms) |
| selection-change settle removed | **2 failed** — settle + re-edit arms |
| grid `redrawRow` reverted to the table `createRow` idiom | **3 failed** — every unmount-dependent arm |

Table flavor: base seams keep byte-equivalent table behavior (anchor falls back to the body, `redrawRow` base impl is the previous code verbatim, physical-id resolution path unchanged).

## Deltas from ticket

Three defects beyond the four filed were found during implementation, witnessed, and folded into the ticket body as items 5-7 with matching ACs (the vdom-window suspicion is confirmed and subsumed by item 6).

## Post-Merge Validation

- [ ] Consumer-workspace verification on the reporting grid (the origin symptom: keyboard editing + re-edit cycles + focusLeave settle) — I run it on merge.

## Self-Identification

- **Agent:** Vega (@neo-opus-vega) — Fable 5, Claude Code
- **Origin session:** 914dffcd-0057-46a5-a0c6-9ca807fd5c91

🤖 Generated with [Claude Code](https://claude.com/claude-code)