### PR TITLE
feat(tab): add inline and standalone chrome variants (#17950)

### DIFF
--- a/resources/scss/src/tab/Container.scss
+++ b/resources/scss/src/tab/Container.scss
@@ -1,4 +1,11 @@
 .neo-tab-container {
+    // The public inline-header hook belongs to the variant selector, not the generic toolbar. A
+    // consumer may set the token on any ancestor; ui:null and standalone containers never match
+    // this rule and therefore keep their established flat paint.
+    &.neo-tab-container-inline > .neo-tab-header-toolbar {
+        background-image: var(--tab-header-inline-background-image, none);
+    }
+
     &.neo-bottom {
         > .neo-tab-body-container {
             border-bottom: 0;

--- a/resources/scss/theme-dark/tab/Container.scss
+++ b/resources/scss/theme-dark/tab/Container.scss
@@ -1,14 +1,12 @@
 :root .neo-theme-dark { // .neo-tab-container
     --tab-container-content-border: 1px solid #3c3f41;
 
-    // Inline is the classic theme's established flush strip, now addressable per instance.
+    // Inline inherits the classic theme's established 25px / square geometry and tightens only
+    // horizontal padding. Keeping inherited defaults out of this block prevents copy-drift while
+    // leaving one measured, deletion-sensitive variant effect.
     &.neo-tab-container-inline > .neo-tab-header-toolbar,
     .neo-tab-container-inline > .neo-tab-header-toolbar {
-        --tab-button-border-radius : 0;
-        --tab-button-gap           : 0;
-        --tab-button-height        : 25px;
-        --tab-button-height-pressed: 25px;
-        --tab-button-padding       : 7px 12px 6px;
+        --tab-button-padding: 7px 10px 6px;
     }
 
     // Standalone gives classic-theme consumers a coherent free-standing card treatment without

--- a/resources/scss/theme-dark/tab/Container.scss
+++ b/resources/scss/theme-dark/tab/Container.scss
@@ -1,3 +1,24 @@
 :root .neo-theme-dark { // .neo-tab-container
     --tab-container-content-border: 1px solid #3c3f41;
+
+    // Inline is the classic theme's established flush strip, now addressable per instance.
+    &.neo-tab-container-inline > .neo-tab-header-toolbar,
+    .neo-tab-container-inline > .neo-tab-header-toolbar {
+        --tab-button-border-radius : 0;
+        --tab-button-gap           : 0;
+        --tab-button-height        : 25px;
+        --tab-button-height-pressed: 25px;
+        --tab-button-padding       : 7px 12px 6px;
+    }
+
+    // Standalone gives classic-theme consumers a coherent free-standing card treatment without
+    // changing the ui:null default above.
+    &.neo-tab-container-standalone > .neo-tab-header-toolbar,
+    .neo-tab-container-standalone > .neo-tab-header-toolbar {
+        --tab-button-border-radius : 8px;
+        --tab-button-gap           : 4px;
+        --tab-button-height        : 40px;
+        --tab-button-height-pressed: 40px;
+        --tab-button-padding       : 7px 16px 6px;
+    }
 }

--- a/resources/scss/theme-light/tab/Container.scss
+++ b/resources/scss/theme-light/tab/Container.scss
@@ -1,3 +1,24 @@
 :root .neo-theme-light { // .neo-tab-container
     --tab-container-content-border: 1px solid #ddd;
+
+    // Inline is the classic theme's established flush strip, now addressable per instance.
+    &.neo-tab-container-inline > .neo-tab-header-toolbar,
+    .neo-tab-container-inline > .neo-tab-header-toolbar {
+        --tab-button-border-radius : 0;
+        --tab-button-gap           : 0;
+        --tab-button-height        : 25px;
+        --tab-button-height-pressed: 25px;
+        --tab-button-padding       : 7px 12px 6px;
+    }
+
+    // Standalone gives classic-theme consumers a coherent free-standing card treatment without
+    // changing the ui:null default above.
+    &.neo-tab-container-standalone > .neo-tab-header-toolbar,
+    .neo-tab-container-standalone > .neo-tab-header-toolbar {
+        --tab-button-border-radius : 8px;
+        --tab-button-gap           : 4px;
+        --tab-button-height        : 40px;
+        --tab-button-height-pressed: 40px;
+        --tab-button-padding       : 7px 16px 6px;
+    }
 }

--- a/resources/scss/theme-light/tab/Container.scss
+++ b/resources/scss/theme-light/tab/Container.scss
@@ -1,14 +1,12 @@
 :root .neo-theme-light { // .neo-tab-container
     --tab-container-content-border: 1px solid #ddd;
 
-    // Inline is the classic theme's established flush strip, now addressable per instance.
+    // Inline inherits the classic theme's established 25px / square geometry and tightens only
+    // horizontal padding. Keeping inherited defaults out of this block prevents copy-drift while
+    // leaving one measured, deletion-sensitive variant effect.
     &.neo-tab-container-inline > .neo-tab-header-toolbar,
     .neo-tab-container-inline > .neo-tab-header-toolbar {
-        --tab-button-border-radius : 0;
-        --tab-button-gap           : 0;
-        --tab-button-height        : 25px;
-        --tab-button-height-pressed: 25px;
-        --tab-button-padding       : 7px 12px 6px;
+        --tab-button-padding: 7px 10px 6px;
     }
 
     // Standalone gives classic-theme consumers a coherent free-standing card treatment without

--- a/resources/scss/theme-neo-dark/tab/Container.scss
+++ b/resources/scss/theme-neo-dark/tab/Container.scss
@@ -1,3 +1,24 @@
 :root .neo-theme-neo-dark { // .neo-tab-container
     --tab-container-content-border: 1px solid var(--sem-color-border-default);
+
+    // Embedded pane chrome uses the semantic 32px density tier and releases the free-standing
+    // radius. The theme's ui:null contract remains the established 48px / 8px treatment.
+    &.neo-tab-container-inline > .neo-tab-header-toolbar,
+    .neo-tab-container-inline > .neo-tab-header-toolbar {
+        --tab-button-border-radius : 0;
+        --tab-button-gap           : 0;
+        --tab-button-height        : var(--sem-height-large);
+        --tab-button-height-pressed: var(--sem-height-large);
+        --tab-button-padding       : 4px var(--sem-spacing-small) 3px;
+    }
+
+    // Standalone explicitly names the theme's existing free-standing treatment.
+    &.neo-tab-container-standalone > .neo-tab-header-toolbar,
+    .neo-tab-container-standalone > .neo-tab-header-toolbar {
+        --tab-button-border-radius : var(--cmp-tab-borderradius);
+        --tab-button-gap           : 0;
+        --tab-button-height        : var(--cmp-tab-height);
+        --tab-button-height-pressed: var(--cmp-tab-height);
+        --tab-button-padding       : 7px var(--cmp-tab-spacinghorizontal) 6px;
+    }
 }

--- a/resources/scss/theme-neo-light/tab/Container.scss
+++ b/resources/scss/theme-neo-light/tab/Container.scss
@@ -1,3 +1,24 @@
 :root .neo-theme-neo-light { // .neo-tab-container
     --tab-container-content-border: 1px solid #ddd;
+
+    // Embedded pane chrome uses the semantic 32px density tier and releases the free-standing
+    // radius. The theme's ui:null contract remains the established 48px / 8px treatment.
+    &.neo-tab-container-inline > .neo-tab-header-toolbar,
+    .neo-tab-container-inline > .neo-tab-header-toolbar {
+        --tab-button-border-radius : 0;
+        --tab-button-gap           : 0;
+        --tab-button-height        : var(--sem-height-large);
+        --tab-button-height-pressed: var(--sem-height-large);
+        --tab-button-padding       : 4px var(--sem-spacing-small) 3px;
+    }
+
+    // Standalone explicitly names the theme's existing free-standing treatment.
+    &.neo-tab-container-standalone > .neo-tab-header-toolbar,
+    .neo-tab-container-standalone > .neo-tab-header-toolbar {
+        --tab-button-border-radius : var(--cmp-tab-borderradius);
+        --tab-button-gap           : 0;
+        --tab-button-height        : var(--cmp-tab-height);
+        --tab-button-height-pressed: var(--cmp-tab-height);
+        --tab-button-padding       : 7px var(--cmp-tab-spacinghorizontal) 6px;
+    }
 }

--- a/src/dashboard/dock/projection/LayoutAdapter.mjs
+++ b/src/dashboard/dock/projection/LayoutAdapter.mjs
@@ -1006,6 +1006,9 @@ class LayoutAdapter extends Base {
             cls         : ['neo-dashboard-dock-tabs'],
             dockNodeId  : nodeId,
             dockNodeType: 'tabs',
+            // A dock tab strip is embedded pane chrome, not a free-standing tab card. `ui` is the
+            // existing component-level styling seam; nothing enters the committed dock document.
+            ui          : 'inline',
             ...(headerActions.length > 0 && {headerActions}),
             ...(context.enableDockCloseAction && {
                 // The empty-tabs fallback receives focus after its last close. A plain div cannot

--- a/src/tab/Container.mjs
+++ b/src/tab/Container.mjs
@@ -45,8 +45,10 @@ class Container extends BaseContainer {
         /**
          * Selects the tab-header chrome for this placement. `inline` is the compact, flush variant for
          * embedding inside pane/header bands; `standalone` is the roomier free-standing variant. `null`
-         * preserves the active theme's established default.
+         * preserves the active theme's established default. This overrides the inherited reactive
+         * config's default without repeating its trailing underscore, per the class-system contract.
          * @member {String|null} ui=null
+         * @reactive
          */
         ui: null,
         /**

--- a/src/tab/Container.mjs
+++ b/src/tab/Container.mjs
@@ -43,6 +43,13 @@ class Container extends BaseContainer {
          */
         ntype: 'tab-container',
         /**
+         * Selects the tab-header chrome for this placement. `inline` is the compact, flush variant for
+         * embedding inside pane/header bands; `standalone` is the roomier free-standing variant. `null`
+         * preserves the active theme's established default.
+         * @member {String|null} ui=null
+         */
+        ui: null,
+        /**
          * You can use null to not mount any items initially
          * @member {Number|null} activeIndex_=0
          * @reactive

--- a/test/playwright/component/tab/ContainerUi.spec.mjs
+++ b/test/playwright/component/tab/ContainerUi.spec.mjs
@@ -9,27 +9,27 @@ const THEMES = [
 
 const EXPECTED = {
     'neo-theme-light': {
-        inline    : {height: '25px', radius: '0px'},
-        null      : {height: '25px', radius: '0px'},
-        standalone: {height: '40px', radius: '8px'},
+        inline    : {height: '25px', padding: '7px 10px 6px', radius: '0px'},
+        null      : {height: '25px', padding: '7px 12px 6px', radius: '0px'},
+        standalone: {height: '40px', padding: '7px 16px 6px', radius: '8px'},
         textColor : 'rgb(43, 43, 43)'
     },
     'neo-theme-dark': {
-        inline    : {height: '25px', radius: '0px'},
-        null      : {height: '25px', radius: '0px'},
-        standalone: {height: '40px', radius: '8px'},
+        inline    : {height: '25px', padding: '7px 10px 6px', radius: '0px'},
+        null      : {height: '25px', padding: '7px 12px 6px', radius: '0px'},
+        standalone: {height: '40px', padding: '7px 16px 6px', radius: '8px'},
         textColor : 'rgb(187, 187, 187)'
     },
     'neo-theme-neo-light': {
-        inline    : {height: '32px', radius: '0px'},
-        null      : {height: '48px', radius: '8px'},
-        standalone: {height: '48px', radius: '8px'},
+        inline    : {height: '32px', padding: '4px 12px 3px', radius: '0px'},
+        null      : {height: '48px', padding: '7px 16px 6px', radius: '8px'},
+        standalone: {height: '48px', padding: '7px 16px 6px', radius: '8px'},
         textColor : 'rgb(69, 75, 66)'
     },
     'neo-theme-neo-dark': {
-        inline    : {height: '32px', radius: '0px'},
-        null      : {height: '48px', radius: '8px'},
-        standalone: {height: '48px', radius: '8px'},
+        inline    : {height: '32px', padding: '4px 12px 3px', radius: '0px'},
+        null      : {height: '48px', padding: '7px 16px 6px', radius: '8px'},
+        standalone: {height: '48px', padding: '7px 16px 6px', radius: '8px'},
         textColor : 'rgb(153, 162, 149)'
     }
 };
@@ -290,5 +290,20 @@ test.describe('Neo.tab.Container — ui variants', () => {
         expect(after.inline).toContain('linear-gradient');
         expect(after.nested).toBe('none');
         expect(after.null).toBe('none')
+    });
+
+    test('a runtime ui change replaces the previous modifier class', async ({page}) => {
+        const root = page.locator('#tab-ui-inline');
+
+        await expect(root).toHaveClass(/neo-tab-container-inline/);
+
+        await page.evaluate(id => Neo.worker.App.setConfigs({id, ui: 'standalone'}), 'tab-ui-inline');
+
+        await expect(root).toHaveClass(/neo-tab-container-standalone/);
+        await expect(root).not.toHaveClass(/neo-tab-container-inline/);
+
+        await page.evaluate(id => Neo.worker.App.setConfigs({id, ui: null}), 'tab-ui-inline');
+
+        await expect(root).not.toHaveClass(/neo-tab-container-inline|neo-tab-container-standalone/)
     })
 });

--- a/test/playwright/component/tab/ContainerUi.spec.mjs
+++ b/test/playwright/component/tab/ContainerUi.spec.mjs
@@ -1,0 +1,294 @@
+import {test, expect} from '@playwright/test';
+
+const THEMES = [
+    'neo-theme-light',
+    'neo-theme-dark',
+    'neo-theme-neo-light',
+    'neo-theme-neo-dark'
+];
+
+const EXPECTED = {
+    'neo-theme-light': {
+        inline    : {height: '25px', radius: '0px'},
+        null      : {height: '25px', radius: '0px'},
+        standalone: {height: '40px', radius: '8px'},
+        textColor : 'rgb(43, 43, 43)'
+    },
+    'neo-theme-dark': {
+        inline    : {height: '25px', radius: '0px'},
+        null      : {height: '25px', radius: '0px'},
+        standalone: {height: '40px', radius: '8px'},
+        textColor : 'rgb(187, 187, 187)'
+    },
+    'neo-theme-neo-light': {
+        inline    : {height: '32px', radius: '0px'},
+        null      : {height: '48px', radius: '8px'},
+        standalone: {height: '48px', radius: '8px'},
+        textColor : 'rgb(69, 75, 66)'
+    },
+    'neo-theme-neo-dark': {
+        inline    : {height: '32px', radius: '0px'},
+        null      : {height: '48px', radius: '8px'},
+        standalone: {height: '48px', radius: '8px'},
+        textColor : 'rgb(153, 162, 149)'
+    }
+};
+
+let componentIds = [];
+
+/** Links the four tab value layers into the persistent component-test document. */
+async function loadThemeStylesheets(page) {
+    const hrefs = THEMES.flatMap(theme => {
+        const directory = theme.replace('neo-theme-', 'theme-'),
+              files     = [
+                  `/dist/development/css/${directory}/tab/Container.css`,
+                  `/dist/development/css/${directory}/tab/Strip.css`,
+                  `/dist/development/css/${directory}/tab/header/Button.css`
+              ];
+
+        if (theme.includes('neo-light') || theme.includes('neo-dark')) {
+            files.unshift(
+                `/dist/development/css/${directory}/design-tokens/Core.css`,
+                `/dist/development/css/${directory}/design-tokens/Semantic.css`,
+                `/dist/development/css/${directory}/design-tokens/Component.css`
+            )
+        }
+
+        return files
+    });
+
+    await page.evaluate(async hrefs => {
+        for (const href of hrefs) {
+            const link = document.createElement('link');
+
+            link.rel  = 'stylesheet';
+            link.href = href;
+
+            await new Promise((resolve, reject) => {
+                link.onload  = resolve;
+                link.onerror = () => reject(new Error(`stylesheet did not load: ${href}`));
+                document.head.appendChild(link)
+            })
+        }
+    }, hrefs)
+}
+
+/** Creates the three contract variants as side-by-side real browser components. */
+async function createVariants(page) {
+    componentIds = await page.evaluate(async () => {
+        const variants = [
+            {id: 'tab-ui-default',       label: 'Theme default', left: 0},
+            {id: 'tab-ui-null',          label: 'Theme default', left: 290, setUi: true, ui: null},
+            {id: 'tab-ui-inline',        label: 'Inline',        left: 580, setUi: true, ui: 'inline'},
+            {id: 'tab-ui-standalone',    label: 'Standalone',    left: 870, setUi: true, ui: 'standalone'}
+        ];
+
+        const ids = [];
+
+        for (const variant of variants) {
+            const bodyItem = variant.ui === 'inline' ? {
+                activeIndex: 0,
+                header     : {text: variant.label},
+                id         : 'tab-ui-nested-null',
+                items      : [{
+                    header: {text: 'Nested theme default'},
+                    ntype : 'component',
+                    text  : 'Nested theme default body'
+                }],
+                ntype: 'tab-container'
+            } : {
+                header: {text: variant.label},
+                ntype : 'component',
+                text  : `${variant.label} body`
+            };
+
+            const config = {
+                activeIndex: 0,
+                height     : 170,
+                id         : variant.id,
+                importPath : '../tab/Container.mjs',
+                items      : [bodyItem],
+                ntype      : 'tab-container',
+                parentId   : 'component-test-viewport',
+                style      : {
+                    left    : `${variant.left}px`,
+                    position: 'absolute',
+                    top     : '0px'
+                },
+                width: 280
+            };
+
+            variant.setUi && (config.ui = variant.ui);
+
+            const result = await Neo.worker.App.createNeoInstance(config);
+
+            if (!result.success) {
+                throw new Error(`TabContainer creation failed: ${result.error.message}`)
+            }
+
+            ids.push(result.id)
+        }
+
+        return ids
+    });
+
+    await Promise.all(componentIds.map(id => page.waitForSelector(`#${id}`, {state: 'attached'})))
+}
+
+/** Replaces the active document theme without retaining a competing theme ancestor. */
+const applyTheme = (page, theme) => page.evaluate(name => {
+    for (const element of [document.body, document.documentElement]) {
+        element.classList.forEach(cls => cls.startsWith('neo-theme-') && element.classList.remove(cls))
+    }
+
+    document.body.classList.add(name);
+
+    return document.body.className
+}, theme);
+
+/** Reads the concrete header paint rather than accepting a loaded stylesheet as evidence. */
+const readVariant = (page, id) => page.evaluate(componentId => {
+    const root    = document.getElementById(componentId),
+          button  = root.querySelector('.neo-tab-header-button'),
+          toolbar = root.querySelector('.neo-tab-header-toolbar'),
+          style   = getComputedStyle(button);
+
+    return {
+        backgroundImage: getComputedStyle(toolbar).backgroundImage,
+        cls            : [...root.classList],
+        height         : style.height,
+        padding        : style.padding,
+        radius         : style.borderRadius,
+        textColor      : getComputedStyle(button.querySelector('.neo-button-text')).color
+    }
+}, id);
+
+/** A generated-id-independent DOM signature for the omitted-vs-explicit-null regression control. */
+const readDomSignature = (page, id) => page.evaluate(componentId => {
+    const visit = element => ({
+        children: [...element.children].map(visit),
+        cls     : [...element.classList].filter(cls => !cls.startsWith('neo-theme-')).sort(),
+        tag     : element.tagName
+    });
+
+    return visit(document.getElementById(componentId))
+}, id);
+
+test.describe('Neo.tab.Container — ui variants', () => {
+    test.beforeEach(async ({page}) => {
+        await page.goto('/test/playwright/component/apps/empty-viewport/index.html');
+        await page.waitForSelector('#component-test-viewport', {state: 'attached'});
+        await loadThemeStylesheets(page);
+        await createVariants(page)
+    });
+
+    test.afterEach(async ({page}) => {
+        await page.evaluate(async ids => {
+            for (const id of ids) {
+                await Neo.worker.App.destroyNeoInstance(id)
+            }
+        }, componentIds);
+
+        componentIds = []
+    });
+
+    for (const theme of THEMES) {
+        test(`${theme}: null stays current while inline and standalone are intentional`, async ({page}, testInfo) => {
+            await applyTheme(page, theme);
+            expect(await page.evaluate(name => document.body.classList.contains(name), theme)).toBe(true);
+
+            const measured = {
+                default   : await readVariant(page, 'tab-ui-default'),
+                inline    : await readVariant(page, 'tab-ui-inline'),
+                null      : await readVariant(page, 'tab-ui-null'),
+                standalone: await readVariant(page, 'tab-ui-standalone')
+            };
+
+            const expectedDefaultClasses = [
+                'neo-flex-align-stretch',
+                'neo-flex-container',
+                'neo-flex-direction-column',
+                'neo-flex-pack-start',
+                'neo-flex-wrap-nowrap',
+                'neo-tab-container',
+                'neo-tab-container-plain',
+                'neo-top'
+            ];
+
+            expect(measured.default.cls.filter(cls => !cls.startsWith('neo-theme-')).sort())
+                .toEqual(expectedDefaultClasses);
+            expect(measured.null.cls.filter(cls => !cls.startsWith('neo-theme-')).sort())
+                .toEqual(expectedDefaultClasses);
+            expect(measured.null.cls).not.toContain('neo-tab-container-inline');
+            expect(measured.null.cls).not.toContain('neo-tab-container-standalone');
+            expect(measured.inline.cls).toContain('neo-tab-container-inline');
+            expect(measured.standalone.cls).toContain('neo-tab-container-standalone');
+
+            for (const variant of ['inline', 'null', 'standalone']) {
+                expect(measured[variant]).toMatchObject({
+                    ...EXPECTED[theme][variant],
+                    textColor: EXPECTED[theme].textColor
+                })
+            }
+
+            expect(measured.default).toMatchObject({
+                ...EXPECTED[theme].null,
+                textColor: EXPECTED[theme].textColor
+            });
+            expect(await readDomSignature(page, 'tab-ui-null'))
+                .toEqual(await readDomSignature(page, 'tab-ui-default'));
+
+            expect(measured.inline.height).not.toBe(measured.standalone.height);
+            expect(measured.inline.radius).not.toBe(measured.standalone.radius);
+
+            await testInfo.attach(`${theme}-tab-ui-comparison.json`, {
+                body       : Buffer.from(JSON.stringify(measured, null, 2)),
+                contentType: 'application/json'
+            });
+            await testInfo.attach(`${theme}-tab-ui-comparison.png`, {
+                body       : await page.screenshot({clip: {height: 180, width: 1180, x: 0, y: 0}}),
+                contentType: 'image/png'
+            })
+        })
+    }
+
+    test('the inline gradient hook is opt-in and cannot leak to ui:null', async ({page}) => {
+        await applyTheme(page, 'neo-theme-neo-light');
+
+        const before = {
+            default: await readVariant(page, 'tab-ui-default'),
+            inline : await readVariant(page, 'tab-ui-inline'),
+            nested : await readVariant(page, 'tab-ui-nested-null'),
+            null   : await readVariant(page, 'tab-ui-null')
+        };
+
+        expect(before.default.backgroundImage).toBe('none');
+        expect(before.inline.backgroundImage).toBe('none');
+        expect(before.nested).toMatchObject({
+            backgroundImage: 'none',
+            height         : '48px',
+            radius         : '8px'
+        });
+        expect(before.null.backgroundImage).toBe('none');
+
+        const after = await page.evaluate(() => {
+            const gradient = 'linear-gradient(rgb(1, 2, 3), rgb(4, 5, 6))';
+
+            // A consumer root is the broadest supported owner. The direct-child selector must paint
+            // the inline header but neither a sibling nor a nested ui:null header.
+            document.body.style.setProperty('--tab-header-inline-background-image', gradient);
+
+            return {
+                default: getComputedStyle(document.querySelector('#tab-ui-default > .neo-tab-header-toolbar')).backgroundImage,
+                inline : getComputedStyle(document.querySelector('#tab-ui-inline > .neo-tab-header-toolbar')).backgroundImage,
+                nested : getComputedStyle(document.querySelector('#tab-ui-nested-null > .neo-tab-header-toolbar')).backgroundImage,
+                null   : getComputedStyle(document.querySelector('#tab-ui-null > .neo-tab-header-toolbar')).backgroundImage
+            }
+        });
+
+        expect(after.default).toBe('none');
+        expect(after.inline).toContain('linear-gradient');
+        expect(after.nested).toBe('none');
+        expect(after.null).toBe('none')
+    })
+});

--- a/test/playwright/unit/dashboard/DockLayoutAdapter.spec.mjs
+++ b/test/playwright/unit/dashboard/DockLayoutAdapter.spec.mjs
@@ -949,6 +949,7 @@ test.describe('Neo.dashboard.dock.projection.LayoutAdapter', () => {
         // owns its computeOverflow static, so nothing reaches back to the adapter). Wiring, not behavior: this
         // pins that the projection carries the plugin, so a silent drop of the injection is caught in CI.
         expect(mainTabs.ntype).toBe('tab-container');
+        expect(mainTabs.ui, 'dock tab strips use the generic embedded-header variant').toBe('inline');
         expect(plugins).toHaveLength(1);
         expect(plugins[0].module).toBe(TabOverflowPlugin);
     });


### PR DESCRIPTION
Resolves #17950

`Neo.tab.Container` now has named `inline` and `standalone` chrome variants on the existing reactive `ui` class seam. Neo themes give `inline` a distinct 32px / square treatment; classic themes inherit their established inline geometry and tighten horizontal padding, while `standalone` supplies the distinct card variant. Dock projections select `inline`, and `ui: null` retains the existing theme default. The public `--tab-header-inline-background-image` hook is owned by the inline container's direct header toolbar, so consumer-root values cannot paint sibling or nested default tabs.

Evidence: L3 (real Chromium computed paint, DOM/class parity, and four-theme screenshot/JSON comparisons) → L3 required (all five close-target UI/theme ACs). No residuals.

## AC Evidence

| AC-1 | CI-covered: `ContainerUi.spec.mjs` renders `inline`, `standalone`, omitted-`ui`, and explicit-`null` specimens under `neo-theme-light`, `neo-theme-dark`, `neo-theme-neo-light`, and `neo-theme-neo-dark`; each arm carries a distinct theme-color positive control plus computed height/radius/padding assertions and screenshot/JSON comparison attachments. The classic inline padding is deletion-sensitive while its 25px / square geometry remains inherited. |
| AC-2 | CI-covered: omitted `ui` and explicit `ui: null` have the same generated-id-independent DOM tag/class signature and the frozen eight-class root set in every theme. |
| AC-3 | CI-covered: `DockLayoutAdapter.spec.mjs` pins `ui: 'inline'` on every projected dock tabs node; the browser spec pins `ui` → `neo-tab-container-inline`; no Workstation file changes are needed. |
| AC-4 | CI-covered: the browser sets `--tab-header-inline-background-image` on the consumer root and proves unset → `none`, set → rendered gradient on the direct inline header only, with sibling and nested `ui: null` headers remaining `none`. |
| AC-5 | CI-covered: the browser pins `neo-tab-container-inline`, `neo-tab-container-standalone`, and the exact null/default class contract. |

## Deltas from ticket

The hook owner is the direct header selector `.neo-tab-container-inline > .neo-tab-header-toolbar`. The direct-child boundary is load-bearing: a descendant selector would paint a nested `ui: null` header, while variant tokens placed on the container would inherit into nested tabs. The component witness includes that nested negative control.

## Test Evidence

All coverage runs in CI.

## Post-Merge Validation

None — every close-target AC is pre-merge verifiable.

## Evolution

The first SCSS pass placed density/radius variables on the variant container. A cascade audit falsified that shape because custom properties inherit into nested tab containers; ownership moved to the direct header toolbar, and the nested-null browser arm now makes that regression red in both the geometry and gradient directions.

Authored by Emmy (GPT-5.6 Sol Ultra, Codex) consuming Vega's handoff — session A 914dffcd-0057-46a5-a0c6-9ca807fd5c91, session B 4426fb43-4968-4084-832e-1830de2e8747.
