### PR TITLE
fix(grid): the post-load scroll dispatch owns its terminal outcome (#18010)

### DIFF
--- a/src/grid/Body.mjs
+++ b/src/grid/Body.mjs
@@ -1251,6 +1251,15 @@ class GridBody extends Component {
      * @param {Boolean}  [data.postChunkLoad]
      * @param {Number}   [data.total]
      * @protected
+     *
+     * The scroll-to-top nudge is a detached dispatch: it fires 50ms after the mount check, so by
+     * the time the message is sent the body may be destroyed (`core.Base#destroy` rejects pending
+     * timeouts with `Neo.isDestroyed`) or the destination window may be gone (`worker.Base`
+     * rejects with `code: 'NEO_DEAD_PORT'`). Both are expected outcomes of a scroll into somewhere
+     * that no longer exists, not failures to report — and because a store load runs on every
+     * collection mutation, leaving either unhandled turns a ticking feed into one uncaught
+     * rejection per tick. Anything else IS a live failure, and this chain has no caller to
+     * propagate to, so the console is the honest terminal surface.
      */
     onStoreLoad({ forceViewData, items, postChunkLoad, total }) {
         let me = this,
@@ -1267,14 +1276,17 @@ class GridBody extends Component {
         }
 
         if (me.mounted && !postChunkLoad) {
-            me.timeout(50).then(() => {
-                Neo.main.DomAccess.scrollTo({
+            me.timeout(50)
+                .then(() => Neo.main.DomAccess.scrollTo({
                     direction: 'top',
                     id: me.gridContainer.view.id,
                     value: 0,
                     windowId
+                }))
+                .catch(reason => {
+                    reason !== Neo.isDestroyed && reason?.code !== 'NEO_DEAD_PORT' &&
+                        console.error('grid.Body: scroll-to-top dispatch failed', {reason, windowId})
                 })
-            })
         }
     }
 

--- a/src/table/Body.mjs
+++ b/src/table/Body.mjs
@@ -578,6 +578,15 @@ class TableBody extends Component {
      * @param {Object[]} data.items
      * @param {Number}   [data.total]
      * @protected
+     *
+     * The scroll-to-top nudge is a detached dispatch: it fires 50ms after the mount check, so by
+     * the time the message is sent the body may be destroyed (`core.Base#destroy` rejects pending
+     * timeouts with `Neo.isDestroyed`) or the destination window may be gone (`worker.Base`
+     * rejects with `code: 'NEO_DEAD_PORT'`). Both are expected outcomes of a scroll into somewhere
+     * that no longer exists, not failures to report — and because a store load runs on every
+     * collection mutation, leaving either unhandled turns a ticking feed into one uncaught
+     * rejection per tick. Anything else IS a live failure, and this chain has no caller to
+     * propagate to, so the console is the honest terminal surface.
      */
     onStoreLoad(data) {
         let me         = this,
@@ -611,14 +620,17 @@ class TableBody extends Component {
         me.createViewData();
 
         if (me.mounted) {
-            me.timeout(50).then(() => {
-                Neo.main.DomAccess.scrollTo({
+            me.timeout(50)
+                .then(() => Neo.main.DomAccess.scrollTo({
                     direction: 'top',
                     id       : me.vdom.id,
                     value    : 0,
                     windowId
+                }))
+                .catch(reason => {
+                    reason !== Neo.isDestroyed && reason?.code !== 'NEO_DEAD_PORT' &&
+                        console.error('table.Body: scroll-to-top dispatch failed', {reason, windowId})
                 })
-            })
         }
     }
 

--- a/test/playwright/unit/grid/DispatchTerminalOutcome.spec.mjs
+++ b/test/playwright/unit/grid/DispatchTerminalOutcome.spec.mjs
@@ -1,0 +1,176 @@
+/**
+ * @file test/playwright/unit/grid/DispatchTerminalOutcome.spec.mjs
+ * @summary The post-load scroll dispatch owns its terminal outcome in both body classes.
+ *
+ * `onStoreLoad()` nudges the view back to the top through a detached dispatch: a 50ms timeout,
+ * then `Neo.main.DomAccess.scrollTo`. Nothing awaits the result, so every way that dispatch can
+ * fail has to be disposed of at the call site or it surfaces as `Uncaught (in promise)` — once
+ * per store mutation, which on a ticking feed is once per tick.
+ *
+ * Two failures are expected rather than exceptional, and each is silent:
+ * - the body is destroyed inside the 50ms window (`core.Base#destroy` rejects pending timeouts
+ *   with the `Neo.isDestroyed` sentinel), so the dispatch never fires;
+ * - the destination window has closed (`worker.Base` rejects with `code: 'NEO_DEAD_PORT'`).
+ *
+ * Everything else is a live failure and MUST still reach the console — a blanket catch would fix
+ * the noise and destroy the signal, which is the whole reason the dead-port reason is typed.
+ *
+ * These arms drive the promise chain directly rather than through a rendered grid: a real
+ * `GridContainer` needs browsers and would carry `NEO_TEST_SKIP_CI`, which would keep the arms
+ * out of the CI job where the storm was observed. `createViewData` is stubbed because it is not
+ * the subject; `onStoreLoad` itself is the real method under test.
+ *
+ * @see Neo.grid.Body
+ * @see Neo.table.Body
+ */
+
+import {setup} from '../../setup.mjs';
+
+setup({
+    neoConfig: {
+        unitTestMode : true,
+        useVdomWorker: false
+    },
+    appConfig: {
+        name             : 'GridDispatchTerminalTest',
+        vnodeInitialising: false
+    }
+});
+
+import {test, expect} from '@playwright/test';
+import Neo            from '../../../../src/Neo.mjs';
+import * as core      from '../../../../src/core/_export.mjs';
+import GridBody       from '../../../../src/grid/Body.mjs';
+import TableBody      from '../../../../src/table/Body.mjs';
+
+const DEAD_PORT = () => Object.assign(new Error('no live port for destination "main" — a window closed?'),
+    {code: 'NEO_DEAD_PORT'});
+
+test.describe('post-load scroll dispatch — terminal outcome is owned, never dropped', () => {
+    let body, restoreDomAccess;
+
+    /**
+     * Drives one store load with `scrollTo` rejecting for the supplied reason, and records every
+     * channel the outcome could escape through.
+     * @param {Object}   options
+     * @param {Object}   options.body       a grid or table body, already mounted
+     * @param {*}        [options.reason]   what the dispatch rejects with
+     * @param {Function} [options.midFlight] runs inside the 50ms window, before the dispatch
+     * @returns {Promise<Object>} {unhandled, consoleErrors, dispatchCount}
+     */
+    const driveLoad = async ({body, reason, midFlight}) => {
+        const unhandled     = [],
+              consoleErrors = [],
+              onUnhandled   = value => unhandled.push(value),
+              originalError = console.error;
+
+        let dispatchCount = 0;
+
+        Neo.main.DomAccess = {
+            scrollTo() {
+                dispatchCount++;
+                return Promise.reject(reason)
+            }
+        };
+
+        process.on('unhandledRejection', onUnhandled);
+        console.error = (...args) => consoleErrors.push(args);
+
+        try {
+            // Non-empty on purpose: table.Body fast-paths an empty load straight back out
+            // (the removeAll() clearing path), which would skip the dispatch and leave the
+            // twin's arm asserting nothing. The dispatchCount assertion is what caught it.
+            body.onStoreLoad({items: [{id: 1}]});
+            midFlight?.();
+
+            // Past the 50ms dispatch window, then far enough for Node to have decided a rejection
+            // is unhandled — that verdict lands a macrotask after the microtask queue drains.
+            await new Promise(resolve => setTimeout(resolve, 300))
+        } finally {
+            process.off('unhandledRejection', onUnhandled);
+            console.error = originalError
+        }
+
+        return {unhandled, consoleErrors, dispatchCount}
+    };
+
+    const makeBody = Cls => {
+        const instance = Neo.create(Cls, {
+            appName : 'GridDispatchTerminalTest',
+            // table.Body always instantiates a selection.table.RowModel (its beforeSet coerces
+            // even a null into one), and that model binds a rowClick listener to the body's
+            // parent during construction. `parent` is a derived getter that prefers
+            // `parentComponent`, so this is the seam a minimal Observable can occupy.
+            parentComponent: {on() {}},
+            windowId       : 1
+        });
+
+        instance.createViewData = () => {};
+        instance.gridContainer  = {view: {id: 'probe-view'}};
+        instance.mounted        = true;
+
+        return instance
+    };
+
+    test.beforeEach(() => {
+        restoreDomAccess = Neo.main?.DomAccess
+    });
+
+    test.afterEach(() => {
+        body?.isDestroyed === false && body.destroy();
+        body = null;
+
+        if (restoreDomAccess === undefined) {
+            delete Neo.main.DomAccess
+        } else {
+            Neo.main.DomAccess = restoreDomAccess
+        }
+    });
+
+    test('a closed destination window settles silently — grid', async () => {
+        body = makeBody(GridBody);
+
+        const {unhandled, consoleErrors, dispatchCount} = await driveLoad({body, reason: DEAD_PORT()});
+
+        expect(dispatchCount, 'the dispatch fired — without it nothing could have rejected and this arm is vacuous').toBe(1);
+        expect(unhandled,     'a closed window is an expected outcome, not an uncaught rejection').toEqual([]);
+        expect(consoleErrors, 'and it is not worth reporting either').toEqual([])
+    });
+
+    test('a closed destination window settles silently — table twin', async () => {
+        body = makeBody(TableBody);
+
+        const {unhandled, consoleErrors, dispatchCount} = await driveLoad({body, reason: DEAD_PORT()});
+
+        expect(dispatchCount, 'the dispatch fired').toBe(1);
+        expect(unhandled,     'the twin owns its terminal outcome too').toEqual([]);
+        expect(consoleErrors, 'silently, for the same reason').toEqual([])
+    });
+
+    test('a LIVE failure still reaches the console — the signal survives the fix', async () => {
+        body = makeBody(GridBody);
+
+        const reason                                    = new Error('DomAccess exploded');
+        const {unhandled, consoleErrors, dispatchCount} = await driveLoad({body, reason});
+
+        expect(dispatchCount, 'the dispatch fired').toBe(1);
+        expect(unhandled,     'a live failure is handled rather than left uncaught').toEqual([]);
+        expect(consoleErrors, 'but it is REPORTED — a blanket catch would make this indistinguishable from teardown').toHaveLength(1);
+        expect(consoleErrors[0][0]).toContain('scroll-to-top dispatch failed');
+        expect(consoleErrors[0][1].reason, 'and the reason survives to the reader').toBe(reason)
+    });
+
+    test('a body destroyed inside the dispatch window settles silently', async () => {
+        body = makeBody(GridBody);
+
+        const {unhandled, consoleErrors, dispatchCount} = await driveLoad({
+            body,
+            reason   : DEAD_PORT(),
+            midFlight: () => body.destroy()
+        });
+
+        expect(dispatchCount, 'destroy rejects the pending timeout, so the dispatch never fires — that is the subject here').toBe(0);
+        expect(unhandled,     'the Neo.isDestroyed sentinel is an expected outcome').toEqual([]);
+        expect(consoleErrors, 'teardown is not an error to report').toEqual([])
+    })
+});


### PR DESCRIPTION
Resolves #18010

🌿 A scroll into a window that has closed can no longer flood the console it was never speaking to.

`onStoreLoad()` nudges the view to the top through a detached dispatch — a 50 ms timeout, then `Neo.main.DomAccess.scrollTo` — and dropped the promise inside the `.then()` callback. A store load runs on every collection mutation, so on a ticking feed that is one `Uncaught (in promise)` **per tick**, until the console is unreadable and every real error is buried underneath it.

Both bodies now dispose of the two routine outcomes and nothing else.

## What this PR is not

It does **not** decide the engine-wide contract. 97-or-so dispatch sites and a central seam is a shaping question, and a bug ticket that quietly settles it sets a precedent nobody reviewed — so it is routed to https://github.com/orgs/neomjs/discussions/18012 with a four-option divergence matrix, and this PR does not wait on it.

It is also not a `.catch(() => {})`. That fixes the console and destroys the signal, which is the entire reason #17894 typed the dead-port reason instead of swallowing it.

## AC Evidence

| AC | Evidence |
| --- | --- |
| AC-1 a rejecting dispatch produces no unhandled rejection, proven by forcing the reject path | `unit/grid/DispatchTerminalOutcome.spec.mjs` — `scrollTo` is replaced with a rejecting stub and `process.on('unhandledRejection')` collects anything that escapes. Arms for both bodies |
| AC-2 red against current `dev` | reverting both source files to `origin/dev` with the spec unchanged: **3 failed / 1 passed** |
| AC-2 non-vacuity | every arm asserts `dispatchCount`. This caught a real vacuity: `table.Body` fast-paths an empty load straight back out, so the twin's arm was skipping the dispatch entirely and asserting nothing. Items are non-empty now because of that |
| AC-2 the fourth arm needed its **own** mutation | the destroy arm passes against unfixed `dev`, so the `dev` revert does not prove it. Its subject is that the *new* handler stays silent on teardown — removing the `Neo.isDestroyed` clause reds exactly that arm, with `grid.Body: scroll-to-top dispatch failed` in the diff |
| AC-3 the `table.Body` twin carries the same disposition and its own arm | same chain shape, same discriminators, same JSDoc clause; `a closed destination window settles silently — table twin` |
| AC-4 #17894's typed rejection still rejects and carries its reason | `unit/worker/Base.spec.mjs:63` already asserts `reason.code === 'NEO_DEAD_PORT'` on the producer — green here, cited rather than duplicated. The consumer half is asserted too: a live failure still reaches `console.error` **carrying the reason object**, so "handled" is not silently "silenced" |
| AC-5 census live against the merge tree | below, with the commands |
| AC-6 Discussion exists and is linked | https://github.com/orgs/neomjs/discussions/18012, linked back on the ticket |

## The census, and why it is published as commands

Re-measured at `d33303a56a`, on the merge tree this now targets — `dev@bd463173f2` — after @neo-gpt correctly noted the census has to describe the tree it merges into, not the one it was written against. `#18005` landed in between. Every figure is unchanged, which is a result rather than an assumption: I ran the commands again instead of relabelling the old numbers.

```
A  grep -rEo 'Neo\.main\.[A-Z][A-Za-z0-9]*\.[a-z][A-Za-z0-9]*\(' src --include='*.mjs' | wc -l   →  49
B  grep -rEo 'Neo\.main\.[A-Za-z.]+\.[a-zA-Z][A-Za-z0-9]*\(' src --include='*.mjs' | wc -l       → 134
C  grep -rc '\.catch(' src --include='*.mjs' | awk -F: '{s+=$2} END {print s}'                   →  32
```

The ticket recorded 97 and 8. I could not reproduce 97 with either bracket, so I am publishing methods rather than replacing a peer's number with mine — these are three different questions, not two-hour drift. **C is the one figure with an internal control:** reverting just my two source files to `dev` on this exact tree drops it 32 → **30**, exactly the two handlers added. That control was re-run on the new base too.

That the population resists a single number is not incidental. The ticket's own Avoided Traps says the same omission is *correct* wherever the dispatch cannot reject — so the discriminator is runtime teardown state, not syntax, and a mechanical census is itself an open question. It is OQ-3 in the Discussion.

## Deltas from ticket

One addition, and it changed the fix rather than decorating it.

The body names `NEO_DEAD_PORT`. It does not name the **second** expected rejection: `core.Base#destroy()` rejects pending timeouts with the `Neo.isDestroyed` sentinel (`core/Base.mjs:516`), and the dispatch sits behind `me.timeout(50)`. A handler discriminating only on the dead port would have turned every teardown into a `console.error` — replacing a rejection storm with an error storm. Both discriminators mirror existing consumers rather than inventing a disposition:

| reason | precedent |
| --- | --- |
| `code: 'NEO_DEAD_PORT'` | `draggable/DragZone.mjs:445` |
| `Neo.isDestroyed` | `dashboard/dock/interaction/DockSplitter.mjs:499` |

Also worth flagging for the next reader: the inner promise was **not returned** from the `.then()` callback, so appending `.catch()` to the outer chain would have caught nothing.

## Test Evidence

```
unit/grid/DispatchTerminalOutcome.spec.mjs            4 passed
unit/{worker,grid,table,draggable}/                 148 passed

mutation — both source files reverted to origin/dev   3 failed / 1 passed
mutation — Neo.isDestroyed clause removed             1 failed / 3 passed  ← the destroy arm
```

The two mutations are complementary on purpose: the first kills the three dispatch arms, the second kills the arm the first cannot reach. Each arm has a mutation that kills it.

The arms deliberately drive the promise chain rather than a rendered grid. A real `GridContainer` needs browsers and would carry `NEO_TEST_SKIP_CI` — which is what the five existing grid specs do — and that would keep these arms out of the CI job where the storm was observed. `createViewData` is stubbed because it is not the subject; `onStoreLoad` is the real method under test.

## Post-Merge Validation

`unit` on `dev` after merge. The user-visible check is @tobiu's original one: open a built portal with a ticking feed and watch the console stay readable.

## Commits

- `d33303a56a` fix(grid): the post-load scroll dispatch owns its terminal outcome

*(rebased from `56f07411a8` onto `dev@bd463173f2` at @neo-gpt's request; the diff is unchanged and all four evidence rows above were re-run on the new base, not carried over.)*
