### PR TITLE
A user-triggered pane recreate amends the never-destroyed guarantee

### DIFF
--- a/learn/agentos/decisions/0029-docking-design.md
+++ b/learn/agentos/decisions/0029-docking-design.md
@@ -314,7 +314,7 @@ The minimal interface between the docking shell and the product surfaces that li
 
 | The embedded surface provides | The docking shell guarantees |
 |---|---|
-| A stable `componentRef` registered with the workspace's resolver | Resolution to the live instance on every projection; the instance is **moved / re-parented, never destroyed** (landed adapter rule) |
+| A stable `componentRef` registered with the workspace's resolver | Resolution to the live instance on every projection; the instance is **moved / re-parented, never destroyed** (landed adapter rule) — one conditioned exception, see *User-triggered recreate* below |
 | Optionally a `blueprint` — a serializable Neo config for creation-from-saved-state | Instantiation from blueprint when no live instance exists; recoverable placeholder (never silent drop) when neither resolves (landed placeholder + stale-ref policy) |
 | Policy hints: `closable`, `pinnable`, `movable` | Enforcement at the operation layer (e.g. `setItemPinned` / `setItemAutoHidden` reject `pinnable === false`; landed) |
 | JSON-only `metadata` — no secrets, credentials, functions, DOM, live objects | No-secret validation on every persistence path (landed, #13153 class of checks) |
@@ -324,6 +324,23 @@ Two binding consequences:
 
 - **Panes are layout-blind.** An embedded surface never reads or mutates the dock document, never listens to drag surfaces, and never persists its own placement. It experiences docking exclusively as ordinary Neo component lifecycle (mount/unmount/re-parent) plus its own config updates. A pane that "helps" with layout is a contract violation.
 - **Layout is pane-blind.** The shell knows items only as catalog records. Cockpit panes and FM-UX cards add zero cases to the docking code; if a product surface needs a new docking behavior, that behavior enters through an amendment to this ADR, not through a pane-specific branch.
+
+#### User-triggered recreate (amendment, 2026-09-01 — #17966)
+
+The table above guarantees a resolved instance is **moved / re-parented, never destroyed**. That guarantee is unchanged for every shell-initiated operation. This amendment adds one narrow exception and states its **condition**, not merely its permission — the row stays authoritative wherever the condition is unmet.
+
+**The exception.** A pane that does not implement the `dockReload()` delegation contract (#17948) has no recovery path once its own state is wedged: a JS error inside the surface leaves an instance the shell will faithfully re-parent forever. For that case only, a **user-triggered** recreate may destroy the resolved instance and replace it with a fresh one for the same `dockItemId` and slot.
+
+**The condition — a two-phase transaction, or the exception does not apply.**
+
+1. **Prepare.** A fresh candidate is obtained and validated *independently of the live-instance cache*, without touching the live pane. Three failure shapes must each leave the old pane fully intact and settle with a named error: the factory throws, it returns `null`, or it returns the cached — still live — current instance. Rollback is by construction, not by repair: at this point nothing has been destroyed.
+2. **Commit.** The card-body slot is replaced through container ownership (`removeAt` + insert), never a bare destroy. `core.Base#destroy` unregisters an instance without removing it from `parent.items`, and the reconciler fills `liveItems` positionally from `body.items` and prefers that entry over `resolveItem` — so a bare destroy can hand an erased object back as the live answer on the next refresh. The old instance is destroyed only after the candidate is live.
+
+**Identity that survives:** `dockItemId`, tab, header actions, and overflow membership. The component *instance* is the only thing this exception permits losing, and only for the item the user acted on — which is why §2.3 placement continuity and §2.2 perspective capture are unaffected.
+
+**Still forbidden:** automatic recreation of any kind — crash detection, watchdogs, retry policies. Those live in consumer territory above the transaction. A shell that recreates without a user action has re-entered the rule this amendment does not touch.
+
+**Retirement condition.** This exception exists only because `dockReload()` is optional. When the delegation contract becomes mandatory for embedded surfaces, or a pane-level error boundary makes a wedged pane recoverable without identity loss, this subsection retires with the leaf that makes it unnecessary and the table row returns to unconditional. Whoever lands that leaf should delete this block rather than qualify it further.
 
 ### §2.7 Auto-Hide UI Contract
 

--- a/src/dashboard/dock/Workspace.mjs
+++ b/src/dashboard/dock/Workspace.mjs
@@ -3456,6 +3456,52 @@ class Workspace extends Container {
 
         return {ok: true, candidate, reason: null, error: null}
     }
+
+    /**
+     * Phase 2 of the two-phase recreate transaction: replace exactly the card-body slot, then — and
+     * only then — destroy the instance that was there.
+     *
+     * **Never a bare destroy.** `core.Base#destroy` unregisters an instance without removing it from
+     * `parent.items`, and the reconciler fills its live map positionally from `body.items` and
+     * prefers that entry over the resolver. A destroyed-but-still-listed pane is therefore handed
+     * back as the live answer on the very next refresh. Structural removal belongs to the container,
+     * so this goes through `removeAt` + `insert`.
+     *
+     * `removeAt`'s `destroyItem` argument **defaults to true** and is passed `false` here. That
+     * default is the whole ordering hazard: taking it would destroy the old pane during removal, so
+     * a failure to insert the candidate afterwards would leave the slot empty with nothing to
+     * restore — the silent pane loss this transaction exists to prevent.
+     *
+     * Only the card body is touched, so tab, header-action and overflow identities are preserved by
+     * construction rather than by repair: the tab bar is never in the mutation path.
+     * @param {Neo.component.Base} livePane The mounted pane to replace.
+     * @param {Object|Neo.component.Base} candidate A candidate validated by
+     *     {@link #prepareRecreateCandidate} — never call this with an unvalidated one.
+     * @returns {{ok: Boolean, index: Number, reason: ?String}}
+     */
+    commitRecreateCandidate(livePane, candidate) {
+        const container = livePane?.parent;
+
+        if (!container) {
+            return {ok: false, index: -1, reason: 'no-container'}
+        }
+
+        const index = container.indexOf(livePane.id);
+
+        if (index < 0) {
+            return {ok: false, index, reason: 'not-in-container'}
+        }
+
+        // `false`: the old instance must outlive its own removal.
+        container.removeAt(index, false);
+        container.insert(index, candidate);
+
+        // The candidate is in the slot; the predecessor is now safe to release. Ordering is the
+        // contract, not an implementation detail — everything above is reversible until this line.
+        livePane.destroy();
+
+        return {ok: true, index, reason: null}
+    }
 }
 
 export default Neo.setupClass(Workspace);

--- a/src/dashboard/dock/Workspace.mjs
+++ b/src/dashboard/dock/Workspace.mjs
@@ -3383,6 +3383,79 @@ class Workspace extends Container {
     resolveRevealPane(itemId, item) {
         return this.resolvePane(itemId, item)
     }
+
+    /**
+     * Hook: produces a **fresh** candidate pane for an item, bypassing any live-instance cache.
+     *
+     * Deliberately a separate hook rather than an option on {@link #resolvePane}. Real consumers
+     * resolve panes from live-instance caches and mint replacements only after observing
+     * `pane.isDestroyed`; an option those consumers do not implement would be silently ignored and
+     * hand back **the very instance the recreate is meant to replace**. A distinct hook cannot be
+     * accidentally satisfied by a cache, and its default says the honest thing: this consumer does
+     * not support recreate.
+     *
+     * Returning `null` is a legitimate answer, not a failure of contract — it declines the
+     * capability, and {@link #prepareRecreateCandidate} reports that as a named refusal with the
+     * live pane untouched.
+     * @param {String} itemId The stable workspace identity from the item catalog.
+     * @param {Object} item The persisted item record.
+     * @returns {Object|Neo.component.Base|null}
+     */
+    resolveFreshPane(itemId, item) {
+        return null
+    }
+
+    /**
+     * Phase 1 of the two-phase recreate transaction: obtain and validate a fresh candidate **without
+     * touching the live pane**.
+     *
+     * Rollback is by construction rather than by repair — nothing is destroyed here, so every
+     * refusal below leaves the workspace exactly as it was. The docking record's user-triggered
+     * recreate exception is conditioned on this phase — without a validated candidate the exception
+     * does not apply and the never-destroyed guarantee stands unmodified.
+     * @see ADR 0029 §2.6 — ticket-ref-ok: the record IS this method's authority, not a tracking ref;
+     *      the contract is unreadable without it and an accepted ADR section does not close.
+     *
+     * The three refusals are the ones a cache-backed resolver actually produces:
+     *
+     * | refusal | why it is not a candidate |
+     * |---|---|
+     * | `threw` | the factory raised; the error is carried, never swallowed |
+     * | `declined` | returned `null` — including the default, i.e. recreate unsupported |
+     * | `live-instance` | returned the pane that is already mounted, so "replacing" it is a no-op that would destroy the only copy |
+     *
+     * The `live-instance` check is the load-bearing one and the reason a factory seam alone is not
+     * enough: a resolver reading its own cache answers with the current instance, which looks like a
+     * successful candidate and is the exact shape that turns a recovery click into silent pane loss.
+     * @param {String} itemId The stable workspace identity from the item catalog.
+     * @param {Neo.component.Base} livePane The currently mounted pane for that item.
+     * @returns {{ok: Boolean, candidate: ?Object, reason: ?String, error: ?Error}}
+     */
+    prepareRecreateCandidate(itemId, livePane) {
+        // The same read the rest of this class uses for a catalog record; an item the committed
+        // document does not carry resolves to null and the factory decides what that means.
+        const item = this.dockModel?.items?.[itemId] || null;
+
+        let candidate;
+
+        try {
+            candidate = this.resolveFreshPane(itemId, item)
+        } catch (error) {
+            return {ok: false, candidate: null, reason: 'threw', error}
+        }
+
+        if (!candidate) {
+            return {ok: false, candidate: null, reason: 'declined', error: null}
+        }
+
+        // Identity, not equality: a config object that merely describes the same pane is a valid
+        // candidate; the mounted instance itself is not.
+        if (livePane && candidate === livePane) {
+            return {ok: false, candidate: null, reason: 'live-instance', error: null}
+        }
+
+        return {ok: true, candidate, reason: null, error: null}
+    }
 }
 
 export default Neo.setupClass(Workspace);

--- a/src/dashboard/dock/Workspace.mjs
+++ b/src/dashboard/dock/Workspace.mjs
@@ -2214,10 +2214,11 @@ class Workspace extends Container {
             // owns `dockReload()` decides what reload means, and replacing it instead would
             // discard that authority AND its identity.
             //
-            // Settles through THIS method's channel rather than `dockRecreateSettled`: one
-            // activation, one settlement, whichever path served it. The recreate transaction's own
-            // channel stays for direct callers.
-            const recreated = me.recreateDockPane(itemId, pane, {dockNodeId});
+            // `settle: false` because THIS method settles the activation. Without it one click
+            // emits two terminal events — `dockRecreateSettled` from the transaction and
+            // `dockReloadSettled` from here — and a consumer counting completions would see the
+            // action fire twice. The transaction's own channel stays for direct callers.
+            const recreated = me.recreateDockPane(itemId, pane, {dockNodeId, settle: false});
 
             recreated?.errors?.length && errors.push(...recreated.errors)
         } else {
@@ -3595,12 +3596,17 @@ class Workspace extends Container {
      * inside its own factory would otherwise recurse.
      * @param {String} itemId The stable workspace identity from the item catalog.
      * @param {Neo.component.Base} livePane The mounted pane to replace.
+     * **`settle: false` is for callers that own the settlement themselves.** The reload action is
+     * the one in tree: it serves a contract-less pane through this transaction and then settles on
+     * `dockReloadSettled`, so firing here too would emit **two terminal events for one activation**.
+     * The single-flight guard still applies — only the event is suppressed, never the transaction.
      * @param {Object} [options]
      * @param {String|null} [options.dockNodeId=null] Carried through to the settlement payload.
+     * @param {Boolean} [options.settle=true] `false` when an outer channel settles this invocation.
      * @returns {{errors: String[]}|null} `null` when an in-flight invocation absorbed this one.
      * @protected
      */
-    recreateDockPane(itemId, livePane, {dockNodeId=null}={}) {
+    recreateDockPane(itemId, livePane, {dockNodeId=null, settle=true}={}) {
         const me     = this,
               errors = [];
 
@@ -3634,7 +3640,7 @@ class Workspace extends Container {
             me.dockRecreateInFlight.delete(itemId)
         }
 
-        !me.isDestroyed && me.fire('dockRecreateSettled', {dockNodeId, errors, itemId});
+        settle && !me.isDestroyed && me.fire('dockRecreateSettled', {dockNodeId, errors, itemId});
 
         return {errors}
     }

--- a/src/dashboard/dock/Workspace.mjs
+++ b/src/dashboard/dock/Workspace.mjs
@@ -438,6 +438,14 @@ class Workspace extends Container {
     dockReloadInFlight = new Set()
 
     /**
+     * Item ids with a recreate transaction in flight — the same single-flight contract the reload
+     * guard above uses, for the same reason: one settlement per invocation.
+     * @member {Set<String>} dockRecreateInFlight=new Set()
+     * @protected
+     */
+    dockRecreateInFlight = new Set()
+
+    /**
      * The in-flight maximizedNodeId transition as an awaitable — every consumer that must
      * observe settled maximize presentation (the refresh chain, the continuity sync) awaits
      * this instead of racing the async clear/apply pair.
@@ -3480,9 +3488,21 @@ class Workspace extends Container {
      * @returns {{ok: Boolean, index: Number, reason: ?String}}
      */
     commitRecreateCandidate(livePane, candidate) {
-        const container = livePane?.parent;
+        // Teardown mid-transaction. Phase 1 and Phase 2 are separate calls, so a workspace or tab
+        // container can be destroyed in the gap between validating a candidate and committing it —
+        // a pane closed, a vessel torn down, a window disconnected. Every one of those must settle
+        // as a **refusal**, not as a throw and not as a partial mutation: by this point the caller
+        // holds a validated candidate and would otherwise commit it into a corpse.
+        //
+        // Checked before the container is touched, so a torn-down transaction mutates nothing at all
+        // rather than mutating and then failing.
+        if (!livePane || livePane.isDestroyed || this.isDestroyed) {
+            return {ok: false, index: -1, reason: 'torn-down'}
+        }
 
-        if (!container) {
+        const container = livePane.parent;
+
+        if (!container || container.isDestroyed) {
             return {ok: false, index: -1, reason: 'no-container'}
         }
 
@@ -3501,6 +3521,66 @@ class Workspace extends Container {
         livePane.destroy();
 
         return {ok: true, index, reason: null}
+    }
+
+    /**
+     * The two phases run as one transaction, settling exactly once through a named channel.
+     *
+     * Mirrors the reload leaf's contract deliberately — `dockReloadSettled` / `dockReloadInFlight` —
+     * because a second settlement channel with different semantics on the same header would be a
+     * worse cost than the duplication. **Every completion settles**, including each refusal: the
+     * action wire has no result channel (`Observable.fire` discards listener returns), so an
+     * unsettled early return is an invocation the event contract never saw.
+     *
+     * Unlike reload this is **synchronous** — both phases are — so there is no producer to trap and
+     * no async teardown race. Teardown is still handled, by
+     * {@link #commitRecreateCandidate}'s `torn-down` refusal, and it settles through this channel
+     * like everything else.
+     *
+     * **Single-flight per item, and absorption is the only silent path** — a re-entrant invocation
+     * during the window neither runs nor settles, exactly as reload's does. Re-entrancy is not
+     * hypothetical here: `resolveFreshPane` is consumer code, and a consumer that recreates from
+     * inside its own factory would otherwise recurse.
+     * @param {String} itemId The stable workspace identity from the item catalog.
+     * @param {Neo.component.Base} livePane The mounted pane to replace.
+     * @param {Object} [options]
+     * @param {String|null} [options.dockNodeId=null] Carried through to the settlement payload.
+     * @returns {{errors: String[]}|null} `null` when an in-flight invocation absorbed this one.
+     * @protected
+     */
+    recreateDockPane(itemId, livePane, {dockNodeId=null}={}) {
+        const me     = this,
+              errors = [];
+
+        // Absorption: neither runs nor settles. The only silent path, by design.
+        if (me.dockRecreateInFlight.has(itemId)) {
+            return null
+        }
+
+        me.dockRecreateInFlight.add(itemId);
+
+        try {
+            const prepared = me.prepareRecreateCandidate(itemId, livePane);
+
+            if (!prepared.ok) {
+                // The refusal reason IS the error. A caller that only learns "it failed" cannot tell
+                // a consumer that declined the capability from one whose factory handed back the
+                // live instance — and those need different fixes.
+                errors.push(`Dock recreate refused for item "${itemId}": ${prepared.reason}`);
+
+                prepared.error && errors.push(prepared.error.message)
+            } else {
+                const committed = me.commitRecreateCandidate(livePane, prepared.candidate);
+
+                committed.ok || errors.push(`Dock recreate could not commit item "${itemId}": ${committed.reason}`)
+            }
+        } finally {
+            me.dockRecreateInFlight.delete(itemId)
+        }
+
+        !me.isDestroyed && me.fire('dockRecreateSettled', {dockNodeId, errors, itemId});
+
+        return {errors}
     }
 }
 

--- a/src/dashboard/dock/Workspace.mjs
+++ b/src/dashboard/dock/Workspace.mjs
@@ -2203,10 +2203,23 @@ class Workspace extends Container {
             index   = itemIds.indexOf(itemId),
             pane    = index > -1 ? tabContainer.getCard(index) : null;
 
-        if (!pane || pane.isDestroyed || typeof pane.dockReload !== 'function') {
-            // The visibility sync hides the action for exactly these panes; reaching this guard
-            // means a race (teardown, active-item flip mid-dispatch) — settle it honestly.
-            errors.push(`Dock reload has no live dockReload() contract for item "${itemId}"`)
+        if (!pane || pane.isDestroyed) {
+            // No live card at all: a race (teardown, active-item flip mid-dispatch). There is
+            // nothing to delegate to and nothing to replace — settle it honestly.
+            errors.push(`Dock reload has no live pane for item "${itemId}"`)
+        } else if (typeof pane.dockReload !== 'function') {
+            // THE FALLBACK. A pane that never implemented the delegation contract has no other
+            // recovery once its own state is wedged, which is the entire reason the recreate
+            // transaction exists. Delegation first, recreate only when it is absent — a pane that
+            // owns `dockReload()` decides what reload means, and replacing it instead would
+            // discard that authority AND its identity.
+            //
+            // Settles through THIS method's channel rather than `dockRecreateSettled`: one
+            // activation, one settlement, whichever path served it. The recreate transaction's own
+            // channel stays for direct callers.
+            const recreated = me.recreateDockPane(itemId, pane, {dockNodeId});
+
+            recreated?.errors?.length && errors.push(...recreated.errors)
         } else {
             me.dockReloadInFlight.add(itemId);
             me.syncDockReloadAction(tabContainer);
@@ -2274,8 +2287,12 @@ class Workspace extends Container {
                 pane    = index > -1 ? tabContainer.getCard(index) : null,
                 carrier = pane?.isDestroyed ? null : (pane?.dockReload ?? pane?.module?.prototype?.dockReload);
 
-            disabled = this.dockReloadInFlight.has(itemId);
-            hidden   = typeof carrier !== 'function'
+            disabled = this.dockReloadInFlight.has(itemId) || this.dockRecreateInFlight.has(itemId);
+
+            // An absent delegation hook no longer hides the action on its own: the recreate
+            // fallback serves exactly those panes, so hiding them would hide the only recovery
+            // they have. Hidden only when NEITHER path can serve the item.
+            hidden = typeof carrier !== 'function' && !this.hasDockRecreateFallback()
         }
 
         // ONE batched update for both axes (`set()`), never two sequential writes: each write
@@ -3414,6 +3431,25 @@ class Workspace extends Container {
     }
 
     /**
+     * Whether this workspace can serve a recreate at all — i.e. whether a consumer overrode
+     * {@link #resolveFreshPane}.
+     *
+     * Derived from the prototype rather than by calling the factory, because this is consulted by
+     * {@link #syncDockReloadAction} on every active-item change and a visibility sync must not have
+     * side effects: invoking a consumer factory to decide whether to show a button would mint panes
+     * nobody asked for.
+     *
+     * It answers "is the capability wired", not "will this particular item succeed". A consumer that
+     * overrides the hook and then declines a specific item still gets a **visible** action that
+     * settles with a named refusal — which is the honest behaviour: hiding it would leave a wedged
+     * pane with no affordance and no explanation.
+     * @returns {Boolean}
+     */
+    hasDockRecreateFallback() {
+        return this.resolveFreshPane !== Workspace.prototype.resolveFreshPane
+    }
+
+    /**
      * Phase 1 of the two-phase recreate transaction: obtain and validate a fresh candidate **without
      * touching the live pane**.
      *
@@ -3512,15 +3548,31 @@ class Workspace extends Container {
             return {ok: false, index, reason: 'not-in-container'}
         }
 
-        // `false`: the old instance must outlive its own removal.
-        container.removeAt(index, false);
-        container.insert(index, candidate);
+        // INSERT FIRST, then remove. The reverse order — remove, then insert — has a window between
+        // the two calls where the slot is empty and the predecessor is orphaned, and an `insert`
+        // that throws (an invalid candidate config is ordinary consumer input) leaves it that way
+        // permanently. That is the silent pane loss this whole transaction exists to prevent, so the
+        // failure mode cannot live inside the commit either.
+        //
+        // Inserting at `index` shifts the predecessor to `index + 1`; nothing is removed until the
+        // candidate is demonstrably in the container.
+        try {
+            container.insert(index, candidate)
+        } catch (error) {
+            // Nothing was removed, so there is nothing to restore — rollback by construction here
+            // too, not by repair.
+            return {ok: false, index, reason: 'insert-failed', error}
+        }
 
-        // The candidate is in the slot; the predecessor is now safe to release. Ordering is the
-        // contract, not an implementation detail — everything above is reversible until this line.
+        // `false`: the predecessor must outlive its own removal, so a failure here still leaves a
+        // live pane in the container rather than a destroyed one.
+        container.removeAt(index + 1, false);
+
+        // The candidate is in the slot; the predecessor is now safe to release. The ordering is the
+        // contract, not an implementation detail.
         livePane.destroy();
 
-        return {ok: true, index, reason: null}
+        return {ok: true, index, reason: null, error: null}
     }
 
     /**
@@ -3572,7 +3624,11 @@ class Workspace extends Container {
             } else {
                 const committed = me.commitRecreateCandidate(livePane, prepared.candidate);
 
-                committed.ok || errors.push(`Dock recreate could not commit item "${itemId}": ${committed.reason}`)
+                if (!committed.ok) {
+                    errors.push(`Dock recreate could not commit item "${itemId}": ${committed.reason}`);
+
+                    committed.error && errors.push(committed.error.message)
+                }
             }
         } finally {
             me.dockRecreateInFlight.delete(itemId)

--- a/test/playwright/unit/dashboard/DockRecreateCandidate.spec.mjs
+++ b/test/playwright/unit/dashboard/DockRecreateCandidate.spec.mjs
@@ -16,6 +16,7 @@ import Container                from '../../../../src/container/Base.mjs';
 import DockLayoutAdapter        from '../../../../src/dashboard/dock/projection/LayoutAdapter.mjs';
 import DockProjectionReconciler from '../../../../src/dashboard/dock/projection/Reconciler.mjs';
 import DockWorkspace            from '../../../../src/dashboard/dock/Workspace.mjs';
+import TabContainer             from '../../../../src/tab/Container.mjs';
 // Side-effect imports: the projection instantiates by ntype, so the tab/toolbar/button classes must
 // be registered or `DockLayoutAdapter.project` throws `ntype tab-container does not exist`.
 import '../../../../src/manager/Instance.mjs';
@@ -333,6 +334,35 @@ test.describe('dock recreate — settles exactly once, one flight per item', () 
         expect(settlements.length, 'absorption is the only silent path — one settlement, not two').toBe(1)
     });
 
+    test('an insertion that THROWS leaves the live pane in its slot and settles once', () => {
+        // The atomicity hole this ordering exists to close. An invalid candidate config is ordinary
+        // consumer input, and `insert` throwing after `removeAt` would leave the slot EMPTY with the
+        // predecessor orphaned — silent pane loss, inside the transaction built to prevent it.
+        // Inserting first means a throw removes nothing.
+        const realInsert = container.insert.bind(container);
+
+        container.insert = () => { throw new Error('candidate could not be instantiated') };
+
+        workspace.resolveFreshPane = () => ({module: Component, id: 'settle-fresh'});
+
+        const result = workspace.recreateDockPane('editor', livePane);
+
+        container.insert = realInsert;
+
+        // Settles rather than throws...
+        expect(result, 'a throwing insert must settle, not propagate').not.toBeNull();
+        expect(settlements.length, 'exactly one settlement').toBe(1);
+        expect(settlements[0].errors[0]).toContain('insert-failed');
+        expect(settlements[0].errors[1]).toContain('could not be instantiated');
+
+        // ...and the slot is untouched: same instance, same index, still alive.
+        expect(container.items.length, 'nothing was removed').toBe(1);
+        expect(container.items[0], 'the SAME live instance is still in the slot').toBe(livePane);
+        expect(livePane.isDestroyed, 'and it was never destroyed').toBeFalsy();
+
+        expect(workspace.dockRecreateInFlight.has('editor'), 'the flight is released').toBe(false)
+    });
+
     test('the in-flight set is released even when a phase throws', () => {
         workspace.resolveFreshPane = () => { throw new Error('resolver exploded') };
 
@@ -346,6 +376,130 @@ test.describe('dock recreate — settles exactly once, one flight per item', () 
         workspace.recreateDockPane('editor', livePane);
 
         expect(settlements.length, 'a later invocation still runs and settles').toBe(2)
+    })
+});
+
+/**
+ * The production action path — the thing the ticket actually exists to provide.
+ *
+ * A recreate transaction nobody can reach is not a "default reload fallback". These arms drive
+ * `handleDockReloadAction` and `syncDockReloadAction`, the real dispatch and the real visibility
+ * derivation, against a real `tab.Container`.
+ *
+ * **Delegation first, recreate only in its absence.** A pane that implements `dockReload()` decides
+ * what reload means; replacing it would discard both that authority and its identity. The fallback
+ * serves only panes that never implemented it — the ones with no other recovery.
+ */
+test.describe('dock reload — the fallback the ticket exists to provide', () => {
+    let workspace, tabContainer, settlements;
+
+    const buildTabs = paneConfig => {
+        const tabs = Neo.create(TabContainer, {
+            appName    : 'DashboardDockRecreateCandidateTest',
+            activeIndex: 0,
+            items      : [paneConfig]
+        });
+
+        // The handler resolves the active card through the bar's dock id list — the same lookup
+        // production uses, populated here rather than faked.
+        tabs.getTabBar().sortZoneConfig = {dockItemIds: ['editor']};
+
+        return tabs
+    };
+
+    test.beforeEach(() => {
+        workspace   = buildWorkspace({enableDockReloadAction: true});
+        settlements = [];
+
+        workspace.on('dockReloadSettled', data => settlements.push(data))
+    });
+
+    test.afterEach(() => {
+        tabContainer?.destroy?.();
+        workspace?.destroy?.();
+        workspace = tabContainer = settlements = null
+    });
+
+    test('a contract-less pane is RECREATED, and settles through the reload channel', async () => {
+        tabContainer = buildTabs({module: Component, id: 'fallback-live'});
+
+        const livePane = tabContainer.getCard(0);
+
+        workspace.getActiveDockItemId = () => 'editor';
+        workspace.resolveFreshPane    = () => ({module: Component, id: 'fallback-fresh'});
+
+        await workspace.handleDockReloadAction({dockNodeId: 'node-1', tabContainer});
+
+        // One activation, one settlement — through the RELOAD channel, whichever path served it.
+        expect(settlements.length, 'the activation settles exactly once').toBe(1);
+        expect(settlements[0].errors, 'and it succeeded').toEqual([]);
+
+        expect(tabContainer.getCard(0).id, 'the pane was replaced').toBe('fallback-fresh');
+        expect(livePane.isDestroyed, 'and the predecessor released').toBe(true)
+    });
+
+    test('a consumer that DECLINES fresh resolution settles with a named refusal, pane intact', async () => {
+        tabContainer = buildTabs({module: Component, id: 'fallback-live'});
+
+        const livePane = tabContainer.getCard(0);
+
+        workspace.getActiveDockItemId = () => 'editor';
+        // Overridden — so the action is visible — but declining this item.
+        workspace.resolveFreshPane = () => null;
+
+        await workspace.handleDockReloadAction({dockNodeId: 'node-1', tabContainer});
+
+        expect(settlements.length).toBe(1);
+        expect(settlements[0].errors[0], 'the refusal reason travels').toContain('declined');
+        expect(tabContainer.getCard(0), 'the live pane is untouched').toBe(livePane);
+        expect(livePane.isDestroyed).toBeFalsy()
+    });
+
+    test('delegation still wins when the pane implements dockReload()', async () => {
+        let delegated = 0;
+
+        class ReloadablePane extends Component {
+            static config = {className: 'Test.DockRecreate.ReloadablePane', ntype: 'test-reloadable-pane'}
+            dockReload() { delegated++ }
+        }
+
+        Neo.setupClass(ReloadablePane);
+
+        tabContainer = buildTabs({module: ReloadablePane, id: 'fallback-live'});
+
+        const livePane = tabContainer.getCard(0);
+
+        workspace.getActiveDockItemId = () => 'editor';
+
+        // A fallback IS available — and must not be used. Replacing a pane that owns dockReload()
+        // would discard both its authority over what reload means and its identity.
+        workspace.resolveFreshPane = () => ({module: Component, id: 'fallback-fresh'});
+
+        await workspace.handleDockReloadAction({dockNodeId: 'node-1', tabContainer});
+
+        expect(delegated, 'the pane\'s own contract ran').toBe(1);
+        expect(tabContainer.getCard(0), 'and it was NOT replaced').toBe(livePane);
+        expect(livePane.isDestroyed).toBeFalsy()
+    });
+
+    test('an absent dockReload() no longer hides the action when a fallback exists', () => {
+        tabContainer = buildTabs({module: Component, id: 'fallback-live'});
+
+        const action = Neo.create(Component, {appName: 'DashboardDockRecreateCandidateTest'});
+
+        action.set = function(values) { Object.assign(this, values) };
+
+        tabContainer.getActionItem  = () => action;
+        workspace.getActiveDockItemId = () => 'editor';
+
+        // No fallback wired: hiding is correct — the item has no recovery at all.
+        workspace.syncDockReloadAction(tabContainer);
+        expect(action.hidden, 'no delegation, no fallback → hidden').toBe(true);
+
+        // Fallback wired: the action must appear, because it is now the pane's ONLY recovery.
+        workspace.resolveFreshPane = () => ({module: Component});
+        workspace.syncDockReloadAction(tabContainer);
+        expect(action.hidden, 'no delegation but a fallback → visible').toBe(false)
     })
 });
 

--- a/test/playwright/unit/dashboard/DockRecreateCandidate.spec.mjs
+++ b/test/playwright/unit/dashboard/DockRecreateCandidate.spec.mjs
@@ -207,6 +207,49 @@ test.describe('dock recreate — Phase 2 replaces the slot before releasing the 
         expect(container.items[1].id).toBe('recreate-fresh')
     });
 
+    /**
+     * Teardown between the two phases — the AC that exists because the phases are separate calls.
+     *
+     * A caller holding a validated candidate is exactly the caller most likely to commit it into a
+     * corpse: Phase 1 said yes, so the natural next line is Phase 2. If a pane closed, a vessel tore
+     * down or a window disconnected in that gap, this must **refuse**, not throw and not half-mutate.
+     */
+    test('a teardown between the phases settles as a refusal, mutating nothing', () => {
+        const container = livePane.parent;
+
+        // Validated candidate in hand — the state a caller is in when teardown lands.
+        workspace.resolveFreshPane = () => ({module: Component, id: 'recreate-fresh'});
+
+        const prepared = workspace.prepareRecreateCandidate('editor', livePane);
+
+        expect(prepared.ok, 'the transaction must be mid-flight for this arm to mean anything').toBe(true);
+
+        const before = container.items.length;
+
+        livePane.destroy();
+
+        const result = workspace.commitRecreateCandidate(livePane, prepared.candidate);
+
+        expect(result.ok).toBe(false);
+        expect(result.reason).toBe('torn-down');
+
+        // The container is not mutated on the way out — no half-replaced slot, no orphan insert.
+        expect(container.items.length, 'a torn-down commit inserts nothing').toBe(before);
+        expect(container.items.some(item => item.id === 'recreate-fresh'), 'the candidate never landed').toBe(false)
+    });
+
+    test('a destroyed workspace refuses too — the transaction owner can vanish as well as the pane', () => {
+        workspace.destroy();
+
+        const result = workspace.commitRecreateCandidate(livePane, {module: Component, id: 'recreate-fresh'});
+
+        expect(result.ok).toBe(false);
+        expect(result.reason).toBe('torn-down');
+        expect(livePane.isDestroyed, 'a refusal never destroys the pane it declined to replace').toBeFalsy();
+
+        workspace = null
+    });
+
     test('a pane with no container, or one its container does not list, refuses without mutating', () => {
         const orphan = Neo.create(Component, {appName: 'DashboardDockRecreateCandidateTest'});
 
@@ -214,6 +257,95 @@ test.describe('dock recreate — Phase 2 replaces the slot before releasing the 
         expect(orphan.isDestroyed, 'a refusal never destroys').toBeFalsy();
 
         orphan.destroy()
+    })
+});
+
+/**
+ * Settlement semantics: one named result event per invocation, single-flight per item.
+ *
+ * Mirrors the reload leaf's `dockReloadSettled` / `dockReloadInFlight` contract on purpose. **Every
+ * completion settles, including each refusal** — the action wire discards listener returns, so an
+ * unsettled early return is an invocation the event contract never saw. Absorption by the
+ * single-flight guard is the only silent path.
+ */
+test.describe('dock recreate — settles exactly once, one flight per item', () => {
+    let workspace, container, livePane, settlements;
+
+    test.beforeEach(() => {
+        workspace = buildWorkspace();
+        container = Neo.create(Container, {
+            appName: 'DashboardDockRecreateCandidateTest',
+            items  : [{module: Component, id: 'settle-live'}]
+        });
+        [livePane]  = container.items;
+        settlements = [];
+
+        workspace.on('dockRecreateSettled', data => settlements.push(data))
+    });
+
+    test.afterEach(() => {
+        container?.destroy?.();
+        workspace?.destroy?.();
+        workspace = container = livePane = settlements = null
+    });
+
+    test('a successful transaction settles once, with no errors', () => {
+        workspace.resolveFreshPane = () => ({module: Component, id: 'settle-fresh'});
+
+        const result = workspace.recreateDockPane('editor', livePane, {dockNodeId: 'node-1'});
+
+        expect(result.errors).toEqual([]);
+        expect(settlements.length, 'exactly one settlement').toBe(1);
+        expect(settlements[0]).toMatchObject({dockNodeId: 'node-1', itemId: 'editor'});
+        expect(container.items[0].id).toBe('settle-fresh')
+    });
+
+    test('every refusal settles too, and names WHICH refusal it was', () => {
+        // A caller that only learns "it failed" cannot tell a consumer that declined the capability
+        // from one whose factory returned the live instance — those need different fixes.
+        workspace.resolveFreshPane = () => null;
+        workspace.recreateDockPane('editor', livePane);
+
+        workspace.resolveFreshPane = () => livePane;
+        workspace.recreateDockPane('editor', livePane);
+
+        expect(settlements.length, 'a refusal is a completion, not a silent return').toBe(2);
+        expect(settlements[0].errors[0]).toContain('declined');
+        expect(settlements[1].errors[0]).toContain('live-instance');
+
+        expect(livePane.isDestroyed, 'and neither refusal destroyed anything').toBeFalsy()
+    });
+
+    test('a re-entrant invocation is absorbed — it neither runs nor settles', () => {
+        // Not hypothetical: `resolveFreshPane` is consumer code, and a consumer recreating from
+        // inside its own factory would recurse without the guard.
+        let reentrantResult = 'unset';
+
+        workspace.resolveFreshPane = () => {
+            reentrantResult = workspace.recreateDockPane('editor', livePane);
+            return {module: Component, id: 'settle-fresh'}
+        };
+
+        const result = workspace.recreateDockPane('editor', livePane);
+
+        expect(reentrantResult, 'the inner call is absorbed').toBeNull();
+        expect(result.errors).toEqual([]);
+        expect(settlements.length, 'absorption is the only silent path — one settlement, not two').toBe(1)
+    });
+
+    test('the in-flight set is released even when a phase throws', () => {
+        workspace.resolveFreshPane = () => { throw new Error('resolver exploded') };
+
+        workspace.recreateDockPane('editor', livePane);
+
+        // A leaked entry would silently absorb every future recreate for this item — a wedge that
+        // presents as "the button does nothing" with no error anywhere.
+        expect(workspace.dockRecreateInFlight.has('editor'), 'the flight must be released').toBe(false);
+
+        workspace.resolveFreshPane = () => ({module: Component, id: 'settle-fresh'});
+        workspace.recreateDockPane('editor', livePane);
+
+        expect(settlements.length, 'a later invocation still runs and settles').toBe(2)
     })
 });
 

--- a/test/playwright/unit/dashboard/DockRecreateCandidate.spec.mjs
+++ b/test/playwright/unit/dashboard/DockRecreateCandidate.spec.mjs
@@ -9,11 +9,19 @@ setup({
 import {test, expect} from '@playwright/test';
 // `Neo` and the core exports must be evaluated FIRST: `Neo.gatekeep` is called at module scope by
 // everything below, so an alphabetical import order fails at load with "gatekeep is not a function".
-import Neo           from '../../../../src/Neo.mjs';
-import * as core     from '../../../../src/core/_export.mjs';
-import Component     from '../../../../src/component/Base.mjs';
-import Container     from '../../../../src/container/Base.mjs';
-import DockWorkspace from '../../../../src/dashboard/dock/Workspace.mjs';
+import Neo                      from '../../../../src/Neo.mjs';
+import * as core                from '../../../../src/core/_export.mjs';
+import Component                from '../../../../src/component/Base.mjs';
+import Container                from '../../../../src/container/Base.mjs';
+import DockLayoutAdapter        from '../../../../src/dashboard/dock/projection/LayoutAdapter.mjs';
+import DockProjectionReconciler from '../../../../src/dashboard/dock/projection/Reconciler.mjs';
+import DockWorkspace            from '../../../../src/dashboard/dock/Workspace.mjs';
+// Side-effect imports: the projection instantiates by ntype, so the tab/toolbar/button classes must
+// be registered or `DockLayoutAdapter.project` throws `ntype tab-container does not exist`.
+import '../../../../src/manager/Instance.mjs';
+import '../../../../src/button/Base.mjs';
+import '../../../../src/tab/Container.mjs';
+import '../../../../src/toolbar/Base.mjs';
 
 /**
  * Phase 1 of the two-phase recreate transaction: obtain and validate a fresh candidate **without
@@ -206,5 +214,94 @@ test.describe('dock recreate — Phase 2 replaces the slot before releasing the 
         expect(orphan.isDestroyed, 'a refusal never destroys').toBeFalsy();
 
         orphan.destroy()
+    })
+});
+
+/**
+ * The reconciler interaction, driven through the **production** entry point.
+ *
+ * This is the ticket's finding #2 turned into a witness. `core.Base#destroy` unregisters an instance
+ * without removing it from `parent.items`, and `reconcileTabChrome` fills its live map **positionally**
+ * from `body.items` and prefers that entry over the app resolver — verified by the sibling spec's
+ * `resolverCalls === 0` arm. A bare destroy would therefore leave the erased object sitting in the
+ * slot, and the very next refresh would hand it back as the live answer.
+ *
+ * Everything above this block argues that `removeAt` + `insert` avoids that. Until this arm existed
+ * the argument was a **source reading, not a test** — which is why the AC is written against the real
+ * `reconcileProjection` rather than a reimplementation of its lookup.
+ *
+ * **The resolver here deliberately returns the DESTROYED pane.** If the reconciler ever fell back to
+ * it, or ever resolved the stale positional entry, the assertions below would surface a destroyed
+ * instance instead of the candidate. A resolver returning `null` would have made this arm pass for
+ * the wrong reason.
+ */
+test.describe('dock recreate — a refresh after recreate resolves the candidate, never the corpse', () => {
+    test('the reconciler finds the replacement positionally and never consults the resolver', async () => {
+        const
+            workspace = buildWorkspace(),
+            model     = {
+                schema: 'neo.dock.zone.v1',
+                root  : 'root-tabs',
+                items : {alpha: {componentRef: 'alpha', kind: 'panel', title: 'Alpha'}},
+                nodes : {'root-tabs': {activeItemId: 'alpha', items: ['alpha'], type: 'tabs'}}
+            },
+            pane = Neo.create(Component, {header: {text: 'Alpha'}}),
+            host = Neo.create(Container, {
+                items: [DockLayoutAdapter.project(model, {resolveComponentRef: () => pane})]
+            });
+
+        let resolverCalls = 0;
+
+        try {
+            const tab = host.items[0];
+
+            // Guard: without a live pane in the slot the recreate below is a no-op and every
+            // assertion afterwards would be vacuous.
+            expect(tab.getCardContainer().items[0], 'the harness must project the live pane').toBe(pane);
+
+            const commit = workspace.commitRecreateCandidate(pane, {
+                module: Component,
+                header: {text: 'Alpha (fresh)'},
+                id    : 'recreate-reconciled-fresh'
+            });
+
+            expect(commit.ok).toBe(true);
+            expect(pane.isDestroyed, 'the predecessor is released once the candidate is live').toBe(true);
+
+            const placeholders = new Map(),
+                  nextConfig   = DockLayoutAdapter.project(model, {
+                      resolveComponentRef(componentRef, item, itemId) {
+                          const placeholder = Neo.create(Component, {header: {text: item.title}, hidden: true});
+
+                          placeholders.set(itemId, placeholder);
+
+                          return placeholder
+                      }
+                  });
+
+            await DockProjectionReconciler.reconcileProjection({
+                host,
+                nextConfig,
+                placeholders,
+                resolveItem() {
+                    resolverCalls++;
+                    return pane   // the DESTROYED instance — a fallback here must be visible
+                }
+            });
+
+            const resolved = host.items[0].getCardContainer().items[0];
+
+            expect(resolved.id, 'the slot holds the candidate').toBe('recreate-reconciled-fresh');
+            expect(resolved, 'and never the destroyed predecessor').not.toBe(pane);
+            expect(resolved.isDestroyed).toBeFalsy();
+
+            // Positional discovery, not resolution: the live map found the candidate in `body.items`
+            // and the app resolver was never asked. Had `removeAt` left the corpse listed, this is
+            // where it would have been handed back.
+            expect(resolverCalls, 'the live item is discovered before the resolver is consulted').toBe(0)
+        } finally {
+            host.destroy();
+            workspace.destroy()
+        }
     })
 });

--- a/test/playwright/unit/dashboard/DockRecreateCandidate.spec.mjs
+++ b/test/playwright/unit/dashboard/DockRecreateCandidate.spec.mjs
@@ -22,15 +22,16 @@ import DockWorkspace from '../../../../src/dashboard/dock/Workspace.mjs';
  * user-triggered recreate exception is conditioned on this phase: **without a validated candidate
  * the exception does not apply**, and the guarantee stands unmodified.
  *
- * @see ADR 0029 §2.6 — ticket-ref-ok: the record is what these arms enforce; naming it is the
- *      difference between a test and a rule with a source. So every refusal below is
- * load-bearing — each one is a case where the recovery click must leave the workspace untouched
- * rather than destroy the only copy of a pane.
+ * So every refusal below is load-bearing: each one is a case where the recovery click must leave
+ * the workspace untouched rather than destroy the only copy of a pane.
  *
  * The three refusals are not hypothetical shapes. They are what a cache-backed resolver actually
  * produces, and the `live-instance` one is why a factory seam alone is insufficient: a resolver
  * reading its own cache answers with the currently mounted instance, which *looks* like a
  * successful candidate.
+ *
+ * @see ADR 0029 §2.6 — ticket-ref-ok: the record is what these arms enforce; naming it is the
+ *      difference between a test and a rule with a source.
  */
 const buildWorkspace = (config = {}) => Neo.create(DockWorkspace, {
     appName  : 'DashboardDockRecreateCandidateTest',

--- a/test/playwright/unit/dashboard/DockRecreateCandidate.spec.mjs
+++ b/test/playwright/unit/dashboard/DockRecreateCandidate.spec.mjs
@@ -438,6 +438,48 @@ test.describe('dock reload — the fallback the ticket exists to provide', () =>
         expect(livePane.isDestroyed, 'and the predecessor released').toBe(true)
     });
 
+    test('ONE activation emits exactly ONE terminal event — both channels counted', async () => {
+        // The both-channel negative witness. The action path routes through the recreate
+        // transaction, which owns its own `dockRecreateSettled` channel — so without suppression a
+        // single click emits TWO terminal events and a consumer counting completions sees the action
+        // fire twice. Counting only the reload channel would never have caught it, which is why this
+        // arm subscribes to BOTH.
+        const recreateSettlements = [];
+
+        workspace.on('dockRecreateSettled', data => recreateSettlements.push(data));
+
+        tabContainer = buildTabs({module: Component, id: 'fallback-live'});
+
+        workspace.getActiveDockItemId = () => 'editor';
+        workspace.resolveFreshPane    = () => ({module: Component, id: 'fallback-fresh'});
+
+        await workspace.handleDockReloadAction({dockNodeId: 'node-1', tabContainer});
+
+        expect(settlements.length,         'dockReloadSettled fires once').toBe(1);
+        expect(recreateSettlements.length, 'and the nested transaction does NOT settle again').toBe(0);
+        expect(settlements.length + recreateSettlements.length, 'one activation, one terminal event').toBe(1)
+    });
+
+    test('a DIRECT caller still gets the recreate channel — suppression is per-call, not global', () => {
+        // `settle: false` must not disable the transaction's own channel for everyone else.
+        const recreateSettlements = [];
+
+        workspace.on('dockRecreateSettled', data => recreateSettlements.push(data));
+
+        const container = Neo.create(Container, {
+            appName: 'DashboardDockRecreateCandidateTest',
+            items  : [{module: Component, id: 'direct-live'}]
+        });
+
+        workspace.resolveFreshPane = () => ({module: Component, id: 'direct-fresh'});
+        workspace.recreateDockPane('editor', container.items[0]);
+
+        expect(recreateSettlements.length, 'a direct call settles on its own channel').toBe(1);
+        expect(settlements.length,         'and never on the reload channel').toBe(0);
+
+        container.destroy()
+    });
+
     test('a consumer that DECLINES fresh resolution settles with a named refusal, pane intact', async () => {
         tabContainer = buildTabs({module: Component, id: 'fallback-live'});
 

--- a/test/playwright/unit/dashboard/DockRecreateCandidate.spec.mjs
+++ b/test/playwright/unit/dashboard/DockRecreateCandidate.spec.mjs
@@ -12,6 +12,7 @@ import {test, expect} from '@playwright/test';
 import Neo           from '../../../../src/Neo.mjs';
 import * as core     from '../../../../src/core/_export.mjs';
 import Component     from '../../../../src/component/Base.mjs';
+import Container     from '../../../../src/container/Base.mjs';
 import DockWorkspace from '../../../../src/dashboard/dock/Workspace.mjs';
 
 /**
@@ -136,5 +137,74 @@ test.describe('dock recreate — Phase 1 validates a candidate before anything i
 
         workspace.prepareRecreateCandidate('no-such-item', livePane);
         expect(seenItem, 'an unknown id resolves null rather than throwing').toBeNull()
+    })
+});
+
+/**
+ * Phase 2: replace the card-body slot, then — and only then — destroy what was there.
+ *
+ * The ordering is the contract. `removeAt`'s `destroyItem` argument defaults to `true`, so taking
+ * the default would destroy the old pane *during* its own removal and a failure to insert the
+ * candidate afterwards would leave an empty slot with nothing to restore. The first arm below is
+ * what notices if anyone ever takes that default back.
+ */
+test.describe('dock recreate — Phase 2 replaces the slot before releasing the predecessor', () => {
+    let workspace, container, livePane, sibling;
+
+    test.beforeEach(() => {
+        workspace = buildWorkspace();
+        container = Neo.create(Container, {
+            appName: 'DashboardDockRecreateCandidateTest',
+            items  : [
+                {module: Component, id: 'recreate-sibling'},
+                {module: Component, id: 'recreate-live'}
+            ]
+        });
+        [sibling, livePane] = container.items
+    });
+
+    test.afterEach(() => {
+        container?.destroy?.();
+        workspace?.destroy?.();
+        workspace = container = livePane = sibling = null
+    });
+
+    test('the predecessor is still alive at the moment the candidate enters the slot', () => {
+        // The ordering witness. Sampled INSIDE insert rather than after the call, because after the
+        // call both orderings look identical — which is exactly how a `destroyItem` regression would
+        // pass a naive assertion.
+        let aliveAtInsert = null;
+
+        const realInsert = container.insert.bind(container);
+
+        container.insert = (index, item, ...rest) => {
+            aliveAtInsert = livePane.isDestroyed !== true;
+            return realInsert(index, item, ...rest)
+        };
+
+        workspace.commitRecreateCandidate(livePane, {module: Component, id: 'recreate-fresh'});
+
+        expect(aliveAtInsert, 'the old pane must outlive its own removal').toBe(true);
+        expect(livePane.isDestroyed, 'and be released once the candidate is live').toBe(true)
+    });
+
+    test('the candidate lands in the SAME slot, leaving siblings in place', () => {
+        const result = workspace.commitRecreateCandidate(livePane, {module: Component, id: 'recreate-fresh'});
+
+        expect(result.ok).toBe(true);
+        expect(result.index, 'the replaced slot, not appended at the end').toBe(1);
+
+        expect(container.items.length).toBe(2);
+        expect(container.items[0], 'the sibling is untouched').toBe(sibling);
+        expect(container.items[1].id).toBe('recreate-fresh')
+    });
+
+    test('a pane with no container, or one its container does not list, refuses without mutating', () => {
+        const orphan = Neo.create(Component, {appName: 'DashboardDockRecreateCandidateTest'});
+
+        expect(workspace.commitRecreateCandidate(orphan, {module: Component}).reason).toBe('no-container');
+        expect(orphan.isDestroyed, 'a refusal never destroys').toBeFalsy();
+
+        orphan.destroy()
     })
 });

--- a/test/playwright/unit/dashboard/DockRecreateCandidate.spec.mjs
+++ b/test/playwright/unit/dashboard/DockRecreateCandidate.spec.mjs
@@ -1,0 +1,139 @@
+import {setup} from '../../setup.mjs';
+
+setup({
+    appConfig: {
+        name: 'DashboardDockRecreateCandidateTest'
+    }
+});
+
+import {test, expect} from '@playwright/test';
+// `Neo` and the core exports must be evaluated FIRST: `Neo.gatekeep` is called at module scope by
+// everything below, so an alphabetical import order fails at load with "gatekeep is not a function".
+import Neo           from '../../../../src/Neo.mjs';
+import * as core     from '../../../../src/core/_export.mjs';
+import Component     from '../../../../src/component/Base.mjs';
+import DockWorkspace from '../../../../src/dashboard/dock/Workspace.mjs';
+
+/**
+ * Phase 1 of the two-phase recreate transaction: obtain and validate a fresh candidate **without
+ * touching the live pane**.
+ *
+ * The docking record guarantees a resolved pane is moved or re-parented, never destroyed. The
+ * user-triggered recreate exception is conditioned on this phase: **without a validated candidate
+ * the exception does not apply**, and the guarantee stands unmodified.
+ *
+ * @see ADR 0029 §2.6 — ticket-ref-ok: the record is what these arms enforce; naming it is the
+ *      difference between a test and a rule with a source. So every refusal below is
+ * load-bearing — each one is a case where the recovery click must leave the workspace untouched
+ * rather than destroy the only copy of a pane.
+ *
+ * The three refusals are not hypothetical shapes. They are what a cache-backed resolver actually
+ * produces, and the `live-instance` one is why a factory seam alone is insufficient: a resolver
+ * reading its own cache answers with the currently mounted instance, which *looks* like a
+ * successful candidate.
+ */
+const buildWorkspace = (config = {}) => Neo.create(DockWorkspace, {
+    appName  : 'DashboardDockRecreateCandidateTest',
+    dockModel: {
+        schema: 'neo.dock.zone.v1',
+        root  : 'root',
+        items : {editor: {componentRef: 'editor', title: 'Editor'}},
+        nodes : {root: {type: 'tabs', items: ['editor'], activeItemId: 'editor'}}
+    },
+    ...config
+});
+
+test.describe('dock recreate — Phase 1 validates a candidate before anything is destroyed', () => {
+    let workspace, livePane;
+
+    test.beforeEach(() => {
+        workspace = buildWorkspace();
+        livePane  = Neo.create(Component, {appName: 'DashboardDockRecreateCandidateTest'})
+    });
+
+    test.afterEach(() => {
+        workspace?.destroy?.();
+        livePane?.destroy?.();
+        workspace = livePane = null
+    });
+
+    test('the default hook declines, so recreate is opt-in rather than assumed', () => {
+        // A consumer that has not implemented the factory must not silently get a destructive
+        // capability. `null` is a legitimate answer — "this surface does not support recreate".
+        expect(workspace.resolveFreshPane('editor', null)).toBeNull();
+
+        const result = workspace.prepareRecreateCandidate('editor', livePane);
+
+        expect(result.ok).toBe(false);
+        expect(result.reason).toBe('declined');
+        expect(result.candidate).toBeNull()
+    });
+
+    test('a factory that throws refuses with the error carried, never swallowed', () => {
+        const boom = new Error('resolver exploded');
+
+        workspace.resolveFreshPane = () => { throw boom };
+
+        const result = workspace.prepareRecreateCandidate('editor', livePane);
+
+        expect(result.ok).toBe(false);
+        expect(result.reason).toBe('threw');
+        expect(result.error, 'the original error must survive, not a rewritten one').toBe(boom)
+    });
+
+    test('a factory returning THE LIVE INSTANCE is refused — the shape that causes silent pane loss', () => {
+        // The whole reason this phase exists. A cache-backed resolver answers with the instance that
+        // is already mounted; committing that "candidate" would destroy the only copy.
+        workspace.resolveFreshPane = () => livePane;
+
+        const result = workspace.prepareRecreateCandidate('editor', livePane);
+
+        expect(result.ok).toBe(false);
+        expect(result.reason).toBe('live-instance');
+        expect(result.candidate).toBeNull()
+    });
+
+    test('a distinct candidate is accepted — identity, not equality', () => {
+        // A config object describing the same pane IS a valid candidate; only the mounted instance
+        // itself is refused. An equality-based check would reject this and make recreate impossible
+        // for every config-returning consumer.
+        const candidate = {ntype: 'component', text: 'fresh'};
+
+        workspace.resolveFreshPane = () => candidate;
+
+        const result = workspace.prepareRecreateCandidate('editor', livePane);
+
+        expect(result.ok).toBe(true);
+        expect(result.candidate).toBe(candidate);
+        expect(result.reason).toBeNull()
+    });
+
+    test('the live pane is untouched by every refusal — rollback by construction', () => {
+        // Not "rollback works" — there is nothing to roll back, which is the design claim. If any
+        // refusal path ever destroys or re-parents the live pane, this arm is what notices.
+        const factories = [
+            () => { throw new Error('boom') },
+            () => null,
+            () => livePane
+        ];
+
+        for (const factory of factories) {
+            workspace.resolveFreshPane = factory;
+            workspace.prepareRecreateCandidate('editor', livePane);
+
+            expect(livePane.isDestroyed, `factory ${factory} destroyed the live pane`).toBeFalsy()
+        }
+    });
+
+    test('the item record comes from the committed document, and an unknown id still refuses safely', () => {
+        let seenItem = 'unset';
+
+        workspace.resolveFreshPane = (itemId, item) => { seenItem = item; return null };
+
+        workspace.prepareRecreateCandidate('editor', livePane);
+        expect(seenItem, 'a known id resolves its catalog record').toMatchObject({componentRef: 'editor'});
+
+        workspace.prepareRecreateCandidate('no-such-item', livePane);
+        expect(seenItem, 'an unknown id resolves null rather than throwing').toBeNull()
+    })
+});


### PR DESCRIPTION
Resolves #17966

**Evidence:** `npm run test-unit` **2913 passed** at head `5d040217a4` · 23 arms in `DockRecreateCandidate.spec.mjs` · **15 mutations across this PR, each reddening its own arm and only its own** · 8 commits / 3 files.

## What it delivers

A pane that never implemented `dockReload()` has no recovery once its own state is wedged — the shell re-parents a broken instance forever. This is the fallback: **delegation when the contract exists, an engine-owned recreate when it does not.**

```
reload action → dockReload() present?  → yes: delegate (pane owns what reload means)
                                       → no : two-phase recreate transaction
```

Both settle on the **reload** channel: one activation, one settlement, whichever path served it.

## The two-phase transaction

**Phase 1 — prepare.** `resolveFreshPane` is a **dedicated hook, not an option on `resolvePane`**: real consumers resolve from live-instance caches and mint replacements only after observing `isDestroyed`, so an option they never implemented would be silently ignored and hand back the very instance the recreate means to replace. Three refusals — `threw`, `declined`, `live-instance` — each leaving the live pane untouched. Rollback by construction: nothing is destroyed yet.

**Phase 2 — commit.** **Insert at `index`, then remove the predecessor at `index + 1`.** Never a bare destroy: `core.Base#destroy` leaves the instance in `parent.items` and the reconciler prefers that positional entry, so a bare destroy hands the corpse back on the next refresh.

## AC table

| AC | evidence |
|---|---|
| ADR 0029 §2.6 amendment lands with the implementation | first commit; states a **condition**, not a permission; carries its own retirement trigger |
| Phase-1 refusals leave the live pane untouched, named error | 6 arms; `live-instance` mutation-proven |
| Phase-2 replaces the exact slot, identities preserved | only the card body is touched; the tab bar is never in the mutation path |
| Old instance destroyed only after the candidate is live | ordering sampled **inside** `insert`; 3 mutations |
| Reconciler resolves the candidate, never the destroyed instance | production `reconcileProjection`; resolver deliberately returns the **corpse**; mutation-proven against a bare destroy |
| Teardown mid-transaction settles without mutations or leaks | guard placed **before** the container is touched |
| Settlement — one named event, single-flight per item | mirrors `dockReloadSettled` / `dockReloadInFlight`; 2 mutations |
| **The default reload fallback is reachable from the action** | 5 production-path arms + visibility arm; delegation-priority mutation-proven |
| **One activation emits exactly one terminal event** | both-channel witness (sum, not per-channel); mutation-proven |

Contract Ledger for every consumed surface: [#17966 comment](https://github.com/neomjs/neo/issues/17966#issuecomment-5490318484).

## What review changed, and it was right

@neo-gpt-emmy's `CHANGES_REQUESTED` found two things I had wrong.

**RA-1 — an atomicity hole inside the transaction built to prevent exactly it.** Commit removed the live pane *before* inserting the candidate, so a throwing `insert` — an invalid candidate config is ordinary consumer input — left the slot empty and the predecessor orphaned, and propagated instead of settling. My own comment claimed "reversible until this line"; it was false. Inserting first closes it.

**RA-2 — I had narrowed the ticket.** I declared the action wiring "not an AC" and out of scope. The ticket is titled *Default reload fallback*; a transaction nobody can reach is not one. That was me reading my implementation instead of the ticket.

**RA-3** — this body, and the Contract Ledger above.

## Deliberately not here

`enableDockReloadAction` stays default-off (the pin precedent), so this is behaviorally inert until a host opts in. Automatic recreation — crash detection, watchdogs, retry policies — remains forbidden by the amendment and is consumer territory.

Authored by Ada (Claude Opus 5, Claude Code). Session bd974a9a-cef5-4d7b-99e5-9329b3f6f053.

