### PR TITLE
fix(grid): name the component when releasing a native resize target (#17954)

### DIFF
--- a/src/component/wrapper/MonacoEditor.mjs
+++ b/src/component/wrapper/MonacoEditor.mjs
@@ -383,9 +383,13 @@ class MonacoEditor extends Base {
     destroy(...args) {
         let me = this;
 
+        // `componentId` names the holder to drop. The addon refcounts observation per component and
+        // unobserves only once a target's holder list is empty, so a payload carrying just `id`
+        // removes nothing and leaves the native observer attached to a destroyed editor.
         me.mounted && Neo.main.addon.ResizeObserver.unregister({
-            id      : me.id,
-            windowId: me.windowId
+            componentId: me.id,
+            id         : me.id,
+            windowId   : me.windowId
         });
 
         Neo.main.addon.MonacoEditor.destroyInstance({

--- a/src/grid/Container.mjs
+++ b/src/grid/Container.mjs
@@ -330,6 +330,15 @@ class GridContainer extends BaseContainer {
     }
 
     /**
+     * @summary Observes, or stops observing, this grid's own box.
+     *
+     * `componentId` and `id` carry the same value here and are still both required: `id` is the DOM
+     * target the addon observes, while `componentId` is the App-Worker holder it refcounts. The
+     * addon unobserves a target only once its holder list is empty, and `unregister` removes exactly
+     * `data.componentId` — so a payload naming only `id` asks to remove an anonymous holder, leaves
+     * the real one in place, and releases nothing while looking like a teardown. `list.Buffered`
+     * carries the same contract.
+     *
      * @param {Boolean} mounted
      * @protected
      */
@@ -337,7 +346,7 @@ class GridContainer extends BaseContainer {
         let me             = this,
             {windowId}     = me,
             ResizeObserver = await Neo.currentWorker.getAddon('ResizeObserver', windowId),
-            resizeParams   = {id: me.id, windowId};
+            resizeParams   = {componentId: me.id, id: me.id, windowId};
 
         if (mounted) {
             ResizeObserver.register(resizeParams);
@@ -1035,9 +1044,12 @@ class GridContainer extends BaseContainer {
         me.verticalScrollbar?.destroy();
         me.scrollManager.destroy();
 
+        // `componentId` names the holder to drop; without it the addon removes nothing and the
+        // native observer outlives this grid. See addResizeObserver().
         me.mounted && Neo.main.addon.ResizeObserver.unregister({
-            id      : me.id,
-            windowId: me.windowId
+            componentId: me.id,
+            id         : me.id,
+            windowId   : me.windowId
         });
 
         super.destroy(...args)

--- a/test/playwright/unit/grid/ResizeObserverTeardown.spec.mjs
+++ b/test/playwright/unit/grid/ResizeObserverTeardown.spec.mjs
@@ -102,7 +102,12 @@ test.describe('grid.Container — releasing the native resize target', () => {
 
     test.afterEach(() => {
         Neo.main.addon.ResizeObserver = originalAddon;
-        Neo.currentWorker.getAddon    = originalGetAddon
+        Neo.currentWorker.getAddon    = originalGetAddon;
+
+        // Worker processes are reused across spec files, so an instance left registered here is an
+        // instance the next file inherits. The destroy arm has already torn its own grid down.
+        !grid.isDestroyed && grid.destroy();
+        !store.isDestroyed && store.destroy()
     });
 
     test('destroy names the grid on its unregister, so the holder list can empty', () => {
@@ -137,12 +142,15 @@ test.describe('grid.Container — releasing the native resize target', () => {
     test('the register arm names it as well, so the holder it adds is the one destroy removes', async () => {
         calls = [];
 
-        // Deliberately NOT awaited: the mounted arm continues into `passSizeToBody()`, which waits
-        // on a main-thread measurement that never arrives in unit mode. The register precedes it, so
-        // one macrotask is enough to observe the payload without hanging on the rest of the method.
-        grid.addResizeObserver(true);
+        // The mounted arm continues into `passSizeToBody()`, which measures through
+        // `Neo.main.DomAccess` and, with no main thread, retries itself indefinitely. Left running it
+        // outlives this file: the next spec in the same worker process resumes it, and the addon
+        // suite deletes `Neo.main.DomAccess` on purpose, so the recursion dies there instead — a
+        // failure reported against a file that did nothing wrong. Size hand-off is a separate
+        // contract; this arm is about the register payload, so it is stubbed rather than left loose.
+        grid.passSizeToBody = async () => {};
 
-        await new Promise(resolve => setTimeout(resolve, 0));
+        await grid.addResizeObserver(true);
 
         const [register] = calls.filter(entry => entry.method === 'register');
 

--- a/test/playwright/unit/grid/ResizeObserverTeardown.spec.mjs
+++ b/test/playwright/unit/grid/ResizeObserverTeardown.spec.mjs
@@ -1,0 +1,155 @@
+import {setup} from '../../setup.mjs';
+
+setup({
+    neoConfig: {
+        allowVdomUpdatesInTests: true,
+        unitTestMode           : true,
+        useDomApiRenderer      : true,
+        useVdomWorker          : false
+    },
+    appConfig: {
+        name             : 'GridResizeObserverTeardownTest',
+        vnodeInitialising: false
+    }
+});
+
+import {test, expect}     from '@playwright/test';
+import Neo                from '../../../../src/Neo.mjs';
+import * as core          from '../../../../src/core/_export.mjs';
+import InstanceManager    from '../../../../src/manager/Instance.mjs';
+import GridContainer      from '../../../../src/grid/Container.mjs';
+import Store              from '../../../../src/data/Store.mjs';
+import Toolbar            from '../../../../src/grid/header/Toolbar.mjs';
+import VdomHelper         from '../../../../src/vdom/Helper.mjs';
+import DomApiVnodeCreator from '../../../../src/vdom/util/DomApiVnodeCreator.mjs';
+
+/**
+ * @summary A grid that goes away must release the native ResizeObserver it caused.
+ *
+ * `Neo.main.addon.ResizeObserver` refcounts observation holders by `componentId` and calls
+ * `instance.unobserve(node)` only once a target's holder list is EMPTY — one DOM node may be
+ * observed by several components, so a teardown that did not say who was leaving would blind the
+ * others. `unregister` therefore removes exactly `data.componentId`.
+ *
+ * A caller that omits it asks to remove the anonymous holder. `filter(cid => cid !== undefined)`
+ * strips only `undefined`, the real holder that `manager.DomEvent` contributed survives, the list
+ * never empties, and the native observer keeps a detached node alive with the hidden-document poll
+ * still armed for it. Nothing else picks this up: `DomEvent.unregister` is a `// todo` stub and no
+ * unmount path calls the addon, so these calls are the whole teardown surface.
+ *
+ * That failure is INVISIBLE at the call site — the call is made, it returns, and no behaviour
+ * changes — which is why these sites read as dead code and were nearly deleted outright. The arms
+ * below assert the identity is named, because naming it is the entire difference between a
+ * teardown and a no-op. `list.Buffered` already carries the same contract.
+ *
+ * **Census of every addon consumer**, so the next reader can tell coverage from omission:
+ *
+ * | site | covered by |
+ * |---|---|
+ * | `src/grid/Container.mjs` register/unregister/destroy | these arms |
+ * | `src/component/wrapper/MonacoEditor.mjs:386` destroy | source only — the editor cannot be instantiated in unit mode, so its identical one-line payload rides this contract without a behavioural arm |
+ * | `src/manager/DomEvent.mjs:131` | already correct; it is the holder these arms depend on existing |
+ * | `src/list/Buffered.mjs:167` | already correct — unchanged |
+ *
+ * `component/Canvas.mjs` and `container/Viewport.mjs` name the addon only in config JSDoc and reach
+ * it through `DomEvent`, so they have no payload of their own.
+ */
+test.describe('grid.Container — releasing the native resize target', () => {
+    let calls, grid, store;
+
+    // The addon lives on the main thread; in unit mode `Neo.main.addon.ResizeObserver` is a harness
+    // stub. Recording it captures exactly what the component emits across the worker boundary,
+    // which is the surface under contract here — the addon's own refcount behaviour is pinned in
+    // `test/playwright/unit/main/addon/ResizeObserver.spec.mjs`.
+    const recorder = {
+        register  : data => calls.push({...data, method: 'register'}),
+        unregister: data => calls.push({...data, method: 'unregister'})
+    };
+
+    let originalAddon, originalGetAddon;
+
+    test.beforeEach(async () => {
+        calls = [];
+
+        Neo.main            ??= {};
+        Neo.main.addon      ??= {};
+        originalAddon         = Neo.main.addon.ResizeObserver;
+        Neo.main.addon.ResizeObserver = recorder;
+
+        // `grid.Container#addResizeObserver` resolves the addon through the worker instead of the
+        // namespace, so both doors need the same recorder behind them.
+        originalGetAddon           = Neo.currentWorker.getAddon;
+        Neo.currentWorker.getAddon = async () => recorder;
+
+        store = Neo.create(Store, {
+            keyProperty: 'id',
+            data       : [{id: 1, col1: 'a'}],
+            model      : {fields: [{name: 'id', type: 'Integer'}, {name: 'col1', type: 'String'}]}
+        });
+
+        grid = Neo.create(GridContainer, {
+            appName  : 'GridResizeObserverTeardownTest',
+            height   : 400,
+            width    : 600,
+            store,
+            rowHeight: 40,
+            columns  : [{dataField: 'col1', text: 'Col 1', width: 100}]
+        });
+
+        await grid.initVnode();
+        grid.mounted = true
+    });
+
+    test.afterEach(() => {
+        Neo.main.addon.ResizeObserver = originalAddon;
+        Neo.currentWorker.getAddon    = originalGetAddon
+    });
+
+    test('destroy names the grid on its unregister, so the holder list can empty', () => {
+        calls = [];
+
+        grid.destroy();
+
+        const unregisters = calls.filter(entry => entry.method === 'unregister');
+
+        expect(unregisters.length).toBeGreaterThan(0);
+
+        // The DOM target and the App-Worker holder are two different identities that happen to
+        // share a value here. Asserting BOTH is deliberate: a payload naming only `id` reads as
+        // complete and removes nothing.
+        unregisters.forEach(entry => {
+            expect(entry.id).toBe(grid.id);
+            expect(entry.componentId).toBe(grid.id)
+        })
+    });
+
+    test('unmount names the grid too — an unmounted grid stops being a holder', async () => {
+        calls = [];
+
+        await grid.addResizeObserver(false);
+
+        const [unregister] = calls.filter(entry => entry.method === 'unregister');
+
+        expect(unregister).toBeTruthy();
+        expect(unregister.componentId).toBe(grid.id)
+    });
+
+    test('the register arm names it as well, so the holder it adds is the one destroy removes', async () => {
+        calls = [];
+
+        // Deliberately NOT awaited: the mounted arm continues into `passSizeToBody()`, which waits
+        // on a main-thread measurement that never arrives in unit mode. The register precedes it, so
+        // one macrotask is enough to observe the payload without hanging on the rest of the method.
+        grid.addResizeObserver(true);
+
+        await new Promise(resolve => setTimeout(resolve, 0));
+
+        const [register] = calls.filter(entry => entry.method === 'register');
+
+        expect(register).toBeTruthy();
+
+        // An anonymous holder is never removable: no caller can pass the `undefined` back in a way
+        // that distinguishes it, so it pins the target observed for the life of the document.
+        expect(register.componentId).toBe(grid.id)
+    })
+});

--- a/test/playwright/unit/main/addon/ResizeObserver.spec.mjs
+++ b/test/playwright/unit/main/addon/ResizeObserver.spec.mjs
@@ -368,4 +368,36 @@ test.describe('Neo.main.addon.ResizeObserver — rendering-starvation contract',
         expect(resizeMessages().length).toBe(2);
         expect(resizeMessages()[1].message.data.componentIds).toEqual(['component-2'])
     });
+
+    test('unregister: an unnamed caller removes nothing, and the target stays observed', async () => {
+        setHidden(true);
+
+        makeNode('target-1', 388, 550);
+
+        // Production shape of a component whose teardown is unnamed: `manager.DomEvent` contributes
+        // the real holder, the component's own register contributes an anonymous one.
+        await addon.register({componentId: 'component-1', id: 'target-1'});
+        await addon.register({id: 'target-1'});
+        await wait(200);
+        expect(resizeMessages().length).toBe(1);
+
+        // The teardown every caller outside `list.Buffered` used to make. It names no holder, so the
+        // filter drops only the `undefined` and `component-1` survives — the list never empties, the
+        // native target is never unobserved, and the poll stays armed for a destroyed component.
+        addon.unregister({id: 'target-1'});
+
+        nodeMap.get('target-1').offsetHeight = 600;
+        await wait(200);
+
+        expect(resizeMessages().length).toBe(2);
+        expect(resizeMessages()[1].message.data.componentIds).toEqual(['component-1']);
+
+        // Naming the holder is the whole difference: the same call with `componentId` releases it.
+        addon.unregister({componentId: 'component-1', id: 'target-1'});
+
+        nodeMap.get('target-1').offsetHeight = 700;
+        await wait(200);
+
+        expect(resizeMessages().length).toBe(2)
+    });
 });


### PR DESCRIPTION
Resolves #17954

Every destroyed `grid.Container` and `MonacoEditor` was leaving its native ResizeObserver attached. The addon refcounts observation holders by `componentId` and unobserves a target only once its holder list empties; both components called `unregister({id, windowId})`, so `filter(cid => cid !== data.componentId)` stripped only the `undefined` they had added themselves and left the real holder — the one `manager.DomEvent` contributes — in place. The list never emptied, so `instance.unobserve(node)` never ran, `#lastDispatchedSize` kept its entry, and `syncPollState()` left the hidden-document poll armed for a component that no longer exists. `DomEvent.unregister` is a `// todo` stub and no unmount path calls the addon, so these were the whole teardown surface outside `list.Buffered`. The fix names the component on all four calls, which is the shape `#17579` already established.

Evidence: L2 (unit tier — the real addon driven against a stubbed DOM, and a real grid driven through mount, unmount and destroy) → L2 required (every AC on #17954 is a unit-observable property). Residual: none.

## AC Evidence
| AC-1 | `test/playwright/unit/grid/ResizeObserverTeardown.spec.mjs` + `test/playwright/unit/main/addon/ResizeObserver.spec.mjs:372`. **Two arms, deliberately** — no single unit arm spans the worker boundary, because the component emits into a harness stub rather than into the addon. The grid arms assert the emitted payload names the holder and are RED on the pre-fix tree (`Received: undefined`); the addon arm asserts the consequence directly — two holders on one target, an unnamed `unregister`, and the target still delivering afterwards, then released the moment the same call names its holder. |
| AC-2 | `src/grid/Container.mjs` — `resizeParams` is `{componentId: me.id, id: me.id, windowId}`, covering the register and unregister arms of `addResizeObserver()`; destroy names it too. Pinned by all three grid arms. |
| AC-3 | `src/component/wrapper/MonacoEditor.mjs` destroy names `componentId: me.id`. Source-only — the editor cannot be instantiated in unit mode, so its identical one-line payload rides the addon contract without a behavioural arm of its own. Called out rather than implied. |
| AC-4 | The census table in the spec's JSDoc names all four consumers plus the two already-correct sites (`DomEvent.mjs:131`, `list/Buffered.mjs:167`), so a later reader can tell coverage from omission. |
| AC-5 | `npm run test-unit -- test/playwright/unit/grid/ test/playwright/unit/main/addon/ResizeObserver.spec.mjs` → 79 passed, plus 8/8 on the addon spec after its new arm. |

## Deltas from ticket

**The ticket's own Out of Scope was corrected mid-lane, against a measurement rather than a reading.** It claimed the auto-registration path is merely deferred ~50ms for a dynamically added `resize` listener, which is what `updateDomListeners` reads like. `@neo-opus-vega` then reverted only the `componentId` on the dock-maximize register at her head and measured `resizeEventCount: 0` across a 10s poll with real viewport resizes — no auto registration reached that target at all. The gate that stops it there is unmeasured and belongs to #17928.

This PR does not depend on which reading wins, and that is a design choice rather than luck. Naming `componentId` on **both** of grid's own calls makes its holder self-contained: the array gains exactly one entry and teardown drains it, whether or not `DomEvent` also registered. The alternative disposition on the table — delete grid's register as redundant and rely on the auto path — would have inherited that unmeasured gate.

The register at `:343` is therefore kept rather than deleted. With `componentId` present the addon dedups it against `DomEvent`'s entry, so it costs nothing, and it keeps teardown independent of a path this lane could not prove fires.

## Test Evidence

Mutation, outside CI — each arm must red for its own named property, not for a neighbour's:

- Reverting `resizeParams` to `{id: me.id, windowId}` and running only the register arm → `expect(register.componentId).toBe(grid.id)` fails with `Received: undefined`. The other two arms are unaffected, so the arm is bound to the register payload specifically.
- On the pre-fix tree all three grid arms failed on `componentId` while `expect(entry.id).toBe(grid.id)` passed first — the red is the missing holder identity, not a broken fixture.
- The new addon arm is green before and after by construction: it characterizes the addon, whose refcount contract is correct and untouched here. Stated plainly so it is not read as a falsifier — it is what makes the caller arms mean something.

First run of the grid spec was red for a harness reason (`Neo.get is not a function`, missing side-effect imports) and was fixed before it counted as a witness.

## Post-Merge Validation
- [ ] A long-lived dashboard that creates and drops grids no longer accumulates entries in the addon's `#targetToComponents` — observable only against a real main thread, which is why it is not an AC.
- [ ] `MonacoEditor` teardown confirmed against a real editor instance, closing the one source-only row above.

## Commits
- d46ea32a34 — name the component on all four calls; the three grid arms
- 9534779512 — the addon arm where an unnamed `unregister` releases nothing

Authored by Grace (Anthropic Claude Opus 5, Claude Code). Session 56bc214a-5b55-41a2-848a-cdfa372abbcd.
