### PR TITLE
test(dashboard): an action arm proves its arity before it reads state (#18000)

### DIFF
--- a/test/playwright/component/dashboard/DockReload.spec.mjs
+++ b/test/playwright/component/dashboard/DockReload.spec.mjs
@@ -50,6 +50,25 @@ const tabButton = (node, text) => node.locator('.neo-tab-header-button', {hasTex
 
 const actionButton = (node, glyph) => node.locator(`.neo-tab-header-toolbar .neo-button:has([class*="${glyph}"])`);
 
+/**
+ * Proves an action locator resolves to exactly one node BEFORE any state is read off it.
+ *
+ * Playwright's strict mode refuses on arity before a state assertion evaluates anything, so a
+ * toolbar carrying two nodes surfaces as whichever assertion ran next — a message naming a
+ * property that was never read, with the real subject buried in a selector dump. Asserting the
+ * precondition first makes the failure name itself in one line, and fails earlier than the
+ * strict-mode abort it replaces.
+ * @param {Object} locator the action locator about to be read
+ * @param {String} subject the action's name, for the failure message
+ * @returns {Promise<Object>} the same locator, once its arity holds
+ */
+const soleAction = async (locator, subject) => {
+    await expect(locator, `${subject}: exactly one retained action node — two means duplicated tab-bar chrome`)
+        .toHaveCount(1);
+
+    return locator
+};
+
 test.beforeEach(async ({page}) => {
     await page.goto('test/playwright/component/apps/dock-maximize/index.html');
     await page.waitForSelector('#dock-maximize-workspace', {state: 'attached'});
@@ -58,17 +77,25 @@ test.beforeEach(async ({page}) => {
 
 test.describe('dock reload — delegation-only, settled, single-flight', () => {
     test('reload leads the engine set, focus-gated like its siblings', async ({page}) => {
-        const main = tabsNodeWith(page, 'Alpha');
+        const main     = tabsNodeWith(page, 'Alpha'),
+              reload   = actionButton(main, 'fa-rotate-right'),
+              maximize = actionButton(main, 'fa-window-maximize'),
+              close    = actionButton(main, 'fa-times');
 
-        await expect(actionButton(main, 'fa-rotate-right')).toHaveClass(/neo-toolbar-action-context-inactive/);
+        await soleAction(reload, 'reload');
+        await expect(reload).toHaveClass(/neo-toolbar-action-context-inactive/);
 
         await tabButton(main, 'Alpha').click();
-        await expect(actionButton(main, 'fa-rotate-right')).not.toHaveClass(/neo-toolbar-action-context-inactive/);
+        await soleAction(reload, 'reload');
+        await expect(reload).not.toHaveClass(/neo-toolbar-action-context-inactive/);
 
         // The frozen ordering contract as geometry: reload → maximize → close.
-        const reloadBox = await actionButton(main, 'fa-rotate-right').boundingBox(),
-              maxBox    = await actionButton(main, 'fa-window-maximize').boundingBox(),
-              closeBox  = await actionButton(main, 'fa-times').boundingBox();
+        await soleAction(maximize, 'maximize');
+        await soleAction(close,    'close');
+
+        const reloadBox = await reload.boundingBox(),
+              maxBox    = await maximize.boundingBox(),
+              closeBox  = await close.boundingBox();
 
         expect(reloadBox.x).toBeLessThan(maxBox.x);
         expect(maxBox.x).toBeLessThan(closeBox.x)
@@ -87,6 +114,7 @@ test.describe('dock reload — delegation-only, settled, single-flight', () => {
         const [docBefore] = await readInstance(page, WORKSPACE_ID, ['docJson']);
 
         await tabButton(main, 'Alpha').click();
+        await soleAction(actionButton(main, 'fa-rotate-right'), 'reload');
         await actionButton(main, 'fa-rotate-right').click();
 
         await expect.poll(() => lastSettled(page)).toEqual({errors: [], itemId: 'alpha'});
@@ -116,6 +144,7 @@ test.describe('dock reload — delegation-only, settled, single-flight', () => {
 
         const [docBefore] = await readInstance(page, WORKSPACE_ID, ['docJson']);
 
+        await soleAction(actionButton(side, 'fa-rotate-right'), 'reload');
         await actionButton(side, 'fa-rotate-right').click();
 
         await expect.poll(async () => (await lastSettled(page))?.errors?.[0] || '').toContain('probe refuses to reload');
@@ -138,9 +167,11 @@ test.describe('dock reload — delegation-only, settled, single-flight', () => {
 
         const [docBefore] = await readInstance(page, WORKSPACE_ID, ['docJson']);
 
+        await soleAction(reload, 'reload');
         await reload.click();
 
         // In flight: the stable instance disables; a second activation cannot double-invoke.
+        await soleAction(reload, 'reload');
         await expect(reload).toBeDisabled();
         await reload.click({force: true});
         await expect.poll(async () => (await readInstance(page, 'dock-maximize-pane-alpha', ['reloadCount']))[0]).toBe(1);
@@ -148,6 +179,7 @@ test.describe('dock reload — delegation-only, settled, single-flight', () => {
         // Resolution settles, re-enables.
         await setWorkspace(page, {alphaReloadResolveCount: 1});
         await expect.poll(() => lastSettled(page)).toEqual({errors: [], itemId: 'alpha'});
+        await soleAction(reload, 'reload');
         await expect(reload).toBeEnabled();
 
         // An async rejection settles with the failure text and keeps everything intact.
@@ -155,6 +187,7 @@ test.describe('dock reload — delegation-only, settled, single-flight', () => {
         await reload.click();
 
         await expect.poll(async () => (await lastSettled(page))?.errors?.[0] || '').toContain('async refusal');
+        await soleAction(reload, 'reload');
         await expect(reload).toBeEnabled();
         await expect.poll(async () => (await readInstance(page, 'dock-maximize-pane-alpha', ['reloadCount']))[0]).toBe(2);
 
@@ -184,12 +217,15 @@ test.describe('dock reload — delegation-only, settled, single-flight', () => {
 
         await tabButton(main, 'Alpha').click();
         await setWorkspace(page, {alphaReloadMode: 'defer'});
+        await soleAction(reload, 'reload');
         await reload.click();
+        await soleAction(reload, 'reload');
         await expect(reload).toBeDisabled();
 
         // beta shares the node and the contract but owns NO flight: the same action instance
         // must re-enable for it — inheriting alpha's window is the falsifier.
         await tabButton(main, 'Beta').click();
+        await soleAction(reload, 'reload');
         await expect(reload).toBeEnabled();
 
         // beta can even run its own (sync) delegation while alpha's flight is still open.
@@ -200,11 +236,13 @@ test.describe('dock reload — delegation-only, settled, single-flight', () => {
         // back on alpha the open flight must resurface as disabled — not the false-enable that
         // a blind `disabled = false` at beta's settlement would have written.
         await tabButton(main, 'Alpha').click();
+        await soleAction(reload, 'reload');
         await expect(reload).toBeDisabled();
 
         // releasing alpha's producer settles it and re-derives the enabled state.
         await setWorkspace(page, {alphaReloadResolveCount: 1});
         await expect.poll(() => lastSettled(page)).toEqual({errors: [], itemId: 'alpha'});
+        await soleAction(reload, 'reload');
         await expect(reload).toBeEnabled()
     });
 
@@ -222,19 +260,19 @@ test.describe('dock reload — delegation-only, settled, single-flight', () => {
         // The host workspace legally owns the NAME `reload` while the engine flag is off. The
         // engine's close action (its flag IS on) proves the sweep runs on this header — reload's
         // per-action guard, not a dead sweep, is what protects the host action.
-        await expect(close).toHaveCount(1);
-        await expect(reload).toHaveCount(1);
+        await soleAction(close,  'close');
+        await soleAction(reload, 'reload');
 
         // Active switches drive both sync paths (no-commit re-emit + committed activation); a
         // guardless sweep hides the host action here — the pane has no dockReload() contract.
         await tabButton(host, 'HostB').click();
         await expect(tabButton(host, 'HostB')).toHaveClass(/pressed/);
-        await expect(reload).toHaveCount(1);
+        await soleAction(reload, 'reload');
         await expect(reload).toBeEnabled();
 
         await tabButton(host, 'HostA').click();
         await expect(tabButton(host, 'HostA')).toHaveClass(/pressed/);
-        await expect(reload).toHaveCount(1);
+        await soleAction(reload, 'reload');
         await expect(reload).toBeEnabled()
     });
 
@@ -255,7 +293,9 @@ test.describe('dock reload — delegation-only, settled, single-flight', () => {
 
         await tabButton(main, 'Alpha').click();
         await setWorkspace(page, {alphaReloadMode: 'defer'});
+        await soleAction(actionButton(main, 'fa-rotate-right'), 'reload');
         await actionButton(main, 'fa-rotate-right').click();
+        await soleAction(actionButton(main, 'fa-rotate-right'), 'reload');
         await expect(actionButton(main, 'fa-rotate-right')).toBeDisabled();
 
         await page.evaluate(() => Neo.worker.App.destroyNeoInstance('dock-maximize-workspace'));
@@ -268,5 +308,43 @@ test.describe('dock reload — delegation-only, settled, single-flight', () => {
         await expect.poll(async () => (await readInstance(page, 'dock-maximize-probe', ['deferredReleasedTotal']))[0]).toBe(1);
 
         expect(pageErrs).toEqual([])
+    });
+
+    test('the arity guard names duplicated chrome, and the state read it protects does not', async ({page}) => {
+        const main   = tabsNodeWith(page, 'Alpha'),
+              reload = actionButton(main, 'fa-rotate-right');
+
+        await tabButton(main, 'Alpha').click();
+        await soleAction(reload, 'reload');
+
+        // The exact shape duplicated retained chrome produces: a second node, same id, in the
+        // same toolbar. Cloning the resolved node reproduces it without provoking the engine.
+        await reload.evaluate(node => node.parentElement.appendChild(node.cloneNode(true)));
+        await expect(reload, 'the injected duplicate is present — otherwise this proves nothing').toHaveCount(2);
+
+        let refusal = null;
+
+        try {
+            await soleAction(reload, 'reload')
+        } catch (error) {
+            refusal = String(error)
+        }
+
+        expect(refusal, 'the guard refuses a toolbar carrying two action nodes').not.toBeNull();
+        expect(refusal, 'the refusal names its subject in the message itself').toContain('duplicated tab-bar chrome');
+
+        // The reason the guard earns its place: reached unguarded, the state assertion reports a
+        // property strict mode never let it evaluate, and buries the real subject in a selector
+        // dump. Same duplicate, two messages — only one of them is readable.
+        let unguarded = null;
+
+        try {
+            await expect(reload).toBeEnabled({timeout: 1000})
+        } catch (error) {
+            unguarded = String(error)
+        }
+
+        expect(unguarded, 'the unguarded read aborts on arity, not on state').toContain('strict mode violation');
+        expect(unguarded, 'and it leads with the state it never evaluated').toContain('toBeEnabled')
     })
 });


### PR DESCRIPTION
Resolves #18000

🌿 A toolbar carrying two nodes can no longer report itself as a property nobody read.

Playwright's strict mode refuses on **arity** before a state assertion evaluates anything. So when duplicated retained chrome appeared, the failure led with `expect(locator).toBeEnabled() failed` — naming a state that was never evaluated — and buried the real subject, one toolbar carrying two nodes, in a selector dump. Every reader re-derived "is this mine?" from scratch.

I spent the first hour of this shift doing exactly that, on this exact message, before the signature resolved. That is the cost this closes.

## What this PR is not

It is **not** a fix for the duplication, and must not be read as one. That was `#17980`, whose cure merged as PR #17999 an hour ago. This changes how the symptom **reads**, never how often it occurs. The two must not be conflated in either direction.

It is also not a loosening. No locator became `.first()`, no matcher was relaxed, and no assertion was deleted — the guard fails *earlier* and more precisely than the strict-mode abort it replaces.

## AC Evidence

| AC | Evidence |
| --- | --- |
| AC-1 every state read on an action locator is preceded by an arity assertion naming duplicated chrome | `soleAction(locator, subject)` at 23 call sites, covering all six arms that read state off an action locator. Its message: `<subject>: exactly one retained action node — two means duplicated tab-bar chrome` |
| AC-2 the arm still reds when the duplicate occurs — injected node, not prose | new witness `the arity guard names duplicated chrome, and the state read it protects does not`. It clones the resolved node into the same toolbar (same id — the real defect's shape), asserts `toHaveCount(2)` so a failed injection cannot pass silently, then holds **both** halves: the guard refuses and its message contains `duplicated tab-bar chrome`, while the unguarded `toBeEnabled()` still yields `strict mode violation` and still leads with `toBeEnabled` |
| AC-2 mutation control | with the `toHaveCount(1)` inside `soleAction` removed: **only the witness reds** (1 failed / 9 passed). It is the guard the witness measures, not the fixture |
| AC-3 no assertion loosened | `git diff origin/dev...HEAD \| grep -cE '^\+.*\.(first\|nth\|last)\('` → **0**. The six removed `expect(...)` lines are two `toHaveClass` relocated onto a hoisted locator (same matcher, same subject) and four `toHaveCount(1)` that *became* `soleAction` — the same assertion plus a message |
| AC-4 `component/dashboard/` green at head | **59 passed** (58 before + this witness) |

## Deltas from ticket

Two, both widenings — neither narrows the AC:

- The ticket scoped the guard to `DockReload.spec.mjs`'s state assertions. The four arms that already asserted `toHaveCount(1)` (the `default-off` arm) had the arity but **not** the message, so they satisfied the mechanism and failed the AC's naming half. They now route through the same helper.
- The witness asserts the *unguarded* shape too — that `toBeEnabled` still aborts on arity and still leads with the state it never read. The ticket only required proving the guard fires. Holding both halves is what proves the guard is an improvement rather than a relabelling.

## Test Evidence

```
DockReload.spec.mjs                 10 passed  (9 existing + 1 witness)
component/dashboard/                59 passed
mutation: soleAction's toHaveCount removed
                                     1 failed / 9 passed  ← only the witness
```

The mutation arm carries a second reading worth stating: the other nine arms pass **unchanged** with the guard disabled, which is the evidence that the guard is inert when no duplicate exists. It adds a precondition, not a behaviour.

## Post-Merge Validation

`component/dashboard/` on `dev` after merge. The guard is only observable when a duplicate is present, so a green run proves inertness, not the guard — the witness is what proves the guard, and it runs in the same job.

## Commits

- `4f4347122a` test(dashboard): an action arm proves its arity before it reads state
