### PR TITLE
The buffered scroll seat survives a mounted-range rebuild (#17878)

### DIFF
--- a/resources/scss/src/list/Buffered.scss
+++ b/resources/scss/src/list/Buffered.scss
@@ -1,0 +1,22 @@
+.neo-buffered-list {
+    // A buffered list owns its scroll seat and rebuilds its bounded pool between two spacers whose
+    // heights encode the unmounted extents (`topHeight = range[0] * itemHeight`). Crossing a
+    // mounted-range boundary therefore RESIZES the top spacer while the user is scrolling.
+    //
+    // Browser scroll anchoring reads that resize as content shifting under the viewport and compensates
+    // by moving `scrollTop` to hold the visible rows still. For an ordinary document that is the right
+    // behaviour; for a virtualized list it is a feedback loop — the compensated position crosses the
+    // next boundary, which resizes the spacer again, which compensates again. Measured before this
+    // rule: a 180px wheel gesture reached 3,780px within 1.5s and kept climbing (~3,600px/s), with
+    // `mountedRange` advancing in lockstep. Gestures that stayed below the boundary drifted zero.
+    //
+    // The spacer heights ARE the scroll geometry here, so the engine must own the seat outright rather
+    // than let the user agent second-guess it. `grid/View.scss` and `grid/Container.scss` carry the
+    // same rule for the same reason; this is that lesson applied to the list surface, which never
+    // received it.
+    //
+    // Pinned by `test/playwright/component/list/BufferedScrollAnchor.spec.mjs`, whose assertions are
+    // deliberately delayed — the position is correct at the instant the gesture ends and only diverges
+    // ~100ms later, so an immediate assertion cannot witness this.
+    overflow-anchor: none;
+}

--- a/test/playwright/component/apps/buffered-list/app.mjs
+++ b/test/playwright/component/apps/buffered-list/app.mjs
@@ -1,0 +1,73 @@
+import Buffered  from '../../../../../src/list/Buffered.mjs';
+import Component from '../../../../../src/component/Base.mjs';
+import Store     from '../../../../../src/data/Store.mjs';
+import Viewport  from '../../../../../src/container/Viewport.mjs';
+
+/**
+ * @summary One pooled row. Recycled by the list, never one instance per record.
+ * @class Neo.BufferedListTestApp.PooledRow
+ * @extends Neo.component.Base
+ */
+class PooledRow extends Component {
+    static config = {
+        className: 'Neo.BufferedListTestApp.PooledRow',
+        record_  : null
+    }
+
+    afterSetRecord(value, oldValue) {
+        this.text = value ? `Record ${value.id}` : ''
+    }
+}
+
+PooledRow = Neo.setupClass(PooledRow);
+
+/**
+ * @summary A `Neo.list.Buffered` with a geometry chosen so a wheel witness can compute exact expectations.
+ *
+ * Every number here is load-bearing for `BufferedWheelFidelity.spec.mjs` and none of them is arbitrary:
+ *
+ * - `itemHeight: 40` — the mounted range is `Math.floor(scrollTop / itemHeight)`, so a round row height
+ *   lets the spec state a boundary crossing as an exact pixel offset instead of approximating one.
+ * - `height: 400` → `availableRows` 10, and with `bufferRowRange: 3` a pool of 16 rows. Both are small
+ *   enough to assert the whole pool identity, which is what proves a scroll did NOT recycle.
+ * - `recordCount: 5000` → a 200,000px scroll range, far beyond any single wheel gesture, so the witness
+ *   never accidentally clamps at an edge and reads the clamp as fidelity.
+ * - `bufferRowRange: 3` is the shipped default. A witness that tuned it would be testing a configuration
+ *   nobody runs.
+ *
+ * The list is the viewport's only child so nothing else can claim the wheel event or the scroll seat.
+ * Native scrolling stays physical authority — the app deliberately registers no wheel handling, because
+ * what is under test is whether the App Worker perturbs a scroll the browser has ALREADY performed,
+ * not how the gesture is intercepted. Adding a handler here would replace the subject with a stub.
+ */
+const
+    itemHeight  = 40,
+    recordCount = 5000;
+
+export const onStart = () => Neo.app({
+    mainView: {
+        module: Viewport,
+        id    : 'buffered-list-test-viewport',
+        items : [{
+            module        : Buffered,
+            bufferRowRange: 3,
+            height        : 400,
+            id            : 'buffered-list-under-test',
+            itemConfig    : ({record}) => ({module: PooledRow, record}),
+            itemHeight,
+            store         : {
+                module     : Store,
+                keyProperty: 'id',
+                data       : Array.from({length: recordCount}, (_, id) => ({id, name: `Record ${id}`})),
+                model      : {
+                    fields: [
+                        {name: 'id',   type: 'Integer'},
+                        {name: 'name', type: 'String'}
+                    ]
+                }
+            },
+            width: 300
+        }]
+    },
+    name: 'BufferedListTestApp'
+});

--- a/test/playwright/component/apps/buffered-list/app.mjs
+++ b/test/playwright/component/apps/buffered-list/app.mjs
@@ -24,7 +24,7 @@ PooledRow = Neo.setupClass(PooledRow);
 /**
  * @summary A `Neo.list.Buffered` with a geometry chosen so a wheel witness can compute exact expectations.
  *
- * Every number here is load-bearing for `BufferedWheelFidelity.spec.mjs` and none of them is arbitrary:
+ * Every number here is load-bearing for `BufferedScrollAnchor.spec.mjs` and none of them is arbitrary:
  *
  * - `itemHeight: 40` — the mounted range is `Math.floor(scrollTop / itemHeight)`, so a round row height
  *   lets the spec state a boundary crossing as an exact pixel offset instead of approximating one.

--- a/test/playwright/component/apps/buffered-list/index.html
+++ b/test/playwright/component/apps/buffered-list/index.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Neo.mjs Component Test App</title>
+</head>
+<body>
+    <script src="../../../../../src/MicroLoader.mjs" type="module"></script>
+</body>
+</html>

--- a/test/playwright/component/apps/buffered-list/neo-config.json
+++ b/test/playwright/component/apps/buffered-list/neo-config.json
@@ -1,0 +1,6 @@
+{
+    "appPath"    : "test/playwright/component/apps/buffered-list/app.mjs",
+    "basePath"   : "../../../../../",
+    "environment": "development",
+    "mainPath"   : "./Main.mjs"
+}

--- a/test/playwright/component/list/BufferedScrollAnchor.spec.mjs
+++ b/test/playwright/component/list/BufferedScrollAnchor.spec.mjs
@@ -50,6 +50,22 @@ const
 const domScrollTop = page => page.evaluate(id => document.getElementById(id)?.scrollTop ?? -1, LIST_ID);
 
 /**
+ * The list's own `mountedRange`, read from the App Worker.
+ *
+ * This is the executable half of the boundary claim. The pixel arithmetic in the docblock says 180px
+ * crosses and 120px does not, but a comment cannot fail — if later geometry moved the first boundary
+ * above 180px, both arms below would keep passing while **no spacer ever rebuilt**, and the regression
+ * would silently stop exercising the causal path it exists to pin. Asserting the range makes the
+ * crossing a measured precondition rather than a derived assumption.
+ * @param {Object} page
+ * @returns {Promise<Number[]>}
+ */
+const mountedRange = page => page.evaluate(
+    id => Neo.worker.App.getConfigs({id, keys: 'mountedRange'}),
+    LIST_ID
+);
+
+/**
  * Drives `count` wheel deltas, then lets the page settle long enough for a runaway to express itself.
  * @param {Object} page
  * @param {Number} count
@@ -84,6 +100,11 @@ test.describe('Neo.list.Buffered — the scroll seat survives a mounted-range re
         // report distinguishes "never scrolled correctly" from "scrolled correctly, then ran away".
         expect(immediate, 'the gesture itself must land on its exact sum').toBe(180);
 
+        // The crossing is a MEASURED precondition, not an inference from the fixture's pixel arithmetic.
+        // Without this the arm could pass under a geometry where no rebuild ever happened.
+        expect(await mountedRange(page), 'the gesture must actually have crossed into the next window')
+            .toEqual([1, 17]);
+
         expect(settled, `the seat must not move after the input stops (settled ${SETTLE_MS}ms)`).toBe(180)
     });
 
@@ -94,6 +115,13 @@ test.describe('Neo.list.Buffered — the scroll seat survives a mounted-range re
         const {immediate, settled} = await wheelThenSettle(page, 4);
 
         expect(immediate, 'a below-boundary gesture lands on its sum').toBe(120);
+
+        // The symmetric half of the crossing assertion: this arm's whole meaning is that NO rebuild
+        // occurred. Asserting the range stayed put is what makes it a control rather than a second
+        // sample of the same condition.
+        expect(await mountedRange(page), 'no buffer edge was crossed, so the window must not have moved')
+            .toEqual([0, 16]);
+
         expect(settled, 'and stays there — this arm never reproduced the defect').toBe(120)
     })
 });

--- a/test/playwright/component/list/BufferedScrollAnchor.spec.mjs
+++ b/test/playwright/component/list/BufferedScrollAnchor.spec.mjs
@@ -1,0 +1,99 @@
+import {test, expect} from '@playwright/test';
+
+/**
+ * @file test/playwright/component/list/BufferedScrollAnchor.spec.mjs
+ * @summary A buffered list must stay where the user stopped scrolling, including after a mounted-range
+ * rebuild.
+ *
+ * ## The defect this pins
+ *
+ * Crossing a mounted-range boundary makes `createItems()` rebuild the bounded pool with a new top-spacer
+ * height (`topHeight = range[0] * itemHeight`). The browser's **scroll anchoring** treats that resize as
+ * content shifting under the viewport and compensates by moving `scrollTop` to keep the visible rows
+ * still. The compensated position crosses the *next* boundary, which rebuilds again — a self-sustaining
+ * scroll that runs away from the user at roughly 3,600px/s.
+ *
+ * Measured before the fix: six 30px wheel deltas (180px total, one delta past the 160px boundary) left
+ * the seat at **3,780px after 1.5s and still climbing**, with `mountedRange` advancing in lockstep. Four
+ * and five deltas — 120px and 150px, both below the boundary — drifted **zero**. The trigger is the
+ * boundary crossing, not the gesture size or rate.
+ *
+ * ## Why the assertions are delayed, and why that is the whole point
+ *
+ * At the instant the gesture ends the position is **correct**: 180 is 180. The runaway needs ~100ms to
+ * become visible. Coverage that samples one animation frame after the last wheel therefore passes
+ * honestly while measuring the wrong moment — which is exactly how this defect survived a suite that
+ * asserted exact scroll sums and went 20/20 across four repeats.
+ *
+ * **A settle window is load-bearing here, not test hygiene.** Removing it does not make these arms
+ * flaky; it makes them blind.
+ *
+ * ## Geometry
+ *
+ * The harness pins `itemHeight: 40`, `height: 400`, `bufferRowRange: 3` (shipped default) → 10 visible
+ * rows, a 16-row pool, and the first boundary at an exact pixel:
+ *
+ *     firstVisible = floor(scrollTop / 40) · visibleEnd = firstVisible + 10
+ *     range [0,16] survives while visibleEnd <= 16 - 3  ⇒  scrollTop <= 159
+ */
+
+const
+    LIST_ID     = 'buffered-list-under-test',
+    // Long enough that a runaway is unmissable (it advances ~3,600px/s) and short enough to stay cheap.
+    SETTLE_MS   = 600,
+    WHEEL_DELTA = 30;
+
+/**
+ * @param {Object} page
+ * @returns {Promise<Number>}
+ */
+const domScrollTop = page => page.evaluate(id => document.getElementById(id)?.scrollTop ?? -1, LIST_ID);
+
+/**
+ * Drives `count` wheel deltas, then lets the page settle long enough for a runaway to express itself.
+ * @param {Object} page
+ * @param {Number} count
+ * @returns {Promise<{settled: Number, immediate: Number}>}
+ */
+async function wheelThenSettle(page, count) {
+    for (let i = 0; i < count; i++) {
+        await page.mouse.wheel(0, WHEEL_DELTA);
+        await page.evaluate(() => new Promise(resolve => requestAnimationFrame(() => setTimeout(resolve, 0))))
+    }
+
+    const immediate = await domScrollTop(page);
+
+    await page.evaluate(ms => new Promise(resolve => setTimeout(resolve, ms)), SETTLE_MS);
+
+    return {immediate, settled: await domScrollTop(page)}
+}
+
+test.describe('Neo.list.Buffered — the scroll seat survives a mounted-range rebuild', () => {
+    test.beforeEach(async ({page}) => {
+        await page.goto('test/playwright/component/apps/buffered-list/index.html');
+        await page.waitForSelector(`#${LIST_ID}`, {state: 'attached'});
+        await page.locator(`#${LIST_ID}`).hover();
+        await expect.poll(() => domScrollTop(page)).toBe(0)
+    });
+
+    test('a gesture that CROSSES the boundary stays put after settling', async ({page}) => {
+        // 6 x 30 = 180px: one delta past the 160px boundary, so the pool rebuilds.
+        const {immediate, settled} = await wheelThenSettle(page, 6);
+
+        // The immediate reading is correct even when the defect is present — asserted here so a failure
+        // report distinguishes "never scrolled correctly" from "scrolled correctly, then ran away".
+        expect(immediate, 'the gesture itself must land on its exact sum').toBe(180);
+
+        expect(settled, `the seat must not move after the input stops (settled ${SETTLE_MS}ms)`).toBe(180)
+    });
+
+    test('CONTROL: a gesture that stays BELOW the boundary was never affected', async ({page}) => {
+        // 4 x 30 = 120px, short of 160px, so no rebuild occurs. This arm passed both before and after
+        // the fix; it is here to prove the regression above is specific to the boundary crossing rather
+        // than to scrolling in general — without it, a fix that simply froze scrolling would look green.
+        const {immediate, settled} = await wheelThenSettle(page, 4);
+
+        expect(immediate, 'a below-boundary gesture lands on its sum').toBe(120);
+        expect(settled, 'and stays there — this arm never reproduced the defect').toBe(120)
+    })
+});


### PR DESCRIPTION
Resolves #17878

A small wheel gesture could run a buffered list away by thousands of pixels. One CSS property fixes it; the rest of this PR is the instrument that proves the property is the right one.

Evidence: L3 (real-browser component tier, real wheel gestures, headed + headless) → L3 required; no residuals.

## The defect

Six 30px deltas — 180px, one delta past the mounted-range boundary — left the seat at **3,780px within 1.5s and still climbing** at ~3,600px/s, `mountedRange` advancing in lockstep. The trigger is the **boundary crossing**, not the gesture size or rate:

| wheels × 30px | total | crosses the 160px boundary | @0ms | @1500ms | drift |
|---|---|---|---|---|---|
| 4 | 120 | no | 120 `[0,16]` | 120 `[0,16]` | **0** |
| 5 | 150 | no | 150 `[0,16]` | 150 `[0,16]` | **0** |
| 6 | 180 | **yes** | 180 `[1,17]` | **3780** `[91,…]` | **+3600** |

## The mechanism, isolated by a controlled pair

Crossing the boundary makes `createItems()` rebuild with a new top-spacer height (`topHeight = range[0] * itemHeight`). Browser **scroll anchoring** reads that resize as content shifting under the viewport and compensates by moving `scrollTop` — and the compensated position crosses the next boundary, which resizes again. For an ordinary document that compensation is correct; for a virtualized list whose spacer heights *are* the scroll geometry it is a feedback loop.

Same gesture, one variable:

| condition | @0ms | @1500ms | drift |
|---|---|---|---|
| control | 180 | 3780 | +3600 |
| `overflow-anchor: none` | 180 | **180** | **0** |

**`grid/View.scss:4` and `grid/Container.scss:11` already carry this rule for the same reason** — `overflow-anchor` appears nowhere else in the tree. The remedy was learned once for the grid and never applied to the list surface.

## Deltas from ticket

The ticket prescribed *"do not rebuild pooled VDOM while `mountedRange` is unchanged"*, with the clause **"unless the red witness disproves that prescription."** The witness disproved it: the unconditional `createItems()` rebuild is real, verified at `Buffered.mjs:695-707` against `:314-335`, and is **not** this defect's cause. It does not move the scroll seat; the browser's compensation for the spacer resize does. The rebuild is therefore left untouched as a separate performance concern rather than changed on a hunch.

`#17878`'s operative ACs were amended at the author's direction (RA-1) to **scope-transfer** AC-2's negative-direction half plus AC-4 and AC-5 into the existing `#17940` lane, where the instrument breadth belongs and where they are now restated verbatim and still required. This is a transfer, not a reduction: nothing is dropped, and this PR is the complete remaining `#17878` scope. That removes the cyclic topology in the previous revision of this body, which called those three "delivered by #17941" while #17941 is open, `CHANGES_REQUESTED`, and must rebase onto *this* PR.

## Test Evidence

`test/playwright/component/list/BufferedScrollAnchor.spec.mjs` — 2 arms, both required.

**Red-first receipt.** The regression was written and run **before** the fix existed:

| | boundary arm (180px, crosses) | control (120px, below) |
|---|---|---|
| without `overflow-anchor: none` | **RED** — settled **1620** ≠ 180 | GREEN |
| with the fix | GREEN — settled 180 | GREEN |

**Both arms read `mountedRange` from the App Worker** and assert it exactly — `[1, 17]` crossing, `[0, 16]` control. Comment-derived pixel arithmetic cannot fail; without the executable assertion a later geometry change could move the first boundary above 180px and leave both arms green while **no spacer ever rebuilt**, silently retiring the causal path this regression exists to pin (RA-2).

The boundary arm asserts the **immediate** value as well as the settled one, so a failure distinguishes *"never scrolled correctly"* from *"scrolled correctly, then ran away"*. The below-boundary control passed before and after the fix, and exists so that a change which merely froze scrolling cannot read as green.

**The settle window is load-bearing, not hygiene.** At the instant the gesture ends the position is correct — 180 is 180 — and only diverges ~100ms later. Coverage sampling one animation frame after the last wheel passes *honestly* while measuring the wrong moment; that is exactly how this survived a suite asserting exact scroll sums at 20/20 across four repeats. Removing the delay would not make these arms flaky, it would make them blind. The spec says so in-file, because "unnecessary wait" is what a future tidy-up would call it.

**Receipts:** `npx playwright test test/playwright/component/list/BufferedScrollAnchor.spec.mjs -c test/playwright/playwright.config.component.mjs` → 2/2, and again with `--headed` → 2/2. Existing `test/playwright/unit/list/` → **32/32** incl. `Buffered.spec.mjs`. The suite proves its own served tree: the harness app exists only on this branch, so a run against another checkout 404s rather than passing.

## AC Evidence

| AC | Evidence |
|---|---|
| AC-1 red-first reproduction | Boundary arm reds at **1620 vs 180** pre-fix while the control passes; both green post-fix, headed and headless. |
| AC-2 positive small deltas incremental before a boundary | Below-boundary control: 120px lands and stays, `mountedRange` asserted `[0,16]`. *(Negative direction scope-transferred to `#17940`.)* |
| AC-3 boundary crossing produces no viewport jump | Boundary arm: 180px lands and stays, `mountedRange` asserted `[1,17]`. |
| AC-6 rebuild prescription | **Disproved** via the AC's own clause — see `## Deltas from ticket`. |
| AC-7 existing coverage green | `test/playwright/unit/list/` 32/32. |

## Post-Merge Validation

- The operator-reported symptom is a **product** observation on the Agent Institution Activity history. After merge, confirm on that surface that repeated small wheel gestures no longer jump — this PR proves the generic component, not that specific app's configuration.
- `#17941` rebases onto this and republishes `24d5318e48`'s three P2 repairs; its boundary arm should flip from red to green **without edits**, which is itself a post-merge check that this fix is what that arm was detecting.
- If any other virtualized surface is added later, `overflow-anchor` is now the property to carry — grid and list both set it, and nothing else in the tree does.

Authored by Ada (Claude Opus 5, Claude Code). Session 05d6d0ba-aeba-48c1-8687-a51674325080.
