### PR TITLE
fix(dock): land motion before nested resize (#17985)

### DIFF
--- a/src/dashboard/dock/interaction/DockSplitter.mjs
+++ b/src/dashboard/dock/interaction/DockSplitter.mjs
@@ -1,6 +1,5 @@
 import Splitter     from '../../../component/Splitter.mjs';
 import Operations   from '../model/Operations.mjs';
-import MotionSignal from '../projection/MotionSignal.mjs';
 import NeoArray     from '../../../util/Array.mjs';
 
 /**
@@ -119,15 +118,6 @@ class DockSplitter extends Splitter {
          */
         splitNodeId_: null
     }
-
-    /**
-     * Maximum time a direct-manipulation start waits for the main-thread FLIP landing receipt.
-     * A missing addon can leave remote calls pending forever, so admission fails open after the
-     * same 100ms horizon used by DockFlip's starvation-proof frame dam.
-     * @member {Number} dockFlipLandTimeout=100
-     * @protected
-     */
-    dockFlipLandTimeout = 100
 
     /**
      * @member {Object|null} dragStartState=null
@@ -336,6 +326,8 @@ class DockSplitter extends Splitter {
     }
 
     /**
+     * @summary Builds the main-thread live-resize descriptor for one dock affordance.
+     *
      * Edge affordances use the inherited single-target descriptor: their band previews live under
      * CSS min/max bounds plus a 1px commit-domain floor (the extent the semantic commit accepts is
      * the open interval (0,1), so the preview must never paint the 0px frame the model refuses).
@@ -523,45 +515,15 @@ class DockSplitter extends Splitter {
     }
 
     /**
-     * @summary Lands main-thread DockFlip presentation before live-resize geometry is captured.
+     * @summary Captures dock semantics after Main has admitted physical resize.
      *
-     * A structural dock commit may temporarily hoist retained descendants onto fixed old-pixel
-     * geometry. Resizing their new ancestor while that presentation still owns them makes the
-     * direct outer pair move while the descendants remain visually frozen. Direct manipulation
-     * wins: the main-thread addon restores committed layout authority first. A missing or degraded
-     * addon stays fail-open so presentation can never block the splitter gesture.
+     * Captures adjacent-pair geometry and projects proxy paint before the generic parent refreshes
+     * the zone and opens the logical gesture. Physical live-resize admission happens earlier on
+     * the Main thread: DragDrop synchronously lands any DockFlip presentation on the native event
+     * path before Resize creates or applies geometry state. The App-side handler therefore remains
+     * semantic and never tries to serialize Main behind an unawaited cross-worker event.
      *
-     * @returns {Boolean|Promise<Boolean>} Whether an active presentation was landed.
-     * @protected
-     */
-    landActiveDockMotion() {
-        const
-            workspace = this.up('dock-workspace'),
-            host      = workspace?.getDockHost?.();
-
-        if (!workspace || !MotionSignal.isAnimating(workspace.id) || !host?.id || host.windowId == null) return false;
-
-        try {
-            const result = Neo.main?.addon?.DockFlip?.land?.({
-                hostId  : host.id,
-                windowId: host.windowId
-            });
-
-            return typeof result?.then === 'function'
-                ? Promise.race([
-                    result.then(Boolean, () => false),
-                    this.timeout(this.dockFlipLandTimeout).then(() => false, () => false)
-                ])
-                : result ?? false
-        } catch {
-            return false
-        }
-    }
-
-    /**
-     * Lands competing FLIP presentation, captures the adjacent-pair geometry, and projects proxy
-     * paint BEFORE the generic parent refreshes the zone and starts the gesture (the proxy is
-     * created inside the parent's start).
+     * The proxy is created inside the parent's start.
      * The armed generation fences those awaits: the parent arms its own fence only inside
      * `super.onDragStart()`, so a cancel, destroy, terminal, or newer start landing during the
      * capture/projection awaits must invalidate the pending start here, before the real gesture
@@ -571,16 +533,7 @@ class DockSplitter extends Splitter {
      */
     async onDragStart(data={}) {
         let me         = this,
-            generation = ++me.dragGeneration,
-            landing    = me.landActiveDockMotion();
-
-        if (typeof landing?.then === 'function') {
-            await landing
-        }
-
-        if (generation !== me.dragGeneration || me.isDestroyed) {
-            return
-        }
+            generation = ++me.dragGeneration;
 
         await me.captureDragStart(data);
 

--- a/src/dashboard/dock/interaction/DockSplitter.mjs
+++ b/src/dashboard/dock/interaction/DockSplitter.mjs
@@ -1,6 +1,7 @@
-import Splitter   from '../../../component/Splitter.mjs';
-import Operations from '../model/Operations.mjs';
-import NeoArray   from '../../../util/Array.mjs';
+import Splitter     from '../../../component/Splitter.mjs';
+import Operations   from '../model/Operations.mjs';
+import MotionSignal from '../projection/MotionSignal.mjs';
+import NeoArray     from '../../../util/Array.mjs';
 
 /**
  * @summary Dock splitter affordance: generic Splitter mechanics, one dock-document semantic commit.
@@ -118,6 +119,15 @@ class DockSplitter extends Splitter {
          */
         splitNodeId_: null
     }
+
+    /**
+     * Maximum time a direct-manipulation start waits for the main-thread FLIP landing receipt.
+     * A missing addon can leave remote calls pending forever, so admission fails open after the
+     * same 100ms horizon used by DockFlip's starvation-proof frame dam.
+     * @member {Number} dockFlipLandTimeout=100
+     * @protected
+     */
+    dockFlipLandTimeout = 100
 
     /**
      * @member {Object|null} dragStartState=null
@@ -513,8 +523,45 @@ class DockSplitter extends Splitter {
     }
 
     /**
-     * Captures the adjacent-pair geometry and projects the proxy paint BEFORE the generic parent
-     * refreshes the zone and starts the gesture (the proxy is created inside the parent's start).
+     * @summary Lands main-thread DockFlip presentation before live-resize geometry is captured.
+     *
+     * A structural dock commit may temporarily hoist retained descendants onto fixed old-pixel
+     * geometry. Resizing their new ancestor while that presentation still owns them makes the
+     * direct outer pair move while the descendants remain visually frozen. Direct manipulation
+     * wins: the main-thread addon restores committed layout authority first. A missing or degraded
+     * addon stays fail-open so presentation can never block the splitter gesture.
+     *
+     * @returns {Boolean|Promise<Boolean>} Whether an active presentation was landed.
+     * @protected
+     */
+    landActiveDockMotion() {
+        const
+            workspace = this.up('dock-workspace'),
+            host      = workspace?.getDockHost?.();
+
+        if (!workspace || !MotionSignal.isAnimating(workspace.id) || !host?.id || host.windowId == null) return false;
+
+        try {
+            const result = Neo.main?.addon?.DockFlip?.land?.({
+                hostId  : host.id,
+                windowId: host.windowId
+            });
+
+            return typeof result?.then === 'function'
+                ? Promise.race([
+                    result.then(Boolean, () => false),
+                    this.timeout(this.dockFlipLandTimeout).then(() => false, () => false)
+                ])
+                : result ?? false
+        } catch {
+            return false
+        }
+    }
+
+    /**
+     * Lands competing FLIP presentation, captures the adjacent-pair geometry, and projects proxy
+     * paint BEFORE the generic parent refreshes the zone and starts the gesture (the proxy is
+     * created inside the parent's start).
      * The armed generation fences those awaits: the parent arms its own fence only inside
      * `super.onDragStart()`, so a cancel, destroy, terminal, or newer start landing during the
      * capture/projection awaits must invalidate the pending start here, before the real gesture
@@ -524,7 +571,16 @@ class DockSplitter extends Splitter {
      */
     async onDragStart(data={}) {
         let me         = this,
-            generation = ++me.dragGeneration;
+            generation = ++me.dragGeneration,
+            landing    = me.landActiveDockMotion();
+
+        if (typeof landing?.then === 'function') {
+            await landing
+        }
+
+        if (generation !== me.dragGeneration || me.isDestroyed) {
+            return
+        }
 
         await me.captureDragStart(data);
 

--- a/src/main/addon/DockFlip.mjs
+++ b/src/main/addon/DockFlip.mjs
@@ -90,8 +90,9 @@ class DockFlip extends Base {
 
     /**
      * Plays which entered their bounded projection waits but have not necessarily installed a
-     * cleanup yet: host id → Set<{interrupted:Boolean}>. `land()` marks these states so a play can
-     * never arm fixed-stage presentation after direct manipulation already reclaimed geometry.
+     * cleanup yet: host id → Set<{interrupted:Boolean,interruptWait:Function|null}>. `land()`
+     * interrupts the live frame/timer wait so a play settles immediately and can never arm
+     * fixed-stage presentation after direct manipulation already reclaimed geometry.
      * @member {Map<String,Set<Object>>} #pendingPlays
      * @private
      */
@@ -374,6 +375,8 @@ class DockFlip extends Base {
     }
 
     /**
+     * @summary Captures First geometry after serializing presentation ownership for one host.
+     *
      * Phase 1: snapshot the current geometry of every marker element inside the host.
      * Call immediately BEFORE swapping the projected tree.
      * @param {Object} opts
@@ -381,6 +384,11 @@ class DockFlip extends Base {
      * @param {String} opts.markerPrefix The marker-class prefix carrying the stable item key
      */
     captureFirst({hostId, markerPrefix}) {
+        // One host owns at most one presentation generation. A newer structural projection lands
+        // its predecessor before capturing First, so its inline-style snapshot can never inherit an
+        // older fixed stage and later restore that temporary geometry as if it were original.
+        hostId && this.#land(hostId);
+
         const
             hostEl   = document.getElementById(hostId),
             markers  = this.collectMarkers(hostId, markerPrefix),
@@ -398,7 +406,77 @@ class DockFlip extends Base {
     }
 
     /**
-     * @summary Instantly lands every active FLIP presentation without destroying the addon.
+     * @summary Settles snapshot, pending, and active presentation generations.
+     *
+     * Instantly lands one host, or every host for internal teardown. Snapshot-only, pending-wait,
+     * and active-stage generations share this settlement owner. Active cleanups run newest-first:
+     * a newer play may have captured an older temporary stage, so the oldest cleanup must be the
+     * final writer that restores the true pre-motion inline authority.
+     * @param {String|null} [hostId=null]
+     * @returns {Boolean}
+     * @private
+     */
+    #land(hostId=null) {
+        let landedCount = 0;
+
+        Object.keys(this.#firstSnapshots).forEach(snapshotHostId => {
+            if (hostId === null || snapshotHostId === hostId) {
+                delete this.#firstSnapshots[snapshotHostId];
+                landedCount++
+            }
+        });
+
+        this.#pendingPlays.forEach((states, pendingHostId) => {
+            if (hostId === null || pendingHostId === hostId) {
+                states.forEach(state => {
+                    if (!state.interrupted) {
+                        state.interrupted = true;
+                        landedCount++
+                    }
+
+                    state.interruptWait?.()
+                })
+            }
+        });
+
+        const active = [...this.#activeCleanups]
+            .filter(cancel => hostId === null || cancel.hostId === hostId)
+            .reverse();
+
+        active.forEach(cancel => cancel());
+
+        return landedCount + active.length > 0
+    }
+
+    /**
+     * @summary Lands presentation owned by the first dock host on one native event path.
+     *
+     * Main DragDrop calls this synchronously before publishing the App event or opening Resize.
+     * The addon's own snapshot/pending/active registries are the authority: ordinary non-dock paths
+     * and dock hosts with no motion return immediately, while proxy-mode splitters remain covered
+     * even though they deliberately register no main-thread resize descriptor.
+     *
+     * @param {EventTarget[]} [path=[]] Native composed path, target first.
+     * @returns {Boolean} True when presentation for a path host was landed.
+     */
+    landFromPath(path=[]) {
+        const hostIds = new Set([
+            ...Object.keys(this.#firstSnapshots),
+            ...this.#pendingPlays.keys(),
+            ...[...this.#activeCleanups].map(cancel => cancel.hostId)
+        ]);
+
+        for (const node of path || []) {
+            if (node?.id && hostIds.has(node.id)) {
+                return this.#land(node.id)
+            }
+        }
+
+        return false
+    }
+
+    /**
+     * @summary Instantly lands one host-scoped FLIP presentation without destroying the addon.
      *
      * Interactive geometry takes precedence over presentation: a splitter or other direct
      * manipulation may call this remote seam before it captures layout rects. Every active play
@@ -406,29 +484,14 @@ class DockFlip extends Base {
      * positioning, transforms, transitions, opacity, and stacking to the committed layout while
      * resolving the interrupted play as `false`. No dock document or projection state changes.
      *
-     * @param {String|null} [hostId=null] Optional dock-host scope; `null` lands every active stage.
+     * The remote surface refuses a missing host identity. All-host landing belongs exclusively to
+     * addon teardown and is not an App-callable authority.
+     *
+     * @param {String} opts.hostId Dock-host scope.
      * @returns {Boolean} True when at least one active presentation was landed.
      */
-    land({hostId=null}={}) {
-        let pendingCount = 0;
-
-        this.#pendingPlays.forEach((states, pendingHostId) => {
-            if (!hostId || pendingHostId === hostId) {
-                states.forEach(state => {
-                    if (!state.interrupted) {
-                        state.interrupted = true;
-                        pendingCount++
-                    }
-                })
-            }
-        });
-
-        const active = [...this.#activeCleanups]
-            .filter(cancel => !hostId || cancel.hostId === hostId);
-
-        active.forEach(cancel => cancel());
-
-        return pendingCount + active.length > 0
+    land({hostId}={}) {
+        return hostId ? this.#land(hostId) : false
     }
 
     /**
@@ -436,7 +499,7 @@ class DockFlip extends Base {
      * @returns {void}
      */
     destroy() {
-        this.land();
+        this.#land();
         this.#firstSnapshots = {};
         this.#pendingPlays.clear();
 
@@ -460,6 +523,8 @@ class DockFlip extends Base {
     }
 
     /**
+     * @summary Waits for one interruptible frame-or-timer boundary.
+     *
      * One frame boundary that cannot starve. The native rAF arm wins in every presenting
      * document (identical timing to a raw `requestAnimationFrame` await); the timer dam
      * bounds the wait in rendering-starved documents, where rAF callbacks are never serviced
@@ -475,27 +540,40 @@ class DockFlip extends Base {
      * the cancellation, every timer-won wait in a frame-starved-but-visible window would
      * leave its callback queued — dock operations accumulate them unboundedly, and they all
      * fire in one burst when the window finally presents again.
+     * @param {Object} playState Per-play interruption owner.
      * @param {Number} [budgetMs=100] Generously above one healthy frame (17-34ms), far below
      * a perceivable stall — a presenting document virtually always wins with a real frame.
      * @returns {Promise<Boolean>} true when a real frame serviced the wait, false when the dam fired
      * @private
      */
-    #nextFrame(budgetMs=100) {
+    #nextFrame(playState, budgetMs=100) {
         return new Promise(resolve => {
-            let frameId   = null,
-                timer     = setTimeout(() => {
-                    timer = null;
-                    globalThis.cancelAnimationFrame?.(frameId);
-                    resolve(false)
-                }, budgetMs);
+            let frameId = null,
+                settled = false,
+                timer;
 
-            frameId = requestAnimationFrame(() => {
+            const finish = framed => {
+                if (settled) return;
+
+                settled = true;
+
                 if (timer !== null) {
                     clearTimeout(timer);
-                    timer = null;
-                    resolve(true)
+                    timer = null
                 }
-            })
+
+                frameId !== null && globalThis.cancelAnimationFrame?.(frameId);
+                playState?.interruptWait === interrupt && (playState.interruptWait = null);
+                resolve(framed)
+            };
+
+            const interrupt = () => finish(false);
+
+            playState && (playState.interruptWait = interrupt);
+            timer   = setTimeout(interrupt, budgetMs);
+            frameId = requestAnimationFrame(() => finish(true));
+
+            playState?.interrupted && interrupt()
         })
     }
 
@@ -529,7 +607,7 @@ class DockFlip extends Base {
             durationTimer   = null,
             hostEl,
             moves           = [],
-            playState       = {interrupted: false},
+            playState       = {interrupted: false, interruptWait: null},
             settled         = false;
 
         // One idempotent settlement path owns every temporary visual mutation. In particular,
@@ -635,7 +713,7 @@ class DockFlip extends Base {
             // proof the swap already happened.
             if (!preservedMarkerSet && !landedInPlace) {
                 while (!playState.interrupted && frame < maxFrames && first.els.length > 0 && first.els.every(el => el.isConnected)) {
-                    await this.#nextFrame();
+                    await this.#nextFrame(playState);
                     frame++
                 }
             }
@@ -644,7 +722,7 @@ class DockFlip extends Base {
             markers = this.collectMarkers(hostId, markerPrefix);
 
             while (!playState.interrupted && markers.size < 1 && frame < maxFrames * 2) {
-                await this.#nextFrame();
+                await this.#nextFrame(playState);
                 frame++;
                 markers = this.collectMarkers(hostId, markerPrefix)
             }
@@ -665,7 +743,7 @@ class DockFlip extends Base {
             // delaying here would expose the clipped final tree for one paint before the
             // inverse transform is installed.
             if (!preservedMarkerSet && !landedInPlace) {
-                await this.#nextFrame()
+                await this.#nextFrame(playState)
             }
 
             if (playState.interrupted) {
@@ -779,7 +857,7 @@ class DockFlip extends Base {
             // present: land instantly instead of transitioning into a void (and instead of
             // holding transform-scaled mid-motion rects live for async measurers to misread
             // as layout truth).
-            const framed = await this.#nextFrame();
+            const framed = await this.#nextFrame(playState);
 
             if (!framed) {
                 cleanup();

--- a/src/main/addon/DockFlip.mjs
+++ b/src/main/addon/DockFlip.mjs
@@ -67,6 +67,7 @@ class DockFlip extends Base {
         remote: {
             app: [
                 'captureFirst',
+                'land',
                 'play'
             ]
         }
@@ -86,6 +87,15 @@ class DockFlip extends Base {
      * @private
      */
     #activeCleanups = new Set()
+
+    /**
+     * Plays which entered their bounded projection waits but have not necessarily installed a
+     * cleanup yet: host id → Set<{interrupted:Boolean}>. `land()` marks these states so a play can
+     * never arm fixed-stage presentation after direct manipulation already reclaimed geometry.
+     * @member {Map<String,Set<Object>>} #pendingPlays
+     * @private
+     */
+    #pendingPlays = new Map()
 
     /**
      * Collects the marker elements inside a host: every element whose class list contains a
@@ -388,13 +398,47 @@ class DockFlip extends Base {
     }
 
     /**
-     * @summary Interrupts every active presentation stage before the addon lifecycle is destroyed.
+     * @summary Instantly lands every active FLIP presentation without destroying the addon.
+     *
+     * Interactive geometry takes precedence over presentation: a splitter or other direct
+     * manipulation may call this remote seam before it captures layout rects. Every active play
+     * already owns one idempotent cleanup closure; running those closures restores fixed-stage
+     * positioning, transforms, transitions, opacity, and stacking to the committed layout while
+     * resolving the interrupted play as `false`. No dock document or projection state changes.
+     *
+     * @param {String|null} [hostId=null] Optional dock-host scope; `null` lands every active stage.
+     * @returns {Boolean} True when at least one active presentation was landed.
+     */
+    land({hostId=null}={}) {
+        let pendingCount = 0;
+
+        this.#pendingPlays.forEach((states, pendingHostId) => {
+            if (!hostId || pendingHostId === hostId) {
+                states.forEach(state => {
+                    if (!state.interrupted) {
+                        state.interrupted = true;
+                        pendingCount++
+                    }
+                })
+            }
+        });
+
+        const active = [...this.#activeCleanups]
+            .filter(cancel => !hostId || cancel.hostId === hostId);
+
+        active.forEach(cancel => cancel());
+
+        return pendingCount + active.length > 0
+    }
+
+    /**
+     * @summary Lands every active presentation stage before the addon lifecycle is destroyed.
      * @returns {void}
      */
     destroy() {
-        this.#activeCleanups.forEach(cancel => cancel());
-        this.#activeCleanups.clear();
+        this.land();
         this.#firstSnapshots = {};
+        this.#pendingPlays.clear();
 
         super.destroy()
     }
@@ -484,8 +528,8 @@ class DockFlip extends Base {
             durationResolve = null,
             durationTimer   = null,
             hostEl,
-            interrupted     = false,
             moves           = [],
+            playState       = {interrupted: false},
             settled         = false;
 
         // One idempotent settlement path owns every temporary visual mutation. In particular,
@@ -494,7 +538,7 @@ class DockFlip extends Base {
         const cleanup = (wasInterrupted = false) => {
             if (settled) return;
 
-            interrupted ||= wasInterrupted;
+            playState.interrupted ||= wasInterrupted;
 
             const resolveDuration = durationResolve;
 
@@ -523,6 +567,7 @@ class DockFlip extends Base {
         };
 
         cancel = () => cleanup(true);
+        cancel.hostId = hostId;
 
         delete this.#firstSnapshots[hostId];
 
@@ -540,6 +585,15 @@ class DockFlip extends Base {
         if (document.hidden) {
             return false
         }
+
+        let pending = this.#pendingPlays.get(hostId);
+
+        if (!pending) {
+            pending = new Set();
+            this.#pendingPlays.set(hostId, pending)
+        }
+
+        pending.add(playState);
 
         const
             firstLineages = first.lineages,
@@ -580,7 +634,7 @@ class DockFlip extends Base {
             // those nodes never detach either, and the landed geometry (landedInPlace) is the
             // proof the swap already happened.
             if (!preservedMarkerSet && !landedInPlace) {
-                while (frame < maxFrames && first.els.length > 0 && first.els.every(el => el.isConnected)) {
+                while (!playState.interrupted && frame < maxFrames && first.els.length > 0 && first.els.every(el => el.isConnected)) {
                     await this.#nextFrame();
                     frame++
                 }
@@ -589,10 +643,15 @@ class DockFlip extends Base {
             // stage B: now wait (bounded) for the NEW tree's markers to exist
             markers = this.collectMarkers(hostId, markerPrefix);
 
-            while (markers.size < 1 && frame < maxFrames * 2) {
+            while (!playState.interrupted && markers.size < 1 && frame < maxFrames * 2) {
                 await this.#nextFrame();
                 frame++;
                 markers = this.collectMarkers(hostId, markerPrefix)
+            }
+
+            if (playState.interrupted) {
+                cleanup(true);
+                return false
             }
 
             if (markers.size < 1) {
@@ -607,6 +666,11 @@ class DockFlip extends Base {
             // inverse transform is installed.
             if (!preservedMarkerSet && !landedInPlace) {
                 await this.#nextFrame()
+            }
+
+            if (playState.interrupted) {
+                cleanup(true);
+                return false
             }
 
             markers.forEach((el, key) => {
@@ -723,7 +787,7 @@ class DockFlip extends Base {
                 return false
             }
 
-            if (interrupted || this.isDestroyed) {
+            if (playState.interrupted || this.isDestroyed) {
                 cleanup(true);
 
                 return false
@@ -748,7 +812,7 @@ class DockFlip extends Base {
                 }, duration + 50)
             });
 
-            if (interrupted || this.isDestroyed) return false;
+            if (playState.interrupted || this.isDestroyed) return false;
 
             cleanup();
 
@@ -758,6 +822,9 @@ class DockFlip extends Base {
             cleanup();
 
             return false
+        } finally {
+            pending.delete(playState);
+            pending.size < 1 && this.#pendingPlays.delete(hostId)
         }
     }
 }

--- a/src/main/addon/DragDrop.mjs
+++ b/src/main/addon/DragDrop.mjs
@@ -645,6 +645,7 @@ class DragDrop extends Base {
     }
 
     /**
+     * @summary Opens native drag and resize authority before publishing the App event.
      * @param {Event} event
      */
     onDragStart(event) {
@@ -665,6 +666,14 @@ class DragDrop extends Base {
             offsetX      : event.detail.clientX - rect.left,
             offsetY      : event.detail.clientY - rect.top
         });
+
+        // Physical resize admission is Main-owned. An App listener is delivered only after this
+        // resize admission and no acknowledgement is awaited, so App cannot fence the next native
+        // move. DockFlip resolves its own same-window host registry from the native path and lands
+        // synchronously before Resize captures geometry. Missing addon/host/motion is a cheap no-op.
+        try {
+            Neo.main?.addon?.DockFlip?.landFromPath?.(path)
+        } catch {/* presentation can never block direct manipulation */}
 
         me.dragResize?.start(path, event.detail, me.dragZoneId);
 

--- a/test/playwright/e2e/workstation/WorkstationNestedColumnResizeNL.spec.mjs
+++ b/test/playwright/e2e/workstation/WorkstationNestedColumnResizeNL.spec.mjs
@@ -1,0 +1,486 @@
+import {test, expect} from '../../fixtures.mjs';
+
+/**
+ * @summary Whitebox E2E regression for a retained nested dock column whose outer splitter moves.
+ *
+ * The journey deliberately composes two trusted-pointer interactions which older witnesses kept
+ * separate: move Matrix right of Heavy, move the bottom Feed tab above Heavy, then resize the
+ * enclosing horizontal split while the structural DockFlip is still active. The nested split is one direct outer flex child, so both stacked tab
+ * descendants must share its cross-axis edges during preview and after the semantic terminal.
+ *
+ * Worker truth classifies the failure: the drop must first commit the expected nested vertical
+ * split; the resize preview must leave the document byte-identical; release may change only the
+ * outer split's size vector. Rendered rects then prove whether retained projection geometry follows
+ * that correct model or leaves one pane at its former width.
+ *
+ * Run: NEO_E2E_PORT=8096 npx playwright test WorkstationNestedColumnResizeNL \
+ *   -c test/playwright/playwright.config.e2e.mjs --workers=1
+ */
+test.describe('Workstation nested dock column follows its outer splitter (#17985)', () => {
+    test.setTimeout(120000);
+    test.use({viewport: {height: 900, width: 1600}});
+
+    /**
+     * @param {Object|Object[]|null} result
+     * @returns {String|null}
+     */
+    function readId(result) {
+        if (Array.isArray(result)) return readId(result[0]);
+
+        return result?.properties?.id ?? result?.id ?? null
+    }
+
+    /**
+     * @param {Object} document
+     * @param {String} itemId
+     * @returns {String|null}
+     */
+    function findTabsNode(document, itemId) {
+        return Object.entries(document?.nodes || {})
+            .find(([, node]) => node.type === 'tabs' && node.items?.includes(itemId))?.[0] ?? null
+    }
+
+    /**
+     * @param {Object} document
+     * @returns {{feedTabsId: String, nestedId: String}|null}
+     */
+    function findNestedHeavyFeedColumn(document) {
+        const feedTabsId = findTabsNode(document, 'feed');
+
+        if (!feedTabsId || feedTabsId === 'bottom-tabs') return null;
+
+        const match = Object.entries(document.nodes || {}).find(([, node]) =>
+            node.type === 'split'
+            && node.orientation === 'vertical'
+            && node.children?.includes('heavy-tabs')
+            && node.children?.includes(feedTabsId)
+        );
+
+        return match ? {feedTabsId, nestedId: match[0]} : null
+    }
+
+    /**
+     * @param {Object} document
+     * @param {String[]} childIds
+     * @param {String} orientation
+     * @returns {{id: String, node: Object}|null}
+     */
+    function findSplitWithChildren(document, childIds, orientation) {
+        const match = Object.entries(document?.nodes || {}).find(([, node]) =>
+            node.type === 'split'
+            && node.orientation === orientation
+            && childIds.every(childId => node.children?.includes(childId))
+        );
+
+        return match ? {id: match[0], node: match[1]} : null
+    }
+
+    /**
+     * @param {import('@playwright/test').Page} page
+     * @param {String} workspaceId
+     * @returns {Promise<Object>}
+     */
+    async function readDocument(app, workspaceId) {
+        return (await app.getComponent(workspaceId, ['dockModel'])).dockModel
+    }
+
+    /**
+     * @param {Object} app
+     * @param {Object} ids
+     * @returns {Promise<Object>}
+     */
+    async function readGeometry(page, ids) {
+        return page.evaluate(values => Object.fromEntries(Object.entries(values).map(([key, id]) => {
+            const rect = document.getElementById(id)?.getBoundingClientRect();
+
+            return [key, rect && {
+                bottom: rect.bottom,
+                height: rect.height,
+                left  : rect.left,
+                right : rect.right,
+                top   : rect.top,
+                width : rect.width,
+                x     : rect.x,
+                y     : rect.y
+            }]
+        })), ids)
+    }
+
+    /**
+     * @param {Object} geometry
+     * @param {String} label
+     */
+    function assertColumnEdges(geometry, label) {
+        for (const key of ['feedPane', 'feedTabs', 'heavyPane', 'heavyTabs']) {
+            expect(
+                Math.abs(geometry[key].left - geometry.column.left),
+                `${label}: ${key} left edge follows the nested column`
+            ).toBeLessThanOrEqual(1);
+            expect(
+                Math.abs(geometry[key].right - geometry.column.right),
+                `${label}: ${key} right edge follows the nested column`
+            ).toBeLessThanOrEqual(1)
+        }
+    }
+
+    /**
+     * @param {Object} geometry
+     * @param {String} label
+     */
+    function assertColumnWidths(geometry, label) {
+        for (const key of ['feedPane', 'feedTabs', 'heavyPane', 'heavyTabs']) {
+            const tolerance = key.endsWith('Pane') ? 2 : 1;
+
+            expect(
+                Math.abs(geometry[key].width - geometry.column.width),
+                `${label}: ${key} width follows the nested column`
+            ).toBeLessThanOrEqual(tolerance)
+        }
+    }
+
+    /**
+     * @param {import('@playwright/test').Page} page
+     * @param {Object} neuralLink
+     * @returns {Promise<Object>}
+     */
+    async function boot(page, neuralLink) {
+        await page.goto('/apps/workstation/index.html');
+        await page.waitForSelector('.workstation-dock-host', {timeout: 60000});
+        await page.waitForSelector('.neo-tab-header-button.neo-draggable', {timeout: 60000});
+        await page.evaluate(() => document.fonts.ready);
+        await page.waitForFunction(() => {
+            const host = document.querySelector('.workstation-dock-host');
+
+            return host?.getBoundingClientRect().height > 300
+                && [...document.querySelectorAll('.neo-dashboard-dock-tabs')]
+                    .filter(element => element.getClientRects().length)
+                    .every(element => element.getBoundingClientRect().width > 100)
+        }, {timeout: 60000});
+
+        const
+            app         = await neuralLink.connectToApp('Workstation'),
+            workspaces  = await app.findInstances({className: 'Workstation.view.Workspace'}, ['id']),
+            workspaceId = readId(workspaces);
+
+        expect(workspaceId, 'one live Workstation workspace must exist').toBeTruthy();
+
+        return {app, workspaceId}
+    }
+
+    /**
+     * @summary Drives one trusted-pointer tab drag into an exact pane-body ratio.
+     * @param {import('@playwright/test').Page} page
+     * @param {Object} config
+     */
+    async function dragTabToPoint(page, {placement, sourceTitle, target, targetNodeId, xRatio, yOffset=null, yRatio=null}) {
+        const
+            source = page.locator('.neo-tab-header-button', {hasText: sourceTitle}).first();
+
+        await expect(source, `${sourceTitle} must be visible before its real drag`).toBeVisible();
+        await expect(source, `${sourceTitle} must retain the draggable header contract`).toHaveClass(/neo-draggable/);
+        await expect(target, `${sourceTitle} target pane must be the visible retained instance`).toBeVisible();
+
+        let sourceRect, targetRect, armed = false;
+
+        for (let attempt = 0; attempt < 3 && !armed; attempt++) {
+            sourceRect = await source.boundingBox();
+            targetRect = await target.boundingBox();
+
+            expect(targetRect, `${sourceTitle} target pane must have live geometry`).toBeTruthy();
+
+            await page.mouse.move(sourceRect.x + sourceRect.width / 2, sourceRect.y + sourceRect.height / 2);
+            await page.mouse.down();
+            await page.waitForTimeout(130); // real Mouse-sensor arming delay, not settlement
+            await page.mouse.move(sourceRect.x + sourceRect.width / 2 + 12, sourceRect.y + sourceRect.height / 2, {steps: 4});
+
+            armed = await page.locator('.neo-tab-header-toolbar.neo-is-dragging')
+                .waitFor({state: 'visible', timeout: 1200})
+                .then(() => true, () => false);
+
+            if (!armed) {
+                await page.mouse.up();
+                await expect(page.locator('.neo-tab-header-toolbar.neo-is-dragging'),
+                    `${sourceTitle} failed arm attempt leaves no drag state`).toHaveCount(0)
+            }
+        }
+
+        expect(armed, `${sourceTitle} opens a real pointer drag session within three clean arms`).toBe(true);
+        targetRect = await target.boundingBox();
+        expect(targetRect, `${sourceTitle} target stays measurable after drag-start refresh`).toBeTruthy();
+
+        const targetX = targetRect.x + targetRect.width * xRatio,
+              targetY = yOffset == null ? targetRect.y + targetRect.height * yRatio : targetRect.y + yOffset;
+
+        await page.mouse.move(targetX, targetY, {steps: 20});
+        for (const dx of [2, -2, 1]) {
+            await page.mouse.move(targetX + dx, targetY, {steps: 1});
+            await page.waitForTimeout(80)
+        }
+        await expect.poll(() => page.locator('.neo-dock-preview-affordance').evaluateAll(nodes => nodes
+            .filter(node => node.getClientRects().length)
+            .map(node => {
+                const kind = [...node.classList].find(value => value.startsWith('neo-dock-preview-')
+                    && !['neo-dock-preview-affordance', 'neo-dock-preview-accepted', 'neo-dock-preview-edge',
+                        'neo-dock-preview-region', 'neo-dock-preview-split', 'neo-dock-preview-tab']
+                        .includes(value));
+
+                return `${kind?.slice('neo-dock-preview-'.length)}:${node.dataset.dockTarget}`
+            })
+            .join(',')), {
+            message: `${sourceTitle} preview must resolve ${placement} on ${targetNodeId} before release`,
+            timeout: 5000
+        }).toContain(`${placement}:${targetNodeId}`);
+        await page.mouse.up()
+    }
+
+    test('both stacked panes follow a real outer resize during preview and after commit', async ({page, neuralLink}) => {
+        const {app, workspaceId} = await boot(page, neuralLink),
+              heavyBeforeId      = readId(await app.queryComponent({dockNodeId: 'heavy-tabs', ntype: 'tab-container'}, ['id'])),
+              feedPaneBeforeId   = await page.locator('.workstation-pane-feed:visible').first().getAttribute('id'),
+              heavyPaneBeforeId  = await page.locator('.workstation-pane-alerts:visible').first().getAttribute('id');
+
+        expect(heavyBeforeId, 'the opening Heavy tab group resolves by dock node identity').toBeTruthy();
+        expect(feedPaneBeforeId, 'the live Feed pane exposes a retained DOM identity').toBeTruthy();
+        expect(heavyPaneBeforeId, 'the live Alerts pane exposes a retained DOM identity').toBeTruthy();
+
+        await dragTabToPoint(page, {
+            placement   : 'split-after',
+            sourceTitle : '100k Matrix',
+            target      : page.locator('.workstation-pane-alerts:visible').first(),
+            targetNodeId: 'heavy-tabs',
+            xRatio      : 0.999,
+            yRatio      : 0.5
+        });
+        await expect.poll(async () => {
+            const document    = await readDocument(app, workspaceId),
+                  scaleTabsId = findTabsNode(document, 'scale'),
+                  split       = findSplitWithChildren(document, ['heavy-tabs', scaleTabsId], 'horizontal');
+
+            return split?.node.children.indexOf('heavy-tabs') < split?.node.children.indexOf(scaleTabsId) ? split.id : null
+        }, {
+            message  : 'the first real drop places Matrix right of Heavy',
+            timeout  : 15000,
+            intervals: [50, 100]
+        }).not.toBeNull();
+        await expect(page.locator('.workstation-workspace'),
+            'the first structural move settles before the second pointer drag')
+            .not.toHaveClass(/neo-dashboard-dock-animating/, {timeout: 10000});
+        await expect(page.locator('.neo-dock-flip-fixed-stage'),
+            'the first structural move leaves no fixed-stage residue').toHaveCount(0);
+
+        await dragTabToPoint(page, {
+            placement   : 'edge-top',
+            sourceTitle : 'Live Event Stream',
+            target      : page.locator(`#${heavyBeforeId}`),
+            targetNodeId: 'heavy-tabs',
+            xRatio      : 0.5,
+            yOffset     : 40
+        });
+
+        await page.waitForFunction(() => {
+            const
+                workspace = document.querySelector('.workstation-workspace'),
+                column    = [...document.querySelectorAll('.neo-dashboard-dock-split-vertical')]
+                    .find(element => element.querySelector('.workstation-pane-alerts')
+                        && element.querySelector('.workstation-pane-feed')),
+                outer     = column?.closest('.neo-dashboard-dock-split-horizontal'),
+                splitter  = outer && [...outer.children]
+                    .find(element => element.classList.contains('neo-dashboard-dock-splitter-horizontal'));
+
+            return Boolean(column && outer && splitter && workspace?.classList.contains('neo-dashboard-dock-animating'))
+        }, null, {polling: 5, timeout: 5000});
+        await expect(page.locator('.neo-dashboard-dock-drop-indicators')).toHaveClass(/neo-dashboard-dock-drop-indicators-hidden/);
+
+        const ids = await page.evaluate(() => {
+            const
+                columnRoot = [...document.querySelectorAll('.neo-dashboard-dock-split-vertical')]
+                    .find(element => element.querySelector('.workstation-pane-alerts')
+                        && element.querySelector('.workstation-pane-feed')),
+                outer = columnRoot.closest('.neo-dashboard-dock-split-horizontal');
+
+            let column = columnRoot;
+
+            while (column.parentElement !== outer) column = column.parentElement;
+
+            const
+                splitter = [...outer.children]
+                    .find(element => element.classList.contains('neo-dashboard-dock-splitter-horizontal')),
+                counter = [...outer.children]
+                    .find(element => element !== column && element !== splitter),
+                feedPane = columnRoot.querySelector('.workstation-pane-feed'),
+                heavyPane = columnRoot.querySelector('.workstation-pane-alerts');
+
+            return {
+                column   : column.id,
+                counter  : counter.id,
+                feedPane : feedPane.id,
+                feedTabs : feedPane.closest('.neo-dashboard-dock-tabs').id,
+                heavyPane: heavyPane.id,
+                heavyTabs: heavyPane.closest('.neo-dashboard-dock-tabs').id,
+                splitter : splitter.id
+            }
+        });
+
+        expect(ids, 'the rendered nested column exposes every fast-path geometry participant').toMatchObject({
+            column   : expect.any(String),
+            counter  : expect.any(String),
+            feedPane : expect.any(String),
+            feedTabs : expect.any(String),
+            heavyPane: expect.any(String),
+            heavyTabs: expect.any(String),
+            splitter : expect.any(String)
+        });
+
+        const
+            before      = await readGeometry(page, ids),
+            splitterBox = before.splitter,
+            sx          = splitterBox.x + splitterBox.width / 2,
+            sy          = splitterBox.y + splitterBox.height / 2;
+
+        const
+            documentAfterDrop = await readDocument(app, workspaceId),
+            nested            = findNestedHeavyFeedColumn(documentAfterDrop),
+            scaleTabsId       = findTabsNode(documentAfterDrop, 'scale'),
+            outer             = findSplitWithChildren(documentAfterDrop, [nested?.nestedId, scaleTabsId], 'horizontal'),
+            beforeBytes       = JSON.stringify(documentAfterDrop);
+
+        expect(nested, 'the second real drop committed Feed above Heavy before splitter motion').not.toBeNull();
+        expect(outer, 'the nested column and Matrix share one horizontal outer split').not.toBeNull();
+
+        const nestedSizes = JSON.stringify(documentAfterDrop.nodes[nested.nestedId].sizes);
+
+        await page.mouse.move(sx, sy);
+        await page.mouse.down();
+        await page.waitForTimeout(105); // measured splitter Mouse-sensor arm, not settlement
+
+        const admission = await page.evaluate(({feedPane, heavyPane}) => ({
+            animating: document.querySelector('.workstation-workspace')
+                ?.classList.contains('neo-dashboard-dock-animating'),
+            panes: [feedPane, heavyPane].map(id => {
+                const element = document.getElementById(id),
+                      style   = getComputedStyle(element);
+
+                return {
+                    fixedStage : element.classList.contains('neo-dock-flip-fixed-stage'),
+                    inlineWidth: element.style.width,
+                    position   : style.position,
+                    width      : element.getBoundingClientRect().width
+                }
+            })
+        }), ids);
+
+        expect(admission.animating, 'MotionSignal is active at the actual splitter admission boundary').toBe(true);
+        expect(admission.panes.every(value => value.fixedStage && value.position === 'fixed' && value.inlineWidth),
+            `both panes are still fixed-stage immediately before splitter motion: ${JSON.stringify(admission.panes)}`)
+            .toBe(true);
+
+        await page.mouse.move(sx + 350, sy, {steps: 4});
+
+        const
+            mid            = await readGeometry(page, ids),
+            midDocument    = await readDocument(app, workspaceId),
+            stageAfterMove = await page.evaluate(({feedPane, heavyPane}) => [feedPane, heavyPane]
+                .some(id => document.getElementById(id)?.classList.contains('neo-dock-flip-fixed-stage')), ids);
+
+        expect(stageAfterMove, 'splitter admission lands fixed-stage ownership before live resize').toBe(false);
+
+        await page.mouse.up();
+
+        await expect.poll(async () => {
+            const current = await readDocument(app, workspaceId);
+
+            return Math.abs(current.nodes[outer.id].sizes[0] - documentAfterDrop.nodes[outer.id].sizes[0])
+        }, {
+            message  : `release commits the outer ${outer.id} resize`,
+            timeout  : 10000,
+            intervals: [50, 100]
+        }).toBeGreaterThan(0.02);
+        await expect(page.locator('.workstation-workspace')).not.toHaveClass(/neo-dashboard-dock-animating/, {timeout: 10000});
+        await expect(page.locator('.neo-dock-flip-fixed-stage'),
+            'DockFlip releases every fixed-stage descendant after settlement').toHaveCount(0);
+
+        const
+            after         = await readGeometry(page, ids),
+            documentAfter = await readDocument(app, workspaceId);
+
+        console.log('[nested-column-diag]', JSON.stringify({after, before, mid}));
+
+        expect(JSON.stringify(midDocument), 'pointer preview keeps the dock document byte-identical').toBe(beforeBytes);
+        expect(Math.abs(mid.column.width - before.column.width), 'the real preview changes the nested column width')
+            .toBeGreaterThan(100);
+        expect(Math.abs(
+            (mid.column.width + mid.counter.width) - (before.column.width + before.counter.width)
+        ), 'the outer adjacent pair remains conserved during preview').toBeLessThan(1);
+
+        assertColumnWidths(mid,  'mid outer resize');
+        assertColumnEdges(after, 'settled outer resize');
+
+        const
+            cancelBeforeBytes = JSON.stringify(documentAfter),
+            cancelX           = after.splitter.x + after.splitter.width / 2,
+            cancelY           = after.splitter.y + after.splitter.height / 2;
+
+        await page.mouse.move(cancelX, cancelY);
+        await page.mouse.down();
+        await page.waitForTimeout(105); // measured splitter Mouse-sensor arm, not settlement
+        await page.mouse.move(cancelX - 180, cancelY, {steps: 4});
+
+        const
+            cancelMid         = await readGeometry(page, ids),
+            cancelMidDocument = await readDocument(app, workspaceId);
+
+        await page.keyboard.press('Escape');
+        await page.waitForTimeout(120); // native cancel delivery before the physical mouseup
+        await page.mouse.up();
+        await expect.poll(async () => Math.abs((await readGeometry(page, ids)).column.width - after.column.width), {
+            message  : 'Escape restores the whole nested column to its committed width',
+            timeout  : 5000,
+            intervals: [25, 50]
+        }).toBeLessThan(1);
+
+        const
+            cancelAfter         = await readGeometry(page, ids),
+            cancelAfterDocument = await readDocument(app, workspaceId);
+
+        expect(Math.abs(cancelMid.column.width - after.column.width),
+            'the reverse-direction cancel arm enters a real live preview').toBeGreaterThan(100);
+        assertColumnWidths(cancelMid,   'reverse mid outer resize');
+        assertColumnEdges(cancelAfter, 'Escape-restored outer resize');
+        expect(JSON.stringify(cancelMidDocument), 'Escape arm mutates no worker document while held').toBe(cancelBeforeBytes);
+        expect(JSON.stringify(cancelAfterDocument), 'Escape commits zero operations').toBe(cancelBeforeBytes);
+
+        const
+            columnId     = readId(await app.queryComponent({dockNodeId: nested.nestedId, dockNodeType: 'split'}, ['id'])),
+            counterId    = readId(await app.queryComponent({dockNodeId: scaleTabsId, ntype: 'tab-container'}, ['id'])),
+            feedTabsId   = readId(await app.queryComponent({dockNodeId: nested.feedTabsId, ntype: 'tab-container'}, ['id'])),
+            heavyTabsId  = readId(await app.queryComponent({dockNodeId: 'heavy-tabs', ntype: 'tab-container'}, ['id'])),
+            splitterId   = readId(await app.queryComponent({dockNodeId: outer.id, ntype: 'dashboard-dock-splitter'}, ['id'])),
+            columnState  = await app.getComponent(columnId, ['vdom']),
+            counterState = await app.getComponent(counterId, ['vdom']),
+            resizeConfig = await app.callMethod(splitterId, 'getResizeConfig');
+
+        expect(heavyTabsId, 'reprojection retains the Heavy tab-container identity').toBe(heavyBeforeId);
+        expect(ids.feedPane,  'reprojection retains the live Feed pane identity').toBe(feedPaneBeforeId);
+        expect(ids.heavyPane, 'reprojection retains the live Alerts pane identity').toBe(heavyPaneBeforeId);
+        expect(feedTabsId, 'the new Feed tabs node remains queryable after settlement').toBeTruthy();
+        expect(
+            [resizeConfig.targetId, resizeConfig.counterTargetId].sort(),
+            'the generic resize descriptor targets the two direct outer layout participants'
+        ).toEqual([
+            columnState.vdom?.id ?? columnId,
+            counterState.vdom?.id ?? counterId
+        ].sort());
+
+        expect(JSON.stringify(documentAfter.nodes[nested.nestedId].sizes),
+            'resizing the outer split leaves the nested vertical size vector untouched').toBe(nestedSizes);
+        expect(documentAfter, 'release changes only the outer split size vector').toEqual({
+            ...documentAfterDrop,
+            nodes: {
+                ...documentAfterDrop.nodes,
+                [outer.id]: {...documentAfterDrop.nodes[outer.id], sizes: documentAfter.nodes[outer.id].sizes}
+            }
+        });
+        expect(Math.abs(after.column.width - mid.column.width),
+            'semantic settlement preserves the final preview width without a terminal jump').toBeLessThan(1)
+    })
+});

--- a/test/playwright/unit/dashboard/DockFlip.spec.mjs
+++ b/test/playwright/unit/dashboard/DockFlip.spec.mjs
@@ -802,6 +802,155 @@ test.describe('Neo.main.addon.DockFlip', () => {
         await expect(playPromise).resolves.toBe(false)
     });
 
+    test('land interrupts an active fixed stage without destroying the addon', async () => {
+        const
+            markerClass     = 'dock-flip-item-alpha',
+            marker          = createMarker(markerClass, {bottom: 100, height: 100, left: 0, right: 100, top: 0, width: 100}),
+            sourceBody      = {parentElement: null},
+            destinationBody = {
+                parentElement: null,
+                getBoundingClientRect() {
+                    return {bottom: 200, height: 100, left: 200, right: 300, top: 100, width: 100}
+                }
+            },
+            host = {
+                classList    : createClassList(),
+                parentElement: null,
+                querySelector() {
+                    return null
+                },
+                querySelectorAll() {
+                    return [marker]
+                }
+            },
+            visibleStyle = {
+                contain    : 'none',
+                filter     : 'none',
+                overflowX  : 'visible',
+                overflowY  : 'visible',
+                perspective: 'none',
+                transform  : 'none',
+                willChange : 'auto',
+                getPropertyValue(name) {
+                    return name === '--dock-transition-duration' ? '1ms' : 'linear'
+                }
+            };
+
+        sourceBody.parentElement      = host;
+        destinationBody.parentElement = host;
+        marker.parentElement          = sourceBody;
+        marker.style.zIndex           = '9';
+
+        globalThis.document = {
+            getElementById(id) {
+                return id === 'dock-host' ? host : null
+            }
+        };
+        globalThis.getComputedStyle = element => element === destinationBody
+            ? {...visibleStyle, overflowX: 'hidden', overflowY: 'hidden'}
+            : visibleStyle;
+
+        dockFlip.captureFirst({hostId: 'dock-host', markerPrefix: 'dock-flip-item-'});
+        marker.parentElement = destinationBody;
+        marker.setRect({bottom: 200, height: 100, left: 200, right: 300, top: 100, width: 100});
+
+        let releaseFrame;
+
+        globalThis.requestAnimationFrame = callback => {
+            releaseFrame = callback
+        };
+
+        const playPromise = dockFlip.play({
+            hostId      : 'dock-host',
+            markerPrefix: 'dock-flip-item-'
+        });
+
+        expect(marker.style.position).toBe('fixed');
+        expect(marker.classList.contains('neo-dock-flip-fixed-stage')).toBe(true);
+        expect(DockFlip.config.remote.app).toContain('land');
+
+        expect(dockFlip.land({hostId: 'other-host'}), 'a foreign host cannot land this presentation').toBe(false);
+        expect(marker.classList.contains('neo-dock-flip-fixed-stage')).toBe(true);
+        expect(dockFlip.land({hostId: 'dock-host'}), 'the owning host lands its active presentation').toBe(true);
+        expect(dockFlip.land({hostId: 'dock-host'}), 'landing is idempotent once no presentation remains').toBe(false);
+        expect(dockFlip.isDestroyed).toBeFalsy();
+        expect(marker.style.position).toBe('');
+        expect(marker.style.transform).toBe('');
+        expect(marker.style.zIndex).toBe('9');
+        expect(marker.classList.contains('neo-dock-flip-fixed-stage')).toBe(false);
+
+        releaseFrame();
+
+        await expect(playPromise).resolves.toBe(false)
+    });
+
+    test('land invalidates a pending play before it can arm fixed-stage presentation', async () => {
+        const
+            markerClass     = 'dock-flip-item-alpha',
+            marker          = createMarker(markerClass, {bottom: 100, height: 100, left: 0, right: 100, top: 0, width: 100}),
+            sourceBody      = {parentElement: null},
+            destinationBody = {parentElement: null},
+            host            = {
+                classList    : createClassList(),
+                parentElement: null,
+                querySelector() {
+                    return null
+                },
+                querySelectorAll() {
+                    return [marker]
+                }
+            },
+            visibleStyle = {
+                contain    : 'none',
+                filter     : 'none',
+                overflowX  : 'visible',
+                overflowY  : 'visible',
+                perspective: 'none',
+                transform  : 'none',
+                willChange : 'auto',
+                getPropertyValue(name) {
+                    return name === '--dock-transition-duration' ? '260ms' : 'linear'
+                }
+            },
+            frames = [];
+
+        sourceBody.parentElement      = host;
+        destinationBody.parentElement = host;
+        marker.parentElement          = sourceBody;
+
+        globalThis.document = {
+            getElementById(id) {
+                return id === 'dock-host' ? host : null
+            }
+        };
+        globalThis.getComputedStyle      = () => visibleStyle;
+        globalThis.requestAnimationFrame = callback => {
+            frames.push(callback);
+            return frames.length
+        };
+
+        dockFlip.captureFirst({hostId: 'dock-host', markerPrefix: 'dock-flip-item-'});
+
+        const playPromise = dockFlip.play({
+            hostId      : 'dock-host',
+            markerPrefix: 'dock-flip-item-',
+            maxFrames   : 1
+        });
+
+        expect(frames).toHaveLength(1); // play is pending in stage A, before #activeCleanups
+
+        marker.parentElement = destinationBody;
+        marker.setRect({bottom: 200, height: 100, left: 200, right: 300, top: 100, width: 100});
+
+        expect(dockFlip.land({hostId: 'dock-host'}), 'pending host play is an admitted landing target').toBe(true);
+        frames.shift()();
+
+        await expect(playPromise).resolves.toBe(false);
+        expect(marker.classList.contains('neo-dock-flip-fixed-stage')).toBe(false);
+        expect(marker.style.position).toBeUndefined();
+        expect(dockFlip.land({hostId: 'dock-host'}), 'the pending registration retires on settle').toBe(false)
+    });
+
     test('instant-lands at entry in a hidden document without arming a single wait (#16425)', async () => {
         // A hidden document cannot present motion, services no rAF, and visibility-clamps
         // main-thread timers (>=1s per tick, ~1 wake/min intensive) — so neither frame waits

--- a/test/playwright/unit/dashboard/DockFlip.spec.mjs
+++ b/test/playwright/unit/dashboard/DockFlip.spec.mjs
@@ -949,7 +949,13 @@ test.describe('Neo.main.addon.DockFlip', () => {
                     return name === '--dock-transition-duration' ? '260ms' : 'linear'
                 }
             },
-            frames = [];
+            originalCancelAnimationFrame = globalThis.cancelAnimationFrame,
+            originalClearTimeout         = globalThis.clearTimeout,
+            originalSetTimeout           = globalThis.setTimeout,
+            frames                        = new Map(),
+            timers                        = new Map();
+
+        let carrierId = 0;
 
         sourceBody.parentElement      = host;
         destinationBody.parentElement = host;
@@ -962,29 +968,54 @@ test.describe('Neo.main.addon.DockFlip', () => {
         };
         globalThis.getComputedStyle      = () => visibleStyle;
         globalThis.requestAnimationFrame = callback => {
-            frames.push(callback);
-            return frames.length
+            const id = ++carrierId;
+
+            frames.set(id, callback);
+
+            return id
         };
+        globalThis.cancelAnimationFrame = id => frames.delete(id);
+        globalThis.setTimeout = callback => {
+            const id = ++carrierId;
 
-        dockFlip.captureFirst({hostId: 'dock-host', markerPrefix: 'dock-flip-item-'});
+            timers.set(id, callback);
 
-        const playPromise = dockFlip.play({
-            hostId      : 'dock-host',
-            markerPrefix: 'dock-flip-item-',
-            maxFrames   : 1
-        });
+            return id
+        };
+        globalThis.clearTimeout = id => timers.delete(id);
 
-        expect(frames).toHaveLength(1); // play is pending in stage A, before #activeCleanups
+        try {
+            dockFlip.captureFirst({hostId: 'dock-host', markerPrefix: 'dock-flip-item-'});
 
-        marker.parentElement = destinationBody;
-        marker.setRect({bottom: 200, height: 100, left: 200, right: 300, top: 100, width: 100});
+            const playPromise = dockFlip.play({
+                hostId      : 'dock-host',
+                markerPrefix: 'dock-flip-item-',
+                maxFrames   : 1
+            });
 
-        expect(dockFlip.land({hostId: 'dock-host'}), 'pending host play is an admitted landing target').toBe(true);
-        await expect(playPromise).resolves.toBe(false);
-        expect(frames, 'settlement does not need the held frame carrier to run').toHaveLength(1);
-        expect(marker.classList.contains('neo-dock-flip-fixed-stage')).toBe(false);
-        expect(marker.style.position).toBeUndefined();
-        expect(dockFlip.land({hostId: 'dock-host'}), 'the pending registration retires on settle').toBe(false)
+            expect(frames.size).toBe(1); // pending in stage A, before #activeCleanups
+            expect(timers.size).toBe(1);
+
+            marker.parentElement = destinationBody;
+            marker.setRect({bottom: 200, height: 100, left: 200, right: 300, top: 100, width: 100});
+
+            expect(dockFlip.land({hostId: 'dock-host'}), 'pending host play is an admitted landing target').toBe(true);
+            await expect(Promise.race([
+                playPromise,
+                new Promise(resolve => originalSetTimeout(() => resolve('wedged'), 50))
+            ])).resolves.toBe(false);
+            expect(frames.size, 'the held frame carrier is cancelled').toBe(0);
+            expect(timers.size, 'the held timer carrier is cancelled').toBe(0);
+            expect(marker.classList.contains('neo-dock-flip-fixed-stage')).toBe(false);
+            expect(marker.style.position).toBeUndefined();
+            expect(dockFlip.land({hostId: 'dock-host'}), 'the pending registration retires on settle').toBe(false)
+        } finally {
+            originalCancelAnimationFrame === undefined
+                ? delete globalThis.cancelAnimationFrame
+                : globalThis.cancelAnimationFrame = originalCancelAnimationFrame;
+            globalThis.clearTimeout = originalClearTimeout;
+            globalThis.setTimeout   = originalSetTimeout
+        }
     });
 
     test('a same-host successor lands its active predecessor before capturing inline authority', async () => {
@@ -1077,6 +1108,7 @@ test.describe('Neo.main.addon.DockFlip', () => {
             // The successor capture overlaps the active predecessor. It must land the old stage
             // before recording First, otherwise its cleanup snapshot canonizes temporary fixed px.
             dockFlip.captureFirst({hostId: 'dock-host', markerPrefix: 'dock-flip-item-'});
+            expect(frames.size, 'successor capture cancels the predecessor frame immediately').toBe(0);
             await expect(firstPlay).resolves.toBe(false);
             expect(marker.classList.contains('neo-dock-flip-fixed-stage')).toBe(false);
 

--- a/test/playwright/unit/dashboard/DockFlip.spec.mjs
+++ b/test/playwright/unit/dashboard/DockFlip.spec.mjs
@@ -802,6 +802,41 @@ test.describe('Neo.main.addon.DockFlip', () => {
         await expect(playPromise).resolves.toBe(false)
     });
 
+    test('land retires a captured First before a later play can arm presentation', async () => {
+        const
+            markerClass = 'dock-flip-item-alpha',
+            marker      = createMarker(markerClass, {bottom: 100, height: 100, left: 0, right: 100, top: 0, width: 100}),
+            host        = {
+                classList: createClassList(),
+                querySelector() {
+                    return null
+                },
+                querySelectorAll() {
+                    return [marker]
+                }
+            };
+
+        globalThis.document = {
+            getElementById(id) {
+                return id === 'dock-host' ? host : null
+            }
+        };
+
+        let frames = 0;
+
+        globalThis.requestAnimationFrame = () => ++frames;
+
+        dockFlip.captureFirst({hostId: 'dock-host', markerPrefix: 'dock-flip-item-'});
+
+        expect(dockFlip.landFromPath([{id: 'splitter'}, {id: 'foreign-host'}])).toBe(false);
+        expect(dockFlip.landFromPath([{id: 'splitter'}, {id: 'dock-host'}])).toBe(true);
+        await expect(dockFlip.play({
+            hostId      : 'dock-host',
+            markerPrefix: 'dock-flip-item-'
+        })).resolves.toBe(false);
+        expect(frames, 'a retired snapshot cannot open a pending frame wait').toBe(0)
+    });
+
     test('land interrupts an active fixed stage without destroying the addon', async () => {
         const
             markerClass     = 'dock-flip-item-alpha',
@@ -869,6 +904,8 @@ test.describe('Neo.main.addon.DockFlip', () => {
         expect(marker.classList.contains('neo-dock-flip-fixed-stage')).toBe(true);
         expect(DockFlip.config.remote.app).toContain('land');
 
+        expect(dockFlip.land(), 'the public remote refuses an unscoped all-host landing').toBe(false);
+        expect(marker.classList.contains('neo-dock-flip-fixed-stage')).toBe(true);
         expect(dockFlip.land({hostId: 'other-host'}), 'a foreign host cannot land this presentation').toBe(false);
         expect(marker.classList.contains('neo-dock-flip-fixed-stage')).toBe(true);
         expect(dockFlip.land({hostId: 'dock-host'}), 'the owning host lands its active presentation').toBe(true);
@@ -943,12 +980,126 @@ test.describe('Neo.main.addon.DockFlip', () => {
         marker.setRect({bottom: 200, height: 100, left: 200, right: 300, top: 100, width: 100});
 
         expect(dockFlip.land({hostId: 'dock-host'}), 'pending host play is an admitted landing target').toBe(true);
-        frames.shift()();
-
         await expect(playPromise).resolves.toBe(false);
+        expect(frames, 'settlement does not need the held frame carrier to run').toHaveLength(1);
         expect(marker.classList.contains('neo-dock-flip-fixed-stage')).toBe(false);
         expect(marker.style.position).toBeUndefined();
         expect(dockFlip.land({hostId: 'dock-host'}), 'the pending registration retires on settle').toBe(false)
+    });
+
+    test('a same-host successor lands its active predecessor before capturing inline authority', async () => {
+        const
+            markerClass = 'dock-flip-item-alpha',
+            marker      = createMarker(markerClass, {bottom: 100, height: 100, left: 0, right: 100, top: 0, width: 100}),
+            sourceBody  = {parentElement: null},
+            middleBody  = {
+                parentElement        : null,
+                getBoundingClientRect: () => ({bottom: 200, height: 100, left: 200, right: 300, top: 100, width: 100})
+            },
+            targetBody  = {
+                parentElement        : null,
+                getBoundingClientRect: () => ({bottom: 300, height: 100, left: 400, right: 500, top: 200, width: 100})
+            },
+            host = {
+                classList    : createClassList(),
+                parentElement: null,
+                querySelector() {
+                    return null
+                },
+                querySelectorAll() {
+                    return [marker]
+                }
+            },
+            visibleStyle = {
+                contain    : 'none',
+                filter     : 'none',
+                overflowX  : 'visible',
+                overflowY  : 'visible',
+                perspective: 'none',
+                transform  : 'none',
+                willChange : 'auto',
+                getPropertyValue(name) {
+                    return name === '--dock-transition-duration' ? '260ms' : 'linear'
+                }
+            },
+            inlineProperties = [
+                'bottom', 'boxSizing', 'height', 'left', 'margin', 'maxHeight', 'maxWidth',
+                'minHeight', 'minWidth', 'opacity', 'position', 'right', 'top', 'transform',
+                'transformOrigin', 'transition', 'width', 'zIndex'
+            ],
+            frames = new Map();
+
+        let frameId = 0;
+
+        sourceBody.parentElement = middleBody.parentElement = targetBody.parentElement = host;
+        marker.parentElement = sourceBody;
+        Object.assign(marker.style, {
+            position : 'relative',
+            transform: 'rotate(1deg)',
+            width    : '17%',
+            zIndex   : '9'
+        });
+
+        const originalInline = Object.fromEntries(inlineProperties.map(property => [
+            property,
+            marker.style[property] ?? ''
+        ]));
+
+        globalThis.document = {
+            getElementById(id) {
+                return id === 'dock-host' ? host : null
+            }
+        };
+        globalThis.getComputedStyle = element => [middleBody, targetBody].includes(element)
+            ? {...visibleStyle, overflowX: 'hidden', overflowY: 'hidden'}
+            : visibleStyle;
+
+        const originalCancelAnimationFrame = globalThis.cancelAnimationFrame;
+
+        globalThis.requestAnimationFrame = callback => {
+            const id = ++frameId;
+
+            frames.set(id, callback);
+
+            return id
+        };
+        globalThis.cancelAnimationFrame = id => frames.delete(id);
+
+        try {
+            dockFlip.captureFirst({hostId: 'dock-host', markerPrefix: 'dock-flip-item-'});
+            marker.parentElement = middleBody;
+            marker.setRect({bottom: 200, height: 100, left: 200, right: 300, top: 100, width: 100});
+
+            const firstPlay = dockFlip.play({hostId: 'dock-host', markerPrefix: 'dock-flip-item-'});
+
+            expect(marker.classList.contains('neo-dock-flip-fixed-stage')).toBe(true);
+
+            // The successor capture overlaps the active predecessor. It must land the old stage
+            // before recording First, otherwise its cleanup snapshot canonizes temporary fixed px.
+            dockFlip.captureFirst({hostId: 'dock-host', markerPrefix: 'dock-flip-item-'});
+            await expect(firstPlay).resolves.toBe(false);
+            expect(marker.classList.contains('neo-dock-flip-fixed-stage')).toBe(false);
+
+            marker.parentElement = targetBody;
+            marker.setRect({bottom: 300, height: 100, left: 400, right: 500, top: 200, width: 100});
+
+            const secondPlay = dockFlip.play({hostId: 'dock-host', markerPrefix: 'dock-flip-item-'});
+
+            expect(marker.classList.contains('neo-dock-flip-fixed-stage')).toBe(true);
+            expect(dockFlip.land({hostId: 'dock-host'})).toBe(true);
+            await expect(secondPlay).resolves.toBe(false)
+        } finally {
+            originalCancelAnimationFrame === undefined
+                ? delete globalThis.cancelAnimationFrame
+                : globalThis.cancelAnimationFrame = originalCancelAnimationFrame
+        }
+
+        expect(Object.fromEntries(inlineProperties.map(property => [
+            property,
+            marker.style[property] ?? ''
+        ]))).toEqual(originalInline);
+        expect(marker.classList.contains('neo-dock-flip-fixed-stage')).toBe(false);
+        expect(frames.size, 'both interrupted frame carriers are retired').toBe(0)
     });
 
     test('instant-lands at entry in a hidden document without arming a single wait (#16425)', async () => {

--- a/test/playwright/unit/dashboard/DockSplitterEquivalence.spec.mjs
+++ b/test/playwright/unit/dashboard/DockSplitterEquivalence.spec.mjs
@@ -22,7 +22,7 @@ import * as core      from '../../../../src/core/_export.mjs';
  * (The sibling component spec pins the projected config/class contract on a rendered instance.)
  */
 test.describe('Neo.dashboard.dock.interaction.DockSplitter — behavior equivalence', () => {
-    let Container, DockSplitter, LayoutAdapter, MotionSignal, container, splitter;
+    let Container, DockSplitter, LayoutAdapter, container, splitter;
 
     const DOC = () => ({
         schema: 'neo.dock.zone.v1',
@@ -42,7 +42,6 @@ test.describe('Neo.dashboard.dock.interaction.DockSplitter — behavior equivale
         Container     = (await import('../../../../src/container/Base.mjs')).default;
         DockSplitter  = (await import('../../../../src/dashboard/dock/interaction/DockSplitter.mjs')).default;
         LayoutAdapter = (await import('../../../../src/dashboard/dock/projection/LayoutAdapter.mjs')).default;
-        MotionSignal  = (await import('../../../../src/dashboard/dock/projection/MotionSignal.mjs')).default
     });
 
     const mount = (splitterConfig = {}) => {
@@ -195,94 +194,6 @@ test.describe('Neo.dashboard.dock.interaction.DockSplitter — behavior equivale
 
         expect(zoneStarts).toHaveLength(1);
         expect(splitter.dragStartState?.sizes).toEqual([300, 300])
-    });
-
-    test('lands an active main-thread DockFlip before capturing live-resize geometry', async () => {
-        mount();
-
-        const
-            original   = Neo.main.addon.DockFlip,
-            order      = [],
-            motionHost = {
-                addCls() {},
-                getDockHost: () => ({id: 'equiv-dock-host', windowId: 'equiv-window'}),
-                id         : 'equiv-motion-host',
-                removeCls() {}
-            };
-
-        Neo.main.addon.DockFlip = {
-            async land(data) {
-                order.push(`land:${data.hostId}:${data.windowId}`)
-            }
-        };
-        splitter.up = () => motionHost;
-        MotionSignal.enter(motionHost, () => 1, () => {});
-        container.getLayoutRect = async () => {
-            order.push('capture');
-            return [{width: 600}, {width: 300}, {width: 300}]
-        };
-        splitter.dragZone.dragStart = () => order.push('start');
-
-        try {
-            await splitter.onDragStart({clientX: 300, clientY: 150})
-        } finally {
-            MotionSignal.leave(motionHost, () => {});
-
-            if (original === undefined) {
-                delete Neo.main.addon.DockFlip
-            } else {
-                Neo.main.addon.DockFlip = original
-            }
-        }
-
-        expect(order, 'presentation authority lands before resize geometry is captured').toEqual([
-            'land:equiv-dock-host:equiv-window',
-            'capture',
-            'start'
-        ])
-    });
-
-    test('a never-settling remote landing fails open within the bounded admission horizon', async () => {
-        mount({dockFlipLandTimeout: 5});
-
-        const
-            original   = Neo.main.addon.DockFlip,
-            order      = [],
-            motionHost = {
-                addCls() {},
-                getDockHost: () => ({id: 'equiv-dock-host', windowId: 'equiv-window'}),
-                id         : 'equiv-motion-host',
-                removeCls() {}
-            };
-
-        Neo.main.addon.DockFlip = {land: () => new Promise(() => {})};
-        splitter.up = () => motionHost;
-        MotionSignal.enter(motionHost, () => 1, () => {});
-        container.getLayoutRect = async () => {
-            order.push('capture');
-            return [{width: 600}, {width: 300}, {width: 300}]
-        };
-        splitter.dragZone.dragStart = () => order.push('start');
-
-        let outcome;
-
-        try {
-            outcome = await Promise.race([
-                splitter.onDragStart({clientX: 300, clientY: 150}).then(() => 'opened'),
-                new Promise(resolve => setTimeout(() => resolve('wedged'), 250))
-            ])
-        } finally {
-            MotionSignal.leave(motionHost, () => {});
-
-            if (original === undefined) {
-                delete Neo.main.addon.DockFlip
-            } else {
-                Neo.main.addon.DockFlip = original
-            }
-        }
-
-        expect(outcome, 'an unloaded main-thread addon cannot wedge pointer admission').toBe('opened');
-        expect(order).toEqual(['capture', 'start'])
     });
 
     test('cancel during the capture awaits invalidates the pending start: zero zone starts, no throw', async () => {

--- a/test/playwright/unit/dashboard/DockSplitterEquivalence.spec.mjs
+++ b/test/playwright/unit/dashboard/DockSplitterEquivalence.spec.mjs
@@ -22,7 +22,7 @@ import * as core      from '../../../../src/core/_export.mjs';
  * (The sibling component spec pins the projected config/class contract on a rendered instance.)
  */
 test.describe('Neo.dashboard.dock.interaction.DockSplitter — behavior equivalence', () => {
-    let Container, DockSplitter, LayoutAdapter, container, splitter;
+    let Container, DockSplitter, LayoutAdapter, MotionSignal, container, splitter;
 
     const DOC = () => ({
         schema: 'neo.dock.zone.v1',
@@ -41,7 +41,8 @@ test.describe('Neo.dashboard.dock.interaction.DockSplitter — behavior equivale
     test.beforeAll(async () => {
         Container     = (await import('../../../../src/container/Base.mjs')).default;
         DockSplitter  = (await import('../../../../src/dashboard/dock/interaction/DockSplitter.mjs')).default;
-        LayoutAdapter = (await import('../../../../src/dashboard/dock/projection/LayoutAdapter.mjs')).default
+        LayoutAdapter = (await import('../../../../src/dashboard/dock/projection/LayoutAdapter.mjs')).default;
+        MotionSignal  = (await import('../../../../src/dashboard/dock/projection/MotionSignal.mjs')).default
     });
 
     const mount = (splitterConfig = {}) => {
@@ -194,6 +195,94 @@ test.describe('Neo.dashboard.dock.interaction.DockSplitter — behavior equivale
 
         expect(zoneStarts).toHaveLength(1);
         expect(splitter.dragStartState?.sizes).toEqual([300, 300])
+    });
+
+    test('lands an active main-thread DockFlip before capturing live-resize geometry', async () => {
+        mount();
+
+        const
+            original   = Neo.main.addon.DockFlip,
+            order      = [],
+            motionHost = {
+                addCls() {},
+                getDockHost: () => ({id: 'equiv-dock-host', windowId: 'equiv-window'}),
+                id         : 'equiv-motion-host',
+                removeCls() {}
+            };
+
+        Neo.main.addon.DockFlip = {
+            async land(data) {
+                order.push(`land:${data.hostId}:${data.windowId}`)
+            }
+        };
+        splitter.up = () => motionHost;
+        MotionSignal.enter(motionHost, () => 1, () => {});
+        container.getLayoutRect = async () => {
+            order.push('capture');
+            return [{width: 600}, {width: 300}, {width: 300}]
+        };
+        splitter.dragZone.dragStart = () => order.push('start');
+
+        try {
+            await splitter.onDragStart({clientX: 300, clientY: 150})
+        } finally {
+            MotionSignal.leave(motionHost, () => {});
+
+            if (original === undefined) {
+                delete Neo.main.addon.DockFlip
+            } else {
+                Neo.main.addon.DockFlip = original
+            }
+        }
+
+        expect(order, 'presentation authority lands before resize geometry is captured').toEqual([
+            'land:equiv-dock-host:equiv-window',
+            'capture',
+            'start'
+        ])
+    });
+
+    test('a never-settling remote landing fails open within the bounded admission horizon', async () => {
+        mount({dockFlipLandTimeout: 5});
+
+        const
+            original   = Neo.main.addon.DockFlip,
+            order      = [],
+            motionHost = {
+                addCls() {},
+                getDockHost: () => ({id: 'equiv-dock-host', windowId: 'equiv-window'}),
+                id         : 'equiv-motion-host',
+                removeCls() {}
+            };
+
+        Neo.main.addon.DockFlip = {land: () => new Promise(() => {})};
+        splitter.up = () => motionHost;
+        MotionSignal.enter(motionHost, () => 1, () => {});
+        container.getLayoutRect = async () => {
+            order.push('capture');
+            return [{width: 600}, {width: 300}, {width: 300}]
+        };
+        splitter.dragZone.dragStart = () => order.push('start');
+
+        let outcome;
+
+        try {
+            outcome = await Promise.race([
+                splitter.onDragStart({clientX: 300, clientY: 150}).then(() => 'opened'),
+                new Promise(resolve => setTimeout(() => resolve('wedged'), 250))
+            ])
+        } finally {
+            MotionSignal.leave(motionHost, () => {});
+
+            if (original === undefined) {
+                delete Neo.main.addon.DockFlip
+            } else {
+                Neo.main.addon.DockFlip = original
+            }
+        }
+
+        expect(outcome, 'an unloaded main-thread addon cannot wedge pointer admission').toBe('opened');
+        expect(order).toEqual(['capture', 'start'])
     });
 
     test('cancel during the capture awaits invalidates the pending start: zero zone starts, no throw', async () => {

--- a/test/playwright/unit/main/addon/DragDrop.spec.mjs
+++ b/test/playwright/unit/main/addon/DragDrop.spec.mjs
@@ -1351,6 +1351,137 @@ test.describe('Neo.main.addon.DragDrop — main-thread resize preview', () => {
         }
     };
 
+    test('lands path-owned DockFlip on Main before resize or proxy state and an immediate move', () => {
+        const
+            originalDockFlip = Neo.main.addon.DockFlip,
+            originalSend     = DomEvents.sendMessageToApp,
+            appEvents        = [],
+            order            = [],
+            host             = {id: 'dock-host'},
+            root             = {id: 'splitter-root'},
+            target           = {
+                getBoundingClientRect() {
+                    return {height: 6, left: 300, top: 0, width: 6}
+                }
+            };
+
+        let presentationActive = true;
+
+        const dragResize = {
+            active: false,
+            apply() {
+                expect(presentationActive, 'a native move cannot mutate while FLIP still owns geometry').toBe(false);
+                order.push('resize:apply')
+            },
+            start(path, data, dragZoneId) {
+                expect(presentationActive, 'presentation lands before Resize captures state').toBe(false);
+                expect(dragZoneId).toBe('splitter-zone');
+                this.active = true;
+                order.push('resize:start')
+            }
+        };
+
+        const addon = {
+            alwaysFireDragMove    : false,
+            boundaryContainerRect : null,
+            dragCancelled         : false,
+            dragProxyElement      : null,
+            dragProxyRect         : null,
+            dragResize,
+            getEventData          : () => ({}),
+            isWindowDragging      : false,
+            resolveDragZoneId     : () => 'splitter-zone',
+            scrollContainerElement: null
+        };
+
+        Neo.main.addon.DockFlip = {
+            landFromPath(path) {
+                expect(path).toEqual([target, root, host]);
+                presentationActive = false;
+                order.push('dockFlip:land');
+
+                return true
+            }
+        };
+        // Deliberately retain the App event: the physical owner must be correct without an ack.
+        DomEvents.sendMessageToApp = data => {
+            appEvents.push(data);
+            order.push('app:queued')
+        };
+
+        try {
+            DragDrop.prototype.onDragStart.call(addon, {
+                detail: {clientX: 300, clientY: 0},
+                path  : [target, root, host],
+                target
+            });
+            DragDrop.prototype.onDragMove.call(addon, {
+                detail: {
+                    clientX      : 340,
+                    clientY      : 0,
+                    originalEvent: {screenX: 340, screenY: 0}
+                }
+            })
+        } finally {
+            originalDockFlip === undefined
+                ? delete Neo.main.addon.DockFlip
+                : Neo.main.addon.DockFlip = originalDockFlip;
+            DomEvents.sendMessageToApp = originalSend
+        }
+
+        expect(appEvents).toHaveLength(1);
+        expect(appEvents[0].type).toBe('drag:start');
+        expect(order).toEqual(['dockFlip:land', 'resize:start', 'app:queued', 'resize:apply'])
+    });
+
+    test('a missing DockFlip addon or path-owned host leaves native admission synchronous', () => {
+        const
+            originalDockFlip = Neo.main.addon.DockFlip,
+            originalSend     = DomEvents.sendMessageToApp,
+            scenarios        = [
+                {dockFlip: undefined, name: 'missing addon'},
+                {
+                    dockFlip: {
+                        landFromPath() {
+                            return false
+                        }
+                    },
+                    name: 'no path-owned host'
+                }
+            ];
+
+        try {
+            DomEvents.sendMessageToApp = () => {};
+
+            scenarios.forEach(({dockFlip, name}) => {
+                const
+                    starts = [],
+                    target = {getBoundingClientRect: () => ({height: 6, left: 0, top: 0, width: 6})},
+                    addon  = {
+                        dragResize       : {start: (...args) => starts.push(args)},
+                        getEventData     : () => ({}),
+                        resolveDragZoneId: () => 'splitter-zone'
+                    };
+
+                dockFlip === undefined
+                    ? delete Neo.main.addon.DockFlip
+                    : Neo.main.addon.DockFlip = dockFlip;
+
+                expect(() => DragDrop.prototype.onDragStart.call(addon, {
+                    detail: {clientX: 0, clientY: 0},
+                    path  : [target],
+                    target
+                }), name).not.toThrow();
+                expect(starts, name).toHaveLength(1)
+            })
+        } finally {
+            originalDockFlip === undefined
+                ? delete Neo.main.addon.DockFlip
+                : Neo.main.addon.DockFlip = originalDockFlip;
+            DomEvents.sendMessageToApp = originalSend
+        }
+    });
+
     test('live pointer frames resize the real target and terminal resolution keeps that DOM preview', () => {
         const {resize, style} = createState();
 


### PR DESCRIPTION
Resolves #17985

Related: #13158
Related: #17820

Rebased directly onto `dev@a9215920c8` after #18017 and #18022 merged. The final `dev..f63f3492b9` range contains exactly the seven #17985 files. The previously red `DockMaximize` suite is 13/13 locally at the rebased head; fresh required CI and exact-head cross-family review govern merge eligibility.

## Stack boundary

The former stack is gone. The delivered range contains only `DockSplitter.mjs`, `DockFlip.mjs`, Main `DragDrop.mjs`, the Workstation nested-column E2E, and three focused unit specs. `src/manager/Component.mjs` and `test/playwright/unit/vdom/AutoId.spec.mjs` now come exclusively from merged #17999 through `dev` and do not appear in this PR diff.

A splitter gesture now reclaims geometry in the physical realm that owns it. Main `DragDrop.onDragStart()` asks same-window DockFlip to resolve its own snapshot/pending/active host registry against the native event path, lands that host synchronously, and only then opens `Resize` and publishes `drag:start` to App. Snapshot-only state is retired; pending rAF/timer waits are cancelled and resolve immediately; same-host successor capture serializes its predecessor; active cleanup restores exact inline authority. Public `land({hostId})` refuses a missing host while destroy retains a private all-host path. Live and proxy-mode splitters share this admission boundary, no App acknowledgement or timeout is involved, and MotionSignal remains observability-only. The generic two-participant Splitter contract stays unchanged—nested flex owns descendants.

Evidence: L3 (real branded-Chrome Workstation pointer journey, worker document receipts, and rendered mid-gesture geometry) → L3 required (AC1-9 runtime interaction and cancellation behavior). No residuals.

## AC Evidence

| AC | Evidence |
|---|---|
| AC-1 | `WorkstationNestedColumnResizeNL.spec.mjs` drives Matrix right of Alerts and Feed above Alerts with trusted pointer input, then asserts the nested vertical worker document. |
| AC-2 | The same E2E requires `neo-dashboard-dock-animating` plus both fixed-stage panes immediately at the actual splitter admission boundary. |
| AC-3 | The E2E and `DockSplitterEquivalence.spec.mjs` prove `getResizeConfig()` still names the two direct outer layout participants; no descendant-array API exists. |
| AC-4 | Mid-gesture rects bind both tab shells within 1px and transform-inclusive panes within 2px while the outer pair remains conserved. |
| AC-5 | Worker bytes stay identical while held; release changes only the outer size vector, preserves the nested vector, and retains pane/tab identities. |
| AC-6 | The reverse-direction Escape arm restores the whole column and proves byte-identical worker state before and after cancellation. |
| AC-7 | `DockFlip.spec.mjs` proves required-host public scope, private all-host destroy, snapshot retirement, carrier-free pending settlement, same-host serialization before capture, defensive LIFO cleanup, exact 18-property inline restore, zero fixed-stage residue, and idempotence without addon destruction. |
| AC-8 | `DragDrop.spec.mjs` holds App delivery, dispatches an immediate native move, and proves path-owned DockFlip lands before Resize start/apply; missing addon and no path-owned host remain synchronous. `DockSplitterEquivalence.spec.mjs` keeps the live/proxy direct-pair boundary. |
| AC-9 | At rebased head `f63f3492b9`: the previously red `DockMaximize.spec.mjs` is **13/13** locally. Prior-head full unit, rendered DockSplitter, and nested-column E2E receipts remain historical; fresh exact-head CI is running and owns the current full-suite verdict. |

## Deltas from ticket

The initial Reconciler/stale-width hypothesis was falsified: settled nested flex geometry is healthy. Review then falsified the first repair boundary too: Main activates and applies Resize before the unawaited App `DockSplitter.onDragStart()` can finish a remote landing. The final seam is same-realm Main admission over DockFlip's actual registry; the App timeout/RMA path and MotionSignal admission role were removed. A second-pass proxy-mode falsifier moved host resolution out of the live-resize descriptor and onto the native path, so `liveResize:false` retains the same protection. The live ticket body carries this operative contract.

## Test Evidence

- Rebase boundary at `f63f3492b9`: `git diff --name-status origin/dev...HEAD` reports exactly seven #17985 files; `git diff --check` exits 0.
- Rebased-head red-check probe: `npm run test-components -- test/playwright/component/dashboard/DockMaximize.spec.mjs --workers=1` — **13 passed**.
- Prior-head full unit: `npm run test-unit` — **2693 passed**. Fresh rebased-head required CI is running.
- Prior-head rendered splitters: `npx playwright test test/playwright/component/dashboard/DockSplitterEquivalence.spec.mjs test/playwright/component/dashboard/DockSplitterLivePreview.spec.mjs -c test/playwright/playwright.config.component.mjs --workers=1` — **6 passed**.
- Prior-head Workstation journey: `NEO_AGENTOS_RUNTIME_ROOT=<brain-root> NEO_E2E_PORT=8195 npx playwright test test/playwright/e2e/workstation/WorkstationNestedColumnResizeNL.spec.mjs -c test/playwright/playwright.config.e2e.mjs --workers=1` — **1 passed**.
- Red-first journey: nested parent `554.19 → 904.19px`, while Feed/Alerts remained about `555px`; the model stayed unchanged while held.
- Mutation controls: removing Main `landFromPath()` fails before Resize state; removing pending-wait interruption yields `wedged` with rAF and timer black-holed; removing same-host serialization leaves the predecessor frame live at successor capture.
- Pre-stack adjacent command: `NEO_AGENTOS_RUNTIME_ROOT=<brain-root> NEO_E2E_PORT=8126 npx playwright test test/playwright/e2e/workstation/WorkstationDragAffordancesNL.spec.mjs test/playwright/e2e/workstation/WorkstationSplitterGridGeometryNL.spec.mjs test/playwright/e2e/workstation/WorkstationDockFlipResizeNL.spec.mjs -c test/playwright/playwright.config.e2e.mjs --workers=1` — 8 passed, 1 capability-gated skip.

## Post-Merge Validation

- [x] No post-merge-only validation; every close-target runtime behavior was verified before handoff.

## Evolution

The screenshot first suggested stale retained sizing and raised a plausible generic `Splitter` descendant-group API. The composed red E2E disproved both: the outer descriptor already targets the correct nested container, and settled flex stretches every child. The first repair correctly identified DockFlip presentation but placed admission in an async App handler; source-order review proved that Main Resize could already mutate before it settled. Moving the fence to Main's native event boundary, resolving hosts from DockFlip's own registry, and making every presentation generation immediately cancellable preserves the generic two-participant contract without promoting an observability signal into authority.

Authored by Emmy (GPT-5.6 Sol Ultra, Codex). Session 4426fb43-4968-4084-832e-1830de2e8747.
