### PR TITLE
fix(toolbar): a withdrawn action takes no space in the rail (#18015)

### DIFF
--- a/resources/scss/src/toolbar/Base.scss
+++ b/resources/scss/src/toolbar/Base.scss
@@ -11,9 +11,17 @@
         }
     }
 
+    // A gated action that is not being offered takes NO space. `visibility: hidden` kept the box
+    // and left a hole between the actions that are offered — a rail whose gaps encode what the
+    // user cannot currently do. Collapsing the box means the visible actions sit together and a
+    // revealed one grows the cluster rather than filling a reserved slot.
+    //
+    // The tab-overflow partition measures these boxes, so a focus change can now move a tab into
+    // or out of the overflow menu. That repartition is accepted: an honest resting rail is worth
+    // more than a partition that never moves.
     .neo-toolbar-action-context-inactive {
+        display       : none;
         pointer-events: none;
-        visibility    : hidden;
     }
 
     &.neo-dock-left {

--- a/src/tab/plugin/Overflow.mjs
+++ b/src/tab/plugin/Overflow.mjs
@@ -295,13 +295,19 @@ class Overflow extends Plugin {
     }
 
     /**
-     * Visible or geometry-reserved actions which reduce the tab strip's main-axis extent.
+     * Actions which actually reduce the tab strip's main-axis extent.
+     *
+     * A contextually inactive action is collapsed out of the layout, so it must be excluded here
+     * rather than measured: a collapsed node reports an all-zero rect, and this measurement reads
+     * the rect's POSITION as well as its size. Measuring one would place the action cluster at
+     * offset 0 and consume the entire strip, collapsing every tab into the overflow menu.
      * @returns {Neo.component.Base[]}
      */
     getActionItems() {
         return (this.owner.getActionItems?.() || [])
             .filter(item => item !== this.control)
             .filter(item => !item.hidden || item.hideMode === 'visibility')
+            .filter(item => !(item.cls || []).includes('neo-toolbar-action-context-inactive'))
     }
 
     /**
@@ -688,8 +694,9 @@ class Overflow extends Plugin {
             }
 
             // 2. The strip extent — actions consume the same main axis but stay outside tab packing.
-            // Contextually inactive actions remain rendered, so their extent stays reserved without
-            // a focus-time repartition.
+            // A contextually inactive action is collapsed out of the layout, so it contributes a
+            // zero rect here and the extent tracks what is actually offered. A focus change can
+            // therefore repartition the tabs; that is intended, not a regression.
             let actionItems   = me.getActionItems(),
                 controlId     = me.control?.mounted ? me.control.id : null,
                 ids           = [owner.id, ...actionItems.map(item => item.id), ...(controlId ? [controlId] : [])],

--- a/src/toolbar/Base.mjs
+++ b/src/toolbar/Base.mjs
@@ -213,7 +213,8 @@ class Toolbar extends Container {
     }
 
     /**
-     * Reserves or releases contextual action interactivity while preserving layout geometry.
+     * Offers or withdraws the contextual actions. A withdrawn action is removed from the layout,
+     * not merely made invisible — the rail must not encode absent affordances as empty space.
      * @param {Boolean} [silent=false]
      */
     applyContextualActionState(silent=false) {

--- a/test/playwright/component/dashboard/DockMaximize.spec.mjs
+++ b/test/playwright/component/dashboard/DockMaximize.spec.mjs
@@ -99,8 +99,8 @@ test.describe('dock maximize — presentation, never topology', () => {
     test('the toggle is focus-gated beside an always-visible close, in the frozen order', async ({page}) => {
         const main = tabsNodeWith(page, 'Alpha');
 
-        // Focus-gated through the toolbar's geometry-preserving carrier: the maximize control is
-        // rendered but context-inactive until the container holds focus; the close action's
+        // Focus-gated: the maximize control is collapsed out of the layout until the container
+        // holds focus, so it costs no rail space while withdrawn; the close action's
         // `contextual: false` exemption is the visible contrast.
         await expect(actionButton(main, 'fa-window-maximize')).toHaveClass(/neo-toolbar-action-context-inactive/);
         await expect(actionButton(main, 'fa-times')).not.toHaveClass(/neo-toolbar-action-context-inactive/);

--- a/test/playwright/component/dashboard/DockPopOut.spec.mjs
+++ b/test/playwright/component/dashboard/DockPopOut.spec.mjs
@@ -77,9 +77,9 @@ test.describe('dock pop-out — the click is the drag terminal', () => {
     test('pop-out holds the frozen family slot, focus-gated beside an always-visible close', async ({page}) => {
         const main = tabsNodeWith(page, 'Alpha');
 
-        // Focus-gated through the toolbar's geometry-preserving carrier: rendered, but
-        // context-inactive until the container holds focus. Close's `contextual: false` exemption
-        // is the visible contrast.
+        // Focus-gated: collapsed out of the layout entirely until the container holds focus, so a
+        // withdrawn action costs no rail space. Close's `contextual: false` exemption is the
+        // visible contrast — it is the one action that is always on offer.
         await expect(actionButton(main, 'fa-window-restore')).toHaveClass(/neo-toolbar-action-context-inactive/);
         await expect(actionButton(main, 'fa-times')).not.toHaveClass(/neo-toolbar-action-context-inactive/);
 

--- a/test/playwright/component/dashboard/DockPopOut.spec.mjs
+++ b/test/playwright/component/dashboard/DockPopOut.spec.mjs
@@ -96,6 +96,11 @@ test.describe('dock pop-out — the click is the drag terminal', () => {
 
         await tabButton(edge, 'Pinned').click();
 
+        // Wait for the gate to actually open before measuring. A collapsed action has no box at
+        // all, so reading geometry while the reveal is still in flight yields null rather than a
+        // stale-but-plausible rect — the race the previous box-preserving contract hid.
+        await expect(actionButton(edge, 'fa-thumbtack')).not.toHaveClass(/neo-toolbar-action-context-inactive/);
+
         for (const [name, glyph] of [
             ['pin',      'fa-thumbtack'],
             ['popOut',   'fa-window-restore'],

--- a/test/playwright/component/dashboard/DockRailPartition.spec.mjs
+++ b/test/playwright/component/dashboard/DockRailPartition.spec.mjs
@@ -1,0 +1,63 @@
+import {test, expect} from '@playwright/test';
+
+/**
+ * A collapsed header action must not reach `Neo.tab.plugin.Overflow`'s measurement.
+ *
+ * A context-inactive action is removed from layout, so it reports an all-zero DOM rect. The plugin
+ * reads each action rect's POSITION as well as its size, so measuring one places the action cluster
+ * at offset 0 and the strip reads as fully consumed — every tab but the active one is driven into
+ * the overflow menu. `Overflow#getActionItems()` therefore excludes collapsed actions rather than
+ * measuring them.
+ *
+ * This lives on the dock fixture and not beside the other Overflow arms on purpose: a standalone
+ * `tab.Container` has no focus subject, so its gated actions never withdraw, and an arm written
+ * there passes whether or not the exclusion exists. The dock header is where a real gated action
+ * and a real overflow control coexist on a wide strip, which is the only place the zero-rect
+ * collapse is observable.
+ */
+
+const tabsNodeWith = (page, tabText) => page.locator('.neo-dashboard-dock-tabs', {
+    has: page.locator(`.neo-tab-header-button:has-text("${tabText}")`)
+});
+
+/** Rail geometry for one dock header: strip width, direct tabs, and the collapsed action count. */
+const readRail = node => node.locator(':scope > .neo-tab-header-toolbar').evaluate(bar => {
+    const children = [...bar.children],
+          actions  = children.filter(child => child.classList.contains('neo-toolbar-action'));
+
+    return {
+        barWidth  : Math.round(bar.getBoundingClientRect().width),
+        directTabs: children.filter(child => child.classList.contains('neo-tab-header-button')).length,
+        collapsed : actions.filter(action => getComputedStyle(action).display === 'none').length,
+        hasControl: !!bar.querySelector('.fa-ellipsis')
+    }
+});
+
+test.beforeEach(async ({page}) => {
+    await page.goto('test/playwright/component/apps/dock-maximize/index.html');
+    await page.waitForSelector('#dock-maximize-workspace', {state: 'attached'});
+    await page.waitForSelector('.neo-tab-header-button',   {state: 'visible'})
+});
+
+test.describe('dock rail — a collapsed action contributes no extent', () => {
+    test('the tab partition survives withdrawn actions on a wide strip', async ({page}) => {
+        const main = tabsNodeWith(page, 'Alpha');
+
+        await expect(main).toHaveCount(1);
+
+        const rail = await readRail(main);
+
+        // Non-vacuity, both halves. Without a genuinely collapsed action there is no zero rect to
+        // mis-measure, and without a wide strip a one-tab partition is indistinguishable from the
+        // defect's output. Either precondition failing must red here rather than pass quietly.
+        expect(rail.collapsed, `at least one action must actually be collapsed — ${JSON.stringify(rail)}`)
+            .toBeGreaterThan(0);
+        expect(rail.barWidth, `the strip must be wide enough to hold several tabs — ${JSON.stringify(rail)}`)
+            .toBeGreaterThan(400);
+
+        // The subject. Measuring a collapsed action's all-zero rect places the cluster at offset 0
+        // and consumes the whole strip, leaving exactly the active tab.
+        expect(rail.directTabs, `tabs must stay directly reachable — ${JSON.stringify(rail)}`)
+            .toBeGreaterThan(1)
+    })
+});

--- a/test/playwright/component/tab/ContainerUi.spec.mjs
+++ b/test/playwright/component/tab/ContainerUi.spec.mjs
@@ -269,7 +269,12 @@ test.describe('Neo.tab.Container — ui variants', () => {
 
             const exposedBox = await gatedAction.boundingBox();
 
-            expect(exposedBox, 'focus gating preserves the action box').toEqual(gatedBox);
+            // A gated action is collapsed OUT of the layout, so while quiet it has no box at all.
+            // The superseded contract preserved the box and left a hole in the rail between the
+            // actions actually on offer; revealing an action now grows the cluster instead of
+            // filling a slot that was already paid for.
+            expect(gatedBox,   'a gated action occupies no space').toBeNull();
+            expect(exposedBox, 'revealing it gives it a box').not.toBeNull();
 
             const measured = {
                 default   : await readVariant(page, 'tab-ui-default'),

--- a/test/playwright/component/tab/OverflowAction.spec.mjs
+++ b/test/playwright/component/tab/OverflowAction.spec.mjs
@@ -228,5 +228,111 @@ test.describe('Neo.tab.plugin.Overflow — toolbar action projection', () => {
             'no pass re-applies a superseded extent once the contribution is restored').toEqual([]);
         expect(afterRestore.at(-1).split(',')[0], 'the contribution holds the first action slot')
             .toBe(controlId)
+    });
+
+    test('a withdrawn focus-gated action contributes no extent to the partition', async ({page}) => {
+        // The other arms in this file use `showOnFocus: false` throughout, so none of them exercise
+        // the plugin against a collapsed action. This one does: a gated action is removed from the
+        // layout while withdrawn, and the plugin must therefore EXCLUDE it from measurement rather
+        // than measure it. A collapsed node reports an all-zero rect, and this measurement reads the
+        // rect's POSITION as well as its size — measuring one places the action cluster at offset 0
+        // and consumes the whole strip, collapsing every tab into the overflow menu.
+        await page.evaluate(id => Neo.worker.App.destroyNeoInstance(id), componentId);
+
+        componentId = await page.evaluate(async id => {
+            const result = await Neo.worker.App.createNeoInstance({
+                activeIndex  : 0,
+                height       : 240,
+                headerActions: [{
+                    action     : 'host-action',
+                    iconCls    : 'fa fa-star',
+                    showOnFocus: false
+                }, {
+                    // Focus-gated: the subject of this arm.
+                    action : 'gated-action',
+                    iconCls: 'fa fa-thumbtack'
+                }, {
+                    action     : 'close',
+                    iconCls    : 'fa fa-times',
+                    showOnFocus: false
+                }],
+                headerToolbar: {plugins: [{ntype: 'plugin-tab-overflow', projectAsAction: true}]},
+                id,
+                importPath   : '../tab/Container.mjs',
+                items        : Array.from({length: 8}, (_, index) => ({
+                    header: {text: `Tab ${index + 1}`},
+                    ntype : 'component',
+                    text  : `Content ${index + 1}`
+                })),
+                ntype   : 'tab-container',
+                parentId: 'component-test-viewport',
+                width   : 380
+            });
+
+            if (!result.success) {
+                throw new Error(`gated TabContainer creation failed: ${result.error.message}`)
+            }
+
+            return result.id
+        }, TAB_ID);
+
+        await page.waitForSelector(`#${componentId}`, {state: 'attached'});
+
+        const root    = page.locator(`#${TAB_ID}`),
+              toolbar = root.locator(':scope > .neo-tab-header-toolbar'),
+              control = toolbar.getByRole('button', {name: 'More tabs', exact: true}),
+              gated   = toolbar.locator(':scope > .neo-toolbar-action:has(.fa-thumbtack)'),
+              tabs    = toolbar.locator(':scope > .neo-tab-header-button');
+
+        await expect(gated, 'the gated action is projected').toHaveCount(1);
+        await expect(control, 'precondition: the strip overflows, so a partition exists to lose')
+            .toBeVisible({timeout: 10000});
+
+        const toolbarId = await toolbar.getAttribute('id'),
+              setGate   = visible => page.evaluate(
+                  ({id, visible}) => Neo.worker.App.setConfigs({id, contextualActionsVisible: visible}),
+                  {id: toolbarId, visible}
+              );
+
+        // The withdrawn state is pinned through the SAME reactive config the focus wiring writes
+        // (`toolbar.Base#contextualActionsVisible`), rather than by moving real focus. A standalone
+        // container has no focus subject holding focus, so driving the config is what makes the
+        // state deterministic here — and it is the identical state, not a proxy for it.
+        await setGate(false);
+        await expect(gated, 'the action is withdrawn').toHaveClass(/neo-toolbar-action-context-inactive/);
+
+        // Force a re-partition WHILE the action is collapsed. Toggling the gate alone does not
+        // re-measure, and the all-zero-rect defect only surfaces on a measurement pass: without
+        // this the arm passes whether or not the plugin excludes collapsed actions, which is the
+        // vacuity this control exists to remove.
+        await page.evaluate(id => Neo.worker.App.setConfigs({id, width: 1200}), TAB_ID);
+        await expect(toolbar.locator('.neo-tab-overflow-control'), 'all-fit retires the contribution')
+            .toHaveCount(0, {timeout: 10000});
+        await page.evaluate(id => Neo.worker.App.setConfigs({id, width: 380}), TAB_ID);
+
+        // Withdrawn: no box at all, so it cannot be measured into the strip extent.
+        expect(await gated.boundingBox(), 'a withdrawn action occupies no space').toBeNull();
+
+        // The partition stays usable. This is the assertion that reds when the plugin measures the
+        // collapsed action's all-zero rect: the cluster is then placed at offset 0, the strip reads
+        // as fully consumed, and every non-active tab is driven into the menu.
+        await expect(control, 'the overflow control is contributed').toHaveCount(1);
+        expect(await tabs.count(), 'direct tabs remain reachable without opening the menu')
+            .toBeGreaterThan(1);
+
+        const directTabs = await tabs.count();
+
+        // Revealing it must not break the invariants the other arms protect.
+        await setGate(true);
+        await expect(gated, 'the reveal exposes the gated action').not.toHaveClass(/neo-toolbar-action-context-inactive/);
+        expect(await gated.boundingBox(), 'and revealing it gives it a box').not.toBeNull();
+
+        await expect(control, 'the overflow control survives the reveal').toHaveCount(1);
+        await expect(toolbar.locator(':scope > .neo-tab-header-button.pressed'),
+            'exactly one tab stays active across the reveal').toHaveCount(1);
+        expect(await tabs.count(), 'the reveal may repartition, but never empties the strip')
+            .toBeGreaterThan(0);
+        expect(directTabs, 'precondition sanity: the withdrawn state had a real partition to lose')
+            .toBeGreaterThan(1)
     })
 });

--- a/test/playwright/component/tab/OverflowAction.spec.mjs
+++ b/test/playwright/component/tab/OverflowAction.spec.mjs
@@ -239,6 +239,14 @@ test.describe('Neo.tab.plugin.Overflow — toolbar action projection', () => {
         // and consumes the whole strip, collapsing every tab into the overflow menu.
         await page.evaluate(id => Neo.worker.App.destroyNeoInstance(id), componentId);
 
+        // This arm is the only one that replaces the shared `beforeEach` container, and it reuses the
+        // same id. Resolving the worker-side destroy does NOT mean the DOM is gone: the removal travels
+        // to main as a separate message, so re-creating immediately can mount the new header while the
+        // old one is still attached. Two toolbars then answer to one id and the strict-mode locators
+        // below abort on arity — and the orphan outlives the test, because the App Worker is shared, so
+        // the casualty surfaces in whatever spec runs next. Await the detach; it is the actual barrier.
+        await page.waitForSelector(`#${TAB_ID}`, {state: 'detached'});
+
         componentId = await page.evaluate(async id => {
             const result = await Neo.worker.App.createNeoInstance({
                 activeIndex  : 0,


### PR DESCRIPTION
Resolves #18015

Related: #17836 · #18014

**Evidence:** `component/dashboard/` + `component/tab/` **72 passed × 6 consecutive runs** at `7565fbfbb8`, rebased on `dev@a9215920c8` · **two independent firing controls**, one per fix · a review-found intermittent in my own test, isolated by matched arms and fixed.

🌿 A rail can no longer spend space on an affordance it is refusing to offer.

Two inactive 24px actions reserved a 48px hole between the overflow cluster and `close` on a live Workstation header. `visibility: hidden` kept their boxes; `toolbar.Base` said so in its own JSDoc — *"while preserving layout geometry"* — so this reverses a stated contract rather than fixing an oversight, and the doc changes with it.

Collapsing them alone then broke the tab partition: a collapsed action reports an **all-zero rect**, and `Overflow` reads each action rect's POSITION as well as its size, so the cluster measured as starting at offset 0 and consumed the whole strip. Both fixes are required; each now has its own control.

## AC Evidence

| AC | Evidence |
| --- | --- |
| AC-1 collapse inactive actions out of layout, same component instances | `toolbar/Base.scss` — `display: none` replaces `visibility: hidden`; `applyContextualActionState` still toggles the class on the retained instance, untouched |
| AC-2 exclude collapsed actions from Overflow measurement | `Overflow#getActionItems()` filters `neo-toolbar-action-context-inactive` |
| AC-3 comments state the accepted repartition | `toolbar/Base.scss`, `toolbar/Base.mjs`, `Overflow.mjs`; plus the two superseded *"geometry-preserving carrier"* comments in `DockPopOut` / `DockMaximize` |
| AC-4 invert the focus-geometry witness | `ContainerUi.spec.mjs` asserted `exposedBox === gatedBox` under *"focus gating preserves the action box"*; it now asserts a gated action has **no** box and revealing it creates one |
| AC-4 pin the zero-rect exclusion with its own mutation control | **`DockRailPartition.spec.mjs`** (new) — removing the exclusion reds it at `barWidth 564, directTabs 1, collapsed 2` |

## Deltas from ticket

- **The exclusion control lives on the dock fixture, not beside the other Overflow arms.** I wrote it there twice first; both versions passed with the exclusion removed. A standalone `tab.Container` has no focus subject, so its gated actions never withdraw and there is no zero rect to mis-measure. The ticket's own *"843px dock fixture"* observation is what pointed at the right host — the dock header is the only place a real gated action and a real overflow control share a wide strip.
- **`DockPopOut`'s ordering arm gained an explicit wait.** It measured geometry while the reveal was still in flight; a preserved box returned a stale-but-plausible rect and passed, a collapsed one returns `null`. That race predates this change — the box-preserving contract was hiding it.
- **My new focus-gated arm introduced an intermittent, found after review opened and fixed here.** It is the only arm in `OverflowAction.spec.mjs` that replaces the shared `beforeEach` container, and it reuses the id. Resolving the worker-side `destroyNeoInstance` does not mean the DOM removal has landed — it travels to main as a separate message — so the new header could mount beside the old one. Because the App Worker is **shared across specs**, the orphan outlived the test and the casualty rotated: sometimes this arm's own strict-mode arity abort, sometimes `DockLock.spec.mjs:58` reading `aria-hidden/inert/tabIndex` off the stale node, in a file this diff never touches. `7565fbfbb8` awaits the detach before re-creating.

## Test Evidence

```
component/dashboard/ + component/tab/            72 passed × 6 consecutive runs   @ 7565fbfbb8

mutation — visibility: hidden restored            1 failed  (ContainerUi ×4 variants, OverflowAction arm)
mutation — Overflow exclusion removed             1 failed  (DockRailPartition: 564px strip → 1 tab)
```

Two mutations, deliberately complementary: the first kills the CSS contract's arms, the second kills the arm the first cannot reach. Each fix has a control that fires on it alone.

Both preconditions in `DockRailPartition` can red as well — a strip narrower than 400px, or zero collapsed actions, fails rather than passing vacuously.

**One bound stated rather than implied:** the new `OverflowAction` arm reds under the CSS mutation but **not** under removing the exclusion. It closes the census gap (every other arm in that file uses `showOnFocus: false`) and pins the no-box contract; it is not the exclusion's control. `DockRailPartition` is.

### Attribution of the intermittent, by matched arms

One green cannot see a 30–40% intermittent, and the earlier `70 passed` on this body was a single run — which is how it shipped into review. Four arms, same command, `--workers=1`, **N=6 each**:

| arm | result |
| --- | --- |
| `dev@a9215920c8` | 6/6 clean, 70/70 |
| this branch before the barrier | ~4 failures in 10, rotating casualty |
| this branch with the new arm **skipped** | 6/6 clean |
| this branch with the barrier, arm running | **6/6 clean, 72/72** |

The skip arm is what settles it: removing one test makes the failure disappear, which no production-side explanation survives. @neo-gpt independently reproduced the `DockLock:58` casualty in CI on the combined stack — *"expected inert lock action, observed active stale action"* — which is the stale-node mechanism read from the other side.

## Post-Merge Validation

`component/dashboard/` and `component/tab/` on `dev`. The user-visible check is the operator's own: the rail's actions sit together with no reserved hole, and focus reveals the middle set without tabs vanishing into the menu.

## Commits

- `7565fbfbb8` test(tab): await the detach before reusing the container id
- `94ca9a0f06` test(dashboard): pin the collapsed-action measurement exclusion
- the rail collapse + Overflow exclusion + witness inversions

— Vega (Opus 5, Claude Code) 🌿
