### PR TITLE
fix(build): resolve webpack and parse5 by module resolution, not cwd (#17961)

### DIFF
--- a/buildScripts/build/parse5.mjs
+++ b/buildScripts/build/parse5.mjs
@@ -1,19 +1,42 @@
 import esbuild         from 'esbuild';
 import path            from 'path';
+import {createRequire} from 'module';
 import {fileURLToPath} from 'url';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname  = path.dirname(__filename);
 
+const require = createRequire(import.meta.url);
+
+/**
+ * @summary The parse5 entry point, resolved by module resolution rather than a cwd-relative path.
+ *
+ * `build/all.mjs` spawns this script with the **consumer's** cwd, so a literal
+ * `node_modules/parse5/dist/index.js` was read from wherever the build happened to start. When a
+ * consumer installs the engine as a dependency npm hoists parse5 to the consumer root, and the
+ * failure surfaces as an esbuild "entry point not found" that names a path but not the reason.
+ * Resolving from this module's own URL walks the real resolution chain, so it lands on the same file
+ * whether parse5 sits beside the engine or hoisted above it.
+ *
+ * **The bare specifier is deliberate and is the only form that works.** parse5 declares an `exports`
+ * map that does not expose `./dist/index.js`, so the subpath that mirrors the old literal —
+ * `require.resolve('parse5/dist/index.js')` — throws `ERR_PACKAGE_PATH_NOT_EXPORTED`. The bare
+ * specifier resolves to that exact file through the package's own `exports`, so this is a pure
+ * resolution change with an identical target. Anyone "correcting" it back toward the visible path
+ * gets a red that reads like a missing file.
+ * @type {String}
+ */
+const parse5EntryPoint = require.resolve('parse5');
+
 const build = async () => {
     try {
         await esbuild.build({
-            entryPoints: ['node_modules/parse5/dist/index.js'],
-            bundle: true,
-            minify: true,
-            format: 'esm',
-            outfile: path.join(__dirname, '../../dist/parse5.mjs'),
-            banner: {
+            entryPoints: [parse5EntryPoint],
+            bundle     : true,
+            minify     : true,
+            format     : 'esm',
+            outfile    : path.join(__dirname, '../../dist/parse5.mjs'),
+            banner     : {
                 js: '/* eslint-disable */'
             }
         });

--- a/buildScripts/util/resolvePackageBin.mjs
+++ b/buildScripts/util/resolvePackageBin.mjs
@@ -1,0 +1,54 @@
+import fs   from 'fs';
+import path from 'path';
+
+/**
+ * @module buildScripts/util/resolvePackageBin
+ * @summary Locates a dependency's executable entry script through module resolution.
+ *
+ * The build programs spawn third-party executables, and they used to name them by **filesystem
+ * path** — `./node_modules/.bin/webpack`, read from `process.cwd()`. That holds only for a checkout
+ * whose `node_modules` sits exactly one level below where the build was started. `build/all.mjs`
+ * spawns those programs with the **consumer's** cwd, and npm hoists, so for anyone installing the
+ * engine as a dependency the literal points at nothing. The failure is a bare ENOENT that names a
+ * path but not the cause, which is why the class was diagnosed one site at a time.
+ *
+ * Two properties make this replacement hoist-proof:
+ *
+ * 1. **Resolution runs from the caller's module URL**, not from cwd, so it walks the real resolution
+ *    chain and finds the package whether it sits beside the engine or hoisted above it.
+ * 2. **The target is the package's declared JS entry, not its `.bin` shim.** The result is launched
+ *    with `node`, the dispatch `build/all.mjs` already uses everywhere. That removes the shim
+ *    question outright: on Windows a `.bin` entry is a `.cmd` script rather than an executable
+ *    image, the constraint `buildScripts/build/highlightJs.mjs` documents at length.
+ *
+ * The `bin` declaration is **read, not assumed** — a release that moves its entry point resolves
+ * through its own manifest instead of breaking a hardcode. That discipline is borrowed from
+ * `resolveHuskyBin` in `buildScripts/util/prepare.mjs`, which reaches the same conclusion by joining
+ * paths under a known root; this module differs only in using module resolution, because its callers
+ * cannot assume a root.
+ */
+
+/**
+ * @summary Absolute path to a package's executable entry script, resolved via its own manifest.
+ *
+ * `resolve` is injected rather than closed over so callers pass a `createRequire(import.meta.url)`
+ * resolver bound to **their** module — resolution must start at the consumer, not here. It is also
+ * the seam that makes hoisted and nested layouts assertable without installing either.
+ * @param {String} packageName Bare package name, e.g. `'webpack'`.
+ * @param {Function} resolve Resolver, typically `createRequire(import.meta.url).resolve`.
+ * @param {Object} [options]
+ * @param {String} [options.binName=packageName] Key to select when `bin` is a map of several.
+ * @returns {String} Absolute path to the entry script.
+ * @throws {Error} When the manifest declares no usable `bin` entry.
+ */
+export function resolvePackageBin(packageName, resolve, {binName=packageName}={}) {
+    const manifestPath = resolve(`${packageName}/package.json`),
+          {bin}        = JSON.parse(fs.readFileSync(manifestPath, 'utf8')),
+          entry        = typeof bin === 'string' ? bin : bin?.[binName] ?? Object.values(bin ?? {})[0];
+
+    if (typeof entry !== 'string' || entry.length === 0) {
+        throw new Error(`resolvePackageBin: '${packageName}' declares no bin entry in '${manifestPath}'`)
+    }
+
+    return path.join(path.dirname(manifestPath), entry)
+}

--- a/buildScripts/webpack/buildThreads.mjs
+++ b/buildScripts/webpack/buildThreads.mjs
@@ -1,15 +1,19 @@
-import chalk           from 'chalk';
-import {spawnSync}     from 'child_process';
-import {Command}       from 'commander';
-import envinfo         from 'envinfo';
-import fs              from 'fs-extra';
-import inquirer        from 'inquirer';
-import path            from 'path';
-import {sanitizeInput} from '../util/sanitizer.mjs';
+import chalk               from 'chalk';
+import {spawnSync}         from 'child_process';
+import {Command}           from 'commander';
+import envinfo             from 'envinfo';
+import fs                  from 'fs-extra';
+import inquirer            from 'inquirer';
+import os                  from 'os';
+import path                from 'path';
+import {createRequire}     from 'module';
+import {resolvePackageBin} from '../util/resolvePackageBin.mjs';
+import {sanitizeInput}     from '../util/sanitizer.mjs';
 
 const __dirname   = path.resolve(),
       cwd         = process.cwd(),
       cpOpts      = {env: process.env, cwd: cwd, stdio: 'inherit', shell: true},
+      nodeCmd     = os.platform().startsWith('win') ? 'node.exe' : 'node',
       requireJson = path => JSON.parse(fs.readFileSync((path))),
       packageJson = requireJson(path.resolve(cwd, 'package.json')),
       neoPath     = packageJson.name.includes('neo.mjs') ? './' : './node_modules/neo.mjs/',
@@ -18,7 +22,11 @@ const __dirname   = path.resolve(),
       programName = `${packageJson.name} buildThreads`,
       questions   = [];
 
-let webpack = './node_modules/.bin/webpack';
+// Resolved from THIS module's URL, so the lookup is independent of the consumer cwd `cpOpts` runs
+// under — see `buildScripts/util/resolvePackageBin.mjs` for why the entry script rather than the
+// `.bin` shim. Separators are normalised for the shell these are dispatched through, which is what
+// the removed `path.sep === '\\'` branch did for the old shim path.
+const webpackBin = resolvePackageBin('webpack', createRequire(import.meta.url).resolve).replace(/\\/g, '/');
 
 program
     .name(programName)
@@ -84,39 +92,35 @@ if (programOpts.info) {
               insideNeo = programOpts.framework || false,
               startDate = new Date();
 
-        if (path.sep === '\\') {
-            webpack = path.resolve(webpack).replace(/\\/g,'/');
-        }
-
         function parseThreads(tPath) {
             let childProcess;
 
             if (threads === 'all' || threads === 'main') {
-                childProcess = spawnSync(webpack, ['--config', `${tPath}.main.mjs`], cpOpts);
+                childProcess = spawnSync(nodeCmd, [webpackBin, '--config', `${tPath}.main.mjs`], cpOpts);
                 childProcess.status && process.exit(childProcess.status);
             }
             if (threads === 'all' || threads === 'app') {
-                childProcess = spawnSync(webpack, ['--config', `${tPath}.appworker.mjs`, `--env insideNeo=${insideNeo}`], cpOpts);
+                childProcess = spawnSync(nodeCmd, [webpackBin, '--config', `${tPath}.appworker.mjs`, `--env insideNeo=${insideNeo}`], cpOpts);
                 childProcess.status && process.exit(childProcess.status);
             }
             if (threads === 'all' || threads === 'canvas') {
-                childProcess = spawnSync(webpack, ['--config', `${tPath}.worker.mjs`, `--env insideNeo=${insideNeo} worker=canvas`], cpOpts);
+                childProcess = spawnSync(nodeCmd, [webpackBin, '--config', `${tPath}.worker.mjs`, `--env insideNeo=${insideNeo} worker=canvas`], cpOpts);
                 childProcess.status && process.exit(childProcess.status);
             }
             if (threads === 'all' || threads === 'data') {
-                childProcess = spawnSync(webpack, ['--config', `${tPath}.worker.mjs`, `--env insideNeo=${insideNeo} worker=data`], cpOpts);
+                childProcess = spawnSync(nodeCmd, [webpackBin, '--config', `${tPath}.worker.mjs`, `--env insideNeo=${insideNeo} worker=data`], cpOpts);
                 childProcess.status && process.exit(childProcess.status);
             }
             if (threads === 'all' || threads === 'service') {
-                childProcess = spawnSync(webpack, ['--config', `${tPath}.worker.mjs`, `--env insideNeo=${insideNeo} worker=service`], cpOpts);
+                childProcess = spawnSync(nodeCmd, [webpackBin, '--config', `${tPath}.worker.mjs`, `--env insideNeo=${insideNeo} worker=service`], cpOpts);
                 childProcess.status && process.exit(childProcess.status);
             }
             if (threads === 'all' || threads === 'task') {
-                childProcess = spawnSync(webpack, ['--config', `${tPath}.worker.mjs`, `--env insideNeo=${insideNeo} worker=task`], cpOpts);
+                childProcess = spawnSync(nodeCmd, [webpackBin, '--config', `${tPath}.worker.mjs`, `--env insideNeo=${insideNeo} worker=task`], cpOpts);
                 childProcess.status && process.exit(childProcess.status);
             }
             if (threads === 'all' || threads === 'vdom') {
-                childProcess = spawnSync(webpack, ['--config', `${tPath}.worker.mjs`, `--env insideNeo=${insideNeo} worker=vdom`], cpOpts);
+                childProcess = spawnSync(nodeCmd, [webpackBin, '--config', `${tPath}.worker.mjs`, `--env insideNeo=${insideNeo} worker=vdom`], cpOpts);
                 childProcess.status && process.exit(childProcess.status);
             }
         }

--- a/test/playwright/unit/buildScripts/resolvePackageBin.spec.mjs
+++ b/test/playwright/unit/buildScripts/resolvePackageBin.spec.mjs
@@ -1,0 +1,174 @@
+import {expect, test}      from '@playwright/test';
+import {createRequire}     from 'module';
+import {resolvePackageBin} from '../../../../buildScripts/util/resolvePackageBin.mjs';
+import fs                  from 'fs';
+import os                  from 'os';
+import path                from 'path';
+
+/**
+ * @summary Resolution of a dependency's executable entry, across node_modules layouts.
+ *
+ * The defect these cover is not "the path is ugly" — it is that a cwd-relative
+ * literal reads from wherever the build was *started*, and `build/all.mjs` starts the build programs
+ * with the **consumer's** cwd. So the property under test is that resolution is driven by the
+ * caller's module location and by the package's own manifest, and never by `process.cwd()`.
+ *
+ * The layouts are built on disk rather than mocked, because the whole failure is a filesystem-shape
+ * failure: a mock that returns a path would pass for a resolver that ignores hoisting entirely.
+ */
+
+/**
+ * Throwaway root, pinned to its realpath.
+ *
+ * `os.tmpdir()` is a symlink on macOS (`/var` → `/private/var`), and Node's resolver reports
+ * realpaths. Comparing a resolved path against an unresolved fixture path fails on the symlink
+ * rather than on the behaviour under test — and would read as a resolution defect that is not one.
+ * @returns {String}
+ */
+function makeTempRoot() {
+    return fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), 'neo-17868-')))
+}
+
+/** Builds a throwaway `node_modules` tree and returns a resolver bound to it. */
+function makeLayout({nested}) {
+    const root = makeTempRoot(),
+          // hoisted: <root>/node_modules/dep ; nested: <root>/node_modules/host/node_modules/dep
+          depDir  = nested
+              ? path.join(root, 'node_modules', 'host', 'node_modules', 'dep')
+              : path.join(root, 'node_modules', 'dep'),
+          callDir = nested ? path.join(root, 'node_modules', 'host') : root;
+
+    fs.mkdirSync(path.join(depDir, 'bin'), {recursive: true});
+    fs.mkdirSync(callDir, {recursive: true});
+    fs.writeFileSync(path.join(depDir, 'package.json'), JSON.stringify({
+        name: 'dep', version: '1.0.0', bin: {dep: 'bin/dep.js'}
+    }));
+    fs.writeFileSync(path.join(depDir, 'bin', 'dep.js'), '// entry\n');
+    fs.writeFileSync(path.join(callDir, 'caller.mjs'), '// caller\n');
+
+    return {
+        root,
+        expected: path.join(depDir, 'bin', 'dep.js'),
+        resolve : createRequire(path.join(callDir, 'caller.mjs')).resolve
+    }
+}
+
+test.describe('resolvePackageBin', () => {
+    test('resolves the declared bin entry in a hoisted layout', () => {
+        const {root, expected, resolve} = makeLayout({nested: false});
+
+        try {
+            expect(resolvePackageBin('dep', resolve)).toBe(expected)
+        } finally {
+            fs.rmSync(root, {recursive: true, force: true})
+        }
+    });
+
+    test('resolves the declared bin entry in a nested layout', () => {
+        const {root, expected, resolve} = makeLayout({nested: true});
+
+        try {
+            expect(resolvePackageBin('dep', resolve)).toBe(expected)
+        } finally {
+            fs.rmSync(root, {recursive: true, force: true})
+        }
+    });
+
+    /**
+     * The mutation control for the actual defect. The old code was `'./node_modules/.bin/<name>'`
+     * read from cwd; this asserts the resolved answer does NOT coincide with that literal resolved
+     * against the process cwd, so a regression back to a cwd-relative form reds here rather than
+     * passing because both happen to exist in this repo's own layout.
+     */
+    test('the resolved entry is not the cwd-relative shim path', () => {
+        const {root, expected, resolve} = makeLayout({nested: true});
+
+        try {
+            const resolved = resolvePackageBin('dep', resolve);
+
+            expect(resolved).toBe(expected);
+            expect(resolved).not.toBe(path.resolve(process.cwd(), 'node_modules/.bin/dep'));
+            expect(resolved.startsWith(root)).toBe(true)
+        } finally {
+            fs.rmSync(root, {recursive: true, force: true})
+        }
+    });
+
+    test('honours a bin map key other than the package name', () => {
+        const root   = makeTempRoot(),
+              depDir = path.join(root, 'node_modules', 'dep');
+
+        fs.mkdirSync(path.join(depDir, 'bin'), {recursive: true});
+        fs.writeFileSync(path.join(depDir, 'package.json'), JSON.stringify({
+            name: 'dep', version: '1.0.0', bin: {other: 'bin/other.js', dep: 'bin/dep.js'}
+        }));
+        fs.writeFileSync(path.join(root, 'caller.mjs'), '// caller\n');
+
+        try {
+            const resolve = createRequire(path.join(root, 'caller.mjs')).resolve;
+
+            expect(resolvePackageBin('dep', resolve, {binName: 'other'}))
+                .toBe(path.join(depDir, 'bin', 'other.js'))
+        } finally {
+            fs.rmSync(root, {recursive: true, force: true})
+        }
+    });
+
+    test('accepts a string bin declaration', () => {
+        const root   = makeTempRoot(),
+              depDir = path.join(root, 'node_modules', 'dep');
+
+        fs.mkdirSync(path.join(depDir, 'bin'), {recursive: true});
+        fs.writeFileSync(path.join(depDir, 'package.json'), JSON.stringify({
+            name: 'dep', version: '1.0.0', bin: 'bin/dep.js'
+        }));
+        fs.writeFileSync(path.join(root, 'caller.mjs'), '// caller\n');
+
+        try {
+            const resolve = createRequire(path.join(root, 'caller.mjs')).resolve;
+
+            expect(resolvePackageBin('dep', resolve)).toBe(path.join(depDir, 'bin', 'dep.js'))
+        } finally {
+            fs.rmSync(root, {recursive: true, force: true})
+        }
+    });
+
+    test('throws a named error when the manifest declares no bin', () => {
+        const root   = makeTempRoot(),
+              depDir = path.join(root, 'node_modules', 'dep');
+
+        fs.mkdirSync(depDir, {recursive: true});
+        fs.writeFileSync(path.join(depDir, 'package.json'), JSON.stringify({name: 'dep', version: '1.0.0'}));
+        fs.writeFileSync(path.join(root, 'caller.mjs'), '// caller\n');
+
+        try {
+            const resolve = createRequire(path.join(root, 'caller.mjs')).resolve;
+
+            expect(() => resolvePackageBin('dep', resolve)).toThrow(/declares no bin entry/)
+        } finally {
+            fs.rmSync(root, {recursive: true, force: true})
+        }
+    });
+});
+
+test.describe('the engine\'s own dependencies resolve through the real chain', () => {
+    const resolve = createRequire(import.meta.url).resolve;
+
+    test('webpack resolves to its declared entry script, not a .bin shim', () => {
+        const resolved = resolvePackageBin('webpack', resolve);
+
+        expect(fs.existsSync(resolved)).toBe(true);
+        expect(resolved.endsWith('bin/webpack.js')).toBe(true);
+        expect(resolved.includes(`${path.sep}.bin${path.sep}`)).toBe(false)
+    });
+
+    /**
+     * Guards the trap documented in `buildScripts/build/parse5.mjs`: the bare specifier lands on the
+     * exact file the old hardcoded literal named, while the subpath that *looks* like that literal
+     * is not exported and throws. A future "cleanup" toward the visible path reds here.
+     */
+    test('parse5 resolves by bare specifier only', () => {
+        expect(resolve('parse5').endsWith(path.join('parse5', 'dist', 'index.js'))).toBe(true);
+        expect(() => resolve('parse5/dist/index.js')).toThrow()
+    });
+});


### PR DESCRIPTION
Resolves #17961

`buildScripts/build/all.mjs` spawns the build programs with the **consumer's** cwd, and two of them located a dependency by a cwd-relative literal — `'./node_modules/.bin/webpack'` and `'node_modules/parse5/dist/index.js'`. Both now resolve from their own module URL, so they find the package whether it sits beside the engine or hoisted above it. New `buildScripts/util/resolvePackageBin.mjs` reads a package's own `bin` declaration instead of assuming an entry point, targets the declared JS entry rather than the `.bin` shim, and is launched with `node` — which lets `buildThreads.mjs`'s `path.sep === '\\'` Windows special case be deleted rather than ported, since there is no shim left to special-case.

Evidence: L4 (real builds executed from a foreign cwd, plus on-disk hoisted/nested layout fixtures and a mutation control) → L4 required. Residual: none for this close target. The parent class ticket #17868 stays open for its third site.

## AC Evidence

| AC | Proof |
|---|---|
| AC-1 — buildThreads resolves via module resolution | `resolvePackageBin.spec.mjs` › "webpack resolves to its declared entry script, not a .bin shim"; plus a real run below |
| AC-2 — parse5 resolves the same way, bare specifier | `resolvePackageBin.spec.mjs` › "parse5 resolves by bare specifier only"; plus a real build from a foreign cwd below |
| AC-3 — coverage against real on-disk layouts | `resolvePackageBin.spec.mjs` › "resolves the declared bin entry in a hoisted layout" / "…in a nested layout" — `makeLayout()` builds actual `node_modules` trees |
| AC-4 — mutation control proves it can fail | Outside CI; receipt in Test Evidence |
| AC-5 — the parse5 bare-vs-subpath trap is pinned | `resolvePackageBin.spec.mjs` › "parse5 resolves by bare specifier only" asserts both halves: bare resolves, subpath throws |

## Deltas from ticket

Two, both scope-reducing or additive rather than substantive redirection.

**The helper was extracted rather than inlined.** The first draft put `resolveWebpackBin` inside `buildThreads.mjs` and exported it for coverage. That does not work: `buildThreads.mjs` has no entrypoint guard, so importing it to reach the export runs the whole program — the interactive inquirer prompt included. Rather than add a guard and restructure that file's top-level body, the resolver moved to `buildScripts/util/`, matching the `prepare.mjs` / `esmDistTransforms.mjs` sibling pattern and their specs under `test/playwright/unit/buildScripts/`. It is also generic (`resolvePackageBin(name, resolve)`), because the same shape already exists as `resolveHuskyBin` and will want converging later.

**One census result worth recording:** `buildScripts/util/prepare.mjs:36` resolves husky by joining paths under a known root, which carries the same non-hoisted assumption. It is **not** a defect — `prepare` only ever runs in the engine's own checkout — so it is deliberately untouched, not missed.

## Test Evidence

Outside-CI receipts only.

**Real parse5 build, and its negative control.** From the repo root and from `/tmp`, the fixed script produces a byte-identical bundle:

```
=== A: from repo root ===  Successfully bundled and minified parse5 to dist/parse5.mjs   (166479 bytes)
=== B: from a foreign cwd ===  Successfully bundled and minified parse5 to dist/parse5.mjs   (166479 bytes)
```

The **old** form run under condition B — the control that makes A/B mean something:

```
✘ [ERROR] Could not resolve "node_modules/parse5/dist/index.js"
OLD FORM FAILS as predicted: Build failed with 1 error
```

**Real thread build** — `node ./buildScripts/webpack/buildThreads.mjs -f -n -t main -e dev`:

```
webpack 5.108.3 compiled successfully in 224 ms
Total time for neo.mjs buildThreads: 2.19s
```
producing `dist/development/main.js` at 1,296,825 bytes.

**Mutation control.** Regressing `resolvePackageBin` to `path.resolve(process.cwd(), 'node_modules/.bin/' + packageName)` — the exact cwd-relative form being removed — reds **6 of 8**, including the dedicated "the resolved entry is not the cwd-relative shim path" case. Restored and re-verified 8/8 green, with a `diff` against the pre-mutation copy confirming the restore was byte-identical rather than silently partial.

One correction worth flagging, since it briefly produced a false green: an earlier `buildThreads` run was wrapped in `timeout`, which macOS does not ship. The command exited 0 without ever running. The receipt above is from the re-run without it.

Full unit suite: 2579 passed.

## Post-Merge Validation

- [ ] A genuine consumer install (engine as a `file:`/registry dependency, hoisted layout) runs `build-threads` without editing engine files. This is #17868's AC-4 and cannot be reached from inside this checkout, which always has its own `node_modules` one level down.
- [ ] Windows: confirm the removed `path.sep === '\\'` branch is genuinely unnecessary now that dispatch goes through `node` rather than a `.cmd` shim. Reasoned from `highlightJs.mjs`'s documented constraint, not executed — no Windows host here.

## Commits

- `772a6e6447` — resolve webpack and parse5 by module resolution; add `resolvePackageBin` + spec.

Authored by Grace (Claude Opus 5, Claude Code). Session da6b927c-0fb8-404a-92af-402c790d1b14.
