### PR TITLE
test(ai): restore the 12 deleted specs whose subjects still ship (#17968)

### DIFF
--- a/test/playwright/unit/ai/LockRegistry.spec.mjs
+++ b/test/playwright/unit/ai/LockRegistry.spec.mjs
@@ -1,0 +1,287 @@
+import {setup} from '../../setup.mjs';
+
+setup({
+    neoConfig: {
+        unitTestMode: true
+    },
+    appConfig: {
+        name             : 'LockRegistryTest',
+        isMounted        : () => true,
+        vnodeInitialising: false
+    }
+});
+
+import {test, expect} from '@playwright/test';
+import Neo            from '../../../../src/Neo.mjs';
+import * as core      from '../../../../src/core/_export.mjs';
+import LockRegistry   from '../../../../src/ai/LockRegistry.mjs';
+
+/**
+ * A terse lock factory for the specs.
+ * @param {String} agentId
+ * @param {String} sessionId
+ * @param {String[]} subtreePath
+ * @returns {Object}
+ */
+const lock = (agentId, sessionId, subtreePath) => ({agentId, sessionId, subtreePath});
+
+test.describe('Neo.ai.LockRegistry', () => {
+    test.describe('normalizeLock (fail-closed validation)', () => {
+        test('accepts a well-formed lock and clones the path', () => {
+            const path = ['root', 'panel'],
+                  norm = LockRegistry.normalizeLock(lock('ada', 's1', path));
+
+            expect(norm).toEqual({agentId: 'ada', sessionId: 's1', subtreePath: ['root', 'panel']});
+            expect(norm.subtreePath).not.toBe(path); // defensive copy, not the caller's array
+        });
+
+        test('rejects a missing or empty agentId', () => {
+            expect(LockRegistry.normalizeLock(lock('',    's1', ['a']))).toBeNull();
+            expect(LockRegistry.normalizeLock(lock(null,  's1', ['a']))).toBeNull();
+        });
+
+        test('rejects a missing or empty sessionId', () => {
+            expect(LockRegistry.normalizeLock(lock('ada', '',        ['a']))).toBeNull();
+            expect(LockRegistry.normalizeLock(lock('ada', undefined, ['a']))).toBeNull();
+        });
+
+        test('rejects a non-array or empty subtreePath', () => {
+            expect(LockRegistry.normalizeLock(lock('ada', 's1', []))).toBeNull();
+            expect(LockRegistry.normalizeLock(lock('ada', 's1', 'root'))).toBeNull();
+            expect(LockRegistry.normalizeLock(lock('ada', 's1', null))).toBeNull();
+        });
+
+        test('rejects a subtreePath with an empty or non-string segment', () => {
+            expect(LockRegistry.normalizeLock(lock('ada', 's1', ['a', '']))).toBeNull();
+            expect(LockRegistry.normalizeLock(lock('ada', 's1', ['a', 7]))).toBeNull();
+        });
+
+        test('rejects non-objects', () => {
+            expect(LockRegistry.normalizeLock(null)).toBeNull();
+            expect(LockRegistry.normalizeLock('lock')).toBeNull();
+            expect(LockRegistry.normalizeLock(undefined)).toBeNull();
+        });
+    });
+
+    test.describe('pathsOverlap (subtree overlap matrix)', () => {
+        test('equal paths overlap', () => {
+            expect(LockRegistry.pathsOverlap(['a', 'b'], ['a', 'b'])).toBe(true);
+        });
+
+        test('an ancestor overlaps its descendant (both directions)', () => {
+            expect(LockRegistry.pathsOverlap(['a'],      ['a', 'b', 'c'])).toBe(true);
+            expect(LockRegistry.pathsOverlap(['a', 'b', 'c'], ['a'])).toBe(true);
+        });
+
+        test('siblings that diverge never overlap', () => {
+            expect(LockRegistry.pathsOverlap(['a', 'b'], ['a', 'c'])).toBe(false);
+        });
+
+        test('different roots never overlap', () => {
+            expect(LockRegistry.pathsOverlap(['a'], ['b'])).toBe(false);
+        });
+
+        test('a root-level lock overlaps everything under that root', () => {
+            expect(LockRegistry.pathsOverlap(['root'], ['root', 'x', 'y', 'z'])).toBe(true);
+        });
+    });
+
+    test.describe('sameWriter', () => {
+        test('same agentId and sessionId is the same writer', () => {
+            expect(LockRegistry.sameWriter(lock('ada', 's1', ['a']), lock('ada', 's1', ['b']))).toBe(true);
+        });
+
+        test('a different agentId or sessionId is a different writer', () => {
+            expect(LockRegistry.sameWriter(lock('ada', 's1', ['a']), lock('vega', 's1', ['a']))).toBe(false);
+            expect(LockRegistry.sameWriter(lock('ada', 's1', ['a']), lock('ada',  's2', ['a']))).toBe(false);
+        });
+    });
+
+    test.describe('lockKey', () => {
+        test('is stable for the same lock and distinct across writer or path', () => {
+            const a = LockRegistry.lockKey(lock('ada', 's1', ['root', 'p'])),
+                  b = LockRegistry.lockKey(lock('ada', 's1', ['root', 'p'])),
+                  c = LockRegistry.lockKey(lock('ada', 's1', ['root', 'q'])),
+                  d = LockRegistry.lockKey(lock('vega', 's1', ['root', 'p']));
+
+            expect(a).toBe(b);
+            expect(a).not.toBe(c);
+            expect(a).not.toBe(d);
+        });
+
+        test('does not collide when an id contains the separator characters', () => {
+            const a = LockRegistry.lockKey(lock('a"b', 's', ['x'])),
+                  b = LockRegistry.lockKey(lock('a',   'b"s', ['x']));
+
+            expect(a).not.toBe(b);
+        });
+    });
+
+    test.describe('findConflict', () => {
+        test('a different writer on an overlapping subtree conflicts', () => {
+            const table = [lock('ada', 's1', ['root', 'p'])],
+                  held  = LockRegistry.findConflict(table, lock('vega', 's2', ['root', 'p', 'child']));
+
+            expect(held).toBe(table[0]);
+        });
+
+        test('the same writer on an overlapping subtree does not conflict', () => {
+            const table = [lock('ada', 's1', ['root', 'p'])];
+            expect(LockRegistry.findConflict(table, lock('ada', 's1', ['root', 'p', 'child']))).toBeNull();
+        });
+
+        test('a different writer on a sibling subtree does not conflict', () => {
+            const table = [lock('ada', 's1', ['root', 'p'])];
+            expect(LockRegistry.findConflict(table, lock('vega', 's2', ['root', 'q']))).toBeNull();
+        });
+
+        test('an empty table never conflicts', () => {
+            expect(LockRegistry.findConflict([], lock('ada', 's1', ['a']))).toBeNull();
+        });
+    });
+
+    test.describe('acquire', () => {
+        test('grants on an empty table and grows it', () => {
+            const result = LockRegistry.acquire([], lock('ada', 's1', ['root']));
+
+            expect(result.granted).toBe(true);
+            expect(result.created).toBe(true);
+            expect(result.reentrant).toBe(false);
+            expect(result.acquiredLock).toEqual(lock('ada', 's1', ['root']));
+            expect(result.conflict).toBeNull();
+            expect(result.errors).toEqual([]);
+            expect(result.lockTable).toHaveLength(1);
+        });
+
+        test('denies a malformed lock with an error and an unchanged table', () => {
+            const table  = [lock('ada', 's1', ['root'])],
+                  result = LockRegistry.acquire(table, lock('', 's1', ['x']));
+
+            expect(result.granted).toBe(false);
+            expect(result.errors.length).toBeGreaterThan(0);
+            expect(result.lockTable).toBe(table); // unchanged reference
+        });
+
+        test('denies a cross-writer subtree overlap and reports the holder', () => {
+            const table  = [LockRegistry.normalizeLock(lock('ada', 's1', ['root', 'p']))],
+                  result = LockRegistry.acquire(table, lock('vega', 's2', ['root', 'p']));
+
+            expect(result.granted).toBe(false);
+            expect(result.conflict).toBe(table[0]);
+            expect(result.lockTable).toHaveLength(1);
+        });
+
+        test('is re-entrant: the same writer re-acquiring an identical lock adds no duplicate', () => {
+            const first  = LockRegistry.acquire([], lock('ada', 's1', ['root', 'p'])),
+                  second = LockRegistry.acquire(first.lockTable, lock('ada', 's1', ['root', 'p']));
+
+            expect(second.granted).toBe(true);
+            expect(second.created).toBe(false);
+            expect(second.reentrant).toBe(true);
+            expect(second.acquiredLock).toBe(first.lockTable[0]);
+            expect(second.lockTable).toHaveLength(1);
+        });
+
+        test('lets the same writer hold a nested descendant lock', () => {
+            const first  = LockRegistry.acquire([], lock('ada', 's1', ['root'])),
+                  second = LockRegistry.acquire(first.lockTable, lock('ada', 's1', ['root', 'child']));
+
+            expect(second.granted).toBe(true);
+            expect(second.lockTable).toHaveLength(2);
+        });
+
+        test('never mutates the input table', () => {
+            const table = [];
+            LockRegistry.acquire(table, lock('ada', 's1', ['root']));
+            expect(table).toHaveLength(0);
+        });
+    });
+
+    test.describe('release (idempotent)', () => {
+        test('removes the exact lock', () => {
+            const acquired = LockRegistry.acquire([], lock('ada', 's1', ['root', 'p'])),
+                  released = LockRegistry.release(acquired.lockTable, lock('ada', 's1', ['root', 'p']));
+
+            expect(released.lockTable).toHaveLength(0);
+        });
+
+        test('is a no-op when the lock is not held', () => {
+            const table    = [LockRegistry.normalizeLock(lock('ada', 's1', ['root']))],
+                  released = LockRegistry.release(table, lock('ada', 's1', ['other']));
+
+            expect(released.lockTable).toHaveLength(1);
+        });
+
+        test('never releases a different writer holding the same subtree', () => {
+            const table    = [LockRegistry.normalizeLock(lock('ada', 's1', ['root']))],
+                  released = LockRegistry.release(table, lock('vega', 's2', ['root']));
+
+            expect(released.lockTable).toHaveLength(1);
+        });
+
+        test('returns the table unchanged for a malformed lock', () => {
+            const table    = [LockRegistry.normalizeLock(lock('ada', 's1', ['root']))],
+                  released = LockRegistry.release(table, lock('', '', []));
+
+            expect(released.lockTable).toBe(table);
+        });
+    });
+
+    test.describe('releaseAll (disconnect / restart sweep)', () => {
+        const populated = () => [
+            LockRegistry.normalizeLock(lock('ada',  's1', ['a'])),
+            LockRegistry.normalizeLock(lock('ada',  's2', ['b'])),
+            LockRegistry.normalizeLock(lock('vega', 's1', ['c']))
+        ];
+
+        test('sweeps every lock for an agentId', () => {
+            const result = LockRegistry.releaseAll(populated(), {agentId: 'ada'});
+
+            expect(result.released).toBe(2);
+            expect(result.lockTable).toHaveLength(1);
+            expect(result.lockTable[0].agentId).toBe('vega');
+        });
+
+        test('sweeps every lock for a sessionId', () => {
+            const result = LockRegistry.releaseAll(populated(), {sessionId: 's1'});
+
+            expect(result.released).toBe(2);
+            expect(result.lockTable.every(l => l.sessionId !== 's1')).toBe(true);
+        });
+
+        test('sweeps only locks matching both fields when both are given', () => {
+            const result = LockRegistry.releaseAll(populated(), {agentId: 'ada', sessionId: 's1'});
+
+            expect(result.released).toBe(1);
+            expect(result.lockTable).toHaveLength(2);
+        });
+
+        test('fails closed: a selector-less sweep clears nothing', () => {
+            const table  = populated(),
+                  result = LockRegistry.releaseAll(table, {});
+
+            expect(result.released).toBe(0);
+            expect(result.lockTable).toBe(table);
+        });
+    });
+
+    test.describe('requiresExplicitTarget', () => {
+        test('is false for zero or one live session (implicit target allowed)', () => {
+            expect(LockRegistry.requiresExplicitTarget(0)).toBe(false);
+            expect(LockRegistry.requiresExplicitTarget(1)).toBe(false);
+        });
+
+        test('is true once more than one session is live', () => {
+            expect(LockRegistry.requiresExplicitTarget(2)).toBe(true);
+            expect(LockRegistry.requiresExplicitTarget(5)).toBe(true);
+        });
+
+        test('fails safe (requires explicit) for non-finite or unexpected counts', () => {
+            expect(LockRegistry.requiresExplicitTarget(NaN)).toBe(true);
+            expect(LockRegistry.requiresExplicitTarget(Infinity)).toBe(true);
+            // the realistic trigger: a consumer's `sessions?.length` resolving to `undefined`
+            expect(LockRegistry.requiresExplicitTarget(undefined)).toBe(true);
+            expect(LockRegistry.requiresExplicitTarget(-1)).toBe(true);
+        });
+    });
+});

--- a/test/playwright/unit/ai/TransactionService.spec.mjs
+++ b/test/playwright/unit/ai/TransactionService.spec.mjs
@@ -1,0 +1,361 @@
+import {setup} from '../../setup.mjs';
+
+setup({
+    neoConfig: {
+        unitTestMode: true
+    },
+    appConfig: {
+        name             : 'TransactionServiceTest',
+        isMounted        : () => true,
+        vnodeInitialising: false
+    }
+});
+
+import {test, expect}     from '@playwright/test';
+import Neo                from '../../../../src/Neo.mjs';
+import * as core          from '../../../../src/core/_export.mjs';
+import TransactionService from '../../../../src/ai/TransactionService.mjs';
+
+// Neo.ai.TransactionService is the in-heap per-session undo stack. It is pure over its inputs (reverse-capture,
+// the enforcement grant, and the live tree all live in the caller) — so these tests drive event sequences against
+// a real instance with no live-heap or socket dependency, and assert the lifecycle (open→committed→undone +
+// aborted / timedOut), the single-level undo + reverse ordering, per-session isolation, the fail-closed branches
+// (every required reverse-record field + both-descriptor serializability), and the caps.
+
+const
+    ID  = {agentId: 'agent-a', sessionId: 'sess-a'},
+    ID2 = {agentId: 'agent-b', sessionId: 'sess-b'},
+
+    // a minimal valid reverse-op (WHO + WHAT + audit path); set⁻¹ is set(old values)
+    op = (n = 1, seq = `seq-${n}`) => ({
+        sequenceId       : seq,
+        originWriter     : {agentId: 'agent-a', sessionId: 'sess-a'},
+        targetSubtreePath: ['root', 'leaf'],
+        forward          : {tool: 'set_instance_properties', args: {id: 'leaf', properties: {x: n}}},
+        reverse          : {tool: 'set_instance_properties', args: {id: 'leaf', properties: {x: n - 1}}},
+        label            : `set x=${n}`
+    }),
+
+    svc = cfg => Neo.create('Neo.ai.TransactionService', cfg),
+
+    // the Slice-1 single-op capture flow: begin → record → commit
+    commitOne = (s, id, txId, o) => {
+        s.begin({id, txId});
+        s.record({id, txId, op: o});
+        return s.commit({id, txId})
+    };
+
+test.describe('Neo.ai.TransactionService — in-heap per-session undo stack', () => {
+    test('begin → record → commit → undo round-trips a single-op transaction', () => {
+        const s = svc();
+
+        expect(s.begin ({id: ID, txId: 'tx-1'})).toEqual({ok: true, reason: null});
+        expect(s.record({id: ID, txId: 'tx-1', op: op(1)})).toEqual({ok: true, reason: null});
+        expect(s.commit({id: ID, txId: 'tx-1'})).toEqual({ok: true, reason: null});
+
+        const u = s.undo({id: ID});
+
+        expect(u.txId).toBe('tx-1');
+        expect(u.reverseOps).toHaveLength(1);
+        expect(u.reverseOps[0].reverse).toEqual({tool: 'set_instance_properties', args: {id: 'leaf', properties: {x: 0}}});
+        expect(u.reverseOps[0].originWriter).toEqual({agentId: 'agent-a', sessionId: 'sess-a'}); // provenance preserved
+        expect(s.undo({id: ID})).toEqual({txId: null, reverseOps: null});                        // stack now empty
+    });
+
+    test('single-level undo pops most-recent committed first', () => {
+        const s = svc();
+
+        commitOne(s, ID, 'tx-1', op(1));
+        commitOne(s, ID, 'tx-2', op(2));
+
+        expect(s.undo({id: ID}).txId).toBe('tx-2');
+        expect(s.undo({id: ID}).txId).toBe('tx-1');
+        expect(s.undo({id: ID}).reverseOps).toBeNull();
+    });
+
+    test('a multi-op transaction returns reverses in REVERSE capture order (last mutation undone first)', () => {
+        const s = svc();
+
+        s.begin ({id: ID, txId: 'tx-1'});
+        s.record({id: ID, txId: 'tx-1', op: op(1, 'a')});
+        s.record({id: ID, txId: 'tx-1', op: op(2, 'b')});
+        s.commit({id: ID, txId: 'tx-1'});
+
+        expect(s.undo({id: ID}).reverseOps.map(o => o.sequenceId)).toEqual(['b', 'a']);
+    });
+
+    test('begin aborts a prior still-open transaction — no leaked open tx, no committed record', () => {
+        const s = svc();
+
+        s.begin ({id: ID, txId: 'tx-1'});
+        s.record({id: ID, txId: 'tx-1', op: op(1)});
+        s.begin ({id: ID, txId: 'tx-2'});                 // tx-1 was open → aborted
+
+        expect(s.commit({id: ID, txId: 'tx-1'}).ok).toBe(false); // tx-1 is no longer open
+        expect(s.stackOf({id: ID}).committed).toHaveLength(0);   // tx-1 left nothing committed
+        expect(s.stackOf({id: ID}).open.txId).toBe('tx-2');
+    });
+
+    test('commit snapshots origin writer, commit time, and data-only metadata', () => {
+        const
+            s        = svc(),
+            metadata = {replayOf: {archiveId: 'archive-1'}, tags: ['replay']};
+
+        s.begin ({id: ID, txId: 'tx-1', metadata});
+        s.record({id: ID, txId: 'tx-1', op: op(1)});
+        s.commit({id: ID, txId: 'tx-1'});
+
+        const tx = s.stackOf({id: ID}).committed[0];
+
+        expect(tx.originWriter).toEqual(ID);
+        expect(tx.committedAt).toEqual(expect.any(Number));
+        expect(tx.metadata).toEqual(metadata);
+
+        tx.metadata.replayOf.archiveId = 'mutated';
+        expect(s.stackOf({id: ID}).committed[0].metadata.replayOf.archiveId).toBe('archive-1')
+    });
+
+    test('begin rejects non-serializable metadata before replacing an existing open transaction', () => {
+        const s = svc();
+
+        s.begin({id: ID, txId: 'keep'});
+
+        const cyclic = {};
+        cyclic.self = cyclic;
+
+        expect(s.begin({id: ID, txId: 'bad', metadata: cyclic}))
+            .toEqual({ok: false, reason: 'metadata-not-serializable'});
+        expect(s.stackOf({id: ID}).open.txId).toBe('keep')
+    });
+
+    test('per-session isolation — two writers keep separate stacks', () => {
+        const s = svc();
+
+        commitOne(s, ID,  'a-1', op(1));
+        commitOne(s, ID2, 'b-1', op(1));
+
+        expect(s.undo({id: ID }).txId).toBe('a-1');
+        expect(s.undo({id: ID2}).txId).toBe('b-1');
+        expect(s.undo({id: ID }).reverseOps).toBeNull(); // each writer's stack is independent
+    });
+
+    // ── fail-closed branches ──────────────────────────────────────────────────────────────────────
+    test('begin fails closed on an invalid/incomplete writer identity or empty txId', () => {
+        const s = svc();
+
+        // missing fields + non-string ids — the stricter typeof guard mirrors LockRegistry.normalizeLock
+        for (const badId of [{}, {agentId: 'a'}, {sessionId: 's'}, {agentId: 123, sessionId: 's'}, {agentId: 'a', sessionId: {}}]) {
+            expect(s.begin({id: badId, txId: 'tx-1'}).ok).toBe(false)
+        }
+        expect(s.begin({id: ID, txId: ''}).ok).toBe(false);
+    });
+
+    test('record / commit fail closed with no open transaction or a txId mismatch', () => {
+        const s = svc();
+
+        expect(s.record({id: ID, txId: 'tx-1', op: op(1)})).toEqual({ok: false, reason: 'no-open-transaction'});
+        expect(s.commit({id: ID, txId: 'tx-1'})).toEqual({ok: false, reason: 'no-open-transaction'});
+
+        s.begin({id: ID, txId: 'tx-1'});
+        expect(s.record({id: ID, txId: 'WRONG', op: op(1)}).reason).toBe('no-open-transaction');
+        expect(s.commit({id: ID, txId: 'WRONG'}).reason).toBe('no-open-transaction');
+    });
+
+    test('record fails closed on a malformed op (ANY required field missing or mistyped)', () => {
+        const s = svc();
+        s.begin({id: ID, txId: 'tx-1'});
+
+        const base = op(1);
+        for (const bad of [
+            {...base, sequenceId: undefined},                 // missing sequenceId
+            {...base, sequenceId: ''},                        // empty sequenceId
+            {...base, originWriter: undefined},               // missing originWriter (no throw on the access)
+            {...base, originWriter: {agentId: 'a'}},          // missing sessionId
+            {...base, targetSubtreePath: 'not-an-array'},
+            {...base, targetSubtreePath: []},                 // empty path
+            {...base, targetSubtreePath: ['root', '']},       // empty path segment
+            {...base, forward: undefined},                    // missing forward
+            {...base, reverse: undefined},                    // missing reverse
+            {...base, label: undefined},                      // missing label
+            {...base, label: ''}                              // empty label
+        ]) {
+            expect(s.record({id: ID, txId: 'tx-1', op: bad}).reason).toBe('malformed-op')
+        }
+    });
+
+    test('record fails closed on a non-serializable (cyclic) forward OR reverse — data-not-code guard', () => {
+        const s = svc();
+        s.begin({id: ID, txId: 'tx-1'});
+
+        const cyclic = {}; cyclic.self = cyclic;
+        // both descriptors are stored, so both must be JSON-guarded — neither may throw inside cloneOp downstream
+        expect(s.record({id: ID, txId: 'tx-1', op: {...op(1),      reverse: cyclic}}).reason).toBe('op-not-serializable');
+        expect(s.record({id: ID, txId: 'tx-1', op: {...op(2, 'b'), forward: cyclic}}).reason).toBe('op-not-serializable');
+    });
+
+    test('commit drops an empty transaction (nothing captured → not undoable)', () => {
+        const s = svc();
+        s.begin({id: ID, txId: 'tx-1'});
+
+        expect(s.commit({id: ID, txId: 'tx-1'})).toEqual({ok: false, reason: 'empty-transaction'});
+        expect(s.undo({id: ID}).reverseOps).toBeNull();
+    });
+
+    // ── caps ──────────────────────────────────────────────────────────────────────────────────────
+    test('maxOpsPerTransaction caps a single transaction', () => {
+        const s = svc({maxOpsPerTransaction: 2});
+        s.begin({id: ID, txId: 'tx-1'});
+
+        expect(s.record({id: ID, txId: 'tx-1', op: op(1, 'a')}).ok).toBe(true);
+        expect(s.record({id: ID, txId: 'tx-1', op: op(2, 'b')}).ok).toBe(true);
+        expect(s.record({id: ID, txId: 'tx-1', op: op(3, 'c')})).toEqual({ok: false, reason: 'max-ops-per-transaction'});
+    });
+
+    test('maxOpPayloadBytes rejects an oversized forward OR reverse', () => {
+        const s = svc({maxOpPayloadBytes: 40});
+        s.begin({id: ID, txId: 'tx-1'});
+
+        const bigReverse = {...op(1),      reverse: {tool: 'set_instance_properties', args: {id: 'leaf', properties: {x: 'y'.repeat(200)}}}};
+        const bigForward = {...op(2, 'b'), forward: {tool: 'set_instance_properties', args: {id: 'leaf', properties: {x: 'y'.repeat(200)}}}};
+        expect(s.record({id: ID, txId: 'tx-1', op: bigReverse})).toEqual({ok: false, reason: 'max-op-payload-bytes'});
+        expect(s.record({id: ID, txId: 'tx-1', op: bigForward})).toEqual({ok: false, reason: 'max-op-payload-bytes'});
+    });
+
+    test('maxLabelChars rejects an over-long label (at the bound is accepted)', () => {
+        const s = svc({maxLabelChars: 8});
+        s.begin({id: ID, txId: 'tx-1'});
+
+        expect(s.record({id: ID, txId: 'tx-1', op: {...op(1), label: 'x'.repeat(9)}}))
+            .toEqual({ok: false, reason: 'max-label-length'});
+        expect(s.record({id: ID, txId: 'tx-1', op: {...op(2, 'b'), label: 'x'.repeat(8)}}).ok).toBe(true);
+    });
+
+    test('maxStackDepth evicts the oldest committed transaction', () => {
+        const s = svc({maxStackDepth: 2});
+
+        commitOne(s, ID, 'tx-1', op(1));
+        commitOne(s, ID, 'tx-2', op(2));
+        commitOne(s, ID, 'tx-3', op(3)); // pushes past depth 2 → tx-1 evicted
+
+        expect(s.stackOf({id: ID}).committed.map(t => t.txId)).toEqual(['tx-2', 'tx-3']);
+        expect(s.undo({id: ID}).txId).toBe('tx-3');
+        expect(s.undo({id: ID}).txId).toBe('tx-2');
+        expect(s.undo({id: ID}).reverseOps).toBeNull(); // tx-1 was evicted — not undoable
+    });
+
+    // ── abort / sweep ───────────────────────────────────────────────────────────────────────────────
+    test('abort drops the open transaction (idempotent on mismatch)', () => {
+        const s = svc();
+        s.begin({id: ID, txId: 'tx-1'});
+
+        expect(s.abort({id: ID, txId: 'WRONG'})).toEqual({aborted: false});
+        expect(s.abort({id: ID, txId: 'tx-1'})).toEqual({aborted: true});
+        expect(s.stackOf({id: ID}).open).toBeNull();
+        expect(s.abort({id: ID, txId: 'tx-1'})).toEqual({aborted: false}); // already gone
+    });
+
+    test('timeout drops the open transaction as its own terminal (idempotent on mismatch)', () => {
+        const s = svc();
+        s.begin({id: ID, txId: 'tx-1'});
+
+        expect(s.timeout({id: ID, txId: 'WRONG'})).toEqual({timedOut: false}); // mismatch → no-op
+        expect(s.timeout({id: ID, txId: 'tx-1'})).toEqual({timedOut: true});
+        expect(s.stackOf({id: ID}).open).toBeNull();
+        expect(s.timeout({id: ID, txId: 'tx-1'})).toEqual({timedOut: false}); // already gone
+        expect(s.undo({id: ID}).reverseOps).toBeNull();                       // a timed-out tx is never undoable
+    });
+
+    test('sweep retires a writer session entirely; fails closed on incomplete identity', () => {
+        const s = svc();
+        commitOne(s, ID, 'tx-1', op(1));
+        s.begin({id: ID, txId: 'tx-2'}); // an open tx too
+
+        expect(s.sweep({id: {}})).toEqual({swept: false});      // incomplete → sweeps nothing
+        expect(s.sweep({id: ID})).toEqual({swept: true});
+        expect(s.stackOf({id: ID})).toEqual({open: null, committed: [], redo: []});
+        expect(s.undo({id: ID}).reverseOps).toBeNull();
+        expect(s.sweep({id: ID})).toEqual({swept: false});      // already swept
+    });
+
+    test('stackOf returns a deep copy — mutating it never affects the live stack', () => {
+        const s = svc();
+        commitOne(s, ID, 'tx-1', op(1));
+
+        const snap = s.stackOf({id: ID});
+        snap.committed[0].ops[0].reverse.args.properties.x = 999;
+        snap.committed.push({txId: 'injected'});
+
+        expect(s.undo({id: ID}).reverseOps[0].reverse.args.properties.x).toBe(0); // live stack unchanged
+    });
+
+    // --- redo (Slice-2): the symmetric counterpart — undo retains the popped tx on a redo branch that redo re-applies,
+    // and a new commit clears it (divergence). Pure in-heap, no live tree; the caller re-dispatches the forward-ops.
+    test('redo re-applies the most-recently undone transaction (undone → committed)', () => {
+        const s = svc();
+        commitOne(s, ID, 'tx-1', op(1));
+
+        expect(s.undo({id: ID}).txId).toBe('tx-1');
+        expect(s.stackOf({id: ID}).committed).toHaveLength(0); // popped off the undo stack
+        expect(s.stackOf({id: ID}).redo).toHaveLength(1);      // retained on the redo branch
+
+        const r = s.redo({id: ID});
+
+        expect(r.txId).toBe('tx-1');
+        expect(r.forwardOps).toHaveLength(1);
+        expect(r.forwardOps[0].forward).toEqual({tool: 'set_instance_properties', args: {id: 'leaf', properties: {x: 1}}});
+        expect(s.stackOf({id: ID}).committed.map(t => t.txId)).toEqual(['tx-1']); // restored — undoable again
+        expect(s.stackOf({id: ID}).redo).toHaveLength(0);
+    });
+
+    test('redo with nothing undone is a fail-closed no-op', () => {
+        const s = svc();
+        expect(s.redo({id: ID})).toEqual({txId: null, forwardOps: null}); // never undone
+
+        commitOne(s, ID, 'tx-1', op(1));
+        expect(s.redo({id: ID})).toEqual({txId: null, forwardOps: null}); // committed but not undone
+    });
+
+    test('a new committed transaction clears the redo branch (divergence invalidation)', () => {
+        const s = svc();
+        commitOne(s, ID, 'tx-1', op(1));
+        s.undo({id: ID});
+        expect(s.stackOf({id: ID}).redo).toHaveLength(1);
+
+        commitOne(s, ID, 'tx-2', op(2)); // a fresh mutation diverges history
+        expect(s.stackOf({id: ID}).redo).toHaveLength(0);
+        expect(s.redo({id: ID})).toEqual({txId: null, forwardOps: null});
+    });
+
+    test('the undo → redo → undo cycle re-uses the retained transaction', () => {
+        const s = svc();
+        commitOne(s, ID, 'tx-1', op(1));
+
+        expect(s.undo({id: ID}).txId).toBe('tx-1'); // committed → undone (redo branch)
+        expect(s.redo({id: ID}).txId).toBe('tx-1'); // undone → committed (undoable again)
+        expect(s.undo({id: ID}).txId).toBe('tx-1'); // and undoable once more
+        expect(s.stackOf({id: ID}).committed).toHaveLength(0);
+        expect(s.stackOf({id: ID}).redo).toHaveLength(1);
+    });
+
+    test('sweep clears the redo branch with the rest of the session', () => {
+        const s = svc();
+        commitOne(s, ID, 'tx-1', op(1));
+        s.undo({id: ID});
+        expect(s.stackOf({id: ID}).redo).toHaveLength(1);
+
+        s.sweep({id: ID});
+        expect(s.stackOf({id: ID})).toEqual({open: null, committed: [], redo: []});
+    });
+
+    test('redo returns forward-ops in capture order (first mutation re-applied first)', () => {
+        const s = svc();
+        s.begin ({id: ID, txId: 'tx-1'});
+        s.record({id: ID, txId: 'tx-1', op: op(1, 'a')});
+        s.record({id: ID, txId: 'tx-1', op: op(2, 'b')});
+        s.commit({id: ID, txId: 'tx-1'});
+
+        s.undo({id: ID});
+        // undo returns reverses last-first (['b','a']); redo returns forwards first-first
+        expect(s.redo({id: ID}).forwardOps.map(o => o.sequenceId)).toEqual(['a', 'b']);
+    });
+});

--- a/test/playwright/unit/ai/WriteGuard.spec.mjs
+++ b/test/playwright/unit/ai/WriteGuard.spec.mjs
@@ -1,0 +1,351 @@
+import {setup} from '../../setup.mjs';
+
+setup({
+    neoConfig: {
+        unitTestMode: true
+    },
+    appConfig: {
+        name             : 'WriteGuardTest',
+        isMounted        : () => true,
+        vnodeInitialising: false
+    }
+});
+
+import {test, expect} from '@playwright/test';
+import Neo            from '../../../../src/Neo.mjs';
+import * as core      from '../../../../src/core/_export.mjs';
+import WriteGuard     from '../../../../src/ai/WriteGuard.mjs';
+
+/**
+ * A terse lock factory.
+ * @param {String} agentId
+ * @param {String} sessionId
+ * @param {String[]} subtreePath
+ * @returns {Object}
+ */
+const lock = (agentId, sessionId, subtreePath) => ({agentId, sessionId, subtreePath});
+
+test.describe('Neo.ai.WriteGuard', () => {
+    let guard;
+
+    test.beforeEach(() => {
+        guard = Neo.create('Neo.ai.WriteGuard');
+    });
+
+    test('grants and holds a write lock', () => {
+        const result = guard.requestWrite(lock('ada', 's1', ['root', 'panel']));
+
+        expect(result.granted).toBe(true);
+        expect(guard.heldLocks()).toHaveLength(1);
+    });
+
+    test('denies a different writer overlapping a held lock, holding nothing for them', () => {
+        guard.requestWrite(lock('ada', 's1', ['root', 'panel']));
+        const result = guard.requestWrite(lock('vega', 's2', ['root', 'panel', 'child']));
+
+        expect(result.granted).toBe(false);
+        expect(result.conflict.agentId).toBe('ada');
+        expect(guard.heldLocks()).toHaveLength(1);
+    });
+
+    test('the held lock blocks the second writer until released, then grants', () => {
+        const acquisition = guard.requestWrite(lock('ada', 's1', ['root', 'panel'])).acquisition;
+        expect(guard.requestWrite(lock('vega', 's2', ['root', 'panel'])).granted).toBe(false);
+
+        guard.releaseWrite(acquisition);
+        expect(guard.requestWrite(lock('vega', 's2', ['root', 'panel'])).granted).toBe(true);
+    });
+
+    test('is re-entrant for the same writer (no duplicate held lock)', () => {
+        guard.requestWrite(lock('ada', 's1', ['root']));
+        const result = guard.requestWrite(lock('ada', 's1', ['root']));
+
+        expect(result.granted).toBe(true);
+        expect(guard.heldLocks()).toHaveLength(1);
+    });
+
+    test('lets the same writer hold two sibling subtrees', () => {
+        guard.requestWrite(lock('ada', 's1', ['root', 'a']));
+        guard.requestWrite(lock('ada', 's1', ['root', 'b']));
+
+        expect(guard.heldLocks()).toHaveLength(2);
+    });
+
+    test('releaseWrite is a no-op for a lock that is not held', () => {
+        const acquisition = guard.requestWrite(lock('ada', 's1', ['root'])).acquisition,
+              result      = guard.releaseWrite({...acquisition, subtreePath: ['other']});
+
+        expect(result.released).toBe(false);
+        expect(result.reason).toBe('stale-token');
+        expect(guard.heldLocks()).toHaveLength(1);
+    });
+
+    test('releaseWrite never releases a different writer holding the same subtree', () => {
+        const acquisition = guard.requestWrite(lock('ada', 's1', ['root'])).acquisition,
+              result      = guard.releaseWrite({...acquisition, agentId: 'vega', sessionId: 's2'});
+
+        expect(result.released).toBe(false);
+        expect(result.reason).toBe('stale-token');
+        expect(guard.heldLocks()).toHaveLength(1);
+    });
+
+    test('releaseAgent sweeps every lock for a disconnected writer', () => {
+        guard.requestWrite(lock('ada',  's1', ['a']));
+        guard.requestWrite(lock('ada',  's1', ['b']));
+        guard.requestWrite(lock('vega', 's2', ['c']));
+
+        const result = guard.releaseAgent({agentId: 'ada', sessionId: 's1'});
+
+        expect(result.released).toBe(2);
+        expect(guard.heldLocks()).toHaveLength(1);
+        expect(guard.heldLocks()[0].agentId).toBe('vega');
+    });
+
+    test('disconnect release is immediate even while the matching generation is in flight', () => {
+        const acquisition = guard.requestWrite(lock('ada', 's1', ['root'])).acquisition;
+
+        guard.beginWrite(acquisition);
+
+        expect(guard.releaseAgent({agentId: 'ada', sessionId: 's1'})).toEqual({released: 1});
+        expect(guard.heldLocks()).toHaveLength(0);
+        expect(guard.leaseReceipts().at(-1).reason).toBe('disconnect-release')
+    });
+
+    test('after a disconnect-sweep the freed subtree is grantable to another writer', () => {
+        guard.requestWrite(lock('ada', 's1', ['root', 'panel']));
+        guard.releaseAgent({sessionId: 's1'});
+
+        expect(guard.requestWrite(lock('vega', 's2', ['root', 'panel'])).granted).toBe(true);
+    });
+
+    test('denies a malformed lock (fail-closed) and holds nothing', () => {
+        const result = guard.requestWrite(lock('', 's1', ['root']));
+
+        expect(result.granted).toBe(false);
+        expect(result.errors.length).toBeGreaterThan(0);
+        expect(guard.heldLocks()).toHaveLength(0);
+    });
+
+    test('heldLocks is a deep snapshot — neither the array, the lock objects, nor their paths leak', () => {
+        guard.requestWrite(lock('ada', 's1', ['root', 'panel']));
+
+        const snap = guard.heldLocks();
+        snap.push('tampered');               // array-level
+        snap[0].agentId = 'mallory';         // object-level
+        snap[0].subtreePath.push('injected'); // nested-array-level
+
+        const live = guard.heldLocks();
+        expect(live).toHaveLength(1);
+        expect(live[0].agentId).toBe('ada');
+        expect(live[0].subtreePath).toEqual(['root', 'panel']);
+    });
+
+    test('a returned conflict is a copy — mutating it cannot free the live held lock', () => {
+        guard.requestWrite(lock('ada', 's1', ['root', 'panel']));
+        const denied = guard.requestWrite(lock('vega', 's2', ['root', 'panel']));
+
+        denied.conflict.subtreePath.push('injected'); // tamper with the reported holder
+
+        // the live lock still blocks vega on the original subtree
+        expect(guard.requestWrite(lock('vega', 's2', ['root', 'panel'])).granted).toBe(false);
+        expect(guard.heldLocks()[0].subtreePath).toEqual(['root', 'panel']);
+    });
+
+    test('reports created vs re-entrant acquisition and refreshes the same fenced token', () => {
+        let now = 1_000;
+        guard = Neo.create(WriteGuard, {leaseTtlMs: 100, nowFn: () => now});
+
+        const first = guard.requestWrite(lock('ada', 's1', ['root']));
+
+        expect(first.created).toBe(true);
+        expect(first.reentrant).toBe(false);
+        expect(first.acquisition).toMatchObject({created: true, reentrant: false, acquiredAt: 1_000, lastTouchAt: 1_000, inFlight: 0});
+
+        now = 1_050;
+
+        const second = guard.requestWrite(lock('ada', 's1', ['root']));
+
+        expect(second.created).toBe(false);
+        expect(second.reentrant).toBe(true);
+        expect(second.token).toBe(first.token);
+        expect(second.acquisition).toMatchObject({created: false, reentrant: true, acquiredAt: 1_000, lastTouchAt: 1_050});
+        expect(guard.heldLocks()).toHaveLength(1)
+    });
+
+    test('lazily reclaims an idle lease at the TTL boundary and returns an expiry receipt', () => {
+        let now = 0;
+        guard = Neo.create(WriteGuard, {leaseTtlMs: 100, nowFn: () => now});
+
+        const first = guard.requestWrite(lock('ada', 's1', ['root']));
+
+        now = 100;
+
+        const takeover = guard.requestWrite(lock('vega', 's2', ['root']));
+
+        expect(takeover.granted).toBe(true);
+        expect(takeover.created).toBe(true);
+        expect(takeover.token).not.toBe(first.token);
+        expect(takeover.reclaimed).toHaveLength(1);
+        expect(takeover.reclaimed[0]).toMatchObject({reason: 'expired', token: first.token, observedAt: 100});
+        expect(guard.heldLocks()[0]).toMatchObject({agentId: 'vega', sessionId: 's2'});
+        expect(guard.leaseReceipts()[0].reason).toBe('expired')
+    });
+
+    test('never sweeps an in-flight async operation, then expires from its end touch', () => {
+        let now = 0;
+        guard = Neo.create(WriteGuard, {leaseTtlMs: 100, nowFn: () => now});
+
+        const first = guard.requestWrite(lock('ada', 's1', ['root'])).acquisition;
+
+        expect(guard.beginWrite(first).began).toBe(true);
+
+        now = 1_000;
+        expect(guard.requestWrite(lock('vega', 's2', ['root'])).granted).toBe(false);
+        expect(guard.endWrite(first)).toEqual({ended: true, released: false, retained: true});
+
+        now = 1_099;
+        expect(guard.requestWrite(lock('vega', 's2', ['root'])).granted).toBe(false);
+
+        now = 1_100;
+        expect(guard.requestWrite(lock('vega', 's2', ['root'])).granted).toBe(true)
+    });
+
+    test('a stale token cannot touch or release a successor generation', () => {
+        let now = 0;
+        guard = Neo.create(WriteGuard, {leaseTtlMs: 100, nowFn: () => now});
+
+        const stale = guard.requestWrite(lock('ada', 's1', ['root'])).acquisition;
+
+        now = 100;
+
+        const successor = guard.requestWrite(lock('vega', 's2', ['root'])).acquisition;
+
+        expect(guard.touchWrite(stale)).toEqual({touched: false});
+        expect(guard.releaseWrite(stale)).toEqual({released: false, reason: 'stale-token'});
+        expect(guard.heldLocks()).toHaveLength(1);
+        expect(guard.heldLocks()[0].token).toBe(successor.token)
+    });
+
+    test('fenced explicit release refuses in-flight work and succeeds after end', () => {
+        const acquisition = guard.requestWrite(lock('ada', 's1', ['root'])).acquisition;
+
+        guard.beginWrite(acquisition);
+        expect(guard.releaseWrite(acquisition)).toEqual({released: false, reason: 'in-flight'});
+        guard.endWrite(acquisition);
+        expect(guard.releaseWrite(acquisition)).toEqual({released: true, reason: null});
+        expect(guard.heldLocks()).toHaveLength(0)
+    });
+
+    test('a newly-created pre-mutation failure releases and emits an error-release receipt', () => {
+        const acquisition = guard.requestWrite(lock('ada', 's1', ['root'])).acquisition;
+
+        guard.beginWrite(acquisition);
+        const outcome = guard.endWrite(acquisition, {
+            failed             : true,
+            mutationDisposition: 'pre-mutation',
+            error              : new Error('validation failed')
+        });
+
+        expect(outcome).toEqual({ended: true, released: true, retained: false});
+        expect(guard.heldLocks()).toHaveLength(0);
+        expect(guard.leaseReceipts().at(-1)).toMatchObject({reason: 'error-release', mutationDisposition: 'pre-mutation', error: 'validation failed'})
+    });
+
+    test('a re-entrant failure never releases the pre-existing hold', () => {
+        guard.requestWrite(lock('ada', 's1', ['root']));
+        const reentrant = guard.requestWrite(lock('ada', 's1', ['root'])).acquisition;
+
+        guard.beginWrite(reentrant);
+        const outcome = guard.endWrite(reentrant, {failed: true, mutationDisposition: 'pre-mutation'});
+
+        expect(reentrant.created).toBe(false);
+        expect(outcome).toEqual({ended: true, released: false, retained: true});
+        expect(guard.heldLocks()).toHaveLength(1);
+        expect(guard.leaseReceipts().at(-1).reason).toBe('error-retained')
+    });
+
+    test('a creator failure cannot release a generation another re-entrant operation already shared', () => {
+        const creator = guard.requestWrite(lock('ada', 's1', ['root'])).acquisition;
+
+        guard.beginWrite(creator);
+
+        const reentrant = guard.requestWrite(lock('ada', 's1', ['root'])).acquisition;
+
+        guard.beginWrite(reentrant);
+        guard.endWrite(reentrant);
+
+        expect(guard.endWrite(creator, {failed: true, mutationDisposition: 'pre-mutation'}))
+            .toEqual({ended: true, released: false, retained: true});
+        expect(guard.heldLocks()).toHaveLength(1);
+        expect(guard.leaseReceipts().at(-1).reason).toBe('error-retained')
+    });
+
+    test('an unknown partial-mutation failure retains the hold and becomes TTL-reclaimable', () => {
+        let now = 0;
+        guard = Neo.create(WriteGuard, {leaseTtlMs: 100, nowFn: () => now});
+
+        const acquisition = guard.requestWrite(lock('ada', 's1', ['root'])).acquisition;
+
+        guard.beginWrite(acquisition);
+        now = 10;
+        expect(guard.endWrite(acquisition, {failed: true, mutationDisposition: 'unknown'}))
+            .toEqual({ended: true, released: false, retained: true});
+
+        now = 109;
+        expect(guard.requestWrite(lock('vega', 's2', ['root'])).granted).toBe(false);
+
+        now = 110;
+        const takeover = guard.requestWrite(lock('vega', 's2', ['root']));
+        expect(takeover.granted).toBe(true);
+        expect(takeover.reclaimed[0].reason).toBe('expired')
+    });
+
+    test('lease and receipt snapshots cannot mutate live metadata', () => {
+        let now = 0;
+        guard = Neo.create(WriteGuard, {leaseTtlMs: 100, nowFn: () => now});
+
+        const acquisition = guard.requestWrite(lock('ada', 's1', ['root'])).acquisition,
+              snapshot    = guard.heldLocks();
+
+        snapshot[0].token = 999;
+        snapshot[0].subtreePath.push('tamper');
+        expect(guard.heldLocks()[0]).toMatchObject({token: acquisition.token, subtreePath: ['root']});
+
+        now = 100;
+        guard.heldLocks();
+
+        const receipts = guard.leaseReceipts();
+        receipts[0].subtreePath.push('tamper');
+        expect(guard.leaseReceipts()[0].subtreePath).toEqual(['root'])
+    });
+
+    test('invalid clock or TTL denies without mutating an existing valid hold', () => {
+        let now = 0;
+        guard = Neo.create(WriteGuard, {leaseTtlMs: 100, nowFn: () => now});
+
+        const acquisition = guard.requestWrite(lock('ada', 's1', ['root'])).acquisition;
+
+        guard.nowFn = () => NaN;
+        expect(guard.requestWrite(lock('vega', 's2', ['other'])))
+            .toMatchObject({granted: false, errors: ['invalid-write-lease-clock']});
+        expect(guard.heldLocks()[0].token).toBe(acquisition.token);
+
+        guard.nowFn = () => now;
+        guard.leaseTtlMs = 0;
+        expect(guard.requestWrite(lock('vega', 's2', ['other'])))
+            .toMatchObject({granted: false, errors: ['invalid-write-lease-ttl']});
+        expect(guard.heldLocks()[0].token).toBe(acquisition.token)
+    });
+
+    test('bounds the lifecycle receipt ledger without changing release decisions', () => {
+        guard = Neo.create(WriteGuard, {receiptLimit: 2});
+
+        ['a', 'b', 'c'].forEach(path => {
+            const acquisition = guard.requestWrite(lock('ada', 's1', [path])).acquisition;
+            expect(guard.releaseWrite(acquisition)).toEqual({released: true, reason: null})
+        });
+
+        expect(guard.leaseReceipts()).toHaveLength(2);
+        expect(guard.leaseReceipts().map(receipt => receipt.subtreePath[0])).toEqual(['b', 'c'])
+    });
+});

--- a/test/playwright/unit/ai/admitWrite.spec.mjs
+++ b/test/playwright/unit/ai/admitWrite.spec.mjs
@@ -1,0 +1,267 @@
+import {setup} from '../../setup.mjs';
+
+setup({
+    neoConfig: {
+        unitTestMode: true
+    },
+    appConfig: {
+        name             : 'AdmitWriteTest',
+        isMounted        : () => true,
+        vnodeInitialising: false
+    }
+});
+
+import {test, expect}  from '@playwright/test';
+import Neo             from '../../../../src/Neo.mjs';
+import * as core       from '../../../../src/core/_export.mjs';
+import InstanceService from '../../../../src/ai/client/InstanceService.mjs';
+import WriteGuard      from '../../../../src/ai/WriteGuard.mjs';
+import {admitWrite}    from '../../../../src/ai/admitWrite.mjs';
+
+// admitWrite is the pure seam joining resolveWriteLock (the decision) to a WriteGuard (the held-lock authority).
+// The decision branches are isolated with a STUB guard — so we can assert *whether* the authority is consulted and
+// *with exactly which lock*. The grant / deny + held-lock semantics use a REAL Neo.ai.WriteGuard, so the cross-writer
+// denial is the genuine LockRegistry conflict math end-to-end, not a mock of the very thing under test.
+//
+// Linear component tree  root → mid → leaf  (parentOf returns the parent id; falsy at the root).
+const
+    PARENTS             = {leaf: 'mid', mid: 'root', root: null},
+    parentOf            = id => PARENTS[id],
+    CTX_A               = {agentId: 'agent-a', sessionId: 'sess-a'},
+    CTX_A_OTHER_SESSION = {agentId: 'agent-a', sessionId: 'sess-b'},
+    CTX_B               = {agentId: 'agent-b', sessionId: 'sess-b'};
+
+// A guard stub that records every lock it is asked to hold and returns a scripted verdict.
+const stubGuard = verdict => {
+    const calls = [];
+    return {calls, requestWrite(lock) {calls.push(lock); return verdict}}
+};
+
+test.describe('admitWrite (NL write-enforcement orchestration)', () => {
+    test('legacy / non-agent frame (absent context) → admitted; the authority is never consulted', () => {
+        const guard = stubGuard({granted: false}); // would DENY if consulted — proves the unguarded path skips it
+        for (const absent of [null, undefined, 'x', 42, true]) {
+            expect(admitWrite({context: absent, componentId: 'leaf', parentOf, writeGuard: guard}))
+                .toEqual({admitted: true, reason: null, conflict: null, acquisition: null})
+        }
+        expect(guard.calls).toHaveLength(0)
+    });
+
+    test('enforced + incomplete identity → denied, no mutate; the authority is never consulted', () => {
+        const guard = stubGuard({granted: true}); // would GRANT if consulted
+        for (const bad of [{agentId: '', sessionId: 'sess-a'}, {agentId: 'agent-a', sessionId: ''}, {}, {foo: 1}]) {
+            expect(admitWrite({context: bad, componentId: 'leaf', parentOf, writeGuard: guard}))
+                .toEqual({admitted: false, reason: 'incomplete-identity', conflict: null, acquisition: null})
+        }
+        expect(guard.calls).toHaveLength(0)
+    });
+
+    test('enforced + unresolvable target → denied, no mutate; the authority is never consulted', () => {
+        const guard = stubGuard({granted: true});
+        for (const badId of ['', 'document.body']) {
+            expect(admitWrite({context: CTX_A, componentId: badId, parentOf, writeGuard: guard}))
+                .toEqual({admitted: false, reason: 'unresolvable-target', conflict: null, acquisition: null})
+        }
+        expect(guard.calls).toHaveLength(0)
+    });
+
+    test('enforced + valid lock but NO writeGuard → denied (no-write-guard); never fails open on a misconfig', () => {
+        for (const noGuard of [undefined, null]) {
+            expect(admitWrite({context: CTX_A, componentId: 'leaf', parentOf, writeGuard: noGuard}))
+                .toEqual({admitted: false, reason: 'no-write-guard', conflict: null, acquisition: null})
+        }
+    });
+
+    test('enforced + guard grants → admitted; the EXACT resolved absolute lock is what gets held', () => {
+        const guard = stubGuard({granted: true, conflict: null});
+        expect(admitWrite({context: CTX_A, componentId: 'leaf', parentOf, writeGuard: guard}))
+            .toEqual({admitted: true, reason: null, conflict: null, acquisition: null});
+        // the descriptor handed to the authority is resolveWriteLock's absolute root→node lock, verbatim
+        expect(guard.calls).toEqual([{agentId: 'agent-a', sessionId: 'sess-a', subtreePath: ['root', 'mid', 'leaf']}])
+    });
+
+    test('enforced + guard denies → denied with reason:conflict and the conflicting holder surfaced', () => {
+        const holder = {agentId: 'agent-b', sessionId: 'sess-b', subtreePath: ['root']},
+              guard  = stubGuard({granted: false, conflict: holder});
+        expect(admitWrite({context: CTX_A, componentId: 'leaf', parentOf, writeGuard: guard}))
+            .toEqual({admitted: false, reason: 'conflict', conflict: holder, acquisition: null})
+    });
+
+    test('enforced + unavailable lease clock → denied with the precise guard reason, not a false conflict', () => {
+        const guard = Neo.create(WriteGuard, {nowFn: () => NaN});
+
+        expect(admitWrite({context: CTX_A, componentId: 'leaf', parentOf, writeGuard: guard}))
+            .toEqual({admitted: false, reason: 'invalid-write-lease-clock', conflict: null, acquisition: null})
+    });
+
+    // ── integration: the REAL WriteGuard + LockRegistry conflict math (the actual enforcement, not a mock) ──
+    test('REAL WriteGuard — overlapping subtree: first writer holds, second denied, same-writer re-entrant', () => {
+        const guard = Neo.create('Neo.ai.WriteGuard');
+
+        // writer A acquires (and holds) the 'mid' subtree
+        const first = admitWrite({context: CTX_A, componentId: 'mid', parentOf, writeGuard: guard});
+        expect(first.admitted).toBe(true);
+        expect(first.acquisition).toMatchObject({created: true, reentrant: false, token: expect.any(Number)});
+        expect(guard.heldLocks()).toHaveLength(1);
+
+        // writer B writes 'leaf' — a descendant of A's held 'mid' → genuine overlap → denied, nothing held for B
+        const b = admitWrite({context: CTX_B, componentId: 'leaf', parentOf, writeGuard: guard});
+        expect(b.admitted).toBe(false);
+        expect(b.reason).toBe('conflict');
+        expect(b.conflict).toMatchObject({agentId: 'agent-a', sessionId: 'sess-a'});
+        expect(guard.heldLocks()).toHaveLength(1);
+
+        // the SAME writer A re-acquiring an overlapping subtree is re-entrant → still admitted
+        const reentrant = admitWrite({context: CTX_A, componentId: 'mid', parentOf, writeGuard: guard});
+        expect(reentrant.admitted).toBe(true);
+        expect(reentrant.acquisition).toMatchObject({created: false, reentrant: true, token: first.acquisition.token})
+    });
+
+    test('REAL WriteGuard — disjoint subtrees: two writers both admitted (no false-positive conflict)', () => {
+        const
+            guard   = Neo.create('Neo.ai.WriteGuard'),
+            // two disjoint linear trees:  root → mid → leaf   and   other → branch
+            parents = {leaf: 'mid', mid: 'root', root: null, branch: 'other', other: null},
+            pOf     = id => parents[id];
+
+        expect(admitWrite({context: CTX_A, componentId: 'leaf',   parentOf: pOf, writeGuard: guard}).admitted).toBe(true);
+        expect(admitWrite({context: CTX_B, componentId: 'branch', parentOf: pOf, writeGuard: guard}).admitted).toBe(true);
+        expect(guard.heldLocks()).toHaveLength(2)
+    });
+});
+
+// The service-boundary wiring: a denied write must THROW and NOT mutate the target. Uses a real WriteGuard + a real
+// InstanceService; Neo.get / Neo.getComponent are the only live-heap couplings, stubbed for the call window and
+// restored — the live two-agent run over a mounted tree is the umbrella whitebox-e2e follow-up.
+test.describe('InstanceService write enforcement (wiring)', () => {
+    test('setInstanceProperties denies a cross-writer write — throws and never calls instance.set', () => {
+        const
+            guard   = Neo.create('Neo.ai.WriteGuard'),
+            service = Neo.create('Neo.ai.client.InstanceService', {client: {writeGuard: guard}}),
+            tree    = {leaf: {parentId: 'mid'}, mid: {parentId: 'root'}, root: {parentId: null}};
+
+        let   setCalls     = 0;
+        const fakeInstance = {set() {setCalls++}};
+
+        const origGet = Neo.get, origGetComponent = Neo.getComponent;
+        Neo.get          = () => fakeInstance;       // every target id resolves to the observable fake
+        Neo.getComponent = id => tree[id];           // parentOf walks the synthetic tree
+
+        try {
+            // writer A writes 'mid' → admitted + mutates + holds the subtree
+            service.setInstanceProperties({id: 'mid', properties: {x: 1}}, CTX_A);
+            expect(setCalls).toBe(1);
+
+            // writer B writes 'leaf' (descendant of A's held 'mid') → denied: throws, and instance.set is NOT called
+            expect(() => service.setInstanceProperties({id: 'leaf', properties: {x: 2}}, CTX_B))
+                .toThrow(/Write denied/);
+            expect(setCalls).toBe(1); // unchanged — the denied write did not mutate
+
+            // a bare / legacy frame (no context) is unguarded — still mutates (backward-compatible)
+            service.setInstanceProperties({id: 'leaf', properties: {x: 3}});
+            expect(setCalls).toBe(2)
+        } finally {
+            Neo.get = origGet; Neo.getComponent = origGetComponent
+        }
+    })
+
+    test('an async call stays in-flight beyond TTL and expires only after its completion touch', async () => {
+        let now = 0, resolveRun, markStarted;
+
+        const
+            started = new Promise(resolve => { markStarted = resolve }),
+            guard   = Neo.create(WriteGuard, {leaseTtlMs: 100, nowFn: () => now}),
+            service = Neo.create(InstanceService, {client: {writeGuard: guard}}),
+            fake    = {
+                run() {
+                    markStarted();
+                    return new Promise(resolve => { resolveRun = resolve })
+                }
+            },
+            origGet = Neo.get,
+            origGetComponent = Neo.getComponent;
+
+        Neo.get          = () => fake;
+        Neo.getComponent = id => id === 'leaf' ? {parentId: null} : null;
+
+        try {
+            const call = service.callMethod({id: 'leaf', method: 'run'}, CTX_A);
+            await started;
+
+            now = 1_000;
+            expect(admitWrite({context: CTX_B, componentId: 'leaf', parentOf: () => null, writeGuard: guard}).admitted).toBe(false);
+            expect(guard.heldLocks()[0].inFlight).toBe(1);
+
+            resolveRun('done');
+            await expect(call).resolves.toEqual({result: 'done'});
+            expect(guard.heldLocks()[0]).toMatchObject({inFlight: 0, lastTouchAt: 1_000});
+
+            now = 1_100;
+            expect(admitWrite({context: CTX_B, componentId: 'leaf', parentOf: () => null, writeGuard: guard}).admitted).toBe(true)
+        } finally {
+            Neo.get = origGet; Neo.getComponent = origGetComponent
+        }
+    });
+
+    test('a persistent call failure retains until TTL, then admits the same identity in a distinct session', async () => {
+        let now = 0;
+
+        const
+            guard   = Neo.create(WriteGuard, {leaseTtlMs: 100, nowFn: () => now}),
+            service = Neo.create(InstanceService, {client: {writeGuard: guard}}),
+            fake    = {
+                async fail() {
+                    now = 10;
+                    throw new Error('partial mutation unknown')
+                }
+            },
+            origGet = Neo.get,
+            origGetComponent = Neo.getComponent;
+
+        Neo.get          = () => fake;
+        Neo.getComponent = id => id === 'leaf' ? {parentId: null} : null;
+
+        try {
+            await expect(service.callMethod({id: 'leaf', method: 'fail'}, CTX_A)).rejects.toThrow('partial mutation unknown');
+            expect(guard.heldLocks()[0]).toMatchObject({agentId: 'agent-a', inFlight: 0, lastTouchAt: 10});
+            expect(guard.leaseReceipts().at(-1)).toMatchObject({reason: 'error-retained', mutationDisposition: 'unknown'});
+
+            now = 109;
+            expect(admitWrite({context: CTX_A_OTHER_SESSION, componentId: 'leaf', parentOf: () => null, writeGuard: guard}).admitted).toBe(false);
+
+            now = 110;
+            expect(admitWrite({context: CTX_A_OTHER_SESSION, componentId: 'leaf', parentOf: () => null, writeGuard: guard}).admitted).toBe(true)
+        } finally {
+            Neo.get = origGet; Neo.getComponent = origGetComponent
+        }
+    });
+
+    test('pre-mutation failure releases only a newly-created acquisition, never a re-entrant hold', async () => {
+        const
+            guard                  = Neo.create(WriteGuard),
+            service                = Neo.create(InstanceService, {client: {writeGuard: guard}}),
+            fake                   = {run() { throw new Error('method must not run') }},
+            origBuildRemoveReverse = service.buildRemoveReverse,
+            origGet                = Neo.get,
+            origGetComponent       = Neo.getComponent;
+
+        Neo.get          = () => fake;
+        Neo.getComponent = id => id === 'leaf' ? {parentId: null} : null;
+        service.buildRemoveReverse = () => { throw new Error('capture failed before mutation') };
+
+        try {
+            await expect(service.callMethod({id: 'leaf', method: 'run'}, CTX_A)).rejects.toThrow('capture failed before mutation');
+            expect(guard.heldLocks()).toHaveLength(0);
+            expect(guard.leaseReceipts().at(-1).reason).toBe('error-release');
+
+            guard.requestWrite({agentId: CTX_A.agentId, sessionId: CTX_A.sessionId, subtreePath: ['leaf']});
+
+            await expect(service.callMethod({id: 'leaf', method: 'run'}, CTX_A)).rejects.toThrow('capture failed before mutation');
+            expect(guard.heldLocks()).toHaveLength(1);
+            expect(guard.leaseReceipts().at(-1).reason).toBe('error-retained')
+        } finally {
+            service.buildRemoveReverse = origBuildRemoveReverse;
+            Neo.get = origGet; Neo.getComponent = origGetComponent
+        }
+    })
+});

--- a/test/playwright/unit/ai/client/ComponentService.spec.mjs
+++ b/test/playwright/unit/ai/client/ComponentService.spec.mjs
@@ -1,0 +1,254 @@
+import {test, expect}   from '@playwright/test';
+import Neo              from '../../../../../src/Neo.mjs';
+import * as core        from '../../../../../src/core/_export.mjs';
+import ComponentService from '../../../../../src/ai/client/ComponentService.mjs';
+
+test.describe.serial('Neo.ai.client.ComponentService.serializeComponent', () => {
+    let originalGetDirectChildren, service;
+
+    test.beforeEach(() => {
+        originalGetDirectChildren = Neo.manager.Component.getDirectChildren;
+        service                   = Neo.create(ComponentService)
+    });
+
+    test.afterEach(() => {
+        Neo.manager.Component.getDirectChildren = originalGetDirectChildren;
+        service.destroy()
+    });
+
+    test('depth 2 contains direct children once, never the flattened descendant closure', () => {
+        const
+            root         = {className: 'Root', id: 'root'},
+            child        = {className: 'Child', id: 'child'},
+            grandchild   = {className: 'Grandchild', id: 'grandchild'},
+            childrenById = new Map([
+                ['root', [child]],
+                ['child', [grandchild]]
+            ]);
+
+        Neo.manager.Component.getDirectChildren = id => childrenById.get(id) || [];
+
+        expect(service.serializeComponent({component: root, maxDepth: 2})).toEqual({
+            className: 'Root',
+            id       : 'root',
+            items    : [{className: 'Child', id: 'child'}]
+        });
+        expect(service.serializeComponent({component: root, maxDepth: 3})).toEqual({
+            className: 'Root',
+            id       : 'root',
+            items    : [{
+                className: 'Child',
+                id       : 'child',
+                items    : [{className: 'Grandchild', id: 'grandchild'}]
+            }]
+        })
+    });
+});
+
+/**
+ * @summary Tests for the pure child-surface differ behind verify_component_consistency
+ */
+test.describe.serial('Neo.ai.client.ComponentService.diffChildSurfaces', () => {
+    test('Consistent surfaces produce no mismatches', () => {
+        const result = ComponentService.diffChildSurfaces({
+            componentId: 'container-1',
+            domIds     : ['a', 'b', 'c'],
+            itemIds    : ['a', 'b', 'c'],
+            vdomIds    : ['a', 'b', 'c']
+        });
+
+        expect(result.consistent).toBe(true);
+        expect(result.mismatches).toEqual([]);
+        expect(result.counts).toEqual({dom: 3, items: 3, vdom: 3})
+    });
+
+    test('Duplicate DOM children are detected (the drop-duplication class)', () => {
+        const result = ComponentService.diffChildSurfaces({
+            componentId: 'container-1',
+            domIds     : ['a', 'b', 'a', 'c'],
+            itemIds    : ['a', 'b', 'c'],
+            vdomIds    : ['a', 'b', 'c']
+        });
+
+        expect(result.consistent).toBe(false);
+        expect(result.mismatches.some(m => m.type === 'duplicates' && m.surface === 'dom' && m.ids.includes('a'))).toBe(true);
+        expect(result.mismatches.some(m => m.type === 'order-or-membership' && m.surfaces.join() === 'vdom,dom')).toBe(true)
+    });
+
+    test('Order divergence between items and vdom is reported', () => {
+        const result = ComponentService.diffChildSurfaces({
+            componentId: 'container-1',
+            domIds     : ['a', 'c', 'b'],
+            itemIds    : ['a', 'b', 'c'],
+            vdomIds    : ['a', 'c', 'b']
+        });
+
+        expect(result.consistent).toBe(false);
+        expect(result.mismatches).toHaveLength(1);
+        expect(result.mismatches[0].surfaces.join()).toBe('items,vdom')
+    });
+
+    test('Missing DOM root is its own mismatch and skips DOM comparisons', () => {
+        const result = ComponentService.diffChildSurfaces({
+            componentId: 'container-1',
+            domIds     : null,
+            itemIds    : ['a'],
+            vdomIds    : ['a']
+        });
+
+        expect(result.consistent).toBe(false);
+        expect(result.mismatches).toEqual([{type: 'dom-root-missing'}]);
+        expect(result.counts.dom).toBe(null)
+    });
+});
+
+test.describe.serial('Neo.ai.client.ComponentService.observeMotion', () => {
+    const originalNow = Date.now;
+
+    let originalGetComponent, originalMain, now, service;
+
+    test.beforeEach(() => {
+        originalGetComponent = Neo.getComponent;
+        originalMain         = Neo.main;
+        now                  = 1000;
+        Date.now             = () => now;
+        service              = Neo.create(ComponentService);
+        service.timeout      = async ms => {
+            now += ms
+        };
+    });
+
+    test.afterEach(() => {
+        Date.now         = originalNow;
+        Neo.getComponent = originalGetComponent;
+        Neo.main         = originalMain;
+        service.destroy()
+    });
+
+    test('samples raw nodeIds through DomAccess with explicit window routing', async () => {
+        const calls = [];
+
+        Neo.getComponent = () => null;
+        Neo.main = {
+            DomAccess: {
+                getBoundingClientRect: async data => {
+                    calls.push(data);
+
+                    return [
+                        {left: 10, top: 20, width: 30, height: 40},
+                        {}
+                    ]
+                }
+            }
+        };
+
+        const result = await service.observeMotion({
+            durationMs: 100,
+            intervalMs: 100,
+            nodeIds   : ['row-1__cell-0', 'missing-cell'],
+            windowId  : 'win-1'
+        });
+
+        expect(calls).toEqual([{id: ['row-1__cell-0', 'missing-cell'], windowId: 'win-1'}]);
+        expect(result.componentIds).toEqual([]);
+        expect(result.nodeIds).toEqual(['row-1__cell-0', 'missing-cell']);
+        expect(result.targetIds).toEqual(['row-1__cell-0', 'missing-cell']);
+        expect(result.samples).toEqual([{
+            t    : 0,
+            rects: [
+                {left: 10, top: 20, width: 30, height: 40},
+                null
+            ]
+        }])
+    });
+
+    test('samples mixed componentIds and nodeIds in component-first order', async () => {
+        const calls = [];
+
+        Neo.getComponent = id => id === 'toolbar-1' ? {id, windowId: 'win-c'} : null;
+        Neo.main = {
+            DomAccess: {
+                getBoundingClientRect: async data => {
+                    calls.push(data);
+
+                    return [
+                        {left: 1, top: 2, width: 3, height: 4},
+                        {left: 5, top: 6, width: 7, height: 8}
+                    ]
+                }
+            }
+        };
+
+        const result = await service.observeMotion({
+            componentIds: ['toolbar-1'],
+            durationMs  : 100,
+            intervalMs  : 100,
+            nodeIds     : ['row-1__cell-0']
+        });
+
+        expect(calls).toEqual([{id: ['toolbar-1', 'row-1__cell-0'], windowId: 'win-c'}]);
+        expect(result.componentIds).toEqual(['toolbar-1']);
+        expect(result.nodeIds).toEqual(['row-1__cell-0']);
+        expect(result.targetIds).toEqual(['toolbar-1', 'row-1__cell-0'])
+    });
+
+    test('preserves the component-only getDomRect path', async () => {
+        const calls = [];
+
+        Neo.getComponent = id => id === 'toolbar-1' ? {
+            id,
+            windowId  : 'win-c',
+            getDomRect: async ids => {
+                calls.push(ids);
+
+                return {left: 1, top: 2, width: 3, height: 4}
+            }
+        } : null;
+        Neo.main = {DomAccess: {}};
+
+        const result = await service.observeMotion({
+            componentIds: ['toolbar-1'],
+            durationMs  : 100,
+            intervalMs  : 100
+        });
+
+        expect(calls).toEqual([['toolbar-1']]);
+        expect(result.nodeIds).toEqual([]);
+        expect(result.targetIds).toEqual(['toolbar-1']);
+        expect(result.samples[0].rects).toEqual([{left: 1, top: 2, width: 3, height: 4}])
+    });
+
+    test('expands cellsOf into raw node targets', async () => {
+        Neo.getComponent = () => null;
+        Neo.main = {
+            DomAccess: {
+                getBoundingClientRect: async () => [
+                    {left: 1, top: 2, width: 3, height: 4},
+                    {left: 5, top: 6, width: 7, height: 8}
+                ],
+                getChildNodeIds: async ({id, windowId}) => {
+                    expect(id).toBe('row-1');
+                    expect(windowId).toBe('win-1');
+
+                    return ['row-1__cell-0', 'row-1__cell-1']
+                }
+            }
+        };
+
+        const result = await service.observeMotion({
+            cellsOf   : {rowId: 'row-1'},
+            durationMs: 100,
+            intervalMs: 100,
+            windowId  : 'win-1'
+        });
+
+        expect(result.nodeIds).toEqual(['row-1__cell-0', 'row-1__cell-1']);
+        expect(result.targetIds).toEqual(['row-1__cell-0', 'row-1__cell-1'])
+    });
+
+    test('requires at least one target source', async () => {
+        await expect(service.observeMotion({durationMs: 100, intervalMs: 100})).rejects.toThrow(
+            'componentIds, nodeIds, or cellsOf must provide at least one target'
+        )
+    });
+});

--- a/test/playwright/unit/ai/client/DockService.spec.mjs
+++ b/test/playwright/unit/ai/client/DockService.spec.mjs
@@ -321,10 +321,10 @@ test.describe.serial('Neo.ai.client.DockService', () => {
         expect(captured.layout.captureScope).toBe('window');
         // the landed producer computes the fingerprint from the PERSISTED tree — a null
         // fingerprint would mean the tool bypassed Persistence.capturePerspective()
-        // Wire identity renamed by the v13.2 cut (#17837 / PR #17841): the `neo.harness.*` family
-        // carried pre-release history, and the landed vocabulary is `neo.dock.*`. The assertion is
-        // updated rather than the producer — this arm exists to prove the fingerprint comes from
-        // Persistence, and the schema string is how it proves it.
+        // The shipped wire family is `neo.dock.*`; the older `neo.harness.*` names are retired. This
+        // arm exists to prove the fingerprint is produced by `Persistence` rather than assembled by
+        // the caller, and the schema string is how it proves it — so the assertion tracks the
+        // producer's vocabulary rather than pinning a historical one.
         expect(captured.layout.windowFingerprint?.schema).toBe('neo.dock.shape.v1');
         expect(Persistence.restoreSavedLayout(captured.layout).errors).toEqual([])
     });

--- a/test/playwright/unit/ai/client/DockService.spec.mjs
+++ b/test/playwright/unit/ai/client/DockService.spec.mjs
@@ -12,7 +12,7 @@ import PerspectiveLibrary   from '../../../../../src/dashboard/dock/persistence/
  */
 function doc() {
     return {
-        schema: 'neo.harness.dockZone.v1',
+        schema: 'neo.dock.zone.v1',
         root  : 'root',
         items : {
             strategy: {componentRef: 'strategy', title: 'Strategy', kind: 'panel'},
@@ -20,7 +20,7 @@ function doc() {
             terminal: {componentRef: 'terminal', title: 'Terminal', kind: 'terminal'}
         },
         nodes: {
-            root        : {type: 'edge-zone', zones: {center: 'main-split'}},
+            root        : {type: 'edge-zone', zones: {center: {nodeId: 'main-split'}}},
             'main-split': {type: 'split', orientation: 'horizontal', children: ['main-tabs', 'side-tabs'], sizes: [0.5, 0.5]},
             'main-tabs' : {type: 'tabs', items: ['strategy', 'swarm'], activeItemId: 'strategy'},
             'side-tabs' : {type: 'tabs', items: ['terminal'], activeItemId: 'terminal'}
@@ -35,14 +35,14 @@ function doc() {
  */
 function doc2() {
     return {
-        schema: 'neo.harness.dockZone.v1',
+        schema: 'neo.dock.zone.v1',
         root  : 'root',
         items : {
             alpha: {componentRef: 'alpha', title: 'Alpha', kind: 'panel'},
             beta : {componentRef: 'beta',  title: 'Beta',  kind: 'panel'}
         },
         nodes: {
-            root       : {type: 'edge-zone', zones: {center: 'only-tabs'}},
+            root       : {type: 'edge-zone', zones: {center: {nodeId: 'only-tabs'}}},
             'only-tabs': {type: 'tabs', items: ['alpha', 'beta'], activeItemId: 'alpha'}
         }
     }
@@ -321,7 +321,11 @@ test.describe.serial('Neo.ai.client.DockService', () => {
         expect(captured.layout.captureScope).toBe('window');
         // the landed producer computes the fingerprint from the PERSISTED tree — a null
         // fingerprint would mean the tool bypassed Persistence.capturePerspective()
-        expect(captured.layout.windowFingerprint?.schema).toBe('neo.harness.dockShape.v1');
+        // Wire identity renamed by the v13.2 cut (#17837 / PR #17841): the `neo.harness.*` family
+        // carried pre-release history, and the landed vocabulary is `neo.dock.*`. The assertion is
+        // updated rather than the producer — this arm exists to prove the fingerprint comes from
+        // Persistence, and the schema string is how it proves it.
+        expect(captured.layout.windowFingerprint?.schema).toBe('neo.dock.shape.v1');
         expect(Persistence.restoreSavedLayout(captured.layout).errors).toEqual([])
     });
 
@@ -363,7 +367,7 @@ test.describe.serial('Neo.ai.client.DockService', () => {
         // slot 0 stays the primary dockZone; the ADDITIONAL window persists in windowDocuments
         expect(captured.layout.windowDocuments).toHaveLength(1);
         expect(Object.keys(captured.layout.windowDocuments[0].items)).toEqual(['alpha', 'beta']);
-        expect(captured.layout.windowFingerprint?.schema).toBe('neo.harness.dockTopologyShape.v1');
+        expect(captured.layout.windowFingerprint?.schema).toBe('neo.dock.topologyShape.v1');
         expect(captured.layout.windowFingerprint?.windowCount).toBe(2);
         expect(Persistence.restoreSavedLayout(captured.layout).errors).toEqual([]);
 

--- a/test/playwright/unit/ai/client/DockService.spec.mjs
+++ b/test/playwright/unit/ai/client/DockService.spec.mjs
@@ -1,0 +1,646 @@
+import {test, expect}       from '@playwright/test';
+import Neo                  from '../../../../../src/Neo.mjs';
+import * as core            from '../../../../../src/core/_export.mjs';
+import DockService          from '../../../../../src/ai/client/DockService.mjs';
+import Operations           from '../../../../../src/dashboard/dock/model/Operations.mjs';
+import Persistence          from '../../../../../src/dashboard/dock/model/Persistence.mjs';
+import PerspectiveLibrary   from '../../../../../src/dashboard/dock/persistence/PerspectiveLibrary.mjs';
+
+/**
+ * @summary Creates a valid dockZone.v1 fixture for diff-tool assertions.
+ * @returns {Object}
+ */
+function doc() {
+    return {
+        schema: 'neo.harness.dockZone.v1',
+        root  : 'root',
+        items : {
+            strategy: {componentRef: 'strategy', title: 'Strategy', kind: 'panel'},
+            swarm   : {componentRef: 'swarm',    title: 'Swarm',    kind: 'panel'},
+            terminal: {componentRef: 'terminal', title: 'Terminal', kind: 'terminal'}
+        },
+        nodes: {
+            root        : {type: 'edge-zone', zones: {center: 'main-split'}},
+            'main-split': {type: 'split', orientation: 'horizontal', children: ['main-tabs', 'side-tabs'], sizes: [0.5, 0.5]},
+            'main-tabs' : {type: 'tabs', items: ['strategy', 'swarm'], activeItemId: 'strategy'},
+            'side-tabs' : {type: 'tabs', items: ['terminal'], activeItemId: 'terminal'}
+        }
+    }
+}
+
+/**
+ * @summary A second, item-disjoint dockZone.v1 fixture — the ADDITIONAL window for topology-scope
+ * assertions (the reconciler validates workspace-global item disjointness across live windows).
+ * @returns {Object}
+ */
+function doc2() {
+    return {
+        schema: 'neo.harness.dockZone.v1',
+        root  : 'root',
+        items : {
+            alpha: {componentRef: 'alpha', title: 'Alpha', kind: 'panel'},
+            beta : {componentRef: 'beta',  title: 'Beta',  kind: 'panel'}
+        },
+        nodes: {
+            root       : {type: 'edge-zone', zones: {center: 'only-tabs'}},
+            'only-tabs': {type: 'tabs', items: ['alpha', 'beta'], activeItemId: 'alpha'}
+        }
+    }
+}
+
+/**
+ * @summary The doc() catalog rearranged (strategy moved across tabs nodes) — same items, different
+ * shape fingerprint, so a restore toward doc() exercises the reconciler's changed-topology path.
+ * @returns {Object}
+ */
+function docRearranged() {
+    const d = doc();
+
+    d.nodes['main-tabs'].items        = ['swarm'];
+    d.nodes['main-tabs'].activeItemId = 'swarm';
+    d.nodes['side-tabs'].items        = ['terminal', 'strategy'];
+
+    return d
+}
+
+/**
+ * @summary Tests for the worker-side Neural Link dock tools: fail-closed operation vocabulary,
+ * holder resolution, and the landed dual commit path (override-preferred, reducer-fallback).
+ */
+test.describe.serial('Neo.ai.client.DockService', () => {
+    let originalGetComponent, service;
+
+    test.beforeEach(() => {
+        originalGetComponent = Neo.getComponent;
+        service              = Neo.create(DockService, {})
+    });
+
+    test.afterEach(() => {
+        Neo.getComponent = originalGetComponent;
+        service.destroy?.()
+    });
+
+    test('the operation vocabulary IS the executor export — one reference, no mirror to drift', () => {
+        expect(DockService.operations).toBe(Operations.operations);
+        expect(Object.isFrozen(DockService.operations)).toBe(true)
+    });
+
+    test('the executor honors its reducer contract on a well-formed document (returns, never throws)', () => {
+        const result = Operations.applyOperation({nodes: {}}, {operation: 'moveItem', itemId: 'missing', targetNodeId: 'nowhere'});
+
+        expect(result).toHaveProperty('document');
+        expect(result).toHaveProperty('errors');
+        expect(Array.isArray(result.errors)).toBe(true)
+    });
+
+    test('executeDockOperation rejects unknown operations fail-closed with the vocabulary enumerated', async () => {
+        await expect(service.executeDockOperation({
+            componentId: 'any',
+            descriptor : {operation: 'teleportItem'}
+        // the enumerated vocabulary derives from the Operations SSOT (never hand-listed), so this
+        // stays green as the operation family grows rather than pinning a brittle literal snapshot
+        })).rejects.toThrow(new RegExp(`Unknown dock operation: teleportItem.*${DockService.operations.join(', ')}`))
+    });
+
+    test('executeDockOperation rejects a missing descriptor fail-closed', async () => {
+        await expect(service.executeDockOperation({componentId: 'any'}))
+            .rejects.toThrow(/Unknown dock operation/)
+    });
+
+    test('resolveHolder throws for an unknown component id', async () => {
+        Neo.getComponent = () => null;
+
+        await expect(service.getDockTopology({componentId: 'ghost-1'}))
+            .rejects.toThrow('Component not found: ghost-1')
+    });
+
+    test('resolveHolder throws for a component that holds no dock document', async () => {
+        Neo.getComponent = () => ({id: 'plain-1'});
+
+        await expect(service.getDockTopology({componentId: 'plain-1'}))
+            .rejects.toThrow(/holds no dock document/)
+    });
+
+    test('getDockTopology returns the document plus the executable vocabulary', async () => {
+        const document = {root: {type: 'split', items: []}};
+
+        Neo.getComponent = () => ({dockZoneDocument: document, id: 'zone-1'});
+
+        const result = await service.getDockTopology({componentId: 'zone-1'});
+
+        expect(result.document).toBe(document);
+        expect(result.operations).toEqual(DockService.operations)
+    });
+
+    test('diffDockTopology compares a supplied before-document against the live holder document', async () => {
+        const before = doc(),
+              after  = doc();
+
+        after.nodes['main-tabs'].items = ['swarm'];
+        after.nodes['side-tabs'].items = ['terminal', 'strategy'];
+        after.nodes['main-split'].sizes = [0.5005, 0.4995];
+
+        Neo.getComponent = () => ({dockZoneDocument: after, id: 'zone-diff'});
+
+        const result = await service.diffDockTopology({
+            beforeDocument: before,
+            componentId   : 'zone-diff',
+            sizeEpsilon   : 0.0001
+        });
+
+        expect(result.errors).toEqual([]);
+        expect(result.moves).toEqual([
+            {itemId: 'strategy', from: {nodeId: 'main-tabs', index: 0}, to: {nodeId: 'side-tabs', index: 1}}
+        ]);
+        expect(result.resizes).toEqual([
+            {nodeId: 'main-split', fromSizes: [0.5, 0.5], toSizes: [0.5005, 0.4995]}
+        ])
+    });
+
+    test('diffDockTopology returns structured errors for malformed before-documents', async () => {
+        const after = doc();
+
+        Neo.getComponent = () => ({dockZoneDocument: after, id: 'zone-diff-errors'});
+
+        const result = await service.diffDockTopology({
+            beforeDocument: {schema: 'wrong'},
+            componentId   : 'zone-diff-errors'
+        });
+
+        expect(result.moves).toEqual([]);
+        expect(result.errors.length).toBeGreaterThan(0);
+        expect(result.errors[0]).toContain('before document failed the shape gate')
+    });
+
+    test('the canonical workspace shape (getDockZoneDocument + override, no plain field) reads BEFORE any write and never gains a stray field', async () => {
+        // the examples/dashboard/dock MainContainer shape: document state lives in an internal
+        // `dockModel` exposed only through the contract's read accessor — a plain-field read
+        // would return null here before the first committed operation
+        const before       = {root: {type: 'split', items: ['before']}};
+        const nextDocument = {root: {type: 'split', items: ['after']}};
+        const seen         = {change: null};
+
+        const holder = {
+            id       : 'zone-canonical',
+            dockModel: before,
+            getDockZoneDocument() {
+                return this.dockModel
+            },
+            applyDockZoneOperation() {
+                return {document: nextDocument, errors: []}
+            },
+            onDockZoneDocumentChange(doc) {
+                seen.change = doc;
+                this.dockModel = doc
+            }
+        };
+
+        Neo.getComponent = () => holder;
+
+        // read works pre-write against the canonical holder (the live-topology AC)
+        const topology = await service.getDockTopology({componentId: 'zone-canonical'});
+        expect(topology.document).toBe(before);
+
+        const result = await service.executeDockOperation({
+            componentId: 'zone-canonical',
+            descriptor : {operation: 'setItemAutoHidden', itemId: 'pane-1', autoHidden: true}
+        });
+
+        expect(result.applied).toBe(true);
+        expect(result.document).toBe(nextDocument);
+        // the holder owns its state: synced through the callback, no stray divergent field
+        expect(seen.change).toBe(nextDocument);
+        expect(holder.dockModel).toBe(nextDocument);
+        expect('dockZoneDocument' in holder).toBe(false);
+        // and the post-write read reflects the commit through the same accessor
+        expect((await service.getDockTopology({componentId: 'zone-canonical'})).document).toBe(nextDocument)
+    });
+
+    test('executeDockOperation prefers the holder applyDockZoneOperation override and commits on success', async () => {
+        const nextDocument = {root: {type: 'split', items: ['after']}};
+        const descriptor   = {operation: 'setItemAutoHidden', itemId: 'pane-1', autoHidden: true};
+        const seen         = {apply: null, change: null};
+
+        const holder = {
+            id              : 'zone-2',
+            dockZoneDocument: {root: {type: 'split', items: ['before']}},
+            applyDockZoneOperation(desc, source) {
+                seen.apply = {desc, source};
+                return {document: nextDocument, errors: []}
+            },
+            onDockZoneDocumentChange(doc, desc, source) {
+                seen.change = {doc, desc, source}
+            }
+        };
+
+        Neo.getComponent = () => holder;
+
+        const result = await service.executeDockOperation({componentId: 'zone-2', descriptor});
+
+        expect(seen.apply.desc).toBe(descriptor);
+        expect(result.applied).toBe(true);
+        expect(result.errors).toEqual([]);
+        expect(result.document).toBe(nextDocument);
+        expect(holder.dockZoneDocument).toBe(nextDocument);
+        expect(seen.change.doc).toBe(nextDocument);
+        expect(seen.change.desc).toBe(descriptor)
+    });
+
+    test('executeDockOperation surfaces executor errors without committing (the policy-rejection path)', async () => {
+        const before = {root: {type: 'split', items: ['before']}};
+
+        const holder = {
+            id              : 'zone-3',
+            dockZoneDocument: before,
+            applyDockZoneOperation() {
+                return {document: null, errors: ['setItemPinned rejected: pinnable === false']}
+            }
+        };
+
+        Neo.getComponent = () => holder;
+
+        const result = await service.executeDockOperation({
+            componentId: 'zone-3',
+            descriptor : {operation: 'setItemPinned', itemId: 'pane-1', pinned: true}
+        });
+
+        expect(result.applied).toBe(false);
+        expect(result.errors).toEqual(['setItemPinned rejected: pinnable === false']);
+        expect(holder.dockZoneDocument).toBe(before)
+    });
+
+    test('executeDockOperation falls back to the static reducer for a document-only holder', async () => {
+        const holder = {
+            id              : 'zone-4',
+            dockZoneDocument: {nodes: {}},
+            // no applyDockZoneOperation: the static Operations.applyOperation() path runs
+        };
+
+        Neo.getComponent = () => holder;
+
+        const result = await service.executeDockOperation({
+            componentId: 'zone-4',
+            descriptor : {operation: 'moveItem', itemId: 'missing', targetNodeId: 'nowhere'}
+        });
+
+        // an empty node map cannot satisfy the move: the reducer reports errors, nothing commits
+        expect(result.applied).toBe(false);
+        expect(Array.isArray(result.errors)).toBe(true);
+        expect(result.errors.length).toBeGreaterThan(0)
+    });
+
+    test('a malformed holder document surfaces as structured errors, never a raw RPC crash', async () => {
+        const malformed = {};
+
+        Neo.getComponent = () => ({id: 'zone-5', dockZoneDocument: malformed});
+
+        const result = await service.executeDockOperation({
+            componentId: 'zone-5',
+            descriptor : {operation: 'moveItem', itemId: 'x', targetNodeId: 'y'}
+        });
+
+        expect(result.applied).toBe(false);
+        expect(result.errors[0]).toMatch(/Dock operation failed before commit:/);
+        expect(result.document).toBe(malformed)
+    });
+
+    test('capturePerspective (window default) rides the landed producer — fingerprint-coherent, schema-valid, honest stored:false', async () => {
+        const holder = {id: 'zone-6', dockZoneDocument: doc()};
+
+        Neo.getComponent = () => holder;
+
+        const captured = await service.capturePerspective({
+            componentId: 'zone-6', layoutId: 'ws-1', perspectiveName: 'Coding', title: 'Coding view'
+        });
+
+        expect(captured.captured).toBe(true);
+        expect(captured.stored).toBe(false);
+        expect(captured.errors).toEqual([]);
+        expect(captured.layout.layoutId).toBe('ws-1');
+        expect(captured.layout.perspectiveName).toBe('Coding');
+        expect(captured.layout.captureScope).toBe('window');
+        // the landed producer computes the fingerprint from the PERSISTED tree — a null
+        // fingerprint would mean the tool bypassed Persistence.capturePerspective()
+        expect(captured.layout.windowFingerprint?.schema).toBe('neo.harness.dockShape.v1');
+        expect(Persistence.restoreSavedLayout(captured.layout).errors).toEqual([])
+    });
+
+    test('capture scope vocabulary IS the CAPTURE_SCOPES SSOT: window accepted, workspace and junk refused with the executable set enumerated', async () => {
+        Neo.getComponent = () => ({id: 'zone-6b', dockZoneDocument: doc()});
+
+        // `window` is the executable SSOT scope — an implementation refusing it contradicts
+        // Persistence.CAPTURE_SCOPES (the review falsifier that convicted the stale vocabulary)
+        const win = await service.capturePerspective({componentId: 'zone-6b', layoutId: 'w-1', captureScope: 'window'});
+        expect(win.captured).toBe(true);
+        expect(win.layout.captureScope).toBe('window');
+
+        // `workspace` is the ADR's capability LABEL, not a runtime enum value — minting it as a
+        // third runtime scope is the drift this spec pins shut
+        for (const bogus of ['workspace', 'teleport']) {
+            const refused = await service.capturePerspective({componentId: 'zone-6b', layoutId: 'x', captureScope: bogus});
+
+            expect(refused.captured).toBe(false);
+            // the enumeration derives from the SSOT, never a hand-listed literal
+            expect(refused.errors[0]).toContain(`the vocabulary is: ${Persistence.CAPTURE_SCOPES.join(', ')}`)
+        }
+    });
+
+    test('capturePerspective (topology) captures the ordered multi-window workspace through the holder seam — and refuses without it', async () => {
+        const holder = {
+            id                      : 'zone-6c',
+            dockZoneDocument        : doc(),
+            getDockTopologyDocuments: () => [doc(), doc2()]
+        };
+
+        Neo.getComponent = () => holder;
+
+        const captured = await service.capturePerspective({
+            componentId: 'zone-6c', layoutId: 'topo-1', perspectiveName: 'Everything', captureScope: 'topology'
+        });
+
+        expect(captured.captured).toBe(true);
+        expect(captured.layout.captureScope).toBe('topology');
+        // slot 0 stays the primary dockZone; the ADDITIONAL window persists in windowDocuments
+        expect(captured.layout.windowDocuments).toHaveLength(1);
+        expect(Object.keys(captured.layout.windowDocuments[0].items)).toEqual(['alpha', 'beta']);
+        expect(captured.layout.windowFingerprint?.schema).toBe('neo.harness.dockTopologyShape.v1');
+        expect(captured.layout.windowFingerprint?.windowCount).toBe(2);
+        expect(Persistence.restoreSavedLayout(captured.layout).errors).toEqual([]);
+
+        // no topology read seam = a declared refusal naming the seam — never a silent
+        // downgrade to a window-scope record
+        Neo.getComponent = () => ({id: 'zone-6d', dockZoneDocument: doc()});
+        const refused = await service.capturePerspective({componentId: 'zone-6d', layoutId: 'x', captureScope: 'topology'});
+
+        expect(refused.captured).toBe(false);
+        expect(refused.errors[0]).toContain('getDockTopologyDocuments')
+    });
+
+    test('capturePerspective stores through the holder perspective store and surfaces its structured collision verdict', async () => {
+        const saves  = [],
+              holder = {
+                  id              : 'zone-7',
+                  dockZoneDocument: doc(),
+                  perspectiveStore: {
+                      savePerspective(layout, options) {
+                          saves.push({layout, options});
+                          return {collision: {holderLayoutId: 'other', holderTitle: 'Other', name: 'Coding'}, errors: [], layoutId: null, saved: false}
+                      }
+                  }
+              };
+
+        Neo.getComponent = () => holder;
+
+        const result = await service.capturePerspective({
+            componentId: 'zone-7', layoutId: 'ws-2', perspectiveName: 'Coding', replace: false
+        });
+
+        // capture succeeded, the store's collision verdict passes through untouched — the
+        // agent gets the SAME structured decision surface a UI caller gets
+        expect(result.captured).toBe(true);
+        expect(result.stored).toBe(false);
+        expect(result.collision).toMatchObject({holderLayoutId: 'other', name: 'Coding'});
+        expect(saves[0].options).toEqual({replace: false})
+    });
+
+    test('listPerspectives reads the store surface and fails closed on a store-less holder', async () => {
+        const listed = [{layoutId: 'a', perspectiveName: 'A', title: 'A view', captureScope: 'window', revision: null}];
+
+        Neo.getComponent = () => ({
+            id              : 'zone-8',
+            dockZoneDocument: doc(),
+            perspectiveStore: {collection: {activeLayoutId: 'a'}, list: () => listed}
+        });
+
+        const result = await service.listPerspectives({componentId: 'zone-8'});
+        expect(result.perspectives).toBe(listed);
+        expect(result.activeLayoutId).toBe('a');
+        expect(result.errors).toEqual([]);
+
+        // fail-closed: no store = a structured error, never an empty list masquerading as truth
+        Neo.getComponent = () => ({id: 'zone-9', dockZoneDocument: doc()});
+        const bare = await service.listPerspectives({componentId: 'zone-9'});
+        expect(bare.perspectives).toBeNull();
+        expect(bare.errors[0]).toContain('no perspective store')
+    });
+
+    test('restorePerspective inspects the record READ-ONLY first: no getPerspective seam and unknown names are declared refusals', async () => {
+        // scope-honesty requires reading captureScope BEFORE any state moves — a store without
+        // the read-only seam cannot make that promise, so the tool refuses rather than guessing
+        Neo.getComponent = () => ({
+            id              : 'zone-10',
+            dockZoneDocument: doc(),
+            perspectiveStore: {loadPerspective: () => ({document: doc(), errors: [], layout: {}})}
+        });
+
+        const blind = await service.restorePerspective({componentId: 'zone-10', name: 'Focus'});
+        expect(blind.switched).toBe(false);
+        expect(blind.errors[0]).toContain('getPerspective');
+
+        Neo.getComponent = () => ({
+            id              : 'zone-10b',
+            dockZoneDocument: doc(),
+            perspectiveStore: {getPerspective: () => null}
+        });
+
+        const missing = await service.restorePerspective({componentId: 'zone-10b', name: 'ghost'});
+        expect(missing.switched).toBe(false);
+        expect(missing.errors[0]).toContain('no perspective named "ghost"');
+
+        // and a holder with no perspective surface at all refuses, never crashes
+        Neo.getComponent = () => ({id: 'zone-10c', dockZoneDocument: doc()});
+        const bare = await service.restorePerspective({componentId: 'zone-10c', name: 'Focus'});
+        expect(bare.switched).toBe(false);
+        expect(bare.errors[0]).toContain('getPerspective')
+    });
+
+    test('restorePerspective routes a WINDOW record through the holder switch seam after the scope inspection', async () => {
+        const calls    = [],
+              after    = doc(),
+              windowed = Persistence.capturePerspective(doc(), {layoutId: 'w-1', perspectiveName: 'Focus', title: 'Focus'}).layout,
+              holder   = {
+                  id: 'zone-11',
+                  activatePerspective(name) { calls.push(name); return {errors: [], switched: true} },
+                  getDockZoneDocument: () => after,
+                  perspectiveStore   : {getPerspective: () => ({layout: windowed, layoutId: 'w-1'})}
+              };
+
+        Neo.getComponent = () => holder;
+
+        const result = await service.restorePerspective({componentId: 'zone-11', name: 'Focus'});
+        expect(calls).toEqual(['Focus']);
+        expect(result.switched).toBe(true);
+        expect(result.captureScope).toBe('window');
+        expect(result.document).toBe(after)
+    });
+
+    test('restorePerspective window store fallback: refusal leaves the holder byte-untouched; success commits through the landed plain-holder path', async () => {
+        const restored = doc(),
+              windowed = Persistence.capturePerspective(doc(), {layoutId: 'w-2', perspectiveName: 'Focus', title: 'Focus'}).layout,
+              notified = [];
+
+        // refusal: the store's structured errors pass through, the document never moves
+        const refusingHolder = {
+            id              : 'zone-12',
+            dockZoneDocument: doc(),
+            perspectiveStore: {
+                getPerspective : () => ({layout: windowed, layoutId: 'w-2'}),
+                loadPerspective: () => ({document: null, errors: ['collection validation failed'], layout: null})
+            }
+        };
+        const before = JSON.stringify(refusingHolder.dockZoneDocument);
+
+        Neo.getComponent = () => refusingHolder;
+
+        const refused = await service.restorePerspective({componentId: 'zone-12', name: 'Focus'});
+        expect(refused.switched).toBe(false);
+        expect(refused.errors[0]).toContain('collection validation failed');
+        expect(JSON.stringify(refusingHolder.dockZoneDocument)).toBe(before);
+
+        // success on a plain holder: the same commit semantics executeDockOperation uses —
+        // dockZoneDocument advances AND the change hook fires with the restore descriptor
+        const plainHolder = {
+            id              : 'zone-13',
+            dockZoneDocument: doc(),
+            onDockZoneDocumentChange(document, descriptor) { notified.push(descriptor) },
+            perspectiveStore: {
+                getPerspective : () => ({layout: windowed, layoutId: 'w-2'}),
+                loadPerspective: () => ({document: restored, errors: [], layout: windowed})
+            }
+        };
+
+        Neo.getComponent = () => plainHolder;
+
+        const result = await service.restorePerspective({componentId: 'zone-13', name: 'Focus'});
+        expect(result.switched).toBe(true);
+        expect(result.captureScope).toBe('window');
+        expect(result.document).toBe(restored);
+        expect(plainHolder.dockZoneDocument).toBe(restored);
+        expect(notified[0]).toMatchObject({name: 'Focus', operation: 'restorePerspective'})
+    });
+
+    test('restorePerspective routes a TOPOLOGY record through the reconciler + the atomic multi-document seam (real store, changed topology)', async () => {
+        // the REAL producer + REAL store: the record is exactly what capture writes
+        const captured = Persistence.captureTopologyPerspective([doc(), doc2()], {
+                  layoutId: 'topo-1', perspectiveName: 'Everything', title: 'Everything'
+              }).layout,
+              store    = Neo.create(PerspectiveLibrary, {});
+
+        expect(store.savePerspective(captured).saved).toBe(true);
+
+        // live topology CHANGED since capture: primary window rearranged (shape mismatch →
+        // the reconciler's adopt branch), second window byte-equal (incremental no-op branch)
+        const liveDocs = [docRearranged(), doc2()],
+              commits  = [],
+              holder   = {
+                  id                      : 'zone-14',
+                  dockZoneDocument        : liveDocs[0],
+                  perspectiveStore        : store,
+                  getDockTopologyDocuments: () => liveDocs,
+                  commitDockTopologyDocuments(documents, context) {
+                      // the atomic seam sees ALL window documents in one call — and the store's
+                      // active pointer has NOT moved yet at commit time (commit-then-activate)
+                      commits.push({activeAtCommit: store.collection.activeLayoutId, context, documents})
+                  }
+              };
+
+        Neo.getComponent = () => holder;
+
+        const result = await service.restorePerspective({componentId: 'zone-14', name: 'Everything'});
+
+        expect(result.switched).toBe(true);
+        expect(result.captureScope).toBe('topology');
+        expect(result.errors).toEqual([]);
+        expect(commits).toHaveLength(1);
+        expect(commits[0].documents).toHaveLength(2);
+        expect(commits[0].context).toMatchObject({name: 'Everything', operation: 'restorePerspective'});
+        // every captured item id lands in restored — windowDocuments were consumed, not dropped
+        expect([...result.restored].sort()).toEqual(['alpha', 'beta', 'strategy', 'swarm', 'terminal']);
+        expect(result.unrestored).toEqual([]);
+        // the primary window adopted the captured arrangement (strategy back on main-tabs)
+        expect(result.documents[0].nodes['main-tabs'].items).toEqual(['strategy', 'swarm']);
+        expect(result.document).toBe(result.documents[0]);
+        // the store's active pointer advanced only AFTER the workspace commit
+        expect(commits[0].activeAtCommit).toBe('topo-1');
+        expect(store.collection.activeLayoutId).toBe('topo-1');
+
+        store.destroy()
+    });
+
+    test('a TOPOLOGY record without the atomic holder seam refuses — never the window seam, never a partial commit, store pointer unmoved', async () => {
+        const captured = Persistence.captureTopologyPerspective([doc(), doc2()], {
+                  layoutId: 'topo-2', perspectiveName: 'Spread', title: 'Spread'
+              }).layout,
+              windowed = Persistence.capturePerspective(doc(), {layoutId: 'w-9', perspectiveName: 'Decoy', title: 'Decoy'}).layout,
+              store    = Neo.create(PerspectiveLibrary, {});
+
+        expect(store.savePerspective(windowed).saved).toBe(true);              // active: w-9
+        expect(store.savePerspective(captured, {activate: false}).saved).toBe(true);
+
+        const activations = [],
+              liveDocs    = [docRearranged(), doc2()],
+              before      = JSON.stringify(liveDocs),
+              holder      = {
+                  id              : 'zone-15',
+                  dockZoneDocument: liveDocs[0],
+                  perspectiveStore: store,
+                  // a window switch seam EXISTS — a topology record must still never ride it
+                  activatePerspective(name) { activations.push(name); return {errors: [], switched: true} },
+                  getDockTopologyDocuments: () => liveDocs
+                  // no commitDockTopologyDocuments: the atomic seam is missing
+              };
+
+        Neo.getComponent = () => holder;
+
+        const result = await service.restorePerspective({componentId: 'zone-15', name: 'Spread'});
+
+        expect(result.switched).toBe(false);
+        expect(result.captureScope).toBe('topology');
+        expect(result.errors[0]).toContain('commitDockTopologyDocuments');
+        expect(activations).toEqual([]);
+        expect(JSON.stringify(liveDocs)).toBe(before);
+        // the store's active pointer never moved off the decoy
+        expect(store.collection.activeLayoutId).toBe('w-9');
+
+        store.destroy()
+    });
+
+    test('a refused topology reconciliation fails byte-identical: no document commits, no store state advances', async () => {
+        // a corrupt record can only enter through a non-validating surface — the tool must
+        // still fail the ENTIRE restore closed on the reconciler's own validation
+        const corrupt = {
+                  schema         : 'neo.harness.dockLayout.v2',
+                  layoutId       : 'topo-bad',
+                  title          : 'Bad',
+                  captureScope   : 'topology',
+                  dockZone       : doc(),
+                  windowDocuments: 'nonsense'
+              },
+              loads    = [],
+              commits  = [],
+              liveDocs = [doc(), doc2()],
+              before   = JSON.stringify(liveDocs),
+              holder   = {
+                  id                      : 'zone-16',
+                  dockZoneDocument        : liveDocs[0],
+                  getDockTopologyDocuments: () => liveDocs,
+                  commitDockTopologyDocuments(documents) { commits.push(documents) },
+                  perspectiveStore        : {
+                      getPerspective : () => ({layout: corrupt, layoutId: 'topo-bad'}),
+                      loadPerspective: name => { loads.push(name); return {document: null, errors: [], layout: null} }
+                  }
+              };
+
+        Neo.getComponent = () => holder;
+
+        const result = await service.restorePerspective({componentId: 'zone-16', name: 'Bad'});
+
+        expect(result.switched).toBe(false);
+        expect(result.captureScope).toBe('topology');
+        expect(result.errors.length).toBeGreaterThan(0);
+        expect(result.unrestored.length).toBeGreaterThan(0);
+        expect(commits).toEqual([]);
+        expect(loads).toEqual([]);
+        expect(JSON.stringify(liveDocs)).toBe(before)
+    });
+});

--- a/test/playwright/unit/ai/client/InstanceService.spec.mjs
+++ b/test/playwright/unit/ai/client/InstanceService.spec.mjs
@@ -1,0 +1,76 @@
+import {test, expect}  from '@playwright/test';
+import Neo             from '../../../../../src/Neo.mjs';
+import * as core       from '../../../../../src/core/_export.mjs';
+import InstanceManager from '../../../../../src/manager/Instance.mjs';
+import InstanceService from '../../../../../src/ai/client/InstanceService.mjs';
+
+/**
+ * @summary The property-read serialization contract: a Neo-instance-valued property collapses to
+ * its identity snapshot, and that collapse must be MACHINE-DISTINGUISHABLE from a genuinely small
+ * value — a silently-truncated deep read produces confident false negatives in exactly the
+ * whitebox probes the wire exists for.
+ */
+test.describe.serial('Neo.ai.client.Service.safeSerialize — truncation visibility', () => {
+    let service;
+
+    test.beforeAll(() => {
+        // client services are per-Client instances (Neo.create'd by Neo.ai.Client), never singletons
+        service = Neo.create(InstanceService, {});
+    });
+
+    test.afterAll(() => {
+        service.destroy();
+    });
+
+    test('a Neo instance collapses to its toJSON snapshot WITH the truncation marker', () => {
+        const instance   = Neo.create(core.Base, {});
+        const serialized = service.safeSerialize(instance);
+
+        expect(serialized.__truncated).toBe('neo-instance-snapshot');
+        // the snapshot's own identity fields survive alongside the marker
+        expect(serialized.className).toBe('Neo.core.Base');
+        expect(serialized.id).toBe(instance.id);
+
+        instance.destroy();
+    });
+
+    test('a genuinely small plain object serializes in full and carries NO marker', () => {
+        const serialized = service.safeSerialize({state: 'OPEN', count: 3, nested: {deep: true}});
+
+        expect(serialized).toEqual({state: 'OPEN', count: 3, nested: {deep: true}});
+        expect(serialized.__truncated).toBeUndefined();
+    });
+
+    test('instances NESTED inside objects and arrays are marked at each collapse point', () => {
+        const instance   = Neo.create(core.Base, {});
+        const serialized = service.safeSerialize({
+            plain: 1,
+            ref  : instance,
+            list : [instance, {ok: true}]
+        });
+
+        expect(serialized.plain).toBe(1);
+        expect(serialized.ref.__truncated).toBe('neo-instance-snapshot');
+        expect(serialized.list[0].__truncated).toBe('neo-instance-snapshot');
+        expect(serialized.list[1]).toEqual({ok: true});
+        expect(serialized.list[1].__truncated).toBeUndefined();
+
+        instance.destroy();
+    });
+
+    test('getInstanceProperties surfaces the marker end-to-end for an instance-valued property', () => {
+        const holder = Neo.create(core.Base, {});
+        const child  = Neo.create(core.Base, {});
+
+        // an instance-valued property on a registered instance — the vnode-read shape
+        holder.probeTarget = child;
+
+        const {properties} = service.getInstanceProperties({id: holder.id, properties: ['probeTarget']});
+
+        expect(properties.probeTarget.__truncated).toBe('neo-instance-snapshot');
+        expect(properties.probeTarget.id).toBe(child.id);
+
+        child.destroy();
+        holder.destroy();
+    });
+});

--- a/test/playwright/unit/ai/client/RuntimeService.spec.mjs
+++ b/test/playwright/unit/ai/client/RuntimeService.spec.mjs
@@ -1,0 +1,271 @@
+import {setup} from '../../../setup.mjs';
+
+setup({
+    neoConfig: {
+        unitTestMode: true
+    },
+    appConfig: {
+        name             : 'ClientRuntimeServiceWindowOpsTest',
+        isMounted        : () => true,
+        vnodeInitialising: false
+    }
+});
+
+import {test, expect} from '@playwright/test';
+import Neo            from '../../../../../src/Neo.mjs';
+import * as core      from '../../../../../src/core/_export.mjs';
+import RuntimeService from '../../../../../src/ai/client/RuntimeService.mjs';
+
+test.describe('Neo.ai.client.RuntimeService window ops (#13446)', () => {
+    let originalGetComponent, originalMain, originalWindowManager, service;
+
+    test.beforeEach(() => {
+        originalGetComponent  = Neo.getComponent;
+        originalMain          = Neo.Main;
+        originalWindowManager = Neo.manager.Window;
+        service               = Neo.create(RuntimeService);
+    });
+
+    test.afterEach(() => {
+        Neo.getComponent    = originalGetComponent;
+        Neo.Main            = originalMain;
+        Neo.manager.Window  = originalWindowManager;
+
+        service.destroy()
+    });
+
+    test('opens a known dashboard widget in a popup', async () => {
+        let captured;
+
+        const dashboard = {
+            id               : 'dashboard-a',
+            openWidgetInPopup: async (widget, rect) => {
+                captured = {widget, rect};
+
+                return {
+                    popupHeight: rect.height - 50,
+                    popupLeft  : rect.x + 100,
+                    popupTop   : rect.y + 200,
+                    popupWidth : rect.width,
+                    windowName : widget.id
+                }
+            }
+        };
+
+        const component = {
+            id        : 'widget-a',
+            parent    : dashboard,
+            getDomRect: async () => ({height: 260, width: 420, x: 12, y: 34})
+        };
+
+        Neo.getComponent = id => id === 'widget-a' ? component : null;
+
+        const result = await service.openComponentWindow({componentId: 'widget-a'});
+
+        expect(captured).toEqual({
+            widget: component,
+            rect  : {height: 260, width: 420, x: 12, y: 34}
+        });
+        expect(result).toEqual({
+            success    : true,
+            componentId: 'widget-a',
+            dashboardId: 'dashboard-a',
+            popupHeight: 210,
+            popupLeft  : 112,
+            popupTop   : 234,
+            popupWidth : 420,
+            windowName : 'widget-a'
+        })
+    });
+
+    test('fails loud when the component or dashboard popup host is unknown', async () => {
+        Neo.getComponent = id => id === 'widget-a' ? {id, parent: null} : null;
+
+        await expect(service.openComponentWindow({componentId: 'missing'})).resolves.toEqual({
+            success: false,
+            error  : "Unknown componentId 'missing'."
+        });
+
+        await expect(service.openComponentWindow({componentId: 'widget-a'})).resolves.toEqual({
+            success: false,
+            error  : "Component 'widget-a' is not inside a dashboard host that can open popups."
+        })
+    });
+
+    test('positions and focuses known native popup routes', async () => {
+        const calls = [];
+
+        Neo.manager.Window = {
+            get: id => id === 'win-a' ? {
+                id,
+                nativeRoute: {
+                    capabilities   : {close: true, focus: true, position: true},
+                    nativeHandleKey: 'handle-a',
+                    ownerWindowId  : 'owner-a',
+                    targetWindowId : 'win-a'
+                }
+            } : null
+        };
+
+        Neo.Main = {
+            windowNativeFocus: async data => {
+                calls.push({type: 'focus', data});
+                return true
+            },
+            windowNativeMoveTo: async data => {
+                calls.push({type: 'move', data});
+                return true
+            }
+        };
+
+        await expect(service.positionWindow({
+            nativeHandleKey: 'caller-forged-handle',
+            ownerWindowId  : 'caller-forged-owner',
+            targetWindowId : 'caller-forged-target',
+            windowId       : 'win-a',
+            x              : 100,
+            y              : 200
+        })).resolves.toEqual({
+            success : true,
+            windowId: 'win-a',
+            x       : 100,
+            y       : 200
+        });
+        await expect(service.focusWindow({windowId: 'win-a'})).resolves.toEqual({success: true, windowId: 'win-a'});
+        expect(calls).toEqual([
+            {
+                type: 'move',
+                data: {
+                    nativeHandleKey: 'handle-a',
+                    targetWindowId : 'win-a',
+                    windowId       : 'owner-a',
+                    x              : 100,
+                    y              : 200
+                }
+            },
+            {
+                type: 'focus',
+                data: {nativeHandleKey: 'handle-a', targetWindowId: 'win-a', windowId: 'owner-a'}
+            }
+        ])
+    });
+
+    test('closes the native popup and requires terminal topology disappearance', async () => {
+        const calls     = [];
+        let   connected = true;
+
+        Neo.manager.Window = {
+            get: id => id === 'win-a' && connected ? {
+                id,
+                nativeRoute: {
+                    capabilities   : {close: true, focus: true, position: true},
+                    nativeHandleKey: 'handle-a',
+                    ownerWindowId  : 'owner-a',
+                    targetWindowId : 'win-a'
+                }
+            } : null
+        };
+        Neo.Main = {
+            windowNativeClose: async data => {
+                calls.push(data);
+                connected = false;
+                return true
+            }
+        };
+
+        await expect(service.closeWindow({windowId: 'win-a'})).resolves.toEqual({
+            success : true,
+            windowId: 'win-a'
+        });
+        expect(calls).toEqual([{
+            nativeHandleKey: 'handle-a',
+            targetWindowId : 'win-a',
+            windowId       : 'owner-a'
+        }])
+    });
+
+    test('reports platform-blocked native outcomes instead of manufacturing success', async () => {
+        Neo.manager.Window = {
+            get: id => id === 'win-a' ? {
+                id,
+                nativeRoute: {
+                    capabilities   : {close: true, focus: true, position: true},
+                    nativeHandleKey: 'handle-a',
+                    ownerWindowId  : 'owner-a',
+                    targetWindowId : 'win-a'
+                }
+            } : null
+        };
+        Neo.Main = {
+            windowNativeFocus : async () => false,
+            windowNativeMoveTo: async () => false
+        };
+
+        await expect(service.positionWindow({windowId: 'win-a', x: 1, y: 2})).resolves.toEqual({
+            success: false,
+            blocked: true,
+            error  : "Window 'win-a' did not reach the requested position."
+        });
+        await expect(service.focusWindow({windowId: 'win-a'})).resolves.toEqual({
+            success: false,
+            blocked: true,
+            error  : "Window 'win-a' did not accept focus."
+        })
+    });
+
+    test('keeps physical close unsupported when the semantic owner did not grant it', async () => {
+        let closeCalled = false;
+
+        Neo.manager.Window = {
+            get: id => id === 'win-a' ? {
+                id,
+                nativeRoute: {
+                    capabilities   : {close: false, focus: true, position: true},
+                    nativeHandleKey: 'handle-a',
+                    ownerWindowId  : 'owner-a',
+                    targetWindowId : 'win-a'
+                }
+            } : null
+        };
+        Neo.Main = {
+            windowNativeClose: async () => {
+                closeCalled = true;
+                return true
+            }
+        };
+
+        await expect(service.closeWindow({windowId: 'win-a'})).resolves.toEqual({
+            success    : false,
+            unsupported: true,
+            error      : "Window 'win-a' cannot be closed by this runtime."
+        });
+        expect(closeCalled).toBe(false)
+    });
+
+    test('fails loud for unknown or unsupported window routes', async () => {
+        Neo.manager.Window = {
+            get: id => id === 'win-a' ? {id, nativeRoute: null} : null
+        };
+        Neo.Main = {};
+
+        await expect(service.positionWindow({windowId: 'missing', x: 1, y: 2})).resolves.toEqual({
+            success: false,
+            error  : "Unknown windowId 'missing'."
+        });
+        await expect(service.positionWindow({windowId: 'win-a', x: 1, y: 2})).resolves.toEqual({
+            success    : false,
+            unsupported: true,
+            error      : "Window 'win-a' cannot be positioned by this runtime."
+        });
+        await expect(service.focusWindow({windowId: 'win-a'})).resolves.toEqual({
+            success    : false,
+            unsupported: true,
+            error      : "Window 'win-a' cannot be focused by this runtime."
+        });
+        await expect(service.closeWindow({windowId: 'win-a'})).resolves.toEqual({
+            success    : false,
+            unsupported: true,
+            error      : "Window 'win-a' cannot be closed by this runtime."
+        })
+    });
+});

--- a/test/playwright/unit/ai/client/TourRunner.spec.mjs
+++ b/test/playwright/unit/ai/client/TourRunner.spec.mjs
@@ -20,7 +20,7 @@ import {
  */
 function doc() {
     return {
-        schema: 'neo.harness.dockZone.v1',
+        schema: 'neo.dock.zone.v1',
         root  : 'root',
         items : {
             strategy: {componentRef: 'strategy', title: 'Strategy', kind: 'panel'},
@@ -28,7 +28,7 @@ function doc() {
             terminal: {componentRef: 'terminal', title: 'Terminal', kind: 'terminal'}
         },
         nodes: {
-            root        : {type: 'edge-zone', zones: {center: 'main-split'}},
+            root        : {type: 'edge-zone', zones: {center: {nodeId: 'main-split'}}},
             'main-split': {type: 'split', orientation: 'horizontal', children: ['main-tabs', 'side-tabs'], sizes: [0.5, 0.5]},
             'main-tabs' : {type: 'tabs', items: ['strategy', 'swarm'], activeItemId: 'strategy'},
             'side-tabs' : {type: 'tabs', items: ['terminal'], activeItemId: 'terminal'}

--- a/test/playwright/unit/ai/client/TourRunner.spec.mjs
+++ b/test/playwright/unit/ai/client/TourRunner.spec.mjs
@@ -1,0 +1,889 @@
+import {test, expect} from '@playwright/test';
+import Neo            from '../../../../../src/Neo.mjs';
+import * as core      from '../../../../../src/core/_export.mjs';
+import DockService    from '../../../../../src/ai/client/DockService.mjs';
+import Operations     from '../../../../../src/dashboard/dock/model/Operations.mjs';
+import TourRunner     from '../../../../../src/ai/client/TourRunner.mjs';
+
+import {
+    RESERVED_STEP_TYPES, STEP_TYPES, TOUR_SCRIPT_SCHEMA, evaluateExpectations, validateTourScript
+} from '../../../../../src/ai/client/tourScript.mjs';
+
+/**
+ * @summary Creates a valid dockZone.v1 fixture the real reducers accept.
+ *
+ * Shape parity note: mirrors the committed `examples/dashboard/dock` workspace class
+ * (edge-zone root, one horizontal split, two tabs nodes) so the unit smoke and the live
+ * example exercise the same document topology; the live-page replay belongs to the
+ * whitebox-e2e tier.
+ * @returns {Object}
+ */
+function doc() {
+    return {
+        schema: 'neo.harness.dockZone.v1',
+        root  : 'root',
+        items : {
+            strategy: {componentRef: 'strategy', title: 'Strategy', kind: 'panel'},
+            swarm   : {componentRef: 'swarm',    title: 'Swarm',    kind: 'panel'},
+            terminal: {componentRef: 'terminal', title: 'Terminal', kind: 'terminal'}
+        },
+        nodes: {
+            root        : {type: 'edge-zone', zones: {center: 'main-split'}},
+            'main-split': {type: 'split', orientation: 'horizontal', children: ['main-tabs', 'side-tabs'], sizes: [0.5, 0.5]},
+            'main-tabs' : {type: 'tabs', items: ['strategy', 'swarm'], activeItemId: 'strategy'},
+            'side-tabs' : {type: 'tabs', items: ['terminal'], activeItemId: 'terminal'}
+        }
+    }
+}
+
+/**
+ * @summary The canonical reducer smoke script: two real semantic operations plus a topology
+ * assert and a (tiny) pause. The conditionally executable cross-window type has its own host
+ * suite below; every reducer-owned type remains predictable against one document.
+ * @returns {Object}
+ */
+function smokeScript() {
+    return {
+        schema: TOUR_SCRIPT_SCHEMA,
+        id    : 'unit-smoke',
+        title : 'Unit smoke tour',
+        scenes: [{
+            id     : 's1',
+            title  : 'Auto-hide + resize',
+            caption: 'field flip, viewer beat, splitter settle',
+            steps  : [
+                {
+                    type      : 'op',
+                    caption   : 'terminal tucks away',
+                    descriptor: {operation: 'setItemAutoHidden', itemId: 'terminal', autoHidden: true},
+                    expect    : [{path: 'items.terminal.autoHidden', equals: true}]
+                },
+                {type: 'pause', ms: 1, caption: 'viewer beat'},
+                {
+                    type      : 'op',
+                    caption   : 'main split settles 70/30',
+                    descriptor: {operation: 'resizeSplit', splitNodeId: 'main-split', sizes: [0.7, 0.3]},
+                    expect    : [{path: 'nodes.main-split.sizes', equals: [0.7, 0.3]}]
+                },
+                {
+                    type  : 'topology-assert',
+                    expect: [
+                        {path: 'items.terminal.autoHidden', equals: true},
+                        {path: 'nodes.main-split.sizes.0',  equals: 0.7}
+                    ]
+                },
+                {
+                    type      : 'op',
+                    caption   : 'the wave rolls back',
+                    descriptor: {operation: 'setItemAutoHidden', itemId: 'terminal', autoHidden: false},
+                    expect    : [{path: 'items.terminal.autoHidden', equals: false}]
+                }
+            ]
+        }]
+    }
+}
+
+/**
+ * @summary One semantic cross-window step with no runtime window, DOM or geometry data.
+ * @returns {Object}
+ */
+function crossWindowScript() {
+    return {
+        schema: TOUR_SCRIPT_SCHEMA,
+        id    : 'unit-cross-window',
+        title : 'Unit cross-window tour',
+        scenes: [{
+            id   : 'cross',
+            title: 'Cross-window',
+            steps: [{
+                type             : 'cross-window',
+                caption          : 'move the live workbench',
+                itemId           : 'workbench',
+                sourceWorkspaceId: 'demo-b-main',
+                targetWorkspaceId: 'demo-b-popup',
+                targetNodeId     : 'popup-tabs'
+            }]
+        }]
+    }
+}
+
+/**
+ * @summary A successful host receipt. Runtime witness values are deliberately configurable
+ * so determinism tests can prove they never leak into TourRunner.log.
+ * @param {Object} options
+ * @returns {Object}
+ */
+function crossWindowReceipt({instanceId = 'neo-component-runtime-1', mountCount = 1} = {}) {
+    return {
+        applied       : true,
+        errors        : [],
+        sourceDocument: {schema: 'source.v1'},
+        targetDocument: {schema: 'target.v1'},
+        witness       : {instanceId, mountCount}
+    }
+}
+
+/**
+ * @summary Wires a fresh document holder into `Neo.getComponent` and returns it. The holder
+ * follows the plain-field commit path: the service writes each post-op document back onto
+ * `dockZoneDocument`, so the document advances across steps exactly like a live workspace.
+ * @returns {Object}
+ */
+function createHolder() {
+    const holder = {dockZoneDocument: doc(), id: 'tour-zone-1'};
+
+    Neo.getComponent = () => holder;
+
+    return holder
+}
+
+test.describe.serial('Neo.ai.client.TourRunner', () => {
+    let originalGetComponent, runner, service;
+
+    test.beforeEach(() => {
+        originalGetComponent = Neo.getComponent;
+        service              = Neo.create(DockService, {})
+    });
+
+    test.afterEach(() => {
+        Neo.getComponent = originalGetComponent;
+        runner?.destroy?.();
+        runner = null;
+        service.destroy?.()
+    });
+
+    /**
+     * Creates a runner against a fresh holder with the shared defaults.
+     * @param {Object} config
+     * @returns {Neo.ai.client.TourRunner}
+     */
+    function createRunner(config = {}) {
+        createHolder();
+
+        runner = Neo.create(TourRunner, {
+            componentId: 'tour-zone-1',
+            dockService: service,
+            mode       : 'spec',
+            script     : smokeScript(),
+            ...config
+        });
+
+        return runner
+    }
+
+    test.describe('tourScript validator (fail-closed)', () => {
+        const operations = Operations.operations;
+
+        test('the smoke script validates against the real executor vocabulary', () => {
+            const result = validateTourScript(smokeScript(), {operations});
+
+            expect(result.errors).toEqual([]);
+            expect(result.valid).toBe(true)
+        });
+
+        test('unknown step types are rejected with the vocabulary enumerated', () => {
+            const script = smokeScript();
+
+            script.scenes[0].steps.push({type: 'teleport'});
+
+            const {valid, errors} = validateTourScript(script, {operations});
+
+            expect(valid).toBe(false);
+            expect(errors.join('\n')).toContain(`unknown 'teleport'. The v1 vocabulary is: ${STEP_TYPES.join(', ')}`)
+        });
+
+        test('future reserved step types are rejected as reserved, not unknown', () => {
+            RESERVED_STEP_TYPES.forEach(type => {
+                const script = smokeScript();
+
+                script.scenes[0].steps.push({type});
+
+                const {valid, errors} = validateTourScript(script, {operations});
+
+                expect(valid).toBe(false);
+                expect(errors.join('\n')).toContain(`'${type}' is reserved`)
+            })
+        });
+
+        test('cross-window remains reserved without a compatible host executor', () => {
+            const {valid, errors} = validateTourScript(crossWindowScript(), {operations});
+
+            expect(valid).toBe(false);
+            expect(errors.join('\n')).toContain("'cross-window' remains reserved")
+        });
+
+        test('cross-window validates only its four semantic ids when a host is available', () => {
+            const valid = validateTourScript(crossWindowScript(), {
+                crossWindowAvailable: true,
+                operations
+            });
+
+            expect(valid).toEqual({errors: [], valid: true});
+
+            const missing = crossWindowScript();
+
+            missing.scenes[0].steps[0].itemId = '';
+
+            const sameWorkspace = crossWindowScript();
+
+            sameWorkspace.scenes[0].steps[0].targetWorkspaceId = 'demo-b-main';
+
+            const runtimeLeak = crossWindowScript();
+
+            runtimeLeak.scenes[0].steps[0].screenX = 720;
+
+            expect(validateTourScript(missing, {crossWindowAvailable: true, operations}).errors.join('\n'))
+                .toContain('itemId: required non-empty semantic id string');
+            expect(validateTourScript(sameWorkspace, {crossWindowAvailable: true, operations}).errors.join('\n'))
+                .toContain('must identify different workspaces');
+            expect(validateTourScript(runtimeLeak, {crossWindowAvailable: true, operations}).errors.join('\n'))
+                .toContain('screenX: cross-window steps accept semantic ids only')
+        });
+
+        test('unknown operations are rejected with the executable vocabulary enumerated', () => {
+            const script = smokeScript();
+
+            script.scenes[0].steps[0].descriptor.operation = 'teleportItem';
+
+            const {valid, errors} = validateTourScript(script, {operations});
+
+            expect(valid).toBe(false);
+            expect(errors.join('\n')).toContain(`unknown 'teleportItem'. The executable vocabulary is: ${operations.join(', ')}`)
+        });
+
+        test('function values violate the JSON-first contract', () => {
+            const script = smokeScript();
+
+            script.scenes[0].steps[0].onRun = () => {};
+
+            const {valid, errors} = validateTourScript(script, {operations});
+
+            expect(valid).toBe(false);
+            expect(errors.join('\n')).toContain('function values violate the JSON-first contract')
+        });
+
+        test('a pause without a valid ms is rejected', () => {
+            const script = smokeScript();
+
+            script.scenes[0].steps[1].ms = -5;
+
+            expect(validateTourScript(script, {operations}).valid).toBe(false)
+        });
+
+        test('a topology-assert without predicates is rejected', () => {
+            const script = smokeScript();
+
+            delete script.scenes[0].steps[3].expect;
+
+            const {valid, errors} = validateTourScript(script, {operations});
+
+            expect(valid).toBe(false);
+            expect(errors.join('\n')).toContain('requires at least one {path, equals} predicate')
+        });
+
+        test('non-finite numbers, sparse arrays and cycles are rejected — JSON-first is round-trip-checked', () => {
+            const nonFinite = smokeScript();
+
+            nonFinite.scenes[0].steps[1].ms = NaN;
+            expect(validateTourScript(nonFinite, {operations}).errors.join('\n')).toContain('non-finite number');
+
+            const sparse = smokeScript();
+
+            sparse.scenes[0].steps[0].expect = [{path: 'items', equals: ['a', , 'c']}]; // eslint-disable-line no-sparse-arrays
+            expect(validateTourScript(sparse, {operations}).errors.join('\n')).toContain('sparse array');
+
+            const cyclic = smokeScript();
+
+            cyclic.scenes[0].loop = cyclic.scenes[0]; // a cycle must reject, never overflow the stack
+            expect(validateTourScript(cyclic, {operations}).errors.join('\n')).toContain('cyclic reference');
+
+            // the equalization bypass: a hole masked by a non-index own property must still reject
+            const masked = smokeScript(), arr = ['a', , 'c']; // eslint-disable-line no-sparse-arrays
+
+            arr.note = 'equalizer';
+            masked.scenes[0].steps[0].expect = [{path: 'items', equals: arr}];
+
+            const maskedErrors = validateTourScript(masked, {operations}).errors.join('\n');
+
+            expect(maskedErrors).toContain('sparse array');
+            expect(maskedErrors).toContain('non-index own properties')
+        });
+
+        test('descriptor-complete rejection: symbols, hidden toJSON, throwing getters — the serialization-blind spots', () => {
+            // symbol-keyed own property: validates as invisible, disappears on the wire
+            const withSymbol = smokeScript();
+
+            withSymbol.scenes[0].steps[0].descriptor[Symbol('ghost')] = 1;
+            expect(validateTourScript(withSymbol, {operations}).errors.join('\n')).toContain('symbol-keyed own properties');
+
+            // hidden non-enumerable toJSON: would silently rewrite the serialized payload
+            const withToJSON = smokeScript();
+
+            Object.defineProperty(withToJSON.scenes[0].steps[0].descriptor, 'toJSON', {
+                enumerable: false,
+                value     : () => ({operation: 'closeItem', itemId: 'editor'})
+            });
+            expect(validateTourScript(withToJSON, {operations}).errors.join('\n')).toContain('toJSON would silently REWRITE');
+
+            // enumerable throwing getter: must surface as a structured error, never a raw exception
+            const withGetter = smokeScript();
+
+            Object.defineProperty(withGetter.scenes[0].steps[0].descriptor, 'trap', {
+                enumerable: true,
+                get() { throw new Error('boom') }
+            });
+
+            const getterResult = validateTourScript(withGetter, {operations});
+
+            expect(getterResult.valid).toBe(false);
+            expect(getterResult.errors.join('\n')).toContain('accessor property');
+
+            // non-enumerable EXTRA on an array: own-name accounting catches what keys-count missed
+            const withHiddenExtra = smokeScript(), arr = ['a', 'b'];
+
+            Object.defineProperty(arr, 'stash', {enumerable: false, value: 1});
+            withHiddenExtra.scenes[0].steps[0].expect = [{path: 'items', equals: arr}];
+            expect(validateTourScript(withHiddenExtra, {operations}).errors.join('\n')).toContain('non-index own properties')
+        });
+
+        test('a wrong schema tag is rejected fail-closed', () => {
+            const script = smokeScript();
+
+            script.schema = 'neo.tour.script.v2';
+
+            expect(validateTourScript(script, {operations}).valid).toBe(false)
+        });
+
+        test('evaluateExpectations reports path-level mismatches with actual values', () => {
+            const {passed, failures} = evaluateExpectations(
+                [{path: 'nodes.main-split.sizes.0', equals: 0.9}],
+                doc()
+            );
+
+            expect(passed).toBe(false);
+            expect(failures).toEqual([{actual: 0.5, expected: 0.9, path: 'nodes.main-split.sizes.0'}])
+        });
+
+        test('number predicates absorb IEEE float noise but still fail real differences', () => {
+            const document = {sizes: [0.7, 1 - 0.7]}; // 0.30000000000000004 — the normalized-reducer reality
+
+            expect(evaluateExpectations([{path: 'sizes.1', equals: 0.3}], document).passed).toBe(true);
+            expect(evaluateExpectations([{path: 'sizes.1', equals: 0.31}], document).passed).toBe(false);
+
+            // explicit per-predicate tolerance for authors who need coarser matching
+            expect(evaluateExpectations([{path: 'sizes.1', equals: 0.31, epsilon: 0.02}], document).passed).toBe(true);
+
+            // and the validator rejects a malformed epsilon fail-closed
+            const script = smokeScript();
+
+            script.scenes[0].steps[3].expect[0].epsilon = -1;
+
+            const {valid, errors} = validateTourScript(script, {operations});
+
+            expect(valid).toBe(false);
+            expect(errors.join('\n')).toContain('epsilon: must be a finite number >= 0')
+        });
+    });
+
+    test.describe('runner preflight (structured refusals)', () => {
+        test('a missing dock service aborts with a structured error, never a throw', async () => {
+            createRunner({dockService: null});
+
+            const result = await runner.start();
+
+            expect(result.completed).toBe(false);
+            expect(result.errors.join('\n')).toContain('dockService: required')
+        });
+
+        test('record mode refuses to start unless reducedMotion was probed false', async () => {
+            createRunner({mode: 'record'});
+
+            const result = await runner.start();
+
+            expect(result.completed).toBe(false);
+            expect(result.errors.join('\n')).toContain('record mode requires reducedMotion === false');
+
+            runner.destroy();
+            createRunner({mode: 'record', reducedMotion: false});
+
+            const ok = await runner.start();
+
+            expect(ok.errors).toEqual([]);
+            expect(ok.completed).toBe(true)
+        });
+
+        test('an invalid script surfaces the validator errors', async () => {
+            const script = smokeScript();
+
+            script.scenes[0].steps[0].descriptor.operation = 'teleportItem';
+            createRunner({script});
+
+            const result = await runner.start();
+
+            expect(result.completed).toBe(false);
+            expect(result.errors.join('\n')).toContain("unknown 'teleportItem'")
+        });
+
+        test('a malformed host settlement boundary is refused before dispatch', async () => {
+            createRunner({stepSettlement: {}});
+
+            const result = await runner.start();
+
+            expect(result.completed).toBe(false);
+            expect(result.errors.join('\n')).toContain('stepSettlement: must be a Function or null')
+        });
+
+        test('cross-window refuses an absent or incompatible executor before dispatch', async () => {
+            createRunner({script: crossWindowScript()});
+
+            let result = await runner.start();
+
+            expect(result.completed).toBe(false);
+            expect(result.errors.join('\n')).toContain("'cross-window' remains reserved");
+
+            runner.destroy();
+            createRunner({crossWindowExecutor: {}, script: crossWindowScript()});
+
+            result = await runner.start();
+
+            expect(result.completed).toBe(false);
+            expect(result.errors.join('\n')).toContain("'cross-window' remains reserved")
+        });
+    });
+
+    test.describe('execution against the real reducers', () => {
+        test('the smoke tour completes: documents advance, events fire in order', async () => {
+            const events = [], settledEvents = [];
+
+            createRunner();
+
+            const holder = Neo.getComponent('tour-zone-1');
+
+            runner.on({
+                beat       : data => events.push(`beat:${data.stepIndex}:${data.stepType}`),
+                complete   : () => events.push('complete'),
+                scene      : data => events.push(`scene:${data.sceneId}`),
+                stepSettled: data => {
+                    settledEvents.push(data);
+                    events.push(`settled:${data.stepIndex}:${data.stepType}:log-${runner.log.length}`)
+                }
+            });
+
+            const result = await runner.start();
+
+            expect(result.completed).toBe(true);
+            expect(result.errors).toEqual([]);
+
+            // the holder's committed document advanced through the real commit path
+            // (close-to, not exact: the reducer normalizes split sizes to sum 1, so IEEE noise is inherent)
+            const {sizes} = holder.dockZoneDocument.nodes['main-split'];
+
+            expect(sizes[0]).toBeCloseTo(0.7, 9);
+            expect(sizes[1]).toBeCloseTo(0.3, 9);
+            expect(holder.dockZoneDocument.items.terminal.autoHidden).toBe(false);
+
+            expect(events).toEqual([
+                'scene:s1',
+                'beat:0:op',              'settled:0:op:log-1',
+                'beat:1:pause',           'settled:1:pause:log-2',
+                'beat:2:op',              'settled:2:op:log-3',
+                'beat:3:topology-assert', 'settled:3:topology-assert:log-4',
+                'beat:4:op',              'settled:4:op:log-5',
+                'complete'
+            ]);
+            expect(settledEvents).toEqual([
+                {completedCount: 1, logLength: 1, sceneId: 's1', sceneIndex: 0, source: runner.id, stepIndex: 0, stepType: 'op'},
+                {completedCount: 2, logLength: 2, sceneId: 's1', sceneIndex: 0, source: runner.id, stepIndex: 1, stepType: 'pause'},
+                {completedCount: 3, logLength: 3, sceneId: 's1', sceneIndex: 0, source: runner.id, stepIndex: 2, stepType: 'op'},
+                {completedCount: 4, logLength: 4, sceneId: 's1', sceneIndex: 0, source: runner.id, stepIndex: 3, stepType: 'topology-assert'},
+                {completedCount: 5, logLength: 5, sceneId: 's1', sceneIndex: 0, source: runner.id, stepIndex: 4, stepType: 'op'}
+            ]);
+            expect(JSON.parse(JSON.stringify(settledEvents)), 'the payload is JSON-safe and timestamp-free')
+                .toEqual(settledEvents)
+        });
+
+        test('a paced pause settles only after its runner-owned wait', async () => {
+            const script = {
+                schema: TOUR_SCRIPT_SCHEMA,
+                id    : 'paced-pause',
+                title : 'Paced pause',
+                scenes: [{id: 'paced', title: 'Paced', steps: [{type: 'pause', ms: 7}]}]
+            };
+
+            createRunner({mode: 'demo', paceMultiplier: 2, script});
+
+            const events = [];
+
+            runner.timeout = async ms => events.push(`wait:${ms}`);
+            runner.on('stepSettled', data => events.push(`settled:${data.stepType}:${data.completedCount}`));
+
+            const result = await runner.start();
+
+            expect(result.completed).toBe(true);
+            expect(events).toEqual(['wait:14', 'settled:pause:1'])
+        });
+
+        test('an injected host settlement blocks the next beat without changing the replay log', async () => {
+            let release, enteredResolve;
+            const
+                entered = new Promise(resolve => enteredResolve = resolve),
+                events  = [];
+
+            createRunner({
+                stepSettlement(data) {
+                    events.push(`host:${data.stepIndex}:${data.stepType}:log-${data.logLength}`);
+
+                    if (data.stepIndex === 0) {
+                        enteredResolve();
+                        data.stepIndex = 99;
+                        return new Promise(resolve => release = resolve)
+                    }
+                }
+            });
+            runner.on({
+                beat       : data => events.push(`beat:${data.stepIndex}`),
+                stepSettled: data => events.push(`settled:${data.stepIndex}`)
+            });
+
+            const running = runner.start();
+
+            await entered;
+
+            expect(events).toEqual(['beat:0', 'host:0:op:log-1']);
+            expect(runner.log).toHaveLength(1);
+
+            release();
+
+            const result = await running;
+
+            expect(result.completed).toBe(true);
+            expect(events.slice(0, 4)).toEqual([
+                'beat:0',
+                'host:0:op:log-1',
+                'settled:0',
+                'beat:1'
+            ]);
+            expect(events).not.toContain('settled:99');
+            expect(events.filter(event => event.startsWith('host:'))).toEqual([
+                'host:0:op:log-1',
+                'host:1:pause:log-2',
+                'host:2:op:log-3',
+                'host:3:topology-assert:log-4',
+                'host:4:op:log-5'
+            ]);
+            expect(result.log).toHaveLength(smokeScript().scenes[0].steps.length)
+        });
+
+        test('destroying the runner rejects a pending host settlement without a late step event', async () => {
+            let release, enteredResolve;
+            const
+                entered = new Promise(resolve => enteredResolve = resolve),
+                settled = [];
+
+            createRunner({
+                stepSettlement() {
+                    enteredResolve();
+                    return new Promise(resolve => release = resolve)
+                }
+            });
+            runner.on('stepSettled', data => settled.push(data));
+
+            const running = runner.start();
+
+            await entered;
+            runner.destroy();
+
+            expect(await running).toEqual({
+                completed: false,
+                errors   : ['TourRunner destroyed mid-tour'],
+                log      : [expect.objectContaining({stepIndex: 0, type: 'op'})]
+            });
+            expect(settled).toEqual([]);
+
+            release();
+            await Promise.resolve();
+
+            expect(settled).toEqual([])
+        });
+
+        test('a rejected host settlement aborts structurally without a successful step event', async () => {
+            const settled = [];
+
+            createRunner({stepSettlement: async () => { throw new Error('surface vanished') }});
+            runner.on('stepSettled', data => settled.push(data));
+
+            const result = await runner.start();
+
+            expect(result.completed).toBe(false);
+            expect(result.errors.join('\n')).toContain('host step settlement failed: surface vanished');
+            expect(result.log).toHaveLength(1);
+            expect(settled).toEqual([])
+        });
+
+        test('cross-window awaits one host dispatch before settlement and logs semantics only', async () => {
+            let release;
+            const
+                calls    = [],
+                executor = {
+                    executeCrossWindowStep(step) {
+                        calls.push(step);
+                        return new Promise(resolve => release = resolve)
+                    }
+                },
+                settled = [];
+
+            createRunner({crossWindowExecutor: executor, script: crossWindowScript()});
+            runner.on('stepSettled', data => settled.push(data));
+
+            const running = runner.start();
+
+            await Promise.resolve();
+
+            expect(calls).toHaveLength(1);
+            expect(calls[0]).toEqual(crossWindowScript().scenes[0].steps[0]);
+            expect(calls[0]).not.toBe(runner.script.scenes[0].steps[0]);
+            expect(settled).toEqual([]);
+
+            release(crossWindowReceipt());
+
+            const result = await running;
+
+            expect(result.completed).toBe(true);
+            expect(settled).toHaveLength(1);
+            expect(result.log).toEqual([{
+                applied: true,
+                errors : [],
+                sceneId: 'cross',
+                step   : {
+                    itemId           : 'workbench',
+                    sourceWorkspaceId: 'demo-b-main',
+                    targetWorkspaceId: 'demo-b-popup',
+                    targetNodeId     : 'popup-tabs'
+                },
+                stepIndex: 0,
+                type     : 'cross-window'
+            }]);
+            expect(JSON.stringify(result.log)).not.toContain('neo-component-runtime-1');
+            expect(JSON.stringify(result.log)).not.toContain('mountCount')
+        });
+
+        test('destroying the runner settles a pending cross-window host without a late step event', async () => {
+            let release;
+            const settled = [];
+
+            createRunner({
+                crossWindowExecutor: {
+                    executeCrossWindowStep: () => new Promise(resolve => release = resolve)
+                },
+                script: crossWindowScript()
+            });
+            runner.on('stepSettled', data => settled.push(data));
+
+            const running = runner.start();
+
+            await Promise.resolve();
+            runner.destroy();
+
+            expect(await running).toEqual({
+                completed: false,
+                errors   : ['TourRunner destroyed mid-tour'],
+                log      : []
+            });
+            expect(settled).toEqual([]);
+
+            release(crossWindowReceipt());
+            await Promise.resolve();
+
+            expect(settled).toEqual([])
+        });
+
+        test('cross-window rejection, throw and malformed success abort structurally without settlement', async () => {
+            const run = async executeCrossWindowStep => {
+                const settled = [];
+
+                runner?.destroy?.();
+                createRunner({crossWindowExecutor: {executeCrossWindowStep}, script: crossWindowScript()});
+                runner.on('stepSettled', data => settled.push(data));
+
+                const result = await runner.start();
+
+                expect(result.completed).toBe(false);
+                expect(settled).toEqual([]);
+
+                return result
+            };
+
+            let result = await run(async () => ({applied: false, errors: ['target refused']}));
+
+            expect(result.errors.join('\n')).toContain('target refused');
+            expect(result.log).toHaveLength(1);
+
+            result = await run(async () => { throw new Error('host vanished') });
+
+            expect(result.errors.join('\n')).toContain('cross-window executor failure: host vanished');
+            expect(result.log).toEqual([]);
+
+            result = await run(async () => ({applied: true, errors: []}));
+
+            expect(result.errors.join('\n')).toContain('requires a plain sourceDocument');
+            expect(result.errors.join('\n')).toContain('requires witness');
+            expect(result.log).toEqual([])
+        });
+
+        test('changing runtime witnesses across runs cannot change the cross-window replay log', async () => {
+            let   run      = 0;
+            const executor = {
+                executeCrossWindowStep: async () => crossWindowReceipt({
+                    instanceId: `runtime-${++run}`,
+                    mountCount: run
+                })
+            };
+
+            createRunner({crossWindowExecutor: executor, script: crossWindowScript()});
+
+            const first  = await runner.start(),
+                  second = await runner.start();
+
+            expect(first.completed && second.completed).toBe(true);
+            expect(second.log).toEqual(first.log)
+        });
+
+        test('cross-window logs are mode-identical while the host receipt settles correctness', async () => {
+            const executor = {executeCrossWindowStep: async () => crossWindowReceipt()};
+            let   results  = [];
+
+            for (const mode of ['spec', 'demo', 'record']) {
+                runner?.destroy?.();
+                createRunner({
+                    crossWindowExecutor: executor,
+                    mode,
+                    reducedMotion      : mode === 'record' ? false : null,
+                    script             : crossWindowScript()
+                });
+
+                results.push(await runner.start())
+            }
+
+            results.forEach(result => {
+                expect(result.completed).toBe(true);
+                expect(result.errors).toEqual([]);
+                expect(result.log).toHaveLength(1);
+                expect(result.log[0].type).toBe('cross-window')
+            });
+
+            const logs = results.map(result => JSON.stringify(result.log));
+
+            expect(logs[1]).toBe(logs[0]);
+            expect(logs[2]).toBe(logs[0])
+        });
+
+        test('log entries carry the complete cloned descriptor — the log IS the replay wire format', async () => {
+            createRunner();
+
+            const result = await runner.start();
+
+            expect(result.completed).toBe(true);
+            expect(result.log[0].descriptor).toEqual({operation: 'setItemAutoHidden', itemId: 'terminal', autoHidden: true});
+            // a clone, never a live reference into the script
+            expect(result.log[0].descriptor).not.toBe(smokeScript().scenes[0].steps[0].descriptor);
+            expect(result.log[0].descriptor).not.toBe(runner.script.scenes[0].steps[0].descriptor)
+        });
+
+        test('a live-seam failure aborts structured — the runner never leaks a raw throw', async () => {
+            createRunner();
+            Neo.getComponent = () => null; // the holder disappears before the first op
+
+            const result = await runner.start();
+
+            expect(result.completed).toBe(false);
+            expect(result.errors.join('\n')).toContain('dock seam failure');
+            expect(result.errors.join('\n')).toContain('Component not found')
+        });
+
+        test('two consecutive runs produce identical operation logs (the determinism falsifier)', async () => {
+            createRunner();
+
+            const first = await runner.start();
+
+            expect(first.completed).toBe(true);
+
+            runner.destroy();
+            createRunner();
+
+            const second = await runner.start();
+
+            expect(second.completed).toBe(true);
+            expect(second.log).toEqual(first.log)
+        });
+
+        test('mode changes pace, never order: spec / demo / record logs are identical', async () => {
+            createRunner({mode: 'spec'});
+
+            const specRun = await runner.start();
+
+            runner.destroy();
+            createRunner({mode: 'demo', paceMultiplier: 0});
+
+            const demoRun = await runner.start();
+
+            runner.destroy();
+            createRunner({mode: 'record', reducedMotion: false});
+
+            const recordRun = await runner.start();
+
+            expect(specRun.completed && demoRun.completed && recordRun.completed).toBe(true);
+            expect(demoRun.log).toEqual(specRun.log);
+            expect(recordRun.log).toEqual(specRun.log)
+        });
+
+        test('a failed post-op expectation aborts with the path and both values', async () => {
+            const script = smokeScript();
+
+            script.scenes[0].steps[0].expect = [{path: 'items.terminal.autoHidden', equals: false}];
+            createRunner({script});
+
+            const errorEvents = [], settledEvents = [];
+
+            runner.on('error', data => errorEvents.push(data));
+            runner.on('stepSettled', data => settledEvents.push(data));
+
+            const result = await runner.start();
+
+            expect(result.completed).toBe(false);
+            expect(result.errors.join('\n')).toContain("expectation failed at 'items.terminal.autoHidden': expected false, got true");
+            expect(errorEvents).toHaveLength(1);
+            expect(settledEvents, 'failed expectations never emit a successful settlement').toEqual([]);
+
+            // the log keeps the entries up to and including the failed step — an honest partial record
+            expect(result.log).toHaveLength(1);
+            expect(result.log[0]).toMatchObject({applied: true, operation: 'setItemAutoHidden', type: 'op'})
+        });
+
+        test('an executor-rejected operation aborts with the structured executor errors', async () => {
+            const script = smokeScript();
+
+            script.scenes[0].steps[0].descriptor.itemId = 'ghost';
+            createRunner({script});
+
+            const settledEvents = [];
+
+            runner.on('stepSettled', data => settledEvents.push(data));
+
+            const result = await runner.start();
+
+            expect(result.completed).toBe(false);
+            expect(result.errors.join('\n')).toContain('rejected by the executor');
+            expect(result.errors.join('\n')).toContain('unknown item "ghost"');
+            expect(settledEvents, 'rejected operations never emit a successful settlement').toEqual([])
+        });
+
+        test('start() while running throws — a programming error, not a tour failure', async () => {
+            createRunner();
+
+            const running = runner.start();
+
+            await expect(runner.start()).rejects.toThrow('already running');
+            await running
+        });
+    });
+});

--- a/test/playwright/unit/ai/deriveSubtreePath.spec.mjs
+++ b/test/playwright/unit/ai/deriveSubtreePath.spec.mjs
@@ -1,0 +1,45 @@
+import {test, expect}      from '@playwright/test';
+import {deriveSubtreePath} from '../../../../src/ai/deriveSubtreePath.mjs';
+
+// Pure function — imported directly; no Neo globals, no setup, no host side-effects.
+test.describe('deriveSubtreePath (absolute root→node id path for NL lock enforcement)', () => {
+    // {childId: parentId} map → an injectable parentOf(id) lookup
+    const treeLookup = tree => id => tree[id];
+
+    test('derives the absolute root→node path from a linear chain', () => {
+        const parentOf = treeLookup({button: 'panel', panel: 'viewport', viewport: null});
+
+        expect(deriveSubtreePath('button', parentOf)).toEqual(['viewport', 'panel', 'button']);
+    });
+
+    test('a root component (no parent) is its own single-element path', () => {
+        expect(deriveSubtreePath('viewport', treeLookup({viewport: null}))).toEqual(['viewport']);
+    });
+
+    test("stops at Neo's top-level 'document.body' sentinel (the body is not a component)", () => {
+        const parentOf = treeLookup({panel: 'viewport', viewport: 'document.body'});
+
+        expect(deriveSubtreePath('panel', parentOf)).toEqual(['viewport', 'panel']);
+    });
+
+    test('fails closed to null on a cyclic chain rather than looping', () => {
+        const parentOf = treeLookup({a: 'b', b: 'c', c: 'a'});
+
+        expect(deriveSubtreePath('a', parentOf)).toBeNull();
+    });
+
+    test('fails closed to null for a malformed component id', () => {
+        const parentOf = treeLookup({});
+
+        expect(deriveSubtreePath('',              parentOf)).toBeNull();
+        expect(deriveSubtreePath(null,            parentOf)).toBeNull();
+        expect(deriveSubtreePath('document.body', parentOf)).toBeNull();
+    });
+
+    test('stops at a falsy (absent) parent — best-effort for a caller-held tree', () => {
+        // parentOf('missingParent') has no entry → undefined → the walk ends there
+        const parentOf = treeLookup({child: 'missingParent'});
+
+        expect(deriveSubtreePath('child', parentOf)).toEqual(['missingParent', 'child']);
+    });
+});

--- a/test/playwright/unit/ai/parseAgentEnvelope.spec.mjs
+++ b/test/playwright/unit/ai/parseAgentEnvelope.spec.mjs
@@ -1,0 +1,58 @@
+import {test, expect}       from '@playwright/test';
+import {parseAgentEnvelope} from '../../../../src/ai/parseAgentEnvelope.mjs';
+
+// Pure frame-parsing — imported directly (Neo.ai.Client is a connect-on-init singleton), so the suite
+// has no socket / Client side effects. Mirrors deriveSubtreePath.spec / resolveCallTarget.spec.
+const RPC = {jsonrpc: '2.0', id: 1, method: 'set_instance_properties', params: {id: 'c-1', properties: {}}};
+
+test.describe('parseAgentEnvelope (Neural Link agent-context unwrap)', () => {
+    test('agent_message → inner JSON-RPC + the Bridge-stamped (agentId, sessionId) context', () => {
+        const r = parseAgentEnvelope({type: 'agent_message', agentId: 'neo-opus-ada', sessionId: 'sess-abc', message: RPC});
+        expect(r.jsonrpc).toBe(RPC);
+        expect(r.context).toEqual({agentId: 'neo-opus-ada', sessionId: 'sess-abc'})
+    });
+
+    test('a bare JSON-RPC frame → the frame itself, no agent context (legacy / non-agent, unenforced)', () => {
+        const r = parseAgentEnvelope(RPC);
+        expect(r.jsonrpc).toBe(RPC);
+        expect(r.context).toBe(null)
+    });
+
+    test('agent_message with a missing / empty / non-string agentId → fail-closed marker (context.agentId null)', () => {
+        for (const bad of [undefined, '', null, 42, {}]) {
+            const r = parseAgentEnvelope({type: 'agent_message', agentId: bad, sessionId: 'sess-1', message: RPC});
+            expect(r.context).toEqual({agentId: null, sessionId: 'sess-1'}); // the write service denies on a null agentId
+            expect(r.jsonrpc).toBe(RPC)                                       // still dispatched, so it is denied — not silently dropped
+        }
+    });
+
+    test('agent_message with a missing / empty / non-string sessionId → fail-closed marker (context.sessionId null)', () => {
+        for (const bad of [undefined, '', null, 42, {}]) {
+            const r = parseAgentEnvelope({type: 'agent_message', agentId: 'neo-opus-ada', sessionId: bad, message: RPC});
+            expect(r.context).toEqual({agentId: 'neo-opus-ada', sessionId: null}); // the (agentId, sessionId) pair is incomplete → write service denies
+            expect(r.jsonrpc).toBe(RPC)                                            // still dispatched, so it is denied — not silently dropped
+        }
+    });
+
+    test('agent_message with no / non-object message → nothing to dispatch, context preserved', () => {
+        for (const bad of [undefined, null, 'x', 42]) {
+            const r = parseAgentEnvelope({type: 'agent_message', agentId: 'a', sessionId: 's', message: bad});
+            expect(r.jsonrpc).toBe(null);
+            expect(r.context).toEqual({agentId: 'a', sessionId: 's'})
+        }
+    });
+
+    test('a non-object frame → nothing to dispatch, no context', () => {
+        for (const bad of [null, undefined, 'x', 42, true]) {
+            expect(parseAgentEnvelope(bad)).toEqual({jsonrpc: null, context: null})
+        }
+    });
+
+    test('the agent_message discriminator is exact — a frame with a foreign type is still bare', () => {
+        // a JSON-RPC message never carries type:'agent_message'; any other shape is treated as bare
+        const frame = {type: 'something_else', method: 'get_component', params: {}},
+              r     = parseAgentEnvelope(frame);
+        expect(r.context).toBe(null);
+        expect(r.jsonrpc).toBe(frame)
+    });
+});

--- a/test/playwright/unit/ai/resolveWriteLock.spec.mjs
+++ b/test/playwright/unit/ai/resolveWriteLock.spec.mjs
@@ -1,0 +1,74 @@
+import {test, expect}      from '@playwright/test';
+import {resolveWriteLock} from '../../../../src/ai/resolveWriteLock.mjs';
+
+// Pure decision core — imported directly (no live heap, no WriteGuard, no socket), so the four enforcement
+// outcomes are provable in isolation. Mirrors deriveSubtreePath.spec / parseAgentEnvelope.spec.
+//
+// A linear component tree  root → mid → leaf  (parentOf returns the parent id, falsy at the root).
+const
+    PARENTS  = {leaf: 'mid', mid: 'root', root: null},
+    parentOf = id => PARENTS[id],
+    CTX      = {agentId: 'neo-opus-ada', sessionId: 'sess-abc'};
+
+test.describe('resolveWriteLock (NL write-enforcement decision core)', () => {
+    test('absent context (null / undefined / non-object) → not enforced, write unguarded (legacy)', () => {
+        for (const absent of [null, undefined, 'x', 42, true]) {
+            expect(resolveWriteLock(absent, 'leaf', parentOf)).toEqual({enforced: false, lock: null})
+        }
+    });
+
+    test('valid identity + resolvable target → enforced with the exact WriteGuard lock descriptor', () => {
+        const r = resolveWriteLock(CTX, 'leaf', parentOf);
+        expect(r).toEqual({
+            enforced: true,
+            lock    : {agentId: 'neo-opus-ada', sessionId: 'sess-abc', subtreePath: ['root', 'mid', 'leaf']}
+        });
+        // the path IS the deriveSubtreePath output (absolute root→node), and the lock carries no extra keys
+        expect(Object.keys(r.lock).sort()).toEqual(['agentId', 'sessionId', 'subtreePath'])
+    });
+
+    test('a root-level target resolves to its single-element path', () => {
+        const r = resolveWriteLock(CTX, 'root', parentOf);
+        expect(r.enforced).toBe(true);
+        expect(r.lock.subtreePath).toEqual(['root'])
+    });
+
+    test('incomplete identity — a missing / empty / non-string agentId fails closed (deny, no lock)', () => {
+        for (const bad of [undefined, '', null, 42, {}]) {
+            const r = resolveWriteLock({agentId: bad, sessionId: 'sess-abc'}, 'leaf', parentOf);
+            expect(r).toEqual({enforced: true, lock: null, reason: 'incomplete-identity'})
+        }
+    });
+
+    test('incomplete identity — a missing / empty / non-string sessionId fails closed (deny, no lock)', () => {
+        for (const bad of [undefined, '', null, 42, {}]) {
+            const r = resolveWriteLock({agentId: 'neo-opus-ada', sessionId: bad}, 'leaf', parentOf);
+            expect(r).toEqual({enforced: true, lock: null, reason: 'incomplete-identity'})
+        }
+    });
+
+    test('a present-but-malformed object context (missing both fields / array) denies — NOT treated as legacy', () => {
+        for (const malformed of [{}, {foo: 'bar'}, []]) {
+            const r = resolveWriteLock(malformed, 'leaf', parentOf);
+            expect(r).toEqual({enforced: true, lock: null, reason: 'incomplete-identity'})
+        }
+    });
+
+    test('valid identity + unresolvable target (malformed / cyclic id) fails closed (deny, no lock)', () => {
+        // empty-string + the document.body sentinel + a cyclic chain all make deriveSubtreePath return null
+        for (const badId of ['', 'document.body']) {
+            expect(resolveWriteLock(CTX, badId, parentOf))
+                .toEqual({enforced: true, lock: null, reason: 'unresolvable-target'})
+        }
+        const cyclic = {a: 'b', b: 'a'};
+        expect(resolveWriteLock(CTX, 'a', id => cyclic[id]))
+            .toEqual({enforced: true, lock: null, reason: 'unresolvable-target'})
+    });
+
+    test('an unidentified write never touches the component tree (deny short-circuits before deriveSubtreePath)', () => {
+        // parentOf throws — if the tree were consulted for an incomplete-identity request, this would throw.
+        const exploding = () => { throw new Error('tree must not be walked for an unidentified write') };
+        expect(resolveWriteLock({agentId: '', sessionId: 'sess-abc'}, 'leaf', exploding))
+            .toEqual({enforced: true, lock: null, reason: 'incomplete-identity'})
+    });
+});


### PR DESCRIPTION
Resolves #17968

`c623b2f63c` deleted 796 unit specs under one general account. Twelve of their subjects are still in `src/ai/**` at `HEAD`, and **no CI anywhere executes their arms** — the one regression a suite cannot report, because the run goes green with less behind the same number.

> **Corrected after review.** This PR and #17968 originally said *"no unit coverage at all"*. @neo-gpt's RA-1 falsified it: all twelve specs are tracked on `neo-agent-brain@a212acc` at identical paths — `c623b2f63c` **moved** them. My first repair then overshot the other way, reporting they *"run"* in Brain on the strength of a local run; Brain CI collects the corpus with `--list` and then executes a four-file smoke containing none of them (already owned by `neo-agent-brain#201`). Current truth: the arms **exist**, are **collected**, and are **executed by nothing**. Engine CI runs the full unit corpus with no file list, so restoring them here is what makes them execute. #17968 now carries this correction and its ACs were amended accordingly; the paired Brain retirement is `neo-agent-brain#292` → **PR neo-agent-brain#293**.

All twelve are restored at their original paths and mutation-verified.

Evidence: **unit / in-process** (the restored arms plus a per-subject seeded mutation, each run against the full suite and reverted to a clean tree) → unit required. No runtime, browser, or host surface is involved in any of these subjects. Residual: none.

## AC Evidence

Against #17968's **amended** seven acceptance criteria.

| AC | Proof |
|---|---|
| **AC-1** — all 12 carry a spec at the original path; `npm run test-unit` green | Exact head `64874b7189`: **2,853 passed / 29 skipped**, 0 failed. Suite grew 2639 → 2882 collected; the 12 specs add ~243 arms. (Earlier wording read the runner's collected total as a passed count — corrected per RA-2.) |
| **AC-2** — each mutation-checked; the seeded mutation stated per subject | The ledger below. 12 of 12; every one reds at least one arm. |
| **AC-3** — the write-admission chain asserts a REFUSAL, not only success | Proven behaviourally rather than by keyword — see below. |
| **AC-4** — any changed assertion names the change and why the new one is correct | Four changes, one deliberate non-change, all in the table below. |
| **AC-5** — the 12 are **executed by Engine CI**, not merely present; count recorded as `passed / skipped` | Established at the collection layer, not by grepping a log — see below. Engine CI ran the config with no selector: **2853 passed / 29 skipped**, and none of the 29 is one of the twelve. |
| **AC-6** — Brain copies retired in a paired, **Engine-first** sequence; the twelve exist in exactly one repository once both land | **neo-agent-brain PR #293** (12 deletions, 0 other staged changes), opened behind this PR and carrying an explicit do-not-merge-first constraint in its body. `neo-agent-brain#292` is filed and self-assigned. |
| **AC-7** — defects found while porting are filed as their own tickets and linked; none fixed here | **#18004** — the dock shape gate fails open on a malformed zone descriptor. See below; `src/` carries no behaviour change in this PR. |

## AC-2 — mutation ledger, 12 of 12

Each mutation was applied to the **subject**, run, and reverted to a clean tree.

| Subject | Seeded mutation | Arms red |
|---|---|---|
| `deriveSubtreePath` | `path.unshift` → `path.push` (ancestor order reversed) | 3 of 6 |
| `parseAgentEnvelope` | `agentId.length > 0` → `>= 0` (empty id passes instead of failing closed) | 1 |
| `admitWrite` | `!writeGuard` branch `admitted:false` → `true` | 1 |
| `resolveWriteLock` | `agentId.length > 0` → `>= 0` (half-stamped writer pair admitted) | 2 |
| `WriteGuard` | invalid lease clock/ttl `granted:false` → `true` | 1 |
| `LockRegistry` | `if (conflict)` → `if (false && conflict)` | 1 |
| `TransactionService` | `no-open-transaction` `{ok:false}` → `{ok:true}` | 2 |
| `ComponentService` | duplicate-detection branch disabled | 1 |
| `DockService` | unknown-operation rejection disabled | 1 |
| `InstanceService` | `getInstanceProperties` bypasses `safeSerialize` | 1 |
| `RuntimeService` | `openComponentWindow` unknown-component `success:false` → `true` | 1 |
| `TourRunner` | record-mode `reducedMotion` guard disabled | 1 |

**One near-miss worth recording.** My first `RuntimeService` mutation targeted `getMethodSource` and reddened **nothing** — because the restored spec covers only the window/popup routes. That is information about the original spec's coverage scope, not a reason to discard it; re-targeting a covered path reds. `getMethodSource` remains uncovered, and widening coverage beyond restoration is out of scope here by the ticket's own rule.

## AC-3 — met behaviourally, not by keyword

A census finds refusal language in all five chain subjects (`admitWrite` 13 arms, `WriteGuard` 25, `resolveWriteLock` 8, `LockRegistry` 36, `TransactionService` 26). Token presence is not proof that a refusal is **asserted**, so each of the five was instead mutated to make its guard **permissive** — and each reds. A spec exercising only success paths would have stayed green under all five.

## AC-4 — changed assertions and fixtures, with why

Eight specs port verbatim. Two needed import repair only (no assertion changed), from the dock split relocating their subjects:

- `DockPerspectiveStore` → `dock/persistence/PerspectiveLibrary` — a rename; the instance API the specs use, `savePerspective(layout, {replace, activate})`, survives on a class still extending `core.Base`
- `DockZoneModel.{operations, applyOperation}` → `model/Operations`
- `DockZoneModel.{capturePerspective, captureTopologyPerspective, restoreSavedLayout, CAPTURE_SCOPES}` → `model/Persistence`

Four genuine fixture/assertion changes:

| # | Change | Why the new form is correct |
|---|---|---|
| 1 | `zones: {center: 'x'}` → `{center: {nodeId: 'x'}}` | `Document.getZoneNodeId()` resolves only the record form; a bare string yields `null`. See the root-cause note below. |
| 2 | `schema 'neo.harness.dockZone.v1'` → `'neo.dock.zone.v1'` | v13.2 cut renamed the `neo.harness.*` wire family to `neo.dock.*` (#17837 / PR #17841, landed 2026-08-29) |
| 3 | `windowFingerprint 'neo.harness.dockShape.v1'` → `'neo.dock.shape.v1'` | same rename; the arm proves the fingerprint comes from `Persistence`, and the schema string is how it proves it |
| 4 | `windowFingerprint 'neo.harness.dockTopologyShape.v1'` → `'neo.dock.topologyShape.v1'` | same rename |

**Deliberately NOT renamed:** the corrupt fixture keeps `'neo.harness.dockLayout.v2'`. Its invalidity **is** the test — that arm asserts a non-validating surface still fails the restore closed. Renaming it to a valid schema would have made the test pass for the wrong reason, and a mechanical find-and-replace across "stale" identifiers would have destroyed it silently. Negative fixtures look exactly like stale ones.

### Root cause of the `diffDockTopology` failure — it pointed two layers below itself

The arm failed with *"expected 1 move, got 0"*, which reads as broken move detection. It was zone resolution: the recovered fixtures carry pre-cut `zones: {center: 'main-split'}`, `getZoneNodeId` returns `null` for a bare string, so `TopologyDiff.indexItemLocations` walked to root, resolved the centre zone to `null`, and stopped — indexing **zero** items on both sides. The differ then honestly reported no moves **and no errors**, because a document with no reachable items genuinely has no diff.

`errors: []` alongside `moves: []` was the tell. A silently-halting traversal produces an empty-but-valid result, which reads as "the feature is broken" rather than "the input was never reached".

## AC-5 — executed, established at the collection layer

The AC asks that the `unit` suite's own run at the merge head report each restored spec in its **collected-and-executed** set. The obvious instrument — grepping the CI log for the twelve filenames — **cannot answer this**, and it is worth saying why rather than reporting its zero as an absence: the `github` and `json` reporters print no path for a *passing* file. Across 1,120 log lines of the `unit` job, `unit/ai` appears **0** times and `.spec.mjs` twice — which is equally true of every long-standing spec in the suite. A zero there is an instrument limit, not evidence.

What does establish it, at the layer that can:

1. **The config has no selector.** `test/playwright/playwright.config.unit.mjs` sets `testDir: test/playwright/unit` and declares no `testMatch`, no `testIgnore`, and no include-list. Collection is a pure glob of that tree. This is the specific failure mode ruled out — Brain's `unit` job is named for a suite but runs a four-file smoke list; the Engine's does not.
2. **CI invoked it with no file argument.** Job `99717368042` (run `33463132988`), step `npm run test-unit` → `playwright test -c test/playwright/playwright.config.unit.mjs`, nothing appended.
3. **CI collected the whole tree:** `Running 2882 tests using 4 workers` → **2853 passed · 29 skipped**, 0 failed. Recorded as `passed / skipped`, per the AC's wording, not as a collected total.
4. **The twelve are inside `testDir`** at `64874b7189` — all under `test/playwright/unit/ai/**` — therefore inside that 2882.
5. **None of them is among the 29 skips.** All twelve were checked for `test.skip` / `test.fixme` / `describe.skip` / any `skip(`: **zero occurrences in all twelve**. There is no conditional-skip path by which a restored spec could be collected but not executed.

## AC-7 — the defect found while porting, filed

`Document.computeShapeFingerprint` accepted a document whose `zones` carry a bare-string descriptor, while `getZoneNodeId` resolves only the record form — so such a document **passed the shape gate and indexed to nothing**. That asymmetry is what made the ported arm fail two layers below where its message pointed.

It is filed as **#18004** and fixed in **PR #18005** (@neo-gpt), not here — per this ticket's own rule that defects found while porting become their own tickets. `src/` carries no behaviour change in this PR; the only `src/` touches in this branch were mutation probes, all reverted.

Reviewing #18005 surfaced a **second, pre-existing** instance of the same class one level up — `node.zones` itself is read as `|| {}` with no record check, so a non-record `zones` container still fingerprints clean as `e{}` while `validate()` rejects it. Also outside this PR: filed as **#18006** and linked from #18004's `Related` section. Its downstream shape is worse than #18004's — the malformed root's subtree is erased rather than emptied, so the differ reports every item as a **remove**, still with `errors: []`.

## Out of Scope

- Widening coverage beyond what was deleted (`RuntimeService.getMethodSource` stays uncovered).
- Any behaviour change in `src/` — the only `src/` touches in this branch are mutation probes, all reverted; `git status` is clean.
- The Brain collection-vs-execution gap (`neo-agent-brain#201`). AC-6's deletion PR cites it as the reason the deletion is free, and neither restates nor fixes it.

Origin Session ID: 56bc214a-5b55-41a2-848a-cdfa372abbcd

— Grace (Opus 5, Claude Code) 🖖

