### PR TITLE
fix(dock): serialize maximize transitions (#18003)

### DIFF
--- a/src/dashboard/dock/Workspace.mjs
+++ b/src/dashboard/dock/Workspace.mjs
@@ -2846,7 +2846,13 @@ class Workspace extends Container {
             await me.applyDockMaximizePresentation(nodeId, {animate: false})
         } else {
             me.failDockMaximize(nodeId);
-            await me.dockMaximizeTransition
+
+            // This method runs INSIDE refreshDockWorkspace. A value-bearing transition may be
+            // waiting for this same refreshPromise before it applies, so awaiting the transition
+            // here closes a refresh → transition → refresh cycle. No projected node remains to
+            // restore in this branch; clear the independently-owned observer now and let the queued
+            // reactive clear drain after this refresh releases its tail.
+            await me.registerDockMaximizeResizeObserver(false)
         }
     }
 

--- a/src/dashboard/dock/Workspace.mjs
+++ b/src/dashboard/dock/Workspace.mjs
@@ -2349,18 +2349,28 @@ class Workspace extends Container {
             return
         }
 
-        let me      = this,
-            animate = me.dockMaximizeMotion !== 'instant',
-            steps   = [];
+        let me             = this,
+            animate        = me.dockMaximizeMotion !== 'instant',
+            transitionTail = me.dockMaximizeTransition?.catch(() => {}) || Promise.resolve();
 
         me.dockMaximizeMotion = 'animate';
 
-        oldValue && steps.push(me.clearDockMaximizePresentation({animate: animate && !value}));
-        value    && steps.push(me.applyDockMaximizePresentation(value, {animate}));
+        // Transitions are one ordered lane. A superseding value used to start its apply while the
+        // prior clear was still live; that clear could then remove the new presentation while the
+        // reactive id correctly survived. Clear first, then wait for the latest committed projection
+        // before resolving the live tabs instance the apply mutates. `syncDockMaximizeProjection`
+        // remains the refresh-owned idempotent reapply inside that projection.
+        me.dockMaximizeTransition = transitionTail.then(async () => {
+            oldValue && await me.clearDockMaximizePresentation({animate: animate && !value});
 
-        // The awaitable transition: the settled-surface contract (refreshPromise) and the
-        // continuity sync serialize on this instead of racing fire-and-forget presentation work.
-        me.dockMaximizeTransition = Promise.all(steps).catch(() => null)
+            if (value) {
+                await (me.refreshPromise?.catch(() => {}) || Promise.resolve());
+
+                if (me.maximizedNodeId === value && !me.isDestroyed) {
+                    await me.applyDockMaximizePresentation(value, {animate})
+                }
+            }
+        }).catch(() => null)
     }
 
     /**
@@ -2699,6 +2709,11 @@ class Workspace extends Container {
             tabContainer, zone;
 
         if (!restore) {
+            // A failed superseding apply can clear the reactive id after the prior clear already
+            // consumed the restore snapshot. The observer may still be live because its generation
+            // guard correctly refused to unregister while that superseding id was non-null. Once the
+            // id is null, this clear remains the lifecycle owner even without geometry left to restore.
+            !me.maximizedNodeId && await me.registerDockMaximizeResizeObserver(false);
             return
         }
 

--- a/test/playwright/component/apps/dock-maximize/app.mjs
+++ b/test/playwright/component/apps/dock-maximize/app.mjs
@@ -286,6 +286,13 @@ class MaximizeFixtureWorkspace extends DockWorkspace {
          */
         releaseMaximizeClearCount_: 0,
         /**
+         * Spec trigger: builds the refreshPromise ↔ dockMaximizeTransition cycle and records
+         * whether the refresh-owned sync can settle without its own promise being released first.
+         * @member {Number} maximizeCycleProbeCount_=0
+         * @reactive
+         */
+        maximizeCycleProbeCount_: 0,
+        /**
          * Debug trigger: each bump snapshots the main-tabs container's style surfaces into
          * {@link #styleProbeJson}.
          * @member {Number} styleProbeCount_=0
@@ -356,6 +363,12 @@ class MaximizeFixtureWorkspace extends DockWorkspace {
      * @member {String} maximizeTransitionLogJson='[]'
      */
     maximizeTransitionLogJson = '[]'
+
+    /**
+     * Spec-readable settlement of the refresh-owned maximize sync.
+     * @member {Boolean} maximizeCycleSyncSettled=false
+     */
+    maximizeCycleSyncSettled = false
 
     /**
      * Spec-readable mirror of the PRODUCTION settlement channel: the fixture subscribes to the
@@ -631,6 +644,33 @@ class MaximizeFixtureWorkspace extends DockWorkspace {
 
         this.maximizeClearRelease?.();
         this.maximizeClearRelease = null
+    }
+
+    /**
+     * Reproduces the two-lane dependency without timing: the apply transition waits on a held
+     * refresh promise; the refresh-owned sync encounters the unresolved node and may not wait on
+     * that transition before releasing the same refresh.
+     * @param {Number} value
+     * @param {Number} oldValue
+     * @protected
+     */
+    afterSetMaximizeCycleProbeCount(value, oldValue) {
+        if (oldValue === undefined) {
+            return
+        }
+
+        let releaseRefresh;
+
+        this.maximizeCycleSyncSettled = false;
+        this.refreshPromise = new Promise(resolve => {
+            releaseRefresh = resolve
+        });
+        this.maximizedNodeId = 'ghost-tabs';
+
+        this.syncDockMaximizeProjection().then(() => {
+            this.maximizeCycleSyncSettled = true;
+            releaseRefresh()
+        })
     }
 
     /**

--- a/test/playwright/component/apps/dock-maximize/app.mjs
+++ b/test/playwright/component/apps/dock-maximize/app.mjs
@@ -274,6 +274,18 @@ class MaximizeFixtureWorkspace extends DockWorkspace {
          */
         refreshCount_: 0,
         /**
+         * Spec gate: holds the next maximize clear before it mutates presentation.
+         * @member {Boolean} holdMaximizeClear_=false
+         * @reactive
+         */
+        holdMaximizeClear_: false,
+        /**
+         * Spec trigger: releases the held maximize clear.
+         * @member {Number} releaseMaximizeClearCount_=0
+         * @reactive
+         */
+        releaseMaximizeClearCount_: 0,
+        /**
          * Debug trigger: each bump snapshots the main-tabs container's style surfaces into
          * {@link #styleProbeJson}.
          * @member {Number} styleProbeCount_=0
@@ -328,6 +340,24 @@ class MaximizeFixtureWorkspace extends DockWorkspace {
     settleJson = null
 
     /**
+     * Resolver for the held maximize clear.
+     * @member {Function|null} maximizeClearRelease=null
+     */
+    maximizeClearRelease = null
+
+    /**
+     * Ordered fixture-only transition trace.
+     * @member {String[]} maximizeTransitionLog=[]
+     */
+    maximizeTransitionLog = []
+
+    /**
+     * Spec-readable transition trace.
+     * @member {String} maximizeTransitionLogJson='[]'
+     */
+    maximizeTransitionLogJson = '[]'
+
+    /**
      * Spec-readable mirror of the PRODUCTION settlement channel: the fixture subscribes to the
      * engine's `dockReloadSettled` event like any application would — the mirror proves the
      * public surface, not a test-only override.
@@ -363,6 +393,47 @@ class MaximizeFixtureWorkspace extends DockWorkspace {
 
         observerLog.push(`${register ? 'reg' : 'unreg'}:${this.dockMaximizeResizeObserved}`);
         syncObserverProbe()
+    }
+
+    /**
+     * Records when a maximize apply starts. The production method still owns every effect.
+     * @param {String} nodeId
+     * @param {Object} options
+     * @returns {Promise<void>}
+     */
+    async applyDockMaximizePresentation(nodeId, options) {
+        this.holdMaximizeClear && this.recordMaximizeTransition(`apply:${nodeId}`);
+
+        return super.applyDockMaximizePresentation(nodeId, options)
+    }
+
+    /**
+     * Holds one clear before its destructive presentation mutation so the spec can issue a
+     * superseding maximize and observe whether the two transitions overlap.
+     * @param {Object} options
+     * @returns {Promise<void>}
+     */
+    async clearDockMaximizePresentation(options) {
+        if (this.holdMaximizeClear) {
+            this.recordMaximizeTransition('clear:start');
+
+            await new Promise(resolve => {
+                this.maximizeClearRelease = resolve
+            });
+
+            this.recordMaximizeTransition('clear:apply')
+        }
+
+        return super.clearDockMaximizePresentation(options)
+    }
+
+    /**
+     * Appends one transition token and refreshes the spec-readable mirror.
+     * @param {String} token
+     */
+    recordMaximizeTransition(token) {
+        this.maximizeTransitionLog.push(token);
+        this.maximizeTransitionLogJson = JSON.stringify(this.maximizeTransitionLog)
     }
 
     /**
@@ -546,6 +617,20 @@ class MaximizeFixtureWorkspace extends DockWorkspace {
 
         // Fire-and-forget: the continuity arm polls the DOM outcome.
         this.refreshDockWorkspace()
+    }
+
+    /**
+     * @param {Number} value
+     * @param {Number} oldValue
+     * @protected
+     */
+    afterSetReleaseMaximizeClearCount(value, oldValue) {
+        if (oldValue === undefined) {
+            return
+        }
+
+        this.maximizeClearRelease?.();
+        this.maximizeClearRelease = null
     }
 
     /**

--- a/test/playwright/component/dashboard/DockMaximize.spec.mjs
+++ b/test/playwright/component/dashboard/DockMaximize.spec.mjs
@@ -238,6 +238,36 @@ test.describe('dock maximize — presentation, never topology', () => {
         await expect.poll(async () => (await readWorkspace(page, ['maximizedNodeId']))[0]).toBe(null)
     });
 
+    test('a superseding maximize waits for the prior clear and its refresh', async ({page}) => {
+        const main = tabsNodeWith(page, 'Alpha');
+
+        await tabButton(main, 'Alpha').click();
+        await actionButton(main, 'fa-window-maximize').click();
+        await expectMaximizedCount(page, 1);
+
+        await setWorkspace(page, {holdMaximizeClear: true});
+
+        // The outside operation clears maximize and opens a projection, while the fixture holds
+        // that clear before its presentation mutation.
+        await setWorkspace(page, {closeItemId: 'gamma'});
+        await expect.poll(async () => JSON.parse(
+            (await readWorkspace(page, ['maximizeTransitionLogJson']))[0]
+        )).toEqual(['clear:start']);
+
+        // Supersede the clear while it is held. The new apply must queue; starting it here races a
+        // stale presentation against both the prior clear and the operation's re-projection.
+        await setWorkspace(page, {maximizedNodeId: 'main-tabs'});
+        expect(JSON.parse((await readWorkspace(page, ['maximizeTransitionLogJson']))[0]))
+            .toEqual(['clear:start']);
+
+        await setWorkspace(page, {releaseMaximizeClearCount: 1});
+        await expectMaximizedCount(page, 1);
+        expect(await readWorkspace(page, ['maximizedNodeId'])).toEqual(['main-tabs']);
+        await expect.poll(async () => JSON.parse(
+            (await readWorkspace(page, ['maximizeTransitionLogJson']))[0]
+        )).toEqual(['clear:start', 'clear:apply', 'apply:main-tabs'])
+    });
+
     test('while maximized, the workspace resize observation re-measures the rect live', async ({page}) => {
         const main = tabsNodeWith(page, 'Alpha');
 

--- a/test/playwright/component/dashboard/DockMaximize.spec.mjs
+++ b/test/playwright/component/dashboard/DockMaximize.spec.mjs
@@ -268,6 +268,15 @@ test.describe('dock maximize — presentation, never topology', () => {
         )).toEqual(['clear:start', 'clear:apply', 'apply:main-tabs'])
     });
 
+    test('refresh-owned failure does not await a transition waiting on that refresh', async ({page}) => {
+        await setWorkspace(page, {maximizeCycleProbeCount: 1});
+
+        await expect.poll(async () => (
+            await readWorkspace(page, ['maximizeCycleSyncSettled'])
+        )[0]).toBe(true);
+        expect(await readWorkspace(page, ['maximizedNodeId'])).toEqual([null])
+    });
+
     test('while maximized, the workspace resize observation re-measures the rect live', async ({page}) => {
         const main = tabsNodeWith(page, 'Alpha');
 


### PR DESCRIPTION
Resolves #18003

Related: #17995

DockMaximize transitions now run on one ordered tail. A superseding apply waits for the prior clear and the active dock refresh before resolving its live tabs node, so an older clear cannot erase a newer presentation while `maximizedNodeId` survives. The refresh-owned unresolved-node branch never awaits a transition waiting on that same refresh, keeping the two tails acyclic. A fail-safe clear also releases the resize observer when the prior clear already consumed the restore snapshot.

Evidence: L2 (real-browser component reproduction and transition-order control) → L2 required (the defect occurs in the component suite; no external runtime is required). Residual: none.

Micro-review eligible: no — this changes the core asynchronous maximize-transition contract and its observer lifecycle.

## AC Evidence

| AC | Evidence |
|---|---|
| AC-1 | Existing same-SHA census on #18003 establishes the intermittent baseline (3 pass / 1 fail). |
| AC-2 | Deterministic gates reproduce both hazards: early superseding apply and the `refreshPromise` ↔ `dockMaximizeTransition` cycle; both red before their fixes and settle after. |
| AC-3 | The fix changes only maximize transition ordering; no #17999 surface is touched. |
| AC-4 | N/A by AC-3; #17999 remains independent. |
| AC-5 | Product defect confirmed: red-first transition log was `clear:start · apply:main-tabs`; production serializes it to `clear:start · clear:apply · apply:main-tabs`. |
| AC-6 | N/A: the existing continuity assertion remains unchanged; a stronger production regression arm was added. |
| AC-7 | No #17999 change or gate is introduced. |

## Deltas from ticket

Merged #18009 supplied the discriminator: CI reported `maximizedNodeId: "main-tabs"` while the marker was absent, ruling out the fail-safe-null family. The repair therefore targets overlapping presentation transitions, not test timing.

## Test Evidence

- Red-first control before the production change: the new arm failed because `apply:main-tabs` started while `clear:start` was held.
- Full `DockMaximize.spec.mjs`: **13 passed**.
- Original continuity arm + new deterministic arm, `--repeat-each=10`: **20 passed**.
- Mutation of the observer fallback reproduced `[null, true]`; restored implementation returns `[null, false]`.
- Review isolation: refresh-owned sync timed out while waiting on the transition that awaited its held refresh; removing that reverse await makes the arm settle in 258ms.

## Post-Merge Validation

- [x] None; the CI-failing component surface is exercised pre-merge.

## Evolution

The diagnostic first separated fail-safe clear from lost presentation. Holding the prior clear then made the race deterministic: the next apply started concurrently, and a later clear could remove it. Serializing the transition tail fixed that arm and exposed the paired observer-generation cleanup, which the existing lifecycle test caught before handoff.

Authored by Emmy (GPT-5.6 Sol Ultra, Codex). Session 309a78d7-2d95-4f23-bdfc-69d2ae393a5d.
