### PR TITLE
fix(tab): an action-group insert must not recapture the tab split (#18001)

### DIFF
--- a/src/tab/plugin/Overflow.mjs
+++ b/src/tab/plugin/Overflow.mjs
@@ -538,7 +538,28 @@ class Overflow extends Plugin {
      * Tab-set-mutation handler — a header add (`insert`) or reorder (`moveTo`) changed the button set, so
      * recapture natural widths (an added button has none cached) and re-partition against the mutated set.
      */
-    onTabSetChange() {
+    onTabSetChange({item}={}) {
+        // The owner's `insert` / `remove` also fire for its ACTION group — a consumer `actions`
+        // replacement, the action spacer, and this plugin's own contribution all move through the same
+        // container methods. None of those is a tab-set mutation: they change the tab-EXCLUSIVE extent,
+        // which `actionsChange` already re-projects through onActionSetChange WITHOUT a recapture.
+        //
+        // Recapturing on them is not merely redundant, it is wrong. A recapture restores every hidden
+        // header to the DOM for its measure window (project() step 1), and `insert` fires only AFTER
+        // its own promiseUpdate round-trip — so an action replacement queues a recapture that lands
+        // late and re-applies an all-fit split over the split a newer resize had already applied. The
+        // header then flaps for one pass: the overflowing tabs return and the overflow control leaves,
+        // in a state that reads as coherent because it IS one — the all-fit verdict for the old extent.
+        // `Container#insert` fires ONCE for a batch, with `item` carrying the whole array (its per-item
+        // recursion is silent), so the membership test has to cover both shapes.
+        let members = Array.isArray(item) ? item : item ? [item] : [];
+
+        if (members.length > 0 && members.every(member =>
+            member?.isToolbarAction === true || member?.isToolbarActionSpacer === true
+        )) {
+            return
+        }
+
         this.project(true)
     }
 

--- a/test/playwright/component/tab/OverflowAction.spec.mjs
+++ b/test/playwright/component/tab/OverflowAction.spec.mjs
@@ -178,5 +178,55 @@ test.describe('Neo.tab.plugin.Overflow — toolbar action projection', () => {
         await menuItem.click();
         await expect(toolbar.locator('.neo-tab-header-button.pressed:visible').filter({hasText: selected}),
             'selection still activates through activeIndex after the hidden replacement').toHaveCount(1)
+    });
+
+    test('the restored split settles once — no pass re-applies a superseded extent', async ({page}) => {
+        const root    = page.locator(`#${TAB_ID}`),
+              toolbar = root.locator(':scope > .neo-tab-header-toolbar'),
+              control = toolbar.getByRole('button', {name: 'More tabs', exact: true});
+
+        await expect(control).toBeVisible({timeout: 10000});
+
+        const controlId = await control.getAttribute('id');
+
+        await replaceHeaderActions(page, 'visible');
+        await expect(toolbar.getByRole('button', {name: 'host visible', exact: true})).toBeVisible();
+
+        await page.evaluate(id => Neo.worker.App.setConfigs({id, width: 1200}), TAB_ID);
+        await expect(toolbar.locator(`#${controlId}`), 'all-fit hides the contribution from DOM')
+            .toHaveCount(0, {timeout: 10000});
+
+        await replaceHeaderActions(page, 'hidden');
+        await expect(toolbar.getByRole('button', {name: 'host hidden', exact: true})).toBeVisible();
+
+        await page.evaluate(id => Neo.worker.App.setConfigs({id, width: 380}), TAB_ID);
+
+        // A retrying assertion cannot witness a transient — it polls until the contribution returns and
+        // then stops looking, which is why the sibling arm above races this defect instead of pinning it.
+        // So sample from the moment the width is set, WITHOUT waiting for the restore first: record every
+        // distinct state of the action group, then assert against the recorded sequence. Waiting for the
+        // contribution before sampling would let the flap happen inside the wait and go unrecorded.
+        const states = [];
+
+        for (let i = 0; i < 80; i++) {
+            const ids = (await actionIds(toolbar)).join(',');
+
+            states.at(-1) !== ids && states.push(ids);
+            await page.waitForTimeout(25)
+        }
+
+        const restoredAt = states.findIndex(state => state.split(',').includes(controlId));
+
+        expect(restoredAt, 'the contribution returns after the narrow resize').toBeGreaterThan(-1);
+
+        // Once it is back it must STAY back. A later state without it means a projection pass applied a
+        // verdict measured against the superseded (wide) extent, taking the contribution out of the DOM
+        // and the overflowing tabs back into it — a state that reads as coherent because it is one.
+        const afterRestore = states.slice(restoredAt);
+
+        expect(afterRestore.filter(state => !state.split(',').includes(controlId)),
+            'no pass re-applies a superseded extent once the contribution is restored').toEqual([]);
+        expect(afterRestore.at(-1).split(',')[0], 'the contribution holds the first action slot')
+            .toBe(controlId)
     })
 });

--- a/test/playwright/unit/tab/plugin/Overflow.spec.mjs
+++ b/test/playwright/unit/tab/plugin/Overflow.spec.mjs
@@ -1414,5 +1414,59 @@ test.describe('Neo.tab.plugin.Overflow (tab-set mutation invalidation)', () => {
         owner.fire('remove', {index: 1, item: {id: 'b2'}});
 
         expect(projected, 'owner `remove` re-runs project so a removed tab drops from the split + menu').toBe(true)
+    });
+
+    // The owner's `insert` / `remove` also carry its ACTION group — a consumer `actions`
+    // replacement moves through the same container methods as a tab add. Recapturing on those restores
+    // every hidden header to DOM for the measure window, and `insert` fires only AFTER its own
+    // promiseUpdate round-trip, so the pass lands late and re-applies an all-fit split over a newer
+    // resize's split. `actionsChange` already covers the real (extent-only) effect without a recapture.
+    test('an action-group `insert` does NOT recapture — it is an extent change, not a tab-set mutation', async () => {
+        const {plugin, owner} = createWiredPlugin();
+        await new Promise(resolve => setTimeout(resolve, 0));
+
+        let   projected = false;
+        const orig      = plugin.project.bind(plugin);
+        plugin.project = arg => { projected = true; return orig(arg) };
+
+        owner.fire('insert', {index: 2, item: {id: 'neo-button-9', isToolbarAction: true}});
+
+        expect(projected, 'a single action insert must not re-run project').toBe(false);
+
+        // The extent DID change, and the action-set channel is what must carry it.
+        owner.fire('actionsChange', {actions: []});
+        expect(projected, '`actionsChange` still re-projects the tab-exclusive extent').toBe(true)
+    });
+
+    test('a BATCHED action insert does not recapture — `Container#insert` fires once with the whole array', async () => {
+        const {plugin, owner} = createWiredPlugin();
+        await new Promise(resolve => setTimeout(resolve, 0));
+
+        let   projected = false;
+        const orig      = plugin.project.bind(plugin);
+        plugin.project = arg => { projected = true; return orig(arg) };
+
+        // The shape `syncActions` actually produces: the per-item recursion is silent, so the single
+        // fired event carries an ARRAY. A membership test written for one instance misses this entirely.
+        owner.fire('insert', {index: 2, item: [
+            {id: 'neo-component-4', isToolbarActionSpacer: true},
+            {id: 'neo-button-9',    isToolbarAction      : true},
+            {id: 'neo-button-10',   isToolbarAction      : true}
+        ]});
+
+        expect(projected, 'a batched action insert must not re-run project').toBe(false)
+    });
+
+    test('a MIXED batch still recaptures — only an all-action batch is exempt', async () => {
+        const {plugin, owner} = createWiredPlugin();
+        await new Promise(resolve => setTimeout(resolve, 0));
+
+        let   recapture = null;
+        const orig      = plugin.project.bind(plugin);
+        plugin.project = arg => { recapture = arg; return orig(arg) };
+
+        owner.fire('insert', {index: 2, item: [{id: 'neo-button-9', isToolbarAction: true}, {id: 'b3'}]});
+
+        expect(recapture, 'a batch containing a real tab still recaptures').toBe(true)
     })
 });


### PR DESCRIPTION
Resolves #18001

`Neo.tab.plugin.Overflow.onTabSetChange` recaptured on every owner `insert` / `remove`, but those events also carry the toolbar's **action group** — a consumer `headerActions` replacement, the action spacer, and the plugin's own overflow contribution all move through the same container methods as a tab add. A recapture restores every hidden header to the DOM for its measure window, and `Container#insert` fires only *after* its own `promiseUpdate` round-trip, so an action replacement queued a pass that landed late and re-applied an **all-fit split measured at the previous extent** over the split a newer resize had already applied. The header flapped for one pass: overflowing tabs back in, overflow contribution out. This PR makes the plugin ignore `insert` / `remove` whose payload is entirely action-group members; `actionsChange` → `onActionSetChange` already carries the real (extent-only) effect as `project(false)`, so the guard restores the documented design rather than removing coverage.

Evidence: L3 (real-browser component arms + unit lifecycle arms at the PR head) → L3 required (the close target binds a rendered runtime property — a DOM state that appears and disappears across projection passes). No residuals.

## AC Evidence

| AC-1 | *No pass applies a verdict measured against a superseded extent.* CI-covered: `test/playwright/component/tab/OverflowAction.spec.mjs` → *the restored split settles once*, asserting the contribution never leaves the action group again once restored. |
| AC-2 | *The producer is identified and stated.* It is **neither** candidate the ticket enumerated: not `onResize`, not `actionsChange`. It is the raw `insert` event → `onTabSetChange` → `project(true)`. Isolated outside CI by disabling `onTabSetChange` outright — 16/16 green — while both named candidates stayed live. See *Deltas*. |
| AC-3 | *A non-retrying arm witnesses the transient.* CI-covered: the same new arm samples from the moment the width is set, **not** after waiting for the contribution to return — a retrying assertion polls past a transient, which is how the pre-existing arm raced this for its whole life. |
| AC-4 | *Negative control: the arm reds with the fix reverted.* Outside CI: `git checkout origin/dev -- src/tab/plugin/Overflow.mjs` with both spec files kept → **3 failed / 13 passed** at `--repeat-each=16 --workers=1`; unit side 2 of the 3 new arms red. Receipts below. |
| AC-5 | *The rate is re-measured on the fix branch and reported as a number.* Outside CI: **48 passed / 0 failed** — whole spec, 3 tests × `--repeat-each=16 --workers=1`. |

## Deltas from ticket

**The ticket's mechanism was wrong and I corrected it before writing any code** — [comment](https://github.com/neomjs/neo/issues/18001#issuecomment-5488966139), body amended. It claimed the contribution is *replaced by a newly created instance* (`neo-button-3` → `neo-button-7`). A non-retrying witness showed `neo-button-7` is the consumer's own `host hidden` action standing in the slot while the **same** `neo-button-3` is transiently out of the DOM. `#17951`'s contribution seam is exonerated; the retained-instance invariant was never broken.

**AC-2's enumeration was also incomplete.** The ticket offered two candidate producers; the real one is a third — the owner's raw `insert`, whose recapture is spurious for an action change. Settled by elimination (disable `onTabSetChange` → 16/16), not by argument.

**One non-obvious shape.** `Container#insert` makes its per-item recursion silent and fires **once with the whole array** — the shape `toolbar.Base#syncActions` produces. A guard written for a single instance is a silent no-op here: my first attempt measured an unchanged 3/16, which is what sent me to `Container#insert`'s source. A batch is exempt only when *every* member is an action-group member; a mixed batch still recaptures, and that boundary has its own arm.

## Test Evidence

All new coverage runs in CI (`unit` + `components`). The two receipts below are the mutation/negative-control results a green suite cannot show.

Negative control — `src/tab/plugin/Overflow.mjs` reverted to `origin/dev@68efc42bb2`, both spec files kept:

```
component  -g "settles once" --repeat-each=16 --workers=1  →  3 failed / 13 passed
unit       test/playwright/unit/tab/plugin/Overflow.spec.mjs →  2 failed / 39 passed
```

The 2 unit reds are the two defect arms. The third new arm (*a MIXED batch still recaptures*) passes both ways **by construction** — it pins the boundary the fix must not overshoot, not the defect.

Discriminating probe — `onTabSetChange` disabled entirely (`return` before `project(true)`): **16/16 green**, which is what proved the recapture path is the producer rather than the coalescing gates in `project()`.

Fix branch, whole spec: **48 passed** (3 × 16). Tab unit suite: **60 passed**. Tab component suite: **8 passed**.

## Post-Merge Validation

Nothing is deferred past merge. Every AC is proven at this head: the invariant runs in the `components` job, the boundary runs in `unit`, and both the negative control and the rate re-measurement are recorded above. The other two `components` intermittents @neo-opus-vega named at 2026-08-31T23:31Z (`menu/SpawnAnimation`, #17980's `DockReload`) are untouched here and remain independently owned and intermittent. This exact head's `components` job is green.

## Commits

- `fix(tab): an action-group insert must not recapture the tab split (#18001)` — the guard plus its four arms.

Authored by Grace (Anthropic Claude Opus 5, Claude Code). Session e923dea0-0d1f-4063-959b-b3b98e4414ad.

