### PR TITLE
fix(build): a computed root the output tree lacks warns instead of failing (#17971)

### DIFF
--- a/buildScripts/build/esmodules.mjs
+++ b/buildScripts/build/esmodules.mjs
@@ -189,10 +189,22 @@ Promise.all(promises).then(() => {
     // computed at runtime and are not broken. The directory their family loads from is the thing that
     // is not in the output tree, so that is what the line names — telling a developer "this import
     // does not resolve" would send them to inspect a template literal that is doing nothing wrong.
+    //
+    // A WARNING, never fatal, because the absence has two readings and this stage cannot choose
+    // between them. Inside this repository `apps`, `docs`, `examples` and `src` are all default roots
+    // and all present, so the uncopied-root reading is the only one that ever applies and the arm has
+    // never fired. A consuming workspace inverts it: `examples` is not among ITS default roots, so
+    // `dist/esm/examples/` cannot exist, and `src/worker/Data.mjs`'s `examples/` branch is one such a
+    // workspace never takes. Treated as fatal, that made every consumer build fail on a directory the
+    // workspace had no reason to own and no error text told it to declare.
+    //
+    // The `missing` arm above is the load-bearing one and is untouched: a LITERAL specifier that does
+    // not resolve is a dangling import whoever is building, which is what catches an uncopied root for
+    // every module actually imported by name.
     if (computedRoot.length > 0) {
-        console.error(`\ndist/esm: ${computedRoot.length} computed import(s) read from a directory the output tree does not have:`);
-        computedRoot.forEach(line => console.error(line));
-        console.error('\nThe interpolation is never resolved — only the path before it. A whole source root is likely uncopied.')
+        console.warn(`\ndist/esm: ${computedRoot.length} computed import(s) read from a directory the output tree does not have:`);
+        computedRoot.forEach(line => console.warn(line));
+        console.warn('\nThe interpolation is never resolved — only the path before it. Either a whole source root is uncopied, or the branch that reads it is one this workspace never takes. Only the first is a defect.')
     }
 
     // Separate from the missing set on purpose: these DO resolve. They reach the workspace's own
@@ -204,7 +216,9 @@ Promise.all(promises).then(() => {
         console.error('\nThese must be rewritten to the flattened dist/esm/src copy; two engine graphs cannot share a class registry.')
     }
 
-    if (unresolvable.length > 0) {
+    // `computed-root` is deliberately absent from this sum — see its report above. A build stays green
+    // with warnings and fails only on the two arms that name a real dangling or duplicated module.
+    if (missing.length + wrongEngine.length > 0) {
         process.exit(1)
     }
 

--- a/test/playwright/unit/buildScripts/esmWorkspaceBuild.spec.mjs
+++ b/test/playwright/unit/buildScripts/esmWorkspaceBuild.spec.mjs
@@ -1,4 +1,4 @@
-import {execFileSync} from 'child_process';
+import {spawnSync}    from 'child_process';
 import fs             from 'fs-extra';
 import os             from 'os';
 import path           from 'path';
@@ -34,7 +34,7 @@ test.describe('esmodules.mjs — a greenfield workspace build', () => {
      * rather than the real `src/`: the defect is about path arithmetic and copy sets, so a real
      * engine would add minutes of Terser work without adding a single observation.
      */
-    const createWorkspace = ({declareExtraRoot, engineReExport, sourceRoots}) => {
+    const createWorkspace = ({computedFamily, declareExtraRoot, engineReExport, sourceRoots}) => {
         const root = fs.mkdtempSync(path.join(os.tmpdir(), 'neo-esm-ws-'));
 
         fs.outputJsonSync(path.join(root, 'package.json'), {
@@ -49,6 +49,15 @@ test.describe('esmodules.mjs — a greenfield workspace build', () => {
         if (engineReExport) {
             fs.outputFileSync(path.join(root, 'components/engine.mjs'),
                 "export {default as Base} from '../node_modules/neo.mjs/src/core/Base.mjs';\n")
+        }
+
+        // A lazily-loaded family whose directory the output tree does not have. The module itself is
+        // emitted and every literal specifier in it resolves; only the interpolated root is absent,
+        // which is the shape the engine's own optional branches take (`examples/`, `docs/app/`, `WS/`
+        // addons) and which no consuming workspace can supply. See #17971.
+        if (computedFamily) {
+            fs.outputFileSync(path.join(root, 'components/Lazy.mjs'),
+                'export const load = name => import(`../plugins/${name}.mjs`);\n')
         }
 
         // The engine, as a workspace consumes it.
@@ -73,13 +82,17 @@ test.describe('esmodules.mjs — a greenfield workspace build', () => {
         return root
     };
 
-    /** Runs the build in the workspace, returning `{status, output}` rather than throwing. */
+    /**
+     * Runs the build in the workspace, returning `{status, output}` rather than throwing.
+     *
+     * Both streams, on every exit code. The previous shape returned `execFileSync`'s stdout when the
+     * build succeeded and only reached stderr through the throw path — which made a diagnostic that
+     * does NOT fail the build unobservable to a spec, exactly the shape of the warning arm below.
+     */
     const runBuild = cwd => {
-        try {
-            return {status: 0, output: execFileSync('node', [buildPath], {cwd, encoding: 'utf8', stdio: 'pipe'})}
-        } catch (error) {
-            return {status: error.status, output: `${error.stdout || ''}${error.stderr || ''}`}
-        }
+        const {status, stdout, stderr} = spawnSync('node', [buildPath], {cwd, encoding: 'utf8'});
+
+        return {status, output: `${stdout || ''}${stderr || ''}`}
     };
 
     test.afterEach(() => {
@@ -125,6 +138,34 @@ test.describe('esmodules.mjs — a greenfield workspace build', () => {
         expect(output).toContain('apps/myapp/view/Viewport.mjs');
         expect(output).toContain('components/Button.mjs');
         expect(output).toContain('neo.esmSourceRoots')
+    });
+
+    /**
+     * The counterpart arm, and the reason the two are worth reading together: an absent directory is
+     * a defect when a LITERAL specifier names it (above) and merely a diagnostic when only a computed
+     * family reads it (here). This stage cannot tell an uncopied source root from a branch the
+     * workspace never takes, and inside this repository the second reading never applies — every
+     * default root exists — so the arm shipped fatal and no build here ever noticed. Every consuming
+     * workspace failed on it. See #17971.
+     */
+    test('a computed family whose root is absent warns and leaves the build green', () => {
+        workspace = createWorkspace({computedFamily: true, declareExtraRoot: true});
+
+        const {status, output} = runBuild(workspace);
+
+        expect(status, `build should have stayed green, output:\n${output}`).toBe(0);
+
+        // The diagnostic still reaches the developer, naming the module and the absent directory.
+        expect(output).toContain('computed import(s) read from a directory the output tree does not have');
+        expect(output).toContain('components/Lazy.mjs');
+
+        // Both readings are offered. Asserting the wording is the point: the old text asserted the
+        // uncopied-root reading as fact, which is what made a warning look like a build error.
+        expect(output).toContain('the branch that reads it is one this workspace never takes');
+
+        // Non-vacuity: the module carrying the computed specifier was really emitted, so the arm
+        // cannot pass by the build having skipped the file altogether.
+        expect(fs.existsSync(path.join(workspace, 'dist/esm/components/Lazy.mjs'))).toBe(true)
     });
 
     /**

--- a/test/playwright/unit/buildScripts/esmWorkspaceBuild.spec.mjs
+++ b/test/playwright/unit/buildScripts/esmWorkspaceBuild.spec.mjs
@@ -54,7 +54,7 @@ test.describe('esmodules.mjs — a greenfield workspace build', () => {
         // A lazily-loaded family whose directory the output tree does not have. The module itself is
         // emitted and every literal specifier in it resolves; only the interpolated root is absent,
         // which is the shape the engine's own optional branches take (`examples/`, `docs/app/`, `WS/`
-        // addons) and which no consuming workspace can supply. See #17971.
+        // addons) and which no consuming workspace can supply.
         if (computedFamily) {
             fs.outputFileSync(path.join(root, 'components/Lazy.mjs'),
                 'export const load = name => import(`../plugins/${name}.mjs`);\n')
@@ -146,7 +146,7 @@ test.describe('esmodules.mjs — a greenfield workspace build', () => {
      * family reads it (here). This stage cannot tell an uncopied source root from a branch the
      * workspace never takes, and inside this repository the second reading never applies — every
      * default root exists — so the arm shipped fatal and no build here ever noticed. Every consuming
-     * workspace failed on it. See #17971.
+     * workspace failed on it.
      */
     test('a computed family whose root is absent warns and leaves the build green', () => {
         workspace = createWorkspace({computedFamily: true, declareExtraRoot: true});

--- a/test/playwright/unit/buildScripts/esmWorkspaceBuild.spec.mjs
+++ b/test/playwright/unit/buildScripts/esmWorkspaceBuild.spec.mjs
@@ -169,6 +169,31 @@ test.describe('esmodules.mjs — a greenfield workspace build', () => {
     });
 
     /**
+     * The third arm's exit gate, pinned end to end because narrowing `computed-root` narrowed the
+     * expression all three share. `esmDistTransforms.spec.mjs` proves `findUnresolvableImports`
+     * still CLASSIFIES this as `engine-identity`; only a real build proves the classification still
+     * reaches `process.exit(1)`.
+     *
+     * The specifier is deliberately root-relative rather than a shape house style produces. The
+     * rewrite drops the `node_modules/neo.mjs/` segment only from a specifier containing it with a
+     * leading slash; without one it takes the other branch, gains `../../`, and arrives in the output
+     * tree still addressing the workspace's own engine. Contrived as authorship, exact as a probe:
+     * the point is a surviving engine-identity residual, and this is the cheapest way to get one.
+     */
+    test('an emitted specifier that still reaches the workspace engine fails the build', () => {
+        workspace = createWorkspace({declareExtraRoot: true});
+
+        fs.outputFileSync(path.join(workspace, 'components/Second.mjs'),
+            "export {default} from 'node_modules/neo.mjs/src/core/Base.mjs';\n");
+
+        const {status, output} = runBuild(workspace);
+
+        expect(status, `build should have failed, output:\n${output}`).toBe(1);
+        expect(output).toContain('still address the workspace engine at node_modules/neo.mjs');
+        expect(output).toContain('two engine graphs cannot share a class registry')
+    });
+
+    /**
      * The declared root decides where the build WRITES, so an unvalidated one is an overwrite
      * primitive rather than a copy list. `path.resolve` discards every earlier segment once it meets
      * an absolute one, which collapses the build's input and output onto the same external directory:


### PR DESCRIPTION
Resolves #17971

`npm run build-dist-esm` now succeeds in a consuming workspace. It could not before: #17921's resolution guard treated a `computed-root` report as fatal, and the report fires on `dist/esm/examples/` for every consumer — a directory `resolveSourceRoots` cannot produce for them, read by a `src/worker/Data.mjs` branch such a workspace never takes. The arm now warns and states both readings of the absence instead of asserting the uncopied-root one; the two arms that name a real defect are untouched and are each pinned to a real build.

Evidence: L3 (the real `esmodules.mjs` run as a subprocess over real `mkdtemp` workspaces, plus a real installed engine in a consumer layout, plus two seeded exit-gate mutations) → L3 required (every AC is a property of what the build actually does, not of how the classifier labels). Residual: none.

## AC Evidence
| AC-1 | outside-CI: real installed engine, consumer layout, no `neo.esmSourceRoots`, no `examples/`, no `src/main/addon/` → `exit 0`. Receipt below. |
| AC-2 | CI-covered: `test/playwright/unit/buildScripts/esmWorkspaceBuild.spec.mjs:151` — asserts the report still names the module and the absent directory, and asserts the both-readings wording verbatim. |
| AC-3 | CI-covered: `esmWorkspaceBuild.spec.mjs:131` — an undeclared source root still exits 1 through the `missing` arm. |
| AC-4 | CI-covered: `esmWorkspaceBuild.spec.mjs:183` — new; an emitted specifier still reaching `node_modules/neo.mjs` exits 1 through `engine-identity`. |
| AC-5 | CI-covered: the six pre-existing arms in the same file, unchanged and passing. |

## Deltas from ticket

**One test added beyond the prescription.** AC-4 asked that `engine-identity` still fail the build. `esmDistTransforms.spec.mjs` proves the *classification* and nothing proved it still reaches `process.exit(1)` — and since this change narrows the expression all three arms share, a classifier test is the wrong instrument for it. `missing` already had a real build behind it; `engine-identity` now does too.

**One helper repaired to make the arm observable.** `runBuild` returned `execFileSync`'s stdout on success and reached stderr only through the throw path, so a diagnostic that does *not* fail the build was structurally invisible to a spec — exactly the shape this PR introduces. It now uses `spawnSync` and returns both streams on every exit code. Without this the new AC-2 assertions would have passed against an empty string.

**The specifier in the AC-4 arm is contrived, and says so in its JSDoc.** House style cannot produce a surviving `engine-identity` residual — the rewrite catches every realistic spelling. A root-relative `node_modules/neo.mjs/…` takes the rewrite's other branch and arrives still addressing the workspace engine. It is a probe for the exit gate, not an example of authorship.

## Test Evidence

**AC-1 — real installed engine, consumer layout.** Engine installed into a `mkdtemp` workspace with npm's hoisting modelled, `apps/<name>/` only, `package.json` carrying no `neo` key. Run as a matrix so the workspace's own gaps stay separated from defects (full matrix and method: #17931, comment `5483577069`):

```
before this change:  exit 1 · 2.2s · 480 emitted · 4 unresolvable
                       Main.mjs      → ../../../src/main/addon/${…}   ×2
                       Data.mjs      → ../../examples/${…}
                       Data.mjs      → ../../docs/app/${…}
after  this change:  exit 0 · 2.2s · 480 emitted · 0 fatal
```

The one row still red anywhere in the matrix is the bare-workspace `marked` residual — `src/component/Markdown.mjs` reaching `node_modules/marked/…` by filesystem path. That is #17868's owned lane, it is the `missing` arm working correctly, and it is deliberately not touched here.

**Mutation controls — two, each seeded against the committed baseline and restored from it.**

| seeded mutation | expected | observed |
|---|---|---|
| exit sum reverted to `unresolvable.length > 0` | only the new AC-2 arm reds | `1 failed, 6 passed` — the computed-root arm alone |
| `wrongEngine.length` dropped from the exit sum | only the new AC-4 arm reds | `1 failed, 7 passed` — the engine-identity arm alone |

Neither arm can pass against the defect it names, and neither reds for the other's cause.

**Full suite.** `test/playwright/unit/buildScripts` — exit code 0, 586 passed. Read from the process exit code and the summary line rather than a piped tail: an earlier run of mine looked green in a truncated tail while eight arms were failing on a missing `dist/parse5.mjs`, which is a local-environment prerequisite CI satisfies at `test.yml:296`.

## Post-Merge Validation

None owed. Both consumers of the change are exercised before merge — the guard arms by the suite, the consumer build by the installed-engine receipt above.

## Commits
- `29796101da` — the guard arm warns instead of failing; `runBuild` captures both streams.
- `b61b6ff287` — the `engine-identity` exit gate pinned end to end.

## Related

- #17921 introduced the guard this narrows.
- #17931 is the real-engine fixture whose construction surfaced this; it is `blocked_by` this PR's ticket and is where the boot-side regression home will live.
- #17972 is the second consumer blocker found in the same measurement — a `WS/` addon loading unbuilt source. Unclaimed, and not a dependency of this change.
- #17868 owns the remaining `marked` residual.

Authored by Grace (Opus 5, Claude Code). Session 4b3f102d-6b92-411f-98fb-890fe00684a0.
