### PR TITLE
feat(tab): project overflow as a stable header action (#17951)

### DIFF
--- a/learn/agentos/decisions/0029-docking-design.md
+++ b/learn/agentos/decisions/0029-docking-design.md
@@ -271,9 +271,12 @@ The preview layer carries grouped intent with one additive, optional, runtime-on
 #### Tab overflow
 
 Overflow is a **generic tab-subsystem affordance — not a dock concern, not a model change**. When a `tabs` node's
-headers exceed the available extent, the overflowing tabs collapse behind a floating control whose menu reaches them;
-selection commits through the ordinary `setActiveItem` path. `Neo.tab.plugin.Overflow` owns the partition, while
-`Neo.dashboard.dock.projection.LayoutAdapter.projectTabsNode()` only installs the plugin. Nothing new persists.
+headers exceed the available extent, the overflowing tabs collapse behind a control whose menu reaches them;
+selection commits through the ordinary `setActiveItem` path. `Neo.tab.plugin.Overflow` owns the partition and its
+default remains an out-of-collection floating control. Composed headers with an existing action rail may opt into a
+stable, focus-independent toolbar contribution instead: it occupies the first action slot only while overflowing,
+survives consumer-action replacement, and self-excludes from its own partition/visibility feedback. The dock adapter
+only installs that generic plugin mode. Nothing new persists.
 
 ### §2.5 Core-Lift Clause Disposition
 

--- a/src/dashboard/dock/projection/LayoutAdapter.mjs
+++ b/src/dashboard/dock/projection/LayoutAdapter.mjs
@@ -1081,10 +1081,11 @@ class LayoutAdapter extends Base {
             // hit-test the target zone and commit a `moveItem`. Still one drag system — no parallel pipeline.
             headerToolbar : {
                 // Tab-overflow affordance: when the projected headers exceed the toolbar width, the
-                // overflowing tabs collapse behind a floating overflow control whose menu reaches them
-                // (Neo.tab.plugin.Overflow — a generic tab-subsystem plugin the dock only consumes). Zero
-                // new model state: a menu selection routes through the tab.Container's existing activeIndex.
-                plugins       : [{module: TabOverflowPlugin}],
+                // overflowing tabs collapse behind the first stable header action whose menu reaches them
+                // (Neo.tab.plugin.Overflow — a generic tab-subsystem plugin the dock only consumes). The
+                // generic default stays floating; composed dock headers opt into their owned action rail.
+                // Zero new model state: menu selection routes through tab.Container's existing activeIndex.
+                plugins       : [{module: TabOverflowPlugin, projectAsAction: true}],
                 sortZoneConfig: {
                     module: TabSortZone,
                     // A dock host spans multiple tab strips. Workspace-backed compositions supply

--- a/src/tab/plugin/Overflow.mjs
+++ b/src/tab/plugin/Overflow.mjs
@@ -3,7 +3,7 @@ import Plugin from '../../plugin/Base.mjs';
 
 /**
  * @summary The tab-overflow affordance for a projected tab header toolbar: when headers exceed the
- * available main-axis extent, overflowing tabs collapse behind a floating control whose menu reaches them.
+ * available main-axis extent, overflowing tabs collapse behind one control whose menu reaches them.
  *
  * The pure decision is this plugin's own static {@link Neo.tab.plugin.Overflow.computeOverflow} — a
  * projection concern, nothing persists. This plugin is the RUNTIME complement: it measures the live header extents
@@ -13,13 +13,13 @@ import Plugin from '../../plugin/Base.mjs';
  * constraint). `items` order and `activeItemId` already capture the state; overflow is projection only.
  *
  * It attaches to the projected tab header toolbar (`Neo.tab.header.Toolbar`) — it is NOT a dock-specific
- * `tab.Container` fork (the model contract's Split/Tab Adapter Boundary). The overflow control is an
- * OUT-OF-COLLECTION floating button rooted at `document.body`, deliberately NOT a member of `owner.items`:
- * the control has independent mount/alignment/menu lifecycle and therefore remains outside `owner.items`.
- * Ordinary flat toolbar actions can live in that collection because the tab toolbar and SortZone now expose
- * one explicit tab-button subset; the overflow control is still intentionally not an action or tab. It carries
- * none of a tab button's `activeIndex` click wiring (that lives in `getTabButtonConfig`, which the plugin
- * bypasses), so selecting it opens its menu rather than activating a phantom card.
+ * `tab.Container` fork (the model contract's Split/Tab Adapter Boundary). The default embodiment is the
+ * historic OUT-OF-COLLECTION floating button rooted at `document.body`, with independent mount/alignment/menu
+ * lifecycle. {@link #projectAsAction} instead contributes one stable, focus-independent toolbar action for
+ * composed headers that already own an action rail. The toolbar preserves that contribution across consumer
+ * `actions` replacements; the plugin hides it (removeDom) while everything fits and self-excludes it from
+ * partition geometry and visibility feedback. Neither embodiment is a tab: both bypass `getTabButtonConfig`,
+ * so clicking opens the menu rather than activating a phantom card.
  *
  * Natural-width discipline: overflowing buttons are removed from the DOM (Neo's built-in `hidden` /
  * removeDom), so re-measuring them would collapse their width to 0 and corrupt the next split. The plugin
@@ -43,12 +43,18 @@ class Overflow extends Plugin {
          */
         ntype: 'plugin-tab-overflow',
         /**
-         * Main-axis size (px) the overflow control reserves from the header extent — handed to the pure core as
-         * `controlWidth`, which reserves it ONLY when something overflows (a control that exists only when
-         * needed must not consume space while everything fits). The historic config name stays compatible.
+         * Main-axis size (px) the floating control reserves from the header extent — handed to the pure core as
+         * `controlWidth`, which reserves it ONLY when something overflows. Action projection instead converges
+         * from zero to the contributed button's rendered extent; this historic estimate remains floating-only.
          * @member {Number} controlWidth=40
          */
-        controlWidth: 40
+        controlWidth: 40,
+        /**
+         * Projects the overflow control through the toolbar's stable contribution seam instead of as a
+         * floating `document.body` child. Disabled by default for byte-identical generic behavior.
+         * @member {Boolean} projectAsAction=false
+         */
+        projectAsAction: false
     }
 
     /**
@@ -248,10 +254,10 @@ class Overflow extends Plugin {
 
         me.onResize = me.onResize.bind(me);
 
-        // The control is deliberately outside the owner's component collection and DOM subtree, so container
-        // theme propagation cannot reach it. Keep that floating embodiment subscribed to every component in
-        // the source toolbar's theme chain; button.Base carries the resolved nearest-active theme through to
-        // the generated floating menu.List.
+        // The default floating control is outside the owner's component collection and DOM subtree, so
+        // container theme propagation cannot reach it. Keep that embodiment subscribed to every component in
+        // the source toolbar's theme chain; action mode inherits the same theme natively, and these idempotent
+        // updates keep both embodiments on one menu-theme path.
         //
         // Config subscribers run before the publisher's afterSetTheme() updates its cls carrier. Re-resolve in
         // the next microtask so getTheme() sees the completed ancestor change rather than the prior theme.
@@ -263,7 +269,8 @@ class Overflow extends Plugin {
             });
             if (me.owner.getConfig?.('dock')) {
                 me.observeConfig(me.owner, 'dock', () => {
-                    me.dockRecapturePending = true
+                    me.dockRecapturePending = true;
+                    me.measuredControlWidth = null
                 })
             }
         }
@@ -293,6 +300,7 @@ class Overflow extends Plugin {
      */
     getActionItems() {
         return (this.owner.getActionItems?.() || [])
+            .filter(item => item !== this.control)
             .filter(item => !item.hidden || item.hideMode === 'visibility')
     }
 
@@ -342,6 +350,7 @@ class Overflow extends Plugin {
         let me      = this,
             {owner} = me;
 
+        me.projectAsAction && me.createActionControl();
         owner.addDomListeners([{resize: me.onResize, scope: me}]);
         // Re-run on activation too: selecting a hidden tab flips activeIndex, and active-never-hidden must
         // then surface the newly-active tab into the header (swapping a fitting one into the overflow menu).
@@ -352,8 +361,8 @@ class Overflow extends Plugin {
         owner.on('insert', me.onTabSetChange, me);
         owner.on('remove', me.onTabSetChange, me);
         owner.on('actionsChange', me.onActionSetChange, me);
-        owner.on('actionGeometryChange', me.onActionSetChange, me);
-        owner.on('actionVisibilityChange', me.onActionSetChange, me);
+        owner.on('actionGeometryChange', me.onActionGeometryChange, me);
+        owner.on('actionVisibilityChange', me.onActionVisibilityChange, me);
         me.getTabContainer()?.on('moveTo', me.onTabSetChange, me);
         me.project(true)
     }
@@ -363,6 +372,26 @@ class Overflow extends Plugin {
      */
     onActionSetChange() {
         this.project(false)
+    }
+
+    /**
+     * Action geometry changes alter the tab-exclusive extent. The contributed control's own resize
+     * is intentionally included: it is how action mode replaces its first zero-width estimate with
+     * rendered truth.
+     * @protected
+     */
+    onActionGeometryChange() {
+        this.project(false)
+    }
+
+    /**
+     * Ignores the contributed control's own show/hide signal so its partition verdict cannot re-enter
+     * itself. Availability changes from every other action still re-project the tab extent.
+     * @param {Object} data
+     * @protected
+     */
+    onActionVisibilityChange({component}={}) {
+        component !== this.control && this.project(false)
     }
 
     /**
@@ -540,6 +569,14 @@ class Overflow extends Plugin {
             buttons  = me.getTabButtons(),
             geometry = me.getMainAxisConfig();
 
+        // Retiring an action contribution emits actionsChange synchronously. The destroy interceptor has
+        // already raised isDestroying at that point, but super.destroy() has not yet removed this listener's
+        // identity. Do not start one final DOM round-trip against the retiring control / owner boundary.
+        if (me.isDestroying || me.isDestroyed) {
+            me.resolveProjectionIdle?.();
+            return
+        }
+
         // The tab SortZone deliberately freezes item rectangles for the gesture. A resize/action
         // projection can otherwise hide or show members underneath that snapshot. Queue one sticky
         // pass and drain only after dragEnd restores natural layout.
@@ -643,9 +680,25 @@ class Overflow extends Plugin {
                 coordinateKey = geometry.dimension === 'width' ? 'x' : 'y',
                 ownerStart    = Number(ownerRect?.[startKey] ?? ownerRect?.[coordinateKey]),
                 actionStart   = Number(actionRects[0]?.[startKey] ?? actionRects[0]?.[coordinateKey]),
-                extent        = Number.isFinite(ownerStart) && Number.isFinite(actionStart)
+                ownerSize     = Number(ownerRect?.[geometry.dimension]),
+                actionSize    = actionRects.reduce((sum, rect) => {
+                    let size = Number(rect?.[geometry.dimension]);
+
+                    return sum + (Number.isFinite(size) ? Math.max(0, size) : 0)
+                }, 0),
+                coordinateExtent = Number.isFinite(ownerStart) && Number.isFinite(actionStart)
                     ? Math.max(0, Math.floor(actionStart - ownerStart))
-                    : Math.max(0, Math.floor(ownerRect?.[geometry.dimension] || 0)),
+                    : null,
+                sizeExtent = Number.isFinite(ownerSize)
+                    ? Math.max(0, Math.floor(ownerSize - actionSize))
+                    : null,
+                // Visible tabs can briefly push the action rail beyond the owner after a wide→narrow resize.
+                // Its coordinate then overstates available space and self-sustains an all-visible split. The
+                // rendered action widths provide the owner-bounded ceiling; the coordinate remains authoritative
+                // whenever gaps, margins, or another stricter boundary make it smaller.
+                extent = coordinateExtent === null
+                    ? sizeExtent || 0
+                    : sizeExtent === null ? coordinateExtent : Math.min(coordinateExtent, sizeExtent),
                 tabContainer  = me.getTabContainer(),
                 activeButton  = buttons[tabContainer?.activeIndex] || null,
                 items         = buttons.map(button => ({id: button.id, headerWidth: me.naturalWidths[button.id]}));
@@ -656,7 +709,9 @@ class Overflow extends Plugin {
 
             // 3. The pure decision: active-never-hidden packing, overflow-only control reservation.
             //    The pure core is this plugin's own static (below) — no adapter namespace-reach, no cycle.
-            let controlWidth = Math.max(me.controlWidth, me.measuredControlWidth || 0),
+            let controlWidth = me.projectAsAction
+                    ? me.measuredControlWidth || 0
+                    : Math.max(me.controlWidth, me.measuredControlWidth || 0),
                 {hidden}     = Overflow.computeOverflow({
                     activeItemId: activeButton?.id,
                     controlWidth,
@@ -878,15 +933,48 @@ class Overflow extends Plugin {
     }
 
     /**
-     * Creates / updates / tears down the single overflow control. A menu selection sets the
+     * Creates the hidden, stable toolbar contribution used by {@link #projectAsAction}. It exists before
+     * the first overflow so a consumer `actions` replacement while everything fits cannot erase the future
+     * affordance. The menu is supplied by the first real partition; no empty-menu async work is started.
+     * @returns {Neo.button.Base}
+     * @protected
+     */
+    createActionControl() {
+        let me = this;
+
+        if (me.control) {
+            return me.control
+        }
+
+        if (!Neo.isFunction(me.owner.addActionContribution)) {
+            throw new Error('Neo.tab.plugin.Overflow: projectAsAction requires a toolbar action-contribution owner')
+        }
+
+        me.control = me.owner.addActionContribution({
+            module : Button,
+            cls    : ['neo-tab-overflow-control'],
+            handler: Neo.emptyFn,
+            hidden : true,
+            iconCls: me.getMainAxisConfig().dimension === 'height'
+                ? 'fa fa-ellipsis-vertical'
+                : 'fa fa-ellipsis',
+            role       : 'button',
+            showOnFocus: false,
+            vdom       : {'aria-label': 'More tabs'}
+        });
+
+        return me.control
+    }
+
+    /**
+     * Creates / updates / hides or tears down the single overflow control. A menu selection sets the
      * tab.Container's `activeIndex` (the ordinary activation path); the follow-up measure pass then
      * surfaces the now-active tab by construction (active-never-hidden), so the selected tab is never
      * left in the menu.
      *
      * The control is a `button.Base` with a `menu` config — button.Base builds the dropdown `menu.List`
-     * itself, so no menu is hand-assembled here. It is a floating instance rooted at `document.body` (out
-     * of `owner.items`), and excluded from `getTabButtons()` by identity so it is never measured or hidden
-     * as a tab — see the class note on why the control must stay out of the SortZone-draggable collection.
+     * itself, so no menu is hand-assembled here. Floating mode destroys its body-rooted embodiment when
+     * everything fits; action mode keeps one toolbar contribution and toggles its `hidden` state.
      * @param {Object[]} hiddenMeta  `{text, iconCls, index}` per hidden tab, in header order.
      * @param {Neo.tab.Container} tabContainer
      */
@@ -894,6 +982,22 @@ class Overflow extends Plugin {
         let me = this;
 
         if (hiddenMeta.length < 1) {
+            if (me.projectAsAction) {
+                me.appliedHiddenIds     = null;
+                me.hiddenSignature      = null;
+                me.menuProjectionQueued = false;
+                me.menuRecaptureQueued  = false;
+                me.observedMenuList     = null;
+                if (me.control) {
+                    if (!me.control.hidden) {
+                        me.control.hidden = true
+                    } else if (!me.control.vdom?.removeDom) {
+                        me.control.hide()
+                    }
+                }
+                return
+            }
+
             if (me.control) {
                 let control = me.control;
 
@@ -922,6 +1026,8 @@ class Overflow extends Plugin {
                 cls  : ['neo-tab-overflow-menu'],
                 items: menuItems
             };
+
+        me.projectAsAction && !me.control && me.createActionControl();
 
         if (me.control) {
             let {menuList} = me.control;
@@ -952,7 +1058,13 @@ class Overflow extends Plugin {
             // rejection releases isVnodeInitializing before rethrowing, so the guard above
             // re-opens and a later sync retries. The align follows only a successful mount
             // (mirroring the sync-time re-align below).
-            if (!me.control.mounted && !me.control.isVnodeInitializing && !me.remountArming) {
+            if (me.projectAsAction) {
+                if (me.control.hidden) {
+                    me.control.hidden = false
+                } else if (me.control.vdom?.removeDom) {
+                    me.control.show()
+                }
+            } else if (!me.control.mounted && !me.control.isVnodeInitializing && !me.remountArming) {
                 me.remountArming = true;
 
                 me.control.initVnode(true)
@@ -1016,12 +1128,15 @@ class Overflow extends Plugin {
         // RA-13: re-align against the CURRENT owner rect. A floating component aligns once at mount and does
         // NOT re-align when its target moves. Re-aligning on each sync re-pins it to the current action or
         // owner edge — cheap + idempotent. The e2e owner-exact geometry assertion falsifies its absence.
-        if (me.control?.mounted) {
-            me.control.align   = me.getControlAlign();
+        if (me.control) {
             me.control.iconCls = me.getMainAxisConfig().dimension === 'height'
                 ? 'fa fa-ellipsis-vertical'
                 : 'fa fa-ellipsis';
-            me.control.alignTo()
+
+            if (!me.projectAsAction && me.control.mounted) {
+                me.control.align = me.getControlAlign();
+                me.control.alignTo()
+            }
         }
     }
 
@@ -1051,7 +1166,13 @@ class Overflow extends Plugin {
         me.menuProjectionQueued   = false;
         me.menuRecaptureQueued    = false;
         me.observedMenuList       = null;
-        me.control?.destroy(true);
+        if (me.control && !me.control.isDestroyed) {
+            if (me.control.isToolbarActionContribution === true) {
+                me.owner.removeActionContribution(me.control)
+            } else {
+                me.control.destroy(true)
+            }
+        }
         me.control = null;
         super.destroy(...args)
     }

--- a/src/toolbar/Base.mjs
+++ b/src/toolbar/Base.mjs
@@ -103,6 +103,14 @@ class Toolbar extends Container {
     }
 
     /**
+     * Action instances whose resize / visibility signals are already bound. Contributions survive
+     * consumer action rebuilds, so binding by collection pass would otherwise multiply listeners.
+     * @member {WeakSet<Neo.component.Base>}
+     * @protected
+     */
+    actionBindingItems = new WeakSet()
+
+    /**
      * Reconciles a live action-collection replacement after construction. Initial materialisation
      * stays inside createItems() so the toolbar still commits one child tree.
      * @param {Object[]|String[]|null} value
@@ -305,10 +313,15 @@ class Toolbar extends Container {
      * Observes availability changes whose geometry can alter a consumer such as tab overflow.
      * @protected
      */
-    bindActionItems() {
+    bindActionItems(items=this.getActionItems()) {
         let me = this;
 
-        me.getActionItems().forEach(item => {
+        items.forEach(item => {
+            if (me.actionBindingItems.has(item)) {
+                return
+            }
+
+            me.actionBindingItems.add(item);
             item.addDomListeners({resize: me.onActionResize, scope: me});
             item.on('hiddenChange', () => {
                 me.fire('actionVisibilityChange', {action: item.action, component: item})
@@ -412,12 +425,21 @@ class Toolbar extends Container {
             return []
         }
 
-        return [{
+        return [this.createActionSpacerConfig(), ...actions.map(action => this.createActionItemConfig(action))]
+    }
+
+    /**
+     * Returns the toolbar-owned spacer config shared by consumer actions and contributed actions.
+     * @returns {Object}
+     * @protected
+     */
+    createActionSpacerConfig() {
+        return {
             module               : Component,
             cls                  : ['neo-toolbar-action-spacer'],
             flex                 : 1,
             isToolbarActionSpacer: true
-        }, ...actions.map(action => this.createActionItemConfig(action))]
+        }
     }
 
     /**
@@ -433,6 +455,45 @@ class Toolbar extends Container {
             component,
             scope : this
         })
+    }
+
+    /**
+     * Adds one toolbar-owned action contribution ahead of consumer actions. Contributions are not
+     * written into {@link #actions}; the consumer remains the sole owner of that config, while the
+     * toolbar preserves the contributed instance across every consumer action rebuild.
+     * @param {Object} config Action config.
+     * @returns {Neo.component.Base} The stable contributed action instance.
+     */
+    addActionContribution(config) {
+        let me            = this,
+            actionItems   = me.getActionItems(),
+            firstAction   = actionItems[0],
+            firstConsumer = actionItems.find(item => item.isToolbarActionContribution !== true),
+            spacer        = me.getActionSpacer(),
+            contribution;
+
+        if (!spacer) {
+            spacer = me.insert(firstAction ? me.items.indexOf(firstAction) : me.items.length,
+                me.createActionSpacerConfig(), true)
+        }
+
+        firstConsumer = me.getActionItems().find(item => item.isToolbarActionContribution !== true);
+        contribution  = me.insert(firstConsumer ? me.items.indexOf(firstConsumer) : me.items.length,
+            me.createActionItemConfig({...config, isToolbarActionContribution: true}));
+
+        me.bindActionItems([contribution]);
+        me.applyContextualActionState(true);
+        me.fire('actionsChange', {actions: me.getActionItems()});
+
+        return contribution
+    }
+
+    /**
+     * Returns action instances contributed outside the consumer-owned {@link #actions} config.
+     * @returns {Neo.component.Base[]}
+     */
+    getActionContributionItems() {
+        return this.getActionItems().filter(item => item.isToolbarActionContribution === true)
     }
 
     /**
@@ -462,14 +523,49 @@ class Toolbar extends Container {
     }
 
     /**
+     * Retires one contributed action instance. The toolbar's ordinary item-destruction path owns
+     * contributions during toolbar teardown; contributors use this method for earlier retirement.
+     * @param {Neo.component.Base} instance
+     * @returns {Neo.component.Base|null}
+     */
+    removeActionContribution(instance) {
+        let me = this;
+
+        if (instance?.isToolbarActionContribution !== true || !me.items.includes(instance)) {
+            return null
+        }
+
+        me.remove(instance, true, true);
+
+        if (me.getActionItems().length === 0) {
+            let spacer = me.getActionSpacer();
+
+            spacer && me.remove(spacer, true, true)
+        }
+
+        me.updateDepth = -1;
+        me.update();
+        me.fire('actionsChange', {actions: me.getActionItems()});
+
+        return instance
+    }
+
+    /**
      * Replaces only the toolbar-owned action group while preserving every ordinary item.
      * @param {Object[]|String[]|null} actions
      * @protected
      */
     syncActions(actions) {
-        let me      = this,
-            owned   = [me.getActionSpacer(), ...me.getActionItems()].filter(Boolean),
-            configs = me.createActionItemConfigs(actions);
+        let me            = this,
+            contributions = me.getActionContributionItems(),
+            owned         = contributions.length > 0
+                ? me.getActionItems().filter(item => item.isToolbarActionContribution !== true)
+                : [me.getActionSpacer(), ...me.getActionItems()].filter(Boolean),
+            configs       = contributions.length > 0
+                ? Array.isArray(actions) && actions.length > 0
+                    ? actions.map(action => me.createActionItemConfig(action))
+                    : []
+                : me.createActionItemConfigs(actions);
 
         owned
             .map(item => me.items.indexOf(item))

--- a/test/playwright/component/tab/OverflowAction.spec.mjs
+++ b/test/playwright/component/tab/OverflowAction.spec.mjs
@@ -1,0 +1,182 @@
+import {test, expect} from '@playwright/test';
+
+const TAB_ID = 'overflow-action-tab-container';
+
+let componentId = null;
+
+/**
+ * Creates a real TabContainer whose Overflow plugin contributes into a host/close action rail.
+ * @param {Object} page
+ * @returns {Promise<String>}
+ */
+async function createTabContainer(page) {
+    const result = await page.evaluate(async id => {
+        const loaded = await Neo.worker.App.loadModule({path: '../tab/plugin/Overflow.mjs'});
+
+        if (!loaded.success) {
+            throw new Error(`Overflow module load failed: ${loaded.error?.message}`)
+        }
+
+        return Neo.worker.App.createNeoInstance({
+            activeIndex  : 0,
+            height       : 240,
+            headerActions: [{
+                action     : 'host-action',
+                iconCls    : 'fa fa-star',
+                showOnFocus: false
+            }, {
+                action     : 'close',
+                iconCls    : 'fa fa-times',
+                showOnFocus: false
+            }],
+            headerToolbar: {
+                plugins: [{ntype: 'plugin-tab-overflow', projectAsAction: true}]
+            },
+            id,
+            importPath: '../tab/Container.mjs',
+            items     : Array.from({length: 8}, (_, index) => ({
+                header: {text: `Tab ${index + 1}`},
+                ntype : 'component',
+                text  : `Content ${index + 1}`
+            })),
+            ntype   : 'tab-container',
+            parentId: 'component-test-viewport',
+            width   : 380
+        })
+    }, TAB_ID);
+
+    if (!result.success) {
+        throw new Error(`TabContainer creation failed: ${result.error.message}`)
+    }
+
+    return result.id
+}
+
+/** Returns the action-root ids in rendered toolbar order. */
+const actionIds = toolbar => toolbar.locator(':scope > .neo-toolbar-action')
+    .evaluateAll(nodes => nodes.map(node => node.id));
+
+/** Replaces consumer actions through the public TabContainer config path. */
+const replaceHeaderActions = (page, suffix) => page.evaluate(({id, suffix}) =>
+    Neo.worker.App.setConfigs({
+        id,
+        headerActions: [{
+            action     : `host-${suffix}`,
+            iconCls    : 'fa fa-bolt',
+            showOnFocus: false
+        }, {
+            action     : 'close',
+            iconCls    : 'fa fa-times',
+            showOnFocus: false
+        }]
+    }), {id: TAB_ID, suffix});
+
+test.describe('Neo.tab.plugin.Overflow — toolbar action projection', () => {
+    test.beforeEach(async ({page}) => {
+        await page.goto('/test/playwright/component/apps/empty-viewport/index.html');
+        await page.waitForSelector('#component-test-viewport', {state: 'attached'});
+
+        componentId = await createTabContainer(page);
+        await page.waitForSelector(`#${componentId}`, {state: 'attached'})
+    });
+
+    test.afterEach(async ({page}) => {
+        if (componentId) {
+            await page.evaluate(id => Neo.worker.App.destroyNeoInstance(id), componentId);
+            componentId = null
+        }
+    });
+
+    test('renders first, outside focus gating, with measured non-overlap and ordinary menu activation', async ({page}) => {
+        const errors = [];
+
+        page.on('pageerror', error => errors.push(String(error?.message || error)));
+
+        const root    = page.locator(`#${TAB_ID}`),
+              toolbar = root.locator(':scope > .neo-tab-header-toolbar'),
+              control = toolbar.getByRole('button', {name: 'More tabs', exact: true}),
+              host    = toolbar.getByRole('button', {name: 'host action', exact: true}),
+              close   = toolbar.getByRole('button', {name: 'close', exact: true});
+
+        await expect(control).toBeVisible({timeout: 10000});
+        await expect(host).toBeVisible();
+        await expect(close).toBeVisible();
+        await expect(control).not.toHaveClass(/neo-toolbar-action-context-inactive/);
+        await expect(control).not.toHaveAttribute('aria-hidden');
+        await expect(page.locator('body > .neo-tab-overflow-control')).toHaveCount(0);
+
+        const ids = await actionIds(toolbar);
+
+        expect(ids[0], 'Overflow owns the first action slot').toBe(await control.getAttribute('id'));
+        expect(ids.at(-1), 'close remains the final action').toBe(await close.getAttribute('id'));
+
+        const visibleTabs = toolbar.locator(':scope > .neo-tab-header-button:visible'),
+              lastTab     = visibleTabs.last(),
+              tabBox      = await lastTab.boundingBox(),
+              controlBox  = await control.boundingBox();
+
+        expect(tabBox.x + tabBox.width,
+            'the visible tab partition ends before the measured contribution').toBeLessThanOrEqual(controlBox.x + 1);
+
+        await control.click();
+
+        const menuItem = page.locator('.neo-tab-overflow-menu:visible .neo-list-item').first();
+
+        await expect(menuItem).toBeVisible({timeout: 10000});
+
+        const selected = (await menuItem.innerText()).trim();
+
+        await menuItem.click();
+        await expect(toolbar.locator('.neo-tab-header-button.pressed:visible').filter({hasText: selected}))
+            .toHaveCount(1, {timeout: 10000});
+        expect(errors).toEqual([])
+    });
+
+    test('preserves one instance across visible and all-fit consumer action replacements', async ({page}) => {
+        const root    = page.locator(`#${TAB_ID}`),
+              toolbar = root.locator(':scope > .neo-tab-header-toolbar'),
+              control = toolbar.getByRole('button', {name: 'More tabs', exact: true});
+
+        await expect(control).toBeVisible({timeout: 10000});
+
+        const controlId = await control.getAttribute('id');
+
+        await replaceHeaderActions(page, 'visible');
+        await expect(toolbar.getByRole('button', {name: 'host visible', exact: true})).toBeVisible();
+        expect((await actionIds(toolbar))[0]).toBe(controlId);
+        await expect(toolbar.locator(`#${controlId}`)).toHaveCount(1);
+
+        await page.evaluate(id => Neo.worker.App.setConfigs({id, width: 1200}), TAB_ID);
+        await expect(toolbar.locator(`#${controlId}`), 'all-fit hides the contribution from DOM')
+            .toHaveCount(0, {timeout: 10000});
+
+        await replaceHeaderActions(page, 'hidden');
+        await expect(toolbar.getByRole('button', {name: 'host hidden', exact: true})).toBeVisible();
+
+        await page.evaluate(id => Neo.worker.App.setConfigs({id, width: 380}), TAB_ID);
+
+        const restored = toolbar.locator(`#${controlId}`);
+
+        await expect(restored, 'the pre-overflow contribution instance returns after replacement')
+            .toBeVisible({timeout: 10000});
+        await expect(toolbar.locator('.neo-tab-overflow-control')).toHaveCount(1);
+
+        const ids = await actionIds(toolbar);
+
+        expect(ids[0]).toBe(controlId);
+        expect(ids.at(-1)).toBe(await toolbar.getByRole('button', {name: 'close', exact: true}).getAttribute('id'));
+
+        await restored.click();
+
+        const menuItem = page.locator('.neo-tab-overflow-menu:visible .neo-list-item').first();
+
+        await expect(menuItem, 'the recovered contribution keeps its ordinary menu route')
+            .toBeVisible({timeout: 10000});
+
+        const selected = (await menuItem.innerText()).trim();
+
+        await menuItem.click();
+        await expect(toolbar.locator('.neo-tab-header-button.pressed:visible').filter({hasText: selected}),
+            'selection still activates through activeIndex after the hidden replacement').toHaveCount(1)
+    })
+});

--- a/test/playwright/e2e/dashboard/DockTabOverflowNL.spec.mjs
+++ b/test/playwright/e2e/dashboard/DockTabOverflowNL.spec.mjs
@@ -1,15 +1,13 @@
 import { test, expect } from '../../fixtures.mjs';
 
 /**
- * Out-of-collection floating dock tab-overflow control — the retained minimal generic runtime witness for
- * Neo.tab.plugin.Overflow (the dense composed workstation journey lives in the dense-workstation scene).
+ * Dock tab-overflow action — the composed-header runtime witness for Neo.tab.plugin.Overflow.
  *
  * At a narrow viewport the heavy `main-tabs` node overflows; the runtime {@link Neo.tab.plugin.Overflow}
- * plugin (injected by `DockLayoutAdapter.projectTabsNode` into the projected header toolbar) creates a single
- * overflow control (a `button.Base` with a `menu`) and mounts it as a `floating` component to `document.body`
- * — OUT of the header toolbar's item collection, so `owner.items` stays exactly the real tabs (the collection
- * invariant; a trailing toolbar item would be SortZone-draggable and corrupt the committed dock tab order).
- * The parentless `initVnode(true)` autoMount reaches the DOM via the merged hidden-document render-queue drain.
+ * plugin (injected by `LayoutAdapter.projectTabsNode`) contributes one stable control as the FIRST toolbar
+ * action. Tab buttons remain the SortZone's explicit subset, so the action is never draggable; host/engine
+ * actions follow it and close stays last. Widening hides the contribution through removeDom, narrowing restores
+ * the SAME instance, and no floating body-rooted control exists in this mode.
  *
  * Asserted against the page's OWN DOM — deliberately NOT via the neuralLink bridge, whose `connectToApp`
  * appName-fallback can latch a long-lived stale resident and read the wrong app. The page DOM is the ground
@@ -17,49 +15,57 @@ import { test, expect } from '../../fixtures.mjs';
  *
  * Run: NEO_E2E_PORT=8094 npx playwright test dashboard/DockTabOverflowNL -c test/playwright/playwright.config.e2e.mjs --workers=1
  */
-test.describe('dock tab-overflow floating control', () => {
+test.describe('dock tab-overflow action control', () => {
     test.setTimeout(120000);
     test.use({ viewport: { width: 600, height: 800 } });
 
-    test('the floating overflow control renders at document.body, aligns to its owner toolbar, and its menu surfaces + activates the hidden tabs', async ({ page }) => {
+    test('the overflow action stays first, resize-stable, focus-independent, and activates hidden tabs', async ({ page }) => {
         const pageErrors = [];
         page.on('pageerror', err => { pageErrors.push(err.message); console.error('BROWSER JS ERROR:', err) });
         await page.goto('/examples/dashboard/dock/');
 
-        const control = page.locator('.neo-tab-overflow-control');
-        await expect(control).toHaveCount(1, { timeout: 45000 });
-
-        // Out-of-collection invariant: a FLOATING direct child of document.body, NOT a nested header-toolbar
-        // item — so `owner.items` stays exactly the real tabs (a toolbar item would be SortZone-draggable).
-        const parentIsBody = await page.evaluate(() =>
-            document.querySelector('.neo-tab-overflow-control')?.parentElement === document.body);
-        expect(parentIsBody, 'the overflow control must be a direct floating child of document.body').toBe(true);
-
-        // It carries the ellipsis affordance.
-        await expect(control.locator('.fa-ellipsis')).toHaveCount(1);
-
-        // Owner-EXACT geometry: the control's right edge aligns (within 2px) immediately before the
-        // persistent Dock close-action rail, and its top aligns to that action inside the toolbar
-        // carrying 'Strategy' — NOT a stale pre-settle position. This requires the
-        // `.neo-button.neo-floating { position: fixed }` cascade fix; without it the control is pinned
-        // to its offsetParent instead
-        // of the viewport and lands at the wrong coordinates.
         const mainToolbar = page.locator('.neo-tab-header-toolbar').filter({ hasText: 'Strategy' }).first(),
+              control     = mainToolbar.getByRole('button', {name: 'More tabs', exact: true}),
               closeAction = mainToolbar.getByRole('button', {name: 'close', exact: true});
 
+        await expect(control).toHaveCount(1, {timeout: 45000});
         await expect(closeAction).toBeVisible();
+        await expect(control.locator('.fa-ellipsis')).toHaveCount(1);
+        await expect(page.locator('body > .neo-tab-overflow-control'),
+            'dock action mode creates no floating body-rooted control').toHaveCount(0);
+        expect(await control.evaluate(node => node.parentElement?.classList.contains('neo-tab-header-toolbar')),
+            'the control is a real toolbar item').toBe(true);
+        await expect(control).not.toHaveClass(/neo-toolbar-action-context-inactive/);
+        await expect(control).not.toHaveAttribute('aria-hidden');
 
-        const controlBox = await control.boundingBox(),
-              actionBox  = await closeAction.boundingBox();
+        const actions = mainToolbar.locator('.neo-toolbar-action');
+        expect(await actions.first().getAttribute('id'), 'Overflow is the first action').toBe(await control.getAttribute('id'));
+        expect(await actions.last().getAttribute('id'), 'close remains the last action').toBe(await closeAction.getAttribute('id'));
 
-        expect(Math.abs((controlBox.x + controlBox.width) - actionBox.x),
-            'control right edge aligns immediately before the Dock action rail').toBeLessThanOrEqual(2);
-        expect(Math.abs(controlBox.y - actionBox.y),
-            'control top aligns to the adjacent Dock action').toBeLessThanOrEqual(2);
+        await expect.poll(async () => {
+            const controlBox = await control.boundingBox(),
+                  actionBox  = await closeAction.boundingBox();
+
+            return Math.max(
+                Math.abs((controlBox.x + controlBox.width) - actionBox.x),
+                Math.abs(controlBox.y - actionBox.y)
+            )
+        }, {
+            message: 'the settled overflow control ends immediately before the Dock action on its baseline',
+            timeout: 10000
+        }).toBeLessThanOrEqual(2);
         await expect(mainToolbar.locator('.neo-toolbar-action.neo-draggable')).toHaveCount(0);
 
+        // Stable presence contract: all-fit removes the DOM, overflow restores the exact instance.
+        const controlId = await control.getAttribute('id');
+
+        await page.setViewportSize({width: 1600, height: 800});
+        await expect(control).toHaveCount(0, {timeout: 10000});
+        await page.setViewportSize({width: 600, height: 800});
+        await expect(page.locator(`#${controlId}`), 'the same contributed instance returns').toBeVisible({timeout: 10000});
+
         // Clicking the control opens its dropdown menu of hidden tabs.
-        await control.click();
+        await page.locator(`#${controlId}`).click();
         const menuItems = page.locator('.neo-menu-list:visible .neo-list-item').filter({ hasText: /\S/ });
         await expect(menuItems.first()).toBeVisible({ timeout: 10000 });
 

--- a/test/playwright/unit/dashboard/DockLayoutAdapter.spec.mjs
+++ b/test/playwright/unit/dashboard/DockLayoutAdapter.spec.mjs
@@ -1066,6 +1066,7 @@ test.describe('Neo.dashboard.dock.projection.LayoutAdapter', () => {
         expect(mainTabs.ntype).toBe('tab-container');
         expect(plugins).toHaveLength(1);
         expect(plugins[0].module).toBe(TabOverflowPlugin);
+        expect(plugins[0].projectAsAction, 'dock headers project Overflow into their action rail').toBe(true);
     });
 
     test.describe('tab sort boundary + tear-out projection threading', () => {

--- a/test/playwright/unit/tab/HeaderActions.spec.mjs
+++ b/test/playwright/unit/tab/HeaderActions.spec.mjs
@@ -114,6 +114,62 @@ test.describe.serial('Neo tab header actions', () => {
         expect(secondBoundAction.handler()).toBe(2)
     });
 
+    test('contributed actions stay first and preserve identity across consumer replacements', () => {
+        const toolbar = own(Neo.create(Toolbar, {
+                  actions: [{action: 'first', iconCls: 'fa fa-one'}],
+                  items  : [{module: Component, flag: 'ordinary'}]
+              })),
+              events  = [],
+              changes = [];
+
+        toolbar.on('actionVisibilityChange', data => events.push(data.component));
+        toolbar.on('actionsChange', data => changes.push(data.actions));
+
+        const contribution = toolbar.addActionContribution({
+            action     : 'overflow',
+            hidden     : true,
+            iconCls    : 'fa fa-ellipsis',
+            showOnFocus: false
+        });
+
+        expect(contribution.isToolbarActionContribution).toBe(true);
+        expect(toolbar.items.map(item => item.isToolbarActionSpacer ? 'spacer' : item.action || item.flag))
+            .toEqual(['ordinary', 'spacer', 'overflow', 'first']);
+
+        toolbar.actions = [
+            {action: 'second', iconCls: 'fa fa-two'},
+            {action: 'third',  iconCls: 'fa fa-three'}
+        ];
+
+        expect(toolbar.getActionContributionItems()).toEqual([contribution]);
+        expect(toolbar.items.map(item => item.isToolbarActionSpacer ? 'spacer' : item.action || item.flag))
+            .toEqual(['ordinary', 'spacer', 'overflow', 'second', 'third']);
+        expect(changes.at(-1).map(item => item.action)).toEqual(['overflow', 'second', 'third']);
+
+        contribution.hidden = false;
+        contribution.hidden = true;
+        expect(events, 'a preserved contribution is bound once, not once per rebuild')
+            .toEqual([contribution, contribution]);
+
+        toolbar.actions = null;
+        expect(toolbar.getActionContributionItems()).toEqual([contribution]);
+        expect(toolbar.items.map(item => item.isToolbarActionSpacer ? 'spacer' : item.action || item.flag))
+            .toEqual(['ordinary', 'spacer', 'overflow']);
+
+        expect(toolbar.removeActionContribution(contribution)).toBe(contribution);
+        expect(contribution.isDestroyed).toBe(true);
+        expect(toolbar.getActionSpacer()).toBeNull();
+        expect(toolbar.items.map(item => item.flag)).toEqual(['ordinary']);
+
+        const teardownContribution = toolbar.addActionContribution({
+            action : 'teardown',
+            iconCls: 'fa fa-x'
+        });
+
+        toolbar.destroy();
+        expect(teardownContribution.isDestroyed, 'toolbar teardown owns contributed instances').toBe(true)
+    });
+
     test('contextual inactivity reserves the instance while leaving consumer availability intact', () => {
         const toolbar = own(Neo.create(Toolbar, {
                   actions: [{action: 'contextual', contextual: true, iconCls: 'fa fa-eye'}]

--- a/test/playwright/unit/tab/plugin/Overflow.spec.mjs
+++ b/test/playwright/unit/tab/plugin/Overflow.spec.mjs
@@ -224,6 +224,45 @@ test.describe('Neo.tab.plugin.Overflow (re-entrancy contract)', () => {
         expect(plugin.measuring, 'no pass is left latched').toBe(false)
     });
 
+    test('action mode excludes its own geometry and visibility feedback, but not other actions', () => {
+        const plugin = createPlugin(async () => []),
+              own    = {hidden: false, id: 'overflow-action'},
+              host   = {action: 'host', hidden: false, id: 'host-action'};
+        let projections = 0;
+
+        plugin.control              = own;
+        plugin.owner.getActionItems = () => [own, host];
+        plugin.project              = () => { projections++ };
+
+        expect(plugin.getActionItems(), 'only the plugin contribution self-excludes').toEqual([host]);
+
+        plugin.onActionVisibilityChange({component: own});
+        expect(projections, 'the contribution hidden flip cannot re-enter its own partition').toBe(0);
+
+        plugin.onActionVisibilityChange({component: host});
+        plugin.onActionGeometryChange({component: own});
+        expect(projections, 'host visibility and rendered contribution width remain live inputs').toBe(2);
+
+        plugin.control = null
+    });
+
+    test('contribution retirement cannot start a projection after the destroy boundary', async () => {
+        let geometryReads = 0;
+
+        const plugin = createPlugin(async () => {
+            geometryReads++;
+            return []
+        });
+
+        await new Promise(resolve => setTimeout(resolve, 0));
+        geometryReads = 0;
+        plugin.isDestroying = true;
+
+        await plugin.project(false);
+
+        expect(geometryReads, 'the synchronous actionsChange from retirement performs no DOM round-trip').toBe(0)
+    });
+
     test('a recapture restores hidden-button config and VDOM removal state atomically', async () => {
         const
             makeButton = id => ({
@@ -481,11 +520,14 @@ test.describe('Neo.tab.plugin.Overflow (re-entrancy contract)', () => {
     });
 
     test('main-axis geometry reserves actions and maps all four toolbar orientations', async () => {
-        const action = {hidden: false, id: 'action-1'};
+        const action  = {hidden: false, id: 'action-1'};
+        let   actionX = 200,
+            actionY  = 240;
+
         const plugin = createPlugin(async ids => ids.map(id => id === 'tab-overflow-test-owner'
             ? {height: 300, left: 0, top: 0, width: 240, x: 0, y: 0}
             : id === action.id
-                ? {height: 20, left: 200, top: 240, width: 20, x: 200, y: 240}
+                ? {height: 20, left: actionX, top: actionY, width: 20, x: actionX, y: actionY}
                 : {height: 130, width: 110}));
 
         await new Promise(resolve => setTimeout(resolve, 0));
@@ -516,6 +558,17 @@ test.describe('Neo.tab.plugin.Overflow (re-entrancy contract)', () => {
 
         expect(split.hidden, 'the first action starts at x=200 despite its 20px width').toEqual(['b2']);
         expect(split.activeCap).toMatchObject({maxSize: 'maxWidth', usable: 160});
+
+        actionX             = 300;
+        plugin.naturalWidths = {b1: 120, b2: 120};
+        await plugin.project(false);
+
+        expect(split.hidden, 'a tab-pushed action rail cannot enlarge the toolbar extent').toEqual(['b2']);
+        expect(split.activeCap, 'the rendered action width bounds the pushed coordinate to the owner')
+            .toMatchObject({maxSize: 'maxWidth', usable: 180});
+
+        actionX              = 200;
+        plugin.naturalWidths = {b1: 110, b2: 110};
 
         const bothButtons = plugin.owner.items;
         plugin.owner.items = [bothButtons[0]];


### PR DESCRIPTION
Resolves #17951

Related: #13158

Tab overflow can now opt into a toolbar-owned, stable action contribution. The contribution stays first, survives consumer `headerActions` rebuilds, remains outside focus gating, and is removeDom-hidden while every tab fits; dock projections opt in while generic tab consumers retain the floating default. The shared extent calculation also bounds a temporarily pushed action rail to its owner, so wide-to-narrow transitions converge instead of self-sustaining an all-visible split.

Evidence: L3 (real Chromium component and dock/generic E2E probes) → L3 required (all eight runtime and browser ACs). No residuals.

## AC Evidence

| AC | Evidence |
|---|---|
| AC-1 | The existing generic floating-mode journey remains unchanged and green in `test/playwright/e2e/tab/TabHeaderActionsNL.spec.mjs`; action mode defaults off. |
| AC-2 | `test/playwright/component/tab/OverflowAction.spec.mjs` and `test/playwright/e2e/dashboard/DockTabOverflowNL.spec.mjs` assert first action position, final close position, and zero body-rooted floating controls. |
| AC-3 | Both browser witnesses exercise all-fit removal and resize-driven restoration of the same contributed instance. |
| AC-4 | The component witness asserts focus-independent visibility and activates a hidden tab through the existing menu/`activeIndex` route. |
| AC-5 | The visible-overflow replacement arm preserves the contribution id, singleton count, and first position across `headerActions` replacement. |
| AC-6 | The all-fit replacement arm widens, replaces actions while the contribution is absent from DOM, shrinks, recovers the same singleton first, and reopens the menu to activate a hidden tab. |
| AC-7 | `HeaderActions.spec.mjs` pins contribution ownership, ordering, identity, listener idempotence, removal, and toolbar teardown; `Overflow.spec.mjs` pins self-exclusion, destroy-boundary suppression, and owner-bounded geometry. |
| AC-8 | ADR 0029 §2.4 now distinguishes default floating and opt-in action-slot projection; `DockLayoutAdapter.spec.mjs` pins the dock opt-in. |

## Deltas from ticket

Two in-scope hardenings emerged from the required negative-state witness: projection stops at the plugin destroy boundary when contribution retirement synchronously emits `actionsChange`, and action-derived extent is capped by owner size minus rendered action widths when visible tabs temporarily push the rail beyond the toolbar.

## Test Evidence

- `NEO_AGENTOS_RUNTIME_ROOT="$PWD/../neo-agent-brain" npx playwright test dashboard/DockTabOverflowNL.spec.mjs tab/TabHeaderActionsNL.spec.mjs -c test/playwright/playwright.config.e2e.mjs --workers=1` → 2 passed: dock action mode and retained generic floating mode.

## Post-Merge Validation

None — every close-target behavior is verifiable before merge and has a committed witness.

## Evolution

The hidden-state replacement arm initially proved identity but not post-recovery menu routing. Adding that falsifier exposed a transient wide-to-narrow state where tab buttons could push the action coordinate beyond the toolbar and make an all-visible split look valid. The final shape combines the coordinate boundary with an owner-size/action-width ceiling, and the dock geometry assertion now waits for the event-driven projection to settle instead of sampling an intermediate frame.

Authored by Emmy (GPT-5.6 Sol Ultra, Codex). Session 4426fb43-4968-4084-832e-1830de2e8747.
