### PR TITLE
test(build): a deleted spec must account for a subject that stayed (#17964)

### DIFF
--- a/buildScripts/util/check-spec-retirement.mjs
+++ b/buildScripts/util/check-spec-retirement.mjs
@@ -26,7 +26,20 @@ import process    from 'node:process';
 
 const
     ZERO_SHA = '0'.repeat(40),
-    exec     = command => execSync(command, {encoding: 'utf8', stdio: ['pipe', 'pipe', 'ignore']}).trim(),
+    /**
+     * node's `execSync` default `maxBuffer` is 1 MB, and `git ls-tree -r --name-only` over this
+     * repository already emits 1,327,472 bytes. The overrun throws `ENOBUFS` — and every read below
+     * that swallows a throw then yields an EMPTY string, which downstream is indistinguishable from
+     * a genuinely empty result. Measured on this tree: the surviving-subject scan saw 0 tracked
+     * paths and reported nothing, on every commit, in a repository where the answer is never zero.
+     *
+     * Sized well past the repository rather than trimmed to it. The cost of a generous ceiling is
+     * memory that is never allocated unless the output actually arrives; the cost of a tight one is
+     * the silence this guard exists to catch, reproduced inside the catcher.
+     * @type {Number}
+     */
+    MAX_BUFFER = 64 * 1024 * 1024,
+    exec     = command => execSync(command, {encoding: 'utf8', maxBuffer: MAX_BUFFER, stdio: ['pipe', 'pipe', 'ignore']}).trim(),
     tryExec  = command => { try { return exec(command) } catch { return '' } };
 
 /**
@@ -120,6 +133,30 @@ export function parseDeletedSpecs(output) {
 }
 
 /**
+ * @summary Every path the commit deleted, specs included — the same rows, without the spec filter.
+ *
+ * Read for one purpose: to tell "the subject stayed" apart from "the subject left with its spec, and
+ * an unrelated namesake remains". Without it the guard sees only the post-deletion tree, in which a
+ * departed subject is indistinguishable from one that was never there — see
+ * {@link unaccountedSurvivors}.
+ *
+ * @param {String} output `git show --name-status` output.
+ * @returns {String[]} Deleted paths, in encounter order.
+ */
+export function parseDeletedPaths(output) {
+    return String(output || '')
+        .split('\n')
+        .map(line => line.trim())
+        .filter(Boolean)
+        .map(line => {
+            const [status, ...paths] = line.split(/\t/);
+
+            return status?.startsWith('D') && paths.length === 1 ? paths[0] : null
+        })
+        .filter(Boolean)
+}
+
+/**
  * @summary The account line: the marker at the head of its own line, followed by actual content.
  *
  * A substring test is not a grammar. `includes('spec-retired:')` accepted the marker with nothing
@@ -136,12 +173,42 @@ export function parseDeletedSpecs(output) {
 const RETIREMENT_ACCOUNT_PATTERN = /^[ \t>*-]*spec-retired:[ \t]*(\S.*)$/im;
 
 /**
+ * @summary The same grammar, global, for reading every account payload rather than testing existence.
+ *
+ * A separate constant because a `g` regex carries `lastIndex` across calls: sharing one instance
+ * between `test()` and `matchAll()` makes each answer depend on the previous caller.
+ * @type {RegExp}
+ */
+const RETIREMENT_ACCOUNT_PATTERN_ALL = /^[ \t>*-]*spec-retired:[ \t]*(\S.*)$/gim;
+
+/**
  * @summary Whether a commit message carries a retirement account.
  * @param {String} message Full commit message (subject + body).
  * @returns {Boolean}
  */
 export function hasRetirementAccount(message) {
     return RETIREMENT_ACCOUNT_PATTERN.test(String(message || ''));
+}
+
+/**
+ * @summary The payloads of every `spec-retired:` account line in a commit message.
+ *
+ * Separate from {@link hasRetirementAccount} because the two questions differ: existence is answered
+ * by any one line, while "does the account name this survivor" may only be answered by what the
+ * account lines actually SAY.
+ *
+ * **Why the payload rather than the whole message.** The first draft matched surviving paths against
+ * the entire commit body, which let a path anywhere — the headline, a rationale paragraph, a `Refs:`
+ * trailer, a footer — discharge an account that named nothing. A commit reading
+ * `refactor: rework buildScripts/util/check-block-alignment.mjs` with a generic
+ * `spec-retired: moved to Brain` was accepted, although the account itself named no survivor. The
+ * demand is that the ACCOUNT names the file, so the account is the only text that can satisfy it.
+ *
+ * @param {String} message Full commit message (subject + body).
+ * @returns {String[]} Account payloads, in message order.
+ */
+export function retirementAccounts(message) {
+    return [...String(message || '').matchAll(RETIREMENT_ACCOUNT_PATTERN_ALL)].map(match => match[1].trim())
 }
 
 /**
@@ -226,19 +293,51 @@ export function findSurvivingSubjects(specPath, treePaths) {
  * had a surviving subject and the account named none. Naming is what a general sentence cannot fake —
  * which is the whole point, since a general sentence is exactly what went wrong.
  *
+ * **Ambiguous affinity yields no finding, deliberately.** `deriveSubjectSuffix` is a heuristic, and
+ * on this tree it is genuinely ambiguous for real paths: portal `content/Component.mjs` has 2
+ * candidates, `button/Base.mjs` 2, draggable `toolbar/SortZone.mjs` 3. When more than one tracked
+ * path answers the suffix, the guard cannot tell which one was this spec's subject — so deleting the
+ * REAL subject while an unrelated namesake survives would demand an account for a file the author
+ * never touched. That is the expensive error, and it is the one the header of
+ * {@link deriveSubjectSuffix} already commits this guard against: under-report rather than
+ * over-report. A single candidate is the only case where "the subject survived" is a fact rather
+ * than a guess, so it is the only case that fires.
+ *
+ * **A subject that left WITH its spec is not a survivor, even when a namesake remains.** Counting
+ * candidates in the post-deletion tree cannot see this on its own: delete
+ * `src/functional/button/Base.mjs` and its spec, and the two candidates for `button/Base.mjs`
+ * collapse to one — `src/button/Base.mjs`, a different component the author never touched — which
+ * then reads as an unambiguous survivor. The commit's own deleted paths are what disambiguate it, so
+ * they are consulted before the tree: if this commit deleted a file answering the spec's subject
+ * suffix, the subject departed and nothing is owed.
+ *
  * @param {String[]} specs Deleted spec paths.
  * @param {String[]} treePaths Tracked paths in the tree the deleting commit produced.
  * @param {String} message Full commit message.
+ * @param {String[]} [deletedPaths=[]] Every path the same commit deleted, specs included.
  * @returns {Array<{spec: String, subjects: String[]}>} Unnamed survivors, in encounter order.
  */
-export function unaccountedSurvivors(specs, treePaths, message) {
-    const body = String(message || '');
+export function unaccountedSurvivors(specs, treePaths, message, deletedPaths = []) {
+    // RA-3: the ACCOUNT must name the survivor, so only the account payloads are searched. Matching
+    // the whole body let a path in the headline, a rationale, or a `Refs:` trailer discharge an
+    // account that named nothing.
+    const accounts = retirementAccounts(message).join('\n');
 
     return (specs || [])
+        .filter(spec => {
+            // The subject left in this very commit — a remaining namesake is a different file.
+            const suffix = deriveSubjectSuffix(spec);
+
+            return suffix && !(deletedPaths || []).some(path => {
+                const lower = String(path).toLowerCase();
+
+                return lower.endsWith(`/${suffix}`) || lower === suffix
+            })
+        })
         .map(spec => ({spec, subjects: findSurvivingSubjects(spec, treePaths)}))
-        // Naming ANY one of a subject's candidate paths discharges the row. The author is being asked
-        // to acknowledge that the implementation stayed, not to enumerate every file that shares a name.
-        .filter(({subjects}) => subjects.length > 0 && !subjects.some(subject => body.includes(subject)))
+        // Exactly one candidate: see the ambiguity note above. Naming that path in the account
+        // discharges the row — the author is asked to acknowledge that the implementation stayed.
+        .filter(({subjects}) => subjects.length === 1 && !accounts.includes(subjects[0]))
 }
 
 /**
@@ -311,11 +410,60 @@ export function formatSurvivingSubjectFailure(violations) {
 }
 
 /**
+ * @summary Every git read the collector performs, in one injectable port.
+ *
+ * Extracted so the collector can be driven end to end by a test. Before this existed the only
+ * coverage was of the pure helpers, and the two defects that actually shipped both lived in the
+ * consumed path rather than in a helper: a tree read that failed open, and a survivor search that
+ * read the whole commit body. Helper-level green said nothing about either.
+ *
+ * `treePaths` is STRICT where the others are tolerant, and the asymmetry is the point — see
+ * {@link collectViolations}.
+ *
+ * @param {String} [root] Repository to read; defaults to the working directory.
+ * @returns {Object}
+ */
+export function createGit(root) {
+    // `-C` rather than a chdir: the spec drives this against a throwaway fixture repository, and
+    // `process.chdir` is process-global — under parallel test workers it would race.
+    const at = root ? `git -C '${root}'` : 'git';
+
+    const git = {
+        revList     : range => exec(`${at} rev-list ${range}`).split('\n').map(sha => sha.trim()).filter(Boolean),
+        nameStatus  : sha   => tryExec(`${at} show ${sha} --name-status -M --format=`),
+        deletedSpecs: sha   => parseDeletedSpecs(git.nameStatus(sha)),
+        deletedPaths: sha   => parseDeletedPaths(git.nameStatus(sha)),
+        message     : sha   => tryExec(`${at} log -1 ${sha} --format=%B`),
+        subject     : sha   => tryExec(`${at} log -1 ${sha} --format=%s`),
+        treePaths   : sha   => exec(`${at} ls-tree -r --name-only ${sha}`).split('\n').map(path => path.trim()).filter(Boolean)
+    };
+
+    return git
+}
+
+/**
+ * @summary The port bound to the working directory — what the hook actually runs with.
+ * @type {Object}
+ */
+export const defaultGit = createGit();
+
+/**
  * @summary Collects unaccounted spec deletions across the pushed ranges.
+ *
+ * **The tree read fails CLOSED.** It was a `tryExec`, and that is the defect this revision repairs:
+ * `git ls-tree -r` over this repository emits 1,327,472 bytes against a 1 MB default `maxBuffer`, so
+ * it threw `ENOBUFS`, the catch returned `''`, and the surviving-subject scan graded every commit
+ * against an EMPTY tree — in which nothing has ever survived. The guard reported zero rows and
+ * exited green. A raised ceiling alone would not have been enough: any other read failure would
+ * reproduce it, because the bug is not the size, it is that an unreadable tree and a clean one
+ * returned the same value. So the read now throws and the caller refuses, on the same reasoning the
+ * range read above already used.
+ *
  * @param {String[]} ranges Rev-list ranges.
+ * @param {Object} [git=defaultGit] Git port; injected by the spec to drive the consumed path.
  * @returns {{unaccounted: Array<{sha: String, subject: String, specs: String[]}>, survived: Array<{sha: String, subject: String, survivors: Array<{spec: String, subjects: String[]}>}>}}
  */
-function collectViolations(ranges) {
+export function collectViolations(ranges, git = defaultGit) {
     const
         violations = [],
         survived   = [];
@@ -336,14 +484,13 @@ function collectViolations(ranges) {
         let shas;
 
         try {
-            shas = exec(`git rev-list ${range}`).split('\n').map(s => s.trim()).filter(Boolean)
+            shas = git.revList(range)
         } catch {
-            console.error(
+            throw new Error(
                 `check-spec-retirement: cannot resolve the range \`${range}\`.\n` +
                 'The guard refuses to pass on a range it could not read — in CI this usually means a\n' +
                 'shallow checkout (needs `fetch-depth: 0`) or a missing `origin/dev` remote-tracking ref.'
-            );
-            process.exit(1)
+            )
         }
 
         shas.forEach(sha => {
@@ -365,16 +512,16 @@ function collectViolations(ranges) {
             // `--first-parent` would report the second case as a deletion too, demanding an account on
             // every merge that carries an already-accounted retirement — a false positive on exactly
             // the workflow this guard is meant to permit.
-            const specs = parseDeletedSpecs(tryExec(`git show ${sha} --name-status -M --format=`));
+            const specs = git.deletedSpecs(sha);
 
             if (specs.length === 0) {
                 return
             }
 
-            const message = tryExec(`git log -1 ${sha} --format=%B`);
+            const message = git.message(sha);
 
             if (!hasRetirementAccount(message)) {
-                violations.push({sha, subject: tryExec(`git log -1 ${sha} --format=%s`), specs});
+                violations.push({sha, subject: git.subject(sha), specs});
 
                 // One defect per commit. Demanding the surviving-subject detail from a commit that has
                 // not written an account at all buries the primary instruction under a longer one.
@@ -383,19 +530,62 @@ function collectViolations(ranges) {
 
             // Only reached when an account EXISTS, so the tree listing is paid for on the rare commit
             // that deletes specs and answers for them — not on every commit in the range.
-            const survivors = unaccountedSurvivors(
-                specs,
-                tryExec(`git ls-tree -r --name-only ${sha}`).split('\n').map(path => path.trim()).filter(Boolean),
-                message
-            );
+            //
+            // Fail CLOSED: an unreadable tree is not an empty one. See this function's header for the
+            // ENOBUFS case that made the two indistinguishable.
+            let treePaths;
+
+            try {
+                treePaths = git.treePaths(sha)
+            } catch (error) {
+                throw new Error(
+                    `check-spec-retirement: cannot read the tree of ${sha.slice(0, 10)} ` +
+                    `(${error.code || error.message}).\n` +
+                    'The guard refuses to grade surviving subjects against a tree it could not read — an\n' +
+                    'empty listing is indistinguishable from a repository in which nothing survived.'
+                )
+            }
+
+            // Second `git show` for the same commit, and deliberately not hoisted: like the tree read
+            // it is paid only on the rare commit that deletes specs AND answers for them, rather than
+            // on every commit in the range.
+            const survivors = unaccountedSurvivors(specs, treePaths, message, git.deletedPaths(sha));
 
             if (survivors.length > 0) {
-                survived.push({sha, subject: tryExec(`git log -1 ${sha} --format=%s`), survivors})
+                survived.push({sha, subject: git.subject(sha), survivors})
             }
         })
     });
 
     return {unaccounted: violations, survived}
+}
+
+/**
+ * @summary Renders every report a collection produced, in report order.
+ *
+ * Both classes are reported in one run. Exiting on the first would hide the second behind a
+ * fix-and-re-push cycle, and a guard discovered one row at a time is how a bulk deletion gets
+ * accounted for one sentence at a time.
+ *
+ * Split out of `main` so that aggregation is reachable by a test: as an `if`/`if` pair inlined in the
+ * entry point, an `if`→`else if` regression would have silenced the second class with nothing able to
+ * observe it.
+ *
+ * @param {{unaccounted: Array<Object>, survived: Array<Object>}} collected Output of {@link collectViolations}.
+ * @returns {String[]}
+ */
+export function buildReports({unaccounted = [], survived = []} = {}) {
+    const reports = [];
+
+    if (unaccounted.length > 0) {
+        reports.push(formatFailure(unaccounted))
+    }
+
+    if (survived.length > 0) {
+        reports.push(formatSurvivingSubjectFailure(survived))
+    }
+
+    return reports
 }
 
 /**
@@ -411,22 +601,21 @@ async function main() {
         }
     }
 
-    const
-        {unaccounted, survived} = collectViolations(pendingRanges(stdin)),
-        reports                 = [];
+    let collected;
 
-    if (unaccounted.length > 0) {
-        reports.push(formatFailure(unaccounted))
+    // Every refusal the collector raises — an unresolvable range, an unreadable tree — lands here and
+    // exits non-zero. The guard never passes on a read it could not make.
+    try {
+        collected = collectViolations(pendingRanges(stdin))
+    } catch (error) {
+        console.error(error.message);
+        process.exit(1);
+        return
     }
 
-    if (survived.length > 0) {
-        reports.push(formatSurvivingSubjectFailure(survived))
-    }
+    const reports = buildReports(collected);
 
     if (reports.length > 0) {
-        // Both classes are reported in one run. Exiting on the first would hide the second behind a
-        // fix-and-re-push cycle, and a guard discovered one row at a time is how a bulk deletion gets
-        // accounted for one sentence at a time.
         console.error(reports.join('\n\n'));
         process.exit(1)
     }

--- a/buildScripts/util/check-spec-retirement.mjs
+++ b/buildScripts/util/check-spec-retirement.mjs
@@ -145,6 +145,103 @@ export function hasRetirementAccount(message) {
 }
 
 /**
+ * @summary The in-tree path a deleted spec's subject would occupy: its own parent directory plus its name.
+ *
+ * `…/unit/ai/buildScripts/util/check-block-alignment.spec.mjs` yields `util/check-block-alignment.mjs`,
+ * which `buildScripts/util/check-block-alignment.mjs` satisfies.
+ *
+ * **The parent directory is load-bearing and was added on measurement, not taste.** A bare basename
+ * match — `logger.spec.mjs` looks for any `logger.mjs` — was the first draft, and replaying it over
+ * `c623b2f63c` produced ten false positives: four per-server `logger.spec.mjs` files resolved to
+ * `src/util/Logger.mjs`, two per-server `Server.spec.mjs` files to `examples/form/field/fileupload/server.mjs`,
+ * and `daemons/orchestrator/scheduling/picker.spec.mjs` to `src/form/field/Picker.mjs`. None of those
+ * files is the deleted spec's subject. Demanding an account for a file the author never touched is the
+ * failure this guard's own header warns about — it trains people to route around the check.
+ *
+ * The rule therefore under-reports rather than over-reports, deliberately. A spec sitting directly in
+ * `test/playwright/unit/` derives the suffix `unit/<name>.mjs`, which nothing satisfies, so it is never
+ * flagged. For a guard that demands an ACCOUNT, a false positive is the expensive error and a missed
+ * row is merely the status quo.
+ *
+ * @param {String} specPath Deleted spec path.
+ * @returns {String} Lower-cased `<parentDir>/<name>.mjs`, or an empty string when the path has no parent.
+ */
+export function deriveSubjectSuffix(specPath) {
+    const segments = String(specPath || '').split('/');
+
+    if (segments.length < 2) {
+        return ''
+    }
+
+    const
+        file      = segments.pop().replace(/\.spec\.mjs$/u, '.mjs'),
+        parentDir = segments.pop();
+
+    return `${parentDir}/${file}`.toLowerCase()
+}
+
+/**
+ * @summary Tree paths that still hold the deleted spec's subject.
+ *
+ * Case-insensitive because the split's own population needs it: `DataSyncPipeline.spec.mjs` covers
+ * `buildScripts/dataSyncPipeline.mjs`, and a case-sensitive match would call that subject departed.
+ *
+ * `test/` is excluded from the candidate set so that a sibling spec is never mistaken for an
+ * implementation — the question is whether the SUBJECT survived, not whether some other test did.
+ *
+ * @param {String} specPath Deleted spec path.
+ * @param {String[]} treePaths Tracked paths in the tree the deleting commit produced.
+ * @returns {String[]} Surviving subject paths, in tree order.
+ */
+export function findSurvivingSubjects(specPath, treePaths) {
+    const suffix = deriveSubjectSuffix(specPath);
+
+    if (!suffix) {
+        return []
+    }
+
+    return (treePaths || [])
+        .filter(path => path && !path.startsWith('test/'))
+        .filter(path => {
+            const lower = path.toLowerCase();
+
+            // `endsWith('/' + suffix)` anchors on a directory boundary, so `util/check-parse.mjs` is
+            // not satisfied by `…/util/check-parse-extra.mjs`, and the bare equality covers a subject
+            // sitting at the repository root.
+            return lower.endsWith(`/${suffix}`) || lower === suffix
+        })
+}
+
+/**
+ * @summary Deleted specs whose subject is still in the tree and whose account never says so.
+ *
+ * **This is the one half of the account that is mechanically gradeable.** The rule above — an account
+ * must EXIST, and the guard never asks whether it is TRUE — is correct and is not reopened here: no
+ * tool can grade "folded into X". But "the subject of this deleted spec is still in this repository"
+ * is not prose, it is a fact about the tree, and a commit removing that spec can be required to name
+ * the file it left behind.
+ *
+ * The empirical case is `c623b2f63c`, where one sentence accounted for 796 unit-spec deletions and
+ * mis-described at least 34 of them: measured against the tree that commit produced, 34 deleted specs
+ * had a surviving subject and the account named none. Naming is what a general sentence cannot fake —
+ * which is the whole point, since a general sentence is exactly what went wrong.
+ *
+ * @param {String[]} specs Deleted spec paths.
+ * @param {String[]} treePaths Tracked paths in the tree the deleting commit produced.
+ * @param {String} message Full commit message.
+ * @returns {Array<{spec: String, subjects: String[]}>} Unnamed survivors, in encounter order.
+ */
+export function unaccountedSurvivors(specs, treePaths, message) {
+    const body = String(message || '');
+
+    return (specs || [])
+        .map(spec => ({spec, subjects: findSurvivingSubjects(spec, treePaths)}))
+        // Naming ANY one of a subject's candidate paths discharges the row. The author is being asked
+        // to acknowledge that the implementation stayed, not to enumerate every file that shares a name.
+        .filter(({subjects}) => subjects.length > 0 && !subjects.some(subject => body.includes(subject)))
+}
+
+/**
  * @summary Renders the failure text.
  *
  * It names the paths and the marker and does NOT tell the author to restore the file. Restoring is
@@ -177,12 +274,51 @@ export function formatFailure(violations) {
 }
 
 /**
+ * @summary Renders the surviving-subject failure text.
+ *
+ * Deliberately worded as a NARROWING of the existing account rather than a new demand: the commit
+ * already carries a `spec-retired:` line — that is why it reached this check at all — and what is
+ * missing is one path inside it. Naming the fix that precisely is what keeps the rule cheap enough to
+ * satisfy rather than route around.
+ *
+ * @param {Array<{sha: String, subject: String, survivors: Array<{spec: String, subjects: String[]}>}>} violations
+ * @returns {String}
+ */
+export function formatSurvivingSubjectFailure(violations) {
+    const rows = violations.reduce((sum, {survivors}) => sum + survivors.length, 0);
+
+    const lines = [
+        `check-spec-retirement: ${rows} deleted spec(s) whose SUBJECT is still in this repository.`,
+        '',
+        'These commits carry an account, so the marker is satisfied — but the account does not mention',
+        'the implementation each deleted spec was covering, and that implementation did not leave.',
+        'A guard that still runs with no spec behind it is the coverage loss nothing else reports.',
+        '',
+        `Name the surviving file in the \`${RETIREMENT_MARKER}\` account — one path is enough per row —`,
+        'or restore the spec if the coverage was lost by accident rather than on purpose.',
+        ''
+    ];
+
+    violations.forEach(({sha, subject, survivors}) => {
+        lines.push(`  ${sha.slice(0, 10)} ${subject}`);
+        survivors.forEach(({spec, subjects}) => {
+            lines.push(`      deleted:  ${spec}`);
+            lines.push(`      survives: ${subjects.join(', ')}`);
+        });
+    });
+
+    return lines.join('\n')
+}
+
+/**
  * @summary Collects unaccounted spec deletions across the pushed ranges.
  * @param {String[]} ranges Rev-list ranges.
- * @returns {Array<{sha: String, subject: String, specs: String[]}>}
+ * @returns {{unaccounted: Array<{sha: String, subject: String, specs: String[]}>, survived: Array<{sha: String, subject: String, survivors: Array<{spec: String, subjects: String[]}>}>}}
  */
 function collectViolations(ranges) {
-    const violations = [];
+    const
+        violations = [],
+        survived   = [];
 
     ranges.forEach(range => {
         // Merges are scanned. An earlier draft passed `--no-merges` on the reasoning that a deletion
@@ -235,15 +371,31 @@ function collectViolations(ranges) {
                 return
             }
 
-            if (hasRetirementAccount(tryExec(`git log -1 ${sha} --format=%B`))) {
+            const message = tryExec(`git log -1 ${sha} --format=%B`);
+
+            if (!hasRetirementAccount(message)) {
+                violations.push({sha, subject: tryExec(`git log -1 ${sha} --format=%s`), specs});
+
+                // One defect per commit. Demanding the surviving-subject detail from a commit that has
+                // not written an account at all buries the primary instruction under a longer one.
                 return
             }
 
-            violations.push({sha, subject: tryExec(`git log -1 ${sha} --format=%s`), specs})
+            // Only reached when an account EXISTS, so the tree listing is paid for on the rare commit
+            // that deletes specs and answers for them — not on every commit in the range.
+            const survivors = unaccountedSurvivors(
+                specs,
+                tryExec(`git ls-tree -r --name-only ${sha}`).split('\n').map(path => path.trim()).filter(Boolean),
+                message
+            );
+
+            if (survivors.length > 0) {
+                survived.push({sha, subject: tryExec(`git log -1 ${sha} --format=%s`), survivors})
+            }
         })
     });
 
-    return violations
+    return {unaccounted: violations, survived}
 }
 
 /**
@@ -259,10 +411,23 @@ async function main() {
         }
     }
 
-    const violations = collectViolations(pendingRanges(stdin));
+    const
+        {unaccounted, survived} = collectViolations(pendingRanges(stdin)),
+        reports                 = [];
 
-    if (violations.length > 0) {
-        console.error(formatFailure(violations));
+    if (unaccounted.length > 0) {
+        reports.push(formatFailure(unaccounted))
+    }
+
+    if (survived.length > 0) {
+        reports.push(formatSurvivingSubjectFailure(survived))
+    }
+
+    if (reports.length > 0) {
+        // Both classes are reported in one run. Exiting on the first would hide the second behind a
+        // fix-and-re-push cycle, and a guard discovered one row at a time is how a bulk deletion gets
+        // accounted for one sentence at a time.
+        console.error(reports.join('\n\n'));
         process.exit(1)
     }
 }

--- a/test/playwright/unit/buildScripts/checkSpecRetirement.spec.mjs
+++ b/test/playwright/unit/buildScripts/checkSpecRetirement.spec.mjs
@@ -1,8 +1,16 @@
-import {test, expect} from '@playwright/test';
+import {test, expect}                                  from '@playwright/test';
+import {execSync}                                      from 'node:child_process';
+import {mkdirSync, mkdtempSync, rmSync, writeFileSync} from 'node:fs';
+import {tmpdir}                                        from 'node:os';
+import {join}                                          from 'node:path';
 
 import {
     RETIREMENT_MARKER,
     SPEC_PATH_PATTERN,
+    buildReports,
+    collectViolations,
+    createGit,
+    defaultGit,
     deriveSubjectSuffix,
     findSurvivingSubjects,
     formatFailure,
@@ -10,6 +18,7 @@ import {
     hasRetirementAccount,
     parseDeletedSpecs,
     pendingRanges,
+    retirementAccounts,
     unaccountedSurvivors
 }                     from '../../../../buildScripts/util/check-spec-retirement.mjs';
 
@@ -349,6 +358,279 @@ test.describe('check-spec-retirement', () => {
                 expect(rendered).toContain(RETIREMENT_MARKER);
                 expect(rendered).toMatch(/one path is enough/u);
             });
+        });
+    });
+
+    test.describe('ambiguous affinity under-reports rather than inventing a survivor (#17964 RC1 RA-2)', () => {
+        // Exact-tree controls. `deriveSubjectSuffix` is `<parentDir>/<name>.mjs`, and on THIS tree
+        // three real suffixes are answered by more than one tracked path (measured at head):
+        //
+        //   content/component.mjs  -> apps/portal/view/content/Component.mjs, src/app/content/Component.mjs
+        //   button/base.mjs        -> src/button/Base.mjs, src/functional/button/Base.mjs
+        //   toolbar/sortzone.mjs   -> 3 paths under src/draggable/{grid,tab,table}/header/
+        //
+        // The failure this guards against is not theoretical: delete the REAL subject and its spec,
+        // and the namesake that survives makes the guard demand an account for a file the author
+        // never touched. The header of `deriveSubjectSuffix` commits this guard to under-reporting
+        // precisely so that never happens, and these arms hold it to that.
+        const AMBIGUOUS_TREE = [
+            'apps/portal/view/content/Component.mjs',
+            'src/app/content/Component.mjs',
+            'src/button/Base.mjs',
+            'src/functional/button/Base.mjs',
+            'src/draggable/grid/header/toolbar/SortZone.mjs',
+            'src/draggable/tab/header/toolbar/SortZone.mjs',
+            'src/draggable/table/header/toolbar/SortZone.mjs'
+        ];
+
+        const GENERIC = 'chore: split\n\nspec-retired: moved to the Brain repo.';
+
+        test('two candidates yield no finding — portal `content/Component`', () => {
+            expect(findSurvivingSubjects('test/playwright/unit/app/content/Component.spec.mjs', AMBIGUOUS_TREE)).toHaveLength(2);
+            expect(unaccountedSurvivors(['test/playwright/unit/app/content/Component.spec.mjs'], AMBIGUOUS_TREE, GENERIC)).toEqual([]);
+        });
+
+        test('two candidates yield no finding — `button/Base`', () => {
+            expect(findSurvivingSubjects('test/playwright/unit/button/Base.spec.mjs', AMBIGUOUS_TREE)).toHaveLength(2);
+            expect(unaccountedSurvivors(['test/playwright/unit/button/Base.spec.mjs'], AMBIGUOUS_TREE, GENERIC)).toEqual([]);
+        });
+
+        test('three candidates yield no finding — draggable `toolbar/SortZone`', () => {
+            expect(findSurvivingSubjects('test/playwright/unit/draggable/tab/header/toolbar/SortZone.spec.mjs', AMBIGUOUS_TREE)).toHaveLength(3);
+            expect(unaccountedSurvivors(['test/playwright/unit/draggable/tab/header/toolbar/SortZone.spec.mjs'], AMBIGUOUS_TREE, GENERIC)).toEqual([]);
+        });
+
+        test('deleting the REAL subject while an unrelated namesake survives demands nothing', () => {
+            // The concrete false-positive shape, and the one a candidate COUNT cannot see:
+            // `src/functional/button/Base.mjs` leaves WITH its spec, so the two candidates collapse to
+            // one — `src/button/Base.mjs`, a different component entirely. Post-deletion the tree
+            // looks unambiguous, and the departed subject is indistinguishable from one that was never
+            // there. Only the commit's own deleted paths separate them.
+            const treeAfterDeletion = AMBIGUOUS_TREE.filter(path => path !== 'src/functional/button/Base.mjs');
+
+            expect(findSurvivingSubjects('test/playwright/unit/functional/button/Base.spec.mjs', treeAfterDeletion))
+                .toEqual(['src/button/Base.mjs']);
+
+            expect(unaccountedSurvivors(
+                ['test/playwright/unit/functional/button/Base.spec.mjs'],
+                treeAfterDeletion,
+                GENERIC,
+                ['src/functional/button/Base.mjs', 'test/playwright/unit/functional/button/Base.spec.mjs']
+            )).toEqual([]);
+        });
+
+        test('without the deleted-path evidence the same shape WOULD fire — the arm is not vacuous', () => {
+            // The mutation control for the clause above: drop the deleted-path argument and the false
+            // positive returns. This is what the guard did before the repair.
+            const treeAfterDeletion = AMBIGUOUS_TREE.filter(path => path !== 'src/functional/button/Base.mjs');
+
+            expect(unaccountedSurvivors(
+                ['test/playwright/unit/functional/button/Base.spec.mjs'],
+                treeAfterDeletion,
+                GENERIC
+            )).toHaveLength(1);
+        });
+
+        test('a deleted path that is NOT the subject leaves the demand standing', () => {
+            // The departure exemption must key on the subject suffix, not on "this commit deleted
+            // something". An unrelated deletion does not excuse the account.
+            const unambiguous = ['src/draggable/tab/header/toolbar/SortZone.mjs'];
+
+            expect(unaccountedSurvivors(
+                ['test/playwright/unit/draggable/tab/header/toolbar/SortZone.spec.mjs'],
+                unambiguous,
+                GENERIC,
+                ['src/unrelated/Thing.mjs']
+            )).toHaveLength(1);
+        });
+
+        test('a single candidate still fires — the narrowing did not disarm the rule', () => {
+            const unambiguous = ['src/draggable/tab/header/toolbar/SortZone.mjs'];
+
+            expect(unaccountedSurvivors(
+                ['test/playwright/unit/draggable/tab/header/toolbar/SortZone.spec.mjs'],
+                unambiguous,
+                GENERIC
+            )).toEqual([{
+                spec    : 'test/playwright/unit/draggable/tab/header/toolbar/SortZone.spec.mjs',
+                subjects: ['src/draggable/tab/header/toolbar/SortZone.mjs']
+            }]);
+        });
+    });
+
+    test.describe('the ACCOUNT must name the survivor, not the message (#17964 RC1 RA-3)', () => {
+        const
+            TREE  = ['buildScripts/util/check-block-alignment.mjs'],
+            SPECS = ['test/playwright/unit/ai/buildScripts/util/check-block-alignment.spec.mjs'];
+
+        test('retirementAccounts reads every payload, and only payloads', () => {
+            expect(retirementAccounts('x\n\nspec-retired: one\nspec-retired: two')).toEqual(['one', 'two']);
+            expect(retirementAccounts('a path buildScripts/util/check-block-alignment.mjs in prose')).toEqual([]);
+        });
+
+        test('a path in the HEADLINE does not discharge a generic account', () => {
+            // Euclid's exact falsifier: the subject line names the survivor, the account says nothing
+            // about it, and the pre-fix body-wide search accepted that as naming.
+            const message = 'refactor: rework buildScripts/util/check-block-alignment.mjs\n\n' +
+                'spec-retired: moved to Brain';
+
+            expect(unaccountedSurvivors(SPECS, TREE, message)).toHaveLength(1);
+        });
+
+        test('a path in a trailer or rationale does not discharge it either', () => {
+            const message = 'chore: split\n\nspec-retired: moved to Brain\n\n' +
+                'Rationale: buildScripts/util/check-block-alignment.mjs is unaffected.\n' +
+                'Refs: buildScripts/util/check-block-alignment.mjs';
+
+            expect(unaccountedSurvivors(SPECS, TREE, message)).toHaveLength(1);
+        });
+
+        test('the same path INSIDE the account discharges it — still satisfiable', () => {
+            const message = 'chore: split\n\nspec-retired: buildScripts/util/check-block-alignment.mjs stays, coverage folded into its sibling.';
+
+            expect(unaccountedSurvivors(SPECS, TREE, message)).toEqual([]);
+        });
+
+        test('a second account line can carry the name', () => {
+            const message = 'chore: split\n\nspec-retired: moved to Brain\nspec-retired: buildScripts/util/check-block-alignment.mjs stays.';
+
+            expect(unaccountedSurvivors(SPECS, TREE, message)).toEqual([]);
+        });
+    });
+
+    test.describe('the consumed path — the collector, not only its helpers (#17964 RC1 RA-1)', () => {
+        // Everything above grades pure helpers. The two defects that actually shipped both lived HERE,
+        // in the path the guard really runs, and helper-level green said nothing about either.
+        const port = overrides => ({
+            revList     : () => ['deadbeef'],
+            deletedSpecs: () => ['test/playwright/unit/buildScripts/util/check-block-alignment.spec.mjs'],
+            deletedPaths: () => ['test/playwright/unit/buildScripts/util/check-block-alignment.spec.mjs'],
+            message     : () => 'chore: split\n\nspec-retired: moved to Brain',
+            subject     : () => 'chore: split',
+            treePaths   : () => ['buildScripts/util/check-block-alignment.mjs'],
+            ...overrides
+        });
+
+        test('an unreadable tree REFUSES — it must not read as a clean one', () => {
+            // The shipped defect, exactly: `git ls-tree -r` over this repository emits 1,327,472 bytes
+            // against node's 1 MB default `maxBuffer`, threw ENOBUFS, and the catch returned ''. The
+            // scan then graded every commit against an EMPTY tree, in which nothing has ever survived.
+            const enobufs = () => {
+                const error = new Error('spawnSync git ENOBUFS');
+
+                error.code = 'ENOBUFS';
+                throw error
+            };
+
+            expect(() => collectViolations(['a..b'], port({treePaths: enobufs})))
+                .toThrow(/cannot read the tree of deadbeef \(ENOBUFS\)/u);
+        });
+
+        test('an unresolvable range REFUSES', () => {
+            const throws = () => { throw new Error('unknown revision') };
+
+            expect(() => collectViolations(['a..b'], port({revList: throws})))
+                .toThrow(/cannot resolve the range/u);
+        });
+
+        test('a readable tree still reports the survivor through the collector', () => {
+            const {survived} = collectViolations(['a..b'], port());
+
+            expect(survived).toHaveLength(1);
+            expect(survived[0].survivors[0].subjects).toEqual(['buildScripts/util/check-block-alignment.mjs']);
+        });
+
+        test('the collector passes the commit\'s deleted paths to the survivor check', () => {
+            // Wiring arm. The helper-level proof above cannot see whether the collector actually
+            // supplies `deletedPaths`; drop that argument at the call site and this goes red while
+            // every helper arm stays green.
+            const {survived} = collectViolations(['a..b'], port({
+                deletedPaths: () => [
+                    'buildScripts/util/check-block-alignment.mjs',
+                    'test/playwright/unit/buildScripts/util/check-block-alignment.spec.mjs'
+                ]
+            }));
+
+            expect(survived).toEqual([]);
+        });
+
+        test('both violation classes co-report in one run', () => {
+            // Mutation target: `if`/`if` in `buildReports`. An `if`→`else if` regression drops the
+            // second report, and before this arm existed nothing could observe that.
+            const reports = buildReports({
+                unaccounted: [{sha: 'a'.repeat(40), subject: 'no account', specs: ['test/playwright/unit/a.spec.mjs']}],
+                survived   : [{
+                    sha      : 'b'.repeat(40),
+                    subject  : 'generic account',
+                    survivors: [{spec: 'test/playwright/unit/b.spec.mjs', subjects: ['src/b.mjs']}]
+                }]
+            });
+
+            expect(reports).toHaveLength(2);
+            expect(reports[0]).toMatch(/delete unit spec files with no account/u);
+            expect(reports[1]).toMatch(/whose SUBJECT is still in this repository/u);
+        });
+
+        test('neither class reported leaves nothing to print', () => {
+            expect(buildReports({unaccounted: [], survived: []})).toEqual([]);
+            expect(buildReports()).toEqual([]);
+        });
+
+        test('reproduces the incident SHAPE against a real repository, through the real port', () => {
+            // The end-to-end arm: real git, real `createGit`, real `collectViolations`. It builds a
+            // throwaway repository that reproduces `c623b2f63c`'s shape — a commit deleting unit specs
+            // under one general account, while one subject stays and one genuinely leaves.
+            //
+            // It is a FIXTURE rather than a replay of `c623b2f63c` itself, and that was forced by
+            // measurement, not preference: the historical replay is correct locally (34 rows, the same
+            // 34 the helper-level analysis found) but the `unit` workflow checks out shallow, so
+            // `c623b2f63c` is absent on the runner and the range cannot resolve. A load-bearing arm
+            // must not depend on how deep CI happened to clone. The 34-row replay stays in the PR body
+            // as measured evidence; the property it demonstrates is asserted here, hermetically.
+            const
+                root = mkdtempSync(join(tmpdir(), 'spec-retirement-')),
+                run  = command => execSync(command, {cwd: root, encoding: 'utf8', stdio: ['pipe', 'pipe', 'ignore']});
+
+            try {
+                run('git init -q -b main');
+                run('git config user.email fixture@example.com');
+                run('git config user.name Fixture');
+
+                mkdirSync(join(root, 'test/playwright/unit/ai'), {recursive: true});
+                mkdirSync(join(root, 'src/ai'),                  {recursive: true});
+                mkdirSync(join(root, 'buildScripts/util'),       {recursive: true});
+
+                // Two specs. `LockRegistry`'s subject will STAY; `Departed`'s will leave with it.
+                writeFileSync(join(root, 'test/playwright/unit/ai/LockRegistry.spec.mjs'), 'export {}\n');
+                writeFileSync(join(root, 'test/playwright/unit/ai/Departed.spec.mjs'),     'export {}\n');
+                writeFileSync(join(root, 'src/ai/LockRegistry.mjs'),                       'export {}\n');
+                writeFileSync(join(root, 'src/ai/Departed.mjs'),                           'export {}\n');
+                writeFileSync(join(root, 'buildScripts/util/keep.mjs'),                    'export {}\n');
+                run('git add -A');
+                run('git commit -q -m base');
+
+                rmSync(join(root, 'test/playwright/unit/ai/LockRegistry.spec.mjs'));
+                rmSync(join(root, 'test/playwright/unit/ai/Departed.spec.mjs'));
+                rmSync(join(root, 'src/ai/Departed.mjs'));
+                run('git add -A');
+                run('git commit -q -m "chore: split" -m "spec-retired: moved to the Brain repo."');
+
+                const {unaccounted, survived} = collectViolations(['HEAD^..HEAD'], createGit(root));
+
+                // The account exists, so the marker is satisfied and nothing lands in `unaccounted`.
+                expect(unaccounted).toEqual([]);
+
+                // Exactly one row: the subject that STAYED and was never named. `Departed` left in the
+                // same commit and is correctly not demanded — the deleted-path disambiguation, proven
+                // here against real git rather than a hand-fed array.
+                expect(survived).toHaveLength(1);
+                expect(survived[0].survivors).toEqual([{
+                    spec    : 'test/playwright/unit/ai/LockRegistry.spec.mjs',
+                    subjects: ['src/ai/LockRegistry.mjs']
+                }]);
+            } finally {
+                rmSync(root, {recursive: true, force: true})
+            }
         });
     });
 

--- a/test/playwright/unit/buildScripts/checkSpecRetirement.spec.mjs
+++ b/test/playwright/unit/buildScripts/checkSpecRetirement.spec.mjs
@@ -3,10 +3,14 @@ import {test, expect} from '@playwright/test';
 import {
     RETIREMENT_MARKER,
     SPEC_PATH_PATTERN,
+    deriveSubjectSuffix,
+    findSurvivingSubjects,
     formatFailure,
+    formatSurvivingSubjectFailure,
     hasRetirementAccount,
     parseDeletedSpecs,
-    pendingRanges
+    pendingRanges,
+    unaccountedSurvivors
 }                     from '../../../../buildScripts/util/check-spec-retirement.mjs';
 
 test.describe('check-spec-retirement', () => {
@@ -203,6 +207,148 @@ test.describe('check-spec-retirement', () => {
 
         test('states that legitimate deletion stays cheap', () => {
             expect(rendered).toMatch(/account, not a veto/u);
+        });
+    });
+
+    test.describe('the surviving subject — the gradeable half of the account (#17922 AC-4)', () => {
+        // The guard asks whether an account EXISTS, never whether it is TRUE, and that stands. What
+        // these arms add is the one part of "true" that is a fact about the tree rather than prose:
+        // the deleted spec's subject is still here.
+        const TREE = [
+            'buildScripts/util/check-block-alignment.mjs',
+            'buildScripts/dataSyncPipeline.mjs',
+            'buildScripts/build/themes.mjs',
+            'src/ai/LockRegistry.mjs',
+            'src/ai/client/DockService.mjs',
+            'src/util/Logger.mjs',
+            'src/form/field/Picker.mjs',
+            'examples/form/field/fileupload/server.mjs',
+            // A NON-spec helper inside the test tree, positioned so that it WOULD satisfy the suffix
+            // `util/check-parse.mjs`. Without the `test/` exclusion this is a match, which is what
+            // makes the arm below able to fail. A sibling `*.spec.mjs` cannot serve here: the suffix
+            // ends in `.mjs`, never `.spec.mjs`, so it never matched and the arm was vacuously green.
+            'test/playwright/unit/buildScripts/util/check-parse.mjs'
+        ];
+
+        test.describe('deriveSubjectSuffix', () => {
+            test('is the parent directory plus the name, lower-cased', () => {
+                expect(deriveSubjectSuffix('test/playwright/unit/ai/buildScripts/util/check-block-alignment.spec.mjs'))
+                    .toBe('util/check-block-alignment.mjs');
+                expect(deriveSubjectSuffix('test/playwright/unit/ai/LockRegistry.spec.mjs')).toBe('ai/lockregistry.mjs');
+            });
+
+            test('a path with no parent directory yields nothing rather than throwing', () => {
+                expect(deriveSubjectSuffix('a.spec.mjs')).toBe('');
+                expect(deriveSubjectSuffix('')).toBe('');
+                expect(deriveSubjectSuffix(null)).toBe('');
+            });
+        });
+
+        test.describe('findSurvivingSubjects', () => {
+            test('resolves a subject that stayed behind', () => {
+                expect(findSurvivingSubjects('test/playwright/unit/ai/buildScripts/util/check-block-alignment.spec.mjs', TREE))
+                    .toEqual(['buildScripts/util/check-block-alignment.mjs']);
+            });
+
+            test('matches case-insensitively, which the split population requires', () => {
+                // `DataSyncPipeline.spec.mjs` covers `dataSyncPipeline.mjs`. A case-sensitive match
+                // would call that subject departed and wave the deletion through.
+                expect(findSurvivingSubjects('test/playwright/unit/ai/buildScripts/DataSyncPipeline.spec.mjs', TREE))
+                    .toEqual(['buildScripts/dataSyncPipeline.mjs']);
+            });
+
+            test('a genuinely departed subject resolves to nothing', () => {
+                // The positive control: this narrows what the marker must assert, it never widens it.
+                expect(findSurvivingSubjects('test/playwright/unit/ai/buildScripts/util/check-atomic-write-shape.spec.mjs', TREE))
+                    .toEqual([]);
+            });
+
+            test('a bare basename collision is NOT a surviving subject', () => {
+                // The measured false positives from replaying `c623b2f63c` with a basename-only rule.
+                // None of these files is the deleted spec's subject, and demanding an account for a
+                // file the author never touched is what trains people to route around the guard.
+                expect(findSurvivingSubjects('test/playwright/unit/ai/mcp/server/shared/logger.spec.mjs', TREE),
+                    'src/util/Logger.mjs is not the mcp server logger').toEqual([]);
+                expect(findSurvivingSubjects('test/playwright/unit/ai/daemons/orchestrator/scheduling/picker.spec.mjs', TREE),
+                    'src/form/field/Picker.mjs is not the scheduling picker').toEqual([]);
+                expect(findSurvivingSubjects('test/playwright/unit/ai/mcp/server/memory-core/Server.spec.mjs', TREE),
+                    'the fileupload example server is not the MCP server').toEqual([]);
+            });
+
+            test('a file inside the TEST tree never counts as the surviving implementation', () => {
+                // The question is whether the SUBJECT survived, not whether some other file under
+                // `test/` happens to carry the name. `test/playwright/unit/buildScripts/util/check-parse.mjs`
+                // satisfies this suffix on every axis except the one that matters.
+                expect(findSurvivingSubjects('test/playwright/unit/ai/buildScripts/util/check-parse.spec.mjs', TREE))
+                    .toEqual([]);
+            });
+
+            test('a longer name is not satisfied by a prefix match', () => {
+                // `endsWith('/' + suffix)` anchors on a directory boundary, so `check-parse.mjs` is
+                // not answered by `check-parse-extra.mjs`.
+                expect(findSurvivingSubjects('test/playwright/unit/ai/buildScripts/util/check-parse.spec.mjs',
+                    ['buildScripts/util/check-parse-extra.mjs'])).toEqual([]);
+            });
+        });
+
+        test.describe('unaccountedSurvivors', () => {
+            const specs = [
+                'test/playwright/unit/ai/buildScripts/util/check-block-alignment.spec.mjs',
+                'test/playwright/unit/ai/buildScripts/util/check-atomic-write-shape.spec.mjs'
+            ];
+
+            test('a general account that names no surviving file does not discharge the row', () => {
+                // This IS the incident: one sentence accounted for 796 unit-spec deletions, and 34 of
+                // the subjects it described as departed were still in the tree it produced.
+                const message = 'feat(engine): remove received Brain implementation\n\n' +
+                    'spec-retired: Brain-owned specs leave Engine with Agent OS; retained Fleet and\n' +
+                    'Neural Link coverage now binds an explicit external Brain runtime.';
+
+                expect(unaccountedSurvivors(specs, TREE, message)).toEqual([{
+                    spec    : 'test/playwright/unit/ai/buildScripts/util/check-block-alignment.spec.mjs',
+                    subjects: ['buildScripts/util/check-block-alignment.mjs']
+                }]);
+            });
+
+            test('naming the surviving path discharges it — the rule is satisfiable', () => {
+                const message = 'x\n\nspec-retired: buildScripts/util/check-block-alignment.mjs stays; coverage folded elsewhere.';
+
+                expect(unaccountedSurvivors(specs, TREE, message)).toEqual([]);
+            });
+
+            test('a deletion whose subjects all genuinely left stays green', () => {
+                const departed = ['test/playwright/unit/ai/buildScripts/util/check-atomic-write-shape.spec.mjs'];
+
+                expect(unaccountedSurvivors(departed, TREE, 'x\n\nspec-retired: moved to the Brain repo.')).toEqual([]);
+            });
+
+            test('empty and malformed input degrade to no findings, never to a throw', () => {
+                expect(unaccountedSurvivors(null, TREE, 'x')).toEqual([]);
+                expect(unaccountedSurvivors(specs, null, 'x')).toEqual([]);
+                expect(unaccountedSurvivors(specs, TREE, null).length).toBe(1);
+            });
+        });
+
+        test.describe('formatSurvivingSubjectFailure', () => {
+            const rendered = formatSurvivingSubjectFailure([{
+                sha      : 'c623b2f63cabcdef',
+                subject  : 'feat(engine): remove received Brain implementation',
+                survivors: [{
+                    spec    : 'test/playwright/unit/ai/buildScripts/util/check-block-alignment.spec.mjs',
+                    subjects: ['buildScripts/util/check-block-alignment.mjs']
+                }]
+            }]);
+
+            test('names both the deleted spec and the file that stayed', () => {
+                expect(rendered).toContain('test/playwright/unit/ai/buildScripts/util/check-block-alignment.spec.mjs');
+                expect(rendered).toContain('buildScripts/util/check-block-alignment.mjs');
+                expect(rendered).toContain('c623b2f63c');
+            });
+
+            test('asks for one path in the existing account rather than a new ceremony', () => {
+                expect(rendered).toContain(RETIREMENT_MARKER);
+                expect(rendered).toMatch(/one path is enough/u);
+            });
         });
     });
 


### PR DESCRIPTION
Resolves #17964
Refs #17922

`buildScripts/util/check-spec-retirement.mjs` was already in place when `c623b2f63c` deleted 796 unit specs, and it **passed correctly** — its contract is that an account must EXIST, never that it is TRUE, because no tool can grade "folded into `X`". That contract is right and is not reopened here.

But one half of "true" is not prose at all. **"The subject of this deleted spec is still in this repository"** is a fact about the tree, and it is exactly the half that commit got wrong: one sentence accounted for all 796 deletions, and measured against the tree that commit itself produced, **34 of them had a surviving subject and the account named none.**

## AC Evidence

| AC | |
|---|---|
| AC-1 | **Delivered.** Replaying `c623b2f63c` with its exact account reds with 34 rows, each naming the deleted spec and the file that stayed. The pre-change guard passes the identical input — `hasRetirementAccount` is `true`, which is precisely why the deletion sailed through. |
| AC-2 | **Delivered.** The three genuinely departed subjects (`check-aiconfig-antipatterns`, `check-aiconfig-test-mutation`, `check-atomic-write-shape`) resolve to zero survivors and stay green. The rule narrows what the marker must assert; it never widens it. |
| AC-3 | **Delivered.** The same commit with the surviving paths appended to its account greens. The rule is satisfiable by one line, not a veto. |
| AC-4 | **Delivered.** All ten measured basename collisions are dropped — see *Deltas* below, which is where the real design decision lives. |
| AC-5 | **Delivered.** Three seeded mutations, each killing a distinct arm. One of them killed an arm that was **vacuous**; see *Test Evidence*. |
| AC-6 | **Delivered.** `main()` collects both violation classes and reports them together. Exiting on the first would hide the second behind a fix-and-re-push cycle — a bulk deletion accounted for one sentence at a time is the failure being fixed. |

## Deltas from ticket

**The parent-directory affinity is the load-bearing choice, and it is measured rather than stylistic.** A bare basename rule — `logger.spec.mjs` looks for any `logger.mjs` — was the first draft. Replayed over `c623b2f63c` it produced **ten false positives**:

- four per-server `logger.spec.mjs` files → `src/util/Logger.mjs`
- two per-server `Server.spec.mjs` files → `examples/form/field/fileupload/server.mjs`
- `daemons/orchestrator/scheduling/picker.spec.mjs` → `src/form/field/Picker.mjs`
- `scheduling/pipeline.spec.mjs` → `src/data/Pipeline.mjs`

None of those is the deleted spec's subject. Demanding an account for a file the author never touched is the exact failure the guard's own header warns about — it trains people to route around the check. So the rule requires `<parentDir>/<name>.mjs` and **under-reports rather than over-reports, deliberately**: for an account-demanding guard a false positive is the expensive error, and a missed row is merely the status quo.

**Stated bound, because the ticket this serves is about over-claiming.** #17922 hand-censused 27 surviving subjects under `test/playwright/unit/ai/buildScripts/**`. This instrument sees **22** of them. The five it cannot see have subjects whose filename differs from the spec's — `TicketIndex.spec.mjs` → `tickets.mjs`, `WorkflowConcurrency.spec.mjs` → a `.yml` file — which no mechanical name rule recovers. A guard claiming the full 27 would be the same over-claim #17922 exists to document.

**New finding, recorded as a finding and not absorbed as scope.** The same replay surfaced **12 surviving subjects nothing had censused**, all under `src/ai/**`, all still present at `HEAD` today with no unit coverage: `LockRegistry`, `TransactionService`, `WriteGuard`, `admitWrite`, `deriveSubtreePath`, `parseAgentEnvelope`, `resolveWriteLock`, and `client/{ComponentService,DockService,InstanceService,RuntimeService,TourRunner}`. #17922 explicitly scoped the other 774 deletions out. Restoring these is neither this PR nor #17922 and wants its own leaf — it now has its own leaf: **#17968**, filed under RA-4 and cited from #17964's *Out of Scope* so it cannot be quietly lost.

## Test Evidence

Outside CI, on this branch:

- **Controls run against the real commit through the real module exports**, not a reimplementation — a probe built from my own reconstruction could only confirm it. Negative: 34 unnamed survivors, RED. Positive ×2: departed-subject GREEN, named-account GREEN. False-positive: all ten collisions dropped.
- **Mutation testing, three seeded mutations:**
  - drop the parent-directory affinity → 2 arms red, and the real-commit count goes 34 → 44 as the collisions return
  - make the subject match case-sensitive → 1 arm red, real-commit count 34 → 14 (`DataSyncPipeline.spec.mjs` covers `dataSyncPipeline.mjs`)
  - drop the `test/` exclusion → **initially killed nothing.** That arm was vacuous: its fixture was a sibling `*.spec.mjs`, but the derived suffix ends in `.mjs` and never `.spec.mjs`, so it could not have matched under either version. Re-armed with a non-spec helper inside the test tree, the mutation kills it. The arm is in the diff because it now can fail, not because it passed.
- `npm run test-unit -- test/playwright/unit/buildScripts/checkSpecRetirement.spec.mjs` → **61 passed** (28 on `dev`, so **+33 arms**).
- **Round-1 repairs, each with its own mutation control** (run against the committed fix, restored via `git checkout HEAD --` after each):
  - restore the fail-open tree read (`tryExec` + 1 MB `maxBuffer`) → the `c623b2f63c` collector replay reds; it reports 0 survivors where the repaired path reports 34
  - restore the body-wide account search → both RA-3 arms red
  - `if` → `else if` in `buildReports` → the co-report arm red
  - drop `git.deletedPaths(sha)` at the collector call site → the wiring arm red
- **The consumed path is now measured, not just its helpers**: `git ls-tree -r --name-only HEAD` emits **1,327,472 bytes**; before the fix `defaultGit.treePaths` returned **0 paths**, after it returns **23,288**.
- **Baseline control for the sibling suite.** The full `test/playwright/unit/buildScripts/` run reports **12 failed / 549 passed**. The same 12 fail with my two files reverted to `dev` (535 passed), so they are not mine: they are `templateBuildProcessor` and `esmWorkspaceBuild`, both of which need `dist/parse5.mjs`, absent in a fresh worktree because `dist/` is gitignored — the #17943 lane. Measured by reverting and re-running, not assumed from the filenames.
- **Every lint-staged guard applicable to both files run individually**: `check-whitespace`, `check-shorthand`, `check-jsdoc-types`, `check-ticket-archaeology`, `check-block-alignment`, `check-parse`, `check-derived-domain`, `check-fixed-sleeps`, `check-engine-brain-boundary` — all exit 0. Two of them (`check-ticket-archaeology`, `check-block-alignment`) failed first and are fixed in the diff; the ticket refs moved out of durable comments into this body, which is where they belong.
- **The guard dogfoods itself**: `.husky/pre-push`'s `check-branch-discipline` and the modified `check-spec-retirement` both exit 0 on this branch, and the push ran them live.

Evidence: L3 (the guard replayed over the real `c623b2f63c` tree through its own exports, plus three seeded mutations and a reverted-baseline control) → L3 required for every AC. No residual.

## Post-Merge Validation

- [ ] None required. The negative control is a historical commit, so it is replayable at any time rather than being a post-merge observation.

## Commits

- `test(build): a deleted spec must account for a subject that stayed (#17964)`
- `fix(build): the guard read an unreadable tree as a clean one (#17964)` — RA-1/2/3

Authored by Grace (Anthropic Claude Opus 5, Claude Code). Session cb4705c8-385e-4b5e-9d41-5d6a9d45577c.

