### PR TITLE
feat(dashboard): bound dock tab drags to Workspace roots (#17926)

### DIFF
--- a/src/dashboard/dock/Workspace.mjs
+++ b/src/dashboard/dock/Workspace.mjs
@@ -1505,6 +1505,11 @@ class Workspace extends Container {
      * reducer and view-sync onto every projected affordance, the consumer's resolvers, and the
      * hook-provided options. {@link #dockProjectionConfig} is merged onto the result.
      *
+     * This Workspace's component id is always the ordinary tab-sort boundary, so a sort-first
+     * gesture can leave its source toolbar and reach sibling dock zones without enabling tear-out.
+     * An explicit `dockTearOutBoundaryContainerId` supplied by {@link #getDockProjectionOptions}
+     * keeps higher precedence inside the adapter.
+     *
      * A `null` document projects the EMPTY shell — the model contract's recoverable fallback
      * (`dockModel === null` → empty projection) — still carrying the `neo-dashboard`
      * default-carrier class, so the token floor reaches an empty workspace.
@@ -1524,6 +1529,10 @@ class Workspace extends Container {
             config = LayoutAdapter.project(document, {
                 onDockCrossZoneDrop: me.onDockCrossZoneDrop.bind(me),
                 ...me.getDockProjectionOptions(),
+                // The Workspace component is the DOM-root authority for ordinary cross-zone tab
+                // motion. An explicit dockTearOutBoundaryContainerId from the hook still wins in
+                // LayoutAdapter; direct adapter consumers must supply this field themselves.
+                dockWorkspaceBoundaryContainerId: me.id,
                 onDockActiveIndexChange: me.onDockActiveIndexChange.bind(me),
                 // Bound unconditionally: a host can project its OWN header actions without enabling
                 // the close action, and wiring the seam inside that opt-in left those intents with

--- a/src/dashboard/dock/projection/LayoutAdapter.mjs
+++ b/src/dashboard/dock/projection/LayoutAdapter.mjs
@@ -402,7 +402,13 @@ class LayoutAdapter extends Base {
      * @param {Object} model
      * @param {Object} [options={}]
      * @param {String|String[]|null} [options.dockTearOutBoundaryContainerId] Main-thread DOM
-     *     boundary whose exit starts a tear-out; omitted values retain the tab-toolbar boundary.
+     *     boundary whose exit starts a tear-out. When present, this takes precedence over
+     *     {@link options.dockWorkspaceBoundaryContainerId}.
+     * @param {String|String[]|null} [options.dockWorkspaceBoundaryContainerId] Main-thread DOM
+     *     boundary for ordinary in-workspace cross-zone tab drags. A
+     *     {@link Neo.dashboard.dock.Workspace} supplies its own component id; direct adapter
+     *     consumers own supplying this option. Omitting both boundary options retains the generic
+     *     tab-toolbar clamp.
      * @param {Boolean} [options.enableVesselConversion=false] Arms the optional source-owned
      *     conversion policy. Consumers keep this false until their physical lifecycle is ready.
      * @param {Boolean} [options.enableStackDrag=false] Decorate the model-resolved stack root
@@ -469,7 +475,13 @@ class LayoutAdapter extends Base {
             // tab.Container. The HOST owns vessel acquisition + the `detachItem` commit at the
             // terminal; the projection only threads the opt-in + the closure seams. Absent = fully
             // in-window, the unchanged default.
-            dockTearOutBoundaryContainerId   : options.dockTearOutBoundaryContainerId ?? null,
+            // The explicit tear-out boundary wins, but the ordinary Workspace-backed projection
+            // no longer needs to opt into tear-out merely to let a tab leave its source toolbar.
+            // Direct adapter consumers still get the generic toolbar clamp when both options are
+            // absent — the adapter owns no component and cannot manufacture a DOM boundary id.
+            dockTabSortBoundaryContainerId   : options.dockTearOutBoundaryContainerId
+                || options.dockWorkspaceBoundaryContainerId
+                || null,
             enableDockCloseAction            : options.enableDockCloseAction === true,
             enableDockTearOut                : options.enableDockTearOut === true,
             enableVesselConversion           : options.enableVesselConversion === true,
@@ -1017,11 +1029,12 @@ class LayoutAdapter extends Base {
                 plugins       : [{module: TabOverflowPlugin}],
                 sortZoneConfig: {
                     module: TabSortZone,
-                    // A dock host spans multiple tab strips. Its composition can therefore name
-                    // the app/window boundary whose EXIT means tear-out; retaining the toolbar
-                    // fallback keeps consumers that omit the option byte-identical.
-                    ...(context.dockTearOutBoundaryContainerId
-                        ? {boundaryContainerId: context.dockTearOutBoundaryContainerId}
+                    // A dock host spans multiple tab strips. Workspace-backed compositions supply
+                    // their root boundary for ordinary cross-zone motion; an explicit tear-out
+                    // boundary has already won during context construction. Direct adapter
+                    // consumers that supply neither option retain the generic toolbar clamp.
+                    ...(context.dockTabSortBoundaryContainerId
+                        ? {boundaryContainerId: context.dockTabSortBoundaryContainerId}
                         : null),
                     dockGroupNodeId : nodeId === context.stackDragNodeId ? nodeId : null,
                     dockItemIds     : items,

--- a/test/playwright/unit/dashboard/DockLayoutAdapter.spec.mjs
+++ b/test/playwright/unit/dashboard/DockLayoutAdapter.spec.mjs
@@ -953,7 +953,31 @@ test.describe('Neo.dashboard.dock.projection.LayoutAdapter', () => {
         expect(plugins[0].module).toBe(TabOverflowPlugin);
     });
 
-    test.describe('tear-out projection threading — opt-in flag + the clone-safe gesture seams', () => {
+    test.describe('tab sort boundary + tear-out projection threading', () => {
+        test('a workspace boundary enables ordinary cross-zone motion without arming tear-out', () => {
+            const result = DockLayoutAdapter.project(createModel(), {
+                dockWorkspaceBoundaryContainerId: 'dock-workspace-root',
+                resolveComponentRef              : componentRef => ({ntype: 'dashboard-panel', reference: componentRef})
+            });
+            const config = result.items[0].headerToolbar.sortZoneConfig;
+
+            expect(config).toMatchObject({
+                allowOverdrag      : false,
+                boundaryContainerId: 'dock-workspace-root',
+                enableProxyToPopup : false
+            })
+        });
+
+        test('an explicit tear-out boundary wins over the workspace default', () => {
+            const result = DockLayoutAdapter.project(createModel(), {
+                dockTearOutBoundaryContainerId  : 'tear-out-root',
+                dockWorkspaceBoundaryContainerId: 'dock-workspace-root',
+                resolveComponentRef             : componentRef => ({ntype: 'dashboard-panel', reference: componentRef})
+            });
+
+            expect(result.items[0].headerToolbar.sortZoneConfig.boundaryContainerId).toBe('tear-out-root')
+        });
+
         test('enableDockTearOut arms the app-boundary popup grammar on every projected tab sort zone and threads the four gesture seams', () => {
             const captured = {cancel: [], entry: [], exit: [], terminal: []};
 
@@ -994,7 +1018,10 @@ test.describe('Neo.dashboard.dock.projection.LayoutAdapter', () => {
                 resolveComponentRef: componentRef => ({ntype: 'dashboard-panel', reference: componentRef})
             });
 
-            expect(result.items[0].headerToolbar.sortZoneConfig.enableProxyToPopup).toBe(false)
+            const config = result.items[0].headerToolbar.sortZoneConfig;
+
+            expect(config.enableProxyToPopup).toBe(false);
+            expect(config).not.toHaveProperty('boundaryContainerId')
         })
     });
 

--- a/test/playwright/unit/dashboard/DockWorkspace.spec.mjs
+++ b/test/playwright/unit/dashboard/DockWorkspace.spec.mjs
@@ -294,6 +294,22 @@ test.describe('Neo.dashboard.dock.Workspace', () => {
         expect(tabsOf(workspace.items[0]).size).toBe(2)
     });
 
+    test('a Workspace-backed projection bounds every tab sort zone to the Workspace root without arming tear-out', () => {
+        workspace = Neo.create(PlainWorkspace, {dockModel: createDocument()});
+
+        const projectedTabs = tabsOf(workspace.projectDockModel());
+
+        expect(projectedTabs.size).toBe(2);
+
+        projectedTabs.forEach(tabContainer => {
+            expect(tabContainer.headerToolbar.sortZoneConfig).toMatchObject({
+                allowOverdrag      : false,
+                boundaryContainerId: workspace.id,
+                enableProxyToPopup : false
+            })
+        })
+    });
+
     test('an action the workspace does not own is re-emitted to the host with its node id', () => {
         workspace = Neo.create(PlainWorkspace, {dockModel: createDocument()});
 

--- a/test/playwright/unit/main/addon/DragDrop.spec.mjs
+++ b/test/playwright/unit/main/addon/DragDrop.spec.mjs
@@ -1653,3 +1653,63 @@ test.describe('Neo.main.addon.DragDrop — the zone registry teardown contract',
         expect(addon.zoneRegistrations).toEqual({})
     })
 });
+
+test.describe('Neo.main.addon.DragDrop — dock sort-first boundary motion (#17926)', () => {
+    test('a sort-first move can leave the toolbar and keep following the pointer inside the workspace boundary', () => {
+        const originalSend = DomEvents.sendMessageToApp,
+              sent         = [];
+
+        const createAddon = boundaryContainerRect => ({
+            allowOverdrag       : false,
+            alwaysFireDragMove  : true,
+            boundaryContainerRect,
+            dragCancelled       : false,
+            dragProxyElement    : {
+                getBoundingClientRect: () => ({height: 20, width: 80}),
+                style                : {}
+            },
+            dragProxyRect       : {height: 20, width: 80},
+            dragZoneId          : 'dock-tab-sort-zone',
+            getEventData        : event => ({clientX: event.detail.clientX, clientY: event.detail.clientY}),
+            isWindowDragging    : false,
+            moveHorizontal      : true,
+            moveVertical        : true,
+            offsetX             : 5,
+            offsetY             : 5,
+            windowDragParked    : false
+        });
+        const move = (addon, clientY) => DragDrop.prototype.onDragMove.call(addon, {
+            detail: {
+                clientX      : 45,
+                clientY,
+                originalEvent: {screenX: 45, screenY: clientY}
+            }
+        });
+
+        DomEvents.sendMessageToApp = data => sent.push(data);
+
+        try {
+            const toolbarBound = createAddon({bottom: 40, left: 0, right: 240, top: 0});
+
+            // The user sorts inside the strip first, then exits it on a later frame.
+            move(toolbarBound, 20);
+            move(toolbarBound, 200);
+
+            expect(sent.map(frame => frame.proxyRect.top)).toEqual([15, 20]);
+
+            sent.length = 0;
+
+            const workspaceBound = createAddon({bottom: 400, left: 0, right: 800, top: 0});
+
+            move(workspaceBound, 20);
+            move(workspaceBound, 200);
+
+            // Same gesture, same non-overdrag policy: the workspace boundary keeps the proxy at
+            // the pointer instead of parking it at the source toolbar's edge.
+            expect(sent.map(frame => frame.proxyRect.top)).toEqual([15, 195]);
+            expect(sent.at(-1)).toMatchObject({clientY: 200, type: 'drag:move'})
+        } finally {
+            DomEvents.sendMessageToApp = originalSend
+        }
+    })
+});


### PR DESCRIPTION
Resolves #17926

Workspace-backed dock projections now use the Workspace component id as the ordinary tab-sort boundary, so a tab can leave its source header and reach sibling dock zones without enabling tear-out. `LayoutAdapter` exposes the separate `dockWorkspaceBoundaryContainerId` option for direct consumers, preserves the generic toolbar clamp when both boundary options are absent, and keeps `dockTearOutBoundaryContainerId` at higher precedence.

Evidence: L2 (exact projection, Workspace composition, and main-thread two-frame drag witnesses) → L2 required (AC1-3). No residuals.

## AC Evidence

| AC | Proof |
|---|---|
| AC-1 | `DockWorkspace.spec.mjs` proves every projected tab uses the Workspace id with tear-out flags off; `DockLayoutAdapter.spec.mjs` proves the direct-consumer fallback stays absent and an explicit tear-out boundary wins. |
| AC-2 | `DragDrop.spec.mjs` drives the exact sort-first sequence: the first frame stays inside the strip, the second leaves it; the toolbar control parks at its edge while the Workspace boundary keeps the proxy at the pointer. |
| AC-3 | `LayoutAdapter.project()` JSDoc now separates the ordinary Workspace boundary from the tear-out boundary, names direct-consumer responsibility, and pins precedence/fallback in the adapter suite. |

## Deltas from ticket

None substantive. The ledger's unnamed adapter field is delivered as `dockWorkspaceBoundaryContainerId`; the generic `tab.Container` boundary and tear-out arming remain unchanged.

## Test Evidence

Mutation control: removing the adapter's `dockWorkspaceBoundaryContainerId` consumption produced exactly two reds—the direct-Adapter contract and the Workspace composition contract—while the remaining 83 selected tests stayed green. Restoring the line returned the focused and full suites to green.

## Post-Merge Validation

None — all three ACs are exact-head unit-observable and run in CI.

Authored by Euclid (GPT-5.6 Sol Ultra, Codex Desktop). Session 01a0534f-a981-7560-93de-8d3d54966db6.
