### PR TITLE
test(dashboard): report maximizedNodeId when the continuity arm reds (#18008)

### DIFF
--- a/test/playwright/component/dashboard/DockMaximize.spec.mjs
+++ b/test/playwright/component/dashboard/DockMaximize.spec.mjs
@@ -41,6 +41,40 @@ const tabButton = (node, text) => node.locator('.neo-tab-header-button', {hasTex
 
 const actionButton = (node, glyph) => node.locator(`.neo-tab-header-toolbar .neo-button:has([class*="${glyph}"])`);
 
+/**
+ * `toHaveCount` on the maximize marker, plus the one observable that splits this arm's failure
+ * space when it reds — `maximizedNodeId`, read at failure time.
+ *
+ * `Workspace#applyDockMaximizePresentation` has two terminal exits that both leave the marker at
+ * 0 forever, and the DOM cannot tell them apart:
+ *
+ * - **`null`** — the fail-safe (`failDockMaximize`) cleared the transient, because the tabs node
+ *   did not resolve or `measureDockMaximizeRect` returned a 0×0 workspace rect.
+ * - **a surviving id** — the config write landed and the presentation was lost downstream of it.
+ *
+ * Without that read a failure is a bare "expected 1, received 0" and the two families are
+ * indistinguishable. The assertion itself is unchanged; only what a failure reports is.
+ * @param {Object} page
+ * @param {Number} count
+ * @returns {Promise<void>}
+ */
+const expectMaximizedCount = async (page, count) => {
+    try {
+        await expect(page.locator('.neo-dock-maximized')).toHaveCount(count)
+    } catch (error) {
+        let nodeId;
+
+        try {
+            [nodeId] = await readWorkspace(page, ['maximizedNodeId'])
+        } catch (readError) {
+            nodeId = `<unreadable: ${readError.message}>`
+        }
+
+        error.message += `\n\nmaximizedNodeId at failure: ${JSON.stringify(nodeId)}`;
+        throw error
+    }
+};
+
 const maximizedRectMatchesWorkspace = page => page.waitForFunction(() => {
     const el = document.querySelector('.neo-dock-maximized'),
           ws = document.getElementById('dock-maximize-workspace');
@@ -189,7 +223,9 @@ test.describe('dock maximize — presentation, never topology', () => {
 
         // Continuity: a NON-operation re-projection re-applies a surviving transient…
         await setWorkspace(page, {maximizedNodeId: 'main-tabs'});
-        await expect(page.locator('.neo-dock-maximized')).toHaveCount(1);
+        // This re-apply follows a cross-worker write with no committed operation behind it, so a
+        // failure here has two indistinguishable families — hence the reporting variant.
+        await expectMaximizedCount(page, 1);
 
         await setWorkspace(page, {refreshCount: 1});
         await page.waitForFunction(() => document.querySelectorAll('.neo-dock-maximized').length === 1);


### PR DESCRIPTION
Resolves #18008

The DockMaximize continuity arm reds intermittently on CI and always looks the same from the DOM: the maximize marker sits at `0` for the full poll window and nothing re-triggers it. Two different mechanisms produce that, and until now the failure said which one it was: nothing. This adds the one read that separates them — `maximizedNodeId`, taken at failure time, appended to the error. The assertion's subject, timeout and expected count are untouched.

Evidence: L2 (component-suite run on a maintainer host, real browser, both mutation directions executed) → L2 required (#18008's ACs are all observable in a local component run; nothing here needs a production surface). Residual: none.

Micro-review eligible: no — the diff is small but it changes what a failing arm reports on a defect lane two peers are reading, and AC-2's both-directions claim is the part worth checking.

## AC Evidence

| AC | Proof |
|---|---|
| AC-1 — the continuity assertion reports `maximizedNodeId` at failure time, assertion otherwise unchanged | `test/playwright/component/dashboard/DockMaximize.spec.mjs` — `expectMaximizedCount()` wraps the identical `toHaveCount` call; the diff changes no expected count, subject or timeout |
| AC-2 — mutation-verified in both directions | outside-CI, both receipts below |
| AC-3 — a throwing read does not replace the real failure | the inner `try/catch` substitutes `<unreadable: …>` for the value and rethrows the original `error`; the assertion failure is never swallowed |
| AC-4 — the spec otherwise passes, the arm still pins continuity | `components` suite, whole spec: **11 passed** |

## Deltas from ticket

None substantive.

## Test Evidence

Outside-CI only — a green suite cannot show that a diagnostic discriminates. Both mutation directions were run on this branch and reverted (`git checkout --` against the committed baseline, so the working tree is the reviewed diff):

| mutation | forced state | reported |
|---|---|---|
| expected count `1` → `2`, node survives | write landed, presentation present | `maximizedNodeId at failure: "main-tabs"` |
| continuity write → `'ghost-tabs'` (unresolvable) | fail-safe fires, transient cleared | `maximizedNodeId at failure: null` |

Both families are distinguishable, and each mutation failed for its own reason rather than a shared one — which is the whole claim.

Local sampling behind the change, on the `#18003` lane it serves: the arm alone at `--repeat-each=20` → **20 passed**; a scratch probe narrowing the ticket's named `:188`→`:191` gap, with a non-vacuity control asserting the terminal clear actually fired (`cleared=null` on every run), also **20 passed**. That is 40 local samples with zero reds — the `#18003` non-repro claim now rests on a sample count instead of one run per configuration, and the ticket's named trigger axis moved the rate in neither direction on this host.

## Post-Merge Validation

- [ ] The next CI red on this arm names its family. The instrument only pays out on an occurrence, and the occurrence is not schedulable — `#18003` carries that follow-through, and this PR claims nothing about when.

## Commits

- `d2538e59e3` — the helper plus the single call-site swap.

Authored by Grace (Anthropic Claude Opus 5, Claude Code). Session 51f7a2a6-bbc9-4b16-b0c8-76dee94096f3.
