### PR TITLE
test(dock): accept idempotent maximize reapply (#18021)

### DIFF
--- a/test/playwright/component/dashboard/DockMaximize.spec.mjs
+++ b/test/playwright/component/dashboard/DockMaximize.spec.mjs
@@ -265,7 +265,14 @@ test.describe('dock maximize — presentation, never topology', () => {
         expect(await readWorkspace(page, ['maximizedNodeId'])).toEqual(['main-tabs']);
         await expect.poll(async () => JSON.parse(
             (await readWorkspace(page, ['maximizeTransitionLogJson']))[0]
-        )).toEqual(['clear:start', 'clear:apply', 'apply:main-tabs'])
+        ).length).toBeGreaterThanOrEqual(3);
+
+        const transitions = JSON.parse((await readWorkspace(page, ['maximizeTransitionLogJson']))[0]);
+
+        expect(transitions.slice(0, 2)).toEqual(['clear:start', 'clear:apply']);
+        expect(transitions.slice(2).length, 'at least one apply must follow the clear').toBeGreaterThan(0);
+        expect([...new Set(transitions.slice(2))], 'every later apply is the same idempotent reapply')
+            .toEqual(['apply:main-tabs'])
     });
 
     test('refresh-owned failure does not await a transition waiting on that refresh', async ({page}) => {


### PR DESCRIPTION
Resolves #18021

Related: #17995 · #18017 · #17836

The DockMaximize transition-order arm now asserts the contract it owns: no apply before the held clear, followed by one or more identical idempotent applies. It no longer rejects the permitted refresh-owned reapply that appeared after #18017 merged.

Evidence: L2 (real-browser component suite and 20-sample focused repeat) → L2 required (test-oracle correction only). Residual: none.

Micro-review eligible: test-only mechanical correction — runtime source is untouched.

## AC Evidence

| AC | Evidence |
|---|---|
| AC-1 | Settled log accepts one or multiple post-clear `apply:main-tabs` tokens. |
| AC-2 | The pre-release assertion still requires exactly `['clear:start']`, so an early apply fails. |
| AC-3 | A `Set` assertion rejects every unexpected post-clear token. |
| AC-4 | Full DockMaximize **13/13**; focused arm `--repeat-each=20` **20/20**. |

## Deltas from ticket

None substantive.

## Test Evidence

- Full `DockMaximize.spec.mjs`: **13 passed**.
- Corrected transition arm repeated 20 times: **20 passed**.

## Post-Merge Validation

- [x] None; the CI component oracle is fully testable pre-merge.

Authored by Emmy (GPT-5.6 Sol Ultra, Codex). Session 309a78d7-2d95-4f23-bdfc-69d2ae393a5d.
