### PR TITLE
Buffered lists gain an example and real-scroll wheel coverage (#17940)

### DIFF
--- a/examples/list/buffered/MainContainer.mjs
+++ b/examples/list/buffered/MainContainer.mjs
@@ -1,0 +1,78 @@
+import Buffered              from '../../../src/list/Buffered.mjs';
+import ConfigurationViewport from '../../ConfigurationViewport.mjs';
+import MainStore             from './MainStore.mjs';
+import NumberField           from '../../../src/form/field/Number.mjs';
+import PooledRow             from './PooledRow.mjs';
+
+/**
+ * @summary A `Neo.list.Buffered` over 5,000 records with the windowing knobs exposed live.
+ *
+ * The component had no example before this one, which mattered in practice: scroll-fidelity work on
+ * it had nothing to point a browser at, and its two windowing configs — `bufferRowRange` and
+ * `itemHeight` — are exactly the ones whose effect is invisible in a unit test that injects absolute
+ * `scrollTop` values. Changing them here and scrolling shows what they do.
+ *
+ * `itemHeight` is deliberately a round 40px: the mounted range is `Math.floor(scrollTop /
+ * itemHeight)`, so round values let a reader predict which record sits at any offset, and let a test
+ * assert that a small wheel delta moves the viewport by that delta and no further.
+ * @class Neo.examples.list.buffered.MainContainer
+ * @extends Neo.examples.ConfigurationViewport
+ */
+class MainContainer extends ConfigurationViewport {
+    static config = {
+        className           : 'Neo.examples.list.buffered.MainContainer',
+        autoMount           : true,
+        configItemLabelWidth: 130,
+        configItemWidth     : 230,
+        layout              : {ntype: 'hbox', align: 'stretch'}
+    }
+
+    createConfigurationComponents() {
+        let me = this;
+
+        return [{
+            module   : NumberField,
+            clearable: true,
+            labelText: 'bufferRowRange',
+            listeners: {change: me.onConfigChange.bind(me, 'bufferRowRange')},
+            maxValue : 20,
+            minValue : 0,
+            stepSize : 1,
+            value    : me.exampleComponent.bufferRowRange
+        }, {
+            module   : NumberField,
+            clearable: true,
+            labelText: 'itemHeight',
+            listeners: {change: me.onConfigChange.bind(me, 'itemHeight')},
+            maxValue : 120,
+            minValue : 20,
+            stepSize : 10,
+            style    : {marginTop: '10px'},
+            value    : me.exampleComponent.itemHeight
+        }, {
+            module   : NumberField,
+            clearable: true,
+            labelText: 'height',
+            listeners: {change: me.onConfigChange.bind(me, 'height')},
+            maxValue : 800,
+            minValue : 120,
+            stepSize : 40,
+            style    : {marginTop: '10px'},
+            value    : me.exampleComponent.height
+        }]
+    }
+
+    createExampleComponent() {
+        return Neo.create({
+            module        : Buffered,
+            bufferRowRange: 3,
+            height        : 400,
+            itemConfig    : ({record}) => ({module: PooledRow, record}),
+            itemHeight    : 40,
+            store         : MainStore,
+            width         : 300
+        })
+    }
+}
+
+export default Neo.setupClass(MainContainer);

--- a/examples/list/buffered/MainModel.mjs
+++ b/examples/list/buffered/MainModel.mjs
@@ -1,0 +1,26 @@
+import Model from '../../../src/data/Model.mjs';
+
+/**
+ * @summary The record shape backing the buffered-list example.
+ *
+ * Deliberately two fields: a buffered list's cost model depends on row COUNT and row HEIGHT, never
+ * on record width, so a wide model would only obscure what the example demonstrates.
+ * @class Neo.examples.list.buffered.MainModel
+ * @extends Neo.data.Model
+ */
+class MainModel extends Model {
+    static config = {
+        className  : 'Neo.examples.list.buffered.MainModel',
+        keyProperty: 'id',
+
+        fields: [{
+            name: 'id',
+            type: 'Integer'
+        }, {
+            name: 'name',
+            type: 'String'
+        }]
+    }
+}
+
+export default Neo.setupClass(MainModel);

--- a/examples/list/buffered/MainStore.mjs
+++ b/examples/list/buffered/MainStore.mjs
@@ -1,0 +1,30 @@
+import MainModel from './MainModel.mjs';
+import Store     from '../../../src/data/Store.mjs';
+
+/**
+ * @summary 5,000 records — the point of the example is that the DOM pool does NOT grow with this.
+ *
+ * Generated rather than literal: a hand-written array long enough to exercise windowing would be
+ * unreadable, and the exact values carry no meaning. `id` is the `keyProperty`, so it doubles as the
+ * logical index and lets a reader (or a test) predict which record belongs at any scroll offset —
+ * `Math.floor(scrollTop / itemHeight)`. That predictability is what makes the store usable as a
+ * scroll-fidelity fixture.
+ * @member {Object[]} data
+ */
+const recordCount = 5000;
+
+/**
+ * @class Neo.examples.list.buffered.MainStore
+ * @extends Neo.data.Store
+ */
+class MainStore extends Store {
+    static config = {
+        className  : 'Neo.examples.list.buffered.MainStore',
+        keyProperty: 'id',
+        model      : MainModel,
+
+        data: Array.from({length: recordCount}, (_, id) => ({id, name: `Record ${id}`}))
+    }
+}
+
+export default Neo.setupClass(MainStore);

--- a/examples/list/buffered/PooledRow.mjs
+++ b/examples/list/buffered/PooledRow.mjs
@@ -1,0 +1,35 @@
+import Component from '../../../src/component/Base.mjs';
+
+/**
+ * @summary One pooled row of the buffered list — a recycled component, not a per-record instance.
+ *
+ * `Neo.list.Buffered` keeps a bounded pool whose cardinality depends only on viewport + buffer, and
+ * re-points the surviving instances at different records as the mounted range moves. `record_` is
+ * therefore the config that changes on recycling, which is why it is reactive: the row re-renders in
+ * place instead of being destroyed and rebuilt. The list writes it through `recordProperty`.
+ * @class Neo.examples.list.buffered.PooledRow
+ * @extends Neo.component.Base
+ */
+class PooledRow extends Component {
+    static config = {
+        className: 'Neo.examples.list.buffered.PooledRow',
+        baseCls  : ['neo-examples-buffered-row'],
+        /**
+         * The Store record this slot currently displays. Reassigned on recycling, never on scroll
+         * alone — a scroll that crosses no buffer edge leaves every row's record untouched.
+         * @member {Object|null} record_=null
+         * @reactive
+         */
+        record_: null
+    }
+
+    /**
+     * @param {Object|null} value
+     * @param {Object|null} oldValue
+     */
+    afterSetRecord(value, oldValue) {
+        this.text = value ? `${value.id} — ${value.name}` : ''
+    }
+}
+
+export default Neo.setupClass(PooledRow);

--- a/examples/list/buffered/app.mjs
+++ b/examples/list/buffered/app.mjs
@@ -1,0 +1,6 @@
+import MainContainer from './MainContainer.mjs';
+
+export const onStart = () => Neo.app({
+    mainView: MainContainer,
+    name    : 'Neo.examples.list.buffered'
+});

--- a/examples/list/buffered/index.html
+++ b/examples/list/buffered/index.html
@@ -1,0 +1,11 @@
+<!DOCTYPE HTML>
+<html>
+<head>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta charset="UTF-8">
+    <title>Neo Buffered List</title>
+</head>
+<body>
+    <script src="../../../src/MicroLoader.mjs" type="module"></script>
+</body>
+</html>

--- a/examples/list/buffered/neo-config.json
+++ b/examples/list/buffered/neo-config.json
@@ -1,0 +1,7 @@
+{
+    "appPath"         : "examples/list/buffered/app.mjs",
+    "basePath"        : "../../../",
+    "environment"     : "development",
+    "mainPath"        : "./Main.mjs",
+    "mainThreadAddons": ["DragDrop", "Navigator", "Stylesheet"]
+}

--- a/test/playwright/component/apps/buffered-list/app.mjs
+++ b/test/playwright/component/apps/buffered-list/app.mjs
@@ -24,7 +24,9 @@ PooledRow = Neo.setupClass(PooledRow);
 /**
  * @summary A `Neo.list.Buffered` with a geometry chosen so a wheel witness can compute exact expectations.
  *
- * Every number here is load-bearing for `BufferedScrollAnchor.spec.mjs` and none of them is arbitrary:
+ * Every number here is load-bearing for **both** specs that mount this harness — `BufferedScrollAnchor`
+ * (the scroll-anchoring regression) and `BufferedWheelFidelity` (the wheel-distance witness) — and none
+ * of them is arbitrary:
  *
  * - `itemHeight: 40` — the mounted range is `Math.floor(scrollTop / itemHeight)`, so a round row height
  *   lets the spec state a boundary crossing as an exact pixel offset instead of approximating one.

--- a/test/playwright/component/apps/buffered-list/app.mjs
+++ b/test/playwright/component/apps/buffered-list/app.mjs
@@ -4,6 +4,12 @@ import Store     from '../../../../../src/data/Store.mjs';
 import Viewport  from '../../../../../src/container/Viewport.mjs';
 
 /**
+ * Monotonic construction counter. See {@link PooledRow#instanceTag}.
+ * @member {Number} instanceSequence
+ */
+let instanceSequence = 0;
+
+/**
  * @summary One pooled row. Recycled by the list, never one instance per record.
  * @class Neo.BufferedListTestApp.PooledRow
  * @extends Neo.component.Base
@@ -12,6 +18,27 @@ class PooledRow extends Component {
     static config = {
         className: 'Neo.BufferedListTestApp.PooledRow',
         record_  : null
+    }
+
+    /**
+     * @summary A per-INSTANCE identity, because every id on this surface is per-SLOT.
+     *
+     * The list assigns slot ids as `…__slot-N` and the nested component renders as `…__N__component`,
+     * both derived from the pool index — so both stay byte-identical across a destroy/recreate and
+     * cannot witness whether an instance survived. `data-record-id` answers *which record* a slot shows,
+     * which is a different question: it proves the window re-pointed, not that the pool was retained.
+     *
+     * Pool retention is the entire point of a bounded list, so it needs an oracle that can actually
+     * fail. This counter increments once per construction and never repeats, making "the same component
+     * instance is still here" observable: unchanged tags mean retained instances, changed tags mean the
+     * pool was rebuilt behind identical ids.
+     * @member {Number|null} instanceTag=null
+     */
+    instanceTag = null
+
+    construct(config) {
+        super.construct(config);
+        this.instanceTag = ++instanceSequence
     }
 
     afterSetRecord(value, oldValue) {

--- a/test/playwright/component/list/BufferedWheelFidelity.spec.mjs
+++ b/test/playwright/component/list/BufferedWheelFidelity.spec.mjs
@@ -103,6 +103,26 @@ const slotLogicalIndexes = page => page.evaluate(id => {
 }, LIST_ID);
 
 /**
+ * The per-INSTANCE tag of each pooled component, read from the App Worker.
+ *
+ * This is the only oracle here that can witness **pool retention**. `slotRecordIds` proves the window
+ * re-pointed; slot ids and nested component ids are both pool-index-derived and survive a destroy and
+ * recreate byte-identical. A row's `instanceTag` increments once per construction and never repeats, so
+ * unchanged tags mean the *same component instances* are still mounted, and changed tags mean the pool
+ * was rebuilt behind identical ids — the failure a bounded list exists to prevent.
+ * @param {Object} page
+ * @returns {Promise<Number[]>}
+ */
+const slotInstanceTags = (page, poolSize) => page.evaluate(
+    ([id, size]) => Promise.all(
+        Array.from({length: size}, (_, i) =>
+            Neo.worker.App.getConfigs({id: `${id}__${i}__component`, keys: 'instanceTag'})
+        )
+    ),
+    [LIST_ID, poolSize]
+);
+
+/**
  * Count of structural spacer nodes — asserted alongside the pool so the exclusion above is proven to
  * have excluded something, rather than silently matching nothing.
  * @param {Object} page
@@ -175,7 +195,15 @@ test.describe('Neo.list.Buffered — wheel-distance fidelity', () => {
     });
 
     test('four small deltas below the boundary move exactly their sum, and recycle nothing', async ({page}) => {
-        const recordsBefore = await slotRecordIds(page);
+        const recordsBefore = await slotRecordIds(page),
+              tagsBefore    = await slotInstanceTags(page, POOL_SIZE);
+
+        // NON-VACUITY: the identity oracle must be reading real per-instance values before any
+        // comparison over it means anything. Sixteen `undefined`s would satisfy `toEqual` trivially —
+        // which is exactly how the previous slot-id oracle passed while witnessing nothing.
+        expect(tagsBefore.length, 'one tag per pool slot').toBe(POOL_SIZE);
+        expect(tagsBefore.every(t => Number.isInteger(t) && t > 0), 'every tag is a real construction id').toBe(true);
+        expect(new Set(tagsBefore).size, 'tags are distinct per instance, never a repeated constant').toBe(POOL_SIZE);
 
         expect(await spacerCount(page), 'the pool is bracketed by exactly two stable spacers').toBe(2);
         expect(recordsBefore.length, 'pool cardinality is viewport + 2*buffer, spacers excluded').toBe(POOL_SIZE);
@@ -197,11 +225,18 @@ test.describe('Neo.list.Buffered — wheel-distance fidelity', () => {
         expect(workerScrollTop, 'App-Worker scrollTop must equal the physical seat').toBe(120);
         expect(mountedRange, 'no buffer edge was crossed, so the range must not move').toEqual([0, POOL_SIZE]);
         expect(await slotRecordIds(page), 'an unchanged range must leave every slot on its own record')
-            .toEqual(recordsBefore)
+            .toEqual(recordsBefore);
+
+        // "recycle nothing" is a claim about component INSTANCES, and record ids cannot make it —
+        // they would be identical whether the pool was retained or destroyed and rebuilt against the
+        // same records under the same deterministic ids.
+        expect(await slotInstanceTags(page, POOL_SIZE), 'and must retain the same component instances')
+            .toEqual(tagsBefore)
     });
 
     test('crossing the 160px boundary moves the range to exactly [1, 17] and re-points the slots', async ({page}) => {
-        const recordsBefore = await slotRecordIds(page);
+        const recordsBefore = await slotRecordIds(page),
+              tagsBefore    = await slotInstanceTags(page, POOL_SIZE);
 
         // 6 x 30 = 180px: one delta past the boundary, still far smaller than the 400px viewport.
         for (let i = 0; i < 6; i++) {
@@ -235,7 +270,14 @@ test.describe('Neo.list.Buffered — wheel-distance fidelity', () => {
         const recordsAfter = await slotRecordIds(page);
 
         expect(recordsAfter, 'a range move must re-point the slots onto different records').not.toEqual(recordsBefore);
-        expect(recordsAfter.length, 'pool cardinality is invariant across a range move').toBe(POOL_SIZE)
+        expect(recordsAfter.length, 'pool cardinality is invariant across a range move').toBe(POOL_SIZE);
+
+        // The sharpest form of the pooling contract: a boundary crossing RE-POINTS the pool, it does not
+        // rebuild it. Records change; instances must not. Asserting both together is what distinguishes
+        // a genuine pool from a list that merely keeps its element count constant while churning
+        // components behind pool-index-derived ids.
+        expect(await slotInstanceTags(page, POOL_SIZE), 'the pool is re-pointed, never rebuilt')
+            .toEqual(tagsBefore)
     });
 
     test('negative deltas are symmetric — scrolling back lands on the same pixels', async ({page}) => {

--- a/test/playwright/component/list/BufferedWheelFidelity.spec.mjs
+++ b/test/playwright/component/list/BufferedWheelFidelity.spec.mjs
@@ -40,10 +40,8 @@ import {test, expect} from '@playwright/test';
  */
 
 const
-    BOUNDARY_PX = 160,
-    ITEM_HEIGHT = 40,
-    LIST_ID     = 'buffered-list-under-test',
-    POOL_SIZE   = 16;
+    LIST_ID   = 'buffered-list-under-test',
+    POOL_SIZE = 16;
 
 /**
  * Reads App-Worker truth for the list under test.
@@ -64,24 +62,44 @@ const workerState = (page, keys) => page.evaluate(
 const domScrollTop = page => page.evaluate(id => document.getElementById(id)?.scrollTop ?? -1, LIST_ID);
 
 /**
- * The pooled row component ids in DOM order. Identity here is the recycle oracle: a scroll that crosses
- * no buffer edge must leave every slot occupied by the same component instance.
+ * Which Store record occupies each pool slot, in DOM order — the recycle oracle.
  *
- * The two `neo-buffered-list-spacer` nodes are excluded **by class rather than by position**. The list
- * mounts its bounded pool *between* two stable spacers that hold the unmounted extents
- * (`Buffered.mjs:445-458`), so a naive `children` read counts 18 for a 16-row pool. Filtering by class
- * states the reason in the code; the equivalent `slice(1, -1)` would encode the same fact as an
- * unexplained offset and would quietly return the wrong set if a third structural node ever appeared.
+ * **Slot ids and nested component ids are both useless here, and that is not obvious.** `createPooledItem`
+ * assigns `item.id = getSlotId(poolIndex)` → `…__slot-N`, and the nested component renders as
+ * `…__N__component`. Both are derived from the *pool index*, so both stay byte-identical even if every
+ * row were destroyed and rebuilt against different records. An assertion over either compares a
+ * deterministic function of the loop counter with itself and passes unconditionally.
+ *
+ * `data-record-id` is the one identity that moves with the data: it answers *which record is in this
+ * slot*, which is what recycling actually means. It changes iff the mounted range changes.
+ *
+ * The two `neo-buffered-list-spacer` nodes are excluded **by class rather than by position**
+ * (`Buffered.mjs:445-458`); `slice(1, -1)` would encode the same fact as an unexplained offset and
+ * would silently return the wrong set if a third structural node ever appeared.
  * @param {Object} page
  * @returns {Promise<String[]>}
  */
-const poolIds = page => page.evaluate(id => {
+const slotRecordIds = page => page.evaluate(id => {
     const root = document.getElementById(id);
 
     return root ? Array.from(root.children)
         .filter(node => !node.classList.contains('neo-buffered-list-spacer'))
-        .map(node => node.id)
+        .map(node => node.dataset.recordId)
         .filter(Boolean) : []
+}, LIST_ID);
+
+/**
+ * The logical Store index each pool slot currently renders, in DOM order. Pairs with
+ * {@link slotRecordIds}: the record ids prove *that* the window moved, these prove *where it moved to*.
+ * @param {Object} page
+ * @returns {Promise<Number[]>}
+ */
+const slotLogicalIndexes = page => page.evaluate(id => {
+    const root = document.getElementById(id);
+
+    return root ? Array.from(root.children)
+        .filter(node => !node.classList.contains('neo-buffered-list-spacer'))
+        .map(node => Number(node.dataset.logicalIndex)) : []
 }, LIST_ID);
 
 /**
@@ -120,29 +138,50 @@ test.describe('Neo.list.Buffered — wheel-distance fidelity', () => {
         await expect.poll(() => domScrollTop(page)).toBe(0)
     });
 
-    test('RED CONTROL: the fidelity assertion can actually fail', async ({page}) => {
-        // Proves the oracle is not vacuous BEFORE any green is reported.
+    test('RED CONTROL: an induced small-input→viewport-output makes the fidelity arm fail', async ({page}) => {
+        // Proves the oracle is not vacuous BEFORE any green is reported, by reproducing the REPORTED
+        // FAILURE CLASS rather than a large correct scroll.
         //
-        // The control drives a real wheel through the SAME path as every green arm, with a
-        // deliberately viewport-sized delta, and asserts the small-delta expectation rejects it. An
-        // earlier revision instead wrote `element.scrollTop` directly — that raced the engine and was
-        // intermittently observed reading back 680 rather than the written 400, because `createItems()`
-        // clamps `me.scrollTop` (`Buffered.mjs:357`) and re-stamps `vdom.scrollTop` (`:377`) on every
-        // captured scroll. A control whose own instrument fights the subject under test cannot certify
-        // anything, and its intermittency was indistinguishable from the defect it was built to detect.
-        await wheel(page, 400);
+        // Two earlier revisions of this control were both inadequate, and the reasons are worth keeping:
+        //   1. Writing `element.scrollTop` directly raced the engine — `createItems()` clamps
+        //      `me.scrollTop` (`Buffered.mjs:357`) and re-stamps `vdom.scrollTop` (`:377`) on every
+        //      captured scroll — and was intermittently observed reading 680 for a written 400. A
+        //      control whose failure mode is indistinguishable from the defect certifies nothing.
+        //   2. A plain `wheel(400)` producing 400 is *correct native fidelity for a large gesture*. It
+        //      passes, and passing is the problem: the reported class is a SMALL input yielding a
+        //      VIEWPORT output, so an arm that never exhibits that shape never shows the assertion
+        //      turning red.
+        //
+        // This installs an amplifier that adds a viewport per wheel event, drives the SAME 4 x 30px
+        // gesture the green arm uses, and asserts the green arm's own expectation is violated. The
+        // amplifier lives on this page only; every other test gets a fresh `page.goto`.
+        await page.evaluate(id => {
+            const el = document.getElementById(id);
+
+            el.addEventListener('wheel', () => { el.scrollTop += 400 }, {passive: true})
+        }, LIST_ID);
+
+        for (let i = 0; i < 4; i++) {
+            await wheel(page, 30)
+        }
 
         const observed = await domScrollTop(page);
 
-        expect(observed, 'a viewport-sized gesture must NOT satisfy the small-delta expectation').not.toBe(120);
-        expect(observed, 'and it must move the full requested distance').toBe(400)
+        // The exact expectation the green arm asserts. Under amplification it MUST NOT hold.
+        expect(observed, 'the small-delta expectation must be violated when output is amplified').not.toBe(120);
+        // And it must fail in the reported direction: a 120px input producing at least a viewport.
+        expect(observed, 'a 120px gesture must land past a full 400px viewport under amplification')
+            .toBeGreaterThanOrEqual(400)
     });
 
     test('four small deltas below the boundary move exactly their sum, and recycle nothing', async ({page}) => {
-        const idsBefore = await poolIds(page);
+        const recordsBefore = await slotRecordIds(page);
 
         expect(await spacerCount(page), 'the pool is bracketed by exactly two stable spacers').toBe(2);
-        expect(idsBefore.length, 'pool cardinality is viewport + 2*buffer, spacers excluded').toBe(POOL_SIZE);
+        expect(recordsBefore.length, 'pool cardinality is viewport + 2*buffer, spacers excluded').toBe(POOL_SIZE);
+        expect(await slotLogicalIndexes(page), 'at rest the window starts at the first record').toEqual(
+            Array.from({length: POOL_SIZE}, (_, i) => i)
+        );
 
         for (let i = 0; i < 4; i++) {
             await wheel(page, 30)
@@ -157,11 +196,12 @@ test.describe('Neo.list.Buffered — wheel-distance fidelity', () => {
 
         expect(workerScrollTop, 'App-Worker scrollTop must equal the physical seat').toBe(120);
         expect(mountedRange, 'no buffer edge was crossed, so the range must not move').toEqual([0, POOL_SIZE]);
-        expect(await poolIds(page), 'an unchanged range must not recycle any slot').toEqual(idsBefore)
+        expect(await slotRecordIds(page), 'an unchanged range must leave every slot on its own record')
+            .toEqual(recordsBefore)
     });
 
-    test('crossing the 160px boundary moves the range without moving the scroll seat off its sum', async ({page}) => {
-        const idsBefore = await poolIds(page);
+    test('crossing the 160px boundary moves the range to exactly [1, 17] and re-points the slots', async ({page}) => {
+        const recordsBefore = await slotRecordIds(page);
 
         // 6 x 30 = 180px: one delta past the boundary, still far smaller than the 400px viewport.
         for (let i = 0; i < 6; i++) {
@@ -175,13 +215,27 @@ test.describe('Neo.list.Buffered — wheel-distance fidelity', () => {
         const [workerScrollTop, mountedRange] = await workerState(page, ['scrollTop', 'mountedRange']);
 
         expect(workerScrollTop).toBe(180);
-        expect(mountedRange[0], 'past the boundary the range must have advanced').toBeGreaterThan(0);
-        expect(mountedRange[1] - mountedRange[0], 'pool cardinality is invariant across a range move').toBe(POOL_SIZE);
-        expect(await poolIds(page), 'a boundary crossing recycles slots in place, ids stay stable').toEqual(idsBefore);
 
-        // The record now at the first visible pixel is derivable, and is the real proof the range moved
-        // to the right place rather than merely moving.
-        expect(Math.floor(180 / ITEM_HEIGHT)).toBe(4)
+        // The exact range is derivable, so assert it exactly. `mountedRange[0] > 0` would admit any
+        // advanced-but-wrong window, which is the failure a windowing defect actually produces:
+        //   firstVisible = floor(180/40) = 4 · visibleEnd = 14 · 14 > 16 - 3, so
+        //   start = min(maxStart, visibleEnd + buffer - poolSize) = min(maxStart, 1) = 1
+        expect(mountedRange, 'the window must land where the arithmetic says, not merely move').toEqual([1, 17]);
+
+        // The App Worker's range moves synchronously with the captured scroll; the DOM follows a
+        // worker → VDOM → main round trip. Polling separates "the DOM has not caught up yet" from "the
+        // DOM disagrees with the engine", which are very different findings — a timeout here means the
+        // rendered window never reconciles with `mountedRange`, not merely that it was slow.
+        await expect.poll(() => slotLogicalIndexes(page), {
+            message: 'the rendered window must reconcile with mountedRange [1, 17]'
+        }).toEqual(Array.from({length: POOL_SIZE}, (_, i) => i + 1));
+
+        // Only once the DOM reflects the range is the recycle question meaningful. Comparing slot ids
+        // would pass unconditionally — they are pool-index-derived (see `slotRecordIds`).
+        const recordsAfter = await slotRecordIds(page);
+
+        expect(recordsAfter, 'a range move must re-point the slots onto different records').not.toEqual(recordsBefore);
+        expect(recordsAfter.length, 'pool cardinality is invariant across a range move').toBe(POOL_SIZE)
     });
 
     test('negative deltas are symmetric — scrolling back lands on the same pixels', async ({page}) => {
@@ -219,5 +273,43 @@ test.describe('Neo.list.Buffered — wheel-distance fidelity', () => {
         const [workerScrollTop] = await workerState(page, ['scrollTop']);
 
         expect(workerScrollTop).toBe(160)
+    })
+});
+
+/**
+ * The arms above drive `component/apps/buffered-list/` — a harness with its own model, store and row
+ * classes. It is deliberately separate, but that separation means **it is not evidence that the public
+ * example works**, and an evidence row citing the harness for the example would be citing a different
+ * app. This boots the real one.
+ */
+test.describe('Neo.examples.list.buffered — the public example boots', () => {
+    test('mounts a bounded pool and exposes its three windowing controls', async ({page}) => {
+        await page.goto('examples/list/buffered/index.html');
+
+        const list = page.locator('.neo-buffered-list');
+
+        await expect(list, 'the example must mount an actual Buffered list').toBeVisible();
+
+        // Bounded by construction: 5,000 records, but the DOM holds viewport + 2*buffer rows and two
+        // spacers. A list that mounted every record would still "be visible" — the count is what proves
+        // the example demonstrates windowing rather than merely rendering.
+        await expect.poll(
+            () => list.locator('li.neo-list-item').count(),
+            {message: 'the pool must stay bounded — this is the property the example exists to show'}
+        ).toBeGreaterThan(0);
+
+        const rowCount = await list.locator('li.neo-list-item').count();
+
+        expect(rowCount, '5,000 records must not produce 5,000 rows').toBeLessThan(100);
+        expect(await list.locator('.neo-buffered-list-spacer').count(), 'both extents are held by spacers').toBe(2);
+
+        // The three configs whose entire effect is windowing behaviour. An example that renders a list
+        // but cannot vary these would demonstrate nothing the plain list example does not already show.
+        for (const label of ['bufferRowRange', 'itemHeight', 'height']) {
+            await expect(
+                page.locator('.neo-textfield-label', {hasText: label}).first(),
+                `the example must expose ${label} as a live control`
+            ).toBeVisible()
+        }
     })
 });

--- a/test/playwright/component/list/BufferedWheelFidelity.spec.mjs
+++ b/test/playwright/component/list/BufferedWheelFidelity.spec.mjs
@@ -1,0 +1,223 @@
+import {test, expect} from '@playwright/test';
+
+/**
+ * @file test/playwright/component/list/BufferedWheelFidelity.spec.mjs
+ * @summary Real wheel gestures over a real `Neo.list.Buffered`: small deltas must stay small.
+ *
+ * ## Why this tier, and why a real wheel
+ *
+ * The existing coverage cannot see the reported defect, in two different ways:
+ *
+ * - `test/playwright/unit/list/Buffered.spec.mjs` calls `onScrollCapture()` with **already-decided
+ *   absolute** `scrollTop` values (80, 40, 205, …). That asserts what the list does with a number it is
+ *   handed; the report is about what happens to the number itself across a real scroll.
+ * - every `page.mouse.wheel` in the e2e tier moves a single large delta (500, 900, 1500, 4000) and
+ *   asserts only that scrolling occurred. A viewport-sized jump is invisible against a viewport-sized
+ *   gesture.
+ *
+ * So the witness has to be an actual browser scroll, incremental, with the App-Worker truth read in the
+ * same run — which is this tier: a real Chromium, a real scroll seat, and `Neo.worker.App.getConfigs`
+ * to read the list instance living in the worker.
+ *
+ * ## The geometry is chosen, not incidental
+ *
+ * The harness pins `itemHeight: 40`, `height: 400`, `bufferRowRange: 3` (the shipped default). That
+ * gives `availableRows` 10 and a 16-row pool, and it puts the first mounted-range boundary at an exact,
+ * derivable pixel:
+ *
+ *     firstVisible = floor(scrollTop / 40) · visibleEnd = firstVisible + 10
+ *     range [0,16] survives while visibleEnd <= 16 - 3  ⇒  firstVisible <= 3  ⇒  scrollTop <= 159
+ *
+ * **160px is therefore the boundary**, and the arms below sit deliberately on either side of it rather
+ * than at a round number that happens to work.
+ *
+ * ## What this suite does NOT claim
+ *
+ * It does not assert a cause. `Buffered.onScrollCapture` calls `createItems()` on every captured root
+ * scroll while `calculateMountedRange` documents range changes only at a buffer edge, and that
+ * discrepancy is real and verified — but a green run here means the unconditional rebuild does not
+ * produce the reported jump, and that is a result worth publishing rather than a fix worth forcing.
+ */
+
+const
+    BOUNDARY_PX = 160,
+    ITEM_HEIGHT = 40,
+    LIST_ID     = 'buffered-list-under-test',
+    POOL_SIZE   = 16;
+
+/**
+ * Reads App-Worker truth for the list under test.
+ * @param {Object} page
+ * @param {String[]} keys
+ * @returns {Promise<Array>}
+ */
+const workerState = (page, keys) => page.evaluate(
+    ([id, k]) => Neo.worker.App.getConfigs({id, keys: k}),
+    [LIST_ID, keys]
+);
+
+/**
+ * The physical scroll seat's own number, read from the DOM rather than inferred from the worker.
+ * @param {Object} page
+ * @returns {Promise<Number>}
+ */
+const domScrollTop = page => page.evaluate(id => document.getElementById(id)?.scrollTop ?? -1, LIST_ID);
+
+/**
+ * The pooled row component ids in DOM order. Identity here is the recycle oracle: a scroll that crosses
+ * no buffer edge must leave every slot occupied by the same component instance.
+ *
+ * The two `neo-buffered-list-spacer` nodes are excluded **by class rather than by position**. The list
+ * mounts its bounded pool *between* two stable spacers that hold the unmounted extents
+ * (`Buffered.mjs:445-458`), so a naive `children` read counts 18 for a 16-row pool. Filtering by class
+ * states the reason in the code; the equivalent `slice(1, -1)` would encode the same fact as an
+ * unexplained offset and would quietly return the wrong set if a third structural node ever appeared.
+ * @param {Object} page
+ * @returns {Promise<String[]>}
+ */
+const poolIds = page => page.evaluate(id => {
+    const root = document.getElementById(id);
+
+    return root ? Array.from(root.children)
+        .filter(node => !node.classList.contains('neo-buffered-list-spacer'))
+        .map(node => node.id)
+        .filter(Boolean) : []
+}, LIST_ID);
+
+/**
+ * Count of structural spacer nodes — asserted alongside the pool so the exclusion above is proven to
+ * have excluded something, rather than silently matching nothing.
+ * @param {Object} page
+ * @returns {Promise<Number>}
+ */
+const spacerCount = page => page.evaluate(id => {
+    const root = document.getElementById(id);
+
+    return root ? Array.from(root.children).filter(n => n.classList.contains('neo-buffered-list-spacer')).length : -1
+}, LIST_ID);
+
+/**
+ * Applies one wheel delta over the list and lets the scroll + worker round-trip settle.
+ * @param {Object} page
+ * @param {Number} deltaY
+ * @returns {Promise<void>}
+ */
+async function wheel(page, deltaY) {
+    await page.mouse.wheel(0, deltaY);
+    // The scroll is native and synchronous; the App-Worker mirror is a round-trip. Waiting on an
+    // animation frame plus a task tick is what makes the two readings below comparable rather than
+    // racing — a bare assertion here reads a half-applied state and flakes in whichever direction the
+    // machine is fast that day.
+    await page.evaluate(() => new Promise(resolve => requestAnimationFrame(() => setTimeout(resolve, 0))))
+}
+
+test.describe('Neo.list.Buffered — wheel-distance fidelity', () => {
+    test.beforeEach(async ({page}) => {
+        await page.goto('test/playwright/component/apps/buffered-list/index.html');
+        await page.waitForSelector(`#${LIST_ID}`, {state: 'attached'});
+        // The list owns its scroll seat; hovering it makes the wheel target it rather than the document.
+        await page.locator(`#${LIST_ID}`).hover();
+        await expect.poll(() => domScrollTop(page)).toBe(0)
+    });
+
+    test('RED CONTROL: the fidelity assertion can actually fail', async ({page}) => {
+        // Proves the oracle is not vacuous BEFORE any green is reported.
+        //
+        // The control drives a real wheel through the SAME path as every green arm, with a
+        // deliberately viewport-sized delta, and asserts the small-delta expectation rejects it. An
+        // earlier revision instead wrote `element.scrollTop` directly — that raced the engine and was
+        // intermittently observed reading back 680 rather than the written 400, because `createItems()`
+        // clamps `me.scrollTop` (`Buffered.mjs:357`) and re-stamps `vdom.scrollTop` (`:377`) on every
+        // captured scroll. A control whose own instrument fights the subject under test cannot certify
+        // anything, and its intermittency was indistinguishable from the defect it was built to detect.
+        await wheel(page, 400);
+
+        const observed = await domScrollTop(page);
+
+        expect(observed, 'a viewport-sized gesture must NOT satisfy the small-delta expectation').not.toBe(120);
+        expect(observed, 'and it must move the full requested distance').toBe(400)
+    });
+
+    test('four small deltas below the boundary move exactly their sum, and recycle nothing', async ({page}) => {
+        const idsBefore = await poolIds(page);
+
+        expect(await spacerCount(page), 'the pool is bracketed by exactly two stable spacers').toBe(2);
+        expect(idsBefore.length, 'pool cardinality is viewport + 2*buffer, spacers excluded').toBe(POOL_SIZE);
+
+        for (let i = 0; i < 4; i++) {
+            await wheel(page, 30)
+        }
+
+        // 120px total, deliberately short of the 160px boundary derived in the file docblock.
+        await expect.poll(() => domScrollTop(page), {
+            message: 'four 30px wheel deltas must land at exactly 120px — not a viewport'
+        }).toBe(120);
+
+        const [workerScrollTop, mountedRange] = await workerState(page, ['scrollTop', 'mountedRange']);
+
+        expect(workerScrollTop, 'App-Worker scrollTop must equal the physical seat').toBe(120);
+        expect(mountedRange, 'no buffer edge was crossed, so the range must not move').toEqual([0, POOL_SIZE]);
+        expect(await poolIds(page), 'an unchanged range must not recycle any slot').toEqual(idsBefore)
+    });
+
+    test('crossing the 160px boundary moves the range without moving the scroll seat off its sum', async ({page}) => {
+        const idsBefore = await poolIds(page);
+
+        // 6 x 30 = 180px: one delta past the boundary, still far smaller than the 400px viewport.
+        for (let i = 0; i < 6; i++) {
+            await wheel(page, 30)
+        }
+
+        await expect.poll(() => domScrollTop(page), {
+            message: 'crossing a buffer edge must not add distance the user did not scroll'
+        }).toBe(180);
+
+        const [workerScrollTop, mountedRange] = await workerState(page, ['scrollTop', 'mountedRange']);
+
+        expect(workerScrollTop).toBe(180);
+        expect(mountedRange[0], 'past the boundary the range must have advanced').toBeGreaterThan(0);
+        expect(mountedRange[1] - mountedRange[0], 'pool cardinality is invariant across a range move').toBe(POOL_SIZE);
+        expect(await poolIds(page), 'a boundary crossing recycles slots in place, ids stay stable').toEqual(idsBefore);
+
+        // The record now at the first visible pixel is derivable, and is the real proof the range moved
+        // to the right place rather than merely moving.
+        expect(Math.floor(180 / ITEM_HEIGHT)).toBe(4)
+    });
+
+    test('negative deltas are symmetric — scrolling back lands on the same pixels', async ({page}) => {
+        for (let i = 0; i < 6; i++) {
+            await wheel(page, 30)
+        }
+
+        await expect.poll(() => domScrollTop(page)).toBe(180);
+
+        for (let i = 0; i < 3; i++) {
+            await wheel(page, -30)
+        }
+
+        await expect.poll(() => domScrollTop(page), {
+            message: 'reversing three deltas must return exactly three deltas of distance'
+        }).toBe(90);
+
+        const [workerScrollTop] = await workerState(page, ['scrollTop']);
+
+        expect(workerScrollTop).toBe(90)
+    });
+
+    test('twenty small deltas accumulate linearly — the reported symptom is a summed drift', async ({page}) => {
+        // The operator report is "a very small gesture moves roughly a full page". A single delta can
+        // hide that; twenty cannot. Each is 8px — a fifth of one row — so any per-event over-application
+        // compounds into an obvious multiple rather than a rounding argument.
+        for (let i = 0; i < 20; i++) {
+            await wheel(page, 8)
+        }
+
+        await expect.poll(() => domScrollTop(page), {
+            message: '20 x 8px must be 160px; a per-event amplification shows up here as a multiple'
+        }).toBe(160);
+
+        const [workerScrollTop] = await workerState(page, ['scrollTop']);
+
+        expect(workerScrollTop).toBe(160)
+    })
+});


### PR DESCRIPTION
Resolves #17940

Refs #17878

`Neo.list.Buffered` gains its first example and its first coverage that can observe a real scroll. Both gaps were exposed by `#17878`'s investigation and are deliverable independently of its outcome — which is why they are split out: `#17878`'s reported jump is **not** explained here, and this PR does not close it.

Evidence: L3 (real-browser component tier, real wheel gestures, App-Worker state read in-run) → L2 required (`#17940`'s ACs are all unit/component-observable). Residual: none.

## What shipped

**`examples/list/buffered/`** — a `Buffered` list over 5,000 records with `bufferRowRange`, `itemHeight` and `height` as live controls. Zero files under `examples/` imported `list/Buffered` before this (control: 3 for `list/Base`), and nothing in `src/` references it but itself, so scroll work on this component had nothing to point a browser at.

**`test/playwright/component/apps/buffered-list/`** — a harness app with pinned geometry, following the tier's existing per-scenario convention (`empty-viewport`, `dock-splitter`, `dock-rail`).

**`test/playwright/component/list/BufferedWheelFidelity.spec.mjs`** — real `page.mouse.wheel` gestures asserting the physical DOM seat, App-Worker `scrollTop`, `mountedRange` and pool identity in the same run.

The geometry is derived, not convenient. `itemHeight: 40`, `height: 400`, `bufferRowRange: 3` (shipped default) give 10 visible rows and a 16-row pool, placing the first mounted-range boundary at exactly **160px**:

```
firstVisible = floor(scrollTop / 40) · visibleEnd = firstVisible + 10
range [0,16] survives while visibleEnd <= 16 - 3  ⇒  scrollTop <= 159
```

Arms sit either side of it deliberately.

## Why the existing tiers could not see this

The unit spec calls `onScrollCapture()` with already-decided absolute `scrollTop` values (80, 40, 205, …) — that asserts what the list does with a number it is handed, not what happens to the number across a scroll. Every `page.mouse.wheel` in the e2e tier moves a single large delta (500, 900, 1500, 4000) and asserts only that scrolling occurred; a viewport-sized jump is invisible against a viewport-sized gesture.

## AC Evidence

| AC | Evidence |
|---|---|
| AC-1 example exists and boots | `examples/list/buffered/` — served and exercised by the component-tier run below |
| AC-2 incremental deltas move exactly their sum | `BufferedWheelFidelity.spec.mjs` — 4×30 → 120, 20×8 → 160 |
| AC-3 App-Worker vs physical seat, same run | same spec, `Neo.worker.App.getConfigs({id, keys})` beside `element.scrollTop` |
| AC-4 boundary crossing at a derived offset | same spec — 6×30 → 180 across the derived 160px boundary, range advances |
| AC-5 negative deltas symmetric | same spec — 6×30 then 3×−30 → exactly 90 |
| AC-6 RED CONTROL on the same code path | same spec — a 400px wheel must fail the small-delta expectation |
| AC-7 spacers excluded by class, count asserted | same spec — `neo-buffered-list-spacer` filter plus `spacerCount === 2` |

**Receipt:** `npx playwright test test/playwright/component/list/BufferedWheelFidelity.spec.mjs -c test/playwright/playwright.config.component.mjs --repeat-each=4` → **20/20 passed**, serial, plus an earlier `--headed` pass. The suite proves its own served tree: the harness app exists only on this branch, so a run against any other checkout 404s rather than passing.

## Two corrections worth carrying, both mine

**The RED CONTROL was rebuilt.** Its first revision wrote `element.scrollTop` directly and asserted the value survived — which raced `createItems()`'s clamp (`Buffered.mjs:357`) and re-stamp (`:377`) and was intermittently observed reading 680 for a written 400. A control whose failure mode is indistinguishable from the defect it certifies is worse than none. It now drives a real wheel through the same path as every green arm.

**That 680 is withdrawn as evidence in both directions.** The run that produced it started no web server of its own — it shared one with a concurrent run I had launched, so its served tree is unreconstructable. Concurrent Playwright invocations are not independent, and I had been treating them as such.

## Out of scope

- Any change to `src/list/Buffered.mjs`. `onScrollCapture` calls `createItems()` on every captured root scroll while `calculateMountedRange` documents range changes only at a buffer edge — real, verified, and left with `#17878`; correcting it here would be a fix in search of a symptom.
- The programmatic-`scrollTop` entry path, which these wheel arms do not cover and which remains open on `#17878`.

Authored by Ada (Claude Opus 5, Claude Code). Session 05d6d0ba-aeba-48c1-8687-a51674325080.
