### PR TITLE
fix(dashboard): fail closed on malformed zone fingerprints (#18004)

### DIFF
--- a/src/dashboard/dock/model/Document.mjs
+++ b/src/dashboard/dock/model/Document.mjs
@@ -1001,8 +1001,8 @@ class Document extends Base {
      * fixed {@link #dockZoneEdgeKeys} order.
      *
      * Optional edge-zone slots may be absent. A present slot whose descriptor cannot resolve to a
-     * node id fails closed, so malformed topology can never fingerprint identically to an empty
-     * edge-zone and pass downstream shape gates as a legitimate no-change result.
+     * node id fails closed, so that corrupt descriptor cannot fingerprint identically to an omitted
+     * slot and pass downstream shape gates as a legitimate no-change result.
      * @param {Object} document The committed dock-zone document.
      * @returns {{fingerprint:(Object|null), errors:String[]}}
      * @static

--- a/src/dashboard/dock/model/Document.mjs
+++ b/src/dashboard/dock/model/Document.mjs
@@ -999,6 +999,10 @@ class Document extends Base {
      * where or when they were captured (the persistence guardrail for `windowFingerprint`).
      * Deterministic by construction: child arrays keep document order, edge zones walk in the
      * fixed {@link #dockZoneEdgeKeys} order.
+     *
+     * Optional edge-zone slots may be absent. A present slot whose descriptor cannot resolve to a
+     * node id fails closed, so malformed topology can never fingerprint identically to an empty
+     * edge-zone and pass downstream shape gates as a legitimate no-change result.
      * @param {Object} document The committed dock-zone document.
      * @returns {{fingerprint:(Object|null), errors:String[]}}
      * @static
@@ -1037,14 +1041,26 @@ class Document extends Base {
                     return `${node.orientation === 'horizontal' ? 'h' : 'v'}(${(node.children || []).map(walk).join(',')})`;
                 case 'tabs':
                     return `t${node.items?.length || 0}`;
-                case 'edge-zone':
+                case 'edge-zone': {
+                    const zones = node.zones || {};
+
                     return `e{${[...Document.dockZoneEdgeKeys]
                         .map(zone => {
-                            let nodeId = Document.getZoneNodeId(node.zones?.[zone]);
+                            if (!Object.hasOwn(zones, zone)) {
+                                return ''
+                            }
 
-                            return nodeId ? `${zone}:${walk(nodeId)}` : ''
+                            let childNodeId = Document.getZoneNodeId(zones[zone]);
+
+                            if (!childNodeId) {
+                                errors.push(`fingerprint walk found unusable descriptor for edge-zone "${nodeId}" zone "${zone}"`);
+                                return ''
+                            }
+
+                            return `${zone}:${walk(childNodeId)}`
                         })
                         .filter(Boolean).join(',')}}`;
+                }
                 default:
                     errors.push(`fingerprint walk found unsupported node type "${node.type}"`);
                     return '?'

--- a/test/playwright/unit/dashboard/DockTopologyDiff.spec.mjs
+++ b/test/playwright/unit/dashboard/DockTopologyDiff.spec.mjs
@@ -9,6 +9,7 @@ setup({
 import {test, expect}   from '@playwright/test';
 import Neo              from '../../../../src/Neo.mjs';
 import * as core        from '../../../../src/core/_export.mjs';
+import Document         from '../../../../src/dashboard/dock/model/Document.mjs';
 import DockTopologyDiff from '../../../../src/dashboard/dock/model/TopologyDiff.mjs';
 
 /**
@@ -169,5 +170,44 @@ test.describe('Neo.dashboard.dock.model.TopologyDiff (#14650)', () => {
 
         expect(cycleResult.errors[0]).toContain('before document failed the shape gate');
         expect(cycleResult.errors[0]).toContain('cycle')
+    });
+
+    test('present malformed zone descriptors fail the shape gate on both sides; absent zones stay valid', () => {
+        const malformedDescriptors = ['main-split', {}, {nodeId: ''}];
+
+        malformedDescriptors.forEach(descriptor => {
+            const malformed = doc();
+
+            malformed.nodes.root.zones.center = descriptor;
+
+            expect(Document.validate(malformed), 'the document validator rejects the same descriptor')
+                .not.toEqual([]);
+
+            const gate = Document.computeShapeFingerprint(malformed);
+
+            expect(gate.fingerprint, 'a malformed present zone never yields a success fingerprint').toBe(null);
+            expect(gate.errors.join(' ')).toContain('zone "center"');
+
+            for (const side of ['before', 'after']) {
+                const result = side === 'before'
+                    ? DockTopologyDiff.diffDockDocuments(malformed, doc())
+                    : DockTopologyDiff.diffDockDocuments(doc(), malformed);
+
+                expect(result.errors[0]).toContain(`${side} document failed the shape gate`);
+                expect(result.moves).toEqual([]);
+                expect(result.adds).toEqual([]);
+                expect(result.removes).toEqual([]);
+                expect(result.unchanged).toEqual([])
+            }
+        });
+
+        const absent = doc();
+
+        delete absent.nodes.root.zones.center;
+
+        const absentGate = Document.computeShapeFingerprint(absent);
+
+        expect(absentGate.errors, 'an omitted optional zone remains valid').toEqual([]);
+        expect(absentGate.fingerprint?.shape).toBe('e{}')
     });
 });


### PR DESCRIPTION
Resolves #18004

A present `edge-zone` key with an unusable descriptor was collapsing to the same `e{}` fingerprint as a legitimately absent optional zone. `TopologyDiff` therefore returned an all-empty, error-free result for malformed input—the exact shape of a valid no-change comparison.

## What changed

- `Document.computeShapeFingerprint()` now distinguishes an omitted canonical zone from a present descriptor that cannot resolve a non-empty node id.
- Omitted optional zones remain silent and retain the existing `e{}` fingerprint.
- Present malformed descriptors push a side-propagating shape-gate error, so the public fingerprint is `null` and `TopologyDiff` fails closed.
- The existing `DockTopologyDiff` suite covers a bare string, an empty record, and an empty `nodeId`; both `before` and `after` positions; validator/fingerprint polarity; empty result categories; and the absent-zone negative control.

## Evidence Audit

Red before the production change, with the final spec already present:

```text
Expected fingerprint: null
Received: {schema:"neo.dock.shape.v1", shape:"e{}", ...}
```

Green after the change: **8/8** focused arms. Reverting the production hunk restores the exact red above.

Evidence: **L2** (direct unit execution of the model gate and its TopologyDiff consumer) → **L2 required** (pure deterministic model contract). Residual: none.

## Source of Authority

`Document.validate()` already rejects all three descriptor forms. `computeShapeFingerprint()` is TopologyDiff's documented fail-closed shape gate; its `errors` array is the only signal `diffDockDocuments()` consumes before returning semantic categories. The fix belongs at that producer boundary, not as a second check in TopologyDiff.

## Deltas from ticket

None. The implementation keeps the ticket's bounded polarity repair: no `validate()` refactor, caller census, schema compatibility reader, or diagnostic cleanup.

## Test Evidence

- `DockTopologyDiff.spec.mjs`: **8/8 passed**.
- Pre-rebase full unit corpus at `ac770ec4eb`: **2,680/2,680 passed**.
- Post-rebase focused suite at the current head: **8/8 passed**; exact-head hosted CI follows the push.
- JSDoc type parser: **1,201 files / 0 unparseable expressions**.
- `node --check src/dashboard/dock/model/Document.mjs`: passed.
- `git diff --check`: clean.
- Exact base: `origin/dev@8cfa78702b`; two commits ahead.

## Post-Merge Validation

- [x] No post-merge-only validation. The model contract and both consumer-side positions are fully executable before merge.

## Commits

- `f273db5174` — `fix(dashboard): fail closed on malformed zone fingerprints (#18004)`
- `5f54c3f1e2` — `docs(dashboard): scope the zone fingerprint guarantee (#18004)`

## Evolution

The restored DockService arm initially looked like broken move detection because TopologyDiff returned zero moves. The tell was `errors: []`: the tree walk had erased an invalid present zone into the same term used for an absent one. Preserving the absent/malformed distinction at fingerprint construction makes every downstream consumer honest without duplicating validation policy.

Authored by Euclid (GPT-5.6 Sol Ultra, Codex Desktop). Origin Session ID: 01a0534f-a981-7560-93de-8d3d54966db6.
