### PR TITLE
fix(dashboard): fail closed on malformed zones containers (#18006)

### DIFF
--- a/src/dashboard/dock/model/Document.mjs
+++ b/src/dashboard/dock/model/Document.mjs
@@ -1000,9 +1000,11 @@ class Document extends Base {
      * Deterministic by construction: child arrays keep document order, edge zones walk in the
      * fixed {@link #dockZoneEdgeKeys} order.
      *
-     * Optional edge-zone slots may be absent. A present slot whose descriptor cannot resolve to a
-     * node id fails closed, so that corrupt descriptor cannot fingerprint identically to an omitted
-     * slot and pass downstream shape gates as a legitimate no-change result.
+     * An edge-zone must carry a JSON-record zones container; malformed containers fail closed
+     * instead of collapsing into the legitimate empty-record shape. Optional slots may be absent.
+     * A present slot whose descriptor cannot resolve to a node id also fails closed, so corrupt
+     * input cannot fingerprint identically to an omitted slot and pass downstream shape gates as a
+     * legitimate no-change result.
      * @param {Object} document The committed dock-zone document.
      * @returns {{fingerprint:(Object|null), errors:String[]}}
      * @static
@@ -1042,7 +1044,12 @@ class Document extends Base {
                 case 'tabs':
                     return `t${node.items?.length || 0}`;
                 case 'edge-zone': {
-                    const zones = node.zones || {};
+                    if (!Document.isJsonRecord(node.zones)) {
+                        errors.push(`fingerprint walk found a non-record zones container for edge-zone "${nodeId}"`);
+                        return '?'
+                    }
+
+                    const zones = node.zones;
 
                     return `e{${[...Document.dockZoneEdgeKeys]
                         .map(zone => {

--- a/test/playwright/unit/dashboard/DockTopologyDiff.spec.mjs
+++ b/test/playwright/unit/dashboard/DockTopologyDiff.spec.mjs
@@ -210,4 +210,53 @@ test.describe('Neo.dashboard.dock.model.TopologyDiff (#14650)', () => {
         expect(absentGate.errors, 'an omitted optional zone remains valid').toEqual([]);
         expect(absentGate.fingerprint?.shape).toBe('e{}')
     });
+
+    test('non-record zone containers fail the validator and shape gate together, never fabricating categories', () => {
+        const malformedContainers = ['main-split', [], null, 42],
+              emptyCategories     = {
+                  adds         : [],
+                  autoHideFlips: [],
+                  moves        : [],
+                  removes      : [],
+                  resizes      : [],
+                  tabReorders  : [],
+                  unchanged    : []
+              };
+
+        malformedContainers.forEach(zones => {
+            const malformed = doc();
+
+            malformed.nodes.root.zones = zones;
+
+            const validationErrors = Document.validate(malformed),
+                  gate             = Document.computeShapeFingerprint(malformed);
+
+            expect(validationErrors.length > 0,
+                `validator and fingerprint gate must agree for zones=${JSON.stringify(zones)}`)
+                .toBe(gate.errors.length > 0);
+            expect(gate.fingerprint, 'a non-record zones container never yields a success fingerprint').toBe(null);
+
+            for (const side of ['before', 'after']) {
+                const result = side === 'before'
+                    ? DockTopologyDiff.diffDockDocuments(malformed, doc())
+                    : DockTopologyDiff.diffDockDocuments(doc(), malformed);
+
+                expect(result.errors[0]).toContain(`${side} document failed the shape gate`);
+
+                for (const [category, expected] of Object.entries(emptyCategories)) {
+                    expect(result[category], `${side} ${category} stays empty for zones=${JSON.stringify(zones)}`)
+                        .toEqual(expected)
+                }
+            }
+        });
+
+        const empty = doc();
+
+        empty.nodes.root.zones = {};
+
+        const gate = Document.computeShapeFingerprint(empty);
+
+        expect(gate.errors, 'an empty zones record is the legitimate no-occupancy case').toEqual([]);
+        expect(gate.fingerprint?.shape).toBe('e{}')
+    });
 });


### PR DESCRIPTION
Resolves #18006

Related: #18004

The dock shape gate now rejects an `edge-zone` whose `zones` container is not a JSON record, instead of collapsing malformed input into the legitimate empty `e{}` shape and letting `TopologyDiff` fabricate error-free semantic categories.

Evidence: L2 (pure data-plane unit and mutation evidence) → L2 required (AC-1–7). No residuals.

## AC Evidence

| AC | Evidence |
|---|---|
| AC-1 | `DockTopologyDiff.spec.mjs` covers string, array, `null`, and number containers; each produces gate errors and a null fingerprint. |
| AC-2 | The same arm proves a well-formed empty `{}` zones record remains clean with shape `e{}`. |
| AC-3 | Every malformed form is exercised as both `before` and `after`; each error keeps the existing side-named prefix. |
| AC-4 | One property assertion binds `Document.validate()` rejection to fingerprint-gate rejection for every specimen. |
| AC-5 | Every semantic category is asserted empty, preventing the former fabricated-removes result. |
| AC-6 | Red-first control on unchanged `dev`: focused suite was 8/9, failing at validator/gate disagreement; restored source is 9/9. |
| AC-7 | Full unit corpus: 2,927/2,927. |

## Deltas from ticket

The diagnostic stays in the fingerprint walk's existing voice. No traversal unification, broad container census, or `Document.validate()` change was needed.

## Test Evidence

- Pre-fix focused control: 8 passed, 1 failed at the new validator/gate property.
- Post-fix focused suite: 9/9 passed.
- Full unit suite: 2,927/2,927 passed.

## Post-Merge Validation

- [x] None; the delivered contract is fully exercised before merge.

Authored by Emmy (GPT-5.6 Sol Ultra, Codex). Session 309a78d7-2d95-4f23-bdfc-69d2ae393a5d.
