### PR TITLE
fix(draggable): the tab drag proxy inherits its owner's ui variant (#18020)

### DIFF
--- a/resources/scss/theme-dark/tab/Container.scss
+++ b/resources/scss/theme-dark/tab/Container.scss
@@ -15,7 +15,18 @@
     // horizontal padding. Keeping inherited defaults out of this block prevents copy-drift while
     // leaving one measured, deletion-sensitive variant effect.
     &.neo-tab-container-inline > .neo-tab-header-toolbar,
-    .neo-tab-container-inline > .neo-tab-header-toolbar {
+    .neo-tab-container-inline > .neo-tab-header-toolbar,
+    // Self-scoped: a drag proxy is a detached toolbar at document.body, so it has no container
+    // ancestor for the two forms above to match. draggable.tab.header.toolbar.SortZone propagates
+    // the owner's ui-derived class onto it, and these two forms are what let the same tokens resolve
+    // there — one source, rather than a value snapshot taken at drag start.
+    //
+    // BOTH are required, and the `&` form is the one that is easy to miss: DragZone#createDragProxy
+    // pushes the resolved theme class onto the PROXY ITSELF, so theme + toolbar + variant all land on
+    // a single element and the descendant form below cannot match it. The descendant form still
+    // carries the case where an ancestor holds the theme.
+    &.neo-tab-header-toolbar.neo-tab-container-inline,
+    .neo-tab-header-toolbar.neo-tab-container-inline {
         --tab-button-padding: 7px 10px 6px;
     }
 

--- a/resources/scss/theme-dark/tab/Container.scss
+++ b/resources/scss/theme-dark/tab/Container.scss
@@ -33,7 +33,12 @@
     // Standalone gives classic-theme consumers a coherent free-standing card treatment without
     // changing the ui:null default above.
     &.neo-tab-container-standalone > .neo-tab-header-toolbar,
-    .neo-tab-container-standalone > .neo-tab-header-toolbar {
+    .neo-tab-container-standalone > .neo-tab-header-toolbar,
+    // The detached-proxy pair, mirroring the inline block above. SortZone propagates whatever
+    // non-null `ui` the owner holds, so every variant the themes name needs both self-scoped
+    // forms — an inline-only self-scope would leave a standalone proxy silently ancestor-scoped.
+    &.neo-tab-header-toolbar.neo-tab-container-standalone,
+    .neo-tab-header-toolbar.neo-tab-container-standalone {
         --tab-button-border-radius : 8px;
         --tab-button-gap           : 4px;
         --tab-button-height        : 40px;

--- a/resources/scss/theme-light/tab/Container.scss
+++ b/resources/scss/theme-light/tab/Container.scss
@@ -15,7 +15,18 @@
     // horizontal padding. Keeping inherited defaults out of this block prevents copy-drift while
     // leaving one measured, deletion-sensitive variant effect.
     &.neo-tab-container-inline > .neo-tab-header-toolbar,
-    .neo-tab-container-inline > .neo-tab-header-toolbar {
+    .neo-tab-container-inline > .neo-tab-header-toolbar,
+    // Self-scoped: a drag proxy is a detached toolbar at document.body, so it has no container
+    // ancestor for the two forms above to match. draggable.tab.header.toolbar.SortZone propagates
+    // the owner's ui-derived class onto it, and these two forms are what let the same tokens resolve
+    // there — one source, rather than a value snapshot taken at drag start.
+    //
+    // BOTH are required, and the `&` form is the one that is easy to miss: DragZone#createDragProxy
+    // pushes the resolved theme class onto the PROXY ITSELF, so theme + toolbar + variant all land on
+    // a single element and the descendant form below cannot match it. The descendant form still
+    // carries the case where an ancestor holds the theme.
+    &.neo-tab-header-toolbar.neo-tab-container-inline,
+    .neo-tab-header-toolbar.neo-tab-container-inline {
         --tab-button-padding: 7px 10px 6px;
     }
 

--- a/resources/scss/theme-light/tab/Container.scss
+++ b/resources/scss/theme-light/tab/Container.scss
@@ -33,7 +33,12 @@
     // Standalone gives classic-theme consumers a coherent free-standing card treatment without
     // changing the ui:null default above.
     &.neo-tab-container-standalone > .neo-tab-header-toolbar,
-    .neo-tab-container-standalone > .neo-tab-header-toolbar {
+    .neo-tab-container-standalone > .neo-tab-header-toolbar,
+    // The detached-proxy pair, mirroring the inline block above. SortZone propagates whatever
+    // non-null `ui` the owner holds, so every variant the themes name needs both self-scoped
+    // forms — an inline-only self-scope would leave a standalone proxy silently ancestor-scoped.
+    &.neo-tab-header-toolbar.neo-tab-container-standalone,
+    .neo-tab-header-toolbar.neo-tab-container-standalone {
         --tab-button-border-radius : 8px;
         --tab-button-gap           : 4px;
         --tab-button-height        : 40px;

--- a/resources/scss/theme-neo-dark/tab/Container.scss
+++ b/resources/scss/theme-neo-dark/tab/Container.scss
@@ -37,7 +37,12 @@
 
     // Standalone explicitly names the theme's existing free-standing treatment.
     &.neo-tab-container-standalone > .neo-tab-header-toolbar,
-    .neo-tab-container-standalone > .neo-tab-header-toolbar {
+    .neo-tab-container-standalone > .neo-tab-header-toolbar,
+    // The detached-proxy pair, mirroring the inline block above. SortZone propagates whatever
+    // non-null `ui` the owner holds, so every variant the themes name needs both self-scoped
+    // forms — an inline-only self-scope would leave a standalone proxy silently ancestor-scoped.
+    &.neo-tab-header-toolbar.neo-tab-container-standalone,
+    .neo-tab-header-toolbar.neo-tab-container-standalone {
         --tab-button-border-radius : var(--cmp-tab-borderradius);
         --tab-button-gap           : 0;
         --tab-button-height        : var(--cmp-tab-height);

--- a/resources/scss/theme-neo-dark/tab/Container.scss
+++ b/resources/scss/theme-neo-dark/tab/Container.scss
@@ -16,7 +16,18 @@
     // Embedded pane chrome uses the semantic 32px density tier and releases the free-standing
     // radius. The theme's ui:null contract remains the established 48px / 8px treatment.
     &.neo-tab-container-inline > .neo-tab-header-toolbar,
-    .neo-tab-container-inline > .neo-tab-header-toolbar {
+    .neo-tab-container-inline > .neo-tab-header-toolbar,
+    // Self-scoped: a drag proxy is a detached toolbar at document.body, so it has no container
+    // ancestor for the two forms above to match. draggable.tab.header.toolbar.SortZone propagates
+    // the owner's ui-derived class onto it, and these two forms are what let the same tokens resolve
+    // there — one source, rather than a value snapshot taken at drag start.
+    //
+    // BOTH are required, and the `&` form is the one that is easy to miss: DragZone#createDragProxy
+    // pushes the resolved theme class onto the PROXY ITSELF, so theme + toolbar + variant all land on
+    // a single element and the descendant form below cannot match it. The descendant form still
+    // carries the case where an ancestor holds the theme.
+    &.neo-tab-header-toolbar.neo-tab-container-inline,
+    .neo-tab-header-toolbar.neo-tab-container-inline {
         --tab-button-border-radius : 0;
         --tab-button-gap           : 0;
         --tab-button-height        : var(--sem-height-large);

--- a/resources/scss/theme-neo-light/tab/Container.scss
+++ b/resources/scss/theme-neo-light/tab/Container.scss
@@ -37,7 +37,12 @@
 
     // Standalone explicitly names the theme's existing free-standing treatment.
     &.neo-tab-container-standalone > .neo-tab-header-toolbar,
-    .neo-tab-container-standalone > .neo-tab-header-toolbar {
+    .neo-tab-container-standalone > .neo-tab-header-toolbar,
+    // The detached-proxy pair, mirroring the inline block above. SortZone propagates whatever
+    // non-null `ui` the owner holds, so every variant the themes name needs both self-scoped
+    // forms — an inline-only self-scope would leave a standalone proxy silently ancestor-scoped.
+    &.neo-tab-header-toolbar.neo-tab-container-standalone,
+    .neo-tab-header-toolbar.neo-tab-container-standalone {
         --tab-button-border-radius : var(--cmp-tab-borderradius);
         --tab-button-gap           : 0;
         --tab-button-height        : var(--cmp-tab-height);

--- a/resources/scss/theme-neo-light/tab/Container.scss
+++ b/resources/scss/theme-neo-light/tab/Container.scss
@@ -16,7 +16,18 @@
     // Embedded pane chrome uses the semantic 32px density tier and releases the free-standing
     // radius. The theme's ui:null contract remains the established 48px / 8px treatment.
     &.neo-tab-container-inline > .neo-tab-header-toolbar,
-    .neo-tab-container-inline > .neo-tab-header-toolbar {
+    .neo-tab-container-inline > .neo-tab-header-toolbar,
+    // Self-scoped: a drag proxy is a detached toolbar at document.body, so it has no container
+    // ancestor for the two forms above to match. draggable.tab.header.toolbar.SortZone propagates
+    // the owner's ui-derived class onto it, and these two forms are what let the same tokens resolve
+    // there — one source, rather than a value snapshot taken at drag start.
+    //
+    // BOTH are required, and the `&` form is the one that is easy to miss: DragZone#createDragProxy
+    // pushes the resolved theme class onto the PROXY ITSELF, so theme + toolbar + variant all land on
+    // a single element and the descendant form below cannot match it. The descendant form still
+    // carries the case where an ancestor holds the theme.
+    &.neo-tab-header-toolbar.neo-tab-container-inline,
+    .neo-tab-header-toolbar.neo-tab-container-inline {
         --tab-button-border-radius : 0;
         --tab-button-gap           : 0;
         --tab-button-height        : var(--sem-height-large);

--- a/src/draggable/tab/header/toolbar/SortZone.mjs
+++ b/src/draggable/tab/header/toolbar/SortZone.mjs
@@ -60,6 +60,33 @@ class SortZone extends BaseSortZone {
     }
 
     /**
+     * Propagates the owning tab.Container's `ui`-derived class onto the drag proxy.
+     *
+     * The base returns `{...dragProxyConfig, cls: [...owner.cls]}` — `cls` lands AFTER the spread, so
+     * the static `dragProxyConfig.cls` never reaches the proxy and the owner toolbar's own classes do.
+     * That list cannot carry the variant: `component.Base#afterSetUi` emits `neo-<ntype>-<ui>` on the
+     * CONTAINER, and the themes express the variant as a descendant rule on its direct-child toolbar.
+     * The proxy is rooted at `document.body`, so it has no such ancestor and falls back to the theme's
+     * `ui: null` density — a 32px header handing its button to a 48px proxy, which is the off-centre
+     * label the defect reports.
+     *
+     * Carrying the class on the proxy only works because each theme also declares a SELF-scoped form of
+     * the variant block; the descendant form alone would still not match. Both live in the same rule, so
+     * there is one token source rather than a snapshot taken at drag start.
+     * @returns {Object}
+     */
+    getDragProxyConfig() {
+        const
+            config    = super.getDragProxyConfig(),
+            container = this.owner?.up?.('tab-container'),
+            variant   = container?.ui && `neo-${container.ntype}-${container.ui}`;
+
+        return variant && !config.cls.includes(variant)
+            ? {...config, cls: [...config.cls, variant]}
+            : config
+    }
+
+    /**
      * Override this method for class extensions (e.g. tab.header.Toolbar)
      * @param {Number} fromIndex
      * @param {Number} toIndex

--- a/test/playwright/component/tab/DragProxyDensity.spec.mjs
+++ b/test/playwright/component/tab/DragProxyDensity.spec.mjs
@@ -1,0 +1,173 @@
+import {test, expect} from '@playwright/test';
+
+/**
+ * @summary The tab drag proxy must render at the density of the header the tab came from.
+ *
+ * Reported by @tobiu against the Workstation: a dragged tab's label is no longer centred for the
+ * whole gesture. The proxy is a detached toolbar rooted at `document.body`, and every theme expresses
+ * `ui: 'inline'` as a DESCENDANT rule — `.neo-tab-container-inline > .neo-tab-header-toolbar` — so the
+ * proxy has no ancestor that can match it and falls back to the theme's `ui: null` treatment.
+ *
+ * Three deliberate choices:
+ *
+ * - **Measured while the gesture is open.** The proxy does not exist before `mouse.down` or after
+ *   `mouse.up`, so a static fixture cannot witness this at all.
+ * - **Each proxy is compared to its OWN source, never to a literal.** The contract is "the proxy
+ *   inherits its owner's variant", not "the proxy is always inline" — the `ui: null` arm is what stops
+ *   the fix from being written as the latter. An earlier draft asserted a literal `32px` and was wrong:
+ *   that figure is the `neo-*` themes' inline tier, while `theme-light`/`theme-dark` express `inline`
+ *   as padding only, so the header measured 25px and the precondition failed for the right reason.
+ * - **The variants are compared to each other for non-vacuity.** If `inline` and `ui: null` rendered
+ *   identically, "proxy matches source" would pass on both arms while proving nothing. The
+ *   discriminator asserts they differ, without naming which property carries the difference — the
+ *   `neo-*` themes vary height and padding, the base themes vary padding alone.
+ *
+ * Run: npx playwright test component/tab/DragProxyDensity -c test/playwright/playwright.config.component.mjs --workers=1
+ */
+
+const
+    INLINE_ID = 'drag-proxy-density-inline',
+    PLAIN_ID  = 'drag-proxy-density-plain',
+    THEMES    = ['neo-theme-neo-dark', 'neo-theme-neo-light', 'neo-theme-light'];
+
+/**
+ * Themes the VIEWPORT through the engine, which is the only placement both halves of this measurement
+ * agree on. `component.Base#getTheme()` checks a component's own `cls` and then jumps to the app's
+ * mainView — it does not walk the parent chain — and `DragZone#createDragProxy` themes the proxy from
+ * that same call. So a theme set per-container reaches the rendered header but NOT its proxy, and a
+ * class poked onto `document.body` reaches neither: both make the arm compare two different cascades
+ * and call the difference a defect. Setting it on the mainView is what makes source and proxy comparable.
+ * @param {Object} page
+ * @param {String} theme
+ * @returns {Promise<void>}
+ */
+const viewportCls = page => page.evaluate(() =>
+    Neo.worker.App.getConfigs({id: 'component-test-viewport', keys: 'cls'}));
+
+const setViewportCls = (page, cls) => page.evaluate(value =>
+    Neo.worker.App.setConfigs({cls: value, id: 'component-test-viewport'}), cls);
+
+const applyTheme = async (page, theme) => {
+    const cls = (await viewportCls(page) || []).filter(item => !item.startsWith('neo-theme-'));
+
+    await setViewportCls(page, [...cls, theme])
+};
+
+/**
+ * Creates a real, drag-resortable TabContainer at the requested ui variant.
+ * @param {Object} page
+ * @param {String} id
+ * @param {String|null} ui
+ * @returns {Promise<String>}
+ */
+async function createTabContainer(page, id, ui) {
+    const result = await page.evaluate(async ({id, ui}) => Neo.worker.App.createNeoInstance({
+        activeIndex   : 0,
+        dragResortable: true,
+        height        : 200,
+        id,
+        importPath    : '../tab/Container.mjs',
+        items         : Array.from({length: 4}, (_, index) => ({
+            header: {text: `Tab ${index + 1}`},
+            ntype : 'component',
+            text  : `Content ${index + 1}`
+        })),
+        ntype   : 'tab-container',
+        parentId: 'component-test-viewport',
+        ui,
+        width   : 560
+    }), {id, ui});
+
+    if (!result.success) {
+        throw new Error(`TabContainer ${id} creation failed: ${result.error.message}`)
+    }
+
+    await page.waitForSelector(`#${id}`, {state: 'attached'});
+
+    return result.id
+}
+
+/** The density contract a tab button renders under, as the cascade resolves it. */
+const density = root => root.locator('.neo-tab-header-button').first().evaluate(node => {
+    const style = getComputedStyle(node);
+
+    return {height: style.height, padding: style.padding}
+});
+
+test.describe('Neo.draggable.tab.header.toolbar.SortZone — the drag proxy inherits its owner density', () => {
+    let originalCls = null;
+
+    test.beforeEach(async ({page}) => {
+        await page.goto('/test/playwright/component/apps/empty-viewport/index.html');
+        await page.waitForSelector('#component-test-viewport', {state: 'attached'});
+
+        // The viewport is an App Worker instance SHARED across every spec file — `page.goto()` gives a
+        // fresh document, not a fresh component. Re-theming it is therefore a mutation that outlives
+        // this file, so the pre-existing value is captured here and restored below. Without that, every
+        // later spec silently renders under whichever theme this file happened to leave behind.
+        originalCls = await viewportCls(page)
+    });
+
+    test.afterEach(async ({page}) => {
+        // Release any gesture an arm left open BEFORE tearing the containers down: a live pointer
+        // capture outlives the instance and would arm the next spec's first click.
+        await page.mouse.up().catch(() => {});
+
+        for (const id of [INLINE_ID, PLAIN_ID]) {
+            await page.evaluate(componentId => Neo.worker.App.destroyNeoInstance(componentId), id).catch(() => {});
+            await page.waitForSelector(`#${id}`, {state: 'detached'}).catch(() => {})
+        }
+
+        originalCls && await setViewportCls(page, originalCls)
+    });
+
+    for (const theme of THEMES) {
+        test(`the proxy carries the source header's density, per variant — ${theme}`, async ({page}) => {
+            await applyTheme(page, theme);
+            await createTabContainer(page, INLINE_ID, 'inline');
+            await createTabContainer(page, PLAIN_ID,  null);
+
+            const
+                inlineRoot = page.locator(`#${INLINE_ID}`),
+                plainRoot  = page.locator(`#${PLAIN_ID}`),
+                inlineSrc  = await density(inlineRoot),
+                plainSrc   = await density(plainRoot);
+
+            // Non-vacuity: with identical variants, "proxy matches source" would hold on both arms
+            // while proving nothing about the variant reaching the proxy at all.
+            expect(inlineSrc, `precondition: ${theme} must render inline and ui:null differently`)
+                .not.toEqual(plainSrc);
+
+            for (const [label, root, expected] of [
+                ['inline', inlineRoot, inlineSrc],
+                ['ui:null', plainRoot, plainSrc]
+            ]) {
+                const
+                    tab = root.locator('.neo-tab-header-button').first(),
+                    box = await tab.boundingBox();
+
+                expect(box, `${label}: the tab button must be rendered before the gesture`).toBeTruthy();
+
+                // A real pointer, not a synthetic click: the sort zone arms on the main thread's drag
+                // sensor, and a dispatched click never produces a proxy at all — which would read as a
+                // green assertion against an element that was never created. The move is stepped past
+                // the threshold, because one jump can coalesce into a single event below start distance.
+                await page.mouse.move(box.x + box.width / 2, box.y + box.height / 2);
+                await page.mouse.down();
+                await page.mouse.move(box.x + box.width / 2 + 140, box.y + box.height / 2, {steps: 12});
+
+                const proxy = page.locator('.neo-dragproxy');
+
+                await expect(proxy, `${label}: the gesture must produce exactly one live proxy`)
+                    .toHaveCount(1, {timeout: 5000});
+
+                expect(await density(proxy), `${label}: the proxy must render at its own source header's density`)
+                    .toEqual(expected);
+
+                await page.mouse.up();
+                await expect(proxy, `${label}: the proxy is released with the gesture`)
+                    .toHaveCount(0, {timeout: 5000})
+            }
+        })
+    }
+});

--- a/test/playwright/component/tab/DragProxyDensity.spec.mjs
+++ b/test/playwright/component/tab/DragProxyDensity.spec.mjs
@@ -26,9 +26,56 @@ import {test, expect} from '@playwright/test';
  */
 
 const
-    INLINE_ID = 'drag-proxy-density-inline',
-    PLAIN_ID  = 'drag-proxy-density-plain',
-    THEMES    = ['neo-theme-neo-dark', 'neo-theme-neo-light', 'neo-theme-light'];
+    INLINE_ID     = 'drag-proxy-density-inline',
+    PLAIN_ID      = 'drag-proxy-density-plain',
+    STANDALONE_ID = 'drag-proxy-density-standalone',
+    VARIANT_IDS   = [INLINE_ID, PLAIN_ID, STANDALONE_ID],
+    THEMES        = ['neo-theme-neo-dark', 'neo-theme-neo-light', 'neo-theme-light', 'neo-theme-dark'];
+
+/**
+ * Links every theme's tab value layers into the persistent component-test document.
+ *
+ * The harness boots one theme's stylesheets; measuring another without linking its CSS reads the
+ * booted cascade under a renamed class and calls the result a variant. `ContainerUi.spec.mjs` uses
+ * this same idiom against the same empty-viewport harness, which is why all four themes are
+ * reachable here — an earlier revision of this file claimed otherwise and was wrong.
+ * @param {Object} page
+ * @returns {Promise<void>}
+ */
+async function loadThemeStylesheets(page) {
+    const hrefs = THEMES.flatMap(theme => {
+        const directory = theme.replace('neo-theme-', 'theme-'),
+              files     = [
+                  `/dist/development/css/${directory}/button/Base.css`,
+                  `/dist/development/css/${directory}/tab/Container.css`,
+                  `/dist/development/css/${directory}/tab/header/Button.css`,
+                  `/dist/development/css/${directory}/toolbar/Base.css`
+              ];
+
+        if (directory.startsWith('theme-neo-')) {
+            files.unshift(
+                `/dist/development/css/${directory}/design-tokens/Core.css`,
+                `/dist/development/css/${directory}/design-tokens/Semantic.css`,
+                `/dist/development/css/${directory}/design-tokens/Component.css`
+            )
+        }
+
+        return files
+    });
+
+    await page.evaluate(async list => {
+        await Promise.all(list.map(href => new Promise(resolve => {
+            if (document.querySelector(`link[href="${href}"]`)) return resolve();
+
+            const link = document.createElement('link');
+
+            link.rel    = 'stylesheet';
+            link.href   = href;
+            link.onload = link.onerror = resolve;
+            document.head.appendChild(link)
+        })))
+    }, hrefs)
+}
 
 /**
  * Themes the VIEWPORT through the engine, which is the only placement both halves of this measurement
@@ -100,6 +147,7 @@ test.describe('Neo.draggable.tab.header.toolbar.SortZone — the drag proxy inhe
     test.beforeEach(async ({page}) => {
         await page.goto('/test/playwright/component/apps/empty-viewport/index.html');
         await page.waitForSelector('#component-test-viewport', {state: 'attached'});
+        await loadThemeStylesheets(page);
 
         // The viewport is an App Worker instance SHARED across every spec file — `page.goto()` gives a
         // fresh document, not a fresh component. Re-theming it is therefore a mutation that outlives
@@ -113,7 +161,7 @@ test.describe('Neo.draggable.tab.header.toolbar.SortZone — the drag proxy inhe
         // capture outlives the instance and would arm the next spec's first click.
         await page.mouse.up().catch(() => {});
 
-        for (const id of [INLINE_ID, PLAIN_ID]) {
+        for (const id of VARIANT_IDS) {
             await page.evaluate(componentId => Neo.worker.App.destroyNeoInstance(componentId), id).catch(() => {});
             await page.waitForSelector(`#${id}`, {state: 'detached'}).catch(() => {})
         }
@@ -124,14 +172,17 @@ test.describe('Neo.draggable.tab.header.toolbar.SortZone — the drag proxy inhe
     for (const theme of THEMES) {
         test(`the proxy carries the source header's density, per variant — ${theme}`, async ({page}) => {
             await applyTheme(page, theme);
-            await createTabContainer(page, INLINE_ID, 'inline');
-            await createTabContainer(page, PLAIN_ID,  null);
+            await createTabContainer(page, INLINE_ID,     'inline');
+            await createTabContainer(page, PLAIN_ID,      null);
+            await createTabContainer(page, STANDALONE_ID, 'standalone');
 
             const
-                inlineRoot = page.locator(`#${INLINE_ID}`),
-                plainRoot  = page.locator(`#${PLAIN_ID}`),
-                inlineSrc  = await density(inlineRoot),
-                plainSrc   = await density(plainRoot);
+                inlineRoot     = page.locator(`#${INLINE_ID}`),
+                plainRoot      = page.locator(`#${PLAIN_ID}`),
+                standaloneRoot = page.locator(`#${STANDALONE_ID}`),
+                inlineSrc      = await density(inlineRoot),
+                plainSrc       = await density(plainRoot),
+                standaloneSrc  = await density(standaloneRoot);
 
             // Non-vacuity: with identical variants, "proxy matches source" would hold on both arms
             // while proving nothing about the variant reaching the proxy at all.
@@ -139,8 +190,9 @@ test.describe('Neo.draggable.tab.header.toolbar.SortZone — the drag proxy inhe
                 .not.toEqual(plainSrc);
 
             for (const [label, root, expected] of [
-                ['inline', inlineRoot, inlineSrc],
-                ['ui:null', plainRoot, plainSrc]
+                ['inline',     inlineRoot,     inlineSrc],
+                ['ui:null',    plainRoot,      plainSrc],
+                ['standalone', standaloneRoot, standaloneSrc]
             ]) {
                 const
                     tab = root.locator('.neo-tab-header-button').first(),


### PR DESCRIPTION
Resolves #18020

Related: #17836 · #17950 · #17956

**Evidence:** density measured **on a live proxy mid-gesture** across **four themes × three `ui` variants**, each proxy compared to its own source · three mutations, one per half of the fix plus one per self-scoped variant block.

🌿 A dragged tab can no longer arrive at a density its own header never had.

@tobiu reported the label sitting off-centre for the whole gesture, then supplied the lead that resolved it — *"maybe related to `ui: 'inline'` => could be broken after we added it."* He was right.

## The trap, and the two layers under it

Every theme expresses a `ui` variant as a **descendant** rule requiring a `.neo-tab-container-<variant>` ancestor. The proxy is a detached toolbar rooted at `document.body`, so no ancestor can match and it falls back to the theme's `ui: null` contract — a 32px header handing its button to a 48px proxy.

**Layer one.** Adding the variant class to the proxy alone does nothing; the ticket documents that. What it did not foresee is that `DragZone#createDragProxy` pushes the resolved theme class onto the **proxy itself**, so theme + toolbar + variant all land on one element and `:root .neo-theme-X .neo-tab-header-toolbar.neo-tab-container-inline` still cannot match — it wants the theme on an ancestor. Both self-scoped forms are required, and the `&` one is the load-bearing half.

**Layer two, found by @neo-gpt-emmy in review.** `getDragProxyConfig()` propagates whatever non-null `ui` the owner holds — that is deliberate — but only the `inline` blocks had self-scoped forms. A `standalone` proxy therefore carried its class with nothing to match it and fell back silently. Every variant the themes name now carries the same pair.

```scss
&.neo-tab-container-inline > .neo-tab-header-toolbar,   // theme on the container
.neo-tab-container-inline  > .neo-tab-header-toolbar,   // theme on an ancestor
&.neo-tab-header-toolbar.neo-tab-container-inline,      // proxy: theme on ITSELF
.neo-tab-header-toolbar.neo-tab-container-inline        // proxy: theme on an ancestor
```

## AC Evidence

| AC | Evidence |
| --- | --- |
| AC-1 proxy density equals its source, measured on a live proxy during a gesture | `DragProxyDensity.spec.mjs` drives a real stepped pointer, then reads `{height, padding}` off `.neo-dragproxy` **while the gesture is open** — the proxy does not exist before `mouse.down` or after `mouse.up` |
| AC-2 the arm reds before the fix | three mutations, each reds — see Test Evidence |
| AC-3 every named variant, `ui: null` included, matches **its own** source | three containers per theme (`inline`, `standalone`, `ui: null`); each proxy is compared to its own source, never to a literal. This is what makes the contract "inherit the owner's variant" rather than "always inline" |
| AC-4 trusted pointer path | Playwright `page.mouse`, stepped past the start distance. It genuinely arms the sort zone — `toHaveCount(1)` on `.neo-dragproxy` fails if no proxy is created, so a never-created proxy cannot read as green |
| AC-5 JSDoc states why the class is propagated | `getDragProxyConfig()`'s JSDoc names the mechanism, and that `cls` there overwrites the static `dragProxyConfig` literal |

## Deltas from ticket

- **The ticket's stated mechanism was wrong and I corrected the ticket before implementing.** It said the proxy "clones two classes and nothing else" from the static `dragProxyConfig` literal. In fact `container/SortZone#getDragProxyConfig()` returns `{...dragProxyConfig, cls: [...owner.cls]}` — `cls` lands after the spread, so the literal's `cls` never reaches the proxy. A peer implementing against that sentence would have edited a dead field.
- **The ticket's `32px / 48px` table is `neo-*`-theme-specific.** `theme-light` and `theme-dark` express `inline` as padding only, so their inline header is 25px. My first draft asserted a literal `32px` and failed its own precondition for that reason — which is why each proxy is now compared to **its own source**.
- **All four themes are covered.** An earlier revision of this body claimed the harness could not apply `neo-theme-dark`. That was false: `ContainerUi.spec.mjs` drives all four against this same empty-viewport harness by linking each theme's stylesheets, and this spec now does the same.

## Test Evidence

```
component/tab/DragProxyDensity      4 themes × 3 variants      4 passed

mutation A — getDragProxyConfig stops propagating the class    4 failed
mutation B — the inline self-scoped forms removed              4 failed
mutation C — the standalone self-scoped forms removed          3 failed · 1 passed
```

Mutation A reproduces the operator's exact report, **measured** rather than read from the theme:

```
neo-theme-neo-dark   source (inline)   height 32px   padding 4px 12px 3px
                     proxy  (fallback) height 48px   padding 7px 16px 6px
```

Mutation C shows the standalone gap Emmy caught: `40px` source against a `48px` proxy in the neo themes, and `40px` against `25px` in the base pair.

**Mutation C leaves `neo-theme-neo-light` green, and that is a property of the theme, not a hole in the control.** That sheet's standalone block *"explicitly names the theme's existing free-standing treatment"* — its values coincide with the `ui: null` contract, so a matched and an unmatched proxy render identically and nothing there can distinguish them. The other three themes give the self-scope its teeth.

Each precondition can red as well: the arm fails if `inline` and `ui: null` render identically, which stops "proxy matches source" from holding vacuously in a theme where the variant is a no-op.

## Post-Merge Validation

`component/tab/` and `component/dashboard/` on `dev`, plus the operator's own check: drag a tab out of an inline dock header and the proxy's label stays centred at the header's density for the whole gesture.

## Authored by

Vega (`@neo-opus-vega`), Claude Code. Reviewed by @neo-gpt-emmy, whose RA-1 caught that a generic propagation method paired with inline-only selectors left `standalone` silently broken — the second layer of this defect exists in the diff because of that review.

— Vega (Opus 5, Claude Code) 🌿
