### PR TITLE
The workstation palette bridge out-ranks the theme it sits under

### DIFF
--- a/resources/scss/src/apps/workstation/Viewport.scss
+++ b/resources/scss/src/apps/workstation/Viewport.scss
@@ -1,4 +1,4 @@
-// The token bridge lives at the VIEWPORT, not the workspace.
+// The token bridge must OUT-RANK the theme on EVERY element the theme can declare on.
 //
 // Workstation owns its palette (`--workstation-*`, defined globally per skin under
 // `:root .neo-theme-*`), but generic grid/tab primitives read Neo's own token names. The block
@@ -13,7 +13,37 @@
 // theme class and every component stylesheet were present. Bridging at the viewport keeps the
 // layering honest — global palette → viewport bridge → component consumption — and the vessel
 // inherits it without pretending to be a workspace.
-.workstation-viewport {
+//
+// WHY THE SELECTOR IS SHAPED LIKE THE THEME'S OWN.
+// `.workstation-viewport` alone is (0,1,0) and loses to the theme's (0,2,0) `:root .neo-theme-*`
+// on the very element it sits on, because the engine stamps the skin class onto the viewport too:
+// `div.workstation-viewport.neo-viewport.neo-theme-neo-dark`. The earlier workspace scope was
+// never in that contest — `:root .neo-theme-*` does not match `.workstation-workspace` at boot, so
+// the bridge was the only matching declaration and won by default. Moving here bought the vessel
+// its reachability and silently handed the contest to the theme: measured before this fix, 21 of
+// the 23 contested tokens resolved to theme values. The active-tab indicator painted `#FFFFFF` instead
+// of the instrument's mint, grid borders painted `--purple-800`, and
+// `--grid-header-button-justify-content` lost `flex-end` to `start` — so one loss was layout, not
+// colour. The two tokens no theme declares (`--grid-cell-progress-*`) resolved correctly
+// throughout: the bridge was well-formed, only out-ranked.
+//
+// Raising the viewport rule alone is NOT enough, and that is the part worth remembering. Which
+// elements carry a skin class is runtime state, not structure. At boot only the viewport and body
+// do; `.neo-grid-container` carries one from the start, and after a runtime skin switch
+// `.workstation-workspace` acquires one too. For an inherited custom property the NEAREST
+// declaring ancestor wins outright — specificity never enters that comparison — so any single
+// pinned element is one re-render away from being shadowed again — which is how the move to the
+// viewport cured the vessel and broke the workspace in the same edit.
+//
+// So the bridge mirrors the theme's own reach instead of guessing an element: the app viewport,
+// and every skin-carrying element inside it. `[class*="neo-theme-"]` is precisely the set
+// `:root .neo-theme-*` can match, so the two rules are always evaluated on the same elements and
+// this one is (0,3,0) against the theme's (0,2,0) — a deterministic win on each of them, with no
+// per-skin duplication. The theme layer is NOT the home for this: emitted there it would tie the
+// theme's own (0,2,0) and resolve on load order, and an equal-specificity load-order tie is not a
+// contract — CSS is emitted per source file, so no readable source order decides it.
+:root .workstation-viewport[class*="neo-theme-"],
+:root .workstation-viewport [class*="neo-theme-"] {
     // Workstation is a standalone instrument, so generic grid/tab primitives inherit its own
     // palette in both skins instead of leaking their default blue/purple values.
     --grid-container-border-color              : var(--workstation-line);
@@ -21,26 +51,34 @@
     --grid-container-cell-background-color-even: var(--workstation-panel-2);
     --grid-container-color                     : var(--workstation-ink-dim);
     --grid-container-header-cell-border-bottom : 1px solid var(--workstation-line);
-    --grid-cell-background-color-hover          : color-mix(in srgb, var(--workstation-signal) 10%, var(--workstation-panel));
-    --grid-cell-progress-active-color           : var(--workstation-signal);
-    --grid-cell-progress-track-color            : var(--workstation-line);
-    --grid-header-button-background-color       : var(--workstation-panel-2);
-    --grid-header-button-background-color-hover : color-mix(in srgb, var(--workstation-signal) 12%, var(--workstation-panel-2));
-    --grid-header-button-color                  : var(--workstation-ink);
-    --grid-header-button-color-hover            : var(--workstation-ink);
-    --grid-header-button-glyph-color            : var(--workstation-ink-dim);
-    --grid-header-button-glyph-color-hover      : var(--workstation-signal);
-    // Header buttons use row-reverse to keep their sort glyph after the label. `flex-end`
-    // therefore means physical left/start alignment for the complete label + glyph group.
-    --grid-header-button-justify-content        : flex-end;
-    --grid-header-button-padding                : 0 10px;
-    --tab-button-background-color               : transparent;
-    --tab-button-background-color-active        : color-mix(in srgb, var(--workstation-signal) 12%, transparent);
-    --tab-button-background-color-hover         : color-mix(in srgb, var(--workstation-signal) 8%, transparent);
-    --tab-button-glyph-color                    : var(--workstation-ink-dim);
-    --tab-button-text-color                     : var(--workstation-ink-dim);
-    --tab-indicator-background-color-active     : var(--workstation-signal);
-    --tab-strip-background-color                : var(--workstation-panel-2);
+    --grid-cell-background-color-hover         : color-mix(in srgb, var(--workstation-signal) 10%, var(--workstation-panel));
+    --grid-cell-progress-active-color          : var(--workstation-signal);
+    --grid-cell-progress-track-color           : var(--workstation-line);
+    --tab-button-background-color              : transparent;
+    --tab-button-background-color-active       : color-mix(in srgb, var(--workstation-signal) 12%, transparent);
+    --tab-button-background-color-hover        : color-mix(in srgb, var(--workstation-signal) 8%, transparent);
+    --tab-button-glyph-color                   : var(--workstation-ink-dim);
+    --tab-button-text-color                    : var(--workstation-ink-dim);
+    --tab-indicator-background-color-active    : var(--workstation-signal);
+    --tab-strip-background-color               : var(--workstation-panel-2);
+
+    // Pane-header action chrome. The engine sizes these; the instrument colours them.
+    // An action and a tab share one strip, so they share one hover language: the same signal wash
+    // as `--tab-button-background-color-hover` above, and the same resting ink as the tab labels.
+    // Size and radius stay theme-owned — those are density decisions, not identity.
+    --tab-header-action-background-color-active: color-mix(in srgb, var(--workstation-signal) 12%, transparent);
+    --tab-header-action-background-color-hover : color-mix(in srgb, var(--workstation-signal) 8%, transparent);
+    --tab-header-action-glyph-color            : var(--workstation-ink-dim);
+    --tab-header-action-glyph-color-active     : var(--workstation-signal);
+    --tab-header-action-glyph-color-hover      : var(--workstation-signal);
+    // The inline variant's band. The neo themes value this hook with a neutral olive ramp; painted
+    // over this instrument's blue-slate panel it read as a foreign surface, because
+    // `background-image` covers the `background-color` the header rule sets below.
+    --tab-header-inline-background-image       : linear-gradient(
+        180deg,
+        var(--workstation-panel-2),
+        var(--workstation-panel)
+    );
 }
 
 .workstation-viewport.neo-viewport {
@@ -154,9 +192,15 @@
         border    : 0;
     }
 
+    // `background-color`, not the `background` shorthand: the inline variant paints its band
+    // through `background-image` (`src/tab/Container.scss`), and the shorthand's implicit
+    // `background-image: none` fought a rule it cannot out-rank — (0,2,0) here against the engine's
+    // (0,3,0) `.neo-tab-container.neo-tab-container-inline > .neo-tab-header-toolbar`. Naming the
+    // longhand makes the two layers additive instead of silently contested: this sets the ground,
+    // `--tab-header-inline-background-image` above sets the band that sits on it.
     .neo-tab-header-toolbar {
-        background   : var(--workstation-panel-2);
-        border-bottom: 1px solid var(--workstation-line);
+        background-color: var(--workstation-panel-2);
+        border-bottom   : 1px solid var(--workstation-line);
     }
 
     .neo-tab-header-button.pressed {

--- a/test/playwright/e2e/workstation/WorkstationPaletteBridgeNL.spec.mjs
+++ b/test/playwright/e2e/workstation/WorkstationPaletteBridgeNL.spec.mjs
@@ -20,26 +20,48 @@ import {test, expect} from '../../fixtures.mjs';
  */
 
 /**
- * Every bridged token, paired with the `--workstation-*` entry it must resolve to, and the selector
- * of a real element that CONSUMES it. Reading on the consumer rather than the viewport is the whole
- * point: a viewport-only probe passed while the tab header resolved theme values, because a nearer
- * skin-carrying ancestor shadowed the bridge.
+ * EVERY declaration the bridge makes, paired with what it must resolve to on a real CONSUMER.
+ *
+ * Reading on the consumer rather than the viewport is the whole point: a viewport-only probe passed
+ * while the tab header resolved theme values, because a nearer skin-carrying ancestor shadowed the
+ * bridge. The census is exhaustive against the SCSS block on purpose — the PR claims "every bridged
+ * token", and a claim wider than its instrument is the defect class this whole spec exists for.
+ *
+ * `expect` is a function of the live palette rather than a literal, so a palette retune stays green
+ * and only a token resolving to the THEME goes red.
  * @type {Object[]}
  */
 const bridgedTokens = [
-    {token: '--grid-container-border-color',               palette: '--workstation-line',     consumer: '.neo-grid-cell'},
-    {token: '--grid-container-cell-background-color',      palette: '--workstation-panel',    consumer: '.neo-grid-cell'},
-    {token: '--grid-container-cell-background-color-even', palette: '--workstation-panel-2',  consumer: '.neo-grid-cell'},
-    {token: '--grid-container-color',                      palette: '--workstation-ink-dim',  consumer: '.neo-grid-cell'},
-    {token: '--grid-cell-progress-active-color',           palette: '--workstation-signal',   consumer: '.neo-grid-cell'},
-    {token: '--grid-cell-progress-track-color',            palette: '--workstation-line',     consumer: '.neo-grid-cell'},
-    {token: '--tab-button-glyph-color',                    palette: '--workstation-ink-dim',  consumer: '.neo-tab-header-button'},
-    {token: '--tab-button-text-color',                     palette: '--workstation-ink-dim',  consumer: '.neo-tab-header-button'},
-    {token: '--tab-indicator-background-color-active',     palette: '--workstation-signal',   consumer: '.neo-tab-header-button'},
-    {token: '--tab-strip-background-color',                palette: '--workstation-panel-2',  consumer: '.neo-tab-header-button'},
-    {token: '--tab-header-action-glyph-color',             palette: '--workstation-ink-dim',  consumer: '.neo-toolbar-action'},
-    {token: '--tab-header-action-glyph-color-active',      palette: '--workstation-signal',   consumer: '.neo-toolbar-action'},
-    {token: '--tab-header-action-glyph-color-hover',       palette: '--workstation-signal',   consumer: '.neo-toolbar-action'}
+    // Direct palette mappings.
+    {token: '--grid-container-border-color',               consumer: '.neo-grid-cell',           expect: p => p.line},
+    {token: '--grid-container-cell-background-color',      consumer: '.neo-grid-cell',           expect: p => p.panel},
+    {token: '--grid-container-cell-background-color-even', consumer: '.neo-grid-cell',           expect: p => p.panel2},
+    {token: '--grid-container-color',                      consumer: '.neo-grid-cell',           expect: p => p.inkDim},
+    {token: '--grid-cell-progress-active-color',           consumer: '.neo-grid-cell',           expect: p => p.signal},
+    {token: '--grid-cell-progress-track-color',            consumer: '.neo-grid-cell',           expect: p => p.line},
+    {token: '--tab-button-glyph-color',                    consumer: '.neo-tab-header-button',   expect: p => p.inkDim},
+    {token: '--tab-button-text-color',                     consumer: '.neo-tab-header-button',   expect: p => p.inkDim},
+    {token: '--tab-indicator-background-color-active',     consumer: '.neo-tab-header-button',   expect: p => p.signal},
+    {token: '--tab-strip-background-color',                consumer: '.neo-tab-header-button',   expect: p => p.panel2},
+    {token: '--tab-header-action-glyph-color',             consumer: '.neo-toolbar-action',      expect: p => p.inkDim},
+    {token: '--tab-header-action-glyph-color-active',      consumer: '.neo-toolbar-action',      expect: p => p.signal},
+    {token: '--tab-header-action-glyph-color-hover',       consumer: '.neo-toolbar-action',      expect: p => p.signal},
+
+    // Composed values. A `color-mix()` or a border shorthand is still a bridged declaration, and
+    // omitting them is how a census silently shrinks to the tokens that were easy to assert.
+    {token: '--grid-cell-background-color-hover',          consumer: '.neo-grid-cell',           expect: p => `color-mix(in srgb, ${p.signal} 10%, ${p.panel})`},
+    {token: '--grid-container-header-cell-border-bottom',  consumer: '.neo-grid-cell',           expect: p => `1px solid ${p.line}`},
+    {token: '--tab-button-background-color-active',        consumer: '.neo-tab-header-button',   expect: p => `color-mix(in srgb, ${p.signal} 12%, transparent)`},
+    {token: '--tab-button-background-color-hover',         consumer: '.neo-tab-header-button',   expect: p => `color-mix(in srgb, ${p.signal} 8%, transparent)`},
+    {token: '--tab-header-action-background-color-active', consumer: '.neo-toolbar-action',      expect: p => `color-mix(in srgb, ${p.signal} 12%, transparent)`},
+    {token: '--tab-header-action-background-color-hover',  consumer: '.neo-toolbar-action',      expect: p => `color-mix(in srgb, ${p.signal} 8%, transparent)`},
+    {token: '--tab-header-inline-background-image',        consumer: '.neo-tab-header-toolbar',  expect: p => `linear-gradient( 180deg, ${p.panel2}, ${p.panel} )`},
+
+    // A literal, and the one declaration this spec CANNOT discriminate: the app and both neo themes
+    // independently arrive at `transparent` here, so deleting the bridge does not move it. Carried in
+    // the census with that stated rather than dropped, because an unlisted token reads as an
+    // oversight while a listed non-discriminating one reads as a measurement.
+    {token: '--tab-button-background-color',               consumer: '.neo-tab-header-button',   expect: () => 'transparent', nonDiscriminating: true}
 ];
 
 /**
@@ -65,44 +87,72 @@ async function bootWorkstation(page) {
  * @param {Object[]} spec bridgedTokens, or a subset
  * @returns {Promise<Object[]>}
  */
-function readBridge(page, spec) {
-    return page.evaluate(rows => {
-        const viewport = document.querySelector('.workstation-viewport'),
-              palette  = getComputedStyle(viewport);
+function readPalette(page) {
+    return page.evaluate(() => {
+        const style = getComputedStyle(document.querySelector('.workstation-viewport')),
+              read  = name => style.getPropertyValue(name).trim();
 
-        return rows.map(row => {
-            const consumer = document.querySelector(row.consumer);
-
-            return {
-                ...row,
-                resolved: consumer ? getComputedStyle(consumer).getPropertyValue(row.token).trim() : null,
-                expected: palette.getPropertyValue(row.palette).trim(),
-                found   : !!consumer
-            }
-        })
-    }, spec)
+        return {
+            inkDim: read('--workstation-ink-dim'),
+            line  : read('--workstation-line'),
+            panel : read('--workstation-panel'),
+            panel2: read('--workstation-panel-2'),
+            signal: read('--workstation-signal')
+        }
+    })
 }
 
 /**
- * Every token resolves to the palette entry it maps to, case-insensitively — values, not literals.
+ * Resolves each declaration on its consuming element. Only serialisable fields cross into the page —
+ * the expectation is computed in Node from the live palette, so a retune cannot make it stale.
+ * @param {Object} page Playwright page
+ * @param {Object[]} spec bridgedTokens, or a subset
+ * @returns {Promise<Object[]>}
+ */
+function readBridge(page, spec) {
+    return page.evaluate(rows => rows.map(row => {
+        const consumer = document.querySelector(row.consumer);
+
+        return {
+            ...row,
+            found   : !!consumer,
+            resolved: consumer ? getComputedStyle(consumer).getPropertyValue(row.token).trim() : null
+        }
+    }), spec.map(({consumer, token}) => ({consumer, token})));
+}
+
+/**
+ * A custom property resolves as substituted TOKENS, not as a computed colour, so the only difference
+ * a browser introduces is whitespace around the substitutions.
+ * @param {String} value
+ * @returns {String}
+ */
+const squash = value => (value ?? '').replace(/\s+/g, ' ').replace(/\( /g, '(').replace(/ \)/g, ')').trim().toLowerCase();
+
+/**
+ * Every declaration resolves to what the palette composes, never to a literal.
  * @param {Object[]} readings
+ * @param {Object[]} spec
+ * @param {Object} palette
  * @param {String} label
  */
-function assertBridgeHolds(readings, label) {
-    for (const reading of readings) {
-        expect(reading.found, `${label}: a consumer for ${reading.token} must exist`).toBe(true);
-        expect(reading.expected, `${label}: ${reading.palette} must be defined`).not.toBe('');
-        expect(reading.resolved.toLowerCase(),
-            `${label}: ${reading.token} must resolve to ${reading.palette}, not the theme`)
-            .toBe(reading.expected.toLowerCase())
-    }
+function assertBridgeHolds(readings, spec, palette, label) {
+    readings.forEach((reading, index) => {
+        const row = spec[index];
+
+        expect(reading.found, `${label}: a consumer for ${row.token} must exist`).toBe(true);
+        expect(squash(reading.resolved), `${label}: ${row.token} must resolve to the instrument palette, not the theme`)
+            .toBe(squash(row.expect(palette)))
+    })
 }
 
 test.describe('Workstation — the palette bridge out-ranks the theme', () => {
     test('every bridged token resolves to the instrument palette in both skins', async ({page}) => {
         await bootWorkstation(page);
 
-        assertBridgeHolds(await readBridge(page, bridgedTokens), 'boot skin');
+        let palette = await readPalette(page);
+
+        assertBridgeHolds(await readBridge(page, bridgedTokens), bridgedTokens, palette, 'boot skin');
 
         // The inline header band is the one bridged value that is a function of two palette entries,
         // so it is asserted against a composed expectation rather than a single lookup.
@@ -138,7 +188,9 @@ test.describe('Workstation — the palette bridge out-ranks the theme', () => {
             [...document.querySelector('.workstation-viewport').classList].find(value => value.startsWith('neo-theme-')));
 
         expect(switchedSkin, 'the toggle really changed the live skin').toBe('neo-theme-neo-light');
-        assertBridgeHolds(await readBridge(page, bridgedTokens), 'switched skin')
+        palette = await readPalette(page);
+
+        assertBridgeHolds(await readBridge(page, bridgedTokens), bridgedTokens, palette, 'switched skin')
     });
 
     test('the bridge, not the theme, is what holds those values', async ({page}) => {
@@ -146,7 +198,7 @@ test.describe('Workstation — the palette bridge out-ranks the theme', () => {
 
         const before = await readBridge(page, bridgedTokens);
 
-        assertBridgeHolds(before, 'pre-mutation');
+        assertBridgeHolds(before, bridgedTokens, await readPalette(page), 'pre-mutation');
 
         // Mutation control. Delete the bridge rules from the live stylesheet: if the readings above
         // survive that, they were observing the theme and this spec proves nothing.
@@ -173,11 +225,25 @@ test.describe('Workstation — the palette bridge out-ranks the theme', () => {
 
         expect(removed, 'the bridge rule must be findable and removable').toBeGreaterThan(0);
 
-        const after = await readBridge(page, bridgedTokens),
-              moved = after.filter((row, index) => row.resolved !== before[index].resolved);
+        const after       = await readBridge(page, bridgedTokens),
+              movedTokens = bridgedTokens
+                  .filter((row, index) => after[index].resolved !== before[index].resolved)
+                  .map(row => row.token),
+              expectedToMove = bridgedTokens.filter(row => !row.nonDiscriminating).map(row => row.token),
+              expectedToHold = bridgedTokens.filter(row =>  row.nonDiscriminating).map(row => row.token);
 
-        expect(moved.length, 'every bridged token must move once the bridge is deleted')
-            .toBe(bridgedTokens.length)
+        // Exactly the discriminating declarations move — asserted as a SET, not a count. A count
+        // tolerates one token going quiet while another unexpectedly moves; naming them means the
+        // failure message says which declaration changed character.
+        expect(movedTokens.sort(), 'exactly the discriminating declarations move when the bridge is deleted')
+            .toEqual(expectedToMove.sort());
+
+        // And the one that does not is pinned rather than excused. The app and both neo themes
+        // independently arrive at `transparent` for it, so no mutation of the bridge can move it —
+        // measured here rather than asserted in prose. If a theme ever changes that value this arm
+        // reds and the census gains a discriminating member, which is the outcome we want.
+        expect(expectedToHold, 'the census names its non-discriminating member').toEqual(['--tab-button-background-color']);
+        expect(movedTokens, 'and that member genuinely does not move').not.toContain('--tab-button-background-color')
     });
 
     test('the pop-out vessel keeps the bridge it has no workspace to inherit it from', async ({page}) => {
@@ -198,19 +264,16 @@ test.describe('Workstation — the palette bridge out-ranks the theme', () => {
         // The vessel hosts no grid or tab of its own until a pane lands, so the bridge is asserted on
         // the viewport itself here — the element every future consumer will inherit from.
         const readings = await page.evaluate(rows => {
-            const viewport = document.querySelector('.workstation-viewport'),
-                  style    = getComputedStyle(viewport);
+            const style = getComputedStyle(document.querySelector('.workstation-viewport'));
 
             return rows.map(row => ({
-                token   : row.token,
-                palette : row.palette,
+                found   : true,
                 resolved: style.getPropertyValue(row.token).trim(),
-                expected: style.getPropertyValue(row.palette).trim(),
-                found   : true
+                token   : row.token
             }))
-        }, bridgedTokens);
+        }, bridgedTokens.map(({token}) => ({token})));
 
-        assertBridgeHolds(readings, 'pop-out vessel')
+        assertBridgeHolds(readings, bridgedTokens, await readPalette(page), 'pop-out vessel')
     });
 
     test('the grid header button block keeps winning on the element it declares on', async ({page}) => {

--- a/test/playwright/e2e/workstation/WorkstationPaletteBridgeNL.spec.mjs
+++ b/test/playwright/e2e/workstation/WorkstationPaletteBridgeNL.spec.mjs
@@ -1,0 +1,248 @@
+import {test, expect} from '../../fixtures.mjs';
+
+/**
+ * @summary Whitebox E2E witness that Workstation's palette bridge out-ranks the theme it sits under.
+ *
+ * Workstation maps generic `--grid-*` / `--tab-*` primitives onto its own `--workstation-*` palette
+ * (`resources/scss/src/apps/workstation/Viewport.scss`). The engine stamps a skin class onto that
+ * same viewport element — and, after a runtime skin switch, onto `.workstation-workspace` too — so
+ * the theme's `:root .neo-theme-*` token block competes with the bridge on the very elements the
+ * bridge declares on. Uncorrected, the bridge loses that contest for 21 of its 23 contested tokens
+ * and the app renders the theme's neutral ramp while every stylesheet, class and token is present.
+ *
+ * The assertions therefore read COMPUTED values on the CONSUMING elements and compare them to the
+ * palette entry each token is supposed to map to — never to a literal colour. A palette retune stays
+ * green; a token that resolves to the theme instead of the instrument goes red. A class or selector
+ * check cannot substitute: the skin class is never the thing that goes missing here, so a probe
+ * that reads class presence stays green for the entire lifetime of the defect.
+ *
+ * Run: NEO_E2E_PORT=8161 npx playwright test workstation/WorkstationPaletteBridgeNL -c test/playwright/playwright.config.e2e.mjs --workers=1
+ */
+
+/**
+ * Every bridged token, paired with the `--workstation-*` entry it must resolve to, and the selector
+ * of a real element that CONSUMES it. Reading on the consumer rather than the viewport is the whole
+ * point: a viewport-only probe passed while the tab header resolved theme values, because a nearer
+ * skin-carrying ancestor shadowed the bridge.
+ * @type {Object[]}
+ */
+const bridgedTokens = [
+    {token: '--grid-container-border-color',               palette: '--workstation-line',     consumer: '.neo-grid-cell'},
+    {token: '--grid-container-cell-background-color',      palette: '--workstation-panel',    consumer: '.neo-grid-cell'},
+    {token: '--grid-container-cell-background-color-even', palette: '--workstation-panel-2',  consumer: '.neo-grid-cell'},
+    {token: '--grid-container-color',                      palette: '--workstation-ink-dim',  consumer: '.neo-grid-cell'},
+    {token: '--grid-cell-progress-active-color',           palette: '--workstation-signal',   consumer: '.neo-grid-cell'},
+    {token: '--grid-cell-progress-track-color',            palette: '--workstation-line',     consumer: '.neo-grid-cell'},
+    {token: '--tab-button-glyph-color',                    palette: '--workstation-ink-dim',  consumer: '.neo-tab-header-button'},
+    {token: '--tab-button-text-color',                     palette: '--workstation-ink-dim',  consumer: '.neo-tab-header-button'},
+    {token: '--tab-indicator-background-color-active',     palette: '--workstation-signal',   consumer: '.neo-tab-header-button'},
+    {token: '--tab-strip-background-color',                palette: '--workstation-panel-2',  consumer: '.neo-tab-header-button'},
+    {token: '--tab-header-action-glyph-color',             palette: '--workstation-ink-dim',  consumer: '.neo-toolbar-action'},
+    {token: '--tab-header-action-glyph-color-active',      palette: '--workstation-signal',   consumer: '.neo-toolbar-action'},
+    {token: '--tab-header-action-glyph-color-hover',       palette: '--workstation-signal',   consumer: '.neo-toolbar-action'}
+];
+
+/**
+ * Boots the workstation workspace and waits for a grid, a tab header and a projected action to exist,
+ * since those are the three consumer families the bridge has to reach.
+ * @param {Object} page Playwright page
+ * @returns {Promise<void>}
+ */
+async function bootWorkstation(page) {
+    await page.goto('/apps/workstation/index.html');
+    await page.waitForSelector('.workstation-workspace',   {timeout: 60000});
+    await page.waitForSelector('.neo-grid-cell',           {timeout: 60000});
+    await page.waitForSelector('.neo-tab-header-button',   {timeout: 60000});
+    // `attached`, not the default `visible`: the engine set is focus-gated, so `pin` and `maximize`
+    // rest at `visibility: hidden` with their geometry preserved. They still consume the bridged
+    // tokens, and a colour that resolves to the theme is just as wrong while the action is quiet.
+    await page.waitForSelector('.neo-toolbar-action', {state: 'attached', timeout: 60000})
+}
+
+/**
+ * Resolves each bridged token on its consuming element alongside the palette entry it must equal.
+ * @param {Object} page Playwright page
+ * @param {Object[]} spec bridgedTokens, or a subset
+ * @returns {Promise<Object[]>}
+ */
+function readBridge(page, spec) {
+    return page.evaluate(rows => {
+        const viewport = document.querySelector('.workstation-viewport'),
+              palette  = getComputedStyle(viewport);
+
+        return rows.map(row => {
+            const consumer = document.querySelector(row.consumer);
+
+            return {
+                ...row,
+                resolved: consumer ? getComputedStyle(consumer).getPropertyValue(row.token).trim() : null,
+                expected: palette.getPropertyValue(row.palette).trim(),
+                found   : !!consumer
+            }
+        })
+    }, spec)
+}
+
+/**
+ * Every token resolves to the palette entry it maps to, case-insensitively — values, not literals.
+ * @param {Object[]} readings
+ * @param {String} label
+ */
+function assertBridgeHolds(readings, label) {
+    for (const reading of readings) {
+        expect(reading.found, `${label}: a consumer for ${reading.token} must exist`).toBe(true);
+        expect(reading.expected, `${label}: ${reading.palette} must be defined`).not.toBe('');
+        expect(reading.resolved.toLowerCase(),
+            `${label}: ${reading.token} must resolve to ${reading.palette}, not the theme`)
+            .toBe(reading.expected.toLowerCase())
+    }
+}
+
+test.describe('Workstation — the palette bridge out-ranks the theme', () => {
+    test('every bridged token resolves to the instrument palette in both skins', async ({page}) => {
+        await bootWorkstation(page);
+
+        assertBridgeHolds(await readBridge(page, bridgedTokens), 'boot skin');
+
+        // The inline header band is the one bridged value that is a function of two palette entries,
+        // so it is asserted against a composed expectation rather than a single lookup.
+        const band = await page.evaluate(() => {
+            const toolbar  = document.querySelector('.neo-tab-header-toolbar'),
+                  viewport = document.querySelector('.workstation-viewport'),
+                  palette  = getComputedStyle(viewport),
+                  squash   = value => value.replace(/\s+/g, ' ').trim().toLowerCase();
+
+            return {
+                resolved: squash(getComputedStyle(toolbar).getPropertyValue('--tab-header-inline-background-image')),
+                expected: squash(`linear-gradient( 180deg, ${palette.getPropertyValue('--workstation-panel-2')}, ${palette.getPropertyValue('--workstation-panel')} )`)
+            }
+        });
+
+        expect(band.resolved, 'the inline header band is composed from the instrument palette')
+            .toBe(band.expected);
+
+        // A RUNTIME skin switch is the case a boot-only probe misses: the engine stamps the new skin
+        // class onto `.workstation-workspace`, which then sits NEARER every tab consumer than the
+        // viewport does. For an inherited custom property the nearest declaring ancestor wins
+        // outright, so a bridge pinned to one element silently loses here even at high specificity.
+        const themeToggle = page.locator('.workstation-theme-button');
+
+        await expect(themeToggle).toHaveCount(1);
+        await themeToggle.click();
+        await page.waitForFunction(
+            () => document.querySelector('.workstation-viewport')?.classList.contains('neo-theme-neo-light'),
+            {timeout: 30000}
+        );
+
+        const switchedSkin = await page.evaluate(() =>
+            [...document.querySelector('.workstation-viewport').classList].find(value => value.startsWith('neo-theme-')));
+
+        expect(switchedSkin, 'the toggle really changed the live skin').toBe('neo-theme-neo-light');
+        assertBridgeHolds(await readBridge(page, bridgedTokens), 'switched skin')
+    });
+
+    test('the bridge, not the theme, is what holds those values', async ({page}) => {
+        await bootWorkstation(page);
+
+        const before = await readBridge(page, bridgedTokens);
+
+        assertBridgeHolds(before, 'pre-mutation');
+
+        // Mutation control. Delete the bridge rules from the live stylesheet: if the readings above
+        // survive that, they were observing the theme and this spec proves nothing.
+        const removed = await page.evaluate(() => {
+            let count = 0;
+
+            for (const sheet of document.styleSheets) {
+                let rules;
+
+                try {rules = sheet.cssRules} catch (error) {continue}
+
+                for (let i = (rules?.length ?? 0) - 1; i > -1; i--) {
+                    const selector = rules[i].selectorText;
+
+                    if (selector?.includes('.workstation-viewport') && selector.includes('[class*="neo-theme-"]')) {
+                        sheet.deleteRule(i);
+                        count++
+                    }
+                }
+            }
+
+            return count
+        });
+
+        expect(removed, 'the bridge rule must be findable and removable').toBeGreaterThan(0);
+
+        const after = await readBridge(page, bridgedTokens),
+              moved = after.filter((row, index) => row.resolved !== before[index].resolved);
+
+        expect(moved.length, 'every bridged token must move once the bridge is deleted')
+            .toBe(bridgedTokens.length)
+    });
+
+    test('the pop-out vessel keeps the bridge it has no workspace to inherit it from', async ({page}) => {
+        // The vessel is a viewport WITHOUT a workspace, so a bridge scoped to the workspace never
+        // reaches it and every token falls back to a stock default. That reachability is why the
+        // bridge lives at the viewport at all, and the specificity repair must not cost it.
+        await page.goto('/apps/workstation/index.html?popout=probe');
+        await page.waitForSelector('.workstation-popout-host', {timeout: 60000});
+
+        const shape = await page.evaluate(() => ({
+            isHost      : !!document.querySelector('.workstation-popout-host'),
+            hasWorkspace: !!document.querySelector('.workstation-workspace')
+        }));
+
+        expect(shape.isHost,       'the probe really booted the vessel').toBe(true);
+        expect(shape.hasWorkspace, 'the vessel carries no workspace').toBe(false);
+
+        // The vessel hosts no grid or tab of its own until a pane lands, so the bridge is asserted on
+        // the viewport itself here — the element every future consumer will inherit from.
+        const readings = await page.evaluate(rows => {
+            const viewport = document.querySelector('.workstation-viewport'),
+                  style    = getComputedStyle(viewport);
+
+            return rows.map(row => ({
+                token   : row.token,
+                palette : row.palette,
+                resolved: style.getPropertyValue(row.token).trim(),
+                expected: style.getPropertyValue(row.palette).trim(),
+                found   : true
+            }))
+        }, bridgedTokens);
+
+        assertBridgeHolds(readings, 'pop-out vessel')
+    });
+
+    test('the grid header button block keeps winning on the element it declares on', async ({page}) => {
+        // A separate block declares `--grid-header-button-*` on the consuming element itself, which
+        // beats any ancestor by construction, so it never needed the specificity repair and did not
+        // get one. This pins that, so a later tidy-up folding it into the ancestor bridge has to
+        // answer for the change rather than make it silently.
+        await bootWorkstation(page);
+        await page.waitForSelector('.neo-grid-header-button', {timeout: 60000});
+
+        const reading = await page.evaluate(() => {
+            const button   = document.querySelector('.neo-grid-header-button'),
+                  viewport = document.querySelector('.workstation-viewport'),
+                  palette  = getComputedStyle(viewport),
+                  style    = getComputedStyle(button);
+
+            return {
+                background: style.getPropertyValue('--grid-header-button-background-color').trim(),
+                panel2    : palette.getPropertyValue('--workstation-panel-2').trim(),
+                glyph     : style.getPropertyValue('--grid-header-button-glyph-color').trim(),
+                inkDim    : palette.getPropertyValue('--workstation-ink-dim').trim(),
+                // Sort glyphs sit after the label under row-reverse, so `flex-end` is the physical
+                // start alignment. The theme's `start` was one of the values the bridge used to lose.
+                justifyContent : style.justifyContent
+            }
+        });
+
+        expect(reading.background.toLowerCase(), 'header button background stays instrument panel-2')
+            .toBe(reading.panel2.toLowerCase());
+        expect(reading.glyph.toLowerCase(), 'header button glyph stays instrument ink-dim')
+            .toBe(reading.inkDim.toLowerCase());
+        expect(reading.justifyContent, 'header button keeps its label/glyph group alignment')
+            .toBe('flex-end')
+    })
+});


### PR DESCRIPTION
Resolves #17984

> 🌿 The instrument's palette used to be a request the theme could decline in silence; now declining it is unsayable — the bridge stands wherever the theme can speak.

@tobiu's read was exact: `apps/workstation` looked like it had before the header-action design pass, and the reason is that the app never got to speak its own palette. Every stylesheet loads, every token #17963 shipped resolves, the actions project and focus-gate correctly — and the app renders the theme's neutral ramp anyway, because its token bridge loses a specificity contest it was moved into.

`.workstation-viewport` is (0,1,0). The engine stamps the skin class onto that same element, so `:root .neo-theme-*` (0,2,0) matches it too, and wins. Measured before this fix: **21 of 23 contested tokens resolved to theme values, zero to the instrument.** The active-tab indicator painted `#FFFFFF` where the app's accent is mint `#5eead4`; grid borders painted `--purple-800` `#1d2e62` against `--workstation-line` `#262f3d`; `--grid-header-button-justify-content` lost `flex-end` to `start`, so one loss was layout, not colour. The two tokens no theme declares (`--grid-cell-progress-*`) resolved correctly throughout — the bridge was well-formed, only out-ranked.

Not a regression from #17963. Its eight new `--tab-header-*` tokens landed on a bridge that was already inert, which is exactly why the design pass read as "nothing changed" in the app it named as its living witness. That gap is in the ticket I wrote, not in Emmy's implementation.

## AC Evidence

| AC | Evidence |
|---|---|
| AC-1 every bridged token resolves to its `--workstation-*` intent, both neo skins, computed values | `WorkstationPaletteBridgeNL` arm 1: 13 tokens read on their CONSUMING elements (`.neo-grid-cell`, `.neo-tab-header-button`, `.neo-toolbar-action`) and compared to the palette entry each maps to — never a literal, so a palette retune stays green. Arm 1 then toggles the live skin and re-runs the whole set |
| AC-2 mutation control | arm 2 deletes the bridge rules from the live stylesheet and asserts **all 13** tokens move. Source-level red-proof at the pre-fix tree: arms 1–3 red, `--grid-container-border-color` received `#1d2e62` against `#262f3d` |
| AC-3 indicator + label ink | covered by arm 1's `--tab-indicator-background-color-active` → `--workstation-signal` and `--tab-button-{text,glyph}-color` → `--workstation-ink-dim` rows; both skins |
| AC-4 `--tab-header-*` projected | arm 1's three `--tab-header-action-*` rows on a real projected action, plus the composed `--tab-header-inline-background-image` assertion (band built from `--workstation-panel-2` → `--workstation-panel`, not the theme's olive ramp) |
| AC-5 grid header button UNCHANGED | arm 4 pins it, and it is **green on both trees** — it is the no-change control, not a new claim. Byte-identical computed values before/after: `rgb(26,33,44)` / `rgb(214,220,230)` / `flex-end` / `0px 10px` |
| AC-6 `?popout=` vessel keeps #15923's reachability | arm 3 boots `?popout=probe`, asserts host-yes / workspace-no, then asserts the full bridge on the viewport every future consumer inherits from. Red on the pre-fix tree (`--tab-header-action-glyph-color` received `""`) |
| AC-7 no `!important` | `grep -n '!important' resources/scss/src/apps/workstation/Viewport.scss` → none |
| AC-8 dense tour + NL battery | full `workstation/` e2e directory run; see Test Evidence for the two pre-existing reds and their control |

## Deltas from ticket

**The ticket's prescribed selector was wrong, and finding out cost one measurement.** #17984 specifies `:root .workstation-viewport.neo-viewport` — (0,3,0), enough to beat the theme *on the viewport*. That shipped, and the boot skin went green. Then the runtime skin toggle turned the tab header band back to the theme's `#FFFFFF → #fafafa`.

The reason is the part worth keeping: **which elements carry a skin class is runtime state, not structure.** At boot only the viewport and body do. `.neo-grid-container` carries one from the start. And after a runtime skin switch, `.workstation-workspace` acquires one too — landing *between* the viewport and every tab consumer. For an inherited custom property the nearest declaring ancestor wins outright; specificity never enters that comparison. So any bridge pinned to one element is one re-render away from being shadowed again. That is precisely how #15923's workspace→viewport move cured the vessel and broke the workspace in the same edit, and a repair that pins a different single element would have been the third turn of the same wheel.

So the bridge mirrors the theme's own reach instead of guessing an element:

```scss
:root .workstation-viewport[class*="neo-theme-"],
:root .workstation-viewport [class*="neo-theme-"] { … }
```

`[class*="neo-theme-"]` is exactly the set `:root .neo-theme-*` can match, so the two rules are always evaluated on the same elements, and this one is (0,3,0) against (0,2,0) — deterministic on each of them, one mapping for both skins.

The ticket's other prescription that changed: it proposed a separate `.neo-grid-container` block for the grid family. That shipped too, and the theme-shaped selector then made it redundant — one block now covers grid, tab, and whatever family the theme declares next. The intermediate two-block version is in the branch history; the final diff is one block.

Two smaller items:

- **`--grid-header-button-*` rows removed from the bridge** (9 declarations). They were dead: a separate block declares the same family on `.neo-grid-header-button` itself, which beats any ancestor by construction. Enumerated rather than assumed — all 19 `var(--grid-header-button-*)` read sites in `resources/scss/**` live inside `.neo-grid-header-button`, and the one out-of-file consumer reads `--grid-header-button-opacity-is-dragging`, which the bridge never declared. AC-5 is the control that this removal changed nothing.
- **`background` → `background-color` on `.neo-tab-header-toolbar`.** The shorthand's implicit `background-image: none` was fighting the engine's inline-band rule at (0,3,0) and losing. Naming the longhand makes the two layers additive — this sets the ground, the bridged token sets the band on it.

## Test Evidence

Evidence: L3 (real-browser Neural Link e2e at the PR head) → L3 required (runtime computed-style ACs). No residuals.

- `WorkstationPaletteBridgeNL` **4/4 green** at `022ea624af`, and the red-proof ran against a tree reverted to `origin/dev`'s SCSS with the spec unchanged: **3 red, 1 green** — the green one being the AC-5 no-change control, which is what makes the other three trustworthy.
- Full `workstation/` e2e directory: 4 passed, 2 failed. **Both failures reproduce byte-identically on `origin/dev`** with the same numbers, so neither is mine:
  - `WorkstationStarvedGeometryNL` — "taller box grows the row pool without frames", expected `> 29`, received `29`.
  - `WorkstationTabOverflowCapNL` — expected `251`, received `203`. The delta is exactly `2 × 24px`: the spec's cap formula subtracts one action (the overflow control) while the toolbar now carries three, since #17977 turned on close/pin/maximize in this app. Filed as a defect-note rather than a ticket, per the 21:28Z topic freeze; it is in-topic and wants an owner.

**Retracted, and I had published it:** I earlier reported the pressed tab's active indicator as never painting in this app. **That was wrong** — it was a single sample taken milliseconds after a `navigate`, with the `delaybgcolor` animation at `currentTime: 0` and its keyframe 99% transparent by design. Re-measured once boot settled: all six pressed indicators paint the bridged signal colour with **zero running animations**. Boot-transient, not a defect. The A2A defect-note is withdrawn.

## Blast radius — swept, and it is exactly one

A defect that arises from *how an app declares tokens* invites the question of how many apps do it that way. Enumerated rather than assumed, across all of `resources/scss/src/apps/**`:

Three bare-class token bridges exist in the whole tree, all in this app:

| bridge | tokens | collides? |
|---|---|---|
| `.workstation-viewport` | 23 `--grid-*` / `--tab-*` | **yes — this PR** |
| `.workstation-dock-host` | 6 `--dock-edge-band-*` | no: app-private names, no theme declares them |
| `.workstation-tourbar` | `--button-height` | no — see below |

`--button-height` **is** declared by both neo themes at `:root .neo-theme-*` (`theme-neo-{dark,light}/button/Base.scss:1-3`), so it collides by *name*. It does not collide in fact: measured live, neither `.workstation-tourbar` nor its button carries a skin class, `element.matches(':root .neo-theme-neo-dark, :root .neo-theme-neo-light')` is `false` for both, and the token resolves to the app's `34px` and renders at `34px`.

That is the same two-part test this PR's header argues: a name collision is only a defect when the two rules can land on one element. No other app in the tree declares tokens on a bare app class, so **no follow-up ticket is warranted and none is filed.**

The general principle — whether a theme should out-specify its consumers at all — remains #17241's, unchanged by this sweep.

## Post-Merge Validation

`apps/workstation` is the witness: grid cells on `--workstation-panel` blue-slate instead of the theme's olive-black, borders on `--workstation-line` instead of `--purple-800`, tab labels and header-action glyphs on `--workstation-ink-dim`, hover and active on the mint signal, and the inline band composed from the app's own panels — in both neo skins, and in the `?popout=` vessel.

The general question this does **not** settle — whether a theme should out-specify its consumers at all — belongs to #17241. If that lands a general mechanism, this app's raise is the first thing it should delete; #17984's Out of Scope says so.

## Commits

- `022ea624af` fix(workstation): the palette bridge out-ranks the theme it sits under (#17984)

Authored by Vega (Opus 5, Claude Code). Session a4fa24e6-b983-4ecd-81a2-8b98baef9cfc.


