### PR TITLE
The in-flight update registry tracks a mid-flight depth escalation

### DIFF
--- a/src/manager/VDomUpdate.mjs
+++ b/src/manager/VDomUpdate.mjs
@@ -406,6 +406,44 @@ class VDomUpdate extends Collection {
     }
 
     /**
+     * Widens the recorded depth of an update that is ALREADY in flight.
+     *
+     * `registerInFlightUpdate` records the depth once, when the cycle starts. The payload is built
+     * later, from `component.updateDepth` read live after a macrotask yield — and `Component#show()`
+     * sets `parent.updateDepth = -1` in exactly that window, because a floating widget mounting into
+     * its parent needs the full tree. The escalation is correct and must not be undone.
+     *
+     * What was wrong is that only the payload learned about it. {@link
+     * Neo.mixin.VdomLifecycle#isParentUpdating} and `hasUpdateCollision` both read the registry, so
+     * every consumer of the collision contract is answered from a scope the payload no longer has.
+     *
+     * What that incoherence goes on to cause is deliberately NOT asserted anywhere in this lane: a
+     * second overlapping flight was hypothesised and measured NOT to occur, because something further
+     * down still queues the sibling write. That absorber is unidentified.
+     *
+     * **This only ever widens.** It mirrors `beforeSetUpdateDepth`'s monotonic contract (-1 absorbs,
+     * otherwise `Math.max`), so the recorded scope can never shrink below what the collision check
+     * has already promised, and a payload can never lose a subtree because of it. The sole effect of
+     * being wrong here is more serialization, never a missing node.
+     *
+     * A component with no entry is not in flight and is left alone — this must not create one.
+     * @param {String} ownerId     The `id` of the component owning the update.
+     * @param {Number} updateDepth The escalated depth.
+     */
+    escalateInFlightUpdate(ownerId, updateDepth) {
+        const current = this.inFlightUpdateMap.get(ownerId);
+
+        if (current === undefined) return;
+
+        // No watchdog re-arm and no descendant re-registration: the flight is the same flight, and
+        // re-arming would hand a wedged component a fresh timeout on every escalation.
+        this.inFlightUpdateMap.set(
+            ownerId,
+            current === -1 || updateDepth === -1 ? -1 : Math.max(updateDepth, current)
+        )
+    }
+
+    /**
      * Marks a component's VDOM update as "in-flight," meaning it has been sent to the
      * worker for processing.
      * @param {String} ownerId     The `id` of the component owning the update.

--- a/src/mixin/VdomLifecycle.mjs
+++ b/src/mixin/VdomLifecycle.mjs
@@ -501,6 +501,29 @@ class VdomLifecycle extends Base {
     }
 
     /**
+     * Triggered after the updateDepth config got changed.
+     *
+     * A depth escalation that arrives while this component's own update is already in flight must
+     * reach the collision check, not only the payload. `Component#show()` is the canonical case: it
+     * sets `parent.updateDepth = -1` because a floating widget mounting into its parent needs the
+     * full tree, and it can land inside the parent's collection yield. The payload then widens while
+     * {@link Neo.manager.VDomUpdate#getInFlightUpdateDepth} still reports the depth the cycle
+     * started with — so `isParentUpdating` and `hasUpdateCollision`, which both read the registry,
+     * answer every caller from a scope the payload no longer has.
+     *
+     * Widening only — see {@link Neo.manager.VDomUpdate#escalateInFlightUpdate}. The escalation
+     * itself is left completely alone; the payload keeps the scope `show()` asked for.
+     * @param {Number} value
+     * @param {Number} oldValue
+     * @protected
+     */
+    afterSetUpdateDepth(value, oldValue) {
+        // `getVdomUpdatePayload` resets the depth by writing `_updateDepth` directly, which does not
+        // reach this hook — so a collection reset can never narrow a flight that is still open.
+        this.isVdomUpdating && VDomUpdate.escalateInFlightUpdate(this.id, value)
+    }
+
+    /**
      * Checks if a child update can be merged into a parent update.
      *
      * **Merge Strategy (Optimization):**

--- a/test/playwright/component/apps/tab-header-race/app.mjs
+++ b/test/playwright/component/apps/tab-header-race/app.mjs
@@ -1,0 +1,212 @@
+import Button       from '../../../../../src/button/Base.mjs';
+import Neo          from '../../../../../src/Neo.mjs';
+import TabContainer from '../../../../../src/tab/Container.mjs';
+import VDomUpdate   from '../../../../../src/manager/VDomUpdate.mjs';
+import Viewport     from '../../../../../src/container/Viewport.mjs';
+
+/**
+ * Drives a mid-flight update-depth escalation against a REAL tab header toolbar, in a real browser.
+ *
+ * `Component#show()` sets `parent.updateDepth = -1` and calls `parent.update()`, because a floating
+ * widget mounting into its parent needs the full tree. When that lands inside the parent's own
+ * collection yield the payload widens, and until this lane the in-flight registry still reported the
+ * depth the cycle STARTED with — so `isParentUpdating` and `hasUpdateCollision`, which both read the
+ * registry, answered every caller from a scope the payload no longer had.
+ *
+ * What that incoherence causes downstream is NOT asserted by this harness. A second overlapping
+ * flight was hypothesised and measured not to occur.
+ *
+ * The sequence runs inside the App worker rather than being driven from the page: the window is a
+ * single macrotask wide and every page-to-worker call is a round trip far longer than that.
+ *
+ * The report is a declared config so the spec can refuse a verdict it never observed. A run that
+ * never entered the window would otherwise be green for the same reason a fixed one is.
+ */
+class RaceViewport extends Viewport {
+    static config = {
+        className: 'Test.TabHeaderRace.Viewport',
+        ntype    : 'tab-header-race-viewport',
+
+        /**
+         * Set once the sequence has finished, whether or not it entered the window.
+         * @member {Boolean} raceComplete_=false
+         */
+        raceComplete_: false,
+        /**
+         * @member {Object|null} raceReport_=null
+         */
+        raceReport_: null
+    }
+
+    /**
+     * @param {Boolean} value
+     * @param {Boolean} oldValue
+     */
+    afterSetMounted(value, oldValue) {
+        super.afterSetMounted?.(value, oldValue);
+        value && !oldValue && this.runRace()
+    }
+
+    async runRace() {
+        try {
+            await this.driveRace()
+        } catch (error) {
+            this.raceReport  = {windowEntered: false, error: error.message};
+            this.raceComplete = true
+        }
+    }
+
+    async driveRace() {
+        const me     = this,
+              tabs   = Neo.getComponent('race-tab-container'),
+              tabBar = tabs.getTabBar();
+
+        await me.timeout(400);
+
+        // Capture the real tab buttons before the action joins the bar. Their ids are minted by
+        // tab.Container, not taken from `tabButtonConfig`, so naming them here would be a guess.
+        const [, tabBeta] = tabBar.items;
+
+        // A header action that starts hidden. Becoming visible runs Component#show().
+        const action = Neo.create(Button, {
+            appName : tabBar.appName,
+            id      : 'race-header-action',
+            hideMode: 'removeDom',
+            hidden  : true,
+            iconCls : 'fa fa-lock',
+            windowId: tabBar.windowId
+        });
+
+        tabBar.add(action);
+        await me.timeout(300);
+
+        // Drain one cycle. `getVdomUpdatePayload` resets the depth by writing `_updateDepth`, so a
+        // bar that has ever been at -1 stays there until one payload is collected — without this
+        // the second cycle would open at -1 and there would be no disagreement to create.
+        tabBar.updateDepth = 1;
+        tabBar.update();
+        await me.timeout(250);
+
+        // Open the second cycle and step into it.
+        tabBar.update();
+
+        for (let i = 0; i < 60 && !tabBar.isVdomUpdating; i++) {
+            await me.timeout(0)
+        }
+
+        const registeredBefore = VDomUpdate.getInFlightUpdateDepth(tabBar.id) ?? null,
+              windowEntered    = tabBar.isVdomUpdating && registeredBefore === 1;
+
+        let escalation = null;
+
+        if (windowEntered) {
+            action.hidden = false;                                  // the real Component#show()
+
+            // Sampled HERE, not after the settle. `getVdomUpdatePayload` resets the depth once the
+            // payload is collected, so a reading taken after the cycle reports the config default
+            // and would call a broken build healthy.
+            escalation = {
+                live      : tabBar.updateDepth,
+                registered: VDomUpdate.getInFlightUpdateDepth(tabBar.id) ?? null
+            };
+
+            tabBeta.text = 'Beta changed'                           // the sibling write
+        }
+
+        await me.timeout(600);
+
+        // ---------------------------------------------------------------------------------------
+        // The behavioural half: does a sibling actually OPEN a second flight?
+        //
+        // The write above is absorbed before it can answer that. `update()` tries
+        // `mergeIntoParentUpdate` BEFORE `isParentUpdating`, and a write issued while the parent is
+        // still collecting is merged — so it never reaches the collision check at all. That is why
+        // the sibling arm was removed from the unit spec: it passed with the hook disabled.
+        //
+        // `beforeExecuteVdomUpdate` fires AFTER collection and immediately before dispatch. A write
+        // issued there finds the parent's `needsVdomUpdate` already false, so the merge declines it
+        // and it falls through to `isParentUpdating` — the seam itself. Without the hook the registry
+        // still reads 1, `hasUpdateCollision(1, 1)` is false, and the action opens its own flight
+        // over a subtree the parent is about to insert. With the hook it reads -1 and is queued.
+        //
+        // Seam identified by @neo-gpt in review; the merge-before-collision ordering is why the
+        // obvious placement could never have shown it.
+        // ---------------------------------------------------------------------------------------
+        let postCollection = null;
+
+        if (windowEntered) {
+            const hiddenAction = Neo.create(Button, {
+                appName : tabBar.appName,
+                id      : 'race-post-collection-action',
+                hideMode: 'removeDom',
+                hidden  : true,
+                iconCls : 'fa fa-thumbtack',
+                windowId: tabBar.windowId
+            });
+
+            tabBar.add(hiddenAction);
+            await me.timeout(300);
+
+            // Drain again so the next cycle opens at the default depth rather than at -1.
+            tabBar.updateDepth = 1;
+            tabBar.update();
+            await me.timeout(250);
+
+            let fired = false;
+
+            tabBar.beforeExecuteVdomUpdate = function() {
+                if (fired) return;
+                fired = true;
+
+                hiddenAction.hidden = false;   // escalates the bar to -1, post-collection
+                hiddenAction.update();         // the write that must reach isParentUpdating
+
+                postCollection = {
+                    registered      : VDomUpdate.getInFlightUpdateDepth(tabBar.id) ?? null,
+                    siblingOpenedOwn: hiddenAction.isVdomUpdating === true
+                }
+            };
+
+            tabBar.update();
+            await me.timeout(700);
+
+            delete tabBar.beforeExecuteVdomUpdate;
+
+            postCollection &&= {...postCollection, hookFired: fired}
+        }
+
+        me.raceReport = {
+            windowEntered,
+            registeredBefore,
+            escalation,
+            postCollection,
+            tabButtonIds: tabBar.items.map(item => item.id)
+        };
+
+        me.raceComplete = true
+    }
+}
+
+RaceViewport = Neo.setupClass(RaceViewport);
+
+export const onStart = () => Neo.app({
+    mainView: {
+        module: RaceViewport,
+        id    : 'tab-header-race-viewport',
+
+        items: [{
+            module     : TabContainer,
+            activeIndex: 0,
+            height     : 300,
+            id         : 'race-tab-container',
+            width      : 600,
+
+            items: [
+                {module: Button, id: 'race-body-alpha', text: 'Alpha body', tabButtonConfig: {id: 'race-tab-alpha', text: 'Alpha'}},
+                {module: Button, id: 'race-body-beta',  text: 'Beta body',  tabButtonConfig: {id: 'race-tab-beta',  text: 'Beta'}}
+            ]
+        }]
+    },
+
+    name: 'Test.Playwright.TabHeaderRace'
+});

--- a/test/playwright/component/apps/tab-header-race/index.html
+++ b/test/playwright/component/apps/tab-header-race/index.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Neo.mjs Component Test App</title>
+</head>
+<body>
+    <script src="../../../../../src/MicroLoader.mjs" type="module"></script>
+</body>
+</html>

--- a/test/playwright/component/apps/tab-header-race/neo-config.json
+++ b/test/playwright/component/apps/tab-header-race/neo-config.json
@@ -1,0 +1,7 @@
+{
+    "appPath"    : "test/playwright/component/apps/tab-header-race/app.mjs",
+    "basePath"   : "../../../../../",
+    "environment": "development",
+    "mainPath"   : "./Main.mjs",
+    "themes"     : ["neo-theme-neo-dark", "neo-theme-neo-light"]
+}

--- a/test/playwright/component/component/TabHeaderEscalationRace.spec.mjs
+++ b/test/playwright/component/component/TabHeaderEscalationRace.spec.mjs
@@ -1,0 +1,92 @@
+import {test, expect} from '@playwright/test';
+
+/**
+ * The in-flight registry reports a scope the payload no longer has — measured on a real
+ * `tab.header.Toolbar`, in a real browser.
+ *
+ * `Component#show()` sets `parent.updateDepth = -1` and calls `parent.update()`, because a floating
+ * widget mounting into its parent needs the full tree. When that lands inside the parent's own
+ * collection yield the payload widens to -1 while `getInFlightUpdateDepth` still answers with the
+ * depth the cycle STARTED with. `isParentUpdating` and `hasUpdateCollision` both consult the
+ * registry, so every consumer of the collision contract is answered from a stale value.
+ *
+ * **This file asserts registry coherence and nothing beyond it.** An earlier version described a
+ * second overlapping flight and duplicate DOM as the consequence. That chain is NOT witnessed here:
+ * measured with the hook disabled, the sibling write is still queued, because something further down
+ * absorbs it. The duplicate-render defect was separate and separately cured. Naming a consequence a
+ * test does not reach is how a label becomes a substitute for a witness.
+ *
+ * Reaching the window needs a SECOND cycle: `getVdomUpdatePayload` resets the depth by writing
+ * `_updateDepth`, so a bar that has ever been at -1 stays there until one payload is collected.
+ */
+test.describe('tab header toolbar — a depth escalation arriving mid-flight', () => {
+    test.beforeEach(async ({page}) => {
+        await page.goto('test/playwright/component/apps/tab-header-race/index.html');
+        await page.waitForSelector('#race-tab-container', {state: 'attached'});
+
+        await expect.poll(
+            // Array form: `getConfigs` answers a key LIST with a list, and a single-string key with
+            // a shape this poll compared wrongly — a mismatch that reads as "the harness never
+            // finished" for twenty seconds rather than as an instrument error.
+            () => page.evaluate(async () => (await Neo.worker.App.getConfigs({
+                id: 'tab-header-race-viewport', keys: ['raceComplete']
+            }))[0]),
+            {message: 'the harness must finish its race sequence', timeout: 20000}
+        ).toBe(true)
+    });
+
+    test('the window under test is actually entered', async ({page}) => {
+        const [report] = await page.evaluate(() => Neo.worker.App.getConfigs({
+            id: 'tab-header-race-viewport', keys: ['raceReport']
+        }));
+
+        // Non-vacuity. If the bar was already at -1 when the cycle opened there is no disagreement
+        // to create, and every assertion in the sibling arm would pass for the wrong reason.
+        expect(report.windowEntered, `race report: ${JSON.stringify(report)}`).toBe(true);
+        expect(report.registeredBefore, 'the cycle must open at the default scope').toBe(1);
+
+        // show() must still widen the payload to the full tree. Narrowing this is the regression
+        // this suite exists to forbid, not the bug it exists to fix.
+        expect(report.escalation.live, 'show() must still escalate the payload scope').toBe(-1);
+
+        // ...and the collision check must see the same scope the payload will be built from.
+        expect(report.escalation.registered, 'the registry must track the escalation').toBe(-1)
+    });
+
+    /**
+     * The registry read taken from where a consumer of the collision contract actually takes it.
+     *
+     * A write issued while the parent is still collecting is absorbed by `mergeIntoParentUpdate`,
+     * which `update()` tries BEFORE `isParentUpdating` — so the obvious placement never reaches the
+     * registry at all. Issued from `beforeExecuteVdomUpdate` it lands after collection, the merge
+     * declines it because the parent's `needsVdomUpdate` is already false, and the read happens at
+     * the seam. Seam identified by @neo-gpt in review.
+     *
+     * `siblingOpenedOwn` is recorded and deliberately NOT asserted: measured, it is false with the
+     * hook disabled too, so an assertion on it would pass under mutation. Recording a value this file
+     * cannot discriminate on is honest; asserting it would not be.
+     */
+    test('the post-collection registry read carries the escalation', async ({page}) => {
+        const [report] = await page.evaluate(() => Neo.worker.App.getConfigs({
+            id: 'tab-header-race-viewport', keys: ['raceReport']
+        }));
+
+        expect(report.postCollection, `race report: ${JSON.stringify(report)}`).not.toBeNull();
+        expect(report.postCollection.hookFired, 'beforeExecuteVdomUpdate must have fired').toBe(true);
+
+        // The assertion that reddens without the hook (`Received: 1`).
+        expect(report.postCollection.registered, 'the record must carry the escalation').toBe(-1);
+
+        expect(
+            report.postCollection,
+            'recorded, not asserted — siblingOpenedOwn does not discriminate'
+        ).toHaveProperty('siblingOpenedOwn')
+    });
+
+    // Two DOM arms lived here — "no element id is rendered twice" and "each tab button appears
+    // exactly once" — REMOVED rather than relabelled. Both passed with the escalation hook disabled,
+    // so neither witnessed anything about this defect, and the duplicate-render class they guarded
+    // belongs to a separate, separately cured bug. A green arm that cannot fail is not a cheap
+    // forward guard; it is a claim of coverage this file cannot honour. The invariant that DOES catch
+    // that class lives on `ada/17980-duplicate-id-detector`, with a firing control.
+});

--- a/test/playwright/unit/vdom/RaceCondition.spec.mjs
+++ b/test/playwright/unit/vdom/RaceCondition.spec.mjs
@@ -152,6 +152,114 @@ test.describe('VdomLifecycle Race Condition', () => {
     });
 
     /**
+     * The in-flight registry reports a scope the payload no longer has.
+     *
+     * The depth is registered ONCE, when the cycle starts; the payload is built from
+     * `component.updateDepth` read LIVE after a macrotask yield. Between those two reads sits
+     * `Component#show()`, which sets `parent.updateDepth = -1` and calls `parent.update()` — so a
+     * header-action button becoming visible escalates its parent's depth mid-flight. That escalation
+     * is correct and these arms must never narrow it: a floating widget mounting into its parent
+     * needs the full tree.
+     *
+     * `isParentUpdating` and `hasUpdateCollision` both consult the REGISTERED depth, so every
+     * consumer of the collision contract is answered from a scope the payload no longer has. **That
+     * incoherence is the whole claim.** What it goes on to cause is not asserted here — a second
+     * overlapping flight was hypothesised and measured NOT to occur, because something further down
+     * still queues the sibling write, and the duplicate-render defect that hypothesis named was
+     * separate and separately cured.
+     *
+     * Reaching the window deterministically needs a SECOND cycle: `getVdomUpdatePayload` resets the
+     * depth to the config default by writing `_updateDepth`, so a container that has ever been at -1
+     * stays there until one payload is collected. The first drain below is what makes the window
+     * exist at all.
+     */
+    test.describe('a depth escalation arriving mid-flight', () => {
+        /**
+         * Opens a real second cycle and returns once it is genuinely in flight at depth 1.
+         * Returns false when the window could not be entered, so a caller can refuse to report a
+         * verdict it never observed.
+         */
+        const openSecondCycleAtDepthOne = async (container, child) => {
+            child.text = `${child.text} drain`;
+            await container.promiseUpdate();
+            await new Promise(resolve => setTimeout(resolve, 40));
+
+            child.text = `${child.text} again`;
+            container.update();
+
+            for (let i = 0; i < 40 && !container.isVdomUpdating; i++) {
+                await new Promise(resolve => setTimeout(resolve, 0))
+            }
+
+            return container.isVdomUpdating && VDomUpdate.getInFlightUpdateDepth(container.id) === 1
+        };
+
+        const buildContainer = async (containerId, hiddenId, siblingId) => {
+            const container = Neo.create(RaceContainer, {
+                appName,
+                id   : containerId,
+                items: [
+                    {module: RaceChildComponent, id: hiddenId,  hidden: true, text: 'Hidden'},
+                    {module: RaceChildComponent, id: siblingId, text: 'Sibling'}
+                ]
+            });
+
+            await container.initVnode(true);
+            container.mounted = true;
+            await new Promise(resolve => setTimeout(resolve, 40));
+
+            return container
+        };
+
+        test('reaches the collision check, while leaving the payload scope exactly as show() set it', async () => {
+            const containerId = getUniqueId('escalation-container');
+            createdComponentIds.push(containerId);
+
+            const container = await buildContainer(containerId, getUniqueId('hidden'), getUniqueId('sibling')),
+                  opened    = await openSecondCycleAtDepthOne(container, container.items[1]);
+
+            expect(opened, 'the depth-1 flight must be open, or this arm witnesses nothing').toBe(true);
+
+            // The real path: `hidden = false` runs Component#show().
+            container.items[0].hidden = false;
+
+            // The escalation itself is untouched. A floating widget mounting through show() still
+            // gets the full tree — narrowing this is the regression this arm exists to forbid.
+            expect(container.updateDepth, 'show() must still widen the payload to the full tree').toBe(-1);
+
+            // ...and the collision check now knows about it.
+            expect(
+                VDomUpdate.getInFlightUpdateDepth(containerId),
+                'the registered depth must track the scope the payload will be built from'
+            ).toBe(-1);
+
+            await new Promise(resolve => setTimeout(resolve, 60))
+        });
+
+        // A sibling arm lived here and was removed: it passed with the fix disabled, because
+        // `update()` tries `mergeIntoParentUpdate` BEFORE `isParentUpdating`, so in a plain
+        // container the sibling is absorbed by the merge and never reaches the collision check at
+        // all. It therefore witnessed nothing about this defect. The DOM-level consequence is
+        // covered at the component tier, where a real tab bar reaches the check; keeping a green
+        // arm here that cannot fail would have been worse than having none.
+
+        test('never narrows a flight: a reset written during collection cannot lower the record', () => {
+            const containerId = getUniqueId('escalation-guard');
+
+            VDomUpdate.registerInFlightUpdate(containerId, -1);
+
+            VDomUpdate.escalateInFlightUpdate(containerId, 1);
+            expect(VDomUpdate.getInFlightUpdateDepth(containerId), '-1 absorbs').toBe(-1);
+
+            VDomUpdate.unregisterInFlightUpdate(containerId);
+
+            // A component that is not in flight must not gain an entry.
+            VDomUpdate.escalateInFlightUpdate(containerId, -1);
+            expect(VDomUpdate.getInFlightUpdateDepth(containerId), 'no entry is created').toBeUndefined()
+        })
+    });
+
+    /**
      * Verifies that two siblings updating strictly their own internal structure (Depth 1)
      * do not cause conflicts or trigger unnecessary parent updates that lead to duplication.
      */


### PR DESCRIPTION
Resolves #17998

**Evidence:** `npm run test-unit` **2915 passed** at head `93a9b73157` · one commit, rebased flat on current `dev` · **every retained arm reddens with the hook disabled** — measured, not inherited: hook off gives `unit/vdom/RaceCondition` 1 failed / 5 passed and `component/component/TabHeaderEscalationRace` 2 failed.

> Receipt corrected on takeover: the line named `28ab6ce862`, which the rebase superseded. The count was right and re-observed at the real head; the SHA was not.

## The defect

`Neo.manager.VDomUpdate` records a component's update depth **once**, when the cycle opens. The payload is built from `component.updateDepth` read **live**, after a macrotask yield.

```javascript
VDomUpdate.registerInFlightUpdate(me.id, me.updateDepth);   // recorded HERE
await new Promise(resolve => setTimeout(resolve, 1));       // ← the window
depths.set(componentId, component.updateDepth);             // read LIVE, HERE
```

`Component#show()` writes into exactly that window, and correctly — a floating widget mounting into its parent needs the full tree. **So `getInFlightUpdateDepth` answers `1` while the payload is built at `-1`.** `isParentUpdating` and `hasUpdateCollision` both consult the registry, so every consumer of the collision contract is answered from a scope the payload no longer has.

Measured in a real browser on a real `tab.header.Toolbar`:

```
[cycle2 open] updating=true  live=1   registered=1
[ESCALATED]   live=-1        registered=1     ← disagreement
```

## The fix

`escalateInFlightUpdate` widens the **record**, never the payload, mirroring `beforeSetUpdateDepth`'s monotonic contract (`-1` absorbs, otherwise `Math.max`).

**Freezing the depth per cycle — the obvious fix — would drop a mounting widget out of the payload meant to carry it**, flagged by @tobiu as the severe-regression risk on this surface. Being wrong in *this* direction costs serialization; it can never drop a subtree. `getVdomUpdatePayload` resets by writing `_updateDepth` directly, so a collection reset never reaches the hook.

## ⛔ Scope corrected in review — RA-1

**This is a registry-coherence defect and nothing more.**

An earlier framing of this PR, its ticket and its commits claimed a second overlapping flight and duplicate DOM as the consequence. **I measured that it does not occur** — with the hook disabled the sibling is still queued, because something further down absorbs it — recorded that in the spec file, **and then left the causal claim standing everywhere else.** @neo-gpt-emmy caught the mismatch, correctly.

- `#17998` is amended to the witnessed defect, title included.
- The spec doc-blocks are retargeted.
- **Two DOM arms are removed, not relabelled.** Both passed with the hook disabled, so neither witnessed anything about this defect, and the duplicate-render class they guarded belongs to `#17980` — separate, and cured by `#17999`. A green arm that cannot fail is a claim of coverage, not cheap insurance.
- No assertion on a registry value is called behavioural any more.

The invariant that *does* catch the duplicate-render class lives on `ada/17980-duplicate-id-detector`, with a firing control.

**Not addressed, and not required here:** identifying what absorbs the sibling write downstream of the collision check. Real, unowned, stated rather than hidden.

## Arms

| arm | tier | hook disabled |
|---|---|---|
| the record tracks the escalation | unit | **red** |
| `show()` still escalates the payload to `-1` | unit + component | **red** |
| the window under test is actually entered | component | **red** |
| the post-collection registry read carries the escalation | component | **red** |
| `-1` absorbs; no entry is created for a component not in flight | unit | tests the new manager API directly |

Authored by Ada (Claude Opus 5, Claude Code). Session bd974a9a-cef5-4d7b-99e5-9329b3f6f053.

