### PR TITLE
feat(dashboard): add dock pane lock action (#17949)

### DIFF
--- a/learn/agentos/decisions/0029-docking-design.md
+++ b/learn/agentos/decisions/0029-docking-design.md
@@ -84,7 +84,7 @@ durable half is additive data inside the layout envelope; it does not mint a sta
 
 | State class | Examples | Owner | Persistence |
 |---|---|---|---|
-| **Worker-owned shared truth** | committed `neo.dock.zone.v1` documents incl. tab `activeItemId`, split `sizes`, and edge `extent`/`resizable`; the workspace-set registry; `neo.dock.layout.v1` perspectives; `neo.dock.layoutCollection.v1`; durable placement hints; item catalogs incl. `pinned` / `autoHidden` | workspace container(s) in the App Worker | Serializable per contract rules |
+| **Worker-owned shared truth** | committed `neo.dock.zone.v1` documents incl. tab `activeItemId`, split `sizes`, and edge `extent`/`resizable`; the workspace-set registry; `neo.dock.layout.v1` perspectives; `neo.dock.layoutCollection.v1`; durable placement hints; item catalogs incl. `pinned` / `autoHidden` / `locked` and their policy hints | workspace container(s) in the App Worker | Serializable per contract rules |
 | **Per-window render projection** | projected config trees; edge rails; splitter affordances; tab headers; placeholder panes | `projection.LayoutAdapter.project()` output per window | Never persisted; derived |
 | **Per-window runtime interaction state** | `dockPreview` payloads; reveal/open state of auto-hidden panes (§2.7); hover state; splitter pixel math mid-drag | the window's drag/interaction surfaces | Never persisted; never crosses the seam except as operation descriptors |
 | **Main-thread-only state** | DOM nodes; `DOMRect`s; screen coordinates; native window geometry; `getWindowAt` lookups | main-thread addons (`Neo.manager.Window`, `WindowPosition`) | Never persisted; consumed by arbitration (§2.3), results delivered as semantic events |
@@ -112,6 +112,28 @@ Edge pointer frames resize only main-thread presentation under the target band's
 converts the final pixel size into one normalized `resizeEdgeZone` commit. Escape, stale generation, rejection, and
 destruction restore the prior projection and commit zero operations. Split-node `sizes` remain authoritative only for
 split nodes; an edge never borrows an ancestor split ratio.
+
+#### Committed item lock state (amendment, 2026-08-31 — #17949)
+
+An item may carry committed `locked: true|false` plus the policy hint `lockable: true|false`;
+both are plain JSON booleans in the item catalog and therefore ride saved layouts and perspectives
+without a second persistence surface. Missing `locked` means unlocked, and missing `lockable`
+means the item may be locked. `setItemLocked` is the sole state transition and fails closed for
+unknown items, non-boolean state, and `lockable: false`.
+
+Lock protects the item as a **source** while preserving its role as a target. `closeItem`,
+`detachItem`, and source `moveItem` reject a locked item at the model boundary. The existing
+`addTab` dispatch downgrades an in-tree item to `moveItem`, so in-strip reorder and cross-zone
+movement share that same guard; an unlocked item may still move into a tabs node that contains a
+locked peer.
+
+The interaction layer is derived per projection, never persisted: the Workspace makes the live
+pane root inert, stamps the stable locked visual token, hides close, and removes the tab button's
+`.neo-draggable` source token. A Workspace-owned `WeakMap` records whether the pane already owned
+`vdom.inert` and its prior value; unlock restores that exact ownership/value rather than blindly
+making independently inert content interactive. These presentation guards improve affordance
+honesty, while the reducer remains the independent boundary for stale chrome and programmatic
+descriptors.
 
 ### §2.2 Named Perspectives
 

--- a/resources/scss/src/dashboard/Container.scss
+++ b/resources/scss/src/dashboard/Container.scss
@@ -654,3 +654,11 @@ body > .neo-dock-dragproxy.neo-tab-header-toolbar {
     0%   { opacity: 0.55; }
     100% { opacity: 1; }
 }
+
+// Committed pane lock is model truth; this class is its projection-only visual carrier. Outline is
+// inset from layout via a negative offset, so locking never changes geometry in any theme.
+.neo-dashboard .neo-dock-pane-locked {
+    cursor        : not-allowed;
+    outline       : 1px solid color-mix(in srgb, currentColor 34%, transparent);
+    outline-offset: -1px;
+}

--- a/src/dashboard/dock/Workspace.mjs
+++ b/src/dashboard/dock/Workspace.mjs
@@ -1,5 +1,6 @@
 import Component                   from '../../component/Base.mjs';
 import Container                   from '../../container/Base.mjs';
+import NeoArray                    from '../../util/Array.mjs';
 import LayoutAdapter               from './projection/LayoutAdapter.mjs';
 import MotionSignal                from './projection/MotionSignal.mjs';
 import PreviewProducer             from './interaction/PreviewProducer.mjs';
@@ -123,6 +124,25 @@ class Workspace extends Container {
          * @member {Boolean} enableDockCloseAction=false
          */
         enableDockCloseAction: false,
+        /**
+         * Projects one engine-owned lock toggle into each Dock tab header. The committed
+         * `locked` item field is the hard boundary: close, detach and source movement fail
+         * closed in the reducer. Workspace presentation mirrors that truth by making the pane
+         * inert, hiding close, and suppressing the tab drag source while preserving exact prior
+         * inert and drag-token ownership for unlock. Disabled by default.
+         * @member {Boolean} enableDockLockAction=false
+         */
+        enableDockLockAction: false,
+        /**
+         * Icon of the projected lock action while the active item is unlocked.
+         * @member {String} dockLockIconCls='fa fa-lock'
+         */
+        dockLockIconCls: 'fa fa-lock',
+        /**
+         * Icon of the projected lock action while the active item is locked.
+         * @member {String} dockUnlockIconCls='fa fa-lock-open'
+         */
+        dockUnlockIconCls: 'fa fa-lock-open',
         /**
          * Projects one persistent pin action into each Dock tab header — the entry half of the
          * collapse-to-rail round-trip (docking design record §2.7). Pressing it on an edge-owned pane
@@ -383,6 +403,22 @@ class Workspace extends Container {
      * @protected
      */
     dockMaximizeResizeWired = false
+
+    /**
+     * Exact pre-lock root-inert snapshots keyed by the live pane instance:
+     * `{owned:Boolean, value:*}`. A WeakMap cannot prolong a retired pane's lifetime.
+     * @member {WeakMap<Neo.component.Base,Object>} dockLockPaneState=new WeakMap()
+     * @protected
+     */
+    dockLockPaneState = new WeakMap()
+
+    /**
+     * Whether each live tab button owned the SortZone's `neo-draggable` token before lock
+     * suppressed it. Unlock restores that exact ownership instead of globally arming drag.
+     * @member {WeakMap<Neo.component.Base,Boolean>} dockLockDragState=new WeakMap()
+     * @protected
+     */
+    dockLockDragState = new WeakMap()
 
     /**
      * Restoration snapshot while a maximize presentation is applied:
@@ -1334,11 +1370,11 @@ class Workspace extends Container {
      * the node's retained lifetime — vary an action per active item by moving `hidden` on its stable
      * instance, the way {@link #syncDockCloseAction} does, not by returning a different list. Names
      * must be unique per node, and every engine-owned name is reserved while its own opt-in is on —
-     * `close` under {@link #enableDockCloseAction}, `maximize` under {@link #enableDockMaximizeAction},
-     * `pin` under {@link #enableDockPinAction}, `reload` under {@link #enableDockReloadAction},
-     * `pop-out` while {@link #dockPopOutActionActive} holds — that one is a conjunction rather than a
-     * single opt-in, because the action dispatches into the tear-out lifecycle and is not projected
-     * without it;
+     * `close` under {@link #enableDockCloseAction}, `lock` under {@link #enableDockLockAction},
+     * `maximize` under {@link #enableDockMaximizeAction}, `pin` under {@link #enableDockPinAction},
+     * `reload` under {@link #enableDockReloadAction}, `pop-out` while
+     * {@link #dockPopOutActionActive} holds — that one is a conjunction rather than a single opt-in,
+     * because the action dispatches into the tear-out lifecycle and is not projected without it;
      * both violations throw at projection rather than silently unaddressing an action. Their intent
      * surfaces on the `dockHeaderAction` event — see {@link #onDockHeaderAction}.
      * @returns {Object}
@@ -1394,9 +1430,162 @@ class Workspace extends Container {
 
         let action = tabContainer?.getActionItem?.('close'),
             itemId = this.getActiveDockItemId(tabContainer),
-            hidden = !itemId || this.dockModel?.items?.[itemId]?.closable === false;
+            item   = this.dockModel?.items?.[itemId],
+            hidden = !itemId || item?.closable === false || item?.locked === true;
 
         action && action.hidden !== hidden && (action.hidden = hidden)
+    }
+
+    /**
+     * Synchronizes the retained lock action and every projected pane/button against committed
+     * item truth. The action stays one stable instance; per-item hidden/icon state moves on it.
+     *
+     * Presentation is deliberately a second layer beneath the model guards. Lock stamps
+     * `vdom.inert` plus `neo-dock-pane-locked` in one pane update and removes only the tab
+     * button's `neo-draggable` source token. Unlock restores the exact prior inert ownership/value
+     * and exact prior drag-token ownership. Locked headers remain legal drop targets.
+     * @param {Neo.tab.Container|null} tabContainer
+     * @protected
+     */
+    syncDockLockAction(tabContainer) {
+        let me = this;
+
+        if (!me.enableDockLockAction) return;
+
+        let action       = tabContainer?.getActionItem?.('lock'),
+            activeItemId = me.getActiveDockItemId(tabContainer),
+            activeItem   = me.dockModel?.items?.[activeItemId],
+            hidden       = !activeItemId || activeItem?.lockable === false,
+            iconCls      = activeItem?.locked === true ? me.dockUnlockIconCls : me.dockLockIconCls,
+            changes      = {};
+
+        if (action) {
+            action.hidden  !== hidden  && (changes.hidden  = hidden);
+            action.iconCls !== iconCls && (changes.iconCls = iconCls);
+
+            if (Object.keys(changes).length) {
+                action.setSilent(changes);
+                action.update()
+            }
+        }
+
+        let itemIds = tabContainer?.getTabBar?.()?.sortZoneConfig?.dockItemIds || [],
+            panes   = tabContainer?.getCardContainer?.()?.items || [],
+            buttons = tabContainer?.getTabButtons?.() || [];
+
+        itemIds.forEach((itemId, index) => {
+            me.syncDockLockItemPresentation({
+                button: buttons[index],
+                locked: me.dockModel?.items?.[itemId]?.locked === true,
+                pane  : panes[index]
+            })
+        })
+    }
+
+    /**
+     * Applies or restores one item's lock presentation without changing model state.
+     * @param {Object} data
+     * @param {Neo.tab.header.Button|null} data.button
+     * @param {Boolean} data.locked
+     * @param {Neo.component.Base|null} data.pane
+     * @protected
+     */
+    syncDockLockItemPresentation({button, locked, pane}={}) {
+        let me = this;
+
+        if (pane && !pane.isDestroyed) {
+            let cls     = Array.isArray(pane.cls) ? [...pane.cls] : pane.cls ? [pane.cls] : [],
+                hadCls  = cls.includes('neo-dock-pane-locked'),
+                changed = false,
+                prior,
+                vdom    = pane.vdom;
+
+            if (locked) {
+                if (!me.dockLockPaneState.has(pane)) {
+                    me.dockLockPaneState.set(pane, {
+                        owned: Object.hasOwn(vdom, 'inert'),
+                        value: vdom.inert
+                    })
+                }
+
+                if (vdom.inert !== true) {
+                    vdom.inert = true;
+                    changed = true
+                }
+            } else if (me.dockLockPaneState.has(pane)) {
+                prior = me.dockLockPaneState.get(pane);
+
+                if (prior.owned) {
+                    vdom.inert = prior.value
+                } else {
+                    delete vdom.inert
+                }
+
+                me.dockLockPaneState.delete(pane);
+                changed = true
+            }
+
+            NeoArray.toggle(cls, 'neo-dock-pane-locked', locked);
+
+            if (hadCls !== locked) {
+                pane.setSilent({cls});
+                changed = true
+            }
+
+            changed && pane.update()
+        }
+
+        if (button && !button.isDestroyed) {
+            let cls       = Array.isArray(button.wrapperCls) ? [...button.wrapperCls] : [],
+                draggable = cls.includes('neo-draggable'),
+                restore;
+
+            if (locked) {
+                !me.dockLockDragState.has(button) && me.dockLockDragState.set(button, draggable);
+                NeoArray.remove(cls, 'neo-draggable')
+            } else if (me.dockLockDragState.has(button)) {
+                restore = me.dockLockDragState.get(button);
+                me.dockLockDragState.delete(button);
+                NeoArray.toggle(cls, 'neo-draggable', restore)
+            }
+
+            draggable !== cls.includes('neo-draggable') && (button.wrapperCls = cls)
+        }
+    }
+
+    /**
+     * Synchronizes the currently materialized rail-reveal panes against committed lock truth.
+     *
+     * Rails are synthetic affordances retained across stable-topology reconciliation, so their
+     * projection config is not a state-update channel. The materialization callback covers first
+     * reveal; this sweep covers a lock transition while the same overlay remains open. Dismissed
+     * cached panes restore on their next materialization callback.
+     * @protected
+     */
+    syncDockLockRails() {
+        let me = this;
+
+        if (!me.enableDockLockAction) return;
+
+        const visit = component => {
+            if (!component || component.isDestroyed) return;
+
+            if (component.dockNodeType === 'edge-rail') {
+                let itemId = component.revealOverlay?.revealPaneItemId,
+                    pane   = component.revealOverlay?.paneSlot?.items?.[0];
+
+                if (itemId && pane) {
+                    me.syncDockLockItemPresentation({
+                        locked: me.dockModel?.items?.[itemId]?.locked === true,
+                        pane
+                    })
+                }
+            }
+
+            component.items?.forEach(visit)
+        };
+
+        visit(me.getDockHost()?.items?.[me.dockShellIndex])
     }
 
     /**
@@ -1492,9 +1681,12 @@ class Workspace extends Container {
 
         projectedTabs?.forEach?.(tab => {
             me.syncDockCloseAction(tab);
+            me.syncDockLockAction(tab);
             me.syncDockPinAction(tab);
             me.syncDockReloadAction(tab)
         })
+
+        me.enableDockLockAction && me.syncDockLockRails()
     }
 
     /**
@@ -1517,6 +1709,7 @@ class Workspace extends Container {
             descriptor, result;
 
         me.syncDockCloseAction(container);
+        me.syncDockLockAction(container);
         me.syncDockPinAction(container);
 
         if (!me.dockModel || !itemId || committed === itemId) {
@@ -1554,11 +1747,11 @@ class Workspace extends Container {
      *
      * This class owns the ENGINE SET, each action only while its own opt-in is on: `close`
      * ({@link #enableDockCloseAction}), `maximize` ({@link #enableDockMaximizeAction} — a pure
-     * presentation toggle that never reaches the reducer), `pin` ({@link #enableDockPinAction}),
-     * `reload` ({@link #enableDockReloadAction} — runtime-only like maximize: delegation into the
-     * pane's own `dockReload()`, never an operation) and `pop-out`
-     * ({@link #enableDockPopOutAction}, itself double-gated on
-     * {@link #enableDockTearOutLifecycle}). Every other intent —
+     * presentation toggle that never reaches the reducer), `lock`
+     * ({@link #enableDockLockAction}), `pin` ({@link #enableDockPinAction}), `reload`
+     * ({@link #enableDockReloadAction} — runtime-only like maximize: delegation into the pane's own
+     * `dockReload()`, never an operation) and `pop-out` ({@link #enableDockPopOutAction}, itself
+     * double-gated on {@link #enableDockTearOutLifecycle}). Every other intent —
      * including host actions projected through `resolveDockHeaderActions` — is re-emitted as a
      * **`dockHeaderAction`** event carrying `{action, dockNodeId, tabContainer}`, so a host receives it
      * without subclassing this class or overriding a protected method, and this method returns `null`
@@ -1583,6 +1776,10 @@ class Workspace extends Container {
 
         if (action === 'close' && me.enableDockCloseAction) {
             return me.handleDockCloseAction({dockNodeId, tabContainer})
+        }
+
+        if (action === 'lock' && me.enableDockLockAction) {
+            return me.handleDockLockAction({dockNodeId, tabContainer})
         }
 
         if (action === 'pin' && me.enableDockPinAction) {
@@ -1651,6 +1848,46 @@ class Workspace extends Container {
             me.refreshPromise = me.refreshPromise.then(() => {
                 me.focusDockCloseTarget({dockNodeId: modelNodeId, itemId: focusId})
             })
+        }
+
+        return result
+    }
+
+    /**
+     * @summary Toggles the active item's committed lock state through the reducer.
+     *
+     * On success the committed document advances through the ordinary holder seam, then current
+     * chrome receives the derived presentation immediately; reconciliation repeats the same sync
+     * on retained/new instances. The reducer owns every refusal, including `lockable:false`.
+     * @param {Object} data
+     * @param {String} data.dockNodeId
+     * @param {Neo.tab.Container|null} data.tabContainer
+     * @returns {{document:Object,errors:String[]}|null}
+     * @protected
+     */
+    handleDockLockAction({dockNodeId, tabContainer}={}) {
+        let me     = this,
+            itemId = me.getActiveDockItemId(tabContainer);
+
+        if (!itemId) {
+            return {document: me.dockModel, errors: ['Dock lock action requires an active item']}
+        }
+
+        if (!me.dockModel) {
+            return {document: me.dockModel, errors: ['Dock lock action requires a committed document']}
+        }
+
+        let descriptor = {
+                operation: 'setItemLocked',
+                itemId,
+                locked   : me.dockModel.items[itemId]?.locked !== true
+            },
+            result = me.applyDockZoneOperation(descriptor);
+
+        if (result && !result.errors?.length && result.document) {
+            me.onDockZoneDocumentChange(result.document, descriptor, tabContainer);
+            me.syncDockCloseAction(tabContainer);
+            me.syncDockLockAction(tabContainer)
         }
 
         return result
@@ -2793,6 +3030,10 @@ class Workspace extends Container {
         tail                = me.refreshPromise?.catch(() => {}) || Promise.resolve();
 
         me.dockModel = document;
+        // A currently revealed rail pane is retained outside tab chrome. It already exists at the
+        // commit boundary, so lock presentation follows the sole worker-truth write immediately;
+        // the post-reconcile sweep repeats this for newly materialized/retained surfaces.
+        me.enableDockLockAction && me.syncDockLockRails?.();
 
         me.refreshPromise = tail
             .then(() => me.timeout(0))
@@ -2842,6 +3083,11 @@ class Workspace extends Container {
                 // nowhere to arrive.
                 onDockHeaderAction     : me.onDockHeaderAction.bind(me),
                 ...(me.enableDockCloseAction && {enableDockCloseAction: true}),
+                ...(me.enableDockLockAction && {
+                    dockLockIconCls      : me.dockLockIconCls,
+                    dockUnlockIconCls    : me.dockUnlockIconCls,
+                    enableDockLockAction : true
+                }),
                 ...(me.enableDockPinAction && {enableDockPinAction: true}),
                 ...(me.enableDockReloadAction && {enableDockReloadAction: true}),
                 // The double gate lives here rather than in the adapter: pop-out dispatches into
@@ -2861,6 +3107,10 @@ class Workspace extends Container {
                 onDockZoneDocumentChange : me.onDockZoneDocumentChange.bind(me),
                 resolveComponentRef      : itemResolver || ((componentRef, item, itemId) => me.resolveProjectedPane(itemId, item)),
                 resolveRevealComponentRef: (componentRef, item, itemId) => me.decorateFlipMarker(me.resolveRevealPane(itemId, item), itemId),
+                syncDockLockPane         : (pane, itemId) => me.syncDockLockItemPresentation({
+                    locked: me.dockModel?.items?.[itemId]?.locked === true,
+                    pane
+                }),
                 tabInsertDescriptor
             })
         }

--- a/src/dashboard/dock/Workspace.mjs
+++ b/src/dashboard/dock/Workspace.mjs
@@ -1443,7 +1443,9 @@ class Workspace extends Container {
      * Presentation is deliberately a second layer beneath the model guards. Lock stamps
      * `vdom.inert` plus `neo-dock-pane-locked` in one pane update and removes only the tab
      * button's `neo-draggable` source token. Unlock restores the exact prior inert ownership/value
-     * and exact prior drag-token ownership. Locked headers remain legal drop targets.
+     * and exact prior drag-token ownership. Locked headers remain legal drop targets. The ordinary
+     * lock gesture is focus-gated; once the protective state persists, its unlock reversal becomes
+     * persistent too, so discoverability never depends on re-entering a transient focus context.
      * @param {Neo.tab.Container|null} tabContainer
      * @protected
      */
@@ -1457,14 +1459,30 @@ class Workspace extends Container {
             activeItem   = me.dockModel?.items?.[activeItemId],
             hidden       = !activeItemId || activeItem?.lockable === false,
             iconCls      = activeItem?.locked === true ? me.dockUnlockIconCls : me.dockLockIconCls,
+            ariaLabel    = activeItem?.locked === true ? 'unlock' : 'lock',
+            showOnFocus  = activeItem?.locked !== true,
             changes      = {};
 
         if (action) {
+            let ariaLabelChanged = action.vdom?.['aria-label'] !== ariaLabel;
+
             action.hidden  !== hidden  && (changes.hidden  = hidden);
             action.iconCls !== iconCls && (changes.iconCls = iconCls);
+            action.showOnFocus !== showOnFocus && (changes.showOnFocus = showOnFocus);
 
-            if (Object.keys(changes).length) {
-                action.setSilent(changes);
+            if (Object.keys(changes).length || ariaLabelChanged) {
+                // `setSilent()` consumes non-config class-field keys from its input, so remember
+                // this transition BEFORE handing the batch over.
+                let focusGateChanged = Object.hasOwn(changes, 'showOnFocus');
+
+                Object.keys(changes).length && action.setSilent(changes);
+                ariaLabelChanged && (action.vdom['aria-label'] = ariaLabel);
+
+                // `showOnFocus` is a stable-instance policy flip, not an action-list rebuild. The
+                // toolbar owns the inert/aria/tab-index presentation and must release/re-arm it
+                // before this one update publishes the changed action.
+                focusGateChanged && tabContainer?.getTabBar?.()?.applyContextualActionState(true);
+
                 action.update()
             }
         }
@@ -3077,16 +3095,16 @@ class Workspace extends Container {
                 // motion. An explicit dockTearOutBoundaryContainerId from the hook still wins in
                 // LayoutAdapter; direct adapter consumers must supply this field themselves.
                 dockWorkspaceBoundaryContainerId: me.id,
-                onDockActiveIndexChange: me.onDockActiveIndexChange.bind(me),
+                onDockActiveIndexChange         : me.onDockActiveIndexChange.bind(me),
                 // Bound unconditionally: a host can project its OWN header actions without enabling
                 // the close action, and wiring the seam inside that opt-in left those intents with
                 // nowhere to arrive.
                 onDockHeaderAction     : me.onDockHeaderAction.bind(me),
                 ...(me.enableDockCloseAction && {enableDockCloseAction: true}),
                 ...(me.enableDockLockAction && {
-                    dockLockIconCls      : me.dockLockIconCls,
-                    dockUnlockIconCls    : me.dockUnlockIconCls,
-                    enableDockLockAction : true
+                    dockLockIconCls     : me.dockLockIconCls,
+                    dockUnlockIconCls   : me.dockUnlockIconCls,
+                    enableDockLockAction: true
                 }),
                 ...(me.enableDockPinAction && {enableDockPinAction: true}),
                 ...(me.enableDockReloadAction && {enableDockReloadAction: true}),

--- a/src/dashboard/dock/interaction/Rail.mjs
+++ b/src/dashboard/dock/interaction/Rail.mjs
@@ -118,6 +118,13 @@ class Rail extends Container {
          */
         resolveComponentRef: null,
         /**
+         * Workspace-owned lock presentation callback for the materialized reveal pane:
+         * `(pane, itemId) => void`. Reveal remains policy-free; this callback only derives inert
+         * presentation from committed item truth.
+         * @member {Function|null} syncDockLockPane=null
+         */
+        syncDockLockPane: null,
+        /**
          * Dismiss-grace override in ms; `null` keeps the machine's named design constant.
          * @member {Number|null} revealDismissGraceMs_=null
          * @reactive
@@ -680,6 +687,10 @@ class Rail extends Container {
      * empty overlay). Blueprint- and placeholder-created panes are cached per item and parked
      * the same way: mounted children are never destroyed mid-session (`revealPaneCache` tears
      * down with the rail).
+     *
+     * The optional Workspace lock callback runs after first materialization and again when the
+     * same revealed identity is synchronized, so reveal stays available while its pane derives
+     * inert presentation directly from current committed item truth.
      * @param {Object|null} railItem
      * @protected
      */
@@ -695,12 +706,12 @@ class Rail extends Container {
 
         currentId = me.revealOverlay.revealPaneItemId ?? null;
         nextId    = railItem?.dockItemId ?? null;
+        child     = slot.items?.[0];
 
         if (currentId === nextId) {
+            child && nextId && me.syncDockLockPane?.(child, nextId);
             return
         }
-
-        child = slot.items?.[0];
 
         if (child) {
             slot.remove(child, false)
@@ -733,6 +744,9 @@ class Rail extends Container {
         }
 
         me.revealOverlay.revealPaneItemId = nextId
+
+        child = slot.items?.[0];
+        child && nextId && me.syncDockLockPane?.(child, nextId)
     }
 }
 

--- a/src/dashboard/dock/model/Document.mjs
+++ b/src/dashboard/dock/model/Document.mjs
@@ -43,7 +43,10 @@ class Document extends Base {
      * @protected
      * @static
      */
-    static dockZoneItemKeys = new Set(['componentRef', 'title', 'kind', 'blueprint', 'closable', 'pinnable', 'pinned', 'autoHidden', 'movable', 'metadata'])
+    static dockZoneItemKeys = new Set([
+        'componentRef', 'title', 'kind', 'blueprint', 'closable', 'pinnable', 'pinned',
+        'autoHidden', 'lockable', 'locked', 'movable', 'metadata'
+    ])
 
     /**
      * Fields allowed on persisted dock-zone nodes, keyed by node type.
@@ -730,8 +733,9 @@ class Document extends Base {
      * @summary Validates a dock-zone document against the contract invariants.
      *
      * Checks: schema, root presence, reference integrity (split children / edge-zone zones / tabs
-     * items all resolve), each item appears at most once across the tree, split sizes match child
-     * count and sum to 1, and `tabs.activeItemId` is null or one of `tabs.items`.
+     * items all resolve), each item appears at most once across the tree, committed item-state
+     * booleans have the right type, split sizes match child count and sum to 1, and
+     * `tabs.activeItemId` is null or one of `tabs.items`.
      * @param {Object} document
      * @returns {String[]} the (possibly empty) list of invariant violations
      * @static
@@ -763,6 +767,14 @@ class Document extends Base {
 
             if (Document.isJsonRecord(item) && Object.hasOwn(item, 'autoHidden') && typeof item.autoHidden !== 'boolean') {
                 errors.push(`item "${itemId}" autoHidden must be a boolean`)
+            }
+
+            if (Document.isJsonRecord(item) && Object.hasOwn(item, 'lockable') && typeof item.lockable !== 'boolean') {
+                errors.push(`item "${itemId}" lockable must be a boolean`)
+            }
+
+            if (Document.isJsonRecord(item) && Object.hasOwn(item, 'locked') && typeof item.locked !== 'boolean') {
+                errors.push(`item "${itemId}" locked must be a boolean`)
             }
 
             if (Document.isJsonRecord(item) && item.pinned === true && item.autoHidden === true) {

--- a/src/dashboard/dock/model/Operations.mjs
+++ b/src/dashboard/dock/model/Operations.mjs
@@ -378,12 +378,13 @@ class Operations extends Base {
     }
 
     /**
-     * @summary Updates an item's committed lock state when its policy permits locking.
+     * @summary Updates an item's committed lock state when its policy permits locking or unlocking.
      *
      * Lock is the model boundary beneath the Workspace presentation: while true, close, detach,
      * and source moves fail closed even when stale chrome or a programmatic descriptor bypasses
      * the projected inert and drag-source affordances. An absent value reads as unlocked, matching
-     * the additive boolean-state precedent of pinned and autoHidden.
+     * the additive boolean-state precedent of pinned and autoHidden. `lockable:false` refuses both
+     * directions deliberately: it is permanent item policy, not merely a lock-button visibility hint.
      * @param {Object} document
      * @param {Object} args {itemId, locked}
      * @returns {{document:Object, errors:String[]}}

--- a/src/dashboard/dock/model/Operations.mjs
+++ b/src/dashboard/dock/model/Operations.mjs
@@ -50,6 +50,7 @@ class Operations extends Base {
         resizeEdgeZone   : (document, descriptor) => Operations.resizeEdgeZone(document, descriptor),
         detachItem       : (document, descriptor) => Operations.detachItem(document, descriptor),
         closeItem        : (document, descriptor) => Operations.closeItem(document, descriptor),
+        setItemLocked    : (document, descriptor) => Operations.setItemLocked(document, descriptor),
         setItemPinned    : (document, descriptor) => Operations.setItemPinned(document, descriptor),
         setItemAutoHidden: (document, descriptor) => Operations.setItemAutoHidden(document, descriptor),
         // transferItem / transferNode are TWO-document operations; their single-document dispatch is a
@@ -114,7 +115,9 @@ class Operations extends Base {
     }
 
     /**
-     * @summary Relocates an in-tree `itemId` into the target tabs node at `index`.
+     * @summary Relocates an unlocked in-tree `itemId` into the target tabs node at `index`.
+     *
+     * Locked items fail closed as sources; the target may still contain locked peers.
      * @param {Object} document
      * @param {Object} args {itemId, targetNodeId, index}
      * @returns {{document:Object, errors:String[]}}
@@ -123,6 +126,10 @@ class Operations extends Base {
     static moveItem(document, {itemId, targetNodeId, index} = {}) {
         if (!Document.findContainingTabsId(document, itemId)) {
             return {document, errors: [`item "${itemId}" is not in the tree`]}
+        }
+
+        if (document.items[itemId].locked === true) {
+            return {document, errors: [`item "${itemId}" is locked`]}
         }
 
         return Operations.addTab(document, {itemId, tabsNodeId: targetNodeId, index})
@@ -309,8 +316,8 @@ class Operations extends Base {
     }
 
     /**
-     * @summary Removes `itemId` from the tree but preserves its catalog record (for popup/window
-     * ownership), per the contract's `detachItem`.
+     * @summary Removes an unlocked `itemId` from the tree but preserves its catalog record (for
+     * popup/window ownership), per the contract's `detachItem`. Locked items fail closed.
      * @param {Object} document
      * @param {Object} args {itemId}
      * @returns {{document:Object, errors:String[]}}
@@ -321,6 +328,10 @@ class Operations extends Base {
             return {document, errors: [`item "${itemId}" is not in the tree`]}
         }
 
+        if (document.items[itemId].locked === true) {
+            return {document, errors: [`item "${itemId}" is locked`]}
+        }
+
         let doc = Document.clone(document);
 
         Document.detachFromTabs(doc, itemId);
@@ -329,9 +340,10 @@ class Operations extends Base {
     }
 
     /**
-     * @summary Removes a closeable `itemId` from the tree and catalog. When the item was active,
-     * activates the item at its former index or the preceding item; closing a non-active item
-     * preserves the surviving activation. An explicit `closable:false` fails closed.
+     * @summary Removes an unlocked, closeable `itemId` from the tree and catalog. When the item
+     * was active, activates the item at its former index or the preceding item; closing a
+     * non-active item preserves the surviving activation. Locked and explicit `closable:false`
+     * items fail closed.
      * @param {Object} document
      * @param {Object} args {itemId}
      * @returns {{document:Object, errors:String[]}}
@@ -341,6 +353,7 @@ class Operations extends Base {
         let item = document.items?.[itemId];
 
         if (!item) return {document, errors: [`unknown item "${itemId}"`]};
+        if (item.locked === true) return {document, errors: [`item "${itemId}" is locked`]};
         if (item.closable === false) return {document, errors: [`item "${itemId}" is not closable`]};
 
         let tabsNodeId  = Document.findContainingTabsId(document, itemId),
@@ -360,6 +373,32 @@ class Operations extends Base {
         }
 
         delete doc.items[itemId];
+
+        return Document.commit(document, doc)
+    }
+
+    /**
+     * @summary Updates an item's committed lock state when its policy permits locking.
+     *
+     * Lock is the model boundary beneath the Workspace presentation: while true, close, detach,
+     * and source moves fail closed even when stale chrome or a programmatic descriptor bypasses
+     * the projected inert and drag-source affordances. An absent value reads as unlocked, matching
+     * the additive boolean-state precedent of pinned and autoHidden.
+     * @param {Object} document
+     * @param {Object} args {itemId, locked}
+     * @returns {{document:Object, errors:String[]}}
+     * @static
+     */
+    static setItemLocked(document, {itemId, locked} = {}) {
+        let item = document.items?.[itemId];
+
+        if (!item) return {document, errors: [`unknown item "${itemId}"`]};
+        if (typeof locked !== 'boolean') return {document, errors: ['locked must be a boolean']};
+        if (item.lockable === false) return {document, errors: [`item "${itemId}" is not lockable`]};
+
+        let doc = Document.clone(document);
+
+        doc.items[itemId].locked = locked;
 
         return Document.commit(document, doc)
     }

--- a/src/dashboard/dock/projection/LayoutAdapter.mjs
+++ b/src/dashboard/dock/projection/LayoutAdapter.mjs
@@ -549,7 +549,7 @@ class LayoutAdapter extends Base {
                 || options.resolveComponentRef
                 || (() => null),
             stackDragNodeId,
-            syncDockLockPane                   : options.syncDockLockPane,
+            syncDockLockPane                  : options.syncDockLockPane,
             tabInsertDescriptor               : options.tabInsertDescriptor ?? null,
             vesselConversionConvertThreshold  : options.vesselConversionConvertThreshold,
             vesselConversionPointerExitGraceMs: options.vesselConversionPointerExitGraceMs,
@@ -1084,8 +1084,22 @@ class LayoutAdapter extends Base {
 
         const headerActions = [
             ...hostActions,
-            // Reload leads the engine set per the frozen family order (reload · lock · pin · maximize —
-            // close always last). Not a toggle, so the icon is fixed like pin's. `hidden` is a
+            // Lock leads the frozen engine set. The ordinary lock gesture inherits focus gating;
+            // while the protective state persists, its UNLOCK reversal stays persistent too, so
+            // discoverability never depends on re-entering a transient focus context.
+            ...(context.enableDockLockAction ? [{
+                action : 'lock',
+                hidden : !activeItemId || context.items[activeItemId]?.lockable === false,
+                iconCls: context.items[activeItemId]?.locked === true
+                    ? context.dockUnlockIconCls
+                    : context.dockLockIconCls,
+                showOnFocus: context.items[activeItemId]?.locked !== true,
+                vdom       : {
+                    'aria-label': context.items[activeItemId]?.locked === true ? 'unlock' : 'lock'
+                }
+            }] : []),
+            // Reload follows lock in the frozen family order (lock · reload · pin · maximize — close
+            // always last). Not a toggle, so the icon is fixed like pin's. `hidden` is a
             // CONSTANT true here — per-item availability must ride the ONE retained instance's
             // runtime state (`Workspace#syncDockReloadAction`, the `syncDockCloseAction`
             // pattern), never this config: a row that varies between projections changes the
@@ -1096,13 +1110,6 @@ class LayoutAdapter extends Base {
                 action : 'reload',
                 hidden : true,
                 iconCls: 'fa fa-rotate-right'
-            }] : []),
-            ...(context.enableDockLockAction ? [{
-                action : 'lock',
-                hidden : !activeItemId || context.items[activeItemId]?.lockable === false,
-                iconCls: context.items[activeItemId]?.locked === true
-                    ? context.dockUnlockIconCls
-                    : context.dockLockIconCls
             }] : []),
             ...(context.enableDockPinAction ? [{
                 action    : 'pin',

--- a/src/dashboard/dock/projection/LayoutAdapter.mjs
+++ b/src/dashboard/dock/projection/LayoutAdapter.mjs
@@ -415,6 +415,10 @@ class LayoutAdapter extends Base {
      *     with one runtime-only whole-stack grip and arm its existing dock SortZone.
      * @param {Boolean} [options.enableDockCloseAction=false] Projects one persistent close action
      *     into every tabs header. The workspace owns the effect and policy synchronization.
+     * @param {Boolean} [options.enableDockLockAction=false] Projects one engine-owned lock toggle
+     *     into every tabs header. The workspace owns committed-state dispatch and presentation sync.
+     * @param {String} [options.dockLockIconCls='fa fa-lock'] Icon while the active item is unlocked.
+     * @param {String} [options.dockUnlockIconCls='fa fa-lock-open'] Icon while it is locked.
      * @param {Boolean} [options.enableDockPinAction=false] Projects one persistent pin action into
      *     every tabs header — the collapse-to-rail entry of docking design record §2.7. The workspace
      *     owns the effect and policy synchronization, exactly as it does for close.
@@ -445,10 +449,11 @@ class LayoutAdapter extends Base {
      *     (`hidden` / `disabled`), never in a changing list. Actions project BEFORE the engine set,
      *     their intent arrives through `onDockHeaderAction` like any other, and focus gating is the
      *     tab header's own default. Semantic names must be unique per node, and every engine-owned
-     *     name is reserved while its own opt-in is on — `close` under `enableDockCloseAction`, `maximize` under `enableDockMaximizeAction`, `pin`
-     *     under `enableDockPinAction`, `reload` under `enableDockReloadAction`, `pop-out` under
-     *     `enableDockPopOutAction`. A name is reserved exactly while the engine can project it, so
-     *     `pop-out` is free for a host whenever the workspace's tear-out lifecycle is not armed.
+     *     name is reserved while its own opt-in is on — `close` under `enableDockCloseAction`,
+     *     `lock` under `enableDockLockAction`, `maximize` under `enableDockMaximizeAction`,
+     *     `pin` under `enableDockPinAction`, `reload` under `enableDockReloadAction`, and `pop-out`
+     *     under `enableDockPopOutAction`. A name is reserved exactly while the engine can project it,
+     *     so `pop-out` is free for a host whenever the workspace's tear-out lifecycle is not armed.
      * @param {Function} [options.onDockVesselConversionIn] Source-owned strict park admission.
      * @param {Function} [options.onDockVesselConversionOut] Source-owned strict re-show admission.
      * @param {Function} [options.onDockVesselConversionTerminal] Source-owned parked-vessel
@@ -459,6 +464,8 @@ class LayoutAdapter extends Base {
      *     the exact dragged vessel's live global inner rect; threaded through a clone-safe listener.
      * @param {Function} [options.resolveComponentRef]
      * @param {Function} [options.resolveRevealComponentRef] Durable resolver retained by edge rails.
+     * @param {Function} [options.syncDockLockPane] Workspace-owned lock presentation for a resolved
+     *     rail reveal pane: `(pane, itemId) => void`.
      * @param {Object|null} [options.tabInsertDescriptor] Runtime-only normalized `addTab`
      * correlation consumed by this projection; never part of `model`.
      * @param {Number} [options.vesselConversionConvertThreshold] Provisional convert-in threshold;
@@ -506,9 +513,12 @@ class LayoutAdapter extends Base {
             dockTabSortBoundaryContainerId   : options.dockTearOutBoundaryContainerId
                 || options.dockWorkspaceBoundaryContainerId
                 || null,
+            dockLockIconCls                  : options.dockLockIconCls || 'fa fa-lock',
             dockMaximizeIconCls              : options.dockMaximizeIconCls || 'far fa-window-maximize',
             dockPopOutIconCls                : options.dockPopOutIconCls || 'far fa-window-restore',
+            dockUnlockIconCls                : options.dockUnlockIconCls || 'fa fa-lock-open',
             enableDockCloseAction            : options.enableDockCloseAction === true,
+            enableDockLockAction             : options.enableDockLockAction === true,
             enableDockMaximizeAction         : options.enableDockMaximizeAction === true,
             enableDockPinAction              : options.enableDockPinAction === true,
             enableDockPopOutAction           : options.enableDockPopOutAction === true,
@@ -539,6 +549,7 @@ class LayoutAdapter extends Base {
                 || options.resolveComponentRef
                 || (() => null),
             stackDragNodeId,
+            syncDockLockPane                   : options.syncDockLockPane,
             tabInsertDescriptor               : options.tabInsertDescriptor ?? null,
             vesselConversionConvertThreshold  : options.vesselConversionConvertThreshold,
             vesselConversionPointerExitGraceMs: options.vesselConversionPointerExitGraceMs,
@@ -596,7 +607,8 @@ class LayoutAdapter extends Base {
      * The metadata carries stable `dockItemId` + `dockEdge` so the rail's click (and the follow-up
      * reveal/pin slice) can address the item semantically, plus the `restorable` policy projection
      * (`pinnable !== false`) — a tab whose restore the model would reject renders disabled instead
-     * of lying about the affordance.
+     * of lying about the affordance. Lock never removes the rail affordance; Workspace derives inert
+     * reveal presentation directly from committed item truth rather than duplicating it here.
      * No DOMRect, hover, or open geometry is emitted — reveal/open state stays runtime-only per the
      * JSON-first guardrail (DockZoneModel.md §Serializable vs Runtime).
      * @param {String} itemId
@@ -646,7 +658,8 @@ class LayoutAdapter extends Base {
             ntype                   : 'dashboard-dock-rail',
             onDockZoneDocumentChange: context.onDockZoneDocumentChange,
             railItems               : itemIds.map(itemId => this.createRailTab(itemId, edge, context)),
-            resolveComponentRef     : context.resolveRevealComponentRef
+            resolveComponentRef     : context.resolveRevealComponentRef,
+            syncDockLockPane        : context.syncDockLockPane
         }
     }
 
@@ -1033,6 +1046,7 @@ class LayoutAdapter extends Base {
                   // is not one lowercase word — `pop-out` yielded `enableDockPop-outAction`, sending
                   // the host to grep for something unfindable. Pairing them here cannot drift.
                   ['close',    {enabled: context.enableDockCloseAction,    optIn: 'enableDockCloseAction'}],
+                  ['lock',     {enabled: context.enableDockLockAction,     optIn: 'enableDockLockAction'}],
                   ['maximize', {enabled: context.enableDockMaximizeAction, optIn: 'enableDockMaximizeAction'}],
                   ['pin',      {enabled: context.enableDockPinAction,      optIn: 'enableDockPinAction'}],
                   // Reserved only while the flag is on — and that flag is already the AND of
@@ -1070,7 +1084,7 @@ class LayoutAdapter extends Base {
 
         const headerActions = [
             ...hostActions,
-            // Reload leads the engine set per the frozen family order (reload · pin · maximize —
+            // Reload leads the engine set per the frozen family order (reload · lock · pin · maximize —
             // close always last). Not a toggle, so the icon is fixed like pin's. `hidden` is a
             // CONSTANT true here — per-item availability must ride the ONE retained instance's
             // runtime state (`Workspace#syncDockReloadAction`, the `syncDockCloseAction`
@@ -1082,6 +1096,13 @@ class LayoutAdapter extends Base {
                 action : 'reload',
                 hidden : true,
                 iconCls: 'fa fa-rotate-right'
+            }] : []),
+            ...(context.enableDockLockAction ? [{
+                action : 'lock',
+                hidden : !activeItemId || context.items[activeItemId]?.lockable === false,
+                iconCls: context.items[activeItemId]?.locked === true
+                    ? context.dockUnlockIconCls
+                    : context.dockLockIconCls
             }] : []),
             ...(context.enableDockPinAction ? [{
                 action    : 'pin',
@@ -1122,7 +1143,9 @@ class LayoutAdapter extends Base {
             ...(context.enableDockCloseAction ? [{
                 action    : 'close',
                 contextual: false,
-                hidden    : !activeItemId || context.items[activeItemId]?.closable === false,
+                hidden    : !activeItemId
+                    || context.items[activeItemId]?.closable === false
+                    || context.items[activeItemId]?.locked === true,
                 iconCls   : 'fa fa-times'
             }] : [])
         ];

--- a/src/toolbar/Base.mjs
+++ b/src/toolbar/Base.mjs
@@ -221,12 +221,19 @@ class Toolbar extends Container {
             visible = me.contextualActionsVisible;
 
         me.getActionItems().forEach(item => {
-            if (!me.isFocusGatedAction(item)) {
+            let focusGated      = me.isFocusGatedAction(item),
+                ownsInactiveTab = Object.hasOwn(item, '_toolbarActionTabIndex');
+
+            // A live action may leave the focus gate so a persistent protective state can keep its
+            // reversal discoverable. If this toolbar previously made it inactive, the opt-out must
+            // release that owned layer once; a persistent action that was never gated stays
+            // untouched, including any consumer-owned inert/aria state.
+            if (!focusGated && !ownsInactiveTab) {
                 return
             }
 
             let cls      = [...(item.cls || [])],
-                inactive = !visible,
+                inactive = focusGated && !visible,
                 vdom     = item.vdom;
 
             NeoArray.toggle(cls, 'neo-toolbar-action-context-inactive', inactive);
@@ -244,13 +251,15 @@ class Toolbar extends Container {
                 delete vdom['aria-hidden'];
                 delete vdom.inert;
 
-                if (item._toolbarActionTabIndex === null) {
-                    delete vdom.tabIndex
-                } else {
-                    vdom.tabIndex = item._toolbarActionTabIndex
-                }
+                if (ownsInactiveTab) {
+                    if (item._toolbarActionTabIndex === null) {
+                        delete vdom.tabIndex
+                    } else {
+                        vdom.tabIndex = item._toolbarActionTabIndex
+                    }
 
-                delete item._toolbarActionTabIndex
+                    delete item._toolbarActionTabIndex
+                }
             }
 
             !silent && item.update()

--- a/test/playwright/component/apps/dock-lock/app.mjs
+++ b/test/playwright/component/apps/dock-lock/app.mjs
@@ -1,0 +1,185 @@
+import DockWorkspace from '../../../../../src/dashboard/dock/Workspace.mjs';
+import Viewport      from '../../../../../src/container/Viewport.mjs';
+import '../../../../../src/tab/Container.mjs';
+
+const fixtureDocument = {
+    schema: 'neo.dock.zone.v1',
+    root  : 'root',
+    items : {
+        alpha : {componentRef: 'alpha',  title: 'Alpha',  kind: 'panel'},
+        beta  : {componentRef: 'beta',   title: 'Beta',   kind: 'panel'},
+        railed: {
+            componentRef: 'railed',
+            title       : 'Railed',
+            kind        : 'panel',
+            autoHidden  : true,
+            locked      : true
+        }
+    },
+    nodes: {
+        root       : {type: 'edge-zone', zones: {
+            center: {nodeId: 'main-tabs'},
+            right : {nodeId: 'edge-tabs', extent: 0.25}
+        }},
+        'main-tabs': {type: 'tabs', items: ['alpha', 'beta'], activeItemId: 'alpha'},
+        'edge-tabs': {type: 'tabs', items: ['railed'], activeItemId: 'railed'}
+    }
+};
+
+/**
+ * @summary Rendered-browser fixture for committed dock lock, inert restoration, source suppression,
+ * and rail-reveal composition.
+ */
+class LockFixtureWorkspace extends DockWorkspace {
+    static config = {
+        /**
+         * @member {String} className='Test.Playwright.Component.DockLock.Workspace'
+         * @protected
+         */
+        className: 'Test.Playwright.Component.DockLock.Workspace',
+        /**
+         * @member {Boolean} enableDockCloseAction=true
+         */
+        enableDockCloseAction: true,
+        /**
+         * @member {Boolean} enableDockLockAction=true
+         */
+        enableDockLockAction: true,
+        /**
+         * @member {String} id='dock-lock-workspace'
+         */
+        id: 'dock-lock-workspace',
+        /**
+         * @member {Object} layout={ntype:'vbox',align:'stretch'}
+         */
+        layout: {ntype: 'vbox', align: 'stretch'},
+        /**
+         * Spec trigger: one JSON operation descriptor is reduced through the real model boundary.
+         * @member {String|null} operationJson_=null
+         * @reactive
+         */
+        operationJson_: null,
+        /**
+         * Spec trigger: awaits the live Workspace refresh chain and mirrors the settled value.
+         * @member {Number} settleProbeCount_=0
+         * @reactive
+         */
+        settleProbeCount_: 0
+    }
+
+    /**
+     * Spec-readable committed-document mirror.
+     * @member {String|null} docJson=null
+     */
+    docJson = null
+
+    /**
+     * Spec-readable result of the latest programmatic operation.
+     * @member {String|null} operationResultJson=null
+     */
+    operationResultJson = null
+
+    /**
+     * Last refresh-chain settlement observed by {@link #settleProbeCount}.
+     * @member {Number} settledProbeCount=0
+     */
+    settledProbeCount = 0
+
+    /**
+     * @param {String|null} value
+     * @param {String|null} oldValue
+     * @protected
+     */
+    afterSetOperationJson(value, oldValue) {
+        if (oldValue === undefined || !value) {
+            return
+        }
+
+        const descriptor = JSON.parse(value),
+              result     = this.applyDockZoneOperation(descriptor);
+
+        if (result && !result.errors?.length && result.document) {
+            this.onDockZoneDocumentChange(result.document, descriptor, this)
+        }
+
+        this.operationResultJson = JSON.stringify({
+            errors  : result?.errors || [],
+            document: result?.document || null
+        })
+    }
+
+    /**
+     * @param {Number} value
+     * @param {Number} oldValue
+     * @protected
+     */
+    async afterSetSettleProbeCount(value, oldValue) {
+        if (oldValue === undefined) {
+            return
+        }
+
+        await this.refreshPromise;
+
+        !this.isDestroyed && (this.settledProbeCount = value)
+    }
+
+    /**
+     * @param {Object} config
+     */
+    construct(config) {
+        super.construct(config);
+
+        this.add(this.projectDockModel());
+        this.onDockZoneDocumentChange(structuredClone(fixtureDocument))
+    }
+
+    /**
+     * @param {Object} document
+     * @param {Object} [descriptor]
+     * @param {Object} [source]
+     */
+    onDockZoneDocumentChange(document, descriptor, source) {
+        super.onDockZoneDocumentChange(document, descriptor, source);
+        this.docJson = JSON.stringify(this.dockModel)
+    }
+
+    /**
+     * @summary Resolves one test pane. Beta deliberately owns inert before dock lock touches it.
+     * @param {String} itemId
+     * @param {Object} item
+     * @returns {Object}
+     */
+    resolvePane(itemId, item) {
+        const vdom = {
+            cn: [{
+                tag : 'button',
+                id  : `dock-lock-control-${itemId}`,
+                text: `${item?.title || itemId} control`
+            }]
+        };
+
+        itemId === 'beta' && (vdom.inert = true);
+
+        return {
+            cls  : ['dock-lock-test-pane'],
+            id   : `dock-lock-pane-${itemId}`,
+            ntype: 'component',
+            style: {
+                alignItems    : 'center',
+                display       : 'flex',
+                justifyContent: 'center'
+            },
+            vdom
+        }
+    }
+}
+
+LockFixtureWorkspace = Neo.setupClass(LockFixtureWorkspace);
+
+export const onStart = () => Neo.app({
+    mainView: {
+        module: Viewport,
+        items : [{module: LockFixtureWorkspace, flex: 1}]
+    },
+    name: 'Test.Playwright.DockLock'
+});

--- a/test/playwright/component/apps/dock-lock/index.html
+++ b/test/playwright/component/apps/dock-lock/index.html
@@ -6,6 +6,7 @@
     <title>Neo.mjs Dock Lock Test App</title>
 </head>
 <body>
+    <button id="dock-lock-outside-focus" type="button">Outside dock focus</button>
     <script src="../../../../../src/MicroLoader.mjs" type="module"></script>
 </body>
 </html>

--- a/test/playwright/component/apps/dock-lock/index.html
+++ b/test/playwright/component/apps/dock-lock/index.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Neo.mjs Dock Lock Test App</title>
+</head>
+<body>
+    <script src="../../../../../src/MicroLoader.mjs" type="module"></script>
+</body>
+</html>

--- a/test/playwright/component/apps/dock-lock/neo-config.json
+++ b/test/playwright/component/apps/dock-lock/neo-config.json
@@ -1,0 +1,10 @@
+{
+    "appPath"         : "test/playwright/component/apps/dock-lock/app.mjs",
+    "basePath"        : "../../../../../",
+    "environment"     : "development",
+    "mainPath"        : "./Main.mjs",
+    "mainThreadAddons": ["DragDrop", "Navigator", "Stylesheet"],
+    "themes"          : ["neo-theme-neo-dark", "neo-theme-neo-light"],
+    "useAiClient"     : true,
+    "useSharedWorkers": false
+}

--- a/test/playwright/component/dashboard/DockLock.spec.mjs
+++ b/test/playwright/component/dashboard/DockLock.spec.mjs
@@ -94,9 +94,24 @@ test.describe('dock lock — committed boundary plus reversible presentation', (
 
         expect(keyboardFocus).not.toContain('dock-lock-control-alpha');
 
-        await tabButton(main, 'Alpha').click();
-        await awaitRefresh(page);
-        await actionButton(main, 'fa-lock-open').click();
+        const outside = page.locator('#dock-lock-outside-focus'),
+              unlock  = actionButton(main, 'fa-lock-open');
+
+        await outside.focus();
+        await expect(outside).toBeFocused();
+
+        // A persistent protective state must not hide its reversal behind transient focus. With
+        // focus deliberately outside the dock, only unlock stays discoverable/actionable; no other
+        // contextual sibling is exposed by this.
+        await expect(unlock).not.toHaveClass(/neo-toolbar-action-context-inactive/);
+        await expect(unlock).toHaveAttribute('aria-label', 'unlock');
+        expect(await unlock.evaluate(node => ({
+            ariaHidden: node.getAttribute('aria-hidden'),
+            inert     : node.inert,
+            tabIndex  : node.tabIndex
+        }))).toEqual({ariaHidden: null, inert: false, tabIndex: 0});
+
+        await unlock.click();
         await awaitRefresh(page);
 
         await expect(page.locator('#dock-lock-pane-alpha')).not.toHaveClass(/neo-dock-pane-locked/);
@@ -111,6 +126,18 @@ test.describe('dock lock — committed boundary plus reversible presentation', (
         await page.mouse.click(box.x + box.width / 2, box.y + box.height / 2);
         expect(await page.evaluate(() => window.__dockLockClicks)).toBe(2);
 
+        await outside.focus();
+        const relock = actionButton(main, 'fa-lock');
+
+        await expect(relock).toHaveClass(/neo-toolbar-action-context-inactive/);
+        await expect(relock).toHaveAttribute('aria-label', 'lock');
+        expect(await relock.evaluate(node => ({
+            ariaHidden: node.getAttribute('aria-hidden'),
+            inert     : node.inert,
+            tabIndex  : node.tabIndex
+        }))).toEqual({ariaHidden: 'true', inert: true, tabIndex: -1});
+
+        await tabButton(main, 'Beta').focus();
         await tabButton(main, 'Beta').click();
         await awaitRefresh(page);
         expect(await readInertOwnership(page, 'dock-lock-pane-beta')).toEqual({owned: true, value: true});

--- a/test/playwright/component/dashboard/DockLock.spec.mjs
+++ b/test/playwright/component/dashboard/DockLock.spec.mjs
@@ -1,0 +1,163 @@
+import {test, expect} from '@playwright/test';
+
+const WORKSPACE_ID = 'dock-lock-workspace';
+
+const readConfigs = async (page, id, keys) => {
+    const reply = await page.evaluate(
+        data => Neo.worker.App.getConfigs(data),
+        {id, keys}
+    );
+
+    return reply?.data ?? reply
+};
+
+const setWorkspace = (page, configs) => page.evaluate(
+    data => Neo.worker.App.setConfigs(data),
+    {id: WORKSPACE_ID, ...configs}
+);
+
+let settleProbeCount = 0;
+
+/**
+ * Awaits the Workspace refresh chain through the fixture-owned semantic settlement probe.
+ * @param {import('@playwright/test').Page} page
+ * @returns {Promise<void>}
+ */
+const awaitRefresh = async page => {
+    const value = ++settleProbeCount;
+
+    await setWorkspace(page, {settleProbeCount: value});
+    await expect.poll(async () => (await readConfigs(page, WORKSPACE_ID, ['settledProbeCount']))[0])
+        .toBe(value)
+};
+
+const tabsNodeWith = (page, tabText) => page.locator('.neo-dashboard-dock-tabs', {
+    has: page.locator(`.neo-tab-header-button:has-text("${tabText}")`)
+});
+
+const tabButton = (node, text) => node.locator('.neo-tab-header-button', {hasText: text});
+
+const actionButton = (node, glyph) =>
+    node.locator(`.neo-tab-header-toolbar .neo-button:has([class*="${glyph}"])`);
+
+const readInertOwnership = (page, id) => page.evaluate(async componentId => {
+    const reply  = await Neo.worker.App.getConfigs({id: componentId, keys: ['vdom']}),
+          [vdom] = reply?.data ?? reply;
+
+    return {owned: Object.hasOwn(vdom, 'inert'), value: vdom.inert}
+}, id);
+
+test.beforeEach(async ({page}) => {
+    await page.goto('test/playwright/component/apps/dock-lock/index.html');
+    await page.waitForSelector('#dock-lock-workspace', {state: 'attached'});
+    await page.waitForSelector('.neo-tab-header-button', {state: 'visible'});
+    await awaitRefresh(page)
+});
+
+test.describe('dock lock — committed boundary plus reversible presentation', () => {
+    test('inert blocks pointer and keyboard, then unlock restores absent and owned inert exactly', async ({page}) => {
+        const main  = tabsNodeWith(page, 'Alpha'),
+              alpha = page.locator('#dock-lock-control-alpha');
+
+        await page.evaluate(() => {
+            window.__dockLockClicks = 0;
+            document.getElementById('dock-lock-control-alpha')
+                .addEventListener('click', () => window.__dockLockClicks++)
+        });
+
+        let box = await alpha.boundingBox();
+
+        await page.mouse.click(box.x + box.width / 2, box.y + box.height / 2);
+        expect(await page.evaluate(() => window.__dockLockClicks)).toBe(1);
+
+        await tabButton(main, 'Alpha').click();
+        await awaitRefresh(page);
+        await actionButton(main, 'fa-lock').click();
+        await awaitRefresh(page);
+
+        await expect(page.locator('#dock-lock-pane-alpha')).toHaveClass(/neo-dock-pane-locked/);
+        await expect(page.locator('#dock-lock-pane-alpha')).toHaveCSS('outline-style', 'solid');
+        await expect(tabButton(main, 'Alpha')).not.toHaveClass(/neo-draggable/);
+        await expect(actionButton(main, 'fa-times')).toBeHidden();
+        expect(await page.locator('#dock-lock-pane-alpha').evaluate(node => node.inert)).toBe(true);
+
+        box = await alpha.boundingBox();
+        await page.mouse.click(box.x + box.width / 2, box.y + box.height / 2);
+        expect(await page.evaluate(() => window.__dockLockClicks)).toBe(1);
+
+        const keyboardFocus = [];
+
+        for (let i = 0; i < 8; i++) {
+            await page.keyboard.press('Tab');
+            keyboardFocus.push(await page.evaluate(() => document.activeElement?.id || null))
+        }
+
+        expect(keyboardFocus).not.toContain('dock-lock-control-alpha');
+
+        await tabButton(main, 'Alpha').click();
+        await awaitRefresh(page);
+        await actionButton(main, 'fa-lock-open').click();
+        await awaitRefresh(page);
+
+        await expect(page.locator('#dock-lock-pane-alpha')).not.toHaveClass(/neo-dock-pane-locked/);
+        await expect(tabButton(main, 'Alpha')).toHaveClass(/neo-draggable/);
+        await expect(actionButton(main, 'fa-times')).toBeVisible();
+        expect(await readInertOwnership(page, 'dock-lock-pane-alpha')).toEqual({
+            owned: false,
+            value: undefined
+        });
+
+        box = await alpha.boundingBox();
+        await page.mouse.click(box.x + box.width / 2, box.y + box.height / 2);
+        expect(await page.evaluate(() => window.__dockLockClicks)).toBe(2);
+
+        await tabButton(main, 'Beta').click();
+        await awaitRefresh(page);
+        expect(await readInertOwnership(page, 'dock-lock-pane-beta')).toEqual({owned: true, value: true});
+
+        await actionButton(main, 'fa-lock').click();
+        await awaitRefresh(page);
+        await actionButton(main, 'fa-lock-open').click();
+        await awaitRefresh(page);
+
+        expect(await readInertOwnership(page, 'dock-lock-pane-beta')).toEqual({owned: true, value: true})
+    });
+
+    test('locked rail remains revealable while inert, then re-reveals interactive after unlock', async ({page}) => {
+        const railTab = page.locator('.neo-dashboard-dock-edge-rail').getByText('Railed'),
+              overlay = page.locator(
+                  '.neo-dashboard-dock-reveal-overlay:not(.neo-dashboard-dock-reveal-overlay-hidden)'
+              );
+
+        await railTab.click();
+        await expect(overlay).toHaveCount(1);
+        await expect(page.locator('#dock-lock-pane-railed')).toHaveClass(/neo-dock-pane-locked/);
+        expect(await page.locator('#dock-lock-pane-railed').evaluate(node => node.inert)).toBe(true);
+
+        await setWorkspace(page, {
+            operationJson: JSON.stringify({
+                operation: 'setItemLocked',
+                itemId   : 'railed',
+                locked   : false,
+                attempt  : 1
+            })
+        });
+
+        await expect.poll(async () => {
+            const [json] = await readConfigs(page, WORKSPACE_ID, ['docJson']);
+
+            return JSON.parse(json).items.railed.locked
+        }).toBe(false);
+        await awaitRefresh(page);
+
+        // Reconciliation may dismiss the transient overlay through its ordinary focus/pointer state
+        // machine. Orthogonality means the rail remains usable, not that one reveal is persistent.
+        await railTab.click();
+        await expect(overlay).toHaveCount(1);
+        await expect(page.locator('#dock-lock-pane-railed')).not.toHaveClass(/neo-dock-pane-locked/);
+        expect(await readInertOwnership(page, 'dock-lock-pane-railed')).toEqual({
+            owned: false,
+            value: undefined
+        })
+    })
+});

--- a/test/playwright/e2e/dashboard/DockLockActionNL.spec.mjs
+++ b/test/playwright/e2e/dashboard/DockLockActionNL.spec.mjs
@@ -1,0 +1,117 @@
+import {test, expect} from '../../fixtures.mjs';
+
+const WORKSPACE_ID = 'dock-lock-workspace';
+
+const asArray = value => Array.isArray(value) ? value : value ? [value] : [];
+
+const values = record => record?.properties ?? record ?? {};
+
+const tabsNodeWith = (page, tabText) => page.locator('.neo-dashboard-dock-tabs', {
+    has: page.locator(`.neo-tab-header-button:has-text("${tabText}")`)
+});
+
+const tabButton = (node, text) => node.locator('.neo-tab-header-button', {hasText: text});
+
+const actionButton = (node, glyph) =>
+    node.locator(`.neo-tab-header-toolbar .neo-button:has([class*="${glyph}"])`);
+
+const dragAfter = async (page, source, target) => {
+    const from = await source.boundingBox(),
+          to   = await target.boundingBox(),
+          y    = from.y + from.height / 2;
+
+    await page.mouse.move(from.x + from.width / 2, y);
+    await page.mouse.down();
+    await page.waitForTimeout(150);
+    await page.mouse.move(to.x + to.width / 2, y, {steps: 40});
+    await page.mouse.up()
+};
+
+test.describe('dock lock action — Whitebox gesture contract', () => {
+    test('lock refuses stale close and drag; unlock restores both gestures', async ({page, neuralLink}) => {
+        await page.goto('/test/playwright/component/apps/dock-lock/');
+        await page.waitForSelector('#dock-lock-workspace', {state: 'visible'});
+
+        const app  = await neuralLink.connectToApp('Test.Playwright.DockLock'),
+              main = tabsNodeWith(page, 'Alpha');
+
+        const readDocument = async () => {
+            const component = await app.getComponent(WORKSPACE_ID, ['dockModel']);
+
+            return values(component).dockModel
+        };
+
+        const awaitRefresh = async value => {
+            await app.setProperties(WORKSPACE_ID, {settleProbeCount: value});
+            await expect.poll(async () => {
+                const component = await app.getComponent(WORKSPACE_ID, ['settledProbeCount']);
+
+                return values(component).settledProbeCount
+            }).toBe(value)
+        };
+
+        await tabButton(main, 'Alpha').click();
+        await actionButton(main, 'fa-lock').click();
+
+        await expect.poll(async () => (await readDocument()).items.alpha.locked).toBe(true);
+
+        const before     = structuredClone(await readDocument()),
+              tabsRecord = asArray(await app.queryComponent(
+                  {dockNodeId: 'main-tabs'},
+                  ['id']
+              ))[0],
+              tabsId     = tabsRecord?.id ?? values(tabsRecord).id;
+
+        expect(tabsId).toBeTruthy();
+
+        // Stale presentation falsifier: bypass hidden chrome through the real TabContainer event
+        // route. Workspace still reaches handleDockCloseAction, and the model remains the boundary.
+        await app.callMethod(tabsId, 'onHeaderAction', [{action: 'close'}]);
+
+        expect(await readDocument()).toEqual(before);
+
+        await app.getDragTrace(true);
+        await dragAfter(page, tabButton(main, 'Alpha'), tabButton(main, 'Beta'));
+
+        expect((await readDocument()).nodes['main-tabs'].items).toEqual(['alpha', 'beta']);
+        expect((await app.getDragTrace()).traces || [],
+            'a locked header never arms the SortZone').toEqual([]);
+
+        const lockedConsistency = await app.verifyComponentConsistency(WORKSPACE_ID),
+              lockedMismatches  =
+                  lockedConsistency?.mismatches || lockedConsistency?.result?.mismatches || [];
+
+        expect(lockedMismatches, 'the refused locked gesture leaves every render surface exact')
+            .toEqual([]);
+
+        await actionButton(main, 'fa-lock-open').click();
+        await expect.poll(async () => (await readDocument()).items.alpha.locked).toBe(false);
+        await expect(tabButton(main, 'Alpha')).toHaveClass(/neo-draggable/);
+
+        await app.getDragTrace(true);
+        await dragAfter(page, tabButton(main, 'Alpha'), tabButton(main, 'Beta'));
+
+        let unlockedEnd;
+
+        await expect.poll(async () => {
+            const traceData = await app.getDragTrace(),
+                  traces    = traceData?.traces || traceData?.result?.traces || [],
+                  trace     = traces[traces.length - 1];
+
+            unlockedEnd = trace?.events?.find(event => event.t === 'end') || null;
+
+            return unlockedEnd
+        }, {message: 'the restored SortZone commits the one-slot reorder'})
+            .toMatchObject({from: 0, to: 1});
+
+        expect(unlockedEnd.noop).not.toBe(true);
+
+        await expect.poll(async () => (await readDocument()).nodes['main-tabs'].items)
+            .toEqual(['beta', 'alpha']);
+        await awaitRefresh(1);
+
+        await actionButton(main, 'fa-times').click();
+        await expect.poll(async () => Boolean((await readDocument()).items.alpha)).toBe(false);
+        await awaitRefresh(2);
+    })
+});

--- a/test/playwright/unit/dashboard/DockLayoutAdapter.spec.mjs
+++ b/test/playwright/unit/dashboard/DockLayoutAdapter.spec.mjs
@@ -551,13 +551,14 @@ test.describe('Neo.dashboard.dock.projection.LayoutAdapter', () => {
         expect(hostOwned.headerActions.map(action => action.action)).toEqual(['maximize'])
     });
 
-    test('reload leads the engine set and reserves its name through the guard table', () => {
+    test('lock leads reload in the engine set and reload reserves its name through the guard table', () => {
         const
             model       = createModel(),
             resolvePane = componentRef => ({ntype: 'dashboard-panel', reference: componentRef}),
 
             enabled = DockLayoutAdapter.project(model, {
                 enableDockCloseAction   : true,
+                enableDockLockAction    : true,
                 enableDockMaximizeAction: true,
                 enableDockPinAction     : true,
                 enableDockReloadAction  : true,
@@ -566,15 +567,15 @@ test.describe('Neo.dashboard.dock.projection.LayoutAdapter', () => {
 
             enabledMain = getProjectedChildren(enabled)[0];
 
-        // The frozen family order: reload leads the engine set, close stays last.
+        // The frozen family order: lock leads reload in the engine set; close stays last.
         expect(enabledMain.headerActions.map(action => action.action))
-            .toEqual(['reload', 'pin', 'maximize', 'close']);
+            .toEqual(['lock', 'reload', 'pin', 'maximize', 'close']);
 
         // Focus-gated like its engine siblings — no `contextual` opt-out — and it SHIPS hidden:
         // availability is a live-card contract probe only the workspace can run post-mount.
-        expect(enabledMain.headerActions[0].contextual).toBeUndefined();
-        expect(enabledMain.headerActions[0].hidden).toBe(true);
-        expect(enabledMain.headerActions[0].iconCls).toBe('fa fa-rotate-right');
+        expect(enabledMain.headerActions[1].contextual).toBeUndefined();
+        expect(enabledMain.headerActions[1].hidden).toBe(true);
+        expect(enabledMain.headerActions[1].iconCls).toBe('fa fa-rotate-right');
 
         // Off = byte-identical: no reload entry materialises for the flag alone.
         const withoutReload = getProjectedChildren(DockLayoutAdapter.project(model, {
@@ -1231,7 +1232,7 @@ test.describe('Neo.dashboard.dock.projection.LayoutAdapter', () => {
         test('a workspace boundary enables ordinary cross-zone motion without arming tear-out', () => {
             const result = DockLayoutAdapter.project(createModel(), {
                 dockWorkspaceBoundaryContainerId: 'dock-workspace-root',
-                resolveComponentRef              : componentRef => ({ntype: 'dashboard-panel', reference: componentRef})
+                resolveComponentRef             : componentRef => ({ntype: 'dashboard-panel', reference: componentRef})
             });
             const config = result.items[0].headerToolbar.sortZoneConfig;
 

--- a/test/playwright/unit/dashboard/DockLockAction.spec.mjs
+++ b/test/playwright/unit/dashboard/DockLockAction.spec.mjs
@@ -133,15 +133,19 @@ test.describe('Neo.dashboard.dock.Workspace lock action', () => {
         document.items.alpha.locked = true;
 
         let tabs = findTabsConfig(LayoutAdapter.project(document, {
-            dockLockIconCls    : 'lock-action',
-            dockUnlockIconCls  : 'unlock-action',
+            dockLockIconCls      : 'lock-action',
+            dockUnlockIconCls    : 'unlock-action',
             enableDockCloseAction: true,
             enableDockLockAction : true,
             resolveComponentRef  : () => ({ntype: 'component'})
         }));
 
         expect(tabs.headerActions.find(action => action.action === 'lock'))
-            .toMatchObject({hidden: false, iconCls: 'unlock-action'});
+            .toMatchObject({
+                hidden : false,
+                iconCls: 'unlock-action',
+                vdom   : {'aria-label': 'unlock'}
+            });
         expect(tabs.headerActions.find(action => action.action === 'close').hidden).toBe(true);
 
         document.items.alpha.lockable = false;
@@ -167,8 +171,8 @@ test.describe('Neo.dashboard.dock.Workspace lock action', () => {
                       }
                   },
                   nodes: {
-                      root        : {type: 'edge-zone', zones: {right: {nodeId: 'edge-tabs'}}},
-                      'edge-tabs' : {type: 'tabs', items: ['railed'], activeItemId: 'railed'}
+                      root       : {type: 'edge-zone', zones: {right: {nodeId: 'edge-tabs'}}},
+                      'edge-tabs': {type: 'tabs', items: ['railed'], activeItemId: 'railed'}
                   }
               },
               syncPane = () => {},
@@ -209,11 +213,11 @@ test.describe('Neo.dashboard.dock.Workspace lock action', () => {
 
     test('locks and unlocks the real pane, action, close affordance, and tab drag source', () => {
         workspace = Neo.create(LockWorkspace, {
-            dockModel             : createDocument(),
-            dockLockIconCls       : 'lock-action',
-            dockUnlockIconCls     : 'unlock-action',
-            enableDockCloseAction : true,
-            enableDockLockAction  : true
+            dockModel            : createDocument(),
+            dockLockIconCls      : 'lock-action',
+            dockUnlockIconCls    : 'unlock-action',
+            enableDockCloseAction: true,
+            enableDockLockAction : true
         });
 
         const tabContainer = Reconciler.collectProjectedTabs(workspace.items[0]).get('main-tabs'),
@@ -236,6 +240,10 @@ test.describe('Neo.dashboard.dock.Workspace lock action', () => {
         expect(pane.cls).toContain('neo-dock-pane-locked');
         expect(tabButton.wrapperCls).not.toContain('neo-draggable');
         expect(lockAction.iconCls).toBe('unlock-action');
+        expect(lockAction.vdom['aria-label']).toBe('unlock');
+        expect(lockAction.showOnFocus, 'the reversal stays persistent while the lock persists').toBe(false);
+        expect(lockAction.cls).not.toContain('neo-toolbar-action-context-inactive');
+        expect(lockAction.vdom.inert).toBeUndefined();
         expect(closeAction.hidden).toBe(true);
 
         const unlocked = workspace.handleDockLockAction({dockNodeId: 'main-tabs', tabContainer});
@@ -247,6 +255,10 @@ test.describe('Neo.dashboard.dock.Workspace lock action', () => {
         expect(pane.cls).not.toContain('neo-dock-pane-locked');
         expect(tabButton.wrapperCls).toContain('neo-draggable');
         expect(lockAction.iconCls).toBe('lock-action');
+        expect(lockAction.vdom['aria-label']).toBe('lock');
+        expect(lockAction.showOnFocus, 'unlock restores the family focus gate').toBe(true);
+        expect(lockAction.cls).toContain('neo-toolbar-action-context-inactive');
+        expect(lockAction.vdom.inert).toBe(true);
         expect(closeAction.hidden).toBe(false)
     });
 

--- a/test/playwright/unit/dashboard/DockLockAction.spec.mjs
+++ b/test/playwright/unit/dashboard/DockLockAction.spec.mjs
@@ -1,0 +1,276 @@
+import {setup} from '../../setup.mjs';
+
+setup({
+    appConfig: {
+        name: 'NeoDashboardDockLockActionTest'
+    }
+});
+
+import {test, expect} from '@playwright/test';
+import Neo            from '../../../../src/Neo.mjs';
+import * as core      from '../../../../src/core/_export.mjs';
+import DockWorkspace  from '../../../../src/dashboard/dock/Workspace.mjs';
+import LayoutAdapter  from '../../../../src/dashboard/dock/projection/LayoutAdapter.mjs';
+import Reconciler     from '../../../../src/dashboard/dock/projection/Reconciler.mjs';
+import '../../../../src/manager/Instance.mjs';
+import '../../../../src/tab/Container.mjs';
+
+/**
+ * @summary Creates the minimal committed document for the engine-owned lock action.
+ * @returns {Object}
+ */
+function createDocument() {
+    return {
+        schema: 'neo.dock.zone.v1',
+        root  : 'main-tabs',
+        items : {
+            alpha: {componentRef: 'alpha', title: 'Alpha', kind: 'panel'},
+            beta : {componentRef: 'beta',  title: 'Beta',  kind: 'panel'}
+        },
+        nodes: {
+            'main-tabs': {type: 'tabs', items: ['alpha', 'beta'], activeItemId: 'alpha'}
+        }
+    }
+}
+
+/**
+ * @summary Workspace fixture that mounts the real projected tab composition once.
+ */
+class LockWorkspace extends DockWorkspace {
+    static config = {
+        className: 'Test.Unit.Dashboard.DockLockAction.Workspace',
+        layout   : {ntype: 'vbox', align: 'stretch'}
+    }
+
+    construct(config) {
+        super.construct(config);
+        this.add(this.projectDockModel())
+    }
+}
+
+LockWorkspace = Neo.setupClass(LockWorkspace);
+
+/**
+ * @summary Returns the first projected tabs config from a projection tree.
+ * @param {Object} config
+ * @returns {Object|null}
+ */
+function findTabsConfig(config) {
+    if (config?.dockNodeType === 'tabs') {
+        return config
+    }
+
+    for (const child of config?.items || []) {
+        const match = findTabsConfig(child);
+
+        if (match) {
+            return match
+        }
+    }
+
+    return null
+}
+
+/**
+ * @summary Returns the first projected config carrying one dock node type.
+ * @param {Object} config
+ * @param {String} dockNodeType
+ * @returns {Object|null}
+ */
+function findDockConfig(config, dockNodeType) {
+    if (config?.dockNodeType === dockNodeType) {
+        return config
+    }
+
+    for (const child of config?.items || []) {
+        const match = findDockConfig(child, dockNodeType);
+
+        if (match) {
+            return match
+        }
+    }
+
+    return null
+}
+
+test.describe('Neo.dashboard.dock.Workspace lock action', () => {
+    let workspace;
+
+    test.afterEach(() => {
+        workspace?.destroy?.();
+        workspace = null
+    });
+
+    test('projects byte-identically while off, then owns the frozen leading slot and name while on', () => {
+        const document = createDocument(),
+              project  = extra => LayoutAdapter.project(document, {
+                  resolveComponentRef: () => ({ntype: 'component'}),
+                  ...extra
+              }),
+              baseline = project({}),
+              off      = project({enableDockLockAction: false});
+
+        expect(JSON.stringify(off)).toBe(JSON.stringify(baseline));
+        expect(findTabsConfig(project({
+            enableDockCloseAction   : true,
+            enableDockLockAction    : true,
+            enableDockMaximizeAction: true
+        })).headerActions.map(action => action.action)).toEqual(['lock', 'maximize', 'close']);
+
+        expect(findTabsConfig(project({
+            resolveDockHeaderActions: () => [{action: 'lock'}]
+        })).headerActions.map(action => action.action)).toEqual(['lock']);
+
+        expect(() => project({
+            enableDockLockAction    : true,
+            resolveDockHeaderActions: () => [{action: 'lock'}]
+        })).toThrow(/"lock" is reserved while enableDockLockAction is on/)
+    });
+
+    test('derives initial icon, policy visibility, and locked close state from the committed item', () => {
+        const document = createDocument();
+
+        document.items.alpha.locked = true;
+
+        let tabs = findTabsConfig(LayoutAdapter.project(document, {
+            dockLockIconCls    : 'lock-action',
+            dockUnlockIconCls  : 'unlock-action',
+            enableDockCloseAction: true,
+            enableDockLockAction : true,
+            resolveComponentRef  : () => ({ntype: 'component'})
+        }));
+
+        expect(tabs.headerActions.find(action => action.action === 'lock'))
+            .toMatchObject({hidden: false, iconCls: 'unlock-action'});
+        expect(tabs.headerActions.find(action => action.action === 'close').hidden).toBe(true);
+
+        document.items.alpha.lockable = false;
+        tabs = findTabsConfig(LayoutAdapter.project(document, {
+            enableDockLockAction: true,
+            resolveComponentRef : () => ({ntype: 'component'})
+        }));
+
+        expect(tabs.headerActions.find(action => action.action === 'lock').hidden).toBe(true)
+    });
+
+    test('threads committed lock truth to a railed reveal pane without suppressing reveal', () => {
+        const document = {
+                  schema: 'neo.dock.zone.v1',
+                  root  : 'root',
+                  items : {
+                      railed: {
+                          componentRef: 'railed',
+                          title       : 'Railed',
+                          kind        : 'panel',
+                          autoHidden  : true,
+                          locked      : true
+                      }
+                  },
+                  nodes: {
+                      root        : {type: 'edge-zone', zones: {right: {nodeId: 'edge-tabs'}}},
+                      'edge-tabs' : {type: 'tabs', items: ['railed'], activeItemId: 'railed'}
+                  }
+              },
+              syncPane = () => {},
+              rail     = findDockConfig(LayoutAdapter.project(document, {
+                  resolveComponentRef: () => ({ntype: 'component'}),
+                  syncDockLockPane   : syncPane
+              }), 'edge-rail');
+
+        expect(rail, 'the locked auto-hidden item still projects its reveal affordance').toBeTruthy();
+        expect(rail.railItems).toEqual([{
+            dockEdge  : 'right',
+            dockItemId: 'railed',
+            restorable: true,
+            title     : 'Railed'
+        }]);
+        expect(rail.syncDockLockPane).toBe(syncPane)
+    });
+
+    test('an empty retained-tabs map falls back to the fresh projected shell', () => {
+        const document = createDocument();
+
+        document.items.alpha.locked = true;
+        workspace = Neo.create(LockWorkspace, {
+            dockModel           : document,
+            enableDockLockAction: true
+        });
+
+        const tabContainer = Reconciler.collectProjectedTabs(workspace.items[0]).get('main-tabs'),
+              pane         = tabContainer.getActiveCard();
+
+        expect(Object.hasOwn(pane.vdom, 'inert')).toBe(false);
+
+        workspace.syncDockHeaderActions(new Map());
+
+        expect(pane.vdom.inert).toBe(true);
+        expect(pane.cls).toContain('neo-dock-pane-locked')
+    });
+
+    test('locks and unlocks the real pane, action, close affordance, and tab drag source', () => {
+        workspace = Neo.create(LockWorkspace, {
+            dockModel             : createDocument(),
+            dockLockIconCls       : 'lock-action',
+            dockUnlockIconCls     : 'unlock-action',
+            enableDockCloseAction : true,
+            enableDockLockAction  : true
+        });
+
+        const tabContainer = Reconciler.collectProjectedTabs(workspace.items[0]).get('main-tabs'),
+              pane         = tabContainer.getActiveCard(),
+              tabButton    = tabContainer.getTabButtons()[0],
+              lockAction   = tabContainer.getActionItem('lock'),
+              closeAction  = tabContainer.getActionItem('close');
+
+        pane.vdom.inert = false;
+        tabButton.addWrapperCls('neo-draggable');
+        workspace.syncDockHeaderActions();
+
+        expect(tabButton.wrapperCls).toContain('neo-draggable');
+
+        const locked = workspace.handleDockLockAction({dockNodeId: 'main-tabs', tabContainer});
+
+        expect(locked.errors).toEqual([]);
+        expect(workspace.dockModel.items.alpha.locked).toBe(true);
+        expect(pane.vdom.inert).toBe(true);
+        expect(pane.cls).toContain('neo-dock-pane-locked');
+        expect(tabButton.wrapperCls).not.toContain('neo-draggable');
+        expect(lockAction.iconCls).toBe('unlock-action');
+        expect(closeAction.hidden).toBe(true);
+
+        const unlocked = workspace.handleDockLockAction({dockNodeId: 'main-tabs', tabContainer});
+
+        expect(unlocked.errors).toEqual([]);
+        expect(workspace.dockModel.items.alpha.locked).toBe(false);
+        expect(Object.hasOwn(pane.vdom, 'inert')).toBe(true);
+        expect(pane.vdom.inert).toBe(false);
+        expect(pane.cls).not.toContain('neo-dock-pane-locked');
+        expect(tabButton.wrapperCls).toContain('neo-draggable');
+        expect(lockAction.iconCls).toBe('lock-action');
+        expect(closeAction.hidden).toBe(false)
+    });
+
+    test('restores absent inert ownership and fails closed for lockable false', () => {
+        const document = createDocument();
+
+        document.items.alpha.lockable = false;
+        workspace = Neo.create(LockWorkspace, {
+            dockModel           : document,
+            enableDockLockAction: true
+        });
+
+        const tabContainer = Reconciler.collectProjectedTabs(workspace.items[0]).get('main-tabs'),
+              pane         = tabContainer.getActiveCard(),
+              refused      = workspace.handleDockLockAction({dockNodeId: 'main-tabs', tabContainer});
+
+        expect(refused.document).toBe(workspace.dockModel);
+        expect(refused.errors.join(' ')).toContain('not lockable');
+        expect(Object.hasOwn(pane.vdom, 'inert')).toBe(false);
+
+        workspace.dockModel.items.alpha.lockable = true;
+        workspace.handleDockLockAction({dockNodeId: 'main-tabs', tabContainer});
+        workspace.handleDockLockAction({dockNodeId: 'main-tabs', tabContainer});
+
+        expect(Object.hasOwn(pane.vdom, 'inert')).toBe(false)
+    })
+});

--- a/test/playwright/unit/dashboard/DockZoneModel.spec.mjs
+++ b/test/playwright/unit/dashboard/DockZoneModel.spec.mjs
@@ -110,6 +110,20 @@ test.describe('Neo.dashboard.dock.model.Document', () => {
             expect(Document.validate(doc())).toEqual([])
         });
 
+        test('treats absent lock state as unlocked and rejects non-boolean lock fields', () => {
+            const input = doc();
+
+            expect(input.items.strategy.locked).toBeUndefined();
+            expect(Document.validate(input)).toEqual([]);
+
+            input.items.strategy.locked = 'true';
+            expect(Document.validate(input).join(' ')).toContain('locked must be a boolean');
+
+            input.items.strategy.locked   = false;
+            input.items.strategy.lockable = 'false';
+            expect(Document.validate(input).join(' ')).toContain('lockable must be a boolean')
+        });
+
         test('rejects a wrong schema', () => {
             const d = doc();
             d.schema = 'neo.dock.zone.v2';
@@ -202,6 +216,26 @@ test.describe('Neo.dashboard.dock.model.Document', () => {
             expect(restored.errors).toEqual([]);
             expect(restored.document).toEqual(layout.dockZone);
             expect(restored.document).not.toBe(layout.dockZone)
+        });
+
+        test('round-trips committed lock state and policy through a perspective', () => {
+            const input = doc();
+
+            input.items.strategy.locked   = true;
+            input.items.strategy.lockable = false;
+
+            const {layout, errors} = Persistence.createSavedLayout(input, {
+                layoutId: 'locked-workspace',
+                title   : 'Locked Workspace'
+            });
+
+            expect(errors).toEqual([]);
+            expect(layout.dockZone.items.strategy).toMatchObject({locked: true, lockable: false});
+
+            const restored = Persistence.restoreSavedLayout(layout);
+
+            expect(restored.errors).toEqual([]);
+            expect(restored.document.items.strategy).toMatchObject({locked: true, lockable: false})
         });
 
         test('fails closed for unsupported wrapper schema', () => {
@@ -1556,6 +1590,96 @@ test.describe('Neo.dashboard.dock.model.Document', () => {
             const pinned = Operations.setItemAutoHidden(pinnedInput, {itemId: 'terminal', autoHidden: true});
             expect(pinned.document).toBe(pinnedInput);
             expect(pinned.errors.join(' ')).toContain('pinned')
+        })
+    });
+
+    test.describe('setItemLocked', () => {
+        test('updates committed lock state without mutating caller input', () => {
+            const input    = doc(),
+                  snapshot = JSON.stringify(input),
+                  locked   = Operations.applyOperation(input, {
+                      operation: 'setItemLocked',
+                      itemId   : 'strategy',
+                      locked   : true
+                  });
+
+            expect(locked.errors).toEqual([]);
+            expect(locked.document.items.strategy.locked).toBe(true);
+            expect(JSON.stringify(input)).toBe(snapshot);
+            expect(input.items.strategy.locked).toBeUndefined();
+
+            const unlocked = Operations.setItemLocked(locked.document, {
+                itemId: 'strategy',
+                locked: false
+            });
+
+            expect(unlocked.errors).toEqual([]);
+            expect(unlocked.document.items.strategy.locked).toBe(false)
+        });
+
+        test('fails closed for unknown items, non-boolean state, and non-lockable items', () => {
+            const input = doc();
+
+            input.items.strategy.lockable = false;
+
+            for (const result of [
+                Operations.setItemLocked(input, {itemId: 'ghost', locked: true}),
+                Operations.setItemLocked(input, {itemId: 'strategy', locked: 'true'}),
+                Operations.setItemLocked(input, {itemId: 'strategy', locked: true})
+            ]) {
+                expect(result.document).toBe(input);
+                expect(result.errors.length).toBeGreaterThan(0)
+            }
+        });
+
+        test('guards close, detach, cross-zone move, and the addTab reorder downgrade', () => {
+            const locked = Operations.setItemLocked(doc(), {itemId: 'strategy', locked: true});
+
+            expect(locked.errors).toEqual([]);
+
+            const snapshot = JSON.stringify(locked.document),
+                  attempts = [
+                      Operations.closeItem(locked.document, {itemId: 'strategy'}),
+                      Operations.detachItem(locked.document, {itemId: 'strategy'}),
+                      Operations.moveItem(locked.document, {itemId: 'strategy', targetNodeId: 'side-tabs'}),
+                      Operations.applyOperation(locked.document, {
+                          operation : 'addTab',
+                          itemId    : 'strategy',
+                          tabsNodeId: 'side-tabs',
+                          index     : 0
+                      })
+                  ];
+
+            for (const result of attempts) {
+                expect(result.document).toBe(locked.document);
+                expect(result.errors.join(' ')).toContain('locked');
+                expect(JSON.stringify(locked.document)).toBe(snapshot)
+            }
+        });
+
+        test('keeps locked headers as drop targets and restores structural operations after unlock', () => {
+            const locked = Operations.setItemLocked(doc(), {itemId: 'terminal', locked: true});
+
+            expect(locked.errors).toEqual([]);
+
+            const intoLockedNode = Operations.moveItem(locked.document, {
+                itemId      : 'strategy',
+                targetNodeId: 'side-tabs',
+                index       : 0
+            });
+
+            expect(intoLockedNode.errors).toEqual([]);
+            expect(intoLockedNode.document.nodes['side-tabs'].items).toEqual(['strategy', 'terminal']);
+
+            const unlocked = Operations.setItemLocked(locked.document, {itemId: 'terminal', locked: false});
+
+            expect(unlocked.errors).toEqual([]);
+            expect(Operations.closeItem(unlocked.document, {itemId: 'terminal'}).errors).toEqual([]);
+            expect(Operations.detachItem(unlocked.document, {itemId: 'terminal'}).errors).toEqual([]);
+            expect(Operations.moveItem(unlocked.document, {
+                itemId      : 'terminal',
+                targetNodeId: 'main-tabs'
+            }).errors).toEqual([])
         })
     });
 

--- a/test/playwright/unit/tab/HeaderActions.spec.mjs
+++ b/test/playwright/unit/tab/HeaderActions.spec.mjs
@@ -427,6 +427,43 @@ test.describe.serial('Neo tab header actions', () => {
         expect(legacyGated.showOnFocus).toBe(true)
     });
 
+    test('a live action can leave and re-enter the focus gate without retaining toolbar-owned inert state', () => {
+        const tabs = own(Neo.create(TabContainer, {
+                  headerActions: [
+                      {action: 'reversible', iconCls: 'fa fa-lock'},
+                      {action: 'sibling',    iconCls: 'fa fa-thumbtack'}
+                  ],
+                  items        : [{module: Component, header: {text: 'One'}}]
+              })),
+              action = tabs.getActionItem('reversible'),
+              sibling = tabs.getActionItem('sibling'),
+              bar    = tabs.getTabBar();
+
+        // The tab header defaults to gated and starts outside focus.
+        expect(action.cls).toContain('neo-toolbar-action-context-inactive');
+        expect(action.vdom).toMatchObject({'aria-hidden': 'true', inert: true, tabIndex: -1});
+
+        // A persistent protective state can keep its reversal discoverable outside transient
+        // focus. The toolbar owns this inert/aria/tab-index layer, so leaving the gate must release
+        // exactly it.
+        action.showOnFocus = false;
+        bar.applyContextualActionState(true);
+
+        expect(action.cls).not.toContain('neo-toolbar-action-context-inactive');
+        expect(action.vdom.inert).toBeUndefined();
+        expect(action.vdom['aria-hidden']).toBeUndefined();
+        expect(action.vdom.tabIndex).toBeUndefined();
+        expect(sibling.cls, 'the exception releases only the reversal').toContain('neo-toolbar-action-context-inactive');
+        expect(sibling.vdom.inert).toBe(true);
+
+        // Returning to the ordinary gate while focus is still outside re-arms the same instance.
+        action.showOnFocus = true;
+        bar.applyContextualActionState(true);
+
+        expect(action.cls).toContain('neo-toolbar-action-context-inactive');
+        expect(action.vdom).toMatchObject({'aria-hidden': 'true', inert: true, tabIndex: -1})
+    });
+
     test('a mixed actionDefaults lets the CURRENT key decide, not the deprecated one', () => {
         const container = own(Neo.create(BaseContainer, {
                   items: [{


### PR DESCRIPTION
Resolves #17949

Dock items now carry an additive committed `locked` state and `lockable` policy. The model rejects close, detach, and source movement while locked; DockWorkspace projects one stable toggle at the frozen leading slot that derives inert pane presentation, close visibility, and tab drag-source admission from the committed document. Lock is focus-gated while unlocked; its unlock reversal stays persistent while the protective state persists, with accessible label and glyph moving together. Unlock restores exact prior inert and drag-token ownership, including independently inert panes and live rail reveals.

Decision Record impact: amends ADR 0029 §2.1 with the committed lock state, model boundary, and projection/runtime-state classification.

Evidence: L3 (exact-head real Chrome component probes plus a Neural Link gesture journey) → L3 required (browser-visible inert, pointer/keyboard, rail, close, and drag ACs). #17949 residuals: none. Branch-level CI remains gated by existing #17980's duplicate-chrome check; that is a prerequisite, not a #17949 residual.

## AC Evidence
| AC-1 | CI-covered: `DockLockAction.spec.mjs` proves byte-identical default-off projection, frozen lock-before-reload order, unlocked focus gating, locked persistence, accessible lock/unlock names, and the reserved host name. |
| AC-2 | CI + L3: `DockZoneModel.spec.mjs` proves `setItemLocked(true)`; `DockLock.spec.mjs` proves rendered inert, close hiding, drag-token removal, and the solid locked cue. |
| AC-3 | CI-covered: `DockZoneModel.spec.mjs` proves close, detach, moveItem, and the in-tree addTab→moveItem downgrade reject byte-identically while locked. |
| AC-4 | CI + L3: `DockLock.spec.mjs` proves pointer/keyboard and presentation restoration plus an actionable unlock with focus deliberately outside the dock; `DockLockActionNL.spec.mjs` proves the restored drag and close gestures commit. |
| AC-5 | CI-covered: saved-layout create/restore round-trips `locked` and `lockable`; a legacy item with neither remains valid and unlocked. |
| AC-6 | L3: a pane that independently owns `inert:true` survives lock→unlock with the same ownership/value; a pane with no property restores to no property. |
| AC-7 | CI + L3: direct reducer calls and the live TabContainer `close` event reject while presentation is bypassed; the model is the independent boundary. |
| AC-8 | L3 outside CI: the Whitebox journey locks, refuses stale close and real drag with zero surface drift, unlocks, commits the semantic 0→1 reorder, and closes the item. |

## Deltas from ticket

- A locked auto-hidden item remains revealable. Because stable-topology reconciliation retains synthetic rails, Workspace supplies the initial materialization callback and also synchronizes an already-open rail pane directly after the sole `dockModel` write.
- An empty retained-tabs map now falls back to the fresh shell walk; otherwise a newly materialized lock surface could miss its first sync.
- No permission semantics, workspace-wide lock, or non-active header affordance was added.
- Integration note: merged reload/header-chrome siblings `#17974`, `#17977`, and pop-out sibling `#17970` are composed at the current `origin/dev@e6dd69891c`. The rebase retained both lock and pop-out ownership, routing, reserved-name rows, and browser witnesses.
- The first full-CI component run exposed the lock witness asserting before reconciliation settled (with the red roaming into reload on the slower runner). The fixture already owned a semantic `refreshPromise` probe but the spec did not consume it. The corrected witness awaits that probe at every lock/unlock boundary; no retry, timeout, or production delay was added. It also narrows the rail assertion to the ticket contract: locked items remain revealable, and unlock restores interaction on the next reveal; transient overlay persistence is state-machine policy, not lock semantics.
- Two later CI runs proved the merged reload duplicate survives after a consumer awaits `refreshPromise`: one toolbar still contains two reload nodes with the same id. The test-side settle bridge was therefore removed; #17982 keeps the strict arity instrument and is a hard dependency on #17980's production collision fix, to be stacked once that PR is approved.
- The third CI run reached the lock witness itself: `waitForSelector` saw the fixture's initial shell before its boot refresh settled, so the spec attached its physical-click listener to the control that reconciliation replaced. `beforeEach` now consumes the same semantic settlement before any DOM identity is captured.
- The next exact CI receipt found one unlock action—no duplicate—but still context-inactive after focus left. The ticket-author re-measurement proved header focus could recover it, falsifying an initial unreachability explanation while preserving the UX defect: a persistent protective state hid its reversal behind transient focus. The accepted contract now keeps only unlock persistent while locked; sibling engine actions stay gated. A deterministic outside-focus arm proves the exception and its re-arm after unlock.
- The same receipt exposed `aria-label="lock"` under the unlock glyph. Initial projection and retained-instance sync now derive both from the same committed `locked` truth, with unit and rendered assertions in both directions.
- The implementation had drifted to reload-before-lock even though the cross-leaf contract already froze lock-before-reload. This PR now conforms the implementation and documents that it did not move the family contract.

## Test Evidence

- Full unit corpus on rebased head `de8edcf52a`: 2649 passed / 28 skipped (2677 total).
- Exact-head L3 component battery: DockLock + merged DockPopOut 7/7. It proves the outside-focus unlock is visible, actionable, correctly named, and returns to focus gating; computed cue, physical pointer, keyboard exclusion, exact inert restoration, rail re-reveal, and all five pop-out arms also pass.
- Exact-head L3 Whitebox command with explicit Brain runtime root: `DockLockActionNL.spec.mjs` — 1/1; Neural Link observed committed lock/operation truth, the SortZone trace, refused stale gestures, and restored close/drag commits.
- Static guards: block alignment clean; JSDoc type parse 1201/1201; fixed-sleep guard clean; `git diff --check` clean.
- Red controls: the pre-implementation model battery failed 6 new arms; the action battery failed all 4 initial arms; the rail live-unlock and empty-retained-map controls each failed before their owning sync; the final correction produced three independent red unit arms (gate release, locked reversal state, order) plus two red label/glyph arms before their repairs.

## Post-Merge Validation

None owed. The merged sibling-head rebase and combined-tree rerun are complete. Before this PR can become merge-eligible, #17980's production collision fix must land or be stacked and prove the strict duplicate-chrome check green; that is a pre-merge dependency, not deferred validation.

## Commits

- `625107aff3` — committed schema, reducer guards, persistence round-trip, ADR amendment
- `1b95b6eea2` — action projection, exact presentation restoration, rail composition, browser and Whitebox witnesses
- `de8edcf52a` — persistent unlock reversal, label/glyph parity, frozen order conformance, outside-focus proof

## Evolution

The rendered rail falsifier rejected duplicating `locked` into retained rail metadata: that copy does not refresh on stable-topology reconciliation. The final shape keeps one authority—current `dockModel`—and uses a Workspace-owned materialization callback plus commit/reconcile sweeps.

Related: #13158

Authored by Euclid (GPT-5.6 Sol Ultra, Codex Desktop) consuming Vega's ticket contract — session A 914dffcd-0057-46a5-a0c6-9ca807fd5c91, session B 01a0534f-a981-7560-93de-8d3d54966db6.
