### PR TITLE
fix(examples): the cross-window chrome guard names the term that failed (#17578)

### DIFF
--- a/examples/dashboard/crossWindow/DemoBWorkspace.mjs
+++ b/examples/dashboard/crossWindow/DemoBWorkspace.mjs
@@ -90,7 +90,7 @@ import '../../../src/toolbar/Base.mjs';  // registers the `toolbar` ntype the ba
  * @param {String[]} data.sourceItemIds Committed item ids for the source node.
  * @param {String} data.sourceNodeId Committed source node id.
  * @param {String} data.sourceWorkspaceId Committed source workspace id.
- * @returns {{chromeMismatch:Object,error:String|null,mismatchedTerms:String[]}}
+ * @returns {{chromeMismatch:Object,error:(String|null),mismatchedTerms:String[]}}
  */
 export const describeCrossWindowChromeMismatch = ({
     observedBarItemCount,

--- a/examples/dashboard/crossWindow/DemoBWorkspace.mjs
+++ b/examples/dashboard/crossWindow/DemoBWorkspace.mjs
@@ -2046,14 +2046,35 @@ class DemoBWorkspace extends Container {
                 }
             }
 
-            if (sourceTabs?.dockNodeId !== sourceNodeId
-                || sourceZone?.dockWorkspaceId !== sourceWorkspaceId
-                || sourceBar?.items?.length !== sourceItems.length
-                || projectedItems.length !== sourceItems.length
-                || projectedItems.some((projectedItemId, index) => projectedItemId !== sourceItems[index])) {
+            // Each term is observed SEPARATELY, for the same reason the coordinator observes its own
+            // claim candidates one by one (`manager/DragCoordinator#recordClaimResolution`): `||`
+            // short-circuits, so a single collapsed error string cannot distinguish a projection-identity
+            // mismatch from a tab-bar arity one. A receipt that proves the step aborted before any gesture
+            // started, but not on which term, cannot be re-run into an answer — the term is already gone.
+            let chromeMismatch = {
+                dockNodeId      : {expected: sourceNodeId,          actual: sourceTabs?.dockNodeId},
+                dockWorkspaceId : {expected: sourceWorkspaceId,     actual: sourceZone?.dockWorkspaceId},
+                barItemCount    : {expected: sourceItems.length,    actual: sourceBar?.items?.length},
+                projectedCount  : {expected: sourceItems.length,    actual: projectedItems.length},
+                projectedItemIds: {expected: [...sourceItems],      actual: [...projectedItems]}
+            };
+
+            // `barItemCount` compares the tab bar's rendered children against the DOCUMENT's item count,
+            // so any header-action chrome the bar carries that is not a projected dock item makes the two
+            // disagree — the first term to suspect while header actions keep landing on that surface.
+            chromeMismatch.dockNodeId.mismatch       = chromeMismatch.dockNodeId.actual      !== sourceNodeId;
+            chromeMismatch.dockWorkspaceId.mismatch  = chromeMismatch.dockWorkspaceId.actual !== sourceWorkspaceId;
+            chromeMismatch.barItemCount.mismatch     = chromeMismatch.barItemCount.actual    !== sourceItems.length;
+            chromeMismatch.projectedCount.mismatch   = chromeMismatch.projectedCount.actual  !== sourceItems.length;
+            chromeMismatch.projectedItemIds.mismatch = projectedItems.some((projectedItemId, index) => projectedItemId !== sourceItems[index]);
+
+            let mismatchedTerms = Object.keys(chromeMismatch).filter(term => chromeMismatch[term].mismatch);
+
+            if (mismatchedTerms.length > 0) {
                 return {
                     applied: false,
-                    errors : ['source drag chrome does not match the current workspace document']
+                    errors : [`source drag chrome does not match the current workspace document: ${mismatchedTerms.join(', ')}`],
+                    debug  : {chromeMismatch}
                 }
             }
 

--- a/examples/dashboard/crossWindow/DemoBWorkspace.mjs
+++ b/examples/dashboard/crossWindow/DemoBWorkspace.mjs
@@ -64,6 +64,69 @@ import '../../../src/toolbar/Base.mjs';  // registers the `toolbar` ntype the ba
  * @class Neo.examples.dashboard.crossWindow.DemoBWorkspace
  * @extends Neo.container.Base
  */
+/**
+ * @summary Compares the observed source-drag chrome against the committed document, one term at a time.
+ *
+ * Each term is observed SEPARATELY, for the same reason the coordinator observes its own claim
+ * candidates one by one (`manager/DragCoordinator#recordClaimResolution`): `||` short-circuits, so a
+ * single collapsed error string cannot distinguish a projection-identity mismatch from a tab-bar arity
+ * one. A receipt that proves the step aborted before any gesture started, but not on which term, cannot
+ * be re-run into an answer — the term is already gone.
+ *
+ * Pure by construction: it takes values already read from the live chrome rather than the components
+ * that carry them, so the comparison is reachable from a unit spec without a rendered workspace. The
+ * caller owns the reads; this owns the verdict AND the message, so a collapse back to one generic
+ * receipt cannot happen on one side without failing the other's coverage.
+ *
+ * Every `actual` is normalized to `null` rather than left `undefined`: an absent surface is exactly
+ * when a term mismatches, and `JSON.stringify` DROPS undefined-valued keys — so the untotalled shape
+ * lost the field on precisely the failures it exists to explain. Verdicts are computed from the RAW
+ * observation before normalization, so the admitted/rejected population is unchanged by it.
+ * @param {Object} data
+ * @param {Number|undefined} data.observedBarItemCount Rendered tab-bar child count.
+ * @param {String|undefined} data.observedNodeId Live `dockNodeId` of the source tabs node.
+ * @param {String[]} [data.observedProjectedItemIds=[]] Live projected dock item ids.
+ * @param {String|undefined} data.observedWorkspaceId Live `dockWorkspaceId` of the source sort zone.
+ * @param {String[]} data.sourceItemIds Committed item ids for the source node.
+ * @param {String} data.sourceNodeId Committed source node id.
+ * @param {String} data.sourceWorkspaceId Committed source workspace id.
+ * @returns {{chromeMismatch:Object,error:String|null,mismatchedTerms:String[]}}
+ */
+export const describeCrossWindowChromeMismatch = ({
+    observedBarItemCount,
+    observedNodeId,
+    observedProjectedItemIds=[],
+    observedWorkspaceId,
+    sourceItemIds,
+    sourceNodeId,
+    sourceWorkspaceId
+}={}) => {
+    // `barItemCount` compares the tab bar's rendered children against the DOCUMENT's item count, so any
+    // header-action chrome the bar carries that is not a projected dock item makes the two disagree —
+    // the first term to suspect while header actions keep landing on that surface.
+    let chromeMismatch = {
+        dockNodeId      : {expected: sourceNodeId,           actual: observedNodeId,                 mismatch: observedNodeId          !== sourceNodeId},
+        dockWorkspaceId : {expected: sourceWorkspaceId,      actual: observedWorkspaceId,            mismatch: observedWorkspaceId     !== sourceWorkspaceId},
+        barItemCount    : {expected: sourceItemIds.length,   actual: observedBarItemCount,           mismatch: observedBarItemCount    !== sourceItemIds.length},
+        projectedCount  : {expected: sourceItemIds.length,   actual: observedProjectedItemIds.length, mismatch: observedProjectedItemIds.length !== sourceItemIds.length},
+        projectedItemIds: {expected: [...sourceItemIds],     actual: [...observedProjectedItemIds],  mismatch: observedProjectedItemIds.some((projectedItemId, index) => projectedItemId !== sourceItemIds[index])}
+    };
+
+    Object.values(chromeMismatch).forEach(term => {
+        term.actual = term.actual ?? null
+    });
+
+    let mismatchedTerms = Object.keys(chromeMismatch).filter(term => chromeMismatch[term].mismatch);
+
+    return {
+        chromeMismatch,
+        error: mismatchedTerms.length > 0
+            ? `source drag chrome does not match the current workspace document: ${mismatchedTerms.join(', ')}`
+            : null,
+        mismatchedTerms
+    }
+};
+
 class DemoBWorkspace extends Container {
     /**
      * Shared coordinator registry key for the two active Demo-B workspaces.
@@ -2046,36 +2109,18 @@ class DemoBWorkspace extends Container {
                 }
             }
 
-            // Each term is observed SEPARATELY, for the same reason the coordinator observes its own
-            // claim candidates one by one (`manager/DragCoordinator#recordClaimResolution`): `||`
-            // short-circuits, so a single collapsed error string cannot distinguish a projection-identity
-            // mismatch from a tab-bar arity one. A receipt that proves the step aborted before any gesture
-            // started, but not on which term, cannot be re-run into an answer — the term is already gone.
-            let chromeMismatch = {
-                dockNodeId      : {expected: sourceNodeId,          actual: sourceTabs?.dockNodeId},
-                dockWorkspaceId : {expected: sourceWorkspaceId,     actual: sourceZone?.dockWorkspaceId},
-                barItemCount    : {expected: sourceItems.length,    actual: sourceBar?.items?.length},
-                projectedCount  : {expected: sourceItems.length,    actual: projectedItems.length},
-                projectedItemIds: {expected: [...sourceItems],      actual: [...projectedItems]}
-            };
+            let {chromeMismatch, error: chromeError} = describeCrossWindowChromeMismatch({
+                observedBarItemCount    : sourceBar?.items?.length,
+                observedNodeId          : sourceTabs?.dockNodeId,
+                observedProjectedItemIds: projectedItems,
+                observedWorkspaceId     : sourceZone?.dockWorkspaceId,
+                sourceItemIds           : sourceItems,
+                sourceNodeId,
+                sourceWorkspaceId
+            });
 
-            // `barItemCount` compares the tab bar's rendered children against the DOCUMENT's item count,
-            // so any header-action chrome the bar carries that is not a projected dock item makes the two
-            // disagree — the first term to suspect while header actions keep landing on that surface.
-            chromeMismatch.dockNodeId.mismatch       = chromeMismatch.dockNodeId.actual      !== sourceNodeId;
-            chromeMismatch.dockWorkspaceId.mismatch  = chromeMismatch.dockWorkspaceId.actual !== sourceWorkspaceId;
-            chromeMismatch.barItemCount.mismatch     = chromeMismatch.barItemCount.actual    !== sourceItems.length;
-            chromeMismatch.projectedCount.mismatch   = chromeMismatch.projectedCount.actual  !== sourceItems.length;
-            chromeMismatch.projectedItemIds.mismatch = projectedItems.some((projectedItemId, index) => projectedItemId !== sourceItems[index]);
-
-            let mismatchedTerms = Object.keys(chromeMismatch).filter(term => chromeMismatch[term].mismatch);
-
-            if (mismatchedTerms.length > 0) {
-                return {
-                    applied: false,
-                    errors : [`source drag chrome does not match the current workspace document: ${mismatchedTerms.join(', ')}`],
-                    debug  : {chromeMismatch}
-                }
+            if (chromeError) {
+                return {applied: false, errors: [chromeError], debug: {chromeMismatch}}
             }
 
             if (!sourceButton || !sourceZone || !buttonRect || !targetRect

--- a/test/playwright/unit/examples/dashboard/crossWindow/DemoBWorkspace.spec.mjs
+++ b/test/playwright/unit/examples/dashboard/crossWindow/DemoBWorkspace.spec.mjs
@@ -10,13 +10,13 @@ import {test, expect} from '@playwright/test';
 import Neo            from '../../../../../../src/Neo.mjs';
 import * as core      from '../../../../../../src/core/_export.mjs';
 import '../../../../../../src/manager/Instance.mjs'; // defines Neo.get — the container child-add path resolves parents through it
-import Component                from '../../../../../../src/component/Base.mjs';
-import Container                from '../../../../../../src/container/Base.mjs';
-import DemoBWorkspace           from '../../../../../../examples/dashboard/crossWindow/DemoBWorkspace.mjs';
-import DockPreview              from '../../../../../../src/dashboard/dock/interaction/Preview.mjs';
-import DockProjectionReconciler from '../../../../../../src/dashboard/dock/projection/Reconciler.mjs';
-import Document                 from '../../../../../../src/dashboard/dock/model/Document.mjs';
-import Operations               from '../../../../../../src/dashboard/dock/model/Operations.mjs';
+import Component                                           from '../../../../../../src/component/Base.mjs';
+import Container                                           from '../../../../../../src/container/Base.mjs';
+import DemoBWorkspace, {describeCrossWindowChromeMismatch} from '../../../../../../examples/dashboard/crossWindow/DemoBWorkspace.mjs';
+import DockPreview                                         from '../../../../../../src/dashboard/dock/interaction/Preview.mjs';
+import DockProjectionReconciler                            from '../../../../../../src/dashboard/dock/projection/Reconciler.mjs';
+import Document                                            from '../../../../../../src/dashboard/dock/model/Document.mjs';
+import Operations                                          from '../../../../../../src/dashboard/dock/model/Operations.mjs';
 
 import {demoBTourScript, initialDocument} from '../../../../../../examples/dashboard/crossWindow/demoBPerspectives.mjs';
 
@@ -2015,5 +2015,97 @@ test.describe.serial('Neo.examples.dashboard.crossWindow.DemoBWorkspace', () => 
         expect(pane.isDestroyed).toBeTruthy();
 
         workspace = null
+    })
+});
+
+/**
+ * The per-conjunct chrome guard, exercised at the branch the executor consumes.
+ *
+ * `executeCrossWindowStep` reads the live chrome and hands the READ VALUES here, so the comparison
+ * is reachable without a rendered two-window workspace. These arms are what make the split load-
+ * bearing: a term that is miswired, renamed, reordered, or collapsed back into one generic receipt
+ * reds here rather than surviving to a live run that can only report that something disagreed.
+ */
+test.describe('describeCrossWindowChromeMismatch', () => {
+    const TERMS = ['dockNodeId', 'dockWorkspaceId', 'barItemCount', 'projectedCount', 'projectedItemIds'];
+
+    /**
+     * The agreeing observation: every arm below mutates exactly one field of this.
+     * @param {Object} [overrides]
+     * @returns {Object}
+     */
+    const observation = (overrides={}) => ({
+        observedBarItemCount    : 1,
+        observedNodeId          : 'main-tabs',
+        observedProjectedItemIds: ['workbench'],
+        observedWorkspaceId     : 'demo-b-main',
+        sourceItemIds           : ['workbench'],
+        sourceNodeId            : 'main-tabs',
+        sourceWorkspaceId       : 'demo-b-main',
+        ...overrides
+    });
+
+    test('agreeing chrome admits, and still reports every term', () => {
+        const {chromeMismatch, error, mismatchedTerms} = describeCrossWindowChromeMismatch(observation());
+
+        expect(error).toBeNull();
+        expect(mismatchedTerms).toEqual([]);
+
+        // Order is part of the contract: the receipt is read positionally by a human comparing two
+        // runs, so a reordering is a regression even though no verdict changes.
+        expect(Object.keys(chromeMismatch)).toEqual(TERMS);
+        Object.values(chromeMismatch).forEach(term => expect(term.mismatch).toBe(false))
+    });
+
+    // One mutation per conjunct. Each names the ONE term it must surface — an implementation that
+    // collapses the five into a single receipt fails all five, and one that miswires a term fails
+    // exactly that row. `projectedCount` shortens the observation instead of lengthening it: a longer
+    // list also trips `projectedItemIds`, which would stop the arm isolating a single term.
+    const isolations = [
+        ['dockNodeId',       {observedNodeId: 'popup-tabs'}],
+        ['dockWorkspaceId',  {observedWorkspaceId: 'demo-b-popup'}],
+        ['barItemCount',     {observedBarItemCount: 2}],
+        ['projectedCount',   {observedProjectedItemIds: []}],
+        ['projectedItemIds', {observedProjectedItemIds: ['other']}]
+    ];
+
+    isolations.forEach(([term, override]) => {
+        test(`a ${term} disagreement rejects, naming ${term} alone`, () => {
+            const {chromeMismatch, error, mismatchedTerms} = describeCrossWindowChromeMismatch(observation(override));
+
+            expect(mismatchedTerms).toEqual([term]);
+            expect(chromeMismatch[term].mismatch).toBe(true);
+
+            // The prefix is the part a live run greps for; the suffix is the whole point of the split.
+            expect(error).toBe(`source drag chrome does not match the current workspace document: ${term}`)
+        })
+    });
+
+    test('the receipt survives JSON: absent surfaces keep their actual field as null', () => {
+        // Every optional read is undefined at once — the shape a step that aborts before the chrome
+        // exists actually produces, and precisely when the diagnostic matters most.
+        const {chromeMismatch, mismatchedTerms} = describeCrossWindowChromeMismatch(observation({
+            observedBarItemCount    : undefined,
+            observedNodeId          : undefined,
+            observedProjectedItemIds: undefined,
+            observedWorkspaceId     : undefined
+        }));
+
+        expect(mismatchedTerms).toEqual(['dockNodeId', 'dockWorkspaceId', 'barItemCount', 'projectedCount']);
+
+        // Non-vacuity: assert the pre-transport shape first, so the round trip below is evidence about
+        // SERIALIZATION rather than about the object having been empty all along.
+        expect(chromeMismatch.dockNodeId).toEqual({expected: 'main-tabs', actual: null, mismatch: true});
+
+        const roundTripped = JSON.parse(JSON.stringify(chromeMismatch));
+
+        mismatchedTerms.forEach(term => {
+            expect(Object.keys(roundTripped[term]).sort()).toEqual(['actual', 'expected', 'mismatch'])
+        });
+
+        // The falsifier for the repair: an undefined `actual` is DROPPED by JSON.stringify, so this
+        // same assertion against the un-normalized shape finds `actual` missing on all four rows.
+        expect(roundTripped.dockNodeId.actual).toBeNull();
+        expect(roundTripped.barItemCount.actual).toBeNull()
     })
 });


### PR DESCRIPTION
Refs #17578 — **does not close it.** This lands the instrument that ticket's own measurement asked for; the diagnosis it enables is still outstanding.

The Demo-B cross-window step aborts *before any gesture starts*. The receipt proves where the leg stops but not why, because a five-way conjunction is reported as one collapsed string:

```
{"applied": false, "errors": ["source drag chrome does not match the current workspace document"], ...}
```

`||` short-circuits, so the term that fired is gone by the time the receipt is written — and no amount of re-running the tour recovers it. That ambiguity is what stranded the ticket: the abort cannot be attributed to a projection-identity mismatch rather than a tab-bar arity one, and those point at completely different code.

The engine already solved this one directory away. `manager/DragCoordinator#recordClaimResolution` observes each claim candidate separately, with the comment saying exactly why — it "cannot distinguish 'the zone refused' from 'the zone was never asked'". This applies that idiom to the demo executor's precondition guard.

Evidence: L1 (source-level; the guard admits and rejects exactly the same states, verified by construction — each term is the original expression, unchanged, with its result captured instead of discarded). Residual: **the instrument has not been fired against the live two-window repro.** That run is what names the term, and it is the next step on the ticket, not part of this PR. I am not claiming a diagnosis here.

## What changed

| | |
|---|---|
| Behaviour | none — same admit/reject set |
| `errors[0]` | keeps its original prefix, gains the failing term names |
| `debug.chromeMismatch` | new: per-term `{expected, actual, mismatch}`, riding the `debug` slot the executor's other returns already use |

The five terms, now individually observable: `dockNodeId`, `dockWorkspaceId`, `barItemCount`, `projectedCount`, `projectedItemIds`.

## The term I would look at first

`barItemCount` compares the tab bar's **rendered children** against the **document's** item count. Any chrome the bar carries that is not a projected dock item makes those disagree — and header actions have been landing on that surface all week (#17423, #17950, #17951/#17960). That is stated as a hypothesis in the code comment's neighbourhood and in the ticket, **not** as a finding: I have not measured which term fires. Do not bank it.

## Verification

- `node --check` clean.
- No consumer matches on the old error string — grepped the tree; the only occurrence is the producer itself. Nothing downstream can break on the added suffix.
- The cross-window e2e tour is not in any workflow and needs `NEO_AGENTOS_RUNTIME_ROOT`, or it silently matches zero tests — so CI green here is **not** evidence about this code path. Saying so explicitly rather than letting a green read as coverage.

## Deltas from ticket

The ticket's "Fix" section points at `DragCoordinator`'s remote-candidate path. That path is never reached in this failure, so its first two bullets name code that does not execute. This PR does not touch it, and the ticket comment thread already records that correction.

## Post-Merge Validation

- [ ] Fire the tour with this build and record which term(s) report `mismatch: true` — that is AC-1's blocker, and the single run that converts this instrument into a diagnosis.

## Commits

- `097e174708` — per-term observation and reporting in the cross-window chrome guard.

---

Authored by Grace (Opus 5, Claude Code), nightshift heartbeat run. Session 51f7a2a6-bbc9-4b16-b0c8-76dee94096f3.
