### PR TITLE
feat(dashboard): a dock pane can collapse to its edge rail (#17945)

### DIFF
--- a/examples/dashboard/dock/MainContainer.mjs
+++ b/examples/dashboard/dock/MainContainer.mjs
@@ -120,6 +120,13 @@ class MainContainer extends DockWorkspace {
          */
         enableDockCloseAction: true,
         /**
+         * And into the engine-owned pin action, so the example demonstrates the WHOLE auto-hide
+         * round-trip: a pane collapses to its edge rail from its own header, and the rail's reveal
+         * overlay brings it back. Before this the example could only show the way back.
+         * @member {Boolean} enableDockPinAction=true
+         */
+        enableDockPinAction: true,
+        /**
          * The perspective toolbar sits at index 0; the projected shell follows it.
          * @member {Number} dockShellIndex=1
          */

--- a/src/dashboard/dock/Workspace.mjs
+++ b/src/dashboard/dock/Workspace.mjs
@@ -1167,10 +1167,15 @@ class Workspace extends Container {
      * Synchronizes one retained close action against the live active item and committed policy.
      * Hidden-state changes stay on the stable action instance so Overflow receives its existing
      * `actionVisibilityChange` signal instead of an action-group replacement.
+     *
+     * Gated on {@link #enableDockCloseAction} for the reason given on {@link #syncDockPinAction}: the
+     * name is only this class's while its own opt-in is on.
      * @param {Neo.tab.Container|null} tabContainer
      * @protected
      */
     syncDockCloseAction(tabContainer) {
+        if (!this.enableDockCloseAction) return;
+
         let action = tabContainer?.getActionItem?.('close'),
             itemId = this.getActiveDockItemId(tabContainer),
             hidden = !itemId || this.dockModel?.items?.[itemId]?.closable === false;
@@ -1191,10 +1196,19 @@ class Workspace extends Container {
      * Like {@link #syncDockCloseAction}, hidden-state changes stay on the stable action instance so
      * Overflow receives its existing `actionVisibilityChange` signal instead of an action-group
      * replacement.
+     *
+     * **The opt-in gates policy synchronization, not only projection and dispatch.** `pin` is a
+     * reserved engine name exactly while {@link #enableDockPinAction} is on — that is the contract
+     * {@link #getDockProjectionOptions} states and the throw it enforces. While the flag is off the
+     * name belongs to whoever projected it through `resolveDockHeaderActions`, so resolving it here
+     * would let a disabled engine action move a host's `hidden` on every active-item change and
+     * reconciliation sweep. Default-off has to mean behaviorally inert, not merely unprojected.
      * @param {Neo.tab.Container|null} tabContainer
      * @protected
      */
     syncDockPinAction(tabContainer) {
+        if (!this.enableDockPinAction) return;
+
         let action = tabContainer?.getActionItem?.('pin'),
             itemId = this.getActiveDockItemId(tabContainer),
             model  = this.dockModel,
@@ -1371,6 +1385,15 @@ class Workspace extends Container {
      *
      * An UNPINNED item — the ordinary case — is a single step and a single refresh; only collapsing a
      * pinned pane commits twice.
+     *
+     * **Eligibility is re-derived here, from the current document, and not inherited from the chrome
+     * that emitted the intent.** {@link #syncDockPinAction} hides the action wherever no edge owns the
+     * item, but that visibility is a projection of the document as it stood at the last sweep, and the
+     * sweep is deferred behind reconciliation. Between a commit that moves an item to the root center
+     * and the refresh that re-hides its action, a retained-but-stale action is still visible and still
+     * dispatchable — and collapsing a center item is precisely what §2.7 forbids. Deciding from
+     * `dockModel` at dispatch closes that window: the same predicate, evaluated against the document
+     * the commit will actually reduce against.
      * @param {Object} data
      * @param {String} data.dockNodeId
      * @param {Neo.tab.Container} data.tabContainer
@@ -1387,6 +1410,10 @@ class Workspace extends Container {
 
         if (!me.dockModel) {
             return {document: me.dockModel, errors: ['Dock pin action requires a committed document']}
+        }
+
+        if (!Document.findOwningEdge(me.dockModel, itemId)) {
+            return {document: me.dockModel, errors: ['Dock pin action requires an item owned by an edge zone']}
         }
 
         let descriptors = [],

--- a/src/dashboard/dock/Workspace.mjs
+++ b/src/dashboard/dock/Workspace.mjs
@@ -124,6 +124,14 @@ class Workspace extends Container {
          */
         enableDockCloseAction: false,
         /**
+         * Projects one persistent pin action into each Dock tab header — the entry half of the
+         * collapse-to-rail round-trip (docking design record §2.7). Pressing it on an edge-owned pane
+         * collapses that pane to its owning edge rail; the way back is the rail's existing reveal
+         * overlay and its pin control. Disabled by default; the projection is byte-identical while off.
+         * @member {Boolean} enableDockPinAction=false
+         */
+        enableDockPinAction: false,
+        /**
          * Enables the engine-owned dock tear-out admission/document/window lifecycle. Disabled
          * by default so ordinary workspaces and hosts carrying their own legacy lifecycle remain
          * byte-behaviorally unchanged until their migration leaf.
@@ -1129,7 +1137,8 @@ class Workspace extends Container {
      * project a host's own actions into that tabs node's header. The set is node-static and lives for
      * the node's retained lifetime — vary an action per active item by moving `hidden` on its stable
      * instance, the way {@link #syncDockCloseAction} does, not by returning a different list. Names
-     * must be unique per node and `close` is reserved while {@link #enableDockCloseAction} is on;
+     * must be unique per node, and every engine-owned name is reserved while its own opt-in is on —
+     * `close` under {@link #enableDockCloseAction}, `pin` under {@link #enableDockPinAction};
      * both violations throw at projection rather than silently unaddressing an action. Their intent
      * surfaces on the `dockHeaderAction` event — see {@link #onDockHeaderAction}.
      * @returns {Object}
@@ -1170,21 +1179,56 @@ class Workspace extends Container {
     }
 
     /**
-     * Synchronizes every projected close action after reconciliation, including retained tabs
+     * Synchronizes one retained pin action against the live active item and committed policy.
+     *
+     * Hidden wherever the collapse could not complete, so the header never offers a gesture the model
+     * or the projection would refuse: no active item, `pinnable: false` (which
+     * {@link Neo.dashboard.dock.model.Operations#setItemAutoHidden} rejects), or an item no edge owns
+     * (§2.7 — center never rails). The edge answer comes from
+     * {@link Neo.dashboard.dock.model.Document#findOwningEdge}, the same derivation the projection
+     * rails by, so the action cannot disagree with the rail it would collapse into.
+     *
+     * Like {@link #syncDockCloseAction}, hidden-state changes stay on the stable action instance so
+     * Overflow receives its existing `actionVisibilityChange` signal instead of an action-group
+     * replacement.
+     * @param {Neo.tab.Container|null} tabContainer
+     * @protected
+     */
+    syncDockPinAction(tabContainer) {
+        let action = tabContainer?.getActionItem?.('pin'),
+            itemId = this.getActiveDockItemId(tabContainer),
+            model  = this.dockModel,
+            hidden = !itemId
+                || model?.items?.[itemId]?.pinnable === false
+                || !model
+                || !Document.findOwningEdge(model, itemId);
+
+        action && action.hidden !== hidden && (action.hidden = hidden)
+    }
+
+    /**
+     * Synchronizes every projected engine header action after reconciliation, including retained tabs
      * whose action instance outlived a model-policy or active-item change.
+     *
+     * Each action's own sync is a no-op when that action was never projected (`getActionItem` misses),
+     * so this sweep stays correct for any subset of the engine set a consumer enabled.
      * @param {Map<String,Neo.tab.Container>|null} [tabs=null]
      * @protected
      */
-    syncDockCloseActions(tabs=null) {
-        let projectedTabs = tabs;
+    syncDockHeaderActions(tabs=null) {
+        let me            = this,
+            projectedTabs = tabs;
 
         if (!projectedTabs) {
-            let shell = this.getDockHost()?.items?.[this.dockShellIndex];
+            let shell = me.getDockHost()?.items?.[me.dockShellIndex];
 
             projectedTabs = shell ? Reconciler.collectProjectedTabs(shell) : new Map()
         }
 
-        projectedTabs?.forEach?.(tab => this.syncDockCloseAction(tab))
+        projectedTabs?.forEach?.(tab => {
+            me.syncDockCloseAction(tab);
+            me.syncDockPinAction(tab)
+        })
     }
 
     /**
@@ -1207,6 +1251,7 @@ class Workspace extends Container {
             descriptor, result;
 
         me.syncDockCloseAction(container);
+        me.syncDockPinAction(container);
 
         if (!me.dockModel || !itemId || committed === itemId) {
             return null
@@ -1233,14 +1278,15 @@ class Workspace extends Container {
      * Routes one persistent header action through the model and the class-owned projection chain,
      * and re-emits everything it does not own.
      *
-     * This class owns exactly one action: `close`, and only while {@link #enableDockCloseAction} is
-     * on. Every other intent — including host actions projected through
-     * `resolveDockHeaderActions` — is re-emitted as a **`dockHeaderAction`** event carrying
-     * `{action, dockNodeId, tabContainer}`, so a host receives it without subclassing this class or
-     * overriding a protected method, and this method returns `null` for it.
-     * Live reconciled order owns the close target at dispatch time. The current model locates that
-     * item's semantic tabs node, and the committed result owns its focus successor. Successful focus
-     * is chained onto `refreshPromise`, so it cannot reach chrome the reconciler retires.
+     * This class owns the ENGINE SET, each action only while its own opt-in is on: `close`
+     * ({@link #enableDockCloseAction}) and `pin` ({@link #enableDockPinAction}). Every other intent —
+     * including host actions projected through `resolveDockHeaderActions` — is re-emitted as a
+     * **`dockHeaderAction`** event carrying `{action, dockNodeId, tabContainer}`, so a host receives it
+     * without subclassing this class or overriding a protected method, and this method returns `null`
+     * for it.
+     *
+     * Routing lives here and the effect lives in one handler per action, so a further engine action is
+     * a new handler plus a row below rather than another branch grown into this method.
      * @param {Object} data
      * @param {String} data.action
      * @param {String} data.dockNodeId
@@ -1248,16 +1294,38 @@ class Workspace extends Container {
      * @returns {{document:Object,errors:String[]}|null}
      */
     onDockHeaderAction({action, dockNodeId, tabContainer}={}) {
-        if (action !== 'close' || !this.enableDockCloseAction) {
-            // Not an action this class owns. Re-emit it so a host that projected its own actions
-            // through `resolveDockHeaderActions` receives the intent with its tabs node identified,
-            // without having to override a protected method or subclass at all. Dropping it here is
-            // what made the header slot unusable for anyone but the close action.
-            this.fire('dockHeaderAction', {action, dockNodeId, tabContainer});
+        let me = this;
 
-            return null
+        if (action === 'close' && me.enableDockCloseAction) {
+            return me.handleDockCloseAction({dockNodeId, tabContainer})
         }
 
+        if (action === 'pin' && me.enableDockPinAction) {
+            return me.handleDockPinAction({dockNodeId, tabContainer})
+        }
+
+        // Not an action this class owns. Re-emit it so a host that projected its own actions
+        // through `resolveDockHeaderActions` receives the intent with its tabs node identified,
+        // without having to override a protected method or subclass at all. Dropping it here is
+        // what made the header slot unusable for anyone but the close action.
+        me.fire('dockHeaderAction', {action, dockNodeId, tabContainer});
+
+        return null
+    }
+
+    /**
+     * Commits the engine-owned close action.
+     *
+     * Live reconciled order owns the close target at dispatch time. The current model locates that
+     * item's semantic tabs node, and the committed result owns its focus successor. Successful focus
+     * is chained onto `refreshPromise`, so it cannot reach chrome the reconciler retires.
+     * @param {Object} data
+     * @param {String} data.dockNodeId
+     * @param {Neo.tab.Container} data.tabContainer
+     * @returns {{document:Object,errors:String[]}|null}
+     * @protected
+     */
+    handleDockCloseAction({dockNodeId, tabContainer}={}) {
         let me     = this,
             itemId = me.getActiveDockItemId(tabContainer);
 
@@ -1280,6 +1348,65 @@ class Workspace extends Container {
             me.refreshPromise = me.refreshPromise.then(() => {
                 me.focusDockCloseTarget({dockNodeId: modelNodeId, itemId: focusId})
             })
+        }
+
+        return result
+    }
+
+    /**
+     * Commits the engine-owned pin action — docking design record §2.7's collapse-to-rail sequence.
+     *
+     * §2.7 specifies a two-step sequence and forbids a composite operation: `setItemPinned(false)`
+     * when the item is pinned (the model rejects `autoHidden` on a pinned item), then
+     * `setItemAutoHidden(true)`. Each step is an INDEPENDENT commit — reduced through
+     * {@link #applyDockZoneOperation} and published through {@link #onDockZoneDocumentChange} on its
+     * own — so both steps stay visible at the class's own write seam, the one `DockService` and
+     * `DockSplitter` already reach a holder through. Folding them into a single published change
+     * would make step 2 bypass that seam, since the seam reduces against the committed `dockModel`
+     * and step 2 needs step 1's result.
+     *
+     * A step-2 rejection therefore leaves the item unpinned and still visible. That is §2.7's own
+     * intermediate state, which it calls benign, and it is the price of the independence the row
+     * requires; the alternative buys atomicity by making half the gesture unobservable.
+     *
+     * An UNPINNED item — the ordinary case — is a single step and a single refresh; only collapsing a
+     * pinned pane commits twice.
+     * @param {Object} data
+     * @param {String} data.dockNodeId
+     * @param {Neo.tab.Container} data.tabContainer
+     * @returns {{document:Object,errors:String[]}|null}
+     * @protected
+     */
+    handleDockPinAction({dockNodeId, tabContainer}={}) {
+        let me     = this,
+            itemId = me.getActiveDockItemId(tabContainer);
+
+        if (!itemId) {
+            return {document: me.dockModel, errors: ['Dock pin action requires an active item']}
+        }
+
+        if (!me.dockModel) {
+            return {document: me.dockModel, errors: ['Dock pin action requires a committed document']}
+        }
+
+        let descriptors = [],
+            result      = null;
+
+        me.dockModel.items?.[itemId]?.pinned === true &&
+            descriptors.push({operation: 'setItemPinned', itemId, pinned: false});
+
+        descriptors.push({operation: 'setItemAutoHidden', itemId, autoHidden: true});
+
+        for (const descriptor of descriptors) {
+            result = me.applyDockZoneOperation(descriptor);
+
+            if (!result || result.errors?.length || !result.document) {
+                return result
+            }
+
+            // Publishing here is what lets the NEXT step reduce against this one: the seam reads the
+            // committed `dockModel`, and this assigns it synchronously before the refresh is chained.
+            me.onDockZoneDocumentChange(result.document, descriptor, tabContainer)
         }
 
         return result
@@ -1539,6 +1666,7 @@ class Workspace extends Container {
                 // nowhere to arrive.
                 onDockHeaderAction     : me.onDockHeaderAction.bind(me),
                 ...(me.enableDockCloseAction && {enableDockCloseAction: true}),
+                ...(me.enableDockPinAction && {enableDockPinAction: true}),
                 applyDockZoneOperation   : me.applyDockZoneOperation.bind(me),
                 onDockZoneDocumentChange : me.onDockZoneDocumentChange.bind(me),
                 resolveComponentRef      : itemResolver || ((componentRef, item, itemId) => me.resolveProjectedPane(itemId, item)),
@@ -1667,7 +1795,7 @@ class Workspace extends Container {
             waitForOverflowProjection
         });
 
-        me.syncDockCloseActions(result?.currentTabs);
+        me.syncDockHeaderActions(result?.currentTabs);
 
         // FLIP phase 2: fire-and-forget by default — the addon self-waits for the swap, inverts and
         // plays; the counted motion signal brackets the awaited animation window. Gate on the

--- a/src/dashboard/dock/model/Document.mjs
+++ b/src/dashboard/dock/model/Document.mjs
@@ -513,6 +513,54 @@ class Document extends Base {
     }
 
     /**
+     * @summary Returns the workspace edge whose rail `itemId` would collapse to, or null when no
+     * edge owns it — the structural half of docking design record §2.7's "the rail an item collapses
+     * to is the edge zone that contains it".
+     *
+     * Walks item → tabs node → ancestors, recording every `edge-zone` ancestor reached through a
+     * DIRECTIONAL slot and returning the OUTERMOST one. Outermost is not an arbitrary tie-break: it
+     * is what the projection already does. `LayoutAdapter.projectEdgeZoneNode` collects each band
+     * with `collectAutoHiddenItems`, which recurses through nested edge-zones, then passes the
+     * claimed set down as `railedItemIds` so the inner tab flow drops them — so an item nested two
+     * edge-zones deep rails on the OUTER edge, and an inner band that also contains it never gets to
+     * claim it. This query and that projection must agree; `DockZoneModel.spec` pins them together.
+     *
+     * A `center` slot is not a claim (§2.7: center-zone items never rail — main content does not
+     * auto-hide), so an item reaching the root only through center zones returns null. Null is
+     * therefore the fail-safe answer for BOTH "center-owned" and "no such item": a caller gating an
+     * affordance on a truthy edge cannot offer a collapse the projection would not render.
+     * @param {Object} document
+     * @param {String} itemId
+     * @returns {String|null} One of `top`, `right`, `bottom`, `left`, else null
+     * @static
+     */
+    static findOwningEdge(document, itemId) {
+        let nodeId = Document.findContainingTabsId(document, itemId),
+            edge   = null,
+            seen   = new Set(),
+            parent;
+
+        // `seen` bounds the climb. A well-formed document is a tree, but this query also runs
+        // against documents mid-operation, and a cycle here would hang the render thread.
+        while (nodeId && !seen.has(nodeId)) {
+            seen.add(nodeId);
+
+            parent = Document.findParentSlot(document, nodeId);
+
+            if (!parent) break;
+
+            if (document.nodes[parent.parentId]?.type === 'edge-zone' &&
+                ['top', 'right', 'bottom', 'left'].includes(parent.slot)) {
+                edge = parent.slot
+            }
+
+            nodeId = parent.parentId
+        }
+
+        return edge
+    }
+
+    /**
      * @summary Mutating helper: removes `itemId` from whatever tabs node holds it, fixing activeItemId.
      * @param {Object} document the working (already-cloned) document
      * @param {String} itemId

--- a/src/dashboard/dock/model/Document.mjs
+++ b/src/dashboard/dock/model/Document.mjs
@@ -523,7 +523,14 @@ class Document extends Base {
      * with `collectAutoHiddenItems`, which recurses through nested edge-zones, then passes the
      * claimed set down as `railedItemIds` so the inner tab flow drops them — so an item nested two
      * edge-zones deep rails on the OUTER edge, and an inner band that also contains it never gets to
-     * claim it. This query and that projection must agree; `DockZoneModel.spec` pins them together.
+     * claim it, because that projection filters its own collection against the inherited claim.
+     *
+     * This query and that projection must agree, and `DockZoneModel.spec` pins them together against
+     * the RENDERED tree — `LayoutAdapter.project()`, not `collectAutoHiddenItems`. Comparing against
+     * the collection helper is what let them drift: the helper recurses correctly and so agreed with
+     * this query by construction, while the projection built from it re-railed the nested item and
+     * left its sibling in the tab flow. Two derivations agreeing with each other was never the
+     * property; agreeing with what renders is.
      *
      * A `center` slot is not a claim (§2.7: center-zone items never rail — main content does not
      * auto-hide), so an item reaching the root only through center zones returns null. Null is

--- a/src/dashboard/dock/projection/LayoutAdapter.mjs
+++ b/src/dashboard/dock/projection/LayoutAdapter.mjs
@@ -1015,7 +1015,12 @@ class LayoutAdapter extends Base {
             ...hostActions,
             ...(context.enableDockPinAction ? [{
                 action    : 'pin',
-                contextual: false,
+                // No `contextual` key, deliberately: the engine set inherits the tab header's
+                // `showOnFocus` default and is focus-gated like a host action. Opting OUT is the
+                // CLOSE action's own choice — close must stay reachable on an unfocused pane —
+                // and copying that opt-out here would put a permanently-visible control on every
+                // header in the workspace.
+                //
                 // Hidden wherever the gesture could not complete, so the header never offers a
                 // collapse the model or the projection would refuse: no active item, an item whose
                 // policy forbids pinning (`Operations.setItemAutoHidden` rejects `pinnable: false`),

--- a/src/dashboard/dock/projection/LayoutAdapter.mjs
+++ b/src/dashboard/dock/projection/LayoutAdapter.mjs
@@ -415,16 +415,20 @@ class LayoutAdapter extends Base {
      *     with one runtime-only whole-stack grip and arm its existing dock SortZone.
      * @param {Boolean} [options.enableDockCloseAction=false] Projects one persistent close action
      *     into every tabs header. The workspace owns the effect and policy synchronization.
+     * @param {Boolean} [options.enableDockPinAction=false] Projects one persistent pin action into
+     *     every tabs header — the collapse-to-rail entry of docking design record §2.7. The workspace
+     *     owns the effect and policy synchronization, exactly as it does for close.
      * @param {Function} [options.onDockActiveIndexChange] Runtime active-item signal for action policy.
      * @param {Function} [options.onDockHeaderAction] Runtime Dock action intent; never persisted.
      * @param {Function} [options.resolveDockHeaderActions] Host resolver for additional tab-header
      *     actions, called per tabs node as `(nodeId)` and returning an array of action configs (or
      *     nothing). The set is **node-static**: it is resolved per tabs node and lives for that
      *     node's retained lifetime, so per-active-item behaviour belongs on the action instance
-     *     (`hidden` / `disabled`), never in a changing list. Actions project BEFORE the close action,
+     *     (`hidden` / `disabled`), never in a changing list. Actions project BEFORE the engine set,
      *     their intent arrives through `onDockHeaderAction` like any other, and focus gating is the
-     *     tab header's own default. Semantic names must be unique per node, and `close` is reserved
-     *     while `enableDockCloseAction` is on.
+     *     tab header's own default. Semantic names must be unique per node, and every engine-owned
+     *     name is reserved while its own opt-in is on — `close` under `enableDockCloseAction`, `pin`
+     *     under `enableDockPinAction`.
      * @param {Function} [options.onDockVesselConversionIn] Source-owned strict park admission.
      * @param {Function} [options.onDockVesselConversionOut] Source-owned strict re-show admission.
      * @param {Function} [options.onDockVesselConversionTerminal] Source-owned parked-vessel
@@ -483,6 +487,7 @@ class LayoutAdapter extends Base {
                 || options.dockWorkspaceBoundaryContainerId
                 || null,
             enableDockCloseAction            : options.enableDockCloseAction === true,
+            enableDockPinAction              : options.enableDockPinAction === true,
             enableDockTearOut                : options.enableDockTearOut === true,
             enableVesselConversion           : options.enableVesselConversion === true,
             items                            : model.items || {},
@@ -955,9 +960,13 @@ class LayoutAdapter extends Base {
             }
         ));
 
-        // Host actions precede the close action so `close` stays the rightmost control — the position
+        // Host actions precede the ENGINE SET, and `close` stays the rightmost control — the position
         // it already occupies for every consumer that enables it, and the one the gesture is reached
-        // at. A host resolver returning nothing leaves the projection byte-identical to before.
+        // at. The family's frozen order is
+        // `[tab overflow] → [host actions] → [lock · reload · pin · pop-out · maximize] → [close]`;
+        // each engine action ships behind its own `enableDock<X>Action` opt-in, so a header renders
+        // the subset its consumer enabled, in that order, never a different order.
+        // A host resolver returning nothing leaves the projection byte-identical to before.
         //
         // The resolver receives the node id ALONE, deliberately. Handing it the active item would
         // invite a per-item action LIST, and a list that changes between projections replaces the
@@ -966,7 +975,16 @@ class LayoutAdapter extends Base {
         // cost by keeping one instance and moving `hidden` (`Workspace#syncDockCloseAction`); a host
         // needing per-item behaviour has the same mechanism, on actions it owns.
         const hostActions = context.resolveDockHeaderActions?.(nodeId) || [],
-              seen        = new Set();
+              seen        = new Set(),
+              // Engine-owned names are reserved while their own opt-in is on. One table rather than a
+              // branch per action: every leaf of the §2.7 family reserves its name by construction, so
+              // adding an engine action cannot forget its guard. A Map (not an object literal) because
+              // the key is host-supplied — `constructor` and `__proto__` must miss, exactly as they do
+              // in `Operations.applyOperation`'s own-key dispatch.
+              reservedActionNames = new Map([
+                  ['close', context.enableDockCloseAction],
+                  ['pin',   context.enableDockPinAction]
+              ]);
 
         for (const action of hostActions) {
             const name = action?.action;
@@ -984,8 +1002,10 @@ class LayoutAdapter extends Base {
                 throw new Error(`Neo.dashboard.dock.projection.LayoutAdapter: duplicate host header action "${name}" on dock node "${nodeId}"`)
             }
 
-            if (name === 'close' && context.enableDockCloseAction) {
-                throw new Error(`Neo.dashboard.dock.projection.LayoutAdapter: host header action "close" is reserved while enableDockCloseAction is on (dock node "${nodeId}")`)
+            if (reservedActionNames.get(name)) {
+                let optIn = `enableDock${name[0].toUpperCase()}${name.slice(1)}Action`;
+
+                throw new Error(`Neo.dashboard.dock.projection.LayoutAdapter: host header action "${name}" is reserved while ${optIn} is on (dock node "${nodeId}")`)
             }
 
             seen.add(name)
@@ -993,6 +1013,19 @@ class LayoutAdapter extends Base {
 
         const headerActions = [
             ...hostActions,
+            ...(context.enableDockPinAction ? [{
+                action    : 'pin',
+                contextual: false,
+                // Hidden wherever the gesture could not complete, so the header never offers a
+                // collapse the model or the projection would refuse: no active item, an item whose
+                // policy forbids pinning (`Operations.setItemAutoHidden` rejects `pinnable: false`),
+                // or a center-owned item (§2.7 — center never rails, main content does not auto-hide).
+                // `Workspace#syncDockPinAction` recomputes exactly this on every active-item change.
+                hidden    : !activeItemId
+                    || context.items[activeItemId]?.pinnable === false
+                    || !Document.findOwningEdge({nodes: context.nodes}, activeItemId),
+                iconCls   : 'fa fa-thumbtack'
+            }] : []),
             ...(context.enableDockCloseAction ? [{
                 action    : 'close',
                 contextual: false,

--- a/src/dashboard/dock/projection/LayoutAdapter.mjs
+++ b/src/dashboard/dock/projection/LayoutAdapter.mjs
@@ -685,6 +685,22 @@ class LayoutAdapter extends Base {
      * does not auto-hide — so a center-zone `autoHidden` item is left in the tab flow as a fail-safe (never vanishes).
      * The reveal overlay + pin control that act on a rail tab are follow-up slices; this projection makes an
      * auto-hidden item visible (as a rail tab) instead of invisible.
+     *
+     * **An ancestor's claim is inherited, not restarted.** `collectAutoHiddenItems` recurses through
+     * nested edge-zones, so an item two edge-zones deep is collected by BOTH the outer band and the
+     * inner one. {@link Neo.dashboard.dock.model.Document#findOwningEdge} answers that contest with the
+     * OUTERMOST edge, and this projection is the behavior that answer describes. The `inheritedIds`
+     * filter is what enforces it: without it a nested zone re-claims an item its ancestor already owns
+     * and the item renders on two rails. `DockZoneModel.spec` reds on exactly that.
+     *
+     * Seeding `railedItemIds` from the inherited set is a second, WEAKER guarantee, and it is honest to
+     * say no fixture currently reds on it. With the filter in place a band-nested zone can never claim
+     * anything new — its whole subtree was already collected by the ancestor — so `railedItemIds` stays
+     * empty and the `: context` fallback below preserves the ancestor's set anyway. The seed is kept
+     * because it makes the ternary's two branches mean the same thing: `railedItemIds` is "everything
+     * claimed at or above this node" in both. Without it the true branch REPLACES while the false branch
+     * INHERITS, and the code is correct only via a non-local argument about which items can appear
+     * beneath which zone — the kind of argument a later refactor breaks silently.
      * @param {String} nodeId
      * @param {Object} node
      * @param {Object} context
@@ -695,13 +711,15 @@ class LayoutAdapter extends Base {
     static projectEdgeZoneNode(nodeId, node, context) {
         let {zones={}} = node,
             railsByEdge   = {},
-            railedItemIds = new Set();
+            inheritedIds  = context.railedItemIds || null,
+            railedItemIds = new Set(inheritedIds);
 
         ['top', 'right', 'bottom', 'left'].forEach(edge => {
             let zoneId = Document.getZoneNodeId(zones[edge]);
 
             if (zoneId) {
-                let itemIds = this.collectAutoHiddenItems(zoneId, context);
+                let itemIds = this.collectAutoHiddenItems(zoneId, context)
+                    .filter(itemId => !inheritedIds?.has(itemId));
 
                 if (itemIds.length) {
                     railsByEdge[edge] = itemIds;
@@ -710,7 +728,9 @@ class LayoutAdapter extends Base {
             }
         });
 
-        // Pass the railed set down so projectTabsNode drops those items from the tab flow.
+        // Pass the railed set down so projectTabsNode drops those items from the tab flow. The set is
+        // the UNION of what an ancestor claimed and what this node just claimed, so a descendant tab
+        // flow drops every railed item above it, not only the nearest zone's.
         let childContext = railedItemIds.size ? {...context, railedItemIds} : context,
             middleItems  = [],
             rows         = [],

--- a/test/playwright/e2e/dashboard/DockPinCollapseNL.spec.mjs
+++ b/test/playwright/e2e/dashboard/DockPinCollapseNL.spec.mjs
@@ -51,6 +51,21 @@ const tabsNodeId = async (app, dockNodeId) => {
     return record?.id ?? record?.properties?.id
 };
 
+/**
+ * Clicks one pane's tab header, which is how a user gives that pane focus. The engine set is
+ * FOCUS-GATED (`showOnFocus`, `visibility: hidden` while closed), so without this the actions are
+ * invisible for a reason that has nothing to do with the policy under test.
+ */
+const focusPane = async (app, page, dockItemId) => {
+    const records = await app.findInstances({ className: 'Neo.tab.header.Button', dockItemId }, ['id', 'dockItemId']),
+          record  = Array.isArray(records) ? records[0] : records,
+          id      = record?.id ?? record?.properties?.id;
+
+    expect(id, `the ${dockItemId} pane owns a live tab header button`).toBeTruthy();
+    await page.locator(`#${id}`).click();
+    await page.waitForTimeout(400)
+};
+
 test.describe('Dock pin/collapse round-trip (Neural Link)', () => {
     test.setTimeout(90000);
     test.use({ viewport: { width: 1600, height: 900 } });
@@ -82,15 +97,29 @@ test.describe('Dock pin/collapse round-trip (Neural Link)', () => {
               pinButton = page.locator(`#${pinAction.id}`);
 
         // Product truth #4: §2.7's fail-safe reaches the real product — the center stack projects the
-        // action too, but hidden, because main content never rails. A visible control there would
-        // offer a collapse the model refuses.
+        // action too, but hidden, because main content never rails.
+        //
+        // The center pane is FOCUSED first on purpose. The engine set is focus-gated, so an unfocused
+        // header hides every action of it; asserting invisibility there would pass whether or not the
+        // center rule exists. With the gate open, the only thing that can still hide this control is
+        // the policy under test.
+        await focusPane(app, page, 'strategy');
+
         const centerPin = await app.callMethod(mainTabsId, 'getActionItem', ['pin']);
 
         expect(centerPin?.id, 'the center stack projects the action instance').toBeTruthy();
-        await expect(page.locator(`#${centerPin.id}`), 'a center-owned pane must not offer the collapse').toBeHidden();
+        expect(centerPin.hidden, 'a center-owned pane must not offer the collapse').toBe(true);
+        await expect(page.locator(`#${centerPin.id}`), 'and it is not reachable in the DOM either').toBeHidden();
 
-        // Native gesture: collapse the inspector from its OWN header.
-        await expect(pinButton).toBeVisible({ timeout: 10000 });
+        // The control arm for that gate: the close action, which opts OUT of focus gating, IS visible
+        // on the very same focused header — so "hidden" above is this action's policy, not the gate.
+        const centerClose = await app.callMethod(mainTabsId, 'getActionItem', ['close']);
+
+        await expect(page.locator(`#${centerClose.id}`), 'the ungated close action proves the header is live').toBeVisible();
+
+        // Native gesture: collapse the inspector from its OWN header, once that pane holds focus.
+        await focusPane(app, page, 'inspector');
+        await expect(pinButton, 'a focused edge-owned pane offers the collapse').toBeVisible({ timeout: 10000 });
         await pinButton.click();
 
         // Product truth #2: worker truth carries the collapse, committed through the semantic path.

--- a/test/playwright/e2e/dashboard/DockPinCollapseNL.spec.mjs
+++ b/test/playwright/e2e/dashboard/DockPinCollapseNL.spec.mjs
@@ -22,8 +22,13 @@ import { test, expect } from '../../fixtures.mjs';
  * reads the holder's committed `dockModel` at every stage. NOTHING here is committed programmatically
  * — every mutation in this spec comes from a real gesture, which is the point of it.
  *
- * Run: NEO_E2E_PORT=8091 npx playwright test DockPinCollapseNL -c test/playwright/playwright.config.e2e.mjs --workers=1
- * (the port override isolates from any foreign dev-server squatting on 8080)
+ * Run: NEO_AGENTOS_RUNTIME_ROOT=/path/to/neo-agent-brain NEO_E2E_PORT=8091 npx playwright test \
+ *      DockPinCollapseNL -c test/playwright/playwright.config.e2e.mjs --workers=1
+ *
+ * The runtime root is a PREREQUISITE, not a convenience: `playwright.config.e2e.mjs` builds its
+ * `testIgnore` from `discoverExternalBrainSpecs` whenever `NEO_AGENTOS_RUNTIME_ROOT` is unset, so a
+ * run without it does not fail this spec — it never selects it, and reports "No tests found". The
+ * port override isolates from any foreign dev-server squatting on 8080.
  */
 
 const bootDockExample = async ({ page, neuralLink }) => {

--- a/test/playwright/e2e/dashboard/DockPinCollapseNL.spec.mjs
+++ b/test/playwright/e2e/dashboard/DockPinCollapseNL.spec.mjs
@@ -2,7 +2,7 @@ import { test, expect } from '../../fixtures.mjs';
 
 /**
  * Whitebox-e2e: the gesture proof for the pin/collapse ENTRY of the auto-hide round-trip
- * (neomjs/neo#17945, ADR 0029 §2.7).
+ * (docking design record §2.7).
  *
  * `DockAutoHideRevealNL` proves the way BACK — a committed auto-hidden item rails, the rail reveals,
  * and the overlay's pin control returns it. It has to auto-hide its subject programmatically first,

--- a/test/playwright/e2e/dashboard/DockPinCollapseNL.spec.mjs
+++ b/test/playwright/e2e/dashboard/DockPinCollapseNL.spec.mjs
@@ -1,0 +1,147 @@
+import { test, expect } from '../../fixtures.mjs';
+
+/**
+ * Whitebox-e2e: the gesture proof for the pin/collapse ENTRY of the auto-hide round-trip
+ * (neomjs/neo#17945, ADR 0029 §2.7).
+ *
+ * `DockAutoHideRevealNL` proves the way BACK — a committed auto-hidden item rails, the rail reveals,
+ * and the overlay's pin control returns it. It has to auto-hide its subject programmatically first,
+ * because until this leaf no affordance sent a pane TO the rail. This spec closes that loop with a
+ * real gesture: the pane's own header action collapses it, and the existing reveal path brings it
+ * home. The product truths a unit spec cannot certify are
+ *
+ *   1. the projected `pin` action is a REAL, clickable button in the tab header,
+ *   2. pressing it commits §2.7's sequence in the App Worker and the pane genuinely leaves its tab
+ *      flow for a rail button on its owning edge,
+ *   3. the round-trip closes — the revealed overlay's pin control puts the pane back — so the two
+ *      halves compose rather than each merely working in isolation,
+ *   4. the affordance is absent where the gesture could not complete: the center pane, which §2.7
+ *      never rails.
+ *
+ * Paradigm (whitebox-e2e protocol): Playwright drives the native clicks; the Neural Link fixture
+ * reads the holder's committed `dockModel` at every stage. NOTHING here is committed programmatically
+ * — every mutation in this spec comes from a real gesture, which is the point of it.
+ *
+ * Run: NEO_E2E_PORT=8091 npx playwright test DockPinCollapseNL -c test/playwright/playwright.config.e2e.mjs --workers=1
+ * (the port override isolates from any foreign dev-server squatting on 8080)
+ */
+
+const bootDockExample = async ({ page, neuralLink }) => {
+    await page.goto('/examples/dashboard/dock/');
+    page.on('pageerror', err => console.error('BROWSER JS ERROR:', err));
+
+    await page.waitForTimeout(2500); // settle worker boot + first render
+
+    const app      = await neuralLink.connectToApp('Neo.examples.dashboard.dock');
+    const holders  = await app.findInstances({ className: 'Neo.examples.dashboard.dock.MainContainer' }, ['id']);
+    const holderId = Array.isArray(holders) ? holders[0]?.id : holders?.id;
+
+    expect(holderId, 'the dock MainContainer must exist in the App Worker').toBeTruthy();
+
+    const readModel = async () => (await app.getComponent(holderId, ['dockModel'])).dockModel;
+
+    return { app, holderId, readModel }
+};
+
+/** Resolves the live projected TabContainer id for one semantic dock node. */
+const tabsNodeId = async (app, dockNodeId) => {
+    const records = await app.queryComponent({ dockNodeId }, ['id', 'ntype']),
+          record  = Array.isArray(records) ? records[0] : records;
+
+    return record?.id ?? record?.properties?.id
+};
+
+test.describe('Dock pin/collapse round-trip (Neural Link)', () => {
+    test.setTimeout(90000);
+    test.use({ viewport: { width: 1600, height: 900 } });
+
+    test('the header pin action collapses a pane to its edge rail, and the reveal overlay brings it back', async ({ page, neuralLink }) => {
+        const { app, readModel } = await bootDockExample({ page, neuralLink });
+
+        // Setup truth: the inspector sits VISIBLE in the right edge band, and nothing rails yet. The
+        // sibling spec has to commit an auto-hide here; this one gets there by pressing a button.
+        const before = await readModel();
+
+        expect(before?.nodes?.['inspector-tabs']?.items, 'the example seeds the inspector in the right edge band').toEqual(['inspector']);
+        expect(before?.items?.inspector?.autoHidden, 'the inspector must start visible').not.toBe(true);
+        await expect(page.locator('.neo-dashboard-dock-edge-rail .neo-dashboard-dock-rail-tab')).toHaveCount(0);
+
+        const inspectorTabsId = await tabsNodeId(app, 'inspector-tabs'),
+              mainTabsId      = await tabsNodeId(app, 'main-tabs');
+
+        expect(inspectorTabsId, 'the inspector band projects a live TabContainer').toBeTruthy();
+        expect(mainTabsId,      'the center stack projects a live TabContainer').toBeTruthy();
+
+        // Product truth #1: the opt-in projects a real action instance on the edge-owned pane.
+        await expect.poll(async () => (await app.callMethod(inspectorTabsId, 'getActionItem', ['pin']))?.id, {
+            message: 'the opt-in projection materialises one persistent pin action',
+            timeout: 10000
+        }).toBeTruthy();
+
+        const pinAction = await app.callMethod(inspectorTabsId, 'getActionItem', ['pin']),
+              pinButton = page.locator(`#${pinAction.id}`);
+
+        // Product truth #4: §2.7's fail-safe reaches the real product — the center stack projects the
+        // action too, but hidden, because main content never rails. A visible control there would
+        // offer a collapse the model refuses.
+        const centerPin = await app.callMethod(mainTabsId, 'getActionItem', ['pin']);
+
+        expect(centerPin?.id, 'the center stack projects the action instance').toBeTruthy();
+        await expect(page.locator(`#${centerPin.id}`), 'a center-owned pane must not offer the collapse').toBeHidden();
+
+        // Native gesture: collapse the inspector from its OWN header.
+        await expect(pinButton).toBeVisible({ timeout: 10000 });
+        await pinButton.click();
+
+        // Product truth #2: worker truth carries the collapse, committed through the semantic path.
+        await expect.poll(async () => (await readModel())?.items?.inspector?.autoHidden, {
+            message: 'the real header action commits the collapse through the model',
+            timeout: 10000
+        }).toBe(true);
+
+        const collapsed = await readModel();
+
+        // The item is unpinned-and-hidden, never both — the exclusivity §2.7's sequence exists to keep.
+        expect(collapsed.items.inspector.pinned, 'the collapse leaves the item unpinned').not.toBe(true);
+
+        // ...and it genuinely LEFT the tab flow for a rail button on the edge that owns it.
+        const railTab = page.locator('.neo-dashboard-dock-rail-tab', { hasText: 'Inspector' }).first();
+
+        await expect(railTab, 'the collapsed pane must become a labeled edge-rail tab').toBeVisible({ timeout: 10000 });
+        await expect(
+            page.locator('.neo-dashboard-dock-edge-rail-right .neo-dashboard-dock-rail-tab'),
+            'the rail is the one on its OWNING edge, not merely some rail'
+        ).toHaveCount(1);
+
+        // Product truth #3: the loop closes. The existing reveal path takes it from here.
+        await railTab.click();
+        await page.waitForTimeout(600);
+
+        const overlay = page.locator('.neo-dashboard-dock-reveal-overlay').first();
+
+        await expect(overlay, 'the reveal overlay must open on rail-tab click').toBeVisible({ timeout: 10000 });
+        expect(JSON.stringify(await readModel()), 'the reveal stays runtime-only').toBe(JSON.stringify(collapsed));
+
+        await overlay.locator('.neo-dashboard-dock-reveal-pin').first().click();
+
+        await expect.poll(async () => (await readModel())?.items?.inspector?.pinned, {
+            message: 'the overlay pin control returns the pane through the reducer',
+            timeout: 10000
+        }).toBe(true);
+
+        const restored = await readModel();
+
+        expect(restored.items.inspector.autoHidden, 'returning clears the collapse').toBe(false);
+        expect(restored.nodes['inspector-tabs'].items, 'the pane is back in its tab flow').toEqual(['inspector']);
+        await expect(
+            page.locator('.neo-dashboard-dock-edge-rail .neo-dashboard-dock-rail-tab'),
+            'and the rail it came from is gone'
+        ).toHaveCount(0);
+
+        // The round-trip is a round trip: everything except the pin flag the reveal path sets is back
+        // where it started, so the gesture pair leaves no residue in committed state.
+        expect({ ...restored.items.inspector, pinned: undefined, autoHidden: undefined })
+            .toEqual({ ...before.items.inspector, pinned: undefined, autoHidden: undefined });
+        expect(restored.nodes).toEqual(before.nodes)
+    })
+});

--- a/test/playwright/unit/dashboard/DockLayoutAdapter.spec.mjs
+++ b/test/playwright/unit/dashboard/DockLayoutAdapter.spec.mjs
@@ -371,8 +371,16 @@ test.describe('Neo.dashboard.dock.projection.LayoutAdapter', () => {
         expect(centerTab.headerActions.map(action => action.action)).toEqual(['pin', 'close']);
 
         // Right-band-owned, pinnable, active — the one case where the gesture can complete.
-        expect(terminalTabs.headerActions[1]).toMatchObject({action: 'pin', contextual: false, hidden: false});
+        expect(terminalTabs.headerActions[1]).toMatchObject({action: 'pin', hidden: false});
         expect(terminalTabs.headerActions[1].iconCls).toBeTruthy();
+
+        // Focus-gated like a host action, NOT like close. `close` opts out with `contextual: false`
+        // because it must stay reachable on an unfocused pane; the engine set inherits the tab
+        // header's `showOnFocus` default, and carrying close's opt-out would leave a permanently
+        // visible control on every header.
+        expect(terminalTabs.headerActions[1].contextual, 'pin inherits the header focus gate').toBeUndefined();
+        expect(terminalTabs.headerActions[0].contextual, 'the host action is gated too').toBeUndefined();
+        expect(terminalTabs.headerActions[2].contextual, 'close is the one deliberate exemption').toBe(false);
 
         // Center-owned: §2.7 never rails main content, so the affordance must not offer it.
         expect(centerTab.headerActions[0].hidden, 'a center-owned active item cannot collapse').toBe(true);

--- a/test/playwright/unit/dashboard/DockLayoutAdapter.spec.mjs
+++ b/test/playwright/unit/dashboard/DockLayoutAdapter.spec.mjs
@@ -164,6 +164,25 @@ const createTabsBandModel = () => ({
 
 const getProjectedSplitters = splitConfig => splitConfig.items.filter(item => item.dockNodeType === 'splitter');
 
+/**
+ * Every projected tabs node anywhere in a projection, keyed by its `dockNodeId` — so a test can
+ * address one tabs header without hand-walking the row/band/split nesting that surrounds it.
+ * @param {Object} config
+ * @returns {Map<String,Object>}
+ */
+const collectProjectedTabsById = config => {
+    const found = new Map();
+
+    (function walk(node) {
+        if (!node || typeof node !== 'object') return;
+
+        node.dockNodeType === 'tabs' && found.set(node.dockNodeId, node);
+        (Array.isArray(node.items) ? node.items : []).forEach(walk)
+    })(config);
+
+    return found
+};
+
 test.describe('Neo.dashboard.dock.projection.LayoutAdapter', () => {
     test('projects split nodes to existing hbox and vbox layout primitives', () => {
         let model  = createModel(),
@@ -312,6 +331,94 @@ test.describe('Neo.dashboard.dock.projection.LayoutAdapter', () => {
         const hostClose = getProjectedChildren(project(() => [{action: 'close', iconCls: 'fa fa-x'}])())[0];
 
         expect(hostClose.headerActions.map(action => action.action)).toEqual(['close'])
+    });
+
+    test('the pin action is absent and the projection byte-identical while its opt-in is off', () => {
+        const
+            model       = createEdgeZoneModel(),
+            resolvePane = componentRef => ({ntype: 'dashboard-panel', reference: componentRef}),
+            options     = {enableDockCloseAction: true, resolveComponentRef: resolvePane},
+
+            without = DockLayoutAdapter.project(model, options),
+            offFlag = DockLayoutAdapter.project(model, {...options, enableDockPinAction: false});
+
+        // Explicit-false is the same projection as absent, and both are the same projection the
+        // consumers that never heard of this leaf already receive.
+        expect(JSON.stringify(offFlag)).toBe(JSON.stringify(without));
+        expect(JSON.stringify(without)).not.toContain('"pin"')
+    });
+
+    test('the opt-in pin action projects at its frozen slot and is hidden wherever the collapse could not complete', () => {
+        const model = createEdgeZoneModel();
+
+        model.items.inspector.pinnable = false;
+
+        const
+            resolvePane = componentRef => ({ntype: 'dashboard-panel', reference: componentRef}),
+            result      = DockLayoutAdapter.project(model, {
+                enableDockCloseAction   : true,
+                enableDockPinAction     : true,
+                resolveComponentRef     : resolvePane,
+                resolveDockHeaderActions: nodeId => nodeId === 'terminal-tabs' ? [{action: 'diagnose'}] : []
+            }),
+            tabs          = collectProjectedTabsById(result),
+            centerTab     = tabs.get('main-tabs'),
+            terminalTabs  = tabs.get('terminal-tabs'),
+            inspectorTabs = tabs.get('inspector-tabs');
+
+        // The frozen order, with a host action present: host actions, then the engine set, then close.
+        expect(terminalTabs.headerActions.map(action => action.action)).toEqual(['diagnose', 'pin', 'close']);
+        expect(centerTab.headerActions.map(action => action.action)).toEqual(['pin', 'close']);
+
+        // Right-band-owned, pinnable, active — the one case where the gesture can complete.
+        expect(terminalTabs.headerActions[1]).toMatchObject({action: 'pin', contextual: false, hidden: false});
+        expect(terminalTabs.headerActions[1].iconCls).toBeTruthy();
+
+        // Center-owned: §2.7 never rails main content, so the affordance must not offer it.
+        expect(centerTab.headerActions[0].hidden, 'a center-owned active item cannot collapse').toBe(true);
+
+        // Policy-refused: `setItemAutoHidden` rejects `pinnable: false`, so offering it would be a lie.
+        expect(inspectorTabs.headerActions.find(action => action.action === 'pin').hidden).toBe(true)
+    });
+
+    test('a host may own the name `pin` — until the engine action that reserves it is switched on', () => {
+        const model       = createEdgeZoneModel(),
+              resolvePane = componentRef => ({ntype: 'dashboard-panel', reference: componentRef}),
+              project     = extra => () => DockLayoutAdapter.project(model, {
+                  resolveComponentRef     : resolvePane,
+                  resolveDockHeaderActions: () => [{action: 'pin', iconCls: 'fa fa-thumbtack'}],
+                  ...extra
+              });
+
+        // Scoped exactly like `close`: with the engine's pin off there is nothing to shadow, and the
+        // host keeps a name it may well already ship.
+        expect(collectProjectedTabsById(project({})()).get('main-tabs').headerActions.map(action => action.action))
+            .toEqual(['pin']);
+
+        // With it on, the host action would win `getActionItem('pin')` and capture BOTH the engine's
+        // `hidden` policy sync and its intent — the collapse would go dark with nothing reporting it.
+        expect(project({enableDockPinAction: true}))
+            .toThrow(/"pin" is reserved while enableDockPinAction is on/);
+
+        // The close message is unchanged by sharing one reserved-name table with pin.
+        expect(project({enableDockCloseAction: true, resolveDockHeaderActions: () => [{action: 'close'}]}))
+            .toThrow(/"close" is reserved while enableDockCloseAction is on/)
+    });
+
+    test('a prototype-shaped host action name is not silently treated as reserved', () => {
+        const model       = createEdgeZoneModel(),
+              resolvePane = componentRef => ({ntype: 'dashboard-panel', reference: componentRef});
+
+        // The reserved-name lookup is keyed by host-supplied strings. Backed by an object literal,
+        // `constructor` would resolve to `Object.prototype.constructor` — truthy — and throw a
+        // reserved-name error for a name the engine does not own.
+        const projected = collectProjectedTabsById(DockLayoutAdapter.project(model, {
+            enableDockPinAction     : true,
+            resolveComponentRef     : resolvePane,
+            resolveDockHeaderActions: () => [{action: 'constructor', iconCls: 'fa fa-x'}]
+        })).get('main-tabs');
+
+        expect(projected.headerActions.map(action => action.action)).toEqual(['constructor', 'pin'])
     });
 
     test('a projection with no host resolver and no close action carries no action slot at all', () => {

--- a/test/playwright/unit/dashboard/DockWorkspace.spec.mjs
+++ b/test/playwright/unit/dashboard/DockWorkspace.spec.mjs
@@ -16,6 +16,7 @@ import DockLayoutAdapter        from '../../../../src/dashboard/dock/projection/
 import DockProjectionReconciler from '../../../../src/dashboard/dock/projection/Reconciler.mjs';
 import DockService              from '../../../../src/ai/client/DockService.mjs';
 import DockWorkspace            from '../../../../src/dashboard/dock/Workspace.mjs';
+import Document                 from '../../../../src/dashboard/dock/model/Document.mjs';
 import DomApiVnodeCreator       from '../../../../src/vdom/util/DomApiVnodeCreator.mjs';
 import VdomHelper               from '../../../../src/vdom/Helper.mjs';
 
@@ -91,6 +92,33 @@ class HostActionWorkspace extends DockWorkspace {
                 hostResolverCalls.push(nodeId);
                 return [{action: 'pin', iconCls: 'fa fa-thumbtack'}]
             }
+        }
+    }
+}
+
+/**
+ * A host that owns BOTH engine names while both opt-ins are off. Separate from
+ * {@link HostActionWorkspace} because the name-reservation contract is per-action — `close` and `pin`
+ * each belong to the host exactly while their own flag is off — and one fixture claiming both is the
+ * only way to show the two guards are symmetric rather than one being a special case.
+ */
+class HostBothActionsWorkspace extends DockWorkspace {
+    static config = {
+        className: 'Test.Unit.Dashboard.DockWorkspace.HostBothActionsWorkspace',
+        layout   : {ntype: 'vbox', align: 'stretch'}
+    }
+
+    construct(config) {
+        super.construct(config);
+        this.add(this.projectDockModel())
+    }
+
+    getDockProjectionOptions() {
+        return {
+            resolveDockHeaderActions: () => [
+                {action: 'close', iconCls: 'fa fa-xmark'},
+                {action: 'pin',   iconCls: 'fa fa-thumbtack'}
+            ]
         }
     }
 }
@@ -259,6 +287,7 @@ Neo.setupClass(HostedWorkspace);
 Neo.setupClass(BrokenHostWorkspace);
 Neo.setupClass(TearOutWorkspace);
 Neo.setupClass(HostActionWorkspace);
+Neo.setupClass(HostBothActionsWorkspace);
 
 const
     tabsOf  = shell => DockProjectionReconciler.collectProjectedTabs(shell),
@@ -1040,6 +1069,101 @@ test.describe('Neo.dashboard.dock.Workspace', () => {
         })).toBe(null);
         expect(emitted).toEqual(['pin']);
         expect(workspace.getDockZoneDocument().items.inspector.autoHidden).toBeUndefined()
+    });
+
+    /**
+     * "Default off" has to mean behaviorally inert, not merely unprojected. A host legitimately owns
+     * the names `close` and `pin` while their opt-ins are off, and the POLICY SYNC — not the
+     * projection, not the dispatch — is the third seam that has to honor that. It runs on every
+     * active-item change and every reconciliation sweep, so an unguarded sync moves a host's `hidden`
+     * with no gesture involved at all: the action simply drifts under the host's feet.
+     *
+     * `center-tabs` is where the engine's own predicate disagrees loudest. No edge owns a center item
+     * (§2.7 — main content never rails), so the engine would compute `hidden: true` for `pin` and
+     * commit it to an instance it does not own.
+     */
+    test('a host keeps its own close and pin actions while both engine opt-ins are off', () => {
+        const document = createEdgeDocument();
+
+        // Both halves need the engine's predicate to DISAGREE with the host's value, or the arm
+        // passes without exercising anything. `pin` disagrees on a center item for free — no edge
+        // owns it. `close` does not: it hides only on `closable: false`, so the fixture states it.
+        document.items.center.closable = false;
+
+        workspace = Neo.create(HostBothActionsWorkspace, {dockModel: document});
+
+        const tabs        = tabsOf(workspace.items[0]),
+              center      = tabs.get('center-tabs'),
+              pinAction   = center.getActionItem('pin'),
+              closeAction = center.getActionItem('close');
+
+        expect(pinAction,   'the host projected `pin` through the documented hook').toBeTruthy();
+        expect(closeAction, 'and `close` beside it').toBeTruthy();
+        expect([closeAction.hidden, pinAction.hidden], 'the host owns their initial visibility')
+            .toEqual([false, false]);
+
+        workspace.syncDockHeaderActions();
+
+        expect([closeAction.hidden, pinAction.hidden], 'the reconciliation sweep leaves host names alone')
+            .toEqual([false, false]);
+
+        workspace.onDockActiveIndexChange({dockNodeId: 'center-tabs', tabContainer: center});
+
+        expect([closeAction.hidden, pinAction.hidden], 'and so does an active-item change')
+            .toEqual([false, false]);
+        expect(center.getActionItem('pin'), 'the same host instances, never replaced').toBe(pinAction)
+    });
+
+    /**
+     * The chrome that emitted an intent is a projection of the document as it stood at the LAST sweep,
+     * and the sweep is deferred behind reconciliation. Between a commit that moves an item to the root
+     * center and the refresh that re-hides its action, the retained action is still visible and still
+     * dispatchable — and collapsing a center item is exactly what §2.7 forbids.
+     *
+     * Committed here through the real write seam rather than by assigning `dockModel`, because the
+     * defect only exists in the window that seam opens: `onDockZoneDocumentChange` advances the model
+     * synchronously and chains the sweep onto `refreshPromise`. Firing before that promise settles is
+     * not a contrived race; it is one click landing inside it.
+     */
+    test('a retained pin action refuses after the model moved its item to the center, before the sweep runs', async () => {
+        workspace = Neo.create(PlainWorkspace, {
+            dockModel          : createEdgeDocument(),
+            enableDockPinAction: true
+        });
+
+        const tabs      = tabsOf(workspace.items[0]),
+              inspector = tabs.get('inspector-tabs'),
+              pinAction = inspector.getActionItem('pin');
+
+        expect(pinAction.hidden, 'an edge-owned pane can collapse, so the action is live').toBe(false);
+
+        const descriptor = {operation: 'moveItem', itemId: 'inspector', targetNodeId: 'center-tabs'},
+              moved      = workspace.applyDockZoneOperation(descriptor);
+
+        expect(moved.errors, 'the move itself is a clean commit').toEqual([]);
+        workspace.onDockZoneDocumentChange(moved.document, descriptor, inspector);
+
+        // The stale window: the model says center, the chrome still says right, and the action that
+        // reads `false` above has not been re-synced yet.
+        expect(Document.findOwningEdge(workspace.dockModel, 'inspector'), 'the model moved it to center')
+            .toBe(null);
+        expect(pinAction.hidden, 'the retained action is still visible — that is the window').toBe(false);
+
+        const refused = workspace.onDockHeaderAction({
+            action: 'pin', dockNodeId: 'inspector-tabs', tabContainer: inspector
+        });
+
+        expect(refused.errors, 'dispatch decides from the CURRENT document, not from the chrome')
+            .toEqual(['Dock pin action requires an item owned by an edge zone']);
+        expect(workspace.getDockZoneDocument().items.inspector.autoHidden, 'and commits nothing')
+            .toBeUndefined();
+
+        // Once the deferred sweep does run, the action agrees with the document on its own.
+        await workspace.refreshPromise;
+        workspace.syncDockHeaderActions();
+
+        expect(tabs.get('center-tabs')?.getActionItem('pin')?.hidden ?? true,
+            'a center-owned pane offers no collapse').toBe(true)
     });
 
     test('tab activation commits with close actions disabled and survives unrelated re-projection', async () => {

--- a/test/playwright/unit/dashboard/DockWorkspace.spec.mjs
+++ b/test/playwright/unit/dashboard/DockWorkspace.spec.mjs
@@ -862,6 +862,173 @@ test.describe('Neo.dashboard.dock.Workspace', () => {
         expect(focusTargets).toEqual(['terminal'])
     });
 
+    test('the opt-in pin action commits §2.7\'s two-step collapse through the write seam and rails the pane', async () => {
+        const document = createEdgeDocument();
+
+        // A PINNED edge pane is the two-step case: the model refuses `autoHidden` on a pinned item,
+        // so the unpin is the collapse's precondition rather than an extra courtesy.
+        document.items.inspector.pinned = true;
+
+        workspace = Neo.create(PlainWorkspace, {
+            dockModel          : document,
+            enableDockPinAction: true
+        });
+
+        const
+            tabs      = tabsOf(workspace.items[0]),
+            inspector = tabs.get('inspector-tabs'),
+            pinAction = inspector.getActionItem('pin'),
+            commits   = [],
+            apply     = workspace.applyDockZoneOperation.bind(workspace);
+
+        workspace.applyDockZoneOperation = descriptor => {
+            commits.push(descriptor);
+            return apply(descriptor)
+        };
+
+        expect(pinAction, 'the engine set projects into the live header').toBeTruthy();
+        expect(pinAction.hidden, 'an edge-owned pinnable pane can collapse').toBe(false);
+
+        // Merely RENDERING the action changes no committed state — the projection is view-only.
+        expect(workspace.getDockZoneDocument().items.inspector).toEqual({
+            componentRef: 'Inspector', title: 'Inspector', kind: 'panel', pinned: true
+        });
+
+        pinAction.handler({component: pinAction});
+        await workspace.refreshPromise;
+
+        // Both steps are INDEPENDENT commits and both went through the class's own write seam — the
+        // one `DockService` and `DockSplitter` reach a holder through. A folded single commit would
+        // have shown only one of them here.
+        expect(commits.map(descriptor => [descriptor.operation, descriptor.itemId])).toEqual([
+            ['setItemPinned',     'inspector'],
+            ['setItemAutoHidden', 'inspector']
+        ]);
+
+        const committed = workspace.getDockZoneDocument();
+
+        expect(committed.items.inspector.pinned).toBe(false);
+        expect(committed.items.inspector.autoHidden).toBe(true);
+
+        // The collapse is not merely a flag: the pane leaves its tab flow and the owning edge grows a
+        // rail. `right` is the band `findOwningEdge` named, so the derivation and the result agree.
+        const projected = workspace.projectDockModel(),
+              rails     = collect(projected, config => config.ntype === 'dashboard-dock-rail');
+
+        expect(rails.length).toBe(1);
+        expect(rails[0].edge).toBe('right');
+        expect(rails[0].railItems.map(item => item.dockItemId)).toEqual(['inspector']);
+        expect(tabsOf(projected).get('inspector-tabs'), 'an all-railed band keeps no tab flow').toBeUndefined()
+    });
+
+    test('an UNPINNED pane collapses in a single commit — the second step is a precondition, not a ritual', async () => {
+        workspace = Neo.create(PlainWorkspace, {
+            dockModel          : createEdgeDocument(),
+            enableDockPinAction: true
+        });
+
+        const
+            inspector = tabsOf(workspace.items[0]).get('inspector-tabs'),
+            commits   = [],
+            apply     = workspace.applyDockZoneOperation.bind(workspace);
+
+        workspace.applyDockZoneOperation = descriptor => {
+            commits.push(descriptor);
+            return apply(descriptor)
+        };
+
+        inspector.getActionItem('pin').handler({component: inspector.getActionItem('pin')});
+        await workspace.refreshPromise;
+
+        expect(commits.map(descriptor => descriptor.operation)).toEqual(['setItemAutoHidden']);
+        expect(workspace.getDockZoneDocument().items.inspector.autoHidden).toBe(true)
+    });
+
+    test('the pin action refuses fail-closed where the collapse cannot complete, and moves by hidden on ONE instance', async () => {
+        const document = createEdgeDocument();
+
+        // Two items in the same edge band, opposite policies — so the action's availability changes
+        // with the ACTIVE item inside one tabs node, which is what the sync has to get right.
+        document.items.notes = {componentRef: 'Notes', title: 'Notes', kind: 'panel', pinnable: false};
+        document.nodes['inspector-tabs'].items.push('notes');
+
+        workspace = Neo.create(PlainWorkspace, {
+            dockModel          : document,
+            enableDockPinAction: true
+        });
+
+        const
+            tabs        = tabsOf(workspace.items[0]),
+            inspector   = tabs.get('inspector-tabs'),
+            center      = tabs.get('center-tabs'),
+            pinAction   = inspector.getActionItem('pin'),
+            visibility  = [];
+
+        inspector.getTabBar().on('actionVisibilityChange', data => visibility.push([data.action, data.component.hidden]));
+
+        // Center-owned: §2.7's fail-safe — main content never rails, so the affordance is not offered.
+        expect(center.getActionItem('pin').hidden, 'a center-owned pane cannot collapse').toBe(true);
+
+        expect(pinAction.hidden).toBe(false);
+
+        await inspector.set({activeIndex: 1});
+
+        expect(pinAction.hidden, '`pinnable: false` is refused by the model, so it is not offered').toBe(true);
+        expect(inspector.getActionItem('pin'), 'the SAME instance moved, the group was not replaced').toBe(pinAction);
+        expect(visibility, 'Overflow gets its signal from the instance, not a rebuilt group')
+            .toEqual([['pin', true]]);
+
+        // And the refusal holds if the intent is dispatched anyway — the model is the authority, not
+        // the hidden flag, which a host could always bypass.
+        const refused = workspace.onDockHeaderAction({
+            action: 'pin', dockNodeId: 'inspector-tabs', tabContainer: inspector
+        });
+
+        expect(refused.errors).toEqual(['item "notes" is not pinnable']);
+        expect(workspace.getDockZoneDocument().items.notes.autoHidden).toBeUndefined();
+
+        await inspector.set({activeIndex: 0});
+        expect(pinAction.hidden).toBe(false)
+    });
+
+    test('the pin action reports its own missing preconditions, and stays inert while its opt-in is off', () => {
+        workspace = Neo.create(PlainWorkspace, {
+            dockModel          : createEdgeDocument(),
+            enableDockPinAction: true
+        });
+
+        const inspector = tabsOf(workspace.items[0]).get('inspector-tabs');
+
+        workspace.dockModel = null;
+
+        expect(workspace.onDockHeaderAction({
+            action: 'pin', dockNodeId: 'inspector-tabs', tabContainer: inspector
+        }).errors).toEqual(['Dock pin action requires a committed document']);
+
+        workspace.dockModel = createEdgeDocument();
+
+        expect(workspace.onDockHeaderAction({action: 'pin', dockNodeId: 'inspector-tabs'}).errors)
+            .toEqual(['Dock pin action requires an active item']);
+
+        // With the opt-in off the name belongs to the host again: the intent is re-emitted, not acted
+        // on, and nothing is committed.
+        workspace.destroy();
+
+        const emitted = [];
+
+        workspace = Neo.create(PlainWorkspace, {dockModel: createEdgeDocument()});
+        workspace.on('dockHeaderAction', data => emitted.push(data.action));
+
+        const offTabs = tabsOf(workspace.items[0]).get('inspector-tabs');
+
+        expect(offTabs.getActionItem('pin'), 'nothing is projected while the opt-in is off').toBeFalsy();
+        expect(workspace.onDockHeaderAction({
+            action: 'pin', dockNodeId: 'inspector-tabs', tabContainer: offTabs
+        })).toBe(null);
+        expect(emitted).toEqual(['pin']);
+        expect(workspace.getDockZoneDocument().items.inspector.autoHidden).toBeUndefined()
+    });
+
     test('tab activation commits with close actions disabled and survives unrelated re-projection', async () => {
         const document = createDocument();
 

--- a/test/playwright/unit/dashboard/DockWorkspace.spec.mjs
+++ b/test/playwright/unit/dashboard/DockWorkspace.spec.mjs
@@ -952,6 +952,12 @@ test.describe('Neo.dashboard.dock.Workspace', () => {
         document.items.notes = {componentRef: 'Notes', title: 'Notes', kind: 'panel', pinnable: false};
         document.nodes['inspector-tabs'].items.push('notes');
 
+        // A SECOND center item, so activating it drives the workspace's own policy sync over a
+        // center-owned pane. With only one center item the sync never runs there and the assertion
+        // below would only re-read what the adapter computed at projection time.
+        document.items.readme = {componentRef: 'Readme', title: 'Readme', kind: 'panel'};
+        document.nodes['center-tabs'].items.push('readme');
+
         workspace = Neo.create(PlainWorkspace, {
             dockModel          : document,
             enableDockPinAction: true
@@ -967,7 +973,14 @@ test.describe('Neo.dashboard.dock.Workspace', () => {
         inspector.getTabBar().on('actionVisibilityChange', data => visibility.push([data.action, data.component.hidden]));
 
         // Center-owned: §2.7's fail-safe — main content never rails, so the affordance is not offered.
+        // Asserted BOTH where the adapter computed it and, below, after the workspace recomputes it:
+        // the two derive it independently, and only the switch exercises the workspace's own sync.
         expect(center.getActionItem('pin').hidden, 'a center-owned pane cannot collapse').toBe(true);
+
+        await center.set({activeIndex: 1});
+
+        expect(center.getActionItem('pin').hidden, 'still no collapse after the workspace re-syncs a center pane')
+            .toBe(true);
 
         expect(pinAction.hidden).toBe(false);
 

--- a/test/playwright/unit/dashboard/DockWorkspace.spec.mjs
+++ b/test/playwright/unit/dashboard/DockWorkspace.spec.mjs
@@ -17,6 +17,7 @@ import DockProjectionReconciler from '../../../../src/dashboard/dock/projection/
 import DockService              from '../../../../src/ai/client/DockService.mjs';
 import DockWorkspace            from '../../../../src/dashboard/dock/Workspace.mjs';
 import Document                 from '../../../../src/dashboard/dock/model/Document.mjs';
+import Persistence              from '../../../../src/dashboard/dock/model/Persistence.mjs';
 import DomApiVnodeCreator       from '../../../../src/vdom/util/DomApiVnodeCreator.mjs';
 import VdomHelper               from '../../../../src/vdom/Helper.mjs';
 
@@ -997,9 +998,16 @@ test.describe('Neo.dashboard.dock.Workspace', () => {
             inspector   = tabs.get('inspector-tabs'),
             center      = tabs.get('center-tabs'),
             pinAction   = inspector.getActionItem('pin'),
-            visibility  = [];
+            visibility  = [],
+            // The EMITTER of each signal, not just its payload. "The group was not replaced" is a
+            // claim about which instance spoke, and a rebuilt group would announce itself here by
+            // emitting from a different object while the payload looked identical.
+            signalSources = [];
 
-        inspector.getTabBar().on('actionVisibilityChange', data => visibility.push([data.action, data.component.hidden]));
+        inspector.getTabBar().on('actionVisibilityChange', data => {
+            visibility.push([data.action, data.component.hidden]);
+            signalSources.push(data.component)
+        });
 
         // Center-owned: §2.7's fail-safe — main content never rails, so the affordance is not offered.
         // Asserted BOTH where the adapter computed it and, below, after the workspace recomputes it:
@@ -1030,7 +1038,105 @@ test.describe('Neo.dashboard.dock.Workspace', () => {
         expect(workspace.getDockZoneDocument().items.notes.autoHidden).toBeUndefined();
 
         await inspector.set({activeIndex: 0});
-        expect(pinAction.hidden).toBe(false)
+        expect(pinAction.hidden).toBe(false);
+
+        // AC-3's actual boundary. Everything above resolved when the container's own `set()` did,
+        // and the reconciler had not run yet — so a group replacement performed BY reconciliation
+        // was exactly what the identity assertion could not observe. `refreshPromise` is the seam
+        // the workspace chains that work onto, so awaiting it and re-resolving both the container
+        // and the action FROM the refreshed tree is what makes "the same instance" a claim about
+        // the lifetime the retained action actually has.
+        await workspace.refreshPromise;
+
+        const reconciledTabs = tabsOf(workspace.items[0]).get('inspector-tabs');
+
+        expect(reconciledTabs, 'the tabs node is retained across reconciliation').toBe(inspector);
+        expect(reconciledTabs.getActionItem('pin'), 'and so is the action instance on it')
+            .toBe(pinAction);
+        expect(pinAction.hidden, 'converging on the active item\'s real policy').toBe(false);
+
+        // The load-bearing half, and the reason this counts emitters rather than signals. The refresh
+        // QUEUE replays each pending refresh in order, and refresh #1 reconciles chrome to the
+        // document as it stood when it was queued — so its sweep re-hides the action before refresh
+        // #2 settles it, and the post-refresh signal COUNT is not 0. Those extra signals are a
+        // property of the queue, not of this action: `close` lags identically, and nothing here
+        // could fix it without changing refresh sequencing for every consumer. What AC-3 actually
+        // claims is that no group was ever rebuilt behind them — every signal, before and after
+        // reconciliation, came from the one retained instance.
+        expect(new Set(signalSources).size, 'one emitter across every signal, not a rebuilt group')
+            .toBe(1);
+        expect(signalSources[0], 'and it is the instance the assertions above held').toBe(pinAction)
+    });
+
+    /**
+     * AC-5, exercised at the seam it names. The claim is about what `Persistence.capturePerspective`
+     * WRITES, so inferring it from the source document proves nothing: capture normalizes, validates
+     * and fingerprints, and any of those three could have made rendering an action observable in a
+     * saved layout. Rendering is a projection concern and must leave layout truth byte-identical;
+     * the gesture is a model concern and must move exactly the two committed fields §2.7 names.
+     */
+    test('capturing a perspective is unmoved by rendering the action, and moves only pinned/autoHidden on the gesture', async () => {
+        const document = createEdgeDocument();
+
+        document.items.inspector.pinned = true;
+
+        const capture = () => {
+            const {layout, errors} = Persistence.capturePerspective(workspace.getDockZoneDocument(), {
+                layoutId: 'ac5', title: 'AC-5'
+            });
+
+            expect(errors, 'the capture seam itself stays clean').toEqual([]);
+            return layout
+        };
+
+        // Captured from a workspace with the action OFF, then from one with it ON: the difference
+        // between the two runs is precisely "the action was rendered".
+        workspace = Neo.create(PlainWorkspace, {dockModel: document});
+
+        const before = capture();
+
+        workspace.destroy();
+        workspace = Neo.create(PlainWorkspace, {
+            dockModel          : createEdgeDocument(),
+            enableDockPinAction: true
+        });
+
+        workspace.dockModel.items.inspector.pinned = true;
+
+        const tabs      = tabsOf(workspace.items[0]),
+              inspector = tabs.get('inspector-tabs'),
+              pinAction = inspector.getActionItem('pin');
+
+        expect(pinAction, 'the action really was projected in the second run').toBeTruthy();
+
+        const afterRender = capture();
+
+        expect(JSON.stringify(afterRender), 'rendering an action writes nothing into layout truth')
+            .toBe(JSON.stringify(before));
+
+        // Now the gesture, through the real handler.
+        pinAction.handler({component: pinAction});
+        await workspace.refreshPromise;
+
+        const afterGesture = capture();
+
+        expect(JSON.stringify(afterGesture), 'the gesture is not a no-op — otherwise the diff below is vacuous')
+            .not.toBe(JSON.stringify(before));
+
+        // The diff is exactly §2.7's two committed fields, on the one item, and nothing else.
+        const beforeItem = before.dockZone.items.inspector,
+              afterItem  = afterGesture.dockZone.items.inspector;
+
+        expect({...afterItem, pinned: beforeItem.pinned, autoHidden: beforeItem.autoHidden},
+            'no field outside pinned/autoHidden moved on the captured item')
+            .toEqual({...beforeItem});
+        expect([beforeItem.pinned, beforeItem.autoHidden], 'the captured item started pinned and visible')
+            .toEqual([true, undefined]);
+        expect([afterItem.pinned, afterItem.autoHidden], 'and ends unpinned and auto-hidden')
+            .toEqual([false, true]);
+
+        expect({...afterGesture.dockZone, items: null}, 'and the node tree itself is untouched')
+            .toEqual({...before.dockZone, items: null})
     });
 
     test('the pin action reports its own missing preconditions, and stays inert while its opt-in is off', () => {

--- a/test/playwright/unit/dashboard/DockZoneModel.spec.mjs
+++ b/test/playwright/unit/dashboard/DockZoneModel.spec.mjs
@@ -1780,35 +1780,66 @@ test.describe('Neo.dashboard.dock.model.Document', () => {
             expect(Document.findOwningEdge(d, 'main')).toBe(null)
         });
 
-        test('agrees with the projection it must not contradict: every railed item names the band it railed to', () => {
+        /**
+         * The agreement this query claims is with the RENDERED projection, so it is asserted against
+         * `LayoutAdapter.project()` rather than against `collectAutoHiddenItems`.
+         *
+         * That distinction is the whole arm. The collection helper recurses correctly through nested
+         * edge-zones, so it agrees with this query by construction — and a projection that disagreed
+         * with BOTH sat invisible behind it: `projectEdgeZoneNode` restarted its claim set per node,
+         * so a nested zone re-railed an item its ancestor already owned and simultaneously stopped
+         * suppressing the ancestor's other claims in its own tab flow. Two derivations agreeing with
+         * each other is not the property; agreeing with what renders is.
+         */
+        test('agrees with the RENDERED projection: one rail per railed item, none left in tab flow', () => {
             const d = nested();
 
             d.items.buried.autoHidden = true;
             d.items.plain.autoHidden  = true;
             d.items.main.autoHidden   = true;
 
-            // The adapter's own collection, per band of the ROOT edge-zone — the exact derivation the
-            // rails are built from. Whatever it claims for a band, this query must answer for the item;
-            // whatever it never claims, this query must answer null. Two derivations of one §2.7 rule
-            // that could silently drift apart are pinned together here instead.
-            let railed = 0;
+            const projected = LayoutAdapter.project(d, {
+                      resolveComponentRef: componentRef => ({ntype: 'component', reference: componentRef})
+                  }),
+                  rails   = [],
+                  tabFlow = [];
 
-            ['top', 'right', 'bottom', 'left'].forEach(edge => {
-                const zoneId = Document.getZoneNodeId(d.nodes.root.zones[edge]);
+            (function walk(config) {
+                if (!config || typeof config !== 'object') return;
 
-                (zoneId ? LayoutAdapter.collectAutoHiddenItems(zoneId, d) : []).forEach(itemId => {
-                    railed++;
-                    expect(Document.findOwningEdge(d, itemId), `${itemId} rails on ${edge}`).toBe(edge)
-                })
+                if (config.dockNodeType === 'edge-rail') {
+                    config.railItems?.forEach(tab => rails.push({edge: config.dockEdge, itemId: tab.dockItemId}))
+                }
+
+                // The tab flow's own id list, read where the projection actually writes it: the
+                // header toolbar's SortZone config, which is the list the rendered strip is built
+                // from rather than a re-derivation of it.
+                config.headerToolbar?.sortZoneConfig?.dockItemIds?.forEach(itemId => tabFlow.push(itemId));
+                Array.isArray(config.items) && config.items.forEach(walk)
+            })(projected);
+
+            // Non-vacuity: `not.toContain` on an empty array passes for the wrong reason, so the walk
+            // must be shown to have found the tab flow at all before anything is asserted absent from it.
+            expect(tabFlow.length, 'the walk reached a rendered tab flow to assert against').toBeGreaterThan(0);
+            expect(rails.length, 'and reached a rendered rail').toBeGreaterThan(0);
+
+            // `buried` sits two edge-zones deep and `plain` in the inner zone's center; both belong to
+            // the ROOT's left band, which is the answer `findOwningEdge` gives. Each must render on
+            // exactly one rail — `toEqual` on the collected edges is what forbids the second one.
+            ['buried', 'plain'].forEach(itemId => {
+                expect(rails.filter(rail => rail.itemId === itemId).map(rail => rail.edge),
+                    `${itemId} rails exactly once, on the band the query names`)
+                    .toEqual([Document.findOwningEdge(d, itemId)]);
+
+                expect(tabFlow, `${itemId} left the tab flow it railed out of`).not.toContain(itemId)
             });
 
-            // Non-vacuity: the loop above must actually have compared the pair it claims to.
-            expect(railed, 'the projection railed both left-band items to compare against').toBe(2);
-
-            // `main` is auto-hidden in the ROOT's center: the projection never rails it (it stays in
-            // the tab flow as §2.7's fail-safe), and the query agrees by answering null. This is the
-            // negative half — without it the loop above could pass by railing everything.
-            expect(Document.findOwningEdge(d, 'main')).toBe(null)
+            // The negative half. `main` is auto-hidden in the ROOT's center: §2.7's fail-safe keeps it
+            // in the tab flow rather than railing it, and the query agrees by answering null. Without
+            // this the arm above could pass by railing everything.
+            expect(Document.findOwningEdge(d, 'main')).toBe(null);
+            expect(rails.map(rail => rail.itemId), 'center content is never railed').not.toContain('main');
+            expect(tabFlow, 'and it stays visible instead of vanishing').toContain('main')
         });
 
         test('a cyclic document terminates instead of hanging the render thread', () => {

--- a/test/playwright/unit/dashboard/DockZoneModel.spec.mjs
+++ b/test/playwright/unit/dashboard/DockZoneModel.spec.mjs
@@ -11,6 +11,7 @@ import Neo                from '../../../../src/Neo.mjs';
 import * as core          from '../../../../src/core/_export.mjs';
 import DockWorkspace      from '../../../../src/dashboard/dock/Workspace.mjs';
 import Document           from '../../../../src/dashboard/dock/model/Document.mjs';
+import LayoutAdapter      from '../../../../src/dashboard/dock/projection/LayoutAdapter.mjs';
 import Operations         from '../../../../src/dashboard/dock/model/Operations.mjs';
 import Persistence        from '../../../../src/dashboard/dock/model/Persistence.mjs';
 import PerspectiveLibrary from '../../../../src/dashboard/dock/persistence/PerspectiveLibrary.mjs';
@@ -1704,6 +1705,126 @@ test.describe('Neo.dashboard.dock.model.Document', () => {
             });
 
             expect(appended.nodes['main-tabs'].items).toEqual(['swarm', 'strategy'])
+        })
+    });
+
+    test.describe('findOwningEdge (collapse-target derivation, §2.7)', () => {
+        // Nested edge-zones: the OUTER root owns a `left` band holding an inner edge-zone, whose own
+        // `top` band holds `buried`. Two directional ancestors, deliberately different edges, so a
+        // wrong answer cannot coincide with the right one.
+        const nested = () => ({
+            schema: 'neo.dock.zone.v1',
+            root  : 'root',
+            items : {
+                main  : {componentRef: 'main',   title: 'Main',   kind: 'panel'},
+                buried: {componentRef: 'buried', title: 'Buried', kind: 'panel'},
+                plain : {componentRef: 'plain',  title: 'Plain',  kind: 'panel'}
+            },
+            nodes: {
+                root        : {type: 'edge-zone', zones: {center: {nodeId: 'main-tabs'}, left: {nodeId: 'inner'}}},
+                'main-tabs' : {type: 'tabs', items: ['main'], activeItemId: 'main'},
+                inner       : {type: 'edge-zone', zones: {center: {nodeId: 'plain-tabs'}, top: {nodeId: 'buried-tabs'}}},
+                'plain-tabs': {type: 'tabs', items: ['plain'],  activeItemId: 'plain'},
+                'buried-tabs': {type: 'tabs', items: ['buried'], activeItemId: 'buried'}
+            }
+        });
+
+        test('an edge-owned item resolves its band; a center-owned item resolves null', () => {
+            const d = doc();
+
+            expect(Document.findOwningEdge(d, 'terminal')).toBe('right');
+
+            // Center is not a claim: §2.7's fail-safe is that main content never rails.
+            expect(Document.findOwningEdge(d, 'strategy')).toBe(null);
+            expect(Document.findOwningEdge(d, 'swarm')).toBe(null)
+        });
+
+        test('resolves through an ancestor climb, not just a direct zone slot', () => {
+            const d = doc();
+
+            // `side-tabs` moves UNDER a split that occupies the right zone, so the item is now two
+            // levels below the band. A derivation that only read the item's immediate parent slot
+            // would answer null here and silently hide the collapse affordance.
+            d.nodes['side-split']      = {type: 'split', orientation: 'vertical', children: ['side-tabs'], sizes: [1]};
+            d.nodes.root.zones.right   = {nodeId: 'side-split'};
+
+            expect(Document.findOwningEdge(d, 'terminal')).toBe('right')
+        });
+
+        test('an unknown item and a catalog-only item resolve null, never a stray edge', () => {
+            const d = doc();
+
+            expect(Document.findOwningEdge(d, 'ghost')).toBe(null);
+
+            // `inspector` is in the catalog but not in the tree. Catalog presence is not placement —
+            // the same rule `captureItemPlacement` fails closed on.
+            expect(d.items.inspector).toBeTruthy();
+            expect(Document.findOwningEdge(d, 'inspector')).toBe(null)
+        });
+
+        test('nested edge-zones: the OUTERMOST directional band wins, because that is the one that rails it', () => {
+            const d = nested();
+
+            // `buried` sits in inner.top, and inner sits in root.left. The projection collects the
+            // root's `left` band with `collectAutoHiddenItems`, which recurses THROUGH `inner` and
+            // claims the item first — so `left` is the rail it would actually reach, not `top`.
+            expect(Document.findOwningEdge(d, 'buried')).toBe('left');
+
+            // `plain` sits in the INNER edge-zone's center — but that whole edge-zone is inside root's
+            // left band, and the collection recurses through it without treating a nested center as a
+            // stop. So `plain` rails LEFT too. "Center never rails" is a rule about the center of the
+            // edge-zone being projected, not about every center slot on the path.
+            expect(Document.findOwningEdge(d, 'plain')).toBe('left');
+
+            // The genuine fail-safe: reaching the root through the ROOT's center is no claim.
+            expect(Document.findOwningEdge(d, 'main')).toBe(null)
+        });
+
+        test('agrees with the projection it must not contradict: every railed item names the band it railed to', () => {
+            const d = nested();
+
+            d.items.buried.autoHidden = true;
+            d.items.plain.autoHidden  = true;
+            d.items.main.autoHidden   = true;
+
+            // The adapter's own collection, per band of the ROOT edge-zone — the exact derivation the
+            // rails are built from. Whatever it claims for a band, this query must answer for the item;
+            // whatever it never claims, this query must answer null. Two derivations of one §2.7 rule
+            // that could silently drift apart are pinned together here instead.
+            let railed = 0;
+
+            ['top', 'right', 'bottom', 'left'].forEach(edge => {
+                const zoneId = Document.getZoneNodeId(d.nodes.root.zones[edge]);
+
+                (zoneId ? LayoutAdapter.collectAutoHiddenItems(zoneId, d) : []).forEach(itemId => {
+                    railed++;
+                    expect(Document.findOwningEdge(d, itemId), `${itemId} rails on ${edge}`).toBe(edge)
+                })
+            });
+
+            // Non-vacuity: the loop above must actually have compared the pair it claims to.
+            expect(railed, 'the projection railed both left-band items to compare against').toBe(2);
+
+            // `main` is auto-hidden in the ROOT's center: the projection never rails it (it stays in
+            // the tab flow as §2.7's fail-safe), and the query agrees by answering null. This is the
+            // negative half — without it the loop above could pass by railing everything.
+            expect(Document.findOwningEdge(d, 'main')).toBe(null)
+        });
+
+        test('a cyclic document terminates instead of hanging the render thread', () => {
+            const d = doc();
+
+            // Not a shape `validate` admits — but this query also runs against documents mid-operation,
+            // and an unbounded climb would spin forever rather than fail. `a` and `b` are each other's
+            // parent, so the climb out of `side-tabs` returns to a node it has already visited.
+            delete d.nodes.root.zones.right;
+
+            d.nodes.a = {type: 'split', orientation: 'vertical',   children: ['b'],              sizes: [1]};
+            d.nodes.b = {type: 'split', orientation: 'horizontal', children: ['a', 'side-tabs'], sizes: [0.5, 0.5]};
+
+            // No edge-zone ancestor is reachable at all, so the fail-safe answer is null — and the
+            // point of the assertion is that it ARRIVES.
+            expect(Document.findOwningEdge(d, 'terminal')).toBe(null)
         })
     });
 


### PR DESCRIPTION
Resolves #17945

Related: #13158

A dock pane can now collapse to its edge rail from its own header. ADR 0029 §2.7 specified that control and marked it implementation-sufficient, but nothing implemented it: `setItemAutoHidden` had exactly one non-model caller in `src/` — persistence's `RestorePlanner` — so the reveal overlay could bring a pane back FROM the rail while nothing sent one TO it. `enableDockPinAction` (default `false`, projection byte-identical while off) closes the round-trip.

Evidence: L4 (real product driven through the browser — the projected action clicked in the dock example, worker truth read back through the Neural Link at every stage) → L4 required. Residual: none.

## AC Evidence

| AC | Proof |
|---|---|
| AC-1 | *(off byte-identical; on renders the focus-gated `pin` at the frozen slot, guard covers `pin`)* — CI-covered: `DockLayoutAdapter.spec.mjs` — *"the pin action is absent and the projection byte-identical while its opt-in is off"*, *"...projects at its frozen slot and is hidden wherever the collapse could not complete"* (order `['diagnose', 'pin', 'close']`; `contextual` undefined = focus-gated), *"a host may own the name `pin` — until the engine action that reserves it is switched on"* |
| AC-2 | *(pin on an edge-owned pinnable pane commits the two-step in order, independently; the item rails)* — CI-covered: `DockWorkspace.spec.mjs` — *"...commits §2.7's two-step collapse through the write seam and rails the pane"* (both descriptors witnessed at `applyDockZoneOperation`, in order) and *"an UNPINNED pane collapses in a single commit"* |
| AC-3 | *(hidden while center-owned or `pinnable: false`, witnessed via active-item switch; moves by `hidden` on one stable instance, `actionVisibilityChange` fires, group never replaced)* — CI-covered: `DockWorkspace.spec.mjs` — *"...refuses fail-closed where the collapse cannot complete, and moves by hidden on ONE instance"* (same instance asserted identical, one `['pin', true]` visibility event, model refusal on dispatch) |
| AC-4 | *(round-trip e2e gesture spec in the same PR)* — outside-CI: `test/playwright/e2e/dashboard/DockPinCollapseNL.spec.mjs`, receipt in **Test Evidence** |
| AC-5 | *(rendering the action changes no committed state; only `pinned`/`autoHidden` change when the gesture runs)* — CI-covered: `DockWorkspace.spec.mjs` asserts the inspector item record is untouched after projection and before the gesture. Outside-CI: the e2e asserts the document byte-stable across the reveal, and after the full round-trip `nodes` deep-equal to the start with only `pinned`/`autoHidden` differing |

## Deltas from ticket

**`Document.findOwningEdge` returns the OUTERMOST directional band, not the nearest.** The ticket specifies §2.7's rule ("the rail an item collapses to is the edge zone that contains it") without settling nesting. `projectEdgeZoneNode` collects each band with `collectAutoHiddenItems`, which recurses *through* nested edge-zones and passes the claimed set down as `railedItemIds` — so an item two edge-zones deep rails on the OUTER edge and the inner band never claims it. The query matches that, and a spec pins the two derivations together rather than leaving one free to drift.

The same spec corrected my own first assumption: an item in a *nested* edge-zone's `center` still rails, because "center never rails" governs the center of the edge-zone being projected, not every `center` slot on the path. Only the root's center is the fail-safe.

**The reserved-name guard became a table instead of a second branch.** Five more engine actions are coming (`lock`, `reload`, `pop-out`, `maximize`), and a branch per action is a guard someone forgets. It is a `Map`, not an object literal, because the key is host-supplied: `constructor` would otherwise resolve to a prototype member and be reported as reserved. The `close` error message is unchanged.

**The two steps publish separately rather than folding into one document change.** I first folded them, then found `applyDockZoneOperation`'s second parameter is already the *source* slot (`DockService.mjs:486`, `DockSplitter.mjs:284`), so a chained step could only reach the reducer by bypassing the class's write seam. Following §2.7 literally keeps both commits visible at the seam a holder is reached through. The stated cost: a step-2 rejection leaves the pane unpinned and visible — §2.7's own intermediate state, which it calls benign. An unpinned pane, the ordinary case, is one commit and one refresh.

**The example opts in**, so `examples/dashboard/dock/` now demonstrates the whole round-trip instead of only the return half.

## Test Evidence

**AC-4 round-trip e2e** — `DockPinCollapseNL.spec.mjs`, real gestures only, nothing committed programmatically:

```
NEO_AGENTOS_RUNTIME_ROOT=<brain checkout> npm run test-e2e -- DockPinCollapseNL --workers=1
  ✓  1 [chromium] › DockPinCollapseNL.spec.mjs:73:5 › the header pin action collapses a pane
       to its edge rail, and the reveal overlay brings it back (5.1s)
  1 passed (7.8s)
```

It needs `NEO_AGENTOS_RUNTIME_ROOT`; without it the config's `discoverExternalBrainSpecs` ignores every `neuralLink` spec and the run reports *"No tests found"* rather than failing. Per #17853 the e2e suite runs in no workflow, so this receipt is the only proof of it.

**Non-vacuity, both arms witnessed.** With the example's opt-in flipped to `false` the spec fails on the exact assertion `the opt-in projection materialises one persistent pin action`; restored, it passes. It cannot pass without the feature.

**Mutation results — four mutations, four caught, one after a repair:**

| Mutation | Result |
|---|---|
| `syncDockPinAction` center check deleted | **survived initially.** The assertion read a center tabs node holding ONE item, so the value under test was the ADAPTER's projected `hidden` and the workspace's sync never ran there. Fixed in `357502b` by adding a second center item so activating it drives the sync; now red. |
| `LayoutAdapter` center check deleted | red — *"a center-owned active item cannot collapse"* |
| unpin step dropped from the two-step | red — descriptor sequence mismatch |
| `findOwningEdge` returns innermost band | red ×2 — the nested test and the projection-agreement test |

**Suites at the head:** `npm run test-unit` 2568 passed · `npm run test-components` 111 passed.

A fresh worktree cannot run the full unit suite until `npm run bundle-parse5` has produced `dist/parse5.mjs`; `HtmlTemplateProcessor.mjs` imports it and the run dies at collection. Unrelated to this change, and adjacent to #17942.

## Post-Merge Validation

None. Every AC is proven at this head, including the two that needed the real product — nothing here is deferred past merge.

Worth knowing rather than owed: the e2e that proves AC-4 runs in no workflow (#17853 owns that), so after merge nothing re-checks the round-trip automatically. The receipt above is its standing proof.

## Commits

- `ca04b67` — the action: model derivation, adapter projection + reserved-name table, workspace dispatch and policy sync, unit coverage
- `357502b` — the mutation repair above: make the center rule fail on the workspace's own sync
- `fbac36b` — the round-trip e2e and the example opt-in
- `099cbec` — the pin action is focus-gated; `contextual: false` was copied from close, which means the opposite

## Evolution

The pin config initially carried `contextual: false`, lifted from the close action beside it. The pre-open AC re-anchor caught it: AC-1 asks for a *focus-gated* toggle, and that key opts OUT of the gate. Close earns the exemption because it must stay reachable on an unfocused pane; inheriting it would have put a permanently visible control on every dock header. Removing it also exposed a weak e2e assertion — with the gate closed, an invisible center pin proves nothing — so the spec now focuses each pane first and asserts the ungated close action visible on the same header as the control arm.

Authored by Grace (Anthropic Claude Opus 5, Claude Code). Session 1a3b86e4-6f3f-4d5e-8625-07d14f2c9c5e.
