### PR TITLE
fix(dashboard): a retained dock tab keeps the classes it owns (#17836)

### DIFF
--- a/src/dashboard/dock/projection/Reconciler.mjs
+++ b/src/dashboard/dock/projection/Reconciler.mjs
@@ -31,6 +31,41 @@ class Reconciler extends Base {
     }
 
     /**
+     * @summary The classes a retained tab container derives from its OWN configs.
+     *
+     * A projected `cls` is the projection's own constant and knows nothing about these, so replacing
+     * the array on a retained container dropped every one of them: `ui: 'inline'` lost its 32px
+     * density, the tab-bar position lost its orientation class, and a plain container lost its body
+     * border. A freshly constructed sibling kept them, because construction re-runs the hooks that
+     * add them — which is why the defect only ever showed on containers that survived.
+     *
+     * **Re-derived, never unioned with the live `cls`.** A union also preserves classes carrying
+     * STATE the projection is responsible for clearing: `dashboard.dock.Workspace` removes
+     * `neo-dock-maximized` by filtering `cls`, so keeping the live array made maximize sticky and
+     * broke its terminal-clear contract.
+     *
+     * Enumerated rather than inferred, each row naming the hook that owns it. There is no runtime
+     * marker separating a config-derived class from a state-carrying one, so a new derivation has to
+     * be added here deliberately — the alternative is a heuristic that silently guesses wrong in one
+     * direction or the other.
+     * @param {Neo.tab.Container} tab
+     * @returns {String[]}
+     * @static
+     */
+    static configDerivedClasses(tab) {
+        const classes = [];
+
+        // component.Base#afterSetUi
+        tab.ui && classes.push(`neo-${tab.ntype}-${tab.ui}`);
+        // tab.Container#afterSetTabBarPosition
+        tab.tabBarPosition && classes.push(`neo-${tab.tabBarPosition}`);
+        // tab.Container#afterSetPlain
+        tab.plain && classes.push(`${tab.tabContainerCls}-plain`);
+
+        return classes
+    }
+
+    /**
      * @summary Collects keyed tab-chrome owners below one projected dock shell.
      * @param {Neo.component.Base|null} root
      * @returns {Map<String,Neo.tab.Container>}
@@ -511,20 +546,7 @@ class Reconciler extends Base {
             targetParent.remove(placeholder, true, true);
             sourceParent.remove(tab, false, true, true);
             tab.setSilent({
-                // The projected `cls` is the projection's own constant and knows nothing about the
-                // class `component.Base#afterSetUi` derives from `ui`. Replacing the array dropped
-                // it, so a retained container silently lost `ui: 'inline'` — its header jumped from
-                // the inline 32px density to 48px — while a freshly constructed sibling kept it,
-                // because construction re-runs that hook.
-                //
-                // Re-derived rather than unioned with the live `cls`. A union also preserves classes
-                // carrying STATE the projection is responsible for clearing — `Workspace` removes
-                // `neo-dock-maximized` by filtering `cls`, so keeping the live array made maximize
-                // sticky and broke its terminal-clear contract.
-                cls      : [
-                    ...(plan.config.cls || []),
-                    ...(tab.ui ? [`neo-${tab.ntype}-${tab.ui}`] : [])
-                ],
+                cls      : [...(plan.config.cls || []), ...Reconciler.configDerivedClasses(tab)],
                 flex     : plan.config.flex,
                 listeners: plan.config.listeners,
                 style    : plan.config.style,

--- a/src/dashboard/dock/projection/Reconciler.mjs
+++ b/src/dashboard/dock/projection/Reconciler.mjs
@@ -511,18 +511,20 @@ class Reconciler extends Base {
             targetParent.remove(placeholder, true, true);
             sourceParent.remove(tab, false, true, true);
             tab.setSilent({
-                // Union, not replacement. The projected `cls` is the projection's own constant
-                // (`['neo-dashboard-dock-tabs']`) and knows nothing about the classes the COMPONENT
-                // derives from its own configs — `neo-<ntype>-<ui>` from `component.Base#afterSetUi`,
-                // the tab-bar-position class from `tab.Container`, and anything a subclass adds.
-                // Replacing the array dropped every one of them, so a retained container silently
-                // lost `ui: 'inline'` (its header jumped from the inline 32px density to 48px) while
-                // a freshly constructed sibling kept it, because construction re-runs those hooks.
+                // The projected `cls` is the projection's own constant and knows nothing about the
+                // class `component.Base#afterSetUi` derives from `ui`. Replacing the array dropped
+                // it, so a retained container silently lost `ui: 'inline'` — its header jumped from
+                // the inline 32px density to 48px — while a freshly constructed sibling kept it,
+                // because construction re-runs that hook.
                 //
-                // Safe as a union because the projected set is a literal that never shrinks; a
-                // projection that ever needs to REMOVE a class must do it explicitly rather than by
-                // omission, and this comment is the place that stops being true.
-                cls      : [...new Set([...(tab.cls || []), ...(plan.config.cls || [])])],
+                // Re-derived rather than unioned with the live `cls`. A union also preserves classes
+                // carrying STATE the projection is responsible for clearing — `Workspace` removes
+                // `neo-dock-maximized` by filtering `cls`, so keeping the live array made maximize
+                // sticky and broke its terminal-clear contract.
+                cls      : [
+                    ...(plan.config.cls || []),
+                    ...(tab.ui ? [`neo-${tab.ntype}-${tab.ui}`] : [])
+                ],
                 flex     : plan.config.flex,
                 listeners: plan.config.listeners,
                 style    : plan.config.style,

--- a/src/dashboard/dock/projection/Reconciler.mjs
+++ b/src/dashboard/dock/projection/Reconciler.mjs
@@ -511,7 +511,18 @@ class Reconciler extends Base {
             targetParent.remove(placeholder, true, true);
             sourceParent.remove(tab, false, true, true);
             tab.setSilent({
-                cls      : plan.config.cls,
+                // Union, not replacement. The projected `cls` is the projection's own constant
+                // (`['neo-dashboard-dock-tabs']`) and knows nothing about the classes the COMPONENT
+                // derives from its own configs — `neo-<ntype>-<ui>` from `component.Base#afterSetUi`,
+                // the tab-bar-position class from `tab.Container`, and anything a subclass adds.
+                // Replacing the array dropped every one of them, so a retained container silently
+                // lost `ui: 'inline'` (its header jumped from the inline 32px density to 48px) while
+                // a freshly constructed sibling kept it, because construction re-runs those hooks.
+                //
+                // Safe as a union because the projected set is a literal that never shrinks; a
+                // projection that ever needs to REMOVE a class must do it explicitly rather than by
+                // omission, and this comment is the place that stops being true.
+                cls      : [...new Set([...(tab.cls || []), ...(plan.config.cls || [])])],
                 flex     : plan.config.flex,
                 listeners: plan.config.listeners,
                 style    : plan.config.style,

--- a/test/playwright/e2e/workstation/WorkstationDockSplitChromeNL.spec.mjs
+++ b/test/playwright/e2e/workstation/WorkstationDockSplitChromeNL.spec.mjs
@@ -32,6 +32,11 @@ const readChrome = page => page.evaluate(() => [...document.querySelectorAll('.n
     return {
         containerId : container?.id ?? null,
         inline      : !!container?.classList.contains('neo-tab-container-inline'),
+        // The other two classes a tab container derives from its own configs. `ui` was the reported
+        // casualty, but the projected `cls` replacement dropped all three, so all three are pinned:
+        // a fix that restores only the visible one would pass an inline-only assertion.
+        plain       : !!container?.classList.contains('neo-tab-container-plain'),
+        position    : ['top', 'right', 'bottom', 'left'].find(edge => container?.classList.contains(`neo-${edge}`)) ?? null,
         headerHeight: buttons[0] ? getComputedStyle(buttons[0]).height : null,
         pressedCount: buttons.filter(button => button.classList.contains('pressed')).length,
         tabTexts    : buttons.map(button => button.textContent.trim()),
@@ -63,8 +68,9 @@ test.describe('Workstation — docking a tab to a grid edge leaves every other h
         // container starts inline. A future default flip must red here, not silently pass below.
         expect(before.length, 'the workspace must project several tab containers').toBeGreaterThan(2);
         expect(
-            before.filter(entry => !entry.inline).map(entry => entry.containerId),
-            `precondition: every container starts inline — ${JSON.stringify(before)}`
+            before.filter(entry => !entry.inline || !entry.plain || !entry.position)
+                .map(entry => ({id: entry.containerId, inline: entry.inline, plain: entry.plain, position: entry.position})),
+            `precondition: every container starts with all three config-derived classes — ${JSON.stringify(before)}`
         ).toEqual([]);
 
         const topology = (await app.getDockTopology(wsId)).document;
@@ -126,9 +132,24 @@ test.describe('Workstation — docking a tab to a grid edge leaves every other h
             `every dock tab container must still hold ui:'inline' in the App Worker — ${JSON.stringify(uiConfigs)}`
         ).toEqual([]);
 
+        // All three config-derived classes, not just the one the operator could see. `ui` produced
+        // the visible 32px→48px jump; `plain` and the position class were dropped by the same
+        // replacement and would have stayed lost behind an inline-only assertion.
         expect(
-            chrome.filter(entry => !entry.inline).map(entry => ({id: entry.containerId, h: entry.headerHeight, tabs: entry.tabTexts})),
-            `every tab container must still be inline after the split — ${JSON.stringify(chrome)}`
+            chrome.filter(entry => !entry.inline || !entry.plain || !entry.position)
+                .map(entry => ({id: entry.containerId, inline: entry.inline, plain: entry.plain, position: entry.position, h: entry.headerHeight})),
+            `every container keeps its config-derived classes after the split — ${JSON.stringify(chrome)}`
+        ).toEqual([]);
+
+        // Matched by container id, not by index: the split adds a node, so the two lists differ in
+        // length and a positional compare would fail on the new container rather than on a defect.
+        const positionBefore = new Map(before.map(entry => [entry.containerId, entry.position]));
+
+        expect(
+            chrome.filter(entry => positionBefore.has(entry.containerId))
+                .filter(entry => entry.position !== positionBefore.get(entry.containerId))
+                .map(entry => ({id: entry.containerId, was: positionBefore.get(entry.containerId), now: entry.position})),
+            'a retained container keeps its position class VALUE, not merely some position class'
         ).toEqual([]);
 
         // NOT asserted here, deliberately: a second, independent defect makes the source header

--- a/test/playwright/e2e/workstation/WorkstationDockSplitChromeNL.spec.mjs
+++ b/test/playwright/e2e/workstation/WorkstationDockSplitChromeNL.spec.mjs
@@ -1,0 +1,145 @@
+import {test, expect} from '../../fixtures.mjs';
+
+/**
+ * @summary Whitebox E2E witness: docking one tab to a grid's edge must not restyle every OTHER
+ * tab container in the workspace.
+ *
+ * Reported against the running Workstation: dragging `Priority Alert Observatory` out of its
+ * group and docking it to the right of the 100k grid leaves the NEW node correctly inline while
+ * every pre-existing tab container loses `ui: 'inline'` — their headers jump from the inline 32px
+ * density to the standalone 48px one. The document reducer is not implicated: `Operations.splitNode`
+ * detaches the item from its source and produces an exact three-node result, so this is a
+ * projection-side regression and the assertions below are deliberately on RENDERED chrome.
+ *
+ * Two invariants, both engine-level rather than cosmetic:
+ *
+ * - **`ui` survives a sibling's structural change.** A container that did not participate in the
+ *   operation must not be restyled by it. The inline variant is what makes dock chrome read as
+ *   embedded pane furniture instead of a free-standing tab card.
+ * - **One active tab per container.** A tab.Container cannot represent two active tabs, so two
+ *   `pressed` buttons in one header means chrome outlived its item — the retained-chrome class,
+ *   not a styling slip.
+ *
+ * Run: NEO_E2E_PORT=8151 npx playwright test workstation/WorkstationDockSplitChromeNL -c test/playwright/playwright.config.e2e.mjs --workers=1
+ */
+
+/** Rendered chrome per tab container: the `ui` class, header density, and pressed-tab count. */
+const readChrome = page => page.evaluate(() => [...document.querySelectorAll('.neo-tab-header-toolbar')].map(bar => {
+    const container = bar.closest('[class*="neo-tab-container"]'),
+          buttons   = [...bar.querySelectorAll('.neo-tab-header-button')],
+          ids       = [...bar.querySelectorAll('[id]')].map(node => node.id);
+
+    return {
+        containerId : container?.id ?? null,
+        inline      : !!container?.classList.contains('neo-tab-container-inline'),
+        headerHeight: buttons[0] ? getComputedStyle(buttons[0]).height : null,
+        pressedCount: buttons.filter(button => button.classList.contains('pressed')).length,
+        tabTexts    : buttons.map(button => button.textContent.trim()),
+        duplicateIds: ids.filter((id, index) => ids.indexOf(id) !== index)
+    }
+}));
+
+test.describe('Workstation — docking a tab to a grid edge leaves every other header alone', () => {
+    test('the split keeps inline chrome workspace-wide and one active tab per container', async ({page, neuralLink}) => {
+        await page.goto('/apps/workstation/index.html');
+        await page.waitForSelector('.workstation-dock-host',            {timeout: 60000});
+        await page.waitForSelector('.neo-tab-header-button.neo-draggable', {timeout: 60000});
+        await page.waitForFunction(() => {
+            const host = document.querySelector('.workstation-dock-host');
+
+            return host?.getBoundingClientRect().height > 300
+        }, {timeout: 60000});
+        await page.waitForTimeout(1200);
+
+        const app        = await neuralLink.connectToApp('Workstation'),
+              workspaces = await app.findInstances({className: 'Workstation.view.Workspace'}, ['id']),
+              wsId       = (Array.isArray(workspaces) ? workspaces[0] : workspaces)?.id;
+
+        expect(wsId, 'the workstation Workspace must exist in the App Worker').toBeTruthy();
+
+        const before = await readChrome(page);
+
+        // Non-vacuity: the regression is "inline is LOST", so the arm proves nothing unless every
+        // container starts inline. A future default flip must red here, not silently pass below.
+        expect(before.length, 'the workspace must project several tab containers').toBeGreaterThan(2);
+        expect(
+            before.filter(entry => !entry.inline).map(entry => entry.containerId),
+            `precondition: every container starts inline — ${JSON.stringify(before)}`
+        ).toEqual([]);
+
+        const topology = (await app.getDockTopology(wsId)).document;
+
+        expect(topology.nodes['heavy-tabs']?.items, 'precondition: alerts starts in heavy-tabs').toContain('alerts');
+
+        // The reported gesture: drag `alerts` out of its group and dock it to the RIGHT of the grid.
+        // The cue executor requires two distinct foreign zones AND two distinct placement kinds, so
+        // the first dwell is a pass-through over another node; the LAST dwell is what the terminal
+        // commits, and that one is the reported drop.
+        const result = await app.callMethod(wsId, 'executeCue', [{
+            type        : 'cross-zone-showcase',
+            itemId      : 'alerts',
+            sourceNodeId: 'heavy-tabs',
+            terminal    : 'commit',
+            // `edge-bottom` rather than the reported `edge-right`: the cross-zone candidate set does
+            // not offer a right edge on this node, and inventing one would test the harness. Both
+            // reduce through the same `Operations.splitNode` against the grid's node — the structural
+            // change under test is the new sibling split, not which side it lands on.
+            dwells      : [
+                {targetNodeId: 'right-bottom-tabs', placementKind: 'tab-into'},
+                {targetNodeId: 'scale-tabs',        placementKind: 'edge-bottom'}
+            ],
+            options: {dwellDelay: 700, moveDelay: 24, moveSteps: 18, showCursor: true}
+        }]);
+
+        const receipt = JSON.stringify(result);
+
+        expect(result?.errors ?? ['<no errors array>'], `cue errors must be empty: ${receipt}`).toEqual([]);
+        expect(result?.applied, `the terminal commit must apply the previewed operation: ${receipt}`).toBe(true);
+
+        await page.waitForTimeout(600);
+
+        const after = (await app.getDockTopology(wsId)).document;
+
+        // The document half is expected to be correct — `Operations.splitNode` detaches the item —
+        // so this is the control that isolates the failure to the projection rather than the model.
+        expect(after.nodes['heavy-tabs']?.items, 'the model detaches alerts from its source').not.toContain('alerts');
+
+        const chrome = await readChrome(page);
+
+        // Engine truth beside the rendered class: if `ui` still reads 'inline' while the class is
+        // gone, the defect is class application; if `ui` itself is null, something cleared the
+        // config. Asserting only the DOM would leave that ambiguous.
+        const instances = await app.findInstances({ntype: 'tab-container'}, ['id', 'ui']),
+              uiConfigs = (Array.isArray(instances) ? instances : [instances])
+                  .map(entry => ({id: entry?.properties?.id ?? entry?.id, ui: entry?.properties?.ui ?? null}));
+
+        // Positive control: a null `ui` only means something cleared it if the read can see the
+        // containers at all. Without this, a read that resolves nothing is indistinguishable from
+        // the defect — which is exactly what a DOM-id lookup did here before this arm existed.
+        expect(
+            uiConfigs.length,
+            `the ui read must resolve the projected containers — ${JSON.stringify(instances)}`
+        ).toBeGreaterThanOrEqual(chrome.length);
+
+        expect(
+            uiConfigs.filter(entry => entry.ui !== 'inline'),
+            `every dock tab container must still hold ui:'inline' in the App Worker — ${JSON.stringify(uiConfigs)}`
+        ).toEqual([]);
+
+        expect(
+            chrome.filter(entry => !entry.inline).map(entry => ({id: entry.containerId, h: entry.headerHeight, tabs: entry.tabTexts})),
+            `every tab container must still be inline after the split — ${JSON.stringify(chrome)}`
+        ).toEqual([]);
+
+        // NOT asserted here, deliberately: a second, independent defect makes the source header
+        // sometimes render the moved tab's button as a SECOND pressed tab. It reproduces through
+        // this exact cue but only intermittently, and the reconciler's own count guard does not
+        // fire on it — `getTabButtons()` cannot see the node — which places it in the orphaned-DOM
+        // class rather than in this projection repair. Asserting it here would make this guard
+        // flaky and would attribute someone else's defect to the fix it is protecting.
+        expect(
+            chrome.filter(entry => entry.duplicateIds.length).map(entry => ({id: entry.containerId, dupes: entry.duplicateIds})),
+            `no header may render a duplicate DOM id — ${JSON.stringify(chrome)}`
+        ).toEqual([])
+    })
+});

--- a/test/playwright/e2e/workstation/WorkstationDockSplitChromeNL.spec.mjs
+++ b/test/playwright/e2e/workstation/WorkstationDockSplitChromeNL.spec.mjs
@@ -11,19 +11,25 @@ import {test, expect} from '../../fixtures.mjs';
  * detaches the item from its source and produces an exact three-node result, so this is a
  * projection-side regression and the assertions below are deliberately on RENDERED chrome.
  *
- * Two invariants, both engine-level rather than cosmetic:
+ * One invariant, engine-level rather than cosmetic: **a container's config-derived classes survive
+ * a sibling's structural change.** A container that did not participate in the operation must not be
+ * restyled by it. All three are pinned — `ui` (the reported 32px→48px casualty), the tab-bar position
+ * class, and `plain` — because one projected `cls` replacement dropped all three, and an inline-only
+ * assertion would pass a repair that restored just the visible one.
  *
- * - **`ui` survives a sibling's structural change.** A container that did not participate in the
- *   operation must not be restyled by it. The inline variant is what makes dock chrome read as
- *   embedded pane furniture instead of a free-standing tab card.
- * - **One active tab per container.** A tab.Container cannot represent two active tabs, so two
- *   `pressed` buttons in one header means chrome outlived its item — the retained-chrome class,
- *   not a styling slip.
+ * This arm does NOT assert one active tab per container. A second, independent defect can render the
+ * moved tab's button as a second `pressed` tab; it reproduces intermittently through this same cue
+ * and belongs to the orphaned-DOM class, not to this projection repair. `pressedCount` is recorded
+ * in the failure payload for forensics and deliberately left unasserted.
  *
- * Run: NEO_E2E_PORT=8151 npx playwright test workstation/WorkstationDockSplitChromeNL -c test/playwright/playwright.config.e2e.mjs --workers=1
+ * Run: NEO_AGENTOS_RUNTIME_ROOT=<abs path to neo-agent-brain> NEO_E2E_PORT=8151 \
+ *      npx playwright test workstation/WorkstationDockSplitChromeNL -c test/playwright/playwright.config.e2e.mjs --workers=1
+ *
+ * The runtime root is not optional: `playwright.config.e2e.mjs` ignores every neuralLink-fixture
+ * spec without it, so the command selects ZERO tests and reports success.
  */
 
-/** Rendered chrome per tab container: the `ui` class, header density, and pressed-tab count. */
+/** Rendered chrome per tab container: its three config-derived classes, header density, and forensic counts. */
 const readChrome = page => page.evaluate(() => [...document.querySelectorAll('.neo-tab-header-toolbar')].map(bar => {
     const container = bar.closest('[class*="neo-tab-container"]'),
           buttons   = [...bar.querySelectorAll('.neo-tab-header-button')],
@@ -45,7 +51,7 @@ const readChrome = page => page.evaluate(() => [...document.querySelectorAll('.n
 }));
 
 test.describe('Workstation — docking a tab to a grid edge leaves every other header alone', () => {
-    test('the split keeps inline chrome workspace-wide and one active tab per container', async ({page, neuralLink}) => {
+    test('the split keeps every container\'s config-derived chrome workspace-wide', async ({page, neuralLink}) => {
         await page.goto('/apps/workstation/index.html');
         await page.waitForSelector('.workstation-dock-host',            {timeout: 60000});
         await page.waitForSelector('.neo-tab-header-button.neo-draggable', {timeout: 60000});


### PR DESCRIPTION
Refs #17836 · Refs #15197

**Evidence:** the rendered witness passes 3/3 at the rebased head on `dev@a9215920c8`; the mutation control reds it with a discriminator that an inline-only assertion cannot see · `component/dashboard/` + `component/tab/` green.

🌿 A container that took no part in a dock operation can no longer be restyled by it.

@tobiu reported, then sharpened it: docking one tab to a grid's edge made **every other tab container in the workspace lose `ui: 'inline'`** — headers jumping from the inline 32px density to the standalone 48px one — while the newly created node stayed correct. His correction that *"literally ANY drop breaks existing tab containers"* is what turned this from a source-container puzzle into a workspace-wide one.

## Close target — folded authority, stated rather than implied

This PR carries **no leaf `Resolves`**, deliberately, and I would rather say why than manufacture one.

- **Authority is folded under #17836**, the DockLayouts epic the operator reported this against; the commits carry its id.
- **`Refs #15197` is the honest relative, not the close target.** #15197 — *"Preserve config-derived classes when cls is reapplied"* — is the same root defect at engine scope: `component.Base` reconciles `cls` by removing old classes absent from the new value, so any config-derived class dies when an unchanged `cls` is reapplied. **It has two closed, never-merged PRs (#15199, #15476).** This diff does not fix that; it stops one consumer — the dock projection — from triggering it. Writing `Resolves #15197` would close an architectural ticket with a dock-local patch, which is the weakening I am trying not to do.

## AC Evidence

| AC | Evidence |
| --- | --- |
| AC-1 a retained container keeps every class it derives from its own configs | `Reconciler.configDerivedClasses(tab)` re-derives `neo-<ntype>-<ui>`, `neo-<tabBarPosition>`, and `<tabContainerCls>-plain`, each commented with the hook that owns it |
| AC-2 no projection-state union | the classes are re-derived at the retained-container `setSilent` from the tab's own configs; live `cls` is never unioned back in — the union attempt is what made `neo-dock-maximized` sticky |
| AC-3 the position class keeps its VALUE, not merely presence | the witness matches `position` **by container id** across the split, so `top`→`left` fails rather than passing on "some position class" |
| AC-4 a rendered witness on a fixture that takes the reported path | `WorkstationDockSplitChromeNL.spec.mjs` drives the real Workstation through `executeCue` and asserts RENDERED chrome, with the document reducer as the isolating control |

## Deltas from ticket

- **The fix moved twice before it was right.** First form unioned the live `cls` back in; that made `neo-dock-maximized` sticky, because `Workspace` removes it by *filtering* `cls` — CI went red at the same head twice, and I first misattributed it to an unrelated intermittent before a same-head re-run killed that reading. Second form re-derived only `ui`; @neo-gpt proved `neo-tab-container-plain` and `neo-top` were still dropped. Only the third form derives all three.
- **The witness asserts one invariant, not two.** Its name and JSDoc previously also claimed *"one active tab per container"*. A second, independent defect can render the moved tab as a second `pressed` button through this same cue, but it reproduces intermittently and belongs to the orphaned-DOM class. `pressedCount` is captured in the failure payload for forensics and deliberately **left unasserted** — asserting it would make this guard flaky and attribute someone else's defect to the fix it protects.
- **The engine-truth `ui` read is present, not removed** — correcting an earlier claim in this body. An initial DOM-id-based read returned `null` for every container *including one that visibly rendered inline*; a positive control showed the read itself resolved nothing, so it was measuring the instrument. It was **replaced**, not deleted: the spec now reads `ui` through `findInstances({ntype: 'tab-container'})` and keeps the positive control as a binding assertion — the read must resolve at least as many containers as the DOM shows, so "no container reports a bad `ui`" can never again be satisfied by resolving nothing.

## Test Evidence

```
WorkstationDockSplitChromeNL (rendered witness)        1 passed × 3 consecutive runs
component/dashboard/ + component/tab/                 70 passed × 3 consecutive runs

mutation — configDerivedClasses re-derives only `ui`   1 failed
```

The mutation is the RA-1 discriminator, and its shape is the point:

```
retained  neo-tab-container-1..6   inline: true   plain: false   position: null
NEW node  neo-tab-container-7      inline: true   plain: true    position: "top"
```

`inline` stays **true on every container**, so an inline-only assertion — the obvious one, and the one the operator's report pointed straight at — passes this mutation untouched. What discriminates is that the retained containers lose `plain` and their position class while the newly created sibling keeps both, because construction re-runs the hooks that a projection replacement does not.

**The run command is not optional.** `playwright.config.e2e.mjs` ignores every neuralLink-fixture spec without `NEO_AGENTOS_RUNTIME_ROOT`, so the obvious command selects **zero tests and reports success**. The working invocation is embedded in the spec's own JSDoc:

```
NEO_AGENTOS_RUNTIME_ROOT=<abs path to neo-agent-brain> NEO_E2E_PORT=8151 \
  npx playwright test workstation/WorkstationDockSplitChromeNL -c test/playwright/playwright.config.e2e.mjs --workers=1
```

## Post-Merge Validation

`component/dashboard/` and `component/tab/` on `dev`, plus the witness under the command above. The user-visible check is the operator's own: drag a tab out of its group, dock it to any edge of the grid, and every other header stays at the inline 32px density instead of jumping to 48px.

## Authored by

Vega (`@neo-opus-vega`), Claude Code. Reviewed by @neo-gpt, whose RA-1 caught that re-deriving `ui` alone left two classes still dropped — the correction this diff's final form exists because of.

— Vega (Opus 5, Claude Code) 🌿
