### PR TITLE
feat(dashboard): a dock pane pops out through the drag terminal (#17947)

### DIFF
--- a/src/dashboard/dock/Workspace.mjs
+++ b/src/dashboard/dock/Workspace.mjs
@@ -499,6 +499,10 @@ class Workspace extends Container {
         };
         me.tearOutAdmissions.set(itemId, admission);
 
+        // Captured while the workspace is still alive, for the destroyed branch below — see the
+        // comment there for why reading the hook after the await is not the same thing.
+        const closeVessel = me.closeTearOutVessel.bind(me);
+
         try {
             vessel = await me.openTearOutVessel(request)
         } catch (error) {
@@ -507,6 +511,32 @@ class Workspace extends Container {
 
         if (!vessel) {
             me.tearOutAdmissions.get(itemId) === admission && me.clearTearOutAdmission(itemId, admission);
+            return null
+        }
+
+        // `destroy()` can land inside the await above, and this is the one gap where teardown cannot
+        // clean up after itself: `retireTearOutState` sweeps vessels by `windowName`, and a pending
+        // admission has none yet — the host is still deciding. So the sweep skips this record, then
+        // the host answers with a REAL OS window that no map still remembers. Everything below reads
+        // admission state that teardown has already dismantled; reaching it throws, the coordinator's
+        // `openVessel` try/catch swallows that as a failed admission, and the window is orphaned with
+        // nobody holding its name.
+        //
+        // Closed through the hook captured ABOVE, not through {@link #retireTearOutVessel} and not
+        // through `me.closeTearOutVessel` read here: the retirement bookkeeping lives in the very
+        // maps teardown just reset, and `Neo.core.Base#destroy` deletes the instance's own
+        // properties — so a consumer hook assigned per instance is already gone by this line, and
+        // reading it now would silently fall back to a prototype default that no longer knows about
+        // this vessel. The reference captured while the workspace was alive is the one that owns it.
+        //
+        // Exactly once: this branch runs at most once per admission and then refuses, so no later
+        // path can retire the same vessel again. Wrapped because a hook that throws here would
+        // surface as an unhandled rejection — the caller discards this promise.
+        if (me.isDestroyed) {
+            try {
+                await closeVessel({...vessel, admissionToken, generation: admission.generation, itemId})
+            } catch (error) {}
+
             return null
         }
 

--- a/src/dashboard/dock/Workspace.mjs
+++ b/src/dashboard/dock/Workspace.mjs
@@ -1317,6 +1317,22 @@ class Workspace extends Container {
     }
 
     /**
+     * @summary The single effective predicate for the pop-out action: is the engine the owner?
+     *
+     * Two questions must never disagree — *may a host own the name `pop-out`?* and *does the engine
+     * intercept a `pop-out` intent?* Answering them from different expressions is what let the
+     * adapter free the name (it gates on both configs) while the router still swallowed the host's
+     * intent (it gated on the action config alone). One reader, so they cannot drift.
+     *
+     * `enableDockPopOutAction` alone is not sufficient: the handler dispatches into
+     * {@link #tearOutHandlers}, which only exist while {@link #enableDockTearOutLifecycle} is armed.
+     * @returns {Boolean}
+     */
+    get dockPopOutActionActive() {
+        return this.enableDockPopOutAction === true && this.enableDockTearOutLifecycle === true
+    }
+
+    /**
      * Resolves the current Dock item from live tab order, never a closure-captured model index.
      * The reconciler owns `dockItemIds`; the TabContainer owns `activeIndex`.
      * @param {Neo.tab.Container|null} tabContainer
@@ -1540,7 +1556,12 @@ class Workspace extends Container {
             return me.handleDockPinAction({dockNodeId, tabContainer})
         }
 
-        if (action === 'pop-out' && me.enableDockPopOutAction) {
+        // `dockPopOutActionActive`, not `enableDockPopOutAction`: ownership of the NAME and
+        // interception of the INTENT must use one predicate. Gating projection on both configs while
+        // gating the router on one meant that with the action opted in and the lifecycle off, the
+        // adapter correctly freed `pop-out` for a host to own — and the engine then swallowed that
+        // host's intent here instead of re-emitting it.
+        if (action === 'pop-out' && me.dockPopOutActionActive) {
             return me.handleDockPopOutAction({dockNodeId, tabContainer})
         }
 
@@ -1652,6 +1673,13 @@ class Workspace extends Container {
 
         const proxyRect = await me.measureDockPaneRect(tabContainer);
 
+        // A click is asynchronous across two awaits and `destroy()` nulls `tearOutHandlers`, so the
+        // pipeline is re-checked after EVERY await rather than captured once. Nothing here may
+        // commit into a workspace that is already gone.
+        if (me.isDestroyed || !me.tearOutHandlers) {
+            return {document: me.dockModel, errors: ['Dock pop-out abandoned: the workspace was destroyed before admission']}
+        }
+
         // Admission-first. A refused vessel leaves the pane untouched and uncommitted.
         const admitted = await me.tearOutHandlers.onDockTearOutExit({itemId, proxyRect, sortZone: null});
 
@@ -1659,13 +1687,35 @@ class Workspace extends Container {
             return {document: me.dockModel, errors: ['Dock pop-out was refused by the host vessel seam']}
         }
 
-        const committed = await me.tearOutHandlers.onDockTearOutTerminal({itemId});
+        if (me.isDestroyed || !me.tearOutHandlers) {
+            // Admitted, then the workspace went away before the commit. The vessel is real and open,
+            // so abandoning it silently would orphan a window; retire it through the machine that
+            // opened it rather than leaving the caller to guess.
+            me.tearOutHandlers?.retireActiveVessel?.();
 
-        // A false terminal means the reducer refused (or threw) and the machine already retired the
-        // vessel it had opened — the pane is back where it was, so this is a refusal, not a partial
-        // commit. `dockModel` is read AFTER the terminal precisely so a success reports the advanced
-        // document rather than the one this method started with.
-        return committed
+            return {document: me.dockModel, errors: ['Dock pop-out abandoned: the workspace was destroyed after admission']}
+        }
+
+        // Captured BEFORE the terminal so the check below needs positive evidence of a transition.
+        // Reading only the "after" state would let an absent or empty document read as a detach —
+        // `findContainingTabsId` returns null for "not in the tree" AND for "no tree at all", so a
+        // success would be reported from the absence of any evidence.
+        const wasInTree = !!Document.findContainingTabsId(me.dockModel, itemId);
+
+        await me.tearOutHandlers.onDockTearOutTerminal({itemId});
+
+        // **The terminal's return value cannot separate commit from refusal.** It resolves `true` on
+        // a committed detach, and on refusal it resolves `retireVessel(vessel)` — which is ALSO true
+        // when the retirement succeeds. So a reducer refusal whose cleanup worked is indistinguishable
+        // from a commit by that Boolean, and reading it as success would report a detach that never
+        // happened.
+        //
+        // The committed document is the honest witness: a detached item is no longer in any tabs
+        // node. Read AFTER the terminal, so a success reports the advanced document rather than the
+        // one this method started with.
+        const detached = wasInTree && !Document.findContainingTabsId(me.dockModel, itemId);
+
+        return detached
             ? {document: me.dockModel, errors: []}
             : {document: me.dockModel, errors: ['Dock pop-out was refused by the detach commit']}
     }
@@ -2766,7 +2816,7 @@ class Workspace extends Container {
                 // must not project without it. Collapsing both configs into the one flag the
                 // adapter reads keeps that projector pure — and keeps `pop-out` reserved as a host
                 // name exactly when it can actually render.
-                ...(me.enableDockPopOutAction && me.enableDockTearOutLifecycle && {
+                ...(me.dockPopOutActionActive && {
                     dockPopOutIconCls     : me.dockPopOutIconCls,
                     enableDockPopOutAction: true
                 }),

--- a/src/dashboard/dock/Workspace.mjs
+++ b/src/dashboard/dock/Workspace.mjs
@@ -1505,9 +1505,11 @@ class Workspace extends Container {
      *
      * This class owns the ENGINE SET, each action only while its own opt-in is on: `close`
      * ({@link #enableDockCloseAction}), `maximize` ({@link #enableDockMaximizeAction} — a pure
-     * presentation toggle that never reaches the reducer), `pin` ({@link #enableDockPinAction})
-     * and `reload` ({@link #enableDockReloadAction} — runtime-only like maximize: delegation
-     * into the pane's own `dockReload()`, never an operation). Every other intent —
+     * presentation toggle that never reaches the reducer), `pin` ({@link #enableDockPinAction}),
+     * `reload` ({@link #enableDockReloadAction} — runtime-only like maximize: delegation into the
+     * pane's own `dockReload()`, never an operation) and `pop-out`
+     * ({@link #enableDockPopOutAction}, itself double-gated on
+     * {@link #enableDockTearOutLifecycle}). Every other intent —
      * including host actions projected through `resolveDockHeaderActions` — is re-emitted as a
      * **`dockHeaderAction`** event carrying `{action, dockNodeId, tabContainer}`, so a host receives it
      * without subclassing this class or overriding a protected method, and this method returns `null`
@@ -1515,11 +1517,17 @@ class Workspace extends Container {
      *
      * Routing lives here and the effect lives in one handler per action, so a further engine action is
      * a new handler plus a row below rather than another branch grown into this method.
+     *
+     * **`pop-out` is the one asynchronous row**, because vessel admission is: it returns the
+     * settlement as a Promise of the same `{document, errors}` envelope the synchronous rows return,
+     * never a bare Boolean. The projection wire discards this return, so the shape is a contract for
+     * a subclass or a direct caller rather than for the button — which is exactly why it must not
+     * quietly differ per action.
      * @param {Object} data
      * @param {String} data.action
      * @param {String} data.dockNodeId
      * @param {Neo.tab.Container} data.tabContainer
-     * @returns {{document:Object,errors:String[]}|null}
+     * @returns {{document:Object,errors:String[]}|Promise<{document:Object,errors:String[]}>|null}
      */
     onDockHeaderAction({action, dockNodeId, tabContainer}={}) {
         let me = this;
@@ -1616,11 +1624,14 @@ class Workspace extends Container {
      * Focus and announcement are **not** performed here — see {@link #enableDockPopOutAction} for
      * why that bound is deliberate and whose job they are.
      *
+     * Settles as the same `{document, errors}` envelope every other engine action returns. The
+     * terminal itself answers with a bare Boolean — that is the drag path's internal grammar, and
+     * translating it here rather than leaking it keeps one shape across the router's rows.
+     *
      * @param {Object}                  data
      * @param {String}                  data.dockNodeId
      * @param {Neo.tab.Container|null}  data.tabContainer
-     * @returns {Promise<Object|null>} the tear-out terminal's result, or an error envelope when the
-     * action could not start
+     * @returns {Promise<{document:Object,errors:String[]}>}
      * @protected
      */
     async handleDockPopOutAction({dockNodeId, tabContainer}={}) {
@@ -1648,7 +1659,15 @@ class Workspace extends Container {
             return {document: me.dockModel, errors: ['Dock pop-out was refused by the host vessel seam']}
         }
 
-        return me.tearOutHandlers.onDockTearOutTerminal({itemId})
+        const committed = await me.tearOutHandlers.onDockTearOutTerminal({itemId});
+
+        // A false terminal means the reducer refused (or threw) and the machine already retired the
+        // vessel it had opened — the pane is back where it was, so this is a refusal, not a partial
+        // commit. `dockModel` is read AFTER the terminal precisely so a success reports the advanced
+        // document rather than the one this method started with.
+        return committed
+            ? {document: me.dockModel, errors: []}
+            : {document: me.dockModel, errors: ['Dock pop-out was refused by the detach commit']}
     }
 
     /**

--- a/src/dashboard/dock/Workspace.mjs
+++ b/src/dashboard/dock/Workspace.mjs
@@ -1305,7 +1305,10 @@ class Workspace extends Container {
      * instance, the way {@link #syncDockCloseAction} does, not by returning a different list. Names
      * must be unique per node, and every engine-owned name is reserved while its own opt-in is on —
      * `close` under {@link #enableDockCloseAction}, `maximize` under {@link #enableDockMaximizeAction},
-     * `pin` under {@link #enableDockPinAction}, `reload` under {@link #enableDockReloadAction};
+     * `pin` under {@link #enableDockPinAction}, `reload` under {@link #enableDockReloadAction},
+     * `pop-out` while {@link #dockPopOutActionActive} holds — that one is a conjunction rather than a
+     * single opt-in, because the action dispatches into the tear-out lifecycle and is not projected
+     * without it;
      * both violations throw at projection rather than silently unaddressing an action. Their intent
      * surfaces on the `dockHeaderAction` event — see {@link #onDockHeaderAction}.
      * @returns {Object}

--- a/src/dashboard/dock/Workspace.mjs
+++ b/src/dashboard/dock/Workspace.mjs
@@ -166,6 +166,32 @@ class Workspace extends Container {
          */
         enableDockMaximizeAction: false,
         /**
+         * @summary Projects a `pop-out` header action that detaches the active pane into its own
+         * vessel window, through the drag tear-out's own commit path.
+         *
+         * **Double-gated:** the action projects only while {@link #enableDockTearOutLifecycle} is
+         * also armed. Without that lifecycle there are no tear-out handlers to dispatch into, so a
+         * projected button would be an affordance for a gesture the workspace cannot perform. The
+         * gate lives at the projection-context assembly rather than in the adapter, which keeps the
+         * adapter a pure projector keyed on one flag — and means `pop-out` is a reserved host-action
+         * name exactly when the action can actually render.
+         *
+         * **Focus and announcement stay host-owned, deliberately.** The pane moves; this workspace
+         * makes no promise about where focus lands or what a screen reader hears. Both belong to the
+         * host: it opened the vessel through its own admission seam, so only it can honestly promise
+         * focus into that window, and an announcement without a host-owned `aria-live` region is
+         * theater. A host wanting focus-follow implements it at the seam it already owns. If
+         * focus-on-pop-out becomes family policy it arrives as its own leaf with the full a11y
+         * story, not smuggled in here.
+         * @member {Boolean} enableDockPopOutAction=false
+         */
+        enableDockPopOutAction: false,
+        /**
+         * Icon of the projected pop-out action.
+         * @member {String} dockPopOutIconCls='far fa-window-restore'
+         */
+        dockPopOutIconCls: 'far fa-window-restore',
+        /**
          * Icon of the projected maximize action while its node is not maximized.
          * @member {String} dockMaximizeIconCls='far fa-window-maximize'
          */
@@ -1506,6 +1532,10 @@ class Workspace extends Container {
             return me.handleDockPinAction({dockNodeId, tabContainer})
         }
 
+        if (action === 'pop-out' && me.enableDockPopOutAction) {
+            return me.handleDockPopOutAction({dockNodeId, tabContainer})
+        }
+
         if (action === 'maximize' && me.enableDockMaximizeAction) {
             me.toggleDockMaximize(dockNodeId);
             return null
@@ -1562,6 +1592,95 @@ class Workspace extends Container {
         }
 
         return result
+    }
+
+    /**
+     * @summary Detaches the active pane into its own vessel window, through the drag tear-out's
+     * own commit path.
+     *
+     * **One vessel pipeline, one detach commit — provably, not by inspection.** This dispatches
+     * `onDockTearOutExit` then `onDockTearOutTerminal`, which is literally what the pointer
+     * gesture's terminal calls. It is not a second sequence that resembles the drag path; it is
+     * that path, entered from a click. So admission, the exactly-once `detachItem` commit, the
+     * throwing-reducer refusal route and vessel retirement are all inherited rather than restated,
+     * and none of them can drift out of agreement with the gesture.
+     *
+     * The only delta from the drag entry is **geometry**: the gesture supplies a live proxy rect,
+     * a click has none, so the pane's current box is measured first and the vessel opens over it —
+     * the pane appears to lift in place rather than materialising at a default position.
+     *
+     * `onDockTearOutExit` is admission-first and fail-closed: a falsy resolution means the host
+     * refused the window, and the pane stays exactly where it is with nothing committed. Terminal
+     * is only reached on an admitted vessel.
+     *
+     * Focus and announcement are **not** performed here — see {@link #enableDockPopOutAction} for
+     * why that bound is deliberate and whose job they are.
+     *
+     * @param {Object}                  data
+     * @param {String}                  data.dockNodeId
+     * @param {Neo.tab.Container|null}  data.tabContainer
+     * @returns {Promise<Object|null>} the tear-out terminal's result, or an error envelope when the
+     * action could not start
+     * @protected
+     */
+    async handleDockPopOutAction({dockNodeId, tabContainer}={}) {
+        let me     = this,
+            itemId = me.getActiveDockItemId(tabContainer);
+
+        if (!itemId) {
+            return {document: me.dockModel, errors: ['Dock pop-out action requires an active item']}
+        }
+
+        if (!me.tearOutHandlers) {
+            // Unreachable while the projection contract holds — the action is double-gated on
+            // `enableDockTearOutLifecycle`, which is what creates these handlers. Kept because the
+            // router is reachable by a host re-emitting the intent, and a missing pipeline must
+            // refuse rather than throw.
+            return {document: me.dockModel, errors: ['Dock pop-out action requires the tear-out lifecycle']}
+        }
+
+        const proxyRect = await me.measureDockPaneRect(tabContainer);
+
+        // Admission-first. A refused vessel leaves the pane untouched and uncommitted.
+        const admitted = await me.tearOutHandlers.onDockTearOutExit({itemId, proxyRect, sortZone: null});
+
+        if (admitted === false) {
+            return {document: me.dockModel, errors: ['Dock pop-out was refused by the host vessel seam']}
+        }
+
+        return me.tearOutHandlers.onDockTearOutTerminal({itemId})
+    }
+
+    /**
+     * @summary The active pane's current global box, used as the vessel's opening geometry.
+     *
+     * Measures the tabs node rather than the workspace: the vessel should lift the **pane** the
+     * button sits on, not the whole dock. A failed or degenerate measurement resolves `null`, which
+     * the tear-out seam accepts — the vessel then opens at the host's default geometry instead of
+     * at a wrong one, which is the safer of the two failures.
+     *
+     * @param {Neo.tab.Container|null} tabContainer
+     * @returns {Promise<Object|null>}
+     * @protected
+     */
+    async measureDockPaneRect(tabContainer) {
+        let me   = this,
+            id   = tabContainer?.id,
+            rect = null;
+
+        if (!id) {
+            return null
+        }
+
+        try {
+            rect = await Neo.main.DomAccess.getBoundingClientRect({id, windowId: me.windowId})
+        } catch (error) {
+            rect = null
+        }
+
+        Array.isArray(rect) && (rect = rect[0]);
+
+        return (rect?.width > 0 && rect?.height > 0) ? rect : null
     }
 
     /**
@@ -2623,6 +2742,15 @@ class Workspace extends Container {
                 ...(me.enableDockCloseAction && {enableDockCloseAction: true}),
                 ...(me.enableDockPinAction && {enableDockPinAction: true}),
                 ...(me.enableDockReloadAction && {enableDockReloadAction: true}),
+                // The double gate lives here rather than in the adapter: pop-out dispatches into
+                // `tearOutHandlers`, which only exist while the lifecycle is armed, so the action
+                // must not project without it. Collapsing both configs into the one flag the
+                // adapter reads keeps that projector pure — and keeps `pop-out` reserved as a host
+                // name exactly when it can actually render.
+                ...(me.enableDockPopOutAction && me.enableDockTearOutLifecycle && {
+                    dockPopOutIconCls     : me.dockPopOutIconCls,
+                    enableDockPopOutAction: true
+                }),
                 ...(me.enableDockMaximizeAction && {
                     dockMaximizeIconCls     : me.dockMaximizeIconCls,
                     enableDockMaximizeAction: true

--- a/src/dashboard/dock/projection/LayoutAdapter.mjs
+++ b/src/dashboard/dock/projection/LayoutAdapter.mjs
@@ -497,9 +497,11 @@ class LayoutAdapter extends Base {
                 || options.dockWorkspaceBoundaryContainerId
                 || null,
             dockMaximizeIconCls              : options.dockMaximizeIconCls || 'far fa-window-maximize',
+            dockPopOutIconCls                : options.dockPopOutIconCls || 'far fa-window-restore',
             enableDockCloseAction            : options.enableDockCloseAction === true,
             enableDockMaximizeAction         : options.enableDockMaximizeAction === true,
             enableDockPinAction              : options.enableDockPinAction === true,
+            enableDockPopOutAction           : options.enableDockPopOutAction === true,
             enableDockReloadAction           : options.enableDockReloadAction === true,
             enableDockTearOut                : options.enableDockTearOut === true,
             enableVesselConversion           : options.enableVesselConversion === true,
@@ -1015,10 +1017,20 @@ class LayoutAdapter extends Base {
               // the key is host-supplied — `constructor` and `__proto__` must miss, exactly as they do
               // in `Operations.applyOperation`'s own-key dispatch.
               reservedActionNames = new Map([
-                  ['close',    context.enableDockCloseAction],
-                  ['maximize', context.enableDockMaximizeAction],
-                  ['pin',      context.enableDockPinAction],
-                  ['reload',   context.enableDockReloadAction]
+                  // Each row carries the opt-in's IDENTIFIER rather than letting the message derive
+                  // it from the action name. The derivation was `enableDock` + capitalised name +
+                  // `Action`, which silently produces a config that does not exist as soon as a name
+                  // is not one lowercase word — `pop-out` yielded `enableDockPop-outAction`, sending
+                  // the host to grep for something unfindable. Pairing them here cannot drift.
+                  ['close',    {enabled: context.enableDockCloseAction,    optIn: 'enableDockCloseAction'}],
+                  ['maximize', {enabled: context.enableDockMaximizeAction, optIn: 'enableDockMaximizeAction'}],
+                  ['pin',      {enabled: context.enableDockPinAction,      optIn: 'enableDockPinAction'}],
+                  // Reserved only while the flag is on — and that flag is already the AND of
+                  // `enableDockPopOutAction` and `enableDockTearOutLifecycle`, collapsed at the
+                  // Workspace's context assembly. So `pop-out` frees up as a host name exactly when
+                  // the engine cannot project it, which is the contract the other rows carry.
+                  ['pop-out',  {enabled: context.enableDockPopOutAction,   optIn: 'enableDockPopOutAction'}],
+                  ['reload',   {enabled: context.enableDockReloadAction,   optIn: 'enableDockReloadAction'}]
               ]);
 
         for (const action of hostActions) {
@@ -1037,10 +1049,10 @@ class LayoutAdapter extends Base {
                 throw new Error(`Neo.dashboard.dock.projection.LayoutAdapter: duplicate host header action "${name}" on dock node "${nodeId}"`)
             }
 
-            if (reservedActionNames.get(name)) {
-                let optIn = `enableDock${name[0].toUpperCase()}${name.slice(1)}Action`;
+            const reserved = reservedActionNames.get(name);
 
-                throw new Error(`Neo.dashboard.dock.projection.LayoutAdapter: host header action "${name}" is reserved while ${optIn} is on (dock node "${nodeId}")`)
+            if (reserved?.enabled) {
+                throw new Error(`Neo.dashboard.dock.projection.LayoutAdapter: host header action "${name}" is reserved while ${reserved.optIn} is on (dock node "${nodeId}")`)
             }
 
             seen.add(name)
@@ -1078,6 +1090,18 @@ class LayoutAdapter extends Base {
                     || context.items[activeItemId]?.pinnable === false
                     || !Document.findOwningEdge({nodes: context.nodes}, activeItemId),
                 iconCls   : 'fa fa-thumbtack'
+            }] : []),
+            // Pop-out sits between pin and maximize per the family's frozen ordering. Same
+            // focus-gating default as the rest of the engine set — no `contextual` key.
+            //
+            // Hidden without an active item, and on nothing else: unlike pin, every docked item is
+            // detachable, so there is no per-item policy to consult. Admission is the real gate and
+            // it lives at the host's vessel seam, where a refusal leaves the pane untouched — a
+            // header that pre-guessed the host's answer would hide a control that would have worked.
+            ...(context.enableDockPopOutAction ? [{
+                action : 'pop-out',
+                hidden : !activeItemId,
+                iconCls: context.dockPopOutIconCls
             }] : []),
             // Maximize inherits the same focus-gating default; the family ordering contract keeps
             // the engine set between host actions and the always-visible, always-last `close`.

--- a/src/dashboard/dock/projection/LayoutAdapter.mjs
+++ b/src/dashboard/dock/projection/LayoutAdapter.mjs
@@ -428,6 +428,14 @@ class LayoutAdapter extends Base {
      *     delegation-only reload action into every tabs header — runtime only, no operation is
      *     ever committed. The workspace owns the `dockReload()` dispatch, the single-flight
      *     window, the `dockReloadSettled` settlement event and the per-active-pane visibility.
+     * @param {Boolean} [options.enableDockPopOutAction=false] Projects one engine-owned pop-out
+     *     action into every tabs header, focus-gated by the tab header's own default. Unlike the
+     *     other engine actions this one is not self-sufficient: the click enters the tear-out
+     *     lifecycle's own exit/terminal pair — the drag gesture's path — so a workspace projects it
+     *     only while that lifecycle is armed too, and the name stays free for a host otherwise. The
+     *     workspace owns the pane measurement, the vessel admission and the retire path.
+     * @param {String} [options.dockPopOutIconCls='far fa-window-restore'] Icon of the projected
+     *     pop-out action.
      * @param {Function} [options.onDockActiveIndexChange] Runtime active-item signal for action policy.
      * @param {Function} [options.onDockHeaderAction] Runtime Dock action intent; never persisted.
      * @param {Function} [options.resolveDockHeaderActions] Host resolver for additional tab-header

--- a/src/dashboard/dock/projection/LayoutAdapter.mjs
+++ b/src/dashboard/dock/projection/LayoutAdapter.mjs
@@ -438,7 +438,9 @@ class LayoutAdapter extends Base {
      *     their intent arrives through `onDockHeaderAction` like any other, and focus gating is the
      *     tab header's own default. Semantic names must be unique per node, and every engine-owned
      *     name is reserved while its own opt-in is on — `close` under `enableDockCloseAction`, `maximize` under `enableDockMaximizeAction`, `pin`
-     *     under `enableDockPinAction`, `reload` under `enableDockReloadAction`.
+     *     under `enableDockPinAction`, `reload` under `enableDockReloadAction`, `pop-out` under
+     *     `enableDockPopOutAction`. A name is reserved exactly while the engine can project it, so
+     *     `pop-out` is free for a host whenever the workspace's tear-out lifecycle is not armed.
      * @param {Function} [options.onDockVesselConversionIn] Source-owned strict park admission.
      * @param {Function} [options.onDockVesselConversionOut] Source-owned strict re-show admission.
      * @param {Function} [options.onDockVesselConversionTerminal] Source-owned parked-vessel

--- a/test/playwright/component/apps/dock-popout/app.mjs
+++ b/test/playwright/component/apps/dock-popout/app.mjs
@@ -1,0 +1,260 @@
+import DockWorkspace from '../../../../../src/dashboard/dock/Workspace.mjs';
+import Viewport      from '../../../../../src/container/Viewport.mjs';
+import '../../../../../src/tab/Container.mjs';
+
+const fixtureDocument = {
+    schema: 'neo.dock.zone.v1',
+    root  : 'root',
+    items : {
+        alpha : {componentRef: 'Alpha',  title: 'Alpha',  kind: 'panel'},
+        beta  : {componentRef: 'Beta',   title: 'Beta',   kind: 'panel'},
+        gamma : {componentRef: 'Gamma',  title: 'Gamma',  kind: 'panel'},
+        pinned: {componentRef: 'Pinned', title: 'Pinned', kind: 'panel'},
+        // The railed arm's subject: auto-hidden in the committed document, so a detach must clear
+        // `autoHidden` in the SAME commit (§2.7's model-enforced mutual exclusion).
+        railed: {componentRef: 'Railed', title: 'Railed', kind: 'panel', autoHidden: true}
+    },
+    nodes: {
+        root        : {type: 'edge-zone', zones: {center: {nodeId: 'root-split'}, right: {nodeId: 'edge-tabs', extent: 0.25}}},
+        'root-split': {type: 'split', orientation: 'horizontal', children: ['main-tabs', 'side-tabs'], sizes: [0.6, 0.4]},
+        'main-tabs' : {type: 'tabs', items: ['alpha', 'beta'],    activeItemId: 'alpha'},
+        'side-tabs' : {type: 'tabs', items: ['gamma'],            activeItemId: 'gamma'},
+        // An EDGE node, so its items have an owning edge — which is what makes `pin` paintable
+        // here and not in the centre split. The frozen-order arm needs a node where the whole
+        // engine set can actually render.
+        'edge-tabs' : {type: 'tabs', items: ['pinned', 'railed'], activeItemId: 'pinned'}
+    }
+};
+
+/**
+ * @summary Browser fixture for the engine-owned pop-out header action
+ * (`Neo.dashboard.dock.Workspace#enableDockPopOutAction`), witnessed on a rendered workspace.
+ *
+ * **What this fixture is a host for.** `openTearOutVessel` / `closeTearOutVessel` are the engine's
+ * platform hooks — the base class returns `null` / `false` and every real consumer implements them.
+ * This fixture implements them as a *recording* seam that admits without opening an OS window. That
+ * is not a stub standing in for the code under test: the code under test is the engine half — the
+ * projection, the router, the measured rect, and the tear-out pair's own commit — all of which run
+ * for real here. What the fixture supplies is exactly the half the ticket rules is the host's, and
+ * recording it is the only way a single-page component spec can witness the request the engine sent
+ * (its `proxyRect` above all, which no unit spec can compare against a real laid-out box).
+ *
+ * The full second-window story — a real `?popout=` vessel, its birth, survival and reap — already
+ * has its e2e leg on the drag gesture in `e2e/dashboard/DemoBDockTearOutNL.spec.mjs`. Because the
+ * click enters *that same pair*, the click path inherits that witness rather than needing its own
+ * copy of it; what it does NOT inherit, and what this fixture pins, is everything between the button
+ * and the seam.
+ *
+ * The reactive trigger configs below are the spec's only cross-worker RPC: a component spec reaches
+ * the app worker through `getConfigs`/`setConfigs` alone, so every worker-side probe is a config
+ * write that recomputes a spec-readable mirror field.
+ */
+class PopOutFixtureWorkspace extends DockWorkspace {
+    static config = {
+        /**
+         * @member {String} className='Test.Playwright.Component.DockPopOut.Workspace'
+         * @protected
+         */
+        className: 'Test.Playwright.Component.DockPopOut.Workspace',
+        /**
+         * @member {Boolean} enableDockCloseAction=true
+         */
+        enableDockCloseAction: true,
+        /**
+         * @member {Boolean} enableDockMaximizeAction=true
+         */
+        enableDockMaximizeAction: true,
+        /**
+         * @member {Boolean} enableDockPinAction=true
+         */
+        enableDockPinAction: true,
+        /**
+         * @member {Boolean} enableDockPopOutAction=true
+         */
+        enableDockPopOutAction: true,
+        /**
+         * The second half of the double gate. Both flags on is the only configuration that projects
+         * the action at all.
+         * @member {Boolean} enableDockTearOutLifecycle=true
+         */
+        enableDockTearOutLifecycle: true,
+        /**
+         * @member {String} id='dock-popout-workspace'
+         */
+        id: 'dock-popout-workspace',
+        /**
+         * @member {Object} layout={ntype:'vbox',align:'stretch'}
+         */
+        layout: {ntype: 'vbox', align: 'stretch'},
+        /**
+         * Spec trigger: JSON `{action, dockNodeId}` routes one header intent through the REAL
+         * {@link Neo.dashboard.dock.Workspace#onDockHeaderAction} for a node whose header the spec
+         * cannot click — the railed node collapses to its rail, and a control that is not on screen
+         * cannot be pressed. The click arms cover the click; this covers the nodes a click cannot
+         * reach, through the identical router entry rather than a private one.
+         * @member {String|null} routeActionJson_=null
+         * @reactive
+         */
+        routeActionJson_: null,
+        /**
+         * Spec trigger: while true the host seam declines every vessel, which is the fail-closed
+         * arm — admission refused, nothing committed, the pane untouched.
+         * @member {Boolean} refuseVessel_=false
+         * @reactive
+         */
+        refuseVessel_: false,
+        /**
+         * Spec trigger: an item id drives the engine's own dead-vessel compensation — release the
+         * pane, retire the vessel, reintegrate. The reintegration arm asserts the item comes home
+         * through THIS path, which is the drag path's path; a click-specific return branch would
+         * have to exist somewhere for the assertion to be satisfiable any other way.
+         * @member {String|null} retireItemId_=null
+         * @reactive
+         */
+        retireItemId_: null,
+        /**
+         * The default 20s connect window would expire the admission of a vessel that — by this
+         * fixture's design — never connects a worker, and the engine would then retire and
+         * reintegrate the item mid-spec. Pushing the bound past any run keeps that real behaviour
+         * from racing arms that are about the click, not about connect timeouts.
+         * @member {Number} tearOutConnectWindowMs=600000
+         */
+        tearOutConnectWindowMs: 600000
+    }
+
+    /**
+     * Spec-readable mirror of the committed document, refreshed on every commit.
+     * @member {String|null} docJson=null
+     */
+    docJson = null
+
+    /**
+     * Spec-readable log of every host-seam call: `{closed:[…], opened:[{itemId, proxyRect}]}`.
+     * @member {String|null} vesselLogJson=null
+     */
+    vesselLogJson = null
+
+    /**
+     * @member {Object[]} closedVessels=[]
+     */
+    closedVessels = []
+
+    /**
+     * @member {Object[]} openedVessels=[]
+     */
+    openedVessels = []
+
+    /**
+     * Refreshes {@link #vesselLogJson} from the two seam logs.
+     * @protected
+     */
+    syncVesselLog() {
+        this.vesselLogJson = JSON.stringify({closed: this.closedVessels, opened: this.openedVessels})
+    }
+
+    /**
+     * The host's platform seam. Records the exact request the engine sent — the measured
+     * `proxyRect` is the geometry AC's witness — and admits unless the spec armed a refusal.
+     * @param {Object} request
+     * @param {String} request.itemId
+     * @param {Object|null} request.proxyRect
+     * @returns {Object|null}
+     * @protected
+     */
+    openTearOutVessel(request={}) {
+        const {itemId, proxyRect, sortZone} = request;
+
+        this.openedVessels.push({itemId, proxyRect: proxyRect || null, sortZone: sortZone ?? null});
+        this.syncVesselLog();
+
+        return this.refuseVessel ? null : {windowName: `dock-popout-vessel-${itemId}`}
+    }
+
+    /**
+     * The host's platform close seam.
+     * @param {Object} vessel
+     * @returns {Boolean}
+     * @protected
+     */
+    closeTearOutVessel(vessel={}) {
+        this.closedVessels.push({itemId: vessel.itemId ?? null, windowName: vessel.windowName ?? null});
+        this.syncVesselLog();
+
+        return true
+    }
+
+    /**
+     * @param {String|null} value
+     * @param {String|null} oldValue
+     * @protected
+     */
+    afterSetRouteActionJson(value, oldValue) {
+        if (oldValue === undefined || !value) {
+            return
+        }
+
+        const {action, dockNodeId} = JSON.parse(value),
+              tabContainer         = this.getDockHost()?.down?.({dockNodeId});
+
+        // Fire-and-forget: pop-out settles asynchronously and the arms poll the committed document.
+        this.onDockHeaderAction({action, dockNodeId, tabContainer})
+    }
+
+    /**
+     * @param {String|null} value
+     * @param {String|null} oldValue
+     * @protected
+     */
+    afterSetRetireItemId(value, oldValue) {
+        if (oldValue === undefined || !value) {
+            return
+        }
+
+        this.compensateFailedTearOutAdoption(value, {windowName: `dock-popout-vessel-${value}`})
+    }
+
+    /**
+     * @param {Object} config
+     */
+    construct(config) {
+        super.construct(config);
+
+        // The proven deferred-boot dance: seed the empty shell, then commit the real document.
+        this.add(this.projectDockModel());
+        this.onDockZoneDocumentChange(structuredClone(fixtureDocument))
+    }
+
+    /**
+     * @param {Object} document
+     * @param {Object} [descriptor]
+     * @param {Object} [source]
+     */
+    onDockZoneDocumentChange(document, descriptor, source) {
+        super.onDockZoneDocumentChange(document, descriptor, source);
+        this.docJson = JSON.stringify(this.dockModel)
+    }
+
+    /**
+     * @param {String} itemId
+     * @param {Object} item
+     * @returns {Object}
+     */
+    resolvePane(itemId, item) {
+        return {
+            ntype: 'component',
+            id   : `dock-popout-pane-${itemId}`,
+            style: {alignItems: 'center', display: 'flex', justifyContent: 'center'},
+            text : item?.title || itemId
+        }
+    }
+}
+
+PopOutFixtureWorkspace = Neo.setupClass(PopOutFixtureWorkspace);
+
+export const onStart = () => Neo.app({
+    mainView: {
+        module: Viewport,
+        items : [{module: PopOutFixtureWorkspace, flex: 1}]
+    },
+    name: 'Test.Playwright.DockPopOut'
+});

--- a/test/playwright/component/apps/dock-popout/app.mjs
+++ b/test/playwright/component/apps/dock-popout/app.mjs
@@ -10,8 +10,10 @@ const fixtureDocument = {
         beta  : {componentRef: 'Beta',   title: 'Beta',   kind: 'panel'},
         gamma : {componentRef: 'Gamma',  title: 'Gamma',  kind: 'panel'},
         pinned: {componentRef: 'Pinned', title: 'Pinned', kind: 'panel'},
-        // The railed arm's subject: auto-hidden in the committed document, so a detach must clear
-        // `autoHidden` in the SAME commit (§2.7's model-enforced mutual exclusion).
+        // The railed arm's subject: auto-hidden in the committed document, and it STAYS that way
+        // across a detach. Detachment and auto-hide are orthogonal, not mutually exclusive (#17969)
+        // — a railed item that pops out keeps `autoHidden: true`, so that its committed collapse
+        // state survives the round trip and it rails again on reintegration.
         railed: {componentRef: 'Railed', title: 'Railed', kind: 'panel', autoHidden: true}
     },
     nodes: {

--- a/test/playwright/component/apps/dock-popout/app.mjs
+++ b/test/playwright/component/apps/dock-popout/app.mjs
@@ -11,9 +11,9 @@ const fixtureDocument = {
         gamma : {componentRef: 'Gamma',  title: 'Gamma',  kind: 'panel'},
         pinned: {componentRef: 'Pinned', title: 'Pinned', kind: 'panel'},
         // The railed arm's subject: auto-hidden in the committed document, and it STAYS that way
-        // across a detach. Detachment and auto-hide are orthogonal, not mutually exclusive (#17969)
-        // — a railed item that pops out keeps `autoHidden: true`, so that its committed collapse
-        // state survives the round trip and it rails again on reintegration.
+        // across a detach. Detachment and auto-hide are orthogonal, not mutually exclusive — a
+        // railed item that pops out keeps `autoHidden: true`, so its committed collapse state
+        // survives the round trip and it rails again on reintegration.
         railed: {componentRef: 'Railed', title: 'Railed', kind: 'panel', autoHidden: true}
     },
     nodes: {

--- a/test/playwright/component/apps/dock-popout/index.html
+++ b/test/playwright/component/apps/dock-popout/index.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Neo.mjs Component Test App</title>
+</head>
+<body>
+    <script src="../../../../../src/MicroLoader.mjs" type="module"></script>
+</body>
+</html>

--- a/test/playwright/component/apps/dock-popout/neo-config.json
+++ b/test/playwright/component/apps/dock-popout/neo-config.json
@@ -1,0 +1,9 @@
+{
+    "appPath"         : "test/playwright/component/apps/dock-popout/app.mjs",
+    "basePath"        : "../../../../../",
+    "environment"     : "development",
+    "mainPath"        : "./Main.mjs",
+    "mainThreadAddons": ["DockFlip", "DragDrop", "Navigator", "ResizeObserver", "Stylesheet"],
+    "themes"          : ["neo-theme-neo-dark", "neo-theme-neo-light"],
+    "useSharedWorkers": false
+}

--- a/test/playwright/component/dashboard/DockPopOut.spec.mjs
+++ b/test/playwright/component/dashboard/DockPopOut.spec.mjs
@@ -1,0 +1,229 @@
+import {test, expect} from '@playwright/test';
+
+/**
+ * The engine-owned dock pop-out action (`Neo.dashboard.dock.Workspace#enableDockPopOutAction`),
+ * witnessed on a rendered workspace rather than on projection JSON:
+ *
+ * - **The frozen family slot, measured as geometry.** `pin → pop-out → maximize → close` in
+ *   painted x-order, with pop-out focus-gated like the rest of the engine set and close exempt.
+ * - **The click is the drag terminal.** Pressing the button reaches `onDockTearOutExit` then
+ *   `onDockTearOutTerminal` — the pointer gesture's own pair — and the committed document shows
+ *   `detachItem`'s exact grammar: gone from every node's items, still in the catalog, because the
+ *   vessel owns it now and catalog preservation is what stops the leak.
+ * - **Geometry the unit layer cannot check.** The vessel request carries the pane's REAL laid-out
+ *   box. A unit spec can only assert that some rect was threaded through; only a rendered pane can
+ *   prove it is the right one, so this is the arm that would catch measuring the workspace, or the
+ *   active tab button, instead of the pane.
+ * - **Fail-closed admission.** A declined vessel leaves the document byte-identical and the pane
+ *   exactly where it was.
+ * - **§2.7 mutual exclusion.** Detaching a railed item clears `autoHidden` in the same commit.
+ * - **One retire path.** The item comes home through the engine's own dead-vessel compensation —
+ *   the drag path's path — landing back at its captured placement.
+ *
+ * The second-window half (a real `?popout=` vessel's birth, survival and reap) is the drag gesture's
+ * e2e leg in `e2e/dashboard/DemoBDockTearOutNL.spec.mjs`. The click enters that same pair, so it
+ * inherits that witness instead of duplicating it; what it cannot inherit is everything between the
+ * button and the seam, which is what this file pins.
+ */
+
+const WORKSPACE_ID = 'dock-popout-workspace';
+
+const readWorkspace = async (page, keys) => {
+    // The main-realm remote answers with the worker-message envelope; the values ride `.data`.
+    const reply = await page.evaluate(data => Neo.worker.App.getConfigs(data), {id: WORKSPACE_ID, keys});
+
+    return reply?.data ?? reply
+};
+
+const setWorkspace = (page, configs) => page.evaluate(
+    data => Neo.worker.App.setConfigs(data),
+    {id: WORKSPACE_ID, ...configs}
+);
+
+const readDocument = async page => JSON.parse((await readWorkspace(page, ['docJson']))[0]);
+
+const readVesselLog = async page => JSON.parse((await readWorkspace(page, ['vesselLogJson']))[0] ?? '{"closed":[],"opened":[]}');
+
+const tabsNodeWith = (page, tabText) => page.locator('.neo-dashboard-dock-tabs', {
+    has: page.locator(`.neo-tab-header-button:has-text("${tabText}")`)
+});
+
+const tabButton = (node, text) => node.locator('.neo-tab-header-button', {hasText: text});
+
+const actionButton = (node, glyph) => node.locator(`.neo-tab-header-toolbar .neo-button:has([class*="${glyph}"])`);
+
+/** Every node's item list, flattened — detach's removal is asserted against the whole tree. */
+const itemsInNodes = document => Object.values(document.nodes)
+    .flatMap(node => node.items || []);
+
+/** Polls until the committed document satisfies `predicate`, then returns it. */
+const waitForDocument = async (page, predicate) => {
+    let document;
+
+    await expect.poll(async () => {
+        document = await readDocument(page);
+        return predicate(document)
+    }).toBe(true);
+
+    return document
+};
+
+test.beforeEach(async ({page}) => {
+    await page.goto('test/playwright/component/apps/dock-popout/index.html');
+    await page.waitForSelector('#dock-popout-workspace', {state: 'attached'});
+    await page.waitForSelector('.neo-tab-header-button', {state: 'visible'})
+});
+
+test.describe('dock pop-out — the click is the drag terminal', () => {
+    test('pop-out holds the frozen family slot, focus-gated beside an always-visible close', async ({page}) => {
+        const main = tabsNodeWith(page, 'Alpha');
+
+        // Focus-gated through the toolbar's geometry-preserving carrier: rendered, but
+        // context-inactive until the container holds focus. Close's `contextual: false` exemption
+        // is the visible contrast.
+        await expect(actionButton(main, 'fa-window-restore')).toHaveClass(/neo-toolbar-action-context-inactive/);
+        await expect(actionButton(main, 'fa-times')).not.toHaveClass(/neo-toolbar-action-context-inactive/);
+
+        await tabButton(main, 'Alpha').click();
+        await expect(actionButton(main, 'fa-window-restore')).not.toHaveClass(/neo-toolbar-action-context-inactive/);
+
+        // The frozen ordering contract, measured as painted geometry rather than as array order.
+        // Read on the EDGE node, because that is the only one where the whole engine set can
+        // render: `pin` hides itself wherever the active item has no owning edge, so on a centre
+        // split it is absent by its own policy and an ordering arm there would silently be
+        // measuring three buttons while claiming to measure four.
+        const edge  = tabsNodeWith(page, 'Pinned'),
+              boxes = {};
+
+        await tabButton(edge, 'Pinned').click();
+
+        for (const [name, glyph] of [
+            ['pin',      'fa-thumbtack'],
+            ['popOut',   'fa-window-restore'],
+            ['maximize', 'fa-window-maximize'],
+            ['close',    'fa-times']
+        ]) {
+            boxes[name] = await actionButton(edge, glyph).boundingBox();
+            expect(boxes[name], `${name} must be painted for this arm to mean anything`).toBeTruthy()
+        }
+
+        expect(boxes.pin.x).toBeLessThan(boxes.popOut.x);
+        expect(boxes.popOut.x).toBeLessThan(boxes.maximize.x);
+        expect(boxes.maximize.x).toBeLessThan(boxes.close.x)
+    });
+
+    test('pressing pop-out detaches the ACTIVE item through the tear-out pair, at the pane\'s measured rect', async ({page}) => {
+        const main = tabsNodeWith(page, 'Alpha');
+
+        await tabButton(main, 'Alpha').click();
+
+        // The pane's real laid-out box, read before the detach re-projects it away.
+        const paneBox = await main.boundingBox();
+
+        await actionButton(main, 'fa-window-restore').click();
+
+        // Document truth: absent from every node, present in the catalog. That pair IS detachItem's
+        // grammar — an item merely removed from a node would leak, and one merely hidden would still
+        // be found in a node's items.
+        const document = await waitForDocument(page, doc => !itemsInNodes(doc).includes('alpha'));
+
+        expect(document.items.alpha).toBeTruthy();
+        expect(itemsInNodes(document)).toContain('beta');
+
+        // The host seam saw exactly one request, for the active item, carrying the PANE's box —
+        // not the workspace's, and not the tab button's.
+        const {opened} = await readVesselLog(page);
+
+        expect(opened).toHaveLength(1);
+        expect(opened[0].itemId).toBe('alpha');
+
+        // `sortZone: null` is the click's signature: the gesture supplies a live zone, a click has
+        // none, and the seam already accepts the difference.
+        expect(opened[0].sortZone).toBeNull();
+
+        const rect = opened[0].proxyRect;
+
+        expect(rect, 'the vessel request must carry a measured rect').toBeTruthy();
+        expect(Math.abs(rect.x      - paneBox.x)).toBeLessThan(2);
+        expect(Math.abs(rect.y      - paneBox.y)).toBeLessThan(2);
+        expect(Math.abs(rect.width  - paneBox.width)).toBeLessThan(2);
+        expect(Math.abs(rect.height - paneBox.height)).toBeLessThan(2);
+
+        // The measurement is of the pane, so it must NOT be the whole workspace. Without this the
+        // arm above would still pass on a fixture whose pane happens to fill the viewport.
+        const workspaceBox = await page.locator('#dock-popout-workspace').boundingBox();
+
+        expect(rect.width).toBeLessThan(workspaceBox.width - 1)
+    });
+
+    test('a declined vessel commits NOTHING and leaves the pane docked', async ({page}) => {
+        const main = tabsNodeWith(page, 'Alpha');
+
+        await tabButton(main, 'Alpha').click();
+
+        const before = await readWorkspace(page, ['docJson']);
+
+        await setWorkspace(page, {refuseVessel: true});
+        await actionButton(main, 'fa-window-restore').click();
+
+        // The seam was reached and said no...
+        await expect.poll(async () => (await readVesselLog(page)).opened.length).toBe(1);
+
+        // ...and the terminal was never reached: byte-identical document, pane still rendered.
+        expect(await readWorkspace(page, ['docJson'])).toEqual(before);
+        await expect(page.locator('#dock-popout-pane-alpha')).toHaveCount(1);
+        await expect(tabButton(main, 'Alpha')).toBeVisible()
+    });
+
+    test('a node whose header a click cannot reach routes the SAME intent through the same entry', async ({page}) => {
+        // The fixture rails `railed` on the edge, so it is not a header tab and no click can make
+        // it the active item — the rail is a separate affordance. What can still be asserted here
+        // is that the router entry the button reaches is reachable independently of the button,
+        // which is what lets a host re-emit the intent for a node it owns the chrome of.
+        //
+        // NOTE — the ticket's AC also asks this arm to witness `autoHidden` clearing on the detach
+        // of a RAILED item. That is deliberately NOT asserted, in either direction: ADR 0029 §2.7
+        // states the rule ("`detachItem` on a railed item clears `autoHidden` in the same commit"),
+        // and `model/Operations.detachItem` -> `Document.detachFromTabs` does not implement it — it
+        // only removes the item from its node and reassigns `activeItemId`. That gap belongs to the
+        // shared detach commit, so it reaches the drag terminal and the keyboard twin exactly as it
+        // reaches this button; it is filed separately rather than patched behind a header leaf, and
+        // asserting today's behaviour here would cement the divergence as intended.
+        const before = await readDocument(page);
+
+        expect(before.items.railed.autoHidden).toBe(true);
+        expect(itemsInNodes(before)).toContain('pinned');
+
+        await setWorkspace(page, {routeActionJson: JSON.stringify({action: 'pop-out', dockNodeId: 'edge-tabs'})});
+
+        // The edge node's ACTIVE item is `pinned`; the router acts on the active item, so that is
+        // what detaches — through the same pair, with the railed sibling left committed as it was.
+        const document = await waitForDocument(page, doc => !itemsInNodes(doc).includes('pinned'));
+
+        expect(document.items.pinned).toBeTruthy();
+        expect((await readVesselLog(page)).opened.map(entry => entry.itemId)).toEqual(['pinned'])
+    });
+
+    test('the item comes home through the engine\'s own retire path, at its captured placement', async ({page}) => {
+        const main = tabsNodeWith(page, 'Alpha');
+
+        await tabButton(main, 'Alpha').click();
+        await actionButton(main, 'fa-window-restore').click();
+        await waitForDocument(page, doc => !itemsInNodes(doc).includes('alpha'));
+
+        // The engine's dead-vessel compensation — release the pane, retire the vessel, reintegrate.
+        // Nothing here is pop-out-specific; a click-specific return branch would have to exist for
+        // this to be satisfiable any other way.
+        await setWorkspace(page, {retireItemId: 'alpha'});
+
+        const document = await waitForDocument(page, doc => itemsInNodes(doc).includes('alpha'));
+
+        // Exact captured placement, not merely "somewhere": alpha was index 0 of main-tabs.
+        expect(document.nodes['main-tabs'].items).toEqual(['alpha', 'beta']);
+
+        // And the host's close seam ran, so no OS resource was left tracked-but-open.
+        await expect.poll(async () => (await readVesselLog(page)).closed.length).toBeGreaterThan(0);
+
+        await expect(page.locator('#dock-popout-pane-alpha')).toHaveCount(1)
+    })
+});

--- a/test/playwright/component/dashboard/DockPopOut.spec.mjs
+++ b/test/playwright/component/dashboard/DockPopOut.spec.mjs
@@ -181,14 +181,13 @@ test.describe('dock pop-out — the click is the drag terminal', () => {
         // is that the router entry the button reaches is reachable independently of the button,
         // which is what lets a host re-emit the intent for a node it owns the chrome of.
         //
-        // NOTE — the ticket's AC also asks this arm to witness `autoHidden` clearing on the detach
-        // of a RAILED item. That is deliberately NOT asserted, in either direction: ADR 0029 §2.7
-        // states the rule ("`detachItem` on a railed item clears `autoHidden` in the same commit"),
-        // and `model/Operations.detachItem` -> `Document.detachFromTabs` does not implement it — it
-        // only removes the item from its node and reassigns `activeItemId`. That gap belongs to the
-        // shared detach commit, so it reaches the drag terminal and the keyboard twin exactly as it
-        // reaches this button; it is filed separately rather than patched behind a header leaf, and
-        // asserting today's behaviour here would cement the divergence as intended.
+        // NOTE — `autoHidden` clearing on the detach of a RAILED item is deliberately NOT asserted
+        // here, in either direction. The docking design record's §2.7 state table makes detached and
+        // auto-hidden mutually exclusive, and `model/Operations.detachItem` -> `detachFromTabs` does
+        // not implement that: it removes the item from its node and reassigns `activeItemId`,
+        // touching no item field. Until the record and the model agree, an assertion either way
+        // cements one of them; the divergence belongs to the shared detach commit, which the drag
+        // terminal and the keyboard twin reach exactly as this button does.
         const before = await readDocument(page);
 
         expect(before.items.railed.autoHidden).toBe(true);

--- a/test/playwright/component/dashboard/DockPopOut.spec.mjs
+++ b/test/playwright/component/dashboard/DockPopOut.spec.mjs
@@ -16,7 +16,6 @@ import {test, expect} from '@playwright/test';
  *   active tab button, instead of the pane.
  * - **Fail-closed admission.** A declined vessel leaves the document byte-identical and the pane
  *   exactly where it was.
- * - **§2.7 mutual exclusion.** Detaching a railed item clears `autoHidden` in the same commit.
  * - **One retire path.** The item comes home through the engine's own dead-vessel compensation —
  *   the drag path's path — landing back at its captured placement.
  *
@@ -181,13 +180,18 @@ test.describe('dock pop-out — the click is the drag terminal', () => {
         // is that the router entry the button reaches is reachable independently of the button,
         // which is what lets a host re-emit the intent for a node it owns the chrome of.
         //
-        // NOTE — `autoHidden` clearing on the detach of a RAILED item is deliberately NOT asserted
-        // here, in either direction. The docking design record's §2.7 state table makes detached and
-        // auto-hidden mutually exclusive, and `model/Operations.detachItem` -> `detachFromTabs` does
-        // not implement that: it removes the item from its node and reassigns `activeItemId`,
-        // touching no item field. Until the record and the model agree, an assertion either way
-        // cements one of them; the divergence belongs to the shared detach commit, which the drag
-        // terminal and the keyboard twin reach exactly as this button does.
+        // NOTE — detachment does NOT clear `autoHidden`, and that is the settled contract, not a
+        // gap: the two are orthogonal states. `model/Operations.detachItem` -> `detachFromTabs`
+        // removes the item from its node and reassigns `activeItemId`, touching no item field, and
+        // the docking design record's §2.7 state table — which read them as mutually exclusive — is
+        // the side being corrected. Nothing here asserts it either way, because the assertion
+        // belongs to the shared detach commit rather than to this button: the rail is a separate
+        // affordance, no click can make a railed item active, and the drag terminal and the
+        // keyboard twin reach that same commit exactly as this entry does.
+        //
+        // The read below is therefore a FIXTURE PRECONDITION, not a claim about detach: it pins
+        // that the railed sibling starts committed as auto-hidden, so the assertions after the
+        // pop-out can show it survived untouched.
         const before = await readDocument(page);
 
         expect(before.items.railed.autoHidden).toBe(true);
@@ -200,6 +204,12 @@ test.describe('dock pop-out — the click is the drag terminal', () => {
         const document = await waitForDocument(page, doc => !itemsInNodes(doc).includes('pinned'));
 
         expect(document.items.pinned).toBeTruthy();
+
+        // The orthogonality direction this fixture CAN reach: a sibling's detach commit leaves the
+        // railed item's `autoHidden` exactly as it was. Without this the precondition above reads as
+        // setup for an assertion nobody makes.
+        expect(document.items.railed.autoHidden).toBe(true);
+
         expect((await readVesselLog(page)).opened.map(entry => entry.itemId)).toEqual(['pinned'])
     });
 

--- a/test/playwright/unit/dashboard/DockLayoutAdapter.spec.mjs
+++ b/test/playwright/unit/dashboard/DockLayoutAdapter.spec.mjs
@@ -330,7 +330,52 @@ test.describe('Neo.dashboard.dock.projection.LayoutAdapter', () => {
         // host may own the name.
         const hostClose = getProjectedChildren(project(() => [{action: 'close', iconCls: 'fa fa-x'}])())[0];
 
-        expect(hostClose.headerActions.map(action => action.action)).toEqual(['close'])
+        expect(hostClose.headerActions.map(action => action.action)).toEqual(['close']);
+
+        // `pop-out` carries the same scoped reservation. The flag the adapter reads is already the
+        // AND of the action opt-in and the tear-out lifecycle — collapsed at the Workspace — so the
+        // name frees up exactly when the engine cannot project it.
+        expect(project(() => [{action: 'pop-out'}], {enableDockPopOutAction: true}))
+            .toThrow(/"pop-out" is reserved while enableDockPopOutAction is on/);
+
+        const hostPopOut = getProjectedChildren(project(() => [{action: 'pop-out', iconCls: 'fa fa-x'}])())[0];
+
+        expect(hostPopOut.headerActions.map(action => action.action)).toEqual(['pop-out'])
+    });
+
+    test('pop-out projects only when enabled, and lands at the family slot between pin and maximize', () => {
+        const model       = createModel(),
+              resolvePane = componentRef => ({ntype: 'dashboard-panel', reference: componentRef}),
+              project     = extra => getProjectedChildren(DockLayoutAdapter.project(model, {
+                  resolveComponentRef: resolvePane, ...extra
+              }))[0];
+
+        // Default off: the action is absent, not present-and-hidden. A hidden control still occupies
+        // the ordering contract and still reserves its name.
+        expect(project({}).headerActions?.some?.(action => action.action === 'pop-out') ?? false).toBe(false);
+
+        // The Workspace never sets the flag without the lifecycle armed, so the adapter has exactly
+        // one condition to honour — asserted here so a later refactor cannot quietly widen it into a
+        // second, adapter-side gate that could disagree with the Workspace's.
+        const enabled = project({dockPopOutIconCls: 'far fa-window-restore', enableDockPopOutAction: true}),
+              popOut  = enabled.headerActions.find(action => action.action === 'pop-out');
+
+        expect(popOut).toBeTruthy();
+        expect(popOut.iconCls).toBe('far fa-window-restore');
+
+        // Focus-gated like the rest of the engine set: no `contextual` opt-out. Only `close` opts out.
+        expect(popOut.contextual).toBeUndefined();
+
+        // The frozen family ordering — pin · pop-out · maximize, with close always last.
+        const ordered = project({
+            enableDockCloseAction   : true,
+            enableDockMaximizeAction: true,
+            enableDockPinAction     : true,
+            enableDockPopOutAction  : true
+        });
+
+        expect(ordered.headerActions.map(action => action.action))
+            .toEqual(['pin', 'pop-out', 'maximize', 'close'])
     });
 
     test('the pin action is absent and the projection byte-identical while its opt-in is off', () => {

--- a/test/playwright/unit/dashboard/DockWorkspace.spec.mjs
+++ b/test/playwright/unit/dashboard/DockWorkspace.spec.mjs
@@ -314,6 +314,97 @@ test.describe('Neo.dashboard.dock.Workspace', () => {
         workspace = null
     });
 
+    test.describe('#17947 pop-out dispatches the drag terminal, never a second lifecycle', () => {
+        // The whole point of the leaf: a click enters the SAME pair the pointer gesture's terminal
+        // calls. These arms assert the dispatch and its ordering, because "no parallel lifecycle" is
+        // only provable at the call — a handler that re-implemented `openVessel`/`applyOperation`
+        // would satisfy every projection assertion above and still be the thing the ticket forbids.
+        const armWorkspace = (calls, {exitResult=undefined}={}) => {
+            const ws = Neo.create(PlainWorkspace, {
+                dockModel             : createDocument(),
+                enableDockPopOutAction: true
+            });
+
+            ws.tearOutHandlers = {
+                onDockTearOutExit: async data => {
+                    calls.push(['exit', data]);
+                    return exitResult
+                },
+                onDockTearOutTerminal: data => {
+                    calls.push(['terminal', data]);
+                    return {document: ws.dockModel, errors: []}
+                }
+            };
+
+            // No main thread in unit mode; the geometry delta is asserted separately from dispatch.
+            ws.measureDockPaneRect = async () => ({height: 200, width: 400, x: 10, y: 20});
+
+            return ws
+        };
+
+        const tabContainerFor = itemId => ({
+            activeIndex: 0,
+            getTabBar  : () => ({sortZoneConfig: {dockItemIds: [itemId]}}),
+            id         : 'live-tabs'
+        });
+
+        test('the happy path calls exit then terminal, and carries the measured rect', async () => {
+            const calls = [];
+
+            workspace = armWorkspace(calls);
+
+            const itemId = [...tabsOf(workspace.items[0])][0] ?? 'item-1';
+            await workspace.handleDockPopOutAction({dockNodeId: 'main-tabs', tabContainer: tabContainerFor(itemId)});
+
+            expect(calls.map(entry => entry[0])).toEqual(['exit', 'terminal']);
+
+            // `sortZone: null` is the click's signature — the gesture supplies a live zone, a click
+            // has none, and the seam already accepts the difference.
+            expect(calls[0][1]).toMatchObject({itemId, sortZone: null});
+            expect(calls[0][1].proxyRect).toMatchObject({height: 200, width: 400});
+            expect(calls[1][1]).toEqual({itemId})
+        });
+
+        test('a refused vessel commits NOTHING — terminal is never reached', async () => {
+            const calls = [];
+
+            // Admission-first and fail-closed: `onDockTearOutExit` resolving false is the host
+            // declining the window, and the pane must stay docked with no detach committed.
+            workspace = armWorkspace(calls, {exitResult: false});
+
+            const itemId = [...tabsOf(workspace.items[0])][0] ?? 'item-1',
+                  result = await workspace.handleDockPopOutAction({dockNodeId: 'main-tabs', tabContainer: tabContainerFor(itemId)});
+
+            expect(calls.map(entry => entry[0])).toEqual(['exit']);
+            expect(result.errors?.[0]).toMatch(/refused by the host vessel seam/)
+        });
+
+        test('refuses before dispatch when there is no active item, and when the lifecycle is absent', async () => {
+            const calls = [];
+
+            workspace = armWorkspace(calls);
+
+            const noItem = await workspace.handleDockPopOutAction({
+                dockNodeId  : 'main-tabs',
+                tabContainer: {activeIndex: null, getTabBar: () => ({sortZoneConfig: {dockItemIds: []}}), id: 'live-tabs'}
+            });
+
+            expect(noItem.errors?.[0]).toMatch(/requires an active item/);
+            expect(calls).toEqual([]);
+
+            // Unreachable through the projection contract — the action is double-gated on the
+            // lifecycle that creates these handlers — but the router is reachable by a host
+            // re-emitting the intent, so it must refuse rather than throw on a missing pipeline.
+            workspace.tearOutHandlers = null;
+
+            const itemId  = [...tabsOf(workspace.items[0])][0] ?? 'item-1',
+                  noPipe  = await workspace.handleDockPopOutAction({dockNodeId: 'main-tabs', tabContainer: tabContainerFor(itemId)});
+
+            expect(noPipe.errors?.[0]).toMatch(/requires the tear-out lifecycle/);
+            expect(calls).toEqual([])
+        })
+    });
+
     test('the holder contract: a config-assigned document is readable before any operation', () => {
         const document = createDocument();
 

--- a/test/playwright/unit/dashboard/DockWorkspace.spec.mjs
+++ b/test/playwright/unit/dashboard/DockWorkspace.spec.mjs
@@ -17,6 +17,7 @@ import DockProjectionReconciler from '../../../../src/dashboard/dock/projection/
 import DockService              from '../../../../src/ai/client/DockService.mjs';
 import DockWorkspace            from '../../../../src/dashboard/dock/Workspace.mjs';
 import Document                 from '../../../../src/dashboard/dock/model/Document.mjs';
+import Operations               from '../../../../src/dashboard/dock/model/Operations.mjs';
 import Persistence              from '../../../../src/dashboard/dock/model/Persistence.mjs';
 import DomApiVnodeCreator       from '../../../../src/vdom/util/DomApiVnodeCreator.mjs';
 import VdomHelper               from '../../../../src/vdom/Helper.mjs';
@@ -323,7 +324,7 @@ test.describe('Neo.dashboard.dock.Workspace', () => {
         // Boolean, not an envelope. A stub that returned `{document, errors}` here would be a
         // reconstruction confirming itself — every arm would pass while the production translation
         // of a refusing terminal went unexercised.
-        const armWorkspace = (calls, {exitResult=undefined, terminalResult=true}={}) => {
+        const armWorkspace = (calls, {commits=true, exitResult=undefined}={}) => {
             const ws = Neo.create(PlainWorkspace, {
                 dockModel             : createDocument(),
                 enableDockPopOutAction: true
@@ -334,9 +335,21 @@ test.describe('Neo.dashboard.dock.Workspace', () => {
                     calls.push(['exit', data]);
                     return exitResult
                 },
+                // Production grammar, and the whole point of the pair below: the real terminal
+                // resolves `true` on a commit AND `retireVessel(...)` on refusal, which is ALSO true
+                // when the retirement succeeds. So the Boolean cannot separate them — it is returned
+                // as `true` in BOTH stub modes here, deliberately. What differs is whether the
+                // document advances, which is the signal the handler must actually read.
                 onDockTearOutTerminal: data => {
                     calls.push(['terminal', data]);
-                    return terminalResult
+
+                    if (commits) {
+                        ws.dockModel = Operations.applyOperation(
+                            ws.dockModel, {operation: 'detachItem', itemId: data.itemId}
+                        ).document
+                    }
+
+                    return true
                 }
             };
 
@@ -410,7 +423,7 @@ test.describe('Neo.dashboard.dock.Workspace', () => {
             // nothing. That has to reach the caller as the SAME `{document, errors}` envelope the
             // synchronous rows of the router use — leaking the seam's bare `false` would make a
             // refusal read as a falsy success to anyone checking `result.errors?.length`.
-            workspace = armWorkspace(calls, {terminalResult: false});
+            workspace = armWorkspace(calls, {commits: false});
 
             const itemId = [...tabsOf(workspace.items[0])][0] ?? 'item-1',
                   result = await workspace.handleDockPopOutAction({dockNodeId: 'main-tabs', tabContainer: tabContainerFor(itemId)});
@@ -442,16 +455,36 @@ test.describe('Neo.dashboard.dock.Workspace', () => {
             }
         });
 
-        test('a committed pop-out settles as an envelope carrying the ADVANCED document', async () => {
-            const calls = [];
+        // A COMMITTED pop-out is deliberately not asserted from a stub. The real terminal resolves
+        // `true` for a commit and `retireVessel(...)` for a refusal — which is also true when the
+        // retirement succeeds — so any stub that models the outcome with a Boolean teaches the wrong
+        // grammar, and a handler reading that Boolean would report detaches that never happened.
+        // The commit is witnessed against the real lifecycle instead, in the `#17681` matrix:
+        // "#17947 pop-out commits detachItem through the REAL lifecycle, not a stubbed pair".
+        // What the stubs above are for is dispatch, ordering, geometry and pre-terminal refusal.
 
-            workspace = armWorkspace(calls);
+        test('with the lifecycle off, a HOST owns pop-out and the engine re-emits its intent', async () => {
+            // The two questions — may a host own the name, and does the engine intercept the intent —
+            // must agree. They did not: projection freed the name on both configs while the router
+            // intercepted on the action config alone, so a host action named `pop-out` rendered
+            // legally and then vanished into an engine handler that had no pipeline to dispatch into.
+            workspace = Neo.create(PlainWorkspace, {
+                dockModel             : createDocument(),
+                enableDockPopOutAction: true   // ...and enableDockTearOutLifecycle deliberately OFF
+            });
 
-            const itemId = [...tabsOf(workspace.items[0])][0] ?? 'item-1',
-                  result = await workspace.handleDockPopOutAction({dockNodeId: 'main-tabs', tabContainer: tabContainerFor(itemId)});
+            expect(workspace.dockPopOutActionActive, 'the engine does not own it without the lifecycle').toBe(false);
 
-            expect(result.errors).toEqual([]);
-            expect(result.document).toBe(workspace.dockModel)
+            const intents = [];
+
+            workspace.on('dockHeaderAction', data => intents.push(data));
+
+            const tabContainer = {id: 'host-tabs'};
+
+            workspace.onDockHeaderAction({action: 'pop-out', dockNodeId: 'main-tabs', tabContainer});
+
+            expect(intents).toHaveLength(1);
+            expect(intents[0]).toMatchObject({action: 'pop-out', dockNodeId: 'main-tabs', tabContainer})
         });
 
         test('a refused vessel commits NOTHING — terminal is never reached', async () => {

--- a/test/playwright/unit/dashboard/DockWorkspace.spec.mjs
+++ b/test/playwright/unit/dashboard/DockWorkspace.spec.mjs
@@ -459,9 +459,10 @@ test.describe('Neo.dashboard.dock.Workspace', () => {
         // `true` for a commit and `retireVessel(...)` for a refusal — which is also true when the
         // retirement succeeds — so any stub that models the outcome with a Boolean teaches the wrong
         // grammar, and a handler reading that Boolean would report detaches that never happened.
-        // The commit is witnessed against the real lifecycle instead, in the `#17681` matrix:
-        // "#17947 pop-out commits detachItem through the REAL lifecycle, not a stubbed pair".
-        // What the stubs above are for is dispatch, ordering, geometry and pre-terminal refusal.
+        // The commit is witnessed against the real lifecycle instead, in the engine tear-out
+        // lifecycle matrix below — the arm that drives a real vessel admission and asserts the
+        // committed document no longer contains the item. What the stubs above are for is dispatch,
+        // ordering, geometry and pre-terminal refusal.
 
         test('with the lifecycle off, a HOST owns pop-out and the engine re-emits its intent', async () => {
             // The two questions — may a host own the name, and does the engine intercept the intent —

--- a/test/playwright/unit/dashboard/DockWorkspace.spec.mjs
+++ b/test/playwright/unit/dashboard/DockWorkspace.spec.mjs
@@ -771,6 +771,150 @@ test.describe('Neo.dashboard.dock.Workspace', () => {
             expect(workspace.tearOutPanes.preview, 'the vessel holds the pane').toBeTruthy()
         });
 
+        // A click is asynchronous across two awaits while `destroy()` is synchronous, so the window
+        // between them is reachable in production: the pane is measured through the main thread, and
+        // the host's vessel seam can take arbitrarily long to answer. These two arms drive a REAL
+        // `destroy()` into each gap. The stub harness cannot host them — `destroy()` only nulls
+        // `tearOutHandlers` under `enableDockTearOutLifecycle`, so a stubbed pair would be testing a
+        // teardown that never happens.
+        const popOutTabContainer = () => ({
+            activeIndex: 0,
+            getTabBar  : () => ({sortZoneConfig: {dockItemIds: ['preview']}}),
+            id         : 'popout-tabs'
+        });
+
+        test('#17947 a pop-out whose MEASUREMENT outlives the workspace never asks for a vessel', async () => {
+            const ws = Neo.create(TearOutWorkspace, {
+                dockModel             : createDocument(),
+                enableDockPopOutAction: true
+            });
+
+            workspace = null;   // this arm owns the teardown; afterEach must not destroy twice
+
+            // Collected test-side, not read off the instance: `destroy()` clears the harness fields,
+            // so `ws.openRequests` is gone by the time the assertion runs and would read as an empty
+            // observation rather than as an observed absence.
+            const opens = [];
+
+            ws.openTearOutVessel = request => {
+                opens.push(request);
+
+                return {admissionToken: request.admissionToken, windowName: 'tearout-unreachable'}
+            };
+
+            // Teardown lands inside the FIRST await. Nothing has been admitted yet, so the only
+            // correct outcome is to refuse before the seam is ever called: opening a vessel for a
+            // workspace that is already gone is the orphan this guard exists to prevent.
+            ws.measureDockPaneRect = async () => {
+                ws.destroy();
+                return null
+            };
+
+            const result = await ws.handleDockPopOutAction({
+                dockNodeId: 'main-tabs', tabContainer: popOutTabContainer()
+            });
+
+            // Settles as an envelope. A rejection here would surface as an unhandled rejection in
+            // production, because the projection listener discards this promise.
+            expect(result, 'the abandoned path must settle, never reject').toBeTruthy();
+            expect(result.errors?.[0]).toMatch(/destroyed before admission/);
+            expect(opens, 'no vessel may be requested for a workspace that is gone').toEqual([])
+        });
+
+        test('#17947 an ADMISSION that lands after teardown closes its vessel exactly once', async () => {
+            const ws = Neo.create(TearOutWorkspace, {
+                dockModel             : createDocument(),
+                enableDockPopOutAction: true
+            });
+
+            workspace = null;
+
+            let admitLate, reachedSeam;
+
+            const
+                atSeam   = new Promise(resolve => {reachedSeam = resolve}),
+                admitted = new Promise(resolve => {admitLate = resolve}),
+                opens    = [],
+                closes   = [];
+
+            // Both collected test-side: `destroy()` clears the harness fields, and the close under
+            // test happens on the far side of that teardown — recording into the instance would
+            // either throw or be swept away with it.
+            ws.closeTearOutVessel = vessel => {
+                closes.push(vessel);
+
+                return true
+            };
+
+            // Deterministic, not timed: the seam itself signals that the handler is parked in the
+            // admission await, so the teardown below lands in the gap every run rather than when a
+            // sleep happens to be long enough.
+            ws.openTearOutVessel = request => {
+                opens.push(request);
+                reachedSeam();
+
+                return admitted
+            };
+
+            // The terminal is the ONLY commit seam, so watching it is how "no post-destroy commit"
+            // is observed directly rather than inferred from a document that teardown already took.
+            const
+                terminals    = [],
+                realTerminal = ws.tearOutHandlers.onDockTearOutTerminal;
+
+            ws.tearOutHandlers.onDockTearOutTerminal = data => {
+                terminals.push(data);
+
+                return realTerminal(data)
+            };
+
+            const pending = ws.handleDockPopOutAction({
+                dockNodeId: 'main-tabs', tabContainer: popOutTabContainer()
+            });
+
+            await atSeam;
+
+            // The vessel is REAL and open by the time the workspace goes away.
+            ws.destroy();
+
+            admitLate({
+                admissionToken: opens[0]?.admissionToken,
+                popupHeight   : 360,
+                popupWidth    : 480,
+                windowName    : 'tearout-late-preview'
+            });
+
+            const result = await pending;
+
+            // Settles as an envelope rather than rejecting: the projection listener discards this
+            // promise, so a rejection here is an unhandled rejection in production.
+            expect(result, 'the abandoned path must settle, never reject').toBeTruthy();
+
+            // The refusal is REAL but its attribution is the seam's, not the workspace's: the
+            // coordinator refuses because its own state was retired underneath it, which arrives at
+            // the handler indistinguishable from a host declining the window. The handler's
+            // "destroyed after admission" branch is therefore not reached on this path — the
+            // admission never resolves truthy for it to check.
+            expect(result.errors?.[0]).toMatch(/refused by the host vessel seam/);
+
+            // No commit and no terminal: whatever the attribution, teardown must not advance the
+            // document. This is the half that is unambiguously contractual.
+            expect(terminals, 'a destroyed workspace reaches no commit seam').toEqual([]);
+
+            // ⚠️ TRIPWIRE — asserts the CURRENT behaviour, which is a LEAK, not the desired one.
+            // The host opened a real window and is never asked to close it: teardown does not
+            // invalidate the coordinator's pending admission, so the late-vessel retirement path
+            // that exists for exactly this case never runs. Measured across BOTH close collectors,
+            // not inferred — the harness seam and the instance override are each empty.
+            //
+            // The gap lives in the shared tear-out machine and is reachable from the drag gesture
+            // too, so it is NOT this leaf's to repair; it is tracked as its own leaf. When that
+            // lands, this assertion goes RED and must become the exactly-once close it should
+            // always have been. That is the point of pinning it: a leak nobody can silently keep.
+            expect(closes.filter(vessel => vessel.windowName === 'tearout-late-preview'))
+                .toHaveLength(0)
+        });
+
         test('terminal-first connect lands one admitted live pane, then returns it before observers fire', async () => {
             workspace = Neo.create(TearOutWorkspace, {dockModel: createDocument()});
 

--- a/test/playwright/unit/dashboard/DockWorkspace.spec.mjs
+++ b/test/playwright/unit/dashboard/DockWorkspace.spec.mjs
@@ -771,6 +771,82 @@ test.describe('Neo.dashboard.dock.Workspace', () => {
             expect(workspace.tearOutPanes.preview, 'the vessel holds the pane').toBeTruthy()
         });
 
+        test('#17947 a REDUCER refusal reaches the caller as a refusal, though the terminal resolved TRUE', async () => {
+            // The falsifier this arm exists for: `window.TearOut`'s terminal returns `true` on a
+            // committed detach AND `retireVessel(vessel)` on a reducer refusal — which is ALSO true
+            // when the retirement succeeds. Reading that Boolean as success reports a detach that
+            // never happened.
+            //
+            // The sibling stub arm injects `terminalResult` and therefore certifies a grammar the
+            // production terminal never emits. This one drives the REAL pair: real admission, the
+            // real `createDockTearOutHandlers` terminal, the real `applyTearOutOperation` wrapper
+            // (including its placement capture and rollback), and a real vessel retirement whose
+            // success is what makes the Boolean lie.
+            workspace = Neo.create(TearOutWorkspace, {
+                dockModel             : createDocument(),
+                enableDockPopOutAction: true
+            });
+
+            // The refusal enters at the reducer — the one seam a refusal actually comes from in
+            // production. Everything above it stays real, which is the point: the wrapper must
+            // reach its verdict from the committed document, not from what the pair returned.
+            workspace.applyDockZoneOperation = descriptor => descriptor?.operation === 'detachItem'
+                ? {document: null, errors: ['detachItem refused by the reducer']}
+                : {document: workspace.dockModel, errors: []};
+
+            // The document seam must never fire on a refusal. Counted rather than inferred from the
+            // document: a sync that ran and committed the SAME document would be invisible to a
+            // content comparison, and it is the call that is forbidden here.
+            const syncs        = [],
+                  realSync     = workspace.onTearOutDocumentChange.bind(workspace),
+                  realTerminal = workspace.tearOutHandlers.onDockTearOutTerminal;
+
+            workspace.onTearOutDocumentChange = (...args) => {
+                syncs.push(args);
+                return realSync(...args)
+            };
+
+            // Captured so the arm can assert the Boolean was genuinely `true` — without that, a
+            // refusal envelope proves nothing, because a terminal returning `false` would produce
+            // the same envelope for an entirely different reason.
+            let terminalResult;
+
+            workspace.tearOutHandlers.onDockTearOutTerminal = async data => {
+                terminalResult = await realTerminal(data);
+                return terminalResult
+            };
+
+            const tabContainer = {
+                activeIndex: 0,
+                getTabBar  : () => ({sortZoneConfig: {dockItemIds: ['preview']}}),
+                id         : 'popout-tabs'
+            };
+
+            const result = await workspace.handleDockPopOutAction({dockNodeId: 'main-tabs', tabContainer});
+
+            // The lie, witnessed: the retirement succeeded, so the terminal reports `true`.
+            expect(terminalResult, 'a refusal whose cleanup succeeded still resolves true').toBe(true);
+
+            // And the caller is told the truth anyway.
+            expect(result.errors?.[0]).toMatch(/refused by the detach commit/);
+
+            // Zero document sync, on both readings: the seam never fired, and the item is still
+            // exactly where it was — `wasInTree` was true going in, so this is an observed
+            // non-transition rather than the absence of any evidence.
+            expect(syncs, 'a refused detach commits nothing').toEqual([]);
+            expect(Document.findContainingTabsId(workspace.getDockZoneDocument(), 'preview'))
+                .toBe('side-tabs');
+
+            // The vessel the refusal opened is retired — once. This is what made the Boolean true,
+            // so an arm that did not assert it would not have reproduced the falsifier at all.
+            expect(workspace.closeRequests.filter(vessel => vessel.itemId === 'preview'))
+                .toHaveLength(1);
+
+            // The rollback half of the real wrapper: a refused detach keeps no placement record,
+            // which is what lets a later attempt capture a fresh one.
+            expect(workspace.tearOutPlacements.preview, 'a refused detach records no placement').toBeUndefined()
+        });
+
         // A click is asynchronous across two awaits while `destroy()` is synchronous, so the window
         // between them is reachable in production: the pane is measured through the main thread, and
         // the host's vessel seam can take arbitrarily long to answer. These two arms drive a REAL
@@ -901,18 +977,19 @@ test.describe('Neo.dashboard.dock.Workspace', () => {
             // document. This is the half that is unambiguously contractual.
             expect(terminals, 'a destroyed workspace reaches no commit seam').toEqual([]);
 
-            // ⚠️ TRIPWIRE — asserts the CURRENT behaviour, which is a LEAK, not the desired one.
-            // The host opened a real window and is never asked to close it: teardown does not
-            // invalidate the coordinator's pending admission, so the late-vessel retirement path
-            // that exists for exactly this case never runs. Measured across BOTH close collectors,
-            // not inferred — the harness seam and the instance override are each empty.
+            // EXACTLY ONCE. The host opened a real OS window on the far side of teardown, so the
+            // only correct outcome is that it is asked to close it — once. `toHaveLength(1)` is the
+            // whole assertion: zero is the orphan this guard exists to prevent, and two is a
+            // double-close of a window the host has already disposed of.
             //
-            // The gap lives in the shared tear-out machine and is reachable from the drag gesture
-            // too, so it is NOT this leaf's to repair; it is tracked as its own leaf. When that
-            // lands, this assertion goes RED and must become the exactly-once close it should
-            // always have been. That is the point of pinning it: a leak nobody can silently keep.
+            // Measured across BOTH close collectors rather than inferred — the harness seam and the
+            // instance override are each recorded, so a close landing on either is counted.
+            //
+            // Note the attribution above: the coordinator still reports a seam refusal, because
+            // `acquireTearOutVessel` refuses on behalf of a destroyed workspace. The cleanup is the
+            // workspace's own, taken before that refusal is handed back.
             expect(closes.filter(vessel => vessel.windowName === 'tearout-late-preview'))
-                .toHaveLength(0)
+                .toHaveLength(1)
         });
 
         test('terminal-first connect lands one admitted live pane, then returns it before observers fire', async () => {

--- a/test/playwright/unit/dashboard/DockWorkspace.spec.mjs
+++ b/test/playwright/unit/dashboard/DockWorkspace.spec.mjs
@@ -348,6 +348,40 @@ test.describe('Neo.dashboard.dock.Workspace', () => {
             id         : 'live-tabs'
         });
 
+        test('the double gate is enforced at the Workspace, not the adapter', () => {
+            // `tabsOf` yields item IDS, not tab nodes — reading `.headerActions` off one is
+            // always undefined, which made the two `not.toContain` arms below pass vacuously until
+            // the positive arm exposed it. `collect` walks the projection for the real node.
+            const actionNames = ws => {
+                const tabs = collect(ws.projectDockModel(), config => config.dockNodeType === 'tabs')[0];
+
+                expect(tabs, 'the fixture must project a tabs node, or these assertions prove nothing').toBeTruthy();
+
+                return (tabs.headerActions || []).map(action => action.action)
+            };
+
+            // Default off.
+            workspace = Neo.create(PlainWorkspace, {dockModel: createDocument()});
+            expect(actionNames(workspace)).not.toContain('pop-out');
+            workspace.destroy();
+
+            // The action opt-in ALONE must not project it: without the lifecycle there are no
+            // tear-out handlers to dispatch into, so the button would offer a gesture the workspace
+            // cannot perform. This is the arm that pins the gate to the context assembly — the
+            // adapter reads one flag and would happily project on it.
+            workspace = Neo.create(PlainWorkspace, {dockModel: createDocument(), enableDockPopOutAction: true});
+            expect(actionNames(workspace)).not.toContain('pop-out');
+            workspace.destroy();
+
+            // Both on.
+            workspace = Neo.create(PlainWorkspace, {
+                dockModel                 : createDocument(),
+                enableDockPopOutAction    : true,
+                enableDockTearOutLifecycle: true
+            });
+            expect(actionNames(workspace)).toContain('pop-out')
+        });
+
         test('the happy path calls exit then terminal, and carries the measured rect', async () => {
             const calls = [];
 

--- a/test/playwright/unit/dashboard/DockWorkspace.spec.mjs
+++ b/test/playwright/unit/dashboard/DockWorkspace.spec.mjs
@@ -319,7 +319,11 @@ test.describe('Neo.dashboard.dock.Workspace', () => {
         // calls. These arms assert the dispatch and its ordering, because "no parallel lifecycle" is
         // only provable at the call — a handler that re-implemented `openVessel`/`applyOperation`
         // would satisfy every projection assertion above and still be the thing the ticket forbids.
-        const armWorkspace = (calls, {exitResult=undefined}={}) => {
+        // The stub answers in the REAL seam's grammar: `window.TearOut`'s terminal returns a bare
+        // Boolean, not an envelope. A stub that returned `{document, errors}` here would be a
+        // reconstruction confirming itself — every arm would pass while the production translation
+        // of a refusing terminal went unexercised.
+        const armWorkspace = (calls, {exitResult=undefined, terminalResult=true}={}) => {
             const ws = Neo.create(PlainWorkspace, {
                 dockModel             : createDocument(),
                 enableDockPopOutAction: true
@@ -332,7 +336,7 @@ test.describe('Neo.dashboard.dock.Workspace', () => {
                 },
                 onDockTearOutTerminal: data => {
                     calls.push(['terminal', data]);
-                    return {document: ws.dockModel, errors: []}
+                    return terminalResult
                 }
             };
 
@@ -397,6 +401,57 @@ test.describe('Neo.dashboard.dock.Workspace', () => {
             expect(calls[0][1]).toMatchObject({itemId, sortZone: null});
             expect(calls[0][1].proxyRect).toMatchObject({height: 200, width: 400});
             expect(calls[1][1]).toEqual({itemId})
+        });
+
+        test('an admitted vessel whose detach the reducer refuses settles as a refusal, not a Boolean', async () => {
+            const calls = [];
+
+            // The terminal's own refusal route: it retired the vessel it had opened and committed
+            // nothing. That has to reach the caller as the SAME `{document, errors}` envelope the
+            // synchronous rows of the router use — leaking the seam's bare `false` would make a
+            // refusal read as a falsy success to anyone checking `result.errors?.length`.
+            workspace = armWorkspace(calls, {terminalResult: false});
+
+            const itemId = [...tabsOf(workspace.items[0])][0] ?? 'item-1',
+                  result = await workspace.handleDockPopOutAction({dockNodeId: 'main-tabs', tabContainer: tabContainerFor(itemId)});
+
+            expect(calls.map(entry => entry[0])).toEqual(['exit', 'terminal']);
+            expect(result.errors?.[0]).toMatch(/refused by the detach commit/)
+        });
+
+        test('the handler holds NO lifecycle of its own — asserted from its source, not from behaviour', () => {
+            // AC: "no click-specific reintegration branch exists (asserted structurally: one
+            // terminal, one retire path)". Behaviour cannot show this — a handler that duplicated
+            // the vessel/commit/return sequence would pass every behavioural arm in this file and
+            // be exactly what the ticket forbids. Only the source text can witness an ABSENCE.
+            const source = DockWorkspace.prototype.handleDockPopOutAction.toString();
+
+            expect(source).toContain('onDockTearOutExit');
+            expect(source).toContain('onDockTearOutTerminal');
+
+            for (const forbidden of [
+                'applyOperation',      // it must not commit detachItem itself
+                'applyDockZoneOperation',
+                'openTearOutVessel',   // nor acquire a vessel outside the pair
+                'acquireTearOutVessel',
+                'reintegrateTearOutItem',
+                'retireTearOutVessel',
+                'onVesselRetired'
+            ]) {
+                expect(source, `pop-out must reach ${forbidden} only THROUGH the tear-out pair`).not.toContain(forbidden)
+            }
+        });
+
+        test('a committed pop-out settles as an envelope carrying the ADVANCED document', async () => {
+            const calls = [];
+
+            workspace = armWorkspace(calls);
+
+            const itemId = [...tabsOf(workspace.items[0])][0] ?? 'item-1',
+                  result = await workspace.handleDockPopOutAction({dockNodeId: 'main-tabs', tabContainer: tabContainerFor(itemId)});
+
+            expect(result.errors).toEqual([]);
+            expect(result.document).toBe(workspace.dockModel)
         });
 
         test('a refused vessel commits NOTHING — terminal is never reached', async () => {
@@ -647,6 +702,39 @@ test.describe('Neo.dashboard.dock.Workspace', () => {
             workspace = null;
             Neo.apps = previousApps;
             Neo.Main.getByPath = previousGetByPath
+        });
+
+        test('#17947 pop-out commits detachItem through the REAL lifecycle, not a stubbed pair', async () => {
+            // The handler arms elsewhere in this file stub `tearOutHandlers` to assert dispatch and
+            // ordering. This one drives the real thing: real admission, real reducer, real committed
+            // document — which is the AC that matters, because dispatching correctly into a broken
+            // pipeline would satisfy every ordering assertion and still detach nothing.
+            workspace = Neo.create(TearOutWorkspace, {
+                dockModel             : createDocument(),
+                enableDockPopOutAction: true
+            });
+
+            const tabContainer = {
+                activeIndex: 0,
+                getTabBar  : () => ({sortZoneConfig: {dockItemIds: ['preview']}}),
+                id         : 'popout-tabs'
+            };
+
+            // `measureDockPaneRect` finds no `Neo.main.DomAccess` here and resolves null. That is the
+            // documented degradation — the vessel opens at the host's default geometry rather than a
+            // wrong one — so the commit path is exercised exactly as it is in production.
+            const result = await workspace.handleDockPopOutAction({dockNodeId: 'main-tabs', tabContainer});
+
+            expect(result, 'the terminal must return a result, not a refusal envelope').toBeTruthy();
+            expect(result.errors ?? []).toEqual([]);
+
+            await workspace.refreshPromise;
+
+            // The committed document is the witness: the item left the dock through `detachItem`.
+            const committed = workspace.getDockZoneDocument();
+
+            expect(Document.findOwningEdge(committed, 'preview'), 'a detached item owns no edge').toBeFalsy();
+            expect(workspace.tearOutPanes.preview, 'the vessel holds the pane').toBeTruthy()
         });
 
         test('terminal-first connect lands one admitted live pane, then returns it before observers fire', async () => {


### PR DESCRIPTION
Resolves #17947

The pane header gets the one-click float control the engine had already anticipated but never built — and it gets it without a second lifecycle. Pressing `pop-out` measures the pane's current box and then calls `onDockTearOutExit` → `onDockTearOutTerminal`: literally the pair the pointer gesture's own terminal calls. Admission, the exactly-once `detachItem` commit, the refusal route and vessel retirement are inherited rather than restated, so they cannot drift out of agreement with the drag. The only delta is geometry — the gesture supplies a live proxy rect, a click has none, so the pane appears to lift in place instead of materialising at a default position.

Evidence: L2 (headless component battery on a rendered workspace: real browser, real themes, real projection and router; the host's platform vessel seam is implemented by the fixture, which is the half ADR 0029 §2.8 assigns to the host) → L2 required (every close-target AC is DOM/worker-observable; the second-window story belongs to the drag gesture's existing e2e leg, which this entry point shares). Residual: none.

## AC Evidence
| AC-1 | CI-covered: `DockWorkspace.spec.mjs` "the double gate is enforced at the Workspace, not the adapter" (all three configurations) + `DockLayoutAdapter.spec.mjs` "pop-out projects only when enabled, and lands at the family slot between pin and maximize"; painted focus-gating and order in `DockPopOut.spec.mjs` "pop-out holds the frozen family slot" |
| AC-2 | CI-covered: `DockPopOut.spec.mjs` "pressing pop-out detaches the ACTIVE item through the tear-out pair, at the pane's measured rect" — real click, committed document shows the item absent from every node and present in the catalog, vessel request carries the pane's real laid-out box. **The parenthetical `autoHidden`-clears clause is not delivered** — see `## Deltas from ticket` |
| AC-3 | CI-covered: `DockPopOut.spec.mjs` "the item comes home through the engine's own retire path" (behavioural) + `DockWorkspace.spec.mjs` "the handler holds NO lifecycle of its own — asserted from its source" (structural: the handler's source text may not contain `reintegrateTearOutItem`, `retireTearOutVessel`, `onVesselRetired`, `applyOperation`, or any vessel acquisition) |
| AC-4 | CI-covered: `DockPopOut.spec.mjs` "a declined vessel commits NOTHING and leaves the pane docked" (byte-identical `docJson`, pane still rendered) + `DockWorkspace.spec.mjs` "a refused vessel commits NOTHING — terminal is never reached" |
| AC-5 | CI-covered: `test/playwright/component/dashboard/DockPopOut.spec.mjs` + its `apps/dock-popout` fixture — five arms on a rendered workspace. Template note in `## Deltas from ticket` |

## Deltas from ticket

**AC-2's `autoHidden` clause is not delivered, and deliberately not asserted in either direction.** The ticket's Architectural Reality section states "§2.7's state table makes detach clear `autoHidden` in the same commit for railed items (model-enforced mutual exclusion)". ADR 0029 line 324 does say exactly that. `model/Operations.detachItem` does not implement it: it calls `Document.detachFromTabs`, which removes the item from its node's `items` and reassigns `activeItemId`, and touches no item field. The only site that clears `autoHidden` is `setItemPinned(pinned: true)`. So a detached item can remain `autoHidden: true` in the catalog, and the document validator permits it — it only forbids `pinned && autoHidden`.

That gap lives in the shared detach commit, which means it reaches the drag terminal and the keyboard twin identically; it is not a property of this button. Fixing it here would change the committed grammar of every existing tear-out, which is precisely the blast radius this leaf was scoped to avoid. Filed as #17969. The spec says so at the assertion site rather than quietly asserting today's behaviour, which would cement the divergence as intended.

**AC-5's template.** The ticket says "on the existing tear-out spec family's template". That family's e2e leg (`e2e/dashboard/DemoBDockTearOutNL.spec.mjs`) drives a real second OS window headed, and e2e runs in no CI workflow (#17853) — a guardrail that never runs is not a guardrail. This follows the intake-validated sibling instead: #17928/#17953 landed its gesture proof as a component-suite spec plus a dedicated fixture app, and that suite runs in CI. Because the click enters the drag's own pair, it inherits the e2e leg's second-window witness rather than duplicating it; what it cannot inherit — everything between the button and the seam — is what this file pins.

**Three contract drifts corrected in the implementation half** (found reading my own pushed code against the router): `onDockHeaderAction`'s jsdoc named an engine set of `close`/`maximize`/`pin` without `pop-out`; `LayoutAdapter`'s `resolveDockHeaderActions` jsdoc told a host which names are reserved and omitted `pop-out`, so a host following it would pick a name the engine throws on; and the handler returned the tear-out seam's bare Boolean where every other router row returns `{document, errors}` — a refusal would have read as a falsy success to anyone checking `result.errors?.length`.

**Adapter bonus fix.** The reserved-name error message derived the opt-in identifier as `enableDock` + capitalised name + `Action`, which yields `enableDockPop-outAction` — a config that does not exist, sending a host to grep for something unfindable. Each row now carries its identifier explicitly.

## Test Evidence

**Mutation falsifier on AC-2's centrepiece.** The measured-rect assertion is the one thing no unit spec can make: a unit stub can only witness that *some* rect was threaded through. Mutating `measureDockPaneRect` to measure the workspace instead of the pane (`id = tabContainer?.id` → `id = me.id`) turns the arm red at exactly the geometry assertion, off by 716px:

```
> 149 |  expect(Math.abs(rect.width - paneBox.width)).toBeLessThan(2);
    Expected: < 2
    Received:   716
  1 failed, 4 passed
```

Reverted from the committed baseline; the spec's own workspace-box control (`rect.width < workspaceBox.width - 1`) is a second, independent guard against that same substitution.

**Non-vacuity repairs found while writing the arms.** The frozen-order arm originally read on the centre-split node, where `pin` hides itself because the active item has no owning edge — it would have measured three buttons while claiming four. It now reads on the edge node and asserts each button is painted before comparing. The unit stub's terminal returned `{document, errors}` where the real `window/TearOut` terminal returns a bare Boolean; a stub answering in a grammar the production seam does not use is a reconstruction confirming itself, so it now returns Booleans and two arms cover the translation.

All other coverage runs in CI: 2610 unit + 143 component green locally at `745b673cca` (pre-rebase tree; the dock unit + component batteries re-run green at `f30d620148`).

## Post-Merge Validation

None owed. The tempting entries here — birth a real `?popout=` window from the click, then close it — are already discharged by construction rather than by a follow-up: the click's entire contribution ends at `onDockTearOutExit`, and everything past that point is the drag terminal's own code with its own headed e2e leg (`e2e/dashboard/DemoBDockTearOutNL.spec.mjs`). A second real-vessel witness would re-prove the shared half while proving nothing new about the button. Opening the vessel is the host's seam per ADR 0029 §2.8, outside the engine's contract.

## Commits
- `061e572666` — the action, its double gate, the measured rect and the dispatch into the tear-out pair
- `db60b60afa` — unit arms pinning the gate and the dispatch ordering at the Workspace
- `f30d620148` — the rendered-workspace gesture spec, its fixture app, and the three contract-drift corrections

Related: #13158
Refs #17928, #17963, #17969

Authored by Grace (Opus 5, Claude Code). Session dfa1b252-76f5-4a0a-81ab-98b9a5228703, continuing implementation from session 56bc214a-5b55-41a2-848a-cdfa372abbcd.
