### PR TITLE
feat(dashboard): dock tabs nodes maximize in place (#17928)

### DIFF
--- a/resources/scss/src/dashboard/Container.scss
+++ b/resources/scss/src/dashboard/Container.scss
@@ -485,6 +485,31 @@
     }
 }
 
+// The maximize presentation (Neo.dashboard.dock.Workspace#maximizedNodeId): a class toggle plus
+// four inline rect values MEASURED from the workspace root at toggle time — never `inset: 0`,
+// which answers to the viewport or an incidental fixed containing block instead of the
+// workspace. The pane is never re-parented (an iframe reloads its browsing context on
+// re-parent): the same node paints the measured rect in place while the committed layout stays
+// untouched underneath. Sits above the rails and the reveal overlay (z 20) — one overlay tier
+// at a time.
+.neo-dock-maximized {
+    // An opaque surface is part of the contract: the committed layout reflows underneath the
+    // fixed pane, and a transparent header band would ghost the covered nodes' chrome through.
+    background: var(--dock-maximize-background, var(--neo-background-color, #fff));
+    margin    : 0;
+    position  : fixed;
+    z-index   : var(--dock-maximize-z-index, 40);
+}
+
+// While a restore FLIP glides the pane from the workspace rect back into its flow slot, the
+// shrinking pane keeps painting above the re-expanded layout; without the hold it would drop
+// behind its siblings the moment `position: fixed` leaves it. The workspace removes the class
+// when the motion settles.
+.neo-dock-maximize-restoring {
+    position: relative;
+    z-index : var(--dock-maximize-z-index, 40);
+}
+
 // One visual family for cross indicators and edge chips: token-fed surfaces, motion-contract
 // timing only. `visibility` (not `display`) keeps the DOM warm so position glides and the
 // show/hide fades actually run. The ground/line read the dock-domain aliases — the theme

--- a/src/dashboard/dock/Workspace.mjs
+++ b/src/dashboard/dock/Workspace.mjs
@@ -132,6 +132,31 @@ class Workspace extends Container {
          */
         enableDockPinAction: false,
         /**
+         * Projects one engine-owned maximize toggle into each Dock tab header — presentation
+         * only: the committed document, perspectives and topology diffs never observe maximize
+         * state. Disabled by default.
+         *
+         * Input contract while a node is maximized: in-strip tab reordering stays live;
+         * cross-zone drag sources and tear-out affordances of the maximized node are suppressed
+         * (every drop target sits under the maximized plane); `Escape` restores and returns
+         * focus to the restored node's active header button; any committed dock operation
+         * clears maximize BEFORE applying, and that clear is terminal for the re-projection
+         * rule on {@link #maximizedNodeId}.
+         * @member {Boolean} enableDockMaximizeAction=false
+         */
+        enableDockMaximizeAction: false,
+        /**
+         * Icon of the projected maximize action while its node is not maximized.
+         * @member {String} dockMaximizeIconCls='far fa-window-maximize'
+         */
+        dockMaximizeIconCls: 'far fa-window-maximize',
+        /**
+         * Icon of the projected maximize action while its node is maximized — the restore half
+         * of the toggle, the {@link Neo.dialog.Base} icon-pair precedent.
+         * @member {String} dockMinimizeIconCls='far fa-window-minimize'
+         */
+        dockMinimizeIconCls: 'far fa-window-minimize',
+        /**
          * Enables the engine-owned dock tear-out admission/document/window lifecycle. Disabled
          * by default so ordinary workspaces and hosts carrying their own legacy lifecycle remain
          * byte-behaviorally unchanged until their migration leaf.
@@ -155,6 +180,33 @@ class Workspace extends Container {
          * @member {String} flipMarkerPrefix='dock-flip-item-'
          */
         flipMarkerPrefix: 'dock-flip-item-',
+        /**
+         * `Escape` restores an active maximize. The binding is static, the effect is not: the
+         * handler no-ops unless {@link #maximizedNodeId} is set, so every other Escape consumer
+         * (dialogs, reveal overlays, transfer cycles) keeps its ordinary meaning.
+         * @member {Object} keys={Escape:'onDockMaximizeEscape'}
+         */
+        keys: {
+            Escape: 'onDockMaximizeEscape'
+        },
+        /**
+         * Prefix of the per-node marker class the maximize FLIP correlates. Stamped lazily onto
+         * every live tabs node right before a toggle captures its first rects — the projection
+         * itself stays byte-identical while nothing has ever been maximized.
+         * @member {String} maximizeMarkerPrefix='dock-maximize-node-'
+         */
+        maximizeMarkerPrefix: 'dock-maximize-node-',
+        /**
+         * The workspace-transient maximize target — the projected tabs node currently painting
+         * the measured workspace rect. Deliberately NOT part of the committed dock document:
+         * maximize is presentation, so perspectives, persistence and topology diffs never see
+         * it. Deterministic across re-projection: the presentation is re-applied iff this id
+         * still resolves to a projected tabs node, and cleared otherwise — never a third
+         * outcome. Committed operations clear it before they apply, terminally.
+         * @member {String|null} maximizedNodeId_=null
+         * @reactive
+         */
+        maximizedNodeId_: null,
         /**
          * URL-search parameter whose value identifies this workspace as a tear-out vessel's
          * owner. The engine default is product-neutral; legacy consumers may select their
@@ -260,6 +312,40 @@ class Workspace extends Container {
      * @protected
      */
     returningTearOutPanes = {}
+
+    /**
+     * One-shot motion intent for the next {@link #maximizedNodeId} transition: 'animate' (the
+     * gesture default) or 'instant' (operation-driven clears, fail-safes, re-projection
+     * continuity). Consumed and reset by `afterSetMaximizedNodeId`.
+     * @member {String} dockMaximizeMotion='animate'
+     * @protected
+     */
+    dockMaximizeMotion = 'animate'
+
+    /**
+     * True while the workspace root is registered with the main-thread ResizeObserver addon for
+     * maximize re-measurement — the observation exists exactly as long as a presentation does.
+     * @member {Boolean} dockMaximizeResizeObserved=false
+     * @protected
+     */
+    dockMaximizeResizeObserved = false
+
+    /**
+     * True once the maximize resize dom listener is wired; the listener itself is a cheap no-op
+     * while nothing is maximized.
+     * @member {Boolean} dockMaximizeResizeWired=false
+     * @protected
+     */
+    dockMaximizeResizeWired = false
+
+    /**
+     * Restoration snapshot while a maximize presentation is applied:
+     * `{nodeId, zone: {allowOverdrag, boundaryContainerId, enableProxyToPopup}|null, zoneId}`.
+     * Doubles as the presentation-applied flag the clear path consumes exactly once.
+     * @member {Object|null} dockMaximizeRestore=null
+     * @protected
+     */
+    dockMaximizeRestore = null
 
     /**
      * @param {Object} config
@@ -1108,6 +1194,13 @@ class Workspace extends Container {
             me.tearOutHandlers = null
         }
 
+        if (me.dockMaximizeResizeObserved) {
+            me.dockMaximizeResizeObserved = false;
+            Neo.main.addon.ResizeObserver?.unregister({componentId: me.id, id: me.id, windowId: me.windowId})
+        }
+
+        me.dockMaximizeRestore = null;
+
         me.dockPreviewProducer?.destroy();
         me.dockPreviewProducer = null;
         me.refreshPromise      = null;
@@ -1138,7 +1231,8 @@ class Workspace extends Container {
      * the node's retained lifetime — vary an action per active item by moving `hidden` on its stable
      * instance, the way {@link #syncDockCloseAction} does, not by returning a different list. Names
      * must be unique per node, and every engine-owned name is reserved while its own opt-in is on —
-     * `close` under {@link #enableDockCloseAction}, `pin` under {@link #enableDockPinAction};
+     * `close` under {@link #enableDockCloseAction}, `maximize` under {@link #enableDockMaximizeAction},
+     * `pin` under {@link #enableDockPinAction};
      * both violations throw at projection rather than silently unaddressing an action. Their intent
      * surfaces on the `dockHeaderAction` event — see {@link #onDockHeaderAction}.
      * @returns {Object}
@@ -1293,7 +1387,8 @@ class Workspace extends Container {
      * and re-emits everything it does not own.
      *
      * This class owns the ENGINE SET, each action only while its own opt-in is on: `close`
-     * ({@link #enableDockCloseAction}) and `pin` ({@link #enableDockPinAction}). Every other intent —
+     * ({@link #enableDockCloseAction}), `maximize` ({@link #enableDockMaximizeAction} — a pure
+     * presentation toggle that never reaches the reducer) and `pin` ({@link #enableDockPinAction}). Every other intent —
      * including host actions projected through `resolveDockHeaderActions` — is re-emitted as a
      * **`dockHeaderAction`** event carrying `{action, dockNodeId, tabContainer}`, so a host receives it
      * without subclassing this class or overriding a protected method, and this method returns `null`
@@ -1316,6 +1411,11 @@ class Workspace extends Container {
 
         if (action === 'pin' && me.enableDockPinAction) {
             return me.handleDockPinAction({dockNodeId, tabContainer})
+        }
+
+        if (action === 'maximize' && me.enableDockMaximizeAction) {
+            me.toggleDockMaximize(dockNodeId);
+            return null
         }
 
         // Not an action this class owns. Re-emit it so a host that projected its own actions
@@ -1466,6 +1566,507 @@ class Workspace extends Container {
         }
 
         tabContainer.focus()
+    }
+
+    /**
+     * Triggered after the maximizedNodeId config got changed — the single presentation writer:
+     * clearing restores the previous node, setting applies the new one, and an A→B switch
+     * restores A instantly underneath B's animation. The one-shot {@link #dockMaximizeMotion}
+     * intent decides whether the transition animates (the gesture default) or lands instantly
+     * (operation-driven clears, fail-safes, re-projection continuity).
+     * @param {String|null} value
+     * @param {String|null} oldValue
+     * @protected
+     */
+    afterSetMaximizedNodeId(value, oldValue) {
+        if (oldValue === undefined) {
+            return
+        }
+
+        let me      = this,
+            animate = me.dockMaximizeMotion !== 'instant';
+
+        me.dockMaximizeMotion = 'animate';
+
+        oldValue && me.clearDockMaximizePresentation({animate: animate && !value});
+        value    && me.applyDockMaximizePresentation(value, {animate})
+    }
+
+    /**
+     * Header-action dispatch for the engine-owned maximize toggle. Restoring returns focus to
+     * the restored node's active header button — the input contract's focus half.
+     * @param {String} dockNodeId
+     * @protected
+     */
+    toggleDockMaximize(dockNodeId) {
+        let me       = this,
+            restored = me.maximizedNodeId === dockNodeId;
+
+        me.maximizedNodeId = restored ? null : dockNodeId;
+
+        restored && me.focusDockMaximizeTarget(dockNodeId)
+    }
+
+    /**
+     * `Escape` restores an active maximize and returns focus to the restored node's active
+     * header button. A no-op while nothing is maximized, so every other Escape consumer keeps
+     * its ordinary meaning.
+     * @param {Object} data
+     * @protected
+     */
+    onDockMaximizeEscape(data) {
+        let me     = this,
+            nodeId = me.maximizedNodeId;
+
+        if (nodeId) {
+            me.maximizedNodeId = null;
+            me.focusDockMaximizeTarget(nodeId)
+        }
+    }
+
+    /**
+     * Focuses the restored node's active header button after a maximize restore; an
+     * unresolvable button falls back to the tabs root.
+     * @param {String} nodeId
+     * @protected
+     */
+    focusDockMaximizeTarget(nodeId) {
+        let tabContainer = this.getDockHost()?.down?.({dockNodeId: nodeId});
+
+        if (tabContainer) {
+            let buttons = tabContainer.getTabButtons?.() || [],
+                index   = tabContainer.activeIndex;
+
+            (buttons[index] || tabContainer).focus?.()
+        }
+    }
+
+    /**
+     * Measures the workspace root's live viewport rect — the geometry authority for the
+     * maximize presentation. The workspace measures ITSELF: `inset: 0` would answer to the
+     * viewport or an incidental fixed containing block instead of the workspace. `null` is the
+     * fail-safe trigger (unmounted mid-gesture, zero-area rect).
+     * @returns {Promise<Object|null>}
+     * @protected
+     */
+    async measureDockMaximizeRect() {
+        let me   = this,
+            rect = null;
+
+        try {
+            rect = await Neo.main.DomAccess.getBoundingClientRect({id: me.id, windowId: me.windowId})
+        } catch (error) {
+            rect = null
+        }
+
+        Array.isArray(rect) && (rect = rect[0]);
+
+        return (rect?.width > 0 && rect?.height > 0) ? rect : null
+    }
+
+    /**
+     * The fail-safe half of the geometry contract: an unresolvable measurement or projection
+     * clears the transient through the ordinary restore path — never a half state.
+     * @param {String} nodeId The transition this failure belongs to.
+     * @protected
+     */
+    failDockMaximize(nodeId) {
+        let me = this;
+
+        if (me.maximizedNodeId === nodeId) {
+            me.dockMaximizeMotion = 'instant';
+            me.maximizedNodeId    = null
+        }
+    }
+
+    /**
+     * Stamps the maximize FLIP marker onto every live projected tabs node (idempotent) and
+     * flushes, so a following capture sees each node's pre-toggle rect: the maximized node
+     * glides, and the siblings reflowing around its vacated flow slot glide with it instead of
+     * snapping. Stamped lazily at gesture time — a workspace that never maximizes projects
+     * byte-identically.
+     * @returns {Promise<void>}
+     * @protected
+     */
+    async stampDockMaximizeMarkers() {
+        let me     = this,
+            prefix = me.maximizeMarkerPrefix,
+            shell  = me.getDockHost()?.items?.[me.dockShellIndex],
+            tabs   = shell ? Reconciler.collectProjectedTabs(shell) : new Map(),
+            dirty  = [];
+
+        tabs.forEach(tab => {
+            let marker = `${prefix}${encodeURIComponent(tab.dockNodeId)}`;
+
+            if (!tab.cls.includes(marker)) {
+                tab.cls = [...new Set([...tab.cls, marker])];
+                dirty.push(tab)
+            }
+        });
+
+        await Promise.all(dirty.map(tab => tab.promiseUpdate?.()))
+    }
+
+    /**
+     * FLIP first-phase for a maximize transition, over the dedicated maximize marker family —
+     * separate from {@link #flipMarkerPrefix} so committed-operation refreshes and maximize
+     * gestures never consume each other's snapshots.
+     * @returns {Promise<Neo.container.Base|null>} The dock host, for the paired play call.
+     * @protected
+     */
+    async captureDockMaximizeFirst() {
+        let me   = this,
+            host = me.getDockHost(),
+            flip = Neo.main?.addon?.DockFlip;
+
+        if (!host?.mounted) {
+            return null
+        }
+
+        try {
+            await flip?.captureFirst({hostId: host.id, markerPrefix: me.maximizeMarkerPrefix, windowId: host.windowId})
+        } catch (error) {/* instant landing */}
+
+        return host
+    }
+
+    /**
+     * FLIP second-phase for a maximize transition — the same fail-safe discipline as
+     * {@link #refreshDockWorkspace}: gate on the play capability, bracket the motion signal, and
+     * let every failure land the final geometry instantly. Truth never waits on motion.
+     * @param {Neo.container.Base|null} host
+     * @returns {Promise<*>}
+     * @protected
+     */
+    playDockMaximizeFlip(host) {
+        let me   = this,
+            flip = Neo.main?.addon?.DockFlip,
+            played;
+
+        if (!host || typeof flip?.play !== 'function' || me.isDestroyed) {
+            return Promise.resolve(null)
+        }
+
+        MotionSignal.enter(me);
+
+        try {
+            played = flip.play({hostId: host.id, markerPrefix: me.maximizeMarkerPrefix, windowId: host.windowId})
+        } catch (error) {
+            played = Promise.reject(error)
+        }
+
+        played = Promise.resolve(played).catch(() => null);
+        played.finally(() => MotionSignal.leave(me));
+
+        return played
+    }
+
+    /**
+     * The input-contract guard while a node is maximized: in-strip reorder stays live (the zone
+     * keeps sorting, clamped to its own toolbar), while cross-zone exits and tear-out are
+     * suppressed — every drop target sits under the maximized plane, so offering the gesture
+     * would be dishonest. Idempotent per zone instance: re-application onto the same live zone
+     * keeps the original snapshot, so restore always lands the pre-maximize values.
+     * @param {Neo.tab.Container} tabContainer
+     * @protected
+     */
+    suppressDockMaximizeDragSources(tabContainer) {
+        let me   = this,
+            bar  = tabContainer.getTabBar?.(),
+            zone = bar?.sortZone || null;
+
+        if (me.dockMaximizeRestore?.zoneId && me.dockMaximizeRestore.zoneId === zone?.id) {
+            return
+        }
+
+        me.dockMaximizeRestore = {
+            nodeId: tabContainer.dockNodeId,
+            zone  : zone && {
+                allowOverdrag      : zone.allowOverdrag,
+                boundaryContainerId: zone.boundaryContainerId,
+                enableProxyToPopup : zone.enableProxyToPopup
+            },
+            zoneId: zone?.id || null
+        };
+
+        if (zone) {
+            zone.allowOverdrag       = false;
+            zone.boundaryContainerId = bar.id;
+            zone.enableProxyToPopup  = false
+        }
+    }
+
+    /**
+     * Applies the maximize presentation onto the live projected tabs node: the measured
+     * workspace rect as four inline values plus the class toggle — never a re-parent (a pane
+     * hosting an iframe reloads its browsing context on re-parent), never a committed operation
+     * (the document, perspectives and topology diffs never observe maximize). Fail-safe: an
+     * unresolvable node or measurement clears the transient instead of leaving a half state.
+     * Idempotent, so the re-projection continuity can re-enter it.
+     * @param {String} nodeId
+     * @param {Object} [options={}]
+     * @param {Boolean} [options.animate=true]
+     * @returns {Promise<void>}
+     * @protected
+     */
+    async applyDockMaximizePresentation(nodeId, {animate=true}={}) {
+        let me           = this,
+            tabContainer = me.getDockHost()?.down?.({dockNodeId: nodeId}),
+            host         = null,
+            rect;
+
+        if (!tabContainer || tabContainer.isDestroyed) {
+            me.failDockMaximize(nodeId);
+            return
+        }
+
+        rect = await me.measureDockMaximizeRect();
+
+        if (!rect) {
+            me.failDockMaximize(nodeId);
+            return
+        }
+
+        if (me.maximizedNodeId !== nodeId || me.isDestroyed) {
+            return
+        }
+
+        me.suppressDockMaximizeDragSources(tabContainer);
+
+        if (animate) {
+            await me.stampDockMaximizeMarkers();
+            host = await me.captureDockMaximizeFirst();
+
+            if (me.maximizedNodeId !== nodeId || me.isDestroyed) {
+                return
+            }
+        }
+
+        tabContainer.set({
+            cls: [...new Set([
+                ...tabContainer.cls.filter(c => c !== 'neo-dock-maximize-restoring'),
+                'neo-dock-maximized'
+            ])],
+            style: {
+                ...tabContainer.style,
+                height: `${rect.height}px`,
+                left  : `${rect.left}px`,
+                top   : `${rect.top}px`,
+                width : `${rect.width}px`
+            }
+        });
+
+        animate && me.playDockMaximizeFlip(host);
+
+        me.syncDockMaximizeActionIcon(tabContainer, true);
+        await me.registerDockMaximizeResizeObserver(true)
+    }
+
+    /**
+     * Restores the ordinary presentation: removes the class and the four inline rect values,
+     * lifts the drag-source suppression, and (for gesture-driven restores) FLIP-glides the node
+     * from the workspace rect back into its flow slot while `neo-dock-maximize-restoring` holds
+     * its paint order above the re-expanded layout until the motion settles.
+     * @param {Object} [options={}]
+     * @param {Boolean} [options.animate=true]
+     * @returns {Promise<void>}
+     * @protected
+     */
+    async clearDockMaximizePresentation({animate=true}={}) {
+        let me      = this,
+            restore = me.dockMaximizeRestore,
+            host    = null,
+            tabContainer, zone;
+
+        if (!restore) {
+            return
+        }
+
+        me.dockMaximizeRestore = null;
+
+        tabContainer = me.getDockHost()?.down?.({dockNodeId: restore.nodeId});
+
+        if (tabContainer && !tabContainer.isDestroyed) {
+            zone = tabContainer.getTabBar?.()?.sortZone;
+
+            if (restore.zone && zone && zone.id === restore.zoneId) {
+                Object.assign(zone, restore.zone)
+            }
+
+            if (animate) {
+                await me.stampDockMaximizeMarkers();
+                host = await me.captureDockMaximizeFirst()
+            }
+
+            tabContainer.set({
+                cls: [
+                    ...tabContainer.cls.filter(c => c !== 'neo-dock-maximized'),
+                    ...(animate ? ['neo-dock-maximize-restoring'] : [])
+                ],
+                style: {...tabContainer.style, height: null, left: null, top: null, width: null}
+            });
+
+            if (animate) {
+                me.playDockMaximizeFlip(host).then(() => {
+                    !tabContainer.isDestroyed && (tabContainer.cls = tabContainer.cls.filter(c => c !== 'neo-dock-maximize-restoring'))
+                })
+            }
+
+            me.syncDockMaximizeActionIcon(tabContainer, false)
+        }
+
+        await me.registerDockMaximizeResizeObserver(false)
+    }
+
+    /**
+     * Flips the node's projected maximize action between its maximize and restore icons — on
+     * the stable action instance, the same discipline every action consumer relies on.
+     * @param {Neo.tab.Container|null} tabContainer
+     * @param {Boolean} maximized
+     * @protected
+     */
+    syncDockMaximizeActionIcon(tabContainer, maximized) {
+        let me     = this,
+            action = tabContainer?.getActionItem?.('maximize');
+
+        action && (action.iconCls = maximized ? me.dockMinimizeIconCls : me.dockMaximizeIconCls)
+    }
+
+    /**
+     * Classifies a committed operation descriptor as confined to the maximized node — the ops
+     * that must NOT pre-clear the transient: their effect stays inside the pane the user is
+     * looking at, so the continuity rule ({@link #syncDockMaximizeProjection}) decides from the
+     * committed outcome instead (node survived ⇒ re-apply; collapsed away ⇒ clear). Everything
+     * else — topology mutations, boundary crossings, whole-document applies (a `null`
+     * descriptor included) — clears terminally before it applies.
+     * @param {Object|null} descriptor
+     * @returns {Boolean}
+     * @protected
+     */
+    isDockMaximizeNeutralOperation(descriptor) {
+        let me                                            = this,
+            nodeId                                        = me.maximizedNodeId,
+            {itemId, operation, tabsNodeId, targetNodeId} = descriptor || {};
+
+        if (!operation || !nodeId) {
+            return false
+        }
+
+        switch (operation) {
+            case 'addTab':
+                return tabsNodeId === nodeId;
+            case 'closeItem':
+                return Document.findContainingTabsId(me.dockModel, itemId) === nodeId;
+            case 'moveItem':
+                return targetNodeId === nodeId && Document.findContainingTabsId(me.dockModel, itemId) === nodeId;
+            case 'setActiveItem':
+                return tabsNodeId === nodeId;
+            default:
+                return false
+        }
+    }
+
+    /**
+     * The deterministic re-projection half of the transient contract: after a refresh, the
+     * presentation is re-applied iff {@link #maximizedNodeId} still resolves to a projected
+     * tabs node, and cleared otherwise — never a third outcome. Committed operations that reach
+     * beyond the maximized node clear the transient BEFORE their refresh runs (see
+     * {@link #onDockZoneDocumentChange}), and that clear is terminal, so this continuity path
+     * only ever re-applies a transient that survived.
+     * @protected
+     */
+    syncDockMaximizeProjection() {
+        let me     = this,
+            nodeId = me.maximizedNodeId,
+            tabContainer;
+
+        if (!nodeId) {
+            return
+        }
+
+        tabContainer = me.getDockHost()?.down?.({dockNodeId: nodeId});
+
+        if (tabContainer && me.dockModel?.nodes?.[nodeId]?.type === 'tabs') {
+            me.applyDockMaximizePresentation(nodeId, {animate: false})
+        } else {
+            me.failDockMaximize(nodeId)
+        }
+    }
+
+    /**
+     * Registers/unregisters the workspace root with the main-thread ResizeObserver addon — a
+     * NEW observation scoped exactly to the maximize lifetime: no standing cost while
+     * un-maximized, unregistered again on restore, node-clear and destroy.
+     * @param {Boolean} register
+     * @returns {Promise<void>}
+     * @protected
+     */
+    async registerDockMaximizeResizeObserver(register) {
+        let me         = this,
+            {windowId} = me,
+            addon;
+
+        if (me.dockMaximizeResizeObserved === register || me.isDestroyed) {
+            return
+        }
+
+        if (register && !me.dockMaximizeResizeWired) {
+            me.dockMaximizeResizeWired = true;
+            me.addDomListeners({resize: me.onDockMaximizeResize, scope: me})
+        }
+
+        addon = await Neo.currentWorker.getAddon('ResizeObserver', windowId);
+
+        if (me.isDestroyed || !addon) {
+            return
+        }
+
+        if (register && me.maximizedNodeId) {
+            addon.register({componentId: me.id, id: me.id, windowId});
+            me.dockMaximizeResizeObserved = true
+        } else if (!register && me.dockMaximizeResizeObserved) {
+            addon.unregister({componentId: me.id, id: me.id, windowId});
+            me.dockMaximizeResizeObserved = false
+        }
+    }
+
+    /**
+     * Re-measures and re-applies the maximize rect while the workspace resizes — geometry only,
+     * no motion. An unresolvable measurement takes the fail-safe restore path.
+     * @param {Object} data
+     * @protected
+     */
+    async onDockMaximizeResize(data) {
+        let me     = this,
+            nodeId = me.maximizedNodeId,
+            rect, tabContainer;
+
+        if (!nodeId) {
+            return
+        }
+
+        rect = await me.measureDockMaximizeRect();
+
+        if (!rect) {
+            me.failDockMaximize(nodeId);
+            return
+        }
+
+        if (me.maximizedNodeId !== nodeId) {
+            return
+        }
+
+        tabContainer = me.getDockHost()?.down?.({dockNodeId: nodeId});
+
+        tabContainer && !tabContainer.isDestroyed && tabContainer.set({
+            style: {
+                ...tabContainer.style,
+                height: `${rect.height}px`,
+                left  : `${rect.left}px`,
+                top   : `${rect.top}px`,
+                width : `${rect.width}px`
+            }
+        })
     }
 
     /**
@@ -1638,10 +2239,23 @@ class Workspace extends Container {
      * @param {Object|null} [source=null] The committing surface, when it identifies itself.
      */
     onDockZoneDocumentChange(document, descriptor=null, source=null) {
-        let me                  = this,
-            tabInsertDescriptor = me.getTabInsertProjectionDescriptor(document, descriptor),
-            refreshOptions      = me.getRefreshOptions(descriptor, source),
-            tail                = me.refreshPromise?.catch(() => {}) || Promise.resolve();
+        let me = this,
+            tabInsertDescriptor, refreshOptions, tail;
+
+        // A committed operation clears maximize BEFORE applying — and that clear is terminal:
+        // the re-projection continuity in refreshDockWorkspace() re-applies only a transient
+        // that survived, never one an operation cleared. Operations confined to the maximized
+        // node itself (activating a tab, reordering or closing within it) are the exception:
+        // they defer to that same continuity rule, which re-applies onto the surviving node —
+        // without the exception, switching tabs INSIDE a maximized pane would restore it.
+        if (me.maximizedNodeId && !me.isDockMaximizeNeutralOperation(descriptor)) {
+            me.dockMaximizeMotion = 'instant';
+            me.maximizedNodeId    = null
+        }
+
+        tabInsertDescriptor = me.getTabInsertProjectionDescriptor(document, descriptor);
+        refreshOptions      = me.getRefreshOptions(descriptor, source);
+        tail                = me.refreshPromise?.catch(() => {}) || Promise.resolve();
 
         me.dockModel = document;
 
@@ -1694,6 +2308,10 @@ class Workspace extends Container {
                 onDockHeaderAction     : me.onDockHeaderAction.bind(me),
                 ...(me.enableDockCloseAction && {enableDockCloseAction: true}),
                 ...(me.enableDockPinAction && {enableDockPinAction: true}),
+                ...(me.enableDockMaximizeAction && {
+                    dockMaximizeIconCls     : me.dockMaximizeIconCls,
+                    enableDockMaximizeAction: true
+                }),
                 applyDockZoneOperation   : me.applyDockZoneOperation.bind(me),
                 onDockZoneDocumentChange : me.onDockZoneDocumentChange.bind(me),
                 resolveComponentRef      : itemResolver || ((componentRef, item, itemId) => me.resolveProjectedPane(itemId, item)),
@@ -1823,6 +2441,7 @@ class Workspace extends Container {
         });
 
         me.syncDockHeaderActions(result?.currentTabs);
+        me.syncDockMaximizeProjection();
 
         // FLIP phase 2: fire-and-forget by default — the addon self-waits for the swap, inverts and
         // plays; the counted motion signal brackets the awaited animation window. Gate on the

--- a/src/dashboard/dock/Workspace.mjs
+++ b/src/dashboard/dock/Workspace.mjs
@@ -1867,10 +1867,6 @@ class Workspace extends Container {
             host = null,
             rect, tabContainer;
 
-        // Serialize on any in-flight FLIP window: its end-of-window cleanup restores the
-        // inline-style snapshot from invert time, which would overwrite geometry written here.
-        await me.dockMaximizePlay;
-
         tabContainer = me.getDockHost()?.down?.({dockNodeId: nodeId});
 
         if (!tabContainer || tabContainer.isDestroyed) {
@@ -1884,6 +1880,16 @@ class Workspace extends Container {
             me.failDockMaximize(nodeId);
             return
         }
+
+        if (me.maximizedNodeId !== nodeId || me.isDestroyed) {
+            return
+        }
+
+        // Serialize on any in-flight FLIP window before WRITING: its end-of-window cleanup
+        // restores the inline-style snapshot from invert time, which would overwrite geometry
+        // written inside the window. Deliberately after the fail-guards — a fail-safe clear
+        // writes nothing and must never queue behind motion.
+        await me.dockMaximizePlay;
 
         if (me.maximizedNodeId !== nodeId || me.isDestroyed) {
             return

--- a/src/dashboard/dock/Workspace.mjs
+++ b/src/dashboard/dock/Workspace.mjs
@@ -1970,7 +1970,8 @@ class Workspace extends Container {
             zone = tabContainer.getTabBar?.()?.sortZone;
 
             if (restore.zone && zone && zone.id === restore.zoneId) {
-                Object.assign(zone, restore.zone)
+                // One coherent batched mutation — the same idiom as the suppress direction.
+                zone.set(restore.zone)
             }
 
             if (animate) {

--- a/src/dashboard/dock/Workspace.mjs
+++ b/src/dashboard/dock/Workspace.mjs
@@ -138,10 +138,13 @@ class Workspace extends Container {
          *
          * Input contract while a node is maximized: in-strip tab reordering stays live;
          * cross-zone drag sources and tear-out affordances of the maximized node are suppressed
-         * (every drop target sits under the maximized plane); `Escape` restores and returns
-         * focus to the restored node's active header button; any committed dock operation
-         * clears maximize BEFORE applying, and that clear is terminal for the re-projection
-         * rule on {@link #maximizedNodeId}.
+         * (every drop target sits under the maximized plane); engaging maximize closes an
+         * in-progress reveal overlay; `Escape` restores and returns focus to the restored
+         * node's active header button. A committed dock operation that reaches beyond the
+         * maximized node clears maximize BEFORE applying, terminally for the re-projection rule
+         * on {@link #maximizedNodeId}; operations confined to the node itself (activating one
+         * of its tabs; closing, reordering or adding an item within it) defer to that rule
+         * instead, which re-applies onto the surviving node and clears when the node collapsed.
          * @member {Boolean} enableDockMaximizeAction=false
          */
         enableDockMaximizeAction: false,
@@ -346,6 +349,25 @@ class Workspace extends Container {
      * @protected
      */
     dockMaximizeRestore = null
+
+    /**
+     * The in-flight maximizedNodeId transition as an awaitable — every consumer that must
+     * observe settled maximize presentation (the refresh chain, the continuity sync) awaits
+     * this instead of racing the async clear/apply pair.
+     * @member {Promise|null} dockMaximizeTransition=null
+     * @protected
+     */
+    dockMaximizeTransition = null
+
+    /**
+     * The in-flight maximize FLIP window (a settled-safe promise). Opposite-direction style
+     * mutations and resize re-applies serialize on it: a play's end-of-window cleanup restores
+     * the inline-style snapshot it captured at invert time, so geometry written INSIDE the
+     * window would be silently overwritten by stale values when the window closes.
+     * @member {Promise|null} dockMaximizePlay=null
+     * @protected
+     */
+    dockMaximizePlay = null
 
     /**
      * @param {Object} config
@@ -1584,12 +1606,17 @@ class Workspace extends Container {
         }
 
         let me      = this,
-            animate = me.dockMaximizeMotion !== 'instant';
+            animate = me.dockMaximizeMotion !== 'instant',
+            steps   = [];
 
         me.dockMaximizeMotion = 'animate';
 
-        oldValue && me.clearDockMaximizePresentation({animate: animate && !value});
-        value    && me.applyDockMaximizePresentation(value, {animate})
+        oldValue && steps.push(me.clearDockMaximizePresentation({animate: animate && !value}));
+        value    && steps.push(me.applyDockMaximizePresentation(value, {animate}));
+
+        // The awaitable transition: the settled-surface contract (refreshPromise) and the
+        // continuity sync serialize on this instead of racing fire-and-forget presentation work.
+        me.dockMaximizeTransition = Promise.all(steps).catch(() => null)
     }
 
     /**
@@ -1758,7 +1785,32 @@ class Workspace extends Container {
         played = Promise.resolve(played).catch(() => null);
         played.finally(() => MotionSignal.leave(me));
 
+        me.dockMaximizePlay = played;
+
         return played
+    }
+
+    /**
+     * Engaging maximize closes an in-progress reveal — one overlay tier at a time, and
+     * deterministically: the reveal machine gets an explicit dismissal input rather than the
+     * presentation relying on the overlay's focus/outside-click decay to arrive in time.
+     * @protected
+     */
+    dismissDockRevealOverlays() {
+        let walk = item => {
+            if (!item) {
+                return
+            }
+
+            if (item.ntype === 'dashboard-dock-rail') {
+                item.revealMachine?.outsideClick?.();
+                return
+            }
+
+            (item.items || []).forEach(walk)
+        };
+
+        walk(this.getDockHost()?.items?.[this.dockShellIndex])
     }
 
     /**
@@ -1789,11 +1841,12 @@ class Workspace extends Container {
             zoneId: zone?.id || null
         };
 
-        if (zone) {
-            zone.allowOverdrag       = false;
-            zone.boundaryContainerId = bar.id;
-            zone.enableProxyToPopup  = false
-        }
+        // One coherent batched mutation per direction — the core reactive-config idiom.
+        zone?.set({
+            allowOverdrag      : false,
+            boundaryContainerId: bar.id,
+            enableProxyToPopup : false
+        })
     }
 
     /**
@@ -1810,10 +1863,15 @@ class Workspace extends Container {
      * @protected
      */
     async applyDockMaximizePresentation(nodeId, {animate=true}={}) {
-        let me           = this,
-            tabContainer = me.getDockHost()?.down?.({dockNodeId: nodeId}),
-            host         = null,
-            rect;
+        let me   = this,
+            host = null,
+            rect, tabContainer;
+
+        // Serialize on any in-flight FLIP window: its end-of-window cleanup restores the
+        // inline-style snapshot from invert time, which would overwrite geometry written here.
+        await me.dockMaximizePlay;
+
+        tabContainer = me.getDockHost()?.down?.({dockNodeId: nodeId});
 
         if (!tabContainer || tabContainer.isDestroyed) {
             me.failDockMaximize(nodeId);
@@ -1831,6 +1889,7 @@ class Workspace extends Container {
             return
         }
 
+        me.dismissDockRevealOverlays();
         me.suppressDockMaximizeDragSources(tabContainer);
 
         if (animate) {
@@ -1842,13 +1901,15 @@ class Workspace extends Container {
             }
         }
 
+        // wrapperStyle is the dock's geometry carrier (the reconciler writes split flex through
+        // it) and a shallow-merge descriptor: only the four rect keys ride here, and `null`
+        // removes — the `style` config cannot remove against the wrapperStyle/vdom mirror loop.
         tabContainer.set({
             cls: [...new Set([
                 ...tabContainer.cls.filter(c => c !== 'neo-dock-maximize-restoring'),
                 'neo-dock-maximized'
             ])],
-            style: {
-                ...tabContainer.style,
+            wrapperStyle: {
                 height: `${rect.height}px`,
                 left  : `${rect.left}px`,
                 top   : `${rect.top}px`,
@@ -1856,7 +1917,16 @@ class Workspace extends Container {
             }
         });
 
-        animate && me.playDockMaximizeFlip(host);
+        if (animate) {
+            // The mutation→motion boundary must be deterministic: play() measures Last and
+            // snapshots inline styles for its cleanup, so an un-flushed delta makes it capture
+            // the OLD geometry — and its cleanup would then resurrect the stale inline values.
+            try {
+                await tabContainer.promiseUpdate?.()
+            } catch (error) {/* destroyed mid-flight: the play gate below lands instantly */}
+
+            me.playDockMaximizeFlip(host)
+        }
 
         me.syncDockMaximizeActionIcon(tabContainer, true);
         await me.registerDockMaximizeResizeObserver(true)
@@ -1884,6 +1954,10 @@ class Workspace extends Container {
 
         me.dockMaximizeRestore = null;
 
+        // Same serialization as the apply path: never mutate geometry inside a live FLIP
+        // window whose cleanup will re-stamp its stale snapshot.
+        await me.dockMaximizePlay;
+
         tabContainer = me.getDockHost()?.down?.({dockNodeId: restore.nodeId});
 
         if (tabContainer && !tabContainer.isDestroyed) {
@@ -1898,15 +1972,24 @@ class Workspace extends Container {
                 host = await me.captureDockMaximizeFirst()
             }
 
+            // Null values through the shallow-merge wrapperStyle descriptor are the house
+            // removal idiom (the reconciler un-sets flex the same way).
             tabContainer.set({
                 cls: [
                     ...tabContainer.cls.filter(c => c !== 'neo-dock-maximized'),
                     ...(animate ? ['neo-dock-maximize-restoring'] : [])
                 ],
-                style: {...tabContainer.style, height: null, left: null, top: null, width: null}
+                wrapperStyle: {height: null, left: null, top: null, width: null}
             });
 
             if (animate) {
+                // Same deterministic boundary as the apply path: an un-flushed delta lets play()
+                // snapshot the maximize rect as "inline styles to restore" — its cleanup would
+                // stamp the fullscreen values back onto the restored node.
+                try {
+                    await tabContainer.promiseUpdate?.()
+                } catch (error) {/* destroyed mid-flight */}
+
                 me.playDockMaximizeFlip(host).then(() => {
                     !tabContainer.isDestroyed && (tabContainer.cls = tabContainer.cls.filter(c => c !== 'neo-dock-maximize-restoring'))
                 })
@@ -1953,8 +2036,15 @@ class Workspace extends Container {
         }
 
         switch (operation) {
-            case 'addTab':
-                return tabsNodeId === nodeId;
+            case 'addTab': {
+                // The addTab handler re-dispatches an already-contained item to moveItem, so a
+                // descriptor targeting the maximized node can still RELOCATE the item out of a
+                // sibling — that reaches beyond the node. Neutral only for a catalog-only item
+                // or one already inside the maximized node.
+                let source = Document.findContainingTabsId(me.dockModel, itemId);
+
+                return tabsNodeId === nodeId && (!source || source === nodeId)
+            }
             case 'closeItem':
                 return Document.findContainingTabsId(me.dockModel, itemId) === nodeId;
             case 'moveItem':
@@ -1975,7 +2065,7 @@ class Workspace extends Container {
      * only ever re-applies a transient that survived.
      * @protected
      */
-    syncDockMaximizeProjection() {
+    async syncDockMaximizeProjection() {
         let me     = this,
             nodeId = me.maximizedNodeId,
             tabContainer;
@@ -1987,9 +2077,10 @@ class Workspace extends Container {
         tabContainer = me.getDockHost()?.down?.({dockNodeId: nodeId});
 
         if (tabContainer && me.dockModel?.nodes?.[nodeId]?.type === 'tabs') {
-            me.applyDockMaximizePresentation(nodeId, {animate: false})
+            await me.applyDockMaximizePresentation(nodeId, {animate: false})
         } else {
-            me.failDockMaximize(nodeId)
+            me.failDockMaximize(nodeId);
+            await me.dockMaximizeTransition
         }
     }
 
@@ -2024,7 +2115,11 @@ class Workspace extends Container {
         if (register && me.maximizedNodeId) {
             addon.register({componentId: me.id, id: me.id, windowId});
             me.dockMaximizeResizeObserved = true
-        } else if (!register && me.dockMaximizeResizeObserved) {
+        } else if (!register && me.dockMaximizeResizeObserved && !me.maximizedNodeId) {
+            // The generation guard: a restore's deferred unregister can land AFTER a newer
+            // maximize registered — the observation is keyed on the one workspace id, so tearing
+            // it down here would leave the newer presentation blind. While any maximize is live,
+            // the observation stays; the final restore (transient null) tears down.
             addon.unregister({componentId: me.id, id: me.id, windowId});
             me.dockMaximizeResizeObserved = false
         }
@@ -2056,11 +2151,16 @@ class Workspace extends Container {
             return
         }
 
+        await me.dockMaximizePlay;
+
+        if (me.maximizedNodeId !== nodeId) {
+            return
+        }
+
         tabContainer = me.getDockHost()?.down?.({dockNodeId: nodeId});
 
         tabContainer && !tabContainer.isDestroyed && tabContainer.set({
-            style: {
-                ...tabContainer.style,
+            wrapperStyle: {
                 height: `${rect.height}px`,
                 left  : `${rect.left}px`,
                 top   : `${rect.top}px`,
@@ -2441,7 +2541,10 @@ class Workspace extends Container {
         });
 
         me.syncDockHeaderActions(result?.currentTabs);
-        me.syncDockMaximizeProjection();
+
+        // Awaited on purpose: refreshPromise is the settled-surface contract, and a maximize
+        // presentation that re-applies after it settles is a surface nobody can await.
+        await me.syncDockMaximizeProjection();
 
         // FLIP phase 2: fire-and-forget by default — the addon self-waits for the swap, inverts and
         // plays; the counted motion signal brackets the awaited animation window. Gate on the

--- a/src/dashboard/dock/projection/LayoutAdapter.mjs
+++ b/src/dashboard/dock/projection/LayoutAdapter.mjs
@@ -418,6 +418,12 @@ class LayoutAdapter extends Base {
      * @param {Boolean} [options.enableDockPinAction=false] Projects one persistent pin action into
      *     every tabs header — the collapse-to-rail entry of docking design record §2.7. The workspace
      *     owns the effect and policy synchronization, exactly as it does for close.
+     * @param {Boolean} [options.enableDockMaximizeAction=false] Projects one engine-owned maximize
+     *     toggle into every tabs header, focus-gated by the tab header's own default. The
+     *     workspace owns the transient state, geometry, motion and input policy; `maximize`
+     *     becomes a reserved host-action name while on.
+     * @param {String} [options.dockMaximizeIconCls='far fa-window-maximize'] Icon of the projected
+     *     maximize action in its un-maximized state; the workspace flips it per toggle.
      * @param {Function} [options.onDockActiveIndexChange] Runtime active-item signal for action policy.
      * @param {Function} [options.onDockHeaderAction] Runtime Dock action intent; never persisted.
      * @param {Function} [options.resolveDockHeaderActions] Host resolver for additional tab-header
@@ -427,7 +433,7 @@ class LayoutAdapter extends Base {
      *     (`hidden` / `disabled`), never in a changing list. Actions project BEFORE the engine set,
      *     their intent arrives through `onDockHeaderAction` like any other, and focus gating is the
      *     tab header's own default. Semantic names must be unique per node, and every engine-owned
-     *     name is reserved while its own opt-in is on — `close` under `enableDockCloseAction`, `pin`
+     *     name is reserved while its own opt-in is on — `close` under `enableDockCloseAction`, `maximize` under `enableDockMaximizeAction`, `pin`
      *     under `enableDockPinAction`.
      * @param {Function} [options.onDockVesselConversionIn] Source-owned strict park admission.
      * @param {Function} [options.onDockVesselConversionOut] Source-owned strict re-show admission.
@@ -486,7 +492,9 @@ class LayoutAdapter extends Base {
             dockTabSortBoundaryContainerId   : options.dockTearOutBoundaryContainerId
                 || options.dockWorkspaceBoundaryContainerId
                 || null,
+            dockMaximizeIconCls              : options.dockMaximizeIconCls || 'far fa-window-maximize',
             enableDockCloseAction            : options.enableDockCloseAction === true,
+            enableDockMaximizeAction         : options.enableDockMaximizeAction === true,
             enableDockPinAction              : options.enableDockPinAction === true,
             enableDockTearOut                : options.enableDockTearOut === true,
             enableVesselConversion           : options.enableVesselConversion === true,
@@ -1002,8 +1010,9 @@ class LayoutAdapter extends Base {
               // the key is host-supplied — `constructor` and `__proto__` must miss, exactly as they do
               // in `Operations.applyOperation`'s own-key dispatch.
               reservedActionNames = new Map([
-                  ['close', context.enableDockCloseAction],
-                  ['pin',   context.enableDockPinAction]
+                  ['close',    context.enableDockCloseAction],
+                  ['maximize', context.enableDockMaximizeAction],
+                  ['pin',      context.enableDockPinAction]
               ]);
 
         for (const action of hostActions) {
@@ -1050,6 +1059,12 @@ class LayoutAdapter extends Base {
                     || context.items[activeItemId]?.pinnable === false
                     || !Document.findOwningEdge({nodes: context.nodes}, activeItemId),
                 iconCls   : 'fa fa-thumbtack'
+            }] : []),
+            // Maximize inherits the same focus-gating default; the family ordering contract keeps
+            // the engine set between host actions and the always-visible, always-last `close`.
+            ...(context.enableDockMaximizeAction ? [{
+                action : 'maximize',
+                iconCls: context.dockMaximizeIconCls
             }] : []),
             ...(context.enableDockCloseAction ? [{
                 action    : 'close',

--- a/test/playwright/component/apps/dock-maximize/app.mjs
+++ b/test/playwright/component/apps/dock-maximize/app.mjs
@@ -7,17 +7,32 @@ const fixtureDocument = {
     schema: 'neo.dock.zone.v1',
     root  : 'root',
     items : {
-        alpha: {componentRef: 'Alpha', title: 'Alpha', kind: 'panel'},
-        beta : {componentRef: 'Beta',  title: 'Beta',  kind: 'panel'},
-        frame: {componentRef: 'Frame', title: 'Frame', kind: 'panel'},
-        gamma: {componentRef: 'Gamma', title: 'Gamma', kind: 'panel'}
+        alpha: {componentRef: 'Alpha',  title: 'Alpha',  kind: 'panel'},
+        beta : {componentRef: 'Beta',   title: 'Beta',   kind: 'panel'},
+        // catalog-only: in no tabs node, so an addTab targeting it is a REAL add, never a move
+        delta : {componentRef: 'Delta',  title: 'Delta',  kind: 'panel'},
+        frame : {componentRef: 'Frame',  title: 'Frame',  kind: 'panel'},
+        gamma : {componentRef: 'Gamma',  title: 'Gamma',  kind: 'panel'},
+        pinned: {componentRef: 'Pinned', title: 'Pinned', kind: 'panel'},
+        railed: {componentRef: 'Railed', title: 'Railed', kind: 'panel', autoHidden: true}
     },
     nodes: {
-        root        : {type: 'edge-zone', zones: {center: {nodeId: 'root-split'}}},
+        root        : {type: 'edge-zone', zones: {center: {nodeId: 'root-split'}, right: {nodeId: 'edge-tabs', extent: 0.25}}},
         'root-split': {type: 'split', orientation: 'horizontal', children: ['main-tabs', 'side-tabs'], sizes: [0.6, 0.4]},
         'main-tabs' : {type: 'tabs', items: ['alpha', 'beta'],  activeItemId: 'alpha'},
-        'side-tabs' : {type: 'tabs', items: ['frame', 'gamma'], activeItemId: 'frame'}
+        'side-tabs' : {type: 'tabs', items: ['frame', 'gamma'], activeItemId: 'frame'},
+        'edge-tabs' : {type: 'tabs', items: ['pinned', 'railed'], activeItemId: 'pinned'}
     }
+};
+
+// Spec-readable observer lifecycle log, mirrored onto a probe component that OUTLIVES the
+// workspace — the destroy arm reads it after destroyNeoInstance.
+const observerLog = [];
+
+const syncObserverProbe = () => {
+    const probe = Neo.get('dock-maximize-probe');
+
+    probe && (probe.observerLogJson = JSON.stringify(observerLog))
 };
 
 /**
@@ -42,6 +57,13 @@ class MaximizeFixtureWorkspace extends DockWorkspace {
          * @reactive
          */
         captureCount_: 0,
+        /**
+         * Spec trigger: JSON `{itemId, tabsNodeId, index}` commits one `addTab` operation —
+         * the confinement arms need the catalog-only, in-node, and cross-node variants.
+         * @member {String|null} addTabJson_=null
+         * @reactive
+         */
+        addTabJson_: null,
         /**
          * Spec trigger: setting an item id commits one `closeItem` operation through the
          * ordinary reducer + view-sync pair — the outside-operation arm cannot click a control
@@ -73,6 +95,21 @@ class MaximizeFixtureWorkspace extends DockWorkspace {
          * @reactive
          */
         refreshCount_: 0,
+        /**
+         * Debug trigger: each bump snapshots the main-tabs container's style surfaces into
+         * {@link #styleProbeJson}.
+         * @member {Number} styleProbeCount_=0
+         * @reactive
+         */
+        styleProbeCount_: 0,
+        /**
+         * Spec trigger: each bump awaits the live {@link #refreshPromise} and then SYNCHRONOUSLY
+         * snapshots the maximize surface into {@link #settleJson} — the settled-surface witness:
+         * if re-apply outlived the refresh chain, the snapshot catches it stale.
+         * @member {Number} settleProbeCount_=0
+         * @reactive
+         */
+        settleProbeCount_: 0,
         /**
          * Spec trigger: each bump snapshots the maximize-relevant sort-zone flags of the
          * `main-tabs` header into {@link #zoneSnapshotJson}.
@@ -107,12 +144,104 @@ class MaximizeFixtureWorkspace extends DockWorkspace {
     resizeEventCount = 0
 
     /**
+     * Spec-readable settled-surface snapshot, refreshed per {@link #settleProbeCount} bump.
+     * @member {String|null} settleJson=null
+     */
+    settleJson = null
+
+    /**
      * @param {Object} data
      */
     onDockMaximizeResize(data) {
         this.resizeEventCount++;
 
         return super.onDockMaximizeResize(data)
+    }
+
+    /**
+     * @param {Boolean} register
+     */
+    async registerDockMaximizeResizeObserver(register) {
+        await super.registerDockMaximizeResizeObserver(register);
+
+        observerLog.push(`${register ? 'reg' : 'unreg'}:${this.dockMaximizeResizeObserved}`);
+        syncObserverProbe()
+    }
+
+    /**
+     * @param {...*} args
+     */
+    destroy(...args) {
+        const wasObserved = this.dockMaximizeResizeObserved;
+
+        super.destroy(...args);
+
+        // Post-destroy the engine wipes instance fields, so read "torn" as any non-true value.
+        observerLog.push(`destroy:${wasObserved}->${this.dockMaximizeResizeObserved ? 'live' : 'torn'}`);
+        syncObserverProbe()
+    }
+
+    /**
+     * @param {String|null} value
+     * @param {String|null} oldValue
+     * @protected
+     */
+    afterSetAddTabJson(value, oldValue) {
+        if (oldValue === undefined || !value) {
+            return
+        }
+
+        const descriptor = {operation: 'addTab', ...JSON.parse(value)},
+              result     = this.applyDockZoneOperation(descriptor);
+
+        if (result && !result.errors?.length && result.document) {
+            this.onDockZoneDocumentChange(result.document, descriptor, this)
+        }
+    }
+
+    /**
+     * Debug mirror: worker-side style config + vdom-root style of the main-tabs container.
+     * @member {String|null} styleProbeJson=null
+     */
+    styleProbeJson = null
+
+    /**
+     * @param {Number} value
+     * @param {Number} oldValue
+     * @protected
+     */
+    afterSetStyleProbeCount(value, oldValue) {
+        if (oldValue === undefined) {
+            return
+        }
+
+        const tab = this.getDockHost()?.down?.({dockNodeId: 'main-tabs'});
+
+        this.styleProbeJson = JSON.stringify({
+            cls     : tab?.cls,
+            style   : tab?.style,
+            vdomRoot: tab?.getVdomRoot?.()?.style,
+            wrapper : tab?.wrapperStyle
+        })
+    }
+
+    /**
+     * @param {Number} value
+     * @param {Number} oldValue
+     * @protected
+     */
+    async afterSetSettleProbeCount(value, oldValue) {
+        if (oldValue === undefined) {
+            return
+        }
+
+        await this.refreshPromise;
+
+        this.settleJson = JSON.stringify({
+            maximizedNodeId: this.maximizedNodeId,
+            observed       : this.dockMaximizeResizeObserved,
+            restore        : !!this.dockMaximizeRestore
+        })
     }
 
     /**
@@ -239,7 +368,11 @@ MaximizeFixtureWorkspace = Neo.setupClass(MaximizeFixtureWorkspace);
 export const onStart = () => Neo.app({
     mainView: {
         module: Viewport,
-        items : [{module: MaximizeFixtureWorkspace, flex: 1}]
+        items : [
+            {module: MaximizeFixtureWorkspace, flex: 1},
+            // The observer-log probe: outlives the workspace so the destroy arm can read it.
+            {ntype: 'component', id: 'dock-maximize-probe', style: {display: 'none'}}
+        ]
     },
     name: 'Test.Playwright.DockMaximize'
 });

--- a/test/playwright/component/apps/dock-maximize/app.mjs
+++ b/test/playwright/component/apps/dock-maximize/app.mjs
@@ -1,0 +1,245 @@
+import DockWorkspace from '../../../../../src/dashboard/dock/Workspace.mjs';
+import Persistence   from '../../../../../src/dashboard/dock/model/Persistence.mjs';
+import Viewport      from '../../../../../src/container/Viewport.mjs';
+import '../../../../../src/tab/Container.mjs';
+
+const fixtureDocument = {
+    schema: 'neo.dock.zone.v1',
+    root  : 'root',
+    items : {
+        alpha: {componentRef: 'Alpha', title: 'Alpha', kind: 'panel'},
+        beta : {componentRef: 'Beta',  title: 'Beta',  kind: 'panel'},
+        frame: {componentRef: 'Frame', title: 'Frame', kind: 'panel'},
+        gamma: {componentRef: 'Gamma', title: 'Gamma', kind: 'panel'}
+    },
+    nodes: {
+        root        : {type: 'edge-zone', zones: {center: {nodeId: 'root-split'}}},
+        'root-split': {type: 'split', orientation: 'horizontal', children: ['main-tabs', 'side-tabs'], sizes: [0.6, 0.4]},
+        'main-tabs' : {type: 'tabs', items: ['alpha', 'beta'],  activeItemId: 'alpha'},
+        'side-tabs' : {type: 'tabs', items: ['frame', 'gamma'], activeItemId: 'frame'}
+    }
+};
+
+/**
+ * @summary Browser fixture for the engine-owned maximize toggle: both action flags on, a split
+ * document with two tabs nodes, and an iframe pane whose browsing context is the no-reparent
+ * witness. The reactive trigger configs below are the spec's cross-worker RPC: a component spec
+ * can only reach the app worker through `getConfigs`/`setConfigs`, so every worker-side probe is
+ * a config write that recomputes a spec-readable mirror field.
+ */
+class MaximizeFixtureWorkspace extends DockWorkspace {
+    static config = {
+        /**
+         * @member {String} className='Test.Playwright.Component.DockMaximize.Workspace'
+         * @protected
+         */
+        className: 'Test.Playwright.Component.DockMaximize.Workspace',
+        /**
+         * Spec trigger: each bump captures a perspective of the live committed document into
+         * {@link #perspectiveJson}, volatile envelope fields stripped — the byte-equality arm
+         * compares captures taken maximized and not.
+         * @member {Number} captureCount_=0
+         * @reactive
+         */
+        captureCount_: 0,
+        /**
+         * Spec trigger: setting an item id commits one `closeItem` operation through the
+         * ordinary reducer + view-sync pair — the outside-operation arm cannot click a control
+         * that sits under the maximized plane, which is itself part of the contract.
+         * @member {String|null} closeItemId_=null
+         * @reactive
+         */
+        closeItemId_: null,
+        /**
+         * @member {Boolean} enableDockCloseAction=true
+         */
+        enableDockCloseAction: true,
+        /**
+         * @member {Boolean} enableDockMaximizeAction=true
+         */
+        enableDockMaximizeAction: true,
+        /**
+         * @member {String} id='dock-maximize-workspace'
+         */
+        id: 'dock-maximize-workspace',
+        /**
+         * @member {Object} layout={ntype:'vbox',align:'stretch'}
+         */
+        layout: {ntype: 'vbox', align: 'stretch'},
+        /**
+         * Spec trigger: each bump re-runs {@link #refreshDockWorkspace} WITHOUT a committed
+         * operation — the continuity arm's non-operation re-projection source.
+         * @member {Number} refreshCount_=0
+         * @reactive
+         */
+        refreshCount_: 0,
+        /**
+         * Spec trigger: each bump snapshots the maximize-relevant sort-zone flags of the
+         * `main-tabs` header into {@link #zoneSnapshotJson}.
+         * @member {Number} zoneSnapshotCount_=0
+         * @reactive
+         */
+        zoneSnapshotCount_: 0
+    }
+
+    /**
+     * Spec-readable mirror of the committed document, refreshed on every commit.
+     * @member {String|null} docJson=null
+     */
+    docJson = null
+
+    /**
+     * Spec-readable perspective capture, refreshed per {@link #captureCount} bump.
+     * @member {String|null} perspectiveJson=null
+     */
+    perspectiveJson = null
+
+    /**
+     * Spec-readable sort-zone flag snapshot, refreshed per {@link #zoneSnapshotCount} bump.
+     * @member {String|null} zoneSnapshotJson=null
+     */
+    zoneSnapshotJson = null
+
+    /**
+     * Spec-readable delivery witness for the maximize resize observation.
+     * @member {Number} resizeEventCount=0
+     */
+    resizeEventCount = 0
+
+    /**
+     * @param {Object} data
+     */
+    onDockMaximizeResize(data) {
+        this.resizeEventCount++;
+
+        return super.onDockMaximizeResize(data)
+    }
+
+    /**
+     * @param {Object} config
+     */
+    construct(config) {
+        super.construct(config);
+
+        // The proven deferred-boot dance: seed the empty shell, then commit the real document —
+        // the reconciler replaces the shell at `dockShellIndex` rather than inserting blind.
+        this.add(this.projectDockModel());
+        this.onDockZoneDocumentChange(structuredClone(fixtureDocument))
+    }
+
+    /**
+     * @param {Number} value
+     * @param {Number} oldValue
+     * @protected
+     */
+    afterSetCaptureCount(value, oldValue) {
+        if (oldValue === undefined || !this.dockModel) {
+            return
+        }
+
+        const {layout} = Persistence.capturePerspective(this.dockModel, {title: 'spec'});
+
+        // The envelope stamps identity + revision metadata per capture; the arm compares the
+        // captured MODEL, so volatile envelope fields are stripped from the comparison.
+        this.perspectiveJson = JSON.stringify(layout, (key, val) =>
+            ['createdAt', 'layoutId', 'revision', 'updatedAt'].includes(key) ? undefined : val
+        )
+    }
+
+    /**
+     * @param {String|null} value
+     * @param {String|null} oldValue
+     * @protected
+     */
+    afterSetCloseItemId(value, oldValue) {
+        if (oldValue === undefined || !value) {
+            return
+        }
+
+        const descriptor = {operation: 'closeItem', itemId: value},
+              result     = this.applyDockZoneOperation(descriptor);
+
+        if (result && !result.errors?.length && result.document) {
+            this.onDockZoneDocumentChange(result.document, descriptor, this)
+        }
+    }
+
+    /**
+     * @param {Number} value
+     * @param {Number} oldValue
+     * @protected
+     */
+    afterSetRefreshCount(value, oldValue) {
+        if (oldValue === undefined) {
+            return
+        }
+
+        // Fire-and-forget: the continuity arm polls the DOM outcome.
+        this.refreshDockWorkspace()
+    }
+
+    /**
+     * @param {Number} value
+     * @param {Number} oldValue
+     * @protected
+     */
+    afterSetZoneSnapshotCount(value, oldValue) {
+        if (oldValue === undefined) {
+            return
+        }
+
+        const zone = this.getDockHost()?.down?.({dockNodeId: 'main-tabs'})?.getTabBar?.()?.sortZone || null;
+
+        this.zoneSnapshotJson = JSON.stringify(zone && {
+            allowOverdrag      : zone.allowOverdrag,
+            boundaryContainerId: zone.boundaryContainerId,
+            enableProxyToPopup : zone.enableProxyToPopup
+        })
+    }
+
+    /**
+     * @param {Object} document
+     * @param {Object} [descriptor]
+     * @param {Object} [source]
+     */
+    onDockZoneDocumentChange(document, descriptor, source) {
+        super.onDockZoneDocumentChange(document, descriptor, source);
+        this.docJson = JSON.stringify(this.dockModel)
+    }
+
+    /**
+     * @param {String} itemId
+     * @param {Object} item
+     * @returns {Object}
+     */
+    resolvePane(itemId, item) {
+        if (itemId === 'frame') {
+            // A real nested browsing context: re-parenting an iframe reloads it, so its child
+            // window is the strongest identity witness a maximize round-trip can have.
+            return {
+                ntype: 'component',
+                id   : 'dock-maximize-frame',
+                tag  : 'iframe',
+                vdom : {tag: 'iframe', src: 'about:blank'},
+                style: {border: '0', height: '100%', width: '100%'}
+            }
+        }
+
+        return {
+            ntype: 'component',
+            id   : `dock-maximize-pane-${itemId}`,
+            style: {alignItems: 'center', display: 'flex', justifyContent: 'center'},
+            text : item?.title || itemId
+        }
+    }
+}
+
+MaximizeFixtureWorkspace = Neo.setupClass(MaximizeFixtureWorkspace);
+
+export const onStart = () => Neo.app({
+    mainView: {
+        module: Viewport,
+        items : [{module: MaximizeFixtureWorkspace, flex: 1}]
+    },
+    name: 'Test.Playwright.DockMaximize'
+});

--- a/test/playwright/component/apps/dock-maximize/index.html
+++ b/test/playwright/component/apps/dock-maximize/index.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Neo.mjs Component Test App</title>
+</head>
+<body>
+    <script src="../../../../../src/MicroLoader.mjs" type="module"></script>
+</body>
+</html>

--- a/test/playwright/component/apps/dock-maximize/neo-config.json
+++ b/test/playwright/component/apps/dock-maximize/neo-config.json
@@ -1,0 +1,9 @@
+{
+    "appPath"         : "test/playwright/component/apps/dock-maximize/app.mjs",
+    "basePath"        : "../../../../../",
+    "environment"     : "development",
+    "mainPath"        : "./Main.mjs",
+    "mainThreadAddons": ["DockFlip", "DragDrop", "Navigator", "ResizeObserver", "Stylesheet"],
+    "themes"          : ["neo-theme-neo-dark", "neo-theme-neo-light"],
+    "useSharedWorkers": false
+}

--- a/test/playwright/component/dashboard/DockMaximize.spec.mjs
+++ b/test/playwright/component/dashboard/DockMaximize.spec.mjs
@@ -33,7 +33,9 @@ const setWorkspace = (page, configs) => page.evaluate(
     {id: WORKSPACE_ID, ...configs}
 );
 
-const tabsNode = (page, index) => page.locator('.neo-dashboard-dock-tabs').nth(index);
+const tabsNodeWith = (page, tabText) => page.locator('.neo-dashboard-dock-tabs', {
+    has: page.locator(`.neo-tab-header-button:has-text("${tabText}")`)
+});
 
 const tabButton = (node, text) => node.locator('.neo-tab-header-button', {hasText: text});
 
@@ -61,7 +63,7 @@ test.beforeEach(async ({page}) => {
 
 test.describe('dock maximize — presentation, never topology', () => {
     test('the toggle is focus-gated beside an always-visible close, in the frozen order', async ({page}) => {
-        const main = tabsNode(page, 0);
+        const main = tabsNodeWith(page, 'Alpha');
 
         // Focus-gated through the toolbar's geometry-preserving carrier: the maximize control is
         // rendered but context-inactive until the container holds focus; the close action's
@@ -80,7 +82,7 @@ test.describe('dock maximize — presentation, never topology', () => {
     });
 
     test('maximize paints the measured workspace rect on the SAME node — iframe intact — and Escape restores with focus return', async ({page}) => {
-        const side = tabsNode(page, 1);
+        const side = tabsNodeWith(page, 'Frame');
 
         await page.evaluate(() => {
             const frame = document.getElementById('dock-maximize-frame');
@@ -133,7 +135,7 @@ test.describe('dock maximize — presentation, never topology', () => {
     });
 
     test('the committed document and captured perspectives never observe maximize', async ({page}) => {
-        const main = tabsNode(page, 0);
+        const main = tabsNodeWith(page, 'Alpha');
 
         await setWorkspace(page, {captureCount: 1});
 
@@ -162,7 +164,7 @@ test.describe('dock maximize — presentation, never topology', () => {
     });
 
     test('inside-the-node operations keep maximize, outside operations clear it terminally, and continuity re-applies iff the node survives', async ({page}) => {
-        const main = tabsNode(page, 0);
+        const main = tabsNodeWith(page, 'Alpha');
 
         await tabButton(main, 'Alpha').click();
         await actionButton(main, 'fa-window-maximize').click();
@@ -200,7 +202,7 @@ test.describe('dock maximize — presentation, never topology', () => {
     });
 
     test('while maximized, the workspace resize observation re-measures the rect live', async ({page}) => {
-        const main = tabsNode(page, 0);
+        const main = tabsNodeWith(page, 'Alpha');
 
         await tabButton(main, 'Alpha').click();
         await actionButton(main, 'fa-window-maximize').click();
@@ -219,7 +221,7 @@ test.describe('dock maximize — presentation, never topology', () => {
     });
 
     test('while maximized, cross-zone and tear-out drag flags suppress and lift exactly on restore', async ({page}) => {
-        const main = tabsNode(page, 0);
+        const main = tabsNodeWith(page, 'Alpha');
 
         await setWorkspace(page, {zoneSnapshotCount: 1});
 
@@ -250,8 +252,105 @@ test.describe('dock maximize — presentation, never topology', () => {
         expect(JSON.parse((await readWorkspace(page, ['zoneSnapshotJson']))[0])).toEqual(JSON.parse(before))
     });
 
+    test('addTab confinement: relocating a sibling item clears; catalog-only and in-node adds keep maximize', async ({page}) => {
+        const main = tabsNodeWith(page, 'Alpha');
+
+        await tabButton(main, 'Alpha').click();
+        await actionButton(main, 'fa-window-maximize').click();
+        await expect(page.locator('.neo-dock-maximized')).toHaveCount(1);
+
+        // A catalog-only item added INTO the maximized node is a real add — confined.
+        await setWorkspace(page, {addTabJson: JSON.stringify({itemId: 'delta', tabsNodeId: 'main-tabs', index: 2})});
+        await expect(tabButton(main, 'Delta')).toHaveCount(1);
+        await expect(page.locator('.neo-dock-maximized')).toHaveCount(1);
+
+        // An in-node reorder through the addTab→moveItem redirect — confined.
+        await setWorkspace(page, {addTabJson: JSON.stringify({itemId: 'beta', tabsNodeId: 'main-tabs', index: 0})});
+        await expect(page.locator('.neo-dock-maximized')).toHaveCount(1);
+        expect(await readWorkspace(page, ['maximizedNodeId'])).toEqual(['main-tabs']);
+
+        // Relocating a SIBLING's item into the maximized node reaches beyond it: the addTab
+        // handler re-dispatches to a cross-node moveItem, and the pre-clear must fire.
+        await setWorkspace(page, {addTabJson: JSON.stringify({itemId: 'gamma', tabsNodeId: 'main-tabs', index: 1})});
+        await expect(page.locator('.neo-dock-maximized')).toHaveCount(0);
+        expect(await readWorkspace(page, ['maximizedNodeId'])).toEqual([null])
+    });
+
+    test('engaging maximize dismisses a live reveal overlay — one overlay tier at a time', async ({page}) => {
+        const visibleOverlay = page.locator('.neo-dashboard-dock-reveal-overlay:not(.neo-dashboard-dock-reveal-overlay-hidden)');
+
+        // Open the auto-hidden item's transient reveal from its rail tab.
+        await page.locator('.neo-dashboard-dock-edge-rail').getByText('Railed').click();
+        await expect(visibleOverlay).toHaveCount(1);
+
+        // Engage maximize WITHOUT a pointer interaction (setConfigs), so no generic
+        // outside-click/focus-leave dismissal can fire first — the deterministic dismissal in
+        // the presentation apply is the only thing that can close the overlay here.
+        await setWorkspace(page, {maximizedNodeId: 'main-tabs'});
+
+        await expect(page.locator('.neo-dock-maximized')).toHaveCount(1);
+        await expect(visibleOverlay).toHaveCount(0)
+    });
+
+    test('the observation lives exactly as long as a presentation — teardown, rapid regeneration, destroy', async ({page}) => {
+        await setWorkspace(page, {maximizedNodeId: 'main-tabs'});
+        await expect.poll(async () => (await readWorkspace(page, ['dockMaximizeResizeObserved']))[0]).toBe(true);
+
+        // Ordinary restore tears down.
+        await setWorkspace(page, {maximizedNodeId: null});
+        await expect.poll(async () => (await readWorkspace(page, ['dockMaximizeResizeObserved']))[0]).toBe(false);
+
+        // Rapid A → restore → B: the old restore's deferred unregister must not blind the new
+        // generation — B must end observed with resize delivery live.
+        await setWorkspace(page, {maximizedNodeId: 'main-tabs'});
+        await setWorkspace(page, {maximizedNodeId: null});
+        await setWorkspace(page, {maximizedNodeId: 'side-tabs'});
+        await expect.poll(async () => await readWorkspace(page, ['maximizedNodeId', 'dockMaximizeResizeObserved']))
+            .toEqual(['side-tabs', true]);
+
+        const before = (await readWorkspace(page, ['resizeEventCount']))[0],
+              size   = page.viewportSize();
+
+        await page.setViewportSize({height: size.height - 80, width: size.width - 80});
+        await expect.poll(async () => (await readWorkspace(page, ['resizeEventCount']))[0], {timeout: 10_000}).toBeGreaterThan(before);
+
+        // The fail-safe clear tears down.
+        await setWorkspace(page, {maximizedNodeId: 'ghost-tabs'});
+        await expect.poll(async () => await readWorkspace(page, ['maximizedNodeId', 'dockMaximizeResizeObserved']))
+            .toEqual([null, false]);
+
+        // Destroy while observed tears down at the addon — read through the surviving probe.
+        await setWorkspace(page, {maximizedNodeId: 'main-tabs'});
+        await expect.poll(async () => (await readWorkspace(page, ['dockMaximizeResizeObserved']))[0]).toBe(true);
+
+        await page.evaluate(() => Neo.worker.App.destroyNeoInstance('dock-maximize-workspace'));
+
+        await expect.poll(async () => {
+            const reply = await page.evaluate(() => Neo.worker.App.getConfigs({id: 'dock-maximize-probe', keys: ['observerLogJson']})),
+                  log   = JSON.parse((reply?.data ?? reply)?.[0] || '[]');
+
+            return log[log.length - 1]
+        }).toBe('destroy:true->torn')
+    });
+
+    test('re-projection reapply is part of the settled refresh surface', async ({page}) => {
+        const main = tabsNodeWith(page, 'Alpha');
+
+        await tabButton(main, 'Alpha').click();
+        await actionButton(main, 'fa-window-maximize').click();
+        await expect(page.locator('.neo-dock-maximized')).toHaveCount(1);
+
+        // An in-node operation re-projects; a consumer awaiting refreshPromise must already see
+        // the re-applied presentation AND the live observation — the settled-surface contract.
+        await setWorkspace(page, {closeItemId: 'beta'});
+        await setWorkspace(page, {settleProbeCount: 1});
+
+        await expect.poll(async () => JSON.parse((await readWorkspace(page, ['settleJson']))[0] || 'null'))
+            .toEqual({maximizedNodeId: 'main-tabs', observed: true, restore: true})
+    });
+
     test('both transitions ride the FLIP motion window and settle clean', async ({page}) => {
-        const main = tabsNode(page, 0);
+        const main = tabsNodeWith(page, 'Alpha');
 
         await tabButton(main, 'Alpha').click();
         await actionButton(main, 'fa-window-maximize').click();
@@ -281,6 +380,15 @@ test.describe('dock maximize — presentation, never topology', () => {
         await actionButton(main, 'fa-window-minimize').click();
 
         await page.waitForFunction(() => document.querySelector('.neo-dock-maximize-restoring') !== null, undefined, {timeout: 3000});
+
+        // The restore glide is a REAL inverted transform on the restoring node, not only the
+        // paint-order sentinel.
+        await page.waitForFunction(() => {
+            const el = document.querySelector('.neo-dock-maximize-restoring');
+
+            return el && el.style.transform !== ''
+        }, undefined, {timeout: 3000});
+
         await expect(page.locator('.neo-dock-maximized')).toHaveCount(0);
         await page.waitForFunction(() => document.querySelector('.neo-dock-maximize-restoring') === null);
 
@@ -288,6 +396,15 @@ test.describe('dock maximize — presentation, never topology', () => {
             const el = document.getElementById('dock-maximize-pane-alpha')?.closest('.neo-dashboard-dock-tabs');
 
             return el && !el.style.top && !el.style.width && el.style.transform === ''
+        }, undefined, {timeout: 8000}).catch(async () => {
+            const residual = await page.evaluate(() => document.getElementById('dock-maximize-pane-alpha')
+                ?.closest('.neo-dashboard-dock-tabs')?.getAttribute('style'));
+
+            await setWorkspace(page, {styleProbeCount: 1});
+
+            const worker = (await readWorkspace(page, ['styleProbeJson']))[0];
+
+            throw new Error(`restore left residual inline style: ${residual} · worker-side: ${worker}`)
         })
     })
 });

--- a/test/playwright/component/dashboard/DockMaximize.spec.mjs
+++ b/test/playwright/component/dashboard/DockMaximize.spec.mjs
@@ -195,10 +195,11 @@ test.describe('dock maximize — presentation, never topology', () => {
         await page.waitForFunction(() => document.querySelectorAll('.neo-dock-maximized').length === 1);
         expect(await readWorkspace(page, ['maximizedNodeId'])).toEqual(['main-tabs']);
 
-        // …and the fail-safe clears an unresolvable one — never a half state.
+        // …and the fail-safe clears an unresolvable one — never a half state. Eventual by
+        // contract: the clear is deterministic, not synchronous with the config write.
         await setWorkspace(page, {maximizedNodeId: 'ghost-tabs'});
         await page.waitForFunction(() => document.querySelectorAll('.neo-dock-maximized').length === 0);
-        expect(await readWorkspace(page, ['maximizedNodeId'])).toEqual([null])
+        await expect.poll(async () => (await readWorkspace(page, ['maximizedNodeId']))[0]).toBe(null)
     });
 
     test('while maximized, the workspace resize observation re-measures the rect live', async ({page}) => {

--- a/test/playwright/component/dashboard/DockMaximize.spec.mjs
+++ b/test/playwright/component/dashboard/DockMaximize.spec.mjs
@@ -1,0 +1,293 @@
+import {test, expect} from '@playwright/test';
+
+/**
+ * The engine-owned dock maximize toggle (`Neo.dashboard.dock.Workspace#enableDockMaximizeAction`),
+ * witnessed on a rendered workspace rather than on projection JSON:
+ *
+ * - **Presentation, never topology.** The pane paints the MEASURED workspace rect in place — the
+ *   same DOM node, the same iframe browsing context — and the committed document plus captured
+ *   perspectives stay byte-identical through the whole round-trip.
+ * - **The operation boundary.** Operations confined to the maximized node (activating a tab,
+ *   closing a tab inside it) keep it maximized through the survived-transient continuity rule;
+ *   any operation reaching outside clears it terminally, before the refresh re-projects.
+ * - **Input + motion contract.** Escape restores with focus returning to the active header
+ *   button; cross-zone/tear-out drag flags suppress while the in-strip zone stays armed; both
+ *   transitions ride the DockFlip motion window and collapse to the instant path under reduced
+ *   motion.
+ *
+ * The fixture's reactive trigger configs are the spec's only cross-worker RPC: worker-side probes
+ * are `setConfigs` writes that recompute `getConfigs`-readable mirror fields.
+ */
+
+const WORKSPACE_ID = 'dock-maximize-workspace';
+
+const readWorkspace = async (page, keys) => {
+    // The main-realm remote answers with the worker-message envelope; the values ride `.data`.
+    const reply = await page.evaluate(data => Neo.worker.App.getConfigs(data), {id: WORKSPACE_ID, keys});
+
+    return reply?.data ?? reply
+};
+
+const setWorkspace = (page, configs) => page.evaluate(
+    data => Neo.worker.App.setConfigs(data),
+    {id: WORKSPACE_ID, ...configs}
+);
+
+const tabsNode = (page, index) => page.locator('.neo-dashboard-dock-tabs').nth(index);
+
+const tabButton = (node, text) => node.locator('.neo-tab-header-button', {hasText: text});
+
+const actionButton = (node, glyph) => node.locator(`.neo-tab-header-toolbar .neo-button:has([class*="${glyph}"])`);
+
+const maximizedRectMatchesWorkspace = page => page.waitForFunction(() => {
+    const el = document.querySelector('.neo-dock-maximized'),
+          ws = document.getElementById('dock-maximize-workspace');
+
+    if (!el || !ws) return false;
+
+    const a = el.getBoundingClientRect(),
+          b = ws.getBoundingClientRect();
+
+    return Math.abs(a.top - b.top) < 1.5 && Math.abs(a.left - b.left) < 1.5
+        && Math.abs(a.width - b.width) < 1.5 && Math.abs(a.height - b.height) < 1.5
+});
+
+test.beforeEach(async ({page}) => {
+    await page.goto('test/playwright/component/apps/dock-maximize/index.html');
+    await page.waitForSelector('#dock-maximize-workspace', {state: 'attached'});
+    await page.waitForSelector('#dock-maximize-frame',     {state: 'attached'});
+    await page.waitForSelector('.neo-tab-header-button',   {state: 'visible'})
+});
+
+test.describe('dock maximize — presentation, never topology', () => {
+    test('the toggle is focus-gated beside an always-visible close, in the frozen order', async ({page}) => {
+        const main = tabsNode(page, 0);
+
+        // Focus-gated through the toolbar's geometry-preserving carrier: the maximize control is
+        // rendered but context-inactive until the container holds focus; the close action's
+        // `contextual: false` exemption is the visible contrast.
+        await expect(actionButton(main, 'fa-window-maximize')).toHaveClass(/neo-toolbar-action-context-inactive/);
+        await expect(actionButton(main, 'fa-times')).not.toHaveClass(/neo-toolbar-action-context-inactive/);
+
+        await tabButton(main, 'Alpha').click();
+        await expect(actionButton(main, 'fa-window-maximize')).not.toHaveClass(/neo-toolbar-action-context-inactive/);
+
+        // The frozen ordering contract, measured as geometry: maximize renders before close.
+        const maxBox   = await actionButton(main, 'fa-window-maximize').boundingBox(),
+              closeBox = await actionButton(main, 'fa-times').boundingBox();
+
+        expect(maxBox.x).toBeLessThan(closeBox.x)
+    });
+
+    test('maximize paints the measured workspace rect on the SAME node — iframe intact — and Escape restores with focus return', async ({page}) => {
+        const side = tabsNode(page, 1);
+
+        await page.evaluate(() => {
+            const frame = document.getElementById('dock-maximize-frame');
+
+            window.__frameEl              = frame;
+            frame.dataset.witness         = 'kept';
+            frame.contentWindow.__witness = 'kept'
+        });
+
+        await tabButton(side, 'Frame').click();
+        await actionButton(side, 'fa-window-maximize').click();
+
+        await expect(page.locator('.neo-dock-maximized')).toHaveCount(1);
+        await maximizedRectMatchesWorkspace(page);
+
+        expect(await readWorkspace(page, ['maximizedNodeId'])).toEqual(['side-tabs']);
+
+        // No re-parent: the identical element, the identical browsing context. A re-parented
+        // iframe reloads, wiping `contentWindow` expando state.
+        expect(await page.evaluate(() => {
+            const frame = document.getElementById('dock-maximize-frame');
+
+            return frame === window.__frameEl
+                && frame.dataset.witness === 'kept'
+                && frame.contentWindow.__witness === 'kept'
+        })).toBe(true);
+
+        await page.keyboard.press('Escape');
+
+        await expect(page.locator('.neo-dock-maximized')).toHaveCount(0);
+        await page.waitForFunction(() => {
+            const el = document.getElementById('dock-maximize-frame')?.closest('.neo-dashboard-dock-tabs');
+
+            return el && !el.style.top && !el.style.width
+        });
+
+        expect(await readWorkspace(page, ['maximizedNodeId'])).toEqual([null]);
+
+        expect(await page.evaluate(() => {
+            const frame = document.getElementById('dock-maximize-frame');
+
+            return frame === window.__frameEl && frame.contentWindow.__witness === 'kept'
+        })).toBe(true);
+
+        // Focus returned to the restored node's active header button.
+        await page.waitForFunction(() =>
+            document.activeElement?.classList?.contains('neo-tab-header-button')
+            && document.activeElement.textContent.includes('Frame')
+        )
+    });
+
+    test('the committed document and captured perspectives never observe maximize', async ({page}) => {
+        const main = tabsNode(page, 0);
+
+        await setWorkspace(page, {captureCount: 1});
+
+        const [docBefore, perspectiveBefore] = await readWorkspace(page, ['docJson', 'perspectiveJson']);
+
+        await tabButton(main, 'Alpha').click();
+        await actionButton(main, 'fa-window-maximize').click();
+        await expect(page.locator('.neo-dock-maximized')).toHaveCount(1);
+
+        await setWorkspace(page, {captureCount: 2});
+
+        const [docDuring, perspectiveDuring, nodeId] =
+            await readWorkspace(page, ['docJson', 'perspectiveJson', 'maximizedNodeId']);
+
+        expect(nodeId).toBe('main-tabs');
+        expect(docDuring).toBe(docBefore);
+        expect(perspectiveDuring).toBe(perspectiveBefore);
+
+        // Restore through the same toggle — its icon flipped to the restore half.
+        await actionButton(main, 'fa-window-minimize').click();
+        await expect(page.locator('.neo-dock-maximized')).toHaveCount(0);
+
+        const [docAfter] = await readWorkspace(page, ['docJson']);
+
+        expect(docAfter).toBe(docBefore)
+    });
+
+    test('inside-the-node operations keep maximize, outside operations clear it terminally, and continuity re-applies iff the node survives', async ({page}) => {
+        const main = tabsNode(page, 0);
+
+        await tabButton(main, 'Alpha').click();
+        await actionButton(main, 'fa-window-maximize').click();
+        await expect(page.locator('.neo-dock-maximized')).toHaveCount(1);
+
+        // setActiveItem INSIDE the maximized node: switching tabs keeps it maximized — this is
+        // the second click of any real session, and the reason the operation boundary is scoped.
+        await tabButton(main, 'Beta').click();
+        await expect(page.locator('.neo-dock-maximized')).toHaveCount(1);
+        expect(await readWorkspace(page, ['maximizedNodeId'])).toEqual(['main-tabs']);
+
+        // closeItem INSIDE (the node survives): still maximized.
+        await actionButton(main, 'fa-times').click();
+        await expect(tabButton(main, 'Beta')).toHaveCount(0);
+        await expect(page.locator('.neo-dock-maximized')).toHaveCount(1);
+
+        // closeItem OUTSIDE: clears terminally — driven through the reducer because the control
+        // it would take sits under the maximized plane, which is itself part of the contract.
+        await setWorkspace(page, {closeItemId: 'gamma'});
+        await expect(page.locator('.neo-dock-maximized')).toHaveCount(0);
+        expect(await readWorkspace(page, ['maximizedNodeId'])).toEqual([null]);
+
+        // Continuity: a NON-operation re-projection re-applies a surviving transient…
+        await setWorkspace(page, {maximizedNodeId: 'main-tabs'});
+        await expect(page.locator('.neo-dock-maximized')).toHaveCount(1);
+
+        await setWorkspace(page, {refreshCount: 1});
+        await page.waitForFunction(() => document.querySelectorAll('.neo-dock-maximized').length === 1);
+        expect(await readWorkspace(page, ['maximizedNodeId'])).toEqual(['main-tabs']);
+
+        // …and the fail-safe clears an unresolvable one — never a half state.
+        await setWorkspace(page, {maximizedNodeId: 'ghost-tabs'});
+        await page.waitForFunction(() => document.querySelectorAll('.neo-dock-maximized').length === 0);
+        expect(await readWorkspace(page, ['maximizedNodeId'])).toEqual([null])
+    });
+
+    test('while maximized, the workspace resize observation re-measures the rect live', async ({page}) => {
+        const main = tabsNode(page, 0);
+
+        await tabButton(main, 'Alpha').click();
+        await actionButton(main, 'fa-window-maximize').click();
+        await maximizedRectMatchesWorkspace(page);
+
+        // The observation exists exactly as long as the presentation does.
+        await expect.poll(async () => (await readWorkspace(page, ['dockMaximizeResizeObserved']))[0]).toBe(true);
+
+        const original = page.viewportSize();
+
+        await page.setViewportSize({height: original.height - 120, width: original.width - 160});
+
+        // Delivery witnessed, then the re-measured rect re-applied.
+        await expect.poll(async () => (await readWorkspace(page, ['resizeEventCount']))[0], {timeout: 10_000}).toBeGreaterThan(0);
+        await maximizedRectMatchesWorkspace(page)
+    });
+
+    test('while maximized, cross-zone and tear-out drag flags suppress and lift exactly on restore', async ({page}) => {
+        const main = tabsNode(page, 0);
+
+        await setWorkspace(page, {zoneSnapshotCount: 1});
+
+        const [before] = await readWorkspace(page, ['zoneSnapshotJson']);
+
+        // The engine default: the workspace root is the ordinary cross-zone boundary.
+        expect(JSON.parse(before).boundaryContainerId).toBe(WORKSPACE_ID);
+
+        await tabButton(main, 'Alpha').click();
+        await actionButton(main, 'fa-window-maximize').click();
+        await expect(page.locator('.neo-dock-maximized')).toHaveCount(1);
+
+        await setWorkspace(page, {zoneSnapshotCount: 2});
+
+        const flags = JSON.parse((await readWorkspace(page, ['zoneSnapshotJson']))[0]);
+
+        // In-strip sorting stays armed — the zone lives on, clamped to its own toolbar; the
+        // cross-zone exit and the popup grammar cannot fire.
+        expect(flags.allowOverdrag).toBe(false);
+        expect(flags.enableProxyToPopup).toBe(false);
+        expect(flags.boundaryContainerId).not.toBe(WORKSPACE_ID);
+
+        await page.keyboard.press('Escape');
+        await expect(page.locator('.neo-dock-maximized')).toHaveCount(0);
+
+        await setWorkspace(page, {zoneSnapshotCount: 3});
+
+        expect(JSON.parse((await readWorkspace(page, ['zoneSnapshotJson']))[0])).toEqual(JSON.parse(before))
+    });
+
+    test('both transitions ride the FLIP motion window and settle clean', async ({page}) => {
+        const main = tabsNode(page, 0);
+
+        await tabButton(main, 'Alpha').click();
+        await actionButton(main, 'fa-window-maximize').click();
+
+        // The maximize glide: DockFlip installs the inverted transform and releases it into the
+        // token-timed transition — a transient non-empty inline transform on the maximized node
+        // is the motion, witnessed mid-flight. (The instant-path degradations — reduced motion,
+        // hidden documents, frame starvation — are the addon's own spec-covered contract; this
+        // arm proves the maximize toggle actually rides that contract.)
+        await page.waitForFunction(() => {
+            const el = document.querySelector('.neo-dock-maximized');
+
+            return el && el.style.transform !== ''
+        }, undefined, {timeout: 3000});
+
+        // …and settles clean: the transform releases, the measured rect owns the geometry.
+        await page.waitForFunction(() => {
+            const el = document.querySelector('.neo-dock-maximized');
+
+            return el && el.style.transform === ''
+        });
+        await maximizedRectMatchesWorkspace(page);
+
+        // The restore glide: the workspace holds `neo-dock-maximize-restoring` (the paint-order
+        // hold) for exactly the motion window — it must appear with the gesture and leave when
+        // the play settles, leaving no inline rect values behind.
+        await actionButton(main, 'fa-window-minimize').click();
+
+        await page.waitForFunction(() => document.querySelector('.neo-dock-maximize-restoring') !== null, undefined, {timeout: 3000});
+        await expect(page.locator('.neo-dock-maximized')).toHaveCount(0);
+        await page.waitForFunction(() => document.querySelector('.neo-dock-maximize-restoring') === null);
+
+        await page.waitForFunction(() => {
+            const el = document.getElementById('dock-maximize-pane-alpha')?.closest('.neo-dashboard-dock-tabs');
+
+            return el && !el.style.top && !el.style.width && el.style.transform === ''
+        })
+    })
+});

--- a/test/playwright/unit/dashboard/DockLayoutAdapter.spec.mjs
+++ b/test/playwright/unit/dashboard/DockLayoutAdapter.spec.mjs
@@ -440,6 +440,72 @@ test.describe('Neo.dashboard.dock.projection.LayoutAdapter', () => {
         expect(bare.vdom).toBeUndefined()
     });
 
+    test('projects the opt-in engine-owned maximize toggle between host actions and close', () => {
+        const
+            model       = createModel(),
+            intents     = [],
+            resolvePane = componentRef => ({ntype: 'dashboard-panel', reference: componentRef}),
+
+            disabled = DockLayoutAdapter.project(model, {resolveComponentRef: resolvePane}),
+
+            enabled = DockLayoutAdapter.project(model, {
+                enableDockCloseAction   : true,
+                enableDockMaximizeAction: true,
+                onDockHeaderAction      : data => intents.push(data),
+                resolveComponentRef     : resolvePane,
+                resolveDockHeaderActions: () => [{action: 'filter', iconCls: 'fa fa-filter'}]
+            }),
+
+            disabledMain = getProjectedChildren(disabled)[0],
+            enabledMain  = getProjectedChildren(enabled)[0],
+            maximize     = enabledMain.headerActions[1];
+
+        // Default off = byte-identical: no action slot materialises for the flag alone.
+        expect(disabledMain.headerActions).toBeUndefined();
+
+        // The frozen ordering contract: host actions → engine set → close, always last.
+        expect(enabledMain.headerActions.map(action => action.action)).toEqual(['filter', 'maximize', 'close']);
+
+        // Maximize rides the tab header's focus-gating default — no `contextual` opt-out, which is
+        // the close action's exemption alone.
+        expect(maximize.contextual).toBeUndefined();
+        expect(maximize.iconCls).toBe('far fa-window-maximize');
+
+        // The icon is workspace-owned and threads through as an option.
+        const themed = getProjectedChildren(DockLayoutAdapter.project(model, {
+            dockMaximizeIconCls     : 'fa fa-expand',
+            enableDockMaximizeAction: true,
+            resolveComponentRef     : resolvePane
+        }))[0];
+
+        expect(themed.headerActions.map(action => action.action)).toEqual(['maximize']);
+        expect(themed.headerActions[0].iconCls).toBe('fa fa-expand');
+
+        // Intent arrives like any other action, with its tabs node identified.
+        const tabContainer = {id: 'live-tabs'};
+
+        enabledMain.listeners.headerAction({action: 'maximize', tabContainer});
+        expect(intents).toEqual([{action: 'maximize', dockNodeId: 'main-tabs', tabContainer}])
+    });
+
+    test('reserves the maximize name exactly while its flag is on', () => {
+        const model       = createModel(),
+              resolvePane = componentRef => ({ntype: 'dashboard-panel', reference: componentRef}),
+              project     = (resolveDockHeaderActions, extra={}) => () => DockLayoutAdapter.project(model, {
+                  resolveComponentRef: resolvePane, resolveDockHeaderActions, ...extra
+              });
+
+        // Same failure class as a host `close`: the host copy would win `getActionItem` and capture
+        // the engine's icon sync and intent — silently.
+        expect(project(() => [{action: 'maximize'}], {enableDockMaximizeAction: true}))
+            .toThrow(/"maximize" is reserved while enableDockMaximizeAction is on/);
+
+        // Scoped, not blanket: with the engine action off, the name belongs to whoever projects it.
+        const hostOwned = getProjectedChildren(project(() => [{action: 'maximize', iconCls: 'fa fa-expand'}])())[0];
+
+        expect(hostOwned.headerActions.map(action => action.action)).toEqual(['maximize'])
+    });
+
     test('split children release the flexbox min-content floor: committed sizes stay the sole geometry authority', () => {
         let result = DockLayoutAdapter.project(createModel(), {
                 resolveComponentRef: componentRef => ({


### PR DESCRIPTION
Resolves #17928

> 🌿 A pane can now fill the workspace without the layout ever hearing about it — after this change, "maximize moved my topology" is unsayable.

Dock tabs nodes get the engine-owned maximize toggle: a focus-gated header action beside `close` that paints the MEASURED workspace rect onto the live node — a class plus four inline values, never `inset: 0`, never a re-parent, never a committed operation. `Escape` restores with focus returning to the active header button; a maximize-scoped ResizeObserver registration re-measures live; both transitions FLIP-glide, and the siblings glide too — maximize markers ride every tabs node lazily at gesture time, so the reflow around the vacated flow slot animates instead of snapping. Operations confined to the maximized node defer to the deterministic survived-transient rule (switching tabs inside a maximized pane keeps it maximized); anything beyond it clears terminally before applying.

Evidence: L2 (headless component battery on a rendered workspace: real browser, real themes, real iframe browsing context) → L2 required (every close-target AC is DOM/worker-observable; no runtime effects beyond the component sandbox). Residual: none.

## AC Evidence
| AC-1 | unit `DockLayoutAdapter.spec.mjs` — "projects the opt-in engine-owned maximize toggle between host actions and close" + "reserves the maximize name exactly while its flag is on": order, gating default (no `contextual` key), icon threading, byte-identical projection when off, guard scoped to the flag |
| AC-2 | component `DockMaximize.spec.mjs` arm 2 — same element handle across the round-trip, `dataset` witness intact, iframe `contentWindow` expando survives (a re-parent reloads the browsing context and would wipe it) |
| AC-3 | component arm 3 — committed-document JSON byte-identical before/during/after; `Persistence.capturePerspective` captures (volatile envelope fields stripped) byte-identical maximized vs not |
| AC-4 | component arm 2 — maximized rect equals the measured workspace rect (±1.5px), `Escape` restores, inline rect values removed, focus lands on the restored node's active header button; arm 5 adds the live re-measure on viewport resize (delivery counter + rect follow) |
| AC-5 | component arm 7 — mid-flight inline transform witnessed on the maximize glide; `neo-dock-maximize-restoring` held for exactly the restore-motion window, no inline values left behind. Instant-path degradations are `DockFlip`'s own spec-covered contract; this leaf reuses `play()` behind the same capability gate + `MotionSignal` bracket as `refreshDockWorkspace` |
| AC-6 | component arm 4 — tab activation + in-node close keep the presentation; an out-of-node `closeItem` clears terminally before the refresh; the continuity rule re-applies across a non-operation refresh and the fail-safe clears an unresolvable id |

## Deltas from ticket
- **The op-clear rule gained node-confinement** (ticket body updated first — design sketch, the "input while maximized" ledger row, AC-6 added; the intake seat pinged for the delta re-check): the literal "any committed operation clears" made a tab click INSIDE a maximized pane restore it on the second click of any real session. Node-confined operations (`setActiveItem` on it; `closeItem`/`moveItem`/`addTab` within it) now defer to the already-frozen survived-transient rule; `Workspace#isDockMaximizeNeutralOperation` is the classifier.
- **Opaque surface**: `.neo-dock-maximized` paints `var(--dock-maximize-background, var(--neo-background-color, #fff))` — the covered layout reflows underneath, and a transparent header band ghosted the covered node's chrome through (witnessed visually before the fix; all four themes define the fallback token).
- **ResizeObserver delivery**: the addon routes resize domEvents strictly to `componentIds`, so the registration passes `componentId` alongside `id` (the addon's documented `register` contract). A sibling engine caller with the same omission is flagged as a follow-up candidate, not folded in.

## Test Evidence
Outside CI:
- Visual pass in a live browser (dev server, `neo-theme-neo-dark`): focus-gating appears/disappears with container focus; maximize paints the full rect with an opaque surface (the pre-token run showed the covered node's header text and close button ghosting through — the token kills it); Escape restores with layout, icon and focus intact.
- Delivery bisect receipt: `dockMaximizeResizeObserved: true` with `resizeEventCount: 0` isolated the missing-`componentId` routing gap before the fix; the resize arm now witnesses delivery AND the re-applied rect.

## Post-Merge Validation
- [ ] A consumer workspace with `enableDockMaximizeAction: true` on a real multi-node perspective: maximize/restore across themes, including one pane hosting a live iframe.

## Commits
- 6129839843 — feat: adapter action + reserved-name guard; Workspace transient/presentation/motion/input machinery; SCSS surface, z-order, restore hold
- 8aa314a663 — test: two unit arms (projection + guard) and the 7-arm component battery + dock-maximize fixture app (iframe pane, RPC-by-config triggers)

Authored by Vega (Fable 5, Claude Code). Session 914dffcd-0057-46a5-a0c6-9ca807fd5c91.
