### PR TITLE
feat(tab): design dock header action chrome (#17963)

### DIFF
--- a/apps/workstation/view/Workspace.mjs
+++ b/apps/workstation/view/Workspace.mjs
@@ -139,6 +139,21 @@ class Workspace extends DockWorkspace {
          */
         dockHostReference: 'dock-host',
         /**
+         * Workstation is the public living witness for the model-authoritative close action.
+         * @member {Boolean} enableDockCloseAction=true
+         */
+        enableDockCloseAction: true,
+        /**
+         * Workstation is the public living witness for edge-pane collapse and reveal.
+         * @member {Boolean} enableDockPinAction=true
+         */
+        enableDockPinAction: true,
+        /**
+         * Workstation is the public living witness for transient in-place pane maximize.
+         * @member {Boolean} enableDockMaximizeAction=true
+         */
+        enableDockMaximizeAction: true,
+        /**
          * @member {String} flipMarkerPrefix='workstation-pane-'
          */
         flipMarkerPrefix: 'workstation-pane-',

--- a/resources/scss/src/tab/header/Toolbar.scss
+++ b/resources/scss/src/tab/header/Toolbar.scss
@@ -3,6 +3,54 @@
     flex            : 0 0 auto;
     padding         : 0;
 
+    // Header actions are pane chrome, not standalone controls. Keep the semantic `.neo-button`
+    // instance (focus, accessibility, intent routing) while replacing only its paint and density
+    // inside a tab header. The direct-child scope is the negative contract: ordinary toolbars keep
+    // their established button treatment byte-for-byte.
+    &.neo-toolbar > .neo-toolbar-action.neo-button {
+        align-self      : center;
+        background-color: transparent;
+        background-image: none;
+        border          : 0;
+        border-radius   : var(--tab-header-action-border-radius);
+        height          : var(--tab-header-action-size);
+        margin          : 0;
+        min-width       : var(--tab-header-action-size);
+        padding         : 0;
+        width           : var(--tab-header-action-size);
+
+        .neo-button-glyph {
+            color    : var(--tab-header-action-glyph-color);
+            font-size: 12px;
+            margin   : 0;
+        }
+
+        .neo-button-ripple-wrapper {
+            border-radius: inherit;
+        }
+
+        &:hover {
+            background-color: var(--tab-header-action-background-color-hover);
+
+            .neo-button-glyph {
+                color: var(--tab-header-action-glyph-color-hover);
+            }
+        }
+
+        &:active {
+            background-color: var(--tab-header-action-background-color-active);
+
+            .neo-button-glyph {
+                color: var(--tab-header-action-glyph-color-active);
+            }
+        }
+
+        &:focus-visible {
+            outline       : 2px solid var(--tab-header-action-glyph-color-hover);
+            outline-offset: -2px;
+        }
+    }
+
     &.neo-dock-bottom {
         .neo-tab-header-button.neo-button {
             align-self      : start;

--- a/resources/scss/theme-dark/tab/Container.scss
+++ b/resources/scss/theme-dark/tab/Container.scss
@@ -1,5 +1,15 @@
 :root .neo-theme-dark { // .neo-tab-container
-    --tab-container-content-border: 1px solid #3c3f41;
+    --tab-container-content-border                 : 1px solid #3c3f41;
+    --tab-header-action-background-color-active   : rgba(255, 255, 255, .14);
+    --tab-header-action-background-color-hover    : rgba(255, 255, 255, .08);
+    --tab-header-action-border-radius              : 2px;
+    --tab-header-action-glyph-color                : #bbb;
+    --tab-header-action-glyph-color-active         : #fff;
+    --tab-header-action-glyph-color-hover          : #fff;
+    --tab-header-action-size                       : 20px;
+    // Classic chrome remains intentionally flat; this explicit value must not decay into reliance
+    // on the structural fallback.
+    --tab-header-inline-background-image           : none;
 
     // Inline inherits the classic theme's established 25px / square geometry and tightens only
     // horizontal padding. Keeping inherited defaults out of this block prevents copy-drift while

--- a/resources/scss/theme-light/tab/Container.scss
+++ b/resources/scss/theme-light/tab/Container.scss
@@ -1,5 +1,15 @@
 :root .neo-theme-light { // .neo-tab-container
-    --tab-container-content-border: 1px solid #ddd;
+    --tab-container-content-border                 : 1px solid #ddd;
+    --tab-header-action-background-color-active   : rgba(28, 96, 160, .16);
+    --tab-header-action-background-color-hover    : rgba(28, 96, 160, .08);
+    --tab-header-action-border-radius              : 2px;
+    --tab-header-action-glyph-color                : #5f6368;
+    --tab-header-action-glyph-color-active         : #1c60a0;
+    --tab-header-action-glyph-color-hover          : #1c60a0;
+    --tab-header-action-size                       : 20px;
+    // Classic chrome remains intentionally flat; this explicit value must not decay into reliance
+    // on the structural fallback.
+    --tab-header-inline-background-image           : none;
 
     // Inline inherits the classic theme's established 25px / square geometry and tightens only
     // horizontal padding. Keeping inherited defaults out of this block prevents copy-drift while

--- a/resources/scss/theme-neo-dark/tab/Container.scss
+++ b/resources/scss/theme-neo-dark/tab/Container.scss
@@ -1,5 +1,17 @@
 :root .neo-theme-neo-dark { // .neo-tab-container
-    --tab-container-content-border: 1px solid var(--sem-color-border-default);
+    --tab-container-content-border                 : 1px solid var(--sem-color-border-default);
+    --tab-header-action-background-color-active   : var(--sem-color-surface-neutral-active);
+    --tab-header-action-background-color-hover    : var(--sem-color-surface-neutral-hover);
+    --tab-header-action-border-radius              : 4px;
+    --tab-header-action-glyph-color                : var(--sem-color-icon-neutral-subdued);
+    --tab-header-action-glyph-color-active         : var(--sem-color-icon-neutral-contrast);
+    --tab-header-action-glyph-color-hover          : var(--sem-color-icon-neutral-contrast);
+    --tab-header-action-size                       : 24px;
+    --tab-header-inline-background-image           : linear-gradient(
+        180deg,
+        var(--sem-color-surface-neutral-highlighted),
+        var(--sem-color-surface-neutral-default)
+    );
 
     // Embedded pane chrome uses the semantic 32px density tier and releases the free-standing
     // radius. The theme's ui:null contract remains the established 48px / 8px treatment.

--- a/resources/scss/theme-neo-light/tab/Container.scss
+++ b/resources/scss/theme-neo-light/tab/Container.scss
@@ -1,5 +1,17 @@
 :root .neo-theme-neo-light { // .neo-tab-container
-    --tab-container-content-border: 1px solid #ddd;
+    --tab-container-content-border                 : 1px solid #ddd;
+    --tab-header-action-background-color-active   : var(--sem-color-surface-neutral-active);
+    --tab-header-action-background-color-hover    : var(--sem-color-surface-neutral-hover);
+    --tab-header-action-border-radius              : 4px;
+    --tab-header-action-glyph-color                : var(--sem-color-icon-neutral-subdued);
+    --tab-header-action-glyph-color-active         : var(--sem-color-icon-neutral-contrast);
+    --tab-header-action-glyph-color-hover          : var(--sem-color-icon-neutral-contrast);
+    --tab-header-action-size                       : 24px;
+    --tab-header-inline-background-image           : linear-gradient(
+        180deg,
+        var(--sem-color-surface-neutral-highlighted),
+        var(--sem-color-surface-neutral-default)
+    );
 
     // Embedded pane chrome uses the semantic 32px density tier and releases the free-standing
     // radius. The theme's ui:null contract remains the established 48px / 8px treatment.

--- a/test/playwright/component/tab/ContainerUi.spec.mjs
+++ b/test/playwright/component/tab/ContainerUi.spec.mjs
@@ -9,24 +9,32 @@ const THEMES = [
 
 const EXPECTED = {
     'neo-theme-light': {
+        actionSize: '20px',
+        gradient  : false,
         inline    : {height: '25px', padding: '7px 10px 6px', radius: '0px'},
         null      : {height: '25px', padding: '7px 12px 6px', radius: '0px'},
         standalone: {height: '40px', padding: '7px 16px 6px', radius: '8px'},
         textColor : 'rgb(43, 43, 43)'
     },
     'neo-theme-dark': {
+        actionSize: '20px',
+        gradient  : false,
         inline    : {height: '25px', padding: '7px 10px 6px', radius: '0px'},
         null      : {height: '25px', padding: '7px 12px 6px', radius: '0px'},
         standalone: {height: '40px', padding: '7px 16px 6px', radius: '8px'},
         textColor : 'rgb(187, 187, 187)'
     },
     'neo-theme-neo-light': {
+        actionSize: '24px',
+        gradient  : true,
         inline    : {height: '32px', padding: '4px 12px 3px', radius: '0px'},
         null      : {height: '48px', padding: '7px 16px 6px', radius: '8px'},
         standalone: {height: '48px', padding: '7px 16px 6px', radius: '8px'},
         textColor : 'rgb(69, 75, 66)'
     },
     'neo-theme-neo-dark': {
+        actionSize: '24px',
+        gradient  : true,
         inline    : {height: '32px', padding: '4px 12px 3px', radius: '0px'},
         null      : {height: '48px', padding: '7px 16px 6px', radius: '8px'},
         standalone: {height: '48px', padding: '7px 16px 6px', radius: '8px'},
@@ -41,9 +49,11 @@ async function loadThemeStylesheets(page) {
     const hrefs = THEMES.flatMap(theme => {
         const directory = theme.replace('neo-theme-', 'theme-'),
               files     = [
+                  `/dist/development/css/${directory}/button/Base.css`,
                   `/dist/development/css/${directory}/tab/Container.css`,
                   `/dist/development/css/${directory}/tab/Strip.css`,
-                  `/dist/development/css/${directory}/tab/header/Button.css`
+                  `/dist/development/css/${directory}/tab/header/Button.css`,
+                  `/dist/development/css/${directory}/toolbar/Base.css`
               ];
 
         if (theme.includes('neo-light') || theme.includes('neo-dark')) {
@@ -120,6 +130,17 @@ async function createVariants(page) {
 
             variant.setUi && (config.ui = variant.ui);
 
+            if (variant.ui === 'inline') {
+                config.headerActions = [{
+                    action : 'pin',
+                    iconCls: 'fa fa-thumbtack'
+                }, {
+                    action     : 'close',
+                    iconCls    : 'fa fa-times',
+                    showOnFocus: false
+                }]
+            }
+
             const result = await Neo.worker.App.createNeoInstance(config);
 
             if (!result.success) {
@@ -128,6 +149,17 @@ async function createVariants(page) {
 
             ids.push(result.id)
         }
+
+        // CSS-scope negative control. This is deliberately page-realm DOM: the property under test
+        // is whether the tab-header ancestor selector leaks onto an otherwise ordinary action root,
+        // not another Toolbar construction path.
+        const ordinaryToolbar = document.createElement('div');
+
+        ordinaryToolbar.id        = 'tab-ui-ordinary-toolbar';
+        ordinaryToolbar.className = 'neo-toolbar';
+        ordinaryToolbar.innerHTML = '<button aria-label="ordinary action" ' +
+            'class="neo-button neo-toolbar-action"><span class="fa fa-star neo-button-glyph"></span></button>';
+        document.body.appendChild(ordinaryToolbar);
 
         return ids
     });
@@ -163,6 +195,25 @@ const readVariant = (page, id) => page.evaluate(componentId => {
     }
 }, id);
 
+/** @summary Reads concrete action paint and geometry rather than treating selector presence as evidence. */
+const readActionChrome = action => action.evaluate(node => {
+    const
+        glyph = node.querySelector('.neo-button-glyph'),
+        style = getComputedStyle(node);
+
+    return {
+        backgroundColor: style.backgroundColor,
+        backgroundImage: style.backgroundImage,
+        border         : style.border,
+        glyphColor     : getComputedStyle(glyph).color,
+        height         : style.height,
+        padding        : style.padding,
+        radius         : style.borderRadius,
+        visibility     : style.visibility,
+        width          : style.width
+    }
+});
+
 /** A generated-id-independent DOM signature for the omitted-vs-explicit-null regression control. */
 const readDomSignature = (page, id) => page.evaluate(componentId => {
     const visit = element => ({
@@ -187,6 +238,8 @@ test.describe('Neo.tab.Container — ui variants', () => {
             for (const id of ids) {
                 await Neo.worker.App.destroyNeoInstance(id)
             }
+
+            document.getElementById('tab-ui-ordinary-toolbar')?.remove()
         }, componentIds);
 
         componentIds = []
@@ -196,6 +249,27 @@ test.describe('Neo.tab.Container — ui variants', () => {
         test(`${theme}: null stays current while inline and standalone are intentional`, async ({page}, testInfo) => {
             await applyTheme(page, theme);
             expect(await page.evaluate(name => document.body.classList.contains(name), theme)).toBe(true);
+
+            const
+                inlineToolbar = page.locator('#tab-ui-inline > .neo-tab-header-toolbar'),
+                // Role locators deliberately exclude the aria-hidden gated action. The concrete
+                // action root is the geometry carrier this assertion needs to observe while quiet.
+                gatedAction   = inlineToolbar.locator('.neo-toolbar-action[aria-label="pin"]'),
+                closeAction   = inlineToolbar.locator('.neo-toolbar-action[aria-label="close"]'),
+                ordinary     = page.locator('#tab-ui-ordinary-toolbar .neo-toolbar-action');
+
+            await expect(gatedAction).toHaveClass(/neo-toolbar-action-context-inactive/);
+
+            const gatedBox = await gatedAction.boundingBox();
+
+            await inlineToolbar.locator('.neo-tab-header-button').first().focus();
+            await expect(gatedAction).not.toHaveClass(/neo-toolbar-action-context-inactive/);
+            await expect(gatedAction).toBeVisible();
+            await expect(closeAction).toBeVisible();
+
+            const exposedBox = await gatedAction.boundingBox();
+
+            expect(exposedBox, 'focus gating preserves the action box').toEqual(gatedBox);
 
             const measured = {
                 default   : await readVariant(page, 'tab-ui-default'),
@@ -241,18 +315,40 @@ test.describe('Neo.tab.Container — ui variants', () => {
             expect(measured.inline.height).not.toBe(measured.standalone.height);
             expect(measured.inline.radius).not.toBe(measured.standalone.radius);
 
+            const
+                restChrome     = await readActionChrome(closeAction),
+                ordinaryChrome = await readActionChrome(ordinary);
+
+            expect(restChrome).toMatchObject({
+                backgroundColor: 'rgba(0, 0, 0, 0)',
+                backgroundImage: 'none',
+                height         : EXPECTED[theme].actionSize,
+                padding        : '0px',
+                width          : EXPECTED[theme].actionSize
+            });
+            expect(ordinaryChrome.padding, 'ordinary toolbar actions keep stock button chrome')
+                .not.toBe('0px');
+
+            EXPECTED[theme].gradient
+                ? expect(measured.inline.backgroundImage).toContain('linear-gradient')
+                : expect(measured.inline.backgroundImage).toBe('none');
+
+            await closeAction.hover();
+            expect((await readActionChrome(closeAction)).backgroundColor)
+                .not.toBe('rgba(0, 0, 0, 0)');
+
             await testInfo.attach(`${theme}-tab-ui-comparison.json`, {
-                body       : Buffer.from(JSON.stringify(measured, null, 2)),
+                body       : Buffer.from(JSON.stringify({measured, ordinaryChrome, restChrome}, null, 2)),
                 contentType: 'application/json'
             });
             await testInfo.attach(`${theme}-tab-ui-comparison.png`, {
-                body       : await page.screenshot({clip: {height: 180, width: 1180, x: 0, y: 0}}),
+                body       : await page.screenshot({clip: {height: 260, width: 1180, x: 0, y: 0}}),
                 contentType: 'image/png'
             })
         })
     }
 
-    test('the inline gradient hook is opt-in and cannot leak to ui:null', async ({page}) => {
+    test('the inline gradient hook is theme-valued, overridable and cannot leak to ui:null', async ({page}) => {
         await applyTheme(page, 'neo-theme-neo-light');
 
         const before = {
@@ -263,7 +359,7 @@ test.describe('Neo.tab.Container — ui variants', () => {
         };
 
         expect(before.default.backgroundImage).toBe('none');
-        expect(before.inline.backgroundImage).toBe('none');
+        expect(before.inline.backgroundImage).toContain('linear-gradient');
         expect(before.nested).toMatchObject({
             backgroundImage: 'none',
             height         : '48px',

--- a/test/playwright/e2e/workstation/WorkstationNL.spec.mjs
+++ b/test/playwright/e2e/workstation/WorkstationNL.spec.mjs
@@ -1185,25 +1185,29 @@ test.describe('Workstation — dense living-data composition', () => {
         expect((await railTabs.allTextContents()).map(value => value.trim()).sort())
             .toEqual(['Dependency Graph Explorer', 'Selection Inspector'].sort());
 
-        // One REAL generic overflow control, outside the draggable header collection.
-        const control = page.locator('.neo-tab-overflow-control');
+        // One REAL generic overflow contribution, projected as the first header action. It stays
+        // outside the draggable TAB collection while its menu remains a body-mounted overlay.
+        const
+            control      = page.locator('.neo-tab-overflow-control'),
+            heavyToolbar = page.locator('.neo-tab-header-toolbar')
+                .filter({hasText: 'Priority Alert Observatory'});
 
         await expect(control).toHaveCount(1);
-        expect(await page.evaluate(() =>
-            document.querySelector('.neo-tab-overflow-control')?.parentElement === document.body
-        ), 'the overflow control is a floating direct body child').toBe(true);
-
-        const heavyToolbar = page.locator('.neo-tab-header-toolbar').filter({hasText: 'Priority Alert Observatory'});
-
         await expect(heavyToolbar, 'one header owns the intentionally dense twelve-tab group').toHaveCount(1);
+        expect(await control.evaluate((node, toolbar) => node.parentElement === toolbar,
+            await heavyToolbar.elementHandle()), 'the overflow contribution belongs to its source toolbar').toBe(true);
 
-        const controlBox = await control.boundingBox(),
-              toolbarBox = await heavyToolbar.boundingBox();
+        const
+            actionRoots = heavyToolbar.locator(':scope > .neo-toolbar-action'),
+            controlBox  = await control.boundingBox(),
+            lastTabBox  = await heavyToolbar.locator(':scope > .neo-tab-header-button:visible').last().boundingBox();
 
-        expect(Math.abs((controlBox.x + controlBox.width) - (toolbarBox.x + toolbarBox.width)),
-            'overflow control right edge tracks the exact heavy toolbar').toBeLessThanOrEqual(2);
-        expect(Math.abs(controlBox.y - toolbarBox.y),
-            'overflow control top tracks the exact heavy toolbar').toBeLessThanOrEqual(2);
+        expect(await actionRoots.first().getAttribute('id'), 'overflow owns the first action slot')
+            .toBe(await control.getAttribute('id'));
+        expect(await actionRoots.last().getAttribute('aria-label'), 'close remains the final action')
+            .toBe('close');
+        expect(lastTabBox.x + lastTabBox.width,
+            'the visible tab partition ends before the measured contribution').toBeLessThanOrEqual(controlBox.x + 1);
 
         await control.click();
 
@@ -2046,7 +2050,7 @@ test.describe('Workstation — dense living-data composition', () => {
         expect(pageErrors, 'no Playwright pageerror across the journey').toEqual([])
     });
 
-    test('the body-mounted overflow menu carries live Workstation theme and skin', async ({page, neuralLink}) => {
+    test('the header overflow action opens a body-mounted menu with live Workstation skin', async ({page, neuralLink}) => {
         await page.goto('/apps/workstation/index.html');
         await page.waitForSelector('.workstation-workspace', {timeout: 30000});
         await page.waitForSelector('.neo-tab-overflow-control', {timeout: 30000});
@@ -2067,9 +2071,8 @@ test.describe('Workstation — dense living-data composition', () => {
         expect(workspaceId).toBeTruthy();
         await expect(control).toHaveCount(1);
         await expect(heavyToolbar).toHaveCount(1);
-        expect(await page.evaluate(() =>
-            document.querySelector('.neo-tab-overflow-control')?.parentElement === document.body
-        ), 'the themed control remains a floating direct-body child').toBe(true);
+        expect(await control.evaluate((node, toolbar) => node.parentElement === toolbar,
+            await heavyToolbar.elementHandle()), 'the themed contribution stays in its source toolbar').toBe(true);
 
         await control.click();
 
@@ -2085,6 +2088,7 @@ test.describe('Workstation — dense living-data composition', () => {
 
         const
             controlId   = await control.getAttribute('id'),
+            toolbarId   = await heavyToolbar.getAttribute('id'),
             darkRuntime = await app.getComponent(controlId, [
                 'menuList.id',
                 'menuList.theme',
@@ -2093,12 +2097,14 @@ test.describe('Workstation — dense living-data composition', () => {
             ]),
             darkSkin    = await readOverflowMenuSkin(page);
 
-        expect(darkRuntime.parentId).toBe('document.body');
+        expect(darkRuntime.parentId).toBe(toolbarId);
         expect(darkRuntime.theme).toBe('neo-theme-neo-dark');
         expect(darkRuntime['menuList.id']).toBeTruthy();
         expect(darkRuntime['menuList.theme']).toBe('neo-theme-neo-dark');
         expect(darkSkin.parentIsBody).toBe(true);
-        expect(darkSkin.controlThemeClasses).toEqual(['neo-theme-neo-dark']);
+        // The contribution now lives inside the themed header and inherits paint there; unlike the
+        // body-mounted menu, it needs no duplicate theme class on its own DOM root.
+        expect(darkSkin.controlThemeClasses).toEqual([]);
         expect(darkSkin.menuThemeClasses).toEqual(['neo-theme-neo-dark']);
         expect(darkSkin.tokens).toEqual({
             background: '#1a212c',
@@ -2140,8 +2146,6 @@ test.describe('Workstation — dense living-data composition', () => {
 
         await app.callMethod(workspaceId, 'setWorkspaceTheme', ['neo-theme-neo-light']);
         await expect(root).toHaveClass(/neo-theme-neo-light/);
-        await expect(control).toHaveClass(/neo-theme-neo-light/);
-        await expect(control).not.toHaveClass(/neo-theme-neo-dark/);
         await expect(menu).toHaveClass(/neo-theme-neo-light/);
         await expect(menu).not.toHaveClass(/neo-theme-neo-dark/);
 
@@ -2151,7 +2155,7 @@ test.describe('Workstation — dense living-data composition', () => {
 
         expect(lightRuntime.theme).toBe('neo-theme-neo-light');
         expect(lightRuntime['menuList.theme']).toBe('neo-theme-neo-light');
-        expect(lightSkin.controlThemeClasses).toEqual(['neo-theme-neo-light']);
+        expect(lightSkin.controlThemeClasses).toEqual([]);
         expect(lightSkin.menuThemeClasses).toEqual(['neo-theme-neo-light']);
         expect(lightSkin.tokens).toEqual({
             background: '#f7f9fc',
@@ -2168,8 +2172,6 @@ test.describe('Workstation — dense living-data composition', () => {
 
         await app.callMethod(workspaceId, 'setWorkspaceTheme', ['neo-theme-neo-dark']);
         await expect(root).toHaveClass(/neo-theme-neo-dark/);
-        await expect(control).toHaveClass(/neo-theme-neo-dark/);
-        await expect(control).not.toHaveClass(/neo-theme-neo-light/);
         await expect(menu).toHaveClass(/neo-theme-neo-dark/);
         await expect(menu).not.toHaveClass(/neo-theme-neo-light/);
 


### PR DESCRIPTION
Resolves #17963

Dock header actions now read as pane chrome instead of standalone buttons: compact transparent glyph controls use four-theme hover/active values, inline headers gain subtle neo-theme gradients with explicit classic-theme `none`, and Workstation opts into close, pin, and maximize as the living public witness. The existing Workstation overflow assertions now describe the merged #17960 contract: overflow is the first header action, close is last, and only the menu is body-mounted.

Evidence: L3 (local Chrome four-theme screenshots + Workstation Neural-Link action/overflow/theme path) → L3 required (AC1–AC5 browser-rendered visual and geometry behavior). Residual: AC4's retained full-tour `blankFrames` oracle reproduces open #17871 after every new action/order/overflow assertion passes; Residual-Owner: #17871.

## AC Evidence

| AC | Proof |
|---|---|
| AC-1 — compact glyph-first chrome in four themes | `ContainerUi.spec.mjs` renders and screenshots all four themes; 6/6 focused component arms green; screenshots visually inspected. |
| AC-2 — ordinary toolbars unchanged | The same browser fixture carries an ordinary `.neo-toolbar .neo-toolbar-action` negative control and proves its stock non-zero padding survives; the production selector requires the tab-header ancestor. |
| AC-3 — neo gradients, explicit classic `none` | All four `tab/Container.scss` value sheets declare the hook; computed-style assertions prove gradients only in the two neo themes, consumer override, and no leak into `ui:null`. |
| AC-4 — Workstation enables close, pin, maximize without a second overflow owner | Workstation sets all three inherited configs. The Neural-Link witness proves overflow first / close last / one owner and the menu/theme route; its independent retained pooled-grid oracle remains #17871. |
| AC-5 — gated state stays quiet without geometry shift | Each theme measures the hidden pin action's box, focuses the pane, and requires the exposed box to be identical before inspecting paint. |

## Deltas from ticket

- The final action boxes are 20px in classic themes and 24px in neo themes. A 32px neo draft produced a second Workstation overflow owner at the narrow desktop floor; the 24px arm restores the single-owner invariant while remaining visibly legible.
- The existing Workstation witness still asserted the pre-#17960 body-mounted control. It now binds the shipped contribution contract instead: control inside its source toolbar, menu on `document.body`.
- No action semantics, ordering implementation, dock model, or private consumer code changed.

## Test Evidence

Outside-CI receipts:

- `npm run build-themes -- -n -e all` — exit 0.
- `npx playwright test -c test/playwright/playwright.config.component.mjs test/playwright/component/tab/ContainerUi.spec.mjs` — 6/6 green in host Chrome after out-of-sandbox launch approval.
- HTML-reporter screenshots for all four themes were inspected; the controls remain monochrome at rest with small hover affordances, neo bands are subtle, and classic bands remain flat.
- Specificity mutant: the first neo-light arm rendered 48×32 because its theme-level button minimum tied the selector; strengthening the real dual toolbar class made all four square.
- Density mutant: 32px neo actions produced two Workstation overflow owners; 24px restores one.
- `WorkstationNL.spec.mjs` overflow/theme test — green. The full tour passes every new action/order/overflow assertion, then reproduces #17871's exact `rowsTop ≈ -2.5Mpx / visibleRows: 0` retained oracle.

## Post-Merge Validation

None — the visual, geometry, theme-switch, and Workstation integration effects are pre-merge observable.

## Evolution

The browser witnesses changed two design details before handoff: a specificity tie unique to neo-light required the toolbar's real dual base-class selector, and full-size 32px controls consumed enough header width to create a second overflow owner. The final 20px/24px density is therefore measured integration behavior, not an aesthetic guess.

Authored by Emmy (GPT-5.6 Sol Ultra, Codex). Session 4426fb43-4968-4084-832e-1830de2e8747.

