### PR TITLE
fix(build): publish the parse5 bundle a consumer cannot rebuild (#17943)

### DIFF
--- a/.github/workflows/check-package-contents.yml
+++ b/.github/workflows/check-package-contents.yml
@@ -40,6 +40,18 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      # `dist/` is gitignored, so a fresh checkout has NONE of the build outputs a publish would
+      # carry — and `npm publish` runs `build-all` first (`buildScripts/release/publish.mjs`, which
+      # bundles parse5 via `buildScripts/build/all.mjs`). Without this step the pack under test is
+      # not the shape that ships: it can still prove nothing forbidden leaked, but it cannot prove a
+      # required artifact is present, because the artifact was never produced on this runner.
+      #
+      # Only parse5 is built, not `build-all`. It is the one build output the package is required to
+      # contain, it takes one esbuild call, and a full build here would cost minutes to prove nothing
+      # this check asserts.
+      - name: Bundle parse5
+        run: npm run bundle-parse5
+
       # A CI checkout has no live `.neo-ai-data/logs`, `sqlite/` or `wake-daemon/`, so a green here
       # proves the resources/content rule but CANNOT prove the Agent OS one — the
       # files it guards do not exist on this runner. That half is covered by the unit spec over the

--- a/.npmignore
+++ b/.npmignore
@@ -68,7 +68,15 @@ resources/content/
 
 /buildScripts/webpack/json/myApps.json
 
-/dist
+# The contents are excluded rather than the directory itself, because an ignore rule on `/dist`
+# cannot be undone: a negation never re-includes a file whose parent directory is excluded. Same
+# shape the `/apps/**/*` rules above use for the same reason.
+/dist/*
+# `src/functional/util/HtmlTemplateProcessor.mjs` imports this bundle by relative path, and
+# `buildScripts/util/templateBuildProcessor.mjs` imports it at module scope — so an installed engine
+# needs it to RUN the dist/esm build, not merely to execute the tree that build emits. It cannot be
+# produced on the consumer side: parse5 and esbuild are both devDependencies.
+!/dist/parse5.mjs
 /docs/output
 /tmp
 

--- a/buildScripts/util/check-package-contents.mjs
+++ b/buildScripts/util/check-package-contents.mjs
@@ -78,6 +78,41 @@ export const FORBIDDEN_PREFIXES = [
 ];
 
 /**
+ * Files the tarball MUST contain. The mirror image of the rules above, and it exists because the
+ * two failures are not symmetric in how they announce themselves: a leak is discovered by anyone who
+ * unpacks the tarball, while a silent DROP is discovered by a consumer, at the point of use, with a
+ * module-not-found error naming a path nobody recognises.
+ *
+ * A `.npmignore` cannot express "keep exactly this file" without help, which is the second reason
+ * this list exists. An ignore rule on a directory is not reversible — a negation never re-includes a
+ * file whose parent directory is excluded — so `/dist/*` plus `!/dist/parse5.mjs` is the only shape
+ * that ships one file out of that tree, and it is one careless edit away from `/dist` again.
+ * @type {Array<{path: String, why: String}>}
+ */
+export const REQUIRED_ENTRIES = [
+    {
+        path: 'dist/parse5.mjs',
+        why : 'src/functional/util/HtmlTemplateProcessor.mjs imports this bundle by relative path, and buildScripts/util/templateBuildProcessor.mjs imports it at module scope — so an installed engine needs it to RUN the dist/esm build, not merely to execute the tree that build emits. A consumer cannot rebuild it: parse5 and esbuild are both devDependencies.'
+    }
+];
+
+/**
+ * @summary Pure predicate: which required entries are missing from the packed set?
+ *
+ * Split out from the pack invocation for the same reason as its counterpart below — the rule is
+ * testable by planting a path list, with no tarball on disk.
+ *
+ * @param {String[]} packedPaths Tarball-relative paths, as reported by `npm pack --json`.
+ * @param {Array<Object>} [rules=REQUIRED_ENTRIES] The presence rules to enforce.
+ * @returns {Array<{path: String, why: String}>} One entry per rule with no matching packed path.
+ */
+export function findMissingEntries(packedPaths, rules = REQUIRED_ENTRIES) {
+    const packed = new Set(packedPaths);
+
+    return rules.filter(rule => !packed.has(rule.path))
+}
+
+/**
  * @summary Pure predicate: which packed paths violate the forbidden-prefix rules?
  *
  * Split out from the `npm pack` invocation so the rule logic is unit-testable without spawning a
@@ -137,10 +172,27 @@ export function parsePackOutput(raw) {
 }
 
 if (import.meta.url === `file://${process.argv[1]}`) {
-    const raw    = execFileSync('npm', ['pack', '--dry-run', '--json'], {cwd: ROOT, encoding: 'utf8', maxBuffer: 64 * 1024 * 1024}),
-          report = parsePackOutput(raw)[0],
-          files  = report.files.map(file => file.path),
-          found  = findForbiddenEntries(files);
+    const raw     = execFileSync('npm', ['pack', '--dry-run', '--json'], {cwd: ROOT, encoding: 'utf8', maxBuffer: 64 * 1024 * 1024}),
+          report  = parsePackOutput(raw)[0],
+          files   = report.files.map(file => file.path),
+          found   = findForbiddenEntries(files),
+          missing = findMissingEntries(files);
+
+    if (missing.length) {
+        console.error(`\x1b[31mcheck-package-contents: ${missing.length} required entr(ies) missing from the npm tarball:\x1b[0m`);
+
+        for (const rule of missing) {
+            console.error(`\n  ${rule.path}`);
+            console.error(`    ${rule.why}`)
+        }
+
+        console.error(`
+Either an .npmignore rule stopped covering this file, or the release build did not produce it before
+packing. Check the pack first — 'npm pack --dry-run --json' is what ships, and the ignore patterns
+are only what someone believes ships.`);
+
+        process.exit(1)
+    }
 
     if (found.length) {
         console.error(`\x1b[31mcheck-package-contents: ${found.length} forbidden entr(ies) in the npm tarball:\x1b[0m`);
@@ -170,5 +222,5 @@ check, and let the pack decide.`);
         process.exit(1)
     }
 
-    console.log(`check-package-contents: OK — ${report.entryCount} files, ${(report.size / 1048576).toFixed(2)} MiB tarball, ${(report.unpackedSize / 1048576).toFixed(2)} MiB unpacked; no forbidden entries.`)
+    console.log(`check-package-contents: OK — ${report.entryCount} files, ${(report.size / 1048576).toFixed(2)} MiB tarball, ${(report.unpackedSize / 1048576).toFixed(2)} MiB unpacked; no forbidden entries, all ${REQUIRED_ENTRIES.length} required entr(ies) present.`)
 }

--- a/test/playwright/unit/buildScripts/checkPackageContents.spec.mjs
+++ b/test/playwright/unit/buildScripts/checkPackageContents.spec.mjs
@@ -138,3 +138,58 @@ test.describe('check-package-contents — fires on private state, not on the tra
         expect(FORBIDDEN_PREFIXES.every(rule => rule.prefix.endsWith('/'))).toBe(true);
     });
 });
+
+/**
+ * The mirror image of the suite above. A leak announces itself to anyone who unpacks the tarball; a
+ * silent DROP announces itself to a consumer, at the point of use, as a module-not-found error naming
+ * a path nobody recognises. Only one of those two is discoverable from this repository, which is why
+ * the presence half needs a gate at all.
+ *
+ * `dist/parse5.mjs` is the case that motivated it: `/dist` was excluded wholesale, so the bundle
+ * `HtmlTemplateProcessor` imports never shipped, and — because `templateBuildProcessor` imports it at
+ * module scope — an installed engine could not even START a `dist/esm` build. The `.npmignore` shape
+ * that fixes it (`/dist/*` plus a negation) is one careless edit away from `/dist` again, and an
+ * ignore rule cannot express "keep exactly this one".
+ */
+test.describe('check-package-contents — a required entry cannot be silently dropped', () => {
+    let findMissingEntries, REQUIRED_ENTRIES;
+
+    test.beforeAll(async () => {
+        ({findMissingEntries, REQUIRED_ENTRIES} =
+            await import('../../../../buildScripts/util/check-package-contents.mjs'));
+    });
+
+    test('FIRES: the parse5 bundle absent from the packed set', () => {
+        // The exact regression `/dist` produced: a plausible-looking tarball with the producer script
+        // present and the artifact it produces missing.
+        const packed = ['src/Neo.mjs', 'buildScripts/build/parse5.mjs', 'package.json'];
+
+        expect(findMissingEntries(packed).map(entry => entry.path)).toEqual(['dist/parse5.mjs'])
+    });
+
+    test('PASSES: the same set once the artifact ships', () => {
+        const packed = ['src/Neo.mjs', 'buildScripts/build/parse5.mjs', 'dist/parse5.mjs'];
+
+        expect(findMissingEntries(packed)).toEqual([])
+    });
+
+    test('the match is EXACT, so a lookalike path cannot satisfy the rule', () => {
+        // A prefix or suffix match would let `dist/esm/dist/parse5.mjs` — the copy the build emits
+        // INTO the output tree — stand in for the published bundle at the root. They are different
+        // files with different consumers, and only the root one is what an installed engine imports.
+        const packed = ['dist/esm/dist/parse5.mjs', 'vendor/dist/parse5.mjs', 'dist/parse5.mjs.map'];
+
+        expect(findMissingEntries(packed).map(entry => entry.path)).toEqual(['dist/parse5.mjs'])
+    });
+
+    test('every required entry carries a reason, because the failure message is the whole product', () => {
+        // Same contract the forbidden rules carry: the consumer reading this failure is holding a
+        // broken install and needs to know what the file is FOR, not merely that it is absent.
+        expect(REQUIRED_ENTRIES.length).toBeGreaterThan(0);
+
+        REQUIRED_ENTRIES.forEach(rule => {
+            expect(rule.path).toBeTruthy();
+            expect(rule.why.length).toBeGreaterThan(40)
+        })
+    })
+});


### PR DESCRIPTION
Resolves #17943

Refs #17931

`src/functional/util/HtmlTemplateProcessor.mjs` imports `../../../dist/parse5.mjs` by relative path, and `buildScripts/util/templateBuildProcessor.mjs` imports the same bundle **at module scope** — so an installed engine needs that file to *run* a `dist/esm` build, not merely to execute the tree the build emits. `.npmignore` excluded `/dist` wholesale, and `parse5` and `esbuild` are both devDependencies, so a consumer had neither the artifact nor its inputs. This ships the artifact, adds the guard that stops it being dropped again, and makes the CI check pack a release-shaped tree so that guard can actually observe presence.

Evidence: L3 (a real `npm pack --dry-run` subprocess against the real tree, plus the guard's own entrypoint run to a red and a green) → L3 required (every remaining AC on #17943 is a property of what npm actually packs). Residual: none.

## AC Evidence
| AC-1 | Decision recorded in #17943 with both rejections on measurement: option 2 refuted by `parse5@8.0.1`'s internal `entities/decode` / `entities/escape` imports — Node exports-map subpaths no browser resolves and `esmDistTransforms#rewriteImportPaths` does not handle; option 3 refuted by `templateBuildProcessor.mjs:2` importing at module scope, so a lazy *runtime* import leaves the build-time consumer dead. |
| AC-4 | `REQUIRED_ENTRIES` + `findMissingEntries` in `check-package-contents.mjs`, with four arms in `checkPackageContents.spec.mjs` — including an exact-match arm proving `dist/esm/dist/parse5.mjs` (the copy the build emits *into* the output tree) cannot stand in for the published bundle at the root. |
| AC-5 | `templateBuildProcessor.mjs` is untouched and now finds the bundle in an installed engine for the first time. `buildScripts/release/publish.mjs:146` runs `build-all` and `buildScripts/build/all.mjs:135` bundles parse5, so the release path produces the artifact before packing — verified by reading both call sites. |

AC-2 and AC-3 are **struck through on #17943 and scope-transferred to #17931**, which owns the installed-engine fixture they require; they were never satisfiable from here. #17931 gained an explicit template-parse AC to receive them. `Refs`, not a second close target — this PR does not deliver #17931.

## Deltas from ticket

**The ticket's own fix sketch was wrong, and I wrote that ticket.** It said "add a negation for `dist/parse5.mjs` in `.npmignore`". That alone ships nothing: an ignore rule on a *directory* is not reversible, because a negation never re-includes a file whose parent is excluded. The working shape excludes the contents — `/dist/*` plus the negation — which is exactly what the `/apps/**/*` rules above it already do.

**The CI check had never been able to test presence.** `dist/` is gitignored, so the runner packed a tree with no build outputs, while `npm publish` runs `build-all` first. The job could prove nothing forbidden leaked and *structurally could not* prove a required artifact was present. Bundling parse5 before the check closes that.

**#17943 gained a Contract Ledger** (RA-2) covering the package path, release producer, `.npmignore` rule, the guard, CI fidelity, and the consumer-validation owner.

## Test Evidence

Outside-CI, on this tree at current `dev`:

- **Same-tree delta, which is the durable claim.** With the fix the pack contains **exactly one more file** than without it, and the only `parse5` paths are `buildScripts/build/parse5.mjs` (the 784-byte producer) and `dist/parse5.mjs` (163 KB). The absolute total is deliberately not quoted: it has been measured at 5328/5329, 5327/5328 and 5335/5336 by two people across three trees this afternoon, moving with unrelated merges every time, while the delta and the two paths never changed. RA-3 was right that the total is the wrong claim to carry.
- **The exclusion is proven against real content, not an empty directory.** `dist/` holds 24,125 files locally across `development`, `esm`, `production`, `highlight`, and the knowledge-base JSONL. One is packed.
- **End-to-end mutation, twice.** Reverting `.npmignore` to `/dist` exits the guard **1**, naming the file and why it matters. Separately, moving `dist/parse5.mjs` aside reproduces the CI failure exactly (**exit 1**) and `npm run bundle-parse5` takes it to **0** — which is what proves the workflow step, not just the rule, is the fix.
- `npm run test-unit -- test/playwright/unit/buildScripts/` → **534 passed**.

## Post-Merge Validation

None. The pack gate now runs pre-merge on a release-shaped tree, which is strictly stronger than observing a published tarball afterwards; and the consumer-side proof is owned by #17931 rather than being a residual of this PR. The publication checkbox an earlier revision carried is removed on RA-2 rather than re-homed, because it duplicated a gate that already runs.

## Commits
- `fix(build): publish the parse5 bundle a consumer cannot rebuild (#17943)`
- `ci(build): the package check must pack a release-shaped tree (#17943)`

Authored by Grace (Anthropic Claude Opus 5, Claude Code). Session 56bc214a-5b55-41a2-848a-cdfa372abbcd.
