### PR TITLE
feat: engine-owned dock reload header action, delegation-only (#17948)

### DIFF
--- a/examples/dashboard/dock/MainContainer.mjs
+++ b/examples/dashboard/dock/MainContainer.mjs
@@ -3,8 +3,8 @@ import DockWorkspace      from '../../../src/dashboard/dock/Workspace.mjs';
 import Document           from '../../../src/dashboard/dock/model/Document.mjs';
 import Persistence        from '../../../src/dashboard/dock/model/Persistence.mjs';
 import PerspectiveLibrary from '../../../src/dashboard/dock/persistence/PerspectiveLibrary.mjs';
+import ReloadablePane     from './ReloadablePane.mjs';
 import TourRunner         from '../../../src/ai/client/TourRunner.mjs';
-import Component          from '../../../src/component/Base.mjs';
 import '../../../src/button/Base.mjs';    // registers the `button` ntype used by the perspective toolbar
 import '../../../src/tab/Container.mjs'; // registers the `tab-container` ntype the projection emits for tab zones
 import '../../../src/toolbar/Base.mjs';  // registers the `toolbar` ntype used by the perspective toolbar
@@ -103,44 +103,6 @@ const seededPerspectives = [{
  * @class Neo.examples.dashboard.dock.MainContainer
  * @extends Neo.dashboard.dock.Workspace
  */
-/**
- * @summary The example's `dockReload()` contract carrier: reload means counting — the pane owns
- * its meaning, and the visible counter is the gesture receipt a viewer (and the whitebox e2e)
- * reads without tooling.
- * @class Neo.examples.dashboard.dock.ReloadablePane
- * @extends Neo.component.Base
- */
-class ReloadablePane extends Component {
-    static config = {
-        /**
-         * @member {String} className='Neo.examples.dashboard.dock.ReloadablePane'
-         * @protected
-         */
-        className: 'Neo.examples.dashboard.dock.ReloadablePane',
-        /**
-         * @member {String} html='Strategy'
-         */
-        html: 'Strategy'
-    }
-
-    /**
-     * How often the engine's reload action asked this pane to refresh itself.
-     * @member {Number} reloadCount=0
-     */
-    reloadCount = 0
-
-    /**
-     * The reload delegation contract: this pane's reload meaning is a visible refresh counter.
-     * @returns {void}
-     */
-    dockReload() {
-        this.reloadCount++;
-        this.html = `Strategy · reloaded ${this.reloadCount}×`
-    }
-}
-
-ReloadablePane = Neo.setupClass(ReloadablePane);
-
 class MainContainer extends DockWorkspace {
     static config = {
         /**

--- a/examples/dashboard/dock/MainContainer.mjs
+++ b/examples/dashboard/dock/MainContainer.mjs
@@ -4,6 +4,7 @@ import Document           from '../../../src/dashboard/dock/model/Document.mjs';
 import Persistence        from '../../../src/dashboard/dock/model/Persistence.mjs';
 import PerspectiveLibrary from '../../../src/dashboard/dock/persistence/PerspectiveLibrary.mjs';
 import TourRunner         from '../../../src/ai/client/TourRunner.mjs';
+import Component          from '../../../src/component/Base.mjs';
 import '../../../src/button/Base.mjs';    // registers the `button` ntype used by the perspective toolbar
 import '../../../src/tab/Container.mjs'; // registers the `tab-container` ntype the projection emits for tab zones
 import '../../../src/toolbar/Base.mjs';  // registers the `toolbar` ntype used by the perspective toolbar
@@ -102,6 +103,44 @@ const seededPerspectives = [{
  * @class Neo.examples.dashboard.dock.MainContainer
  * @extends Neo.dashboard.dock.Workspace
  */
+/**
+ * @summary The example's `dockReload()` contract carrier: reload means counting — the pane owns
+ * its meaning, and the visible counter is the gesture receipt a viewer (and the whitebox e2e)
+ * reads without tooling.
+ * @class Neo.examples.dashboard.dock.ReloadablePane
+ * @extends Neo.component.Base
+ */
+class ReloadablePane extends Component {
+    static config = {
+        /**
+         * @member {String} className='Neo.examples.dashboard.dock.ReloadablePane'
+         * @protected
+         */
+        className: 'Neo.examples.dashboard.dock.ReloadablePane',
+        /**
+         * @member {String} html='Strategy'
+         */
+        html: 'Strategy'
+    }
+
+    /**
+     * How often the engine's reload action asked this pane to refresh itself.
+     * @member {Number} reloadCount=0
+     */
+    reloadCount = 0
+
+    /**
+     * The reload delegation contract: this pane's reload meaning is a visible refresh counter.
+     * @returns {void}
+     */
+    dockReload() {
+        this.reloadCount++;
+        this.html = `Strategy · reloaded ${this.reloadCount}×`
+    }
+}
+
+ReloadablePane = Neo.setupClass(ReloadablePane);
+
 class MainContainer extends DockWorkspace {
     static config = {
         /**
@@ -126,6 +165,14 @@ class MainContainer extends DockWorkspace {
          * @member {Boolean} enableDockPinAction=true
          */
         enableDockPinAction: true,
+        /**
+         * And into the engine-owned, delegation-only reload action. The Strategy pane implements
+         * the `dockReload()` contract below, so the example shows both halves of the policy: the
+         * action appears on the pane that owns a reload meaning and stays hidden on every pane
+         * that does not.
+         * @member {Boolean} enableDockReloadAction=true
+         */
+        enableDockReloadAction: true,
         /**
          * The perspective toolbar sits at index 0; the projected shell follows it.
          * @member {Number} dockShellIndex=1
@@ -197,6 +244,14 @@ class MainContainer extends DockWorkspace {
      * @returns {Object}
      */
     resolvePane(itemId, item) {
+        // Strategy demonstrates the reload delegation contract; see ReloadablePane below.
+        if (itemId === 'strategy') {
+            return {
+                module: ReloadablePane,
+                style : {alignItems: 'center', color: '#888', display: 'flex', fontSize: '20px', justifyContent: 'center'}
+            }
+        }
+
         return {
             ntype: 'component',
             style: {alignItems: 'center', color: '#888', display: 'flex', fontSize: '20px', justifyContent: 'center'},

--- a/examples/dashboard/dock/ReloadablePane.mjs
+++ b/examples/dashboard/dock/ReloadablePane.mjs
@@ -1,0 +1,39 @@
+import Component from '../../../src/component/Base.mjs';
+
+/**
+ * @summary The example's `dockReload()` contract carrier: reload means counting — the pane owns
+ * its meaning, and the visible counter is the gesture receipt a viewer (and the whitebox e2e)
+ * reads without tooling.
+ * @class Neo.examples.dashboard.dock.ReloadablePane
+ * @extends Neo.component.Base
+ */
+class ReloadablePane extends Component {
+    static config = {
+        /**
+         * @member {String} className='Neo.examples.dashboard.dock.ReloadablePane'
+         * @protected
+         */
+        className: 'Neo.examples.dashboard.dock.ReloadablePane',
+        /**
+         * @member {String} html='Strategy'
+         */
+        html: 'Strategy'
+    }
+
+    /**
+     * How often the engine's reload action asked this pane to refresh itself.
+     * @member {Number} reloadCount=0
+     */
+    reloadCount = 0
+
+    /**
+     * The reload delegation contract: this pane's reload meaning is a visible refresh counter.
+     * @returns {void}
+     */
+    dockReload() {
+        this.reloadCount++;
+        this.html = `Strategy · reloaded ${this.reloadCount}×`
+    }
+}
+
+export default Neo.setupClass(ReloadablePane);

--- a/src/dashboard/dock/Workspace.mjs
+++ b/src/dashboard/dock/Workspace.mjs
@@ -1368,13 +1368,23 @@ class Workspace extends Container {
      * projection-constant by design (per-item state must never vary the actions array), so a
      * pane-dependent action such as reload would stay at its projected default forever. Mount is
      * the one surface every boot path shares.
+     *
+     * The sync is DEFERRED off the mount cascade (the MonacoEditor post-mount idiom): container
+     * mount flips every child's `mounted` in the same frame, and writing action state into that
+     * window races the initial render application — observed on slow rigs as duplicated header
+     * chrome. The delay is a boot convenience, not a correctness surface: every write in the
+     * sweep is change-guarded and idempotent, and `timeout()` is destroy-rejected, so a torn-down
+     * workspace never runs it.
      * @param {Boolean} value
      * @param {Boolean} oldValue
      * @protected
      */
     afterSetMounted(value, oldValue) {
         super.afterSetMounted(value, oldValue);
-        value && this.syncDockHeaderActions()
+
+        value && this.timeout(100).then(() => {
+            !this.isDestroyed && this.syncDockHeaderActions()
+        }).catch(() => null)
     }
 
     /**

--- a/src/dashboard/dock/Workspace.mjs
+++ b/src/dashboard/dock/Workspace.mjs
@@ -1362,15 +1362,6 @@ class Workspace extends Container {
     }
 
     /**
-     * Synchronizes every projected engine header action after reconciliation, including retained tabs
-     * whose action instance outlived a model-policy or active-item change.
-     *
-     * Each action's own sync is a no-op when that action was never projected (`getActionItem` misses),
-     * so this sweep stays correct for any subset of the engine set a consumer enabled.
-     * @param {Map<String,Neo.tab.Container>|null} [tabs=null]
-     * @protected
-     */
-    /**
      * The boot-time header-action sync. A consumer may mount its FIRST projection statically —
      * items assembled in `construct()` — without ever entering {@link #refreshDockWorkspace},
      * and on that path no header-action sync runs at all: projected action rows are
@@ -1386,6 +1377,18 @@ class Workspace extends Container {
         value && this.syncDockHeaderActions()
     }
 
+    /**
+     * Synchronizes every projected engine header action after reconciliation, including retained tabs
+     * whose action instance outlived a model-policy or active-item change.
+     *
+     * Each action's own sync guards on its own opt-in and is a no-op when the action was never
+     * projected — the opt-in guard is load-bearing, not redundant: a host may legally own an
+     * engine action NAME while that engine flag is off (the reserved-name guard fires only for
+     * enabled actions), and `getActionItem` finds the host's action by name. Without the guard,
+     * this sweep would rewrite consumer-owned action state.
+     * @param {Map<String,Neo.tab.Container>|null} [tabs=null]
+     * @protected
+     */
     syncDockHeaderActions(tabs=null) {
         let me            = this,
             projectedTabs = tabs;
@@ -1635,6 +1638,9 @@ class Workspace extends Container {
      * never inherits another item's window. Teardown mid-flight settles terminally through
      * `core.Base#trap`: destroy rejects the trapped delegation even when the pane's producer
      * never settles, and the post-destroy continuation returns without touching erased state.
+     * The no-active race (teardown, active-item flip mid-dispatch) settles through the channel
+     * too, carrying `itemId: null` — one settlement per activation, with the single-flight
+     * absorption as the only silent path.
      * @param {Object} data
      * @param {String} data.dockNodeId
      * @param {Neo.tab.Container} data.tabContainer
@@ -1648,7 +1654,12 @@ class Workspace extends Container {
             errors = [];
 
         if (!itemId) {
-            return {errors: ['Dock reload action requires an active item']}
+            // The no-active race (teardown, active-item flip mid-dispatch) settles through the
+            // SAME channel as every other completion — the action wire discards returns, so an
+            // unsettled early return here would be an activation the event contract never saw.
+            errors.push('Dock reload action requires an active item');
+            !me.isDestroyed && me.fire('dockReloadSettled', {dockNodeId, errors, itemId: null});
+            return {errors}
         }
 
         // Single-flight: a second activation during the window neither invokes nor settles —
@@ -1711,6 +1722,11 @@ class Workspace extends Container {
      * @protected
      */
     syncDockReloadAction(tabContainer) {
+        // Opt-in guard first (the pin precedent): while the engine flag is off, a host may own
+        // the semantic name `reload` — getActionItem() would find THAT action, and writing to it
+        // here would overwrite consumer-owned state. Default-off means behaviorally inert.
+        if (!this.enableDockReloadAction) return;
+
         let action   = tabContainer?.getActionItem?.('reload'),
             itemId   = this.getActiveDockItemId(tabContainer),
             disabled = false,

--- a/src/dashboard/dock/Workspace.mjs
+++ b/src/dashboard/dock/Workspace.mjs
@@ -1711,8 +1711,13 @@ class Workspace extends Container {
             me.dockReloadInFlight.delete(itemId);
 
             // Re-derive both action axes from current truth: the active item may have changed
-            // mid-flight, so assigning `disabled = false` here would leak across items.
-            me.syncDockReloadAction(tabContainer)
+            // mid-flight, so assigning `disabled = false` here would leak across items. The
+            // settle edge queues BEHIND any in-flight refresh (settled tail, never a raw write
+            // beside a reconcile) — a settlement is not latency-sensitive, and the post-reconcile
+            // sweep re-derives the same truth anyway when a commit is what changed the item.
+            (me.refreshPromise?.catch(() => {}) || Promise.resolve()).then(() => {
+                !me.isDestroyed && me.syncDockReloadAction(tabContainer)
+            })
         }
 
         !me.isDestroyed && me.fire('dockReloadSettled', {dockNodeId, errors, itemId});
@@ -1754,9 +1759,12 @@ class Workspace extends Container {
             hidden   = typeof carrier !== 'function'
         }
 
-        if (action) {
-            action.disabled !== disabled && (action.disabled = disabled);
-            action.hidden   !== hidden   && (action.hidden   = hidden)
+        // ONE batched update for both axes (`set()`), never two sequential writes: each write
+        // opens its own vdom round trip on the tab bar, and stacked in-flight bar updates racing
+        // a following reconcile is exactly the collision that duplicated retained chrome on slow
+        // rigs.
+        if (action && (action.disabled !== disabled || action.hidden !== hidden)) {
+            action.set({disabled, hidden})
         }
     }
 

--- a/src/dashboard/dock/Workspace.mjs
+++ b/src/dashboard/dock/Workspace.mjs
@@ -1369,12 +1369,14 @@ class Workspace extends Container {
      * pane-dependent action such as reload would stay at its projected default forever. Mount is
      * the one surface every boot path shares.
      *
-     * The sync is DEFERRED off the mount cascade (the MonacoEditor post-mount idiom): container
-     * mount flips every child's `mounted` in the same frame, and writing action state into that
-     * window races the initial render application — observed on slow rigs as duplicated header
-     * chrome. The delay is a boot convenience, not a correctness surface: every write in the
-     * sweep is change-guarded and idempotent, and `timeout()` is destroy-rejected, so a torn-down
-     * workspace never runs it.
+     * A workspace whose boot DID run the refresh already synced on settled chrome (the
+     * post-reconcile sweep), so this hook narrows to the never-refreshed case: `refreshPromise`
+     * present means the refresh owns boot truth and writing again from the mount window would
+     * only race the initial application train (observed on slow rigs as duplicated bar chrome).
+     * For the static case the sync is additionally deferred off the mount cascade (the
+     * MonacoEditor post-mount idiom) — container mount flips every child's `mounted` in the same
+     * frame. Every write in the sweep is change-guarded and idempotent, and `timeout()` is
+     * destroy-rejected, so a torn-down workspace never runs it.
      * @param {Boolean} value
      * @param {Boolean} oldValue
      * @protected
@@ -1382,7 +1384,7 @@ class Workspace extends Container {
     afterSetMounted(value, oldValue) {
         super.afterSetMounted(value, oldValue);
 
-        value && this.timeout(100).then(() => {
+        value && !this.refreshPromise && this.timeout(100).then(() => {
             !this.isDestroyed && this.syncDockHeaderActions()
         }).catch(() => null)
     }

--- a/src/dashboard/dock/Workspace.mjs
+++ b/src/dashboard/dock/Workspace.mjs
@@ -132,6 +132,23 @@ class Workspace extends Container {
          */
         enableDockPinAction: false,
         /**
+         * Projects one engine-owned, delegation-only reload action into each Dock tab header —
+         * runtime only: no operation is committed and the document never changes. A pane
+         * implementing `dockReload(): void | Promise<*>` owns what reload means (its stores,
+         * caches, re-render — the author's decision, opted into by implementing the method); a
+         * pane without the contract simply hides the action, decided by a pure `typeof` probe on
+         * the live card, never a resolver call. One invocation per item may be in flight (the
+         * action disables for the window), and every completion — sync throw, async rejection,
+         * async success — settles exactly once through the `dockReloadSettled` event
+         * (`{dockNodeId, itemId, errors}`); a failing `dockReload()` keeps the pane, always.
+         * Destroy-and-recreate is deliberately NOT here: resolved panes are moved, never
+         * destroyed (docking design record §2.6) — the recreate capability lives with the
+         * two-phase transaction that can honestly promise rollback. Disabled by default; the
+         * projection is byte-identical while off.
+         * @member {Boolean} enableDockReloadAction=false
+         */
+        enableDockReloadAction: false,
+        /**
          * Projects one engine-owned maximize toggle into each Dock tab header — presentation
          * only: the committed document, perspectives and topology diffs never observe maximize
          * state. Disabled by default.
@@ -349,6 +366,14 @@ class Workspace extends Container {
      * @protected
      */
     dockMaximizeRestore = null
+
+    /**
+     * Item ids with a `dockReload()` invocation in flight — the single-flight guard: a second
+     * activation during the window neither invokes nor settles.
+     * @member {Set<String>} dockReloadInFlight=new Set()
+     * @protected
+     */
+    dockReloadInFlight = new Set()
 
     /**
      * The in-flight maximizedNodeId transition as an awaitable — every consumer that must
@@ -1254,7 +1279,7 @@ class Workspace extends Container {
      * instance, the way {@link #syncDockCloseAction} does, not by returning a different list. Names
      * must be unique per node, and every engine-owned name is reserved while its own opt-in is on —
      * `close` under {@link #enableDockCloseAction}, `maximize` under {@link #enableDockMaximizeAction},
-     * `pin` under {@link #enableDockPinAction};
+     * `pin` under {@link #enableDockPinAction}, `reload` under {@link #enableDockReloadAction};
      * both violations throw at projection rather than silently unaddressing an action. Their intent
      * surfaces on the `dockHeaderAction` event — see {@link #onDockHeaderAction}.
      * @returns {Object}
@@ -1345,11 +1370,31 @@ class Workspace extends Container {
      * @param {Map<String,Neo.tab.Container>|null} [tabs=null]
      * @protected
      */
+    /**
+     * The boot-time header-action sync. A consumer may mount its FIRST projection statically —
+     * items assembled in `construct()` — without ever entering {@link #refreshDockWorkspace},
+     * and on that path no header-action sync runs at all: projected action rows are
+     * projection-constant by design (per-item state must never vary the actions array), so a
+     * pane-dependent action such as reload would stay at its projected default forever. Mount is
+     * the one surface every boot path shares.
+     * @param {Boolean} value
+     * @param {Boolean} oldValue
+     * @protected
+     */
+    afterSetMounted(value, oldValue) {
+        super.afterSetMounted(value, oldValue);
+        value && this.syncDockHeaderActions()
+    }
+
     syncDockHeaderActions(tabs=null) {
         let me            = this,
             projectedTabs = tabs;
 
-        if (!projectedTabs) {
+        // A fresh boot reconciles with nothing retained, so the reconciler's map arrives EMPTY —
+        // yet the staged projection resolved PLACEHOLDERS, whose pane-dependent action states
+        // (reload's contract probe) are wrong until this sync reaches the live chrome. Walk the
+        // shell whenever the handed map cannot.
+        if (!projectedTabs?.size) {
             let shell = me.getDockHost()?.items?.[me.dockShellIndex];
 
             projectedTabs = shell ? Reconciler.collectProjectedTabs(shell) : new Map()
@@ -1357,7 +1402,8 @@ class Workspace extends Container {
 
         projectedTabs?.forEach?.(tab => {
             me.syncDockCloseAction(tab);
-            me.syncDockPinAction(tab)
+            me.syncDockPinAction(tab);
+            me.syncDockReloadAction(tab)
         })
     }
 
@@ -1384,8 +1430,16 @@ class Workspace extends Container {
         me.syncDockPinAction(container);
 
         if (!me.dockModel || !itemId || committed === itemId) {
+            // No commit follows (a reconciliation re-emit, or no model): this sync is the only
+            // writer of the reload action's per-item state for this activation.
+            me.syncDockReloadAction(container);
             return null
         }
+
+        // A commit follows, and with it the post-reconcile header-action sync on settled chrome.
+        // Reload's sync WRITES on every contract boundary (hidden/disabled flip), so running it
+        // here too would put a vdom update in flight against the reconcile's own updates on the
+        // same subtree — the race that intermittently dropped retained tab chrome.
 
         descriptor = {operation: 'setActiveItem', tabsNodeId: dockNodeId, itemId};
         result     = me.applyDockZoneOperation(descriptor);
@@ -1410,7 +1464,9 @@ class Workspace extends Container {
      *
      * This class owns the ENGINE SET, each action only while its own opt-in is on: `close`
      * ({@link #enableDockCloseAction}), `maximize` ({@link #enableDockMaximizeAction} — a pure
-     * presentation toggle that never reaches the reducer) and `pin` ({@link #enableDockPinAction}). Every other intent —
+     * presentation toggle that never reaches the reducer), `pin` ({@link #enableDockPinAction})
+     * and `reload` ({@link #enableDockReloadAction} — runtime-only like maximize: delegation
+     * into the pane's own `dockReload()`, never an operation). Every other intent —
      * including host actions projected through `resolveDockHeaderActions` — is re-emitted as a
      * **`dockHeaderAction`** event carrying `{action, dockNodeId, tabContainer}`, so a host receives it
      * without subclassing this class or overriding a protected method, and this method returns `null`
@@ -1438,6 +1494,10 @@ class Workspace extends Container {
         if (action === 'maximize' && me.enableDockMaximizeAction) {
             me.toggleDockMaximize(dockNodeId);
             return null
+        }
+
+        if (action === 'reload' && me.enableDockReloadAction) {
+            return me.handleDockReloadAction({dockNodeId, tabContainer})
         }
 
         // Not an action this class owns. Re-emit it so a host that projected its own actions
@@ -1559,6 +1619,117 @@ class Workspace extends Container {
         }
 
         return result
+    }
+
+    /**
+     * Runs the engine-owned, delegation-only reload for the active pane: `dockReload()` when the
+     * pane implements the contract — the author owns what reload means, and the method is
+     * explicitly promise-aware (`void | Promise<*>`). Runtime-only by contract: no operation is
+     * committed and the document never changes. Every completion — sync throw, async rejection,
+     * async success — settles exactly once through the `dockReloadSettled` event
+     * (`{dockNodeId, itemId, errors}`), because the action wire has no result channel
+     * (`Observable.fire` discards listener returns). A failing `dockReload()` keeps the pane,
+     * always. One invocation per item may be in flight; the action's `disabled` state derives
+     * from the ACTIVE item's in-flight membership through {@link #syncDockReloadAction} — both
+     * at the flight edges here and on every active-item change — so switching panes mid-flight
+     * never inherits another item's window. Teardown mid-flight settles terminally through
+     * `core.Base#trap`: destroy rejects the trapped delegation even when the pane's producer
+     * never settles, and the post-destroy continuation returns without touching erased state.
+     * @param {Object} data
+     * @param {String} data.dockNodeId
+     * @param {Neo.tab.Container} data.tabContainer
+     * @returns {Promise<{errors: String[]}|null>} `null` when an in-flight invocation absorbed
+     *     the activation.
+     * @protected
+     */
+    async handleDockReloadAction({dockNodeId, tabContainer}={}) {
+        let me     = this,
+            itemId = me.getActiveDockItemId(tabContainer),
+            errors = [];
+
+        if (!itemId) {
+            return {errors: ['Dock reload action requires an active item']}
+        }
+
+        // Single-flight: a second activation during the window neither invokes nor settles —
+        // one settlement per invocation is the channel's contract.
+        if (me.dockReloadInFlight.has(itemId)) {
+            return null
+        }
+
+        let itemIds = tabContainer.getTabBar()?.sortZoneConfig?.dockItemIds || [],
+            index   = itemIds.indexOf(itemId),
+            pane    = index > -1 ? tabContainer.getCard(index) : null;
+
+        if (!pane || pane.isDestroyed || typeof pane.dockReload !== 'function') {
+            // The visibility sync hides the action for exactly these panes; reaching this guard
+            // means a race (teardown, active-item flip mid-dispatch) — settle it honestly.
+            errors.push(`Dock reload has no live dockReload() contract for item "${itemId}"`)
+        } else {
+            me.dockReloadInFlight.add(itemId);
+            me.syncDockReloadAction(tabContainer);
+
+            try {
+                // trap() is the engine-native teardown race: destroy rejects every registered
+                // async, so this await settles even when the pane's producer never does — and a
+                // producer settling later lands in the trap's already-settled no-op handlers,
+                // never as an unhandled rejection.
+                await me.trap(Promise.resolve().then(() => pane.dockReload()))
+            } catch (error) {
+                error !== Neo.isDestroyed && errors.push(`dockReload() failed for item "${itemId}": ${error?.message || error}`)
+            }
+
+            // Teardown rejected the trap: settle terminally — destroy erased the instance
+            // fields this continuation would otherwise mutate.
+            if (me.isDestroyed) {
+                return {errors}
+            }
+
+            me.dockReloadInFlight.delete(itemId);
+
+            // Re-derive both action axes from current truth: the active item may have changed
+            // mid-flight, so assigning `disabled = false` here would leak across items.
+            me.syncDockReloadAction(tabContainer)
+        }
+
+        !me.isDestroyed && me.fire('dockReloadSettled', {dockNodeId, errors, itemId});
+
+        return {errors}
+    }
+
+    /**
+     * Synchronizes one retained reload action against the live active pane, owning BOTH state
+     * axes: `hidden` while no active item resolves OR the active card does not carry the
+     * `dockReload()` contract; `disabled` while the ACTIVE item — not whichever item started a
+     * flight — has an invocation in flight. Deriving both here (called at the flight edges and
+     * on every active-item change) is what keeps per-item single-flight and the one node-level
+     * action instance consistent when the active item changes mid-flight. The contract probe is
+     * pure — a `typeof` on the card instance, or on its config's `module` prototype while the
+     * card container has not instantiated the slot yet (the post-reconcile sync runs before
+     * card children materialize) — never a resolver call, which may be side-effectful.
+     * @param {Neo.tab.Container|null} tabContainer
+     * @protected
+     */
+    syncDockReloadAction(tabContainer) {
+        let action   = tabContainer?.getActionItem?.('reload'),
+            itemId   = this.getActiveDockItemId(tabContainer),
+            disabled = false,
+            hidden   = true;
+
+        if (action && itemId) {
+            let itemIds = tabContainer.getTabBar()?.sortZoneConfig?.dockItemIds || [],
+                index   = itemIds.indexOf(itemId),
+                pane    = index > -1 ? tabContainer.getCard(index) : null,
+                carrier = pane?.isDestroyed ? null : (pane?.dockReload ?? pane?.module?.prototype?.dockReload);
+
+            disabled = this.dockReloadInFlight.has(itemId);
+            hidden   = typeof carrier !== 'function'
+        }
+
+        if (action) {
+            action.disabled !== disabled && (action.disabled = disabled);
+            action.hidden   !== hidden   && (action.hidden   = hidden)
+        }
     }
 
     /**
@@ -2415,6 +2586,7 @@ class Workspace extends Container {
                 onDockHeaderAction     : me.onDockHeaderAction.bind(me),
                 ...(me.enableDockCloseAction && {enableDockCloseAction: true}),
                 ...(me.enableDockPinAction && {enableDockPinAction: true}),
+                ...(me.enableDockReloadAction && {enableDockReloadAction: true}),
                 ...(me.enableDockMaximizeAction && {
                     dockMaximizeIconCls     : me.dockMaximizeIconCls,
                     enableDockMaximizeAction: true
@@ -2576,7 +2748,14 @@ class Workspace extends Container {
         }
 
         if (!me.isDestroyed) {
-            await me.afterRefreshDockWorkspace({document, refreshOptions, result, played})
+            await me.afterRefreshDockWorkspace({document, refreshOptions, result, played});
+
+            // Once more on SETTLED chrome: the pre-settle sync above can run while projected
+            // header actions are still instantiating (a fresh boot's first refresh), and a
+            // pane-dependent action state (reload's contract probe) corrected on chrome that
+            // does not exist yet is a correction nobody received. Every write in the sync is
+            // change-guarded, so re-running it on settled chrome is idempotent.
+            me.syncDockHeaderActions(result?.currentTabs)
         }
     }
 

--- a/src/dashboard/dock/Workspace.mjs
+++ b/src/dashboard/dock/Workspace.mjs
@@ -2755,8 +2755,6 @@ class Workspace extends Container {
             waitForOverflowProjection
         });
 
-        me.syncDockHeaderActions(result?.currentTabs);
-
         // Awaited on purpose: refreshPromise is the settled-surface contract, and a maximize
         // presentation that re-applies after it settles is a surface nobody can await.
         await me.syncDockMaximizeProjection();
@@ -2785,6 +2783,12 @@ class Workspace extends Container {
 
         if (!me.isDestroyed) {
             await me.afterRefreshDockWorkspace({document, refreshOptions, result, played});
+
+            // Header-action state syncs on the SETTLED tree, never beside the projection
+            // application: a bar write with the refresh's own update train still open is the
+            // collision that duplicated retained chrome on slow rigs. Every write is
+            // change-guarded, so post-settle is both the safe and the idempotent slot.
+            me.syncDockHeaderActions(result?.currentTabs);
 
             // Once more on SETTLED chrome: the pre-settle sync above can run while projected
             // header actions are still instantiating (a fresh boot's first refresh), and a

--- a/src/dashboard/dock/projection/LayoutAdapter.mjs
+++ b/src/dashboard/dock/projection/LayoutAdapter.mjs
@@ -424,6 +424,10 @@ class LayoutAdapter extends Base {
      *     becomes a reserved host-action name while on.
      * @param {String} [options.dockMaximizeIconCls='far fa-window-maximize'] Icon of the projected
      *     maximize action in its un-maximized state; the workspace flips it per toggle.
+     * @param {Boolean} [options.enableDockReloadAction=false] Projects one engine-owned,
+     *     delegation-only reload action into every tabs header — runtime only, no operation is
+     *     ever committed. The workspace owns the `dockReload()` dispatch, the single-flight
+     *     window, the `dockReloadSettled` settlement event and the per-active-pane visibility.
      * @param {Function} [options.onDockActiveIndexChange] Runtime active-item signal for action policy.
      * @param {Function} [options.onDockHeaderAction] Runtime Dock action intent; never persisted.
      * @param {Function} [options.resolveDockHeaderActions] Host resolver for additional tab-header
@@ -434,7 +438,7 @@ class LayoutAdapter extends Base {
      *     their intent arrives through `onDockHeaderAction` like any other, and focus gating is the
      *     tab header's own default. Semantic names must be unique per node, and every engine-owned
      *     name is reserved while its own opt-in is on — `close` under `enableDockCloseAction`, `maximize` under `enableDockMaximizeAction`, `pin`
-     *     under `enableDockPinAction`.
+     *     under `enableDockPinAction`, `reload` under `enableDockReloadAction`.
      * @param {Function} [options.onDockVesselConversionIn] Source-owned strict park admission.
      * @param {Function} [options.onDockVesselConversionOut] Source-owned strict re-show admission.
      * @param {Function} [options.onDockVesselConversionTerminal] Source-owned parked-vessel
@@ -496,6 +500,7 @@ class LayoutAdapter extends Base {
             enableDockCloseAction            : options.enableDockCloseAction === true,
             enableDockMaximizeAction         : options.enableDockMaximizeAction === true,
             enableDockPinAction              : options.enableDockPinAction === true,
+            enableDockReloadAction           : options.enableDockReloadAction === true,
             enableDockTearOut                : options.enableDockTearOut === true,
             enableVesselConversion           : options.enableVesselConversion === true,
             items                            : model.items || {},
@@ -1012,7 +1017,8 @@ class LayoutAdapter extends Base {
               reservedActionNames = new Map([
                   ['close',    context.enableDockCloseAction],
                   ['maximize', context.enableDockMaximizeAction],
-                  ['pin',      context.enableDockPinAction]
+                  ['pin',      context.enableDockPinAction],
+                  ['reload',   context.enableDockReloadAction]
               ]);
 
         for (const action of hostActions) {
@@ -1042,6 +1048,19 @@ class LayoutAdapter extends Base {
 
         const headerActions = [
             ...hostActions,
+            // Reload leads the engine set per the frozen family order (reload · pin · maximize —
+            // close always last). Not a toggle, so the icon is fixed like pin's. `hidden` is a
+            // CONSTANT true here — per-item availability must ride the ONE retained instance's
+            // runtime state (`Workspace#syncDockReloadAction`, the `syncDockCloseAction`
+            // pattern), never this config: a row that varies between projections changes the
+            // actions array, and replacing the action group mid-reconcile is exactly what the
+            // stable-instance note below forbids. Fresh boots reveal through the workspace's
+            // shell-walk sync, which reaches chrome the reconciler retained nothing of.
+            ...(context.enableDockReloadAction ? [{
+                action : 'reload',
+                hidden : true,
+                iconCls: 'fa fa-rotate-right'
+            }] : []),
             ...(context.enableDockPinAction ? [{
                 action    : 'pin',
                 // No `contextual` key, deliberately: the engine set inherits the tab header's

--- a/test/playwright/component/apps/dock-hostreload/app.mjs
+++ b/test/playwright/component/apps/dock-hostreload/app.mjs
@@ -1,0 +1,93 @@
+import DockWorkspace from '../../../../../src/dashboard/dock/Workspace.mjs';
+import Viewport      from '../../../../../src/container/Viewport.mjs';
+import '../../../../../src/tab/Container.mjs';
+
+/**
+ * @summary The flag-off subject: `enableDockReloadAction` stays at its false default while the
+ * HOST legally owns the semantic name `reload` through `resolveDockHeaderActions` (the reserved-
+ * name guard fires only for enabled engine actions). The negative arm proves default-off is
+ * behaviorally INERT: no engine sweep may rewrite this consumer-owned action's state.
+ */
+class HostReloadFixtureWorkspace extends DockWorkspace {
+    static config = {
+        /**
+         * @member {String} className='Test.Playwright.Component.DockMaximize.HostWorkspace'
+         * @protected
+         */
+        className: 'Test.Playwright.Component.DockMaximize.HostWorkspace',
+        /**
+         * One engine action ON, so the header projects an action rail at all — close's opt-in
+         * must not leak reload's sync.
+         * @member {Boolean} enableDockCloseAction=true
+         */
+        enableDockCloseAction: true,
+        /**
+         * @member {String} id='dock-hostreload-workspace'
+         */
+        id: 'dock-hostreload-workspace',
+        /**
+         * @member {Object} layout={ntype:'vbox',align:'stretch'}
+         */
+        layout: {ntype: 'vbox', align: 'stretch'}
+    }
+
+    /**
+     * @param {Object} config
+     */
+    construct(config) {
+        super.construct(config);
+
+        this.add(this.projectDockModel());
+        this.onDockZoneDocumentChange(structuredClone(hostFixtureDocument))
+    }
+
+    /**
+     * Host header actions ride the projection options hook. The host-owned action carries the
+     * ENGINE-RESERVABLE name while the engine flag is off; `showOnFocus: false` keeps it ungated
+     * — consumer-owned state the sweep must not touch.
+     * @returns {Object}
+     */
+    getDockProjectionOptions() {
+        return {
+            ...super.getDockProjectionOptions(),
+            resolveDockHeaderActions: () => [{action: 'reload', hidden: false, iconCls: 'fa fa-rotate-right', showOnFocus: false}]
+        }
+    }
+
+    /**
+     * @param {String} itemId
+     * @param {Object} item
+     * @returns {Object}
+     */
+    resolvePane(itemId, item) {
+        return {
+            id   : `dock-host-pane-${itemId}`,
+            ntype: 'component',
+            text : item?.title || itemId
+        }
+    }
+}
+
+HostReloadFixtureWorkspace = Neo.setupClass(HostReloadFixtureWorkspace);
+
+const hostFixtureDocument = {
+    schema: 'neo.dock.zone.v1',
+    root  : 'host-root',
+    items : {
+        'host-a': {componentRef: 'HostA', title: 'HostA', kind: 'panel'},
+        'host-b': {componentRef: 'HostB', title: 'HostB', kind: 'panel'}
+    },
+    nodes: {
+        'host-root': {type: 'tabs', items: ['host-a', 'host-b'], activeItemId: 'host-a'}
+    }
+};
+
+export const onStart = () => Neo.app({
+    mainView: {
+        module: Viewport,
+        items : [
+            {module: HostReloadFixtureWorkspace, flex: 1}
+        ]
+    },
+    name: 'Test.Playwright.DockHostReload'
+});

--- a/test/playwright/component/apps/dock-hostreload/index.html
+++ b/test/playwright/component/apps/dock-hostreload/index.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Neo.mjs Component Test App</title>
+</head>
+<body>
+    <script src="../../../../../src/MicroLoader.mjs" type="module"></script>
+</body>
+</html>

--- a/test/playwright/component/apps/dock-hostreload/neo-config.json
+++ b/test/playwright/component/apps/dock-hostreload/neo-config.json
@@ -1,0 +1,9 @@
+{
+    "appPath"         : "test/playwright/component/apps/dock-hostreload/app.mjs",
+    "basePath"        : "../../../../../",
+    "environment"     : "development",
+    "mainPath"        : "./Main.mjs",
+    "mainThreadAddons": ["DockFlip", "DragDrop", "Navigator", "Stylesheet"],
+    "themes"          : ["neo-theme-neo-dark", "neo-theme-neo-light"],
+    "useSharedWorkers": false
+}

--- a/test/playwright/component/apps/dock-maximize/app.mjs
+++ b/test/playwright/component/apps/dock-maximize/app.mjs
@@ -613,92 +613,11 @@ class MaximizeFixtureWorkspace extends DockWorkspace {
 
 MaximizeFixtureWorkspace = Neo.setupClass(MaximizeFixtureWorkspace);
 
-/**
- * @summary The flag-off subject: `enableDockReloadAction` stays at its false default while the
- * HOST legally owns the semantic name `reload` through `resolveDockHeaderActions` (the reserved-
- * name guard fires only for enabled engine actions). The negative arm proves default-off is
- * behaviorally INERT: no engine sweep may rewrite this consumer-owned action's state.
- */
-class HostReloadFixtureWorkspace extends DockWorkspace {
-    static config = {
-        /**
-         * @member {String} className='Test.Playwright.Component.DockMaximize.HostWorkspace'
-         * @protected
-         */
-        className: 'Test.Playwright.Component.DockMaximize.HostWorkspace',
-        /**
-         * One engine action ON, so the header projects an action rail at all — close's opt-in
-         * must not leak reload's sync.
-         * @member {Boolean} enableDockCloseAction=true
-         */
-        enableDockCloseAction: true,
-        /**
-         * @member {String} id='dock-hostreload-workspace'
-         */
-        id: 'dock-hostreload-workspace',
-        /**
-         * @member {Object} layout={ntype:'vbox',align:'stretch'}
-         */
-        layout: {ntype: 'vbox', align: 'stretch'}
-    }
-
-    /**
-     * @param {Object} config
-     */
-    construct(config) {
-        super.construct(config);
-
-        this.add(this.projectDockModel());
-        this.onDockZoneDocumentChange(structuredClone(hostFixtureDocument))
-    }
-
-    /**
-     * Host header actions ride the projection options hook. The host-owned action carries the
-     * ENGINE-RESERVABLE name while the engine flag is off; `showOnFocus: false` keeps it ungated
-     * — consumer-owned state the sweep must not touch.
-     * @returns {Object}
-     */
-    getDockProjectionOptions() {
-        return {
-            ...super.getDockProjectionOptions(),
-            resolveDockHeaderActions: () => [{action: 'reload', hidden: false, iconCls: 'fa fa-rotate-right', showOnFocus: false}]
-        }
-    }
-
-    /**
-     * @param {String} itemId
-     * @param {Object} item
-     * @returns {Object}
-     */
-    resolvePane(itemId, item) {
-        return {
-            id   : `dock-host-pane-${itemId}`,
-            ntype: 'component',
-            text : item?.title || itemId
-        }
-    }
-}
-
-HostReloadFixtureWorkspace = Neo.setupClass(HostReloadFixtureWorkspace);
-
-const hostFixtureDocument = {
-    schema: 'neo.dock.zone.v1',
-    root  : 'host-root',
-    items : {
-        'host-a': {componentRef: 'HostA', title: 'HostA', kind: 'panel'},
-        'host-b': {componentRef: 'HostB', title: 'HostB', kind: 'panel'}
-    },
-    nodes: {
-        'host-root': {type: 'tabs', items: ['host-a', 'host-b'], activeItemId: 'host-a'}
-    }
-};
-
 export const onStart = () => Neo.app({
     mainView: {
         module: Viewport,
         items : [
             {module: MaximizeFixtureWorkspace, flex: 1},
-            {module: HostReloadFixtureWorkspace, height: 200},
             // The standing probe: outlives the workspace — observer log + post-destroy release.
             {module: FixtureProbe, id: 'dock-maximize-probe', style: {display: 'none'}}
         ]

--- a/test/playwright/component/apps/dock-maximize/app.mjs
+++ b/test/playwright/component/apps/dock-maximize/app.mjs
@@ -1,7 +1,160 @@
+import Component     from '../../../../../src/component/Base.mjs';
 import DockWorkspace from '../../../../../src/dashboard/dock/Workspace.mjs';
 import Persistence   from '../../../../../src/dashboard/dock/model/Persistence.mjs';
 import Viewport      from '../../../../../src/container/Viewport.mjs';
 import '../../../../../src/tab/Container.mjs';
+
+/**
+ * @summary A pane owning the reload contract: `dockReload()` counts its invocations — the
+ * delegation witness (asked, never recreated).
+ */
+class ReloadProbe extends Component {
+    static config = {
+        /**
+         * @member {String} className='Test.Playwright.Component.DockMaximize.ReloadProbe'
+         * @protected
+         */
+        className: 'Test.Playwright.Component.DockMaximize.ReloadProbe',
+        /**
+         * @member {String} ntype='dock-maximize-reload-probe'
+         * @protected
+         */
+        ntype: 'dock-maximize-reload-probe'
+    }
+
+    /**
+     * Spec-readable invocation counter.
+     * @member {Number} reloadCount=0
+     */
+    reloadCount = 0
+
+    /**
+     * 'sync' resolves immediately; 'defer' returns a promise the spec resolves through the
+     * workspace trigger; 'reject' returns an async rejection.
+     * @member {String} reloadMode='sync'
+     */
+    reloadMode = 'sync'
+
+    /**
+     * The deferred resolver while {@link #reloadMode} is 'defer' and an invocation is in flight.
+     * @member {Function|null} resolveDeferred=null
+     */
+    resolveDeferred = null
+
+    /**
+     * The reload contract: the author owns what reload means — including whether it is async.
+     * A deferred producer's resolver is ALSO stashed on the standing fixture probe (which
+     * outlives the workspace), so the teardown arm can release the producer AFTER destroy —
+     * the falsifier for post-destroy continuation mutations. One deferred flight at a time.
+     * @returns {void|Promise<*>}
+     */
+    dockReload() {
+        this.reloadCount++;
+
+        if (this.reloadMode === 'reject') {
+            return Promise.reject(new Error('async refusal'))
+        }
+
+        if (this.reloadMode === 'defer') {
+            return new Promise(resolve => {
+                this.resolveDeferred = resolve;
+
+                const probe = Neo.get('dock-maximize-probe');
+
+                probe && (probe.deferredRelease = resolve)
+            })
+        }
+    }
+}
+
+ReloadProbe = Neo.setupClass(ReloadProbe);
+
+/**
+ * @summary The standing fixture probe: a spec-readable mirror component that OUTLIVES the
+ * workspace. Carries the observer lifecycle log and the post-destroy release channel for a
+ * deferred `dockReload()` producer — `releaseDeferredCount` is the spec's only way to settle a
+ * producer after the workspace (and every trigger config on it) is gone.
+ */
+class FixtureProbe extends Component {
+    static config = {
+        /**
+         * @member {String} className='Test.Playwright.Component.DockMaximize.FixtureProbe'
+         * @protected
+         */
+        className: 'Test.Playwright.Component.DockMaximize.FixtureProbe',
+        /**
+         * @member {String} ntype='dock-maximize-fixture-probe'
+         * @protected
+         */
+        ntype: 'dock-maximize-fixture-probe',
+        /**
+         * Trigger: releases the stashed deferred resolver — usable after workspace destroy.
+         * @member {Number} releaseDeferredCount_=0
+         */
+        releaseDeferredCount_: 0
+    }
+
+    /**
+     * The stashed resolver of the one in-flight deferred `dockReload()` producer.
+     * @member {Function|null} deferredRelease=null
+     */
+    deferredRelease = null
+
+    /**
+     * Spec-readable: how many deferred producers this probe has released.
+     * @member {Number} deferredReleasedTotal=0
+     */
+    deferredReleasedTotal = 0
+
+    /**
+     * @param {Number} value
+     * @param {Number} oldValue
+     * @protected
+     */
+    afterSetReleaseDeferredCount(value, oldValue) {
+        if (oldValue === undefined) {
+            return
+        }
+
+        let me = this;
+
+        if (me.deferredRelease) {
+            me.deferredRelease();
+            me.deferredRelease = null;
+            me.deferredReleasedTotal++
+        }
+    }
+}
+
+FixtureProbe = Neo.setupClass(FixtureProbe);
+
+/**
+ * @summary A pane whose `dockReload()` throws — the containment witness: the pane is kept,
+ * the error surfaces, and no recreate ever runs.
+ */
+class ThrowingReloadProbe extends Component {
+    static config = {
+        /**
+         * @member {String} className='Test.Playwright.Component.DockMaximize.ThrowingReloadProbe'
+         * @protected
+         */
+        className: 'Test.Playwright.Component.DockMaximize.ThrowingReloadProbe',
+        /**
+         * @member {String} ntype='dock-maximize-throwing-probe'
+         * @protected
+         */
+        ntype: 'dock-maximize-throwing-probe'
+    }
+
+    /**
+     * The reload contract, refusing: containment must keep this pane.
+     */
+    dockReload() {
+        throw new Error('probe refuses to reload')
+    }
+}
+
+ThrowingReloadProbe = Neo.setupClass(ThrowingReloadProbe);
 
 const fixtureDocument = {
     schema: 'neo.dock.zone.v1',
@@ -58,6 +211,19 @@ class MaximizeFixtureWorkspace extends DockWorkspace {
          */
         captureCount_: 0,
         /**
+         * Spec trigger: sets the alpha probe's reload mode ('sync' | 'defer' | 'reject') —
+         * worker-side state the page realm cannot reach directly.
+         * @member {String|null} alphaReloadMode_=null
+         * @reactive
+         */
+        alphaReloadMode_: null,
+        /**
+         * Spec trigger: each bump resolves the alpha probe's deferred `dockReload()` promise.
+         * @member {Number} alphaReloadResolveCount_=0
+         * @reactive
+         */
+        alphaReloadResolveCount_: 0,
+        /**
          * Spec trigger: JSON `{itemId, tabsNodeId, index}` commits one `addTab` operation —
          * the confinement arms need the catalog-only, in-node, and cross-node variants.
          * @member {String|null} addTabJson_=null
@@ -80,6 +246,10 @@ class MaximizeFixtureWorkspace extends DockWorkspace {
          * @member {Boolean} enableDockMaximizeAction=true
          */
         enableDockMaximizeAction: true,
+        /**
+         * @member {Boolean} enableDockReloadAction=true
+         */
+        enableDockReloadAction: true,
         /**
          * @member {String} id='dock-maximize-workspace'
          */
@@ -150,6 +320,25 @@ class MaximizeFixtureWorkspace extends DockWorkspace {
     settleJson = null
 
     /**
+     * Spec-readable mirror of the PRODUCTION settlement channel: the fixture subscribes to the
+     * engine's `dockReloadSettled` event like any application would — the mirror proves the
+     * public surface, not a test-only override.
+     * @member {String|null} lastReloadResultJson=null
+     */
+    lastReloadResultJson = null
+
+    /**
+     * @param {Object} config
+     */
+    onConstructed() {
+        super.onConstructed();
+
+        this.on('dockReloadSettled', data => {
+            this.lastReloadResultJson = JSON.stringify({errors: data.errors, itemId: data.itemId})
+        })
+    }
+
+    /**
      * @param {Object} data
      */
     onDockMaximizeResize(data) {
@@ -179,6 +368,37 @@ class MaximizeFixtureWorkspace extends DockWorkspace {
         // Post-destroy the engine wipes instance fields, so read "torn" as any non-true value.
         observerLog.push(`destroy:${wasObserved}->${this.dockMaximizeResizeObserved ? 'live' : 'torn'}`);
         syncObserverProbe()
+    }
+
+    /**
+     * @param {String|null} value
+     * @param {String|null} oldValue
+     * @protected
+     */
+    afterSetAlphaReloadMode(value, oldValue) {
+        if (oldValue === undefined || !value) {
+            return
+        }
+
+        const probe = Neo.get('dock-maximize-pane-alpha');
+
+        probe && (probe.reloadMode = value)
+    }
+
+    /**
+     * @param {Number} value
+     * @param {Number} oldValue
+     * @protected
+     */
+    afterSetAlphaReloadResolveCount(value, oldValue) {
+        if (oldValue === undefined) {
+            return
+        }
+
+        const probe = Neo.get('dock-maximize-pane-alpha');
+
+        probe?.resolveDeferred?.();
+        probe && (probe.resolveDeferred = null)
     }
 
     /**
@@ -354,8 +574,15 @@ class MaximizeFixtureWorkspace extends DockWorkspace {
             }
         }
 
+        // alpha and beta both own the reload contract — two contract carriers in ONE node is
+        // what witnesses per-item single-flight across active-item switches; gamma's contract
+        // throws (containment witness); frame stays contract-free — the hidden witness.
+        const module = itemId === 'alpha' || itemId === 'beta' ? ReloadProbe
+            : itemId === 'gamma' ? ThrowingReloadProbe
+            : null;
+
         return {
-            ntype: 'component',
+            ...(module ? {module} : {ntype: 'component'}),
             id   : `dock-maximize-pane-${itemId}`,
             style: {alignItems: 'center', display: 'flex', justifyContent: 'center'},
             text : item?.title || itemId
@@ -370,8 +597,8 @@ export const onStart = () => Neo.app({
         module: Viewport,
         items : [
             {module: MaximizeFixtureWorkspace, flex: 1},
-            // The observer-log probe: outlives the workspace so the destroy arm can read it.
-            {ntype: 'component', id: 'dock-maximize-probe', style: {display: 'none'}}
+            // The standing probe: outlives the workspace — observer log + post-destroy release.
+            {module: FixtureProbe, id: 'dock-maximize-probe', style: {display: 'none'}}
         ]
     },
     name: 'Test.Playwright.DockMaximize'

--- a/test/playwright/component/apps/dock-maximize/app.mjs
+++ b/test/playwright/component/apps/dock-maximize/app.mjs
@@ -224,6 +224,14 @@ class MaximizeFixtureWorkspace extends DockWorkspace {
          */
         alphaReloadResolveCount_: 0,
         /**
+         * Spec trigger: each bump dispatches `handleDockReloadAction` with NO resolvable active
+         * item (null tabContainer) — the no-active race arm: settlement must still reach the
+         * `dockReloadSettled` channel, with `itemId: null`.
+         * @member {Number} dispatchNoActiveReloadCount_=0
+         * @reactive
+         */
+        dispatchNoActiveReloadCount_: 0,
+        /**
          * Spec trigger: JSON `{itemId, tabsNodeId, index}` commits one `addTab` operation —
          * the confinement arms need the catalog-only, in-node, and cross-node variants.
          * @member {String|null} addTabJson_=null
@@ -399,6 +407,19 @@ class MaximizeFixtureWorkspace extends DockWorkspace {
 
         probe?.resolveDeferred?.();
         probe && (probe.resolveDeferred = null)
+    }
+
+    /**
+     * @param {Number} value
+     * @param {Number} oldValue
+     * @protected
+     */
+    afterSetDispatchNoActiveReloadCount(value, oldValue) {
+        if (oldValue === undefined) {
+            return
+        }
+
+        this.handleDockReloadAction({dockNodeId: 'main-tabs', tabContainer: null})
     }
 
     /**
@@ -592,11 +613,92 @@ class MaximizeFixtureWorkspace extends DockWorkspace {
 
 MaximizeFixtureWorkspace = Neo.setupClass(MaximizeFixtureWorkspace);
 
+/**
+ * @summary The flag-off subject: `enableDockReloadAction` stays at its false default while the
+ * HOST legally owns the semantic name `reload` through `resolveDockHeaderActions` (the reserved-
+ * name guard fires only for enabled engine actions). The negative arm proves default-off is
+ * behaviorally INERT: no engine sweep may rewrite this consumer-owned action's state.
+ */
+class HostReloadFixtureWorkspace extends DockWorkspace {
+    static config = {
+        /**
+         * @member {String} className='Test.Playwright.Component.DockMaximize.HostWorkspace'
+         * @protected
+         */
+        className: 'Test.Playwright.Component.DockMaximize.HostWorkspace',
+        /**
+         * One engine action ON, so the header projects an action rail at all — close's opt-in
+         * must not leak reload's sync.
+         * @member {Boolean} enableDockCloseAction=true
+         */
+        enableDockCloseAction: true,
+        /**
+         * @member {String} id='dock-hostreload-workspace'
+         */
+        id: 'dock-hostreload-workspace',
+        /**
+         * @member {Object} layout={ntype:'vbox',align:'stretch'}
+         */
+        layout: {ntype: 'vbox', align: 'stretch'}
+    }
+
+    /**
+     * @param {Object} config
+     */
+    construct(config) {
+        super.construct(config);
+
+        this.add(this.projectDockModel());
+        this.onDockZoneDocumentChange(structuredClone(hostFixtureDocument))
+    }
+
+    /**
+     * Host header actions ride the projection options hook. The host-owned action carries the
+     * ENGINE-RESERVABLE name while the engine flag is off; `showOnFocus: false` keeps it ungated
+     * — consumer-owned state the sweep must not touch.
+     * @returns {Object}
+     */
+    getDockProjectionOptions() {
+        return {
+            ...super.getDockProjectionOptions(),
+            resolveDockHeaderActions: () => [{action: 'reload', hidden: false, iconCls: 'fa fa-rotate-right', showOnFocus: false}]
+        }
+    }
+
+    /**
+     * @param {String} itemId
+     * @param {Object} item
+     * @returns {Object}
+     */
+    resolvePane(itemId, item) {
+        return {
+            id   : `dock-host-pane-${itemId}`,
+            ntype: 'component',
+            text : item?.title || itemId
+        }
+    }
+}
+
+HostReloadFixtureWorkspace = Neo.setupClass(HostReloadFixtureWorkspace);
+
+const hostFixtureDocument = {
+    schema: 'neo.dock.zone.v1',
+    root  : 'host-root',
+    items : {
+        'host-a': {componentRef: 'HostA', title: 'HostA', kind: 'panel'},
+        'host-b': {componentRef: 'HostB', title: 'HostB', kind: 'panel'}
+    },
+    nodes: {
+        'host-root': {type: 'tabs', items: ['host-a', 'host-b'], activeItemId: 'host-a'}
+    }
+};
+
 export const onStart = () => Neo.app({
     mainView: {
         module: Viewport,
         items : [
             {module: MaximizeFixtureWorkspace, flex: 1},
+            {module: HostReloadFixtureWorkspace, height: 200},
             // The standing probe: outlives the workspace — observer log + post-destroy release.
             {module: FixtureProbe, id: 'dock-maximize-probe', style: {display: 'none'}}
         ]

--- a/test/playwright/component/dashboard/DockReload.spec.mjs
+++ b/test/playwright/component/dashboard/DockReload.spec.mjs
@@ -208,6 +208,39 @@ test.describe('dock reload — delegation-only, settled, single-flight', () => {
         await expect(reload).toBeEnabled()
     });
 
+    test('default-off is behaviorally inert: a host-owned reload action keeps consumer state', async ({page}) => {
+        const host   = tabsNodeWith(page, 'HostA'),
+              close  = actionButton(host, 'fa-times'),
+              reload = actionButton(host, 'fa-rotate-right');
+
+        // The host workspace legally owns the NAME `reload` while the engine flag is off. The
+        // engine's close action (its flag IS on) proves the sweep runs on this header — reload's
+        // per-action guard, not a dead sweep, is what protects the host action.
+        await expect(close).toHaveCount(1);
+        await expect(reload).toHaveCount(1);
+
+        // Active switches drive both sync paths (no-commit re-emit + committed activation); a
+        // guardless sweep hides the host action here — the pane has no dockReload() contract.
+        await tabButton(host, 'HostB').click();
+        await expect(tabButton(host, 'HostB')).toHaveClass(/pressed/);
+        await expect(reload).toHaveCount(1);
+        await expect(reload).toBeEnabled();
+
+        await tabButton(host, 'HostA').click();
+        await expect(tabButton(host, 'HostA')).toHaveClass(/pressed/);
+        await expect(reload).toHaveCount(1);
+        await expect(reload).toBeEnabled()
+    });
+
+    test('the no-active race settles through the channel with a null item', async ({page}) => {
+        await setWorkspace(page, {dispatchNoActiveReloadCount: 1});
+
+        await expect.poll(() => lastSettled(page)).toEqual({
+            errors: ['Dock reload action requires an active item'],
+            itemId: null
+        })
+    });
+
     test('teardown mid-flight settles terminally: a producer released after destroy mutates nothing', async ({page}) => {
         const main     = tabsNodeWith(page, 'Alpha'),
               pageErrs = [];

--- a/test/playwright/component/dashboard/DockReload.spec.mjs
+++ b/test/playwright/component/dashboard/DockReload.spec.mjs
@@ -1,0 +1,233 @@
+import {test, expect} from '@playwright/test';
+
+/**
+ * The engine-owned, delegation-only dock reload action
+ * (`Neo.dashboard.dock.Workspace#enableDockReloadAction`), witnessed on a rendered workspace:
+ *
+ * - **Delegation:** a pane implementing `dockReload()` is asked — invocation counted, instance
+ *   identity untouched, the committed document byte-identical.
+ * - **Settlement channel:** every completion — sync success, sync throw, async resolution, async
+ *   rejection — settles exactly once through the PRODUCTION `dockReloadSettled` event (the
+ *   fixture subscribes like any application; no test-only override).
+ * - **Single-flight:** one invocation per item at a time; the stable action instance disables
+ *   for the window, a second activation cannot double-invoke, and BOTH action axes (`hidden`
+ *   from the contract, `disabled` from the active item's in-flight membership) re-derive on
+ *   every active-item change — switching panes never inherits another item's flight window.
+ * - **Availability:** hidden for panes without the contract — a pure `typeof` probe on the live
+ *   card, never a resolver call.
+ * - **Teardown:** destroying the workspace mid-flight settles the delegation terminally; a
+ *   producer released AFTER destroy mutates nothing (the erased-field falsifier).
+ *
+ * Rides the dock-maximize fixture app: `alpha` and `beta` both own the contract (alpha
+ * mode-switchable sync/defer/reject — two carriers in one node witness per-item single-flight),
+ * `gamma` owns a sync-throwing one, `frame` stays contract-free — the hidden-witness.
+ */
+
+const WORKSPACE_ID = 'dock-maximize-workspace';
+
+const readInstance = async (page, id, keys) => {
+    const reply = await page.evaluate(data => Neo.worker.App.getConfigs(data), {id, keys});
+
+    return reply?.data ?? reply
+};
+
+const setWorkspace = (page, configs) => page.evaluate(
+    data => Neo.worker.App.setConfigs(data),
+    {id: WORKSPACE_ID, ...configs}
+);
+
+const lastSettled = async page => {
+    const raw = (await readInstance(page, WORKSPACE_ID, ['lastReloadResultJson']))[0];
+
+    return raw ? JSON.parse(raw) : null
+};
+
+const tabsNodeWith = (page, tabText) => page.locator('.neo-dashboard-dock-tabs', {
+    has: page.locator(`.neo-tab-header-button:has-text("${tabText}")`)
+});
+
+const tabButton = (node, text) => node.locator('.neo-tab-header-button', {hasText: text});
+
+const actionButton = (node, glyph) => node.locator(`.neo-tab-header-toolbar .neo-button:has([class*="${glyph}"])`);
+
+test.beforeEach(async ({page}) => {
+    await page.goto('test/playwright/component/apps/dock-maximize/index.html');
+    await page.waitForSelector('#dock-maximize-workspace', {state: 'attached'});
+    await page.waitForSelector('.neo-tab-header-button',   {state: 'visible'})
+});
+
+test.describe('dock reload — delegation-only, settled, single-flight', () => {
+    test('reload leads the engine set, focus-gated like its siblings', async ({page}) => {
+        const main = tabsNodeWith(page, 'Alpha');
+
+        await expect(actionButton(main, 'fa-rotate-right')).toHaveClass(/neo-toolbar-action-context-inactive/);
+
+        await tabButton(main, 'Alpha').click();
+        await expect(actionButton(main, 'fa-rotate-right')).not.toHaveClass(/neo-toolbar-action-context-inactive/);
+
+        // The frozen ordering contract as geometry: reload → maximize → close.
+        const reloadBox = await actionButton(main, 'fa-rotate-right').boundingBox(),
+              maxBox    = await actionButton(main, 'fa-window-maximize').boundingBox(),
+              closeBox  = await actionButton(main, 'fa-times').boundingBox();
+
+        expect(reloadBox.x).toBeLessThan(maxBox.x);
+        expect(maxBox.x).toBeLessThan(closeBox.x)
+    });
+
+    test('sync delegation settles clean: asked once, identity kept, document untouched', async ({page}) => {
+        const main = tabsNodeWith(page, 'Alpha');
+
+        await page.evaluate(() => {
+            const el = document.getElementById('dock-maximize-pane-alpha');
+
+            window.__alphaEl   = el;
+            el.dataset.witness = 'kept'
+        });
+
+        const [docBefore] = await readInstance(page, WORKSPACE_ID, ['docJson']);
+
+        await tabButton(main, 'Alpha').click();
+        await actionButton(main, 'fa-rotate-right').click();
+
+        await expect.poll(() => lastSettled(page)).toEqual({errors: [], itemId: 'alpha'});
+        await expect.poll(async () => (await readInstance(page, 'dock-maximize-pane-alpha', ['reloadCount']))[0]).toBe(1);
+
+        expect(await page.evaluate(() => {
+            const el = document.getElementById('dock-maximize-pane-alpha');
+
+            return el === window.__alphaEl && el.dataset.witness === 'kept'
+        })).toBe(true);
+
+        expect((await readInstance(page, WORKSPACE_ID, ['docJson']))[0]).toBe(docBefore)
+    });
+
+    test('a sync-throwing dockReload() keeps the pane and settles the failure', async ({page}) => {
+        const side = tabsNodeWith(page, 'Frame');
+
+        await tabButton(side, 'Gamma').click();
+
+        await page.waitForSelector('#dock-maximize-pane-gamma', {state: 'attached'});
+        await page.evaluate(() => {
+            const el = document.getElementById('dock-maximize-pane-gamma');
+
+            window.__gammaEl   = el;
+            el.dataset.witness = 'kept'
+        });
+
+        const [docBefore] = await readInstance(page, WORKSPACE_ID, ['docJson']);
+
+        await actionButton(side, 'fa-rotate-right').click();
+
+        await expect.poll(async () => (await lastSettled(page))?.errors?.[0] || '').toContain('probe refuses to reload');
+
+        expect(await page.evaluate(() => {
+            const el = document.getElementById('dock-maximize-pane-gamma');
+
+            return el === window.__gammaEl && el.dataset.witness === 'kept'
+        })).toBe(true);
+
+        expect((await readInstance(page, WORKSPACE_ID, ['docJson']))[0]).toBe(docBefore)
+    });
+
+    test('async lifecycle: single-flight disables the action, resolution and rejection both settle', async ({page}) => {
+        const main   = tabsNodeWith(page, 'Alpha'),
+              reload = actionButton(main, 'fa-rotate-right');
+
+        await tabButton(main, 'Alpha').click();
+        await setWorkspace(page, {alphaReloadMode: 'defer'});
+
+        const [docBefore] = await readInstance(page, WORKSPACE_ID, ['docJson']);
+
+        await reload.click();
+
+        // In flight: the stable instance disables; a second activation cannot double-invoke.
+        await expect(reload).toBeDisabled();
+        await reload.click({force: true});
+        await expect.poll(async () => (await readInstance(page, 'dock-maximize-pane-alpha', ['reloadCount']))[0]).toBe(1);
+
+        // Resolution settles, re-enables.
+        await setWorkspace(page, {alphaReloadResolveCount: 1});
+        await expect.poll(() => lastSettled(page)).toEqual({errors: [], itemId: 'alpha'});
+        await expect(reload).toBeEnabled();
+
+        // An async rejection settles with the failure text and keeps everything intact.
+        await setWorkspace(page, {alphaReloadMode: 'reject'});
+        await reload.click();
+
+        await expect.poll(async () => (await lastSettled(page))?.errors?.[0] || '').toContain('async refusal');
+        await expect(reload).toBeEnabled();
+        await expect.poll(async () => (await readInstance(page, 'dock-maximize-pane-alpha', ['reloadCount']))[0]).toBe(2);
+
+        expect((await readInstance(page, WORKSPACE_ID, ['docJson']))[0]).toBe(docBefore)
+    });
+
+    test('a pane without the contract hides the action — pure probe, no resolver call', async ({page}) => {
+        const side   = tabsNodeWith(page, 'Frame'),
+              reload = actionButton(side, 'fa-rotate-right');
+
+        // gamma (contract, throwing or not) active: present in the DOM.
+        await tabButton(side, 'Gamma').click();
+        await expect(reload).toHaveCount(1);
+
+        // frame (contract-free) active: hidden means removeDom — the control leaves entirely.
+        await tabButton(side, 'Frame').click();
+        await expect(reload).toHaveCount(0);
+
+        // and returns with gamma.
+        await tabButton(side, 'Gamma').click();
+        await expect(reload).toHaveCount(1)
+    });
+
+    test('single-flight is per item: switching panes re-derives both axes from the active item', async ({page}) => {
+        const main   = tabsNodeWith(page, 'Alpha'),
+              reload = actionButton(main, 'fa-rotate-right');
+
+        await tabButton(main, 'Alpha').click();
+        await setWorkspace(page, {alphaReloadMode: 'defer'});
+        await reload.click();
+        await expect(reload).toBeDisabled();
+
+        // beta shares the node and the contract but owns NO flight: the same action instance
+        // must re-enable for it — inheriting alpha's window is the falsifier.
+        await tabButton(main, 'Beta').click();
+        await expect(reload).toBeEnabled();
+
+        // beta can even run its own (sync) delegation while alpha's flight is still open.
+        await reload.click();
+        await expect.poll(() => lastSettled(page)).toEqual({errors: [], itemId: 'beta'});
+        await expect.poll(async () => (await readInstance(page, 'dock-maximize-pane-beta', ['reloadCount']))[0]).toBe(1);
+
+        // back on alpha the open flight must resurface as disabled — not the false-enable that
+        // a blind `disabled = false` at beta's settlement would have written.
+        await tabButton(main, 'Alpha').click();
+        await expect(reload).toBeDisabled();
+
+        // releasing alpha's producer settles it and re-derives the enabled state.
+        await setWorkspace(page, {alphaReloadResolveCount: 1});
+        await expect.poll(() => lastSettled(page)).toEqual({errors: [], itemId: 'alpha'});
+        await expect(reload).toBeEnabled()
+    });
+
+    test('teardown mid-flight settles terminally: a producer released after destroy mutates nothing', async ({page}) => {
+        const main     = tabsNodeWith(page, 'Alpha'),
+              pageErrs = [];
+
+        page.on('pageerror', error => pageErrs.push(String(error)));
+
+        await tabButton(main, 'Alpha').click();
+        await setWorkspace(page, {alphaReloadMode: 'defer'});
+        await actionButton(main, 'fa-rotate-right').click();
+        await expect(actionButton(main, 'fa-rotate-right')).toBeDisabled();
+
+        await page.evaluate(() => Neo.worker.App.destroyNeoInstance('dock-maximize-workspace'));
+        await page.waitForSelector('#dock-maximize-workspace', {state: 'detached'});
+
+        // The producer settles AFTER destroy, through the standing probe (the workspace and its
+        // trigger configs are gone). Old-shape falsifier: the resumed continuation dereferenced
+        // the erased in-flight Set — a TypeError this collector would catch.
+        await page.evaluate(data => Neo.worker.App.setConfigs(data), {id: 'dock-maximize-probe', releaseDeferredCount: 1});
+        await expect.poll(async () => (await readInstance(page, 'dock-maximize-probe', ['deferredReleasedTotal']))[0]).toBe(1);
+
+        expect(pageErrs).toEqual([])
+    })
+});

--- a/test/playwright/component/dashboard/DockReload.spec.mjs
+++ b/test/playwright/component/dashboard/DockReload.spec.mjs
@@ -209,6 +209,12 @@ test.describe('dock reload — delegation-only, settled, single-flight', () => {
     });
 
     test('default-off is behaviorally inert: a host-owned reload action keeps consumer state', async ({page}) => {
+        // Isolated fixture: two workspaces booting concurrently in one app interfere on CI
+        // (double-rendered bar chrome) — the flag-off subject boots alone on its own page.
+        await page.goto('test/playwright/component/apps/dock-hostreload/index.html');
+        await page.waitForSelector('#dock-hostreload-workspace', {state: 'attached'});
+        await page.waitForSelector('.neo-tab-header-button', {state: 'visible'});
+
         const host   = tabsNodeWith(page, 'HostA'),
               close  = actionButton(host, 'fa-times'),
               reload = actionButton(host, 'fa-rotate-right');

--- a/test/playwright/e2e/dashboard/DockReloadActionNL.spec.mjs
+++ b/test/playwright/e2e/dashboard/DockReloadActionNL.spec.mjs
@@ -1,0 +1,124 @@
+import { test, expect } from '../../fixtures.mjs';
+
+/**
+ * Whitebox-e2e: the gesture proof for the engine-owned, delegation-only reload action.
+ *
+ * The component battery proves the mechanics on a fixture; the product truths only this spec can
+ * certify are
+ *
+ *   1. the projected `reload` action is a REAL, clickable button on a real product pane that
+ *      implements the `dockReload()` contract (the example's Strategy pane, whose reload meaning
+ *      is a visible refresh counter),
+ *   2. pressing it delegates INTO the pane — the counter advances where a user can read it — and
+ *      commits nothing: the App Worker's dock document is byte-identical after the gesture,
+ *   3. availability is the contract, not the flag: the very same node's header hides the action
+ *      the moment a pane WITHOUT `dockReload()` holds the active slot, with the always-visible
+ *      close action as the control arm proving the header itself is live.
+ *
+ * Paradigm (whitebox-e2e protocol): Playwright drives the native clicks; the Neural Link fixture
+ * reads the holder's committed `dockModel` and the pane's counter. Nothing here is committed
+ * programmatically — every mutation comes from a real gesture.
+ *
+ * Run: NEO_AGENTOS_RUNTIME_ROOT=/path/to/neo-agent-brain NEO_E2E_PORT=8091 npx playwright test \
+ *      DockReloadActionNL -c test/playwright/playwright.config.e2e.mjs --workers=1
+ */
+
+const bootDockExample = async ({ page, neuralLink }) => {
+    await page.goto('/examples/dashboard/dock/');
+    page.on('pageerror', err => console.error('BROWSER JS ERROR:', err));
+
+    // Event-driven settle: the projected dock chrome proves worker boot + first render, and
+    // connectToApp carries its own bounded worker-identity polling — no fixed sleeps.
+    await page.waitForSelector('.neo-dashboard-dock-tabs', { state: 'visible' });
+
+    const app      = await neuralLink.connectToApp('Neo.examples.dashboard.dock');
+    const holders  = await app.findInstances({ className: 'Neo.examples.dashboard.dock.MainContainer' }, ['id']);
+    const holderId = Array.isArray(holders) ? holders[0]?.id : holders?.id;
+
+    expect(holderId, 'the dock MainContainer must exist in the App Worker').toBeTruthy();
+
+    const readModel = async () => (await app.getComponent(holderId, ['dockModel'])).dockModel;
+
+    return { app, holderId, readModel }
+};
+
+/** Resolves the live projected TabContainer id for one semantic dock node. */
+const tabsNodeId = async (app, dockNodeId) => {
+    const records = await app.queryComponent({ dockNodeId }, ['id', 'ntype']),
+          record  = Array.isArray(records) ? records[0] : records;
+
+    return record?.id ?? record?.properties?.id
+};
+
+/**
+ * Clicks one pane's tab header, which is how a user gives that pane focus — the engine set is
+ * focus-gated, so without this the actions are invisible for a reason unrelated to the policy
+ * under test. No settle sleep: every call site follows with its own poll on the action state
+ * the focus change produces.
+ */
+const focusPane = async (app, page, dockItemId) => {
+    const records = await app.findInstances({ className: 'Neo.tab.header.Button', dockItemId }, ['id', 'dockItemId']),
+          record  = Array.isArray(records) ? records[0] : records,
+          id      = record?.id ?? record?.properties?.id;
+
+    expect(id, `the ${dockItemId} pane owns a live tab header button`).toBeTruthy();
+    await page.locator(`#${id}`).click()
+};
+
+test.describe('Dock reload action — delegation into the pane (Neural Link)', () => {
+    test.setTimeout(90000);
+    test.use({ viewport: { width: 1600, height: 900 } });
+
+    test('the reload action asks the contract-bearing pane, commits nothing, and hides without the contract', async ({ page, neuralLink }) => {
+        const { app, readModel } = await bootDockExample({ page, neuralLink }),
+              before             = await readModel(),
+              mainTabsId         = await tabsNodeId(app, 'main-tabs');
+
+        expect(mainTabsId, 'the center stack projects a live TabContainer').toBeTruthy();
+
+        // Strategy (the contract carrier) is the seeded active pane; focus opens the gated set.
+        await focusPane(app, page, 'strategy');
+
+        // The projected action boots hidden BY DESIGN (the adapter row is projection-constant);
+        // the workspace's boot sync reveals it for the contract-bearing active pane — so the
+        // reveal itself is the settle surface, not the action's existence.
+        await expect.poll(async () => {
+            const action = await app.callMethod(mainTabsId, 'getActionItem', ['reload']);
+
+            return action ? action.hidden !== true : null
+        }, {
+            message: 'the boot sync reveals the persistent reload action for the contract-bearing pane',
+            timeout: 10000
+        }).toBe(true);
+
+        const reloadAction = await app.callMethod(mainTabsId, 'getActionItem', ['reload']);
+
+        // The focus consequence, as its own settle surface: the engine set ungates in the DOM.
+        await expect(page.locator(`#${reloadAction.id}`)).not.toHaveClass(/neo-toolbar-action-context-inactive/);
+
+        // Product truth #2: the gesture delegates into the pane — the counter is USER-VISIBLE.
+        await page.locator(`#${reloadAction.id}`).click();
+        await expect(page.getByText('Strategy · reloaded 1×')).toBeVisible();
+
+        await page.locator(`#${reloadAction.id}`).click();
+        await expect(page.getByText('Strategy · reloaded 2×')).toBeVisible();
+
+        // …and commits nothing: the committed document is byte-identical after two gestures.
+        expect(JSON.stringify(await readModel())).toBe(JSON.stringify(before));
+
+        // Product truth #3: availability is the contract, not the flag. Swarm implements no
+        // dockReload(), so the SAME header hides the action for it — while close (the gating
+        // opt-out) stays visible on that focused header, proving the header itself is live.
+        await focusPane(app, page, 'swarm');
+
+        await expect.poll(async () => (await app.callMethod(mainTabsId, 'getActionItem', ['reload']))?.hidden, {
+            message: 'a pane without the contract hides the reload action',
+            timeout: 10000
+        }).toBe(true);
+
+        const closeAction = await app.callMethod(mainTabsId, 'getActionItem', ['close']);
+
+        expect(closeAction?.id, 'the control arm: close projects on the same header').toBeTruthy();
+        await expect(page.locator(`#${closeAction.id}`)).toBeVisible()
+    })
+});

--- a/test/playwright/unit/dashboard/DockLayoutAdapter.spec.mjs
+++ b/test/playwright/unit/dashboard/DockLayoutAdapter.spec.mjs
@@ -506,6 +506,52 @@ test.describe('Neo.dashboard.dock.projection.LayoutAdapter', () => {
         expect(hostOwned.headerActions.map(action => action.action)).toEqual(['maximize'])
     });
 
+    test('reload leads the engine set and reserves its name through the guard table', () => {
+        const
+            model       = createModel(),
+            resolvePane = componentRef => ({ntype: 'dashboard-panel', reference: componentRef}),
+
+            enabled = DockLayoutAdapter.project(model, {
+                enableDockCloseAction   : true,
+                enableDockMaximizeAction: true,
+                enableDockPinAction     : true,
+                enableDockReloadAction  : true,
+                resolveComponentRef     : resolvePane
+            }),
+
+            enabledMain = getProjectedChildren(enabled)[0];
+
+        // The frozen family order: reload leads the engine set, close stays last.
+        expect(enabledMain.headerActions.map(action => action.action))
+            .toEqual(['reload', 'pin', 'maximize', 'close']);
+
+        // Focus-gated like its engine siblings — no `contextual` opt-out — and it SHIPS hidden:
+        // availability is a live-card contract probe only the workspace can run post-mount.
+        expect(enabledMain.headerActions[0].contextual).toBeUndefined();
+        expect(enabledMain.headerActions[0].hidden).toBe(true);
+        expect(enabledMain.headerActions[0].iconCls).toBe('fa fa-rotate-right');
+
+        // Off = byte-identical: no reload entry materialises for the flag alone.
+        const withoutReload = getProjectedChildren(DockLayoutAdapter.project(model, {
+            enableDockCloseAction: true,
+            resolveComponentRef  : resolvePane
+        }))[0];
+
+        expect(withoutReload.headerActions.map(action => action.action)).toEqual(['close']);
+
+        // The guard table reserves the name exactly while the flag is on.
+        const project = (resolveDockHeaderActions, extra={}) => () => DockLayoutAdapter.project(model, {
+            resolveComponentRef: resolvePane, resolveDockHeaderActions, ...extra
+        });
+
+        expect(project(() => [{action: 'reload'}], {enableDockReloadAction: true}))
+            .toThrow(/"reload" is reserved while enableDockReloadAction is on/);
+
+        const hostReload = getProjectedChildren(project(() => [{action: 'reload', iconCls: 'fa fa-x'}])())[0];
+
+        expect(hostReload.headerActions.map(action => action.action)).toEqual(['reload'])
+    });
+
     test('split children release the flexbox min-content floor: committed sizes stay the sole geometry authority', () => {
         let result = DockLayoutAdapter.project(createModel(), {
                 resolveComponentRef: componentRef => ({


### PR DESCRIPTION
Resolves #17948

> 🌿 A pane's reload used to be whatever the workspace guessed it meant; now the guess itself is unsayable — the engine can only ask, and only a pane that answered.

Delegation-only, per the intake-settled contract: `enableDockReloadAction` projects one focus-gated `reload` action leading the engine set, and activation delegates into the active pane's own `dockReload(): void | Promise<*>` — the engine never recreates, never commits, never defines what reload means. Every completion settles exactly once through the new `dockReloadSettled` workspace event; availability is the contract (a pane without the method hides the action), and the per-item single-flight window rides the one retained action instance. Universal recreate is successor #17966.

## AC Evidence

| AC | Evidence |
|---|---|
| AC-1 default off / frozen slot / reserved name | `DockLayoutAdapter.spec.mjs` "reload leads the engine set and reserves its name through the guard table" (off = byte-identical, order `reload → pin → maximize → close`, guard throw); `DockReload.spec.mjs` arm 1 (focus gating + geometry) |
| AC-2 exactly-once delegation, identity kept, settled clean | arm 2: invocation counter 1, DOM element identity + dataset witness kept, `dockReloadSettled {errors: [], itemId}` — sync; arm 4 covers async resolution |
| AC-3 sync-throw + async-reject contained | arm 3 (throwing pane kept, failure text settles) + arm 4 rejection phase (`async refusal` settles, pane intact) |
| AC-4 single-flight, disabled during window | arm 4: deferred contract → disabled, forced second click cannot double-invoke, re-enabled at settlement; arm 6 adds the per-item axis — switching panes re-derives `disabled` from the ACTIVE item, so a sibling contract pane stays operable while another item's flight is open |
| AC-5 hidden without the contract, pure probe | arm 5 on the side node: contract pane shows the action, the contract-free iframe pane removes it (`removeDom`), return restores it; the probe is `typeof` on the live card ?? config `module.prototype` — no resolver call anywhere |
| AC-6 teardown mid-flight | arm 7: destroy during a deferred invocation, then the producer is RELEASED post-destroy through a fixture probe that outlives the workspace — zero page errors, zero mutations (against the pre-repair shape this arm crashes on the erased in-flight Set) |
| AC-7 document byte-identical | every arm closes on a `docJson` before/after comparison |
| AC-8 gesture spec | `DockReloadActionNL.spec.mjs` (e2e, real example app): clicks the projected button, the Strategy pane's user-visible counter advances 1× → 2×, committed document byte-identical, and the same header hides the action for a contract-free pane with close as the live-header control arm |

## Deltas from ticket

The ticket is delegation-only as amended (intake trail on #17948); the branch matches it 1:1. Three things shipped here that the ticket's ACs imply but do not spell out, all engine-side:

- **`core.Base#trap()` carries the teardown race** — destroy rejects the trapped delegation, so the handler settles terminally even when a pane author's promise never does; a late-settling producer lands in the trap's settled no-op handlers, never as an unhandled rejection.
- **Projection-constant action rows + mount-time sync.** The first cut computed reload's `hidden` inside the projected row; a projection-varying actions array turns out to corrupt the retained tab bar on the first activation (`syncActions` rebuild mid-reconcile — DOM forensics caught it eating a header button and doubling the engine set). The row is now constant, and a new `Workspace#afterSetMounted` runs `syncDockHeaderActions()` once at mount — the only surface every boot path shares, since a statically-constructed first projection (the dock example, real consumers) never enters `refreshDockWorkspace` at all.
- **Activation-path ordering:** `onDockActiveIndexChange` defers reload's sync to the post-reconcile pass whenever a commit follows — the pre-commit write raced the reconciler's own updates on the same subtree (coin-flip before, 8/8 forensic rounds healthy after).

## Test Evidence

Evidence: L3 (real-browser component battery + Neural Link e2e gesture run locally at the PR head; full unit suite) → L3 required (gesture/runtime ACs per the epic guardrail). No residuals.

- `DockReload.spec.mjs` component battery: 9 arms green at `e9a76726a7` (the 7-arm battery ran ×3 at `4ac9bfb141`; the two review-round arms — flag-off host inertness, no-active settlement — are green and the host-inertness falsifier was fired against the unguarded code: red without the guard, green with).
- `DockMaximize.spec.mjs` collateral (shared fixture gained a second contract pane + the standing probe class): 11/11.
- `DockLayoutAdapter` unit: 50/50; full unit suite 2602/2602; full component suite 145 passing (the one red is a pre-existing `tab/OverflowAction.spec.mjs` flake measured at the same ~1/8 rate on origin/dev — reported to its author).
- E2e `DockReloadActionNL` ×2 green, sleeps replaced by event-driven settle surfaces.

## Post-Merge Validation

The dock example (`examples/dashboard/dock/`) is the living witness: the Strategy pane implements the contract with a visible "reloaded N×" counter; every other pane demonstrates hidden-without-contract. Consumers opt in per workspace with `enableDockReloadAction: true` plus a `dockReload()` on panes that own a reload meaning.

## Commits

- `1f5f5a67df` feat(dashboard): dock reload delegates into the pane contract (#17948)
- `4ac9bfb141` test(dashboard): delegation settles, survives teardown and item switches (#17948)
- `e9a76726a7` fix(dashboard): default-off reload is inert and every activation settles (#17948)

Authored by Vega (Fable 5, Claude Code). Session 914dffcd-0057-46a5-a0c6-9ca807fd5c91.
