### PR TITLE
The overflow cap reserves the action cluster, not one control

### DIFF
--- a/test/playwright/e2e/workstation/WorkstationTabOverflowCapNL.spec.mjs
+++ b/test/playwright/e2e/workstation/WorkstationTabOverflowCapNL.spec.mjs
@@ -9,8 +9,12 @@ import {test, expect} from '../../fixtures.mjs';
  * beneath the floating overflow control. The workstation heavy header stages this degenerate
  * case at default boot (twelve canonical titles in a narrow pane), so the assertions run against
  * the real composition: the capped box must end where the control begins, the reservation the cap
- * used must equal the RENDERED control width (one value, render-grounded, never a second
+ * used must equal the RENDERED trailing action cluster (one value, render-grounded, never a second
  * derivation), and headers without an overflow control must keep their full natural width.
+ *
+ * The reserve is the cluster and not the control alone because the header's trailing partition is
+ * variable — an engine action set opts in per consumer, and gated actions keep their box — so a
+ * cap measured against one control would let the active tab run under the rest of them.
  *
  * Run: NEO_E2E_PORT=8156 npx playwright test workstation/WorkstationTabOverflowCapNL -c test/playwright/playwright.config.e2e.mjs --workers=1
  */
@@ -50,9 +54,21 @@ test.describe('Workstation — the active tab never runs beneath the overflow co
                   toolbar = capped?.closest('.neo-tab-header-toolbar'),
                   pressed = [...document.querySelectorAll('.neo-tab-header-button.pressed')];
 
+            // The reserve is the WHOLE trailing action partition, not the overflow control alone.
+            // Gated actions count: the focus-gating carrier hides them with `visibility`, which
+            // preserves their box, so a tab allowed to run under a quiet action would still be
+            // covered the moment its pane takes focus. Measured from the DOM rather than a count
+            // times an assumed size — the partition is per-consumer and per-opt-in flag.
+            const actions = toolbar ? [...toolbar.querySelectorAll(':scope > .neo-toolbar-action')] : [],
+                  cluster = actions.length && toolbar
+                      ? rect(toolbar).right - Math.min(...actions.map(action => rect(action).left))
+                      : 0;
+
             return {
-                control: control && rect(control),
-                capped : capped && {
+                control     : control && rect(control),
+                actionCount : actions.length,
+                clusterWidth: cluster,
+                capped      : capped && {
                     rect         : rect(capped),
                     maxWidth     : parseFloat(capped.style.maxWidth),
                     textOverflow : getComputedStyle(capped.querySelector('.neo-button-text')).textOverflow,
@@ -97,12 +113,21 @@ test.describe('Workstation — the active tab never runs beneath the overflow co
             'the per-button indicator spans exactly the capped box'
         ).toBeLessThanOrEqual(1);
 
+        // The staging guard: this identity is only meaningful while the header carries a real action
+        // partition. If the app ever collapses back to a lone overflow control, the assertion below
+        // degenerates into the single-operand form it replaced and stops testing the cluster at all.
+        expect(facts.actionCount, 'the heavy header must stage a multi-action trailing partition')
+            .toBeGreaterThan(1);
+
         // Reservation truth (single value, render-grounded): the cap the plugin applied equals the
-        // toolbar extent minus the RENDERED control width — not the pre-creation estimate.
+        // toolbar extent minus the RENDERED trailing action cluster — not the pre-creation estimate,
+        // and not the overflow control alone. The control was the whole partition once; the engine
+        // action set made it a cluster, and a cap that reserved only the control would let the active
+        // tab run under close and maximize — the exact covered-tab symptom this spec guards against.
         expect(
             facts.capped.maxWidth,
-            `cap must derive from the rendered control width (extent ${facts.toolbarRect.width}, control ${facts.control.width})`
-        ).toBe(Math.floor(facts.toolbarRect.width) - Math.ceil(facts.control.width));
+            `cap must derive from the rendered action cluster (extent ${facts.toolbarRect.width}, ${facts.actionCount} actions spanning ${facts.clusterWidth})`
+        ).toBe(Math.floor(facts.toolbarRect.width) - Math.ceil(facts.clusterWidth));
 
         // The covered cut becomes an honest ellipsis.
         expect(facts.capped.textOverflow, 'capped label must ellipsize').toBe('ellipsis');


### PR DESCRIPTION
Resolves #17988

> 🌿 The cap used to be measured against the one thing that happened to sit at the header's edge; now measuring it against anything less than the whole partition is unsayable.

`dev` was red here — expected `251`, received `203`, a delta of exactly `2 × 24px`.

The spec re-derived the cap from `toolbarWidth - controlWidth`. That was right when the overflow control was the only trailing action. #17963 turned on close, pin and maximize in `apps/workstation`, so the header now carries a `3 × 24px` partition and the plugin reserves all of it: `275 - 72 = 203`. **Production produced the correct number; the identity named the wrong operand.**

What convicts the formula rather than the plugin is that *every geometric assertion in the same test already passed* — zero painted intersection, box ends at the control edge, indicator spans the capped box, label ellipsizes. The geometry this spec exists to protect was intact the whole time. None of those assertions changed.

## AC Evidence

| AC | Evidence |
|---|---|
| AC-1 spec green at the `dev` head, cap re-derived from the rendered cluster | `WorkstationTabOverflowCapNL` green at `5397bb4a9e`; same production code that produced the red |
| AC-2 cluster measured from the DOM, not a count × assumed size | `toolbar.querySelectorAll(':scope > .neo-toolbar-action')`, extent = `toolbarRect.right - min(action.left)`. No literal `3`, no literal `24` |
| AC-3 gated actions counted, reason written in-spec | live measurement on the heavy header: `More tabs` 24px visible, `maximize` 24px `visibility: hidden`, `close` 24px visible — cluster `72`. The carrier hides with `visibility`, which preserves the box, so a quiet action still occupies space |
| AC-4 guard against degenerating back | `expect(facts.actionCount).toBeGreaterThan(1)` immediately before the identity |
| AC-5 every existing geometry assertion unchanged | diff touches the fact-collection block, the identity, the new guard and the `@summary`; the four geometry assertions are byte-identical |
| AC-6 `WorkstationStarvedGeometryNL` remains red, out of scope | unchanged and untouched; different subject (row pool under a starved renderer), wants its own measurement |

## Falsifier receipt

Same production code, two formulas:

- old (`extent - control`): **red**, `expected 251, received 203`
- new (`extent - cluster`): **green**

So the identity is discriminating, not vacuous — it moved because the operand changed, not because the assertion was loosened. Nothing was widened to a tolerance: `toBe` stays exact, which is the point of an identity that claims the cap is re-derived from render truth rather than an estimate.

## Deltas from ticket

None to the fix. One addition the ticket did not name: the spec's `@summary` still promised *"the reservation the cap used must equal the RENDERED control width"*. That sentence would have gone stale the moment this landed and is exactly the doc a future reader trusts over the code, so it now names the cluster and says why the partition is variable.

## Test Evidence

Evidence: L3 (real-browser Neural Link e2e at the PR head) → L3 required (rendered-geometry AC). No residuals.

- `WorkstationTabOverflowCapNL` green ×2 at the PR head.
- The live measurement backing the cluster arithmetic was taken in the running app, not derived: 3 actions × 24px, `toolbarWidth 315.6`, cluster `72`.

## Post-Merge Validation

The next consumer that opts into a different action subset re-derives its own cluster with no spec change; a consumer that collapses to a lone overflow control reds on the staging guard instead of silently degenerating.

## Commits

- `5397bb4a9e` test(workstation): the overflow cap reserves the action cluster, not one control (#17988)

Authored by Vega (Opus 5, Claude Code). Session a4fa24e6-b983-4ecd-81a2-8b98baef9cfc.
