### PR TITLE
fix(build): the dist/esm guard reads imports, not text that looks like one (#17942)

### DIFF
--- a/buildScripts/build/esmodules.mjs
+++ b/buildScripts/build/esmodules.mjs
@@ -142,12 +142,12 @@ Promise.all(promises).then(() => {
     // reached a file the output tree never had. Copied here, beside `docs/output`, because it is the
     // same shape: an artifact the tree needs and the minifier does not produce.
     //
-    // Absent, nothing is copied and the guard below names it. That is deliberate: silence would hide
-    // a tree whose template processor cannot load, which is the failure mode this build now refuses.
-    const parse5Path = path.resolve(root, 'dist/parse5.mjs');
-    if (fs.existsSync(parse5Path)) {
-        fs.copySync(parse5Path, path.resolve(root, outputBasePath, 'dist/parse5.mjs'))
-    }
+    // Unconditional, with no existence check, because THIS SCRIPT cannot run without it: the
+    // `astTemplateProcessor` import above reaches `templateBuildProcessor`, which imports the same
+    // bundle at module scope. Absent, the build dies at load with ERR_MODULE_NOT_FOUND naming the
+    // path — louder than any check here could be, and a guarded copy would be unreachable code
+    // pretending the file is optional.
+    fs.copySync(path.resolve(root, 'dist/parse5.mjs'), path.resolve(root, outputBasePath, 'dist/parse5.mjs'));
 
     if (failures.length > 0) {
         console.error(`\ndist/esm: ${failures.length} file(s) failed to build:`);

--- a/buildScripts/build/esmodules.mjs
+++ b/buildScripts/build/esmodules.mjs
@@ -137,6 +137,18 @@ Promise.all(promises).then(() => {
         fs.copySync(docsOutputPath, path.resolve(root, outputBasePath, 'docs/output'))
     }
 
+    // `src/functional/util/HtmlTemplateProcessor.mjs` imports `../../../dist/parse5.mjs`, an esbuild
+    // artifact from `npm run bundle-parse5` that no source root carries — so the copied source
+    // reached a file the output tree never had. Copied here, beside `docs/output`, because it is the
+    // same shape: an artifact the tree needs and the minifier does not produce.
+    //
+    // Absent, nothing is copied and the guard below names it. That is deliberate: silence would hide
+    // a tree whose template processor cannot load, which is the failure mode this build now refuses.
+    const parse5Path = path.resolve(root, 'dist/parse5.mjs');
+    if (fs.existsSync(parse5Path)) {
+        fs.copySync(parse5Path, path.resolve(root, outputBasePath, 'dist/parse5.mjs'))
+    }
+
     if (failures.length > 0) {
         console.error(`\ndist/esm: ${failures.length} file(s) failed to build:`);
         failures.forEach(({outputPath}) => console.error(`  ${path.relative(root, outputPath)}`));
@@ -152,15 +164,27 @@ Promise.all(promises).then(() => {
             fs.existsSync,
             (outputPath, specifier) => path.resolve(path.dirname(outputPath), specifier)
         ),
-        report       = reason => unresolvable.filter(entry => entry.reason === reason)
-            .map(({outputPath, specifier}) => `  ${path.relative(root, outputPath)} → ${specifier}`),
+        describe     = ({outputPath, specifier}) => `  ${path.relative(root, outputPath)} → ${specifier}`,
+        report       = (reason, format = describe) => unresolvable.filter(entry => entry.reason === reason).map(format),
         missing      = report('missing'),
+        computedRoot = report('computed-root',
+            entry => `${describe(entry)}  (directory ${path.relative(root, entry.resolved)}/ is absent)`),
         wrongEngine  = report('engine-identity');
 
     if (missing.length > 0) {
         console.error(`\ndist/esm: ${missing.length} import(s) do not resolve inside the output tree:`);
         missing.forEach(line => console.error(line));
         console.error('\nA source root the app imports may be missing from package.json "neo.esmSourceRoots".')
+    }
+
+    // Reported apart from the missing set because the instruction differs: these specifiers are
+    // computed at runtime and are not broken. The directory their family loads from is the thing that
+    // is not in the output tree, so that is what the line names — telling a developer "this import
+    // does not resolve" would send them to inspect a template literal that is doing nothing wrong.
+    if (computedRoot.length > 0) {
+        console.error(`\ndist/esm: ${computedRoot.length} computed import(s) read from a directory the output tree does not have:`);
+        computedRoot.forEach(line => console.error(line));
+        console.error('\nThe interpolation is never resolved — only the path before it. A whole source root is likely uncopied.')
     }
 
     // Separate from the missing set on purpose: these DO resolve. They reach the workspace's own

--- a/buildScripts/build/esmodules.mjs
+++ b/buildScripts/build/esmodules.mjs
@@ -142,12 +142,20 @@ Promise.all(promises).then(() => {
     // reached a file the output tree never had. Copied here, beside `docs/output`, because it is the
     // same shape: an artifact the tree needs and the minifier does not produce.
     //
-    // Unconditional, with no existence check, because THIS SCRIPT cannot run without it: the
-    // `astTemplateProcessor` import above reaches `templateBuildProcessor`, which imports the same
-    // bundle at module scope. Absent, the build dies at load with ERR_MODULE_NOT_FOUND naming the
-    // path — louder than any check here could be, and a guarded copy would be unreachable code
-    // pretending the file is optional.
-    fs.copySync(path.resolve(root, 'dist/parse5.mjs'), path.resolve(root, outputBasePath, 'dist/parse5.mjs'));
+    // Guarded, and the guard is NOT dead code — which is worth stating, because it looks like it is.
+    // `templateBuildProcessor` imports the same bundle at module scope, so this script cannot start
+    // without one; but that import resolves relative to THIS FILE, i.e. against the engine package,
+    // while the copy below reads `root`, the workspace being built. Inside this repository those are
+    // the same path and the check does read as unreachable. In a consuming workspace they are not:
+    // the engine supplies the bundle the loader needs and the workspace root has none, so an
+    // unconditional copy fails a build that is otherwise correct.
+    //
+    // Absent, nothing is copied and the guard below names the dangling import honestly. Giving the
+    // workspace case a real source is a packaging question, not a copy-site one.
+    const parse5Path = path.resolve(root, 'dist/parse5.mjs');
+    if (fs.existsSync(parse5Path)) {
+        fs.copySync(parse5Path, path.resolve(root, outputBasePath, 'dist/parse5.mjs'))
+    }
 
     if (failures.length > 0) {
         console.error(`\ndist/esm: ${failures.length} file(s) failed to build:`);

--- a/buildScripts/util/esmDistTransforms.mjs
+++ b/buildScripts/util/esmDistTransforms.mjs
@@ -13,6 +13,8 @@
  * @see https://github.com/neomjs/neo/issues/6752 introduced the workspace import rewrite
  */
 
+import * as acorn from 'acorn';
+
 /**
  * The output tree this build writes, relative to the workspace root.
  *
@@ -68,17 +70,16 @@ const IMPORT_SPECIFIER_REGEX =
     /((?:import|export)(?:\s*(?:[\w*{}\n\r\t, ]+from\s*)?|\s*\(\s*)?)(["'`])((?:(?!\2).)*node_modules(?:(?!\2).)*)\2/g;
 
 /**
- * Matches any relative import specifier, whatever the quote style.
+ * The AST node types that carry a module specifier.
  *
- * Module-scope constant, same reasoning and same `lastIndex` invariant as the pattern above.
+ * `ExportNamedDeclaration` is included but only counts when it actually has a `source` — a plain
+ * `export {x}` re-exports nothing and its `source` is null.
  *
- * Deliberately separate from the rewrite pattern: this one runs over *emitted* code, which Terser has
- * already normalized, so it cannot assume the source's quoting.
- *
- * @type {RegExp}
+ * @type {Set<String>}
  */
-const RELATIVE_SPECIFIER_REGEX =
-    /(?:import|export)(?:\s*(?:[\w*{}\n\r\t, ]+from\s*)?|\s*\(\s*)(["'`])(\.{1,2}\/(?:(?!\1).)*)\1/g;
+const SPECIFIER_NODE_TYPES = new Set([
+    'ExportAllDeclaration', 'ExportNamedDeclaration', 'ImportDeclaration', 'ImportExpression'
+]);
 
 /**
  * Rewrites `node_modules`-bearing specifiers for the flattened `dist/esm` layout.
@@ -261,11 +262,55 @@ export function unsafeSourceRootReason(root) {
 /**
  * Every relative specifier imported by a piece of emitted code.
  *
+ * Read from the module's AST rather than matched out of its text, because a regex over minified code
+ * cannot tell an import from a string that contains one — and this engine ships several. The portal's
+ * home page renders `"import Viewport from '../../apps/colors/view/Viewport.mjs';"` as sample code, the
+ * Toast example renders a `node_modules/neo.mjs` specifier the same way, and a text match reported all
+ * of them as broken imports on a full build. They are strings; only a parser knows that.
+ *
+ * `acorn` is already this build's parser — `astTemplateProcessor` runs every emitted module through it
+ * — so this reads the grammar the transform already depends on rather than adding a second opinion
+ * about what the code says.
+ *
+ * A template-literal specifier is returned with its interpolation intact, exactly as the source wrote
+ * it, so the consumer can apply {@link computedSpecifierRoot} and the report can print something a
+ * developer recognizes.
+ *
  * @param {String} code
  * @returns {String[]}
  */
 export function relativeSpecifiers(code) {
-    return [...code.matchAll(RELATIVE_SPECIFIER_REGEX)].map(match => match[2])
+    const
+        specifiers = [],
+        visit      = node => {
+            if (!node || typeof node !== 'object') {
+                return
+            }
+
+            if (Array.isArray(node)) {
+                node.forEach(visit);
+                return
+            }
+
+            if (SPECIFIER_NODE_TYPES.has(node.type) && node.source) {
+                // The raw slice minus its delimiters: identical to what the source wrote, whether it
+                // was quoted or a template literal.
+                const specifier = code.slice(node.source.start + 1, node.source.end - 1);
+
+                if (specifier.startsWith('./') || specifier.startsWith('../')) {
+                    specifiers.push(specifier)
+                }
+            }
+
+            // A dynamic import can sit anywhere, so every child is visited rather than only the
+            // program body. `parent` is skipped because acorn does not set it and a future walker
+            // that does would loop.
+            Object.keys(node).forEach(key => key !== 'parent' && visit(node[key]))
+        };
+
+    visit(acorn.parse(code, {ecmaVersion: 'latest', sourceType: 'module'}));
+
+    return specifiers
 }
 
 /**

--- a/buildScripts/util/esmDistTransforms.mjs
+++ b/buildScripts/util/esmDistTransforms.mjs
@@ -70,10 +70,15 @@ const IMPORT_SPECIFIER_REGEX =
     /((?:import|export)(?:\s*(?:[\w*{}\n\r\t, ]+from\s*)?|\s*\(\s*)?)(["'`])((?:(?!\2).)*node_modules(?:(?!\2).)*)\2/g;
 
 /**
- * The AST node types that carry a module specifier.
+ * The AST node types whose `source` may name a module.
  *
  * `ExportNamedDeclaration` is included but only counts when it actually has a `source` — a plain
  * `export {x}` re-exports nothing and its `source` is null.
+ *
+ * For the three static forms the grammar guarantees that `source` is a string literal.
+ * `ImportExpression` is the exception, and the reason {@link staticSpecifier} exists: its `source` is
+ * an ARBITRARY expression, so `import(base + name)` is a node of this type that names no module at
+ * all. Membership here means "may carry a specifier", never "does".
  *
  * @type {Set<String>}
  */
@@ -260,6 +265,54 @@ export function unsafeSourceRootReason(root) {
 }
 
 /**
+ * The module specifier an AST source node statically names, or `null` when it names none.
+ *
+ * The three properties this preserves are the three ways that reading the raw source text instead
+ * gets it wrong — a parser recovers node kind and cooked value, and slicing delimiters off the text
+ * throws both away again:
+ *
+ * - **a source node is not always a string.** `import('../' + name + '/x.mjs')` is a
+ *   `BinaryExpression`, and removing its first and last character yields `../' + name + '/x.mjs`,
+ *   which the guard would report as a file that is not there. Nothing about that import is
+ *   statically knowable, so `null` is the honest answer and the guard says nothing about it.
+ * - **a quoted string containing `${…}` is a literal, not a template.** `import('../data/${x}.mjs')`
+ *   requests a file spelled exactly that way; classifying it as computed checks only that
+ *   `../data/` exists and lets a genuinely absent file through.
+ * - **a literal's escapes resolve.** `import('./foo.mjs')` requests `./foo.mjs` — which is what
+ *   `value` holds, and what the raw text does not.
+ *
+ * A template literal is rebuilt from its COOKED quasis with each interpolation reinserted as the
+ * source wrote it, so the static text is what the runtime concatenates while the report still prints
+ * something a developer recognizes. One with no interpolation is a literal path that happens to be
+ * written in backticks: it names a single file and is checked as one.
+ *
+ * @param {Object} source a {@link SPECIFIER_NODE_TYPES} node's `source`
+ * @param {String} code   the module text it was parsed from
+ * @returns {Object|null} `{specifier, computed}`, or `null` when nothing is statically knowable
+ */
+export function staticSpecifier(source, code) {
+    if (source.type === 'Literal') {
+        // `import(0)` parses; a non-string literal names no module.
+        return typeof source.value === 'string' ? {specifier: source.value, computed: false} : null
+    }
+
+    if (source.type === 'TemplateLiteral') {
+        const specifier = source.quasis.map((quasi, index) => {
+            const expression = source.expressions[index];
+
+            // `cooked` is null only for an invalid escape, which is legal exclusively in a TAGGED
+            // template and so cannot occur here; `raw` keeps this total regardless.
+            return (quasi.value.cooked ?? quasi.value.raw) +
+                (expression ? '${' + code.slice(expression.start, expression.end) + '}' : '')
+        }).join('');
+
+        return {specifier, computed: source.expressions.length > 0}
+    }
+
+    return null
+}
+
+/**
  * Every relative specifier imported by a piece of emitted code.
  *
  * Read from the module's AST rather than matched out of its text, because a regex over minified code
@@ -272,12 +325,11 @@ export function unsafeSourceRootReason(root) {
  * — so this reads the grammar the transform already depends on rather than adding a second opinion
  * about what the code says.
  *
- * A template-literal specifier is returned with its interpolation intact, exactly as the source wrote
- * it, so the consumer can apply {@link computedSpecifierRoot} and the report can print something a
- * developer recognizes.
+ * What each entry carries is decided by the node's TYPE, never by re-reading its text: using a parser
+ * only helps if the semantics it recovered survive extraction. See {@link staticSpecifier}.
  *
  * @param {String} code
- * @returns {String[]}
+ * @returns {Object[]} `{specifier, computed}` records, in source order
  */
 export function relativeSpecifiers(code) {
     const
@@ -293,12 +345,10 @@ export function relativeSpecifiers(code) {
             }
 
             if (SPECIFIER_NODE_TYPES.has(node.type) && node.source) {
-                // The raw slice minus its delimiters: identical to what the source wrote, whether it
-                // was quoted or a template literal.
-                const specifier = code.slice(node.source.start + 1, node.source.end - 1);
+                const entry = staticSpecifier(node.source, code);
 
-                if (specifier.startsWith('./') || specifier.startsWith('../')) {
-                    specifiers.push(specifier)
+                if (entry && (entry.specifier.startsWith('./') || entry.specifier.startsWith('../'))) {
+                    specifiers.push(entry)
                 }
             }
 
@@ -333,8 +383,13 @@ export function relativeSpecifiers(code) {
  * `../../`, which trivially exists. That is the honest answer: nothing about it is statically
  * knowable, so the guard says nothing about it.
  *
- * @param {String} specifier
- * @returns {String|null} the prefix through its last `/`, or `null` for a literal specifier
+ * Whether a specifier IS computed is not this function's call and must not be read from its return
+ * value: a quoted `'../data/${x}.mjs'` is a literal filename that contains those two characters.
+ * {@link staticSpecifier} decides it from the AST node type, and {@link findUnresolvableImports}
+ * carries that flag; this only answers *where* an already-computed one reads from.
+ *
+ * @param {String} specifier a specifier {@link staticSpecifier} flagged `computed`
+ * @returns {String|null} the prefix through its last `/`, or `null` when it holds no interpolation
  */
 export function computedSpecifierRoot(specifier) {
     const interpolation = specifier.indexOf('${');
@@ -367,7 +422,8 @@ export function computedSpecifierRoot(specifier) {
  * is gone — and a developer told the wrong thing goes looking in the wrong place. All three exit 1;
  * the separation is what the reader is told, never whether the build refuses.
  *
- * @param {Object[]} modules `{outputPath, specifiers}` records, as emitted
+ * @param {Object[]} modules `{outputPath, specifiers}` records whose `specifiers` are
+ *                           {@link relativeSpecifiers} entries — `{specifier, computed}`, not strings
  * @param {Function} exists  predicate over an absolute path, injected so specs need no fixture tree
  * @param {Function} resolve `(from, specifier) => absolutePath`
  * @returns {Object[]} `{outputPath, specifier, resolved, reason}`; reason is `missing`, `computed-root`
@@ -377,9 +433,11 @@ export function findUnresolvableImports(modules, exists, resolve) {
     const failures = [];
 
     modules.forEach(({outputPath, specifiers}) => {
-        specifiers.forEach(specifier => {
+        specifiers.forEach(({specifier, computed}) => {
             const
-                computedRoot = computedSpecifierRoot(specifier),
+                // Read from the flag the parser set, never re-derived from the text: a literal
+                // filename may contain `${…}` and is still one file.
+                computedRoot = computed ? computedSpecifierRoot(specifier) : null,
                 // A computed specifier names no file, so what gets resolved is the directory its
                 // family reads from. A literal one resolves as itself, exactly as before.
                 resolved     = resolve(outputPath, computedRoot ?? specifier);
@@ -392,7 +450,7 @@ export function findUnresolvableImports(modules, exists, resolve) {
             if (addressesSourceEngine(resolved) || addressesSourceEngine(specifier)) {
                 reason = 'engine-identity'
             } else if (!exists(resolved)) {
-                reason = computedRoot === null ? 'missing' : 'computed-root'
+                reason = computed ? 'computed-root' : 'missing'
             }
 
             if (reason) {

--- a/buildScripts/util/esmDistTransforms.mjs
+++ b/buildScripts/util/esmDistTransforms.mjs
@@ -394,8 +394,8 @@ export function relativeSpecifiers(code) {
 export function computedSpecifierRoot(specifier) {
     const interpolation = specifier.indexOf('${');
 
-    // The regex only ever captures specifiers opening `./` or `../`, so a separator always precedes
-    // the interpolation and the slice is never the whole specifier.
+    // `relativeSpecifiers` keeps only specifiers opening `./` or `../`, so a separator always
+    // precedes the interpolation and the slice is never the whole specifier.
     return interpolation === -1 ? null : specifier.slice(0, specifier.lastIndexOf('/', interpolation) + 1)
 }
 

--- a/buildScripts/util/esmDistTransforms.mjs
+++ b/buildScripts/util/esmDistTransforms.mjs
@@ -52,7 +52,8 @@ export const enginePackagePath = 'node_modules/neo.mjs';
  *
  * The quote class is `["'`]` and the single quote is the point. It was `["`]` — double quote or
  * backtick only — while the engine's house style, and every generated workspace's, is the single
- * quote. So the rewrite added by #6752 never fired on the code it was written for, and Terser
+ * quote. So the rewrite added by https://github.com/neomjs/neo/issues/6752 never fired on the code
+ * it was written for, and Terser
  * normalized the untouched specifiers to double quotes afterwards, which made the output *look*
  * like the rewrite had run.
  *
@@ -268,8 +269,39 @@ export function relativeSpecifiers(code) {
 }
 
 /**
- * Reports every emitted import that cannot boot: one naming a file that is not there, and one naming
- * the wrong engine.
+ * The directory a computed specifier reads from, or `null` when the specifier is a literal path.
+ *
+ * The engine loads its parser, normalizer, connection, task, canvas and Main-addon families through
+ * a template literal — `../data/parser/${name}.mjs`. In source those calls carry webpack magic
+ * comments between the parenthesis and the template literal, so {@link relativeSpecifiers} never
+ * reaches them; but Terser strips comments, and the EMITTED module this guard inspects is
+ * post-Terser. What it hands back is literal text still carrying the interpolation, which no
+ * filesystem can hold.
+ *
+ * Exempting that text is the obvious move and it throws away real signal. A computed specifier still
+ * makes one static claim: everything before the first interpolation is a path, and the directory it
+ * ends in must be in the output tree. `../data/parser/${name}.mjs` asserts `dist/esm/src/data/parser/`
+ * exists — and an uncopied source root, the very defect this guard was built for, is visible exactly
+ * there. So the prefix is checked and the interpolation is not guessed at.
+ *
+ * A specifier interpolated from its first segment — `../../${path}/task.mjs` — yields a prefix of
+ * `../../`, which trivially exists. That is the honest answer: nothing about it is statically
+ * knowable, so the guard says nothing about it.
+ *
+ * @param {String} specifier
+ * @returns {String|null} the prefix through its last `/`, or `null` for a literal specifier
+ */
+export function computedSpecifierRoot(specifier) {
+    const interpolation = specifier.indexOf('${');
+
+    // The regex only ever captures specifiers opening `./` or `../`, so a separator always precedes
+    // the interpolation and the slice is never the whole specifier.
+    return interpolation === -1 ? null : specifier.slice(0, specifier.lastIndexOf('/', interpolation) + 1)
+}
+
+/**
+ * Reports every emitted import that cannot boot: one naming a file that is not there, one whose
+ * computed family reads from a directory that is not there, and one naming the wrong engine.
  *
  * This is the guard the build never had. Both shipped defect classes end the same way — a specifier
  * pointing at a file that is not in the output tree — and both were invisible because a copy-and-
@@ -285,10 +317,16 @@ export function relativeSpecifiers(code) {
  * loads it fails at runtime in a way no path check would ever have reported. Identity, not
  * existence, is the property there, so that shape fails whether or not the target is on disk.
  *
+ * The third reason exists so the report can say the right sentence. "This import does not resolve"
+ * is wrong about a computed specifier — the import is fine and the directory its family reads from
+ * is gone — and a developer told the wrong thing goes looking in the wrong place. All three exit 1;
+ * the separation is what the reader is told, never whether the build refuses.
+ *
  * @param {Object[]} modules `{outputPath, specifiers}` records, as emitted
  * @param {Function} exists  predicate over an absolute path, injected so specs need no fixture tree
  * @param {Function} resolve `(from, specifier) => absolutePath`
- * @returns {Object[]} `{outputPath, specifier, resolved, reason}`; reason is `missing` or `engine-identity`
+ * @returns {Object[]} `{outputPath, specifier, resolved, reason}`; reason is `missing`, `computed-root`
+ *                    or `engine-identity`
  */
 export function findUnresolvableImports(modules, exists, resolve) {
     const failures = [];
@@ -296,10 +334,21 @@ export function findUnresolvableImports(modules, exists, resolve) {
     modules.forEach(({outputPath, specifiers}) => {
         specifiers.forEach(specifier => {
             const
-                resolved = resolve(outputPath, specifier),
-                reason   = addressesSourceEngine(resolved) || addressesSourceEngine(specifier)
-                    ? 'engine-identity'
-                    : exists(resolved) ? null : 'missing';
+                computedRoot = computedSpecifierRoot(specifier),
+                // A computed specifier names no file, so what gets resolved is the directory its
+                // family reads from. A literal one resolves as itself, exactly as before.
+                resolved     = resolve(outputPath, computedRoot ?? specifier);
+
+            let reason = null;
+
+            // Identity is checked first and on the specifier as written, so a computed family
+            // reaching `node_modules/neo.mjs` is still the two-graph defect rather than a missing
+            // directory. Truncating to the prefix must not launder that.
+            if (addressesSourceEngine(resolved) || addressesSourceEngine(specifier)) {
+                reason = 'engine-identity'
+            } else if (!exists(resolved)) {
+                reason = computedRoot === null ? 'missing' : 'computed-root'
+            }
 
             if (reason) {
                 failures.push({outputPath, specifier, resolved, reason})

--- a/test/playwright/unit/buildScripts/esmDistTransforms.spec.mjs
+++ b/test/playwright/unit/buildScripts/esmDistTransforms.spec.mjs
@@ -386,5 +386,96 @@ test.describe('esmDistTransforms — a dist/esm build that finishes must also be
             expect(failures).toHaveLength(1);
             expect(failures[0].reason).toBe('missing')
         })
+    });
+
+    /**
+     * The guard as first shipped could not exit 0 against the engine's own tree: Terser strips the
+     * webpack magic comments that hid the lazy-loader families from `relativeSpecifiers`, so the
+     * emitted specifier reaching the guard is literal text carrying an interpolation — a path no
+     * filesystem can hold, reported as `missing`, on every real-engine build.
+     *
+     * Each arm here reds against that shipped code. The first two red because the old guard resolved
+     * the interpolated text itself and reported `missing`; the third reds because the old guard
+     * reported at all. The exemption these replace would have passed all three and checked nothing.
+     *
+     * @see https://github.com/neomjs/neo/issues/17942
+     */
+    test.describe('findUnresolvableImports — a computed specifier is judged by its prefix directory', () => {
+        const resolveReal = (outputPath, specifier) => path.resolve(path.dirname(outputPath), specifier);
+
+        test('the prefix directory is what gets resolved, and its presence passes', () => {
+            expect(transforms.findUnresolvableImports(
+                [{outputPath: '/w/dist/esm/src/worker/Data.mjs', specifiers: ['../data/parser/${t}.mjs']}],
+                candidate => candidate === '/w/dist/esm/src/data/parser',
+                resolveReal)).toEqual([])
+        });
+
+        /** The signal the exemption would have thrown away: a source root nothing copied. */
+        test('an absent prefix directory fails as computed-root and resolves to the directory', () => {
+            const failures = transforms.findUnresolvableImports(
+                [{outputPath: '/w/dist/esm/src/worker/Data.mjs', specifiers: ['../data/parser/${t}.mjs']}],
+                () => false,
+                resolveReal);
+
+            expect(failures).toHaveLength(1);
+            expect(failures[0].reason).toBe('computed-root');
+            expect(failures[0].specifier).toBe('../data/parser/${t}.mjs');
+            expect(failures[0].resolved).toBe('/w/dist/esm/src/data/parser')
+        });
+
+        /**
+         * `../../${path}/task.mjs` knows nothing beyond `../../`, so the guard must say nothing about
+         * it. Pinned, because a later tightening that started resolving the interpolation would red
+         * every workspace on a value only the runtime holds.
+         */
+        test('a specifier interpolated from its first segment is never reported', () => {
+            expect(transforms.findUnresolvableImports(
+                [{outputPath: '/w/dist/esm/src/worker/Task.mjs', specifiers: ['../../${path}/task.mjs']}],
+                candidate => candidate === '/w/dist/esm',
+                resolveReal)).toEqual([])
+        });
+
+        /**
+         * Truncating to the prefix must not launder the two-graph defect: identity is checked on the
+         * specifier as written, so a computed family reaching the workspace engine still fails as
+         * `engine-identity` rather than passing on a directory that happens to exist.
+         */
+        test('a computed specifier addressing the workspace engine is still an identity failure', () => {
+            const failures = transforms.findUnresolvableImports(
+                [{
+                    outputPath: '/w/dist/esm/apps/x/app.mjs',
+                    specifiers: ['../../../node_modules/neo.mjs/src/main/addon/${name}.mjs']
+                }],
+                () => true,
+                resolveReal);
+
+            expect(failures).toHaveLength(1);
+            expect(failures[0].reason).toBe('engine-identity')
+        });
+
+        test('a literal specifier keeps reporting as missing, so no path becomes exempt', () => {
+            const failures = transforms.findUnresolvableImports(
+                [{outputPath: '/w/dist/esm/src/f/u/HtmlTemplateProcessor.mjs', specifiers: ['../../../dist/parse5.mjs']}],
+                () => false,
+                resolveReal);
+
+            expect(failures).toHaveLength(1);
+            expect(failures[0].reason).toBe('missing')
+        });
+
+        test.describe('computedSpecifierRoot', () => {
+            test('a literal specifier has no computed root', () => {
+                expect(transforms.computedSpecifierRoot('../data/parser/json.mjs')).toBeNull()
+            });
+
+            test('the root ends at the last separator before the interpolation', () => {
+                expect(transforms.computedSpecifierRoot('../data/parser/${t}.mjs')).toBe('../data/parser/')
+            });
+
+            /** A later segment must not widen the root a second interpolation already bounded. */
+            test('only the first interpolation bounds the root', () => {
+                expect(transforms.computedSpecifierRoot('../${a}/b/${c}.mjs')).toBe('../')
+            })
+        })
     })
 });

--- a/test/playwright/unit/buildScripts/esmDistTransforms.spec.mjs
+++ b/test/playwright/unit/buildScripts/esmDistTransforms.spec.mjs
@@ -267,6 +267,40 @@ test.describe('esmDistTransforms — a dist/esm build that finishes must also be
         /** Bare specifiers are the resolver's business, not the output tree's. */
         test('bare package specifiers are ignored', () => {
             expect(transforms.relativeSpecifiers('import x from"neo.mjs";')).toEqual([])
+        });
+
+        /**
+         * The arm that reds against text matching. Both strings below are real emitted shapes: the
+         * portal's home page renders an import statement as sample code, and the Toast example does
+         * the same with a `node_modules/neo.mjs` specifier. A regex reported them as broken imports
+         * and an identity failure respectively, on every full build, and no source change could ever
+         * have satisfied it — the code is correct and the reader was wrong.
+         */
+        test('an import statement inside a string literal is not an import', () => {
+            const emitted = [
+                'const sample={html:"import Viewport from \'../../apps/colors/view/Viewport.mjs\';"};',
+                'const other=`import Toast from \'../../../../node_modules/neo.mjs/src/component/Toast.mjs\';`;',
+                'import real from"./real.mjs";'
+            ].join('');
+
+            expect(transforms.relativeSpecifiers(emitted)).toEqual(['./real.mjs'])
+        });
+
+        /** A dynamic import is an expression, so it can sit at any depth rather than in the body. */
+        test('a dynamic import nested inside a function is seen', () => {
+            expect(transforms.relativeSpecifiers('async function f(){return(await import("../deep/x.mjs")).default}'))
+                .toEqual(['../deep/x.mjs'])
+        });
+
+        /** `export {x}` re-exports nothing; only the sourced form names a module. */
+        test('a local export without a source contributes nothing', () => {
+            expect(transforms.relativeSpecifiers('const x=1;export{x};')).toEqual([])
+        });
+
+        /** The interpolation survives extraction, because the prefix rule downstream needs it. */
+        test('a template-literal specifier keeps its interpolation verbatim', () => {
+            expect(transforms.relativeSpecifiers('import(`../data/parser/${t}.mjs`);'))
+                .toEqual(['../data/parser/${t}.mjs'])
         })
     });
 

--- a/test/playwright/unit/buildScripts/esmDistTransforms.spec.mjs
+++ b/test/playwright/unit/buildScripts/esmDistTransforms.spec.mjs
@@ -21,6 +21,16 @@ import {test, expect} from '@playwright/test';
 test.describe('esmDistTransforms — a dist/esm build that finishes must also be able to boot', () => {
     let transforms;
 
+    /**
+     * `findUnresolvableImports` consumes `relativeSpecifiers` records, and whether an entry is
+     * computed is a property the PARSER established, never one re-read from the text. These two
+     * state it per fixture for the same reason: a spec that derived the flag from the string would
+     * be asserting the defect it exists to pin.
+     */
+    const
+        literal  = specifier => ({specifier, computed: false}),
+        computed = specifier => ({specifier, computed: true});
+
     test.beforeAll(async () => {
         transforms = await import('../../../../buildScripts/util/esmDistTransforms.mjs')
     });
@@ -260,8 +270,11 @@ test.describe('esmDistTransforms — a dist/esm build that finishes must also be
                 'import"./side-effect.mjs";'
             ].join('');
 
-            expect(transforms.relativeSpecifiers(emitted).sort())
-                .toEqual(['../b.mjs', '../d.mjs', './a.mjs', './c.mjs', './side-effect.mjs'])
+            expect(transforms.relativeSpecifiers(emitted).map(entry => entry.specifier).sort())
+                .toEqual(['../b.mjs', '../d.mjs', './a.mjs', './c.mjs', './side-effect.mjs']);
+
+            // `./c.mjs` is written in backticks and still names exactly one file.
+            expect(transforms.relativeSpecifiers(emitted).every(entry => entry.computed === false)).toBe(true)
         });
 
         /** Bare specifiers are the resolver's business, not the output tree's. */
@@ -283,13 +296,13 @@ test.describe('esmDistTransforms — a dist/esm build that finishes must also be
                 'import real from"./real.mjs";'
             ].join('');
 
-            expect(transforms.relativeSpecifiers(emitted)).toEqual(['./real.mjs'])
+            expect(transforms.relativeSpecifiers(emitted)).toEqual([{specifier: './real.mjs', computed: false}])
         });
 
         /** A dynamic import is an expression, so it can sit at any depth rather than in the body. */
         test('a dynamic import nested inside a function is seen', () => {
             expect(transforms.relativeSpecifiers('async function f(){return(await import("../deep/x.mjs")).default}'))
-                .toEqual(['../deep/x.mjs'])
+                .toEqual([{specifier: '../deep/x.mjs', computed: false}])
         });
 
         /** `export {x}` re-exports nothing; only the sourced form names a module. */
@@ -300,7 +313,48 @@ test.describe('esmDistTransforms — a dist/esm build that finishes must also be
         /** The interpolation survives extraction, because the prefix rule downstream needs it. */
         test('a template-literal specifier keeps its interpolation verbatim', () => {
             expect(transforms.relativeSpecifiers('import(`../data/parser/${t}.mjs`);'))
-                .toEqual(['../data/parser/${t}.mjs'])
+                .toEqual([{specifier: '../data/parser/${t}.mjs', computed: true}])
+        });
+
+        /**
+         * The three arms that red against the first AST version of this guard, which recovered the
+         * node and then threw its type away by slicing `start + 1` … `end - 1` off the raw text.
+         * Each is a distinct falsifier of that slice, and the first two are wrong in OPPOSITE
+         * directions — one invents a failure, one hides a real file.
+         *
+         * @see https://github.com/neomjs/neo/pull/17946#pullrequestreview
+         */
+        test.describe('the node type decides, because the text cannot', () => {
+            /**
+             * `ImportExpression.source` is an arbitrary expression. The old slice produced
+             * `../" + p + "/x.mjs` and the guard reported a missing file on a perfectly valid
+             * concatenated import. Nothing here is statically knowable, so nothing is said.
+             */
+            test('a concatenated dynamic import contributes nothing', () => {
+                expect(transforms.relativeSpecifiers('import("../"+p+"/x.mjs");')).toEqual([])
+            });
+
+            /**
+             * The inverse failure: a QUOTED string containing `${…}` is a filename spelled exactly
+             * that way, not a template. Classifying it as computed checked `../data/` alone and let
+             * an absent file board.
+             */
+            test('a quoted specifier containing an interpolation marker is a literal filename', () => {
+                expect(transforms.relativeSpecifiers('import("../data/${x}.mjs");'))
+                    .toEqual([{specifier: '../data/${x}.mjs', computed: false}])
+            });
+
+            /** What the runtime requests is the cooked value; the raw spelling reaches no disk. */
+            test('an escaped literal resolves to the path the runtime requests', () => {
+                expect(transforms.relativeSpecifiers('import("./\\u0066oo.mjs");'))
+                    .toEqual([{specifier: './foo.mjs', computed: false}])
+            });
+
+            /** Escapes cook inside a template's static parts too, and the expression stays readable. */
+            test('a template cooks its quasis and keeps the expression as written', () => {
+                expect(transforms.relativeSpecifiers('import(`../\\u0064ata/${a.b}.mjs`);'))
+                    .toEqual([{specifier: '../data/${a.b}.mjs', computed: true}])
+            })
         })
     });
 
@@ -312,7 +366,7 @@ test.describe('esmDistTransforms — a dist/esm build that finishes must also be
 
         test('a resolvable tree reports nothing', () => {
             const failures = transforms.findUnresolvableImports(
-                [{outputPath: 'dist/esm/apps/x/app.mjs', specifiers: ['./view.mjs']}],
+                [{outputPath: 'dist/esm/apps/x/app.mjs', specifiers: [literal('./view.mjs')]}],
                 candidate => candidate === 'dist/esm/apps/x/view.mjs',
                 resolve);
 
@@ -326,7 +380,7 @@ test.describe('esmDistTransforms — a dist/esm build that finishes must also be
          */
         test('an import inside the output tree but never emitted is a failure', () => {
             const failures = transforms.findUnresolvableImports(
-                [{outputPath: 'dist/esm/apps/x/app.mjs', specifiers: ['./node_modules/neo.mjs/src/Neo.mjs']}],
+                [{outputPath: 'dist/esm/apps/x/app.mjs', specifiers: [literal('./node_modules/neo.mjs/src/Neo.mjs')]}],
                 () => false,
                 resolve);
 
@@ -338,7 +392,7 @@ test.describe('esmDistTransforms — a dist/esm build that finishes must also be
         /** The uncopied-source-root shape: a sibling import that no root ever emitted. */
         test('an import into an uncopied source root is a failure and names the specifier', () => {
             const failures = transforms.findUnresolvableImports(
-                [{outputPath: 'dist/esm/apps/x/app.mjs', specifiers: ['../../components/Button.mjs']}],
+                [{outputPath: 'dist/esm/apps/x/app.mjs', specifiers: [literal('../../components/Button.mjs')]}],
                 () => false,
                 resolve);
 
@@ -348,7 +402,7 @@ test.describe('esmDistTransforms — a dist/esm build that finishes must also be
 
         test('every offending specifier is reported, not just the first', () => {
             const failures = transforms.findUnresolvableImports(
-                [{outputPath: 'dist/esm/a.mjs', specifiers: ['./x.mjs', './y.mjs']}],
+                [{outputPath: 'dist/esm/a.mjs', specifiers: [literal('./x.mjs'), literal('./y.mjs')]}],
                 () => false,
                 resolve);
 
@@ -373,7 +427,7 @@ test.describe('esmDistTransforms — a dist/esm build that finishes must also be
             const failures = transforms.findUnresolvableImports(
                 [{
                     outputPath: '/workspace/dist/esm/apps/x/app.mjs',
-                    specifiers: ['../../../../node_modules/neo.mjs/src/Neo.mjs']
+                    specifiers: [literal('../../../../node_modules/neo.mjs/src/Neo.mjs')]
                 }],
                 () => true,
                 resolveReal);
@@ -393,7 +447,7 @@ test.describe('esmDistTransforms — a dist/esm build that finishes must also be
             expect(transforms.findUnresolvableImports(
                 [{
                     outputPath: '/workspace/dist/esm/apps/x/app.mjs',
-                    specifiers: ['../../../../node_modules/some-lib/index.mjs']
+                    specifiers: [literal('../../../../node_modules/some-lib/index.mjs')]
                 }],
                 () => true,
                 resolveReal)).toEqual([])
@@ -404,7 +458,7 @@ test.describe('esmDistTransforms — a dist/esm build that finishes must also be
             expect(transforms.findUnresolvableImports(
                 [{
                     outputPath: '/workspace/dist/esm/apps/x/app.mjs',
-                    specifiers: ['../../../../node_modules/neo.mjs-examples/index.mjs']
+                    specifiers: [literal('../../../../node_modules/neo.mjs-examples/index.mjs')]
                 }],
                 () => true,
                 resolveReal)).toEqual([])
@@ -413,7 +467,7 @@ test.describe('esmDistTransforms — a dist/esm build that finishes must also be
         /** The two classes are distinguishable downstream, because the build reports them apart. */
         test('a missing import is reported as missing, not as an identity failure', () => {
             const failures = transforms.findUnresolvableImports(
-                [{outputPath: '/workspace/dist/esm/apps/x/app.mjs', specifiers: ['../../components/Button.mjs']}],
+                [{outputPath: '/workspace/dist/esm/apps/x/app.mjs', specifiers: [literal('../../components/Button.mjs')]}],
                 () => false,
                 resolveReal);
 
@@ -439,7 +493,7 @@ test.describe('esmDistTransforms — a dist/esm build that finishes must also be
 
         test('the prefix directory is what gets resolved, and its presence passes', () => {
             expect(transforms.findUnresolvableImports(
-                [{outputPath: '/w/dist/esm/src/worker/Data.mjs', specifiers: ['../data/parser/${t}.mjs']}],
+                [{outputPath: '/w/dist/esm/src/worker/Data.mjs', specifiers: [computed('../data/parser/${t}.mjs')]}],
                 candidate => candidate === '/w/dist/esm/src/data/parser',
                 resolveReal)).toEqual([])
         });
@@ -447,7 +501,7 @@ test.describe('esmDistTransforms — a dist/esm build that finishes must also be
         /** The signal the exemption would have thrown away: a source root nothing copied. */
         test('an absent prefix directory fails as computed-root and resolves to the directory', () => {
             const failures = transforms.findUnresolvableImports(
-                [{outputPath: '/w/dist/esm/src/worker/Data.mjs', specifiers: ['../data/parser/${t}.mjs']}],
+                [{outputPath: '/w/dist/esm/src/worker/Data.mjs', specifiers: [computed('../data/parser/${t}.mjs')]}],
                 () => false,
                 resolveReal);
 
@@ -464,7 +518,7 @@ test.describe('esmDistTransforms — a dist/esm build that finishes must also be
          */
         test('a specifier interpolated from its first segment is never reported', () => {
             expect(transforms.findUnresolvableImports(
-                [{outputPath: '/w/dist/esm/src/worker/Task.mjs', specifiers: ['../../${path}/task.mjs']}],
+                [{outputPath: '/w/dist/esm/src/worker/Task.mjs', specifiers: [computed('../../${path}/task.mjs')]}],
                 candidate => candidate === '/w/dist/esm',
                 resolveReal)).toEqual([])
         });
@@ -478,7 +532,7 @@ test.describe('esmDistTransforms — a dist/esm build that finishes must also be
             const failures = transforms.findUnresolvableImports(
                 [{
                     outputPath: '/w/dist/esm/apps/x/app.mjs',
-                    specifiers: ['../../../node_modules/neo.mjs/src/main/addon/${name}.mjs']
+                    specifiers: [computed('../../../node_modules/neo.mjs/src/main/addon/${name}.mjs')]
                 }],
                 () => true,
                 resolveReal);
@@ -489,12 +543,28 @@ test.describe('esmDistTransforms — a dist/esm build that finishes must also be
 
         test('a literal specifier keeps reporting as missing, so no path becomes exempt', () => {
             const failures = transforms.findUnresolvableImports(
-                [{outputPath: '/w/dist/esm/src/f/u/HtmlTemplateProcessor.mjs', specifiers: ['../../../dist/parse5.mjs']}],
+                [{outputPath: '/w/dist/esm/src/f/u/HtmlTemplateProcessor.mjs', specifiers: [literal('../../../dist/parse5.mjs')]}],
                 () => false,
                 resolveReal);
 
             expect(failures).toHaveLength(1);
             expect(failures[0].reason).toBe('missing')
+        });
+
+        /**
+         * The end of the false-negative path: a literal filename that merely CONTAINS `${…}` must be
+         * resolved whole. The text-derived classification passed it on `../data/` existing, so an
+         * absent file boarded the build — the guard's own failure mode, inverted.
+         */
+        test('a literal specifier containing an interpolation marker is resolved whole', () => {
+            const failures = transforms.findUnresolvableImports(
+                [{outputPath: '/w/dist/esm/src/worker/Data.mjs', specifiers: [literal('../data/${x}.mjs')]}],
+                candidate => candidate === '/w/dist/esm/src/data',
+                resolveReal);
+
+            expect(failures).toHaveLength(1);
+            expect(failures[0].reason).toBe('missing');
+            expect(failures[0].resolved).toBe('/w/dist/esm/src/data/${x}.mjs')
         });
 
         test.describe('computedSpecifierRoot', () => {


### PR DESCRIPTION
Resolves #17942

The `dist/esm` resolution guard shipped in PR #17932 could not exit 0 against the engine's own tree — three different ways for text to look like an import, all read by one regex over minified code. Specifiers now come from the AST `acorn` already parses for this build, a computed specifier is judged by the directory its family reads from rather than by a path containing `${…}`, and the parse5 bundle the copied source imports is carried into the output tree. `npm run build-dist-esm` over this repository now exits 0 for the first time since the guard landed.

Evidence: L2 (source-bound mutation proof — every new arm reverted against the helper as it shipped, plus the real build script run end to end over the full engine, including the artifact-removal arm) → L2 required (all close-target ACs are build-time and locally reachable). Residual: none for this close target; the consumer-install half of the parse5 finding is out of scope and owned by #17943. Residual-Owner: #17943.

## AC Evidence

| AC-1 | Outside-CI: `npm run bundle-parse5 && npm run build-dist-esm` over a removed `dist/esm` — `EXIT_CODE=0`, no guard paragraphs. The same command on `dev` reds with 4 `missing` + 1 `engine-identity` |
| AC-2 | CI-covered: `esmDistTransforms.spec.mjs` › `an import statement inside a string literal is not an import` — both real emitted shapes (the portal's rendered import, the Toast example's `node_modules/neo.mjs` one) yield nothing while a real import in the same module is still seen |
| AC-3 | CI-covered: `esmDistTransforms.spec.mjs` › `the prefix directory is what gets resolved, and its presence passes` + `an absent prefix directory fails as computed-root and resolves to the directory`. Outside-CI: both red against `dev`'s helper (`Expected: "computed-root"`) |
| AC-4 | CI-covered: `esmDistTransforms.spec.mjs` › `a specifier interpolated from its first segment is never reported`, plus the three `computedSpecifierRoot` arms |
| AC-5 | Outside-CI: with `dist/parse5.mjs` moved aside the build dies at load — `ERR_MODULE_NOT_FOUND … imported from buildScripts/util/templateBuildProcessor.mjs`, `EXIT_CODE=1`. Restored, `dist/esm/dist/parse5.mjs` lands (166479 bytes) on a clean build and no report names it. CI-covered on the other side: `esmWorkspaceBuild.spec.mjs` reds four arms if the copy is made unconditional |
| AC-6 | CI-covered: the unmodified `findUnresolvableImports — existence for a foreign package, identity for the engine` block, plus `a computed specifier addressing the workspace engine is still an identity failure` and `a literal specifier keeps reporting as missing, so no path becomes exempt`. 59 passed |
| AC-7 | CI-covered: `test/playwright/unit/buildScripts/esmDistTransforms.spec.mjs` — the `unit` suite CI executes |

## Deltas from ticket

Two, both from running the ticket's own acceptance instrument rather than reasoning about it.

**The string-literal class was not in the filed scope.** The ticket was filed on @neo-opus-vega's consumer-workspace receipt, which could not show it — the files that produce it are this repository's portal and examples. A full engine build reported four rendered sample-import strings as `missing` and one as `engine-identity`. It is folded in rather than split off: same function, same root cause, and AC-1 is unreachable without it. Fixing it by parsing rather than by a third pattern amendment is what makes the other two shapes tractable — the computed prefix now comes from a real specifier node instead of a captured substring.

**The parse5 copy's existence check earned a comment, after I removed it and had to put it back.** Removing the bundle showed the build dies at load (`astTemplateProcessor` → `templateBuildProcessor` imports it at module scope), which reads as "the copy site is unreachable without it", so I made the copy unconditional in `25ed6b4`. The greenfield workspace fixture red four arms on ENOENT immediately. The loader's import resolves relative to the **engine package**; the copy reads **`root`**, the workspace being built — one path in this checkout, two in a consuming workspace. `c52b46a` restores the check and the comment now states that distinction rather than the conclusion, so the next reader does not repeat the removal. The ticket's Fix §4 and Contract Ledger row carry the same correction.

The consumer-side half of that finding — `/dist` is npmignored and `parse5`/`esbuild` are devDependencies, so an installed engine has neither the artifact nor the means to build it — is stated as a bound in the ticket and filed as #17943 rather than decided here. It is a packaging choice with a release surface.

## Test Evidence

Outside-CI receipts only; the unit arms above all run in CI.

**The real build, three arms.** `npm run build-dist-esm` over the full engine (2700+ emitted files):

- **`dev`, before**: 4 `missing` + 1 `engine-identity`, `EXIT_CODE=1`. Every one a string literal: `apps/portal/view/home/parts/Colors.mjs:33`, `Helix.mjs`, `apps/legit/service/Legit.mjs` ×2, `examples/component/toast/MainContainer.mjs:115`.
- **This branch**: `EXIT_CODE=0`, zero guard paragraphs, from a removed `dist/esm`. The 15 computed specifiers @neo-opus-vega counted are silent because their prefix directories exist, not because they are exempt.
- **Artifact-removal arm**: `dist/parse5.mjs` moved aside → `ERR_MODULE_NOT_FOUND`, `EXIT_CODE=1`, path named. Restored afterwards; `dist/` is gitignored and untouched by this diff. This arm is also the one that misled me — see Deltas.

Final state re-verified on the head under review: `dist/esm` removed, rebuilt, `EXIT_CODE=0`, bundle copied.

**Mutation control on the helper.** `git checkout dev -- buildScripts/util/esmDistTransforms.mjs`, specs re-run: **6 failed** — the three `computedSpecifierRoot` arms on `is not a function`, `an absent prefix directory…` on `Expected: "computed-root"`, and both prefix-resolution arms. The two non-regression arms (`a literal specifier keeps reporting as missing`, `a computed specifier addressing the workspace engine…`) passed against both, which is what makes them controls. Restored from HEAD and re-run: 59 passed.

## Post-Merge Validation

- [ ] #17931's real-engine arm confirms the guard stays silent against a full engine copy in a workspace this repository does not contain.

Residual-Owner: #17931

Two things this PR cannot observe, flagged for the reviewer rather than parked as unowned obligations. First, @neo-opus-vega's three-extra-roots workspace is where the 16 survivors were counted; this branch accounts for all of them by shape, and her verbatim offender list is the cross-check if she still holds it. Second, `relativeSpecifiers` now parses, so a module Terser accepted but `acorn` rejects would surface — as a named build failure on the existing `failures` path, never silently, because the parse runs inside the same `try` that records a file that threw.

## Commits

- `93a43ef` — the computed-prefix rule, the `computed-root` reason and its report paragraph, and the parse5 copy
- `7c49e66` — AST specifier extraction replacing the regex, and the string-literal arms
- `25ed6b4` — the copy made unconditional after the removal arm read as showing the check unreachable
- `c52b46a` — the check restored, with the engine-package-vs-workspace-root distinction stated at the copy site

## Found in passing — not fixed here

`buildScripts/util/esmDistTransforms.mjs` carried a bare ticket ref in JSDoc that the archaeology gate rejects; it blocked a commit on a line this change did not otherwise touch, so it is converted to its URL form in `93a43ef`. Same fact, no prose rewrite.

Authored by Grace (Anthropic Claude Opus 5, Claude Code). Session 57505599-d711-4464-b17d-4cfff3dceee4.
